### PR TITLE
Adapt obsolete `adb` instructions

### DIFF
--- a/docs/pages/workflow/android-studio-emulator.md
+++ b/docs/pages/workflow/android-studio-emulator.md
@@ -39,6 +39,8 @@ echo "export PATH=$HOME/Library/Android/sdk/platform-tools:\$PATH" >> ~/`[[ $SHE
 source ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bash_profile'`
 ```
 
+- Finally, make sure that you can run `adb --version` from your terminal.
+
 ## Step 2: Set up a virtual device
 
 - On the Android Studio main screen, click "Configure", then "AVD Manager" in the dropdown.

--- a/docs/pages/workflow/android-studio-emulator.md
+++ b/docs/pages/workflow/android-studio-emulator.md
@@ -39,8 +39,6 @@ echo "export PATH=$HOME/Library/Android/sdk/platform-tools:\$PATH" >> ~/`[[ $SHE
 source ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bash_profile'`
 ```
 
-- Finally, make sure that you can run `adb` from your terminal.
-
 ## Step 2: Set up a virtual device
 
 - On the Android Studio main screen, click "Configure", then "AVD Manager" in the dropdown.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

We have had multiple students report `adb` fails for them on the command line, but Expo still works just fine with their virtual devices

# How

<!--
How did you build this feature or fix this bug and why?
-->

Tested with multiple students

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Tested with multiple students

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
