### PR TITLE
[docs] EAS Update docs versions and fixes

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -46,6 +46,7 @@ const sections = [
       'How to optimize assets for EAS Update',
       'Using expo-updates with a custom updates server',
       'Migrating from Classic Updates to EAS Update',
+      'Using EAS Update with a bare React Native project',
       'Runtime versions and updates',
       'Known issues',
       'FAQ',

--- a/docs/pages/eas-update/bare-react-native.md
+++ b/docs/pages/eas-update/bare-react-native.md
@@ -79,7 +79,7 @@ Once we've built our project into a build, the `expo-updates` library will make 
 
 If we create a build with EAS Build, the channel name from **eas.json** will automatically be added to our build's **AndroidManifest.xml** and **Expo.plist** at build time. If you're using EAS Build, the following steps are not necessary.
 
-If your project is not using EAS Build or you are creating release builds with either `expo run:ios --configuration Release` or `expo run:android --configuration release`, you'll need to set the channel configuration manually inside both **AndroidManifest.xml** and **Expo.plist**.
+If your project is not using EAS Build or you are creating release builds with either `expo run:ios --configuration Release` or `expo run:android --variant release`, you'll need to set the channel configuration manually inside both **AndroidManifest.xml** and **Expo.plist**.
 
 In **AndroidManifest.xml**, you'll need to add the following, replacing `your-channel-name` with the channel that matches your project:
 

--- a/docs/pages/eas-update/getting-started.md
+++ b/docs/pages/eas-update/getting-started.md
@@ -4,7 +4,16 @@ title: Getting started
 
 Setting up EAS Update allows you to push critical bug fixes and improvements that your users need right away.
 
-EAS Update is in "preview", meaning that we may still make breaking developer-facing changes. With that, EAS Update is ready for production apps. Read through the [known issues](/eas-update/known-issues) to ensure EAS Update is ready for your project.
+EAS Update is in "preview", meaning that we may still make breaking developer-facing changes. With that, EAS Update is ready for production apps. While we do not intend to make end-user facing changes, we may require you to make new builds of your project before EAS Update is publicly available. Read through the [known issues](/eas-update/known-issues) to ensure EAS Update is ready for your project.
+
+## Prerequisites
+
+EAS Update requires the following versions or greater:
+
+- Expo SDK 44
+- expo-updates 0.11.2-rc.0
+- Expo CLI 5.0.0
+- EAS CLI 0.41.0
 
 ## Install Expo CLI and EAS CLI
 
@@ -13,8 +22,6 @@ EAS Update is in "preview", meaning that we may still make breaking developer-fa
    ```bash
    npm install --global eas-cli expo-cli
    ```
-
-   EAS Update requires EAS CLI >= 0.40.0 and Expo CLI >= 4.13.0. Your project must also be on Expo SDK 43 or above. To upgrade, run `expo upgrade`.
 
 ## Create an Expo account
 
@@ -40,7 +47,7 @@ expo init
 1. Install the latest `expo-updates` library with:
 
    ```bash
-   expo install expo-updates
+   yarn add expo-updates@0.11.2-rc.0
    ```
 
 2. Initialize your project with EAS Update:

--- a/docs/pages/eas-update/migrate-to-eas-update.md
+++ b/docs/pages/eas-update/migrate-to-eas-update.md
@@ -4,6 +4,15 @@ title: Migrating from Classic Updates to EAS Update
 
 EAS Update is the next generation of Expo's updates service. If you're using Classic Updates, this guide will help you upgrade to EAS Update.
 
+## Prerequisites
+
+EAS Update requires the following versions or greater:
+
+- Expo SDK 44
+- expo-updates 0.11.2-rc.0
+- Expo CLI 5.0.0
+- EAS CLI 0.41.0
+
 ## Install Expo CLI and EAS CLI
 
 1. Install EAS and Expo CLIs with:
@@ -11,8 +20,6 @@ EAS Update is the next generation of Expo's updates service. If you're using Cla
    ```bash
    npm install --global eas-cli expo-cli
    ```
-
-   EAS Update requires EAS CLI >= 0.40.0 and Expo CLI >= 4.13.0. Your project must also be on Expo SDK 43 or above. To upgrade, run `expo upgrade`.
 
 2. Then, log in with your expo account:
 
@@ -27,7 +34,7 @@ You'll need to make the following changes to your project:
 1. Install the latest `expo-updates` library with:
 
    ```bash
-   expo install expo-updates
+   yarn add expo-updates@0.11.2-rc.0
    ```
 
 2. Initialize your project with EAS Update:


### PR DESCRIPTION
Adds versions of libraries and tools needed to use EAS Update.
Fixes expo run:android command.
Moves the bare react native doc into the correct spot in the navigation.