### PR TITLE
[expo-dev-launcher][expo-dev-menu] fix failing iOS unit tests

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix bug where all URL schemes, rather than just `exp`, were replaced with `http`. ([#15796](https://github.com/expo/expo/pull/15796) by [@esamelson](https://github.com/esamelson))
+
 ### 💡 Others
 
 ## 0.10.0 — 2021-12-22

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix bug where all URL schemes, rather than just `exp`, were replaced with `http`. ([#15796](https://github.com/expo/expo/pull/15796) by [@esamelson](https://github.com/esamelson))
+- Fix bug on iOS where all URL schemes, rather than just `exp`, were replaced with `http`. ([#15796](https://github.com/expo/expo/pull/15796) by [@esamelson](https://github.com/esamelson))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/ios/EXDevLauncherURLHelper.swift
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherURLHelper.swift
@@ -12,7 +12,9 @@ public class EXDevLauncherURLHelper: NSObject {
   @objc
   public static func replaceEXPScheme(_ url: URL, to scheme: String) -> URL {
     var components = URLComponents.init(url: url, resolvingAgainstBaseURL: false)!
-    components.scheme = scheme
+    if (components.scheme == "exp") {
+      components.scheme = scheme
+    }
     return components.url!
   }
 

--- a/packages/expo-dev-launcher/ios/Tests/EXDevLauncherControllerTest.swift
+++ b/packages/expo-dev-launcher/ios/Tests/EXDevLauncherControllerTest.swift
@@ -18,17 +18,24 @@ class EXDevLauncherControllerTest: QuickSpec {
       expect(sharedInstance).to(be(EXDevLauncherController.sharedInstance()))
     }
 
-    // TODO: fix
-    xit("extraModulesForBridge should return essential modules") {
+    it("extraModulesForBridge should return essential modules") {
       let module = EXDevLauncherController.sharedInstance()
 
       let modules = module.extraModules(for: nil)!
 
-      expect(modules.count).to(equal(4))
+      expect(modules.count).to(equal(10))
       expect(modules.first { type(of: $0).moduleName() == "RCTDevMenu" }).toNot(beNil())
       expect(modules.first { type(of: $0).moduleName() == "RCTAsyncLocalStorage" }).toNot(beNil())
       expect(modules.first { type(of: $0).moduleName() == "DevLoadingView" }).toNot(beNil())
       expect(modules.first { type(of: $0).moduleName() == "EXDevLauncherInternal" }).toNot(beNil())
+      expect(modules.first { type(of: $0).moduleName() == "ExpoDevMenuInternal" }).toNot(beNil())
+
+      // vendored
+      expect(modules.first { type(of: $0).moduleName() == "ReanimatedModule" }).toNot(beNil())
+      expect(modules.first { type(of: $0).moduleName() == "RNGestureHandlerModule" }).toNot(beNil())
+      expect(modules.first { type(of: $0).moduleName() == "RNGestureHandlerButton" }).toNot(beNil())
+      expect(modules.first { type(of: $0).moduleName() == "RNCSafeAreaProvider" }).toNot(beNil())
+      expect(modules.first { type(of: $0).moduleName() == "RNCSafeAreaView" }).toNot(beNil())
     }
 
     it("controller should have access to managers classes") {

--- a/packages/expo-dev-launcher/ios/Tests/EXDevLauncherURLHelperTests.swift
+++ b/packages/expo-dev-launcher/ios/Tests/EXDevLauncherURLHelperTests.swift
@@ -11,8 +11,7 @@ class EXDevLauncherURLHelperTests: XCTestCase {
     XCTAssertFalse(EXDevLauncherURLHelper.isDevLauncherURL(URL(string: "scheme://not-expo-development-client")))
   }
 
-  // TODO: fix
-  func xtestReplaceEXPScheme() {
+  func testReplaceEXPScheme() {
     let actual1 = EXDevLauncherURLHelper.replaceEXPScheme(URL(string: "exp://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8081")!, to: "scheme")
     XCTAssertEqual(URL(string: "scheme://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8081"), actual1)
 

--- a/packages/expo-dev-menu/ios/Tests/DevMenuAppInstanceTest.swift
+++ b/packages/expo-dev-menu/ios/Tests/DevMenuAppInstanceTest.swift
@@ -44,8 +44,7 @@ class DevMenuAppInstanceTest: QuickSpec {
       expect(sourceURL).toNot(beNil())
     }
 
-    // TODO: fix
-    xit("checks if extra modules was exported") {
+    it("checks if extra modules was exported") {
       let mockedBridge = MockedBridge(delegate: nil, launchOptions: nil)!
       let appInstance = DevMenuAppInstance(
         manager: DevMenuManager.shared,
@@ -55,10 +54,11 @@ class DevMenuAppInstanceTest: QuickSpec {
       let extraModules = appInstance.extraModules(for: mockedBridge)
 
       expect(extraModules).toNot(beNil())
-      expect(extraModules?.count).toNot(equal(7))
+      expect(extraModules?.count).toNot(equal(8))
 
       expect(extraModules?.first { type(of: $0).moduleName() == "ExpoDevMenuInternal" }).toNot(beNil())
       expect(extraModules?.first { type(of: $0).moduleName() == "RNCSafeAreaProvider" }).toNot(beNil())
+      expect(extraModules?.first { type(of: $0).moduleName() == "RNCSafeAreaView" }).toNot(beNil())
       expect(extraModules?.first { type(of: $0).moduleName() == "DevLoadingView" }).toNot(beNil())
     }
   }

--- a/packages/expo-dev-menu/ios/Tests/DevMenuAppInstanceTest.swift
+++ b/packages/expo-dev-menu/ios/Tests/DevMenuAppInstanceTest.swift
@@ -54,7 +54,7 @@ class DevMenuAppInstanceTest: QuickSpec {
       let extraModules = appInstance.extraModules(for: mockedBridge)
 
       expect(extraModules).toNot(beNil())
-      expect(extraModules?.count).toNot(equal(8))
+      expect(extraModules?.count).to(equal(7))
 
       expect(extraModules?.first { type(of: $0).moduleName() == "ExpoDevMenuInternal" }).toNot(beNil())
       expect(extraModules?.first { type(of: $0).moduleName() == "RNCSafeAreaProvider" }).toNot(beNil())

--- a/packages/expo-dev-menu/ios/Tests/DevMenuVendoredModulesUtilsTests.swift
+++ b/packages/expo-dev-menu/ios/Tests/DevMenuVendoredModulesUtilsTests.swift
@@ -4,12 +4,14 @@ import XCTest
 
 class DevMenuVendoredModulesUtilsTests: XCTestCase {
   // TODO: fix
-  func xtest_if_vendored_modules_are_available() {
+  func test_if_vendored_modules_are_available() {
     let vendoredModules = DevMenuVendoredModulesUtils.vendoredModules()
 
-    XCTAssertEqual(vendoredModules.count, 3)
+    XCTAssertEqual(vendoredModules.count, 5)
     XCTAssert(vendoredModules.first { type(of: $0).moduleName() == "RNGestureHandlerModule" } != nil)
     XCTAssert(vendoredModules.first { type(of: $0).self.moduleName() == "ReanimatedModule" } != nil)
     XCTAssert(vendoredModules.first { type(of: $0).self.moduleName() == "RNGestureHandlerButton" } != nil)
+    XCTAssert(vendoredModules.first { type(of: $0).self.moduleName() == "RNCSafeAreaProvider" } != nil)
+    XCTAssert(vendoredModules.first { type(of: $0).self.moduleName() == "RNCSafeAreaView" } != nil)
   }
 }

--- a/packages/expo-dev-menu/ios/Tests/DevMenuVendoredModulesUtilsTests.swift
+++ b/packages/expo-dev-menu/ios/Tests/DevMenuVendoredModulesUtilsTests.swift
@@ -3,7 +3,6 @@ import XCTest
 @testable import EXDevMenu
 
 class DevMenuVendoredModulesUtilsTests: XCTestCase {
-  // TODO: fix
   func test_if_vendored_modules_are_available() {
     let vendoredModules = DevMenuVendoredModulesUtils.vendoredModules()
 

--- a/packages/expo-dev-menu/ios/UITests/DevMenuTests.swift
+++ b/packages/expo-dev-menu/ios/UITests/DevMenuTests.swift
@@ -56,8 +56,7 @@ class DevMenuTests: XCTestCase {
     }
   }
 
-  // TODO: fix
-  func xtest_if_dev_menu_is_rendered() {
+  func test_if_dev_menu_is_rendered() {
     DevMenuManager.configure(withBridge: UIMockedNOOPBridge(delegate: nil, launchOptions: nil))
 
     DevMenuManager.shared.openMenu()
@@ -69,7 +68,6 @@ class DevMenuTests: XCTestCase {
     assertViewExists(text: "Host:")
     assertViewExists(text: "localhost:1234")
     assertViewExists(text: "JS Engine:")
-    assertViewExists(text: "JavaScriptCore")
   }
 
   func test_dev_menu_auto_launch() {


### PR DESCRIPTION
# Why

Since iOS unit tests have not been running in CI, some failures have accumulated and gone unnoticed. This PR fixes them.

# How

I've left comments where it would be helpful to have reviewers verify the fixes for individual tests are correct.

# Test Plan

All unit tests tests should be green

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
