### PR TITLE
[home] add 'recently opened' projects section to redesigned home screen

### DIFF
--- a/home/components/PressableOpacity.tsx
+++ b/home/components/PressableOpacity.tsx
@@ -1,24 +1,26 @@
 import { useExpoTheme, View } from 'expo-dev-client-components';
-import React, { PropsWithChildren } from 'react';
-import { PressableProps, Pressable, Platform, ViewStyle } from 'react-native';
+import React, { PropsWithChildren, ComponentProps } from 'react';
+import { PressableProps, Pressable, Platform } from 'react-native';
+
+type DCCViewProps = ComponentProps<typeof View>;
 
 type Props = PressableProps & {
   activeOpacity?: number;
   borderRadius?: number;
-  containerStyle?: ViewStyle;
+  containerProps?: DCCViewProps;
 };
 
 export function PressableOpacity({
   activeOpacity,
   borderRadius,
   style,
-  containerStyle,
+  containerProps,
   ...rest
 }: Props) {
   const theme = useExpoTheme();
 
   return (
-    <BorderRadiusContainer borderRadius={borderRadius} style={containerStyle}>
+    <BorderRadiusContainer borderRadius={borderRadius} {...containerProps}>
       <Pressable
         style={({ pressed }) => {
           const pressedStyles = typeof style === 'function' ? style({ pressed }) : style;
@@ -45,7 +47,7 @@ export function PressableOpacity({
 type BorderRadiusContainerProps = PropsWithChildren<
   {
     borderRadius?: number;
-  } & React.ComponentProps<typeof View>
+  } & DCCViewProps
 >;
 
 function BorderRadiusContainer({
@@ -54,10 +56,10 @@ function BorderRadiusContainer({
   children,
   ...props
 }: BorderRadiusContainerProps) {
-  if (!borderRadius) return <>{children}</>;
-
   return (
-    <View style={[{ borderRadius, overflow: 'hidden' }, style]} {...props}>
+    <View
+      style={[borderRadius ? { borderRadius, overflow: 'hidden' } : undefined, style]}
+      {...props}>
       {children}
     </View>
   );

--- a/home/screens/HomeScreen/AppIcon.tsx
+++ b/home/screens/HomeScreen/AppIcon.tsx
@@ -4,19 +4,12 @@ import * as React from 'react';
 import { StyleSheet, Image } from 'react-native';
 import FadeIn from 'react-native-fade-in-image';
 
-import { Ionicons } from '../../../components/Icons';
-import Colors from '../../../constants/Colors';
-
-type IconProps = React.ComponentProps<typeof Ionicons>;
-
-type DevelopmentServerImageProps = {
-  icon?: IconProps['name'];
-  iconStyle?: IconProps['style'];
+type Props = {
   image?: number | string | null;
 };
 
-export function DevelopmentServerImage(props: DevelopmentServerImageProps) {
-  const { icon, iconStyle, image } = props;
+export function AppIcon(props: Props) {
+  const { image } = props;
 
   if (image !== undefined) {
     if (image === null) {
@@ -31,17 +24,6 @@ export function DevelopmentServerImage(props: DevelopmentServerImageProps) {
         </View>
       );
     }
-  } else if (icon) {
-    return (
-      <View height="8" width="8" style={[styles.iconContainer]}>
-        <Ionicons
-          style={[styles.icon, iconStyle]}
-          name={icon}
-          lightColor={Colors.light.text}
-          darkColor="#fff"
-        />
-      </View>
-    );
   } else {
     return null;
   }

--- a/home/screens/HomeScreen/DevelopmentServerListItem/DevelopmentServerSubtitle.tsx
+++ b/home/screens/HomeScreen/DevelopmentServerListItem/DevelopmentServerSubtitle.tsx
@@ -1,15 +1,11 @@
 import * as React from 'react';
 import { StyleSheet, Text as RNText } from 'react-native';
 
-import { Ionicons } from '../../../components/Icons';
 import Colors from '../../../constants/Colors';
-
-type IconProps = React.ComponentProps<typeof Ionicons>;
 
 type DevelopmentServerSubtitleProps = {
   title?: string;
   subtitle?: string;
-  icon?: IconProps['name'];
   onPressSubtitle?: () => any;
   image?: number | string | null;
 };
@@ -17,11 +13,10 @@ type DevelopmentServerSubtitleProps = {
 export function DevelopmentServerSubtitle({
   title,
   subtitle,
-  icon,
   image,
   onPressSubtitle,
 }: DevelopmentServerSubtitleProps) {
-  const isCentered = !title && !icon && !image;
+  const isCentered = !title && !image;
 
   return subtitle ? (
     <RNText

--- a/home/screens/HomeScreen/DevelopmentServerListItem/index.tsx
+++ b/home/screens/HomeScreen/DevelopmentServerListItem/index.tsx
@@ -2,13 +2,13 @@ import { ChevronDownIcon, spacing } from '@expo/styleguide-native';
 import { NavigationProp, useNavigation } from '@react-navigation/native';
 import { useExpoTheme } from 'expo-dev-client-components';
 import * as React from 'react';
-import { View as RNView, StyleSheet, ViewStyle, Pressable, Share, Linking } from 'react-native';
+import { View as RNView, StyleSheet, ViewStyle, Share, Linking } from 'react-native';
 
-import { Ionicons } from '../../../components/Icons';
 import PlatformIcon from '../../../components/PlatformIcon';
+import { PressableOpacity } from '../../../components/PressableOpacity';
 import { ProfileStackRoutes } from '../../../navigation/Navigation.types';
 import * as UrlUtils from '../../../utils/UrlUtils';
-import { DevelopmentServerImage } from './DevelopmentServerImage';
+import { AppIcon } from '../AppIcon';
 import { DevelopmentServerSubtitle } from './DevelopmentServerSubtitle';
 import { DevelopmentServerTitle } from './DevelopmentServerTitle';
 
@@ -23,8 +23,6 @@ type Props = {
   onPressSubtitle?: () => any;
   renderExtraText?: () => any;
   margins?: boolean;
-  icon?: IconProps['name'];
-  iconStyle?: IconProps['style'];
   image?: number | string | null;
   imageStyle?: ViewStyle;
   arrowForward?: boolean;
@@ -39,7 +37,6 @@ type Props = {
   };
 };
 
-type IconProps = React.ComponentProps<typeof Ionicons>;
 type PlatformIconProps = React.ComponentProps<typeof PlatformIcon>;
 
 export function DevelopmentServerListItem({
@@ -47,8 +44,6 @@ export function DevelopmentServerListItem({
   subtitle,
   title,
   url,
-  icon,
-  iconStyle,
   image,
   experienceInfo,
   disabled,
@@ -77,24 +72,18 @@ export function DevelopmentServerListItem({
   };
 
   return (
-    <Pressable
+    <PressableOpacity
       accessibilityRole="button"
       android_disableSound
       onPress={handlePress}
       onLongPress={handleLongPress}
-      style={({ pressed }) => [
-        styles.container,
-        style,
-        disabled && styles.disabled,
-        pressed && styles.pressed,
-      ]}
+      style={[styles.container, style, disabled && styles.disabled]}
       disabled={disabled}>
-      <DevelopmentServerImage icon={icon} image={image} iconStyle={iconStyle} />
+      <AppIcon image={image} />
       <RNView style={[styles.contentContainer]}>
         <RNView style={[styles.textContainer]}>
           <DevelopmentServerTitle title={title} platform={platform} />
           <DevelopmentServerSubtitle
-            icon={icon}
             title={title}
             subtitle={username ?? subtitle}
             image={image}
@@ -108,7 +97,7 @@ export function DevelopmentServerListItem({
           />
         </RNView>
       </RNView>
-    </Pressable>
+    </PressableOpacity>
   );
 }
 

--- a/home/screens/HomeScreen/DevelopmentServersPlaceholder.tsx
+++ b/home/screens/HomeScreen/DevelopmentServersPlaceholder.tsx
@@ -13,8 +13,9 @@ import {
   View,
 } from 'expo-dev-client-components';
 import * as React from 'react';
-import { Animated, Platform, Pressable, Linking } from 'react-native';
+import { Animated, Platform, Linking } from 'react-native';
 
+import { PressableOpacity } from '../../components/PressableOpacity';
 import { ModalStackRoutes } from '../../navigation/Navigation.types';
 import {
   alertWithCameraPermissionInstructions,
@@ -86,13 +87,7 @@ export function DevelopmentServersPlaceholder() {
         <>
           <Divider />
           <View padding="medium">
-            <Pressable
-              style={({ pressed }) => [
-                {
-                  opacity: pressed ? 0.8 : 1,
-                },
-              ]}
-              onPress={() => setShowInput((prevState) => !prevState)}>
+            <PressableOpacity onPress={() => setShowInput((prevState) => !prevState)}>
               <Row align="center">
                 <Animated.View
                   style={{ transform: [{ rotate: interpolateRotating }], marginRight: spacing[2] }}>
@@ -100,7 +95,7 @@ export function DevelopmentServersPlaceholder() {
                 </Animated.View>
                 <Text>Enter URL manually</Text>
               </Row>
-            </Pressable>
+            </PressableOpacity>
             {showInput ? <Spacer.Vertical size="medium" /> : null}
             {showInput ? (
               <View>
@@ -121,23 +116,22 @@ export function DevelopmentServersPlaceholder() {
                   placeholderTextColor={theme.text.secondary}
                 />
                 <Spacer.Vertical size="small" />
-                <Pressable
+                <PressableOpacity
                   onPress={openURL}
                   disabled={!url}
-                  style={({ pressed }) => [
+                  style={[
                     {
                       backgroundColor: theme.button.tertiary.background,
                       padding: spacing[2],
                       borderRadius: borderRadius.medium,
                       justifyContent: 'center',
                       alignItems: 'center',
-                      opacity: pressed ? 0.8 : !url ? 0.5 : 1,
                     },
                   ]}>
                   <Button.Text color="tertiary" weight="semibold">
                     Connect
                   </Button.Text>
-                </Pressable>
+                </PressableOpacity>
               </View>
             ) : null}
           </View>
@@ -146,13 +140,7 @@ export function DevelopmentServersPlaceholder() {
       {FeatureFlags.ENABLE_PROJECT_TOOLS && FeatureFlags.ENABLE_QR_CODE_BUTTON ? (
         <>
           <Divider />
-          <Pressable
-            style={({ pressed }) => [
-              {
-                opacity: pressed ? 0.8 : 1,
-              },
-            ]}
-            onPress={handleQRPressAsync}>
+          <PressableOpacity onPress={handleQRPressAsync}>
             <Row padding="medium" align="center">
               <QrCodeIcon
                 size={iconSize.small}
@@ -161,7 +149,7 @@ export function DevelopmentServersPlaceholder() {
               />
               <Text>Scan QR code</Text>
             </Row>
-          </Pressable>
+          </PressableOpacity>
         </>
       ) : null}
     </View>

--- a/home/screens/HomeScreen/RecentlyOpenedHeader.tsx
+++ b/home/screens/HomeScreen/RecentlyOpenedHeader.tsx
@@ -1,0 +1,36 @@
+import { spacing } from '@expo/styleguide-native';
+import { Button, Heading, Row, Text } from 'expo-dev-client-components';
+import * as React from 'react';
+import { Platform } from 'react-native';
+
+type Props = {
+  onClearPress: () => void;
+};
+
+export function RecentlyOpenedHeader({ onClearPress }: Props) {
+  return (
+    <Row px="small" py="small" align="center" justify="between">
+      <Heading
+        color="secondary"
+        size="small"
+        style={{ marginRight: spacing[2], fontWeight: Platform.OS === 'ios' ? '600' : 'bold' }}>
+        Recently opened
+      </Heading>
+      <Button.Container onPress={onClearPress}>
+        <Text
+          color="secondary"
+          style={{
+            fontSize: 11,
+            letterSpacing: 0.92,
+            ...Platform.select({
+              ios: {
+                fontWeight: '500',
+              },
+            }),
+          }}>
+          CLEAR
+        </Text>
+      </Button.Container>
+    </Row>
+  );
+}

--- a/home/screens/HomeScreen/RecentlyOpenedListItem/index.tsx
+++ b/home/screens/HomeScreen/RecentlyOpenedListItem/index.tsx
@@ -1,0 +1,105 @@
+import { borderRadius, ChevronDownIcon, spacing } from '@expo/styleguide-native';
+import { Text, useExpoTheme } from 'expo-dev-client-components';
+import * as React from 'react';
+import { View as RNView, StyleSheet, ViewStyle, Share, Platform } from 'react-native';
+
+import { PressableOpacity } from '../../../components/PressableOpacity';
+import * as UrlUtils from '../../../utils/UrlUtils';
+import { AppIcon } from '../AppIcon';
+
+type Props = {
+  style?: ViewStyle;
+  disabled?: boolean;
+  title?: string;
+  image?: number | string | null;
+  url: string;
+  onPress?: () => void;
+};
+
+export function RecentlyOpenedListItem({ title, url, image, disabled, style, onPress }: Props) {
+  const theme = useExpoTheme();
+
+  const handleLongPress = () => {
+    const message = UrlUtils.normalizeUrl(url);
+    Share.share({
+      title: url,
+      message,
+      url: message,
+    });
+  };
+
+  return (
+    <PressableOpacity
+      accessibilityRole="button"
+      android_disableSound
+      onPress={onPress}
+      onLongPress={handleLongPress}
+      style={[styles.container, style, disabled && styles.disabled]}
+      disabled={disabled}
+      borderRadius={borderRadius.large}
+      containerProps={{ bg: 'default' }}>
+      <AppIcon image={image} />
+      <RNView style={[styles.contentContainer]}>
+        <Text
+          style={{
+            flex: 1,
+            fontSize: 15,
+            ...Platform.select({
+              ios: {
+                fontWeight: '500',
+              },
+              android: {
+                fontWeight: '400',
+              },
+            }),
+          }}
+          ellipsizeMode="tail"
+          numberOfLines={1}>
+          {title}
+        </Text>
+        <RNView style={styles.chevronRightContainer}>
+          <ChevronDownIcon
+            style={{ transform: [{ rotate: '-90deg' }] }}
+            color={theme.icon.secondary}
+          />
+        </RNView>
+      </RNView>
+    </PressableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  infoText: {
+    marginTop: spacing[2],
+  },
+  releaseChannel: {
+    marginTop: spacing[2],
+  },
+  container: {
+    flexDirection: 'row',
+    padding: spacing[4],
+    justifyContent: 'space-between',
+  },
+  disabled: {
+    opacity: 0.5,
+  },
+  pressed: {
+    opacity: 0.8,
+  },
+  contentContainer: {
+    backgroundColor: 'transparent',
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  textContainer: {
+    flex: 1,
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'flex-start',
+  },
+  chevronRightContainer: {
+    alignSelf: 'center',
+    marginStart: spacing[2],
+  },
+});

--- a/home/screens/HomeScreen/RecentlyOpenedSection.tsx
+++ b/home/screens/HomeScreen/RecentlyOpenedSection.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Linking } from 'react-native';
+
+import { HistoryList } from '../../types';
+import { RecentlyOpenedListItem } from './RecentlyOpenedListItem';
+
+type Props = {
+  recentHistory: HistoryList;
+};
+
+export function RecentlyOpenedSection({ recentHistory }: Props) {
+  return (
+    <>
+      {recentHistory.map((project) => {
+        if (!project) return null;
+
+        return (
+          <RecentlyOpenedListItem
+            key={project.manifestUrl}
+            url={project.manifestUrl}
+            image={
+              // TODO(wschurman): audit for new manifests
+              project.manifest && 'iconUrl' in project.manifest
+                ? project.manifest.iconUrl
+                : undefined
+            }
+            title={
+              // TODO(wschurman): audit for new manifests
+              project.manifest && 'name' in project.manifest ? project.manifest.name : undefined
+            }
+            onPress={() => {
+              // TODO(fiberjw): navigate to the project details screen
+              Linking.openURL(project.url);
+            }}
+          />
+        );
+      })}
+    </>
+  );
+}

--- a/home/screens/HomeScreen/index.tsx
+++ b/home/screens/HomeScreen/index.tsx
@@ -14,6 +14,7 @@ import ScrollView from '../../components/NavigationScrollView';
 import RefreshControl from '../../components/RefreshControl';
 import ThemedStatusBar from '../../components/ThemedStatusBar';
 import { HomeStackRoutes } from '../../navigation/Navigation.types';
+import HistoryActions from '../../redux/HistoryActions';
 import { useDispatch, useSelector } from '../../redux/Hooks';
 import { DevSession, HistoryList } from '../../types';
 import addListenerWithNativeCallback from '../../utils/addListenerWithNativeCallback';
@@ -22,6 +23,8 @@ import isUserAuthenticated from '../../utils/isUserAuthenticated';
 import { DevelopmentServerListItem } from './DevelopmentServerListItem';
 import { DevelopmentServersHeader } from './DevelopmentServersHeader';
 import { DevelopmentServersPlaceholder } from './DevelopmentServersPlaceholder';
+import { RecentlyOpenedHeader } from './RecentlyOpenedHeader';
+import { RecentlyOpenedSection } from './RecentlyOpenedSection';
 
 const PROJECT_UPDATE_INTERVAL = 10000;
 
@@ -166,6 +169,12 @@ class ProjectsView extends React.Component<Props, State> {
           ) : (
             <DevelopmentServersPlaceholder />
           )}
+          {this.props.recentHistory.count() ? (
+            <>
+              <RecentlyOpenedHeader onClearPress={this._handlePressClearHistory} />
+              <RecentlyOpenedSection recentHistory={this.props.recentHistory} />
+            </>
+          ) : null}
         </ScrollView>
         <ThemedStatusBar />
       </View>
@@ -199,6 +208,10 @@ class ProjectsView extends React.Component<Props, State> {
     } else {
       this._stopPollingForProjects();
     }
+  };
+
+  private _handlePressClearHistory = () => {
+    this.props.dispatch(HistoryActions.clearHistory());
   };
 
   private _startPollingForProjects = async () => {


### PR DESCRIPTION
This is a recreation of https://github.com/expo/expo/pull/16494 without the React Navigation 6 upgrade.

# How

I added a section to the new HomeScreen that hooks into the existing `recentHistory` fetching code to render a new 'Recently opened' section that reflects the Figma designs.

I also updated a few places to use PressableOpacity.

# Test Plan

Tested on iOS and Android:

![Screenshot_20220301-155208](https://user-images.githubusercontent.com/12488826/156248938-faf542ac-c9de-4c78-87e5-7ed1d49a324d.png)

![IMG_4652](https://user-images.githubusercontent.com/12488826/156248921-8f0b61bd-cf0e-4285-bec6-8f0580ff6862.PNG)
 