### PR TITLE
[dev-client][CI] Save logs on the failure

### DIFF
--- a/packages/expo-dev-client/.detoxrc.js
+++ b/packages/expo-dev-client/.detoxrc.js
@@ -56,6 +56,7 @@ module.exports = {
     rootDir: artifactsPath,
     plugins: {
       uiHierarchy: { enabled: true, keepOnlyFailedTestsArtifacts: true },
+      log: { enabled: true, keepOnlyFailedTestsArtifacts: true },
       screenshot: {
         enabled: true,
         keepOnlyFailedTestsArtifacts: true,


### PR DESCRIPTION
# Why

Saves logs on the failure to better understand why tests didn't pass sometimes. 
