### PR TITLE
[media-library][android] Fix requesting optional location permission

### DIFF
--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Don't ask for `ACCESS_MEDIA_LOCATION` permission if it's not present in `AndroidManifest.xml`.
+
 ### 💡 Others
 
 - Updated `@expo/config-plugins` from `4.0.2` to `4.0.14` ([#15621](https://github.com/expo/expo/pull/15621) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Don't ask for `ACCESS_MEDIA_LOCATION` permission if it's not present in `AndroidManifest.xml`.
+- Don't ask for `ACCESS_MEDIA_LOCATION` permission if it's not present in `AndroidManifest.xml`. ([#16034](https://github.com/expo/expo/pull/16034) by [@barthap](https://github.com/barthap))
 
 ### 💡 Others
 

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.kt
@@ -1,6 +1,7 @@
 package expo.modules.medialibrary
 
 import android.Manifest.permission.*
+import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
@@ -339,11 +340,17 @@ class MediaLibraryModule(
       ?.hasGrantedPermissions(WRITE_EXTERNAL_STORAGE)
       ?.not() ?: false
 
+  @SuppressLint("InlinedApi")
   private fun getManifestPermissions(writeOnly: Boolean): Array<String> {
+    // ACCESS_MEDIA_LOCATION should not be requested if it's absent in android-manifest
+    val shouldAddMediaLocationAccess =
+      Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q &&
+        MediaLibraryUtils.hasManifestPermission(context, ACCESS_MEDIA_LOCATION)
+
     return listOfNotNull(
       WRITE_EXTERNAL_STORAGE,
       READ_EXTERNAL_STORAGE.takeIf { !writeOnly },
-      ACCESS_MEDIA_LOCATION.takeIf { Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q }
+      ACCESS_MEDIA_LOCATION.takeIf { shouldAddMediaLocationAccess }
     ).toTypedArray()
   }
 

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryUtils.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryUtils.kt
@@ -250,7 +250,7 @@ object MediaLibraryUtils {
   }
 
   /**
-   * Checks, whenever an appplication represented by [context] contains specific [permission]
+   * Checks, whenever an application represented by [context] contains specific [permission]
    * in `AndroidManifest.xml`:
    *
    * ```xml

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryUtils.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryUtils.kt
@@ -3,11 +3,13 @@ package expo.modules.medialibrary
 import android.content.ContentResolver
 import android.content.ContentUris
 import android.content.Context
+import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
 import android.os.Environment
 import android.provider.MediaStore
 import android.text.TextUtils
+import android.util.Log
 import android.webkit.MimeTypeMap
 import expo.modules.core.Promise
 import expo.modules.core.utilities.ifNull
@@ -234,4 +236,27 @@ object MediaLibraryUtils {
   @Deprecated("It uses deprecated Android method under the hood. See implementation for details.")
   fun getEnvDirectoryForAssetType(mimeType: String?, useCameraDir: Boolean): File =
     Environment.getExternalStoragePublicDirectory(getRelativePathForAssetType(mimeType, useCameraDir))
+
+  private fun getManifestPermissions(context: Context): Set<String> {
+    val pm: PackageManager = context.packageManager
+    return try {
+      val packageInfo = pm.getPackageInfo(context.packageName, PackageManager.GET_PERMISSIONS)
+      packageInfo.requestedPermissions?.toSet() ?: emptySet()
+    } catch (e: PackageManager.NameNotFoundException) {
+      Log.e("expo-media-library", "Failed to list AndroidManifest.xml permissions")
+      e.printStackTrace()
+      emptySet()
+    }
+  }
+
+  /**
+   * Checks, whenever an appplication represented by [context] contains specific [permission]
+   * in `AndroidManifest.xml`:
+   *
+   * ```xml
+   *  <uses-permission android:name="<<PERMISSION STRING HERE>>" />
+   *  ```
+   */
+  fun hasManifestPermission(context: Context, permission: String): Boolean =
+    getManifestPermissions(context).contains(permission)
 }


### PR DESCRIPTION
# Why

In #14413 the optional `ACCESS_MEDIA_LOCATION` permission was introduced. Generally it's optional, required only if requesting `latitude` and `longitude` from asset EXIF tags.
It can be added to `AndroidManifest.xml` [by a config plugin](https://github.com/expo/expo/issues/15273#issuecomment-1005440392) in managed, or manually in bare workflow.

But `MediaLibrary.requestPermissionsAsync()` asked for it even if it's not present in the manifest, which caused issues. 

Resolves #15273 
Resolves ENG-3968

More context: https://github.com/expo/expo/issues/15273#issuecomment-1005440392

# How

Check if the permission is present in `AndroidManifest.xml` and ask for it only if present there.

# Test Plan

- Added the `<uses-permission android:name="android.permission.ACCESS_MEDIA_LOCATION" />` to `AndroidManifest.xml`, then ensured that `MediaLibrary.requestPermissionsAsync()` asks for media location permission.
- Removed the line from manifest, ensured that `MediaLibrary.requestPermissionsAsync()` no longer asks for it.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
