### PR TITLE
feat: add customizable margin for splash screen android

### DIFF
--- a/packages/expo-splash-screen/CHANGELOG.md
+++ b/packages/expo-splash-screen/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### 🛠 Breaking changes
 
 ### 🎉 New features
+- add customizable margin for splash screen android ([#16182](https://github.com/expo/expo/pull/16182) by [@nomi9995](https://github.com/nomi9995))
+
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-splash-screen/README.md
+++ b/packages/expo-splash-screen/README.md
@@ -513,6 +513,7 @@ The easiest way to configure the splash screen in bare React Native projects is 
 6. [(<em>optional</em>) Customzine `resizeMode`](#-optional-customize-resizemode)
 7. [(<em>optional</em>) Enable dark mode](#-optional-enable-dark-mode-1)
 8. [(<em>optional</em>) Customize StatusBar](#-customize-statusbar-1)
+8. [(<em>optional</em>) Customize Margin](#-customize-margin)
 
 #### 🛠 Configure `res/drawable/splashscreen_image.png`
 
@@ -731,6 +732,22 @@ To make the StatusBar translucent update your `res/values/strings.xml` file with
 </resources>
 ```
 
+#### 🛠 (<em>optional</em>) Customize Margin
+
+The default margin of `splashscreen_image.png` is `top=0`,`left=0`,`right=0` and `bottom=0`. If you want to have different margin, you need to override in `res/values/strings.xml`.
+
+```diff
+--- a/android/app/src/main/res/values/strings.xml
++++ b/android/app/src/main/res/values/strings.xml
+ <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+ <resources>
+   <string name="app_name">sdk42</string>
++  <integer name="expo_splash_screen_top">0</integer>
++  <integer name="expo_splash_screen_left">0</integer>
++  <integer name="expo_splash_screen_right">0</integer>
++  <integer name="expo_splash_screen_bottom">0</integer>
+</resources>
+```
 ## 👏 Contributing
 
 Contributions are very welcome! Please refer to guidelines described in the [contributing guide](https://github.com/expo/expo#contributing).

--- a/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/NativeResourcesBasedSplashScreenViewProvider.kt
+++ b/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/NativeResourcesBasedSplashScreenViewProvider.kt
@@ -1,6 +1,7 @@
 package expo.modules.splashscreen
 
 import android.content.Context
+import android.widget.RelativeLayout
 import androidx.core.content.ContextCompat
 
 // this needs to stay for versioning to work
@@ -23,6 +24,12 @@ class NativeResourcesBasedSplashScreenViewProvider(
 
     splashScreenView.imageView.setImageResource(getImageResource())
     splashScreenView.configureImageViewResizeMode(resizeMode)
+    splashScreenView.also { view -> view.layoutParams= RelativeLayout.LayoutParams(
+      RelativeLayout.LayoutParams.MATCH_PARENT,
+      RelativeLayout.LayoutParams.MATCH_PARENT,
+    ).apply {
+      setMargins(context.resources.getInteger(R.integer.expo_splash_screen_left),context.resources.getInteger(R.integer.expo_splash_screen_top), context.resources.getInteger(R.integer.expo_splash_screen_right), context.resources.getInteger(R.integer.expo_splash_screen_bottom))
+    } }
 
     return splashScreenView
   }

--- a/packages/expo-splash-screen/android/src/main/res/values/strings.xml
+++ b/packages/expo-splash-screen/android/src/main/res/values/strings.xml
@@ -2,4 +2,8 @@
 <resources>
   <string name="expo_splash_screen_resize_mode" translatable="false">contain</string>
   <string name="expo_splash_screen_status_bar_translucent" translatable="false">false</string>
+  <integer name="expo_splash_screen_top">0</integer>
+  <integer name="expo_splash_screen_left">0</integer>
+  <integer name="expo_splash_screen_right">0</integer>
+  <integer name="expo_splash_screen_bottom">0</integer>
 </resources>


### PR DESCRIPTION
# Why
I needed to give some margin of my `splashscreen_image.png` so that I added this as optional
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How
by adding `integer` in `res/values/strings.xml` and accessing these integer `.kt` files and applying margin

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
you can test margin by adding these integers into `res/values/strings.xml` 

```
<integer name="expo_splash_screen_top">0</integer>
<integer name="expo_splash_screen_left">0</integer>
<integer name="expo_splash_screen_right">0</integer>
<integer name="expo_splash_screen_bottom">0</integer>
```

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
