### PR TITLE
[document-picker][ios] pass iCloudContainerEnvironment to plugin

### DIFF
--- a/packages/expo-document-picker/CHANGELOG.md
+++ b/packages/expo-document-picker/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Pass iCloudContainerEnvironment to plugin. ([#15774](https://github.com/expo/expo/pull/15774) by [@wkozyra95](https://github.com/wkozyra95))
+
 ### 💡 Others
 
 - Updated `@expo/config-plugins` from `4.0.2` to `4.0.14` ([#15621](https://github.com/expo/expo/pull/15621) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/expo-document-picker/plugin/build/withDocumentPicker.js
+++ b/packages/expo-document-picker/plugin/build/withDocumentPicker.js
@@ -3,8 +3,8 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const config_plugins_1 = require("@expo/config-plugins");
 const withDocumentPickerIOS_1 = require("./withDocumentPickerIOS");
 const pkg = require('expo-document-picker/package.json');
-const withDocumentPicker = (config, { appleTeamId = process.env.EXPO_APPLE_TEAM_ID } = {}) => {
-    config = (0, withDocumentPickerIOS_1.withDocumentPickerIOS)(config, { appleTeamId });
+const withDocumentPicker = (config, { appleTeamId = process.env.EXPO_APPLE_TEAM_ID, iCloudContainerEnvironment } = {}) => {
+    config = (0, withDocumentPickerIOS_1.withDocumentPickerIOS)(config, { appleTeamId, iCloudContainerEnvironment });
     return config;
 };
 exports.default = (0, config_plugins_1.createRunOncePlugin)(withDocumentPicker, pkg.name, pkg.version);

--- a/packages/expo-document-picker/plugin/src/withDocumentPicker.ts
+++ b/packages/expo-document-picker/plugin/src/withDocumentPicker.ts
@@ -6,9 +6,9 @@ const pkg = require('expo-document-picker/package.json');
 
 const withDocumentPicker: ConfigPlugin<IosProps | void> = (
   config,
-  { appleTeamId = process.env.EXPO_APPLE_TEAM_ID } = {}
+  { appleTeamId = process.env.EXPO_APPLE_TEAM_ID, iCloudContainerEnvironment } = {}
 ) => {
-  config = withDocumentPickerIOS(config, { appleTeamId });
+  config = withDocumentPickerIOS(config, { appleTeamId, iCloudContainerEnvironment });
   return config;
 };
 


### PR DESCRIPTION
# Why

https://github.com/expo/eas-cli/issues/860

iCloudContainerEnvironment is not passed correctly

If I understand correctly because of this issue and https://github.com/expo/expo-cli/pull/4109 `iCloudContainerEnvironment` is always undefined and `*.entitlments` file is always invalid which disables icloud functionality in the document picker

# How



# Test Plan

tested by applying the same changes in node_modules for a managed project and running prebuild

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
