### PR TITLE
[av][iOS] Re-enable `expotools prebuild expo-av`

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -18,7 +18,8 @@ PODS:
     - ExpoModulesCore
   - EXAV (11.1.0):
     - ExpoModulesCore
-    - ReactCommon/turbomodule/core
+    - React-runtimeexecutor
+    - ReactCommon
   - EXBackgroundFetch (10.1.0):
     - ExpoModulesCore
     - UMTaskManagerInterface
@@ -710,6 +711,24 @@ PODS:
     - ReactCommon/turbomodule/core (= 0.67.2)
   - React-runtimeexecutor (0.67.2):
     - React-jsi (= 0.67.2)
+  - ReactCommon (0.67.2):
+    - React-logger (= 0.67.2)
+    - ReactCommon/react_debug_core (= 0.67.2)
+    - ReactCommon/turbomodule (= 0.67.2)
+  - ReactCommon/react_debug_core (0.67.2):
+    - React-logger (= 0.67.2)
+  - ReactCommon/turbomodule (0.67.2):
+    - DoubleConversion
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-callinvoker (= 0.67.2)
+    - React-Core (= 0.67.2)
+    - React-cxxreact (= 0.67.2)
+    - React-jsi (= 0.67.2)
+    - React-logger (= 0.67.2)
+    - React-perflogger (= 0.67.2)
+    - ReactCommon/turbomodule/core (= 0.67.2)
+    - ReactCommon/turbomodule/samples (= 0.67.2)
   - ReactCommon/turbomodule/core (0.67.2):
     - DoubleConversion
     - glog
@@ -720,6 +739,17 @@ PODS:
     - React-jsi (= 0.67.2)
     - React-logger (= 0.67.2)
     - React-perflogger (= 0.67.2)
+  - ReactCommon/turbomodule/samples (0.67.2):
+    - DoubleConversion
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-callinvoker (= 0.67.2)
+    - React-Core (= 0.67.2)
+    - React-cxxreact (= 0.67.2)
+    - React-jsi (= 0.67.2)
+    - React-logger (= 0.67.2)
+    - React-perflogger (= 0.67.2)
+    - ReactCommon/turbomodule/core (= 0.67.2)
   - RNCAsyncStorage (1.15.14):
     - React-Core
   - RNCMaskedView (0.2.6):
@@ -1283,7 +1313,7 @@ SPEC CHECKSUMS:
   DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
   EXAmplitude: f346f64108b628046524182a8cc30df407643dc9
   EXApplication: bdc8dc27713235565da1029a34385229f31b8e08
-  EXAV: 6bef4f902a70b704f5407876698527ab75cba15f
+  EXAV: 851ef1eacaea082131b77a54d02cc1140257af63
   EXBackgroundFetch: 12e8a8c522a2d2c5be07168d74af76567841f023
   EXBarCodeScanner: 0c10fb2bda9e188450b58cc89f7c6177b73f5c25
   EXBattery: 097a76ebb674c57d3df6e1ebcd6e243d569161b5

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1817,6 +1817,7 @@ PODS:
     - ExpoModulesCore
   - EXAV (11.1.0):
     - ExpoModulesCore
+    - React-runtimeexecutor
     - ReactCommon
   - EXBackgroundFetch (10.1.0):
     - ExpoModulesCore
@@ -4197,7 +4198,7 @@ SPEC CHECKSUMS:
   EXAmplitude: f346f64108b628046524182a8cc30df407643dc9
   EXAppleAuthentication: 27a4f7dc44a1b510f5af945b58643165ee486d89
   EXApplication: bdc8dc27713235565da1029a34385229f31b8e08
-  EXAV: b6c9cc97f13081575bdbd1dd4d0031b21d5b1b87
+  EXAV: 851ef1eacaea082131b77a54d02cc1140257af63
   EXBackgroundFetch: 12e8a8c522a2d2c5be07168d74af76567841f023
   EXBarCodeScanner: 0c10fb2bda9e188450b58cc89f7c6177b73f5c25
   EXBattery: 097a76ebb674c57d3df6e1ebcd6e243d569161b5

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1817,7 +1817,7 @@ PODS:
     - ExpoModulesCore
   - EXAV (11.1.0):
     - ExpoModulesCore
-    - ReactCommon/turbomodule/core
+    - ReactCommon
   - EXBackgroundFetch (10.1.0):
     - ExpoModulesCore
     - UMTaskManagerInterface
@@ -2420,6 +2420,24 @@ PODS:
     - ReactCommon/turbomodule/core (= 0.67.2)
   - React-runtimeexecutor (0.67.2):
     - React-jsi (= 0.67.2)
+  - ReactCommon (0.67.2):
+    - React-logger (= 0.67.2)
+    - ReactCommon/react_debug_core (= 0.67.2)
+    - ReactCommon/turbomodule (= 0.67.2)
+  - ReactCommon/react_debug_core (0.67.2):
+    - React-logger (= 0.67.2)
+  - ReactCommon/turbomodule (0.67.2):
+    - DoubleConversion
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-callinvoker (= 0.67.2)
+    - React-Core (= 0.67.2)
+    - React-cxxreact (= 0.67.2)
+    - React-jsi (= 0.67.2)
+    - React-logger (= 0.67.2)
+    - React-perflogger (= 0.67.2)
+    - ReactCommon/turbomodule/core (= 0.67.2)
+    - ReactCommon/turbomodule/samples (= 0.67.2)
   - ReactCommon/turbomodule/core (0.67.2):
     - DoubleConversion
     - glog
@@ -2430,6 +2448,17 @@ PODS:
     - React-jsi (= 0.67.2)
     - React-logger (= 0.67.2)
     - React-perflogger (= 0.67.2)
+  - ReactCommon/turbomodule/samples (0.67.2):
+    - DoubleConversion
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-callinvoker (= 0.67.2)
+    - React-Core (= 0.67.2)
+    - React-cxxreact (= 0.67.2)
+    - React-jsi (= 0.67.2)
+    - React-logger (= 0.67.2)
+    - React-perflogger (= 0.67.2)
+    - ReactCommon/turbomodule/core (= 0.67.2)
   - RNGestureHandler (2.1.0):
     - React-Core
   - RNReanimated (2.3.1):
@@ -4168,7 +4197,7 @@ SPEC CHECKSUMS:
   EXAmplitude: f346f64108b628046524182a8cc30df407643dc9
   EXAppleAuthentication: 27a4f7dc44a1b510f5af945b58643165ee486d89
   EXApplication: bdc8dc27713235565da1029a34385229f31b8e08
-  EXAV: 6bef4f902a70b704f5407876698527ab75cba15f
+  EXAV: b6c9cc97f13081575bdbd1dd4d0031b21d5b1b87
   EXBackgroundFetch: 12e8a8c522a2d2c5be07168d74af76567841f023
   EXBarCodeScanner: 0c10fb2bda9e188450b58cc89f7c6177b73f5c25
   EXBattery: 097a76ebb674c57d3df6e1ebcd6e243d569161b5

--- a/packages/expo-av/ios/EXAV.podspec
+++ b/packages/expo-av/ios/EXAV.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.static_framework = true
 
   s.dependency 'ExpoModulesCore'
-  s.dependency 'ReactCommon/turbomodule/core'
+  s.dependency 'ReactCommon'
 
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')
     s.source_files = "#{s.name}/**/*.h"

--- a/packages/expo-av/ios/EXAV.podspec
+++ b/packages/expo-av/ios/EXAV.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
 
   s.dependency 'ExpoModulesCore'
   s.dependency 'ReactCommon'
-  # 'React-runtimeexecutor' is added only for prebuilding purposes only as this process cannot resolve transitive headers' paths at the time of writing.
+  # 'React-runtimeexecutor' is added only for prebuilding purposes as this process cannot resolve transitive headers' paths at the time of writing.
   # This dependency is implicitly included via following chain: 'ReactCommon' -> 'ReactCommon/turbomodule' -> 'React-cxxreact' -> 'React-runtimeexecutor'.
   # TODO: remove once perbuilding starts supporting resolution of transitive dependencies
   s.dependency 'React-runtimeexecutor'

--- a/packages/expo-av/ios/EXAV.podspec
+++ b/packages/expo-av/ios/EXAV.podspec
@@ -16,6 +16,10 @@ Pod::Spec.new do |s|
 
   s.dependency 'ExpoModulesCore'
   s.dependency 'ReactCommon'
+  # 'React-runtimeexecutor' is added only for prebuilding purposes only as this process cannot resolve transitive headers' paths at the time of writing.
+  # This dependency is implicitly included via following chain: 'ReactCommon' -> 'ReactCommon/turbomodule' -> 'React-cxxreact' -> 'React-runtimeexecutor'.
+  # TODO: remove once perbuilding starts supporting resolution of transitive dependencies
+  s.dependency 'React-runtimeexecutor'
 
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')
     s.source_files = "#{s.name}/**/*.h"

--- a/packages/expo-av/ios/EXAV.podspec
+++ b/packages/expo-av/ios/EXAV.podspec
@@ -17,8 +17,8 @@ Pod::Spec.new do |s|
   s.dependency 'ExpoModulesCore'
   s.dependency 'ReactCommon'
   # 'React-runtimeexecutor' is added only for prebuilding purposes as this process cannot resolve transitive headers' paths at the time of writing.
-  # This dependency is implicitly included via following chain: 'ReactCommon' -> 'ReactCommon/turbomodule' -> 'React-cxxreact' -> 'React-runtimeexecutor'.
-  # TODO: remove once perbuilding starts supporting resolution of transitive dependencies
+  # This dependency is transitively included via following chain: 'ReactCommon' -> 'ReactCommon/turbomodule' -> 'React-cxxreact' -> 'React-runtimeexecutor'.
+  # TODO: remove once prebuilding starts supporting resolution of transitive dependencies
   s.dependency 'React-runtimeexecutor'
 
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')

--- a/tools/src/prebuilds/Prebuilder.ts
+++ b/tools/src/prebuilds/Prebuilder.ts
@@ -26,7 +26,7 @@ export const PACKAGES_TO_PREBUILD = [
   // 'expo-app-auth',
   // 'expo-apple-authentication',
   // 'expo-application',
-  // 'expo-av',
+  'expo-av',
   // 'expo-background-fetch',
   'expo-barcode-scanner',
   // 'expo-battery',


### PR DESCRIPTION
# Why

[ENG-2608](https://linear.app/expo/issue/ENG-2608/follow-up-on-expo-av-prebuild-failure)

# How

I've disassembled the prebuilding process, took advantage of `--generate-specs` flag to generate the `project.xcworkspace` and opened the project with Xcode.
I've tracked down the missing paths in the `HEADER_SEARCH_PATHS` and manually added them - it worked and prebuilding was fine again.
I've found out that https://github.com/expo/expo/blob/65463262f85f607c32cdc72952c4b37f313da15f/tools/src/prebuilds/XcodeGen.ts#L148-L180 is not adding transitive headers' paths to the resulting accumulator that is later written to `.pbxproj`.
To workaround this limitation I've added redundant dependency to the podspec. This dependency does not need to be there for any Xcode-based process, but it has to be there for the sake of prebuilding 👀 

# Test Plan

- [x] `et prebuild expo-av` works
- [x] Building `Expo Go` from Xcode works

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
