### PR TITLE
[ios] Introduce the concept of chainable exceptions

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -12,6 +12,7 @@
 - The `ModuleDefinition` will use class name if the `name` component wasn't provided in Sweet API on Android. ([#15738](https://github.com/expo/expo/pull/15738) by [@lukmccall](https://github.com/lukmccall))
 - Added `onViewDestroys` component to the `ViewManager` in Sweet API on Android. ([#15740](https://github.com/expo/expo/pull/15740) by [@lukmccall](https://github.com/lukmccall))
 - Added shortened `constants` component that takes `vargs Pair<String, Any?>` as an argument in Sweet API on Android. ([#15742](https://github.com/expo/expo/pull/15742) by [@lukmccall](https://github.com/lukmccall))
+- Introduced the concept of chainable exceptions in Sweet API on iOS. ([#15813](https://github.com/expo/expo/pull/15813) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/Swift/Exceptions/ChainableException.swift
+++ b/packages/expo-modules-core/ios/Swift/Exceptions/ChainableException.swift
@@ -18,6 +18,11 @@ public protocol ChainableException: Error, AnyObject {
    Sets the direct cause of the exception and returns itself.
    */
   func causedBy(_ error: Error) -> Self
+
+  /**
+   Tells whether any of the cause in chain is of given type.
+   */
+  func isCausedBy<ErrorType: Error>(_ errorType: ErrorType.Type) -> Bool
 }
 
 public extension ChainableException {
@@ -32,5 +37,15 @@ public extension ChainableException {
   func causedBy(_ error: Error) -> Self {
     cause = error
     return self
+  }
+
+  func isCausedBy<ErrorType: Error>(_ errorType: ErrorType.Type) -> Bool {
+    if cause is ErrorType {
+      return true
+    }
+    if let cause = cause as? ChainableException {
+      return cause.isCausedBy(errorType)
+    }
+    return false
   }
 }

--- a/packages/expo-modules-core/ios/Swift/Exceptions/ChainableException.swift
+++ b/packages/expo-modules-core/ios/Swift/Exceptions/ChainableException.swift
@@ -1,0 +1,36 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+/**
+ An exception that may have been caused by another error.
+ */
+public protocol ChainableException: Error, AnyObject {
+  /**
+   The direct cause of the exception.
+   */
+  var cause: Error? { get set }
+
+  /**
+   The first error that started the chain of exceptions.
+   */
+  var rootCause: Error? { get }
+
+  /**
+   Sets the direct cause of the exception and returns itself.
+   */
+  func causedBy(_ error: Error) -> Self
+}
+
+public extension ChainableException {
+  var rootCause: Error? {
+    if let cause = cause as? ChainableException {
+      return cause.rootCause ?? cause
+    }
+    return cause
+  }
+
+  @discardableResult
+  func causedBy(_ error: Error) -> Self {
+    cause = error
+    return self
+  }
+}

--- a/packages/expo-modules-core/ios/Swift/Exceptions/CodedError.swift
+++ b/packages/expo-modules-core/ios/Swift/Exceptions/CodedError.swift
@@ -18,7 +18,7 @@ public extension CodedError {
    */
   var code: String {
     let className = String(describing: type(of: self))
-      .replacingOccurrences(of: #"(Error)?(<.*>)?$"#, with: "", options: .regularExpression)
+      .replacingOccurrences(of: #"(Error|Exception)?(<.*>)?$"#, with: "", options: .regularExpression)
     let regex = try! NSRegularExpression(pattern: "(.)([A-Z])", options: [])
     let range = NSRange(location: 0, length: className.count)
 

--- a/packages/expo-modules-core/ios/Swift/Exceptions/Exception.swift
+++ b/packages/expo-modules-core/ios/Swift/Exceptions/Exception.swift
@@ -13,16 +13,16 @@ open class Exception: CodedError, ChainableException, CustomStringConvertible, C
   }
 
   /**
-   The location in code where the exception was created.
+   The origin in code where the exception was created.
    */
-  open var location: ExceptionLocation
+  open var origin: ExceptionOrigin
 
   /**
    The default initializer that captures the place in the code where the exception was created.
    - Warning: Call it only without arguments!
    */
   public init(file: String = #fileID, line: UInt = #line, function: String = #function) {
-    self.location = ExceptionLocation(file: file, line: line, function: function)
+    self.origin = ExceptionOrigin(file: file, line: line, function: function)
   }
 
   // MARK: ChainableException
@@ -38,7 +38,7 @@ open class Exception: CodedError, ChainableException, CustomStringConvertible, C
   // MARK: CustomDebugStringConvertible
 
   open var debugDescription: String {
-    let debugDescription = "\(name): \(reason) (at \(location.file):\(location.line))"
+    let debugDescription = "\(name): \(reason) (at \(origin.file):\(origin.line))"
     return concatDescription(debugDescription, withCause: cause, debug: true)
   }
 }

--- a/packages/expo-modules-core/ios/Swift/Exceptions/Exception.swift
+++ b/packages/expo-modules-core/ios/Swift/Exceptions/Exception.swift
@@ -1,0 +1,62 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+open class Exception: CodedError, ChainableException, CustomStringConvertible, CustomDebugStringConvertible {
+  open var name: String {
+    return String(describing: Self.self)
+  }
+
+  /**
+   String describing the reason of the exception.
+   */
+  open var reason: String {
+    "undefined reason"
+  }
+
+  /**
+   The location in code where the exception was created.
+   */
+  open var location: ExceptionLocation
+
+  /**
+   The default initializer that captures the place in the code where the exception was created.
+   - Warning: Call it only without arguments!
+   */
+  public init(file: String = #fileID, line: UInt = #line, function: String = #function) {
+    self.location = ExceptionLocation(file: file, line: line, function: function)
+  }
+
+  // MARK: ChainableException
+
+  open var cause: Error?
+
+  // MARK: CustomStringConvertible
+
+  open var description: String {
+    return concatDescription(reason, withCause: cause, debug: false)
+  }
+
+  // MARK: CustomDebugStringConvertible
+
+  open var debugDescription: String {
+    let debugDescription = "\(name): \(reason) (at \(location.file):\(location.line))"
+    return concatDescription(debugDescription, withCause: cause, debug: true)
+  }
+}
+
+/**
+ Concatenates the exception description with its cause description.
+ */
+private func concatDescription(_ description: String, withCause cause: Error?, debug: Bool = false) -> String {
+  let causeSeparator = "\n→ Caused by: "
+  switch cause {
+  case let cause as Exception:
+    return description + causeSeparator + (debug ? cause.debugDescription : cause.description)
+  case let cause as CodedError:
+    // `CodedError` is deprecated but we need to provide backwards compatibility as some modules already used it.
+    return description + causeSeparator + cause.description
+  case let cause?:
+    return description + causeSeparator + cause.localizedDescription
+  default:
+    return description
+  }
+}

--- a/packages/expo-modules-core/ios/Swift/Exceptions/ExceptionLocation.swift
+++ b/packages/expo-modules-core/ios/Swift/Exceptions/ExceptionLocation.swift
@@ -1,0 +1,28 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+/**
+ Represents the place in code where the exception was created.
+ */
+public struct ExceptionLocation: CustomStringConvertible {
+  /**
+   The path to the file in which the exception was created.
+   */
+  let file: String
+
+  /**
+   The line number on which the exception was created.
+   */
+  let line: UInt
+
+  /**
+   The name (selector) of the declaration in which the exception was created.
+   */
+  let function: String
+
+  /**
+   Stringified representation of the exception location.
+   */
+  public var description: String {
+    "at \(file):\(line) in \(function)"
+  }
+}

--- a/packages/expo-modules-core/ios/Swift/Exceptions/ExceptionOrigin.swift
+++ b/packages/expo-modules-core/ios/Swift/Exceptions/ExceptionOrigin.swift
@@ -3,7 +3,7 @@
 /**
  Represents the place in code where the exception was created.
  */
-public struct ExceptionLocation: CustomStringConvertible {
+public struct ExceptionOrigin: CustomStringConvertible {
   /**
    The path to the file in which the exception was created.
    */
@@ -20,7 +20,7 @@ public struct ExceptionLocation: CustomStringConvertible {
   let function: String
 
   /**
-   Stringified representation of the exception location.
+   Stringified representation of the exception origin.
    */
   public var description: String {
     "at \(file):\(line) in \(function)"

--- a/packages/expo-modules-core/ios/Swift/Exceptions/GenericException.swift
+++ b/packages/expo-modules-core/ios/Swift/Exceptions/GenericException.swift
@@ -1,0 +1,20 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+/**
+ The exception that needs some additional parameters to be best described.
+ */
+open class GenericException<ParamsType>: Exception {
+  /**
+   The additional parameters passed to the initializer.
+   */
+  public let params: ParamsType
+
+  /**
+   The default initializer that takes a tuple of params and captures the place in the code where the exception was created.
+   - Warning: Call it only with one argument!
+   */
+  public init(_ params: ParamsType, file: String = #fileID, line: UInt = #line, function: String = #function) {
+    self.params = params
+    super.init(file: file, line: line, function: function)
+  }
+}

--- a/packages/expo-modules-core/ios/Swift/Functions/ConcreteFunction.swift
+++ b/packages/expo-modules-core/ios/Swift/Functions/ConcreteFunction.swift
@@ -113,12 +113,12 @@ internal class InvalidArgsNumberException: GenericException<(received: Int, expe
 
 internal class ArgumentCastException: GenericException<(index: Int, type: AnyArgumentType)> {
   override var reason: String {
-    "Argument at index \"\(params.index)\" couldn't be casted to type \"\(params.type.description)\"."
+    "Argument at index '\(params.index)' couldn't be casted to type '\(params.type.description)'."
   }
 }
 
 internal class FunctionCallException: GenericException<String> {
   override var reason: String {
-    "Call to function '\(params)' has been rejected"
+    "Call to function '\(params)' has been rejected."
   }
 }

--- a/packages/expo-modules-core/ios/Swift/Records/Field.swift
+++ b/packages/expo-modules-core/ios/Swift/Records/Field.swift
@@ -76,27 +76,30 @@ public final class Field<Type>: AnyFieldInternal {
    */
   internal func set(_ newValue: Any?) throws {
     if newValue == nil && (!isOptional || isRequired) {
-      throw FieldRequiredError(fieldKey: key!)
+      throw FieldRequiredException(key!)
     }
-    guard let value = try? fieldType.cast(newValue) as? Type else {
-      throw FieldInvalidTypeError(fieldKey: key!, value: newValue, desiredType: Type.self)
+    do {
+      if let value = try fieldType.cast(newValue) as? Type {
+        wrappedValue = value
+      }
+    } catch {
+      throw FieldInvalidTypeException((fieldKey: key!, value: newValue, desiredType: Type.self)).causedBy(error)
     }
-    wrappedValue = value
   }
 }
 
-internal struct FieldRequiredError: CodedError {
-  let fieldKey: String
-  var description: String {
-    "Value for field `\(fieldKey)` is required, got `nil`"
+internal class FieldRequiredException: GenericException<String> {
+  override var reason: String {
+    "Value for field '\(params)' is required, got nil."
   }
 }
 
-internal struct FieldInvalidTypeError: CodedError {
-  let fieldKey: String
-  let value: Any?
-  let desiredType: Any.Type
-  var description: String {
-    "Cannot cast value `\(String(describing: value!))` (\(type(of: value!))) for field `\(fieldKey)` (\(String(describing: desiredType)))"
+internal class FieldInvalidTypeException: GenericException<(fieldKey: String, value: Any?, desiredType: Any.Type)> {
+  override var reason: String {
+    let value = String(describing: params.value!)
+    let valueType = type(of: params.value!)
+    let desiredType = String(describing: params.desiredType)
+
+    return "Cannot cast value '\(value)' (\(valueType)) for field '\(params.fieldKey)' (\(desiredType))"
   }
 }

--- a/packages/expo-modules-core/ios/Tests/ExceptionsSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/ExceptionsSpec.swift
@@ -1,0 +1,112 @@
+// Copyright 2021-present 650 Industries. All rights reserved.
+
+import Quick
+import Nimble
+
+@testable import ExpoModulesCore
+
+final class ExceptionsSpec: QuickSpec {
+  override func spec() {
+    it("has name") {
+      let error = TestException()
+      expect(error.name) == "TestException"
+    }
+
+    it("has code") {
+      let error = TestException()
+      expect(error.code) == "ERR_TEST"
+    }
+
+    it("has reason") {
+      let error = TestException()
+      expect(error.reason) == "This is the test exception"
+    }
+
+    it("can be chained once") {
+      func throwable() throws {
+        do {
+          throw TestExceptionCause()
+        } catch {
+          throw TestException().causedBy(error)
+        }
+      }
+      expect { try throwable() }.to(throwError { error in
+        testChainedExceptionTypes(error: error, types: [TestException.self, TestExceptionCause.self])
+      })
+    }
+
+    it("can be chained twice") {
+      func throwable() throws {
+        do {
+          do {
+            throw TestExceptionCause()
+          } catch {
+            throw TestExceptionCause().causedBy(error)
+          }
+        } catch {
+          throw TestException().causedBy(error)
+        }
+      }
+      expect { try throwable() }.to(throwError { error in
+        testChainedExceptionTypes(error: error, types: [TestException.self, TestExceptionCause.self, TestExceptionCause.self])
+      })
+    }
+
+    it("includes cause description") {
+      func throwable() throws {
+        do {
+          throw TestExceptionCause()
+        } catch {
+          throw TestException().causedBy(error)
+        }
+      }
+      expect { try throwable() }.to(throwError { error in
+        if let error = error as? TestException, let cause = error.cause as? TestExceptionCause {
+          expect(error.description).to(contain(cause.description))
+        } else {
+          fail("Error and its cause are not of expected types.")
+        }
+      })
+    }
+
+    it("has root cause") {
+      let a = TestException()
+      let b = TestException().causedBy(a)
+      let c = TestException().causedBy(b)
+
+      expect(c.rootCause) === a
+    }
+  }
+}
+
+class TestException: Exception {
+  override var reason: String {
+    "This is the test exception"
+  }
+}
+
+class TestExceptionCause: Exception {
+  override var reason: String {
+    "This is the cause of the test exception"
+  }
+}
+
+/**
+ Tests whether the exception chain matches given types and their order.
+ */
+private func testChainedExceptionTypes(error: Error, types: [Error.Type]) {
+  var next: Error? = error
+
+  for errorType in types {
+    let expectedErrorTypeName = String(describing: errorType)
+    let currentErrorTypeName = String(describing: type(of: next!))
+
+    expect(currentErrorTypeName).to(equal(expectedErrorTypeName), description: "The cause is not of type \(expectedErrorTypeName)")
+
+    if let chainableException = next as? ChainableException {
+      next = chainableException.cause
+    } else {
+      next = nil
+    }
+  }
+}

--- a/packages/expo-modules-core/ios/Tests/FunctionSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/FunctionSpec.swift
@@ -152,9 +152,8 @@ class FunctionSpec: QuickSpec {
         // Function expects one argument, let's give it more.
         .call(function: functionName, args: [1, 2]) { _, error in
           expect(error).notTo(beNil())
-          expect(error).to(beAKindOf(InvalidArgsNumberException.self))
-          expect(error?.code).to(equal("ERR_INVALID_ARGS_NUMBER"))
-          expect(error?.description).to(equal(InvalidArgsNumberException((received: 2, expected: 1)).description))
+          expect(error).to(beAKindOf(FunctionCallException.self))
+          expect((error as! Exception).isCausedBy(InvalidArgsNumberException.self)) == true
           done()
         }
       }
@@ -170,9 +169,8 @@ class FunctionSpec: QuickSpec {
         // Function expects a string, let's give it a number.
         .call(function: functionName, args: [1]) { value, error in
           expect(error).notTo(beNil())
-          expect(error).to(beAKindOf(Conversions.CastingError<String>.self))
-          expect(error?.code).to(equal("ERR_CASTING_FAILED"))
-          expect(error?.description).to(equal(Conversions.CastingError<String>(value: 1).description))
+          expect(error).to(beAKindOf(FunctionCallException.self))
+          expect((error as! Exception).isCausedBy(Conversions.CastingError<String>.self)) == true
           done()
         }
       }

--- a/packages/expo-modules-core/ios/Tests/FunctionSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/FunctionSpec.swift
@@ -152,9 +152,9 @@ class FunctionSpec: QuickSpec {
         // Function expects one argument, let's give it more.
         .call(function: functionName, args: [1, 2]) { _, error in
           expect(error).notTo(beNil())
-          expect(error).to(beAKindOf(InvalidArgsNumberError.self))
+          expect(error).to(beAKindOf(InvalidArgsNumberException.self))
           expect(error?.code).to(equal("ERR_INVALID_ARGS_NUMBER"))
-          expect(error?.description).to(equal(InvalidArgsNumberError(received: 2, expected: 1).description))
+          expect(error?.description).to(equal(InvalidArgsNumberException((received: 2, expected: 1)).description))
           done()
         }
       }

--- a/packages/expo-modules-core/ios/Tests/RecordSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/RecordSpec.swift
@@ -37,14 +37,9 @@ class RecordSpec: QuickSpec {
         @Field(.required) var a: Int
       }
 
-      do {
-        _ = try TestRecord(from: [:])
-        fail()
-      } catch let error as CodedError {
+      expect { try TestRecord(from: [:]) }.to(throwError { error in
         expect(error).to(beAKindOf(FieldRequiredException.self))
-        expect(error.code).to(equal("ERR_FIELD_REQUIRED"))
-        expect(error.description).to(equal(FieldRequiredException("a").description))
-      }
+      })
     }
 
     it("throws when casting is not possible") {
@@ -53,14 +48,9 @@ class RecordSpec: QuickSpec {
       }
       let dict = ["a": "try with String instead of Int"]
 
-      do {
-        _ = try TestRecord(from: dict)
-        fail()
-      } catch let error as CodedError {
+      expect { try TestRecord(from: dict) }.to(throwError { error in
         expect(error).to(beAKindOf(FieldInvalidTypeException.self))
-        expect(error.code).to(equal("ERR_FIELD_INVALID_TYPE"))
-        expect(error.description).to(equal(FieldInvalidTypeException((fieldKey: "a", value: dict["a"], desiredType: Int.self)).description))
-      }
+      })
     }
   }
 }

--- a/packages/expo-modules-core/ios/Tests/RecordSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/RecordSpec.swift
@@ -41,9 +41,9 @@ class RecordSpec: QuickSpec {
         _ = try TestRecord(from: [:])
         fail()
       } catch let error as CodedError {
-        expect(error).to(beAKindOf(FieldRequiredError.self))
+        expect(error).to(beAKindOf(FieldRequiredException.self))
         expect(error.code).to(equal("ERR_FIELD_REQUIRED"))
-        expect(error.description).to(equal(FieldRequiredError(fieldKey: "a").description))
+        expect(error.description).to(equal(FieldRequiredException("a").description))
       }
     }
 
@@ -57,9 +57,9 @@ class RecordSpec: QuickSpec {
         _ = try TestRecord(from: dict)
         fail()
       } catch let error as CodedError {
-        expect(error).to(beAKindOf(FieldInvalidTypeError.self))
+        expect(error).to(beAKindOf(FieldInvalidTypeException.self))
         expect(error.code).to(equal("ERR_FIELD_INVALID_TYPE"))
-        expect(error.description).to(equal(FieldInvalidTypeError(fieldKey: "a", value: dict["a"], desiredType: Int.self).description))
+        expect(error.description).to(equal(FieldInvalidTypeException((fieldKey: "a", value: dict["a"], desiredType: Int.self)).description))
       }
     }
   }


### PR DESCRIPTION
# Why

Since we've moved arguments validation from the module's functions to the core, the rejection errors are not always useful to narrow down the real reason of failure. One thing (probably only?) I like in Java is the exception chaining.

Also, Swift uses `Error` protocol to represent any kind of failures, but in some languages (including Java/Kotlin) the error means something that breaks the application that it cannot continue to run (out of memory, dividing by zero). On the other side, the exception means something that can be and should be handled by the developer.

# How

- Created base `Exception` class that other exceptions can inherit from
- `GenericException` for parametrized exceptions
- The exceptions can be chained using `causedBy` function
- Migrated some core coded errors to exceptions
- Added unit tests

# Test Plan

Demo of `console.error(err)` on the JS side:
![Screen Shot 2022-01-06 at 10 40 03](https://user-images.githubusercontent.com/1714764/148364232-7b735979-80f4-470f-9405-b282bd75a251.png)
