### PR TITLE
[ncl] Support platform-specific function demo

### DIFF
--- a/apps/native-component-list/src/components/FunctionDemo/FunctionDemo.tsx
+++ b/apps/native-component-list/src/components/FunctionDemo/FunctionDemo.tsx
@@ -7,6 +7,7 @@ import ActionButton from './ActionButton';
 import Configurator from './Configurator';
 import Divider from './Divider';
 import FunctionSignature from './FunctionSignature';
+import Platforms from './Platforms';
 import {
   ActionFunction,
   ArgumentName,
@@ -14,9 +15,11 @@ import {
   FunctionArgument,
   FunctionParameter,
   OnArgumentChangeCallback,
+  Platform,
   PrimitiveArgument,
   PrimitiveParameter,
 } from './index.types';
+import { isCurrentPlatformSupported } from './utils';
 
 const STRING_TRIM_THRESHOLD = 300;
 
@@ -29,6 +32,10 @@ type Props = {
    * Function name. Used in signature rendering.
    */
   name: string;
+  /**
+   * Supported platforms. Used in signature rendering and to grey-out unavailable functions.
+   */
+  platforms?: Platform[];
   /**
    * Function-only parameters. Function's arguments are constructed based on these parameters and passed as-is to the actions callbacks.
    * These should reflect the actual function signature (type of arguments, default values, order, etc.).
@@ -91,7 +98,23 @@ export type FunctionDescription = Omit<Props, 'namespace' | 'renderAdditionalRes
  * }
  * ```
  */
-export default function FunctionDemo({
+export default function FunctionDemo({ name, platforms = [], ...contentProps }: Props) {
+  const disabled = !isCurrentPlatformSupported(platforms);
+
+  return (
+    <View style={disabled && styles.demoContainerDisabled}>
+      <Platforms
+        platforms={platforms}
+        style={styles.platformBadge}
+        textStyle={styles.platformText}
+      />
+      <HeadingText style={disabled && styles.headerDisabled}>{name}</HeadingText>
+      {!disabled && <FunctionDemoContent name={name} {...contentProps} />}
+    </View>
+  );
+}
+
+function FunctionDemoContent({
   namespace,
   name,
   parameters = [],
@@ -116,7 +139,6 @@ export default function FunctionDemo({
 
   return (
     <>
-      <HeadingText>{name}</HeadingText>
       <Configurator parameters={parameters} onChange={updateArgument} value={args} />
       {additionalParameters.length > 0 && (
         <>
@@ -243,5 +265,19 @@ const styles = StyleSheet.create({
     right: 0,
     bottom: 3,
     flexDirection: 'row',
+  },
+  platformBadge: {
+    position: 'absolute',
+    top: 5,
+  },
+  platformText: {
+    fontSize: 10,
+  },
+  headerDisabled: {
+    textDecorationLine: 'line-through',
+    color: '#999',
+  },
+  demoContainerDisabled: {
+    marginBottom: 10,
   },
 });

--- a/apps/native-component-list/src/components/FunctionDemo/Platforms.tsx
+++ b/apps/native-component-list/src/components/FunctionDemo/Platforms.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, Text, StyleSheet, StyleProp, TextStyle, ViewStyle } from 'react-native';
 
 import { Platform } from './index.types';
 
@@ -10,19 +10,27 @@ function joinWithCamelCase<T extends string, H extends string>([first, second]: 
   return `${first}${second.charAt(0).toUpperCase()}${second.slice(1)}` as `${H}${Capitalize<T>}`;
 }
 
-function PlatformIndicator({ platform }: { platform: Platform }) {
+function PlatformIndicator({ platform, textStyle }: { platform: Platform; textStyle?: TextStyle }) {
   return (
     <View style={[styles.platform, styles[joinWithCamelCase(['platform', platform])]]}>
-      <Text style={styles.platformText}>{platform}</Text>
+      <Text style={[styles.platformText, textStyle]}>{platform}</Text>
     </View>
   );
 }
 
-export default function Platforms({ platforms }: { platforms: Platform[] }) {
+export default function Platforms({
+  platforms,
+  style,
+  textStyle,
+}: {
+  platforms: Platform[];
+  style?: StyleProp<ViewStyle>;
+  textStyle?: TextStyle;
+}) {
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, style]}>
       {platforms.map((platform) => (
-        <PlatformIndicator key={platform} platform={platform} />
+        <PlatformIndicator key={platform} platform={platform} textStyle={textStyle} />
       ))}
     </View>
   );


### PR DESCRIPTION
# Why

To support platform-specific functions

# How

Made platform badges from arguments/options a bit bigger and displayed right above function header.

Unavailable functions are grayed-out:

<img src="https://user-images.githubusercontent.com/278340/157663901-1df8e044-f4e0-4e98-9000-d0b80092f21e.jpeg" width="300" />

> I deliberately set `getUrlAsync` to iOS and `setUrlAsync` to Android for demo purposes 😉 

# Test Plan

Clipboard NCL screen (WIP)