### PR TITLE
[dev-launcher] update button background on error prompt (dark mode)

### DIFF
--- a/packages/expo-dev-launcher/bundle/screens/HomeScreen.tsx
+++ b/packages/expo-dev-launcher/bundle/screens/HomeScreen.tsx
@@ -107,9 +107,9 @@ export function HomeScreen({
       </View>
       <ScrollView contentContainerStyle={{ paddingBottom: scale['48'] }}>
         {crashReport && (
-          <View px="medium" py="small">
-            <Button.ScaleOnPressContainer onPress={onCrashReportPress} bg="default">
-              <Row align="center" padding="medium">
+          <View px="medium" py="small" mt="small">
+            <Button.ScaleOnPressContainer onPress={onCrashReportPress} bg="default" rounded="large">
+              <Row align="center" padding="medium" bg="default">
                 <Button.Text color="default">
                   The last time you tried to open an app the development build crashed. Tap to get
                   more information.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Before: 
<img width="364" alt="Screen Shot 2022-02-28 at 2 09 45 PM" src="https://user-images.githubusercontent.com/40680668/156067116-ec0b5d94-6b53-4404-9b23-447185a09a07.png">


Makes it stand out a bit more on dark mode: 

<img width="350" alt="Screen Shot 2022-02-28 at 2 13 20 PM" src="https://user-images.githubusercontent.com/40680668/156067175-6feeedb4-5e65-400b-9d29-29f9038d0e2a.png">


