### PR TITLE
[expo-update][android] Upgrade test packages and remove mockito

### DIFF
--- a/packages/expo-updates/android/build.gradle
+++ b/packages/expo-updates/android/build.gradle
@@ -108,15 +108,13 @@ dependencies {
   implementation("commons-fileupload:commons-fileupload:1.4")
   implementation("org.apache.commons:commons-lang3:3.9")
 
-  testImplementation 'junit:junit:4.12'
-  testImplementation 'androidx.test:core:1.0.0'
-  testImplementation 'org.mockito:mockito-core:1.10.19'
+  testImplementation 'junit:junit:4.13.1'
+  testImplementation 'androidx.test:core:1.4.0'
   testImplementation 'io.mockk:mockk:1.12.0'
 
-  androidTestImplementation 'androidx.test:runner:1.1.0'
-  androidTestImplementation 'androidx.test:core:1.0.0'
-  androidTestImplementation 'androidx.test:rules:1.1.0'
-  androidTestImplementation 'org.mockito:mockito-android:3.7.7'
+  androidTestImplementation 'androidx.test:runner:1.4.0'
+  androidTestImplementation 'androidx.test:core:1.4.0'
+  androidTestImplementation 'androidx.test:rules:1.4.0'
   androidTestImplementation 'io.mockk:mockk-android:1.12.0'
   androidTestImplementation "androidx.room:room-testing:$room_version"
 

--- a/packages/expo-updates/android/src/test/java/expo/modules/updates/UpdatesConfigurationTest.kt
+++ b/packages/expo-updates/android/src/test/java/expo/modules/updates/UpdatesConfigurationTest.kt
@@ -3,13 +3,11 @@ package expo.modules.updates
 import android.net.Uri
 import io.mockk.every
 import io.mockk.mockk
+import junit.framework.TestCase
 import org.junit.Assert
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.runners.MockitoJUnitRunner
 
-@RunWith(MockitoJUnitRunner::class)
-class UpdatesConfigurationTest {
+class UpdatesConfigurationTest : TestCase() {
   @Test
   fun testGetNormalizedUrlOrigin_NoPort() {
     val mockedUri = mockk<Uri>()

--- a/packages/expo-updates/android/src/test/java/expo/modules/updates/UpdatesUtilsTest.kt
+++ b/packages/expo-updates/android/src/test/java/expo/modules/updates/UpdatesUtilsTest.kt
@@ -3,13 +3,11 @@ package expo.modules.updates
 import expo.modules.updates.db.entity.AssetEntity
 import io.mockk.every
 import io.mockk.mockk
+import junit.framework.TestCase
 import org.junit.Assert
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.runners.MockitoJUnitRunner
 
-@RunWith(MockitoJUnitRunner::class)
-class UpdatesUtilsTest {
+class UpdatesUtilsTest : TestCase() {
   @Test
   fun testCreateFilenameForAsset() {
     val assetEntity = AssetEntity("key", ".png")


### PR DESCRIPTION
# Why

`mockk` is preferred due to cleaner syntax (no `when` keyword conflict and better type inference).

This also just brings all packages related to tests up to date.

# How

Remove dependency, upgrade packages.

# Test Plan

Run all tests.