### PR TITLE
[expo-updates] add missing @JvmStatic to UpdatesDevLauncherController.initialize

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Add missing @JvmStatic annotation to `UpdatesDevLauncherController.initialize`.
+
 ### 💡 Others
 
 ## 0.11.2-rc.0 — 2021-12-13

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Add missing @JvmStatic annotation to `UpdatesDevLauncherController.initialize`.
+- Add missing @JvmStatic annotation to `UpdatesDevLauncherController.initialize`. ([#15561](https://github.com/expo/expo/pull/15561) by [@esamelson](https://github.com/esamelson))
 
 ### 💡 Others
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
@@ -137,7 +137,7 @@ class UpdatesDevLauncherController : UpdatesInterface {
         return checkNotNull(singletonInstance) { "UpdatesDevLauncherController.instance was called before the module was initialized" }
       }
 
-    fun initialize(context: Context): UpdatesDevLauncherController {
+    @JvmStatic fun initialize(context: Context): UpdatesDevLauncherController {
       if (singletonInstance == null) {
         singletonInstance = UpdatesDevLauncherController()
       }


### PR DESCRIPTION
# Why

Without this, the full integration with expo-dev-client cannot be installed as [these instructions](https://docs.expo.dev/development/installation/#loading-published-updates) cause the build to fail.

# How

Add missing annotation so `initialize` can be accessed as a static method from Java.

# Test Plan

Tested on an SDK 44 bare project in which I followed all the instructions in the doc linked above. Build failed before this change, succeeded after.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
