### PR TITLE
[docs] Fix constants example in expo modules guide

### DIFF
--- a/docs/pages/modules/module-api.md
+++ b/docs/pages/modules/module-api.md
@@ -117,11 +117,17 @@ constants {
 ```
 
 ```kotlin
+// Passed as arguments
 constants(
-  mapOf(
+  "PI" to kotlin.math.PI
+)
+
+// or returned by the closure
+constants {
+  return@constants mapOf(
     "PI" to kotlin.math.PI
   )
-)
+}
 ```
 
 </CodeBlocksTable>


### PR DESCRIPTION
# Why

Kotlin example was invalid, it wouldn't compile that way.

# How

Like in Swift counterpart, shown example usage in two valid ways

<img width="785" alt="Screenshot 2022-02-10 at 17 19 39" src="https://user-images.githubusercontent.com/278340/153450190-adeb757a-b259-4acb-b604-9f144354f868.png">

# Test Plan

None