### PR TITLE
[expo] Delete TYPESCRIPT.md

### DIFF
--- a/packages/expo/TYPESCRIPT.md
+++ b/packages/expo/TYPESCRIPT.md
@@ -1,1 +1,0 @@
-We are migrating the Expo SDK to TypeScript. If you are working on this, make sure you run `yarn build` (or `yarn expo-module tsc`) in this folder when you make changes.


### PR DESCRIPTION
This file was just a message that is no longer relevant. Migration to TS is done.
