### PR TITLE
[image-picker][Android][plugin] Migrate to `com.github.CanHub:Android-Image-Cropper`

### DIFF
--- a/THIRD-PARTY-LICENSES
+++ b/THIRD-PARTY-LICENSES
@@ -31,8 +31,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ===============================================================================
 
-                             Android-Image-Cropper
-               https://github.com/ArthurHub/Android-Image-Cropper
+                        CanHub/Android-Image-Cropper
+               https://github.com/CanHub/Android-Image-Cropper
 
 -------------------------------------------------------------------------------
 
@@ -479,4 +479,4 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-=============================================================================== 
+===============================================================================

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -142,7 +142,6 @@ dependencies {
   implementation 'com.facebook.device.yearclass:yearclass:2.1.0'
   implementation 'commons-io:commons-io:1.4'
   implementation 'me.leolin:ShortcutBadger:1.1.4@aar'
-  implementation 'com.theartofdev.edmodo:android-image-cropper:2.8.0' // to be removed once old sdks migrate to the com.github.CanHub:Android-Image-Cropper
   implementation 'com.github.CanHub:Android-Image-Cropper:1.1.1'
   implementation 'commons-codec:commons-codec:1.10'
   implementation 'com.segment.analytics.android:analytics:4.3.0'

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -142,7 +142,8 @@ dependencies {
   implementation 'com.facebook.device.yearclass:yearclass:2.1.0'
   implementation 'commons-io:commons-io:1.4'
   implementation 'me.leolin:ShortcutBadger:1.1.4@aar'
-  implementation 'com.theartofdev.edmodo:android-image-cropper:2.8.0'
+  implementation 'com.theartofdev.edmodo:android-image-cropper:2.8.0' // to be removed once old sdks migrate to the com.github.CanHub:Android-Image-Cropper
+  implementation 'com.github.CanHub:Android-Image-Cropper:1.1.1'
   implementation 'commons-codec:commons-codec:1.10'
   implementation 'com.segment.analytics.android:analytics:4.3.0'
   implementation 'com.google.zxing:core:3.3.3'

--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -100,6 +100,8 @@ repositories {
 android {
   compileSdkVersion safeExtGet("compileSdkVersion", 30)
 
+  ndkVersion "21.1.6352462"
+
   compileOptions {
     sourceCompatibility = '1.8'
     targetCompatibility = '1.8'

--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -218,7 +218,7 @@ import org.apache.tools.ant.taskdefs.condition.Os
 
 class GenerateDynamicMacrosPlugin implements Plugin<Project> {
   @Override
-  void apply(Project target) {
+  void apply(org.gradle.api.Project target) {
     target.exec {
       def configuration = target.gradle.startParameter.taskNames.any {
         it.toLowerCase().contains("release")
@@ -339,7 +339,7 @@ dependencies {
   releaseApi 'com.squareup.leakcanary:leakcanary-android-no-op:1.4-beta1'
   api 'commons-io:commons-io:2.6'
   api 'me.leolin:ShortcutBadger:1.1.4@aar'
-  api 'com.theartofdev.edmodo:android-image-cropper:2.8.0'
+  implementation "com.github.CanHub:Android-Image-Cropper:1.1.1"
   api 'commons-codec:commons-codec:1.10'
   api 'net.openid:appauth:0.7.1'
   api 'com.airbnb.android:lottie:3.4.0'

--- a/android/versioned-abis/expoview-abi42_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi42_0_0/build.gradle
@@ -120,7 +120,7 @@ dependencies {
   releaseApi 'com.squareup.leakcanary:leakcanary-android-no-op:1.4-beta1'
   api 'commons-io:commons-io:2.6'
   api 'me.leolin:ShortcutBadger:1.1.4@aar'
-  api 'com.theartofdev.edmodo:android-image-cropper:2.7.0'
+  implementation "com.github.CanHub:Android-Image-Cropper:1.1.1"
   api 'commons-codec:commons-codec:1.10'
   api 'net.openid:appauth:0.7.1'
   api 'com.airbnb.android:lottie:3.4.0'

--- a/android/versioned-abis/expoview-abi42_0_0/src/main/AndroidManifest.xml
+++ b/android/versioned-abis/expoview-abi42_0_0/src/main/AndroidManifest.xml
@@ -186,7 +186,7 @@
         </provider>
 
         <activity
-            android:name="com.theartofdev.edmodo.cropper.CropImageActivity"
+            android:name="com.canhub.cropper.CropImageActivity"
             android:theme="@style/Base.Theme.AppCompat" /> <!-- https://developer.android.com/guide/topics/manifest/provider-element.html -->
         <provider
             android:name="abi42_0_0.expo.modules.imagepicker.ImagePickerFileProvider"

--- a/android/versioned-abis/expoview-abi42_0_0/src/main/java/abi42_0_0/expo/modules/imagepicker/ImagePickerConstants.kt
+++ b/android/versioned-abis/expoview-abi42_0_0/src/main/java/abi42_0_0/expo/modules/imagepicker/ImagePickerConstants.kt
@@ -23,6 +23,8 @@ object ImagePickerConstants {
   const val MISSING_URL_MESSAGE = "Intent doesn't contain `url`."
   const val ERR_CAN_NOT_OPEN_CROP = "ERR_CAN_NOT_OPEN_CROP"
   const val CAN_NOT_OPEN_CROP_MESSAGE = "Can not open the crop tool."
+  const val ERR_CROPPING_FAILURE = "ERR_CROPPING_FAILURE"
+  const val CROPPING_FAILURE_MESSAGE = "Cropping operation failed"
 
   const val OPTION_QUALITY = "quality"
   const val OPTION_ALLOWS_EDITING = "allowsEditing"

--- a/android/versioned-abis/expoview-abi42_0_0/src/main/java/abi42_0_0/expo/modules/imagepicker/ImagePickerModule.kt
+++ b/android/versioned-abis/expoview-abi42_0_0/src/main/java/abi42_0_0/expo/modules/imagepicker/ImagePickerModule.kt
@@ -10,7 +10,7 @@ import android.net.Uri
 import android.os.Bundle
 import android.provider.MediaStore
 import android.util.Log
-import com.theartofdev.edmodo.cropper.CropImage
+import com.canhub.cropper.CropImage
 import abi42_0_0.expo.modules.imagepicker.ImagePickerOptions.Companion.optionsFromMap
 import abi42_0_0.expo.modules.imagepicker.exporters.CompressionImageExporter
 import abi42_0_0.expo.modules.imagepicker.exporters.CropImageExporter
@@ -340,7 +340,10 @@ class ImagePickerModule(
     val contentResolver = activity.application.contentResolver
 
     if (requestCode == CropImage.CROP_IMAGE_ACTIVITY_REQUEST_CODE) {
-      val result = CropImage.getActivityResult(intent)
+      val result = CropImage.getActivityResult(intent).ifNull {
+        promise.reject(ImagePickerConstants.ERR_CROPPING_FAILURE, ImagePickerConstants.CROPPING_FAILURE_MESSAGE)
+        return
+      }
       val exporter = CropImageExporter(result.rotation, result.cropRect, pickerOptions.isBase64)
       ImageResultTask(promise, result.uri, contentResolver, CropFileProvider(result.uri), pickerOptions.isExif, exporter).execute()
       return

--- a/android/versioned-abis/expoview-abi43_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi43_0_0/build.gradle
@@ -129,7 +129,7 @@ dependencies {
   releaseApi 'com.squareup.leakcanary:leakcanary-android-no-op:1.4-beta1'
   api 'commons-io:commons-io:2.6'
   api 'me.leolin:ShortcutBadger:1.1.4@aar'
-  api 'com.theartofdev.edmodo:android-image-cropper:2.8.0'
+  implementation "com.github.CanHub:Android-Image-Cropper:1.1.1"
   api 'commons-codec:commons-codec:1.10'
   api 'net.openid:appauth:0.7.1'
   api 'com.airbnb.android:lottie:3.4.0'

--- a/android/versioned-abis/expoview-abi43_0_0/src/main/AndroidManifest.xml
+++ b/android/versioned-abis/expoview-abi43_0_0/src/main/AndroidManifest.xml
@@ -264,7 +264,7 @@
         </provider>
 
         <activity
-            android:name="com.theartofdev.edmodo.cropper.CropImageActivity"
+            android:name="com.canhub.cropper.CropImageActivity"
             android:theme="@style/Base.Theme.AppCompat" /> <!-- https://developer.android.com/guide/topics/manifest/provider-element.html -->
         <provider
             android:name="abi43_0_0.expo.modules.imagepicker.ImagePickerFileProvider"

--- a/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/imagepicker/ImagePickerConstants.kt
+++ b/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/imagepicker/ImagePickerConstants.kt
@@ -26,6 +26,8 @@ object ImagePickerConstants {
   const val COROUTINE_CANCELED = "Coroutine canceled by module destruction."
   const val PROMISES_CANCELED = "Module destroyed, all promises canceled."
   const val UNKNOWN_EXCEPTION = "Unknown exception."
+  const val ERR_CROPPING_FAILURE = "ERR_CROPPING_FAILURE"
+  const val CROPPING_FAILURE_MESSAGE = "Cropping operation failed"
 
   const val OPTION_QUALITY = "quality"
   const val OPTION_ALLOWS_EDITING = "allowsEditing"

--- a/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/imagepicker/ImagePickerModule.kt
+++ b/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/imagepicker/ImagePickerModule.kt
@@ -10,7 +10,7 @@ import android.net.Uri
 import android.os.Bundle
 import android.provider.MediaStore
 import android.util.Log
-import com.theartofdev.edmodo.cropper.CropImage
+import com.canhub.cropper.CropImage
 import abi43_0_0.expo.modules.core.ExportedModule
 import abi43_0_0.expo.modules.core.ModuleRegistry
 import abi43_0_0.expo.modules.core.ModuleRegistryDelegate
@@ -355,7 +355,10 @@ class ImagePickerModule(
     val contentResolver = activity.application.contentResolver
 
     if (requestCode == CropImage.CROP_IMAGE_ACTIVITY_REQUEST_CODE) {
-      val result = CropImage.getActivityResult(intent)
+      val result = CropImage.getActivityResult(intent).ifNull {
+        promise.reject(ImagePickerConstants.ERR_CROPPING_FAILURE, ImagePickerConstants.CROPPING_FAILURE_MESSAGE)
+        return
+      }
       val exporter = CropImageExporter(result.rotation, result.cropRect, pickerOptions.isBase64)
       ImageResultTask(
         promise,

--- a/android/versioned-abis/expoview-abi44_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi44_0_0/build.gradle
@@ -130,7 +130,7 @@ dependencies {
   releaseApi 'com.squareup.leakcanary:leakcanary-android-no-op:1.4-beta1'
   api 'commons-io:commons-io:2.6'
   api 'me.leolin:ShortcutBadger:1.1.4@aar'
-  api 'com.theartofdev.edmodo:android-image-cropper:2.8.0'
+  implementation "com.github.CanHub:Android-Image-Cropper:1.1.1"
   api 'commons-codec:commons-codec:1.10'
   api 'net.openid:appauth:0.7.1'
   api 'com.airbnb.android:lottie:3.4.0'

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/AndroidManifest.xml
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/AndroidManifest.xml
@@ -265,7 +265,7 @@
         </provider>
 
         <activity
-            android:name="com.theartofdev.edmodo.cropper.CropImageActivity"
+            android:name="com.canhub.edmodo.cropper.CropImageActivity"
             android:theme="@style/Base.Theme.AppCompat" /> <!-- https://developer.android.com/guide/topics/manifest/provider-element.html -->
         <provider
             android:name="abi44_0_0.expo.modules.imagepicker.ImagePickerFileProvider"

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/imagepicker/ImagePickerConstants.kt
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/imagepicker/ImagePickerConstants.kt
@@ -26,6 +26,8 @@ object ImagePickerConstants {
   const val COROUTINE_CANCELED = "Coroutine canceled by module destruction."
   const val PROMISES_CANCELED = "Module destroyed, all promises canceled."
   const val UNKNOWN_EXCEPTION = "Unknown exception."
+  const val ERR_CROPPING_FAILURE = "ERR_CROPPING_FAILURE"
+  const val CROPPING_FAILURE_MESSAGE = "Cropping operation failed"
 
   const val OPTION_QUALITY = "quality"
   const val OPTION_ALLOWS_EDITING = "allowsEditing"

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/imagepicker/ImagePickerModule.kt
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/imagepicker/ImagePickerModule.kt
@@ -10,7 +10,7 @@ import android.net.Uri
 import android.os.Bundle
 import android.provider.MediaStore
 import android.util.Log
-import com.theartofdev.edmodo.cropper.CropImage
+import com.canhub.cropper.CropImage
 import abi44_0_0.expo.modules.core.ExportedModule
 import abi44_0_0.expo.modules.core.ModuleRegistry
 import abi44_0_0.expo.modules.core.ModuleRegistryDelegate
@@ -356,7 +356,10 @@ class ImagePickerModule(
     val contentResolver = activity.application.contentResolver
 
     if (requestCode == CropImage.CROP_IMAGE_ACTIVITY_REQUEST_CODE) {
-      val result = CropImage.getActivityResult(intent)
+      val result = CropImage.getActivityResult(intent).ifNull {
+        promise.reject(ImagePickerConstants.ERR_CROPPING_FAILURE, ImagePickerConstants.CROPPING_FAILURE_MESSAGE)
+        return
+      }
       val exporter = CropImageExporter(result.rotation, result.cropRect, pickerOptions.isBase64)
       ImageResultTask(
         promise,

--- a/apps/bare-sandbox/android/app/src/main/AndroidManifest.xml
+++ b/apps/bare-sandbox/android/app/src/main/AndroidManifest.xml
@@ -40,6 +40,6 @@
         <data android:scheme="dev.expo.devclient"/>
       </intent-filter>
     </activity>
-    <activity android:name="com.theartofdev.edmodo.cropper.CropImageActivity" android:theme="@style/Base.Theme.AppCompat"/>
+    <activity android:name="com.canhub.cropper.CropImageActivity" android:theme="@style/Base.Theme.AppCompat"/>
   </application>
 </manifest>

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- On Android migrated cropping library from `com.theartofdev.edmodo:android-image-cropper@2.8.0` (available from `jcenter()`) to `com.github.CanHub:Android-Image-Cropper@1.1.1` (available from `jitpack.io`). ([#11647](https://github.com/expo/expo/pull/11647) by [@bbarthec](https://github.com/bbarthec))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/expo-image-picker/README.md
+++ b/packages/expo-image-picker/README.md
@@ -51,7 +51,7 @@ In `AndroidManifest.xml` add the following `activity` within `application`:
 
 ```xml
 <activity
-  android:name="com.theartofdev.edmodo.cropper.CropImageActivity"
+  android:name="com.canhub.cropper.CropImageActivity"
   android:theme="@style/Base.Theme.AppCompat">
 </activity>
 ```

--- a/packages/expo-image-picker/android/build.gradle
+++ b/packages/expo-image-picker/android/build.gradle
@@ -13,6 +13,7 @@ buildscript {
 
   repositories {
     mavenCentral()
+    maven { url 'https://jitpack.io' }
   }
 
   dependencies {
@@ -72,7 +73,8 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.6.10')}"
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.1")
-  api 'com.theartofdev.edmodo:android-image-cropper:2.8.0'
+  implementation "com.github.CanHub:Android-Image-Cropper:1.1.1"
+  implementation "androidx.exifinterface:exifinterface:1.3.3"
   api "androidx.legacy:legacy-support-v4:1.0.0"
   api 'commons-codec:commons-codec:1.10'
   api 'commons-io:commons-io:2.6'

--- a/packages/expo-image-picker/android/build.gradle
+++ b/packages/expo-image-picker/android/build.gradle
@@ -13,7 +13,6 @@ buildscript {
 
   repositories {
     mavenCentral()
-    maven { url 'https://jitpack.io' }
   }
 
   dependencies {

--- a/packages/expo-image-picker/android/src/main/AndroidManifest.xml
+++ b/packages/expo-image-picker/android/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
 
     <application>
       <activity
-        android:name="com.theartofdev.edmodo.cropper.CropImageActivity"
+        android:name="com.canhub.cropper.CropImageActivity"
         android:theme="@style/Base.Theme.AppCompat"/>
       <!-- https://developer.android.com/guide/topics/manifest/provider-element.html -->
         <provider

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerConstants.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerConstants.kt
@@ -26,6 +26,8 @@ object ImagePickerConstants {
   const val COROUTINE_CANCELED = "Coroutine canceled by module destruction."
   const val PROMISES_CANCELED = "Module destroyed, all promises canceled."
   const val UNKNOWN_EXCEPTION = "Unknown exception."
+  const val ERR_CROPPING_FAILURE = "ERR_CROPPING_FAILURE"
+  const val CROPPING_FAILURE_MESSAGE = "Cropping operation failed"
 
   const val OPTION_QUALITY = "quality"
   const val OPTION_ALLOWS_EDITING = "allowsEditing"

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
@@ -10,7 +10,7 @@ import android.net.Uri
 import android.os.Bundle
 import android.provider.MediaStore
 import android.util.Log
-import com.theartofdev.edmodo.cropper.CropImage
+import com.canhub.cropper.CropImage
 import expo.modules.core.ExportedModule
 import expo.modules.core.ModuleRegistry
 import expo.modules.core.ModuleRegistryDelegate
@@ -356,7 +356,11 @@ class ImagePickerModule(
     val contentResolver = activity.application.contentResolver
 
     if (requestCode == CropImage.CROP_IMAGE_ACTIVITY_REQUEST_CODE) {
-      val result = CropImage.getActivityResult(intent)
+      val result = CropImage.getActivityResult(intent).ifNull {
+        promise.reject(ImagePickerConstants.ERR_CROPPING_FAILURE, ImagePickerConstants.CROPPING_FAILURE_MESSAGE)
+        return
+      }
+
       val exporter = CropImageExporter(result.rotation, result.cropRect, pickerOptions.isBase64)
       ImageResultTask(
         promise,

--- a/packages/expo-image-picker/plugin/build/withImagePicker.js
+++ b/packages/expo-image-picker/plugin/build/withImagePicker.js
@@ -11,10 +11,10 @@ function setImagePickerManifestActivity(androidManifest) {
     if (!app.activity) {
         app.activity = [];
     }
-    if (!app.activity.find(({ $ }) => $['android:name'] === 'com.theartofdev.edmodo.cropper.CropImageActivity')) {
+    if (!app.activity.find(({ $ }) => $['android:name'] === 'com.canhub.cropper.CropImageActivity')) {
         app.activity.push({
             $: {
-                'android:name': 'com.theartofdev.edmodo.cropper.CropImageActivity',
+                'android:name': 'com.canhub.cropper.CropImageActivity',
                 'android:theme': '@style/Base.Theme.AppCompat',
             },
         });

--- a/packages/expo-image-picker/plugin/src/__tests__/withImagePicker-test.ts
+++ b/packages/expo-image-picker/plugin/src/__tests__/withImagePicker-test.ts
@@ -17,7 +17,7 @@ describe(setImagePickerManifestActivity, () => {
     const app = AndroidConfig.Manifest.getMainApplicationOrThrow(androidManifestJson);
     expect(app.activity[2]).toStrictEqual({
       $: {
-        'android:name': 'com.theartofdev.edmodo.cropper.CropImageActivity',
+        'android:name': 'com.canhub.cropper.CropImageActivity',
         'android:theme': '@style/Base.Theme.AppCompat',
       },
     });

--- a/packages/expo-image-picker/plugin/src/withImagePicker.ts
+++ b/packages/expo-image-picker/plugin/src/withImagePicker.ts
@@ -19,14 +19,10 @@ export function setImagePickerManifestActivity(
   if (!app.activity) {
     app.activity = [];
   }
-  if (
-    !app.activity.find(
-      ({ $ }) => $['android:name'] === 'com.theartofdev.edmodo.cropper.CropImageActivity'
-    )
-  ) {
+  if (!app.activity.find(({ $ }) => $['android:name'] === 'com.canhub.cropper.CropImageActivity')) {
     app.activity.push({
       $: {
-        'android:name': 'com.theartofdev.edmodo.cropper.CropImageActivity',
+        'android:name': 'com.canhub.cropper.CropImageActivity',
         'android:theme': '@style/Base.Theme.AppCompat',
       },
     });

--- a/template-files/android/AndroidManifest.xml
+++ b/template-files/android/AndroidManifest.xml
@@ -79,7 +79,7 @@
           android:host="expo.io"
           android:path="/expo-go"
           android:scheme="http"/>
-        
+
         <data
           android:host="expo.dev"
           android:path="/expo-go"
@@ -94,7 +94,7 @@
         <category android:name="android.intent.category.DEFAULT"/>
         <category android:name="android.intent.category.BROWSABLE"/>
       </intent-filter>
-      
+
       <!-- This has to be separate from the exp[s]:// scheme filter. No idea why -->
       <intent-filter>
         <data
@@ -309,7 +309,7 @@
 
     <!-- ImagePicker native module -->
     <activity
-      android:name="com.theartofdev.edmodo.cropper.CropImageActivity"
+      android:name="com.canhub.cropper.CropImageActivity"
       android:theme="@style/Base.Theme.AppCompat">
     </activity>
 


### PR DESCRIPTION
# Why

Part of [ENG-1858](https://linear.app/expo/issue/ENG-2858/remove-jcenter)

# How

Migrated to `https://github.com/CanHub/Android-Image-Cropper@1.1.1`.
Version 1.0.0 is published invalidly to the jitpack.io repository. 

# Test Plan

- [x] `bare-expo`#`image-picker-screen` - editing files works & `test-suite` works
- [x] `Expo Go@unversioned & @SDK44` works

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
