### PR TITLE
[docs] add dev-client/SDK compatibility

### DIFF
--- a/docs/pages/development/compatibility.md
+++ b/docs/pages/development/compatibility.md
@@ -6,10 +6,21 @@ The `expo-dev-client` library is only compatible with specific versions of certa
 
 You do not need to use any of these packages in your project in order to use `expo-dev-client`, but if you do, you must use a compatible version.
 
+## Expo SDKs
+
+This table lists the highest minor version of `expo-dev-client` that is supported by each Expo SDK version.
+
+| Expo SDK | expo-dev-client     |
+| -------- | ------------------- |
+| SDK 44   | `0.8.X`             |
+| SDK 43   | `0.8.X`             |
+| SDK 42   | `0.7.X`             |
+
 ## react-native
 
 | expo-dev-client | react-native        |
 | --------------- | ------------------- |
+| `0.8.X`         | `0.64.X`            |
 | `0.7.X`         | `0.62.X` - `0.64.X` |
 | `0.6.X`         | `0.62.X` - `0.63.X` |
 


### PR DESCRIPTION
# Why

expo-dev-client@0.8.x is no longer compatible with SDK 42 due to the autolinking changes. We should indicate this in docs.

# How

Added a new table for SDK compatibility. It shows the highest version of dev-client compatible with each SDK version (rather than the other way around, which would require a lot more testing I don't think we want to commit to).

Also added a row for 0.8.x's react-native compatibility, since it was missing. Even though all the versions we've released so far have had bundles compiled with RN 62, I thought it would be better to err on the side of caution and not officially say we support RN 62 or 63 with all 0.8.x releases.

# Test Plan

Ran docs locally, ensured tables rendered correctly.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
