### PR TITLE
[dev-launcher] ui improvements / updates to modals

### DIFF
--- a/packages/expo-dev-launcher/bundle/components/redesign/AppProviders.tsx
+++ b/packages/expo-dev-launcher/bundle/components/redesign/AppProviders.tsx
@@ -3,11 +3,11 @@ import { darkNavigationTheme, lightNavigationTheme } from 'expo-dev-client-compo
 import * as React from 'react';
 import { StatusBar, useColorScheme } from 'react-native';
 
-import { ModalProvider } from '../../components/redesign/Modal';
 import { UserData } from '../../functions/getUserProfileAsync';
 import { BuildInfoProvider } from '../../hooks/useBuildInfo';
 import { DevMenuSettingsProvider } from '../../hooks/useDevMenuSettings';
 import { DevSessionsProvider } from '../../hooks/useDevSessions';
+import { ModalProvider } from '../../hooks/useModalStack';
 import { PendingDeepLinkProvider } from '../../hooks/usePendingDeepLink';
 import { RecentApp, RecentlyOpenedAppsProvider } from '../../hooks/useRecentlyOpenedApps';
 import { UserContextProvider } from '../../hooks/useUser';

--- a/packages/expo-dev-launcher/bundle/components/redesign/DeepLinkModal.tsx
+++ b/packages/expo-dev-launcher/bundle/components/redesign/DeepLinkModal.tsx
@@ -1,9 +1,7 @@
 import {
   View,
-  Heading,
   Text,
   Row,
-  XIcon,
   Spacer,
   Button,
   StatusIndicator,
@@ -11,7 +9,7 @@ import {
   Divider,
 } from 'expo-dev-client-components';
 import * as React from 'react';
-import { ActivityIndicator, Alert, ScrollView } from 'react-native';
+import { ActivityIndicator, ScrollView } from 'react-native';
 
 import { useDevSessions } from '../../hooks/useDevSessions';
 import { useModalStack } from '../../hooks/useModalStack';
@@ -65,8 +63,6 @@ export function DeepLinkModal({ pendingDeepLink }: DeepLinkModalProps) {
           </View>
         </Button.ScaleOnPressContainer>
       </View>
-
-      <Spacer.Vertical size="large" />
     </View>
   );
 }

--- a/packages/expo-dev-launcher/bundle/components/redesign/DevServerExplainerModal.tsx
+++ b/packages/expo-dev-launcher/bundle/components/redesign/DevServerExplainerModal.tsx
@@ -1,0 +1,25 @@
+import { Text, Spacer, View } from 'expo-dev-client-components';
+import * as React from 'react';
+
+export function DevServerExplainerModal() {
+  return (
+    <View>
+      <Spacer.Vertical size="small" />
+      <Text size="medium">Start a local development server with:</Text>
+      <Spacer.Vertical size="small" />
+
+      <View bg="secondary" border="default" rounded="medium" padding="medium">
+        <Text type="mono">expo start</Text>
+      </View>
+
+      <Spacer.Vertical size="large" />
+      <Text>Then, select the local server when it appears here.</Text>
+      <Spacer.Vertical size="small" />
+      <Text>
+        Alternatively, open the Camera app and scan the QR code that appears in your terminal
+      </Text>
+
+      <Spacer.Vertical size="large" />
+    </View>
+  );
+}

--- a/packages/expo-dev-launcher/bundle/components/redesign/DevServerExplainerModal.tsx
+++ b/packages/expo-dev-launcher/bundle/components/redesign/DevServerExplainerModal.tsx
@@ -18,8 +18,6 @@ export function DevServerExplainerModal() {
       <Text>
         Alternatively, open the Camera app and scan the QR code that appears in your terminal
       </Text>
-
-      <Spacer.Vertical size="large" />
     </View>
   );
 }

--- a/packages/expo-dev-launcher/bundle/components/redesign/LoadAppErrorModal.tsx
+++ b/packages/expo-dev-launcher/bundle/components/redesign/LoadAppErrorModal.tsx
@@ -1,0 +1,10 @@
+import { View, Text } from 'expo-dev-client-components';
+import * as React from 'react';
+
+export function LoadAppErrorModal({ message }) {
+  return (
+    <View>
+      <Text>{message}</Text>
+    </View>
+  );
+}

--- a/packages/expo-dev-launcher/bundle/components/redesign/LogoutConfirmationModal.tsx
+++ b/packages/expo-dev-launcher/bundle/components/redesign/LogoutConfirmationModal.tsx
@@ -1,0 +1,46 @@
+import { Button, Heading, Row, Spacer, View } from 'expo-dev-client-components';
+import * as React from 'react';
+
+export function LogoutConfirmationModal({ onLogoutPress, onClosePress }) {
+  return (
+    <View>
+      <Spacer.Vertical size="medium" />
+
+      <Heading size="small" weight="medium">Are you sure you want to log out?</Heading>
+
+      <Spacer.Vertical size="large" />
+
+      <Row>
+        <View flex="1" style={{ flexGrow: 1 }}>
+          <Button.ScaleOnPressContainer
+            bg="tertiary"
+            rounded="medium"
+            onPress={onLogoutPress}
+            accessibilityLabel="Log out">
+            <View padding="small" rounded="medium">
+              <Button.Text color="tertiary" weight="bold" align="center">
+                Log Out
+              </Button.Text>
+            </View>
+          </Button.ScaleOnPressContainer>
+        </View>
+
+        <Spacer.Horizontal size="medium" />
+
+        <View flex="1" style={{ flexGrow: 1 }}>
+          <Button.ScaleOnPressContainer
+            bg="ghost"
+            border="ghost"
+            rounded="medium"
+            onPress={onClosePress}>
+            <View padding="small" rounded="medium">
+              <Button.Text color="ghost" weight="bold" align="center">
+                Nevermind
+              </Button.Text>
+            </View>
+          </Button.ScaleOnPressContainer>
+        </View>
+      </Row>
+    </View>
+  );
+}

--- a/packages/expo-dev-launcher/bundle/components/redesign/LogoutConfirmationModal.tsx
+++ b/packages/expo-dev-launcher/bundle/components/redesign/LogoutConfirmationModal.tsx
@@ -6,7 +6,9 @@ export function LogoutConfirmationModal({ onLogoutPress, onClosePress }) {
     <View>
       <Spacer.Vertical size="medium" />
 
-      <Heading size="small" weight="medium">Are you sure you want to log out?</Heading>
+      <Heading size="small" weight="medium">
+        Are you sure you want to log out?
+      </Heading>
 
       <Spacer.Vertical size="large" />
 

--- a/packages/expo-dev-launcher/bundle/components/redesign/UrlDropdown.tsx
+++ b/packages/expo-dev-launcher/bundle/components/redesign/UrlDropdown.tsx
@@ -86,7 +86,7 @@ export function UrlDropdown({ onSubmit }: UrlDropdownProps) {
               autoCapitalize="none"
               autoCompleteType="off"
               autoCorrect={false}
-              placeholder={`${clientUrlScheme || 'myapp'}://expo-development-client/...`}
+              placeholder="http://10.0.0.25:19000"
               placeholderTextColor={theme.text.secondary}
               ref={ref as any}
               value={inputValue}

--- a/packages/expo-dev-launcher/bundle/components/redesign/__tests__/DeepLinkModal.test.tsx
+++ b/packages/expo-dev-launcher/bundle/components/redesign/__tests__/DeepLinkModal.test.tsx
@@ -13,9 +13,9 @@ const mockGetPendingDeepLink = getPendingDeepLink as jest.Mock;
 const mockAddDeepLinkListener = addDeepLinkListener as jest.Mock;
 const mockLoadApp = loadApp as jest.Mock;
 
-const fakeLocalPackager: DevSession = {
+const fakeLocalDevSession: DevSession = {
   url: 'hello',
-  description: 'fakePackagerDescription',
+  description: 'fakeDevSessionDescription',
   source: 'test',
 };
 
@@ -38,36 +38,35 @@ describe('<DeepLinkPrompt />', () => {
 
     await act(async () => {
       expect(getPendingDeepLink).toHaveBeenCalled();
-      await waitFor(() => getByText(/deep link received/i));
       await waitFor(() => getByText(fakeDeepLink));
     });
   });
 
-  test('shows packagers in modal', async () => {
-    const closeFn = jest.fn();
+  test('shows dev sessions in modal', async () => {
+    const fakeDeepLink = 'testing-testing-123';
+    mockGetPendingDeepLink.mockResolvedValueOnce(fakeDeepLink);
 
-    const { getByText } = render(<DeepLinkModal onClosePress={closeFn} pendingDeepLink="123" />, {
-      initialAppProviderProps: { initialDevSessions: [fakeLocalPackager] },
+    const { getByText } = render(null, {
+      initialAppProviderProps: { initialDevSessions: [fakeLocalDevSession] },
     });
+
+    expect(queryByText(fakeLocalDevSession.description)).toBe(null);
 
     await act(async () => {
       await waitFor(() => getByText(/deep link received/i));
-      getByText(fakeLocalPackager.description);
+      getByText(fakeLocalDevSession.description);
     });
   });
 
   test('packagers in modal call loadApp() when pressed', async () => {
-    const closeFn = jest.fn();
-
-    const { getByText } = render(<DeepLinkModal onClosePress={closeFn} pendingDeepLink="123" />, {
-      initialAppProviderProps: { initialDevSessions: [fakeLocalPackager] },
+    const { getByText } = render(<DeepLinkModal pendingDeepLink="123" />, {
+      initialAppProviderProps: { initialDevSessions: [fakeLocalDevSession] },
     });
 
     await act(async () => {
       expect(loadApp).not.toHaveBeenCalled();
 
-      await waitFor(() => getByText(/deep link received/i));
-      const button = getByText(fakeLocalPackager.description);
+      const button = await waitFor(() => getByText(fakeLocalDevSession.description));
       fireEvent.press(button);
 
       expect(loadApp).toHaveBeenCalled();
@@ -75,21 +74,15 @@ describe('<DeepLinkPrompt />', () => {
   });
 
   test('shows empty message when no packagers are found', async () => {
-    const closeFn = jest.fn();
-
-    const { getByText, queryByText } = render(
-      <DeepLinkModal onClosePress={closeFn} pendingDeepLink="123" />,
-      {
-        initialAppProviderProps: { initialDevSessions: [], initialRecentlyOpenedApps: [] },
-      }
-    );
+    const { getByText, queryByText } = render(<DeepLinkModal pendingDeepLink="123" />, {
+      initialAppProviderProps: { initialDevSessions: [], initialRecentlyOpenedApps: [] },
+    });
 
     expect(queryByText(/unable to find any packagers/i)).toBe(null);
 
     await act(async () => {
       expect(queryByText(/unable to find any packagers/i)).toBe(null);
-      await waitFor(() => getByText(/deep link received/i));
-      getByText(/unable to find any packagers/i);
+      await waitFor(() => getByText(/unable to find any packagers/i));
     });
   });
 

--- a/packages/expo-dev-launcher/bundle/functions/__tests__/getInitialData.test.ts
+++ b/packages/expo-dev-launcher/bundle/functions/__tests__/getInitialData.test.ts
@@ -4,7 +4,6 @@ import { getSettingsAsync } from '../../native-modules/DevMenuInternal';
 import { getInitialData } from '../getInitialData';
 import { restoreUserAsync } from '../restoreUserAsync';
 
-// jest.mock('../getDevSessionsAsync');
 jest.mock('../restoreUserAsync');
 
 const mockRestoreUserAsync = restoreUserAsync as jest.Mock;
@@ -20,6 +19,7 @@ describe('getInitialData()', () => {
     expect(getBuildInfoAsync).not.toHaveBeenCalled();
     expect(getSettingsAsync).not.toHaveBeenCalled();
     expect(restoreUserAsync).not.toHaveBeenCalled();
+    expect(queryDevSessionsAsync).not.toHaveBeenCalled();
 
     await getInitialData();
 

--- a/packages/expo-dev-launcher/bundle/functions/createAsyncStack.ts
+++ b/packages/expo-dev-launcher/bundle/functions/createAsyncStack.ts
@@ -72,7 +72,9 @@ export function createAsyncStack<T>(): IStack<T> {
     const item = lookup[key];
 
     if (item) {
-      item.status = 'settled';
+      if (item.status === 'pushing') {
+        item.status = 'settled';
+      }
 
       emit('pushend', key);
 

--- a/packages/expo-dev-launcher/bundle/hooks/useModalStack.tsx
+++ b/packages/expo-dev-launcher/bundle/hooks/useModalStack.tsx
@@ -1,14 +1,12 @@
-import { Button } from 'expo-dev-client-components';
+import { Button, Heading, Row, Spacer, View, XIcon } from 'expo-dev-client-components';
 import * as React from 'react';
 import { Animated, StyleSheet, useWindowDimensions } from 'react-native';
 
-import { createAsyncStack, StackItem, useStackItems } from '../../functions/createAsyncStack';
+import { createAsyncStack, StackItem, useStackItems } from '../functions/createAsyncStack';
 
 export type ModalProps = {
   element: React.ReactElement<any>;
-  modalProps?: {
-    backgroundColor?: string;
-  };
+  title: string;
 };
 
 const ModalContext = React.createContext(createAsyncStack<ModalProps>());
@@ -55,15 +53,19 @@ function ModalStackContainer() {
     <Animated.View
       style={[StyleSheet.absoluteFillObject, { backgroundColor }]}
       pointerEvents={hasModal ? 'auto' : 'none'}>
-      {modals.map((item) => (
-        <ModalScreen
-          key={item.key}
-          {...item}
-          onClose={() => modalStack.pop()}
-          onPopEnd={() => modalStack.onPopEnd(item.key)}
-          onPushEnd={() => modalStack.onPushEnd(item.key)}
-        />
-      ))}
+      <Button.Container
+        style={{ ...StyleSheet.absoluteFillObject, justifyContent: 'center', alignItems: 'center' }}
+        onPress={() => modalStack.pop()}>
+        {modals.map((item) => (
+          <ModalScreen
+            key={item.key}
+            {...item}
+            onClose={() => modalStack.pop()}
+            onPopEnd={() => modalStack.onPopEnd(item.key)}
+            onPushEnd={() => modalStack.onPushEnd(item.key)}
+          />
+        ))}
+      </Button.Container>
     </Animated.View>
   );
 }
@@ -74,14 +76,7 @@ type ModalScreenProps = StackItem<ModalProps> & {
   onClose: () => void;
 };
 
-function ModalScreen({
-  status,
-  element,
-  onPopEnd,
-  onPushEnd,
-  onClose,
-  modalProps,
-}: ModalScreenProps) {
+function ModalScreen({ status, element, onPopEnd, onPushEnd, onClose, title }: ModalScreenProps) {
   const { height } = useWindowDimensions();
 
   const animatedValue = React.useRef(new Animated.Value(status === 'settled' ? 1 : 0));
@@ -118,10 +113,47 @@ function ModalScreen({
   return (
     <Animated.View
       pointerEvents={status === 'popping' ? 'none' : 'auto'}
-      style={[StyleSheet.absoluteFillObject, { transform: [{ translateY }] }]}>
-      <Button.Container style={StyleSheet.absoluteFill} onPress={() => onClose()}>
-        {element}
+      style={[
+        StyleSheet.absoluteFillObject,
+        { justifyContent: 'center', transform: [{ translateY }] },
+      ]}>
+      <Button.Container>
+        <View mx="medium" bg="default" rounded="large" overflow="hidden" shadow="medium">
+          <ModalHeader title={title} />
+          <View px="small">{element}</View>
+
+          <Spacer.Vertical size="medium" />
+        </View>
       </Button.Container>
     </Animated.View>
+  );
+}
+
+function ModalHeader({ title = '' }) {
+  const modalStack = useModalStack();
+
+  const onClosePress = () => {
+    modalStack.pop();
+  };
+
+  return (
+    <View padding="small">
+      <Row align="center" bg="default">
+        <View>
+          <Heading size="small">{title}</Heading>
+        </View>
+        <Spacer.Horizontal size="flex" />
+
+        <Button.ScaleOnPressContainer
+          bg="default"
+          rounded="full"
+          onPress={onClosePress}
+          minScale={0.85}>
+          <View padding="tiny" rounded="full">
+            <XIcon />
+          </View>
+        </Button.ScaleOnPressContainer>
+      </Row>
+    </View>
   );
 }

--- a/packages/expo-dev-launcher/bundle/hooks/useModalStack.tsx
+++ b/packages/expo-dev-launcher/bundle/hooks/useModalStack.tsx
@@ -120,6 +120,7 @@ function ModalScreen({ status, element, onPopEnd, onPushEnd, onClose, title }: M
       <Button.Container>
         <View mx="medium" bg="default" rounded="large" overflow="hidden" shadow="medium">
           <ModalHeader title={title} />
+
           <View px="small">{element}</View>
 
           <Spacer.Vertical size="medium" />

--- a/packages/expo-dev-launcher/bundle/hooks/usePendingDeepLink.tsx
+++ b/packages/expo-dev-launcher/bundle/hooks/usePendingDeepLink.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { DeepLinkModal } from '../components/redesign/DeepLinkModal';
-import { useModalStack } from '../components/redesign/Modal';
+import { useModalStack } from '../hooks/useModalStack';
 import { addDeepLinkListener, getPendingDeepLink } from '../native-modules/DevLauncherInternal';
 
 type PendingDeepLinkContext = {
@@ -29,7 +29,8 @@ export function PendingDeepLinkProvider({
       if (url) {
         setPendingDeepLink(url);
         modalStack.push({
-          element: <DeepLinkModal pendingDeepLink={url} onClosePress={() => modalStack.pop()} />,
+          title: 'Deep link received:',
+          element: <DeepLinkModal pendingDeepLink={url} />,
         });
       }
     });
@@ -40,7 +41,8 @@ export function PendingDeepLinkProvider({
       if (url) {
         setPendingDeepLink(url);
         modalStack.push({
-          element: <DeepLinkModal pendingDeepLink={url} onClosePress={() => modalStack.pop()} />,
+          title: 'Deep link received:',
+          element: <DeepLinkModal pendingDeepLink={url} />,
         });
       }
     });

--- a/packages/expo-dev-launcher/bundle/screens/HomeScreen.tsx
+++ b/packages/expo-dev-launcher/bundle/screens/HomeScreen.tsx
@@ -215,10 +215,12 @@ function DevSessionList({ devSessions = [], onDevSessionPress }: DevSessionListP
               <Row align="center" padding="medium">
                 <StatusIndicator size="small" status="success" />
                 <Spacer.Horizontal size="small" />
-                <Button.Text color="default" numberOfLines={1} style={{ flexShrink: 1 }}>
-                  {devSession.description}
-                </Button.Text>
-                <Spacer.Horizontal size="flex" />
+                <View flex="1">
+                  <Button.Text color="default" numberOfLines={1}>
+                    {devSession.description}
+                  </Button.Text>
+                </View>
+                <Spacer.Horizontal size="small" />
                 <ChevronRightIcon />
               </Row>
             </Button.ScaleOnPressContainer>

--- a/packages/expo-dev-launcher/bundle/screens/HomeScreen.tsx
+++ b/packages/expo-dev-launcher/bundle/screens/HomeScreen.tsx
@@ -11,18 +11,19 @@ import {
   StatusIndicator,
   TerminalIcon,
   ChevronRightIcon,
-  XIcon,
   InfoIcon,
 } from 'expo-dev-client-components';
 import * as React from 'react';
-import { Alert, ScrollView } from 'react-native';
+import { ScrollView } from 'react-native';
 
 import { AppHeader } from '../components/redesign/AppHeader';
-import { useModalStack } from '../components/redesign/Modal';
+import { DevServerExplainerModal } from '../components/redesign/DevServerExplainerModal';
+import { LoadAppErrorModal } from '../components/redesign/LoadAppErrorModal';
 import { PulseIndicator } from '../components/redesign/PulseIndicator';
 import { UrlDropdown } from '../components/redesign/UrlDropdown';
 import { useBuildInfo } from '../hooks/useBuildInfo';
 import { useDevSessions } from '../hooks/useDevSessions';
+import { useModalStack } from '../hooks/useModalStack';
 import { useRecentlyOpenedApps } from '../hooks/useRecentlyOpenedApps';
 import { loadApp } from '../native-modules/DevLauncherInternal';
 import { DevSession } from '../types';
@@ -56,7 +57,10 @@ export function HomeScreen({
 
   const onLoadUrl = (url: string) => {
     loadApp(url).catch((error) => {
-      Alert.alert('Oops!', error.message);
+      modalStack.push({
+        title: 'Error loading app',
+        element: <LoadAppErrorModal message={error.message} />,
+      });
     });
   };
 
@@ -81,7 +85,7 @@ export function HomeScreen({
   };
 
   const onDevServerQuestionPress = () => {
-    modalStack.push({ element: <DevServerExplainerModal /> });
+    modalStack.push({ title: 'Development servers', element: <DevServerExplainerModal /> });
   };
 
   return (
@@ -266,48 +270,6 @@ function RecentlyOpenedApps({ onAppPress }) {
             </View>
           );
         })}
-      </View>
-    </View>
-  );
-}
-
-function DevServerExplainerModal() {
-  const modalStack = useModalStack();
-
-  const onClosePress = () => {
-    modalStack.pop();
-  };
-
-  return (
-    <View style={{ flex: 1, justifyContent: 'center' }} px="medium">
-      <View padding="medium" bg="default" rounded="large">
-        <Row align="center">
-          <Heading size="small">Development servers</Heading>
-          <Spacer.Horizontal size="flex" />
-          <Button.ScaleOnPressContainer
-            bg="default"
-            rounded="full"
-            onPress={onClosePress}
-            accessibilityHint="Close modal">
-            <View padding="tiny">
-              <XIcon />
-            </View>
-          </Button.ScaleOnPressContainer>
-        </Row>
-        <Spacer.Vertical size="small" />
-        <Text size="medium">Start a local development server with:</Text>
-        <Spacer.Vertical size="small" />
-
-        <View bg="secondary" border="default" rounded="medium" padding="medium">
-          <Text type="mono">expo start</Text>
-        </View>
-
-        <Spacer.Vertical size="large" />
-        <Text>Then, select the local server when it appears here.</Text>
-        <Spacer.Vertical size="small" />
-        <Text>
-          Alternatively, open the Camera app and scan the QR code that appears in your terminal.
-        </Text>
       </View>
     </View>
   );

--- a/packages/expo-dev-launcher/bundle/screens/UserProfileScreen.tsx
+++ b/packages/expo-dev-launcher/bundle/screens/UserProfileScreen.tsx
@@ -11,14 +11,17 @@ import {
   XIcon,
 } from 'expo-dev-client-components';
 import * as React from 'react';
-import { ActivityIndicator, Alert } from 'react-native';
+import { ActivityIndicator } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
+import { LogoutConfirmationModal } from '../components/redesign/LogoutConfirmationModal';
 import { UserAccount, UserData } from '../functions/getUserProfileAsync';
+import { useModalStack } from '../hooks/useModalStack';
 import { useUser, useUserActions } from '../hooks/useUser';
 
 export function UserProfileScreen({ navigation }) {
   const { userData, selectedAccount } = useUser();
+  const modalStack = useModalStack();
   const actions = useUserActions();
   const [isLoading, setIsLoading] = React.useState(false);
 
@@ -39,18 +42,18 @@ export function UserProfileScreen({ navigation }) {
   };
 
   const onLogoutPress = () => {
-    Alert.alert('Log out', 'Are you sure you want to log out?', [
-      {
-        text: 'Log out',
-        onPress: () => actions.logout(),
-        style: 'cancel',
-      },
-      {
-        text: 'Nevermind',
-        onPress: () => {},
-        style: 'default',
-      },
-    ]);
+    modalStack.push({
+      title: 'Confirm logout?',
+      element: (
+        <LogoutConfirmationModal
+          onClosePress={() => modalStack.pop()}
+          onLogoutPress={() => {
+            actions.logout();
+            modalStack.pop();
+          }}
+        />
+      ),
+    });
   };
 
   const onClosePress = () => {

--- a/packages/expo-dev-launcher/bundle/screens/__tests__/HomeScreen.test.tsx
+++ b/packages/expo-dev-launcher/bundle/screens/__tests__/HomeScreen.test.tsx
@@ -31,7 +31,7 @@ const devSessionInstructionsRegex = /start a local development server with/i;
 const fetchingDevSessionsRegex = /searching for development servers/i;
 const refetchDevSessionsRegex = /refetch development servers/i;
 const textInputToggleRegex = /enter url manually/i;
-const textInputPlaceholder = `${clientUrlScheme}://expo-development-client/...`;
+const textInputPlaceholder = 'http://10.0.0.25:19000';
 
 const mockLoadApp = loadApp as jest.Mock;
 
@@ -115,7 +115,7 @@ describe('<HomeScreen />', () => {
     });
   });
 
-  test('select DevSession by entered url', async () => {
+  test('select dev session by entered url', async () => {
     const { getByText, getByPlaceholderText } = renderHomeScreen();
 
     expect(() => getByPlaceholderText(textInputPlaceholder)).toThrow();

--- a/packages/expo-dev-launcher/bundle/screens/__tests__/UserProfileScreen.test.tsx
+++ b/packages/expo-dev-launcher/bundle/screens/__tests__/UserProfileScreen.test.tsx
@@ -154,25 +154,27 @@ describe('<UserProfileScreen />', () => {
     });
   });
 
-  // this will be feasible once we show a real modal prompt instead of needing to mock Alert.alert
-  // test('logout', async () => {
-  //   const { getByA11yLabel, getByText } = renderProfileScreen();
+  test('logout', async () => {
+    const { getByA11yLabel, getByText } = renderProfileScreen();
 
-  //   await act(async () => {
-  //     const loginButton = getByA11yLabel(/log in/i);
-  //     fireEvent.press(loginButton);
+    await act(async () => {
+      const loginButton = getByA11yLabel(/log in/i);
+      fireEvent.press(loginButton);
 
-  //     const logoutButton = await waitFor(() => getByText(/log out/i));
+      const logoutButton = await waitFor(() => getByText(/log out/i));
 
-  //     mockSetSessionAsync.mockClear();
-  //     fireEvent.press(logoutButton);
+      mockSetSessionAsync.mockClear();
+      fireEvent.press(logoutButton);
 
+      await waitFor(() => getByText(/are you sure you want to log out/i));
+      const button = getByA11yLabel(/log out/i);
 
-  //     expect(setSessionAsync).toHaveBeenCalledTimes(1);
-  //     expect(setSessionAsync).toHaveBeenLastCalledWith(null);
-  //   });
-  // });
-  test.todo('logout')
+      fireEvent.press(button);
+      expect(setSessionAsync).toHaveBeenCalledTimes(1);
+      expect(setSessionAsync).toHaveBeenLastCalledWith(null);
+    });
+  });
+
   test.todo('failed login / signup response');
 });
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

adding modals instead of the system `Alert` prompt for more consistent UI: 

<img width="353" alt="Screen Shot 2022-01-03 at 10 44 02 AM" src="https://user-images.githubusercontent.com/40680668/147970489-ef6a0da0-52f6-4f9c-8519-5a11b20e5d7f.png">

<img width="372" alt="Screen Shot 2022-01-03 at 10 46 33 AM" src="https://user-images.githubusercontent.com/40680668/147970501-021d7ef7-d70a-46e7-ad77-0a7696b0bb04.png">

one nice side benefit is the tests also read a bit clearer than they would with the alert module being mocked

while I was doing this, I also made it a bit easier to use the modal api, including common modal behaviour by default for all modals (e.g a title prop and close button defaults) 

other minor UI touchups I don't think are worth mentioning


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

tests should pass

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
