### PR TITLE
expo-module-template: Add scripts + missing dev dependency

### DIFF
--- a/packages/expo-module-template/$package.json
+++ b/packages/expo-module-template/$package.json
@@ -5,8 +5,13 @@
   "main": "build/<%- project.name %>.js",
   "types": "build/<%- project.name %>.d.ts",
   "scripts": {
-    "build": "tsc",
-    "lint": "eslint ."
+    "build": "expo-module build",
+    "clean": "expo-module clean",
+    "lint": "expo-module lint",
+    "test": "expo-module test",
+    "prepare": "expo-module prepare",
+    "prepublishOnly": "expo-module prepublishOnly",
+    "expo-module": "expo-module"
   },
   "keywords": ["react-native", "expo", "<%- project.slug %>", "<%- project.name %>"],
   "repository": "<%- repo %>",
@@ -18,7 +23,8 @@
   "homepage": "<%- repo %>#readme",
   "dependencies": {},
   "devDependencies": {
-    "expo-module-scripts": "^2.0.0"
+    "expo-module-scripts": "^2.0.0",
+    "expo-modules-core": "^0.6.5"
   },
   "peerDependencies": {
     "expo": "*"


### PR DESCRIPTION
# Why

Running `npx create-expo-module` does not currently work properly.

# How

Fixed two issues:

1. #15878
2. Updated `scripts` to use `expo-module`

# Test Plan

`create-expo-module` should complete successfully.

# Checklist

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [X] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
