### PR TITLE
[dev-launcher][android] Fix duplicated `DevLauncherPackage`

### DIFF
--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherPackageDelegate.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherPackageDelegate.kt
@@ -1,21 +1,16 @@
 package expo.modules.devlauncher
 
-import com.facebook.react.ReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
-import com.facebook.react.uimanager.ViewManager
 import expo.modules.devlauncher.modules.DevLauncherDevMenuExtensions
 import expo.modules.devlauncher.modules.DevLauncherInternalModule
 import expo.modules.devlauncher.modules.DevLauncherModule
-import expo.modules.core.interfaces.Package
 
-class DevLauncherPackage : Package, ReactPackage {
-  override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> =
+object DevLauncherPackageDelegate {
+  fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> =
     listOf(
       DevLauncherModule(reactContext),
       DevLauncherInternalModule(reactContext),
       DevLauncherDevMenuExtensions(reactContext)
     )
-
-  override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> = emptyList()
 }

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/DevLauncherPackage.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/DevLauncherPackage.kt
@@ -7,7 +7,7 @@ import com.facebook.react.uimanager.ViewManager
 import expo.modules.core.interfaces.Package
 
 class DevLauncherPackage : Package, ReactPackage {
-  override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> = listOf()
+  override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> = DevLauncherPackageDelegate.createNativeModules(reactContext);
 
   override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> = emptyList()
 }

--- a/packages/expo-dev-launcher/android/src/release/java/expo/modules/devlauncher/DevLauncherPackageDelegate.kt
+++ b/packages/expo-dev-launcher/android/src/release/java/expo/modules/devlauncher/DevLauncherPackageDelegate.kt
@@ -1,0 +1,8 @@
+package expo.modules.devlauncher
+
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.ReactApplicationContext
+
+object DevLauncherPackageDelegate {
+  fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> = emptyList()
+}


### PR DESCRIPTION
# Why

Fixes:
```
java.lang.IllegalStateException: Native module EXDevLauncher tried to override DevLauncherModule. Check the getPackages() method in MainApplication.java, it might be that module is being created twice. If this was your intention, set canOverrideExistingModule=true. This error may also be present if the package is present only once in getPackages() but is also automatically added later during build time by autolinking. Try removing the existing entry and rebuild.
```
