### PR TITLE
[docs] fix Bugsnag example link

### DIFF
--- a/docs/pages/guides/using-bugsnag.md
+++ b/docs/pages/guides/using-bugsnag.md
@@ -1,4 +1,3 @@
-
 ---
 title: Using Bugsnag
 ---

--- a/docs/pages/guides/using-bugsnag.md
+++ b/docs/pages/guides/using-bugsnag.md
@@ -1,3 +1,4 @@
+
 ---
 title: Using Bugsnag
 ---
@@ -81,5 +82,5 @@ Type definitions provided and will be picked up automatically by the TypeScript 
 
 - Read the [full integration guide](https://docs.bugsnag.com/platforms/react-native/expo/)
 - View [`@bugsnag/js`](https://github.com/bugsnag/bugsnag-js), the library powering Bugsnag’s JavaScript error reporting, on GitHub
-- Explore [the example project](https://github.com/bugsnag/bugsnag-js/tree/master/examples/expo)
+- Explore [the example project](https://github.com/bugsnag/bugsnag-js/tree/next/examples/js/expo)
 - Get [support](https://docs.bugsnag.com/#support) for your questions and feature requests


### PR DESCRIPTION
# Why

Fixes #16004
* #16004

# How

Update the link to moved example.

# Test Plan

No 404, when running locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
