### PR TITLE
[camera] update tests to use exported types

### DIFF
--- a/packages/expo-camera/src/utils/__tests__/props-test.node.ts
+++ b/packages/expo-camera/src/utils/__tests__/props-test.node.ts
@@ -1,3 +1,4 @@
+import { AutoFocus, CameraType, FlashMode, WhiteBalance } from '../../Camera.types';
 import { convertNativeProps } from '../props';
 
 describe(convertNativeProps, () => {
@@ -7,10 +8,10 @@ describe(convertNativeProps, () => {
   it(`converts known properties to native props`, () => {
     expect(
       convertNativeProps({
-        type: 'front',
-        flashMode: 'torch',
-        autoFocus: 'auto',
-        whiteBalance: 'continuous',
+        type: CameraType.front,
+        flashMode: FlashMode.torch,
+        autoFocus: AutoFocus.auto,
+        whiteBalance: WhiteBalance.continuous,
       })
     ).toStrictEqual({
       autoFocus: 'auto',

--- a/packages/expo-camera/src/utils/__tests__/props-test.ts
+++ b/packages/expo-camera/src/utils/__tests__/props-test.ts
@@ -1,4 +1,5 @@
 import { Platform } from 'react-native';
+import { AutoFocus, CameraType, FlashMode, WhiteBalance } from '../../Camera.types';
 
 import { ensureNativeProps } from '../props';
 
@@ -9,10 +10,10 @@ describe(ensureNativeProps, () => {
 
     expect(
       ensureNativeProps({
-        type: 'front',
-        flashMode: 'torch',
-        autoFocus: 'auto',
-        whiteBalance: 'continuous',
+        type: CameraType.front,
+        flashMode: FlashMode.torch,
+        autoFocus: AutoFocus.auto,
+        whiteBalance: WhiteBalance.continuous,
         poster: './image.png',
         ratio: '1080p',
         useCamera2Api: true,


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
looks like some changes to the typings of this module broke the test suite - I've updated to use the exported types which I believe is more in line with our docs anyways

# How

<!--
How did you build this feature or fix this bug and why?
-->

updated to exported camera prop types and reran tests

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

test suite should pass

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
