### PR TITLE
[docs] add `prebuildCommand` to eas.json schema

### DIFF
--- a/docs/scripts/schemas/unversioned/eas-json-build-common-schema.js
+++ b/docs/scripts/schemas/unversioned/eas-json-build-common-schema.js
@@ -45,7 +45,9 @@ export default [
     type: 'string',
     description: [
       'Optional override of the prebuild command used by EAS.',
+      'For example, you can specify `prebuild --template example-template` to use a custom template.',
       'Note: `--platform` and `--non-interactive` will be added automatically by the build engine, so you do not need to specify them manually.',
+      '[Learn more about prebuild options](/workflow/expo-cli/#expo-prebuild).'
     ],
   },
   {

--- a/docs/scripts/schemas/unversioned/eas-json-build-common-schema.js
+++ b/docs/scripts/schemas/unversioned/eas-json-build-common-schema.js
@@ -47,7 +47,7 @@ export default [
       'Optional override of the prebuild command used by EAS.',
       'For example, you can specify `prebuild --template example-template` to use a custom template.',
       'Note: `--platform` and `--non-interactive` will be added automatically by the build engine, so you do not need to specify them manually.',
-      '[Learn more about prebuild options](/workflow/expo-cli/#expo-prebuild).'
+      '[Learn more about prebuild options](../../workflow/expo-cli/#expo-prebuild).'
     ],
   },
   {

--- a/docs/scripts/schemas/unversioned/eas-json-build-common-schema.js
+++ b/docs/scripts/schemas/unversioned/eas-json-build-common-schema.js
@@ -41,6 +41,14 @@ export default [
     ],
   },
   {
+    name: 'prebuildCommand',
+    type: 'string',
+    description: [
+      'Optional override of the prebuild command used by EAS.',
+      'Note: `--platform` and `--non-interactive` will be added automatically by the build engine, so do not need to be specified.',
+    ],
+  },
+  {
     name: 'node',
     type: 'string',
     description: [ 'Version of Node.js.' ],

--- a/docs/scripts/schemas/unversioned/eas-json-build-common-schema.js
+++ b/docs/scripts/schemas/unversioned/eas-json-build-common-schema.js
@@ -45,7 +45,7 @@ export default [
     type: 'string',
     description: [
       'Optional override of the prebuild command used by EAS.',
-      'Note: `--platform` and `--non-interactive` will be added automatically by the build engine, so do not need to be specified.',
+      'Note: `--platform` and `--non-interactive` will be added automatically by the build engine, so you do not need to specify them manually.',
     ],
   },
   {


### PR DESCRIPTION
# Why

- https://github.com/expo/eas-cli/pull/919 - hold until merged and released.

# How

Updated the schema doc

# Test Plan

`yarn dev`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
