### PR TITLE
[docs] Partially add redesigned sidebar navigation

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -95,6 +95,7 @@
     "semver": "^7.3.5",
     "sitemap": "^6.3.0",
     "typescript": "^4.5.4",
-    "unist-builder": "^2.0.0"
+    "unist-builder": "^2.0.0",
+    "unist-util-visit": "^2.0.3"
   }
 }

--- a/docs/ui/components/Navigation/GroupList.tsx
+++ b/docs/ui/components/Navigation/GroupList.tsx
@@ -1,0 +1,30 @@
+import { css } from '@emotion/react';
+import { spacing, theme, typography } from '@expo/styleguide';
+import React, { PropsWithChildren } from 'react';
+
+import { NavigationRenderProps } from '.';
+
+import { CALLOUT } from '~/ui/components/Text';
+
+type GroupListProps = PropsWithChildren<NavigationRenderProps>;
+
+export function GroupList({ route, children }: GroupListProps) {
+  if (route.type !== 'group') {
+    throw new Error(`Navigation node is not a group`);
+  }
+
+  return (
+    <>
+      <CALLOUT css={textStyle}>{route.name}</CALLOUT>
+      {children}
+    </>
+  );
+}
+
+const textStyle = css({
+  ...typography.utility.weight.medium,
+  borderBottom: `1px solid ${theme.border.default}`,
+  padding: spacing[1],
+  marginLeft: spacing[4],
+  marginBottom: spacing[2],
+});

--- a/docs/ui/components/Navigation/GroupList.tsx
+++ b/docs/ui/components/Navigation/GroupList.tsx
@@ -25,6 +25,7 @@ const textStyle = css({
   ...typography.utility.weight.medium,
   borderBottom: `1px solid ${theme.border.default}`,
   padding: spacing[1],
+  paddingLeft: spacing[4] + spacing[1.5], // padding + icon width
   marginLeft: spacing[4],
   marginBottom: spacing[2],
 });

--- a/docs/ui/components/Navigation/GroupList.tsx
+++ b/docs/ui/components/Navigation/GroupList.tsx
@@ -10,7 +10,7 @@ type GroupListProps = PropsWithChildren<NavigationRenderProps>;
 
 export function GroupList({ route, children }: GroupListProps) {
   if (route.type !== 'group') {
-    throw new Error(`Navigation node is not a group`);
+    throw new Error(`Navigation route is not a group`);
   }
 
   return (

--- a/docs/ui/components/Navigation/Navigation.test.tsx
+++ b/docs/ui/components/Navigation/Navigation.test.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import node from 'unist-builder';
+import visit from 'unist-util-visit';
+
+import { findActiveRoute } from './Navigation';
+import { NavigationNode } from './types';
+
+describe(findActiveRoute, () => {
+  it('finds active page in list', () => {
+    const list = [
+      node('page', { name: 'Page 1', href: '/build' }),
+      node('page', { name: 'Page 2', href: '/build/setup' }),
+      node('page', { name: 'Page 3', href: '/build/eas-json' }),
+    ];
+    expect(findActiveRoute(list, '/build/setup')).toMatchObject({
+      page: findNode(list, { type: 'page', name: 'Page 2' }),
+      group: null,
+      section: null,
+    });
+  });
+
+  it('finds active page and group in list', () => {
+    const list = [
+      node('group', { name: 'Group 1' }, []),
+      node('group', { name: 'Group 2' }, [
+        node('page', { name: 'Page 1', href: '/build' }),
+        node('page', { name: 'Page 2', href: '/build/setup' }),
+        node('page', { name: 'Page 3', href: '/build/eas-json' }),
+      ]),
+    ];
+    expect(findActiveRoute(list, '/build/eas-json')).toMatchObject({
+      page: findNode(list, { type: 'page', name: 'Page 3' }),
+      group: findNode(list, { type: 'group', name: 'Group 2' }),
+      section: null,
+    });
+  });
+
+  it('finds active page, group, and section in list', () => {
+    const list = [
+      node('section', { name: 'Section 1' }, [
+        node('group', { name: 'Group 1' }, []),
+        node('group', { name: 'Group 2' }, [
+          node('page', { name: 'Page 1', href: '/build' }),
+          node('page', { name: 'Page 2', href: '/build/flutter' }),
+        ]),
+      ]),
+      node('section', { name: 'Section 2' }, [
+        node('group', { name: 'Group 3' }, []),
+        node('group', { name: 'Group 4' }, [
+          node('page', { name: 'Page 3', href: '/build/classic' }),
+          node('page', { name: 'Page 4', href: '/build/eas-json' }),
+        ]),
+      ]),
+    ];
+    expect(findActiveRoute(list, '/build/eas-json')).toMatchObject({
+      page: findNode(list, { type: 'page', name: 'Page 4' }),
+      group: findNode(list, { type: 'group', name: 'Group 4' }),
+      section: findNode(list, { type: 'section', name: 'Section 2' }),
+    });
+  });
+
+  it('skips hidden navigation node', () => {
+    const list = [
+      node('group', { name: 'Group 1' }, []),
+      node('group', { name: 'Group 2', hidden: true }, [
+        node('page', { name: 'Page 1', href: '/build' }),
+        node('page', { name: 'Page 2', href: '/build/setup' }),
+        node('page', { name: 'Page 3', href: '/build/eas-json' }),
+      ]),
+    ];
+    expect(findActiveRoute(list, '/build/eas-json')).toMatchObject({
+      page: null,
+      group: null,
+      section: null,
+    });
+  });
+});
+
+/** Helper function to find the first node that matches the predicate */
+function findNode(
+  list: NavigationNode[],
+  predicate: Partial<NavigationNode> | ((node: NavigationNode) => boolean)
+): NavigationNode | null {
+  let result = null;
+  visit(node('root', list), predicate as any, node => {
+    result = node;
+  });
+  return result;
+}

--- a/docs/ui/components/Navigation/Navigation.tsx
+++ b/docs/ui/components/Navigation/Navigation.tsx
@@ -59,7 +59,10 @@ export function findActiveRoute(routes: NavigationNode[], pathname: string) {
 
     switch (route.type) {
       case 'page':
-        if (route.href === pathname) activeRoutes.page = route;
+        if (route.href === pathname) {
+          activeRoutes.page = route;
+          break;
+        }
         break;
 
       case 'group':
@@ -68,6 +71,7 @@ export function findActiveRoute(routes: NavigationNode[], pathname: string) {
           if (nestedActiveRoutes.page) {
             activeRoutes.page = nestedActiveRoutes.page;
             activeRoutes.group = route;
+            break;
           }
         }
         break;
@@ -79,6 +83,7 @@ export function findActiveRoute(routes: NavigationNode[], pathname: string) {
             activeRoutes.page = nestedActiveRoutes.page;
             activeRoutes.group = nestedActiveRoutes.group;
             activeRoutes.section = route;
+            break;
           }
         }
         break;

--- a/docs/ui/components/Navigation/Navigation.tsx
+++ b/docs/ui/components/Navigation/Navigation.tsx
@@ -1,4 +1,5 @@
-import React, { ComponentType } from 'react';
+import { useRouter } from 'next/router';
+import React, { ComponentType, useMemo } from 'react';
 
 import { GroupList } from './GroupList';
 import { PageLink } from './PageLink';
@@ -11,7 +12,9 @@ export type NavigationProps = {
 };
 
 export function Navigation({ routes }: NavigationProps) {
-  return <nav>{routes.map(navigationRenderer)}</nav>;
+  const router = useRouter();
+  const activeRoutes = useMemo(() => findActiveRoute(routes, router.pathname), [router.pathname]);
+  return <nav>{routes.map(route => navigationRenderer(route, activeRoutes))}</nav>;
 }
 
 const renderers: Record<NavigationType, ComponentType<NavigationRenderProps>> = {
@@ -20,14 +23,67 @@ const renderers: Record<NavigationType, ComponentType<NavigationRenderProps>> = 
   page: PageLink,
 };
 
-function navigationRenderer(route: NavigationNode) {
+function navigationRenderer(
+  route: NavigationNode,
+  activeRoutes: Record<NavigationType, NavigationNode | null>
+) {
   if (route.hidden) return null;
   const Component = renderers[route.type];
   const routeKey = `${route.type}-${route.name}`;
+  const isActive = activeRoutes[route.type] === route;
   const hasChildren = route.type !== 'page' && route.children.length;
   return (
-    <Component key={routeKey} route={route}>
-      {hasChildren && route.children.map(navigationRenderer)}
+    <Component key={routeKey} route={route} isActive={isActive}>
+      {hasChildren && route.children.map(nested => navigationRenderer(nested, activeRoutes))}
     </Component>
   );
+}
+
+/**
+ * Find the active routes by pathname, and do it once.
+ * This will iterate the tree and find the nodes which are "active".
+ *   - Page -> if the pathname matches the page's href property
+ *   - Group -> if the group contains an active page
+ *   - Section -> if the section contains an active group or page
+ */
+export function findActiveRoute(routes: NavigationNode[], pathname: string) {
+  const activeRoutes: Record<NavigationType, NavigationNode | null> = {
+    page: null,
+    group: null,
+    section: null,
+  };
+
+  for (const route of routes) {
+    // Try to exit early on hidden routes
+    if (route.hidden) continue;
+
+    switch (route.type) {
+      case 'page':
+        if (route.href === pathname) activeRoutes.page = route;
+        break;
+
+      case 'group':
+        {
+          const nestedActiveRoutes = findActiveRoute(route.children, pathname);
+          if (nestedActiveRoutes.page) {
+            activeRoutes.page = nestedActiveRoutes.page;
+            activeRoutes.group = route;
+          }
+        }
+        break;
+
+      case 'section':
+        {
+          const nestedActiveRoutes = findActiveRoute(route.children, pathname);
+          if (nestedActiveRoutes.group || nestedActiveRoutes.page) {
+            activeRoutes.page = nestedActiveRoutes.page;
+            activeRoutes.group = nestedActiveRoutes.group;
+            activeRoutes.section = route;
+          }
+        }
+        break;
+    }
+  }
+
+  return activeRoutes;
 }

--- a/docs/ui/components/Navigation/Navigation.tsx
+++ b/docs/ui/components/Navigation/Navigation.tsx
@@ -1,0 +1,33 @@
+import React, { ComponentType } from 'react';
+
+import { GroupList } from './GroupList';
+import { PageLink } from './PageLink';
+import { SectionList } from './SectionList';
+import { NavigationNode, NavigationRenderProps, NavigationType } from './types';
+
+export type NavigationProps = {
+  /** The tree of navigation nodes to render in the sidebar */
+  routes: NavigationNode[];
+};
+
+export function Navigation({ routes }: NavigationProps) {
+  return <nav>{routes.map(navigationRenderer)}</nav>;
+}
+
+const renderers: Record<NavigationType, ComponentType<NavigationRenderProps>> = {
+  section: SectionList,
+  group: GroupList,
+  page: PageLink,
+};
+
+function navigationRenderer(route: NavigationNode) {
+  if (route.hidden) return null;
+  const Component = renderers[route.type];
+  const routeKey = `${route.type}-${route.name}`;
+  const hasChildren = route.type !== 'page' && route.children.length;
+  return (
+    <Component key={routeKey} route={route}>
+      {hasChildren && route.children.map(navigationRenderer)}
+    </Component>
+  );
+}

--- a/docs/ui/components/Navigation/PageLink.tsx
+++ b/docs/ui/components/Navigation/PageLink.tsx
@@ -47,7 +47,7 @@ const markerStyle = css({
 
 const markerStyleActive = css({
   visibility: 'visible',
-})
+});
 
 const textStyle = css({
   color: theme.text.secondary,

--- a/docs/ui/components/Navigation/PageLink.tsx
+++ b/docs/ui/components/Navigation/PageLink.tsx
@@ -8,7 +8,7 @@ import { A, CALLOUT } from '~/ui/components/Text';
 
 export function PageLink({ route, isActive }: NavigationRenderProps) {
   if (route.type !== 'page') {
-    throw new Error(`Navigation node is not a page`);
+    throw new Error(`Navigation route is not a page`);
   }
 
   return (

--- a/docs/ui/components/Navigation/PageLink.tsx
+++ b/docs/ui/components/Navigation/PageLink.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { borderRadius, shadows, spacing, theme, typography } from '@expo/styleguide';
+import { borderRadius, iconSize, shadows, spacing, theme, typography } from '@expo/styleguide';
 import React from 'react';
 
 import { NavigationRenderProps } from './types';
@@ -13,6 +13,7 @@ export function PageLink({ route, isActive }: NavigationRenderProps) {
 
   return (
     <A css={[linkStyle, isActive && linkStyleActive]} href={route.href}>
+      <i css={[markerStyle, isActive && markerStyleActive]} />
       <CALLOUT css={[textStyle, isActive && textStyleActive]} tag="span">
         {route.sidebarTitle || route.name}
       </CALLOUT>
@@ -21,9 +22,11 @@ export function PageLink({ route, isActive }: NavigationRenderProps) {
 }
 
 const linkStyle = css({
-  display: 'block',
+  display: 'flex',
+  flexDirection: 'row',
+  alignItems: 'center',
   borderRadius: borderRadius.medium,
-  padding: spacing[1.5],
+  padding: `${spacing[1.5]}px ${spacing[2]}px`,
   margin: `${spacing[1]}px ${spacing[4]}px`,
 });
 
@@ -31,6 +34,20 @@ const linkStyleActive = css({
   backgroundColor: theme.background.default,
   boxShadow: shadows.micro,
 });
+
+const markerStyle = css({
+  flexShrink: 0,
+  backgroundColor: theme.icon.secondary,
+  borderRadius: iconSize.micro,
+  width: iconSize.micro / 2,
+  height: iconSize.micro / 2,
+  marginRight: spacing[2],
+  visibility: 'hidden',
+});
+
+const markerStyleActive = css({
+  visibility: 'visible',
+})
 
 const textStyle = css({
   color: theme.text.secondary,

--- a/docs/ui/components/Navigation/PageLink.tsx
+++ b/docs/ui/components/Navigation/PageLink.tsx
@@ -1,0 +1,42 @@
+import { css } from '@emotion/react';
+import { borderRadius, shadows, spacing, theme, typography } from '@expo/styleguide';
+import React from 'react';
+
+import { NavigationRenderProps } from './types';
+
+import { A, CALLOUT } from '~/ui/components/Text';
+
+export function PageLink({ route, isActive }: NavigationRenderProps) {
+  if (route.type !== 'page') {
+    throw new Error(`Navigation node is not a page`);
+  }
+
+  return (
+    <A css={[linkStyle, isActive && linkStyleActive]} href={route.href}>
+      <CALLOUT css={[textStyle, isActive && textStyleActive]} tag="span">
+        {route.sidebarTitle || route.name}
+      </CALLOUT>
+    </A>
+  );
+}
+
+const linkStyle = css({
+  display: 'block',
+  borderRadius: borderRadius.medium,
+  padding: spacing[1.5],
+  margin: `${spacing[1]}px ${spacing[4]}px`,
+});
+
+const linkStyleActive = css({
+  backgroundColor: theme.background.default,
+  boxShadow: shadows.micro,
+});
+
+const textStyle = css({
+  color: theme.text.secondary,
+});
+
+const textStyleActive = css({
+  ...typography.utility.weight.medium,
+  color: theme.text.default,
+});

--- a/docs/ui/components/Navigation/SectionList.tsx
+++ b/docs/ui/components/Navigation/SectionList.tsx
@@ -1,0 +1,51 @@
+import { css } from '@emotion/react';
+import { iconSize, spacing, typography } from '@expo/styleguide';
+import React, { PropsWithChildren } from 'react';
+
+import { NavigationRenderProps } from '.';
+
+import { CALLOUT } from '~/ui/components/Text';
+import { durations } from '~/ui/foundations/durations';
+import { ChevronDownIcon } from '~/ui/foundations/icons';
+
+type SectionListProps = PropsWithChildren<NavigationRenderProps>;
+
+export function SectionList({ route, isActive, children }: SectionListProps) {
+  if (route.type !== 'section') {
+    throw new Error(`Navigation node is not a section`);
+  }
+
+  return (
+    <details open={isActive || route.collapsed === false}>
+      <summary css={summaryStyle}>
+        <ChevronDownIcon css={iconStyle} size={iconSize.small} />
+        <CALLOUT css={textStyle} tag="span">
+          {route.name}
+        </CALLOUT>
+      </summary>
+      <div>{children}</div>
+    </details>
+  );
+}
+
+const summaryStyle = css({
+  display: 'flex',
+  flexDirection: 'row',
+  alignItems: 'center',
+  listStyle: 'none',
+  userSelect: 'none',
+  margin: `0 ${spacing[4]}px`,
+});
+
+const iconStyle = css({
+  flexShrink: 0,
+  transform: 'rotate(-90deg)',
+  transition: `transform ${durations.hover}`,
+
+  'details[open] &': { transform: 'rotate(0)' },
+});
+
+const textStyle = css({
+  ...typography.utility.weight.medium,
+  padding: spacing[1.5],
+});

--- a/docs/ui/components/Navigation/SectionList.tsx
+++ b/docs/ui/components/Navigation/SectionList.tsx
@@ -12,7 +12,7 @@ type SectionListProps = PropsWithChildren<NavigationRenderProps>;
 
 export function SectionList({ route, isActive, children }: SectionListProps) {
   if (route.type !== 'section') {
-    throw new Error(`Navigation node is not a section`);
+    throw new Error(`Navigation route is not a section`);
   }
 
   return (

--- a/docs/ui/components/Navigation/SectionList.tsx
+++ b/docs/ui/components/Navigation/SectionList.tsx
@@ -16,7 +16,7 @@ export function SectionList({ route, isActive, children }: SectionListProps) {
   }
 
   return (
-    <details css={detailsStyle} open={isActive || route.collapsed === false}>
+    <details css={detailsStyle} open={isActive || route.collapsed !== true}>
       <summary css={summaryStyle}>
         <ChevronDownIcon css={iconStyle} size={iconSize.small} />
         <CALLOUT css={textStyle} tag="span">

--- a/docs/ui/components/Navigation/SectionList.tsx
+++ b/docs/ui/components/Navigation/SectionList.tsx
@@ -16,7 +16,7 @@ export function SectionList({ route, isActive, children }: SectionListProps) {
   }
 
   return (
-    <details open={isActive || route.collapsed === false}>
+    <details css={detailsStyle} open={isActive || route.collapsed === false}>
       <summary css={summaryStyle}>
         <ChevronDownIcon css={iconStyle} size={iconSize.small} />
         <CALLOUT css={textStyle} tag="span">
@@ -27,6 +27,11 @@ export function SectionList({ route, isActive, children }: SectionListProps) {
     </details>
   );
 }
+
+const detailsStyle = css({
+  paddingTop: spacing[3],
+  marginBottom: spacing[3],
+});
 
 const summaryStyle = css({
   display: 'flex',

--- a/docs/ui/components/Navigation/index.ts
+++ b/docs/ui/components/Navigation/index.ts
@@ -1,0 +1,1 @@
+export * from './types';

--- a/docs/ui/components/Navigation/index.ts
+++ b/docs/ui/components/Navigation/index.ts
@@ -1,1 +1,2 @@
 export * from './types';
+export { Navigation } from './Navigation';

--- a/docs/ui/components/Navigation/types.ts
+++ b/docs/ui/components/Navigation/types.ts
@@ -1,0 +1,45 @@
+export type NavigationTypes = 'section' | 'group' | 'page';
+
+export type NavigationRenderProps = {
+  /** The navigation node or route to render */
+  route: Section | Group | Page;
+  /** If this navigation node is considered "active", e.g. current page or containing current page */
+  isActive?: boolean;
+};
+
+export type NavigationNode<Type extends NavigationTypes, Data extends object> = Data & {
+  /** The type of the navigation node */
+  type: Type;
+  /** The name of the navigation node */
+  name: string;
+  /** If this navigation node should be rendered */
+  hidden?: boolean;
+};
+
+export type Section = NavigationNode<
+  'section',
+  {
+    /** The groups or pages it should render within the collapsible section */
+    children: (Group | Page)[];
+    /** If the section should be rendered as "closed" by default */
+    collapsed?: boolean;
+  }
+>;
+
+export type Group = NavigationNode<
+  'group',
+  {
+    /** The pages it should render within the group list */
+    children: Page[];
+  }
+>;
+
+export type Page = NavigationNode<
+  'page',
+  {
+    /** The display text of the link in the sidebar, falls back to `name` */
+    sidebarTitle?: string;
+    /** The pathname to link to the page */
+    href: string;
+  }
+>;

--- a/docs/ui/components/Navigation/types.ts
+++ b/docs/ui/components/Navigation/types.ts
@@ -1,13 +1,15 @@
-export type NavigationTypes = 'section' | 'group' | 'page';
+export type NavigationType = 'section' | 'group' | 'page';
+
+export type NavigationNode = Section | Group | Page;
 
 export type NavigationRenderProps = {
   /** The navigation node or route to render */
-  route: Section | Group | Page;
+  route: NavigationNode;
   /** If this navigation node is considered "active", e.g. current page or containing current page */
   isActive?: boolean;
 };
 
-export type NavigationNode<Type extends NavigationTypes, Data extends object> = Data & {
+export type Node<Type extends NavigationType, Data extends object> = Data & {
   /** The type of the navigation node */
   type: Type;
   /** The name of the navigation node */
@@ -16,7 +18,7 @@ export type NavigationNode<Type extends NavigationTypes, Data extends object> = 
   hidden?: boolean;
 };
 
-export type Section = NavigationNode<
+export type Section = Node<
   'section',
   {
     /** The groups or pages it should render within the collapsible section */
@@ -26,7 +28,7 @@ export type Section = NavigationNode<
   }
 >;
 
-export type Group = NavigationNode<
+export type Group = Node<
   'group',
   {
     /** The pages it should render within the group list */
@@ -34,7 +36,7 @@ export type Group = NavigationNode<
   }
 >;
 
-export type Page = NavigationNode<
+export type Page = Node<
   'page',
   {
     /** The display text of the link in the sidebar, falls back to `name` */

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -9041,7 +9041,7 @@ unist-util-visit-parents@^3.0.0:
     "@types/unist" "^2.0.0"
     unist-util-is "^4.0.0"
 
-unist-util-visit@2.0.3, unist-util-visit@^2.0.0:
+unist-util-visit@2.0.3, unist-util-visit@^2.0.0, unist-util-visit@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-2.0.3.tgz#c3703893146df47203bb8a9795af47d7b971208c"
   integrity sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==


### PR DESCRIPTION
# Why

Part of [ENG-3962](https://linear.app/expo/issue/ENG-3962/add-new-components-as-separate-prs-in-expoexpo), follow-up PR #16094 and PR #16093

This adds the new redesigned navigational sidebar to the docs, **_BUT_** it's not all functionality from the designs. This only replaces what we currently have a sidebar content, these things are still TBD:

- [ ] Scroll inside navigation with a upper fade → todo in future PR
- [ ] Add new root links to the top of the sidebar → todo in future PR
- [x] Add (back) version selector on versioned pages
    → PR #16194
- [x] Clean up the navigation constant to remove unnecessary nodes ([as described here](https://github.com/expo/expo/pull/16093#discussion_r793707166)) 
    → PR #16193

I'll follow up with the navigation constant clean-up with a stacked PR. We can add the other parts later.

# How

- Added **ui/components/Navigation**
- Added a component for each node type (**page**, **group**, **section**)
- Added recursive render method that picks component based on node type
- ✨✨✨ _**wrote tests**_ ✨✨✨

# Test Plan

- See tests
- Open random URL and see if
  - Sidebar is fully functioning
  - Version selector is rendered
  - Scroll position is maintained when going to another page

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
