### PR TITLE
[updates] Fix building error on aarch64 jdk

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fix the view does not update from screen rotation on iOS devices. ([#15608](https://github.com/expo/expo/pull/15608) by [@kudo](https://github.com/kudo))
+- Fix building error on AArch64 JDK. ([#15669](https://github.com/expo/expo/pull/15669) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-updates/android/build.gradle
+++ b/packages/expo-updates/android/build.gradle
@@ -100,6 +100,10 @@ dependencies {
   implementation "androidx.room:room-runtime:$room_version"
   kapt "androidx.room:room-compiler:$room_version"
 
+  // force upgrade sqlite-jdbc to support building on aarch64 jdk of macos m1.
+  // https://issuetracker.google.com/issues/174695268
+  kapt "org.xerial:sqlite-jdbc:3.36.0"
+
   implementation("com.squareup.okhttp3:okhttp:3.12.1")
   implementation("com.squareup.okhttp3:okhttp-urlconnection:3.12.1")
   implementation("com.squareup.okio:okio:1.15.0")


### PR DESCRIPTION
# Why

fix #15634

# How

we had some concern to bump `room` and `compileSdkVersion` in the meantime. upgrading the `sqlite-jdbc` as the version included in room 2.4.0 would be lower risky.

# Test Plan

- follow #15634 reproducible steps
- expo run:android --variant release

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
