### PR TITLE
Updated video description to save time

### DIFF
--- a/docs/pages/versions/unversioned/sdk/video.md
+++ b/docs/pages/versions/unversioned/sdk/video.md
@@ -38,6 +38,7 @@ export default function App() {
         ref={video}
         style={styles.video}
         source={{
+          //Be careful this link is http, if your request configuration accepts only ssl, this video cannot be loaded. 
           uri: 'http://d23dyxeqlo5psv.cloudfront.net/big_buck_bunny.mp4',
         }}
         useNativeControls

--- a/docs/pages/versions/unversioned/sdk/video.md
+++ b/docs/pages/versions/unversioned/sdk/video.md
@@ -38,7 +38,6 @@ export default function App() {
         ref={video}
         style={styles.video}
         source={{
-          //Be careful this link is http, if your request configuration accepts only ssl, this video cannot be loaded. 
           uri: 'https://d23dyxeqlo5psv.cloudfront.net/big_buck_bunny.mp4',
         }}
         useNativeControls

--- a/docs/pages/versions/unversioned/sdk/video.md
+++ b/docs/pages/versions/unversioned/sdk/video.md
@@ -39,7 +39,7 @@ export default function App() {
         style={styles.video}
         source={{
           //Be careful this link is http, if your request configuration accepts only ssl, this video cannot be loaded. 
-          uri: 'http://d23dyxeqlo5psv.cloudfront.net/big_buck_bunny.mp4',
+          uri: 'https://d23dyxeqlo5psv.cloudfront.net/big_buck_bunny.mp4',
         }}
         useNativeControls
         resizeMode="contain"


### PR DESCRIPTION
When i copy and paste this code to my project, I couldn't play this video. Then, I realized this link is http. in ios env. you can send request with ssl only. In my opinion, you should change link `http` => `https` or write this comment block to remind it.

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
