### PR TITLE
[docs] Update github action workflow examples

### DIFF
--- a/docs/pages/build/building-on-ci.md
+++ b/docs/pages/build/building-on-ci.md
@@ -205,16 +205,16 @@ jobs:
         with:
           node-version: 16.x
           cache: npm
-      - name: Setup Expo
-        uses: expo/expo-github-action@v6
+      - name: Setup Expo and EAS
+        uses: expo/expo-github-action@v7
         with:
           expo-version: 5.x
-          expo-cache: true
+          eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}
       - name: Install dependencies
         run: npm ci
       - name: Build on EAS
-        run: npx eas-cli build --platform all --non-interactive
+        run: eas build --platform all --non-interactive
 ```
 
 > Put this into `.github/workflows/eas-build.yml` in the root of your repository.

--- a/docs/pages/build/building-on-ci.md
+++ b/docs/pages/build/building-on-ci.md
@@ -191,34 +191,28 @@ workflows:
 ```yaml
 name: EAS Build
 on:
+  workflow_dispatch:
   push:
     branches:
       - master
-  workflow_dispatch:
-
 jobs:
   build:
     name: Install and build
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v1
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
         with:
           node-version: 16.x
-
+          cache: npm
       - name: Setup Expo
-        uses: expo/expo-github-action@v5
+        uses: expo/expo-github-action@v6
         with:
-          expo-version: 4.x
-          expo-token: ${{ secrets.EXPO_TOKEN }}
+          expo-version: 5.x
           expo-cache: true
-
+          token: ${{ secrets.EXPO_TOKEN }}
       - name: Install dependencies
         run: npm ci
-
       - name: Build on EAS
         run: npx eas-cli build --platform all --non-interactive
 ```

--- a/docs/pages/eas-update/github-actions.md
+++ b/docs/pages/eas-update/github-actions.md
@@ -27,9 +27,10 @@ We can configure GitHub Actions to run on any GitHub event. One of the most comm
                exit 1
              fi
          - uses: actions/checkout@v2
-         - uses: actions/setup-node@v1
+         - uses: actions/setup-node@v2
            with:
              node-version: 16.x
+             cache: yarn
          - uses: expo/expo-github-action@v6
            with:
              expo-version: latest
@@ -37,16 +38,6 @@ We can configure GitHub Actions to run on any GitHub event. One of the most comm
              token: ${{ secrets.EXPO_TOKEN }}
              expo-cache: true
              eas-cache: true
-         - name: Find cache
-           id: yarn-cache-dir-path
-           run: echo "::set-output name=dir::$(yarn cache dir)"
-         - name: Restore cache
-           uses: actions/cache@v2
-           with:
-             path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-             key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-             restore-keys: |
-               ${{ runner.os }}-yarn-
          - name: Install dependencies
            run: yarn install
          - name: Publish update

--- a/docs/pages/eas-update/github-actions.md
+++ b/docs/pages/eas-update/github-actions.md
@@ -31,13 +31,11 @@ We can configure GitHub Actions to run on any GitHub event. One of the most comm
            with:
              node-version: 16.x
              cache: yarn
-         - uses: expo/expo-github-action@v6
+         - uses: expo/expo-github-action@v7
            with:
              expo-version: latest
              eas-version: latest
              token: ${{ secrets.EXPO_TOKEN }}
-             expo-cache: true
-             eas-cache: true
          - name: Install dependencies
            run: yarn install
          - name: Publish update


### PR DESCRIPTION
# Why

Following PR #15845, this updates the 2 GitHub Actions examples we have in our docs.

# How

- Updated EGA to v6
- Updated Expo CLI to v5
- Updated setup-node with built-in cache


# Test Plan

Docs change only

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
