### PR TITLE
[expo-dev-launcher] add auto updates integration on Android

### DIFF
--- a/apps/bare-expo/android/build.gradle
+++ b/apps/bare-expo/android/build.gradle
@@ -16,6 +16,7 @@ buildscript {
         // for expo-dev-client
         // TODO: remove once bare-expo has been upgraded to SDK 45 on main
         expoPackageVersion = "45.0.0"
+        expoUpdatesVersion = null
     }
     repositories {
         google()

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Add support for React Native `0.67.X`. ([#16038](https://github.com/expo/expo/pull/16038) by [@kudo](https://github.com/kudo))
 - Add the crash report screen. ([#16341](https://github.com/expo/expo/pull/16341) by [@lukmccall](https://github.com/lukmccall))
 - Add expo-modules automatic setup on Android. ([#16441](https://github.com/expo/expo/pull/16441) by [@esamelson](https://github.com/esamelson))
+- Add support for auto-setup with updates integration on Android. ([#16442](https://github.com/expo/expo/pull/16442) by [@esamelson](https://github.com/esamelson))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-dev-launcher/android/build.gradle
+++ b/packages/expo-dev-launcher/android/build.gradle
@@ -80,6 +80,12 @@ android {
         } else {
           srcDirs += 'src/react-native-64'
         }
+
+        if (projectIncludesExpoUpdates()) {
+          srcDirs += 'src/with-updates'
+        } else {
+          srcDirs += 'src/without-updates'
+        }
       }
     }
     debug {
@@ -123,6 +129,10 @@ dependencies {
   implementation project(":expo-manifests")
   implementation project(":expo-updates-interface")
   implementation project(":expo-dev-menu")
+
+  if (projectIncludesExpoUpdates()) {
+    implementation project(":expo-updates")
+  }
 
   //noinspection GradleDynamicVersion
   implementation 'com.facebook.react:react-native:+'  // From node_modules
@@ -189,6 +199,15 @@ def getRNVersion() {
 
 def getExpoPackageVersion() {
   return getNodeModulesPackageVersion("expo", "expoPackageVersion")
+}
+
+def projectIncludesExpoUpdates() {
+  try {
+    def version = getNodeModulesPackageVersion("expo-updates", "expoUpdatesVersion")
+    return version != null
+  } catch (Exception e) {
+    return false
+  }
 }
 
 // [BEGIN] Workaround okhttp/okio compatibility issue

--- a/packages/expo-dev-launcher/android/src/expo-45/java/expo/modules/devlauncher/DevLauncherPackageDelegate.kt
+++ b/packages/expo-dev-launcher/android/src/expo-45/java/expo/modules/devlauncher/DevLauncherPackageDelegate.kt
@@ -38,7 +38,7 @@ object DevLauncherPackageDelegate {
         override fun onCreate(application: Application?) {
           if (shouldEnableAutoSetup && application != null && application is ReactApplication) {
             DevLauncherController.initialize(application, application.reactNativeHost)
-            // TODO: optional updates
+            DevLauncherUpdatesInterfaceDelegate.initializeUpdatesInterface(application)
           }
         }
       }

--- a/packages/expo-dev-launcher/android/src/with-updates/java/expo/modules/devlauncher/DevLauncherUpdatesInterfaceDelegate.kt
+++ b/packages/expo-dev-launcher/android/src/with-updates/java/expo/modules/devlauncher/DevLauncherUpdatesInterfaceDelegate.kt
@@ -1,0 +1,10 @@
+package expo.modules.devlauncher
+
+import android.content.Context
+import expo.modules.updates.UpdatesDevLauncherController
+
+object DevLauncherUpdatesInterfaceDelegate {
+  fun initializeUpdatesInterface(context: Context) {
+    DevLauncherController.instance.updatesInterface = UpdatesDevLauncherController.initialize(context)
+  }
+}

--- a/packages/expo-dev-launcher/android/src/without-updates/java/expo/modules/devlauncher/DevLauncherUpdatesInterfaceDelegate.kt
+++ b/packages/expo-dev-launcher/android/src/without-updates/java/expo/modules/devlauncher/DevLauncherUpdatesInterfaceDelegate.kt
@@ -1,0 +1,7 @@
+package expo.modules.devlauncher
+
+import android.content.Context
+
+object DevLauncherUpdatesInterfaceDelegate {
+  fun initializeUpdatesInterface(context: Context) { }
+}


### PR DESCRIPTION
# Why

resolves ENG-2611 and resolves ENG-2662; also related ENG-4209

Add the final missing piece to #16441 , automatic updates integration if the expo-updates package is included in the project.

# How

- added a gradle script that checks to see if expo-updates can be found in node dependencies and conditionally adds both the gradle dependency and the actual logic to initialize the UpdatesInterface
- added an override capability for projects in monorepos (such as bare-expo 😛 )

# Test Plan

expo init bare
install dev-client and updates
resolve all changed packages locally
✅ project builds in debug mode
✅ can open published projects via URL bar
✅ can switch back and forth between published and local development projects

expo init bare
install dev-client (NOT) updates
resolve all changed packages locally
✅ project still builds in debug mode without updates
✅ can open local development projects
✅ trying to open published projects shows the normal alert

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
