### PR TITLE
[docs] add types and fix mdx link rewrite on windows

### DIFF
--- a/docs/mdx-plugins/remark-export-headings.js
+++ b/docs/mdx-plugins/remark-export-headings.js
@@ -1,8 +1,8 @@
 const visit = require('unist-util-visit');
 
 /**
- * @typedef {import('mdast').Root} Root - https://github.com/syntax-tree/mdast#root
- * @typedef {import('mdast').Heading} Heading - https://github.com/syntax-tree/mdast#heading
+ * @typedef {import('@types/mdast').Root} Root - https://github.com/syntax-tree/mdast#root
+ * @typedef {import('@types/mdast').Heading} Heading - https://github.com/syntax-tree/mdast#heading
  */
 
 /**
@@ -20,7 +20,7 @@ module.exports = function remarkExportHeadings(options = {}) {
   return tree => {
     const headings = [];
 
-    /** @param {Heading} node -  */
+    /** @param {Heading} node */
     const visitor = node => {
       if (node.children.length > 0) {
         headings.push({

--- a/docs/mdx-plugins/remark-export-yaml.js
+++ b/docs/mdx-plugins/remark-export-yaml.js
@@ -2,8 +2,8 @@ const yaml = require('js-yaml');
 const visit = require('unist-util-visit');
 
 /**
- * @typedef {import('mdast').Root} Root - https://github.com/syntax-tree/mdast#root
- * @typedef {import('mdast').YAML} Yaml - https://github.com/syntax-tree/mdast#yaml
+ * @typedef {import('@types/mdast').Root} Root - https://github.com/syntax-tree/mdast#root
+ * @typedef {import('@types/mdast').YAML} Yaml - https://github.com/syntax-tree/mdast#yaml
  */
 
 /**
@@ -21,7 +21,7 @@ module.exports = function remarkExportYaml(options = {}) {
   return tree => {
     let yamlTransformed = false;
 
-    /** @param {Yaml} node -  */
+    /** @param {Yaml} node */
     const visitor = node => {
       const data = yaml.load(node.value);
 

--- a/docs/mdx-plugins/remark-link-rewrite.js
+++ b/docs/mdx-plugins/remark-link-rewrite.js
@@ -65,7 +65,7 @@ module.exports = function remarkLinkRewrite(options) {
         }
 
         // force forward slash on non-posix systems
-        node.url = `/${newUrl.replaceAll('\\', '/')}`;
+        node.url = `/${newUrl.replace(/\\/g, '/')}`;
       }
     });
   };

--- a/docs/mdx-plugins/remark-link-rewrite.js
+++ b/docs/mdx-plugins/remark-link-rewrite.js
@@ -2,6 +2,11 @@ const path = require('path');
 const visit = require('unist-util-visit');
 const { URL } = require('url');
 
+/**
+ * @typedef {import('@types/mdast').Root} Root - https://github.com/syntax-tree/mdast#root
+ * @typedef {import('vfile').VFile} VFile - https://github.com/syntax-tree/unist#file
+ */
+
 const DEFAULT_OPTIONS = {
   extension: 'md',
   pagesDir: 'pages',
@@ -24,6 +29,10 @@ const FAKE_DOMAIN = 'https://fake.domain';
 module.exports = function remarkLinkRewrite(options) {
   const settings = { ...DEFAULT_OPTIONS, ...options };
 
+  /**
+   * @param {Root} tree
+   * @param {VFile} file
+   */
   return (tree, file) => {
     // we can't rewrite files without knowing where the file exists
     if (!file.cwd || !file.history || !file.history.length) {
@@ -55,7 +64,8 @@ module.exports = function remarkLinkRewrite(options) {
           newUrl = newUrl.replace(ignoredIndex, '');
         }
 
-        node.url = `/${newUrl}`;
+        // force forward slash on non-posix systems
+        node.url = `/${newUrl.replaceAll('\\', '/')}`;
       }
     });
   };

--- a/docs/mdx-plugins/remark-link-rewrite.test.js
+++ b/docs/mdx-plugins/remark-link-rewrite.test.js
@@ -7,6 +7,7 @@ const makeFile = filePath => ({
   cwd: '/absolue/path/to/docs',
   history: [path.join('/absolue/path/to/docs/pages', filePath)],
 });
+
 const rewrite = (file, url) => {
   const link = { type: 'link', url };
   const tree = { type: 'root', children: [link] };


### PR DESCRIPTION
# Why

Part of [ENG-3960](https://linear.app/expo/issue/ENG-3960/refactor-navigation-and-navigation-data-into-single-file)

On Windows, both the `remark-link-rewrite` and `constants/navigation.js` + `constants/navigation-data.js` uses back slashes in the URLs it generates. This fixes the link rewrite, and by that, should fix all links within the MDX pages.

This does **_not_** fix the sidebar links, which is generated by the navigation constants. That's still broken on Windows at the moment, and should be fixed when we consolidate these navigation constants files.

# How

- Ran `yarn test remark-link-rewrite` to make sure all tests pass on Windows

# Test Plan

- See unit tests

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
