### PR TITLE
[core] Add onNewIntent and onBackPressed to ReactActivityLifecycleListener

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Add `onNewIntent` and `onBackPressed` support to `ReactActivityLifecycleListener`.
+- Add `onNewIntent` and `onBackPressed` support to `ReactActivityLifecycleListener`. ([#15550](https://github.com/expo/expo/pull/15550) by [@Kudo](https://github.com/Kudo))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add `onNewIntent` and `onBackPressed` support to `ReactActivityLifecycleListener`.
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/core/interfaces/ReactActivityLifecycleListener.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/core/interfaces/ReactActivityLifecycleListener.java
@@ -1,6 +1,7 @@
 package expo.modules.core.interfaces;
 
 import android.app.Activity;
+import android.content.Intent;
 import android.os.Bundle;
 
 public interface ReactActivityLifecycleListener {
@@ -11,4 +12,26 @@ public interface ReactActivityLifecycleListener {
   default void onPause(Activity activity) {}
 
   default void onDestroy(Activity activity) {}
+
+  /**
+   * Called when {@link com.facebook.react.ReactActivity} received `onNewIntent`
+   * Every listener will receive this callback.
+   * `ReactActivityDelegateWrapper.onNewIntent` will get `true` if there's some module returns `true`
+   *
+   * @return true if this module wants to return `true` from `ReactActivityDelegateWrapper.onNewIntent`
+   */
+  default boolean onNewIntent(Intent intent) {
+    return false;
+  }
+
+  /**
+   * Called when {@link com.facebook.react.ReactActivity} received `onBackPressed`
+   * Every listener will receive this callback.
+   * `ReactActivityDelegateWrapper.onBackPressed` will get `true` if there's some module returns `true`
+   *
+   * @return true if this module wants to return `true` from `ReactActivityDelegateWrapper.onBackPressed`
+   */
+  default boolean onBackPressed() {
+    return false;
+  }
 }

--- a/packages/expo/android/build.gradle
+++ b/packages/expo/android/build.gradle
@@ -71,6 +71,9 @@ android {
   kotlinOptions {
     jvmTarget = '1.8'
   }
+  testOptions {
+    unitTests.includeAndroidResources = true
+  }
 
   sourceSets {
     main {
@@ -79,11 +82,23 @@ android {
       }
     }
   }
+
+  unitTestVariants.all {
+    it.mergedFlavor.manifestPlaceholders = [
+      // Fix expo-app-auth manifest merger issue for unit test
+      appAuthRedirectScheme: "test"
+    ]
+  }
 }
 
 dependencies { dependencyHandler ->
   //noinspection GradleDynamicVersion
   implementation 'com.facebook.react:react-native:+'
+
+  testImplementation 'junit:junit:4.13.1'
+  testImplementation 'androidx.test:core:1.4.0'
+  testImplementation "com.google.truth:truth:1.1.2"
+  testImplementation 'io.mockk:mockk:1.12.0'
 
   // Link expo modules as dependencies of the adapter. It uses `api` configuration so they all will be visible for the app as well.
   // A collection of the dependencies depends on the options passed to `useExpoModules` in your project's `settings.gradle`.

--- a/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
+++ b/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
@@ -13,6 +13,7 @@ import com.facebook.react.ReactInstanceManager
 import com.facebook.react.ReactNativeHost
 import com.facebook.react.ReactRootView
 import com.facebook.react.modules.core.PermissionListener
+import expo.modules.core.interfaces.ReactActivityLifecycleListener
 import java.lang.reflect.Method
 
 class ReactActivityDelegateWrapper(
@@ -45,7 +46,7 @@ class ReactActivityDelegateWrapper(
     return delegate.reactInstanceManager
   }
 
-  override fun getMainComponentName(): String {
+  override fun getMainComponentName(): String? {
     return delegate.mainComponentName
   }
 
@@ -115,11 +116,19 @@ class ReactActivityDelegateWrapper(
   }
 
   override fun onBackPressed(): Boolean {
-    return delegate.onBackPressed()
+    val listenerResult = reactActivityLifecycleListeners
+      .map(ReactActivityLifecycleListener::onBackPressed)
+      .fold(false) { accu, current -> accu || current }
+    val delegateResult = delegate.onBackPressed()
+    return listenerResult || delegateResult
   }
 
   override fun onNewIntent(intent: Intent?): Boolean {
-    return delegate.onNewIntent(intent)
+    val listenerResult = reactActivityLifecycleListeners
+      .map { it.onNewIntent(intent) }
+      .fold(false) { accu, current -> accu || current }
+    val delegateResult = delegate.onNewIntent(intent)
+    return listenerResult || delegateResult
   }
 
   override fun onWindowFocusChanged(hasFocus: Boolean) {

--- a/packages/expo/android/src/test/java/expo/modules/ReactActivityDelegateWrapperTest.kt
+++ b/packages/expo/android/src/test/java/expo/modules/ReactActivityDelegateWrapperTest.kt
@@ -1,0 +1,109 @@
+package expo.modules
+
+import android.content.Context
+import android.content.Intent
+import com.facebook.react.ReactActivity
+import com.facebook.react.ReactActivityDelegate
+import com.google.common.truth.Truth.assertThat
+import expo.modules.core.interfaces.Package
+import expo.modules.core.interfaces.ReactActivityHandler
+import expo.modules.core.interfaces.ReactActivityLifecycleListener
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.RelaxedMockK
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+internal class ReactActivityDelegateWrapperTest {
+  lateinit var mockPackage0: MockPackage
+
+  lateinit var mockPackage1: MockPackage
+
+  @RelaxedMockK
+  lateinit var activity: ReactActivity
+
+  @RelaxedMockK
+  lateinit var delegate: ReactActivityDelegate
+
+  @Before
+  fun setUp() {
+    mockPackage0 = MockPackage()
+    mockPackage1 = MockPackage()
+    MockKAnnotations.init(this)
+    mockkObject(ExpoModulesPackage.Companion)
+    every { ExpoModulesPackage.Companion.packageList } returns listOf(mockPackage0, mockPackage1)
+  }
+
+  @After
+  fun tearDown() {
+    unmockkAll()
+  }
+
+  @Test
+  fun `onBackPressed should call each handler's callback just once`() {
+    val delegateWrapper = ReactActivityDelegateWrapper(activity, delegate)
+    every { mockPackage0.reactActivityLifecycleListener.onBackPressed() } returns true
+
+    delegateWrapper.onBackPressed()
+
+    verify(exactly = 1) { mockPackage0.reactActivityLifecycleListener.onBackPressed() }
+    verify(exactly = 1) { mockPackage1.reactActivityLifecycleListener.onBackPressed() }
+    verify(exactly = 1) { delegate.onBackPressed() }
+  }
+
+  @Test
+  fun `onBackPressed should return true if someone returns true`() {
+    val delegateWrapper = ReactActivityDelegateWrapper(activity, delegate)
+    every { mockPackage0.reactActivityLifecycleListener.onBackPressed() } returns false
+    every { mockPackage1.reactActivityLifecycleListener.onBackPressed() } returns true
+    every { delegate.onBackPressed() } returns false
+
+    val result = delegateWrapper.onBackPressed()
+    assertThat(result).isTrue()
+  }
+
+  @Test
+  fun `onNewIntent should call each handler's callback just once`() {
+    val intent = mockk<Intent>()
+    val delegateWrapper = ReactActivityDelegateWrapper(activity, delegate)
+    every { mockPackage0.reactActivityLifecycleListener.onNewIntent(intent) } returns false
+    every { mockPackage1.reactActivityLifecycleListener.onNewIntent(intent) } returns true
+    every { delegate.onNewIntent(intent) } returns false
+
+    delegateWrapper.onNewIntent(intent)
+
+    verify(exactly = 1) { mockPackage0.reactActivityLifecycleListener.onNewIntent(any()) }
+    verify(exactly = 1) { mockPackage1.reactActivityLifecycleListener.onNewIntent(any()) }
+    verify(exactly = 1) { delegate.onNewIntent(any()) }
+  }
+
+  @Test
+  fun `onNewIntent should return true if someone returns true`() {
+    val intent = mockk<Intent>()
+    val delegateWrapper = ReactActivityDelegateWrapper(activity, delegate)
+    every { mockPackage0.reactActivityLifecycleListener.onNewIntent(intent) } returns false
+    every { mockPackage1.reactActivityLifecycleListener.onNewIntent(intent) } returns true
+    every { delegate.onNewIntent(intent) } returns false
+
+    val result = delegateWrapper.onNewIntent(intent)
+    assertThat(result).isTrue()
+  }
+}
+
+internal class MockPackage : Package {
+  val reactActivityLifecycleListener = mockk<ReactActivityLifecycleListener>(relaxed = true)
+  val reactActivityHandler = mockk<ReactActivityHandler>(relaxed = true)
+
+  override fun createReactActivityLifecycleListeners(activityContext: Context?): List<ReactActivityLifecycleListener> {
+    return listOf(reactActivityLifecycleListener)
+  }
+
+  override fun createReactActivityHandlers(activityContext: Context?): List<ReactActivityHandler> {
+    return listOf(reactActivityHandler)
+  }
+}


### PR DESCRIPTION
# Why

enhance 3rd party integration for `react-native-branch` to support `onNewIntent`

# How

add `onNewIntent` and `onBackPressed` to `ReactActivityLifecycleListener`

# Test Plan

## unit test - `ReactActivityDelegateWrapperTest`

Test | Duration | Result
-- | -- | --
onBackPressed should call each handler's callback just once | 0.596s | passed
onBackPressed should return true if someone returns true | 0.606s | passed
onNewIntent should call each handler's callback just once | 7.578s | passed
onNewIntent should return true if someone returns true | 0.631s | passed


# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
