### PR TITLE
[navigation-bar] Fix getVisibilityAsync crash Android 10 and older

### DIFF
--- a/packages/expo-navigation-bar/CHANGELOG.md
+++ b/packages/expo-navigation-bar/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix `getVisiblilityAsync` crashing on Android 10 and older.
+
 ### 💡 Others
 
 - Updated `@expo/config-plugins` from `4.0.2` to `4.0.14` ([#15621](https://github.com/expo/expo/pull/15621) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/expo-navigation-bar/CHANGELOG.md
+++ b/packages/expo-navigation-bar/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix `getVisiblilityAsync` crashing on Android 10 and older.
+- Fix `getVisiblilityAsync` crashing on Android 10 and older. ([#16445](https://github.com/expo/expo/pull/16445) by [@barthap](https://github.com/barthap))
 
 ### 💡 Others
 

--- a/packages/expo-navigation-bar/android/src/main/java/expo/modules/navigationbar/NavigationBarModule.kt
+++ b/packages/expo-navigation-bar/android/src/main/java/expo/modules/navigationbar/NavigationBarModule.kt
@@ -111,14 +111,14 @@ class NavigationBarModule(context: Context) : ExportedModule(context) {
   @ExpoMethod
   fun getVisibilityAsync(promise: Promise) {
     safeRunOnUiThread(promise) {
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-        val visibility = if (it.window.decorView.rootWindowInsets.isVisible(WindowInsets.Type.navigationBars())) "visible" else "hidden"
-        promise.resolve(visibility)
+      val isVisible = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        it.window.decorView.rootWindowInsets.isVisible(WindowInsets.Type.navigationBars())
       } else {
-        // TODO: Verify this works
-        @Suppress("DEPRECATION") val visibility = if ((View.SYSTEM_UI_FLAG_HIDE_NAVIGATION and it.window.decorView.systemUiVisibility) == 0) "visible" else "hidden"
-        promise.resolve(visibility)
+        @Suppress("DEPRECATION")
+        (View.SYSTEM_UI_FLAG_HIDE_NAVIGATION and it.window.decorView.systemUiVisibility) == 0
       }
+      val visibility = if (isVisible) "visible" else "hidden"
+      promise.resolve(visibility)
     }
   }
 


### PR DESCRIPTION
# Why

Fixes #16373 

# How

Looks like it was a typo-like bug. For API introduced in API 30 (Android R), we checked for `Build.VERSION_CODES.M` (Marshmallow - API 23) 😅 

Also, fixed a `// TODO: Verify this works` - it looks like it does 😉 

# Test Plan

- NCL on API 31
- NCL on API 28
