### PR TITLE
Add emulator folder to PATH in Android Studio Emulator docs

### DIFF
--- a/docs/pages/workflow/android-studio-emulator.md
+++ b/docs/pages/workflow/android-studio-emulator.md
@@ -27,10 +27,11 @@ If you don't have an Android device available to test with, we recommend using t
 echo "export ANDROID_SDK=$ANDROID_SDK" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bash_profile'`
 ```
 
-- On macOS, you will also need to add `platform-tools` to your `~/.bash_profile` (or `~/.zshenv` if you use Zsh) - eg. `export PATH=/your/path/here:$PATH`. Copy and paste this line to do this automatically for Bash and Zsh:
+- On macOS, you will also need to add `platform-tools` and `emulator` to your `~/.bash_profile` (or `~/.zshenv` if you use Zsh) - eg. `export PATH=/your/path/here:$PATH`. Copy and paste these lines to do this automatically for Bash and Zsh:
 
 ```bash
 echo "export PATH=$HOME/Library/Android/sdk/platform-tools:\$PATH" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bash_profile'`
+echo "export PATH=$HOME/Library/Android/sdk/emulator:\$PATH" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bash_profile'`
 ```
 
 - Reload the path environment variables by running:


### PR DESCRIPTION
# Why

Some newcomers might be running into the same issue

# How

I went through the process of creating a virtual device.
If I launched the device beforehand through the Android Studio UI, then opening went fine.
But when not, I ran into the following issue: 

```
› Opening on Android...
No Android connected device found, and no emulators could be started automatically.
Please connect a device or create an emulator (https://docs.expo.dev/workflow/android-studio-emulator).
Then follow the instructions here to enable USB debugging:
https://developer.android.com/studio/run/device.html#developer-device-options. If you are using Genymotion go to Settings -> ADB, select "Use custom Android SDK tools", and point it at your Android SDK directory.
```

This was unexpected because the iOS virtual device launched just fine.

Got inspired by this [answer](https://stackoverflow.com/a/58767984) from Stack Overflow, and added the `emulator` folder to PATH.
Opening on Android worked properly afterwards.

# Test Plan

Go through the steps from the docs with a bare Mac