### PR TITLE
[home] add new tab icons and associated screens for redesign behind flag

### DIFF
--- a/apps/native-component-list/src/navigation/ExpoComponentsStackNavigator.tsx
+++ b/apps/native-component-list/src/navigation/ExpoComponentsStackNavigator.tsx
@@ -1,6 +1,7 @@
 import { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
 import { createStackNavigator } from '@react-navigation/stack';
 import * as React from 'react';
+import { View } from 'react-native';
 
 import TabIcon from '../components/TabIcon';
 import { Layout } from '../constants';

--- a/apps/native-component-list/src/navigation/ExpoComponentsStackNavigator.tsx
+++ b/apps/native-component-list/src/navigation/ExpoComponentsStackNavigator.tsx
@@ -1,7 +1,6 @@
 import { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
 import { createStackNavigator } from '@react-navigation/stack';
 import * as React from 'react';
-import { View } from 'react-native';
 
 import TabIcon from '../components/TabIcon';
 import { Layout } from '../constants';

--- a/home/components/Icons.tsx
+++ b/home/components/Icons.tsx
@@ -3,7 +3,7 @@ import DefaultMaterialIcons from '@expo/vector-icons/build/MaterialIcons';
 import { useTheme } from '@react-navigation/native';
 import * as React from 'react';
 import { Platform } from 'react-native';
-import { Svg, Path } from 'react-native-svg';
+import { Svg, Path, SvgProps } from 'react-native-svg';
 
 import Colors from '../constants/Colors';
 
@@ -113,6 +113,40 @@ export function Store({
   return (
     <Svg width={size} fill={fill} height={size} viewBox="0 0 512 512" {...props}>
       <Path d="M325.3 234.3L104.6 13l280.8 161.2-60.1 60.1zM47 0C34 6.8 25.3 19.2 25.3 35.3v441.3c0 16.1 8.7 28.5 21.7 35.3l256.6-256L47 0zm425.2 225.6l-58.9-34.1-65.7 64.5 65.7 64.5 60.1-34.1c18-14.3 18-46.5-1.2-60.8zM104.6 499l280.8-161.2-60.1-60.1L104.6 499z" />
+    </Svg>
+  );
+}
+
+export default function DiagnosticsIcon(props: SvgProps & Props) {
+  const { size, color, width, height } = props;
+  return (
+    <Svg
+      width={size || width || 20}
+      height={size || height || 20}
+      viewBox="0 0 20 20"
+      fill="none"
+      {...props}>
+      <Path
+        d="M13.8 2.7998H15.6C16.0774 2.7998 16.5353 2.98945 16.8728 3.32701C17.2104 3.66458 17.4 4.12242 17.4 4.59981V17.1998C17.4 17.6772 17.2104 18.1351 16.8728 18.4726C16.5353 18.8102 16.0774 18.9999 15.6 18.9999H4.80001C4.32261 18.9999 3.86478 18.8102 3.52721 18.4726C3.18964 18.1351 3 17.6772 3 17.1998V4.59981C3 4.12242 3.18964 3.66458 3.52721 3.32701C3.86478 2.98945 4.32261 2.7998 4.80001 2.7998H6.60001"
+        stroke={color || '#000'}
+        strokeWidth="1.80001"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <Path
+        d="M12.8999 1H7.49986C7.0028 1 6.59985 1.40294 6.59985 1.9V3.70001C6.59985 4.19707 7.0028 4.60001 7.49986 4.60001H12.8999C13.3969 4.60001 13.7999 4.19707 13.7999 3.70001V1.9C13.7999 1.40294 13.3969 1 12.8999 1Z"
+        stroke={color || '#000'}
+        strokeWidth="1.80001"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <Path
+        d="M6 12H7.5L9 8.5L11.5 14.5L13 12H14.5"
+        stroke={color || '#000'}
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
     </Svg>
   );
 }

--- a/home/constants/Flags.ts
+++ b/home/constants/Flags.ts
@@ -1,0 +1,1 @@
+export const NAVIGATION_REDESIGN_ENABLED = __DEV__;

--- a/home/navigation/Navigation.tsx
+++ b/home/navigation/Navigation.tsx
@@ -203,11 +203,10 @@ function DiagnosticsStackScreen() {
 const RootStack = createStackNavigator();
 
 function TabNavigator(props: { theme: string }) {
+  const projectsOrHomeScreen = NAVIGATION_REDESIGN_ENABLED ? 'HomeStack' : 'ProjectsStack';
   const initialRouteName = Environment.IsIOSRestrictedBuild
     ? 'ProfileStackScreen'
-    : NAVIGATION_REDESIGN_ENABLED
-    ? 'HomeStack'
-    : 'ProjectsStack';
+    : projectsOrHomeScreen;
 
   return (
     <BottomTab.Navigator {...getNavigatorProps(props)} initialRouteName={initialRouteName}>

--- a/home/navigation/Navigation.tsx
+++ b/home/navigation/Navigation.tsx
@@ -1,4 +1,4 @@
-import { HomeFilledIcon, HomeIcon, SettingsFilledIcon } from '@expo/styleguide-native';
+import { HomeFilledIcon, SettingsFilledIcon } from '@expo/styleguide-native';
 import Entypo from '@expo/vector-icons/build/Entypo';
 import Ionicons from '@expo/vector-icons/build/Ionicons';
 import {

--- a/home/navigation/Navigation.tsx
+++ b/home/navigation/Navigation.tsx
@@ -1,3 +1,4 @@
+import { HomeFilledIcon, HomeIcon, SettingsFilledIcon } from '@expo/styleguide-native';
 import Entypo from '@expo/vector-icons/build/Entypo';
 import Ionicons from '@expo/vector-icons/build/Ionicons';
 import {
@@ -7,9 +8,12 @@ import {
   RouteProp,
 } from '@react-navigation/native';
 import { createStackNavigator, TransitionPresets } from '@react-navigation/stack';
+import DiagnosticsIcon from 'components/Icons';
+import { NAVIGATION_REDESIGN_ENABLED } from 'constants/Flags';
 import Constants from 'expo-constants';
 import * as React from 'react';
 import { Platform, StyleSheet, Linking } from 'react-native';
+import HomeScreen from 'screens/HomeScreen';
 
 import OpenProjectByURLButton from '../components/OpenProjectByURLButton.ios';
 import OptionsButton from '../components/OptionsButton';
@@ -39,6 +43,7 @@ import {
 import BottomTab, { getNavigatorProps } from './BottomTabNavigator';
 import {
   DiagnosticsStackRoutes,
+  HomeStackRoutes,
   ModalStackRoutes,
   ProfileStackRoutes,
   ProjectsStackRoutes,
@@ -47,6 +52,7 @@ import defaultNavigationOptions from './defaultNavigationOptions';
 
 // TODO(Bacon): Do we need to create a new one each time?
 const ProjectsStack = createStackNavigator<ProjectsStackRoutes>();
+const HomeStack = createStackNavigator<HomeStackRoutes>();
 
 function useThemeName() {
   const theme = useTheme();
@@ -91,6 +97,26 @@ function ProjectsStackScreen() {
         }}
       />
     </ProjectsStack.Navigator>
+  );
+}
+
+function HomeStackScreen() {
+  const theme = useThemeName();
+  return (
+    <HomeStack.Navigator initialRouteName="Home" screenOptions={defaultNavigationOptions(theme)}>
+      <HomeStack.Screen
+        name="Home"
+        component={HomeScreen}
+        options={{
+          title: 'Home',
+          ...Platform.select({
+            ios: {
+              headerRight: () => (Constants.isDevice ? null : <OpenProjectByURLButton />),
+            },
+          }),
+        }}
+      />
+    </HomeStack.Navigator>
   );
 }
 
@@ -179,30 +205,55 @@ const RootStack = createStackNavigator();
 function TabNavigator(props: { theme: string }) {
   const initialRouteName = Environment.IsIOSRestrictedBuild
     ? 'ProfileStackScreen'
+    : NAVIGATION_REDESIGN_ENABLED
+    ? 'HomeStack'
     : 'ProjectsStack';
 
   return (
     <BottomTab.Navigator {...getNavigatorProps(props)} initialRouteName={initialRouteName}>
-      <BottomTab.Screen
-        name="ProjectsStack"
-        component={ProjectsStackScreen}
-        options={{
-          tabBarIcon: (props) => <Entypo {...props} style={styles.icon} name="grid" size={24} />,
-          tabBarLabel: 'Projects',
-        }}
-      />
+      {NAVIGATION_REDESIGN_ENABLED ? (
+        <BottomTab.Screen
+          name="HomeStack"
+          component={HomeStackScreen}
+          options={{
+            tabBarIcon: ({ color }) => (
+              <HomeFilledIcon style={styles.icon} color={color} size={24} />
+            ),
+            tabBarLabel: 'Home',
+          }}
+        />
+      ) : (
+        <BottomTab.Screen
+          name="ProjectsStack"
+          component={ProjectsStackScreen}
+          options={{
+            tabBarIcon: (props) => <Entypo {...props} style={styles.icon} name="grid" size={24} />,
+            tabBarLabel: 'Projects',
+          }}
+        />
+      )}
       {Platform.OS === 'ios' && (
         <BottomTab.Screen
           name="DiagnosticsStack"
           component={DiagnosticsStackScreen}
           options={{
-            tabBarIcon: (props) => (
-              <Ionicons {...props} style={styles.icon} name="ios-git-branch" size={26} />
-            ),
+            tabBarIcon: (props) => <DiagnosticsIcon {...props} style={styles.icon} size={24} />,
             tabBarLabel: 'Diagnostics',
           }}
         />
       )}
+      {NAVIGATION_REDESIGN_ENABLED ? (
+        <BottomTab.Screen
+          name="SettingsScreen"
+          component={UserSettingsScreen}
+          options={{
+            title: 'Settings',
+            headerShown: true,
+            tabBarIcon: (props) => <SettingsFilledIcon {...props} style={styles.icon} size={24} />,
+            tabBarLabel: 'Settings',
+          }}
+        />
+      ) : null}
       <BottomTab.Screen
         name="ProfileStack"
         component={ProfileStackScreen}

--- a/home/navigation/Navigation.types.ts
+++ b/home/navigation/Navigation.types.ts
@@ -6,6 +6,11 @@ export type ProjectsStackRoutes = {
   Projects: object;
 };
 
+export type HomeStackRoutes = {
+  Home: object;
+  Account: { accountName: string };
+};
+
 export type ProfileStackRoutes = {
   Profile: object;
   ProfileAllProjects: object;

--- a/home/package.json
+++ b/home/package.json
@@ -20,6 +20,7 @@
     "@apollo/client": "^3.4.10",
     "@expo/react-native-action-sheet": "^2.1.0",
     "@expo/sdk-runtime-versions": "^1.0.0",
+    "@expo/styleguide-native": "^1.0.0",
     "@expo/vector-icons": "^12.0.4",
     "@react-native-async-storage/async-storage": "~1.15.0",
     "@react-native-community/netinfo": "7.1.3",

--- a/home/screens/HomeScreen.tsx
+++ b/home/screens/HomeScreen.tsx
@@ -1,0 +1,432 @@
+import { StackScreenProps } from '@react-navigation/stack';
+import Constants from 'expo-constants';
+import * as React from 'react';
+import { Alert, AppState, Clipboard, Linking, Platform, StyleSheet, View } from 'react-native';
+
+import ApiV2HttpClient from '../api/ApiV2HttpClient';
+import Config from '../api/Config';
+import Connectivity from '../api/Connectivity';
+import DevIndicator from '../components/DevIndicator';
+import ListItem from '../components/ListItem';
+import ScrollView from '../components/NavigationScrollView';
+import NoProjectsOpen from '../components/NoProjectsOpen';
+import ProjectListItem from '../components/ProjectListItem';
+import ProjectTools from '../components/ProjectTools';
+import RefreshControl from '../components/RefreshControl';
+import SectionHeader from '../components/SectionHeader';
+import { StyledText } from '../components/Text';
+import ThemedStatusBar from '../components/ThemedStatusBar';
+import { AllStackRoutes, HomeStackRoutes } from '../navigation/Navigation.types';
+import HistoryActions from '../redux/HistoryActions';
+import { useDispatch, useSelector } from '../redux/Hooks';
+import { DevSession, HistoryList } from '../types';
+import Environment from '../utils/Environment';
+import addListenerWithNativeCallback from '../utils/addListenerWithNativeCallback';
+import getSnackId from '../utils/getSnackId';
+import isUserAuthenticated from '../utils/isUserAuthenticated';
+
+const PROJECT_UPDATE_INTERVAL = 10000;
+
+type Props = NavigationProps & {
+  dispatch: (data: any) => any;
+  isFocused: boolean;
+  recentHistory: HistoryList;
+  allHistory: HistoryList;
+  isAuthenticated: boolean;
+};
+
+type State = {
+  projects: DevSession[];
+  isNetworkAvailable: boolean;
+  isRefreshing: boolean;
+};
+
+type NavigationProps = StackScreenProps<HomeStackRoutes, 'Home'>;
+
+export default function HomeScreen(props: NavigationProps) {
+  const [isFocused, setFocused] = React.useState(true);
+  React.useEffect(() => {
+    const unsubscribe = props.navigation.addListener('focus', () => {
+      setFocused(true);
+    });
+    const unsubscribeBlur = props.navigation.addListener('blur', () => {
+      setFocused(false);
+    });
+
+    return () => {
+      unsubscribe();
+      unsubscribeBlur();
+    };
+  }, [props.navigation]);
+
+  const dispatch = useDispatch();
+  const { recentHistory, allHistory, isAuthenticated } = useSelector(
+    React.useCallback((data) => {
+      const { history } = data.history;
+
+      return {
+        recentHistory: history.take(10) as HistoryList,
+        allHistory: history as HistoryList,
+        isAuthenticated: isUserAuthenticated(data.session),
+      };
+    }, [])
+  );
+  return (
+    <ProjectsView
+      {...props}
+      isFocused={isFocused}
+      dispatch={dispatch}
+      recentHistory={recentHistory}
+      allHistory={allHistory}
+      isAuthenticated={isAuthenticated}
+    />
+  );
+}
+
+class ProjectsView extends React.Component<Props, State> {
+  private _projectPolling?: ReturnType<typeof setInterval>;
+
+  state: State = {
+    projects: [],
+    isNetworkAvailable: Connectivity.isAvailable(),
+    isRefreshing: false,
+  };
+
+  componentDidMount() {
+    AppState.addEventListener('change', this._maybeResumePollingFromAppState);
+    Connectivity.addListener(this._updateConnectivity);
+
+    // @evanbacon: Without this setTimeout, the state doesn't update correctly and the "Recently in Development" items don't load for 10 seconds.
+    setTimeout(() => {
+      this._startPollingForProjects();
+    }, 1);
+
+    // NOTE(brentvatne): if we add QR code button to the menu again, we'll need to
+    // find a way to move this listener up to the root of the app in order to ensure
+    // that it has been registered regardless of whether we have been on the project
+    // screen in the home app
+    addListenerWithNativeCallback('ExponentKernel.showQRReader', async () => {
+      // @ts-ignore
+      this.props.navigation.navigate('QRCode');
+      return { success: true };
+    });
+  }
+
+  componentWillUnmount() {
+    this._stopPollingForProjects();
+    AppState.removeEventListener('change', this._maybeResumePollingFromAppState);
+    Connectivity.removeListener(this._updateConnectivity);
+  }
+
+  render() {
+    const { projects, isNetworkAvailable, isRefreshing } = this.state;
+
+    return (
+      <View style={styles.container}>
+        <ScrollView
+          refreshControl={
+            <RefreshControl refreshing={isRefreshing} onRefresh={this._handleRefreshAsync} />
+          }
+          key={Platform.OS === 'ios' ? this.props.allHistory.count() : 'scroll-view'}
+          stickyHeaderIndices={Platform.OS === 'ios' ? [0, 2, 4] : []}
+          style={styles.container}
+          contentContainerStyle={styles.contentContainer}>
+          <SectionHeader
+            title={
+              (Platform.OS === 'ios' && Environment.IOSClientReleaseType === 'SIMULATOR') ||
+              (Platform.OS === 'android' && !Constants.isDevice)
+                ? 'Clipboard'
+                : 'Tools'
+            }
+          />
+          {this._renderProjectTools()}
+
+          <SectionHeader
+            title="Recently in development"
+            buttonLabel="Help"
+            onPress={this._handlePressHelpProjects}
+            leftContent={
+              <DevIndicator
+                style={styles.devIndicator}
+                isActive={projects && !!projects.length}
+                isNetworkAvailable={isNetworkAvailable}
+              />
+            }
+          />
+          {this._renderProjects()}
+
+          <SectionHeader
+            title="Recently opened"
+            buttonLabel="Clear"
+            onPress={this._handlePressClearHistory}
+          />
+          {this._renderRecentHistory()}
+          {this._renderConstants()}
+        </ScrollView>
+        <ThemedStatusBar />
+      </View>
+    );
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    if (!prevProps.isFocused && this.props.isFocused) {
+      this._fetchProjectsAsync();
+    }
+
+    if (prevProps.isAuthenticated && !this.props.isAuthenticated) {
+      // Remove all projects except Snack, because they are tied to device id
+      // Fix this lint warning when converting to hooks
+      // eslint-disable-next-line
+      this.setState(({ projects }) => ({
+        projects: projects.filter((p) => p.source === 'snack'),
+      }));
+    }
+  }
+
+  private _updateConnectivity = (isAvailable: boolean): void => {
+    if (isAvailable !== this.state.isNetworkAvailable) {
+      this.setState({ isNetworkAvailable: isAvailable });
+    }
+  };
+
+  private _maybeResumePollingFromAppState = (nextAppState: string): void => {
+    if (nextAppState === 'active' && !this._projectPolling) {
+      this._startPollingForProjects();
+    } else {
+      this._stopPollingForProjects();
+    }
+  };
+
+  private _startPollingForProjects = async () => {
+    this._fetchProjectsAsync();
+    this._projectPolling = setInterval(this._fetchProjectsAsync, PROJECT_UPDATE_INTERVAL);
+  };
+
+  private _stopPollingForProjects = async () => {
+    if (this._projectPolling) {
+      clearInterval(this._projectPolling);
+    }
+    this._projectPolling = undefined;
+  };
+
+  private _fetchProjectsAsync = async () => {
+    try {
+      const api = new ApiV2HttpClient();
+      const projects = await api.getAsync('development-sessions', {
+        deviceId: getSnackId(),
+      });
+      this.setState({ projects });
+    } catch (e) {
+      // this doesn't really matter, we will try again later
+      if (__DEV__) {
+        console.log(e);
+      }
+    }
+  };
+
+  private _handleRefreshAsync = async () => {
+    this.setState({ isRefreshing: true });
+
+    try {
+      await Promise.all([
+        this._fetchProjectsAsync(),
+        new Promise((resolve) => setTimeout(resolve, 1000)),
+      ]);
+    } catch (e) {
+      // not sure what to do here, maybe nothing?
+    } finally {
+      this.setState({ isRefreshing: false });
+    }
+  };
+
+  private _handlePressHelpProjects = () => {
+    if (!this.state.isNetworkAvailable) {
+      Alert.alert(
+        'No network connection available',
+        `You must be connected to the internet to view a list of your projects open in development.`
+      );
+    }
+
+    const baseMessage = `Make sure you are signed in to the same Expo account on your computer and this app. Also verify that your computer is connected to the internet, and ideally to the same Wi-Fi network as your mobile device. Lastly, ensure that you are using the latest version of Expo CLI. Pull to refresh to update.`;
+    const message = Platform.select({
+      ios: Constants.isDevice
+        ? baseMessage
+        : `${baseMessage} If this still doesn't work, press the + icon on the header to type the project URL manually.`,
+      android: baseMessage,
+    });
+    Alert.alert('Troubleshooting', message);
+  };
+
+  private _handlePressClearHistory = () => {
+    this.props.dispatch(HistoryActions.clearHistory());
+  };
+
+  private _renderProjectTools = () => {
+    // Disable polling the clipboard on iOS because it presents a notification every time the clipboard is read.
+    const pollForUpdates = this.props.isFocused && Platform.OS !== 'ios';
+    return <ProjectTools pollForUpdates={pollForUpdates} />;
+  };
+
+  private _renderRecentHistory = () => {
+    return this.props.allHistory.count() === 0
+      ? this._renderEmptyRecentHistory()
+      : this._renderRecentHistoryItems();
+  };
+
+  private _renderEmptyRecentHistory = () => {
+    return <ListItem subtitle={`You haven't opened any projects recently.`} last />;
+  };
+
+  private _renderRecentHistoryItems = () => {
+    const extractUsername = (manifestUrl: string) => {
+      const usernameMatches = manifestUrl.match(/@.*?\//);
+      if (!usernameMatches) {
+        return null;
+      }
+      const username = usernameMatches[0];
+      if (!username) {
+        return null;
+      } else {
+        return username.slice(0, username.length - 1);
+      }
+    };
+
+    return this.props.recentHistory.map((project, i) => {
+      if (!project) return null;
+      const username = project.manifestUrl.includes(`exp://${Config.api.host}`)
+        ? extractUsername(project.manifestUrl)
+        : undefined;
+      let releaseChannel =
+        project.manifest && 'releaseChannel' in project.manifest
+          ? project.manifest.releaseChannel
+          : null;
+      releaseChannel = releaseChannel === 'default' ? undefined : releaseChannel;
+      return (
+        <ProjectListItem
+          key={project.manifestUrl}
+          url={project.manifestUrl}
+          image={
+            // TODO(wschurman): audit for new manifests
+            project.manifest && 'iconUrl' in project.manifest ? project.manifest.iconUrl : undefined
+          }
+          title={
+            // TODO(wschurman): audit for new manifests
+            project.manifest && 'name' in project.manifest ? project.manifest.name : undefined
+          }
+          subtitle={username || project.manifestUrl}
+          username={username ?? undefined}
+          releaseChannel={releaseChannel ?? undefined}
+          onPress={() => Linking.openURL(project.url)}
+          last={i === this.props.recentHistory.count() - 1}
+        />
+      );
+    });
+  };
+
+  private _renderConstants = () => {
+    return (
+      <View style={styles.constantsContainer}>
+        <StyledText
+          style={styles.deviceIdText}
+          onPress={this._copySnackIdToClipboard}
+          lightColor="rgba(0,0,0,0.3)"
+          darkColor="rgba(255,255,255,0.6)">
+          Device ID: {getSnackId()}
+        </StyledText>
+        <StyledText
+          style={styles.expoVersionText}
+          onPress={this._copyClientVersionToClipboard}
+          lightColor="rgba(0,0,0,0.3)"
+          darkColor="rgba(255,255,255,0.6)">
+          Client version: {Constants.expoVersion}
+        </StyledText>
+        <StyledText
+          style={styles.supportSdksText}
+          lightColor="rgba(0,0,0,0.3)"
+          darkColor="rgba(255,255,255,0.6)">
+          Supported {Environment.supportedSdksString}
+        </StyledText>
+      </View>
+    );
+  };
+
+  private _copySnackIdToClipboard = () => {
+    Clipboard.setString(getSnackId());
+
+    // Should have some integrated alert banner
+    alert('The device ID has been copied to your clipboard');
+  };
+
+  private _copyClientVersionToClipboard = () => {
+    if (Constants.expoVersion) {
+      Clipboard.setString(Constants.expoVersion);
+      alert(`The app's version has been copied to your clipboard.`);
+    } else {
+      // this should not ever happen
+      alert(`Something went wrong - the app's version is not available.`);
+    }
+  };
+
+  private _renderProjects = () => {
+    const { projects } = this.state;
+
+    if (projects && projects.length) {
+      return (
+        <View>
+          {projects.map((project, i) => (
+            <ProjectListItem
+              key={project.url}
+              url={project.url}
+              image={
+                project.source === 'desktop'
+                  ? require('../assets/cli.png')
+                  : require('../assets/snack.png')
+              }
+              imageStyle={styles.projectImageStyle}
+              title={project.description}
+              platform={project.platform}
+              subtitle={project.url}
+              last={i === projects.length - 1}
+            />
+          ))}
+        </View>
+      );
+    } else {
+      return <NoProjectsOpen isAuthenticated={this.props.isAuthenticated} />;
+    }
+  };
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  contentContainer: {
+    paddingTop: 5,
+  },
+  projectImageStyle: {
+    borderWidth: 1,
+    borderColor: 'rgba(0, 0, 32, 0.1)',
+  },
+  constantsContainer: {
+    paddingHorizontal: 20,
+    paddingBottom: 20,
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+    flex: 1,
+  },
+  devIndicator: {
+    marginRight: 7,
+  },
+  deviceIdText: {
+    fontSize: 11,
+    marginBottom: 5,
+  },
+  expoVersionText: {
+    fontSize: 11,
+    marginBottom: 5,
+  },
+  supportSdksText: {
+    fontSize: 11,
+  },
+});

--- a/home/screens/HomeScreen.tsx
+++ b/home/screens/HomeScreen.tsx
@@ -16,7 +16,7 @@ import RefreshControl from '../components/RefreshControl';
 import SectionHeader from '../components/SectionHeader';
 import { StyledText } from '../components/Text';
 import ThemedStatusBar from '../components/ThemedStatusBar';
-import { AllStackRoutes, HomeStackRoutes } from '../navigation/Navigation.types';
+import { HomeStackRoutes } from '../navigation/Navigation.types';
 import HistoryActions from '../redux/HistoryActions';
 import { useDispatch, useSelector } from '../redux/Hooks';
 import { DevSession, HistoryList } from '../types';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1574,6 +1574,11 @@
   resolved "https://registry.yarnpkg.com/@expo/styleguide-native/-/styleguide-native-0.4.1.tgz#93f8e5e40a68c4f776f59ea43a542ba2e926a0d7"
   integrity sha512-g4PWLTJwzH4GKFfrYN8NP0OY3DtFbqIggiFebeWyFfTrmD/Kgb2ZDWQRAe9AyfukzTvhfg+IG9289anaLHBydg==
 
+"@expo/styleguide-native@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@expo/styleguide-native/-/styleguide-native-1.0.0.tgz#12251f4e22054c6288d1273031d011930cee5898"
+  integrity sha512-izMGG/1BtnFvYfH5QO+DDWNWbm5EvQ987j8fFUlwMYtqsSQ83frFYP8swiInfw1/W/qJtuFqtiHU+g/w962Aow==
+
 "@expo/vector-icons@^12.0.4":
   version "12.0.5"
   resolved "https://registry.yarnpkg.com/@expo/vector-icons/-/vector-icons-12.0.5.tgz#bc508ad05fb7e9a3e008704977cfec6c18aa7728"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3204,15 +3204,7 @@
   resolved "https://registry.yarnpkg.com/@react-native/polyfills/-/polyfills-2.0.0.tgz#4c40b74655c83982c8cf47530ee7dc13d957b6aa"
   integrity sha512-K0aGNn1TjalKj+65D7ycc1//H9roAQ51GJVk5ZJQFb2teECGmzd86bYDC0aYdbRf7gtovescq4Zt6FR0tgXiHQ==
 
-"@react-navigation/bottom-tabs@5.11.15":
-  version "5.11.15"
-  resolved "https://registry.yarnpkg.com/@react-navigation/bottom-tabs/-/bottom-tabs-5.11.15.tgz#f973625cc32d9c5a4067851f084cb11ccd68fe79"
-  integrity sha512-TBY419W6aN/HZg98xbVp5Bx1HEF5sXuHR5f55W6KMI4k2AvxlwelKD1wbfvEcX2iuQT0YUiiXsACRFUSECYhkw==
-  dependencies:
-    color "^3.1.3"
-    react-native-iphone-x-helper "^1.3.0"
-
-"@react-navigation/bottom-tabs@^6.2.0":
+"@react-navigation/bottom-tabs@^6.0.9", "@react-navigation/bottom-tabs@^6.2.0":
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/@react-navigation/bottom-tabs/-/bottom-tabs-6.2.0.tgz#8f6b650c2d05fa63ac42d5e662aece9e554d7a38"
   integrity sha512-MNwXbybjapRFZJtO+fNu5YuTYQGzzYAUIF4IsY2+ZBXoCRpzuDq8gXV7ChKDJaaTeX39IoDUng3qGXbvtVcivA==


### PR DESCRIPTION
# Why

We have new icons for the Expo Tab bar and also entirely new tabs in the new Redesign, so this sets up the navigation for building on top of going forward.

# How

- added @expo/styleguide-native package for SVG Icons
- added "Home" tab that's a duplication of the existing Projects screen (behind flag)
- added "Settings" tab that renders the UserSettings screen (behind flag)
- changed the diagnostics screen icon

# Test Plan

The extra/duplicate tabs aren't shown in production, and the old tabs will be removed in a future PR. The only thing that should affect users if we publish `home` is that they will have a nicer Diagnostics tab icon on iOS.

Tested in iOS and Android.

![IMG_4619](https://user-images.githubusercontent.com/12488826/155437294-151861b4-2a2e-48de-9a74-b9d13e0363c9.PNG)
![Screenshot_20220223-200409](https://user-images.githubusercontent.com/12488826/155437383-fecb2e15-565c-47a9-93af-af7be2406b63.png)


