### PR TITLE
Add step to reload environment variables

### DIFF
--- a/docs/pages/workflow/android-studio-emulator.md
+++ b/docs/pages/workflow/android-studio-emulator.md
@@ -33,7 +33,13 @@ echo "export ANDROID_SDK=$ANDROID_SDK" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zs
 echo "export PATH=$HOME/Library/Android/sdk/platform-tools:\$PATH" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bash_profile'`
 ```
 
-- Make sure that you can run `adb` from your terminal.
+- Reload the path environment variables by running:
+
+```bash
+source ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bash_profile'`
+```
+
+- Finally, make sure that you can run `adb` from your terminal.
 
 ## Step 2: Set up a virtual device
 


### PR DESCRIPTION
Hi Expo team, thanks so much for your continued work here!

# Why

The `PATH` and `ANDROID_SDK` variables are not reloaded before asking the user to try to run `adb`

# How

This adds a `source` command to reload the path variables before the user tries to run `adb`

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

I tested with a bootcamp student of ours, and it worked for them.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
