### PR TITLE
docs: remove unreferenced information

### DIFF
--- a/docs/pages/development/getting-started.md
+++ b/docs/pages/development/getting-started.md
@@ -11,9 +11,6 @@ Development builds of your app are Debug builds of your project that include the
 
 `expo-dev-client` is designed to support any workflow, release process, or set of dependencies in the Expo / React Native ecosystem. Whatever the needs of your project, either now or in the future, you'll be able to create development builds for it and get the productivity and quality of life improvements of JavaScript-driven development.
 
-Of course, there are always tradeoffs, and that flexibility means there's not just one way to get started. To help you choose the options that are right for you, these icons indicate:
-
-
 ## Installing `expo-dev-client` in your project
 
 If you have used Expo before, especially with the Managed workflow, [config plugins](/guides/config-plugins.md) will let you customize your project from JavaScript without ever needing to directly modify Xcode or Android Studio projects.


### PR DESCRIPTION
# Why

https://github.com/expo/expo/commit/0a5b256daf8f8e36a054a1e0d245b3019bd5d24d removed the icons from this docs page. However, the sentence that was leading up to these icons was left behind. Also, as we don't really highlight the tradeoffs anymore, I removed that part of the sentence as well.

# How

Manually.

# Test Plan

Mk. Eyeball II.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
