### PR TITLE
[sweet][kotlin] Add basic view's callbacks support

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -128,6 +128,9 @@ class AppContext(
     )
   }
 
+  internal val callbackInvoker: EventEmitter?
+    get() = legacyModule()
+
   fun onDestroy() {
     reactContextHolder.get()?.removeLifecycleEventListener(reactLifecycleDelegate)
     registry.post(EventName.MODULE_DESTROY)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KotlinInteropModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KotlinInteropModuleRegistry.kt
@@ -18,7 +18,7 @@ class KotlinInteropModuleRegistry(
   legacyModuleRegistry: expo.modules.core.ModuleRegistry,
   reactContext: WeakReference<ReactApplicationContext>
 ) {
-  private val appContext = AppContext(modulesProvider, legacyModuleRegistry, reactContext)
+  internal val appContext = AppContext(modulesProvider, legacyModuleRegistry, reactContext)
 
   private val registry: ModuleRegistry
     get() = appContext.registry

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/callbacks/Callback.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/callbacks/Callback.kt
@@ -1,0 +1,5 @@
+package expo.modules.kotlin.callbacks
+
+interface Callback<T> {
+  fun invoke(arg: T)
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/callbacks/Callback.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/callbacks/Callback.kt
@@ -1,5 +1,5 @@
 package expo.modules.kotlin.callbacks
 
-interface Callback<T> {
-  fun invoke(arg: T)
+fun interface Callback<T> {
+  operator fun invoke(arg: T)
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/callbacks/ViewCallback.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/callbacks/ViewCallback.kt
@@ -1,0 +1,25 @@
+package expo.modules.kotlin.callbacks
+
+import android.os.Bundle
+import android.view.View
+import com.facebook.react.bridge.ReactContext
+import expo.modules.adapters.react.NativeModulesProxy
+import expo.modules.kotlin.modules.Module
+import kotlin.reflect.KType
+
+class ViewCallback<T>(
+  private val name: String,
+  private val type: KType,
+  private val view: View
+) : Callback<T> {
+  internal lateinit var module: Module
+
+  override fun invoke(arg: T) {
+    val reactContext = view.context as ReactContext
+    val nativeModulesProxy = reactContext.getNativeModule(NativeModulesProxy::class.java) ?: return
+    val appContext = nativeModulesProxy.kotlinInteropModuleRegistry.appContext
+
+    // TODO(@lukmccall): handles other types
+    appContext.callbackInvoker?.emit(view.id, name, arg as Bundle)
+  }
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/callbacks/ViewCallback.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/callbacks/ViewCallback.kt
@@ -14,7 +14,7 @@ class ViewCallback<T>(
 ) : Callback<T> {
   internal lateinit var module: Module
 
-  override fun invoke(arg: T) {
+  override operator fun invoke(arg: T) {
     val reactContext = view.context as ReactContext
     val nativeModulesProxy = reactContext.getNativeModule(NativeModulesProxy::class.java) ?: return
     val appContext = nativeModulesProxy.kotlinInteropModuleRegistry.appContext

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/callbacks/ViewCallbackDelegate.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/callbacks/ViewCallbackDelegate.kt
@@ -1,0 +1,27 @@
+@file:OptIn(ExperimentalStdlibApi::class)
+
+package expo.modules.kotlin.callbacks
+
+import android.view.View
+import java.lang.ref.WeakReference
+import kotlin.reflect.KProperty
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
+
+class ViewCallbackDelegate<T>(private val type: KType, view: View) {
+  private val viewHolder = WeakReference(view)
+  internal var wasValidated = false
+
+  operator fun getValue(thisRef: View, property: KProperty<*>): Callback<T> {
+    if (!wasValidated) {
+      throw IllegalStateException("You have to export this property as a callback in the `ViewManager`.")
+    }
+
+    val view = viewHolder.get() ?: throw IllegalStateException("Can't send event from view which was deallocated.")
+    return ViewCallback(property.name, type, view)
+  }
+}
+
+inline fun <reified T> View.callback(): ViewCallbackDelegate<T> {
+  return ViewCallbackDelegate(typeOf<T>(), this)
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/callbacks/ViewCallbackDelegate.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/callbacks/ViewCallbackDelegate.kt
@@ -10,14 +10,14 @@ import kotlin.reflect.typeOf
 
 class ViewCallbackDelegate<T>(private val type: KType, view: View) {
   private val viewHolder = WeakReference(view)
-  internal var wasValidated = false
+  internal var isValidated = false
 
   operator fun getValue(thisRef: View, property: KProperty<*>): Callback<T> {
-    if (!wasValidated) {
+    if (!isValidated) {
       throw IllegalStateException("You have to export this property as a callback in the `ViewManager`.")
     }
 
-    val view = viewHolder.get() ?: throw IllegalStateException("Can't send event from view which was deallocated.")
+    val view = viewHolder.get() ?: throw IllegalStateException("Can't send an event from the view that is deallocated.")
     return ViewCallback(property.name, type, view)
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/CallbacksDefinition.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/CallbacksDefinition.kt
@@ -1,0 +1,3 @@
+package expo.modules.kotlin.views
+
+class CallbacksDefinition(val names: Array<out String>)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/GroupViewManagerWrapper.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/GroupViewManagerWrapper.kt
@@ -24,4 +24,13 @@ class GroupViewManagerWrapper(
     super.onDropViewInstance(view)
     viewWrapperDelegate.onDestroy(view)
   }
+
+  override fun getExportedCustomDirectEventTypeConstants(): Map<String, Any>? {
+    viewWrapperDelegate.getExportedCustomDirectEventTypeConstants()?.let {
+      val directEvents = super.getExportedCustomDirectEventTypeConstants() ?: emptyMap()
+      return directEvents + it
+    }
+
+    return super.getExportedCustomDirectEventTypeConstants()
+  }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/SimpleViewManagerWrapper.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/SimpleViewManagerWrapper.kt
@@ -23,4 +23,13 @@ class SimpleViewManagerWrapper(
     super.onDropViewInstance(view)
     viewWrapperDelegate.onDestroy(view)
   }
+
+  override fun getExportedCustomDirectEventTypeConstants(): Map<String, Any>? {
+    viewWrapperDelegate.getExportedCustomDirectEventTypeConstants()?.let {
+      val directEvents = super.getExportedCustomDirectEventTypeConstants() ?: emptyMap()
+      return directEvents + it
+    }
+
+    return super.getExportedCustomDirectEventTypeConstants()
+  }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerDefinition.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerDefinition.kt
@@ -12,7 +12,8 @@ class ViewManagerDefinition(
   private val viewFactory: (Context) -> View,
   private val viewType: Class<out View>,
   private val props: Map<String, AnyViewProp>,
-  val onViewDestroys: ((View) -> Unit)? = null
+  val onViewDestroys: ((View) -> Unit)? = null,
+  val callbacksDefinition: CallbacksDefinition? = null
 ) {
 
   fun createView(context: Context): View = viewFactory(context)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerDefinitionBuilder.kt
@@ -19,12 +19,15 @@ class ViewManagerDefinitionBuilder {
   @PublishedApi
   internal var onViewDestroys: ((View) -> Unit)? = null
 
+  private var callbacksDefinition: CallbacksDefinition? = null
+
   fun build(): ViewManagerDefinition =
     ViewManagerDefinition(
       requireNotNull(viewFactory),
       requireNotNull(viewType),
       props,
-      onViewDestroys
+      onViewDestroys,
+      callbacksDefinition
     )
 
   /**
@@ -54,5 +57,12 @@ class ViewManagerDefinitionBuilder {
       typeOf<PropType>().toAnyType(),
       body
     )
+  }
+
+  /**
+   * Defines prop names that should be treated as callbacks.
+   */
+  fun callbacks(vararg callbacks: String) {
+    callbacksDefinition = CallbacksDefinition(callbacks)
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerDefinitionBuilder.kt
@@ -62,7 +62,7 @@ class ViewManagerDefinitionBuilder {
   /**
    * Defines prop names that should be treated as callbacks.
    */
-  fun callbacks(vararg callbacks: String) {
+  fun events(vararg callbacks: String) {
     callbacksDefinition = CallbacksDefinition(callbacks)
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerWrapperDelegate.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerWrapperDelegate.kt
@@ -55,22 +55,22 @@ class ViewManagerWrapperDelegate(internal var moduleHolder: ModuleHolder) {
 
     callbacks.forEach {
       val property = propertiesMap[it].ifNull {
-        Log.w("ExpoModuleCore", "Cannot find property for $it in ${kClass.simpleName}.")
+        Log.w("ExpoModuleCore", "Property `$it` does not exist in ${kClass.simpleName}.")
         return@forEach
       }
       property.isAccessible = true
 
       val delegate = property.getDelegate(view).ifNull {
-        Log.w("ExpoModulesCore", "Cannot find property delegate for $it in ${kClass.simpleName}")
+        Log.w("ExpoModulesCore", "Property delegate for `$it` in ${kClass.simpleName} does not exist.")
         return@forEach
       }
 
       val viewDelegate = (delegate as? ViewCallbackDelegate<*>).ifNull {
-        Log.w("ExpoModulesCore", "Cannot case `$it` property delegate into the `ViewCallbackDelegate`.")
+        Log.w("ExpoModulesCore", "Property delegate for `$it` cannot be cased to `ViewCallbackDelegate`.")
         return@forEach
       }
 
-      viewDelegate.wasValidated = true
+      viewDelegate.isValidated = true
     }
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerWrapperDelegate.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerWrapperDelegate.kt
@@ -1,9 +1,14 @@
 package expo.modules.kotlin.views
 
 import android.content.Context
+import android.util.Log
 import android.view.View
 import com.facebook.react.bridge.ReadableMap
+import expo.modules.core.utilities.ifNull
 import expo.modules.kotlin.ModuleHolder
+import expo.modules.kotlin.callbacks.ViewCallbackDelegate
+import kotlin.reflect.full.declaredMemberProperties
+import kotlin.reflect.jvm.isAccessible
 
 class ViewManagerWrapperDelegate(internal var moduleHolder: ModuleHolder) {
   private val definition: ViewManagerDefinition
@@ -12,8 +17,13 @@ class ViewManagerWrapperDelegate(internal var moduleHolder: ModuleHolder) {
   val name: String
     get() = moduleHolder.name
 
-  fun createView(context: Context): View =
-    definition.createView(context)
+  fun createView(context: Context): View {
+    return definition
+      .createView(context)
+      .also {
+        configureView(it)
+      }
+  }
 
   fun setProxiedProperties(view: View, proxiedProperties: ReadableMap) {
     definition.setProps(proxiedProperties, view)
@@ -21,4 +31,46 @@ class ViewManagerWrapperDelegate(internal var moduleHolder: ModuleHolder) {
 
   fun onDestroy(view: View) =
     definition.onViewDestroys?.invoke(view)
+
+  fun getExportedCustomDirectEventTypeConstants(): Map<String, Any>? {
+    return definition
+      .callbacksDefinition
+      ?.names
+      ?.map {
+        it to mapOf(
+          "registrationName" to it
+        )
+      }
+      ?.toMap()
+  }
+
+  private fun configureView(view: View) {
+    val callbacks = definition.callbacksDefinition?.names ?: return
+
+    val kClass = view.javaClass.kotlin
+    val propertiesMap = kClass
+      .declaredMemberProperties
+      .map { it.name to it }
+      .toMap()
+
+    callbacks.forEach {
+      val property = propertiesMap[it].ifNull {
+        Log.w("ExpoModuleCore", "Cannot find property for $it in ${kClass.simpleName}.")
+        return@forEach
+      }
+      property.isAccessible = true
+
+      val delegate = property.getDelegate(view).ifNull {
+        Log.w("ExpoModulesCore", "Cannot find property delegate for $it in ${kClass.simpleName}")
+        return@forEach
+      }
+
+      val viewDelegate = (delegate as? ViewCallbackDelegate<*>).ifNull {
+        Log.w("ExpoModulesCore", "Cannot case `$it` property delegate into the `ViewCallbackDelegate`.")
+        return@forEach
+      }
+
+      viewDelegate.wasValidated = true
+    }
+  }
 }


### PR DESCRIPTION
# Why

Adds a very primitive view callbacks support. 

# How

- Extends a `ViewManager` DSL. 
- Creates a property delegate that handles callbacks.

> Note
- currently, we only support bundle as an event payload
- you have to call `invoke` method on the Callback instance - it will be changed in the future 

# Test Plan

- bare-expo ✅

# How to create a callback

```kotlin
// module definition
ViewManager {
	// ...
	callbacks("onChange")
}
```

```kotlin
// view
class MyView : View {
	val onChange by callback<Bundle>()

	fun invokeOnChange(event: Bundle) {
		onChange.invoke(event)
	}
}
```


