### PR TITLE
[gl] Fix draw loop race condition

### DIFF
--- a/apps/native-component-list/src/screens/GL/GLReanimatedExample.tsx
+++ b/apps/native-component-list/src/screens/GL/GLReanimatedExample.tsx
@@ -46,11 +46,6 @@ function initializeContext(gl: ExpoWebGLRenderingContext, asset: Asset): RenderC
   }
 `;
   const vertices = new Float32Array([0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0]);
-  // const gl = global.__EXGLContexts[String(contextid)];
-  // This sets drawing buffer size to physical pixel size.
-  // For example, our GL View size is 150x150 virtual pixels and PixelRatio.get() returns 3.
-  // Then, gl.drawingBufferWidth and gl.drawingBufferHeight will equal 450 physical pixels.
-  gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
   const vert = gl.createShader(gl.VERTEX_SHADER)!;
   gl.shaderSource(vert, vertShader);
   gl.compileShader(vert);

--- a/ios/versioned/sdk44/EXGL/EXGL/ABI44_0_0EXGLView.mm
+++ b/ios/versioned/sdk44/EXGL/EXGL/ABI44_0_0EXGLView.mm
@@ -246,7 +246,7 @@
     // This happens exactly at `gl.endFrameEXP()` in the queue
     if (_viewColorbuffer != 0 && !_renderbufferPresented) {
       // bind renderbuffer and present it on the layer
-      [_glContext runInEAGLContext:_uiEaglCtx callback:^{
+      [_glContext runAsync:^{
         glBindRenderbuffer(GL_RENDERBUFFER, self->_viewColorbuffer);
         [self->_uiEaglCtx presentRenderbuffer:GL_RENDERBUFFER];
       }];

--- a/packages/expo-gl/CHANGELOG.md
+++ b/packages/expo-gl/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix segfault in iOS draw loop. ([#15653](https://github.com/expo/expo/pull/15653) by [@wkozyra95](https://github.com/wkozyra95))
+
 ### 💡 Others
 
 ## 11.1.1 — 2021-12-08

--- a/packages/expo-gl/ios/EXGL/EXGLView.mm
+++ b/packages/expo-gl/ios/EXGL/EXGLView.mm
@@ -246,7 +246,7 @@
     // This happens exactly at `gl.endFrameEXP()` in the queue
     if (_viewColorbuffer != 0 && !_renderbufferPresented) {
       // bind renderbuffer and present it on the layer
-      [_glContext runInEAGLContext:_uiEaglCtx callback:^{
+      [_glContext runAsync:^{
         glBindRenderbuffer(GL_RENDERBUFFER, self->_viewColorbuffer);
         [self->_uiEaglCtx presentRenderbuffer:GL_RENDERBUFFER];
       }];


### PR DESCRIPTION
# Why

```
0   AppleMetalGLRenderer          	0x00000001f20e1f0c GLRResourceList::addResource(GLRResource*) + 372 (gld_resourcelist.mm:242)
1   AppleMetalGLRenderer          	0x00000001f20e47f0 GLDTextureRec::blitAccum(id<MTLBlitCommandEncoder>, GLRResourceList*) + 184 (gld_texture.mm:825)
2   AppleMetalGLRenderer          	0x00000001f20db860 gldSetInteger + 864 (glr_context.mm:1051)
3   GLEngine                      	0x00000001bef76df0 gliPresentViewES_Exec + 136 (gli_drawable_es.c:102)
4   OpenGLES                      	0x00000001bef83cc0 -[EAGLContext presentRenderbuffer:] + 80 (eagl_context.m:594)
5   Expo Go                       	0x0000000101d08854 -[EXGLContext runInEAGLContext:callback:] + 84 (EXGLContext.mm:56)
6   Expo Go                       	0x0000000101d0bea8 -[EXGLView draw] + 180 (EXGLView.mm:249)
7   QuartzCore                    	0x0000000184c88d90 CA::Display::DisplayLink::dispatch_items(unsigned long long, unsigned long long, unsigned long long) + 756 (CADisplay.mm:4165)
8   QuartzCore                    	0x0000000184de3344 CA::Display::DisplayLink::dispatch_deferred_display_links() + 356 (CADisplay.mm:2610)
```

# How

run draw call on gl thread
cleanup ncl example unrelated to the issue

# Test Plan

The issue was reproducible on reanimated gl example especially when using worklets, it does not happen anymore after the fix, tested on versioned and unversioned client

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
