### PR TITLE
[docs] Various fixes in EAS docs

### DIFF
--- a/docs/pages/build-reference/android-builds.md
+++ b/docs/pages/build-reference/android-builds.md
@@ -12,7 +12,7 @@ Let's take a closer look at the steps for building Android projects with EAS Bui
 
 The first phase happens on your computer. EAS CLI is in charge of completing the following steps:
 
-1. If `cli.requireCommit` is set to `true` in `eas.json`, check if the git index is clean - this means that there aren't any uncommitted changes. If it's not clean, EAS CLI will provide an option to commit local changes for you or abort the build process.
+1. If `cli.requireCommit` is set to `true` in **eas.json**, check if the git index is clean - this means that there aren't any uncommitted changes. If it's not clean, EAS CLI will provide an option to commit local changes for you or abort the build process.
 1. Prepare the credentials needed for the build unless `builds.android.PROFILE_NAME.withoutCredentials` is set to `true`.
 
    - Depending on the value of `builds.android.PROFILE_NAME.credentialsSource`, the credentials are obtained from either the local **credentials.json** file or from the EAS servers. If the `remote` mode is selected but no credentials exist yet, you're prompted to generate a new keystore.

--- a/docs/pages/build-reference/build-configuration.md
+++ b/docs/pages/build-reference/build-configuration.md
@@ -63,6 +63,6 @@ In the example above, we defined exactly the same Android application id and iOS
 #### 5. Next steps
 
 That's all there is to configuring a project to be compatible with EAS Build.
-There is one final step if you set `cli.requireCommit` to `true` in your `eas.json` — you'll be prompted to commit all the changes we made for you. You can choose to review them before committing, and you can either specify the git commit message or use a default message.
+There is one final step if you set `cli.requireCommit` to `true` in your **eas.json** — you'll be prompted to commit all the changes we made for you. You can choose to review them before committing, and you can either specify the git commit message or use a default message.
 
 <ImageSpotlight alt="Application identifier prompts in eas build:configure" src="/static/images/eas-build/configure/03-next-steps.png" containerStyle={{ paddingBottom: 0 }} />

--- a/docs/pages/build-reference/how-tos.md
+++ b/docs/pages/build-reference/how-tos.md
@@ -82,7 +82,7 @@ e.g.
 
 If you are using the default VCS workflow, the content of your working directory will be uploaded to EAS Build as it is, including the content of Git submodules. If you are building on CI you will need to initialize them, otherwise, empty directories will be uploaded.
 
-If you have `cli.requireCommit` set to `true` in `eas.json` you will need to initialize your submodules on EAS Build worker.
+If you have `cli.requireCommit` set to `true` in **eas.json** you will need to initialize your submodules on EAS Build worker.
 First, create a [secret](/build-reference/variables/#using-secrets-in-environment-variables) with a base64 encoded private SSH key that has permission to access submodule repositories. Next, add an `eas-build-pre-install` npm hook to check out those submodules, for example:
 
 ```bash

--- a/docs/pages/build-reference/ios-builds.md
+++ b/docs/pages/build-reference/ios-builds.md
@@ -12,7 +12,7 @@ Let's take a closer look at the steps for building iOS projects with EAS Build. 
 
 The first phase happens on your computer. EAS CLI is in charge of completing the following steps:
 
-1. If `cli.requireCommit` is set to `true` in `eas.json`, check if the git index is clean - this means that there aren't any uncommitted changes. If it's not clean, EAS CLI will provide an option to commit local changes for you or abort the build process.
+1. If `cli.requireCommit` is set to `true` in **eas.json**, check if the git index is clean - this means that there aren't any uncommitted changes. If it's not clean, EAS CLI will provide an option to commit local changes for you or abort the build process.
 1. Prepare the credentials needed for the build.
 
    - Depending on the value of `builds.ios.PROFILE_NAME.credentialsSource`, the credentials are obtained from either the local **credentials.json** file or from the EAS servers. If the `remote` mode is selected but no credentials exist yet, you're offered to generate them.

--- a/docs/pages/build/automating-submissions.md
+++ b/docs/pages/build/automating-submissions.md
@@ -14,12 +14,12 @@ By default, `--auto-submit` will try to use a submission profile with the same n
 
 ### Build profile environment variables and submissions
 
-When running `eas build --profile <profile-name> --auto-submit`, the project's `app.config.js` will be evaluated using any environment variables associated with the build profile `<profile-name>`. For example, suppose we ran `eas build -p ios --profile production --auto-submit` with the following configuration:
+When running `eas build --profile <profile-name> --auto-submit`, the project's **app.config.js** will be evaluated using any environment variables associated with the build profile `<profile-name>`. For example, suppose we ran `eas build -p ios --profile production --auto-submit` with the following configuration:
 
 ```json
 // eas.json
 {
-  "build" {
+  "build": {
     "production": {
       "env": {
         "APP_ENV": "production"
@@ -47,4 +47,4 @@ export default () => {
 }
 ```
 
-The `APP_ENV` variable from the `production` profile will be used when evaluating `app.config.js` for the submission, and therefore the name will be 'My App' and the bundle identifier will be 'com.my.app'.
+The `APP_ENV` variable from the `production` profile will be used when evaluating **app.config.js** for the submission, and therefore the name will be 'My App' and the bundle identifier will be 'com.my.app'.

--- a/docs/pages/build/eas-json.md
+++ b/docs/pages/build/eas-json.md
@@ -52,13 +52,15 @@ You may alternatively prefer for your development build to [run in an iOS simula
 
 ```json
 {
-  // ...
-  "development": {
-    "developmentClient": true,
-    "distribution": "internal",
-    "ios": {
-      "simulator": true
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal",
+      "ios": {
+        "simulator": true
+      }
     }
+    // ...
   }
   // ...
 }
@@ -74,9 +76,11 @@ A minimal `preview` profile looks like this:
 
 ```json
 {
-  // ...
-  "preview": {
-    "distribution": "internal"
+  "build": {
+    "preview": {
+      "distribution": "internal"
+    }
+    // ...
   }
   // ...
 }
@@ -94,8 +98,10 @@ A minimal `production` profile looks like this:
 
 ```json
 {
-  // ...
-  "production": {}
+  "build": {
+    "production": {}
+    // ...
+  }
   // ...
 }
 ```
@@ -114,9 +120,11 @@ Versions for the most common build tools can be set on build profiles with field
 
 ```json
 {
-  // ...
-  "production": {
-    "node": "16.13.0"
+  "build": {
+    "production": {
+      "node": "16.13.0"
+    }
+    // ...
   }
   // ...
 }
@@ -126,18 +134,20 @@ It's common to want to share build tool configuration between profiles, and we c
 
 ```json
 {
-  // ...
-  "production": {
-    "node": "16.13.0"
-  },
-  "preview": {
-    "extends": "production",
-    "distribution": "internal"
-  },
-  "development": {
-    "extends": "production",
-    "developmentClient": "true",
-    "distribution": "internal"
+  "build": {
+    "production": {
+      "node": "16.13.0"
+    },
+    "preview": {
+      "extends": "production",
+      "distribution": "internal"
+    },
+    "development": {
+      "extends": "production",
+      "developmentClient": "true",
+      "distribution": "internal"
+    }
+    // ...
   }
   // ...
 }
@@ -151,24 +161,26 @@ If you are using the Expo managed workflow, EAS Build will pick the appropriate 
 
 ## Environment variables
 
-You can configure environment variables on your build profiles using the `"env"` field. These environment variable those will be used to evaluate `app.config.js` locally when you run `eas build`, and they will also be set on the EAS Build worker.
+You can configure environment variables on your build profiles using the `"env"` field. These environment variable those will be used to evaluate **app.config.js** locally when you run `eas build`, and they will also be set on the EAS Build worker.
 
 ```json
 {
-  // ...
-  "production": {
-    "node": "16.13.0",
-    "env": {
-      "API_URL": "https://company.com/api"
+  "build": {
+    "production": {
+      "node": "16.13.0",
+      "env": {
+        "API_URL": "https://company.com/api"
+      }
+    },
+    "preview": {
+      "extends": "production",
+      "distribution": "internal",
+      "env": {
+        "API_URL": "https://staging.company.com/api"
+      }
     }
-  },
-  "preview": {
-    "extends": "production",
-    "distribution": "internal",
-    "env": {
-      "API_URL": "https://staging.company.com/api"
-    }
-  },
+    // ...
+  }
   // ...
 }
 ```

--- a/docs/pages/development/build.md
+++ b/docs/pages/development/build.md
@@ -9,13 +9,13 @@ import TerminalBlock from '~/components/plugins/TerminalBlock';
 
 ### Setting up EAS
 
-You can set up your project to use EAS by running 
-<TerminalBlock cmd={[`eas build:configure`]} /> 
+You can set up your project to use EAS by running
+<TerminalBlock cmd={[`eas build:configure`]} />
 
 If you have not installed EAS CLI yet, you can do so by running `npm install -g eas-cli`.
 
-This command will create an [`eas.json`](/build/eas-json.md) file.
-If you have an existing `eas.json` file that does not have a "development" profile already, edit the file to add one:
+This command will create an [**eas.json**](/build/eas-json.md) file.
+If you have an existing **eas.json** file that does not have a "development" profile already, edit the file to add one:
 
 ```json
 {
@@ -34,7 +34,6 @@ This profile has two options set:
 - Setting `distribution` to "internal" will make a build ready for [internal distribution](/build/internal-distribution).
 
 ### Running a build
-
 
 <Tabs tabs={["For Android", "For iOS"]}>
 
@@ -63,7 +62,6 @@ Note: If you register any new iOS devices, you'll need create a new development 
 
 </Tab>
 </Tabs>
-
 
 ## Locally with Xcode and Android Studio
 

--- a/docs/pages/distribution/release-channels.md
+++ b/docs/pages/distribution/release-channels.md
@@ -21,7 +21,7 @@ with the Expo CLI. Your users can see this release in the Expo Go app with a par
 
 ## Build with Channels
 
-[Set your release channel](/build/updates.md) in the build profile in `eas.json`:
+[Set your release channel](/build/updates.md) in the build profile in **eas.json**:
 
 ```json
 {
@@ -60,7 +60,7 @@ Consider a situation where you have a Staging stack for testing on Expo Go, and 
 
 On the staging stack, run `expo publish --release-channel staging`. Your test users can see the staging version of your app by specifying the channel in the query parameter of the URL (ie)`https://exp.host/@username/yourApp?release-channel=staging`, then opening the URL in their web browser, and finally scanning the QR code with the Expo Go app. Alternatively, they can open that URL directly on their mobile device.
 
-On the production stack, release v1 of your app by running `expo publish --release-channel prod-v1`. You can build this version of your app into a standalone ipa by running `eas build --platform ios --profile prod` with `releaseChannel` set to `prod-v1` in the `prod` build profile in `eas.json`:
+On the production stack, release v1 of your app by running `expo publish --release-channel prod-v1`. You can build this version of your app into a standalone ipa by running `eas build --platform ios --profile prod` with `releaseChannel` set to `prod-v1` in the `prod` build profile in **eas.json**:
 
 ```json
 {


### PR DESCRIPTION
# Why

I noticed two issues in EAS docs:
- some code blocks from `eas.json` were missing the parent `"build"` field
- file names were not following our style guide — should use bold styling instead of code

# How

Fixed code examples and made file names (`eas.json` and `app.config.js`) bold.

# Test Plan

Ran docs locally and confirmed the changes look well.
