### PR TITLE
[docs] Replace deprecated Constants.isDevice in different pages

### DIFF
--- a/docs/pages/push-notifications/overview.md
+++ b/docs/pages/push-notifications/overview.md
@@ -18,7 +18,7 @@ There are three main steps to setting up push notifications, and we provide a gu
 The code below shows a full example of how to register for, send, and receive push notifications in an Expo app. But make sure to read the rest of the guide, so that you understand how Expo's push notification service works, what the best practices are, and how to investigate any problems you run into!
 
 ```js
-import Constants from 'expo-constants';
+import Device from 'expo-device';
 import * as Notifications from 'expo-notifications';
 import React, { useState, useEffect, useRef } from 'react';
 import { Text, View, Button, Platform } from 'react-native';
@@ -102,7 +102,7 @@ async function sendPushNotification(expoPushToken) {
 
 async function registerForPushNotificationsAsync() {
   let token;
-  if (Constants.isDevice) {
+  if (Device.isDevice) {
     const { status: existingStatus } = await Notifications.getPermissionsAsync();
     let finalStatus = existingStatus;
     if (existingStatus !== 'granted') {

--- a/docs/pages/push-notifications/push-notifications-setup.md
+++ b/docs/pages/push-notifications/push-notifications-setup.md
@@ -23,7 +23,7 @@ The following method takes care of all this for you, so feel free to copy/paste 
 ```javascript
 registerForPushNotificationsAsync = async () => {
   /* @info We should also make sure the app is running on a physical device, since push notifications won't work on a simulator. */
-  if (Constants.isDevice) {
+  if (Device.isDevice) {
     /* @end */
     const { status: existingStatus } = await Notifications.getPermissionsAsync();
     let finalStatus = existingStatus;
@@ -64,7 +64,7 @@ registerForPushNotificationsAsync = async () => {
 ```javascript
 registerForPushNotificationsAsync = async () => {
   /* @info We should also make sure the app is running on a physical device, since push notifications won't work on a simulator. */
-  if (Constants.isDevice) {
+  if (Device.isDevice) {
     /* @end */
     const { status: existingStatus } = await Permissions.getAsync(Permissions.NOTIFICATIONS);
     let finalStatus = existingStatus;

--- a/docs/pages/versions/unversioned/sdk/location.md
+++ b/docs/pages/versions/unversioned/sdk/location.md
@@ -51,7 +51,7 @@ If you're using the iOS or Android Emulators, ensure that [Location is enabled](
 import React, { useState, useEffect } from 'react';
 import { Platform, Text, View, StyleSheet } from 'react-native';
 /* @hide */
-import Constants from 'expo-constants';
+import Device from 'expo-device';
 /* @end */
 import * as Location from 'expo-location';
 
@@ -62,7 +62,7 @@ export default function App() {
   useEffect(() => {
     (async () => {
       /* @hide */
-      if (Platform.OS === 'android' && !Constants.isDevice) {
+      if (Platform.OS === 'android' && !Device.isDevice) {
         setErrorMsg(
           'Oops, this will not work on Snack in an Android emulator. Try it on your device!'
         );

--- a/docs/pages/versions/unversioned/sdk/notifications.md
+++ b/docs/pages/versions/unversioned/sdk/notifications.md
@@ -431,7 +431,6 @@ Returns a `Promise` that resolves to an object with the following fields:
 #### Fetching the Expo push token and uploading it to a server
 
 ```ts
-import Device from 'expo-device';
 import * as Notifications from 'expo-notifications';
 
 export async function registerForPushNotificationsAsync(userId: string) {

--- a/docs/pages/versions/unversioned/sdk/notifications.md
+++ b/docs/pages/versions/unversioned/sdk/notifications.md
@@ -174,7 +174,7 @@ Check out the Snack below to see Notifications in action, but be sure to use a p
 <SnackInline label='Push Notifications' dependencies={['expo-constants', 'expo-permissions', 'expo-notifications']}>
 
 ```js
-import Constants from 'expo-constants';
+import Device from 'expo-constants';
 import * as Notifications from 'expo-notifications';
 import React, { useState, useEffect, useRef } from 'react';
 import { Text, View, Button, Platform } from 'react-native';
@@ -246,7 +246,7 @@ async function schedulePushNotification() {
 
 async function registerForPushNotificationsAsync() {
   let token;
-  if (Constants.isDevice) {
+  if (Device.isDevice) {
     const { status: existingStatus } = await Notifications.getPermissionsAsync();
     let finalStatus = existingStatus;
     if (existingStatus !== 'granted') {
@@ -431,7 +431,7 @@ Returns a `Promise` that resolves to an object with the following fields:
 #### Fetching the Expo push token and uploading it to a server
 
 ```ts
-import Constants from 'expo-constants';
+import Device from 'expo-device';
 import * as Notifications from 'expo-notifications';
 
 export async function registerForPushNotificationsAsync(userId: string) {


### PR DESCRIPTION
# Why

`Constants.isDevice` is deprecated.

# How

Used `Device.isDevice` from `expo-device` instead.

# Test Plan

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
