### PR TITLE
[expo-dev-menu] fix backwards compatibility with AppDelegate

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - Fix compatibility with react-native 0.66. ([#15914](https://github.com/expo/expo/pull/15914) by [@kudo](https://github.com/kudo))
 - Fix Android crash when using Hermes on react-native 0.67. ([#16099](https://github.com/expo/expo/pull/16099) by [@kudo](https://github.com/kudo))
+- Fix backwards compatibility with AppDelegate in existing projects.
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 - Fix compatibility with react-native 0.66. ([#15914](https://github.com/expo/expo/pull/15914) by [@kudo](https://github.com/kudo))
 - Fix Android crash when using Hermes on react-native 0.67. ([#16099](https://github.com/expo/expo/pull/16099) by [@kudo](https://github.com/kudo))
-- Fix backwards compatibility with AppDelegate in existing projects.
+- Fix backwards compatibility with AppDelegate in existing projects. ([#16497](https://github.com/expo/expo/pull/16497) by [@esamelson](https://github.com/esamelson))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/ios/DevMenuManager.swift
+++ b/packages/expo-dev-menu/ios/DevMenuManager.swift
@@ -70,6 +70,12 @@ open class DevMenuManager: NSObject {
   lazy var appInstance: DevMenuAppInstance = DevMenuAppInstance(manager: self)
 
   var currentScreen: String?
+
+  /**
+   For backwards compatibility in projects that call this method from AppDelegate
+   */
+  @objc
+  public static func configure(withBridge bridge: AnyObject) { }
   
   @objc
   public var currentBridge: RCTBridge? {

--- a/packages/expo-dev-menu/ios/DevMenuManager.swift
+++ b/packages/expo-dev-menu/ios/DevMenuManager.swift
@@ -74,6 +74,7 @@ open class DevMenuManager: NSObject {
   /**
    For backwards compatibility in projects that call this method from AppDelegate
    */
+  @available(*, deprecated, message: "Manual setup of DevMenuManager in AppDelegate is deprecated in favor of automatic setup with Expo Modules")
   @objc
   public static func configure(withBridge bridge: AnyObject) { }
   


### PR DESCRIPTION
# Why

ENG-4209

Noticed that https://github.com/expo/expo/commit/86220016092e1a20549eafb3c60f8fe3f3320cad inadvertently broke backwards compatibility with any projects that have the dev menu AppDelegate integration (i.e. that have dev menu but not dev launcher).

# How

Stub in the function called from the [config plugin](https://github.com/expo/expo/blob/79333a097f4e731c6d32cd54a72c6fd94e462c13/packages/expo-dev-menu/plugin/src/withDevMenuAppDelegate.ts#L12).

# Test Plan

SDK 44 project with dev menu (but not dev launcher) builds

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
