### PR TITLE
[expo-localization] fix: Exception in HostObject::get for prop 'NativeUnimoduleProxy': java.lang.NullPointerException

### DIFF
--- a/packages/expo-localization/CHANGELOG.md
+++ b/packages/expo-localization/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - Fix `Plugin with id 'maven' not found` build error from Android Gradle 7. ([#16080](https://github.com/expo/expo/pull/16080) by [@kudo](https://github.com/kudo))
+- Exception in HostObject::get for prop 'NativeUnimoduleProxy': java.lang.NullPointerException ([#16316](https://github.com/expo/expo/pull/16316) by [@nomi9995](https://github.com/nomi9995))
 
 ### 💡 Others
 

--- a/packages/expo-localization/android/src/main/java/expo/modules/localization/LocalizationModule.kt
+++ b/packages/expo-localization/android/src/main/java/expo/modules/localization/LocalizationModule.kt
@@ -24,11 +24,11 @@ class LocalizationModule(context: Context) : ExportedModule(context) {
 
   override fun getName() = "ExpoLocalization"
 
-  override fun getConstants(): Map<String, Any> {
-    val constants = HashMap<String, Any>()
+  override fun getConstants(): Map<String, Any?> {
+    val constants = HashMap<String, Any?>()
     val bundle = bundledConstants
     for (key in bundle.keySet()) {
-      constants[key] = bundle[key] as Any
+      constants[key] = bundle[key] as Any?
     }
     return constants
   }


### PR DESCRIPTION
# Why

Fixes #15899

I just migrated to the expo from `react-native-unimodules`. this error was happening only for android when I open app on android.
**if I uninstall the app and reinstall the app then this error is gone.**
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How
by tested this code for `expo-localization` https://github.com/expo/expo/issues/15899#issuecomment-1039952877 it is working for me & @photorouletteadmin
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
you have to migrate the expo from `react-native-unimodules` to `expo-modules`. this error was happening only for android when you will install the app over existing app and open app.
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
