### PR TITLE
[docs] Add redesigned collapsible component

### DIFF
--- a/docs/ui/components/Collapsible/Collapsible.test.tsx
+++ b/docs/ui/components/Collapsible/Collapsible.test.tsx
@@ -1,0 +1,56 @@
+import { fireEvent, render } from '@testing-library/react';
+
+import { Collapsible, DETAILS, SUMMARY } from '.';
+
+import { P } from '~/ui/components/Text';
+
+describe(Collapsible, () => {
+  it('hides content by default', () => {
+    const { getByText } = render(<Collapsible summary="Summary">Content</Collapsible>);
+    expect(getByText('Summary')).toBeVisible();
+    expect(getByText('Content')).not.toBeVisible();
+  });
+
+  it('shows content when opened', () => {
+    const { getByText } = render(<Collapsible summary="Summary">Content</Collapsible>);
+    fireEvent.click(getByText('Summary'));
+    expect(getByText('Summary')).toBeVisible();
+    expect(getByText('Content')).toBeVisible();
+  });
+
+  it('shows content when rendered with open', () => {
+    const { getByText } = render(
+      <Collapsible summary="Summary" open>
+        Content
+      </Collapsible>
+    );
+    expect(getByText('Summary')).toBeVisible();
+    expect(getByText('Content')).toBeVisible();
+  });
+});
+
+// TODO(cedric): remove everything below this line once we switch to MDX v2
+describe(DETAILS, () => {
+  it('renders without summary', () => {
+    const { getByText } = render(
+      <DETAILS>
+        <P>Content</P>
+      </DETAILS>
+    );
+    expect(getByText('Content')).toBeInTheDocument();
+  });
+
+  it('renders with hidden and separated content', () => {
+    const { getByTestId } = render(
+      <DETAILS testID="parent">
+        {/* @ts-ignore - We have to fake MDX v1's original type prop here, thats what we use to find it */}
+        <SUMMARY testID="summary" originalType="summary">
+          Summary
+        </SUMMARY>
+        <P testID="content">Content</P>
+      </DETAILS>
+    );
+    expect(getByTestId('summary').parentNode).toBe(getByTestId('parent'));
+    expect(getByTestId('content').parentNode).not.toBe(getByTestId('parent'));
+  });
+});

--- a/docs/ui/components/Collapsible/index.tsx
+++ b/docs/ui/components/Collapsible/index.tsx
@@ -6,18 +6,20 @@ import { HEADLINE } from '~/ui/components/Text';
 import { durations } from '~/ui/foundations/durations';
 import { ChevronDownIcon } from '~/ui/foundations/icons';
 
-type CollapsibleProps = PropsWithChildren<
-  Pick<HTMLDetailsElement, 'open'> & {
-    title: ReactNode;
-  }
->;
+type CollapsibleProps = PropsWithChildren<{
+  /** The content of the collapsible summary */
+  summary: ReactNode;
+  /** If the collapsible should be rendered "open" by default */
+  open?: boolean;
+  testID?: string;
+}>;
 
-export function Collapsible({ title, children, ...rest }: CollapsibleProps) {
+export function Collapsible({ summary, open, testID, children }: CollapsibleProps) {
   return (
-    <details css={detailsStyle} {...rest}>
+    <details css={detailsStyle} open={open} data-testid={testID}>
       <summary css={summaryStyle}>
         <ChevronDownIcon css={markerStyle} size={iconSize.small} />
-        <HEADLINE tag="span">{title}</HEADLINE>
+        <HEADLINE tag="span">{summary}</HEADLINE>
       </summary>
       <div css={contentStyle}>{children}</div>
     </details>
@@ -66,14 +68,14 @@ const contentStyle = css({
 
 // TODO(cedric): remove everything below this line once we switch to MDX v2,
 // that won't support separate <details> and <summary> tags.
-
 // To implement this collapsible with MDX v1, without changing the pages, we need to add them separately to markdown.
 
 /** @deprecated please use `<Collapsible>` instead of `<DETAILS>` */
 export const DETAILS = ({
+  testID,
   children,
   ...rest
-}: PropsWithChildren<Pick<HTMLDetailsElement, 'open'>>) => {
+}: PropsWithChildren<Omit<CollapsibleProps, 'summary'>>) => {
   // Pull out the `<summary>` to style the content differently.
   const childrenList = React.Children.toArray(children);
   const summary = childrenList.find(node => nodeIsTag(node, 'summary'));
@@ -82,16 +84,16 @@ export const DETAILS = ({
   }
 
   return (
-    <details css={detailsStyle} {...rest}>
+    <details css={detailsStyle} data-testid={testID} {...rest}>
       {summary}
       <div css={contentStyle}>{childrenList}</div>
     </details>
   );
 };
 
-/** @deprecated please use `<Collapsible>` instead of `<summary>` */
-export const SUMMARY = ({ children }: PropsWithChildren<object>) => (
-  <summary css={summaryStyle}>
+/** @deprecated please use `<Collapsible>` instead of `<SUMMARY>` */
+export const SUMMARY = ({ testID, children }: PropsWithChildren<{ testID?: string }>) => (
+  <summary css={summaryStyle} data-testid={testID}>
     <ChevronDownIcon css={markerStyle} size={iconSize.small} />
     <HEADLINE tag="span">{children}</HEADLINE>
   </summary>

--- a/docs/ui/components/Collapsible/index.tsx
+++ b/docs/ui/components/Collapsible/index.tsx
@@ -45,13 +45,15 @@ const summaryStyle = css({
   userSelect: 'none',
   backgroundColor: theme.background.secondary,
   padding: spacing[1.5],
+  paddingRight: spacing[3],
   margin: 0,
 
   '&::marker': { content: '""' },
 });
 
 const markerStyle = css({
-  margin: `0 ${spacing[1.5]}px`,
+  flexShrink: 0,
+  marginRight: spacing[1.5],
   transform: 'rotate(-90deg)',
   transition: `transform ${durations.hover}`,
 

--- a/docs/ui/components/Collapsible/index.tsx
+++ b/docs/ui/components/Collapsible/index.tsx
@@ -45,12 +45,11 @@ const summaryStyle = css({
   flexDirection: 'row',
   alignItems: 'center',
   userSelect: 'none',
+  listStyle: 'none',
   backgroundColor: theme.background.secondary,
   padding: spacing[1.5],
   paddingRight: spacing[3],
   margin: 0,
-
-  '&::marker': { content: '""' },
 });
 
 // TODO(cedric): remove this when we removed all `h4` tags in the MDX files

--- a/docs/ui/components/Collapsible/index.tsx
+++ b/docs/ui/components/Collapsible/index.tsx
@@ -4,7 +4,7 @@ import React, { PropsWithChildren, ReactNode } from 'react';
 
 import { HEADLINE } from '~/ui/components/Text';
 import { durations } from '~/ui/foundations/durations';
-import { ChevronDownIcon } from '~/ui/foundations/icons';
+import { TriangleDownIcon } from '~/ui/foundations/icons';
 
 type CollapsibleProps = PropsWithChildren<{
   /** The content of the collapsible summary */
@@ -18,7 +18,7 @@ export function Collapsible({ summary, open, testID, children }: CollapsibleProp
   return (
     <details css={detailsStyle} open={open} data-testid={testID}>
       <summary css={summaryStyle}>
-        <ChevronDownIcon css={markerStyle} size={iconSize.small} />
+        <TriangleDownIcon css={markerStyle} size={iconSize.small} />
         <HEADLINE tag="span" css={headlineStyle}>
           {summary}
         </HEADLINE>
@@ -106,7 +106,7 @@ export const DETAILS = ({
 /** @deprecated please use `<Collapsible>` instead of `<SUMMARY>` */
 export const SUMMARY = ({ testID, children }: PropsWithChildren<{ testID?: string }>) => (
   <summary css={summaryStyle} data-testid={testID}>
-    <ChevronDownIcon css={markerStyle} size={iconSize.small} />
+    <TriangleDownIcon css={markerStyle} size={iconSize.small} />
     <HEADLINE tag="span" css={headlineStyle}>
       {children}
     </HEADLINE>

--- a/docs/ui/components/Collapsible/index.tsx
+++ b/docs/ui/components/Collapsible/index.tsx
@@ -1,0 +1,102 @@
+import { css } from '@emotion/react';
+import { borderRadius, iconSize, shadows, spacing, theme } from '@expo/styleguide';
+import React, { PropsWithChildren, ReactNode } from 'react';
+
+import { HEADLINE } from '~/ui/components/Text';
+import { durations } from '~/ui/foundations/durations';
+import { ChevronDownIcon } from '~/ui/foundations/icons';
+
+type CollapsibleProps = PropsWithChildren<
+  Pick<HTMLDetailsElement, 'open'> & {
+    title: ReactNode;
+  }
+>;
+
+export function Collapsible({ title, children, ...rest }: CollapsibleProps) {
+  return (
+    <details css={detailsStyle} {...rest}>
+      <summary css={summaryStyle}>
+        <ChevronDownIcon css={markerStyle} size={iconSize.small} />
+        <HEADLINE tag="span">{title}</HEADLINE>
+      </summary>
+      <div css={contentStyle}>{children}</div>
+    </details>
+  );
+}
+
+const detailsStyle = css({
+  overflow: 'hidden',
+  background: theme.background.default,
+  border: `1px solid ${theme.border.default}`,
+  borderRadius: borderRadius.medium,
+  padding: 0,
+
+  '&[open]': {
+    boxShadow: shadows.tiny,
+  },
+});
+
+const summaryStyle = css({
+  display: 'flex',
+  flexDirection: 'row',
+  alignItems: 'center',
+  userSelect: 'none',
+  backgroundColor: theme.background.secondary,
+  padding: spacing[1.5],
+  margin: 0,
+
+  '&::marker': { content: '""' },
+});
+
+const markerStyle = css({
+  margin: `0 ${spacing[1.5]}px`,
+  transform: 'rotate(-90deg)',
+  transition: `transform ${durations.hover}`,
+
+  'details[open] &': { transform: 'rotate(0)' },
+});
+
+const contentStyle = css({
+  padding: `${spacing[2]}px ${spacing[4]}px 0`,
+
+  p: {
+    marginLeft: 0,
+  },
+});
+
+// TODO(cedric): remove everything below this line once we switch to MDX v2,
+// that won't support separate <details> and <summary> tags.
+
+// To implement this collapsible with MDX v1, without changing the pages, we need to add them separately to markdown.
+
+/** @deprecated please use `<Collapsible>` instead of `<DETAILS>` */
+export const DETAILS = ({
+  children,
+  ...rest
+}: PropsWithChildren<Pick<HTMLDetailsElement, 'open'>>) => {
+  // Pull out the `<summary>` to style the content differently.
+  const childrenList = React.Children.toArray(children);
+  const summary = childrenList.find(node => nodeIsTag(node, 'summary'));
+  if (summary) {
+    childrenList.splice(childrenList.indexOf(summary), 1);
+  }
+
+  return (
+    <details css={detailsStyle} {...rest}>
+      {summary}
+      <div css={contentStyle}>{childrenList}</div>
+    </details>
+  );
+};
+
+/** @deprecated please use `<Collapsible>` instead of `<summary>` */
+export const SUMMARY = ({ children }: PropsWithChildren<object>) => (
+  <summary css={summaryStyle}>
+    <ChevronDownIcon css={markerStyle} size={iconSize.small} />
+    <HEADLINE tag="span">{children}</HEADLINE>
+  </summary>
+);
+
+function nodeIsTag(node: ReactNode, tag: string) {
+  return typeof node === 'object' ? (node as any).props?.originalType === tag : false;
+}

--- a/docs/ui/components/Collapsible/index.tsx
+++ b/docs/ui/components/Collapsible/index.tsx
@@ -19,7 +19,9 @@ export function Collapsible({ summary, open, testID, children }: CollapsibleProp
     <details css={detailsStyle} open={open} data-testid={testID}>
       <summary css={summaryStyle}>
         <ChevronDownIcon css={markerStyle} size={iconSize.small} />
-        <HEADLINE tag="span">{summary}</HEADLINE>
+        <HEADLINE tag="span" css={headlineStyle}>
+          {summary}
+        </HEADLINE>
       </summary>
       <div css={contentStyle}>{children}</div>
     </details>
@@ -49,6 +51,15 @@ const summaryStyle = css({
   margin: 0,
 
   '&::marker': { content: '""' },
+});
+
+// TODO(cedric): remove this when we removed all `h4` tags in the MDX files
+const headlineStyle = css({
+  h4: {
+    display: 'inline',
+    margin: '0 !important',
+    padding: '0 !important',
+  },
 });
 
 const markerStyle = css({
@@ -97,7 +108,9 @@ export const DETAILS = ({
 export const SUMMARY = ({ testID, children }: PropsWithChildren<{ testID?: string }>) => (
   <summary css={summaryStyle} data-testid={testID}>
     <ChevronDownIcon css={markerStyle} size={iconSize.small} />
-    <HEADLINE tag="span">{children}</HEADLINE>
+    <HEADLINE tag="span" css={headlineStyle}>
+      {children}
+    </HEADLINE>
   </summary>
 );
 

--- a/docs/ui/components/Collapsible/index.tsx
+++ b/docs/ui/components/Collapsible/index.tsx
@@ -3,7 +3,6 @@ import { borderRadius, iconSize, shadows, spacing, theme } from '@expo/styleguid
 import React, { PropsWithChildren, ReactNode } from 'react';
 
 import { HEADLINE } from '~/ui/components/Text';
-import { durations } from '~/ui/foundations/durations';
 import { TriangleDownIcon } from '~/ui/foundations/icons';
 
 type CollapsibleProps = PropsWithChildren<{
@@ -65,7 +64,7 @@ const markerStyle = css({
   flexShrink: 0,
   marginRight: spacing[1.5],
   transform: 'rotate(-90deg)',
-  transition: `transform ${durations.hover}`,
+  transition: `transform 200ms`,
 
   'details[open] &': { transform: 'rotate(0)' },
 });

--- a/docs/ui/components/Collapsible/index.tsx
+++ b/docs/ui/components/Collapsible/index.tsx
@@ -36,7 +36,7 @@ const detailsStyle = css({
   padding: 0,
 
   '&[open]': {
-    boxShadow: shadows.tiny,
+    boxShadow: shadows.micro,
   },
 });
 

--- a/docs/ui/components/Markdown/Blockquote.test.tsx
+++ b/docs/ui/components/Markdown/Blockquote.test.tsx
@@ -4,7 +4,7 @@ import { Blockquote } from './Blockquote';
 
 import { P } from '~/ui/components/Text';
 
-describe('Blockquote', () => {
+describe(Blockquote, () => {
   it('renders with default info icon', () => {
     const { getByTitle } = render(<Blockquote>Hello</Blockquote>);
     expect(getByTitle('Info-icon')).toBeInTheDocument();

--- a/docs/ui/components/Markdown/index.tsx
+++ b/docs/ui/components/Markdown/index.tsx
@@ -4,6 +4,7 @@ import React, { ComponentType, PropsWithChildren } from 'react';
 
 import { Blockquote } from './Blockquote';
 
+import { DETAILS, SUMMARY } from '~/ui/components/Collapsible';
 import { Cell, HeaderCell, Row, Table, TableHead } from '~/ui/components/Table';
 import { A, H1, H2, H4, H5, CODE, P, BOLD, UL, OL, LI } from '~/ui/components/Text';
 
@@ -92,15 +93,13 @@ const markdownStyles: Record<string, Config | null> = {
     css: typography.utility.anchor,
   },
   details: {
-    Component: 'details',
-    css: typography.body.paragraph,
-  },
-  summary: {
-    Component: 'summary',
-    css: typography.body.paragraph,
+    Component: DETAILS,
     style: {
       marginBottom: 16,
     },
+  },
+  summary: {
+    Component: SUMMARY,
   },
   table: {
     Component: Table,

--- a/docs/ui/components/Markdown/index.tsx
+++ b/docs/ui/components/Markdown/index.tsx
@@ -76,6 +76,9 @@ const markdownStyles: Record<string, Config | null> = {
   },
   blockquote: {
     Component: Blockquote,
+    style: {
+      marginBottom: paragraphMarginBottom,
+    },
   },
   img: {
     Component: 'img',

--- a/docs/ui/foundations/icons.tsx
+++ b/docs/ui/foundations/icons.tsx
@@ -22,6 +22,7 @@ export {
   GithubIcon,
   InfoIcon,
   SparklesIcon,
+  TriangleDownIcon,
   TwitterIcon,
   WarningIcon,
 } from '@expo/styleguide';


### PR DESCRIPTION
# Why

Part of [ENG-3962](https://linear.app/expo/issue/ENG-3962/add-new-components-as-separate-prs-in-expoexpo)

This adds a collapsible component, including separate components for MDX v1 usage.

## Example

state | light | dark
--- | --- | ---
closed | ![image](https://user-images.githubusercontent.com/1203991/152433433-443927bf-a273-4a5f-9f31-b811251eb554.png) | ![image](https://user-images.githubusercontent.com/1203991/152433297-b270d7c0-95e9-42ff-aaf8-45e73e76afbc.png)
open | ![image](https://user-images.githubusercontent.com/1203991/152433401-b6c0f77a-de7c-4a1e-9633-72937b39299a.png) | ![image](https://user-images.githubusercontent.com/1203991/152433340-6c3ac3b9-1a2f-4e9f-97fa-f82e69730fc4.png)
hover | ![image](https://user-images.githubusercontent.com/1203991/152433497-079c40e0-1089-48a0-a6c8-07165fa71a82.png) | ![image](https://user-images.githubusercontent.com/1203991/152433534-7a7121f0-6427-4c34-9ed5-43f5ff9e25e0.png)

## Why create `DETAILS` and `SUMMARY` components?

For the eventual migration towards MDX v2, we can't use the collapsible implementation as we currently use it. It violates the [interleaving rules](https://mdxjs.com/docs/what-is-mdx/#interleaving) because of the `<p>` and `<summary>` locations. That's why I created a general-purpose `<Collapsible summary={...}>...</Collapsible>` component. This should work pretty nicely in MDX v2, including nested MDX/JSX inside the `summary` prop. e.g.

```mdx
// This is invalid in MDX v2
<details><summary>This is the summary</summary><p>

Content

</p>
</details>

// Valid in MDX v2
<Collapsible summary="This is the summary">
  Content
</Collapsible>

// In MDX v2 we can use most of JSX, e.g.
<Collapsible summary={<CAPTION>Some special summary</CAPTION>}>
```

To make the transition less intensive, I added these MDX v1 components. These are applied automatically with the current setup, without having to change too much. It does require us removing nested `<h4>` elements from the `<summary>` elements though.

## Pages currently using `<h4>` inside `<summary>`

- [ ] **bare/installing-unimodules.md**
- [ ] **bare/installing-updates.md**
- [ ] **build/internal-distribution.md**
- [ ] **build/setup.md**
- [ ] **build-reference/limitations.md**
- [ ] **build-reference/troubleshooting.md**
- [ ] **get-started/create-a-new-app.md**
- [ ] **guides/configuring-statusbar.md**
- [ ] **guides/linking.md**
- [ ] **guides/using-hermes.md**
- [ ] **guides/using-sentry.md**
- [ ] **introduction/faq.md**
- [ ] **introduction/why-not-expo.md**
- [ ] **push-notifications/faq.md**
- [ ] **submit/ios.md**
- [ ] **tutorial/configuration.md**
- [ ] **tutorial/image-picker.md**
- [ ] **tutorial/sharing.md**
- [ ] **ui-programming/z-index.md**

# How

- Created collapsible component based on `details` and `summary`
- Added temporary `DETAILS` and `SUMMARY` components for MDX v1 with the same styling

# Test Plan

Actually using this in production will be a huge switch. We often embed `<h4>` elements inside the summary, which we should not do anymore (I think? @jonsamp).

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
