### PR TITLE
[autolinking] Fix umbrella directory not found from use_frameworks!

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix `umbrella directory '../../Public/React-Core/React' not found` build error when in `use_frameworks!` mode. ([#15773](https://github.com/expo/expo/pull/15773) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 0.5.4 — 2021-12-29

--- a/packages/expo-modules-autolinking/scripts/ios/React-Core.modulemap
+++ b/packages/expo-modules-autolinking/scripts/ios/React-Core.modulemap
@@ -1,6 +1,0 @@
-module React {
-  umbrella "../../Public/React-Core/React"
-
-  export *
-  module * { export * }
-}

--- a/packages/expo-modules-autolinking/scripts/ios/autolinking_manager.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/autolinking_manager.rb
@@ -2,8 +2,10 @@ require_relative 'constants'
 require_relative 'package'
 
 # Require extensions to CocoaPods' classes
+require_relative 'cocoapods/pod_target'
 require_relative 'cocoapods/sandbox'
 require_relative 'cocoapods/target_definition'
+require_relative 'cocoapods/umbrella_header_generator'
 require_relative 'cocoapods/user_project_integrator'
 
 module Expo

--- a/packages/expo-modules-autolinking/scripts/ios/cocoapods/pod_target.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/cocoapods/pod_target.rb
@@ -1,0 +1,50 @@
+module Pod
+  class PodTarget
+    private
+
+    _original_module_map_path = instance_method(:module_map_path)
+
+    public
+
+    # CocoaPods's default modulemap did not generate submodules correctly
+    # `ios/Pods/Headers/Public/React/React-Core.modulemap`
+    # ```
+    # module React {
+    #   umbrella header "React-Core-umbrella.h"
+    #
+    #   export *
+    #   module * { export * }
+    # }
+    # ```
+    # clang will generate submodules for headers relative to the umbrella header directory.
+    # https://github.com/llvm/llvm-project/blob/2782cb8da0b3c180fa7c8627cb255a026f3d25a2/clang/lib/Lex/ModuleMap.cpp#L1133
+    # In this case, it is `ios/Pods/Headers/Public/React`.
+    # But the React public headers are placed in `ios/Pods/Headers/Public/React-Core/React`, so clang cannot find the headers and generate submodules.
+    #
+    # This case happens when a pod's name different to its module name, e.g. the pod name is `React-Core` but the module name is `React` since it defines header_dir as `React`.
+    # To fix the issue, we rewrite the `module_map_path` and `umbrella_header_path` to be with the public headers,
+    # i.e. `ios/Pods/Headers/Public/React-Core/React/React-Core.modulemap` and `ios/Pods/Headers/Public/React-Core/React/React-Core-umbrella.h`
+    #
+    def rewrite_module_dir
+      if ['React-Core'].include?(name) && product_module_name != name
+        return sandbox.public_headers.root + name + product_module_name
+      end
+      return nil
+    end
+
+    def umbrella_header_path
+      if dir = self.rewrite_module_dir
+        return dir + "#{label}-umbrella.h"
+      end
+      super
+    end
+
+    define_method(:module_map_path) do
+      if dir = self.rewrite_module_dir
+        return dir + "#{label}.modulemap"
+      end
+      _original_module_map_path.bind(self).()
+    end
+
+  end # class PodTarget
+end # module Pod

--- a/packages/expo-modules-autolinking/scripts/ios/cocoapods/sandbox.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/cocoapods/sandbox.rb
@@ -19,25 +19,6 @@ module Pod
       if name == 'React-Core'
         spec_json = JSON.parse(spec.to_pretty_json)
 
-        # CocoaPods's default modulemap did not generate submodules correctly
-        # `ios/Pods/Headers/Public/React/React-Core.modulemap`
-        # ```
-        # module React {
-        #   umbrella header "React-Core-umbrella.h"
-        #
-        #   export *
-        #   module * { export * }
-        # }
-        # ```
-        # clang will generate submodules for headers relative to the umbrella header directory.
-        # https://github.com/llvm/llvm-project/blob/2782cb8da0b3c180fa7c8627cb255a026f3d25a2/clang/lib/Lex/ModuleMap.cpp#L1133
-        # In this case, it is `ios/Pods/Headers/Public/React`.
-        # But React headers are placed in `ios/Pods/Headers/Public/React-Core/React`, so clang cannot find the headers and generate submodules.
-        # We patch `React-Core.podspec` to use custom modulemap and use `umbrella "../../Public/React-Core/React"` for clang to generate submodules correctly.
-        # Since CocoaPods generates the umbrella headers based on public headers,
-        # it is pretty safe to replace the umbrella header with the `umbrella` directory search inside the public headers directory.
-        spec_json['module_map'] ||= File.join(__dir__, '..', 'React-Core.modulemap')
-
         # clang module does not support objc++.
         # We should put Hermes headers inside private headers directory.
         # Otherwise, clang will throw errors in building module.

--- a/packages/expo-modules-autolinking/scripts/ios/cocoapods/umbrella_header_generator.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/cocoapods/umbrella_header_generator.rb
@@ -1,0 +1,22 @@
+module Pod
+  module Generator
+    class UmbrellaHeader
+      private
+
+      _original_generate = instance_method(:generate)
+
+      public
+
+      define_method (:generate) do
+        if self.target.is_a?(Pod::PodTarget) && self.target.rewrite_module_dir
+          # If we write the `umbrella_header_path`, the import headers are in the same directory,
+          # e.g. `#import "React/RCTBridge.h"` -> `#import "RCTBridge.h"`
+          self.imports = self.imports.map { |import| import.basename }
+        end
+
+        _original_generate.bind(self).()
+      end
+
+    end # class UmbrellaHeader
+  end # module Generator
+end # module Pod

--- a/tools/src/versioning/ios/index.ts
+++ b/tools/src/versioning/ios/index.ts
@@ -14,7 +14,7 @@ import { renderExpoKitPodspecAsync } from '../../dynamic-macros/IosMacrosGenerat
 import { runTransformPipelineAsync } from './transforms';
 import { injectMacros } from './transforms/injectMacros';
 import { kernelFilesTransforms } from './transforms/kernelFilesTransforms';
-import { podspecTransforms, generateModulemapAsync } from './transforms/podspecTransforms';
+import { podspecTransforms } from './transforms/podspecTransforms';
 import { postTransforms } from './transforms/postTransforms';
 import { getVersionedDirectory, getVersionedExpoKitPath } from './utils';
 import { versionExpoModulesAsync } from './versionExpoModules';
@@ -321,8 +321,6 @@ async function generateReactNativePodspecsAsync(
     );
 
     const podspecSource = await fs.readFile(podspecFile, 'utf8');
-
-    await generateModulemapAsync(podspecFile, versionName);
 
     const podspecOutput = await runTransformPipelineAsync({
       pipeline: podspecTransforms(versionName),

--- a/tools/src/versioning/ios/transforms/podspecTransforms.ts
+++ b/tools/src/versioning/ios/transforms/podspecTransforms.ts
@@ -1,6 +1,3 @@
-import fs from 'fs-extra';
-import path from 'path';
-
 import { TransformPipeline } from '.';
 
 export function podspecTransforms(versionName: string): TransformPipeline {
@@ -40,13 +37,6 @@ export function podspecTransforms(versionName: string): TransformPipeline {
         paths: 'React-Core.podspec',
         replace: /"AccessibilityResources"/g,
         with: `"${versionName}AccessibilityResources"`,
-      },
-      {
-        // Add custom modulemap for React-Core to generate correct submodules for swift integration
-        // Learn more: `packages/expo-modules-autolinking/scripts/ios/cocoapods/sandbox.rb`
-        paths: 'React-Core.podspec',
-        replace: /(s.default_subspec\s+=.*$)/mg,
-        with: `$1\n  s.module_map             = "${versionName}React-Core.modulemap"`,
       },
       {
         // Hide Hermes headers from public headers because clang modoules does not support c++
@@ -100,19 +90,4 @@ export function podspecTransforms(versionName: string): TransformPipeline {
       },
     ],
   };
-}
-
-export async function generateModulemapAsync(podspecFile: string, versionName: string) {
-    const basename = path.basename(podspecFile, '.podspec');
-    if (basename === 'React-Core') {
-      const modulemap = `\
-module ${versionName}React {
-  umbrella "../../Public/${versionName}React-Core/${versionName}React"
-
-  export *
-  module * { export * }
-}`;
-      const modulemapPath = path.join(path.dirname(podspecFile), `${versionName}React-Core.modulemap`);
-      await fs.writeFile(modulemapPath, modulemap);
-    }
 }


### PR DESCRIPTION
# Why

fix umbrella header not found from `use_frameworks!` because framework files will be copied into DerivedData folder and the folder structure is different to CocoaPods header folders.
fix #15749

# How

instead of using custom modulemap with the `umbrella directory '../../Public/React-Core/React'`. this change further patch CocoaPods to generate umbrella header and modulemap file together with the public header files.

# Test Plan

- bare-expo ci passed
-
```
expo init sdk44 # select bare
yarn add file:/path/to/expo/expo/packages/expo-modules-autolinking
add `use_frameworks!` in `ios/Podfile`
expo run:ios
```

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
