### PR TITLE
[apps] Enforce 'util' version to fix errors on import

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     ]
   },
   "resolutions": {
-    "react-native": "0.64.3"
+    "react-native": "0.64.3",
+    "**/util": "~0.12.4"
   },
   "dependencies": {
     "@expo/config-types": "^43.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9867,11 +9867,6 @@ inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, i
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
-inherits@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
-  integrity sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=
-
 inherits@2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
@@ -18058,28 +18053,7 @@ util.promisify@~1.0.0:
     has-symbols "^1.0.1"
     object.getownpropertydescriptors "^2.1.0"
 
-util@0.10.3:
-  version "0.10.3"
-  resolved "https://registry.yarnpkg.com/util/-/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
-  integrity sha1-evsa/lCAUkZInj23/g7TeTNqwPk=
-  dependencies:
-    inherits "2.0.1"
-
-util@^0.10.3:
-  version "0.10.4"
-  resolved "https://registry.yarnpkg.com/util/-/util-0.10.4.tgz#3aa0125bfe668a4672de58857d3ace27ecb76901"
-  integrity sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==
-  dependencies:
-    inherits "2.0.3"
-
-util@^0.11.0:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/util/-/util-0.11.1.tgz#3236733720ec64bb27f6e26f421aaa2e1b588d61"
-  integrity sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==
-  dependencies:
-    inherits "2.0.3"
-
-util@^0.12.0:
+util@0.10.3, util@^0.10.3, util@^0.11.0, util@^0.12.0, util@~0.12.4:
   version "0.12.4"
   resolved "https://registry.yarnpkg.com/util/-/util-0.12.4.tgz#66121a31420df8f01ca0c464be15dfa1d1850253"
   integrity sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==


### PR DESCRIPTION
# Why

the js import error: `Error: Requiring module "../../packages/expo-notifications/build/index.js", which threw an exception: TypeError: Cannot read property 'isPromise' of undefined, js engine: hermes` will show in red box and break detox testing. 

the dependency: `updateDevicePushTokenAsync.ts` -> `@ide/backoff` -> `require('assert')` -> `require('util')` and `util.types.isPromise`.

`util.types.isPromise` is added after util@0.12, but the old `util` be hoisted to workspace:

```
=> Found "util@0.10.4"
info Reasons this module exists
   - "_project_#native-component-list#path" depends on it
   - Hoisted from "_project_#native-component-list#path#util"
info Disk size without dependencies: "68KB"
info Disk size with unique dependencies: "88KB"
info Disk size with transitive dependencies: "88KB"
info Number of shared dependencies: 1
=> Found "assert#util@0.12.4"
info This module exists because "_project_#expo-notifications#assert" depends on it.
info Disk size without dependencies: "56KB"
info Disk size with unique dependencies: "376KB"
info Disk size with transitive dependencies: "7.28MB"
info Number of shared dependencies: 23
=> Found "node-libs-browser#util@0.11.1"
info This module exists because "_project_#expo-yarn-workspaces#@expo#webpack-config#webpack#node-libs-browser" depends on it.
info Disk size without dependencies: "48KB"
info Disk size with unique dependencies: "68KB"
info Disk size with transitive dependencies: "68KB"
info Number of shared dependencies: 1
=> Found "node-libs-browser#assert#util@0.10.3"
info This module exists because "_project_#expo-yarn-workspaces#@expo#webpack-config#webpack#node-libs-browser#assert" depends on it.
info Disk size without dependencies: "96KB"
info Disk size with unique dependencies: "116KB"
info Disk size with transitive dependencies: "116KB"
info Number of shared dependencies: 1
```
in theory, from `assert` to import `util`, it should import the nested one. so it should not be a big problem even the old `util` be hoisted to workspace.

however, in #15621, the new `@expo/metro-config@~0.3.7`, we added `nodeModulesPaths` to metro config. the old metro resolver will prepend `nodeModulesPaths` before all resolution path. this will make `assert` to import the old `util` from workspace. this issue is fixed in the latest metro version: https://github.com/facebook/metro/pull/738.



# How

have a workaround to force `util@~0.12.4` for all dependencies

# Test Plan

test-suite ci green

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
