### PR TITLE
[ios][core] Add the base class for expo views

### DIFF
--- a/packages/expo-modules-core/ios/ExpoModulesCore.h
+++ b/packages/expo-modules-core/ios/ExpoModulesCore.h
@@ -1,5 +1,9 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
+// Some headers needs to be imported from Objective-C code too.
+// Otherwise they won't be visible in `ExpoModulesCore-Swift.h`.
+#import <React/RCTView.h>
+
 #if __has_include("ExpoModulesCore-umbrella.h")
 #import "ExpoModulesCore-umbrella.h"
 #endif

--- a/packages/expo-modules-core/ios/Swift/Views/ExpoView.swift
+++ b/packages/expo-modules-core/ios/Swift/Views/ExpoView.swift
@@ -1,0 +1,8 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+import React
+
+/**
+ The view that just extends `RCTView`. In the future we may add more features here.
+ */
+open class ExpoView: RCTView {}


### PR DESCRIPTION
# Why

Expo view managers should return a view that extends `RCTView` rather than `UIView` to handle some styles like borders. As a forward-looking solution, I propose having our own `ExpoView` class that for now just extends `RCTView`. In the future we may want to use it to provide more features/customization.

# How

Added `ExpoView` class that subclasses `RCTView`

# Test Plan

CI passes, I tested it locally with linear gradient view (I'll open separate PR with this)
