### PR TITLE
[tools] Introduce sync-sdk-branch-changelogs

### DIFF
--- a/tools/src/Changelogs.ts
+++ b/tools/src/Changelogs.ts
@@ -344,7 +344,7 @@ export class Changelog {
   }
 
   /**
-   * Insert an `VERSION_EMPTY_PARAGRAPH_TEXT` version section before first published version.
+   * Inserts an `VERSION_EMPTY_PARAGRAPH_TEXT` version section before first published version.
    */
   async insertEmptyPublishedVersionAsync(
     version: string,
@@ -376,7 +376,7 @@ export class Changelog {
   }
 
   /**
-   * Remove an entry under specific version and change type.
+   * Removes an entry under specific version and change type.
    */
   async removeEntryAsync(
     version: string,
@@ -426,7 +426,7 @@ export class Changelog {
   }
 
   /**
-   * Move an entry from a version section to another. If no `newVersion` section exists, will create one.
+   * Moves an entry from a version section to another. If no `newVersion` section exists, will create one.
    */
   async moveEntryBetweenVersionsAsync(
     entry: ChangelogEntry | string,

--- a/tools/src/Changelogs.ts
+++ b/tools/src/Changelogs.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import fs from 'fs-extra';
 import semver from 'semver';
 import semverRegex from 'semver-regex';
@@ -34,6 +35,9 @@ export type ChangelogVersionChanges = Record<ChangeType, ChangelogEntry[]>;
 export type ChangelogChanges = {
   totalCount: number;
   versions: Record<string, ChangelogVersionChanges>;
+
+  // {version -> versionDate} map
+  versionDateMap: Record<string, string>;
 };
 
 /**
@@ -179,7 +183,8 @@ export class Changelog {
   ): Promise<ChangelogChanges> {
     const tokens = await this.getTokensAsync();
     const versions: ChangelogChanges['versions'] = {};
-    const changes: ChangelogChanges = { totalCount: 0, versions };
+    const versionDateMap = {};
+    const changes: ChangelogChanges = { totalCount: 0, versions, versionDateMap };
 
     let currentVersion: string | null = null;
     let currentSection: string | null = null;
@@ -205,6 +210,12 @@ export class Changelog {
 
           if (!versions[currentVersion]) {
             versions[currentVersion] = {} as ChangelogVersionChanges;
+          }
+
+          // version format is `{version} - {date}`.
+          const currentVersionDate = token.text.substring(parsedVersion.length + 3);
+          if (!versionDateMap[currentVersionDate]) {
+            versionDateMap[currentVersion] = currentVersionDate;
           }
         } else if (currentVersion && token.depth === CHANGE_TYPE_HEADING_DEPTH) {
           currentSection = token.text;
@@ -333,6 +344,125 @@ export class Changelog {
   }
 
   /**
+   * Insert an `VERSION_EMPTY_PARAGRAPH_TEXT` version section before first published version.
+   */
+  async insertEmptyPublishedVersionAsync(
+    version: string,
+    versionDate: string | null
+  ): Promise<boolean> {
+    const tokens = await this.getTokensAsync();
+
+    const versionIndex = tokens.findIndex((token) => isVersionToken(token, version));
+    if (versionIndex !== -1) {
+      throw new Error(`Version section ${version} existed.`);
+    }
+
+    const firstPublishedVersionHeadingIndex = tokens.findIndex(
+      (token) => isVersionToken(token) && !isVersionToken(token, UNPUBLISHED_VERSION_NAME)
+    );
+
+    const dateString = versionDate ?? new Date().toISOString().substring(0, 10);
+    const newSectionTokens = [
+      Markdown.createHeadingToken(`${version} - ${dateString}`, VERSION_HEADING_DEPTH),
+      {
+        type: Markdown.TokenType.PARAGRAPH,
+        text: VERSION_EMPTY_PARAGRAPH_TEXT,
+      } as Markdown.ParagraphToken,
+    ];
+
+    // Insert new tokens before first publiushed version header.
+    tokens.splice(firstPublishedVersionHeadingIndex, 0, ...newSectionTokens);
+    return true;
+  }
+
+  /**
+   * Remove an entry under specific version and change type.
+   */
+  async removeEntryAsync(
+    version: string,
+    type: ChangeType | string,
+    entry: ChangelogEntry | string
+  ): Promise<boolean> {
+    const tokens = await this.getTokensAsync();
+
+    const versionIndex = tokens.findIndex((token) => isVersionToken(token, version));
+    if (versionIndex === -1) {
+      throw new Error(`Version ${version} not found.`);
+    }
+
+    const changeTypeIndex = tokens.findIndex(
+      (token, i) => i >= versionIndex && isChangeTypeToken(token, type)
+    );
+    if (changeTypeIndex === -1) {
+      throw new Error(`Change type ${type} not found.`);
+    }
+
+    const entryText = typeof entry === 'string' ? entry : entry.message;
+    for (let i = changeTypeIndex + 1; i < tokens.length; i++) {
+      if (isVersionToken(tokens[i]) || isChangeTypeToken(tokens[i])) {
+        // Hit other section and stop iteration
+        break;
+      }
+
+      const token = tokens[i];
+      assert(Markdown.isListToken(token));
+
+      for (const [itemIndex, item] of token.items.entries()) {
+        const text = (item.tokens.find(Markdown.isTextToken)?.text ?? item.text).trim();
+        if (text === entryText) {
+          token.items.splice(itemIndex, 1);
+
+          // Remove empty change type section
+          if (token.items.length === 0) {
+            tokens.splice(i, 1);
+          }
+
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Move an entry from a version section to another. If no `newVersion` section exists, will create one.
+   */
+  async moveEntryBetweenVersionsAsync(
+    entry: ChangelogEntry | string,
+    type: ChangeType | string,
+    oldVersion: string,
+    newVersion: string,
+    newVersionDate: string | null
+  ): Promise<boolean> {
+    const removed = await this.removeEntryAsync(oldVersion, type, entry);
+    if (!removed) {
+      return false;
+    }
+
+    const tokens = await this.getTokensAsync();
+    const versionIndex = tokens.findIndex((token) => isVersionToken(token, newVersion));
+    if (versionIndex === -1) {
+      // if there's no existing version section, create one.
+      const firstPublishedVersionHeadingIndex = tokens.findIndex(
+        (token) => isVersionToken(token) && !isVersionToken(token, UNPUBLISHED_VERSION_NAME)
+      );
+
+      const dateString = newVersionDate ?? new Date().toISOString().substring(0, 10);
+      const newSectionTokens = [
+        Markdown.createHeadingToken(`${newVersion} - ${dateString}`, VERSION_HEADING_DEPTH),
+        Markdown.createHeadingToken(String(type), CHANGE_TYPE_HEADING_DEPTH),
+      ];
+
+      // Insert new tokens before first publiushed version header.
+      tokens.splice(firstPublishedVersionHeadingIndex, 0, ...newSectionTokens);
+    }
+
+    await this.insertEntriesAsync(newVersion, type, null, [entry]);
+    return true;
+  }
+
+  /**
    * Renames header of unpublished changes to given version and adds new section with unpublished changes on top.
    */
   async cutOffAsync(
@@ -389,6 +519,37 @@ export class Changelog {
       throw new Error('Tokens have not been loaded yet!');
     }
     return Markdown.render(this.tokens);
+  }
+}
+
+/**
+ * Memory based changelog
+ */
+export class MemChangelog extends Changelog {
+  content: string;
+
+  constructor(content: string) {
+    super('');
+    this.content = content;
+  }
+
+  async fileExistsAsync(): Promise<boolean> {
+    throw new Error('Unsupported function for MemChangelog.');
+  }
+
+  async saveAsync(): Promise<void> {
+    throw new Error('Unsupported function for MemChangelog.');
+  }
+
+  async getTokensAsync(): Promise<Markdown.Tokens> {
+    if (!this.tokens) {
+      try {
+        this.tokens = Markdown.lexify(this.content);
+      } catch (error) {
+        this.tokens = [];
+      }
+    }
+    return this.tokens;
   }
 }
 

--- a/tools/src/Git.ts
+++ b/tools/src/Git.ts
@@ -1,6 +1,6 @@
 import fs from 'fs-extra';
 import parseDiff from 'parse-diff';
-import { join } from 'path';
+import { join, relative } from 'path';
 
 import { spawnAsync, SpawnResult, SpawnOptions } from './Utils';
 import { EXPO_DIR } from './Constants';
@@ -406,6 +406,14 @@ export class GitDirectory {
           path: columns.slice(4).join('').trim(),
         };
       });
+  }
+
+  /**
+   * Read a file content from a given ref.
+   */
+  async readFileAsync(ref: string, path): Promise<string> {
+    const { stdout } = await this.runAsync(['show', `${ref}:${relative(EXPO_DIR, path)}`]);
+    return stdout;
   }
 
   /**

--- a/tools/src/Git.ts
+++ b/tools/src/Git.ts
@@ -409,7 +409,7 @@ export class GitDirectory {
   }
 
   /**
-   * Read a file content from a given ref.
+   * Reads a file content from a given ref.
    */
   async readFileAsync(ref: string, path): Promise<string> {
     const { stdout } = await this.runAsync(['show', `${ref}:${relative(EXPO_DIR, path)}`]);

--- a/tools/src/commands/SyncSdkBranchChangelogs.ts
+++ b/tools/src/commands/SyncSdkBranchChangelogs.ts
@@ -27,7 +27,7 @@ export default (program: Command) => {
       await Git.fetchAsync();
       console.log('');
 
-      const packages = await getPackagesAsync();
+      const packages = await getPackagesWithChangelogAsync();
 
       for (const pkg of packages) {
         let changed = false;
@@ -45,15 +45,15 @@ export default (program: Command) => {
 };
 
 /**
- * Get packages where have changelog
+ * Gets packages with a changelog file.
  */
-async function getPackagesAsync(): Promise<Package[]> {
+async function getPackagesWithChangelogAsync(): Promise<Package[]> {
   const packages = await getListOfPackagesAsync();
   return filterAsync(packages, (pkg) => pkg.hasChangelogAsync());
 }
 
 /**
- * Sync changelog of a package from `sourceBranch` to current branch
+ * Syncs changelog of a package from `sourceBranch` to current branch
  */
 async function syncChangelogAsync(pkg: Package, sourceBranch: string) {
   const sourceChangelog = new MemChangelog(

--- a/tools/src/commands/SyncSdkBranchChangelogs.ts
+++ b/tools/src/commands/SyncSdkBranchChangelogs.ts
@@ -1,0 +1,117 @@
+import chalk from 'chalk';
+import semver from 'semver';
+import { Command } from '@expo/commander';
+import { Changelog, MemChangelog, UNPUBLISHED_VERSION_NAME } from '../Changelogs';
+import Git from '../Git';
+import { Package, getListOfPackagesAsync } from '../Packages';
+import { filterAsync } from '../Utils';
+
+type CommandOptions = {
+  branch: string;
+};
+
+export default (program: Command) => {
+  program
+    .command('sync-sdk-branch-changelogs')
+    .alias('ssbc')
+    .description('Sync packages changelogs from sdk branch to current branch.')
+    .option('-b, --branch <name>', 'Source branch name')
+    .asyncAction(async (options: CommandOptions) => {
+      if (!options.branch) {
+        throw new Error(
+          'Missing branch name. Run with `--branch <name>` to specify source branch.'
+        );
+      }
+
+      console.log('\u203A Fetching git changes');
+      await Git.fetchAsync();
+      console.log('');
+
+      const packages = await getPackagesAsync();
+
+      for (const pkg of packages) {
+        let changed = false;
+        try {
+          changed = await syncChangelogAsync(pkg, options.branch);
+        } catch (e) {
+          const errorMessage = e.message ?? String(e);
+          console.error(`❌ ${chalk.red(pkg.packageName)}: ${errorMessage}`);
+        }
+        if (changed) {
+          console.log(`✅ ${pkg.packageName}`);
+        }
+      }
+    });
+};
+
+/**
+ * Get packages where have changelog
+ */
+async function getPackagesAsync(): Promise<Package[]> {
+  const packages = await getListOfPackagesAsync();
+  return filterAsync(packages, (pkg) => pkg.hasChangelogAsync());
+}
+
+/**
+ * Sync changelog of a package from `sourceBranch` to current branch
+ */
+async function syncChangelogAsync(pkg: Package, sourceBranch: string) {
+  const sourceChangelog = new MemChangelog(
+    await Git.readFileAsync(`origin/${sourceBranch}`, pkg.changelogPath)
+  );
+  const targetChangelog = new Changelog(pkg.changelogPath);
+
+  const sourceLastVersion = await sourceChangelog.getLastPublishedVersionAsync();
+  const targetLastVersion = await targetChangelog.getLastPublishedVersionAsync();
+  if (!sourceLastVersion || !targetLastVersion) {
+    throw new Error('Cannot determine latest published version');
+  }
+
+  if (semver.gt(targetLastVersion, sourceLastVersion)) {
+    throw new Error(
+      'Current version is newer than source branch and there might be some inconsistency in between, e.g. canary version published. Please update manually.'
+    );
+  } else if (semver.eq(sourceLastVersion, targetLastVersion)) {
+    return false;
+  }
+
+  const changes = await sourceChangelog.getChangesAsync(targetLastVersion, sourceLastVersion);
+
+  if (changes.totalCount < 1) {
+    return false;
+  }
+
+  delete changes.versions[UNPUBLISHED_VERSION_NAME];
+  let updated = false;
+  for (const version of Object.keys(changes.versions).sort((v1, v2) =>
+    semver.gt(v1, v2) ? 1 : -1
+  )) {
+    const groupData = changes.versions[version];
+    if (Object.keys(groupData).length === 0) {
+      const result = await targetChangelog.insertEmptyPublishedVersionAsync(
+        version,
+        changes.versionDateMap[version]
+      );
+      updated ||= result;
+      continue;
+    }
+
+    for (const [changeType, entries] of Object.entries(groupData)) {
+      for (const entry of entries) {
+        const result = await targetChangelog.moveEntryBetweenVersionsAsync(
+          entry,
+          changeType,
+          UNPUBLISHED_VERSION_NAME,
+          version,
+          changes.versionDateMap[version]
+        );
+        updated ||= result;
+      }
+    }
+  }
+  if (updated) {
+    await targetChangelog.saveAsync();
+  }
+
+  return true;
+}


### PR DESCRIPTION
# Why

make life easier when syncing changelogs from sdk branches to main

# How

1. get published versions in sdk branch changelogs
2. get changes from published versions.
3. back to current branch (main), move changed items from unpublished section to versioned section.

![Screen Shot 2022-02-24 at 10 42 09 PM](https://user-images.githubusercontent.com/46429/155551097-5f9a7b61-b7ef-4d24-876c-5b3c0f08d23f.png)

# Test Plan

[this commit](https://github.com/expo/expo/commit/b7c8f465ce9c9f25eb311ba414ec7a365b46e284) changes are mostly from this tool.
