### PR TITLE
[modules-core][Kotlin] Add basic support for suspend functions

### DIFF
--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -97,9 +97,7 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
   implementation "org.jetbrains.kotlin:kotlin-reflect:${getKotlinVersion()}"
   implementation 'androidx.annotation:annotation:1.2.0'
-
-  // used only in `expo.modules.core.errors.ModuleDestroyedException` for API export
-  compileOnly("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3")
+  implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3"
 
   //noinspection GradleDynamicVersion
   implementation 'com.facebook.react:react-native:+'
@@ -109,6 +107,7 @@ dependencies {
   testImplementation 'io.mockk:mockk:1.10.6'
   testImplementation "com.google.truth:truth:1.1.2"
   testImplementation "org.robolectric:robolectric:4.5.1"
+  testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.0"
 }
 
 /**

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -97,7 +97,7 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
   implementation "org.jetbrains.kotlin:kotlin-reflect:${getKotlinVersion()}"
   implementation 'androidx.annotation:annotation:1.2.0'
-  implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3"
+  implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.0"
 
   //noinspection GradleDynamicVersion
   implementation 'com.facebook.react:react-native:+'

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -148,6 +148,7 @@ class AppContext(
   fun onDestroy() {
     reactContextHolder.get()?.removeLifecycleEventListener(reactLifecycleDelegate)
     registry.post(EventName.MODULE_DESTROY)
+    registry.cleanUp()
   }
 
   fun onHostResume() {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
@@ -39,4 +39,8 @@ class ModuleHolder(val module: Module) {
     val listener = definition.eventListeners[eventName] ?: return
     (listener as? EventListenerWithSenderAndPayload<Sender, Payload>)?.call(sender, payload)
   }
+
+  fun cleanUp() {
+    module.cleanUp()
+  }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleRegistry.kt
@@ -17,7 +17,7 @@ class ModuleRegistry(
   fun register(module: Module) {
     val holder = ModuleHolder(module)
     module._appContext = requireNotNull(appContext.get()) { "Cannot create a module for invalid app context." }
-    module._coroutineScopeDelegate = lazy {
+    module.coroutineScopeDelegate = lazy {
       CoroutineScope(
         Dispatchers.Default +
           SupervisorJob() +

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncSuspendFunction.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncSuspendFunction.kt
@@ -1,0 +1,34 @@
+package expo.modules.kotlin.functions
+
+import expo.modules.kotlin.Promise
+import expo.modules.kotlin.exception.CodedException
+import expo.modules.kotlin.exception.UnexpectedException
+import expo.modules.kotlin.types.AnyType
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+class AsyncSuspendFunction(
+  name: String,
+  argsType: Array<AnyType>,
+  scopeProvider: Lazy<CoroutineScope>,
+  private val body: suspend CoroutineScope.(args: Array<out Any?>) -> Any?
+) : AnyFunction(name, argsType) {
+  private val scope by scopeProvider
+
+  // TODO(@lukmccall): improve error messages
+  override fun callImplementation(args: Array<out Any?>, promise: Promise) {
+    scope.launch {
+      try {
+        val result = body.invoke(scope, args)
+        if (isActive) {
+          promise.resolve(result)
+        }
+      } catch (e: CodedException) {
+        promise.reject(e)
+      } catch (e: Throwable) {
+        promise.reject(UnexpectedException(e))
+      }
+    }
+  }
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/Module.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/Module.kt
@@ -17,8 +17,8 @@ abstract class Module {
 
   @Suppress("PropertyName")
   @PublishedApi
-  internal lateinit var _coroutineScopeDelegate: Lazy<CoroutineScope>
-  val coroutineScope by _coroutineScopeDelegate
+  internal lateinit var coroutineScopeDelegate: Lazy<CoroutineScope>
+  val coroutineScope by coroutineScopeDelegate
 
   fun sendEvent(name: String, body: Bundle?) {
     moduleEventEmitter?.emit(name, body)
@@ -27,7 +27,7 @@ abstract class Module {
   abstract fun definition(): ModuleDefinitionData
 
   internal fun cleanUp() {
-    if (_coroutineScopeDelegate.isInitialized()) {
+    if (coroutineScopeDelegate.isInitialized()) {
       coroutineScope.cancel(ModuleDestroyedException())
     }
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/Module.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/Module.kt
@@ -18,7 +18,7 @@ abstract class Module {
   @Suppress("PropertyName")
   @PublishedApi
   internal lateinit var coroutineScopeDelegate: Lazy<CoroutineScope>
-  val coroutineScope by coroutineScopeDelegate
+  val coroutineScope get() = coroutineScopeDelegate.value
 
   fun sendEvent(name: String, body: Bundle?) {
     moduleEventEmitter?.emit(name, body)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionBuilder.kt
@@ -32,7 +32,7 @@ import expo.modules.kotlin.views.ViewManagerDefinitionBuilder
 import kotlin.reflect.typeOf
 
 @DefinitionMarker
-class ModuleDefinitionBuilder(private val module: Module? = null) {
+class ModuleDefinitionBuilder(@PublishedApi internal val module: Module? = null) {
   private var name: String? = null
   private var constantsProvider = { emptyMap<String, Any?>() }
   private var eventsDefinition: EventsDefinition? = null

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/functions/AsyncSuspendFunctionTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/functions/AsyncSuspendFunctionTest.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
-import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
 
@@ -25,7 +24,7 @@ class AsyncSuspendFunctionTest {
 
   @Test
   fun `suspend block should resolve promise on finish`() {
-    val suspendMethod = SuspendMethod("test", emptyArray(), lazy { testScope }) {
+    val suspendMethod = AsyncSuspendFunction("test", emptyArray(), lazy { testScope }) {
       delay(2000)
     }
     val promiseMock = PromiseMock()

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/functions/AsyncSuspendFunctionTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/functions/AsyncSuspendFunctionTest.kt
@@ -1,0 +1,156 @@
+package expo.modules.kotlin.functions
+
+import com.facebook.react.bridge.JavaOnlyArray
+import com.google.common.truth.Truth
+import expo.modules.PromiseMock
+import expo.modules.PromiseState
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AsyncSuspendFunctionTest {
+  @Test
+  fun `suspend block should resolve promise on finish`() = runTest {
+    val suspendMethod = AsyncSuspendFunction("test", emptyArray(), lazy { this }) {
+      delay(2000)
+    }
+    val promiseMock = PromiseMock()
+
+    suspendMethod.call(JavaOnlyArray(), promiseMock)
+    testScheduler.advanceTimeBy(3000)
+
+    Truth.assertThat(promiseMock.state).isEqualTo(PromiseState.RESOLVED)
+  }
+
+  @Test
+  fun `suspend block should reject promise when throws`() = runTest {
+    val suspendMethod = AsyncSuspendFunction("test", emptyArray(), lazy { this }) {
+      delay(2000)
+      throw IllegalStateException()
+    }
+    val promiseMock = PromiseMock()
+
+    suspendMethod.call(JavaOnlyArray(), promiseMock)
+    testScheduler.advanceTimeBy(3000)
+
+    Truth.assertThat(promiseMock.state).isEqualTo(PromiseState.REJECTED)
+  }
+
+  @Test
+  fun `suspend block should be cancelable`() {
+    val testScope = TestScope()
+    val suspendMethod = AsyncSuspendFunction("test", emptyArray(), lazy { testScope }) {
+      delay(2000)
+    }
+    val promiseMock = PromiseMock()
+
+    suspendMethod.call(JavaOnlyArray(), promiseMock)
+    testScope.testScheduler.advanceTimeBy(1000)
+    testScope.cancel()
+    Truth.assertThat(promiseMock.state).isEqualTo(PromiseState.NONE)
+  }
+
+  @Test
+  fun `suspend block should wait for children`() {
+    val testScope = TestScope()
+    var wasAsyncCalled = false
+    var wasLaunchCalled = false
+
+    val suspendMethod = AsyncSuspendFunction("test", emptyArray(), lazy { testScope }) {
+      val deferred = async {
+        delay(1000)
+        wasAsyncCalled = true
+      }
+      launch {
+        delay(4000)
+        wasLaunchCalled = true
+      }
+      deferred.await()
+      delay(2000)
+    }
+    val promiseMock = PromiseMock()
+
+    suspendMethod.call(JavaOnlyArray(), promiseMock)
+    testScope.testScheduler.advanceTimeBy(3500)
+
+    Truth.assertThat(promiseMock.state).isEqualTo(PromiseState.RESOLVED)
+    Truth.assertThat(wasAsyncCalled).isTrue()
+    Truth.assertThat(wasLaunchCalled).isFalse()
+  }
+
+  @Test
+  fun `suspend block should clean whole coroutine hierarchy`() {
+    val testScope = TestScope()
+    var wasAsyncCalled = false
+    var wasLaunchCalled = false
+
+    val suspendMethod = AsyncSuspendFunction("test", emptyArray(), lazy { testScope }) {
+      val deferred = async {
+        delay(1000)
+        wasAsyncCalled = true
+      }
+      launch {
+        delay(1000)
+        wasLaunchCalled = true
+      }
+      deferred.await()
+      delay(2000)
+    }
+    val promiseMock = PromiseMock()
+
+    suspendMethod.call(JavaOnlyArray(), promiseMock)
+    testScope.testScheduler.advanceTimeBy(500)
+    testScope.cancel()
+    Truth.assertThat(promiseMock.state).isEqualTo(PromiseState.NONE)
+    Truth.assertThat(wasAsyncCalled).isFalse()
+    Truth.assertThat(wasLaunchCalled).isFalse()
+  }
+
+  @Test
+  fun `should handle multiple calls`() {
+    val testScope = TestScope(SupervisorJob())
+    val suspendMethod = AsyncSuspendFunction("test", emptyArray(), lazy { testScope }) {
+      delay(2000)
+    }
+    val promiseMock1 = PromiseMock()
+    val promiseMock2 = PromiseMock()
+
+    suspendMethod.call(JavaOnlyArray(), promiseMock1)
+    suspendMethod.call(JavaOnlyArray(), promiseMock2)
+
+    testScope.testScheduler.advanceTimeBy(2500)
+
+    Truth.assertThat(promiseMock1.state).isEqualTo(PromiseState.RESOLVED)
+    Truth.assertThat(promiseMock2.state).isEqualTo(PromiseState.RESOLVED)
+  }
+
+  @Test
+  fun `should not cancel siblings `() {
+    val testScope = TestScope(SupervisorJob())
+    val suspendMethod1 = AsyncSuspendFunction("test1", emptyArray(), lazy { testScope }) {
+      delay(2000)
+    }
+    val suspendMethod2 = AsyncSuspendFunction("test2", emptyArray(), lazy { testScope }) {
+      delay(1000)
+      throw IllegalStateException()
+    }
+
+    val promiseMock1 = PromiseMock()
+    val promiseMock2 = PromiseMock()
+
+    suspendMethod1.call(JavaOnlyArray(), promiseMock1)
+    suspendMethod2.call(JavaOnlyArray(), promiseMock2)
+
+    testScope.testScheduler.advanceTimeBy(2500)
+
+    Truth.assertThat(promiseMock1.state).isEqualTo(PromiseState.RESOLVED)
+    Truth.assertThat(promiseMock2.state).isEqualTo(PromiseState.REJECTED)
+  }
+}


### PR DESCRIPTION
# Why

To make our API complete, I would like to add support for suspending functions. This is the first step in achieving that. 

# How

- Added a wrapper to a suspend function which allows us to call them as non suspend. 
- Added a coroutine context to each module. Note that this context is lazy. So it won't be created if nothing uses it.

> Note:
Suspend API isn't exported via the `ModuleDefinitionBuilder`, cause we still have to discuss how the API will look like. 

# Test Plan

- unit tests ✅