### PR TITLE
unified import path in Customizing Metro docs

### DIFF
--- a/docs/pages/guides/customizing-metro.md
+++ b/docs/pages/guides/customizing-metro.md
@@ -51,7 +51,7 @@ By default, Metro uses [`uglify-es`](https://github.com/mishoo/UglifyJS) to mini
 **metro.config.js**
 
 ```js
-const { getDefaultConfig } = require('expo/metro-config');
+const { getDefaultConfig } = require('@expo/metro-config');
 
 const config = getDefaultConfig(__dirname);
 
@@ -74,7 +74,7 @@ Now set terser with `transformer.minifierPath`, and pass in [`terser` options](h
 **metro.config.js**
 
 ```js
-const { getDefaultConfig } = require('expo/metro-config');
+const { getDefaultConfig } = require('@expo/metro-config');
 
 const config = getDefaultConfig(__dirname);
 


### PR DESCRIPTION
I just added missing `@` in the 'Optimizations' & 'Using Terser' sections to make all import the same and avoid confusing when reading the docs or try to debug something in there.

# Why

that part is tricky enough! a `@` or not can make difference (and it may lead to a build request just to check... 🤷🏽‍♂️ ).. I passed through this when I was trying to fix another issue around. it made me confused because my build was okay in a case and not in another.

# How

I just add missing `@` to imports, it's that simple.

# Test Plan

try to read docs again.. it's cooler now, and less itchy.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
