### PR TITLE
[docs] Show clearer notices that "expo build" will stop on Jan 4, 2023, update ExpoKit deprecation messages

### DIFF
--- a/docs/pages/archived/adhoc-builds.md
+++ b/docs/pages/archived/adhoc-builds.md
@@ -2,7 +2,7 @@
 title: Custom Expo Go builds
 ---
 
-> 🚫 **This experimental feature has been cancelled, and it is not supported in SDK >= 41, but you can keep using it for SDK <= 40 projects**. We are working on a more flexible and portable development client library. You can read more about this in the ["Expo managed workflow in 2021" blog posts](https://blog.expo.dev/expo-managed-workflow-in-2021-5b887bbf7dbb).
+> 🚫 **This experimental feature has been cancelled, and it is not supported in SDK >= 41, but you can keep using it for SDK <= 40 projects until January 4, 2023**. We are working on a more flexible and portable development client library. You can read more about this in the ["Expo managed workflow in 2021" blog posts](https://blog.expo.dev/expo-managed-workflow-in-2021-5b887bbf7dbb).
 
 Build and install a custom version of [Expo Go](../get-started/installation.md#2-mobile-app-expo-client-for-ios) with your own Apple Credentials using our build service. This custom version of the Expo Go app contains features that were previously only available on the Android versions. Our build service will prepare your custom Expo Go app, and you can install it to your iOS device directly from our website.
 

--- a/docs/pages/classic/building-standalone-apps.md
+++ b/docs/pages/classic/building-standalone-apps.md
@@ -2,7 +2,9 @@
 title: Building Standalone Apps
 ---
 
-> 🆕 [Try creating your build with EAS Build](/build/setup.md), our new and improved build service.
+> 🆕 [Try creating your build with EAS Build](/build/setup.md), the modern build service with support for custom native code and smaller app archives.
+
+> ⚠️ [The Classic Build service (`expo build:{android,ios}`) is in maintenance mode](https://blog.expo.dev/turtle-goes-out-to-sea-d334db2a6b60) and has been superseded by [EAS Build](/build/setup.md). SDK 46 will be the last SDK supported by Classic Builds and the Classic Build service will stop running for all SDK versions after January 4, 2023.
 
 The purpose of this guide is to help you create standalone binaries of your Expo app for iOS and
 Android which can be submitted to the Apple App Store and Google Play Store.

--- a/docs/pages/expokit/eject.md
+++ b/docs/pages/expokit/eject.md
@@ -2,7 +2,7 @@
 title: Ejecting to ExpoKit
 ---
 
-> **ExpoKit is deprecated and will no longer be supported after SDK 38. If you need to make customizations to your Expo project, we recommend using the [bare workflow](../workflow/customizing.md) instead.**
+> 🚫 ExpoKit is deprecated and is no longer supported after SDK 38. If you need to make customizations to your Expo project, we recommend using the [bare workflow](../workflow/customizing.md) instead.
 
 ExpoKit is an Objective-C and Java library that allows you to use the Expo platform and your existing Expo project as part of a larger standard native project -- one that you would normally create using Xcode, Android Studio, or `react-native init`.
 

--- a/docs/pages/expokit/expokit.md
+++ b/docs/pages/expokit/expokit.md
@@ -2,7 +2,7 @@
 title: Developing With ExpoKit
 ---
 
-> **ExpoKit is deprecated and will no longer be supported after SDK 38. If you need to make customizations to your Expo project, we recommend using the [bare workflow](../workflow/customizing.md) instead.**
+> 🚫 ExpoKit is deprecated and is no longer supported after SDK 38. If you need to make customizations to your Expo project, we recommend using the [bare workflow](../workflow/customizing.md) instead.
 
 ExpoKit is an Objective-C and Java library that allows you to use the Expo platform with a
 native iOS/Android project.

--- a/docs/pages/expokit/overview.md
+++ b/docs/pages/expokit/overview.md
@@ -2,11 +2,11 @@
 title: Overview
 ---
 
-> **ExpoKit is deprecated and will no longer be supported after SDK 38. If you need to make customizations to your Expo project, we recommend using the [bare workflow](../workflow/customizing.md) instead.**
+> 🚫 ExpoKit is deprecated and is no longer supported after SDK 38. If you need to make customizations to your Expo project, we recommend using the [bare workflow](../workflow/customizing.md) instead.**
 
 ExpoKit is an Objective-C and Java library that allows you to use the Expo platform and your existing Expo project as part of a larger standard native project -- one that you would normally create using Xcode, Android Studio, or `react-native init`.
 
-Because Expo already provides the ability to [render native binaries for the App Store](../distribution/building-standalone-apps.md), most Expo developers do not need to use ExpoKit. In some cases, projects need to make use of third-party Objective-C or Java native code that is not included in the core Expo SDK. ExpoKit provides this ability.
+Because Expo already provides the ability to [build native binaries for the App Store](../distribution/building-standalone-apps.md), most Expo developers do not need to use ExpoKit. In some cases, projects need to make use of third-party Objective-C or Java native code that is not included in the core Expo SDK. ExpoKit provides this ability.
 
 This documentation will discuss:
 

--- a/docs/pages/expokit/universal-modules-and-expokit.md
+++ b/docs/pages/expokit/universal-modules-and-expokit.md
@@ -2,7 +2,7 @@
 title: Universal Modules and ExpoKit
 ---
 
-> **ExpoKit is deprecated and will no longer be supported after SDK 38. If you need to make customizations to your Expo project, we recommend using the [bare workflow](../workflow/customizing.md) instead.**
+> 🚫 ExpoKit is deprecated and is no longer supported after SDK 38. If you need to make customizations to your Expo project, we recommend using the [bare workflow](../workflow/customizing.md) instead.
 
 Universal Modules are pieces of the Expo SDK with some special properties:
 

--- a/docs/pages/workflow/glossary-of-terms.md
+++ b/docs/pages/workflow/glossary-of-terms.md
@@ -27,7 +27,7 @@ The command-line tool for working with EAS. <!-- Pending creation of eas-cli [Re
 The term "eject" was popularized by [create-react-app](https://github.com/facebookincubator/create-react-app), and it is used in Expo to describe leaving the cozy comfort of the standard Expo development environment, where you do not have to deal with build configuration or native code. When you "eject" from Expo, you have two choices:
 
 - _Eject to bare workflow_, where you jump between [workflows](../introduction/managed-vs-bare.md) and move into the bare workflow, where you can continue to use Expo APIs but have access and full control over your native iOS and Android projects.
-- _Eject to ExpoKit_, where you get the native projects along with [ExpoKit](#expokit). This option is deprecated and support for ExpoKit will be removed after SDK 38. We recommend ejecting to the bare workflow instead.
+- _Eject to ExpoKit_, where you get the native projects along with [ExpoKit](#expokit). This option is deprecated and support for ExpoKit was removed after SDK 38.
 
 ### Emulator
 
@@ -61,7 +61,7 @@ The Expo SDK provides access to device/system functionality such as camera, push
 
 ExpoKit is an Objective-C and Java library that allows you to use the [Expo SDK](#expo-sdk) and platform and your existing Expo project as part of a larger standard native project — one that you would normally create using Xcode, Android Studio, or `react-native init`. [Read more](../expokit/eject.md).
 
-**ExpoKit is deprecated and support for ExpoKit will be removed after SDK 38. We recommend ejecting to the bare workflow instead.**
+**Support for ExpoKit ended after SDK 38. Expo modules can implement support for custom native configuration, and projects that need even more custom native code can [expose their Android Studio and Xcode projects with `expo prebuild`](/workflow/customizing/).**
 
 ### iOS
 

--- a/docs/pages/workflow/upgrading-expo-sdk-walkthrough.md
+++ b/docs/pages/workflow/upgrading-expo-sdk-walkthrough.md
@@ -6,7 +6,7 @@ If you are a couple of versions behind, upgrading your projects Expo SDK version
 
 Expo maintains ~6 months of backwards compatibility. Once an SDK version has been deprecated, you will no longer be able to use the Expo Go app for development or build new binaries via `expo build`. You will still be able to publish updates via `expo publish`, and build using `eas build`, however. Deprecations **will not** affect standalone apps you have in production.
 
-> **Note**: If you are running ExpoKit inside a native project, upgrading will require extra steps. ExpoKit is deprecated and will no longer be supported after SDK 38. We recommend [migrating existing ExpoKit projects to the bare workflow](../bare/migrating-from-expokit.md).
+> **Note**: If you are running ExpoKit inside a native project, upgrading will require extra steps. ExpoKit is deprecated and is no longer supported after SDK 38. We recommend [migrating existing ExpoKit projects to the bare workflow](../bare/migrating-from-expokit.md).
 
 ## SDK 44
 


### PR DESCRIPTION
# Why

Re-share the announcement that expo build will support up to and including SDK 46 and will stop on Jan 4, 2023. Also updated some ExpoKit deprecation messages. Also made clear old ad-hoc Expo Go (which uses the expo build infra) will go away on Jan 4.

# Test Plan

yarn && yarn dev -> browse docs http://localhost:3002/classic/building-standalone-apps/