### PR TITLE
[docs] Use unist structure in navigation and update sidebar

### DIFF
--- a/docs/components/DocumentationSidebar.tsx
+++ b/docs/components/DocumentationSidebar.tsx
@@ -7,7 +7,7 @@ import DocumentationSidebarLink from '~/components/DocumentationSidebarLink';
 import DocumentationSidebarTitle from '~/components/DocumentationSidebarTitle';
 import VersionSelector from '~/components/VersionSelector';
 import * as Constants from '~/constants/theme';
-import { NavigationRoute } from '~/types/common';
+import { NavigationType, NavigationRoute } from '~/types/common';
 
 const STYLES_SIDEBAR = css`
   padding: 20px 24px 24px 24px;
@@ -35,6 +35,12 @@ type SidebarNodeProps = Pick<SidebarProps, 'router'> & {
   parentRoute?: NavigationRoute;
 };
 
+const renderTypes: Record<NavigationType, React.ComponentType<SidebarNodeProps> | null> = {
+  section: DocumentationSidebarSection,
+  group: DocumentationSidebarGroup,
+  page: null, // Pages are rendered inside groups and should not be rendered directly
+};
+
 // TODO(cedric): move navigation over to unist format and use type to select different "renderers"
 export default function DocumentationSidebar(props: SidebarProps) {
   return (
@@ -42,26 +48,22 @@ export default function DocumentationSidebar(props: SidebarProps) {
       {!props.isVersionSelectorHidden && (
         <VersionSelector version={props.version} onSetVersion={props.onSetVersion} />
       )}
-      {props.routes.map(section => (
-        <DocumentationSidebarSection
-          key={`section-${section.name}`}
-          router={props.router}
-          route={section}
-        />
-      ))}
+      {props.routes.map(route => {
+        const Component = renderTypes[route.type];
+        return (
+          !!Component && (
+            <Component key={`${route.type}-${route.name}`} router={props.router} route={route} />
+          )
+        );
+      })}
     </nav>
   );
 }
 
 function DocumentationSidebarSection(props: SidebarNodeProps) {
-  // If the section or group is hidden, we should not render it
-  if (props.route.hidden) {
+  // If the section or group is hidden, or has no content, we should not render it
+  if (props.route.hidden || !props.route.children?.length) {
     return null;
-  }
-
-  // If a group was passed instead of section, just render that instead
-  if (!props.route.children) {
-    return <DocumentationSidebarGroup {...props} />;
   }
 
   return (
@@ -89,7 +91,7 @@ function DocumentationSidebarGroup(props: SidebarNodeProps) {
           {props.route.sidebarTitle || props.route.name}
         </DocumentationSidebarTitle>
       )}
-      {(props.route.posts || []).map(page => (
+      {(props.route.children || []).map(page => (
         <DocumentationSidebarLink
           key={`${props.route.name}-${page.name}`}
           router={props.router}
@@ -108,8 +110,8 @@ function shouldSkipTitle(info: NavigationRoute, parentGroup?: NavigationRoute) {
     // so it is collapsable
     return true;
   } else if (
-    info.posts &&
-    ((info.posts[0] || {}).sidebarTitle || (info.posts[0] || {}).name) === info.name
+    info.children &&
+    ((info.children[0] || {}).sidebarTitle || (info.children[0] || {}).name) === info.name
   ) {
     // If the first child post in the group has the same name as the group, then hide the
     // group title, lest we be very repetititve

--- a/docs/components/DocumentationSidebar.tsx
+++ b/docs/components/DocumentationSidebar.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import { NextRouter } from 'next/router';
 import * as React from 'react';
 
-import DocumentationSidebarCollapsible from '~/components/DocumentationSidebarGroup';
+import DocumentationSidebarCollapsible from '~/components/DocumentationSidebarCollapsible';
 import DocumentationSidebarLink from '~/components/DocumentationSidebarLink';
 import DocumentationSidebarTitle from '~/components/DocumentationSidebarTitle';
 import VersionSelector from '~/components/VersionSelector';
@@ -41,7 +41,6 @@ const renderTypes: Record<NavigationType, React.ComponentType<SidebarNodeProps> 
   page: null, // Pages are rendered inside groups and should not be rendered directly
 };
 
-// TODO(cedric): move navigation over to unist format and use type to select different "renderers"
 export default function DocumentationSidebar(props: SidebarProps) {
   return (
     <nav css={STYLES_SIDEBAR} data-sidebar>

--- a/docs/components/DocumentationSidebarCollapsible.tsx
+++ b/docs/components/DocumentationSidebarCollapsible.tsx
@@ -47,7 +47,11 @@ type Props = {
   info: NavigationRoute;
 };
 
-export default class DocumentationSidebarGroup extends React.Component<Props, { isOpen: boolean }> {
+type State = {
+  isOpen: boolean;
+};
+
+export default class DocumentationSidebarCollapsible extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
 
@@ -110,7 +114,7 @@ export default class DocumentationSidebarGroup extends React.Component<Props, { 
 
     let posts: NavigationRoute[] = [];
     sections?.forEach(section => {
-      posts = [...posts, ...(section?.posts ?? [])];
+      posts = [...posts, ...(section?.children ?? [])];
     });
 
     posts.forEach(isSectionActive);

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -3,6 +3,7 @@
 const frontmatter = require('front-matter');
 const fs = require('fs');
 const path = require('path');
+const make = require('unist-builder');
 const { URL } = require('url');
 
 const { LATEST_VERSION, VERSIONS } = require('./versions');
@@ -381,24 +382,12 @@ module.exports = {
 
 // --- MDX methods ---
 
-/**
- * @param {string} name
- * @param {any[]} [children=[]]
- * @param {Partial<import('~/types/common').NavigationRoute>} [overwrites={}]
- */
-function makeSection(name, children = [], overwrites = {}) {
-  // TODO(cedric): refactor node types to match unist
-  return { name, children, ...overwrites };
+function makeSection(name, children = [], props = {}) {
+  return make('section', { name, ...props }, children);
 }
 
-/**
- * @param {string} name
- * @param {any[]} [children=[]]
- * @param {Partial<import('~/types/common').NavigationRoute>} [overwrites={}]
- */
-function makeGroup(name, children = [], overwrites = {}) {
-  // TODO(cedric): refactor node types to match unist
-  return { name, posts: children, ...overwrites };
+function makeGroup(name, children = [], props = {}) {
+  return make('group', { name, ...props }, children);
 }
 
 /**
@@ -435,7 +424,7 @@ function makePage(file) {
   if (data.hidden) {
     result.hidden = data.hidden;
   }
-  return result;
+  return make('page', result);
 }
 
 // --- Other helpers ---

--- a/docs/types/common.ts
+++ b/docs/types/common.ts
@@ -27,7 +27,10 @@ export type Url = {
   pathname: string;
 };
 
+export type NavigationType = 'section' | 'group' | 'page';
+
 export type NavigationRoute = {
+  type: NavigationType;
   name: string;
   href: string;
   as?: string;
@@ -36,5 +39,4 @@ export type NavigationRoute = {
   sidebarTitle?: string;
   weight?: number;
   children?: NavigationRoute[];
-  posts?: NavigationRoute[];
 };


### PR DESCRIPTION
# Why

Part of [ENG-4014](https://linear.app/expo/issue/ENG-4014/simplify-sidebar-rendering) and [ENG-4012](https://linear.app/expo/issue/ENG-4012/refactor-navigation-to-match-unified-syntax-tree-spec)

This is a follow-up PR to demonstrate the need for PR #16093. By switching over to the [unist spec]() in the navigation constant, we can improve rendering by assuming a few things. We don't need to validate if `children` or `posts` is defined in the navigation node, that's described by the new `type`. It's not perfect yet because we use a single `NavigationRoute` type for sections, groups, and pages.

With this, we can extend the sidebar with the functionality we need for the redesign. Simply add a new type and sidebar "renderer" (which is also type-guarded, if you forget this) and add whatever you want in **constants/navigation.js**. 

> We can rename the section and/or group to better differentiate the different rendering components in the future sidebar. But let's keep **constants/navigation.js** in sync with that.

# How

- Switched `makeSection`, `makeGroup` and `makePage` over to [`unist-builder`](https://github.com/syntax-tree/unist-builder/tree/2.0.3)
- Updated `DocumentationSidebar` to use the right component for each navigation type
- Added `NavigationType`

# Test Plan

- Go over all root categories and check if the sidebar is rendered properly

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
