### PR TITLE
[docs] Simplify the table of contents with intersection observers

### DIFF
--- a/docs/common/use-table-of-contents.ts
+++ b/docs/common/use-table-of-contents.ts
@@ -1,0 +1,109 @@
+import { useRouter } from 'next/router';
+import { useCallback, useEffect, useState } from 'react';
+
+type TableOfContentsOptions = {
+  /** The root containing element to search for headings and observe them scrolling */
+  root?: Element;
+  /** The query selector to fetch all headings, defaults to `h2, h3` */
+  selector?: string;
+};
+
+/**
+ * Find the headings within an element to generate a table of contents.
+ * This also uses an intersection observer to detect whenever headings are visible.
+ *
+ * @todo Remove "first flash of unstyled content" by extracting headings from MDX
+ */
+export function useTableOfContents(options: TableOfContentsOptions = {}) {
+  const [activeId, setActiveId] = useState<string>();
+  const headings = useHeadings(options.root, options.selector);
+  const router = useRouter();
+
+  useObserver(options.root, setActiveId, headings);
+
+  const onRouteChange = useCallback(
+    (url: string) => setActiveId(url.split('#', 2).pop()!),
+    [setActiveId]
+  );
+
+  useEffect(function onDidMount() {
+    router.events.on('hashChangeStart', onRouteChange);
+    if (window.location.hash) {
+      onRouteChange(window.location.hash);
+    }
+    return () => router.events.off('hashChangeStart', onRouteChange);
+  }, []);
+
+  return { headings, activeId };
+}
+
+/**
+ * Find the heading elements within a root element.
+ */
+function useHeadings(root: Element | undefined, selector = 'h2, h3') {
+  const [headings, setHeadings] = useState<HTMLHeadingElement[]>([]);
+
+  useEffect(
+    function onDidMount() {
+      const elements = root?.querySelectorAll<HTMLHeadingElement>(selector);
+      if (elements?.length) {
+        setHeadings(Array.from(elements));
+      } else {
+        setHeadings([]);
+      }
+    },
+    [root, selector]
+  );
+
+  return headings;
+}
+
+/**
+ * Observe elements to detect them being scrolled in and out of view.
+ * This uses an intersection observer under the hood.
+ */
+function useObserver(
+  root: Element | undefined,
+  onVisible: (id: string) => any,
+  observerables: Element[]
+) {
+  // TODO(cedric): find a better way to detect changes of the observerables
+  const observerablesHash = observerables.map(el => findHeadingId(el)).join('');
+
+  const onObserve = useCallback(
+    (entries: IntersectionObserverEntry[]) => {
+      const visible = entries.filter(entry => entry.isIntersecting);
+      if (visible.length === 1) {
+        // TODO(cedric): move the heading id back the the heading element
+        onVisible(findHeadingId(visible[0].target));
+      } else if (visible.length > 1) {
+        const sorted = visible.sort(
+          (a, b) => observerables.indexOf(a.target) - observerables.indexOf(b.target)
+        );
+        onVisible(findHeadingId(sorted[0].target));
+      }
+    },
+    [onVisible, observerablesHash]
+  );
+
+  useEffect(
+    function onDidMount() {
+      const observer = new IntersectionObserver(onObserve, {
+        root,
+        // TODO(cedric): make sure these margins are tweaked properly with the new heading components
+        rootMargin: '-25% 0px -25% 0px',
+      });
+      observerables.forEach(observerable => observer.observe(observerable));
+      return () => observer.disconnect();
+    },
+    [root, onVisible, onObserve, observerablesHash]
+  );
+}
+
+/**
+ * Find the heading ID of a heading.
+ * @todo move the heading id back the the heading element, making this function obsolete
+ */
+export function findHeadingId(element: Element) {
+  return Array.from(element.getElementsByTagName('span')).find(span => span.id)!.id;
+}


### PR DESCRIPTION
# Why

Fixes [ENG-3963](https://linear.app/expo/issue/ENG-3963/simplify-the-table-of-contents-scroll-detection)

# How

Created a `useTableOfContents` hook that does the following:

1. Find all heading elements that should be rendered in the TOC
2. Observe all heading elements to determine the current active heading
3. Add an empty `DocumentationSidebarRight` to test the hook

It's not fully finished yet, there are still some things to do:

1. Update table of contents styling to match the new design
2. Clean up all refs, custom scroll handlers, and in-view calculations
3. Add back smooth scrolling that listens to any URL hash change (makes smooth scrolling available to MDX hash links)
4. Render the different types of heading elements according to their content (e.g. text vs code headings)

# Test Plan

TBD

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
