### PR TITLE
[camera] fix failing test after docs conversion

### DIFF
--- a/packages/expo-camera/src/utils/__tests__/props-test.node.ts
+++ b/packages/expo-camera/src/utils/__tests__/props-test.node.ts
@@ -1,3 +1,4 @@
+import { AutoFocus, CameraType, FlashMode, WhiteBalance } from '../../Camera.types';
 import { convertNativeProps } from '../props';
 
 describe(convertNativeProps, () => {
@@ -7,10 +8,10 @@ describe(convertNativeProps, () => {
   it(`converts known properties to native props`, () => {
     expect(
       convertNativeProps({
-        type: 'front',
-        flashMode: 'torch',
-        autoFocus: 'auto',
-        whiteBalance: 'continuous',
+        type: 'front' as CameraType,
+        flashMode: 'torch' as FlashMode,
+        autoFocus: 'auto' as AutoFocus,
+        whiteBalance: 'continuous' as WhiteBalance,
       })
     ).toStrictEqual({
       autoFocus: 'auto',

--- a/packages/expo-camera/src/utils/__tests__/props-test.ts
+++ b/packages/expo-camera/src/utils/__tests__/props-test.ts
@@ -1,5 +1,6 @@
 import { Platform } from 'react-native';
 
+import { AutoFocus, CameraType, FlashMode, WhiteBalance } from '../../Camera.types';
 import { ensureNativeProps } from '../props';
 
 describe(ensureNativeProps, () => {
@@ -9,10 +10,10 @@ describe(ensureNativeProps, () => {
 
     expect(
       ensureNativeProps({
-        type: 'front',
-        flashMode: 'torch',
-        autoFocus: 'auto',
-        whiteBalance: 'continuous',
+        type: 'front' as CameraType,
+        flashMode: 'torch' as FlashMode,
+        autoFocus: 'auto' as AutoFocus,
+        whiteBalance: 'continuous' as WhiteBalance,
         poster: './image.png',
         ratio: '1080p',
         useCamera2Api: true,

--- a/packages/expo-camera/src/utils/__tests__/props-test.ts
+++ b/packages/expo-camera/src/utils/__tests__/props-test.ts
@@ -52,10 +52,10 @@ describe(ensureNativeProps, () => {
         },
         // Web and node
         default: {
-          autoFocus: 'auto',
-          flashMode: 'torch',
-          type: 'front',
-          whiteBalance: 'continuous',
+          autoFocus: 'auto' as AutoFocus,
+          flashMode: 'torch' as FlashMode,
+          type: 'front' as CameraType,
+          whiteBalance: 'continuous' as WhiteBalance,
           barCodeScannerSettings: {},
           onBarCodeScanned,
           onFacesDetected,


### PR DESCRIPTION
# Why

Refs #15936

It looks like I have missed the failing test in `expo-camera` during the docs conversion. 🤦 

# How

Fix broken test by casing raw string values to appropriate type.

This probably has been caused by changing the `ConstantsType` type definition, which was earlier defined in a way, which do not use the created and included in camera enums, but only their values, which leads to other type issues (ex. no information about actual type) and was different than usual `Constants` typing in other Expo packages.

It might be worth in the future to dig deeper into this and unify the `Constants` typings and declarations across all Expo packages.

# Test Plan

`yarn test` in `expo-camera` do not fail.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
