### PR TITLE
[fix] Invoke super methods in the AppDelegate.m to support ExpoAppDelegateSubscriber

### DIFF
--- a/templates/expo-template-bare-minimum/ios/HelloWorld/AppDelegate.m
+++ b/templates/expo-template-bare-minimum/ios/HelloWorld/AppDelegate.m
@@ -63,17 +63,14 @@ static void InitializeFlipper(UIApplication *application) {
 
 // Linking API
 - (BOOL)application:(UIApplication *)application openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
-  return [super application:application openURL:url options:options] || [RCTLinkingManager application:application openURL:url options:options];
+  [RCTLinkingManager application:application openURL:url options:options];
+  return [super application:application openURL:url options:options];
 }
 
 // Universal Links
 - (BOOL)application:(UIApplication *)application continueUserActivity:(nonnull NSUserActivity *)userActivity restorationHandler:(nonnull void (^)(NSArray<id<UIUserActivityRestoring>> * _Nullable))restorationHandler {
-  return [super application:application
-       continueUserActivity:userActivity
-         restorationHandler:restorationHandler]
-  || [RCTLinkingManager application:application
-               continueUserActivity:userActivity
-                 restorationHandler:restorationHandler];
+  [RCTLinkingManager application:application continueUserActivity:userActivity restorationHandler:restorationHandler];
+  return [super application:application continueUserActivity:userActivity restorationHandler:restorationHandler];
 }
 
 @end

--- a/templates/expo-template-bare-minimum/ios/HelloWorld/AppDelegate.m
+++ b/templates/expo-template-bare-minimum/ios/HelloWorld/AppDelegate.m
@@ -63,14 +63,17 @@ static void InitializeFlipper(UIApplication *application) {
 
 // Linking API
 - (BOOL)application:(UIApplication *)application openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
-  return [RCTLinkingManager application:application openURL:url options:options];
+  return [super application:application openURL:url options:options] || [RCTLinkingManager application:application openURL:url options:options];
 }
 
 // Universal Links
 - (BOOL)application:(UIApplication *)application continueUserActivity:(nonnull NSUserActivity *)userActivity restorationHandler:(nonnull void (^)(NSArray<id<UIUserActivityRestoring>> * _Nullable))restorationHandler {
-  return [RCTLinkingManager application:application
-                   continueUserActivity:userActivity
-                     restorationHandler:restorationHandler];
+  return [super application:application
+       continueUserActivity:userActivity
+         restorationHandler:restorationHandler]
+  || [RCTLinkingManager application:application
+               continueUserActivity:userActivity
+                 restorationHandler:restorationHandler];
 }
 
 @end


### PR DESCRIPTION
# Why

@giautm observed that the lack of super invocations was preventing ExpoAppDelegateSubscriber to work as expected.

# How

Add `[super ...]` calls to extended AppDelegate methods.

> I'm not 100% certain if the `||` is correct, based on what I've seen it's the closest option.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

In a local project, install `expo-screen-orientation` and add methods to the subscriber file then observe if they are called:

```swift
  public func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
    return true
  }
  
  public func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
    return true
  }
```