### PR TITLE
[guides] developing Expo Go update and corrections

### DIFF
--- a/guides/Developing Expo Go.md
+++ b/guides/Developing Expo Go.md
@@ -21,7 +21,7 @@ This is the source code for the Expo Go app used to view projects published to t
 
 To build Expo Go, follow the instructions in the [Setup](#configuring-your-environment) section below. Use the [Expo CLI](https://docs.expo.dev/workflow/expo-cli) to use Expo's infrastructure to build your app.
 
-Please ask us on the [forums](https://forums.expo.dev/) if you get stuck.
+Please ask us on the [forums](https://forums.expo.dev) if you get stuck.
 
 ## External Contributions
 
@@ -37,8 +37,8 @@ If you need to make native code changes to your Expo project, such as adding cus
 
 > Note: We support building Expo Go only on macOS.
 
-- Install [direnv](http://direnv.net/)
-- Clone this repo; we recommend cloning it to a directory whose full path does not include any spaces (you should clone all the submodules with `git clone --recurse-submodules`)
+- Install [direnv](http://direnv.net/).
+- Clone this repo; we recommend cloning it to a directory whose full path does not include any spaces (you should clone all the submodules with `git clone --recurse-submodules`).
 - Run `yarn` in the root directory.
 - Run `yarn setup:native` in the root directory.
 - Run `yarn build` in the `packages/expo` directory.
@@ -51,8 +51,8 @@ If you need to make native code changes to your Expo project, such as adding cus
 
 ### Android
 
-- Make sure you have Android Studio 3 installed
-- See "Running on a Device"
+- Make sure you have Android Studio 3 or newer installed.
+- See ["Running on a Device"](#running-on-a-device).
 
 ## Running on a Device
 
@@ -127,4 +127,4 @@ For native XCTest unit tests:
 - Press Command+U in XCode to build and test the `Tests` unit test target.
 - Alternatively, run `fastlane ios test` from the parent directory of `ios`.
 
-For JS integration tests, test the `ExponentIntegrationTests` target (not included in the default test scheme). This target requires you to configure `EXTestEnvironment.plist` with a key `testSuiteUrl` whose value is the URL to load some version of Expo's [test-suite](apps/test-suite) app. This will run a bunch of Jasmine tests against the Expo SDK.
+For JS integration tests, test the `ExponentIntegrationTests` target (not included in the default test scheme). This target requires you to configure `EXTestEnvironment.plist` with a key `testSuiteUrl` whose value is the URL to load some version of Expo's [test-suite](../apps/test-suite) app. This will run a bunch of Jasmine tests against the Expo SDK.

--- a/guides/Developing Expo Go.md
+++ b/guides/Developing Expo Go.md
@@ -13,14 +13,13 @@
   - [iOS](#ios-2)
 - [Modifying JS Code](#modifying-js-code)
 - [Tests](#tests)
-
   - [iOS](#ios-3)
 
 ## Introduction
 
 This is the source code for the Expo Go app used to view projects published to the Expo service. If you want to build and install Expo Go directly onto a device, you're in the right place. Note that if you just want to install Expo Go on a simulator, you do not need to build it from source. Instead, you should [follow the instructions here](https://docs.expo.dev/versions/latest/introduction/installation.html).
 
-To build Expo Go, follow the instructions in the [Setup](#setup) section below. Use the [Expo CLI](https://docs.expo.dev/workflow/expo-cli) to use Expo's infrastructure to build your app.
+To build Expo Go, follow the instructions in the [Setup](#configuring-your-environment) section below. Use the [Expo CLI](https://docs.expo.dev/workflow/expo-cli) to use Expo's infrastructure to build your app.
 
 Please ask us on the [forums](https://forums.expo.dev/) if you get stuck.
 
@@ -41,7 +40,7 @@ If you need to make native code changes to your Expo project, such as adding cus
 - Install [direnv](http://direnv.net/)
 - Clone this repo; we recommend cloning it to a directory whose full path does not include any spaces (you should clone all the submodules with `git clone --recurse-submodules`)
 - Run `yarn` in the root directory.
-- Run `npm run setup:native` in the root directory.
+- Run `yarn setup:native` in the root directory.
 - Run `yarn build` in the `packages/expo` directory.
 
 ### iOS

--- a/guides/Developing Expo Go.md
+++ b/guides/Developing Expo Go.md
@@ -18,25 +18,25 @@
 
 ## Introduction
 
-This is the source code for the Expo Go app used to view projects published to the Expo service. If you want to build and install Expo Go directly onto a device, you're in the right place. Note that if you just want to install Expo Go on a simulator, you do not need to build it from source. Instead, you should [follow the instructions here](https://docs.expo.io/versions/latest/introduction/installation.html).
+This is the source code for the Expo Go app used to view projects published to the Expo service. If you want to build and install Expo Go directly onto a device, you're in the right place. Note that if you just want to install Expo Go on a simulator, you do not need to build it from source. Instead, you should [follow the instructions here](https://docs.expo.dev/versions/latest/introduction/installation.html).
 
-To build Expo Go, follow the instructions in the [Setup](#setup) section below. Use the [Expo CLI](https://docs.expo.io/versions/latest/workflow/expo-cli) to use Expo's infrastructure to build your app.
+To build Expo Go, follow the instructions in the [Setup](#setup) section below. Use the [Expo CLI](https://docs.expo.dev/workflow/expo-cli) to use Expo's infrastructure to build your app.
 
-Please ask us on the [forums](https://forums.expo.io/) if you get stuck.
+Please ask us on the [forums](https://forums.expo.dev/) if you get stuck.
 
 ## External Contributions
 
-Please check with us before putting work into a Pull Request! We don't yet have a good guide available that covers the nuances of how to work with Expo Go and the types of PRs that we accept so you will want a direct line of communication with someone on the team to ask us questions. The best place to talk to us is either on Slack at https://slack.expo.io or the forums at https://forums.expo.io.
+Please check with us before putting work into a Pull Request! We don't yet have a good guide available that covers the nuances of how to work with Expo Go and the types of PRs that we accept, so you will want a direct line of communication with someone on the team to ask us questions. The best place to talk to us is either on Discord at https://chat.expo.dev or the forums at https://forums.expo.dev.
 
 **Disclaimers:**
 
-If you want to build a standalone app that has a custom icon and name, see [our documentation here](https://docs.expo.io/versions/latest/distribution/building-standalone-apps/). You're in the wrong place and you shouldn't need to build Expo Go from source.
+If you want to build a standalone app that has a custom icon and name, see [our documentation here](https://docs.expo.dev/classic/building-standalone-apps). You're in the wrong place and you shouldn't need to build Expo Go from source.
 
-If you need to make native code changes to your Expo project, such as adding custom native modules, we can [generate a native project for you](https://docs.expo.io/versions/latest/expokit/eject). You're in the wrong place and you shouldn't need to build Expo Go from source.
+If you need to make native code changes to your Expo project, such as adding custom native modules, we can [generate a native project for you](https://docs.expo.dev/expokit/eject). You're in the wrong place and you shouldn't need to build Expo Go from source.
 
 ## Configuring your environment
 
-Note: We support building Expo Go only on macOS.
+> Note: We support building Expo Go only on macOS.
 
 - Install [direnv](http://direnv.net/)
 - Clone this repo; we recommend cloning it to a directory whose full path does not include any spaces (you should clone all the submodules with `git clone --recurse-submodules`)
@@ -59,13 +59,13 @@ Note: We support building Expo Go only on macOS.
 
 ### iOS
 
-- In Xcode's menu bar, open the **Xcode** drop-down menu, and select **Preferences**. Then in the **Accounts** tab of the preferences menu, add your personal or team apple developer account.
+- In Xcode's menu bar, open the **Xcode** drop-down menu, and select **Preferences**. Then in the **Accounts** tab of the preferences menu, add your personal or team Apple Developer account.
 - Connect your test device to your computer with a USB cable.
 - In Xcode's menu bar, open the **Product** drop-down menu, select **Destination**, then in the _Device_ grouping select your device.
 - In the project navigator, select the **Exponent** project to bring up the project's settings, and then:
   - In the **General** tab, in the **Identity** section, put in a unique Bundle Identifier.
-  - Also in the **General** tab, in the **Signing** section, select your personal or team apple developer account as your **Team**, and create a new signing certificate by clicking **Fix Issue**.
-- Finally, run the build
+  - Also in the **General** tab, in the **Signing** section, select your personal or team Apple Developer account as your **Team**, and create a new signing certificate by clicking **Fix Issue**.
+- Finally, run the build.
 
 ### Android
 
@@ -78,11 +78,11 @@ Note: We support building Expo Go only on macOS.
 
 ## Standalone Apps
 
-If you don't need custom native code outside of the Expo SDK, head over to [our documentation on building standalone apps without needing Android Studio and Xcode](https://docs.expo.io/versions/latest/distribution/building-standalone-apps/).
+If you don't need custom native code outside of the Expo SDK, head over to [our documentation on building standalone apps without needing Android Studio and Xcode](https://docs.expo.dev/classic/building-standalone-apps).
 
-If you need standalone apps as built by running `expo build:ios` or `expo build:android` for a supported SDK version, check out our docs on [using turtle-cli to build apps locally or on CI](https://docs.expo.io/versions/latest/distribution/turtle-cli/).
+If you need standalone apps as built by running `expo build:ios` or `expo build:android` for a supported SDK version, check out our docs on [using turtle-cli to build apps locally or on CI](https://docs.expo.dev/classic/turtle-cli).
 
-If you're still here, you need to build a standalone app with code currently on `master` or another unreleased branch. Make sure to follow the [Configure app.json](https://docs.expo.io/versions/latest/distribution/building-standalone-apps/#2-configure-appjson) section of the docs before continuing. You'll need to add the appropriate fields to your `app.json` before the standalone app scripts can run. Once that's done, continue on to the platform-specific instructions.
+If you're still here, you need to build a standalone app with code currently on `master` or another unreleased branch. Make sure to follow the [Configure app.json](https://docs.expo.dev/classic/building-standalone-apps/#2-configure-appjson) section of the docs before continuing. You'll need to add the appropriate fields to your `app.json` before the standalone app scripts can run. Once that's done, continue on to the platform-specific instructions.
 
 ### Android
 
@@ -97,7 +97,9 @@ Here are the steps to build a standalone Android app:
 
 ### iOS
 
-The iOS standalone app script has two actions, `build` and `configure`. `build` creates an archive or a simulator build of the Expo iOS workspace. `configure` accepts a path to an existing archive and modifies all its configuration files so that it will run as a standalone Expo project rather than in Expo Go.
+The iOS standalone app script has two actions, `build` and `configure`:
+- `build` creates an archive or a simulator build of the Expo iOS workspace,
+- `configure` accepts a path to an existing archive and modifies all its configuration files so that it will run as a standalone Expo project rather than in Expo Go.
 
 Here are the steps to build a standalone iOS app:
 
@@ -105,15 +107,15 @@ Here are the steps to build a standalone iOS app:
 - `et ios-shell-app --action build --type [simulator or archive] --configuration [Debug or Release]`
 - The resulting archive will be created at `../shellAppBase-[type]`.
 - `et ios-shell-app --url [the published experience url] --action configure --type [simulator or archive] --archivePath [path to ExpoKitApp.app] --sdkVersion [sdk version of your experience] --output your-app.tar.gz`
-- This bundle is not signed and cannot be submitted to iTunes Connect as-is; you'll need to manually sign it if you'd like to submit it to Apple. [Fastlane](https://fastlane.tools/) is a good option for this. Also, [Expo will do this for you](https://docs.expo.io/versions/latest/distribution/building-standalone-apps/) if you don't need to build this project from source.
+- This bundle is not signed and cannot be submitted to iTunes Connect as-is; you'll need to manually sign it if you'd like to submit it to Apple. [Fastlane](https://fastlane.tools/) is a good option for this. Also, [Expo will do this for you](https://docs.expo.dev/classic/building-standalone-apps) if you don't need to build this project from source.
 - If you created a simulator build in the first step, unpack the tar.gz using `tar -xvzf your-app.tar.gz`. Then you can run this on iPhone Simulator using `xcrun simctl install booted <app path>` and `xcrun simctl launch booted <app identifier>`. Another alternative which some people prefer is to install the [ios-sim](https://github.com/phonegap/ios-sim) tool and then use `ios-sim launch <app path>`.
 - There are a few more optional flags you can pass to this script. They are all documented in the block comments inside `xdl/src/detach/IosShellApp.js`.
 
 ## Modifying JS Code
 
-The Expo Go apps run a root Expo project in addition to native code. By default this will use a published version of the project, so any changes made in the `home` directory will not show up without some extra work.
+The Expo Go apps run a root Expo project in addition to native code. By default, this will use a published version of the project, so any changes made in the `home` directory will not show up without some extra work.
 
-Serve this project locally by running `expo start` from the `home` directory. On iOS, you'll additionally need to set `DEV_KERNEL_SOURCE` to `LOCAL` in `EXBuildConstants.plist` (the default is `PUBLISHED`).
+Serve this project locally by running `expo start` from the `home` directory. **On iOS**, you'll additionally need to set `DEV_KERNEL_SOURCE` to `LOCAL` in `EXBuildConstants.plist` (the default is `PUBLISHED`).
 
 The native Android Studio and Xcode projects have a build hook which will find this if `expo start` is running. Keep this running and rebuild the app on each platform.
 


### PR DESCRIPTION
# Why

This small PR updates the "Developing Expo Go" guide. Most of the changes are related to the outdated links or formatting.

# How

The changes includes:
* update of Expo TLD in links
* replace URL which results with redirects with the updated version
* replace mention about shut down Snack with Discord
* small stylistic corrections

# Test Plan

N/A

# Checklist

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
