### PR TITLE
[cli][start] Added persisted project state modules

### DIFF
--- a/packages/expo/cli/start/project/ProjectDevices.ts
+++ b/packages/expo/cli/start/project/ProjectDevices.ts
@@ -1,0 +1,96 @@
+import { createTemporaryProjectFile } from './dotExpo';
+
+export type DeviceInfo = {
+  installationId: string;
+  lastUsed: number;
+};
+
+export type DevicesInfo = {
+  devices: DeviceInfo[];
+};
+
+const DEVICES_FILE_NAME = 'devices.json';
+
+const MILLISECONDS_IN_30_DAYS = 30 * 24 * 60 * 60 * 1000;
+
+export const DevicesFile = createTemporaryProjectFile<DevicesInfo>(DEVICES_FILE_NAME, {
+  devices: [],
+});
+
+let devicesInfo: DevicesInfo | null = null;
+
+export async function getDevicesInfoAsync(projectRoot: string): Promise<DevicesInfo> {
+  if (devicesInfo) {
+    return devicesInfo;
+  }
+  return readDevicesInfoAsync(projectRoot);
+}
+
+export async function readDevicesInfoAsync(projectRoot: string): Promise<DevicesInfo> {
+  try {
+    devicesInfo = await DevicesFile.readAsync(projectRoot);
+
+    // if the file on disk has old devices, filter them out here before we use them
+    const filteredDevices = filterOldDevices(devicesInfo.devices);
+    if (filteredDevices.length < devicesInfo.devices.length) {
+      devicesInfo = {
+        ...devicesInfo,
+        devices: filteredDevices,
+      };
+      // save the newly filtered list for consistency
+      try {
+        await setDevicesInfoAsync(projectRoot, devicesInfo);
+      } catch {
+        // do nothing here, we'll just keep using the filtered list in memory for now
+      }
+    }
+
+    return devicesInfo;
+  } catch {
+    return await DevicesFile.setAsync(origin, { devices: [] });
+  }
+}
+
+export async function setDevicesInfoAsync(
+  projectRoot: string,
+  json: DevicesInfo
+): Promise<DevicesInfo> {
+  devicesInfo = json;
+  return await DevicesFile.setAsync(projectRoot, json);
+}
+
+export async function saveDevicesAsync(
+  projectRoot: string,
+  deviceIds: string | string[]
+): Promise<void> {
+  const currentTime = new Date().getTime();
+  const newDeviceIds = typeof deviceIds === 'string' ? [deviceIds] : deviceIds;
+
+  const { devices } = await getDevicesInfoAsync(projectRoot);
+  const newDevicesJson = devices
+    .filter((device) => {
+      if (newDeviceIds.includes(device.installationId)) {
+        return false;
+      }
+      return true;
+    })
+    .concat(newDeviceIds.map((deviceId) => ({ installationId: deviceId, lastUsed: currentTime })));
+  await setDevicesInfoAsync(projectRoot, { devices: filterOldDevices(newDevicesJson) });
+}
+
+function filterOldDevices(devices: DeviceInfo[]) {
+  const currentTime = new Date().getTime();
+  return (
+    devices
+      .filter((device) => {
+        // filter out any devices that haven't been used to open this project in 30 days
+        if (currentTime - device.lastUsed > MILLISECONDS_IN_30_DAYS) {
+          return false;
+        }
+        return true;
+      })
+      // keep only the 10 most recently used devices
+      .sort((a, b) => b.lastUsed - a.lastUsed)
+      .slice(0, 10)
+  );
+}

--- a/packages/expo/cli/start/project/ProjectDevices.ts
+++ b/packages/expo/cli/start/project/ProjectDevices.ts
@@ -63,32 +63,22 @@ export async function saveDevicesAsync(
   projectRoot: string,
   deviceIds: string | string[]
 ): Promise<void> {
-  const currentTime = new Date().getTime();
+  const currentTime = Date.now();
   const newDeviceIds = typeof deviceIds === 'string' ? [deviceIds] : deviceIds;
 
   const { devices } = await getDevicesInfoAsync(projectRoot);
   const newDevicesJson = devices
-    .filter((device) => {
-      if (newDeviceIds.includes(device.installationId)) {
-        return false;
-      }
-      return true;
-    })
+    .filter((device) => !newDeviceIds.includes(device.installationId))
     .concat(newDeviceIds.map((deviceId) => ({ installationId: deviceId, lastUsed: currentTime })));
   await setDevicesInfoAsync(projectRoot, { devices: filterOldDevices(newDevicesJson) });
 }
 
 function filterOldDevices(devices: DeviceInfo[]) {
-  const currentTime = new Date().getTime();
+  const currentTime = Date.now();
   return (
     devices
-      .filter((device) => {
-        // filter out any devices that haven't been used to open this project in 30 days
-        if (currentTime - device.lastUsed > MILLISECONDS_IN_30_DAYS) {
-          return false;
-        }
-        return true;
-      })
+      // filter out any devices that haven't been used to open this project in 30 days
+      .filter((device) => currentTime - device.lastUsed <= MILLISECONDS_IN_30_DAYS)
       // keep only the 10 most recently used devices
       .sort((a, b) => b.lastUsed - a.lastUsed)
       .slice(0, 10)

--- a/packages/expo/cli/start/project/ProjectSettings.ts
+++ b/packages/expo/cli/start/project/ProjectSettings.ts
@@ -1,0 +1,9 @@
+import { createTemporaryProjectFile } from './dotExpo';
+
+const SETTINGS_FILE_NAME = 'settings.json';
+
+export const ProjectSettings = createTemporaryProjectFile<{
+  urlRandomness: string | null;
+}>(SETTINGS_FILE_NAME, {
+  urlRandomness: null,
+});

--- a/packages/expo/cli/start/project/__tests__/ProjectDevices-test.ts
+++ b/packages/expo/cli/start/project/__tests__/ProjectDevices-test.ts
@@ -1,0 +1,98 @@
+import fs from 'fs-extra';
+import path from 'path';
+
+import * as ProjectDevices from '../ProjectDevices';
+
+describe('devices info', () => {
+  let projectRoot: string;
+
+  beforeAll(() => {
+    projectRoot = path.join('/', 'tmp', 'xdl-project-settings');
+  });
+
+  afterEach(async () => {
+    await ProjectDevices.setDevicesInfoAsync(projectRoot, { devices: [] });
+  });
+
+  afterAll(() => {
+    if (projectRoot) {
+      fs.removeSync(projectRoot);
+    }
+  });
+
+  it('should persist device info to disk', async () => {
+    await ProjectDevices.saveDevicesAsync(projectRoot, 'test-device-id');
+
+    const file = path.join(projectRoot, '.expo', 'devices.json');
+    expect(fs.existsSync(file)).toBe(true);
+
+    const { devices } = JSON.parse(fs.readFileSync(file, 'utf8'));
+    expect(devices.length).toBe(1);
+    expect(devices[0].installationId).toBe('test-device-id');
+  });
+
+  it('should save an array of devices', async () => {
+    await ProjectDevices.saveDevicesAsync(projectRoot, ['device-id-1', 'device-id-2']);
+    const { devices } = await ProjectDevices.getDevicesInfoAsync(projectRoot);
+    expect(devices.length).toBe(2);
+    expect(devices.some((device) => device.installationId === 'device-id-1')).toBe(true);
+    expect(devices.some((device) => device.installationId === 'device-id-2')).toBe(true);
+  });
+
+  it('should save at most 10 devices', async () => {
+    const deviceIds = [];
+    for (let i = 0; i < 11; i++) {
+      deviceIds.push(`device-id-${i}`);
+    }
+    await ProjectDevices.saveDevicesAsync(projectRoot, deviceIds);
+    const { devices } = await ProjectDevices.getDevicesInfoAsync(projectRoot);
+    expect(devices.length).toBe(10);
+  });
+
+  it('should remove older devices if the total number exceeds 10', async () => {
+    const currentTime = new Date().getTime();
+    const earlierTime = currentTime - 10;
+    const earliestTime = currentTime - 20;
+
+    const devicesInfo = [{ installationId: 'oldest-device', lastUsed: earliestTime }];
+    for (let i = 0; i < 9; i++) {
+      devicesInfo.push({ installationId: `device-id-${i}`, lastUsed: earlierTime });
+    }
+    await ProjectDevices.setDevicesInfoAsync(projectRoot, {
+      devices: devicesInfo,
+    });
+
+    await ProjectDevices.saveDevicesAsync(projectRoot, 'newest-device');
+    const { devices } = await ProjectDevices.getDevicesInfoAsync(projectRoot);
+    expect(devices.length).toBe(10);
+    expect(devices[0].installationId).toBe('newest-device');
+    expect(devices.some((device) => device.installationId === 'oldest-device')).toBe(false);
+  });
+
+  it('should remove any devices last used before 30 days ago', async () => {
+    const currentTime = new Date().getTime();
+    const time30DaysAnd1SecondAgo = currentTime - 30 * 24 * 60 * 60 * 1000 - 1000;
+    await ProjectDevices.setDevicesInfoAsync(projectRoot, {
+      devices: [{ installationId: 'very-old-device-id', lastUsed: time30DaysAnd1SecondAgo }],
+    });
+    await ProjectDevices.saveDevicesAsync(projectRoot, 'new-device-id');
+    const { devices } = await ProjectDevices.getDevicesInfoAsync(projectRoot);
+    expect(devices.length).toBe(1);
+    expect(devices[0].installationId).toBe('new-device-id');
+  });
+
+  it('should remove old devices when reading for the first time from disk', async () => {
+    const currentTime = new Date().getTime();
+    const time30DaysAnd1SecondAgo = currentTime - 30 * 24 * 60 * 60 * 1000 - 1000;
+    await ProjectDevices.setDevicesInfoAsync(projectRoot, {
+      devices: [
+        { installationId: 'very-old-device-id', lastUsed: time30DaysAnd1SecondAgo },
+        { installationId: 'new-device-id', lastUsed: currentTime },
+      ],
+    });
+    // use readDeviceInfoAsync to bypass memoized devices and read from disk
+    const { devices } = await ProjectDevices.readDevicesInfoAsync(projectRoot);
+    expect(devices.length).toBe(1);
+    expect(devices[0].installationId).toBe('new-device-id');
+  });
+});

--- a/packages/expo/cli/start/project/__tests__/ProjectDevices-test.ts
+++ b/packages/expo/cli/start/project/__tests__/ProjectDevices-test.ts
@@ -1,4 +1,4 @@
-import fs from 'fs-extra';
+import { fs } from 'memfs';
 import path from 'path';
 
 import * as ProjectDevices from '../ProjectDevices';
@@ -16,7 +16,7 @@ describe('devices info', () => {
 
   afterAll(() => {
     if (projectRoot) {
-      fs.removeSync(projectRoot);
+      fs.rmdirSync(projectRoot);
     }
   });
 
@@ -26,7 +26,7 @@ describe('devices info', () => {
     const file = path.join(projectRoot, '.expo', 'devices.json');
     expect(fs.existsSync(file)).toBe(true);
 
-    const { devices } = JSON.parse(fs.readFileSync(file, 'utf8'));
+    const { devices } = JSON.parse(fs.readFileSync(file, 'utf8').toString());
     expect(devices.length).toBe(1);
     expect(devices[0].installationId).toBe('test-device-id');
   });

--- a/packages/expo/cli/start/project/__tests__/dotExpo-test.ts
+++ b/packages/expo/cli/start/project/__tests__/dotExpo-test.ts
@@ -1,0 +1,38 @@
+import { vol } from 'memfs';
+
+import { createTemporaryProjectFile } from '../dotExpo';
+
+beforeEach(() => {
+  vol.reset();
+});
+
+describe(createTemporaryProjectFile, () => {
+  it(`creates persisted file`, async () => {
+    const projectRoot = '/';
+
+    const creator = createTemporaryProjectFile<{ foo: string; baz?: boolean }>('foo.json', {
+      foo: 'bar',
+    });
+
+    // Ensure instantiation doesn't have side-effects.
+    expect(vol.toJSON()).toEqual({});
+
+    // This has side-effects that ensure the directory.
+    const file = creator.getFile(projectRoot);
+
+    // README is bootstrapped.
+    expect(vol.readFileSync('/.expo/README.md', 'utf8')).toMatch(/Why do I have a folder named/);
+
+    // File is not automatically written...
+    await expect(file.getAsync('foo', null)).rejects.toThrowError(/ENOENT/);
+
+    // Matches defaults and doesn't fail when the file doesn't exist.
+    expect(await creator.readAsync(projectRoot)).toEqual({ foo: 'bar' });
+
+    // Modify the file.
+    await creator.setAsync(projectRoot, { foo: 'baz', baz: true });
+
+    // Persisted changes are reflected in the file.
+    expect(await creator.readAsync(projectRoot)).toEqual({ foo: 'baz', baz: true });
+  });
+});

--- a/packages/expo/cli/start/project/dotExpo.ts
+++ b/packages/expo/cli/start/project/dotExpo.ts
@@ -1,5 +1,5 @@
 import JsonFile, { JSONObject } from '@expo/json-file';
-import fs from 'fs-extra';
+import fs from 'fs';
 import path from 'path';
 
 /** Create a set of functions for managing a file in the project's `.expo` directory. */
@@ -46,7 +46,7 @@ function getDotExpoProjectDirectory(projectRoot: string): string {
 
 function ensureDotExpoProjectDirectoryInitialized(projectRoot: string): string {
   const dirPath = getDotExpoProjectDirectory(projectRoot);
-  fs.ensureDirSync(dirPath);
+  fs.mkdirSync(dirPath, { recursive: true });
 
   const readmeFilePath = path.resolve(dirPath, 'README.md');
   if (!fs.existsSync(readmeFilePath)) {

--- a/packages/expo/cli/start/project/dotExpo.ts
+++ b/packages/expo/cli/start/project/dotExpo.ts
@@ -1,5 +1,5 @@
 import JsonFile, { JSONObject } from '@expo/json-file';
-import fs, { ensureDirSync } from 'fs-extra';
+import fs from 'fs-extra';
 import path from 'path';
 
 /** Create a set of functions for managing a file in the project's `.expo` directory. */
@@ -13,7 +13,7 @@ export function createTemporaryProjectFile<T extends JSONObject>(fileName: strin
     let projectSettings;
     try {
       projectSettings = await getFile(projectRoot).readAsync();
-    } catch (e) {
+    } catch {
       projectSettings = await getFile(projectRoot).writeAsync(defaults);
     }
     // Set defaults for any missing fields
@@ -25,7 +25,7 @@ export function createTemporaryProjectFile<T extends JSONObject>(fileName: strin
       return await getFile(projectRoot).mergeAsync(json, {
         cantReadFileDefault: defaults,
       });
-    } catch (e) {
+    } catch {
       return await getFile(projectRoot).writeAsync({
         ...defaults,
         ...json,
@@ -46,7 +46,7 @@ function getDotExpoProjectDirectory(projectRoot: string): string {
 
 function ensureDotExpoProjectDirectoryInitialized(projectRoot: string): string {
   const dirPath = getDotExpoProjectDirectory(projectRoot);
-  ensureDirSync(dirPath);
+  fs.ensureDirSync(dirPath);
 
   const readmeFilePath = path.resolve(dirPath, 'README.md');
   if (!fs.existsSync(readmeFilePath)) {

--- a/packages/expo/cli/start/project/dotExpo.ts
+++ b/packages/expo/cli/start/project/dotExpo.ts
@@ -1,0 +1,67 @@
+import JsonFile, { JSONObject } from '@expo/json-file';
+import fs, { ensureDirSync } from 'fs-extra';
+import path from 'path';
+
+/** Create a set of functions for managing a file in the project's `.expo` directory. */
+export function createTemporaryProjectFile<T extends JSONObject>(fileName: string, defaults: T) {
+  function getFile(projectRoot: string): JsonFile<T> {
+    const dotExpoDir = ensureDotExpoProjectDirectoryInitialized(projectRoot);
+    return new JsonFile<T>(path.join(dotExpoDir, fileName));
+  }
+
+  async function readAsync(projectRoot: string): Promise<T> {
+    let projectSettings;
+    try {
+      projectSettings = await getFile(projectRoot).readAsync();
+    } catch (e) {
+      projectSettings = await getFile(projectRoot).writeAsync(defaults);
+    }
+    // Set defaults for any missing fields
+    return { ...defaults, ...projectSettings };
+  }
+
+  async function setAsync(projectRoot: string, json: Partial<T>): Promise<T> {
+    try {
+      return await getFile(projectRoot).mergeAsync(json, {
+        cantReadFileDefault: defaults,
+      });
+    } catch (e) {
+      return await getFile(projectRoot).writeAsync({
+        ...defaults,
+        ...json,
+      });
+    }
+  }
+
+  return {
+    getFile,
+    readAsync,
+    setAsync,
+  };
+}
+
+function getDotExpoProjectDirectory(projectRoot: string): string {
+  return path.join(projectRoot, '.expo');
+}
+
+function ensureDotExpoProjectDirectoryInitialized(projectRoot: string): string {
+  const dirPath = getDotExpoProjectDirectory(projectRoot);
+  ensureDirSync(dirPath);
+
+  const readmeFilePath = path.resolve(dirPath, 'README.md');
+  if (!fs.existsSync(readmeFilePath)) {
+    fs.writeFileSync(
+      readmeFilePath,
+      `> Why do I have a folder named ".expo" in my project?
+The ".expo" folder is created when an Expo project is started using "expo start" command.
+> What do the files contain?
+- "devices.json": contains information about devices that have recently opened this project. This is used to populate the "Development sessions" list in your development builds.
+- "settings.json": contains the server configuration that is used to serve the application manifest.
+> Should I commit the ".expo" folder?
+No, you should not share the ".expo" folder. It does not contain any information that is relevant for other developers working on the project, it is specific to your machine.
+Upon project creation, the ".expo" folder is already added to your ".gitignore" file.
+`
+    );
+  }
+  return dirPath;
+}


### PR DESCRIPTION
# Why

- Pulls in persistent settings code from https://github.com/expo/expo/pull/16160 to make review easier.
- Persistent modules are used for storing recent devices and the tunnel randomness used with ngrok.
- There is currently no mechanism for running this code outside of the comprehensive testing.

# Test Plan

- comprehensive unit tests, can also checkout https://github.com/expo/expo/pull/16160 and run the initial version there.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
