### PR TITLE
[workspace] update RN website submodule branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "docs/react-native-website"]
   path = docs/react-native-website
   url = git@github.com:facebook/react-native-website.git
+  branch = main
   update = checkout
 [submodule "react-native-lab/react-native"]
   path = react-native-lab/react-native


### PR DESCRIPTION
# Why

When fetching/updating the submodule manually, not via provided in workspace scripts the checkout of React Native website repo fails.

# How

List the `main` branch directly in the submodules config.

# Test Plan

```
git submodule update --remote --merge
```

Works as intended after the change.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
