### PR TITLE
[dev-client] fix e2e ci build error

### DIFF
--- a/packages/expo-dev-client/e2e/ios/AppDelegate.m
+++ b/packages/expo-dev-client/e2e/ios/AppDelegate.m
@@ -5,6 +5,7 @@
 #import <React/RCTRootView.h>
 #import <React/RCTLinkingManager.h>
 
+@import ExpoModulesCore;
 @import EXDevMenu;
 
 #import <EXDevLauncher/EXDevLauncherController.h>


### PR DESCRIPTION
# Why

to make my RN 0.68 upgrade pr ci all green and found dev-client e2e ci task failed for a while.
e.g. https://github.com/expo/expo/runs/5466750947?check_suite_focus=true

```
/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/87cf5cc295b3d8b52a4404cb9fa3356f/ios/src/AppDelegate.m:48:4: error: definition of 'EXAppDelegateWrapper' must be imported from module 'ExpoModulesCore' before it is required
  [super application:application didFinishLaunchingWithOptions:launchOptions];
   ^
In module 'EXDevMenu' imported from /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/87cf5cc295b3d8b52a4404cb9fa3356f/ios/src/AppDelegate.m:8:
In module 'ExpoModulesCore' imported from /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/87cf5cc295b3d8b52a4404cb9fa3356f/ios/build/Build/Products/Debug-iphonesimulator/expo-dev-menu/Swift Compatibility Header/EXDevMenu-Swift.h:192:
/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/87cf5cc295b3d8b52a4404cb9fa3356f/ios/Pods/Headers/Public/ExpoModulesCore/ExpoModulesCore/EXAppDelegateWrapper.h:13:12: note: definition here is not reachable
@interface EXAppDelegateWrapper : UIResponder <UIApplicationDelegate>
           ^
23 warnings and 1 error generated.
```

# How

import `ExpoModulesCore` before `EXDevMenu`

# Test Plan

dev-client e2e ci passed
