### PR TITLE
docs: Improve guidance for Android EAS submit on CI

### DIFF
--- a/docs/pages/submit/android.md
+++ b/docs/pages/submit/android.md
@@ -55,7 +55,7 @@ The command will perform the following steps:
 
 The `eas submit` command is able to perform submissions from a CI environment. All you have to do is ensure that all required information is provided with **eas.json** and environment variables. Mainly, providing the archive source (`--latest`, `--id`, `--path`, or `--url`) is essential. Also, make sure that the Android package name is present in your [app config file](/workflow/configuration.md).
 
-For Android submissions, you must provide the path to your Google Services JSON key using the `serviceAccountKeyPath` key in **eas.json**. You may also find the `track` and `releaseStatus` parameters useful.
+For Android submissions, you can upload your Google Services JSON file in the Credentials section of your project on the Expo dashboard manually or run `eas submit -p android` to interactively specify the Google Services JSON file path locally and upload it to EAS servers. This file should NOT be included in any kind of version control such as Git as it contains secrets that are used to access your Google Play Store listing.  You may also find the `track` and `releaseStatus` parameters useful.
 
 Example usage:
 


### PR DESCRIPTION
- This improves the docs by stating that the file path to the Google Services JSON file is not required on CI as it will already be uploaded to EAS servers either manually or by first running `eas submit -p android` locally
- This also ensures people do not accidentally add the services file to their version control unnecessarily and insecurely

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
