### PR TITLE
Stop using jcenter in bare template

### DIFF
--- a/templates/expo-template-bare-minimum/android/build.gradle
+++ b/templates/expo-template-bare-minimum/android/build.gradle
@@ -10,7 +10,6 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
     dependencies {
         classpath("com.android.tools.build:gradle:4.1.0")
@@ -31,10 +30,14 @@ allprojects {
             // Android JSC is installed from npm
             url(new File(["node", "--print", "require.resolve('jsc-android/package.json')"].execute(null, rootDir).text.trim(), "../dist"))
         }
-
+        mavenCentral {
+            // We don't want to fetch react-native from Maven Central as there are
+            // older versions over there.
+            content {
+                excludeGroup "com.facebook.react"
+            }
+        }
         google()
-        mavenCentral()
-        jcenter()
         maven { url 'https://www.jitpack.io' }
     }
 }


### PR DESCRIPTION
# Why

[JCenter is shutting down in February](https://blog.gradle.org/jcenter-shutdown) and already has intermittent downtime, so we should stop depending on it. I should have made this change earlier, apologies.

# How

Remove jcenter from build.gradle, update mavenCentral block to exclude `com.facebook.react` as in the React Native default template. 

# Test Plan

- Ran a build on EAS Build before this change, it failed: https://expo.dev/accounts/notbrent/projects/testjc/builds/1ed66ff8-9deb-43a0-8d91-5719b40cce0f
- Ran a build on EAS Build with this change, it succeeded: https://expo.dev/accounts/notbrent/projects/testjc/builds/7165bd75-7fea-4ac2-8925-758e3d5c82a0

# Follow up

- Backport to old SDK versions
- Broadcast to developers building bare apps that they should also remove jcenter

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
