### PR TITLE
[dev-menu][android] fixes for dev menu on android

### DIFF
--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherDevMenuExtensions.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherDevMenuExtensions.kt
@@ -30,7 +30,7 @@ class DevLauncherDevMenuExtensions(
         return@export
       }
 
-      action("dev-launcher-back-to-launcher", {
+      action("backToLauncher", {
         controller?.navigateToLauncher()
       }) {
         isEnabled = { true }

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
@@ -308,6 +308,10 @@ object DevMenuManager : DevMenuManagerInterface, LifecycleEventListener {
     )
 
     activity.startActivity(Intent(activity, DevMenuActivity::class.java))
+
+    hostReactContext
+      ?.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+      ?.emit("openDevMenu", null)
   }
 
   /**

--- a/packages/expo-dev-menu/app/components/Main.tsx
+++ b/packages/expo-dev-menu/app/components/Main.tsx
@@ -18,7 +18,8 @@ import {
   Image,
 } from 'expo-dev-client-components';
 import * as React from 'react';
-import { Switch } from 'react-native';
+import { Platform } from 'react-native';
+import { TouchableWithoutFeedback, Switch } from 'react-native-gesture-handler';
 
 import { useAppInfo } from '../hooks/useAppInfo';
 import { useClipboard } from '../hooks/useClipboard';
@@ -36,7 +37,7 @@ export function Main() {
     urlClipboard.onCopyPress(hostUrl);
   }
 
-  function onCopyappInfoPress() {
+  function onCopyAppInfoPress() {
     const { runtimeVersion, sdkVersion, appName, appVersion } = appInfo;
     appInfoClipboard.onCopyPress({ runtimeVersion, sdkVersion, appName, appVersion });
   }
@@ -86,15 +87,13 @@ export function Main() {
 
           <Spacer.Horizontal size="flex" />
 
-          <Button.ScaleOnPressContainer
-            bg="ghost"
-            rounded="full"
-            minScale={0.8}
-            onPress={actions.closeMenu}>
-            <View padding="micro">
-              <XIcon />
-            </View>
-          </Button.ScaleOnPressContainer>
+          <GestureHandlerTouchableWrapper onPress={actions.closeMenu}>
+            <Button.ScaleOnPressContainer bg="ghost" rounded="full" minScale={0.8}>
+              <View padding="micro">
+                <XIcon />
+              </View>
+            </Button.ScaleOnPressContainer>
+          </GestureHandlerTouchableWrapper>
         </Row>
       </View>
 
@@ -145,12 +144,14 @@ export function Main() {
         </View>
       </Row>
 
-      <View mx="small" rounded="large" bg="default">
-        <SettingsRowButton
-          label="Toggle performance monitor"
-          icon={<PerformanceIcon />}
-          onPress={actions.togglePerformanceMonitor}
-        />
+      <View mx="small">
+        <View roundedTop="large">
+          <SettingsRowButton
+            label="Toggle performance monitor"
+            icon={<PerformanceIcon />}
+            onPress={actions.togglePerformanceMonitor}
+          />
+        </View>
         <Divider />
         <SettingsRowButton
           label="Toggle element inspector"
@@ -158,21 +159,25 @@ export function Main() {
           onPress={actions.toggleElementInspector}
         />
         <Divider />
-        <SettingsRowSwitch
-          testID="local-dev-tools"
-          label="Local dev tools"
-          icon={<DebugIcon />}
-          isEnabled={devSettings.isDebuggingRemotely}
-          setIsEnabled={actions.toggleDebugRemoteJS}
-        />
+        <View bg="default">
+          <SettingsRowSwitch
+            testID="local-dev-tools"
+            label="Local dev tools"
+            icon={<DebugIcon />}
+            isEnabled={devSettings.isDebuggingRemotely}
+            setIsEnabled={actions.toggleDebugRemoteJS}
+          />
+        </View>
         <Divider />
-        <SettingsRowSwitch
-          testID="fast-refresh"
-          label="Fast refresh"
-          icon={<RunIcon />}
-          isEnabled={devSettings.isHotLoadingEnabled}
-          setIsEnabled={actions.toggleFastRefresh}
-        />
+        <View bg="default" roundedBottom="large">
+          <SettingsRowSwitch
+            testID="fast-refresh"
+            label="Fast refresh"
+            icon={<RunIcon />}
+            isEnabled={devSettings.isHotLoadingEnabled}
+            setIsEnabled={actions.toggleFastRefresh}
+          />
+        </View>
       </View>
 
       <Spacer.Vertical size="large" />
@@ -194,18 +199,19 @@ export function Main() {
           </>
         )}
 
-        <Button.ScaleOnPressContainer
-          onPress={onCopyappInfoPress}
-          disabled={hasCopiedAppInfoContent}
-          bg="default"
-          roundedTop="none"
-          roundedBottom="large">
-          <Row px="medium" py="small" align="center">
-            <Text color="primary" size="large">
-              {hasCopiedAppInfoContent ? 'Copied to clipboard!' : 'Tap to Copy All'}
-            </Text>
-          </Row>
-        </Button.ScaleOnPressContainer>
+        <GestureHandlerTouchableWrapper onPress={onCopyAppInfoPress}>
+          <Button.ScaleOnPressContainer
+            bg="default"
+            roundedTop="none"
+            roundedBottom="large"
+            disabled={hasCopiedAppInfoContent}>
+            <Row px="medium" py="small" align="center">
+              <Text color="primary" size="large">
+                {hasCopiedAppInfoContent ? 'Copied to clipboard!' : 'Tap to Copy All'}
+              </Text>
+            </Row>
+          </Button.ScaleOnPressContainer>
+        </GestureHandlerTouchableWrapper>
       </View>
     </View>
   );
@@ -219,17 +225,19 @@ type ActionButtonProps = {
 
 function ActionButton({ icon, label, onPress }: ActionButtonProps) {
   return (
-    <Button.ScaleOnPressContainer minScale={0.9} bg="default" onPress={onPress}>
-      <View padding="small" rounded="large">
-        <View align="centered">{icon}</View>
+    <GestureHandlerTouchableWrapper onPress={onPress}>
+      <Button.ScaleOnPressContainer minScale={0.9} bg="default" onPress={onPress}>
+        <View padding="small" rounded="large">
+          <View align="centered">{icon}</View>
 
-        <Spacer.Vertical size="tiny" />
+          <Spacer.Vertical size="tiny" />
 
-        <Text size="small" align="center">
-          {label}
-        </Text>
-      </View>
-    </Button.ScaleOnPressContainer>
+          <Text size="small" align="center">
+            {label}
+          </Text>
+        </View>
+      </Button.ScaleOnPressContainer>
+    </GestureHandlerTouchableWrapper>
   );
 }
 
@@ -242,40 +250,42 @@ type SettingsRowButtonProps = {
 
 function SettingsRowButton({ label, icon, description = '', onPress }: SettingsRowButtonProps) {
   return (
-    <Button.ScaleOnPressContainer onPress={onPress}>
-      <Row padding="small" align="center">
-        <View width="large" height="large">
-          {icon}
-        </View>
+    <GestureHandlerTouchableWrapper onPress={onPress}>
+      <Button.ScaleOnPressContainer onPress={onPress} bg="default">
+        <Row padding="small" align="center">
+          <View width="large" height="large">
+            {icon}
+          </View>
 
-        <Spacer.Horizontal size="small" />
+          <Spacer.Horizontal size="small" />
 
-        <View>
-          <Text>{label}</Text>
-        </View>
+          <View>
+            <Text>{label}</Text>
+          </View>
 
-        <Spacer.Horizontal size="flex" />
+          <Spacer.Horizontal size="flex" />
 
-        <View style={{ width: 64, alignItems: 'flex-end' }} />
-      </Row>
+          <View style={{ width: 64, alignItems: 'flex-end' }} />
+        </Row>
 
-      {Boolean(description) && (
-        <View style={{ transform: [{ translateY: -8 }] }}>
-          <Row px="small" align="center">
-            <Spacer.Horizontal size="large" />
+        {Boolean(description) && (
+          <View style={{ transform: [{ translateY: -8 }] }}>
+            <Row px="small" align="center">
+              <Spacer.Horizontal size="large" />
 
-            <View shrink="1" px="small">
-              <Text size="small" color="secondary" leading="large">
-                {description}
-              </Text>
-            </View>
+              <View shrink="1" px="small">
+                <Text size="small" color="secondary" leading="large">
+                  {description}
+                </Text>
+              </View>
 
-            <View style={{ width: 64 }} />
-          </Row>
-          <Spacer.Vertical size="tiny" />
-        </View>
-      )}
-    </Button.ScaleOnPressContainer>
+              <View style={{ width: 64 }} />
+            </Row>
+            <Spacer.Vertical size="tiny" />
+          </View>
+        )}
+      </Button.ScaleOnPressContainer>
+    </GestureHandlerTouchableWrapper>
   );
 }
 
@@ -353,4 +363,13 @@ function AppInfoRow({ title, value }: AppInfoRowProps) {
       <Text>{value}</Text>
     </Row>
   );
+}
+
+// TODO - move this to `expo-dev-client-components`
+function GestureHandlerTouchableWrapper({ onPress, children }) {
+  if (Platform.OS === 'android') {
+    return <TouchableWithoutFeedback onPress={onPress}>{children}</TouchableWithoutFeedback>;
+  }
+
+  return children;
 }

--- a/packages/expo-dev-menu/app/hooks/useBottomSheet.tsx
+++ b/packages/expo-dev-menu/app/hooks/useBottomSheet.tsx
@@ -42,8 +42,12 @@ export function BottomSheetProvider({ children }: BottomSheetProviderProps) {
 
   const callbackNode = React.useRef(new Value(0));
 
+  function hideApp() {
+    hideMenu();
+  }
+
   const trackCallbackNode = React.useRef(
-    onChange(callbackNode.current, cond(eq(callbackNode.current, 0), call([], hideMenu)))
+    onChange(callbackNode.current, cond(eq(callbackNode.current, 0), call([], hideApp)))
   );
 
   const backgroundOpacity = callbackNode.current.interpolate({

--- a/packages/expo-dev-menu/app/hooks/useDevSettings.tsx
+++ b/packages/expo-dev-menu/app/hooks/useDevSettings.tsx
@@ -15,6 +15,18 @@ export function useDevSettings() {
     isPerfMonitorShown: false,
   });
 
+  // toggle value so that there is no lag in response to user input
+  // these values will update to the correct value after the native fn is executed via updateSettings()
+  // by this time the bottom sheet will likely be closed
+  function eagerToggleValue(key: keyof DevMenu.DevSettings) {
+    setDevSettings((prevSettings) => {
+      return {
+        ...prevSettings,
+        [key]: !prevSettings[key],
+      };
+    });
+  }
+
   React.useEffect(() => {
     DevMenu.getDevSettingsAsync().then(setDevSettings);
   }, []);
@@ -25,39 +37,43 @@ export function useDevSettings() {
   }, []);
 
   const toggleElementInspector = React.useCallback(async () => {
+    eagerToggleValue('isElementInspectorShown');
     await DevMenu.toggleElementInspectorAsync();
     bottomSheet.collapse();
-    await updateSettings();
+    updateSettings();
   }, []);
 
   const toggleFastRefresh = React.useCallback(async () => {
+    eagerToggleValue('isHotLoadingEnabled');
     await DevMenu.toggleFastRefreshAsync();
     bottomSheet.collapse();
-    await updateSettings();
+    updateSettings();
   }, []);
 
   const toggleDebugRemoteJS = React.useCallback(async () => {
+    eagerToggleValue('isDebuggingRemotely');
     await DevMenu.toggleDebugRemoteJSAsync();
     bottomSheet.collapse();
-    await updateSettings();
+    updateSettings();
   }, []);
 
   const togglePerformanceMonitor = React.useCallback(async () => {
+    eagerToggleValue('isPerfMonitorShown');
     await DevMenu.togglePerformanceMonitorAsync();
     bottomSheet.collapse();
-    await updateSettings();
+    updateSettings();
   }, []);
 
   const navigateToLauncher = React.useCallback(async () => {
     await DevMenu.navigateToLauncherAsync();
+    updateSettings();
     bottomSheet.collapse();
-    await updateSettings();
   }, []);
 
   const reload = React.useCallback(async () => {
     await DevMenu.reloadAsync();
     bottomSheet.collapse();
-    await updateSettings();
+    updateSettings();
   }, []);
 
   const closeMenu = React.useCallback(async () => {

--- a/packages/expo-dev-menu/setupTests.ts
+++ b/packages/expo-dev-menu/setupTests.ts
@@ -18,9 +18,9 @@ jest.mock('react-native-reanimated', () => {
 jest.mock('react-native/Libraries/Components/Switch/Switch', () => {
   const View = require('react-native/Libraries/Components/View/View');
   const React = require('react');
-  function MockSwitch(props) {
+  const MockSwitch = React.forwardRef((props, ref) => {
     return React.createElement(View, { ...props, onPress: props.onValueChange });
-  }
+  });
 
   // workaround to be compatible with modern `Switch` in RN 0.66 which has ESM export
   // Use `return { default: MockSwitch };` when we drop support for SDK 44


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

-  `Pressable` component was not playing nice inside of gesture handler components on Android (thanks @lukmccall  for the tip) 
- there was no open even emitted on Android so I added one for parity
- also updated the key for navigating to launch screen for parity 
- created an issue to update the shared button component to use gesture-handler touchable instead of RN ones: 

https://linear.app/expo/issue/ENG-4075/update-button-to-be-touchablewithoutfeedback


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

- unit tests pass
- ensured that all the buttons on the dev menu work for android
- toggling dev menu from Expo CLI and gestures should work as expected 
- since I changed some markup I also ensured everything still works and looks good on iOS

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
