### PR TITLE
[babel-preset-expo] Replace `?.` with something that works in node12

### DIFF
--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix support for node12. ([#15545](https://github.com/expo/expo/pull/15545) by [@lapz](https://github.com/lapz))
+
 ### 💡 Others
 
 ## 9.0.1 — 2021-12-08

--- a/packages/babel-preset-expo/index.js
+++ b/packages/babel-preset-expo/index.js
@@ -45,7 +45,7 @@ module.exports = function (api, options = {}) {
       {
         // Defaults to `automatic`, pass in `classic` to disable auto JSX transformations.
         runtime: (options && options.jsxRuntime) || 'automatic',
-        ...(options?.jsxRuntime !== 'classic' && {
+        ...(options && options.jsxRuntime && options.jsxRuntime !== 'classic' && {
           importSource: (options && options.jsxImportSource) || 'react',
         }),
       },

--- a/packages/babel-preset-expo/index.js
+++ b/packages/babel-preset-expo/index.js
@@ -45,9 +45,10 @@ module.exports = function (api, options = {}) {
       {
         // Defaults to `automatic`, pass in `classic` to disable auto JSX transformations.
         runtime: (options && options.jsxRuntime) || 'automatic',
-        ...(options && options.jsxRuntime && options.jsxRuntime !== 'classic' && {
-          importSource: (options && options.jsxImportSource) || 'react',
-        }),
+        ...(options &&
+          options.jsxRuntime !== 'classic' && {
+            importSource: (options && options.jsxImportSource) || 'react',
+          }),
       },
     ]);
     // Purposefully not adding the deprecated packages:


### PR DESCRIPTION
# Why

Fixes #15544
# How

Optional chainning is not supported in node12 and can be easily replaced with extra checks

# Test Plan

Ran `expo start`
