### PR TITLE
[template] Reorder AppDelegate methods to prevent breaking behavior.

### DIFF
--- a/templates/expo-template-bare-minimum/ios/HelloWorld/AppDelegate.m
+++ b/templates/expo-template-bare-minimum/ios/HelloWorld/AppDelegate.m
@@ -63,14 +63,13 @@ static void InitializeFlipper(UIApplication *application) {
 
 // Linking API
 - (BOOL)application:(UIApplication *)application openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
-  [RCTLinkingManager application:application openURL:url options:options];
-  return [super application:application openURL:url options:options];
+  return [super application:application openURL:url options:options] || [RCTLinkingManager application:application openURL:url options:options];
 }
 
 // Universal Links
 - (BOOL)application:(UIApplication *)application continueUserActivity:(nonnull NSUserActivity *)userActivity restorationHandler:(nonnull void (^)(NSArray<id<UIUserActivityRestoring>> * _Nullable))restorationHandler {
-  [RCTLinkingManager application:application continueUserActivity:userActivity restorationHandler:restorationHandler];
-  return [super application:application continueUserActivity:userActivity restorationHandler:restorationHandler];
+  BOOL result = [RCTLinkingManager application:application continueUserActivity:userActivity restorationHandler:restorationHandler];
+  return [super application:application continueUserActivity:userActivity restorationHandler:restorationHandler] || result;
 }
 
 @end


### PR DESCRIPTION
# Why

- As [mentioned](https://github.com/expo/expo/pull/15684#issuecomment-1004534929), the proposed order would change from returning true to always returning false. CC @giautm

# How

- Attempt to replicate the previous unimodule adapter behavior.
- `[application: openURL: options:]` can be used to skip the `RCTLinkingManager` (Linking API) delegate method.
- `[application: continueUserActivity: restorationHandler:]` can not override the `RCTLinkingManager` method.

