### PR TITLE
[iOS][video-thumbnails] Fix memory leak

### DIFF
--- a/packages/expo-video-thumbnails/CHANGELOG.md
+++ b/packages/expo-video-thumbnails/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fix `Plugin with id 'maven' not found` build error from Android Gradle 7. ([#16080](https://github.com/expo/expo/pull/16080) by [@kudo](https://github.com/kudo))
+- Fix memory leak on iOS (imgRef was never released) ([#16132](https://github.com/expo/expo/pull/16132) by [@Hirbod](https://github.com/Hirbod) and [@bulgr0z](https://github.com/bulgr0z))
 
 ### 💡 Others
 

--- a/packages/expo-video-thumbnails/ios/EXVideoThumbnails/EXVideoThumbnailsModule.m
+++ b/packages/expo-video-thumbnails/ios/EXVideoThumbnails/EXVideoThumbnailsModule.m
@@ -66,6 +66,8 @@ EX_EXPORT_METHOD_AS(getThumbnail,
   NSURL *fileURL = [NSURL fileURLWithPath:newPath];
   NSString *filePath = [fileURL absoluteString];
 
+  CGImageRelease(imgRef);
+  
   resolve(@{
             @"uri" : filePath,
             @"width" : @(thumbnail.size.width),


### PR DESCRIPTION
Fixes #15927

# Why

imgRef references are never released after use, causing a crash when package is used heavily since everything will be kept in RAM.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Call `CGImageRelease` on `imgRef` to release the reference.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Tested on multiple devices. RAM is not growing anymore.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
