### PR TITLE
[docs] add doc on expo-dev-client usage

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -51,6 +51,7 @@ const sections = [
       'Using EAS Update with a bare React Native project',
       'Runtime versions and updates',
       'Using environment variables with EAS Update',
+      'Using expo-dev-client with EAS Update',
       'Known issues',
       'FAQ',
     ],

--- a/docs/pages/eas-update/expo-dev-client.md
+++ b/docs/pages/eas-update/expo-dev-client.md
@@ -1,0 +1,37 @@
+---
+title: Using expo-dev-client with EAS Update
+---
+
+> ⚠️ This guide is likely to change as we continue to work on EAS Update.
+
+The [`expo-dev-client`](/development/introduction) library allows us to launch different versions of our project. One of the most popular use-cases is to preview a published update inside a development build, using the `expo-dev-client` library.
+
+The `expo-dev-client` library supports loading published EAS Updates through channels. Below, learn how to load a specific channel to preview an update in a development build.
+
+## How to load a published EAS Update inside a development build
+
+1. Create a [development build](/development/getting-started) of the project.
+2. Next, make non-native changes locally, then publish them using `eas update --branch ...`. The branch specified should correspond to a channel. You can see how channels are linked to branches with `eas channel:list`.
+3. After publishing an update, it's time to load the update in the development build. To accomplish this, we'll have to construct a specific URL. The URL will look like this:
+
+   ```bash
+   exp+[project-slug]://expo-development-client/?url=[https://u.expo.dev/project-id]?channel-name=[channel]
+
+   # Example
+
+   exp+form-duo://expo-development-client/?url=https://u.expo.dev/675cb1f0-fa3c-11e8-ac99-6374d9643cb2?channel-name=preview
+   ```
+
+   Let's break down the parts of this URL:
+
+   - `exp+`: The beginning of the URL.
+   - `form-duo`: This is the project slug found in **app.json**/**app.config.js**.
+   - `://expo-development-client/`: necessary for the deep link to work with the `expo-dev-client` library.
+   - `?url=`: Defines a `url` query parameter.
+   - `https://u.expo.dev/675cb1f0-fa3c-11e8-ac99-6374d9643cb2`: This is the updates URL, which is inside the project's app config (**app.json**/**app.config.js**) under `updates.url`.
+   - `?channel-name=`: Defines a channel query parameter.
+   - `preview`: The name of the channel to request.
+
+4. Once we've constructed the URL, we can either copy/paste it directly into the `expo-dev-client`'s launcher screen. Alternatively, we could create a QR code of the URL, then scan it. Scanning this URL should open up the development build to the specified channel.
+
+If you'd like to see a working example, check out this [demo repo](https://github.com/jonsamp/test-expo-dev-client-eas-update).

--- a/docs/pages/eas/index.md
+++ b/docs/pages/eas/index.md
@@ -11,3 +11,5 @@ Read the full pitch at [expo.dev/eas](https://expo.dev/eas), or follow the links
 - **EAS Build**: Compile and sign Android/iOS apps with custom native code in the cloud. [Learn more](/build/introduction.md).
 
 - **EAS Submit**: Upload your app to the Apple App Store or Google Play Store from the cloud with one CLI command. [Learn more](/submit/introduction.md).
+
+- **EAS Update** (preview): Address small bugs and push quick fixes directly to end-users. [Learn more](/eas-update/introduction.md).


### PR DESCRIPTION
Closes ENG-3873
Closes ENG-3874

Adds doc on how to use EAS Update with expo-dev-client.