### PR TITLE
[av] iOS: fix typo warning in Xcode

### DIFF
--- a/packages/expo-av/ios/EXAV/EXAVPlayerData.m
+++ b/packages/expo-av/ios/EXAV/EXAVPlayerData.m
@@ -882,7 +882,7 @@ NSString *const EXAVPlayerDataObserverMetadataKeyPath = @"timedMetadata";
       MTAudioProcessingTapCallbacks callbacks;
 
       callbacks.version = kMTAudioProcessingTapCallbacksVersion_0;
-      callbacks.clientInfo = (__bridge void *)self,
+      callbacks.clientInfo = (__bridge void *)self;
       callbacks.init = EXTapInit;
       callbacks.finalize = EXTapFinalize;
       callbacks.prepare = EXTapPrepare;


### PR DESCRIPTION
# Why

This fixes the warning for EXAV when building project in Xcode.

<img width="343" alt="Screenshot 2021-12-17 at 15 48 20" src="https://user-images.githubusercontent.com/719641/146562225-b73e244b-f3bd-416e-9bdc-3478d2c25be0.png">

# How

Replace `,` with `;` at the end of the line.

# Test Plan

Project using EXAV build and works as intended.

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
