### PR TITLE
[ncl] fix few warnings and ignores

### DIFF
--- a/apps/native-component-list/src/components/Face.tsx
+++ b/apps/native-component-list/src/components/Face.tsx
@@ -1,4 +1,4 @@
-import { FaceFeature } from 'expo-face-detector';
+import { FaceFeature, Point } from 'expo-face-detector';
 import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 
@@ -9,7 +9,7 @@ export const scaledFace =
   ({ faceID, bounds, rollAngle, yawAngle }: FaceFeature) =>
     (
       <View
-        key={faceID}
+        key={`face-${faceID || yawAngle}`}
         style={[
           styles.face,
           {
@@ -31,7 +31,7 @@ export const scaledFace =
     );
 
 export const scaledLandmarks = (scale: number) => (face: FaceFeature) => {
-  const renderLandmark = (position?: { x: number; y: number }) =>
+  const renderLandmark = (position?: Point) =>
     position && (
       <View
         key={`${position?.x ?? 'no-x'}${position?.y ?? 'no-y'}`}
@@ -46,7 +46,7 @@ export const scaledLandmarks = (scale: number) => (face: FaceFeature) => {
     );
   console.log('landmark', face);
   return (
-    <View key={`landmarks-${face.faceID}`}>
+    <View key={`landmarks-${face.faceID || face.yawAngle}`}>
       {renderLandmark(face.leftEyePosition)}
       {renderLandmark(face.rightEyePosition)}
       {renderLandmark(face.leftEarPosition)}

--- a/apps/native-component-list/src/navigation/RootNavigation.tsx
+++ b/apps/native-component-list/src/navigation/RootNavigation.tsx
@@ -12,7 +12,7 @@ import MainTabNavigator from './MainTabNavigator';
 const Switch = createStackNavigator();
 
 export const linking = {
-  prefixes: [Linking.makeUrl('/')],
+  prefixes: [Linking.createURL('/')],
   config: {
     screens: {
       main: {

--- a/apps/native-component-list/src/screens/Contacts/ContactUtils.ts
+++ b/apps/native-component-list/src/screens/Contacts/ContactUtils.ts
@@ -85,7 +85,6 @@ export async function getGroupWithNameAsync(
 export async function cloneAsync(contactId: string) {
   const contact = await Contacts.getContactByIdAsync(contactId);
   if (contact) {
-    // @ts-ignore
     await Contacts.addContactAsync(contact);
   }
 }
@@ -93,8 +92,7 @@ export async function cloneAsync(contactId: string) {
 export async function ensureGroupAsync(groupName: string) {
   const group = await getGroupWithNameAsync(groupName);
   if (!group) {
-    const groupId = await Contacts.createGroupAsync(groupName);
-    return groupId;
+    return await Contacts.createGroupAsync(groupName);
   }
   return group.id;
 }
@@ -103,10 +101,9 @@ export async function deleteGroupWithNameAsync(groupName: string) {
   try {
     const group = await getGroupWithNameAsync(groupName);
     if (group) {
-      Contacts.removeGroupAsync(group.id!);
+      await Contacts.removeGroupAsync(group.id!);
     }
   } catch ({ message }) {
-    // tslint:disable-next-line no-console
     console.error(message);
   }
 }
@@ -120,7 +117,6 @@ export async function removeAllChildrenFromGroupWithNameAsync(groupName: string)
       contacts.map((contact) => Contacts.removeContactFromGroupAsync(contact.id, groupId!))
     );
   } catch ({ message }) {
-    // tslint:disable-next-line no-console
     console.error(message);
   }
 }
@@ -129,7 +125,7 @@ export async function debugAddFirstContactToGroupAsync() {
   const groupId = await ensureGroupAsync('Expo Contacts');
   const { data: contacts } = await Contacts.getContactsAsync({ pageSize: 1 });
   const contact = contacts[0];
-  Contacts.addExistingContactToGroupAsync(contact.id, groupId!);
+  await Contacts.addExistingContactToGroupAsync(contact.id, groupId!);
 }
 
 export function presentNewContactFormAsync({

--- a/apps/native-component-list/src/screens/FaceDetectorScreen.tsx
+++ b/apps/native-component-list/src/screens/FaceDetectorScreen.tsx
@@ -19,9 +19,8 @@ interface State {
 }
 
 const imageViewSize = 300;
-// See: https://github.com/expo/expo/pull/10229#discussion_r490961694
-// eslint-disable-next-line @typescript-eslint/ban-types
-export default class FeceDetectorScreen extends React.Component<{}, State> {
+
+export default class FaceDetectorScreen extends React.Component<object, State> {
   static navigationOptions = {
     title: 'FaceDetector',
   };
@@ -152,12 +151,12 @@ export default class FeceDetectorScreen extends React.Component<{}, State> {
 
   _maybeRenderDetectedFacesAndLandmarks = () => {
     const { selection, faceDetection } = this.state;
-    if (selection && faceDetection) {
-      const { pixelsToDisplayScale } = calculateImageScale(selection as ImageInfo);
+    if (selection && !selection?.cancelled && faceDetection) {
+      const { pixelsToDisplayScale } = calculateImageScale(selection);
       return (
         <View
           style={{
-            ...imageOverflowSizeAndPosition(selection as ImageInfo),
+            ...imageOverflowSizeAndPosition(selection),
             position: 'absolute',
           }}>
           {this.state.faceDetection &&


### PR DESCRIPTION
# Why

During the work on the latest PRs I have spotted few warning and ignores in NCL app, let's fix those.

# How

This PR includes the TS types corrections, duplicated keys warnings (`faceID` not always exist) fixes, replacements of deprecated methods and fixes warnings of async method executed without await.

I have also corrected the `FaceDetectorScreen` screen name.

# Test Plan

NCL apps build and runs correctly. I did not see the described above warning anymore.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
