### PR TITLE
[docs] update dev client installation instructions to be based on SDK 44 template

### DIFF
--- a/docs/public/static/diffs/client/app-delegate-expo-modules.diff
+++ b/docs/public/static/diffs/client/app-delegate-expo-modules.diff
@@ -2,10 +2,10 @@ diff --git a/ios/expodevexample/AppDelegate.m b/ios/expodevexample/AppDelegate.m
 index 837259e..7e619d8 100644
 --- a/ios/expodevexample/AppDelegate.m
 +++ b/ios/expodevexample/AppDelegate.m
-@@ -11,6 +11,14 @@
- #import <EXSplashScreen/EXSplashScreenService.h>
- #import <UMCore/UMModuleRegistryProvider.h>
- 
+@@ -6,6 +6,14 @@
+ #import <React/RCTLinkingManager.h>
+ #import <React/RCTConvert.h>
+
 +#if defined(EX_DEV_MENU_ENABLED)
 +@import EXDevMenu;
 +#endif
@@ -17,14 +17,11 @@ index 837259e..7e619d8 100644
  #if defined(FB_SONARKIT_ENABLED) && __has_include(<FlipperKit/FlipperClient.h>)
  #import <FlipperKit/FlipperClient.h>
  #import <FlipperKitLayoutPlugin/FlipperKitLayoutPlugin.h>
-@@ -40,7 +40,23 @@ - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(
- #if defined(FB_SONARKIT_ENABLED) && __has_include(<FlipperKit/FlipperClient.h>)
+@@ -33,18 +41,30 @@ static void InitializeFlipper(UIApplication *application) {
    InitializeFlipper(application);
  #endif
--  
-+
+
 +  self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
-+
 +#if defined(EX_DEV_LAUNCHER_ENABLED)
 +  EXDevLauncherController *controller = [EXDevLauncherController sharedInstance];
 +  [controller startWithWindow:self.window delegate:(id<EXDevLauncherControllerDelegate>)self launchOptions:launchOptions];
@@ -39,30 +36,24 @@ index 837259e..7e619d8 100644
 +
 +- (RCTBridge *)initializeReactNativeApp:(NSDictionary *)launchOptions
 +{
-   RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
-   RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge moduleName:@"main" initialProperties:nil];
-   id rootViewBackgroundColor = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"RCTRootViewBackgroundColor"];
-@@ -50,16 +66,13 @@ - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(
-     rootView.backgroundColor = [UIColor whiteColor];
-   }
- 
+   RCTBridge *bridge = [self.reactDelegate createBridgeWithDelegate:self launchOptions:launchOptions];
+   RCTRootView *rootView = [self.reactDelegate createRootViewWithBridge:bridge moduleName:@"main" initialProperties:nil];
+   rootView.backgroundColor = [UIColor whiteColor];
 -  self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
-   UIViewController *rootViewController = [UIViewController new];
+   UIViewController *rootViewController = [self.reactDelegate createRootViewController];
    rootViewController.view = rootView;
    self.window.rootViewController = rootViewController;
    [self.window makeKeyAndVisible];
- 
+
 -  [super application:application didFinishLaunchingWithOptions:launchOptions];
 -
 -  return YES;
-- }
 +  return bridge;
-+}
- 
+  }
+
  - (NSArray<id<RCTBridgeModule>> *)extraModulesForBridge:(RCTBridge *)bridge
- {
-@@ -69,7 +82,11 @@ - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(
- 
+@@ -55,7 +75,11 @@ static void InitializeFlipper(UIApplication *application) {
+
  - (NSURL *)sourceURLForBridge:(RCTBridge *)bridge {
   #ifdef DEBUG
 -  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
@@ -70,35 +61,35 @@ index 837259e..7e619d8 100644
 +    return [[EXDevLauncherController sharedInstance] sourceUrl];
 +  #else
 +    return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
-+  #endif 
++  #endif
   #else
    return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
   #endif
-@@ -77,6 +94,11 @@ - (NSURL *)sourceURLForBridge:(RCTBridge *)bridge {
- 
+@@ -63,6 +87,11 @@ static void InitializeFlipper(UIApplication *application) {
+
  // Linking API
  - (BOOL)application:(UIApplication *)application openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
 +#if defined(EX_DEV_LAUNCHER_ENABLED)
 +  if ([EXDevLauncherController.sharedInstance onDeepLink:url options:options]) {
-+      return true;
++    return true;
 +  }
 +#endif
    return [RCTLinkingManager application:application openURL:url options:options];
  }
- 
-@@ -88,3 +110,15 @@ - (BOOL)application:(UIApplication *)application continueUserActivity:(nonnull N
+
+@@ -74,3 +103,15 @@ static void InitializeFlipper(UIApplication *application) {
  }
- 
+
  @end
 +
 +#if defined(EX_DEV_LAUNCHER_ENABLED)
 +@implementation AppDelegate (EXDevLauncherControllerDelegate)
-+ 
++
 +- (void)devLauncherController:(EXDevLauncherController *)developmentClientController
-+          didStartWithSuccess:(BOOL)success
++    didStartWithSuccess:(BOOL)success
 +{
 +  developmentClientController.appBridge = [self initializeReactNativeApp:[EXDevLauncherController.sharedInstance getLaunchOptions]];
 +}
-+ 
++
 +@end
 +#endif

--- a/docs/public/static/diffs/client/main-activity-and-application-expo-modules.diff
+++ b/docs/public/static/diffs/client/main-activity-and-application-expo-modules.diff
@@ -2,84 +2,65 @@ diff --git a/android/app/src/main/java/com/expodevexample/MainActivity.java b/an
 index ca9e0d1..4ee67d1 100644
 --- a/android/app/src/main/java/com/expodevexample/MainActivity.java
 +++ b/android/app/src/main/java/com/expodevexample/MainActivity.java
-@@ -1,16 +1,18 @@
- package com.expodevexample;
- 
-+import android.content.Intent;
+@@ -2,14 +2,18 @@ package com.expodevexample;
+
+ import android.os.Build;
  import android.os.Bundle;
- 
--import com.facebook.react.ReactActivity;
++import android.content.Intent;
+
+ import com.facebook.react.ReactActivity;
  import com.facebook.react.ReactActivityDelegate;
  import com.facebook.react.ReactRootView;
- import com.swmansion.gesturehandler.react.RNGestureHandlerEnabledRootView;
- 
+
 +import expo.modules.devlauncher.DevLauncherController;
 +import expo.modules.devmenu.react.DevMenuAwareReactActivity;
- import expo.modules.splashscreen.singletons.SplashScreen;
- import expo.modules.splashscreen.SplashScreenImageResizeMode;
- 
+ import expo.modules.ReactActivityDelegateWrapper;
+
 -public class MainActivity extends ReactActivity {
 +public class MainActivity extends DevMenuAwareReactActivity {
++
    @Override
    protected void onCreate(Bundle savedInstanceState) {
-     super.onCreate(savedInstanceState);
-@@ -31,11 +33,21 @@ public class MainActivity extends ReactActivity {
- 
-     @Override
-     protected ReactActivityDelegate createReactActivityDelegate() {
--      return new ReactActivityDelegateWrapper(
--        this,
--        new ReactActivityDelegate(this, getMainComponentName()) {
--          @Override
--          protected ReactRootView createRootView() {
--            return new RNGestureHandlerEnabledRootView(MainActivity.this);
--          }
--      });
-+      return DevLauncherController.wrapReactActivityDelegate(
+     // Set the theme to AppTheme BEFORE onCreate to support
+@@ -30,11 +34,23 @@ public class MainActivity extends ReactActivity {
+
+   @Override
+   protected ReactActivityDelegate createReactActivityDelegate() {
+-    return new ReactActivityDelegateWrapper(this,
+-      new ReactActivityDelegate(this, getMainComponentName())
++    return DevLauncherController.wrapReactActivityDelegate(
++      this,
++      () -> new ReactActivityDelegateWrapper(
 +        this,
-+        () -> new ReactActivityDelegateWrapper(
-+          this,
-+          new ReactActivityDelegate(this, getMainComponentName()) {
-+            @Override
-+            protected ReactRootView createRootView() {
-+              return new RNGestureHandlerEnabledRootView(MainActivity.this);
-+            }
-+          }
-+        )
-+      );
-     }
-+
-+    @Override
-+    public void onNewIntent(Intent intent) {
-+        if (DevLauncherController.tryToHandleIntent(this, intent)) {
-+           return;
-+        }
-+        super.onNewIntent(intent);
-     }
- }
++        new ReactActivityDelegate(this, getMainComponentName())
++      )
+     );
+   }
+
++  @Override
++  public void onNewIntent(Intent intent) {
++    if (DevLauncherController.tryToHandleIntent(this, intent)) {
++      return;
++    }
++    super.onNewIntent(intent);
++  }
 diff --git a/android/app/src/main/java/com/expodevexample/MainApplication.java b/android/app/src/main/java/com/expodevexample/MainApplication.java
 index 78736bf..bce13b9 100644
 --- a/android/app/src/main/java/com/expodevexample/MainApplication.java
 +++ b/android/app/src/main/java/com/expodevexample/MainApplication.java
-@@ -19,6 +19,7 @@ import org.unimodules.adapters.react.ReactModuleRegistryProvider;
- import org.unimodules.core.interfaces.Package;
- import org.unimodules.core.interfaces.SingletonModule;
- import expo.modules.constants.ConstantsPackage;
+@@ -13,6 +13,7 @@ import com.facebook.react.ReactPackage;
+ import com.facebook.soloader.SoLoader;
+
+ import expo.modules.ApplicationLifecycleDispatcher;
 +import expo.modules.devlauncher.DevLauncherController;
- import expo.modules.permissions.PermissionsPackage;
- import expo.modules.filesystem.FileSystemPackage;
- import expo.modules.updates.UpdatesController;
- 
- public class MainApplication extends Application implements ReactApplication {
-@@ -77,6 +78,7 @@ public class MainApplication extends Application implements ReactApplication {
-   @Override
-   public void onCreate() {
+ import expo.modules.ReactNativeHostWrapper;
+
+ import com.facebook.react.bridge.JSIModulePackage;
+@@ -54,6 +55,7 @@ public class MainApplication extends Application implements ReactApplication {
      super.onCreate();
      SoLoader.init(this, /* native exopackage */ false);
 
-@@ -85,6 +87,7 @@ public class MainApplication extends Application implements ReactApplication {
-    
-
 +    DevLauncherController.initialize(this, getReactNativeHost());
      initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
+     ApplicationLifecycleDispatcher.onApplicationCreate(this);
    }


### PR DESCRIPTION
# Why

This updates the dev client installation instructions ("With Expo modules" tab) so the code diffs are based on the SDK 44 project templates rather than older ones. There have been some changes to the template projects due to recent Expo module improvements, so the existing diffs are a bit outdated.

# How

- expo init / expo prebuild
- commit
- yarn add expo-dev-client / expo prebuild --clean
- move a few of the changes around in MainActivity/MainApplication/AppDelegate to make the diffs look nicer
- git diff, copy+paste

# Test Plan

Ran locally, verified everything looks good

<img width="1187" alt="Screen Shot 2022-01-06 at 11 41 18 AM" src="https://user-images.githubusercontent.com/19958240/148441611-7b7755e4-8128-4426-9c0c-0acffbb4259d.png">
<img width="1170" alt="Screen Shot 2022-01-06 at 11 41 32 AM" src="https://user-images.githubusercontent.com/19958240/148441617-7cd36613-716d-4f35-962b-716a8af47ea9.png">
<img width="1202" alt="Screen Shot 2022-01-06 at 11 41 35 AM" src="https://user-images.githubusercontent.com/19958240/148441629-c9893211-81f4-4321-81aa-b751c09588e3.png">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
