### PR TITLE
[docs] adds note about babel plugin

### DIFF
--- a/docs/pages/eas-update/environment-variables.md
+++ b/docs/pages/eas-update/environment-variables.md
@@ -2,6 +2,8 @@
 title: Using environment variables with EAS Update
 ---
 
+> ⚠️ The APIs below are not stable and are expected to change as we develop EAS Update. An alternate solution is to use a babel plugin to transform variables into environment variables, as described [here](/guides/environment-variables/#using-babel-to-replace-variables).
+
 EAS Build and EAS Update allow setting and getting environment variables at different times. There are multiple steps to ensure the proper environment variables are available when developing, building, and publishing an update to a project.
 
 ## Setting up the app config


### PR DESCRIPTION
Another option for setting env vars is to use a babel plugin. This change adds a note about it in the EAS Update docs.