### PR TITLE
Update media-library.md

### DIFF
--- a/docs/pages/versions/unversioned/sdk/media-library.md
+++ b/docs/pages/versions/unversioned/sdk/media-library.md
@@ -47,7 +47,7 @@ Learn how to configure the native projects in the [installation instructions in 
         {
           "photosPermission": "Allow $(PRODUCT_NAME) to access your photos.",
           "savePhotosPermission": "Allow $(PRODUCT_NAME) to save photos.",
-          "isAccessMediaLocationEnabled": true
+          "isAccessMediaLocationEnabled": false
         }
       ]
     ]
@@ -60,7 +60,7 @@ Learn how to configure the native projects in the [installation instructions in 
 <ConfigPluginProperties properties={[
 { name: 'photosPermission', platform: 'ios', description: 'Sets the iOS `NSPhotoLibraryUsageDescription` permission message in Info.plist.', default: '"Allow $(PRODUCT_NAME) to access your photos."' },
 { name: 'savePhotosPermission', platform: 'ios', description: 'Sets the iOS `NSPhotoLibraryAddUsageDescription` permission message in Info.plist.', default: '"Allow $(PRODUCT_NAME) to save photos."' },
-{ name: 'isAccessMediaLocationEnabled', platform: 'android', description: 'Sets whether or not to request the `ACCESS_MEDIA_LOCATION` permission on Android.', default: 'false' },
+{ name: 'isAccessMediaLocationEnabled', platform: 'android', description: 'Sets whether or not to request the `ACCESS_MEDIA_LOCATION` permission on Android.', default: 'true' },
 ]} />
 
 ## API


### PR DESCRIPTION
Ref: https://github.com/expo/expo/blob/c3c052a24696187831f6943d74fb6d190594823c/packages/expo-media-library/plugin/src/withMediaLibrary.ts#L55

If we pass `true` to `isAccessMediaLocationEnabled`, it fails to run the plugin.

```shell
[android.manifest]: withAndroidManifestBaseMod: permission.includes is not a function
```

According to the logic, it is set `isAccessMediaLocationEnabled` to `true` by default.

# Why

The document and the code are not matched. So I update the document to match it to the code logic.

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
