### PR TITLE
[dev-launcher] Add support for RN 67

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Add expo-modules and ReactDelegate-based automatic setup on iOS. ([#16190](https://github.com/expo/expo/pull/16190) by [@esamelson](https://github.com/esamelson))
 - Add support for auto-setup with updates integration on iOS. ([#16230](https://github.com/expo/expo/pull/16230) by [@esamelson](https://github.com/esamelson))
+- Add support for th React Native `0.67.X`.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-dev-launcher/android/build.gradle
+++ b/packages/expo-dev-launcher/android/build.gradle
@@ -57,7 +57,9 @@ android {
       java {
         def rnVersion = getRNVersion()
 
-        if (rnVersion >= versionToNumber(0, 66, 0)) {
+        if (rnVersion >= versionToNumber(0, 67, 0)) {
+          srcDirs += "src/react-native-67"
+        } else if (rnVersion >= versionToNumber(0, 66, 0)) {
           srcDirs += "src/react-native-66"
         } else if (rnVersion >= versionToNumber(0, 65, 0)) {
           srcDirs += "src/react-native-65"

--- a/packages/expo-dev-launcher/android/src/react-native-67/expo/modules/devlauncher/rncompatibility/DevLauncherDevSupportManager.kt
+++ b/packages/expo-dev-launcher/android/src/react-native-67/expo/modules/devlauncher/rncompatibility/DevLauncherDevSupportManager.kt
@@ -45,7 +45,7 @@ class DevLauncherDevSupportManager(
   redBoxHandler: RedBoxHandler?,
   devBundleDownloadListener: DevBundleDownloadListener?,
   minNumShakes: Int,
-  customPackagerCommandHandlers: MutableMap<String, RequestHandler>?
+  customPackagerCommandHandlers: MutableMap<String, RequestHandler>?,
 ) : DevSupportManagerBase(
   applicationContext,
   reactInstanceManagerHelper,
@@ -54,7 +54,8 @@ class DevLauncherDevSupportManager(
   redBoxHandler,
   devBundleDownloadListener,
   minNumShakes,
-  customPackagerCommandHandlers
+  customPackagerCommandHandlers,
+  null
 ), DevLauncherKoinComponent {
   private val controller: DevLauncherControllerInterface by inject()
 


### PR DESCRIPTION
# Why

Adds support for RN 67.
Closes ENG-3973.

# How

`DevSupportManagerBase` has one more constructor parameter. So, I've copied the previous implementation and I've added a missing value. 

I didn't find any other problems 🎉

# Test Plan

- Tested using app with rn `0.67.2` and `dev-client`:
  - iOS  ✅
    - compilation ✅
    - open a launcher app ✅
    - log in ✅
    - open a local app ✅
    - open dev menu ✅
    - test dev menu actions ✅
    - test terminal (websockets) shourcuts ✅
    - go back to the launcher ✅ 
  - Android ✅
    - compilation ✅
    - open a launcher app ✅
    - log in ✅
    - open a local app ✅
    - open dev menu ✅
    - test dev menu actions ✅
    - test terminal (websockets) shourcuts ✅
    - go back to the launcher ✅ 