### PR TITLE
[expo-dev-launcher] include expo-platform header in manifest requests

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fix plugin when `MainActivity.onNewIntent` exists. ([#15459](https://github.com/expo/expo/pull/15459) by [@janicduplessis](https://github.com/janicduplessis))
 - Fix plugin when `expo-updates` is not present. ([#15541](https://github.com/expo/expo/pull/15541) by [@esamelson](https://github.com/esamelson))
+- Include expo-platform header in manifest requests. ([#15563](https://github.com/expo/expo/pull/15563) by [@esamelson](https://github.com/esamelson))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/helpers/DevLauncherOkHttpExtension.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/helpers/DevLauncherOkHttpExtension.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 import kotlinx.coroutines.suspendCancellableCoroutine
 import okhttp3.Call
 import okhttp3.Callback
+import okhttp3.Headers
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
@@ -31,5 +32,5 @@ suspend inline fun Request.await(okHttpClient: OkHttpClient): Response {
   }
 }
 
-fun fetch(url: Uri, method: String) =
-  Request.Builder().method(method, null).url(url.toString()).build()
+fun fetch(url: Uri, method: String, headers: Headers) =
+  Request.Builder().method(method, null).url(url.toString()).headers(headers).build()

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParser.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParser.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 import expo.modules.devlauncher.helpers.await
 import expo.modules.devlauncher.helpers.fetch
 import expo.modules.manifests.core.Manifest
+import okhttp3.Headers
 import okhttp3.OkHttpClient
 import org.json.JSONObject
 import java.io.Reader
@@ -13,7 +14,7 @@ class DevLauncherManifestParser(
   private val url: Uri
 ) {
   suspend fun isManifestUrl(): Boolean {
-    val response = fetch(url, "HEAD").await(httpClient)
+    val response = fetch(url, "HEAD", getHeaders()).await(httpClient)
     val contentType = response.header("Content-Type")
     // published projects may respond unsuccessfully to HEAD requests sent with no headers
     return !response.isSuccessful
@@ -22,7 +23,7 @@ class DevLauncherManifestParser(
   }
 
   private suspend fun downloadManifest(): Reader {
-    val response = fetch(url, "GET").await(httpClient)
+    val response = fetch(url, "GET", getHeaders()).await(httpClient)
     if (!response.isSuccessful) {
       throw Exception("Failed to open app.\n\nIf you are trying to load the app from a development server, check your network connectivity and make sure you can access the server from your device.\n\nIf you are trying to open a published project, install a compatible version of expo-updates and follow all setup and integration steps.")
     }
@@ -34,5 +35,9 @@ class DevLauncherManifestParser(
     downloadManifest().use {
       return Manifest.fromManifestJson(JSONObject(it.readText()))
     }
+  }
+
+  private fun getHeaders(): Headers {
+    return Headers.of(mapOf("expo-platform" to "android"))
   }
 }

--- a/packages/expo-dev-launcher/android/src/test/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParserTest.kt
+++ b/packages/expo-dev-launcher/android/src/test/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParserTest.kt
@@ -90,6 +90,20 @@ internal class DevLauncherManifestParserTest {
   }
 
   @Test
+  fun `isManifestUrl includes expo-platform header`() = runBlocking {
+    val manifestParser = DevLauncherManifestParser(
+      client,
+      Uri.parse(server.url("/").toString())
+    )
+
+    server.enqueue(MockResponse().setResponseCode(200))
+    manifestParser.isManifestUrl()
+
+    val request = server.takeRequest()
+    Truth.assertThat(request.getHeader("expo-platform")).isEqualTo("android")
+  }
+
+  @Test
   fun `checks if parseManifest parses successful response`() = runBlocking {
     val manifestParser = DevLauncherManifestParser(
       client,

--- a/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestParser.m
+++ b/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestParser.m
@@ -91,6 +91,7 @@ typedef void (^CompletionHandler)(NSData *data, NSURLResponse *response);
 {
   NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:self.url];
   [request setHTTPMethod:method];
+  [request setValue:@"ios" forHTTPHeaderField:@"expo-platform"];
   NSURLSessionDataTask *dataTask = [self.session dataTaskWithRequest:request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
     if (error) {
       onError(error);

--- a/packages/expo-dev-launcher/ios/Tests/EXDevLauncherManifestParserTests.m
+++ b/packages/expo-dev-launcher/ios/Tests/EXDevLauncherManifestParserTests.m
@@ -117,6 +117,29 @@
   [self waitForExpectationsWithTimeout:5 handler:nil];
 }
 
+- (void)testIsManifestURL_RequestIncludesPlatformHeader
+{
+  [HTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest * _Nonnull request) {
+    return [request.URL.host isEqualToString:@"ohhttpstubs"] && [request.URL.path isEqualToString:@"/platform"];
+  } withStubResponse:^HTTPStubsResponse * _Nonnull(NSURLRequest * _Nonnull request) {
+    XCTAssertEqualObjects(@"ios", request.allHTTPHeaderFields[@"expo-platform"]);
+    return [HTTPStubsResponse responseWithData:[NSData new] statusCode:200 headers:nil];
+  }];
+
+  EXDevLauncherManifestParser *parser = [[EXDevLauncherManifestParser alloc] initWithURL:[NSURL URLWithString:@"http://ohhttpstubs/platform"] session:NSURLSession.sharedSession];
+
+  XCTestExpectation *expectation = [self expectationWithDescription:@"request should include expo-platform header"];
+
+  [parser isManifestURLWithCompletion:^(BOOL isManifestURL) {
+    [expectation fulfill];
+  } onError:^(NSError * _Nonnull error) {
+    XCTFail(@"Response should have been successful");
+    [expectation fulfill];
+  }];
+
+  [self waitForExpectationsWithTimeout:5 handler:nil];
+}
+
 - (void)testParseManifest
 {
   [HTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest * _Nonnull request) {


### PR DESCRIPTION
# Why

Dev clients cannot current load modern manifests in development (without the expo-updates integration) because the expo-platform header is missing from the manifest request.

# How

Add the missing header to requests from DevLauncherManifestParser.

# Test Plan

Manual testing on both platforms, in a bare SDK 44 app with expo-dev-client installed (but not the expo-updates integration). Trying to load a manifest served by expo-cli from `expo start --dev-client --force-manifest-type=expo-updates`.

Before this change, on both platforms an alert would appear as well as an error message in the expo-cli logs. After this change, no error message appears and the app loads successfully on iOS. On Android no error message appears and we get further in loading before running into an additional issue (possibly due to changes in expo-modules-core interacting poorly with dev-client) which I'm investigating separately.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
