### PR TITLE
[docs] Apply consistent styling to list items and update the link of react-native-elements docs

### DIFF
--- a/docs/pages/guides/userinterface.md
+++ b/docs/pages/guides/userinterface.md
@@ -7,7 +7,7 @@ The User Interface (UI) is a huge part of any app. If the icon is your front doo
 Below (in no particular order) are some of the most popular UI Libraries. Test them all out and see what you like!
 
 - [React Native Paper](https://github.com/callstack/react-native-paper), and their [docs](https://callstack.github.io/react-native-paper/index.html)
-- [React Native UI Lib](https://github.com/wix/react-native-ui-lib), and their [docs](https://wix.github.io/react-native-ui-lib/).
+- [React Native UI Lib](https://github.com/wix/react-native-ui-lib), and their [docs](https://wix.github.io/react-native-ui-lib/)
 - [React Native Elements](https://react-native-training.github.io/react-native-elements/), and their [docs](https://react-native-training.github.io/react-native-elements/docs/getting_started.html)
 - [Native Base](https://nativebase.io/), and their [docs](https://docs.nativebase.io/)
 - [React Native Material UI](https://github.com/xotahal/react-native-material-ui), and their [docs](https://github.com/xotahal/react-native-material-ui/blob/master/docs/GettingStarted.md)

--- a/docs/pages/guides/userinterface.md
+++ b/docs/pages/guides/userinterface.md
@@ -8,7 +8,7 @@ Below (in no particular order) are some of the most popular UI Libraries. Test t
 
 - [React Native Paper](https://github.com/callstack/react-native-paper), and their [docs](https://callstack.github.io/react-native-paper/index.html)
 - [React Native UI Lib](https://github.com/wix/react-native-ui-lib), and their [docs](https://wix.github.io/react-native-ui-lib/)
-- [React Native Elements](https://react-native-training.github.io/react-native-elements/), and their [docs](https://react-native-training.github.io/react-native-elements/docs/getting_started.html)
+- [React Native Elements](https://reactnativeelements.com/), and their [docs](https://reactnativeelements.com/docs)
 - [Native Base](https://nativebase.io/), and their [docs](https://docs.nativebase.io/)
 - [React Native Material UI](https://github.com/xotahal/react-native-material-ui), and their [docs](https://github.com/xotahal/react-native-material-ui/blob/master/docs/GettingStarted.md)
 - [React Native UI Kitten](https://akveo.github.io/react-native-ui-kitten/#/home), and their [docs](https://akveo.github.io/react-native-ui-kitten/#/docs/quick-start/getting-started)


### PR DESCRIPTION
# Why

This PR removes an extra period at the end of the second list item. This allows maintaining a consistent styling in docs. It also updates the link of `react-native-elements` docs.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
