### PR TITLE
[camera] Fix null pointer exception when barcode scanner or face detector are not installed

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - Fix `Plugin with id 'maven' not found` build error from Android Gradle 7. ([#16080](https://github.com/expo/expo/pull/16080) by [@kudo](https://github.com/kudo))
+- Fix null pointer exception when barcode scanner or face detector are not installed.
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 🐛 Bug fixes
 
 - Fix `Plugin with id 'maven' not found` build error from Android Gradle 7. ([#16080](https://github.com/expo/expo/pull/16080) by [@kudo](https://github.com/kudo))
-- Fix null pointer exception when barcode scanner or face detector are not installed.
+- Fix null pointer exception when barcode scanner or face detector are not installed. ([#16167](https://github.com/expo/expo/pull/16167) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
@@ -178,8 +178,8 @@ class ExpoCameraView(
    * Additionally supports [codabar, code128, maxicode, rss14, rssexpanded, upc_a, upc_ean]
    */
   private fun initBarCodeScanner() {
-    val barCodeScannerProvider: BarCodeScannerProviderInterface by moduleRegistry()
-    barCodeScanner = barCodeScannerProvider.createBarCodeDetectorWithContext(context)
+    val barCodeScannerProvider: BarCodeScannerProviderInterface? by moduleRegistry()
+    barCodeScanner = barCodeScannerProvider?.createBarCodeDetectorWithContext(context)
   }
 
   fun setShouldScanBarCodes(shouldScanBarCodes: Boolean) {
@@ -210,8 +210,8 @@ class ExpoCameraView(
         isNew = false
         if (!Build.FINGERPRINT.contains("generic")) {
           start()
-          val faceDetectorProvider: FaceDetectorProviderInterface by moduleRegistry()
-          faceDetector = faceDetectorProvider.createFaceDetectorWithContext(context)
+          val faceDetectorProvider: FaceDetectorProviderInterface? by moduleRegistry()
+          faceDetector = faceDetectorProvider?.createFaceDetectorWithContext(context)
           pendingFaceDetectorSettings.let {
             faceDetector?.setSettings(it)
             pendingFaceDetectorSettings = null


### PR DESCRIPTION
# Why

Fixes #15547
Fixes #15768

# How

It turned out that we introduced a regression when migrating the code from Java to Kotlin. The barcode scanner and face detector providers should be optional when requesting them from the module registry.

# Test Plan

Tested against provided reproducible demo
