### PR TITLE
[ios][web-browser] Fix dismissing the browser

### DIFF
--- a/packages/expo-web-browser/ios/WebBrowserSession.swift
+++ b/packages/expo-web-browser/ios/WebBrowserSession.swift
@@ -40,8 +40,8 @@ internal class WebBrowserSession: NSObject, SFSafariViewControllerDelegate {
   }
 
   func dismiss() {
-    viewController.dismiss(animated: true) { [weak self] in
-      self?.finish(type: "dismiss")
+    viewController.dismiss(animated: true) {
+      self.finish(type: "dismiss")
     }
   }
 


### PR DESCRIPTION
# Why

During WebBrowser NCL examples rewrite (#16267) I found a regression that the promise in `WebBrowser.openBrowserAsync` is not being resolved when the `WebBrowser.dismissBrowser()` is called. It's been introduced in #16201.

# How

That is because we unset the only strong reference on the `WebBrowserSession` immediately when the `dismissBrowser` is called and with `[weak self]` capture it gets destroyed before the view controller is fully dismissed when the promise from `openBrowserAsync` is being resolved.

Removing `[weak self]` makes sure the session (and its promise) is still hold in memory until the controller is dismissed, which allows the promise to be resolved.

No changelog entry needed because the regression was not released yet.

# Test Plan

Tested as part of the aforementioned PR (#16267)
