### PR TITLE
[video-thumbnails] Added the ability for thumbnails to be generated from "content://" scheme on Android

### DIFF
--- a/packages/expo-video-thumbnails/CHANGELOG.md
+++ b/packages/expo-video-thumbnails/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### 💡 Others
 
+## 6.2.0 — 2021-12-14
+
+- Thumbnails can now be generated with 'content://' paths on Android[#15553](https://github.com/expo/expo/pull/15553) by (@lukebrandonfarrell)[https://github.com/lukebrandonfarrell]
+
 ## 6.1.0 — 2021-12-03
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-video-thumbnails/CHANGELOG.md
+++ b/packages/expo-video-thumbnails/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unpublished
 
+- Thumbnails can now be generated with `content://` paths on Android. ([#15553](https://github.com/expo/expo/pull/15553) by [@lukebrandonfarrell](https://github.com/lukebrandonfarrell))
+
 ### 🛠 Breaking changes
 
 ### 🎉 New features
@@ -9,10 +11,6 @@
 ### 🐛 Bug fixes
 
 ### 💡 Others
-
-## 6.2.0 — 2021-12-14
-
-- Thumbnails can now be generated with `content://` paths on Android. ([#15553](https://github.com/expo/expo/pull/15553) by [@lukebrandonfarrell](https://github.com/lukebrandonfarrell))
 
 ## 6.1.0 — 2021-12-03
 

--- a/packages/expo-video-thumbnails/CHANGELOG.md
+++ b/packages/expo-video-thumbnails/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ## 6.2.0 — 2021-12-14
 
-- Thumbnails can now be generated with 'content://' paths on Android[#15553](https://github.com/expo/expo/pull/15553) by (@lukebrandonfarrell)[https://github.com/lukebrandonfarrell]
+- Thumbnails can now be generated with `content://` paths on Android. ([#15553](https://github.com/expo/expo/pull/15553) by [@lukebrandonfarrell](https://github.com/lukebrandonfarrell))
 
 ## 6.1.0 — 2021-12-03
 

--- a/packages/expo-video-thumbnails/android/src/main/java/expo/modules/videothumbnails/VideoThumbnailsModule.java
+++ b/packages/expo-video-thumbnails/android/src/main/java/expo/modules/videothumbnails/VideoThumbnailsModule.java
@@ -70,7 +70,7 @@ public class VideoThumbnailsModule extends ExportedModule {
       try {
         if (URLUtil.isFileUrl(mSourceFilename)) {
           retriever.setDataSource(Uri.decode(mSourceFilename).replace("file://", ""));
-        } else if(URLUtil.isContentUrl(mSourceFilename)) {
+        } else if (URLUtil.isContentUrl(mSourceFilename)) {
           Uri fileUri = Uri.parse(mSourceFilename);
           FileDescriptor fileDescriptor = mContext.getContentResolver().openFileDescriptor(fileUri, "r").getFileDescriptor();
           FileInputStream inputStream = new FileInputStream(fileDescriptor);

--- a/packages/expo-video-thumbnails/package.json
+++ b/packages/expo-video-thumbnails/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-video-thumbnails",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "description": "ExpoVideoThumbnails standalone module",
   "main": "build/VideoThumbnails.js",
   "types": "build/VideoThumbnails.d.ts",

--- a/packages/expo-video-thumbnails/package.json
+++ b/packages/expo-video-thumbnails/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-video-thumbnails",
-  "version": "6.2.0",
+  "version": "6.1.0",
   "description": "ExpoVideoThumbnails standalone module",
   "main": "build/VideoThumbnails.js",
   "types": "build/VideoThumbnails.d.ts",


### PR DESCRIPTION
# Why

Currently it is not possible to generate a thumbnail from a 'content://' path of Android. Fixes #7832 (even though it has been closed erroneously ;)). This adds functionality to the `VideoThumbnails.getThumbnailAsync` method.

# How

We add an extra `else` condition to check if file is `content://` path with `URLUtil.isContentUrl(mSourceFilename)` and if `true` open ani put stream using a `FileDescriptor` to set the retriever data source `retriever.setDataSource` which is used to generate the thumbnail.

# Test Plan

Tests on a physical Android device with a `content://` URI.

# Checklist

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [X] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
