### PR TITLE
[sweet][kotlin] Fix callbacks not working if only one callback was registered 

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/GroupViewManagerWrapper.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/GroupViewManagerWrapper.kt
@@ -3,6 +3,7 @@ package expo.modules.kotlin.views
 import android.view.View
 import android.view.ViewGroup
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.common.MapBuilder
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.ViewGroupManager
 import com.facebook.react.uimanager.annotations.ReactProp
@@ -28,7 +29,14 @@ class GroupViewManagerWrapper(
   override fun getExportedCustomDirectEventTypeConstants(): Map<String, Any>? {
     viewWrapperDelegate.getExportedCustomDirectEventTypeConstants()?.let {
       val directEvents = super.getExportedCustomDirectEventTypeConstants() ?: emptyMap()
-      return directEvents + it
+      val builder = MapBuilder.builder<String, Any>()
+      directEvents.forEach { event ->
+        builder.put(event.key, event.value)
+      }
+      it.forEach { event ->
+        builder.put(event.key, event.value)
+      }
+      return builder.build()
     }
 
     return super.getExportedCustomDirectEventTypeConstants()

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/SimpleViewManagerWrapper.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/SimpleViewManagerWrapper.kt
@@ -2,6 +2,7 @@ package expo.modules.kotlin.views
 
 import android.view.View
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.common.MapBuilder
 import com.facebook.react.uimanager.SimpleViewManager
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.annotations.ReactProp
@@ -27,7 +28,14 @@ class SimpleViewManagerWrapper(
   override fun getExportedCustomDirectEventTypeConstants(): Map<String, Any>? {
     viewWrapperDelegate.getExportedCustomDirectEventTypeConstants()?.let {
       val directEvents = super.getExportedCustomDirectEventTypeConstants() ?: emptyMap()
-      return directEvents + it
+      val builder = MapBuilder.builder<String, Any>()
+      directEvents.forEach { event ->
+        builder.put(event.key, event.value)
+      }
+      it.forEach { event ->
+        builder.put(event.key, event.value)
+      }
+      return builder.build()
     }
 
     return super.getExportedCustomDirectEventTypeConstants()

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerWrapperDelegate.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerWrapperDelegate.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.Log
 import android.view.View
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.common.MapBuilder
 import expo.modules.core.utilities.ifNull
 import expo.modules.kotlin.ModuleHolder
 import expo.modules.kotlin.callbacks.ViewCallbackDelegate
@@ -33,15 +34,16 @@ class ViewManagerWrapperDelegate(internal var moduleHolder: ModuleHolder) {
     definition.onViewDestroys?.invoke(view)
 
   fun getExportedCustomDirectEventTypeConstants(): Map<String, Any>? {
-    return definition
+    val builder = MapBuilder.builder<String, Any>()
+    definition
       .callbacksDefinition
       ?.names
-      ?.map {
-        it to mapOf(
-          "registrationName" to it
+      ?.forEach {
+        builder.put(
+          it, MapBuilder.of<String, Any>("registrationName", it)
         )
       }
-      ?.toMap()
+    return builder.build()
   }
 
   private fun configureView(view: View) {


### PR DESCRIPTION
# Why

Fix callbacks not working if only one callback was registered.

# How

For some reason, RN requires that the `getExportedCustomDirectEventTypeConstants` will be a hashmap. Kotlin collection factory functions use a different map type if only one element is present. I tested that feature with multiple callbacks registered. So I missed that detail.

# Test Plan

- bare-expo ✅