### PR TITLE
[dev-launcher] Improve error handling when opening the app from a deep link on Android

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - Add persisted installation ID and include in manifest requests. ([#15538](https://github.com/expo/expo/pull/15538) by [@esamelson](https://github.com/esamelson))
 - Improve dev session request logic and use device ID when available. ([#15542](https://github.com/expo/expo/pull/15542) by [@esamelson](https://github.com/esamelson))
-- Improve error handling when opening the app from a deep link on Android.
+- Improve error handling when opening the app from a deep link on Android. ([#15637](https://github.com/expo/expo/pull/15637) by [@lukmccall](https://github.com/lukmccall))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Add persisted installation ID and include in manifest requests. ([#15538](https://github.com/expo/expo/pull/15538) by [@esamelson](https://github.com/esamelson))
 - Improve dev session request logic and use device ID when available. ([#15542](https://github.com/expo/expo/pull/15542) by [@esamelson](https://github.com/esamelson))
+- Improve error handling when opening the app from a deep link on Android.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -29,6 +29,7 @@ import expo.modules.devlauncher.launcher.DevLauncherIntentRegistryInterface
 import expo.modules.devlauncher.launcher.DevLauncherLifecycle
 import expo.modules.devlauncher.launcher.DevLauncherReactActivityDelegateSupplier
 import expo.modules.devlauncher.launcher.DevLauncherRecentlyOpenedAppsRegistry
+import expo.modules.devlauncher.launcher.errors.DevLauncherAppError
 import expo.modules.devlauncher.launcher.errors.DevLauncherErrorActivity
 import expo.modules.devlauncher.launcher.errors.DevLauncherUncaughtExceptionHandler
 import expo.modules.devlauncher.launcher.loaders.DevLauncherAppLoaderFactoryInterface
@@ -192,7 +193,11 @@ class DevLauncherController private constructor()
         }
 
         coroutineScope.launch {
-          loadApp(appUrl, activityToBeInvalidated)
+          try {
+            loadApp(appUrl, activityToBeInvalidated)
+          } catch (e: Throwable) {
+            DevLauncherErrorActivity.showFatalError(context, DevLauncherAppError(e.message, e))
+          }
         }
         return true
       }


### PR DESCRIPTION
# Why

Closes ENG-2507.

# How

Caught all exceptions that may occur during loading the app from a deep link.

# Test Plan

- Run `adb shell am start -a android.intent.action.VIEW -d "bareexpo://expo-development-client/?url=exp%3A%2F%2F192.168.0.136%3A19000"` with non-exisint url