### PR TITLE
[updates-interface][updates][dev-launcher] add EXUpdatesControllerRegistry

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Add expo-modules and ReactDelegate-based automatic setup on iOS. ([#16190](https://github.com/expo/expo/pull/16190) by [@esamelson](https://github.com/esamelson))
+- Add support for auto-setup with updates integration on iOS. ([#16230](https://github.com/expo/expo/pull/16230) by [@esamelson](https://github.com/esamelson))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-dev-launcher/expo-dev-launcher.podspec
+++ b/packages/expo-dev-launcher/expo-dev-launcher.podspec
@@ -28,10 +28,8 @@ Pod::Spec.new do |s|
     ]
   }
 
-  # TODO(eric): remove once updates integration is sorted out
   s.xcconfig = {
-    'GCC_PREPROCESSOR_DEFINITIONS' => "EX_DEV_LAUNCHER_ENABLED=1 EX_DEV_LAUNCHER_VERSION=#{s.version}",
-    'OTHER_SWIFT_FLAGS' => '-DEX_DEV_LAUNCHER_ENABLED=1'
+    'GCC_PREPROCESSOR_DEFINITIONS' => "EX_DEV_LAUNCHER_VERSION=#{s.version}"
   }
 
   # Swift/Objective-C compatibility

--- a/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
+++ b/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
@@ -1,6 +1,7 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
 import ExpoModulesCore
+import EXUpdatesInterface
 
 public class ExpoDevLauncherReactDelegateHandler: ExpoReactDelegateHandler, RCTBridgeDelegate, EXDevLauncherControllerDelegate {
   private weak var reactDelegate: ExpoReactDelegate?
@@ -33,6 +34,9 @@ public class ExpoDevLauncherReactDelegateHandler: ExpoReactDelegateHandler, RCTB
     self.launchOptions = launchOptions
 
     EXDevLauncherController.sharedInstance().autoSetupPrepare(self, launchOptions: launchOptions)
+    if (EXUpdatesControllerRegistry.sharedInstance().controller != nil) {
+      EXDevLauncherController.sharedInstance().updatesInterface = EXUpdatesControllerRegistry.sharedInstance().controller
+    }
     return EXDevLauncherDeferredRCTBridge(delegate: self.bridgeDelegate!, launchOptions: self.launchOptions)
   }
 

--- a/packages/expo-updates-interface/CHANGELOG.md
+++ b/packages/expo-updates-interface/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add controller registry in order to support dev client auto-setup with updates integration on iOS. ([#16230](https://github.com/expo/expo/pull/16230) by [@esamelson](https://github.com/esamelson))
+
 ### 🐛 Bug fixes
 
 - Fix `Plugin with id 'maven' not found` build error from Android Gradle 7. ([#16080](https://github.com/expo/expo/pull/16080) by [@kudo](https://github.com/kudo))

--- a/packages/expo-updates-interface/ios/EXUpdatesInterface/EXUpdatesControllerRegistry.h
+++ b/packages/expo-updates-interface/ios/EXUpdatesInterface/EXUpdatesControllerRegistry.h
@@ -1,0 +1,16 @@
+//  Copyright © 2022-present 650 Industries. All rights reserved.
+
+#import <EXUpdatesInterface/EXUpdatesExternalInterface.h>
+
+/**
+ * Simple singleton registry that holds a reference to a single controller implementing
+ * EXUpdatesExternalInterface. This allows modules (like expo-dev-launcher) to acccess such a
+ * controller without their podspec needing to declare a dependency on expo-updates.
+ */
+@interface EXUpdatesControllerRegistry : NSObject
+
+@property (nonatomic, weak) id<EXUpdatesExternalInterface> controller;
+
++ (instancetype)sharedInstance;
+
+@end

--- a/packages/expo-updates-interface/ios/EXUpdatesInterface/EXUpdatesControllerRegistry.m
+++ b/packages/expo-updates-interface/ios/EXUpdatesInterface/EXUpdatesControllerRegistry.m
@@ -1,0 +1,19 @@
+//  Copyright © 2022-present 650 Industries. All rights reserved.
+
+#import <EXUpdatesInterface/EXUpdatesControllerRegistry.h>
+
+@implementation EXUpdatesControllerRegistry
+
++ (instancetype)sharedInstance
+{
+  static EXUpdatesControllerRegistry *theRegistry;
+  static dispatch_once_t once;
+  dispatch_once(&once, ^{
+    if (!theRegistry) {
+      theRegistry = [[EXUpdatesControllerRegistry alloc] init];
+    }
+  });
+  return theRegistry;
+}
+
+@end

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Add iOS support for code signing. ([#15682](https://github.com/expo/expo/pull/15682) by [@wschurman](https://github.com/wschurman))
 - Add CLI. ([#16216](https://github.com/expo/expo/pull/16216) by [@wschurman](https://github.com/wschurman))
+- Add support for dev client auto-setup with updates integration on iOS. ([#16230](https://github.com/expo/expo/pull/16230) by [@esamelson](https://github.com/esamelson))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/expo-module.config.json
+++ b/packages/expo-updates/expo-module.config.json
@@ -2,6 +2,7 @@
   "name": "expo-updates",
   "platforms": ["ios", "android"],
   "ios": {
+    "appDelegateSubscribers": ["ExpoUpdatesAppDelegateSubscriber"],
     "reactDelegateHandlers": ["ExpoUpdatesReactDelegateHandler"]
   }
 }

--- a/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesAppDelegateSubscriber.swift
+++ b/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesAppDelegateSubscriber.swift
@@ -1,0 +1,13 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+import ExpoModulesCore
+import EXUpdatesInterface
+
+public class ExpoUpdatesAppDelegateSubscriber: ExpoAppDelegateSubscriber {
+  public func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
+    if EXAppDefines.APP_DEBUG {
+      EXUpdatesControllerRegistry.sharedInstance().controller = EXUpdatesDevLauncherController.sharedInstance()
+    }
+    return false
+  }
+}


### PR DESCRIPTION
# Why

ENG-2611 and ENG-2662

# How

add `EXUpdatesControllerRegistry` to updates-interface, register the `UpdatesDevLauncherController` before it's needed, then access it from `ExpoDevLauncherReactDelegateHandler`.

# Test Plan

expo init bare
install dev-client and updates
resolve all changed packages locally
✅ project builds in debug mode
✅ can open published projects via URL bar
✅ can switch back and forth between published and local development projects

expo init bare
install dev-client (NOT) updates
resolve all changed packages locally
✅ project still builds in debug mode without updates
✅ can open local development projects
✅ trying to open published projects shows the normal alert

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
