### PR TITLE
[docs] correct link to members settings

### DIFF
--- a/docs/pages/guides/sharing-preview-releases.md
+++ b/docs/pages/guides/sharing-preview-releases.md
@@ -12,7 +12,7 @@ The typical means of distribution for a mobile app is through the Apple App Stor
 If you are using the Expo Managed workflow, you can share your application with your team through the Expo Go app. Expo Go is the easiest option to set up, doesn't require a paid Apple Developer account, and works the same on both platforms.  Your users will launch the application through Expo Go rather than from an app icon though, so if that experience is important to you, consider [Internal Distribution](#internal-distribution) or [TestFlight for iOS](#testflight) instead.
 
 1. Publish the latest version of your project to Expo's servers by running `expo publish`.
-2. [Invite your teammate](https://expo.dev/settings/members) to the Expo account that owns the project.
+2. [Invite your teammate](https://expo.dev/accounts/[account]/settings/members) to the Expo account that owns the project.
 3. Have them [download the Expo Go app](https://expo.dev/expo-go) onto their device.
 4. They'll be able to open your application from the Profile tab of their Expo Go app.
 

--- a/docs/pages/guides/sharing-preview-releases.md
+++ b/docs/pages/guides/sharing-preview-releases.md
@@ -12,7 +12,7 @@ The typical means of distribution for a mobile app is through the Apple App Stor
 If you are using the Expo Managed workflow, you can share your application with your team through the Expo Go app. Expo Go is the easiest option to set up, doesn't require a paid Apple Developer account, and works the same on both platforms.  Your users will launch the application through Expo Go rather than from an app icon though, so if that experience is important to you, consider [Internal Distribution](#internal-distribution) or [TestFlight for iOS](#testflight) instead.
 
 1. Publish the latest version of your project to Expo's servers by running `expo publish`.
-2. [Invite your teammate](https://expo.dev/[account]/[project]/settings/members) to the Expo account that owns the project.
+2. [Invite your teammate](https://expo.dev/settings/members) to the Expo account that owns the project.
 3. Have them [download the Expo Go app](https://expo.dev/expo-go) onto their device.
 4. They'll be able to open your application from the Profile tab of their Expo Go app.
 


### PR DESCRIPTION
# Why

Fixes #16046

* #16046

# How

It looks like we can use https://expo.dev/settings/members link here which redirects the user to the correct wizard or setting page based on the account and available projects.

# Test Plan

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
