### PR TITLE
[dev-client] Run e2e tests weekly on the latest RN version

### DIFF
--- a/.github/workflows/development-client-latest-e2e.yml
+++ b/.github/workflows/development-client-latest-e2e.yml
@@ -1,0 +1,49 @@
+name: Development Client latest e2e
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: '0 0 * * SUN' # 0:00 AM UTC time every Sunday
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  detox_latest_e2e:
+    runs-on: macos-11
+    steps:
+      - name: 👀 Checkout
+        uses: actions/checkout@v2
+      - name: 🍺 Install required tools
+        run: |
+          brew tap wix/brew
+          brew install applesimutils
+          brew install watchman
+          echo "$(pwd)/bin" >> $GITHUB_PATH
+      - name: 💎 Setup Ruby and install gems
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - name: 💎 Install cocoapods
+        run: sudo gem install cocoapods
+      - name: 🤖 Set up android emulator
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 29
+          avd-name: DevClientEmulator
+          script: echo "expo is awesome"
+      - name: 🧶 Install `expo-test-runner`
+        run: |
+          yarn global add expo-test-runner@$(cat package.json | grep '"expo-test-runner": "[0-9]*\.[0-9]*\.[0-9]*' | head -n 1 | awk '{print $2}' | sed 's/"//g; s/,//g')
+        working-directory: packages/expo-dev-client
+      - name: 🏃‍♂️ Run tests
+        run: |
+          yarn latest-e2e
+        working-directory: packages/expo-dev-client
+      - name: Store artifacts of build failures
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: expo-dev-client-latest-e2e-artifacts
+          path: packages/expo-dev-client/artifacts

--- a/packages/expo-dev-client/package.json
+++ b/packages/expo-dev-client/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0",
-    "expo-test-runner": "0.0.7"
+    "expo-test-runner": "0.0.8"
   },
   "peerDependencies": {
     "expo": "*"

--- a/packages/expo-dev-client/package.json
+++ b/packages/expo-dev-client/package.json
@@ -12,7 +12,8 @@
     "prepare": "expo-module prepare",
     "prepublishOnly": "expo-module prepublishOnly",
     "expo-module": "expo-module",
-    "e2e": "expo-test-runner run-test -t e2e"
+    "e2e": "expo-test-runner run-test -t e2e",
+    "latest-e2e": "expo-test-runner run-test -t latest-e2e"
   },
   "keywords": [
     "react-native",

--- a/packages/expo-dev-client/test-runner.config.js
+++ b/packages/expo-dev-client/test-runner.config.js
@@ -1,60 +1,74 @@
+const baseDevClientE2E = {
+  preset: 'detox',
+  reactVersion: '17.0.1',
+  reactNativeVersion: '0.67.3',
+  detoxConfigFile: '.detoxrc.js',
+  appEntryPoint: 'e2e/app/App.tsx',
+  android: {
+    mainApplication: 'e2e/android/MainApplication.java',
+    mainActivity: 'e2e/android/MainActivity.java',
+    detoxTestFile: 'e2e/android/DetoxTest.java',
+  },
+  ios: {
+    appDelegate: 'e2e/ios/AppDelegate.m',
+  },
+  dependencies: [
+    {
+      name: 'expo',
+      path: '../expo',
+    },
+    {
+      name: 'expo-modules-core',
+      path: '../expo-modules-core',
+    },
+    {
+      name: 'expo-modules-autolinking',
+      path: '../expo-modules-autolinking',
+    },
+    {
+      name: 'expo-dev-client',
+      path: '../expo-dev-client',
+    },
+    {
+      name: 'expo-dev-launcher',
+      path: '../expo-dev-launcher',
+    },
+    {
+      name: 'expo-dev-menu',
+      path: '../expo-dev-menu',
+    },
+    {
+      name: 'expo-dev-menu-interface',
+      path: '../expo-dev-menu-interface',
+    },
+    {
+      name: 'expo-manifests',
+      path: '../expo-manifests',
+    },
+    {
+      name: 'expo-updates-interface',
+      path: '../expo-updates-interface',
+    },
+  ],
+  additionalFiles: ['e2e'],
+};
+
 module.exports = {
   applications: {
     'dev-client-e2e': {
-      preset: 'detox',
-      reactVersion: '17.0.1',
-      reactNativeVersion: '0.64.2',
-      detoxConfigFile: '.detoxrc.js',
-      appEntryPoint: 'e2e/app/App.tsx',
-      android: {
-        mainApplication: 'e2e/android/MainApplication.java',
-        mainActivity: 'e2e/android/MainActivity.java',
-        detoxTestFile: 'e2e/android/DetoxTest.java',
-      },
-      ios: {
-        appDelegate: 'e2e/ios/AppDelegate.m',
-      },
-      dependencies: [
-        {
-          name: 'expo',
-          path: '../expo',
-        },
-        {
-          name: 'expo-modules-core',
-          path: '../expo-modules-core',
-        },
-        {
-          name: 'expo-modules-autolinking',
-          path: '../expo-modules-autolinking',
-        },
-        {
-          name: 'expo-dev-client',
-          path: '../expo-dev-client',
-        },
-        {
-          name: 'expo-dev-launcher',
-          path: '../expo-dev-launcher',
-        },
-        {
-          name: 'expo-dev-menu',
-          path: '../expo-dev-menu',
-        },
-        {
-          name: 'expo-dev-menu-interface',
-          path: '../expo-dev-menu-interface',
-        },
-        {
-          name: 'expo-manifests',
-          path: '../expo-manifests',
-        },
-        {
-          name: 'expo-updates-interface',
-          path: '../expo-updates-interface',
-        },
-      ],
-      additionalFiles: ['e2e'],
+      ...baseDevClientE2E,
       tests: {
         e2e: {
+          shouldRunBundler: true,
+          configurations: ['ios', 'android'],
+        },
+      },
+    },
+    'dev-client-latest-e2e': {
+      ...baseDevClientE2E,
+      reactNativeVersion: 'next',
+      tests: {
+        'latest-e2e': {
           shouldRunBundler: true,
           configurations: ['ios', 'android'],
         },


### PR DESCRIPTION
# Why

Closes ENG-2193.

# How

- Updated RN version in the base tests
- Added e2e tests which will be run with the next version of the RN
- Added a new action to run new tests weekly

# Test Plan

- run `latest-e2e` tests locally. 
