### PR TITLE
[sweet][kotlin] Add `onViewDestroys` method to ViewManager

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/GroupViewManagerWrapper.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/GroupViewManagerWrapper.kt
@@ -19,4 +19,9 @@ class GroupViewManagerWrapper(
   fun setProxiedProperties(view: View, proxiedProperties: ReadableMap) {
     viewWrapperDelegate.setProxiedProperties(view, proxiedProperties)
   }
+
+  override fun onDropViewInstance(view: ViewGroup) {
+    super.onDropViewInstance(view)
+    viewWrapperDelegate.onDestroy(view)
+  }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/SimpleViewManagerWrapper.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/SimpleViewManagerWrapper.kt
@@ -18,4 +18,9 @@ class SimpleViewManagerWrapper(
   fun setProxiedProperties(view: View, proxiedProperties: ReadableMap) {
     viewWrapperDelegate.setProxiedProperties(view, proxiedProperties)
   }
+
+  override fun onDropViewInstance(view: View) {
+    super.onDropViewInstance(view)
+    viewWrapperDelegate.onDestroy(view)
+  }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerDefinition.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerDefinition.kt
@@ -12,7 +12,7 @@ class ViewManagerDefinition(
   private val viewFactory: (Context) -> View,
   private val viewType: Class<out View>,
   private val props: Map<String, AnyViewProp>,
-  val onDestroy: ((View) -> Unit)? = null
+  val onViewDestroys: ((View) -> Unit)? = null
 ) {
 
   fun createView(context: Context): View = viewFactory(context)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerDefinition.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerDefinition.kt
@@ -11,7 +11,9 @@ import expo.modules.kotlin.recycle
 class ViewManagerDefinition(
   private val viewFactory: (Context) -> View,
   private val viewType: Class<out View>,
-  private val props: Map<String, AnyViewProp>
+  private val props: Map<String, AnyViewProp>,
+  val onDestroy: ((View) -> Unit)? = null
+  val callbacksDefinition: CallbacksDefinition? = null
 ) {
 
   fun createView(context: Context): View = viewFactory(context)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerDefinition.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerDefinition.kt
@@ -13,7 +13,6 @@ class ViewManagerDefinition(
   private val viewType: Class<out View>,
   private val props: Map<String, AnyViewProp>,
   val onDestroy: ((View) -> Unit)? = null
-  val callbacksDefinition: CallbacksDefinition? = null
 ) {
 
   fun createView(context: Context): View = viewFactory(context)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerDefinitionBuilder.kt
@@ -17,14 +17,14 @@ class ViewManagerDefinitionBuilder {
   @PublishedApi
   internal var props = mutableMapOf<String, AnyViewProp>()
   @PublishedApi
-  internal var onDestroy: ((View) -> Unit)? = null
+  internal var onViewDestroys: ((View) -> Unit)? = null
 
   fun build(): ViewManagerDefinition =
     ViewManagerDefinition(
       requireNotNull(viewFactory),
       requireNotNull(viewType),
       props,
-      onDestroy
+      onViewDestroys
     )
 
   /**
@@ -38,8 +38,8 @@ class ViewManagerDefinitionBuilder {
   /**
    * Creates view's lifecycle listener that is called right after the view isn't longer used by React Native.
    */
-  inline fun <reified ViewType : View> onDestroy(noinline body: (view: ViewType) -> Unit) {
-    onDestroy = { body(it as ViewType)}
+  inline fun <reified ViewType : View> onViewDestroys(noinline body: (view: ViewType) -> Unit) {
+    onViewDestroys = { body(it as ViewType) }
   }
 
   /**

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerDefinitionBuilder.kt
@@ -16,12 +16,15 @@ class ViewManagerDefinitionBuilder {
   internal var viewType: Class<out View>? = null
   @PublishedApi
   internal var props = mutableMapOf<String, AnyViewProp>()
+  @PublishedApi
+  internal var onDestroy: ((View) -> Unit)? = null
 
   fun build(): ViewManagerDefinition =
     ViewManagerDefinition(
       requireNotNull(viewFactory),
       requireNotNull(viewType),
-      props
+      props,
+      onDestroy
     )
 
   /**
@@ -30,6 +33,13 @@ class ViewManagerDefinitionBuilder {
   inline fun <reified ViewType : View> view(noinline body: (Context) -> ViewType) {
     viewType = ViewType::class.java
     viewFactory = body
+  }
+
+  /**
+   * Creates view's lifecycle listener that is called right after the view isn't longer used by React Native.
+   */
+  inline fun <reified ViewType : View> onDestroy(noinline body: (view: ViewType) -> Unit) {
+    onDestroy = { body(it as ViewType)}
   }
 
   /**

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerWrapperDelegate.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerWrapperDelegate.kt
@@ -18,4 +18,7 @@ class ViewManagerWrapperDelegate(internal var moduleHolder: ModuleHolder) {
   fun setProxiedProperties(view: View, proxiedProperties: ReadableMap) {
     definition.setProps(proxiedProperties, view)
   }
+
+  fun onDestroy(view: View) =
+    definition.onDestroy?.invoke(view)
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerWrapperDelegate.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerWrapperDelegate.kt
@@ -20,5 +20,5 @@ class ViewManagerWrapperDelegate(internal var moduleHolder: ModuleHolder) {
   }
 
   fun onDestroy(view: View) =
-    definition.onDestroy?.invoke(view)
+    definition.onViewDestroys?.invoke(view)
 }


### PR DESCRIPTION
# Why

Adds a new method to ViewManager DSL - `onViewDestroys`. This method is called when the view isn't longer used by React Native.

# How

Extends a DSL of the ViewManger and called passed block in view managers wrappers.

# Test Plan

- bare-expo ✅