### PR TITLE
[dev-launcher] Fix crash when using hermes on android react-native 0.67

### DIFF
--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/DevLauncherClientHost.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/DevLauncherClientHost.kt
@@ -1,9 +1,14 @@
 package expo.modules.devlauncher.launcher
 
 import android.app.Application
+import com.facebook.hermes.reactexecutor.HermesExecutorFactory
 import com.facebook.react.ReactNativeHost
 import com.facebook.react.ReactPackage
+import com.facebook.react.bridge.JavaScriptExecutorFactory
+import com.facebook.react.jscexecutor.JSCExecutorFactory
+import com.facebook.react.modules.systeminfo.AndroidInfoHelpers
 import com.facebook.react.shell.MainReactPackage
+import com.facebook.soloader.SoLoader
 import expo.modules.devlauncher.DevLauncherController
 import expo.modules.devlauncher.DevLauncherPackage
 import expo.modules.devlauncher.helpers.findDevMenuPackage
@@ -44,6 +49,14 @@ class DevLauncherClientHost(
     ) +
       devMenuRelatedPackages +
       additionalPackages
+  }
+
+  override fun getJavaScriptExecutorFactory(): JavaScriptExecutorFactory? {
+    SoLoader.init(application.applicationContext, /* native exopackage */ false)
+    if (SoLoader.getLibraryPath("libjsc.so") != null) {
+      return JSCExecutorFactory(application.packageName, AndroidInfoHelpers.getFriendlyDeviceName())
+    }
+    return HermesExecutorFactory()
   }
 
   override fun getJSMainModuleName() = "index"


### PR DESCRIPTION
# Why

Fixes:
```
FATAL EXCEPTION: main
Process: dev.expo.payments, PID: 18344
java.lang.NoClassDefFoundError: com.facebook.react.jscexecutor.JSCExecutor
```

It's turned out that we have to do a similar thing to https://github.com/expo/expo/pull/16099 in `dev-launcher`.

# Test Plan

- run `bare-expo` with Hermes.
