### PR TITLE
Change 'apk' to 'aab' as playstore no longer accept apk

### DIFF
--- a/docs/pages/workflow/expo-cli.md
+++ b/docs/pages/workflow/expo-cli.md
@@ -10,7 +10,7 @@ Expo CLI is a command line app that is the main interface between a developer an
 - Creating new projects
 - Developing your app: running the project server, viewing logs, opening your app in a simulator
 - [Publishing](publishing.md) your app JavaScript and other assets and managing releasing them as updates
-- [Building binaries](../distribution/building-standalone-apps.md) (`apk` and `ipa` files) to be [uploaded to the App Store and Play Store](../distribution/uploading-apps.md)
+- [Building binaries](../distribution/building-standalone-apps.md) (`aab` and `ipa` files) to be [uploaded to the App Store and Play Store](../distribution/uploading-apps.md)
 - Managing Apple Credentials and Google Keystores
 
 You may use the CLI in your terminal or use the web based interface (it opens automatically by default, or you can press d from the CLI to open it on demand). The web interface enables you to use some of the most often used features from a quick-to-use graphical interface. We’ve only scratched the surface of what expo-cli can do so far. Be sure to check out all the possible commands below!


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
playstore no longer accept apk
# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
