### PR TITLE
[expotools] read from expo-module.config.json in Packages

### DIFF
--- a/tools/src/Packages.ts
+++ b/tools/src/Packages.ts
@@ -64,13 +64,13 @@ export type ExpoModuleConfig = {
 export class Package {
   path: string;
   packageJson: PackageJson;
-  unimoduleJson: ExpoModuleConfig;
+  expoModuleConfig: ExpoModuleConfig;
   packageView?: Npm.PackageViewType | null;
 
   constructor(rootPath: string, packageJson?: PackageJson) {
     this.path = rootPath;
     this.packageJson = packageJson || require(path.join(rootPath, 'package.json'));
-    this.unimoduleJson = readExpoModuleConfigJson(rootPath);
+    this.expoModuleConfig = readExpoModuleConfigJson(rootPath);
   }
 
   get hasPlugin(): boolean {
@@ -86,7 +86,7 @@ export class Package {
   }
 
   get packageSlug(): string {
-    return (this.unimoduleJson && this.unimoduleJson.name) || this.packageName;
+    return (this.expoModuleConfig && this.expoModuleConfig.name) || this.packageName;
   }
 
   get scripts(): { [key: string]: string } {
@@ -94,13 +94,13 @@ export class Package {
   }
 
   get podspecPath(): string | null {
-    if (this.unimoduleJson?.ios?.podspecPath) {
-      return this.unimoduleJson.ios.podspecPath;
+    if (this.expoModuleConfig?.ios?.podspecPath) {
+      return this.expoModuleConfig.ios.podspecPath;
     }
 
     const iosConfig = {
       subdirectory: 'ios',
-      ...(this.unimoduleJson?.ios ?? {}),
+      ...(this.expoModuleConfig?.ios ?? {}),
     };
 
     // Obtain podspecName by looking for podspecs
@@ -117,10 +117,10 @@ export class Package {
   get podspecName(): string | null {
     const iosConfig = {
       subdirectory: 'ios',
-      ...(this.unimoduleJson?.ios ?? {}),
+      ...(this.expoModuleConfig?.ios ?? {}),
     };
 
-    // 'ios.podName' is actually not used anywhere in our unimodules, but let's have the same logic as react-native-unimodules script.
+    // 'ios.podName' is actually not used anywhere in our modules, but let's have the same logic as react-native-unimodules script.
     if ('podName' in iosConfig) {
       return iosConfig.podName as string;
     }
@@ -133,11 +133,11 @@ export class Package {
   }
 
   get iosSubdirectory(): string {
-    return this.unimoduleJson?.ios?.subdirectory ?? 'ios';
+    return this.expoModuleConfig?.ios?.subdirectory ?? 'ios';
   }
 
   get androidSubdirectory(): string {
-    return this.unimoduleJson?.android?.subdirectory ?? 'android';
+    return this.expoModuleConfig?.android?.subdirectory ?? 'android';
   }
 
   get androidPackageName(): string | null {
@@ -156,13 +156,13 @@ export class Package {
     return path.join(this.path, 'CHANGELOG.md');
   }
 
-  isUnimodule() {
-    return !!this.unimoduleJson;
+  isExpoModule() {
+    return !!this.expoModuleConfig;
   }
 
   isSupportedOnPlatform(platform: 'ios' | 'android'): boolean {
-    if (this.unimoduleJson) {
-      return this.unimoduleJson.platforms?.includes(platform) ?? false;
+    if (this.expoModuleConfig) {
+      return this.expoModuleConfig.platforms?.includes(platform) ?? false;
     } else if (platform === 'android') {
       return fs.existsSync(path.join(this.path, this.androidSubdirectory, 'build.gradle'));
     } else if (platform === 'ios') {


### PR DESCRIPTION
# Why

Prerequisite for running dev-client iOS unit tests in CI -- expotools needs to be able to detect that they have native unit tests, which means it needs to be able to read their podspecs from non-default locations (added in d1194e24fde231b0ab0a2a3f9b6b99ef2fca134c).

# How

- Noticed that expotools wasn't updated to read expo-module.config.json; updated it to look for this file and, if it exists, prefer it over unimodule.json.
- Added a new `podspecPath` property that returns a relative path to the module's podspec. It uses the corresponding property of expo-module.config.json if it exists, and falls back to the existing logic (which searches inside the ios subdirectory) if it doesn't.
- Updated the two methods that use the podspec path (`hasNativeTestsAsync` and `getPodspecAsync`) to use the `podspecPath` property rather than assuming a hardcoded location.

# Test Plan

Tested this change as a part of the test plan for https://github.com/expo/expo/pull/15795. Prior to this change, `hasNativeTestsAsync('ios')` returned true for 6 packages, and afterwards, it returns true for 8 (the same 6 + dev-launcher and dev-menu).

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
