### PR TITLE
[dev-launcher] Added `android:exported="true"` to the launcher activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,7 +186,7 @@ Package-specific changes not released in any SDK will be added here just before 
 - Updated `firebase` from `8.2.3` to `8.10.0`. ([#14259](https://github.com/expo/expo/pull/14259) by [@IjzerenHein](https://github.com/IjzerenHein))
 - Updated `@react-native-community/netinfo` from `6.0.0` to `6.0.2`. ([#14329](https://github.com/expo/expo/pull/14329) by [@cruzach](https://github.com/cruzach))
 - Updated `react-native-webview` from `11.6.2` to `11.13.0`. ([#14301](https://github.com/expo/expo/pull/14301) by [@kudo](https://github.com/kudo))
-- Updated `react-native-lottie` from `4.0.2` to `4.0.3`. ([#14331](https://github.com/expo/expo/pull/14331) by [@cruzach](https://github.com/cruzach))
+- Updated `lottie-react-native` from `4.0.2` to `4.0.3`. ([#14331](https://github.com/expo/expo/pull/14331) by [@cruzach](https://github.com/cruzach))
 - Updated `@stripe/stripe-react-native` from `0.1.4` to `0.2.2`. ([#14357](https://github.com/expo/expo/pull/14357) & [#14452](https://github.com/expo/expo/pull/14452) by [@cruzach](https://github.com/cruzach))
 - Updated `react-native-safe-area-context` from `3.2.0` to `3.3.2`. ([#14303](https://github.com/expo/expo/pull/14303) by [@kudo](https://github.com/kudo))
 - Updated `@react-native-community/viewpager` from `5.0.11` to `react-native-pager-view@5.4.6`. ([#14348](https://github.com/expo/expo/pull/14348) by [@cruzach](https://github.com/cruzach)) ([#14657](https://github.com/expo/expo/pull/14657) by [@kudo](https://github.com/kudo))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,7 +186,7 @@ Package-specific changes not released in any SDK will be added here just before 
 - Updated `firebase` from `8.2.3` to `8.10.0`. ([#14259](https://github.com/expo/expo/pull/14259) by [@IjzerenHein](https://github.com/IjzerenHein))
 - Updated `@react-native-community/netinfo` from `6.0.0` to `6.0.2`. ([#14329](https://github.com/expo/expo/pull/14329) by [@cruzach](https://github.com/cruzach))
 - Updated `react-native-webview` from `11.6.2` to `11.13.0`. ([#14301](https://github.com/expo/expo/pull/14301) by [@kudo](https://github.com/kudo))
-- Updated `lottie-react-native` from `4.0.2` to `4.0.3`. ([#14331](https://github.com/expo/expo/pull/14331) by [@cruzach](https://github.com/cruzach))
+- Updated `react-native-lottie` from `4.0.2` to `4.0.3`. ([#14331](https://github.com/expo/expo/pull/14331) by [@cruzach](https://github.com/cruzach))
 - Updated `@stripe/stripe-react-native` from `0.1.4` to `0.2.2`. ([#14357](https://github.com/expo/expo/pull/14357) & [#14452](https://github.com/expo/expo/pull/14452) by [@cruzach](https://github.com/cruzach))
 - Updated `react-native-safe-area-context` from `3.2.0` to `3.3.2`. ([#14303](https://github.com/expo/expo/pull/14303) by [@kudo](https://github.com/kudo))
 - Updated `@react-native-community/viewpager` from `5.0.11` to `react-native-pager-view@5.4.6`. ([#14348](https://github.com/expo/expo/pull/14348) by [@cruzach](https://github.com/cruzach)) ([#14657](https://github.com/expo/expo/pull/14657) by [@kudo](https://github.com/kudo))

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- Added `android:exported="true"` to the activity. Cause on Android 12 and higher it needs to [explicity decalred](https://developer.android.com/about/versions/12/behavior-changes-12#exported) . ([#16367](https://github.com/expo/expo/pull/16367) by [@wbroek](https://github.com/wbroek))
 - Fix build errors on React Native 0.66 caused by `okio` and `okhttp`. ([#15632](https://github.com/expo/expo/pull/15632) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Added `android:exported="true"` to the activity. Cause on Android 12 and higher it needs to [explicity decalred](https://developer.android.com/about/versions/12/behavior-changes-12#exported). ([#16367](https://github.com/expo/expo/pull/16367) by [@wbroek](https://github.com/wbroek))
+- Added `android:exported="true"` to the activity, cause on Android 12 and higher it needs to [explicity declared](https://developer.android.com/about/versions/12/behavior-changes-12#exported). ([#16367](https://github.com/expo/expo/pull/16367) by [@wbroek](https://github.com/wbroek))
 - Fix build errors on React Native 0.66 caused by `okio` and `okhttp`. ([#15632](https://github.com/expo/expo/pull/15632) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Added `android:exported="true"` to the activity. Cause on Android 12 and higher it needs to [explicity decalred](https://developer.android.com/about/versions/12/behavior-changes-12#exported) . ([#16367](https://github.com/expo/expo/pull/16367) by [@wbroek](https://github.com/wbroek))
+- Added `android:exported="true"` to the activity. Cause on Android 12 and higher it needs to [explicity decalred](https://developer.android.com/about/versions/12/behavior-changes-12#exported). ([#16367](https://github.com/expo/expo/pull/16367) by [@wbroek](https://github.com/wbroek))
 - Fix build errors on React Native 0.66 caused by `okio` and `okhttp`. ([#15632](https://github.com/expo/expo/pull/15632) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others

--- a/packages/expo-dev-launcher/android/src/main/AndroidManifest.xml
+++ b/packages/expo-dev-launcher/android/src/main/AndroidManifest.xml
@@ -6,7 +6,8 @@
       android:name="expo.modules.devlauncher.launcher.DevLauncherActivity"
       android:screenOrientation="portrait"
       android:theme="@style/Theme.DevLauncher.LauncherActivity"
-      android:launchMode="singleTask" 
+      android:launchMode="singleTask"
+      android:exported="true"
       >
       <intent-filter>
         <action android:name="android.intent.action.VIEW"/>


### PR DESCRIPTION
# Why
Fixes https://github.com/expo/expo/issues/16366 not be able to publish to Google Play

# How

As mentioned in the [Android docs ](https://developer.android.com/about/versions/12/behavior-changes-12#exported) if an activity has intent filters you need to explicitly set the exported attributes

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
