### PR TITLE
[eyw] Add .cjs to allowed file extensions

### DIFF
--- a/packages/expo-yarn-workspaces/CHANGELOG.md
+++ b/packages/expo-yarn-workspaces/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Support looking up .cjs and .mjs files (still the bundler's job to be able to handle these files; EYW just allows them to be found) ([#15836](https://github.com/expo/expo/pull/15836) by [@ide](https://github.com/ide))
+- Support looking up .cjs (still the bundler's job to be able to handle these files; EYW just allows them to be found) ([#15836](https://github.com/expo/expo/pull/15836) by [@ide](https://github.com/ide))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-yarn-workspaces/CHANGELOG.md
+++ b/packages/expo-yarn-workspaces/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Support looking up .cjs and .mjs files (still the bundler's job to be able to handle these files; EYW just allows them to be found)
+- Support looking up .cjs and .mjs files (still the bundler's job to be able to handle these files; EYW just allows them to be found) ([#15836](https://github.com/expo/expo/pull/15836) by [@ide](https://github.com/ide))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-yarn-workspaces/CHANGELOG.md
+++ b/packages/expo-yarn-workspaces/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Support looking up .cjs and .mjs files (still the bundler's job to be able to handle these files; EYW just allows them to be found)
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-yarn-workspaces/index.js
+++ b/packages/expo-yarn-workspaces/index.js
@@ -74,8 +74,8 @@ exports.createMetroConfiguration = function createMetroConfiguration(projectPath
       // test-suite includes a db asset
       assetExts: [...assetExts, 'db'],
 
-      // Include .cjs and .mjs files
-      sourceExts: [...sourceExts, 'cjs', 'mjs'],
+      // Include .cjs files
+      sourceExts: [...sourceExts, 'cjs'],
 
       // Make the symlinked packages visible to Metro
       extraNodeModules,

--- a/packages/expo-yarn-workspaces/index.js
+++ b/packages/expo-yarn-workspaces/index.js
@@ -5,7 +5,7 @@ const debug = require('debug')('workspaces');
 const findYarnWorkspaceRoot = require('find-yarn-workspace-root');
 // TODO: Use the vendored metro config in a future version after SDK 41 is released
 // const { getDefaultConfig } = require('expo/metro-config');
-const { assetExts } = require('metro-config/src/defaults/defaults');
+const { assetExts, sourceExts } = require('metro-config/src/defaults/defaults');
 const path = require('path');
 
 const getSymlinkedNodeModulesForDirectory = require('./common/get-symlinked-modules');
@@ -73,6 +73,9 @@ exports.createMetroConfiguration = function createMetroConfiguration(projectPath
       ...defaultConfig.resolver,
       // test-suite includes a db asset
       assetExts: [...assetExts, 'db'],
+
+      // Include .cjs and .mjs files
+      sourceExts: [...sourceExts, 'cjs', 'mjs'],
 
       // Make the symlinked packages visible to Metro
       extraNodeModules,

--- a/packages/expo-yarn-workspaces/package.json
+++ b/packages/expo-yarn-workspaces/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-yarn-workspaces",
-  "version": "1.7.1",
+  "version": "1.7.0",
   "description": "A private package for working with Yarn workspaces within the Expo repository",
   "author": "Expo",
   "license": "MIT",

--- a/packages/expo-yarn-workspaces/package.json
+++ b/packages/expo-yarn-workspaces/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-yarn-workspaces",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "A private package for working with Yarn workspaces within the Expo repository",
   "author": "Expo",
   "license": "MIT",


### PR DESCRIPTION
Why
---
When we updated `@apollo/client` to a newer minor/patch version due to a yarn.lock refresh, it caused the publishing step for Home to fail because that package specifies a .cjs file under package.json->main. This commit adds .cjs to the list of extensions treated as source files.

How
---
Add cjs to sourceExts for our Metro config.

Test Plan
---------
Open Home in Expo Go and see that it bundles successfully and loads and runs successfully.
