### PR TITLE
[expo-dev-client][bare-expo] restore ability of host apps to disable dev client

### DIFF
--- a/apps/bare-expo/android/app/src/main/java/dev/expo/payments/MainApplication.java
+++ b/apps/bare-expo/android/app/src/main/java/dev/expo/payments/MainApplication.java
@@ -17,8 +17,10 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import expo.modules.ReactNativeHostWrapper;
 import expo.modules.ApplicationLifecycleDispatcher;
+import expo.modules.devlauncher.DevLauncherPackageDelegate;
 
 public class MainApplication extends Application implements ReactApplication {
+  static final boolean USE_DEV_CLIENT = false;
 
   private final ReactNativeHost mReactNativeHost = new ReactNativeHostWrapper(
     this,
@@ -55,6 +57,9 @@ public class MainApplication extends Application implements ReactApplication {
     super.onCreate();
     SoLoader.init(this, /* native exopackage */ false);
     ReactNativeFlipper.initializeFlipper(this);
+    if (!USE_DEV_CLIENT) {
+      DevLauncherPackageDelegate.enableAutoSetup = false;
+    }
     ApplicationLifecycleDispatcher.onApplicationCreate(this);
   }
 

--- a/apps/bare-expo/ios/BareExpo/AppDelegate.swift
+++ b/apps/bare-expo/ios/BareExpo/AppDelegate.swift
@@ -8,10 +8,7 @@
 
 import Foundation
 import ExpoModulesCore
-import EXDevMenuInterface
-#if EX_DEV_MENU_ENABLED
-import EXDevMenu
-#endif
+import EXDevLauncher
 
 #if FB_SONARKIT_ENABLED && canImport(FlipperKit)
 import FlipperKit
@@ -19,8 +16,14 @@ import FlipperKit
 
 @UIApplicationMain
 class AppDelegate: ExpoAppDelegate, RCTBridgeDelegate {
+  let useDevClient: Bool = false
+
   override func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
     initializeFlipper(with: application)
+
+    if (!useDevClient) {
+      ExpoDevLauncherReactDelegateHandler.enableAutoSetup = false
+    }
 
     let bridge = reactDelegate.createBridge(delegate: self, launchOptions: launchOptions)
     let rootView = reactDelegate.createRootView(bridge: bridge, moduleName: "main", initialProperties: nil)

--- a/packages/expo-dev-launcher/android/src/expo-44/java/expo/modules/devlauncher/DevLauncherPackageDelegate.kt
+++ b/packages/expo-dev-launcher/android/src/expo-44/java/expo/modules/devlauncher/DevLauncherPackageDelegate.kt
@@ -12,6 +12,9 @@ import expo.modules.devlauncher.modules.DevLauncherModule
 import expo.modules.devlauncher.modules.DevLauncherAuth
 
 object DevLauncherPackageDelegate {
+  @JvmField
+  var enableAutoSetup: Boolean? = null
+
   fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> =
     listOf(
       DevLauncherModule(reactContext),

--- a/packages/expo-dev-launcher/android/src/expo-45/java/expo/modules/devlauncher/DevLauncherPackageDelegate.kt
+++ b/packages/expo-dev-launcher/android/src/expo-45/java/expo/modules/devlauncher/DevLauncherPackageDelegate.kt
@@ -18,10 +18,19 @@ import expo.modules.devlauncher.modules.DevLauncherModule
 import expo.modules.devlauncher.modules.DevLauncherAuth
 
 object DevLauncherPackageDelegate {
-  val shouldEnableAutoSetup: Boolean by lazy {
-    // Backwards compatibility -- if the MainApplication has already set up expo-dev-launcher,
-    // we just skip auto-setup in this case.
-    !DevLauncherController.wasInitialized()
+  @JvmField
+  var enableAutoSetup: Boolean? = null
+  private val shouldEnableAutoSetup: Boolean by lazy {
+    if (enableAutoSetup != null) {
+      // if someone else has set this explicitly, use that value
+      return@lazy enableAutoSetup!!
+    }
+    if (DevLauncherController.wasInitialized()) {
+      // Backwards compatibility -- if the MainApplication has already set up expo-dev-launcher,
+      // we just skip auto-setup in this case.
+      return@lazy false
+    }
+    return@lazy true
   }
 
   fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> =

--- a/packages/expo-dev-launcher/android/src/release/java/expo/modules/devlauncher/DevLauncherPackageDelegate.kt
+++ b/packages/expo-dev-launcher/android/src/release/java/expo/modules/devlauncher/DevLauncherPackageDelegate.kt
@@ -8,6 +8,9 @@ import expo.modules.core.interfaces.ReactActivityLifecycleListener
 import expo.modules.core.interfaces.ReactActivityHandler
 
 object DevLauncherPackageDelegate {
+  @JvmField
+  var enableAutoSetup: Boolean? = null
+
   fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> = emptyList()
   fun createApplicationLifecycleListeners(context: Context?): List<ApplicationLifecycleListener> = emptyList()
   fun createReactActivityLifecycleListeners(activityContext: Context?): List<ReactActivityLifecycleListener> = emptyList()

--- a/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
+++ b/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
@@ -5,13 +5,20 @@ import EXDevMenu
 import EXUpdatesInterface
 
 public class ExpoDevLauncherReactDelegateHandler: ExpoReactDelegateHandler, RCTBridgeDelegate, EXDevLauncherControllerDelegate {
+  public static var enableAutoSetup: Bool?
+
   private weak var reactDelegate: ExpoReactDelegate?
   private var bridgeDelegate: RCTBridgeDelegate?
   private var launchOptions: [AnyHashable : Any]?
   private var deferredRootView: EXDevLauncherDeferredRCTRootView?
   private var rootViewModuleName: String?
   private var rootViewInitialProperties: [AnyHashable : Any]?
-  public static var shouldEnableAutoSetup: Bool = {
+  static var shouldEnableAutoSetup: Bool = {
+    // if someone else has set this explicitly, use that value
+    if enableAutoSetup != nil {
+      return enableAutoSetup!
+    }
+
     if !EXAppDefines.APP_DEBUG {
       return false
     }
@@ -28,7 +35,7 @@ public class ExpoDevLauncherReactDelegateHandler: ExpoReactDelegateHandler, RCTB
   required init() {
     super.init()
     // DevLauncherController will handle dev menu configuration, so dev menu auto-setup is not needed
-    ExpoDevMenuReactDelegateHandler.shouldEnableAutoSetup = false
+    ExpoDevMenuReactDelegateHandler.enableAutoSetup = false
   }
 
   public override func createBridge(reactDelegate: ExpoReactDelegate, bridgeDelegate: RCTBridgeDelegate, launchOptions: [AnyHashable : Any]?) -> RCTBridge? {

--- a/packages/expo-dev-menu/android/src/expo-44/java/expo/modules/devmenu/DevMenuPackageDelegate.kt
+++ b/packages/expo-dev-menu/android/src/expo-44/java/expo/modules/devmenu/DevMenuPackageDelegate.kt
@@ -5,6 +5,9 @@ import expo.modules.core.interfaces.ReactActivityHandler
 import expo.modules.core.interfaces.ReactActivityLifecycleListener
 
 object DevMenuPackageDelegate {
+  @JvmField
+  var enableAutoSetup: Boolean? = null
+
   fun createReactActivityLifecycleListeners(activityContext: Context?): List<ReactActivityLifecycleListener> = emptyList()
   fun createReactActivityHandlers(activityContext: Context?): List<ReactActivityHandler> = emptyList()
 }

--- a/packages/expo-dev-menu/android/src/expo-45/java/expo/modules/devmenu/DevMenuPackageDelegate.kt
+++ b/packages/expo-dev-menu/android/src/expo-45/java/expo/modules/devmenu/DevMenuPackageDelegate.kt
@@ -11,10 +11,21 @@ import expo.modules.core.interfaces.ReactActivityLifecycleListener
 import expo.modules.devmenu.react.DevMenuAwareReactActivity
 
 object DevMenuPackageDelegate {
-  // Backwards compatibility -- if the MainActivity is already an instance of
-  // DevMenuAwareReactActivity, we just skip auto-setup in this case.
-  fun shouldEnableAutoSetup(activityContext: Context?): Boolean =
-    !(activityContext != null && activityContext is DevMenuAwareReactActivity)
+  @JvmField
+  var enableAutoSetup: Boolean? = null
+
+  fun shouldEnableAutoSetup(activityContext: Context?): Boolean {
+    if (enableAutoSetup != null) {
+      // if someone else has set this explicitly, use that value
+      return enableAutoSetup!!
+    }
+    if (activityContext != null && activityContext is DevMenuAwareReactActivity) {
+      // Backwards compatibility -- if the MainActivity is already an instance of
+      // DevMenuAwareReactActivity, we skip auto-setup.
+      return false
+    }
+    return true
+  }
 
   fun createReactActivityLifecycleListeners(activityContext: Context?): List<ReactActivityLifecycleListener> {
     if (!shouldEnableAutoSetup(activityContext)) {

--- a/packages/expo-dev-menu/android/src/release/java/expo/modules/devmenu/DevMenuPackageDelegate.kt
+++ b/packages/expo-dev-menu/android/src/release/java/expo/modules/devmenu/DevMenuPackageDelegate.kt
@@ -5,6 +5,9 @@ import expo.modules.core.interfaces.ReactActivityHandler
 import expo.modules.core.interfaces.ReactActivityLifecycleListener
 
 object DevMenuPackageDelegate {
+  @JvmField
+  var enableAutoSetup: Boolean? = null
+
   fun createReactActivityLifecycleListeners(activityContext: Context?): List<ReactActivityLifecycleListener> = emptyList()
   fun createReactActivityHandlers(activityContext: Context?): List<ReactActivityHandler> = emptyList()
 }

--- a/packages/expo-dev-menu/ios/ReactDelegateHandler/ExpoDevMenuReactDelegateHandler.swift
+++ b/packages/expo-dev-menu/ios/ReactDelegateHandler/ExpoDevMenuReactDelegateHandler.swift
@@ -3,10 +3,18 @@
 import ExpoModulesCore
 
 public class ExpoDevMenuReactDelegateHandler: ExpoReactDelegateHandler {
-  public static var shouldEnableAutoSetup: Bool = {
+  public static var enableAutoSetup: Bool?
+
+  private static var shouldEnableAutoSetup: Bool = {
+    // if someone else has set this explicitly, use that value
+    if enableAutoSetup != nil {
+      return enableAutoSetup!
+    }
+
     if !EXAppDefines.APP_DEBUG {
       return false
     }
+
     return true
   }()
 


### PR DESCRIPTION
# Why

#16190 and #16441 took away the ability of host apps (like bare-expo) to disable launching the dev client in debug builds. This PR adds the functionality back to the libraries and bare-expo.

# How

- Added a publicly accessible static variable to the ReactDelegate/Package classes that, if set, overrides the default `shouldEnableAutoSetup` value. I decided to keep this simple & not documented for now since it is mostly for our internal use.
- Returned bare-expo to its default of running with the dev launcher disabled.

# Test Plan

bare-expo:
✅ build with useDevClient = false doesn’t start launcher, loads test-suite app right away
✅ build with useDevClient = true starts launcher

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
