### PR TITLE
[expo-dev-launcher] turn off updates auto-setup in debug builds

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix opening published projects on Android.
+
 ### 💡 Others
 
 ## 0.10.3 — 2022-02-01

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix opening published projects on Android.
+- Fix opening published projects on Android. ([#16157](https://github.com/expo/expo/pull/16157) by [@esamelson](https://github.com/esamelson))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/android/src/debug/AndroidManifest.xml
+++ b/packages/expo-dev-launcher/android/src/debug/AndroidManifest.xml
@@ -1,0 +1,7 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  package="expo.modules.devlauncher">
+
+  <application>
+    <meta-data android:name="expo.modules.updates.AUTO_SETUP" android:value="false"/>
+  </application>
+</manifest>


### PR DESCRIPTION
# Why

fixes ENG-4052

# How

The new expo-modules [auto-setup for expo-updates](https://github.com/expo/expo/blob/15994b1d8d4ec996304609902bb8a33c99170f0b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.kt#L39-L65) is erroneously being triggered when using the dev launcher to open published updates, because in this case `useDeveloperSupport` is (correctly) false.

However, when expo-dev-launcher is controlling expo-updates we shouldn't use the auto setup. We can use the provided override to turn off auto setup, in an AndroidManifest specific to `debug` builds.

This makes the behavior equivalent to older projects from before the auto-setup existed -- dev launcher controlled expo-updates in debug builds, and the normal flow for expo-updates would only be triggered in builds where `BuildConfig.DEBUG` was false.

# Test Plan

expo init
expo install expo-dev-client expo-updates
expo prebuild
add this change locally to node_modules
cd android && ./gradlew installDebug

✅ can open published project via launcher screen URL input (`https://staging.exp.host/@thetc/test-project-page`)
✅ can open published project via deep link (`adb shell am start -d "exp+dc-android-83://expo-development-client/?url=https%3A%2F%2Fstaging.exp.host%2F%40thetc%2Ftest-project-page%3Frelease-channel%3Ddefault"`)
✅ can still open local development project just fine

./gradlew assembleRelease

✅ release build runs, loads project
✅ publish update -> restart twice -> update loads (auto setup still works in release builds)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
