### PR TITLE
[expo-notifications][docs] Fix readme

### DIFF
--- a/packages/expo-notifications/README.md
+++ b/packages/expo-notifications/README.md
@@ -754,18 +754,18 @@ The `taskName` argument is the string you passed to `TaskManager.defineTask` as 
 
 #### Examples
 
-Implementing a notification handler that always shows the notification when it is received
-
 ```ts
+import * as TaskManager from 'expo-task-manager';
 import * as Notifications from 'expo-notifications';
 
-Notifications.setNotificationHandler({
-  handleNotification: async () => ({
-    shouldShowAlert: true,
-    shouldPlaySound: false,
-    shouldSetBadge: false,
-  }),
+const BACKGROUND_NOTIFICATION_TASK = 'BACKGROUND-NOTIFICATION-TASK';
+
+TaskManager.defineTask(BACKGROUND_NOTIFICATION_TASK, ({ data, error, executionInfo }) => {
+  console.log('Received a notification in the background!');
+  // Do something with the notification data
 });
+
+Notifications.registerTaskAsync(BACKGROUND_NOTIFICATION_TASK);
 ```
 
 ### `unregisterTaskAsync(taskName: string): void`


### PR DESCRIPTION
# Why

Noticed a discrepancy between this readme and the docs: https://docs.expo.dev/versions/latest/sdk/notifications/#handling-incoming-notifications-when-the-app-is-1

# How

Update to be the same (rest of this readme is the same I think).

# Test Plan

Inspect.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
