### PR TITLE
[gh] add timeouts to unit tests jobs

### DIFF
--- a/.github/workflows/android-instrumentation-tests.yml
+++ b/.github/workflows/android-instrumentation-tests.yml
@@ -25,6 +25,7 @@ concurrency:
 jobs:
   test:
     runs-on: macos-11
+    timeout-minutes: 60
     env:
       NDK_ABI_FILTERS: x86_64
     steps:
@@ -64,6 +65,7 @@ jobs:
         run: sed -i '' 's/^APP_ABI := .*$/APP_ABI := $(if $(NDK_ABI_FILTERS),$(NDK_ABI_FILTERS),$(armeabi-v7a x86 arm64-v8a x86_64))/g' ReactAndroid/src/main/jni/Application.mk
         working-directory: react-native-lab/react-native
       - name: 🎸 Run instrumented unit tests
+        timeout-minutes: 30
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 29

--- a/.github/workflows/android-unit-tests.yml
+++ b/.github/workflows/android-unit-tests.yml
@@ -27,6 +27,7 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-18.04
+    timeout-minutes: 60
     env:
       NDK_ABI_FILTERS: x86_64
     steps:
@@ -74,6 +75,7 @@ jobs:
         working-directory: android
         run: ./gradlew spotlessCheck || { echo '::error Spotless lint failed. Run `./gradlew spotlessApply` to automatically fix formatting.' && exit 1; }
       - name: Run native Android unit tests
+        timeout-minutes: 30
         env:
           ANDROID_NDK_HOME: /usr/local/lib/android/sdk/ndk/19.2.5345600/
         run: expotools native-unit-tests --platform android

--- a/.github/workflows/ios-unit-tests.yml
+++ b/.github/workflows/ios-unit-tests.yml
@@ -37,6 +37,7 @@ concurrency:
 jobs:
   build:
     runs-on: macos-11
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
         with:
@@ -98,4 +99,5 @@ jobs:
         run: pod install
         working-directory: apps/bare-expo/ios
       - name: Run native iOS unit tests
+        timeout-minutes: 45
         run: expotools native-unit-tests --platform ios


### PR DESCRIPTION
# Why

https://github.com/expo/expo/runs/4723924017?check_suite_focus=true -- I think this was a fluke (this job seems to be running fine on other commits) but probably a good idea to add shorter timeouts to these jobs anyway.

# How

Added shorter timeouts to all the native unit tests jobs, for both the unit test step and the overall job.

# Test Plan

Tested with shorter timeouts in https://github.com/expo/expo/pull/15824, to make sure the settings have an effect. Also verified that time spent in a queue does NOT seem to count towards the overall job timeout (the iOS Unit Tests job there was sitting in the queue for > 2 mins but didn't get canceled until 2 mins after it actually started).

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
