### PR TITLE
[docs] Update CircleCI config in Setting up CI

### DIFF
--- a/docs/pages/guides/setting-up-continuous-integration.md
+++ b/docs/pages/guides/setting-up-continuous-integration.md
@@ -374,46 +374,40 @@ pipelines:
 
 ```yaml
 ---
-version: 2
-publish: &publish
-  working_directory: ~/my-app
-  docker:
-    - image: circleci/node:10.4.1
-  steps:
-    - checkout
-
-    - run:
-        name: Installing dependencies
-        command: npm ci
-
-    - run:
-        name: Login into Expo
-        command: npx expo-cli login -u $EXPO_USERNAME -p $EXPO_PASSWORD
-
-    - run:
-        name: Publish to Expo
-        command: npx expo-cli publish --non-interactive --max-workers 1 --release-channel $EXPO_RELEASE_CHANNEL
+version: 2.1
 
 jobs:
-  publish_to_expo_dev:
-    environment:
-      EXPO_RELEASE_CHANNEL: dev
-    <<: *publish
-
-  publish_to_expo_prod:
-    environment:
-      EXPO_RELEASE_CHANNEL: default
-    <<: *publish
+  publish_to_expo:
+    parameters:
+      release-channel:
+        type: string
+        default: 'default'
+    docker:
+      - image: cimg/node:lts
+    working_directory: ~/my-app
+    steps:
+      - checkout
+      - run:
+          name: Installing dependencies
+          command: npm ci
+      - run:
+          name: Login into Expo
+          command: npx expo-cli login -u $EXPO_USERNAME -p $EXPO_PASSWORD
+      - run:
+          name: Publish to Expo
+          command: npx expo-cli publish --non-interactive --max-workers 1 --release-channel << parameters.release-channel >>
 
 workflows:
-  version: 2
   my_app:
     jobs:
-      - publish_to_expo_dev:
+      - publish_to_expo:
+          name: publish_to_expo_dev
+          release-channel: dev
           filters:
             branches:
               only: development
-      - publish_to_expo_prod:
+      - publish_to_expo:
+          name: publish_to_expo_prod
           filters:
             branches:
               only: master


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

`circleci/*` images have been deprecated[^1] in favor of `cimg/*` on December 31, 2021.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Replaced `circleci/node:16` with `cimg/node:lts`.

We can't refer to major versions with `cimg/*`, so I used `lts` instead to not have to update this example on each major/minor release.

Also, instead of using a YML anchor, we can leverage CircleCI config to create a job that will take `release-channel` as a parameter.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Ran `circleci config validate` on this configuration sample, config file is valid.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).

[^1]: [Legacy Convenience Image Deprecation](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034)