### PR TITLE
[docs] use --auto for EAS Update CI action

### DIFF
--- a/docs/pages/eas-update/github-actions.md
+++ b/docs/pages/eas-update/github-actions.md
@@ -50,7 +50,7 @@ We can configure GitHub Actions to run on any GitHub event. One of the most comm
          - name: Install dependencies
            run: yarn install
          - name: Publish update
-           run: eas update --branch $(echo ${{ github.ref }} | sed 's|refs/heads/||') --message "${{ github.event.head_commit.message }}"
+           run: eas update --auto
    ```
 
    In the code above, we set the action to run every time code is pushed to the "production" branch. In the `update` job, we set up Node, in addition to Expo's GitHub Action: `expo-github-action`. We then add a couple steps to cache any dependencies installed from the last run to speed this script up on subsequent runs. At the end, we install dependencies (`yarn install`), then create a branch on EAS, then publish the branch. The EAS branch will be named after the GitHub branch, and the message for the update will match the commit's message.


### PR DESCRIPTION
Use `--auto` instead of the `sed` command in the CI action template, since we confirmed it works on GitHub Actions.