### PR TITLE
[home] implement redesigned snacks list page

### DIFF
--- a/home/components/RedesignedSnacksListItem.tsx
+++ b/home/components/RedesignedSnacksListItem.tsx
@@ -4,7 +4,7 @@ import { Row, Spacer, Text, useExpoTheme, View } from 'expo-dev-client-component
 import React from 'react';
 import { Linking, Platform, Share, StyleSheet } from 'react-native';
 
-import * as UrlUtils from '../../utils/UrlUtils';
+import * as UrlUtils from '../utils/UrlUtils';
 
 type Props = {
   url: string;
@@ -22,7 +22,7 @@ function normalizeDescription(description?: string): string | undefined {
  * the snacks list page for an account.
  */
 
-export function SnacksListItem({ description, isDraft, name, url }: Props) {
+export function RedesignedSnacksListItem({ description, isDraft, name, url }: Props) {
   const theme = useExpoTheme();
 
   const handlePressProject = () => {
@@ -59,7 +59,7 @@ export function SnacksListItem({ description, isDraft, name, url }: Props) {
             {isDraft && (
               <>
                 <Spacer.Vertical size="tiny" />
-                <View bg="secondary" rounded="medium" flex="0" padding="tiny">
+                <View bg="secondary" rounded="medium" flex="0" padding="tiny" border="default">
                   <Text size="small">Draft</Text>
                 </View>
               </>

--- a/home/graphql/types.ts
+++ b/home/graphql/types.ts
@@ -4232,10 +4232,10 @@ export const HomeScreenDataDocument = gql`
     query HomeScreenData {
   viewer {
     ...CurrentUserData
-    apps(limit: 3, offset: 0, includeUnpublished: true) {
+    apps(limit: 5, offset: 0, includeUnpublished: true) {
       ...CommonAppData
     }
-    snacks(limit: 3, offset: 0) {
+    snacks(limit: 5, offset: 0) {
       ...CommonSnackData
     }
     appCount

--- a/home/navigation/Navigation.tsx
+++ b/home/navigation/Navigation.tsx
@@ -35,6 +35,7 @@ import ProjectsForAccountScreen from '../screens/ProjectsForAccountScreen';
 import ProjectsScreen from '../screens/ProjectsScreen';
 import QRCodeScreen from '../screens/QRCodeScreen';
 import { RedesignedProjectsListScreen } from '../screens/RedesignedProjectsListScreen';
+import { RedesignedSnacksListScreen } from '../screens/RedesignedSnacksListScreen.tsx';
 import SnacksForAccountScreen from '../screens/SnacksForAccountScreen';
 import UserSettingsScreen from '../screens/UserSettingsScreen';
 import Environment from '../utils/Environment';
@@ -121,6 +122,13 @@ function HomeStackScreen() {
         component={RedesignedProjectsListScreen}
         options={{
           title: 'Projects',
+        }}
+      />
+      <HomeStack.Screen
+        name="RedesignedSnacksList"
+        component={RedesignedSnacksListScreen}
+        options={{
+          title: 'Snacks',
         }}
       />
     </HomeStack.Navigator>

--- a/home/navigation/Navigation.types.ts
+++ b/home/navigation/Navigation.types.ts
@@ -9,6 +9,7 @@ export type ProjectsStackRoutes = {
 export type HomeStackRoutes = {
   Home: object;
   RedesignedProjectsList: { accountName: string };
+  RedesignedSnacksList: { accountName: string };
   Account: { accountName: string };
 };
 

--- a/home/screens/HomeScreen/HomeScreenData.query.graphql
+++ b/home/screens/HomeScreen/HomeScreenData.query.graphql
@@ -1,10 +1,10 @@
 query HomeScreenData {
   viewer {
     ...CurrentUserData
-    apps(limit: 3, offset: 0, includeUnpublished: true) {
+    apps(limit: 5, offset: 0, includeUnpublished: true) {
       ...CommonAppData
     }
-    snacks(limit: 3, offset: 0) {
+    snacks(limit: 5, offset: 0) {
       ...CommonSnackData
     }
     appCount

--- a/home/screens/HomeScreen/HomeScreenView.tsx
+++ b/home/screens/HomeScreen/HomeScreenView.tsx
@@ -147,6 +147,7 @@ export class HomeScreenView extends React.Component<Props, State> {
               <Spacer.Vertical size="medium" />
               <TextHeader header="Snacks" />
               <SnacksSection
+                accountName={this.props.currentUser?.username}
                 snacks={this.props.currentUser.snacks.slice(0, 3)}
                 showMore={this.props.currentUser.snacks.length > 3}
               />

--- a/home/screens/HomeScreen/SnacksSection.tsx
+++ b/home/screens/HomeScreen/SnacksSection.tsx
@@ -1,22 +1,27 @@
 import { ChevronDownIcon } from '@expo/styleguide-native';
+import { useNavigation } from '@react-navigation/native';
+import { StackNavigationProp } from '@react-navigation/stack';
 import { PressableOpacity } from 'components/PressableOpacity';
 import { Divider, Row, useExpoTheme, View, Text } from 'expo-dev-client-components';
 import { CommonSnackDataFragment } from 'graphql/types';
+import { HomeStackRoutes } from 'navigation/Navigation.types';
 import React, { Fragment } from 'react';
 
-import { SnacksListItem } from './SnacksListItem';
+import { RedesignedSnacksListItem } from '../../components/RedesignedSnacksListItem';
 
 type Props = {
   snacks: CommonSnackDataFragment[];
   showMore: boolean;
+  accountName: string;
 };
 
-export function SnacksSection({ snacks, showMore }: Props) {
+export function SnacksSection({ snacks, showMore, accountName }: Props) {
   const theme = useExpoTheme();
 
+  const navigation = useNavigation<StackNavigationProp<HomeStackRoutes>>();
+
   function onSeeAllSnacksPress() {
-    // TODO(fiberjw): navigate to the snacks list page
-    console.log('onSeeAllSnacksPress');
+    navigation.push('RedesignedSnacksList', { accountName });
   }
 
   return (
@@ -26,7 +31,7 @@ export function SnacksSection({ snacks, showMore }: Props) {
 
         return (
           <Fragment key={snack.id}>
-            <SnacksListItem
+            <RedesignedSnacksListItem
               name={snack.name}
               description={snack.description}
               isDraft={snack.isDraft}

--- a/home/screens/RedesignedSnacksListScreen.tsx/SnackList.tsx
+++ b/home/screens/RedesignedSnacksListScreen.tsx/SnackList.tsx
@@ -1,0 +1,104 @@
+import { Divider, View } from 'expo-dev-client-components';
+import * as React from 'react';
+import { ActivityIndicator, FlatList, View as RNView } from 'react-native';
+import InfiniteScrollView from 'react-native-infinite-scroll-view';
+
+import { RedesignedSnacksListItem } from '../../components/RedesignedSnacksListItem';
+import { CommonSnackDataFragment } from '../../graphql/types';
+
+type Props = {
+  data: CommonSnackDataFragment[];
+  loadMoreAsync: () => Promise<any>;
+};
+
+export function SnackListView(props: Props) {
+  const [isReady, setReady] = React.useState(false);
+
+  React.useEffect(() => {
+    const _readyTimer = setTimeout(() => {
+      setReady(true);
+    }, 500);
+    return () => {
+      clearTimeout(_readyTimer);
+    };
+  }, []);
+
+  if (!isReady) {
+    return (
+      <RNView style={{ flex: 1, padding: 30, alignItems: 'center' }}>
+        <ActivityIndicator />
+      </RNView>
+    );
+  }
+
+  if (!props.data?.length) {
+    return <RNView style={{ flex: 1 }} />;
+  }
+
+  return <SnackList {...props} />;
+}
+
+function SnackList({ data, loadMoreAsync }: Props) {
+  const [isLoadingMore, setLoadingMore] = React.useState(false);
+  const isLoading = React.useRef<null | boolean>(false);
+
+  const extractKey = React.useCallback((item) => item.slug, []);
+
+  const handleLoadMoreAsync = async () => {
+    if (isLoading.current) return;
+    isLoading.current = true;
+    setLoadingMore(true);
+
+    try {
+      await loadMoreAsync();
+    } catch (e) {
+      console.error(e);
+    } finally {
+      isLoading.current = false;
+      setLoadingMore(false);
+    }
+  };
+
+  const canLoadMore = () => {
+    // TODO: replace the code below this comment with the following line
+    // once we have implemented snackCount
+    // return this.props.data.snacks.length < this.props.data.snackCount;
+
+    if (isLoadingMore) {
+      return false;
+    } else {
+      return true;
+    }
+  };
+
+  const renderItem = React.useCallback(({ item: snack, index }) => {
+    return (
+      <RedesignedSnacksListItem
+        key={index.toString()}
+        url={snack.fullName}
+        name={snack.name}
+        description={snack.description}
+        isDraft={snack.isDraft}
+      />
+    );
+  }, []);
+
+  return (
+    <View flex="1" padding="medium">
+      <View flex="1" bg="default" border="hairline" rounded="large">
+        <FlatList
+          data={data}
+          keyExtractor={extractKey}
+          renderItem={renderItem}
+          // @ts-expect-error typescript cannot infer that props should include infinite-scroll-view props
+          renderLoadingIndicator={() => <RNView />}
+          renderScrollComponent={(props) => <InfiniteScrollView {...props} />}
+          style={{ flex: 1, overflow: 'hidden' }}
+          ItemSeparatorComponent={Divider}
+          canLoadMore={canLoadMore()}
+          onLoadMoreAsync={handleLoadMoreAsync}
+        />
+      </View>
+    </View>
+  );
+}

--- a/home/screens/RedesignedSnacksListScreen.tsx/SnacksList.tsx
+++ b/home/screens/RedesignedSnacksListScreen.tsx/SnacksList.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+
+import { useHome_AccountSnacksQuery } from '../../graphql/types';
+import { SnackListView } from './SnackList';
+
+function useSnacksQuery({ accountName }: { accountName: string }) {
+  const { data, fetchMore } = useHome_AccountSnacksQuery({
+    variables: {
+      accountName,
+      limit: 15,
+      offset: 0,
+    },
+    fetchPolicy: 'cache-and-network',
+  });
+
+  const snacks = data?.account.byName.snacks;
+
+  const loadMoreAsync = React.useCallback(() => {
+    return fetchMore({
+      variables: {
+        offset: snacks?.length || 0,
+      },
+      updateQuery: (previousData, { fetchMoreResult }) => {
+        if (!fetchMoreResult?.account?.byName) {
+          return previousData;
+        }
+        return {
+          account: {
+            ...previousData.account,
+            ...fetchMoreResult.account,
+            byName: {
+              ...previousData.account.byName,
+              ...fetchMoreResult.account.byName,
+              snacks: [
+                ...previousData.account.byName.snacks,
+                ...fetchMoreResult.account.byName.snacks,
+              ],
+            },
+          },
+        };
+      },
+    });
+  }, [fetchMore, snacks]);
+
+  return {
+    snacks,
+    loadMoreAsync,
+  };
+}
+
+export function SnacksList({ accountName }: { accountName: string }) {
+  const { snacks, loadMoreAsync } = useSnacksQuery({ accountName });
+  return <SnackListView data={snacks ?? []} loadMoreAsync={loadMoreAsync} />;
+}

--- a/home/screens/RedesignedSnacksListScreen.tsx/index.tsx
+++ b/home/screens/RedesignedSnacksListScreen.tsx/index.tsx
@@ -1,0 +1,13 @@
+import { StackScreenProps } from '@react-navigation/stack';
+import * as React from 'react';
+
+import { HomeStackRoutes } from '../../navigation/Navigation.types';
+import { SnacksList } from './SnacksList';
+
+export function RedesignedSnacksListScreen({
+  route,
+}: StackScreenProps<HomeStackRoutes, 'RedesignedSnacksList'>) {
+  const { accountName } = route.params ?? {};
+
+  return <SnacksList accountName={accountName} />;
+}


### PR DESCRIPTION
# Why

The new redesign included a page that lists every Snack an account has. It is linked from the Home screen

# How

I created a new screen that reused logic from the existing Snacks list page, but with different item components being rendered.

# Test Plan

Open the home page with an account that has more than 3 Snacks. Then, click the 'See all snacks' button and you will be sent to the new page.

This was tested on iOS and Android:

![IMG_4727](https://user-images.githubusercontent.com/12488826/157975321-05418328-3474-4f54-b6fb-04b1561caf52.PNG)

![IMG_4726](https://user-images.githubusercontent.com/12488826/157975323-e739a430-3773-46c4-85cb-b5a4ce60cc56.PNG)

![Screenshot_20220311-164030](https://user-images.githubusercontent.com/12488826/157975366-41b59f90-4804-48af-81a4-076c5796fd64.png)

