### PR TITLE
[ios][image-manipulator] Fix creating the directory for image manipulation results

### DIFF
--- a/packages/expo-image-manipulator/ios/ImageManipulatorModule.swift
+++ b/packages/expo-image-manipulator/ios/ImageManipulatorModule.swift
@@ -106,7 +106,7 @@ public class ImageManipulatorModule: Module {
     let filename = UUID().uuidString.appending(options.format.fileExtension)
     let fileUrl = directory.appendingPathComponent(filename)
 
-    fileSystem.ensureDirExists(withPath: directory.absoluteString)
+    fileSystem.ensureDirExists(withPath: directory.path)
 
     guard let data = imageData(from: image, format: options.format, compression: options.compress) else {
       throw CorruptedImageDataError()


### PR DESCRIPTION
# Why

When I've been testing chainable exceptions, I noticed that if the ImageManipulator folder for its results was not created yet, the `ensureDirExists` function failed because it expects the path instead of the absolute URL string (with `file://`).

# How

Changed `absoluteString` to `path`

# Test Plan

Tested by manipulating an image on the device where `ImageManipulator` cache directory didn't exist.

I'm not adding changelog entry because it fixes something that was introduced in unpublished changes from #15277 