### PR TITLE
[android] Fix missing scoped permission

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/utils/ScopedPermissionsRequester.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/utils/ScopedPermissionsRequester.kt
@@ -133,6 +133,7 @@ class ScopedPermissionsRequester(private val experienceKey: ExperienceKey) {
       Manifest.permission.WRITE_CONTACTS -> R.string.perm_contacts_write
       Manifest.permission.READ_EXTERNAL_STORAGE -> R.string.perm_camera_roll_read
       Manifest.permission.WRITE_EXTERNAL_STORAGE -> R.string.perm_camera_roll_write
+      Manifest.permission.ACCESS_MEDIA_LOCATION -> R.string.perm_access_media_location
       Manifest.permission.RECORD_AUDIO -> R.string.perm_audio_recording
       Settings.ACTION_MANAGE_WRITE_SETTINGS -> R.string.perm_system_brightness
       Manifest.permission.READ_CALENDAR -> R.string.perm_calendar_read

--- a/android/expoview/src/main/res/values/strings.xml
+++ b/android/expoview/src/main/res/values/strings.xml
@@ -21,6 +21,7 @@
   <string name="perm_camera">accessing camera</string>
   <string name="perm_camera_roll_read">reading camera roll</string>
   <string name="perm_camera_roll_write">modifying camera roll</string>
+  <string name="perm_access_media_location">accessing media location</string>
   <string name="perm_contacts_read">reading contacts</string>
   <string name="perm_contacts_write">modifying contacts</string>
   <string name="perm_fine_location">fine location</string>


### PR DESCRIPTION
# Why

Fixes (at least partially) https://github.com/expo/expo/issues/15273#issuecomment-996758326

It addresses the unhandled promise error:
```
[Unhandled promise rejection: Error: Encountered an exception while calling native method: Exception occurred while executing exported method requestPermissionsAsync on module ExponentMediaLibrary: String resource ID #0xffffffff]
```

# How

lukmccall discovered that scoped permission `ACCESS_MEDIA_LOCATION` introduced in #14413 was missing in some `strings.xml` mappings, which caused `ResourceNotFoundException` when trying to display this message:

<img alt="Screenshot 2021-12-20 at 12 36 50" src="https://user-images.githubusercontent.com/278340/146763506-317f8d97-7b11-4ddb-ace0-1dab8c856aba.png" width="200"/>

**I am still investigating if this was the root cause of the original issue**, because this PR fixes some problems mentioned there, but it's strictly related to managed/Expo Go, however the bare workflow was indicated there

# Test Plan

TBD

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
