### PR TITLE
[docs] Tweak table for markdown usage

### DIFF
--- a/docs/global-styles/tables.ts
+++ b/docs/global-styles/tables.ts
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import { theme, typography } from '@expo/styleguide';
 
+// TODO(cedric): move these global table styles to ui/components/Table
 export const globalTables = css`
   table {
     margin-bottom: 1rem;

--- a/docs/ui/components/Markdown/index.tsx
+++ b/docs/ui/components/Markdown/index.tsx
@@ -2,7 +2,7 @@ import { css, CSSObject } from '@emotion/react';
 import { typography } from '@expo/styleguide';
 import React, { ComponentType, PropsWithChildren } from 'react';
 
-import { Cell, HeaderCell, Row, Table } from '~/ui/components/Table';
+import { Cell, HeaderCell, Row, Table, TableHead } from '~/ui/components/Table';
 import { A, H1, H2, H4, H5, CODE, P, BOLD, UL, OL, LI } from '~/ui/components/Text';
 
 type Config = ConfigStyles & {
@@ -107,6 +107,9 @@ const markdownStyles: Record<string, Config | null> = {
       margin: '16px 0px 32px 0px',
       borderCollapse: 'collapse',
     },
+  },
+  thead: {
+    Component: TableHead,
   },
   tr: {
     Component: Row,

--- a/docs/ui/components/Table/Cell.tsx
+++ b/docs/ui/components/Table/Cell.tsx
@@ -7,8 +7,12 @@ type CellProps = PropsWithChildren<{
   textAlign?: TextAlign;
 }>;
 
-export const Cell = ({ children, textAlign }: CellProps) => (
-  <td css={css({ borderBottom: 0, verticalAlign: 'middle', wordBreak: 'break-word', textAlign })}>
-    {children}
-  </td>
+export const Cell = ({ children, textAlign = TextAlign.Left }: CellProps) => (
+  <td css={[tableCellStyle, { textAlign }]}>{children}</td>
 );
+
+const tableCellStyle = css({
+  borderBottom: 0,
+  verticalAlign: 'middle',
+  wordBreak: 'break-word',
+});

--- a/docs/ui/components/Table/Table.tsx
+++ b/docs/ui/components/Table/Table.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import { theme, borderRadius } from '@expo/styleguide';
 import React, { PropsWithChildren } from 'react';
 
-import { TableHead } from './TableHead';
+import { TableHeaders } from './TableHeaders';
 import { TextAlign } from './types';
 
 type TableProps = PropsWithChildren<{
@@ -10,12 +10,12 @@ type TableProps = PropsWithChildren<{
   headersAlign?: TextAlign[];
 }>;
 
-export const Table = ({ children, headers = [], headersAlign = [] }: TableProps) => (
+export const Table = ({ children, headers = [], headersAlign }: TableProps) => (
   <div css={tableWrapperStyle}>
     <table css={tableStyle}>
       {headers.length ? (
         <>
-          <TableHead headers={headers} headersAlign={headersAlign} />
+          <TableHeaders headers={headers} headersAlign={headersAlign} />
           <tbody>{children}</tbody>
         </>
       ) : (

--- a/docs/ui/components/Table/TableHead.tsx
+++ b/docs/ui/components/Table/TableHead.tsx
@@ -1,24 +1,13 @@
-import React from 'react';
+import { css } from '@emotion/react';
+import { theme } from '@expo/styleguide';
+import React, { PropsWithChildren } from 'react';
 
-import { HeaderCell } from './HeaderCell';
-import { Row } from './Row';
-import { TextAlign } from './types';
+type TableHeadProps = PropsWithChildren<object>;
 
-type TableHeadProps = {
-  headers: string[];
-  headersAlign?: TextAlign[];
-};
-
-export const TableHead = ({ headers, headersAlign }: TableHeadProps) => (
-  <thead>
-    <Row>
-      {headers.map((header, i) => (
-        <HeaderCell
-          key={`table-header-${i}`}
-          textAlign={(headersAlign && headersAlign[i]) || TextAlign.Left}>
-          {header}
-        </HeaderCell>
-      ))}
-    </Row>
-  </thead>
+export const TableHead = ({ children }: TableHeadProps) => (
+  <thead css={tableHeadStyle}>{children}</thead>
 );
+
+const tableHeadStyle = css({
+  backgroundColor: theme.background.secondary,
+});

--- a/docs/ui/components/Table/TableHeaders.tsx
+++ b/docs/ui/components/Table/TableHeaders.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import { HeaderCell } from './HeaderCell';
+import { Row } from './Row';
+import { TableHead } from './TableHead';
+import { TextAlign } from './types';
+
+type TableHeadersProps = {
+  headers: string[];
+  headersAlign?: TextAlign[];
+};
+
+export const TableHeaders = ({ headers, headersAlign = [] }: TableHeadersProps) => (
+  <TableHead>
+    <Row>
+      {headers.map((header, i) => (
+        <HeaderCell key={`table-header-${i}`} textAlign={headersAlign[i]}>
+          {header}
+        </HeaderCell>
+      ))}
+    </Row>
+  </TableHead>
+);

--- a/docs/ui/components/Table/index.ts
+++ b/docs/ui/components/Table/index.ts
@@ -2,4 +2,5 @@ export { Cell } from './Cell';
 export { HeaderCell } from './HeaderCell';
 export { Row } from './Row';
 export { Table } from './Table';
+export { TableHead } from './TableHead';
 export { TextAlign } from './types';


### PR DESCRIPTION
# Why

When implementing the table in markdown, the `thead` tag is passed as children into the table. We should support styling that too.

# How

- Add separate table head component
- Implement table head component in markdown

# Test Plan

To test if markdown renders this nicely:

- Open **pages/_app.tsx**
- Change markdown import to `import { markdownComponents as newMarkdownComponents } from '~/ui/components/Markdown'`
- Update `const markdownComponents` to include `newMarkdownComponents`
- Open [/introduction/managed-vs-bare](http://localhost:3002/introduction/managed-vs-bare/)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
