### PR TITLE
[dev-launcher] fix header layout issue

### DIFF
--- a/packages/expo-dev-launcher/bundle/components/AppHeader.tsx
+++ b/packages/expo-dev-launcher/bundle/components/AppHeader.tsx
@@ -33,44 +33,49 @@ export function AppHeader({ title, subtitle, appImageUri, onUserProfilePress }: 
       <View style={{ height: insets.top }} />
 
       <Row align="center" pb="small">
-        <Row px="medium">
-          {Boolean(appImageUri) && (
-            <>
-              <Image size="xl" rounded="medium" source={{ uri: appImageUri }} />
-              <Spacer.Horizontal size="small" />
-            </>
-          )}
-
-          <View>
-            <Heading weight="semibold">{title}</Heading>
-            <Text size="small" color="secondary">
-              {subtitle}
-            </Text>
-          </View>
-        </Row>
-
-        <Spacer.Horizontal />
-
-        <Button.ScaleOnPressContainer
-          onPress={onUserProfilePress}
-          minScale={0.85}
-          accessibilityLabel="Navigate to User Profile"
-          bg="ghost"
-          rounded="full">
-          <View>
-            {isAuthenticated ? (
-              <View rounded="full" padding="small">
-                <Image size="xl" rounded="full" source={{ uri: selectedUserImage }} />
-              </View>
-            ) : (
-              <View mx="small">
-                <View bg="default" rounded="full" padding="tiny">
-                  <UserIcon />
-                </View>
-              </View>
+        <Spacer.Horizontal size="medium" />
+        <View flex="1" shrink="1">
+          <Row align="center">
+            {Boolean(appImageUri) && (
+              <>
+                <Image size="xl" rounded="large" source={{ uri: appImageUri }} />
+                <Spacer.Horizontal size="small" />
+              </>
             )}
-          </View>
-        </Button.ScaleOnPressContainer>
+
+            <View flex="1">
+              <Heading weight="semibold" numberOfLines={1}>
+                {title}
+              </Heading>
+              <Text size="small" color="secondary">
+                {subtitle}
+              </Text>
+            </View>
+          </Row>
+        </View>
+
+        <View>
+          <Button.ScaleOnPressContainer
+            onPress={onUserProfilePress}
+            minScale={0.85}
+            accessibilityLabel="Navigate to User Profile"
+            bg="ghost"
+            rounded="full">
+            <View>
+              {isAuthenticated ? (
+                <View rounded="full" padding="small">
+                  <Image size="xl" rounded="full" source={{ uri: selectedUserImage }} />
+                </View>
+              ) : (
+                <View mx="small">
+                  <View bg="default" rounded="full" padding="tiny">
+                    <UserIcon />
+                  </View>
+                </View>
+              )}
+            </View>
+          </Button.ScaleOnPressContainer>
+        </View>
       </Row>
 
       <Divider weight="thin" />


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

this was something flagged by Jon in his design feedback that was missed - long app titles were pushing the user icon off of the screen, fixed:


<img width="365" alt="Screen Shot 2022-02-28 at 1 14 29 PM" src="https://user-images.githubusercontent.com/40680668/156059802-90449ac3-6ed5-42c1-9942-5ac5501df024.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
