### PR TITLE
[iOS][Expo Go] Add `EXAppViewController` as a direct child of `EXRootViewController`

### DIFF
--- a/ios/Exponent/ExpoKit/EXViewController.h
+++ b/ios/Exponent/ExpoKit/EXViewController.h
@@ -7,7 +7,7 @@
 
 @protocol EXViewControllerDelegate <NSObject>
 
-- (void)viewController:(EXViewController *)vc didNavigateAppToVisible:(EXKernelAppRecord *)appRecord;
+- (void)viewController:(EXViewController * _Nonnull)vc didNavigateAppToVisible:(EXKernelAppRecord * _Nonnull)appRecord;
 
 @end
 
@@ -18,7 +18,7 @@
  */
 - (void)createRootAppAndMakeVisible;
 
-@property (nonatomic, strong) UIViewController *contentViewController;
-@property (nonatomic, weak) id<EXViewControllerDelegate> delegate;
+@property (nonatomic, strong, nullable) UIViewController *contentViewController;
+@property (nonatomic, weak, nullable) id<EXViewControllerDelegate> delegate;
 
 @end


### PR DESCRIPTION
[see Slack message/question](https://exponent-internal.slack.com/archives/C1QLJDKDZ/p1642546014020800)

For some reason `EXAppViewController` was added to the `EXRootViewController` not as a child view controller,
but as a detached view controller (method `UIViewController:addChildViewController` was never called).

Such scenario is breaking views hierarchy and instead of following view hierarchy:
```
<EXRootViewController 0x10f00ef40>, state: appeared, view: <UIView 0x10f10bec0>
   | <EXAppViewController 0x10f02d390>, state: appeared, view: <UIView 0x10f0820a0>
   |    | <ABI43_0_0RNScreensNavigationController 0x10f996c00>, state: appeared, view: <UILayoutContainerView 0x116539160>
   |    |    | <ABI43_0_0RNSScreen 0x116537360>, state: appeared, view: <ABI43_0_0RNSScreenView 0x116537000>
   + <ABI43_0_0RNSScreen 0x11666cc70>, state: appeared, view: <ABI43_0_0RNSScreenView 0x11666c910>, presented with: <_UIPageSheetPresentationController 0x11657cfa0>
   |    | <ABI43_0_0RNScreensNavigationController 0x110116600>, state: appeared, view: <UILayoutContainerView 0x11657ef90>
   |    |    | <ABI43_0_0RNSScreen 0x11666bb10>, state: appeared, view: <ABI43_0_0RNSScreenView 0x11666b7b0>
```
iOS presented
```
<EXRootViewController 0x10f00ef40>, state: appeared, view: <UIView 0x10f10bec0>
```

and thus some more sophisticated navigation mechanisms had a rough time managing child controllers.

# Why

Resolves https://github.com/software-mansion/react-native-screens/issues/1266
The problem this PR is solving could be described like this:
- some ViewControllers are wrongly anchored in the ViewsController hierarchy and I suspect [`UINavigationController`](https://developer.apple.com/documentation/uikit/uinavigationcontroller?language=objc) might take a blame for that as it's unaware of the detached hierarchy above it.
- I tried to fix it differently, by either iterating over `childViewControllers` of the parent controller to find the top-most view controller or by applying https://gist.github.com/snikch/3661188 that takes into account the different behaviour of `UINavigationController`, but still failed to fix the problem
- I guess there might be a problem now with the following method override, but I'll test it out: https://github.com/expo/expo/blob/5b628740a12371d965b1cb57d83022f5a55ba889/ios/Exponent/ExpoKit/EXViewController.m#L57-L71


# How

I've refactored the relation between [`EXRootVIewController`](https://github.com/expo/expo/blob/master/ios/Client/EXRootViewController.m) and [`EXAppViewController`](https://github.com/expo/expo/blob/master/ios/Exponent/Kernel/Views/EXAppViewController.m) to be parent-child like.

# Test Plan

- [x] check `ncl` navigations screens
- [x] check `ncl` react-native components screen
- [x] check behaviour of https://github.com/expo/expo/blob/5b628740a12371d965b1cb57d83022f5a55ba889/ios/Exponent/ExpoKit/EXViewController.m#L57-L71

I've tried the very same [Snack that is reported in the referred issue](https://snack.expo.dev/@aeid/thrilled-strawberries) and obtained proper behaviour:

| Broken behaviour |  Fixed behaviour |
| --- | --- |
|  ![148911398-0098b462-aaf3-457a-8753-f3157a902466](https://user-images.githubusercontent.com/16623003/150174714-bf5dce4a-eac8-4584-9d4c-ba8199514f7a.gif) | <video src="https://user-images.githubusercontent.com/16623003/150174691-8464cc78-37a4-4fad-bf0b-94c3d434cd0e.mov" /> |

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
