### PR TITLE
[docs] Update CircleCI config in Building on CI

### DIFF
--- a/docs/pages/build/building-on-ci.md
+++ b/docs/pages/build/building-on-ci.md
@@ -156,26 +156,17 @@ version: 2.1
 executors:
   default:
     docker:
-      - image: circleci/node:16
+      - image: cimg/node:lts
     working_directory: ~/my-app
-
-commands:
-  attach_project:
-    steps:
-      - attach_workspace:
-          at: ~/my-app
 
 jobs:
   eas_build:
     executor: default
     steps:
       - checkout
-      - attach_project
-
       - run:
           name: Install dependencies
           command: npm ci
-
       - run:
           name: Trigger build
           command: npx eas-cli build --platform all --non-interactive


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

`circleci/*` images have been deprecated[^1] in favor of `cimg/*` on December 31, 2021.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Replaced `circleci/node:16` with `cimg/node:lts`.

We can't refer to major versions with `cimg/*`, so I used `lts` instead to not have to update this example on each major/minor release.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Ran `circleci config validate` on this configuration sample, config file is valid.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).

[^1]: [Legacy Convenience Image Deprecation](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034)