### PR TITLE
Fixed deprecated Constants.isDevice in admob.md

### DIFF
--- a/docs/pages/versions/unversioned/sdk/admob.md
+++ b/docs/pages/versions/unversioned/sdk/admob.md
@@ -129,12 +129,12 @@ await AdMobRewarded.showAdAsync();
 - Ensure you **never** load a real production ad in an Android Emulator or iOS Simulator. Failure to do this can result in a ban from the AdMob program.
 
 ```tsx
-import Constants from 'expo-constants';
+import * as Device from 'expo-device';
 
 const testID = 'google-test-id';
 const productionID = 'my-id';
 // Is a real device and running in production.
-const adUnitID = Constants.isDevice && !__DEV__ ? productionID : testID;
+const adUnitID = Device.isDevice && !__DEV__ ? productionID : testID;
 ```
 
 ## Methods


### PR DESCRIPTION
Replaced deprecated Constants.isDevice with Device.isDevice from expo-device in admob.md example

# Why

Constants.isDevice is deprecated.

# How

Used Device.isDevice from expo-device instead.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
