### PR TITLE
Guess the device language on iOS rather than using the app-specific lang

### DIFF
--- a/packages/expo-localization/CHANGELOG.md
+++ b/packages/expo-localization/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Guess the device language on iOS rather than using the app-specific language.
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/expo-localization/CHANGELOG.md
+++ b/packages/expo-localization/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🛠 Breaking changes
 
-- Guess the device language on iOS rather than using the app-specific language.
+- Guess the device language on iOS rather than using the app-specific language. ([#15807](https://github.com/expo/expo/pull/15807) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🎉 New features
 

--- a/packages/expo-localization/ios/LocalizationModule.swift
+++ b/packages/expo-localization/ios/LocalizationModule.swift
@@ -15,16 +15,28 @@ public class LocalizationModule: Module {
       return Self.getCurrentLocalization()
     }
   }
+  
+  // If the application isn't manually localized for the device language then the
+  // native `Locale.current` will fallback on using English US
+  // [cite](https://stackoverflow.com/questions/48136456/locale-current-reporting-wrong-language-on-device).
+  // This method will attempt to return the locale that the device is using regardless of the app,
+  // providing better parity across platforms.
+  static func getPreferredLocale() -> Locale {
+      guard let preferredIdentifier = Locale.preferredLanguages.first else {
+          return Locale.current
+      }
+      return Locale(identifier: preferredIdentifier)
+  }
 
   static func getCurrentLocalization() -> [String: Any?] {
-    let locale = Locale.current
+    let locale = getPreferredLocale()
     let languageCode = locale.languageCode ?? "en"
     var languageIds = Locale.preferredLanguages
 
     if languageIds.isEmpty {
       languageIds.append("en-US")
     }
-
+    
     return [
       "currency": locale.currencyCode ?? "USD",
       "decimalSeparator": locale.decimalSeparator ?? ".",

--- a/packages/expo-localization/ios/LocalizationModule.swift
+++ b/packages/expo-localization/ios/LocalizationModule.swift
@@ -36,7 +36,6 @@ public class LocalizationModule: Module {
     if languageIds.isEmpty {
       languageIds.append("en-US")
     }
-    
     return [
       "currency": locale.currencyCode ?? "USD",
       "decimalSeparator": locale.decimalSeparator ?? ".",


### PR DESCRIPTION
# Why

- fix https://github.com/expo/expo/issues/12737

I thought about maybe adding a "device" locale and "app" locale system but given that web and Android don't appear to have this distinction, it didn't seem very important.

Further, we may want to add something like `isLayoutRTL` in the future, and expose a native function like `isLocaleRTL(locale: string): Promise<boolean>`:
```swift
var isLayoutRTL = false
EXUtilities.performSynchronously {
  isLayoutRTL = UIApplication.shared.userInterfaceLayoutDirection == UIUserInterfaceLayoutDirection.rightToLeft
}
```

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

- https://stackoverflow.com/a/48138683/4047926

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- In a project, change the Simulator language to "Hebrew" in the device settings, then print out:
```js
import { isRTL, getLocalizationAsync } from "expo-localization";
import { StyleSheet, Text, I18nManager, View } from "react-native";

export default function App() {
  getLocalizationAsync().then(console.log);
  return (
    <View style={styles.container}>
      <Text style={styles.paragraph}>isRTL: {isRTL ? "true" : "false"}</Text>
      <Text style={styles.paragraph}>
        RN isRTL: {I18nManager.isRTL ? "true" : "false"}
      </Text>
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    justifyContent: "center",
    backgroundColor: "#ecf0f1",
    padding: 8,
  },
  paragraph: {
    margin: 24,
    fontSize: 18,
    fontWeight: "bold",
    textAlign: "center",
  },
});

```

- The expo RTL should be true, the RN one can sometimes be true and sometimes be false.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
