### PR TITLE
[android] Fix another background task exception

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
@@ -259,7 +259,7 @@ abstract class ReactNativeActivity :
 
   // endregion
   override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {
-    this.devSupportManager?.let { devSupportManager ->
+   devSupportManager?.let { devSupportManager ->
       if (!isCrashed && devSupportManager.call("getDevSupportEnabled") as Boolean) {
         val didDoubleTapR = Assertions.assertNotNull(doubleTapReloadRecognizer)
           .didDoubleTapR(keyCode, currentFocus)

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
@@ -259,7 +259,7 @@ abstract class ReactNativeActivity :
 
   // endregion
   override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {
-   devSupportManager?.let { devSupportManager ->
+    devSupportManager?.let { devSupportManager ->
       if (!isCrashed && devSupportManager.call("getDevSupportEnabled") as Boolean) {
         val didDoubleTapR = Assertions.assertNotNull(doubleTapReloadRecognizer)
           .didDoubleTapR(keyCode, currentFocus)
@@ -612,7 +612,7 @@ abstract class ReactNativeActivity :
   }
 
   val devSupportManager: RNObject?
-    get() = if (reactInstanceManager.isNotNull) reactInstanceManager.callRecursive("getDevSupportManager") else null
+    get() = reactInstanceManager.takeIf { it.isNotNull }?.callRecursive("getDevSupportManager")
 
   // deprecated in favor of Expo.Linking.makeUrl
   // TODO: remove this

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
@@ -259,8 +259,8 @@ abstract class ReactNativeActivity :
 
   // endregion
   override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {
-    if (reactInstanceManager.isNotNull && !isCrashed) {
-      if (devSupportManager.call("getDevSupportEnabled") as Boolean) {
+    this.devSupportManager?.let { devSupportManager ->
+      if (!isCrashed && devSupportManager.call("getDevSupportEnabled") as Boolean) {
         val didDoubleTapR = Assertions.assertNotNull(doubleTapReloadRecognizer)
           .didDoubleTapR(keyCode, currentFocus)
         if (didDoubleTapR) {
@@ -269,6 +269,7 @@ abstract class ReactNativeActivity :
         }
       }
     }
+
     return super.onKeyUp(keyCode, event)
   }
 
@@ -610,8 +611,8 @@ abstract class ReactNativeActivity :
     )
   }
 
-  val devSupportManager: RNObject
-    get() = reactInstanceManager.callRecursive("getDevSupportManager")!!
+  val devSupportManager: RNObject?
+    get() = if (reactInstanceManager.isNotNull) reactInstanceManager.callRecursive("getDevSupportManager") else null
 
   // deprecated in favor of Expo.Linking.makeUrl
   // TODO: remove this

--- a/android/expoview/src/main/java/host/exp/exponent/headless/InternalHeadlessAppLoader.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/headless/InternalHeadlessAppLoader.kt
@@ -284,7 +284,7 @@ class InternalHeadlessAppLoader(private val context: Context) :
     }
 
     val reactInstanceManager = builder.callRecursive("build")
-    val devSupportManager = this.reactInstanceManager!!.callRecursive("getDevSupportManager")
+    val devSupportManager = reactInstanceManager!!.callRecursive("getDevSupportManager")
     if (devSupportManager != null) {
       val devSettings = devSupportManager.callRecursive("getDevSettings")
       devSettings?.setField("exponentActivityId", activityId)

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/VersionedUtils.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/VersionedUtils.kt
@@ -56,27 +56,37 @@ object VersionedUtils {
   }
 
   private fun reloadExpoApp() {
-    val currentActivity = Exponent.instance.currentActivity
-    if (currentActivity is ReactNativeActivity) {
-      currentActivity.devSupportManager.callRecursive("reloadExpoApp")
-    } else {
+    val currentActivity = Exponent.instance.currentActivity as? ReactNativeActivity ?: return let {
       FLog.e(
         ReactConstants.TAG,
         "Unable to reload the app because the current activity could not be found."
       )
     }
+    val devSupportManager = currentActivity.devSupportManager ?: return let {
+      FLog.e(
+        ReactConstants.TAG,
+        "Unable to get the DevSupportManager from current activity."
+      )
+    }
+
+    devSupportManager.callRecursive("reloadExpoApp")
   }
 
   private fun toggleElementInspector() {
-    val currentActivity = Exponent.instance.currentActivity
-    if (currentActivity is ReactNativeActivity) {
-      currentActivity.devSupportManager.callRecursive("toggleElementInspector")
-    } else {
+    val currentActivity = Exponent.instance.currentActivity as? ReactNativeActivity ?: return let {
       FLog.e(
         ReactConstants.TAG,
         "Unable to toggle the element inspector because the current activity could not be found."
       )
     }
+    val devSupportManager = currentActivity.devSupportManager ?: return let {
+      FLog.e(
+        ReactConstants.TAG,
+        "Unable to get the DevSupportManager from current activity."
+      )
+    }
+
+    devSupportManager.callRecursive("toggleElementInspector")
   }
 
   private fun requestOverlayPermission(context: Context) {
@@ -102,38 +112,48 @@ object VersionedUtils {
   }
 
   private fun togglePerformanceMonitor() {
-    val currentActivity = Exponent.instance.currentActivity
-    if (currentActivity is ReactNativeActivity) {
-      val devSettings = currentActivity.devSupportManager.callRecursive("getDevSettings")
-      if (devSettings != null) {
-        val isFpsDebugEnabled = devSettings.call("isFpsDebugEnabled") as Boolean
-        if (!isFpsDebugEnabled) {
-          // Request overlay permission if needed when "Show Perf Monitor" option is selected
-          requestOverlayPermission(currentActivity)
-        }
-        devSettings.call("setFpsDebugEnabled", !isFpsDebugEnabled)
-      }
-    } else {
+    val currentActivity = Exponent.instance.currentActivity as? ReactNativeActivity ?: return let {
       FLog.e(
         ReactConstants.TAG,
         "Unable to toggle the performance monitor because the current activity could not be found."
       )
     }
+    val devSupportManager = currentActivity.devSupportManager ?: return let {
+      FLog.e(
+        ReactConstants.TAG,
+        "Unable to get the DevSupportManager from current activity."
+      )
+    }
+
+    val devSettings = devSupportManager.callRecursive("getDevSettings")
+    if (devSettings != null) {
+      val isFpsDebugEnabled = devSettings.call("isFpsDebugEnabled") as Boolean
+      if (!isFpsDebugEnabled) {
+        // Request overlay permission if needed when "Show Perf Monitor" option is selected
+        requestOverlayPermission(currentActivity)
+      }
+      devSettings.call("setFpsDebugEnabled", !isFpsDebugEnabled)
+    }
   }
 
   private fun toggleRemoteJSDebugging() {
-    val currentActivity = Exponent.instance.currentActivity
-    if (currentActivity is ReactNativeActivity) {
-      val devSettings = currentActivity.devSupportManager.callRecursive("getDevSettings")
-      if (devSettings != null) {
-        val isRemoteJSDebugEnabled = devSettings.call("isRemoteJSDebugEnabled") as Boolean
-        devSettings.call("setRemoteJSDebugEnabled", !isRemoteJSDebugEnabled)
-      }
-    } else {
+    val currentActivity = Exponent.instance.currentActivity as? ReactNativeActivity ?: return let {
       FLog.e(
         ReactConstants.TAG,
         "Unable to toggle remote JS debugging because the current activity could not be found."
       )
+    }
+    val devSupportManager = currentActivity.devSupportManager ?: return let {
+      FLog.e(
+        ReactConstants.TAG,
+        "Unable to get the DevSupportManager from current activity."
+      )
+    }
+
+    val devSettings = devSupportManager.callRecursive("getDevSettings")
+    if (devSettings != null) {
+      val isRemoteJSDebugEnabled = devSettings.call("isRemoteJSDebugEnabled") as Boolean
+      devSettings.call("setRemoteJSDebugEnabled", !isRemoteJSDebugEnabled)
     }
   }
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/VersionedUtils.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/VersionedUtils.kt
@@ -56,13 +56,13 @@ object VersionedUtils {
   }
 
   private fun reloadExpoApp() {
-    val currentActivity = Exponent.instance.currentActivity as? ReactNativeActivity ?: return let {
+    val currentActivity = Exponent.instance.currentActivity as? ReactNativeActivity ?: return run {
       FLog.e(
         ReactConstants.TAG,
         "Unable to reload the app because the current activity could not be found."
       )
     }
-    val devSupportManager = currentActivity.devSupportManager ?: return let {
+    val devSupportManager = currentActivity.devSupportManager ?: return run {
       FLog.e(
         ReactConstants.TAG,
         "Unable to get the DevSupportManager from current activity."
@@ -73,13 +73,13 @@ object VersionedUtils {
   }
 
   private fun toggleElementInspector() {
-    val currentActivity = Exponent.instance.currentActivity as? ReactNativeActivity ?: return let {
+    val currentActivity = Exponent.instance.currentActivity as? ReactNativeActivity ?: return run {
       FLog.e(
         ReactConstants.TAG,
         "Unable to toggle the element inspector because the current activity could not be found."
       )
     }
-    val devSupportManager = currentActivity.devSupportManager ?: return let {
+    val devSupportManager = currentActivity.devSupportManager ?: return run {
       FLog.e(
         ReactConstants.TAG,
         "Unable to get the DevSupportManager from current activity."
@@ -112,13 +112,13 @@ object VersionedUtils {
   }
 
   private fun togglePerformanceMonitor() {
-    val currentActivity = Exponent.instance.currentActivity as? ReactNativeActivity ?: return let {
+    val currentActivity = Exponent.instance.currentActivity as? ReactNativeActivity ?: return run {
       FLog.e(
         ReactConstants.TAG,
         "Unable to toggle the performance monitor because the current activity could not be found."
       )
     }
-    val devSupportManager = currentActivity.devSupportManager ?: return let {
+    val devSupportManager = currentActivity.devSupportManager ?: return run {
       FLog.e(
         ReactConstants.TAG,
         "Unable to get the DevSupportManager from current activity."
@@ -137,13 +137,13 @@ object VersionedUtils {
   }
 
   private fun toggleRemoteJSDebugging() {
-    val currentActivity = Exponent.instance.currentActivity as? ReactNativeActivity ?: return let {
+    val currentActivity = Exponent.instance.currentActivity as? ReactNativeActivity ?: return run {
       FLog.e(
         ReactConstants.TAG,
         "Unable to toggle remote JS debugging because the current activity could not be found."
       )
     }
-    val devSupportManager = currentActivity.devSupportManager ?: return let {
+    val devSupportManager = currentActivity.devSupportManager ?: return run {
       FLog.e(
         ReactConstants.TAG,
         "Unable to get the DevSupportManager from current activity."

--- a/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/host/exp/exponent/VersionedUtils.java
+++ b/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/host/exp/exponent/VersionedUtils.java
@@ -50,22 +50,36 @@ public class VersionedUtils {
 
   private static void reloadExpoApp() {
     Activity currentActivity = Exponent.getInstance().getCurrentActivity();
-    if (currentActivity instanceof ReactNativeActivity) {
-      ReactNativeActivity reactNativeActivity = (ReactNativeActivity) currentActivity;
-      reactNativeActivity.getDevSupportManager().callRecursive("reloadExpoApp");
-    } else {
+    if (!(currentActivity instanceof ReactNativeActivity)) {
       FLog.e(ReactConstants.TAG, "Unable to reload the app because the current activity could not be found.");
+      return;
     }
+
+    ReactNativeActivity reactNativeActivity = (ReactNativeActivity) currentActivity;
+    RNObject devSupportManager = reactNativeActivity.getDevSupportManager();
+    if (devSupportManager == null) {
+      FLog.e(ReactConstants.TAG, "Unable to get the DevSupportManager from current activity.");
+      return;
+    }
+
+    devSupportManager.callRecursive("reloadExpoApp");
   }
 
   private static void toggleElementInspector() {
     Activity currentActivity = Exponent.getInstance().getCurrentActivity();
-    if (currentActivity instanceof ReactNativeActivity) {
-      ReactNativeActivity reactNativeActivity = (ReactNativeActivity) currentActivity;
-      reactNativeActivity.getDevSupportManager().callRecursive("toggleElementInspector");
-    } else {
+    if (!(currentActivity instanceof ReactNativeActivity)) {
       FLog.e(ReactConstants.TAG, "Unable to toggle the element inspector because the current activity could not be found.");
+      return;
     }
+
+    ReactNativeActivity reactNativeActivity = (ReactNativeActivity) currentActivity;
+    RNObject devSupportManager = reactNativeActivity.getDevSupportManager();
+    if (devSupportManager == null) {
+      FLog.e(ReactConstants.TAG, "Unable to get the DevSupportManager from current activity.");
+      return;
+    }
+
+    devSupportManager.callRecursive("toggleElementInspector");
   }
 
   private static void requestOverlayPermission(Context context) {
@@ -90,34 +104,47 @@ public class VersionedUtils {
 
   private static void togglePerformanceMonitor() {
     Activity currentActivity = Exponent.getInstance().getCurrentActivity();
-    if (currentActivity instanceof ReactNativeActivity) {
-      ReactNativeActivity reactNativeActivity = (ReactNativeActivity) currentActivity;
-      RNObject devSettings = reactNativeActivity.getDevSupportManager().callRecursive("getDevSettings");
-
-      if (devSettings != null) {
-        boolean isFpsDebugEnabled = (boolean) devSettings.call("isFpsDebugEnabled");
-        if (!isFpsDebugEnabled) {
-          // Request overlay permission if needed when "Show Perf Monitor" option is selected
-          requestOverlayPermission(currentActivity);
-        }
-        devSettings.call("setFpsDebugEnabled", !isFpsDebugEnabled);
-      }
-    } else {
+    if (!(currentActivity instanceof ReactNativeActivity)) {
       FLog.e(ReactConstants.TAG, "Unable to toggle the performance monitor because the current activity could not be found.");
+      return;
+    }
+
+    ReactNativeActivity reactNativeActivity = (ReactNativeActivity) currentActivity;
+    RNObject devSupportManager = reactNativeActivity.getDevSupportManager();
+    if (devSupportManager == null) {
+      FLog.e(ReactConstants.TAG, "Unable to get the DevSupportManager from current activity.");
+      return;
+    }
+
+    RNObject devSettings = devSupportManager.callRecursive("getDevSettings");
+    if (devSettings != null) {
+      boolean isFpsDebugEnabled = (boolean) devSettings.call("isFpsDebugEnabled");
+      if (!isFpsDebugEnabled) {
+        // Request overlay permission if needed when "Show Perf Monitor" option is selected
+        requestOverlayPermission(currentActivity);
+      }
+      devSettings.call("setFpsDebugEnabled", !isFpsDebugEnabled);
     }
   }
 
   private static void toggleRemoteJSDebugging() {
     Activity currentActivity = Exponent.getInstance().getCurrentActivity();
-    if (currentActivity instanceof ReactNativeActivity) {
-      ReactNativeActivity reactNativeActivity = (ReactNativeActivity) currentActivity;
-      RNObject devSettings = reactNativeActivity.getDevSupportManager().callRecursive("getDevSettings");
-      if (devSettings != null) {
-        boolean isRemoteJSDebugEnabled = (boolean) devSettings.call("isRemoteJSDebugEnabled");
-        devSettings.call("setRemoteJSDebugEnabled", !isRemoteJSDebugEnabled);
-      }
-    } else {
+    if (!(currentActivity instanceof ReactNativeActivity)) {
       FLog.e(ReactConstants.TAG, "Unable to toggle remote JS debugging because the current activity could not be found.");
+      return;
+    }
+
+    ReactNativeActivity reactNativeActivity = (ReactNativeActivity) currentActivity;
+    RNObject devSupportManager = reactNativeActivity.getDevSupportManager();
+    if (devSupportManager == null) {
+      FLog.e(ReactConstants.TAG, "Unable to get the DevSupportManager from current activity.");
+      return;
+    }
+
+    RNObject devSettings = devSupportManager.callRecursive("getDevSettings");
+    if (devSettings != null) {
+      boolean isRemoteJSDebugEnabled = (boolean) devSettings.call("isRemoteJSDebugEnabled");
+      devSettings.call("setRemoteJSDebugEnabled", !isRemoteJSDebugEnabled);
     }
   }
 

--- a/android/versioned-abis/expoview-abi42_0_0/src/main/java/abi42_0_0/host/exp/exponent/VersionedUtils.java
+++ b/android/versioned-abis/expoview-abi42_0_0/src/main/java/abi42_0_0/host/exp/exponent/VersionedUtils.java
@@ -67,22 +67,36 @@ public class VersionedUtils {
 
   private static void reloadExpoApp() {
     Activity currentActivity = Exponent.getInstance().getCurrentActivity();
-    if (currentActivity instanceof ReactNativeActivity) {
-      ReactNativeActivity reactNativeActivity = (ReactNativeActivity) currentActivity;
-      reactNativeActivity.getDevSupportManager().callRecursive("reloadExpoApp");
-    } else {
+    if (!(currentActivity instanceof ReactNativeActivity)) {
       FLog.e(ReactConstants.TAG, "Unable to reload the app because the current activity could not be found.");
+      return;
     }
+
+    ReactNativeActivity reactNativeActivity = (ReactNativeActivity) currentActivity;
+    RNObject devSupportManager = reactNativeActivity.getDevSupportManager();
+    if (devSupportManager == null) {
+      FLog.e(ReactConstants.TAG, "Unable to get the DevSupportManager from current activity.");
+      return;
+    }
+
+    devSupportManager.callRecursive("reloadExpoApp");
   }
 
   private static void toggleElementInspector() {
     Activity currentActivity = Exponent.getInstance().getCurrentActivity();
-    if (currentActivity instanceof ReactNativeActivity) {
-      ReactNativeActivity reactNativeActivity = (ReactNativeActivity) currentActivity;
-      reactNativeActivity.getDevSupportManager().callRecursive("toggleElementInspector");
-    } else {
+    if (!(currentActivity instanceof ReactNativeActivity)) {
       FLog.e(ReactConstants.TAG, "Unable to toggle the element inspector because the current activity could not be found.");
+      return;
     }
+
+    ReactNativeActivity reactNativeActivity = (ReactNativeActivity) currentActivity;
+    RNObject devSupportManager = reactNativeActivity.getDevSupportManager();
+    if (devSupportManager == null) {
+      FLog.e(ReactConstants.TAG, "Unable to get the DevSupportManager from current activity.");
+      return;
+    }
+
+    devSupportManager.callRecursive("toggleElementInspector");
   }
 
   private static void requestOverlayPermission(Context context) {
@@ -107,34 +121,47 @@ public class VersionedUtils {
 
   private static void togglePerformanceMonitor() {
     Activity currentActivity = Exponent.getInstance().getCurrentActivity();
-    if (currentActivity instanceof ReactNativeActivity) {
-      ReactNativeActivity reactNativeActivity = (ReactNativeActivity) currentActivity;
-      RNObject devSettings = reactNativeActivity.getDevSupportManager().callRecursive("getDevSettings");
-
-      if (devSettings != null) {
-        boolean isFpsDebugEnabled = (boolean) devSettings.call("isFpsDebugEnabled");
-        if (!isFpsDebugEnabled) {
-          // Request overlay permission if needed when "Show Perf Monitor" option is selected
-          requestOverlayPermission(currentActivity);
-        }
-        devSettings.call("setFpsDebugEnabled", !isFpsDebugEnabled);
-      }
-    } else {
+    if (!(currentActivity instanceof ReactNativeActivity)) {
       FLog.e(ReactConstants.TAG, "Unable to toggle the performance monitor because the current activity could not be found.");
+      return;
+    }
+
+    ReactNativeActivity reactNativeActivity = (ReactNativeActivity) currentActivity;
+    RNObject devSupportManager = reactNativeActivity.getDevSupportManager();
+    if (devSupportManager == null) {
+      FLog.e(ReactConstants.TAG, "Unable to get the DevSupportManager from current activity.");
+      return;
+    }
+
+    RNObject devSettings = devSupportManager.callRecursive("getDevSettings");
+    if (devSettings != null) {
+      boolean isFpsDebugEnabled = (boolean) devSettings.call("isFpsDebugEnabled");
+      if (!isFpsDebugEnabled) {
+        // Request overlay permission if needed when "Show Perf Monitor" option is selected
+        requestOverlayPermission(currentActivity);
+      }
+      devSettings.call("setFpsDebugEnabled", !isFpsDebugEnabled);
     }
   }
 
   private static void toggleRemoteJSDebugging() {
     Activity currentActivity = Exponent.getInstance().getCurrentActivity();
-    if (currentActivity instanceof ReactNativeActivity) {
-      ReactNativeActivity reactNativeActivity = (ReactNativeActivity) currentActivity;
-      RNObject devSettings = reactNativeActivity.getDevSupportManager().callRecursive("getDevSettings");
-      if (devSettings != null) {
-        boolean isRemoteJSDebugEnabled = (boolean) devSettings.call("isRemoteJSDebugEnabled");
-        devSettings.call("setRemoteJSDebugEnabled", !isRemoteJSDebugEnabled);
-      }
-    } else {
+    if (!(currentActivity instanceof ReactNativeActivity)) {
       FLog.e(ReactConstants.TAG, "Unable to toggle remote JS debugging because the current activity could not be found.");
+      return;
+    }
+
+    ReactNativeActivity reactNativeActivity = (ReactNativeActivity) currentActivity;
+    RNObject devSupportManager = reactNativeActivity.getDevSupportManager();
+    if (devSupportManager == null) {
+      FLog.e(ReactConstants.TAG, "Unable to get the DevSupportManager from current activity.");
+      return;
+    }
+
+    RNObject devSettings = devSupportManager.callRecursive("getDevSettings");
+    if (devSettings != null) {
+      boolean isRemoteJSDebugEnabled = (boolean) devSettings.call("isRemoteJSDebugEnabled");
+      devSettings.call("setRemoteJSDebugEnabled", !isRemoteJSDebugEnabled);
     }
   }
 

--- a/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/host/exp/exponent/VersionedUtils.kt
+++ b/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/host/exp/exponent/VersionedUtils.kt
@@ -56,27 +56,37 @@ object VersionedUtils {
   }
 
   private fun reloadExpoApp() {
-    val currentActivity = Exponent.instance.currentActivity
-    if (currentActivity is ReactNativeActivity) {
-      currentActivity.devSupportManager.callRecursive("reloadExpoApp")
-    } else {
+    val currentActivity = Exponent.instance.currentActivity as? ReactNativeActivity ?: return let {
       FLog.e(
         ReactConstants.TAG,
         "Unable to reload the app because the current activity could not be found."
       )
     }
+    val devSupportManager = currentActivity.devSupportManager ?: return let {
+      FLog.e(
+        ReactConstants.TAG,
+        "Unable to get the DevSupportManager from current activity."
+      )
+    }
+
+    devSupportManager.callRecursive("reloadExpoApp")
   }
 
   private fun toggleElementInspector() {
-    val currentActivity = Exponent.instance.currentActivity
-    if (currentActivity is ReactNativeActivity) {
-      currentActivity.devSupportManager.callRecursive("toggleElementInspector")
-    } else {
+    val currentActivity = Exponent.instance.currentActivity as? ReactNativeActivity ?: return let {
       FLog.e(
         ReactConstants.TAG,
         "Unable to toggle the element inspector because the current activity could not be found."
       )
     }
+    val devSupportManager = currentActivity.devSupportManager ?: return let {
+      FLog.e(
+        ReactConstants.TAG,
+        "Unable to get the DevSupportManager from current activity."
+      )
+    }
+
+    devSupportManager.callRecursive("toggleElementInspector")
   }
 
   private fun requestOverlayPermission(context: Context) {
@@ -102,38 +112,48 @@ object VersionedUtils {
   }
 
   private fun togglePerformanceMonitor() {
-    val currentActivity = Exponent.instance.currentActivity
-    if (currentActivity is ReactNativeActivity) {
-      val devSettings = currentActivity.devSupportManager.callRecursive("getDevSettings")
-      if (devSettings != null) {
-        val isFpsDebugEnabled = devSettings.call("isFpsDebugEnabled") as Boolean
-        if (!isFpsDebugEnabled) {
-          // Request overlay permission if needed when "Show Perf Monitor" option is selected
-          requestOverlayPermission(currentActivity)
-        }
-        devSettings.call("setFpsDebugEnabled", !isFpsDebugEnabled)
-      }
-    } else {
+    val currentActivity = Exponent.instance.currentActivity as? ReactNativeActivity ?: return let {
       FLog.e(
         ReactConstants.TAG,
         "Unable to toggle the performance monitor because the current activity could not be found."
       )
     }
+    val devSupportManager = currentActivity.devSupportManager ?: return let {
+      FLog.e(
+        ReactConstants.TAG,
+        "Unable to get the DevSupportManager from current activity."
+      )
+    }
+
+    val devSettings = devSupportManager.callRecursive("getDevSettings")
+    if (devSettings != null) {
+      val isFpsDebugEnabled = devSettings.call("isFpsDebugEnabled") as Boolean
+      if (!isFpsDebugEnabled) {
+        // Request overlay permission if needed when "Show Perf Monitor" option is selected
+        requestOverlayPermission(currentActivity)
+      }
+      devSettings.call("setFpsDebugEnabled", !isFpsDebugEnabled)
+    }
   }
 
   private fun toggleRemoteJSDebugging() {
-    val currentActivity = Exponent.instance.currentActivity
-    if (currentActivity is ReactNativeActivity) {
-      val devSettings = currentActivity.devSupportManager.callRecursive("getDevSettings")
-      if (devSettings != null) {
-        val isRemoteJSDebugEnabled = devSettings.call("isRemoteJSDebugEnabled") as Boolean
-        devSettings.call("setRemoteJSDebugEnabled", !isRemoteJSDebugEnabled)
-      }
-    } else {
+    val currentActivity = Exponent.instance.currentActivity as? ReactNativeActivity ?: return let {
       FLog.e(
         ReactConstants.TAG,
         "Unable to toggle remote JS debugging because the current activity could not be found."
       )
+    }
+    val devSupportManager = currentActivity.devSupportManager ?: return let {
+      FLog.e(
+        ReactConstants.TAG,
+        "Unable to get the DevSupportManager from current activity."
+      )
+    }
+
+    val devSettings = devSupportManager.callRecursive("getDevSettings")
+    if (devSettings != null) {
+      val isRemoteJSDebugEnabled = devSettings.call("isRemoteJSDebugEnabled") as Boolean
+      devSettings.call("setRemoteJSDebugEnabled", !isRemoteJSDebugEnabled)
     }
   }
 

--- a/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/host/exp/exponent/VersionedUtils.kt
+++ b/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/host/exp/exponent/VersionedUtils.kt
@@ -56,13 +56,13 @@ object VersionedUtils {
   }
 
   private fun reloadExpoApp() {
-    val currentActivity = Exponent.instance.currentActivity as? ReactNativeActivity ?: return let {
+    val currentActivity = Exponent.instance.currentActivity as? ReactNativeActivity ?: return run {
       FLog.e(
         ReactConstants.TAG,
         "Unable to reload the app because the current activity could not be found."
       )
     }
-    val devSupportManager = currentActivity.devSupportManager ?: return let {
+    val devSupportManager = currentActivity.devSupportManager ?: return run {
       FLog.e(
         ReactConstants.TAG,
         "Unable to get the DevSupportManager from current activity."
@@ -73,13 +73,13 @@ object VersionedUtils {
   }
 
   private fun toggleElementInspector() {
-    val currentActivity = Exponent.instance.currentActivity as? ReactNativeActivity ?: return let {
+    val currentActivity = Exponent.instance.currentActivity as? ReactNativeActivity ?: return run {
       FLog.e(
         ReactConstants.TAG,
         "Unable to toggle the element inspector because the current activity could not be found."
       )
     }
-    val devSupportManager = currentActivity.devSupportManager ?: return let {
+    val devSupportManager = currentActivity.devSupportManager ?: return run {
       FLog.e(
         ReactConstants.TAG,
         "Unable to get the DevSupportManager from current activity."
@@ -112,13 +112,13 @@ object VersionedUtils {
   }
 
   private fun togglePerformanceMonitor() {
-    val currentActivity = Exponent.instance.currentActivity as? ReactNativeActivity ?: return let {
+    val currentActivity = Exponent.instance.currentActivity as? ReactNativeActivity ?: return run {
       FLog.e(
         ReactConstants.TAG,
         "Unable to toggle the performance monitor because the current activity could not be found."
       )
     }
-    val devSupportManager = currentActivity.devSupportManager ?: return let {
+    val devSupportManager = currentActivity.devSupportManager ?: return run {
       FLog.e(
         ReactConstants.TAG,
         "Unable to get the DevSupportManager from current activity."
@@ -137,13 +137,13 @@ object VersionedUtils {
   }
 
   private fun toggleRemoteJSDebugging() {
-    val currentActivity = Exponent.instance.currentActivity as? ReactNativeActivity ?: return let {
+    val currentActivity = Exponent.instance.currentActivity as? ReactNativeActivity ?: return run {
       FLog.e(
         ReactConstants.TAG,
         "Unable to toggle remote JS debugging because the current activity could not be found."
       )
     }
-    val devSupportManager = currentActivity.devSupportManager ?: return let {
+    val devSupportManager = currentActivity.devSupportManager ?: return run {
       FLog.e(
         ReactConstants.TAG,
         "Unable to get the DevSupportManager from current activity."

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/host/exp/exponent/VersionedUtils.kt
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/host/exp/exponent/VersionedUtils.kt
@@ -56,27 +56,37 @@ object VersionedUtils {
   }
 
   private fun reloadExpoApp() {
-    val currentActivity = Exponent.instance.currentActivity
-    if (currentActivity is ReactNativeActivity) {
-      currentActivity.devSupportManager.callRecursive("reloadExpoApp")
-    } else {
+    val currentActivity = Exponent.instance.currentActivity as? ReactNativeActivity ?: return let {
       FLog.e(
         ReactConstants.TAG,
         "Unable to reload the app because the current activity could not be found."
       )
     }
+    val devSupportManager = currentActivity.devSupportManager ?: return let {
+      FLog.e(
+        ReactConstants.TAG,
+        "Unable to get the DevSupportManager from current activity."
+      )
+    }
+
+    devSupportManager.callRecursive("reloadExpoApp")
   }
 
   private fun toggleElementInspector() {
-    val currentActivity = Exponent.instance.currentActivity
-    if (currentActivity is ReactNativeActivity) {
-      currentActivity.devSupportManager.callRecursive("toggleElementInspector")
-    } else {
+    val currentActivity = Exponent.instance.currentActivity as? ReactNativeActivity ?: return let {
       FLog.e(
         ReactConstants.TAG,
         "Unable to toggle the element inspector because the current activity could not be found."
       )
     }
+    val devSupportManager = currentActivity.devSupportManager ?: return let {
+      FLog.e(
+        ReactConstants.TAG,
+        "Unable to get the DevSupportManager from current activity."
+      )
+    }
+
+    devSupportManager.callRecursive("toggleElementInspector")
   }
 
   private fun requestOverlayPermission(context: Context) {
@@ -102,38 +112,48 @@ object VersionedUtils {
   }
 
   private fun togglePerformanceMonitor() {
-    val currentActivity = Exponent.instance.currentActivity
-    if (currentActivity is ReactNativeActivity) {
-      val devSettings = currentActivity.devSupportManager.callRecursive("getDevSettings")
-      if (devSettings != null) {
-        val isFpsDebugEnabled = devSettings.call("isFpsDebugEnabled") as Boolean
-        if (!isFpsDebugEnabled) {
-          // Request overlay permission if needed when "Show Perf Monitor" option is selected
-          requestOverlayPermission(currentActivity)
-        }
-        devSettings.call("setFpsDebugEnabled", !isFpsDebugEnabled)
-      }
-    } else {
+    val currentActivity = Exponent.instance.currentActivity as? ReactNativeActivity ?: return let {
       FLog.e(
         ReactConstants.TAG,
         "Unable to toggle the performance monitor because the current activity could not be found."
       )
     }
+    val devSupportManager = currentActivity.devSupportManager ?: return let {
+      FLog.e(
+        ReactConstants.TAG,
+        "Unable to get the DevSupportManager from current activity."
+      )
+    }
+
+    val devSettings = devSupportManager.callRecursive("getDevSettings")
+    if (devSettings != null) {
+      val isFpsDebugEnabled = devSettings.call("isFpsDebugEnabled") as Boolean
+      if (!isFpsDebugEnabled) {
+        // Request overlay permission if needed when "Show Perf Monitor" option is selected
+        requestOverlayPermission(currentActivity)
+      }
+      devSettings.call("setFpsDebugEnabled", !isFpsDebugEnabled)
+    }
   }
 
   private fun toggleRemoteJSDebugging() {
-    val currentActivity = Exponent.instance.currentActivity
-    if (currentActivity is ReactNativeActivity) {
-      val devSettings = currentActivity.devSupportManager.callRecursive("getDevSettings")
-      if (devSettings != null) {
-        val isRemoteJSDebugEnabled = devSettings.call("isRemoteJSDebugEnabled") as Boolean
-        devSettings.call("setRemoteJSDebugEnabled", !isRemoteJSDebugEnabled)
-      }
-    } else {
+    val currentActivity = Exponent.instance.currentActivity as? ReactNativeActivity ?: return let {
       FLog.e(
         ReactConstants.TAG,
         "Unable to toggle remote JS debugging because the current activity could not be found."
       )
+    }
+    val devSupportManager = currentActivity.devSupportManager ?: return let {
+      FLog.e(
+        ReactConstants.TAG,
+        "Unable to get the DevSupportManager from current activity."
+      )
+    }
+
+    val devSettings = devSupportManager.callRecursive("getDevSettings")
+    if (devSettings != null) {
+      val isRemoteJSDebugEnabled = devSettings.call("isRemoteJSDebugEnabled") as Boolean
+      devSettings.call("setRemoteJSDebugEnabled", !isRemoteJSDebugEnabled)
     }
   }
 

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/host/exp/exponent/VersionedUtils.kt
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/host/exp/exponent/VersionedUtils.kt
@@ -56,13 +56,13 @@ object VersionedUtils {
   }
 
   private fun reloadExpoApp() {
-    val currentActivity = Exponent.instance.currentActivity as? ReactNativeActivity ?: return let {
+    val currentActivity = Exponent.instance.currentActivity as? ReactNativeActivity ?: return run {
       FLog.e(
         ReactConstants.TAG,
         "Unable to reload the app because the current activity could not be found."
       )
     }
-    val devSupportManager = currentActivity.devSupportManager ?: return let {
+    val devSupportManager = currentActivity.devSupportManager ?: return run {
       FLog.e(
         ReactConstants.TAG,
         "Unable to get the DevSupportManager from current activity."
@@ -73,13 +73,13 @@ object VersionedUtils {
   }
 
   private fun toggleElementInspector() {
-    val currentActivity = Exponent.instance.currentActivity as? ReactNativeActivity ?: return let {
+    val currentActivity = Exponent.instance.currentActivity as? ReactNativeActivity ?: return run {
       FLog.e(
         ReactConstants.TAG,
         "Unable to toggle the element inspector because the current activity could not be found."
       )
     }
-    val devSupportManager = currentActivity.devSupportManager ?: return let {
+    val devSupportManager = currentActivity.devSupportManager ?: return run {
       FLog.e(
         ReactConstants.TAG,
         "Unable to get the DevSupportManager from current activity."
@@ -112,13 +112,13 @@ object VersionedUtils {
   }
 
   private fun togglePerformanceMonitor() {
-    val currentActivity = Exponent.instance.currentActivity as? ReactNativeActivity ?: return let {
+    val currentActivity = Exponent.instance.currentActivity as? ReactNativeActivity ?: return run {
       FLog.e(
         ReactConstants.TAG,
         "Unable to toggle the performance monitor because the current activity could not be found."
       )
     }
-    val devSupportManager = currentActivity.devSupportManager ?: return let {
+    val devSupportManager = currentActivity.devSupportManager ?: return run {
       FLog.e(
         ReactConstants.TAG,
         "Unable to get the DevSupportManager from current activity."
@@ -137,13 +137,13 @@ object VersionedUtils {
   }
 
   private fun toggleRemoteJSDebugging() {
-    val currentActivity = Exponent.instance.currentActivity as? ReactNativeActivity ?: return let {
+    val currentActivity = Exponent.instance.currentActivity as? ReactNativeActivity ?: return run {
       FLog.e(
         ReactConstants.TAG,
         "Unable to toggle remote JS debugging because the current activity could not be found."
       )
     }
-    val devSupportManager = currentActivity.devSupportManager ?: return let {
+    val devSupportManager = currentActivity.devSupportManager ?: return run {
       FLog.e(
         ReactConstants.TAG,
         "Unable to get the DevSupportManager from current activity."


### PR DESCRIPTION
# Why

yet another exception specific happen to background task manager, especially switching from background to foreground. the `JSIModulePackage` is called before the `ReactInstanceManager` attached to `ReactNativeActivity`. in this case,  we will get a NPE like this:

```
wn:ReactInstanceManager  W  Instance detached from instance manager
     ExperienceActivity  E  java.lang.NullPointerException
                      j  E  Runtime exception in RNObject when calling method getDevSupportManager: java.lang.NullPointerException: null receiver
             System.err  W  java.lang.reflect.InvocationTargetException
                         W      at java.lang.reflect.Method.invoke(Native Method)
                         W      at com.facebook.react.bridge.DefaultNativeModuleCallExceptionHandler.handleException(DefaultNativeModuleCallExceptionHandler.java:4)
                         W      at com.facebook.react.devsupport.DisabledDevSupportManager.handleException(DisabledDevSupportManager.java:1)
                         W      at com.facebook.react.ReactInstanceManager$5.run(ReactInstanceManager.java:19)
                         W      at java.lang.Thread.run(Thread.java:920)
                         W  Caused by: com.facebook.react.common.JavascriptException
                         W      at host.exp.exponent.ReactNativeStaticHelpers.handleReactNativeError(ReactNativeStaticHelpers.kt:8)
                         W      ... 5 more
```

fixes #15515

# How

- leverage kotlin nullable for `ReactNativeActivity.devSupportManager`
- backport VersionedUtils changes to versioned code

# Test Plan

- [standalone app] follow #15515 steps
- [versioned expo go] test changed functions from sdk41-44 & unversioned apps
  - reload
  - toggleElementInspector
  - togglePerformanceMonitor
  - toggleRemoteJSDebugging

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
