### PR TITLE
[docs] Add grid based layout component

### DIFF
--- a/docs/ui/components/Layout/Layout.tsx
+++ b/docs/ui/components/Layout/Layout.tsx
@@ -2,6 +2,8 @@ import { css } from '@emotion/react';
 import { breakpoints } from '@expo/styleguide';
 import React, { PropsWithChildren, ReactNode } from 'react';
 
+import { LayoutScroll } from './LayoutScroll';
+
 type LayoutProps = PropsWithChildren<{
   /** The content within the top bar that spans the columns */
   header: ReactNode;
@@ -16,7 +18,11 @@ export function Layout({ header, navigation, sidebar, children }: LayoutProps) {
     <div css={layoutStyle}>
       <div css={headerStyle}>{header}</div>
       <div css={navigationStyle}>{navigation}</div>
-      <div css={contentStyle}>{children}</div>
+      <div css={contentStyle}>
+        <LayoutScroll>
+          <div css={innerContentStyle}>{children}</div>
+        </LayoutScroll>
+      </div>
       <div css={sidebarStyle}>{sidebar}</div>
     </div>
   );
@@ -25,7 +31,7 @@ export function Layout({ header, navigation, sidebar, children }: LayoutProps) {
 const layoutStyle = css({
   display: 'grid',
   height: '100vh',
-  gridTemplateRows: '60px auto',
+  gridTemplateRows: '60px calc(100vh - 60px)',
   gridTemplateColumns: 'min-content auto min-content',
   gridTemplateAreas: `
     "header header header"
@@ -34,13 +40,20 @@ const layoutStyle = css({
 });
 
 const headerStyle = css({ gridArea: 'header' });
-const contentStyle = css({ gridArea: 'content' });
 
 const navigationStyle = css({
   gridArea: 'navigation',
   [`@media screen and (max-width: 768px)`]: {
     display: 'none',
   },
+});
+
+const contentStyle = css({ gridArea: 'content' });
+const innerContentStyle = css({
+  margin: '0 auto',
+  maxWidth: breakpoints.large,
+  height: '100%',
+  overflowY: 'visible',
 });
 
 const sidebarStyle = css({

--- a/docs/ui/components/Layout/LayoutScroll.tsx
+++ b/docs/ui/components/Layout/LayoutScroll.tsx
@@ -1,0 +1,37 @@
+import { css } from '@emotion/react';
+import { theme } from '@expo/styleguide';
+import React, { HTMLAttributes, PropsWithChildren } from 'react';
+
+type LayoutScrollProps = PropsWithChildren<HTMLAttributes<HTMLDivElement>>;
+
+export function LayoutScroll({ children, ...rest }: LayoutScrollProps) {
+  return (
+    <div css={scrollStyle} {...rest}>
+      {children}
+    </div>
+  );
+}
+
+const scrollStyle = css({
+  height: '100%',
+  scrollBehavior: 'smooth',
+  overflowY: 'auto',
+  /* width */
+  '::-webkit-scrollbar': {
+    width: '6px',
+  },
+  /* Track */
+  '::-webkit-scrollbar-track': {
+    backgroundColor: 'transparent',
+    cursor: 'pointer',
+  },
+  /* Handle */
+  '::-webkit-scrollbar-thumb': {
+    backgroundColor: theme.background.tertiary,
+    borderRadius: '10px',
+  },
+  /* Handle on hover */
+  '::-webkit-scrollbar-thumb:hover': {
+    backgroundColor: theme.background.quaternary,
+  },
+});

--- a/docs/ui/components/Layout/index.ts
+++ b/docs/ui/components/Layout/index.ts
@@ -1,0 +1,2 @@
+export * from './Layout';
+export * from './LayoutScroll';

--- a/docs/ui/components/Layout/index.tsx
+++ b/docs/ui/components/Layout/index.tsx
@@ -1,0 +1,51 @@
+import { css } from '@emotion/react';
+import { breakpoints } from '@expo/styleguide';
+import React, { PropsWithChildren, ReactNode } from 'react';
+
+type LayoutProps = PropsWithChildren<{
+  /** The content within the top bar that spans the columns */
+  header: ReactNode;
+  /** The content within the left column */
+  navigation?: ReactNode;
+  /** The content within the right column */
+  sidebar?: ReactNode;
+}>;
+
+export function Layout({ header, navigation, sidebar, children }: LayoutProps) {
+  return (
+    <div css={layoutStyle}>
+      <div css={headerStyle}>{header}</div>
+      <div css={navigationStyle}>{navigation}</div>
+      <div css={contentStyle}>{children}</div>
+      <div css={sidebarStyle}>{sidebar}</div>
+    </div>
+  );
+}
+
+const layoutStyle = css({
+  display: 'grid',
+  height: '100vh',
+  gridTemplateRows: '60px auto',
+  gridTemplateColumns: 'min-content auto min-content',
+  gridTemplateAreas: `
+    "header header header"
+    "navigation content sidebar"
+  `,
+});
+
+const headerStyle = css({ gridArea: 'header' });
+const contentStyle = css({ gridArea: 'content' });
+
+const navigationStyle = css({
+  gridArea: 'navigation',
+  [`@media screen and (max-width: 768px)`]: {
+    display: 'none',
+  },
+});
+
+const sidebarStyle = css({
+  gridArea: 'sidebar',
+  [`@media screen and (max-width: ${breakpoints.medium}px)`]: {
+    display: 'none',
+  },
+});


### PR DESCRIPTION
# Why

Alternative CSS Grid approach to #16206

This adds the basic layout component that the following layout.

```
     (width: 100%)
|--------- A ---------| (height: 60px)
|- B -|--- C ---|- D -| (height: 100vh - 60px)
```

- **A** — Requires banner header which is always visible
    - → Always show
- **B** — Optional navigation sidebar on the left
    - → Hide when empty, or _window_ is `<=768px` (custom) 
- **C** — The page content (`width: 100%; height: 100%`)
    - → Always show
    - → Set max width of `1200px` (`breakpoints.large`), align center when space is available
    - → Add custom scroll bars when height overflows
- **D** — Optional table of contents sidebar on the right (`width: min-content; height: 100%`)
    - → Hide when empty, or _window_ is `<=900px` (`breakpoints.medium`)

## Screenshots

<details><summary>Used code to generate screenshots below</summary>

```jsx
import { css } from '@emotion/react';
import React from 'react';

import { Layout } from '~/ui/components/Layout';

export default function TestPage() {
  const layoutProps = {
    header: <div css={headerStyle}>A</div>,
    navigation: <div css={navigationStyle}>B</div>,
    sidebar: <div css={sidebarStyle}>D</div>,
  };

  return (
    <Layout {...layoutProps}>
      <div css={contentStyle}>{fill(100)}</div>
    </Layout>
  );
}

function fill(length: number) {
  return Array(length).fill(<>C<br /></>);
}

const block = {
  display: 'flex',
  width: '100%',
  minHeight: '100%',
  justifyContent: 'center',
  alignItems: 'center',
  color: 'black',
  fontWeight: 'bold',
};

const headerStyle = css({
  ...block,
  backgroundColor: 'yellow',
});

const navigationStyle = css({
  ...block,
  backgroundColor: 'red',
  width: '200px',
});

const contentStyle = css({
  ...block,
  backgroundColor: 'green',
});

const sidebarStyle = css({
  ...block,
  backgroundColor: 'blue',
  width: '200px',
});
```

</details>

<details><summary>1. normal screen width with all columns</summary>

![localhost_3002_test_ (2)](https://user-images.githubusercontent.com/1203991/153021705-eacdac16-332f-43e5-b818-6d374ea1aabf.png)

</details>

<details><summary>2. normal screen width without <b>D</b> content</summary>

![localhost_3002_test_ (3)](https://user-images.githubusercontent.com/1203991/153021873-01fbadda-6a50-4652-8628-c35ba7482c7f.png)

</details>

<details><summary>3. normal screen width without <b>B</b> and <b>D</b> content</summary>

![localhost_3002_test_ (8)](https://user-images.githubusercontent.com/1203991/153024242-95db430a-02dc-499c-982c-be6034145d62.png)

</details>

<details><summary>4. large screen width with all columns</summary>

![localhost_3002_test_ (4)](https://user-images.githubusercontent.com/1203991/153022036-d8257697-54e1-41d2-8b06-6476a32f0c95.png)

</details>

<details><summary>5. small screen width auto-hiding <b>D</b></summary>

![localhost_3002_test_ (5)](https://user-images.githubusercontent.com/1203991/153022217-ffb9d81c-0b79-423a-a332-86fd3042643c.png)

</details>

<details><summary>6. tiny screen width auto-hiding <b>B</b> and <b>D</b></summary>

![localhost_3002_test_ (6)](https://user-images.githubusercontent.com/1203991/153022293-275c138a-d8c1-40cc-b126-c13f57103905.png)

</details>

<details><summary>7. normal screen width auto-scrolling <b>C</b></summary>

![image](https://user-images.githubusercontent.com/1203991/153022607-67a99a18-4222-4f37-a771-530c053e2f63.png)

</details>


# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
