### PR TITLE
[core][ios] Fix modules registration on iOS in bare-expo

### DIFF
--- a/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.mm
+++ b/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.mm
@@ -152,7 +152,7 @@ RCT_EXPORT_MODULE(NativeUnimoduleProxy)
   if (!_bridge) {
     // The `setBridge` can be called during module setup or after. Registering more modules
     // during setup causes a crash due to mutating `_moduleDataByID` while it's being enumerated.
-    // In just that case we register them asynchronously.
+    // In that case we register them asynchronously.
     if ([[bridge valueForKey:@"_moduleSetupComplete"] boolValue]) {
       [self registerExpoModulesInBridge:bridge];
     } else {


### PR DESCRIPTION
# Why

@Kudo found out that bare-expo doesn't work after my changes introduced in #15731 where I wrapped modules registration by `dispatch_async`, because it's been crashing in Expo Go — the registration happened at the same time that React Native enumerated an array of modules and of course mutating an array during enumeration is not allowed. However, now it turns out that running it asynchronously breaks in bare-expo 🤯

# How

I figured out that the `setBridge` in Expo Go is invoked when `bridge._moduleSetupComplete` is false, however in bare-expo it's true. This flag is set to true right after enumeration that caused the crash in Expo Go (https://github.com/expo/react-native/blob/c2123c9a4fab761b3cd503724ab66fd4bfa2914e/React/CxxBridge/RCTCxxBridge.mm#L928), which means in bare-expo it is safe to run this code synchronously, but in Expo Go it's not.

I couldn't figure out what makes the difference, though 🤷‍♂️

# Test Plan

Both Expo Go and bare-expo are not crashing when the JS app launches.
