### PR TITLE
[docs] Anonymize GA IPs

### DIFF
--- a/docs/common/analytics.tsx
+++ b/docs/common/analytics.tsx
@@ -18,6 +18,7 @@ export function TrackPageView({ id }: { id: string }) {
       window?.gtag?.('config', id, {
         page_path: url,
         transport_type: 'beacon',
+        anonymize_ip: true,
       });
     };
 

--- a/docs/pages/_app.tsx
+++ b/docs/pages/_app.tsx
@@ -45,6 +45,7 @@ export function reportWebVitals({ id, name, label, value }: NextWebVitalsMetric)
     event_label: id,
     // Use a non-interaction event to avoid affecting bounce rate.
     non_interaction: true,
+    anonymize_ip: true,
   });
 }
 
@@ -66,7 +67,7 @@ function App({ Component, pageProps }: AppProps) {
                 window.dataLayer = window.dataLayer || [];
                 function gtag(){dataLayer.push(arguments);}
                 gtag('js', new Date());
-                gtag('config', '${googleAnalyticsId}', { 'transport_type': 'beacon' });
+                gtag('config', '${googleAnalyticsId}', { 'transport_type': 'beacon', 'anonymize_ip': true });
               `,
           }}
         />


### PR DESCRIPTION
# Why

Google retains IPs (even if they don't display them to us) of all the events we send over to GA. This may cause issues due to GDPR concerns.

# How

I followed the guide [here](https://support.google.com/analytics/answer/2763052?hl=en) to anonymize ips before sending them over (we are using UA not GA4 so it's opt in).

# Test Plan

Visited some routes with no or few users locally then viewed the real-time reports to make I was viewing the page.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
