### PR TITLE
[docs] Fix broken link on app credentials page

### DIFF
--- a/docs/pages/app-signing/app-credentials.md
+++ b/docs/pages/app-signing/app-credentials.md
@@ -6,7 +6,7 @@ import { InlineCode } from '~/components/base/code';
 
 Expo automates the process of signing your app for iOS and Android, but in both cases you can choose to provide your own overrides. [EAS Build](/build/introduction.md) can generate signed or unsigned applications, but in order to distribute your application through the stores, it **must** be a signed application.
 
-On this page, we'll talk about the credentials that each platform requires. If you're curious about how we store your credentials on our end, take a look at our [security documentation](security.md).
+On this page, we'll talk about the credentials that each platform requires. If you're curious about how we store your credentials on our end, take a look at our [security documentation](/distribution/security.md).
 
 <details><summary><strong>Are you using the classic build system?</strong> (<InlineCode>expo build:[android|ios]</InlineCode>)</summary> <p>
 


### PR DESCRIPTION
Fix the "security documentation" link so that it no longer 404s.

# Why
The "security documentation" link on the [App Credentials Explained](https://docs.expo.dev/app-signing/app-credentials/) page is broken.

# How

I updated the link.

# Test Plan

I ran the site locally and confirmed that my updated link now goes to the security page.

# Checklist

I do not believe these checklist items apply to this change.

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
