### PR TITLE
[sdk-44] update bundledNativeModules for expo-updates@0.11.2

### DIFF
--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -87,7 +87,7 @@
   "expo-system-ui": "~1.1.0",
   "expo-task-manager": "~10.1.0",
   "expo-tracking-transparency": "~2.1.0",
-  "expo-updates": "~0.11.1",
+  "expo-updates": "~0.11.2",
   "expo-video-thumbnails": "~6.1.0",
   "expo-web-browser": "~10.1.0",
   "lottie-react-native": "5.0.1",


### PR DESCRIPTION
# Why

just published expo-updates from master, so we need to update this manually for now.

not sure how urgent this is since the `~` means new projects will get 0.11.2 anyway, just opening this PR to keep track of this.