### PR TITLE
[docs] add subscription callout to eas update docs

### DIFF
--- a/docs/pages/eas-update/introduction.md
+++ b/docs/pages/eas-update/introduction.md
@@ -8,6 +8,8 @@ import Head from '~/components/Head'
 
 > ⚠️ EAS Update is in "preview", meaning that we may still make breaking developer-facing changes. With that, EAS Update is ready for production apps. While we do not intend to make end-user facing changes, we may require you to make new builds of your project before EAS Update is publicly available. Read through the [known issues](/eas-update/known-issues) to ensure EAS Update is ready for your project.
 
+> EAS Update is currently only available to users subscribed to the EAS Production or EAS Enterprise plans. [Sign up](https://expo.dev/pricing).
+
 **EAS Update** is a hosted service that serves updates for projects using the `expo-updates` library.
 
 EAS Update makes fixing small bugs and pushing quick fixes a snap in between app store submissions. It accomplishes this by allowing an end-user's app to swap out the non-native parts of their app (for example, JS, styling, and image changes) with a new update that contains bug fixes and other updates.


### PR DESCRIPTION
adds a callout to state that EAS Update is only available to paid EAS subscribers at the moment