### PR TITLE
[modules-core][Android] Add utility to infer error codes

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
@@ -32,7 +32,8 @@ open class CodedException(
     /**
      * The code is inferred from the class name — e.g. the code of `ModuleNotFoundException` becomes `ERR_MODULE_NOT_FOUND`.
      */
-    private fun inferCode(clazz: Class<*>): String {
+    @PublishedApi
+    internal fun inferCode(clazz: Class<*>): String {
       val name = requireNotNull(clazz.simpleName) { "Cannot infer code name from class name. We don't support anonymous classes." }
 
       return "ERR_" + name
@@ -42,6 +43,21 @@ open class CodedException(
     }
   }
 }
+
+/**
+ * Infers error code from the exception class name -
+ * e.g. the code of `ModuleNotFoundException` becomes `ERR_MODULE_NOT_FOUND`.
+ *
+ * Example:
+ * ```kt
+ * class NoPermissionException : CodedException()
+ * val errorCode = errorCodeOf<NoPermissionException>() // ERR_NO_PERMISSION
+ * ```
+ *
+ * **Note**: This works only if the exception class didn't overwrite the error code manually.
+ */
+inline fun <reified T : CodedException> errorCodeOf(): String =
+  CodedException.inferCode(T::class.java)
 
 internal class IncompatibleArgTypeException(
   argumentType: KType,


### PR DESCRIPTION
# Why

Really useful in tests, because we no longer have to define constants like `const val ERR_NO_PERMISSION` etc.
```kt
class NoPermissionException : CodedException()

val exception = runCatching { permissionShouldFailHere() }.exceptionOrNull()

assertEquals(errorCodeOf<NoPermissionException>(), exception.code)
```

It is possible to get this without such utility: `val errorCode = NoPermissionException().code` but this unnecessarily creates new object

# How

Added simple wrapper leveraging Kotlin generics for the existing inference code

# Test Plan

My example test case works
