### PR TITLE
[cli] Disable extra tests that are unrelated to the CLI

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -5,12 +5,12 @@ on:
     branches: [main, 'sdk-*']
     paths:
       - .github/workflows/cli.yml
-      - packages/**
+      - packages/expo/**
       - yarn.lock
   pull_request:
     paths:
       - .github/workflows/cli.yml
-      - packages/**
+      - packages/expo/**
       - yarn.lock
   schedule:
     - cron: 0 14 * * *

--- a/.github/workflows/native-component-list.yml
+++ b/.github/workflows/native-component-list.yml
@@ -8,6 +8,10 @@ on:
       - apps/native-component-list/**
       - packages/**
       - yarn.lock
+      # Ignore Expo CLI for now...
+      - !packages/expo/cli/**
+      - !packages/expo/bin/**
+      - !packages/expo/e2e/**
   push:
     branches: [main]
     paths:
@@ -15,6 +19,10 @@ on:
       - apps/native-component-list/**
       - packages/**
       - yarn.lock
+      # Ignore Expo CLI for now...
+      - !packages/expo/cli/**
+      - !packages/expo/bin/**
+      - !packages/expo/e2e/**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}

--- a/.github/workflows/native-component-list.yml
+++ b/.github/workflows/native-component-list.yml
@@ -8,10 +8,11 @@ on:
       - apps/native-component-list/**
       - packages/**
       - yarn.lock
+    paths-ignore:
       # Ignore Expo CLI for now...
-      - !packages/expo/cli/**
-      - !packages/expo/bin/**
-      - !packages/expo/e2e/**
+      - packages/expo/cli/**
+      - packages/expo/bin/**
+      - packages/expo/e2e/**
   push:
     branches: [main]
     paths:
@@ -19,10 +20,11 @@ on:
       - apps/native-component-list/**
       - packages/**
       - yarn.lock
+    paths-ignore:
       # Ignore Expo CLI for now...
-      - !packages/expo/cli/**
-      - !packages/expo/bin/**
-      - !packages/expo/e2e/**
+      - packages/expo/cli/**
+      - packages/expo/bin/**
+      - packages/expo/e2e/**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}

--- a/.github/workflows/publish-demo.yml
+++ b/.github/workflows/publish-demo.yml
@@ -9,10 +9,11 @@ on:
       - yarn.lock
       - apps/**
       - packages/**
+    paths-ignore:
       # Ignore Expo CLI for now...
-      - !packages/expo/cli/**
-      - !packages/expo/bin/**
-      - !packages/expo/e2e/**
+      - packages/expo/cli/**
+      - packages/expo/bin/**
+      - packages/expo/e2e/**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}

--- a/.github/workflows/publish-demo.yml
+++ b/.github/workflows/publish-demo.yml
@@ -9,7 +9,10 @@ on:
       - yarn.lock
       - apps/**
       - packages/**
-
+      # Ignore Expo CLI for now...
+      - !packages/expo/cli/**
+      - !packages/expo/bin/**
+      - !packages/expo/e2e/**
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/publish-demo.yml
+++ b/.github/workflows/publish-demo.yml
@@ -13,6 +13,7 @@ on:
       - !packages/expo/cli/**
       - !packages/expo/bin/**
       - !packages/expo/e2e/**
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -14,20 +14,22 @@ on:
       - tools/**
       - packages/**
       - yarn.lock
+    paths-ignore:
       # Ignore Expo CLI for now...
-      - !packages/expo/cli/**
-      - !packages/expo/bin/**
-      - !packages/expo/e2e/**
+      - packages/expo/cli/**
+      - packages/expo/bin/**
+      - packages/expo/e2e/**
   pull_request:
     paths:
       - .github/workflows/sdk.yml
       - tools/**
       - packages/**
       - yarn.lock
+    paths-ignore:
       # Ignore Expo CLI for now...
-      - !packages/expo/cli/**
-      - !packages/expo/bin/**
-      - !packages/expo/e2e/**
+      - packages/expo/cli/**
+      - packages/expo/bin/**
+      - packages/expo/e2e/**
   schedule:
     - cron: 0 14 * * *
 

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -14,12 +14,20 @@ on:
       - tools/**
       - packages/**
       - yarn.lock
+      # Ignore Expo CLI for now...
+      - !packages/expo/cli/**
+      - !packages/expo/bin/**
+      - !packages/expo/e2e/**
   pull_request:
     paths:
       - .github/workflows/sdk.yml
       - tools/**
       - packages/**
       - yarn.lock
+      # Ignore Expo CLI for now...
+      - !packages/expo/cli/**
+      - !packages/expo/bin/**
+      - !packages/expo/e2e/**
   schedule:
     - cron: 0 14 * * *
 

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -17,10 +17,11 @@ on:
       - apps/test-suite/**
       - packages/**
       - yarn.lock
+    paths-ignore:
       # Ignore Expo CLI for now...
-      - !packages/expo/cli/**
-      - !packages/expo/bin/**
-      - !packages/expo/e2e/**
+      - packages/expo/cli/**
+      - packages/expo/bin/**
+      - packages/expo/e2e/**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -17,6 +17,10 @@ on:
       - apps/test-suite/**
       - packages/**
       - yarn.lock
+      # Ignore Expo CLI for now...
+      - !packages/expo/cli/**
+      - !packages/expo/bin/**
+      - !packages/expo/e2e/**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}


### PR DESCRIPTION
Until we integrate the CLI manually into each CI test.

# Why

Reduce CI time while the CLI is currently unrelated to most tests.

# How

Match against CLI files in the action triggers.
