### PR TITLE
[jest-expo] Remove jest dependency, leave installing it up to the developer

### DIFF
--- a/docs/pages/guides/testing-with-jest.md
+++ b/docs/pages/guides/testing-with-jest.md
@@ -8,7 +8,7 @@ title: Testing with Jest
 
 The first thing we'll want to do is install jest-expo, it's a Jest preset that mocks out the native side of the Expo SDK and handles some configuration for you.
 
-To install the compatible version of `jest-expo` for your project, run: `expo install jest-expo`
+To install the compatible version of `jest-expo` for your project, run: `expo install jest-expo jest`
 
 Then we need to add/update **package.json** to include:
 

--- a/guides/releasing/Release Workflow.md
+++ b/guides/releasing/Release Workflow.md
@@ -475,15 +475,15 @@ Once everything above is completed and Apple has approved Expo Go (iOS) for the 
 **How:**
 
 - For each of the following packages, run `et update-versions -k 'relatedPackages.<package-name>' -v '^X.Y.Z'`
-  - `typescript`
-  - `@types/react`
-  - `@types/react-dom`
-  - `@types/react-native`
-  - `react-native-web`
-  - `babel-preset-expo`
   - `@babel/core`
   - `@expo/webpack-config`
-  - `react-native-unimodules`
+  - `@types/react-dom`
+  - `@types/react-native`
+  - `@types/react`
+  - `babel-preset-expo`
+  - `jest`
+  - `react-native-web`
+  - `typescript`
 - One way to get the right version numbers is to run `yarn why <package-name>` to see which version is used by apps in the expo/expo repo. Generally the version numbers should have a carat (`^`) except for `react-native-unimodules`, which should have a tilde (`~`).
 
 ## 5.4. Re-publish project templates

--- a/packages/jest-expo/README.md
+++ b/packages/jest-expo/README.md
@@ -4,7 +4,7 @@ A [Jest](https://facebook.github.io/jest/) preset to painlessly test your Expo /
 
 ### Installation
 
-- To install the compatible version of `jest-expo` for your project, run: `expo install jest-expo`
+- To install the compatible version of `jest-expo` and `jest` for your project, run: `expo install jest-expo jest`.
 - Add the following config to `package.json`:
 
   ```json
@@ -26,6 +26,8 @@ A [Jest](https://facebook.github.io/jest/) preset to painlessly test your Expo /
   ```
 
 - Run `npm test` and it should pass
+
+>  You can use a different version of `jest` than the one that is installed with `expo install`, but keep in mind that the SDK and `jest-expo` are built against that version.
 
 ## Platforms
 

--- a/packages/jest-expo/package.json
+++ b/packages/jest-expo/package.json
@@ -35,7 +35,6 @@
     "@jest/create-cache-key-function": "^26.6.2",
     "babel-jest": "^26.6.3",
     "find-up": "^5.0.0",
-    "jest": "^26.6.3",
     "jest-watch-select-projects": "^2.0.0",
     "jest-watch-typeahead": "0.6.4",
     "json5": "^2.1.0",

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -39,6 +39,7 @@
     "@types/react": "~17.0.21",
     "@types/react-native": "~0.64.12",
     "jest-expo": "~43.0.1",
+    "jest": "^26.6.3",
     "react-test-renderer": "17.0.1",
     "typescript": "~4.3.5"
   }


### PR DESCRIPTION
# Why

This gives developers more direct control over the jest version in their app, to fix #14823

# How

Remove the dependency, update related docs.

# Test Plan

Tabs template works as expected.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
