### PR TITLE
[ios] Add missing initializer to LinearGradient

### DIFF
--- a/packages/expo-linear-gradient/CHANGELOG.md
+++ b/packages/expo-linear-gradient/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Prevent crashes by adding unimplemented `CALayer` initializer `'init(layer:)'`. ([#15843](https://github.com/expo/expo/pull/15843) by [@dillonhafer](https://github.com/dillonhafer))
+- Prevent crashes by adding unimplemented `CALayer` initializer `init(layer:)`. ([#15843](https://github.com/expo/expo/pull/15843) by [@dillonhafer](https://github.com/dillonhafer))
 
 ### 💡 Others
 

--- a/packages/expo-linear-gradient/CHANGELOG.md
+++ b/packages/expo-linear-gradient/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Prevent crashes by adding unimplemented `CALayer` initializer `'init(layer:)'`. ([#15843](https://github.com/expo/expo/pull/15843) by [@dillonhafer](https://github.com/dillonhafer))
+
 ### 💡 Others
 
 ## 11.0.0 — 2021-12-03

--- a/packages/expo-linear-gradient/ios/LinearGradientLayer.swift
+++ b/packages/expo-linear-gradient/ios/LinearGradientLayer.swift
@@ -18,6 +18,12 @@ final class LinearGradientLayer: CALayer {
     self.needsDisplayOnBoundsChange = true
     self.masksToBounds = true
   }
+  
+  override init(layer: Any) {
+    super.init(layer: layer)
+    self.needsDisplayOnBoundsChange = true
+    self.masksToBounds = true
+  }
 
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")


### PR DESCRIPTION
# Why

Prevent crashes in iOS

```
ExpoLinearGradient/LinearGradientLayer.swift:10: Fatal error: Use of unimplemented initializer 'init(layer:)' for class 'ExpoLinearGradient.LinearGradientLayer'
```

# How

Adding an unimplemented initializer

# Test Plan

Unsure

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
