### PR TITLE
Upgrade types for React Native 0.66

### DIFF
--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -126,7 +126,7 @@
   "devDependencies": {
     "@babel/core": "^7.12.9",
     "@types/react": "~17.0.21",
-    "@types/react-native": "~0.64.12",
+    "@types/react-native": "~0.66.13",
     "babel-plugin-module-resolver": "^4.1.0",
     "babel-preset-expo": "~9.0.0",
     "detox": "^19.4.1",

--- a/apps/native-component-list/src/screens/TextToSpeechScreen.tsx
+++ b/apps/native-component-list/src/screens/TextToSpeechScreen.tsx
@@ -1,8 +1,8 @@
+import { Picker } from '@react-native-picker/picker';
 import * as Speech from 'expo-speech';
 import * as React from 'react';
 import {
   Button,
-  Picker,
   Platform,
   ScrollView,
   StyleSheet,

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -119,7 +119,7 @@
     "@types/js-yaml": "^3.12.2",
     "@types/prompts": "^2.0.6",
     "@types/react": "~17.0.21",
-    "@types/react-native": "~0.64.12",
+    "@types/react-native": "~0.66.13",
     "@types/react-test-renderer": "^17.0.1",
     "@types/uuid": "^3.4.7",
     "arg": "4.1.0",

--- a/templates/expo-template-blank-typescript/package.json
+++ b/templates/expo-template-blank-typescript/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@babel/core": "^7.12.9",
     "@types/react": "~17.0.21",
-    "@types/react-native": "~0.64.12",
+    "@types/react-native": "~0.66.13",
     "typescript": "~4.3.5"
   }
 }

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@babel/core": "^7.12.9",
     "@types/react": "~17.0.21",
-    "@types/react-native": "~0.64.12",
+    "@types/react-native": "~0.66.13",
     "jest-expo": "~43.0.1",
     "jest": "^26.6.3",
     "react-test-renderer": "17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3938,10 +3938,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-native@~0.64.12":
-  version "0.64.21"
-  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.64.21.tgz#f45aaac377ae2b2195e03597d4fd9fe366b2fcb5"
-  integrity sha512-62eOyNblPNzhCcLczhGnyJpokMnRH+cnkFg/LdLhFEu04USqBPJPwa1q90d7Iv7llprOaUGaeGKOsNLrjMCWYw==
+"@types/react-native@~0.66.13":
+  version "0.66.13"
+  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.66.13.tgz#90f0c828c6267af8648649f90c02c92fbb596d68"
+  integrity sha512-Yp8hiCvez9HdaSNx1xKMog8uzXEugk47nmfWvXLnyERchjcnaF4VZwi9NmZMU5ETrx7apN+aynBdC+64JM9o2g==
   dependencies:
     "@types/react" "*"
 


### PR DESCRIPTION
# Why

`AppState.removeEventListener` is no longer available on Android in RN 0.66 and since we use it in SDK tests, we need to bump `@types/react-native` too.

# How

Upgraded `@types/react-native` to `0.66.13`

# Test Plan

Confirmed the `AppState.addEventListener` now returns `NativeEventSubscription` containing `remove()` function that is the replacement for `removeEventListener`
