### PR TITLE
[docs] Move EAS Update to feature preview

### DIFF
--- a/docs/constants/FeatureFlags.js
+++ b/docs/constants/FeatureFlags.js
@@ -1,6 +1,6 @@
 // If you change the flag value, you need to restart the dev server.
 const flags = {
-  isDevClientInFeaturePreview: true,
+  exampleFlag: true,
 };
 
 const shouldShowFeaturePreviewLink = () => {

--- a/docs/constants/navigation-data.js
+++ b/docs/constants/navigation-data.js
@@ -4,8 +4,6 @@ const fm = require('front-matter');
 const fs = require('fs-extra');
 const path = require('path');
 
-const { isDevClientInFeaturePreview } = require('./FeatureFlags');
-
 // TODO(brentvatne): move this to navigation.js so it's all in one place!
 // Map directories in a version directory to a section name
 const DIR_MAPPING = {
@@ -141,14 +139,8 @@ const referenceDirectories = fs
 const startingDirectories = ['introduction', 'get-started', 'tutorial', 'next-steps'];
 
 const easDirectories = ['eas', 'build', 'app-signing', 'build-reference', 'submit'];
-let previewDirectories = ['preview', 'eas-update']; // a private preview section which isn't linked in the documentation
-let featurePreviewDirectories = ['feature-preview']; // a public preview section which is linked under `Feature Preview`
-
-if (isDevClientInFeaturePreview) {
-  featurePreviewDirectories = [...featurePreviewDirectories, 'development'];
-} else {
-  previewDirectories = [...previewDirectories, 'development'];
-}
+const previewDirectories = ['preview']; // a private preview section which isn't linked in the documentation
+const featurePreviewDirectories = ['feature-preview', 'development', 'eas-update']; // a public preview section which is linked under `Feature Preview`
 
 // Find any directories that aren't reference or starting directories. Also exclude the api
 // directory, which is just a shortcut.

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -19,12 +19,13 @@ const GROUPS = {
   'Expo SDK': ['Expo SDK'],
   'Configuration Files': ['Configuration Files'],
   'React Native': ['React Native'],
-  Preview: ['Preview', 'EAS Update'],
+  Preview: ['Preview'],
   EAS: ['EAS'],
   'EAS Build': ['Start Building', 'App Signing', 'Reference'],
   'EAS Submit': ['EAS Submit'],
   'Technical Specs': ['Technical Specs'],
   'Development Builds': ['Development Builds'],
+  'EAS Update': ['EAS Update'],
 };
 
 // This array provides the **ordering** for pages within each section

--- a/docs/pages/eas-update/getting-started.md
+++ b/docs/pages/eas-update/getting-started.md
@@ -4,8 +4,6 @@ title: Getting started
 
 Setting up EAS Update allows you to push critical bug fixes and improvements that your users need right away.
 
-EAS Update is in "preview", meaning that we may still make breaking developer-facing changes. With that, EAS Update is ready for production apps. While we do not intend to make end-user facing changes, we may require you to make new builds of your project before EAS Update is publicly available. Read through the [known issues](/eas-update/known-issues) to ensure EAS Update is ready for your project.
-
 ## Prerequisites
 
 EAS Update requires the following versions or greater:

--- a/docs/pages/eas-update/introduction.md
+++ b/docs/pages/eas-update/introduction.md
@@ -2,7 +2,7 @@
 title: Introduction
 ---
 
-> ⚠️ EAS Update is currently in development and is not ready for use in production.
+> ⚠️ EAS Update is in "preview", meaning that we may still make breaking developer-facing changes. With that, EAS Update is ready for production apps. While we do not intend to make end-user facing changes, we may require you to make new builds of your project before EAS Update is publicly available. Read through the [known issues](/eas-update/known-issues) to ensure EAS Update is ready for your project.
 
 **EAS Update** is a hosted service that serves updates for projects using the `expo-updates` library.
 


### PR DESCRIPTION
# Why

EAS Update is ready to go into feature preview. This PR adds the EAS Update docs to the "feature preview" section of the docs, which is linked from the "feature preview" link in the docs header.

<img width="1582" alt="Screen Shot 2021-12-15 at 1 05 09 PM" src="https://user-images.githubusercontent.com/6455018/146241271-1486719c-cf2d-42d3-a2ae-0f13ea077c07.png">

# Test Plan

Make sure the docs show the EAS Update docs in the feature preview section, and that links like /eas-update/introduction take you there.