### PR TITLE
[sweet api][kotlin] Add explicit null conversion in promise wrapper

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KPromiseWrapper.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KPromiseWrapper.kt
@@ -13,7 +13,7 @@ class KPromiseWrapper(
   override fun resolve(value: Any?) {
     bridgePromise.resolve(
       when (value) {
-        is Unit -> null
+        null, is Unit -> null
         is Bundle -> Arguments.fromBundle(value)
         is List<*> -> Arguments.fromList(value)
         is Array<*> -> Arguments.fromArray(value)


### PR DESCRIPTION
# Why

This PR just improve readability. Before, it wasn't clear how we handle nulls in promises. 
