### PR TITLE
[sweet][kotlin] Add error chaining

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/DynamicExtenstions.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/DynamicExtenstions.kt
@@ -3,7 +3,9 @@ package expo.modules.kotlin
 import com.facebook.react.bridge.Dynamic
 
 inline fun <T> Dynamic.recycle(block: Dynamic.() -> T): T {
-  val result = block(this)
-  this.recycle()
-  return result
+  try {
+    return block(this)
+  } finally {
+    this.recycle()
+  }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KotlinInteropModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KotlinInteropModuleRegistry.kt
@@ -31,7 +31,7 @@ class KotlinInteropModuleRegistry(
     try {
       requireNotNull(
         registry.getModuleHolder(moduleName)
-      ) { "Trying to call '$method' on the nom-existing module '$moduleName'" }
+      ) { "Trying to call '$method' on the non-existing module '$moduleName'" }
         .call(method, arguments, promise)
     } catch (e: CodedException) {
       promise.reject(e)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KotlinInteropModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KotlinInteropModuleRegistry.kt
@@ -31,7 +31,7 @@ class KotlinInteropModuleRegistry(
     try {
       requireNotNull(
         registry.getModuleHolder(moduleName)
-      ) { "Trying to call `$method` on the nom-existing module `$moduleName`" }
+      ) { "Trying to call '$method' on the nom-existing module '$moduleName'" }
         .call(method, arguments, promise)
     } catch (e: CodedException) {
       promise.reject(e)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KotlinInteropModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KotlinInteropModuleRegistry.kt
@@ -3,6 +3,8 @@ package expo.modules.kotlin
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.uimanager.ViewManager
+import expo.modules.kotlin.exception.CodedException
+import expo.modules.kotlin.exception.UnexpectedException
 import expo.modules.kotlin.views.GroupViewManagerWrapper
 import expo.modules.kotlin.views.SimpleViewManagerWrapper
 import expo.modules.kotlin.views.ViewManagerWrapperDelegate
@@ -26,9 +28,16 @@ class KotlinInteropModuleRegistry(
   fun hasModule(name: String): Boolean = registry.hasModule(name)
 
   fun callMethod(moduleName: String, method: String, arguments: ReadableArray, promise: Promise) {
-    registry
-      .getModuleHolder(moduleName)
-      ?.call(method, arguments, promise)
+    try {
+      requireNotNull(
+        registry.getModuleHolder(moduleName)
+      ) { "Trying to call `$method` on the nom-existing module `$moduleName`" }
+        .call(method, arguments, promise)
+    } catch (e: CodedException) {
+      promise.reject(e)
+    } catch (e: Throwable) {
+      promise.reject(UnexpectedException(e))
+    }
   }
 
   fun exportedModulesConstants(): Map<ModuleName, ModuleConstants> {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
@@ -1,23 +1,24 @@
 package expo.modules.kotlin
 
 import com.facebook.react.bridge.ReadableArray
-import expo.modules.core.utilities.ifNull
 import expo.modules.kotlin.events.BasicEventListener
 import expo.modules.kotlin.events.EventListenerWithPayload
 import expo.modules.kotlin.events.EventListenerWithSenderAndPayload
 import expo.modules.kotlin.events.EventName
+import expo.modules.kotlin.exception.MethodCallException
 import expo.modules.kotlin.exception.MethodNotFoundException
+import expo.modules.kotlin.exception.exceptionDecorator
 import expo.modules.kotlin.modules.Module
 
 class ModuleHolder(val module: Module) {
   val definition = module.definition()
   val name get() = definition.name
 
-  fun call(methodName: String, args: ReadableArray, promise: Promise) {
-    val method = definition.methods[methodName].ifNull {
-      promise.reject(MethodNotFoundException(methodName, definition.name))
-      return
-    }
+  fun call(methodName: String, args: ReadableArray, promise: Promise) = exceptionDecorator({
+    MethodCallException(methodName, definition.name, it)
+  }) {
+    val method = definition.methods[methodName]
+      ?: throw MethodNotFoundException()
 
     method.call(args, promise)
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
@@ -5,7 +5,7 @@ import expo.modules.kotlin.events.BasicEventListener
 import expo.modules.kotlin.events.EventListenerWithPayload
 import expo.modules.kotlin.events.EventListenerWithSenderAndPayload
 import expo.modules.kotlin.events.EventName
-import expo.modules.kotlin.exception.MethodCallException
+import expo.modules.kotlin.exception.FunctionCallException
 import expo.modules.kotlin.exception.MethodNotFoundException
 import expo.modules.kotlin.exception.exceptionDecorator
 import expo.modules.kotlin.modules.Module
@@ -15,7 +15,7 @@ class ModuleHolder(val module: Module) {
   val name get() = definition.name
 
   fun call(methodName: String, args: ReadableArray, promise: Promise) = exceptionDecorator({
-    MethodCallException(methodName, definition.name, it)
+    FunctionCallException(methodName, definition.name, it)
   }) {
     val method = definition.methods[methodName]
       ?: throw MethodNotFoundException()

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/Promise.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/Promise.kt
@@ -8,6 +8,6 @@ interface Promise {
   fun reject(code: String, message: String?, cause: Throwable?)
 
   fun reject(exception: CodedException) {
-    reject(exception.code, exception.message, exception.cause)
+    reject(exception.code, exception.localizedMessage, exception.cause)
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
@@ -87,7 +87,7 @@ internal class FunctionCallException(
   moduleName: String,
   cause: CodedException
 ) : DecoratedException(
-  message = "Call to function '${moduleName}.$methodName' has been rejected.",
+  message = "Call to function '$moduleName.$methodName' has been rejected.",
   cause,
 )
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
@@ -48,14 +48,14 @@ internal class IncompatibleArgTypeException(
   desiredType: KType,
   cause: Throwable? = null
 ) : CodedException(
-  message = "Argument type $argumentType is not compatible with expected type $desiredType.",
+  message = "Argument type '$argumentType' is not compatible with expected type '$desiredType'.",
   cause = cause
 )
 
 internal class MissingTypeConverter(
   forType: KType
 ) : CodedException(
-  message = "Cannot find type converter for $forType.",
+  message = "Cannot find type converter for '$forType'.",
 )
 
 internal class InvalidArgsNumberException(received: Int, expected: Int) :
@@ -74,20 +74,20 @@ internal class UnexpectedException(val throwable: Throwable) :
  * A base class for all exceptions used in `exceptionDecorator` function.
  */
 internal open class DecoratedException(
-  message: String?,
+  message: String,
   cause: CodedException,
 ) : CodedException(
   cause.code,
-  message = "$message${System.lineSeparator()}caused by: ${cause.localizedMessage ?: cause}",
+  message = "$message${System.lineSeparator()}→ Caused by: ${cause.localizedMessage ?: cause}",
   cause
 )
 
-internal class MethodCallException(
+internal class FunctionCallException(
   methodName: String,
   moduleName: String,
   cause: CodedException
 ) : DecoratedException(
-  message = "Cannot call `$methodName` from the `$moduleName`.",
+  message = "Call to function '${moduleName}.$methodName' has been rejected.",
   cause,
 )
 
@@ -97,7 +97,7 @@ internal class ArgumentCastException(
   providedType: ReadableType,
   cause: CodedException,
 ) : DecoratedException(
-  message = "Cannot obtain `$argIndex` parameter. Tried to cast `${providedType.name}` to `$argDesiredType`.",
+  message = "Argument at index '$argIndex' couldn't be casted to type '$argDesiredType' (received '$providedType').",
   cause,
 )
 
@@ -107,7 +107,7 @@ internal class FieldCastException(
   providedType: ReadableType,
   cause: CodedException
 ) : DecoratedException(
-  message = "Cannot obtain `$fieldName` field. Tried to cast `${providedType.name}` to $fieldType`.",
+  message = "Cannot cast '${providedType.name}' for field '$fieldName' ('$fieldType').",
   cause
 )
 
@@ -115,7 +115,7 @@ internal class RecordCastException(
   recordType: KType,
   cause: CodedException
 ) : DecoratedException(
-  message = "Cannot create a record of the type: `$recordType`.",
+  message = "Cannot create a record of the type: '$recordType'.",
   cause
 )
 
@@ -125,6 +125,6 @@ internal class CollectionElementCastException(
   providedType: ReadableType,
   cause: CodedException
 ) : DecoratedException(
-  message = "Cannot cast `${providedType.name}` to `$elementType` required by the collection of type: `$collectionType`.",
+  message = "Cannot cast '${providedType.name}' to '$elementType' required by the collection of type: '$collectionType'.",
   cause
 )

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/ExceptionDecorator.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/ExceptionDecorator.kt
@@ -1,12 +1,11 @@
 package expo.modules.kotlin.exception
 
-
 internal inline fun <T> exceptionDecorator(decoratorBlock: (e: CodedException) -> Throwable, block: () -> T): T {
   return try {
     block()
   } catch (e: CodedException) {
     throw decoratorBlock(e)
   } catch (e: Throwable) {
-    throw  decoratorBlock(UnexpectedException(e))
+    throw decoratorBlock(UnexpectedException(e))
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/ExceptionDecorator.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/ExceptionDecorator.kt
@@ -1,0 +1,12 @@
+package expo.modules.kotlin.exception
+
+
+internal inline fun <T> exceptionDecorator(decoratorBlock: (e: CodedException) -> Throwable, block: () -> T): T {
+  return try {
+    block()
+  } catch (e: CodedException) {
+    throw decoratorBlock(e)
+  } catch (e: Throwable) {
+    throw  decoratorBlock(UnexpectedException(e))
+  }
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/methods/AnyMethod.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/methods/AnyMethod.kt
@@ -2,31 +2,26 @@ package expo.modules.kotlin.methods
 
 import com.facebook.react.bridge.ReadableArray
 import expo.modules.kotlin.Promise
+import expo.modules.kotlin.exception.ArgumentCastException
 import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.exception.InvalidArgsNumberException
-import expo.modules.kotlin.exception.UnexpectedException
+import expo.modules.kotlin.exception.exceptionDecorator
 import expo.modules.kotlin.iterator
 import expo.modules.kotlin.recycle
 import expo.modules.kotlin.types.AnyType
-import kotlin.jvm.Throws
 
 abstract class AnyMethod(
   protected val name: String,
   private val desiredArgsTypes: Array<AnyType>
 ) {
+  @Throws(CodedException::class)
   fun call(args: ReadableArray, promise: Promise) {
     if (desiredArgsTypes.size != args.size()) {
-      promise.reject(InvalidArgsNumberException(args.size(), desiredArgsTypes.size))
-      return
+      throw InvalidArgsNumberException(args.size(), desiredArgsTypes.size)
     }
-    try {
-      val convertedArgs = convertArgs(args)
-      callImplementation(convertedArgs, promise)
-    } catch (codedError: CodedException) {
-      promise.reject(codedError)
-    } catch (e: Throwable) {
-      promise.reject(UnexpectedException(e))
-    }
+
+    val convertedArgs = convertArgs(args)
+    callImplementation(convertedArgs, promise)
   }
 
   @Throws(CodedException::class)
@@ -40,9 +35,13 @@ abstract class AnyMethod(
     val argIterator = args.iterator()
     desiredArgsTypes
       .withIndex()
-      .forEach { (index, type) ->
+      .forEach { (index, desiredType) ->
         argIterator.next().recycle {
-          finalArgs[index] = type.convert(this)
+          exceptionDecorator({ cause ->
+            ArgumentCastException(desiredType.kType, index, type, cause)
+          }) {
+            finalArgs[index] = desiredType.convert(this)
+          }
         }
       }
     return finalArgs

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/PairTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/PairTypeConverter.kt
@@ -1,28 +1,45 @@
 package expo.modules.kotlin.types
 
 import com.facebook.react.bridge.Dynamic
+import com.facebook.react.bridge.ReadableArray
+import expo.modules.kotlin.exception.CollectionElementCastException
+import expo.modules.kotlin.exception.exceptionDecorator
+import expo.modules.kotlin.recycle
 import kotlin.reflect.KType
 
 class PairTypeConverter(
   converterProvider: TypeConverterProvider,
-  type: KType,
-) : TypeConverter<Pair<*, *>>(type.isMarkedNullable) {
-  private val firstConverter = converterProvider.obtainTypeConverter(
-    requireNotNull(type.arguments.getOrNull(0)?.type) {
-      "The pair type should contain the type of the first parameter."
-    }
-  )
-  private val secondConverter = converterProvider.obtainTypeConverter(
-    requireNotNull(type.arguments.getOrNull(1)?.type) {
-      "The pair type should contain the type of the second parameter."
-    }
+  private val pairType: KType,
+) : TypeConverter<Pair<*, *>>(pairType.isMarkedNullable) {
+  private val converters = listOf(
+    converterProvider.obtainTypeConverter(
+      requireNotNull(pairType.arguments.getOrNull(0)?.type)
+      {
+        "The pair type should contain the type of the first parameter."
+      }
+    ),
+    converterProvider.obtainTypeConverter(
+      requireNotNull(pairType.arguments.getOrNull(1)?.type) {
+        "The pair type should contain the type of the second parameter."
+      }
+    )
   )
 
   override fun convertNonOptional(value: Dynamic): Pair<*, *> {
     val jsArray = value.asArray()
     return Pair(
-      firstConverter.convert(jsArray.getDynamic(0)),
-      secondConverter.convert(jsArray.getDynamic(1)),
+      convertElement(jsArray, 0),
+      convertElement(jsArray, 1)
     )
+  }
+
+  private fun convertElement(array: ReadableArray, index: Int): Any? {
+    return array.getDynamic(index).recycle {
+      exceptionDecorator({ cause ->
+        CollectionElementCastException(pairType, pairType.arguments[index].type!!, type, cause)
+      }) {
+        converters[index].convert(this)
+      }
+    }
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/PairTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/PairTypeConverter.kt
@@ -13,8 +13,7 @@ class PairTypeConverter(
 ) : TypeConverter<Pair<*, *>>(pairType.isMarkedNullable) {
   private val converters = listOf(
     converterProvider.obtainTypeConverter(
-      requireNotNull(pairType.arguments.getOrNull(0)?.type)
-      {
+      requireNotNull(pairType.arguments.getOrNull(0)?.type) {
         "The pair type should contain the type of the first parameter."
       }
     ),

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverter.kt
@@ -1,6 +1,7 @@
 package expo.modules.kotlin.types
 
 import com.facebook.react.bridge.Dynamic
+import expo.modules.kotlin.exception.NullArgumentException
 
 abstract class TypeConverter<Type : Any>(
   private val isOptional: Boolean
@@ -10,7 +11,7 @@ abstract class TypeConverter<Type : Any>(
       if (isOptional) {
         return null
       }
-      throw IllegalArgumentException()
+      throw NullArgumentException()
     }
     return convertNonOptional(value)
   }

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/TruthExtensions.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/TruthExtensions.kt
@@ -1,0 +1,18 @@
+package expo.modules
+
+import com.google.common.truth.Truth
+import org.junit.Assert
+
+inline fun <reified T : Throwable> assertThrows(expectedMessage: String? = null, block: () -> Any?) {
+  try {
+    block()
+  } catch (e: Throwable) {
+    Truth.assertThat(e).isInstanceOf(T::class.java)
+    expectedMessage?.let {
+      Truth.assertThat(e.localizedMessage).isEqualTo(it)
+    }
+    return
+  }
+
+  Assert.fail("Provided block should throw.")
+}

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/KotlinInteropModuleRegistryTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/KotlinInteropModuleRegistryTest.kt
@@ -1,15 +1,35 @@
 package expo.modules.kotlin
 
+import com.facebook.react.bridge.JavaOnlyArray
+import com.facebook.react.bridge.JavaOnlyMap
 import com.google.common.truth.Truth
+import expo.modules.PromiseMock
+import expo.modules.PromiseState
+import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
+import expo.modules.kotlin.records.Field
+import expo.modules.kotlin.records.Record
 import io.mockk.mockk
 import org.junit.Test
 import java.lang.ref.WeakReference
 
-class DummyModule_1 : Module() {
+private class DomainError : CodedException("Something went wrong")
+
+private class MyRecord : Record {
+  @Field
+  lateinit var string: String
+}
+
+private class DummyModule_1 : Module() {
   override fun definition() = ModuleDefinition {
     name("dummy-1")
+    function("f1") {
+      throw NullPointerException()
+    }
+    function<Int, MyRecord>("f2") {
+      throw NullPointerException()
+    }
     constants {
       mapOf(
         "c1" to 123,
@@ -19,16 +39,22 @@ class DummyModule_1 : Module() {
   }
 }
 
-class DummyModule_2 : Module() {
+private class DummyModule_2 : Module() {
   override fun definition() = ModuleDefinition {
     name("dummy-2")
+    function("f1") {
+      throw DomainError()
+    }
+    function("f2") { arg1: Int ->
+      arg1
+    }
     viewManager {
       view { mockk() }
     }
   }
 }
 
-val provider = object : ModulesProvider {
+private val provider = object : ModulesProvider {
   override fun getModulesList(): List<Class<out Module>> {
     return listOf(
       DummyModule_1::class.java,
@@ -38,26 +64,20 @@ val provider = object : ModulesProvider {
 }
 
 class KotlinInteropModuleRegistryTest {
+  private val interopModuleRegistry = KotlinInteropModuleRegistry(
+    provider,
+    mockk(),
+    WeakReference(mockk(relaxed = true))
+  )
+
   @Test
   fun `should register modules from provider`() {
-    val interopModuleRegistry = KotlinInteropModuleRegistry(
-      provider,
-      mockk(),
-      WeakReference(mockk(relaxed = true))
-    )
-
     interopModuleRegistry.hasModule("dummy-1")
     interopModuleRegistry.hasModule("dummy-2")
   }
 
   @Test
   fun `should export constants`() {
-    val interopModuleRegistry = KotlinInteropModuleRegistry(
-      provider,
-      mockk(),
-      WeakReference(mockk(relaxed = true))
-    )
-
     Truth.assertThat(interopModuleRegistry.exportedModulesConstants())
       .containsExactly(
         "dummy-1", mapOf("c1" to 123, "c2" to "123"),
@@ -67,17 +87,97 @@ class KotlinInteropModuleRegistryTest {
 
   @Test
   fun `should export view manages`() {
-    val interopModuleRegistry = KotlinInteropModuleRegistry(
-      provider,
-      mockk(),
-      WeakReference(mockk(relaxed = true))
-    )
-
     val rnManagers = interopModuleRegistry.exportViewManagers()
     val expoManagersNames = interopModuleRegistry.exportedViewManagersNames()
 
     Truth.assertThat(rnManagers).hasSize(1)
     Truth.assertThat(rnManagers.first().name).isEqualTo("ViewManagerAdapter_dummy-2")
     Truth.assertThat(expoManagersNames).containsExactly("dummy-2")
+  }
+
+  @Test
+  fun `call method should reject if something goes wrong`() {
+    val mockedPromise = PromiseMock()
+    val mockedPromise2 = PromiseMock()
+
+    interopModuleRegistry.callMethod("dummy-1", "f1", JavaOnlyArray(), mockedPromise)
+    interopModuleRegistry.callMethod("dummy-2", "f1", JavaOnlyArray(), mockedPromise2)
+
+    Truth.assertThat(mockedPromise.state).isEqualTo(PromiseState.REJECTED)
+    Truth.assertThat(mockedPromise.rejectMessage).isEqualTo(
+      """
+      Cannot call `f1` from the `dummy-1`.
+      caused by: java.lang.NullPointerException
+      """.trimIndent()
+    )
+
+    Truth.assertThat(mockedPromise2.state).isEqualTo(PromiseState.REJECTED)
+    Truth.assertThat(mockedPromise2.rejectMessage).isEqualTo(
+      """
+      Cannot call `f1` from the `dummy-2`.
+      caused by: Something went wrong
+      """.trimIndent()
+    )
+  }
+
+  @Test
+  fun `call method should reject if method was called with incorrect arguments`() {
+    val testCases = listOf(
+      Triple(
+        "dummy-1",
+        "f10",
+        JavaOnlyArray()
+      ) to """
+        Cannot call `f10` from the `dummy-1`.
+        caused by: Method does not exist.
+      """.trimIndent(),
+      Triple(
+        "dummy-1",
+        "f1",
+        JavaOnlyArray().apply { pushInt(1) }
+      ) to """
+        Cannot call `f1` from the `dummy-1`.
+        caused by: Received 1 arguments, but 0 was expected.
+      """.trimIndent(),
+      Triple(
+        "dummy-2",
+        "f2",
+        JavaOnlyArray().apply { pushString("string") }
+      ) to """
+        Cannot call `f2` from the `dummy-2`.
+        caused by: Cannot obtain `0` parameter. Tried to cast `String` to `kotlin.Int`.
+        caused by: java.lang.ClassCastException: java.lang.String cannot be cast to java.lang.Number
+      """.trimIndent(),
+      Triple(
+        "dummy-2",
+        "f2",
+        JavaOnlyArray()
+      ) to """
+        Cannot call `f2` from the `dummy-2`.
+        caused by: Received 0 arguments, but 1 was expected.
+      """.trimIndent(),
+      Triple(
+        "dummy-1",
+        "f2",
+        JavaOnlyArray().apply { pushMap(JavaOnlyMap().apply { putInt("string", 10) }) }
+      ) to """
+        Cannot call `f2` from the `dummy-1`.
+        caused by: Cannot obtain `0` parameter. Tried to cast `Map` to `expo.modules.kotlin.MyRecord`.
+        caused by: Cannot create a record of the type: `expo.modules.kotlin.MyRecord`.
+        caused by: Cannot obtain `string` field. Tried to cast `Number` to kotlin.String`.
+        caused by: java.lang.ClassCastException: java.lang.Double cannot be cast to java.lang.String
+      """.trimIndent()
+    )
+
+    testCases.forEach {
+      val callValues = it.first
+      val expected = it.second
+      val promise = PromiseMock()
+
+      interopModuleRegistry.callMethod(callValues.first, callValues.second, callValues.third, promise)
+
+      Truth.assertThat(promise.state).isEqualTo(PromiseState.REJECTED)
+      Truth.assertThat(promise.rejectMessage).isEqualTo(expected)
+    }
   }
 }

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/ModuleHolderTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/ModuleHolderTest.kt
@@ -5,7 +5,7 @@ import com.google.common.truth.Truth
 import expo.modules.PromiseMock
 import expo.modules.PromiseState
 import expo.modules.assertThrows
-import expo.modules.kotlin.exception.MethodCallException
+import expo.modules.kotlin.exception.FunctionCallException
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 import org.junit.Test
@@ -31,13 +31,13 @@ class ModuleHolderTest {
     val holder = ModuleHolder(EmptyModule())
     val promise = PromiseMock()
 
-    assertThrows<MethodCallException>(
+    assertThrows<FunctionCallException>(
       """
-      Cannot call `not existing method` from the `empty-module`.
-      caused by: Method does not exist.
+      Call to function 'empty-module.not_existing_method' has been rejected.
+      → Caused by: Method does not exist.
       """.trimIndent()
     ) {
-      holder.call("not existing method", JavaOnlyArray(), promise)
+      holder.call("not_existing_method", JavaOnlyArray(), promise)
     }
 
     Truth.assertThat(promise.state).isEqualTo(PromiseState.NONE)

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/ModuleHolderTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/ModuleHolderTest.kt
@@ -4,6 +4,8 @@ import com.facebook.react.bridge.JavaOnlyArray
 import com.google.common.truth.Truth
 import expo.modules.PromiseMock
 import expo.modules.PromiseState
+import expo.modules.assertThrows
+import expo.modules.kotlin.exception.MethodCallException
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 import org.junit.Test
@@ -25,12 +27,19 @@ class ModuleHolderTest {
   }
 
   @Test
-  fun `should reject if method doesn't exist`() {
+  fun `should throw if method doesn't exist`() {
     val holder = ModuleHolder(EmptyModule())
     val promise = PromiseMock()
 
-    holder.call("not existing method", JavaOnlyArray(), promise)
-    Truth.assertThat(promise.state).isEqualTo(PromiseState.REJECTED)
-    Truth.assertThat(promise.rejectCode).isEqualTo("ERR_METHOD_NOT_FOUND")
+    assertThrows<MethodCallException>(
+      """
+      Cannot call `not existing method` from the `empty-module`.
+      caused by: Method does not exist.
+      """.trimIndent()
+    ) {
+      holder.call("not existing method", JavaOnlyArray(), promise)
+    }
+
+    Truth.assertThat(promise.state).isEqualTo(PromiseState.NONE)
   }
 }

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/methods/AnyMethodTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/methods/AnyMethodTest.kt
@@ -6,7 +6,10 @@ import com.facebook.react.bridge.JavaOnlyArray
 import com.google.common.truth.Truth
 import expo.modules.PromiseMock
 import expo.modules.PromiseState
+import expo.modules.assertThrows
 import expo.modules.kotlin.Promise
+import expo.modules.kotlin.exception.ArgumentCastException
+import expo.modules.kotlin.exception.InvalidArgsNumberException
 import expo.modules.kotlin.types.toAnyType
 import org.junit.Test
 import kotlin.reflect.KType
@@ -22,65 +25,74 @@ class AnyMethodTest {
   }
 
   @Test
-  fun `call should reject if pass more arguments then expected`() {
+  fun `call should throw if pass more arguments then expected`() {
     val method = MockedAnyMethod(arrayOf(typeOf<Int>()))
     val promise = PromiseMock()
 
-    method.call(
-      JavaOnlyArray().apply {
-        pushInt(1)
-        pushInt(2)
-      },
-      promise
-    )
+    assertThrows<InvalidArgsNumberException>("Received 2 arguments, but 1 was expected.") {
+      method.call(
+        JavaOnlyArray().apply {
+          pushInt(1)
+          pushInt(2)
+        },
+        promise
+      )
+    }
 
-    Truth.assertThat(promise.state).isEqualTo(PromiseState.REJECTED)
-    Truth.assertThat(promise.rejectCode).isEqualTo("ERR_INVALID_ARGS_NUMBER")
+    Truth.assertThat(promise.state).isEqualTo(PromiseState.NONE)
   }
 
   @Test
-  fun `call should reject if pass less arguments then expected`() {
+  fun `call should throw if pass less arguments then expected`() {
     val method = MockedAnyMethod(arrayOf(typeOf<Int>(), typeOf<Int>()))
     val promise = PromiseMock()
 
-    method.call(
-      JavaOnlyArray().apply {
-        pushInt(1)
-      },
-      promise
-    )
+    assertThrows<InvalidArgsNumberException>("Received 1 arguments, but 2 was expected.") {
+      method.call(
+        JavaOnlyArray().apply {
+          pushInt(1)
+        },
+        promise
+      )
+    }
 
-    Truth.assertThat(promise.state).isEqualTo(PromiseState.REJECTED)
-    Truth.assertThat(promise.rejectCode).isEqualTo("ERR_INVALID_ARGS_NUMBER")
+    Truth.assertThat(promise.state).isEqualTo(PromiseState.NONE)
   }
 
   @Test
-  fun `call should reject if cannot convert args`() {
+  fun `call should throw if cannot convert args`() {
     val method = MockedAnyMethod(arrayOf(typeOf<Int>()))
     val promise = PromiseMock()
 
-    method.call(
-      JavaOnlyArray().apply {
-        pushString("STRING")
-      },
-      promise
-    )
+    assertThrows<ArgumentCastException>(
+      """
+      Cannot obtain `0` parameter. Tried to cast `String` to `kotlin.Int`.
+      caused by: java.lang.ClassCastException: java.lang.String cannot be cast to java.lang.Number
+      """.trimIndent()
+    ) {
+      method.call(
+        JavaOnlyArray().apply {
+          pushString("STRING")
+        },
+        promise
+      )
+    }
 
-    Truth.assertThat(promise.state).isEqualTo(PromiseState.REJECTED)
-    Truth.assertThat(promise.rejectCode).isEqualTo("ERR_UNEXPECTED")
+    Truth.assertThat(promise.state).isEqualTo(PromiseState.NONE)
   }
 
   @Test
-  fun `unknown exception should be wrapped into UnexpectedException`() {
+  fun `sync exception shouldn't be converter into promise rejection`() {
     val method = MockedAnyMethod(emptyArray())
     val promise = PromiseMock()
 
-    method.call(
-      JavaOnlyArray(),
-      promise
-    )
+    assertThrows<NullPointerException> {
+      method.call(
+        JavaOnlyArray(),
+        promise
+      )
+    }
 
-    Truth.assertThat(promise.state).isEqualTo(PromiseState.REJECTED)
-    Truth.assertThat(promise.rejectCode).isEqualTo("ERR_UNEXPECTED")
+    Truth.assertThat(promise.state).isEqualTo(PromiseState.NONE)
   }
 }

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/methods/AnyMethodTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/methods/AnyMethodTest.kt
@@ -66,8 +66,8 @@ class AnyMethodTest {
 
     assertThrows<ArgumentCastException>(
       """
-      Cannot obtain `0` parameter. Tried to cast `String` to `kotlin.Int`.
-      caused by: java.lang.ClassCastException: java.lang.String cannot be cast to java.lang.Number
+      Argument at index '0' couldn't be casted to type 'kotlin.Int' (received 'String').
+      → Caused by: java.lang.ClassCastException: java.lang.String cannot be cast to java.lang.Number
       """.trimIndent()
     ) {
       method.call(


### PR DESCRIPTION
# Why

Closes ENG-2803.

# How

Added a `DecoreatedError` and `errorDecorator` helper which allows you to chain multiple exceptions. This allows us to provide more readable error messages. For instance, if we couldn't convert a field in the record, you would an error looking like this:
```
Cannot call `f2` from the `dummy-1`.
caused by: Cannot obtain `0` parameter. Tried to cast `Map` to `expo.modules.kotlin.MyRecord`.
caused by: Cannot create a record of the type: `expo.modules.kotlin.MyRecord`.
caused by: Cannot obtain `string` field. Tried to cast `Number` to kotlin.String`.
caused by: java.lang.ClassCastException: java.lang.Double cannot be cast to java.lang.String
```
 instead of:
```
java.lang.ClassCastException: java.lang.Double cannot be cast to java.lang.String
```

Also, I've changed one important thing. The majority of our API won't reject a Promise, but instead, it will throw an exception. 
This change doesn't affect users, cause we still convert exceptions into promise rejection, but we are doing it in the `KotlinInteropModuleRegistry`. 

> Note:
This PR adds an error chaining only to a method call - not to props. I will do it in a separate PR.

# Test Plan

- unit tests ✅
