### PR TITLE
[dev-menu] add new functions to dev menu

### DIFF
--- a/packages/expo-dev-menu/.npmignore
+++ b/packages/expo-dev-menu/.npmignore
@@ -7,5 +7,6 @@ __mocks__
 __tests__
 
 /babel.config.js
+/metro.config.js
 /android/src/androidTest/
 /android/src/test/

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/modules/DevMenuInternalModule.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/modules/DevMenuInternalModule.kt
@@ -35,6 +35,15 @@ interface DevMenuInternalMenuControllerModuleInterface {
 
   @ReactMethod
   fun fetchDataSourceAsync(id: String?, promise: Promise)
+
+  @ReactMethod
+  fun getDevSettingsAsync(promise: Promise)
+
+  @ReactMethod
+  fun getBuildInfoAsync(promise: Promise)
+
+  @ReactMethod
+  fun copyToClipboardAsync(content: String, promise: Promise)
 }
 
 interface DevMenuInternalSessionManagerModuleInterface {

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/modules/internals/DevMenuInternalMenuControllerModule.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/modules/internals/DevMenuInternalMenuControllerModule.kt
@@ -1,9 +1,15 @@
 package expo.modules.devmenu.modules.internals
 
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.content.pm.PackageManager
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.devsupport.DevInternalSettings
+import expo.modules.devmenu.devtools.DevMenuDevToolsDelegate
 import expo.modules.devmenu.modules.DevMenuInternalMenuControllerModuleInterface
 import expo.modules.devmenu.modules.DevMenuManagerProvider
 import kotlinx.coroutines.launch
@@ -83,5 +89,96 @@ class DevMenuInternalMenuControllerModule(private val reactContext: ReactContext
       val result = Arguments.fromList(data.map { it.serialize() })
       promise.resolve(result)
     }
+  }
+
+  override fun getDevSettingsAsync(promise: Promise) {
+    val reactInstanceManager = devMenuManger.getSession()?.reactInstanceManager
+    val map = Arguments.createMap()
+
+    if (reactInstanceManager != null) {
+      val devDelegate = DevMenuDevToolsDelegate(devMenuManger, reactInstanceManager)
+      val devSettings = devDelegate.devSettings
+      val devInternalSettings = (devSettings as? DevInternalSettings)
+
+      map.apply {
+        if (devInternalSettings != null) {
+          putBoolean("isDebuggingRemotely", devSettings.isRemoteJSDebugEnabled)
+          putBoolean("isElementInspectorShown", devSettings.isElementInspectorEnabled)
+          putBoolean("isHotLoadingEnabled", devSettings.isHotModuleReplacementEnabled)
+          putBoolean("isPerfMonitorShown", devSettings.isFpsDebugEnabled)
+        }
+      }
+    }
+
+    promise.resolve(map)
+  }
+
+  override fun getBuildInfoAsync(promise: Promise) {
+    val map = Arguments.createMap()
+    val packageManager = reactContext.packageManager
+    val packageName = reactContext.packageName
+    val packageInfo =  packageManager.getPackageInfo(packageName, 0)
+
+    var appVersion = packageInfo.versionName
+    val applicationInfo = packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA)
+    var appName = packageManager.getApplicationLabel(applicationInfo).toString()
+    val runtimeVersion = getMetadataValue("expo.modules.updates.EXPO_RUNTIME_VERSION")
+    val sdkVersion = getMetadataValue("expo.modules.updates.EXPO_SDK_VERSION")
+    var appIcon = getApplicationIconUri()
+    var hostUrl = reactContext.sourceURL
+
+    val manifest = devMenuManger.getSession()?.appInfo
+
+    if (manifest != null) {
+      if (manifest.get("appName") != null) {
+        appName = manifest.get("appName") as String
+      }
+
+      if (manifest.get("appVersion") != null) {
+        appVersion = manifest.get("appVersion") as String
+      }
+
+      if (manifest.get("hostUrl") != null) {
+        hostUrl = manifest.get("hostUrl") as String
+      }
+    }
+
+    map.apply {
+      putString("appVersion", appVersion)
+      putString("appName", appName)
+      putString("appIcon", appIcon)
+      putString("runtimeVersion", runtimeVersion)
+      putString("sdkVersion", sdkVersion)
+      putString("hostUrl", hostUrl)
+    }
+
+    promise.resolve(map)
+  }
+
+  override fun copyToClipboardAsync(content: String, promise: Promise) {
+    val clipboard = reactContext.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+    val clip = ClipData.newPlainText(null, content)
+    clipboard.setPrimaryClip(clip)
+    promise.resolve(null)
+  }
+
+  private fun getMetadataValue(key: String): String {
+    val packageManager = reactContext.packageManager
+    val packageName = reactContext.packageName
+    val applicationInfo = packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA)
+    return applicationInfo.metaData?.get(key)?.toString() ?: ""
+  }
+
+  private fun getApplicationIconUri(): String {
+    var appIcon = ""
+    val packageManager = reactContext.packageManager
+    val packageName = reactContext.packageName
+    val applicationInfo = packageManager.getApplicationInfo(packageName, 0)
+
+    if (applicationInfo.icon != null) {
+      appIcon = "" + applicationInfo.icon
+    }
+    //    TODO - figure out how to get resId for AdaptiveIconDrawable icons
+    return appIcon
   }
 }

--- a/packages/expo-dev-menu/app/native-modules/DevMenu.ts
+++ b/packages/expo-dev-menu/app/native-modules/DevMenu.ts
@@ -66,12 +66,7 @@ export async function toggleFastRefreshAsync() {
 }
 
 export async function getDevSettingsAsync(): Promise<DevSettings> {
-  return {
-    isDebuggingRemotely: false,
-    isElementInspectorShown: false,
-    isHotLoadingEnabled: false,
-    isPerfMonitorShown: false,
-  };
+  return await DevMenu.getDevSettingsAsync();
 }
 
 export async function getBuildInfoAsync(): Promise<BuildInfo> {

--- a/packages/expo-dev-menu/ios/DevMenuAppInstance.swift
+++ b/packages/expo-dev-menu/ios/DevMenuAppInstance.swift
@@ -3,6 +3,7 @@
 @objc
 class DevMenuAppInstance: DevMenuBaseAppInstance, RCTBridgeDelegate {
   static private var CloseEventName = "closeDevMenu"
+  static private var OpenEventName = "openDevMenu"
 
   private let manager: DevMenuManager
 
@@ -41,6 +42,10 @@ class DevMenuAppInstance: DevMenuBaseAppInstance, RCTBridgeDelegate {
    */
   public func sendCloseEvent() {
     bridge?.enqueueJSCall("RCTDeviceEventEmitter.emit", args: [DevMenuAppInstance.CloseEventName])
+  }
+  
+  public func sendOpenEvent() {
+    bridge?.enqueueJSCall("RCTDeviceEventEmitter.emit", args: [DevMenuAppInstance.OpenEventName])
   }
 
   // MARK: RCTBridgeDelegate

--- a/packages/expo-dev-menu/ios/DevMenuManager.swift
+++ b/packages/expo-dev-menu/ios/DevMenuManager.swift
@@ -155,6 +155,7 @@ open class DevMenuManager: NSObject, DevMenuManagerProtocol {
   @objc
   @discardableResult
   public func openMenu() -> Bool {
+    appInstance.sendOpenEvent()
     return openMenu(nil)
   }
 

--- a/packages/expo-dev-menu/ios/DevMenuRCTBridge.m
+++ b/packages/expo-dev-menu/ios/DevMenuRCTBridge.m
@@ -17,6 +17,8 @@
  */
 - (RCTDevSettings *)devSettings
 {
+  // uncomment below to enable fast refresh for development builds of DevMenu
+  //  return super.devSettings;
   return nil;
 }
 

--- a/packages/expo-dev-menu/ios/EXDevMenuBuildInfo.h
+++ b/packages/expo-dev-menu/ios/EXDevMenuBuildInfo.h
@@ -1,0 +1,13 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+#import <Foundation/Foundation.h>
+#import <React/RCTBridge.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface EXDevMenuBuildInfo : NSObject
+
++ (NSDictionary *)getBuildInfoForBridge:(RCTBridge *)bridge andManifest:(NSDictionary *)manifest;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-dev-menu/ios/EXDevMenuBuildInfo.m
+++ b/packages/expo-dev-menu/ios/EXDevMenuBuildInfo.m
@@ -1,0 +1,77 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+#import "EXDevMenuBuildInfo.h"
+
+@implementation EXDevMenuBuildInfo
+
++(NSDictionary *)getBuildInfoForBridge:(RCTBridge *)bridge andManifest:(NSDictionary *)manifest
+{
+  NSMutableDictionary *buildInfo = [NSMutableDictionary new];
+
+  NSString *appIcon = [EXDevMenuBuildInfo getAppIcon];
+  NSString *runtimeVersion = [EXDevMenuBuildInfo getUpdatesConfigForKey:@"EXUpdatesRuntimeVersion"];
+  NSString *sdkVersion = [EXDevMenuBuildInfo getUpdatesConfigForKey:@"EXUpdatesSDKVersion"];
+  NSString *appVersion = [EXDevMenuBuildInfo getFormattedAppVersion];
+  NSString *appName = [[NSBundle mainBundle] objectForInfoDictionaryKey: @"CFBundleDisplayName"] ?: [[NSBundle mainBundle] objectForInfoDictionaryKey: @"CFBundleExecutable"];
+  NSString *hostUrl = [bridge.bundleURL host] ?: @"";
+
+  if (manifest[@"appName"] != nil) {
+    appName = manifest[@"appName"];
+  }
+  
+  if (manifest[@"appVersion"] != nil) {
+    appVersion = manifest[@"appVersion"];
+  }
+  
+  if (manifest[@"hostUrl"] != nil) {
+    hostUrl = manifest[@"hostUrl"];
+  }
+
+  buildInfo[@"appName"] = appName;
+  buildInfo[@"appIcon"] = appIcon;
+  buildInfo[@"appVersion"] = appVersion;
+  buildInfo[@"runtimeVersion"] = runtimeVersion;
+  buildInfo[@"sdkVersion"] = sdkVersion;
+  buildInfo[@"hostUrl"] = hostUrl;
+
+  return buildInfo;
+}
+
++(NSString *)getAppIcon
+{
+  NSString *appIcon = @"";
+  NSString *appIconName = [[[[[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleIcons"] objectForKey:@"CFBundlePrimaryIcon"] objectForKey:@"CFBundleIconFiles"]  lastObject];
+  
+  if (appIconName != nil) {
+    NSString *resourcePath = [[NSBundle mainBundle] resourcePath];
+    NSString *appIconPath = [[resourcePath stringByAppendingString:appIconName] stringByAppendingString:@".png"];
+    appIcon = [@"file://" stringByAppendingString:appIconPath];
+  }
+  
+  return appIcon;
+}
+
++(NSString *)getUpdatesConfigForKey:(NSString *)key
+{
+  NSString *value = @"";
+  NSString *path = [[NSBundle mainBundle] pathForResource:@"Expo" ofType:@"plist"];
+  
+  if (path != nil) {
+    NSDictionary *expoConfig = [NSDictionary dictionaryWithContentsOfFile:path];
+    
+    if (expoConfig != nil) {
+      value = [expoConfig objectForKey:key] ?: @"";
+    }
+  }
+
+  return value;
+}
+
++(NSString *)getFormattedAppVersion
+{
+  NSString *shortVersion = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
+  NSString *buildVersion = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"];
+  NSString *appVersion = [NSString stringWithFormat:@"%@ (%@)", shortVersion, buildVersion];
+  return appVersion;
+}
+
+@end

--- a/packages/expo-dev-menu/ios/Headers/EXDevMenu-Bridging-Header.h
+++ b/packages/expo-dev-menu/ios/Headers/EXDevMenu-Bridging-Header.h
@@ -23,3 +23,4 @@
 // Private
 #import "RCTPerfMonitor+Private.h"
 #import "DevMenuBaseAppInstance.h"
+#import "EXDevMenuBuildInfo.h"

--- a/packages/expo-dev-menu/ios/Modules/DevMenuInternalModule.m
+++ b/packages/expo-dev-menu/ios/Modules/DevMenuInternalModule.m
@@ -29,7 +29,8 @@ RCT_EXTERN_METHOD(getAuthSchemeAsync:(RCTPromiseResolveBlock)resolve reject:(RCT
 
 RCT_EXTERN_METHOD(setSessionAsync:(NSDictionary *)session resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(restoreSessionAsync:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
-
+RCT_EXTERN_METHOD(getBuildInfoAsync:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(getDevSettingsAsync:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
 /**
  * Helper that is used in openBrowserAsync and openAuthSessionAsync
@@ -93,6 +94,15 @@ RCT_EXPORT_METHOD(openAuthSessionAsync:(NSString *)authURL
 {
   self.redirectResolve = nil;
   self.redirectReject = nil;
+}
+
+RCT_EXPORT_METHOD(copyToClipboardAsync:(NSString *)content
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+  UIPasteboard *clipboard = [UIPasteboard generalPasteboard];
+  clipboard.string = (content ?: @"");
+  resolve(nil);
 }
 
 @end

--- a/packages/expo-dev-menu/ios/Modules/DevMenuInternalModule.swift
+++ b/packages/expo-dev-menu/ios/Modules/DevMenuInternalModule.swift
@@ -202,4 +202,35 @@ public class DevMenuInternalModule: NSObject, RCTBridgeModule {
 
     resolve(DevMenuInternalModule.defaultScheme)
   }
+  
+  @objc
+  func getBuildInfoAsync(_ resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
+    let bridge = manager.delegate?.appBridge?(forDevMenuManager: self.manager)
+    let manifest = manager.session?.appInfo ?? [:]
+    
+    let buildInfo = EXDevMenuBuildInfo.getFor(bridge as! RCTBridge, andManifest: manifest as Any as! [AnyHashable : Any])
+        
+    resolve([
+      "appName": buildInfo["appName"],
+      "appIcon": buildInfo["appIcon"],
+      "appVersion": buildInfo["appVersion"],
+      "runtimeVersion": buildInfo["runtimeVersion"],
+      "sdkVersion": buildInfo["sdkVersion"],
+      "hostUrl": buildInfo["hostUrl"],
+    ])
+  }
+  
+  @objc
+  func getDevSettingsAsync(_ resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
+    let bridge = manager.delegate?.appBridge?(forDevMenuManager: self.manager)
+    
+    if let devSettings = bridge?.module(forName: "DevSettings") as? RCTDevSettings {
+      resolve([
+        "isDebuggingRemotely": devSettings.isDebuggingRemotely,
+        "isElementInspectorShown": devSettings.isElementInspectorShown,
+        "isHotLoadingEnabled": devSettings.isHotLoadingEnabled,
+        "isPerfMonitorShown": devSettings.isPerfMonitorShown,
+      ])
+    }
+  }
 }

--- a/packages/expo-dev-menu/metro.config.js
+++ b/packages/expo-dev-menu/metro.config.js
@@ -2,6 +2,23 @@ const { createMetroConfiguration } = require('expo-yarn-workspaces');
 
 const config = createMetroConfiguration(__dirname);
 
+config.server = {
+  enhanceMiddleware: (middleware) => {
+    return (req, res, next) => {
+      const url = new URL(req.url, `http://${req.headers.host}`);
+      const platform = url.searchParams.get('platform');
+
+      // When an asset is imported outside the project root, it has wrong path on Android
+      // So we fix the path to correct one
+      if (platform === 'android' && /\/assets\/.+\.(png|jpg|jpeg)\?.+$/.test(req.url)) {
+        req.url = `/assets/../${req.url}`;
+      }
+
+      return middleware(req, res, next);
+    };
+  },
+};
+
 const { EXPO_BUNDLE_APP } = process.env;
 
 if (EXPO_BUNDLE_APP) {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
this adds a couple methods on the DevMenu native module in order to get some information about the app that is running 

at this point I think it would be a good idea to remove the dev menu from the dev launcher all together, it doesn't make sense as it provides no useful options when open in the launcher

# How

<!--
How did you build this feature or fix this bug and why?
-->

Mostly reused some code from the dev launcher, repurposed some for the dev menu and then updated the react code to actually use these methods (instead of the stubs)

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

- toggling the dev menu and updating the various settings

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
