### PR TITLE
[yarn-workspace][bare-expo] Fix wrong react-native bundling

### DIFF
--- a/apps/bare-expo/metro.config.js
+++ b/apps/bare-expo/metro.config.js
@@ -8,7 +8,7 @@ module.exports = {
   // NOTE(brentvatne): This can be removed when
   // https://github.com/facebook/metro/issues/290 is fixed.
   server: {
-    enhanceMiddleware: middleware => {
+    enhanceMiddleware: (middleware) => {
       return (req, res, next) => {
         // When an asset is imported outside the project root, it has wrong path on Android
         // This happens for the back button in stack, so we fix the path to correct one
@@ -34,5 +34,17 @@ module.exports = {
         return middleware(req, res, next);
       };
     },
+  },
+
+  resolver: {
+    ...baseConfig.resolver,
+    blockList: [
+      ...baseConfig.resolver.blockList,
+
+      // Exclude react-native-lab from haste map.
+      // Because react-native versions may be different between node_modules/react-native and react-native-lab,
+      // we should use the one from node_modules for bare-expo.
+      /\breact-native-lab\b/,
+    ],
   },
 };

--- a/packages/expo-yarn-workspaces/CHANGELOG.md
+++ b/packages/expo-yarn-workspaces/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Remove deprecated metro config `blacklistRE` and drop `react-native@<0.64.0` support. ([#16479](https://github.com/expo/expo/pull/16479) by [@kudo](https://github.com/kudo))
+
 ### 🎉 New features
 
 - Support looking up .cjs (still the bundler's job to be able to handle these files; EYW just allows them to be found) ([#15836](https://github.com/expo/expo/pull/15836) by [@ide](https://github.com/ide))

--- a/packages/expo-yarn-workspaces/index.js
+++ b/packages/expo-yarn-workspaces/index.js
@@ -10,23 +10,6 @@ const path = require('path');
 
 const getSymlinkedNodeModulesForDirectory = require('./common/get-symlinked-modules');
 
-let exclusionList;
-try {
-  // blacklist was removed in the metro-config version used by
-  // react-native@0.64, but the interface is the same as the replacement,
-  // exclusionList, so we can use blacklist if it's available and otherwise
-  // use exclusionList.
-  exclusionList = require('metro-config/src/defaults/blacklist');
-} catch (e) {
-  if (e.code !== 'MODULE_NOT_FOUND') {
-    throw e;
-  }
-
-  // Require exclusionList after attempting to load blacklist, so if an error is
-  // thrown then it is the same as if we only required exclusionList.
-  exclusionList = require('metro-config/src/defaults/exclusionList');
-}
-
 /**
  * Returns a configuration object in the format expected for "metro.config.js" files. The
  * configuration:
@@ -84,10 +67,7 @@ exports.createMetroConfiguration = function createMetroConfiguration(projectPath
       providesModuleNodeModules: [],
 
       // Ignore JS files in the native Android and Xcode projects
-      blacklistRE: exclusionList([
-        /.*\/android\/React(Android|Common)\/.*/,
-        /.*\/versioned-react-native\/.*/,
-      ]),
+      blockList: [/.*\/android\/React(Android|Common)\/.*/, /.*\/versioned-react-native\/.*/],
     },
 
     transformer: {

--- a/packages/expo-yarn-workspaces/index.js
+++ b/packages/expo-yarn-workspaces/index.js
@@ -66,8 +66,12 @@ exports.createMetroConfiguration = function createMetroConfiguration(projectPath
       // Use Node-style module resolution instead of Haste everywhere
       providesModuleNodeModules: [],
 
-      // Ignore JS files in the native Android and Xcode projects
-      blockList: [/.*\/android\/React(Android|Common)\/.*/, /.*\/versioned-react-native\/.*/],
+      // Ignore test files and JS files in the native Android and Xcode projects
+      blockList: [
+        /\/__tests__\/.*/,
+        /.*\/android\/React(Android|Common)\/.*/,
+        /.*\/versioned-react-native\/.*/,
+      ],
     },
 
     transformer: {


### PR DESCRIPTION
# Why

when `react-native-lab` submodule checkout in expo/expo, bare-expo js bundle would accidentally resolve js files from `react-native-lab/react-native` but not  `node_modules/react-native`. if the two react-native versions are different, for example, when we upgrade react-native in bare-expo but not in expo-go, there are some javascript errors.

# How

- exclude `react-native-lab` from bare-expo's metro haste map.
- update expo-yarn-workspace to remove deprecated `blacklistRE` and also support array based `blockList`.
  - more context: react-native@0.63.0 with metro@0.59.0 has the old `blacklistRE`. expo sdk 42 is the last version we support for react-native 0.63 and we are going to remove sdk42 in this sdk cycle. after that react-native@0.64.0 with metro@0.64.0 has the new `blockList` property and it also supports `Array<RegExp>`, so we can just use the new `blockList` in favor of internal `exclusionList`.

# Test Plan

1. `yarn start` in bare-expo
2. download bundle by `wget -O 1.bundle 'http://localhost:8081/index.bundle?platform=ios&dev=true&minify=false&app=dev.expo.Payments&modulesOnly=false&runModule=true'`
3. check react-native-lab pattern in the bundle, by `grep react-native-lab 1.bundle`

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
