### PR TITLE
[expo-updates] fix IllegalThreadStateException stemming from Updates events

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix `IllegalThreadStateException` that occurred when creating an event to send to React Native early in the app lifecycle.
+- Fix `IllegalThreadStateException` that occurred when creating an event to send to React Native early in the app lifecycle. ([#15880](https://github.com/expo/expo/pull/15880) by [@esamelson](https://github.com/esamelson))
 
 ### 💡 Others
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix `IllegalThreadStateException` that occurred when creating an event to send to React Native early in the app lifecycle.
+
 ### 💡 Others
 
 - Updated `@expo/config-plugins` from `4.0.2` to `4.0.14`, `@expo/config` from `^6.0.6` to `^6.0.14` and `@expo/metro-config` from `~0.2.6` to `~0.3.7` ([#15621](https://github.com/expo/expo/pull/15621) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.kt
@@ -54,14 +54,12 @@ class UpdatesController private constructor(
 
   // TODO: move away from DatabaseHolder pattern to Handler thread
   private val databaseHandlerThread = HandlerThread("expo-updates-database")
-  private var isDatabaseHandlerThreadStarted = false
   private lateinit var databaseHandler: Handler
   private fun initializeDatabaseHandler() {
-    if (!isDatabaseHandlerThreadStarted) {
-      isDatabaseHandlerThreadStarted = true
+    if (!::databaseHandler.isInitialized) {
       databaseHandlerThread.start()
+      databaseHandler = Handler(databaseHandlerThread.looper)
     }
-    databaseHandler = Handler(databaseHandlerThread.looper)
   }
 
   private var isStarted = false

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.kt
@@ -136,16 +136,17 @@ object UpdatesUtils {
   ) {
     val host = reactNativeHost?.get()
     if (host != null) {
-      val instanceManager = host.reactInstanceManager
       AsyncTask.execute {
         try {
           var reactContext: ReactContext? = null
           // in case we're trying to send an event before the reactContext has been initialized
           // continue to retry for 5000ms
           for (i in 0..4) {
-            reactContext = instanceManager.currentReactContext
-            if (reactContext != null) {
-              break
+            if (host.hasInstance()) {
+              reactContext = host.reactInstanceManager.currentReactContext
+              if (reactContext != null) {
+                break
+              }
             }
             Thread.sleep(1000)
           }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.kt
@@ -142,6 +142,9 @@ object UpdatesUtils {
           // in case we're trying to send an event before the reactContext has been initialized
           // continue to retry for 5000ms
           for (i in 0..4) {
+            // Calling host.reactInstanceManager has a side effect of creating a new
+            // reactInstanceManager if there isn't already one. We want to avoid this so we check
+            // if it has an instance first.
             if (host.hasInstance()) {
               reactContext = host.reactInstanceManager.currentReactContext
               if (reactContext != null) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/errorrecovery/ErrorRecovery.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/errorrecovery/ErrorRecovery.kt
@@ -13,13 +13,17 @@ import kotlin.Exception
 
 class ErrorRecovery {
   internal val handlerThread = HandlerThread("expo-updates-error-recovery")
+  private var isHandlerThreadStarted = false
   internal lateinit var handler: Handler
 
   private var weakReactInstanceManager: WeakReference<ReactInstanceManager>? = null
   private var previousExceptionHandler: DefaultNativeModuleCallExceptionHandler? = null
 
   fun initialize(delegate: ErrorRecoveryDelegate) {
-    handlerThread.start()
+    if (!isHandlerThreadStarted) {
+      isHandlerThreadStarted = true
+      handlerThread.start()
+    }
     handler = ErrorRecoveryHandler(handlerThread.looper, delegate)
   }
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/errorrecovery/ErrorRecovery.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/errorrecovery/ErrorRecovery.kt
@@ -13,18 +13,16 @@ import kotlin.Exception
 
 class ErrorRecovery {
   internal val handlerThread = HandlerThread("expo-updates-error-recovery")
-  private var isHandlerThreadStarted = false
   internal lateinit var handler: Handler
 
   private var weakReactInstanceManager: WeakReference<ReactInstanceManager>? = null
   private var previousExceptionHandler: DefaultNativeModuleCallExceptionHandler? = null
 
   fun initialize(delegate: ErrorRecoveryDelegate) {
-    if (!isHandlerThreadStarted) {
-      isHandlerThreadStarted = true
+    if (!::handler.isInitialized) {
       handlerThread.start()
+      handler = ErrorRecoveryHandler(handlerThread.looper, delegate)
     }
-    handler = ErrorRecoveryHandler(handlerThread.looper, delegate)
   }
 
   fun startMonitoring(reactInstanceManager: ReactInstanceManager) {


### PR DESCRIPTION
# Why

resolves ENG-2829

# How

Investigated and determined that the issue is caused in the following way:
(1) ReactNativeHostWrapper calls onWillCreateReactInstanceManager, which starts the updates process via UpdatesPackage (UpdatesController.initialize() -> UpdatesController.start())
(2) no update is found. UpdatesController immediately tries to emit an event to the Updates native module
(3) UpdatesUtils.sendEventFromReactNative calls ReactNativeHost.getReactInstanceManager(), which has a side effect of creating a new ReactInstanceManager if the host doesn't have one. **In this case it seems that there's a race condition and the ReactInstanceManager being created in (1) isn't finished initializing yet, so we inadvertently create a new one here.**
(4) ReactNativeHostWrapper calls onWillCreateReactInstanceManager a second time
(5) UpdatesController.initialize() is called a second time. **There is already a singleton instance, so this should no-op, but due to a bug in the initialize method, `start` is called a second time as well.**
(6) `start` is called on the database handler thread a second time, which causes the `IllegalThreadStateException`.

This PR includes 5 fixes, **each of which is enough to stop the crash by itself**, but having all 5 is the safest and most correct.
- UpdatesUtils.kt: check `ReactNativeHost.hasInstance()` before calling `getReactInstanceManager()`; this prevents us from inadvertently creating an instance when we don't mean to.
- UpdatesController.initialize(): noop if the singleton has already been initialized before this method was called. This was the intended behavior and was probably overlooked when `initializeWithoutStarting` was factored out.
- UpdatesController.start(): keep a piece of state that prevents `start` from being called twice on the same instance (which is always an error).
- handler threads: keep a piece of state that prevents `start` from being called twice on the same thread (which will always result in an `IllegalThreadStateException`).

# Test Plan

Reproduced issue using the repo provided here: https://github.com/expo/expo/issues/15708#issuecomment-1009339263 . With this change patched locally, the app no longer crashes when built in release mode.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
