### PR TITLE
[test-suite] lint files, add lint check to CI

### DIFF
--- a/.github/workflows/test-suite-lint.yml
+++ b/.github/workflows/test-suite-lint.yml
@@ -1,0 +1,47 @@
+name: Test Suite Lint
+
+on:
+  workflow_dispatch: {}
+  push:
+    branches: [master]
+    paths:
+      - apps/test-suite/**
+  pull_request:
+    paths:
+      - apps/test-suite/**
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: ⬢ Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14.17'
+      - name: 👀 Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: ♻️ Restore workspace node modules
+        uses: actions/cache@v2
+        id: node-modules-cache
+        with:
+          path: |
+            # See "workspaces" → "packages" in the root package.json for the source of truth of
+            # which node_modules are affected by the root yarn.lock
+            node_modules
+            apps/*/node_modules
+            home/node_modules
+            packages/*/node_modules
+            packages/@unimodules/*/node_modules
+            react-native-lab/react-native/node_modules
+          key: ${{ runner.os }}-modules-${{ hashFiles('yarn.lock') }}
+      - name: 🧶 Install node modules in root dir
+        run: yarn install --frozen-lockfile
+      - name: 🚨 Lint test-suite files
+        run: yarn lint --max-warnings 0
+        working-directory: apps/test-suite

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -23,6 +23,37 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: ⬢ Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14.17'
+      - name: 👀 Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: ♻️ Restore workspace node modules
+        uses: actions/cache@v2
+        id: node-modules-cache
+        with:
+          path: |
+            # See "workspaces" → "packages" in the root package.json for the source of truth of
+            # which node_modules are affected by the root yarn.lock
+            node_modules
+            apps/*/node_modules
+            home/node_modules
+            packages/*/node_modules
+            packages/@unimodules/*/node_modules
+            react-native-lab/react-native/node_modules
+          key: ${{ runner.os }}-modules-${{ hashFiles('yarn.lock') }}
+      - name: 🧶 Install node modules in root dir
+        run: yarn install --frozen-lockfile
+      - name: 🚨 Lint `test-suite` files
+        run: yarn lint --max-warnings 0
+        working-directory: apps/test-suite
+
   web:
     runs-on: ubuntu-18.04
     steps:
@@ -121,10 +152,10 @@ jobs:
       - name: 🥥 Install pods in apps/bare-expo/ios
         run: pod install
         working-directory: apps/bare-expo/ios
-      - name: Clean Detox
+      - name: 🧹 Clean Detox
         run: yarn detox:clean
         working-directory: apps/bare-expo
-      - name: Build iOS project for Detox
+      - name: 🏗️ Build iOS project for Detox
         run: yarn ios:detox:build:release
         working-directory: apps/bare-expo
         timeout-minutes: 30
@@ -187,7 +218,7 @@ jobs:
       - name: ⚛️ Display React Native config
         run: yarn react-native config
         working-directory: apps/bare-expo
-      - name: Clean Detox
+      - name: 🧹 Clean Detox
         run: yarn detox:clean
         working-directory: apps/bare-expo
       - name: 💿 Patch react-native to support single abi
@@ -201,7 +232,7 @@ jobs:
         timeout-minutes: 35
         env:
           GRADLE_OPTS: '-Dorg.gradle.internal.http.connectionTimeout=180000 -Dorg.gradle.internal.http.socketTimeout=180000 -Dorg.gradle.internal.network.retry.max.attempts=18 -Dorg.gradle.internal.network.retry.initial.backOff=2000'
-      - name: Build Android project for Detox
+      - name: 🏗️ Build Android project for Detox
         run: yarn android:detox:build:release
         working-directory: apps/bare-expo
         timeout-minutes: 35

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -23,37 +23,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: ⬢ Setup Node
-        uses: actions/setup-node@v2
-        with:
-          node-version: '14.17'
-      - name: 👀 Checkout
-        uses: actions/checkout@v2
-        with:
-          submodules: true
-      - name: ♻️ Restore workspace node modules
-        uses: actions/cache@v2
-        id: node-modules-cache
-        with:
-          path: |
-            # See "workspaces" → "packages" in the root package.json for the source of truth of
-            # which node_modules are affected by the root yarn.lock
-            node_modules
-            apps/*/node_modules
-            home/node_modules
-            packages/*/node_modules
-            packages/@unimodules/*/node_modules
-            react-native-lab/react-native/node_modules
-          key: ${{ runner.os }}-modules-${{ hashFiles('yarn.lock') }}
-      - name: 🧶 Install node modules in root dir
-        run: yarn install --frozen-lockfile
-      - name: 🚨 Lint `test-suite` files
-        run: yarn lint --max-warnings 0
-        working-directory: apps/test-suite
-
   web:
     runs-on: ubuntu-18.04
     steps:

--- a/apps/test-suite/.eslintrc.js
+++ b/apps/test-suite/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+  root: true,
+  extends: ['universe/native'],
+  rules: {
+    'no-useless-escape': 0,
+  },
+};

--- a/apps/test-suite/AppNavigator.js
+++ b/apps/test-suite/AppNavigator.js
@@ -24,7 +24,6 @@ const shouldDisableTransition = !!global.DETOX;
 const transitionSpec = shouldDisableTransition ? { open: spec, close: spec } : undefined;
 
 export default function AppNavigator(props) {
-
   React.useLayoutEffect(() => {
     if (props.navigation) {
       props.navigation.setOptions({
@@ -34,7 +33,7 @@ export default function AppNavigator(props) {
           const color = focused ? Colors.activeTintColor : Colors.inactiveTintColor;
           return <MaterialCommunityIcons name="format-list-checks" size={27} color={color} />;
         },
-      })
+      });
     }
   }, [props.navigation]);
 

--- a/apps/test-suite/ExponentTest.js
+++ b/apps/test-suite/ExponentTest.js
@@ -1,5 +1,5 @@
-import { NativeModules } from 'react-native';
 import getenv from 'getenv';
+import { NativeModules } from 'react-native';
 
 // Used for bare android device farm builds
 const ExponentTest = (NativeModules && NativeModules.ExponentTest) || {

--- a/apps/test-suite/TestModules.js
+++ b/apps/test-suite/TestModules.js
@@ -178,5 +178,7 @@ export function getTestModules() {
     modules.push(optionalRequire(() => require('./tests/Cellular')));
     modules.push(optionalRequire(() => require('./tests/BarCodeScanner')));
   }
-  return modules.filter(Boolean).sort((a, b) => a.name.toLowerCase() > b.name.toLowerCase() ? 1 : -1);
+  return modules
+    .filter(Boolean)
+    .sort((a, b) => (a.name.toLowerCase() > b.name.toLowerCase() ? 1 : -1));
 }

--- a/apps/test-suite/babel.config.js
+++ b/apps/test-suite/babel.config.js
@@ -1,4 +1,4 @@
-module.exports = function(api) {
+module.exports = function (api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],

--- a/apps/test-suite/components/SpecResult.js
+++ b/apps/test-suite/components/SpecResult.js
@@ -14,11 +14,12 @@ function getStatusEmoji(status) {
 
 export default function SpecResult({ status = Statuses.Running, description, failedExpectations }) {
   const renderExpectations = React.useMemo(
-    () => (e, i) => (
-      <Text testID="test_suite_text_spec_exception" key={i}>
-        {e.get('message')}
-      </Text>
-    ),
+    () => (e, i) =>
+      (
+        <Text testID="test_suite_text_spec_exception" key={i}>
+          {e.get('message')}
+        </Text>
+      ),
     []
   );
 

--- a/apps/test-suite/components/SuiteResult.js
+++ b/apps/test-suite/components/SuiteResult.js
@@ -5,7 +5,7 @@ import SpecResult from './SpecResult';
 
 export default function SuiteResult({ r, depth }) {
   const renderSpecResult = React.useMemo(
-    () => r => {
+    () => (r) => {
       const status = r.get('status');
       const key = r.get('id');
       const description = r.get('description');
@@ -24,7 +24,7 @@ export default function SuiteResult({ r, depth }) {
   );
 
   const renderSuiteResult = React.useMemo(
-    () => r => <SuiteResult key={r.get('result').get('id')} r={r} depth={depth + 1} />,
+    () => (r) => <SuiteResult key={r.get('result').get('id')} r={r} depth={depth + 1} />,
     [depth]
   );
 

--- a/apps/test-suite/components/Suites.js
+++ b/apps/test-suite/components/Suites.js
@@ -10,7 +10,7 @@ export default function Suites({ suites, done, numFailed, results }) {
 
   const renderItem = ({ item }) => <SuiteResult r={item} depth={0} />;
 
-  const keyExtractor = item => item.get('result').get('id');
+  const keyExtractor = (item) => item.get('result').get('id');
 
   const scrollToEnd = React.useMemo(
     () => () => {

--- a/apps/test-suite/functions/src/index.ts
+++ b/apps/test-suite/functions/src/index.ts
@@ -7,7 +7,7 @@ export class ArgumentError extends functions.https.HttpsError {
   }
 }
 
-exports.echoMessage = functions.https.onCall(data => {
+exports.echoMessage = functions.https.onCall((data) => {
   const { message } = data;
   if (!message) {
     throw new ArgumentError(`Hi 👋, you did not specify a message`);

--- a/apps/test-suite/metro.config.js
+++ b/apps/test-suite/metro.config.js
@@ -8,7 +8,7 @@ module.exports = {
   // NOTE(brentvatne): This can be removed when
   // https://github.com/facebook/metro/issues/290 is fixed.
   server: {
-    enhanceMiddleware: middleware => {
+    enhanceMiddleware: (middleware) => {
       return (req, res, next) => {
         // When an asset is imported outside the project root, it has wrong path on Android
         // This happens for the back button in stack, so we fix the path to correct one

--- a/apps/test-suite/package.json
+++ b/apps/test-suite/package.json
@@ -4,7 +4,8 @@
   "description": "Test suite for the Expo SDK",
   "main": "__generated__/AppEntry.js",
   "scripts": {
-    "postinstall": "expo-yarn-workspaces postinstall"
+    "postinstall": "expo-yarn-workspaces postinstall",
+    "lint": "eslint ."
   },
   "author": "",
   "license": "MIT",

--- a/apps/test-suite/screens/SelectScreen.js
+++ b/apps/test-suite/screens/SelectScreen.js
@@ -9,9 +9,7 @@ import PlatformTouchable from '../components/PlatformTouchable';
 import Colors from '../constants/Colors';
 
 function ListItem({ title, onPressItem, selected, id }) {
-  function onPress() {
-    onPressItem(id);
-  }
+  const onPress = () => onPressItem(id);
 
   return (
     <PlatformTouchable onPress={onPress}>
@@ -28,7 +26,7 @@ function ListItem({ title, onPressItem, selected, id }) {
 }
 
 function createQueryString(tests) {
-  if (!Array.isArray(tests) || !tests.every(v => typeof v === 'string')) {
+  if (!Array.isArray(tests) || !tests.every((v) => typeof v === 'string')) {
     throw new Error(
       `test-suite: Cannot create query string for runner. Expected array of strings, instead got: ${tests}`
     );
@@ -71,9 +69,9 @@ export default class SelectScreen extends React.PureComponent {
     Linking.removeEventListener('url', this._handleOpenURL);
   }
 
-  checkLinking = incomingTests => {
+  checkLinking = (incomingTests) => {
     // TODO(Bacon): bare-expo should pass a space-separated string.
-    const tests = incomingTests.split(',').map(v => v.trim());
+    const tests = incomingTests.split(',').map((v) => v.trim());
     const query = createQueryString(tests);
     this.props.navigation.navigate('run', { tests: query });
   };
@@ -91,7 +89,7 @@ export default class SelectScreen extends React.PureComponent {
 
     if (url.includes('/all')) {
       // Test all available modules
-      const query = createQueryString(getTestModules().map(m => m.name));
+      const query = createQueryString(getTestModules().map((m) => m.name));
 
       this.props.navigation.navigate('run', {
         tests: query,
@@ -113,16 +111,16 @@ export default class SelectScreen extends React.PureComponent {
     Linking.addEventListener('url', this._handleOpenURL);
 
     Linking.getInitialURL()
-      .then(url => {
+      .then((url) => {
         this._handleOpenURL({ url });
       })
-      .catch(err => console.error('Failed to load initial URL', err));
+      .catch((err) => console.error('Failed to load initial URL', err));
   }
 
   _keyExtractor = ({ name }) => name;
 
-  _onPressItem = id => {
-    this.setState(state => {
+  _onPressItem = (id) => {
+    this.setState((state) => {
       const selected = new Set(state.selected);
       if (selected.has(id)) selected.delete(id);
       else selected.add(id);
@@ -140,11 +138,11 @@ export default class SelectScreen extends React.PureComponent {
   );
 
   _selectAll = () => {
-    this.setState(state => {
-      if (state.selected.size === this.state.modules.length) {
+    this.setState((prevState) => {
+      if (prevState.selected.size === prevState.modules.length) {
         return { selected: new Set() };
       }
-      return { selected: new Set(this.state.modules.map(item => item.name)) };
+      return { selected: new Set(prevState.modules.map((item) => item.name)) };
     });
   };
 
@@ -165,7 +163,8 @@ export default class SelectScreen extends React.PureComponent {
     const buttonTitle = allSelected ? 'Deselect All' : 'Select All';
 
     return (
-      <React.Fragment>
+      // eslint-disable-next-line react/jsx-fragments
+      <>
         <FlatList
           data={this.state.modules}
           extraData={this.state}
@@ -179,7 +178,7 @@ export default class SelectScreen extends React.PureComponent {
           onRun={this._navigateToTests}
           onToggle={this._selectAll}
         />
-      </React.Fragment>
+      </>
     );
   }
 }

--- a/apps/test-suite/screens/TestScreen.js
+++ b/apps/test-suite/screens/TestScreen.js
@@ -32,7 +32,7 @@ export default class TestScreen extends React.Component {
     const selectedTestNames = selectionQuery.split(' ');
 
     // We get test modules here to make sure that React Native will reload this component when tests were changed.
-    const selectedModules = getTestModules().filter(m => selectedTestNames.includes(m.name));
+    const selectedModules = getTestModules().filter((m) => selectedTestNames.includes(m.name));
 
     if (!selectedModules.length) {
       console.log('[TEST_SUITE]', 'No selected modules', selectedTestNames);
@@ -46,24 +46,24 @@ export default class TestScreen extends React.Component {
     this._isMounted = false;
   }
 
-  setPortalChild = testPortal => {
+  setPortalChild = (testPortal) => {
     if (this._isMounted) return this.setState({ testPortal });
   };
 
   cleanupPortal = () => {
-    return new Promise(resolve => {
+    return new Promise((resolve) => {
       if (this._isMounted) this.setState({ testPortal: null }, resolve);
     });
   };
 
-  _runTests = async modules => {
+  _runTests = async (modules) => {
     // Reset results state
     this.setState(initialState);
 
     const { jasmineEnv, jasmine } = await this._setupJasmine();
 
     await Promise.all(
-      modules.map(m =>
+      modules.map((m) =>
         m.test(jasmine, {
           setPortalChild: this.setPortalChild,
           cleanupPortal: this.cleanupPortal,
@@ -86,7 +86,7 @@ export default class TestScreen extends React.Component {
 
     // Get the interface and make it support `async ` by default
     const jasmine = jasmineModule.interface(jasmineCore, jasmineEnv);
-    const doneIfy = fn => async done => {
+    const doneIfy = (fn) => async (done) => {
       try {
         await Promise.resolve(fn());
         done();
@@ -198,7 +198,7 @@ export default class TestScreen extends React.Component {
         if (app._isMounted) {
           app.setState(({ state }) => ({
             state: state
-              .updateIn(state.get('path'), children =>
+              .updateIn(state.get('path'), (children) =>
                 children.push(
                   Immutable.fromJS({
                     result: jasmineResult,
@@ -207,7 +207,7 @@ export default class TestScreen extends React.Component {
                   })
                 )
               )
-              .update('path', path => path.push(state.getIn(path).size, 'children')),
+              .update('path', (path) => path.push(state.getIn(path).size, 'children')),
           }));
         }
       },
@@ -216,17 +216,12 @@ export default class TestScreen extends React.Component {
         if (app._isMounted) {
           app.setState(({ state }) => ({
             state: state
-              .updateIn(
-                state
-                  .get('path')
-                  .pop()
-                  .pop(),
-                children =>
-                  children.update(children.size - 1, child =>
-                    child.set('result', child.get('result'))
-                  )
+              .updateIn(state.get('path').pop().pop(), (children) =>
+                children.update(children.size - 1, (child) =>
+                  child.set('result', child.get('result'))
+                )
               )
-              .update('path', path => path.pop().pop()),
+              .update('path', (path) => path.pop().pop()),
           }));
         }
       },
@@ -234,15 +229,10 @@ export default class TestScreen extends React.Component {
       specStarted(jasmineResult) {
         if (app._isMounted) {
           app.setState(({ state }) => ({
-            state: state.updateIn(
-              state
-                .get('path')
-                .pop()
-                .pop(),
-              children =>
-                children.update(children.size - 1, child =>
-                  child.update('specs', specs => specs.push(Immutable.fromJS(jasmineResult)))
-                )
+            state: state.updateIn(state.get('path').pop().pop(), (children) =>
+              children.update(children.size - 1, (child) =>
+                child.update('specs', (specs) => specs.push(Immutable.fromJS(jasmineResult)))
+              )
             ),
           }));
         }
@@ -256,17 +246,12 @@ export default class TestScreen extends React.Component {
         }
         if (app._isMounted) {
           app.setState(({ state }) => ({
-            state: state.updateIn(
-              state
-                .get('path')
-                .pop()
-                .pop(),
-              children =>
-                children.update(children.size - 1, child =>
-                  child.update('specs', specs =>
-                    specs.set(specs.size - 1, Immutable.fromJS(jasmineResult))
-                  )
+            state: state.updateIn(state.get('path').pop().pop(), (children) =>
+              children.update(children.size - 1, (child) =>
+                child.update('specs', (specs) =>
+                  specs.set(specs.size - 1, Immutable.fromJS(jasmineResult))
                 )
+              )
             ),
           }));
         }

--- a/apps/test-suite/tests/AdMobBanner.js
+++ b/apps/test-suite/tests/AdMobBanner.js
@@ -39,7 +39,7 @@ export function test(t, { setPortalChild, cleanupPortal }) {
         await mountAndWaitFor(<AdMobBanner bannerSize="banner" adUnitID={validAdUnitID} />);
       });
 
-      forEach(sizes, size => {
+      forEach(sizes, (size) => {
         t.describe(`when given size = ${size}`, () => {
           t.it('displays an ad', async () => {
             await mountAndWaitFor(<AdMobBanner bannerSize={size} adUnitID={validAdUnitID} />);

--- a/apps/test-suite/tests/AdMobInterstitial.js
+++ b/apps/test-suite/tests/AdMobInterstitial.js
@@ -1,5 +1,5 @@
-import { Platform } from 'react-native';
 import { AdMobInterstitial, setTestDeviceIDAsync } from 'expo-ads-admob';
+import { Platform } from 'react-native';
 
 export const name = 'AdMobInterstitial';
 

--- a/apps/test-suite/tests/AdMobPublisherBanner.js
+++ b/apps/test-suite/tests/AdMobPublisherBanner.js
@@ -39,7 +39,7 @@ export function test(t, { setPortalChild, cleanupPortal }) {
         await mountAndWaitFor(<PublisherBanner bannerSize="banner" adUnitID={validAdUnitID} />);
       });
 
-      forEach(sizes, size => {
+      forEach(sizes, (size) => {
         t.describe(`when given size = ${size}`, () => {
           t.it('displays an ad', async () => {
             await mountAndWaitFor(<PublisherBanner bannerSize={size} adUnitID={validAdUnitID} />);

--- a/apps/test-suite/tests/AdMobRewarded.js
+++ b/apps/test-suite/tests/AdMobRewarded.js
@@ -1,6 +1,5 @@
-import { Platform } from 'react-native';
 import { AdMobRewarded, setTestDeviceIDAsync } from 'expo-ads-admob';
-import { waitFor } from './helpers';
+import { Platform } from 'react-native';
 
 export const name = 'AdMobRewarded';
 

--- a/apps/test-suite/tests/Application.js
+++ b/apps/test-suite/tests/Application.js
@@ -1,5 +1,6 @@
 import * as Application from 'expo-application';
 import { Platform } from 'react-native';
+
 import ExponentTest from '../ExponentTest';
 
 export const name = 'Application';
@@ -30,7 +31,7 @@ export async function test({ describe, it, expect, jasmine }) {
     });
     describe(`Application.getInstallationTimeAsync()`, () => {
       it(`returns a Date object`, async () => {
-        let installationTime = await Application.getInstallationTimeAsync();
+        const installationTime = await Application.getInstallationTimeAsync();
         expect(installationTime).toBeDefined();
         expect(installationTime).toEqual(jasmine.any(Date));
       });
@@ -98,7 +99,7 @@ export async function test({ describe, it, expect, jasmine }) {
   } else if (Platform.OS === 'android') {
     describe(`Android device tests`, () => {
       it(`gets Application.androidId as a String`, () => {
-        let androidId = Application.androidId;
+        const androidId = Application.androidId;
 
         expect(androidId).toBeDefined();
         expect(androidId).toEqual(jasmine.any(String));

--- a/apps/test-suite/tests/Asset.js
+++ b/apps/test-suite/tests/Asset.js
@@ -1,7 +1,7 @@
 'use strict';
 
-import * as FileSystem from 'expo-file-system';
 import { Asset } from 'expo-asset';
+import * as FileSystem from 'expo-file-system';
 
 export const name = 'Asset';
 
@@ -34,7 +34,7 @@ export function test(t) {
           const asset = Asset.fromModule(module);
           t.expect(asset.name).toBe(name);
           t.expect(asset.type).toBe(type);
-          Object.keys(more).forEach(member => t.expect(asset[member]).toBe(more[member]));
+          Object.keys(more).forEach((member) => t.expect(asset[member]).toBe(more[member]));
         });
 
         t.it("when downloaded, has a 'file://' localUri", async () => {
@@ -50,7 +50,11 @@ export function test(t) {
             const asset = Asset.fromModule(module);
             await asset.downloadAsync();
 
-            const { exists, md5, uri: cacheUri } = await FileSystem.getInfoAsync(asset.localUri, {
+            const {
+              exists,
+              md5,
+              uri: cacheUri,
+            } = await FileSystem.getInfoAsync(asset.localUri, {
               cache: true,
               md5: true,
             });

--- a/apps/test-suite/tests/Asset.web.js
+++ b/apps/test-suite/tests/Asset.web.js
@@ -27,7 +27,7 @@ export async function test(t) {
           t.expect(asset.name).toMatch(new RegExp(`${name}.*\.${type}`));
           t.expect(asset.type).toBe(type);
           console.log(asset);
-          Object.keys(more).forEach(member => t.expect(asset[member]).toBe(more[member]));
+          Object.keys(more).forEach((member) => t.expect(asset[member]).toBe(more[member]));
         });
 
         t.it("when downloaded, has a 'file://' localUri", async () => {

--- a/apps/test-suite/tests/BarCodeScanner.js
+++ b/apps/test-suite/tests/BarCodeScanner.js
@@ -12,7 +12,8 @@ export const name = 'BarCodeScanner';
 const style = { width: 200, height: 200 };
 
 export async function test(t, { setPortalChild, cleanupPortal }) {
-  const shouldSkipTestsRequiringPermissions = await TestUtils.shouldSkipTestsRequiringPermissionsAsync();
+  const shouldSkipTestsRequiringPermissions =
+    await TestUtils.shouldSkipTestsRequiringPermissionsAsync();
   const describeWithPermissions = shouldSkipTestsRequiringPermissions ? t.xdescribe : t.describe;
 
   const testPoint = (value, expected, inaccuracy) => {
@@ -38,7 +39,7 @@ export async function test(t, { setPortalChild, cleanupPortal }) {
 
   describeWithPermissions('BarCodeScanner', () => {
     const mountAndWaitFor = (child, propName = 'ref') =>
-      new Promise(resolve => {
+      new Promise((resolve) => {
         const response = originalMountAndWaitFor(child, propName, setPortalChild);
         setTimeout(() => resolve(response), 1500);
       });

--- a/apps/test-suite/tests/Basic.js
+++ b/apps/test-suite/tests/Basic.js
@@ -5,7 +5,7 @@ export const name = 'Basic';
 export function test(t) {
   t.describe('Basic', () => {
     t.it('waits 0.5 seconds and passes', async () => {
-      await new Promise(resolve => setTimeout(resolve, 500));
+      await new Promise((resolve) => setTimeout(resolve, 500));
       t.expect(true).toBe(true);
     });
     t.it('2 + 2 is 4?', () => {

--- a/apps/test-suite/tests/Brightness.js
+++ b/apps/test-suite/tests/Brightness.js
@@ -7,7 +7,8 @@ export const name = 'Brightness';
 export const EPSILON = Math.pow(10, -5);
 
 export async function test(t) {
-  const shouldSkipTestsRequiringPermissions = await TestUtils.shouldSkipTestsRequiringPermissionsAsync();
+  const shouldSkipTestsRequiringPermissions =
+    await TestUtils.shouldSkipTestsRequiringPermissionsAsync();
   const describeWithPermissions = shouldSkipTestsRequiringPermissions ? t.xdescribe : t.describe;
 
   t.describe(name, () => {

--- a/apps/test-suite/tests/Calendar.js
+++ b/apps/test-suite/tests/Calendar.js
@@ -25,13 +25,13 @@ async function createTestCalendarAsync(patch = {}) {
 
 async function getCalendarByIdAsync(calendarId) {
   const calendars = await Calendar.getCalendarsAsync();
-  return calendars.find(calendar => calendar.id === calendarId);
+  return calendars.find((calendar) => calendar.id === calendarId);
 }
 
 async function pickCalendarSourceIdAsync() {
   if (Platform.OS === 'ios') {
     const sources = await Calendar.getSourcesAsync();
-    const mainSource = sources.find(source => source.name === 'iCloud') || sources[0];
+    const mainSource = sources.find((source) => source.name === 'iCloud') || sources[0];
     return mainSource && mainSource.id;
   }
 }
@@ -62,11 +62,12 @@ async function createTestAttendeeAsync(eventId) {
 
 async function getAttendeeByIdAsync(eventId, attendeeId) {
   const attendees = await Calendar.getAttendeesForEventAsync(eventId);
-  return attendees.find(attendee => attendee.id === attendeeId);
+  return attendees.find((attendee) => attendee.id === attendeeId);
 }
 
 export async function test(t) {
-  const shouldSkipTestsRequiringPermissions = await TestUtils.shouldSkipTestsRequiringPermissionsAsync();
+  const shouldSkipTestsRequiringPermissions =
+    await TestUtils.shouldSkipTestsRequiringPermissionsAsync();
   const describeWithPermissions = shouldSkipTestsRequiringPermissions ? t.xdescribe : t.describe;
 
   function testCalendarShape(calendar) {
@@ -79,7 +80,7 @@ export async function test(t) {
     t.expect(typeof calendar.allowsModifications).toBe('boolean');
 
     t.expect(Array.isArray(calendar.allowedAvailabilities)).toBe(true);
-    calendar.allowedAvailabilities.forEach(availability => {
+    calendar.allowedAvailabilities.forEach((availability) => {
       t.expect(Object.values(Calendar.Availability)).toContain(availability);
     });
 
@@ -97,12 +98,12 @@ export async function test(t) {
       calendar.timeZone && t.expect(typeof calendar.timeZone).toBe('string');
 
       t.expect(Array.isArray(calendar.allowedReminders)).toBe(true);
-      calendar.allowedReminders.forEach(reminder => {
+      calendar.allowedReminders.forEach((reminder) => {
         t.expect(Object.values(Calendar.AlarmMethod)).toContain(reminder);
       });
 
       t.expect(Array.isArray(calendar.allowedAttendeeTypes)).toBe(true);
-      calendar.allowedAttendeeTypes.forEach(attendeeType => {
+      calendar.allowedAttendeeTypes.forEach((attendeeType) => {
         t.expect(Object.values(Calendar.AttendeeType)).toContain(attendeeType);
       });
 
@@ -273,7 +274,7 @@ export async function test(t) {
         await Calendar.deleteCalendarAsync(calendarId);
 
         const calendars = await Calendar.getCalendarsAsync();
-        t.expect(calendars.findIndex(calendar => calendar.id === calendarId)).toBe(-1);
+        t.expect(calendars.findIndex((calendar) => calendar.id === calendarId)).toBe(-1);
       });
     });
 
@@ -460,7 +461,7 @@ export async function test(t) {
 
           t.expect(Array.isArray(attendees)).toBe(true);
 
-          const newAttendee = attendees.find(attendee => attendee.id === attendeeId);
+          const newAttendee = attendees.find((attendee) => attendee.id === attendeeId);
 
           t.expect(newAttendee).toBeDefined();
           testAttendeeShape(newAttendee);

--- a/apps/test-suite/tests/CalendarReminders.js
+++ b/apps/test-suite/tests/CalendarReminders.js
@@ -14,11 +14,6 @@ async function createTestReminderAsync(calendarId) {
   });
 }
 
-async function getFirstCalendarForRemindersAsync() {
-  const calendars = await Calendar.getCalendarsAsync(Calendar.EntityTypes.REMINDER);
-  return calendars[0] && calendars[0].id;
-}
-
 function expectMethodsToReject(t, methods) {
   for (const methodName of methods) {
     t.describe(`${methodName}()`, () => {
@@ -47,7 +42,8 @@ function testReminderShape(t, reminder) {
 }
 
 export async function test(t) {
-  const shouldSkipTestsRequiringPermissions = await TestUtils.shouldSkipTestsRequiringPermissionsAsync();
+  const shouldSkipTestsRequiringPermissions =
+    await TestUtils.shouldSkipTestsRequiringPermissionsAsync();
   const describeWithPermissions = shouldSkipTestsRequiringPermissions ? t.xdescribe : t.describe;
 
   describeWithPermissions('CalendarReminders', () => {

--- a/apps/test-suite/tests/Camera.js
+++ b/apps/test-suite/tests/Camera.js
@@ -10,19 +10,20 @@ export const name = 'Camera';
 const style = { width: 200, height: 200 };
 
 export async function test(t, { setPortalChild, cleanupPortal }) {
-  const shouldSkipTestsRequiringPermissions = await TestUtils.shouldSkipTestsRequiringPermissionsAsync();
+  const shouldSkipTestsRequiringPermissions =
+    await TestUtils.shouldSkipTestsRequiringPermissionsAsync();
   const describeWithPermissions = shouldSkipTestsRequiringPermissions ? t.xdescribe : t.describe;
 
   describeWithPermissions('Camera', () => {
     let instance = null;
     let originalTimeout;
 
-    const refSetter = ref => {
+    const refSetter = (ref) => {
       instance = ref;
     };
 
     const mountAndWaitFor = (child, propName = 'onCameraReady') =>
-      new Promise(resolve => {
+      new Promise((resolve) => {
         const response = originalMountAndWaitFor(child, propName, setPortalChild);
         setTimeout(() => resolve(response), 1500);
       });
@@ -260,7 +261,7 @@ export async function test(t, { setPortalChild, cleanupPortal }) {
             .recordAsync({
               codec: '123',
             })
-            .catch(error => {
+            .catch((error) => {
               t.expect(error.message).toMatch(/(?=.*codec)(?=.*is not supported)/i);
             });
         });
@@ -292,7 +293,7 @@ export async function test(t, { setPortalChild, cleanupPortal }) {
       });
 
       // Test for the fix to: https://github.com/expo/expo/issues/1976
-      const testFrontCameraRecording = async camera => {
+      const testFrontCameraRecording = async (camera) => {
         await mountAndWaitFor(camera);
         const response = await instance.recordAsync({ maxDuration: 2 });
 
@@ -350,7 +351,7 @@ export async function test(t, { setPortalChild, cleanupPortal }) {
         t.it('started/stopped manually', async () => {
           await mountAndWaitFor(<Camera style={style} ref={refSetter} />);
 
-          const recordFor = duration =>
+          const recordFor = (duration) =>
             new Promise(async (resolve, reject) => {
               const recordingPromise = instance.recordAsync();
               await waitFor(duration);
@@ -373,7 +374,7 @@ export async function test(t, { setPortalChild, cleanupPortal }) {
         t.it('started/stopped automatically', async () => {
           await mountAndWaitFor(<Camera style={style} ref={refSetter} />);
 
-          const recordFor = duration =>
+          const recordFor = (duration) =>
             new Promise(async (resolve, reject) => {
               try {
                 const response = await instance.recordAsync({ maxDuration: duration / 1000 });

--- a/apps/test-suite/tests/Constants.js
+++ b/apps/test-suite/tests/Constants.js
@@ -6,7 +6,7 @@ export const name = 'Constants';
 
 export function test(t) {
   t.describe('Constants', () => {
-    ['expoVersion', 'linkingUri'].forEach(v =>
+    ['expoVersion', 'linkingUri'].forEach((v) =>
       t.it(`can only use ${v} in the managed workflow`, () => {
         if (
           Constants.appOwnership === 'expo' ||
@@ -28,7 +28,7 @@ export function test(t) {
       'manifest',
       'nativeAppVersion',
       'nativeBuildVersion',
-    ].forEach(v =>
+    ].forEach((v) =>
       t.it(`has ${v}`, () => {
         t.expect(Constants[v]).toBeDefined();
       })

--- a/apps/test-suite/tests/Contacts.js
+++ b/apps/test-suite/tests/Contacts.js
@@ -19,24 +19,15 @@ async function sortContacts(contacts, sortField, expect) {
   }
 }
 
-export async function test({
-  describe,
-  it,
-  xdescribe,
-  xit,
-  fit,
-  jasmine,
-  expect,
-  afterAll,
-  beforeAll,
-}) {
-  const shouldSkipTestsRequiringPermissions = await TestUtils.shouldSkipTestsRequiringPermissionsAsync();
+export async function test({ describe, it, xdescribe, jasmine, expect, afterAll }) {
+  const shouldSkipTestsRequiringPermissions =
+    await TestUtils.shouldSkipTestsRequiringPermissionsAsync();
   const describeWithPermissions = shouldSkipTestsRequiringPermissions ? xdescribe : describe;
 
   function compareArrays(array, expected) {
     return expected.reduce(
       (result, expectedItem) =>
-        result && array.filter(item => compareObjects(item, expectedItem)).length,
+        result && array.filter((item) => compareObjects(item, expectedItem)).length,
       true
     );
   }
@@ -80,7 +71,7 @@ export async function test({
     });
 
     const createdContactIds = [];
-    const createContact = async contact => {
+    const createContact = async (contact) => {
       const id = await Contacts.addContactAsync(contact);
       createdContactIds.push({ id, contact });
       return id;
@@ -123,7 +114,7 @@ export async function test({
       ];
 
       await Promise.all(
-        contacts.map(async contact => {
+        contacts.map(async (contact) => {
           const id = await createContact(contact);
           expect(typeof id).toBe('string');
         })
@@ -227,7 +218,7 @@ export async function test({
 
       const newContactId = await createContact(contact);
 
-      const { data, hasNextPage, hasPreviousPage, ...props } = await Contacts.getContactsAsync({
+      const { data, hasNextPage, hasPreviousPage } = await Contacts.getContactsAsync({
         id: newContactId,
       });
 
@@ -554,8 +545,8 @@ export async function test({
         let errorMessage;
         try {
           await Contacts.removeGroupAsync('some-value');
-        } catch ({ message }) {
-          errorMessage = message;
+        } catch (e) {
+          errorMessage = e.message;
         } finally {
           expect(errorMessage).toBe(
             `The method or property Contacts.removeGroupAsync is not available on android, are you sure you've linked all the native dependencies properly?`
@@ -566,8 +557,8 @@ export async function test({
           let errorMessage;
           try {
             await Contacts.removeGroupAsync(group.id);
-          } catch ({ message }) {
-            errorMessage = message;
+          } catch (e) {
+            errorMessage = e.message;
           }
           expect(errorMessage).toBeUndefined();
         }

--- a/apps/test-suite/tests/Device.js
+++ b/apps/test-suite/tests/Device.js
@@ -7,14 +7,14 @@ export const name = 'Device';
 export async function test(t) {
   t.describe(`Device.getDeviceType()`, () => {
     t.it(`returns enum values`, async () => {
-      let deviceType = await Device.getDeviceTypeAsync();
+      const deviceType = await Device.getDeviceTypeAsync();
       t.expect(Object.values(Device.DeviceType).includes(deviceType)).toBeTruthy();
     });
   });
 
   t.describe(`Device.getUptimeAsync()`, () => {
     t.it(`calls getUptimeAsync() and returns number`, async () => {
-      let uptime = await Device.getUptimeAsync();
+      const uptime = await Device.getUptimeAsync();
       t.expect(uptime).toBeDefined();
       t.expect(typeof uptime).toEqual('number');
     });
@@ -23,17 +23,17 @@ export async function test(t) {
   if (Platform.OS === 'ios') {
     t.describe(`Device on iOS`, () => {
       t.it(`gets most constants and correct types`, async () => {
-        let brand = Device.brand;
-        let manufacturer = Device.manufacturer;
-        let modelName = Device.modelName;
-        let osName = Device.osName;
-        let totalMemory = Device.totalMemory;
-        let isDevice = Device.isDevice;
-        let osBuildId = Device.osBuildId;
-        let osInternalBuildId = Device.osInternalBuildId;
-        let osVersion = Device.osVersion;
-        let deviceName = Device.deviceName;
-        let deviceYearClass = Device.deviceYearClass;
+        const brand = Device.brand;
+        const manufacturer = Device.manufacturer;
+        const modelName = Device.modelName;
+        const osName = Device.osName;
+        const totalMemory = Device.totalMemory;
+        const isDevice = Device.isDevice;
+        const osBuildId = Device.osBuildId;
+        const osInternalBuildId = Device.osInternalBuildId;
+        const osVersion = Device.osVersion;
+        const deviceName = Device.deviceName;
+        const deviceYearClass = Device.deviceYearClass;
         t.expect(brand).toBeDefined();
         t.expect(typeof brand).toEqual('string');
         t.expect(manufacturer).toBeDefined();
@@ -59,10 +59,10 @@ export async function test(t) {
       });
 
       t.it(`doesn't get Android-only constants`, async () => {
-        let osBuildFingerprint = Device.osBuildFingerprint;
-        let designName = Device.designName;
-        let productName = Device.productName;
-        let platformApiLevel = Device.platformApiLevel;
+        const osBuildFingerprint = Device.osBuildFingerprint;
+        const designName = Device.designName;
+        const productName = Device.productName;
+        const platformApiLevel = Device.platformApiLevel;
         t.expect(designName).toBeNull();
         t.expect(productName).toBeNull();
         t.expect(platformApiLevel).toBeNull();
@@ -70,14 +70,12 @@ export async function test(t) {
       });
 
       t.it(`getPlatformFeaturesAsync() returns empty array on iOS`, async () => {
-        let allFeatures;
-        allFeatures = await Device.getPlatformFeaturesAsync();
+        const allFeatures = await Device.getPlatformFeaturesAsync();
         t.expect(allFeatures).toEqual([]);
       });
 
       t.it(`hasPlatformFeatureAsync() returns false on iOS`, async () => {
-        let hasFeature;
-        hasFeature = await Device.hasPlatformFeatureAsync('amazon_fire_tv');
+        const hasFeature = await Device.hasPlatformFeatureAsync('amazon_fire_tv');
         t.expect(hasFeature).toEqual(false);
       });
 
@@ -106,8 +104,8 @@ export async function test(t) {
       });
 
       t.it(`gets osBuildId same as osInternalBuildId`, async () => {
-        let osBuildId = await Device.osBuildId;
-        let osInternalBuildId = await Device.osInternalBuildId;
+        const osBuildId = await Device.osBuildId;
+        const osInternalBuildId = await Device.osInternalBuildId;
         t.expect(Device.osBuildId).toBeTruthy();
         t.expect(Device.osInternalBuildId).toBeTruthy();
         t.expect(osBuildId).toEqual(osInternalBuildId);
@@ -116,21 +114,21 @@ export async function test(t) {
   } else if (Platform.OS === 'android') {
     t.describe(`Device on Android`, () => {
       t.it(`gets constants and correct types`, async () => {
-        let designName = await Device.designName;
-        let productName = await Device.productName;
-        let brand = await Device.brand;
-        let manufacturer = await Device.manufacturer;
-        let modelName = await Device.modelName;
-        let osName = await Device.osName;
-        let totalMemory = await Device.totalMemory;
-        let isDevice = await Device.isDevice;
-        let osBuildId = await Device.osBuildId;
-        let osBuildFingerprint = await Device.osBuildFingerprint;
-        let osInternalBuildId = await Device.osInternalBuildId;
-        let platformApiLevel = await Device.platformApiLevel;
-        let osVersion = await Device.osVersion;
-        let deviceName = await Device.deviceName;
-        let deviceYearClass = await Device.deviceYearClass;
+        const designName = await Device.designName;
+        const productName = await Device.productName;
+        const brand = await Device.brand;
+        const manufacturer = await Device.manufacturer;
+        const modelName = await Device.modelName;
+        const osName = await Device.osName;
+        const totalMemory = await Device.totalMemory;
+        const isDevice = await Device.isDevice;
+        const osBuildId = await Device.osBuildId;
+        const osBuildFingerprint = await Device.osBuildFingerprint;
+        const osInternalBuildId = await Device.osInternalBuildId;
+        const platformApiLevel = await Device.platformApiLevel;
+        const osVersion = await Device.osVersion;
+        const deviceName = await Device.deviceName;
+        const deviceYearClass = await Device.deviceYearClass;
         t.expect(designName).toBeDefined();
         t.expect(typeof designName).toEqual('string');
         t.expect(productName).toBeDefined();
@@ -181,6 +179,7 @@ export async function test(t) {
           error = e;
         }
         t.expect(hasFeature).toEqual(t.jasmine.any(Boolean));
+        t.expect(error).toBeUndefined();
       });
 
       t.it(
@@ -195,16 +194,17 @@ export async function test(t) {
           }
           t.expect(hasFeature).toEqual(t.jasmine.any(Boolean));
           t.expect(hasFeature).toEqual(false);
+          t.expect(error).toBeUndefined();
         }
       );
 
       t.it(`calls getMaxMemoryAsync() and returns a number under integer limit`, async () => {
-        let maxMemory = await Device.getMaxMemoryAsync();
+        const maxMemory = await Device.getMaxMemoryAsync();
         t.expect(maxMemory).toBeLessThanOrEqual(Number.MAX_SAFE_INTEGER);
       });
 
       t.it(`calls getPlatformFeaturesAsync()`, async () => {
-        let allFeatures = await Device.getPlatformFeaturesAsync();
+        const allFeatures = await Device.getPlatformFeaturesAsync();
         t.expect(allFeatures).toBeDefined();
       });
     });

--- a/apps/test-suite/tests/FBBannerAd.js
+++ b/apps/test-suite/tests/FBBannerAd.js
@@ -1,7 +1,8 @@
 'use strict';
 
-import React from 'react';
 import * as FacebookAds from 'expo-ads-facebook';
+import React from 'react';
+
 import { mountAndWaitForWithTimeout } from './helpers';
 
 const { BannerAd, AdSettings } = FacebookAds;

--- a/apps/test-suite/tests/FBNativeAd.js
+++ b/apps/test-suite/tests/FBNativeAd.js
@@ -4,14 +4,8 @@ import * as FacebookAds from 'expo-ads-facebook';
 import React from 'react';
 import { View, Text } from 'react-native';
 
-const {
-  NativeAdsManager,
-  AdSettings,
-  withNativeAd,
-  AdMediaView,
-  AdIconView,
-  AdTriggerView,
-} = FacebookAds;
+const { NativeAdsManager, AdSettings, withNativeAd, AdMediaView, AdIconView, AdTriggerView } =
+  FacebookAds;
 
 try {
   AdSettings.addTestDevice(AdSettings.currentDeviceHash);
@@ -70,7 +64,7 @@ export function test(t, { setPortalChild, cleanupPortal }) {
     t.describe('when given a valid placementId', () => {
       let nativeAd;
 
-      const mountAndWaitFor = child =>
+      const mountAndWaitFor = (child) =>
         new Promise((resolve, reject) => {
           const clonedChild = React.cloneElement(child, { onAdLoaded: resolve, onError: reject });
           setPortalChild(clonedChild);
@@ -92,7 +86,7 @@ export function test(t, { setPortalChild, cleanupPortal }) {
         30000
       );
 
-      variables.forEach(variable => {
+      variables.forEach((variable) => {
         t.it(`checking if variable ${variable} is not null`, () => {
           t.expect(nativeAd ? nativeAd[variable] : null).not.toBeNull();
         });

--- a/apps/test-suite/tests/FileSystem.js
+++ b/apps/test-suite/tests/FileSystem.js
@@ -9,7 +9,7 @@ export const name = 'FileSystem';
 
 export async function test({ describe, expect, it, ...t }) {
   describe('FileSystem', () => {
-    const throws = async run => {
+    const throws = async (run) => {
       let error = null;
       try {
         await run();
@@ -47,40 +47,33 @@ export async function test({ describe, expect, it, ...t }) {
       return;
     }
 
-    it(
-      'delete(idempotent) -> !exists -> download(md5, uri) -> exists ' + '-> delete -> !exists',
-      async () => {
-        const localUri = FS.documentDirectory + 'download1.png';
+    it('delete(idempotent) -> !exists -> download(md5, uri) -> exists -> delete -> !exists', async () => {
+      const localUri = FS.documentDirectory + 'download1.png';
 
-        const assertExists = async expectedToExist => {
-          const { exists } = await FS.getInfoAsync(localUri);
-          if (expectedToExist) {
-            expect(exists).toBeTruthy();
-          } else {
-            expect(exists).not.toBeTruthy();
-          }
-        };
+      const assertExists = async (expectedToExist) => {
+        const { exists } = await FS.getInfoAsync(localUri);
+        if (expectedToExist) {
+          expect(exists).toBeTruthy();
+        } else {
+          expect(exists).not.toBeTruthy();
+        }
+      };
 
-        await FS.deleteAsync(localUri, { idempotent: true });
-        await assertExists(false);
+      await FS.deleteAsync(localUri, { idempotent: true });
+      await assertExists(false);
 
-        const {
-          md5,
-          headers,
-        } = await FS.downloadAsync(
-          'https://s3-us-west-1.amazonaws.com/test-suite-data/avatar2.png',
-          localUri,
-          { md5: true }
-        );
-        expect(md5).toBe('1e02045c10b8f1145edc7c8375998f87');
-        await assertExists(true);
-        expect(headers['Content-Type']).toBe('image/png');
+      const { md5, headers } = await FS.downloadAsync(
+        'https://s3-us-west-1.amazonaws.com/test-suite-data/avatar2.png',
+        localUri,
+        { md5: true }
+      );
+      expect(md5).toBe('1e02045c10b8f1145edc7c8375998f87');
+      await assertExists(true);
+      expect(headers['Content-Type']).toBe('image/png');
 
-        await FS.deleteAsync(localUri);
-        await assertExists(false);
-      },
-      9000
-    );
+      await FS.deleteAsync(localUri);
+      await assertExists(false);
+    }, 9000);
 
     it('Can read/write Base64', async () => {
       const asset = await Asset.fromModule(require('../assets/icons/app.png'));
@@ -125,9 +118,7 @@ export async function test({ describe, expect, it, ...t }) {
     it('download(md5, uri) -> read -> delete -> !exists -> read[error]', async () => {
       const localUri = FS.documentDirectory + 'download1.txt';
 
-      const {
-        md5,
-      } = await FS.downloadAsync(
+      const { md5 } = await FS.downloadAsync(
         'https://s3-us-west-1.amazonaws.com/test-suite-data/text-file.txt',
         localUri,
         { md5: true }
@@ -156,7 +147,7 @@ export async function test({ describe, expect, it, ...t }) {
       const { exists } = await FS.getInfoAsync(localUri);
       expect(exists).not.toBeTruthy();
 
-      const writeAndVerify = async expected => {
+      const writeAndVerify = async (expected) => {
         await FS.writeAsStringAsync(localUri, expected);
         const string = await FS.readAsStringAsync(localUri);
         expect(string).toBe(expected);
@@ -385,9 +376,7 @@ export async function test({ describe, expect, it, ...t }) {
 
       await FS.deleteAsync(localUri, { idempotent: true });
 
-      const {
-        md5,
-      } = await FS.downloadAsync(
+      const { md5 } = await FS.downloadAsync(
         'https://s3-us-west-1.amazonaws.com/test-suite-data/avatar2.png',
         localUri,
         { md5: true }
@@ -419,7 +408,7 @@ export async function test({ describe, expect, it, ...t }) {
     it('download(network failure)', async () => {
       const localUri = FS.documentDirectory + 'download1.png';
 
-      const assertExists = async expectedToExist => {
+      const assertExists = async (expectedToExist) => {
         const { exists } = await FS.getInfoAsync(localUri);
         if (expectedToExist) {
           expect(exists).toBeTruthy();
@@ -448,7 +437,7 @@ export async function test({ describe, expect, it, ...t }) {
     it('download(404)', async () => {
       const localUri = FS.documentDirectory + 'download1.png';
 
-      const assertExists = async expectedToExist => {
+      const assertExists = async (expectedToExist) => {
         const { exists } = await FS.getInfoAsync(localUri);
         if (expectedToExist) {
           expect(exists).toBeTruthy();

--- a/apps/test-suite/tests/FirebaseJSSDKCompat.js
+++ b/apps/test-suite/tests/FirebaseJSSDKCompat.js
@@ -58,10 +58,7 @@ export async function test({ describe, it, expect, beforeAll }) {
       it(`reads data once`, async () => {
         let error = null;
         try {
-          const snapshot = await firebase
-            .database()
-            .ref('/test1')
-            .once('value');
+          const snapshot = await firebase.database().ref('/test1').once('value');
           expect(snapshot.val()).toBe('foobar');
         } catch (e) {
           error = e;
@@ -78,10 +75,7 @@ export async function test({ describe, it, expect, beforeAll }) {
       it(`gets a collection`, async () => {
         let error = null;
         try {
-          const { docs } = await firebase
-            .firestore()
-            .collection('tests')
-            .get();
+          const { docs } = await firebase.firestore().collection('tests').get();
           expect(docs.length).toBeGreaterThan(0);
         } catch (e) {
           error = e;
@@ -91,10 +85,7 @@ export async function test({ describe, it, expect, beforeAll }) {
       it(`gets a document`, async () => {
         let error = null;
         try {
-          const snapshot = await firebase
-            .firestore()
-            .doc('tests/doc1')
-            .get();
+          const snapshot = await firebase.firestore().doc('tests/doc1').get();
           expect(snapshot).not.toBeNull();
         } catch (e) {
           error = e;
@@ -131,10 +122,7 @@ export async function test({ describe, it, expect, beforeAll }) {
       it(`lists all files`, async () => {
         let error = null;
         try {
-          const files = await firebase
-            .storage()
-            .ref('public')
-            .listAll();
+          const files = await firebase.storage().ref('public').listAll();
           expect(files.items.length).toBeGreaterThan(0);
         } catch (e) {
           error = e;
@@ -144,10 +132,7 @@ export async function test({ describe, it, expect, beforeAll }) {
       it(`downloads a file`, async () => {
         let error = null;
         try {
-          const files = await firebase
-            .storage()
-            .ref('public')
-            .listAll();
+          const files = await firebase.storage().ref('public').listAll();
           expect(files.items.length).toBeGreaterThan(0);
           const file = files.items[0];
           const downloadUrl = await file.getDownloadURL();

--- a/apps/test-suite/tests/FirebaseRecaptcha.js
+++ b/apps/test-suite/tests/FirebaseRecaptcha.js
@@ -33,7 +33,7 @@ export async function test(
       it(`mounts`, async () => {
         await mountAndWaitFor(
           <FirebaseRecaptchaVerifierModal
-            ref={ref => (ref ? ref.verify() : undefined)}
+            ref={(ref) => (ref ? ref.verify() : undefined)}
             style={style}
             firebaseConfig={firebaseConfig}
           />

--- a/apps/test-suite/tests/Font.js
+++ b/apps/test-suite/tests/Font.js
@@ -40,7 +40,7 @@ export async function test({ beforeEach, afterAll, describe, it, expect }) {
       if (Platform.OS === 'web') {
         const styleSheet = document.getElementById('expo-generated-fonts');
         expect(!!styleSheet).toBe(true);
-        const [rule] = [...styleSheet.sheet.cssRules].filter(rule => {
+        const [rule] = [...styleSheet.sheet.cssRules].filter((rule) => {
           return (
             rule instanceof CSSFontFaceRule &&
             rule.style.fontFamily === 'cool-font' &&

--- a/apps/test-suite/tests/GLView.js
+++ b/apps/test-suite/tests/GLView.js
@@ -16,7 +16,7 @@ export async function test(
   let instance = null;
   let originalTimeout;
 
-  const refSetter = ref => {
+  const refSetter = (ref) => {
     instance = ref;
   };
 
@@ -35,9 +35,9 @@ export async function test(
   });
 
   function getContextAsync() {
-    return new Promise(async resolve => {
+    return new Promise(async (resolve) => {
       await mountAndWaitFor(
-        <GLView onContextCreate={context => resolve(context)} ref={refSetter} style={style} />,
+        <GLView onContextCreate={(context) => resolve(context)} ref={refSetter} style={style} />,
         'onContextCreate',
         setPortalChild
       );

--- a/apps/test-suite/tests/GoogleSignIn.js
+++ b/apps/test-suite/tests/GoogleSignIn.js
@@ -51,7 +51,7 @@ export async function test({
     it('has constants', () => {
       function validateConstants(constants) {
         expect(constants).toBeDefined();
-        Object.values(constants).map(constant => {
+        Object.values(constants).map((constant) => {
           expect(typeof constant).toBe('string');
         });
       }

--- a/apps/test-suite/tests/ImageManipulator.js
+++ b/apps/test-suite/tests/ImageManipulator.js
@@ -105,8 +105,8 @@ export async function test(t) {
         );
 
         if (Platform.OS === 'web') {
-          const imageInfo = await fetch(image.localUri).then(a => a.blob());
-          const resultInfo = await fetch(result.uri).then(a => a.blob());
+          const imageInfo = await fetch(image.localUri).then((a) => a.blob());
+          const resultInfo = await fetch(result.uri).then((a) => a.blob());
 
           t.expect(imageInfo.size).toBeGreaterThan(resultInfo.size);
         } else {

--- a/apps/test-suite/tests/Location.js
+++ b/apps/test-suite/tests/Location.js
@@ -13,10 +13,11 @@ const GEOFENCING_TASK = 'geofencing-task';
 export const name = 'Location';
 
 export async function test(t) {
-  const shouldSkipTestsRequiringPermissions = await TestUtils.shouldSkipTestsRequiringPermissionsAsync();
+  const shouldSkipTestsRequiringPermissions =
+    await TestUtils.shouldSkipTestsRequiringPermissionsAsync();
   const describeWithPermissions = shouldSkipTestsRequiringPermissions ? t.xdescribe : t.describe;
 
-  const testShapeOrUnauthorized = testFunction => async () => {
+  const testShapeOrUnauthorized = (testFunction) => async () => {
     const providerStatus = await Location.getProviderStatusAsync();
     if (providerStatus.locationServicesEnabled) {
       const { status } = await TestUtils.acceptPermissionsAndRunCommandAsync(() => {
@@ -212,7 +213,7 @@ export async function test(t) {
         'gets a result of the correct shape (without high accuracy), or ' +
           'throws error if no permission or disabled (when trying again after 1 second)',
         async () => {
-          await new Promise(resolve => setTimeout(resolve, 1000));
+          await new Promise((resolve) => setTimeout(resolve, 1000));
           await testShapeOrUnauthorized(() =>
             Location.getCurrentPositionAsync({
               accuracy: Location.Accuracy.Balanced,
@@ -226,7 +227,7 @@ export async function test(t) {
         'gets a result of the correct shape (with high accuracy), or ' +
           'throws error if no permission or disabled (when trying again after 1 second)',
         async () => {
-          await new Promise(resolve => setTimeout(resolve, 1000));
+          await new Promise((resolve) => setTimeout(resolve, 1000));
           await testShapeOrUnauthorized(() =>
             Location.getCurrentPositionAsync({
               accuracy: Location.Accuracy.Highest,
@@ -337,7 +338,7 @@ export async function test(t) {
     describeWithPermissions('Location.watchPositionAsync()', () => {
       t.it('gets a result of the correct shape', async () => {
         await new Promise(async (resolve, reject) => {
-          const subscriber = await Location.watchPositionAsync({}, location => {
+          const subscriber = await Location.watchPositionAsync({}, (location) => {
             testLocationShape(location);
             subscriber.remove();
             resolve();
@@ -346,22 +347,22 @@ export async function test(t) {
       });
 
       t.it('can be called simultaneously', async () => {
-        const spies = [1, 2, 3].map(number => t.jasmine.createSpy(`watchPosition${number}`));
+        const spies = [1, 2, 3].map((number) => t.jasmine.createSpy(`watchPosition${number}`));
 
         const subscribers = await Promise.all(
-          spies.map(spy => Location.watchPositionAsync({}, spy))
+          spies.map((spy) => Location.watchPositionAsync({}, spy))
         );
 
-        await new Promise(resolve => setTimeout(resolve, 3000));
+        await new Promise((resolve) => setTimeout(resolve, 3000));
 
-        spies.forEach(spy => t.expect(spy).toHaveBeenCalled());
-        subscribers.forEach(subscriber => subscriber.remove());
+        spies.forEach((spy) => t.expect(spy).toHaveBeenCalled());
+        subscribers.forEach((subscriber) => subscriber.remove());
       });
     });
 
     if (Platform.OS !== 'web') {
       describeWithPermissions('Location.getHeadingAsync()', () => {
-        const testCompass = options => async () => {
+        const testCompass = (options) => async () => {
           // Disable Compass Test if in simulator
           if (Constants.isDevice) {
             const { status } = await TestUtils.acceptPermissionsAndRunCommandAsync(() => {
@@ -434,7 +435,7 @@ export async function test(t) {
             t.expect(Array.isArray(result)).toBe(true);
             t.expect(typeof result[0]).toBe('object');
             const fields = ['city', 'street', 'region', 'country', 'postalCode', 'name'];
-            fields.forEach(field => {
+            fields.forEach((field) => {
               t.expect(
                 typeof result[field] === 'string' || typeof result[field] === 'undefined'
               ).toBe(true);

--- a/apps/test-suite/tests/MediaLibrary.js
+++ b/apps/test-suite/tests/MediaLibrary.js
@@ -4,7 +4,7 @@ import { Platform } from 'react-native';
 
 import * as TestUtils from '../TestUtils';
 import { isDeviceFarm } from '../utils/Environment';
-import { waitFor } from './helpers'
+import { waitFor } from './helpers';
 
 export const name = 'MediaLibrary';
 
@@ -19,7 +19,7 @@ const WAIT_TIME = 1000;
 const IMG_NUMBER = 3;
 const VIDEO_NUMBER = 1;
 const F_SIZE = IMG_NUMBER + VIDEO_NUMBER;
-const MEDIA_TYPES = [MediaLibrary.MediaType.photo, MediaLibrary.MediaType.video];
+// const MEDIA_TYPES = [MediaLibrary.MediaType.photo, MediaLibrary.MediaType.video];
 const DEFAULT_MEDIA_TYPES = [MediaLibrary.MediaType.photo];
 const DEFAULT_PAGE_SIZE = 20;
 const ASSET_KEYS = [
@@ -91,7 +91,7 @@ async function checkIfThrows(f) {
 }
 
 function timeoutWrapper(fun, time) {
-  return new Promise(resolve => {
+  return new Promise((resolve) => {
     setTimeout(() => {
       fun();
       resolve(null);
@@ -189,33 +189,33 @@ export async function test(t) {
       t.describe('Every return value has proper shape', async () => {
         t.it('createAssetAsync', () => {
           const keys = Object.keys(testAssets[0]);
-          ASSET_KEYS.forEach(key => t.expect(keys).toContain(key));
+          ASSET_KEYS.forEach((key) => t.expect(keys).toContain(key));
         });
 
         t.it('getAssetInfoAsync', async () => {
           const { assets } = await MediaLibrary.getAssetsAsync();
           const value = await MediaLibrary.getAssetInfoAsync(assets[0]);
           const keys = Object.keys(value);
-          INFO_KEYS.forEach(key => t.expect(keys).toContain(key));
+          INFO_KEYS.forEach((key) => t.expect(keys).toContain(key));
         });
 
         t.it('getAlbumAsync', async () => {
           const value = await MediaLibrary.getAlbumAsync(ALBUM_NAME);
           const keys = Object.keys(value);
-          ALBUM_KEYS.forEach(key => t.expect(keys).toContain(key));
+          ALBUM_KEYS.forEach((key) => t.expect(keys).toContain(key));
         });
 
         t.it('getAssetsAsync', async () => {
           const value = await MediaLibrary.getAssetsAsync();
           const keys = Object.keys(value);
-          GET_ASSETS_KEYS.forEach(key => t.expect(keys).toContain(key));
+          GET_ASSETS_KEYS.forEach((key) => t.expect(keys).toContain(key));
         });
       });
 
       t.describe('Small tests', async () => {
         t.it('Function getAlbums returns test album', async () => {
           const albums = await MediaLibrary.getAlbumsAsync();
-          t.expect(albums.filter(elem => elem.id === album.id).length).toBe(1);
+          t.expect(albums.filter((elem) => elem.id === album.id).length).toBe(1);
         });
 
         t.it('getAlbum returns test album', async () => {
@@ -269,31 +269,27 @@ export async function test(t) {
           const { assets } = await MediaLibrary.getAssetsAsync(options);
           t.expect(assets.length).toBeLessThanOrEqual(DEFAULT_PAGE_SIZE);
           t.expect(assets.length).toBeGreaterThanOrEqual(IMG_NUMBER);
-          assets.forEach(asset => t.expect(DEFAULT_MEDIA_TYPES).toContain(asset.mediaType));
+          assets.forEach((asset) => t.expect(DEFAULT_MEDIA_TYPES).toContain(asset.mediaType));
         });
 
         t.it('album', async () => {
           const options = { album };
           const { assets } = await MediaLibrary.getAssetsAsync(options);
           t.expect(assets.length).toBe(IMG_NUMBER);
-          assets.forEach(asset => t.expect(DEFAULT_MEDIA_TYPES).toContain(asset.mediaType));
+          assets.forEach((asset) => t.expect(DEFAULT_MEDIA_TYPES).toContain(asset.mediaType));
           if (Platform.OS === 'android')
-            assets.forEach(asset => t.expect(asset.albumId).toBe(album.id));
+            assets.forEach((asset) => t.expect(asset.albumId).toBe(album.id));
         });
 
         t.it('first, after', async () => {
           const options = { first: 2, album };
           {
-            const {
-              assets,
-              endCursor,
-              hasNextPage,
-              totalCount,
-            } = await MediaLibrary.getAssetsAsync(options);
+            const { assets, endCursor, hasNextPage, totalCount } =
+              await MediaLibrary.getAssetsAsync(options);
             t.expect(assets.length).toBe(2);
             t.expect(totalCount).toBe(IMG_NUMBER);
             t.expect(hasNextPage).toBeTruthy();
-            assets.forEach(asset => t.expect(DEFAULT_MEDIA_TYPES).toContain(asset.mediaType));
+            assets.forEach((asset) => t.expect(DEFAULT_MEDIA_TYPES).toContain(asset.mediaType));
             options.after = endCursor;
           }
           {
@@ -308,7 +304,7 @@ export async function test(t) {
           const mediaType = MediaLibrary.MediaType.video;
           const options = { mediaType, album };
           const { assets } = await MediaLibrary.getAssetsAsync(options);
-          assets.forEach(asset => t.expect(asset.mediaType).toBe(mediaType));
+          assets.forEach((asset) => t.expect(asset.mediaType).toBe(mediaType));
           t.expect(assets.length).toBe(1);
         });
 
@@ -317,7 +313,7 @@ export async function test(t) {
           const options = { mediaType, album };
           const { assets } = await MediaLibrary.getAssetsAsync(options);
           t.expect(assets.length).toBe(IMG_NUMBER);
-          assets.forEach(asset => t.expect(asset.mediaType).toBe(mediaType));
+          assets.forEach((asset) => t.expect(asset.mediaType).toBe(mediaType));
         });
 
         t.it('check size - photo', async () => {
@@ -325,7 +321,7 @@ export async function test(t) {
           const options = { mediaType, album };
           const { assets } = await MediaLibrary.getAssetsAsync(options);
           t.expect(assets.length).toBe(IMG_NUMBER);
-          assets.forEach(asset => {
+          assets.forEach((asset) => {
             t.expect(asset.width).not.toEqual(0);
             t.expect(asset.height).not.toEqual(0);
           });
@@ -336,7 +332,7 @@ export async function test(t) {
           const options = { mediaType, album };
           const { assets } = await MediaLibrary.getAssetsAsync(options);
           t.expect(assets.length).toBe(VIDEO_NUMBER);
-          assets.forEach(asset => {
+          assets.forEach((asset) => {
             t.expect(asset.width).not.toEqual(0);
             t.expect(asset.height).not.toEqual(0);
           });
@@ -388,7 +384,7 @@ export async function test(t) {
             ios: ['isNetworkAsset'],
             default: [],
           });
-          expectedExtraKeys.forEach(key => t.expect(keys).toContain(key));
+          expectedExtraKeys.forEach((key) => t.expect(keys).toContain(key));
           if (Platform.OS === 'ios') {
             t.expect(value['isNetworkAsset']).toBe(false);
           }
@@ -407,7 +403,7 @@ export async function test(t) {
             ios: ['isNetworkAsset'],
             default: [],
           });
-          expectedExtraKeys.forEach(key => t.expect(keys).not.toContain(key));
+          expectedExtraKeys.forEach((key) => t.expect(keys).not.toContain(key));
         });
 
         t.it('shouldDownloadFromNetwork: false, for videos', async () => {
@@ -423,7 +419,7 @@ export async function test(t) {
             ios: ['isNetworkAsset'],
             default: [],
           });
-          expectedExtraKeys.forEach(key => t.expect(keys).toContain(key));
+          expectedExtraKeys.forEach((key) => t.expect(keys).toContain(key));
           if (Platform.OS === 'ios') {
             t.expect(value['isNetworkAsset']).toBe(false);
           }
@@ -442,7 +438,7 @@ export async function test(t) {
             ios: ['isNetworkAsset'],
             default: [],
           });
-          expectedExtraKeys.forEach(key => t.expect(keys).not.toContain(key));
+          expectedExtraKeys.forEach((key) => t.expect(keys).not.toContain(key));
         });
       });
     });
@@ -454,12 +450,12 @@ export async function test(t) {
           const assets = await getAssets(files);
           const result = await MediaLibrary.deleteAssetsAsync(assets);
           const deletedAssets = await Promise.all(
-            assets.map(async asset => await MediaLibrary.getAssetInfoAsync(asset))
+            assets.map(async (asset) => await MediaLibrary.getAssetInfoAsync(asset))
           );
           t.expect(result).toEqual(true);
           t.expect(assets.length).not.toEqual(0);
           t.expect(deletedAssets.length).toEqual(assets.length);
-          deletedAssets.forEach(deletedAsset => t.expect(deletedAsset).toBeNull);
+          deletedAssets.forEach((deletedAsset) => t.expect(deletedAsset).toBeNull);
         },
         TIMEOUT_WHEN_USER_NEEDS_TO_INTERACT
       );

--- a/apps/test-suite/tests/Network.js
+++ b/apps/test-suite/tests/Network.js
@@ -1,11 +1,9 @@
 import * as Network from 'expo-network';
 import { Platform } from 'react-native';
 
-import { isDeviceFarm } from '../utils/Environment';
-
 export const name = 'Network';
-const Ipv4Regex = /^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
-const macAddressRegex = /^([0-9a-fA-F]{2}[:.-]){5}[0-9a-fA-F]{2}$/;
+const Ipv4Regex =
+  /^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
 
 export async function test(t) {
   if (Platform.OS === 'android') {

--- a/apps/test-suite/tests/Notifications.js
+++ b/apps/test-suite/tests/Notifications.js
@@ -14,7 +14,8 @@ import { waitFor } from './helpers';
 export const name = 'Notifications';
 
 export async function test(t) {
-  const shouldSkipTestsRequiringPermissions = await TestUtils.shouldSkipTestsRequiringPermissionsAsync();
+  const shouldSkipTestsRequiringPermissions =
+    await TestUtils.shouldSkipTestsRequiringPermissionsAsync();
   const describeWithPermissions = shouldSkipTestsRequiringPermissions ? t.xdescribe : t.describe;
 
   t.describe('Notifications', () => {
@@ -24,7 +25,7 @@ export async function test(t) {
       let tokenFromMethodCall = null;
 
       t.beforeAll(() => {
-        subscription = Notifications.addPushTokenListener(newEvent => {
+        subscription = Notifications.addPushTokenListener((newEvent) => {
           tokenFromEvent = newEvent;
         });
       });
@@ -131,7 +132,7 @@ export async function test(t) {
         expoPushToken = pushToken.data;
 
         Notifications.setNotificationHandler({
-          handleNotification: async notification => {
+          handleNotification: async (notification) => {
             notificationToHandle = notification;
             if (handleFuncOverride) {
               return await handleFuncOverride(notification);
@@ -143,7 +144,7 @@ export async function test(t) {
               };
             }
           },
-          handleSuccess: event => {
+          handleSuccess: (event) => {
             handleSuccessEvent = event;
           },
           handleError: (...event) => {
@@ -151,7 +152,7 @@ export async function test(t) {
           },
         });
 
-        receivedSubscription = Notifications.addNotificationReceivedListener(event => {
+        receivedSubscription = Notifications.addNotificationReceivedListener((event) => {
           receivedEvent = event;
         });
       });
@@ -664,7 +665,7 @@ export async function test(t) {
         });
 
         t.afterEach(async () => {
-          allTestCategoryIds.forEach(async id => {
+          allTestCategoryIds.forEach(async (id) => {
             await Notifications.deleteNotificationCategoryAsync(id);
           });
         });
@@ -694,7 +695,7 @@ export async function test(t) {
 
       t.describe('setNotificationCategoriesAsync()', () => {
         t.afterEach(async () => {
-          allTestCategoryIds.forEach(async id => {
+          allTestCategoryIds.forEach(async (id) => {
             await Notifications.deleteNotificationCategoryAsync(id);
           });
         });
@@ -741,7 +742,7 @@ export async function test(t) {
 
       t.describe('deleteNotificationCategoriesAsync()', () => {
         t.afterEach(async () => {
-          allTestCategoryIds.forEach(async id => {
+          allTestCategoryIds.forEach(async (id) => {
             await Notifications.deleteNotificationCategoryAsync(id);
           });
         });
@@ -825,7 +826,7 @@ export async function test(t) {
           handleNotification: async () => ({
             shouldShowAlert: true,
           }),
-          handleSuccess: notificationId => {
+          handleSuccess: (notificationId) => {
             notificationStatuses[notificationId] = true;
           },
         });
@@ -975,9 +976,8 @@ export async function test(t) {
         'triggers a notification which emits an event',
         async () => {
           const notificationReceivedSpy = t.jasmine.createSpy('notificationReceived');
-          const subscription = Notifications.addNotificationReceivedListener(
-            notificationReceivedSpy
-          );
+          const subscription =
+            Notifications.addNotificationReceivedListener(notificationReceivedSpy);
           await Notifications.scheduleNotificationAsync({
             identifier,
             content: notification,
@@ -1030,9 +1030,8 @@ export async function test(t) {
         'triggers a notification which contains the custom color',
         async () => {
           const notificationReceivedSpy = t.jasmine.createSpy('notificationReceived');
-          const subscription = Notifications.addNotificationReceivedListener(
-            notificationReceivedSpy
-          );
+          const subscription =
+            Notifications.addNotificationReceivedListener(notificationReceivedSpy);
           await Notifications.scheduleNotificationAsync({
             identifier,
             content: notification,
@@ -1062,7 +1061,7 @@ export async function test(t) {
         async () => {
           let notificationFromEvent = undefined;
           Notifications.setNotificationHandler({
-            handleNotification: async event => {
+            handleNotification: async (event) => {
               notificationFromEvent = event;
               return {
                 shouldShowAlert: true,
@@ -1086,7 +1085,7 @@ export async function test(t) {
         async () => {
           let notificationFromEvent = undefined;
           Notifications.setNotificationHandler({
-            handleNotification: async event => {
+            handleNotification: async (event) => {
               notificationFromEvent = event;
               return {
                 shouldShowAlert: true,
@@ -1123,7 +1122,7 @@ export async function test(t) {
         async () => {
           let notificationFromEvent = undefined;
           Notifications.setNotificationHandler({
-            handleNotification: async event => {
+            handleNotification: async (event) => {
               notificationFromEvent = event;
               return {
                 shouldShowAlert: true,
@@ -1160,7 +1159,7 @@ export async function test(t) {
         async () => {
           let notificationFromEvent = undefined;
           Notifications.setNotificationHandler({
-            handleNotification: async event => {
+            handleNotification: async (event) => {
               notificationFromEvent = event;
               return {
                 shouldShowAlert: true,
@@ -1342,9 +1341,8 @@ export async function test(t) {
           'schedules a notification with calendar trigger',
           async () => {
             const notificationReceivedSpy = t.jasmine.createSpy('notificationReceived');
-            const subscription = Notifications.addNotificationReceivedListener(
-              notificationReceivedSpy
-            );
+            const subscription =
+              Notifications.addNotificationReceivedListener(notificationReceivedSpy);
             await Notifications.scheduleNotificationAsync({
               identifier,
               content: notification,
@@ -1440,9 +1438,8 @@ export async function test(t) {
         'makes a scheduled notification not trigger',
         async () => {
           const notificationReceivedSpy = t.jasmine.createSpy('notificationReceived');
-          const subscription = Notifications.addNotificationReceivedListener(
-            notificationReceivedSpy
-          );
+          const subscription =
+            Notifications.addNotificationReceivedListener(notificationReceivedSpy);
           await Notifications.scheduleNotificationAsync({
             identifier,
             content: notification,
@@ -1464,9 +1461,8 @@ export async function test(t) {
         'removes all scheduled notifications',
         async () => {
           const notificationReceivedSpy = t.jasmine.createSpy('notificationReceived');
-          const subscription = Notifications.addNotificationReceivedListener(
-            notificationReceivedSpy
-          );
+          const subscription =
+            Notifications.addNotificationReceivedListener(notificationReceivedSpy);
           for (let i = 0; i < 3; i += 1) {
             await Notifications.scheduleNotificationAsync({
               identifier: `notification-${i}`,
@@ -1584,7 +1580,7 @@ export async function test(t) {
             shouldShowAlert: true,
           }),
         });
-        subscription = Notifications.addNotificationResponseReceivedListener(anEvent => {
+        subscription = Notifications.addNotificationResponseReceivedListener((anEvent) => {
           event = anEvent;
         });
       });

--- a/apps/test-suite/tests/Recording.js
+++ b/apps/test-suite/tests/Recording.js
@@ -46,7 +46,8 @@ const amrSettings = {
 // > Source: https://developer.android.com/reference/android/media/MediaRecorder.html#stop()
 
 export async function test(t) {
-  const shouldSkipTestsRequiringPermissions = await TestUtils.shouldSkipTestsRequiringPermissionsAsync();
+  const shouldSkipTestsRequiringPermissions =
+    await TestUtils.shouldSkipTestsRequiringPermissionsAsync();
   const describeWithPermissions = shouldSkipTestsRequiringPermissions ? t.xdescribe : t.describe;
 
   describeWithPermissions('Recording', () => {
@@ -323,7 +324,7 @@ export async function test(t) {
         await recordingObject.startAsync();
 
         const recordingDuration = defaultRecordingDurationMillis;
-        await new Promise(resolve => {
+        await new Promise((resolve) => {
           setTimeout(async () => {
             await recordingObject.stopAndUnloadAsync();
             let error = null;
@@ -353,7 +354,7 @@ export async function test(t) {
           await recordingObject.startAsync();
 
           const recordingDuration = defaultRecordingDurationMillis;
-          await new Promise(resolve => {
+          await new Promise((resolve) => {
             setTimeout(async () => {
               await recordingObject.stopAndUnloadAsync();
               let error = null;
@@ -415,7 +416,7 @@ export async function test(t) {
         await recordingObject.startAsync();
 
         const recordingDuration = defaultRecordingDurationMillis;
-        await new Promise(resolve => {
+        await new Promise((resolve) => {
           setTimeout(async () => {
             await recordingObject.stopAndUnloadAsync();
             let error = null;
@@ -446,7 +447,7 @@ export async function test(t) {
           await recordingObject.startAsync();
 
           const recordingDuration = defaultRecordingDurationMillis;
-          await new Promise(resolve => {
+          await new Promise((resolve) => {
             setTimeout(async () => {
               await recordingObject.stopAndUnloadAsync();
               let error = null;

--- a/apps/test-suite/tests/SMSCommon.js
+++ b/apps/test-suite/tests/SMSCommon.js
@@ -51,12 +51,12 @@ const numbers = ['0123456789', '9876543210'];
 
 export async function loadAttachmentsAsync(expect) {
   const files = [pngFile, gifFile, audioFile];
-  await Promise.all(files.map(file => loadAndSaveFile(file, expect)));
+  await Promise.all(files.map((file) => loadAndSaveFile(file, expect)));
 }
 
 export async function cleanupAttachmentsAsync(expect) {
   const files = [pngFile, gifFile, audioFile];
-  await Promise.all(files.map(file => cleanupFile(file, expect)));
+  await Promise.all(files.map((file) => cleanupFile(file, expect)));
 }
 
 export async function testSMSComposeWithSingleImageAttachment(expect) {

--- a/apps/test-suite/tests/SQLite.js
+++ b/apps/test-suite/tests/SQLite.js
@@ -1,8 +1,8 @@
 'use strict';
 
-import { Platform } from 'expo-modules-core';
 import { Asset } from 'expo-asset';
 import * as FS from 'expo-file-system';
+import { Platform } from 'expo-modules-core';
 import * as SQLite from 'expo-sqlite';
 
 export const name = 'SQLite';
@@ -14,7 +14,7 @@ export function test(t) {
       const db = SQLite.openDatabase('test.db');
       await new Promise((resolve, reject) => {
         db.transaction(
-          tx => {
+          (tx) => {
             const nop = () => {};
             const onError = (tx, error) => reject(error);
 
@@ -77,7 +77,7 @@ export function test(t) {
           const db = SQLite.openDatabase('downloaded.db');
           await new Promise((resolve, reject) => {
             db.transaction(
-              tx => {
+              (tx) => {
                 const onError = (tx, error) => reject(error);
                 tx.executeSql(
                   'SELECT * FROM Users',
@@ -104,7 +104,7 @@ export function test(t) {
         const db = SQLite.openDatabase('test.db');
         await new Promise((resolve, reject) => {
           db.transaction(
-            tx => {
+            (tx) => {
               const nop = () => {};
               const onError = (tx, error) => reject(error);
 
@@ -152,7 +152,7 @@ export function test(t) {
         const db = SQLite.openDatabase('test.db');
         await new Promise((resolve, reject) => {
           db.transaction(
-            tx => {
+            (tx) => {
               const nop = () => {};
               const onError = (tx, error) => reject(error);
 
@@ -198,7 +198,7 @@ export function test(t) {
       const db = SQLite.openDatabase('test.db');
       await new Promise((resolve, reject) => {
         db.transaction(
-          tx => {
+          (tx) => {
             const nop = () => {};
             const onError = (tx, error) => reject(error);
 
@@ -243,7 +243,7 @@ export function test(t) {
         const db = SQLite.openDatabase('test.db');
         await new Promise((resolve, reject) => {
           db.transaction(
-            tx => {
+            (tx) => {
               const nop = () => {};
               const onError = (tx, error) => reject(error);
 
@@ -290,7 +290,7 @@ export function test(t) {
       const db = SQLite.openDatabase('test.db');
       await new Promise((resolve, reject) => {
         db.transaction(
-          tx => {
+          (tx) => {
             const nop = () => {};
             const onError = (tx, error) => reject(error);
 
@@ -314,8 +314,7 @@ export function test(t) {
       });
       await new Promise((resolve, reject) => {
         db.transaction(
-          tx => {
-            const nop = () => {};
+          (tx) => {
             const onError = (tx, error) => reject(error);
             tx.executeSql(
               'DELETE FROM Users WHERE name=?',
@@ -355,7 +354,7 @@ export function test(t) {
         db.exec([{ sql: 'PRAGMA foreign_keys = ON;', args: [] }], false, () => {});
         await new Promise((resolve, reject) => {
           db.transaction(
-            tx => {
+            (tx) => {
               const nop = () => {};
               const onError = (tx, error) => reject(error);
 
@@ -394,7 +393,7 @@ export function test(t) {
         });
         await new Promise((resolve, reject) => {
           db.transaction(
-            tx => {
+            (tx) => {
               const nop = () => {};
               const onError = (tx, error) => reject(error);
               tx.executeSql('PRAGMA foreign_keys=on;', [], nop, onError);

--- a/apps/test-suite/tests/SVG.js
+++ b/apps/test-suite/tests/SVG.js
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import * as Svg from 'react-native-svg';
+
 import { mountAndWaitFor as originalMountAndWaitFor } from './helpers';
 
 export const name = 'SVG';

--- a/apps/test-suite/tests/ScreenOrientation.js
+++ b/apps/test-suite/tests/ScreenOrientation.js
@@ -8,7 +8,7 @@ export const name = 'ScreenOrientation';
 // Wait until we are in desiredOrientation
 // Fail if we are not in a validOrientation
 const applyAsync = ({ desiredOrientationLock, desiredOrientations, validOrientations }) => {
-  return new Promise(async function(resolve, reject) {
+  return new Promise(async function (resolve, reject) {
     let subscriptionCancelled = false;
     const subscription = ScreenOrientation.addOrientationChangeListener(
       ({ orientationInfo, orientationLock }) => {
@@ -113,7 +113,7 @@ export function test(t) {
       t.it(
         'Register for the callback, set to landscape orientation and get the correct orientation',
         async () => {
-          const callListenerAsync = new Promise(async function(resolve, reject) {
+          const callListenerAsync = new Promise(async function (resolve, reject) {
             // Register for screen orientation changes
             ScreenOrientation.addOrientationChangeListener(({ orientationInfo }) => {
               const { orientation } = orientationInfo;

--- a/apps/test-suite/tests/Segment.js
+++ b/apps/test-suite/tests/Segment.js
@@ -73,6 +73,7 @@ export function test(t) {
 
     t.it('non-existant method fails', () => {
       t.expect(() => {
+        // eslint-disable-next-line import/namespace
         Segment.doesNotExist();
       }).toThrow();
     });

--- a/apps/test-suite/tests/Speech.js
+++ b/apps/test-suite/tests/Speech.js
@@ -7,7 +7,7 @@ import { waitFor } from './helpers';
 
 export const name = 'Speech';
 
-const longTextToSpeak = 'One ring to rule them all.';
+// const longTextToSpeak = 'One ring to rule them all.';
 const shortTextToSpeak = 'Hi!';
 
 // Some of the tests consistently fail on Android:
@@ -141,7 +141,7 @@ export function test(t) {
 
         t.expect(voices.length).toBeGreaterThan(0);
 
-        t.expect(voices.map(voice => voice.language)).toContain('en-US');
+        t.expect(voices.map((voice) => voice.language)).toContain('en-US');
       });
     });
   });

--- a/apps/test-suite/tests/StoreReview.ios.js
+++ b/apps/test-suite/tests/StoreReview.ios.js
@@ -1,5 +1,5 @@
-import * as StoreReview from 'expo-store-review';
 import Constants from 'expo-constants';
+import * as StoreReview from 'expo-store-review';
 
 export const name = 'StoreReview';
 

--- a/apps/test-suite/tests/TaskManager.js
+++ b/apps/test-suite/tests/TaskManager.js
@@ -78,7 +78,7 @@ export async function test(t) {
 
         t.expect(registeredTasks).toBeDefined();
         t.expect(registeredTasks.length).toBe(1);
-        t.expect(registeredTasks.find(task => task.taskName === DEFINED_TASK_NAME)).toEqual(
+        t.expect(registeredTasks.find((task) => task.taskName === DEFINED_TASK_NAME)).toEqual(
           t.jasmine.objectContaining({
             taskName: DEFINED_TASK_NAME,
             taskType: 'backgroundFetch',
@@ -123,4 +123,4 @@ export async function test(t) {
 
 // Empty task so we can properly test some methods.
 // We are telling iOS that we successfully fetched new data, to prevent possible throttle from iOS
-TaskManager.defineTask(DEFINED_TASK_NAME, () => BackgroundFetch.Result.NewData);
+TaskManager.defineTask(DEFINED_TASK_NAME, () => BackgroundFetch.BackgroundFetchResult.NewData);

--- a/apps/test-suite/tests/Video.js
+++ b/apps/test-suite/tests/Video.js
@@ -1,9 +1,9 @@
 'use strict';
 
-import React from 'react';
-import { forEach } from 'lodash';
-import { Video } from 'expo-av';
 import { Asset } from 'expo-asset';
+import { Video } from 'expo-av';
+import { forEach } from 'lodash';
+import React from 'react';
 import { Platform } from 'react-native';
 
 import { waitFor, retryForStatus, mountAndWaitFor as originalMountAndWaitFor } from './helpers';

--- a/apps/test-suite/tests/helpers.js
+++ b/apps/test-suite/tests/helpers.js
@@ -5,10 +5,10 @@ import { isMatch } from 'lodash';
 import React from 'react';
 import { Alert } from 'react-native';
 
-export const waitFor = millis => new Promise(resolve => setTimeout(resolve, millis));
+export const waitFor = (millis) => new Promise((resolve) => setTimeout(resolve, millis));
 
-export const alertAndWaitForResponse = async message => {
-  return new Promise(resolve => Alert.alert(message, null, [{ text: 'OK', onPress: resolve }]));
+export const alertAndWaitForResponse = async (message) => {
+  return new Promise((resolve) => Alert.alert(message, null, [{ text: 'OK', onPress: resolve }]));
 };
 
 export const retryForStatus = (object, status) =>
@@ -30,13 +30,13 @@ export const retryForStatus = (object, status) =>
 export const mountAndWaitFor = (
   child: React.Node,
   propName = 'ref',
-  setPortalChild: React.Node => void
+  setPortalChild: (React.Node) => void
 ) =>
-  new Promise(resolve => {
+  new Promise((resolve) => {
     // `ref` prop is set directly in the child, not in the `props` object.
     // https://github.com/facebook/react/issues/8873#issuecomment-275423780
     const previousPropFunc = propName === 'ref' ? child.ref : child.props[propName];
-    const newPropFunc = val => {
+    const newPropFunc = (val) => {
       previousPropFunc && previousPropFunc(val);
       resolve(val);
     };
@@ -54,7 +54,7 @@ export class TimeoutError extends Error {
 export const mountAndWaitForWithTimeout = (
   child: React.Node,
   propName = 'ref',
-  setPortalChild: React.Node => void,
+  setPortalChild: (React.Node) => void,
   timeout
 ) =>
   Promise.race([

--- a/apps/test-suite/webpack.config.js
+++ b/apps/test-suite/webpack.config.js
@@ -1,6 +1,6 @@
 const createConfigAsync = require('@expo/webpack-config');
 
-module.exports = async env => {
+module.exports = async (env) => {
   const config = await createConfigAsync(env);
   // allow reloading when the packages are updated.
   if (config.devServer) {


### PR DESCRIPTION
# Why

The Test Suite app contains quite a lot of code, but the app directory is excluded from the workspace lint check, so the files are not linted ATM.

# How

This PR adds lint command to the Test Suite app (with a base config) and updates the workflow to include the lint checks.

Almost all the changed files, besides the configs, are the result of lint run.

I have only applied small fix for the BackgroundFetch test, which included the old constant name (I'm not sure why this do not fail earlier 🤷‍♂️ ).

# Test Plan

`yarn lint` run in `apps/test-suite` directory do not yield any errors.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
