### PR TITLE
[expo-dev-launcher] take 2 at SDK 44 plugin compatibility

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -11,8 +11,7 @@
 - Fix plugin when `MainActivity.onNewIntent` exists. ([#15459](https://github.com/expo/expo/pull/15459) by [@janicduplessis](https://github.com/janicduplessis))
 - Fix plugin when `expo-updates` is not present. ([#15541](https://github.com/expo/expo/pull/15541) by [@esamelson](https://github.com/esamelson))
 - Include expo-platform header in manifest requests. ([#15563](https://github.com/expo/expo/pull/15563) by [@esamelson](https://github.com/esamelson))
-- Fix plugin compatibility with SDK 44. ([#15562](https://github.com/expo/expo/pull/15562) by [@lukmccall](https://github.com/lukmccall))
-- Second pass at fixing SDK 44 compatibility in config plugin.
+- Fix plugin compatibility with SDK 44. ([#15562](https://github.com/expo/expo/pull/15562) & [#15570](https://github.com/expo/expo/pull/15570) by [@lukmccall](https://github.com/lukmccall) & [@esamelson](https://github.com/esamelson))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fix plugin when `expo-updates` is not present. ([#15541](https://github.com/expo/expo/pull/15541) by [@esamelson](https://github.com/esamelson))
 - Include expo-platform header in manifest requests. ([#15563](https://github.com/expo/expo/pull/15563) by [@esamelson](https://github.com/esamelson))
 - Fix plugin compatibility with SDK 44. ([#15562](https://github.com/expo/expo/pull/15562) by [@lukmccall](https://github.com/lukmccall))
+- Second pass at fixing SDK 44 compatibility in config plugin.
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/plugin/build/withDevLauncherAppDelegate.js
+++ b/packages/expo-dev-launcher/plugin/build/withDevLauncherAppDelegate.js
@@ -157,6 +157,20 @@ const DEV_LAUNCHER_INITIALIZE_REACT_NATIVE_APP_FUNCTION_DEFINITION = (viewContro
   return bridge;
 }
 `;
+const DEV_LAUNCHER_INITIALIZE_REACT_NATIVE_APP_FUNCTION_DEFINITION_SDK_44 = `
+- (RCTBridge *)initializeReactNativeApp:(NSDictionary *)launchOptions
+{
+  RCTBridge *bridge = [self.reactDelegate createBridgeWithDelegate:self launchOptions:launchOptions];
+  RCTRootView *rootView = [self.reactDelegate createRootViewWithBridge:bridge moduleName:@"main" initialProperties:nil];
+  rootView.backgroundColor = [UIColor whiteColor];
+  UIViewController *rootViewController = [self.reactDelegate createRootViewController];
+  rootViewController.view = rootView;
+  self.window.rootViewController = rootViewController;
+  [self.window makeKeyAndVisible];
+
+  return bridge;
+ }
+`;
 function addImports(appDelegate, shouldAddUpdatesIntegration) {
     if (!appDelegate.includes(DEV_LAUNCHER_APP_DELEGATE_IOS_IMPORT) &&
         !appDelegate.includes(DEV_LAUNCHER_UPDATES_APP_DELEGATE_IOS_IMPORT)) {
@@ -212,10 +226,13 @@ function modifyLegacyAppDelegate(appDelegate, expoUpdatesVersion = null) {
 exports.modifyLegacyAppDelegate = modifyLegacyAppDelegate;
 function modifyAppDelegate(appDelegate, expoUpdatesVersion = null) {
     const shouldAddUpdatesIntegration = expoUpdatesVersion != null && semver_1.default.gt(expoUpdatesVersion, '0.6.0');
-    if (!DEV_LAUNCHER_INITIALIZE_REACT_NATIVE_APP_FUNCTION_DEFINITION_REGEX.test(appDelegate)) {
+    if (!DEV_LAUNCHER_INITIALIZE_REACT_NATIVE_APP_FUNCTION_DEFINITION_REGEX.test(appDelegate) &&
+        !appDelegate.includes(DEV_LAUNCHER_INITIALIZE_REACT_NATIVE_APP_FUNCTION_DEFINITION_SDK_44)) {
         let initToRemove;
+        let shouldAddSDK44Init = false;
         if (DEV_LAUNCHER_INIT_TO_REMOVE_SDK_44.test(appDelegate)) {
             initToRemove = DEV_LAUNCHER_INIT_TO_REMOVE_SDK_44;
+            shouldAddSDK44Init = true;
         }
         else if (DEV_LAUNCHER_INIT_TO_REMOVE.test(appDelegate)) {
             initToRemove = DEV_LAUNCHER_APP_DELEGATE_BRIDGE;
@@ -228,9 +245,10 @@ function modifyAppDelegate(appDelegate, expoUpdatesVersion = null) {
                 viewControllerInit = p1;
                 return DEV_LAUNCHER_NEW_INIT;
             });
-            appDelegate = (0, utils_1.addLines)(appDelegate, '@implementation AppDelegate', 1, [
-                DEV_LAUNCHER_INITIALIZE_REACT_NATIVE_APP_FUNCTION_DEFINITION(viewControllerInit),
-            ]);
+            const initToAdd = shouldAddSDK44Init
+                ? DEV_LAUNCHER_INITIALIZE_REACT_NATIVE_APP_FUNCTION_DEFINITION_SDK_44
+                : DEV_LAUNCHER_INITIALIZE_REACT_NATIVE_APP_FUNCTION_DEFINITION(viewControllerInit);
+            appDelegate = (0, utils_1.addLines)(appDelegate, '@implementation AppDelegate', 1, [initToAdd]);
         }
         else {
             config_plugins_1.WarningAggregator.addWarningIOS('expo-dev-launcher', `Failed to modify AppDelegate init function. 

--- a/packages/expo-dev-launcher/plugin/src/__tests__/__snapshots__/withDevLauncher-test.ts.snap
+++ b/packages/expo-dev-launcher/plugin/src/__tests__/__snapshots__/withDevLauncher-test.ts.snap
@@ -3,7 +3,14 @@
 exports[`modifyJavaMainActivity modifies the MainActivity file for dev-launcher 1`] = `
 "import android.content.Intent;
 import expo.modules.devlauncher.DevLauncherController;
+import android.os.Build;
+import android.os.Bundle;
+
 import com.facebook.react.ReactActivity;
+import com.facebook.react.ReactActivityDelegate;
+import com.facebook.react.ReactRootView;
+
+import expo.modules.ReactActivityDelegateWrapper;
 
 public class MainActivity extends ReactActivity {
 
@@ -15,13 +22,49 @@ public class MainActivity extends ReactActivity {
     super.onNewIntent(intent);
   }
 
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    // Set the theme to AppTheme BEFORE onCreate to support
+    // coloring the background, status bar, and navigation bar.
+    // This is required for expo-splash-screen.
+    setTheme(R.style.AppTheme);
+    super.onCreate(null);
+  }
+
   /**
-    * Returns the name of the main component registered from JavaScript. This is used to schedule
-    * rendering of the component.
-    */
+   * Returns the name of the main component registered from JavaScript.
+   * This is used to schedule rendering of the component.
+   */
   @Override
   protected String getMainComponentName() {
-    return \\"react-native-project\\";
+    return \\"main\\";
+  }
+
+  @Override
+  protected ReactActivityDelegate createReactActivityDelegate() {
+    return DevLauncherController.wrapReactActivityDelegate(this, () -> new ReactActivityDelegateWrapper(this,
+      new ReactActivityDelegate(this, getMainComponentName())
+    ));
+  }
+
+  /**
+   * Align the back button behavior with Android S
+   * where moving root activities to background instead of finishing activities.
+   * @see <a href=\\"https://developer.android.com/reference/android/app/Activity#onBackPressed()\\">onBackPressed</a>
+   */
+  @Override
+  public void invokeDefaultOnBackPressed() {
+    if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.R) {
+      if (!moveTaskToBack(false)) {
+        // For non-root activities, use the default implementation to finish them.
+        super.invokeDefaultOnBackPressed();
+      }
+      return;
+    }
+
+    // Use the default back button implementation on Android S
+    // because it's doing more than {@link Activity#moveTaskToBack} in fact.
+    super.invokeDefaultOnBackPressed();
   }
 }
 "
@@ -31,6 +74,10 @@ exports[`modifyJavaMainActivity modifies the MainActivity file for dev-launcher 
 "import android.content.Intent;
 import expo.modules.devlauncher.DevLauncherController;
 import com.facebook.react.ReactActivity;
+import com.facebook.react.ReactActivityDelegate;
+import com.facebook.react.ReactRootView;
+
+import expo.modules.ReactActivityDelegateWrapper;
 
 public class MainActivity extends ReactActivity {
   /**
@@ -40,6 +87,13 @@ public class MainActivity extends ReactActivity {
   @Override
   protected String getMainComponentName() {
     return \\"react-native-project\\";
+  }
+
+  @Override
+  protected ReactActivityDelegate createReactActivityDelegate() {
+    return DevLauncherController.wrapReactActivityDelegate(this, () -> new ReactActivityDelegateWrapper(this,
+      new ReactActivityDelegate(this, getMainComponentName())
+    ));
   }
 
   @Override

--- a/packages/expo-dev-launcher/plugin/src/__tests__/fixtures/AppDelegate-expo-modules-sdk-44.m
+++ b/packages/expo-dev-launcher/plugin/src/__tests__/fixtures/AppDelegate-expo-modules-sdk-44.m
@@ -1,0 +1,76 @@
+#import "AppDelegate.h"
+
+#import <React/RCTBridge.h>
+#import <React/RCTBundleURLProvider.h>
+#import <React/RCTRootView.h>
+#import <React/RCTLinkingManager.h>
+#import <React/RCTConvert.h>
+
+#if defined(FB_SONARKIT_ENABLED) && __has_include(<FlipperKit/FlipperClient.h>)
+#import <FlipperKit/FlipperClient.h>
+#import <FlipperKitLayoutPlugin/FlipperKitLayoutPlugin.h>
+#import <FlipperKitUserDefaultsPlugin/FKUserDefaultsPlugin.h>
+#import <FlipperKitNetworkPlugin/FlipperKitNetworkPlugin.h>
+#import <SKIOSNetworkPlugin/SKIOSNetworkAdapter.h>
+#import <FlipperKitReactPlugin/FlipperKitReactPlugin.h>
+
+static void InitializeFlipper(UIApplication *application) {
+  FlipperClient *client = [FlipperClient sharedClient];
+  SKDescriptorMapper *layoutDescriptorMapper = [[SKDescriptorMapper alloc] initWithDefaults];
+  [client addPlugin:[[FlipperKitLayoutPlugin alloc] initWithRootNode:application withDescriptorMapper:layoutDescriptorMapper]];
+  [client addPlugin:[[FKUserDefaultsPlugin alloc] initWithSuiteName:nil]];
+  [client addPlugin:[FlipperKitReactPlugin new]];
+  [client addPlugin:[[FlipperKitNetworkPlugin alloc] initWithNetworkAdapter:[SKIOSNetworkAdapter new]]];
+  [client start];
+}
+#endif
+
+@implementation AppDelegate
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+#if defined(FB_SONARKIT_ENABLED) && __has_include(<FlipperKit/FlipperClient.h>)
+  InitializeFlipper(application);
+#endif
+
+  RCTBridge *bridge = [self.reactDelegate createBridgeWithDelegate:self launchOptions:launchOptions];
+  RCTRootView *rootView = [self.reactDelegate createRootViewWithBridge:bridge moduleName:@"main" initialProperties:nil];
+  rootView.backgroundColor = [UIColor whiteColor];
+  self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+  UIViewController *rootViewController = [self.reactDelegate createRootViewController];
+  rootViewController.view = rootView;
+  self.window.rootViewController = rootViewController;
+  [self.window makeKeyAndVisible];
+
+  [super application:application didFinishLaunchingWithOptions:launchOptions];
+
+  return YES;
+ }
+
+- (NSArray<id<RCTBridgeModule>> *)extraModulesForBridge:(RCTBridge *)bridge
+{
+  // If you'd like to export some custom RCTBridgeModules, add them here!
+  return @[];
+}
+
+- (NSURL *)sourceURLForBridge:(RCTBridge *)bridge {
+ #ifdef DEBUG
+  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
+ #else
+  return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
+ #endif
+}
+
+// Linking API
+- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
+  return [RCTLinkingManager application:application openURL:url options:options];
+}
+
+// Universal Links
+- (BOOL)application:(UIApplication *)application continueUserActivity:(nonnull NSUserActivity *)userActivity restorationHandler:(nonnull void (^)(NSArray<id<UIUserActivityRestoring>> * _Nullable))restorationHandler {
+  return [RCTLinkingManager application:application
+                   continueUserActivity:userActivity
+                     restorationHandler:restorationHandler];
+}
+
+@end

--- a/packages/expo-dev-launcher/plugin/src/__tests__/fixtures/MainActivity-expo-modules.java
+++ b/packages/expo-dev-launcher/plugin/src/__tests__/fixtures/MainActivity-expo-modules.java
@@ -1,0 +1,55 @@
+import android.os.Build;
+import android.os.Bundle;
+
+import com.facebook.react.ReactActivity;
+import com.facebook.react.ReactActivityDelegate;
+import com.facebook.react.ReactRootView;
+
+import expo.modules.ReactActivityDelegateWrapper;
+
+public class MainActivity extends ReactActivity {
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    // Set the theme to AppTheme BEFORE onCreate to support
+    // coloring the background, status bar, and navigation bar.
+    // This is required for expo-splash-screen.
+    setTheme(R.style.AppTheme);
+    super.onCreate(null);
+  }
+
+  /**
+   * Returns the name of the main component registered from JavaScript.
+   * This is used to schedule rendering of the component.
+   */
+  @Override
+  protected String getMainComponentName() {
+    return "main";
+  }
+
+  @Override
+  protected ReactActivityDelegate createReactActivityDelegate() {
+    return new ReactActivityDelegateWrapper(this,
+      new ReactActivityDelegate(this, getMainComponentName())
+    );
+  }
+
+  /**
+   * Align the back button behavior with Android S
+   * where moving root activities to background instead of finishing activities.
+   * @see <a href="https://developer.android.com/reference/android/app/Activity#onBackPressed()">onBackPressed</a>
+   */
+  @Override
+  public void invokeDefaultOnBackPressed() {
+    if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.R) {
+      if (!moveTaskToBack(false)) {
+        // For non-root activities, use the default implementation to finish them.
+        super.invokeDefaultOnBackPressed();
+      }
+      return;
+    }
+
+    // Use the default back button implementation on Android S
+    // because it's doing more than {@link Activity#moveTaskToBack} in fact.
+    super.invokeDefaultOnBackPressed();
+  }
+}

--- a/packages/expo-dev-launcher/plugin/src/__tests__/fixtures/MainActivity-with-on-new-intent.java
+++ b/packages/expo-dev-launcher/plugin/src/__tests__/fixtures/MainActivity-with-on-new-intent.java
@@ -1,4 +1,8 @@
 import com.facebook.react.ReactActivity;
+import com.facebook.react.ReactActivityDelegate;
+import com.facebook.react.ReactRootView;
+
+import expo.modules.ReactActivityDelegateWrapper;
 
 public class MainActivity extends ReactActivity {
   /**
@@ -8,6 +12,13 @@ public class MainActivity extends ReactActivity {
   @Override
   protected String getMainComponentName() {
     return "react-native-project";
+  }
+
+  @Override
+  protected ReactActivityDelegate createReactActivityDelegate() {
+    return new ReactActivityDelegateWrapper(this,
+      new ReactActivityDelegate(this, getMainComponentName())
+    );
   }
 
   @Override

--- a/packages/expo-dev-launcher/plugin/src/__tests__/withDevLauncher-test.ts
+++ b/packages/expo-dev-launcher/plugin/src/__tests__/withDevLauncher-test.ts
@@ -4,9 +4,21 @@ import path from 'path';
 import { modifyJavaMainActivity } from '../withDevLauncher';
 
 describe(modifyJavaMainActivity, () => {
+  /**
+   * The config plugin cannot currently handle projects created with react-native init
+   *
   it(`modifies the MainActivity file for dev-launcher`, () => {
     const fixture = fs.readFileSync(
       path.join(__dirname, 'fixtures', 'MainActivity-react-native.java'),
+      'utf8'
+    );
+    expect(modifyJavaMainActivity(fixture)).toMatchSnapshot();
+  });
+   */
+
+  it(`modifies the MainActivity file for dev-launcher`, () => {
+    const fixture = fs.readFileSync(
+      path.join(__dirname, 'fixtures', 'MainActivity-expo-modules.java'),
       'utf8'
     );
     expect(modifyJavaMainActivity(fixture)).toMatchSnapshot();
@@ -22,7 +34,7 @@ describe(modifyJavaMainActivity, () => {
 
   it(`modifying MainActivity twice doesn't change the content`, () => {
     const firstModification = fs.readFileSync(
-      path.join(__dirname, 'fixtures', 'MainActivity-react-native.java'),
+      path.join(__dirname, 'fixtures', 'MainActivity-expo-modules.java'),
       'utf8'
     );
     modifyJavaMainActivity(firstModification);

--- a/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
+++ b/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
@@ -205,7 +205,7 @@ export function modifyJavaMainActivity(content: string): string {
       WarningAggregator.addWarningAndroid(
         'expo-dev-launcher',
         `Failed to wrap 'ReactActivityDelegate'
-See the expo-dev-client installation instructions to modify your MainApplication.java manually: ${InstallationPage}`
+See the expo-dev-client installation instructions to modify your MainActivity.java manually: ${InstallationPage}`
       );
       return content;
     }

--- a/packages/expo-dev-launcher/plugin/src/withDevLauncherAppDelegate.ts
+++ b/packages/expo-dev-launcher/plugin/src/withDevLauncherAppDelegate.ts
@@ -298,7 +298,7 @@ export function modifyAppDelegate(appDelegate: string, expoUpdatesVersion: strin
       initToRemove = DEV_LAUNCHER_INIT_TO_REMOVE_SDK_44;
       shouldAddSDK44Init = true;
     } else if (DEV_LAUNCHER_INIT_TO_REMOVE.test(appDelegate)) {
-      initToRemove = DEV_LAUNCHER_APP_DELEGATE_BRIDGE;
+      initToRemove = DEV_LAUNCHER_INIT_TO_REMOVE;
     }
 
     if (initToRemove) {

--- a/packages/expo-dev-launcher/plugin/src/withDevLauncherAppDelegate.ts
+++ b/packages/expo-dev-launcher/plugin/src/withDevLauncherAppDelegate.ts
@@ -176,6 +176,21 @@ const DEV_LAUNCHER_INITIALIZE_REACT_NATIVE_APP_FUNCTION_DEFINITION = (
 }
 `;
 
+const DEV_LAUNCHER_INITIALIZE_REACT_NATIVE_APP_FUNCTION_DEFINITION_SDK_44 = `
+- (RCTBridge *)initializeReactNativeApp:(NSDictionary *)launchOptions
+{
+  RCTBridge *bridge = [self.reactDelegate createBridgeWithDelegate:self launchOptions:launchOptions];
+  RCTRootView *rootView = [self.reactDelegate createRootViewWithBridge:bridge moduleName:@"main" initialProperties:nil];
+  rootView.backgroundColor = [UIColor whiteColor];
+  UIViewController *rootViewController = [self.reactDelegate createRootViewController];
+  rootViewController.view = rootView;
+  self.window.rootViewController = rootViewController;
+  [self.window makeKeyAndVisible];
+
+  return bridge;
+ }
+`;
+
 function addImports(appDelegate: string, shouldAddUpdatesIntegration: boolean): string {
   if (
     !appDelegate.includes(DEV_LAUNCHER_APP_DELEGATE_IOS_IMPORT) &&
@@ -273,10 +288,15 @@ export function modifyAppDelegate(appDelegate: string, expoUpdatesVersion: strin
   const shouldAddUpdatesIntegration =
     expoUpdatesVersion != null && semver.gt(expoUpdatesVersion, '0.6.0');
 
-  if (!DEV_LAUNCHER_INITIALIZE_REACT_NATIVE_APP_FUNCTION_DEFINITION_REGEX.test(appDelegate)) {
+  if (
+    !DEV_LAUNCHER_INITIALIZE_REACT_NATIVE_APP_FUNCTION_DEFINITION_REGEX.test(appDelegate) &&
+    !appDelegate.includes(DEV_LAUNCHER_INITIALIZE_REACT_NATIVE_APP_FUNCTION_DEFINITION_SDK_44)
+  ) {
     let initToRemove;
+    let shouldAddSDK44Init = false;
     if (DEV_LAUNCHER_INIT_TO_REMOVE_SDK_44.test(appDelegate)) {
       initToRemove = DEV_LAUNCHER_INIT_TO_REMOVE_SDK_44;
+      shouldAddSDK44Init = true;
     } else if (DEV_LAUNCHER_INIT_TO_REMOVE.test(appDelegate)) {
       initToRemove = DEV_LAUNCHER_APP_DELEGATE_BRIDGE;
     }
@@ -289,9 +309,10 @@ export function modifyAppDelegate(appDelegate: string, expoUpdatesVersion: strin
         viewControllerInit = p1;
         return DEV_LAUNCHER_NEW_INIT;
       });
-      appDelegate = addLines(appDelegate, '@implementation AppDelegate', 1, [
-        DEV_LAUNCHER_INITIALIZE_REACT_NATIVE_APP_FUNCTION_DEFINITION(viewControllerInit),
-      ]);
+      const initToAdd = shouldAddSDK44Init
+        ? DEV_LAUNCHER_INITIALIZE_REACT_NATIVE_APP_FUNCTION_DEFINITION_SDK_44
+        : DEV_LAUNCHER_INITIALIZE_REACT_NATIVE_APP_FUNCTION_DEFINITION(viewControllerInit);
+      appDelegate = addLines(appDelegate, '@implementation AppDelegate', 1, [initToAdd]);
     } else {
       WarningAggregator.addWarningIOS(
         'expo-dev-launcher',


### PR DESCRIPTION
# Why

when testing #15562 on the sdk-44 branch I found there were still a few issues -- (1) some expo-modules stuff would be inadvertently removed from AppDelegate, even though the project would build, and (2) tests were failing.

# How

(commit 1) added the correct logic for SDK 44's `initializeReactNativeApp` function (these regexes are getting so messy, we can't move to expo module initialization soon enough 😅 ), and added tests with a corresponding SDK 44 AppDelegate.m.
(commit 2) fixed wrong string constant that was causing failures for SDK 43 and below
(commit 3) fixed tests on the Android side that were logging warnings. @lukmccall is it correct to say that this config plugin cannot handle projects where `createReactActivityDelegate` isn't already overridden in MainActivity? I modified the tests as such, but if that isn't the case, [this warning](https://github.com/expo/expo/blob/4ca5ff72ef3abcc30cb7936eaf9c4b97fed9a5ad/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts#L205-L209) needs to be changed.

# Test Plan

All tests pass. Manually tested in a blank SDK 44 app; cherry picked these commits onto sdk-44 and then used patch-package to patch entire the expo-dev-launcher package to match sdk-44 HEAD. Ran expo prebuild, saw no errors, eyeballed the code changes, and tested the following scenarios:

✅ project builds on iOS and Android
✅ iOS: can open app served by `expo start --dev-client`
✅ iOS: can open app served by `expo start --dev-client --force-manifest-type=expo-updates`
✅ Android: can open app served by `expo start --dev-client`
✅ Android: can open app served by `expo start --dev-client --force-manifest-type=expo-updates`
✅ expo install expo-updates@0.11.2, expo prebuild --clean, project builds
✅ iOS (with expo-updates integration): can open app served by `expo start --dev-client`
✅ iOS (with expo-updates integration): can open app served by `expo start --dev-client --force-manifest-type=expo-updates`
✅ iOS (with expo-updates integration): can open published app
✅ Android (with expo-updates integration): can open app served by `expo start --dev-client`
✅ Android (with expo-updates integration): can open app served by `expo start --dev-client --force-manifest-type=expo-updates`
✅ Android (with expo-updates integration): can open published app

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
