### PR TITLE
[android][image-picker] Match MediaLibrary.requestPermissionsAsync() to ImagePicker.requestMediaLibraryPermissionsAsync()

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Updated `requestMediaLibraryPermissionsAsync` to ask `ACCESS_MEDIA_LOCATION` permission so that a user can access to image asset info on Android. ([#16541](https://github.com/expo/expo/pull/16541) by [@jparksecurity](https://github.com/jparksecurity))
+
 ### 💡 Others
 
 - Updated `@expo/config-plugins` from `4.0.2` to `4.0.14` ([#15621](https://github.com/expo/expo/pull/15621) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
@@ -7,6 +7,7 @@ import android.content.Intent
 import android.graphics.Bitmap
 import android.media.MediaMetadataRetriever
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import android.provider.MediaStore
 import android.util.Log
@@ -179,11 +180,11 @@ class ImagePickerModule(
   //region helpers
 
   private fun getMediaLibraryPermissions(writeOnly: Boolean): Array<String> {
-    return if (writeOnly) {
-      arrayOf(Manifest.permission.WRITE_EXTERNAL_STORAGE)
-    } else {
-      arrayOf(Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.READ_EXTERNAL_STORAGE)
-    }
+    return listOfNotNull(
+      Manifest.permission.WRITE_EXTERNAL_STORAGE,
+      Manifest.permission.READ_EXTERNAL_STORAGE.takeIf { !writeOnly },
+      Manifest.permission.ACCESS_MEDIA_LOCATION.takeIf { Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q }
+    ).toTypedArray()
   }
 
   private fun launchCameraWithPermissionsGranted(promise: Promise, cameraIntent: Intent, pickerOptions: ImagePickerOptions) {


### PR DESCRIPTION
Match `getMediaLibraryPermissions` to [getManifestPermissions](https://github.com/expo/expo/blob/master/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.kt#L342-L348)

@barthap  I know you work on an issue related to ACCESS_MEDIA_LOCATION

Ref: https://github.com/expo/expo/issues/15273#issuecomment-1005440392

Is there anything we should be concerned about in my proposal?

# Why

making `MediaLibrary.requestPermissionsAsync()` and `ImagePicker.requestMediaLibraryPermissionsAsync()` identical on Android because it is already on iOS.

Ref: https://github.com/expo/expo/issues/11504#issuecomment-844555347

# How

update `getMediaLibraryPermissions` to match `getManifestPermissions`

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
