### PR TITLE
[module-template] Prevent publish-package rewrite the ejs versions

### DIFF
--- a/packages/expo-module-template/android/build.gradle
+++ b/packages/expo-module-template/android/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'maven'
 
 group = '<%- project.package %>'
-version = '10.2.0'
+version = '<%- project.version %>'
 
 buildscript {
   // Simple helper that allows the root project to override versions declared by this library.
@@ -62,7 +62,7 @@ android {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 30)
     versionCode 1
-    versionName "10.2.0"
+    versionName "<%- project.version %>"
   }
   lintOptions {
     abortOnError false

--- a/tools/src/publish-packages/tasks/updateAndroidProjects.ts
+++ b/tools/src/publish-packages/tasks/updateAndroidProjects.ts
@@ -31,6 +31,11 @@ export const updateAndroidProjects = new Task<TaskArgs>(
         continue;
       }
 
+      // the ejs template versions are not necessary to update
+      if (pkg.packageName === 'expo-module-template') {
+        continue;
+      }
+
       const relativeGradlePath = path.relative(EXPO_DIR, gradlePath);
 
       logger.log('  ', `Updating ${yellow('version')} in ${magenta(relativeGradlePath)}`);

--- a/tools/src/publish-packages/tasks/updateAndroidProjects.ts
+++ b/tools/src/publish-packages/tasks/updateAndroidProjects.ts
@@ -31,7 +31,7 @@ export const updateAndroidProjects = new Task<TaskArgs>(
         continue;
       }
 
-      // the ejs template versions are not necessary to update
+      // skip updating versions in the template project
       if (pkg.packageName === 'expo-module-template') {
         continue;
       }


### PR DESCRIPTION
# Why

the ejs template be rewrote from publish-package: https://github.com/expo/expo/commit/c87080dbe1d7cefd66a9f959c090ff1a2d2ab26d

# How

- revert the ejs versions
- add `expo-module-template` as exclusion in publish-package tool

# Test Plan

keep only `updateAndroidProjects` in `publishPackagesPipeline` and run `et pp -D expo-module-template`

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
