### PR TITLE
[expo-updates][android] Use immutable fields in UpdatesConfiguration

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.kt
@@ -139,7 +139,7 @@ class ExpoUpdatesAppLoader @JvmOverloads constructor(
     }
     configMap[UpdatesConfiguration.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY] = requestHeaders
     configMap[UpdatesConfiguration.UPDATES_CONFIGURATION_EXPECTS_EXPO_SIGNED_MANIFEST] = true
-    val configuration = UpdatesConfiguration().loadValuesFromMap(configMap)
+    val configuration = UpdatesConfiguration(null, configMap)
     val sdkVersionsList = mutableListOf<String>().apply {
       (Constants.SDK_VERSIONS_LIST + listOf(RNObject.UNVERSIONED)).forEach {
         add(it)

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/UpdatesConfigurationInstrumentationTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/UpdatesConfigurationInstrumentationTest.kt
@@ -1,65 +1,116 @@
 package expo.modules.updates
 
 import android.content.Context
-import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
+import android.net.Uri
 import android.os.Bundle
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
+import io.mockk.every
+import io.mockk.mockk
 import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito
-import org.mockito.runners.MockitoJUnitRunner
 
-@RunWith(MockitoJUnitRunner::class)
+@RunWith(AndroidJUnit4ClassRunner::class)
 class UpdatesConfigurationInstrumentationTest {
-  var packageName = "test"
-  var runtimeVersion = "3.14"
   @Test
-  @Throws(PackageManager.NameNotFoundException::class)
-  fun testLoadValuesFromMetadata_stripsPrefix() {
-    val metaData = Bundle().apply {
-      putString(
-        "expo.modules.updates.EXPO_RUNTIME_VERSION",
-        String.format("string:%s", runtimeVersion)
-      )
+  fun test_runtimeVersion_stripsPrefix() {
+    val testPackageName = "test"
+    val testRuntimeVersion = "3.14"
+
+    val context = mockk<Context> {
+      every { packageName } returns testPackageName
+      every { packageManager } returns mockk {
+        every { getApplicationInfo(testPackageName, PackageManager.GET_META_DATA) } returns mockk {
+          metaData = Bundle().apply {
+            putString(
+              "expo.modules.updates.EXPO_RUNTIME_VERSION",
+              String.format("string:%s", testRuntimeVersion)
+            )
+          }
+        }
+      }
     }
-    val mockAi = Mockito.mock(ApplicationInfo::class.java)
-    mockAi.metaData = metaData
-    val packageManager = Mockito.mock(
-      PackageManager::class.java
-    )
-    Mockito.`when`(packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA))
-      .thenReturn(mockAi)
-    val context = Mockito.mock(
-      Context::class.java
-    )
-    Mockito.`when`(context.packageName).thenReturn(packageName)
-    Mockito.`when`(context.packageManager).thenReturn(packageManager)
-    var config = UpdatesConfiguration()
-    config = config.loadValuesFromMetadata(context)
-    Assert.assertEquals(runtimeVersion, config.runtimeVersion)
+    val config = UpdatesConfiguration(context, null)
+    Assert.assertEquals(config.runtimeVersion, testRuntimeVersion)
   }
 
   @Test
-  @Throws(PackageManager.NameNotFoundException::class)
-  fun testLoadValuesFromMetadata_worksWithoutPrefix() {
-    val metaData = Bundle().apply {
-      putString("expo.modules.updates.EXPO_RUNTIME_VERSION", runtimeVersion)
+  fun test_runtimeVersion_worksWithoutPrefix() {
+    val testPackageName = "test"
+    val testRuntimeVersion = "3.14"
+
+    val context = mockk<Context> {
+      every { packageName } returns testPackageName
+      every { packageManager } returns mockk {
+        every { getApplicationInfo(testPackageName, PackageManager.GET_META_DATA) } returns mockk {
+          metaData = Bundle().apply {
+            putString("expo.modules.updates.EXPO_RUNTIME_VERSION", testRuntimeVersion)
+          }
+        }
+      }
     }
-    val mockAi = Mockito.mock(ApplicationInfo::class.java)
-    mockAi.metaData = metaData
-    val packageManager = Mockito.mock(
-      PackageManager::class.java
+    val config = UpdatesConfiguration(context, null)
+    Assert.assertEquals(config.runtimeVersion, testRuntimeVersion)
+  }
+
+  @Test
+  fun test_initialization_mapTakesPrecedenceOverContext() {
+    val testPackageName = "test"
+
+    val context = mockk<Context> {
+      every { packageName } returns testPackageName
+      every { packageManager } returns mockk {
+        every { getApplicationInfo(testPackageName, PackageManager.GET_META_DATA) } returns mockk {
+          metaData = Bundle().apply {
+            putBoolean("expo.modules.updates.ENABLED", true)
+            putString("expo.modules.updates.EXPO_SCOPE_KEY", "invalid")
+            putString("expo.modules.updates.EXPO_UPDATE_URL", "http://invalid.com")
+            putString("expo.modules.updates.EXPO_SDK_VERSION", "invalid")
+            putString("expo.modules.updates.EXPO_RUNTIME_VERSION", "invalid")
+            putString("expo.modules.updates.EXPO_RELEASE_CHANNEL", "invalid")
+            putInt("expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS", 9000)
+            putString("expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH", "ALWAYS")
+            putBoolean("expo.modules.updates.HAS_EMBEDDED_UPDATE", true)
+            putString("expo.modules.updates.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY", "{\"test\":\"invalid\"}")
+            putString("expo.modules.updates.CODE_SIGNING_CERTIFICATE", "invalid")
+            putString("expo.modules.updates.CODE_SIGNING_METADATA", "{\"test\":\"invalid\"}")
+          }
+        }
+      }
+    }
+
+    val config = UpdatesConfiguration(
+      context,
+      mapOf(
+        UpdatesConfiguration.UPDATES_CONFIGURATION_ENABLED_KEY to false,
+        UpdatesConfiguration.UPDATES_CONFIGURATION_SCOPE_KEY_KEY to "override",
+        UpdatesConfiguration.UPDATES_CONFIGURATION_UPDATE_URL_KEY to Uri.parse("http://override.com"),
+        UpdatesConfiguration.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY to mapOf("test" to "override"),
+        UpdatesConfiguration.UPDATES_CONFIGURATION_RELEASE_CHANNEL_KEY to "override",
+        UpdatesConfiguration.UPDATES_CONFIGURATION_SDK_VERSION_KEY to "override",
+        UpdatesConfiguration.UPDATES_CONFIGURATION_RUNTIME_VERSION_KEY to "override",
+        UpdatesConfiguration.UPDATES_CONFIGURATION_CHECK_ON_LAUNCH_KEY to "NEVER",
+        UpdatesConfiguration.UPDATES_CONFIGURATION_LAUNCH_WAIT_MS_KEY to 1000,
+        UpdatesConfiguration.UPDATES_CONFIGURATION_HAS_EMBEDDED_UPDATE_KEY to false,
+        UpdatesConfiguration.UPDATES_CONFIGURATION_EXPECTS_EXPO_SIGNED_MANIFEST to false,
+        UpdatesConfiguration.UPDATES_CONFIGURATION_CODE_SIGNING_CERTIFICATE to "override",
+        UpdatesConfiguration.UPDATES_CONFIGURATION_CODE_SIGNING_METADATA to mapOf("test" to "override"),
+      )
     )
-    Mockito.`when`(packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA))
-      .thenReturn(mockAi)
-    val context = Mockito.mock(
-      Context::class.java
-    )
-    Mockito.`when`(context.packageName).thenReturn(packageName)
-    Mockito.`when`(context.packageManager).thenReturn(packageManager)
-    var config = UpdatesConfiguration()
-    config = config.loadValuesFromMetadata(context)
-    Assert.assertEquals(runtimeVersion, config.runtimeVersion)
+
+    Assert.assertEquals(false, config.isEnabled)
+    Assert.assertEquals(false, config.expectsSignedManifest)
+    Assert.assertEquals("override", config.scopeKey)
+    Assert.assertEquals(Uri.parse("http://override.com"), config.updateUrl)
+    Assert.assertEquals("override", config.sdkVersion)
+    Assert.assertEquals("override", config.runtimeVersion)
+    Assert.assertEquals("override", config.releaseChannel)
+    Assert.assertEquals(1000, config.launchWaitMs)
+    Assert.assertEquals(UpdatesConfiguration.CheckAutomaticallyConfiguration.NEVER, config.checkOnLaunch)
+    Assert.assertEquals(false, config.hasEmbeddedUpdate)
+    Assert.assertEquals(mapOf("test" to "override"), config.requestHeaders)
+    Assert.assertEquals("override", config.codeSigningCertificate)
+    Assert.assertEquals(mapOf("test" to "override"), config.codeSigningMetadata)
   }
 }

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/db/BuildDataTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/db/BuildDataTest.kt
@@ -30,12 +30,8 @@ class BuildDataTest {
     "updateUrl" to Uri.parse("https://exp.host/@test/test"),
     "requestHeaders" to mapOf("expo-channel-name" to "testTwo")
   )
-  private val updatesConfigTestChannel = UpdatesConfiguration().loadValuesFromMap(
-    buildMapTestChannel
-  )
-  private val updatesConfigTestTwoChannel = UpdatesConfiguration().loadValuesFromMap(
-    buildMapTestTwoChannel
-  )
+  private val updatesConfigTestChannel = UpdatesConfiguration(null, buildMapTestChannel)
+  private val updatesConfigTestTwoChannel = UpdatesConfiguration(null, buildMapTestTwoChannel)
 
   private val buildMapTestReleaseChannel = mapOf(
     "scopeKey" to scopeKey,
@@ -47,12 +43,8 @@ class BuildDataTest {
     "updateUrl" to Uri.parse("https://exp.host/@test/test"),
     "releaseChannel" to "testTwo"
   )
-  private val updatesConfigTestReleaseChannel = UpdatesConfiguration().loadValuesFromMap(
-    buildMapTestReleaseChannel
-  )
-  private val updatesConfigTestTwoReleaseChannel = UpdatesConfiguration().loadValuesFromMap(
-    buildMapTestTwoReleaseChannel
-  )
+  private val updatesConfigTestReleaseChannel = UpdatesConfiguration(null, buildMapTestReleaseChannel)
+  private val updatesConfigTestTwoReleaseChannel = UpdatesConfiguration(null, buildMapTestTwoReleaseChannel)
 
   private val uuid: UUID = UUID.randomUUID()
   private lateinit var spyBuildData: BuildData

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/launcher/DatabaseLauncherTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/launcher/DatabaseLauncherTest.kt
@@ -52,7 +52,7 @@ class DatabaseLauncherTest {
     db.assetDao().insertAssets(listOf(testAsset), testUpdate)
 
     val launcher = DatabaseLauncher(
-      UpdatesConfiguration(),
+      UpdatesConfiguration(null, null),
       File("test"),
       FileDownloader(context),
       SelectionPolicy(

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/CryptoTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/CryptoTest.kt
@@ -4,7 +4,6 @@ import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
 import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.lang.Error
 
 private const val testBody = "{\"id\":\"0754dad0-d200-d634-113c-ef1f26106028\",\"createdAt\":\"2021-11-23T00:57:14.437Z\",\"runtimeVersion\":\"1\",\"assets\":[{\"hash\":\"cb65fafb5ed456fc3ed8a726cf4087d37b875184eba96f33f6d99104e6e2266d\",\"key\":\"489ea2f19fa850b65653ab445637a181.jpg\",\"contentType\":\"image/jpeg\",\"url\":\"http://192.168.64.1:3000/api/assets?asset=updates/1/assets/489ea2f19fa850b65653ab445637a181&runtimeVersion=1&platform=android\",\"fileExtension\":\".jpg\"}],\"launchAsset\":{\"hash\":\"323ddd1968ee76d4ddbb16b04fb2c3f1b6d1ab9b637d819699fecd6fa0ffb1a8\",\"key\":\"696a70cf7035664c20ea86f67dae822b.bundle\",\"contentType\":\"application/javascript\",\"url\":\"http://192.168.64.1:3000/api/assets?asset=updates/1/bundles/android-696a70cf7035664c20ea86f67dae822b.js&runtimeVersion=1&platform=android\",\"fileExtension\":\".bundle\"}}"
 private const val testCertificate = "-----BEGIN CERTIFICATE-----\nMIIDfzCCAmegAwIBAgIJLGiqnjmA9JmpMA0GCSqGSIb3DQEBCwUAMGkxFDASBgNV\nBAMTC2V4YW1wbGUub3JnMQswCQYDVQQGEwJVUzERMA8GA1UECBMIVmlyZ2luaWEx\nEzARBgNVBAcTCkJsYWNrc2J1cmcxDTALBgNVBAoTBFRlc3QxDTALBgNVBAsTBFRl\nc3QwHhcNMjExMTIyMTc0NzQzWhcNMjIxMTIyMTc0NzQzWjBpMRQwEgYDVQQDEwtl\neGFtcGxlLm9yZzELMAkGA1UEBhMCVVMxETAPBgNVBAgTCFZpcmdpbmlhMRMwEQYD\nVQQHEwpCbGFja3NidXJnMQ0wCwYDVQQKEwRUZXN0MQ0wCwYDVQQLEwRUZXN0MIIB\nIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAucg/fRwgYLxO4fDG1W/ew4Wu\nkqp2+j9mLyA18sd8noCT0eSJwxMTLJJq4biNx6kJEVSQdodN3e/qSJndz+ZHA7b1\n6Do3Ecg5oRvl3HEwaH4AkM2Lj87VjgfxPUsiSHtPd+RTbxnOy9lGupQa/j71WrAq\nzJpNmhP70vzkY4EVejn52kzRPZB3kTxkjggFrG/f18Bcf4VYxN3aLML32jih+UC0\n6fv57HNZZ3ewGSJrLcUdEgctBWiz1gzwF6YdXtEJ14eQbgHgsLsXaEQeg2ncGGxF\n/3rIhsnlWjeIIya7TS0nvqZHNKznZV9EWpZQBFVoLGGrvOdU3pTmP39qbmY0nwID\nAQABoyowKDAOBgNVHQ8BAf8EBAMCB4AwFgYDVR0lAQH/BAwwCgYIKwYBBQUHAwMw\nDQYJKoZIhvcNAQELBQADggEBAALcH9Jb3wq64YkNxUIa25T9umhr4uRe94ESHujM\nIRrBbbqu1p3Vs8N3whZNhcL6Djb4ob18m/aGKbF+UQBMvhn23qRCG6KKzIeDY6Os\n8tYyIwush2XeOFA7S5syPqVBI6PrRBDMCLmAJO4qTM2p0f+zyFXFuytCXOv2fA3M\n88aYVmU7NIfBTFdqNIgSt1yj7FKvd5zgoUyu7mTVdzY59xQzkzYTsnobY2XrTcvY\n6wyRqOAQ86wR8OvDjHB5y/YN2Pdg7d9jUFBCX6Ohr7W3GHrjAadKwq+kbH1aP0oB\nQTFLQQfl3gtJ3Dl/5iBQD38sCIkA54FPSsKTRw3mC4DImBQ=\n-----END CERTIFICATE-----"
@@ -28,8 +27,8 @@ class CryptoTest {
     Assert.assertEquals(codeSigningInfo.algorithm, Crypto.CodeSigningAlgorithm.RSA_SHA256)
   }
 
-  @Test(expected = Error::class)
-  @Throws(Error::class)
+  @Test(expected = Exception::class)
+  @Throws(Exception::class)
   fun test_parseSignatureHeader_ThrowsForInvalidAlg() {
     Crypto.parseSignatureHeader("sig=\"12345\", alg=\"blah\"")
   }
@@ -54,8 +53,8 @@ class CryptoTest {
     Assert.assertEquals(signatureHeader, "sig, keyid=\"test\", alg=\"rsa-v1_5-sha256\"")
   }
 
-  @Test(expected = Error::class)
-  @Throws(Error::class)
+  @Test(expected = Exception::class)
+  @Throws(Exception::class)
   fun test_createAcceptSignatureHeader_ThrowsInvalidAlg() {
     val configuration = Crypto.CodeSigningConfiguration(
       testCertificate,
@@ -83,8 +82,8 @@ class CryptoTest {
     Assert.assertFalse(isValid)
   }
 
-  @Test(expected = Error::class)
-  @Throws(Error::class)
+  @Test(expected = Exception::class)
+  @Throws(Exception::class)
   fun test_verifyCodeSigning_ThrowsWhenKeyDoesNotMatch() {
     val codeSigningConfiguration = Crypto.CodeSigningConfiguration(
       testCertificate,

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/EmbeddedLoaderTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/EmbeddedLoaderTest.kt
@@ -42,7 +42,7 @@ class EmbeddedLoaderTest {
       "updateUrl" to Uri.parse("https://exp.host/@test/test"),
       "runtimeVersion" to "1.0"
     )
-    configuration = UpdatesConfiguration().loadValuesFromMap(configMap)
+    configuration = UpdatesConfiguration(null, configMap)
     val context = InstrumentationRegistry.getInstrumentation().targetContext
     db = Room.inMemoryDatabaseBuilder(context, UpdatesDatabase::class.java).build()
     mockLoaderFiles = mockk(relaxed = true)

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderManifestParsingTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderManifestParsingTest.kt
@@ -33,7 +33,8 @@ class FileDownloaderManifestParsingTest {
       every { body() } returns ResponseBody.create(MediaType.parse("application/json; charset=utf-8"), classicJSON)
     }
 
-    val configuration = UpdatesConfiguration().loadValuesFromMap(
+    val configuration = UpdatesConfiguration(
+      null,
       mapOf(
         UpdatesConfiguration.UPDATES_CONFIGURATION_UPDATE_URL_KEY to Uri.parse("https://exp.host/@test/test"),
       )
@@ -92,7 +93,8 @@ class FileDownloaderManifestParsingTest {
       every { body() } returns ResponseBody.create(MultipartBody.MIXED, contentBuffer.readByteArray())
     }
 
-    val configuration = UpdatesConfiguration().loadValuesFromMap(
+    val configuration = UpdatesConfiguration(
+      null,
       mapOf(
         UpdatesConfiguration.UPDATES_CONFIGURATION_UPDATE_URL_KEY to Uri.parse("https://exp.host/@test/test"),
       )
@@ -139,7 +141,8 @@ class FileDownloaderManifestParsingTest {
       every { body() } returns ResponseBody.create(MediaType.parse("application/json; charset=utf-8"), newJSON)
     }
 
-    val configuration = UpdatesConfiguration().loadValuesFromMap(
+    val configuration = UpdatesConfiguration(
+      null,
       mapOf(
         UpdatesConfiguration.UPDATES_CONFIGURATION_UPDATE_URL_KEY to Uri.parse("https://exp.host/@test/test"),
         UpdatesConfiguration.UPDATES_CONFIGURATION_CODE_SIGNING_CERTIFICATE to newJSONCertificate,
@@ -213,7 +216,8 @@ class FileDownloaderManifestParsingTest {
       every { body() } returns ResponseBody.create(MultipartBody.MIXED, contentBuffer.readByteArray())
     }
 
-    val configuration = UpdatesConfiguration().loadValuesFromMap(
+    val configuration = UpdatesConfiguration(
+      null,
       mapOf(
         UpdatesConfiguration.UPDATES_CONFIGURATION_UPDATE_URL_KEY to Uri.parse("https://exp.host/@test/test"),
         UpdatesConfiguration.UPDATES_CONFIGURATION_CODE_SIGNING_CERTIFICATE to newJSONCertificate,
@@ -260,7 +264,8 @@ class FileDownloaderManifestParsingTest {
       every { body() } returns ResponseBody.create(MediaType.parse("application/json; charset=utf-8"), newJSON)
     }
 
-    val configuration = UpdatesConfiguration().loadValuesFromMap(
+    val configuration = UpdatesConfiguration(
+      null,
       mapOf(
         UpdatesConfiguration.UPDATES_CONFIGURATION_UPDATE_URL_KEY to Uri.parse("https://exp.host/@test/test"),
         UpdatesConfiguration.UPDATES_CONFIGURATION_CODE_SIGNING_CERTIFICATE to newJSONCertificate,

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderTest.kt
@@ -34,7 +34,7 @@ class FileDownloaderTest {
       "runtimeVersion" to "1.0",
       "usesLegacyManifest" to true
     )
-    val config = UpdatesConfiguration().loadValuesFromMap(configMap)
+    val config = UpdatesConfiguration(null, configMap)
     val actual = FileDownloader.createRequestForManifest(config, null, context)
     Assert.assertNull(actual.header("Cache-Control"))
   }
@@ -46,7 +46,7 @@ class FileDownloaderTest {
       "runtimeVersion" to "1.0",
       "usesLegacyManifest" to false
     )
-    val config = UpdatesConfiguration().loadValuesFromMap(configMap)
+    val config = UpdatesConfiguration(null, configMap)
     val actual = FileDownloader.createRequestForManifest(config, null, context)
     Assert.assertNull(actual.header("Cache-Control"))
   }
@@ -59,7 +59,7 @@ class FileDownloaderTest {
       "runtimeVersion" to "1.0",
 
     )
-    val config = UpdatesConfiguration().loadValuesFromMap(configMap)
+    val config = UpdatesConfiguration(null, configMap)
     val extraHeaders = JSONObject().apply {
       put("expo-string", "test")
       put("expo-number", 47.5)
@@ -83,7 +83,7 @@ class FileDownloaderTest {
       "requestHeaders" to headersMap
     )
 
-    val config = UpdatesConfiguration().loadValuesFromMap(configMap)
+    val config = UpdatesConfiguration(null, configMap)
 
     // serverDefinedHeaders should not be able to override preset headers
     val extraHeaders = JSONObject()
@@ -105,7 +105,7 @@ class FileDownloaderTest {
       "requestHeaders" to headersMap
     )
 
-    val config = UpdatesConfiguration().loadValuesFromMap(configMap)
+    val config = UpdatesConfiguration(null, configMap)
 
     val assetEntity = AssetEntity("test", "jpg").apply {
       url = Uri.parse("https://example.com")
@@ -125,7 +125,7 @@ class FileDownloaderTest {
       UpdatesConfiguration.UPDATES_CONFIGURATION_RUNTIME_VERSION_KEY to "1.0",
     )
 
-    val config = UpdatesConfiguration().loadValuesFromMap(configMap)
+    val config = UpdatesConfiguration(null, configMap)
 
     val assetEntity = AssetEntity(UUID.randomUUID().toString(), "jpg").apply {
       url = Uri.parse("https://example.com")

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/RemoteLoaderTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/RemoteLoaderTest.kt
@@ -44,7 +44,7 @@ class RemoteLoaderTest {
       "updateUrl" to Uri.parse("https://exp.host/@test/test"),
       "runtimeVersion" to "1.0"
     )
-    configuration = UpdatesConfiguration().loadValuesFromMap(configMap)
+    configuration = UpdatesConfiguration(null, configMap)
     val context = InstrumentationRegistry.getInstrumentation().targetContext
     db = Room.inMemoryDatabaseBuilder(context, UpdatesDatabase::class.java).build()
     mockLoaderFiles = mockk()

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/LegacyUpdateManifestTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/LegacyUpdateManifestTest.kt
@@ -238,6 +238,6 @@ class LegacyUpdateManifestTest {
   private fun createConfig(): UpdatesConfiguration {
     val configMap = HashMap<String, Any>()
     configMap["updateUrl"] = Uri.parse("https://exp.host/@test/test")
-    return UpdatesConfiguration().loadValuesFromMap(configMap)
+    return UpdatesConfiguration(null, configMap)
   }
 }

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/NewUpdateManifestTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/NewUpdateManifestTest.kt
@@ -62,7 +62,7 @@ class NewUpdateManifestTest {
   private fun createConfig(): UpdatesConfiguration {
     val configMap = HashMap<String, Any>()
     configMap["updateUrl"] = Uri.parse("https://exp.host/@test/test")
-    return UpdatesConfiguration().loadValuesFromMap(configMap)
+    return UpdatesConfiguration(null, configMap)
   }
 
   @Test

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/UpdateManifestFactoryTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/UpdateManifestFactoryTest.kt
@@ -23,7 +23,7 @@ class UpdateManifestFactoryTest {
 
   private fun createConfig(): UpdatesConfiguration {
     val configMap = mapOf("updateUrl" to Uri.parse("https://exp.host/@esamelson/native-component-list"))
-    return UpdatesConfiguration().loadValuesFromMap(configMap)
+    return UpdatesConfiguration(null, configMap)
   }
 
   @Test

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/UpdateManifestMetadataTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/UpdateManifestMetadataTest.kt
@@ -92,7 +92,8 @@ class UpdateManifestMetadataTest {
   }
 
   private fun createConfig(): UpdatesConfiguration {
-    return UpdatesConfiguration().loadValuesFromMap(
+    return UpdatesConfiguration(
+      null,
       mapOf(
         "updateUrl" to Uri.parse("https://exp.host/@test/test")
       )

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/selectionpolicy/SelectionPolicyFilterAwareTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/selectionpolicy/SelectionPolicyFilterAwareTest.kt
@@ -32,7 +32,7 @@ class SelectionPolicyFilterAwareTest {
     manifestFilters = JSONObject("{\"branchname\": \"rollout\"}")
     selectionPolicy = SelectionPolicyFactory.createFilterAwarePolicy("1.0")
     val configMap = mapOf<String, Any>("updateUrl" to Uri.parse("https://exp.host/@test/test"))
-    val config = UpdatesConfiguration().loadValuesFromMap(configMap)
+    val config = UpdatesConfiguration(null, configMap)
     val manifestJsonRollout0 = NewManifest(JSONObject("{\"id\":\"079cde35-8433-4c17-81c8-7117c1513e71\",\"createdAt\":\"2021-01-10T19:39:22.480Z\",\"runtimeVersion\":\"1.0\",\"launchAsset\":{\"hash\":\"DW5MBgKq155wnX8rCP1lnsW6BsTbfKLXxGXRQx1RcOA\",\"key\":\"0436e5821bff7b95a84c21f22a43cb96.bundle\",\"contentType\":\"application/javascript\",\"url\":\"https://url.to/bundle\"},\"assets\":[{\"hash\":\"JSeRsPNKzhVdHP1OEsDVsLH500Zfe4j1O7xWfa14oBo\",\"key\":\"3261e570d51777be1e99116562280926.png\",\"contentType\":\"image/png\",\"url\":\"https://url.to/asset\"}],\"metadata\":{\"branchName\":\"rollout\"}}"))
     updateRollout0 = NewUpdateManifest.fromNewManifest(manifestJsonRollout0, ManifestHeaderData(), null, config).updateEntity
     val manifestJsonDefault1 = NewManifest(JSONObject("{\"id\":\"079cde35-8433-4c17-81c8-7117c1513e72\",\"createdAt\":\"2021-01-11T19:39:22.480Z\",\"runtimeVersion\":\"1.0\",\"launchAsset\":{\"hash\":\"DW5MBgKq155wnX8rCP1lnsW6BsTbfKLXxGXRQx1RcOA\",\"key\":\"0436e5821bff7b95a84c21f22a43cb96.bundle\",\"contentType\":\"application/javascript\",\"url\":\"https://url.to/bundle\"},\"assets\":[{\"hash\":\"JSeRsPNKzhVdHP1OEsDVsLH500Zfe4j1O7xWfa14oBo\",\"key\":\"3261e570d51777be1e99116562280926.png\",\"contentType\":\"image/png\",\"url\":\"https://url.to/asset\"}],\"metadata\":{\"branchName\":\"default\"}}"))

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.kt
@@ -6,177 +6,67 @@ import android.net.Uri
 import android.util.Log
 import expo.modules.updates.loader.Crypto
 
-class UpdatesConfiguration {
+class UpdatesConfiguration private constructor (
+  val isEnabled: Boolean,
+  val expectsSignedManifest: Boolean,
+  val scopeKey: String?,
+  val updateUrl: Uri?,
+  val sdkVersion: String?,
+  val runtimeVersion: String?,
+  val releaseChannel: String,
+  val launchWaitMs: Int,
+  val checkOnLaunch: CheckAutomaticallyConfiguration,
+  val hasEmbeddedUpdate: Boolean, // used only for expo-updates development
+  val requestHeaders: Map<String, String>,
+  val codeSigningCertificate: String?,
+  val codeSigningMetadata: Map<String, String>?,
+) {
   enum class CheckAutomaticallyConfiguration {
     NEVER, ERROR_RECOVERY_ONLY, WIFI_ONLY, ALWAYS
   }
 
-  var isEnabled = false
-    private set
-  var expectsSignedManifest = false
-    private set
-  var scopeKey: String? = null
-    private set
-  var updateUrl: Uri? = null
-    private set
-  var sdkVersion: String? = null
-    private set
-  var runtimeVersion: String? = null
-    private set
-  var releaseChannel = UPDATES_CONFIGURATION_RELEASE_CHANNEL_DEFAULT_VALUE
-    private set
-  var launchWaitMs = UPDATES_CONFIGURATION_LAUNCH_WAIT_MS_DEFAULT_VALUE
-    private set
-  var checkOnLaunch = CheckAutomaticallyConfiguration.ALWAYS
-    private set
-  var hasEmbeddedUpdate = true
-  var requestHeaders = mapOf<String, String>()
-    private set
-
-  private var codeSigningCertificate: String? = null
-  private var codeSigningMetadata: Map<String, String>? = null
-
-  val isMissingRuntimeVersion: Boolean
-    get() = (runtimeVersion == null || runtimeVersion!!.isEmpty()) &&
-      (sdkVersion == null || sdkVersion!!.isEmpty())
-
-  fun loadValuesFromMetadata(context: Context): UpdatesConfiguration {
-    try {
-      val ai = context.packageManager.getApplicationInfo(context.packageName, PackageManager.GET_META_DATA)
-      updateUrl = ai.metaData.getString("expo.modules.updates.EXPO_UPDATE_URL")?.let { Uri.parse(it) }
-      scopeKey = ai.metaData.getString("expo.modules.updates.EXPO_SCOPE_KEY")
-      maybeSetDefaultScopeKey()
-      isEnabled = ai.metaData.getBoolean("expo.modules.updates.ENABLED", true)
-      sdkVersion = ai.metaData.getString("expo.modules.updates.EXPO_SDK_VERSION")
-      releaseChannel = ai.metaData.getString("expo.modules.updates.EXPO_RELEASE_CHANNEL", "default")
-      launchWaitMs = ai.metaData.getInt("expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS", 0)
-      runtimeVersion = ai.metaData["expo.modules.updates.EXPO_RUNTIME_VERSION"]?.toString()?.replaceFirst("^string:".toRegex(), "")
-
-      codeSigningCertificate = ai.metaData["expo.modules.updates.CODE_SIGNING_CERTIFICATE"]?.toString()
-      codeSigningMetadata = UpdatesUtils.getMapFromJSONString(
-        ai.metaData.getString(
-          "expo.modules.updates.CODE_SIGNING_METADATA",
-          "{}"
-        )
-      )
-
-      val checkOnLaunchString = ai.metaData.getString("expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH", "ALWAYS")
-      checkOnLaunch = try {
-        CheckAutomaticallyConfiguration.valueOf(checkOnLaunchString)
+  constructor(context: Context?, overrideMap: Map<String, Any>?) : this(
+    isEnabled = overrideMap?.readValueCheckingType<Boolean>(UPDATES_CONFIGURATION_ENABLED_KEY) ?: context?.getMetadataValue("expo.modules.updates.ENABLED") ?: true,
+    expectsSignedManifest = overrideMap?.readValueCheckingType(UPDATES_CONFIGURATION_EXPECTS_EXPO_SIGNED_MANIFEST) ?: false,
+    scopeKey = maybeGetDefaultScopeKey(
+      overrideMap?.readValueCheckingType<String>(UPDATES_CONFIGURATION_SCOPE_KEY_KEY) ?: context?.getMetadataValue("expo.modules.updates.EXPO_SCOPE_KEY"),
+      updateUrl = overrideMap?.readValueCheckingType<Uri>(UPDATES_CONFIGURATION_UPDATE_URL_KEY) ?: context?.getMetadataValue<String>("expo.modules.updates.EXPO_UPDATE_URL")?.let { Uri.parse(it) },
+    ),
+    updateUrl = overrideMap?.readValueCheckingType<Uri>(UPDATES_CONFIGURATION_UPDATE_URL_KEY) ?: context?.getMetadataValue<String>("expo.modules.updates.EXPO_UPDATE_URL")?.let { Uri.parse(it) },
+    sdkVersion = overrideMap?.readValueCheckingType<String>(UPDATES_CONFIGURATION_SDK_VERSION_KEY) ?: context?.getMetadataValue("expo.modules.updates.EXPO_SDK_VERSION"),
+    runtimeVersion = overrideMap?.readValueCheckingType<String>(UPDATES_CONFIGURATION_RUNTIME_VERSION_KEY) ?: context?.getMetadataValue<Any>("expo.modules.updates.EXPO_RUNTIME_VERSION")?.toString()?.replaceFirst("^string:".toRegex(), ""),
+    releaseChannel = overrideMap?.readValueCheckingType<String>(UPDATES_CONFIGURATION_RELEASE_CHANNEL_KEY) ?: context?.getMetadataValue("expo.modules.updates.EXPO_RELEASE_CHANNEL") ?: UPDATES_CONFIGURATION_RELEASE_CHANNEL_DEFAULT_VALUE,
+    launchWaitMs = overrideMap?.readValueCheckingType<Int>(UPDATES_CONFIGURATION_LAUNCH_WAIT_MS_KEY) ?: context?.getMetadataValue("expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS") ?: UPDATES_CONFIGURATION_LAUNCH_WAIT_MS_DEFAULT_VALUE,
+    checkOnLaunch = overrideMap?.readValueCheckingType<String>(UPDATES_CONFIGURATION_CHECK_ON_LAUNCH_KEY)?.let {
+      try {
+        CheckAutomaticallyConfiguration.valueOf(it)
+      } catch (e: IllegalArgumentException) {
+        throw AssertionError("UpdatesConfiguration failed to initialize: invalid value $it provided for checkOnLaunch")
+      }
+    } ?: (context?.getMetadataValue<String>("expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH") ?: "ALWAYS").let {
+      try {
+        CheckAutomaticallyConfiguration.valueOf(it)
       } catch (e: IllegalArgumentException) {
         Log.e(
           TAG,
-          "Invalid value $checkOnLaunchString for expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH in AndroidManifest; defaulting to ALWAYS"
+          "Invalid value $it for expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH in AndroidManifest; defaulting to ALWAYS"
         )
         CheckAutomaticallyConfiguration.ALWAYS
       }
+    },
+    hasEmbeddedUpdate = overrideMap?.readValueCheckingType<Boolean>(UPDATES_CONFIGURATION_HAS_EMBEDDED_UPDATE_KEY) ?: context?.getMetadataValue("expo.modules.updates.HAS_EMBEDDED_UPDATE") ?: true,
+    requestHeaders = overrideMap?.readValueCheckingType<Map<String, String>>(UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY) ?: (context?.getMetadataValue<String>("expo.modules.updates.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY") ?: "{}").let {
+      UpdatesUtils.getMapFromJSONString(it)
+    },
+    codeSigningCertificate = overrideMap?.readValueCheckingType<String>(UPDATES_CONFIGURATION_CODE_SIGNING_CERTIFICATE) ?: context?.getMetadataValue("expo.modules.updates.CODE_SIGNING_CERTIFICATE"),
+    codeSigningMetadata = overrideMap?.readValueCheckingType<Map<String, String>>(UPDATES_CONFIGURATION_CODE_SIGNING_METADATA) ?: (context?.getMetadataValue<String>("expo.modules.updates.CODE_SIGNING_METADATA") ?: "{}").let {
+      UpdatesUtils.getMapFromJSONString(it)
+    },
+  )
 
-      requestHeaders = UpdatesUtils.getMapFromJSONString(
-        ai.metaData.getString(
-          "expo.modules.updates.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY",
-          "{}"
-        )
-      )
-
-      // used only for expo-updates development
-      hasEmbeddedUpdate = ai.metaData.getBoolean("expo.modules.updates.HAS_EMBEDDED_UPDATE", true)
-    } catch (e: Exception) {
-      Log.e(TAG, "Could not read expo-updates configuration data in AndroidManifest", e)
-    }
-    return this
-  }
-
-  fun loadValuesFromMap(map: Map<String, Any>): UpdatesConfiguration {
-    val isEnabledFromMap = map.readValueCheckingType<Boolean>(UPDATES_CONFIGURATION_ENABLED_KEY)
-    if (isEnabledFromMap != null) {
-      isEnabled = isEnabledFromMap
-    }
-
-    expectsSignedManifest = map.readValueCheckingType(UPDATES_CONFIGURATION_EXPECTS_EXPO_SIGNED_MANIFEST) ?: false
-
-    val updateUrlFromMap = map.readValueCheckingType<Uri>(UPDATES_CONFIGURATION_UPDATE_URL_KEY)
-    if (updateUrlFromMap != null) {
-      updateUrl = updateUrlFromMap
-    }
-
-    val scopeKeyFromMap = map.readValueCheckingType<String>(UPDATES_CONFIGURATION_SCOPE_KEY_KEY)
-    if (scopeKeyFromMap != null) {
-      scopeKey = scopeKeyFromMap
-    }
-    maybeSetDefaultScopeKey()
-
-    val requestHeadersFromMap = map.readValueCheckingType<Map<String, String>>(UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY)
-    if (requestHeadersFromMap != null) {
-      requestHeaders = requestHeadersFromMap
-    }
-
-    val releaseChannelFromMap = map.readValueCheckingType<String>(UPDATES_CONFIGURATION_RELEASE_CHANNEL_KEY)
-    if (releaseChannelFromMap != null) {
-      releaseChannel = releaseChannelFromMap
-    }
-
-    val sdkVersionFromMap = map.readValueCheckingType<String>(UPDATES_CONFIGURATION_SDK_VERSION_KEY)
-    if (sdkVersionFromMap != null) {
-      sdkVersion = sdkVersionFromMap
-    }
-
-    val runtimeVersionFromMap = map.readValueCheckingType<String>(UPDATES_CONFIGURATION_RUNTIME_VERSION_KEY)
-    if (runtimeVersionFromMap != null) {
-      runtimeVersion = runtimeVersionFromMap
-    }
-
-    val checkOnLaunchFromMap = map.readValueCheckingType<String>(UPDATES_CONFIGURATION_CHECK_ON_LAUNCH_KEY)
-    if (checkOnLaunchFromMap != null) {
-      try {
-        checkOnLaunch = CheckAutomaticallyConfiguration.valueOf(checkOnLaunchFromMap)
-      } catch (e: IllegalArgumentException) {
-        throw AssertionError("UpdatesConfiguration failed to initialize: invalid value $checkOnLaunchFromMap provided for checkOnLaunch")
-      }
-    }
-
-    val launchWaitMsFromMap = map.readValueCheckingType<Int>(UPDATES_CONFIGURATION_LAUNCH_WAIT_MS_KEY)
-    if (launchWaitMsFromMap != null) {
-      launchWaitMs = launchWaitMsFromMap
-    }
-
-    val hasEmbeddedUpdateFromMap = map.readValueCheckingType<Boolean>(UPDATES_CONFIGURATION_HAS_EMBEDDED_UPDATE_KEY)
-    if (hasEmbeddedUpdateFromMap != null) {
-      hasEmbeddedUpdate = hasEmbeddedUpdateFromMap
-    }
-
-    val codeSigningCertificateFromMap = map.readValueCheckingType<String>(UPDATES_CONFIGURATION_CODE_SIGNING_CERTIFICATE)
-    if (codeSigningCertificateFromMap != null) {
-      codeSigningCertificate = codeSigningCertificateFromMap
-    }
-
-    val codeSigningMetadataFromMap = map.readValueCheckingType<Map<String, String>>(UPDATES_CONFIGURATION_CODE_SIGNING_METADATA)
-    if (codeSigningMetadataFromMap != null) {
-      codeSigningMetadata = codeSigningMetadataFromMap
-    }
-
-    return this
-  }
-
-  private inline fun <reified T : Any> Map<String, Any>.readValueCheckingType(key: String): T? {
-    if (!containsKey(key)) {
-      return null
-    }
-    val value = this[key]
-    return if (value is T) {
-      value
-    } else {
-      throw AssertionError("UpdatesConfiguration failed to initialize: bad value of type " + value!!.javaClass.simpleName + " provided for key " + key)
-    }
-  }
-
-  private fun maybeSetDefaultScopeKey() {
-    // set updateUrl as the default value if none is provided
-    if (scopeKey == null) {
-      if (updateUrl != null) {
-        scopeKey = getNormalizedUrlOrigin(updateUrl!!)
-      }
-    }
-  }
+  val isMissingRuntimeVersion: Boolean
+    get() = (runtimeVersion == null || runtimeVersion.isEmpty()) &&
+      (sdkVersion == null || sdkVersion.isEmpty())
 
   val codeSigningConfiguration: Crypto.CodeSigningConfiguration? by lazy {
     codeSigningCertificate?.let {
@@ -203,25 +93,57 @@ class UpdatesConfiguration {
 
     private const val UPDATES_CONFIGURATION_RELEASE_CHANNEL_DEFAULT_VALUE = "default"
     private const val UPDATES_CONFIGURATION_LAUNCH_WAIT_MS_DEFAULT_VALUE = 0
+  }
+}
 
-    internal fun getNormalizedUrlOrigin(url: Uri): String {
-      val scheme = url.scheme
-      var port = url.port
-      if (port == getDefaultPortForScheme(scheme)) {
-        port = -1
-      }
-      return if (port > -1) "$scheme://${url.host}:$port" else "$scheme://${url.host}"
-    }
+private inline fun <reified T : Any> Context.getMetadataValue(key: String): T? {
+  val ai = packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA).metaData
+  return when (T::class) {
+    String::class -> ai.getString(key) as T?
+    Boolean::class -> ai.getBoolean(key) as T?
+    Int::class -> ai.getInt(key) as T?
+    else -> ai[key] as T?
+  }
+}
 
-    private fun getDefaultPortForScheme(scheme: String?): Int {
-      if ("http" == scheme || "ws" == scheme) {
-        return 80
-      } else if ("https" == scheme || "wss" == scheme) {
-        return 443
-      } else if ("ftp" == scheme) {
-        return 21
-      }
-      return -1
+private inline fun <reified T : Any> Map<String, Any>.readValueCheckingType(key: String): T? {
+  if (!containsKey(key)) {
+    return null
+  }
+  val value = this[key]
+  return if (value is T) {
+    value
+  } else {
+    throw AssertionError("UpdatesConfiguration failed to initialize: bad value of type " + value!!.javaClass.simpleName + " provided for key " + key)
+  }
+}
+
+private fun getDefaultPortForScheme(scheme: String?): Int {
+  if ("http" == scheme || "ws" == scheme) {
+    return 80
+  } else if ("https" == scheme || "wss" == scheme) {
+    return 443
+  } else if ("ftp" == scheme) {
+    return 21
+  }
+  return -1
+}
+
+internal fun getNormalizedUrlOrigin(url: Uri): String {
+  val scheme = url.scheme
+  var port = url.port
+  if (port == getDefaultPortForScheme(scheme)) {
+    port = -1
+  }
+  return if (port > -1) "$scheme://${url.host}:$port" else "$scheme://${url.host}"
+}
+
+private fun maybeGetDefaultScopeKey(scopeKey: String?, updateUrl: Uri?): String? {
+  // set updateUrl as the default value if none is provided
+  if (scopeKey == null) {
+    if (updateUrl != null) {
+      return getNormalizedUrlOrigin(updateUrl)
     }
   }
+  return scopeKey
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.kt
@@ -433,7 +433,7 @@ class UpdatesController private constructor(
 
     @JvmStatic fun initializeWithoutStarting(context: Context) {
       if (singletonInstance == null) {
-        val updatesConfiguration = UpdatesConfiguration().loadValuesFromMetadata(context)
+        val updatesConfiguration = UpdatesConfiguration(context, null)
         singletonInstance = UpdatesController(context, updatesConfiguration)
       }
     }
@@ -456,9 +456,7 @@ class UpdatesController private constructor(
      */
     @JvmStatic fun initialize(context: Context, configuration: Map<String, Any>) {
       if (singletonInstance == null) {
-        val updatesConfiguration = UpdatesConfiguration()
-          .loadValuesFromMetadata(context)
-          .loadValuesFromMap(configuration)
+        val updatesConfiguration = UpdatesConfiguration(context, configuration)
         singletonInstance = UpdatesController(context, updatesConfiguration)
         singletonInstance!!.start(context)
       }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
@@ -32,9 +32,7 @@ class UpdatesDevLauncherController : UpdatesInterface {
     callback: UpdatesInterface.UpdateCallback
   ) {
     val controller = UpdatesController.instance
-    val updatesConfiguration = UpdatesConfiguration()
-      .loadValuesFromMetadata(context)
-      .loadValuesFromMap(configuration)
+    val updatesConfiguration = UpdatesConfiguration(context, configuration)
     if (updatesConfiguration.updateUrl == null || updatesConfiguration.scopeKey == null) {
       callback.onFailure(Exception("Failed to load update: UpdatesConfiguration object must include a valid update URL"))
       return

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
@@ -79,7 +79,7 @@ class UpdatesModule(
       // and warn the developer if not. This does not take into account any extra configuration
       // provided at runtime in MainApplication.java, because we don't have access to that in a
       // debug build.
-      val configuration = UpdatesConfiguration().loadValuesFromMetadata(context)
+      val configuration = UpdatesConfiguration(context, null)
       constants["isMissingRuntimeVersion"] = configuration.isMissingRuntimeVersion
     }
     return constants

--- a/packages/expo-updates/android/src/test/java/expo/modules/updates/UpdatesConfigurationTest.kt
+++ b/packages/expo-updates/android/src/test/java/expo/modules/updates/UpdatesConfigurationTest.kt
@@ -16,7 +16,7 @@ class UpdatesConfigurationTest {
     every { mockedUri.scheme } returns "https"
     every { mockedUri.host } returns "exp.host"
     every { mockedUri.port } returns -1
-    Assert.assertEquals("https://exp.host", UpdatesConfiguration.getNormalizedUrlOrigin(mockedUri))
+    Assert.assertEquals("https://exp.host", getNormalizedUrlOrigin(mockedUri))
   }
 
   @Test
@@ -25,7 +25,7 @@ class UpdatesConfigurationTest {
     every { mockedUri.scheme } returns "https"
     every { mockedUri.host } returns "exp.host"
     every { mockedUri.port } returns 443
-    Assert.assertEquals("https://exp.host", UpdatesConfiguration.getNormalizedUrlOrigin(mockedUri))
+    Assert.assertEquals("https://exp.host", getNormalizedUrlOrigin(mockedUri))
   }
 
   @Test
@@ -36,7 +36,7 @@ class UpdatesConfigurationTest {
     every { mockedUri.port } returns 47
     Assert.assertEquals(
       "https://exp.host:47",
-      UpdatesConfiguration.getNormalizedUrlOrigin(mockedUri)
+      getNormalizedUrlOrigin(mockedUri)
     )
   }
 }


### PR DESCRIPTION
# Why

Closes ENG-2696.

https://github.com/expo/expo/pull/15514#discussion_r768873737

This allows us to more safely use lazy delegation since now none of the underlying fields can change after construction.

# How

Change initialization to happen in constructor.

Values from the map always take precedence (all previous callsites would do `loadFromContext(...).loadFromMap(...)` meaning map values would override context values), so the pattern here is to do `mapValue ?: contextValue ?: defaultValueIfApplicable`.

# Test Plan

Run all tests.
Run app.