### PR TITLE
Drop most web feature pending links from docs

### DIFF
--- a/docs/pages/versions/unversioned/sdk/amplitude.md
+++ b/docs/pages/versions/unversioned/sdk/amplitude.md
@@ -12,7 +12,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **Please note:** Session tracking may not work correctly when running Experiences in the main Expo app. It will work correctly if you create a standalone app. For example, the version logged when running experiences in the Expo app will be the [Expo app version](constants.md#constantsexpoversion). Whereas in standalone apps, the version set in **app.json** is used. For more information see [this issue on GitHub](https://github.com/expo/expo/issues/4720).
 
-<PlatformsSection android emulator ios simulator web={{ pending: 'https://github.com/expo/expo/issues/6886' }} />
+<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/captureRef.md
+++ b/docs/pages/versions/unversioned/sdk/captureRef.md
@@ -11,7 +11,7 @@ Given a view, `captureRef` will essentially screenshot that view and return an i
 
 If you're interested in taking snapshots from the GLView, we recommend you use [GLView's takeSnapshotAsync](gl-view.md#takesnapshotasyncoptions) instead.
 
-<PlatformsSection android emulator ios simulator  />
+<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/facedetector.md
+++ b/docs/pages/versions/unversioned/sdk/facedetector.md
@@ -11,7 +11,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 **`expo-face-detector`** lets you use the power of the [Google Mobile Vision](https://developers.google.com/vision/face-detection-concepts) framework to detect faces on images.
 
-<PlatformsSection android ios web={{ pending: 'https://github.com/expo/expo/issues/6888' }} />
+<PlatformsSection android ios />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/local-authentication.md
+++ b/docs/pages/versions/unversioned/sdk/local-authentication.md
@@ -10,7 +10,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-local-authentication`** allows you to use FaceID and TouchID (iOS) or the Biometric Prompt (Android) to authenticate the user with a face or fingerprint scan.
 
-<PlatformsSection android emulator ios simulator web={{ pending: 'https://github.com/expo/expo/issues/4045' }} />
+<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/notifications.md
+++ b/docs/pages/versions/unversioned/sdk/notifications.md
@@ -29,9 +29,9 @@ The **`expo-notifications`** provides an API to fetch push notification tokens a
 - 🗂 create, update, delete Android notification channels,
 - 🎨 set custom icon and color for notifications on Android.
 
-<PlatformsSection title="Push notifications Platform Compatibility" android ios web={{ pending: 'https://github.com/expo/expo/issues/6895' }} />
+<PlatformsSection title="Push notifications Platform Compatibility" android ios />
 
-<PlatformsSection title="Local notifications Platform Compatibility" android emulator ios simulator web={{ pending: 'https://github.com/expo/expo/issues/6895' }} />
+<PlatformsSection title="Local notifications Platform Compatibility" android emulator ios simulator />
 
 ## Installation
 
@@ -216,7 +216,8 @@ export default function App() {
         flex: 1,
         alignItems: 'center',
         justifyContent: 'space-around',
-      }}>
+      }}
+    >
       <Text>Your expo push token: {expoPushToken}</Text>
       <View style={{ alignItems: 'center', justifyContent: 'center' }}>
         <Text>Title: {notification && notification.request.content.title} </Text>

--- a/docs/pages/versions/unversioned/sdk/segment.md
+++ b/docs/pages/versions/unversioned/sdk/segment.md
@@ -14,7 +14,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 > **Note:** Session tracking may not work correctly when running Experiences in the main Expo app. It will work correctly if you create a standalone app.
 
-<PlatformsSection android emulator ios simulator web={{ pending: 'https://github.com/expo/expo/issues/6887' }} />
+<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/v40.0.0/sdk/amplitude.md
+++ b/docs/pages/versions/v40.0.0/sdk/amplitude.md
@@ -10,7 +10,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **Please note:** Session tracking may not work correctly when running Experiences in the main Expo app. It will work correctly if you create a standalone app. For example, the version logged when running experiences in the Expo app will be the [Expo app version](constants.md#constantsexpoversion). Whereas in standalone apps, the version set in **app.json** is used. For more information see [this issue on GitHub](https://github.com/expo/expo/issues/4720).
 
-<PlatformsSection android emulator ios simulator web={{ pending: 'https://github.com/expo/expo/issues/6886' }} />
+<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/v40.0.0/sdk/captureRef.md
+++ b/docs/pages/versions/v40.0.0/sdk/captureRef.md
@@ -10,7 +10,7 @@ Given a view, `captureRef` will essentially screenshot that view and return an i
 
 If you're interested in taking snapshots from the GLView, we recommend you use [GLView's takeSnapshotAsync](gl-view.md#takesnapshotasync) instead.
 
-<PlatformsSection android emulator ios simulator  />
+<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/v40.0.0/sdk/facedetector.md
+++ b/docs/pages/versions/v40.0.0/sdk/facedetector.md
@@ -8,7 +8,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-face-detector`** lets you use the power of the [Google Mobile Vision](https://developers.google.com/vision/face-detection-concepts) framework to detect faces on images.
 
-<PlatformsSection android ios web={{ pending: 'https://github.com/expo/expo/issues/6888' }} />
+<PlatformsSection android ios />
 
 ## Installation
 

--- a/docs/pages/versions/v40.0.0/sdk/legacy-notifications.md
+++ b/docs/pages/versions/v40.0.0/sdk/legacy-notifications.md
@@ -10,9 +10,9 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 The `Notifications` API from **`expo`** provides access to remote notifications (also known as push notifications) and local notifications (scheduling and immediate) related functions.
 
-<PlatformsSection title="Push notifications Platform Compatibility" android ios web={{ pending: 'https://github.com/expo/expo/issues/6895' }} />
+<PlatformsSection title="Push notifications Platform Compatibility" android ios />
 
-<PlatformsSection title="Local notifications Platform Compatibility" android emulator ios simulator web={{ pending: 'https://github.com/expo/expo/issues/6895' }} />
+<PlatformsSection title="Local notifications Platform Compatibility" android emulator ios simulator />
 
 > ⚠️ **Important Android limitation:** Local notifications are cleared when an Android device is restarted. ([See the feature request](https://expo.canny.io/feature-requests/p/keep-scheduled-notifications-after-reboot)).
 
@@ -392,5 +392,5 @@ An object used to describe an Android notification channel that you would like t
 ## Error Codes
 
 | Code                                      | Description                                                           |
-| ----------------------------------------- | --------------------------------------------------------------------- |
-| E_NOTIFICATIONS_TOKEN_REGISTRATION_FAILED | The device was unable to register for remote notifications with Expo. |  |
+| ----------------------------------------- | --------------------------------------------------------------------- | --- |
+| E_NOTIFICATIONS_TOKEN_REGISTRATION_FAILED | The device was unable to register for remote notifications with Expo. |     |

--- a/docs/pages/versions/v40.0.0/sdk/local-authentication.md
+++ b/docs/pages/versions/v40.0.0/sdk/local-authentication.md
@@ -8,7 +8,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-local-authentication`** allows you to use FaceID and TouchID (iOS) or the Biometric Prompt (Android) to authenticate the user with a face or fingerprint scan.
 
-<PlatformsSection android emulator ios simulator web={{ pending: 'https://github.com/expo/expo/issues/4045' }} />
+<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/v40.0.0/sdk/notifications.md
+++ b/docs/pages/versions/v40.0.0/sdk/notifications.md
@@ -26,9 +26,9 @@ The **`expo-notifications`** provides an API to fetch push notification tokens a
 - 🗂 create, update, delete Android notification channels,
 - 🎨 set custom icon and color for notifications on Android.
 
-<PlatformsSection title="Push notifications Platform Compatibility" android ios web={{ pending: 'https://github.com/expo/expo/issues/6895' }} />
+<PlatformsSection title="Push notifications Platform Compatibility" android ios />
 
-<PlatformsSection title="Local notifications Platform Compatibility" android emulator ios simulator web={{ pending: 'https://github.com/expo/expo/issues/6895' }} />
+<PlatformsSection title="Local notifications Platform Compatibility" android emulator ios simulator />
 
 ## Installation
 
@@ -220,7 +220,8 @@ export default function App() {
         flex: 1,
         alignItems: 'center',
         justifyContent: 'space-around',
-      }}>
+      }}
+    >
       <Text>Your expo push token: {expoPushToken}</Text>
       <View style={{ alignItems: 'center', justifyContent: 'center' }}>
         <Text>Title: {notification && notification.request.content.title} </Text>
@@ -603,7 +604,8 @@ export default function App() {
             subscription.remove();
           };
         },
-      }}>
+      }}
+    >
       {/* Your app content */}
     </NavigationContainer>
   );

--- a/docs/pages/versions/v40.0.0/sdk/segment.md
+++ b/docs/pages/versions/v40.0.0/sdk/segment.md
@@ -10,7 +10,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 > **Note:** Session tracking may not work correctly when running Experiences in the main Expo app. It will work correctly if you create a standalone app.
 
-<PlatformsSection android emulator ios simulator web={{ pending: 'https://github.com/expo/expo/issues/6887' }} />
+<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/v41.0.0/sdk/amplitude.md
+++ b/docs/pages/versions/v41.0.0/sdk/amplitude.md
@@ -10,7 +10,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **Please note:** Session tracking may not work correctly when running Experiences in the main Expo app. It will work correctly if you create a standalone app. For example, the version logged when running experiences in the Expo app will be the [Expo app version](constants.md#constantsexpoversion). Whereas in standalone apps, the version set in **app.json** is used. For more information see [this issue on GitHub](https://github.com/expo/expo/issues/4720).
 
-<PlatformsSection android emulator ios simulator web={{ pending: 'https://github.com/expo/expo/issues/6886' }} />
+<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/v41.0.0/sdk/captureRef.md
+++ b/docs/pages/versions/v41.0.0/sdk/captureRef.md
@@ -10,7 +10,7 @@ Given a view, `captureRef` will essentially screenshot that view and return an i
 
 If you're interested in taking snapshots from the GLView, we recommend you use [GLView's takeSnapshotAsync](gl-view.md#takesnapshotasyncoptions) instead.
 
-<PlatformsSection android emulator ios simulator  />
+<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/v41.0.0/sdk/facedetector.md
+++ b/docs/pages/versions/v41.0.0/sdk/facedetector.md
@@ -8,7 +8,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-face-detector`** lets you use the power of the [Google Mobile Vision](https://developers.google.com/vision/face-detection-concepts) framework to detect faces on images.
 
-<PlatformsSection android ios web={{ pending: 'https://github.com/expo/expo/issues/6888' }} />
+<PlatformsSection android ios />
 
 ## Installation
 

--- a/docs/pages/versions/v41.0.0/sdk/local-authentication.md
+++ b/docs/pages/versions/v41.0.0/sdk/local-authentication.md
@@ -8,7 +8,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-local-authentication`** allows you to use FaceID and TouchID (iOS) or the Biometric Prompt (Android) to authenticate the user with a face or fingerprint scan.
 
-<PlatformsSection android emulator ios simulator web={{ pending: 'https://github.com/expo/expo/issues/4045' }} />
+<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/v41.0.0/sdk/notifications.md
+++ b/docs/pages/versions/v41.0.0/sdk/notifications.md
@@ -26,9 +26,9 @@ The **`expo-notifications`** provides an API to fetch push notification tokens a
 - 🗂 create, update, delete Android notification channels,
 - 🎨 set custom icon and color for notifications on Android.
 
-<PlatformsSection title="Push notifications Platform Compatibility" android ios web={{ pending: 'https://github.com/expo/expo/issues/6895' }} />
+<PlatformsSection title="Push notifications Platform Compatibility" android ios />
 
-<PlatformsSection title="Local notifications Platform Compatibility" android emulator ios simulator web={{ pending: 'https://github.com/expo/expo/issues/6895' }} />
+<PlatformsSection title="Local notifications Platform Compatibility" android emulator ios simulator />
 
 ## Installation
 
@@ -182,7 +182,8 @@ export default function App() {
         flex: 1,
         alignItems: 'center',
         justifyContent: 'space-around',
-      }}>
+      }}
+    >
       <Text>Your expo push token: {expoPushToken}</Text>
       <View style={{ alignItems: 'center', justifyContent: 'center' }}>
         <Text>Title: {notification && notification.request.content.title} </Text>
@@ -657,7 +658,8 @@ export default function App() {
             subscription.remove();
           };
         },
-      }}>
+      }}
+    >
       {/* Your app content */}
     </NavigationContainer>
   );

--- a/docs/pages/versions/v41.0.0/sdk/segment.md
+++ b/docs/pages/versions/v41.0.0/sdk/segment.md
@@ -10,7 +10,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 > **Note:** Session tracking may not work correctly when running Experiences in the main Expo app. It will work correctly if you create a standalone app.
 
-<PlatformsSection android emulator ios simulator web={{ pending: 'https://github.com/expo/expo/issues/6887' }} />
+<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/v42.0.0/sdk/amplitude.md
+++ b/docs/pages/versions/v42.0.0/sdk/amplitude.md
@@ -10,7 +10,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **Please note:** Session tracking may not work correctly when running Experiences in the main Expo app. It will work correctly if you create a standalone app. For example, the version logged when running experiences in the Expo app will be the [Expo app version](constants.md#constantsexpoversion). Whereas in standalone apps, the version set in **app.json** is used. For more information see [this issue on GitHub](https://github.com/expo/expo/issues/4720).
 
-<PlatformsSection android emulator ios simulator web={{ pending: 'https://github.com/expo/expo/issues/6886' }} />
+<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/v42.0.0/sdk/captureRef.md
+++ b/docs/pages/versions/v42.0.0/sdk/captureRef.md
@@ -10,7 +10,7 @@ Given a view, `captureRef` will essentially screenshot that view and return an i
 
 If you're interested in taking snapshots from the GLView, we recommend you use [GLView's takeSnapshotAsync](gl-view.md#takesnapshotasyncoptions) instead.
 
-<PlatformsSection android emulator ios simulator  />
+<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/v42.0.0/sdk/facedetector.md
+++ b/docs/pages/versions/v42.0.0/sdk/facedetector.md
@@ -8,7 +8,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-face-detector`** lets you use the power of the [Google Mobile Vision](https://developers.google.com/vision/face-detection-concepts) framework to detect faces on images.
 
-<PlatformsSection android ios web={{ pending: 'https://github.com/expo/expo/issues/6888' }} />
+<PlatformsSection android ios />
 
 ## Installation
 

--- a/docs/pages/versions/v42.0.0/sdk/local-authentication.md
+++ b/docs/pages/versions/v42.0.0/sdk/local-authentication.md
@@ -8,7 +8,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-local-authentication`** allows you to use FaceID and TouchID (iOS) or the Biometric Prompt (Android) to authenticate the user with a face or fingerprint scan.
 
-<PlatformsSection android emulator ios simulator web={{ pending: 'https://github.com/expo/expo/issues/4045' }} />
+<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/v42.0.0/sdk/notifications.md
+++ b/docs/pages/versions/v42.0.0/sdk/notifications.md
@@ -26,9 +26,9 @@ The **`expo-notifications`** provides an API to fetch push notification tokens a
 - 🗂 create, update, delete Android notification channels,
 - 🎨 set custom icon and color for notifications on Android.
 
-<PlatformsSection title="Push notifications Platform Compatibility" android ios web={{ pending: 'https://github.com/expo/expo/issues/6895' }} />
+<PlatformsSection title="Push notifications Platform Compatibility" android ios />
 
-<PlatformsSection title="Local notifications Platform Compatibility" android emulator ios simulator web={{ pending: 'https://github.com/expo/expo/issues/6895' }} />
+<PlatformsSection title="Local notifications Platform Compatibility" android emulator ios simulator />
 
 ## Installation
 
@@ -182,7 +182,8 @@ export default function App() {
         flex: 1,
         alignItems: 'center',
         justifyContent: 'space-around',
-      }}>
+      }}
+    >
       <Text>Your expo push token: {expoPushToken}</Text>
       <View style={{ alignItems: 'center', justifyContent: 'center' }}>
         <Text>Title: {notification && notification.request.content.title} </Text>

--- a/docs/pages/versions/v42.0.0/sdk/segment.md
+++ b/docs/pages/versions/v42.0.0/sdk/segment.md
@@ -11,7 +11,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 > **Note:** Session tracking may not work correctly when running Experiences in the main Expo app. It will work correctly if you create a standalone app.
 
-<PlatformsSection android emulator ios simulator web={{ pending: 'https://github.com/expo/expo/issues/6887' }} />
+<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/v43.0.0/sdk/amplitude.md
+++ b/docs/pages/versions/v43.0.0/sdk/amplitude.md
@@ -11,7 +11,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **Please note:** Session tracking may not work correctly when running Experiences in the main Expo app. It will work correctly if you create a standalone app. For example, the version logged when running experiences in the Expo app will be the [Expo app version](constants.md#constantsexpoversion). Whereas in standalone apps, the version set in **app.json** is used. For more information see [this issue on GitHub](https://github.com/expo/expo/issues/4720).
 
-<PlatformsSection android emulator ios simulator web={{ pending: 'https://github.com/expo/expo/issues/6886' }} />
+<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/v43.0.0/sdk/captureRef.md
+++ b/docs/pages/versions/v43.0.0/sdk/captureRef.md
@@ -10,7 +10,7 @@ Given a view, `captureRef` will essentially screenshot that view and return an i
 
 If you're interested in taking snapshots from the GLView, we recommend you use [GLView's takeSnapshotAsync](gl-view.md#takesnapshotasyncoptions) instead.
 
-<PlatformsSection android emulator ios simulator  />
+<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/v43.0.0/sdk/facedetector.md
+++ b/docs/pages/versions/v43.0.0/sdk/facedetector.md
@@ -10,7 +10,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 **`expo-face-detector`** lets you use the power of the [Google Mobile Vision](https://developers.google.com/vision/face-detection-concepts) framework to detect faces on images.
 
-<PlatformsSection android ios web={{ pending: 'https://github.com/expo/expo/issues/6888' }} />
+<PlatformsSection android ios />
 
 ## Installation
 

--- a/docs/pages/versions/v43.0.0/sdk/local-authentication.md
+++ b/docs/pages/versions/v43.0.0/sdk/local-authentication.md
@@ -9,7 +9,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-local-authentication`** allows you to use FaceID and TouchID (iOS) or the Biometric Prompt (Android) to authenticate the user with a face or fingerprint scan.
 
-<PlatformsSection android emulator ios simulator web={{ pending: 'https://github.com/expo/expo/issues/4045' }} />
+<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/v43.0.0/sdk/notifications.md
+++ b/docs/pages/versions/v43.0.0/sdk/notifications.md
@@ -28,9 +28,9 @@ The **`expo-notifications`** provides an API to fetch push notification tokens a
 - 🗂 create, update, delete Android notification channels,
 - 🎨 set custom icon and color for notifications on Android.
 
-<PlatformsSection title="Push notifications Platform Compatibility" android ios web={{ pending: 'https://github.com/expo/expo/issues/6895' }} />
+<PlatformsSection title="Push notifications Platform Compatibility" android ios />
 
-<PlatformsSection title="Local notifications Platform Compatibility" android emulator ios simulator web={{ pending: 'https://github.com/expo/expo/issues/6895' }} />
+<PlatformsSection title="Local notifications Platform Compatibility" android emulator ios simulator />
 
 ## Installation
 
@@ -215,7 +215,8 @@ export default function App() {
         flex: 1,
         alignItems: 'center',
         justifyContent: 'space-around',
-      }}>
+      }}
+    >
       <Text>Your expo push token: {expoPushToken}</Text>
       <View style={{ alignItems: 'center', justifyContent: 'center' }}>
         <Text>Title: {notification && notification.request.content.title} </Text>

--- a/docs/pages/versions/v43.0.0/sdk/segment.md
+++ b/docs/pages/versions/v43.0.0/sdk/segment.md
@@ -11,7 +11,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 > **Note:** Session tracking may not work correctly when running Experiences in the main Expo app. It will work correctly if you create a standalone app.
 
-<PlatformsSection android emulator ios simulator web={{ pending: 'https://github.com/expo/expo/issues/6887' }} />
+<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/v44.0.0/sdk/amplitude.md
+++ b/docs/pages/versions/v44.0.0/sdk/amplitude.md
@@ -11,7 +11,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **Please note:** Session tracking may not work correctly when running Experiences in the main Expo app. It will work correctly if you create a standalone app. For example, the version logged when running experiences in the Expo app will be the [Expo app version](constants.md#constantsexpoversion). Whereas in standalone apps, the version set in **app.json** is used. For more information see [this issue on GitHub](https://github.com/expo/expo/issues/4720).
 
-<PlatformsSection android emulator ios simulator web={{ pending: 'https://github.com/expo/expo/issues/6886' }} />
+<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/v44.0.0/sdk/captureRef.md
+++ b/docs/pages/versions/v44.0.0/sdk/captureRef.md
@@ -10,7 +10,7 @@ Given a view, `captureRef` will essentially screenshot that view and return an i
 
 If you're interested in taking snapshots from the GLView, we recommend you use [GLView's takeSnapshotAsync](gl-view.md#takesnapshotasyncoptions) instead.
 
-<PlatformsSection android emulator ios simulator  />
+<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/v44.0.0/sdk/facedetector.md
+++ b/docs/pages/versions/v44.0.0/sdk/facedetector.md
@@ -10,7 +10,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 **`expo-face-detector`** lets you use the power of the [Google Mobile Vision](https://developers.google.com/vision/face-detection-concepts) framework to detect faces on images.
 
-<PlatformsSection android ios web={{ pending: 'https://github.com/expo/expo/issues/6888' }} />
+<PlatformsSection android ios />
 
 ## Installation
 

--- a/docs/pages/versions/v44.0.0/sdk/local-authentication.md
+++ b/docs/pages/versions/v44.0.0/sdk/local-authentication.md
@@ -9,7 +9,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-local-authentication`** allows you to use FaceID and TouchID (iOS) or the Biometric Prompt (Android) to authenticate the user with a face or fingerprint scan.
 
-<PlatformsSection android emulator ios simulator web={{ pending: 'https://github.com/expo/expo/issues/4045' }} />
+<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/v44.0.0/sdk/notifications.md
+++ b/docs/pages/versions/v44.0.0/sdk/notifications.md
@@ -28,9 +28,9 @@ The **`expo-notifications`** provides an API to fetch push notification tokens a
 - 🗂 create, update, delete Android notification channels,
 - 🎨 set custom icon and color for notifications on Android.
 
-<PlatformsSection title="Push notifications Platform Compatibility" android ios web={{ pending: 'https://github.com/expo/expo/issues/6895' }} />
+<PlatformsSection title="Push notifications Platform Compatibility" android ios />
 
-<PlatformsSection title="Local notifications Platform Compatibility" android emulator ios simulator web={{ pending: 'https://github.com/expo/expo/issues/6895' }} />
+<PlatformsSection title="Local notifications Platform Compatibility" android emulator ios simulator />
 
 ## Installation
 
@@ -215,7 +215,8 @@ export default function App() {
         flex: 1,
         alignItems: 'center',
         justifyContent: 'space-around',
-      }}>
+      }}
+    >
       <Text>Your expo push token: {expoPushToken}</Text>
       <View style={{ alignItems: 'center', justifyContent: 'center' }}>
         <Text>Title: {notification && notification.request.content.title} </Text>

--- a/docs/pages/versions/v44.0.0/sdk/segment.md
+++ b/docs/pages/versions/v44.0.0/sdk/segment.md
@@ -13,7 +13,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 > **Note:** Session tracking may not work correctly when running Experiences in the main Expo app. It will work correctly if you create a standalone app.
 
-<PlatformsSection android emulator ios simulator web={{ pending: 'https://github.com/expo/expo/issues/6887' }} />
+<PlatformsSection android emulator ios simulator />
 
 ## Installation
 


### PR DESCRIPTION
# Why

Most of the remaining features haven't landed for a bunch of assorted reasons, now that the stale bot is closing issues it doesn't make sense to keep these links around.

Left the ones for keep awake since that is still pending.