### PR TITLE
[ios][android][expo-updates] Change asset hash verification encoding to base64url

### DIFF
--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/entity/AssetEntity.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/entity/AssetEntity.kt
@@ -26,11 +26,17 @@ class AssetEntity(@field:ColumnInfo(name = "key") var key: String?, var type: St
   @ColumnInfo(name = "relative_path")
   var relativePath: String? = null
 
+  /**
+   * Hex-encoded SHA-256
+   */
   var hash: ByteArray? = null
 
   @ColumnInfo(name = "hash_type")
   var hashType = HashType.SHA256
 
+  /**
+   * Base64URL-encoded SHA-256
+   */
   @ColumnInfo(name = "expected_hash")
   var expectedHash: String? = null
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
@@ -14,7 +14,6 @@ import expo.modules.updates.manifest.ManifestHeaderData
 import expo.modules.updates.manifest.UpdateManifest
 import expo.modules.updates.selectionpolicy.SelectionPolicies
 import okhttp3.*
-import org.apache.commons.codec.binary.Hex
 import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
@@ -25,6 +24,7 @@ import kotlin.math.min
 import org.apache.commons.fileupload.MultipartStream
 import org.apache.commons.fileupload.ParameterParser
 import java.io.ByteArrayOutputStream
+import android.util.Base64
 
 open class FileDownloader(private val client: OkHttpClient) {
   constructor(context: Context) : this(OkHttpClient.Builder().cache(getCache(context)).build())
@@ -316,10 +316,11 @@ open class FileDownloader(private val client: OkHttpClient) {
             }
 
             override fun onSuccess(file: File, hash: ByteArray) {
-              val hashHexString = String(Hex.encodeHex(hash)).toLowerCase(Locale.ROOT)
+              // base64url - https://datatracker.ietf.org/doc/html/rfc4648#section-5
+              val hashBase64String = Base64.encodeToString(hash, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP)
               val expectedAssetHash = asset.expectedHash?.toLowerCase(Locale.ROOT)
-              if (expectedAssetHash != null && expectedAssetHash != hashHexString) {
-                callback.onFailure(Exception("Asset hash invalid: ${asset.key}; expectedHash: $expectedAssetHash; actualHash: $hashHexString"), asset)
+              if (expectedAssetHash != null && expectedAssetHash != hashBase64String) {
+                callback.onFailure(Exception("Asset hash invalid: ${asset.key}; expectedHash: $expectedAssetHash; actualHash: $hashBase64String"), asset)
                 return
               }
 

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesAppLauncherWithDatabase.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesAppLauncherWithDatabase.m
@@ -294,11 +294,11 @@ static NSString * const EXUpdatesAppLauncherErrorDomain = @"AppLauncher";
                             extraHeaders:asset.extraRequestHeaders ?: @{}
                             successBlock:^(NSData *data, NSURLResponse *response) {
       dispatch_async(self->_launcherQueue, ^{
-        NSString *hashHexString = [EXUpdatesUtils sha256WithData:data];
-        if (asset.expectedHash && ![asset.expectedHash.lowercaseString isEqualToString:hashHexString.lowercaseString]) {
+        NSString *hashBase64String = [EXUpdatesUtils base64UrlEncodedSHA256WithData:data];
+        if (asset.expectedHash && ![asset.expectedHash.lowercaseString isEqualToString:hashBase64String.lowercaseString]) {
           completion([NSError errorWithDomain:EXUpdatesAppLauncherErrorDomain
                                          code:1016
-                                     userInfo:@{NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Asset hash invalid: %@; expectedHash: %@; actualHash: %@", asset.key, asset.expectedHash.lowercaseString, hashHexString.lowercaseString]}],
+                                     userInfo:@{NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Asset hash invalid: %@; expectedHash: %@; actualHash: %@", asset.key, asset.expectedHash.lowercaseString, hashBase64String.lowercaseString]}],
                      asset,
                      assetLocalUrl);
           return;
@@ -307,7 +307,7 @@ static NSString * const EXUpdatesAppLauncherErrorDomain = @"AppLauncher";
         if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
           asset.headers = ((NSHTTPURLResponse *)response).allHeaderFields;
         }
-        asset.contentHash = hashHexString;
+        asset.contentHash = hashBase64String;
         asset.downloadTime = [NSDate date];
         completion(nil, asset, assetLocalUrl);
       });

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoader.m
@@ -237,7 +237,7 @@ static NSString * const EXUpdatesAppLoaderErrorDomain = @"EXUpdatesAppLoader";
   if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
     asset.headers = ((NSHTTPURLResponse *)response).allHeaderFields;
   }
-  asset.contentHash = [EXUpdatesUtils sha256WithData:data];
+  asset.contentHash = [EXUpdatesUtils hexEncodedSHA256WithData:data];
   asset.downloadTime = [NSDate date];
   [self->_finishedAssets addObject:asset];
   [self _notifyProgressWithAsset:asset];
@@ -290,7 +290,7 @@ static NSString * const EXUpdatesAppLoaderErrorDomain = @"EXUpdatesAppLoader";
         // do our best to create a new entry for this file even though it already existed on disk
         // TODO: we should probably get rid of this assumption that if an asset exists on disk with the same filename, it's the same asset
         NSData *contents = [NSData dataWithContentsOfURL:[self->_directory URLByAppendingPathComponent:existingAsset.filename]];
-        existingAsset.contentHash = [EXUpdatesUtils sha256WithData:contents];
+        existingAsset.contentHash = [EXUpdatesUtils hexEncodedSHA256WithData:contents];
         existingAsset.downloadTime = [NSDate date];
         [self->_finishedAssets addObject:existingAsset];
       }

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAsset.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAsset.h
@@ -17,14 +17,14 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nullable, nonatomic, strong) NSString *mainBundleFilename; // used for embedded assets
 @property (nonatomic, assign) BOOL isLaunchAsset;
 @property (nullable, nonatomic, strong) NSDictionary *extraRequestHeaders;
-@property (nullable, nonatomic, strong) NSString *expectedHash;
+@property (nullable, nonatomic, strong) NSString *expectedHash; // base64url-encoded sha-256
 
 /**
  * properties determined at runtime by updates implementation
  */
 @property (nullable, nonatomic, strong) NSDate *downloadTime;
 @property (nullable, nonatomic, strong) NSString *filename;
-@property (nullable, nonatomic, strong) NSString *contentHash;
+@property (nullable, nonatomic, strong) NSString *contentHash; // hex-encoded sha-256
 @property (nullable, nonatomic, strong) NSDictionary *headers;
 
 /**

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesUtils.h
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesUtils.h
@@ -10,7 +10,8 @@ NS_ASSUME_NONNULL_BEGIN
 @interface EXUpdatesUtils : NSObject
 
 + (void)runBlockOnMainThread:(void (^)(void))block;
-+ (NSString *)sha256WithData:(NSData *)data;
++ (NSString *)hexEncodedSHA256WithData:(NSData *)data;
++ (NSString *)base64UrlEncodedSHA256WithData:(NSData *)data;
 + (nullable NSURL *)initializeUpdatesDirectoryWithError:(NSError ** _Nullable)error;
 + (void)sendEventToBridge:(nullable RCTBridge *)bridge withType:(NSString *)eventType body:(NSDictionary *)body;
 + (BOOL)shouldCheckForUpdateWithConfig:(EXUpdatesConfig *)config;

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesUtils.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesUtils.m
@@ -22,7 +22,7 @@ static NSString * const EXUpdatesUtilsErrorDomain = @"EXUpdatesUtils";
   }
 }
 
-+ (NSString *)sha256WithData:(NSData *)data
++ (NSString *)hexEncodedSHA256WithData:(NSData *)data
 {
   uint8_t digest[CC_SHA256_DIGEST_LENGTH];
   CC_SHA256(data.bytes, (CC_LONG)data.length, digest);
@@ -34,6 +34,19 @@ static NSString * const EXUpdatesUtilsErrorDomain = @"EXUpdatesUtils";
   }
 
   return output;
+}
+
++ (NSString *)base64UrlEncodedSHA256WithData:(NSData *)data
+{
+  uint8_t digest[CC_SHA256_DIGEST_LENGTH];
+  CC_SHA256(data.bytes, (CC_LONG)data.length, digest);
+  NSString *base64String = [[NSData dataWithBytes:digest length:CC_SHA256_DIGEST_LENGTH] base64EncodedStringWithOptions:0];
+  
+  // ref. https://datatracker.ietf.org/doc/html/rfc4648#section-5
+  return [[[base64String
+            stringByTrimmingCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@"="]] // remove extra padding
+           stringByReplacingOccurrencesOfString:@"+" withString:@"-"] // replace "+" character w/ "-"
+          stringByReplacingOccurrencesOfString:@"/" withString:@"_"]; // replace "/" character w/ "_"
 }
 
 + (nullable NSURL *)initializeUpdatesDirectoryWithError:(NSError ** _Nullable)error


### PR DESCRIPTION
# Why

Makes the change made to the spec in https://github.com/expo/expo/pull/16170.

# How

Update check.

# Test Plan

Load Expo Go on both ios and android, and load a new asset (published new manifest).