### PR TITLE
[ios][core] Let the sweet functions throw errors

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Added `onViewDestroys` component to the `ViewManager` in Sweet API on Android. ([#15740](https://github.com/expo/expo/pull/15740) by [@lukmccall](https://github.com/lukmccall))
 - Added shortened `constants` component that takes `vargs Pair<String, Any?>` as an argument in Sweet API on Android. ([#15742](https://github.com/expo/expo/pull/15742) by [@lukmccall](https://github.com/lukmccall))
 - Introduced the concept of chainable exceptions in Sweet API on iOS. ([#15813](https://github.com/expo/expo/pull/15813) by [@tsapeta](https://github.com/tsapeta))
-- Sweet function closures can throw errors on iOS.
+- Sweet function closures can throw errors on iOS. ([#15849](https://github.com/expo/expo/pull/15849) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Added `onViewDestroys` component to the `ViewManager` in Sweet API on Android. ([#15740](https://github.com/expo/expo/pull/15740) by [@lukmccall](https://github.com/lukmccall))
 - Added shortened `constants` component that takes `vargs Pair<String, Any?>` as an argument in Sweet API on Android. ([#15742](https://github.com/expo/expo/pull/15742) by [@lukmccall](https://github.com/lukmccall))
 - Introduced the concept of chainable exceptions in Sweet API on iOS. ([#15813](https://github.com/expo/expo/pull/15813) by [@tsapeta](https://github.com/tsapeta))
+- Sweet function closures can throw errors on iOS.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/Swift/Functions/ConcreteFunction.swift
+++ b/packages/expo-modules-core/ios/Swift/Functions/ConcreteFunction.swift
@@ -1,7 +1,7 @@
 import Dispatch
 
 public final class ConcreteFunction<Args, ReturnType>: AnyFunction {
-  public typealias ClosureType = (Args) -> ReturnType
+  public typealias ClosureType = (Args) throws -> ReturnType
 
   public let name: String
 
@@ -41,7 +41,7 @@ public final class ConcreteFunction<Args, ReturnType>: AnyFunction {
       }
 
       let tuple = try Conversions.toTuple(finalArgs) as! Args
-      returnedValue = closure(tuple)
+      returnedValue = try closure(tuple)
     } catch let error as CodedError {
       promise.reject(FunctionCallException(name).causedBy(error))
       return
@@ -72,7 +72,7 @@ public final class ConcreteFunction<Args, ReturnType>: AnyFunction {
       do {
         let finalArgs = try castArguments(args)
         let tuple = try Conversions.toTuple(finalArgs) as! Args
-        return closure(tuple)
+        return try closure(tuple)
       } catch let error {
         return error
       }

--- a/packages/expo-modules-core/ios/Swift/Objects/ObjectDefinitionComponents.swift
+++ b/packages/expo-modules-core/ios/Swift/Objects/ObjectDefinitionComponents.swift
@@ -24,7 +24,7 @@ public func constants(_ body: @autoclosure @escaping () -> [String: Any?]) -> An
  */
 public func function<R>(
   _ name: String,
-  _ closure: @escaping () -> R
+  _ closure: @escaping () throws -> R
 ) -> AnyFunction {
   return ConcreteFunction(
     name,
@@ -38,7 +38,7 @@ public func function<R>(
  */
 public func function<R, A0: AnyArgument>(
   _ name: String,
-  _ closure: @escaping (A0) -> R
+  _ closure: @escaping (A0) throws -> R
 ) -> AnyFunction {
   return ConcreteFunction(
     name,
@@ -52,7 +52,7 @@ public func function<R, A0: AnyArgument>(
  */
 public func function<R, A0: AnyArgument, A1: AnyArgument>(
   _ name: String,
-  _ closure: @escaping (A0, A1) -> R
+  _ closure: @escaping (A0, A1) throws -> R
 ) -> AnyFunction {
   return ConcreteFunction(
     name,
@@ -66,7 +66,7 @@ public func function<R, A0: AnyArgument, A1: AnyArgument>(
  */
 public func function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument>(
   _ name: String,
-  _ closure: @escaping (A0, A1, A2) -> R
+  _ closure: @escaping (A0, A1, A2) throws -> R
 ) -> AnyFunction {
   return ConcreteFunction(
     name,
@@ -84,7 +84,7 @@ public func function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument>(
  */
 public func function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument>(
   _ name: String,
-  _ closure: @escaping (A0, A1, A2, A3) -> R
+  _ closure: @escaping (A0, A1, A2, A3) throws -> R
 ) -> AnyFunction {
   return ConcreteFunction(
     name,
@@ -103,7 +103,7 @@ public func function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: A
  */
 public func function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument, A4: AnyArgument>(
   _ name: String,
-  _ closure: @escaping (A0, A1, A2, A3, A4) -> R
+  _ closure: @escaping (A0, A1, A2, A3, A4) throws -> R
 ) -> AnyFunction {
   return ConcreteFunction(
     name,
@@ -123,7 +123,7 @@ public func function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: A
  */
 public func function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument, A4: AnyArgument, A5: AnyArgument>(
   _ name: String,
-  _ closure: @escaping (A0, A1, A2, A3, A4, A5) -> R
+  _ closure: @escaping (A0, A1, A2, A3, A4, A5) throws -> R
 ) -> AnyFunction {
   return ConcreteFunction(
     name,
@@ -144,7 +144,7 @@ public func function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: A
  */
 public func function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument, A4: AnyArgument, A5: AnyArgument, A6: AnyArgument>(
   _ name: String,
-  _ closure: @escaping (A0, A1, A2, A3, A4, A5, A6) -> R
+  _ closure: @escaping (A0, A1, A2, A3, A4, A5, A6) throws -> R
 ) -> AnyFunction {
   return ConcreteFunction(
     name,
@@ -166,7 +166,7 @@ public func function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: A
  */
 public func function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument, A4: AnyArgument, A5: AnyArgument, A6: AnyArgument, A7: AnyArgument>(
   _ name: String,
-  _ closure: @escaping (A0, A1, A2, A3, A4, A5, A6, A7) -> R
+  _ closure: @escaping (A0, A1, A2, A3, A4, A5, A6, A7) throws -> R
 ) -> AnyFunction {
   return ConcreteFunction(
     name,


### PR DESCRIPTION
# Why

Until now it was not possible to throw inside the function body.

# How

Simply added `throws` to the function closure types.

# Test Plan

CI passed and I tested it manually when trying to convert expo-random to be an expo module.