### PR TITLE
[sweet][kotlin] Add DSL markers

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/DefinitionMarker.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/DefinitionMarker.kt
@@ -1,0 +1,4 @@
+package expo.modules.kotlin.modules
+
+@DslMarker
+internal annotation class DefinitionMarker

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionBuilder.kt
@@ -31,6 +31,7 @@ import expo.modules.kotlin.views.ViewManagerDefinition
 import expo.modules.kotlin.views.ViewManagerDefinitionBuilder
 import kotlin.reflect.typeOf
 
+@DefinitionMarker
 class ModuleDefinitionBuilder(private val module: Module? = null) {
   private var name: String? = null
   private var constantsProvider = { emptyMap<String, Any?>() }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerDefinitionBuilder.kt
@@ -7,6 +7,7 @@ import android.view.View
 import expo.modules.kotlin.types.toAnyType
 import kotlin.reflect.typeOf
 
+@DefinitionMarker
 class ViewManagerDefinitionBuilder {
   @PublishedApi
   internal var viewFactory: ((Context) -> View)? = null

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerDefinitionBuilder.kt
@@ -4,6 +4,7 @@ package expo.modules.kotlin.views
 
 import android.content.Context
 import android.view.View
+import expo.modules.kotlin.modules.DefinitionMarker
 import expo.modules.kotlin.types.toAnyType
 import kotlin.reflect.typeOf
 


### PR DESCRIPTION
# Why

Currently, developers can invoke functions connected with `ModuleDefinition` like `function` inside the `ViewManger` block. That isn't ideal behavior. So I added a DSL block that hides `ModuleDefinition` methods. You can still bypass this, but it is a lot harder. 

# How

Added DSL markers.

# Test Plan

- try to add `function` into `ViewManger` ✅