### PR TITLE
[sweet][kotlin] Use module class name if the name wasn't provided

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/Module.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/Module.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import expo.modules.kotlin.AppContext
 
 abstract class Module {
+  @Suppress("PropertyName")
   internal var _appContext: AppContext? = null
 
   private val moduleEventEmitter by lazy { appContext.eventEmitter(this) }
@@ -19,6 +20,6 @@ abstract class Module {
 }
 
 @Suppress("FunctionName")
-inline fun ModuleDefinition(block: ModuleDefinitionBuilder.() -> Unit): ModuleDefinitionData {
-  return ModuleDefinitionBuilder().also(block).build()
+inline fun Module.ModuleDefinition(block: ModuleDefinitionBuilder.() -> Unit): ModuleDefinitionData {
+  return ModuleDefinitionBuilder(this).also(block).build()
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionBuilder.kt
@@ -31,7 +31,7 @@ import expo.modules.kotlin.views.ViewManagerDefinition
 import expo.modules.kotlin.views.ViewManagerDefinitionBuilder
 import kotlin.reflect.typeOf
 
-class ModuleDefinitionBuilder {
+class ModuleDefinitionBuilder(private val module: Module? = null) {
   private var name: String? = null
   private var constantsProvider = { emptyMap<String, Any?>() }
   private var eventsDefinition: EventsDefinition? = null
@@ -46,8 +46,10 @@ class ModuleDefinitionBuilder {
   internal val eventListeners = mutableMapOf<EventName, EventListener>()
 
   fun build(): ModuleDefinitionData {
+    val moduleName = name ?: module?.javaClass?.simpleName
+
     return ModuleDefinitionData(
-      requireNotNull(name),
+      requireNotNull(moduleName),
       constantsProvider,
       methods,
       viewManagerDefinition,

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/modules/ModuleDefinitionBuilderTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/modules/ModuleDefinitionBuilderTest.kt
@@ -8,7 +8,7 @@ import org.junit.Assert
 import org.junit.Test
 
 class ModuleDefinitionBuilderTest {
-  private inline fun unbindModuleDefinition(block: ModuleDefinitionBuilder.() -> Unit): ModuleDefinitionData {
+  private inline fun unboundModuleDefinition(block: ModuleDefinitionBuilder.() -> Unit): ModuleDefinitionData {
     return ModuleDefinitionBuilder().also(block).build()
   }
 
@@ -25,11 +25,11 @@ class ModuleDefinitionBuilderTest {
   @Test
   fun `builder should throw if modules name wasn't provided`() {
     Assert.assertThrows(IllegalArgumentException::class.java) {
-      unbindModuleDefinition { }
+      unboundModuleDefinition { }
     }
 
     Assert.assertThrows(IllegalArgumentException::class.java) {
-      unbindModuleDefinition {
+      unboundModuleDefinition {
         function("method") { _: Int, _: Int -> }
       }
     }
@@ -40,7 +40,7 @@ class ModuleDefinitionBuilderTest {
     val moduleName = "Module"
     val moduleConstants = emptyMap<String, Any?>()
 
-    val moduleDefinition = unbindModuleDefinition {
+    val moduleDefinition = unboundModuleDefinition {
       name(moduleName)
       constants {
         moduleConstants
@@ -59,7 +59,7 @@ class ModuleDefinitionBuilderTest {
   fun `builder should allow adding view manager`() {
     val moduleName = "Module"
 
-    val moduleDefinition = unbindModuleDefinition {
+    val moduleDefinition = unboundModuleDefinition {
       name(moduleName)
       viewManager {
         view { mockk() }
@@ -74,7 +74,7 @@ class ModuleDefinitionBuilderTest {
   fun `builder should respect events`() {
     val moduleName = "Module"
 
-    val moduleDefinition = unbindModuleDefinition {
+    val moduleDefinition = unboundModuleDefinition {
       name(moduleName)
       onCreate { }
       onDestroy { }
@@ -93,7 +93,7 @@ class ModuleDefinitionBuilderTest {
 
   @Test
   fun `onStartObserving should be translated into method`() {
-    val moduleDefinition = unbindModuleDefinition {
+    val moduleDefinition = unboundModuleDefinition {
       name("module")
       onStartObserving { }
     }
@@ -103,7 +103,7 @@ class ModuleDefinitionBuilderTest {
 
   @Test
   fun `onStopObserving should be translated into method`() {
-    val moduleDefinition = unbindModuleDefinition {
+    val moduleDefinition = unboundModuleDefinition {
       name("module")
       onStopObserving { }
     }

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/modules/ModuleDefinitionBuilderTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/modules/ModuleDefinitionBuilderTest.kt
@@ -8,15 +8,28 @@ import org.junit.Assert
 import org.junit.Test
 
 class ModuleDefinitionBuilderTest {
+  private inline fun unbindModuleDefinition(block: ModuleDefinitionBuilder.() -> Unit): ModuleDefinitionData {
+    return ModuleDefinitionBuilder().also(block).build()
+  }
+
+  private class TestModule : Module() {
+    override fun definition() = ModuleDefinition {}
+  }
+
+  private class TestModuleWithName : Module() {
+    override fun definition() = ModuleDefinition {
+      name("OverriddenName")
+    }
+  }
 
   @Test
   fun `builder should throw if modules name wasn't provided`() {
     Assert.assertThrows(IllegalArgumentException::class.java) {
-      ModuleDefinition { }
+      unbindModuleDefinition { }
     }
 
     Assert.assertThrows(IllegalArgumentException::class.java) {
-      ModuleDefinition {
+      unbindModuleDefinition {
         function("method") { _: Int, _: Int -> }
       }
     }
@@ -27,7 +40,7 @@ class ModuleDefinitionBuilderTest {
     val moduleName = "Module"
     val moduleConstants = emptyMap<String, Any?>()
 
-    val moduleDefinition = ModuleDefinition {
+    val moduleDefinition = unbindModuleDefinition {
       name(moduleName)
       constants {
         moduleConstants
@@ -46,7 +59,7 @@ class ModuleDefinitionBuilderTest {
   fun `builder should allow adding view manager`() {
     val moduleName = "Module"
 
-    val moduleDefinition = ModuleDefinition {
+    val moduleDefinition = unbindModuleDefinition {
       name(moduleName)
       viewManager {
         view { mockk() }
@@ -61,7 +74,7 @@ class ModuleDefinitionBuilderTest {
   fun `builder should respect events`() {
     val moduleName = "Module"
 
-    val moduleDefinition = ModuleDefinition {
+    val moduleDefinition = unbindModuleDefinition {
       name(moduleName)
       onCreate { }
       onDestroy { }
@@ -80,7 +93,7 @@ class ModuleDefinitionBuilderTest {
 
   @Test
   fun `onStartObserving should be translated into method`() {
-    val moduleDefinition = ModuleDefinition {
+    val moduleDefinition = unbindModuleDefinition {
       name("module")
       onStartObserving { }
     }
@@ -90,11 +103,25 @@ class ModuleDefinitionBuilderTest {
 
   @Test
   fun `onStopObserving should be translated into method`() {
-    val moduleDefinition = ModuleDefinition {
+    val moduleDefinition = unbindModuleDefinition {
       name("module")
       onStopObserving { }
     }
 
     Truth.assertThat(moduleDefinition.methods).containsKey("stopObserving")
+  }
+
+  @Test
+  fun `should fallback to module name if the name wasn't provided`() {
+    val moduleDefinition = TestModule().definition()
+
+    Truth.assertThat(moduleDefinition.name).isEqualTo("TestModule")
+  }
+
+  @Test
+  fun `should choose provided name over module class name`() {
+    val moduleDefinition = TestModuleWithName().definition()
+
+    Truth.assertThat(moduleDefinition.name).isEqualTo("OverriddenName")
   }
 }


### PR DESCRIPTION
# Why

`ModuleDefinitionBuilder` will use module class if a name wasn't provided. On iOS, we don't require a name component. On the other hand, you still need to provide a name component on Android. This PR removes that difference.

# Test Plan

- unit tests ✅