### PR TITLE
[random] Fix ios build break on sdk 44

### DIFF
--- a/packages/expo-random/CHANGELOG.md
+++ b/packages/expo-random/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix iOS project build break on SDK 44. ([#15626](https://github.com/expo/expo/pull/15626) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 12.1.0 — 2021-12-03

--- a/packages/expo-random/ios/EXRandom/EXRandom.h
+++ b/packages/expo-random/ios/EXRandom/EXRandom.h
@@ -1,8 +1,4 @@
-#if __has_include("RCTBridgeModule.h")
-#import "RCTBridgeModule.h"
-#else
 #import <React/RCTBridgeModule.h>
-#endif
 
 @interface EXRandom : NSObject <RCTBridgeModule>
 


### PR DESCRIPTION
# Why

for #15299, we should strictly import react headers as `#import <React/*.h>`.

# How

remove `#import "RCTBridgeModule.h"`

# Test Plan

expo init sdk44 #select bare
expo install expo-random
patch `node_modules/expo-random/ios/EXRandom/EXRandom.h`
expo run:ios

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
