### PR TITLE
[cli] Added offline support to cli network requests

### DIFF
--- a/packages/expo/cli/api/__mocks__/settings.ts
+++ b/packages/expo/cli/api/__mocks__/settings.ts
@@ -1,0 +1,3 @@
+export const APISettings = {
+  isOffline: false,
+};

--- a/packages/expo/cli/api/rest/__tests__/wrapFetchWithOffline-test.ts
+++ b/packages/expo/cli/api/rest/__tests__/wrapFetchWithOffline-test.ts
@@ -1,0 +1,25 @@
+import { APISettings } from '../../settings';
+import { wrapFetchWithOffline } from '../wrapFetchWithOffline';
+
+jest.mock('../../settings', () => ({
+  APISettings: {
+    isOffline: true,
+  },
+}));
+
+describe(wrapFetchWithOffline, () => {
+  it(`supports normal requests`, async () => {
+    APISettings.isOffline = false;
+    const input = jest.fn();
+    const next = wrapFetchWithOffline(input);
+    await next('https://example.com/', {});
+    expect(input).toBeCalledWith('https://example.com/', {});
+  });
+  it(`times out instantly when offline`, async () => {
+    APISettings.isOffline = true;
+    const input = jest.fn();
+    const next = wrapFetchWithOffline(input);
+    await next('https://example.com/', {});
+    expect(input).toBeCalledWith('https://example.com/', { timeout: 1 });
+  });
+});

--- a/packages/expo/cli/api/rest/__tests__/wrapFetchWithProgress-test.ts
+++ b/packages/expo/cli/api/rest/__tests__/wrapFetchWithProgress-test.ts
@@ -10,11 +10,14 @@ import { wrapFetchWithProgress } from '../wrapFetchWithProgress';
 const fs = jest.requireActual('fs') as typeof import('fs');
 const pipeline = promisify(Stream.pipeline);
 
+const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
+  fn as jest.MockedFunction<T>;
+
 jest.mock(`../../../log`);
 
 describe(wrapFetchWithProgress, () => {
   beforeEach(() => {
-    jest.mock('../../../log').resetAllMocks();
+    asMock(Log.warn).mockClear();
   });
   it('should call the progress callback', async () => {
     const url = 'https://example.com';

--- a/packages/expo/cli/api/rest/client.ts
+++ b/packages/expo/cli/api/rest/client.ts
@@ -10,6 +10,7 @@ import { FileSystemCache } from './cache/FileSystemCache';
 import { wrapFetchWithCache } from './cache/wrapFetchWithCache';
 import { FetchLike } from './client.types';
 import { wrapFetchWithBaseUrl } from './wrapFetchWithBaseUrl';
+import { wrapFetchWithOffline } from './wrapFetchWithOffline';
 
 export class ApiV2Error extends Error {
   readonly name = 'ApiV2Error';
@@ -86,7 +87,9 @@ export function wrapFetchWithCredentials(fetchFunction: FetchLike): FetchLike {
   };
 }
 
-const fetchWithBaseUrl = wrapFetchWithBaseUrl(fetchInstance, getExpoApiBaseUrl() + '/v2/');
+const fetchWithOffline = wrapFetchWithOffline(fetchInstance);
+
+const fetchWithBaseUrl = wrapFetchWithBaseUrl(fetchWithOffline, getExpoApiBaseUrl() + '/v2/');
 
 const fetchWithCredentials = wrapFetchWithCredentials(fetchWithBaseUrl);
 

--- a/packages/expo/cli/api/rest/wrapFetchWithOffline.ts
+++ b/packages/expo/cli/api/rest/wrapFetchWithOffline.ts
@@ -1,0 +1,14 @@
+import * as Log from '../../log';
+import { APISettings } from '../settings';
+import { FetchLike } from './client.types';
+
+/** Wrap fetch with support for APISettings offline mode. */
+export function wrapFetchWithOffline(fetchFunction: FetchLike): FetchLike {
+  return async function fetchWithOffline(url, options = {}) {
+    if (APISettings.isOffline) {
+      Log.debug('[fetch] Offline: Skipping network request: ' + url);
+      options.timeout = 1;
+    }
+    return fetchFunction(url, options);
+  };
+}

--- a/packages/expo/cli/api/settings.ts
+++ b/packages/expo/cli/api/settings.ts
@@ -1,0 +1,9 @@
+// This file represents temporary globals for the CLI when using the API.
+// Settings should be as minimal as possible since they are globals.
+
+export const APISettings: {
+  /** Should the CLI skip making network requests. */
+  isOffline: boolean;
+} = {
+  isOffline: false,
+};

--- a/packages/expo/cli/api/user/UserSettings.ts
+++ b/packages/expo/cli/api/user/UserSettings.ts
@@ -56,7 +56,6 @@ function getSession(): SessionData | null {
 }
 
 function getAccessToken(): string | null {
-  // TODO: Move to env
   return process.env.EXPO_TOKEN ?? null;
 }
 

--- a/packages/expo/cli/api/user/__mocks__/user.ts
+++ b/packages/expo/cli/api/user/__mocks__/user.ts
@@ -1,2 +1,3 @@
 export const getUserAsync = jest.fn(async () => ({}));
 export const loginAsync = jest.fn();
+export const ANONYMOUS_USERNAME = 'anonymous';

--- a/packages/expo/cli/start/doctor/dependencies/bundledNativeModules.ts
+++ b/packages/expo/cli/start/doctor/dependencies/bundledNativeModules.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 import resolveFrom from 'resolve-from';
 
 import { getNativeModuleVersionsAsync } from '../../../api/getNativeModuleVersions';
+import { APISettings } from '../../../api/settings';
 import * as Log from '../../../log';
 import { CommandError } from '../../../utils/errors';
 
@@ -19,7 +20,7 @@ export async function getBundledNativeModulesAsync(
   projectRoot: string,
   sdkVersion: string
 ): Promise<BundledNativeModules> {
-  if (sdkVersion === 'UNVERSIONED') {
+  if (sdkVersion === 'UNVERSIONED' || APISettings.isOffline) {
     return await getBundledNativeModulesFromExpoPackageAsync(projectRoot);
   } else {
     try {


### PR DESCRIPTION
# Why

- Split out of https://github.com/expo/expo/pull/16160

# How

- Adds the offline functionality from Expo CLI which simply locks the timeout to 1ms.

# Test Plan

- CI should pass.