### PR TITLE
[location] Add missing dependency on unimodules-task-manager-interface

### DIFF
--- a/packages/expo-location/package.json
+++ b/packages/expo-location/package.json
@@ -42,7 +42,8 @@
     "expo-module-scripts": "^2.0.0"
   },
   "dependencies": {
-    "@expo/config-plugins": "^4.0.2"
+    "@expo/config-plugins": "^4.0.2",
+    "unimodules-task-manager-interface": "~7.1.0"
   },
   "peerDependencies": {
     "expo": "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15032,7 +15032,7 @@ react-freeze@^1.0.0:
   resolved "https://registry.yarnpkg.com/react-freeze/-/react-freeze-1.0.0.tgz#b21c65fe1783743007c8c9a2952b1c8879a77354"
   integrity sha512-yQaiOqDmoKqks56LN9MTgY06O0qQHgV4FUrikH357DydArSZHQhl0BJFqGKIZoTqi8JizF9Dxhuk1FIZD6qCaw==
 
-react-is@^16.12.0, react-is@^16.13.0, react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.1:
+react-is@^16.12.0, react-is@^16.13.0, react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==


### PR DESCRIPTION
# Why

Fixes #15548

# How

It looks like this was added in https://github.com/expo/expo/commit/7163468a7cee75a3a0e9cfabc4f773313c57189a#diff-e0fcd312cedc2d70b61525047366114449fee00724fd6bf528cf8308a7b1c17c but only committed to the sdk-43 branch.

# Test Plan

- `expo run:android` on blank managed project w/ expo-location installed will error due to missing dep
- With dependency added, app will build successfully via `expo run:android`
 
# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
