### PR TITLE
[av][Android] Bump `com.google.android.exoplayer:exoplayer` from `2.9.2` to `2.13.3`

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,6 @@ buildscript {
 
     dbFlowVersion = '4.2.4'
     buildToolsVersion = '30.0.2'
-    supportLibVersion = '29.0.0'
     kotlinVersion = '1.6.10'
     gradlePluginVersion = '4.2.2'
     gradleDownloadTaskVersion = '3.4.3'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,7 +16,6 @@ buildscript {
   repositories {
     google()
     mavenCentral()
-    jcenter()
   }
   dependencies {
     classpath "com.android.tools.build:gradle:${gradlePluginVersion}"

--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -84,7 +84,6 @@ buildscript {
     maven { url "https://www.jitpack.io" }
     mavenCentral()
     google()
-    jcenter()
   }
   dependencies {
     classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${safeExtGet('kotlinVersion', '1.6.10')}")
@@ -371,7 +370,7 @@ dependencies {
 
   // expo-av
   // See explanation in expo-av/build.gradle
-  api 'com.google.android.exoplayer:extension-okhttp:2.9.2'
+  api 'com.google.android.exoplayer:extension-okhttp:2.13.3'
 
   // expo-application
   api 'com.android.installreferrer:installreferrer:1.0'

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/av/CustomHeadersOkHttpDataSourceFactory.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/av/CustomHeadersOkHttpDataSourceFactory.kt
@@ -29,7 +29,7 @@ class CustomHeadersOkHttpDataSourceFactory(
   }
 
   override fun createDataSourceInternal(defaultRequestProperties: RequestProperties): OkHttpDataSource {
-    return OkHttpDataSource(callFactory, userAgent, null, cacheControl, defaultRequestProperties)
+    return OkHttpDataSource(callFactory, userAgent, cacheControl, defaultRequestProperties)
   }
 
   init {

--- a/android/versioned-abis/expoview-abi42_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi42_0_0/build.gradle
@@ -21,7 +21,6 @@ buildscript {
     maven { url "https://www.jitpack.io" }
     mavenCentral()
     google()
-    jcenter()
   }
   dependencies {
     classpath 'com.jakewharton:butterknife-gradle-plugin:10.2.1'
@@ -150,7 +149,7 @@ dependencies {
 
   // expo-av
   // See explanation in expo-av/build.gradle
-  api 'com.google.android.exoplayer:extension-okhttp:2.9.2'
+  api 'com.google.android.exoplayer:extension-okhttp:2.13.3'
 
   // expo-application
   api 'com.android.installreferrer:installreferrer:1.0'

--- a/android/versioned-abis/expoview-abi42_0_0/src/main/java/abi42_0_0/expo/modules/av/player/SimpleExoPlayerData.java
+++ b/android/versioned-abis/expoview-abi42_0_0/src/main/java/abi42_0_0/expo/modules/av/player/SimpleExoPlayerData.java
@@ -5,28 +5,25 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.os.Handler;
 
-import androidx.annotation.Nullable;
-
 import android.text.TextUtils;
 import android.util.Log;
 import android.util.Pair;
 import android.view.Surface;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.google.android.exoplayer2.C;
-import com.google.android.exoplayer2.DefaultLoadControl;
-import com.google.android.exoplayer2.DefaultRenderersFactory;
 import com.google.android.exoplayer2.ExoPlaybackException;
-import com.google.android.exoplayer2.ExoPlayerFactory;
-import com.google.android.exoplayer2.Format;
+import com.google.android.exoplayer2.MediaItem;
 import com.google.android.exoplayer2.PlaybackParameters;
 import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.SimpleExoPlayer;
-import com.google.android.exoplayer2.Timeline;
-import com.google.android.exoplayer2.extractor.DefaultExtractorsFactory;
-import com.google.android.exoplayer2.source.AdaptiveMediaSourceEventListener;
 import com.google.android.exoplayer2.source.ExtractorMediaSource;
+import com.google.android.exoplayer2.source.LoadEventInfo;
+import com.google.android.exoplayer2.source.MediaLoadData;
 import com.google.android.exoplayer2.source.MediaSource;
-import com.google.android.exoplayer2.source.TrackGroupArray;
+import com.google.android.exoplayer2.source.MediaSourceEventListener;
 import com.google.android.exoplayer2.source.dash.DashMediaSource;
 import com.google.android.exoplayer2.source.dash.DefaultDashChunkSource;
 import com.google.android.exoplayer2.source.hls.HlsMediaSource;
@@ -34,8 +31,6 @@ import com.google.android.exoplayer2.source.smoothstreaming.DefaultSsChunkSource
 import com.google.android.exoplayer2.source.smoothstreaming.SsMediaSource;
 import com.google.android.exoplayer2.trackselection.AdaptiveTrackSelection;
 import com.google.android.exoplayer2.trackselection.DefaultTrackSelector;
-import com.google.android.exoplayer2.trackselection.TrackSelection;
-import com.google.android.exoplayer2.trackselection.TrackSelectionArray;
 import com.google.android.exoplayer2.trackselection.TrackSelector;
 import com.google.android.exoplayer2.upstream.BandwidthMeter;
 import com.google.android.exoplayer2.upstream.DataSource;
@@ -43,32 +38,33 @@ import com.google.android.exoplayer2.upstream.DataSpec;
 import com.google.android.exoplayer2.upstream.DefaultBandwidthMeter;
 import com.google.android.exoplayer2.upstream.RawResourceDataSource;
 import com.google.android.exoplayer2.util.Util;
+import com.google.android.exoplayer2.video.VideoListener;
 
 import java.io.IOException;
 import java.util.Map;
 
 import abi42_0_0.expo.modules.av.AVManagerInterface;
 import abi42_0_0.expo.modules.av.AudioFocusNotAcquiredException;
-import abi42_0_0.expo.modules.av.player.datasource.CustomHeadersOkHttpDataSourceFactory;
 import abi42_0_0.expo.modules.av.player.datasource.DataSourceFactoryProvider;
 
 class SimpleExoPlayerData extends PlayerData
-  implements Player.EventListener, ExtractorMediaSource.EventListener, SimpleExoPlayer.VideoListener, AdaptiveMediaSourceEventListener {
+    implements Player.EventListener, MediaSourceEventListener, VideoListener {
 
   private static final String IMPLEMENTATION_NAME = "SimpleExoPlayer";
   private static final String TAG = SimpleExoPlayerData.class.getSimpleName();
 
   private SimpleExoPlayer mSimpleExoPlayer = null;
-  private String mOverridingExtension;
+  private final String mOverridingExtension;
   private LoadCompletionListener mLoadCompletionListener = null;
   private boolean mFirstFrameRendered = false;
   private Pair<Integer, Integer> mVideoWidthHeight = null;
   private Integer mLastPlaybackState = null;
   private boolean mIsLooping = false;
   private boolean mIsLoading = true;
-  private Context mReactContext;
+  private final Context mReactContext;
 
-  SimpleExoPlayerData(final AVManagerInterface avModule, final Context context, final Uri uri, final String overridingExtension, final Map<String, Object> requestHeaders) {
+  SimpleExoPlayerData(final AVManagerInterface avModule, final Context context, final Uri uri,
+      final String overridingExtension, final Map<String, Object> requestHeaders) {
     super(avModule, uri, requestHeaders);
     mReactContext = context;
     mOverridingExtension = overridingExtension;
@@ -87,29 +83,31 @@ class SimpleExoPlayerData extends PlayerData
   public void load(final Bundle status, final LoadCompletionListener loadCompletionListener) {
     mLoadCompletionListener = loadCompletionListener;
 
-    // Create a default TrackSelector
-    final Handler mainHandler = new Handler();
-    // Measures bandwidth during playback. Can be null if not required.
-    final BandwidthMeter bandwidthMeter = new DefaultBandwidthMeter();
-    final TrackSelection.Factory trackSelectionFactory = new AdaptiveTrackSelection.Factory();
-    final TrackSelector trackSelector = new DefaultTrackSelector(trackSelectionFactory);
+    final Context context = mAVModule.getContext();
+    final BandwidthMeter bandwidthMeter = new DefaultBandwidthMeter.Builder(context).build();
+    final TrackSelector trackSelector = new DefaultTrackSelector(context, new AdaptiveTrackSelection.Factory());
 
     // Create the player
-    mSimpleExoPlayer = ExoPlayerFactory.newSimpleInstance(
-      mAVModule.getContext(),
-      new DefaultRenderersFactory(mAVModule.getContext()),
-      trackSelector,
-      new DefaultLoadControl(),
-      null,
-      bandwidthMeter);
+    mSimpleExoPlayer = new SimpleExoPlayer.Builder(context)
+        .setTrackSelector(trackSelector)
+        .setBandwidthMeter(bandwidthMeter)
+        .build();
+
     mSimpleExoPlayer.addListener(this);
     mSimpleExoPlayer.addVideoListener(this);
 
     // Produces DataSource instances through which media data is loaded.
-    final DataSource.Factory dataSourceFactory = mAVModule.getModuleRegistry().getModule(DataSourceFactoryProvider.class).createFactory(mReactContext, mAVModule.getModuleRegistry(), Util.getUserAgent(mAVModule.getContext(), "yourApplicationName"), mRequestHeaders, bandwidthMeter.getTransferListener());
+    final DataSource.Factory dataSourceFactory = mAVModule.getModuleRegistry()
+        .getModule(DataSourceFactoryProvider.class)
+        .createFactory(
+            mReactContext,
+            mAVModule.getModuleRegistry(),
+            Util.getUserAgent(context, "yourApplicationName"),
+            mRequestHeaders,
+            bandwidthMeter.getTransferListener());
     try {
       // This is the MediaSource representing the media to be played.
-      final MediaSource source = buildMediaSource(mUri, mOverridingExtension, mainHandler, dataSourceFactory);
+      final MediaSource source = buildMediaSource(mUri, mOverridingExtension, dataSourceFactory);
 
       // Prepare the player with the source.
       mSimpleExoPlayer.prepare(source);
@@ -121,6 +119,7 @@ class SimpleExoPlayerData extends PlayerData
 
   @Override
   public synchronized void release() {
+    stopUpdatingProgressIfNecessary();
     if (mSimpleExoPlayer != null) {
       mSimpleExoPlayer.release();
       mSimpleExoPlayer = null;
@@ -153,7 +152,7 @@ class SimpleExoPlayerData extends PlayerData
 
   @Override
   void applyNewStatus(final Integer newPositionMillis, final Boolean newIsLooping)
-    throws AudioFocusNotAcquiredException, IllegalStateException {
+      throws AudioFocusNotAcquiredException, IllegalStateException {
     if (mSimpleExoPlayer == null) {
       throw new IllegalStateException("mSimpleExoPlayer is null!");
     }
@@ -200,14 +199,14 @@ class SimpleExoPlayerData extends PlayerData
     final int duration = (int) mSimpleExoPlayer.getDuration();
     map.putInt(STATUS_DURATION_MILLIS_KEY_PATH, duration);
     map.putInt(STATUS_POSITION_MILLIS_KEY_PATH,
-      getClippedIntegerForValue((int) mSimpleExoPlayer.getCurrentPosition(), 0, duration));
+        getClippedIntegerForValue((int) mSimpleExoPlayer.getCurrentPosition(), 0, duration));
     map.putInt(STATUS_PLAYABLE_DURATION_MILLIS_KEY_PATH,
-      getClippedIntegerForValue((int) mSimpleExoPlayer.getBufferedPosition(), 0, duration));
+        getClippedIntegerForValue((int) mSimpleExoPlayer.getBufferedPosition(), 0, duration));
 
     map.putBoolean(STATUS_IS_PLAYING_KEY_PATH,
-      mSimpleExoPlayer.getPlayWhenReady() && mSimpleExoPlayer.getPlaybackState() == Player.STATE_READY);
+        mSimpleExoPlayer.getPlayWhenReady() && mSimpleExoPlayer.getPlaybackState() == Player.STATE_READY);
     map.putBoolean(STATUS_IS_BUFFERING_KEY_PATH,
-      mIsLoading || mSimpleExoPlayer.getPlaybackState() == Player.STATE_BUFFERING);
+        mIsLoading || mSimpleExoPlayer.getPlaybackState() == Player.STATE_BUFFERING);
 
     map.putBoolean(STATUS_IS_LOOPING_KEY_PATH, mIsLooping);
   }
@@ -233,7 +232,7 @@ class SimpleExoPlayerData extends PlayerData
 
   // --------- Interface implementation ---------
 
-  // AudioEventHandler
+  // region AudioEventHandler
 
   @Override
   public void pauseImmediately() {
@@ -255,7 +254,9 @@ class SimpleExoPlayerData extends PlayerData
     }
   }
 
-  // ExoPlayer.EventListener
+  // endregion
+
+  // region ExoPlayer.EventListener
 
   @Override
   public void onLoadingChanged(final boolean isLoading) {
@@ -282,12 +283,6 @@ class SimpleExoPlayerData extends PlayerData
   }
 
   @Override
-  public void onTracksChanged(TrackGroupArray trackGroups,
-                              TrackSelectionArray trackSelections) {
-
-  }
-
-  @Override
   public void onPlayerStateChanged(final boolean playWhenReady, final int playbackState) {
     if (playbackState == Player.STATE_READY && mLoadCompletionListener != null) {
       final LoadCompletionListener listener = mLoadCompletionListener;
@@ -296,8 +291,8 @@ class SimpleExoPlayerData extends PlayerData
     }
 
     if (mLastPlaybackState != null
-      && playbackState != mLastPlaybackState
-      && playbackState == Player.STATE_ENDED) {
+        && playbackState != mLastPlaybackState
+        && playbackState == Player.STATE_ENDED) {
       callStatusUpdateListenerWithDidJustFinish();
       stopUpdatingProgressIfNecessary();
     } else {
@@ -320,7 +315,8 @@ class SimpleExoPlayerData extends PlayerData
     // > A period defines a single logical piece of media, for example a media file.
     // > It may also define groups of ads inserted into the media,
     // > along with information about whether those ads have been loaded and played.
-    // Source: https://google.github.io/ExoPlayer/doc/reference/com/google/android/exoplayer2/Timeline.Period.html
+    // Source:
+    // https://google.github.io/ExoPlayer/doc/reference/com/google/android/exoplayer2/Timeline.Period.html
     // So I guess it's safe to say that when a period transition happens,
     // media file transition happens, so we just finished playing one.
     if (reason == Player.DISCONTINUITY_REASON_PERIOD_TRANSITION) {
@@ -328,11 +324,18 @@ class SimpleExoPlayerData extends PlayerData
     }
   }
 
+  // endregion
 
-  // ExtractorMediaSource.EventListener
+  // region MediaSourceEventListener
 
   @Override
-  public void onLoadError(final IOException error) {
+  public void onLoadError(
+      int windowIndex,
+      @Nullable MediaSource.MediaPeriodId mediaPeriodId,
+      LoadEventInfo loadEventInfo,
+      MediaLoadData mediaLoadData,
+      IOException error,
+      boolean wasCanceled) {
     if (mLoadCompletionListener != null) {
       final LoadCompletionListener listener = mLoadCompletionListener;
       mLoadCompletionListener = null;
@@ -351,10 +354,13 @@ class SimpleExoPlayerData extends PlayerData
     release();
   }
 
-  // SimpleExoPlayer.VideoListener
+  // endregion
+
+  // region VideoListener
 
   @Override
-  public void onVideoSizeChanged(final int width, final int height, final int unAppliedRotationDegrees, final float pixelWidthHeightRatio) {
+  public void onVideoSizeChanged(final int width, final int height, final int unAppliedRotationDegrees,
+      final float pixelWidthHeightRatio) {
     // TODO other params?
     mVideoWidthHeight = new Pair<>(width, height);
     if (mFirstFrameRendered && mVideoSizeUpdateListener != null) {
@@ -370,11 +376,13 @@ class SimpleExoPlayerData extends PlayerData
     mFirstFrameRendered = true;
   }
 
-  // https://github.com/google/ExoPlayer/blob/2b20780482a9c6b07416bcbf4de829532859d10a/demos/main/src/main/java/com/google/android/exoplayer2/demo/PlayerActivity.java#L365-L393
-  private MediaSource buildMediaSource(Uri uri, String overrideExtension, Handler mainHandler, DataSource.Factory factory) {
+  // endregion
+
+  private MediaSource buildMediaSource(@NonNull Uri uri, String overrideExtension, DataSource.Factory factory) {
     try {
       if (uri.getScheme() == null) {
-        int resourceId = mReactContext.getResources().getIdentifier(uri.toString(), "raw", mReactContext.getPackageName());
+        int resourceId = mReactContext.getResources().getIdentifier(uri.toString(), "raw",
+            mReactContext.getPackageName());
         DataSpec dataSpec = new DataSpec(RawResourceDataSource.buildRawResourceUri(resourceId));
         final RawResourceDataSource rawResourceDataSource = new RawResourceDataSource(mReactContext);
         rawResourceDataSource.open(dataSpec);
@@ -383,67 +391,57 @@ class SimpleExoPlayerData extends PlayerData
     } catch (Exception e) {
       Log.e(TAG, "Error reading raw resource from ExoPlayer", e);
     }
-    @C.ContentType int type = TextUtils.isEmpty(overrideExtension) ? Util.inferContentType(String.valueOf(uri)) : Util.inferContentType("." + overrideExtension);
+    @C.ContentType
+    int type = TextUtils.isEmpty(overrideExtension) ? Util.inferContentType(String.valueOf(uri))
+        : Util.inferContentType("." + overrideExtension);
     switch (type) {
       case C.TYPE_SS:
-        return new SsMediaSource(uri, factory,
-          new DefaultSsChunkSource.Factory(factory), mainHandler, this);
+        return new SsMediaSource.Factory(new DefaultSsChunkSource.Factory(factory), factory)
+            .createMediaSource(MediaItem.fromUri(uri));
       case C.TYPE_DASH:
-        return new DashMediaSource(uri, factory,
-          new DefaultDashChunkSource.Factory(factory), mainHandler, this);
+        return new DashMediaSource.Factory(new DefaultDashChunkSource.Factory(factory), factory)
+            .createMediaSource(MediaItem.fromUri(uri));
       case C.TYPE_HLS:
-        return new HlsMediaSource(uri, factory, mainHandler, this);
+        return new HlsMediaSource.Factory(factory).createMediaSource(MediaItem.fromUri(uri));
       case C.TYPE_OTHER:
-        return new ExtractorMediaSource(uri, factory, new DefaultExtractorsFactory(), mainHandler, this);
+        return new ExtractorMediaSource.Factory(factory).createMediaSource(MediaItem.fromUri(uri));
       default: {
         throw new IllegalStateException("Content of this type is unsupported at the moment. Unsupported type: " + type);
       }
     }
   }
 
-  // AdaptiveMediaSourceEventListener
+  // region MediaSourceEventListener
+
   @Override
-  public void onMediaPeriodCreated(int windowIndex, MediaSource.MediaPeriodId mediaPeriodId) {
+  public void onLoadStarted(int windowIndex, @Nullable MediaSource.MediaPeriodId mediaPeriodId,
+      LoadEventInfo loadEventInfo, MediaLoadData mediaLoadData) {
 
   }
 
   @Override
-  public void onMediaPeriodReleased(int windowIndex, MediaSource.MediaPeriodId mediaPeriodId) {
+  public void onLoadCompleted(int windowIndex, @Nullable MediaSource.MediaPeriodId mediaPeriodId,
+      LoadEventInfo loadEventInfo, MediaLoadData mediaLoadData) {
 
   }
 
   @Override
-  public void onLoadStarted(int windowIndex, @Nullable MediaSource.MediaPeriodId mediaPeriodId, LoadEventInfo loadEventInfo, MediaLoadData mediaLoadData) {
+  public void onLoadCanceled(int windowIndex, @Nullable MediaSource.MediaPeriodId mediaPeriodId,
+      LoadEventInfo loadEventInfo, MediaLoadData mediaLoadData) {
 
   }
 
   @Override
-  public void onLoadCompleted(int windowIndex, @Nullable MediaSource.MediaPeriodId mediaPeriodId, LoadEventInfo loadEventInfo, MediaLoadData mediaLoadData) {
+  public void onUpstreamDiscarded(int windowIndex, MediaSource.MediaPeriodId mediaPeriodId,
+      MediaLoadData mediaLoadData) {
 
   }
 
   @Override
-  public void onLoadCanceled(int windowIndex, @Nullable MediaSource.MediaPeriodId mediaPeriodId, LoadEventInfo loadEventInfo, MediaLoadData mediaLoadData) {
+  public void onDownstreamFormatChanged(int windowIndex, @Nullable MediaSource.MediaPeriodId mediaPeriodId,
+      MediaLoadData mediaLoadData) {
 
   }
 
-  @Override
-  public void onLoadError(int windowIndex, @Nullable MediaSource.MediaPeriodId mediaPeriodId, LoadEventInfo loadEventInfo, MediaLoadData mediaLoadData, IOException error, boolean wasCanceled) {
-
-  }
-
-  @Override
-  public void onReadingStarted(int windowIndex, MediaSource.MediaPeriodId mediaPeriodId) {
-
-  }
-
-  @Override
-  public void onUpstreamDiscarded(int windowIndex, MediaSource.MediaPeriodId mediaPeriodId, MediaLoadData mediaLoadData) {
-
-  }
-
-  @Override
-  public void onDownstreamFormatChanged(int windowIndex, @Nullable MediaSource.MediaPeriodId mediaPeriodId, MediaLoadData mediaLoadData) {
-
-  }
+  // endregion
 }

--- a/android/versioned-abis/expoview-abi42_0_0/src/main/java/abi42_0_0/expo/modules/av/player/datasource/CustomHeadersOkHttpDataSourceFactory.java
+++ b/android/versioned-abis/expoview-abi42_0_0/src/main/java/abi42_0_0/expo/modules/av/player/datasource/CustomHeadersOkHttpDataSourceFactory.java
@@ -42,6 +42,6 @@ public class CustomHeadersOkHttpDataSourceFactory extends HttpDataSource.BaseFac
   }
 
   protected OkHttpDataSource createDataSourceInternal(HttpDataSource.RequestProperties defaultRequestProperties) {
-    return new OkHttpDataSource(mCallFactory, mUserAgent, null, mCacheControl, defaultRequestProperties);
+    return new OkHttpDataSource(mCallFactory, mUserAgent, mCacheControl, defaultRequestProperties);
   }
 }

--- a/android/versioned-abis/expoview-abi42_0_0/src/main/java/abi42_0_0/expo/modules/av/video/VideoManager.java
+++ b/android/versioned-abis/expoview-abi42_0_0/src/main/java/abi42_0_0/expo/modules/av/video/VideoManager.java
@@ -3,11 +3,10 @@ package abi42_0_0.expo.modules.av.video;
 import android.content.Context;
 import androidx.annotation.Nullable;
 
-import com.yqritc.scalablevideoview.ScalableType;
-
 import java.util.HashMap;
 import java.util.Map;
 
+import abi42_0_0.expo.modules.av.video.scalablevideoview.ScalableType;
 import abi42_0_0.org.unimodules.core.ExportedModule;
 import abi42_0_0.org.unimodules.core.ModuleRegistry;
 import abi42_0_0.org.unimodules.core.Promise;

--- a/android/versioned-abis/expoview-abi42_0_0/src/main/java/abi42_0_0/expo/modules/av/video/VideoTextureView.java
+++ b/android/versioned-abis/expoview-abi42_0_0/src/main/java/abi42_0_0/expo/modules/av/video/VideoTextureView.java
@@ -5,13 +5,13 @@ import android.content.Context;
 import android.graphics.Matrix;
 import android.graphics.SurfaceTexture;
 import android.util.Pair;
+import android.util.Size;
 import android.view.Surface;
 import android.view.TextureView;
 import android.view.View;
 
-import com.yqritc.scalablevideoview.ScalableType;
-import com.yqritc.scalablevideoview.ScaleManager;
-import com.yqritc.scalablevideoview.Size;
+import abi42_0_0.expo.modules.av.video.scalablevideoview.ScalableType;
+import abi42_0_0.expo.modules.av.video.scalablevideoview.ScaleManager;
 
 @SuppressLint("ViewConstructor")
 public class VideoTextureView extends TextureView implements TextureView.SurfaceTextureListener {

--- a/android/versioned-abis/expoview-abi42_0_0/src/main/java/abi42_0_0/expo/modules/av/video/VideoView.java
+++ b/android/versioned-abis/expoview-abi42_0_0/src/main/java/abi42_0_0/expo/modules/av/video/VideoView.java
@@ -9,8 +9,7 @@ import android.view.MotionEvent;
 import android.view.Surface;
 import android.widget.FrameLayout;
 
-import com.yqritc.scalablevideoview.ScalableType;
-
+import abi42_0_0.expo.modules.av.video.scalablevideoview.ScalableType;
 import abi42_0_0.org.unimodules.core.ModuleRegistry;
 import abi42_0_0.org.unimodules.core.Promise;
 import abi42_0_0.org.unimodules.core.arguments.ReadableArguments;

--- a/android/versioned-abis/expoview-abi42_0_0/src/main/java/abi42_0_0/expo/modules/av/video/VideoViewManager.java
+++ b/android/versioned-abis/expoview-abi42_0_0/src/main/java/abi42_0_0/expo/modules/av/video/VideoViewManager.java
@@ -2,11 +2,10 @@ package abi42_0_0.expo.modules.av.video;
 
 import android.content.Context;
 
-import com.yqritc.scalablevideoview.ScalableType;
-
 import java.util.ArrayList;
 import java.util.List;
 
+import abi42_0_0.expo.modules.av.video.scalablevideoview.ScalableType;
 import abi42_0_0.org.unimodules.core.ModuleRegistry;
 import abi42_0_0.org.unimodules.core.ViewManager;
 import abi42_0_0.org.unimodules.core.arguments.ReadableArguments;

--- a/android/versioned-abis/expoview-abi42_0_0/src/main/java/abi42_0_0/expo/modules/av/video/scalablevideoview/PivotPoint.java
+++ b/android/versioned-abis/expoview-abi42_0_0/src/main/java/abi42_0_0/expo/modules/av/video/scalablevideoview/PivotPoint.java
@@ -1,0 +1,17 @@
+package abi42_0_0.expo.modules.av.video.scalablevideoview;
+
+/**
+ * The following class is copied from https://github.com/yqritc/Android-ScalableVideoView/blob/master/library/src/main/java/com/yqritc/scalablevideoview/PivotPoint.java
+ * as the original library (com.yqritc:android-scalablevideoview) is only available on jcenter() repository and we're moved from fetching libraries from there.
+ */
+public enum PivotPoint {
+  LEFT_TOP,
+  LEFT_CENTER,
+  LEFT_BOTTOM,
+  CENTER_TOP,
+  CENTER,
+  CENTER_BOTTOM,
+  RIGHT_TOP,
+  RIGHT_CENTER,
+  RIGHT_BOTTOM
+}

--- a/android/versioned-abis/expoview-abi42_0_0/src/main/java/abi42_0_0/expo/modules/av/video/scalablevideoview/ScalableType.java
+++ b/android/versioned-abis/expoview-abi42_0_0/src/main/java/abi42_0_0/expo/modules/av/video/scalablevideoview/ScalableType.java
@@ -1,0 +1,38 @@
+package abi42_0_0.expo.modules.av.video.scalablevideoview;
+
+/**
+ * The following class is copied from https://github.com/yqritc/Android-ScalableVideoView/blob/master/library/src/main/java/com/yqritc/scalablevideoview/ScalableType.java
+ * as the original library (com.yqritc:android-scalablevideoview) is only available on jcenter() repository and we're moved from fetching libraries from there.
+ */
+public enum ScalableType {
+  NONE,
+
+  FIT_XY,
+  FIT_START,
+  FIT_CENTER,
+  FIT_END,
+
+  LEFT_TOP,
+  LEFT_CENTER,
+  LEFT_BOTTOM,
+  CENTER_TOP,
+  CENTER,
+  CENTER_BOTTOM,
+  RIGHT_TOP,
+  RIGHT_CENTER,
+  RIGHT_BOTTOM,
+
+  LEFT_TOP_CROP,
+  LEFT_CENTER_CROP,
+  LEFT_BOTTOM_CROP,
+  CENTER_TOP_CROP,
+  CENTER_CROP,
+  CENTER_BOTTOM_CROP,
+  RIGHT_TOP_CROP,
+  RIGHT_CENTER_CROP,
+  RIGHT_BOTTOM_CROP,
+
+  START_INSIDE,
+  CENTER_INSIDE,
+  END_INSIDE
+}

--- a/android/versioned-abis/expoview-abi42_0_0/src/main/java/abi42_0_0/expo/modules/av/video/scalablevideoview/ScaleManager.java
+++ b/android/versioned-abis/expoview-abi42_0_0/src/main/java/abi42_0_0/expo/modules/av/video/scalablevideoview/ScaleManager.java
@@ -1,0 +1,193 @@
+package abi42_0_0.expo.modules.av.video.scalablevideoview;
+
+import android.graphics.Matrix;
+import android.util.Size;
+
+/**
+ * The following class is copied from https://github.com/yqritc/Android-ScalableVideoView/blob/master/library/src/main/java/com/yqritc/scalablevideoview/ScaleManager.java
+ * as the original library (com.yqritc:android-scalablevideoview) is only available on jcenter() repository and we're moved from fetching libraries from there.
+ */
+public class ScaleManager {
+
+  private Size mViewSize;
+  private Size mVideoSize;
+
+  public ScaleManager(Size viewSize, Size videoSize) {
+    mViewSize = viewSize;
+    mVideoSize = videoSize;
+  }
+
+  public Matrix getScaleMatrix(ScalableType scalableType) {
+    switch (scalableType) {
+      case NONE:
+        return getNoScale();
+
+      case FIT_XY:
+        return fitXY();
+      case FIT_CENTER:
+        return fitCenter();
+      case FIT_START:
+        return fitStart();
+      case FIT_END:
+        return fitEnd();
+
+      case LEFT_TOP:
+        return getOriginalScale(PivotPoint.LEFT_TOP);
+      case LEFT_CENTER:
+        return getOriginalScale(PivotPoint.LEFT_CENTER);
+      case LEFT_BOTTOM:
+        return getOriginalScale(PivotPoint.LEFT_BOTTOM);
+      case CENTER_TOP:
+        return getOriginalScale(PivotPoint.CENTER_TOP);
+      case CENTER:
+        return getOriginalScale(PivotPoint.CENTER);
+      case CENTER_BOTTOM:
+        return getOriginalScale(PivotPoint.CENTER_BOTTOM);
+      case RIGHT_TOP:
+        return getOriginalScale(PivotPoint.RIGHT_TOP);
+      case RIGHT_CENTER:
+        return getOriginalScale(PivotPoint.RIGHT_CENTER);
+      case RIGHT_BOTTOM:
+        return getOriginalScale(PivotPoint.RIGHT_BOTTOM);
+
+      case LEFT_TOP_CROP:
+        return getCropScale(PivotPoint.LEFT_TOP);
+      case LEFT_CENTER_CROP:
+        return getCropScale(PivotPoint.LEFT_CENTER);
+      case LEFT_BOTTOM_CROP:
+        return getCropScale(PivotPoint.LEFT_BOTTOM);
+      case CENTER_TOP_CROP:
+        return getCropScale(PivotPoint.CENTER_TOP);
+      case CENTER_CROP:
+        return getCropScale(PivotPoint.CENTER);
+      case CENTER_BOTTOM_CROP:
+        return getCropScale(PivotPoint.CENTER_BOTTOM);
+      case RIGHT_TOP_CROP:
+        return getCropScale(PivotPoint.RIGHT_TOP);
+      case RIGHT_CENTER_CROP:
+        return getCropScale(PivotPoint.RIGHT_CENTER);
+      case RIGHT_BOTTOM_CROP:
+        return getCropScale(PivotPoint.RIGHT_BOTTOM);
+
+      case START_INSIDE:
+        return startInside();
+      case CENTER_INSIDE:
+        return centerInside();
+      case END_INSIDE:
+        return endInside();
+
+      default:
+        return null;
+    }
+  }
+
+  private Matrix getMatrix(float sx, float sy, float px, float py) {
+    Matrix matrix = new Matrix();
+    matrix.setScale(sx, sy, px, py);
+    return matrix;
+  }
+
+  private Matrix getMatrix(float sx, float sy, PivotPoint pivotPoint) {
+    switch (pivotPoint) {
+      case LEFT_TOP:
+        return getMatrix(sx, sy, 0, 0);
+      case LEFT_CENTER:
+        return getMatrix(sx, sy, 0, mViewSize.getHeight() / 2f);
+      case LEFT_BOTTOM:
+        return getMatrix(sx, sy, 0, mViewSize.getHeight());
+      case CENTER_TOP:
+        return getMatrix(sx, sy, mViewSize.getWidth() / 2f, 0);
+      case CENTER:
+        return getMatrix(sx, sy, mViewSize.getWidth() / 2f, mViewSize.getHeight() / 2f);
+      case CENTER_BOTTOM:
+        return getMatrix(sx, sy, mViewSize.getWidth() / 2f, mViewSize.getHeight());
+      case RIGHT_TOP:
+        return getMatrix(sx, sy, mViewSize.getWidth(), 0);
+      case RIGHT_CENTER:
+        return getMatrix(sx, sy, mViewSize.getWidth(), mViewSize.getHeight() / 2f);
+      case RIGHT_BOTTOM:
+        return getMatrix(sx, sy, mViewSize.getWidth(), mViewSize.getHeight());
+      default:
+        throw new IllegalArgumentException("Illegal PivotPoint");
+    }
+  }
+
+  private Matrix getNoScale() {
+    float sx = mVideoSize.getWidth() / (float) mViewSize.getWidth();
+    float sy = mVideoSize.getHeight() / (float) mViewSize.getHeight();
+    return getMatrix(sx, sy, PivotPoint.LEFT_TOP);
+  }
+
+  private Matrix getFitScale(PivotPoint pivotPoint) {
+    float sx = (float) mViewSize.getWidth() / mVideoSize.getWidth();
+    float sy = (float) mViewSize.getHeight() / mVideoSize.getHeight();
+    float minScale = Math.min(sx, sy);
+    sx = minScale / sx;
+    sy = minScale / sy;
+    return getMatrix(sx, sy, pivotPoint);
+  }
+
+  private Matrix fitXY() {
+    return getMatrix(1, 1, PivotPoint.LEFT_TOP);
+  }
+
+  private Matrix fitStart() {
+    return getFitScale(PivotPoint.LEFT_TOP);
+  }
+
+  private Matrix fitCenter() {
+    return getFitScale(PivotPoint.CENTER);
+  }
+
+  private Matrix fitEnd() {
+    return getFitScale(PivotPoint.RIGHT_BOTTOM);
+  }
+
+  private Matrix getOriginalScale(PivotPoint pivotPoint) {
+    float sx = mVideoSize.getWidth() / (float) mViewSize.getWidth();
+    float sy = mVideoSize.getHeight() / (float) mViewSize.getHeight();
+    return getMatrix(sx, sy, pivotPoint);
+  }
+
+  private Matrix getCropScale(PivotPoint pivotPoint) {
+    float sx = (float) mViewSize.getWidth() / mVideoSize.getWidth();
+    float sy = (float) mViewSize.getHeight() / mVideoSize.getHeight();
+    float maxScale = Math.max(sx, sy);
+    sx = maxScale / sx;
+    sy = maxScale / sy;
+    return getMatrix(sx, sy, pivotPoint);
+  }
+
+  private Matrix startInside() {
+    if (mVideoSize.getHeight() <= mViewSize.getWidth()
+        && mVideoSize.getHeight() <= mViewSize.getHeight()) {
+      // video is smaller than view size
+      return getOriginalScale(PivotPoint.LEFT_TOP);
+    } else {
+      // either of width or height of the video is larger than view size
+      return fitStart();
+    }
+  }
+
+  private Matrix centerInside() {
+    if (mVideoSize.getHeight() <= mViewSize.getWidth()
+        && mVideoSize.getHeight() <= mViewSize.getHeight()) {
+      // video is smaller than view size
+      return getOriginalScale(PivotPoint.CENTER);
+    } else {
+      // either of width or height of the video is larger than view size
+      return fitCenter();
+    }
+  }
+
+  private Matrix endInside() {
+    if (mVideoSize.getHeight() <= mViewSize.getWidth()
+        && mVideoSize.getHeight() <= mViewSize.getHeight()) {
+      // video is smaller than view size
+      return getOriginalScale(PivotPoint.RIGHT_BOTTOM);
+    } else {
+      // either of width or height of the video is larger than view size
+      return fitEnd();
+    }
+  }
+}

--- a/android/versioned-abis/expoview-abi42_0_0/src/main/java/abi42_0_0/host/exp/exponent/modules/universal/av/CustomHeadersOkHttpDataSourceFactory.java
+++ b/android/versioned-abis/expoview-abi42_0_0/src/main/java/abi42_0_0/host/exp/exponent/modules/universal/av/CustomHeadersOkHttpDataSourceFactory.java
@@ -45,6 +45,6 @@ public class CustomHeadersOkHttpDataSourceFactory extends HttpDataSource.BaseFac
   }
 
   protected OkHttpDataSource createDataSourceInternal(HttpDataSource.RequestProperties defaultRequestProperties) {
-    return new OkHttpDataSource(mCallFactory, mUserAgent, null, mCacheControl, defaultRequestProperties);
+    return new OkHttpDataSource(mCallFactory, mUserAgent, mCacheControl, defaultRequestProperties);
   }
 }

--- a/android/versioned-abis/expoview-abi43_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi43_0_0/build.gradle
@@ -21,7 +21,6 @@ buildscript {
     maven { url "https://www.jitpack.io" }
     mavenCentral()
     google()
-    jcenter()
   }
   dependencies {
     classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${safeExtGet('kotlinVersion', '1.6.10')}")
@@ -157,7 +156,7 @@ dependencies {
 
   // expo-av
   // See explanation in expo-av/build.gradle
-  api 'com.google.android.exoplayer:extension-okhttp:2.9.2'
+  api 'com.google.android.exoplayer:extension-okhttp:2.13.3'
 
   // expo-application
   api 'com.android.installreferrer:installreferrer:1.0'

--- a/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/av/player/SimpleExoPlayerData.java
+++ b/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/av/player/SimpleExoPlayerData.java
@@ -5,28 +5,25 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.os.Handler;
 
-import androidx.annotation.Nullable;
-
 import android.text.TextUtils;
 import android.util.Log;
 import android.util.Pair;
 import android.view.Surface;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.google.android.exoplayer2.C;
-import com.google.android.exoplayer2.DefaultLoadControl;
-import com.google.android.exoplayer2.DefaultRenderersFactory;
 import com.google.android.exoplayer2.ExoPlaybackException;
-import com.google.android.exoplayer2.ExoPlayerFactory;
-import com.google.android.exoplayer2.Format;
+import com.google.android.exoplayer2.MediaItem;
 import com.google.android.exoplayer2.PlaybackParameters;
 import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.SimpleExoPlayer;
-import com.google.android.exoplayer2.Timeline;
-import com.google.android.exoplayer2.extractor.DefaultExtractorsFactory;
-import com.google.android.exoplayer2.source.AdaptiveMediaSourceEventListener;
 import com.google.android.exoplayer2.source.ExtractorMediaSource;
+import com.google.android.exoplayer2.source.LoadEventInfo;
+import com.google.android.exoplayer2.source.MediaLoadData;
 import com.google.android.exoplayer2.source.MediaSource;
-import com.google.android.exoplayer2.source.TrackGroupArray;
+import com.google.android.exoplayer2.source.MediaSourceEventListener;
 import com.google.android.exoplayer2.source.dash.DashMediaSource;
 import com.google.android.exoplayer2.source.dash.DefaultDashChunkSource;
 import com.google.android.exoplayer2.source.hls.HlsMediaSource;
@@ -34,8 +31,6 @@ import com.google.android.exoplayer2.source.smoothstreaming.DefaultSsChunkSource
 import com.google.android.exoplayer2.source.smoothstreaming.SsMediaSource;
 import com.google.android.exoplayer2.trackselection.AdaptiveTrackSelection;
 import com.google.android.exoplayer2.trackselection.DefaultTrackSelector;
-import com.google.android.exoplayer2.trackselection.TrackSelection;
-import com.google.android.exoplayer2.trackselection.TrackSelectionArray;
 import com.google.android.exoplayer2.trackselection.TrackSelector;
 import com.google.android.exoplayer2.upstream.BandwidthMeter;
 import com.google.android.exoplayer2.upstream.DataSource;
@@ -43,32 +38,33 @@ import com.google.android.exoplayer2.upstream.DataSpec;
 import com.google.android.exoplayer2.upstream.DefaultBandwidthMeter;
 import com.google.android.exoplayer2.upstream.RawResourceDataSource;
 import com.google.android.exoplayer2.util.Util;
+import com.google.android.exoplayer2.video.VideoListener;
 
 import java.io.IOException;
 import java.util.Map;
 
 import abi43_0_0.expo.modules.av.AVManagerInterface;
 import abi43_0_0.expo.modules.av.AudioFocusNotAcquiredException;
-import abi43_0_0.expo.modules.av.player.datasource.CustomHeadersOkHttpDataSourceFactory;
 import abi43_0_0.expo.modules.av.player.datasource.DataSourceFactoryProvider;
 
 class SimpleExoPlayerData extends PlayerData
-  implements Player.EventListener, ExtractorMediaSource.EventListener, SimpleExoPlayer.VideoListener, AdaptiveMediaSourceEventListener {
+    implements Player.EventListener, MediaSourceEventListener, VideoListener {
 
   private static final String IMPLEMENTATION_NAME = "SimpleExoPlayer";
   private static final String TAG = SimpleExoPlayerData.class.getSimpleName();
 
   private SimpleExoPlayer mSimpleExoPlayer = null;
-  private String mOverridingExtension;
+  private final String mOverridingExtension;
   private LoadCompletionListener mLoadCompletionListener = null;
   private boolean mFirstFrameRendered = false;
   private Pair<Integer, Integer> mVideoWidthHeight = null;
   private Integer mLastPlaybackState = null;
   private boolean mIsLooping = false;
   private boolean mIsLoading = true;
-  private Context mReactContext;
+  private final Context mReactContext;
 
-  SimpleExoPlayerData(final AVManagerInterface avModule, final Context context, final Uri uri, final String overridingExtension, final Map<String, Object> requestHeaders) {
+  SimpleExoPlayerData(final AVManagerInterface avModule, final Context context, final Uri uri,
+      final String overridingExtension, final Map<String, Object> requestHeaders) {
     super(avModule, uri, requestHeaders);
     mReactContext = context;
     mOverridingExtension = overridingExtension;
@@ -87,29 +83,31 @@ class SimpleExoPlayerData extends PlayerData
   public void load(final Bundle status, final LoadCompletionListener loadCompletionListener) {
     mLoadCompletionListener = loadCompletionListener;
 
-    // Create a default TrackSelector
-    final Handler mainHandler = new Handler();
-    // Measures bandwidth during playback. Can be null if not required.
-    final BandwidthMeter bandwidthMeter = new DefaultBandwidthMeter();
-    final TrackSelection.Factory trackSelectionFactory = new AdaptiveTrackSelection.Factory();
-    final TrackSelector trackSelector = new DefaultTrackSelector(trackSelectionFactory);
+    final Context context = mAVModule.getContext();
+    final BandwidthMeter bandwidthMeter = new DefaultBandwidthMeter.Builder(context).build();
+    final TrackSelector trackSelector = new DefaultTrackSelector(context, new AdaptiveTrackSelection.Factory());
 
     // Create the player
-    mSimpleExoPlayer = ExoPlayerFactory.newSimpleInstance(
-      mAVModule.getContext(),
-      new DefaultRenderersFactory(mAVModule.getContext()),
-      trackSelector,
-      new DefaultLoadControl(),
-      null,
-      bandwidthMeter);
+    mSimpleExoPlayer = new SimpleExoPlayer.Builder(context)
+        .setTrackSelector(trackSelector)
+        .setBandwidthMeter(bandwidthMeter)
+        .build();
+
     mSimpleExoPlayer.addListener(this);
     mSimpleExoPlayer.addVideoListener(this);
 
     // Produces DataSource instances through which media data is loaded.
-    final DataSource.Factory dataSourceFactory = mAVModule.getModuleRegistry().getModule(DataSourceFactoryProvider.class).createFactory(mReactContext, mAVModule.getModuleRegistry(), Util.getUserAgent(mAVModule.getContext(), "yourApplicationName"), mRequestHeaders, bandwidthMeter.getTransferListener());
+    final DataSource.Factory dataSourceFactory = mAVModule.getModuleRegistry()
+        .getModule(DataSourceFactoryProvider.class)
+        .createFactory(
+            mReactContext,
+            mAVModule.getModuleRegistry(),
+            Util.getUserAgent(context, "yourApplicationName"),
+            mRequestHeaders,
+            bandwidthMeter.getTransferListener());
     try {
       // This is the MediaSource representing the media to be played.
-      final MediaSource source = buildMediaSource(mUri, mOverridingExtension, mainHandler, dataSourceFactory);
+      final MediaSource source = buildMediaSource(mUri, mOverridingExtension, dataSourceFactory);
 
       // Prepare the player with the source.
       mSimpleExoPlayer.prepare(source);
@@ -154,7 +152,7 @@ class SimpleExoPlayerData extends PlayerData
 
   @Override
   void applyNewStatus(final Integer newPositionMillis, final Boolean newIsLooping)
-    throws AudioFocusNotAcquiredException, IllegalStateException {
+      throws AudioFocusNotAcquiredException, IllegalStateException {
     if (mSimpleExoPlayer == null) {
       throw new IllegalStateException("mSimpleExoPlayer is null!");
     }
@@ -201,14 +199,14 @@ class SimpleExoPlayerData extends PlayerData
     final int duration = (int) mSimpleExoPlayer.getDuration();
     map.putInt(STATUS_DURATION_MILLIS_KEY_PATH, duration);
     map.putInt(STATUS_POSITION_MILLIS_KEY_PATH,
-      getClippedIntegerForValue((int) mSimpleExoPlayer.getCurrentPosition(), 0, duration));
+        getClippedIntegerForValue((int) mSimpleExoPlayer.getCurrentPosition(), 0, duration));
     map.putInt(STATUS_PLAYABLE_DURATION_MILLIS_KEY_PATH,
-      getClippedIntegerForValue((int) mSimpleExoPlayer.getBufferedPosition(), 0, duration));
+        getClippedIntegerForValue((int) mSimpleExoPlayer.getBufferedPosition(), 0, duration));
 
     map.putBoolean(STATUS_IS_PLAYING_KEY_PATH,
-      mSimpleExoPlayer.getPlayWhenReady() && mSimpleExoPlayer.getPlaybackState() == Player.STATE_READY);
+        mSimpleExoPlayer.getPlayWhenReady() && mSimpleExoPlayer.getPlaybackState() == Player.STATE_READY);
     map.putBoolean(STATUS_IS_BUFFERING_KEY_PATH,
-      mIsLoading || mSimpleExoPlayer.getPlaybackState() == Player.STATE_BUFFERING);
+        mIsLoading || mSimpleExoPlayer.getPlaybackState() == Player.STATE_BUFFERING);
 
     map.putBoolean(STATUS_IS_LOOPING_KEY_PATH, mIsLooping);
   }
@@ -234,7 +232,7 @@ class SimpleExoPlayerData extends PlayerData
 
   // --------- Interface implementation ---------
 
-  // AudioEventHandler
+  // region AudioEventHandler
 
   @Override
   public void pauseImmediately() {
@@ -256,7 +254,9 @@ class SimpleExoPlayerData extends PlayerData
     }
   }
 
-  // ExoPlayer.EventListener
+  // endregion
+
+  // region ExoPlayer.EventListener
 
   @Override
   public void onLoadingChanged(final boolean isLoading) {
@@ -283,12 +283,6 @@ class SimpleExoPlayerData extends PlayerData
   }
 
   @Override
-  public void onTracksChanged(TrackGroupArray trackGroups,
-                              TrackSelectionArray trackSelections) {
-
-  }
-
-  @Override
   public void onPlayerStateChanged(final boolean playWhenReady, final int playbackState) {
     if (playbackState == Player.STATE_READY && mLoadCompletionListener != null) {
       final LoadCompletionListener listener = mLoadCompletionListener;
@@ -297,8 +291,8 @@ class SimpleExoPlayerData extends PlayerData
     }
 
     if (mLastPlaybackState != null
-      && playbackState != mLastPlaybackState
-      && playbackState == Player.STATE_ENDED) {
+        && playbackState != mLastPlaybackState
+        && playbackState == Player.STATE_ENDED) {
       callStatusUpdateListenerWithDidJustFinish();
       stopUpdatingProgressIfNecessary();
     } else {
@@ -321,7 +315,8 @@ class SimpleExoPlayerData extends PlayerData
     // > A period defines a single logical piece of media, for example a media file.
     // > It may also define groups of ads inserted into the media,
     // > along with information about whether those ads have been loaded and played.
-    // Source: https://google.github.io/ExoPlayer/doc/reference/com/google/android/exoplayer2/Timeline.Period.html
+    // Source:
+    // https://google.github.io/ExoPlayer/doc/reference/com/google/android/exoplayer2/Timeline.Period.html
     // So I guess it's safe to say that when a period transition happens,
     // media file transition happens, so we just finished playing one.
     if (reason == Player.DISCONTINUITY_REASON_PERIOD_TRANSITION) {
@@ -329,11 +324,18 @@ class SimpleExoPlayerData extends PlayerData
     }
   }
 
+  // endregion
 
-  // ExtractorMediaSource.EventListener
+  // region MediaSourceEventListener
 
   @Override
-  public void onLoadError(final IOException error) {
+  public void onLoadError(
+      int windowIndex,
+      @Nullable MediaSource.MediaPeriodId mediaPeriodId,
+      LoadEventInfo loadEventInfo,
+      MediaLoadData mediaLoadData,
+      IOException error,
+      boolean wasCanceled) {
     if (mLoadCompletionListener != null) {
       final LoadCompletionListener listener = mLoadCompletionListener;
       mLoadCompletionListener = null;
@@ -352,10 +354,13 @@ class SimpleExoPlayerData extends PlayerData
     release();
   }
 
-  // SimpleExoPlayer.VideoListener
+  // endregion
+
+  // region VideoListener
 
   @Override
-  public void onVideoSizeChanged(final int width, final int height, final int unAppliedRotationDegrees, final float pixelWidthHeightRatio) {
+  public void onVideoSizeChanged(final int width, final int height, final int unAppliedRotationDegrees,
+      final float pixelWidthHeightRatio) {
     // TODO other params?
     mVideoWidthHeight = new Pair<>(width, height);
     if (mFirstFrameRendered && mVideoSizeUpdateListener != null) {
@@ -371,11 +376,13 @@ class SimpleExoPlayerData extends PlayerData
     mFirstFrameRendered = true;
   }
 
-  // https://github.com/google/ExoPlayer/blob/2b20780482a9c6b07416bcbf4de829532859d10a/demos/main/src/main/java/com/google/android/exoplayer2/demo/PlayerActivity.java#L365-L393
-  private MediaSource buildMediaSource(Uri uri, String overrideExtension, Handler mainHandler, DataSource.Factory factory) {
+  // endregion
+
+  private MediaSource buildMediaSource(@NonNull Uri uri, String overrideExtension, DataSource.Factory factory) {
     try {
       if (uri.getScheme() == null) {
-        int resourceId = mReactContext.getResources().getIdentifier(uri.toString(), "raw", mReactContext.getPackageName());
+        int resourceId = mReactContext.getResources().getIdentifier(uri.toString(), "raw",
+            mReactContext.getPackageName());
         DataSpec dataSpec = new DataSpec(RawResourceDataSource.buildRawResourceUri(resourceId));
         final RawResourceDataSource rawResourceDataSource = new RawResourceDataSource(mReactContext);
         rawResourceDataSource.open(dataSpec);
@@ -384,67 +391,57 @@ class SimpleExoPlayerData extends PlayerData
     } catch (Exception e) {
       Log.e(TAG, "Error reading raw resource from ExoPlayer", e);
     }
-    @C.ContentType int type = TextUtils.isEmpty(overrideExtension) ? Util.inferContentType(String.valueOf(uri)) : Util.inferContentType("." + overrideExtension);
+    @C.ContentType
+    int type = TextUtils.isEmpty(overrideExtension) ? Util.inferContentType(String.valueOf(uri))
+        : Util.inferContentType("." + overrideExtension);
     switch (type) {
       case C.TYPE_SS:
-        return new SsMediaSource(uri, factory,
-          new DefaultSsChunkSource.Factory(factory), mainHandler, this);
+        return new SsMediaSource.Factory(new DefaultSsChunkSource.Factory(factory), factory)
+            .createMediaSource(MediaItem.fromUri(uri));
       case C.TYPE_DASH:
-        return new DashMediaSource(uri, factory,
-          new DefaultDashChunkSource.Factory(factory), mainHandler, this);
+        return new DashMediaSource.Factory(new DefaultDashChunkSource.Factory(factory), factory)
+            .createMediaSource(MediaItem.fromUri(uri));
       case C.TYPE_HLS:
-        return new HlsMediaSource(uri, factory, mainHandler, this);
+        return new HlsMediaSource.Factory(factory).createMediaSource(MediaItem.fromUri(uri));
       case C.TYPE_OTHER:
-        return new ExtractorMediaSource(uri, factory, new DefaultExtractorsFactory(), mainHandler, this);
+        return new ExtractorMediaSource.Factory(factory).createMediaSource(MediaItem.fromUri(uri));
       default: {
         throw new IllegalStateException("Content of this type is unsupported at the moment. Unsupported type: " + type);
       }
     }
   }
 
-  // AdaptiveMediaSourceEventListener
+  // region MediaSourceEventListener
+
   @Override
-  public void onMediaPeriodCreated(int windowIndex, MediaSource.MediaPeriodId mediaPeriodId) {
+  public void onLoadStarted(int windowIndex, @Nullable MediaSource.MediaPeriodId mediaPeriodId,
+      LoadEventInfo loadEventInfo, MediaLoadData mediaLoadData) {
 
   }
 
   @Override
-  public void onMediaPeriodReleased(int windowIndex, MediaSource.MediaPeriodId mediaPeriodId) {
+  public void onLoadCompleted(int windowIndex, @Nullable MediaSource.MediaPeriodId mediaPeriodId,
+      LoadEventInfo loadEventInfo, MediaLoadData mediaLoadData) {
 
   }
 
   @Override
-  public void onLoadStarted(int windowIndex, @Nullable MediaSource.MediaPeriodId mediaPeriodId, LoadEventInfo loadEventInfo, MediaLoadData mediaLoadData) {
+  public void onLoadCanceled(int windowIndex, @Nullable MediaSource.MediaPeriodId mediaPeriodId,
+      LoadEventInfo loadEventInfo, MediaLoadData mediaLoadData) {
 
   }
 
   @Override
-  public void onLoadCompleted(int windowIndex, @Nullable MediaSource.MediaPeriodId mediaPeriodId, LoadEventInfo loadEventInfo, MediaLoadData mediaLoadData) {
+  public void onUpstreamDiscarded(int windowIndex, MediaSource.MediaPeriodId mediaPeriodId,
+      MediaLoadData mediaLoadData) {
 
   }
 
   @Override
-  public void onLoadCanceled(int windowIndex, @Nullable MediaSource.MediaPeriodId mediaPeriodId, LoadEventInfo loadEventInfo, MediaLoadData mediaLoadData) {
+  public void onDownstreamFormatChanged(int windowIndex, @Nullable MediaSource.MediaPeriodId mediaPeriodId,
+      MediaLoadData mediaLoadData) {
 
   }
 
-  @Override
-  public void onLoadError(int windowIndex, @Nullable MediaSource.MediaPeriodId mediaPeriodId, LoadEventInfo loadEventInfo, MediaLoadData mediaLoadData, IOException error, boolean wasCanceled) {
-
-  }
-
-  @Override
-  public void onReadingStarted(int windowIndex, MediaSource.MediaPeriodId mediaPeriodId) {
-
-  }
-
-  @Override
-  public void onUpstreamDiscarded(int windowIndex, MediaSource.MediaPeriodId mediaPeriodId, MediaLoadData mediaLoadData) {
-
-  }
-
-  @Override
-  public void onDownstreamFormatChanged(int windowIndex, @Nullable MediaSource.MediaPeriodId mediaPeriodId, MediaLoadData mediaLoadData) {
-
-  }
+  // endregion
 }

--- a/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/av/player/datasource/CustomHeadersOkHttpDataSourceFactory.java
+++ b/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/av/player/datasource/CustomHeadersOkHttpDataSourceFactory.java
@@ -42,6 +42,6 @@ public class CustomHeadersOkHttpDataSourceFactory extends HttpDataSource.BaseFac
   }
 
   protected OkHttpDataSource createDataSourceInternal(HttpDataSource.RequestProperties defaultRequestProperties) {
-    return new OkHttpDataSource(mCallFactory, mUserAgent, null, mCacheControl, defaultRequestProperties);
+    return new OkHttpDataSource(mCallFactory, mUserAgent, mCacheControl, defaultRequestProperties);
   }
 }

--- a/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/av/video/VideoManager.java
+++ b/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/av/video/VideoManager.java
@@ -3,11 +3,10 @@ package abi43_0_0.expo.modules.av.video;
 import android.content.Context;
 import androidx.annotation.Nullable;
 
-import com.yqritc.scalablevideoview.ScalableType;
-
 import java.util.HashMap;
 import java.util.Map;
 
+import abi43_0_0.expo.modules.av.video.scalablevideoview.ScalableType;
 import abi43_0_0.expo.modules.core.ExportedModule;
 import abi43_0_0.expo.modules.core.ModuleRegistry;
 import abi43_0_0.expo.modules.core.Promise;

--- a/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/av/video/VideoTextureView.java
+++ b/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/av/video/VideoTextureView.java
@@ -5,13 +5,13 @@ import android.content.Context;
 import android.graphics.Matrix;
 import android.graphics.SurfaceTexture;
 import android.util.Pair;
+import android.util.Size;
 import android.view.Surface;
 import android.view.TextureView;
 import android.view.View;
 
-import com.yqritc.scalablevideoview.ScalableType;
-import com.yqritc.scalablevideoview.ScaleManager;
-import com.yqritc.scalablevideoview.Size;
+import abi43_0_0.expo.modules.av.video.scalablevideoview.ScalableType;
+import abi43_0_0.expo.modules.av.video.scalablevideoview.ScaleManager;
 
 @SuppressLint("ViewConstructor")
 public class VideoTextureView extends TextureView implements TextureView.SurfaceTextureListener {

--- a/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/av/video/VideoView.java
+++ b/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/av/video/VideoView.java
@@ -9,8 +9,7 @@ import android.view.MotionEvent;
 import android.view.Surface;
 import android.widget.FrameLayout;
 
-import com.yqritc.scalablevideoview.ScalableType;
-
+import abi43_0_0.expo.modules.av.video.scalablevideoview.ScalableType;
 import abi43_0_0.expo.modules.core.ModuleRegistry;
 import abi43_0_0.expo.modules.core.Promise;
 import abi43_0_0.expo.modules.core.arguments.ReadableArguments;

--- a/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/av/video/VideoViewManager.java
+++ b/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/av/video/VideoViewManager.java
@@ -2,11 +2,10 @@ package abi43_0_0.expo.modules.av.video;
 
 import android.content.Context;
 
-import com.yqritc.scalablevideoview.ScalableType;
-
 import java.util.ArrayList;
 import java.util.List;
 
+import abi43_0_0.expo.modules.av.video.scalablevideoview.ScalableType;
 import abi43_0_0.expo.modules.core.ModuleRegistry;
 import abi43_0_0.expo.modules.core.ViewManager;
 import abi43_0_0.expo.modules.core.arguments.ReadableArguments;

--- a/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/av/video/scalablevideoview/PivotPoint.java
+++ b/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/av/video/scalablevideoview/PivotPoint.java
@@ -1,0 +1,17 @@
+package abi43_0_0.expo.modules.av.video.scalablevideoview;
+
+/**
+ * The following class is copied from https://github.com/yqritc/Android-ScalableVideoView/blob/master/library/src/main/java/com/yqritc/scalablevideoview/PivotPoint.java
+ * as the original library (com.yqritc:android-scalablevideoview) is only available on jcenter() repository and we're moved from fetching libraries from there.
+ */
+public enum PivotPoint {
+  LEFT_TOP,
+  LEFT_CENTER,
+  LEFT_BOTTOM,
+  CENTER_TOP,
+  CENTER,
+  CENTER_BOTTOM,
+  RIGHT_TOP,
+  RIGHT_CENTER,
+  RIGHT_BOTTOM
+}

--- a/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/av/video/scalablevideoview/ScalableType.java
+++ b/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/av/video/scalablevideoview/ScalableType.java
@@ -1,0 +1,38 @@
+package abi43_0_0.expo.modules.av.video.scalablevideoview;
+
+/**
+ * The following class is copied from https://github.com/yqritc/Android-ScalableVideoView/blob/master/library/src/main/java/com/yqritc/scalablevideoview/ScalableType.java
+ * as the original library (com.yqritc:android-scalablevideoview) is only available on jcenter() repository and we're moved from fetching libraries from there.
+ */
+public enum ScalableType {
+  NONE,
+
+  FIT_XY,
+  FIT_START,
+  FIT_CENTER,
+  FIT_END,
+
+  LEFT_TOP,
+  LEFT_CENTER,
+  LEFT_BOTTOM,
+  CENTER_TOP,
+  CENTER,
+  CENTER_BOTTOM,
+  RIGHT_TOP,
+  RIGHT_CENTER,
+  RIGHT_BOTTOM,
+
+  LEFT_TOP_CROP,
+  LEFT_CENTER_CROP,
+  LEFT_BOTTOM_CROP,
+  CENTER_TOP_CROP,
+  CENTER_CROP,
+  CENTER_BOTTOM_CROP,
+  RIGHT_TOP_CROP,
+  RIGHT_CENTER_CROP,
+  RIGHT_BOTTOM_CROP,
+
+  START_INSIDE,
+  CENTER_INSIDE,
+  END_INSIDE
+}

--- a/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/av/video/scalablevideoview/ScaleManager.java
+++ b/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/av/video/scalablevideoview/ScaleManager.java
@@ -1,0 +1,193 @@
+package abi43_0_0.expo.modules.av.video.scalablevideoview;
+
+import android.graphics.Matrix;
+import android.util.Size;
+
+/**
+ * The following class is copied from https://github.com/yqritc/Android-ScalableVideoView/blob/master/library/src/main/java/com/yqritc/scalablevideoview/ScaleManager.java
+ * as the original library (com.yqritc:android-scalablevideoview) is only available on jcenter() repository and we're moved from fetching libraries from there.
+ */
+public class ScaleManager {
+
+  private Size mViewSize;
+  private Size mVideoSize;
+
+  public ScaleManager(Size viewSize, Size videoSize) {
+    mViewSize = viewSize;
+    mVideoSize = videoSize;
+  }
+
+  public Matrix getScaleMatrix(ScalableType scalableType) {
+    switch (scalableType) {
+      case NONE:
+        return getNoScale();
+
+      case FIT_XY:
+        return fitXY();
+      case FIT_CENTER:
+        return fitCenter();
+      case FIT_START:
+        return fitStart();
+      case FIT_END:
+        return fitEnd();
+
+      case LEFT_TOP:
+        return getOriginalScale(PivotPoint.LEFT_TOP);
+      case LEFT_CENTER:
+        return getOriginalScale(PivotPoint.LEFT_CENTER);
+      case LEFT_BOTTOM:
+        return getOriginalScale(PivotPoint.LEFT_BOTTOM);
+      case CENTER_TOP:
+        return getOriginalScale(PivotPoint.CENTER_TOP);
+      case CENTER:
+        return getOriginalScale(PivotPoint.CENTER);
+      case CENTER_BOTTOM:
+        return getOriginalScale(PivotPoint.CENTER_BOTTOM);
+      case RIGHT_TOP:
+        return getOriginalScale(PivotPoint.RIGHT_TOP);
+      case RIGHT_CENTER:
+        return getOriginalScale(PivotPoint.RIGHT_CENTER);
+      case RIGHT_BOTTOM:
+        return getOriginalScale(PivotPoint.RIGHT_BOTTOM);
+
+      case LEFT_TOP_CROP:
+        return getCropScale(PivotPoint.LEFT_TOP);
+      case LEFT_CENTER_CROP:
+        return getCropScale(PivotPoint.LEFT_CENTER);
+      case LEFT_BOTTOM_CROP:
+        return getCropScale(PivotPoint.LEFT_BOTTOM);
+      case CENTER_TOP_CROP:
+        return getCropScale(PivotPoint.CENTER_TOP);
+      case CENTER_CROP:
+        return getCropScale(PivotPoint.CENTER);
+      case CENTER_BOTTOM_CROP:
+        return getCropScale(PivotPoint.CENTER_BOTTOM);
+      case RIGHT_TOP_CROP:
+        return getCropScale(PivotPoint.RIGHT_TOP);
+      case RIGHT_CENTER_CROP:
+        return getCropScale(PivotPoint.RIGHT_CENTER);
+      case RIGHT_BOTTOM_CROP:
+        return getCropScale(PivotPoint.RIGHT_BOTTOM);
+
+      case START_INSIDE:
+        return startInside();
+      case CENTER_INSIDE:
+        return centerInside();
+      case END_INSIDE:
+        return endInside();
+
+      default:
+        return null;
+    }
+  }
+
+  private Matrix getMatrix(float sx, float sy, float px, float py) {
+    Matrix matrix = new Matrix();
+    matrix.setScale(sx, sy, px, py);
+    return matrix;
+  }
+
+  private Matrix getMatrix(float sx, float sy, PivotPoint pivotPoint) {
+    switch (pivotPoint) {
+      case LEFT_TOP:
+        return getMatrix(sx, sy, 0, 0);
+      case LEFT_CENTER:
+        return getMatrix(sx, sy, 0, mViewSize.getHeight() / 2f);
+      case LEFT_BOTTOM:
+        return getMatrix(sx, sy, 0, mViewSize.getHeight());
+      case CENTER_TOP:
+        return getMatrix(sx, sy, mViewSize.getWidth() / 2f, 0);
+      case CENTER:
+        return getMatrix(sx, sy, mViewSize.getWidth() / 2f, mViewSize.getHeight() / 2f);
+      case CENTER_BOTTOM:
+        return getMatrix(sx, sy, mViewSize.getWidth() / 2f, mViewSize.getHeight());
+      case RIGHT_TOP:
+        return getMatrix(sx, sy, mViewSize.getWidth(), 0);
+      case RIGHT_CENTER:
+        return getMatrix(sx, sy, mViewSize.getWidth(), mViewSize.getHeight() / 2f);
+      case RIGHT_BOTTOM:
+        return getMatrix(sx, sy, mViewSize.getWidth(), mViewSize.getHeight());
+      default:
+        throw new IllegalArgumentException("Illegal PivotPoint");
+    }
+  }
+
+  private Matrix getNoScale() {
+    float sx = mVideoSize.getWidth() / (float) mViewSize.getWidth();
+    float sy = mVideoSize.getHeight() / (float) mViewSize.getHeight();
+    return getMatrix(sx, sy, PivotPoint.LEFT_TOP);
+  }
+
+  private Matrix getFitScale(PivotPoint pivotPoint) {
+    float sx = (float) mViewSize.getWidth() / mVideoSize.getWidth();
+    float sy = (float) mViewSize.getHeight() / mVideoSize.getHeight();
+    float minScale = Math.min(sx, sy);
+    sx = minScale / sx;
+    sy = minScale / sy;
+    return getMatrix(sx, sy, pivotPoint);
+  }
+
+  private Matrix fitXY() {
+    return getMatrix(1, 1, PivotPoint.LEFT_TOP);
+  }
+
+  private Matrix fitStart() {
+    return getFitScale(PivotPoint.LEFT_TOP);
+  }
+
+  private Matrix fitCenter() {
+    return getFitScale(PivotPoint.CENTER);
+  }
+
+  private Matrix fitEnd() {
+    return getFitScale(PivotPoint.RIGHT_BOTTOM);
+  }
+
+  private Matrix getOriginalScale(PivotPoint pivotPoint) {
+    float sx = mVideoSize.getWidth() / (float) mViewSize.getWidth();
+    float sy = mVideoSize.getHeight() / (float) mViewSize.getHeight();
+    return getMatrix(sx, sy, pivotPoint);
+  }
+
+  private Matrix getCropScale(PivotPoint pivotPoint) {
+    float sx = (float) mViewSize.getWidth() / mVideoSize.getWidth();
+    float sy = (float) mViewSize.getHeight() / mVideoSize.getHeight();
+    float maxScale = Math.max(sx, sy);
+    sx = maxScale / sx;
+    sy = maxScale / sy;
+    return getMatrix(sx, sy, pivotPoint);
+  }
+
+  private Matrix startInside() {
+    if (mVideoSize.getHeight() <= mViewSize.getWidth()
+        && mVideoSize.getHeight() <= mViewSize.getHeight()) {
+      // video is smaller than view size
+      return getOriginalScale(PivotPoint.LEFT_TOP);
+    } else {
+      // either of width or height of the video is larger than view size
+      return fitStart();
+    }
+  }
+
+  private Matrix centerInside() {
+    if (mVideoSize.getHeight() <= mViewSize.getWidth()
+        && mVideoSize.getHeight() <= mViewSize.getHeight()) {
+      // video is smaller than view size
+      return getOriginalScale(PivotPoint.CENTER);
+    } else {
+      // either of width or height of the video is larger than view size
+      return fitCenter();
+    }
+  }
+
+  private Matrix endInside() {
+    if (mVideoSize.getHeight() <= mViewSize.getWidth()
+        && mVideoSize.getHeight() <= mViewSize.getHeight()) {
+      // video is smaller than view size
+      return getOriginalScale(PivotPoint.RIGHT_BOTTOM);
+    } else {
+      // either of width or height of the video is larger than view size
+      return fitEnd();
+    }
+  }
+}

--- a/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/host/exp/exponent/modules/universal/av/CustomHeadersOkHttpDataSourceFactory.kt
+++ b/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/host/exp/exponent/modules/universal/av/CustomHeadersOkHttpDataSourceFactory.kt
@@ -29,7 +29,7 @@ class CustomHeadersOkHttpDataSourceFactory(
   }
 
   override fun createDataSourceInternal(defaultRequestProperties: RequestProperties): OkHttpDataSource {
-    return OkHttpDataSource(callFactory, userAgent, null, cacheControl, defaultRequestProperties)
+    return OkHttpDataSource(callFactory, userAgent, cacheControl, defaultRequestProperties)
   }
 
   init {

--- a/android/versioned-abis/expoview-abi44_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi44_0_0/build.gradle
@@ -21,7 +21,6 @@ buildscript {
     maven { url "https://www.jitpack.io" }
     mavenCentral()
     google()
-    jcenter()
   }
   dependencies {
     classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${safeExtGet('kotlinVersion', '1.6.10')}")
@@ -158,7 +157,7 @@ dependencies {
 
   // expo-av
   // See explanation in expo-av/build.gradle
-  api 'com.google.android.exoplayer:extension-okhttp:2.9.2'
+  api 'com.google.android.exoplayer:extension-okhttp:2.13.3'
 
   // expo-application
   api 'com.android.installreferrer:installreferrer:1.0'

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/av/player/SimpleExoPlayerData.java
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/av/player/SimpleExoPlayerData.java
@@ -5,28 +5,25 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.os.Handler;
 
-import androidx.annotation.Nullable;
-
 import android.text.TextUtils;
 import android.util.Log;
 import android.util.Pair;
 import android.view.Surface;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.google.android.exoplayer2.C;
-import com.google.android.exoplayer2.DefaultLoadControl;
-import com.google.android.exoplayer2.DefaultRenderersFactory;
 import com.google.android.exoplayer2.ExoPlaybackException;
-import com.google.android.exoplayer2.ExoPlayerFactory;
-import com.google.android.exoplayer2.Format;
+import com.google.android.exoplayer2.MediaItem;
 import com.google.android.exoplayer2.PlaybackParameters;
 import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.SimpleExoPlayer;
-import com.google.android.exoplayer2.Timeline;
-import com.google.android.exoplayer2.extractor.DefaultExtractorsFactory;
-import com.google.android.exoplayer2.source.AdaptiveMediaSourceEventListener;
 import com.google.android.exoplayer2.source.ExtractorMediaSource;
+import com.google.android.exoplayer2.source.LoadEventInfo;
+import com.google.android.exoplayer2.source.MediaLoadData;
 import com.google.android.exoplayer2.source.MediaSource;
-import com.google.android.exoplayer2.source.TrackGroupArray;
+import com.google.android.exoplayer2.source.MediaSourceEventListener;
 import com.google.android.exoplayer2.source.dash.DashMediaSource;
 import com.google.android.exoplayer2.source.dash.DefaultDashChunkSource;
 import com.google.android.exoplayer2.source.hls.HlsMediaSource;
@@ -34,8 +31,6 @@ import com.google.android.exoplayer2.source.smoothstreaming.DefaultSsChunkSource
 import com.google.android.exoplayer2.source.smoothstreaming.SsMediaSource;
 import com.google.android.exoplayer2.trackselection.AdaptiveTrackSelection;
 import com.google.android.exoplayer2.trackselection.DefaultTrackSelector;
-import com.google.android.exoplayer2.trackselection.TrackSelection;
-import com.google.android.exoplayer2.trackselection.TrackSelectionArray;
 import com.google.android.exoplayer2.trackselection.TrackSelector;
 import com.google.android.exoplayer2.upstream.BandwidthMeter;
 import com.google.android.exoplayer2.upstream.DataSource;
@@ -43,30 +38,30 @@ import com.google.android.exoplayer2.upstream.DataSpec;
 import com.google.android.exoplayer2.upstream.DefaultBandwidthMeter;
 import com.google.android.exoplayer2.upstream.RawResourceDataSource;
 import com.google.android.exoplayer2.util.Util;
+import com.google.android.exoplayer2.video.VideoListener;
 
 import java.io.IOException;
 import java.util.Map;
 
 import abi44_0_0.expo.modules.av.AVManagerInterface;
 import abi44_0_0.expo.modules.av.AudioFocusNotAcquiredException;
-import abi44_0_0.expo.modules.av.player.datasource.CustomHeadersOkHttpDataSourceFactory;
 import abi44_0_0.expo.modules.av.player.datasource.DataSourceFactoryProvider;
 
 class SimpleExoPlayerData extends PlayerData
-  implements Player.EventListener, ExtractorMediaSource.EventListener, SimpleExoPlayer.VideoListener, AdaptiveMediaSourceEventListener {
+  implements Player.EventListener, MediaSourceEventListener, VideoListener {
 
   private static final String IMPLEMENTATION_NAME = "SimpleExoPlayer";
   private static final String TAG = SimpleExoPlayerData.class.getSimpleName();
 
   private SimpleExoPlayer mSimpleExoPlayer = null;
-  private String mOverridingExtension;
+  private final String mOverridingExtension;
   private LoadCompletionListener mLoadCompletionListener = null;
   private boolean mFirstFrameRendered = false;
   private Pair<Integer, Integer> mVideoWidthHeight = null;
   private Integer mLastPlaybackState = null;
   private boolean mIsLooping = false;
   private boolean mIsLoading = true;
-  private Context mReactContext;
+  private final Context mReactContext;
 
   SimpleExoPlayerData(final AVManagerInterface avModule, final Context context, final Uri uri, final String overridingExtension, final Map<String, Object> requestHeaders) {
     super(avModule, uri, requestHeaders);
@@ -87,29 +82,31 @@ class SimpleExoPlayerData extends PlayerData
   public void load(final Bundle status, final LoadCompletionListener loadCompletionListener) {
     mLoadCompletionListener = loadCompletionListener;
 
-    // Create a default TrackSelector
-    final Handler mainHandler = new Handler();
-    // Measures bandwidth during playback. Can be null if not required.
-    final BandwidthMeter bandwidthMeter = new DefaultBandwidthMeter();
-    final TrackSelection.Factory trackSelectionFactory = new AdaptiveTrackSelection.Factory();
-    final TrackSelector trackSelector = new DefaultTrackSelector(trackSelectionFactory);
+    final Context context = mAVModule.getContext();
+    final BandwidthMeter bandwidthMeter = new DefaultBandwidthMeter.Builder(context).build();
+    final TrackSelector trackSelector = new DefaultTrackSelector(context, new AdaptiveTrackSelection.Factory());
 
     // Create the player
-    mSimpleExoPlayer = ExoPlayerFactory.newSimpleInstance(
-      mAVModule.getContext(),
-      new DefaultRenderersFactory(mAVModule.getContext()),
-      trackSelector,
-      new DefaultLoadControl(),
-      null,
-      bandwidthMeter);
+    mSimpleExoPlayer = new SimpleExoPlayer.Builder(context)
+        .setTrackSelector(trackSelector)
+        .setBandwidthMeter(bandwidthMeter)
+        .build();
+
     mSimpleExoPlayer.addListener(this);
     mSimpleExoPlayer.addVideoListener(this);
 
     // Produces DataSource instances through which media data is loaded.
-    final DataSource.Factory dataSourceFactory = mAVModule.getModuleRegistry().getModule(DataSourceFactoryProvider.class).createFactory(mReactContext, mAVModule.getModuleRegistry(), Util.getUserAgent(mAVModule.getContext(), "yourApplicationName"), mRequestHeaders, bandwidthMeter.getTransferListener());
+    final DataSource.Factory dataSourceFactory = mAVModule.getModuleRegistry()
+        .getModule(DataSourceFactoryProvider.class)
+        .createFactory(
+            mReactContext,
+            mAVModule.getModuleRegistry(),
+            Util.getUserAgent(context, "yourApplicationName"),
+            mRequestHeaders,
+            bandwidthMeter.getTransferListener());
     try {
       // This is the MediaSource representing the media to be played.
-      final MediaSource source = buildMediaSource(mUri, mOverridingExtension, mainHandler, dataSourceFactory);
+      final MediaSource source = buildMediaSource(mUri, mOverridingExtension, dataSourceFactory);
 
       // Prepare the player with the source.
       mSimpleExoPlayer.prepare(source);
@@ -234,7 +231,7 @@ class SimpleExoPlayerData extends PlayerData
 
   // --------- Interface implementation ---------
 
-  // AudioEventHandler
+  // region AudioEventHandler
 
   @Override
   public void pauseImmediately() {
@@ -256,8 +253,9 @@ class SimpleExoPlayerData extends PlayerData
     }
   }
 
-  // ExoPlayer.EventListener
+  // endregion
 
+  // region ExoPlayer.EventListener
   @Override
   public void onLoadingChanged(final boolean isLoading) {
     mIsLoading = isLoading;
@@ -279,12 +277,6 @@ class SimpleExoPlayerData extends PlayerData
 
   @Override
   public void onShuffleModeEnabledChanged(boolean shuffleModeEnabled) {
-
-  }
-
-  @Override
-  public void onTracksChanged(TrackGroupArray trackGroups,
-                              TrackSelectionArray trackSelections) {
 
   }
 
@@ -329,11 +321,19 @@ class SimpleExoPlayerData extends PlayerData
     }
   }
 
+  // endregion
 
-  // ExtractorMediaSource.EventListener
+  // region MediaSourceEventListener
 
   @Override
-  public void onLoadError(final IOException error) {
+  public void onLoadError(
+      int windowIndex,
+      @Nullable MediaSource.MediaPeriodId mediaPeriodId,
+      LoadEventInfo loadEventInfo,
+      MediaLoadData mediaLoadData,
+      IOException error,
+      boolean wasCanceled
+  ) {
     if (mLoadCompletionListener != null) {
       final LoadCompletionListener listener = mLoadCompletionListener;
       mLoadCompletionListener = null;
@@ -352,7 +352,9 @@ class SimpleExoPlayerData extends PlayerData
     release();
   }
 
-  // SimpleExoPlayer.VideoListener
+  // endregion
+
+  // region VideoListener
 
   @Override
   public void onVideoSizeChanged(final int width, final int height, final int unAppliedRotationDegrees, final float pixelWidthHeightRatio) {
@@ -371,8 +373,9 @@ class SimpleExoPlayerData extends PlayerData
     mFirstFrameRendered = true;
   }
 
-  // https://github.com/google/ExoPlayer/blob/2b20780482a9c6b07416bcbf4de829532859d10a/demos/main/src/main/java/com/google/android/exoplayer2/demo/PlayerActivity.java#L365-L393
-  private MediaSource buildMediaSource(Uri uri, String overrideExtension, Handler mainHandler, DataSource.Factory factory) {
+  // endregion
+
+  private MediaSource buildMediaSource(@NonNull Uri uri, String overrideExtension, DataSource.Factory factory) {
     try {
       if (uri.getScheme() == null) {
         int resourceId = mReactContext.getResources().getIdentifier(uri.toString(), "raw", mReactContext.getPackageName());
@@ -387,31 +390,20 @@ class SimpleExoPlayerData extends PlayerData
     @C.ContentType int type = TextUtils.isEmpty(overrideExtension) ? Util.inferContentType(String.valueOf(uri)) : Util.inferContentType("." + overrideExtension);
     switch (type) {
       case C.TYPE_SS:
-        return new SsMediaSource(uri, factory,
-          new DefaultSsChunkSource.Factory(factory), mainHandler, this);
+        return new SsMediaSource.Factory(new DefaultSsChunkSource.Factory(factory), factory).createMediaSource(MediaItem.fromUri(uri));
       case C.TYPE_DASH:
-        return new DashMediaSource(uri, factory,
-          new DefaultDashChunkSource.Factory(factory), mainHandler, this);
+        return new DashMediaSource.Factory(new DefaultDashChunkSource.Factory(factory), factory).createMediaSource(MediaItem.fromUri(uri));
       case C.TYPE_HLS:
-        return new HlsMediaSource(uri, factory, mainHandler, this);
+        return new HlsMediaSource.Factory(factory).createMediaSource(MediaItem.fromUri(uri));
       case C.TYPE_OTHER:
-        return new ExtractorMediaSource(uri, factory, new DefaultExtractorsFactory(), mainHandler, this);
+        return new ExtractorMediaSource.Factory(factory).createMediaSource(MediaItem.fromUri(uri));
       default: {
         throw new IllegalStateException("Content of this type is unsupported at the moment. Unsupported type: " + type);
       }
     }
   }
 
-  // AdaptiveMediaSourceEventListener
-  @Override
-  public void onMediaPeriodCreated(int windowIndex, MediaSource.MediaPeriodId mediaPeriodId) {
-
-  }
-
-  @Override
-  public void onMediaPeriodReleased(int windowIndex, MediaSource.MediaPeriodId mediaPeriodId) {
-
-  }
+  // region MediaSourceEventListener
 
   @Override
   public void onLoadStarted(int windowIndex, @Nullable MediaSource.MediaPeriodId mediaPeriodId, LoadEventInfo loadEventInfo, MediaLoadData mediaLoadData) {
@@ -429,16 +421,6 @@ class SimpleExoPlayerData extends PlayerData
   }
 
   @Override
-  public void onLoadError(int windowIndex, @Nullable MediaSource.MediaPeriodId mediaPeriodId, LoadEventInfo loadEventInfo, MediaLoadData mediaLoadData, IOException error, boolean wasCanceled) {
-
-  }
-
-  @Override
-  public void onReadingStarted(int windowIndex, MediaSource.MediaPeriodId mediaPeriodId) {
-
-  }
-
-  @Override
   public void onUpstreamDiscarded(int windowIndex, MediaSource.MediaPeriodId mediaPeriodId, MediaLoadData mediaLoadData) {
 
   }
@@ -447,4 +429,6 @@ class SimpleExoPlayerData extends PlayerData
   public void onDownstreamFormatChanged(int windowIndex, @Nullable MediaSource.MediaPeriodId mediaPeriodId, MediaLoadData mediaLoadData) {
 
   }
+
+  // endregion
 }

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/av/player/datasource/CustomHeadersOkHttpDataSourceFactory.java
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/av/player/datasource/CustomHeadersOkHttpDataSourceFactory.java
@@ -42,6 +42,6 @@ public class CustomHeadersOkHttpDataSourceFactory extends HttpDataSource.BaseFac
   }
 
   protected OkHttpDataSource createDataSourceInternal(HttpDataSource.RequestProperties defaultRequestProperties) {
-    return new OkHttpDataSource(mCallFactory, mUserAgent, null, mCacheControl, defaultRequestProperties);
+    return new OkHttpDataSource(mCallFactory, mUserAgent, mCacheControl, defaultRequestProperties);
   }
 }

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/av/video/VideoManager.java
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/av/video/VideoManager.java
@@ -3,11 +3,10 @@ package abi44_0_0.expo.modules.av.video;
 import android.content.Context;
 import androidx.annotation.Nullable;
 
-import com.yqritc.scalablevideoview.ScalableType;
-
 import java.util.HashMap;
 import java.util.Map;
 
+import abi44_0_0.expo.modules.av.video.scalablevideoview.ScalableType;
 import abi44_0_0.expo.modules.core.ExportedModule;
 import abi44_0_0.expo.modules.core.ModuleRegistry;
 import abi44_0_0.expo.modules.core.Promise;

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/av/video/VideoTextureView.java
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/av/video/VideoTextureView.java
@@ -5,13 +5,13 @@ import android.content.Context;
 import android.graphics.Matrix;
 import android.graphics.SurfaceTexture;
 import android.util.Pair;
+import android.util.Size;
 import android.view.Surface;
 import android.view.TextureView;
 import android.view.View;
 
-import com.yqritc.scalablevideoview.ScalableType;
-import com.yqritc.scalablevideoview.ScaleManager;
-import com.yqritc.scalablevideoview.Size;
+import abi44_0_0.expo.modules.av.video.scalablevideoview.ScalableType;
+import abi44_0_0.expo.modules.av.video.scalablevideoview.ScaleManager;
 
 @SuppressLint("ViewConstructor")
 public class VideoTextureView extends TextureView implements TextureView.SurfaceTextureListener {

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/av/video/VideoView.java
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/av/video/VideoView.java
@@ -9,8 +9,7 @@ import android.view.MotionEvent;
 import android.view.Surface;
 import android.widget.FrameLayout;
 
-import com.yqritc.scalablevideoview.ScalableType;
-
+import abi44_0_0.expo.modules.av.video.scalablevideoview.ScalableType;
 import abi44_0_0.expo.modules.core.ModuleRegistry;
 import abi44_0_0.expo.modules.core.Promise;
 import abi44_0_0.expo.modules.core.arguments.ReadableArguments;

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/av/video/VideoViewManager.java
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/av/video/VideoViewManager.java
@@ -2,11 +2,10 @@ package abi44_0_0.expo.modules.av.video;
 
 import android.content.Context;
 
-import com.yqritc.scalablevideoview.ScalableType;
-
 import java.util.ArrayList;
 import java.util.List;
 
+import abi44_0_0.expo.modules.av.video.scalablevideoview.ScalableType;
 import abi44_0_0.expo.modules.core.ModuleRegistry;
 import abi44_0_0.expo.modules.core.ViewManager;
 import abi44_0_0.expo.modules.core.arguments.ReadableArguments;

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/av/video/scalablevideoview/PivotPoint.java
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/av/video/scalablevideoview/PivotPoint.java
@@ -1,0 +1,17 @@
+package abi44_0_0.expo.modules.av.video.scalablevideoview;
+
+/**
+ * The following class is copied from https://github.com/yqritc/Android-ScalableVideoView/blob/master/library/src/main/java/com/yqritc/scalablevideoview/PivotPoint.java
+ * as the original library (com.yqritc:android-scalablevideoview) is only available on jcenter() repository and we're moved from fetching libraries from there.
+ */
+public enum PivotPoint {
+  LEFT_TOP,
+  LEFT_CENTER,
+  LEFT_BOTTOM,
+  CENTER_TOP,
+  CENTER,
+  CENTER_BOTTOM,
+  RIGHT_TOP,
+  RIGHT_CENTER,
+  RIGHT_BOTTOM
+}

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/av/video/scalablevideoview/ScalableType.java
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/av/video/scalablevideoview/ScalableType.java
@@ -1,0 +1,38 @@
+package abi44_0_0.expo.modules.av.video.scalablevideoview;
+
+/**
+ * The following class is copied from https://github.com/yqritc/Android-ScalableVideoView/blob/master/library/src/main/java/com/yqritc/scalablevideoview/ScalableType.java
+ * as the original library (com.yqritc:android-scalablevideoview) is only available on jcenter() repository and we're moved from fetching libraries from there.
+ */
+public enum ScalableType {
+  NONE,
+
+  FIT_XY,
+  FIT_START,
+  FIT_CENTER,
+  FIT_END,
+
+  LEFT_TOP,
+  LEFT_CENTER,
+  LEFT_BOTTOM,
+  CENTER_TOP,
+  CENTER,
+  CENTER_BOTTOM,
+  RIGHT_TOP,
+  RIGHT_CENTER,
+  RIGHT_BOTTOM,
+
+  LEFT_TOP_CROP,
+  LEFT_CENTER_CROP,
+  LEFT_BOTTOM_CROP,
+  CENTER_TOP_CROP,
+  CENTER_CROP,
+  CENTER_BOTTOM_CROP,
+  RIGHT_TOP_CROP,
+  RIGHT_CENTER_CROP,
+  RIGHT_BOTTOM_CROP,
+
+  START_INSIDE,
+  CENTER_INSIDE,
+  END_INSIDE
+}

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/av/video/scalablevideoview/ScaleManager.java
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/av/video/scalablevideoview/ScaleManager.java
@@ -1,0 +1,193 @@
+package abi44_0_0.expo.modules.av.video.scalablevideoview;
+
+import android.graphics.Matrix;
+import android.util.Size;
+
+/**
+ * The following class is copied from https://github.com/yqritc/Android-ScalableVideoView/blob/master/library/src/main/java/com/yqritc/scalablevideoview/ScaleManager.java
+ * as the original library (com.yqritc:android-scalablevideoview) is only available on jcenter() repository and we're moved from fetching libraries from there.
+ */
+public class ScaleManager {
+
+  private Size mViewSize;
+  private Size mVideoSize;
+
+  public ScaleManager(Size viewSize, Size videoSize) {
+    mViewSize = viewSize;
+    mVideoSize = videoSize;
+  }
+
+  public Matrix getScaleMatrix(ScalableType scalableType) {
+    switch (scalableType) {
+      case NONE:
+        return getNoScale();
+
+      case FIT_XY:
+        return fitXY();
+      case FIT_CENTER:
+        return fitCenter();
+      case FIT_START:
+        return fitStart();
+      case FIT_END:
+        return fitEnd();
+
+      case LEFT_TOP:
+        return getOriginalScale(PivotPoint.LEFT_TOP);
+      case LEFT_CENTER:
+        return getOriginalScale(PivotPoint.LEFT_CENTER);
+      case LEFT_BOTTOM:
+        return getOriginalScale(PivotPoint.LEFT_BOTTOM);
+      case CENTER_TOP:
+        return getOriginalScale(PivotPoint.CENTER_TOP);
+      case CENTER:
+        return getOriginalScale(PivotPoint.CENTER);
+      case CENTER_BOTTOM:
+        return getOriginalScale(PivotPoint.CENTER_BOTTOM);
+      case RIGHT_TOP:
+        return getOriginalScale(PivotPoint.RIGHT_TOP);
+      case RIGHT_CENTER:
+        return getOriginalScale(PivotPoint.RIGHT_CENTER);
+      case RIGHT_BOTTOM:
+        return getOriginalScale(PivotPoint.RIGHT_BOTTOM);
+
+      case LEFT_TOP_CROP:
+        return getCropScale(PivotPoint.LEFT_TOP);
+      case LEFT_CENTER_CROP:
+        return getCropScale(PivotPoint.LEFT_CENTER);
+      case LEFT_BOTTOM_CROP:
+        return getCropScale(PivotPoint.LEFT_BOTTOM);
+      case CENTER_TOP_CROP:
+        return getCropScale(PivotPoint.CENTER_TOP);
+      case CENTER_CROP:
+        return getCropScale(PivotPoint.CENTER);
+      case CENTER_BOTTOM_CROP:
+        return getCropScale(PivotPoint.CENTER_BOTTOM);
+      case RIGHT_TOP_CROP:
+        return getCropScale(PivotPoint.RIGHT_TOP);
+      case RIGHT_CENTER_CROP:
+        return getCropScale(PivotPoint.RIGHT_CENTER);
+      case RIGHT_BOTTOM_CROP:
+        return getCropScale(PivotPoint.RIGHT_BOTTOM);
+
+      case START_INSIDE:
+        return startInside();
+      case CENTER_INSIDE:
+        return centerInside();
+      case END_INSIDE:
+        return endInside();
+
+      default:
+        return null;
+    }
+  }
+
+  private Matrix getMatrix(float sx, float sy, float px, float py) {
+    Matrix matrix = new Matrix();
+    matrix.setScale(sx, sy, px, py);
+    return matrix;
+  }
+
+  private Matrix getMatrix(float sx, float sy, PivotPoint pivotPoint) {
+    switch (pivotPoint) {
+      case LEFT_TOP:
+        return getMatrix(sx, sy, 0, 0);
+      case LEFT_CENTER:
+        return getMatrix(sx, sy, 0, mViewSize.getHeight() / 2f);
+      case LEFT_BOTTOM:
+        return getMatrix(sx, sy, 0, mViewSize.getHeight());
+      case CENTER_TOP:
+        return getMatrix(sx, sy, mViewSize.getWidth() / 2f, 0);
+      case CENTER:
+        return getMatrix(sx, sy, mViewSize.getWidth() / 2f, mViewSize.getHeight() / 2f);
+      case CENTER_BOTTOM:
+        return getMatrix(sx, sy, mViewSize.getWidth() / 2f, mViewSize.getHeight());
+      case RIGHT_TOP:
+        return getMatrix(sx, sy, mViewSize.getWidth(), 0);
+      case RIGHT_CENTER:
+        return getMatrix(sx, sy, mViewSize.getWidth(), mViewSize.getHeight() / 2f);
+      case RIGHT_BOTTOM:
+        return getMatrix(sx, sy, mViewSize.getWidth(), mViewSize.getHeight());
+      default:
+        throw new IllegalArgumentException("Illegal PivotPoint");
+    }
+  }
+
+  private Matrix getNoScale() {
+    float sx = mVideoSize.getWidth() / (float) mViewSize.getWidth();
+    float sy = mVideoSize.getHeight() / (float) mViewSize.getHeight();
+    return getMatrix(sx, sy, PivotPoint.LEFT_TOP);
+  }
+
+  private Matrix getFitScale(PivotPoint pivotPoint) {
+    float sx = (float) mViewSize.getWidth() / mVideoSize.getWidth();
+    float sy = (float) mViewSize.getHeight() / mVideoSize.getHeight();
+    float minScale = Math.min(sx, sy);
+    sx = minScale / sx;
+    sy = minScale / sy;
+    return getMatrix(sx, sy, pivotPoint);
+  }
+
+  private Matrix fitXY() {
+    return getMatrix(1, 1, PivotPoint.LEFT_TOP);
+  }
+
+  private Matrix fitStart() {
+    return getFitScale(PivotPoint.LEFT_TOP);
+  }
+
+  private Matrix fitCenter() {
+    return getFitScale(PivotPoint.CENTER);
+  }
+
+  private Matrix fitEnd() {
+    return getFitScale(PivotPoint.RIGHT_BOTTOM);
+  }
+
+  private Matrix getOriginalScale(PivotPoint pivotPoint) {
+    float sx = mVideoSize.getWidth() / (float) mViewSize.getWidth();
+    float sy = mVideoSize.getHeight() / (float) mViewSize.getHeight();
+    return getMatrix(sx, sy, pivotPoint);
+  }
+
+  private Matrix getCropScale(PivotPoint pivotPoint) {
+    float sx = (float) mViewSize.getWidth() / mVideoSize.getWidth();
+    float sy = (float) mViewSize.getHeight() / mVideoSize.getHeight();
+    float maxScale = Math.max(sx, sy);
+    sx = maxScale / sx;
+    sy = maxScale / sy;
+    return getMatrix(sx, sy, pivotPoint);
+  }
+
+  private Matrix startInside() {
+    if (mVideoSize.getHeight() <= mViewSize.getWidth()
+        && mVideoSize.getHeight() <= mViewSize.getHeight()) {
+      // video is smaller than view size
+      return getOriginalScale(PivotPoint.LEFT_TOP);
+    } else {
+      // either of width or height of the video is larger than view size
+      return fitStart();
+    }
+  }
+
+  private Matrix centerInside() {
+    if (mVideoSize.getHeight() <= mViewSize.getWidth()
+        && mVideoSize.getHeight() <= mViewSize.getHeight()) {
+      // video is smaller than view size
+      return getOriginalScale(PivotPoint.CENTER);
+    } else {
+      // either of width or height of the video is larger than view size
+      return fitCenter();
+    }
+  }
+
+  private Matrix endInside() {
+    if (mVideoSize.getHeight() <= mViewSize.getWidth()
+        && mVideoSize.getHeight() <= mViewSize.getHeight()) {
+      // video is smaller than view size
+      return getOriginalScale(PivotPoint.RIGHT_BOTTOM);
+    } else {
+      // either of width or height of the video is larger than view size
+      return fitEnd();
+    }
+  }
+}

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/host/exp/exponent/modules/universal/av/CustomHeadersOkHttpDataSourceFactory.kt
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/host/exp/exponent/modules/universal/av/CustomHeadersOkHttpDataSourceFactory.kt
@@ -29,7 +29,7 @@ class CustomHeadersOkHttpDataSourceFactory(
   }
 
   override fun createDataSourceInternal(defaultRequestProperties: RequestProperties): OkHttpDataSource {
-    return OkHttpDataSource(callFactory, userAgent, null, cacheControl, defaultRequestProperties)
+    return OkHttpDataSource(callFactory, userAgent, cacheControl, defaultRequestProperties)
   }
 
   init {

--- a/apps/bare-expo/android/build.gradle
+++ b/apps/bare-expo/android/build.gradle
@@ -20,7 +20,6 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
     dependencies {
         classpath("com.android.tools.build:gradle:$gradlePluginVersion")

--- a/apps/bare-sandbox/android/build.gradle
+++ b/apps/bare-sandbox/android/build.gradle
@@ -10,7 +10,6 @@ buildscript {
     }
     repositories {
         google()
-        jcenter()
     }
     dependencies {
         classpath("com.android.tools.build:gradle:4.2.2")
@@ -33,7 +32,6 @@ allprojects {
         }
 
         google()
-        jcenter()
         maven { url 'https://www.jitpack.io' }
     }
 }

--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Remove deprecated `onIOSFullscreenUpdate` prop from `Video` component. ([#16059](https://github.com/expo/expo/pull/16059) by [@Simek](https://github.com/Simek))
 - Remove unused `presentFullscreenPlayerAsync` method from `Video` component. ([#16059](https://github.com/expo/expo/pull/16059) by [@Simek](https://github.com/Simek))
 - Remove `INTERRUPTION_MODE_*` constants in favor of `InterruptionModeAndroid` and `InterruptionModeIOS` enums. ([#16145](https://github.com/expo/expo/pull/16145) by [@Simek](https://github.com/Simek))
+- On Android upgrade `com.google.android.exoplayer:*:2.9.2` (available from `jcenter()`) to `com.google.android.exoplayer:*:2.13.3` (available from `google()`). ([#16123](https://github.com/expo/expo/pull/16123) by [@bbarthec](https://github.com/bbarthec))
 
 ### 🎉 New features
 

--- a/packages/expo-av/android/build.gradle
+++ b/packages/expo-av/android/build.gradle
@@ -87,18 +87,11 @@ dependencies {
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
 
-  // Newer version introduces dependency versions conflict
-  // on 'com.android.support:support-annotations'
-  api 'com.google.android.exoplayer:exoplayer:2.9.2'
-
-  api 'com.google.android.exoplayer:extension-okhttp:2.9.2'
-
-  api 'com.yqritc:android-scalablevideoview:1.0.1'
+  api 'com.google.android.exoplayer:exoplayer:2.13.3'
+  api 'com.google.android.exoplayer:extension-okhttp:2.13.3'
 
   api "com.squareup.okhttp3:okhttp:3.14.9"
   api "com.squareup.okhttp3:okhttp-urlconnection:3.14.9"
-
-  api "com.android.support:support-annotations:${safeExtGet("supportLibVersion", "29.0.0")}"
 
   testImplementation 'org.junit.jupiter:junit-jupiter-api:5.5.1'
   testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.5.1"

--- a/packages/expo-av/android/src/main/java/expo/modules/av/player/SimpleExoPlayerData.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/player/SimpleExoPlayerData.java
@@ -5,28 +5,25 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.os.Handler;
 
-import androidx.annotation.Nullable;
-
 import android.text.TextUtils;
 import android.util.Log;
 import android.util.Pair;
 import android.view.Surface;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.google.android.exoplayer2.C;
-import com.google.android.exoplayer2.DefaultLoadControl;
-import com.google.android.exoplayer2.DefaultRenderersFactory;
 import com.google.android.exoplayer2.ExoPlaybackException;
-import com.google.android.exoplayer2.ExoPlayerFactory;
-import com.google.android.exoplayer2.Format;
+import com.google.android.exoplayer2.MediaItem;
 import com.google.android.exoplayer2.PlaybackParameters;
 import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.SimpleExoPlayer;
-import com.google.android.exoplayer2.Timeline;
-import com.google.android.exoplayer2.extractor.DefaultExtractorsFactory;
-import com.google.android.exoplayer2.source.AdaptiveMediaSourceEventListener;
 import com.google.android.exoplayer2.source.ExtractorMediaSource;
+import com.google.android.exoplayer2.source.LoadEventInfo;
+import com.google.android.exoplayer2.source.MediaLoadData;
 import com.google.android.exoplayer2.source.MediaSource;
-import com.google.android.exoplayer2.source.TrackGroupArray;
+import com.google.android.exoplayer2.source.MediaSourceEventListener;
 import com.google.android.exoplayer2.source.dash.DashMediaSource;
 import com.google.android.exoplayer2.source.dash.DefaultDashChunkSource;
 import com.google.android.exoplayer2.source.hls.HlsMediaSource;
@@ -34,8 +31,6 @@ import com.google.android.exoplayer2.source.smoothstreaming.DefaultSsChunkSource
 import com.google.android.exoplayer2.source.smoothstreaming.SsMediaSource;
 import com.google.android.exoplayer2.trackselection.AdaptiveTrackSelection;
 import com.google.android.exoplayer2.trackselection.DefaultTrackSelector;
-import com.google.android.exoplayer2.trackselection.TrackSelection;
-import com.google.android.exoplayer2.trackselection.TrackSelectionArray;
 import com.google.android.exoplayer2.trackselection.TrackSelector;
 import com.google.android.exoplayer2.upstream.BandwidthMeter;
 import com.google.android.exoplayer2.upstream.DataSource;
@@ -43,30 +38,30 @@ import com.google.android.exoplayer2.upstream.DataSpec;
 import com.google.android.exoplayer2.upstream.DefaultBandwidthMeter;
 import com.google.android.exoplayer2.upstream.RawResourceDataSource;
 import com.google.android.exoplayer2.util.Util;
+import com.google.android.exoplayer2.video.VideoListener;
 
 import java.io.IOException;
 import java.util.Map;
 
 import expo.modules.av.AVManagerInterface;
 import expo.modules.av.AudioFocusNotAcquiredException;
-import expo.modules.av.player.datasource.CustomHeadersOkHttpDataSourceFactory;
 import expo.modules.av.player.datasource.DataSourceFactoryProvider;
 
 class SimpleExoPlayerData extends PlayerData
-  implements Player.EventListener, ExtractorMediaSource.EventListener, SimpleExoPlayer.VideoListener, AdaptiveMediaSourceEventListener {
+  implements Player.EventListener, MediaSourceEventListener, VideoListener {
 
   private static final String IMPLEMENTATION_NAME = "SimpleExoPlayer";
   private static final String TAG = SimpleExoPlayerData.class.getSimpleName();
 
   private SimpleExoPlayer mSimpleExoPlayer = null;
-  private String mOverridingExtension;
+  private final String mOverridingExtension;
   private LoadCompletionListener mLoadCompletionListener = null;
   private boolean mFirstFrameRendered = false;
   private Pair<Integer, Integer> mVideoWidthHeight = null;
   private Integer mLastPlaybackState = null;
   private boolean mIsLooping = false;
   private boolean mIsLoading = true;
-  private Context mReactContext;
+  private final Context mReactContext;
 
   SimpleExoPlayerData(final AVManagerInterface avModule, final Context context, final Uri uri, final String overridingExtension, final Map<String, Object> requestHeaders) {
     super(avModule, uri, requestHeaders);
@@ -87,29 +82,31 @@ class SimpleExoPlayerData extends PlayerData
   public void load(final Bundle status, final LoadCompletionListener loadCompletionListener) {
     mLoadCompletionListener = loadCompletionListener;
 
-    // Create a default TrackSelector
-    final Handler mainHandler = new Handler();
-    // Measures bandwidth during playback. Can be null if not required.
-    final BandwidthMeter bandwidthMeter = new DefaultBandwidthMeter();
-    final TrackSelection.Factory trackSelectionFactory = new AdaptiveTrackSelection.Factory();
-    final TrackSelector trackSelector = new DefaultTrackSelector(trackSelectionFactory);
+    final Context context = mAVModule.getContext();
+    final BandwidthMeter bandwidthMeter = new DefaultBandwidthMeter.Builder(context).build();
+    final TrackSelector trackSelector = new DefaultTrackSelector(context, new AdaptiveTrackSelection.Factory());
 
     // Create the player
-    mSimpleExoPlayer = ExoPlayerFactory.newSimpleInstance(
-      mAVModule.getContext(),
-      new DefaultRenderersFactory(mAVModule.getContext()),
-      trackSelector,
-      new DefaultLoadControl(),
-      null,
-      bandwidthMeter);
+    mSimpleExoPlayer = new SimpleExoPlayer.Builder(context)
+        .setTrackSelector(trackSelector)
+        .setBandwidthMeter(bandwidthMeter)
+        .build();
+
     mSimpleExoPlayer.addListener(this);
     mSimpleExoPlayer.addVideoListener(this);
 
     // Produces DataSource instances through which media data is loaded.
-    final DataSource.Factory dataSourceFactory = mAVModule.getModuleRegistry().getModule(DataSourceFactoryProvider.class).createFactory(mReactContext, mAVModule.getModuleRegistry(), Util.getUserAgent(mAVModule.getContext(), "yourApplicationName"), mRequestHeaders, bandwidthMeter.getTransferListener());
+    final DataSource.Factory dataSourceFactory = mAVModule.getModuleRegistry()
+        .getModule(DataSourceFactoryProvider.class)
+        .createFactory(
+            mReactContext,
+            mAVModule.getModuleRegistry(),
+            Util.getUserAgent(context, "yourApplicationName"),
+            mRequestHeaders,
+            bandwidthMeter.getTransferListener());
     try {
       // This is the MediaSource representing the media to be played.
-      final MediaSource source = buildMediaSource(mUri, mOverridingExtension, mainHandler, dataSourceFactory);
+      final MediaSource source = buildMediaSource(mUri, mOverridingExtension, dataSourceFactory);
 
       // Prepare the player with the source.
       mSimpleExoPlayer.prepare(source);
@@ -234,7 +231,7 @@ class SimpleExoPlayerData extends PlayerData
 
   // --------- Interface implementation ---------
 
-  // AudioEventHandler
+  // region AudioEventHandler
 
   @Override
   public void pauseImmediately() {
@@ -256,7 +253,9 @@ class SimpleExoPlayerData extends PlayerData
     }
   }
 
-  // ExoPlayer.EventListener
+  // endregion
+
+  // region ExoPlayer.EventListener
 
   @Override
   public void onLoadingChanged(final boolean isLoading) {
@@ -279,12 +278,6 @@ class SimpleExoPlayerData extends PlayerData
 
   @Override
   public void onShuffleModeEnabledChanged(boolean shuffleModeEnabled) {
-
-  }
-
-  @Override
-  public void onTracksChanged(TrackGroupArray trackGroups,
-                              TrackSelectionArray trackSelections) {
 
   }
 
@@ -329,11 +322,19 @@ class SimpleExoPlayerData extends PlayerData
     }
   }
 
+  // endregion
 
-  // ExtractorMediaSource.EventListener
+  // region MediaSourceEventListener
 
   @Override
-  public void onLoadError(final IOException error) {
+  public void onLoadError(
+      int windowIndex,
+      @Nullable MediaSource.MediaPeriodId mediaPeriodId,
+      LoadEventInfo loadEventInfo,
+      MediaLoadData mediaLoadData,
+      IOException error,
+      boolean wasCanceled
+  ) {
     if (mLoadCompletionListener != null) {
       final LoadCompletionListener listener = mLoadCompletionListener;
       mLoadCompletionListener = null;
@@ -352,7 +353,9 @@ class SimpleExoPlayerData extends PlayerData
     release();
   }
 
-  // SimpleExoPlayer.VideoListener
+  // endregion
+
+  // region VideoListener
 
   @Override
   public void onVideoSizeChanged(final int width, final int height, final int unAppliedRotationDegrees, final float pixelWidthHeightRatio) {
@@ -371,8 +374,9 @@ class SimpleExoPlayerData extends PlayerData
     mFirstFrameRendered = true;
   }
 
-  // https://github.com/google/ExoPlayer/blob/2b20780482a9c6b07416bcbf4de829532859d10a/demos/main/src/main/java/com/google/android/exoplayer2/demo/PlayerActivity.java#L365-L393
-  private MediaSource buildMediaSource(Uri uri, String overrideExtension, Handler mainHandler, DataSource.Factory factory) {
+  // endregion
+
+  private MediaSource buildMediaSource(@NonNull Uri uri, String overrideExtension, DataSource.Factory factory) {
     try {
       if (uri.getScheme() == null) {
         int resourceId = mReactContext.getResources().getIdentifier(uri.toString(), "raw", mReactContext.getPackageName());
@@ -387,31 +391,20 @@ class SimpleExoPlayerData extends PlayerData
     @C.ContentType int type = TextUtils.isEmpty(overrideExtension) ? Util.inferContentType(String.valueOf(uri)) : Util.inferContentType("." + overrideExtension);
     switch (type) {
       case C.TYPE_SS:
-        return new SsMediaSource(uri, factory,
-          new DefaultSsChunkSource.Factory(factory), mainHandler, this);
+        return new SsMediaSource.Factory(new DefaultSsChunkSource.Factory(factory), factory).createMediaSource(MediaItem.fromUri(uri));
       case C.TYPE_DASH:
-        return new DashMediaSource(uri, factory,
-          new DefaultDashChunkSource.Factory(factory), mainHandler, this);
+        return new DashMediaSource.Factory(new DefaultDashChunkSource.Factory(factory), factory).createMediaSource(MediaItem.fromUri(uri));
       case C.TYPE_HLS:
-        return new HlsMediaSource(uri, factory, mainHandler, this);
+        return new HlsMediaSource.Factory(factory).createMediaSource(MediaItem.fromUri(uri));
       case C.TYPE_OTHER:
-        return new ExtractorMediaSource(uri, factory, new DefaultExtractorsFactory(), mainHandler, this);
+        return new ExtractorMediaSource.Factory(factory).createMediaSource(MediaItem.fromUri(uri));
       default: {
         throw new IllegalStateException("Content of this type is unsupported at the moment. Unsupported type: " + type);
       }
     }
   }
 
-  // AdaptiveMediaSourceEventListener
-  @Override
-  public void onMediaPeriodCreated(int windowIndex, MediaSource.MediaPeriodId mediaPeriodId) {
-
-  }
-
-  @Override
-  public void onMediaPeriodReleased(int windowIndex, MediaSource.MediaPeriodId mediaPeriodId) {
-
-  }
+  // region MediaSourceEventListener
 
   @Override
   public void onLoadStarted(int windowIndex, @Nullable MediaSource.MediaPeriodId mediaPeriodId, LoadEventInfo loadEventInfo, MediaLoadData mediaLoadData) {
@@ -429,16 +422,6 @@ class SimpleExoPlayerData extends PlayerData
   }
 
   @Override
-  public void onLoadError(int windowIndex, @Nullable MediaSource.MediaPeriodId mediaPeriodId, LoadEventInfo loadEventInfo, MediaLoadData mediaLoadData, IOException error, boolean wasCanceled) {
-
-  }
-
-  @Override
-  public void onReadingStarted(int windowIndex, MediaSource.MediaPeriodId mediaPeriodId) {
-
-  }
-
-  @Override
   public void onUpstreamDiscarded(int windowIndex, MediaSource.MediaPeriodId mediaPeriodId, MediaLoadData mediaLoadData) {
 
   }
@@ -447,4 +430,6 @@ class SimpleExoPlayerData extends PlayerData
   public void onDownstreamFormatChanged(int windowIndex, @Nullable MediaSource.MediaPeriodId mediaPeriodId, MediaLoadData mediaLoadData) {
 
   }
+
+  // endregion
 }

--- a/packages/expo-av/android/src/main/java/expo/modules/av/player/datasource/CustomHeadersOkHttpDataSourceFactory.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/player/datasource/CustomHeadersOkHttpDataSourceFactory.java
@@ -42,6 +42,6 @@ public class CustomHeadersOkHttpDataSourceFactory extends HttpDataSource.BaseFac
   }
 
   protected OkHttpDataSource createDataSourceInternal(HttpDataSource.RequestProperties defaultRequestProperties) {
-    return new OkHttpDataSource(mCallFactory, mUserAgent, null, mCacheControl, defaultRequestProperties);
+    return new OkHttpDataSource(mCallFactory, mUserAgent, mCacheControl, defaultRequestProperties);
   }
 }

--- a/packages/expo-av/android/src/main/java/expo/modules/av/video/VideoManager.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/video/VideoManager.java
@@ -3,11 +3,10 @@ package expo.modules.av.video;
 import android.content.Context;
 import androidx.annotation.Nullable;
 
-import com.yqritc.scalablevideoview.ScalableType;
-
 import java.util.HashMap;
 import java.util.Map;
 
+import expo.modules.av.video.scalablevideoview.ScalableType;
 import expo.modules.core.ExportedModule;
 import expo.modules.core.ModuleRegistry;
 import expo.modules.core.Promise;

--- a/packages/expo-av/android/src/main/java/expo/modules/av/video/VideoTextureView.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/video/VideoTextureView.java
@@ -5,13 +5,13 @@ import android.content.Context;
 import android.graphics.Matrix;
 import android.graphics.SurfaceTexture;
 import android.util.Pair;
+import android.util.Size;
 import android.view.Surface;
 import android.view.TextureView;
 import android.view.View;
 
-import com.yqritc.scalablevideoview.ScalableType;
-import com.yqritc.scalablevideoview.ScaleManager;
-import com.yqritc.scalablevideoview.Size;
+import expo.modules.av.video.scalablevideoview.ScalableType;
+import expo.modules.av.video.scalablevideoview.ScaleManager;
 
 @SuppressLint("ViewConstructor")
 public class VideoTextureView extends TextureView implements TextureView.SurfaceTextureListener {

--- a/packages/expo-av/android/src/main/java/expo/modules/av/video/VideoView.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/video/VideoView.java
@@ -9,8 +9,7 @@ import android.view.MotionEvent;
 import android.view.Surface;
 import android.widget.FrameLayout;
 
-import com.yqritc.scalablevideoview.ScalableType;
-
+import expo.modules.av.video.scalablevideoview.ScalableType;
 import expo.modules.core.ModuleRegistry;
 import expo.modules.core.Promise;
 import expo.modules.core.arguments.ReadableArguments;

--- a/packages/expo-av/android/src/main/java/expo/modules/av/video/VideoViewManager.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/video/VideoViewManager.java
@@ -2,11 +2,10 @@ package expo.modules.av.video;
 
 import android.content.Context;
 
-import com.yqritc.scalablevideoview.ScalableType;
-
 import java.util.ArrayList;
 import java.util.List;
 
+import expo.modules.av.video.scalablevideoview.ScalableType;
 import expo.modules.core.ModuleRegistry;
 import expo.modules.core.ViewManager;
 import expo.modules.core.arguments.ReadableArguments;

--- a/packages/expo-av/android/src/main/java/expo/modules/av/video/scalablevideoview/PivotPoint.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/video/scalablevideoview/PivotPoint.java
@@ -1,0 +1,17 @@
+package expo.modules.av.video.scalablevideoview;
+
+/**
+ * The following class is copied from https://github.com/yqritc/Android-ScalableVideoView/blob/master/library/src/main/java/com/yqritc/scalablevideoview/PivotPoint.java
+ * as the original library (com.yqritc:android-scalablevideoview) is only available on jcenter() repository and we're moved from fetching libraries from there.
+ */
+public enum PivotPoint {
+  LEFT_TOP,
+  LEFT_CENTER,
+  LEFT_BOTTOM,
+  CENTER_TOP,
+  CENTER,
+  CENTER_BOTTOM,
+  RIGHT_TOP,
+  RIGHT_CENTER,
+  RIGHT_BOTTOM
+}

--- a/packages/expo-av/android/src/main/java/expo/modules/av/video/scalablevideoview/ScalableType.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/video/scalablevideoview/ScalableType.java
@@ -1,0 +1,38 @@
+package expo.modules.av.video.scalablevideoview;
+
+/**
+ * The following class is copied from https://github.com/yqritc/Android-ScalableVideoView/blob/master/library/src/main/java/com/yqritc/scalablevideoview/ScalableType.java
+ * as the original library (com.yqritc:android-scalablevideoview) is only available on jcenter() repository and we're moved from fetching libraries from there.
+ */
+public enum ScalableType {
+  NONE,
+
+  FIT_XY,
+  FIT_START,
+  FIT_CENTER,
+  FIT_END,
+
+  LEFT_TOP,
+  LEFT_CENTER,
+  LEFT_BOTTOM,
+  CENTER_TOP,
+  CENTER,
+  CENTER_BOTTOM,
+  RIGHT_TOP,
+  RIGHT_CENTER,
+  RIGHT_BOTTOM,
+
+  LEFT_TOP_CROP,
+  LEFT_CENTER_CROP,
+  LEFT_BOTTOM_CROP,
+  CENTER_TOP_CROP,
+  CENTER_CROP,
+  CENTER_BOTTOM_CROP,
+  RIGHT_TOP_CROP,
+  RIGHT_CENTER_CROP,
+  RIGHT_BOTTOM_CROP,
+
+  START_INSIDE,
+  CENTER_INSIDE,
+  END_INSIDE
+}

--- a/packages/expo-av/android/src/main/java/expo/modules/av/video/scalablevideoview/ScaleManager.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/video/scalablevideoview/ScaleManager.java
@@ -1,0 +1,193 @@
+package expo.modules.av.video.scalablevideoview;
+
+import android.graphics.Matrix;
+import android.util.Size;
+
+/**
+ * The following class is copied from https://github.com/yqritc/Android-ScalableVideoView/blob/master/library/src/main/java/com/yqritc/scalablevideoview/ScaleManager.java
+ * as the original library (com.yqritc:android-scalablevideoview) is only available on jcenter() repository and we're moved from fetching libraries from there.
+ */
+public class ScaleManager {
+
+  private Size mViewSize;
+  private Size mVideoSize;
+
+  public ScaleManager(Size viewSize, Size videoSize) {
+    mViewSize = viewSize;
+    mVideoSize = videoSize;
+  }
+
+  public Matrix getScaleMatrix(ScalableType scalableType) {
+    switch (scalableType) {
+      case NONE:
+        return getNoScale();
+
+      case FIT_XY:
+        return fitXY();
+      case FIT_CENTER:
+        return fitCenter();
+      case FIT_START:
+        return fitStart();
+      case FIT_END:
+        return fitEnd();
+
+      case LEFT_TOP:
+        return getOriginalScale(PivotPoint.LEFT_TOP);
+      case LEFT_CENTER:
+        return getOriginalScale(PivotPoint.LEFT_CENTER);
+      case LEFT_BOTTOM:
+        return getOriginalScale(PivotPoint.LEFT_BOTTOM);
+      case CENTER_TOP:
+        return getOriginalScale(PivotPoint.CENTER_TOP);
+      case CENTER:
+        return getOriginalScale(PivotPoint.CENTER);
+      case CENTER_BOTTOM:
+        return getOriginalScale(PivotPoint.CENTER_BOTTOM);
+      case RIGHT_TOP:
+        return getOriginalScale(PivotPoint.RIGHT_TOP);
+      case RIGHT_CENTER:
+        return getOriginalScale(PivotPoint.RIGHT_CENTER);
+      case RIGHT_BOTTOM:
+        return getOriginalScale(PivotPoint.RIGHT_BOTTOM);
+
+      case LEFT_TOP_CROP:
+        return getCropScale(PivotPoint.LEFT_TOP);
+      case LEFT_CENTER_CROP:
+        return getCropScale(PivotPoint.LEFT_CENTER);
+      case LEFT_BOTTOM_CROP:
+        return getCropScale(PivotPoint.LEFT_BOTTOM);
+      case CENTER_TOP_CROP:
+        return getCropScale(PivotPoint.CENTER_TOP);
+      case CENTER_CROP:
+        return getCropScale(PivotPoint.CENTER);
+      case CENTER_BOTTOM_CROP:
+        return getCropScale(PivotPoint.CENTER_BOTTOM);
+      case RIGHT_TOP_CROP:
+        return getCropScale(PivotPoint.RIGHT_TOP);
+      case RIGHT_CENTER_CROP:
+        return getCropScale(PivotPoint.RIGHT_CENTER);
+      case RIGHT_BOTTOM_CROP:
+        return getCropScale(PivotPoint.RIGHT_BOTTOM);
+
+      case START_INSIDE:
+        return startInside();
+      case CENTER_INSIDE:
+        return centerInside();
+      case END_INSIDE:
+        return endInside();
+
+      default:
+        return null;
+    }
+  }
+
+  private Matrix getMatrix(float sx, float sy, float px, float py) {
+    Matrix matrix = new Matrix();
+    matrix.setScale(sx, sy, px, py);
+    return matrix;
+  }
+
+  private Matrix getMatrix(float sx, float sy, PivotPoint pivotPoint) {
+    switch (pivotPoint) {
+      case LEFT_TOP:
+        return getMatrix(sx, sy, 0, 0);
+      case LEFT_CENTER:
+        return getMatrix(sx, sy, 0, mViewSize.getHeight() / 2f);
+      case LEFT_BOTTOM:
+        return getMatrix(sx, sy, 0, mViewSize.getHeight());
+      case CENTER_TOP:
+        return getMatrix(sx, sy, mViewSize.getWidth() / 2f, 0);
+      case CENTER:
+        return getMatrix(sx, sy, mViewSize.getWidth() / 2f, mViewSize.getHeight() / 2f);
+      case CENTER_BOTTOM:
+        return getMatrix(sx, sy, mViewSize.getWidth() / 2f, mViewSize.getHeight());
+      case RIGHT_TOP:
+        return getMatrix(sx, sy, mViewSize.getWidth(), 0);
+      case RIGHT_CENTER:
+        return getMatrix(sx, sy, mViewSize.getWidth(), mViewSize.getHeight() / 2f);
+      case RIGHT_BOTTOM:
+        return getMatrix(sx, sy, mViewSize.getWidth(), mViewSize.getHeight());
+      default:
+        throw new IllegalArgumentException("Illegal PivotPoint");
+    }
+  }
+
+  private Matrix getNoScale() {
+    float sx = mVideoSize.getWidth() / (float) mViewSize.getWidth();
+    float sy = mVideoSize.getHeight() / (float) mViewSize.getHeight();
+    return getMatrix(sx, sy, PivotPoint.LEFT_TOP);
+  }
+
+  private Matrix getFitScale(PivotPoint pivotPoint) {
+    float sx = (float) mViewSize.getWidth() / mVideoSize.getWidth();
+    float sy = (float) mViewSize.getHeight() / mVideoSize.getHeight();
+    float minScale = Math.min(sx, sy);
+    sx = minScale / sx;
+    sy = minScale / sy;
+    return getMatrix(sx, sy, pivotPoint);
+  }
+
+  private Matrix fitXY() {
+    return getMatrix(1, 1, PivotPoint.LEFT_TOP);
+  }
+
+  private Matrix fitStart() {
+    return getFitScale(PivotPoint.LEFT_TOP);
+  }
+
+  private Matrix fitCenter() {
+    return getFitScale(PivotPoint.CENTER);
+  }
+
+  private Matrix fitEnd() {
+    return getFitScale(PivotPoint.RIGHT_BOTTOM);
+  }
+
+  private Matrix getOriginalScale(PivotPoint pivotPoint) {
+    float sx = mVideoSize.getWidth() / (float) mViewSize.getWidth();
+    float sy = mVideoSize.getHeight() / (float) mViewSize.getHeight();
+    return getMatrix(sx, sy, pivotPoint);
+  }
+
+  private Matrix getCropScale(PivotPoint pivotPoint) {
+    float sx = (float) mViewSize.getWidth() / mVideoSize.getWidth();
+    float sy = (float) mViewSize.getHeight() / mVideoSize.getHeight();
+    float maxScale = Math.max(sx, sy);
+    sx = maxScale / sx;
+    sy = maxScale / sy;
+    return getMatrix(sx, sy, pivotPoint);
+  }
+
+  private Matrix startInside() {
+    if (mVideoSize.getHeight() <= mViewSize.getWidth()
+        && mVideoSize.getHeight() <= mViewSize.getHeight()) {
+      // video is smaller than view size
+      return getOriginalScale(PivotPoint.LEFT_TOP);
+    } else {
+      // either of width or height of the video is larger than view size
+      return fitStart();
+    }
+  }
+
+  private Matrix centerInside() {
+    if (mVideoSize.getHeight() <= mViewSize.getWidth()
+        && mVideoSize.getHeight() <= mViewSize.getHeight()) {
+      // video is smaller than view size
+      return getOriginalScale(PivotPoint.CENTER);
+    } else {
+      // either of width or height of the video is larger than view size
+      return fitCenter();
+    }
+  }
+
+  private Matrix endInside() {
+    if (mVideoSize.getHeight() <= mViewSize.getWidth()
+        && mVideoSize.getHeight() <= mViewSize.getHeight()) {
+      // video is smaller than view size
+      return getOriginalScale(PivotPoint.RIGHT_BOTTOM);
+    } else {
+      // either of width or height of the video is larger than view size
+      return fitEnd();
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8688,10 +8688,10 @@ expo-pwa@0.0.110:
     commander "2.20.0"
     update-check "1.5.3"
 
-expo-test-runner@0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/expo-test-runner/-/expo-test-runner-0.0.7.tgz#929d102c009f5d8d766d022cacf3b17cf54282df"
-  integrity sha512-6gUhNNNmephqKOwUE/RG2Y93Toy4YPHc1osH1sSo+ags0v05/j1t9Usb1xytkG3rWjhGYh+DI8UZ/Gkamo6U4Q==
+expo-test-runner@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/expo-test-runner/-/expo-test-runner-0.0.8.tgz#f4dbed5c72a86236fe10d0f2519d3497f7abba27"
+  integrity sha512-ff5HsoelDmutNmTTApbjrYrKNGpPx8bPQ+oLLu4+RRxBuCjsHf577TjFQa8Suz/grc9f7VK7Nh4doIgukolZHg==
   dependencies:
     "@babel/runtime" "7.9.0"
     "@expo/spawn-async" "^1.5.0"


### PR DESCRIPTION
# Why

Resolves [ENG-2858](https://linear.app/expo/issue/ENG-2858/remove-jcenter)
Continues https://github.com/expo/expo/pull/16122

# How

- Removed `https://github.com/yqritc/Android-ScalableVideoView` by copying the parts into the `expo-av` codebase as it's only available on `jcenter()`
- Bumped the `exoplayer` to the smallest version available on google maven.
- Tweaked the codebase to work with the new version of exoplayer.

# Test Plan

I've succeeded in compiling `bare-expo` and running the `ncl`#`video` screen with both remote and local videos playing nicely.

# TODO

- [x] Ensure `Expo Go` works
- [ ] Backport changes if necessary