### PR TITLE
[expo-updates][ios] Escape code signing header strings

### DIFF
--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/CryptoTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/CryptoTest.kt
@@ -53,6 +53,19 @@ class CryptoTest {
     Assert.assertEquals(signatureHeader, "sig, keyid=\"test\", alg=\"rsa-v1_5-sha256\"")
   }
 
+  @Test
+  fun test_createAcceptSignatureHeader_CreatesSignatureHeaderEscapedValues() {
+    val configuration = Crypto.CodeSigningConfiguration(
+      testCertificate,
+      mapOf(
+        Crypto.CODE_SIGNING_METADATA_ALGORITHM_KEY to "rsa-v1_5-sha256",
+        Crypto.CODE_SIGNING_METADATA_KEY_ID_KEY to """test"hello\"""
+      )
+    )
+    val signatureHeader = Crypto.createAcceptSignatureHeader(configuration)
+    Assert.assertEquals("""sig, keyid="test\"hello\\", alg="rsa-v1_5-sha256"""", signatureHeader)
+  }
+
   @Test(expected = Exception::class)
   @Throws(Exception::class)
   fun test_createAcceptSignatureHeader_ThrowsInvalidAlg() {

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesCodeSigningConfiguration.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesCodeSigningConfiguration.swift
@@ -57,9 +57,16 @@ public class EXUpdatesCodeSigningConfiguration : NSObject {
     algorithm = try parseCodeSigningAlgorithm(metadata[EXUpdatesCodeSigningMetadataFields.AlgorithmFieldKey])
   }
   
+  /**
+   * String escaping is defined by https://www.rfc-editor.org/rfc/rfc8941.html#section-3.3.3
+   */
+  private static func escapeStructuredHeaderStringItem(_ str: String) -> String {
+    return str.replacingOccurrences(of: "\\", with: "\\\\").replacingOccurrences(of: "\"", with: "\\\"")
+  }
+  
   @objc
   public func createAcceptSignatureHeader() -> String {
-    return "sig, keyid=\"\(keyId)\", alg=\"\(algorithm.rawValue)\""
+    return "sig, keyid=\"\(EXUpdatesCodeSigningConfiguration.escapeStructuredHeaderStringItem(keyId))\", alg=\"\(EXUpdatesCodeSigningConfiguration.escapeStructuredHeaderStringItem(algorithm.rawValue))\""
   }
   
   @objc

--- a/packages/expo-updates/ios/Tests/EXUpdatesCodeSigningConfigurationTests.swift
+++ b/packages/expo-updates/ios/Tests/EXUpdatesCodeSigningConfigurationTests.swift
@@ -15,6 +15,14 @@ class EXUpdatesCodeSigningConfigurationTests : XCTestCase {
     XCTAssertEqual(signatureHeader, "sig, keyid=\"root\", alg=\"rsa-v1_5-sha256\"")
   }
   
+  func test_createAcceptSignatureHeader_CreatesSignatureHeaderEscapedValues() throws {
+    let configuration = try EXUpdatesCodeSigningConfiguration(certificate: testCertificate,
+                                                              metadata: [EXUpdatesCodeSigningMetadataFields.AlgorithmFieldKey: EXUpdatesCodeSigningAlgorithm.RSA_SHA256.rawValue,
+                                                                         EXUpdatesCodeSigningMetadataFields.KeyIdFieldKey: #"test"hello\"#])
+    let signatureHeader = configuration.createAcceptSignatureHeader()
+    XCTAssertEqual(signatureHeader, #"sig, keyid="test\"hello\\", alg="rsa-v1_5-sha256""#)
+  }
+  
   func test_createAcceptSignatureHeader_CreatesSignatureHeaderValuesFromConfig() throws {
     let configuration = try EXUpdatesCodeSigningConfiguration(certificate: testCertificate,
                                                               metadata: [EXUpdatesCodeSigningMetadataFields.AlgorithmFieldKey: EXUpdatesCodeSigningAlgorithm.RSA_SHA256.rawValue,


### PR DESCRIPTION
# Why

Structured header strings are escaped according to a specific spec. Since we don't have the formal structured header composer mechanisms in iOS, we just construct the string manually. Eventually when we add the full structured header composer mechanism we can replace this. Until then, we need to escape the user-supplied values (the same as we do on android in the library).

Closes ENG-2834.

Ref: https://github.com/expo/expo/pull/15682#discussion_r782761577

# How

Escape based on the spec and https://github.com/reschke/structured-fields/blob/master/src/main/java/org/greenbytes/http/sfv/StringItem.java#L52

# Test Plan

Inspect & run new test.