### PR TITLE
[core] Add ReactActivityDelegateWrapperTest

### DIFF
--- a/packages/expo/android/build.gradle
+++ b/packages/expo/android/build.gradle
@@ -71,6 +71,9 @@ android {
   kotlinOptions {
     jvmTarget = '1.8'
   }
+  testOptions {
+    unitTests.includeAndroidResources = true
+  }
 
   sourceSets {
     main {
@@ -79,11 +82,23 @@ android {
       }
     }
   }
+
+  unitTestVariants.all {
+    it.mergedFlavor.manifestPlaceholders = [
+      // Fix expo-app-auth manifest merger issue for unit test
+      appAuthRedirectScheme: "test"
+    ]
+  }
 }
 
 dependencies { dependencyHandler ->
   //noinspection GradleDynamicVersion
   implementation 'com.facebook.react:react-native:+'
+
+  testImplementation 'junit:junit:4.13.1'
+  testImplementation 'androidx.test:core:1.4.0'
+  testImplementation "com.google.truth:truth:1.1.2"
+  testImplementation 'io.mockk:mockk:1.12.0'
 
   // Link expo modules as dependencies of the adapter. It uses `api` configuration so they all will be visible for the app as well.
   // A collection of the dependencies depends on the options passed to `useExpoModules` in your project's `settings.gradle`.

--- a/packages/expo/android/src/test/java/expo/modules/ReactActivityDelegateWrapperTest.kt
+++ b/packages/expo/android/src/test/java/expo/modules/ReactActivityDelegateWrapperTest.kt
@@ -1,0 +1,109 @@
+package expo.modules
+
+import android.content.Context
+import android.content.Intent
+import com.facebook.react.ReactActivity
+import com.facebook.react.ReactActivityDelegate
+import com.google.common.truth.Truth.assertThat
+import expo.modules.core.interfaces.Package
+import expo.modules.core.interfaces.ReactActivityHandler
+import expo.modules.core.interfaces.ReactActivityLifecycleListener
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.RelaxedMockK
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+internal class ReactActivityDelegateWrapperTest {
+  lateinit var mockPackage0: MockPackage
+
+  lateinit var mockPackage1: MockPackage
+
+  @RelaxedMockK
+  lateinit var activity: ReactActivity
+
+  @RelaxedMockK
+  lateinit var delegate: ReactActivityDelegate
+
+  @Before
+  fun setUp() {
+    mockPackage0 = MockPackage()
+    mockPackage1 = MockPackage()
+    MockKAnnotations.init(this)
+    mockkObject(ExpoModulesPackage.Companion)
+    every { ExpoModulesPackage.Companion.packageList } returns listOf(mockPackage0, mockPackage1)
+  }
+
+  @After
+  fun tearDown() {
+    unmockkAll()
+  }
+
+  @Test
+  fun `onBackPressed should call each handler's callback just once`() {
+    val delegateWrapper = ReactActivityDelegateWrapper(activity, delegate)
+    every { mockPackage0.reactActivityLifecycleListener.onBackPressed() } returns true
+
+    delegateWrapper.onBackPressed()
+
+    verify(exactly = 1) { mockPackage0.reactActivityLifecycleListener.onBackPressed() }
+    verify(exactly = 1) { mockPackage1.reactActivityLifecycleListener.onBackPressed() }
+    verify(exactly = 1) { delegate.onBackPressed() }
+  }
+
+  @Test
+  fun `onBackPressed should return true if someone returns true`() {
+    val delegateWrapper = ReactActivityDelegateWrapper(activity, delegate)
+    every { mockPackage0.reactActivityLifecycleListener.onBackPressed() } returns false
+    every { mockPackage1.reactActivityLifecycleListener.onBackPressed() } returns true
+    every { delegate.onBackPressed() } returns false
+
+    val result = delegateWrapper.onBackPressed()
+    assertThat(result).isTrue()
+  }
+
+  @Test
+  fun `onNewIntent should call each handler's callback just once`() {
+    val intent = mockk<Intent>()
+    val delegateWrapper = ReactActivityDelegateWrapper(activity, delegate)
+    every { mockPackage0.reactActivityLifecycleListener.onNewIntent(intent) } returns false
+    every { mockPackage1.reactActivityLifecycleListener.onNewIntent(intent) } returns true
+    every { delegate.onNewIntent(intent) } returns false
+
+    delegateWrapper.onNewIntent(intent)
+
+    verify(exactly = 1) { mockPackage0.reactActivityLifecycleListener.onNewIntent(any()) }
+    verify(exactly = 1) { mockPackage1.reactActivityLifecycleListener.onNewIntent(any()) }
+    verify(exactly = 1) { delegate.onNewIntent(any()) }
+  }
+
+  @Test
+  fun `onNewIntent should return true if someone returns true`() {
+    val intent = mockk<Intent>()
+    val delegateWrapper = ReactActivityDelegateWrapper(activity, delegate)
+    every { mockPackage0.reactActivityLifecycleListener.onNewIntent(intent) } returns false
+    every { mockPackage1.reactActivityLifecycleListener.onNewIntent(intent) } returns true
+    every { delegate.onNewIntent(intent) } returns false
+
+    val result = delegateWrapper.onNewIntent(intent)
+    assertThat(result).isTrue()
+  }
+}
+
+internal class MockPackage : Package {
+  val reactActivityLifecycleListener = mockk<ReactActivityLifecycleListener>(relaxed = true)
+  val reactActivityHandler = mockk<ReactActivityHandler>(relaxed = true)
+
+  override fun createReactActivityLifecycleListeners(activityContext: Context?): List<ReactActivityLifecycleListener> {
+    return listOf(reactActivityLifecycleListener)
+  }
+
+  override fun createReactActivityHandlers(activityContext: Context?): List<ReactActivityHandler> {
+    return listOf(reactActivityHandler)
+  }
+}


### PR DESCRIPTION
# Why

add unit test for #15550. since `expo` has autolinking to all packages, building the unit test may take extra time. so i initiated this unit test in separated pr. 

# How

add unit test for `ReactActivityDelegateWrapper.onNewIntent` and `ReactActivityDelegateWrapper.onBackPressed`

# Test Plan

android unit test ci passed

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
