### PR TITLE
[expo-av][iOS] - Fix AVAudioSession deactivation

### DIFF
--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix pauseAsync() causing framedrops and being delayed by not disabling AVAudioSession when there is no need for it ([#15873](https://github.com/expo/expo/pull/16544) by [@hirbod](https://github.com/hirbod) and [@mnightingale](https://github.com/mnightingale))
+- On iOS fix `pauseAsync` causing framedrops and being delayed by not disabling `AVAudioSession` when there is no need for it ([#15873](https://github.com/expo/expo/pull/16544) by [@hirbod](https://github.com/hirbod) and [@mnightingale](https://github.com/mnightingale))
 
 ### 💡 Others
 

--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix pauseAsync() causing framedrops and being delayed by not disabling AVAudioSession when there is no need for it ([#15873](https://github.com/expo/expo/pull/16544) by [@hirbod](https://github.com/hirbod) and [@mnightingale](https://github.com/mnightingale))
+
 ### 💡 Others
 
 ## 11.0.1 — 2022-03-07

--- a/packages/expo-av/ios/EXAV/EXAudioSessionManager.m
+++ b/packages/expo-av/ios/EXAV/EXAudioSessionManager.m
@@ -213,6 +213,19 @@ EX_REGISTER_SINGLETON_MODULE(AudioSessionManager);
   // If the session ought to be deactivated let's deactivate it and then configure.
   // And if the session should be activated, let's configure it first!
 
+  // After ample discussion, testing and consideration, it makes no sense to constantly
+  // disable AVAudioSession as it is a synchronous and blocking process. There were no regressions
+  // in various tests. With this change, pauseAsync() function calls are effectively instant
+  // without frame drops. To avoid triggering unnecessary setActive:YES calls, we still set the variable
+  // without actually disabling the session. We agreed to go this way and in case of
+  // doubt look for another approach in a regression.
+  // See https://github.com/expo/expo/issues/15873
+  
+  if (!shouldBeActive && _sessionIsActive) {
+    _sessionIsActive = NO;
+  }
+  
+  /*
   if (!shouldBeActive && _sessionIsActive) {
     [session setActive:NO error:&error];
     if (!error) {
@@ -223,6 +236,7 @@ EX_REGISTER_SINGLETON_MODULE(AudioSessionManager);
   if (error) {
     return error;
   }
+  */
 
   if (!_activeCategory || ![category isEqualToString:_activeCategory] || options != _activeOptions) {
     [session setCategory:category withOptions:options error:&error];


### PR DESCRIPTION
# Why

After ample discussion, testing and consideration, it makes no sense to constantly disable AudioSession as it is a synchronous and blocking process. 

There were no regressions in various tests. With this change, pauseAsync() function calls are effectively instant without frame drops. 
To avoid triggering unnecessary setActive:YES calls, we still set the variable without actually disabling the session. 

We agreed to go this way and in case of doubt look for another approach in a regression.
See https://github.com/expo/expo/issues/15873

fixes #15873
fixes #5297
fixes #16262
fixes #12613 (even though already closed but never fixed)

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

We're not going to disable the AudioSession anymore, because it's not needed. This make expo-av behave like almost all other apps that work with video and audio (thus making pausing videos fast and non blocking)

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Tested in Simulator and on two real devices running iOS 14 and iOS 15.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
