### PR TITLE
[apps] cleanup and fixes after AV type changes

### DIFF
--- a/apps/test-suite/tests/Audio.js
+++ b/apps/test-suite/tests/Audio.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import { Asset } from 'expo-asset';
-import { Audio } from 'expo-av';
+import { Audio, InterruptionModeAndroid, InterruptionModeIOS } from 'expo-av';
 import { Platform } from 'react-native';
 
 import { retryForStatus, waitFor } from './helpers';
@@ -61,9 +61,9 @@ export function test(t) {
           const mode = {
             playsInSilentModeIOS: false,
             allowsRecordingIOS: true,
-            interruptionModeIOS: Audio.INTERRUPTION_MODE_IOS_DO_NOT_MIX,
+            interruptionModeIOS: InterruptionModeIOS.DoNotMix,
             shouldDuckAndroid: false,
-            interruptionModeAndroid: Audio.INTERRUPTION_MODE_ANDROID_DO_NOT_MIX,
+            interruptionModeAndroid: InterruptionModeAndroid.DoNotMix,
             playThroughEarpieceAndroid: false,
             staysActiveInBackground: false,
           };

--- a/apps/test-suite/tests/Recording.js
+++ b/apps/test-suite/tests/Recording.js
@@ -1,4 +1,4 @@
-import { Audio } from 'expo-av';
+import { Audio, InterruptionModeIOS, InterruptionModeAndroid } from 'expo-av';
 import { Platform } from 'react-native';
 
 import * as TestUtils from '../TestUtils';
@@ -58,8 +58,8 @@ export async function test(t) {
         playsInSilentModeIOS: true,
         staysActiveInBackground: true,
         playThroughEarpieceAndroid: false,
-        interruptionModeIOS: Audio.INTERRUPTION_MODE_IOS_MIX_WITH_OTHERS,
-        interruptionModeAndroid: Audio.INTERRUPTION_MODE_ANDROID_DUCK_OTHERS,
+        interruptionModeIOS: InterruptionModeIOS.MixWithOthers,
+        interruptionModeAndroid: InterruptionModeAndroid.DuckOthers,
       });
 
       await TestUtils.acceptPermissionsAndRunCommandAsync(() => {

--- a/home/screens/AudioDiagnosticsScreen.tsx
+++ b/home/screens/AudioDiagnosticsScreen.tsx
@@ -96,7 +96,7 @@ export default function AudioDiagnosticsScreen() {
 type AudioOptionSwitchProps = {
   title: string;
   disabled?: boolean;
-  value: boolean;
+  value?: boolean;
   onValueChange: (value: boolean) => void;
 };
 

--- a/home/utils/useAudio.ts
+++ b/home/utils/useAudio.ts
@@ -1,7 +1,7 @@
-import { Audio, InterruptionModeAndroid, InterruptionModeIOS } from 'expo-av';
-import { useEffect, useState } from 'react';
+import { Audio, AudioMode, InterruptionModeAndroid } from 'expo-av';
+import { Dispatch, useEffect, useState } from 'react';
 
-export function useAudio(): [boolean, React.Dispatch<boolean>] {
+export function useAudio(): [boolean, Dispatch<boolean>] {
   const [isAudioEnabled, setAudioEnabled] = useState(true);
 
   useEffect(() => {
@@ -14,16 +14,9 @@ export function useAudio(): [boolean, React.Dispatch<boolean>] {
   return [isAudioEnabled, setAudioEnabled];
 }
 
-export type AudioModeState = {
-  interruptionModeIOS: InterruptionModeIOS;
-  playsInSilentModeIOS: boolean;
-  allowsRecordingIOS: boolean;
-  staysActiveInBackground: boolean;
-};
-
 export function useAudioMode(
-  initialAudioMode: AudioModeState
-): [AudioModeState, React.Dispatch<AudioModeState>] {
+  initialAudioMode: Partial<AudioMode>
+): [Partial<AudioMode>, Dispatch<AudioMode>] {
   const [audioMode, setAudioMode] = useState(initialAudioMode);
 
   useEffect(() => {
@@ -33,7 +26,7 @@ export function useAudioMode(
   return [audioMode, setAudioMode];
 }
 
-async function setAudioModeAsync(audioMode: AudioModeState): Promise<void> {
+async function setAudioModeAsync(audioMode: Partial<AudioMode>): Promise<void> {
   await Audio.setAudioModeAsync({
     ...audioMode,
     interruptionModeAndroid: InterruptionModeAndroid.DoNotMix,

--- a/home/utils/useAudio.ts
+++ b/home/utils/useAudio.ts
@@ -16,7 +16,7 @@ export function useAudio(): [boolean, Dispatch<boolean>] {
 
 export function useAudioMode(
   initialAudioMode: Partial<AudioMode>
-): [Partial<AudioMode>, Dispatch<AudioMode>] {
+): [Partial<AudioMode>, Dispatch<Partial<AudioMode>>] {
   const [audioMode, setAudioMode] = useState(initialAudioMode);
 
   useEffect(() => {


### PR DESCRIPTION
# Why

It looks like that the CI in AV conversion to autogenerated docs was green, but anyway, there were some parts of the workspace which started to fail.

Refs:
* #16038 
* #16299

# How

Replace previous interruption modes constants with types and use exported `AudioMode` where possible.

# Test Plan

Home app builds. Test Suite tests are passing.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
