### PR TITLE
[template] Added platform gitignores

### DIFF
--- a/templates/expo-template-bare-minimum/android/gitignore
+++ b/templates/expo-template-bare-minimum/android/gitignore
@@ -1,0 +1,21 @@
+# OSX
+#
+.DS_Store
+
+# Android/IntelliJ
+#
+build/
+.idea
+.gradle
+local.properties
+*.iml
+*.hprof
+
+# BUCK
+buck-out/
+\.buckd/
+*.keystore
+!debug.keystore
+
+# Bundle artifacts
+*.jsbundle

--- a/templates/expo-template-bare-minimum/ios/gitignore
+++ b/templates/expo-template-bare-minimum/ios/gitignore
@@ -1,0 +1,29 @@
+# OSX
+#
+.DS_Store
+
+# Xcode
+#
+build/
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata
+*.xccheckout
+*.moved-aside
+DerivedData
+*.hmap
+*.ipa
+*.xcuserstate
+project.xcworkspace
+
+# Bundle artifacts
+*.jsbundle
+
+# CocoaPods
+/Pods/


### PR DESCRIPTION
# Why

Split up the gitignore and added the patterns to `ios/.gitignore` and `android/.gitignore`. Keeping the existing `./.gitignore` for now since deleting it may cause older versions of prebuild to break. In a future version of prebuild we can get rid of the gitignore merging step altogether, removing the extra side-effect.

- Resolve ENG-3868

# Test Plan

- `npm pack` and `expo prebuild --template path/to/tar` to see if the `gitignore`s were converted to `.gitignore`s.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
