### PR TITLE
[expo-updates][ios] Use constants for EXUpdatesConfig dictionary keys

### DIFF
--- a/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
@@ -345,16 +345,16 @@ NS_ASSUME_NONNULL_BEGIN
   }
 
   _config = [EXUpdatesConfig configWithDictionary:@{
-    @"EXUpdatesURL": httpManifestUrl.absoluteString,
-    @"EXUpdatesSDKVersion": [self _sdkVersions],
-    @"EXUpdatesScopeKey": httpManifestUrl.absoluteString,
-    @"EXUpdatesReleaseChannel": releaseChannel,
-    @"EXUpdatesHasEmbeddedUpdate": @([EXEnvironment sharedEnvironment].isDetached),
-    @"EXUpdatesEnabled": @([EXEnvironment sharedEnvironment].areRemoteUpdatesEnabled),
-    @"EXUpdatesLaunchWaitMs": launchWaitMs,
-    @"EXUpdatesCheckOnLaunch": shouldCheckOnLaunch ? @"ALWAYS" : @"NEVER",
-    @"EXUpdatesExpectsSignedManifest": @YES,
-    @"EXUpdatesRequestHeaders": [self _requestHeaders]
+    EXUpdatesConfigUpdateUrlKey: httpManifestUrl.absoluteString,
+    EXUpdatesConfigSDKVersionKey: [self _sdkVersions],
+    EXUpdatesConfigScopeKeyKey: httpManifestUrl.absoluteString,
+    EXUpdatesConfigReleaseChannelKey: releaseChannel,
+    EXUpdatesConfigHasEmbeddedUpdateKey: @([EXEnvironment sharedEnvironment].isDetached),
+    EXUpdatesConfigEnabledKey: @([EXEnvironment sharedEnvironment].areRemoteUpdatesEnabled),
+    EXUpdatesConfigLaunchWaitMsKey: launchWaitMs,
+    EXUpdatesConfigCheckOnLaunchKey: shouldCheckOnLaunch ? EXUpdatesConfigCheckOnLaunchValueAlways : EXUpdatesConfigCheckOnLaunchValueNever,
+    EXUpdatesConfigExpectsSignedManifestKey: @YES,
+    EXUpdatesConfigRequestHeadersKey: [self _requestHeaders]
   }];
 
   if (![EXEnvironment sharedEnvironment].areRemoteUpdatesEnabled) {

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.h
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.h
@@ -12,7 +12,24 @@ typedef NS_ENUM(NSInteger, EXUpdatesCheckAutomaticallyConfig) {
 };
 
 FOUNDATION_EXPORT NSString * const EXUpdatesConfigPlistName;
+
 FOUNDATION_EXPORT NSString * const EXUpdatesConfigEnableAutoSetupKey;
+FOUNDATION_EXPORT NSString * const EXUpdatesConfigEnabledKey;
+FOUNDATION_EXPORT NSString * const EXUpdatesConfigScopeKeyKey;
+FOUNDATION_EXPORT NSString * const EXUpdatesConfigUpdateUrlKey;
+FOUNDATION_EXPORT NSString * const EXUpdatesConfigRequestHeadersKey;
+FOUNDATION_EXPORT NSString * const EXUpdatesConfigReleaseChannelKey;
+FOUNDATION_EXPORT NSString * const EXUpdatesConfigLaunchWaitMsKey;
+FOUNDATION_EXPORT NSString * const EXUpdatesConfigCheckOnLaunchKey;
+FOUNDATION_EXPORT NSString * const EXUpdatesConfigSDKVersionKey;
+FOUNDATION_EXPORT NSString * const EXUpdatesConfigRuntimeVersionKey;
+FOUNDATION_EXPORT NSString * const EXUpdatesConfigHasEmbeddedUpdateKey;
+FOUNDATION_EXPORT NSString * const EXUpdatesConfigExpectsSignedManifestKey;
+
+FOUNDATION_EXPORT NSString * const EXUpdatesConfigCheckOnLaunchValueAlways;
+FOUNDATION_EXPORT NSString * const EXUpdatesConfigCheckOnLaunchValueWifiOnly;
+FOUNDATION_EXPORT NSString * const EXUpdatesConfigCheckOnLaunchValueErrorRecoveryOnly;
+FOUNDATION_EXPORT NSString * const EXUpdatesConfigCheckOnLaunchValueNever;
 
 
 @interface EXUpdatesConfig : NSObject

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.m
@@ -21,25 +21,26 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NSString * const EXUpdatesConfigPlistName = @"Expo";
+
 NSString * const EXUpdatesConfigEnableAutoSetupKey = @"EXUpdatesAutoSetup";
+NSString * const EXUpdatesConfigEnabledKey = @"EXUpdatesEnabled";
+NSString * const EXUpdatesConfigScopeKeyKey = @"EXUpdatesScopeKey";
+NSString * const EXUpdatesConfigUpdateUrlKey = @"EXUpdatesURL";
+NSString * const EXUpdatesConfigRequestHeadersKey = @"EXUpdatesRequestHeaders";
+NSString * const EXUpdatesConfigReleaseChannelKey = @"EXUpdatesReleaseChannel";
+NSString * const EXUpdatesConfigLaunchWaitMsKey = @"EXUpdatesLaunchWaitMs";
+NSString * const EXUpdatesConfigCheckOnLaunchKey = @"EXUpdatesCheckOnLaunch";
+NSString * const EXUpdatesConfigSDKVersionKey = @"EXUpdatesSDKVersion";
+NSString * const EXUpdatesConfigRuntimeVersionKey = @"EXUpdatesRuntimeVersion";
+NSString * const EXUpdatesConfigHasEmbeddedUpdateKey = @"EXUpdatesHasEmbeddedUpdate";
+NSString * const EXUpdatesConfigExpectsSignedManifestKey = @"EXUpdatesExpectsSignedManifest";
 
-static NSString * const EXUpdatesDefaultReleaseChannelName = @"default";
+NSString * const EXUpdatesConfigReleaseChannelDefaultValue = @"default";
 
-static NSString * const EXUpdatesConfigEnabledKey = @"EXUpdatesEnabled";
-static NSString * const EXUpdatesConfigScopeKeyKey = @"EXUpdatesScopeKey";
-static NSString * const EXUpdatesConfigUpdateUrlKey = @"EXUpdatesURL";
-static NSString * const EXUpdatesConfigRequestHeadersKey = @"EXUpdatesRequestHeaders";
-static NSString * const EXUpdatesConfigReleaseChannelKey = @"EXUpdatesReleaseChannel";
-static NSString * const EXUpdatesConfigLaunchWaitMsKey = @"EXUpdatesLaunchWaitMs";
-static NSString * const EXUpdatesConfigCheckOnLaunchKey = @"EXUpdatesCheckOnLaunch";
-static NSString * const EXUpdatesConfigSDKVersionKey = @"EXUpdatesSDKVersion";
-static NSString * const EXUpdatesConfigRuntimeVersionKey = @"EXUpdatesRuntimeVersion";
-static NSString * const EXUpdatesConfigHasEmbeddedUpdateKey = @"EXUpdatesHasEmbeddedUpdate";
-
-static NSString * const EXUpdatesConfigAlwaysString = @"ALWAYS";
-static NSString * const EXUpdatesConfigWifiOnlyString = @"WIFI_ONLY";
-static NSString * const EXUpdatesConfigErrorRecoveryOnlyString = @"ERROR_RECOVERY_ONLY";
-static NSString * const EXUpdatesConfigNeverString = @"NEVER";
+NSString * const EXUpdatesConfigCheckOnLaunchValueAlways = @"ALWAYS";
+NSString * const EXUpdatesConfigCheckOnLaunchValueWifiOnly = @"WIFI_ONLY";
+NSString * const EXUpdatesConfigCheckOnLaunchValueErrorRecoveryOnly = @"ERROR_RECOVERY_ONLY";
+NSString * const EXUpdatesConfigCheckOnLaunchValueNever = @"NEVER";
 
 @implementation EXUpdatesConfig
 
@@ -49,7 +50,7 @@ static NSString * const EXUpdatesConfigNeverString = @"NEVER";
     _isEnabled = YES;
     _expectsSignedManifest = NO;
     _requestHeaders = @{};
-    _releaseChannel = EXUpdatesDefaultReleaseChannelName;
+    _releaseChannel = EXUpdatesConfigReleaseChannelDefaultValue;
     _launchWaitMs = @(0);
     _checkOnLaunch = EXUpdatesCheckAutomaticallyConfigAlways;
     _hasEmbeddedUpdate = YES;
@@ -82,7 +83,7 @@ static NSString * const EXUpdatesConfigNeverString = @"NEVER";
     _isEnabled = [(NSNumber *)isEnabled boolValue];
   }
   
-  id expectsSignedManifest = config[@"EXUpdatesExpectsSignedManifest"];
+  id expectsSignedManifest = config[EXUpdatesConfigExpectsSignedManifestKey];
   if (expectsSignedManifest && [expectsSignedManifest isKindOfClass:[NSNumber class]]) {
     _expectsSignedManifest = [(NSNumber *)expectsSignedManifest boolValue];
   }
@@ -139,13 +140,13 @@ static NSString * const EXUpdatesConfigNeverString = @"NEVER";
 
   id checkOnLaunch = config[EXUpdatesConfigCheckOnLaunchKey];
   if (checkOnLaunch && [checkOnLaunch isKindOfClass:[NSString class]]) {
-    if ([EXUpdatesConfigNeverString isEqualToString:(NSString *)checkOnLaunch]) {
+    if ([EXUpdatesConfigCheckOnLaunchValueNever isEqualToString:(NSString *)checkOnLaunch]) {
       _checkOnLaunch = EXUpdatesCheckAutomaticallyConfigNever;
-    } else if ([EXUpdatesConfigErrorRecoveryOnlyString isEqualToString:(NSString *)checkOnLaunch]) {
+    } else if ([EXUpdatesConfigCheckOnLaunchValueErrorRecoveryOnly isEqualToString:(NSString *)checkOnLaunch]) {
       _checkOnLaunch = EXUpdatesCheckAutomaticallyConfigErrorRecoveryOnly;
-    } else if ([EXUpdatesConfigWifiOnlyString isEqualToString:(NSString *)checkOnLaunch]) {
+    } else if ([EXUpdatesConfigCheckOnLaunchValueWifiOnly isEqualToString:(NSString *)checkOnLaunch]) {
       _checkOnLaunch = EXUpdatesCheckAutomaticallyConfigWifiOnly;
-    } else if ([EXUpdatesConfigAlwaysString isEqualToString:(NSString *)checkOnLaunch]) {
+    } else if ([EXUpdatesConfigCheckOnLaunchValueAlways isEqualToString:(NSString *)checkOnLaunch]) {
       _checkOnLaunch = EXUpdatesCheckAutomaticallyConfigAlways;
     }
   }

--- a/packages/expo-updates/ios/Tests/EXUpdatesBuildDataTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesBuildDataTests.m
@@ -52,29 +52,29 @@ static NSString * const scopeKey = @"test";
   
   
   _configChannelTestDictionary = @{
-    @"EXUpdatesScopeKey": scopeKey,
-    @"EXUpdatesURL": @"https://exp.host/@test/test",
-    @"EXUpdatesRequestHeaders": @{@"expo-channel-name":@"test"}
+    EXUpdatesConfigScopeKeyKey: scopeKey,
+    EXUpdatesConfigUpdateUrlKey: @"https://exp.host/@test/test",
+    EXUpdatesConfigRequestHeadersKey: @{@"expo-channel-name":@"test"}
   };
   _configChannelTest = [EXUpdatesConfig configWithDictionary:_configChannelTestDictionary];
   _configChannelTestTwoDictionary = @{
-    @"EXUpdatesScopeKey": scopeKey,
-    @"EXUpdatesURL": @"https://exp.host/@test/test",
-    @"EXUpdatesRequestHeaders": @{@"expo-channel-name":@"testTwo"}
+    EXUpdatesConfigScopeKeyKey: scopeKey,
+    EXUpdatesConfigUpdateUrlKey: @"https://exp.host/@test/test",
+    EXUpdatesConfigRequestHeadersKey: @{@"expo-channel-name":@"testTwo"}
   };
   _configChannelTestTwo = [EXUpdatesConfig configWithDictionary:_configChannelTestTwoDictionary
   ];
   
   _configReleaseChannelTestDictionary = @{
-    @"EXUpdatesScopeKey": scopeKey,
-    @"EXUpdatesURL": @"https://exp.host/@test/test",
-    @"EXUpdatesReleaseChannel": @"test",
+    EXUpdatesConfigScopeKeyKey: scopeKey,
+    EXUpdatesConfigUpdateUrlKey: @"https://exp.host/@test/test",
+    EXUpdatesConfigReleaseChannelKey: @"test",
   };
   _configReleaseChannelTest = [EXUpdatesConfig configWithDictionary:_configReleaseChannelTestDictionary];
   _configReleaseChannelTestTwoDictionary = @{
-    @"EXUpdatesScopeKey": scopeKey,
-    @"EXUpdatesURL": @"https://exp.host/@test/test",
-    @"EXUpdatesReleaseChannel": @"testTwo",
+    EXUpdatesConfigScopeKeyKey: scopeKey,
+    EXUpdatesConfigUpdateUrlKey: @"https://exp.host/@test/test",
+    EXUpdatesConfigReleaseChannelKey: @"testTwo",
   };
   _configReleaseChannelTestTwo = [EXUpdatesConfig configWithDictionary:_configReleaseChannelTestTwoDictionary
   ];

--- a/packages/expo-updates/ios/Tests/EXUpdatesDatabaseIntegrityCheckTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesDatabaseIntegrityCheckTests.m
@@ -75,8 +75,8 @@
   NSString *scopeKey = @"testScopeKey";
   NSString *runtimeVersion = @"1.0";
   EXUpdatesConfig *config = [EXUpdatesConfig configWithDictionary:@{
-    @"EXUpdatesScopeKey": scopeKey,
-    @"EXUpdatesRuntimeVersion": runtimeVersion
+    EXUpdatesConfigScopeKeyKey: scopeKey,
+    EXUpdatesConfigRuntimeVersionKey: runtimeVersion
   }];
   EXUpdatesUpdate *update1 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:scopeKey commitTime:[NSDate dateWithTimeIntervalSince1970:1608667851] runtimeVersion:runtimeVersion manifest:nil status:EXUpdatesUpdateStatusReady keep:YES config:config database:_db];
   EXUpdatesUpdate *update2 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:scopeKey commitTime:[NSDate dateWithTimeIntervalSince1970:1608667852] runtimeVersion:runtimeVersion manifest:nil status:EXUpdatesUpdateStatusReady keep:YES config:config database:_db];
@@ -116,8 +116,8 @@
   NSString *scopeKey = @"testScopeKey";
   NSString *runtimeVersion = @"1.0";
   EXUpdatesConfig *config = [EXUpdatesConfig configWithDictionary:@{
-    @"EXUpdatesScopeKey": scopeKey,
-    @"EXUpdatesRuntimeVersion": runtimeVersion
+    EXUpdatesConfigScopeKeyKey: scopeKey,
+    EXUpdatesConfigRuntimeVersionKey: runtimeVersion
   }];
   EXUpdatesUpdate *update1 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:scopeKey commitTime:[NSDate dateWithTimeIntervalSince1970:1608667851] runtimeVersion:runtimeVersion manifest:nil status:EXUpdatesUpdateStatusReady keep:YES config:config database:_db];
   EXUpdatesUpdate *update2 = [EXUpdatesUpdate updateWithId:NSUUID.UUID scopeKey:scopeKey commitTime:[NSDate dateWithTimeIntervalSince1970:1608667852] runtimeVersion:runtimeVersion manifest:nil status:EXUpdatesUpdateStatusReady keep:YES config:config database:_db];

--- a/packages/expo-updates/ios/Tests/EXUpdatesDatabaseTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesDatabaseTests.m
@@ -43,8 +43,7 @@
     @"launchAsset": @{@"url": @"https://url.to/bundle.js", @"contentType": @"application/javascript"}
   }];
   _config = [EXUpdatesConfig configWithDictionary:@{
-    @"EXUpdatesURL": @"https://exp.host/@test/test",
-    @"EXUpdatesUsesLegacyManifest": @(NO)
+    EXUpdatesConfigUpdateUrlKey: @"https://exp.host/@test/test",
   }];
 }
 

--- a/packages/expo-updates/ios/Tests/EXUpdatesFileDownloaderManifestParsingTest.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesFileDownloaderManifestParsingTest.m
@@ -41,7 +41,7 @@
   };
   
   EXUpdatesConfig *config = [EXUpdatesConfig configWithDictionary:@{
-    @"EXUpdatesURL": @"https://exp.host/@test/test",
+    EXUpdatesConfigUpdateUrlKey: @"https://exp.host/@test/test",
   }];
   EXUpdatesFileDownloader *downloader = [[EXUpdatesFileDownloader alloc] initWithUpdatesConfig:config];
   
@@ -83,7 +83,7 @@
   };
   
   EXUpdatesConfig *config = [EXUpdatesConfig configWithDictionary:@{
-    @"EXUpdatesURL": @"https://exp.host/@test/test",
+    EXUpdatesConfigUpdateUrlKey: @"https://exp.host/@test/test",
   }];
   EXUpdatesFileDownloader *downloader = [[EXUpdatesFileDownloader alloc] initWithUpdatesConfig:config];
   

--- a/packages/expo-updates/ios/Tests/EXUpdatesFileDownloaderTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesFileDownloaderTests.m
@@ -14,9 +14,8 @@
 - (void)testCacheControl_LegacyManifest
 {
   EXUpdatesConfig *config = [EXUpdatesConfig configWithDictionary:@{
-    @"EXUpdatesURL": @"https://exp.host/@test/test",
-    @"EXUpdatesRuntimeVersion": @"1.0",
-    @"EXUpdatesUsesLegacyManifest": @(YES)
+    EXUpdatesConfigUpdateUrlKey: @"https://exp.host/@test/test",
+    EXUpdatesConfigRuntimeVersionKey: @"1.0",
   }];
   EXUpdatesFileDownloader *downloader = [[EXUpdatesFileDownloader alloc] initWithUpdatesConfig:config];
 
@@ -28,9 +27,8 @@
 - (void)testCacheControl_NewManifest
 {
   EXUpdatesConfig *config = [EXUpdatesConfig configWithDictionary:@{
-    @"EXUpdatesURL": @"https://u.expo.dev/00000000-0000-0000-0000-000000000000",
-    @"EXUpdatesRuntimeVersion": @"1.0",
-    @"EXUpdatesUsesLegacyManifest": @(NO)
+    EXUpdatesConfigUpdateUrlKey: @"https://u.expo.dev/00000000-0000-0000-0000-000000000000",
+    EXUpdatesConfigRuntimeVersionKey: @"1.0",
   }];
   EXUpdatesFileDownloader *downloader = [[EXUpdatesFileDownloader alloc] initWithUpdatesConfig:config];
 
@@ -42,8 +40,8 @@
 - (void)testExtraHeaders_ObjectTypes
 {
   EXUpdatesConfig *config = [EXUpdatesConfig configWithDictionary:@{
-    @"EXUpdatesURL": @"https://u.expo.dev/00000000-0000-0000-0000-000000000000",
-    @"EXUpdatesRuntimeVersion": @"1.0"
+    EXUpdatesConfigUpdateUrlKey: @"https://u.expo.dev/00000000-0000-0000-0000-000000000000",
+    EXUpdatesConfigRuntimeVersionKey: @"1.0"
   }];
   EXUpdatesFileDownloader *downloader = [[EXUpdatesFileDownloader alloc] initWithUpdatesConfig:config];
 
@@ -62,9 +60,9 @@
 - (void)testExtraHeaders_OverrideOrder
 {
   EXUpdatesConfig *config = [EXUpdatesConfig configWithDictionary:@{
-    @"EXUpdatesURL": @"https://u.expo.dev/00000000-0000-0000-0000-000000000000",
-    @"EXUpdatesRuntimeVersion": @"1.0",
-    @"EXUpdatesRequestHeaders": @{
+    EXUpdatesConfigUpdateUrlKey: @"https://u.expo.dev/00000000-0000-0000-0000-000000000000",
+    EXUpdatesConfigRuntimeVersionKey: @"1.0",
+    EXUpdatesConfigRequestHeadersKey: @{
       // custom headers configured at build-time should be able to override preset headers
       @"expo-updates-environment": @"custom"
     }
@@ -84,9 +82,9 @@
 - (void)testAssetExtraHeaders_OverrideOrder
 {
   EXUpdatesConfig *config = [EXUpdatesConfig configWithDictionary:@{
-    @"EXUpdatesURL": @"https://u.expo.dev/00000000-0000-0000-0000-000000000000",
-    @"EXUpdatesRuntimeVersion": @"1.0",
-    @"EXUpdatesRequestHeaders": @{
+    EXUpdatesConfigUpdateUrlKey: @"https://u.expo.dev/00000000-0000-0000-0000-000000000000",
+    EXUpdatesConfigRuntimeVersionKey: @"1.0",
+    EXUpdatesConfigRequestHeadersKey: @{
       // custom headers configured at build-time should be able to override preset headers
       @"expo-updates-environment": @"custom"
     }

--- a/packages/expo-updates/ios/Tests/EXUpdatesLegacyUpdateTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesLegacyUpdateTests.m
@@ -20,13 +20,12 @@
 - (void)setUp
 {
   _config = [EXUpdatesConfig configWithDictionary:@{
-    @"EXUpdatesURL": @"https://exp.host/@test/test",
-    @"EXUpdatesUsesLegacyManifest": @(YES)
+    EXUpdatesConfigUpdateUrlKey: @"https://exp.host/@test/test",
   }];
 
   _selfHostedConfig = [EXUpdatesConfig configWithDictionary:@{
-    @"EXUpdatesURL": @"https://esamelson.github.io/self-hosting-test/ios-index.json",
-    @"EXUpdatesSDKVersion": @"38.0.0"
+    EXUpdatesConfigUpdateUrlKey: @"https://esamelson.github.io/self-hosting-test/ios-index.json",
+    EXUpdatesConfigSDKVersionKey: @"38.0.0"
   }];
 
   _database = [EXUpdatesDatabase new];
@@ -41,18 +40,18 @@
 {
   EXManifestsLegacyManifest *manifest = [[EXManifestsLegacyManifest alloc] initWithRawManifestJSON:@{}];
   NSURL *expected = [NSURL URLWithString:@"https://d1wp6m56sqw74a.cloudfront.net/~assets/"];
-  XCTAssert([expected isEqual:[EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:manifest config:[EXUpdatesConfig configWithDictionary:@{@"EXUpdatesURL": @"https://exp.host/@test/test"}]]]);
-  XCTAssert([expected isEqual:[EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:manifest config:[EXUpdatesConfig configWithDictionary:@{@"EXUpdatesURL": @"https://expo.io/@test/test"}]]]);
-  XCTAssert([expected isEqual:[EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:manifest config:[EXUpdatesConfig configWithDictionary:@{@"EXUpdatesURL": @"https://expo.test/@test/test"}]]]);
+  XCTAssert([expected isEqual:[EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:manifest config:[EXUpdatesConfig configWithDictionary:@{EXUpdatesConfigUpdateUrlKey: @"https://exp.host/@test/test"}]]]);
+  XCTAssert([expected isEqual:[EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:manifest config:[EXUpdatesConfig configWithDictionary:@{EXUpdatesConfigUpdateUrlKey: @"https://expo.io/@test/test"}]]]);
+  XCTAssert([expected isEqual:[EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:manifest config:[EXUpdatesConfig configWithDictionary:@{EXUpdatesConfigUpdateUrlKey: @"https://expo.test/@test/test"}]]]);
 }
 
 - (void)testBundledAssetBaseUrl_ExpoSubdomain
 {
   EXManifestsLegacyManifest *manifest = [[EXManifestsLegacyManifest alloc] initWithRawManifestJSON:@{}];
   NSURL *expected = [NSURL URLWithString:@"https://d1wp6m56sqw74a.cloudfront.net/~assets/"];
-  XCTAssert([expected isEqual:[EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:manifest config:[EXUpdatesConfig configWithDictionary:@{@"EXUpdatesURL": @"https://staging.exp.host/@test/test"}]]]);
-  XCTAssert([expected isEqual:[EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:manifest config:[EXUpdatesConfig configWithDictionary:@{@"EXUpdatesURL": @"https://staging.expo.io/@test/test"}]]]);
-  XCTAssert([expected isEqual:[EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:manifest config:[EXUpdatesConfig configWithDictionary:@{@"EXUpdatesURL": @"https://staging.expo.test/@test/test"}]]]);
+  XCTAssert([expected isEqual:[EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:manifest config:[EXUpdatesConfig configWithDictionary:@{EXUpdatesConfigUpdateUrlKey: @"https://staging.exp.host/@test/test"}]]]);
+  XCTAssert([expected isEqual:[EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:manifest config:[EXUpdatesConfig configWithDictionary:@{EXUpdatesConfigUpdateUrlKey: @"https://staging.expo.io/@test/test"}]]]);
+  XCTAssert([expected isEqual:[EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:manifest config:[EXUpdatesConfig configWithDictionary:@{EXUpdatesConfigUpdateUrlKey: @"https://staging.expo.test/@test/test"}]]]);
 }
 
 - (void)testBundledAssetBaseUrl_AssetUrlOverride_AbsoluteUrl

--- a/packages/expo-updates/ios/Tests/EXUpdatesNewUpdateTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesNewUpdateTests.m
@@ -19,8 +19,7 @@
 - (void)setUp
 {
   _config = [EXUpdatesConfig configWithDictionary:@{
-    @"EXUpdatesURL": @"https://exp.host/@test/test",
-    @"EXUpdatesUsesLegacyManifest": @(YES)
+    EXUpdatesConfigUpdateUrlKey: @"https://exp.host/@test/test",
   }];
 
   _database = [EXUpdatesDatabase new];

--- a/packages/expo-updates/ios/Tests/EXUpdatesSelectionPolicyFilterAwareTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesSelectionPolicyFilterAwareTests.m
@@ -46,8 +46,8 @@
   NSString *runtimeVersion = @"1.0";
   NSString *scopeKey = @"dummyScope";
   EXUpdatesConfig *config = [EXUpdatesConfig configWithDictionary:@{
-    @"EXUpdatesRuntimeVersion": runtimeVersion,
-    @"EXUpdatesScopeKey": scopeKey
+    EXUpdatesConfigRuntimeVersionKey: runtimeVersion,
+    EXUpdatesConfigScopeKeyKey: scopeKey
   }];
   EXUpdatesDatabase *database = [EXUpdatesDatabase new];
   EXUpdatesManifestHeaders *manifestHeaders = [[EXUpdatesManifestHeaders alloc] initWithProtocolVersion:nil

--- a/packages/expo-updates/ios/Tests/EXUpdatesUpdateTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesUpdateTests.m
@@ -45,7 +45,7 @@
   };
 
   _config = [EXUpdatesConfig configWithDictionary:@{
-    @"EXUpdatesURL": @"https://exp.host/@test/test",
+    EXUpdatesConfigUpdateUrlKey: @"https://exp.host/@test/test",
   }];
 
   _database = [EXUpdatesDatabase new];


### PR DESCRIPTION
# Why

Going to be adding some new constants here for code signing. Figured I'd clean it up a bit first.

# How

Export constants, use them everywhere I could find in unversioned code.

# Test Plan

Build and run tests.