### PR TITLE
[core] Fix ReactInstanceManager.onHostPause exception from background

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### 🐛 Bug fixes
 
 - It's no longer possible to directly call methods from the `ModuleDefinition` in the `ViewManagers` on Android. ([#15741](https://github.com/expo/expo/pull/15741) by [@lukmccall](https://github.com/lukmccall))
+- Fix `ReactInstanceManager.onHostPause` exception from moving Android apps to background. ([#15748](https://github.com/expo/expo/pull/15748) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 


### PR DESCRIPTION
# Why

fix the root cause of #15298
some context in the message: https://github.com/expo/expo/issues/15298#issuecomment-1002634388

# How

should only destroy the `ReactInstanceManager` if it does not bind with an Activity.

# Test Plan

follow steps from https://github.com/expo/expo/issues/15298#issuecomment-1002771784

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
