### PR TITLE
[docs] add section on project transfer and account rename

### DIFF
--- a/docs/pages/accounts/account-types.md
+++ b/docs/pages/accounts/account-types.md
@@ -24,8 +24,9 @@ Common situations where Organizations are useful:
 | **Create Projects**                                                 | X                 | X            |
 | **Build projects to submit to App Store and Play Store**            | X                 | X            |
 | **Release bug fixes with updates**                                  | X                 | X            |
+| **Transfer control of individual projects to another user**         | Beta              | Beta         |
+| **Transfer control of all projects to another user**                |                   | X            |
 | **Programmatic access with limited privileges**                     |                   | X            |
-| **Transfer control of project to another user**                     |                   | X            |
 | **Designate multiple users who have complete control of a project** |                   | X            |
 
 ### Creating New Organizations
@@ -49,3 +50,17 @@ We have taken a lot of care to make sure that all of the functionality that you 
 - Any integrations using your personal access token or webhooks will continue to operate.
 - Your subscription to Developer Services will continue without interruption.
 - Your production apps will continue to operate without interruption.
+
+### Renaming an Account
+
+> ⚠️ This feature is in private beta, please email support@expo.dev with the name of the Personal Account or Organization you would like to rename to get access.
+
+If you aren't happy with the name you originally chose for your account, you may choose a new name a limited number of times. Simply visit [the account settings page](https://expo.dev/accounts/[account]/settings) and follow the prompts under **Rename Account**.
+
+### Transferring Projects Between Accounts
+
+> ⚠️ This feature is in private beta, please email support@expo.dev with the names of the Personal Accounts or Organizations you would like to transfer the project to and from to get access.
+
+If you need to transfer a project between your Personal Account or Organzions you are an Owner of, you can do so by visiting [the project overview page](https://expo.dev/accounts/[account]/projects/[project]) and following the prompts under **Transfer Project**.
+
+> 💡 If you need to transfer a project from your account (`source`) to an Organization (`destination`) you are not the Owner of, you can create a new Organization (`escrow`) to complete the transfer without Owner access on the destination account. You can and the Owner to the `destination` account can safely share Owner access on the `escrow` account.

--- a/docs/pages/accounts/account-types.md
+++ b/docs/pages/accounts/account-types.md
@@ -63,4 +63,4 @@ If you aren't happy with the name you originally chose for your account, you may
 
 If you need to transfer a project between your Personal Account or Organzions you are an Owner of, you can do so by visiting [the project overview page](https://expo.dev/accounts/[account]/projects/[project]) and following the prompts under **Transfer Project**.
 
-> 💡 If you need to transfer a project from your account (`source`) to an Organization (`destination`) you are not the Owner of, you can create a new Organization (`escrow`) to complete the transfer without Owner access on the destination account. You can and the Owner to the `destination` account can safely share Owner access on the `escrow` account.
+> 💡 If you need to transfer a project from your account (`source`) to an Organization (`destination`) you are not the Owner of, you can create a new Organization (`escrow`) to complete the transfer without Owner access on the destination account. You can add the Owner to the `destination` account can safely share Owner access on the `escrow` account.


### PR DESCRIPTION
# Why

So users know how to request access to and use project transfer functionality

# How

Added descriptions of functionality, links to where to access, and a call out on how to request access while in beta

# Test Plan

`yarn dev` and follow links