### PR TITLE
[docs] Mask permissions when creating SSH priv key

### DIFF
--- a/docs/pages/build-reference/git-submodules.mdx
+++ b/docs/pages/build-reference/git-submodules.mdx
@@ -35,8 +35,9 @@ mkdir -p ~/.ssh
 # git remote set-url origin git@github.com:example/repo.git
 
 # restore private key from env variable and generate public key
+umask 0177
 echo "$SSH_KEY_BASE64" | base64 -d > ~/.ssh/id_rsa
-chmod 0600 ~/.ssh/id_rsa
+umask 0022
 ssh-keygen -y -f ~/.ssh/id_rsa > ~/.ssh/id_rsa.pub
 
 # add your git provider to the list of known hosts


### PR DESCRIPTION
# Why

In the Git submodule docs there's a race condition between creating the SSH private key and setting its permissions.

It's generally better to set the umask so that the permissions are correct up front rather than having the permissions incorrect initially until they are changed.

If the example eas-build-pre-install hook is only used on the build servers it probably won't make a difference, but if someone uses it on a multi-user system, their private key would be exposed very briefly if it's done with a create followed by a chmod.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

```
$ umask 0177
$ echo test >id_rsa
$ ls -l id_rsa 
-rw------- 1 michael michael 5 Mar  3 11:30 id_rsa
$ umask 0022
$ echo test >id_rsa.pub
$ ls -l id_rsa.pub 
-rw-r--r-- 1 michael michael 5 Mar  3 11:30 id_rsa.pub
```

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
