### PR TITLE
[android] Fix reanimated exception in remote debugging mode

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/ExpoTurboPackage.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/ExpoTurboPackage.kt
@@ -139,8 +139,13 @@ class ExpoTurboPackage(
   // Reanimated UIManager requires `ReactInstanceManager`,
   // for headless mode we cannot get the hosted `ReactInstanceManager` from current Activity,
   // in this case, we don't override UIManager for reanimated.
+  // besides, we should not override in remote debugging mode because reanimated does not support it.
   private fun shouldOverrideUIManagerForReanimated(): Boolean {
-    return this.reactInstanceManager != null
+    this.reactInstanceManager?.run {
+      return !(devSupportManager.devSettings?.isRemoteJSDebugEnabled ?: false)
+    }
+
+    return false
   }
 
   companion object {

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/host/exp/exponent/ExpoTurboPackage.kt
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/host/exp/exponent/ExpoTurboPackage.kt
@@ -139,8 +139,13 @@ class ExpoTurboPackage(
   // Reanimated UIManager requires `ReactInstanceManager`,
   // for headless mode we cannot get the hosted `ReactInstanceManager` from current Activity,
   // in this case, we don't override UIManager for reanimated.
+  // besides, we should not override in remote debugging mode because reanimated does not support it.
   private fun shouldOverrideUIManagerForReanimated(): Boolean {
-    return this.reactInstanceManager != null
+    this.reactInstanceManager?.run {
+      return !(devSupportManager.devSettings?.isRemoteJSDebugEnabled ?: false)
+    }
+
+    return false
   }
 
   companion object {


### PR DESCRIPTION
# Why

the exception stacktrace:

```
    unknown:ReactNative  E  Exception in native call
                         E  java.lang.NullPointerException: Attempt to invoke interface method 'boolean versioned.host.exp.exponent.modules.api.reanimated.layoutReanimation.NativeMethodsHolder.isLayoutAnimationEnabled()' on a null object reference
                         E      at versioned.host.exp.exponent.modules.api.reanimated.layoutReanimation.AnimationsManager.isLayoutAnimationEnabled(AnimationsManager.java:507)
                         E      at versioned.host.exp.exponent.modules.api.reanimated.layoutReanimation.ReaLayoutAnimator.isLayoutAnimationEnabled(ReanimatedNativeHierarchyManager.java:191)
                         E      at versioned.host.exp.exponent.modules.api.reanimated.layoutReanimation.ReanimatedNativeHierarchyManager.manageChildren(ReanimatedNativeHierarchyManager.java:266)
                         E      at com.facebook.react.uimanager.UIViewOperationQueue$ManageChildrenOperation.execute(UIViewOperationQueue.java:211)
                         E      at com.facebook.react.uimanager.UIViewOperationQueue$1.run(UIViewOperationQueue.java:908)
                         E      at com.facebook.react.uimanager.UIViewOperationQueue.flushPendingBatches(UIViewOperationQueue.java:1019)
                         E      at com.facebook.react.uimanager.UIViewOperationQueue.access$2600(UIViewOperationQueue.java:47)
                         E      at com.facebook.react.uimanager.UIViewOperationQueue$DispatchUIFrameCallback.doFrameGuarded(UIViewOperationQueue.java:1079)
                         E      at com.facebook.react.uimanager.GuardedFrameCallback.doFrame(GuardedFrameCallback.java:29)
                         E      at com.facebook.react.modules.core.ReactChoreographer$ReactChoreographerDispatcher.doFrame(ReactChoreographer.java:175)
                         E      at com.facebook.react.modules.core.ChoreographerCompat$FrameCallback$1.doFrame(ChoreographerCompat.java:85)
                         E      at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1035)
                         E      at android.view.Choreographer.doCallbacks(Choreographer.java:845)
                         E      at android.view.Choreographer.doFrame(Choreographer.java:775)
                         E      at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:1022)
                         E      at android.os.Handler.handleCallback(Handler.java:938)
                         E      at android.os.Handler.dispatchMessage(Handler.java:99)
                         E      at android.os.Looper.loopOnce(Looper.java:201)
                         E      at android.os.Looper.loop(Looper.java:288)
                         E      at android.app.ActivityThread.main(ActivityThread.java:7839)
                         E      at java.lang.reflect.Method.invoke(Native Method)
                         E      at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
                         E      at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003)
```

reanimated 2.3.0 does not support remote debugging mode yet. in expo-go, [we exclude reanimated jsi package in remote debugging mode](https://github.com/expo/expo/blob/204690554b9d9fb8d7e98a97ba5ecfda58b316a0/android/expoview/src/main/java/versioned/host/exp/exponent/VersionedUtils.kt#L187-L205). however, the `UIManager` was overridden as `ReanimatedUIManager`, the inconsistency cause the error.

# How

in remote debugging mode, we should not override `UIManager` for reanimated.

# Test Plan

android unversioned expo-go + ncl with remote debugging on.

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
