### PR TITLE
[docs] Add redesigned layout components

### DIFF
--- a/docs/ui/layouts/Column/Scroll.tsx
+++ b/docs/ui/layouts/Column/Scroll.tsx
@@ -1,0 +1,37 @@
+import { css } from '@emotion/react';
+import { theme } from '@expo/styleguide';
+import React, { HTMLAttributes, PropsWithChildren } from 'react';
+
+type ScrollProps = PropsWithChildren<HTMLAttributes<HTMLDivElement>>;
+
+export function Scroll({ children, ...rest }: ScrollProps) {
+  return (
+    <div css={scrollStyle} {...rest}>
+      {children}
+    </div>
+  );
+}
+
+const scrollStyle = css({
+  height: '100%',
+  scrollBehavior: 'smooth',
+  overflowY: 'auto',
+  /* width */
+  '::-webkit-scrollbar': {
+    width: '6px',
+  },
+  /* Track */
+  '::-webkit-scrollbar-track': {
+    backgroundColor: 'transparent',
+    cursor: 'pointer',
+  },
+  /* Handle */
+  '::-webkit-scrollbar-thumb': {
+    backgroundColor: theme.background.tertiary,
+    borderRadius: '10px',
+  },
+  /* Handle on hover */
+  '::-webkit-scrollbar-thumb:hover': {
+    backgroundColor: theme.background.quaternary,
+  },
+});

--- a/docs/ui/layouts/Column/index.tsx
+++ b/docs/ui/layouts/Column/index.tsx
@@ -1,0 +1,77 @@
+import { css } from '@emotion/react';
+import { breakpoints, theme } from '@expo/styleguide';
+import React, { PropsWithChildren, ReactNode } from 'react';
+
+import { Scroll } from './Scroll';
+
+export { Scroll } from './Scroll';
+
+type ColumnLayoutProps = PropsWithChildren<{
+  /** The navigation sidebar content, either in the right sidebar or overlayed in mobile */
+  navigation: ReactNode;
+  /** The optional table of contents sidebar, adds padding to main content when omitted */
+  sidebar?: ReactNode;
+}>;
+
+export function ColumnLayout({ navigation, sidebar, children }: ColumnLayoutProps) {
+  return (
+    <div css={containerStyle}>
+      <div css={navigationColumnStyle}>{navigation}</div>
+      <div css={[articleColumnStyle, !sidebar && paddedArticleColumnStyle]}>
+        <Scroll>
+          <div css={contentBehaviorStyle}>{children}</div>
+        </Scroll>
+      </div>
+      <div css={sidebarColumnStyle}>{sidebar}</div>
+    </div>
+  );
+}
+
+// TODO(cedric): check if we can centralize or move it somewhere else
+const columnWidth = 200;
+const navigationMinimumWidth = 768;
+const sidebarMinimalWidth = breakpoints.medium;
+
+const containerStyle = css({
+  display: 'flex',
+  flexDirection: 'row',
+  height: '100%',
+});
+
+const navigationColumnStyle = css({
+  backgroundColor: theme.background.secondary,
+  flex: 0,
+  flexBasis: columnWidth,
+
+  [`@media screen and (max-width: ${navigationMinimumWidth}px)`]: {
+    display: 'none',
+  },
+});
+
+const articleColumnStyle = css({
+  flex: 1,
+});
+
+const paddedArticleColumnStyle = css({
+  // Apply right padding to avoid jumping content when the sidebar is toggled hidden/visible
+  paddingRight: columnWidth,
+  // But when the sidebar should never be shown, don't add padding
+  [`@media screen and (max-width: ${sidebarMinimalWidth}px)`]: {
+    paddingRight: 0,
+  },
+});
+
+const sidebarColumnStyle = css({
+  flexBasis: `${columnWidth}px`,
+
+  // Hide the sidebar whenever its empty, or below the media query threshold
+  '&:empty': { display: 'none' },
+  [`@media screen and (max-width: ${sidebarMinimalWidth}px)`]: {
+    display: 'none',
+  },
+});
+
+const contentBehaviorStyle = css({
+  maxWidth: breakpoints.large,
+  margin: '0 auto',
+});

--- a/docs/ui/layouts/Column/index.tsx
+++ b/docs/ui/layouts/Column/index.tsx
@@ -18,7 +18,7 @@ export function ColumnLayout({ navigation, sidebar, children }: ColumnLayoutProp
     <div css={containerStyle}>
       <div css={navigationColumnStyle}>{navigation}</div>
       <div css={articleColumnStyle}>
-        <Scroll css={!sidebar && paddedArticleColumnStyle}>
+        <Scroll>
           <div css={contentBehaviorStyle}>{children}</div>
         </Scroll>
       </div>
@@ -50,15 +50,6 @@ const navigationColumnStyle = css({
 
 const articleColumnStyle = css({
   flex: 1,
-});
-
-const paddedArticleColumnStyle = css({
-  // Apply right padding to avoid jumping content when the sidebar is toggled hidden/visible
-  paddingRight: columnWidth,
-  // But when the sidebar should never be shown, don't add padding
-  [`@media screen and (max-width: ${sidebarMinimalWidth}px)`]: {
-    paddingRight: 0,
-  },
 });
 
 const sidebarColumnStyle = css({

--- a/docs/ui/layouts/Column/index.tsx
+++ b/docs/ui/layouts/Column/index.tsx
@@ -17,8 +17,8 @@ export function ColumnLayout({ navigation, sidebar, children }: ColumnLayoutProp
   return (
     <div css={containerStyle}>
       <div css={navigationColumnStyle}>{navigation}</div>
-      <div css={[articleColumnStyle, !sidebar && paddedArticleColumnStyle]}>
-        <Scroll>
+      <div css={articleColumnStyle}>
+        <Scroll css={!sidebar && paddedArticleColumnStyle}>
           <div css={contentBehaviorStyle}>{children}</div>
         </Scroll>
       </div>

--- a/docs/ui/layouts/Header/index.tsx
+++ b/docs/ui/layouts/Header/index.tsx
@@ -1,0 +1,44 @@
+import { css, Global } from '@emotion/react';
+import { theme } from '@expo/styleguide';
+import React, { PropsWithChildren, ReactNode } from 'react';
+
+type HeaderLayoutProps = PropsWithChildren<{
+  /** The top bar content, with fixed height */
+  header: ReactNode;
+}>;
+
+export function HeaderLayout(props: HeaderLayoutProps) {
+  return (
+    <div css={containerStyle}>
+      <Global styles={globalStyle} />
+      <header css={headerStyle} role="banner">
+        {props.header}
+      </header>
+      <main css={contentStyle}>{props.children}</main>
+    </div>
+  );
+}
+
+const globalStyle = css({
+  'html, body, #__next': {
+    height: '100%',
+    backgroundColor: theme.background.default,
+  },
+});
+
+const containerStyle = css({
+  display: 'flex',
+  flexDirection: 'column',
+  height: '100%',
+  minHeight: '100%',
+});
+
+const headerStyle = css({
+  flexShrink: 0,
+  flexBasis: '60px', // TODO(cedric): find a better place for this
+});
+
+const contentStyle = css({
+  flex: 1,
+  height: 'calc(100% - 60px)',
+});


### PR DESCRIPTION
# Why

Part of [ENG-3962](https://linear.app/expo/issue/ENG-3962/add-new-components-as-separate-prs-in-expoexpo)

This adds two different layouts, `HeaderLayout` and `ColumnLayout`. Both can be used individually, to account for those error pages that just need the `HeaderLayout`.

## Why add these props to the layouts?

Because we currently depend on the MDX wrapper to set up all necessary info from that page (we get it as props), I made all other components injectable. These layout components are _just for the layout only_.

## Why add a separate `Scroll` export on `ColumnLayout`?

We kind of need this scrolling behavior in two different categories.
1. The content of the page should be scrollable by default.
2. The scrollable part below the root links in the navigation on the left.

Alternatively, we could replace this `Scroll` component with:
1. Separately defined scrollable behavior as a foundation and just reuse that CSS object.
2. Skip the jumping content-fix when switching pages from sidebar shown/hidden page.

# How

- Added two layouts and tested responsive behavior on it 

## Screenshots

In these screenshots both layouts are nested, like:

```jsx
<HeaderLayout header={<div>Header</div>}>
  <ColumnLayout
    navigation={<div>Navigation</div>}
    sidebar={<div>Optional sidebar</div>}
  >
    <div>Content</div>
  </ColumnLayout>
</HeaderLayout>
```

### Normal styling

<details><summary>1. <b>Without</b> scrollbars</summary>

![image](https://user-images.githubusercontent.com/1203991/152706500-d2b76fef-d5cd-495a-957b-c0b212890fae.png)

</details>

<details><summary>2. <b>With</b> scrollbars</summary>

![image](https://user-images.githubusercontent.com/1203991/152706593-9f9a1482-9f70-4f24-90ca-b78d96bd2523.png)

</details>

### Marked styling

These are just for the screenshots to mark the areas.
- **yellow** → the top header bar content
- **red** → the left column, or navigation, content
- **green** → the center column, or article, content
- **blue** → the right column, or sidebar, content

<details><summary>3. <b>Normal</b> screen width</summary>

![image](https://user-images.githubusercontent.com/1203991/152706649-dc573fcf-65d3-4a03-baa7-9bdae8336303.png)

</details>

<details><summary>4. <b>Wide</b> screen widths</summary>

![image](https://user-images.githubusercontent.com/1203991/152706785-48140a7a-6686-45d0-8ce9-c66e32d6040a.png)

</details>

<details><summary>5. <b>Wide</b> screen widths, width sidebar <b>hidden</b></summary>

![image](https://user-images.githubusercontent.com/1203991/152706766-297bbde1-b777-4a04-af8a-73cdb8b1b011.png)

</details>

<details><summary>6. <b>Small</b> screen widths</summary>

![image](https://user-images.githubusercontent.com/1203991/152706891-4dfea675-ac8a-4356-a010-33e16715375d.png)

</details>

<details><summary>7. <b>Tiny</b> screen widths (phones)</summary>

![image](https://user-images.githubusercontent.com/1203991/152706907-354d4a47-c1d0-4c45-b4a2-6f690694eac1.png)

</details>

## Media queries

This layout tries to do as minimal as possible in JS, everything is in CSS with media queries. There are a few media queries:
- Width of the screen when the left/navigation column is hidden → `<=768px`
- Width of the screen when the right/sidebar column is hidden → `<=breakpoints.medium` → `<=900px`

> Feel free to (request for) change these settings!

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
