### PR TITLE
Fix installation instructions typo in `docs/pages/build/setup.md`

### DIFF
--- a/docs/pages/build/setup.md
+++ b/docs/pages/build/setup.md
@@ -122,7 +122,7 @@ If you have made it to this step, congratulations! Depending on which path you c
 
 ### Distribute your app to an app store
 
-You will only be able to install the submit to an app store if you built specifically for this purpose. If you created a build for a store, [learn how to submit your app to app stores with EAS Submit](/submit/introduction.md).
+You will only be able to submit to an app store if you built specifically for this purpose. If you created a build for a store, [learn how to submit your app to app stores with EAS Submit](/submit/introduction.md).
 
 ### Install and run the app
 


### PR DESCRIPTION
This didn't make sense to me, seems like a typo, hopefully this was the intended meaning.

# Why

To fix the documentation to make more sense.

# How

Clicked the edit button on the documentation.

# Test Plan

It's just documentation, no tests required.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).