### PR TITLE
[docs] Remove multimanifests from the update docs

### DIFF
--- a/docs/pages/distribution/hosting-your-app.md
+++ b/docs/pages/distribution/hosting-your-app.md
@@ -147,17 +147,6 @@ When Expo CLI bundles your update, minification is always enabled. In order to s
 
 ![Debugging Source Code](/static/images/host-your-app-debug.png)
 
-### Multimanifests
-
-As new Expo SDK versions are released, you may want to serve multiple versions of your app from your server endpoint. For example, if you first released your app with SDK 29 and later upgraded to SDK 30, you'd want users with your old standalone binary to receive the SDK 29 version, and those with the new standalone binary to receive the SDK 30 version.
-In order to do this, you can run `expo export` with some merge flags to combine previously exported updates into a single multiversion update which you can serve from your servers.
-
-Here is an example workflow:
-
-1. Release your update with previous Expo SDKs. For example, when you released SDK 29, you can run `expo export --output-dir sdk29 --public-url <your-public-url>`. This exports the current version of the update (SDK 29) to a directory named `sdk29`.
-
-2. Update your app and include previous Expo SDK versions. For example, if you've previously released SDK 28 and 29 versions of your app, you can include them when you release an SDK 30 version by running `expo export --merge-src-dir sdk29 --merge-src-dir sdk28 --public-url <your-url>`. Alternatively, you could also compress and host the directories and run `expo export --merge-src-url https://examplesite.com/sdk29.tar.gz --merge-src-url https://examplesite.com/sdk28.tar.gz --public-url <your-url>`. This creates a multiversion update in the `dist` output directory. The **asset** and **bundle** folders contain everything that the source directories had, and the **index.json** file contains an array of the individual **index.json** files found in the source directories.
-
 ### Asset Hosting
 
 By default, all assets are hosted from an `assets` path resolving from your `public-url` (e.g. https://expo.github.io/self-hosting-example/assets). You can override this behavior in the `assetUrlOverride` field of your `android-index.json`. All relative URL's will be resolved from the `public-url`.


### PR DESCRIPTION
Why
---
Multimanifests no longer work with expo-updates on Android. They are also not a concept in the modern Expo Updates specification. Removing the section from the docs so there isn't explanation about a feature that doesn't work.

How
---
Remove the section from the docs.
