### PR TITLE
[android] Fix android client build break

### DIFF
--- a/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/expo/modules/updates/UpdatesModule.java
+++ b/android/versioned-abis/expoview-abi41_0_0/src/main/java/abi41_0_0/expo/modules/updates/UpdatesModule.java
@@ -91,7 +91,7 @@ public class UpdatesModule extends ExportedModule {
       // and warn the developer if not. This does not take into account any extra configuration
       // provided at runtime in MainApplication.java, because we don't have access to that in a
       // debug build.
-      UpdatesConfiguration configuration = new UpdatesConfiguration().loadValuesFromMetadata(getContext());
+      UpdatesConfiguration configuration = new UpdatesConfiguration(getContext(), null);
       constants.put("isMissingRuntimeVersion", configuration.isMissingRuntimeVersion());
     }
 

--- a/android/versioned-abis/expoview-abi42_0_0/src/main/java/abi42_0_0/expo/modules/updates/UpdatesDevLauncherController.java
+++ b/android/versioned-abis/expoview-abi42_0_0/src/main/java/abi42_0_0/expo/modules/updates/UpdatesDevLauncherController.java
@@ -58,9 +58,7 @@ public class UpdatesDevLauncherController implements UpdatesInterface {
   @Override
   public void fetchUpdateWithConfiguration(HashMap<String, Object> configuration, Context context, UpdateCallback callback) {
     UpdatesController controller = UpdatesController.getInstance();
-    UpdatesConfiguration updatesConfiguration = new UpdatesConfiguration()
-            .loadValuesFromMetadata(context)
-            .loadValuesFromMap(configuration);
+    UpdatesConfiguration updatesConfiguration = new UpdatesConfiguration(context, configuration);
     if (updatesConfiguration.getUpdateUrl() == null || updatesConfiguration.getScopeKey() == null) {
       callback.onFailure(new Exception("Failed to load update: UpdatesConfiguration object must include a valid update URL"));
       return;

--- a/android/versioned-abis/expoview-abi42_0_0/src/main/java/abi42_0_0/expo/modules/updates/UpdatesModule.java
+++ b/android/versioned-abis/expoview-abi42_0_0/src/main/java/abi42_0_0/expo/modules/updates/UpdatesModule.java
@@ -91,7 +91,7 @@ public class UpdatesModule extends ExportedModule {
       // and warn the developer if not. This does not take into account any extra configuration
       // provided at runtime in MainApplication.java, because we don't have access to that in a
       // debug build.
-      UpdatesConfiguration configuration = new UpdatesConfiguration().loadValuesFromMetadata(getContext());
+      UpdatesConfiguration configuration = new UpdatesConfiguration(getContext(), null);
       constants.put("isMissingRuntimeVersion", configuration.isMissingRuntimeVersion());
     }
 

--- a/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/updates/UpdatesModule.java
+++ b/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/updates/UpdatesModule.java
@@ -91,7 +91,7 @@ public class UpdatesModule extends ExportedModule {
       // and warn the developer if not. This does not take into account any extra configuration
       // provided at runtime in MainApplication.java, because we don't have access to that in a
       // debug build.
-      UpdatesConfiguration configuration = new UpdatesConfiguration().loadValuesFromMetadata(getContext());
+      UpdatesConfiguration configuration = new UpdatesConfiguration(getContext(), null);
       constants.put("isMissingRuntimeVersion", configuration.isMissingRuntimeVersion());
     }
 

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/updates/UpdatesModule.kt
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/updates/UpdatesModule.kt
@@ -76,7 +76,7 @@ class UpdatesModule(
       // and warn the developer if not. This does not take into account any extra configuration
       // provided at runtime in MainApplication.java, because we don't have access to that in a
       // debug build.
-      val configuration = UpdatesConfiguration().loadValuesFromMetadata(context)
+      val configuration = UpdatesConfiguration(context, null)
       constants["isMissingRuntimeVersion"] = configuration.isMissingRuntimeVersion
     }
     return constants


### PR DESCRIPTION
# Why

https://github.com/expo/expo/runs/4556797258?check_suite_focus=true CI build error

# How

backport `UpdatesConfiguration` interface change from #15558 into versioned code

# Test Plan

Android Client CI green

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
