### PR TITLE
Update variants.md

### DIFF
--- a/docs/pages/build-reference/variants.md
+++ b/docs/pages/build-reference/variants.md
@@ -190,13 +190,13 @@ Assign a distinct scheme to every build profile in **eas.json**:
     "development": {
       "ios": {
         "buildConfiguration": "Debug",
-        "scheme": "myapp"
+        "scheme": "myapp-dev"
       }
     },
     "production": {
       "ios": {
         "buildConfiguration": "Release",
-        "scheme": "myapp-dev"
+        "scheme": "myapp"
       }
     }
   }


### PR DESCRIPTION
I think that's what it was intended

# Why

I think this was just a typo (using postfix on prod instead of dev)

# How

it's just a typo fix

# Test Plan

no testing needed

# Checklist


- [x ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
