### PR TITLE
[ncl] Fix `FunctionDemo` not displaying falsy values

### DIFF
--- a/apps/native-component-list/src/components/FunctionDemo/FunctionDemo.tsx
+++ b/apps/native-component-list/src/components/FunctionDemo/FunctionDemo.tsx
@@ -98,7 +98,6 @@ export default function FunctionDemo({
   actions,
   renderAdditionalResult,
   additionalParameters = [],
-  displayUndefinedResult,
 }: Props) {
   const [result, setResult] = useState<unknown>(undefined);
   const [args, updateArgument] = useArguments(parameters);

--- a/apps/native-component-list/src/components/FunctionDemo/FunctionDemo.tsx
+++ b/apps/native-component-list/src/components/FunctionDemo/FunctionDemo.tsx
@@ -48,6 +48,10 @@ type Props = {
    * Rendering function to render some additional components based on the function's result.
    */
   renderAdditionalResult?: (result: unknown) => JSX.Element | void;
+  /**
+   * If true, the result box will de displayed even if action returns `undefined`.
+   */
+  displayUndefinedResult?: boolean;
 };
 
 /**
@@ -98,6 +102,7 @@ export default function FunctionDemo({
   actions,
   renderAdditionalResult,
   additionalParameters = [],
+  displayUndefinedResult,
 }: Props) {
   const [result, setResult] = useState<unknown>(undefined);
   const [args, updateArgument] = useArguments(parameters);
@@ -109,7 +114,12 @@ export default function FunctionDemo({
 
   const handlePress = useCallback(
     async (action: ActionFunction) => {
-      setResult(await action(...args, ...additionalArgs));
+      // force clear the previous result if exists
+      setResult(undefined);
+      const newResult = await action(...args, ...additionalArgs);
+      // undefined is a special value hiding the result box
+      // so we need to replace it with a string
+      setResult(displayUndefinedResult && newResult === undefined ? 'undefined' : newResult);
     },
     [args, additionalArgs]
   );
@@ -136,7 +146,7 @@ export default function FunctionDemo({
           ))}
         </View>
       </View>
-      {result && (
+      {result !== undefined && (
         <>
           <MonoTextWithCountdown onCountdownEnded={() => setResult(undefined)}>
             {resultToString(result)}

--- a/apps/native-component-list/src/components/FunctionDemo/FunctionDemo.tsx
+++ b/apps/native-component-list/src/components/FunctionDemo/FunctionDemo.tsx
@@ -48,10 +48,6 @@ type Props = {
    * Rendering function to render some additional components based on the function's result.
    */
   renderAdditionalResult?: (result: unknown) => JSX.Element | void;
-  /**
-   * If true, the result box will de displayed even if action returns `undefined`.
-   */
-  displayUndefinedResult?: boolean;
 };
 
 /**
@@ -119,7 +115,7 @@ export default function FunctionDemo({
       const newResult = await action(...args, ...additionalArgs);
       // undefined is a special value hiding the result box
       // so we need to replace it with a string
-      setResult(displayUndefinedResult && newResult === undefined ? 'undefined' : newResult);
+      setResult(newResult === undefined ? 'undefined' : newResult);
     },
     [args, additionalArgs]
   );


### PR DESCRIPTION
# Why

Previously, the `FunctionDemo` MonoText result box wasn't rendered, if the result returned by action was falsy (`null`, `undefined`, `false`).

Also, the result wasn't refreshed, if two `actions` (or the same action clicked twice) of the same demo returned the exact same value - it felt like the second action didn't work.

# How

- Treat `undefined` as a special state value that clears the result.
- Clear it always before setting a new result.
- ~~Added prop to specify if the `"undefined"` mono text should be displayed if action returns `undefined`~~ No new features then 😥 

# Test Plan

Tested on new Clipboard NCL screen (WIP)
