### PR TITLE
[docs] Update AppState to stop using deprecated removeEventListener

### DIFF
--- a/docs/pages/versions/unversioned/react-native/appstate.md
+++ b/docs/pages/versions/unversioned/react-native/appstate.md
@@ -31,10 +31,9 @@ const AppStateExample = () => {
   const [appStateVisible, setAppStateVisible] = useState(appState.current);
 
   useEffect(() => {
-    AppState.addEventListener('change', _handleAppStateChange);
-
+    const subscription = AppState.addEventListener("change", _handleAppStateChange);
     return () => {
-      AppState.removeEventListener('change', _handleAppStateChange);
+      subscription.remove();
     };
   }, []);
 


### PR DESCRIPTION
Updated deprecated method `AppState.removeEventListener()` with `remove()` method on the event subscription returned by `addEventListener()`.

# Why

`AppState.removeEventListener()` is deprecated. Docs should show the current method.

# How

Just... edited as needed.

# Test Plan

I edited the text. Looked at it. Saw it was correct. Created a PR. Made coffee. Drank coffee.

# Checklist

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [X] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
