### PR TITLE
[updates] Fix crash when autoSetup=true and enabled=false

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix iOS launch crash when app.json `expo.updates.enabled` is false. ([#15997](https://github.com/expo/expo/pull/15997) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 - Updated `@expo/config-plugins` from `4.0.2` to `4.0.14`, `@expo/config` from `^6.0.6` to `^6.0.14` and `@expo/metro-config` from `~0.2.6` to `~0.3.7` ([#15621](https://github.com/expo/expo/pull/15621) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
@@ -428,9 +428,11 @@ static NSString * const EXUpdatesErrorEventName = @"error";
   [launcher launchUpdateWithConfig:_config];
 
   if (_delegate) {
-    [EXUpdatesUtils runBlockOnMainThread:^{
+    EX_WEAKIFY(self);
+    dispatch_async(dispatch_get_main_queue(), ^{
+      EX_ENSURE_STRONGIFY(self);
       [self->_delegate appController:self didStartWithSuccess:self.launchAssetUrl != nil];
-    }];
+    });
   }
 
   [_errorRecovery writeErrorOrExceptionToLog:error];

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
@@ -10,6 +10,7 @@
 #import <EXUpdates/EXUpdatesSelectionPolicyFactory.h>
 #import <EXUpdates/EXUpdatesUtils.h>
 #import <EXUpdates/EXUpdatesBuildData.h>
+#import <ExpoModulesCore/EXDefines.h>
 #import <React/RCTReloadCommand.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -113,7 +114,11 @@ static NSString * const EXUpdatesErrorEventName = @"error";
     [launcher launchUpdateWithConfig:_config];
 
     if (_delegate) {
-      [_delegate appController:self didStartWithSuccess:self.launchAssetUrl != nil];
+      EX_WEAKIFY(self);
+      dispatch_async(dispatch_get_main_queue(), ^{
+        EX_ENSURE_STRONGIFY(self);
+        [self->_delegate appController:self didStartWithSuccess:self.launchAssetUrl != nil];
+      });
     }
 
     return;

--- a/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesReactDelegateHandler.swift
+++ b/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesReactDelegateHandler.swift
@@ -21,12 +21,6 @@ public class ExpoUpdatesReactDelegateHandler: ExpoReactDelegateHandler, EXUpdate
       return false
     }
 
-    // if `EXUpdatesConfigEnabledKey` is false, disable the auto setup
-    let enabledValue = config[EXUpdatesConfigEnabledKey]
-    if let enabled = enabledValue as? NSNumber, enabled.boolValue == false {
-      return false
-    }
-
     // if `EXUpdatesAutoSetup` is false, disable the auto setup
     let enableAutoSetupValue = config[EXUpdatesConfigEnableAutoSetupKey]
     if let enableAutoSetup = enableAutoSetupValue as? NSNumber, enableAutoSetup.boolValue == false {

--- a/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesReactDelegateHandler.swift
+++ b/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesReactDelegateHandler.swift
@@ -21,6 +21,12 @@ public class ExpoUpdatesReactDelegateHandler: ExpoReactDelegateHandler, EXUpdate
       return false
     }
 
+    // if `EXUpdatesConfigEnabledKey` is false, disable the auto setup
+    let enabledValue = config[EXUpdatesConfigEnabledKey]
+    if let enabled = enabledValue as? NSNumber, enabled.boolValue == false {
+      return false
+    }
+
     // if `EXUpdatesAutoSetup` is false, disable the auto setup
     let enableAutoSetupValue = config[EXUpdatesConfigEnableAutoSetupKey]
     if let enableAutoSetup = enableAutoSetupValue as? NSNumber, enableAutoSetup.boolValue == false {


### PR DESCRIPTION
# Why

the crash happens when expo-updates enabled=false, the call to `appController:didStartWithSuccess:` is immediately. given `ExpoUpdatesReactDelegateHandler` no chance to setup RCTRootView and bind bridge to a nil root view.

fix #15972 

# How

disable auto setup if `enabled` is false.

# Test Plan

follow #15972 steps

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
