### PR TITLE
[workspace] remove unimodules directory from workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
       "apps/test-suite/puppeteer-test",
       "home",
       "packages/*",
-      "packages/@unimodules/*",
       "react-native-lab/react-native"
     ]
   },


### PR DESCRIPTION
# Why

Refs 6bb4396782b3b9ef76d0371bcc932ecfbdfc5ceb

# How

Just one more update related to unimodules deprecation. This one removes the  `packages/@unimodules/*` reference in workspace packages directories.

# Test Plan

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
