### PR TITLE
[config][dev-launcher] Fix compatibility with SDK 44

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fix plugin when `MainActivity.onNewIntent` exists. ([#15459](https://github.com/expo/expo/pull/15459) by [@janicduplessis](https://github.com/janicduplessis))
 - Fix plugin when `expo-updates` is not present. ([#15541](https://github.com/expo/expo/pull/15541) by [@esamelson](https://github.com/esamelson))
 - Include expo-platform header in manifest requests. ([#15563](https://github.com/expo/expo/pull/15563) by [@esamelson](https://github.com/esamelson))
+- Fix plugin compatibility with SDK 44. ([#15562](https://github.com/expo/expo/pull/15562) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/plugin/build/withDevLauncher.js
+++ b/packages/expo-dev-launcher/plugin/build/withDevLauncher.js
@@ -28,7 +28,7 @@ const DEV_LAUNCHER_HANDLE_INTENT = [
     '      return;',
     '    }',
 ].join('\n');
-const DEV_LAUNCHER_WRAPPED_ACTIVITY_DELEGATE = `DevLauncherController.wrapReactActivityDelegate(this, () -> $1);`;
+const DEV_LAUNCHER_WRAPPED_ACTIVITY_DELEGATE = (activityDelegateDeclaration) => `DevLauncherController.wrapReactActivityDelegate(this, () -> ${activityDelegateDeclaration})`;
 const DEV_LAUNCHER_ANDROID_INIT = 'DevLauncherController.initialize(this, getReactNativeHost());';
 const DEV_LAUNCHER_UPDATES_ANDROID_INIT = `if (BuildConfig.DEBUG) {
       DevLauncherController.getInstance().setUpdatesInterface(UpdatesDevLauncherController.initialize(this));
@@ -42,6 +42,26 @@ async function readFileAsync(path) {
 async function saveFileAsync(path, content) {
     return fs_1.default.promises.writeFile(path, content, 'utf8');
 }
+function findClosingBracketMatchIndex(str, pos) {
+    if (str[pos] !== '(') {
+        throw new Error("No '(' at index " + pos);
+    }
+    let depth = 1;
+    for (let i = pos + 1; i < str.length; i++) {
+        switch (str[i]) {
+            case '(':
+                depth++;
+                break;
+            case ')':
+                if (--depth === 0) {
+                    return i;
+                }
+                break;
+        }
+    }
+    return -1; // No matching closing parenthesis
+}
+const replaceBetween = (origin, startIndex, endIndex, insertion) => `${origin.substring(0, startIndex)}${insertion}${origin.substring(endIndex)}`;
 function addJavaImports(javaSource, javaImports) {
     const lines = javaSource.split('\n');
     const lineIndexWithPackageDeclaration = lines.findIndex((line) => line.match(/^package .*;$/));
@@ -127,7 +147,18 @@ function modifyJavaMainActivity(content) {
         content = (0, utils_1.addLines)(content, /super\.onNewIntent\(intent\)/, 0, [DEV_LAUNCHER_HANDLE_INTENT]);
     }
     if (!content.includes('DevLauncherController.wrapReactActivityDelegate')) {
-        content = content.replace(/(new ReactActivityDelegate(Wrapper)?(.|\s)*\}\)?);$/mu, DEV_LAUNCHER_WRAPPED_ACTIVITY_DELEGATE);
+        const activityDelegateMatches = Array.from(content.matchAll(/new ReactActivityDelegate(Wrapper)/g));
+        if (activityDelegateMatches.length !== 1) {
+            config_plugins_1.WarningAggregator.addWarningAndroid('expo-dev-launcher', `Failed to wrap 'ReactActivityDelegate'
+See the expo-dev-client installation instructions to modify your MainApplication.java manually: ${constants_1.InstallationPage}`);
+            return content;
+        }
+        const activityDelegateMatch = activityDelegateMatches[0];
+        const matchIndex = activityDelegateMatch.index;
+        const openingBracketIndex = matchIndex + activityDelegateMatch[0].length; // next character after `new ReactActivityDelegateWrapper`
+        const closingBracketIndex = findClosingBracketMatchIndex(content, openingBracketIndex);
+        const reactActivityDelegateDeclaration = content.substring(matchIndex, closingBracketIndex + 1);
+        content = replaceBetween(content, matchIndex, closingBracketIndex + 1, DEV_LAUNCHER_WRAPPED_ACTIVITY_DELEGATE(reactActivityDelegateDeclaration));
     }
     return content;
 }

--- a/packages/expo-dev-launcher/plugin/build/withDevLauncherAppDelegate.js
+++ b/packages/expo-dev-launcher/plugin/build/withDevLauncherAppDelegate.js
@@ -98,6 +98,16 @@ const DEV_LAUNCHER_INIT_TO_REMOVE = new RegExp(escapeRegExpCharacters(`RCTBridge
   rootViewController.view = rootView;
   self.window.rootViewController = rootViewController;
   [self.window makeKeyAndVisible];`), 'm');
+const DEV_LAUNCHER_INIT_TO_REMOVE_SDK_44 = new RegExp(escapeRegExpCharacters(`RCTBridge *bridge = [self.reactDelegate createBridgeWithDelegate:self launchOptions:launchOptions];
+  RCTRootView *rootView = [self.reactDelegate createRootViewWithBridge:bridge moduleName:@"main" initialProperties:nil];
+  rootView.backgroundColor = [UIColor whiteColor];
+  self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+  UIViewController *rootViewController = `) +
+    `([^;]+)` +
+    escapeRegExpCharacters(`;
+  rootViewController.view = rootView;
+  self.window.rootViewController = rootViewController;
+  [self.window makeKeyAndVisible];`), 'm');
 const DEV_LAUNCHER_NEW_INIT = `self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
 #if defined(EX_DEV_LAUNCHER_ENABLED)
   EXDevLauncherController *controller = [EXDevLauncherController sharedInstance];
@@ -203,11 +213,18 @@ exports.modifyLegacyAppDelegate = modifyLegacyAppDelegate;
 function modifyAppDelegate(appDelegate, expoUpdatesVersion = null) {
     const shouldAddUpdatesIntegration = expoUpdatesVersion != null && semver_1.default.gt(expoUpdatesVersion, '0.6.0');
     if (!DEV_LAUNCHER_INITIALIZE_REACT_NATIVE_APP_FUNCTION_DEFINITION_REGEX.test(appDelegate)) {
-        if (DEV_LAUNCHER_INIT_TO_REMOVE.test(appDelegate)) {
+        let initToRemove;
+        if (DEV_LAUNCHER_INIT_TO_REMOVE_SDK_44.test(appDelegate)) {
+            initToRemove = DEV_LAUNCHER_INIT_TO_REMOVE_SDK_44;
+        }
+        else if (DEV_LAUNCHER_INIT_TO_REMOVE.test(appDelegate)) {
+            initToRemove = DEV_LAUNCHER_APP_DELEGATE_BRIDGE;
+        }
+        if (initToRemove) {
             // UIViewController can be initialized differently depending on whether expo-screen-orientation is installed,
             // so we need to preserve whatever is there already.
             let viewControllerInit;
-            appDelegate = appDelegate.replace(DEV_LAUNCHER_INIT_TO_REMOVE, (match, p1) => {
+            appDelegate = appDelegate.replace(initToRemove, (match, p1) => {
                 viewControllerInit = p1;
                 return DEV_LAUNCHER_NEW_INIT;
             });

--- a/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
+++ b/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
@@ -33,7 +33,8 @@ const DEV_LAUNCHER_HANDLE_INTENT = [
   '      return;',
   '    }',
 ].join('\n');
-const DEV_LAUNCHER_WRAPPED_ACTIVITY_DELEGATE = `DevLauncherController.wrapReactActivityDelegate(this, () -> $1);`;
+const DEV_LAUNCHER_WRAPPED_ACTIVITY_DELEGATE = (activityDelegateDeclaration: string) =>
+  `DevLauncherController.wrapReactActivityDelegate(this, () -> ${activityDelegateDeclaration})`;
 const DEV_LAUNCHER_ANDROID_INIT = 'DevLauncherController.initialize(this, getReactNativeHost());';
 const DEV_LAUNCHER_UPDATES_ANDROID_INIT = `if (BuildConfig.DEBUG) {
       DevLauncherController.getInstance().setUpdatesInterface(UpdatesDevLauncherController.initialize(this));
@@ -51,6 +52,29 @@ async function readFileAsync(path: string): Promise<string> {
 async function saveFileAsync(path: string, content: string): Promise<void> {
   return fs.promises.writeFile(path, content, 'utf8');
 }
+
+function findClosingBracketMatchIndex(str: string, pos: number) {
+  if (str[pos] !== '(') {
+    throw new Error("No '(' at index " + pos);
+  }
+  let depth = 1;
+  for (let i = pos + 1; i < str.length; i++) {
+    switch (str[i]) {
+      case '(':
+        depth++;
+        break;
+      case ')':
+        if (--depth === 0) {
+          return i;
+        }
+        break;
+    }
+  }
+  return -1; // No matching closing parenthesis
+}
+
+const replaceBetween = (origin: string, startIndex: number, endIndex: number, insertion: string) =>
+  `${origin.substring(0, startIndex)}${insertion}${origin.substring(endIndex)}`;
 
 function addJavaImports(javaSource: string, javaImports: string[]): string {
   const lines = javaSource.split('\n');
@@ -173,9 +197,31 @@ export function modifyJavaMainActivity(content: string): string {
   }
 
   if (!content.includes('DevLauncherController.wrapReactActivityDelegate')) {
-    content = content.replace(
-      /(new ReactActivityDelegate(Wrapper)?(.|\s)*\}\)?);$/mu,
-      DEV_LAUNCHER_WRAPPED_ACTIVITY_DELEGATE
+    const activityDelegateMatches = Array.from(
+      content.matchAll(/new ReactActivityDelegate(Wrapper)/g)
+    );
+
+    if (activityDelegateMatches.length !== 1) {
+      WarningAggregator.addWarningAndroid(
+        'expo-dev-launcher',
+        `Failed to wrap 'ReactActivityDelegate'
+See the expo-dev-client installation instructions to modify your MainApplication.java manually: ${InstallationPage}`
+      );
+      return content;
+    }
+
+    const activityDelegateMatch = activityDelegateMatches[0];
+    const matchIndex = activityDelegateMatch.index!;
+    const openingBracketIndex = matchIndex + activityDelegateMatch[0].length; // next character after `new ReactActivityDelegateWrapper`
+
+    const closingBracketIndex = findClosingBracketMatchIndex(content, openingBracketIndex);
+    const reactActivityDelegateDeclaration = content.substring(matchIndex, closingBracketIndex + 1);
+
+    content = replaceBetween(
+      content,
+      matchIndex,
+      closingBracketIndex + 1,
+      DEV_LAUNCHER_WRAPPED_ACTIVITY_DELEGATE(reactActivityDelegateDeclaration)
     );
   }
   return content;


### PR DESCRIPTION
# Why

A follow-up to https://github.com/expo/expo/pull/15541#pullrequestreview-831017214.

# How

The regex which wraps activity delegates caused an infinity loop. I replaced that with a different approach - I'm not longed using regex.
 Also, the init block on iOS is different. 

# Test Plan

- run `expo prebuild` in a project with SDK 44 beta.
> Note: needs https://github.com/expo/expo/pull/15541 to work 