### PR TITLE
[home] add border to pressable diagnostic options

### DIFF
--- a/home/components/PressableOpacity.tsx
+++ b/home/components/PressableOpacity.tsx
@@ -58,8 +58,8 @@ function BorderRadiusContainer({
 }: BorderRadiusContainerProps) {
   return (
     <View
-      style={[borderRadius ? { borderRadius, overflow: 'hidden' } : undefined, style]}
-      {...props}>
+      {...props}
+      style={[borderRadius ? { borderRadius, overflow: 'hidden' } : undefined, style]}>
       {children}
     </View>
   );

--- a/home/screens/RedesignedDiagnosticsScreen/DiagnosticsButton.tsx
+++ b/home/screens/RedesignedDiagnosticsScreen/DiagnosticsButton.tsx
@@ -1,13 +1,6 @@
 import { borderRadius } from '@expo/styleguide-native';
 import { PressableOpacity } from 'components/PressableOpacity';
-import {
-  ChevronRightIcon,
-  Row,
-  Spacer,
-  Text,
-  useExpoTheme,
-  View,
-} from 'expo-dev-client-components';
+import { ChevronRightIcon, Row, Spacer, Text, useExpoTheme } from 'expo-dev-client-components';
 import * as React from 'react';
 import { Platform } from 'react-native';
 
@@ -21,24 +14,25 @@ export function DiagnosticButton({ title, description, onPress }: Props) {
   const theme = useExpoTheme();
 
   return (
-    <PressableOpacity borderRadius={borderRadius.large} onPress={onPress}>
-      <View bg="default" padding="medium">
-        <Row justify="between" align="center">
-          <Text
-            style={{
-              fontSize: 14,
-              lineHeight: 14 * 1.5,
-              fontWeight: Platform.OS === 'android' ? 'bold' : '600',
-            }}>
-            {title}
-          </Text>
-          <ChevronRightIcon size="small" style={{ tintColor: theme.icon.secondary }} />
-        </Row>
-        <Spacer.Vertical size="tiny" />
-        <Text style={{ fontSize: 14, lineHeight: 14 * 1.5 }} color="secondary" size="small">
-          {description}
+    <PressableOpacity
+      borderRadius={borderRadius.large}
+      onPress={onPress}
+      containerProps={{ border: 'hairline', bg: 'default', padding: 'medium' }}>
+      <Row justify="between" align="center">
+        <Text
+          style={{
+            fontSize: 14,
+            lineHeight: 14 * 1.5,
+            fontWeight: Platform.OS === 'android' ? 'bold' : '600',
+          }}>
+          {title}
         </Text>
-      </View>
+        <ChevronRightIcon size="small" style={{ tintColor: theme.icon.secondary }} />
+      </Row>
+      <Spacer.Vertical size="tiny" />
+      <Text style={{ fontSize: 14, lineHeight: 14 * 1.5 }} color="secondary" size="small">
+        {description}
+      </Text>
     </PressableOpacity>
   );
 }


### PR DESCRIPTION
# Why

Container-like objects in the new design language should have borders to help differentiate between themselves and their background.

# How

I added a border to the diagnostics page items and consolidated the props from the child view into the PressableOpacity to reduce unnecessary nesting.

# Test Plan

Visit the Diagnostics screen in development mode to see this change:

![IMG_2C95D8B79623-1](https://user-images.githubusercontent.com/12488826/157921739-c146cddc-ba71-4d16-b5d1-01094e0c6819.jpeg)

