### PR TITLE
[dev-launcher][iOS] Send uncaught exceptions to bundler server

### DIFF
--- a/packages/expo-dev-launcher/Logs/EXDevLauncherRemoteLogsManager.swift
+++ b/packages/expo-dev-launcher/Logs/EXDevLauncherRemoteLogsManager.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+class EXDevLauncherRemoteLogsManager {
+  private var batch: [[String: Any]] = []
+  private let url: URL
+  
+  init(withUrl url: URL) {
+    self.url = url
+  }
+  
+  func deferError(exception: NSException) {
+    batch.append([
+      "level": "error",
+      "body": [
+        "message": exception.description,
+        "stact": exception.callStackSymbols.joined(separator: "\n")
+      ],
+      "includesStack": true
+    ])
+  }
+  
+  func deferError(message: String) {
+    batch.append([
+      "level": "error",
+      "body": message,
+      "includesStack": false
+    ])
+  }
+  
+  func sendSync() {
+    guard let data = try? JSONSerialization.data(withJSONObject: batch, options: []) else {
+      return
+    }
+    
+    batch.removeAll()
+    
+    var request = URLRequest.init(url: self.url)
+    request.httpMethod = "POST"
+    request.httpBody = data
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.setValue(UIDevice.current.identifierForVendor?.uuidString ?? UIDevice.current.name , forHTTPHeaderField: "Device-Id")
+    request.setValue(UIDevice.current.name, forHTTPHeaderField: "Device-Name")
+    
+    let group = DispatchGroup()
+    group.enter()
+    URLSession.shared.dataTask(with: request) { data, response, error in
+      group.leave()
+    }
+    group.wait()
+  }
+}

--- a/packages/expo-dev-launcher/ios/Errors/EXDevLauncherUncaughtExceptionHandler.swift
+++ b/packages/expo-dev-launcher/ios/Errors/EXDevLauncherUncaughtExceptionHandler.swift
@@ -25,11 +25,41 @@ public class EXDevLauncherUncaughtExceptionHandler: NSObject {
     NSSetUncaughtExceptionHandler { exception in
       NSLog("DevLauncher tries to handle uncaught exception: %@", exception)
       NSLog("Stack Trace: %@", exception.callStackSymbols)
+      
+      EXDevLauncherUncaughtExceptionHandler.tryToSendExceptionToBundler(exception: exception)
       EXDevLauncherUncaughtExceptionHandler.defaultHandler?(exception)
     }
   }
 
   static func uninstallHandler() {
     NSSetUncaughtExceptionHandler(defaultHandler)
+  }
+  
+  
+  static func tryToSendExceptionToBundler(exception: NSException) {
+    let controller = EXDevLauncherController.sharedInstance()
+    if (controller.isAppRunning()) {
+      guard let url = getLogsUrl(controller) else {
+        return
+      }
+      
+      let logsManager = EXDevLauncherRemoteLogsManager(withUrl: url)
+      logsManager.deferError(message: "Your app just crashed. See the error below.")
+      logsManager.deferError(exception: exception)
+      logsManager.sendSync()
+    }
+  }
+  
+  static func getLogsUrl(_ controller: EXDevLauncherController) -> URL? {
+    let logsUrlFromManifest = controller.appManifest()?.rawManifestJSON()["logsUrl"] as? String
+    if (logsUrlFromManifest != nil) {
+      return URL.init(string: logsUrlFromManifest!)
+    }
+    
+    guard let appUrl = controller.appBridge?.bundleURL else {
+      return nil
+    }
+    
+    return URL.init(string: "logs", relativeTo: appUrl)
   }
 }

--- a/packages/expo-dev-launcher/ios/Errors/EXDevLauncherUncaughtExceptionHandler.swift
+++ b/packages/expo-dev-launcher/ios/Errors/EXDevLauncherUncaughtExceptionHandler.swift
@@ -26,7 +26,7 @@ public class EXDevLauncherUncaughtExceptionHandler: NSObject {
       NSLog("DevLauncher tries to handle uncaught exception: %@", exception)
       NSLog("Stack Trace: %@", exception.callStackSymbols)
       
-      EXDevLauncherUncaughtExceptionHandler.tryToSendExceptionToBundler(exception: exception)
+      EXDevLauncherUncaughtExceptionHandler.tryToSendExceptionToBundler(exception)
       EXDevLauncherUncaughtExceptionHandler.defaultHandler?(exception)
     }
   }
@@ -36,7 +36,7 @@ public class EXDevLauncherUncaughtExceptionHandler: NSObject {
   }
   
   
-  static func tryToSendExceptionToBundler(exception: NSException) {
+  static func tryToSendExceptionToBundler(_ exception: NSException) {
     let controller = EXDevLauncherController.sharedInstance()
     if (controller.isAppRunning()) {
       guard let url = getLogsUrl(controller) else {
@@ -51,7 +51,7 @@ public class EXDevLauncherUncaughtExceptionHandler: NSObject {
   }
   
   static func getLogsUrl(_ controller: EXDevLauncherController) -> URL? {
-    let logsUrlFromManifest = controller.appManifest()?.rawManifestJSON()["logsUrl"] as? String
+    let logsUrlFromManifest = controller.appManifest()?.rawManifestJSON()["logUrl"] as? String
     if (logsUrlFromManifest != nil) {
       return URL.init(string: logsUrlFromManifest!)
     }

--- a/packages/expo-dev-launcher/ios/Logs/EXDevLauncherRemoteLogsManager.swift
+++ b/packages/expo-dev-launcher/ios/Logs/EXDevLauncherRemoteLogsManager.swift
@@ -13,7 +13,7 @@ class EXDevLauncherRemoteLogsManager {
       "level": "error",
       "body": [
         "message": exception.description,
-        "stact": exception.callStackSymbols.joined(separator: "\n")
+        "stack": exception.callStackSymbols.joined(separator: "\n")
       ],
       "includesStack": true
     ])
@@ -29,6 +29,7 @@ class EXDevLauncherRemoteLogsManager {
   
   func sendSync() {
     guard let data = try? JSONSerialization.data(withJSONObject: batch, options: []) else {
+      batch.removeAll()
       return
     }
     
@@ -45,7 +46,7 @@ class EXDevLauncherRemoteLogsManager {
     group.enter()
     URLSession.shared.dataTask(with: request) { data, response, error in
       group.leave()
-    }
-    group.wait()
+    }.resume()
+    group.wait(timeout: DispatchTime.now() + .seconds(2))
   }
 }


### PR DESCRIPTION
# Why

Part of ENG-2401.

# How

Send uncaught exceptions to the bundler server if possible. Our dev server has its endpoint where we can send logs. So I've just used it. 

# Test Plan

- throws an exception in the start method of the app and check if a log occurs in the console.