### PR TITLE
[expo-json-utils][ios] Add generics to NSDictionary category

### DIFF
--- a/packages/expo-json-utils/ios/EXJSONUtils/NSDictionary+EXJSONUtils.h
+++ b/packages/expo-json-utils/ios/EXJSONUtils/NSDictionary+EXJSONUtils.h
@@ -4,16 +4,16 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface NSDictionary (EXJSONUtils)
+@interface NSDictionary<__covariant KeyType, __covariant ObjectType> (EXJSONUtils)
 
-- (NSString *)stringForKey:(NSString *)key;
-- (nullable NSString *)nullableStringForKey:(NSString *)key;
-- (NSNumber *)numberForKey:(NSString *)key;
-- (nullable NSNumber *)nullableNumberForKey:(NSString *)key;
-- (NSArray *)arrayForKey:(NSString *)key;
-- (nullable NSArray *)nullableArrayForKey:(NSString *)key;
-- (NSDictionary *)dictionaryForKey:(NSString *)key;
-- (nullable NSDictionary *)nullableDictionaryForKey:(NSString *)key;
+- (NSString *)stringForKey:(KeyType)key;
+- (nullable NSString *)nullableStringForKey:(KeyType)key;
+- (NSNumber *)numberForKey:(KeyType)key;
+- (nullable NSNumber *)nullableNumberForKey:(KeyType)key;
+- (NSArray *)arrayForKey:(KeyType)key;
+- (nullable NSArray *)nullableArrayForKey:(KeyType)key;
+- (NSDictionary *)dictionaryForKey:(KeyType)key;
+- (nullable NSDictionary *)nullableDictionaryForKey:(KeyType)key;
 
 @end
 

--- a/packages/expo-json-utils/ios/EXJSONUtils/NSDictionary+EXJSONUtils.m
+++ b/packages/expo-json-utils/ios/EXJSONUtils/NSDictionary+EXJSONUtils.m
@@ -19,35 +19,35 @@
 
 @implementation NSDictionary (EXJSONUtils)
 
-- (NSString *)stringForKey:(NSString *)key {
+- (NSString *)stringForKey:(id)key {
   return EXGetNonNullManifestValue(NSString, key);
 }
 
-- (nullable NSString *)nullableStringForKey:(NSString *)key {
+- (nullable NSString *)nullableStringForKey:(id)key {
   return EXGetNullableManifestValue(NSString, key);
 }
 
-- (NSNumber *)numberForKey:(NSString *)key {
+- (NSNumber *)numberForKey:(id)key {
   return EXGetNonNullManifestValue(NSNumber, key);
 }
 
-- (nullable NSNumber *)nullableNumberForKey:(NSString *)key {
+- (nullable NSNumber *)nullableNumberForKey:(id)key {
   return EXGetNullableManifestValue(NSNumber, key);
 }
 
-- (NSArray *)arrayForKey:(NSString *)key {
+- (NSArray *)arrayForKey:(id)key {
   return EXGetNonNullManifestValue(NSArray, key);
 }
 
-- (nullable NSArray *)nullableArrayForKey:(NSString *)key {
+- (nullable NSArray *)nullableArrayForKey:(id)key {
   return EXGetNullableManifestValue(NSArray, key);
 }
 
-- (NSDictionary *)dictionaryForKey:(NSString *)key {
+- (NSDictionary *)dictionaryForKey:(id)key {
   return EXGetNonNullManifestValue(NSDictionary, key);
 }
 
-- (nullable NSDictionary *)nullableDictionaryForKey:(NSString *)key {
+- (nullable NSDictionary *)nullableDictionaryForKey:(id)key {
   return EXGetNullableManifestValue(NSDictionary, key);
 }
 


### PR DESCRIPTION
# Why

Closes ENG-2631.

When I was writing this I forgot that objective-c had generics.

# How

Add generics. Though the object type generic is not used, it's still useful to specify so that receivers correctly get the generic version.

# Test Plan

Run unit test.