### PR TITLE
[docs] fix broken link to internal distribution

### DIFF
--- a/docs/scripts/schemas/unversioned/eas-json-build-common-schema.js
+++ b/docs/scripts/schemas/unversioned/eas-json-build-common-schema.js
@@ -26,7 +26,7 @@ export default [
     name: 'distribution',
     enum: [ 'store', 'internal' ],
     description: [ 'The method of distributing your app.',
-      '- `internal` - with this option you\'ll be able to share your build URLs with anyone, and they will be able to install the builds to their devices straight from the Expo website. When using `internal`, make sure the build produces an APK or IPA file. Otherwise, the sharable URL will be useless. [Learn more about internal distribution](../internal-distribution).',
+      '- `internal` - with this option you\'ll be able to share your build URLs with anyone, and they will be able to install the builds to their devices straight from the Expo website. When using `internal`, make sure the build produces an APK or IPA file. Otherwise, the sharable URL will be useless. [Learn more about internal distribution](../../build/internal-distribution).',
       ' - `store` - produces builds for store uploads, your build URLs won\'t be sharable.'
     ]
   },


### PR DESCRIPTION
# Why

The "Learn more about internal distribution" link on the [eas.json(https://docs.expo.dev/build-reference/eas-json/)](https://docs.expo.dev/build-reference/eas-json/) is broken.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

I updated the link.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

I confirmed that my updated link work correctly in localhost.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
