### PR TITLE
[sweet api][kotlin] Add more validators

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/FieldValidator.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/FieldValidator.kt
@@ -6,10 +6,77 @@ interface FieldValidator<T> {
   fun validate(value: T)
 }
 
-class NumericRangeValidator<T : Comparable<T>>(private val from: T, private val to: T) : FieldValidator<T> {
+class NumericRangeValidator<T : Comparable<T>>(
+  private val from: T,
+  private val to: T,
+  private val fromInclusive: Boolean,
+  private val toInclusive: Boolean
+) : FieldValidator<T> {
   override fun validate(value: T) {
-    if (value < from || to <= value) {
-      throw ValidationException("Value should be in range $from - $to, got $value")
+    if (
+      value < from ||
+      to < value ||
+      value == from && !fromInclusive ||
+      value == to && !toInclusive
+    ) {
+      throw ValidationException("Value should be in range $from ${if (fromInclusive) "<=" else "<"} 'value' ${if (toInclusive) "<=" else "<"} $to, got $value")
+    }
+  }
+}
+
+class IsNotEmptyCollectionValidator : FieldValidator<Collection<*>> {
+  override fun validate(value: Collection<*>) {
+    if (value.isEmpty()) {
+      throw ValidationException("Collection is empty")
+    }
+  }
+}
+
+class IsNotEmptyArrayValidator : FieldValidator<Array<*>> {
+  override fun validate(value: Array<*>) {
+    if (value.isEmpty()) {
+      throw ValidationException("Array is empty")
+    }
+  }
+}
+
+class CollectionSizeValidator(
+  private val min: Int,
+  private val max: Int
+) : FieldValidator<Collection<*>> {
+  override fun validate(value: Collection<*>) {
+    if (value.size < min || value.size > max) {
+      throw ValidationException("Number of elements in the collection should be between $min and $max, got ${value.size}")
+    }
+  }
+}
+
+class ArraySizeValidator(
+  private val min: Int,
+  private val max: Int
+) : FieldValidator<Array<*>> {
+  override fun validate(value: Array<*>) {
+    if (value.size < min || value.size > max) {
+      throw ValidationException("Number of elements in the array should be between $min and $max, got ${value.size}")
+    }
+  }
+}
+
+class StringSizeValidator(
+  private val min: Int,
+  private val max: Int
+) : FieldValidator<String> {
+  override fun validate(value: String) {
+    if (value.length < min || value.length > max) {
+      throw ValidationException("Length of the string should be between $min and $max, got $value (${value.length} characters)")
+    }
+  }
+}
+
+class RegexValidator(private val regex: Regex) : FieldValidator<CharSequence> {
+  override fun validate(value: CharSequence) {
+    if (!regex.matches(value)) {
+      throw ValidationException("Provided string $value didn't match regex $regex")
     }
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/FieldValidator.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/FieldValidator.kt
@@ -32,6 +32,30 @@ class IsNotEmptyCollectionValidator : FieldValidator<Collection<*>> {
   }
 }
 
+class IsNotEmptyIntArrayValidator : FieldValidator<IntArray> {
+  override fun validate(value: IntArray) {
+    if (value.isEmpty()) {
+      throw ValidationException("Array is empty")
+    }
+  }
+}
+
+class IsNotEmptyFloatArrayValidator : FieldValidator<FloatArray> {
+  override fun validate(value: FloatArray) {
+    if (value.isEmpty()) {
+      throw ValidationException("Array is empty")
+    }
+  }
+}
+
+class IsNotEmptyDoubleArrayValidator : FieldValidator<DoubleArray> {
+  override fun validate(value: DoubleArray) {
+    if (value.isEmpty()) {
+      throw ValidationException("Array is empty")
+    }
+  }
+}
+
 class IsNotEmptyArrayValidator : FieldValidator<Array<*>> {
   override fun validate(value: Array<*>) {
     if (value.isEmpty()) {
@@ -47,6 +71,39 @@ class CollectionSizeValidator(
   override fun validate(value: Collection<*>) {
     if (value.size < min || value.size > max) {
       throw ValidationException("Number of elements in the collection should be between $min and $max, got ${value.size}")
+    }
+  }
+}
+
+class IntArraySizeValidator(
+  private val min: Int,
+  private val max: Int
+) : FieldValidator<IntArray> {
+  override fun validate(value: IntArray) {
+    if (value.size < min || value.size > max) {
+      throw ValidationException("Number of elements in the array should be between $min and $max, got ${value.size}")
+    }
+  }
+}
+
+class DoubleArraySizeValidator(
+  private val min: Int,
+  private val max: Int
+) : FieldValidator<DoubleArray> {
+  override fun validate(value: DoubleArray) {
+    if (value.size < min || value.size > max) {
+      throw ValidationException("Number of elements in the array should be between $min and $max, got ${value.size}")
+    }
+  }
+}
+
+class FloatArraySizeValidator(
+  private val min: Int,
+  private val max: Int
+) : FieldValidator<FloatArray> {
+  override fun validate(value: FloatArray) {
+    if (value.size < min || value.size > max) {
+      throw ValidationException("Number of elements in the array should be between $min and $max, got ${value.size}")
     }
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/RecordTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/RecordTypeConverter.kt
@@ -96,7 +96,7 @@ class RecordTypeConverter<T : Record>(
       .filterNotNull()
       .map { (annotation, binderAnnotation) ->
         val binderInstance = binderAnnotation.binder.createInstance() as ValidationBinder
-        binderInstance.bind(annotation)
+        binderInstance.bind(annotation, property.returnType)
       }
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/RecordTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/RecordTypeConverter.kt
@@ -65,12 +65,14 @@ class RecordTypeConverter<T : Record>(
             descriptor.typeConverter.convert(this)
           }
 
-          descriptor
-            .validators
-            .forEach { validator ->
-              @Suppress("UNCHECKED_CAST")
-              (validator as FieldValidator<Any?>).validate(casted)
-            }
+          if (casted != null) {
+            descriptor
+              .validators
+              .forEach { validator ->
+                @Suppress("UNCHECKED_CAST")
+                (validator as FieldValidator<Any>).validate(casted)
+              }
+          }
 
           javaField.isAccessible = true
           javaField.set(instance, casted)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/ValidationBinder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/ValidationBinder.kt
@@ -2,6 +2,7 @@ package expo.modules.kotlin.records
 
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
+import kotlin.reflect.full.createType
 import kotlin.reflect.full.isSubclassOf
 
 interface ValidationBinder {
@@ -64,6 +65,12 @@ internal class IsCollectionNotEmptyBinder : ValidationBinder {
   override fun bind(annotation: Annotation, fieldType: KType): FieldValidator<*> {
     assert(annotation is IsNotEmpty)
 
+    when (fieldType) {
+      IntArray::class.createType() -> return IsNotEmptyIntArrayValidator()
+      DoubleArray::class.createType() -> return IsNotEmptyDoubleArrayValidator()
+      FloatArray::class.createType() -> return IsNotEmptyFloatArrayValidator()
+    }
+
     val kClass = fieldType.classifier as KClass<*>
     if (kClass.isSubclassOf(Array::class) || kClass.java.isArray) {
       return IsNotEmptyArrayValidator()
@@ -76,13 +83,18 @@ internal class IsCollectionNotEmptyBinder : ValidationBinder {
 internal class SizeBinder : ValidationBinder {
   override fun bind(annotation: Annotation, fieldType: KType): FieldValidator<*> {
     val sizeAnnotation = annotation as Size
+
+    when (fieldType) {
+      IntArray::class.createType() -> return IntArraySizeValidator(sizeAnnotation.min, sizeAnnotation.max)
+      DoubleArray::class.createType() -> return DoubleArraySizeValidator(sizeAnnotation.min, sizeAnnotation.max)
+      FloatArray::class.createType() -> return FloatArraySizeValidator(sizeAnnotation.min, sizeAnnotation.max)
+    }
+
     val kClass = fieldType.classifier as KClass<*>
 
     if (kClass.isSubclassOf(String::class)) {
       return StringSizeValidator(sizeAnnotation.min, sizeAnnotation.max)
-    }
-
-    if (kClass.isSubclassOf(Array::class) || kClass.java.isArray) {
+    } else if (kClass.isSubclassOf(Array::class) || kClass.java.isArray) {
       return ArraySizeValidator(sizeAnnotation.min, sizeAnnotation.max)
     }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/ValidationBinder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/ValidationBinder.kt
@@ -1,9 +1,11 @@
 package expo.modules.kotlin.records
 
 import kotlin.reflect.KClass
+import kotlin.reflect.KType
+import kotlin.reflect.full.isSubclassOf
 
 interface ValidationBinder {
-  fun bind(annotation: Annotation): FieldValidator<*>
+  fun bind(annotation: Annotation, fieldType: KType): FieldValidator<*>
 }
 
 @Retention(AnnotationRetention.RUNTIME)
@@ -11,29 +13,86 @@ interface ValidationBinder {
 annotation class BindUsing(val binder: KClass<*>)
 
 internal class IntRangeBinder : ValidationBinder {
-  override fun bind(annotation: Annotation): FieldValidator<*> {
+  override fun bind(annotation: Annotation, fieldType: KType): FieldValidator<*> {
     val rangeAnnotation = annotation as IntRange
-    return NumericRangeValidator(rangeAnnotation.from, rangeAnnotation.to)
+    return NumericRangeValidator(
+      rangeAnnotation.from,
+      rangeAnnotation.to,
+      rangeAnnotation.fromInclusive,
+      rangeAnnotation.toInclusive
+    )
   }
 }
 
 internal class LongRangeBinder : ValidationBinder {
-  override fun bind(annotation: Annotation): FieldValidator<*> {
+  override fun bind(annotation: Annotation, fieldType: KType): FieldValidator<*> {
     val rangeAnnotation = annotation as LongRange
-    return NumericRangeValidator(rangeAnnotation.from, rangeAnnotation.to)
+    return NumericRangeValidator(
+      rangeAnnotation.from,
+      rangeAnnotation.to,
+      rangeAnnotation.fromInclusive,
+      rangeAnnotation.toInclusive
+    )
   }
 }
 
 internal class FloatRangeBinder : ValidationBinder {
-  override fun bind(annotation: Annotation): FieldValidator<*> {
+  override fun bind(annotation: Annotation, fieldType: KType): FieldValidator<*> {
     val rangeAnnotation = annotation as FloatRange
-    return NumericRangeValidator(rangeAnnotation.from, rangeAnnotation.to)
+    return NumericRangeValidator(
+      rangeAnnotation.from,
+      rangeAnnotation.to,
+      rangeAnnotation.fromInclusive,
+      rangeAnnotation.toInclusive
+    )
   }
 }
 
 internal class DoubleRangeBinder : ValidationBinder {
-  override fun bind(annotation: Annotation): FieldValidator<*> {
+  override fun bind(annotation: Annotation, fieldType: KType): FieldValidator<*> {
     val rangeAnnotation = annotation as DoubleRange
-    return NumericRangeValidator(rangeAnnotation.from, rangeAnnotation.to)
+    return NumericRangeValidator(
+      rangeAnnotation.from,
+      rangeAnnotation.to,
+      rangeAnnotation.fromInclusive,
+      rangeAnnotation.toInclusive
+    )
+  }
+}
+
+internal class IsCollectionNotEmptyBinder : ValidationBinder {
+  override fun bind(annotation: Annotation, fieldType: KType): FieldValidator<*> {
+    assert(annotation is IsNotEmpty)
+
+    val kClass = fieldType.classifier as KClass<*>
+    if (kClass.isSubclassOf(Array::class) || kClass.java.isArray) {
+      return IsNotEmptyArrayValidator()
+    }
+
+    return IsNotEmptyCollectionValidator()
+  }
+}
+
+internal class SizeBinder : ValidationBinder {
+  override fun bind(annotation: Annotation, fieldType: KType): FieldValidator<*> {
+    val sizeAnnotation = annotation as Size
+    val kClass = fieldType.classifier as KClass<*>
+
+    if (kClass.isSubclassOf(String::class)) {
+      return StringSizeValidator(sizeAnnotation.min, sizeAnnotation.max)
+    }
+
+    if (kClass.isSubclassOf(Array::class) || kClass.java.isArray) {
+      return ArraySizeValidator(sizeAnnotation.min, sizeAnnotation.max)
+    }
+
+    return CollectionSizeValidator(sizeAnnotation.min, sizeAnnotation.max)
+  }
+}
+
+internal class RegexBinder : ValidationBinder {
+  override fun bind(annotation: Annotation, fieldType: KType): FieldValidator<*> {
+    val regexAnnotation = annotation as RegularExpression
+    return RegexValidator(regexAnnotation.regex.toRegex())
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/Validators.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/Validators.kt
@@ -3,19 +3,59 @@ package expo.modules.kotlin.records
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.PROPERTY, AnnotationTarget.TYPE, AnnotationTarget.VALUE_PARAMETER)
 @BindUsing(IntRangeBinder::class)
-annotation class IntRange(val from: Int, val to: Int)
+annotation class IntRange(
+  val from: Int,
+  val to: Int,
+  val fromInclusive: Boolean = true,
+  val toInclusive: Boolean = true,
+)
 
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.PROPERTY)
 @BindUsing(LongRangeBinder::class)
-annotation class LongRange(val from: Long, val to: Long)
+annotation class LongRange(
+  val from: Long,
+  val to: Long,
+  val fromInclusive: Boolean = true,
+  val toInclusive: Boolean = true
+)
 
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.PROPERTY)
 @BindUsing(FloatRangeBinder::class)
-annotation class FloatRange(val from: Float, val to: Float)
+annotation class FloatRange(
+  val from: Float,
+  val to: Float,
+  val fromInclusive: Boolean = true,
+  val toInclusive: Boolean = true
+)
 
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.PROPERTY)
 @BindUsing(DoubleRangeBinder::class)
-annotation class DoubleRange(val from: Double, val to: Double)
+annotation class DoubleRange(
+  val from: Double,
+  val to: Double,
+  val fromInclusive: Boolean = true,
+  val toInclusive: Boolean = true
+)
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.PROPERTY)
+@BindUsing(IsCollectionNotEmptyBinder::class)
+annotation class IsNotEmpty
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.PROPERTY)
+@BindUsing(SizeBinder::class)
+annotation class Size(
+  val min: Int = 0,
+  val max: Int = Int.MAX_VALUE
+)
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.PROPERTY)
+@BindUsing(RegexBinder::class)
+annotation class RegularExpression(
+  val regex: String
+)

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/TruthExtensions.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/TruthExtensions.kt
@@ -16,3 +16,13 @@ inline fun <reified T : Throwable> assertThrows(expectedMessage: String? = null,
 
   Assert.fail("Provided block should throw.")
 }
+
+@Suppress("NOTHING_TO_INLINE")
+inline fun Any?.assertNotNull() {
+  Truth.assertThat(this).isNotNull()
+}
+
+@Suppress("NOTHING_TO_INLINE")
+inline fun Any?.assertNull() {
+  Truth.assertThat(this).isNull()
+}

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/records/IsCollectionNotEmptyBinderTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/records/IsCollectionNotEmptyBinderTest.kt
@@ -1,0 +1,27 @@
+package expo.modules.kotlin.records
+
+import com.google.common.truth.Truth
+import org.junit.Test
+import kotlin.reflect.typeOf
+
+class IsCollectionNotEmptyBinderTest {
+  @Test
+  fun `should bind the collection type to the collection validator`() {
+    val binder = IsCollectionNotEmptyBinder()
+    val listValidator = binder.bind(IsNotEmpty(), typeOf<List<Int>>())
+    val mapValidator = binder.bind(IsNotEmpty(), typeOf<Map<Int, Int>>())
+
+    Truth.assertThat(listValidator).isInstanceOf(IsNotEmptyCollectionValidator::class.java)
+    Truth.assertThat(mapValidator).isInstanceOf(IsNotEmptyCollectionValidator::class.java)
+  }
+
+  @Test
+  fun `should bind the array type to the array validator`() {
+    val binder = IsCollectionNotEmptyBinder()
+    val intArrayValidator = binder.bind(IsNotEmpty(), typeOf<IntArray>())
+    val stringArrayValidator = binder.bind(IsNotEmpty(), typeOf<Array<String>>())
+
+    Truth.assertThat(intArrayValidator).isInstanceOf(IsNotEmptyArrayValidator::class.java)
+    Truth.assertThat(stringArrayValidator).isInstanceOf(IsNotEmptyArrayValidator::class.java)
+  }
+}

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/records/IsCollectionNotEmptyBinderTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/records/IsCollectionNotEmptyBinderTest.kt
@@ -19,9 +19,13 @@ class IsCollectionNotEmptyBinderTest {
   fun `should bind the array type to the array validator`() {
     val binder = IsCollectionNotEmptyBinder()
     val intArrayValidator = binder.bind(IsNotEmpty(), typeOf<IntArray>())
+    val doubleArrayValidator = binder.bind(IsNotEmpty(), typeOf<DoubleArray>())
+    val floatArrayValidator = binder.bind(IsNotEmpty(), typeOf<FloatArray>())
     val stringArrayValidator = binder.bind(IsNotEmpty(), typeOf<Array<String>>())
 
-    Truth.assertThat(intArrayValidator).isInstanceOf(IsNotEmptyArrayValidator::class.java)
+    Truth.assertThat(intArrayValidator).isInstanceOf(IsNotEmptyIntArrayValidator::class.java)
+    Truth.assertThat(doubleArrayValidator).isInstanceOf(IsNotEmptyDoubleArrayValidator::class.java)
+    Truth.assertThat(floatArrayValidator).isInstanceOf(IsNotEmptyFloatArrayValidator::class.java)
     Truth.assertThat(stringArrayValidator).isInstanceOf(IsNotEmptyArrayValidator::class.java)
   }
 }

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/records/NumericRangeValidatorTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/records/NumericRangeValidatorTest.kt
@@ -1,0 +1,34 @@
+package expo.modules.kotlin.records
+
+import expo.modules.assertNotNull
+import expo.modules.assertNull
+import org.junit.Test
+
+
+class NumericRangeValidatorTest {
+  @Test
+  fun `should not throw if an argument is in the range`() {
+    val validator = NumericRangeValidator(1, 10, fromInclusive = true, toInclusive = true)
+
+    runCatching { validator.validate(1) }.exceptionOrNull().assertNull()
+    runCatching { validator.validate(5) }.exceptionOrNull().assertNull()
+    runCatching { validator.validate(10) }.exceptionOrNull().assertNull()
+  }
+
+  @Test
+  fun `should throw if an argument is outside of the range`() {
+    val validator1 = NumericRangeValidator(1, 10, fromInclusive = false, toInclusive = true)
+    val validator2 = NumericRangeValidator(1, 10, fromInclusive = true, toInclusive = false)
+    val validator3 = NumericRangeValidator(1, 10, fromInclusive = false, toInclusive = false)
+
+    runCatching { validator1.validate(1) }.exceptionOrNull().assertNotNull()
+    runCatching { validator1.validate(11) }.exceptionOrNull().assertNotNull()
+
+    runCatching { validator2.validate(0) }.exceptionOrNull().assertNotNull()
+    runCatching { validator2.validate(10) }.exceptionOrNull().assertNotNull()
+
+
+    runCatching { validator3.validate(1) }.exceptionOrNull().assertNotNull()
+    runCatching { validator3.validate(10) }.exceptionOrNull().assertNotNull()
+  }
+}

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/records/NumericRangeValidatorTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/records/NumericRangeValidatorTest.kt
@@ -4,7 +4,6 @@ import expo.modules.assertNotNull
 import expo.modules.assertNull
 import org.junit.Test
 
-
 class NumericRangeValidatorTest {
   @Test
   fun `should not throw if an argument is in the range`() {
@@ -26,7 +25,6 @@ class NumericRangeValidatorTest {
 
     runCatching { validator2.validate(0) }.exceptionOrNull().assertNotNull()
     runCatching { validator2.validate(10) }.exceptionOrNull().assertNotNull()
-
 
     runCatching { validator3.validate(1) }.exceptionOrNull().assertNotNull()
     runCatching { validator3.validate(10) }.exceptionOrNull().assertNotNull()

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/records/RecordTypeValidatorsTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/records/RecordTypeValidatorsTest.kt
@@ -1,0 +1,236 @@
+package expo.modules.kotlin.records
+
+import com.facebook.react.bridge.Dynamic
+import com.facebook.react.bridge.DynamicFromObject
+import com.facebook.react.bridge.JavaOnlyArray
+import com.facebook.react.bridge.JavaOnlyMap
+import expo.modules.assertNotNull
+import expo.modules.assertNull
+import expo.modules.kotlin.types.convert
+import org.junit.Test
+import kotlin.reflect.KClass
+import kotlin.reflect.full.createType
+
+class RecordTypeValidatorsTest {
+  private data class TestCase(
+    val jsObjectSetter: JavaOnlyMap.() -> Unit,
+    val recordClass: KClass<out Record>,
+    val shouldThrow: Boolean
+  ) {
+    fun getJSObject(): Dynamic {
+      return DynamicFromObject(
+        JavaOnlyMap().apply {
+          jsObjectSetter.invoke(this)
+        }
+      )
+    }
+  }
+
+  @Test
+  fun `test integration between range validators and record`() {
+    class IntRecord : Record {
+      @Field
+      @IntRange(from = 1, to = 10)
+      val value: Int = 2
+    }
+
+    class FloatRecord : Record {
+      @Field
+      @FloatRange(from = 0f, to = 1f)
+      val value: Float = 0.5f
+    }
+
+    class DoubleRecord : Record {
+      @Field
+      @DoubleRange(from = 0.0, to = 1.0)
+      val value: Double = 0.5
+    }
+
+    val testCases = listOf(
+      TestCase(
+        jsObjectSetter = { putInt("value", 4) },
+        recordClass = IntRecord::class,
+        shouldThrow = false
+      ),
+      TestCase(
+        jsObjectSetter = { putInt("value", 12) },
+        recordClass = IntRecord::class,
+        shouldThrow = true
+      ),
+      TestCase(
+        jsObjectSetter = { putDouble("value", 0.6) },
+        recordClass = FloatRecord::class,
+        shouldThrow = false
+      ),
+      TestCase(
+        jsObjectSetter = { putDouble("value", 2.0) },
+        recordClass = FloatRecord::class,
+        shouldThrow = true
+      ),
+      TestCase(
+        jsObjectSetter = { putDouble("value", 0.6) },
+        recordClass = DoubleRecord::class,
+        shouldThrow = false
+      ),
+      TestCase(
+        jsObjectSetter = { putDouble("value", 2.0) },
+        recordClass = DoubleRecord::class,
+        shouldThrow = true
+      )
+    )
+
+    for (test in testCases) {
+      val exception = runCatching { convert(test.getJSObject(), test.recordClass.createType()) }.exceptionOrNull()
+
+      if (test.shouldThrow) {
+        exception.assertNotNull()
+      } else {
+        exception.assertNull()
+      }
+    }
+  }
+
+  @Test
+  fun `test integration between is not empty validator and record`() {
+    class CollectionRecord : Record {
+      @Field
+      @IsNotEmpty
+      val value: List<Int> = listOf(1)
+    }
+
+    class ArrayRecord : Record {
+      @Field
+      @IsNotEmpty
+      val value: IntArray = IntArray(1) { it }
+    }
+
+    val testCases = listOf(
+      TestCase(
+        jsObjectSetter = { putArray("value", JavaOnlyArray().apply { pushInt(5) }) },
+        recordClass = CollectionRecord::class,
+        shouldThrow = false
+      ),
+      TestCase(
+        jsObjectSetter = { putArray("value", JavaOnlyArray()) },
+        recordClass = CollectionRecord::class,
+        shouldThrow = true
+      ),
+      TestCase(
+        jsObjectSetter = { putArray("value", JavaOnlyArray().apply { pushInt(5) }) },
+        recordClass = ArrayRecord::class,
+        shouldThrow = false
+      ),
+      TestCase(
+        jsObjectSetter = { putArray("value", JavaOnlyArray()) },
+        recordClass = ArrayRecord::class,
+        shouldThrow = true
+      )
+    )
+
+    for (test in testCases) {
+      val exception = runCatching { convert(test.getJSObject(), test.recordClass.createType()) }.exceptionOrNull()
+
+      if (test.shouldThrow) {
+        exception.assertNotNull()
+      } else {
+        exception.assertNull()
+      }
+    }
+  }
+
+  @Test
+  fun `test integration between size validator and record`() {
+    class CollectionRecord : Record {
+      @Field
+      @Size(min = 2)
+      val value: List<Int> = listOf(1, 2)
+    }
+
+    class ArrayRecord : Record {
+      @Field
+      @Size(min = 2)
+      val value: IntArray = IntArray(2) { it }
+    }
+
+    class StringRecord : Record {
+      @Field
+      @Size(min = 2)
+      val value: String = "12"
+    }
+
+    val testCases = listOf(
+      TestCase(
+        jsObjectSetter = { putArray("value", JavaOnlyArray().apply { pushInt(5); pushInt(6) }) },
+        recordClass = CollectionRecord::class,
+        shouldThrow = false
+      ),
+      TestCase(
+        jsObjectSetter = { putArray("value", JavaOnlyArray().apply { pushInt(1) }) },
+        recordClass = CollectionRecord::class,
+        shouldThrow = true
+      ),
+      TestCase(
+        jsObjectSetter = { putArray("value", JavaOnlyArray().apply { pushInt(5); pushInt(6) }) },
+        recordClass = ArrayRecord::class,
+        shouldThrow = false
+      ),
+      TestCase(
+        jsObjectSetter = { putArray("value", JavaOnlyArray().apply { pushInt(1) }) },
+        recordClass = ArrayRecord::class,
+        shouldThrow = true
+      ),
+      TestCase(
+        jsObjectSetter = { putString("value", "1234") },
+        recordClass = StringRecord::class,
+        shouldThrow = false
+      ),
+      TestCase(
+        jsObjectSetter = { putString("value", "1") },
+        recordClass = StringRecord::class,
+        shouldThrow = true
+      )
+    )
+
+    for (test in testCases) {
+      val exception = runCatching { convert(test.getJSObject(), test.recordClass.createType()) }.exceptionOrNull()
+
+      if (test.shouldThrow) {
+        exception.assertNotNull()
+      } else {
+        exception.assertNull()
+      }
+    }
+  }
+
+  @Test
+  fun `test integration between regular expression validator and record`() {
+    class StringRecord : Record {
+      @Field
+      @RegularExpression(regex = "[a-d]*")
+      val value: String = "abcd"
+    }
+
+    val testCases = listOf(
+      TestCase(
+        jsObjectSetter = { putString("value", "aabbccdd") },
+        recordClass = StringRecord::class,
+        shouldThrow = false
+      ),
+      TestCase(
+        jsObjectSetter = { putString("value", "xyz") },
+        recordClass = StringRecord::class,
+        shouldThrow = true
+      )
+    )
+
+    for (test in testCases) {
+      val exception = runCatching { convert(test.getJSObject(), test.recordClass.createType()) }.exceptionOrNull()
+
+      if (test.shouldThrow) {
+        exception.assertNotNull()
+      } else {
+        exception.assertNull()
+      }
+    }
+  }
+}

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/records/RegexValidatorTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/records/RegexValidatorTest.kt
@@ -9,13 +9,13 @@ class RegexValidatorTest {
   fun `should not throw if a value match regex`() {
     val validator = RegexValidator("[a-d]*".toRegex())
 
-    runCatching{ validator.validate("aaaabbbbbccccddd") }.exceptionOrNull().assertNull()
+    runCatching { validator.validate("aaaabbbbbccccddd") }.exceptionOrNull().assertNull()
   }
 
   @Test
   fun `should throw if a value not match regex`() {
     val validator = RegexValidator("[a-d]*".toRegex())
 
-    runCatching{ validator.validate("eeeeffff") }.exceptionOrNull().assertNotNull()
+    runCatching { validator.validate("eeeeffff") }.exceptionOrNull().assertNotNull()
   }
 }

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/records/RegexValidatorTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/records/RegexValidatorTest.kt
@@ -1,0 +1,21 @@
+package expo.modules.kotlin.records
+
+import expo.modules.assertNotNull
+import expo.modules.assertNull
+import org.junit.Test
+
+class RegexValidatorTest {
+  @Test
+  fun `should not throw if a value match regex`() {
+    val validator = RegexValidator("[a-d]*".toRegex())
+
+    runCatching{ validator.validate("aaaabbbbbccccddd") }.exceptionOrNull().assertNull()
+  }
+
+  @Test
+  fun `should throw if a value not match regex`() {
+    val validator = RegexValidator("[a-d]*".toRegex())
+
+    runCatching{ validator.validate("eeeeffff") }.exceptionOrNull().assertNotNull()
+  }
+}

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/records/SizeBinderTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/records/SizeBinderTest.kt
@@ -1,0 +1,35 @@
+package expo.modules.kotlin.records
+
+import com.google.common.truth.Truth
+import org.junit.Test
+import kotlin.reflect.typeOf
+
+class SizeBinderTest {
+  @Test
+  fun `should bind the collection type to the collection validator`() {
+    val binder = SizeBinder()
+    val listValidator = binder.bind(Size(min = 0, max = Int.MAX_VALUE), typeOf<List<Int>>())
+    val mapValidator = binder.bind(Size(min = 0, max = Int.MAX_VALUE), typeOf<Map<Int, Int>>())
+
+    Truth.assertThat(listValidator).isInstanceOf(CollectionSizeValidator::class.java)
+    Truth.assertThat(mapValidator).isInstanceOf(CollectionSizeValidator::class.java)
+  }
+
+  @Test
+  fun `should bind the array type to the array validator`() {
+    val binder = SizeBinder()
+    val intArrayValidator = binder.bind(Size(min = 0, max = Int.MAX_VALUE), typeOf<IntArray>())
+    val stringArrayValidator = binder.bind(Size(min = 0, max = Int.MAX_VALUE), typeOf<Array<String>>())
+
+    Truth.assertThat(intArrayValidator).isInstanceOf(ArraySizeValidator::class.java)
+    Truth.assertThat(stringArrayValidator).isInstanceOf(ArraySizeValidator::class.java)
+  }
+
+  @Test
+  fun `should bind the string type to the string validator`() {
+    val binder = SizeBinder()
+    val stringValidator = binder.bind(Size(min = 0, max = Int.MAX_VALUE), typeOf<String>())
+
+    Truth.assertThat(stringValidator).isInstanceOf(StringSizeValidator::class.java)
+  }
+}

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/records/SizeBinderTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/records/SizeBinderTest.kt
@@ -19,9 +19,13 @@ class SizeBinderTest {
   fun `should bind the array type to the array validator`() {
     val binder = SizeBinder()
     val intArrayValidator = binder.bind(Size(min = 0, max = Int.MAX_VALUE), typeOf<IntArray>())
+    val doubleArrayValidator = binder.bind(Size(min = 0, max = Int.MAX_VALUE), typeOf<DoubleArray>())
+    val floatArrayValidator = binder.bind(Size(min = 0, max = Int.MAX_VALUE), typeOf<FloatArray>())
     val stringArrayValidator = binder.bind(Size(min = 0, max = Int.MAX_VALUE), typeOf<Array<String>>())
 
-    Truth.assertThat(intArrayValidator).isInstanceOf(ArraySizeValidator::class.java)
+    Truth.assertThat(intArrayValidator).isInstanceOf(IntArraySizeValidator::class.java)
+    Truth.assertThat(doubleArrayValidator).isInstanceOf(DoubleArraySizeValidator::class.java)
+    Truth.assertThat(floatArrayValidator).isInstanceOf(FloatArraySizeValidator::class.java)
     Truth.assertThat(stringArrayValidator).isInstanceOf(ArraySizeValidator::class.java)
   }
 


### PR DESCRIPTION
# Why

Close ENG-4298.

# How

Added more validators such as:
- `IsNotEmpty` - can be added to collections or arrays
- `Size` - can be added to collections, arrays and strings
- `RegularExpression` - can be added to strings

# Test Plan

- unit tests ✅