### PR TITLE
[updates] Fix screen orientation regression

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix the view does not update from screen rotation on iOS devices. ([#15608](https://github.com/expo/expo/pull/15608) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 0.11.2 — 2021-12-15

--- a/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesReactDelegateHandler.swift
+++ b/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesReactDelegateHandler.swift
@@ -80,8 +80,9 @@ public class ExpoUpdatesReactDelegateHandler: ExpoReactDelegateHandler, EXUpdate
     let rootView = RCTRootView(bridge: bridge!, moduleName: self.rootViewModuleName!, initialProperties: self.rootViewInitialProperties)
     rootView.backgroundColor = self.deferredRootView?.backgroundColor ?? UIColor.white
     let window = UIApplication.shared.delegate!.window!!
-    window.rootViewController = reactDelegate.createRootViewController()
-    window.rootViewController!.view = rootView
+    let rootViewController = reactDelegate.createRootViewController()
+    rootViewController.view = rootView
+    window.rootViewController = rootViewController
     window.makeKeyAndVisible()
 
     self.cleanup()


### PR DESCRIPTION
# Why

regression for #15100

# How

the call sequence to recreate the rootViewController did matter. i don't know the 

# Test Plan

expo init sdk44
expo install expo-updates expo-screen-orientation
modify the `expo.orientation` to `"default"` in `app.json`
add these code to App.js
```js
import * as ScreenOrientation from 'expo-screen-orientation';

async function changeScreenOrientation() {
  await ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.LANDSCAPE);
}

setTimeout(changeScreenOrientation, 3000);
```
check the view after rotation does not break

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
