### PR TITLE
[sweet][kotlin] Add naive `Record` to `ReadableMap` conversion

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KPromiseWrapper.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KPromiseWrapper.kt
@@ -2,17 +2,23 @@ package expo.modules.kotlin
 
 import android.os.Bundle
 import com.facebook.react.bridge.Arguments
+import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.records.toJSMap
 
 class KPromiseWrapper(
   private val bridgePromise: com.facebook.react.bridge.Promise
 ) : Promise {
 
+  @Suppress("UNCHECKED_CAST")
   override fun resolve(value: Any?) {
     bridgePromise.resolve(
       when (value) {
         is Unit -> null
-        is Bundle -> Arguments.fromBundle(value as Bundle?)
-        is List<*> -> Arguments.fromList(value as List<*>?)
+        is Bundle -> Arguments.fromBundle(value)
+        is List<*> -> Arguments.fromList(value)
+        is Array<*> -> Arguments.fromArray(value)
+        is Map<*, *> -> Arguments.makeNativeMap(value as Map<String, Any?>) // TODO(@lukmccall): add more sophisticated conversion method
+        is Record -> value.toJSMap()
         else -> value
       }
     )

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/Record.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/Record.kt
@@ -1,3 +1,42 @@
 package expo.modules.kotlin.records
 
+import android.os.Bundle
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.ReadableArray
+import com.facebook.react.bridge.ReadableMap
+import java.lang.IllegalArgumentException
+import kotlin.reflect.full.findAnnotation
+import kotlin.reflect.full.memberProperties
+import kotlin.reflect.jvm.isAccessible
+
 interface Record
+
+fun Record.toJSMap(): ReadableMap {
+  val writableMap = Arguments.createMap()
+  javaClass
+    .kotlin
+    .memberProperties.map { property ->
+      val fieldInformation = property.findAnnotation<Field>() ?: return@map
+      val jsKey = fieldInformation.key.takeUnless { it == "" } ?: property.name
+
+      property.isAccessible = true
+
+      // TODO(@lukmccall): add more sophisticated conversion method
+      when (val value = property.get(this)) {
+        null, is Unit -> writableMap.putNull(jsKey)
+        is Boolean -> writableMap.putBoolean(jsKey, value)
+        is Int -> writableMap.putInt(jsKey, value)
+        is Number -> writableMap.putDouble(jsKey, value.toDouble())
+        is String -> writableMap.putString(jsKey, value)
+        is ReadableArray -> writableMap.putArray(jsKey, value)
+        is ReadableMap -> writableMap.putMap(jsKey, value)
+        is Record -> writableMap.putMap(jsKey, value.toJSMap())
+        is Bundle -> writableMap.putMap(jsKey, Arguments.fromBundle(value))
+        is List<*> -> writableMap.putArray(jsKey, Arguments.fromList(value))
+        is Array<*> -> writableMap.putArray(jsKey, Arguments.fromArray(value))
+        else -> throw IllegalArgumentException("Could not convert " + value.javaClass)
+      }
+    }
+
+  return writableMap
+}


### PR DESCRIPTION
# Why

Closes ENG-2814.

# How

Added very naive conversion from `Record` to `ReadableMap`. I'll change how that works in the future, but right now I don't have a better idea of how we can solve that problem. 
Also, I've added the conversion for arrays and maps. 

# Test Plan

- bare-expo - tested by returning a Record and checking js object properties ✅
