### PR TITLE
[docs] Add redesigned page component and design switch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -92,3 +92,25 @@ jobs:
           status: ${{ job.status }}
           fields: job,message,ref,eventName,author,took
           author_name: Docs
+
+  # Temporary job to determine if the redesign works properly
+  docs-next:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🏗 Setup repo
+        uses: actions/checkout@v2
+
+      - name: 🏗 Setup Node 16
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16.x
+          cache: yarn
+      
+      - name: 📦 Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: 👷 Build docs
+        run: yarn build
+        env:
+          NEXT_PUBLIC_EXPO_DESIGN: 1
+          USE_ESBUILD: 1

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,7 +3,8 @@
   "version": "44.0.0",
   "private": true,
   "scripts": {
-    "dev": "rimraf .next/preval && next dev -p 3002",
+    "dev": "rimraf .next && next dev -p 3002",
+    "dev-next": "rimraf .next && npx cross-env NEXT_PUBLIC_EXPO_DESIGN=1 next dev -p 3002",
     "build": "cross-env NODE_OPTIONS=--max-old-space-size=5120 next build",
     "export": "yarn run build && next export && yarn run export-issue-404",
     "export-issue-404": "echo \"🛠  Patching https://github.com/vercel/next.js/issues/16528\"; cp out/404/index.html out/404.html",

--- a/docs/pages/_app.tsx
+++ b/docs/pages/_app.tsx
@@ -1,14 +1,12 @@
 import { ThemeProvider } from '@expo/styleguide';
-import { MDXProvider } from '@mdx-js/react';
 import * as Sentry from '@sentry/browser';
 import { AppProps } from 'next/app';
 import React from 'react';
 
 import { preprocessSentryError } from '~/common/sentry-utilities';
-import * as markdownComponents from '~/common/translate-markdown';
 import { useNProgress } from '~/common/use-nprogress';
-import DocumentationElements from '~/components/page-higher-order/DocumentationElements';
 import { AnalyticsProvider } from '~/providers/Analytics';
+import { MarkdownProvider } from '~/providers/Markdown';
 
 import 'react-diff-view/style/index.css';
 import '@expo/styleguide/dist/expo-theme.css';
@@ -21,11 +19,6 @@ Sentry.init({
   beforeSend: preprocessSentryError,
 });
 
-const rootMarkdownComponents = {
-  ...markdownComponents,
-  wrapper: DocumentationElements,
-};
-
 export { reportWebVitals } from '~/providers/Analytics';
 
 export default function App({ Component, pageProps }: AppProps) {
@@ -33,9 +26,9 @@ export default function App({ Component, pageProps }: AppProps) {
   return (
     <AnalyticsProvider>
       <ThemeProvider>
-        <MDXProvider components={rootMarkdownComponents}>
+        <MarkdownProvider>
           <Component {...pageProps} />
-        </MDXProvider>
+        </MarkdownProvider>
       </ThemeProvider>
     </AnalyticsProvider>
   );

--- a/docs/providers/Markdown.tsx
+++ b/docs/providers/Markdown.tsx
@@ -1,0 +1,17 @@
+import { MDXProvider } from '@mdx-js/react';
+import React, { PropsWithChildren } from 'react';
+
+import * as oldMarkdownComponents from '~/common/translate-markdown';
+import DocumentationPage from '~/components/DocumentationPage';
+import { markdownComponents, MarkdownWrapper } from '~/ui/components/Markdown';
+
+type MarkdownProviderProps = PropsWithChildren<object>;
+
+// TODO(cedric): remove old design after fully switching to new design
+const COMPONENTS = process.env.NEXT_PUBLIC_EXPO_DESIGN
+  ? { ...markdownComponents, wrapper: MarkdownWrapper }
+  : { ...oldMarkdownComponents, wrapper: DocumentationPage };
+
+export function MarkdownProvider(props: MarkdownProviderProps) {
+  return <MDXProvider components={COMPONENTS}>{props.children}</MDXProvider>;
+}

--- a/docs/providers/page-metadata.ts
+++ b/docs/providers/page-metadata.ts
@@ -2,7 +2,7 @@ import { createContext, useContext } from 'react';
 
 import { PageMetadata } from '~/types/common';
 
-export const PageMetadataContext = createContext<PageMetadata>({});
+export const PageMetadataContext = createContext<PageMetadata>({ title: '' });
 
 export function usePageMetadata() {
   return useContext(PageMetadataContext);

--- a/docs/scenes/PageScene/PageHeader.tsx
+++ b/docs/scenes/PageScene/PageHeader.tsx
@@ -1,0 +1,38 @@
+import { css } from '@emotion/react';
+import { theme, spacing } from '@expo/styleguide';
+import React, { ReactNode } from 'react';
+
+import { H1, P } from '~/ui/components/Text';
+
+type PageHeaderProps = {
+  title: string;
+  description?: ReactNode;
+};
+
+export const PageHeader = ({ title, description }: PageHeaderProps) => {
+  const descriptionIsText = typeof description === 'string';
+  const descriptionIsComponent = description && !descriptionIsText;
+
+  return (
+    <header css={PageHeaderStyle}>
+      <H1>{title}</H1>
+      {descriptionIsText && <P css={descriptionStyle}>{description}</P>}
+      {descriptionIsComponent && description}
+    </header>
+  );
+};
+
+const PageHeaderStyle = css({
+  borderBottom: `1px solid ${theme.border.default}`,
+  marginBottom: spacing[4],
+  paddingBottom: spacing[4],
+
+  // Add spacing between title and description, only when description is set
+  'h1 + *': {
+    paddingTop: spacing[1],
+  },
+});
+
+const descriptionStyle = css({
+  color: theme.text.secondary,
+});

--- a/docs/scenes/PageScene/PageScene.tsx
+++ b/docs/scenes/PageScene/PageScene.tsx
@@ -1,0 +1,52 @@
+import { useRouter } from 'next/router';
+import React, { PropsWithChildren, useMemo } from 'react';
+
+import { PageHeader } from './PageHeader';
+import { getActiveSection, getRoutes } from './navigation';
+
+import DocumentationFooter from '~/components/DocumentationFooter';
+import DocumentationHeader from '~/components/DocumentationHeader';
+import { usePageApiVersion } from '~/providers/page-api-version';
+import { PageMetadata } from '~/types/common';
+import { Layout } from '~/ui/components/Layout';
+import { Navigation } from '~/ui/components/Navigation';
+import { TableOfContents } from '~/ui/components/TableOfContents';
+
+type PageProps = PropsWithChildren<{
+  meta: PageMetadata;
+}>;
+
+export function PageScene(props: PageProps) {
+  const router = useRouter();
+  const { version } = usePageApiVersion();
+
+  const activeSection = useMemo(() => getActiveSection(router.pathname), [router.pathname]);
+  const routes = useMemo(() => getRoutes(router.pathname, version), [router.pathname, version]);
+
+  const header = (
+    <DocumentationHeader
+      activeSection={activeSection}
+      isMenuActive={false}
+      isMobileSearchActive={false}
+      isAlgoliaSearchHidden={false}
+      onShowMenu={() => {}}
+      onHideMenu={() => {}}
+      onToggleSearch={() => {}}
+    />
+  );
+
+  const navigation = <Navigation routes={routes} />;
+  const sidebar = !props.meta.hideTOC && <TableOfContents />;
+
+  return (
+    <Layout header={header} navigation={navigation} sidebar={sidebar}>
+      <PageHeader {...props.meta} />
+      {props.children}
+      <DocumentationFooter
+        router={router}
+        title={props.meta.title}
+        sourceCodeUrl={props.meta.sourceCodeUrl}
+      />
+    </Layout>
+  );
+}

--- a/docs/scenes/PageScene/index.ts
+++ b/docs/scenes/PageScene/index.ts
@@ -1,0 +1,1 @@
+export { PageScene } from './PageScene';

--- a/docs/scenes/PageScene/navigation.ts
+++ b/docs/scenes/PageScene/navigation.ts
@@ -1,0 +1,55 @@
+import navigation from '~/constants/navigation';
+
+// TODO(cedric): refactor the documentation header page to handle this logic itself
+
+function isReferencePath(pathname: string) {
+  return pathname.startsWith('/versions');
+}
+
+function isGeneralPath(pathname: string) {
+  return navigation.generalDirectories.some(name => pathname.startsWith(`/${name}`));
+}
+
+function isGettingStartedPath(pathname: string) {
+  return (
+    pathname === '/' || navigation.startingDirectories.some(name => pathname.startsWith(`/${name}`))
+  );
+}
+
+function isFeaturePreviewPath(pathname: string) {
+  return navigation.featurePreviewDirectories.some(name => pathname.startsWith(`/${name}`));
+}
+
+function isPreviewPath(pathname: string) {
+  return navigation.previewDirectories.some(name => pathname.startsWith(`/${name}`));
+}
+
+function isEasPath(pathname: string) {
+  return navigation.easDirectories.some(name => pathname.startsWith(`/${name}`));
+}
+
+export function getActiveSection(pathname: string) {
+  if (isReferencePath(pathname)) {
+    return 'reference';
+  } else if (isGeneralPath(pathname)) {
+    return 'general';
+  } else if (isGettingStartedPath(pathname)) {
+    return 'starting';
+  } else if (isFeaturePreviewPath(pathname)) {
+    return 'featurePreview';
+  } else if (isPreviewPath(pathname)) {
+    return 'preview';
+  } else if (isEasPath(pathname)) {
+    return 'eas';
+  }
+
+  return 'general';
+}
+
+export function getRoutes(pathname: string, version?: string) {
+  if (isReferencePath(pathname)) {
+    return navigation.reference[version as any];
+  } else {
+    return navigation[getActiveSection(pathname)];
+  }
+}

--- a/docs/types/common.ts
+++ b/docs/types/common.ts
@@ -1,5 +1,6 @@
 export type PageMetadata = {
-  title?: string;
+  title: string;
+  description?: string;
   sourceCodeUrl?: string;
   packageName?: string;
   maxHeadingDepth?: number;

--- a/docs/ui/components/Layout/Layout.tsx
+++ b/docs/ui/components/Layout/Layout.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { breakpoints, theme } from '@expo/styleguide';
+import { breakpoints, theme, spacing } from '@expo/styleguide';
 import React, { PropsWithChildren, ReactNode } from 'react';
 
 import { LayoutScroll } from './LayoutScroll';
@@ -53,11 +53,13 @@ const navigationStyle = css({
 });
 
 const contentStyle = css({ gridArea: 'content' });
+
 const innerContentStyle = css({
   margin: '0 auto',
   maxWidth: breakpoints.large,
   height: '100%',
   overflowY: 'visible',
+  padding: spacing[10],
 });
 
 const sidebarStyle = css({

--- a/docs/ui/components/Markdown/Wrapper.tsx
+++ b/docs/ui/components/Markdown/Wrapper.tsx
@@ -1,10 +1,12 @@
+import GithubSlugger from 'github-slugger';
 import { useRouter } from 'next/router';
 import React, { PropsWithChildren } from 'react';
 
 import { PageApiVersionProvider } from '~/providers/page-api-version';
 import { PageMetadataContext } from '~/providers/page-metadata';
+import { PageScene } from '~/scenes/PageScene';
 import { PageMetadata } from '~/types/common';
-import { Page } from '~/ui/components/Page';
+import { AnchorContext } from '~/ui/components/Text';
 
 type MarkdownWrapperProps = PropsWithChildren<{
   meta: PageMetadata;
@@ -14,10 +16,12 @@ export function MarkdownWrapper(props: MarkdownWrapperProps) {
   const router = useRouter();
 
   return (
-    <PageApiVersionProvider router={router}>
-      <PageMetadataContext.Provider value={props.meta}>
-        <Page {...props}>{props.children}</Page>
-      </PageMetadataContext.Provider>
-    </PageApiVersionProvider>
+    <AnchorContext.Provider value={new GithubSlugger()}>
+      <PageApiVersionProvider router={router}>
+        <PageMetadataContext.Provider value={props.meta}>
+          <PageScene {...props}>{props.children}</PageScene>
+        </PageMetadataContext.Provider>
+      </PageApiVersionProvider>
+    </AnchorContext.Provider>
   );
 }

--- a/docs/ui/components/Markdown/Wrapper.tsx
+++ b/docs/ui/components/Markdown/Wrapper.tsx
@@ -1,0 +1,23 @@
+import { useRouter } from 'next/router';
+import React, { PropsWithChildren } from 'react';
+
+import { PageApiVersionProvider } from '~/providers/page-api-version';
+import { PageMetadataContext } from '~/providers/page-metadata';
+import { PageMetadata } from '~/types/common';
+import { Page } from '~/ui/components/Page';
+
+type MarkdownWrapperProps = PropsWithChildren<{
+  meta: PageMetadata;
+}>;
+
+export function MarkdownWrapper(props: MarkdownWrapperProps) {
+  const router = useRouter();
+
+  return (
+    <PageApiVersionProvider router={router}>
+      <PageMetadataContext.Provider value={props.meta}>
+        <Page {...props}>{props.children}</Page>
+      </PageMetadataContext.Provider>
+    </PageApiVersionProvider>
+  );
+}

--- a/docs/ui/components/Markdown/index.tsx
+++ b/docs/ui/components/Markdown/index.tsx
@@ -8,6 +8,8 @@ import { DETAILS, SUMMARY } from '~/ui/components/Collapsible';
 import { Cell, HeaderCell, Row, Table, TableHead } from '~/ui/components/Table';
 import { A, H1, H2, H4, H5, CODE, P, BOLD, UL, OL, LI } from '~/ui/components/Text';
 
+export { MarkdownWrapper } from './Wrapper';
+
 type Config = ConfigStyles & {
   Component: ComponentType<ComponentProps> | string;
 };


### PR DESCRIPTION
# Why

This is a rolling branch to prepare the new designs before deploying, meaning this branch will be refactored often until we get to a shippable state. The fixes required should be in different PRs.

This PR also includes an extra CI check to see if the docs can be built using the new components.

## Todos

- Update old **components/plugins** too use new components
- Code block headers in Table of Contents aren't monotype rendered
    → [ENG-4128](https://linear.app/expo/issue/ENG-4128/fine-tune-table-of-contents-for-code-styled-headings)

## Pending PRs

- #16288 

# How

Puts everything together.

# Test Plan

- `$ yarn dev-next`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
