### PR TITLE
[core][ios] Fixed the deep link wasn't passed to the application

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed the deep link wasn't passed to the application if the application wasn't running when the deep link was sent.
+
 ### 💡 Others
 
 ## 0.6.1 — 2021-12-08

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed the deep link wasn't passed to the application if the application wasn't running when the deep link was sent.
+- Fixed the deep link wasn't passed to the application if the application wasn't running when the deep link was sent. ([#15593](https://github.com/expo/expo/pull/15593) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegate.swift
+++ b/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegate.swift
@@ -21,19 +21,19 @@ open class ExpoAppDelegate: UIResponder, UIApplicationDelegate {
   // MARK: - Initializing the App
 
   open func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
-    let isWillFinishLaunchingWithOptionsImplmented = subscribers.contains {
+    let parsedSubscribers = subscribers.filter {
       $0.responds(to: #selector(application(_:willFinishLaunchingWithOptions:)))
     }
     
     // If we can't find a subscriber that implements `willFinishLaunchingWithOptions`, we will delegate the decision if we can handel the passed URL to
     // the `didFinishLaunchingWithOptions` method by returning `true` here.
     //  You can read more about how iOS handles deep links here: https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623112-application#discussion
-    if (!isWillFinishLaunchingWithOptionsImplmented) {
+    if (parsedSubscribers.isEmpty) {
       return true;
     }
     
-    return subscribers.reduce(false) { result, subscriber in
-      return subscriber.application?(application, willFinishLaunchingWithOptions: launchOptions) ?? false || result
+    return parsedSubscribers.reduce(false) { result, subscriber in
+      return subscriber.application!(application, willFinishLaunchingWithOptions: launchOptions) || result
     }
   }
 

--- a/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegate.swift
+++ b/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegate.swift
@@ -21,6 +21,17 @@ open class ExpoAppDelegate: UIResponder, UIApplicationDelegate {
   // MARK: - Initializing the App
 
   open func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+    let isWillFinishLaunchingWithOptionsImplmented = subscribers.contains {
+      $0.responds(to: #selector(application(_:willFinishLaunchingWithOptions:)))
+    }
+    
+    // If we can't find a subscriber that implements `willFinishLaunchingWithOptions`, we will delegate the decision if we can handel the passed URL to
+    // the `didFinishLaunchingWithOptions` method by returning `true` here.
+    //  You can read more about how iOS handles deep links here: https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623112-application#discussion
+    if (!isWillFinishLaunchingWithOptionsImplmented) {
+      return true;
+    }
+    
     return subscribers.reduce(false) { result, subscriber in
       return subscriber.application?(application, willFinishLaunchingWithOptions: launchOptions) ?? false || result
     }


### PR DESCRIPTION
# Why

Fixes https://exponent-internal.slack.com/archives/C011V63429H/p1639597552094400

# How

```
func application(_ app: UIApplication,
                     open url: URL,
                  options: [UIApplication.OpenURLOptionsKey : Any] = [:])
```
won’t be called if `application(_:willFinishLaunchingWithOptions:)` and `application(_:didFinishLaunchingWithOptions:)` return false.

https://github.com/expo/expo/blob/65463262f85f607c32cdc72952c4b37f313da15f/ios/versioned/sdk44/ExpoModulesCore/AppDelegates/ExpoAppDelegate.swift#L23-L33
Above you can find those two methods and in our case, they always return false when there isn't any subscriber which implements underlying methods. In our template, we don't implement` willFinishLaunchingWithOptions`, and in that case, the deep link won't be propagated.

# Test Plan

- tested in an app with expo 44 beta and dev-client 