### PR TITLE
Remove `react/react-in-jsx-scope` for React 17

### DIFF
--- a/packages/eslint-config-universe/CHANGELOG.md
+++ b/packages/eslint-config-universe/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- `react/react-in-jsx-scope` no longer reports errors (the rule is off) because React 17 no longer requires `react` to be imported.
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/eslint-config-universe/shared/react.js
+++ b/packages/eslint-config-universe/shared/react.js
@@ -33,7 +33,6 @@ module.exports = {
     'react/no-this-in-sfc': 'warn',
     'react/no-unknown-property': 'warn',
     'react/no-will-update-set-state': 'warn',
-    'react/react-in-jsx-scope': 'error',
     'react/require-render-return': 'warn',
     'react/self-closing-comp': 'warn',
 


### PR DESCRIPTION
This ESLint rule is no longer needed for Expo SDK 44. `expo-module-scripts` really aggressively overrides `.eslintrc.js`, so I can't manually override this.

# Why

This rule is no longer necessary in `expo-module-scripts`, nor in any Expo apps.

# How

Removed what I assume to be an unnecessary rule

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

I'm not sure if these apply.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
