### PR TITLE
Use aab for Expo Go for Android

### DIFF
--- a/.github/workflows/client-android.yml
+++ b/.github/workflows/client-android.yml
@@ -119,6 +119,7 @@ jobs:
           ANDROID_KEY_ALIAS: ExponentKey
           ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
           ANDROID_NDK_HOME: /usr/local/lib/android/sdk/ndk/19.2.5345600/
+          IS_APP_BUNDLE:  ${{ github.event.inputs.releaseGooglePlay == 'release-google-play' }}
           IS_RELEASE_BUILD: ${{ github.event.inputs.releaseAPK == 'release-apk' || github.event.inputs.releaseGooglePlay == 'release-google-play' }}
           IS_VERSIONED_FLAVOR: ${{ github.event_name == 'schedule' || steps.flavor.outputs.versioned == 'true' }}
         run: |
@@ -137,7 +138,7 @@ jobs:
           else
             echo "Internal build detected, APK will be signed"
             echo $ANDROID_KEYSTORE_B64 | base64 -d > android/app/release-key.jks
-            bin/fastlane android build build_type:$BUILD_TYPE flavor:$FLAVOR
+            bin/fastlane android build build_type:$BUILD_TYPE flavor:$FLAVOR aab:$IS_APP_BUNDLE
           fi
       - name: 💾 Upload APK artifact
         uses: actions/upload-artifact@v2

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -289,11 +289,11 @@ platform :android do
     adb(command: "shell am start -n host.exp.exponent/host.exp.exponent.LauncherActivity")
   end
 
-  lane :build do |build_type: "Debug", flavor: "versioned", sign: true|
+  lane :build do |build_type: "Debug", flavor: "versioned", sign: true, aab: false|
     ENV['ANDROID_UNSIGNED'] = '1' unless sign
     gradle(
       project_dir: "android",
-      task: "app:assemble",
+      task: aab ? "app:bundle": "app:assemble",
       flavor: flavor,
       build_type: build_type,
     )
@@ -308,7 +308,7 @@ platform :android do
     supply(
       package_name: "host.exp.exponent",
       metadata_path: "./fastlane/android/metadata",
-      apk: "./android/app/build/outputs/apk/versioned/release/app-versioned-release.apk",
+      apk: "./android/app/build/outputs/apk/versioned/release/app-versioned-release.aab",
       track: "production",
       skip_upload_images: true,
       skip_upload_screenshots: true

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -308,7 +308,7 @@ platform :android do
     supply(
       package_name: "host.exp.exponent",
       metadata_path: "./fastlane/android/metadata",
-      apk: "./android/app/build/outputs/apk/versioned/release/app-versioned-release.aab",
+      apk: "./android/app/build/outputs/bundle/versionedRelease/app-versioned-release.aab",
       track: "production",
       skip_upload_images: true,
       skip_upload_screenshots: true


### PR DESCRIPTION
# Why

The APK size of Expo Go increased beyond 100mb (APK limit on play store), so we needed to switch to aab to upload it.

# How

Ended up having to build this locally because Gradle runs out of memory on GitHub Actions.
