### PR TITLE
[docs] Added auth guide for Twitter v2

### DIFF
--- a/docs/pages/guides/authentication.md
+++ b/docs/pages/guides/authentication.md
@@ -43,6 +43,7 @@ If you'd like to see more, you can [open a PR](https://github.com/expo/expo/edit
   <SocialGridItem title="Spotify" protocol={['OAuth 2']} href="#spotify" image="/static/images/sdk/auth-session/spotify.png" />
   <SocialGridItem title="Strava" protocol={['OAuth 2']} href="#strava" image="/static/images/sdk/auth-session/strava.png" />
   <SocialGridItem title="Twitch" protocol={['OAuth 2']} href="#twitch" image="/static/images/sdk/auth-session/twitch.png" />
+  <SocialGridItem title="Twitter" protocol={['OAuth 2']} href="#twitter" image="/static/images/sdk/auth-session/twitter.png" />
   <SocialGridItem title="Uber" protocol={['OAuth 2']} href="#uber" image="/static/images/sdk/auth-session/uber.png" />
 </SocialGrid>
 
@@ -2160,6 +2161,105 @@ export default function App() {
 </Tabs>
 
 <!-- End Twitch -->
+
+### Twitter
+
+<CreateAppButton name="Twitter" href="https://developer.twitter.com/en/portal/projects/new" />
+
+| Website                      | Provider | PKCE      | Auto Discovery | Scopes            |
+| ---------------------------- | -------- | --------- | -------------- | ----------------- |
+| [Get your Config][c-twitter] | OAuth    | Supported | Not Available  | [Info][s-twitter] |
+
+[c-twitter]: https://developer.twitter.com/en/portal/projects/new
+[s-twitter]: https://developer.twitter.com/en/docs/authentication/oauth-2-0/authorization-code
+
+- You will need to be approved by Twitter support before you can use the Twitter v2 API.
+- Web does not appear to work, the Twitter authentication website appears to block the popup, causing the `response` of `useAuthRequest` to always be `{type: 'dismiss'}`.
+- Example redirects:
+  - Expo Go + Proxy: `https://auth.expo.io/@you/your-app`
+  - Standalone or Bare: `com.your.app://`
+  - Web (dev `expo start --https`): `https://localhost:19006` (no ending slash)
+- The `redirectUri` requires 2 slashes (`://`).
+
+#### Expo Go
+
+You must use the proxy service in the Expo Go app because `exp://localhost:19000` cannot be added to your Twitter app as a redirect.
+
+<Tabs tabs={["Auth Code"]}>
+
+<Tab>
+
+<SnackInline label='Twitter Auth Code' dependencies={['expo-auth-session', 'expo-random', 'expo-web-browser']}>
+
+<!-- prettier-ignore -->
+```tsx
+import * as React from 'react';
+import * as WebBrowser from 'expo-web-browser';
+import { makeRedirectUri, useAuthRequest } from 'expo-auth-session';
+import { Button, Platform } from 'react-native';
+
+const useProxy = Platform.select({ web: false, default: true });
+
+/* @info <strong>Web only:</strong> This method should be invoked on the page that the auth popup gets redirected to on web, it'll ensure that authentication is completed properly. On native this does nothing. */
+WebBrowser.maybeCompleteAuthSession();
+/* @end */
+
+// Endpoint
+const discovery = {
+  authorizationEndpoint: "https://twitter.com/i/oauth2/authorize",
+  tokenEndpoint: "https://twitter.com/i/oauth2/token",
+  revocationEndpoint: "https://twitter.com/i/oauth2/revoke",
+};
+
+export default function App() {
+  const [request, response, promptAsync] = useAuthRequest(
+    {
+      clientId: 'CLIENT_ID',
+      redirectUri: makeRedirectUri({
+        /* @info The URI <code>[scheme]://</code> to be used in bare and standalone. If undefined, the <code>scheme</code> property of your app.json or app.config.js will be used instead. */
+        scheme: 'your.app',
+        /* @end */
+        useProxy
+      }),
+      usePKCE: true,
+      scopes: [
+        "tweet.read",
+      ],
+    },
+    discovery
+  );
+
+  React.useEffect(() => {
+    if (response?.type === 'success') {
+      /* @info Exchange the code for an access token in a server. Alternatively you can use the <b>Implicit</b> auth method. */
+      const { code } = response.params;
+      /* @end */
+    }
+  }, [response]);
+
+  return (
+    <Button
+      /* @info Disable the button until the request is loaded asynchronously. */
+      disabled={!request}
+      /* @end */
+      title="Login"
+      onPress={() => {
+        /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
+        promptAsync({ useProxy });
+        /* @end */
+      }}
+    />
+  );
+}
+```
+
+</SnackInline>
+
+</Tab>
+
+</Tabs>
+
+<!-- End Twitter -->
 
 ### Uber
 


### PR DESCRIPTION
# Why

- Highly requested feature.
- Couldn't get web to work, some kinda unknown cross origin request blocking going on.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

- Applied for Twitter v2 dev support.
- Documented how to use Twitter v2 API with `expo-auth-session`.
- Tested on iOS Expo Go and Dev Client. Also tested web but it doesn't work.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
