### PR TITLE
[docs] Fix persisting scroll and background colors in navigation

### DIFF
--- a/docs/ui/components/Layout/LayoutScroll.tsx
+++ b/docs/ui/components/Layout/LayoutScroll.tsx
@@ -1,20 +1,24 @@
 import { css } from '@emotion/react';
 import { theme } from '@expo/styleguide';
-import React, { HTMLAttributes, PropsWithChildren } from 'react';
+import React, { forwardRef, HTMLAttributes, PropsWithChildren } from 'react';
 
-type LayoutScrollProps = PropsWithChildren<HTMLAttributes<HTMLDivElement>>;
+type LayoutScrollProps = PropsWithChildren<
+  HTMLAttributes<HTMLDivElement> & {
+    /** If the scroll container should smoothly scroll when scrolled programatically */
+    smoothScroll?: boolean;
+  }
+>;
 
-export function LayoutScroll({ children, ...rest }: LayoutScrollProps) {
-  return (
-    <div css={scrollStyle} {...rest}>
+export const LayoutScroll = forwardRef<HTMLDivElement, LayoutScrollProps>(
+  ({ smoothScroll, children, ...rest }, ref) => (
+    <div css={[scrollStyle, smoothScroll && smoothScrollBehavior]} {...rest} ref={ref}>
       {children}
     </div>
-  );
-}
+  )
+);
 
 const scrollStyle = css({
   height: '100%',
-  scrollBehavior: 'smooth',
   overflowY: 'auto',
   /* width */
   '::-webkit-scrollbar': {
@@ -34,4 +38,8 @@ const scrollStyle = css({
   '::-webkit-scrollbar-thumb:hover': {
     backgroundColor: theme.background.quaternary,
   },
+});
+
+const smoothScrollBehavior = css({
+  scrollBehavior: 'smooth',
 });

--- a/docs/ui/components/Layout/index.ts
+++ b/docs/ui/components/Layout/index.ts
@@ -1,2 +1,3 @@
 export * from './Layout';
 export * from './LayoutScroll';
+export * from './usePersistScroll';

--- a/docs/ui/components/Layout/usePersistScroll.ts
+++ b/docs/ui/components/Layout/usePersistScroll.ts
@@ -17,7 +17,7 @@ export function usePersistScroll<T extends HTMLElement = HTMLDivElement>(id: str
   useEffect(
     function scrollRefDidMount() {
       if (ref.current && scrollPositions[id] > 0) {
-        ref.current.scrollTop = scrollPositions[id] || 0;
+        ref.current.scrollTop = scrollPositions[id];
       }
     },
     [ref.current]

--- a/docs/ui/components/Layout/usePersistScroll.ts
+++ b/docs/ui/components/Layout/usePersistScroll.ts
@@ -1,0 +1,27 @@
+import { UIEvent, useCallback, useEffect, useRef } from 'react';
+
+/** The list of persisted scroll positions, by id */
+const scrollPositions: Record<string, number> = {};
+
+/**
+ * Keep track and restore the scroll position when changing page.
+ * The ID is used to identify the stored scroll position.
+ */
+export function usePersistScroll<T extends HTMLElement = HTMLDivElement>(id: string) {
+  const ref = useRef<T>(null);
+
+  const onScroll = useCallback((event: UIEvent<T>) => {
+    scrollPositions[id] = event.currentTarget.scrollTop;
+  }, []);
+
+  useEffect(
+    function scrollRefDidMount() {
+      if (ref.current && scrollPositions[id] > 0) {
+        ref.current.scrollTop = scrollPositions[id] || 0;
+      }
+    },
+    [ref.current]
+  );
+
+  return { ref, onScroll };
+}

--- a/docs/ui/components/Navigation/Navigation.tsx
+++ b/docs/ui/components/Navigation/Navigation.tsx
@@ -9,7 +9,7 @@ import { PageLink } from './PageLink';
 import { SectionList } from './SectionList';
 import { NavigationNode, NavigationRenderProps, NavigationType } from './types';
 
-import { LayoutScroll } from '~/ui/components/Layout';
+import { LayoutScroll, usePersistScroll } from '~/ui/components/Layout';
 
 export type NavigationProps = {
   /** The tree of navigation nodes to render in the sidebar */
@@ -19,11 +19,11 @@ export type NavigationProps = {
 export function Navigation({ routes }: NavigationProps) {
   const router = useRouter();
   const activeRoutes = useMemo(() => findActiveRoute(routes, router.pathname), [router.pathname]);
+  const persistScroll = usePersistScroll('navigation');
 
-  // TODO(cedric): add root links above the routes and add fade to scroll
   return (
     <nav css={navigationStyle}>
-      <LayoutScroll>
+      <LayoutScroll {...persistScroll}>
         <ApiVersionSelect />
         {routes.map(route => navigationRenderer(route, activeRoutes))}
       </LayoutScroll>

--- a/docs/ui/components/Navigation/Navigation.tsx
+++ b/docs/ui/components/Navigation/Navigation.tsx
@@ -1,3 +1,5 @@
+import { css } from '@emotion/react';
+import { theme } from '@expo/styleguide';
 import { useRouter } from 'next/router';
 import React, { ComponentType, useMemo } from 'react';
 
@@ -7,6 +9,8 @@ import { PageLink } from './PageLink';
 import { SectionList } from './SectionList';
 import { NavigationNode, NavigationRenderProps, NavigationType } from './types';
 
+import { LayoutScroll } from '~/ui/components/Layout';
+
 export type NavigationProps = {
   /** The tree of navigation nodes to render in the sidebar */
   routes: NavigationNode[];
@@ -15,13 +19,26 @@ export type NavigationProps = {
 export function Navigation({ routes }: NavigationProps) {
   const router = useRouter();
   const activeRoutes = useMemo(() => findActiveRoute(routes, router.pathname), [router.pathname]);
+
+  // TODO(cedric): add root links above the routes and add fade to scroll
   return (
-    <nav>
-      <ApiVersionSelect />
-      {routes.map(route => navigationRenderer(route, activeRoutes))}
+    <nav css={navigationStyle}>
+      <LayoutScroll>
+        <ApiVersionSelect />
+        {routes.map(route => navigationRenderer(route, activeRoutes))}
+      </LayoutScroll>
     </nav>
   );
 }
+
+const navigationStyle = css({
+  width: 280,
+  height: '100%',
+  backgroundColor: theme.background.secondary,
+  '[data-expo-theme="dark"] &': {
+    backgroundColor: theme.background.default,
+  },
+});
 
 const renderers: Record<NavigationType, ComponentType<NavigationRenderProps>> = {
   section: SectionList,

--- a/docs/ui/components/Navigation/PageLink.tsx
+++ b/docs/ui/components/Navigation/PageLink.tsx
@@ -31,8 +31,11 @@ const linkStyle = css({
 });
 
 const linkStyleActive = css({
-  backgroundColor: theme.background.default,
   boxShadow: shadows.micro,
+  backgroundColor: theme.background.default,
+  '[data-expo-theme="dark"] &': {
+    backgroundColor: theme.background.tertiary,
+  }
 });
 
 const markerStyle = css({

--- a/docs/ui/components/Navigation/PageLink.tsx
+++ b/docs/ui/components/Navigation/PageLink.tsx
@@ -35,7 +35,7 @@ const linkStyleActive = css({
   backgroundColor: theme.background.default,
   '[data-expo-theme="dark"] &': {
     backgroundColor: theme.background.tertiary,
-  }
+  },
 });
 
 const markerStyle = css({


### PR DESCRIPTION
# Why

This polishes the style and behavior of the new navigation.

# How

- Added proper background colors for both dark and light mode (they are slightly different)
- Added `usePersistScroll` on **ui/components/Layout** to track and restore the scroll position

# Test Plan

- Open API reference
- Switch light and dark mode
- Scroll a bit down in the navigation
- Click anything
- See if the scroll bar maintains its position after going to that page

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
