### PR TITLE
[document-picker] Handle nil MIME type

### DIFF
--- a/packages/expo-document-picker/CHANGELOG.md
+++ b/packages/expo-document-picker/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Pass iCloudContainerEnvironment to plugin. ([#15774](https://github.com/expo/expo/pull/15774) by [@wkozyra95](https://github.com/wkozyra95))
 - Fix `Plugin with id 'maven' not found` build error from Android Gradle 7. ([#16080](https://github.com/expo/expo/pull/16080) by [@kudo](https://github.com/kudo))
+- Handle nil MIME type. ([#16156](https://github.com/expo/expo/pull/16156) by [@brentvatne](https://github.com/brentvatne))
 
 ### 💡 Others
 

--- a/packages/expo-document-picker/ios/EXDocumentPicker/EXDocumentPickerModule.m
+++ b/packages/expo-document-picker/ios/EXDocumentPicker/EXDocumentPickerModule.m
@@ -186,14 +186,26 @@ EX_EXPORT_METHOD_AS(getDocumentAsync,
     
   NSString *extension = [url pathExtension];
   NSString *mimeType = [EXDocumentPickerModule getMimeType:extension];
+  NSString *name = [url lastPathComponent];
+  NSString *uri = [newUrl absoluteString];
   
-  _resolve(@{
-             @"type": @"success",
-             @"uri": [newUrl absoluteString],
-             @"name": [url lastPathComponent],
-             @"size": @(fileSize),
-             @"mimeType": mimeType
-             });
+  if (mimeType != nil) {
+    _resolve(@{
+               @"type": @"success",
+               @"uri":uri,
+               @"name": name,
+               @"size": @(fileSize),
+               @"mimeType": mimeType
+               });
+  } else {
+    _resolve(@{
+               @"type": @"success",
+               @"uri":uri,
+               @"name": name,
+               @"size": @(fileSize)
+               });
+  }
+
   _resolve = nil;
   _reject = nil;
 }
@@ -245,11 +257,7 @@ EX_EXPORT_METHOD_AS(getDocumentAsync,
 + (NSString *)getMimeType:(NSString *)fileExtension{
   NSString *UTI = (__bridge_transfer NSString *)UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, (__bridge CFStringRef)fileExtension, NULL);
   NSString *mimeType = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)UTI, kUTTagClassMIMEType);
-  if (mimeType != nil) {
-    return mimeType;
-  } else {
-    return @"application/octet-stream";
-  }
+  return mimeType;
 }
 
 @end

--- a/packages/expo-document-picker/ios/EXDocumentPicker/EXDocumentPickerModule.m
+++ b/packages/expo-document-picker/ios/EXDocumentPicker/EXDocumentPickerModule.m
@@ -245,7 +245,11 @@ EX_EXPORT_METHOD_AS(getDocumentAsync,
 + (NSString *)getMimeType:(NSString *)fileExtension{
   NSString *UTI = (__bridge_transfer NSString *)UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, (__bridge CFStringRef)fileExtension, NULL);
   NSString *mimeType = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)UTI, kUTTagClassMIMEType);
-  return mimeType;
+  if (mimeType != nil) {
+    return mimeType;
+  } else {
+    return @"application/octet-stream";
+  }
 }
 
 @end

--- a/packages/expo-document-picker/ios/EXDocumentPicker/EXDocumentPickerModule.m
+++ b/packages/expo-document-picker/ios/EXDocumentPicker/EXDocumentPickerModule.m
@@ -186,25 +186,19 @@ EX_EXPORT_METHOD_AS(getDocumentAsync,
     
   NSString *extension = [url pathExtension];
   NSString *mimeType = [EXDocumentPickerModule getMimeType:extension];
-  NSString *name = [url lastPathComponent];
-  NSString *uri = [newUrl absoluteString];
-  
+
+  NSMutableDictionary *response = [@{
+    @"type": @"success",
+    @"uri": [newUrl absoluteString],
+    @"name": [url lastPathComponent],
+    @"size": @(fileSize)
+  } mutableCopy];
+
   if (mimeType != nil) {
-    _resolve(@{
-               @"type": @"success",
-               @"uri": uri,
-               @"name": name,
-               @"size": @(fileSize),
-               @"mimeType": mimeType
-               });
-  } else {
-    _resolve(@{
-               @"type": @"success",
-               @"uri": uri,
-               @"name": name,
-               @"size": @(fileSize)
-               });
+    response[@"mimeType"] = mimeType;
   }
+
+  _resolve(response);
 
   _resolve = nil;
   _reject = nil;

--- a/packages/expo-document-picker/ios/EXDocumentPicker/EXDocumentPickerModule.m
+++ b/packages/expo-document-picker/ios/EXDocumentPicker/EXDocumentPickerModule.m
@@ -192,7 +192,7 @@ EX_EXPORT_METHOD_AS(getDocumentAsync,
   if (mimeType != nil) {
     _resolve(@{
                @"type": @"success",
-               @"uri":uri,
+               @"uri": uri,
                @"name": name,
                @"size": @(fileSize),
                @"mimeType": mimeType
@@ -200,7 +200,7 @@ EX_EXPORT_METHOD_AS(getDocumentAsync,
   } else {
     _resolve(@{
                @"type": @"success",
-               @"uri":uri,
+               @"uri": uri,
                @"name": name,
                @"size": @(fileSize)
                });


### PR DESCRIPTION
# Why

I believe this fixes #16096

# How

This appears to have been caused by adding the MIME type field for iOS in #13702. `UTTypeCopyPreferredTagWithClass ` can return null, and we don't handle that in our MIME type conversion code.

There are two commits here with possible solutions:
1. Fall back to application/octet-stream if we can't figure out the MIME type.
2. Leave the `mimeType` field out entirely in the response if nil. Types already indicate that this field is optional.

I prefer the second approach but I'm open to either.

# Test Plan

Run the test app from #16096, reproduce by picking a keynote file (for example), then apply this fix manually to node_modules, rebuild, try again. 

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
