### PR TITLE
[dev-launcher] Fix detecting import when using double quotes

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fix bug on iOS where all URL schemes, rather than just `exp`, were replaced with `http`. ([#15796](https://github.com/expo/expo/pull/15796) by [@esamelson](https://github.com/esamelson))
+- Fix detecting import when using double quotes. ([#15898](https://github.com/expo/expo/pull/15898) by [@janicduplessis](https://github.com/janicduplessis))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/plugin/build/withDevLauncher.js
+++ b/packages/expo-dev-launcher/plugin/build/withDevLauncher.js
@@ -34,8 +34,7 @@ const DEV_LAUNCHER_UPDATES_ANDROID_INIT = `if (BuildConfig.DEBUG) {
       DevLauncherController.getInstance().setUpdatesInterface(UpdatesDevLauncherController.initialize(this));
     }`;
 const DEV_LAUNCHER_UPDATES_DEVELOPER_SUPPORT = 'return DevLauncherController.getInstance().getUseDeveloperSupport();';
-const DEV_LAUNCHER_JS_REGISTER_ERROR_HANDLERS = `import 'expo-dev-client'`;
-const DEV_LAUNCHER_JS_REGISTER_ERROR_HANDLERS_VIA_LAUNCHER = `import 'expo-dev-launcher'`;
+const DEV_LAUNCHER_JS_REGISTER_ERROR_HANDLERS_REGEX = /import ['"](?:expo-dev-client|expo-dev-launcher)['"]/;
 async function readFileAsync(path) {
     return fs_1.default.promises.readFile(path, 'utf8');
 }
@@ -201,9 +200,8 @@ const withDevLauncherPodfile = (config) => {
 const withErrorHandling = (config) => {
     const injectErrorHandlers = async (config) => {
         await editIndex(config, (index) => {
-            if (!index.includes(DEV_LAUNCHER_JS_REGISTER_ERROR_HANDLERS) &&
-                !index.includes(DEV_LAUNCHER_JS_REGISTER_ERROR_HANDLERS_VIA_LAUNCHER)) {
-                index = DEV_LAUNCHER_JS_REGISTER_ERROR_HANDLERS + ';\n\n' + index;
+            if (!DEV_LAUNCHER_JS_REGISTER_ERROR_HANDLERS_REGEX.test(index)) {
+                index = `import 'expo-dev-client';\n\n${index}`;
             }
             return index;
         });

--- a/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
+++ b/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
@@ -42,8 +42,8 @@ const DEV_LAUNCHER_UPDATES_ANDROID_INIT = `if (BuildConfig.DEBUG) {
 const DEV_LAUNCHER_UPDATES_DEVELOPER_SUPPORT =
   'return DevLauncherController.getInstance().getUseDeveloperSupport();';
 
-const DEV_LAUNCHER_JS_REGISTER_ERROR_HANDLERS = `import 'expo-dev-client'`;
-const DEV_LAUNCHER_JS_REGISTER_ERROR_HANDLERS_VIA_LAUNCHER = `import 'expo-dev-launcher'`;
+const DEV_LAUNCHER_JS_REGISTER_ERROR_HANDLERS_REGEX =
+  /import ['"](?:expo-dev-client|expo-dev-launcher)['"]/;
 
 async function readFileAsync(path: string): Promise<string> {
   return fs.promises.readFile(path, 'utf8');
@@ -274,11 +274,8 @@ const withDevLauncherPodfile: ConfigPlugin = (config) => {
 const withErrorHandling: ConfigPlugin = (config) => {
   const injectErrorHandlers = async (config: ExportedConfigWithProps) => {
     await editIndex(config, (index) => {
-      if (
-        !index.includes(DEV_LAUNCHER_JS_REGISTER_ERROR_HANDLERS) &&
-        !index.includes(DEV_LAUNCHER_JS_REGISTER_ERROR_HANDLERS_VIA_LAUNCHER)
-      ) {
-        index = DEV_LAUNCHER_JS_REGISTER_ERROR_HANDLERS + ';\n\n' + index;
+      if (!DEV_LAUNCHER_JS_REGISTER_ERROR_HANDLERS_REGEX.test(index)) {
+        index = `import 'expo-dev-client';\n\n${index}`;
       }
       return index;
     });


### PR DESCRIPTION
# Why

If using double quotes in index.js (enforced by prettier) it doesn't detect the import properly.

# How

Uses a regex to find the import.

# Test Plan

Test by running expo prebuild and running different combinations of import style that should be supported.

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
