### PR TITLE
[ios][core] Create JSI host object to access the new expo modules

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Introduced the concept of chainable exceptions in Sweet API on iOS. ([#15813](https://github.com/expo/expo/pull/15813) by [@tsapeta](https://github.com/tsapeta))
 - Sweet function closures can throw errors on iOS. ([#15849](https://github.com/expo/expo/pull/15849) by [@tsapeta](https://github.com/tsapeta))
 - Add `requireNativeModule` function to replace accessing native modules from `NativeModulesProxy`. ([#15848](https://github.com/expo/expo/pull/15848) by [@tsapeta](https://github.com/tsapeta))
+- Implemented basic functionality of JSI host object to replace `NativeModulesProxy` on iOS. ([#15847](https://github.com/expo/expo/pull/15847) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/JSI/ExpoModulesHostObject.h
+++ b/packages/expo-modules-core/ios/JSI/ExpoModulesHostObject.h
@@ -17,11 +17,11 @@ public:
 
   virtual ~ExpoModulesHostObject();
 
-  virtual jsi::Value get(jsi::Runtime &, const jsi::PropNameID &name);
+  jsi::Value get(jsi::Runtime &, const jsi::PropNameID &name) override;
 
-  virtual void set(jsi::Runtime &, const jsi::PropNameID &name, const jsi::Value &value);
+  void set(jsi::Runtime &, const jsi::PropNameID &name, const jsi::Value &value) override;
 
-  virtual std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime &rt);
+  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime &rt) override;
 
 private:
   SwiftInteropBridge *swiftInterop;

--- a/packages/expo-modules-core/ios/JSI/ExpoModulesHostObject.h
+++ b/packages/expo-modules-core/ios/JSI/ExpoModulesHostObject.h
@@ -5,9 +5,9 @@
 #import <vector>
 #import <jsi/jsi.h>
 
-#import <ExpoModulesCore/Swift.h>
-
 using namespace facebook;
+
+@class SwiftInteropBridge;
 
 namespace expo {
 

--- a/packages/expo-modules-core/ios/JSI/ExpoModulesHostObject.h
+++ b/packages/expo-modules-core/ios/JSI/ExpoModulesHostObject.h
@@ -1,0 +1,33 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+#ifdef __cplusplus
+
+#import <vector>
+#import <jsi/jsi.h>
+
+#import <ExpoModulesCore/Swift.h>
+
+using namespace facebook;
+
+namespace expo {
+
+class JSI_EXPORT ExpoModulesHostObject : public jsi::HostObject {
+public:
+  ExpoModulesHostObject(SwiftInteropBridge *interopBridge);
+
+  virtual ~ExpoModulesHostObject();
+
+  virtual jsi::Value get(jsi::Runtime &, const jsi::PropNameID &name);
+
+  virtual void set(jsi::Runtime &, const jsi::PropNameID &name, const jsi::Value &value);
+
+  virtual std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime &rt);
+
+private:
+  SwiftInteropBridge *swiftInterop;
+
+}; // class ExpoModulesHostObject
+
+} // namespace expo
+
+#endif

--- a/packages/expo-modules-core/ios/JSI/ExpoModulesHostObject.h
+++ b/packages/expo-modules-core/ios/JSI/ExpoModulesHostObject.h
@@ -5,7 +5,7 @@
 #import <vector>
 #import <jsi/jsi.h>
 
-using namespace facebook;
+namespace jsi = facebook::jsi;
 
 @class SwiftInteropBridge;
 

--- a/packages/expo-modules-core/ios/JSI/ExpoModulesHostObject.mm
+++ b/packages/expo-modules-core/ios/JSI/ExpoModulesHostObject.mm
@@ -1,6 +1,7 @@
 // Copyright 2022-present 650 Industries. All rights reserved.
 
 #import <ExpoModulesCore/ExpoModulesHostObject.h>
+#import <ExpoModulesCore/Swift.h>
 
 namespace expo {
 

--- a/packages/expo-modules-core/ios/JSI/ExpoModulesHostObject.mm
+++ b/packages/expo-modules-core/ios/JSI/ExpoModulesHostObject.mm
@@ -1,0 +1,39 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+#import <ExpoModulesCore/ExpoModulesHostObject.h>
+
+namespace expo {
+
+ExpoModulesHostObject::ExpoModulesHostObject(SwiftInteropBridge *swiftInterop) : swiftInterop(swiftInterop) {}
+
+ExpoModulesHostObject::~ExpoModulesHostObject() {
+  [swiftInterop setRuntime:nil];
+}
+
+jsi::Value ExpoModulesHostObject::get(jsi::Runtime &runtime, const jsi::PropNameID &name) {
+  NSString *moduleName = [NSString stringWithUTF8String:name.utf8(runtime).c_str()];
+  JavaScriptObject *nativeObject = [swiftInterop getNativeModuleObject:moduleName];
+
+  return nativeObject ? jsi::Value(runtime, *[nativeObject get]) : jsi::Object(runtime);
+}
+
+void ExpoModulesHostObject::set(jsi::Runtime &runtime, const jsi::PropNameID &name, const jsi::Value &value) {
+  std::string message("RuntimeError: Cannot override the host object for expo module '");
+  message += name.utf8(runtime);
+  message += "'.";
+  throw jsi::JSError(runtime, message);
+}
+
+std::vector<jsi::PropNameID> ExpoModulesHostObject::getPropertyNames(jsi::Runtime &runtime) {
+  NSArray<NSString *> *moduleNames = [swiftInterop getModuleNames];
+  std::vector<jsi::PropNameID> propertyNames;
+
+  propertyNames.reserve([moduleNames count]);
+
+  for (NSString *moduleName in moduleNames) {
+    propertyNames.push_back(jsi::PropNameID::forAscii(runtime, [moduleName UTF8String]));
+  }
+  return propertyNames;
+}
+
+} // namespace expo

--- a/packages/expo-modules-core/ios/JSI/ExpoModulesHostObject.mm
+++ b/packages/expo-modules-core/ios/JSI/ExpoModulesHostObject.mm
@@ -15,7 +15,7 @@ jsi::Value ExpoModulesHostObject::get(jsi::Runtime &runtime, const jsi::PropName
   NSString *moduleName = [NSString stringWithUTF8String:name.utf8(runtime).c_str()];
   JavaScriptObject *nativeObject = [swiftInterop getNativeModuleObject:moduleName];
 
-  return nativeObject ? jsi::Value(runtime, *[nativeObject get]) : jsi::Object(runtime);
+  return nativeObject ? jsi::Value(runtime, *[nativeObject get]) : jsi::Value::undefined();
 }
 
 void ExpoModulesHostObject::set(jsi::Runtime &runtime, const jsi::PropNameID &name, const jsi::Value &value) {

--- a/packages/expo-modules-core/ios/JSI/ExpoModulesProxySpec.h
+++ b/packages/expo-modules-core/ios/JSI/ExpoModulesProxySpec.h
@@ -12,6 +12,10 @@ using namespace react;
 
 namespace expo {
 
+using PromiseInvocationBlock = void (^)(RCTPromiseResolveBlock resolveWrapper, RCTPromiseRejectBlock rejectWrapper);
+
+void callPromiseSetupWithBlock(jsi::Runtime &runtime, std::shared_ptr<CallInvoker> jsInvoker, std::shared_ptr<Promise> promise, PromiseInvocationBlock setupBlock);
+
 class JSI_EXPORT ExpoModulesProxySpec : public TurboModule {
 public:
   ExpoModulesProxySpec(std::shared_ptr<CallInvoker> callInvoker, EXNativeModulesProxy *nativeModulesProxy);

--- a/packages/expo-modules-core/ios/JSI/ExpoModulesProxySpec.mm
+++ b/packages/expo-modules-core/ios/JSI/ExpoModulesProxySpec.mm
@@ -7,9 +7,7 @@
 
 namespace expo {
 
-using PromiseInvocationBlock = void (^)(RCTPromiseResolveBlock resolveWrapper, RCTPromiseRejectBlock rejectWrapper);
-
-static void callPromiseSetupWithBlock(jsi::Runtime &runtime, std::shared_ptr<CallInvoker> jsInvoker, std::shared_ptr<Promise> promise, PromiseInvocationBlock setupBlock)
+void callPromiseSetupWithBlock(jsi::Runtime &runtime, std::shared_ptr<CallInvoker> jsInvoker, std::shared_ptr<Promise> promise, PromiseInvocationBlock setupBlock)
 {
   auto weakResolveWrapper = CallbackWrapper::createWeak(promise->resolve_.getFunction(runtime), runtime, jsInvoker);
   auto weakRejectWrapper = CallbackWrapper::createWeak(promise->reject_.getFunction(runtime), runtime, jsInvoker);

--- a/packages/expo-modules-core/ios/JSI/JSIConversions.h
+++ b/packages/expo-modules-core/ios/JSI/JSIConversions.h
@@ -31,6 +31,8 @@ NSString *convertJSIStringToNSString(jsi::Runtime &runtime, const jsi::String &v
 
 NSArray *convertJSIArrayToNSArray(jsi::Runtime &runtime, const jsi::Array &value, std::shared_ptr<CallInvoker> jsInvoker);
 
+NSArray *convertJSIValuesToNSArray(jsi::Runtime &runtime, const jsi::Value *values, size_t count, std::shared_ptr<CallInvoker> jsInvoker);
+
 NSDictionary *convertJSIObjectToNSDictionary(jsi::Runtime &runtime, const jsi::Object &value, std::shared_ptr<CallInvoker> jsInvoker);
 
 id convertJSIValueToObjCObject(jsi::Runtime &runtime, const jsi::Value &value, std::shared_ptr<CallInvoker> jsInvoker);

--- a/packages/expo-modules-core/ios/JSI/JSIConversions.mm
+++ b/packages/expo-modules-core/ios/JSI/JSIConversions.mm
@@ -86,6 +86,15 @@ NSArray *convertJSIArrayToNSArray(jsi::Runtime &runtime, const jsi::Array &value
   return [result copy];
 }
 
+NSArray *convertJSIValuesToNSArray(jsi::Runtime &runtime, const jsi::Value *values, size_t count, std::shared_ptr<CallInvoker> jsInvoker)
+{
+  NSMutableArray *result = [NSMutableArray arrayWithCapacity:count];
+  for (int i = 0; i < count; i++) {
+    result[i] = convertJSIValueToObjCObject(runtime, values[i], jsInvoker);
+  }
+  return result;
+}
+
 NSDictionary *convertJSIObjectToNSDictionary(jsi::Runtime &runtime, const jsi::Object &value, std::shared_ptr<CallInvoker> jsInvoker)
 {
   jsi::Array propertyNames = value.getPropertyNames(runtime);

--- a/packages/expo-modules-core/ios/JSI/JSIInstaller.h
+++ b/packages/expo-modules-core/ios/JSI/JSIInstaller.h
@@ -17,3 +17,13 @@ void installRuntimeObjects(jsi::Runtime &runtime, std::shared_ptr<CallInvoker> c
 } // namespace expo
 
 #endif
+
+#import <ExpoModulesCore/JavaScriptRuntime.h>
+
+@class SwiftInteropBridge;
+
+@interface JavaScriptRuntimeManager : NSObject
+
++ (void)installExpoModulesToRuntime:(nonnull JavaScriptRuntime *)runtime withSwiftInterop:(nonnull SwiftInteropBridge *)swiftInterop;
+
+@end

--- a/packages/expo-modules-core/ios/JSI/JSIInstaller.mm
+++ b/packages/expo-modules-core/ios/JSI/JSIInstaller.mm
@@ -2,11 +2,11 @@
 
 #import <ExpoModulesCore/JSIInstaller.h>
 #import <ExpoModulesCore/ExpoModulesProxySpec.h>
+#import <ExpoModulesCore/ExpoModulesHostObject.h>
+#import <ExpoModulesCore/Swift.h>
 
 using namespace facebook;
 using namespace react;
-
-//using PromiseInvocationBlock = void (^)(RCTPromiseResolveBlock resolveWrapper, RCTPromiseRejectBlock rejectWrapper);
 
 namespace expo {
 
@@ -20,3 +20,15 @@ void installRuntimeObjects(jsi::Runtime &runtime, std::shared_ptr<CallInvoker> c
 }
 
 } // namespace expo
+
+@implementation JavaScriptRuntimeManager
+
++ (void)installExpoModulesToRuntime:(nonnull JavaScriptRuntime *)runtime withSwiftInterop:(nonnull SwiftInteropBridge *)swiftInterop
+{
+  std::shared_ptr<expo::ExpoModulesHostObject> hostObjectPtr = std::make_shared<expo::ExpoModulesHostObject>(swiftInterop);
+  JavaScriptObject *global = [runtime global];
+
+  global[@"ExpoModules"] = [runtime createHostObject:hostObjectPtr];
+}
+
+@end

--- a/packages/expo-modules-core/ios/JSI/JavaScriptObject.h
+++ b/packages/expo-modules-core/ios/JSI/JavaScriptObject.h
@@ -1,0 +1,60 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+#import <Foundation/Foundation.h>
+#import <React/RCTBridgeModule.h>
+
+#ifdef __cplusplus
+#import <jsi/jsi.h>
+#import <ReactCommon/CallInvoker.h>
+
+using namespace facebook;
+#endif
+
+typedef void (^JSAsyncFunctionBlock)(NSArray * _Nonnull, RCTPromiseResolveBlock _Nonnull, RCTPromiseRejectBlock _Nonnull);
+typedef id _Nullable (^JSSyncFunctionBlock)(NSArray * _Nonnull);
+
+@class JavaScriptRuntime;
+
+@interface JavaScriptObject : NSObject
+
+// Some parts of the interface must be hidden for Swift – it can't import any C++ code.
+#ifdef __cplusplus
+- (nonnull instancetype)initWith:(std::shared_ptr<jsi::Object>)jsObject
+                         runtime:(nonnull JavaScriptRuntime *)runtime;
+
+/**
+ Returns the pointer to the underlying object.
+ */
+- (nullable jsi::Object *)get;
+#endif
+
+#pragma mark - Subscripting
+
+/**
+ Subscript getter. Supports only values convertible to Foundation types, otherwise `nil` is returned.
+ */
+- (nullable id)objectForKeyedSubscript:(nonnull NSString *)key;
+
+/**
+ Subscript setter. Only `JavaScriptObject` and Foundation object convertible to JSI values can be used as a value,
+ otherwise the property is set to `undefined`.
+ */
+- (void)setObject:(nullable id)obj forKeyedSubscript:(nonnull NSString *)key;
+
+#pragma mark - Functions
+
+/**
+ Sets given function block on the object as a host function returning a promise.
+ */
+- (void)setAsyncFunction:(nonnull NSString *)key
+               argsCount:(NSInteger)argsCount
+                   block:(nonnull JSAsyncFunctionBlock)block;
+
+/**
+ Sets given synchronous function block as a host function on the object.
+ */
+- (void)setSyncFunction:(nonnull NSString *)name
+              argsCount:(NSInteger)argsCount
+                  block:(nonnull JSSyncFunctionBlock)block;
+
+@end

--- a/packages/expo-modules-core/ios/JSI/JavaScriptObject.h
+++ b/packages/expo-modules-core/ios/JSI/JavaScriptObject.h
@@ -7,8 +7,8 @@
 #import <jsi/jsi.h>
 #import <ReactCommon/CallInvoker.h>
 
-using namespace facebook;
-#endif
+namespace jsi = facebook::jsi;
+#endif // __cplusplus
 
 typedef void (^JSAsyncFunctionBlock)(NSArray * _Nonnull, RCTPromiseResolveBlock _Nonnull, RCTPromiseRejectBlock _Nonnull);
 typedef id _Nullable (^JSSyncFunctionBlock)(NSArray * _Nonnull);
@@ -19,14 +19,14 @@ typedef id _Nullable (^JSSyncFunctionBlock)(NSArray * _Nonnull);
 
 // Some parts of the interface must be hidden for Swift – it can't import any C++ code.
 #ifdef __cplusplus
-- (nonnull instancetype)initWith:(std::shared_ptr<jsi::Object>)jsObject
+- (nonnull instancetype)initWith:(std::shared_ptr<jsi::Object>)jsObjectPtr
                          runtime:(nonnull JavaScriptRuntime *)runtime;
 
 /**
  Returns the pointer to the underlying object.
  */
-- (nullable jsi::Object *)get;
-#endif
+- (nonnull jsi::Object *)get;
+#endif // __cplusplus
 
 #pragma mark - Subscripting
 

--- a/packages/expo-modules-core/ios/JSI/JavaScriptObject.mm
+++ b/packages/expo-modules-core/ios/JSI/JavaScriptObject.mm
@@ -6,21 +6,31 @@
 #import <ExpoModulesCore/ExpoModulesProxySpec.h>
 
 @implementation JavaScriptObject {
+  /**
+   Pointer to the `JavaScriptRuntime` wrapper.
+
+   \note It must be weak because only then the original runtime can be safely deallocated
+   when the JS engine wants to without unsetting it on each created object.
+   */
   __weak JavaScriptRuntime *_runtime;
+
+  /**
+   Shared pointer to the original JSI object that is being wrapped by `JavaScriptObject` class.
+   */
   std::shared_ptr<jsi::Object> _jsObjectPtr;
 }
 
-- (nonnull instancetype)initWith:(std::shared_ptr<jsi::Object>)jsObject
+- (nonnull instancetype)initWith:(std::shared_ptr<jsi::Object>)jsObjectPtr
                          runtime:(nonnull JavaScriptRuntime *)runtime
 {
   if (self = [super init]) {
     _runtime = runtime;
-    _jsObjectPtr = jsObject;
+    _jsObjectPtr = jsObjectPtr;
   }
   return self;
 }
 
-- (jsi::Object *)get
+- (nonnull jsi::Object *)get
 {
   return _jsObjectPtr.get();
 }
@@ -41,12 +51,16 @@
 
 - (void)setObject:(nullable id)obj forKeyedSubscript:(nonnull NSString *)key
 {
-  if (auto runtime = [_runtime get]) {
-    if ([obj isKindOfClass:[JavaScriptObject class]]) {
-      _jsObjectPtr->setProperty(*runtime, [key UTF8String], *[obj get]);
-    } else {
-      _jsObjectPtr->setProperty(*runtime, [key UTF8String], expo::convertObjCObjectToJSIValue(*runtime, obj));
-    }
+  auto runtime = [_runtime get];
+
+  if (!runtime) {
+    NSLog(@"Cannot set '%@' property when the JavaScript runtime is no longer available.", key);
+    return;
+  }
+  if ([obj isKindOfClass:[JavaScriptObject class]]) {
+    _jsObjectPtr->setProperty(*runtime, [key UTF8String], *[obj get]);
+  } else {
+    _jsObjectPtr->setProperty(*runtime, [key UTF8String], expo::convertObjCObjectToJSIValue(*runtime, obj));
   }
 }
 
@@ -56,6 +70,10 @@
                argsCount:(NSInteger)argsCount
                    block:(nonnull JSAsyncFunctionBlock)block
 {
+  if (!_runtime) {
+    NSLog(@"Cannot set '%@' async function when the JavaScript runtime is no longer available.", name);
+    return;
+  }
   jsi::Function function = [_runtime createAsyncFunction:name argsCount:argsCount block:block];
   _jsObjectPtr->setProperty(*[_runtime get], [name UTF8String], function);
 }
@@ -64,6 +82,10 @@
               argsCount:(NSInteger)argsCount
                   block:(nonnull JSSyncFunctionBlock)block
 {
+  if (!_runtime) {
+    NSLog(@"Cannot set '%@' sync function when the JavaScript runtime is no longer available.", name);
+    return;
+  }
   jsi::Function function = [_runtime createSyncFunction:name argsCount:argsCount block:block];
   _jsObjectPtr->setProperty(*[_runtime get], [name UTF8String], function);
 }

--- a/packages/expo-modules-core/ios/JSI/JavaScriptObject.mm
+++ b/packages/expo-modules-core/ios/JSI/JavaScriptObject.mm
@@ -1,0 +1,71 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+#import <ExpoModulesCore/JSIConversions.h>
+#import <ExpoModulesCore/JavaScriptObject.h>
+#import <ExpoModulesCore/JavaScriptRuntime.h>
+#import <ExpoModulesCore/ExpoModulesProxySpec.h>
+
+@implementation JavaScriptObject {
+  __weak JavaScriptRuntime *_runtime;
+  std::shared_ptr<jsi::Object> _jsObjectPtr;
+}
+
+- (nonnull instancetype)initWith:(std::shared_ptr<jsi::Object>)jsObject
+                         runtime:(nonnull JavaScriptRuntime *)runtime
+{
+  if (self = [super init]) {
+    _runtime = runtime;
+    _jsObjectPtr = jsObject;
+  }
+  return self;
+}
+
+- (jsi::Object *)get
+{
+  return _jsObjectPtr.get();
+}
+
+#pragma mark - Subscripting
+
+- (nullable id)objectForKeyedSubscript:(nonnull NSString *)key
+{
+  auto runtime = [_runtime get];
+  auto callInvoker = [_runtime callInvoker];
+
+  if (runtime && callInvoker) {
+    auto value = _jsObjectPtr->getProperty(*runtime, [key UTF8String]);
+    return expo::convertJSIValueToObjCObject(*runtime, value, callInvoker);
+  }
+  return nil;
+}
+
+- (void)setObject:(nullable id)obj forKeyedSubscript:(nonnull NSString *)key
+{
+  if (auto runtime = [_runtime get]) {
+    if ([obj isKindOfClass:[JavaScriptObject class]]) {
+      _jsObjectPtr->setProperty(*runtime, [key UTF8String], *[obj get]);
+    } else {
+      _jsObjectPtr->setProperty(*runtime, [key UTF8String], expo::convertObjCObjectToJSIValue(*runtime, obj));
+    }
+  }
+}
+
+#pragma mark - Functions
+
+- (void)setAsyncFunction:(nonnull NSString *)name
+               argsCount:(NSInteger)argsCount
+                   block:(nonnull JSAsyncFunctionBlock)block
+{
+  jsi::Function function = [_runtime createAsyncFunction:name argsCount:argsCount block:block];
+  _jsObjectPtr->setProperty(*[_runtime get], [name UTF8String], function);
+}
+
+- (void)setSyncFunction:(nonnull NSString *)name
+              argsCount:(NSInteger)argsCount
+                  block:(nonnull JSSyncFunctionBlock)block
+{
+  jsi::Function function = [_runtime createSyncFunction:name argsCount:argsCount block:block];
+  _jsObjectPtr->setProperty(*[_runtime get], [name UTF8String], function);
+}
+
+@end

--- a/packages/expo-modules-core/ios/JSI/JavaScriptRuntime.h
+++ b/packages/expo-modules-core/ios/JSI/JavaScriptRuntime.h
@@ -4,7 +4,10 @@
 
 #ifdef __cplusplus
 #import <ReactCommon/CallInvoker.h>
-#endif
+
+namespace jsi = facebook::jsi;
+namespace react = facebook::react;
+#endif // __cplusplus
 
 @interface JavaScriptRuntime : NSObject
 
@@ -17,7 +20,7 @@ typedef jsi::Value (^JSHostFunctionBlock)(jsi::Runtime &runtime, std::shared_ptr
 /**
  Returns the underlying runtime object.
  */
-- (nullable jsi::Runtime *)get;
+- (nonnull jsi::Runtime *)get;
 
 /**
  Returns the call invoker the runtime was initialized with.
@@ -36,8 +39,7 @@ typedef jsi::Value (^JSHostFunctionBlock)(jsi::Runtime &runtime, std::shared_ptr
 - (jsi::Function)createAsyncFunction:(nonnull NSString *)name
                            argsCount:(NSInteger)argsCount
                                block:(nonnull JSAsyncFunctionBlock)block;
-
-#endif
+#endif // __cplusplus
 
 /**
  Returns the runtime global object for use in Swift.

--- a/packages/expo-modules-core/ios/JSI/JavaScriptRuntime.h
+++ b/packages/expo-modules-core/ios/JSI/JavaScriptRuntime.h
@@ -1,0 +1,52 @@
+// Copyright 2018-present 650 Industries. All rights reserved.
+
+#import <ExpoModulesCore/JavaScriptObject.h>
+
+#ifdef __cplusplus
+#import <ReactCommon/CallInvoker.h>
+#endif
+
+@interface JavaScriptRuntime : NSObject
+
+#ifdef __cplusplus
+typedef jsi::Value (^JSHostFunctionBlock)(jsi::Runtime &runtime, std::shared_ptr<react::CallInvoker> callInvoker, NSArray * _Nonnull arguments);
+
+- (nonnull instancetype)initWithRuntime:(jsi::Runtime &)runtime
+                            callInvoker:(std::shared_ptr<react::CallInvoker>)callInvoker;
+
+/**
+ Returns the underlying runtime object.
+ */
+- (nullable jsi::Runtime *)get;
+
+/**
+ Returns the call invoker the runtime was initialized with.
+ */
+- (std::shared_ptr<react::CallInvoker>)callInvoker;
+
+/**
+ Wraps given host object to `JavaScriptObject`.
+ */
+- (nonnull JavaScriptObject *)createHostObject:(std::shared_ptr<jsi::HostObject>)jsiHostObjectPtr;
+
+- (jsi::Function)createSyncFunction:(nonnull NSString *)name
+                          argsCount:(NSInteger)argsCount
+                              block:(nonnull JSSyncFunctionBlock)block;
+
+- (jsi::Function)createAsyncFunction:(nonnull NSString *)name
+                           argsCount:(NSInteger)argsCount
+                               block:(nonnull JSAsyncFunctionBlock)block;
+
+#endif
+
+/**
+ Returns the runtime global object for use in Swift.
+ */
+- (nonnull JavaScriptObject *)global;
+
+/**
+ Creates a new object for use in Swift.
+ */
+- (nonnull JavaScriptObject *)createObject;
+
+@end

--- a/packages/expo-modules-core/ios/JSI/JavaScriptRuntime.mm
+++ b/packages/expo-modules-core/ios/JSI/JavaScriptRuntime.mm
@@ -1,0 +1,101 @@
+// Copyright 2018-present 650 Industries. All rights reserved.
+
+#import <jsi/jsi.h>
+
+#import <ExpoModulesCore/JavaScriptRuntime.h>
+#import <ExpoModulesCore/ExpoModulesHostObject.h>
+#import <ExpoModulesCore/Swift.h>
+
+using namespace facebook;
+
+@implementation JavaScriptRuntime {
+  jsi::Runtime *_runtime;
+  std::shared_ptr<react::CallInvoker> _jsCallInvoker;
+
+  JavaScriptObject *_global;
+}
+
+- (nonnull instancetype)initWithRuntime:(jsi::Runtime &)runtime callInvoker:(std::shared_ptr<react::CallInvoker>)callInvoker
+{
+  if (self = [super init]) {
+    _runtime = &runtime;
+    _jsCallInvoker = callInvoker;
+
+    auto jsGlobalPtr = std::make_shared<jsi::Object>(_runtime->global());
+    _global = [[JavaScriptObject alloc] initWith:jsGlobalPtr runtime:self];
+  }
+  return self;
+}
+
+- (jsi::Runtime *)get
+{
+  return _runtime;
+}
+
+- (std::shared_ptr<react::CallInvoker>)callInvoker
+{
+  return _jsCallInvoker;
+}
+
+- (nonnull JavaScriptObject *)createObject
+{
+  auto jsObjectPtr = std::make_shared<jsi::Object>(*_runtime);
+  return [[JavaScriptObject alloc] initWith:jsObjectPtr runtime:self];
+}
+
+- (nonnull JavaScriptObject *)createHostObject:(std::shared_ptr<jsi::HostObject>)jsiHostObjectPtr
+{
+  auto jsObjectPtr = std::make_shared<jsi::Object>(jsi::Object::createFromHostObject(*_runtime, jsiHostObjectPtr));
+  return [[JavaScriptObject alloc] initWith:jsObjectPtr runtime:self];
+}
+
+- (nonnull JavaScriptObject *)global
+{
+  return _global;
+}
+
+- (jsi::Function)createSyncFunction:(nonnull NSString *)name
+argsCount:(NSInteger)argsCount block:(nonnull JSSyncFunctionBlock)block
+{
+  return [self createHostFunction:name argsCount:argsCount block:^jsi::Value(jsi::Runtime &runtime, std::shared_ptr<react::CallInvoker> callInvoker, NSArray * _Nonnull arguments) {
+    return expo::convertObjCObjectToJSIValue(runtime, block(arguments));
+  }];
+}
+
+- (jsi::Function)createAsyncFunction:(nonnull NSString *)name
+                           argsCount:(NSInteger)argsCount
+                               block:(nonnull JSAsyncFunctionBlock)block
+{
+  return [self createHostFunction:name argsCount:argsCount block:^jsi::Value(jsi::Runtime &runtime, std::shared_ptr<react::CallInvoker> callInvoker, NSArray *arguments) {
+    // The function that is invoked as a setup of the JavaScript `Promise`.
+    auto promiseSetup = [callInvoker, block, arguments](jsi::Runtime &runtime, std::shared_ptr<Promise> promise) {
+      expo::callPromiseSetupWithBlock(runtime, callInvoker, promise, ^(RCTPromiseResolveBlock resolver, RCTPromiseRejectBlock rejecter) {
+        block(arguments, resolver, rejecter);
+      });
+    };
+    return createPromiseAsJSIValue(runtime, promiseSetup);
+  }];
+}
+
+#pragma mark - Private
+
+typedef jsi::Value (^JSHostFunctionBlock)(jsi::Runtime &runtime, std::shared_ptr<react::CallInvoker> callInvoker, NSArray * _Nonnull arguments);
+
+- (jsi::Function)createHostFunction:(nonnull NSString *)name
+                          argsCount:(NSInteger)argsCount
+                              block:(nonnull JSHostFunctionBlock)block
+{
+  jsi::PropNameID propNameId = jsi::PropNameID::forAscii(*_runtime, [name UTF8String], [name length]);
+  std::weak_ptr<react::CallInvoker> weakCallInvoker = _jsCallInvoker;
+  jsi::HostFunctionType function = [weakCallInvoker, block](jsi::Runtime &runtime, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
+    if (auto callInvoker = weakCallInvoker.lock()) {
+      NSArray *arguments = expo::convertJSIValuesToNSArray(runtime, args, count, callInvoker);
+      return block(runtime, callInvoker, arguments);
+    }
+    // TODO: We should throw some kind of error.
+    return jsi::Value::undefined();
+  };
+  return jsi::Function::createFromHostFunction(*_runtime, propNameId, (unsigned int)argsCount, function);
+}
+
+@end

--- a/packages/expo-modules-core/ios/JSI/JavaScriptRuntime.mm
+++ b/packages/expo-modules-core/ios/JSI/JavaScriptRuntime.mm
@@ -27,7 +27,7 @@ using namespace facebook;
   return self;
 }
 
-- (jsi::Runtime *)get
+- (nonnull jsi::Runtime *)get
 {
   return _runtime;
 }
@@ -55,7 +55,8 @@ using namespace facebook;
 }
 
 - (jsi::Function)createSyncFunction:(nonnull NSString *)name
-argsCount:(NSInteger)argsCount block:(nonnull JSSyncFunctionBlock)block
+                          argsCount:(NSInteger)argsCount
+                              block:(nonnull JSSyncFunctionBlock)block
 {
   return [self createHostFunction:name argsCount:argsCount block:^jsi::Value(jsi::Runtime &runtime, std::shared_ptr<react::CallInvoker> callInvoker, NSArray * _Nonnull arguments) {
     return expo::convertObjCObjectToJSIValue(runtime, block(arguments));

--- a/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.mm
+++ b/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.mm
@@ -416,10 +416,15 @@ RCT_EXPORT_METHOD(callMethod:(NSString *)moduleName methodNameOrKey:(id)methodNa
  */
 - (void)installExpoTurboModules
 {
-  facebook::jsi::Runtime *runtime = [_bridge respondsToSelector:@selector(runtime)] ? reinterpret_cast<facebook::jsi::Runtime *>(_bridge.runtime) : NULL;
+  facebook::jsi::Runtime *jsiRuntime = [_bridge respondsToSelector:@selector(runtime)] ? reinterpret_cast<facebook::jsi::Runtime *>(_bridge.runtime) : nullptr;
 
-  if (runtime) {
-    expo::installRuntimeObjects(*runtime, _bridge.jsCallInvoker, self);
+  if (jsiRuntime) {
+    JavaScriptRuntime *runtime = [[JavaScriptRuntime alloc] initWithRuntime:*jsiRuntime callInvoker:_bridge.jsCallInvoker];
+
+    [JavaScriptRuntimeManager installExpoModulesToRuntime:runtime withSwiftInterop:_swiftInteropBridge];
+    [_swiftInteropBridge setRuntime:runtime];
+
+    expo::installRuntimeObjects(*jsiRuntime, _bridge.jsCallInvoker, self);
   }
 }
 

--- a/packages/expo-modules-core/ios/Swift/AppContext.swift
+++ b/packages/expo-modules-core/ios/Swift/AppContext.swift
@@ -19,6 +19,11 @@ public final class AppContext {
   public internal(set) weak var reactBridge: RCTBridge?
 
   /**
+   JSI runtime of the running app.
+   */
+  public internal(set) var runtime: JavaScriptRuntime?
+
+  /**
    Designated initializer without modules provider.
    */
   public init() {

--- a/packages/expo-modules-core/ios/Swift/Functions/AnyFunction.swift
+++ b/packages/expo-modules-core/ios/Swift/Functions/AnyFunction.swift
@@ -25,6 +25,11 @@ public protocol AnyFunction: AnyDefinition {
   var queue: DispatchQueue? { get }
 
   /**
+   Whether the function needs to be called asynchronously from JavaScript.
+   */
+  var isAsync: Bool { get }
+
+  /**
    Calls the function on given module with arguments and a promise.
    */
   func call(args: [Any], promise: Promise)
@@ -39,4 +44,9 @@ public protocol AnyFunction: AnyDefinition {
    Specifies on which queue the function should run.
    */
   func runOnQueue(_ queue: DispatchQueue?) -> Self
+
+  /**
+   Makes the JavaScript function synchronous.
+   */
+  func runSynchronously() -> Self
 }

--- a/packages/expo-modules-core/ios/Swift/Functions/ConcreteFunction.swift
+++ b/packages/expo-modules-core/ios/Swift/Functions/ConcreteFunction.swift
@@ -15,6 +15,8 @@ public final class ConcreteFunction<Args, ReturnType>: AnyFunction {
 
   public var queue: DispatchQueue?
 
+  public var isAsync: Bool = true
+
   let closure: ClosureType
 
   let argTypes: [AnyArgumentType]
@@ -81,6 +83,11 @@ public final class ConcreteFunction<Args, ReturnType>: AnyFunction {
 
   public func runOnQueue(_ queue: DispatchQueue?) -> Self {
     self.queue = queue
+    return self
+  }
+
+  public func runSynchronously() -> Self {
+    self.isAsync = false
     return self
   }
 

--- a/packages/expo-modules-core/ios/Swift/JavaScriptUtils.swift
+++ b/packages/expo-modules-core/ios/Swift/JavaScriptUtils.swift
@@ -1,0 +1,43 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+// FIXME: Calling module's functions needs solid refactoring to not reference the module holder.
+// Instead, it should be possible to directly call the function instance from here. (added by @tsapeta)
+
+/**
+ Creates a block that is executed when the module's async function is called.
+ */
+internal func createAsyncFunctionBlock(holder: ModuleHolder, name functionName: String) -> JSAsyncFunctionBlock {
+  let moduleName = holder.name
+  return { [weak holder, moduleName] args, resolve, reject in
+    guard let holder = holder else {
+      let exception = ModuleUnavailableException(moduleName)
+      reject(exception.code, exception.description, exception)
+      return
+    }
+    holder.call(function: functionName, args: args) { result, error in
+      if let error = error {
+        reject(error.code, error.description, error)
+      } else {
+        resolve(result)
+      }
+    }
+  }
+}
+
+/**
+ Creates a block that is executed when the module's sync function is called.
+ */
+internal func createSyncFunctionBlock(holder: ModuleHolder, name functionName: String) -> JSSyncFunctionBlock {
+  return { [weak holder] args in
+    guard let holder = holder else {
+      return nil
+    }
+    return holder.callSync(function: functionName, args: args)
+  }
+}
+
+private class ModuleUnavailableException: GenericException<String> {
+  override var reason: String {
+    "Module '\(params)' is no longer available"
+  }
+}

--- a/packages/expo-modules-core/ios/Swift/ModuleRegistry.swift
+++ b/packages/expo-modules-core/ios/Swift/ModuleRegistry.swift
@@ -62,6 +62,10 @@ public final class ModuleRegistry: Sequence {
     return registry[moduleName]?.module
   }
 
+  public func getModuleNames() -> [String] {
+    return Array(registry.keys)
+  }
+
   public func makeIterator() -> IndexingIterator<[ModuleHolder]> {
     return registry.map({ $1 }).makeIterator()
   }

--- a/packages/expo-modules-core/ios/Swift/SwiftInteropBridge.swift
+++ b/packages/expo-modules-core/ios/Swift/SwiftInteropBridge.swift
@@ -103,6 +103,24 @@ public final class SwiftInteropBridge: NSObject {
     }
   }
 
+  /**
+   Sets the JSI runtime on the operating `AppContext`.
+   */
+  @objc
+  public func setRuntime(_ runtime: JavaScriptRuntime?) {
+    appContext.runtime = runtime
+  }
+
+  @objc
+  public func getModuleNames() -> [String] {
+    return registry.getModuleNames()
+  }
+
+  @objc
+  public func getNativeModuleObject(_ moduleName: String) -> JavaScriptObject? {
+    return registry.get(moduleHolderForName: moduleName)?.javaScriptObject
+  }
+
   // MARK: - Events
 
   /**


### PR DESCRIPTION
# Why

Step further to integrate our new modules architecture with JSI and running native functions synchronously.

# How

- Created `ExpoModulesHostObject` that installs into the runtime as `global.ExpoModules`. The host object is an abstract object where we can define our own property getter, allowing us to create JS object for each module lazily.
- Since Swift doesn't understand C++ symbols, it has no direct access to JSI API. To work around this, I created another layer of abstraction to JavaScript runtime (`JavaScriptRuntime`) and objects (`JavaScriptObject`) in ObjC++ to expose some functionalities to Swift.
- Added `isAsync` property to sweet functions and `runSynchronously()` modifier.
- `AppContext` can now access the runtime, so the modules can access the runtime too!

# Further plans

- Make `expo-random` to be an expo module and be the first to use synchronous functions.
- Right now all new modules can be accessed from the host object, however at the beginning we'd like to enable it only for some subset of modules (especially that events are not supported yet). Maybe `useJavaScriptRuntime(true)` definition component?
- Cleanup stuff related to `ExpoModulesProxySpec` TurboModule which was an alternative implementation to `NativeModulesProxy` — the solution with host object is much better, more scalable and that lets us do much more magic in the future, so we can drop the TurboModule (it wasn't used by default anyway).
- Ensure that `JavaScriptRuntime` and `JavaScriptObject` are thread-safe (another addition to bare JSI objects).
- Move some responsibility of calling exported functions from `ModuleHolder` to the respective functions. See my comment in [`JavaScriptUtils.swift`](https://github.com/expo/expo/blob/834695d26d0d4cf19d8281acc46a6f018d5da25c/packages/expo-modules-core/ios/Swift/JavaScriptUtils.swift#L3-L4)
- Switch modules to use `requireNativeModule(moduleName)` instead of `NativeModulesProxy` (see related PR #15848). We also need to replace JS examples in the docs to use this new function because we don't want to introduce developers into the proxy concept.

# Test Plan

- Used `expo-haptics` with a new synchronous function as a playground, all worked as expected.
- Reloading the app works fine (it would crash on JSCRuntime deallocation if there are any unreleased objects)