### PR TITLE
[dev-launcher] contain dev app labels to one line on dev launcher

### DIFF
--- a/packages/expo-dev-launcher/bundle/screens/HomeScreen.tsx
+++ b/packages/expo-dev-launcher/bundle/screens/HomeScreen.tsx
@@ -263,8 +263,11 @@ function RecentlyOpenedApps({ onAppPress }) {
                 <Row align="center" padding="medium">
                   <StatusIndicator size="small" status="success" />
                   <Spacer.Horizontal size="small" />
-                  <Button.Text color="default">{label}</Button.Text>
-                  <Spacer.Horizontal size="flex" />
+                  <View flex="1">
+                    <Button.Text color="default" numberOfLines={1}>
+                      {label}
+                    </Button.Text>
+                  </View>
                   <ChevronRightIcon />
                 </Row>
               </Button.ScaleOnPressContainer>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

I noticed this today when preparing for the demo - sometimes the labels in the dev launcher for different dev apps would have text that can wrap to a second line - especially if its a long name 

# How

<!--
How did you build this feature or fix this bug and why?
-->

contain the label by setting the max number of lines to be 1 - this gives us a shortened text instead of wrapping 

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
