### PR TITLE
[docs] Update installing-expo-modules.md

### DIFF
--- a/docs/pages/bare/installing-expo-modules.md
+++ b/docs/pages/bare/installing-expo-modules.md
@@ -61,7 +61,7 @@ console.log(Constants.systemFonts);
 
 ### Using Expo SDK packages
 
-Once the `expo` package is installed and configured in your project, you can use `expo install` to add any other Expo module from the SDK. Learn more in ["Using Libraries"](../workflow/using-libraries.md).
+Once the `expo` package is installed and configured in your project, you can use `expo install` to add any other Expo module from the SDK. Learn more in ["Using Libraries"](/workflow/using-libraries).
 
 ### Expo modules included in the `expo` package
 

--- a/docs/pages/bare/installing-expo-modules.md
+++ b/docs/pages/bare/installing-expo-modules.md
@@ -61,7 +61,7 @@ console.log(Constants.systemFonts);
 
 ### Using Expo SDK packages
 
-Once the `expo` package is installed and configured in your project, you can use `expo install` to add any other Expo module from the SDK. Learn more in ["Using Libraries"](../using-libraries.md).
+Once the `expo` package is installed and configured in your project, you can use `expo install` to add any other Expo module from the SDK. Learn more in ["Using Libraries"](../workflow/using-libraries/.md).
 
 ### Expo modules included in the `expo` package
 

--- a/docs/pages/bare/installing-expo-modules.md
+++ b/docs/pages/bare/installing-expo-modules.md
@@ -61,7 +61,7 @@ console.log(Constants.systemFonts);
 
 ### Using Expo SDK packages
 
-Once the `expo` package is installed and configured in your project, you can use `expo install` to add any other Expo module from the SDK. Learn more in ["Using Libraries"](../workflow/using-libraries/.md).
+Once the `expo` package is installed and configured in your project, you can use `expo install` to add any other Expo module from the SDK. Learn more in ["Using Libraries"](../workflow/using-libraries.md).
 
 ### Expo modules included in the `expo` package
 


### PR DESCRIPTION
# Why

Link is broken

# How

Change path

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
