### PR TITLE
[docs] Update netinfo.md

### DIFF
--- a/docs/pages/versions/unversioned/sdk/netinfo.md
+++ b/docs/pages/versions/unversioned/sdk/netinfo.md
@@ -59,7 +59,7 @@ In order to access the `ssid` property (available under `state.details.ssid`), t
 ```json
   "ios": {
     "entitlements": {
-      "com.apple.developer.networking.wifi-info": "true"
+      "com.apple.developer.networking.wifi-info": true
     }
   }
 ```

--- a/docs/pages/versions/v44.0.0/sdk/netinfo.md
+++ b/docs/pages/versions/v44.0.0/sdk/netinfo.md
@@ -58,7 +58,7 @@ In order to access the `ssid` property (available under `state.details.ssid`), t
 ```json
   "ios": {
     "entitlements": {
-      "com.apple.developer.networking.wifi-info": "true"
+      "com.apple.developer.networking.wifi-info": true
     }
   }
 ```


### PR DESCRIPTION
Having `true` as a string will fail when building

# Why
The doc contains incorrect info which will cause a crash in practice

# How
`true` as a string will fail as in the provisioning profile file, it will write `<string>true</string>` instead of `<true />`
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
N/A

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
