### PR TITLE
[home] update statusbar and tab colors, add headers to Diagnostics and Settings screens

### DIFF
--- a/home/HomeApp.tsx
+++ b/home/HomeApp.tsx
@@ -1,6 +1,8 @@
 import { ActionSheetProvider } from '@expo/react-native-action-sheet';
+import { darkTheme, lightTheme } from '@expo/styleguide-native';
 import { Ionicons, MaterialIcons } from '@expo/vector-icons';
 import { Assets as StackAssets } from '@react-navigation/stack';
+import FeatureFlags from 'FeatureFlags';
 import { Asset } from 'expo-asset';
 import { ThemePreferenceProvider } from 'expo-dev-client-components';
 import { ThemePreference } from 'expo-dev-client-components/build/ThemeProvider';
@@ -102,16 +104,27 @@ export default function HomeApp() {
     return null;
   }
 
-  let theme = preferredAppearance === undefined ? colorScheme : preferredAppearance;
+  let theme = !preferredAppearance ? colorScheme : preferredAppearance;
   if (theme === undefined) {
     theme = 'light';
   }
 
   const backgroundColor = theme === 'dark' ? '#000000' : '#ffffff';
 
+  const redesignedBackgroundColor =
+    theme === 'dark' ? darkTheme.background.default : lightTheme.background.default;
+
   return (
     <ThemePreferenceProvider theme={preferredAppearance as ThemePreference}>
-      <View style={[styles.container, { backgroundColor }]}>
+      <View
+        style={[
+          styles.container,
+          {
+            backgroundColor: FeatureFlags.ENABLE_2022_NAVIGATION_REDESIGN
+              ? redesignedBackgroundColor
+              : backgroundColor,
+          },
+        ]}>
         <ActionSheetProvider>
           <Navigation theme={theme === 'light' ? ColorTheme.LIGHT : ColorTheme.DARK} />
         </ActionSheetProvider>

--- a/home/HomeApp.tsx
+++ b/home/HomeApp.tsx
@@ -2,7 +2,6 @@ import { ActionSheetProvider } from '@expo/react-native-action-sheet';
 import { darkTheme, lightTheme } from '@expo/styleguide-native';
 import { Ionicons, MaterialIcons } from '@expo/vector-icons';
 import { Assets as StackAssets } from '@react-navigation/stack';
-import FeatureFlags from 'FeatureFlags';
 import { Asset } from 'expo-asset';
 import { ThemePreferenceProvider } from 'expo-dev-client-components';
 import { ThemePreference } from 'expo-dev-client-components/build/ThemeProvider';
@@ -12,6 +11,7 @@ import * as React from 'react';
 import { Linking, Platform, StyleSheet, View, useColorScheme } from 'react-native';
 import url from 'url';
 
+import FeatureFlags from './FeatureFlags';
 import { ColorTheme } from './constants/Colors';
 import Navigation from './navigation/Navigation';
 import HistoryActions from './redux/HistoryActions';

--- a/home/components/ThemedStatusBar.tsx
+++ b/home/components/ThemedStatusBar.tsx
@@ -1,11 +1,15 @@
 import { useTheme, useIsFocused } from '@react-navigation/native';
+import { useExpoTheme } from 'expo-dev-client-components';
 import * as Device from 'expo-device';
 import * as React from 'react';
 import { Platform, StatusBar } from 'react-native';
 
+import FeatureFlags from '../FeatureFlags';
+
 export default function ThemedStatusBar() {
   const theme = useTheme();
   const isFocused = useIsFocused();
+  const expoTheme = useExpoTheme();
 
   // Android below API 23 (Android 6.0) does not support 'dark-content' barStyle:
   // - statusBar shouldn't be translucent
@@ -14,6 +18,10 @@ export default function ThemedStatusBar() {
   const backgroundColor = theme.dark ? '#000000' : translucent ? '#ffffff' : '#00000088';
   const barStyle = theme.dark ? 'light-content' : 'dark-content';
 
+  const redesignedBackgroundColor = FeatureFlags.ENABLE_2022_NAVIGATION_REDESIGN
+    ? expoTheme.background.default
+    : backgroundColor;
+
   // When switching from an Expo project back to home sometimes the status bar will be
   // changed back to the default status bar. This resolves that issue, but is messy.
   if (Platform.OS === 'android' && isFocused) {
@@ -21,6 +29,10 @@ export default function ThemedStatusBar() {
   }
 
   return (
-    <StatusBar translucent={translucent} barStyle={barStyle} backgroundColor={backgroundColor} />
+    <StatusBar
+      translucent={translucent}
+      barStyle={barStyle}
+      backgroundColor={redesignedBackgroundColor}
+    />
   );
 }

--- a/home/navigation/BottomTabNavigator.android.ts
+++ b/home/navigation/BottomTabNavigator.android.ts
@@ -1,7 +1,9 @@
+import { darkTheme, lightTheme } from '@expo/styleguide-native';
 import { createMaterialBottomTabNavigator } from '@react-navigation/material-bottom-tabs';
 import { ComponentProps } from 'react';
 import { StyleSheet } from 'react-native';
 
+import FeatureFlags from '../FeatureFlags';
 import Colors, { ColorTheme } from '../constants/Colors';
 
 const BottomTabNavigator = createMaterialBottomTabNavigator();
@@ -14,10 +16,18 @@ export const getNavigatorProps = (props: {
   shifting: true,
   activeColor: Colors[props.theme].tabIconSelected,
   inactiveColor: Colors[props.theme].tabIconDefault,
+  ...(FeatureFlags.ENABLE_2022_NAVIGATION_REDESIGN && {
+    activeColor: props.theme === 'dark' ? darkTheme.link.default : lightTheme.link.default,
+    inactiveColor: props.theme === 'dark' ? darkTheme.icon.default : lightTheme.icon.default,
+  }),
   barStyle: {
     backgroundColor: Colors[props.theme].cardBackground,
     borderTopWidth:
       props.theme === 'dark' ? StyleSheet.hairlineWidth * 2 : StyleSheet.hairlineWidth,
     borderTopColor: Colors[props.theme].cardSeparator,
+    ...(FeatureFlags.ENABLE_2022_NAVIGATION_REDESIGN && {
+      backgroundColor:
+        props.theme === 'dark' ? darkTheme.background.default : lightTheme.background.default,
+    }),
   },
 });

--- a/home/navigation/BottomTabNavigator.ts
+++ b/home/navigation/BottomTabNavigator.ts
@@ -1,11 +1,25 @@
+import { darkTheme, lightTheme } from '@expo/styleguide-native';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { ComponentProps } from 'react';
+
+import FeatureFlags from '../FeatureFlags';
 
 const BottomTabNavigator = createBottomTabNavigator();
 export default BottomTabNavigator;
 
-export const getNavigatorProps = (_props: {
+export const getNavigatorProps = (props: {
   theme: string;
 }): Partial<ComponentProps<typeof BottomTabNavigator.Navigator>> => ({
-  tabBarOptions: { labelStyle: { fontWeight: '600' }, keyboardHidesTabBar: false },
+  tabBarOptions: {
+    labelStyle: { fontWeight: '600' },
+    keyboardHidesTabBar: false,
+    ...(FeatureFlags.ENABLE_2022_NAVIGATION_REDESIGN && {
+      style: {
+        backgroundColor:
+          props.theme === 'dark' ? darkTheme.background.default : lightTheme.background.default,
+      },
+      activeTintColor: props.theme === 'dark' ? darkTheme.link.default : lightTheme.link.default,
+      inactiveTintColor: props.theme === 'dark' ? darkTheme.icon.default : lightTheme.icon.default,
+    }),
+  },
 });

--- a/home/navigation/Navigation.tsx
+++ b/home/navigation/Navigation.tsx
@@ -53,6 +53,7 @@ import defaultNavigationOptions from './defaultNavigationOptions';
 // TODO(Bacon): Do we need to create a new one each time?
 const ProjectsStack = createStackNavigator<ProjectsStackRoutes>();
 const HomeStack = createStackNavigator<HomeStackRoutes>();
+const SettingsStack = createStackNavigator();
 
 function useThemeName() {
   const theme = useTheme();
@@ -115,6 +116,18 @@ function HomeStackScreen() {
         }}
       />
     </HomeStack.Navigator>
+  );
+}
+
+function SettingsStackScreen() {
+  const themeName = useThemeName();
+
+  return (
+    <SettingsStack.Navigator
+      initialRouteName="Settings"
+      screenOptions={defaultNavigationOptions(themeName)}>
+      <SettingsStack.Screen name="Settings" component={UserSettingsScreen} />
+    </SettingsStack.Navigator>
   );
 }
 
@@ -183,7 +196,6 @@ function DiagnosticsStackScreen() {
         }
         options={{
           title: 'Diagnostics',
-          headerShown: !FeatureFlags.ENABLE_2022_DIAGNOSTICS_REDESIGN,
         }}
       />
       <DiagnosticsStack.Screen
@@ -250,7 +262,7 @@ function TabNavigator(props: { theme: string }) {
       {FeatureFlags.ENABLE_2022_NAVIGATION_REDESIGN ? (
         <BottomTab.Screen
           name="SettingsScreen"
-          component={UserSettingsScreen}
+          component={SettingsStackScreen}
           options={{
             title: 'Settings',
             tabBarIcon: (props) => <SettingsFilledIcon {...props} style={styles.icon} size={24} />,

--- a/home/navigation/defaultNavigationOptions.tsx
+++ b/home/navigation/defaultNavigationOptions.tsx
@@ -1,4 +1,6 @@
+import { darkTheme, lightTheme } from '@expo/styleguide-native';
 import { StackNavigationOptions, HeaderStyleInterpolators } from '@react-navigation/stack';
+import FeatureFlags from 'FeatureFlags';
 import { Platform, StyleSheet } from 'react-native';
 
 import Colors, { ColorTheme } from '../constants/Colors';
@@ -10,6 +12,11 @@ export default (theme: ColorTheme): StackNavigationOptions => {
       elevation: 0,
       backgroundColor: Colors[theme].navBackgroundColor,
       borderBottomWidth: StyleSheet.hairlineWidth,
+      ...(FeatureFlags.ENABLE_2022_NAVIGATION_REDESIGN && {
+        borderBottomColor: theme === 'dark' ? darkTheme.border.default : lightTheme.border.default,
+        backgroundColor:
+          theme === 'dark' ? darkTheme.background.default : lightTheme.background.default,
+      }),
     },
     headerTitleStyle: {
       fontWeight: Platform.OS === 'ios' ? '600' : '400',

--- a/home/screens/HomeScreen/DevelopmentServersPlaceholder.tsx
+++ b/home/screens/HomeScreen/DevelopmentServersPlaceholder.tsx
@@ -27,7 +27,7 @@ export function DevelopmentServersPlaceholder() {
   };
 
   return (
-    <View bg="default" rounded="large" border="hairline">
+    <View bg="default" rounded="large" border="hairline" overflow="hidden">
       <View padding="medium">
         <Text size="small" style={{ marginBottom: spacing[2] }}>
           Start a local development server with:

--- a/home/screens/HomeScreen/index.tsx
+++ b/home/screens/HomeScreen/index.tsx
@@ -1,5 +1,5 @@
 import { StackScreenProps } from '@react-navigation/stack';
-import { ThemeContext } from 'expo-dev-client-components';
+import { ThemeContext, useExpoTheme } from 'expo-dev-client-components';
 import { useHomeScreenDataQuery } from 'graphql/types';
 import * as React from 'react';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -41,10 +41,12 @@ export function HomeScreen(props: NavigationProps) {
     }, [])
   );
 
+  const theme = useExpoTheme();
+
   const { data } = useHomeScreenDataQuery();
 
   return (
-    <SafeAreaView style={{ flex: 1 }} edges={['top']}>
+    <SafeAreaView style={{ flex: 1, backgroundColor: theme.background.default }} edges={['top']}>
       <ThemeContext.Consumer>
         {(theme) => (
           <HomeScreenView

--- a/home/screens/RedesignedDiagnosticsScreen/index.tsx
+++ b/home/screens/RedesignedDiagnosticsScreen/index.tsx
@@ -2,7 +2,6 @@ import { spacing } from '@expo/styleguide-native';
 import { StackNavigationProp, StackScreenProps } from '@react-navigation/stack';
 import { Spacer } from 'expo-dev-client-components';
 import * as React from 'react';
-import { SafeAreaView } from 'react-native-safe-area-context';
 
 import ScrollView from '../../components/NavigationScrollView';
 import { AllStackRoutes } from '../../navigation/Navigation.types';
@@ -13,19 +12,17 @@ export function RedesignedDiagnosticsScreen({
   navigation,
 }: StackScreenProps<AllStackRoutes, 'Diagnostics'>) {
   return (
-    <SafeAreaView style={{ flex: 1 }} edges={['top']}>
-      <ScrollView style={{ flex: 1 }} contentContainerStyle={{ padding: spacing[4] }}>
-        <AudioDiagnostic navigation={navigation} />
-        <Spacer.Vertical size="medium" />
-        {Environment.IsIOSRestrictedBuild ? (
-          <ForegroundLocationDiagnostic navigation={navigation} />
-        ) : (
-          <BackgroundLocationDiagnostic navigation={navigation} />
-        )}
-        <Spacer.Vertical size="medium" />
-        <GeofencingDiagnostic navigation={navigation} />
-      </ScrollView>
-    </SafeAreaView>
+    <ScrollView style={{ flex: 1 }} contentContainerStyle={{ padding: spacing[4] }}>
+      <AudioDiagnostic navigation={navigation} />
+      <Spacer.Vertical size="medium" />
+      {Environment.IsIOSRestrictedBuild ? (
+        <ForegroundLocationDiagnostic navigation={navigation} />
+      ) : (
+        <BackgroundLocationDiagnostic navigation={navigation} />
+      )}
+      <Spacer.Vertical size="medium" />
+      <GeofencingDiagnostic navigation={navigation} />
+    </ScrollView>
   );
 }
 


### PR DESCRIPTION
# Why

I wanted to clean up a few spots in the navigation that didn't match the redesign.

# How

This should all be flagged behind the 2022 navigation redesign flag

- updated statusbar background color to match headers
- updated header background color
- updated tab color
- added headers to Diagnostics and Settings screens

# Test Plan

I tested this on iOS and Android in both light and dark modes.

![IMG_4709](https://user-images.githubusercontent.com/12488826/157693956-cae29059-25f9-4cad-9e21-d8db3adf4802.PNG)

![Screenshot_20220310-102311](https://user-images.githubusercontent.com/12488826/157694269-74ad7b8f-5c1a-43cc-af27-bef220a206af.png)

