### PR TITLE
[expo-dev-launcher] remove initialization side effects

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Simplify dev-launcher / dev-menu relationship on iOS. ([#16067](https://github.com/expo/expo/pull/16067) by [@ajsmth](https://github.com/ajsmth))
 - Simplify dev-launcher / dev-menu relationship on Android. ([#16228](https://github.com/expo/expo/pull/16228) by [@ajsmth](https://github.com/ajsmth))
 - Compatibility with expo-dev-menu auto-setup on iOS. ([#16496](https://github.com/expo/expo/pull/16496) by [@esamelson](https://github.com/esamelson))
+- Remove initialization side effects. ([#16522](https://github.com/expo/expo/pull/16522) by [@esamelson](https://github.com/esamelson))
 
 ## 0.10.4 — 2022-02-07
 

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -77,8 +77,6 @@
     self.errorManager = [[EXDevLauncherErrorManager alloc] initWithController:self];
     self.installationIDHelper = [EXDevLauncherInstallationIDHelper new];
     self.shouldPreferUpdatesInterfaceSourceUrl = NO;
-
-    EXDevLauncherBundleURLProviderInterceptor.isInstalled = true;
   }
   return self;
 }
@@ -173,6 +171,7 @@
 {
   _delegate = delegate;
   _launchOptions = launchOptions;
+  EXDevLauncherBundleURLProviderInterceptor.isInstalled = true;
 }
 
 - (void)autoSetupStart:(UIWindow *)window

--- a/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
+++ b/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
@@ -32,16 +32,13 @@ public class ExpoDevLauncherReactDelegateHandler: ExpoReactDelegateHandler, RCTB
     return true
   }()
 
-  required init() {
-    super.init()
-    // DevLauncherController will handle dev menu configuration, so dev menu auto-setup is not needed
-    ExpoDevMenuReactDelegateHandler.enableAutoSetup = false
-  }
-
   public override func createBridge(reactDelegate: ExpoReactDelegate, bridgeDelegate: RCTBridgeDelegate, launchOptions: [AnyHashable : Any]?) -> RCTBridge? {
     if !ExpoDevLauncherReactDelegateHandler.shouldEnableAutoSetup {
       return nil
     }
+
+    // DevLauncherController will handle dev menu configuration, so dev menu auto-setup is not needed
+    ExpoDevMenuReactDelegateHandler.enableAutoSetup = false
 
     self.reactDelegate = reactDelegate
     self.bridgeDelegate = EXRCTBridgeDelegateInterceptor(bridgeDelegate: bridgeDelegate, interceptor: self)


### PR DESCRIPTION
# Why

When testing #16521 I ran into an unexpected issue caused by a side effect of object initialization, which reminded me that it's an anti-pattern.

I added another instance of this recently in #16496 😅 so removed this and the one other place I encountered an issue with.

# How

- Move `EXDevLauncherBundleURLProviderInterceptor.isInstalled = true` (which causes swizzling) out of `EXDevLauncherController.init` and into `autoSetupPrepare`.
- Moved `ExpoDevMenuReactDelegateHandler.enableAutoSetup = false` to the createBridge method, which is safe because ExpoDevMenuReactDelegateHandler only implements the createRootView method.

# Test Plan

✅ Used breakpoints to verify that our swizzled `guessPackagerHost` is still called on launch, and the original implementation in RCTBundleURLProvider is not
✅ Used breakpoints to verify that the DevMenuManager is not configured by ExpoDevMenuReactDelegateHandler

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
