### PR TITLE
[ios][core] Allow accessing RCTBridge from the modules

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Allow accessing `RCTBridge` from the modules on iOS.
+- Allow accessing `RCTBridge` from the modules on iOS. ([#15816](https://github.com/expo/expo/pull/15816) by [@tsapeta](https://github.com/tsapeta))
 - Added support for native callbacks through the view props in Sweet API on iOS. ([#15731](https://github.com/expo/expo/pull/15731) by [@tsapeta](https://github.com/tsapeta))
 - Added support for native callbacks through the view props in Sweet API on Android. ([#15743](https://github.com/expo/expo/pull/15743) by [@lukmccall](https://github.com/lukmccall))
 - The `ModuleDefinition` will use class name if the `name` component wasn't provided in Sweet API on Android. ([#15738](https://github.com/expo/expo/pull/15738) by [@lukmccall](https://github.com/lukmccall))

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🎉 New features
 
+- Allow accessing `RCTBridge` from the modules on iOS.
 - Added support for native callbacks through the view props in Sweet API on iOS. ([#15731](https://github.com/expo/expo/pull/15731) by [@tsapeta](https://github.com/tsapeta))
 - Added support for native callbacks through the view props in Sweet API on Android. ([#15743](https://github.com/expo/expo/pull/15743) by [@lukmccall](https://github.com/lukmccall))
 - The `ModuleDefinition` will use class name if the `name` component wasn't provided in Sweet API on Android. ([#15738](https://github.com/expo/expo/pull/15738) by [@lukmccall](https://github.com/lukmccall))

--- a/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.mm
+++ b/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.mm
@@ -161,6 +161,7 @@ RCT_EXPORT_MODULE(NativeUnimoduleProxy)
       });
     }
   }
+  [_swiftInteropBridge setReactBridge:bridge];
   _bridge = bridge;
 }
 

--- a/packages/expo-modules-core/ios/Swift/AppContext.swift
+++ b/packages/expo-modules-core/ios/Swift/AppContext.swift
@@ -14,6 +14,11 @@ public final class AppContext {
   public private(set) var legacyModuleRegistry: EXModuleRegistry?
 
   /**
+   React bridge of the context's app.
+   */
+  public internal(set) weak var reactBridge: RCTBridge?
+
+  /**
    Designated initializer without modules provider.
    */
   public init() {

--- a/packages/expo-modules-core/ios/Swift/SwiftInteropBridge.swift
+++ b/packages/expo-modules-core/ios/Swift/SwiftInteropBridge.swift
@@ -1,4 +1,7 @@
+// Copyright 2021-present 650 Industries. All rights reserved.
+
 import Foundation
+import React
 
 @objc
 public final class SwiftInteropBridge: NSObject {
@@ -17,6 +20,11 @@ public final class SwiftInteropBridge: NSObject {
   @objc
   public func hasModule(_ moduleName: String) -> Bool {
     return registry.has(moduleWithName: moduleName)
+  }
+
+  @objc
+  public func setReactBridge(_ reactBridge: RCTBridge) {
+    appContext.reactBridge = reactBridge
   }
 
   @objc


### PR DESCRIPTION
# Why

There was no easy way to access `RCTBridge` from the modules.

# How

The `EXNativeModulesProxy` sets the bridge on `AppContext` as soon as it receives the bridge instance.

# Test Plan

Added breakpoint on one of the native module's function and confirmed `self.appContext.reactBridge` is correctly set.
