### PR TITLE
[cli] lazy load imports to make --help show faster

### DIFF
--- a/packages/expo/cli/config/configAsync.ts
+++ b/packages/expo/cli/config/configAsync.ts
@@ -1,6 +1,4 @@
 import { ExpoConfig, getConfig, ProjectConfig } from '@expo/config';
-import { compileModsAsync } from '@expo/config-plugins/build/plugins/mod-compiler';
-import { getPrebuildConfigAsync } from '@expo/prebuild-config';
 import assert from 'assert';
 import util from 'util';
 
@@ -40,10 +38,15 @@ export async function configAsync(projectRoot: string, options: Options) {
   let config: ProjectConfig;
 
   if (options.type === 'prebuild') {
+    const { getPrebuildConfigAsync } = await import('@expo/prebuild-config');
+
     config = await profile(getPrebuildConfigAsync)(projectRoot, {
       platforms: ['ios', 'android'],
     });
   } else if (options.type === 'introspect') {
+    const { getPrebuildConfigAsync } = await import('@expo/prebuild-config');
+    const { compileModsAsync } = await import('@expo/config-plugins/build/plugins/mod-compiler');
+
     config = await profile(getPrebuildConfigAsync)(projectRoot, {
       platforms: ['ios', 'android'],
     });

--- a/packages/expo/cli/config/index.ts
+++ b/packages/expo/cli/config/index.ts
@@ -4,10 +4,8 @@ import chalk from 'chalk';
 import { Command } from '../../bin/cli';
 import * as Log from '../log';
 import { assertArgs, getProjectRoot } from '../utils/args';
-import { logCmdError } from '../utils/errors';
-import { configAsync } from './configAsync';
 
-export const expoConfig: Command = (argv) => {
+export const expoConfig: Command = async (argv) => {
   const args = assertArgs(
     {
       // Types
@@ -43,6 +41,9 @@ export const expoConfig: Command = (argv) => {
       0
     );
   }
+
+  const { configAsync } = await import('./configAsync');
+  const { logCmdError } = await import('../utils/errors');
 
   return configAsync(getProjectRoot(args), {
     // Parsed options

--- a/packages/expo/cli/config/index.ts
+++ b/packages/expo/cli/config/index.ts
@@ -43,8 +43,12 @@ export const expoConfig: Command = async (argv) => {
   }
 
   // Load modules after the help prompt so `npx expo config -h` shows as fast as possible.
-  const { configAsync } = await import('./configAsync');
-  const { logCmdError } = await import('../utils/errors');
+  const [
+    // ./configAsync
+    { configAsync },
+    // ../utils/errors
+    { logCmdError },
+  ] = await Promise.all([import('./configAsync'), import('../utils/errors')]);
 
   return configAsync(getProjectRoot(args), {
     // Parsed options

--- a/packages/expo/cli/config/index.ts
+++ b/packages/expo/cli/config/index.ts
@@ -42,6 +42,7 @@ export const expoConfig: Command = async (argv) => {
     );
   }
 
+  // Load modules after the help prompt so `npx expo config -h` shows as fast as possible.
   const { configAsync } = await import('./configAsync');
   const { logCmdError } = await import('../utils/errors');
 

--- a/packages/expo/cli/log.ts
+++ b/packages/expo/cli/log.ts
@@ -1,5 +1,3 @@
-import { EXPO_DEBUG } from './utils/env';
-
 export function time(label?: string): void {
   console.time(label);
 }
@@ -21,7 +19,7 @@ export function log(...message: string[]): void {
 }
 
 export function debug(...message: string[]): void {
-  if (EXPO_DEBUG) console.log(...message);
+  if (require('./utils/env').EXPO_DEBUG) console.log(...message);
 }
 
 /** Log a message and exit the current process. If the `code` is non-zero then `console.error` will be used instead of `console.log`. */

--- a/packages/expo/cli/prebuild/index.ts
+++ b/packages/expo/cli/prebuild/index.ts
@@ -4,11 +4,8 @@ import chalk from 'chalk';
 import { Command } from '../../bin/cli';
 import * as Log from '../log';
 import { assertArgs, getProjectRoot } from '../utils/args';
-import { logCmdError } from '../utils/errors';
-import { prebuildAsync } from './prebuildAsync';
-import { resolvePlatformOption, resolveSkipDependencyUpdate } from './resolveOptions';
 
-export const expoPrebuild: Command = (argv) => {
+export const expoPrebuild: Command = async (argv) => {
   const args = assertArgs(
     {
       // Types
@@ -52,6 +49,10 @@ export const expoPrebuild: Command = (argv) => {
       0
     );
   }
+
+  const { prebuildAsync } = await import('./prebuildAsync');
+  const { logCmdError } = await import('../utils/errors');
+  const { resolvePlatformOption, resolveSkipDependencyUpdate } = await import('./resolveOptions');
 
   return prebuildAsync(getProjectRoot(args), {
     // Parsed options

--- a/packages/expo/cli/prebuild/index.ts
+++ b/packages/expo/cli/prebuild/index.ts
@@ -51,9 +51,18 @@ export const expoPrebuild: Command = async (argv) => {
   }
 
   // Load modules after the help prompt so `npx expo prebuild -h` shows as fast as possible.
-  const { prebuildAsync } = await import('./prebuildAsync');
-  const { logCmdError } = await import('../utils/errors');
-  const { resolvePlatformOption, resolveSkipDependencyUpdate } = await import('./resolveOptions');
+  const [
+    // ./prebuildAsync
+    { prebuildAsync },
+    // ./resolveOptions
+    { resolvePlatformOption, resolveSkipDependencyUpdate },
+    // ../utils/errors
+    { logCmdError },
+  ] = await Promise.all([
+    import('./prebuildAsync'),
+    import('./resolveOptions'),
+    import('../utils/errors'),
+  ]);
 
   return prebuildAsync(getProjectRoot(args), {
     // Parsed options

--- a/packages/expo/cli/prebuild/index.ts
+++ b/packages/expo/cli/prebuild/index.ts
@@ -50,6 +50,7 @@ export const expoPrebuild: Command = async (argv) => {
     );
   }
 
+  // Load modules after the help prompt so `npx expo prebuild -h` shows as fast as possible.
   const { prebuildAsync } = await import('./prebuildAsync');
   const { logCmdError } = await import('../utils/errors');
   const { resolvePlatformOption, resolveSkipDependencyUpdate } = await import('./resolveOptions');

--- a/packages/expo/cli/prebuild/prebuildAsync.ts
+++ b/packages/expo/cli/prebuild/prebuildAsync.ts
@@ -2,8 +2,6 @@ import { ExpoConfig } from '@expo/config';
 import { ModPlatform } from '@expo/config-plugins';
 
 import * as Log from '../log';
-import { installCocoaPodsAsync } from '../utils/cocoapods';
-import { maybeBailOnGitStatusAsync } from '../utils/git';
 import { installNodeDependenciesAsync, resolvePackageManager } from '../utils/nodeModules';
 import { logNewSection } from '../utils/ora';
 import { profile } from '../utils/profile';
@@ -55,6 +53,7 @@ export async function prebuildAsync(
   }
 ): Promise<PrebuildResults> {
   if (options.clean) {
+    const { maybeBailOnGitStatusAsync } = await import('../utils/git');
     // Clean the project folders...
     if (await maybeBailOnGitStatusAsync()) {
       return;
@@ -117,6 +116,8 @@ export async function prebuildAsync(
   let podsInstalled: boolean = false;
   // err towards running pod install less because it's slow and users can easily run npx pod-install afterwards.
   if (options.platforms.includes('ios') && options.install && needsPodInstall) {
+    const { installCocoaPodsAsync } = await import('../utils/cocoapods');
+
     podsInstalled = await installCocoaPodsAsync(projectRoot);
   } else {
     Log.debug('Skipped pod install');

--- a/packages/expo/e2e/__tests__/config-test.ts
+++ b/packages/expo/e2e/__tests__/config-test.ts
@@ -2,7 +2,7 @@
 import fs from 'fs/promises';
 import path from 'path';
 
-import { execute, projectRoot, getRoot } from './utils';
+import { execute, projectRoot, getRoot, getLoadedModulesAsync } from './utils';
 
 const originalForceColor = process.env.FORCE_COLOR;
 beforeAll(async () => {
@@ -11,6 +11,21 @@ beforeAll(async () => {
 });
 afterAll(() => {
   process.env.FORCE_COLOR = originalForceColor;
+});
+
+it('loads expected modules by default', async () => {
+  const modules = await getLoadedModulesAsync(`require('../../build-cli/cli/config').expoConfig`);
+  expect(modules).toStrictEqual([
+    'node_modules/ansi-styles/index.js',
+    'node_modules/arg/index.js',
+    'node_modules/chalk/source/index.js',
+    'node_modules/chalk/source/util.js',
+    'node_modules/has-flag/index.js',
+    'node_modules/supports-color/index.js',
+    'packages/expo/build-cli/cli/config/index.js',
+    'packages/expo/build-cli/cli/log.js',
+    'packages/expo/build-cli/cli/utils/args.js',
+  ]);
 });
 
 it('runs `npx expo config --help`', async () => {

--- a/packages/expo/e2e/__tests__/prebuild-test.ts
+++ b/packages/expo/e2e/__tests__/prebuild-test.ts
@@ -5,7 +5,14 @@ import fs from 'fs/promises';
 import klawSync from 'klaw-sync';
 import path from 'path';
 
-import { bin, execute, projectRoot, getRoot, setupTestProjectAsync } from './utils';
+import {
+  bin,
+  execute,
+  projectRoot,
+  getRoot,
+  setupTestProjectAsync,
+  getLoadedModulesAsync,
+} from './utils';
 
 const originalForceColor = process.env.FORCE_COLOR;
 const originalCI = process.env.CI;
@@ -19,6 +26,23 @@ beforeAll(async () => {
 afterAll(() => {
   process.env.FORCE_COLOR = originalForceColor;
   process.env.CI = originalCI;
+});
+
+it('loads expected modules by default', async () => {
+  const modules = await getLoadedModulesAsync(
+    `require('../../build-cli/cli/prebuild').expoPrebuild`
+  );
+  expect(modules).toStrictEqual([
+    'node_modules/ansi-styles/index.js',
+    'node_modules/arg/index.js',
+    'node_modules/chalk/source/index.js',
+    'node_modules/chalk/source/util.js',
+    'node_modules/has-flag/index.js',
+    'node_modules/supports-color/index.js',
+    'packages/expo/build-cli/cli/log.js',
+    'packages/expo/build-cli/cli/prebuild/index.js',
+    'packages/expo/build-cli/cli/utils/args.js',
+  ]);
 });
 
 it('runs `npx expo prebuild --help`', async () => {

--- a/packages/expo/e2e/__tests__/utils.ts
+++ b/packages/expo/e2e/__tests__/utils.ts
@@ -180,3 +180,18 @@ export async function setupTestProjectAsync(name: string, fixtureName: string): 
   expect(exp.sdkVersion).toBe('44.0.0');
   return projectRoot;
 }
+
+/** Returns a list of loaded modules relative to the repo root. Useful for preventing lazy loading from breaking unexpectedly.   */
+export async function getLoadedModulesAsync(statement: string): Promise<string[]> {
+  const repoRoot = path.join(__dirname, '../../../../');
+  const results = await execa(
+    'node',
+    [
+      '-e',
+      [statement, `console.log(JSON.stringify(Object.keys(require('module')._cache)));`].join('\n'),
+    ],
+    { cwd: __dirname }
+  );
+  const loadedModules = JSON.parse(results.stdout.trim());
+  return loadedModules.map((value) => path.relative(repoRoot, value)).sort();
+}


### PR DESCRIPTION
# Why

Noticed `--help` flags were a bit sluggish. This PR improves times:
```
Before: npx expo prebuild -h  0.51s user 0.12s system 105% cpu 0.593 total
After: npx expo prebuild  -h  0.05s user 0.01s system 99% cpu 0.060 total
```

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Lazily load command modules after the help command and argument parsing, this means invalid argument failures are faster too. This PR also makes the config commands slightly faster based on complexity.

# Test Plan

- `time npx expo prebuild -h`
- `time npx expo config -h`