### PR TITLE
[docs] Simplify the documentation sidebar rendering

### DIFF
--- a/docs/components/DocumentationSidebar.tsx
+++ b/docs/components/DocumentationSidebar.tsx
@@ -24,7 +24,7 @@ const STYLES_SECTION_CATEGORY = css`
 
 type SidebarProps = {
   router: NextRouter;
-  routes: NavigationRoute[];
+  routes?: NavigationRoute[];
 };
 
 type SidebarNodeProps = Pick<SidebarProps, 'router'> & {
@@ -38,15 +38,15 @@ const renderTypes: Record<NavigationType, React.ComponentType<SidebarNodeProps> 
   page: null, // Pages are rendered inside groups and should not be rendered directly
 };
 
-export default function DocumentationSidebar(props: SidebarProps) {
+export default function DocumentationSidebar({ router, routes = [] }: SidebarProps) {
   return (
     <nav css={STYLES_SIDEBAR} data-sidebar>
       <VersionSelector />
-      {props.routes.map(route => {
+      {routes.map(route => {
         const Component = renderTypes[route.type];
         return (
           !!Component && (
-            <Component key={`${route.type}-${route.name}`} router={props.router} route={route} />
+            <Component key={`${route.type}-${route.name}`} router={router} route={route} />
           )
         );
       })}

--- a/docs/components/DocumentationSidebar.tsx
+++ b/docs/components/DocumentationSidebar.tsx
@@ -32,6 +32,7 @@ type SidebarNodeProps = Pick<SidebarProps, 'router'> & {
   parentRoute?: NavigationRoute;
 };
 
+// TODO(cedric): move navigation over to unist format and use type to select different "renderers"
 export default function DocumentationSidebar(props: SidebarProps) {
   return (
     <nav css={STYLES_SIDEBAR} data-sidebar>

--- a/docs/components/DocumentationSidebar.tsx
+++ b/docs/components/DocumentationSidebar.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import { NextRouter } from 'next/router';
 import * as React from 'react';
 
-import DocumentationSidebarGroup from '~/components/DocumentationSidebarGroup';
+import DocumentationSidebarCollapsible from '~/components/DocumentationSidebarGroup';
 import DocumentationSidebarLink from '~/components/DocumentationSidebarLink';
 import DocumentationSidebarTitle from '~/components/DocumentationSidebarTitle';
 import VersionSelector from '~/components/VersionSelector';
@@ -22,6 +22,79 @@ const STYLES_SECTION_CATEGORY = css`
   margin-bottom: 24px;
 `;
 
+type SidebarProps = {
+  router: NextRouter;
+  routes: NavigationRoute[];
+};
+
+type SidebarNodeProps = Pick<SidebarProps, 'router'> & {
+  route: NavigationRoute;
+  parentRoute?: NavigationRoute;
+};
+
+export default function NewDocumentationSidebar(props: SidebarProps) {
+  return (
+    <nav css={STYLES_SIDEBAR} data-sidebar>
+      <VersionSelector />
+      {props.routes.map(section => (
+        <NewDocumentationSidebarSection
+          key={`section-${section.name}`}
+          router={props.router}
+          route={section}
+        />
+      ))}
+    </nav>
+  );
+}
+
+function NewDocumentationSidebarSection(props: SidebarNodeProps) {
+  // If the section or group is hidden, we should not render it
+  if (props.route.hidden) {
+    return null;
+  }
+
+  // If a group was passed instead of section, just render that instead
+  if (!props.route.children) {
+    return <NewDocumentationSidebarGroup {...props} />;
+  }
+
+  return (
+    <DocumentationSidebarCollapsible
+      key={`group-${props.route.name}`}
+      router={props.router}
+      info={props.route}>
+      {props.route.children.map(group => (
+        <NewDocumentationSidebarGroup
+          {...props}
+          key={`group-${props.route.name}`}
+          route={group}
+          parentRoute={props.route}
+        />
+      ))}
+    </DocumentationSidebarCollapsible>
+  );
+}
+
+function NewDocumentationSidebarGroup(props: SidebarNodeProps) {
+  return (
+    <div css={STYLES_SECTION_CATEGORY}>
+      {!shouldSkipTitle(props.route, props.parentRoute) && (
+        <DocumentationSidebarTitle key={props.route.sidebarTitle || props.route.name}>
+          {props.route.sidebarTitle || props.route.name}
+        </DocumentationSidebarTitle>
+      )}
+      {(props.route.posts || []).map(page => (
+        <DocumentationSidebarLink
+          key={`${props.route.name}-${page.name}`}
+          router={props.router}
+          info={page}>
+          {page.sidebarTitle || page.name}
+        </DocumentationSidebarLink>
+      ))}
+    </div>
+  );
+}
+
 function shouldSkipTitle(info: NavigationRoute, parentGroup?: NavigationRoute) {
   if (info.name === parentGroup?.name) {
     // If the title of the group is Expo SDK and the section within it has the same name
@@ -38,79 +111,4 @@ function shouldSkipTitle(info: NavigationRoute, parentGroup?: NavigationRoute) {
   }
 
   return false;
-}
-
-type Props = {
-  router: NextRouter;
-  routes: NavigationRoute[];
-};
-
-export default class DocumentationSidebar extends React.Component<Props> {
-  static defaultProps = {
-    routes: [],
-  };
-
-  private renderPostElements = (info: NavigationRoute, category: string) => {
-    return (
-      <DocumentationSidebarLink
-        key={`${category}-${info.name}`}
-        router={this.props.router}
-        info={info}>
-        {info.sidebarTitle || info.name}
-      </DocumentationSidebarLink>
-    );
-  };
-
-  private renderCategoryElements = (info: NavigationRoute, parentGroup?: NavigationRoute) => {
-    if (info.hidden) {
-      return null;
-    }
-
-    if (info.children) {
-      return (
-        <DocumentationSidebarGroup
-          key={`group-${info.name}`}
-          router={this.props.router}
-          info={info}>
-          {info.children.map(categoryInfo => this.renderCategoryElements(categoryInfo, info))}
-        </DocumentationSidebarGroup>
-      );
-    }
-
-    const titleElement = shouldSkipTitle(info, parentGroup) ? null : (
-      <DocumentationSidebarTitle key={info.sidebarTitle || info.name}>
-        {info.sidebarTitle || info.name}
-      </DocumentationSidebarTitle>
-    );
-
-    let postElements;
-    if (info.posts) {
-      postElements = info.posts.map(postInfo => this.renderPostElements(postInfo, info.name));
-    }
-
-    return (
-      <div css={STYLES_SECTION_CATEGORY} key={`category-${info.name}`}>
-        {titleElement}
-        {postElements}
-      </div>
-    );
-  };
-
-  render() {
-    const customDataAttributes = {
-      'data-sidebar': true,
-    };
-
-    return (
-      <nav css={STYLES_SIDEBAR} {...customDataAttributes}>
-        <VersionSelector />
-        {this.props.routes.map(categoryInfo => {
-          if (categoryInfo.hidden) {
-            return null;
-          }
-          return this.renderCategoryElements(categoryInfo);
-        })}
-      </nav>
-    );
-  }
 }

--- a/docs/components/DocumentationSidebar.tsx
+++ b/docs/components/DocumentationSidebar.tsx
@@ -32,12 +32,12 @@ type SidebarNodeProps = Pick<SidebarProps, 'router'> & {
   parentRoute?: NavigationRoute;
 };
 
-export default function NewDocumentationSidebar(props: SidebarProps) {
+export default function DocumentationSidebar(props: SidebarProps) {
   return (
     <nav css={STYLES_SIDEBAR} data-sidebar>
       <VersionSelector />
       {props.routes.map(section => (
-        <NewDocumentationSidebarSection
+        <DocumentationSidebarSection
           key={`section-${section.name}`}
           router={props.router}
           route={section}
@@ -47,7 +47,7 @@ export default function NewDocumentationSidebar(props: SidebarProps) {
   );
 }
 
-function NewDocumentationSidebarSection(props: SidebarNodeProps) {
+function DocumentationSidebarSection(props: SidebarNodeProps) {
   // If the section or group is hidden, we should not render it
   if (props.route.hidden) {
     return null;
@@ -55,7 +55,7 @@ function NewDocumentationSidebarSection(props: SidebarNodeProps) {
 
   // If a group was passed instead of section, just render that instead
   if (!props.route.children) {
-    return <NewDocumentationSidebarGroup {...props} />;
+    return <DocumentationSidebarGroup {...props} />;
   }
 
   return (
@@ -64,7 +64,7 @@ function NewDocumentationSidebarSection(props: SidebarNodeProps) {
       router={props.router}
       info={props.route}>
       {props.route.children.map(group => (
-        <NewDocumentationSidebarGroup
+        <DocumentationSidebarGroup
           {...props}
           key={`group-${props.route.name}`}
           route={group}
@@ -75,7 +75,7 @@ function NewDocumentationSidebarSection(props: SidebarNodeProps) {
   );
 }
 
-function NewDocumentationSidebarGroup(props: SidebarNodeProps) {
+function DocumentationSidebarGroup(props: SidebarNodeProps) {
   return (
     <div css={STYLES_SECTION_CATEGORY}>
       {!shouldSkipTitle(props.route, props.parentRoute) && (

--- a/docs/components/DocumentationSidebarCollapsible.tsx
+++ b/docs/components/DocumentationSidebarCollapsible.tsx
@@ -46,7 +46,11 @@ type Props = {
   info: NavigationRoute;
 };
 
-export default class DocumentationSidebarGroup extends React.Component<Props, { isOpen: boolean }> {
+type State = {
+  isOpen: boolean;
+};
+
+export default class DocumentationSidebarCollapsible extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
 
@@ -109,7 +113,7 @@ export default class DocumentationSidebarGroup extends React.Component<Props, { 
 
     let posts: NavigationRoute[] = [];
     sections?.forEach(section => {
-      posts = [...posts, ...(section?.posts ?? [])];
+      posts = [...posts, ...(section?.children ?? [])];
     });
 
     posts.forEach(isSectionActive);

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -3,6 +3,7 @@
 const frontmatter = require('front-matter');
 const fs = require('fs');
 const path = require('path');
+const make = require('unist-builder');
 const { URL } = require('url');
 
 const { LATEST_VERSION, VERSIONS } = require('./versions');
@@ -381,24 +382,12 @@ module.exports = {
 
 // --- MDX methods ---
 
-/**
- * @param {string} name
- * @param {any[]} [children=[]]
- * @param {Partial<import('~/types/common').NavigationRoute>} [overwrites={}]
- */
-function makeSection(name, children = [], overwrites = {}) {
-  // TODO(cedric): refactor node types to match unist
-  return { name, children, ...overwrites };
+function makeSection(name, children = [], props = {}) {
+  return make('section', { name, ...props }, children);
 }
 
-/**
- * @param {string} name
- * @param {any[]} [children=[]]
- * @param {Partial<import('~/types/common').NavigationRoute>} [overwrites={}]
- */
-function makeGroup(name, children = [], overwrites = {}) {
-  // TODO(cedric): refactor node types to match unist
-  return { name, posts: children, ...overwrites };
+function makeGroup(name, children = [], props = {}) {
+  return make('group', { name, ...props }, children);
 }
 
 /**
@@ -435,7 +424,7 @@ function makePage(file) {
   if (data.hidden) {
     result.hidden = data.hidden;
   }
-  return result;
+  return make('page', result);
 }
 
 // --- Other helpers ---

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -310,7 +310,6 @@ const preview = [
 ];
 
 const featurePreview = [
-  makeGroup('Feature Preview', [], { href: './pages/feature-preview/', hidden: true }),
   makeSection('Development Builds', [
     makeGroup('Development Builds', [
       makePage('development/introduction.md'),

--- a/docs/types/common.ts
+++ b/docs/types/common.ts
@@ -27,7 +27,10 @@ export type Url = {
   pathname: string;
 };
 
+export type NavigationType = 'section' | 'group' | 'page';
+
 export type NavigationRoute = {
+  type: NavigationType;
   name: string;
   href: string;
   as?: string;
@@ -36,5 +39,4 @@ export type NavigationRoute = {
   sidebarTitle?: string;
   weight?: number;
   children?: NavigationRoute[];
-  posts?: NavigationRoute[];
 };


### PR DESCRIPTION
# Why

Part of [ENG-4014](https://linear.app/expo/issue/ENG-4014/simplify-sidebar-rendering)

This makes the sidebar rendering a bit more understandable. The terminology is reused from the **constants/navigation.js**, so it should make a bit more sense how the navigation data is structured. It paves the way for a new sidebar to be implemented 😄 

# How

- Remove recursive rendering of different node types into `Section -> Group -> Page`  order.
- Added `..SidebarSection` and `..SidebarPage` components to split up functional rendering
- Reuse hidden info from navigation node (see PR #16091)
- Removed "hidden"/useless feature preview from navigation

# Test Plan

- Go to each main page and validate the sidebar being rendered properly

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
