### PR TITLE
[docs] APISection components UI tweaks

### DIFF
--- a/docs/components/DocumentationPage.tsx
+++ b/docs/components/DocumentationPage.tsx
@@ -28,8 +28,9 @@ const STYLES_DOCUMENT = css`
   padding: 40px 56px;
 
   hr {
-    border-top: 1px solid ${theme.border.default};
-    border-bottom: 0px;
+    border: 0;
+    height: 0.01rem;
+    background-color: ${theme.border.default};
   }
 
   @media screen and (max-width: ${Constants.breakpoints.mobile}) {

--- a/docs/components/base/code.tsx
+++ b/docs/components/base/code.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { SerializedStyles } from '@emotion/serialize';
 import { theme } from '@expo/styleguide';
 import { Language, Prism } from 'prism-react-renderer';
 import * as React from 'react';
@@ -162,7 +163,7 @@ export class Code extends React.Component<Props> {
 
     // Allow for code blocks without a language.
     if (lang) {
-      // sh isn't supported, use Use sh to match js, and ts
+      // sh isn't supported, use sh to match js, and ts
       if (lang in remapLanguages) {
         lang = remapLanguages[lang];
       }
@@ -182,7 +183,7 @@ export class Code extends React.Component<Props> {
       }
     }
 
-    // Remove leading newline if it exists (because inside <pre> all whitespace is dislayed as is by the browser, and
+    // Remove leading newline if it exists (because inside <pre> all whitespace is displayed as is by the browser, and
     // sometimes, Prism adds a newline before the code)
     if (html.startsWith('\n')) {
       html = html.replace('\n', '');
@@ -202,8 +203,8 @@ const remapLanguages: Record<string, string> = {
   rb: 'ruby',
 };
 
-export const InlineCode: React.FC = ({ children }) => (
-  <code css={STYLES_INLINE_CODE} className="inline">
+export const InlineCode: React.FC<{ customCss?: SerializedStyles }> = ({ children, customCss }) => (
+  <code css={[STYLES_INLINE_CODE, customCss]} className="inline">
     {children}
   </code>
 );

--- a/docs/components/base/list.tsx
+++ b/docs/components/base/list.tsx
@@ -69,19 +69,38 @@ const STYLES_LIST_ITEM = css`
 `;
 
 const STYLE_RETURN_LIST = css`
-  list-style-type: '⇒';
+  list-style-type: '⮑';
   padding-left: 0.5rem;
+  margin-left: 0.25rem;
+
+  ::marker {
+    color: ${theme.text.secondary};
+    font-size: 90%;
+  }
+`;
+
+const STYLE_PROP_LIST = css`
+  ::marker {
+    color: ${theme.text.secondary};
+    font-size: 125%;
+  }
 `;
 
 type LIProps = {
   returnType?: boolean;
-  customCss?: SerializedStyles | undefined;
+  propType?: boolean;
+  customCss?: SerializedStyles;
 };
 
-export const LI: React.FC<LIProps> = ({ children, returnType, customCss }) => {
+export const LI: React.FC<LIProps> = ({ children, returnType, propType, customCss }) => {
   return (
     <li
-      css={[STYLES_LIST_ITEM, returnType && STYLE_RETURN_LIST, customCss]}
+      css={[
+        STYLES_LIST_ITEM,
+        returnType && STYLE_RETURN_LIST,
+        propType && STYLE_PROP_LIST,
+        customCss,
+      ]}
       className="docs-list-item">
       {children}
     </li>

--- a/docs/components/base/list.tsx
+++ b/docs/components/base/list.tsx
@@ -74,7 +74,7 @@ const STYLE_RETURN_LIST = css`
   margin-left: 0.25rem;
 
   ::marker {
-    color: ${theme.text.secondary};
+    color: ${theme.icon.secondary};
     font-size: 90%;
   }
 `;

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -1199,7 +1199,7 @@ This should come from the user field of an
         data-text="true"
       >
         <li
-          class="docs-list-item css-1t0kz9z-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+          class="docs-list-item css-1wwpkbk-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
         >
           <code
             class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
@@ -1365,7 +1365,7 @@ value depending on the state of the credential.
         data-text="true"
       >
         <li
-          class="docs-list-item css-1t0kz9z-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+          class="docs-list-item css-1wwpkbk-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
         >
           <code
             class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
@@ -1620,7 +1620,7 @@ Calling this method will show the sign in modal before actually refreshing the u
         data-text="true"
       >
         <li
-          class="docs-list-item css-1t0kz9z-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+          class="docs-list-item css-1wwpkbk-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
         >
           <code
             class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
@@ -1926,7 +1926,7 @@ the user, since this remains the same for apps released by the same developer.
         data-text="true"
       >
         <li
-          class="docs-list-item css-1t0kz9z-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+          class="docs-list-item css-1wwpkbk-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
         >
           <code
             class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
@@ -2223,7 +2223,7 @@ from using
         data-text="true"
       >
         <li
-          class="docs-list-item css-1t0kz9z-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+          class="docs-list-item css-1wwpkbk-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
         >
           <code
             class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
@@ -2515,7 +2515,7 @@ sign-out operation.
         data-text="true"
       >
         <li
-          class="docs-list-item css-1t0kz9z-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+          class="docs-list-item css-1wwpkbk-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
         >
           <code
             class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
@@ -6104,7 +6104,7 @@ This can be used to quickly create specific permission hooks in every module.
         data-text="true"
       >
         <li
-          class="docs-list-item css-1t0kz9z-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+          class="docs-list-item css-1wwpkbk-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
         >
           <code
             class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
@@ -6330,7 +6330,7 @@ This can be used to quickly create specific permission hooks in every module.
         data-text="true"
       >
         <li
-          class="docs-list-item css-1t0kz9z-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+          class="docs-list-item css-1wwpkbk-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
         >
           <code
             class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
@@ -6514,7 +6514,7 @@ This can be used to quickly create specific permission hooks in every module.
         data-text="true"
       >
         <li
-          class="docs-list-item css-1t0kz9z-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+          class="docs-list-item css-1wwpkbk-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
         >
           <code
             class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
@@ -6816,7 +6816,7 @@ the platform.
         data-text="true"
       >
         <li
-          class="docs-list-item css-1t0kz9z-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+          class="docs-list-item css-1wwpkbk-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
         >
           <code
             class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
@@ -8540,7 +8540,7 @@ exports[`APISection expo-pedometer 1`] = `
         data-text="true"
       >
         <li
-          class="docs-list-item css-1t0kz9z-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+          class="docs-list-item css-1wwpkbk-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
         >
           <code
             class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
@@ -8797,7 +8797,7 @@ exports[`APISection expo-pedometer 1`] = `
         data-text="true"
       >
         <li
-          class="docs-list-item css-1t0kz9z-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+          class="docs-list-item css-1wwpkbk-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
         >
           <code
             class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
@@ -9012,7 +9012,7 @@ a start date that is more than seven days in the past returns only the available
         data-text="true"
       >
         <li
-          class="docs-list-item css-1t0kz9z-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+          class="docs-list-item css-1wwpkbk-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
         >
           <code
             class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
@@ -9162,7 +9162,7 @@ available on this device.
         data-text="true"
       >
         <li
-          class="docs-list-item css-1t0kz9z-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+          class="docs-list-item css-1wwpkbk-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
         >
           <code
             class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
@@ -9404,7 +9404,7 @@ provided with a single argument that is
         data-text="true"
       >
         <li
-          class="docs-list-item css-1t0kz9z-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+          class="docs-list-item css-1wwpkbk-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
         >
           <code
             class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -4177,7 +4177,7 @@ OAuth 2.0 protocol
         </span>
         <br />
         <code
-          class="inline css-3rca64-STYLES_INLINE_CODE-renderEnum-InlineCode"
+          class="inline css-1nolcer-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
         >
           AppleAuthenticationButtonStyle
           .
@@ -4204,7 +4204,7 @@ OAuth 2.0 protocol
         </span>
         <br />
         <code
-          class="inline css-3rca64-STYLES_INLINE_CODE-renderEnum-InlineCode"
+          class="inline css-1nolcer-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
         >
           AppleAuthenticationButtonStyle
           .
@@ -4231,7 +4231,7 @@ OAuth 2.0 protocol
         </span>
         <br />
         <code
-          class="inline css-3rca64-STYLES_INLINE_CODE-renderEnum-InlineCode"
+          class="inline css-1nolcer-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
         >
           AppleAuthenticationButtonStyle
           .
@@ -4337,7 +4337,7 @@ OAuth 2.0 protocol
         </span>
         <br />
         <code
-          class="inline css-3rca64-STYLES_INLINE_CODE-renderEnum-InlineCode"
+          class="inline css-1nolcer-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
         >
           AppleAuthenticationButtonType
           .
@@ -4364,7 +4364,7 @@ OAuth 2.0 protocol
         </span>
         <br />
         <code
-          class="inline css-3rca64-STYLES_INLINE_CODE-renderEnum-InlineCode"
+          class="inline css-1nolcer-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
         >
           AppleAuthenticationButtonType
           .
@@ -4394,7 +4394,7 @@ OAuth 2.0 protocol
         </span>
         <br />
         <code
-          class="inline css-3rca64-STYLES_INLINE_CODE-renderEnum-InlineCode"
+          class="inline css-1nolcer-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
         >
           AppleAuthenticationButtonType
           .
@@ -4539,7 +4539,7 @@ for more details.
         </span>
         <br />
         <code
-          class="inline css-3rca64-STYLES_INLINE_CODE-renderEnum-InlineCode"
+          class="inline css-1nolcer-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
         >
           AppleAuthenticationCredentialState
           .
@@ -4562,7 +4562,7 @@ for more details.
         </span>
         <br />
         <code
-          class="inline css-3rca64-STYLES_INLINE_CODE-renderEnum-InlineCode"
+          class="inline css-1nolcer-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
         >
           AppleAuthenticationCredentialState
           .
@@ -4585,7 +4585,7 @@ for more details.
         </span>
         <br />
         <code
-          class="inline css-3rca64-STYLES_INLINE_CODE-renderEnum-InlineCode"
+          class="inline css-1nolcer-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
         >
           AppleAuthenticationCredentialState
           .
@@ -4608,7 +4608,7 @@ for more details.
         </span>
         <br />
         <code
-          class="inline css-3rca64-STYLES_INLINE_CODE-renderEnum-InlineCode"
+          class="inline css-1nolcer-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
         >
           AppleAuthenticationCredentialState
           .
@@ -4697,7 +4697,7 @@ for more details.
         </span>
         <br />
         <code
-          class="inline css-3rca64-STYLES_INLINE_CODE-renderEnum-InlineCode"
+          class="inline css-1nolcer-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
         >
           AppleAuthenticationOperation
           .
@@ -4720,7 +4720,7 @@ for more details.
         </span>
         <br />
         <code
-          class="inline css-3rca64-STYLES_INLINE_CODE-renderEnum-InlineCode"
+          class="inline css-1nolcer-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
         >
           AppleAuthenticationOperation
           .
@@ -4743,7 +4743,7 @@ for more details.
         </span>
         <br />
         <code
-          class="inline css-3rca64-STYLES_INLINE_CODE-renderEnum-InlineCode"
+          class="inline css-1nolcer-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
         >
           AppleAuthenticationOperation
           .
@@ -4766,7 +4766,7 @@ for more details.
         </span>
         <br />
         <code
-          class="inline css-3rca64-STYLES_INLINE_CODE-renderEnum-InlineCode"
+          class="inline css-1nolcer-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
         >
           AppleAuthenticationOperation
           .
@@ -4943,7 +4943,7 @@ for more details.
         </span>
         <br />
         <code
-          class="inline css-3rca64-STYLES_INLINE_CODE-renderEnum-InlineCode"
+          class="inline css-1nolcer-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
         >
           AppleAuthenticationScope
           .
@@ -4966,7 +4966,7 @@ for more details.
         </span>
         <br />
         <code
-          class="inline css-3rca64-STYLES_INLINE_CODE-renderEnum-InlineCode"
+          class="inline css-1nolcer-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
         >
           AppleAuthenticationScope
           .
@@ -5104,7 +5104,7 @@ for more details.
         </span>
         <br />
         <code
-          class="inline css-3rca64-STYLES_INLINE_CODE-renderEnum-InlineCode"
+          class="inline css-1nolcer-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
         >
           AppleAuthenticationUserDetectionStatus
           .
@@ -5131,7 +5131,7 @@ for more details.
         </span>
         <br />
         <code
-          class="inline css-3rca64-STYLES_INLINE_CODE-renderEnum-InlineCode"
+          class="inline css-1nolcer-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
         >
           AppleAuthenticationUserDetectionStatus
           .
@@ -5158,7 +5158,7 @@ for more details.
         </span>
         <br />
         <code
-          class="inline css-3rca64-STYLES_INLINE_CODE-renderEnum-InlineCode"
+          class="inline css-1nolcer-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
         >
           AppleAuthenticationUserDetectionStatus
           .
@@ -8313,7 +8313,7 @@ For some types, they will represent the area used by the scanner.
         </span>
         <br />
         <code
-          class="inline css-3rca64-STYLES_INLINE_CODE-renderEnum-InlineCode"
+          class="inline css-1nolcer-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
         >
           PermissionStatus
           .
@@ -8336,7 +8336,7 @@ For some types, they will represent the area used by the scanner.
         </span>
         <br />
         <code
-          class="inline css-3rca64-STYLES_INLINE_CODE-renderEnum-InlineCode"
+          class="inline css-1nolcer-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
         >
           PermissionStatus
           .
@@ -8359,7 +8359,7 @@ For some types, they will represent the area used by the scanner.
         </span>
         <br />
         <code
-          class="inline css-3rca64-STYLES_INLINE_CODE-renderEnum-InlineCode"
+          class="inline css-1nolcer-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
         >
           PermissionStatus
           .
@@ -10247,7 +10247,7 @@ provided with a single argument that is
         </span>
         <br />
         <code
-          class="inline css-3rca64-STYLES_INLINE_CODE-renderEnum-InlineCode"
+          class="inline css-1nolcer-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
         >
           PermissionStatus
           .
@@ -10270,7 +10270,7 @@ provided with a single argument that is
         </span>
         <br />
         <code
-          class="inline css-3rca64-STYLES_INLINE_CODE-renderEnum-InlineCode"
+          class="inline css-1nolcer-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
         >
           PermissionStatus
           .
@@ -10293,7 +10293,7 @@ provided with a single argument that is
         </span>
         <br />
         <code
-          class="inline css-3rca64-STYLES_INLINE_CODE-renderEnum-InlineCode"
+          class="inline css-1nolcer-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
         >
           PermissionStatus
           .

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -73,7 +73,7 @@ exports[`APISection expo-apple-authentication 1`] = `
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               AppleAuthenticationButton
             </code>
@@ -120,7 +120,7 @@ exports[`APISection expo-apple-authentication 1`] = `
       </strong>
        
       <code
-        class="inline css-nuv12a-STYLES_INLINE_CODE"
+        class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
       >
         React.FC
         &lt;
@@ -154,7 +154,7 @@ available via the provided properties.
         href="/#isavailableasync"
       >
         <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
         >
           AppleAuthentication.isAvailableAsync()
         </code>
@@ -162,14 +162,14 @@ available via the provided properties.
       
 resolves to 
       <code
-        class="inline css-nuv12a-STYLES_INLINE_CODE"
+        class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
       >
         true
       </code>
       . This component will render nothing if it is not available, and you will get
 a warning in development mode (
       <code
-        class="inline css-nuv12a-STYLES_INLINE_CODE"
+        class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
       >
         __DEV__ === true
       </code>
@@ -183,40 +183,40 @@ a warning in development mode (
     >
       The properties of this component extend from 
       <code
-        class="inline css-nuv12a-STYLES_INLINE_CODE"
+        class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
       >
         View
       </code>
       ; however, you should not attempt to set
 
       <code
-        class="inline css-nuv12a-STYLES_INLINE_CODE"
+        class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
       >
         backgroundColor
       </code>
        or 
       <code
-        class="inline css-nuv12a-STYLES_INLINE_CODE"
+        class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
       >
         borderRadius
       </code>
        with the 
       <code
-        class="inline css-nuv12a-STYLES_INLINE_CODE"
+        class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
       >
         style
       </code>
        property. This will not work and is against
 the App Store Guidelines. Instead, you should use the 
       <code
-        class="inline css-nuv12a-STYLES_INLINE_CODE"
+        class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
       >
         buttonStyle
       </code>
        property to choose one of the
 predefined color styles and the 
       <code
-        class="inline css-nuv12a-STYLES_INLINE_CODE"
+        class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
       >
         cornerRadius
       </code>
@@ -294,7 +294,7 @@ for more details.
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               AppleAuthenticationButtonProps
             </code>
@@ -337,13 +337,59 @@ for more details.
         data-text="true"
       >
         <li
-          class="docs-list-item css-aulog8-STYLES_LIST_ITEM-LI"
+          class="docs-list-item css-1jvmp7m-STYLES_LIST_ITEM-STYLE_PROP_LIST-PROP_LIST_ELEMENT_STYLE-LI"
         >
           <h4
-            class="css-1j2s5xo-h4-h4-STYLES_H4"
+            class="  css-1j2s5xo-h4-h4-STYLES_H4"
+            data-components-heading="true"
             data-heading="true"
           >
-            buttonStyle
+            <div
+              class="css-1rh3o5q-STYLES_PERMALINK"
+            >
+              <span
+                class="css-zonpcr-STYLES_PERMALINK_TARGET"
+                id="buttonstyle"
+              />
+              <a
+                class="css-15lh5hg-STYLES_PERMALINK_LINK"
+                href="#buttonstyle"
+              >
+                <span
+                  class="css-1icvi79-STYLED_PERMALINK_CONTENT"
+                >
+                  buttonStyle
+                </span>
+                <span
+                  class="css-10vdcw8-STYLES_PERMALINK_ICON"
+                >
+                  <svg
+                    aria-label="permalink"
+                    class="anchor-icon"
+                    fill="none"
+                    height="24"
+                    viewBox="0 0 24 24"
+                    width="24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                      stroke="#9B9B9B"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                    />
+                    <path
+                      d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                      stroke="#9B9B9B"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                    />
+                  </svg>
+                </span>
+              </a>
+            </div>
           </h4>
           <p
             class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
@@ -356,7 +402,7 @@ for more details.
             </span>
              
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               <a
                 class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -372,15 +418,64 @@ for more details.
           >
             The Apple-defined color scheme to use to display the button.
           </p>
+          <hr
+            class="css-bxzs19-STYLES_DIVIDER"
+          />
         </li>
         <li
-          class="docs-list-item css-aulog8-STYLES_LIST_ITEM-LI"
+          class="docs-list-item css-1jvmp7m-STYLES_LIST_ITEM-STYLE_PROP_LIST-PROP_LIST_ELEMENT_STYLE-LI"
         >
           <h4
-            class="css-1j2s5xo-h4-h4-STYLES_H4"
+            class="  css-1j2s5xo-h4-h4-STYLES_H4"
+            data-components-heading="true"
             data-heading="true"
           >
-            buttonType
+            <div
+              class="css-1rh3o5q-STYLES_PERMALINK"
+            >
+              <span
+                class="css-zonpcr-STYLES_PERMALINK_TARGET"
+                id="buttontype"
+              />
+              <a
+                class="css-15lh5hg-STYLES_PERMALINK_LINK"
+                href="#buttontype"
+              >
+                <span
+                  class="css-1icvi79-STYLED_PERMALINK_CONTENT"
+                >
+                  buttonType
+                </span>
+                <span
+                  class="css-10vdcw8-STYLES_PERMALINK_ICON"
+                >
+                  <svg
+                    aria-label="permalink"
+                    class="anchor-icon"
+                    fill="none"
+                    height="24"
+                    viewBox="0 0 24 24"
+                    width="24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                      stroke="#9B9B9B"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                    />
+                    <path
+                      d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                      stroke="#9B9B9B"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                    />
+                  </svg>
+                </span>
+              </a>
+            </div>
           </h4>
           <p
             class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
@@ -393,7 +488,7 @@ for more details.
             </span>
              
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               <a
                 class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -409,15 +504,64 @@ for more details.
           >
             The type of button text to display ("Sign In with Apple" vs. "Continue with Apple").
           </p>
+          <hr
+            class="css-bxzs19-STYLES_DIVIDER"
+          />
         </li>
         <li
-          class="docs-list-item css-aulog8-STYLES_LIST_ITEM-LI"
+          class="docs-list-item css-1jvmp7m-STYLES_LIST_ITEM-STYLE_PROP_LIST-PROP_LIST_ELEMENT_STYLE-LI"
         >
           <h4
-            class="css-1j2s5xo-h4-h4-STYLES_H4"
+            class="  css-1j2s5xo-h4-h4-STYLES_H4"
+            data-components-heading="true"
             data-heading="true"
           >
-            cornerRadius
+            <div
+              class="css-1rh3o5q-STYLES_PERMALINK"
+            >
+              <span
+                class="css-zonpcr-STYLES_PERMALINK_TARGET"
+                id="cornerradius"
+              />
+              <a
+                class="css-15lh5hg-STYLES_PERMALINK_LINK"
+                href="#cornerradius"
+              >
+                <span
+                  class="css-1icvi79-STYLED_PERMALINK_CONTENT"
+                >
+                  cornerRadius
+                </span>
+                <span
+                  class="css-10vdcw8-STYLES_PERMALINK_ICON"
+                >
+                  <svg
+                    aria-label="permalink"
+                    class="anchor-icon"
+                    fill="none"
+                    height="24"
+                    viewBox="0 0 24 24"
+                    width="24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                      stroke="#9B9B9B"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                    />
+                    <path
+                      d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                      stroke="#9B9B9B"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                    />
+                  </svg>
+                </span>
+              </a>
+            </div>
           </h4>
           <p
             class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
@@ -435,7 +579,7 @@ for more details.
             </span>
              
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               number
             </code>
@@ -447,21 +591,70 @@ for more details.
             The border radius to use when rendering the button. This works similarly to
 
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               style.borderRadius
             </code>
              in other Views.
           </p>
+          <hr
+            class="css-bxzs19-STYLES_DIVIDER"
+          />
         </li>
         <li
-          class="docs-list-item css-aulog8-STYLES_LIST_ITEM-LI"
+          class="docs-list-item css-1jvmp7m-STYLES_LIST_ITEM-STYLE_PROP_LIST-PROP_LIST_ELEMENT_STYLE-LI"
         >
           <h4
-            class="css-1j2s5xo-h4-h4-STYLES_H4"
+            class="  css-1j2s5xo-h4-h4-STYLES_H4"
+            data-components-heading="true"
             data-heading="true"
           >
-            style
+            <div
+              class="css-1rh3o5q-STYLES_PERMALINK"
+            >
+              <span
+                class="css-zonpcr-STYLES_PERMALINK_TARGET"
+                id="style"
+              />
+              <a
+                class="css-15lh5hg-STYLES_PERMALINK_LINK"
+                href="#style"
+              >
+                <span
+                  class="css-1icvi79-STYLED_PERMALINK_CONTENT"
+                >
+                  style
+                </span>
+                <span
+                  class="css-10vdcw8-STYLES_PERMALINK_ICON"
+                >
+                  <svg
+                    aria-label="permalink"
+                    class="anchor-icon"
+                    fill="none"
+                    height="24"
+                    viewBox="0 0 24 24"
+                    width="24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                      stroke="#9B9B9B"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                    />
+                    <path
+                      d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                      stroke="#9B9B9B"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                    />
+                  </svg>
+                </span>
+              </a>
+            </div>
           </h4>
           <p
             class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
@@ -479,7 +672,7 @@ for more details.
             </span>
              
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               StyleProp
               &lt;
@@ -521,28 +714,77 @@ for more details.
           >
             The custom style to apply to the button. Should not include 
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               backgroundColor
             </code>
              or 
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               borderRadius
             </code>
             
 properties.
           </p>
+          <hr
+            class="css-bxzs19-STYLES_DIVIDER"
+          />
         </li>
         <li
-          class="docs-list-item css-aulog8-STYLES_LIST_ITEM-LI"
+          class="docs-list-item css-1jvmp7m-STYLES_LIST_ITEM-STYLE_PROP_LIST-PROP_LIST_ELEMENT_STYLE-LI"
         >
           <h4
-            class="css-1j2s5xo-h4-h4-STYLES_H4"
+            class="  css-1j2s5xo-h4-h4-STYLES_H4"
+            data-components-heading="true"
             data-heading="true"
           >
-            onPress
+            <div
+              class="css-1rh3o5q-STYLES_PERMALINK"
+            >
+              <span
+                class="css-zonpcr-STYLES_PERMALINK_TARGET"
+                id="onpress"
+              />
+              <a
+                class="css-15lh5hg-STYLES_PERMALINK_LINK"
+                href="#onpress"
+              >
+                <span
+                  class="css-1icvi79-STYLED_PERMALINK_CONTENT"
+                >
+                  onPress
+                </span>
+                <span
+                  class="css-10vdcw8-STYLES_PERMALINK_ICON"
+                >
+                  <svg
+                    aria-label="permalink"
+                    class="anchor-icon"
+                    fill="none"
+                    height="24"
+                    viewBox="0 0 24 24"
+                    width="24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                      stroke="#9B9B9B"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                    />
+                    <path
+                      d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                      stroke="#9B9B9B"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                    />
+                  </svg>
+                </span>
+              </a>
+            </div>
           </h4>
           <p
             class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
@@ -555,7 +797,7 @@ properties.
             </span>
              
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               (
               
@@ -573,7 +815,7 @@ properties.
               href="/#isavailableasync"
             >
               <code
-                class="inline css-nuv12a-STYLES_INLINE_CODE"
+                class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
               >
                 AppleAuthentication.signInAsync
               </code>
@@ -581,23 +823,72 @@ properties.
             
 in here.
           </p>
+          <hr
+            class="css-bxzs19-STYLES_DIVIDER"
+          />
         </li>
       </ul>
       <h4
-        class="css-1j2s5xo-h4-h4-STYLES_H4"
+        class="  css-1j2s5xo-h4-h4-STYLES_H4"
+        data-components-heading="true"
         data-heading="true"
       >
-        Inherited Props
+        <div
+          class="css-1rh3o5q-STYLES_PERMALINK"
+        >
+          <span
+            class="css-zonpcr-STYLES_PERMALINK_TARGET"
+            id="inherited-props"
+          />
+          <a
+            class="css-15lh5hg-STYLES_PERMALINK_LINK"
+            href="#inherited-props"
+          >
+            <span
+              class="css-1icvi79-STYLED_PERMALINK_CONTENT"
+            >
+              Inherited Props
+            </span>
+            <span
+              class="css-10vdcw8-STYLES_PERMALINK_ICON"
+            >
+              <svg
+                aria-label="permalink"
+                class="anchor-icon"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
+        </div>
       </h4>
       <ul
         class="css-1a9yu92-paragraph-STYLES_UNORDERED_LIST-UL"
         data-text="true"
       >
         <li
-          class="docs-list-item css-aulog8-STYLES_LIST_ITEM-LI"
+          class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
         >
           <code
-            class="inline css-nuv12a-STYLES_INLINE_CODE"
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
           >
             <a
               class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -681,7 +972,7 @@ in here.
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               getCredentialStateAsync(user)
             </code>
@@ -774,7 +1065,7 @@ in here.
       data-text="true"
     >
       <li
-        class="docs-list-item css-aulog8-STYLES_LIST_ITEM-LI"
+        class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
       >
         <strong
           class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -782,7 +1073,7 @@ in here.
           user
            (
           <code
-            class="inline css-nuv12a-STYLES_INLINE_CODE"
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
           >
             string
           </code>
@@ -797,7 +1088,7 @@ This should come from the user field of an
             href="/#appleauthenticationcredentialstate"
           >
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               AppleAuthenticationCredential
             </code>
@@ -908,10 +1199,10 @@ This should come from the user field of an
         data-text="true"
       >
         <li
-          class="docs-list-item css-npeppb-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+          class="docs-list-item css-1t0kz9z-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
         >
           <code
-            class="inline css-nuv12a-STYLES_INLINE_CODE"
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
           >
             <a
               class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -943,7 +1234,7 @@ This should come from the user field of an
           href="/#appleauthenticationcredentialstate"
         >
           <code
-            class="inline css-nuv12a-STYLES_INLINE_CODE"
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
           >
             AppleAuthenticationCredentialState
           </code>
@@ -974,7 +1265,7 @@ value depending on the state of the credential.
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               isAvailableAsync()
             </code>
@@ -1074,10 +1365,10 @@ value depending on the state of the credential.
         data-text="true"
       >
         <li
-          class="docs-list-item css-npeppb-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+          class="docs-list-item css-1t0kz9z-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
         >
           <code
-            class="inline css-nuv12a-STYLES_INLINE_CODE"
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
           >
             <a
               class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -1100,13 +1391,13 @@ value depending on the state of the credential.
       >
         A promise that fulfills with 
         <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
         >
           true
         </code>
          if the system supports Apple authentication, and 
         <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
         >
           false
         </code>
@@ -1135,7 +1426,7 @@ value depending on the state of the credential.
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               refreshAsync(options)
             </code>
@@ -1228,7 +1519,7 @@ value depending on the state of the credential.
       data-text="true"
     >
       <li
-        class="docs-list-item css-aulog8-STYLES_LIST_ITEM-LI"
+        class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
       >
         <strong
           class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -1236,7 +1527,7 @@ value depending on the state of the credential.
           options
            (
           <code
-            class="inline css-nuv12a-STYLES_INLINE_CODE"
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
           >
             <a
               class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -1255,7 +1546,7 @@ value depending on the state of the credential.
             href="/#appleauthenticationrefreshoptions"
           >
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               AppleAuthenticationRefreshOptions
             </code>
@@ -1329,10 +1620,10 @@ Calling this method will show the sign in modal before actually refreshing the u
         data-text="true"
       >
         <li
-          class="docs-list-item css-npeppb-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+          class="docs-list-item css-1t0kz9z-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
         >
           <code
-            class="inline css-nuv12a-STYLES_INLINE_CODE"
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
           >
             <a
               class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -1364,7 +1655,7 @@ Calling this method will show the sign in modal before actually refreshing the u
           href="/#appleauthenticationcredential"
         >
           <code
-            class="inline css-nuv12a-STYLES_INLINE_CODE"
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
           >
             AppleAuthenticationCredential
           </code>
@@ -1372,7 +1663,7 @@ Calling this method will show the sign in modal before actually refreshing the u
         
 object after a successful authentication, and rejects with 
         <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
         >
           ERR_CANCELED
         </code>
@@ -1402,7 +1693,7 @@ refresh operation.
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               signInAsync(options)
             </code>
@@ -1495,7 +1786,7 @@ refresh operation.
       data-text="true"
     >
       <li
-        class="docs-list-item css-aulog8-STYLES_LIST_ITEM-LI"
+        class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
       >
         <strong
           class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -1504,7 +1795,7 @@ refresh operation.
           ?
            (
           <code
-            class="inline css-nuv12a-STYLES_INLINE_CODE"
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
           >
             <a
               class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -1523,7 +1814,7 @@ refresh operation.
             href="/#appleauthenticationsigninoptions"
           >
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               AppleAuthenticationSignInOptions
             </code>
@@ -1569,7 +1860,7 @@ You can use
         href="/#appleauthenticationcredential"
       >
         <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
         >
           AppleAuthenticationCredential.user
         </code>
@@ -1635,10 +1926,10 @@ the user, since this remains the same for apps released by the same developer.
         data-text="true"
       >
         <li
-          class="docs-list-item css-npeppb-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+          class="docs-list-item css-1t0kz9z-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
         >
           <code
-            class="inline css-nuv12a-STYLES_INLINE_CODE"
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
           >
             <a
               class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -1670,7 +1961,7 @@ the user, since this remains the same for apps released by the same developer.
           href="/#appleauthenticationcredential"
         >
           <code
-            class="inline css-nuv12a-STYLES_INLINE_CODE"
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
           >
             AppleAuthenticationCredential
           </code>
@@ -1678,7 +1969,7 @@ the user, since this remains the same for apps released by the same developer.
         
 object after a successful authentication, and rejects with 
         <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
         >
           ERR_CANCELED
         </code>
@@ -1708,7 +1999,7 @@ sign-in operation.
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               signOutAsync(options)
             </code>
@@ -1801,7 +2092,7 @@ sign-in operation.
       data-text="true"
     >
       <li
-        class="docs-list-item css-aulog8-STYLES_LIST_ITEM-LI"
+        class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
       >
         <strong
           class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -1809,7 +2100,7 @@ sign-in operation.
           options
            (
           <code
-            class="inline css-nuv12a-STYLES_INLINE_CODE"
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
           >
             <a
               class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -1828,7 +2119,7 @@ sign-in operation.
             href="/#appleauthenticationsignoutoptions"
           >
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               AppleAuthenticationSignOutOptions
             </code>
@@ -1856,7 +2147,7 @@ from using
         href="/#signinasync"
       >
         <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
         >
           signInAsync
         </code>
@@ -1867,7 +2158,7 @@ from using
         href="/#refreshasync"
       >
         <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
         >
           refreshAsync
         </code>
@@ -1932,10 +2223,10 @@ from using
         data-text="true"
       >
         <li
-          class="docs-list-item css-npeppb-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+          class="docs-list-item css-1t0kz9z-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
         >
           <code
-            class="inline css-nuv12a-STYLES_INLINE_CODE"
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
           >
             <a
               class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -1967,7 +2258,7 @@ from using
           href="/#appleauthenticationcredential"
         >
           <code
-            class="inline css-nuv12a-STYLES_INLINE_CODE"
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
           >
             AppleAuthenticationCredential
           </code>
@@ -1975,7 +2266,7 @@ from using
         
 object after a successful authentication, and rejects with 
         <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
         >
           ERR_CANCELED
         </code>
@@ -2055,7 +2346,7 @@ sign-out operation.
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               addRevokeListener(listener)
             </code>
@@ -2148,7 +2439,7 @@ sign-out operation.
       data-text="true"
     >
       <li
-        class="docs-list-item css-aulog8-STYLES_LIST_ITEM-LI"
+        class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
       >
         <strong
           class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -2156,7 +2447,7 @@ sign-out operation.
           listener
            (
           <code
-            class="inline css-nuv12a-STYLES_INLINE_CODE"
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
           >
             () =&gt;
              
@@ -2224,10 +2515,10 @@ sign-out operation.
         data-text="true"
       >
         <li
-          class="docs-list-item css-npeppb-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+          class="docs-list-item css-1t0kz9z-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
         >
           <code
-            class="inline css-nuv12a-STYLES_INLINE_CODE"
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
           >
             <a
               class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -2311,7 +2602,7 @@ sign-out operation.
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               AppleAuthenticationCredential
               
@@ -2358,7 +2649,7 @@ sign-out operation.
         href="/#appleauthenticationsigninasyncoptions"
       >
         <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
         >
           AppleAuthentication.signInAsync()
         </code>
@@ -2370,7 +2661,7 @@ sign-out operation.
         href="/#appleauthenticationrefreshasyncoptions"
       >
         <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
         >
           AppleAuthentication.refreshAsync()
         </code>
@@ -2381,7 +2672,7 @@ sign-out operation.
         href="/#appleauthenticationsignoutasyncoptions"
       >
         <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
         >
           AppleAuthentication.signOutAsync()
         </code>
@@ -2457,7 +2748,7 @@ for more details.
           </td>
           <td>
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               <span>
                 string
@@ -2473,7 +2764,7 @@ for more details.
               A short-lived session token used by your app for proof of authorization when interacting with
 the app's server counterpart. Unlike 
               <code
-                class="inline css-nuv12a-STYLES_INLINE_CODE"
+                class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
               >
                 user
               </code>
@@ -2491,7 +2782,7 @@ the app's server counterpart. Unlike
           </td>
           <td>
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               <span>
                 string
@@ -2506,7 +2797,7 @@ the app's server counterpart. Unlike
             <span>
               The user's email address. Might not be present if you didn't request the 
               <code
-                class="inline css-nuv12a-STYLES_INLINE_CODE"
+                class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
               >
                 EMAIL
               </code>
@@ -2527,7 +2818,7 @@ an Apple domain.
           </td>
           <td>
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               <span>
                 <a
@@ -2547,19 +2838,19 @@ an Apple domain.
             <span>
               The user's name. May be 
               <code
-                class="inline css-nuv12a-STYLES_INLINE_CODE"
+                class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
               >
                 null
               </code>
                or contain 
               <code
-                class="inline css-nuv12a-STYLES_INLINE_CODE"
+                class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
               >
                 null
               </code>
                values if you didn't request the 
               <code
-                class="inline css-nuv12a-STYLES_INLINE_CODE"
+                class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
               >
                 FULL_NAME
               </code>
@@ -2579,7 +2870,7 @@ your app.
           </td>
           <td>
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               <span>
                 string
@@ -2606,7 +2897,7 @@ your app.
           </td>
           <td>
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               <a
                 class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -2632,7 +2923,7 @@ your app.
           </td>
           <td>
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               <span>
                 string
@@ -2647,7 +2938,7 @@ your app.
             <span>
               An arbitrary string that your app provided as 
               <code
-                class="inline css-nuv12a-STYLES_INLINE_CODE"
+                class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
               >
                 state
               </code>
@@ -2655,14 +2946,14 @@ your app.
 credential. Used to verify that the response was from the request you made. Can be used to
 avoid replay attacks. If you did not provide 
               <code
-                class="inline css-nuv12a-STYLES_INLINE_CODE"
+                class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
               >
                 state
               </code>
                when making the sign-in request, this field
 will be 
               <code
-                class="inline css-nuv12a-STYLES_INLINE_CODE"
+                class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
               >
                 null
               </code>
@@ -2680,7 +2971,7 @@ will be
           </td>
           <td>
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               string
             </code>
@@ -2717,7 +3008,7 @@ developers.
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               AppleAuthenticationFullName
               
@@ -2761,7 +3052,7 @@ developers.
       An object representing the tokenized portions of the user's full name. Any of all of the fields
 may be 
       <code
-        class="inline css-nuv12a-STYLES_INLINE_CODE"
+        class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
       >
         null
       </code>
@@ -2792,7 +3083,7 @@ may be
           </td>
           <td>
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               <span>
                 string
@@ -2817,7 +3108,7 @@ may be
           </td>
           <td>
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               <span>
                 string
@@ -2842,7 +3133,7 @@ may be
           </td>
           <td>
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               <span>
                 string
@@ -2867,7 +3158,7 @@ may be
           </td>
           <td>
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               <span>
                 string
@@ -2892,7 +3183,7 @@ may be
           </td>
           <td>
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               <span>
                 string
@@ -2917,7 +3208,7 @@ may be
           </td>
           <td>
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               <span>
                 string
@@ -2955,7 +3246,7 @@ may be
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               AppleAuthenticationRefreshOptions
               
@@ -3002,7 +3293,7 @@ may be
         href="/#appleauthenticationrefreshasyncoptions"
       >
         <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
         >
           AppleAuthentication.refreshAsync()
         </code>
@@ -3084,7 +3375,7 @@ for more details.
           </td>
           <td>
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               <a
                 class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -3101,7 +3392,7 @@ for more details.
 choose to deny your app access to any scope at the time of logging in. You will still need to
 handle 
               <code
-                class="inline css-nuv12a-STYLES_INLINE_CODE"
+                class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
               >
                 null
               </code>
@@ -3109,13 +3400,13 @@ handle
 will only be provided to you the first time each user signs into your app; in subsequent
 requests they will be 
               <code
-                class="inline css-nuv12a-STYLES_INLINE_CODE"
+                class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
               >
                 null
               </code>
               . Defaults to 
               <code
-                class="inline css-nuv12a-STYLES_INLINE_CODE"
+                class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
               >
                 []
               </code>
@@ -3139,7 +3430,7 @@ requests they will be
           </td>
           <td>
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               string
             </code>
@@ -3171,7 +3462,7 @@ OAuth 2.0 protocol
           </td>
           <td>
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               string
             </code>
@@ -3203,7 +3494,7 @@ OAuth 2.0 protocol
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               AppleAuthenticationSignInOptions
               
@@ -3250,7 +3541,7 @@ OAuth 2.0 protocol
         href="/#appleauthenticationsigninasyncoptions"
       >
         <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
         >
           AppleAuthentication.signInAsync()
         </code>
@@ -3332,7 +3623,7 @@ for more details.
           </td>
           <td>
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               string
             </code>
@@ -3368,7 +3659,7 @@ for more details.
           </td>
           <td>
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               <a
                 class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -3385,7 +3676,7 @@ for more details.
 choose to deny your app access to any scope at the time of logging in. You will still need to
 handle 
               <code
-                class="inline css-nuv12a-STYLES_INLINE_CODE"
+                class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
               >
                 null
               </code>
@@ -3393,13 +3684,13 @@ handle
 will only be provided to you the first time each user signs into your app; in subsequent
 requests they will be 
               <code
-                class="inline css-nuv12a-STYLES_INLINE_CODE"
+                class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
               >
                 null
               </code>
               . Defaults to 
               <code
-                class="inline css-nuv12a-STYLES_INLINE_CODE"
+                class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
               >
                 []
               </code>
@@ -3423,7 +3714,7 @@ requests they will be
           </td>
           <td>
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               string
             </code>
@@ -3468,7 +3759,7 @@ OAuth 2.0 protocol
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               AppleAuthenticationSignOutOptions
               
@@ -3515,7 +3806,7 @@ OAuth 2.0 protocol
         href="/#appleauthenticationsignoutasyncoptions"
       >
         <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
         >
           AppleAuthentication.signOutAsync()
         </code>
@@ -3597,7 +3888,7 @@ for more details.
           </td>
           <td>
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               string
             </code>
@@ -3629,7 +3920,7 @@ OAuth 2.0 protocol
           </td>
           <td>
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               string
             </code>
@@ -3661,7 +3952,7 @@ OAuth 2.0 protocol
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               Subscription
               
@@ -3723,7 +4014,7 @@ OAuth 2.0 protocol
           </td>
           <td>
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               (
               
@@ -3811,7 +4102,7 @@ OAuth 2.0 protocol
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               AppleAuthenticationButtonStyle
             </code>
@@ -3857,7 +4148,7 @@ OAuth 2.0 protocol
         href="/#appleauthenticationappleauthenticationbutton"
       >
         <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
         >
           AppleAuthenticationButton
         </code>
@@ -3869,67 +4160,85 @@ OAuth 2.0 protocol
       data-text="true"
     >
       <li
-        class="docs-list-item css-aulog8-STYLES_LIST_ITEM-LI"
+        class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
       >
-        <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+        <span
+          class="css-1aaoyoh-renderEnum"
         >
-          AppleAuthenticationButtonStyle
-          .
-          WHITE
-        </code>
-         : 
-        <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
-        >
-          0
-        </code>
+          <code
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          >
+            WHITE
+          </code>
+        </span>
          - 
         <span>
           White button with black text.
         </span>
-      </li>
-      <li
-        class="docs-list-item css-aulog8-STYLES_LIST_ITEM-LI"
-      >
+        <br />
         <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+          class="inline css-3rca64-STYLES_INLINE_CODE-renderEnum-InlineCode"
         >
           AppleAuthenticationButtonStyle
           .
-          WHITE_OUTLINE
+          WHITE
+           ＝ 
+          0
         </code>
-         : 
-        <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+      </li>
+      <li
+        class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
+      >
+        <span
+          class="css-1aaoyoh-renderEnum"
         >
-          1
-        </code>
+          <code
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          >
+            WHITE_OUTLINE
+          </code>
+        </span>
          - 
         <span>
           White button with a black outline and black text.
         </span>
-      </li>
-      <li
-        class="docs-list-item css-aulog8-STYLES_LIST_ITEM-LI"
-      >
+        <br />
         <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+          class="inline css-3rca64-STYLES_INLINE_CODE-renderEnum-InlineCode"
         >
           AppleAuthenticationButtonStyle
           .
-          BLACK
+          WHITE_OUTLINE
+           ＝ 
+          1
         </code>
-         : 
-        <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+      </li>
+      <li
+        class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
+      >
+        <span
+          class="css-1aaoyoh-renderEnum"
         >
-          2
-        </code>
+          <code
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          >
+            BLACK
+          </code>
+        </span>
          - 
         <span>
           Black button with white text.
         </span>
+        <br />
+        <code
+          class="inline css-3rca64-STYLES_INLINE_CODE-renderEnum-InlineCode"
+        >
+          AppleAuthenticationButtonStyle
+          .
+          BLACK
+           ＝ 
+          2
+        </code>
       </li>
     </ul>
   </div>
@@ -3953,7 +4262,7 @@ OAuth 2.0 protocol
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               AppleAuthenticationButtonType
             </code>
@@ -3999,7 +4308,7 @@ OAuth 2.0 protocol
         href="/#appleauthenticationappleauthenticationbutton"
       >
         <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
         >
           AppleAuthenticationButton
         </code>
@@ -4011,63 +4320,71 @@ OAuth 2.0 protocol
       data-text="true"
     >
       <li
-        class="docs-list-item css-aulog8-STYLES_LIST_ITEM-LI"
+        class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
       >
-        <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+        <span
+          class="css-1aaoyoh-renderEnum"
         >
-          AppleAuthenticationButtonType
-          .
-          SIGN_IN
-        </code>
-         : 
-        <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
-        >
-          0
-        </code>
+          <code
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          >
+            SIGN_IN
+          </code>
+        </span>
          - 
         <span>
           "Sign in with Apple"
         </span>
-      </li>
-      <li
-        class="docs-list-item css-aulog8-STYLES_LIST_ITEM-LI"
-      >
+        <br />
         <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+          class="inline css-3rca64-STYLES_INLINE_CODE-renderEnum-InlineCode"
         >
           AppleAuthenticationButtonType
           .
-          CONTINUE
+          SIGN_IN
+           ＝ 
+          0
         </code>
-         : 
-        <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+      </li>
+      <li
+        class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
+      >
+        <span
+          class="css-1aaoyoh-renderEnum"
         >
-          1
-        </code>
+          <code
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          >
+            CONTINUE
+          </code>
+        </span>
          - 
         <span>
           "Continue with Apple"
         </span>
-      </li>
-      <li
-        class="docs-list-item css-aulog8-STYLES_LIST_ITEM-LI"
-      >
+        <br />
         <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+          class="inline css-3rca64-STYLES_INLINE_CODE-renderEnum-InlineCode"
         >
           AppleAuthenticationButtonType
           .
-          SIGN_UP
+          CONTINUE
+           ＝ 
+          1
         </code>
-         : 
-        <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+      </li>
+      <li
+        class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
+      >
+        <span
+          class="css-1aaoyoh-renderEnum"
         >
-          2
-        </code>
+          <code
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          >
+            SIGN_UP
+          </code>
+        </span>
          - 
         <span>
           "Sign up with Apple" 
@@ -4075,6 +4392,16 @@ OAuth 2.0 protocol
             (requires iOS 13.2 or higher)
           </em>
         </span>
+        <br />
+        <code
+          class="inline css-3rca64-STYLES_INLINE_CODE-renderEnum-InlineCode"
+        >
+          AppleAuthenticationButtonType
+          .
+          SIGN_UP
+           ＝ 
+          2
+        </code>
       </li>
     </ul>
   </div>
@@ -4098,7 +4425,7 @@ OAuth 2.0 protocol
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               AppleAuthenticationCredentialState
             </code>
@@ -4144,7 +4471,7 @@ OAuth 2.0 protocol
         href="/#appleauthenticationgetcredentialstateasyncuser"
       >
         <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
         >
           AppleAuthentication.getCredentialStateAsync()
         </code>
@@ -4199,70 +4526,94 @@ for more details.
       data-text="true"
     >
       <li
-        class="docs-list-item css-aulog8-STYLES_LIST_ITEM-LI"
+        class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
       >
+        <span
+          class="css-1aaoyoh-renderEnum"
+        >
+          <code
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          >
+            REVOKED
+          </code>
+        </span>
+        <br />
         <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+          class="inline css-3rca64-STYLES_INLINE_CODE-renderEnum-InlineCode"
         >
           AppleAuthenticationCredentialState
           .
           REVOKED
-        </code>
-         : 
-        <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
-        >
+           ＝ 
           0
         </code>
       </li>
       <li
-        class="docs-list-item css-aulog8-STYLES_LIST_ITEM-LI"
+        class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
       >
+        <span
+          class="css-1aaoyoh-renderEnum"
+        >
+          <code
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          >
+            AUTHORIZED
+          </code>
+        </span>
+        <br />
         <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+          class="inline css-3rca64-STYLES_INLINE_CODE-renderEnum-InlineCode"
         >
           AppleAuthenticationCredentialState
           .
           AUTHORIZED
-        </code>
-         : 
-        <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
-        >
+           ＝ 
           1
         </code>
       </li>
       <li
-        class="docs-list-item css-aulog8-STYLES_LIST_ITEM-LI"
+        class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
       >
+        <span
+          class="css-1aaoyoh-renderEnum"
+        >
+          <code
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          >
+            NOT_FOUND
+          </code>
+        </span>
+        <br />
         <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+          class="inline css-3rca64-STYLES_INLINE_CODE-renderEnum-InlineCode"
         >
           AppleAuthenticationCredentialState
           .
           NOT_FOUND
-        </code>
-         : 
-        <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
-        >
+           ＝ 
           2
         </code>
       </li>
       <li
-        class="docs-list-item css-aulog8-STYLES_LIST_ITEM-LI"
+        class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
       >
+        <span
+          class="css-1aaoyoh-renderEnum"
+        >
+          <code
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          >
+            TRANSFERRED
+          </code>
+        </span>
+        <br />
         <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+          class="inline css-3rca64-STYLES_INLINE_CODE-renderEnum-InlineCode"
         >
           AppleAuthenticationCredentialState
           .
           TRANSFERRED
-        </code>
-         : 
-        <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
-        >
+           ＝ 
           3
         </code>
       </li>
@@ -4288,7 +4639,7 @@ for more details.
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               AppleAuthenticationOperation
             </code>
@@ -4329,74 +4680,98 @@ for more details.
       data-text="true"
     >
       <li
-        class="docs-list-item css-aulog8-STYLES_LIST_ITEM-LI"
+        class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
       >
-        <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+        <span
+          class="css-1aaoyoh-renderEnum"
         >
-          AppleAuthenticationOperation
-          .
-          IMPLICIT
-        </code>
-         : 
-        <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
-        >
-          0
-        </code>
+          <code
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          >
+            IMPLICIT
+          </code>
+        </span>
          - 
         <span>
           An operation that depends on the particular kind of credential provider.
         </span>
+        <br />
+        <code
+          class="inline css-3rca64-STYLES_INLINE_CODE-renderEnum-InlineCode"
+        >
+          AppleAuthenticationOperation
+          .
+          IMPLICIT
+           ＝ 
+          0
+        </code>
       </li>
       <li
-        class="docs-list-item css-aulog8-STYLES_LIST_ITEM-LI"
+        class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
       >
+        <span
+          class="css-1aaoyoh-renderEnum"
+        >
+          <code
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          >
+            LOGIN
+          </code>
+        </span>
+        <br />
         <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+          class="inline css-3rca64-STYLES_INLINE_CODE-renderEnum-InlineCode"
         >
           AppleAuthenticationOperation
           .
           LOGIN
-        </code>
-         : 
-        <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
-        >
+           ＝ 
           1
         </code>
       </li>
       <li
-        class="docs-list-item css-aulog8-STYLES_LIST_ITEM-LI"
+        class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
       >
+        <span
+          class="css-1aaoyoh-renderEnum"
+        >
+          <code
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          >
+            REFRESH
+          </code>
+        </span>
+        <br />
         <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+          class="inline css-3rca64-STYLES_INLINE_CODE-renderEnum-InlineCode"
         >
           AppleAuthenticationOperation
           .
           REFRESH
-        </code>
-         : 
-        <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
-        >
+           ＝ 
           2
         </code>
       </li>
       <li
-        class="docs-list-item css-aulog8-STYLES_LIST_ITEM-LI"
+        class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
       >
+        <span
+          class="css-1aaoyoh-renderEnum"
+        >
+          <code
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          >
+            LOGOUT
+          </code>
+        </span>
+        <br />
         <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+          class="inline css-3rca64-STYLES_INLINE_CODE-renderEnum-InlineCode"
         >
           AppleAuthenticationOperation
           .
           LOGOUT
-        </code>
-         : 
-        <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
-        >
+           ＝ 
           3
         </code>
       </li>
@@ -4422,7 +4797,7 @@ for more details.
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               AppleAuthenticationScope
             </code>
@@ -4468,7 +4843,7 @@ for more details.
         href="/#appleauthenticationsigninasyncoptions"
       >
         <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
         >
           AppleAuthentication.signInAsync()
         </code>
@@ -4555,36 +4930,48 @@ for more details.
       data-text="true"
     >
       <li
-        class="docs-list-item css-aulog8-STYLES_LIST_ITEM-LI"
+        class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
       >
+        <span
+          class="css-1aaoyoh-renderEnum"
+        >
+          <code
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          >
+            FULL_NAME
+          </code>
+        </span>
+        <br />
         <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+          class="inline css-3rca64-STYLES_INLINE_CODE-renderEnum-InlineCode"
         >
           AppleAuthenticationScope
           .
           FULL_NAME
-        </code>
-         : 
-        <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
-        >
+           ＝ 
           0
         </code>
       </li>
       <li
-        class="docs-list-item css-aulog8-STYLES_LIST_ITEM-LI"
+        class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
       >
+        <span
+          class="css-1aaoyoh-renderEnum"
+        >
+          <code
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          >
+            EMAIL
+          </code>
+        </span>
+        <br />
         <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+          class="inline css-3rca64-STYLES_INLINE_CODE-renderEnum-InlineCode"
         >
           AppleAuthenticationScope
           .
           EMAIL
-        </code>
-         : 
-        <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
-        >
+           ＝ 
           1
         </code>
       </li>
@@ -4610,7 +4997,7 @@ for more details.
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               AppleAuthenticationUserDetectionStatus
             </code>
@@ -4700,67 +5087,85 @@ for more details.
       data-text="true"
     >
       <li
-        class="docs-list-item css-aulog8-STYLES_LIST_ITEM-LI"
+        class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
       >
-        <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+        <span
+          class="css-1aaoyoh-renderEnum"
         >
-          AppleAuthenticationUserDetectionStatus
-          .
-          UNSUPPORTED
-        </code>
-         : 
-        <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
-        >
-          0
-        </code>
+          <code
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          >
+            UNSUPPORTED
+          </code>
+        </span>
          - 
         <span>
           The system does not support this determination and there is no data.
         </span>
-      </li>
-      <li
-        class="docs-list-item css-aulog8-STYLES_LIST_ITEM-LI"
-      >
+        <br />
         <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+          class="inline css-3rca64-STYLES_INLINE_CODE-renderEnum-InlineCode"
         >
           AppleAuthenticationUserDetectionStatus
           .
-          UNKNOWN
+          UNSUPPORTED
+           ＝ 
+          0
         </code>
-         : 
-        <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+      </li>
+      <li
+        class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
+      >
+        <span
+          class="css-1aaoyoh-renderEnum"
         >
-          1
-        </code>
+          <code
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          >
+            UNKNOWN
+          </code>
+        </span>
          - 
         <span>
           The system has not determined whether the user might be a real person.
         </span>
-      </li>
-      <li
-        class="docs-list-item css-aulog8-STYLES_LIST_ITEM-LI"
-      >
+        <br />
         <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+          class="inline css-3rca64-STYLES_INLINE_CODE-renderEnum-InlineCode"
         >
           AppleAuthenticationUserDetectionStatus
           .
-          LIKELY_REAL
+          UNKNOWN
+           ＝ 
+          1
         </code>
-         : 
-        <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+      </li>
+      <li
+        class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
+      >
+        <span
+          class="css-1aaoyoh-renderEnum"
         >
-          2
-        </code>
+          <code
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          >
+            LIKELY_REAL
+          </code>
+        </span>
          - 
         <span>
           The user appears to be a real person.
         </span>
+        <br />
+        <code
+          class="inline css-3rca64-STYLES_INLINE_CODE-renderEnum-InlineCode"
+        >
+          AppleAuthenticationUserDetectionStatus
+          .
+          LIKELY_REAL
+           ＝ 
+          2
+        </code>
       </li>
     </ul>
   </div>
@@ -4840,7 +5245,7 @@ exports[`APISection expo-barcode-scanner 1`] = `
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               BarCodeScanner
             </code>
@@ -4887,7 +5292,7 @@ exports[`APISection expo-barcode-scanner 1`] = `
       </strong>
        
       <code
-        class="inline css-nuv12a-STYLES_INLINE_CODE"
+        class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
       >
         Component
         &lt;
@@ -4921,7 +5326,7 @@ exports[`APISection expo-barcode-scanner 1`] = `
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               BarCodeScannerProps
             </code>
@@ -4964,13 +5369,59 @@ exports[`APISection expo-barcode-scanner 1`] = `
         data-text="true"
       >
         <li
-          class="docs-list-item css-aulog8-STYLES_LIST_ITEM-LI"
+          class="docs-list-item css-1jvmp7m-STYLES_LIST_ITEM-STYLE_PROP_LIST-PROP_LIST_ELEMENT_STYLE-LI"
         >
           <h4
-            class="css-1j2s5xo-h4-h4-STYLES_H4"
+            class="  css-1j2s5xo-h4-h4-STYLES_H4"
+            data-components-heading="true"
             data-heading="true"
           >
-            barCodeTypes
+            <div
+              class="css-1rh3o5q-STYLES_PERMALINK"
+            >
+              <span
+                class="css-zonpcr-STYLES_PERMALINK_TARGET"
+                id="barcodetypes"
+              />
+              <a
+                class="css-15lh5hg-STYLES_PERMALINK_LINK"
+                href="#barcodetypes"
+              >
+                <span
+                  class="css-1icvi79-STYLED_PERMALINK_CONTENT"
+                >
+                  barCodeTypes
+                </span>
+                <span
+                  class="css-10vdcw8-STYLES_PERMALINK_ICON"
+                >
+                  <svg
+                    aria-label="permalink"
+                    class="anchor-icon"
+                    fill="none"
+                    height="24"
+                    viewBox="0 0 24 24"
+                    width="24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                      stroke="#9B9B9B"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                    />
+                    <path
+                      d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                      stroke="#9B9B9B"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                    />
+                  </svg>
+                </span>
+              </a>
+            </div>
           </h4>
           <p
             class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
@@ -4988,7 +5439,7 @@ exports[`APISection expo-barcode-scanner 1`] = `
             </span>
              
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               string[]
             </code>
@@ -4999,14 +5450,14 @@ exports[`APISection expo-barcode-scanner 1`] = `
           >
             An array of bar code types. Usage: 
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               BarCodeScanner.Constants.BarCodeType.&lt;codeType&gt;
             </code>
              where
 
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               codeType
             </code>
@@ -5027,21 +5478,70 @@ minimize battery usage.
           >
             For example: 
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               barCodeTypes={[BarCodeScanner.Constants.BarCodeType.qr]}
             </code>
             .
           </p>
+          <hr
+            class="css-bxzs19-STYLES_DIVIDER"
+          />
         </li>
         <li
-          class="docs-list-item css-aulog8-STYLES_LIST_ITEM-LI"
+          class="docs-list-item css-1jvmp7m-STYLES_LIST_ITEM-STYLE_PROP_LIST-PROP_LIST_ELEMENT_STYLE-LI"
         >
           <h4
-            class="css-1j2s5xo-h4-h4-STYLES_H4"
+            class="  css-1j2s5xo-h4-h4-STYLES_H4"
+            data-components-heading="true"
             data-heading="true"
           >
-            onBarCodeScanned
+            <div
+              class="css-1rh3o5q-STYLES_PERMALINK"
+            >
+              <span
+                class="css-zonpcr-STYLES_PERMALINK_TARGET"
+                id="onbarcodescanned"
+              />
+              <a
+                class="css-15lh5hg-STYLES_PERMALINK_LINK"
+                href="#onbarcodescanned"
+              >
+                <span
+                  class="css-1icvi79-STYLED_PERMALINK_CONTENT"
+                >
+                  onBarCodeScanned
+                </span>
+                <span
+                  class="css-10vdcw8-STYLES_PERMALINK_ICON"
+                >
+                  <svg
+                    aria-label="permalink"
+                    class="anchor-icon"
+                    fill="none"
+                    height="24"
+                    viewBox="0 0 24 24"
+                    width="24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                      stroke="#9B9B9B"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                    />
+                    <path
+                      d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                      stroke="#9B9B9B"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                    />
+                  </svg>
+                </span>
+              </a>
+            </div>
           </h4>
           <p
             class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
@@ -5059,7 +5559,7 @@ minimize battery usage.
             </span>
              
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               <a
                 class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -5118,13 +5618,13 @@ provided with an
               </strong>
                Passing 
               <code
-                class="inline css-nuv12a-STYLES_INLINE_CODE"
+                class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
               >
                 undefined
               </code>
                to the 
               <code
-                class="inline css-nuv12a-STYLES_INLINE_CODE"
+                class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
               >
                 onBarCodeScanned
               </code>
@@ -5135,15 +5635,64 @@ data has been retrieved.
 
             </div>
           </blockquote>
+          <hr
+            class="css-bxzs19-STYLES_DIVIDER"
+          />
         </li>
         <li
-          class="docs-list-item css-aulog8-STYLES_LIST_ITEM-LI"
+          class="docs-list-item css-1jvmp7m-STYLES_LIST_ITEM-STYLE_PROP_LIST-PROP_LIST_ELEMENT_STYLE-LI"
         >
           <h4
-            class="css-1j2s5xo-h4-h4-STYLES_H4"
+            class="  css-1j2s5xo-h4-h4-STYLES_H4"
+            data-components-heading="true"
             data-heading="true"
           >
-            type
+            <div
+              class="css-1rh3o5q-STYLES_PERMALINK"
+            >
+              <span
+                class="css-zonpcr-STYLES_PERMALINK_TARGET"
+                id="type"
+              />
+              <a
+                class="css-15lh5hg-STYLES_PERMALINK_LINK"
+                href="#type"
+              >
+                <span
+                  class="css-1icvi79-STYLED_PERMALINK_CONTENT"
+                >
+                  type
+                </span>
+                <span
+                  class="css-10vdcw8-STYLES_PERMALINK_ICON"
+                >
+                  <svg
+                    aria-label="permalink"
+                    class="anchor-icon"
+                    fill="none"
+                    height="24"
+                    viewBox="0 0 24 24"
+                    width="24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                      stroke="#9B9B9B"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                    />
+                    <path
+                      d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                      stroke="#9B9B9B"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                    />
+                  </svg>
+                </span>
+              </a>
+            </div>
           </h4>
           <p
             class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
@@ -5161,7 +5710,7 @@ data has been retrieved.
             </span>
              
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               <span>
                 'front'
@@ -5183,7 +5732,7 @@ data has been retrieved.
               </span>
                
               <code
-                class="inline css-nuv12a-STYLES_INLINE_CODE"
+                class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
               >
                 Type.back
 
@@ -5196,48 +5745,97 @@ data has been retrieved.
           >
             Camera facing. Use one of 
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               BarCodeScanner.Constants.Type
             </code>
             . Use either 
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               Type.front
             </code>
              or 
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               Type.back
             </code>
             .
 Same as 
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               Camera.Constants.Type
             </code>
             .
           </p>
+          <hr
+            class="css-bxzs19-STYLES_DIVIDER"
+          />
         </li>
       </ul>
       <h4
-        class="css-1j2s5xo-h4-h4-STYLES_H4"
+        class="  css-1j2s5xo-h4-h4-STYLES_H4"
+        data-components-heading="true"
         data-heading="true"
       >
-        Inherited Props
+        <div
+          class="css-1rh3o5q-STYLES_PERMALINK"
+        >
+          <span
+            class="css-zonpcr-STYLES_PERMALINK_TARGET"
+            id="inherited-props"
+          />
+          <a
+            class="css-15lh5hg-STYLES_PERMALINK_LINK"
+            href="#inherited-props"
+          >
+            <span
+              class="css-1icvi79-STYLED_PERMALINK_CONTENT"
+            >
+              Inherited Props
+            </span>
+            <span
+              class="css-10vdcw8-STYLES_PERMALINK_ICON"
+            >
+              <svg
+                aria-label="permalink"
+                class="anchor-icon"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
+        </div>
       </h4>
       <ul
         class="css-1a9yu92-paragraph-STYLES_UNORDERED_LIST-UL"
         data-text="true"
       >
         <li
-          class="docs-list-item css-aulog8-STYLES_LIST_ITEM-LI"
+          class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
         >
           <code
-            class="inline css-nuv12a-STYLES_INLINE_CODE"
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
           >
             <a
               class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -5321,7 +5919,7 @@ Same as
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               usePermissions
             </code>
@@ -5414,7 +6012,7 @@ Same as
       data-text="true"
     >
       <li
-        class="docs-list-item css-aulog8-STYLES_LIST_ITEM-LI"
+        class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
       >
         <strong
           class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -5423,7 +6021,7 @@ Same as
           ?
            (
           <code
-            class="inline css-nuv12a-STYLES_INLINE_CODE"
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
           >
             <a
               class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -5506,10 +6104,10 @@ This can be used to quickly create specific permission hooks in every module.
         data-text="true"
       >
         <li
-          class="docs-list-item css-npeppb-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+          class="docs-list-item css-1t0kz9z-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
         >
           <code
-            class="inline css-nuv12a-STYLES_INLINE_CODE"
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
           >
             [
             <span>
@@ -5631,7 +6229,7 @@ This can be used to quickly create specific permission hooks in every module.
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               BarCodeScanner.
               getPermissionsAsync()
@@ -5732,10 +6330,10 @@ This can be used to quickly create specific permission hooks in every module.
         data-text="true"
       >
         <li
-          class="docs-list-item css-npeppb-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+          class="docs-list-item css-1t0kz9z-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
         >
           <code
-            class="inline css-nuv12a-STYLES_INLINE_CODE"
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
           >
             <a
               class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -5767,7 +6365,7 @@ This can be used to quickly create specific permission hooks in every module.
           href="/#permissionresponse"
         >
           <code
-            class="inline css-nuv12a-STYLES_INLINE_CODE"
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
           >
             PermissionResponse
           </code>
@@ -5797,7 +6395,7 @@ This can be used to quickly create specific permission hooks in every module.
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               BarCodeScanner.
               requestPermissionsAsync()
@@ -5846,13 +6444,13 @@ This can be used to quickly create specific permission hooks in every module.
     >
       On iOS this will require apps to specify the 
       <code
-        class="inline css-nuv12a-STYLES_INLINE_CODE"
+        class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
       >
         NSCameraUsageDescription
       </code>
        entry in the 
       <code
-        class="inline css-nuv12a-STYLES_INLINE_CODE"
+        class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
       >
         Info.plist
       </code>
@@ -5916,10 +6514,10 @@ This can be used to quickly create specific permission hooks in every module.
         data-text="true"
       >
         <li
-          class="docs-list-item css-npeppb-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+          class="docs-list-item css-1t0kz9z-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
         >
           <code
-            class="inline css-nuv12a-STYLES_INLINE_CODE"
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
           >
             <a
               class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -5951,7 +6549,7 @@ This can be used to quickly create specific permission hooks in every module.
           href="/#permissionresponse"
         >
           <code
-            class="inline css-nuv12a-STYLES_INLINE_CODE"
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
           >
             PermissionResponse
           </code>
@@ -5981,7 +6579,7 @@ This can be used to quickly create specific permission hooks in every module.
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               BarCodeScanner.
               scanFromURLAsync(url, barCodeTypes)
@@ -6075,7 +6673,7 @@ This can be used to quickly create specific permission hooks in every module.
       data-text="true"
     >
       <li
-        class="docs-list-item css-aulog8-STYLES_LIST_ITEM-LI"
+        class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
       >
         <strong
           class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -6083,7 +6681,7 @@ This can be used to quickly create specific permission hooks in every module.
           url
            (
           <code
-            class="inline css-nuv12a-STYLES_INLINE_CODE"
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
           >
             string
           </code>
@@ -6095,7 +6693,7 @@ This can be used to quickly create specific permission hooks in every module.
         </span>
       </li>
       <li
-        class="docs-list-item css-aulog8-STYLES_LIST_ITEM-LI"
+        class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
       >
         <strong
           class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -6103,7 +6701,7 @@ This can be used to quickly create specific permission hooks in every module.
           barCodeTypes
            (
           <code
-            class="inline css-nuv12a-STYLES_INLINE_CODE"
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
           >
             string[]
           </code>
@@ -6218,10 +6816,10 @@ the platform.
         data-text="true"
       >
         <li
-          class="docs-list-item css-npeppb-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+          class="docs-list-item css-1t0kz9z-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
         >
           <code
-            class="inline css-nuv12a-STYLES_INLINE_CODE"
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
           >
             <a
               class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -6250,7 +6848,7 @@ the platform.
       >
         A possibly empty array of objects of the 
         <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
         >
           BarCodeScannerResult
         </code>
@@ -6331,7 +6929,7 @@ code.
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               BarCodeBounds
               
@@ -6393,7 +6991,7 @@ code.
           </td>
           <td>
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               <a
                 class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -6419,7 +7017,7 @@ code.
           </td>
           <td>
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               <a
                 class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -6458,7 +7056,7 @@ code.
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               BarCodeEvent
             </code>
@@ -6499,7 +7097,7 @@ code.
       data-text="true"
     >
       <code
-        class="inline css-nuv12a-STYLES_INLINE_CODE"
+        class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
       >
         <a
           class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -6542,7 +7140,7 @@ code.
           </td>
           <td>
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               number
             </code>
@@ -6574,7 +7172,7 @@ code.
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               BarCodeEventCallbackArguments
               
@@ -6636,7 +7234,7 @@ code.
           </td>
           <td>
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               <a
                 class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -6673,7 +7271,7 @@ code.
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               BarCodePoint
               
@@ -6742,7 +7340,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
           </td>
           <td>
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               number
             </code>
@@ -6751,7 +7349,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
             <span>
               The 
               <code
-                class="inline css-nuv12a-STYLES_INLINE_CODE"
+                class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
               >
                 x
               </code>
@@ -6769,7 +7367,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
           </td>
           <td>
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               number
             </code>
@@ -6778,7 +7376,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
             <span>
               The 
               <code
-                class="inline css-nuv12a-STYLES_INLINE_CODE"
+                class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
               >
                 y
               </code>
@@ -6809,7 +7407,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               BarCodeScannedCallback
               ()
@@ -6904,7 +7502,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
         data-text="true"
       >
         <li
-          class="docs-list-item css-aulog8-STYLES_LIST_ITEM-LI"
+          class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
         >
           <strong
             class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -6912,7 +7510,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
             params
              (
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               <a
                 class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -6947,7 +7545,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               BarCodeScannerResult
               
@@ -7017,25 +7615,25 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
         </strong>
          
         <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
         >
           bounds
         </code>
          and 
         <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
         >
           cornerPoints
         </code>
          are not always available. On iOS, for 
         <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
         >
           code39
         </code>
          and 
         <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
         >
           pdf417
         </code>
@@ -7077,7 +7675,7 @@ For some types, they will represent the area used by the scanner.
           </td>
           <td>
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               <a
                 class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -7116,7 +7714,7 @@ For some types, they will represent the area used by the scanner.
           </td>
           <td>
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               <a
                 class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -7143,7 +7741,7 @@ For some types, they will represent the area used by the scanner.
           </td>
           <td>
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               string
             </code>
@@ -7164,7 +7762,7 @@ For some types, they will represent the area used by the scanner.
           </td>
           <td>
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               string
             </code>
@@ -7198,7 +7796,7 @@ For some types, they will represent the area used by the scanner.
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               BarCodeSize
               
@@ -7260,7 +7858,7 @@ For some types, they will represent the area used by the scanner.
           </td>
           <td>
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               number
             </code>
@@ -7281,7 +7879,7 @@ For some types, they will represent the area used by the scanner.
           </td>
           <td>
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               number
             </code>
@@ -7315,7 +7913,7 @@ For some types, they will represent the area used by the scanner.
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               PermissionHookOptions
             </code>
@@ -7359,7 +7957,7 @@ For some types, they will represent the area used by the scanner.
        
       <span>
         <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
         >
           PermissionHookBehavior
         </code>
@@ -7367,7 +7965,7 @@ For some types, they will represent the area used by the scanner.
       </span>
       <span>
         <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
         >
           Options
         </code>
@@ -7446,7 +8044,7 @@ For some types, they will represent the area used by the scanner.
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               PermissionResponse
             </code>
@@ -7508,7 +8106,7 @@ For some types, they will represent the area used by the scanner.
           </td>
           <td>
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               boolean
             </code>
@@ -7528,7 +8126,7 @@ For some types, they will represent the area used by the scanner.
           </td>
           <td>
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               <a
                 class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -7553,7 +8151,7 @@ For some types, they will represent the area used by the scanner.
           </td>
           <td>
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               boolean
             </code>
@@ -7573,7 +8171,7 @@ For some types, they will represent the area used by the scanner.
           </td>
           <td>
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               <a
                 class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -7661,7 +8259,7 @@ For some types, they will represent the area used by the scanner.
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               PermissionStatus
             </code>
@@ -7702,53 +8300,71 @@ For some types, they will represent the area used by the scanner.
       data-text="true"
     >
       <li
-        class="docs-list-item css-aulog8-STYLES_LIST_ITEM-LI"
+        class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
       >
+        <span
+          class="css-1aaoyoh-renderEnum"
+        >
+          <code
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          >
+            DENIED
+          </code>
+        </span>
+        <br />
         <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+          class="inline css-3rca64-STYLES_INLINE_CODE-renderEnum-InlineCode"
         >
           PermissionStatus
           .
           DENIED
-        </code>
-         : 
-        <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
-        >
+           ＝ 
           "denied"
         </code>
       </li>
       <li
-        class="docs-list-item css-aulog8-STYLES_LIST_ITEM-LI"
+        class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
       >
+        <span
+          class="css-1aaoyoh-renderEnum"
+        >
+          <code
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          >
+            GRANTED
+          </code>
+        </span>
+        <br />
         <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+          class="inline css-3rca64-STYLES_INLINE_CODE-renderEnum-InlineCode"
         >
           PermissionStatus
           .
           GRANTED
-        </code>
-         : 
-        <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
-        >
+           ＝ 
           "granted"
         </code>
       </li>
       <li
-        class="docs-list-item css-aulog8-STYLES_LIST_ITEM-LI"
+        class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
       >
+        <span
+          class="css-1aaoyoh-renderEnum"
+        >
+          <code
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          >
+            UNDETERMINED
+          </code>
+        </span>
+        <br />
         <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+          class="inline css-3rca64-STYLES_INLINE_CODE-renderEnum-InlineCode"
         >
           PermissionStatus
           .
           UNDETERMINED
-        </code>
-         : 
-        <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
-        >
+           ＝ 
           "undetermined"
         </code>
       </li>
@@ -7830,7 +8446,7 @@ exports[`APISection expo-pedometer 1`] = `
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               getPermissionsAsync()
             </code>
@@ -7924,10 +8540,10 @@ exports[`APISection expo-pedometer 1`] = `
         data-text="true"
       >
         <li
-          class="docs-list-item css-npeppb-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+          class="docs-list-item css-1t0kz9z-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
         >
           <code
-            class="inline css-nuv12a-STYLES_INLINE_CODE"
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
           >
             <a
               class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -7972,7 +8588,7 @@ exports[`APISection expo-pedometer 1`] = `
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               getStepCountAsync(start, end)
             </code>
@@ -8065,7 +8681,7 @@ exports[`APISection expo-pedometer 1`] = `
       data-text="true"
     >
       <li
-        class="docs-list-item css-aulog8-STYLES_LIST_ITEM-LI"
+        class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
       >
         <strong
           class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -8073,7 +8689,7 @@ exports[`APISection expo-pedometer 1`] = `
           start
            (
           <code
-            class="inline css-nuv12a-STYLES_INLINE_CODE"
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
           >
             <a
               class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -8091,7 +8707,7 @@ exports[`APISection expo-pedometer 1`] = `
         </span>
       </li>
       <li
-        class="docs-list-item css-aulog8-STYLES_LIST_ITEM-LI"
+        class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
       >
         <strong
           class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -8099,7 +8715,7 @@ exports[`APISection expo-pedometer 1`] = `
           end
            (
           <code
-            class="inline css-nuv12a-STYLES_INLINE_CODE"
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
           >
             <a
               class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -8181,10 +8797,10 @@ exports[`APISection expo-pedometer 1`] = `
         data-text="true"
       >
         <li
-          class="docs-list-item css-npeppb-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+          class="docs-list-item css-1t0kz9z-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
         >
           <code
-            class="inline css-nuv12a-STYLES_INLINE_CODE"
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
           >
             <a
               class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -8216,7 +8832,7 @@ exports[`APISection expo-pedometer 1`] = `
           href="/#pedometerresult"
         >
           <code
-            class="inline css-nuv12a-STYLES_INLINE_CODE"
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
           >
             PedometerResult
           </code>
@@ -8296,7 +8912,7 @@ a start date that is more than seven days in the past returns only the available
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               isAvailableAsync()
             </code>
@@ -8396,10 +9012,10 @@ a start date that is more than seven days in the past returns only the available
         data-text="true"
       >
         <li
-          class="docs-list-item css-npeppb-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+          class="docs-list-item css-1t0kz9z-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
         >
           <code
-            class="inline css-nuv12a-STYLES_INLINE_CODE"
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
           >
             <a
               class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -8422,7 +9038,7 @@ a start date that is more than seven days in the past returns only the available
       >
         Returns a promise that fulfills with a 
         <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
         >
           boolean
         </code>
@@ -8452,7 +9068,7 @@ available on this device.
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               requestPermissionsAsync()
             </code>
@@ -8546,10 +9162,10 @@ available on this device.
         data-text="true"
       >
         <li
-          class="docs-list-item css-npeppb-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+          class="docs-list-item css-1t0kz9z-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
         >
           <code
-            class="inline css-nuv12a-STYLES_INLINE_CODE"
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
           >
             <a
               class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -8594,7 +9210,7 @@ available on this device.
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               watchStepCount(callback)
             </code>
@@ -8687,7 +9303,7 @@ available on this device.
       data-text="true"
     >
       <li
-        class="docs-list-item css-aulog8-STYLES_LIST_ITEM-LI"
+        class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
       >
         <strong
           class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -8695,7 +9311,7 @@ available on this device.
           callback
            (
           <code
-            class="inline css-nuv12a-STYLES_INLINE_CODE"
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
           >
             <a
               class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -8715,7 +9331,7 @@ provided with a single argument that is
             href="/#pedometerresult"
           >
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               PedometerResult
             </code>
@@ -8788,10 +9404,10 @@ provided with a single argument that is
         data-text="true"
       >
         <li
-          class="docs-list-item css-npeppb-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+          class="docs-list-item css-1t0kz9z-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
         >
           <code
-            class="inline css-nuv12a-STYLES_INLINE_CODE"
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
           >
             <a
               class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -8812,7 +9428,7 @@ provided with a single argument that is
           href="/#subscription"
         >
           <code
-            class="inline css-nuv12a-STYLES_INLINE_CODE"
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
           >
             Subscription
           </code>
@@ -8820,7 +9436,7 @@ provided with a single argument that is
          that enables you to call
 
         <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
         >
           remove()
         </code>
@@ -8899,7 +9515,7 @@ provided with a single argument that is
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               PedometerResult
               
@@ -8961,7 +9577,7 @@ provided with a single argument that is
           </td>
           <td>
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               number
             </code>
@@ -8995,7 +9611,7 @@ provided with a single argument that is
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               PedometerUpdateCallback
               ()
@@ -9090,7 +9706,7 @@ provided with a single argument that is
         data-text="true"
       >
         <li
-          class="docs-list-item css-aulog8-STYLES_LIST_ITEM-LI"
+          class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
         >
           <strong
             class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -9098,7 +9714,7 @@ provided with a single argument that is
             result
              (
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               <a
                 class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -9133,7 +9749,7 @@ provided with a single argument that is
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               PermissionExpiration
             </code>
@@ -9177,7 +9793,7 @@ provided with a single argument that is
        
       <span>
         <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
         >
           'never'
         </code>
@@ -9185,7 +9801,7 @@ provided with a single argument that is
       </span>
       <span>
         <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
         >
           number
         </code>
@@ -9213,7 +9829,7 @@ provided with a single argument that is
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               Subscription
               
@@ -9275,7 +9891,7 @@ provided with a single argument that is
           </td>
           <td>
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               () =&gt;
                
@@ -9362,7 +9978,7 @@ provided with a single argument that is
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               PermissionResponse
             </code>
@@ -9424,7 +10040,7 @@ provided with a single argument that is
           </td>
           <td>
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               boolean
             </code>
@@ -9444,7 +10060,7 @@ provided with a single argument that is
           </td>
           <td>
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               <a
                 class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -9469,7 +10085,7 @@ provided with a single argument that is
           </td>
           <td>
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               boolean
             </code>
@@ -9489,7 +10105,7 @@ provided with a single argument that is
           </td>
           <td>
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               <a
                 class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -9577,7 +10193,7 @@ provided with a single argument that is
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               PermissionStatus
             </code>
@@ -9618,53 +10234,71 @@ provided with a single argument that is
       data-text="true"
     >
       <li
-        class="docs-list-item css-aulog8-STYLES_LIST_ITEM-LI"
+        class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
       >
+        <span
+          class="css-1aaoyoh-renderEnum"
+        >
+          <code
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          >
+            DENIED
+          </code>
+        </span>
+        <br />
         <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+          class="inline css-3rca64-STYLES_INLINE_CODE-renderEnum-InlineCode"
         >
           PermissionStatus
           .
           DENIED
-        </code>
-         : 
-        <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
-        >
+           ＝ 
           "denied"
         </code>
       </li>
       <li
-        class="docs-list-item css-aulog8-STYLES_LIST_ITEM-LI"
+        class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
       >
+        <span
+          class="css-1aaoyoh-renderEnum"
+        >
+          <code
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          >
+            GRANTED
+          </code>
+        </span>
+        <br />
         <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+          class="inline css-3rca64-STYLES_INLINE_CODE-renderEnum-InlineCode"
         >
           PermissionStatus
           .
           GRANTED
-        </code>
-         : 
-        <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
-        >
+           ＝ 
           "granted"
         </code>
       </li>
       <li
-        class="docs-list-item css-aulog8-STYLES_LIST_ITEM-LI"
+        class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
       >
+        <span
+          class="css-1aaoyoh-renderEnum"
+        >
+          <code
+            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          >
+            UNDETERMINED
+          </code>
+        </span>
+        <br />
         <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
+          class="inline css-3rca64-STYLES_INLINE_CODE-renderEnum-InlineCode"
         >
           PermissionStatus
           .
           UNDETERMINED
-        </code>
-         : 
-        <code
-          class="inline css-nuv12a-STYLES_INLINE_CODE"
-        >
+           ＝ 
           "undetermined"
         </code>
       </li>

--- a/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                     class="css-1icvi79-STYLED_PERMALINK_CONTENT"
                   >
                     <code
-                      class="inline css-nuv12a-STYLES_INLINE_CODE"
+                      class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
                     >
                       name
                     </code>
@@ -136,7 +136,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                     class="css-1icvi79-STYLED_PERMALINK_CONTENT"
                   >
                     <code
-                      class="inline css-nuv12a-STYLES_INLINE_CODE"
+                      class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
                     >
                       androidNavigationBar
                     </code>
@@ -243,7 +243,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                     class="css-1icvi79-STYLED_PERMALINK_CONTENT"
                   >
                     <code
-                      class="inline css-nuv12a-STYLES_INLINE_CODE"
+                      class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
                     >
                       visible
                     </code>
@@ -336,7 +336,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                     class="css-1icvi79-STYLED_PERMALINK_CONTENT"
                   >
                     <code
-                      class="inline css-nuv12a-STYLES_INLINE_CODE"
+                      class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
                     >
                       always
                     </code>
@@ -415,7 +415,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                     class="css-1icvi79-STYLED_PERMALINK_CONTENT"
                   >
                     <code
-                      class="inline css-nuv12a-STYLES_INLINE_CODE"
+                      class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
                     >
                       backgroundColor
                     </code>
@@ -473,7 +473,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           >
             6 character long hex color string, eg: 
             <code
-              class="inline css-nuv12a-STYLES_INLINE_CODE"
+              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
             >
               '#000000'
             </code>
@@ -505,7 +505,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                     class="css-1icvi79-STYLED_PERMALINK_CONTENT"
                   >
                     <code
-                      class="inline css-nuv12a-STYLES_INLINE_CODE"
+                      class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
                     >
                       intentFilters
                     </code>
@@ -635,7 +635,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                     class="css-1icvi79-STYLED_PERMALINK_CONTENT"
                   >
                     <code
-                      class="inline css-nuv12a-STYLES_INLINE_CODE"
+                      class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
                     >
                       autoVerify
                     </code>
@@ -714,7 +714,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                     class="css-1icvi79-STYLED_PERMALINK_CONTENT"
                   >
                     <code
-                      class="inline css-nuv12a-STYLES_INLINE_CODE"
+                      class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
                     >
                       data
                     </code>
@@ -792,7 +792,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                     class="css-1icvi79-STYLED_PERMALINK_CONTENT"
                   >
                     <code
-                      class="inline css-nuv12a-STYLES_INLINE_CODE"
+                      class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
                     >
                       host
                     </code>

--- a/docs/components/plugins/api/APISectionEnums.tsx
+++ b/docs/components/plugins/api/APISectionEnums.tsx
@@ -1,3 +1,5 @@
+import { css } from '@emotion/react';
+import { theme } from '@expo/styleguide';
 import React from 'react';
 
 import { InlineCode } from '~/components/base/code';
@@ -9,6 +11,8 @@ import { CommentTextBlock, mdInlineComponents } from '~/components/plugins/api/A
 export type APISectionEnumsProps = {
   data: EnumDefinitionData[];
 };
+
+const STYLES_ENUM_VALUE = css({ color: theme.text.secondary, fontSize: '75%' });
 
 const sortByValue = (a: EnumValueData, b: EnumValueData) => {
   if (a.defaultValue && b.defaultValue) {
@@ -30,16 +34,22 @@ const renderEnum = ({ name, children, comment }: EnumDefinitionData): JSX.Elemen
     <UL>
       {children.sort(sortByValue).map((enumValue: EnumValueData) => (
         <LI key={enumValue.name}>
-          <InlineCode>
-            {name}.{enumValue.name}
-          </InlineCode>
+          <span css={{ fontSize: '120%' }}>
+            <InlineCode>{enumValue.name}</InlineCode>
+          </span>
+          {enumValue.comment ? (
+            <CommentTextBlock
+              comment={enumValue.comment}
+              components={mdInlineComponents}
+              withDash
+            />
+          ) : null}
+          <br />
           {enumValue?.defaultValue && (
-            <>
-              {' : '}
-              <InlineCode>{enumValue?.defaultValue}</InlineCode>
-            </>
+            <InlineCode customCss={STYLES_ENUM_VALUE}>
+              {name}.{enumValue.name} ＝ {enumValue?.defaultValue}
+            </InlineCode>
           )}
-          <CommentTextBlock comment={enumValue.comment} components={mdInlineComponents} withDash />
         </LI>
       ))}
     </UL>

--- a/docs/components/plugins/api/APISectionProps.tsx
+++ b/docs/components/plugins/api/APISectionProps.tsx
@@ -2,10 +2,9 @@ import { css } from '@emotion/react';
 import React from 'react';
 
 import { InlineCode } from '~/components/base/code';
-import { H4 } from '~/components/base/headings';
 import { LI, UL } from '~/components/base/list';
 import { P } from '~/components/base/paragraph';
-import { H2, H3, H3Code } from '~/components/plugins/Headings';
+import { H2, H3, H3Code, H4 } from '~/components/plugins/Headings';
 import {
   DefaultPropsDefinitionData,
   PropData,
@@ -30,7 +29,12 @@ export type APISectionPropsProps = {
 const UNKNOWN_VALUE = '...';
 
 const PROP_LIST_ELEMENT_STYLE = css`
-  padding: 0;
+  padding-top: 0.15rem;
+  padding-bottom: 0.15rem;
+`;
+
+const STYLES_DIVIDER = css`
+  margin-bottom: 1rem;
 `;
 
 const extractDefaultPropValue = (
@@ -102,7 +106,7 @@ export const renderProp = (
   defaultValue?: string,
   exposeInSidebar?: boolean
 ) => (
-  <LI key={`prop-entry-${name}`} customCss={exposeInSidebar ? PROP_LIST_ELEMENT_STYLE : undefined}>
+  <LI propType key={`prop-entry-${name}`} customCss={PROP_LIST_ELEMENT_STYLE}>
     {exposeInSidebar ? (
       <H3Code>
         <InlineCode>{name}</InlineCode>
@@ -121,6 +125,7 @@ export const renderProp = (
       ) : null}
     </P>
     <CommentTextBlock comment={getCommentOrSignatureComment(comment, signatures)} />
+    <hr css={STYLES_DIVIDER} />
   </LI>
 );
 

--- a/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
+++ b/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
@@ -38,7 +38,7 @@ exports[`APISectionUtils.CommentTextBlock component comment with example 1`] = `
       rel="noopener noreferrer"
     >
       <code
-        class="inline css-nuv12a-STYLES_INLINE_CODE"
+        class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
       >
         Install Referrer API
       </code>


### PR DESCRIPTION
# Why

While working on latest API conversion I have spotted that Components Props section readability could be improved, so I have started experimenting with different tweaks. 

# How

This PR includes the following changes:
* rearranged Enums section, a bit better layout for mobile, but still I'm considering just using table for those
* updated Props entries styling, bigger and less emphasise list bullet, additional divider, spacing tweaks
* updated Methods return value symbol (use Return Arrow from UTF-8)

I have also fixed the HR tag styling in Doc pages, so far the general style was correct, but when HR was used in document content there were white pixels visible at the ends in dark mode (due to the way the HR is styled by default, by browsers).

Most of the changes here are quite small, but when the refreshed docs design will land, I would like to have a big design pass one every component, there is still a lot of room for the improvements. 😉 

# Test Plan

The changes have been tested by running docs website locally.

The Jest test snapshots have been updated to match the UI changes.

# Preview (before & after)

### Props
<img width="390" alt="Screenshot 2022-01-26 at 13 23 50" align="left" src="https://user-images.githubusercontent.com/719641/151164377-a94b46e4-e082-4aa0-9e76-f5196db09382.png">
<img width="390" alt="Screenshot 2022-01-26 at 13 23 33" src="https://user-images.githubusercontent.com/719641/151164380-c9d0d2c4-1678-4db6-a437-87bdd1d8becd.png">

### Enums
<img width="390" alt="Screenshot 2022-01-26 at 12 55 44" align="left" src="https://user-images.githubusercontent.com/719641/151164134-cde0533f-371e-4ccb-917d-55d9b6b9c798.png">
<img width="390" alt="Screenshot 2022-01-26 at 12 55 13" src="https://user-images.githubusercontent.com/719641/151164143-dcbca2bf-a803-4242-882c-0a62674c97f8.png">

### Methods
<img width="390" alt="Screenshot 2022-01-26 at 12 56 13" align="left" src="https://user-images.githubusercontent.com/719641/151164228-bcf0ec0a-ab4d-466f-a160-f008d37c9d49.png">
<img width="390" alt="Screenshot 2022-01-26 at 12 56 37" src="https://user-images.githubusercontent.com/719641/151164225-33570c78-51fd-40af-87e7-321a772617c3.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
