### PR TITLE
[ios] Fix lint issues in Swift files

### DIFF
--- a/ios/Client/AppDelegate.swift
+++ b/ios/Client/AppDelegate.swift
@@ -7,8 +7,8 @@ import ExpoModulesCore
 class AppDelegate: ExpoAppDelegate {
   var rootViewController: EXRootViewController?
 
-  override func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
-    if (application.applicationState != UIApplication.State.background) {
+  override func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
+    if application.applicationState != UIApplication.State.background {
       // App launched in foreground
       setUpUserInterfaceForApplication(application, withLaunchOptions: launchOptions)
     }
@@ -23,8 +23,8 @@ class AppDelegate: ExpoAppDelegate {
     super.applicationWillEnterForeground(application)
   }
 
-  private func setUpUserInterfaceForApplication(_ application: UIApplication, withLaunchOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]?) {
-    if (self.window != nil) {
+  private func setUpUserInterfaceForApplication(_ application: UIApplication, withLaunchOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) {
+    if self.window != nil {
       return
     }
 

--- a/ios/ExpoNotificationServiceExtension/NotificationService.swift
+++ b/ios/ExpoNotificationServiceExtension/NotificationService.swift
@@ -12,15 +12,13 @@
 import UserNotifications
 
 class NotificationService: UNNotificationServiceExtension {
-  
   override func didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void) {
     if let bestAttemptContent = request.content.mutableCopy() as? UNMutableNotificationContent {
       // Modify notification content here...
-      if (!request.content.categoryIdentifier.isEmpty && (request.content.userInfo["experienceId"]) != nil) {
+      if !request.content.categoryIdentifier.isEmpty && (request.content.userInfo["experienceId"]) != nil {
         bestAttemptContent.categoryIdentifier = EXScopedNotificationsUtils.scopedIdentifier(fromId: request.content.categoryIdentifier, forExperience: request.content.userInfo["experienceId"] as! String)
       }
       contentHandler(bestAttemptContent)
     }
   }
-  
 }

--- a/ios/Exponent/Kernel/Views/Loading/EXAppLoadingProgressWindowViewController.swift
+++ b/ios/Exponent/Kernel/Views/Loading/EXAppLoadingProgressWindowViewController.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 @objc
-class EXAppLoadingProgressWindowViewController : UIViewController {
+class EXAppLoadingProgressWindowViewController: UIViewController {
   override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
     let visibleAppSupportedInterfaceOrientations = EXKernel
       .sharedInstance()

--- a/packages/expo-blur/ios/EXBlur/BlurEffectView.swift
+++ b/packages/expo-blur/ios/EXBlur/BlurEffectView.swift
@@ -49,7 +49,7 @@ final class BlurEffectView: UIVisualEffectView {
 }
 
 private func blurEffectStyleFrom(_ tint: String) -> UIBlurEffect.Style {
-  switch (tint) {
+  switch tint {
   case "light": return .extraLight
   case "dark": return .dark
   case "default": return .light

--- a/packages/expo-blur/ios/EXBlur/BlurView.swift
+++ b/packages/expo-blur/ios/EXBlur/BlurView.swift
@@ -3,7 +3,7 @@
 import UIKit
 
 @objc(EXBlurView)
-public class BlurView : UIView {
+public class BlurView: UIView {
   private var blurEffectView: BlurEffectView
 
   override init(frame: CGRect) {
@@ -25,6 +25,6 @@ public class BlurView : UIView {
 
   @objc
   public func setIntensity(_ intensity: Double) {
-    blurEffectView.intensity = intensity;
+    blurEffectView.intensity = intensity
   }
 }

--- a/packages/expo-cellular/ios/CellularModule.swift
+++ b/packages/expo-cellular/ios/CellularModule.swift
@@ -67,8 +67,8 @@ public class CellularModule: Module {
       return .cellular4G
     default:
       if #available(iOS 14.1, *) {
-        if (radioAccessTechnology == CTRadioAccessTechnologyNRNSA ||
-            radioAccessTechnology == CTRadioAccessTechnologyNR) {
+        if radioAccessTechnology == CTRadioAccessTechnologyNRNSA ||
+            radioAccessTechnology == CTRadioAccessTechnologyNR {
           return .cellular5G
         }
       }
@@ -76,7 +76,7 @@ public class CellularModule: Module {
     }
   }
 
-  static func getCurrentCellularInfo() -> [String : Any?] {
+  static func getCurrentCellularInfo() -> [String: Any?] {
     let carrier = Self.currentCarrier()
     let generation = Self.currentCellularGeneration()
 
@@ -86,7 +86,7 @@ public class CellularModule: Module {
       "isoCountryCode": carrier?.isoCountryCode,
       "mobileCountryCode": carrier?.mobileCountryCode,
       "mobileNetworkCode": carrier?.mobileNetworkCode,
-      "generation": generation.rawValue,
+      "generation": generation.rawValue
     ]
   }
 

--- a/packages/expo-cellular/ios/CellularModule.swift
+++ b/packages/expo-cellular/ios/CellularModule.swift
@@ -104,10 +104,8 @@ public class CellularModule: Module {
     let netinfo = CTTelephonyNetworkInfo()
 
     if #available(iOS 12.0, *), let providers = netinfo.serviceSubscriberCellularProviders {
-      for carrier in providers.values {
-        if carrier.carrierName != nil {
-          return carrier
-        }
+      for carrier in providers.values where carrier.carrierName != nil {
+        return carrier
       }
       return providers.values.first
     }

--- a/packages/expo-dev-launcher/ios/EXDevLauncherInstallationIDHelper.swift
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherInstallationIDHelper.swift
@@ -5,12 +5,11 @@ import Foundation
 let DEV_LAUNCHER_INSTALLATION_ID_FILENAME = "expo-dev-launcher-installation-id.txt"
 
 @objc
-public class EXDevLauncherInstallationIDHelper : NSObject  {
-
+public class EXDevLauncherInstallationIDHelper: NSObject {
   @objc
   public func getOrCreateInstallationID() -> String {
     let savedID = getInstallationID()
-    if (savedID != nil) {
+    if savedID != nil {
       return savedID!
     }
 
@@ -22,12 +21,12 @@ public class EXDevLauncherInstallationIDHelper : NSObject  {
   private var installationID: String?
 
   private func getInstallationID() -> String? {
-    if (installationID != nil) {
+    if installationID != nil {
       return installationID
     }
 
     let installationIDFileURL = getInstallationIDFileURL()
-    if (FileManager.default.fileExists(atPath: installationIDFileURL.path)) {
+    if FileManager.default.fileExists(atPath: installationIDFileURL.path) {
       do {
         installationID = try String(contentsOf: installationIDFileURL, encoding: .utf8)
       } catch let error {
@@ -59,7 +58,7 @@ public class EXDevLauncherInstallationIDHelper : NSObject  {
 
   private func getInstallationIDFileURL() -> URL {
     let applicationSupportURL = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-    if (!FileManager.default.fileExists(atPath: applicationSupportURL.path)) {
+    if !FileManager.default.fileExists(atPath: applicationSupportURL.path) {
       do {
         try FileManager.default.createDirectory(at: applicationSupportURL, withIntermediateDirectories: true, attributes: nil)
       } catch let error {

--- a/packages/expo-dev-launcher/ios/EXDevLauncherMenuDelegate.swift
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherMenuDelegate.swift
@@ -1,71 +1,70 @@
 import EXDevMenuInterface
 
-internal class LauncherDelegate : DevMenuDelegateProtocol {
+internal class LauncherDelegate: DevMenuDelegateProtocol {
   private let controller: EXDevLauncherController
-  
+
   init(withController controller: EXDevLauncherController) {
     self.controller = controller
   }
-  
+
   func appBridge(forDevMenuManager manager: DevMenuManagerProtocol) -> AnyObject? {
     return controller.launcherBridge
   }
-  
-  func appInfo(forDevMenuManager manager: DevMenuManagerProtocol) -> [String : Any]? {
+
+  func appInfo(forDevMenuManager manager: DevMenuManagerProtocol) -> [String: Any]? {
     return [
       "appName": "Development Client",
       "appVersion": EXDevLauncherController.version() ?? NSNull(),
       "appIcon": NSNull(),
-      "hostUrl": NSNull(),
+      "hostUrl": NSNull()
     ]
   }
-  
+
   public func supportsDevelopment() -> Bool {
     return false
   }
 }
 
-internal class AppDelegate : DevMenuDelegateProtocol {
+internal class AppDelegate: DevMenuDelegateProtocol {
   private let controller: EXDevLauncherController
-  
+
   init(withController controller: EXDevLauncherController) {
     self.controller = controller
   }
-  
+
   func appBridge(forDevMenuManager manager: DevMenuManagerProtocol) -> AnyObject? {
     return controller.appBridge
   }
-  
-  func appInfo(forDevMenuManager manager: DevMenuManagerProtocol) -> [String : Any]?  {
+
+  func appInfo(forDevMenuManager manager: DevMenuManagerProtocol) -> [String: Any]? {
     guard let manifest = controller.appManifest() else {
       return [
         "appName": "Development Client - App",
         "appVersion": NSNull(),
         "appIcon": NSNull(),
         // AppBridge should be present here, but for safety, we use null checks
-        "hostUrl": controller.appBridge?.bundleURL?.absoluteString ?? NSNull(),
+        "hostUrl": controller.appBridge?.bundleURL?.absoluteString ?? NSNull()
       ]
     }
-    
+
     return [
       "appName": manifest.name(),
       "appVersion": manifest.version(),
       "appIcon": NSNull(),
-      "hostUrl": manifest.bundleUrl(),
+      "hostUrl": manifest.bundleUrl()
     ]
   }
-  
+
   public func supportsDevelopment() -> Bool {
     return true
   }
 }
 
-
 @objc
-public class EXDevLauncherMenuDelegate : NSObject, DevMenuDelegateProtocol {
+public class EXDevLauncherMenuDelegate: NSObject, DevMenuDelegateProtocol {
   private let controller: EXDevLauncherController
-  private let appDelegate: AppDelegate
-  private let launcherDelegate: LauncherDelegate
+  private weak var appDelegate: AppDelegate
+  private weak var launcherDelegate: LauncherDelegate
 
   @objc
   public init(withLauncherController launcherController: EXDevLauncherController) {
@@ -73,7 +72,7 @@ public class EXDevLauncherMenuDelegate : NSObject, DevMenuDelegateProtocol {
     appDelegate = AppDelegate(withController: controller)
     launcherDelegate = LauncherDelegate(withController: controller)
   }
-  
+
   private var currentDelegate: DevMenuDelegateProtocol {
     if controller.isAppRunning() {
       return appDelegate
@@ -81,20 +80,20 @@ public class EXDevLauncherMenuDelegate : NSObject, DevMenuDelegateProtocol {
       return launcherDelegate
     }
   }
-  
+
   public func appBridge(forDevMenuManager manager: DevMenuManagerProtocol) -> AnyObject? {
     return currentDelegate.appBridge?(forDevMenuManager: manager)
   }
-  
-  public func appInfo(forDevMenuManager manager: DevMenuManagerProtocol) -> [String : Any]? {
+
+  public func appInfo(forDevMenuManager manager: DevMenuManagerProtocol) -> [String: Any]? {
     return currentDelegate.appInfo?(forDevMenuManager: manager)
   }
-  
+
   public func supportsDevelopment() -> Bool {
     guard let supportsDevelopment = currentDelegate.supportsDevelopment?() else {
       return true
     }
-    
+
     return supportsDevelopment
   }
 }

--- a/packages/expo-dev-launcher/ios/EXDevLauncherMenuDelegate.swift
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherMenuDelegate.swift
@@ -63,8 +63,8 @@ internal class AppDelegate: DevMenuDelegateProtocol {
 @objc
 public class EXDevLauncherMenuDelegate: NSObject, DevMenuDelegateProtocol {
   private let controller: EXDevLauncherController
-  private weak var appDelegate: AppDelegate
-  private weak var launcherDelegate: LauncherDelegate
+  private let appDelegate: AppDelegate
+  private let launcherDelegate: LauncherDelegate
 
   @objc
   public init(withLauncherController launcherController: EXDevLauncherController) {

--- a/packages/expo-dev-launcher/ios/EXDevLauncherPendingDeepLinkRegistry.swift
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherPendingDeepLinkRegistry.swift
@@ -3,28 +3,28 @@
 import Foundation
 
 @objc
-public class EXDevLauncherPendingDeepLinkRegistry : NSObject {
+public class EXDevLauncherPendingDeepLinkRegistry: NSObject {
   private var listeners: [EXDevLauncherPendingDeepLinkListener] = []
-  
+
   @objc
   public var pendingDeepLink: URL? {
     didSet {
-      if (pendingDeepLink != nil) {
+      if pendingDeepLink != nil {
         listeners.forEach { $0.onNewPendingDeepLink(pendingDeepLink!) }
       }
     }
   }
-  
+
   @objc
   public func subscribe(_ listener: EXDevLauncherPendingDeepLinkListener) {
     self.listeners.append(listener)
   }
-  
+
   @objc
   public func unsubscribe(_ listener: EXDevLauncherPendingDeepLinkListener) {
     self.listeners.removeAll { $0 === listener }
   }
-  
+
   @objc
   public func consumePendingDeepLink() -> URL? {
     let result = pendingDeepLink

--- a/packages/expo-dev-launcher/ios/EXDevLauncherRecentlyOpenedAppsRegistry.swift
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherRecentlyOpenedAppsRegistry.swift
@@ -4,10 +4,10 @@ import Foundation
 
 let RECENTLY_OPENED_APPS_REGISTRY_KEY = "expo.devlauncher.recentlyopenedapps"
 
-let TIME_TO_REMOVE = 1000 * 60 * 60 * 24 * 3 // 3 days
+let TIME_TO_REMOVE = 1_000 * 60 * 60 * 24 * 3 // 3 days
 
 @objc(EXDevLauncherRecentlyOpenedAppsRegistry)
-public class EXDevLauncherRecentlyOpenedAppsRegistry : NSObject {
+public class EXDevLauncherRecentlyOpenedAppsRegistry: NSObject {
   private var appRegistry: [String: Any] {
     get {
       return UserDefaults.standard.dictionary(forKey: RECENTLY_OPENED_APPS_REGISTRY_KEY) ?? [String: Any]()
@@ -16,7 +16,7 @@ public class EXDevLauncherRecentlyOpenedAppsRegistry : NSObject {
       UserDefaults.standard.set(newAppRegistry, forKey: RECENTLY_OPENED_APPS_REGISTRY_KEY)
     }
   }
-  
+
   @objc
   public func appWasOpened(_ url: String, name: String?) {
     var registry = appRegistry
@@ -24,31 +24,31 @@ public class EXDevLauncherRecentlyOpenedAppsRegistry : NSObject {
     if name != nil {
       appEntry["name"] = name
     }
-    registry[url] = appEntry;
+    registry[url] = appEntry
     appRegistry = registry
   }
-  
+
   @objc
   public func recentlyOpenedApps() -> [String: Any] {
     var result = [String: Any]()
     guard let registry = appRegistry as? [String: [String: Any]] else {
       return [:]
     }
-    
+
     appRegistry = registry.filter { (url: String, appEntry: [String: Any]) in
       if getCurrentTimestamp() - (appEntry["timestamp"] as! Int64) > TIME_TO_REMOVE {
-        return false;
+        return false
       }
-      
+
       result[url] = appEntry["name"] ?? NSNull()
-      return true;
+      return true
     }
-        
+
     return result
   }
-  
+
   func getCurrentTimestamp() -> Int64 {
-    return Int64(Date().timeIntervalSince1970 * 1000);
+    return Int64(Date().timeIntervalSince1970 * 1_000)
   }
 
   func resetStorage() {

--- a/packages/expo-dev-launcher/ios/EXDevLauncherURLHelper.swift
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherURLHelper.swift
@@ -3,12 +3,12 @@
 import Foundation
 
 @objc
-public class EXDevLauncherURLHelper : NSObject  {
+public class EXDevLauncherURLHelper: NSObject {
   @objc
   public static func isDevLauncherURL(_ url: URL?) -> Bool {
     return url?.host == "expo-development-client"
   }
-  
+
   @objc
   public static func replaceEXPScheme(_ url: URL, to scheme: String) -> URL {
     var components = URLComponents.init(url: url, resolvingAgainstBaseURL: false)!
@@ -24,7 +24,7 @@ public class EXDevLauncherURLHelper : NSObject  {
         return URL.init(string: parameter.value?.removingPercentEncoding ?? "")
       }
     }
-    
-    return nil;
+
+    return nil
   }
 }

--- a/packages/expo-dev-launcher/ios/EXDevLauncherUtils.swift
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherUtils.swift
@@ -11,18 +11,18 @@ class EXDevLauncherUtils {
       let methodB = class_getInstanceMethod(forClass, selectorB) {
       let impA = method_getImplementation(methodA)
       let argsTypeA = method_getTypeEncoding(methodA)
-      
+
       let impB = method_getImplementation(methodB)
       let argsTypeB = method_getTypeEncoding(methodB)
-      
-      if (class_addMethod(forClass, selectorA, impB, argsTypeB)) {
+
+      if class_addMethod(forClass, selectorA, impB, argsTypeB) {
         class_replaceMethod(forClass, selectorB, impA, argsTypeA)
       } else {
         method_exchangeImplementations(methodA, methodB)
       }
     }
   }
-  
+
   static func resourcesBundle() -> Bundle? {
     let frameworkBundle = Bundle(for: EXDevLauncherUtils.self)
 

--- a/packages/expo-dev-launcher/ios/Errors/EXDevLauncherAppError.swift
+++ b/packages/expo-dev-launcher/ios/Errors/EXDevLauncherAppError.swift
@@ -4,7 +4,7 @@
 public class EXDevLauncherAppError: NSObject {
   let message: String
   let stack: [RCTJSStackFrame]?
-  
+
   @objc
   public init(message: String, stack: [RCTJSStackFrame]? = nil) {
     self.message = message

--- a/packages/expo-dev-launcher/ios/Errors/EXDevLauncherErrorManager.swift
+++ b/packages/expo-dev-launcher/ios/Errors/EXDevLauncherErrorManager.swift
@@ -7,37 +7,37 @@ public class EXDevLauncherErrorManager: NSObject {
   internal weak var controller: EXDevLauncherController?
   private weak var currentVC: EXDevLauncherErrorViewController?
   private var error: EXDevLauncherAppError?
-  
+
   @objc
   public init(controller: EXDevLauncherController) {
     self.controller = controller
     EXDevLauncherRedBoxInterceptor.isInstalled = true
   }
-    
+
   @objc
   public func consumeError() -> EXDevLauncherAppError {
     let result = error!
     error = nil
     return result
   }
-  
+
   @objc
   public func showError(_ error: EXDevLauncherAppError) {
     guard let nextViewController = getNextErrorViewController() else {
       currentVC = nil
       return
     }
-    
+
     self.error = error
     currentVC = nextViewController
     controller?.currentWindow()?.rootViewController = currentVC
   }
-  
+
   private func getNextErrorViewController() -> EXDevLauncherErrorViewController? {
     if currentVC == nil || controller?.currentWindow()?.rootViewController != currentVC {
       return EXDevLauncherErrorViewController.create(forManager: self)
     }
-    
+
     return currentVC
   }
 }

--- a/packages/expo-dev-launcher/ios/Errors/EXDevLauncherErrorViewController.swift
+++ b/packages/expo-dev-launcher/ios/Errors/EXDevLauncherErrorViewController.swift
@@ -6,7 +6,7 @@ import Foundation
 public class EXDevLauncherErrorViewController: UIViewController, UITableViewDataSource {
   internal weak var manager: EXDevLauncherErrorManager?
   var error: EXDevLauncherAppError?
-  
+
   @IBOutlet weak var errorInformation: UILabel!
   @IBOutlet weak var errorStack: UITableView!
 
@@ -17,27 +17,27 @@ public class EXDevLauncherErrorViewController: UIViewController, UITableViewData
       navigateToLauncher()
       return
     }
-    
-    manager?.controller?.loadApp(appUrl, onSuccess: nil, onError: { [weak self] (error) in
+
+    manager?.controller?.loadApp(appUrl, onSuccess: nil, onError: { [weak self] _ in
       self?.navigateToLauncher()
     })
   }
-  
+
   @IBAction func goToHome(_ sender: Any) {
     navigateToLauncher()
   }
-    
+
   public override func viewDidLoad() {
     error = manager?.consumeError()
-    
-    errorInformation.text = error?.message ?? "Unknown error";
+
+    errorInformation.text = error?.message ?? "Unknown error"
     errorStack?.dataSource = self
   }
-  
+
   public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
     return error?.stack?.count ?? 0
   }
-  
+
   public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
     let cell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath) as! EXDevLauncherStackTrace
     let frame = error!.stack![indexPath.item]
@@ -45,7 +45,7 @@ public class EXDevLauncherErrorViewController: UIViewController, UITableViewData
     cell.file.text = frame.file
     return cell
   }
-  
+
   @objc
   public static func create(forManager manager: EXDevLauncherErrorManager) -> EXDevLauncherErrorViewController? {
     guard let bundle = EXDevLauncherUtils.resourcesBundle() else {
@@ -54,11 +54,11 @@ public class EXDevLauncherErrorViewController: UIViewController, UITableViewData
 
     let storyboard = UIStoryboard(name: "EXDevLauncherErrorView", bundle: bundle)
     let vc = storyboard.instantiateViewController(withIdentifier: "EXDevLauncherErrorView") as? EXDevLauncherErrorViewController
-    
+
     vc?.manager = manager
     return vc
   }
-  
+
   private func navigateToLauncher() {
     manager?.controller?.navigateToLauncher()
   }

--- a/packages/expo-dev-launcher/ios/Errors/EXDevLauncherUncaughtExceptionHandler.swift
+++ b/packages/expo-dev-launcher/ios/Errors/EXDevLauncherUncaughtExceptionHandler.swift
@@ -4,13 +4,13 @@ import Foundation
 
 @objc
 public class EXDevLauncherUncaughtExceptionHandler: NSObject {
-  static private var defaultHandler: (@convention(c) (NSException) -> Swift.Void)? = nil
-  
+  static private var defaultHandler: (@convention(c) (NSException) -> Swift.Void)?
+
   @objc
   public static var isInstalled: Bool = false {
     willSet {
-      if (isInstalled != newValue) {
-        if (newValue) {
+      if isInstalled != newValue {
+        if newValue {
           installHandler()
         } else {
           uninstallHandler()
@@ -18,19 +18,18 @@ public class EXDevLauncherUncaughtExceptionHandler: NSObject {
       }
     }
   }
-  
+
   static func installHandler() {
     defaultHandler = NSGetUncaughtExceptionHandler()
-    
+
     NSSetUncaughtExceptionHandler { exception in
-      NSLog("DevLauncher tries to handle uncaught exception: %@", exception);
-      NSLog("Stack Trace: %@", exception.callStackSymbols);
+      NSLog("DevLauncher tries to handle uncaught exception: %@", exception)
+      NSLog("Stack Trace: %@", exception.callStackSymbols)
       EXDevLauncherUncaughtExceptionHandler.defaultHandler?(exception)
     }
   }
-  
+
   static func uninstallHandler() {
     NSSetUncaughtExceptionHandler(defaultHandler)
   }
-  
 }

--- a/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestHelper.swift
+++ b/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestHelper.swift
@@ -14,7 +14,7 @@ public class EXDevLauncherManifestHelper: NSObject {
     } else if orientationMask.contains(.portraitUpsideDown) {
       return UIInterfaceOrientation.portraitUpsideDown
     }
-    
+
     return UIInterfaceOrientation.unknown
   }
 
@@ -26,7 +26,7 @@ public class EXDevLauncherManifestHelper: NSObject {
     } else if orientation == "landscape" {
       orientationMask = .landscape
     }
-    
+
     return defaultOrientationForOrientationMask(orientationMask)
   }
 
@@ -35,16 +35,16 @@ public class EXDevLauncherManifestHelper: NSObject {
     guard var hexString = hexString else {
       return nil
     }
-    
-    if (hexString.count != 7 || !hexString.starts(with: "#")) {
+
+    if hexString.count != 7 || !hexString.starts(with: "#") {
       return nil
     }
-    
+
     hexString.removeFirst()
-    
+
     var rgbValue: UInt64 = 0
     Scanner(string: hexString).scanHexInt64(&rgbValue)
-    
+
     return UIColor(red: CGFloat((rgbValue & 0xFF0000) >> 16) / 255.0,
                    green: CGFloat((rgbValue & 0x00FF00) >> 8) / 255.0,
                    blue: CGFloat(rgbValue & 0x0000FF) / 255.0,
@@ -54,7 +54,7 @@ public class EXDevLauncherManifestHelper: NSObject {
   @objc
   @available(iOS 12.0, *)
   public static func exportManifestUserInterfaceStyle(_ userInterfaceStyle: String?) -> UIUserInterfaceStyle {
-    switch (userInterfaceStyle){
+    switch userInterfaceStyle {
       case "light":
         return .light
       case "dark":

--- a/packages/expo-dev-launcher/ios/ReactNative/EXDevLauncherBundleURLProviderInterceptor.swift
+++ b/packages/expo-dev-launcher/ios/ReactNative/EXDevLauncherBundleURLProviderInterceptor.swift
@@ -10,7 +10,7 @@ public class EXDevLauncherBundleURLProviderInterceptor: NSObject {
       }
     }
   }
-  
+
   static private func swizzle() {
     EXDevLauncherUtils.swizzle(
       selector: #selector(RCTBundleURLProvider.guessPackagerHost),
@@ -25,6 +25,6 @@ extension RCTBundleURLProvider {
   func EXDevLauncher_guessPackagerHost() -> String? {
     // We set the packager host by hand.
     // So we don't want to guess the packager host, cause it can take a lot of time.
-    return nil;
+    return nil
   }
 }

--- a/packages/expo-dev-launcher/ios/ReactNative/EXDevLauncherRedBoxInterceptor.swift
+++ b/packages/expo-dev-launcher/ios/ReactNative/EXDevLauncherRedBoxInterceptor.swift
@@ -5,7 +5,7 @@ import Foundation
 @objc
 public class EXDevLauncherRedBoxInterceptor: NSObject {
   @objc static let customRedBox = EXDevLauncherRedBox()
-  
+
   @objc
   public static var isInstalled: Bool = false {
     willSet {
@@ -14,20 +14,20 @@ public class EXDevLauncherRedBoxInterceptor: NSObject {
       }
     }
   }
-  
+
   static private func swizzle() {
     EXDevLauncherUtils.swizzle(
       selector: #selector(RCTCxxBridge.module(forName:)),
       withSelector: #selector(RCTCxxBridge.EXDevLauncher_module(forName:)),
       forClass: RCTCxxBridge.self
     )
-    
+
     EXDevLauncherUtils.swizzle(
       selector: #selector(RCTCxxBridge.module(forName:lazilyLoadIfNecessary:)),
       withSelector: #selector(RCTCxxBridge.EXDevLauncher_module(forName:lazilyLoadIfNecessary:)),
       forClass: RCTCxxBridge.self
     )
-    
+
     EXDevLauncherUtils.swizzle(
       selector: #selector(RCTCxxBridge.module(for:)),
       withSelector: #selector(RCTCxxBridge.EXDevLauncher_module(forClass:)),
@@ -42,28 +42,28 @@ extension RCTCxxBridge {
     let orginalModule = self.EXDevLauncher_module(forName: name)
     return replaceRedBox(orginalModule)
   }
-  
+
   @objc
   func EXDevLauncher_module(forName name: String, lazilyLoadIfNecessary lazilyLoad: Bool) -> Any? {
     let orginalModule = self.EXDevLauncher_module(forName: name, lazilyLoadIfNecessary: lazilyLoad)
     return replaceRedBox(orginalModule)
   }
-  
+
   @objc
   func EXDevLauncher_module(forClass clazz: Any) -> Any? {
     let orginalModule = self.EXDevLauncher_module(forClass: clazz)
     return replaceRedBox(orginalModule)
   }
-  
+
   @objc
   private func replaceRedBox(_ module: Any?) -> Any? {
-    if (module is RCTRedBox) {
+    if module is RCTRedBox {
       let logBox = EXDevLauncher_module(forClass: RCTLogBox.self) as? RCTLogBox
       let customRedBox = EXDevLauncherRedBoxInterceptor.customRedBox
       customRedBox.register(logBox)
       return customRedBox.unsafe_castToRCTRedBox()
     }
-    
+
     return module
   }
 }

--- a/packages/expo-dev-launcher/ios/Tests/EXDevLauncherControllerTest.swift
+++ b/packages/expo-dev-launcher/ios/Tests/EXDevLauncherControllerTest.swift
@@ -7,32 +7,32 @@ class EXDevLauncherControllerTest: QuickSpec {
   override func spec() {
     it("should return correct version") {
       let version = EXDevLauncherController.version()
-    
+
       expect(version).toNot(beNil())
     }
-    
+
     it("sharedInstance should always return the same instance") {
       let sharedInstance = EXDevLauncherController.sharedInstance()
-      
+
       expect(sharedInstance).toNot(beNil())
       expect(sharedInstance).to(be(EXDevLauncherController.sharedInstance()))
     }
-    
+
     it("extraModulesForBridge should return essential modules") {
       let module = EXDevLauncherController.sharedInstance()
-      
+
       let modules = module.extraModules(for: nil)!
-      
+
       expect(modules.count).to(equal(4))
-      expect(modules.first { type(of: $0).moduleName() == "RCTDevMenu"} ).toNot(beNil())
-      expect(modules.first { type(of: $0).moduleName() == "RCTAsyncLocalStorage"} ).toNot(beNil())
-      expect(modules.first { type(of: $0).moduleName() == "DevLoadingView"} ).toNot(beNil())
-      expect(modules.first { type(of: $0).moduleName() == "EXDevLauncherInternal"} ).toNot(beNil())
+      expect(modules.first { type(of: $0).moduleName() == "RCTDevMenu" }).toNot(beNil())
+      expect(modules.first { type(of: $0).moduleName() == "RCTAsyncLocalStorage" }).toNot(beNil())
+      expect(modules.first { type(of: $0).moduleName() == "DevLoadingView" }).toNot(beNil())
+      expect(modules.first { type(of: $0).moduleName() == "EXDevLauncherInternal" }).toNot(beNil())
     }
-    
+
     it("controller should have access to managers classes") {
       let module = EXDevLauncherController.sharedInstance()
-      
+
       expect(module.errorManager()).toNot(beNil())
       expect(module.pendingDeepLinkRegistry).toNot(beNil())
     }

--- a/packages/expo-dev-launcher/ios/Tests/EXDevLauncherMenuDelegateTest.swift
+++ b/packages/expo-dev-launcher/ios/Tests/EXDevLauncherMenuDelegateTest.swift
@@ -9,48 +9,48 @@ class EXDevLauncherMenuDelegateTest: QuickSpec {
     func isLoggedIn() -> Bool {
       return false
     }
-    
+
     func setSessionSecret(_ sessionSecret: String?) {}
-    
+
     func queryDevSessionsAsync(_ installationID: String?, completionHandler: @escaping HTTPCompletionHandler) {}
-    
+
     func queryUpdateChannels(appId: String, completionHandler: @escaping ([DevMenuEASUpdates.Channel]?, URLResponse?, Error?) -> Void, options: DevMenuGraphQLOptions) {}
-    
+
     func queryUpdateBranches(appId: String, completionHandler: @escaping ([DevMenuEASUpdates.Branch]?, URLResponse?, Error?) -> Void, branchesOptions: DevMenuGraphQLOptions, updatesOptions: DevMenuGraphQLOptions) {}
   }
-  
+
   class MockedMenu: DevMenuManagerProtocol {
     var isVisible: Bool = false
-    
-    var delegate: DevMenuDelegateProtocol?
-    
+
+    weak var delegate: DevMenuDelegateProtocol?
+
     func openMenu(_ screen: String?) -> Bool {
       return true
     }
-    
+
     func openMenu() -> Bool {
       return true
     }
-    
+
     func closeMenu() -> Bool {
       return true
     }
-    
+
     func hideMenu() -> Bool {
       return true
     }
-    
+
     func toggleMenu() -> Bool {
       return true
     }
-    
+
     var expoApiClient: DevMenuExpoApiClientProtocol = MockedApiClient()
   }
-  
+
   override func spec() {
     it("LauncherDelegate should serialize to the correct scheme") {
       let delegate = LauncherDelegate(withController: EXDevLauncherController.sharedInstance())
-      
+
       let appInfo = delegate.appInfo(forDevMenuManager: MockedMenu())!
 
       expect(appInfo["appName"] as? String).to(equal("Development Client"))
@@ -58,18 +58,18 @@ class EXDevLauncherMenuDelegateTest: QuickSpec {
       expect(appInfo["appIcon"]).to(be(NSNull()))
       expect(appInfo["hostUrl"]).to(be(NSNull()))
     }
-   
+
     it("LauncherDelegate shouldn't support developement tools") {
       let delegate = LauncherDelegate(withController: EXDevLauncherController.sharedInstance())
-      
+
       let supportsDevelopment = delegate.supportsDevelopment()
-      
+
       expect(supportsDevelopment).to(beFalse())
     }
-    
+
     it("AppDelegate should serialize to the correct scheme") {
       let delegate = AppDelegate(withController: EXDevLauncherController.sharedInstance())
-      
+
       let appInfo = delegate.appInfo(forDevMenuManager: MockedMenu())!
 
       expect(appInfo["appName"] as? String).to(equal("Development Client - App"))
@@ -77,12 +77,12 @@ class EXDevLauncherMenuDelegateTest: QuickSpec {
       expect(appInfo["appIcon"]).to(be(NSNull()))
       expect(appInfo["hostUrl"]).to(be(NSNull()))
     }
-   
+
     it("AppDelegate should support development tools") {
       let delegate = AppDelegate(withController: EXDevLauncherController.sharedInstance())
-      
+
       let supportsDevelopment = delegate.supportsDevelopment()
-      
+
       expect(supportsDevelopment).to(beTrue())
     }
   }

--- a/packages/expo-dev-launcher/ios/Tests/EXDevLauncherMenuDelegateTest.swift
+++ b/packages/expo-dev-launcher/ios/Tests/EXDevLauncherMenuDelegateTest.swift
@@ -22,7 +22,7 @@ class EXDevLauncherMenuDelegateTest: QuickSpec {
   class MockedMenu: DevMenuManagerProtocol {
     var isVisible: Bool = false
 
-    weak var delegate: DevMenuDelegateProtocol?
+    var delegate: DevMenuDelegateProtocol?
 
     func openMenu(_ screen: String?) -> Bool {
       return true

--- a/packages/expo-dev-launcher/ios/Tests/EXDevLauncherPendingDeepLinkRegistryTest.swift
+++ b/packages/expo-dev-launcher/ios/Tests/EXDevLauncherPendingDeepLinkRegistryTest.swift
@@ -4,44 +4,44 @@ import Nimble
 @testable import EXDevLauncher
 
 class EXDevLauncherPendingDeepLinkRegistryTest: QuickSpec {
-  class Listener : NSObject, EXDevLauncherPendingDeepLinkListener {
+  class Listener: NSObject, EXDevLauncherPendingDeepLinkListener {
     var lastDeepLink: URL?
-    
+
     func onNewPendingDeepLink(_ deepLink: URL!) {
       lastDeepLink = deepLink
     }
   }
-  
+
   override func spec() {
     it("registry should inform all subscribers about new value") {
       let listener = Listener()
       let registry = EXDevLauncherPendingDeepLinkRegistry()
-      
+
       registry.subscribe(listener)
       registry.pendingDeepLink = URL.init(string: "http://localhost:1234")
-      
+
       expect(listener.lastDeepLink?.absoluteString).to(equal("http://localhost:1234"))
     }
-    
+
     it("unsubscribe should work") {
       let listener = Listener()
       let registry = EXDevLauncherPendingDeepLinkRegistry()
-      
+
       registry.subscribe(listener)
       registry.unsubscribe(listener)
       registry.pendingDeepLink = URL.init(string: "http://localhost:1234")
-      
+
       expect(listener.lastDeepLink).to(beNil())
     }
-    
+
     it("consumePendingDeepLink should reset the inner value") {
       let listener = Listener()
       let registry = EXDevLauncherPendingDeepLinkRegistry()
-      
+
       registry.subscribe(listener)
       registry.pendingDeepLink = URL.init(string: "http://localhost:1234")
       let consumedURL = registry.consumePendingDeepLink()
-      
+
       expect(registry.pendingDeepLink).to(beNil())
       expect(listener.lastDeepLink?.absoluteString).to(equal("http://localhost:1234"))
       expect(listener.lastDeepLink).to(be(consumedURL))

--- a/packages/expo-dev-launcher/ios/Tests/EXDevLauncherRCTBridgeTest.swift
+++ b/packages/expo-dev-launcher/ios/Tests/EXDevLauncherRCTBridgeTest.swift
@@ -10,19 +10,19 @@ class EXDevLauncherRCTBridgeTest: QuickSpec {
   class NotAllowModule: NSObject {}
   @objc(DevMenuModule)
   class DevMenuModule: NSObject {}
-  
+
   override func spec() {
     it("should be connected with EXDevLauncherRCTCxxBridge") {
       let bridge = EXDevLauncherRCTBridge(delegate: nil, launchOptions: nil)!
-    
+
       expect(bridge.bridgeClass()).to(be(EXDevLauncherRCTCxxBridge.self))
     }
-    
+
     it("should be able to filter non essential modules") {
       let cxxBridge = EXDevLauncherRCTBridge(delegate: nil, launchOptions: nil)!.batched as! EXDevLauncherRCTCxxBridge
-         
+
       let filteredModules = cxxBridge.filterModuleList([RCTAllowModule.self, NotAllowModule.self, DevMenuModule.self])
-         
+
       expect(filteredModules.count).to(equal(2))
       expect(filteredModules[0]).to(be(RCTAllowModule.self))
       expect(filteredModules[1]).to(be(DevMenuModule.self))

--- a/packages/expo-dev-launcher/ios/Tests/EXDevLauncherRecentlyOpenedAppsRegistryTest.swift
+++ b/packages/expo-dev-launcher/ios/Tests/EXDevLauncherRecentlyOpenedAppsRegistryTest.swift
@@ -6,32 +6,32 @@ import Nimble
 class EXDevLauncherRecentlyOpenedAppsRegistryTest: QuickSpec {
   override func spec() {
     let appsRegistry = EXDevLauncherRecentlyOpenedAppsRegistry()
-    
+
     beforeEach {
       appsRegistry.resetStorage()
     }
-    
+
     it("registry should be empty on start") {
       expect(appsRegistry.recentlyOpenedApps().count).to(equal(0))
     }
-    
+
     it("registry should update when apps are opened") {
       appsRegistry.appWasOpened("http://localhost:1234", name: "app1")
       appsRegistry.appWasOpened("http://localhost:9876", name: "app2")
-      
+
       let openedApps = appsRegistry.recentlyOpenedApps()
-      
+
       expect(openedApps.count).to(equal(2))
       expect(openedApps["http://localhost:1234"] as? String).to(equal("app1"))
       expect(openedApps["http://localhost:9876"] as? String).to(equal("app2"))
     }
-    
+
     it("registry timestamp should be correct") {
       let registerTimestamp = appsRegistry.getCurrentTimestamp()
-      let now = Int64(Date().timeIntervalSince1970 * 1000)
-      
+      let now = Int64(Date().timeIntervalSince1970 * 1_000)
+
       expect(registerTimestamp).to(beLessThanOrEqualTo(now))
-      expect(registerTimestamp).to(beGreaterThan(now - 1000))
+      expect(registerTimestamp).to(beGreaterThan(now - 1_000))
     }
   }
 }

--- a/packages/expo-dev-launcher/ios/Tests/EXDevLauncherRecentlyOpenedAppsRegistryTests.swift
+++ b/packages/expo-dev-launcher/ios/Tests/EXDevLauncherRecentlyOpenedAppsRegistryTests.swift
@@ -6,7 +6,7 @@ import XCTest
 
 class EXDevLauncherRecentlyOpenedAppsRegistry3DaysAgo: EXDevLauncherRecentlyOpenedAppsRegistry {
   override func getCurrentTimestamp() -> Int64 {
-    return Int64((Date().timeIntervalSince1970 - (60 * 60 * 24 * 3) - 1) * 1000); // 3 days and 1 second ago
+    return Int64((Date().timeIntervalSince1970 - (60 * 60 * 24 * 3) - 1) * 1_000); // 3 days and 1 second ago
   }
 }
 

--- a/packages/expo-dev-launcher/ios/Tests/EXDevLauncherTest.swift
+++ b/packages/expo-dev-launcher/ios/Tests/EXDevLauncherTest.swift
@@ -7,11 +7,11 @@ class EXDevLauncherTest: QuickSpec {
   override func spec() {
     it("exported constants should contain correct fields") {
       let module = EXDevLauncher()
-      
+
       let exportedConstants = module.constantsToExport()!
-      
+
       expect(exportedConstants["manifestString"]).toNot(beNil())
-      expect(exportedConstants["manifestURL"]).toNot(beNil())      
+      expect(exportedConstants["manifestURL"]).toNot(beNil())
     }
   }
 }

--- a/packages/expo-dev-launcher/ios/Tests/EXDevLauncherURLHelperTests.swift
+++ b/packages/expo-dev-launcher/ios/Tests/EXDevLauncherURLHelperTests.swift
@@ -14,7 +14,7 @@ class EXDevLauncherURLHelperTests: XCTestCase {
   func testReplaceEXPScheme() {
     let actual = EXDevLauncherURLHelper.replaceEXPScheme(URL(string: "exp://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8081")!, to: "scheme")
     XCTAssertEqual(URL(string: "scheme://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8081"), actual)
-    
+
     let actual = EXDevLauncherURLHelper.replaceEXPScheme(URL(string: "http://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8081")!, to: "scheme")
     XCTAssertEqual(URL(string: "http://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8081"), actual)
   }

--- a/packages/expo-dev-menu-interface/ios/DevMenuBridgeProtocol.swift
+++ b/packages/expo-dev-menu-interface/ios/DevMenuBridgeProtocol.swift
@@ -11,5 +11,5 @@ public protocol DevMenuBridgeProtocol {
   optional func modulesConforming(toProtocol: Protocol) -> [AnyObject]
 
   @objc
-  optional func requestReload() -> Void
+  optional func requestReload()
 }

--- a/packages/expo-dev-menu-interface/ios/DevMenuDelegateProtocol.swift
+++ b/packages/expo-dev-menu-interface/ios/DevMenuDelegateProtocol.swift
@@ -15,7 +15,7 @@ public protocol DevMenuDelegateProtocol {
    Returns a dictionary with the most important informations about the current app.
    */
   @objc
-  optional func appInfo(forDevMenuManager manager: DevMenuManagerProtocol) -> [String : Any]?
+  optional func appInfo(forDevMenuManager manager: DevMenuManagerProtocol) -> [String: Any]?
 
   /**
    Tells the manager whether it can change dev menu visibility. In some circumstances you may want not to show/close the dev menu. (Optional)
@@ -42,7 +42,7 @@ public protocol DevMenuDelegateProtocol {
   @available(iOS 12.0, *)
   @objc
   optional func userInterfaceStyle(forDevMenuManager manager: DevMenuManagerProtocol) -> UIUserInterfaceStyle
-  
+
   @objc
   optional func supportsDevelopment() -> Bool
 }

--- a/packages/expo-dev-menu-interface/ios/DevMenuExtensionProtocol.swift
+++ b/packages/expo-dev-menu-interface/ios/DevMenuExtensionProtocol.swift
@@ -17,7 +17,7 @@ public protocol DevMenuExtensionProtocol {
    This function is optional because otherwise we end up with linker warning:
    `method '+moduleName' in category from /.../expo-dev-menu/libexpo-dev-menu.a(DevMenuExtensions-....o)
    overrides method from class in /.../expo-dev-menu/libexpo-dev-menu.a(DevMenuExtensions-....o`
-   
+
    So we assume that this method will be implemented by `RCTBridgeModule`.
    In theory we can remove it. However, we leave it  to get easy access to the module name.
    */
@@ -30,11 +30,10 @@ public protocol DevMenuExtensionProtocol {
    */
   @objc
   optional func devMenuItems(_ settings: DevMenuExtensionSettingsProtocol) -> DevMenuItemsContainerProtocol?
-  
+
   @objc
   optional func devMenuScreens(_ settings: DevMenuExtensionSettingsProtocol) -> [DevMenuScreen]?
-  
+
   @objc
   optional func devMenuDataSources(_ settings: DevMenuExtensionSettingsProtocol) -> [DevMenuDataSourceProtocol]?
 }
- 

--- a/packages/expo-dev-menu-interface/ios/DevMenuManagerProtocol.swift
+++ b/packages/expo-dev-menu-interface/ios/DevMenuManagerProtocol.swift
@@ -9,42 +9,42 @@ public protocol DevMenuManagerProtocol {
    */
   @objc
   var isVisible: Bool { get }
-  
+
   @objc
   var delegate: DevMenuDelegateProtocol? { get set }
-  
+
   /**
    Opens up the dev menu.
    */
   @objc
   @discardableResult
   func openMenu(_ screen: String?) -> Bool
-  
+
   @objc
   @discardableResult
   func openMenu() -> Bool
-  
+
   /**
    Sends an event to JS to start collapsing the dev menu bottom sheet.
    */
   @objc
   @discardableResult
   func closeMenu() -> Bool
-  
+
   /**
    Forces the dev menu to hide. Called by JS once collapsing the bottom sheet finishes.
    */
   @objc
   @discardableResult
   func hideMenu() -> Bool
-  
+
   /**
    Toggles the visibility of the dev menu.
    */
   @objc
   @discardableResult
   func toggleMenu() -> Bool
-  
+
   @objc
   var expoApiClient: DevMenuExpoApiClientProtocol { get }
 }

--- a/packages/expo-dev-menu-interface/ios/DevMenuManagerProviderProtocol.swift
+++ b/packages/expo-dev-menu-interface/ios/DevMenuManagerProviderProtocol.swift
@@ -4,8 +4,6 @@ import Foundation
 
 @objc
 public protocol DevMenuManagerProviderProtocol {
-  
   @objc
   func getDevMenuManager() -> DevMenuManagerProtocol
-
 }

--- a/packages/expo-dev-menu-interface/ios/DevMenuUIResponderExtensionProtocol.swift
+++ b/packages/expo-dev-menu-interface/ios/DevMenuUIResponderExtensionProtocol.swift
@@ -5,8 +5,6 @@ import UIKit
 
 @objc
 public protocol DevMenuUIResponderExtensionProtocol {
-  
   @objc
   func EXDevMenu_handleKeyCommand(_ key: UIKeyCommand)
-
 }

--- a/packages/expo-dev-menu-interface/ios/ExpoApiClient/DevMenuEASUpdates.swift
+++ b/packages/expo-dev-menu-interface/ios/ExpoApiClient/DevMenuEASUpdates.swift
@@ -5,18 +5,18 @@ import Foundation
 @objc
 public protocol DevMenuConstructibleFromDictionary {
   @objc
-  init(dictionary: [String : Any])
+  init(dictionary: [String: Any])
 }
 
 public struct DevMenuEASUpdates {
   @objc
-  public class Channel : NSObject, DevMenuConstructibleFromDictionary {
+  public class Channel: NSObject, DevMenuConstructibleFromDictionary {
     public let id: String
     public let name: String
     public let createdAt: String
     public let updatedAt: String
-    
-    required public init(dictionary: [String : Any]) {
+
+    required public init(dictionary: [String: Any]) {
       id = dictionary["id"] as! String
       name = dictionary["name"] as! String
       createdAt = dictionary["createdAt"] as! String
@@ -25,27 +25,27 @@ public struct DevMenuEASUpdates {
   }
 
   @objc
-  public class Branch : NSObject, DevMenuConstructibleFromDictionary {
+  public class Branch: NSObject, DevMenuConstructibleFromDictionary {
     public let id: String
     public let updates: [Update]
-    
-    required public init(dictionary: [String : Any]) {
+
+    required public init(dictionary: [String: Any]) {
       id = dictionary["id"] as! String
-      let updatesData = dictionary["updates"] as? [[String : Any]] ?? []
+      let updatesData = dictionary["updates"] as? [[String: Any]] ?? []
       updates = updatesData.map { Update(dictionary: $0) }
     }
   }
 
   @objc
-  public class Update : NSObject, DevMenuConstructibleFromDictionary {
+  public class Update: NSObject, DevMenuConstructibleFromDictionary {
     public let id: String
     public let message: String
     public let platform: String
     public let runtimeVersion: String
     public let createdAt: String
     public let updatedAt: String
-    
-    required public init(dictionary: [String : Any]) {
+
+    required public init(dictionary: [String: Any]) {
       id = dictionary["id"] as! String
       message = dictionary["message"] as! String
       platform = dictionary["platform"] as! String

--- a/packages/expo-dev-menu-interface/ios/ExpoApiClient/DevMenuExpoApiClientProtocol.swift
+++ b/packages/expo-dev-menu-interface/ios/ExpoApiClient/DevMenuExpoApiClientProtocol.swift
@@ -10,13 +10,13 @@ public class DevMenuGraphQLOptions: NSObject {
   public let limit: Int
   @objc
   public let offset: Int
-  
+
   @objc
   public init(withLimit limit: Int = 10, withOffset offset: Int = 0) {
     self.limit = limit
     self.offset = offset
   }
-  
+
   @objc
   public convenience init(withOffset offset: Int) {
     self.init(withLimit: 10, withOffset: offset)
@@ -27,20 +27,20 @@ public class DevMenuGraphQLOptions: NSObject {
 public protocol DevMenuExpoApiClientProtocol {
   @objc
   func isLoggedIn() -> Bool
-  
+
   @objc
   func setSessionSecret(_ sessionSecret: String?)
-  
+
   @objc
   func queryDevSessionsAsync(_ installationID: String?, completionHandler: @escaping HTTPCompletionHandler)
-  
+
   @objc
   func queryUpdateChannels(
     appId: String,
     completionHandler: @escaping ([DevMenuEASUpdates.Channel]?, URLResponse?, Error?) -> Void,
     options: DevMenuGraphQLOptions
   )
-  
+
   @objc
   func queryUpdateBranches(
     appId: String,
@@ -57,7 +57,7 @@ public extension DevMenuExpoApiClientProtocol {
   ) {
     queryUpdateChannels(appId: appId, completionHandler: completionHandler, options: DevMenuGraphQLOptions())
   }
-  
+
   func queryUpdateBranches(
     appId: String,
     completionHandler: @escaping ([DevMenuEASUpdates.Branch]?, URLResponse?, Error?) -> Void

--- a/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuAction.swift
+++ b/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuAction.swift
@@ -7,13 +7,13 @@ import UIKit
 open class DevMenuAction: DevMenuScreenItem, DevMenuCallableProvider {
   @objc
   public var callable: DevMenuExportedAction
-  
+
   @objc
   public var action: () -> Void {
     get { return self.callable.action }
     set { self.callable.action = newValue }
   }
-  
+
   @objc
   open var isAvailable: () -> Bool {
     get {
@@ -23,7 +23,7 @@ open class DevMenuAction: DevMenuScreenItem, DevMenuCallableProvider {
       self.callable.isAvailable = newValue
     }
   }
-  
+
   @objc
   open var isEnabled: () -> Bool = { false }
 
@@ -43,16 +43,16 @@ open class DevMenuAction: DevMenuScreenItem, DevMenuCallableProvider {
   }
 
   @objc
-  public convenience init(withId id: String, action: @escaping () -> ()) {
+  public convenience init(withId id: String, action: @escaping () -> Void) {
     self.init(withId: id)
     self.callable.action = action
   }
-  
+
   @objc
-  public convenience init(withId id: String, _ action: @escaping () -> ()) {
+  public convenience init(withId id: String, _ action: @escaping () -> Void) {
     self.init(withId: id, action: action)
   }
-  
+
   public func registerCallable() -> DevMenuExportedCallable? {
     return self.callable
   }
@@ -61,16 +61,16 @@ open class DevMenuAction: DevMenuScreenItem, DevMenuCallableProvider {
   open func registerKeyCommand(input: String, modifiers: UIKeyModifierFlags) {
     self.callable.registerKeyCommand(input: input, modifiers: modifiers)
   }
-  
+
   @objc
-  open override func serialize() -> [String : Any] {
+  open override func serialize() -> [String: Any] {
     var dict = super.serialize()
     dict["actionId"] = self.callable.id
     dict["keyCommand"] = self.callable.keyCommand == nil ? nil : [
       "input": self.callable.keyCommand!.input!,
       "modifiers": exportKeyCommandModifiers()
     ]
-    
+
     dict["isAvailable"] = isAvailable()
     dict["isEnabled"] = isAvailable()
     dict["label"] = label()
@@ -79,27 +79,27 @@ open class DevMenuAction: DevMenuScreenItem, DevMenuCallableProvider {
 
     return dict
   }
-  
+
   private func exportKeyCommandModifiers() -> Int {
-    var exportedValue = 0;
+    var exportedValue = 0
     let keyCommand = self.callable.keyCommand!
-    
+
     if keyCommand.modifierFlags.contains(.control) {
-      exportedValue += 1 << 0;
+      exportedValue += 1 << 0
     }
-    
+
     if keyCommand.modifierFlags.contains(.alternate) {
-      exportedValue += 1 << 1;
+      exportedValue += 1 << 1
     }
-    
+
     if keyCommand.modifierFlags.contains(.command) {
-      exportedValue += 1 << 2;
+      exportedValue += 1 << 2
     }
-    
+
     if keyCommand.modifierFlags.contains(.shift) {
-      exportedValue += 1 << 3;
+      exportedValue += 1 << 3
     }
-  
+
     return exportedValue
   }
 }

--- a/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuDataSource.swift
+++ b/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuDataSource.swift
@@ -5,7 +5,7 @@ import Foundation
 @objc
 public protocol DevMenuDataSourceItem {
   @objc
-  func serialize() -> [String : Any]
+  func serialize() -> [String: Any]
 }
 
 public typealias DevMenuDataSourceResolver = ([DevMenuDataSourceItem]) -> Void
@@ -13,7 +13,7 @@ public typealias DevMenuDataSourceResolver = ([DevMenuDataSourceItem]) -> Void
 @objc
 public protocol DevMenuDataSourceProtocol {
   var id: String { get }
-  
+
   func fetchData(resolve: @escaping DevMenuDataSourceResolver)
 }
 
@@ -21,12 +21,12 @@ public protocol DevMenuDataSourceProtocol {
 public class DevMenuListDataSource: NSObject, DevMenuDataSourceProtocol {
   public var id: String
   private var dataFetcher: (@escaping ([DevMenuSelectionList.Item]) -> Void) -> Void
-  
+
   public init(id: String, dataFetcher: @escaping (@escaping ([DevMenuSelectionList.Item]) -> Void) -> Void) {
     self.id = id
     self.dataFetcher = dataFetcher
   }
-  
+
   public func fetchData(resolve: @escaping ([DevMenuDataSourceItem]) -> Void) {
     dataFetcher(resolve)
   }

--- a/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuExportedCallable.swift
+++ b/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuExportedCallable.swift
@@ -13,7 +13,7 @@ public protocol DevMenuCallableProvider {
 public class DevMenuExportedCallable: NSObject {
   @objc
   public let id: String
-  
+
   @objc
   init(withId id: String) {
     self.id = id
@@ -23,15 +23,15 @@ public class DevMenuExportedCallable: NSObject {
 @objc
 public class DevMenuExportedFunction: DevMenuExportedCallable {
   @objc
-  public var function: ([String : Any]?) -> Void
-  
+  public var function: ([String: Any]?) -> Void
+
   @objc
-  public init(withId id: String, withFunction function: @escaping ([String : Any]?) -> Void) {
+  public init(withId id: String, withFunction function: @escaping ([String: Any]?) -> Void) {
     self.function = function
     super.init(withId: id)
   }
-  
-  public func call(args: [String : Any]?) {
+
+  public func call(args: [String: Any]?) {
     function(args)
   }
 }
@@ -40,23 +40,23 @@ public class DevMenuExportedFunction: DevMenuExportedCallable {
 public class DevMenuExportedAction: DevMenuExportedCallable {
   @objc
   public var action: () -> Void
-  
+
   @objc
-  public private(set) var keyCommand: UIKeyCommand? = nil
-  
+  public private(set) var keyCommand: UIKeyCommand?
+
   @objc
   public var isAvailable: () -> Bool = { true }
-  
+
   @objc
   public init(withId id: String, withAction action: @escaping  () -> Void) {
     self.action = action
     super.init(withId: id)
   }
-  
+
   public func call() {
     action()
   }
-  
+
   @objc
   public func registerKeyCommand(input: String, modifiers: UIKeyModifierFlags) {
     keyCommand = UIKeyCommand(input: input, modifierFlags: modifiers, action: #selector(DevMenuUIResponderExtensionProtocol.EXDevMenu_handleKeyCommand(_:)))

--- a/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuGroup.swift
+++ b/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuGroup.swift
@@ -5,7 +5,7 @@ import Foundation
 @objc
 open class DevMenuGroup: DevMenuScreenItem, DevMenuItemsContainerProtocol {
   let container = DevMenuItemsContainer()
-  
+
   @objc
   public init() {
     super.init(type: .Group)
@@ -15,21 +15,21 @@ open class DevMenuGroup: DevMenuScreenItem, DevMenuItemsContainerProtocol {
   public func addItem(_ item: DevMenuScreenItem) {
     container.addItem(item)
   }
-  
+
   public func getRootItems() -> [DevMenuScreenItem] {
     return container.getRootItems()
   }
-  
+
   public func getAllItems() -> [DevMenuScreenItem] {
     return container.getAllItems()
   }
-  
-  public func serializeItems() -> [[String : Any]] {
+
+  public func serializeItems() -> [[String: Any]] {
     return container.serializeItems()
   }
 
   @objc
-  public override func serialize() -> [String : Any] {
+  public override func serialize() -> [String: Any] {
     var dict = super.serialize()
     dict["items"] = serializeItems()
     return dict

--- a/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuItem.swift
+++ b/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuItem.swift
@@ -21,9 +21,9 @@ open class DevMenuItem: NSObject {
   }
 
   @objc
-  open func serialize() -> [String : Any] {
+  open func serialize() -> [String: Any] {
     return [
-      "type": type.rawValue,
+      "type": type.rawValue
     ]
   }
 }

--- a/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuItemsContainer.swift
+++ b/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuItemsContainer.swift
@@ -5,11 +5,11 @@ import Foundation
 @objc
 public class DevMenuItemsContainer: NSObject, DevMenuItemsContainerProtocol {
   private var items: [DevMenuScreenItem] = []
-  
+
   public func getRootItems() -> [DevMenuScreenItem] {
     return items.sorted { $0.importance > $1.importance }
   }
-  
+
   public func getAllItems() -> [DevMenuScreenItem] {
     var result: [DevMenuScreenItem] = []
     for item in items {
@@ -20,13 +20,13 @@ public class DevMenuItemsContainer: NSObject, DevMenuItemsContainerProtocol {
     }
     return result.sorted { $0.importance > $1.importance }
   }
-  
+
   @objc
   public func addItem(_ item: DevMenuScreenItem) {
     items.append(item)
   }
-  
-  func serializeItems() -> [[String : Any]] {
+
+  func serializeItems() -> [[String: Any]] {
     return getRootItems().map({ $0.serialize() })
   }
 }

--- a/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuItemsContainerProtocol.swift
+++ b/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuItemsContainerProtocol.swift
@@ -6,7 +6,7 @@ import Foundation
 public protocol DevMenuItemsContainerProtocol {
   @objc
   func getRootItems() -> [DevMenuScreenItem]
-  
+
   @objc
   func getAllItems() -> [DevMenuScreenItem]
 }

--- a/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuLink.swift
+++ b/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuLink.swift
@@ -5,7 +5,7 @@ import Foundation
 @objc
 public class DevMenuLink: DevMenuScreenItem {
   var target: String
-  
+
   @objc
   open var label: () -> String = { "" }
 
@@ -16,9 +16,9 @@ public class DevMenuLink: DevMenuScreenItem {
     self.target = target
     super.init(type: .Link)
   }
-  
+
   @objc
-  open override func serialize() -> [String : Any] {
+  open override func serialize() -> [String: Any] {
     var dict = super.serialize()
     dict["target"] = target
     dict["label"] = label()

--- a/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuScreen.swift
+++ b/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuScreen.swift
@@ -3,32 +3,32 @@
 import Foundation
 
 @objc
-public class DevMenuScreen : DevMenuItem, DevMenuItemsContainerProtocol {
+public class DevMenuScreen: DevMenuItem, DevMenuItemsContainerProtocol {
   let container = DevMenuItemsContainer()
   public private(set) var screenName: String
-  
+
   public func getRootItems() -> [DevMenuScreenItem] {
     return container.getRootItems()
   }
-  
+
   public func getAllItems() -> [DevMenuScreenItem] {
     return container.getAllItems()
   }
-  
+
   public func addItem(_ item: DevMenuScreenItem) {
     container.addItem(item)
   }
-  
-  func serializeItems() -> [[String : Any]] {
+
+  func serializeItems() -> [[String: Any]] {
     return container.serializeItems()
   }
-  
+
   public init(_ screenName: String) {
     self.screenName = screenName
     super.init(type: .Screen)
   }
-  
-  public override func serialize() -> [String : Any] {
+
+  public override func serialize() -> [String: Any] {
     var dict = super.serialize()
     dict["screenName"] = screenName
     dict["items"] = serializeItems()

--- a/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuSelectionList.swift
+++ b/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuSelectionList.swift
@@ -7,37 +7,37 @@ public class DevMenuSelectionList: DevMenuScreenItem, DevMenuCallableProvider {
   @objc
   public class Item: NSObject, DevMenuDataSourceItem {
     @objc
-    public class Tag : NSObject {
+    public class Tag: NSObject {
       @objc
       public var text: () -> String = { "" }
 
       @objc
       public var glyphName: () -> String? = { nil }
-      
-      fileprivate func serialize() -> [String : Any] {
+
+      fileprivate func serialize() -> [String: Any] {
         return [
           "text": text(),
-          "glyphName": glyphName() ?? NSNull(),
+          "glyphName": glyphName() ?? NSNull()
         ]
       }
     }
-    
+
     @objc
-    public var onClickData: () -> [String : Any]? =  { nil }
-    
+    public var onClickData: () -> [String: Any]? = { nil }
+
     @objc
     public var title: () -> String = { "" }
 
     @objc
     public var warning: () -> String? = { nil }
-    
+
     @objc
     public var isChecked: () -> Bool = { false }
-    
+
     @objc
     public var tags: () -> [Tag] = { [] }
-    
-    public func serialize() -> [String : Any] {
+
+    public func serialize() -> [String: Any] {
       return [
         "title": title(),
         "warning": warning() ?? NSNull(),
@@ -47,22 +47,22 @@ public class DevMenuSelectionList: DevMenuScreenItem, DevMenuCallableProvider {
       ]
     }
   }
-  
+
   public static var ActionID = 1
   private let callable: DevMenuExportedFunction
   private var items: [Item] = []
   private let dataSourceId: String?
-  
+
   @objc
   public func addItem(_ item: Item) {
     items.append(item)
   }
-  
+
   @objc
   public convenience init() {
     self.init(dataSourceId: nil)
   }
-  
+
   @objc
   public init(dataSourceId: String?) {
     self.dataSourceId = dataSourceId
@@ -70,21 +70,21 @@ public class DevMenuSelectionList: DevMenuScreenItem, DevMenuCallableProvider {
     DevMenuSelectionList.ActionID += 1
     super.init(type: .SelectionList)
   }
-  
+
   @objc
-  public override func serialize() -> [String : Any] {
+  public override func serialize() -> [String: Any] {
     var dict = super.serialize()
     dict["items"] = items.map { $0.serialize() }
     dict["dataSourceId"] = dataSourceId ?? NSNull()
     dict["actionId"] = self.callable.id
     return dict
   }
-  
+
   @objc
   public func addOnClick(hander: @escaping ([String: Any]?) -> Void) {
     self.callable.function = hander
   }
-  
+
   public func registerCallable() -> DevMenuExportedCallable? {
     return self.callable
   }

--- a/packages/expo-dev-menu-interface/ios/Tests/DevMenuActionTest.swift
+++ b/packages/expo-dev-menu-interface/ios/Tests/DevMenuActionTest.swift
@@ -13,9 +13,9 @@ class DevMenuActionTest: QuickSpec {
       action.detail = { "action-1-details" }
       action.glyphName = { "action-1-glyphname" }
       action.registerKeyCommand(input: "r", modifiers: .command)
-      
+
       let serilizedData = action.serialize()
-      
+
       expect(serilizedData["type"] as? Int).to(equal(ItemType.action.rawValue))
       expect(serilizedData["actionId"] as? String).to(equal("action-1"))
       expect(serilizedData["isAvailable"] as? Bool).to(beTrue())
@@ -23,19 +23,19 @@ class DevMenuActionTest: QuickSpec {
       expect(serilizedData["label"] as? String).to(equal("action-1-label"))
       expect(serilizedData["detail"] as? String).to(equal("action-1-details"))
       expect(serilizedData["glyphName"] as? String).to(equal("action-1-glyphname"))
-      
+
       let keyCommand = serilizedData["keyCommand"] as! [String: Any]
-      
+
       expect(keyCommand["input"] as? String).to(equal("r"))
       expect(keyCommand["modifiers"] as? Int).to(equal(1 << 2))
     }
-    
+
     it("Action callable should be contain passed action") {
       var wasCalled = false
       let action = DevMenuAction(withId: "action-1", { wasCalled = true })
-      
+
       action.callable.call()
-      
+
       expect(wasCalled).to(beTrue())
     }
   }

--- a/packages/expo-dev-menu-interface/ios/Tests/DevMenuEASUpdatesTest.swift
+++ b/packages/expo-dev-menu-interface/ios/Tests/DevMenuEASUpdatesTest.swift
@@ -12,15 +12,15 @@ class DevMenuEASUpdatesTest: QuickSpec {
         "createdAt": "1635508863",
         "updatedAt": "1635508873"
       ]
-      
+
       let channel = DevMenuEASUpdates.Channel(dictionary: seeder)
-      
+
       expect(channel.id).to(equal("1234"))
       expect(channel.name).to(equal("channel-1"))
       expect(channel.createdAt).to(equal("1635508863"))
       expect(channel.updatedAt).to(equal("1635508873"))
     }
-    
+
     it("Update constructor should populate all fields") {
       let seeder = [
         "id": "1234",
@@ -30,9 +30,9 @@ class DevMenuEASUpdatesTest: QuickSpec {
         "createdAt": "1635508863",
         "updatedAt": "1635508873"
       ]
-      
+
       let update = DevMenuEASUpdates.Update(dictionary: seeder)
-      
+
       expect(update.id).to(equal("1234"))
       expect(update.message).to(equal("update-1"))
       expect(update.platform).to(equal("ios"))
@@ -40,7 +40,7 @@ class DevMenuEASUpdatesTest: QuickSpec {
       expect(update.createdAt).to(equal("1635508863"))
       expect(update.updatedAt).to(equal("1635508873"))
     }
-    
+
     it("Branch constructor should populate all fields") {
       let seeder = [
         "id": "1",
@@ -62,12 +62,12 @@ class DevMenuEASUpdatesTest: QuickSpec {
             "updatedAt": "1635508873"
           ]
         ]
-      ] as [String : Any]
-      
+      ] as [String: Any]
+
       let branch = DevMenuEASUpdates.Branch(dictionary: seeder)
       let update1 = branch.updates[0]
       let update2 = branch.updates[1]
-      
+
       expect(branch.id).to(equal("1"))
       expect(update1.id).to(equal("1234"))
       expect(update1.message).to(equal("update-1"))

--- a/packages/expo-dev-menu-interface/ios/Tests/DevMenuItemsContainerTest.swift
+++ b/packages/expo-dev-menu-interface/ios/Tests/DevMenuItemsContainerTest.swift
@@ -7,54 +7,54 @@ class DevMenuItemsContainerTest: QuickSpec {
   override func spec() {
     it("should respect importance") {
       let container = DevMenuItemsContainer()
-      
+
       let seeder = [("action-1", ItemImportance.lowest), ("action-2", ItemImportance.medium), ("action-3", ItemImportance.highest)]
-      
+
       seeder.forEach { actionDate in
         let action = DevMenuAction(withId: actionDate.0)
         action.label = { actionDate.0 }
         action.importance = actionDate.1.rawValue
-        
+
         container.addItem(action)
       }
       let items = container.getRootItems()
-      
+
       expect(items.count).to(equal(3))
       expect((items[0] as! DevMenuAction).label()).to(equal("action-3"))
       expect((items[1] as! DevMenuAction).label()).to(equal("action-2"))
       expect((items[2] as! DevMenuAction).label()).to(equal("action-1"))
     }
-   
+
     it("should unwrap other containers") {
       let container = DevMenuItemsContainer()
       container.addItem(DevMenuAction(withId: "action-1"))
       let innerContainer = DevMenuGroup()
       innerContainer.addItem(DevMenuAction(withId: "action-2"))
       container.addItem(innerContainer)
-      
+
       let items = container.getAllItems()
-      
+
       expect(items.count).to(equal(3))
       expect(items[0] as? DevMenuAction).toNot(beNil())
       expect(items[1] as? DevMenuGroup).toNot(beNil())
       expect(items[2] as? DevMenuAction).toNot(beNil())
     }
-    
+
     it("should serilize items") {
       let container = DevMenuItemsContainer()
       container.addItem(DevMenuAction(withId: "action-1"))
       let innerContainer = DevMenuGroup()
       innerContainer.addItem(DevMenuAction(withId: "action-2"))
       container.addItem(innerContainer)
-       
+
       let items = container.serializeItems()
-       
+
       expect(items.count).to(equal(2))
       expect(items[0]["type"] as? Int).to(equal(ItemType.action.rawValue))
       expect(items[0]["actionId"] as? String).to(equal("action-1"))
-      
+
       expect(items[1]["type"] as? Int).to(equal(ItemType.group.rawValue))
-      
+
       let innerItem = (items[1]["items"] as! [[String: Any]])[0]
       expect(innerItem["type"] as? Int).to(equal(ItemType.action.rawValue))
       expect(innerItem["actionId"] as? String).to(equal("action-2"))

--- a/packages/expo-dev-menu-interface/ios/Tests/DevMenuLinkTest.swift
+++ b/packages/expo-dev-menu-interface/ios/Tests/DevMenuLinkTest.swift
@@ -9,9 +9,9 @@ class DevMenuLinkTest: QuickSpec {
       let link = DevMenuLink(withTarget: "target-1")
       link.glyphName = { "link-1-glyph" }
       link.label = { "link-1-label" }
-      
+
       let serilizedData = link.serialize()
-      
+
       expect(serilizedData["type"] as? Int).to(equal(ItemType.link.rawValue))
       expect(serilizedData["label"] as? String).to(equal("link-1-label"))
       expect(serilizedData["glyphName"] as? String).to(equal("link-1-glyph"))

--- a/packages/expo-dev-menu-interface/ios/Tests/DevMenuScreenTest.swift
+++ b/packages/expo-dev-menu-interface/ios/Tests/DevMenuScreenTest.swift
@@ -7,9 +7,9 @@ class DevMenuScreenTest: QuickSpec {
   override func spec() {
     it("Screen should be serializable") {
       let screen = DevMenuScreen("screen-1")
-      
+
       let serilizedData = screen.serialize()
-      
+
       expect(serilizedData["type"] as? Int).to(equal(ItemType.screen.rawValue))
       expect(serilizedData["screenName"] as? String).to(equal("screen-1"))
     }

--- a/packages/expo-dev-menu-interface/ios/Tests/DevMenuSelectionListTest.swift
+++ b/packages/expo-dev-menu-interface/ios/Tests/DevMenuSelectionListTest.swift
@@ -7,9 +7,9 @@ class DevMenuSelectionListTest: QuickSpec {
   override func spec() {
     it("List should be serializable") {
       let list = DevMenuSelectionList()
-      
+
       let serilizedData = list.serialize()
-      
+
       expect(serilizedData["type"] as? Int).to(equal(ItemType.selectionList.rawValue))
       expect(serilizedData["actionId"] as? String).toNot(beNil())
     }

--- a/packages/expo-dev-menu/ios/DevMenuAppInstance.swift
+++ b/packages/expo-dev-menu/ios/DevMenuAppInstance.swift
@@ -16,7 +16,7 @@ class DevMenuAppInstance: DevMenuBaseAppInstance, RCTBridgeDelegate {
     self.bridge = DevMenuRCTBridge.init(delegate: self, launchOptions: nil)
     fixChromeDevTools()
   }
-  
+
   init(manager: DevMenuManager, bridge: RCTBridge) {
     self.manager = manager
 

--- a/packages/expo-dev-menu/ios/DevMenuDevOptionsDelegate.swift
+++ b/packages/expo-dev-menu/ios/DevMenuDevOptionsDelegate.swift
@@ -5,64 +5,64 @@ import Foundation
 class DevMenuDevOptionsDelegate {
   internal private(set) weak var bridge: RCTBridge?
   internal private(set) weak var devSettings: RCTDevSettings?
-  
+
   #if DEBUG
   internal private(set) weak var perfMonitor: RCTPerfMonitor?
   #endif
-  
+
   internal init(forBridge bridge: RCTBridge) {
     self.bridge = bridge
     devSettings = bridge.module(forName: "DevSettings") as? RCTDevSettings
-    
+
     #if DEBUG
     perfMonitor = bridge.module(forName: "PerfMonitor") as? RCTPerfMonitor
     #endif
   }
-  
+
   internal func reload() {
     // Without this the `expo-splash-screen` will reject
     // No native splash screen registered for given view controller. Call 'SplashScreen.show' for given view controller first.
-    DevMenuManager.shared.hideMenu();
+    DevMenuManager.shared.hideMenu()
 
     bridge?.requestReload()
   }
-  
+
   internal func toggleElementInsector() {
     devSettings?.toggleElementInspector()
   }
-  
+
   internal func toggleRemoteDebugging() {
     guard let devSettings = devSettings else {
       return
     }
-    
+
     DispatchQueue.main.async {
       devSettings.isDebuggingRemotely = !devSettings.isDebuggingRemotely
     }
   }
-  
+
   internal func togglePerformanceMonitor() {
     #if DEBUG
     guard let perfMonitor = perfMonitor else {
       return
     }
-    
+
     guard let devSettings = devSettings else {
       return
     }
-    
+
     DispatchQueue.main.async {
       devSettings.isPerfMonitorShown ? perfMonitor.hide() : perfMonitor.show()
       devSettings.isPerfMonitorShown = !devSettings.isPerfMonitorShown
     }
     #endif
   }
-  
+
   internal func toggleFastRefresh() {
     guard let devSettings = devSettings else {
       return
     }
-    
+
     devSettings.isHotLoadingEnabled = !devSettings.isHotLoadingEnabled
   }
 }

--- a/packages/expo-dev-menu/ios/DevMenuExpoSessionDelegate.swift
+++ b/packages/expo-dev-menu/ios/DevMenuExpoSessionDelegate.swift
@@ -4,17 +4,17 @@ class DevMenuExpoSessionDelegate {
   private static let sessionKey = "expo-dev-menu.session"
   private static let userLoginEvent = "expo.dev-menu.user-login"
   private static let userLogoutEvent = "expo.dev-menu.user-logout"
-  
+
   private let manager: DevMenuManager
-  
+
   init(manager: DevMenuManager) {
     self.manager = manager
   }
-  
-  func setSessionAsync(_ session: Dictionary<String, Any>?) throws {
-    var sessionSecret: String? = nil
-    
-    if (session != nil) {
+
+  func setSessionAsync(_ session: [String: Any]?) throws {
+    var sessionSecret: String?
+
+    if session != nil {
       guard let castedSessionSecret = session!["sessionSecret"] as? String else {
         throw NSError(
           domain: NSExceptionName.invalidArgumentException.rawValue,
@@ -26,26 +26,26 @@ class DevMenuExpoSessionDelegate {
       }
       sessionSecret = castedSessionSecret
     }
-    
+
     setSesssionSecret(sessionSecret)
     UserDefaults.standard.set(session, forKey: DevMenuExpoSessionDelegate.sessionKey)
   }
-  
+
   @discardableResult
-  func restoreSession() -> Dictionary<String, Any>? {
+  func restoreSession() -> [String: Any]? {
     guard let session = UserDefaults.standard.dictionary(forKey: DevMenuExpoSessionDelegate.sessionKey) else {
-      return nil;
+      return nil
     }
-    
+
     setSesssionSecret(session["sessionSecret"] as? String)
     return session
   }
-  
+
   private func setSesssionSecret(_ sessionSecret: String?) {
     let wasLoggedIn = manager.expoApiClient.isLoggedIn()
     manager.expoApiClient.setSessionSecret(sessionSecret)
     let isLoggedIn = manager.expoApiClient.isLoggedIn()
-    
+
     if !wasLoggedIn && isLoggedIn {
       manager.sendEventToDelegateBridge(DevMenuExpoSessionDelegate.userLoginEvent, data: nil)
     } else if wasLoggedIn && !isLoggedIn {

--- a/packages/expo-dev-menu/ios/DevMenuExtensionDefaultSettings.swift
+++ b/packages/expo-dev-menu/ios/DevMenuExtensionDefaultSettings.swift
@@ -2,22 +2,22 @@
 
 import EXDevMenuInterface
 
-class DevMenuExtensionDefaultSettings : DevMenuExtensionSettingsProtocol {
+class DevMenuExtensionDefaultSettings: DevMenuExtensionSettingsProtocol {
   private let manager: DevMenuManager
 
   init(manager: DevMenuManager) {
     self.manager = manager
   }
-  
+
   func wasRunOnDevelopmentBridge() -> Bool {
-    if (manager.delegate?.supportsDevelopment?() == false) {
+    if manager.delegate?.supportsDevelopment?() == false {
       return false
     }
-    
+
     #if DEBUG
-      return true;
+      return true
     #else
-      return false;
+      return false
     #endif
   }
 }

--- a/packages/expo-dev-menu/ios/DevMenuGestureRecognizer.swift
+++ b/packages/expo-dev-menu/ios/DevMenuGestureRecognizer.swift
@@ -17,7 +17,7 @@ class DevMenuGestureRecognizerDelegate {
       cancelGesture(gestureReconizer)
     }
   }
-  
+
   /**
    Use a trick that cancels a gesture.
   */
@@ -29,7 +29,7 @@ class DevMenuGestureRecognizerDelegate {
 
 class DevMenuGestureRecognizer: UILongPressGestureRecognizer {
   static fileprivate let gestureDelegate = DevMenuGestureRecognizerDelegate()
-  
+
   init() {
     super.init(target: DevMenuGestureRecognizer.gestureDelegate, action: #selector(DevMenuGestureRecognizer.gestureDelegate.handleLongPress(_:)))
 

--- a/packages/expo-dev-menu/ios/DevMenuManager.swift
+++ b/packages/expo-dev-menu/ios/DevMenuManager.swift
@@ -2,15 +2,15 @@
 
 import EXDevMenuInterface
 
-class DevMenuBridgeProxyDelegate : DevMenuDelegateProtocol {
+class DevMenuBridgeProxyDelegate: DevMenuDelegateProtocol {
   private let bridge: RCTBridge
-  
+
   init(_ bridge: RCTBridge) {
     self.bridge = bridge
   }
-  
+
   public func appBridge(forDevMenuManager manager: DevMenuManagerProtocol) -> AnyObject? {
-    return self.bridge;
+    return self.bridge
   }
 }
 
@@ -64,9 +64,9 @@ open class DevMenuManager: NSObject, DevMenuManagerProtocol {
   lazy var expoSessionDelegate: DevMenuExpoSessionDelegate = DevMenuExpoSessionDelegate(manager: self)
   lazy var extensionSettings: DevMenuExtensionSettingsProtocol = DevMenuExtensionDefaultSettings(manager: self)
   var canLaunchDevMenuOnStart = true
-  
+
   public var expoApiClient: DevMenuExpoApiClientProtocol = DevMenuExpoApiClient()
-  
+
   /**
    Shared singleton instance.
    */
@@ -89,7 +89,7 @@ open class DevMenuManager: NSObject, DevMenuManagerProtocol {
   public private(set) var session: DevMenuSession?
 
   var currentScreen: String?
-  
+
   /**
    The delegate of `DevMenuManager` implementing `DevMenuDelegateProtocol`.
    */
@@ -106,7 +106,7 @@ open class DevMenuManager: NSObject, DevMenuManagerProtocol {
       }
     }
   }
-  
+
   @objc
   public static func configure(withBridge bridge: AnyObject) {
     if let bridge = bridge as? RCTBridge {
@@ -119,7 +119,7 @@ open class DevMenuManager: NSObject, DevMenuManagerProtocol {
   @objc
   public func autoLaunch(_ shouldRemoveObserver: Bool = true) {
     NotificationCenter.default.removeObserver(self)
-  
+
     DispatchQueue.main.async {
       self.openMenu()
     }
@@ -151,7 +151,7 @@ open class DevMenuManager: NSObject, DevMenuManagerProtocol {
   public func openMenu(_ screen: String? = nil) -> Bool {
     return setVisibility(true, screen: screen)
   }
-  
+
   @objc
   @discardableResult
   public func openMenu() -> Bool {
@@ -164,11 +164,11 @@ open class DevMenuManager: NSObject, DevMenuManagerProtocol {
   @objc
   @discardableResult
   public func closeMenu() -> Bool {
-    if (isVisible) {
+    if isVisible {
       appInstance.sendCloseEvent()
       return true
     }
-    
+
     return false
   }
 
@@ -189,30 +189,30 @@ open class DevMenuManager: NSObject, DevMenuManagerProtocol {
   public func toggleMenu() -> Bool {
     return isVisible ? closeMenu() : openMenu()
   }
-  
+
   @objc
   public func setCurrentScreen(_ screenName: String?) {
     currentScreen = screenName
   }
-  
+
   @objc
   public func sendEventToDelegateBridge(_ eventName: String, data: Any?) {
     guard let bridge = delegate?.appBridge?(forDevMenuManager: self) as? RCTBridge else {
-      return;
+      return
     }
-    
-    let args = data == nil ? [eventName] : [eventName, data!];
+
+    let args = data == nil ? [eventName] : [eventName, data!]
     bridge.enqueueJSCall("RCTDeviceEventEmitter.emit", args: args)
   }
 
   // MARK: internals
 
-  func dispatchCallable(withId id: String, args: [String : Any]?) {
+  func dispatchCallable(withId id: String, args: [String: Any]?) {
     for callable in devMenuCallable {
       if callable.id == id {
         switch callable {
           case let action as DevMenuExportedAction:
-            if (args != nil) {
+            if args != nil {
               NSLog("[DevMenu] Action $@ was called with arguments.", id)
             }
             action.call()
@@ -221,7 +221,6 @@ open class DevMenuManager: NSObject, DevMenuManagerProtocol {
           default:
             NSLog("[DevMenu] Callable $@ has unknown type.", id)
         }
-        
       }
     }
   }
@@ -241,7 +240,7 @@ open class DevMenuManager: NSObject, DevMenuManagerProtocol {
         .map { type(of: $0).moduleName!() }
         .compactMap { $0 } // removes nils
     ).sorted()
-    
+
     return uniqueExtensionNames
       .map({ bridge.module(forName: DevMenuUtils.stripRCT($0)) })
       .filter({ $0 is DevMenuExtensionProtocol }) as? [DevMenuExtensionProtocol]
@@ -253,28 +252,28 @@ open class DevMenuManager: NSObject, DevMenuManagerProtocol {
   var devMenuItems: [DevMenuScreenItem] {
     return extensions?.map { loadDevMenuItems(forExtension: $0)?.getAllItems() ?? [] }.flatMap { $0 } ?? []
   }
-  
+
   /**
    Gathers root `DevMenuItem`s (elements on the main screen) from all dev menu extensions and returns them as an array.
    */
   var devMenuRootItems: [DevMenuScreenItem] {
     return extensions?.map { loadDevMenuItems(forExtension: $0)?.getRootItems() ?? [] }.flatMap { $0 } ?? []
   }
-  
+
   /**
    Gathers `DevMenuScreen`s from all dev menu extensions and returns them as an array.
    */
   var devMenuScreens: [DevMenuScreen] {
-    return extensions?.map { loadDevMenuScreens(forExtension: $0) ?? [] }.flatMap {$0} ?? []
+    return extensions?.map { loadDevMenuScreens(forExtension: $0) ?? [] }.flatMap { $0 } ?? []
   }
-  
+
   /**
    Gathers `DevMenuDataSourceProtocol`s from all dev menu extensions and returns them as an array.
    */
   var devMenuDataSources: [DevMenuDataSourceProtocol] {
-    return extensions?.map { loadDevMenuDataSources(forExtension: $0) ?? [] }.flatMap {$0} ?? []
+    return extensions?.map { loadDevMenuDataSources(forExtension: $0) ?? [] }.flatMap { $0 } ?? []
   }
-  
+
   /**
    Returns an array of `DevMenuExportedCallable`s returned by the dev menu extensions.
    */
@@ -282,7 +281,7 @@ open class DevMenuManager: NSObject, DevMenuManagerProtocol {
     let providers = currentScreen == nil ?
       devMenuItems.filter { $0 is DevMenuCallableProvider } :
       (devMenuScreens.first { $0.screenName == currentScreen }?.getAllItems() ?? []).filter { $0 is DevMenuCallableProvider }
-    
+
     // We use compactMap here to remove nils
     return (providers as! [DevMenuCallableProvider]).compactMap { $0.registerCallable?() }
   }
@@ -290,16 +289,16 @@ open class DevMenuManager: NSObject, DevMenuManagerProtocol {
   /**
    Returns an array of dev menu items serialized to the dictionary.
    */
-  func serializedDevMenuItems() -> [[String : Any]] {
+  func serializedDevMenuItems() -> [[String: Any]] {
     return devMenuRootItems
       .sorted(by: { $0.importance > $1.importance })
       .map({ $0.serialize() })
   }
-  
+
   /**
    Returns an array of dev menu screens serialized to the dictionary.
    */
-  func serializedDevMenuScreens() -> [[String : Any]] {
+  func serializedDevMenuScreens() -> [[String: Any]] {
     return devMenuScreens
       .map({ $0.serialize() })
   }
@@ -326,7 +325,7 @@ open class DevMenuManager: NSObject, DevMenuManagerProtocol {
 
   func readAutoLaunchDisabledState() {
     let userDefaultsValue = UserDefaults.standard.bool(forKey: "EXDevMenuDisableAutoLaunch")
-    if (userDefaultsValue) {
+    if userDefaultsValue {
       self.canLaunchDevMenuOnStart = false
       UserDefaults.standard.removeObject(forKey: "EXDevMenuDisableAutoLaunch")
     } else {
@@ -345,40 +344,40 @@ open class DevMenuManager: NSObject, DevMenuManagerProtocol {
     if let itemsContainer = extensionToDevMenuItemsMap.object(forKey: ext) {
       return itemsContainer
     }
-    
+
     if let itemsContainer = ext.devMenuItems?(extensionSettings) {
       extensionToDevMenuItemsMap.setObject(itemsContainer, forKey: ext)
       return itemsContainer
     }
-    
+
     return nil
   }
-  
+
   private func loadDevMenuScreens(forExtension ext: DevMenuExtensionProtocol) -> [DevMenuScreen]? {
     if let screenContainer = extensionToDevMenuScreensMap.object(forKey: ext) {
       return screenContainer.items
     }
-    
+
     if let screens = ext.devMenuScreens?(extensionSettings) {
       let container = DevMenuCacheContainer<DevMenuScreen>(items: screens)
       extensionToDevMenuScreensMap.setObject(container, forKey: ext)
       return screens
     }
-    
-    return nil;
+
+    return nil
   }
-  
+
   private func loadDevMenuDataSources(forExtension ext: DevMenuExtensionProtocol) -> [DevMenuDataSourceProtocol]? {
     if let dataSourcesContainer = extensionToDevMenuDataSourcesMap.object(forKey: ext) {
       return dataSourcesContainer.items
     }
-    
+
     if let dataSources = ext.devMenuDataSources?(extensionSettings) {
       let container = DevMenuCacheContainer<DevMenuDataSourceProtocol>(items: dataSources)
       extensionToDevMenuDataSourcesMap.setObject(container, forKey: ext)
       return dataSources
     }
-    
+
     return nil
   }
 

--- a/packages/expo-dev-menu/ios/DevMenuPackagerConnectionHandler.swift
+++ b/packages/expo-dev-menu/ios/DevMenuPackagerConnectionHandler.swift
@@ -4,11 +4,11 @@ import Foundation
 
 class DevMenuPackagerConnectionHandler {
   weak var manager: DevMenuManager?
-  
+
   init(manager: DevMenuManager) {
     self.manager = manager
   }
-  
+
   func setup() {
     // `RCT_DEV` isn't available in Swift, that's why we used `DEBUG` instead.
     // It shouldn't diverge, because of the definition of `RCT_DEV`.
@@ -20,7 +20,7 @@ class DevMenuPackagerConnectionHandler {
         queue: DispatchQueue.main,
         forMethod: "sendDevCommand"
       )
-    
+
     RCTPackagerConnection
       .shared()
       .addNotificationHandler(
@@ -30,7 +30,7 @@ class DevMenuPackagerConnectionHandler {
       )
 #endif
   }
-  
+
   @objc
   func sendDevCommandNotificationHandler(_ params: [String: Any]) {
     guard let manager = manager,
@@ -39,9 +39,9 @@ class DevMenuPackagerConnectionHandler {
     else {
       return
     }
-    
+
     let devDelegate = DevMenuDevOptionsDelegate(forBridge: bridge)
-  
+
     switch command {
     case "reload":
       devDelegate.reload()
@@ -54,10 +54,10 @@ class DevMenuPackagerConnectionHandler {
     case "togglePerformanceMonitor":
       devDelegate.togglePerformanceMonitor()
     default:
-      NSLog("Unknown command from packager: %@", command);
+      NSLog("Unknown command from packager: %@", command)
     }
   }
-  
+
   @objc
   func devMenuNotificationHanlder(_ parames: [String: Any]) {
     self.manager?.toggleMenu()

--- a/packages/expo-dev-menu/ios/DevMenuSession.swift
+++ b/packages/expo-dev-menu/ios/DevMenuSession.swift
@@ -12,11 +12,11 @@ public class DevMenuSession {
   /**
    A dictionary of app info corresponding to the `bridge` or guessed based on app's metadata.
    */
-  public let appInfo: [String : Any]
-  
+  public let appInfo: [String: Any]
+
   public let openScreen: String?
 
-  init(bridge: RCTBridge, appInfo: [String : Any]?, screen: String? = nil) {
+  init(bridge: RCTBridge, appInfo: [String: Any]?, screen: String? = nil) {
     self.bridge = bridge
     self.appInfo = appInfo ?? guessAppInfo(forBridge: bridge)
     self.openScreen = screen
@@ -27,7 +27,7 @@ public class DevMenuSession {
  Constructs app info dictionary based on the native app metadata such as `Info.plist`.
  Pretty handy in greenfield apps where we don't have to provide anything else.
  */
-fileprivate func guessAppInfo(forBridge bridge: RCTBridge) -> [String : Any] {
+private func guessAppInfo(forBridge bridge: RCTBridge) -> [String: Any] {
   guard let infoDictionary = Bundle.main.infoDictionary else {
     return [:]
   }
@@ -35,14 +35,14 @@ fileprivate func guessAppInfo(forBridge bridge: RCTBridge) -> [String : Any] {
     "appName": infoDictionary["CFBundleDisplayName"] ?? infoDictionary["CFBundleExecutable"] ?? NSNull(),
     "appVersion": infoDictionary["CFBundleVersion"] ?? NSNull(),
     "appIcon": findAppIconPath() ?? NSNull(),
-    "hostUrl": bridge.bundleURL?.absoluteString ?? NSNull(),
+    "hostUrl": bridge.bundleURL?.absoluteString ?? NSNull()
   ]
 }
 
 /**
  Naively finds path to the AppIcon. It assumes the icon doesn't have a custom name and 60pt version is provided.
  */
-fileprivate func findAppIconPath() -> String? {
+private func findAppIconPath() -> String? {
   if let path = Bundle.main.path(forResource: "AppIcon60x60@3x", ofType: "png")
     ?? Bundle.main.path(forResource: "AppIcon60x60@2x", ofType: "png") {
     return "file://".appending(path)

--- a/packages/expo-dev-menu/ios/DevMenuSettings.swift
+++ b/packages/expo-dev-menu/ios/DevMenuSettings.swift
@@ -8,7 +8,6 @@ let isOnboardingFinishedKey = "EXDevMenuIsOnboardingFinished"
 
 @objc
 public class DevMenuSettings: NSObject {
-
   /**
    Initializes dev menu settings by registering user defaults
    and applying some settings to static classes like interceptors.
@@ -19,14 +18,14 @@ public class DevMenuSettings: NSObject {
       touchGestureEnabledKey: true,
       keyCommandsEnabledKey: true,
       showsAtLaunchKey: false,
-      isOnboardingFinishedKey: false,
+      isOnboardingFinishedKey: false
     ])
 
     /**
      We don't want to uninstall `DevMenuMotionInterceptor`, because otherwise, the app on shake gesture will bring up the dev-menu from the RN.
      So we added `isEnabled` to disable it, but not uninstall.
      */
-    DevMenuMotionInterceptor.isInstalled = true;
+    DevMenuMotionInterceptor.isInstalled = true
     DevMenuMotionInterceptor.isEnabled = DevMenuSettings.motionGestureEnabled
     DevMenuTouchInterceptor.isInstalled = DevMenuSettings.touchGestureEnabled
     DevMenuKeyCommandsInterceptor.isInstalled = DevMenuSettings.keyCommandsEnabled
@@ -104,7 +103,7 @@ public class DevMenuSettings: NSObject {
       "touchGestureEnabled": DevMenuSettings.touchGestureEnabled,
       "keyCommandsEnabled": DevMenuSettings.keyCommandsEnabled,
       "showsAtLaunch": DevMenuSettings.showsAtLaunch,
-      "isOnboardingFinished": DevMenuSettings.isOnboardingFinished,
+      "isOnboardingFinished": DevMenuSettings.isOnboardingFinished
     ]
   }
 }

--- a/packages/expo-dev-menu/ios/DevMenuTestInterceptor.swift
+++ b/packages/expo-dev-menu/ios/DevMenuTestInterceptor.swift
@@ -6,15 +6,15 @@ import Foundation
 public protocol DevMenuTestInterceptor {
   @objc
   var shouldShowAtLaunch: Bool { get }
-  
+
   @objc
   var isOnboardingFinishedKey: Bool { get }
 }
 
 @objc
 public class DevMenuTestInterceptorManager: NSObject {
-  static var interceptor: DevMenuTestInterceptor? = nil
-  
+  static var interceptor: DevMenuTestInterceptor?
+
   @objc
   public static func setTestInterceptor(_ interceptor: DevMenuTestInterceptor?) {
     DevMenuTestInterceptorManager.interceptor = interceptor

--- a/packages/expo-dev-menu/ios/DevMenuUtils.swift
+++ b/packages/expo-dev-menu/ios/DevMenuUtils.swift
@@ -11,11 +11,11 @@ class DevMenuUtils {
       let methodB = class_getInstanceMethod(forClass, selectorB) {
       let impA = method_getImplementation(methodA)
       let argsTypeA = method_getTypeEncoding(methodA)
-      
+
       let impB = method_getImplementation(methodB)
       let argsTypeB = method_getTypeEncoding(methodB)
-      
-      if (class_addMethod(forClass, selectorA, impB, argsTypeB)) {
+
+      if class_addMethod(forClass, selectorA, impB, argsTypeB) {
         class_replaceMethod(forClass, selectorB, impA, argsTypeA)
       } else {
         method_exchangeImplementations(methodA, methodB)
@@ -29,7 +29,7 @@ class DevMenuUtils {
   static func stripRCT(_ str: String) -> String {
     return str.starts(with: "RCT") ? String(str.dropFirst(3)) : str
   }
-  
+
   static func resourcesBundle() -> Bundle? {
     let frameworkBundle = Bundle(for: DevMenuUtils.self)
 

--- a/packages/expo-dev-menu/ios/DevMenuViewController.swift
+++ b/packages/expo-dev-menu/ios/DevMenuViewController.swift
@@ -72,7 +72,7 @@ class DevMenuViewController: UIViewController {
 
   // MARK: private
 
-  private func initialProps() -> [String : Any] {
+  private func initialProps() -> [String: Any] {
     return [
       "enableDevelopmentTools": true,
       "showOnboardingView": manager.shouldShowOnboarding(),

--- a/packages/expo-dev-menu/ios/Interceptors/DevMenuKeyCommandsInterceptor.swift
+++ b/packages/expo-dev-menu/ios/Interceptors/DevMenuKeyCommandsInterceptor.swift
@@ -36,8 +36,8 @@ extension UIResponder: DevMenuUIResponderExtensionProtocol {
   // NOTE: throttle the key handler because on iOS the handleKeyCommand:
   // method gets called repeatedly if the command key is held down.
   static private var lastKeyCommandExecutionTime: TimeInterval = 0
-  static private var lastKeyCommand: UIKeyCommand? = nil
-  
+  static private var lastKeyCommand: UIKeyCommand?
+
   @objc
   var EXDevMenu_keyCommands: [UIKeyCommand] {
     let actions = DevMenuManager.shared.devMenuCallable.filter { $0 is DevMenuExportedAction } as! [DevMenuExportedAction]
@@ -51,11 +51,11 @@ extension UIResponder: DevMenuUIResponderExtensionProtocol {
   @objc
   public func EXDevMenu_handleKeyCommand(_ key: UIKeyCommand) {
     tryHandleKeyCommand(key) {
-      let actions = DevMenuManager.shared.devMenuCallable.filter { $0 is DevMenuExportedAction} as! [DevMenuExportedAction]
+      let actions = DevMenuManager.shared.devMenuCallable.filter { $0 is DevMenuExportedAction } as! [DevMenuExportedAction]
       guard let action = actions.first(where: { $0.keyCommand == key }) else {
         return
       }
-      
+
       if action.isAvailable() {
         action.call()
         DevMenuManager.shared.closeMenu()
@@ -69,11 +69,11 @@ extension UIResponder: DevMenuUIResponderExtensionProtocol {
       DevMenuManager.shared.toggleMenu()
     }
   }
-  
+
   private func shouldTriggerAction(_ key: UIKeyCommand) -> Bool {
     return UIResponder.lastKeyCommand !== key || CACurrentMediaTime() - UIResponder.lastKeyCommandExecutionTime > 0.5
   }
-  
+
   private func tryHandleKeyCommand(_ key: UIKeyCommand, handler: () -> Void ) {
     if shouldTriggerAction(key) {
       handler()

--- a/packages/expo-dev-menu/ios/Interceptors/DevMenuMotionInterceptor.swift
+++ b/packages/expo-dev-menu/ios/Interceptors/DevMenuMotionInterceptor.swift
@@ -15,7 +15,7 @@ class DevMenuMotionInterceptor {
       }
     }
   }
-  
+
   static var isEnabled: Bool = true
 
   static private func swizzle() {

--- a/packages/expo-dev-menu/ios/Modules/DeMenuManagerProvider.swift
+++ b/packages/expo-dev-menu/ios/Modules/DeMenuManagerProvider.swift
@@ -3,8 +3,7 @@
 import EXDevMenuInterface
 
 @objc(DevMenuManagerProvider)
-class DevMenuManagerProvider : NSObject, DevMenuManagerProviderProtocol {
-  
+class DevMenuManagerProvider: NSObject, DevMenuManagerProviderProtocol {
   @objc
   open func getDevMenuManager() -> DevMenuManagerProtocol {
     return DevMenuManager.shared

--- a/packages/expo-dev-menu/ios/Modules/DevMenuExtensions.swift
+++ b/packages/expo-dev-menu/ios/Modules/DevMenuExtensions.swift
@@ -4,7 +4,6 @@ import EXDevMenuInterface
 
 @objc(DevMenuExtensions)
 open class DevMenuExtensions: NSObject, DevMenuExtensionProtocol {
-
   @objc
   open var bridge: RCTBridge?
 
@@ -12,21 +11,21 @@ open class DevMenuExtensions: NSObject, DevMenuExtensionProtocol {
 
   @objc
   open func devMenuItems(_ settings: DevMenuExtensionSettingsProtocol) -> DevMenuItemsContainerProtocol? {
-    if (!settings.wasRunOnDevelopmentBridge()) {
+    if !settings.wasRunOnDevelopmentBridge() {
       return nil
     }
-    
+
     guard let bridge = bridge else {
       return nil
     }
-    
+
     let devDelegate = DevMenuDevOptionsDelegate(forBridge: bridge)
     guard let devSettings = devDelegate.devSettings else {
       return nil
     }
-    
+
     let container = DevMenuItemsContainer()
-    
+
     let reload = DevMenuExtensions.reloadAction(devDelegate.reload)
     reload.isAvailable = { !DevMenuExtensions.checkIfLogBoxIsOpened() }
 
@@ -51,17 +50,17 @@ open class DevMenuExtensions: NSObject, DevMenuExtensionProtocol {
     container.addItem(inspector)
     container.addItem(remoteDebug)
     container.addItem(fastRefresh)
-  
+
     #endif
 
     return container
   }
-  
+
   @objc
   open func devMenuScreens(_ settings: DevMenuExtensionSettingsProtocol) -> [DevMenuScreen]? {
     return nil
   }
-  
+
   @objc
   open func devMenuDataSources(_ settings: DevMenuExtensionSettingsProtocol) -> [DevMenuDataSourceProtocol]? {
     return nil
@@ -69,7 +68,7 @@ open class DevMenuExtensions: NSObject, DevMenuExtensionProtocol {
 
   // MARK: static helpers
 
-  private static func reloadAction(_ action: @escaping () -> ()) -> DevMenuAction {
+  private static func reloadAction(_ action: @escaping () -> Void) -> DevMenuAction {
     let reload = DevMenuAction(withId: "reload", action: action)
     reload.label = { "Reload" }
     reload.glyphName = { "reload" }
@@ -78,7 +77,7 @@ open class DevMenuExtensions: NSObject, DevMenuExtensionProtocol {
     return reload
   }
 
-  private static func elementInspectorAction(_ action: @escaping () -> ()) -> DevMenuAction {
+  private static func elementInspectorAction(_ action: @escaping () -> Void) -> DevMenuAction {
     let inspector = DevMenuAction(withId: "inspector", action: action)
     inspector.label = { inspector.isEnabled() ? "Hide Element Inspector" : "Show Element Inspector" }
     inspector.glyphName = { "border-style" }
@@ -87,7 +86,7 @@ open class DevMenuExtensions: NSObject, DevMenuExtensionProtocol {
     return inspector
   }
 
-  private static func remoteDebugAction(_ action: @escaping () -> ()) -> DevMenuAction {
+  private static func remoteDebugAction(_ action: @escaping () -> Void) -> DevMenuAction {
     let remoteDebug = DevMenuAction(withId: "remote-debug", action: action)
     remoteDebug.label = { remoteDebug.isAvailable() ? remoteDebug.isEnabled() ? "Stop Remote Debugging" : "Debug Remote JS" : "Remote Debugger Unavailable" }
     remoteDebug.glyphName = { "remote-desktop" }
@@ -95,7 +94,7 @@ open class DevMenuExtensions: NSObject, DevMenuExtensionProtocol {
     return remoteDebug
   }
 
-  private static func fastRefreshAction(_ action: @escaping () -> ()) -> DevMenuAction {
+  private static func fastRefreshAction(_ action: @escaping () -> Void) -> DevMenuAction {
     let fastRefresh = DevMenuAction(withId: "fast-refresh", action: action)
     fastRefresh.label = { fastRefresh.isAvailable() ? fastRefresh.isEnabled() ? "Disable Fast Refresh" : "Enable Fast Refresh" : "Fast Refresh Unavailable" }
     fastRefresh.glyphName = { "run-fast" }
@@ -103,7 +102,7 @@ open class DevMenuExtensions: NSObject, DevMenuExtensionProtocol {
     return fastRefresh
   }
 
-  private static func performanceMonitorAction(_ action: @escaping () -> ()) -> DevMenuAction {
+  private static func performanceMonitorAction(_ action: @escaping () -> Void) -> DevMenuAction {
     let perfMonitor = DevMenuAction(withId: "performance-monitor", action: action)
     perfMonitor.label = { perfMonitor.isAvailable() ? perfMonitor.isEnabled() ? "Hide Performance Monitor" : "Show Performance Monitor" : "Performance Monitor Unavailable" }
     perfMonitor.glyphName = { "speedometer" }
@@ -111,14 +110,14 @@ open class DevMenuExtensions: NSObject, DevMenuExtensionProtocol {
     perfMonitor.registerKeyCommand(input: "p", modifiers: .command)
     return perfMonitor
   }
-  
+
   private static func checkIfLogBoxIsOpened() -> Bool {
     return UIApplication.shared.windows.contains {
       let className = String(describing: type(of: $0))
       if className == "RCTLogBoxView" || className == "RCTRedBoxView" {
         return true
       }
-  
+
       return false
     }
   }

--- a/packages/expo-dev-menu/ios/Modules/DevMenuInternalModule.swift
+++ b/packages/expo-dev-menu/ios/Modules/DevMenuInternalModule.swift
@@ -9,24 +9,24 @@ public class DevMenuInternalModule: NSObject, RCTBridgeModule {
   var redirectReject: RCTPromiseRejectBlock?
   @objc
   var authSession: SFAuthenticationSession?
-  
+
   public static func moduleName() -> String! {
     return "ExpoDevMenuInternal"
   }
-  
+
   // Module DevMenuInternalModule requires main queue setup since it overrides `constantsToExport`.
   public static func requiresMainQueueSetup() -> Bool {
-    return true;
+    return true
   }
-  
-  private static var fontsWereLoaded = false;
+
+  private static var fontsWereLoaded = false
   private static let sessionKey = "expo-dev-menu.session"
   private static let userLoginEvent = "expo.dev-menu.user-login"
   private static let userLogoutEvent = "expo.dev-menu.user-logout"
   private static let defaultScheme = "expo-dev-menu"
 
   let manager: DevMenuManager
-  
+
   public override init() {
     self.manager = DevMenuManager.shared
   }
@@ -38,7 +38,7 @@ public class DevMenuInternalModule: NSObject, RCTBridgeModule {
   // MARK: JavaScript API
 
   @objc
-  public func constantsToExport() -> [AnyHashable : Any] {
+  public func constantsToExport() -> [AnyHashable: Any] {
 #if targetEnvironment(simulator)
     let doesDeviceSupportKeyCommands = true
 #else
@@ -46,41 +46,41 @@ public class DevMenuInternalModule: NSObject, RCTBridgeModule {
 #endif
     return ["doesDeviceSupportKeyCommands": doesDeviceSupportKeyCommands]
   }
-  
+
   @objc
   func loadFontsAsync(_ resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
-    if (DevMenuInternalModule.fontsWereLoaded) {
-      resolve(nil);
-      return;
+    if DevMenuInternalModule.fontsWereLoaded {
+      resolve(nil)
+      return
     }
-    
+
     let fonts = ["MaterialCommunityIcons", "Ionicons"]
     for font in fonts {
       guard let path = DevMenuUtils.resourcesBundle()?.path(forResource: font, ofType: "ttf") else {
-        reject("ERR_DEVMENU_CANNOT_FIND_FONT", "Font file for '\(font)' doesn't exist.", nil);
-        return;
+        reject("ERR_DEVMENU_CANNOT_FIND_FONT", "Font file for '\(font)' doesn't exist.", nil)
+        return
       }
       guard let data = FileManager.default.contents(atPath: path) else {
-        reject("ERR_DEVMENU_CANNOT_OPEN_FONT_FILE", "Could not open '\(path)'.", nil);
-        return;
+        reject("ERR_DEVMENU_CANNOT_OPEN_FONT_FILE", "Could not open '\(path)'.", nil)
+        return
       }
-      
+
       guard let provider = CGDataProvider(data: data as CFData) else {
-        reject("ERR_DEVMENU_CANNOT_CREATE_FONT_PROVIDER", "Could not create font provider for '\(font)'.", nil);
-        return;
+        reject("ERR_DEVMENU_CANNOT_CREATE_FONT_PROVIDER", "Could not create font provider for '\(font)'.", nil)
+        return
       }
       guard let cgFont = CGFont(provider) else {
-        reject("ERR_DEVMENU_CANNOT_CREATE_FONT", "Could not create font for '\(font)'.", nil);
-        return;
+        reject("ERR_DEVMENU_CANNOT_CREATE_FONT", "Could not create font for '\(font)'.", nil)
+        return
       }
-        
+
       var error: Unmanaged<CFError>?
       if !CTFontManagerRegisterGraphicsFont(cgFont, &error) {
         reject("ERR_DEVMENU_CANNOT_ADD_FONT", "Could not create font from loaded data for '\(font)'. '\(error.debugDescription)'.", nil)
         return
       }
     }
-    
+
     DevMenuInternalModule.fontsWereLoaded = true
     resolve(nil)
   }
@@ -90,21 +90,21 @@ public class DevMenuInternalModule: NSObject, RCTBridgeModule {
     guard let dataSourceId = dataSourceId else {
       return reject("ERR_DEVMENU_DATA_SOURCE_FAILED", "DataSource ID not provided.", nil)
     }
-    
+
     for dataSource in manager.devMenuDataSources {
-      if (dataSource.id == dataSourceId) {
+      if dataSource.id == dataSourceId {
         dataSource.fetchData { data in
           resolve(data.map { $0.serialize() })
         }
-        return;
+        return
       }
     }
 
     return reject("ERR_DEVMENU_DATA_SOURCE_FAILED", "DataSource \(dataSourceId) not founded.", nil)
   }
-  
+
   @objc
-  func dispatchCallableAsync(_ callableId: String?, args: [String : Any]?, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
+  func dispatchCallableAsync(_ callableId: String?, args: [String: Any]?, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
     guard let callableId = callableId else {
       return reject("ERR_DEVMENU_ACTION_FAILED", "Callable ID not provided.", nil)
     }
@@ -142,64 +142,64 @@ public class DevMenuInternalModule: NSObject, RCTBridgeModule {
       DevMenuSettings.showsAtLaunch = showsAtLaunch
     }
   }
-  
+
   @objc
   func openDevMenuFromReactNative() {
     guard let rctDevMenu = manager.session?.bridge.devMenu else {
       return
     }
-    
+
     DispatchQueue.main.async {
       rctDevMenu.show()
     }
   }
-  
+
   @objc
   func onScreenChangeAsync(_ currentScreen: String?, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
     manager.setCurrentScreen(currentScreen)
     resolve(nil)
   }
-  
+
   @objc
-  func setSessionAsync(_ session: Dictionary<String, Any>?, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
+  func setSessionAsync(_ session: [String: Any]?, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
     do {
       try manager.expoSessionDelegate.setSessionAsync(session)
       resolve(nil)
     } catch let error {
-      reject("ERR_DEVMENU_CANNOT_SAVE_SESSION", error.localizedDescription, error);
+      reject("ERR_DEVMENU_CANNOT_SAVE_SESSION", error.localizedDescription, error)
     }
   }
-  
+
   @objc
   func restoreSessionAsync(_ resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
     resolve(manager.expoSessionDelegate.restoreSession())
   }
-  
+
   @objc
   func getAuthSchemeAsync(_ resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
     guard let urlTypesArray = Bundle.main.infoDictionary?["CFBundleURLTypes"] as? [NSDictionary] else {
       resolve(DevMenuInternalModule.defaultScheme)
       return
     }
-        
+
     if (urlTypesArray
           .contains(where: { ($0["CFBundleURLSchemes"] as? [String] ?? [])
                       .contains(DevMenuInternalModule.defaultScheme) })) {
       resolve(DevMenuInternalModule.defaultScheme)
       return
     }
-    
+
     for urlType in urlTypesArray {
       guard let schemes = urlType["CFBundleURLSchemes"] as? [String] else {
         continue
       }
-      
+
       if schemes.first != nil {
         resolve(schemes.first)
         return
       }
     }
-    
+
     resolve(DevMenuInternalModule.defaultScheme)
   }
 }

--- a/packages/expo-dev-menu/ios/Modules/DevMenuModule.swift
+++ b/packages/expo-dev-menu/ios/Modules/DevMenuModule.swift
@@ -2,7 +2,6 @@
 
 @objc(DevMenuModule)
 open class DevMenuModule: NSObject {
-  
   // MARK: JavaScript API
 
   @objc
@@ -14,30 +13,30 @@ open class DevMenuModule: NSObject {
   func openSettings() {
     DevMenuManager.shared.openMenu("Settings")
   }
-  
+
   @objc
   func openProfile() {
     DevMenuManager.shared.openMenu("Profile")
   }
-  
+
   @objc
   func isLoggedInAsync(_ resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
     resolve(DevMenuManager.shared.expoApiClient.isLoggedIn())
   }
-  
+
   @objc
   func queryDevSessionsAsync(_ installationID: String?, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
-    DevMenuManager.shared.expoApiClient.queryDevSessionsAsync(installationID, completionHandler: { (data, response, error) in
+    DevMenuManager.shared.expoApiClient.queryDevSessionsAsync(installationID, completionHandler: { data, response, error in
       guard error == nil else {
         reject("ERR_DEVMENU_CANNOT_GET_DEV_SESSIONS", error.debugDescription, error)
         return
       }
-      
+
       guard let data = data else {
         resolve(nil)
         return
       }
-      
+
       let response = String(decoding: data, as: UTF8.self)
       resolve(response)
     })

--- a/packages/expo-dev-menu/ios/Modules/MockedSafeAreaViewProvider.swift
+++ b/packages/expo-dev-menu/ios/Modules/MockedSafeAreaViewProvider.swift
@@ -3,7 +3,7 @@
 // React navigation uses a safe area providere, but we don't need this.
 // So we can just mock it.
 @objc(MockedRNCSafeAreaProvider)
-class MockedRNCSafeAreaProvider : RCTViewManager {
+class MockedRNCSafeAreaProvider: RCTViewManager {
   public static override func moduleName() -> String! {
     return "RNCSafeAreaProvider"
   }

--- a/packages/expo-dev-menu/ios/Tests/DevMenuAppInstanceTest.swift
+++ b/packages/expo-dev-menu/ios/Tests/DevMenuAppInstanceTest.swift
@@ -4,22 +4,21 @@ import Nimble
 @testable import EXDevMenu
 
 class DevMenuAppInstanceTest: QuickSpec {
-  
   class MockedBridge: RCTBridge {
     var enqueueJSCallWasCalled = false
-    
+
     override func invalidate() {
       // NOOP
     }
 
     override func enqueueJSCall(_ moduleDotMethod: String!, args: [Any]!) {
       enqueueJSCallWasCalled = true
-      
+
       expect(moduleDotMethod).to(equal("RCTDeviceEventEmitter.emit"))
       expect(args.first as? String).to(equal("closeDevMenu"))
     }
   }
-  
+
   override func spec() {
     it("checks if `sendCloseEvent` sends correct event") {
       let mockedBridge = MockedBridge(delegate: nil, launchOptions: nil)!
@@ -27,39 +26,39 @@ class DevMenuAppInstanceTest: QuickSpec {
         manager: DevMenuManager.shared,
         bridge: mockedBridge
       )
-      
+
       appInstance.sendCloseEvent()
-      
+
       expect(mockedBridge.enqueueJSCallWasCalled).to(beTrue())
     }
-    
+
     it("checks if js bundle was found") {
       let mockedBridge = MockedBridge(delegate: nil, launchOptions: nil)!
       let appInstance = DevMenuAppInstance(
         manager: DevMenuManager.shared,
         bridge: mockedBridge
       )
-      
+
       let sourceURL = appInstance.sourceURL(for: mockedBridge)
-      
+
       expect(sourceURL).toNot(beNil())
     }
-    
+
     it("checks if extra modules was exported") {
       let mockedBridge = MockedBridge(delegate: nil, launchOptions: nil)!
       let appInstance = DevMenuAppInstance(
         manager: DevMenuManager.shared,
         bridge: mockedBridge
       )
-      
+
       let extraModules = appInstance.extraModules(for: mockedBridge)
-      
+
       expect(extraModules).toNot(beNil())
       expect(extraModules?.count).toNot(equal(7))
-      
-      expect(extraModules?.first { type(of: $0).moduleName() == "ExpoDevMenuInternal" } ).toNot(beNil())
-      expect(extraModules?.first { type(of: $0).moduleName() == "RNCSafeAreaProvider" } ).toNot(beNil())
-      expect(extraModules?.first { type(of: $0).moduleName() == "DevLoadingView" } ).toNot(beNil())
+
+      expect(extraModules?.first { type(of: $0).moduleName() == "ExpoDevMenuInternal" }).toNot(beNil())
+      expect(extraModules?.first { type(of: $0).moduleName() == "RNCSafeAreaProvider" }).toNot(beNil())
+      expect(extraModules?.first { type(of: $0).moduleName() == "DevLoadingView" }).toNot(beNil())
     }
   }
 }

--- a/packages/expo-dev-menu/ios/Tests/DevMenuExpoApiClientTests.swift
+++ b/packages/expo-dev-menu/ios/Tests/DevMenuExpoApiClientTests.swift
@@ -2,24 +2,24 @@ import XCTest
 
 @testable import EXDevMenu
 
-fileprivate class MockedDataTask: URLSessionDataTask {
+private class MockedDataTask: URLSessionDataTask {
   private let completionHandler: () -> Void
   init(_ completionHandler: @escaping () -> Void) {
     self.completionHandler = completionHandler
     super.init()
   }
-  
+
   override func resume() {
     completionHandler()
   }
 }
 
-fileprivate class MockedSession: URLSession {
-  var requestInspector: (URLRequest) -> Void = {_ in }
+private class MockedSession: URLSession {
+  var requestInspector: (URLRequest) -> Void = { _ in }
   var completionHandlerSeeder: ((Data?, URLResponse?, Error?) -> Void) -> Void = {
     $0(nil, nil, nil)
   }
-  
+
   override func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
     requestInspector(request)
     return MockedDataTask {
@@ -43,11 +43,11 @@ class DevMenuExpoApiClientTests: XCTestCase {
     }
     apiClient.session = mockedSession
 
-    apiClient.queryDevSessionsAsync(nil, completionHandler: { data, response, error in
+    apiClient.queryDevSessionsAsync(nil, completionHandler: { data, _, _ in
       XCTAssertIdentical(data as AnyObject, expectedData as AnyObject)
       expect.fulfill()
     })
-    
+
     waitForExpectations(timeout: 0)
   }
 
@@ -65,22 +65,22 @@ class DevMenuExpoApiClientTests: XCTestCase {
     }
     apiClient.session = mockedSession
 
-    apiClient.queryDevSessionsAsync("test-installation-id", completionHandler: { data, response, error in
+    apiClient.queryDevSessionsAsync("test-installation-id", completionHandler: { data, _, _ in
       XCTAssertIdentical(data as AnyObject, expectedData as AnyObject)
       expect.fulfill()
     })
 
     waitForExpectations(timeout: 0)
   }
-  
+
   func test_if_isLoggedIn_returns_correct_values() {
     let apiClient = DevMenuExpoApiClient()
-    
+
     XCTAssertFalse(apiClient.isLoggedIn())
     apiClient.sessionSecret = "secret"
     XCTAssertTrue(apiClient.isLoggedIn())
   }
-  
+
   func test_if_session_token_is_attached_to_the_request() {
     let expect = expectation(description: "request callback should be called")
     let apiClient = DevMenuExpoApiClient()
@@ -90,14 +90,14 @@ class DevMenuExpoApiClientTests: XCTestCase {
       XCTAssertEqual($0.value(forHTTPHeaderField: "expo-session"), "secret")
     }
     apiClient.session = mockedSession
-    
-    apiClient.queryDevSessionsAsync(nil, completionHandler: { data, response, error in
+
+    apiClient.queryDevSessionsAsync(nil, completionHandler: { _, _, _ in
       expect.fulfill()
     })
-    
+
     waitForExpectations(timeout: 0)
   }
-  
+
   func test_if_queryUpdateBranches_converts_response_to_object() {
     let serverResponse = """
       {
@@ -148,7 +148,7 @@ class DevMenuExpoApiClientTests: XCTestCase {
         }
       }
     """.data(using: .utf8)
-    
+
     let expect = expectation(description: "request callback should be called")
     let apiClient = DevMenuExpoApiClient()
     let mockedSession = MockedSession()
@@ -158,17 +158,17 @@ class DevMenuExpoApiClientTests: XCTestCase {
     mockedSession.requestInspector = {
       XCTAssertEqual($0.httpMethod, "POST")
     }
-    
+
     apiClient.session = mockedSession
-    apiClient.queryUpdateBranches(appId: "app_id", completionHandler: { branches, response, error in
+    apiClient.queryUpdateBranches(appId: "app_id", completionHandler: { branches, _, error in
       XCTAssertNil(error)
-      
+
       let branches = branches!
       XCTAssertEqual(branches.count, 1)
       let branch = branches[0]
       XCTAssertEqual(branch.id, "0455d584-9130-4b7a-a9c0-f20bffe4ffb4")
       XCTAssertEqual(branch.updates.count, 4)
-      
+
       XCTAssertEqual(branch.updates[0].id, "04264159-e4d4-4085-8633-24400e1188dd")
       XCTAssertEqual(branch.updates[0].createdAt, "2021-04-07T09:46:37.803Z")
       XCTAssertEqual(branch.updates[0].updatedAt, "2021-04-07T09:46:37.803Z")
@@ -180,7 +180,7 @@ class DevMenuExpoApiClientTests: XCTestCase {
 
     waitForExpectations(timeout: 0)
   }
-  
+
   func test_if_queryUpdateChannels_converts_response_to_object() {
     let serverResponse = """
      {
@@ -200,7 +200,7 @@ class DevMenuExpoApiClientTests: XCTestCase {
        }
      }
     """.data(using: .utf8)
-    
+
     let expect = expectation(description: "request callback should be called")
     let apiClient = DevMenuExpoApiClient()
     let mockedSession = MockedSession()
@@ -210,15 +210,15 @@ class DevMenuExpoApiClientTests: XCTestCase {
     mockedSession.requestInspector = {
       XCTAssertEqual($0.httpMethod, "POST")
     }
-    
+
     apiClient.session = mockedSession
-    apiClient.queryUpdateChannels(appId: "app_id", completionHandler: { updates, response, error in
+    apiClient.queryUpdateChannels(appId: "app_id", completionHandler: { updates, _, error in
       XCTAssertNil(error)
 
       let updates = updates!
       XCTAssertEqual(updates.count, 1)
       let update = updates[0]
-      
+
       XCTAssertEqual(update.id, "a7c1bad5-1d21-4930-8660-f56b9cfc10bc")
       XCTAssertEqual(update.name, "main")
       XCTAssertEqual(update.createdAt, "2021-04-01T08:37:05.013Z")
@@ -229,7 +229,7 @@ class DevMenuExpoApiClientTests: XCTestCase {
 
     waitForExpectations(timeout: 0)
   }
-  
+
   func test_if_client_do_not_parse_response_if_error_is_present() {
     let serverResponse = """
      {
@@ -249,7 +249,7 @@ class DevMenuExpoApiClientTests: XCTestCase {
        }
      }
     """.data(using: .utf8)
-    
+
     let expect = expectation(description: "request callback should be called")
     let apiClient = DevMenuExpoApiClient()
     let mockedSession = MockedSession()
@@ -259,9 +259,9 @@ class DevMenuExpoApiClientTests: XCTestCase {
     mockedSession.requestInspector = {
       XCTAssertEqual($0.httpMethod, "POST")
     }
-    
+
     apiClient.session = mockedSession
-    apiClient.queryUpdateChannels(appId: "app_id", completionHandler: { updates, response, error in
+    apiClient.queryUpdateChannels(appId: "app_id", completionHandler: { updates, _, error in
       XCTAssertNil(updates)
       XCTAssertNotNil(error)
 

--- a/packages/expo-dev-menu/ios/Tests/DevMenuExpoSessionDelegateTest.swift
+++ b/packages/expo-dev-menu/ios/Tests/DevMenuExpoSessionDelegateTest.swift
@@ -4,24 +4,22 @@ import Nimble
 @testable import EXDevMenu
 
 class DevMenuExpoSessionDelegateTest: QuickSpec {
-  
   override func spec() {
     it("delegate should save and restore the same value") {
       let delegate = DevMenuExpoSessionDelegate(manager: DevMenuManager.shared)
       let session = ["expo": "is awesome", "key": "value", "sessionSecret": "secret"]
-      
+
       try delegate.setSessionAsync(session)
       let restoredSession = delegate.restoreSession()
-      
-      expect(restoredSession as? Dictionary<String, String>).to(equal(session))
+
+      expect(restoredSession as? [String: String]).to(equal(session))
     }
-    
+
     it("delegate should throw if `sessionSecret` wasn't passed") {
       let delegate = DevMenuExpoSessionDelegate(manager: DevMenuManager.shared)
       let session = ["expo": "is awesome", "key": "value"]
-      
+
       expect { try delegate.setSessionAsync(session) }.to(throwError())
     }
-    
   }
 }

--- a/packages/expo-dev-menu/ios/Tests/DevMenuExtensionsTest.swift
+++ b/packages/expo-dev-menu/ios/Tests/DevMenuExtensionsTest.swift
@@ -10,24 +10,24 @@ class DevMenuExtensionsTest: QuickSpec {
       return true
     }
   }
-  
+
   override func spec() {
     it("getAllItems should return nil when called without the bridge") {
       let settings = MockedSettings()
       let module = DevMenuExtensions()
-      
+
       let itemContainer = module.devMenuItems(settings)
-    
+
       expect(itemContainer).to(beNil())
     }
-    
+
     it("getAllItems should return nil when called without DevSettings") {
       let settings = MockedSettings()
       let module = DevMenuExtensions()
       module.bridge = MockedNOOPBridge(delegate: nil, launchOptions: nil)
-      
+
       let itemContainer = module.devMenuItems(settings)
-    
+
       expect(itemContainer).to(beNil())
     }
   }

--- a/packages/expo-dev-menu/ios/Tests/DevMenuInternalModuleTest.swift
+++ b/packages/expo-dev-menu/ios/Tests/DevMenuInternalModuleTest.swift
@@ -4,7 +4,6 @@ import Nimble
 @testable import EXDevMenu
 
 class DevMenuInternalModuleTest: QuickSpec {
-  
   override func spec() {
     it("constants should contain information about key command support") {
       #if targetEnvironment(simulator)
@@ -13,9 +12,9 @@ class DevMenuInternalModuleTest: QuickSpec {
           let doesDeviceSupportKeyCommands = false
       #endif
       let module = DevMenuInternalModule(manager: DevMenuManager.shared)
-      
+
       let constants = module.constantsToExport()
-      
+
       expect(constants["doesDeviceSupportKeyCommands"] as? Bool).to(equal(doesDeviceSupportKeyCommands))
     }
   }

--- a/packages/expo-dev-menu/ios/Tests/DevMenuManagerProviderTest.swift
+++ b/packages/expo-dev-menu/ios/Tests/DevMenuManagerProviderTest.swift
@@ -7,9 +7,9 @@ class DevMenuManagerProviderTest: QuickSpec {
   override func spec() {
     it("provider should return correct instance of DevManager") {
       let provider = DevMenuManagerProvider()
-      
+
       let providedManager = provider.getDevMenuManager()
-      
+
       expect(providedManager).to(be(DevMenuManager.shared))
       expect(providedManager).to(be(provider.getDevMenuManager()))
     }

--- a/packages/expo-dev-menu/ios/Tests/DevMenuRCTBridgeTest.swift
+++ b/packages/expo-dev-menu/ios/Tests/DevMenuRCTBridgeTest.swift
@@ -8,19 +8,19 @@ class DevMenuRCTBridgeTest: QuickSpec {
   class RCTAllowModule: NSObject {}
   @objc(NotAllowModule)
   class NotAllowModule: NSObject {}
-  
+
   override func spec() {
     it("should be connected with DevMenuRCTCxxBridge") {
       let bridge = DevMenuRCTBridge(delegate: nil, launchOptions: nil)!
-    
+
       expect(bridge.bridgeClass()).to(be(DevMenuRCTCxxBridge.self))
     }
-    
+
     it("should be able to filter non essential modules") {
       let cxxBridge = DevMenuRCTBridge(delegate: nil, launchOptions: nil)!.batched as! DevMenuRCTCxxBridge
-      
+
       let filteredModules = cxxBridge.filterModuleList([RCTAllowModule.self, NotAllowModule.self])
-      
+
       expect(filteredModules.count).to(equal(1))
       expect(filteredModules.first).to(be(RCTAllowModule.self))
     }

--- a/packages/expo-dev-menu/ios/Tests/DevMenuSessionTests.swift
+++ b/packages/expo-dev-menu/ios/Tests/DevMenuSessionTests.swift
@@ -20,15 +20,15 @@ class DevMenuSessionTests: XCTestCase {
       "appIcon": "Icon",
       "hostUrl": "http://localhost:1234"
     ]
-    
+
     let session = DevMenuSession(bridge: MockedNOOPBridge(delegate: nil, launchOptions: nil), appInfo: appInfo)
 
     XCTAssertEqual(session.appInfo as! [String: String], appInfo)
   }
-    
+
   func test_if_session_gets_url_from_bridge() {
     let session = DevMenuSession(bridge: MockedNOOPBridge(delegate: nil, launchOptions: nil), appInfo: nil)
-    
+
     let url = session.appInfo["hostUrl"] as! String
     XCTAssertEqual(url, "http://localhost:1234")
   }

--- a/packages/expo-dev-menu/ios/Tests/DevMenuUtilsTests.swift
+++ b/packages/expo-dev-menu/ios/Tests/DevMenuUtilsTests.swift
@@ -7,10 +7,10 @@ class DevMenuUtilsTest: XCTestCase {
     XCTAssertEqual(DevMenuUtils.stripRCT("RCTTest"), "Test")
     XCTAssertEqual(DevMenuUtils.stripRCT("Test"), "Test")
   }
-  
+
   func test_if_bundle_is_present() {
     let bundle = DevMenuUtils.resourcesBundle()
-    
+
     XCTAssertNotNil(bundle)
     XCTAssertNotNil(bundle!.url(forResource: "EXDevMenuApp.ios", withExtension: "js"))
   }

--- a/packages/expo-dev-menu/ios/Tests/DevMenuVendoredModulesUtilsTests.swift
+++ b/packages/expo-dev-menu/ios/Tests/DevMenuVendoredModulesUtilsTests.swift
@@ -5,7 +5,7 @@ import XCTest
 class DevMenuVendoredModulesUtilsTests: XCTestCase {
   func test_if_vendored_modules_are_available() {
     let vendoredModules = DevMenuVendoredModulesUtils.vendoredModules()
-    
+
     XCTAssertEqual(vendoredModules.count, 3)
     XCTAssert(vendoredModules.first { type(of: $0).moduleName() == "RNGestureHandlerModule" } != nil)
     XCTAssert(vendoredModules.first { type(of: $0).self.moduleName() == "ReanimatedModule" } != nil)

--- a/packages/expo-dev-menu/ios/UITests/DevMenuLooper.swift
+++ b/packages/expo-dev-menu/ios/UITests/DevMenuLooper.swift
@@ -7,23 +7,23 @@ class DevMenuLooper {
     RunLoop.main.run(mode: .common, before: Date(timeIntervalSinceNow: sec))
     RunLoop.main.run(mode: .tracking, before: Date(timeIntervalSinceNow: sec))
   }
-  
+
   static func runMainLoopUntilEmpty() {
     var isEmpty = false
-    
+
     DispatchQueue.main.async {
       isEmpty = true
     }
-    
+
     let timout = Date(timeIntervalSinceNow: DevMenuTestOptions.defaultTimeout)
     while timout.timeIntervalSinceNow > 0 {
-      if (isEmpty) {
+      if isEmpty {
         return
       }
-      
+
       DevMenuLooper.runMainLoop(for: DevMenuTestOptions.loopTime)
     }
-    
+
     XCTFail("Wait for main thread timeout.")
   }
 }

--- a/packages/expo-dev-menu/ios/UITests/DevMenuTests.swift
+++ b/packages/expo-dev-menu/ios/UITests/DevMenuTests.swift
@@ -8,20 +8,20 @@ class MockedExtension: DevMenuExtensionProtocol {
   static func moduleName() -> String! {
     return "MockedExtension"
   }
-  
-  let action: () -> ()
-  init(withAction action: @escaping () -> ()) {
+
+  let action: () -> Void
+  init(withAction action: @escaping () -> Void) {
     self.action = action
   }
-  
+
   func devMenuItems(_ settings: DevMenuExtensionSettingsProtocol) -> DevMenuItemsContainerProtocol? {
     let container = DevMenuItemsContainer()
-    
+
     let action = DevMenuAction(withId: "action", action: action)
     action.label = { "Action" }
-    
+
     container.addItem(action)
-    
+
     return container
   }
 }
@@ -45,24 +45,23 @@ class TestInterceptorOnboardingFinished: DevMenuTestInterceptor {
 }
 
 class DevMenuTests: XCTestCase {
-  
   override func setUp() {
     XCTAssertFalse(DevMenuManager.shared.isVisible)
   }
-  
+
   override func tearDown() {
-    if (DevMenuManager.shared.isVisible) {
+    if DevMenuManager.shared.isVisible {
       DevMenuManager.shared.hideMenu()
       DevMenuLooper.runMainLoopUntilEmpty()
     }
   }
-  
+
   func test_if_dev_menu_is_rendered() {
     DevMenuManager.configure(withBridge: UIMockedNOOPBridge(delegate: nil, launchOptions: nil))
 
     DevMenuManager.shared.openMenu()
     waitForDevMenu()
-    
+
     assertViewExists(text: "AppHost-expo-dev-menu-Unit-Tests")
     assertViewExists(text: "Version:")
     assertViewExists(text: "1")
@@ -76,7 +75,7 @@ class DevMenuTests: XCTestCase {
     DevMenuTestInterceptorManager.setTestInterceptor(TestInterceptorFirstLaunch())
     DevMenuManager.configure(withBridge: UIMockedNOOPBridge(delegate: nil, launchOptions: nil))
     waitForDevMenu()
-    DevMenuTestInterceptorManager.setTestInterceptor(nil);
+    DevMenuTestInterceptorManager.setTestInterceptor(nil)
   }
 
   func test_dev_menu_auto_launch_bypass() {
@@ -103,29 +102,29 @@ class DevMenuTests: XCTestCase {
     waitForDevMenu()
     UserDefaults.standard.set(false, forKey: "EXDevMenuDisableAutoLaunch")
     DevMenuManager.shared.readAutoLaunchDisabledState()
-    DevMenuTestInterceptorManager.setTestInterceptor(nil);
+    DevMenuTestInterceptorManager.setTestInterceptor(nil)
   }
-  
+
   func test_if_dev_menu_can_be_toggled() {
     let label = UILabel()
     label.text = "Test App"
     label.bounds = CGRect(x: 0, y: 0, width: 100, height: 100)
     label.accessibilityIdentifier = "TestApp"
     UIApplication.shared.keyWindow!.rootViewController!.view.addSubview(label)
-        
+
     waitForView(tag: "TestApp")
     DevMenuManager.configure(withBridge: UIMockedNOOPBridge(delegate: nil, launchOptions: nil))
 
     DevMenuManager.shared.toggleMenu()
     waitForDevMenu()
-    
+
     DevMenuManager.shared.toggleMenu()
     waitForView(tag: "TestApp")
-    
+
     DevMenuManager.shared.toggleMenu()
     waitForDevMenu()
   }
-  
+
   func test_if_extension_is_exported() {
     XCTAssertFalse(DevMenuManager.shared.isVisible)
     let expectation = expectation(description: "Action should be called.")
@@ -134,19 +133,19 @@ class DevMenuTests: XCTestCase {
     }
     let mockedBridge = BridgeWithDevMenuExtension(delegate: nil, launchOptions: nil)!
     mockedBridge.extensions.append(mockedExtension)
-    
+
     DevMenuManager.configure(withBridge: mockedBridge)
     DevMenuManager.shared.openMenu()
     waitForDevMenu()
-    
+
     let actionView = DevMenuUIMatchers.waitForView(text: "Action")
     XCTAssertNotNil(actionView)
     // TODO: (@lukmccall) generate a press event
     DevMenuManager.shared.dispatchCallable(withId: "action", args: nil)
-    
+
     waitForExpectations(timeout: 0)
   }
-  
+
   func test_if_menu_can_be_opened_on_settings_screen() {
     DevMenuTestInterceptorManager.setTestInterceptor(TestInterceptorOnboardingFinished())
     DevMenuManager.configure(withBridge: UIMockedNOOPBridge(delegate: nil, launchOptions: nil))
@@ -155,6 +154,6 @@ class DevMenuTests: XCTestCase {
     waitForView(tag: DevMenuViews.settingsScreen)
     waitForView(tag: DevMenuViews.footer)
     XCTAssertTrue(DevMenuManager.shared.isVisible)
-    DevMenuTestInterceptorManager.setTestInterceptor(nil);
+    DevMenuTestInterceptorManager.setTestInterceptor(nil)
   }
 }

--- a/packages/expo-dev-menu/ios/UITests/DevMenuUIMatchers.swift
+++ b/packages/expo-dev-menu/ios/UITests/DevMenuUIMatchers.swift
@@ -12,96 +12,95 @@ class DevMenuUIMatchers {
   static func currentRootView() -> UIView? {
     return UIApplication.shared.keyWindow?.rootViewController?.view
   }
-  
+
   static func findView(rootView: UIView, _ matcher: (UIView) -> Bool) -> UIView? {
     if matcher(rootView) {
       return rootView
     }
-    
+
     for subView in rootView.subviews {
       let found = findView(rootView: subView, matcher)
       if found != nil {
         return found
       }
     }
-    
-    return nil;
+
+    return nil
   }
-  
+
   static func findView(_ matcher: (UIView) -> Bool) -> UIView? {
     guard let view = DevMenuUIMatchers.currentRootView() else {
       return nil
     }
-    
+
     return findView(rootView: view, matcher)
   }
-  
+
   static func findView(rootView: UIView, tag: String) -> UIView? {
     return DevMenuUIMatchers.findView(rootView: rootView) {
       return $0.accessibilityIdentifier == tag && $0.isVisible()
     }
   }
-  
+
   static func findView(tag: String) -> UIView? {
     guard let view = DevMenuUIMatchers.currentRootView() else {
       return nil
     }
-    
+
     return findView(rootView: view, tag: tag)
   }
-  
+
   static func waitForView(_ matcher: (UIView) -> Bool) -> UIView {
     let timer = Date(timeIntervalSinceNow: DevMenuTestOptions.defaultTimeout)
-    
+
     while timer.timeIntervalSinceNow > 0 {
       DevMenuLooper.runMainLoop(for: DevMenuTestOptions.loopTime)
-      
+
       guard let view = DevMenuUIMatchers.currentRootView() else {
         continue
       }
-      
+
       let found = findView(rootView: view, matcher)
-      if (found != nil) {
+      if found != nil {
         return found!
       }
     }
-    
+
     XCTFail("Can not find view.")
     return UIView() // just for compiler
   }
-  
+
   static func waitForView(tag: String) -> UIView {
     return waitForView {
       return $0.accessibilityIdentifier == tag && $0.isVisible()
     }
   }
-  
+
   static func waitForView(text: String) -> UIView {
     return waitForView {
-      if (type(of: $0) == NSClassFromString("RCTTextView")!) {
+      if type(of: $0) == NSClassFromString("RCTTextView")! {
         return $0.isVisible() && ($0.value(forKey: "_textStorage") as! NSTextStorage).string == text
       }
-      
+
       return false
     }
   }
-  
+
   static func findView(rootView: UIView, text: String) -> UIView? {
     findView(rootView: rootView) {
-      if (type(of: $0) == NSClassFromString("RCTTextView")!) {
+      if type(of: $0) == NSClassFromString("RCTTextView")! {
         return $0.isVisible() && ($0.value(forKey: "_textStorage") as! NSTextStorage).string == text
       }
-      
+
       return false
     }
   }
-  
-  
+
   static func findView(text: String) -> UIView? {
     guard let view = DevMenuUIMatchers.currentRootView() else {
       return nil
     }
-    
+
     return findView(rootView: view, text: text)
   }
 }

--- a/packages/expo-dev-menu/ios/UITests/MockedBridges.swift
+++ b/packages/expo-dev-menu/ios/UITests/MockedBridges.swift
@@ -2,11 +2,10 @@
 @testable import EXDevMenuInterface
 
 class UIMockedNOOPBridge: RCTBridge {
-  
   override func invalidate() {
     // NOOP
   }
-  
+
   override func setUp() {
     bundleURL = URL(string: "http://localhost:1234")
   }
@@ -14,15 +13,15 @@ class UIMockedNOOPBridge: RCTBridge {
 
 class BridgeWithDevMenuExtension: UIMockedNOOPBridge {
   var extensions: [DevMenuExtensionProtocol] = []
-  
+
   override func modulesConforming(to protocolClass: Protocol!) -> [Any]! {
     let extensionProtocol: Protocol = DevMenuExtensionProtocol.self
-    if (protocolClass === extensionProtocol) {
+    if protocolClass === extensionProtocol {
       return extensions
     }
     return []
   }
-  
+
   override func module(forName moduleName: String!) -> Any! {
     return extensions.first(where: {
       type(of: $0).moduleName?() == moduleName

--- a/packages/expo-dev-menu/ios/UITests/XCTestCase+DevMenuExtension.swift
+++ b/packages/expo-dev-menu/ios/UITests/XCTestCase+DevMenuExtension.swift
@@ -6,24 +6,24 @@ extension XCTest {
   func assertViewExists(tag: String) {
     XCTAssertNotNil(DevMenuUIMatchers.findView(tag: tag), "View with tag \(tag) does not exists.")
   }
-  
+
   func assertViewExists(text: String) {
     let view = DevMenuUIMatchers.findView(text: text)
     XCTAssertNotNil(view, "View with text \(text) does not exists.")
   }
-  
+
   func waitForView(tag: String) {
     XCTAssertNotNil(DevMenuUIMatchers.waitForView(tag: tag))
   }
-  
+
   func waitForDevMenu() {
     waitForView(tag: DevMenuViews.mainScreen)
     waitForView(tag: DevMenuViews.footer)
     XCTAssertTrue(DevMenuManager.shared.isVisible)
-    
+
     DevMenuLooper.runMainLoopUntilEmpty()
   }
-  
+
   func runMainLoop(for sec: Double) {
     DevMenuLooper.runMainLoop(for: sec)
   }

--- a/packages/expo-image-manipulator/ios/ImageManipulations.swift
+++ b/packages/expo-image-manipulator/ios/ImageManipulations.swift
@@ -177,7 +177,6 @@ internal func fixImageOrientation(_ image: UIImage) throws -> UIImage {
     context.draw(cgImage, in: CGRect(x: 0, y: 0, width: image.size.height, height: image.size.width))
   default:
     context.draw(cgImage, in: CGRect(x: 0, y: 0, width: image.size.width, height: image.size.height))
-    break
   }
 
   guard let newCGImage = context.makeImage() else {

--- a/packages/expo-image-manipulator/ios/ImageManipulations.swift
+++ b/packages/expo-image-manipulator/ios/ImageManipulations.swift
@@ -190,7 +190,7 @@ internal func fixImageOrientation(_ image: UIImage) throws -> UIImage {
  Helper function for drawing the image in graphics context.
  Throws appropriate errors when the context is missing or the image couldn't be rendered.
  */
-fileprivate func drawInNewContext(size: CGSize, drawing: (CGContext) -> ()) throws -> UIImage {
+private func drawInNewContext(size: CGSize, drawing: (CGContext) -> Void) throws -> UIImage {
   UIGraphicsBeginImageContext(size)
 
   guard let context = UIGraphicsGetCurrentContext() else {
@@ -208,4 +208,3 @@ fileprivate func drawInNewContext(size: CGSize, drawing: (CGContext) -> ()) thro
   UIGraphicsEndImageContext()
   return newImage
 }
-

--- a/packages/expo-image-manipulator/ios/ImageManipulatorModule.swift
+++ b/packages/expo-image-manipulator/ios/ImageManipulatorModule.swift
@@ -6,7 +6,7 @@ import UIKit
 import ExpoModulesCore
 
 public class ImageManipulatorModule: Module {
-  typealias LoadImageCallback = (Result<UIImage, Error>) -> ()
+  typealias LoadImageCallback = (Result<UIImage, Error>) -> Void
   typealias SaveImageResult = (url: URL, data: Data)
 
   public func definition() -> ModuleDefinition {
@@ -87,7 +87,7 @@ public class ImageManipulatorModule: Module {
     options.isSynchronous = true
     options.deliveryMode = .highQualityFormat
 
-    PHImageManager.default().requestImage(for: asset, targetSize: size, contentMode: .aspectFit, options: options) { image, info in
+    PHImageManager.default().requestImage(for: asset, targetSize: size, contentMode: .aspectFit, options: options) { image, _ in
       guard let image = image else {
         return callback(.failure(ImageNotFoundError()))
       }

--- a/packages/expo-linear-gradient/ios/LinearGradientLayer.swift
+++ b/packages/expo-linear-gradient/ios/LinearGradientLayer.swift
@@ -77,7 +77,7 @@ final class LinearGradientLayer: CALayer {
     ctx.saveGState()
 
     let colorSpace = CGColorSpaceCreateDeviceRGB()
-    let locations = colors.enumerated().map { (offset: Int, element: CGColor) -> CGFloat in
+    let locations = colors.enumerated().map { (offset: Int, _: CGColor) -> CGFloat in
       if self.locations.count > offset {
         return self.locations[offset]
       } else {

--- a/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegate.swift
+++ b/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegate.swift
@@ -16,28 +16,28 @@ open class ExpoAppDelegate: UIResponder, UIApplicationDelegate {
   open var window: UIWindow?
 
   @objc
-  public let reactDelegate = ExpoReactDelegate(handlers: reactDelegateHandlers)
+  public weak var reactDelegate = ExpoReactDelegate(handlers: reactDelegateHandlers)
 
   // MARK: - Initializing the App
 
-  open func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+  open func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
     let parsedSubscribers = subscribers.filter {
       $0.responds(to: #selector(application(_:willFinishLaunchingWithOptions:)))
     }
-    
+
     // If we can't find a subscriber that implements `willFinishLaunchingWithOptions`, we will delegate the decision if we can handel the passed URL to
     // the `didFinishLaunchingWithOptions` method by returning `true` here.
     //  You can read more about how iOS handles deep links here: https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623112-application#discussion
-    if (parsedSubscribers.isEmpty) {
-      return true;
+    if parsedSubscribers.isEmpty {
+      return true
     }
-    
+
     return parsedSubscribers.reduce(false) { result, subscriber in
       return subscriber.application!(application, willFinishLaunchingWithOptions: launchOptions) || result
     }
   }
 
-  open func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+  open func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
     return subscribers.reduce(false) { result, subscriber in
       return subscriber.application?(application, didFinishLaunchingWithOptions: launchOptions) ?? false || result
     }
@@ -107,7 +107,7 @@ open class ExpoAppDelegate: UIResponder, UIApplicationDelegate {
     subscribers.forEach { $0.application?(application, didFailToRegisterForRemoteNotificationsWithError: error) }
   }
 
-  open func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable : Any], fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
+  open func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable: Any], fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
     let selector = #selector(application(_:didReceiveRemoteNotification:fetchCompletionHandler:))
     let subs = subscribers.filter { $0.responds(to: selector) }
     var subscribersLeft = subs.count
@@ -238,7 +238,7 @@ open class ExpoAppDelegate: UIResponder, UIApplicationDelegate {
 
   // MARK: - Opening a URL-Specified Resource
 
-  open func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+  open func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
     return subscribers.contains { subscriber in
       return subscriber.application?(app, open: url, options: options) ?? false
     }
@@ -283,7 +283,7 @@ open class ExpoAppDelegate: UIResponder, UIApplicationDelegate {
       fatalError("Expo modules provider must implement `ModulesProviderProtocol`.")
     }
     provider.getReactDelegateHandlers()
-      .sorted { (tuple1, tuple2) -> Bool in
+      .sorted { tuple1, tuple2 -> Bool in
         return ModulePriorities.get(tuple1.packageName) > ModulePriorities.get(tuple2.packageName)
       }
       .forEach { handlerTuple in

--- a/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegate.swift
+++ b/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegate.swift
@@ -16,7 +16,7 @@ open class ExpoAppDelegate: UIResponder, UIApplicationDelegate {
   open var window: UIWindow?
 
   @objc
-  public weak var reactDelegate = ExpoReactDelegate(handlers: reactDelegateHandlers)
+  public let reactDelegate = ExpoReactDelegate(handlers: reactDelegateHandlers)
 
   // MARK: - Initializing the App
 
@@ -107,7 +107,11 @@ open class ExpoAppDelegate: UIResponder, UIApplicationDelegate {
     subscribers.forEach { $0.application?(application, didFailToRegisterForRemoteNotificationsWithError: error) }
   }
 
-  open func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable: Any], fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
+  open func application(
+    _ application: UIApplication,
+    didReceiveRemoteNotification userInfo: [AnyHashable: Any],
+    fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
+  ) {
     let selector = #selector(application(_:didReceiveRemoteNotification:fetchCompletionHandler:))
     let subs = subscribers.filter { $0.responds(to: selector) }
     var subscribersLeft = subs.count
@@ -143,7 +147,11 @@ open class ExpoAppDelegate: UIResponder, UIApplicationDelegate {
     }
   }
 
-  open func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
+  open func application(
+    _ application: UIApplication,
+    continue userActivity: NSUserActivity,
+    restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void
+  ) -> Bool {
     let selector = #selector(application(_:continue:restorationHandler:))
     let subs = subscribers.filter { $0.responds(to: selector) }
     var subscribersLeft = subs.count

--- a/packages/expo-modules-core/ios/ReactDelegates/ExpoReactDelegate.swift
+++ b/packages/expo-modules-core/ios/ReactDelegates/ExpoReactDelegate.swift
@@ -12,7 +12,7 @@ public class ExpoReactDelegate: NSObject {
   }
 
   @objc
-  public func createBridge(delegate: RCTBridgeDelegate, launchOptions: [AnyHashable : Any]?) -> RCTBridge {
+  public func createBridge(delegate: RCTBridgeDelegate, launchOptions: [AnyHashable: Any]?) -> RCTBridge {
     self.handlers.forEach { $0.bridgeWillCreate() }
     let result = self.handlers.lazy
       .compactMap { $0.createBridge(reactDelegate: self, bridgeDelegate: delegate, launchOptions: launchOptions) }
@@ -22,7 +22,7 @@ public class ExpoReactDelegate: NSObject {
   }
 
   @objc
-  public func createRootView(bridge: RCTBridge, moduleName: String, initialProperties: [AnyHashable : Any]?) -> RCTRootView {
+  public func createRootView(bridge: RCTBridge, moduleName: String, initialProperties: [AnyHashable: Any]?) -> RCTRootView {
     return self.handlers.lazy
       .compactMap { $0.createRootView(reactDelegate: self, bridge: bridge, moduleName: moduleName, initialProperties: initialProperties) }
       .first(where: { _ in true }) ?? RCTRootView(bridge: bridge, moduleName: moduleName, initialProperties: initialProperties)

--- a/packages/expo-modules-core/ios/ReactDelegates/ExpoReactDelegateHandler.swift
+++ b/packages/expo-modules-core/ios/ReactDelegates/ExpoReactDelegateHandler.swift
@@ -14,7 +14,7 @@ open class ExpoReactDelegateHandler: NSObject {
    Otherwise return nil.
    */
   @objc
-  open func createBridge(reactDelegate: ExpoReactDelegate, bridgeDelegate: RCTBridgeDelegate, launchOptions: [AnyHashable : Any]?) -> RCTBridge? {
+  open func createBridge(reactDelegate: ExpoReactDelegate, bridgeDelegate: RCTBridgeDelegate, launchOptions: [AnyHashable: Any]?) -> RCTBridge? {
     return nil
   }
 
@@ -23,7 +23,7 @@ open class ExpoReactDelegateHandler: NSObject {
    Otherwise return nil.
    */
   @objc
-  open func createRootView(reactDelegate: ExpoReactDelegate, bridge: RCTBridge, moduleName: String, initialProperties: [AnyHashable : Any]?) -> RCTRootView? {
+  open func createRootView(reactDelegate: ExpoReactDelegate, bridge: RCTBridge, moduleName: String, initialProperties: [AnyHashable: Any]?) -> RCTRootView? {
     return nil
   }
 
@@ -36,7 +36,7 @@ open class ExpoReactDelegateHandler: NSObject {
     return nil
   }
 
-  // MARK - event callbacks
+  // MARK: - event callbacks
 
   /**
    Callback before bridge creation

--- a/packages/expo-modules-core/ios/ReactDelegates/ModulePriorities.swift
+++ b/packages/expo-modules-core/ios/ReactDelegates/ModulePriorities.swift
@@ -11,7 +11,7 @@ internal struct ModulePriorities {
     // key: node package name
     // value: priority value, the higher value takes precedence
     "expo-screen-orientation": 10,
-    "expo-updates": 5,
+    "expo-updates": 5
   ]
 
   static func get(_ packageName: String) -> Int {

--- a/packages/expo-modules-core/ios/Swift/AppContext.swift
+++ b/packages/expo-modules-core/ios/Swift/AppContext.swift
@@ -85,7 +85,7 @@ public final class AppContext {
     [
       UIApplication.willEnterForegroundNotification,
       UIApplication.didBecomeActiveNotification,
-      UIApplication.didEnterBackgroundNotification,
+      UIApplication.didEnterBackgroundNotification
     ].forEach { name in
       NotificationCenter.default.addObserver(self, selector: #selector(handleClientAppNotification(_:)), name: name, object: nil)
     }

--- a/packages/expo-modules-core/ios/Swift/Arguments/ArgumentType.swift
+++ b/packages/expo-modules-core/ios/Swift/Arguments/ArgumentType.swift
@@ -1,5 +1,9 @@
 // Copyright 2021-present 650 Industries. All rights reserved.
 
+// Function names should start with a lowercase character, but in this one case
+// we want it to be uppercase as we treat it more like a generic class.
+// swiftlint:disable identifier_name
+
 /**
  Factory creating an instance of the argument type wrapper conforming to `AnyArgumentType`.
  Depending on the given type, it may return one of `ArrayArgumentType`, `OptionalArgumentType`, `ConvertibleArgumentType`, etc.

--- a/packages/expo-modules-core/ios/Swift/Arguments/Convertibles.swift
+++ b/packages/expo-modules-core/ios/Swift/Arguments/Convertibles.swift
@@ -3,11 +3,11 @@
 import UIKit
 import CoreGraphics
 
-/// Here we extend some common iOS types to implement `ConvertibleArgument` protocol and
-/// describe how they can be converted from primitive types received from JavaScript runtime.
-/// This allows these types to be used as argument types of functions callable from JavaScript.
-/// As an example, when the `CGPoint` type is used as an argument type, its instance can be
-/// created from an array of two doubles or an object with `x` and `y` fields.
+// Here we extend some common iOS types to implement `ConvertibleArgument` protocol and
+// describe how they can be converted from primitive types received from JavaScript runtime.
+// This allows these types to be used as argument types of functions callable from JavaScript.
+// As an example, when the `CGPoint` type is used as an argument type, its instance can be
+// created from an array of two doubles or an object with `x` and `y` fields.
 
 // MARK: - Foundation
 

--- a/packages/expo-modules-core/ios/Swift/Conversions.swift
+++ b/packages/expo-modules-core/ios/Swift/Conversions.swift
@@ -1,10 +1,9 @@
-
 internal final class Conversions {
   /**
    Converts an array to tuple. Because of tuples nature, it's not possible to convert an array of any size, so we can support only up to some fixed size.
    */
   static func toTuple(_ array: [Any?]) throws -> Any? {
-    switch (array.count) {
+    switch array.count {
     case 0:
       return ()
     case 1:

--- a/packages/expo-modules-core/ios/Swift/Conversions.swift
+++ b/packages/expo-modules-core/ios/Swift/Conversions.swift
@@ -67,10 +67,10 @@ internal final class Conversions {
         result.invalidKeys.append(key)
       }
     }
-    if result.missingKeys.count > 0 {
+    if !result.missingKeys.isEmpty {
       throw MissingKeysError<ValueType>(keys: result.missingKeys)
     }
-    if result.invalidKeys.count > 0 {
+    if !result.invalidKeys.isEmpty {
       throw CastingValuesError<ValueType>(keys: result.invalidKeys)
     }
     return result.values

--- a/packages/expo-modules-core/ios/Swift/EventListener.swift
+++ b/packages/expo-modules-core/ios/Swift/EventListener.swift
@@ -10,7 +10,7 @@ internal struct EventListener: AnyDefinition {
    */
   init(_ name: EventName, _ listener: @escaping () -> Void) {
     self.name = name
-    self.call = { (sender, payload) in listener() }
+    self.call = { _, _ in listener() }
   }
 
   /**
@@ -18,7 +18,7 @@ internal struct EventListener: AnyDefinition {
    */
   init<Sender>(_ name: EventName, _ listener: @escaping (Sender) -> Void) {
     self.name = name
-    self.call = { (sender, payload) in
+    self.call = { sender, _ in
       guard let sender = sender as? Sender else {
         throw InvalidSenderTypeError(eventName: name, senderType: Sender.self)
       }
@@ -31,7 +31,7 @@ internal struct EventListener: AnyDefinition {
    */
   init<Sender, PayloadType>(_ name: EventName, _ listener: @escaping (Sender, PayloadType?) -> Void) {
     self.name = name
-    self.call = { (sender, payload) in
+    self.call = { sender, payload in
       guard let sender = sender as? Sender else {
         throw InvalidSenderTypeError(eventName: name, senderType: Sender.self)
       }

--- a/packages/expo-modules-core/ios/Swift/Functions/AnyFunction.swift
+++ b/packages/expo-modules-core/ios/Swift/Functions/AnyFunction.swift
@@ -27,7 +27,7 @@ public protocol AnyFunction: AnyDefinition {
   /**
    Calls the function on given module with arguments and a promise.
    */
-  func call(args: [Any], promise: Promise) -> Void
+  func call(args: [Any], promise: Promise)
 
   /**
    Synchronously calls the function with given arguments. If the function takes a promise,

--- a/packages/expo-modules-core/ios/Swift/Functions/ConcreteFunction.swift
+++ b/packages/expo-modules-core/ios/Swift/Functions/ConcreteFunction.swift
@@ -62,7 +62,7 @@ public final class ConcreteFunction<Args, ReturnType>: AnyFunction {
       let promise = Promise {
         result = $0
         semaphore.signal()
-      } rejecter: { error in
+      } rejecter: { _ in
         semaphore.signal()
       }
       call(args: args, promise: promise)
@@ -92,7 +92,7 @@ public final class ConcreteFunction<Args, ReturnType>: AnyFunction {
     if args.count != argumentsCount {
       throw InvalidArgsNumberError(received: args.count, expected: argumentsCount)
     }
-    return try args.enumerated().map { (index, arg) in
+    return try args.enumerated().map { index, arg in
       let expectedType = argumentType(atIndex: index)
 
       // It's safe to unwrap since the arguments count matches.

--- a/packages/expo-modules-core/ios/Swift/ModuleHolder.swift
+++ b/packages/expo-modules-core/ios/Swift/ModuleHolder.swift
@@ -119,9 +119,9 @@ public final class ModuleHolder {
    */
   func modifyListenersCount(_ count: Int) {
     if count > 0 && listenersCount == 0 {
-      let _ = definition.functions["startObserving"]?.callSync(args: [])
+      _ = definition.functions["startObserving"]?.callSync(args: [])
     } else if count < 0 && listenersCount + count <= 0 {
-      let _ = definition.functions["stopObserving"]?.callSync(args: [])
+      _ = definition.functions["stopObserving"]?.callSync(args: [])
     }
     listenersCount = max(0, listenersCount + count)
   }

--- a/packages/expo-modules-core/ios/Swift/ModuleRegistry.swift
+++ b/packages/expo-modules-core/ios/Swift/ModuleRegistry.swift
@@ -1,4 +1,3 @@
-
 public final class ModuleRegistry: Sequence {
   public typealias Element = ModuleHolder
 

--- a/packages/expo-modules-core/ios/Swift/Modules/AnyModule.swift
+++ b/packages/expo-modules-core/ios/Swift/Modules/AnyModule.swift
@@ -1,4 +1,3 @@
-
 /**
  A protocol for any type-erased module that provides functions used by the core.
  */

--- a/packages/expo-modules-core/ios/Swift/Modules/ModuleDefinition.swift
+++ b/packages/expo-modules-core/ios/Swift/Modules/ModuleDefinition.swift
@@ -1,4 +1,3 @@
-
 /**
  A protocol that must be implemented to be a part of module's definition and the module definition itself.
  */

--- a/packages/expo-modules-core/ios/Swift/Modules/ModuleDefinitionBuilder.swift
+++ b/packages/expo-modules-core/ios/Swift/Modules/ModuleDefinitionBuilder.swift
@@ -1,4 +1,3 @@
-
 #if swift(>=5.4)
 /**
  A function builder that provides DSL-like syntax. Thanks to this, the function doesn't need to explicitly return an array,

--- a/packages/expo-modules-core/ios/Swift/ModulesProvider.swift
+++ b/packages/expo-modules-core/ios/Swift/ModulesProvider.swift
@@ -1,4 +1,3 @@
-
 import Foundation
 
 /**

--- a/packages/expo-modules-core/ios/Swift/Objects/ObjectDefinitionComponents.swift
+++ b/packages/expo-modules-core/ios/Swift/Objects/ObjectDefinitionComponents.swift
@@ -157,13 +157,13 @@ public func events(_ names: String...) -> AnyDefinition {
 /**
  Function that is invoked when the first event listener is added.
  */
-public func onStartObserving(_ body: @escaping () -> ()) -> AnyFunction {
+public func onStartObserving(_ body: @escaping () -> Void) -> AnyFunction {
   return ConcreteFunction("startObserving", argTypes: [], body)
 }
 
 /**
  Function that is invoked when all event listeners are removed.
  */
-public func onStopObserving(_ body: @escaping () -> ()) -> AnyFunction {
+public func onStopObserving(_ body: @escaping () -> Void) -> AnyFunction {
   return ConcreteFunction("stopObserving", argTypes: [], body)
 }

--- a/packages/expo-modules-core/ios/Swift/Objects/ObjectDefinitionComponents.swift
+++ b/packages/expo-modules-core/ios/Swift/Objects/ObjectDefinitionComponents.swift
@@ -70,7 +70,11 @@ public func function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument>(
 ) -> AnyFunction {
   return ConcreteFunction(
     name,
-    argTypes: [ArgumentType(A0.self), ArgumentType(A1.self), ArgumentType(A2.self)],
+    argTypes: [
+      ArgumentType(A0.self),
+      ArgumentType(A1.self),
+      ArgumentType(A2.self)
+    ],
     closure
   )
 }
@@ -84,7 +88,12 @@ public func function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: A
 ) -> AnyFunction {
   return ConcreteFunction(
     name,
-    argTypes: [ArgumentType(A0.self), ArgumentType(A1.self), ArgumentType(A2.self), ArgumentType(A3.self)],
+    argTypes: [
+      ArgumentType(A0.self),
+      ArgumentType(A1.self),
+      ArgumentType(A2.self),
+      ArgumentType(A3.self)
+    ],
     closure
   )
 }
@@ -98,7 +107,13 @@ public func function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: A
 ) -> AnyFunction {
   return ConcreteFunction(
     name,
-    argTypes: [ArgumentType(A0.self), ArgumentType(A1.self), ArgumentType(A2.self), ArgumentType(A3.self), ArgumentType(A4.self)],
+    argTypes: [
+      ArgumentType(A0.self),
+      ArgumentType(A1.self),
+      ArgumentType(A2.self),
+      ArgumentType(A3.self),
+      ArgumentType(A4.self)
+    ],
     closure
   )
 }
@@ -112,7 +127,14 @@ public func function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: A
 ) -> AnyFunction {
   return ConcreteFunction(
     name,
-    argTypes: [ArgumentType(A0.self), ArgumentType(A1.self), ArgumentType(A2.self), ArgumentType(A3.self), ArgumentType(A4.self), ArgumentType(A5.self)],
+    argTypes: [
+      ArgumentType(A0.self),
+      ArgumentType(A1.self),
+      ArgumentType(A2.self),
+      ArgumentType(A3.self),
+      ArgumentType(A4.self),
+      ArgumentType(A5.self)
+    ],
     closure
   )
 }
@@ -126,7 +148,15 @@ public func function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: A
 ) -> AnyFunction {
   return ConcreteFunction(
     name,
-    argTypes: [ArgumentType(A0.self), ArgumentType(A1.self), ArgumentType(A2.self), ArgumentType(A3.self), ArgumentType(A4.self), ArgumentType(A5.self), ArgumentType(A6.self)],
+    argTypes: [
+      ArgumentType(A0.self),
+      ArgumentType(A1.self),
+      ArgumentType(A2.self),
+      ArgumentType(A3.self),
+      ArgumentType(A4.self),
+      ArgumentType(A5.self),
+      ArgumentType(A6.self)
+    ],
     closure
   )
 }
@@ -140,7 +170,16 @@ public func function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: A
 ) -> AnyFunction {
   return ConcreteFunction(
     name,
-    argTypes: [ArgumentType(A0.self), ArgumentType(A1.self), ArgumentType(A2.self), ArgumentType(A3.self), ArgumentType(A4.self), ArgumentType(A5.self), ArgumentType(A6.self), ArgumentType(A7.self)],
+    argTypes: [
+      ArgumentType(A0.self),
+      ArgumentType(A1.self),
+      ArgumentType(A2.self),
+      ArgumentType(A3.self),
+      ArgumentType(A4.self),
+      ArgumentType(A5.self),
+      ArgumentType(A6.self),
+      ArgumentType(A7.self)
+    ],
     closure
   )
 }

--- a/packages/expo-modules-core/ios/Swift/Promise.swift
+++ b/packages/expo-modules-core/ios/Swift/Promise.swift
@@ -12,12 +12,12 @@ public struct Promise: AnyArgument {
    Necessary in some places not converted to Swift, such as `EXPermissionsMethodsDelegate`.
    */
   public var legacyRejecter: EXPromiseRejectBlock {
-    return { code, description, error in
+    return { code, description, _ in
       reject(code ?? "", description ?? "")
     }
   }
 
-  public func resolve(_ value: Any? = nil) -> Void {
+  public func resolve(_ value: Any? = nil) {
     resolver(value)
   }
 
@@ -29,7 +29,7 @@ public struct Promise: AnyArgument {
     rejecter(error)
   }
 
-  public func reject(_ code: String, _ description: String) -> Void {
+  public func reject(_ code: String, _ description: String) {
     rejecter(SimpleCodedError(code, description))
   }
 }

--- a/packages/expo-modules-core/ios/Swift/Records/FieldOption.swift
+++ b/packages/expo-modules-core/ios/Swift/Records/FieldOption.swift
@@ -15,7 +15,7 @@ public struct FieldOption: Equatable, Hashable, ExpressibleByIntegerLiteral, Exp
   /**
    Field options are equal when their raw values and parameters are equal.
    */
-  public static func ==(lhs: Self, rhs: Self) -> Bool {
+  public static func == (lhs: Self, rhs: Self) -> Bool {
     return lhs.rawValue == rhs.rawValue && lhs.key == rhs.key
   }
 

--- a/packages/expo-modules-core/ios/Swift/Records/Record.swift
+++ b/packages/expo-modules-core/ios/Swift/Records/Record.swift
@@ -61,7 +61,7 @@ public extension Record {
  Returns an array of fields found in record's mirror. If the field is missing the `key`,
  it gets assigned to the property label, so after all it's safe to enforce unwrapping it (using `key!`).
  */
-fileprivate func fieldsOf(_ record: Record) -> [AnyFieldInternal] {
+private func fieldsOf(_ record: Record) -> [AnyFieldInternal] {
   return Mirror(reflecting: record).children.compactMap { (label: String?, value: Any) in
     guard var field = value as? AnyFieldInternal, let key = field.key ?? convertLabelToKey(label) else {
       return nil
@@ -74,6 +74,6 @@ fileprivate func fieldsOf(_ record: Record) -> [AnyFieldInternal] {
 /**
  Converts mirror's label to field's key by dropping the "_" prefix from wrapped property label.
  */
-fileprivate func convertLabelToKey(_ label: String?) -> String? {
+private func convertLabelToKey(_ label: String?) -> String? {
   return (label != nil && label!.starts(with: "_")) ? String(label!.dropFirst()) : label
 }

--- a/packages/expo-modules-core/ios/Swift/SwiftInteropBridge.swift
+++ b/packages/expo-modules-core/ios/Swift/SwiftInteropBridge.swift
@@ -20,11 +20,13 @@ public final class SwiftInteropBridge: NSObject {
   }
 
   @objc
-  public func callFunction(_ functionName: String,
-                           onModule moduleName: String,
-                           withArgs args: [Any],
-                           resolve: @escaping EXPromiseResolveBlock,
-                           reject: @escaping EXPromiseRejectBlock) {
+  public func callFunction(
+    _ functionName: String,
+    onModule moduleName: String,
+    withArgs args: [Any],
+    resolve: @escaping EXPromiseResolveBlock,
+    reject: @escaping EXPromiseRejectBlock
+  ) {
     registry
       .get(moduleHolderForName: moduleName)?
       .call(function: functionName, args: args) { value, error in
@@ -39,9 +41,11 @@ public final class SwiftInteropBridge: NSObject {
   }
 
   @objc
-  public func callFunctionSync(_ functionName: String,
-                               onModule moduleName: String,
-                               withArgs args: [Any]) -> Any? {
+  public func callFunctionSync(
+    _ functionName: String,
+    onModule moduleName: String,
+    withArgs args: [Any]
+  ) -> Any? {
     return registry
       .get(moduleHolderForName: moduleName)?
       .callSync(function: functionName, args: args)

--- a/packages/expo-modules-core/ios/Swift/SwiftInteropBridge.swift
+++ b/packages/expo-modules-core/ios/Swift/SwiftInteropBridge.swift
@@ -1,4 +1,3 @@
-
 import Foundation
 
 @objc
@@ -53,11 +52,11 @@ public final class SwiftInteropBridge: NSObject {
     var constants = [String: [[String: Any]]]()
 
     for holder in registry {
-      constants[holder.name] = holder.definition.functions.map({ (functionName, function) in
+      constants[holder.name] = holder.definition.functions.map({ functionName, function in
         return [
           "name": functionName,
           "argumentsCount": function.argumentsCount,
-          "key": functionName,
+          "key": functionName
         ]
       })
     }

--- a/packages/expo-modules-core/ios/Swift/Views/ViewManagerDefinitionBuilder.swift
+++ b/packages/expo-modules-core/ios/Swift/Views/ViewManagerDefinitionBuilder.swift
@@ -1,4 +1,3 @@
-
 #if swift(>=5.4)
 /**
  A result builder that captures scoped definitions specific for view managers, such as `ViewFactory` and `ConcreteViewProp`.

--- a/packages/expo-modules-core/ios/Swift/Views/ViewModuleWrapper.swift
+++ b/packages/expo-modules-core/ios/Swift/Views/ViewModuleWrapper.swift
@@ -93,7 +93,7 @@ public final class ViewModuleWrapper: RCTViewManager, DynamicModuleWrapperProtoc
    */
   @objc
   public class func propConfig_proxiedProperties() -> [String] {
-    return ["NSDictionary", "__custom__"];
+    return ["NSDictionary", "__custom__"]
   }
 
   /**

--- a/packages/expo-modules-core/ios/Tests/ArgumentTypeSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/ArgumentTypeSpec.swift
@@ -7,7 +7,6 @@ import Nimble
 
 class ArgumentTypeSpec: QuickSpec {
   override func spec() {
-
     it("casts primitives") {
       let type = ArgumentType(Int.self)
       let value = 123

--- a/packages/expo-modules-core/ios/Tests/FunctionSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/FunctionSpec.swift
@@ -15,7 +15,7 @@ class FunctionSpec: QuickSpec {
             return returnValue
           }
         }
-        .call(function: functionName, args: []) { value, error in
+        .call(function: functionName, args: []) { value, _ in
           expect(value).notTo(beNil())
           expect(value).to(beAKindOf(T.self))
           expect(value as? T).to(equal(returnValue))
@@ -42,7 +42,7 @@ class FunctionSpec: QuickSpec {
     }
 
     it("returns int values") {
-      testFunctionReturning(value: 1234)
+      testFunctionReturning(value: 1_234)
       testFunctionReturning(value: [2, 1, 3, 7])
     }
 
@@ -81,7 +81,7 @@ class FunctionSpec: QuickSpec {
     describe("converting dicts to records") {
       struct TestRecord: Record {
         @Field var property: String = "expo"
-        @Field var optionalProperty: Int? = nil
+        @Field var optionalProperty: Int?
         @Field("propertyWithCustomKey") var customKeyProperty: String = "expo"
       }
       let dict = [
@@ -96,7 +96,7 @@ class FunctionSpec: QuickSpec {
               return a.property
             }
           }
-          .call(function: functionName, args: [dict]) { value, error in
+          .call(function: functionName, args: [dict]) { value, _ in
             expect(value).notTo(beNil())
             expect(value).to(beAKindOf(String.self))
             expect(value).to(be(dict["property"]))
@@ -112,7 +112,7 @@ class FunctionSpec: QuickSpec {
               return a.customKeyProperty
             }
           }
-          .call(function: functionName, args: [dict]) { value, error in
+          .call(function: functionName, args: [dict]) { value, _ in
             expect(value).notTo(beNil())
             expect(value).to(beAKindOf(String.self))
             expect(value).to(be(dict["propertyWithCustomKey"]))
@@ -128,7 +128,7 @@ class FunctionSpec: QuickSpec {
               return a.toDictionary()
             }
           }
-          .call(function: functionName, args: [dict]) { value, error in
+          .call(function: functionName, args: [dict]) { value, _ in
             expect(value).notTo(beNil())
             expect(value).to(beAKindOf(Record.Dict.self))
 
@@ -145,12 +145,12 @@ class FunctionSpec: QuickSpec {
     it("throws when called with more arguments than expected") {
       waitUntil { done in
         mockModuleHolder(appContext) {
-          function(functionName) { (a: Int) in
+          function(functionName) { (_: Int) in
             return "something"
           }
         }
         // Function expects one argument, let's give it more.
-        .call(function: functionName, args: [1, 2]) { value, error in
+        .call(function: functionName, args: [1, 2]) { _, error in
           expect(error).notTo(beNil())
           expect(error).to(beAKindOf(InvalidArgsNumberError.self))
           expect(error?.code).to(equal("ERR_INVALID_ARGS_NUMBER"))
@@ -163,7 +163,7 @@ class FunctionSpec: QuickSpec {
     it("throws when called with arguments of incompatible types") {
       waitUntil { done in
         mockModuleHolder(appContext) {
-          function(functionName) { (a: String) in
+          function(functionName) { (_: String) in
             return "something"
           }
         }

--- a/packages/expo-modules-core/ios/Tests/Mocks/ModuleMocks.swift
+++ b/packages/expo-modules-core/ios/Tests/Mocks/ModuleMocks.swift
@@ -32,7 +32,7 @@ class CustomModule: Module {
 typealias MockedDefinitionFunc = (CustomModule) -> ModuleDefinition
 
 func mockModuleHolder(_ appContext: AppContext, @ModuleDefinitionBuilder _ definitionBody: @escaping () -> ModuleDefinition) -> ModuleHolder {
-  return ModuleHolder(appContext: appContext, module: CustomModule(appContext: appContext, { module in definitionBody() }))
+  return ModuleHolder(appContext: appContext, module: CustomModule(appContext: appContext, { _ in definitionBody() }))
 }
 
 func mockModuleHolder(_ appContext: AppContext, @ModuleDefinitionBuilder _ definitionBody: @escaping (CustomModule) -> ModuleDefinition) -> ModuleHolder {

--- a/packages/expo-modules-core/ios/Tests/Mocks/ModulesProviderMock.swift
+++ b/packages/expo-modules-core/ios/Tests/Mocks/ModulesProviderMock.swift
@@ -3,7 +3,6 @@ import ExpoModulesCore
 public class ModulesProviderMock: ModulesProvider {
   public override func getModuleClasses() -> [AnyModule.Type] {
     return [
-
     ]
   }
 }

--- a/packages/expo-modules-core/ios/Tests/ModuleEventListenersSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/ModuleEventListenersSpec.swift
@@ -21,7 +21,7 @@ class ModuleEventListenersSpec: QuickSpec {
 
     it("calls onCreate once the module instance is created") {
       waitUntil { done in
-        let _ = mockModuleHolder(appContext) {
+        _ = mockModuleHolder(appContext) {
           $0.onCreate {
             done()
           }

--- a/packages/expo-modules-core/ios/Tests/RecordSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/RecordSpec.swift
@@ -7,7 +7,7 @@ class RecordSpec: QuickSpec {
   override func spec() {
     it("initializes with empty dictionary") {
       struct TestRecord: Record { }
-      let _ = try TestRecord(from: [:])
+      _ = try TestRecord(from: [:])
     }
 
     it("works back and forth with a field") {
@@ -38,7 +38,7 @@ class RecordSpec: QuickSpec {
       }
 
       do {
-        let _ = try TestRecord(from: [:])
+        _ = try TestRecord(from: [:])
         fail()
       } catch let error as CodedError {
         expect(error).to(beAKindOf(FieldRequiredError.self))
@@ -54,7 +54,7 @@ class RecordSpec: QuickSpec {
       let dict = ["a": "try with String instead of Int"]
 
       do {
-        let _ = try TestRecord(from: dict)
+        _ = try TestRecord(from: dict)
         fail()
       } catch let error as CodedError {
         expect(error).to(beAKindOf(FieldInvalidTypeError.self))

--- a/packages/expo-screen-orientation/ios/EXScreenOrientation/ScreenOrientationAppDelegate.swift
+++ b/packages/expo-screen-orientation/ios/EXScreenOrientation/ScreenOrientationAppDelegate.swift
@@ -3,7 +3,7 @@
 import ExpoModulesCore
 
 public class ScreenOrientationAppDelegate: ExpoAppDelegateSubscriber {
-  public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+  public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
     if let screenOrientationRegistry = ModuleRegistryProvider.getSingletonModule(for: EXScreenOrientationRegistry.self) as? EXScreenOrientationRegistry {
       screenOrientationRegistry.updateCurrentScreenOrientation()
     }

--- a/packages/expo-screen-orientation/ios/EXScreenOrientation/ScreenOrientationReactDelegateHandler.swift
+++ b/packages/expo-screen-orientation/ios/EXScreenOrientation/ScreenOrientationReactDelegateHandler.swift
@@ -4,6 +4,6 @@ import ExpoModulesCore
 
 public class ScreenOrientationReactDelegateHandler: ExpoReactDelegateHandler {
   public override func createRootViewController(reactDelegate: ExpoReactDelegate) -> UIViewController? {
-    return EXScreenOrientationViewController(defaultScreenOrientationFromPlist: ());
+    return EXScreenOrientationViewController(defaultScreenOrientationFromPlist: ())
   }
 }

--- a/packages/expo-system-ui/ios/ExpoSystemUI/ExpoSystemUIModule.swift
+++ b/packages/expo-system-ui/ios/ExpoSystemUI/ExpoSystemUIModule.swift
@@ -3,10 +3,9 @@
 import ExpoModulesCore
 
 public class ExpoSystemUIModule: Module {
-  
   public func definition() -> ModuleDefinition {
     name("ExpoSystemUI")
-    
+
     onCreate {
       // TODO: Maybe read from the app manifest instead of from Info.plist.
       // Set / reset the initial color on reload and app start.
@@ -24,7 +23,7 @@ public class ExpoSystemUIModule: Module {
   }
 
   static func getBackgroundColor() -> String? {
-    var color: String? = nil
+    var color: String?
     EXUtilities.performSynchronously {
       // Get the root view controller of the delegate window.
       if let window = UIApplication.shared.delegate?.window, let backgroundColor = window?.rootViewController?.view.backgroundColor?.cgColor {
@@ -33,10 +32,10 @@ public class ExpoSystemUIModule: Module {
     }
     return color
   }
-  
+
   static func setBackgroundColorAsync(color: Int?) {
     EXUtilities.performSynchronously {
-      if (color == nil) {
+      if color == nil {
         if let window = UIApplication.shared.delegate?.window {
           window?.backgroundColor = nil
           window?.rootViewController?.view.backgroundColor = UIColor.white

--- a/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesReactDelegateHandler.swift
+++ b/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesReactDelegateHandler.swift
@@ -4,13 +4,13 @@ import ExpoModulesCore
 
 public class ExpoUpdatesReactDelegateHandler: ExpoReactDelegateHandler, EXUpdatesAppControllerDelegate, RCTBridgeDelegate {
   private weak var reactDelegate: ExpoReactDelegate?
-  private var bridgeDelegate: RCTBridgeDelegate?
-  private var launchOptions: [AnyHashable : Any]?
+  private weak var bridgeDelegate: RCTBridgeDelegate?
+  private var launchOptions: [AnyHashable: Any]?
   private var deferredRootView: EXDeferredRCTRootView?
   private var rootViewModuleName: String?
-  private var rootViewInitialProperties: [AnyHashable : Any]?
+  private var rootViewInitialProperties: [AnyHashable: Any]?
   private lazy var shouldEnableAutoSetup: Bool = {
-    if (EXAppDefines.APP_DEBUG) {
+    if EXAppDefines.APP_DEBUG {
       return false
     }
     // if Expo.plist not found or its content is invalid, disable the auto setup
@@ -29,15 +29,15 @@ public class ExpoUpdatesReactDelegateHandler: ExpoReactDelegateHandler, EXUpdate
 
     // Backward compatible if main AppDelegate already has expo-updates setup,
     // we just skip in this case.
-    if (EXUpdatesAppController.sharedInstance().isStarted) {
+    if EXUpdatesAppController.sharedInstance().isStarted {
       return false
     }
 
     return true
   }()
 
-  public override func createBridge(reactDelegate: ExpoReactDelegate, bridgeDelegate: RCTBridgeDelegate, launchOptions: [AnyHashable : Any]?) -> RCTBridge? {
-    if (!shouldEnableAutoSetup) {
+  public override func createBridge(reactDelegate: ExpoReactDelegate, bridgeDelegate: RCTBridgeDelegate, launchOptions: [AnyHashable: Any]?) -> RCTBridge? {
+    if !shouldEnableAutoSetup {
       return nil
     }
 
@@ -56,8 +56,8 @@ public class ExpoUpdatesReactDelegateHandler: ExpoReactDelegateHandler, EXUpdate
     return EXDeferredRCTBridge(delegate: self.bridgeDelegate!, launchOptions: self.launchOptions)
   }
 
-  public override func createRootView(reactDelegate: ExpoReactDelegate, bridge: RCTBridge, moduleName: String, initialProperties: [AnyHashable : Any]?) -> RCTRootView? {
-    if (!shouldEnableAutoSetup) {
+  public override func createRootView(reactDelegate: ExpoReactDelegate, bridge: RCTBridge, moduleName: String, initialProperties: [AnyHashable: Any]?) -> RCTRootView? {
+    if !shouldEnableAutoSetup {
       return nil
     }
 

--- a/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesReactDelegateHandler.swift
+++ b/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesReactDelegateHandler.swift
@@ -4,7 +4,7 @@ import ExpoModulesCore
 
 public class ExpoUpdatesReactDelegateHandler: ExpoReactDelegateHandler, EXUpdatesAppControllerDelegate, RCTBridgeDelegate {
   private weak var reactDelegate: ExpoReactDelegate?
-  private weak var bridgeDelegate: RCTBridgeDelegate?
+  private var bridgeDelegate: RCTBridgeDelegate?
   private var launchOptions: [AnyHashable: Any]?
   private var deferredRootView: EXDeferredRCTRootView?
   private var rootViewModuleName: String?


### PR DESCRIPTION
# Why

I added SwiftLint config in #15638, the time has come to start fixing lint issues.

# How

Ran `swiftlint lint --fix --use-alternative-excluding packages` and manually fixed most remaining warnings. I'll address errors separately as they're much more sensitive (like not using `!` operator).

I'm intentionally not updating changelogs — that's not even worth mentioning.

# Test Plan

Expo Go and bare-expo compiles. Applied changes shouldn't change the behavior.