### PR TITLE
[cli] Pull in start command shim from #16518

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [cli] Added module for starting host tunnels with Ngrok. ([#16556](https://github.com/expo/expo/pull/16556) by [@EvanBacon](https://github.com/EvanBacon))
 - [cli] Added module for updating the "development session" API. ([#16555](https://github.com/expo/expo/pull/16555) by [@EvanBacon](https://github.com/EvanBacon))
 - [cli] Added modules for creating dev server URLs, akin to `UrlUtils` in `xdl`. ([#16557](https://github.com/expo/expo/pull/16557) by [@EvanBacon](https://github.com/EvanBacon))
+- [cli] Added shim for `expo start` command and option resolvers.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -10,7 +10,7 @@
 - [cli] Added module for starting host tunnels with Ngrok. ([#16556](https://github.com/expo/expo/pull/16556) by [@EvanBacon](https://github.com/EvanBacon))
 - [cli] Added module for updating the "development session" API. ([#16555](https://github.com/expo/expo/pull/16555) by [@EvanBacon](https://github.com/EvanBacon))
 - [cli] Added modules for creating dev server URLs, akin to `UrlUtils` in `xdl`. ([#16557](https://github.com/expo/expo/pull/16557) by [@EvanBacon](https://github.com/EvanBacon))
-- [cli] Added shim for `expo start` command and option resolvers.
+- [cli] Added shim for `expo start` command and option resolvers. ([#16587](https://github.com/expo/expo/pull/16587) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo/bin/cli.ts
+++ b/packages/expo/bin/cli.ts
@@ -2,13 +2,13 @@
 import arg from 'arg';
 import chalk from 'chalk';
 
-// TODO: Change to `start`
-const defaultCmd = 'config';
+const defaultCmd = 'start';
 
 export type Command = (argv?: string[]) => void;
 
 const commands: { [command: string]: () => Promise<Command> } = {
   // Add a new command here
+  start: () => import('../cli/start').then((i) => i.expoStart),
   prebuild: () => import('../cli/prebuild').then((i) => i.expoPrebuild),
   config: () => import('../cli/config').then((i) => i.expoConfig),
   // Auth

--- a/packages/expo/cli/start/__tests__/resolveOptions-test.ts
+++ b/packages/expo/cli/start/__tests__/resolveOptions-test.ts
@@ -1,0 +1,82 @@
+import { resolvePortAsync } from '../../utils/port';
+import { resolveHostType, resolvePortsAsync } from '../resolveOptions';
+
+const asMock = (fn: any): jest.Mock => fn as jest.Mock;
+
+jest.mock('../../utils/port', () => {
+  return {
+    resolvePortAsync: jest.fn(),
+  };
+});
+
+describe(resolveHostType, () => {
+  it(`resolves no options`, () => {
+    expect(resolveHostType({})).toBe('lan');
+  });
+  it(`resolves host type`, () => {
+    expect(resolveHostType({ lan: true })).toBe('lan');
+    expect(resolveHostType({ localhost: true })).toBe('localhost');
+    expect(resolveHostType({ tunnel: true })).toBe('tunnel');
+    expect(resolveHostType({ offline: true })).toBe('lan');
+    expect(resolveHostType({ host: 'tunnel' })).toBe('tunnel');
+    // Default
+    expect(resolveHostType({})).toBe('lan');
+  });
+  it(`asserts invalid host type`, () => {
+    expect(() => resolveHostType({ host: 'bacon' })).toThrow();
+  });
+  it(`asserts conflicting options`, () => {
+    expect(() => resolveHostType({ localhost: true, offline: true })).toThrow(/Specify at most/);
+    expect(() => resolveHostType({ localhost: true, host: 'lan' })).toThrow(/Specify at most/);
+    expect(() => resolveHostType({ localhost: true, lan: true })).toThrow(/Specify at most/);
+    expect(() => resolveHostType({ tunnel: true, lan: true })).toThrow(/Specify at most/);
+  });
+});
+
+describe(resolvePortsAsync, () => {
+  beforeEach(() => {
+    asMock(resolvePortAsync).mockImplementation((root, { defaultPort, fallbackPort }) =>
+      Promise.resolve(defaultPort ?? fallbackPort)
+    );
+  });
+  it(`resolves default port for metro`, async () => {
+    await expect(resolvePortsAsync('/noop', {}, { webOnly: false })).resolves.toStrictEqual({
+      metroPort: 19000,
+    });
+  });
+  it(`resolves default port with given port`, async () => {
+    await expect(
+      resolvePortsAsync('/noop', { port: 1234 }, { webOnly: false })
+    ).resolves.toStrictEqual({
+      metroPort: 1234,
+    });
+    await expect(
+      resolvePortsAsync('/noop', { port: 1234, devClient: true }, { webOnly: false })
+    ).resolves.toStrictEqual({
+      metroPort: 1234,
+    });
+    await expect(
+      resolvePortsAsync('/noop', { port: 1234 }, { webOnly: true })
+    ).resolves.toStrictEqual({
+      webpackPort: 1234,
+    });
+  });
+  it(`resolves default port for metro with dev client`, async () => {
+    await expect(
+      resolvePortsAsync('/noop', { devClient: true }, { webOnly: false })
+    ).resolves.toStrictEqual({
+      metroPort: 8081,
+    });
+  });
+  it(`resolves default port for webpack`, async () => {
+    await expect(resolvePortsAsync('/noop', {}, { webOnly: true })).resolves.toStrictEqual({
+      webpackPort: 19006,
+    });
+    // dev client changes nothing on Webpack...
+    await expect(
+      resolvePortsAsync('/noop', { devClient: true }, { webOnly: true })
+    ).resolves.toStrictEqual({
+      webpackPort: 19006,
+    });
+  });
+});

--- a/packages/expo/cli/start/index.ts
+++ b/packages/expo/cli/start/index.ts
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+import chalk from 'chalk';
+
+import { Command } from '../../bin/cli';
+import * as Log from '../log';
+import { assertArgs, getProjectRoot } from '../utils/args';
+import { logCmdError } from '../utils/errors';
+
+export const expoStart: Command = async (argv) => {
+  const args = assertArgs(
+    {
+      // Types
+      '--help': Boolean,
+      '--clear': Boolean,
+      '--max-workers': Number,
+      '--no-dev': Boolean,
+      '--minify': Boolean,
+      '--https': Boolean,
+      '--force-manifest-type': String,
+      '--port': Number,
+      '--dev-client': Boolean,
+      '--scheme': String,
+      '--android': Boolean,
+      '--ios': Boolean,
+      '--web': Boolean,
+      '--host': String,
+      '--tunnel': Boolean,
+      '--lan': Boolean,
+      '--localhost': Boolean,
+      '--offline': Boolean,
+      // Aliases
+      '-h': '--help',
+      '-c': '--clear',
+      '-p': '--port',
+      '-a': '--android',
+      '-i': '--ios',
+      '-w': '--web',
+      '-m': '--host',
+    },
+    argv
+  );
+
+  if (args['--help']) {
+    Log.exit(
+      chalk`
+  {bold Description}
+    Start a local dev server for the app
+
+  {bold Usage}
+    $ npx expo start <dir>
+
+  <dir> is the directory of the Expo project.
+  Defaults to the current working directory.
+
+  {bold Options}
+    -a, --android                          Opens your app in Expo Go on a connected Android device
+    -i, --ios                              Opens your app in Expo Go in a currently running iOS simulator on your computer
+    -w, --web                              Opens your app in a web browser
+
+    -c, --clear                            Clear the bundler cache
+    --max-workers <num>                    Maximum number of tasks to allow Metro to spawn
+    --no-dev                               Bundle in production mode
+    --minify                               Minify JavaScript    
+
+    -m, --host <mode>                      lan, tunnel, localhost. Dev server hosting type. Default: lan.
+                                           - lan: Use the local network
+                                           - tunnel: Use any network by tunnel through ngrok
+                                           - localhost: Connect to the dev server over localhost
+    --tunnel                               Same as --host tunnel
+    --lan                                  Same as --host lan
+    --localhost                            Same as --host localhost
+
+    --offline                              Skip network requests and use anonymous manifest signatures
+    --https                                Start the dev server with https protocol
+    --scheme <scheme>                      Custom URI protocol to use when launching an app
+    -p, --port <port>                      Port to start the dev server on (does not apply to web or tunnel). Default: 19000
+
+    --dev-client                           Experimental: Starts the bundler for use with the expo-development-client
+    --force-manifest-type <manifest-type>  Override auto detection of manifest type
+    -h, --help                             output usage information
+`,
+      0
+    );
+  }
+
+  const projectRoot = getProjectRoot(args);
+  const { resolveOptionsAsync } = await import('./resolveOptions');
+  const options = await resolveOptionsAsync(projectRoot, args).catch(logCmdError);
+
+  const { APISettings } = await import('../api/settings');
+  APISettings.isOffline = options.offline;
+
+  const { startAsync } = await import('./startAsync');
+  return startAsync(projectRoot, options, { webOnly: false }).catch(logCmdError);
+};

--- a/packages/expo/cli/start/resolveOptions.ts
+++ b/packages/expo/cli/start/resolveOptions.ts
@@ -54,7 +54,6 @@ export async function resolveOptionsAsync(projectRoot: string, args: any): Promi
     port: args['--port'],
     minify: !!args['--minify'],
 
-    //
     devClient: !!args['--dev-client'],
 
     scheme,

--- a/packages/expo/cli/start/resolveOptions.ts
+++ b/packages/expo/cli/start/resolveOptions.ts
@@ -1,0 +1,161 @@
+import assert from 'assert';
+
+import { AbortCommandError, CommandError } from '../utils/errors';
+import { resolvePortAsync } from '../utils/port';
+
+export type Options = {
+  forceManifestType: 'classic' | 'expo-updates';
+  android: boolean;
+  web: boolean;
+  ios: boolean;
+  offline: boolean;
+  clear: boolean;
+  dev: boolean;
+  https: boolean;
+  maxWorkers: number;
+  port: number;
+  /** Should instruct the bundler to create minified bundles. */
+  minify: boolean;
+  devClient: boolean;
+  scheme: string;
+  host: 'localhost' | 'lan' | 'tunnel';
+};
+
+export async function resolveOptionsAsync(projectRoot: string, args: any): Promise<Options> {
+  const forceManifestType = args['--force-manifest-type'];
+  if (forceManifestType) {
+    assert.match(forceManifestType, /^(classic|expo-updates)$/);
+  }
+  const host = resolveHostType({
+    host: args['--host'],
+    offline: args['--offline'],
+    lan: args['--lan'],
+    localhost: args['--localhost'],
+    tunnel: args['--tunnel'],
+  });
+
+  const scheme = await resolveSchemeAsync(projectRoot, {
+    scheme: args['--scheme'],
+    devClient: args['--dev-client'],
+  });
+
+  return {
+    forceManifestType,
+
+    android: !!args['--android'],
+    web: !!args['--web'],
+    ios: !!args['--ios'],
+    offline: !!args['--offline'],
+
+    clear: !!args['--clear'],
+    dev: !args['--no-dev'],
+    https: !!args['--https'],
+    maxWorkers: args['--max-workers'],
+    port: args['--port'],
+    minify: !!args['--minify'],
+
+    //
+    devClient: !!args['--dev-client'],
+
+    scheme,
+    host,
+  };
+}
+
+export async function resolveSchemeAsync(
+  projectRoot: string,
+  options: { scheme?: string; devClient?: boolean }
+): Promise<string | null> {
+  const resolveFrom = await import('resolve-from').then((m) => m.default);
+
+  const isDevClientPackageInstalled = (() => {
+    try {
+      // we check if `expo-dev-launcher` is installed instead of `expo-dev-client`
+      // because someone could install only launcher.
+      resolveFrom(projectRoot, 'expo-dev-launcher');
+      return true;
+    } catch {
+      return false;
+    }
+  })();
+
+  if (typeof options.scheme === 'string') {
+    // Use the custom scheme
+    return options.scheme ?? null;
+  } else if (options.devClient || isDevClientPackageInstalled) {
+    const { getOptionalDevClientSchemeAsync } = await import('../utils/scheme');
+    // Attempt to find the scheme or warn the user how to setup a custom scheme
+    return await getOptionalDevClientSchemeAsync(projectRoot);
+  } else {
+    // Ensure this is reset when users don't use `--scheme`, `--dev-client` and don't have the `expo-dev-client` package installed.
+    return null;
+  }
+}
+
+/** Resolve and assert host type options. */
+export function resolveHostType(options: {
+  host?: string;
+  offline?: boolean;
+  lan?: boolean;
+  localhost?: boolean;
+  tunnel?: boolean;
+}): 'lan' | 'tunnel' | 'localhost' {
+  if (
+    [options.offline, options.host, options.lan, options.localhost, options.tunnel].filter((i) => i)
+      .length > 1
+  ) {
+    throw new CommandError(
+      'BAD_ARGS',
+      'Specify at most one of: --offline, --host, --tunnel, --lan, --localhost'
+    );
+  }
+
+  if (options.offline) {
+    // Force `lan` in offline mode.
+    return 'lan';
+  } else if (options.host) {
+    assert.match(options.host, /^(lan|tunnel|localhost)$/);
+    return options.host as 'lan' | 'tunnel' | 'localhost';
+  } else if (options.tunnel) {
+    return 'tunnel';
+  } else if (options.lan) {
+    return 'lan';
+  } else if (options.localhost) {
+    return 'localhost';
+  }
+  return 'lan';
+}
+
+/** Resolve the port options for all supported bundlers. */
+export async function resolvePortsAsync(
+  projectRoot: string,
+  options: Partial<Pick<Options, 'port' | 'devClient'>>,
+  settings: { webOnly?: boolean }
+) {
+  const multiBundlerSettings: { webpackPort?: number; metroPort?: number } = {};
+
+  if (settings.webOnly) {
+    const webpackPort = await resolvePortAsync(projectRoot, {
+      defaultPort: options.port,
+      // Default web port
+      fallbackPort: 19006,
+    });
+    if (!webpackPort) {
+      throw new AbortCommandError();
+    }
+    multiBundlerSettings.webpackPort = webpackPort;
+  } else {
+    const devClientDefaultPort = Number(process.env.RCT_METRO_PORT) || 8081;
+    const expoGoDefaultPort = 19000;
+    const metroPort = await resolvePortAsync(projectRoot, {
+      defaultPort: options.port,
+      fallbackPort: options.devClient ? devClientDefaultPort : expoGoDefaultPort,
+    });
+    if (!metroPort) {
+      throw new AbortCommandError();
+    }
+    multiBundlerSettings.metroPort = metroPort;
+  }
+
+  return multiBundlerSettings;
+}

--- a/packages/expo/cli/start/resolveOptions.ts
+++ b/packages/expo/cli/start/resolveOptions.ts
@@ -145,7 +145,7 @@ export async function resolvePortsAsync(
     }
     multiBundlerSettings.webpackPort = webpackPort;
   } else {
-    const devClientDefaultPort = Number(process.env.RCT_METRO_PORT) || 8081;
+    const devClientDefaultPort = parseInt(process.env.RCT_METRO_PORT, 10) || 8081;
     const expoGoDefaultPort = 19000;
     const metroPort = await resolvePortAsync(projectRoot, {
       defaultPort: options.port,

--- a/packages/expo/cli/start/startAsync.ts
+++ b/packages/expo/cli/start/startAsync.ts
@@ -1,0 +1,12 @@
+import chalk from 'chalk';
+
+import * as Log from '../log';
+import { Options } from './resolveOptions';
+
+export async function startAsync(
+  projectRoot: string,
+  options: Options,
+  settings: { webOnly?: boolean }
+) {
+  Log.log(chalk.gray(`Starting project at ${projectRoot}`));
+}

--- a/packages/expo/e2e/__tests__/config-test.ts
+++ b/packages/expo/e2e/__tests__/config-test.ts
@@ -74,7 +74,7 @@ it('runs `npx expo config --json`', async () => {
 it('throws on invalid project root', async () => {
   expect.assertions(1);
   try {
-    await execute('very---invalid', 'config', '--json');
+    await execute('config', 'very---invalid', '--json');
   } catch (e) {
     expect(e.stderr).toMatch(/Invalid project root: \//);
   }

--- a/packages/expo/e2e/__tests__/index-test.ts
+++ b/packages/expo/e2e/__tests__/index-test.ts
@@ -29,7 +29,7 @@ it('runs `npx expo --help`', async () => {
           $ npx expo <command>
 
         Available commands
-          config, login, logout, prebuild, register, whoami
+          config, login, logout, prebuild, register, start, whoami
 
         Options
           --version, -v   Version number

--- a/packages/expo/e2e/__tests__/start-test.ts
+++ b/packages/expo/e2e/__tests__/start-test.ts
@@ -1,0 +1,179 @@
+/* eslint-env jest */
+import fs from 'fs-extra';
+import path from 'path';
+import execa from 'execa';
+import fetch from 'node-fetch';
+import {
+  execute,
+  projectRoot,
+  getRoot,
+  getLoadedModulesAsync,
+  setupTestProjectAsync,
+  bin,
+} from './utils';
+import JsonFile from '@expo/json-file';
+
+const originalForceColor = process.env.FORCE_COLOR;
+const originalCI = process.env.CI;
+
+beforeAll(async () => {
+  await fs.mkdir(projectRoot, { recursive: true });
+  process.env.FORCE_COLOR = '0';
+  process.env.CI = '1';
+});
+
+afterAll(() => {
+  process.env.FORCE_COLOR = originalForceColor;
+  process.env.CI = originalCI;
+});
+
+it('loads expected modules by default', async () => {
+  const modules = await getLoadedModulesAsync(`require('../../build-cli/cli/start').expoStart`);
+  expect(modules).toStrictEqual([
+    'node_modules/ansi-styles/index.js',
+    'node_modules/arg/index.js',
+    'node_modules/chalk/source/index.js',
+    'node_modules/chalk/source/util.js',
+    'node_modules/has-flag/index.js',
+    'node_modules/supports-color/index.js',
+    'packages/expo/build-cli/cli/log.js',
+    'packages/expo/build-cli/cli/start/index.js',
+    'packages/expo/build-cli/cli/utils/args.js',
+    'packages/expo/build-cli/cli/utils/errors.js',
+  ]);
+});
+
+it('runs `npx expo start --help`', async () => {
+  const results = await execute('start', '--help');
+  expect(results.stdout).toMatchInlineSnapshot(`
+    "
+      Description
+        Start a local dev server for the app
+
+      Usage
+        $ npx expo start <dir>
+
+      <dir> is the directory of the Expo project.
+      Defaults to the current working directory.
+
+      Options
+        -a, --android                          Opens your app in Expo Go on a connected Android device
+        -i, --ios                              Opens your app in Expo Go in a currently running iOS simulator on your computer
+        -w, --web                              Opens your app in a web browser
+
+        -c, --clear                            Clear the bundler cache
+        --max-workers <num>                    Maximum number of tasks to allow Metro to spawn
+        --no-dev                               Bundle in production mode
+        --minify                               Minify JavaScript    
+
+        -m, --host <mode>                      lan, tunnel, localhost. Dev server hosting type. Default: lan.
+                                               - lan: Use the local network
+                                               - tunnel: Use any network by tunnel through ngrok
+                                               - localhost: Connect to the dev server over localhost
+        --tunnel                               Same as --host tunnel
+        --lan                                  Same as --host lan
+        --localhost                            Same as --host localhost
+
+        --offline                              Skip network requests and use anonymous manifest signatures
+        --https                                Start the dev server with https protocol
+        --scheme <scheme>                      Custom URI protocol to use when launching an app
+        -p, --port <port>                      Port to start the dev server on (does not apply to web or tunnel). Default: 19000
+
+        --dev-client                           Experimental: Starts the bundler for use with the expo-development-client
+        --force-manifest-type <manifest-type>  Override auto detection of manifest type
+        -h, --help                             output usage information
+    "
+  `);
+});
+
+beforeAll(async () => {
+  // Kill port
+  await execa('kill', ['-9', '$(lsof -ti:19000)']).catch(() => {});
+});
+
+for (const args of [
+  ['--lan', '--tunnel'],
+  ['--offline', '--localhost'],
+  ['--host', 'localhost', '--tunnel'],
+  ['-m', 'localhost', '--lan', '--offline'],
+]) {
+  it(`asserts invalid URL arguments on \`expo start ${args.join(' ')}\``, async () => {
+    await expect(execa('node', [bin, 'start', ...args], { cwd: projectRoot })).rejects.toThrowError(
+      /Specify at most one of/
+    );
+  });
+}
+
+it(
+  'runs `npx expo start`',
+  async () => {
+    const projectRoot = await setupTestProjectAsync('basic-start', 'with-blank');
+    await fs.remove(path.join(projectRoot, '.expo'));
+
+    const promise = execa('node', [bin, 'start'], { cwd: projectRoot });
+
+    console.log('Starting server');
+
+    await new Promise<void>((resolve, reject) => {
+      promise.on('close', (code: number) => {
+        reject(
+          code === 0
+            ? 'Server closed too early. Run `kill -9 $(lsof -ti:19000)` to kill the orphaned process.'
+            : code
+        );
+      });
+
+      promise.stdout.on('data', (data) => {
+        const stdout = data.toString();
+        console.log('output:', stdout);
+        if (stdout.includes('Logs for your project')) {
+          resolve();
+        }
+      });
+    });
+
+    console.log('Fetching manifest');
+    const results = await fetch('http://localhost:19000/').then((res) => res.json());
+
+    // Required for Expo Go
+    expect(results.packagerOpts).toStrictEqual({
+      dev: true,
+    });
+    expect(results.developer).toStrictEqual({
+      projectRoot: expect.anything(),
+      tool: 'expo-cli',
+    });
+
+    // URLs
+    expect(results.bundleUrl).toBe(
+      'http://127.0.0.1:19000/node_modules/expo/AppEntry.bundle?platform=ios&dev=true&hot=false'
+    );
+    expect(results.debuggerHost).toBe('127.0.0.1:19000');
+    expect(results.hostUri).toBe('127.0.0.1:19000');
+    expect(results.logUrl).toBe('http://127.0.0.1:19000/logs');
+    expect(results.mainModuleName).toBe('node_modules/expo/AppEntry');
+
+    // Manifest
+    expect(results.sdkVersion).toBe('44.0.0');
+    expect(results.slug).toBe('basic-start');
+    expect(results.name).toBe('basic-start');
+
+    // Custom
+    expect(results.__flipperHack).toBe('React Native packager is running');
+
+    console.log('Fetching bundle');
+    const bundle = await fetch(results.bundleUrl).then((res) => res.text());
+    console.log('Fetched bundle: ', bundle.length);
+    expect(bundle.length).toBeGreaterThan(1000);
+    console.log('Finished');
+
+    // Kill process.
+    promise.kill('SIGTERM', {
+      forceKillAfterTimeout: 2000,
+    });
+
+    await promise;
+  },
+  // Could take 45s depending on how fast npm installs
+  60 * 1000
+);

--- a/packages/expo/e2e/__tests__/start-test.ts
+++ b/packages/expo/e2e/__tests__/start-test.ts
@@ -1,17 +1,8 @@
 /* eslint-env jest */
-import fs from 'fs-extra';
-import path from 'path';
 import execa from 'execa';
-import fetch from 'node-fetch';
-import {
-  execute,
-  projectRoot,
-  getRoot,
-  getLoadedModulesAsync,
-  setupTestProjectAsync,
-  bin,
-} from './utils';
-import JsonFile from '@expo/json-file';
+import fs from 'fs-extra';
+
+import { bin, execute, getLoadedModulesAsync, projectRoot } from './utils';
 
 const originalForceColor = process.env.FORCE_COLOR;
 const originalCI = process.env.CI;
@@ -86,11 +77,6 @@ it('runs `npx expo start --help`', async () => {
   `);
 });
 
-beforeAll(async () => {
-  // Kill port
-  await execa('kill', ['-9', '$(lsof -ti:19000)']).catch(() => {});
-});
-
 for (const args of [
   ['--lan', '--tunnel'],
   ['--offline', '--localhost'],
@@ -103,77 +89,3 @@ for (const args of [
     );
   });
 }
-
-it(
-  'runs `npx expo start`',
-  async () => {
-    const projectRoot = await setupTestProjectAsync('basic-start', 'with-blank');
-    await fs.remove(path.join(projectRoot, '.expo'));
-
-    const promise = execa('node', [bin, 'start'], { cwd: projectRoot });
-
-    console.log('Starting server');
-
-    await new Promise<void>((resolve, reject) => {
-      promise.on('close', (code: number) => {
-        reject(
-          code === 0
-            ? 'Server closed too early. Run `kill -9 $(lsof -ti:19000)` to kill the orphaned process.'
-            : code
-        );
-      });
-
-      promise.stdout.on('data', (data) => {
-        const stdout = data.toString();
-        console.log('output:', stdout);
-        if (stdout.includes('Logs for your project')) {
-          resolve();
-        }
-      });
-    });
-
-    console.log('Fetching manifest');
-    const results = await fetch('http://localhost:19000/').then((res) => res.json());
-
-    // Required for Expo Go
-    expect(results.packagerOpts).toStrictEqual({
-      dev: true,
-    });
-    expect(results.developer).toStrictEqual({
-      projectRoot: expect.anything(),
-      tool: 'expo-cli',
-    });
-
-    // URLs
-    expect(results.bundleUrl).toBe(
-      'http://127.0.0.1:19000/node_modules/expo/AppEntry.bundle?platform=ios&dev=true&hot=false'
-    );
-    expect(results.debuggerHost).toBe('127.0.0.1:19000');
-    expect(results.hostUri).toBe('127.0.0.1:19000');
-    expect(results.logUrl).toBe('http://127.0.0.1:19000/logs');
-    expect(results.mainModuleName).toBe('node_modules/expo/AppEntry');
-
-    // Manifest
-    expect(results.sdkVersion).toBe('44.0.0');
-    expect(results.slug).toBe('basic-start');
-    expect(results.name).toBe('basic-start');
-
-    // Custom
-    expect(results.__flipperHack).toBe('React Native packager is running');
-
-    console.log('Fetching bundle');
-    const bundle = await fetch(results.bundleUrl).then((res) => res.text());
-    console.log('Fetched bundle: ', bundle.length);
-    expect(bundle.length).toBeGreaterThan(1000);
-    console.log('Finished');
-
-    // Kill process.
-    promise.kill('SIGTERM', {
-      forceKillAfterTimeout: 2000,
-    });
-
-    await promise;
-  },
-  // Could take 45s depending on how fast npm installs
-  60 * 1000
-);


### PR DESCRIPTION
# Why

- Split out of https://github.com/expo/expo/pull/16518

# How

- Adds a basic shim of the start command.

# Test Plan

- Unit tests
- Some tests that mostly won't work because the PR is too small.
- Can't pull and run locally.
