### PR TITLE
[docs] Update README.md

### DIFF
--- a/packages/expo-file-system/README.md
+++ b/packages/expo-file-system/README.md
@@ -13,7 +13,7 @@ For [managed](https://docs.expo.io/versions/latest/introduction/managed-vs-bare/
 
 # Installation in bare React Native projects
 
-For bare React Native projects, this package is included in [`expo-modules`](https://github.com/expo/expo/tree/master/packages/expo-modules-core). Please refer to those installation instructions to install this package.
+For bare React Native projects, you must ensure that you have [installed and configured the `expo` package](https://docs.expo.dev/bare/installing-expo-modules/) before continuing.
 
 ## Installation in bare iOS React Native project
 

--- a/packages/expo-file-system/README.md
+++ b/packages/expo-file-system/README.md
@@ -13,7 +13,7 @@ For [managed](https://docs.expo.io/versions/latest/introduction/managed-vs-bare/
 
 # Installation in bare React Native projects
 
-For bare React Native projects, this package is included in [`react-native-unimodules`](https://github.com/expo/expo/tree/master/packages/react-native-unimodules). Please refer to those installation instructions to install this package.
+For bare React Native projects, this package is included in [`expo-modules`](https://github.com/expo/expo/tree/master/packages/expo-modules-core). Please refer to those installation instructions to install this package.
 
 ## Installation in bare iOS React Native project
 


### PR DESCRIPTION
# Why

Update the reference from unimodules to expo-modules

# How

Change text and link

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
