### PR TITLE
[expo-av][android] fix video width same as video height

### DIFF
--- a/packages/expo-av/android/src/main/java/expo/modules/av/player/SimpleExoPlayerData.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/player/SimpleExoPlayerData.java
@@ -357,7 +357,8 @@ class SimpleExoPlayerData extends PlayerData
   @Override
   public void onVideoSizeChanged(final int width, final int height, final int unAppliedRotationDegrees, final float pixelWidthHeightRatio) {
     // TODO other params?
-    mVideoWidthHeight = new Pair<>(width, height);
+    int videoWidth = Math.round(width * pixelWidthHeightRatio);
+    mVideoWidthHeight = new Pair<>(videoWidth, height);
     if (mFirstFrameRendered && mVideoSizeUpdateListener != null) {
       mVideoSizeUpdateListener.onVideoSizeUpdate(mVideoWidthHeight);
     }


### PR DESCRIPTION
# Why
On Android for some videos the width is the same as the video height. This PR fixes that issue.

https://github.com/expo/expo/issues/12839

# How
Using pixelWidthHeightRatio as described in https://github.com/google/ExoPlayer/issues/3690

# Test Plan
Tested on emulator with reproducible example https://snack.expo.dev/@trokiize/android-video-size-wrong.

