### PR TITLE
Fix metro configuration for node module resolution

### DIFF
--- a/docs/pages/guides/monorepos.md
+++ b/docs/pages/guides/monorepos.md
@@ -86,7 +86,7 @@ const config = getDefaultConfig(projectRoot);
 // 1. Watch all files within the monorepo
 config.watchFolders = [workspaceRoot];
 // 2. Let Metro know where to resolve packages, and in what order
-config.resolver.nodeModulesPath = [
+config.resolver.nodeModulesPaths = [
   path.resolve(projectRoot, 'node_modules'),
   path.resolve(workspaceRoot, 'node_modules'),
 ];


### PR DESCRIPTION
Thank you to https://pt.stackoverflow.com/a/536982/272012

# Why

Monorepos as per instructions are broken.

# How

Have a working expo app in a yarn workspaces monorepo.

# Test Plan

You can follow the instructions, before and after the change and see the results when you try and run it in a sim

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
