### PR TITLE
Update the docs to include the latest method of creating GoogleAuthPr…

### DIFF
--- a/docs/pages/guides/authentication.md
+++ b/docs/pages/guides/authentication.md
@@ -1237,7 +1237,7 @@ export default function App() {
       /* @info Create a Google credential with the <code>id_token</code> */
       const auth = getAuth();
       const provider = new GoogleAuthProvider();
-      const credential = provider.credential(id_token);
+      const credential = GoogleAuthProvider.credential(id_token);
       /* @end */
       signInWithCredential(auth, credential);
     }

--- a/docs/pages/guides/authentication.md
+++ b/docs/pages/guides/authentication.md
@@ -1236,7 +1236,6 @@ export default function App() {
 
       /* @info Create a Google credential with the <code>id_token</code> */
       const auth = getAuth();
-      const provider = new GoogleAuthProvider();
       const credential = GoogleAuthProvider.credential(id_token);
       /* @end */
       signInWithCredential(auth, credential);


### PR DESCRIPTION
…ovider credential.

# Why
The ```credential``` method is now a static method of the class rather than a method of an instance, so this example doesn't work with the ```firebase``` SDK ^9+


<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
![image](https://user-images.githubusercontent.com/22274537/146576774-6ead829e-d068-4566-b83e-d3b04c122882.png)




# Checklist
- [ x ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
