### PR TITLE
[cli] Created ngrok resolver

### DIFF
--- a/packages/expo/cli/start/doctor/ngrok/ExternalModule.ts
+++ b/packages/expo/cli/start/doctor/ngrok/ExternalModule.ts
@@ -145,11 +145,8 @@ export class ExternalModule<TModule> {
 
   /** Get the module, throws if the module is not versioned correctly. */
   getVersioned(): TModule | null {
-    if (!this.instance) {
-      this.instance = this._resolveModule(true) ?? this._resolveModule(false);
-    }
-
-    return this.instance ?? null;
+    this.instance ??= this._resolveModule(true) ?? this._resolveModule(false);
+    return this.instance;
   }
 
   /** Exposed for testing. */

--- a/packages/expo/cli/start/doctor/ngrok/ExternalModule.ts
+++ b/packages/expo/cli/start/doctor/ngrok/ExternalModule.ts
@@ -11,13 +11,13 @@ import { confirmAsync } from '../../../utils/prompts';
 
 /** An error that is thrown when a package is installed but doesn't meet the version criteria. */
 export class ExternalModuleVersionError extends CommandError {
-  constructor(message: string, public shouldGloballyInstall: boolean) {
+  constructor(message: string, public readonly shouldGloballyInstall: boolean) {
     super('EXTERNAL_MODULE_VERSION', message);
   }
 }
 
 interface PromptOptions {
-  /** Should prompt the user to install, when false the module will just assert on missing packages, default `true` */
+  /** Should prompt the user to install, when false the module will just assert on missing packages, default `true`. Ignored when `autoInstall` is true. */
   shouldPrompt?: boolean;
   /** Should automatically install the package without prompting, default `false` */
   autoInstall?: boolean;
@@ -30,7 +30,7 @@ export interface InstallPromptOptions extends PromptOptions {
 
 export interface ResolvePromptOptions extends PromptOptions {
   /**
-   * Prefer to install the package globally, this can be overwritten if the function
+   * Prefer to install the package globally, this can be overridden if the function
    * detects that a locally installed package simply needs an upgrade, default `false`
    */
   prefersGlobalInstall?: boolean;

--- a/packages/expo/cli/start/doctor/ngrok/ExternalModule.ts
+++ b/packages/expo/cli/start/doctor/ngrok/ExternalModule.ts
@@ -37,8 +37,8 @@ export interface ResolvePromptOptions extends PromptOptions {
 }
 
 /** Resolves a local or globally installed package, prompts to install if missing. */
-export class ExternalModule<IModule> {
-  private instance: IModule | null = null;
+export class ExternalModule<TModule> {
+  private instance: TModule | null = null;
 
   constructor(
     /** Project root for checking if the package is installed locally. */
@@ -58,7 +58,7 @@ export class ExternalModule<IModule> {
   async resolveAsync({
     prefersGlobalInstall,
     ...options
-  }: ResolvePromptOptions = {}): Promise<IModule> {
+  }: ResolvePromptOptions = {}): Promise<TModule> {
     try {
       return (
         this.getVersioned() ??
@@ -85,7 +85,7 @@ export class ExternalModule<IModule> {
     shouldPrompt = true,
     autoInstall,
     shouldGloballyInstall,
-  }: InstallPromptOptions = {}): Promise<IModule> {
+  }: InstallPromptOptions = {}): Promise<TModule> {
     const packageName = [this.pkg.name, this.pkg.versionRange].join('@');
     if (!autoInstall) {
       // Delay the prompt so it doesn't conflict with other dev tool logs
@@ -135,7 +135,7 @@ export class ExternalModule<IModule> {
   }
 
   /** Get the module. */
-  get(): IModule | null {
+  get(): TModule | null {
     try {
       return this.getVersioned();
     } catch {
@@ -144,7 +144,7 @@ export class ExternalModule<IModule> {
   }
 
   /** Get the module, throws if the module is not versioned correctly. */
-  getVersioned(): IModule | null {
+  getVersioned(): TModule | null {
     if (!this.instance) {
       this.instance = this._resolveModule(true) ?? this._resolveModule(false);
     }
@@ -168,7 +168,7 @@ export class ExternalModule<IModule> {
   }
 
   /** Resolve the module and verify the version. Exposed for testing. */
-  _resolveModule(isLocal: boolean): IModule | null {
+  _resolveModule(isLocal: boolean): TModule | null {
     const resolver = isLocal ? this._resolveLocal : this._resolveGlobal;
     try {
       const packageJsonPath = resolver(`${this.pkg.name}/package.json`);

--- a/packages/expo/cli/start/doctor/ngrok/ExternalModule.ts
+++ b/packages/expo/cli/start/doctor/ngrok/ExternalModule.ts
@@ -10,34 +10,48 @@ import { EXPO_DEBUG } from '../../../utils/env';
 import { CommandError } from '../../../utils/errors';
 import { confirmAsync } from '../../../utils/prompts';
 
+/** An error that is thrown when a package is installed but doesn't meet the version criteria. */
 export class ExternalModuleVersionError extends CommandError {
   constructor(message: string, public shouldGloballyInstall: boolean) {
     super('EXTERNAL_MODULE_VERSION', message);
   }
 }
 
-export type InstallPromptOptions = {
+interface PromptOptions {
   /** Should prompt the user to install, when false the module will just assert on missing packages, default `true` */
   shouldPrompt?: boolean;
   /** Should automatically install the package without prompting, default `false` */
   autoInstall?: boolean;
+}
+
+export interface InstallPromptOptions extends PromptOptions {
   /** Should install the package globally, default `false` */
   shouldGloballyInstall?: boolean;
-};
-export type ResolvePromptOptions = Omit<InstallPromptOptions, 'shouldGloballyInstall'> & {
+}
+
+export interface ResolvePromptOptions extends PromptOptions {
   /**
    * Prefer to install the package globally, this can be overwritten if the function
-   * detects that a locally installed package simply needs an upgrade, default `false` */
+   * detects that a locally installed package simply needs an upgrade, default `false`
+   */
   prefersGlobalInstall?: boolean;
-};
+}
 
 /** Resolves a local or globally installed package, prompts to install if missing. */
 export class ExternalModule<IModule> {
   private instance: IModule | null = null;
 
   constructor(
+    /** Project root for checking if the package is installed locally. */
     private projectRoot: string,
-    private pkg: { name: string; versionRange: string },
+    /** Info on the external package. */
+    private pkg: {
+      /** NPM package name. */
+      name: string;
+      /** Required semver range, ex: `^1.0.0`. */
+      versionRange: string;
+    },
+    /** A function used to create the installation prompt message. */
     private promptMessage: (pkgName: string) => string
   ) {}
 

--- a/packages/expo/cli/start/doctor/ngrok/ExternalModule.ts
+++ b/packages/expo/cli/start/doctor/ngrok/ExternalModule.ts
@@ -176,7 +176,14 @@ export class ExternalModule<TModule> {
       if (packageJson) {
         if (semver.satisfies(packageJson.version, this.pkg.versionRange)) {
           const modulePath = resolver(this.pkg.name);
-          return this._require(modulePath);
+          const requiredModule = this._require(modulePath);
+          if (requiredModule == null) {
+            throw new CommandError(
+              'EXTERNAL_MODULE_EXPORT',
+              `${this.pkg.name} exports a nullish value, which is not allowed.`
+            );
+          }
+          return requiredModule;
         }
         throw new ExternalModuleVersionError(
           `Required module '${this.pkg.name}@${packageJson.version}' does not satisfy ${this.pkg.versionRange}. Installed at: ${packageJsonPath}`,
@@ -184,7 +191,7 @@ export class ExternalModule<TModule> {
         );
       }
     } catch (e) {
-      if (e instanceof ExternalModuleVersionError) {
+      if (e instanceof CommandError) {
         throw e;
       }
       Log.debug('[External Module] Failed to resolve module', e);

--- a/packages/expo/cli/start/doctor/ngrok/ExternalModule.ts
+++ b/packages/expo/cli/start/doctor/ngrok/ExternalModule.ts
@@ -1,0 +1,181 @@
+import * as PackageManager from '@expo/package-manager';
+import chalk from 'chalk';
+import requireGlobal from 'requireg';
+import resolveFrom from 'resolve-from';
+import semver from 'semver';
+
+import * as Log from '../../../log';
+import { delayAsync } from '../../../utils/delay';
+import { EXPO_DEBUG } from '../../../utils/env';
+import { CommandError } from '../../../utils/errors';
+import { confirmAsync } from '../../../utils/prompts';
+
+export class ExternalModuleVersionError extends CommandError {
+  constructor(message: string, public shouldGloballyInstall: boolean) {
+    super('EXTERNAL_MODULE_VERSION', message);
+  }
+}
+
+export type InstallPromptOptions = {
+  /** Should prompt the user to install, when false the module will just assert on missing packages, default `true` */
+  shouldPrompt?: boolean;
+  /** Should automatically install the package without prompting, default `false` */
+  autoInstall?: boolean;
+  /** Should install the package globally, default `false` */
+  shouldGloballyInstall?: boolean;
+};
+export type ResolvePromptOptions = Omit<InstallPromptOptions, 'shouldGloballyInstall'> & {
+  /**
+   * Prefer to install the package globally, this can be overwritten if the function
+   * detects that a locally installed package simply needs an upgrade, default `false` */
+  prefersGlobalInstall?: boolean;
+};
+
+/** Resolves a local or globally installed package, prompts to install if missing. */
+export class ExternalModule<IModule> {
+  private instance: IModule | null = null;
+
+  constructor(
+    private projectRoot: string,
+    private pkg: { name: string; versionRange: string },
+    private promptMessage: (pkgName: string) => string
+  ) {}
+
+  /** Resolve the globally or locally installed instance, or prompt to install. */
+  async resolveAsync({
+    prefersGlobalInstall,
+    ...options
+  }: ResolvePromptOptions = {}): Promise<IModule> {
+    try {
+      return (
+        this.getVersioned() ??
+        this.installAsync({
+          ...options,
+          shouldGloballyInstall: prefersGlobalInstall,
+        })
+      );
+    } catch (error: any) {
+      if (error instanceof ExternalModuleVersionError) {
+        // If the module version in not compliant with the version range,
+        // we should prompt the user to install the package where it already exists.
+        return this.installAsync({
+          ...options,
+          shouldGloballyInstall: error.shouldGloballyInstall ?? prefersGlobalInstall,
+        });
+      }
+      throw error;
+    }
+  }
+
+  /** Prompt the user to install the package and try again. */
+  async installAsync({
+    shouldPrompt = true,
+    autoInstall,
+    shouldGloballyInstall,
+  }: InstallPromptOptions = {}): Promise<IModule> {
+    const packageName = [this.pkg.name, this.pkg.versionRange].join('@');
+    if (!autoInstall) {
+      // Delay the prompt so it doesn't conflict with other dev tool logs
+      await delayAsync(100);
+    }
+    const answer =
+      autoInstall ||
+      (shouldPrompt &&
+        (await confirmAsync({
+          message: this.promptMessage(packageName),
+          initial: true,
+        })));
+    if (answer) {
+      Log.log(chalk`Installing ${packageName}...`);
+
+      // Always use npm for global installs
+      const packageManager = shouldGloballyInstall
+        ? new PackageManager.NpmPackageManager({
+            cwd: this.projectRoot,
+            log: Log.log,
+            silent: !EXPO_DEBUG,
+          })
+        : PackageManager.createForProject(this.projectRoot, {
+            silent: !EXPO_DEBUG,
+          });
+
+      try {
+        if (shouldGloballyInstall) {
+          await packageManager.addGlobalAsync(packageName);
+        } else {
+          await packageManager.addDevAsync(packageName);
+        }
+        Log.log(`Installed ${packageName}`);
+      } catch (e) {
+        e.message = `Failed to install ${packageName} ${
+          shouldGloballyInstall ? 'globally' : 'locally'
+        }: ${e.message}`;
+        throw e;
+      }
+      return await this.resolveAsync({ shouldPrompt: false });
+    }
+
+    throw new CommandError(
+      'EXTERNAL_MODULE_AVAILABILITY',
+      `Please install ${packageName} and try again`
+    );
+  }
+
+  /** Get the module. */
+  get(): IModule | null {
+    try {
+      return this.getVersioned();
+    } catch {
+      return null;
+    }
+  }
+
+  /** Get the module, throws if the module is not versioned correctly. */
+  getVersioned(): IModule | null {
+    if (!this.instance) {
+      this.instance = this._resolveModule(true) ?? this._resolveModule(false);
+    }
+
+    return this.instance ?? null;
+  }
+
+  /** Exposed for testing. */
+  _require(moduleId: string): any {
+    return require(moduleId);
+  }
+
+  /** Resolve a copy that's installed in the project. Exposed for testing. */
+  _resolveLocal(moduleId: string): string {
+    return resolveFrom(this.projectRoot, moduleId);
+  }
+
+  /** Resolve a copy that's installed globally. Exposed for testing. */
+  _resolveGlobal(moduleId: string): string {
+    return requireGlobal.resolve(moduleId);
+  }
+
+  /** Resolve the module and verify the version. Exposed for testing. */
+  _resolveModule(isLocal: boolean): IModule | null {
+    const resolver = isLocal ? this._resolveLocal : this._resolveGlobal;
+    try {
+      const packageJsonPath = resolver(`${this.pkg.name}/package.json`);
+      const packageJson = this._require(packageJsonPath);
+      if (packageJson) {
+        if (semver.satisfies(packageJson.version, this.pkg.versionRange)) {
+          const modulePath = resolver(this.pkg.name);
+          return this._require(modulePath);
+        }
+        throw new ExternalModuleVersionError(
+          `Required module '${this.pkg.name}@${packageJson.version}' does not satisfy ${this.pkg.versionRange}. Installed at: ${packageJsonPath}`,
+          !isLocal
+        );
+      }
+    } catch (e) {
+      if (e instanceof ExternalModuleVersionError) {
+        throw e;
+      }
+      Log.debug('[External Module] Failed to resolve module', e);
+      return null;
+    }
+  }
+}

--- a/packages/expo/cli/start/doctor/ngrok/ExternalModule.ts
+++ b/packages/expo/cli/start/doctor/ngrok/ExternalModule.ts
@@ -1,5 +1,4 @@
 import * as PackageManager from '@expo/package-manager';
-import chalk from 'chalk';
 import requireGlobal from 'requireg';
 import resolveFrom from 'resolve-from';
 import semver from 'semver';
@@ -100,7 +99,7 @@ export class ExternalModule<IModule> {
           initial: true,
         })));
     if (answer) {
-      Log.log(chalk`Installing ${packageName}...`);
+      Log.log(`Installing ${packageName}...`);
 
       // Always use npm for global installs
       const packageManager = shouldGloballyInstall

--- a/packages/expo/cli/start/doctor/ngrok/NgrokResolver.ts
+++ b/packages/expo/cli/start/doctor/ngrok/NgrokResolver.ts
@@ -1,0 +1,50 @@
+import { ExternalModule } from './ExternalModule';
+
+export interface NgrokOptions {
+  authtoken?: string;
+  port?: string | number | null;
+  host?: string;
+  httpauth?: string;
+  region?: string;
+  configPath?: string;
+
+  proto?: 'http' | 'tcp' | 'tls';
+  addr?: string;
+  inspect?: boolean;
+  auth?: string;
+  host_header?: string;
+  bind_tls?: true | false | 'both';
+  subdomain?: string;
+  hostname?: string;
+  crt?: string;
+  key?: string;
+  client_cas?: string;
+  remote_addr?: string;
+}
+
+export interface NgrokInstance {
+  getActiveProcess(): { pid: number };
+  connect(
+    props: {
+      hostname: string;
+      configPath: string;
+      onStatusChange: (status: string) => void;
+    } & NgrokOptions
+  );
+  kill(): Promise<void>;
+}
+
+/** Resolves the ngrok instance from local or globally installed package. */
+export class NgrokResolver extends ExternalModule<NgrokInstance> {
+  constructor(projectRoot: string) {
+    super(
+      projectRoot,
+      {
+        name: '@expo/ngrok',
+        versionRange: '^4.1.0',
+      },
+      (packageName) =>
+        `The package ${packageName} is required to use tunnels, would you like to install it globally?`
+    );
+  }
+}

--- a/packages/expo/cli/start/doctor/ngrok/__tests__/ExternalModule-test.ts
+++ b/packages/expo/cli/start/doctor/ngrok/__tests__/ExternalModule-test.ts
@@ -1,0 +1,263 @@
+import * as PackageManager from '@expo/package-manager';
+
+import { delayAsync } from '../../../../utils/delay';
+import { confirmAsync } from '../../../../utils/prompts';
+import { ExternalModule, ExternalModuleVersionError } from '../ExternalModule';
+
+const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
+  fn as jest.MockedFunction<T>;
+
+jest.mock('../../../../utils/prompts');
+jest.mock('../../../../log');
+jest.mock('../../../../utils/delay', () => ({
+  delayAsync: jest.fn(async () => {}),
+}));
+
+jest.mock('@expo/package-manager', () => ({
+  createForProject: jest.fn(() => ({
+    addDevAsync: jest.fn(),
+  })),
+  NpmPackageManager: jest.fn(() => ({
+    addGlobalAsync: jest.fn(),
+  })),
+}));
+
+beforeEach(() => {
+  asMock(confirmAsync).mockClear();
+  asMock(delayAsync).mockClear();
+  asMock(PackageManager.createForProject).mockClear();
+  asMock(PackageManager.NpmPackageManager as any).mockClear();
+});
+
+function createExternalModuleResolver() {
+  const projectRoot = '/';
+  const onMessage = jest.fn((pkgName) => pkgName + ' is required');
+  const externalModule = new ExternalModule<any>(
+    projectRoot,
+    { name: '@expo/ngrok', versionRange: '^4.1.0' },
+    onMessage
+  );
+  // Mock the require statements.
+  externalModule._require = jest.fn();
+  externalModule._resolveLocal = jest.fn((moduleId) => '/path/to/' + moduleId);
+  externalModule._resolveGlobal = jest.fn((moduleId) => '/path/to/' + moduleId);
+  externalModule.getVersioned = jest.fn(externalModule.getVersioned.bind(externalModule));
+  externalModule.installAsync = jest.fn(externalModule.installAsync.bind(externalModule));
+
+  return {
+    projectRoot,
+    externalModule,
+    onMessage,
+  };
+}
+
+describe('get', () => {
+  it(`returns null when the version is incorrect.`, () => {
+    const { externalModule } = createExternalModuleResolver();
+    asMock(externalModule._require).mockReturnValue({
+      version: '1.0.0',
+    });
+
+    const instance = externalModule.get();
+
+    expect(instance).toBe(null);
+  });
+});
+
+describe('getVersioned', () => {
+  it('resolves the local instance of a package', () => {
+    const { externalModule } = createExternalModuleResolver();
+    asMock(externalModule._require)
+      .mockReturnValueOnce({
+        version: '4.1.0',
+      })
+      .mockReturnValueOnce('foobar');
+
+    const instance = externalModule.getVersioned();
+
+    expect(externalModule._resolveLocal).toHaveBeenNthCalledWith(1, '@expo/ngrok/package.json');
+    expect(externalModule._resolveLocal).toHaveBeenNthCalledWith(2, '@expo/ngrok');
+    expect(externalModule._resolveGlobal).toHaveBeenCalledTimes(0);
+    expect(instance).toBe('foobar');
+  });
+
+  it('resolves the global instance of a package', () => {
+    const { externalModule } = createExternalModuleResolver();
+    asMock(externalModule._require)
+      .mockReturnValueOnce(null)
+      .mockReturnValueOnce({
+        version: '4.1.0',
+      })
+      .mockReturnValueOnce('foobar');
+
+    const instance = externalModule.getVersioned();
+
+    expect(externalModule._resolveLocal).toHaveBeenNthCalledWith(1, '@expo/ngrok/package.json');
+    expect(externalModule._resolveLocal).toHaveBeenCalledTimes(1);
+    expect(externalModule._resolveGlobal).toHaveBeenNthCalledWith(1, '@expo/ngrok/package.json');
+    expect(instance).toBe('foobar');
+  });
+});
+
+describe('resolveAsync', () => {
+  it('overwrites preferred global install when local packages needs upgrade', async () => {
+    const { externalModule } = createExternalModuleResolver();
+
+    externalModule.getVersioned = jest.fn(() => {
+      // mock throwing an error when the local version is lower than required.
+      throw new ExternalModuleVersionError('foobar', false);
+    });
+
+    externalModule.installAsync = jest.fn();
+
+    await externalModule.resolveAsync({
+      // overwrites the preferred value since we'll have a more informed guess.
+      prefersGlobalInstall: true,
+    });
+
+    expect(externalModule.installAsync).toHaveBeenCalledWith({ shouldGloballyInstall: false });
+  });
+  it('upgrades non-compliant local package', async () => {
+    const { externalModule } = createExternalModuleResolver();
+    asMock(externalModule._require).mockReturnValueOnce({
+      version: '3.0.0',
+    });
+
+    externalModule.installAsync = jest.fn();
+
+    await externalModule.resolveAsync();
+
+    expect(externalModule.installAsync).toHaveBeenCalledWith({ shouldGloballyInstall: false });
+    expect(externalModule._resolveLocal).toHaveBeenNthCalledWith(1, '@expo/ngrok/package.json');
+    expect(externalModule._resolveGlobal).toHaveBeenCalledTimes(0);
+  });
+
+  it('upgrades non-compliant global package', async () => {
+    const { externalModule } = createExternalModuleResolver();
+
+    asMock(externalModule._require)
+      .mockReturnValueOnce(
+        // Return the local package as null to imply that it doesn't exist.
+        null
+      )
+      .mockReturnValueOnce({
+        version: '3.0.0',
+      });
+
+    externalModule.installAsync = jest.fn();
+
+    await externalModule.resolveAsync();
+
+    expect(externalModule.installAsync).toHaveBeenCalledWith({ shouldGloballyInstall: true });
+    expect(externalModule._resolveLocal).toHaveBeenNthCalledWith(1, '@expo/ngrok/package.json');
+    expect(externalModule._resolveGlobal).toHaveBeenNthCalledWith(1, '@expo/ngrok/package.json');
+  });
+});
+
+describe('installAsync', () => {
+  it(`installs the missing package to project dev dependencies`, async () => {
+    const { externalModule } = createExternalModuleResolver();
+
+    asMock(externalModule.getVersioned).mockReturnValueOnce(
+      // Return the global package as null to imply that it doesn't exist.
+      'foobar'
+    );
+    asMock(confirmAsync)
+      .mockResolvedValueOnce(true)
+      .mockImplementation(() => {
+        throw new Error("shouldn't happen");
+      });
+
+    const addDevAsync = jest.fn();
+
+    asMock(PackageManager.createForProject).mockReturnValueOnce({
+      addDevAsync,
+    } as any);
+
+    const instance = await externalModule.installAsync({ shouldPrompt: true, autoInstall: false });
+
+    expect(externalModule.installAsync).toHaveBeenCalledWith({
+      autoInstall: false,
+      shouldPrompt: true,
+    });
+    expect(delayAsync).toBeCalled();
+
+    expect(instance).toBe('foobar');
+    expect(PackageManager.createForProject).toBeCalled();
+    // Ensure all packages are added as dev dep locally.
+    expect(addDevAsync).toBeCalled();
+  });
+
+  it(`installs the missing package globally with npm`, async () => {
+    const { externalModule } = createExternalModuleResolver();
+
+    asMock(externalModule.getVersioned).mockReturnValueOnce(
+      // Return the global package as null to imply that it doesn't exist.
+      'foobar'
+    );
+
+    const addGlobalAsync = jest.fn();
+
+    asMock(PackageManager.NpmPackageManager as any).mockReturnValueOnce({
+      addGlobalAsync,
+    } as any);
+
+    await externalModule.installAsync({
+      autoInstall: true,
+      shouldGloballyInstall: true,
+    });
+
+    expect(PackageManager.createForProject).not.toBeCalled();
+    // Ensure all packages are added as dev dep locally.
+    expect(addGlobalAsync).toBeCalled();
+    expect(confirmAsync).not.toBeCalled();
+  });
+
+  it(`throws an error when the package cannot be found after install`, async () => {
+    const { externalModule } = createExternalModuleResolver();
+
+    asMock(externalModule.getVersioned).mockReturnValue(
+      // Return the local package as null to imply that it doesn't exist.
+      null
+    );
+    asMock(confirmAsync).mockImplementation(() => {
+      throw new Error("shouldn't happen");
+    });
+
+    asMock(PackageManager.createForProject).mockReturnValueOnce({
+      addDevAsync: jest.fn(),
+    } as any);
+
+    await expect(externalModule.installAsync({ autoInstall: true })).rejects.toThrowError(
+      /Please install .* and try again/
+    );
+
+    expect(externalModule.installAsync).toHaveBeenCalledTimes(2);
+    expect(PackageManager.createForProject).toBeCalled();
+  });
+
+  it(`asserts on missing`, async () => {
+    const { externalModule } = createExternalModuleResolver();
+
+    asMock(externalModule.getVersioned).mockReturnValue(
+      // Return the local package as null to imply that it doesn't exist.
+      null
+    );
+    asMock(confirmAsync).mockImplementation(() => {
+      throw new Error("shouldn't happen");
+    });
+
+    asMock(PackageManager.createForProject).mockReturnValueOnce({
+      addDevAsync: jest.fn(),
+    } as any);
+
+    await expect(
+      externalModule.resolveAsync({ autoInstall: false, shouldPrompt: false })
+    ).rejects.toThrowError(/Please install .* and try again/);
+
+    // Only invoked once, since we're not prompting.
+    expect(externalModule.installAsync).toHaveBeenCalledTimes(1);
+    // No install was called
+    expect(PackageManager.createForProject).toBeCalledTimes(0);
+  });
+});

--- a/packages/expo/cli/start/doctor/ngrok/__tests__/ExternalModule-test.ts
+++ b/packages/expo/cli/start/doctor/ngrok/__tests__/ExternalModule-test.ts
@@ -63,6 +63,17 @@ describe('get', () => {
     expect(instance).toBe(null);
   });
 });
+describe('_resolveModule', () => {
+  it(`asserts when the required package exports a nullish value.`, () => {
+    const { externalModule } = createExternalModuleResolver();
+    asMock(externalModule._require)
+      .mockReturnValueOnce({ version: '4.1.0' })
+      .mockReturnValueOnce(null);
+    asMock(externalModule._resolveLocal).mockReturnValue('/');
+
+    expect(() => externalModule._resolveModule(true)).toThrowError(/exports a nullish value/);
+  });
+});
 
 describe('getVersioned', () => {
   it('resolves the local instance of a package', () => {

--- a/packages/expo/cli/utils/delay.ts
+++ b/packages/expo/cli/utils/delay.ts
@@ -16,9 +16,14 @@ export async function waitForActionAsync<T>({
   let complete: T;
   const start = Date.now();
   do {
+    const actionStartTime = Date.now();
     complete = await action();
 
-    await delayAsync(interval);
+    const actionTimeElapsed = Date.now() - actionStartTime;
+    const remainingDelayInterval = interval - actionTimeElapsed;
+    if (remainingDelayInterval > 0) {
+      await delayAsync(remainingDelayInterval);
+    }
     if (Date.now() - start > maxWaitTime) {
       break;
     }

--- a/packages/expo/cli/utils/delay.ts
+++ b/packages/expo/cli/utils/delay.ts
@@ -1,0 +1,28 @@
+/** Await for a given duration of milliseconds. */
+export function delayAsync(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Wait for a given action to return a truthy value. */
+export async function waitForActionAsync<T>({
+  action,
+  interval = 100,
+  maxWaitTime = 20000,
+}: {
+  action: () => T | Promise<T>;
+  interval?: number;
+  maxWaitTime?: number;
+}): Promise<T> {
+  let complete: T;
+  const start = Date.now();
+  do {
+    complete = await action();
+
+    await delayAsync(interval);
+    if (Date.now() - start > maxWaitTime) {
+      break;
+    }
+  } while (!complete);
+
+  return complete;
+}


### PR DESCRIPTION
# Why

- Split out of https://github.com/expo/expo/pull/16160
- This module is half of the ngrok implementation (the complex half).
- Created a generic module for resolving external packages that aren't shipped in the CLI.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->


# Test Plan

- Unit tests.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
