### PR TITLE
[docs] regenerated docs for expo-cli@5.1.2

### DIFF
--- a/docs/pages/workflow/expo-cli.md
+++ b/docs/pages/workflow/expo-cli.md
@@ -31,6 +31,10 @@ The commands listed below are derived from the latest version of Expo CLI. You c
 
 <!-- BEGIN GENERATED BLOCK. DO NOT MODIFY MANUALLY. https://github.com/expo/expo-cli/blob/main/packages/expo-cli/scripts/introspect.ts -->
 
+> Based on `expo-cli` v5.1.2
+
+---
+
 ### Core
 
 <details>
@@ -42,7 +46,7 @@ The commands listed below are derived from the latest version of Expo CLI. You c
 
 | Option         | Description             |
 | -------------- | ----------------------- |
-| `--platform [all⎮android|ios]` | Platforms: android, ios, all |
+| `--platform [all\|android\|ios]` | Platforms: android, ios, all |
 | `-p, --public-url [url]` | The public url that will host the static files (required) |
 | `-c, --clear` | Clear the Metro bundler cache |
 | `--output-dir [dir]` | The directory to export the static files to |
@@ -51,7 +55,7 @@ The commands listed below are derived from the latest version of Expo CLI. You c
 | `--dev` | Configure static files for developing locally using a non-https server |
 | `-s, --dump-sourcemap` | Dump the source map for debugging the JS bundle |
 | `-q, --quiet` | Suppress verbose output |
-| `-t, --target [managed⎮bare]` | Target environment for which this export is intended |
+| `-t, --target [managed\|bare]` | Target environment for which this export is intended |
 | `--merge-src-dir [dir]` | A repeatable source dir to merge in |
 | `--merge-src-url [url]` | A repeatable source tar.gz file URL to merge in |
 | `--max-workers [num]` | Maximum number of tasks to allow Metro to spawn |
@@ -182,14 +186,11 @@ Alias: `expo r`
 | `-s, --send-to [dest]` | An email address to send a link to |
 | `-c, --clear` | Clear the Metro bundler cache |
 | `--max-workers [num]` | Maximum number of tasks to allow Metro to spawn. |
-| `--dev` | Turn development mode on |
 | `--no-dev` | Turn development mode off |
 | `--minify` | Minify code |
-| `--no-minify` | Do not minify code |
 | `--https` | To start webpack with https protocol |
 | `--force-manifest-type [manifest-type]` | Override auto detection of manifest type |
 | `-p, --port [port]` | Port to start the native Metro bundler on (does not apply to web or tunnel). Default: 19000 |
-| `--no-https` | To start webpack with http protocol |
 | `--dev-client` | Experimental: Starts the bundler for use with the expo-development-client |
 | `--scheme [scheme]` | Custom URI protocol to use with a development build |
 | `-a, --android` | Opens your app in Expo Go on a connected Android device |
@@ -200,6 +201,9 @@ Alias: `expo r`
 | `--lan` | Same as --host lan |
 | `--localhost` | Same as --host localhost |
 | `--offline` | Allows this command to run while offline |
+| `--dev` | Deprecated: Dev mode is used by default |
+| `--no-minify` | Deprecated: Minify is disabled by default |
+| `--no-https` | Deprecated: https is disabled by default |
 | `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
 
 
@@ -217,12 +221,9 @@ Alias: `expo web`
 
 | Option         | Description             |
 | -------------- | ----------------------- |
-| `--dev` | Turn development mode on |
 | `--no-dev` | Turn development mode off |
 | `--minify` | Minify code |
-| `--no-minify` | Do not minify code |
 | `--https` | To start webpack with https protocol |
-| `--no-https` | To start webpack with http protocol |
 | `--force-manifest-type [manifest-type]` | Override auto detection of manifest type |
 | `-p, --port [port]` | Port to start the Webpack bundler on. Default: 19006 |
 | `-s, --send-to [dest]` | An email address to send a link to |
@@ -236,6 +237,9 @@ Alias: `expo web`
 | `--lan` | Same as --host lan |
 | `--localhost` | Same as --host localhost |
 | `--offline` | Allows this command to run while offline |
+| `--dev` | Deprecated: Dev mode is used by default |
+| `--no-minify` | Deprecated: Minify is disabled by default |
+| `--no-https` | Deprecated: https is disabled by default |
 | `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
 
 
@@ -351,8 +355,9 @@ This command does not take any options.
 
 | Option         | Description             |
 | -------------- | ----------------------- |
-| `-t, --type [public⎮prebuild|introspect]` | Type of config to show. |
+| `-t, --type [public\|prebuild\|introspect]` | Type of config to show. |
 | `--full` | Include all project config data |
+| `--json` | Output in JSON format |
 | `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
 
 
@@ -383,6 +388,7 @@ This command does not take any options.
 
 | Option         | Description             |
 | -------------- | ----------------------- |
+| `--fix-dependencies` | Fix incompatible dependency versions |
 | `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
 
 
@@ -439,7 +445,7 @@ Alias: `expo update`
 | -------------- | ----------------------- |
 | `--no-install` | Skip installing npm packages and CocoaPods. |
 | `--npm` | Use npm to install dependencies. (default when Yarn is not installed) |
-| `-p, --platform [all⎮android|ios]` | Platforms to sync: ios, android, all. Default: all |
+| `-p, --platform [all\|android\|ios]` | Platforms to sync: ios, android, all. Default: all |
 | `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
 
 
@@ -459,7 +465,7 @@ Alias: `expo update`
 | `--clean` | Delete the native folders and regenerate them before applying changes |
 | `--npm` | Use npm to install dependencies. (default when Yarn is not installed) |
 | `--template [template]` | Project template to clone from. File path pointing to a local tar file or a github repo |
-| `-p, --platform [all⎮android|ios]` | Platforms to sync: ios, android, all. Default: all |
+| `-p, --platform [all\|android\|ios]` | Platforms to sync: ios, android, all. Default: all |
 | `--skip-dependency-update [dependencies]` | Preserves versions of listed packages in package.json (comma separated list) |
 | `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
 
@@ -485,7 +491,7 @@ Alias: `expo p`
 | `-q, --quiet` | Suppress verbose output from the Metro bundler. |
 | `-s, --send-to [dest]` | A phone number or email address to send a link to |
 | `-c, --clear` | Clear the Metro bundler cache |
-| `-t, --target [managed⎮bare]` | Target environment for which this publish is intended. Options are `managed` or `bare`. |
+| `-t, --target [managed\|bare]` | Target environment for which this publish is intended. Options are `managed` or `bare`. |
 | `--max-workers [num]` | Maximum number of tasks to allow Metro to spawn. |
 | `--release-channel [name]` | The release channel to publish to. Default is 'default'. |
 | `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
@@ -527,7 +533,7 @@ Alias: `expo pr`
 | `--channel-id [channel-id]` | This flag is deprecated. |
 | `-c, --release-channel [name]` | The channel to rollback from. (Required) |
 | `-s, --sdk-version [version]` | The sdk version to rollback. (Required) |
-| `-p, --platform [android⎮ios]` | The platform to rollback. |
+| `-p, --platform [android\|ios]` | The platform to rollback. |
 | `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
 
 
@@ -547,7 +553,7 @@ Alias: `expo ph`
 | -------------- | ----------------------- |
 | `-c, --release-channel [name]` | Filter by release channel. If this flag is not included, the most recent publications will be shown. |
 | `--count [number-of-logs]` | Number of logs to view, maximum 100, default 5. |
-| `-p, --platform [android⎮ios]` | Filter by platform, android or ios. Defaults to both platforms. |
+| `-p, --platform [android\|ios]` | Filter by platform, android or ios. Defaults to both platforms. |
 | `-s, --sdk-version [version]` | Filter by SDK version e.g. 35.0.0 |
 | `-r, --raw` | Produce some raw output. |
 | `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
@@ -581,69 +587,6 @@ Alias: `expo pd`
 
 <details>
 <summary>
-<h4>expo build:ios</h4>
-<p>Build and sign a standalone IPA for the Apple App Store</p>
-</summary>
-<p>
-
-Alias: `expo bi`
-
-| Option         | Description             |
-| -------------- | ----------------------- |
-| `-c, --clear-credentials` | Clear all credentials stored on Expo servers. |
-| `--clear-dist-cert` | Remove Distribution Certificate stored on Expo servers. |
-| `--clear-push-key` | Remove Push Notifications Key stored on Expo servers. |
-| `--clear-push-cert` | Remove Push Notifications Certificate stored on Expo servers. Use of Push Notifications Certificates is deprecated. |
-| `--clear-provisioning-profile` | Remove Provisioning Profile stored on Expo servers. |
-| `-r --revoke-credentials` | Revoke credentials on developer.apple.com, select appropriate using --clear-* options. |
-| `--apple-id [login]` | Apple ID username (please also set the Apple ID password as EXPO_APPLE_PASSWORD environment variable). |
-| `-t --type [archive⎮simulator]` | Type of build: [archive⎮simulator]. |
-| `--release-channel [name]` | Pull from specified release channel. |
-| `--no-publish` | Disable automatic publishing before building. |
-| `--no-wait` | Exit immediately after scheduling build. |
-| `--team-id [apple-teamId]` | Apple Team ID. |
-| `--dist-p12-path [path]` | Path to your Distribution Certificate P12 (set password as EXPO_IOS_DIST_P12_PASSWORD environment variable). |
-| `--push-id [push-id]` | Push Key ID (ex: 123AB4C56D). |
-| `--push-p8-path [path]` | Path to your Push Key .p8 file. |
-| `--provisioning-profile-path [path]` | Path to your Provisioning Profile. |
-| `--public-url [url]` | The URL of an externally hosted manifest (for self-hosted apps). |
-| `--skip-credentials-check` | Skip checking credentials. |
-| `--skip-workflow-check` | Skip warning about build service bare workflow limitations. |
-| `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
-
-
-</p>
-</details>
-
-<details>
-<summary>
-<h4>expo build:android</h4>
-<p>Build and sign a standalone APK or App Bundle for the Google Play Store</p>
-</summary>
-<p>
-
-Alias: `expo ba`
-
-| Option         | Description             |
-| -------------- | ----------------------- |
-| `-c, --clear-credentials` | Clear stored credentials. |
-| `--release-channel [name]` | Pull from specified release channel. |
-| `--no-publish` | Disable automatic publishing before building. |
-| `--no-wait` | Exit immediately after triggering build. |
-| `--keystore-path [path]` | Path to your Keystore: *.jks. |
-| `--keystore-alias [alias]` | Keystore Alias |
-| `--generate-keystore` | [deprecated] Generate Keystore if one does not exist |
-| `--public-url [url]` | The URL of an externally hosted manifest (for self-hosted apps) |
-| `--skip-workflow-check` | Skip warning about build service bare workflow limitations. |
-| `-t --type [app-bundle⎮apk]` | Type of build: [app-bundle⎮apk]. |
-| `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
-
-
-</p>
-</details>
-
-<details>
-<summary>
 <h4>expo build:web</h4>
 <p>Build the web app for production</p>
 </summary>
@@ -654,24 +597,6 @@ Alias: `expo ba`
 | `-c, --clear` | Clear all cached build files and assets. |
 | `--no-pwa` | Prevent webpack from generating the manifest.json and injecting meta into the index.html head. |
 | `-d, --dev` | Turns dev flag on before bundling |
-| `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
-
-
-</p>
-</details>
-
-<details>
-<summary>
-<h4>expo build:status</h4>
-<p>Get the status of the latest build for the project</p>
-</summary>
-<p>
-
-Alias: `expo bs`
-
-| Option         | Description             |
-| -------------- | ----------------------- |
-| `--public-url [url]` | The URL of an externally hosted manifest (for self-hosted apps). |
 | `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
 
 
@@ -691,7 +616,7 @@ Alias: `expo bs`
 
 | Option         | Description             |
 | -------------- | ----------------------- |
-| `-p --platform [android⎮ios]` | Platform: [android⎮ios] |
+| `-p --platform [android\|ios]` | Platform: [android\|ios] |
 | `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
 
 
@@ -950,14 +875,79 @@ Alias: `expo u`
 
 <details>
 <summary>
-<h4>expo client:ios</h4>
-<p>Deprecated in favor of Expo Dev Clients</p>
+<h4>expo build:ios</h4>
+<p>Superseded by eas build in eas-cli</p>
 </summary>
 <p>
 
+Alias: `expo bi`
+
 | Option         | Description             |
 | -------------- | ----------------------- |
+| `-c, --clear-credentials` | Clear all credentials stored on Expo servers. |
+| `--clear-dist-cert` | Remove Distribution Certificate stored on Expo servers. |
+| `--clear-push-key` | Remove Push Notifications Key stored on Expo servers. |
+| `--clear-push-cert` | Remove Push Notifications Certificate stored on Expo servers. Use of Push Notifications Certificates is deprecated. |
+| `--clear-provisioning-profile` | Remove Provisioning Profile stored on Expo servers. |
+| `-r --revoke-credentials` | Revoke credentials on developer.apple.com, select appropriate using --clear-* options. |
 | `--apple-id [login]` | Apple ID username (please also set the Apple ID password as EXPO_APPLE_PASSWORD environment variable). |
+| `-t --type [archive\|simulator]` | Type of build: [archive\|simulator]. |
+| `--release-channel [name]` | Pull from specified release channel. |
+| `--no-publish` | Disable automatic publishing before building. |
+| `--no-wait` | Exit immediately after scheduling build. |
+| `--team-id [apple-teamId]` | Apple Team ID. |
+| `--dist-p12-path [path]` | Path to your Distribution Certificate P12 (set password as EXPO_IOS_DIST_P12_PASSWORD environment variable). |
+| `--push-id [push-id]` | Push Key ID (ex: 123AB4C56D). |
+| `--push-p8-path [path]` | Path to your Push Key .p8 file. |
+| `--provisioning-profile-path [path]` | Path to your Provisioning Profile. |
+| `--public-url [url]` | The URL of an externally hosted manifest (for self-hosted apps). |
+| `--skip-credentials-check` | Skip checking credentials. |
+| `--skip-workflow-check` | Skip warning about build service bare workflow limitations. |
+| `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
+
+
+</p>
+</details>
+
+<details>
+<summary>
+<h4>expo build:android</h4>
+<p>Superseded by eas build in eas-cli</p>
+</summary>
+<p>
+
+Alias: `expo ba`
+
+| Option         | Description             |
+| -------------- | ----------------------- |
+| `-c, --clear-credentials` | Clear stored credentials. |
+| `--release-channel [name]` | Pull from specified release channel. |
+| `--no-publish` | Disable automatic publishing before building. |
+| `--no-wait` | Exit immediately after triggering build. |
+| `--keystore-path [path]` | Path to your Keystore: *.jks. |
+| `--keystore-alias [alias]` | Keystore Alias |
+| `--generate-keystore` | [deprecated] Generate Keystore if one does not exist |
+| `--public-url [url]` | The URL of an externally hosted manifest (for self-hosted apps) |
+| `--skip-workflow-check` | Skip warning about build service bare workflow limitations. |
+| `-t --type [app-bundle\|apk]` | Type of build: [app-bundle\|apk]. |
+| `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
+
+
+</p>
+</details>
+
+<details>
+<summary>
+<h4>expo build:status</h4>
+<p>Superseded by eas build:list in eas-cli</p>
+</summary>
+<p>
+
+Alias: `expo bs`
+
+| Option         | Description             |
+| -------------- | ----------------------- |
+| `--public-url [url]` | The URL of an externally hosted manifest (for self-hosted apps). |
 | `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
 
 
@@ -967,7 +957,7 @@ Alias: `expo u`
 <details>
 <summary>
 <h4>expo upload:android</h4>
-<p>Moved to eas submit in eas-cli</p>
+<p>Superseded by eas submit in eas-cli</p>
 </summary>
 <p>
 
@@ -994,7 +984,7 @@ Alias: `expo ua`
 <details>
 <summary>
 <h4>expo upload:ios</h4>
-<p>Moved to eas submit in eas-cli</p>
+<p>Superseded by eas submit in eas-cli</p>
 </summary>
 <p>
 
@@ -1013,6 +1003,22 @@ Alias: `expo ui`
 | `--company-name [company-name]` | Migrate to eas.json's companyName property |
 | `--sku [sku]` | Migrate to eas.json's sku property |
 | `--language [language]` | Migrate to eas.json's language property |
+| `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
+
+
+</p>
+</details>
+
+<details>
+<summary>
+<h4>expo client:ios</h4>
+<p>Superseded by Expo Dev Clients</p>
+</summary>
+<p>
+
+| Option         | Description             |
+| -------------- | ----------------------- |
+| `--apple-id [login]` | Apple ID username (please also set the Apple ID password as EXPO_APPLE_PASSWORD environment variable). |
 | `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
 
 


### PR DESCRIPTION
# Why

https://github.com/expo/expo-cli/pull/4141 and the recent `expo-cli` release.

# How

Followed the docs [here](https://github.com/expo/expo/blob/master/guides/releasing/Release%20Workflow.md#010-generate-new-sdk-docs), generated from the `expo-cli@5.1.2` tag in `expo/expo-cli`

# Test Plan

Manually verified the integrity of the generated markdown.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
