### PR TITLE
[docs] Move all typography references over to expo styleguide

### DIFF
--- a/docs/components/DocumentationHeader.tsx
+++ b/docs/components/DocumentationHeader.tsx
@@ -8,6 +8,7 @@ import {
   ThemeAutoIcon,
   ChevronDownIcon,
   shadows,
+  typography,
 } from '@expo/styleguide';
 import Link from 'next/link';
 import * as React from 'react';
@@ -37,7 +38,7 @@ const STYLES_TITLE_TEXT = css`
   white-space: nowrap;
   padding-left: 8px;
   font-size: 1.2rem;
-  font-family: ${Constants.fonts.bold};
+  font-family: ${typography.fontFaces.semiBold};
   color: ${theme.text.default};
 `;
 
@@ -153,7 +154,7 @@ const STYLES_MENU_BUTTON = css`
 
 const SECTION_LINK = css`
   text-decoration: none;
-  font-family: ${Constants.fontFamilies.demi};
+  font-family: ${typography.fontFaces.medium};
   cursor: pointer;
 
   padding: 0 16px;

--- a/docs/components/DocumentationSidebarGroup.tsx
+++ b/docs/components/DocumentationSidebarGroup.tsx
@@ -1,12 +1,11 @@
 import { css } from '@emotion/react';
-import { theme } from '@expo/styleguide';
+import { theme, typography } from '@expo/styleguide';
 import { NextRouter } from 'next/router';
 import * as React from 'react';
 
 import stripVersionFromPath from '~/common/stripVersionFromPath';
 import { paragraph } from '~/components/base/typography';
 import ChevronDown from '~/components/icons/ChevronDown';
-import * as Constants from '~/constants/theme';
 import { NavigationRoute } from '~/types/common';
 
 const STYLES_TITLE = css`
@@ -18,7 +17,7 @@ const STYLES_TITLE = css`
   position: relative;
   margin-bottom: 16px;
   text-decoration: none;
-  font-family: ${Constants.fontFamilies.demi};
+  font-family: ${typography.fontFaces.medium};
   user-select: none;
   background: ${theme.background.tertiary};
   padding: 8px 16px;

--- a/docs/components/DocumentationSidebarLink.tsx
+++ b/docs/components/DocumentationSidebarLink.tsx
@@ -1,12 +1,11 @@
 import { css } from '@emotion/react';
-import { theme } from '@expo/styleguide';
+import { theme, typography } from '@expo/styleguide';
 import NextLink from 'next/link';
 import { NextRouter } from 'next/router';
 import * as React from 'react';
 
 import stripVersionFromPath from '~/common/stripVersionFromPath';
 import { paragraph } from '~/components/base/typography';
-import * as Constants from '~/constants/theme';
 import { NavigationRoute } from '~/types/common';
 
 const STYLES_LINK = css`
@@ -18,7 +17,7 @@ const STYLES_ACTIVE = css`
   ${paragraph}
   font-size: 15px;
   line-height: 140%;
-  font-family: ${Constants.fontFamilies.demi};
+  font-family: ${typography.fontFaces.medium};
   color: ${theme.link.default};
   position: relative;
   left: -7px;

--- a/docs/components/DocumentationSidebarRightLink.tsx
+++ b/docs/components/DocumentationSidebarRightLink.tsx
@@ -1,11 +1,10 @@
 import { css } from '@emotion/react';
-import { theme, palette } from '@expo/styleguide';
+import { theme, palette, typography } from '@expo/styleguide';
 import * as React from 'react';
 
 import { BASE_HEADING_LEVEL, Heading, HeadingType } from '../common/headingManager';
 
 import { paragraph } from '~/components/base/typography';
-import * as Constants from '~/constants/theme';
 
 const STYLES_LINK = css`
   ${paragraph}
@@ -23,11 +22,11 @@ const STYLES_LINK = css`
 `;
 
 const STYLES_LINK_HEADER = css`
-  font-family: ${Constants.fontFamilies.demi};
+  font-family: ${typography.fontFaces.medium};
 `;
 
 const STYLES_LINK_CODE = css`
-  font-family: ${Constants.fontFamilies.mono};
+  font-family: ${typography.fontFaces.mono};
   font-size: 13px;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -42,7 +41,7 @@ const STYLES_TOOLTIP = css`
   border-radius: 3px;
   position: absolute;
   background-color: ${palette.dark.white};
-  font-family: ${Constants.fontFamilies.demi};
+  font-family: ${typography.fontFaces.medium};
   max-width: 400px;
   border: 1px solid black;
   padding: 3px 6px;
@@ -56,7 +55,7 @@ const STYLES_TOOLTIP = css`
 `;
 
 const STYLES_CODE_TOOLTIP = css`
-  font-family: ${Constants.fontFamilies.mono};
+  font-family: ${typography.fontFaces.mono};
   font-size: 11px;
 `;
 

--- a/docs/components/DocumentationSidebarTitle.tsx
+++ b/docs/components/DocumentationSidebarTitle.tsx
@@ -1,9 +1,8 @@
 import { css } from '@emotion/react';
-import { theme } from '@expo/styleguide';
+import { theme, typography } from '@expo/styleguide';
 import * as React from 'react';
 
 import { paragraph } from '~/components/base/typography';
-import * as Constants from '~/constants/theme';
 
 const STYLES_TITLE = css`
   ${paragraph}
@@ -12,7 +11,7 @@ const STYLES_TITLE = css`
   position: relative;
   margin-bottom: 12px;
   text-decoration: none;
-  font-family: ${Constants.fontFamilies.demi};
+  font-family: ${typography.fontFaces.medium};
   border-bottom: 1px solid ${theme.border.default};
   padding-bottom: 0.25rem;
 `;

--- a/docs/components/VersionSelector.tsx
+++ b/docs/components/VersionSelector.tsx
@@ -1,11 +1,10 @@
 import { css } from '@emotion/react';
-import { theme } from '@expo/styleguide';
+import { theme, typography } from '@expo/styleguide';
 import * as React from 'react';
 
 import * as Utilities from '~/common/utilities';
 import { paragraph } from '~/components/base/typography';
 import ChevronDownIcon from '~/components/icons/ChevronDown';
-import * as Constants from '~/constants/theme';
 import { VERSIONS, LATEST_VERSION, BETA_VERSION } from '~/constants/versions';
 
 const STYLES_SELECT = css`
@@ -30,7 +29,7 @@ const STYLES_SELECT_TEXT = css`
   align-items: center;
   flex: 1;
   justify-content: space-between;
-  font-family: ${Constants.fontFamilies.demi};
+  font-family: ${typography.fontFaces.medium};
   color: ${theme.text.default};
   font-size: 14px;
 `;

--- a/docs/components/__snapshots__/DocumentationSidebarRight.test.tsx.snap
+++ b/docs/components/__snapshots__/DocumentationSidebarRight.test.tsx.snap
@@ -7,21 +7,21 @@ exports[`DocumentationSidebarRight correctly matches snapshot 1`] = `
     data-sidebar="true"
   >
     <a
-      class="css-19zpey5-paragraph-STYLES_LINK-STYLES_LINK_HEADER-DocumentationSidebarRightLink"
+      class="css-1xv10pi-paragraph-STYLES_LINK-STYLES_LINK_HEADER-DocumentationSidebarRightLink"
       href="#base-level-heading"
       style="padding-left: 0px;"
     >
       Base level heading
     </a>
     <a
-      class="css-3k76hs-paragraph-STYLES_LINK-DocumentationSidebarRightLink"
+      class="css-g9fncx-paragraph-STYLES_LINK-DocumentationSidebarRightLink"
       href="#level-3-subheading"
       style="padding-left: 16px;"
     >
       Level 3 subheading
     </a>
     <a
-      class="css-ds24np-paragraph-STYLES_LINK-STYLES_LINK_CODE-DocumentationSidebarRightLink"
+      class="css-1xrt3wy-paragraph-STYLES_LINK-STYLES_LINK_CODE-DocumentationSidebarRightLink"
       href="#code-heading-depth-1"
       style="padding-left: 16px;"
     >

--- a/docs/components/base/code.tsx
+++ b/docs/components/base/code.tsx
@@ -1,13 +1,11 @@
 import { css } from '@emotion/react';
 import { SerializedStyles } from '@emotion/serialize';
-import { theme } from '@expo/styleguide';
+import { theme, typography } from '@expo/styleguide';
 import { Language, Prism } from 'prism-react-renderer';
 import * as React from 'react';
 import tippy, { roundArrow } from 'tippy.js';
 
 import { installLanguages } from './languages';
-
-import * as Constants from '~/constants/theme';
 
 installLanguages(Prism);
 
@@ -17,7 +15,7 @@ const attributes = {
 
 const STYLES_CODE_BLOCK = css`
   color: ${theme.text.default};
-  font-family: ${Constants.fontFamilies.mono};
+  font-family: ${typography.fontFaces.mono};
   font-size: 13px;
   line-height: 20px;
   white-space: inherit;
@@ -48,7 +46,7 @@ const STYLES_CODE_BLOCK = css`
 
 const STYLES_INLINE_CODE = css`
   color: ${theme.text.default};
-  font-family: ${Constants.fontFamilies.mono};
+  font-family: ${typography.fontFaces.mono};
   font-size: 0.825em;
   white-space: pre-wrap;
   display: inline;

--- a/docs/components/base/details.tsx
+++ b/docs/components/base/details.tsx
@@ -1,7 +1,6 @@
 import { css } from '@emotion/react';
+import { typography } from '@expo/styleguide';
 import * as React from 'react';
-
-import * as Constants from '~/constants/theme';
 
 const STYLES_DETAILS = css`
   margin-bottom: 0px;
@@ -9,7 +8,7 @@ const STYLES_DETAILS = css`
 
 const STYLES_SUMMARY = css`
   margin-bottom: 0px;
-  font-family: ${Constants.fontFamilies.demi};
+  font-family: ${typography.fontFaces.medium};
   font-weight: 400;
 `;
 

--- a/docs/components/base/headings.tsx
+++ b/docs/components/base/headings.tsx
@@ -1,10 +1,8 @@
 import { css } from '@emotion/react';
-import { theme } from '@expo/styleguide';
+import { theme, typography } from '@expo/styleguide';
 import * as React from 'react';
 
 import { h1, h2, h3, h4 } from './typography';
-
-import * as Constants from '~/constants/theme';
 
 const attributes = {
   'data-heading': true,
@@ -33,7 +31,7 @@ const STYLES_H2 = css`
 
   code {
     ${h2}
-    font-family: ${Constants.fontFamilies.mono};
+    font-family: ${typography.fontFaces.mono};
     padding: 1px 8px;
     border-radius: 4px;
   }
@@ -52,7 +50,7 @@ const STYLES_H3 = css`
 
   code {
     ${h3}
-    font-family: ${Constants.fontFamilies.mono};
+    font-family: ${typography.fontFaces.mono};
     padding: 1px 6px;
     border-radius: 4px;
   }
@@ -70,7 +68,7 @@ const STYLES_H4 = css`
 
   code {
     ${h4}
-    font-family: ${Constants.fontFamilies.mono};
+    font-family: ${typography.fontFaces.mono};
     padding: 1px 6px;
     border-radius: 4px;
   }

--- a/docs/components/base/paragraph.tsx
+++ b/docs/components/base/paragraph.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { theme } from '@expo/styleguide';
+import { theme, typography } from '@expo/styleguide';
 import emojiRegex from 'emoji-regex';
 import * as React from 'react';
 
@@ -26,7 +26,7 @@ export const P: React.FC = ({ children }) => (
 const STYLES_BOLD_PARAGRAPH = css`
   ${paragraph}
   font-size: inherit;
-  font-family: ${Constants.fontFamilies.bold};
+  font-family: ${typography.fontFaces.semiBold};
   font-weight: 500;
 `;
 

--- a/docs/components/base/typography.tsx
+++ b/docs/components/base/typography.tsx
@@ -1,10 +1,8 @@
 import { css } from '@emotion/react';
-import { theme } from '@expo/styleguide';
-
-import * as Constants from '~/constants/theme';
+import { theme, typography } from '@expo/styleguide';
 
 export const h1 = css`
-  font-family: ${Constants.fonts.bold};
+  font-family: ${typography.fontFaces.semiBold};
   color: ${theme.text.default};
   font-size: 48px;
   line-height: 120%;
@@ -13,7 +11,7 @@ export const h1 = css`
 `;
 
 export const h2 = css`
-  font-family: ${Constants.fonts.demi};
+  font-family: ${typography.fontFaces.medium};
   color: ${theme.text.default};
   font-size: 30px;
   line-height: 130%;
@@ -22,7 +20,7 @@ export const h2 = css`
 `;
 
 export const h3 = css`
-  font-family: ${Constants.fonts.demi};
+  font-family: ${typography.fontFaces.medium};
   color: ${theme.text.default};
   font-size: 24px;
   line-height: 130%;
@@ -31,7 +29,7 @@ export const h3 = css`
 `;
 
 export const h4 = css`
-  font-family: ${Constants.fonts.bold};
+  font-family: ${typography.fontFaces.semiBold};
   color: ${theme.text.default};
   font-size: 18px;
   line-height: 140%;
@@ -40,7 +38,7 @@ export const h4 = css`
 `;
 
 export const paragraph = css`
-  font-family: ${Constants.fontFamilies.book};
+  font-family: ${typography.fontFaces.regular};
   color: ${theme.text.default};
   font-weight: 400;
   font-size: 16px;

--- a/docs/components/plugins/CodeBlocksTable.tsx
+++ b/docs/components/plugins/CodeBlocksTable.tsx
@@ -1,8 +1,6 @@
 import { css } from '@emotion/react';
-import { theme } from '@expo/styleguide';
+import { theme, typography } from '@expo/styleguide';
 import * as React from 'react';
-
-import * as Constants from '~/constants/theme';
 
 const MDX_CLASS_NAME_TO_TAB_NAME: Record<string, string> = {
   'language-swift': 'Swift',
@@ -52,7 +50,7 @@ const CodeSamplesCSS = css`
 
     span {
       color: ${theme.text.default};
-      font-family: ${Constants.fonts.mono};
+      font-family: ${typography.fontFaces.mono};
       font-size: 15px;
     }
   }

--- a/docs/components/plugins/InstallSection.tsx
+++ b/docs/components/plugins/InstallSection.tsx
@@ -1,11 +1,9 @@
 import { css } from '@emotion/react';
-import { theme } from '@expo/styleguide';
+import { theme, typography } from '@expo/styleguide';
 import * as React from 'react';
 
 import DocumentationPageContext from '../DocumentationPageContext';
 import TerminalBlock from './TerminalBlock';
-
-import * as Constants from '~/constants/theme';
 
 const STYLES_P = css`
   line-height: 1.8rem;
@@ -15,7 +13,7 @@ const STYLES_P = css`
 `;
 
 const STYLES_BOLD = css`
-  font-family: ${Constants.fonts.demi};
+  font-family: ${typography.fontFaces.medium};
   font-weight: 400;
   text-decoration: none;
   color: ${theme.link.default};

--- a/docs/components/plugins/TerminalBlock.tsx
+++ b/docs/components/plugins/TerminalBlock.tsx
@@ -1,8 +1,6 @@
 import { css } from '@emotion/react';
-import { palette } from '@expo/styleguide';
+import { palette, typography } from '@expo/styleguide';
 import * as React from 'react';
-
-import * as Constants from '~/constants/theme';
 
 const STYLES_PROMPT = css`
   background-color: ${palette.light.black};
@@ -16,7 +14,7 @@ const STYLES_PROMPT = css`
 
 const STYLES_LINE = css`
   white-space: nowrap;
-  font-family: ${Constants.fontFamilies.mono};
+  font-family: ${typography.fontFaces.mono};
   font-size: 13px;
   color: ${palette.dark.gray[900]};
   line-height: 160%;
@@ -29,7 +27,7 @@ const STYLES_LINE = css`
 const STYLES_COMMENT = css`
   user-select: none;
   white-space: nowrap;
-  font-family: ${Constants.fontFamilies.mono};
+  font-family: ${typography.fontFaces.mono};
   font-size: 13px;
   color: ${palette.dark.gray[600]};
   line-height: 150%;

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`APISection expo-apple-authentication 1`] = `
 <div>
   <h2
-    class="css-1v5aebx-h2-h2-STYLES_H2"
+    class="css-et60wy-h2-h2-STYLES_H2"
     data-heading="true"
   >
     <div
@@ -55,7 +55,7 @@ exports[`APISection expo-apple-authentication 1`] = `
   </h2>
   <div>
     <h3
-      class="css-icxoph-h3-h3-STYLES_H3"
+      class="css-1fe5f89-h3-h3-STYLES_H3"
       data-heading="true"
     >
       <div
@@ -73,7 +73,7 @@ exports[`APISection expo-apple-authentication 1`] = `
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               AppleAuthenticationButton
             </code>
@@ -110,17 +110,17 @@ exports[`APISection expo-apple-authentication 1`] = `
       </div>
     </h3>
     <p
-      class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+      class="css-101h856-paragraph-STYLES_PARAGRAPH"
       data-text="true"
     >
       <strong
-        class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+        class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
       >
         Type:
       </strong>
        
       <code
-        class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+        class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
       >
         React.FC
         &lt;
@@ -136,7 +136,7 @@ exports[`APISection expo-apple-authentication 1`] = `
       </code>
     </p>
     <p
-      class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+      class="css-101h856-paragraph-STYLES_PARAGRAPH"
       data-text="true"
     >
       This component displays the proprietary "Sign In with Apple" / "Continue with Apple" button on
@@ -145,7 +145,7 @@ authentication process instead of a custom button. Limited customization of the 
 available via the provided properties.
     </p>
     <p
-      class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+      class="css-101h856-paragraph-STYLES_PARAGRAPH"
       data-text="true"
     >
       You should only attempt to render this if 
@@ -154,7 +154,7 @@ available via the provided properties.
         href="/#isavailableasync"
       >
         <code
-          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
         >
           AppleAuthentication.isAvailableAsync()
         </code>
@@ -162,14 +162,14 @@ available via the provided properties.
       
 resolves to 
       <code
-        class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+        class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
       >
         true
       </code>
       . This component will render nothing if it is not available, and you will get
 a warning in development mode (
       <code
-        class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+        class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
       >
         __DEV__ === true
       </code>
@@ -178,45 +178,45 @@ a warning in development mode (
     
 
     <p
-      class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+      class="css-101h856-paragraph-STYLES_PARAGRAPH"
       data-text="true"
     >
       The properties of this component extend from 
       <code
-        class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+        class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
       >
         View
       </code>
       ; however, you should not attempt to set
 
       <code
-        class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+        class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
       >
         backgroundColor
       </code>
        or 
       <code
-        class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+        class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
       >
         borderRadius
       </code>
        with the 
       <code
-        class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+        class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
       >
         style
       </code>
        property. This will not work and is against
 the App Store Guidelines. Instead, you should use the 
       <code
-        class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+        class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
       >
         buttonStyle
       </code>
        property to choose one of the
 predefined color styles and the 
       <code
-        class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+        class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
       >
         cornerRadius
       </code>
@@ -226,14 +226,14 @@ button.
     
 
     <p
-      class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+      class="css-101h856-paragraph-STYLES_PARAGRAPH"
       data-text="true"
     >
       Make sure to attach height and width via the style props as without these styles, the button will
 not appear on the screen.
     </p>
     <blockquote
-      class="css-e76wiv-paragraph-STYLES_BLOCKQUOTE"
+      class="css-1vk32i8-paragraph-STYLES_BLOCKQUOTE"
       data-text="true"
     >
       <div>
@@ -257,7 +257,7 @@ not appear on the screen.
       </div>
       <div>
         <strong
-          class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+          class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
         >
           See: 
         </strong>
@@ -276,7 +276,7 @@ for more details.
       </div>
     </blockquote>
     <h3
-      class="css-icxoph-h3-h3-STYLES_H3"
+      class="css-1fe5f89-h3-h3-STYLES_H3"
       data-heading="true"
     >
       <div
@@ -294,7 +294,7 @@ for more details.
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               AppleAuthenticationButtonProps
             </code>
@@ -333,14 +333,14 @@ for more details.
     <br />
     <div>
       <ul
-        class="css-1a9yu92-paragraph-STYLES_UNORDERED_LIST-UL"
+        class="css-1dmv26-paragraph-STYLES_UNORDERED_LIST-UL"
         data-text="true"
       >
         <li
           class="docs-list-item css-1jvmp7m-STYLES_LIST_ITEM-STYLE_PROP_LIST-PROP_LIST_ELEMENT_STYLE-LI"
         >
           <h4
-            class="  css-1j2s5xo-h4-h4-STYLES_H4"
+            class="  css-838f5l-h4-h4-STYLES_H4"
             data-components-heading="true"
             data-heading="true"
           >
@@ -392,7 +392,7 @@ for more details.
             </div>
           </h4>
           <p
-            class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+            class="css-101h856-paragraph-STYLES_PARAGRAPH"
             data-text="true"
           >
             <span
@@ -402,7 +402,7 @@ for more details.
             </span>
              
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               <a
                 class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -413,7 +413,7 @@ for more details.
             </code>
           </p>
           <p
-            class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+            class="css-101h856-paragraph-STYLES_PARAGRAPH"
             data-text="true"
           >
             The Apple-defined color scheme to use to display the button.
@@ -426,7 +426,7 @@ for more details.
           class="docs-list-item css-1jvmp7m-STYLES_LIST_ITEM-STYLE_PROP_LIST-PROP_LIST_ELEMENT_STYLE-LI"
         >
           <h4
-            class="  css-1j2s5xo-h4-h4-STYLES_H4"
+            class="  css-838f5l-h4-h4-STYLES_H4"
             data-components-heading="true"
             data-heading="true"
           >
@@ -478,7 +478,7 @@ for more details.
             </div>
           </h4>
           <p
-            class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+            class="css-101h856-paragraph-STYLES_PARAGRAPH"
             data-text="true"
           >
             <span
@@ -488,7 +488,7 @@ for more details.
             </span>
              
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               <a
                 class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -499,7 +499,7 @@ for more details.
             </code>
           </p>
           <p
-            class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+            class="css-101h856-paragraph-STYLES_PARAGRAPH"
             data-text="true"
           >
             The type of button text to display ("Sign In with Apple" vs. "Continue with Apple").
@@ -512,7 +512,7 @@ for more details.
           class="docs-list-item css-1jvmp7m-STYLES_LIST_ITEM-STYLE_PROP_LIST-PROP_LIST_ELEMENT_STYLE-LI"
         >
           <h4
-            class="  css-1j2s5xo-h4-h4-STYLES_H4"
+            class="  css-838f5l-h4-h4-STYLES_H4"
             data-components-heading="true"
             data-heading="true"
           >
@@ -564,7 +564,7 @@ for more details.
             </div>
           </h4>
           <p
-            class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+            class="css-101h856-paragraph-STYLES_PARAGRAPH"
             data-text="true"
           >
             <span
@@ -579,19 +579,19 @@ for more details.
             </span>
              
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               number
             </code>
           </p>
           <p
-            class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+            class="css-101h856-paragraph-STYLES_PARAGRAPH"
             data-text="true"
           >
             The border radius to use when rendering the button. This works similarly to
 
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               style.borderRadius
             </code>
@@ -605,7 +605,7 @@ for more details.
           class="docs-list-item css-1jvmp7m-STYLES_LIST_ITEM-STYLE_PROP_LIST-PROP_LIST_ELEMENT_STYLE-LI"
         >
           <h4
-            class="  css-1j2s5xo-h4-h4-STYLES_H4"
+            class="  css-838f5l-h4-h4-STYLES_H4"
             data-components-heading="true"
             data-heading="true"
           >
@@ -657,7 +657,7 @@ for more details.
             </div>
           </h4>
           <p
-            class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+            class="css-101h856-paragraph-STYLES_PARAGRAPH"
             data-text="true"
           >
             <span
@@ -672,7 +672,7 @@ for more details.
             </span>
              
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               StyleProp
               &lt;
@@ -709,18 +709,18 @@ for more details.
             </code>
           </p>
           <p
-            class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+            class="css-101h856-paragraph-STYLES_PARAGRAPH"
             data-text="true"
           >
             The custom style to apply to the button. Should not include 
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               backgroundColor
             </code>
              or 
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               borderRadius
             </code>
@@ -735,7 +735,7 @@ properties.
           class="docs-list-item css-1jvmp7m-STYLES_LIST_ITEM-STYLE_PROP_LIST-PROP_LIST_ELEMENT_STYLE-LI"
         >
           <h4
-            class="  css-1j2s5xo-h4-h4-STYLES_H4"
+            class="  css-838f5l-h4-h4-STYLES_H4"
             data-components-heading="true"
             data-heading="true"
           >
@@ -787,7 +787,7 @@ properties.
             </div>
           </h4>
           <p
-            class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+            class="css-101h856-paragraph-STYLES_PARAGRAPH"
             data-text="true"
           >
             <span
@@ -797,7 +797,7 @@ properties.
             </span>
              
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               (
               
@@ -806,7 +806,7 @@ properties.
             </code>
           </p>
           <p
-            class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+            class="css-101h856-paragraph-STYLES_PARAGRAPH"
             data-text="true"
           >
             The method to call when the user presses the button. You should call 
@@ -815,7 +815,7 @@ properties.
               href="/#isavailableasync"
             >
               <code
-                class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+                class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
               >
                 AppleAuthentication.signInAsync
               </code>
@@ -829,7 +829,7 @@ in here.
         </li>
       </ul>
       <h4
-        class="  css-1j2s5xo-h4-h4-STYLES_H4"
+        class="  css-838f5l-h4-h4-STYLES_H4"
         data-components-heading="true"
         data-heading="true"
       >
@@ -881,14 +881,14 @@ in here.
         </div>
       </h4>
       <ul
-        class="css-1a9yu92-paragraph-STYLES_UNORDERED_LIST-UL"
+        class="css-1dmv26-paragraph-STYLES_UNORDERED_LIST-UL"
         data-text="true"
       >
         <li
           class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
         >
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             <a
               class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -902,7 +902,7 @@ in here.
     </div>
   </div>
   <h2
-    class="css-1v5aebx-h2-h2-STYLES_H2"
+    class="css-et60wy-h2-h2-STYLES_H2"
     data-heading="true"
   >
     <div
@@ -954,7 +954,7 @@ in here.
   </h2>
   <div>
     <h3
-      class="css-icxoph-h3-h3-STYLES_H3"
+      class="css-1fe5f89-h3-h3-STYLES_H3"
       data-heading="true"
     >
       <div
@@ -972,7 +972,7 @@ in here.
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               getCredentialStateAsync(user)
             </code>
@@ -1009,7 +1009,7 @@ in here.
       </div>
     </h3>
     <h4
-      class="  css-1j2s5xo-h4-h4-STYLES_H4"
+      class="  css-838f5l-h4-h4-STYLES_H4"
       data-components-heading="true"
       data-heading="true"
     >
@@ -1061,19 +1061,19 @@ in here.
       </div>
     </h4>
     <ul
-      class="css-1a9yu92-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1dmv26-paragraph-STYLES_UNORDERED_LIST-UL"
       data-text="true"
     >
       <li
         class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
       >
         <strong
-          class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+          class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
         >
           user
            (
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             string
           </code>
@@ -1088,7 +1088,7 @@ This should come from the user field of an
             href="/#appleauthenticationcredentialstate"
           >
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               AppleAuthenticationCredential
             </code>
@@ -1098,7 +1098,7 @@ This should come from the user field of an
       </li>
     </ul>
     <p
-      class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+      class="css-101h856-paragraph-STYLES_PARAGRAPH"
       data-text="true"
     >
       Queries the current state of a user credential, to determine if it is still valid or if it has been revoked.
@@ -1106,7 +1106,7 @@ This should come from the user field of an
     
 
     <blockquote
-      class="css-e76wiv-paragraph-STYLES_BLOCKQUOTE"
+      class="css-1vk32i8-paragraph-STYLES_BLOCKQUOTE"
       data-text="true"
     >
       <div>
@@ -1132,7 +1132,7 @@ This should come from the user field of an
         
 
         <strong
-          class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+          class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
         >
           Note:
         </strong>
@@ -1143,7 +1143,7 @@ This should come from the user field of an
     </blockquote>
     <div>
       <h4
-        class="  css-1j2s5xo-h4-h4-STYLES_H4"
+        class="  css-838f5l-h4-h4-STYLES_H4"
         data-components-heading="true"
         data-heading="true"
       >
@@ -1195,14 +1195,14 @@ This should come from the user field of an
         </div>
       </h4>
       <ul
-        class="css-1a9yu92-paragraph-STYLES_UNORDERED_LIST-UL"
+        class="css-1dmv26-paragraph-STYLES_UNORDERED_LIST-UL"
         data-text="true"
       >
         <li
           class="docs-list-item css-1wwpkbk-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
         >
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             <a
               class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -1225,7 +1225,7 @@ This should come from the user field of an
         </li>
       </ul>
       <p
-        class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+        class="css-101h856-paragraph-STYLES_PARAGRAPH"
         data-text="true"
       >
         A promise that fulfills with an 
@@ -1234,7 +1234,7 @@ This should come from the user field of an
           href="/#appleauthenticationcredentialstate"
         >
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             AppleAuthenticationCredentialState
           </code>
@@ -1247,7 +1247,7 @@ value depending on the state of the credential.
   </div>
   <div>
     <h3
-      class="css-icxoph-h3-h3-STYLES_H3"
+      class="css-1fe5f89-h3-h3-STYLES_H3"
       data-heading="true"
     >
       <div
@@ -1265,7 +1265,7 @@ value depending on the state of the credential.
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               isAvailableAsync()
             </code>
@@ -1302,14 +1302,14 @@ value depending on the state of the credential.
       </div>
     </h3>
     <p
-      class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+      class="css-101h856-paragraph-STYLES_PARAGRAPH"
       data-text="true"
     >
       Determine if the current device's operating system supports Apple authentication.
     </p>
     <div>
       <h4
-        class="  css-1j2s5xo-h4-h4-STYLES_H4"
+        class="  css-838f5l-h4-h4-STYLES_H4"
         data-components-heading="true"
         data-heading="true"
       >
@@ -1361,14 +1361,14 @@ value depending on the state of the credential.
         </div>
       </h4>
       <ul
-        class="css-1a9yu92-paragraph-STYLES_UNORDERED_LIST-UL"
+        class="css-1dmv26-paragraph-STYLES_UNORDERED_LIST-UL"
         data-text="true"
       >
         <li
           class="docs-list-item css-1wwpkbk-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
         >
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             <a
               class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -1386,18 +1386,18 @@ value depending on the state of the credential.
         </li>
       </ul>
       <p
-        class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+        class="css-101h856-paragraph-STYLES_PARAGRAPH"
         data-text="true"
       >
         A promise that fulfills with 
         <code
-          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
         >
           true
         </code>
          if the system supports Apple authentication, and 
         <code
-          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
         >
           false
         </code>
@@ -1408,7 +1408,7 @@ value depending on the state of the credential.
   </div>
   <div>
     <h3
-      class="css-icxoph-h3-h3-STYLES_H3"
+      class="css-1fe5f89-h3-h3-STYLES_H3"
       data-heading="true"
     >
       <div
@@ -1426,7 +1426,7 @@ value depending on the state of the credential.
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               refreshAsync(options)
             </code>
@@ -1463,7 +1463,7 @@ value depending on the state of the credential.
       </div>
     </h3>
     <h4
-      class="  css-1j2s5xo-h4-h4-STYLES_H4"
+      class="  css-838f5l-h4-h4-STYLES_H4"
       data-components-heading="true"
       data-heading="true"
     >
@@ -1515,19 +1515,19 @@ value depending on the state of the credential.
       </div>
     </h4>
     <ul
-      class="css-1a9yu92-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1dmv26-paragraph-STYLES_UNORDERED_LIST-UL"
       data-text="true"
     >
       <li
         class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
       >
         <strong
-          class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+          class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
         >
           options
            (
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             <a
               class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -1546,7 +1546,7 @@ value depending on the state of the credential.
             href="/#appleauthenticationrefreshoptions"
           >
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               AppleAuthenticationRefreshOptions
             </code>
@@ -1556,7 +1556,7 @@ value depending on the state of the credential.
       </li>
     </ul>
     <p
-      class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+      class="css-101h856-paragraph-STYLES_PARAGRAPH"
       data-text="true"
     >
       An operation that refreshes the logged-in user’s credentials.
@@ -1564,7 +1564,7 @@ Calling this method will show the sign in modal before actually refreshing the u
     </p>
     <div>
       <h4
-        class="  css-1j2s5xo-h4-h4-STYLES_H4"
+        class="  css-838f5l-h4-h4-STYLES_H4"
         data-components-heading="true"
         data-heading="true"
       >
@@ -1616,14 +1616,14 @@ Calling this method will show the sign in modal before actually refreshing the u
         </div>
       </h4>
       <ul
-        class="css-1a9yu92-paragraph-STYLES_UNORDERED_LIST-UL"
+        class="css-1dmv26-paragraph-STYLES_UNORDERED_LIST-UL"
         data-text="true"
       >
         <li
           class="docs-list-item css-1wwpkbk-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
         >
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             <a
               class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -1646,7 +1646,7 @@ Calling this method will show the sign in modal before actually refreshing the u
         </li>
       </ul>
       <p
-        class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+        class="css-101h856-paragraph-STYLES_PARAGRAPH"
         data-text="true"
       >
         A promise that fulfills with an 
@@ -1655,7 +1655,7 @@ Calling this method will show the sign in modal before actually refreshing the u
           href="/#appleauthenticationcredential"
         >
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             AppleAuthenticationCredential
           </code>
@@ -1663,7 +1663,7 @@ Calling this method will show the sign in modal before actually refreshing the u
         
 object after a successful authentication, and rejects with 
         <code
-          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
         >
           ERR_CANCELED
         </code>
@@ -1675,7 +1675,7 @@ refresh operation.
   </div>
   <div>
     <h3
-      class="css-icxoph-h3-h3-STYLES_H3"
+      class="css-1fe5f89-h3-h3-STYLES_H3"
       data-heading="true"
     >
       <div
@@ -1693,7 +1693,7 @@ refresh operation.
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               signInAsync(options)
             </code>
@@ -1730,7 +1730,7 @@ refresh operation.
       </div>
     </h3>
     <h4
-      class="  css-1j2s5xo-h4-h4-STYLES_H4"
+      class="  css-838f5l-h4-h4-STYLES_H4"
       data-components-heading="true"
       data-heading="true"
     >
@@ -1782,20 +1782,20 @@ refresh operation.
       </div>
     </h4>
     <ul
-      class="css-1a9yu92-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1dmv26-paragraph-STYLES_UNORDERED_LIST-UL"
       data-text="true"
     >
       <li
         class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
       >
         <strong
-          class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+          class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
         >
           options
           ?
            (
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             <a
               class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -1814,7 +1814,7 @@ refresh operation.
             href="/#appleauthenticationsigninoptions"
           >
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               AppleAuthenticationSignInOptions
             </code>
@@ -1824,14 +1824,14 @@ refresh operation.
       </li>
     </ul>
     <p
-      class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+      class="css-101h856-paragraph-STYLES_PARAGRAPH"
       data-text="true"
     >
       Sends a request to the operating system to initiate the Apple authentication flow, which will
 present a modal to the user over your app and allow them to sign in.
     </p>
     <p
-      class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+      class="css-101h856-paragraph-STYLES_PARAGRAPH"
       data-text="true"
     >
       You can request access to the user's full name and email address in this method, which allows you
@@ -1841,7 +1841,7 @@ of these options at runtime.
     
 
     <p
-      class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+      class="css-101h856-paragraph-STYLES_PARAGRAPH"
       data-text="true"
     >
       Additionally, you will only receive Apple Authentication Credentials the first time users sign
@@ -1860,7 +1860,7 @@ You can use
         href="/#appleauthenticationcredential"
       >
         <code
-          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
         >
           AppleAuthenticationCredential.user
         </code>
@@ -1870,7 +1870,7 @@ the user, since this remains the same for apps released by the same developer.
     </p>
     <div>
       <h4
-        class="  css-1j2s5xo-h4-h4-STYLES_H4"
+        class="  css-838f5l-h4-h4-STYLES_H4"
         data-components-heading="true"
         data-heading="true"
       >
@@ -1922,14 +1922,14 @@ the user, since this remains the same for apps released by the same developer.
         </div>
       </h4>
       <ul
-        class="css-1a9yu92-paragraph-STYLES_UNORDERED_LIST-UL"
+        class="css-1dmv26-paragraph-STYLES_UNORDERED_LIST-UL"
         data-text="true"
       >
         <li
           class="docs-list-item css-1wwpkbk-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
         >
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             <a
               class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -1952,7 +1952,7 @@ the user, since this remains the same for apps released by the same developer.
         </li>
       </ul>
       <p
-        class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+        class="css-101h856-paragraph-STYLES_PARAGRAPH"
         data-text="true"
       >
         A promise that fulfills with an 
@@ -1961,7 +1961,7 @@ the user, since this remains the same for apps released by the same developer.
           href="/#appleauthenticationcredential"
         >
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             AppleAuthenticationCredential
           </code>
@@ -1969,7 +1969,7 @@ the user, since this remains the same for apps released by the same developer.
         
 object after a successful authentication, and rejects with 
         <code
-          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
         >
           ERR_CANCELED
         </code>
@@ -1981,7 +1981,7 @@ sign-in operation.
   </div>
   <div>
     <h3
-      class="css-icxoph-h3-h3-STYLES_H3"
+      class="css-1fe5f89-h3-h3-STYLES_H3"
       data-heading="true"
     >
       <div
@@ -1999,7 +1999,7 @@ sign-in operation.
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               signOutAsync(options)
             </code>
@@ -2036,7 +2036,7 @@ sign-in operation.
       </div>
     </h3>
     <h4
-      class="  css-1j2s5xo-h4-h4-STYLES_H4"
+      class="  css-838f5l-h4-h4-STYLES_H4"
       data-components-heading="true"
       data-heading="true"
     >
@@ -2088,19 +2088,19 @@ sign-in operation.
       </div>
     </h4>
     <ul
-      class="css-1a9yu92-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1dmv26-paragraph-STYLES_UNORDERED_LIST-UL"
       data-text="true"
     >
       <li
         class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
       >
         <strong
-          class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+          class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
         >
           options
            (
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             <a
               class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -2119,7 +2119,7 @@ sign-in operation.
             href="/#appleauthenticationsignoutoptions"
           >
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               AppleAuthenticationSignOutOptions
             </code>
@@ -2129,14 +2129,14 @@ sign-in operation.
       </li>
     </ul>
     <p
-      class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+      class="css-101h856-paragraph-STYLES_PARAGRAPH"
       data-text="true"
     >
       An operation that ends the authenticated session.
 Calling this method will show the sign in modal before actually signing the user out.
     </p>
     <p
-      class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+      class="css-101h856-paragraph-STYLES_PARAGRAPH"
       data-text="true"
     >
       It is not recommended to use this method to sign out the user as it works counterintuitively.
@@ -2147,7 +2147,7 @@ from using
         href="/#signinasync"
       >
         <code
-          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
         >
           signInAsync
         </code>
@@ -2158,7 +2158,7 @@ from using
         href="/#refreshasync"
       >
         <code
-          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
         >
           refreshAsync
         </code>
@@ -2167,7 +2167,7 @@ from using
     </p>
     <div>
       <h4
-        class="  css-1j2s5xo-h4-h4-STYLES_H4"
+        class="  css-838f5l-h4-h4-STYLES_H4"
         data-components-heading="true"
         data-heading="true"
       >
@@ -2219,14 +2219,14 @@ from using
         </div>
       </h4>
       <ul
-        class="css-1a9yu92-paragraph-STYLES_UNORDERED_LIST-UL"
+        class="css-1dmv26-paragraph-STYLES_UNORDERED_LIST-UL"
         data-text="true"
       >
         <li
           class="docs-list-item css-1wwpkbk-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
         >
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             <a
               class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -2249,7 +2249,7 @@ from using
         </li>
       </ul>
       <p
-        class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+        class="css-101h856-paragraph-STYLES_PARAGRAPH"
         data-text="true"
       >
         A promise that fulfills with an 
@@ -2258,7 +2258,7 @@ from using
           href="/#appleauthenticationcredential"
         >
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             AppleAuthenticationCredential
           </code>
@@ -2266,7 +2266,7 @@ from using
         
 object after a successful authentication, and rejects with 
         <code
-          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
         >
           ERR_CANCELED
         </code>
@@ -2276,7 +2276,7 @@ sign-out operation.
     </div>
   </div>
   <h2
-    class="css-1v5aebx-h2-h2-STYLES_H2"
+    class="css-et60wy-h2-h2-STYLES_H2"
     data-heading="true"
   >
     <div
@@ -2328,7 +2328,7 @@ sign-out operation.
   </h2>
   <div>
     <h3
-      class="css-icxoph-h3-h3-STYLES_H3"
+      class="css-1fe5f89-h3-h3-STYLES_H3"
       data-heading="true"
     >
       <div
@@ -2346,7 +2346,7 @@ sign-out operation.
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               addRevokeListener(listener)
             </code>
@@ -2383,7 +2383,7 @@ sign-out operation.
       </div>
     </h3>
     <h4
-      class="  css-1j2s5xo-h4-h4-STYLES_H4"
+      class="  css-838f5l-h4-h4-STYLES_H4"
       data-components-heading="true"
       data-heading="true"
     >
@@ -2435,19 +2435,19 @@ sign-out operation.
       </div>
     </h4>
     <ul
-      class="css-1a9yu92-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1dmv26-paragraph-STYLES_UNORDERED_LIST-UL"
       data-text="true"
     >
       <li
         class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
       >
         <strong
-          class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+          class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
         >
           listener
            (
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             () =&gt;
              
@@ -2459,7 +2459,7 @@ sign-out operation.
     </ul>
     <div>
       <h4
-        class="  css-1j2s5xo-h4-h4-STYLES_H4"
+        class="  css-838f5l-h4-h4-STYLES_H4"
         data-components-heading="true"
         data-heading="true"
       >
@@ -2511,14 +2511,14 @@ sign-out operation.
         </div>
       </h4>
       <ul
-        class="css-1a9yu92-paragraph-STYLES_UNORDERED_LIST-UL"
+        class="css-1dmv26-paragraph-STYLES_UNORDERED_LIST-UL"
         data-text="true"
       >
         <li
           class="docs-list-item css-1wwpkbk-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
         >
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             <a
               class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -2532,7 +2532,7 @@ sign-out operation.
     </div>
   </div>
   <h2
-    class="css-1v5aebx-h2-h2-STYLES_H2"
+    class="css-et60wy-h2-h2-STYLES_H2"
     data-heading="true"
   >
     <div
@@ -2584,7 +2584,7 @@ sign-out operation.
   </h2>
   <div>
     <h3
-      class="css-icxoph-h3-h3-STYLES_H3"
+      class="css-1fe5f89-h3-h3-STYLES_H3"
       data-heading="true"
     >
       <div
@@ -2602,7 +2602,7 @@ sign-out operation.
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               AppleAuthenticationCredential
               
@@ -2640,7 +2640,7 @@ sign-out operation.
       </div>
     </h3>
     <p
-      class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+      class="css-101h856-paragraph-STYLES_PARAGRAPH"
       data-text="true"
     >
       The object type returned from a successful call to 
@@ -2649,7 +2649,7 @@ sign-out operation.
         href="/#appleauthenticationsigninasyncoptions"
       >
         <code
-          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
         >
           AppleAuthentication.signInAsync()
         </code>
@@ -2661,7 +2661,7 @@ sign-out operation.
         href="/#appleauthenticationrefreshasyncoptions"
       >
         <code
-          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
         >
           AppleAuthentication.refreshAsync()
         </code>
@@ -2672,7 +2672,7 @@ sign-out operation.
         href="/#appleauthenticationsignoutasyncoptions"
       >
         <code
-          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
         >
           AppleAuthentication.signOutAsync()
         </code>
@@ -2681,7 +2681,7 @@ sign-out operation.
 which contains all of the pertinent user and credential information.
     </p>
     <blockquote
-      class="css-e76wiv-paragraph-STYLES_BLOCKQUOTE"
+      class="css-1vk32i8-paragraph-STYLES_BLOCKQUOTE"
       data-text="true"
     >
       <div>
@@ -2705,7 +2705,7 @@ which contains all of the pertinent user and credential information.
       </div>
       <div>
         <strong
-          class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+          class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
         >
           See: 
         </strong>
@@ -2741,14 +2741,14 @@ for more details.
         <tr>
           <td>
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               authorizationCode
             </strong>
           </td>
           <td>
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               <span>
                 string
@@ -2764,7 +2764,7 @@ for more details.
               A short-lived session token used by your app for proof of authorization when interacting with
 the app's server counterpart. Unlike 
               <code
-                class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+                class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
               >
                 user
               </code>
@@ -2775,14 +2775,14 @@ the app's server counterpart. Unlike
         <tr>
           <td>
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               email
             </strong>
           </td>
           <td>
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               <span>
                 string
@@ -2797,7 +2797,7 @@ the app's server counterpart. Unlike
             <span>
               The user's email address. Might not be present if you didn't request the 
               <code
-                class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+                class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
               >
                 EMAIL
               </code>
@@ -2811,14 +2811,14 @@ an Apple domain.
         <tr>
           <td>
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               fullName
             </strong>
           </td>
           <td>
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               <span>
                 <a
@@ -2838,19 +2838,19 @@ an Apple domain.
             <span>
               The user's name. May be 
               <code
-                class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+                class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
               >
                 null
               </code>
                or contain 
               <code
-                class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+                class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
               >
                 null
               </code>
                values if you didn't request the 
               <code
-                class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+                class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
               >
                 FULL_NAME
               </code>
@@ -2863,14 +2863,14 @@ your app.
         <tr>
           <td>
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               identityToken
             </strong>
           </td>
           <td>
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               <span>
                 string
@@ -2890,14 +2890,14 @@ your app.
         <tr>
           <td>
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               realUserStatus
             </strong>
           </td>
           <td>
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               <a
                 class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -2916,14 +2916,14 @@ your app.
         <tr>
           <td>
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               state
             </strong>
           </td>
           <td>
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               <span>
                 string
@@ -2938,7 +2938,7 @@ your app.
             <span>
               An arbitrary string that your app provided as 
               <code
-                class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+                class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
               >
                 state
               </code>
@@ -2946,14 +2946,14 @@ your app.
 credential. Used to verify that the response was from the request you made. Can be used to
 avoid replay attacks. If you did not provide 
               <code
-                class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+                class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
               >
                 state
               </code>
                when making the sign-in request, this field
 will be 
               <code
-                class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+                class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
               >
                 null
               </code>
@@ -2964,14 +2964,14 @@ will be
         <tr>
           <td>
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               user
             </strong>
           </td>
           <td>
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               string
             </code>
@@ -2990,7 +2990,7 @@ developers.
   </div>
   <div>
     <h3
-      class="css-icxoph-h3-h3-STYLES_H3"
+      class="css-1fe5f89-h3-h3-STYLES_H3"
       data-heading="true"
     >
       <div
@@ -3008,7 +3008,7 @@ developers.
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               AppleAuthenticationFullName
               
@@ -3046,13 +3046,13 @@ developers.
       </div>
     </h3>
     <p
-      class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+      class="css-101h856-paragraph-STYLES_PARAGRAPH"
       data-text="true"
     >
       An object representing the tokenized portions of the user's full name. Any of all of the fields
 may be 
       <code
-        class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+        class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
       >
         null
       </code>
@@ -3076,14 +3076,14 @@ may be
         <tr>
           <td>
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               familyName
             </strong>
           </td>
           <td>
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               <span>
                 string
@@ -3101,14 +3101,14 @@ may be
         <tr>
           <td>
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               givenName
             </strong>
           </td>
           <td>
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               <span>
                 string
@@ -3126,14 +3126,14 @@ may be
         <tr>
           <td>
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               middleName
             </strong>
           </td>
           <td>
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               <span>
                 string
@@ -3151,14 +3151,14 @@ may be
         <tr>
           <td>
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               namePrefix
             </strong>
           </td>
           <td>
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               <span>
                 string
@@ -3176,14 +3176,14 @@ may be
         <tr>
           <td>
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               nameSuffix
             </strong>
           </td>
           <td>
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               <span>
                 string
@@ -3201,14 +3201,14 @@ may be
         <tr>
           <td>
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               nickname
             </strong>
           </td>
           <td>
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               <span>
                 string
@@ -3228,7 +3228,7 @@ may be
   </div>
   <div>
     <h3
-      class="css-icxoph-h3-h3-STYLES_H3"
+      class="css-1fe5f89-h3-h3-STYLES_H3"
       data-heading="true"
     >
       <div
@@ -3246,7 +3246,7 @@ may be
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               AppleAuthenticationRefreshOptions
               
@@ -3284,7 +3284,7 @@ may be
       </div>
     </h3>
     <p
-      class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+      class="css-101h856-paragraph-STYLES_PARAGRAPH"
       data-text="true"
     >
       The options you can supply when making a call to 
@@ -3293,7 +3293,7 @@ may be
         href="/#appleauthenticationrefreshasyncoptions"
       >
         <code
-          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
         >
           AppleAuthentication.refreshAsync()
         </code>
@@ -3302,7 +3302,7 @@ may be
 You must include the ID string of the user whose credentials you'd like to refresh.
     </p>
     <blockquote
-      class="css-e76wiv-paragraph-STYLES_BLOCKQUOTE"
+      class="css-1vk32i8-paragraph-STYLES_BLOCKQUOTE"
       data-text="true"
     >
       <div>
@@ -3326,7 +3326,7 @@ You must include the ID string of the user whose credentials you'd like to refre
       </div>
       <div>
         <strong
-          class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+          class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
         >
           See: 
         </strong>
@@ -3362,7 +3362,7 @@ for more details.
         <tr>
           <td>
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               requestedScopes
             </strong>
@@ -3375,7 +3375,7 @@ for more details.
           </td>
           <td>
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               <a
                 class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -3392,7 +3392,7 @@ for more details.
 choose to deny your app access to any scope at the time of logging in. You will still need to
 handle 
               <code
-                class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+                class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
               >
                 null
               </code>
@@ -3400,13 +3400,13 @@ handle
 will only be provided to you the first time each user signs into your app; in subsequent
 requests they will be 
               <code
-                class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+                class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
               >
                 null
               </code>
               . Defaults to 
               <code
-                class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+                class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
               >
                 []
               </code>
@@ -3417,7 +3417,7 @@ requests they will be
         <tr>
           <td>
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               state
             </strong>
@@ -3430,7 +3430,7 @@ requests they will be
           </td>
           <td>
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               string
             </code>
@@ -3455,14 +3455,14 @@ OAuth 2.0 protocol
         <tr>
           <td>
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               user
             </strong>
           </td>
           <td>
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               string
             </code>
@@ -3476,7 +3476,7 @@ OAuth 2.0 protocol
   </div>
   <div>
     <h3
-      class="css-icxoph-h3-h3-STYLES_H3"
+      class="css-1fe5f89-h3-h3-STYLES_H3"
       data-heading="true"
     >
       <div
@@ -3494,7 +3494,7 @@ OAuth 2.0 protocol
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               AppleAuthenticationSignInOptions
               
@@ -3532,7 +3532,7 @@ OAuth 2.0 protocol
       </div>
     </h3>
     <p
-      class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+      class="css-101h856-paragraph-STYLES_PARAGRAPH"
       data-text="true"
     >
       The options you can supply when making a call to 
@@ -3541,7 +3541,7 @@ OAuth 2.0 protocol
         href="/#appleauthenticationsigninasyncoptions"
       >
         <code
-          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
         >
           AppleAuthentication.signInAsync()
         </code>
@@ -3550,7 +3550,7 @@ OAuth 2.0 protocol
 None of these options are required.
     </p>
     <blockquote
-      class="css-e76wiv-paragraph-STYLES_BLOCKQUOTE"
+      class="css-1vk32i8-paragraph-STYLES_BLOCKQUOTE"
       data-text="true"
     >
       <div>
@@ -3574,7 +3574,7 @@ None of these options are required.
       </div>
       <div>
         <strong
-          class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+          class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
         >
           See: 
         </strong>
@@ -3610,7 +3610,7 @@ for more details.
         <tr>
           <td>
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               nonce
             </strong>
@@ -3623,7 +3623,7 @@ for more details.
           </td>
           <td>
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               string
             </code>
@@ -3646,7 +3646,7 @@ for more details.
         <tr>
           <td>
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               requestedScopes
             </strong>
@@ -3659,7 +3659,7 @@ for more details.
           </td>
           <td>
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               <a
                 class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -3676,7 +3676,7 @@ for more details.
 choose to deny your app access to any scope at the time of logging in. You will still need to
 handle 
               <code
-                class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+                class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
               >
                 null
               </code>
@@ -3684,13 +3684,13 @@ handle
 will only be provided to you the first time each user signs into your app; in subsequent
 requests they will be 
               <code
-                class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+                class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
               >
                 null
               </code>
               . Defaults to 
               <code
-                class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+                class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
               >
                 []
               </code>
@@ -3701,7 +3701,7 @@ requests they will be
         <tr>
           <td>
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               state
             </strong>
@@ -3714,7 +3714,7 @@ requests they will be
           </td>
           <td>
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               string
             </code>
@@ -3741,7 +3741,7 @@ OAuth 2.0 protocol
   </div>
   <div>
     <h3
-      class="css-icxoph-h3-h3-STYLES_H3"
+      class="css-1fe5f89-h3-h3-STYLES_H3"
       data-heading="true"
     >
       <div
@@ -3759,7 +3759,7 @@ OAuth 2.0 protocol
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               AppleAuthenticationSignOutOptions
               
@@ -3797,7 +3797,7 @@ OAuth 2.0 protocol
       </div>
     </h3>
     <p
-      class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+      class="css-101h856-paragraph-STYLES_PARAGRAPH"
       data-text="true"
     >
       The options you can supply when making a call to 
@@ -3806,7 +3806,7 @@ OAuth 2.0 protocol
         href="/#appleauthenticationsignoutasyncoptions"
       >
         <code
-          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
         >
           AppleAuthentication.signOutAsync()
         </code>
@@ -3815,7 +3815,7 @@ OAuth 2.0 protocol
 You must include the ID string of the user to sign out.
     </p>
     <blockquote
-      class="css-e76wiv-paragraph-STYLES_BLOCKQUOTE"
+      class="css-1vk32i8-paragraph-STYLES_BLOCKQUOTE"
       data-text="true"
     >
       <div>
@@ -3839,7 +3839,7 @@ You must include the ID string of the user to sign out.
       </div>
       <div>
         <strong
-          class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+          class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
         >
           See: 
         </strong>
@@ -3875,7 +3875,7 @@ for more details.
         <tr>
           <td>
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               state
             </strong>
@@ -3888,7 +3888,7 @@ for more details.
           </td>
           <td>
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               string
             </code>
@@ -3913,14 +3913,14 @@ OAuth 2.0 protocol
         <tr>
           <td>
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               user
             </strong>
           </td>
           <td>
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               string
             </code>
@@ -3934,7 +3934,7 @@ OAuth 2.0 protocol
   </div>
   <div>
     <h3
-      class="css-icxoph-h3-h3-STYLES_H3"
+      class="css-1fe5f89-h3-h3-STYLES_H3"
       data-heading="true"
     >
       <div
@@ -3952,7 +3952,7 @@ OAuth 2.0 protocol
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               Subscription
               
@@ -4007,14 +4007,14 @@ OAuth 2.0 protocol
         <tr>
           <td>
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               remove
             </strong>
           </td>
           <td>
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               (
               
@@ -4032,7 +4032,7 @@ OAuth 2.0 protocol
     </table>
   </div>
   <h2
-    class="css-1v5aebx-h2-h2-STYLES_H2"
+    class="css-et60wy-h2-h2-STYLES_H2"
     data-heading="true"
   >
     <div
@@ -4084,7 +4084,7 @@ OAuth 2.0 protocol
   </h2>
   <div>
     <h3
-      class="css-icxoph-h3-h3-STYLES_H3"
+      class="css-1fe5f89-h3-h3-STYLES_H3"
       data-heading="true"
     >
       <div
@@ -4102,7 +4102,7 @@ OAuth 2.0 protocol
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               AppleAuthenticationButtonStyle
             </code>
@@ -4139,7 +4139,7 @@ OAuth 2.0 protocol
       </div>
     </h3>
     <p
-      class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+      class="css-101h856-paragraph-STYLES_PARAGRAPH"
       data-text="true"
     >
       An enum whose values control which pre-defined color scheme to use when rendering an 
@@ -4148,7 +4148,7 @@ OAuth 2.0 protocol
         href="/#appleauthenticationappleauthenticationbutton"
       >
         <code
-          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
         >
           AppleAuthenticationButton
         </code>
@@ -4156,7 +4156,7 @@ OAuth 2.0 protocol
       .
     </p>
     <ul
-      class="css-1a9yu92-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1dmv26-paragraph-STYLES_UNORDERED_LIST-UL"
       data-text="true"
     >
       <li
@@ -4166,7 +4166,7 @@ OAuth 2.0 protocol
           class="css-1aaoyoh-renderEnum"
         >
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             WHITE
           </code>
@@ -4177,7 +4177,7 @@ OAuth 2.0 protocol
         </span>
         <br />
         <code
-          class="inline css-1nolcer-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
+          class="inline css-mcdrx3-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
         >
           AppleAuthenticationButtonStyle
           .
@@ -4193,7 +4193,7 @@ OAuth 2.0 protocol
           class="css-1aaoyoh-renderEnum"
         >
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             WHITE_OUTLINE
           </code>
@@ -4204,7 +4204,7 @@ OAuth 2.0 protocol
         </span>
         <br />
         <code
-          class="inline css-1nolcer-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
+          class="inline css-mcdrx3-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
         >
           AppleAuthenticationButtonStyle
           .
@@ -4220,7 +4220,7 @@ OAuth 2.0 protocol
           class="css-1aaoyoh-renderEnum"
         >
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             BLACK
           </code>
@@ -4231,7 +4231,7 @@ OAuth 2.0 protocol
         </span>
         <br />
         <code
-          class="inline css-1nolcer-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
+          class="inline css-mcdrx3-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
         >
           AppleAuthenticationButtonStyle
           .
@@ -4244,7 +4244,7 @@ OAuth 2.0 protocol
   </div>
   <div>
     <h3
-      class="css-icxoph-h3-h3-STYLES_H3"
+      class="css-1fe5f89-h3-h3-STYLES_H3"
       data-heading="true"
     >
       <div
@@ -4262,7 +4262,7 @@ OAuth 2.0 protocol
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               AppleAuthenticationButtonType
             </code>
@@ -4299,7 +4299,7 @@ OAuth 2.0 protocol
       </div>
     </h3>
     <p
-      class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+      class="css-101h856-paragraph-STYLES_PARAGRAPH"
       data-text="true"
     >
       An enum whose values control which pre-defined text to use when rendering an 
@@ -4308,7 +4308,7 @@ OAuth 2.0 protocol
         href="/#appleauthenticationappleauthenticationbutton"
       >
         <code
-          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
         >
           AppleAuthenticationButton
         </code>
@@ -4316,7 +4316,7 @@ OAuth 2.0 protocol
       .
     </p>
     <ul
-      class="css-1a9yu92-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1dmv26-paragraph-STYLES_UNORDERED_LIST-UL"
       data-text="true"
     >
       <li
@@ -4326,7 +4326,7 @@ OAuth 2.0 protocol
           class="css-1aaoyoh-renderEnum"
         >
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             SIGN_IN
           </code>
@@ -4337,7 +4337,7 @@ OAuth 2.0 protocol
         </span>
         <br />
         <code
-          class="inline css-1nolcer-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
+          class="inline css-mcdrx3-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
         >
           AppleAuthenticationButtonType
           .
@@ -4353,7 +4353,7 @@ OAuth 2.0 protocol
           class="css-1aaoyoh-renderEnum"
         >
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             CONTINUE
           </code>
@@ -4364,7 +4364,7 @@ OAuth 2.0 protocol
         </span>
         <br />
         <code
-          class="inline css-1nolcer-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
+          class="inline css-mcdrx3-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
         >
           AppleAuthenticationButtonType
           .
@@ -4380,7 +4380,7 @@ OAuth 2.0 protocol
           class="css-1aaoyoh-renderEnum"
         >
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             SIGN_UP
           </code>
@@ -4394,7 +4394,7 @@ OAuth 2.0 protocol
         </span>
         <br />
         <code
-          class="inline css-1nolcer-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
+          class="inline css-mcdrx3-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
         >
           AppleAuthenticationButtonType
           .
@@ -4407,7 +4407,7 @@ OAuth 2.0 protocol
   </div>
   <div>
     <h3
-      class="css-icxoph-h3-h3-STYLES_H3"
+      class="css-1fe5f89-h3-h3-STYLES_H3"
       data-heading="true"
     >
       <div
@@ -4425,7 +4425,7 @@ OAuth 2.0 protocol
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               AppleAuthenticationCredentialState
             </code>
@@ -4462,7 +4462,7 @@ OAuth 2.0 protocol
       </div>
     </h3>
     <p
-      class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+      class="css-101h856-paragraph-STYLES_PARAGRAPH"
       data-text="true"
     >
       An enum whose values specify state of the credential when checked with 
@@ -4471,7 +4471,7 @@ OAuth 2.0 protocol
         href="/#appleauthenticationgetcredentialstateasyncuser"
       >
         <code
-          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
         >
           AppleAuthentication.getCredentialStateAsync()
         </code>
@@ -4479,7 +4479,7 @@ OAuth 2.0 protocol
       .
     </p>
     <blockquote
-      class="css-e76wiv-paragraph-STYLES_BLOCKQUOTE"
+      class="css-1vk32i8-paragraph-STYLES_BLOCKQUOTE"
       data-text="true"
     >
       <div>
@@ -4503,7 +4503,7 @@ OAuth 2.0 protocol
       </div>
       <div>
         <strong
-          class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+          class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
         >
           See: 
         </strong>
@@ -4522,7 +4522,7 @@ for more details.
       </div>
     </blockquote>
     <ul
-      class="css-1a9yu92-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1dmv26-paragraph-STYLES_UNORDERED_LIST-UL"
       data-text="true"
     >
       <li
@@ -4532,14 +4532,14 @@ for more details.
           class="css-1aaoyoh-renderEnum"
         >
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             REVOKED
           </code>
         </span>
         <br />
         <code
-          class="inline css-1nolcer-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
+          class="inline css-mcdrx3-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
         >
           AppleAuthenticationCredentialState
           .
@@ -4555,14 +4555,14 @@ for more details.
           class="css-1aaoyoh-renderEnum"
         >
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             AUTHORIZED
           </code>
         </span>
         <br />
         <code
-          class="inline css-1nolcer-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
+          class="inline css-mcdrx3-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
         >
           AppleAuthenticationCredentialState
           .
@@ -4578,14 +4578,14 @@ for more details.
           class="css-1aaoyoh-renderEnum"
         >
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             NOT_FOUND
           </code>
         </span>
         <br />
         <code
-          class="inline css-1nolcer-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
+          class="inline css-mcdrx3-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
         >
           AppleAuthenticationCredentialState
           .
@@ -4601,14 +4601,14 @@ for more details.
           class="css-1aaoyoh-renderEnum"
         >
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             TRANSFERRED
           </code>
         </span>
         <br />
         <code
-          class="inline css-1nolcer-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
+          class="inline css-mcdrx3-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
         >
           AppleAuthenticationCredentialState
           .
@@ -4621,7 +4621,7 @@ for more details.
   </div>
   <div>
     <h3
-      class="css-icxoph-h3-h3-STYLES_H3"
+      class="css-1fe5f89-h3-h3-STYLES_H3"
       data-heading="true"
     >
       <div
@@ -4639,7 +4639,7 @@ for more details.
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               AppleAuthenticationOperation
             </code>
@@ -4676,7 +4676,7 @@ for more details.
       </div>
     </h3>
     <ul
-      class="css-1a9yu92-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1dmv26-paragraph-STYLES_UNORDERED_LIST-UL"
       data-text="true"
     >
       <li
@@ -4686,7 +4686,7 @@ for more details.
           class="css-1aaoyoh-renderEnum"
         >
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             IMPLICIT
           </code>
@@ -4697,7 +4697,7 @@ for more details.
         </span>
         <br />
         <code
-          class="inline css-1nolcer-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
+          class="inline css-mcdrx3-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
         >
           AppleAuthenticationOperation
           .
@@ -4713,14 +4713,14 @@ for more details.
           class="css-1aaoyoh-renderEnum"
         >
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             LOGIN
           </code>
         </span>
         <br />
         <code
-          class="inline css-1nolcer-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
+          class="inline css-mcdrx3-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
         >
           AppleAuthenticationOperation
           .
@@ -4736,14 +4736,14 @@ for more details.
           class="css-1aaoyoh-renderEnum"
         >
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             REFRESH
           </code>
         </span>
         <br />
         <code
-          class="inline css-1nolcer-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
+          class="inline css-mcdrx3-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
         >
           AppleAuthenticationOperation
           .
@@ -4759,14 +4759,14 @@ for more details.
           class="css-1aaoyoh-renderEnum"
         >
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             LOGOUT
           </code>
         </span>
         <br />
         <code
-          class="inline css-1nolcer-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
+          class="inline css-mcdrx3-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
         >
           AppleAuthenticationOperation
           .
@@ -4779,7 +4779,7 @@ for more details.
   </div>
   <div>
     <h3
-      class="css-icxoph-h3-h3-STYLES_H3"
+      class="css-1fe5f89-h3-h3-STYLES_H3"
       data-heading="true"
     >
       <div
@@ -4797,7 +4797,7 @@ for more details.
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               AppleAuthenticationScope
             </code>
@@ -4834,7 +4834,7 @@ for more details.
       </div>
     </h3>
     <p
-      class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+      class="css-101h856-paragraph-STYLES_PARAGRAPH"
       data-text="true"
     >
       An enum whose values specify scopes you can request when calling 
@@ -4843,7 +4843,7 @@ for more details.
         href="/#appleauthenticationsigninasyncoptions"
       >
         <code
-          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
         >
           AppleAuthentication.signInAsync()
         </code>
@@ -4851,7 +4851,7 @@ for more details.
       .
     </p>
     <blockquote
-      class="css-e76wiv-paragraph-STYLES_BLOCKQUOTE"
+      class="css-1vk32i8-paragraph-STYLES_BLOCKQUOTE"
       data-text="true"
     >
       <div>
@@ -4883,7 +4883,7 @@ You will still need to handle null values for any fields you request.
       </div>
     </blockquote>
     <blockquote
-      class="css-e76wiv-paragraph-STYLES_BLOCKQUOTE"
+      class="css-1vk32i8-paragraph-STYLES_BLOCKQUOTE"
       data-text="true"
     >
       <div>
@@ -4907,7 +4907,7 @@ You will still need to handle null values for any fields you request.
       </div>
       <div>
         <strong
-          class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+          class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
         >
           See: 
         </strong>
@@ -4926,7 +4926,7 @@ for more details.
       </div>
     </blockquote>
     <ul
-      class="css-1a9yu92-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1dmv26-paragraph-STYLES_UNORDERED_LIST-UL"
       data-text="true"
     >
       <li
@@ -4936,14 +4936,14 @@ for more details.
           class="css-1aaoyoh-renderEnum"
         >
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             FULL_NAME
           </code>
         </span>
         <br />
         <code
-          class="inline css-1nolcer-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
+          class="inline css-mcdrx3-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
         >
           AppleAuthenticationScope
           .
@@ -4959,14 +4959,14 @@ for more details.
           class="css-1aaoyoh-renderEnum"
         >
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             EMAIL
           </code>
         </span>
         <br />
         <code
-          class="inline css-1nolcer-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
+          class="inline css-mcdrx3-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
         >
           AppleAuthenticationScope
           .
@@ -4979,7 +4979,7 @@ for more details.
   </div>
   <div>
     <h3
-      class="css-icxoph-h3-h3-STYLES_H3"
+      class="css-1fe5f89-h3-h3-STYLES_H3"
       data-heading="true"
     >
       <div
@@ -4997,7 +4997,7 @@ for more details.
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               AppleAuthenticationUserDetectionStatus
             </code>
@@ -5034,13 +5034,13 @@ for more details.
       </div>
     </h3>
     <p
-      class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+      class="css-101h856-paragraph-STYLES_PARAGRAPH"
       data-text="true"
     >
       An enum whose values specify the system's best guess for how likely the current user is a real person.
     </p>
     <blockquote
-      class="css-e76wiv-paragraph-STYLES_BLOCKQUOTE"
+      class="css-1vk32i8-paragraph-STYLES_BLOCKQUOTE"
       data-text="true"
     >
       <div>
@@ -5064,7 +5064,7 @@ for more details.
       </div>
       <div>
         <strong
-          class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+          class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
         >
           See: 
         </strong>
@@ -5083,7 +5083,7 @@ for more details.
       </div>
     </blockquote>
     <ul
-      class="css-1a9yu92-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1dmv26-paragraph-STYLES_UNORDERED_LIST-UL"
       data-text="true"
     >
       <li
@@ -5093,7 +5093,7 @@ for more details.
           class="css-1aaoyoh-renderEnum"
         >
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             UNSUPPORTED
           </code>
@@ -5104,7 +5104,7 @@ for more details.
         </span>
         <br />
         <code
-          class="inline css-1nolcer-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
+          class="inline css-mcdrx3-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
         >
           AppleAuthenticationUserDetectionStatus
           .
@@ -5120,7 +5120,7 @@ for more details.
           class="css-1aaoyoh-renderEnum"
         >
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             UNKNOWN
           </code>
@@ -5131,7 +5131,7 @@ for more details.
         </span>
         <br />
         <code
-          class="inline css-1nolcer-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
+          class="inline css-mcdrx3-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
         >
           AppleAuthenticationUserDetectionStatus
           .
@@ -5147,7 +5147,7 @@ for more details.
           class="css-1aaoyoh-renderEnum"
         >
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             LIKELY_REAL
           </code>
@@ -5158,7 +5158,7 @@ for more details.
         </span>
         <br />
         <code
-          class="inline css-1nolcer-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
+          class="inline css-mcdrx3-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
         >
           AppleAuthenticationUserDetectionStatus
           .
@@ -5175,7 +5175,7 @@ for more details.
 exports[`APISection expo-barcode-scanner 1`] = `
 <div>
   <h2
-    class="css-1v5aebx-h2-h2-STYLES_H2"
+    class="css-et60wy-h2-h2-STYLES_H2"
     data-heading="true"
   >
     <div
@@ -5227,7 +5227,7 @@ exports[`APISection expo-barcode-scanner 1`] = `
   </h2>
   <div>
     <h3
-      class="css-icxoph-h3-h3-STYLES_H3"
+      class="css-1fe5f89-h3-h3-STYLES_H3"
       data-heading="true"
     >
       <div
@@ -5245,7 +5245,7 @@ exports[`APISection expo-barcode-scanner 1`] = `
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               BarCodeScanner
             </code>
@@ -5282,17 +5282,17 @@ exports[`APISection expo-barcode-scanner 1`] = `
       </div>
     </h3>
     <p
-      class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+      class="css-101h856-paragraph-STYLES_PARAGRAPH"
       data-text="true"
     >
       <strong
-        class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+        class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
       >
         Type:
       </strong>
        
       <code
-        class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+        class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
       >
         Component
         &lt;
@@ -5308,7 +5308,7 @@ exports[`APISection expo-barcode-scanner 1`] = `
       </code>
     </p>
     <h3
-      class="css-icxoph-h3-h3-STYLES_H3"
+      class="css-1fe5f89-h3-h3-STYLES_H3"
       data-heading="true"
     >
       <div
@@ -5326,7 +5326,7 @@ exports[`APISection expo-barcode-scanner 1`] = `
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               BarCodeScannerProps
             </code>
@@ -5365,14 +5365,14 @@ exports[`APISection expo-barcode-scanner 1`] = `
     <br />
     <div>
       <ul
-        class="css-1a9yu92-paragraph-STYLES_UNORDERED_LIST-UL"
+        class="css-1dmv26-paragraph-STYLES_UNORDERED_LIST-UL"
         data-text="true"
       >
         <li
           class="docs-list-item css-1jvmp7m-STYLES_LIST_ITEM-STYLE_PROP_LIST-PROP_LIST_ELEMENT_STYLE-LI"
         >
           <h4
-            class="  css-1j2s5xo-h4-h4-STYLES_H4"
+            class="  css-838f5l-h4-h4-STYLES_H4"
             data-components-heading="true"
             data-heading="true"
           >
@@ -5424,7 +5424,7 @@ exports[`APISection expo-barcode-scanner 1`] = `
             </div>
           </h4>
           <p
-            class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+            class="css-101h856-paragraph-STYLES_PARAGRAPH"
             data-text="true"
           >
             <span
@@ -5439,25 +5439,25 @@ exports[`APISection expo-barcode-scanner 1`] = `
             </span>
              
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               string[]
             </code>
           </p>
           <p
-            class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+            class="css-101h856-paragraph-STYLES_PARAGRAPH"
             data-text="true"
           >
             An array of bar code types. Usage: 
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               BarCodeScanner.Constants.BarCodeType.&lt;codeType&gt;
             </code>
              where
 
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               codeType
             </code>
@@ -5473,12 +5473,12 @@ code types. It is recommended to provide only the bar code formats you expect to
 minimize battery usage.
           </p>
           <p
-            class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+            class="css-101h856-paragraph-STYLES_PARAGRAPH"
             data-text="true"
           >
             For example: 
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               barCodeTypes={[BarCodeScanner.Constants.BarCodeType.qr]}
             </code>
@@ -5492,7 +5492,7 @@ minimize battery usage.
           class="docs-list-item css-1jvmp7m-STYLES_LIST_ITEM-STYLE_PROP_LIST-PROP_LIST_ELEMENT_STYLE-LI"
         >
           <h4
-            class="  css-1j2s5xo-h4-h4-STYLES_H4"
+            class="  css-838f5l-h4-h4-STYLES_H4"
             data-components-heading="true"
             data-heading="true"
           >
@@ -5544,7 +5544,7 @@ minimize battery usage.
             </div>
           </h4>
           <p
-            class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+            class="css-101h856-paragraph-STYLES_PARAGRAPH"
             data-text="true"
           >
             <span
@@ -5559,7 +5559,7 @@ minimize battery usage.
             </span>
              
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               <a
                 class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -5570,7 +5570,7 @@ minimize battery usage.
             </code>
           </p>
           <p
-            class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+            class="css-101h856-paragraph-STYLES_PARAGRAPH"
             data-text="true"
           >
             A callback that is invoked when a bar code has been successfully scanned. The callback is
@@ -5586,7 +5586,7 @@ provided with an
           
 
           <blockquote
-            class="css-e76wiv-paragraph-STYLES_BLOCKQUOTE"
+            class="css-1vk32i8-paragraph-STYLES_BLOCKQUOTE"
             data-text="true"
           >
             <div>
@@ -5612,19 +5612,19 @@ provided with an
               
 
               <strong
-                class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+                class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
               >
                 Note:
               </strong>
                Passing 
               <code
-                class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+                class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
               >
                 undefined
               </code>
                to the 
               <code
-                class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+                class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
               >
                 onBarCodeScanned
               </code>
@@ -5643,7 +5643,7 @@ data has been retrieved.
           class="docs-list-item css-1jvmp7m-STYLES_LIST_ITEM-STYLE_PROP_LIST-PROP_LIST_ELEMENT_STYLE-LI"
         >
           <h4
-            class="  css-1j2s5xo-h4-h4-STYLES_H4"
+            class="  css-838f5l-h4-h4-STYLES_H4"
             data-components-heading="true"
             data-heading="true"
           >
@@ -5695,7 +5695,7 @@ data has been retrieved.
             </div>
           </h4>
           <p
-            class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+            class="css-101h856-paragraph-STYLES_PARAGRAPH"
             data-text="true"
           >
             <span
@@ -5710,7 +5710,7 @@ data has been retrieved.
             </span>
              
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               <span>
                 'front'
@@ -5732,7 +5732,7 @@ data has been retrieved.
               </span>
                
               <code
-                class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+                class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
               >
                 Type.back
 
@@ -5740,31 +5740,31 @@ data has been retrieved.
             </span>
           </p>
           <p
-            class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+            class="css-101h856-paragraph-STYLES_PARAGRAPH"
             data-text="true"
           >
             Camera facing. Use one of 
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               BarCodeScanner.Constants.Type
             </code>
             . Use either 
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               Type.front
             </code>
              or 
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               Type.back
             </code>
             .
 Same as 
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               Camera.Constants.Type
             </code>
@@ -5776,7 +5776,7 @@ Same as
         </li>
       </ul>
       <h4
-        class="  css-1j2s5xo-h4-h4-STYLES_H4"
+        class="  css-838f5l-h4-h4-STYLES_H4"
         data-components-heading="true"
         data-heading="true"
       >
@@ -5828,14 +5828,14 @@ Same as
         </div>
       </h4>
       <ul
-        class="css-1a9yu92-paragraph-STYLES_UNORDERED_LIST-UL"
+        class="css-1dmv26-paragraph-STYLES_UNORDERED_LIST-UL"
         data-text="true"
       >
         <li
           class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
         >
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             <a
               class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -5849,7 +5849,7 @@ Same as
     </div>
   </div>
   <h2
-    class="css-1v5aebx-h2-h2-STYLES_H2"
+    class="css-et60wy-h2-h2-STYLES_H2"
     data-heading="true"
   >
     <div
@@ -5901,7 +5901,7 @@ Same as
   </h2>
   <div>
     <h3
-      class="css-icxoph-h3-h3-STYLES_H3"
+      class="css-1fe5f89-h3-h3-STYLES_H3"
       data-heading="true"
     >
       <div
@@ -5919,7 +5919,7 @@ Same as
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               usePermissions
             </code>
@@ -5956,7 +5956,7 @@ Same as
       </div>
     </h3>
     <h4
-      class="  css-1j2s5xo-h4-h4-STYLES_H4"
+      class="  css-838f5l-h4-h4-STYLES_H4"
       data-components-heading="true"
       data-heading="true"
     >
@@ -6008,20 +6008,20 @@ Same as
       </div>
     </h4>
     <ul
-      class="css-1a9yu92-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1dmv26-paragraph-STYLES_UNORDERED_LIST-UL"
       data-text="true"
     >
       <li
         class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
       >
         <strong
-          class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+          class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
         >
           options
           ?
            (
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             <a
               class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -6040,7 +6040,7 @@ Same as
       </li>
     </ul>
     <p
-      class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+      class="css-101h856-paragraph-STYLES_PARAGRAPH"
       data-text="true"
     >
       Create a new permission hook with the permission methods built-in.
@@ -6048,7 +6048,7 @@ This can be used to quickly create specific permission hooks in every module.
     </p>
     <div>
       <h4
-        class="  css-1j2s5xo-h4-h4-STYLES_H4"
+        class="  css-838f5l-h4-h4-STYLES_H4"
         data-components-heading="true"
         data-heading="true"
       >
@@ -6100,14 +6100,14 @@ This can be used to quickly create specific permission hooks in every module.
         </div>
       </h4>
       <ul
-        class="css-1a9yu92-paragraph-STYLES_UNORDERED_LIST-UL"
+        class="css-1dmv26-paragraph-STYLES_UNORDERED_LIST-UL"
         data-text="true"
       >
         <li
           class="docs-list-item css-1wwpkbk-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
         >
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             [
             <span>
@@ -6159,7 +6159,7 @@ This can be used to quickly create specific permission hooks in every module.
     </div>
   </div>
   <h2
-    class="css-1v5aebx-h2-h2-STYLES_H2"
+    class="css-et60wy-h2-h2-STYLES_H2"
     data-heading="true"
   >
     <div
@@ -6211,7 +6211,7 @@ This can be used to quickly create specific permission hooks in every module.
   </h2>
   <div>
     <h3
-      class="css-icxoph-h3-h3-STYLES_H3"
+      class="css-1fe5f89-h3-h3-STYLES_H3"
       data-heading="true"
     >
       <div
@@ -6229,7 +6229,7 @@ This can be used to quickly create specific permission hooks in every module.
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               BarCodeScanner.
               getPermissionsAsync()
@@ -6267,14 +6267,14 @@ This can be used to quickly create specific permission hooks in every module.
       </div>
     </h3>
     <p
-      class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+      class="css-101h856-paragraph-STYLES_PARAGRAPH"
       data-text="true"
     >
       Checks user's permissions for accessing the camera.
     </p>
     <div>
       <h4
-        class="  css-1j2s5xo-h4-h4-STYLES_H4"
+        class="  css-838f5l-h4-h4-STYLES_H4"
         data-components-heading="true"
         data-heading="true"
       >
@@ -6326,14 +6326,14 @@ This can be used to quickly create specific permission hooks in every module.
         </div>
       </h4>
       <ul
-        class="css-1a9yu92-paragraph-STYLES_UNORDERED_LIST-UL"
+        class="css-1dmv26-paragraph-STYLES_UNORDERED_LIST-UL"
         data-text="true"
       >
         <li
           class="docs-list-item css-1wwpkbk-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
         >
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             <a
               class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -6356,7 +6356,7 @@ This can be used to quickly create specific permission hooks in every module.
         </li>
       </ul>
       <p
-        class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+        class="css-101h856-paragraph-STYLES_PARAGRAPH"
         data-text="true"
       >
         Return a promise that fulfills to an object of type 
@@ -6365,7 +6365,7 @@ This can be used to quickly create specific permission hooks in every module.
           href="/#permissionresponse"
         >
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             PermissionResponse
           </code>
@@ -6377,7 +6377,7 @@ This can be used to quickly create specific permission hooks in every module.
   </div>
   <div>
     <h3
-      class="css-icxoph-h3-h3-STYLES_H3"
+      class="css-1fe5f89-h3-h3-STYLES_H3"
       data-heading="true"
     >
       <div
@@ -6395,7 +6395,7 @@ This can be used to quickly create specific permission hooks in every module.
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               BarCodeScanner.
               requestPermissionsAsync()
@@ -6433,24 +6433,24 @@ This can be used to quickly create specific permission hooks in every module.
       </div>
     </h3>
     <p
-      class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+      class="css-101h856-paragraph-STYLES_PARAGRAPH"
       data-text="true"
     >
       Asks the user to grant permissions for accessing the camera.
     </p>
     <p
-      class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+      class="css-101h856-paragraph-STYLES_PARAGRAPH"
       data-text="true"
     >
       On iOS this will require apps to specify the 
       <code
-        class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+        class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
       >
         NSCameraUsageDescription
       </code>
        entry in the 
       <code
-        class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+        class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
       >
         Info.plist
       </code>
@@ -6458,7 +6458,7 @@ This can be used to quickly create specific permission hooks in every module.
     </p>
     <div>
       <h4
-        class="  css-1j2s5xo-h4-h4-STYLES_H4"
+        class="  css-838f5l-h4-h4-STYLES_H4"
         data-components-heading="true"
         data-heading="true"
       >
@@ -6510,14 +6510,14 @@ This can be used to quickly create specific permission hooks in every module.
         </div>
       </h4>
       <ul
-        class="css-1a9yu92-paragraph-STYLES_UNORDERED_LIST-UL"
+        class="css-1dmv26-paragraph-STYLES_UNORDERED_LIST-UL"
         data-text="true"
       >
         <li
           class="docs-list-item css-1wwpkbk-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
         >
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             <a
               class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -6540,7 +6540,7 @@ This can be used to quickly create specific permission hooks in every module.
         </li>
       </ul>
       <p
-        class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+        class="css-101h856-paragraph-STYLES_PARAGRAPH"
         data-text="true"
       >
         Return a promise that fulfills to an object of type 
@@ -6549,7 +6549,7 @@ This can be used to quickly create specific permission hooks in every module.
           href="/#permissionresponse"
         >
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             PermissionResponse
           </code>
@@ -6561,7 +6561,7 @@ This can be used to quickly create specific permission hooks in every module.
   </div>
   <div>
     <h3
-      class="css-icxoph-h3-h3-STYLES_H3"
+      class="css-1fe5f89-h3-h3-STYLES_H3"
       data-heading="true"
     >
       <div
@@ -6579,7 +6579,7 @@ This can be used to quickly create specific permission hooks in every module.
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               BarCodeScanner.
               scanFromURLAsync(url, barCodeTypes)
@@ -6617,7 +6617,7 @@ This can be used to quickly create specific permission hooks in every module.
       </div>
     </h3>
     <h4
-      class="  css-1j2s5xo-h4-h4-STYLES_H4"
+      class="  css-838f5l-h4-h4-STYLES_H4"
       data-components-heading="true"
       data-heading="true"
     >
@@ -6669,19 +6669,19 @@ This can be used to quickly create specific permission hooks in every module.
       </div>
     </h4>
     <ul
-      class="css-1a9yu92-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1dmv26-paragraph-STYLES_UNORDERED_LIST-UL"
       data-text="true"
     >
       <li
         class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
       >
         <strong
-          class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+          class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
         >
           url
            (
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             string
           </code>
@@ -6696,12 +6696,12 @@ This can be used to quickly create specific permission hooks in every module.
         class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
       >
         <strong
-          class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+          class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
         >
           barCodeTypes
            (
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             string[]
           </code>
@@ -6715,7 +6715,7 @@ the platform.
         
 
         <blockquote
-          class="css-e76wiv-paragraph-STYLES_BLOCKQUOTE"
+          class="css-1vk32i8-paragraph-STYLES_BLOCKQUOTE"
           data-text="true"
         >
           <div>
@@ -6741,7 +6741,7 @@ the platform.
             
 
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               Note:
             </strong>
@@ -6753,14 +6753,14 @@ the platform.
       </li>
     </ul>
     <p
-      class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+      class="css-101h856-paragraph-STYLES_PARAGRAPH"
       data-text="true"
     >
       Scan bar codes from the image given by the URL.
     </p>
     <div>
       <h4
-        class="  css-1j2s5xo-h4-h4-STYLES_H4"
+        class="  css-838f5l-h4-h4-STYLES_H4"
         data-components-heading="true"
         data-heading="true"
       >
@@ -6812,14 +6812,14 @@ the platform.
         </div>
       </h4>
       <ul
-        class="css-1a9yu92-paragraph-STYLES_UNORDERED_LIST-UL"
+        class="css-1dmv26-paragraph-STYLES_UNORDERED_LIST-UL"
         data-text="true"
       >
         <li
           class="docs-list-item css-1wwpkbk-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
         >
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             <a
               class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -6843,12 +6843,12 @@ the platform.
         </li>
       </ul>
       <p
-        class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+        class="css-101h856-paragraph-STYLES_PARAGRAPH"
         data-text="true"
       >
         A possibly empty array of objects of the 
         <code
-          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
         >
           BarCodeScannerResult
         </code>
@@ -6859,7 +6859,7 @@ code.
     </div>
   </div>
   <h2
-    class="css-1v5aebx-h2-h2-STYLES_H2"
+    class="css-et60wy-h2-h2-STYLES_H2"
     data-heading="true"
   >
     <div
@@ -6911,7 +6911,7 @@ code.
   </h2>
   <div>
     <h3
-      class="css-icxoph-h3-h3-STYLES_H3"
+      class="css-1fe5f89-h3-h3-STYLES_H3"
       data-heading="true"
     >
       <div
@@ -6929,7 +6929,7 @@ code.
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               BarCodeBounds
               
@@ -6984,14 +6984,14 @@ code.
         <tr>
           <td>
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               origin
             </strong>
           </td>
           <td>
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               <a
                 class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -7010,14 +7010,14 @@ code.
         <tr>
           <td>
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               size
             </strong>
           </td>
           <td>
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               <a
                 class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -7038,7 +7038,7 @@ code.
   </div>
   <div>
     <h3
-      class="css-icxoph-h3-h3-STYLES_H3"
+      class="css-1fe5f89-h3-h3-STYLES_H3"
       data-heading="true"
     >
       <div
@@ -7056,7 +7056,7 @@ code.
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               BarCodeEvent
             </code>
@@ -7093,11 +7093,11 @@ code.
       </div>
     </h3>
     <p
-      class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+      class="css-101h856-paragraph-STYLES_PARAGRAPH"
       data-text="true"
     >
       <code
-        class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+        class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
       >
         <a
           class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -7127,7 +7127,7 @@ code.
         <tr>
           <td>
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               target
             </strong>
@@ -7140,7 +7140,7 @@ code.
           </td>
           <td>
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               number
             </code>
@@ -7154,7 +7154,7 @@ code.
   </div>
   <div>
     <h3
-      class="css-icxoph-h3-h3-STYLES_H3"
+      class="css-1fe5f89-h3-h3-STYLES_H3"
       data-heading="true"
     >
       <div
@@ -7172,7 +7172,7 @@ code.
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               BarCodeEventCallbackArguments
               
@@ -7227,14 +7227,14 @@ code.
         <tr>
           <td>
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               nativeEvent
             </strong>
           </td>
           <td>
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               <a
                 class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -7253,7 +7253,7 @@ code.
   </div>
   <div>
     <h3
-      class="css-icxoph-h3-h3-STYLES_H3"
+      class="css-1fe5f89-h3-h3-STYLES_H3"
       data-heading="true"
     >
       <div
@@ -7271,7 +7271,7 @@ code.
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               BarCodePoint
               
@@ -7309,7 +7309,7 @@ code.
       </div>
     </h3>
     <p
-      class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+      class="css-101h856-paragraph-STYLES_PARAGRAPH"
       data-text="true"
     >
       Those coordinates are represented in the coordinate space of the barcode source (e.g. when you
@@ -7333,14 +7333,14 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
         <tr>
           <td>
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               x
             </strong>
           </td>
           <td>
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               number
             </code>
@@ -7349,7 +7349,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
             <span>
               The 
               <code
-                class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+                class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
               >
                 x
               </code>
@@ -7360,14 +7360,14 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
         <tr>
           <td>
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               y
             </strong>
           </td>
           <td>
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               number
             </code>
@@ -7376,7 +7376,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
             <span>
               The 
               <code
-                class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+                class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
               >
                 y
               </code>
@@ -7389,7 +7389,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
   </div>
   <div>
     <h3
-      class="css-icxoph-h3-h3-STYLES_H3"
+      class="css-1fe5f89-h3-h3-STYLES_H3"
       data-heading="true"
     >
       <div
@@ -7407,7 +7407,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               BarCodeScannedCallback
               ()
@@ -7446,7 +7446,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
     </h3>
     <div>
       <h4
-        class="  css-1j2s5xo-h4-h4-STYLES_H4"
+        class="  css-838f5l-h4-h4-STYLES_H4"
         data-components-heading="true"
         data-heading="true"
       >
@@ -7498,19 +7498,19 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
         </div>
       </h4>
       <ul
-        class="css-1a9yu92-paragraph-STYLES_UNORDERED_LIST-UL"
+        class="css-1dmv26-paragraph-STYLES_UNORDERED_LIST-UL"
         data-text="true"
       >
         <li
           class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
         >
           <strong
-            class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+            class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
           >
             params
              (
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               <a
                 class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -7527,7 +7527,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
   </div>
   <div>
     <h3
-      class="css-icxoph-h3-h3-STYLES_H3"
+      class="css-1fe5f89-h3-h3-STYLES_H3"
       data-heading="true"
     >
       <div
@@ -7545,7 +7545,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               BarCodeScannerResult
               
@@ -7583,7 +7583,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
       </div>
     </h3>
     <blockquote
-      class="css-e76wiv-paragraph-STYLES_BLOCKQUOTE"
+      class="css-1vk32i8-paragraph-STYLES_BLOCKQUOTE"
       data-text="true"
     >
       <div>
@@ -7609,31 +7609,31 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
         
 
         <strong
-          class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+          class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
         >
           Note:
         </strong>
          
         <code
-          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
         >
           bounds
         </code>
          and 
         <code
-          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
         >
           cornerPoints
         </code>
          are not always available. On iOS, for 
         <code
-          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
         >
           code39
         </code>
          and 
         <code
-          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
         >
           pdf417
         </code>
@@ -7662,7 +7662,7 @@ For some types, they will represent the area used by the scanner.
         <tr>
           <td>
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               bounds
             </strong>
@@ -7675,7 +7675,7 @@ For some types, they will represent the area used by the scanner.
           </td>
           <td>
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               <a
                 class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -7701,7 +7701,7 @@ For some types, they will represent the area used by the scanner.
         <tr>
           <td>
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               cornerPoints
             </strong>
@@ -7714,7 +7714,7 @@ For some types, they will represent the area used by the scanner.
           </td>
           <td>
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               <a
                 class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -7734,14 +7734,14 @@ For some types, they will represent the area used by the scanner.
         <tr>
           <td>
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               data
             </strong>
           </td>
           <td>
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               string
             </code>
@@ -7755,14 +7755,14 @@ For some types, they will represent the area used by the scanner.
         <tr>
           <td>
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               type
             </strong>
           </td>
           <td>
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               string
             </code>
@@ -7778,7 +7778,7 @@ For some types, they will represent the area used by the scanner.
   </div>
   <div>
     <h3
-      class="css-icxoph-h3-h3-STYLES_H3"
+      class="css-1fe5f89-h3-h3-STYLES_H3"
       data-heading="true"
     >
       <div
@@ -7796,7 +7796,7 @@ For some types, they will represent the area used by the scanner.
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               BarCodeSize
               
@@ -7851,14 +7851,14 @@ For some types, they will represent the area used by the scanner.
         <tr>
           <td>
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               height
             </strong>
           </td>
           <td>
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               number
             </code>
@@ -7872,14 +7872,14 @@ For some types, they will represent the area used by the scanner.
         <tr>
           <td>
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               width
             </strong>
           </td>
           <td>
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               number
             </code>
@@ -7895,7 +7895,7 @@ For some types, they will represent the area used by the scanner.
   </div>
   <div>
     <h3
-      class="css-icxoph-h3-h3-STYLES_H3"
+      class="css-1fe5f89-h3-h3-STYLES_H3"
       data-heading="true"
     >
       <div
@@ -7913,7 +7913,7 @@ For some types, they will represent the area used by the scanner.
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               PermissionHookOptions
             </code>
@@ -7950,14 +7950,14 @@ For some types, they will represent the area used by the scanner.
       </div>
     </h3>
     <p
-      class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+      class="css-101h856-paragraph-STYLES_PARAGRAPH"
       data-text="true"
     >
       Acceptable values are:
        
       <span>
         <code
-          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
         >
           PermissionHookBehavior
         </code>
@@ -7965,7 +7965,7 @@ For some types, they will represent the area used by the scanner.
       </span>
       <span>
         <code
-          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
         >
           Options
         </code>
@@ -7974,7 +7974,7 @@ For some types, they will represent the area used by the scanner.
     </p>
   </div>
   <h2
-    class="css-1v5aebx-h2-h2-STYLES_H2"
+    class="css-et60wy-h2-h2-STYLES_H2"
     data-heading="true"
   >
     <div
@@ -8026,7 +8026,7 @@ For some types, they will represent the area used by the scanner.
   </h2>
   <div>
     <h3
-      class="css-icxoph-h3-h3-STYLES_H3"
+      class="css-1fe5f89-h3-h3-STYLES_H3"
       data-heading="true"
     >
       <div
@@ -8044,7 +8044,7 @@ For some types, they will represent the area used by the scanner.
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               PermissionResponse
             </code>
@@ -8098,7 +8098,7 @@ For some types, they will represent the area used by the scanner.
         <tr>
           <td>
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               canAskAgain
               
@@ -8106,7 +8106,7 @@ For some types, they will represent the area used by the scanner.
           </td>
           <td>
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               boolean
             </code>
@@ -8118,7 +8118,7 @@ For some types, they will represent the area used by the scanner.
         <tr>
           <td>
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               expires
               
@@ -8126,7 +8126,7 @@ For some types, they will represent the area used by the scanner.
           </td>
           <td>
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               <a
                 class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -8143,7 +8143,7 @@ For some types, they will represent the area used by the scanner.
         <tr>
           <td>
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               granted
               
@@ -8151,7 +8151,7 @@ For some types, they will represent the area used by the scanner.
           </td>
           <td>
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               boolean
             </code>
@@ -8163,7 +8163,7 @@ For some types, they will represent the area used by the scanner.
         <tr>
           <td>
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               status
               
@@ -8171,7 +8171,7 @@ For some types, they will represent the area used by the scanner.
           </td>
           <td>
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               <a
                 class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -8189,7 +8189,7 @@ For some types, they will represent the area used by the scanner.
     </table>
   </div>
   <h2
-    class="css-1v5aebx-h2-h2-STYLES_H2"
+    class="css-et60wy-h2-h2-STYLES_H2"
     data-heading="true"
   >
     <div
@@ -8241,7 +8241,7 @@ For some types, they will represent the area used by the scanner.
   </h2>
   <div>
     <h3
-      class="css-icxoph-h3-h3-STYLES_H3"
+      class="css-1fe5f89-h3-h3-STYLES_H3"
       data-heading="true"
     >
       <div
@@ -8259,7 +8259,7 @@ For some types, they will represent the area used by the scanner.
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               PermissionStatus
             </code>
@@ -8296,7 +8296,7 @@ For some types, they will represent the area used by the scanner.
       </div>
     </h3>
     <ul
-      class="css-1a9yu92-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1dmv26-paragraph-STYLES_UNORDERED_LIST-UL"
       data-text="true"
     >
       <li
@@ -8306,14 +8306,14 @@ For some types, they will represent the area used by the scanner.
           class="css-1aaoyoh-renderEnum"
         >
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             DENIED
           </code>
         </span>
         <br />
         <code
-          class="inline css-1nolcer-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
+          class="inline css-mcdrx3-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
         >
           PermissionStatus
           .
@@ -8329,14 +8329,14 @@ For some types, they will represent the area used by the scanner.
           class="css-1aaoyoh-renderEnum"
         >
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             GRANTED
           </code>
         </span>
         <br />
         <code
-          class="inline css-1nolcer-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
+          class="inline css-mcdrx3-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
         >
           PermissionStatus
           .
@@ -8352,14 +8352,14 @@ For some types, they will represent the area used by the scanner.
           class="css-1aaoyoh-renderEnum"
         >
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             UNDETERMINED
           </code>
         </span>
         <br />
         <code
-          class="inline css-1nolcer-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
+          class="inline css-mcdrx3-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
         >
           PermissionStatus
           .
@@ -8376,7 +8376,7 @@ For some types, they will represent the area used by the scanner.
 exports[`APISection expo-pedometer 1`] = `
 <div>
   <h2
-    class="css-1v5aebx-h2-h2-STYLES_H2"
+    class="css-et60wy-h2-h2-STYLES_H2"
     data-heading="true"
   >
     <div
@@ -8428,7 +8428,7 @@ exports[`APISection expo-pedometer 1`] = `
   </h2>
   <div>
     <h3
-      class="css-icxoph-h3-h3-STYLES_H3"
+      class="css-1fe5f89-h3-h3-STYLES_H3"
       data-heading="true"
     >
       <div
@@ -8446,7 +8446,7 @@ exports[`APISection expo-pedometer 1`] = `
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               getPermissionsAsync()
             </code>
@@ -8484,7 +8484,7 @@ exports[`APISection expo-pedometer 1`] = `
     </h3>
     <div>
       <h4
-        class="  css-1j2s5xo-h4-h4-STYLES_H4"
+        class="  css-838f5l-h4-h4-STYLES_H4"
         data-components-heading="true"
         data-heading="true"
       >
@@ -8536,14 +8536,14 @@ exports[`APISection expo-pedometer 1`] = `
         </div>
       </h4>
       <ul
-        class="css-1a9yu92-paragraph-STYLES_UNORDERED_LIST-UL"
+        class="css-1dmv26-paragraph-STYLES_UNORDERED_LIST-UL"
         data-text="true"
       >
         <li
           class="docs-list-item css-1wwpkbk-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
         >
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             <a
               class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -8570,7 +8570,7 @@ exports[`APISection expo-pedometer 1`] = `
   </div>
   <div>
     <h3
-      class="css-icxoph-h3-h3-STYLES_H3"
+      class="css-1fe5f89-h3-h3-STYLES_H3"
       data-heading="true"
     >
       <div
@@ -8588,7 +8588,7 @@ exports[`APISection expo-pedometer 1`] = `
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               getStepCountAsync(start, end)
             </code>
@@ -8625,7 +8625,7 @@ exports[`APISection expo-pedometer 1`] = `
       </div>
     </h3>
     <h4
-      class="  css-1j2s5xo-h4-h4-STYLES_H4"
+      class="  css-838f5l-h4-h4-STYLES_H4"
       data-components-heading="true"
       data-heading="true"
     >
@@ -8677,19 +8677,19 @@ exports[`APISection expo-pedometer 1`] = `
       </div>
     </h4>
     <ul
-      class="css-1a9yu92-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1dmv26-paragraph-STYLES_UNORDERED_LIST-UL"
       data-text="true"
     >
       <li
         class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
       >
         <strong
-          class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+          class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
         >
           start
            (
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             <a
               class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -8710,12 +8710,12 @@ exports[`APISection expo-pedometer 1`] = `
         class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
       >
         <strong
-          class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+          class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
         >
           end
            (
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             <a
               class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -8734,14 +8734,14 @@ exports[`APISection expo-pedometer 1`] = `
       </li>
     </ul>
     <p
-      class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+      class="css-101h856-paragraph-STYLES_PARAGRAPH"
       data-text="true"
     >
       Get the step count between two dates.
     </p>
     <div>
       <h4
-        class="  css-1j2s5xo-h4-h4-STYLES_H4"
+        class="  css-838f5l-h4-h4-STYLES_H4"
         data-components-heading="true"
         data-heading="true"
       >
@@ -8793,14 +8793,14 @@ exports[`APISection expo-pedometer 1`] = `
         </div>
       </h4>
       <ul
-        class="css-1a9yu92-paragraph-STYLES_UNORDERED_LIST-UL"
+        class="css-1dmv26-paragraph-STYLES_UNORDERED_LIST-UL"
         data-text="true"
       >
         <li
           class="docs-list-item css-1wwpkbk-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
         >
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             <a
               class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -8823,7 +8823,7 @@ exports[`APISection expo-pedometer 1`] = `
         </li>
       </ul>
       <p
-        class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+        class="css-101h856-paragraph-STYLES_PARAGRAPH"
         data-text="true"
       >
         Returns a promise that fulfills with a 
@@ -8832,7 +8832,7 @@ exports[`APISection expo-pedometer 1`] = `
           href="/#pedometerresult"
         >
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             PedometerResult
           </code>
@@ -8842,7 +8842,7 @@ exports[`APISection expo-pedometer 1`] = `
       
 
       <p
-        class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+        class="css-101h856-paragraph-STYLES_PARAGRAPH"
         data-text="true"
       >
         As 
@@ -8858,7 +8858,7 @@ exports[`APISection expo-pedometer 1`] = `
       
 
       <blockquote
-        class="css-e76wiv-paragraph-STYLES_BLOCKQUOTE"
+        class="css-1vk32i8-paragraph-STYLES_BLOCKQUOTE"
         data-text="true"
       >
         <div>
@@ -8894,7 +8894,7 @@ a start date that is more than seven days in the past returns only the available
   </div>
   <div>
     <h3
-      class="css-icxoph-h3-h3-STYLES_H3"
+      class="css-1fe5f89-h3-h3-STYLES_H3"
       data-heading="true"
     >
       <div
@@ -8912,7 +8912,7 @@ a start date that is more than seven days in the past returns only the available
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               isAvailableAsync()
             </code>
@@ -8949,14 +8949,14 @@ a start date that is more than seven days in the past returns only the available
       </div>
     </h3>
     <p
-      class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+      class="css-101h856-paragraph-STYLES_PARAGRAPH"
       data-text="true"
     >
       Returns whether the pedometer is enabled on the device.
     </p>
     <div>
       <h4
-        class="  css-1j2s5xo-h4-h4-STYLES_H4"
+        class="  css-838f5l-h4-h4-STYLES_H4"
         data-components-heading="true"
         data-heading="true"
       >
@@ -9008,14 +9008,14 @@ a start date that is more than seven days in the past returns only the available
         </div>
       </h4>
       <ul
-        class="css-1a9yu92-paragraph-STYLES_UNORDERED_LIST-UL"
+        class="css-1dmv26-paragraph-STYLES_UNORDERED_LIST-UL"
         data-text="true"
       >
         <li
           class="docs-list-item css-1wwpkbk-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
         >
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             <a
               class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -9033,12 +9033,12 @@ a start date that is more than seven days in the past returns only the available
         </li>
       </ul>
       <p
-        class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+        class="css-101h856-paragraph-STYLES_PARAGRAPH"
         data-text="true"
       >
         Returns a promise that fulfills with a 
         <code
-          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
         >
           boolean
         </code>
@@ -9050,7 +9050,7 @@ available on this device.
   </div>
   <div>
     <h3
-      class="css-icxoph-h3-h3-STYLES_H3"
+      class="css-1fe5f89-h3-h3-STYLES_H3"
       data-heading="true"
     >
       <div
@@ -9068,7 +9068,7 @@ available on this device.
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               requestPermissionsAsync()
             </code>
@@ -9106,7 +9106,7 @@ available on this device.
     </h3>
     <div>
       <h4
-        class="  css-1j2s5xo-h4-h4-STYLES_H4"
+        class="  css-838f5l-h4-h4-STYLES_H4"
         data-components-heading="true"
         data-heading="true"
       >
@@ -9158,14 +9158,14 @@ available on this device.
         </div>
       </h4>
       <ul
-        class="css-1a9yu92-paragraph-STYLES_UNORDERED_LIST-UL"
+        class="css-1dmv26-paragraph-STYLES_UNORDERED_LIST-UL"
         data-text="true"
       >
         <li
           class="docs-list-item css-1wwpkbk-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
         >
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             <a
               class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -9192,7 +9192,7 @@ available on this device.
   </div>
   <div>
     <h3
-      class="css-icxoph-h3-h3-STYLES_H3"
+      class="css-1fe5f89-h3-h3-STYLES_H3"
       data-heading="true"
     >
       <div
@@ -9210,7 +9210,7 @@ available on this device.
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               watchStepCount(callback)
             </code>
@@ -9247,7 +9247,7 @@ available on this device.
       </div>
     </h3>
     <h4
-      class="  css-1j2s5xo-h4-h4-STYLES_H4"
+      class="  css-838f5l-h4-h4-STYLES_H4"
       data-components-heading="true"
       data-heading="true"
     >
@@ -9299,19 +9299,19 @@ available on this device.
       </div>
     </h4>
     <ul
-      class="css-1a9yu92-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1dmv26-paragraph-STYLES_UNORDERED_LIST-UL"
       data-text="true"
     >
       <li
         class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
       >
         <strong
-          class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+          class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
         >
           callback
            (
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             <a
               class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -9331,7 +9331,7 @@ provided with a single argument that is
             href="/#pedometerresult"
           >
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               PedometerResult
             </code>
@@ -9341,14 +9341,14 @@ provided with a single argument that is
       </li>
     </ul>
     <p
-      class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+      class="css-101h856-paragraph-STYLES_PARAGRAPH"
       data-text="true"
     >
       Subscribe to pedometer updates.
     </p>
     <div>
       <h4
-        class="  css-1j2s5xo-h4-h4-STYLES_H4"
+        class="  css-838f5l-h4-h4-STYLES_H4"
         data-components-heading="true"
         data-heading="true"
       >
@@ -9400,14 +9400,14 @@ provided with a single argument that is
         </div>
       </h4>
       <ul
-        class="css-1a9yu92-paragraph-STYLES_UNORDERED_LIST-UL"
+        class="css-1dmv26-paragraph-STYLES_UNORDERED_LIST-UL"
         data-text="true"
       >
         <li
           class="docs-list-item css-1wwpkbk-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
         >
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             <a
               class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -9419,7 +9419,7 @@ provided with a single argument that is
         </li>
       </ul>
       <p
-        class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+        class="css-101h856-paragraph-STYLES_PARAGRAPH"
         data-text="true"
       >
         Returns a 
@@ -9428,7 +9428,7 @@ provided with a single argument that is
           href="/#subscription"
         >
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             Subscription
           </code>
@@ -9436,7 +9436,7 @@ provided with a single argument that is
          that enables you to call
 
         <code
-          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
         >
           remove()
         </code>
@@ -9445,7 +9445,7 @@ provided with a single argument that is
     </div>
   </div>
   <h2
-    class="css-1v5aebx-h2-h2-STYLES_H2"
+    class="css-et60wy-h2-h2-STYLES_H2"
     data-heading="true"
   >
     <div
@@ -9497,7 +9497,7 @@ provided with a single argument that is
   </h2>
   <div>
     <h3
-      class="css-icxoph-h3-h3-STYLES_H3"
+      class="css-1fe5f89-h3-h3-STYLES_H3"
       data-heading="true"
     >
       <div
@@ -9515,7 +9515,7 @@ provided with a single argument that is
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               PedometerResult
               
@@ -9570,14 +9570,14 @@ provided with a single argument that is
         <tr>
           <td>
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               steps
             </strong>
           </td>
           <td>
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               number
             </code>
@@ -9593,7 +9593,7 @@ provided with a single argument that is
   </div>
   <div>
     <h3
-      class="css-icxoph-h3-h3-STYLES_H3"
+      class="css-1fe5f89-h3-h3-STYLES_H3"
       data-heading="true"
     >
       <div
@@ -9611,7 +9611,7 @@ provided with a single argument that is
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               PedometerUpdateCallback
               ()
@@ -9650,7 +9650,7 @@ provided with a single argument that is
     </h3>
     <div>
       <h4
-        class="  css-1j2s5xo-h4-h4-STYLES_H4"
+        class="  css-838f5l-h4-h4-STYLES_H4"
         data-components-heading="true"
         data-heading="true"
       >
@@ -9702,19 +9702,19 @@ provided with a single argument that is
         </div>
       </h4>
       <ul
-        class="css-1a9yu92-paragraph-STYLES_UNORDERED_LIST-UL"
+        class="css-1dmv26-paragraph-STYLES_UNORDERED_LIST-UL"
         data-text="true"
       >
         <li
           class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
         >
           <strong
-            class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+            class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
           >
             result
              (
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               <a
                 class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -9731,7 +9731,7 @@ provided with a single argument that is
   </div>
   <div>
     <h3
-      class="css-icxoph-h3-h3-STYLES_H3"
+      class="css-1fe5f89-h3-h3-STYLES_H3"
       data-heading="true"
     >
       <div
@@ -9749,7 +9749,7 @@ provided with a single argument that is
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               PermissionExpiration
             </code>
@@ -9786,14 +9786,14 @@ provided with a single argument that is
       </div>
     </h3>
     <p
-      class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+      class="css-101h856-paragraph-STYLES_PARAGRAPH"
       data-text="true"
     >
       Acceptable values are:
        
       <span>
         <code
-          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
         >
           'never'
         </code>
@@ -9801,7 +9801,7 @@ provided with a single argument that is
       </span>
       <span>
         <code
-          class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+          class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
         >
           number
         </code>
@@ -9811,7 +9811,7 @@ provided with a single argument that is
   </div>
   <div>
     <h3
-      class="css-icxoph-h3-h3-STYLES_H3"
+      class="css-1fe5f89-h3-h3-STYLES_H3"
       data-heading="true"
     >
       <div
@@ -9829,7 +9829,7 @@ provided with a single argument that is
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               Subscription
               
@@ -9884,14 +9884,14 @@ provided with a single argument that is
         <tr>
           <td>
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               remove
             </strong>
           </td>
           <td>
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               () =&gt;
                
@@ -9908,7 +9908,7 @@ provided with a single argument that is
     </table>
   </div>
   <h2
-    class="css-1v5aebx-h2-h2-STYLES_H2"
+    class="css-et60wy-h2-h2-STYLES_H2"
     data-heading="true"
   >
     <div
@@ -9960,7 +9960,7 @@ provided with a single argument that is
   </h2>
   <div>
     <h3
-      class="css-icxoph-h3-h3-STYLES_H3"
+      class="css-1fe5f89-h3-h3-STYLES_H3"
       data-heading="true"
     >
       <div
@@ -9978,7 +9978,7 @@ provided with a single argument that is
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               PermissionResponse
             </code>
@@ -10032,7 +10032,7 @@ provided with a single argument that is
         <tr>
           <td>
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               canAskAgain
               
@@ -10040,7 +10040,7 @@ provided with a single argument that is
           </td>
           <td>
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               boolean
             </code>
@@ -10052,7 +10052,7 @@ provided with a single argument that is
         <tr>
           <td>
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               expires
               
@@ -10060,7 +10060,7 @@ provided with a single argument that is
           </td>
           <td>
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               <a
                 class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -10077,7 +10077,7 @@ provided with a single argument that is
         <tr>
           <td>
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               granted
               
@@ -10085,7 +10085,7 @@ provided with a single argument that is
           </td>
           <td>
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               boolean
             </code>
@@ -10097,7 +10097,7 @@ provided with a single argument that is
         <tr>
           <td>
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               status
               
@@ -10105,7 +10105,7 @@ provided with a single argument that is
           </td>
           <td>
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               <a
                 class="css-12zqqiz-STYLES_EXTERNAL_LINK"
@@ -10123,7 +10123,7 @@ provided with a single argument that is
     </table>
   </div>
   <h2
-    class="css-1v5aebx-h2-h2-STYLES_H2"
+    class="css-et60wy-h2-h2-STYLES_H2"
     data-heading="true"
   >
     <div
@@ -10175,7 +10175,7 @@ provided with a single argument that is
   </h2>
   <div>
     <h3
-      class="css-icxoph-h3-h3-STYLES_H3"
+      class="css-1fe5f89-h3-h3-STYLES_H3"
       data-heading="true"
     >
       <div
@@ -10193,7 +10193,7 @@ provided with a single argument that is
             class="css-1icvi79-STYLED_PERMALINK_CONTENT"
           >
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               PermissionStatus
             </code>
@@ -10230,7 +10230,7 @@ provided with a single argument that is
       </div>
     </h3>
     <ul
-      class="css-1a9yu92-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1dmv26-paragraph-STYLES_UNORDERED_LIST-UL"
       data-text="true"
     >
       <li
@@ -10240,14 +10240,14 @@ provided with a single argument that is
           class="css-1aaoyoh-renderEnum"
         >
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             DENIED
           </code>
         </span>
         <br />
         <code
-          class="inline css-1nolcer-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
+          class="inline css-mcdrx3-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
         >
           PermissionStatus
           .
@@ -10263,14 +10263,14 @@ provided with a single argument that is
           class="css-1aaoyoh-renderEnum"
         >
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             GRANTED
           </code>
         </span>
         <br />
         <code
-          class="inline css-1nolcer-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
+          class="inline css-mcdrx3-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
         >
           PermissionStatus
           .
@@ -10286,14 +10286,14 @@ provided with a single argument that is
           class="css-1aaoyoh-renderEnum"
         >
           <code
-            class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
           >
             UNDETERMINED
           </code>
         </span>
         <br />
         <code
-          class="inline css-1nolcer-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
+          class="inline css-mcdrx3-STYLES_INLINE_CODE-STYLES_ENUM_VALUE-InlineCode"
         >
           PermissionStatus
           .
@@ -10310,7 +10310,7 @@ provided with a single argument that is
 exports[`APISection no data 1`] = `
 <div>
   <p
-    class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+    class="css-101h856-paragraph-STYLES_PARAGRAPH"
     data-text="true"
   >
     No API data file found, sorry!

--- a/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             style="margin-left: 0px; display: block; list-style-type: circle; overflow-x: visible;"
           >
             <div
-              class=" css-xq8ktq-paragraph-STYLES_PARAGRAPH_DIV"
+              class=" css-pb2q8c-paragraph-STYLES_PARAGRAPH_DIV"
               data-text="true"
             >
               <div
@@ -43,7 +43,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                     class="css-1icvi79-STYLED_PERMALINK_CONTENT"
                   >
                     <code
-                      class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+                      class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
                     >
                       name
                     </code>
@@ -85,11 +85,11 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           class="css-1pd7e0y-STYLES_DESCRIPTION_CELL"
         >
           <div
-            class=" css-xq8ktq-paragraph-STYLES_PARAGRAPH_DIV"
+            class=" css-pb2q8c-paragraph-STYLES_PARAGRAPH_DIV"
             data-text="true"
           >
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               (string)
             </strong>
@@ -98,7 +98,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               class="css-lkrdcy-STYLES_DETAILS"
             >
               <summary
-                class="css-642pov-STYLES_SUMMARY"
+                class="css-gqo6ad-STYLES_SUMMARY"
               >
                 Bare Workflow
               </summary>
@@ -118,7 +118,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             style="margin-left: 0px; display: block; list-style-type: circle; overflow-x: visible;"
           >
             <div
-              class=" css-xq8ktq-paragraph-STYLES_PARAGRAPH_DIV"
+              class=" css-pb2q8c-paragraph-STYLES_PARAGRAPH_DIV"
               data-text="true"
             >
               <div
@@ -136,7 +136,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                     class="css-1icvi79-STYLED_PERMALINK_CONTENT"
                   >
                     <code
-                      class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+                      class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
                     >
                       androidNavigationBar
                     </code>
@@ -178,11 +178,11 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           class="css-1pd7e0y-STYLES_DESCRIPTION_CELL"
         >
           <div
-            class=" css-xq8ktq-paragraph-STYLES_PARAGRAPH_DIV"
+            class=" css-pb2q8c-paragraph-STYLES_PARAGRAPH_DIV"
             data-text="true"
           >
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               (object)
             </strong>
@@ -191,7 +191,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               class="css-lkrdcy-STYLES_DETAILS"
             >
               <summary
-                class="css-642pov-STYLES_SUMMARY"
+                class="css-gqo6ad-STYLES_SUMMARY"
               >
                 ExpoKit
               </summary>
@@ -205,7 +205,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               class="css-lkrdcy-STYLES_DETAILS"
             >
               <summary
-                class="css-642pov-STYLES_SUMMARY"
+                class="css-gqo6ad-STYLES_SUMMARY"
               >
                 Bare Workflow
               </summary>
@@ -225,7 +225,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             style="margin-left: 32px; display: list-item; list-style-type: default; overflow-x: visible;"
           >
             <div
-              class=" css-xq8ktq-paragraph-STYLES_PARAGRAPH_DIV"
+              class=" css-pb2q8c-paragraph-STYLES_PARAGRAPH_DIV"
               data-text="true"
             >
               <div
@@ -243,7 +243,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                     class="css-1icvi79-STYLED_PERMALINK_CONTENT"
                   >
                     <code
-                      class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+                      class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
                     >
                       visible
                     </code>
@@ -285,11 +285,11 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           class="css-1pd7e0y-STYLES_DESCRIPTION_CELL"
         >
           <div
-            class=" css-xq8ktq-paragraph-STYLES_PARAGRAPH_DIV"
+            class=" css-pb2q8c-paragraph-STYLES_PARAGRAPH_DIV"
             data-text="true"
           >
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               (enum)
             </strong>
@@ -298,7 +298,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               class="css-lkrdcy-STYLES_DETAILS"
             >
               <summary
-                class="css-642pov-STYLES_SUMMARY"
+                class="css-gqo6ad-STYLES_SUMMARY"
               >
                 ExpoKit
               </summary>
@@ -318,7 +318,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             style="margin-left: 64px; display: list-item; list-style-type: circle; overflow-x: visible;"
           >
             <div
-              class=" css-xq8ktq-paragraph-STYLES_PARAGRAPH_DIV"
+              class=" css-pb2q8c-paragraph-STYLES_PARAGRAPH_DIV"
               data-text="true"
             >
               <div
@@ -336,7 +336,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                     class="css-1icvi79-STYLED_PERMALINK_CONTENT"
                   >
                     <code
-                      class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+                      class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
                     >
                       always
                     </code>
@@ -378,11 +378,11 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           class="css-1pd7e0y-STYLES_DESCRIPTION_CELL"
         >
           <div
-            class=" css-xq8ktq-paragraph-STYLES_PARAGRAPH_DIV"
+            class=" css-pb2q8c-paragraph-STYLES_PARAGRAPH_DIV"
             data-text="true"
           >
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               (boolean)
             </strong>
@@ -397,7 +397,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             style="margin-left: 32px; display: list-item; list-style-type: default; overflow-x: visible;"
           >
             <div
-              class=" css-xq8ktq-paragraph-STYLES_PARAGRAPH_DIV"
+              class=" css-pb2q8c-paragraph-STYLES_PARAGRAPH_DIV"
               data-text="true"
             >
               <div
@@ -415,7 +415,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                     class="css-1icvi79-STYLED_PERMALINK_CONTENT"
                   >
                     <code
-                      class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+                      class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
                     >
                       backgroundColor
                     </code>
@@ -457,23 +457,23 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           class="css-1pd7e0y-STYLES_DESCRIPTION_CELL"
         >
           <div
-            class=" css-xq8ktq-paragraph-STYLES_PARAGRAPH_DIV"
+            class=" css-pb2q8c-paragraph-STYLES_PARAGRAPH_DIV"
             data-text="true"
           >
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               (string)
             </strong>
              - Specifies the background color of the navigation bar. 
           </div>
           <div
-            class=" css-xq8ktq-paragraph-STYLES_PARAGRAPH_DIV"
+            class=" css-pb2q8c-paragraph-STYLES_PARAGRAPH_DIV"
             data-text="true"
           >
             6 character long hex color string, eg: 
             <code
-              class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
               '#000000'
             </code>
@@ -487,7 +487,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             style="margin-left: 0px; display: block; list-style-type: circle; overflow-x: visible;"
           >
             <div
-              class=" css-xq8ktq-paragraph-STYLES_PARAGRAPH_DIV"
+              class=" css-pb2q8c-paragraph-STYLES_PARAGRAPH_DIV"
               data-text="true"
             >
               <div
@@ -505,7 +505,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                     class="css-1icvi79-STYLED_PERMALINK_CONTENT"
                   >
                     <code
-                      class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+                      class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
                     >
                       intentFilters
                     </code>
@@ -547,11 +547,11 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           class="css-1pd7e0y-STYLES_DESCRIPTION_CELL"
         >
           <div
-            class=" css-xq8ktq-paragraph-STYLES_PARAGRAPH_DIV"
+            class=" css-pb2q8c-paragraph-STYLES_PARAGRAPH_DIV"
             data-text="true"
           >
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               (array)
             </strong>
@@ -560,7 +560,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               class="css-lkrdcy-STYLES_DETAILS"
             >
               <summary
-                class="css-642pov-STYLES_SUMMARY"
+                class="css-gqo6ad-STYLES_SUMMARY"
               >
                 Bare Workflow
               </summary>
@@ -572,7 +572,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </details>
           </div>
           <blockquote
-            class="css-e76wiv-paragraph-STYLES_BLOCKQUOTE"
+            class="css-1vk32i8-paragraph-STYLES_BLOCKQUOTE"
             data-text="true"
           >
             <div>
@@ -596,7 +596,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </div>
             <div>
               <div
-                class=" css-xq8ktq-paragraph-STYLES_PARAGRAPH_DIV"
+                class=" css-pb2q8c-paragraph-STYLES_PARAGRAPH_DIV"
                 data-text="true"
               >
                  
@@ -617,7 +617,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             style="margin-left: 32px; display: list-item; list-style-type: default; overflow-x: visible;"
           >
             <div
-              class=" css-xq8ktq-paragraph-STYLES_PARAGRAPH_DIV"
+              class=" css-pb2q8c-paragraph-STYLES_PARAGRAPH_DIV"
               data-text="true"
             >
               <div
@@ -635,7 +635,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                     class="css-1icvi79-STYLED_PERMALINK_CONTENT"
                   >
                     <code
-                      class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+                      class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
                     >
                       autoVerify
                     </code>
@@ -677,11 +677,11 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           class="css-1pd7e0y-STYLES_DESCRIPTION_CELL"
         >
           <div
-            class=" css-xq8ktq-paragraph-STYLES_PARAGRAPH_DIV"
+            class=" css-pb2q8c-paragraph-STYLES_PARAGRAPH_DIV"
             data-text="true"
           >
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               (boolean)
             </strong>
@@ -696,7 +696,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             style="margin-left: 32px; display: list-item; list-style-type: default; overflow-x: visible;"
           >
             <div
-              class=" css-xq8ktq-paragraph-STYLES_PARAGRAPH_DIV"
+              class=" css-pb2q8c-paragraph-STYLES_PARAGRAPH_DIV"
               data-text="true"
             >
               <div
@@ -714,7 +714,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                     class="css-1icvi79-STYLED_PERMALINK_CONTENT"
                   >
                     <code
-                      class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+                      class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
                     >
                       data
                     </code>
@@ -756,11 +756,11 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           class="css-1pd7e0y-STYLES_DESCRIPTION_CELL"
         >
           <div
-            class=" css-xq8ktq-paragraph-STYLES_PARAGRAPH_DIV"
+            class=" css-pb2q8c-paragraph-STYLES_PARAGRAPH_DIV"
             data-text="true"
           >
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               (array || object)
             </strong>
@@ -774,7 +774,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             style="margin-left: 64px; display: list-item; list-style-type: circle; overflow-x: visible;"
           >
             <div
-              class=" css-xq8ktq-paragraph-STYLES_PARAGRAPH_DIV"
+              class=" css-pb2q8c-paragraph-STYLES_PARAGRAPH_DIV"
               data-text="true"
             >
               <div
@@ -792,7 +792,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                     class="css-1icvi79-STYLED_PERMALINK_CONTENT"
                   >
                     <code
-                      class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+                      class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
                     >
                       host
                     </code>
@@ -834,11 +834,11 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           class="css-1pd7e0y-STYLES_DESCRIPTION_CELL"
         >
           <div
-            class=" css-xq8ktq-paragraph-STYLES_PARAGRAPH_DIV"
+            class=" css-pb2q8c-paragraph-STYLES_PARAGRAPH_DIV"
             data-text="true"
           >
             <strong
-              class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
               (string)
             </strong>

--- a/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
+++ b/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`APISectionUtils.CommentTextBlock component basic comment 1`] = `
 <div>
   <p
-    class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+    class="css-101h856-paragraph-STYLES_PARAGRAPH"
     data-text="true"
   >
     This is the basic comment.
@@ -23,11 +23,11 @@ exports[`APISectionUtils.CommentTextBlock component basic inline comment 1`] = `
 exports[`APISectionUtils.CommentTextBlock component comment with example 1`] = `
 <div>
   <p
-    class="css-1xnkoxs-paragraph-STYLES_PARAGRAPH"
+    class="css-101h856-paragraph-STYLES_PARAGRAPH"
     data-text="true"
   >
     <strong
-      class="css-kkqcgt-paragraph-STYLES_BOLD_PARAGRAPH"
+      class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
     >
       Android only.
     </strong>
@@ -38,7 +38,7 @@ exports[`APISectionUtils.CommentTextBlock component comment with example 1`] = `
       rel="noopener noreferrer"
     >
       <code
-        class="inline css-vuokze-STYLES_INLINE_CODE-InlineCode"
+        class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
       >
         Install Referrer API
       </code>
@@ -47,7 +47,7 @@ exports[`APISectionUtils.CommentTextBlock component comment with example 1`] = `
 from the Google Play Store. In practice, the referrer URL may not be a complete, absolute URL.
   </p>
   <h4
-    class="css-1j2s5xo-h4-h4-STYLES_H4"
+    class="css-838f5l-h4-h4-STYLES_H4"
     data-heading="true"
   >
     Example
@@ -58,7 +58,7 @@ from the Google Play Store. In practice, the referrer URL may not be a complete,
       data-text="true"
     >
       <code
-        class="css-13ek3hw-STYLES_CODE_BLOCK"
+        class="css-149nz3h-STYLES_CODE_BLOCK"
       >
         <span
           class="token keyword"

--- a/docs/constants/theme.js
+++ b/docs/constants/theme.js
@@ -1,4 +1,5 @@
-export const fonts = {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const fonts = {
   bold: 'expo-brand-bold',
   book: 'expo-brand-book',
   demi: 'expo-brand-demi',
@@ -8,7 +9,8 @@ export const fonts = {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const fontStack = `system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,'Noto Sans',sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol','Noto Color Emoji'`;
 
-export const fontFamilies = {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const fontFamilies = {
   bold: `${fonts.bold}`,
   book: `${fonts.book}`,
   demi: `${fonts.demi}`,

--- a/docs/global-styles/extras.ts
+++ b/docs/global-styles/extras.ts
@@ -1,7 +1,5 @@
 import { css } from '@emotion/react';
-import { theme, palette } from '@expo/styleguide';
-
-import * as Constants from '~/constants/theme';
+import { theme, palette, typography } from '@expo/styleguide';
 
 export const globalExtras = css`
   img.wide-image {
@@ -37,13 +35,13 @@ export const globalExtras = css`
   details summary h3 {
     font-size: 1.2rem;
     font-weight: 500;
-    font-family: ${Constants.fonts.demi};
+    font-family: ${typography.fontFaces.medium};
     color: ${theme.text.default};
     display: inline-block;
   }
 
   details summary h4 {
-    font-family: ${Constants.fonts.demi};
+    font-family: ${typography.fontFaces.medium};
     color: ${theme.text.default};
     font-size: 1rem;
     font-weight: 500;
@@ -80,7 +78,7 @@ export const globalExtras = css`
     text-decoration: none;
     background: ${theme.button.primary.background};
     color: ${palette.dark.white};
-    font-family: ${Constants.fontFamilies.book};
+    font-family: ${typography.fontFaces.regular};
     font-size: 1rem;
     cursor: pointer;
     -webkit-appearance: none;

--- a/docs/global-styles/fonts.ts
+++ b/docs/global-styles/fonts.ts
@@ -1,10 +1,9 @@
 import { css } from '@emotion/react';
-
-import * as Constants from '~/constants/theme';
+import { typography } from '@expo/styleguide';
 
 export const globalFonts = css`
   @font-face {
-    font-family: ${Constants.fonts.bold};
+    font-family: ${typography.fontFaces.semiBold};
     font-style: normal;
     font-weight: 600;
     src: url('/static/fonts/Inter-SemiBold.woff2?v=3.15') format('woff2'),
@@ -12,7 +11,7 @@ export const globalFonts = css`
   }
 
   @font-face {
-    font-family: ${Constants.fonts.book};
+    font-family: ${typography.fontFaces.regular};
     font-style: normal;
     font-weight: 400;
     src: url('/static/fonts/Inter-Regular.woff2?v=3.15') format('woff2'),
@@ -20,7 +19,7 @@ export const globalFonts = css`
   }
 
   @font-face {
-    font-family: ${Constants.fonts.demi};
+    font-family: ${typography.fontFaces.medium};
     font-style: normal;
     font-weight: 500;
     src: url('/static/fonts/Inter-Medium.woff2?v=3.15') format('woff2'),
@@ -28,7 +27,7 @@ export const globalFonts = css`
   }
 
   @font-face {
-    font-family: ${Constants.fonts.mono};
+    font-family: ${typography.fontFaces.mono};
     src: url('/static/fonts/Menlo-Regular.woff2'),
       url('/static/fonts/Menlo-Regular.woff') format('woff');
   }

--- a/docs/global-styles/reset.ts
+++ b/docs/global-styles/reset.ts
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { theme } from '@expo/styleguide';
+import { theme, typography } from '@expo/styleguide';
 
 import * as Constants from '~/constants/theme';
 
@@ -118,7 +118,7 @@ export const globalReset = css`
   }
 
   body {
-    font-family: ${Constants.fonts.book};
+    font-family: ${typography.fontFaces.regular};
     text-rendering: optimizeLegibility;
     font-size: 16px;
   }

--- a/docs/global-styles/tables.ts
+++ b/docs/global-styles/tables.ts
@@ -1,7 +1,5 @@
 import { css } from '@emotion/react';
-import { theme } from '@expo/styleguide';
-
-import * as Constants from '~/constants/theme';
+import { theme, typography } from '@expo/styleguide';
 
 export const globalTables = css`
   table {
@@ -41,7 +39,7 @@ export const globalTables = css`
   }
 
   th {
-    font-family: ${Constants.fontFamilies.bold};
+    font-family: ${typography.fontFaces.semiBold};
     font-weight: 400;
   }
 `;

--- a/docs/global-styles/tippy.ts
+++ b/docs/global-styles/tippy.ts
@@ -1,8 +1,7 @@
 import { css } from '@emotion/react';
-import { palette } from '@expo/styleguide';
+import { palette, typography } from '@expo/styleguide';
 
 import { paragraph } from '~/components/base/typography';
-import * as Constants from '~/constants/theme';
 
 export const globalTippy = css`
   div.tippy-box {
@@ -19,7 +18,7 @@ export const globalTippy = css`
   .tippy-box[data-theme~='expo'] .tippy-content {
     ${paragraph};
     color: ${palette.dark.gray[900]};
-    font-family: ${Constants.fonts.book};
+    font-family: ${typography.fontFaces.regular};
     font-weight: 400;
     font-size: 16px;
     line-height: 160%;

--- a/docs/package.json
+++ b/docs/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@emotion/react": "^11.4.0",
     "@expo/spawn-async": "^1.5.0",
-    "@expo/styleguide": "^3.0.0",
+    "@expo/styleguide": "^3.5.1",
     "@mdx-js/loader": "^1.6.22",
     "@mdx-js/mdx": "^1.6.22",
     "@mdx-js/react": "^1.6.22",

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -556,7 +556,7 @@
   dependencies:
     cross-spawn "^6.0.5"
 
-"@expo/styleguide@^3.0.0":
+"@expo/styleguide@^3.5.1":
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/@expo/styleguide/-/styleguide-3.5.1.tgz#20a35ab7a376572a3695a0d3e808dc8273ceaf0e"
   integrity sha512-TLJs7nvnpen3pWOQiLjf5x9SN6WOx7ORV5w9Q5mDn8EVBtBf/wuRzt8HdIVj0NOryAO2zC0vdD6xyojtVB4XYQ==


### PR DESCRIPTION
# Why

Part of [ENG-3962](https://linear.app/expo/issue/ENG-3962/add-new-components-as-separate-prs-in-expoexpo)

This only replaces the references we use in all components, it does not redesign anything. I copied this stuff from expo.dev.

# How

Replaced all references of `Constants.fonts` to `typography.fontFaces`:

- `Constants.fonts.bold` → `typography.fontFaces.semiBold` 
- `Constants.fonts.book` → `typography.fontFaces.regular` 
- `Constants.fonts.demi` → `typography.fontFaces.medium`
- `Constants.fonts.mono` → `typography.fontFaces.mono`

@jonsamp Would be nice if we could also register the font files from the package maybe?

# Test Plan

Check if the docs looks ok

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
