### PR TITLE
[tools] remove unused const to fix build

### DIFF
--- a/tools/src/commands/UpdateReactNative.ts
+++ b/tools/src/commands/UpdateReactNative.ts
@@ -18,7 +18,6 @@ type ActionOptions = {
 const REACT_NATIVE_SUBMODULE_PATH = getReactNativeSubmoduleDir();
 const REACT_ANDROID_PATH = path.join(ANDROID_DIR, 'ReactAndroid');
 const REACT_COMMON_PATH = path.join(ANDROID_DIR, 'ReactCommon');
-const REACT_APPLICATION_MK_PATH = path.join(REACT_ANDROID_PATH, 'src/main/jni/Application.mk');
 const REACT_ANDROID_GRADLE_PATH = path.join(REACT_ANDROID_PATH, 'build.gradle');
 
 async function checkoutReactNativeSubmoduleAsync(checkoutRef: string): Promise<void> {


### PR DESCRIPTION
# Why

Refs:
* https://github.com/expo/expo/runs/5354910505?check_suite_focus=true
* #16400

# How

This PR removes the unused constant from the `UpdateReactNative` file, which caused the failure of the build.

# Test Plan

Tools are building correctly.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
