### PR TITLE
[dev-launcher][Android] Save the uncaught exception

### DIFF
--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/errors/DevLauncherErrorRegistry.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/errors/DevLauncherErrorRegistry.kt
@@ -1,0 +1,46 @@
+package expo.modules.devlauncher.launcher.errors
+
+import android.content.Context
+import android.content.SharedPreferences
+import com.google.gson.Gson
+import expo.modules.devlauncher.launcher.DevLauncherRecentlyOpenedAppsRegistry
+
+private const val ERROR_REGISTRY_SHARED_PREFERENCES = "expo.modules.devlauncher.errorregistry"
+private const val ERROR_REGISTRY_SHARED_PREFERENCES_KEY = "SavedError"
+
+data class DevLauncherErrorInstance(
+  val throwable: Throwable,
+  val timestamp: Long = DevLauncherRecentlyOpenedAppsRegistry.TimeHelper.getCurrentTime()
+)
+
+class DevLauncherErrorRegistry(context: Context) {
+  private val sharedPreferences: SharedPreferences = context
+    .getSharedPreferences(
+      ERROR_REGISTRY_SHARED_PREFERENCES,
+      Context.MODE_PRIVATE
+    )
+
+  fun storeException(throwable: Throwable) {
+    val errorInstance = DevLauncherErrorInstance(throwable)
+    val jsonString = Gson().toJson(errorInstance)
+
+    sharedPreferences
+      .edit()
+      .putString(ERROR_REGISTRY_SHARED_PREFERENCES_KEY, jsonString)
+      .apply()
+  }
+
+  fun consumeException(): DevLauncherErrorInstance? {
+    val jsonString = sharedPreferences.getString(ERROR_REGISTRY_SHARED_PREFERENCES_KEY, null)
+      ?: return null
+
+    try {
+      return Gson().fromJson(jsonString, DevLauncherErrorInstance::class.java)
+    } finally {
+      sharedPreferences
+        .edit()
+        .remove(ERROR_REGISTRY_SHARED_PREFERENCES_KEY)
+        .apply()
+    }
+  }
+}

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/errors/DevLauncherUncaughtExceptionHandler.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/errors/DevLauncherUncaughtExceptionHandler.kt
@@ -53,6 +53,8 @@ class DevLauncherUncaughtExceptionHandler(
 
     exceptionWasReported = true
     Log.e("DevLauncher", "DevLauncher tries to handle uncaught exception.", exception)
+    tryToSaveException(exception)
+
     applicationHolder.get()?.let {
       DevLauncherErrorActivity.showFatalError(
         it,
@@ -83,5 +85,11 @@ class DevLauncherUncaughtExceptionHandler(
         exitProcess(0)
       }
     }
+  }
+
+  private fun tryToSaveException(exception: Throwable) {
+    val context = DevLauncherKoinContext.app.koin.getOrNull<Context>() ?: return
+    val errorRegistry = DevLauncherErrorRegistry(context)
+    errorRegistry.storeException(exception)
   }
 }

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/errors/DevLauncherUncaughtExceptionHandler.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/errors/DevLauncherUncaughtExceptionHandler.kt
@@ -2,9 +2,11 @@ package expo.modules.devlauncher.launcher.errors
 
 import android.app.Activity
 import android.app.Application
+import android.content.Context
 import android.os.Bundle
 import android.os.Process
 import android.util.Log
+import expo.modules.devlauncher.koin.DevLauncherKoinContext
 import java.lang.ref.WeakReference
 import java.util.*
 import kotlin.concurrent.schedule


### PR DESCRIPTION
# Why

Part of ENG-2740.

# How

Saved an uncaught exception in shared preferences if possible. 

# Test Plan

- throws an exception in the start method of the app and checks (using a debugger) if shared preferences were updated.