### PR TITLE
[docs] move anchors wrapper to custom Markdown header components

### DIFF
--- a/docs/ui/components/Button/index.ts
+++ b/docs/ui/components/Button/index.ts
@@ -1,2 +1,3 @@
 export { Button } from './Button';
+export type { ButtonProps } from './Button';
 export { ButtonBase } from './ButtonBase';

--- a/docs/ui/components/Markdown/index.tsx
+++ b/docs/ui/components/Markdown/index.tsx
@@ -6,7 +6,9 @@ import { Blockquote } from './Blockquote';
 
 import { DETAILS, SUMMARY } from '~/ui/components/Collapsible';
 import { Cell, HeaderCell, Row, Table, TableHead } from '~/ui/components/Table';
-import { A, H1, H2, H4, H5, CODE, P, BOLD, UL, OL, LI } from '~/ui/components/Text';
+import { A, CODE, P, BOLD, UL, OL, LI, createTextComponent } from '~/ui/components/Text';
+import { TextElement } from '~/ui/components/Text/types';
+import { withAnchor } from '~/ui/components/Text/withAnchor';
 
 type Config = ConfigStyles & {
   Component: ComponentType<ComponentProps> | string;
@@ -25,6 +27,25 @@ type ComponentProps = PropsWithChildren<{
 const headerMarginBottom = '0.5ch';
 const paragraphMarginBottom = '1ch';
 const headerPaddingTop = '1.5ch';
+
+export const H1 = withAnchor(
+  createTextComponent(TextElement.H1, css(typography.headers.default.h1))
+);
+export const H2 = withAnchor(
+  createTextComponent(TextElement.H2, css(typography.headers.default.h2))
+);
+export const H3 = withAnchor(
+  createTextComponent(TextElement.H4, css(typography.headers.default.h3))
+);
+export const H4 = withAnchor(
+  createTextComponent(TextElement.H4, css(typography.headers.default.h4))
+);
+export const H5 = withAnchor(
+  createTextComponent(TextElement.H5, css(typography.headers.default.h5))
+);
+export const H6 = withAnchor(
+  createTextComponent(TextElement.H6, css(typography.headers.default.h6))
+);
 
 const markdownStyles: Record<string, Config | null> = {
   // When using inline markdown, we need to remove the document layout wrapper.

--- a/docs/ui/components/Text/index.tsx
+++ b/docs/ui/components/Text/index.tsx
@@ -4,7 +4,6 @@ import React from 'react';
 
 import { LinkBase, LinkProps } from './Link';
 import { TextComponentProps, TextElement } from './types';
-import { withAnchor } from './withAnchor';
 
 import { durations } from '~/ui/foundations/durations';
 
@@ -55,24 +54,12 @@ const listStyle = css({
   marginLeft: '1.5rem',
 });
 
-export const H1 = withAnchor(
-  createTextComponent(TextElement.H1, css(typography.headers.default.h1))
-);
-export const H2 = withAnchor(
-  createTextComponent(TextElement.H2, css(typography.headers.default.h2))
-);
-export const H3 = withAnchor(
-  createTextComponent(TextElement.H4, css(typography.headers.default.h3))
-);
-export const H4 = withAnchor(
-  createTextComponent(TextElement.H4, css(typography.headers.default.h4))
-);
-export const H5 = withAnchor(
-  createTextComponent(TextElement.H5, css(typography.headers.default.h5))
-);
-export const H6 = withAnchor(
-  createTextComponent(TextElement.H6, css(typography.headers.default.h6))
-);
+export const H1 = createTextComponent(TextElement.H1, css(typography.headers.default.h1));
+export const H2 = createTextComponent(TextElement.H2, css(typography.headers.default.h2));
+export const H3 = createTextComponent(TextElement.H4, css(typography.headers.default.h3));
+export const H4 = createTextComponent(TextElement.H4, css(typography.headers.default.h4));
+export const H5 = createTextComponent(TextElement.H5, css(typography.headers.default.h5));
+export const H6 = createTextComponent(TextElement.H6, css(typography.headers.default.h6));
 export const P = createTextComponent(TextElement.P, css(typography.body.paragraph));
 export const CODE = createTextComponent(TextElement.CODE, css(typography.utility.inlineCode));
 export const LI = createTextComponent(TextElement.LI, css(typography.body.li));


### PR DESCRIPTION
# Why

Currently, new header components are always wrapped with `withAnchor`, which limits their usage on the custom pages.

# How

This PR adds custom Markdown header components which always will be linkable, and leave the `Text` ones as plain variant, for use on the custom pages.

I have also added an export for the `ButtonProps` type, which is handy, when implementing customized `Buttons`.

# Test Plan

Docs website compiles and works as explected.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
