### PR TITLE
fix code example

### DIFF
--- a/docs/pages/guides/linking.md
+++ b/docs/pages/guides/linking.md
@@ -74,7 +74,8 @@ Update: "WebBrowser" is in a separate package so first install `expo-web-browser
 
 ```js
 import React, { Component } from 'react';
-import { Button, Linking, View, StyleSheet } from 'react-native';
+import { Button, View, StyleSheet } from 'react-native';
+import * as Linking from 'expo-linking';
 import * as WebBrowser from 'expo-web-browser';
 import Constants from 'expo-constants';
 


### PR DESCRIPTION
We should use `Linking` from `expo-linking`.
`Linking` from `react-native` should be used for "Projects with Native Code Only".
This is mentioned at the top of this page: https://reactnative.dev/docs/linking

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
