### PR TITLE
[docs] Pass router instead of separate url and asPath properties

### DIFF
--- a/docs/components/DocumentationFooter.test.tsx
+++ b/docs/components/DocumentationFooter.test.tsx
@@ -1,20 +1,23 @@
 import { render } from '@testing-library/react';
+import Router, { NextRouter } from 'next/router';
 import * as React from 'react';
 
 import DocumentationFooter, { githubUrl } from './DocumentationFooter';
 
+const mockRouter = (router: Partial<NextRouter>): NextRouter => ({ ...Router, ...router });
+
 describe('DocumentationFooter', () => {
   test('displays default links', () => {
-    const { container } = render(
-      <DocumentationFooter asPath="/" url={{ pathname: '/example/' }} title="test-title" />
-    );
+    const router = mockRouter({ asPath: '/', pathname: '/example/' });
+    const { container } = render(<DocumentationFooter router={router} title="test-title" />);
 
     expect(container).toHaveTextContent('Ask a question on the forums');
     expect(container).toHaveTextContent('Edit this page');
   });
 
   test('displays forums link with tag', () => {
-    const { container } = render(<DocumentationFooter asPath="/sdk/" title="test-title" />);
+    const router = mockRouter({ asPath: '/sdk/', pathname: '' });
+    const { container } = render(<DocumentationFooter router={router} title="test-title" />);
 
     expect(container).toHaveTextContent(
       'Get help from the community and ask questions about test-title'
@@ -22,14 +25,16 @@ describe('DocumentationFooter', () => {
   });
 
   test('displays issues link', () => {
-    const { container } = render(<DocumentationFooter asPath="/sdk/" title="test-title" />);
+    const router = mockRouter({ asPath: '/sdk/', pathname: '' });
+    const { container } = render(<DocumentationFooter router={router} title="test-title" />);
 
     expect(container).toHaveTextContent('View open bug reports for test-title');
   });
 
   test('displays source code link', () => {
+    const router = mockRouter({ asPath: '/sdk/', pathname: '' });
     const { container } = render(
-      <DocumentationFooter asPath="/sdk/" title="test-title" sourceCodeUrl="/" />
+      <DocumentationFooter router={router} title="test-title" sourceCodeUrl="/" />
     );
 
     expect(container).toHaveTextContent('View source code for test-title');

--- a/docs/components/DocumentationFooter.tsx
+++ b/docs/components/DocumentationFooter.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import { theme } from '@expo/styleguide';
+import { NextRouter } from 'next/router';
 import * as React from 'react';
 
 import { UL, LI } from '~/components/base/list';
@@ -7,7 +8,6 @@ import Bug from '~/components/icons/Bug';
 import ChatBoxes from '~/components/icons/ChatBoxes';
 import Pencil from '~/components/icons/Pencil';
 import Spectacles from '~/components/icons/Spectacles';
-import { Url } from '~/types/common';
 
 const STYLES_FOOTER = css`
   border-top: 1px solid ${theme.border.default};
@@ -58,8 +58,7 @@ export function githubUrl(path: string) {
 const SDK_BLACKLIST = ['Overview'];
 
 type Props = {
-  asPath: string;
-  url?: Url;
+  router: NextRouter;
   title: string;
   sourceCodeUrl?: string;
 };
@@ -79,7 +78,7 @@ export default class DocumentationFooter extends React.PureComponent<Props> {
   }
 
   private renderForumsLink() {
-    if (!this.props.asPath.includes('/sdk/') || SDK_BLACKLIST.includes(this.props.title)) {
+    if (!this.props.router.asPath.includes('/sdk/') || SDK_BLACKLIST.includes(this.props.title)) {
       return (
         <LI>
           <a
@@ -113,14 +112,14 @@ export default class DocumentationFooter extends React.PureComponent<Props> {
   }
 
   private maybeRenderGithubUrl() {
-    if (this.props.url) {
+    if (this.props.router) {
       return (
         <LI>
           <a
             css={STYLES_FOOTER_LINK}
             target="_blank"
             rel="noopener"
-            href={githubUrl(this.props.url.pathname)}>
+            href={githubUrl(this.props.router.pathname)}>
             <span css={STYLES_FOOTER_ICON}>
               <Pencil fillColor="currentColor" />
             </span>
@@ -132,7 +131,7 @@ export default class DocumentationFooter extends React.PureComponent<Props> {
   }
 
   private maybeRenderIssuesLink = () => {
-    if (!this.props.asPath.includes('/sdk/') || SDK_BLACKLIST.includes(this.props.title)) {
+    if (!this.props.router.asPath.includes('/sdk/') || SDK_BLACKLIST.includes(this.props.title)) {
       return;
     }
 
@@ -152,7 +151,7 @@ export default class DocumentationFooter extends React.PureComponent<Props> {
   };
 
   private maybeRenderSourceCodeLink = () => {
-    if (!this.props.asPath.includes('/sdk/') || !this.props.sourceCodeUrl) {
+    if (!this.props.router.asPath.includes('/sdk/') || !this.props.sourceCodeUrl) {
       return;
     }
 

--- a/docs/components/DocumentationPage.tsx
+++ b/docs/components/DocumentationPage.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { theme } from '@expo/styleguide';
 import some from 'lodash/some';
-import Router from 'next/router';
+import Router, { NextRouter } from 'next/router';
 import NProgress from 'nprogress';
 import * as React from 'react';
 
@@ -20,7 +20,7 @@ import { H1 } from '~/components/base/headings';
 import navigation from '~/constants/navigation';
 import * as Constants from '~/constants/theme';
 import { VERSIONS } from '~/constants/versions';
-import { NavigationRoute, Url } from '~/types/common';
+import { NavigationRoute } from '~/types/common';
 
 const STYLES_DOCUMENT = css`
   background: ${theme.background.default};
@@ -50,9 +50,8 @@ const HIDDEN_ON_DESKTOP = css`
 `;
 
 type Props = {
-  url: Url;
+  router: NextRouter;
   title: string;
-  asPath: string;
   sourceCodeUrl?: string;
   /** API Page NPM package name, exposed through context for various React components that consistently use the package name. */
   packageName?: string;
@@ -105,7 +104,7 @@ export default class DocumentationPage extends React.Component<Props, State> {
   };
 
   private handleSetVersion = (version: string) => {
-    let newPath = Utilities.replaceVersionInUrl(this.props.url.pathname, version);
+    let newPath = Utilities.replaceVersionInUrl(this.props.router.pathname, version);
 
     if (!newPath.endsWith('/')) {
       newPath += '/';
@@ -142,46 +141,50 @@ export default class DocumentationPage extends React.Component<Props, State> {
   };
 
   private isReferencePath = () => {
-    return this.props.url.pathname.startsWith('/versions');
+    return this.props.router.pathname.startsWith('/versions');
   };
 
   private isGeneralPath = () => {
     return some(navigation.generalDirectories, name =>
-      this.props.url.pathname.startsWith(`/${name}`)
+      this.props.router.pathname.startsWith(`/${name}`)
     );
   };
 
   private isGettingStartedPath = () => {
     return (
-      this.props.url.pathname === '/' ||
-      some(navigation.startingDirectories, name => this.props.url.pathname.startsWith(`/${name}`))
+      this.props.router.pathname === '/' ||
+      some(navigation.startingDirectories, name =>
+        this.props.router.pathname.startsWith(`/${name}`)
+      )
     );
   };
 
   private isFeaturePreviewPath = () => {
     return some(navigation.featurePreviewDirectories, name =>
-      this.props.url.pathname.startsWith(`/${name}`)
+      this.props.router.pathname.startsWith(`/${name}`)
     );
   };
 
   private isPreviewPath = () => {
     return some(navigation.previewDirectories, name =>
-      this.props.url.pathname.startsWith(`/${name}`)
+      this.props.router.pathname.startsWith(`/${name}`)
     );
   };
 
   private isEasPath = () => {
-    return some(navigation.easDirectories, name => this.props.url.pathname.startsWith(`/${name}`));
+    return some(navigation.easDirectories, name =>
+      this.props.router.pathname.startsWith(`/${name}`)
+    );
   };
 
   private getCanonicalUrl = () => {
     if (this.isReferencePath()) {
       return `https://docs.expo.dev${Utilities.replaceVersionInUrl(
-        this.props.url.pathname,
+        this.props.router.pathname,
         'latest'
       )}`;
     } else {
-      return `https://docs.expo.dev${this.props.url.pathname}`;
+      return `https://docs.expo.dev${this.props.router.pathname}`;
     }
   };
 
@@ -194,7 +197,7 @@ export default class DocumentationPage extends React.Component<Props, State> {
   };
 
   private getVersion = () => {
-    let version = (this.props.asPath || this.props.url.pathname).split(`/`)[2];
+    let version = (this.props.router.asPath || this.props.router.pathname).split(`/`)[2];
     if (!version || !VERSIONS.includes(version)) {
       version = 'latest';
     }
@@ -251,8 +254,7 @@ export default class DocumentationPage extends React.Component<Props, State> {
 
     const sidebarElement = (
       <DocumentationSidebar
-        url={this.props.url}
-        asPath={this.props.asPath}
+        router={this.props.router}
         routes={routes}
         version={version}
         onSetVersion={this.handleSetVersion}
@@ -326,9 +328,8 @@ export default class DocumentationPage extends React.Component<Props, State> {
               {this.props.children}
             </DocumentationPageContext.Provider>
             <DocumentationFooter
+              router={this.props.router}
               title={this.props.title}
-              url={this.props.url}
-              asPath={this.props.asPath}
               sourceCodeUrl={this.props.sourceCodeUrl}
             />
           </div>
@@ -341,15 +342,14 @@ export default class DocumentationPage extends React.Component<Props, State> {
                 {this.props.children}
               </DocumentationPageContext.Provider>
               <DocumentationFooter
+                router={this.props.router}
                 title={this.props.title}
-                asPath={this.props.asPath}
                 sourceCodeUrl={this.props.sourceCodeUrl}
               />
             </div>
             <div css={HIDDEN_ON_DESKTOP}>
               <DocumentationSidebar
-                url={this.props.url}
-                asPath={this.props.asPath}
+                router={this.props.router}
                 routes={routes}
                 version={version}
                 onSetVersion={this.handleSetVersion}

--- a/docs/components/DocumentationSidebar.tsx
+++ b/docs/components/DocumentationSidebar.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { NextRouter } from 'next/router';
 import * as React from 'react';
 
 import DocumentationSidebarGroup from '~/components/DocumentationSidebarGroup';
@@ -7,7 +8,7 @@ import DocumentationSidebarTitle from '~/components/DocumentationSidebarTitle';
 import VersionSelector from '~/components/VersionSelector';
 import { hiddenSections } from '~/constants/navigation';
 import * as Constants from '~/constants/theme';
-import { NavigationRoute, Url } from '~/types/common';
+import { NavigationRoute } from '~/types/common';
 
 const STYLES_SIDEBAR = css`
   padding: 20px 24px 24px 24px;
@@ -49,8 +50,7 @@ function shouldSkipTitle(info: NavigationRoute, parentGroup?: NavigationRoute) {
 }
 
 type Props = {
-  url: Url;
-  asPath: string;
+  router: NextRouter;
   isVersionSelectorHidden: boolean;
   routes: NavigationRoute[];
   version: string;
@@ -66,9 +66,8 @@ export default class DocumentationSidebar extends React.Component<Props> {
     return (
       <DocumentationSidebarLink
         key={`${category}-${info.name}`}
-        info={info}
-        url={this.props.url}
-        asPath={this.props.asPath}>
+        router={this.props.router}
+        info={info}>
         {info.sidebarTitle || info.name}
       </DocumentationSidebarLink>
     );
@@ -83,21 +82,16 @@ export default class DocumentationSidebar extends React.Component<Props> {
       return (
         <DocumentationSidebarGroup
           key={`group-${info.name}`}
-          url={this.props.url}
-          info={info}
-          asPath={this.props.asPath}>
+          router={this.props.router}
+          info={info}>
           {info.children.map(categoryInfo => this.renderCategoryElements(categoryInfo, info))}
         </DocumentationSidebarGroup>
       );
     }
 
     const titleElement = shouldSkipTitle(info, parentGroup) ? null : (
-      <DocumentationSidebarTitle
-        key={info.sidebarTitle ? info.sidebarTitle : info.name}
-        info={info}
-        url={this.props.url}
-        asPath={this.props.asPath}>
-        {info.sidebarTitle ? info.sidebarTitle : info.name}
+      <DocumentationSidebarTitle key={info.sidebarTitle || info.name}>
+        {info.sidebarTitle || info.name}
       </DocumentationSidebarTitle>
     );
 

--- a/docs/components/DocumentationSidebarGroup.tsx
+++ b/docs/components/DocumentationSidebarGroup.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import { theme } from '@expo/styleguide';
+import { NextRouter } from 'next/router';
 import * as React from 'react';
 
 import stripVersionFromPath from '~/common/stripVersionFromPath';
@@ -7,7 +8,7 @@ import { paragraph } from '~/components/base/typography';
 import ChevronDown from '~/components/icons/ChevronDown';
 import { collapsedSections } from '~/constants/navigation';
 import * as Constants from '~/constants/theme';
-import { NavigationRoute, Url } from '~/types/common';
+import { NavigationRoute } from '~/types/common';
 
 const STYLES_TITLE = css`
   ${paragraph}
@@ -43,9 +44,8 @@ if (typeof window !== 'undefined' && !window.hasOwnProperty('sidebarState')) {
 }
 
 type Props = {
-  asPath: string;
+  router: NextRouter;
   info: NavigationRoute;
-  url: Url;
 };
 
 export default class DocumentationSidebarGroup extends React.Component<Props, { isOpen: boolean }> {
@@ -86,7 +86,7 @@ export default class DocumentationSidebarGroup extends React.Component<Props, { 
   private isChildRouteActive() {
     // Special case for "Get Started"
     if (this.props.info.name === 'Getting to know Expo') {
-      if (this.props.asPath.match(/\/versions\/[\w.]+\/$/)) {
+      if (this.props.router.asPath.match(/\/versions\/[\w.]+\/$/)) {
         return true;
       }
     }
@@ -97,8 +97,8 @@ export default class DocumentationSidebarGroup extends React.Component<Props, { 
 
     const isSectionActive = (section: NavigationRoute) => {
       const linkUrl = stripVersionFromPath(section.as || section.href);
-      const pathname = stripVersionFromPath(this.props.url.pathname);
-      const asPath = stripVersionFromPath(this.props.asPath);
+      const pathname = stripVersionFromPath(this.props.router.pathname);
+      const asPath = stripVersionFromPath(this.props.router.asPath);
 
       if (
         linkUrl === pathname ||

--- a/docs/components/DocumentationSidebarLink.tsx
+++ b/docs/components/DocumentationSidebarLink.tsx
@@ -78,7 +78,7 @@ export default class DocumentationSidebarLink extends React.Component<Props> {
 
   isSelected() {
     if (!this.props.router) {
-      console.log('[debug] isSelected bailed out, no url', this.props);
+      console.log('[debug] isSelected bailed out, no router', this.props);
       return false;
     }
 

--- a/docs/components/DocumentationSidebarLink.tsx
+++ b/docs/components/DocumentationSidebarLink.tsx
@@ -1,12 +1,13 @@
 import { css } from '@emotion/react';
 import { theme } from '@expo/styleguide';
 import NextLink from 'next/link';
+import { NextRouter } from 'next/router';
 import * as React from 'react';
 
 import stripVersionFromPath from '~/common/stripVersionFromPath';
 import { paragraph } from '~/components/base/typography';
 import * as Constants from '~/constants/theme';
-import { NavigationRoute, Url } from '~/types/common';
+import { NavigationRoute } from '~/types/common';
 
 const STYLES_LINK = css`
   display: block;
@@ -65,9 +66,8 @@ const STYLES_ACTIVE_BULLET = css`
 `;
 
 type Props = {
-  url: Url;
+  router: NextRouter;
   info: NavigationRoute;
-  asPath: string;
 };
 
 export default class DocumentationSidebarLink extends React.Component<Props> {
@@ -77,14 +77,14 @@ export default class DocumentationSidebarLink extends React.Component<Props> {
   }
 
   isSelected() {
-    if (!this.props.url) {
+    if (!this.props.router) {
       console.log('[debug] isSelected bailed out, no url', this.props);
       return false;
     }
 
     // Special case for root url
     if (this.props.info.name === 'Introduction') {
-      const { asPath } = this.props;
+      const { asPath } = this.props.router;
       if (asPath.match(/\/versions\/[\w.]+\/$/) || asPath === '/versions/latest/') {
         return true;
       }
@@ -92,8 +92,8 @@ export default class DocumentationSidebarLink extends React.Component<Props> {
 
     const linkUrl = stripVersionFromPath(this.props.info.as || this.props.info.href);
     if (
-      linkUrl === stripVersionFromPath(this.props.url.pathname) ||
-      linkUrl === stripVersionFromPath(this.props.asPath)
+      linkUrl === stripVersionFromPath(this.props.router.pathname) ||
+      linkUrl === stripVersionFromPath(this.props.router.asPath)
     ) {
       return true;
     }

--- a/docs/components/DocumentationSidebarTitle.tsx
+++ b/docs/components/DocumentationSidebarTitle.tsx
@@ -4,7 +4,6 @@ import * as React from 'react';
 
 import { paragraph } from '~/components/base/typography';
 import * as Constants from '~/constants/theme';
-import { NavigationRoute, Url } from '~/types/common';
 
 const STYLES_TITLE = css`
   ${paragraph}
@@ -18,14 +17,8 @@ const STYLES_TITLE = css`
   padding-bottom: 0.25rem;
 `;
 
-type Props = {
-  url?: Url;
-  info: NavigationRoute;
-  asPath: string;
-};
+type Props = React.PropsWithChildren<object>;
 
-export default class DocumentationSidebarTitle extends React.Component<Props, any> {
-  render() {
-    return <div css={STYLES_TITLE}>{this.props.children}</div>;
-  }
+export default function DocumentationSidebarTitle(props: Props) {
+  return <div css={STYLES_TITLE}>{props.children}</div>;
 }

--- a/docs/components/page-higher-order/DocumentationElements.tsx
+++ b/docs/components/page-higher-order/DocumentationElements.tsx
@@ -22,9 +22,8 @@ export default function DocumentationElements(props: DocumentationElementsProps)
   return (
     <HeadingsContext.Provider value={manager}>
       <DocumentationPage
+        router={router}
         title={props.meta.title || ''}
-        url={router}
-        asPath={router.asPath}
         packageName={props.meta.packageName}
         sourceCodeUrl={props.meta.sourceCodeUrl}
         tocVisible={!props.meta.hideTOC}


### PR DESCRIPTION
# Why

Part of [ENG-3964](https://linear.app/expo/issue/ENG-3964/split-up-documentationpagetsx)

We used to pass the `url` and `asPath` all the way in this chain of files:
- **components/page-higher-order/DocumentationElements.tsx**
  - **components/DocumentationPage.tsx**
    - **components/DocumentationFooter.tsx**
    - **components/DocumentationSidebar.tsx**
      - **components/DocumentationSidebarGroup.tsx**
      - **components/DocumentationSidebarLink.tsx**

Preferably, we would just use `useRouter` in most scenarios. In this PR I only replaced both `url` and `asPath` with `router` because we are doing the same thing over and over in each component: detect if the link that's being rendered should be rendered as active.

We should find a better way for this to do this once, and reuse it instead of recalculating it in every component.

# How

- Replaced `url={router}` and `asPath={router.asPath}` with just `router={router}` and simplified the props in the whole chain.

# Test Plan

- Open any page through links
- Check if the link is still marked as active

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
