### PR TITLE
[ads-admob] Set GADIsAdManagerApp in Info.plist to fix crash on startup

### DIFF
--- a/packages/expo-ads-admob/CHANGELOG.md
+++ b/packages/expo-ads-admob/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 ### 🐛 Bug fixes
+- Set `GADIsAdManagerApp` in `Info.plist` to `true`. ([#16438](https://github.com/expo/expo/pull/16438) by [@giautm](https://github.com/giautm))
 
 ### 💡 Others
 

--- a/packages/expo-ads-admob/CHANGELOG.md
+++ b/packages/expo-ads-admob/CHANGELOG.md
@@ -7,7 +7,8 @@
 ### 🎉 New features
 
 ### 🐛 Bug fixes
-- Set `GADIsAdManagerApp` in `Info.plist` to `true`. ([#16438](https://github.com/expo/expo/pull/16438) by [@giautm](https://github.com/giautm))
+
+- Fix a crash on startup by setting `GADIsAdManagerApp` in `Info.plist` to `true`. ([#16438](https://github.com/expo/expo/pull/16438) by [@giautm](https://github.com/giautm))
 
 ### 💡 Others
 

--- a/packages/expo-ads-admob/plugin/build/withAdMobIOS.js
+++ b/packages/expo-ads-admob/plugin/build/withAdMobIOS.js
@@ -29,6 +29,7 @@ function setGoogleMobileAdsAppId(config, { GADApplicationIdentifier, ...infoPlis
     return {
         ...infoPlist,
         GADApplicationIdentifier: appId,
+        GADIsAdManagerApp: true,
     };
 }
 exports.setGoogleMobileAdsAppId = setGoogleMobileAdsAppId;

--- a/packages/expo-ads-admob/plugin/src/withAdMobIOS.ts
+++ b/packages/expo-ads-admob/plugin/src/withAdMobIOS.ts
@@ -32,6 +32,7 @@ export function setGoogleMobileAdsAppId(
   return {
     ...infoPlist,
     GADApplicationIdentifier: appId,
+    GADIsAdManagerApp: true,
   };
 }
 


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/16381, close [ENG-4226](https://linear.app/expo/issue/ENG-4226/expo-ads-admob-crashes-at-runtime)

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
