### PR TITLE
[core][ios] Create base class for object-based definitions

### DIFF
--- a/packages/expo-modules-core/ios/Swift/Modules/ModuleDefinition.swift
+++ b/packages/expo-modules-core/ios/Swift/Modules/ModuleDefinition.swift
@@ -9,7 +9,7 @@ public protocol AnyDefinition {}
  of the module and what it exports to the JavaScript world.
  See `ModuleDefinitionBuilder` for more details on how to create it.
  */
-public final class ModuleDefinition: AnyDefinition {
+public final class ModuleDefinition: ObjectDefinition {
   /**
    The module's type associated with the definition. It's used to create the module instance.
    */
@@ -20,8 +20,6 @@ public final class ModuleDefinition: AnyDefinition {
    */
   var name: String
 
-  let functions: [String : AnyFunction]
-  let constants: [ConstantsDefinition]
   let eventListeners: [EventListener]
   let viewManager: ViewManagerDefinition?
 
@@ -33,19 +31,11 @@ public final class ModuleDefinition: AnyDefinition {
   /**
    Initializer that is called by the `ModuleDefinitionBuilder` results builder.
    */
-  init(definitions: [AnyDefinition]) {
+  override init(definitions: [AnyDefinition]) {
     self.name = definitions
       .compactMap { $0 as? ModuleNameDefinition }
       .last?
       .name ?? ""
-
-    self.functions = definitions
-      .compactMap { $0 as? AnyFunction }
-      .reduce(into: [String : AnyFunction]()) { dict, function in
-        dict[function.name] = function
-      }
-
-    self.constants = definitions.compactMap { $0 as? ConstantsDefinition }
 
     self.eventListeners = definitions.compactMap { $0 as? EventListener }
 
@@ -58,6 +48,8 @@ public final class ModuleDefinition: AnyDefinition {
         .compactMap { ($0 as? EventsDefinition)?.names }
         .joined()
     )
+
+    super.init(definitions: definitions)
   }
 
   /**

--- a/packages/expo-modules-core/ios/Swift/Objects/ObjectDefinition.swift
+++ b/packages/expo-modules-core/ios/Swift/Objects/ObjectDefinition.swift
@@ -1,0 +1,30 @@
+// Copyright 2021-present 650 Industries. All rights reserved.
+
+/**
+ Base class for other definitions representing an object, such as `ModuleDefinition`.
+ */
+public class ObjectDefinition: AnyDefinition {
+  /**
+   A dictionary of functions defined by the object.
+   */
+  let functions: [String: AnyFunction]
+
+  /**
+   An array of constants definitions.
+   */
+  let constants: [ConstantsDefinition]
+
+  /**
+   Default initializer receiving children definitions from the result builder.
+   */
+  init(definitions: [AnyDefinition]) {
+    self.functions = definitions
+      .compactMap { $0 as? AnyFunction }
+      .reduce(into: [String: AnyFunction]()) { dict, function in
+        dict[function.name] = function
+      }
+
+    self.constants = definitions
+      .compactMap { $0 as? ConstantsDefinition }
+  }
+}

--- a/packages/expo-modules-core/ios/Swift/Views/ViewManagerDefinition.swift
+++ b/packages/expo-modules-core/ios/Swift/Views/ViewManagerDefinition.swift
@@ -3,7 +3,7 @@ import UIKit
 /**
  The definition of the view manager. It's part of the module definition to scope only view-related definitions.
  */
-public struct ViewManagerDefinition: AnyDefinition {
+public final class ViewManagerDefinition: ObjectDefinition {
   /**
    The view factory that lets us create views.
    */
@@ -14,13 +14,18 @@ public struct ViewManagerDefinition: AnyDefinition {
    */
   let props: [AnyViewProp]
 
-  init(definitions: [AnyDefinition]) {
+  /**
+   Default initializer receiving children definitions from the result builder.
+   */
+  override init(definitions: [AnyDefinition]) {
     self.factory = definitions
       .compactMap { $0 as? ViewFactory }
       .last
 
     self.props = definitions
       .compactMap { $0 as? AnyViewProp }
+
+    super.init(definitions: definitions)
   }
 
   /**


### PR DESCRIPTION
# Why

Some cleanups and preparations for view-manager-specific functions, constants and events (basically sharing some features with `ModuleDefinition`). Actually each object-like definitions can have constants and functions — for example class prototypes.

# How

`ModuleDefinition` and `ViewManagerDefinition` inherit from the base `ObjectDefinition`.

# Test Plan

Unit tests are passing, examples of modules using the new API seem to work as expected
