### PR TITLE
[sweet][kotlin] Add shortened constants method that takes pairs as arguments

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionBuilder.kt
@@ -64,6 +64,13 @@ class ModuleDefinitionBuilder {
     this.constantsProvider = constantsProvider
   }
 
+  /**
+   * Definition of the module's constants to export.
+   */
+  fun constants(vararg constants: Pair<String, Any?>) {
+    constantsProvider = { constants.toMap() }
+  }
+
   @JvmName("methodWithoutArgs")
   inline fun function(
     name: String,


### PR DESCRIPTION
# Why

In Swift, we have something `autoclouser` attribute that allows us to pass a dictionary to `constants` components. Unfortunately, Kotlin doesn't have anything like this, but we can provide a similar experience by accepting vargs of pairs.

# How

Added a new `constants` component. 

# Test Plan

- tested using a following  component: 
```kotlin 
constants(
	"const-1" to 123,
	"const-2" to "abcd"
)
```