### PR TITLE
[expo-dev-launcher] remove SDK 42 compat warning from write_embedded_bundle.sh

### DIFF
--- a/packages/expo-dev-launcher/write_embedded_bundle.sh
+++ b/packages/expo-dev-launcher/write_embedded_bundle.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 
-# TODO: remove once we're confident about dropping SDK 42 support
-REACT_NATIVE_VERSION=$(node --print "require('react-native/package.json').version")
-if ! [[ "$REACT_NATIVE_VERSION" =~ ^0\.63\.[0-9]+$ ]]; then
-  echo -e "\033[1;33mWarning: bundles made with this version of React Native ($REACT_NATIVE_VERSION) will not work in SDK 42.\033[0m"
-fi
-
 # iOS
 
 EXPO_BUNDLE_APP=1 npx react-native bundle \


### PR DESCRIPTION
# Why

0.8.x is already incompatible with SDK 42 due to changes related to expo modules autolinking, so there's no point in continuing to support RN 63 in newer versions of the dev client.

# How

Remove the warning added in #14839

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
