### PR TITLE
[docs] Add renewed version selector to navigation

### DIFF
--- a/docs/ui/components/Navigation/ApiVersionSelect.tsx
+++ b/docs/ui/components/Navigation/ApiVersionSelect.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { borderRadius, iconSize, shadows, spacing, theme, typography } from '@expo/styleguide';
+import { borderRadius, iconSize, shadows, spacing, theme } from '@expo/styleguide';
 import React from 'react';
 
 import { VERSIONS, LATEST_VERSION, BETA_VERSION } from '~/constants/versions';

--- a/docs/ui/components/Navigation/ApiVersionSelect.tsx
+++ b/docs/ui/components/Navigation/ApiVersionSelect.tsx
@@ -1,0 +1,94 @@
+import { css } from '@emotion/react';
+import { borderRadius, iconSize, shadows, spacing, theme, typography } from '@expo/styleguide';
+import React from 'react';
+
+import { VERSIONS, LATEST_VERSION, BETA_VERSION } from '~/constants/versions';
+import { usePageApiVersion } from '~/providers/page-api-version';
+import { LABEL } from '~/ui/components/Text';
+import { ChevronDownIcon } from '~/ui/foundations/icons';
+
+// TODO(cedric): move this to a generic select input, so we can reuse it in the color scheme selector
+
+export function ApiVersionSelect() {
+  const { version, hasVersion, setVersion } = usePageApiVersion();
+
+  if (!hasVersion) {
+    return null;
+  }
+
+  return (
+    <div css={containerStyle}>
+      <label css={labelStyle} htmlFor="api-version-select">
+        <LABEL css={labelTextStyle}>{versionToText(version)}</LABEL>
+        <ChevronDownIcon css={labelIconStyle} size={iconSize.small} />
+      </label>
+      <select
+        id="api-version-select"
+        css={selectStyle}
+        value={version}
+        onChange={event => setVersion(event.target.value)}>
+        {VERSIONS.map(version => (
+          <option key={version} value={version}>
+            {versionToText(version)}
+          </option>
+        ))}
+      </select>
+      {/* Changing versions is a JS only mechanism. To help crawlers find other versions, we add hidden links. */}
+      {VERSIONS.map(version => (
+        <a css={crawlerLinkStyle} key={version} href={`/versions/${version}`} />
+      ))}
+    </div>
+  );
+}
+
+function versionToText(version: string): string {
+  if (version === 'unversioned') {
+    return 'Unversioned';
+  } else if (version === 'latest') {
+    return `${versionToText(LATEST_VERSION)} (latest)`;
+  } else if (version === BETA_VERSION) {
+    return `${versionToText(BETA_VERSION)} (beta)`;
+  }
+  return `SDK ${version.substring(1, 3)}`;
+}
+
+const containerStyle = css({
+  position: 'relative',
+  background: theme.background.default,
+  border: `1px solid ${theme.border.default}`,
+  borderRadius: borderRadius.medium,
+  boxShadow: shadows.input,
+  margin: spacing[4],
+  padding: `${spacing[2]}px ${spacing[3]}px`,
+});
+
+const labelStyle = css({
+  display: 'flex',
+  flexDirection: 'row',
+  alignItems: 'center',
+});
+
+const labelTextStyle = css({
+  flex: 1,
+});
+
+const labelIconStyle = css({
+  flexShrink: 0,
+});
+
+const crawlerLinkStyle = css({
+  display: 'none',
+});
+
+const selectStyle = css({
+  borderRadius: 0,
+  position: 'absolute',
+  width: '100%',
+  height: '100%',
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+  opacity: 0,
+  cursor: 'pointer',
+});

--- a/docs/ui/components/Navigation/Navigation.tsx
+++ b/docs/ui/components/Navigation/Navigation.tsx
@@ -1,6 +1,7 @@
 import { useRouter } from 'next/router';
 import React, { ComponentType, useMemo } from 'react';
 
+import { ApiVersionSelect } from './ApiVersionSelect';
 import { GroupList } from './GroupList';
 import { PageLink } from './PageLink';
 import { SectionList } from './SectionList';
@@ -14,7 +15,12 @@ export type NavigationProps = {
 export function Navigation({ routes }: NavigationProps) {
   const router = useRouter();
   const activeRoutes = useMemo(() => findActiveRoute(routes, router.pathname), [router.pathname]);
-  return <nav>{routes.map(route => navigationRenderer(route, activeRoutes))}</nav>;
+  return (
+    <nav>
+      <ApiVersionSelect />
+      {routes.map(route => navigationRenderer(route, activeRoutes))}
+    </nav>
+  );
 }
 
 const renderers: Record<NavigationType, ComponentType<NavigationRenderProps>> = {


### PR DESCRIPTION
# Why

Part of [ENG-3962](https://linear.app/expo/issue/ENG-3962/add-new-components-as-separate-prs-in-expoexpo), follow-up PR #16192

This adds back the API version selector, but with the new styles.

# How

- Copied existing version selector
- Converted styling to newer format and used styleguide
- Add version selector to sidebar

# Test Plan

- Go to API reference and play around with the selector

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
