### PR TITLE
[docs] EAS Build: update infra docs - macOS Monterey image

### DIFF
--- a/docs/pages/build-reference/infrastructure.md
+++ b/docs/pages/build-reference/infrastructure.md
@@ -15,7 +15,10 @@ When selecting an image for the build you can use the full name provided below o
 - `default` alias will be assigned to the environment that most closely resembles the configuration used for Expo SDK development.
 - `latest` alias will be assigned to the image with the most up to date versions of the software.
 
-> **Note:** If you don't provide `image` in eas.json, your build is going to use the `default` image. There is one exception to this rule - if you have a managed project and you don't specify `image`, it will be chosen based on your Expo SDK version. E.g. SDK 42 and lower uses `macos-big-sur-11.4-xcode-12.5`, and SDK 43 uses `macos-big-sur-11.4-xcode-13.0`.
+> **Note:**
+>
+> - If you have a bare workflow project: your build is going to use the `default` image unless you provide `image` in **eas.json**.
+> - If you have a managed workflow project: your build is going to use an automatically chosen image, unless you provide `image` in **eas.json**.
 
 ## Android build server configurations
 
@@ -133,7 +136,7 @@ When selecting an image for the build you can use the full name provided below o
 
 </details>
 
-#### Image `macos-big-sur-11.4-xcode-13.0` (alias `latest`)
+#### Image `macos-big-sur-11.4-xcode-13.0` (alias `latest`, `default`)
 
 <details><summary>Details</summary>
 

--- a/docs/pages/build-reference/infrastructure.md
+++ b/docs/pages/build-reference/infrastructure.md
@@ -15,16 +15,16 @@ When selecting an image for the build you can use the full name provided below o
 - `default` alias will be assigned to the environment that most closely resembles the configuration used for Expo SDK development.
 - `latest` alias will be assigned to the image with the most up to date versions of the software.
 
-> **Note:** If you don't provide `image` in eas.json, your build is going to use the `default` image. There is one exception to this rule - if you have a managed project and you don't specify `image`, it will be chosen based on your Expo SDK version. E.g. SDKs 41 and lower use `macos-catalina-10.15-xcode-12.1`, SDK 42 uses `macos-big-sur-11.4-xcode-12.5`, and SDK 43 uses `macos-big-sur-11.4-xcode-13.0`.
+> **Note:** If you don't provide `image` in eas.json, your build is going to use the `default` image. There is one exception to this rule - if you have a managed project and you don't specify `image`, it will be chosen based on your Expo SDK version. E.g. SDK 42 and lower uses `macos-big-sur-11.4-xcode-12.5`, and SDK 43 uses `macos-big-sur-11.4-xcode-13.0`.
 
 ## Android build server configurations
 
 - Android workers run on Kubernetes in an isolated environment
   - Every build gets its own container running on a dedicated Kubernetes node
   - Build resources: 4 CPU, 12 GB RAM
-- npm cache deployed with Kubernetes. [Learn more](caching/#javascript-dependencies)
+- NPM cache deployed with Kubernetes. [Learn more](caching/#javascript-dependencies)
 - Maven cache deployed with Kubernetes. [Learn more](caching/#android-dependencies)
-- Global gradle configuration in `~/.gradle/gradle.properties`:
+- Global Gradle configuration in `~/.gradle/gradle.properties`:
 
   ```jsx
   org.gradle.jvmargs=-Xmx14g -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
@@ -117,6 +117,21 @@ When selecting an image for the build you can use the full name provided below o
     - "*"
   npmRegistryServer: "registry=http://10.254.24.8:4873"
   ```
+
+#### Image `macos-monterey-12.1-xcode-13.2`
+
+<details><summary>Details</summary>
+
+- macOS Big Sur 12.1
+- Xcode 13.2.1 (13C100)
+- Node.js 14.18.1
+- Yarn 1.22.10
+- npm 6.14.8
+- fastlane 2.201.0
+- CocoaPods 1.11.2
+- Ruby 2.7
+
+</details>
 
 #### Image `macos-big-sur-11.4-xcode-13.0` (alias `latest`)
 


### PR DESCRIPTION
**Merge after https://github.com/expo/turtle-v2/pull/779 is merged and deployed.**

# Why

- Follow-up to https://github.com/expo/turtle-v2/pull/779
- macOS Catalina will no longer be supported
- Adding macOS Monterey image.

# How

Update docs.

# Test Plan

None