### PR TITLE
[expo-location] Allow location to work with only coarse location permission on Android

### DIFF
--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 ### 🐛 Bug fixes
+
 - Allow location to work on Android with only coarse location permission. All apps do not require fine/precise location permission, but in past Expo was enforcing fine/precise even if you only needed coarse level location. ([#15760](https://github.com/expo/expo/pull/15760) by [@Noitidart](https://github.com/Noitidart))
 
 ### 💡 Others

--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### 🎉 New features
 
 ### 🐛 Bug fixes
-- Allow location to work on Android with only coarse location permission. All apps do not require fine/precise location permission, but in past Expo was enforcing fine/precise even if you only needed coarse level location.
+- Allow location to work on Android with only coarse location permission. All apps do not require fine/precise location permission, but in past Expo was enforcing fine/precise even if you only needed coarse level location. ([#15760](https://github.com/expo/expo/pull/15760) by [@Noitidart](https://github.com/Noitidart))
 
 ### 💡 Others
 

--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 ### 🐛 Bug fixes
+- Allow location to work on Android with only coarse location permission. All apps do not require fine/precise location permission, but in past Expo was enforcing fine/precise even if you only needed coarse level location.
 
 ### 💡 Others
 

--- a/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.java
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.java
@@ -586,7 +586,12 @@ public class LocationModule extends ExportedModule implements LifecycleEventList
    * Checks whether all required permissions have been granted by the user.
    */
   private boolean isMissingForegroundPermissions() {
-    return mPermissionsManager == null || !mPermissionsManager.hasGrantedPermissions(Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION);
+    if (mPermissionsManager == null) {
+      return true;
+    }
+    boolean canAccessFineLocation = mPermissionsManager.hasGrantedPermissions(Manifest.permission.ACCESS_FINE_LOCATION);
+    boolean canAccessCoarseLocation = mPermissionsManager.hasGrantedPermissions(Manifest.permission.ACCESS_COARSE_LOCATION);
+    return !canAccessFineLocation && !canAccessCoarseLocation;
   }
 
   /**


### PR DESCRIPTION
# Why

Some apps only need coarse location. Only apps that need fine location need both enabled (coarse and fine).
# How

My app only needs coarse location so I wanted to remove the extra uneeded permission of fine location. But expo code is forcing fine location. Related discussion - https://forums.expo.dev/t/only-access-coarse-location-not-working-for-lowest-accuracy-location/57837

# Test Plan

Existing test plan should work.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
