### PR TITLE
[emc] fix Kotlin compilation  warning

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
@@ -36,10 +36,11 @@ open class CodedException(
     internal fun inferCode(clazz: Class<*>): String {
       val name = requireNotNull(clazz.simpleName) { "Cannot infer code name from class name. We don't support anonymous classes." }
 
+      @Suppress("Deprecation")
       return "ERR_" + name
         .replace("(Exception)$".toRegex(), "")
         .replace("(.)([A-Z])".toRegex(), "$1_$2")
-        .uppercase(Locale.ROOT)
+        .toUpperCase(Locale.ROOT)
     }
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
@@ -39,7 +39,7 @@ open class CodedException(
       return "ERR_" + name
         .replace("(Exception)$".toRegex(), "")
         .replace("(.)([A-Z])".toRegex(), "$1_$2")
-        .toUpperCase(Locale.ROOT)
+        .uppercase(Locale.ROOT)
     }
   }
 }


### PR DESCRIPTION
# Why

<img width="1484" alt="Screenshot 2022-03-01 at 11 36 02" src="https://user-images.githubusercontent.com/719641/156153645-d7529efa-a032-43dd-8262-fec8fcb68384.png">

# How

This PR fixes the deprecated method usage warning, very simple one, but let's keeps logs clean. 😉 

# Test Plan

Package build as expected.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [X] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
