### PR TITLE
[cli][start] Added UrlCreator module

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### 🎉 New features
 
 - [cli] Added modules for interacting with Apple and Android platforms. ([#16516](https://github.com/expo/expo/pull/16516) by [@EvanBacon](https://github.com/EvanBacon))
-- [cli] Added modules for creating dev server URLs, akin to `UrlUtils` in `xdl`.
+- [cli] Added modules for creating dev server URLs, akin to `UrlUtils` in `xdl`. ([#16557](https://github.com/expo/expo/pull/16557) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - [cli] Added modules for interacting with Apple and Android platforms. ([#16516](https://github.com/expo/expo/pull/16516) by [@EvanBacon](https://github.com/EvanBacon))
+- [cli] Added modules for creating dev server URLs, akin to `UrlUtils` in `xdl`.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo/cli/start/server/UrlCreator.ts
+++ b/packages/expo/cli/start/server/UrlCreator.ts
@@ -1,0 +1,159 @@
+import assert from 'assert';
+import { URL } from 'url';
+
+import * as Log from '../../log';
+import { getIpAddress } from '../../utils/ip';
+
+export interface CreateURLOptions {
+  /** URL scheme to use when opening apps in custom runtimes. */
+  scheme?: string | null;
+  /** Type of dev server host to use. */
+  hostType?: 'localhost' | 'lan' | 'tunnel';
+  /** Requested hostname. */
+  hostname?: string;
+}
+
+export class UrlCreator {
+  constructor(
+    private defaults: CreateURLOptions,
+    private bundlerInfo: { port: number; getTunnelUrl?: () => string }
+  ) {}
+
+  /**
+   * @returns URL like `http://localhost:19000/_expo/loading?platform=ios`
+   */
+  public constructLoadingUrl(opts: CreateURLOptions, platform: string) {
+    const url = new URL('_expo/loading', this.constructUrl({ scheme: 'http', ...opts }));
+    url.search = new URLSearchParams({ platform }).toString();
+    return url.toString();
+  }
+
+  /** Create a URI for launching in a native dev client. Returns `null` when no `scheme` can be resolved. */
+  public constructDevClientUrl(opts?: CreateURLOptions): null | string {
+    const protocol: string = opts?.scheme || this.defaults.scheme;
+
+    if (
+      !protocol ||
+      // Prohibit the use of http(s) in dev client URIs since they'll never be valid.
+      ['http', 'https'].includes(protocol.toLowerCase())
+    ) {
+      return null;
+    }
+
+    const manifestUrl = this.constructUrl({ ...opts, scheme: 'http' });
+    return `${protocol}://expo-development-client/?url=${encodeURIComponent(manifestUrl)}`;
+  }
+
+  /** Create a generic URL. */
+  public constructUrl(opts?: Partial<CreateURLOptions> | null): string {
+    const urlComponents = this.getUrlComponents({
+      ...this.defaults,
+      ...opts,
+    });
+    return joinUrlComponents(urlComponents);
+  }
+
+  /** Get the URL components from the Ngrok server URL. */
+  private getTunnelUrlComponents(opts: Pick<CreateURLOptions, 'scheme'>) {
+    const tunnelUrl = this.bundlerInfo.getTunnelUrl();
+    if (!tunnelUrl) {
+      return null;
+    }
+    const parsed = new URL(tunnelUrl);
+    return {
+      port: parsed.port,
+      hostname: parsed.hostname,
+      protocol: opts.scheme ?? 'http',
+    };
+  }
+
+  private getUrlComponents(opts: CreateURLOptions): {
+    port: string;
+    hostname: string;
+    protocol: string;
+  } {
+    // Proxy comes first.
+    const proxyURL = getProxyUrl();
+    if (proxyURL) {
+      return getUrlComponentsFromProxyUrl(opts, proxyURL);
+    }
+
+    // Ngrok.
+    if (opts.hostType === 'tunnel') {
+      const components = this.getTunnelUrlComponents(opts);
+      if (components) {
+        return components;
+      }
+      Log.warn('Tunnel URL not found (it might not be ready yet), falling back to LAN URL.');
+    } else if (opts.hostType === 'localhost' && !opts.hostname) {
+      opts.hostname = 'localhost';
+    }
+
+    return {
+      hostname: getDefaultHostname(opts),
+      port: this.bundlerInfo.port.toString(),
+      protocol: opts.scheme ?? 'http',
+    };
+  }
+}
+
+function getUrlComponentsFromProxyUrl(opts: Pick<CreateURLOptions, 'scheme'>, url: string) {
+  const parsedProxyUrl = new URL(url);
+  let protocol = opts.scheme || 'http';
+  if (parsedProxyUrl.protocol === 'https:') {
+    if (protocol === 'http') {
+      protocol = 'https';
+    }
+    if (!parsedProxyUrl.port) {
+      parsedProxyUrl.port = '443';
+    }
+  }
+  return {
+    port: parsedProxyUrl.port,
+    hostname: parsedProxyUrl.hostname,
+    protocol,
+  };
+}
+
+function getDefaultHostname(opts: Pick<CreateURLOptions, 'hostname'>) {
+  // TODO: Drop REACT_NATIVE_PACKAGER_HOSTNAME
+  if (process.env.REACT_NATIVE_PACKAGER_HOSTNAME) {
+    return process.env.REACT_NATIVE_PACKAGER_HOSTNAME.trim();
+  } else if (opts.hostname === 'localhost') {
+    // Restrict the use of `localhost`
+    // TODO: Note why we do this.
+    return '127.0.0.1';
+  }
+
+  return opts.hostname || getIpAddress();
+}
+
+function joinUrlComponents({
+  protocol,
+  hostname,
+  port,
+}: {
+  /** Empty string or nullish means no protocol will be added. */
+  protocol?: string | null;
+  hostname?: string | null;
+  port?: string | number | null;
+}): string {
+  assert(hostname, 'hostname cannot be inferred.');
+  // Android HMR breaks without this port 80.
+  // This is because Android React Native WebSocket implementation is not spec compliant and fails without a port:
+  // `E unknown:ReactNative: java.lang.IllegalArgumentException: Invalid URL port: "-1"`
+  // Invoked first in `metro-runtime/src/modules/HMRClient.js`
+  const validPort = port || '80';
+  const validProtocol = protocol ? `${protocol}://` : '';
+
+  return `${validProtocol}${hostname}:${validPort}`;
+}
+
+/** @deprecated */
+function getProxyUrl(): string | undefined {
+  return process.env.EXPO_PACKAGER_PROXY_URL;
+}
+
+// TODO: Drop the undocumented env variables:
+// REACT_NATIVE_PACKAGER_HOSTNAME
+// EXPO_PACKAGER_PROXY_URL

--- a/packages/expo/cli/start/server/UrlCreator.ts
+++ b/packages/expo/cli/start/server/UrlCreator.ts
@@ -13,6 +13,11 @@ export interface CreateURLOptions {
   hostname?: string;
 }
 
+interface UrlComponents {
+  port: string;
+  hostname: string;
+  protocol: string;
+}
 export class UrlCreator {
   constructor(
     private defaults: CreateURLOptions,
@@ -22,15 +27,15 @@ export class UrlCreator {
   /**
    * @returns URL like `http://localhost:19000/_expo/loading?platform=ios`
    */
-  public constructLoadingUrl(opts: CreateURLOptions, platform: string) {
-    const url = new URL('_expo/loading', this.constructUrl({ scheme: 'http', ...opts }));
+  public constructLoadingUrl(options: CreateURLOptions, platform: string): string {
+    const url = new URL('_expo/loading', this.constructUrl({ scheme: 'http', ...options }));
     url.search = new URLSearchParams({ platform }).toString();
     return url.toString();
   }
 
   /** Create a URI for launching in a native dev client. Returns `null` when no `scheme` can be resolved. */
-  public constructDevClientUrl(opts?: CreateURLOptions): null | string {
-    const protocol: string = opts?.scheme || this.defaults.scheme;
+  public constructDevClientUrl(options?: CreateURLOptions): null | string {
+    const protocol: string = options?.scheme || this.defaults.scheme;
 
     if (
       !protocol ||
@@ -40,21 +45,21 @@ export class UrlCreator {
       return null;
     }
 
-    const manifestUrl = this.constructUrl({ ...opts, scheme: 'http' });
+    const manifestUrl = this.constructUrl({ ...options, scheme: 'http' });
     return `${protocol}://expo-development-client/?url=${encodeURIComponent(manifestUrl)}`;
   }
 
   /** Create a generic URL. */
-  public constructUrl(opts?: Partial<CreateURLOptions> | null): string {
+  public constructUrl(options?: Partial<CreateURLOptions> | null): string {
     const urlComponents = this.getUrlComponents({
       ...this.defaults,
-      ...opts,
+      ...options,
     });
     return joinUrlComponents(urlComponents);
   }
 
   /** Get the URL components from the Ngrok server URL. */
-  private getTunnelUrlComponents(opts: Pick<CreateURLOptions, 'scheme'>) {
+  private getTunnelUrlComponents(options: Pick<CreateURLOptions, 'scheme'>): UrlComponents | null {
     const tunnelUrl = this.bundlerInfo.getTunnelUrl();
     if (!tunnelUrl) {
       return null;
@@ -63,43 +68,42 @@ export class UrlCreator {
     return {
       port: parsed.port,
       hostname: parsed.hostname,
-      protocol: opts.scheme ?? 'http',
+      protocol: options.scheme ?? 'http',
     };
   }
 
-  private getUrlComponents(opts: CreateURLOptions): {
-    port: string;
-    hostname: string;
-    protocol: string;
-  } {
+  private getUrlComponents(options: CreateURLOptions): UrlComponents {
     // Proxy comes first.
     const proxyURL = getProxyUrl();
     if (proxyURL) {
-      return getUrlComponentsFromProxyUrl(opts, proxyURL);
+      return getUrlComponentsFromProxyUrl(options, proxyURL);
     }
 
     // Ngrok.
-    if (opts.hostType === 'tunnel') {
-      const components = this.getTunnelUrlComponents(opts);
+    if (options.hostType === 'tunnel') {
+      const components = this.getTunnelUrlComponents(options);
       if (components) {
         return components;
       }
       Log.warn('Tunnel URL not found (it might not be ready yet), falling back to LAN URL.');
-    } else if (opts.hostType === 'localhost' && !opts.hostname) {
-      opts.hostname = 'localhost';
+    } else if (options.hostType === 'localhost' && !options.hostname) {
+      options.hostname = 'localhost';
     }
 
     return {
-      hostname: getDefaultHostname(opts),
+      hostname: getDefaultHostname(options),
       port: this.bundlerInfo.port.toString(),
-      protocol: opts.scheme ?? 'http',
+      protocol: options.scheme ?? 'http',
     };
   }
 }
 
-function getUrlComponentsFromProxyUrl(opts: Pick<CreateURLOptions, 'scheme'>, url: string) {
+function getUrlComponentsFromProxyUrl(
+  options: Pick<CreateURLOptions, 'scheme'>,
+  url: string
+): UrlComponents {
   const parsedProxyUrl = new URL(url);
-  let protocol = opts.scheme || 'http';
+  let protocol = options.scheme ?? 'http';
   if (parsedProxyUrl.protocol === 'https:') {
     if (protocol === 'http') {
       protocol = 'https';
@@ -115,29 +119,20 @@ function getUrlComponentsFromProxyUrl(opts: Pick<CreateURLOptions, 'scheme'>, ur
   };
 }
 
-function getDefaultHostname(opts: Pick<CreateURLOptions, 'hostname'>) {
+function getDefaultHostname(options: Pick<CreateURLOptions, 'hostname'>) {
   // TODO: Drop REACT_NATIVE_PACKAGER_HOSTNAME
   if (process.env.REACT_NATIVE_PACKAGER_HOSTNAME) {
     return process.env.REACT_NATIVE_PACKAGER_HOSTNAME.trim();
-  } else if (opts.hostname === 'localhost') {
+  } else if (options.hostname === 'localhost') {
     // Restrict the use of `localhost`
     // TODO: Note why we do this.
     return '127.0.0.1';
   }
 
-  return opts.hostname || getIpAddress();
+  return options.hostname || getIpAddress();
 }
 
-function joinUrlComponents({
-  protocol,
-  hostname,
-  port,
-}: {
-  /** Empty string or nullish means no protocol will be added. */
-  protocol?: string | null;
-  hostname?: string | null;
-  port?: string | number | null;
-}): string {
+function joinUrlComponents({ protocol, hostname, port }: Partial<UrlComponents>): string {
   assert(hostname, 'hostname cannot be inferred.');
   // Android HMR breaks without this port 80.
   // This is because Android React Native WebSocket implementation is not spec compliant and fails without a port:

--- a/packages/expo/cli/start/server/__tests__/UrlCreator-test.ts
+++ b/packages/expo/cli/start/server/__tests__/UrlCreator-test.ts
@@ -1,0 +1,138 @@
+import * as Log from '../../../log';
+import { UrlCreator } from '../UrlCreator';
+
+jest.mock('../../../log');
+
+beforeEach(() => {
+  delete process.env.EXPO_PACKAGER_PROXY_URL;
+  delete process.env.REACT_NATIVE_PACKAGER_HOSTNAME;
+});
+
+const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
+  fn as jest.MockedFunction<T>;
+
+function createDefaultCreator() {
+  return new UrlCreator({}, { port: 8081, getTunnelUrl: () => `http://tunnel.dev/` });
+}
+
+describe('constructLoadingUrl', () => {
+  it(`creates default`, () => {
+    expect(createDefaultCreator().constructLoadingUrl({}, 'ios')).toMatchInlineSnapshot(
+      `"http://100.100.1.100:8081/_expo/loading?platform=ios"`
+    );
+    expect(createDefaultCreator().constructLoadingUrl({}, 'android')).toMatchInlineSnapshot(
+      `"http://100.100.1.100:8081/_expo/loading?platform=android"`
+    );
+  });
+  it(`creates tunnel`, () => {
+    expect(
+      createDefaultCreator().constructLoadingUrl({ hostType: 'tunnel' }, 'ios')
+    ).toMatchInlineSnapshot(`"http://tunnel.dev/_expo/loading?platform=ios"`);
+  });
+  it(`allows any scheme`, () => {
+    expect(
+      createDefaultCreator().constructLoadingUrl({ scheme: 'my-scheme' }, 'android')
+    ).toMatchInlineSnapshot(`"my-scheme://100.100.1.100:8081/_expo/loading?platform=android"`);
+  });
+});
+
+describe('constructDevClientUrl', () => {
+  it(`returns null when no custom scheme can be resolved`, () => {
+    expect(createDefaultCreator().constructDevClientUrl({})).toEqual(null);
+  });
+  it(`returns null when the custom scheme is restricted`, () => {
+    expect(createDefaultCreator().constructDevClientUrl({ scheme: 'http' })).toEqual(null);
+    expect(createDefaultCreator().constructDevClientUrl({ scheme: 'https' })).toEqual(null);
+  });
+  it(`creates default`, () => {
+    expect(createDefaultCreator().constructDevClientUrl({ scheme: 'bacon' })).toMatchInlineSnapshot(
+      `"bacon://expo-development-client/?url=http%3A%2F%2F100.100.1.100%3A8081"`
+    );
+  });
+  it(`creates tunnel`, () => {
+    expect(
+      createDefaultCreator().constructDevClientUrl({ scheme: 'bacon', hostType: 'tunnel' })
+    ).toMatchInlineSnapshot(`"bacon://expo-development-client/?url=http%3A%2F%2Ftunnel.dev%3A80"`);
+  });
+  it(`creates localhost`, () => {
+    expect(
+      createDefaultCreator().constructDevClientUrl({ scheme: 'bacon', hostType: 'localhost' })
+    ).toMatchInlineSnapshot(`"bacon://expo-development-client/?url=http%3A%2F%2F127.0.0.1%3A8081"`);
+  });
+  it(`uses custom hostname`, () => {
+    expect(
+      createDefaultCreator().constructDevClientUrl({ scheme: 'bacon', hostname: 'foobar.dev' })
+    ).toMatchInlineSnapshot(
+      `"bacon://expo-development-client/?url=http%3A%2F%2Ffoobar.dev%3A8081"`
+    );
+  });
+});
+
+describe('constructUrl', () => {
+  it(`creates default`, () => {
+    expect(createDefaultCreator().constructUrl({})).toMatchInlineSnapshot(
+      `"http://100.100.1.100:8081"`
+    );
+  });
+  it(`uses custom scheme`, () => {
+    expect(createDefaultCreator().constructUrl({ scheme: 'exp' })).toMatchInlineSnapshot(
+      `"exp://100.100.1.100:8081"`
+    );
+  });
+  it(`uses localhost`, () => {
+    expect(createDefaultCreator().constructUrl({ hostType: 'localhost' })).toMatchInlineSnapshot(
+      `"http://127.0.0.1:8081"`
+    );
+  });
+  it(`uses lan`, () => {
+    expect(createDefaultCreator().constructUrl({ hostType: 'lan' })).toMatchInlineSnapshot(
+      `"http://100.100.1.100:8081"`
+    );
+  });
+  it(`uses tunnel`, () => {
+    expect(createDefaultCreator().constructUrl({ hostType: 'tunnel' })).toMatchInlineSnapshot(
+      `"http://tunnel.dev:80"`
+    );
+  });
+  it(`uses defaults`, () => {
+    expect(
+      new UrlCreator({ scheme: 'foobar' }, { port: 8081 }).constructUrl({})
+    ).toMatchInlineSnapshot(`"foobar://100.100.1.100:8081"`);
+  });
+  it(`uses function options over defaults`, () => {
+    expect(
+      new UrlCreator({ scheme: 'foobar' }, { port: 8081 }).constructUrl({ scheme: 'newer' })
+    ).toMatchInlineSnapshot(`"newer://100.100.1.100:8081"`);
+  });
+  it(`warns when tunnel isn't available`, () => {
+    asMock(Log.warn).mockClear();
+    expect(
+      new UrlCreator({}, { port: 8081, getTunnelUrl: () => null }).constructUrl({
+        hostType: 'tunnel',
+      })
+    ).toMatchInlineSnapshot(`"http://100.100.1.100:8081"`);
+    expect(Log.warn).toHaveBeenCalledTimes(1);
+    expect(Log.warn).toHaveBeenCalledWith(expect.stringMatching(/Tunnel/));
+  });
+  it(`changes hostname 'localhost' to '127.0.0.1'`, () => {
+    expect(createDefaultCreator().constructUrl({ hostname: 'localhost' })).toMatchInlineSnapshot(
+      `"http://127.0.0.1:8081"`
+    );
+  });
+  it(`uses a custom hostname`, () => {
+    expect(createDefaultCreator().constructUrl({ hostname: 'foobar.dev' })).toMatchInlineSnapshot(
+      `"http://foobar.dev:8081"`
+    );
+  });
+  it(`uses env variable as proxy`, () => {
+    process.env.EXPO_PACKAGER_PROXY_URL = 'http://localhost:9999';
+    expect(
+      createDefaultCreator().constructUrl({
+        // scheme will be used, all others will be ignored...
+        scheme: 'foobar',
+        hostType: 'tunnel',
+        hostname: 'foobar.dev',
+      })
+    ).toMatchInlineSnapshot(`"foobar://localhost:9999"`);
+  });
+});


### PR DESCRIPTION
# Why

- Split out of https://github.com/expo/expo/pull/16517

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

- Dropped `XDL_PORT`, `XDL_HOST`, `XDL_SCHEME`, `SERVER_URL` in favor of `EXPO_STAGING` and `EXPO_LOCAL` environment variables.
- Dropped `WEB_PORT`, `EXPO_PACKAGER_HOSTNAME`, `EXPO_MANIFEST_PROXY_URL`.
- Dropped `.exprc` support which we read from but didn't write to.
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- Unit tests.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->