### PR TITLE
[docs] Embed navigation behavior in navigation nodes

### DIFF
--- a/docs/components/DocumentationSidebar.tsx
+++ b/docs/components/DocumentationSidebar.tsx
@@ -5,7 +5,6 @@ import DocumentationSidebarGroup from '~/components/DocumentationSidebarGroup';
 import DocumentationSidebarLink from '~/components/DocumentationSidebarLink';
 import DocumentationSidebarTitle from '~/components/DocumentationSidebarTitle';
 import VersionSelector from '~/components/VersionSelector';
-import { hiddenSections } from '~/constants/navigation';
 import * as Constants from '~/constants/theme';
 import { NavigationRoute, Url } from '~/types/common';
 
@@ -118,7 +117,7 @@ export default class DocumentationSidebar extends React.Component<Props> {
         )}
 
         {this.props.routes.map(categoryInfo => {
-          if (categoryIsHidden(categoryInfo.name)) {
+          if (categoryInfo.hidden) {
             return null;
           }
           return this.renderCategoryElements(categoryInfo);
@@ -126,8 +125,4 @@ export default class DocumentationSidebar extends React.Component<Props> {
       </nav>
     );
   }
-}
-
-function categoryIsHidden(categoryName: string): boolean {
-  return hiddenSections.includes(categoryName);
 }

--- a/docs/components/DocumentationSidebar.tsx
+++ b/docs/components/DocumentationSidebar.tsx
@@ -22,14 +22,6 @@ const STYLES_SECTION_CATEGORY = css`
   margin-bottom: 24px;
 `;
 
-function shouldSkipCategory(info: NavigationRoute) {
-  if (info.name === 'Feature Preview') {
-    return true;
-  }
-
-  return false;
-}
-
 function shouldSkipTitle(info: NavigationRoute, parentGroup?: NavigationRoute) {
   if (info.name === parentGroup?.name) {
     // If the title of the group is Expo SDK and the section within it has the same name
@@ -75,7 +67,7 @@ export default class DocumentationSidebar extends React.Component<Props> {
   };
 
   private renderCategoryElements = (info: NavigationRoute, parentGroup?: NavigationRoute) => {
-    if (shouldSkipCategory(info)) {
+    if (info.hidden) {
       return null;
     }
 

--- a/docs/components/DocumentationSidebarGroup.tsx
+++ b/docs/components/DocumentationSidebarGroup.tsx
@@ -5,7 +5,6 @@ import * as React from 'react';
 import stripVersionFromPath from '~/common/stripVersionFromPath';
 import { paragraph } from '~/components/base/typography';
 import ChevronDown from '~/components/icons/ChevronDown';
-import { collapsedSections } from '~/constants/navigation';
 import * as Constants from '~/constants/theme';
 import { NavigationRoute, Url } from '~/types/common';
 
@@ -59,7 +58,7 @@ export default class DocumentationSidebarGroup extends React.Component<Props, { 
 
     // default to always open
     this.state = {
-      isOpen: collapsedSections.includes(props.info.name) ? isOpen : true,
+      isOpen: props.info.collapsed ? isOpen : true,
     };
   }
 

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -8,18 +8,6 @@ const { URL } = require('url');
 const { LATEST_VERSION } = require('./versions');
 const PAGES_DIR = path.resolve(__dirname, '../pages');
 
-// TODO(cedric): refactor hidden and collapsed sections into properties of the groups
-
-/** These directories will not be placed in the sidebar, but will still be searchable */
-const hiddenSections = ['FAQ', 'Troubleshooting'];
-/** These sections will NOT be expanded by default in the sidebar */
-const collapsedSections = [
-  'Deprecated',
-  'Regulatory Compliance',
-  'UI Programming',
-  'Technical Specs',
-];
-
 // TODO(cedric): refactor docs to get rid of the directory lists
 
 /** Manual list of directories to pull in to the getting started tutorial */
@@ -220,34 +208,48 @@ const general = [
     makeGroup('Classic Services', sortAlphabetical(pagesFromDir('classic'))),
   ]),
   makeSection('UI Programming', [
-    makeGroup('UI Programming', [
-      makePage('ui-programming/image-background.md'),
-      makePage('ui-programming/implementing-a-checkbox.md'),
-      makePage('ui-programming/z-index.md'),
-      makePage('ui-programming/using-svgs.md'),
-      makePage('ui-programming/react-native-toast.md'),
-      makePage('ui-programming/react-native-styling-buttons.md'),
-    ]),
+    makeGroup(
+      'UI Programming',
+      [
+        makePage('ui-programming/image-background.md'),
+        makePage('ui-programming/implementing-a-checkbox.md'),
+        makePage('ui-programming/z-index.md'),
+        makePage('ui-programming/using-svgs.md'),
+        makePage('ui-programming/react-native-toast.md'),
+        makePage('ui-programming/react-native-styling-buttons.md'),
+      ],
+      { collapsed: true }
+    ),
   ]),
-  makeSection('Regulatory Compliance', [
-    makeGroup('Regulatory Compliance', sortAlphabetical(pagesFromDir('regulatory-compliance'))),
-  ]),
-  makeSection('Technical Specs', [
-    makeGroup('Technical Specs', [
-      makePage('technical-specs/expo-updates-0.md'),
-      makePage('technical-specs/expo-sfv-0.md'),
-    ]),
-  ]),
-  makeSection('Deprecated', [
-    makeGroup('ExpoKit', [
-      makePage('expokit/overview.md'),
-      makePage('expokit/eject.md'),
-      makePage('expokit/expokit.md'),
-      makePage('expokit/advanced-expokit-topics.md'),
-      makePage('expokit/universal-modules-and-expokit.md'),
-    ]),
-    makeGroup('Archived', sortAlphabetical(pagesFromDir('archived'))),
-  ]),
+  makeSection(
+    'Regulatory Compliance',
+    [makeGroup('Regulatory Compliance', sortAlphabetical(pagesFromDir('regulatory-compliance')))],
+    { collapsed: true }
+  ),
+  makeSection(
+    'Technical Specs',
+    [
+      makeGroup('Technical Specs', [
+        makePage('technical-specs/expo-updates-0.md'),
+        makePage('technical-specs/expo-sfv-0.md'),
+      ]),
+    ],
+    { collapsed: true }
+  ),
+  makeSection(
+    'Deprecated',
+    [
+      makeGroup('ExpoKit', [
+        makePage('expokit/overview.md'),
+        makePage('expokit/eject.md'),
+        makePage('expokit/expokit.md'),
+        makePage('expokit/advanced-expokit-topics.md'),
+        makePage('expokit/universal-modules-and-expokit.md'),
+      ]),
+      makeGroup('Archived', sortAlphabetical(pagesFromDir('archived'))),
+    ],
+    { collapsed: true }
+  ),
 ];
 
 const eas = [
@@ -381,21 +383,24 @@ module.exports = {
   previewDirectories,
   easDirectories,
   featurePreviewDirectories,
-  hiddenSections,
-  collapsedSections,
 };
 
 // --- MDX methods ---
 
-function makeSection(name, children = []) {
+/**
+ * @param {string} name
+ * @param {any[]} [children=[]]
+ * @param {Partial<import('~/types/common').NavigationRoute>} [overwrites={}]
+ */
+function makeSection(name, children = [], overwrites = {}) {
   // TODO(cedric): refactor node types to match unist
-  return { name, children };
+  return { name, children, ...overwrites };
 }
 
 /**
- * @param {string} name 
- * @param {any[]} [children=[]] 
- * @param {Partial<import('~/types/common').NavigationRoute>} [overwrites={}] 
+ * @param {string} name
+ * @param {any[]} [children=[]]
+ * @param {Partial<import('~/types/common').NavigationRoute>} [overwrites={}]
  */
 function makeGroup(name, children = [], overwrites = {}) {
   // TODO(cedric): refactor node types to match unist

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 const path = require('path');
 const { URL } = require('url');
 
-const { LATEST_VERSION } = require('./versions');
+const { LATEST_VERSION, VERSIONS } = require('./versions');
 const PAGES_DIR = path.resolve(__dirname, '../pages');
 
 // TODO(cedric): refactor docs to get rid of the directory lists
@@ -34,11 +34,6 @@ const generalDirectories = fs
         ...easDirectories,
       ].includes(name)
   );
-/** All versioned API directories */
-const referenceDirectories = fs
-  .readdirSync(path.resolve(PAGES_DIR, 'versions'), { withFileTypes: true })
-  .filter(entity => entity.isDirectory())
-  .map(dir => dir.name);
 
 // --- Navigation ---
 
@@ -351,7 +346,7 @@ const featurePreview = [
   ]),
 ];
 
-const reference = referenceDirectories.reduce(
+const reference = VERSIONS.reduce(
   (all, version) => ({
     ...all,
     [version]: [

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -313,7 +313,7 @@ const preview = [
 ];
 
 const featurePreview = [
-  makeGroup('Feature Preview', [], './pages/feature-preview/'),
+  makeGroup('Feature Preview', [], { href: './pages/feature-preview/', hidden: true }),
   makeSection('Development Builds', [
     makeGroup('Development Builds', [
       makePage('development/introduction.md'),
@@ -392,9 +392,14 @@ function makeSection(name, children = []) {
   return { name, children };
 }
 
-function makeGroup(name, children = [], href = '') {
+/**
+ * @param {string} name 
+ * @param {any[]} [children=[]] 
+ * @param {Partial<import('~/types/common').NavigationRoute>} [overwrites={}] 
+ */
+function makeGroup(name, children = [], overwrites = {}) {
   // TODO(cedric): refactor node types to match unist
-  return { name, href, posts: children };
+  return { name, posts: children, ...overwrites };
 }
 
 /**

--- a/docs/types/common.ts
+++ b/docs/types/common.ts
@@ -28,10 +28,11 @@ export type Url = {
 };
 
 export type NavigationRoute = {
-  as?: string;
-  hidden: boolean;
-  href: string;
   name: string;
+  href: string;
+  as?: string;
+  hidden?: boolean;
+  collapsed?: boolean;
   sidebarTitle?: string;
   weight?: number;
   children?: NavigationRoute[];


### PR DESCRIPTION
# Why

Part of [ENG-3960](https://linear.app/expo/issue/ENG-3960/refactor-navigation-and-navigation-data-into-single-file)

This moves all external checks to change the behavior of the sidebar. It embeds the info inside the group or section nodes instead of having to check the name in a list. Makes rendering and maintaining it easier, and we don't have to iterate that much.

# How

- Removed `hiddenSections` and `collapsedSections` lists
- Added overwrites for `makeGroup` and `makeSection`
- Embedded `hidden` and `collapsed` properties inside the group or section nodes

# Test Plan

- Open [/guides](http://localhost:3002/guides/) and validate if these sections are collapsed by default: UI Programming, Regulatory Compliance, Technical Specs, Deprecated
- Open [/feature-preview](http://localhost:3002/feature-preview/) and validate if section "Feature Preview" is not visible

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
