### PR TITLE
[media-library] Update bare installation docs for Android

### DIFF
--- a/packages/expo-media-library/README.md
+++ b/packages/expo-media-library/README.md
@@ -44,6 +44,13 @@ This package automatically adds the `READ_EXTERNAL_STORAGE` and `WRITE_EXTERNAL_
 <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 ```
 
+If you'd like to access asset location (latitude and longitude EXIF tags), you have to add `ACCESS_MEDIA_LOCATION` permission to the `AndroidManifest.xml`:
+
+```xml
+<!-- Add this to AndroidManifest.xml -->
+<uses-permission android:name="android.permission.ACCESS_MEDIA_LOCATION" />
+```
+
 Starting with Android 10, the concept of [scoped storage](https://developer.android.com/training/data-storage#scoped-storage) is introduced. Currently, to make `expo-media-library` working with that change, you have to add `android:requestLegacyExternalStorage="true"` to `AndroidManifest.xml`:
 
 ```xml


### PR DESCRIPTION
# Why

Bare installation docs are missing the installation step about the `ACCESS_MEDIA_LOCATION` permission on Android. The `MediaLibrary.requestPermissionAsync()` fails if it's absent in `AndroidManifest.xml`.

**For managed/prebuild workflow, this permission [is added by a config plugin](https://docs.expo.dev/versions/latest/sdk/media-library/#configuration-in-appjson--appconfigjs) if configured.**

More context in the original issue: https://github.com/expo/expo/issues/15273#issuecomment-1005440392

Resolves ENG-3968