### PR TITLE
[av] fix build error on Expo SDK 44

### DIFF
--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix iOS build with Expo SDK 44. [#15661](https://github.com/expo/expo/pull/15661)
+- Fix iOS build with Expo SDK 44 and React Native 0.65+. ([#15661](https://github.com/expo/expo/pull/15661) by [@schiller-manuel](https://github.com/schiller-manuel))
 
 ### 💡 Others
 

--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix iOS build with Expo SDK 44. [#15661](https://github.com/expo/expo/pull/15661)
+
 ### 💡 Others
 
 ## 10.2.0 — 2021-12-03


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

There is a name clash of property `moduleRegistry` that is already declared in `RCTModuleRegistry`.

This fixes #15627.

# How

Renamed property `moduleRegistry` to `expoModuleRegistry` to resolve this.
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

1.  `npx react-native init ExpoAvError`
2.  `npx install-expo-modules`
3.  `npm install expo-av && npx pod-install`

❌ `npm run ios` now fails 

4. Apply this PR

✅ `npm run ios` now succeeds.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->