### PR TITLE
[expo-dev-launcher][expo-dev-menu] gate config plugin mods by SDK version

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Add the crash report screen. ([#16341](https://github.com/expo/expo/pull/16341) by [@lukmccall](https://github.com/lukmccall))
 - Add expo-modules automatic setup on Android. ([#16441](https://github.com/expo/expo/pull/16441) by [@esamelson](https://github.com/esamelson))
 - Add support for auto-setup with updates integration on Android. ([#16442](https://github.com/expo/expo/pull/16442) by [@esamelson](https://github.com/esamelson))
+- Remove regex-based config plugin mods in SDK 45+ projects.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Add the crash report screen. ([#16341](https://github.com/expo/expo/pull/16341) by [@lukmccall](https://github.com/lukmccall))
 - Add expo-modules automatic setup on Android. ([#16441](https://github.com/expo/expo/pull/16441) by [@esamelson](https://github.com/esamelson))
 - Add support for auto-setup with updates integration on Android. ([#16442](https://github.com/expo/expo/pull/16442) by [@esamelson](https://github.com/esamelson))
-- Remove regex-based config plugin mods in SDK 45+ projects.
+- Remove regex-based config plugin mods in SDK 45+ projects. ([#16495](https://github.com/expo/expo/pull/16495) by [@esamelson](https://github.com/esamelson))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-dev-launcher/plugin/build/withDevLauncher.js
+++ b/packages/expo-dev-launcher/plugin/build/withDevLauncher.js
@@ -215,10 +215,14 @@ const withErrorHandling = (config) => {
     return config;
 };
 const withDevLauncher = (config) => {
-    config = withDevLauncherActivity(config);
-    config = withDevLauncherApplication(config);
-    config = withDevLauncherPodfile(config);
-    config = (0, withDevLauncherAppDelegate_1.withDevLauncherAppDelegate)(config);
+    // projects using SDKs before 45 need the old regex-based integration
+    // TODO: remove these once we drop support for SDK 44
+    if (config.sdkVersion && semver_1.default.lt(config.sdkVersion, '45.0.0')) {
+        config = withDevLauncherActivity(config);
+        config = withDevLauncherApplication(config);
+        config = withDevLauncherPodfile(config);
+        config = (0, withDevLauncherAppDelegate_1.withDevLauncherAppDelegate)(config);
+    }
     config = withErrorHandling(config);
     return config;
 };

--- a/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
+++ b/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
@@ -292,10 +292,14 @@ const withErrorHandling: ConfigPlugin = (config) => {
 };
 
 const withDevLauncher = (config: ExpoConfig) => {
-  config = withDevLauncherActivity(config);
-  config = withDevLauncherApplication(config);
-  config = withDevLauncherPodfile(config);
-  config = withDevLauncherAppDelegate(config);
+  // projects using SDKs before 45 need the old regex-based integration
+  // TODO: remove these once we drop support for SDK 44
+  if (config.sdkVersion && semver.lt(config.sdkVersion, '45.0.0')) {
+    config = withDevLauncherActivity(config);
+    config = withDevLauncherApplication(config);
+    config = withDevLauncherPodfile(config);
+    config = withDevLauncherAppDelegate(config);
+  }
   config = withErrorHandling(config);
   return config;
 };

--- a/packages/expo-dev-menu/.npmignore
+++ b/packages/expo-dev-menu/.npmignore
@@ -7,6 +7,5 @@ __mocks__
 __tests__
 
 /babel.config.js
-/metro.config.js
 /android/src/androidTest/
 /android/src/test/

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Add unit tests for react app. ([#16005](https://github.com/expo/expo/pull/16005) by [@ajsmth](https://github.com/ajsmth))
 - Add expo-modules automatic setup on Android. ([#16441](https://github.com/expo/expo/pull/16441) by [@esamelson](https://github.com/esamelson))
+- Remove regex-based config plugin mods in SDK 45+ projects.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - Add unit tests for react app. ([#16005](https://github.com/expo/expo/pull/16005) by [@ajsmth](https://github.com/ajsmth))
 - Add expo-modules automatic setup on Android. ([#16441](https://github.com/expo/expo/pull/16441) by [@esamelson](https://github.com/esamelson))
-- Remove regex-based config plugin mods in SDK 45+ projects.
+- Remove regex-based config plugin mods in SDK 45+ projects. ([#16495](https://github.com/expo/expo/pull/16495) by [@esamelson](https://github.com/esamelson))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-dev-menu/package.json
+++ b/packages/expo-dev-menu/package.json
@@ -47,7 +47,8 @@
   },
   "dependencies": {
     "@expo/config-plugins": "^4.0.14",
-    "expo-dev-menu-interface": "0.5.1"
+    "expo-dev-menu-interface": "0.5.1",
+    "semver": "^7.3.5"
   },
   "devDependencies": {
     "@apollo/client": "^3.4.10",

--- a/packages/expo-dev-menu/plugin/build/withDevMenu.js
+++ b/packages/expo-dev-menu/plugin/build/withDevMenu.js
@@ -6,6 +6,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const config_plugins_1 = require("@expo/config-plugins");
 const fs_1 = __importDefault(require("fs"));
 const path_1 = __importDefault(require("path"));
+const semver_1 = __importDefault(require("semver"));
 const constants_1 = require("./constants");
 const withDevMenuAppDelegate_1 = require("./withDevMenuAppDelegate");
 const pkg = require('expo-dev-menu/package.json');
@@ -88,9 +89,13 @@ const withDevMenuPodfile = (config) => {
     ]);
 };
 const withDevMenu = (config) => {
-    config = withDevMenuActivity(config);
-    config = withDevMenuPodfile(config);
-    config = (0, withDevMenuAppDelegate_1.withDevMenuAppDelegate)(config);
+    // projects using SDKs before 45 need the old regex-based integration
+    // TODO: remove this config plugin once we drop support for SDK 44
+    if (config.sdkVersion && semver_1.default.lt(config.sdkVersion, '45.0.0')) {
+        config = withDevMenuActivity(config);
+        config = withDevMenuPodfile(config);
+        config = (0, withDevMenuAppDelegate_1.withDevMenuAppDelegate)(config);
+    }
     return config;
 };
 exports.default = (0, config_plugins_1.createRunOncePlugin)(withDevMenu, pkg.name, pkg.version);

--- a/packages/expo-dev-menu/plugin/src/withDevMenu.ts
+++ b/packages/expo-dev-menu/plugin/src/withDevMenu.ts
@@ -9,6 +9,7 @@ import {
 import { ExpoConfig } from '@expo/config-types';
 import fs from 'fs';
 import path from 'path';
+import semver from 'semver';
 
 import { InstallationPage } from './constants';
 import { withDevMenuAppDelegate } from './withDevMenuAppDelegate';
@@ -118,9 +119,13 @@ const withDevMenuPodfile: ConfigPlugin = (config) => {
 };
 
 const withDevMenu = (config: ExpoConfig) => {
-  config = withDevMenuActivity(config);
-  config = withDevMenuPodfile(config);
-  config = withDevMenuAppDelegate(config);
+  // projects using SDKs before 45 need the old regex-based integration
+  // TODO: remove this config plugin once we drop support for SDK 44
+  if (config.sdkVersion && semver.lt(config.sdkVersion, '45.0.0')) {
+    config = withDevMenuActivity(config);
+    config = withDevMenuPodfile(config);
+    config = withDevMenuAppDelegate(config);
+  }
   return config;
 };
 


### PR DESCRIPTION
# Why

ENG-4209

Now that #16190 and #16441 have landed, we will no longer need to run the regex-based config plugin mods in projects that have the new expo-modules features.

# How

- Gate the Podfile, AppDelegate, MainApplication, and MainActivity regex config plugins based on SDK version
- Rebuild
- Commit autogenerated change to .npmignore

# Test Plan

expo init (sdk 44)
add local dev-client, resolve local autolinking
expo prebuild
✅ all config plugin changes are applied as before

set `sdkVersion` to 45 in app.json
expo prebuild
✅ Podfile, AppDelegate, MainApplication, and MainActivity are not changed for dev client
✅ index.js is still changed, and URL schemes still added

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
