### PR TITLE
Update sharing.md code snippet (missing dep)

### DIFF
--- a/docs/pages/tutorial/sharing.md
+++ b/docs/pages/tutorial/sharing.md
@@ -20,7 +20,7 @@ You can install expo-sharing in the same way as you installed expo-image-picker:
 <!-- prettier-ignore -->
 ```js
 import React from 'react';
-import { Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Image, StyleSheet, Text, TouchableOpacity, View, Platform } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
 /* @info As always, we must import it to use it */ import * as Sharing from 'expo-sharing'; /* @end */
 


### PR DESCRIPTION
The "Platform" has not been imported, causing errors.

# Why

Code snipped was failing with error on web app because of missing import for "Platform".

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ v] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [v ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ v] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
