### PR TITLE
[bare] bump Detox to fix CI crash

### DIFF
--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -129,7 +129,7 @@
     "@types/react-native": "~0.64.12",
     "babel-plugin-module-resolver": "^4.1.0",
     "babel-preset-expo": "~9.0.0",
-    "detox": "^18.23.1",
+    "detox": "^19.4.1",
     "expo-module-scripts": "^2.0.0",
     "expo-yarn-workspaces": "^1.6.0",
     "jest-expo": "~44.0.0-beta.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4251,6 +4251,16 @@ ajv@^8.0.1:
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
+ajv@^8.6.3:
+  version "8.8.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.8.2.tgz#01b4fef2007a28bf75f0b7fc009f62679de4abbb"
+  integrity sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.2.2"
+
 align-text@^0.1.1, align-text@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/align-text/-/align-text-0.1.4.tgz#0cd90a561093f35d0a99256c22b7069433fad117"
@@ -7023,11 +7033,12 @@ detect-port-alt@1.1.6:
     address "^1.0.1"
     debug "^2.6.0"
 
-detox@^18.23.1:
-  version "18.23.1"
-  resolved "https://registry.yarnpkg.com/detox/-/detox-18.23.1.tgz#f09f5e50291cdab3d62dc40ff2e8bb5cfb3cb776"
-  integrity sha512-MnOXfTcBBcXTrlLk3EeHq1nEfob79nChZbfOtlEummyec/X+PQzEvmKk2cvsUzu1f7GiNbCiBKN66w47Z7b/CQ==
+detox@^19.4.1:
+  version "19.4.1"
+  resolved "https://registry.yarnpkg.com/detox/-/detox-19.4.1.tgz#9981ef124dfc1a11a8da425daafc161ebfb60980"
+  integrity sha512-zEIM28HP79FkW0nc7FzVVw8l2+Di0mi7JHo8oQKbXhq8gx4QwcLdi697u8cUnmIiKlfgyECSbv279poFlub+DQ==
   dependencies:
+    ajv "^8.6.3"
     bunyan "^1.8.12"
     bunyan-debug-stream "^1.1.0"
     chalk "^2.4.2"


### PR DESCRIPTION
# Why

As seen in this CI workflow:
* https://github.com/expo/expo/runs/4661072695?check_suite_focus=true#step:15:1513

Detox throws `DetoxRuntimeError` and crashes. It looks like the culprit in our case was Firebase integration, and the fix for that has been merged and shipped yesterday. For more information check out:
* https://github.com/wix/Detox/pull/3135

# How

Bump Detox to latest release - `19.4.1`. Release `19.4.0` includes the fix:
* https://github.com/wix/Detox/releases/tag/19.4.0 

This version also adds support for React Native `0.66`, which will be needed in the future anyway. 😉 

As described in Detox releases the major version bump (`18` -> `19`) is not a breaking change for most of the users, and I did not noticed any obvious issues when running Detox locally after bump:
* https://github.com/wix/Detox/releases/tag/19.0.0

# Test Plan

Run locally in `apps/bare-expo`:

* `yarn detox:clean`
* `yarn ios:detox:build:release`
* `yarn ios:detox:test:release`

Run CI to confirm that the bump has helped.

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
