### PR TITLE
[dev-menu] Remove vendored reanimated from release builds

### DIFF
--- a/packages/expo-dev-menu/android/build.gradle
+++ b/packages/expo-dev-menu/android/build.gradle
@@ -74,15 +74,15 @@ def getCurrentFlavor() {
 }
 
 def replaceSoTaskDebug
-def replaceSoTaskRelease
+def replaceSoTaskReleaseWithDevMenu
 
 if (Integer.parseInt(minor) < 65 && shouldSwapJNI()) {
   println("DevMenu will replace JNI library.")
 
   tasks.register("replaceSoTaskDebug", replaceSoTask)
-  tasks.register("replaceSoTaskRelease", replaceSoTask)
+  tasks.register("replaceSoTaskReleaseWithDevMenu", replaceSoTask)
   replaceSoTaskDebug = project.getTasks().getByPath(":expo-dev-menu:replaceSoTaskDebug")
-  replaceSoTaskRelease = project.getTasks().getByPath(":expo-dev-menu:replaceSoTaskRelease")
+  replaceSoTaskReleaseWithDevMenu = project.getTasks().getByPath(":expo-dev-menu:replaceSoTaskReleaseWithDevMenu")
 }
 
 rootProject.getSubprojects().forEach({ project ->
@@ -107,11 +107,11 @@ rootProject.getSubprojects().forEach({ project ->
         )
         project.getTasks().getByPath("${appName}:package${flavorString}Debug").dependsOn(replaceSoTaskDebug)
 
-        replaceSoTaskRelease.dependsOn(
-            project.getTasks().getByPath("${appName}:merge${flavorString}ReleaseNativeLibs"),
-            project.getTasks().getByPath("${appName}:strip${flavorString}ReleaseDebugSymbols")
+        replaceSoTaskReleaseWithDevMenu.dependsOn(
+            project.getTasks().getByPath("${appName}:merge${flavorString}ReleaseWithDevMenuNativeLibs"),
+            project.getTasks().getByPath("${appName}:strip${flavorString}ReleaseWithDevMenuDebugSymbols")
         )
-        project.getTasks().getByPath("${appName}:package${flavorString}Release").dependsOn(replaceSoTaskRelease)
+        project.getTasks().getByPath("${appName}:package${flavorString}ReleaseWithDevMenu").dependsOn(replaceSoTaskReleaseWithDevMenu)
       }
     }
   }
@@ -195,7 +195,7 @@ android {
   }
 
   sourceSets {
-    main {
+    debug {
       jniLibs.srcDir "$reanimatedPath/$reanimatedVersion-$engine/jni"
       java {
         srcDirs += ['../vendored/react-native-gesture-handler/android/']
@@ -237,7 +237,8 @@ repositories {
 dependencies {
   implementation project(':expo-modules-core')
 
-  implementation files("${reanimatedPath}/${minorCopy}-${engine}/classes.jar")
+  debugImplementation files("${reanimatedPath}/${minorCopy}-${engine}/classes.jar")
+  releaseWithDevMenuImplementation files("${reanimatedPath}/${minorCopy}-${engine}/classes.jar")
 
   implementation project(":expo-dev-menu-interface")
 


### PR DESCRIPTION
# Why

Fixes https://forums.expo.dev/t/eas-build-generates-bigger-apk-as-well-as-aab-compared-to-classic-build-after-upgrading-from-sdk-40-to-44/61200.

# How

- Removed from the Reanimated from the release builds. 

# Test Plan

- build release apk and check if vendored module was removed