### PR TITLE
[docs] Add EAS Update to feature preview introduction doc

### DIFF
--- a/docs/pages/eas-update/introduction.md
+++ b/docs/pages/eas-update/introduction.md
@@ -4,7 +4,7 @@ title: Introduction
 
 import Head from '~/components/Head'
 
-<Head title="EAS Update Introduction - Expo Documentation" />
+<Head title="Introduction to EAS Update - Expo Documentation" />
 
 > ⚠️ EAS Update is in "preview", meaning that we may still make breaking developer-facing changes. With that, EAS Update is ready for production apps. While we do not intend to make end-user facing changes, we may require you to make new builds of your project before EAS Update is publicly available. Read through the [known issues](/eas-update/known-issues) to ensure EAS Update is ready for your project.
 

--- a/docs/pages/eas-update/introduction.md
+++ b/docs/pages/eas-update/introduction.md
@@ -2,6 +2,10 @@
 title: Introduction
 ---
 
+import Head from '~/components/Head'
+
+<Head title="EAS Update Introduction - Expo Documentation" />
+
 > ⚠️ EAS Update is in "preview", meaning that we may still make breaking developer-facing changes. With that, EAS Update is ready for production apps. While we do not intend to make end-user facing changes, we may require you to make new builds of your project before EAS Update is publicly available. Read through the [known issues](/eas-update/known-issues) to ensure EAS Update is ready for your project.
 
 **EAS Update** is a hosted service that serves updates for projects using the `expo-updates` library.

--- a/docs/pages/feature-preview/index.md
+++ b/docs/pages/feature-preview/index.md
@@ -10,3 +10,4 @@ We decided to publish some of our new features as a preview to get feedback from
 ### Features in preview
 
 - **expo-dev-client**: When you need to customize your project beyond the standard runtime provided in Expo Go, you can create a development build of your app, install it on your phone, and continue developing. [Learn more](/development/introduction.md).
+- **EAS Update**: EAS Update makes fixing small bugs and pushing quick fixes a snap in between app store submissions. It accomplishes this by allowing an end-user's app to swap out the non-native parts of their app (for example, JS, styling, and image changes) with a new update that contains bug fixes and other updates. [Learn more](/eas-update/introduction.md).


### PR DESCRIPTION
Adds a sentence about EAS Update to the feature preview landing page, alongside expo-dev-client.