### PR TITLE
[android][ios] Upgrade react-native-reanimated to 2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ Package-specific changes not released in any SDK will be added here just before 
 - Updated `@stripe/stripe-react-native` from `0.2.2` to `0.2.3`. ([#15396](https://github.com/expo/expo/pull/15396) by [@brentvatne](https://github.com/brentvatne) and [@kudo](https://github.com/kudo))
 - Updated `react-native-gesture-handler` from `1.10.3` to `2.1.0`. ([#15404](https://github.com/expo/expo/pull/15404) & [#15568](https://github.com/expo/expo/pull/15568) by [@kudo](https://github.com/kudo))
 - Updated `react-native-screens` from `3.8.0` to `3.10.1`. ([#15416](https://github.com/expo/expo/pull/15416) by [@bbarthec](https://github.com/bbarthec))
-- Updated `react-native-reanimated` from `2.2.3` to `2.3.0`. ([#15475](https://github.com/expo/expo/pull/15475) by [@Kudo](https://github.com/Kudo))
+- Updated `react-native-reanimated` from `2.2.3` to `2.3.1`. ([#15475](https://github.com/expo/expo/pull/15475) & [#15574](https://github.com/expo/expo/pull/15574) by [@Kudo](https://github.com/Kudo))
 
 ### 🛠 Breaking changes
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/reanimated/layoutReanimation/Snapshot.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/reanimated/layoutReanimation/Snapshot.java
@@ -5,7 +5,6 @@ import android.view.ViewGroup;
 import com.facebook.react.uimanager.IllegalViewOperationException;
 import com.facebook.react.uimanager.NativeViewHierarchyManager;
 import com.facebook.react.uimanager.ViewManager;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -64,24 +63,24 @@ public class Snapshot {
     globalOriginX = location[0];
     globalOriginY = location[1];
 
-    targetKeysToTransform = new ArrayList<>(
-      Arrays.asList(
-        Snapshot.TARGET_WIDTH,
-        Snapshot.TARGET_HEIGHT,
-        Snapshot.TARGET_ORIGIN_X,
-        Snapshot.TARGET_ORIGIN_Y,
-        Snapshot.TARGET_GLOBAL_ORIGIN_X,
-        Snapshot.TARGET_GLOBAL_ORIGIN_Y)
-    );
-    currentKeysToTransform = new ArrayList<>(
-      Arrays.asList(
-        Snapshot.CURRENT_WIDTH,
-        Snapshot.CURRENT_HEIGHT,
-        Snapshot.CURRENT_ORIGIN_X,
-        Snapshot.CURRENT_ORIGIN_Y,
-        Snapshot.CURRENT_GLOBAL_ORIGIN_X,
-        Snapshot.CURRENT_GLOBAL_ORIGIN_Y)
-    );
+    targetKeysToTransform =
+        new ArrayList<>(
+            Arrays.asList(
+                Snapshot.TARGET_WIDTH,
+                Snapshot.TARGET_HEIGHT,
+                Snapshot.TARGET_ORIGIN_X,
+                Snapshot.TARGET_ORIGIN_Y,
+                Snapshot.TARGET_GLOBAL_ORIGIN_X,
+                Snapshot.TARGET_GLOBAL_ORIGIN_Y));
+    currentKeysToTransform =
+        new ArrayList<>(
+            Arrays.asList(
+                Snapshot.CURRENT_WIDTH,
+                Snapshot.CURRENT_HEIGHT,
+                Snapshot.CURRENT_ORIGIN_X,
+                Snapshot.CURRENT_ORIGIN_Y,
+                Snapshot.CURRENT_GLOBAL_ORIGIN_X,
+                Snapshot.CURRENT_GLOBAL_ORIGIN_Y));
   }
 
   private void addTargetConfig(HashMap<String, Object> data) {

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/host/exp/exponent/modules/api/reanimated/layoutReanimation/Snapshot.java
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/host/exp/exponent/modules/api/reanimated/layoutReanimation/Snapshot.java
@@ -5,7 +5,6 @@ import android.view.ViewGroup;
 import abi44_0_0.com.facebook.react.uimanager.IllegalViewOperationException;
 import abi44_0_0.com.facebook.react.uimanager.NativeViewHierarchyManager;
 import abi44_0_0.com.facebook.react.uimanager.ViewManager;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -64,24 +63,24 @@ public class Snapshot {
     globalOriginX = location[0];
     globalOriginY = location[1];
 
-    targetKeysToTransform = new ArrayList<>(
-      Arrays.asList(
-        Snapshot.TARGET_WIDTH,
-        Snapshot.TARGET_HEIGHT,
-        Snapshot.TARGET_ORIGIN_X,
-        Snapshot.TARGET_ORIGIN_Y,
-        Snapshot.TARGET_GLOBAL_ORIGIN_X,
-        Snapshot.TARGET_GLOBAL_ORIGIN_Y)
-    );
-    currentKeysToTransform = new ArrayList<>(
-      Arrays.asList(
-        Snapshot.CURRENT_WIDTH,
-        Snapshot.CURRENT_HEIGHT,
-        Snapshot.CURRENT_ORIGIN_X,
-        Snapshot.CURRENT_ORIGIN_Y,
-        Snapshot.CURRENT_GLOBAL_ORIGIN_X,
-        Snapshot.CURRENT_GLOBAL_ORIGIN_Y)
-    );
+    targetKeysToTransform =
+        new ArrayList<>(
+            Arrays.asList(
+                Snapshot.TARGET_WIDTH,
+                Snapshot.TARGET_HEIGHT,
+                Snapshot.TARGET_ORIGIN_X,
+                Snapshot.TARGET_ORIGIN_Y,
+                Snapshot.TARGET_GLOBAL_ORIGIN_X,
+                Snapshot.TARGET_GLOBAL_ORIGIN_Y));
+    currentKeysToTransform =
+        new ArrayList<>(
+            Arrays.asList(
+                Snapshot.CURRENT_WIDTH,
+                Snapshot.CURRENT_HEIGHT,
+                Snapshot.CURRENT_ORIGIN_X,
+                Snapshot.CURRENT_ORIGIN_Y,
+                Snapshot.CURRENT_GLOBAL_ORIGIN_X,
+                Snapshot.CURRENT_GLOBAL_ORIGIN_Y));
   }
 
   private void addTargetConfig(HashMap<String, Object> data) {

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -711,7 +711,7 @@ PODS:
     - React-Core
   - RNGestureHandler (2.1.0):
     - React-Core
-  - RNReanimated (2.2.4):
+  - RNReanimated (2.3.1):
     - DoubleConversion
     - FBLazyVector
     - FBReactNativeSpec
@@ -737,7 +737,6 @@ PODS:
     - React-RCTNetwork
     - React-RCTSettings
     - React-RCTText
-    - React-RCTVibration
     - ReactCommon/turbomodule/core
     - Yoga
   - RNScreens (3.10.1):
@@ -892,7 +891,7 @@ DEPENDENCIES:
   - "RNCPicker (from `../../../node_modules/@react-native-picker/picker`)"
   - "RNDateTimePicker (from `../../../node_modules/@react-native-community/datetimepicker`)"
   - RNGestureHandler (from `../../../node_modules/react-native-gesture-handler`)
-  - RNReanimated (from `../node_modules/react-native-reanimated`)
+  - RNReanimated (from `../../../node_modules/react-native-reanimated`)
   - RNScreens (from `../../../node_modules/react-native-screens`)
   - RNSharedElement (from `../../../node_modules/react-native-shared-element`)
   - RNSVG (from `../../../node_modules/react-native-svg`)
@@ -1238,7 +1237,7 @@ EXTERNAL SOURCES:
   RNGestureHandler:
     :path: "../../../node_modules/react-native-gesture-handler"
   RNReanimated:
-    :path: "../node_modules/react-native-reanimated"
+    :path: "../../../node_modules/react-native-reanimated"
   RNScreens:
     :path: "../../../node_modules/react-native-screens"
   RNSharedElement:
@@ -1400,7 +1399,7 @@ SPEC CHECKSUMS:
   RNCPicker: cb57c823d5ce8d2d0b5dfb45ad97b737260dc59e
   RNDateTimePicker: 2224ee77a86b7123377597a015502435e2e49957
   RNGestureHandler: e5c7cab5f214503dcefd6b2b0cefb050e1f51c4a
-  RNReanimated: 024eff8202342abf4b24e11575a16afc441dabfe
+  RNReanimated: 7f143675d94978c3555345d5bfa8ed6ae800c5d3
   RNScreens: 522705f2e5c9d27efb17f24aceb2bf8335bc7b8e
   RNSharedElement: 381b5e33366513cc3f449f2dc3a42c5df0f54021
   RNSVG: 551acb6562324b1d52a4e0758f7ca0ec234e278f

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -115,7 +115,7 @@
     "react-native": "0.64.3",
     "react-native-appearance": "~0.3.4",
     "react-native-gesture-handler": "~2.1.0",
-    "react-native-reanimated": "~2.2.0",
+    "react-native-reanimated": "~2.3.1",
     "react-native-safe-area-context": "3.3.2",
     "react-native-screens": "~3.10.1",
     "react-native-shared-element": "0.8.3",

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -41,8 +41,7 @@
         "expo-ads-admob",
         "expo-apple-authentication",
         "expo-updates",
-        "expo-module-template",
-        "react-native-reanimated"
+        "expo-module-template"
       ],
       "ios": {
         "flags": {

--- a/apps/bare-sandbox/package.json
+++ b/apps/bare-sandbox/package.json
@@ -103,8 +103,7 @@
         "expo-ads-facebook",
         "expo-branch",
         "expo-module-template",
-        "expo-web-browser",
-        "recat-native-reanimated"
+        "expo-web-browser"
       ]
     }
   },

--- a/apps/bare-sandbox/package.json
+++ b/apps/bare-sandbox/package.json
@@ -19,7 +19,7 @@
     "react-dom": "17.0.1",
     "react-native": "0.64.3",
     "react-native-gesture-handler": "~2.1.0",
-    "react-native-reanimated": "~2.2.0",
+    "react-native-reanimated": "~2.3.1",
     "react-native-screens": "~3.10.1",
     "react-native-web": "~0.17.1"
   },

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -155,7 +155,7 @@
     "react-native-maps": "0.29.4",
     "react-native-pager-view": "5.4.9",
     "react-native-paper": "^4.0.1",
-    "react-native-reanimated": "~2.3.0",
+    "react-native-reanimated": "~2.3.1",
     "react-native-redash": "^14.1.1",
     "react-native-safe-area-context": "3.3.2",
     "react-native-safe-area-view": "^0.14.8",

--- a/home/package.json
+++ b/home/package.json
@@ -58,7 +58,7 @@
     "react-native-infinite-scroll-view": "^0.4.5",
     "react-native-maps": "0.29.4",
     "react-native-paper": "^4.0.1",
-    "react-native-reanimated": "~2.3.0",
+    "react-native-reanimated": "~2.3.1",
     "react-native-safe-area-context": "3.3.2",
     "react-native-screens": "~3.10.1",
     "react-redux": "^7.2.0",

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2425,7 +2425,7 @@ PODS:
     - React-perflogger (= 0.64.3)
   - RNGestureHandler (2.1.0):
     - React-Core
-  - RNReanimated (2.3.0):
+  - RNReanimated (2.3.1):
     - DoubleConversion
     - FBLazyVector
     - FBReactNativeSpec
@@ -4288,7 +4288,7 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: 493d9abb8b23c3f84e19ae221eeba92cadcb70dc
   ReactCommon: 8fea6422328e2fc093e25c9fac67adbcf0f04fb4
   RNGestureHandler: e5c7cab5f214503dcefd6b2b0cefb050e1f51c4a
-  RNReanimated: eb7b06098f064677394249e9a5f797cac1f0004f
+  RNReanimated: 7f143675d94978c3555345d5bfa8ed6ae800c5d3
   RNScreens: 522705f2e5c9d27efb17f24aceb2bf8335bc7b8e
   Stripe: 22c1b8da5ee20a1aaf40fd198160efa72e71644a
   stripe-react-native: a5fcf07b49f1208bdc939e31a07320b35a88209f

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1750,7 +1750,7 @@ PODS:
     - RCT-Folly (= 2020.01.13.00)
   - ABI44_0_0RNGestureHandler (2.1.0):
     - ABI44_0_0React-Core
-  - ABI44_0_0RNReanimated (2.3.0):
+  - ABI44_0_0RNReanimated (2.3.1):
     - ABI44_0_0RCTRequired
     - ABI44_0_0RCTTypeSafety
     - ABI44_0_0React
@@ -4138,7 +4138,7 @@ SPEC CHECKSUMS:
   ABI44_0_0React-runtimeexecutor: e896ce310401b7a6c55c8e9ebd05d329425704f0
   ABI44_0_0ReactCommon: 57cd9920705425d6d7979326c5f755a7134612d0
   ABI44_0_0RNGestureHandler: 0ebf658b94a2583f265cd1fc02a50adf7db6f611
-  ABI44_0_0RNReanimated: a5713baac42d25465b994404d8b3fbbf2caeda69
+  ABI44_0_0RNReanimated: 5a9c79f77d68cc558867f38dbd78efe7c6e328ec
   ABI44_0_0RNScreens: 7a62e5f04bfaf607a3927152dbf4efd3fcf2dc8a
   ABI44_0_0stripe-react-native: a28782c19ddabd9a3c901d9b2eb964e8d8ab7d68
   ABI44_0_0UMAppLoader: d00dfac0be21e65771e9c30abf4c2fefe0afa06f

--- a/ios/vendored/sdk44/react-native-reanimated/ABI44_0_0RNReanimated.podspec.json
+++ b/ios/vendored/sdk44/react-native-reanimated/ABI44_0_0RNReanimated.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "ABI44_0_0RNReanimated",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "summary": "More powerful alternative to Animated library for ABI44_0_0React Native.",
   "description": "ABI44_0_0RNReanimated",
   "homepage": "https://github.com/software-mansion/react-native-reanimated",
@@ -14,7 +14,7 @@
   },
   "source": {
     "git": "https://github.com/software-mansion/react-native-reanimated.git",
-    "tag": "2.3.0"
+    "tag": "2.3.1"
   },
   "source_files": [
     "ios/**/*.{mm,h,m}",

--- a/ios/vendored/sdk44/react-native-reanimated/ios/LayoutReanimation/ABI44_0_0REAUIManager.mm
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/LayoutReanimation/ABI44_0_0REAUIManager.mm
@@ -1,6 +1,9 @@
 #import "ABI44_0_0REAUIManager.h"
 #import <Foundation/Foundation.h>
 #include "FeaturesConfig.h"
+#import "ABI44_0_0REAIOSScheduler.h"
+#include "Scheduler.h"
+
 #import <ABI44_0_0React/ABI44_0_0RCTComponentData.h>
 #import <ABI44_0_0React/ABI44_0_0RCTLayoutAnimation.h>
 #import <ABI44_0_0React/ABI44_0_0RCTLayoutAnimationGroup.h>
@@ -8,8 +11,6 @@
 #import <ABI44_0_0React/ABI44_0_0RCTRootShadowView.h>
 #import <ABI44_0_0React/ABI44_0_0RCTRootViewInternal.h>
 #import <ABI44_0_0React/ABI44_0_0RCTUIManagerObserverCoordinator.h>
-#import "ABI44_0_0REAIOSScheduler.h"
-#include "Scheduler.h"
 
 #if __has_include(<ABI44_0_0RNScreens/ABI44_0_0RNSScreen.h>)
 #import <ABI44_0_0RNScreens/ABI44_0_0RNSScreen.h>

--- a/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REAPropsNode.m
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/Nodes/ABI44_0_0REAPropsNode.m
@@ -4,9 +4,9 @@
 #import "ABI44_0_0REANodesManager.h"
 #import "ABI44_0_0REAStyleNode.h"
 
+#import <ABI44_0_0React/ABI44_0_0RCTComponentData.h>
 #import <ABI44_0_0React/ABI44_0_0RCTLog.h>
 #import <ABI44_0_0React/ABI44_0_0RCTUIManager.h>
-#import <ABI44_0_0React/ABI44_0_0RCTComponentData.h>
 
 @implementation ABI44_0_0REAPropsNode {
   NSNumber *_connectedViewTag;

--- a/ios/vendored/unversioned/react-native-reanimated/RNReanimated.podspec.json
+++ b/ios/vendored/unversioned/react-native-reanimated/RNReanimated.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "RNReanimated",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "summary": "More powerful alternative to Animated library for React Native.",
   "description": "RNReanimated",
   "homepage": "https://github.com/software-mansion/react-native-reanimated",
@@ -14,7 +14,7 @@
   },
   "source": {
     "git": "https://github.com/software-mansion/react-native-reanimated.git",
-    "tag": "2.3.0"
+    "tag": "2.3.1"
   },
   "source_files": [
     "ios/**/*.{mm,h,m}",

--- a/ios/vendored/unversioned/react-native-reanimated/ios/LayoutReanimation/REAUIManager.mm
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/LayoutReanimation/REAUIManager.mm
@@ -1,6 +1,9 @@
 #import "REAUIManager.h"
 #import <Foundation/Foundation.h>
 #include "FeaturesConfig.h"
+#import "REAIOSScheduler.h"
+#include "Scheduler.h"
+
 #import <React/RCTComponentData.h>
 #import <React/RCTLayoutAnimation.h>
 #import <React/RCTLayoutAnimationGroup.h>
@@ -8,8 +11,6 @@
 #import <React/RCTRootShadowView.h>
 #import <React/RCTRootViewInternal.h>
 #import <React/RCTUIManagerObserverCoordinator.h>
-#import "REAIOSScheduler.h"
-#include "Scheduler.h"
 
 #if __has_include(<RNScreens/RNSScreen.h>)
 #import <RNScreens/RNSScreen.h>

--- a/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REAPropsNode.m
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REAPropsNode.m
@@ -4,9 +4,9 @@
 #import "REANodesManager.h"
 #import "REAStyleNode.h"
 
+#import <React/RCTComponentData.h>
 #import <React/RCTLog.h>
 #import <React/RCTUIManager.h>
-#import <React/RCTComponentData.h>
 
 @implementation REAPropsNode {
   NSNumber *_connectedViewTag;

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -97,7 +97,7 @@
   "react-native-get-random-values": "~1.7.0",
   "react-native-maps": "0.29.4",
   "react-native-pager-view": "5.4.9",
-  "react-native-reanimated": "~2.3.0",
+  "react-native-reanimated": "~2.3.1",
   "react-native-safe-area-context": "3.3.2",
   "react-native-screens": "~3.10.1",
   "react-native-shared-element": "0.8.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15145,20 +15145,10 @@ react-native-primitives@^0.1.3:
   resolved "https://registry.yarnpkg.com/react-native-primitives/-/react-native-primitives-0.1.3.tgz#ff9548adfcaacb2f2b6a34a078d2643903e17e3d"
   integrity sha512-slhBFw6vKsq76f4G4N4cXL/g3UPq22Fgl2atmSxgGJZs5JK5SPTNbP4AvIcnt72Selj0k9/5fAMFvpUq8qsVbQ==
 
-react-native-reanimated@~2.2.0:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-2.2.4.tgz#36c5d15028b0bd7d479fba5199117ac870c7a532"
-  integrity sha512-Nn648MfEEnTCEiWsl1YmfkojiLyV0NMY0EiRdDRbZNfJVfxBuyqhCxI/4Jd7aBi162qpgf8XK2mByYgvF4zLrQ==
-  dependencies:
-    "@babel/plugin-transform-object-assign" "^7.10.4"
-    fbjs "^3.0.0"
-    mockdate "^3.0.2"
-    string-hash-64 "^1.0.3"
-
-react-native-reanimated@~2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-2.3.0.tgz#5d3bbcd140ab8ad47ac30d873635c7f1c3d06d4f"
-  integrity sha512-MSW2Uzj+Chd6qGS1gqNeF/U2l+xk44cD0PnNbU3v1paDI2/HAlzPhMtEy2WWtz83RZ4FtDuI/0o935SjJ7iSYg==
+react-native-reanimated@~2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-2.3.1.tgz#c7abad48f9e6c84610b0d5e270088ecd61750382"
+  integrity sha512-nzjVqwkB8eeyPKT2KoiA9EEz17ZMFSGMoOTC17Z9b5nE2Z4ZHjHM5EKhY0TlwzXFUuJAE9PhOfxF0wIO/maZSA==
   dependencies:
     "@babel/plugin-transform-object-assign" "^7.10.4"
     "@types/invariant" "^2.2.35"


### PR DESCRIPTION
# Why

upgrade react-native-reanimated to 2.3.1 for sdk 44 release

# How

- `et uvm -m react-native-reanimated -c "2.3.1"`
- revert reanimated autolinking exclusion for bare-expo and bare-sandbox
- `et add-sdk -p ios -s 44.0.0 -v react-native-reanimated`
- `et remove-sdk -p android -s 44.0.0 && et add-sdk -p android -s 44.0.0` and pick reanimated changes.

# Test Plan

android versioned expo go + gesture handler NCL
ios versioned expo go + gesture handler NCL

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
