### PR TITLE
[autolinking][android] Fix `cannot cast object 'ExpoAutolinkingManager@' with class 'ExpoAutolinkingManager' to class 'ExpoAutolinkingManager'`

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unpublished
 
 - Update require logic to find transitive deps that would not be hoisted at the top of the monorepo ([#16419](https://github.com/expo/expo/pull/16419) by [@Titozzz](https://github.com/Titozzz))
+- Fix `cannot cast object 'ExpoAutolinkingManager@' with class 'ExpoAutolinkingManager' to class 'ExpoAutolinkingManager'` on Android when a project is using `buildSrc`.
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unpublished
 
 - Update require logic to find transitive deps that would not be hoisted at the top of the monorepo ([#16419](https://github.com/expo/expo/pull/16419) by [@Titozzz](https://github.com/Titozzz))
-- Fix `cannot cast object 'ExpoAutolinkingManager@' with class 'ExpoAutolinkingManager' to class 'ExpoAutolinkingManager'` on Android when a project is using `buildSrc`.
+- Fix `cannot cast object 'ExpoAutolinkingManager@' with class 'ExpoAutolinkingManager' to class 'ExpoAutolinkingManager'` on Android when a project is using `buildSrc`. ([#16545](https://github.com/expo/expo/pull/16545) by [@lukmccall](https://github.com/lukmccall))
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-modules-autolinking/scripts/android/autolinking_implementation.gradle
+++ b/packages/expo-modules-autolinking/scripts/android/autolinking_implementation.gradle
@@ -131,7 +131,7 @@ class Colors {
 
 // We can't cast a manager that is created in `settings.gradle` to the `ExpoAutolinkingManager` 
 // because if someone is using `buildSrc`, the `ExpoAutolinkingManager` class 
-// will be loaded by two different class loader - `settings.gradle` will used a diffrent loader. 
+// will be loaded by two different class loader - `settings.gradle` will use a diffrent loader. 
 // In the JVM, classes are equal only if were loaded by the same loader.
 // There is nothing that we can do in that case, but to make our code safer, we check if the class name is the same.
 def validateExpoAutolinkingManager(manager) {

--- a/packages/expo-modules-autolinking/scripts/android/autolinking_implementation.gradle
+++ b/packages/expo-modules-autolinking/scripts/android/autolinking_implementation.gradle
@@ -129,6 +129,16 @@ class Colors {
   static final String RESET = "\u001B[0m"
 }
 
+// We can't cast a manager that is created in `settings.gradle` to the `ExpoAutolinkingManager` 
+// because if someone is using `buildSrc`, the `ExpoAutolinkingManager` class 
+// will be loaded by two different class loader - `settings.gradle` will used a diffrent loader. 
+// In the JVM, classes are equal only if were loaded by the same loader.
+// There is nothing that we can do in that case, but to make our code safer, we check if the class name is the same.
+def validateExpoAutolinkingManager(manager) {
+  assert ExpoAutolinkingManager.name == manager.getClass().name
+  return manager
+}
+
 // Here we split the implementation, depending on Gradle context.
 // `rootProject` is a `ProjectDescriptor` if this file is imported in `settings.gradle` context,
 // otherwise we can assume it is imported in `build.gradle`.
@@ -159,7 +169,7 @@ if (rootProject instanceof ProjectDescriptor) {
   }
 
   def addDependencies = { DependencyHandler handler, Project project ->
-    ExpoAutolinkingManager manager = gradle.ext.expoAutolinkingManager
+    def manager = validateExpoAutolinkingManager(gradle.ext.expoAutolinkingManager)
     def modules = manager.getModules()
 
     if (!modules.length) {
@@ -196,7 +206,7 @@ if (rootProject instanceof ProjectDescriptor) {
       return
     }
 
-    ExpoAutolinkingManager manager = gradle.ext.expoAutolinkingManager
+    def manager = validateExpoAutolinkingManager(gradle.ext.expoAutolinkingManager)
 
     if (rootProject.findProject(':expo-modules-core')) {
       // `expo` requires `expo-modules-core` as a dependency, even if autolinking is turned off.


### PR DESCRIPTION
# Why

Closes ENG-4204.

# How

If a project is using `buildSrc`, the Gradle will use different class loaders for `settings.gradle` and for `build.gradle` scripts in modules. Because of that, we can't cast manager created in `settings.gradle` to `ExpoAutolinkingManager` in the `build.gradle` of expo package. I didn't find any workaround, but we don't have to make that cast. 

# Test Plan

- build project with `buildSrc` ✅
