### PR TITLE
[expo-updates][android] Remove unused code and clean up some manifest accesses

### DIFF
--- a/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/BaseLegacyManifest.kt
+++ b/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/BaseLegacyManifest.kt
@@ -13,8 +13,6 @@ abstract class BaseLegacyManifest(json: JSONObject) : Manifest(json) {
 
   override fun getEASProjectID(): String? = json.getNullable("projectId")
 
-  fun getMetadata(): JSONObject? = json.getNullable("metadata")
-
   override fun getAssets(): JSONArray? = json.getNullable("assets")
 
   @Throws(JSONException::class)
@@ -35,14 +33,4 @@ abstract class BaseLegacyManifest(json: JSONObject) : Manifest(json) {
   override fun getAppKey(): String? = json.getNullable("appKey")
 
   fun getCommitTime(): String? = json.getNullable("commitTime")
-
-  @Throws(JSONException::class)
-  private fun getPublishedTime(): String = json.require("publishedTime")
-
-  override fun getSortTime(): String? {
-    // use commitTime instead of publishedTime as it is more accurate;
-    // however, fall back to publishedTime in case older cached manifests do not contain
-    // the commitTime key (we have not always served it)
-    return getCommitTime() ?: getPublishedTime()
-  }
 }

--- a/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/Manifest.kt
+++ b/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/Manifest.kt
@@ -68,6 +68,8 @@ abstract class Manifest(protected val json: JSONObject) {
   @Throws(JSONException::class)
   fun getRevisionId(): String = getExpoClientConfigRootObject()!!.require("revisionId")
 
+  fun getMetadata(): JSONObject? = json.getNullable("metadata")
+
   abstract fun getSDKVersion(): String?
 
   abstract fun getAssets(): JSONArray?
@@ -120,8 +122,6 @@ abstract class Manifest(protected val json: JSONObject) {
     return expoClientConfig.getNullable("updates")
   }
 
-  abstract fun getSortTime(): String?
-
   fun getPrimaryColor(): String? {
     val expoClientConfig = getExpoClientConfigRootObject() ?: return null
     return expoClientConfig.getNullable("primaryColor")
@@ -171,7 +171,7 @@ abstract class Manifest(protected val json: JSONObject) {
     val sharedJsEngine = expoClientConfig.getNullable<String>("jsEngine")
     val androidJsEngine = expoClientConfig
       .getNullable<JSONObject>("android")?.getNullable<String>("jsEngine")
-    return androidJsEngine ?: sharedJsEngine ?: null
+    return androidJsEngine ?: sharedJsEngine
   }
 
   fun getIconUrl(): String? {

--- a/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/NewManifest.kt
+++ b/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/NewManifest.kt
@@ -67,10 +67,6 @@ class NewManifest(json: JSONObject) : Manifest(json) {
 
   override fun getAppKey(): String? = null
 
-  override fun getSortTime(): String {
-    return getCreatedAt()
-  }
-
   private fun getExtra(): JSONObject? {
     return json.getNullable("extra")
   }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
@@ -1,7 +1,6 @@
 package expo.modules.updates
 
 import android.content.Context
-import expo.modules.manifests.core.Manifest.Companion.fromManifestJson
 import expo.modules.updates.db.entity.AssetEntity
 import expo.modules.updates.db.entity.UpdateEntity
 import expo.modules.updates.launcher.DatabaseLauncher
@@ -112,10 +111,7 @@ class UpdatesDevLauncherController : UpdatesInterface {
           controller.setLauncher(launcher)
           callback.onSuccess(object : UpdatesInterface.Update {
             override fun getManifest(): JSONObject {
-              val manifest = fromManifestJson(
-                launcher.launchedUpdate!!.manifest!!
-              )
-              return manifest.getRawJson()
+              return launcher.launchedUpdate!!.manifest!!
             }
 
             override fun getLaunchAssetPath(): String {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/selectionpolicy/SelectionPolicies.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/selectionpolicy/SelectionPolicies.kt
@@ -1,6 +1,7 @@
 package expo.modules.updates.selectionpolicy
 
 import android.util.Log
+import expo.modules.manifests.core.Manifest
 import expo.modules.updates.db.entity.UpdateEntity
 import org.json.JSONObject
 import java.lang.Exception
@@ -9,13 +10,16 @@ object SelectionPolicies {
   val TAG = SelectionPolicies::class.java.simpleName
 
   fun matchesFilters(update: UpdateEntity, manifestFilters: JSONObject?): Boolean {
-    if (manifestFilters == null || update.manifest == null || !update.manifest!!.has("metadata")) {
+    val rawManifest = update.manifest
+    if (manifestFilters == null || rawManifest == null) {
       // empty matches all
       return true
     }
-    try {
-      val metadata = update.manifest!!.getJSONObject("metadata")
 
+    val manifest = Manifest.fromManifestJson(rawManifest)
+    val metadata = manifest.getMetadata() ?: return true // empty matches all
+
+    try {
       // create lowercase copy for case-insensitive search
       val metadataLCKeys = JSONObject()
       val metadataKeySet = metadata.keys()


### PR DESCRIPTION
# Why

`getSortTime` was unused.

Closes ENG-1526.

# How

Remove `getSortTime`. Change direct access of `metadata` manifest field to be through the abstraction.

# Test Plan

Build, run all expo-updates tests.