### PR TITLE
[docs] Update custom push sending documentation for project transfer changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,6 +200,7 @@ Package-specific changes not released in any SDK will be added here just before 
 - Removed `expo-payments-stripe`. Please use `@stripe/stripe-react-native` instead. ([#14382](https://github.com/expo/expo/pull/14382) by [@cruzach](https://github.com/cruzach))
 - Updated firebase to version 9.0.2, including support for compat libraries and new modular style. ([#14616](https://github.com/expo/expo/pull/14616) by [@sebastianwilczek](https://github.com/sebastianwilczek))
 - `navigator.geolocation` is no longer defined automatically as a side effect of the `expo` package. It previously provided a warning that you needed to install `expo-location`. ([#14441](https://github.com/expo/expo/pull/14441) by [@brentvatne](https://github.com/brentvatne)
+- Require scopeKey in custom push notifications. ([#12964](https://github.com/expo/expo/pull/12964) by [@wschurman](https://github.com/wschurman)
 - **`expo-ads-admob`**
   - Dropped support for iOS 11.0 ([#14383](https://github.com/expo/expo/pull/14383) by [@cruzach](https://github.com/cruzach))
 - **`expo-ads-facebook`**
@@ -834,7 +835,6 @@ Package-specific changes not released in any SDK will be added here just before 
 
 ### 🛠 Breaking changes
 
-- Require scopeKey in custom push notifications. ([#12964](https://github.com/expo/expo/pull/12964) by [@wschurman](https://github.com/wschurman)
 - **`expo-battery`**
   - Removed following types: `BatteryLevelUpdateListener `, `BatteryStateUpdateListener` and `PowerModeUpdateListener` as they were only wrapping one-argument events responses. Use event types explicitly instead: `BatteryLevelEvent `, `BatteryStateEvent` and `PowerModeEvent`. ([#12592](https://github.com/expo/expo/pull/12592) by [@Simek](https://github.com/simek)) ([#12592](https://github.com/expo/expo/pull/12592) by [@simek](https://github.com/simek))
 - **`expo-constants`**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -834,6 +834,7 @@ Package-specific changes not released in any SDK will be added here just before 
 
 ### 🛠 Breaking changes
 
+- Require scopeKey in custom push notifications. ([#12964](https://github.com/expo/expo/pull/12964) by [@wschurman](https://github.com/wschurman)
 - **`expo-battery`**
   - Removed following types: `BatteryLevelUpdateListener `, `BatteryStateUpdateListener` and `PowerModeUpdateListener` as they were only wrapping one-argument events responses. Use event types explicitly instead: `BatteryLevelEvent `, `BatteryStateEvent` and `PowerModeEvent`. ([#12592](https://github.com/expo/expo/pull/12592) by [@Simek](https://github.com/simek)) ([#12592](https://github.com/expo/expo/pull/12592) by [@simek](https://github.com/simek))
 - **`expo-constants`**

--- a/docs/pages/push-notifications/sending-notifications-custom.md
+++ b/docs/pages/push-notifications/sending-notifications-custom.md
@@ -45,6 +45,7 @@ await fetch('https://fcm.googleapis.com/fcm/send', {
     priority: 'normal',
     data: {
       experienceId: '@yourExpoUsername/yourProjectSlug',
+      scopeKey: '@yourExpoUsername/yourProjectSlug',
       title: "\uD83D\uDCE7 You've got mail",
       message: 'Hello world! \uD83C\uDF10',
     },
@@ -52,7 +53,7 @@ await fetch('https://fcm.googleapis.com/fcm/send', {
 });
 ```
 
-**The `experienceId` field is required**, otherwise your notifications will not go through to your app. FCM has their full list of supported fields in the notification payload [here](https://firebase.google.com/docs/cloud-messaging/http-server-ref#notification-payload-support), and you can see which ones are supported by `expo-notifications` on Android by looking at [the documentation](../versions/latest/sdk/notifications.md#firebaseremotemessage).
+**The `experienceId` and `scopeKey` fields are required**, otherwise your notifications will not go through to your app. FCM has their full list of supported fields in the notification payload [here](https://firebase.google.com/docs/cloud-messaging/http-server-ref#notification-payload-support), and you can see which ones are supported by `expo-notifications` on Android by looking at [the documentation](../versions/latest/sdk/notifications.md#firebaseremotemessage).
 
 > FCM also provides some server-side libraries in a few languages you can use instead of raw `fetch` requests. [See here for more info](https://firebase.google.com/docs/cloud-messaging/send-message#node.js).
 
@@ -122,6 +123,7 @@ request.write(
       },
     },
     experienceId: '@yourExpoUsername/yourProjectSlug', // Required when testing in the Expo Go app
+    scopeKey: '@yourExpoUsername/yourProjectSlug', // Required when testing in the Expo Go app
   })
 );
 request.end();
@@ -153,6 +155,7 @@ The examples above show bare minimum notification requests, which aren't that ex
   },
   "body": { object of key-value pairs },
   "experienceId": "@yourExpoUsername/yourProjectSlug",
+  "scopeKey": "@yourExpoUsername/yourProjectSlug",
 }
 ```
 
@@ -165,6 +168,7 @@ The examples above show bare minimum notification requests, which aren't that ex
   "priority": "normal" || "high",
   "data": {
     "experienceId": "@yourExpoUsername/yourProjectSlug",
+    "scopeKey": "@yourExpoUsername/yourProjectSlug",
     "title": title of your message,
     "message": body of your message,
     "channelId": the android channel ID associated with this notification,


### PR DESCRIPTION
# Why

In https://github.com/expo/expo/pull/12964 (android), we changed the client code to use the new `scopeKey` field from the notification payload to determine the experience that it should be delivered to (mainly for Expo Go, but for some standalone builds with `expo-notifications` as well in android). 

This was assumed to be safe since I was under the assumption that all notifications were being sent through the Expo push notification service. This assumption turned out to be incorrect, as we documented how to send these without the Expo push service. This documentation wasn't updated accordingly. https://docs.expo.dev/push-notifications/sending-notifications-custom/

Closes https://github.com/expo/expo/issues/15158.

# How

Update documentation.

# Test Plan

Wait for CI.