### PR TITLE
[sweet api][android] Add validators & required fields to records

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
@@ -2,6 +2,7 @@ package expo.modules.kotlin.exception
 
 import com.facebook.react.bridge.ReadableType
 import java.util.*
+import kotlin.reflect.KProperty1
 import kotlin.reflect.KType
 
 /**
@@ -84,8 +85,14 @@ internal class MethodNotFoundException :
 internal class NullArgumentException :
   CodedException(message = "Cannot assigned null to not nullable type.")
 
+internal class FieldRequiredException(property: KProperty1<*, *>) :
+  CodedException(message = "Value for field '$property' is required, got nil")
+
 internal class UnexpectedException(val throwable: Throwable) :
   CodedException(message = throwable.toString(), throwable)
+
+internal class ValidationException(message: String) :
+  CodedException(message = message)
 
 /**
  * A base class for all exceptions used in `exceptionDecorator` function.

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/FieldValidator.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/FieldValidator.kt
@@ -1,0 +1,15 @@
+package expo.modules.kotlin.records
+
+import expo.modules.kotlin.exception.ValidationException
+
+interface FieldValidator<T> {
+  fun validate(value: T)
+}
+
+class NumericRangeValidator<T : Comparable<T>>(private val from: T, private val to: T) : FieldValidator<T> {
+  override fun validate(value: T) {
+    if (value < from || to <= value) {
+      throw ValidationException("Value should be in range $from - $to, got $value")
+    }
+  }
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/RecordTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/RecordTypeConverter.kt
@@ -4,23 +4,41 @@ import com.facebook.react.bridge.Dynamic
 import expo.modules.kotlin.allocators.ObjectConstructor
 import expo.modules.kotlin.allocators.ObjectConstructorFactory
 import expo.modules.kotlin.exception.FieldCastException
+import expo.modules.kotlin.exception.FieldRequiredException
 import expo.modules.kotlin.exception.RecordCastException
 import expo.modules.kotlin.exception.exceptionDecorator
 import expo.modules.kotlin.recycle
 import expo.modules.kotlin.types.TypeConverter
 import expo.modules.kotlin.types.TypeConverterProvider
 import kotlin.reflect.KClass
+import kotlin.reflect.KProperty1
 import kotlin.reflect.KType
+import kotlin.reflect.full.createInstance
 import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.memberProperties
 import kotlin.reflect.jvm.javaField
 
-// TODO(@lukmccall): create all converters during initialization
 class RecordTypeConverter<T : Record>(
   private val converterProvider: TypeConverterProvider,
   val type: KType,
 ) : TypeConverter<T>(type.isMarkedNullable) {
   private val objectConstructorFactory = ObjectConstructorFactory()
+  private val propertyDescriptors: Map<KProperty1<out Any, *>, PropertyDescriptor> =
+    (type.classifier as KClass<*>)
+      .memberProperties
+      .map { property ->
+        val fieldAnnotation = property.findAnnotation<Field>() ?: return@map null
+        val typeConverter = converterProvider.obtainTypeConverter(property.returnType)
+
+        return@map property to PropertyDescriptor(
+          typeConverter,
+          fieldAnnotation,
+          isRequired = property.findAnnotation<Required>() != null,
+          validators = getValidators(property)
+        )
+      }
+      .filterNotNull()
+      .toMap()
 
   override fun convertNonOptional(value: Dynamic): T = exceptionDecorator({ cause -> RecordCastException(type, cause) }) {
     val jsMap = value.asMap()
@@ -28,24 +46,31 @@ class RecordTypeConverter<T : Record>(
     val kClass = type.classifier as KClass<*>
     val instance = getObjectConstructor(kClass.java).construct()
 
-    kClass
-      .memberProperties
-      .map { property ->
-        val filedInformation = property.findAnnotation<Field>() ?: return@map
-        val jsKey = filedInformation.key.takeUnless { it == "" } ?: property.name
+    propertyDescriptors
+      .forEach { (property, descriptor) ->
+        val jsKey = descriptor.fieldAnnotation.key.takeUnless { it.isBlank() } ?: property.name
 
         if (!jsMap.hasKey(jsKey)) {
-          // TODO(@lukmccall): handle required keys
-          return@map
+          if (descriptor.isRequired) {
+            throw FieldRequiredException(property)
+          }
+
+          return@forEach
         }
 
         jsMap.getDynamic(jsKey).recycle {
           val javaField = property.javaField!!
 
-          val elementConverter = converterProvider.obtainTypeConverter(property.returnType)
           val casted = exceptionDecorator({ cause -> FieldCastException(property.name, property.returnType, type, cause) }) {
-            elementConverter.convert(this)
+            descriptor.typeConverter.convert(this)
           }
+
+          descriptor
+            .validators
+            .forEach { validator ->
+              @Suppress("UNCHECKED_CAST")
+              (validator as FieldValidator<Any?>).validate(casted)
+            }
 
           javaField.isAccessible = true
           javaField.set(instance, casted)
@@ -59,4 +84,26 @@ class RecordTypeConverter<T : Record>(
   private fun <T> getObjectConstructor(clazz: Class<T>): ObjectConstructor<T> {
     return objectConstructorFactory.get(clazz)
   }
+
+  private fun getValidators(property: KProperty1<out Any, *>): List<FieldValidator<*>> {
+    return property
+      .annotations
+      .map findValidators@{ annotation ->
+        val binderAnnotation = annotation.annotationClass.findAnnotation<BindUsing>()
+          ?: return@findValidators null
+        annotation to binderAnnotation
+      }
+      .filterNotNull()
+      .map { (annotation, binderAnnotation) ->
+        val binderInstance = binderAnnotation.binder.createInstance() as ValidationBinder
+        binderInstance.bind(annotation)
+      }
+  }
+
+  private data class PropertyDescriptor(
+    val typeConverter: TypeConverter<*>,
+    val fieldAnnotation: Field,
+    val isRequired: Boolean,
+    val validators: List<FieldValidator<*>>
+  )
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/Required.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/Required.kt
@@ -1,0 +1,5 @@
+package expo.modules.kotlin.records
+
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Required

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/ValidationBinder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/ValidationBinder.kt
@@ -1,0 +1,39 @@
+package expo.modules.kotlin.records
+
+import kotlin.reflect.KClass
+
+interface ValidationBinder {
+  fun bind(annotation: Annotation): FieldValidator<*>
+}
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.ANNOTATION_CLASS)
+annotation class BindUsing(val binder: KClass<*>)
+
+internal class IntRangeBinder: ValidationBinder {
+  override fun bind(annotation: Annotation): FieldValidator<*> {
+    val rangeAnnotation = annotation as IntRange
+    return NumericRangeValidator(rangeAnnotation.from, rangeAnnotation.to)
+  }
+}
+
+internal class LongRangeBinder: ValidationBinder {
+  override fun bind(annotation: Annotation): FieldValidator<*> {
+    val rangeAnnotation = annotation as LongRange
+    return NumericRangeValidator(rangeAnnotation.from, rangeAnnotation.to)
+  }
+}
+
+internal class FloatRangeBinder: ValidationBinder {
+  override fun bind(annotation: Annotation): FieldValidator<*> {
+    val rangeAnnotation = annotation as FloatRange
+    return NumericRangeValidator(rangeAnnotation.from, rangeAnnotation.to)
+  }
+}
+
+internal class DoubleRangeBinder: ValidationBinder {
+  override fun bind(annotation: Annotation): FieldValidator<*> {
+    val rangeAnnotation = annotation as DoubleRange
+    return NumericRangeValidator(rangeAnnotation.from, rangeAnnotation.to)
+  }
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/ValidationBinder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/ValidationBinder.kt
@@ -10,28 +10,28 @@ interface ValidationBinder {
 @Target(AnnotationTarget.ANNOTATION_CLASS)
 annotation class BindUsing(val binder: KClass<*>)
 
-internal class IntRangeBinder: ValidationBinder {
+internal class IntRangeBinder : ValidationBinder {
   override fun bind(annotation: Annotation): FieldValidator<*> {
     val rangeAnnotation = annotation as IntRange
     return NumericRangeValidator(rangeAnnotation.from, rangeAnnotation.to)
   }
 }
 
-internal class LongRangeBinder: ValidationBinder {
+internal class LongRangeBinder : ValidationBinder {
   override fun bind(annotation: Annotation): FieldValidator<*> {
     val rangeAnnotation = annotation as LongRange
     return NumericRangeValidator(rangeAnnotation.from, rangeAnnotation.to)
   }
 }
 
-internal class FloatRangeBinder: ValidationBinder {
+internal class FloatRangeBinder : ValidationBinder {
   override fun bind(annotation: Annotation): FieldValidator<*> {
     val rangeAnnotation = annotation as FloatRange
     return NumericRangeValidator(rangeAnnotation.from, rangeAnnotation.to)
   }
 }
 
-internal class DoubleRangeBinder: ValidationBinder {
+internal class DoubleRangeBinder : ValidationBinder {
   override fun bind(annotation: Annotation): FieldValidator<*> {
     val rangeAnnotation = annotation as DoubleRange
     return NumericRangeValidator(rangeAnnotation.from, rangeAnnotation.to)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/Validators.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/Validators.kt
@@ -1,0 +1,25 @@
+package expo.modules.kotlin.records
+
+import kotlin.reflect.KClass
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.PROPERTY, AnnotationTarget.TYPE, AnnotationTarget.VALUE_PARAMETER)
+@BindUsing(IntRangeBinder::class)
+annotation class IntRange(val from: Int, val to: Int)
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.PROPERTY)
+@BindUsing(LongRangeBinder::class)
+annotation class LongRange(val from: Long, val to: Long)
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.PROPERTY)
+@BindUsing(FloatRangeBinder::class)
+annotation class FloatRange(val from: Float, val to: Float)
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.PROPERTY)
+@BindUsing(DoubleRangeBinder::class)
+annotation class DoubleRange(val from: Double, val to: Double)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/Validators.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/Validators.kt
@@ -1,9 +1,5 @@
 package expo.modules.kotlin.records
 
-import kotlin.reflect.KClass
-import kotlin.reflect.KType
-import kotlin.reflect.typeOf
-
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.PROPERTY, AnnotationTarget.TYPE, AnnotationTarget.VALUE_PARAMETER)
 @BindUsing(IntRangeBinder::class)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
@@ -68,6 +68,7 @@ object TypeConverterProviderImpl : TypeConverterProvider {
       return EnumTypeConverter(kClass as KClass<Enum<*>>, type.isMarkedNullable)
     }
 
+    // TODO(@lukmccall): cache record type converters
     if (kClass.isSubclassOf(Record::class)) {
       return RecordTypeConverter<Record>(this, type)
     }

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/records/RecordTypeConverterTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/records/RecordTypeConverterTest.kt
@@ -6,8 +6,6 @@ import com.facebook.react.bridge.JavaOnlyMap
 import com.google.common.truth.Truth
 import expo.modules.kotlin.types.convert
 import org.junit.Test
-import kotlin.reflect.KFunction
-import kotlin.reflect.typeOf
 
 class RecordTypeConverterTest {
   @Test


### PR DESCRIPTION
# Why

Part of https://linear.app/expo/issue/ENG-4123/more-customized-arguments-validation

# How

I've decided to finally add a required field and validators to the records structure. The required field was pretty much straightforward. However, validators were very tricky to implement.  First of all, we have something called `ValidationBinder`.  It's an annotation that you have to add to the final validator annotation to transfer data from annotation to the validator class itself. Let me explain that in more detail using an example:

To create a custom validator: `@IntRange` you will have to define an annotation (that can receive custom arguments) and connect to the binder using `@BindUsing` annotation. The `@BindUsing` requires one argument - class of the binder. The binder implementation will have to convert an annotation object `@IntRange` to an instance of `FieldValidator`. This object is used later to check if the js value is correct. 

# Test Plan

- unit tests ✅