### PR TITLE
[dev-menu] restore onboarding screen and autolaunch on initial install

### DIFF
--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
@@ -233,7 +233,8 @@ object DevMenuManager : DevMenuManagerInterface, LifecycleEventListener {
         } else {
           DevMenuDefaultSettings()
         }).also {
-          shouldLaunchDevMenuOnStart = canLaunchDevMenuOnStart && it.showsAtLaunch
+          var showsAtLaunchPreference = canLaunchDevMenuOnStart && it.showsAtLaunch
+          shouldLaunchDevMenuOnStart = showsAtLaunchPreference || !it.isOnboardingFinished
           if (shouldLaunchDevMenuOnStart) {
             reactContext.addLifecycleEventListener(this)
           }
@@ -466,6 +467,12 @@ object DevMenuManager : DevMenuManagerInterface, LifecycleEventListener {
 
   override fun setCurrentScreen(screen: String?) {
     currentScreenName = screen
+  }
+
+  fun getMenuPreferences(): Bundle {
+    return Bundle().apply {
+      putBoolean("isOnboardingFinished", settings?.isOnboardingFinished ?: false)
+    }
   }
 
   //endregion

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
@@ -233,8 +233,7 @@ object DevMenuManager : DevMenuManagerInterface, LifecycleEventListener {
         } else {
           DevMenuDefaultSettings()
         }).also {
-          var showsAtLaunchPreference = canLaunchDevMenuOnStart && it.showsAtLaunch
-          shouldLaunchDevMenuOnStart = showsAtLaunchPreference || !it.isOnboardingFinished
+          shouldLaunchDevMenuOnStart = canLaunchDevMenuOnStart && (it.showsAtLaunch || !it.isOnboardingFinished)
           if (shouldLaunchDevMenuOnStart) {
             reactContext.addLifecycleEventListener(this)
           }

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuActivity.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuActivity.kt
@@ -40,7 +40,6 @@ class DevMenuActivity : ReactActivity() {
           return
         }
 
-
         val reactDelegate: ReactDelegate = ReactActivityDelegate::class.java
           .getPrivateDeclaredFieldValue("mReactDelegate", this)
 

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuActivity.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuActivity.kt
@@ -24,6 +24,9 @@ import java.util.*
 class DevMenuActivity : ReactActivity() {
   override fun getMainComponentName() = "main"
 
+  private val isSimulator
+    get() = Build.FINGERPRINT.contains("vbox") || Build.FINGERPRINT.contains("generic")
+
   override fun createReactActivityDelegate(): ReactActivityDelegate {
     return object : ReactActivityDelegate(this, mainComponentName) {
       // We don't want to destroy the root view, because we want to reuse it later.
@@ -36,6 +39,7 @@ class DevMenuActivity : ReactActivity() {
           appWasLoaded = true
           return
         }
+
 
         val reactDelegate: ReactDelegate = ReactActivityDelegate::class.java
           .getPrivateDeclaredFieldValue("mReactDelegate", this)
@@ -58,10 +62,11 @@ class DevMenuActivity : ReactActivity() {
       override fun getReactNativeHost() = DevMenuManager.getMenuHost()
 
       override fun getLaunchOptions() = Bundle().apply {
-        putBoolean("showOnboardingView", DevMenuManager.getSettings()?.isOnboardingFinished != true)
         putString("uuid", UUID.randomUUID().toString())
         putBundle("appInfo", DevMenuManager.getAppInfo())
         putBundle("devSettings", DevMenuManager.getDevSettings())
+        putBundle("menuPreferences", DevMenuManager.getMenuPreferences())
+        putBoolean("isSimulator", isSimulator)
       }
 
       override fun createRootView() = createRootView(this@DevMenuActivity)

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuActivity.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuActivity.kt
@@ -24,7 +24,7 @@ import java.util.*
 class DevMenuActivity : ReactActivity() {
   override fun getMainComponentName() = "main"
 
-  private val isSimulator
+  private val isEmulator
     get() = Build.FINGERPRINT.contains("vbox") || Build.FINGERPRINT.contains("generic")
 
   override fun createReactActivityDelegate(): ReactActivityDelegate {
@@ -65,7 +65,7 @@ class DevMenuActivity : ReactActivity() {
         putBundle("appInfo", DevMenuManager.getAppInfo())
         putBundle("devSettings", DevMenuManager.getDevSettings())
         putBundle("menuPreferences", DevMenuManager.getMenuPreferences())
-        putBoolean("isSimulator", isSimulator)
+        putBoolean("isDevice", !isEmulator)
       }
 
       override fun createRootView() = createRootView(this@DevMenuActivity)

--- a/packages/expo-dev-menu/app/App.tsx
+++ b/packages/expo-dev-menu/app/App.tsx
@@ -2,17 +2,21 @@ import React from 'react';
 
 import { AppProviders } from './components/AppProviders';
 import { Main } from './components/Main';
-import { AppInfo, DevSettings } from './native-modules/DevMenu';
+import { Onboarding } from './components/Onboarding';
+import { AppInfo, DevSettings, MenuPreferences } from './native-modules/DevMenu';
 
 type DevMenuInitialProps = {
   appInfo: AppInfo;
   devSettings: DevSettings;
+  menuPreferences: MenuPreferences;
+  isSimulator?: boolean;
 };
 
-export function App({ devSettings, appInfo }: DevMenuInitialProps) {
+export function App({ devSettings, appInfo, menuPreferences, isSimulator }: DevMenuInitialProps) {
   return (
-    <AppProviders appInfo={appInfo} devSettings={devSettings}>
+    <AppProviders appInfo={appInfo} devSettings={devSettings} menuPreferences={menuPreferences}>
       <Main />
+      <Onboarding isSimulator={isSimulator} />
     </AppProviders>
   );
 }

--- a/packages/expo-dev-menu/app/App.tsx
+++ b/packages/expo-dev-menu/app/App.tsx
@@ -9,14 +9,14 @@ type DevMenuInitialProps = {
   appInfo: AppInfo;
   devSettings: DevSettings;
   menuPreferences: MenuPreferences;
-  isSimulator?: boolean;
+  isDevice?: boolean;
 };
 
-export function App({ devSettings, appInfo, menuPreferences, isSimulator }: DevMenuInitialProps) {
+export function App({ devSettings, appInfo, menuPreferences, isDevice }: DevMenuInitialProps) {
   return (
     <AppProviders appInfo={appInfo} devSettings={devSettings} menuPreferences={menuPreferences}>
       <Main />
-      <Onboarding isSimulator={isSimulator} />
+      <Onboarding isDevice={isDevice} />
     </AppProviders>
   );
 }

--- a/packages/expo-dev-menu/app/components/AppProviders.tsx
+++ b/packages/expo-dev-menu/app/components/AppProviders.tsx
@@ -1,20 +1,32 @@
+import { ThemePreferenceProvider } from 'expo-dev-client-components';
 import * as React from 'react';
 
 import { AppInfoContextProvider, AppInfoContextProviderProps } from '../hooks/useAppInfo';
 import { BottomSheetProvider } from '../hooks/useBottomSheet';
 import { DevSettingsProviderProps, DevSettingsProvider } from '../hooks/useDevSettings';
+import { MenuPreferencesProvider, MenuPreferencesProviderProps } from '../hooks/useMenuPreferences';
 
 export type AppProvidersProps = {
   children?: React.ReactNode;
   appInfo?: AppInfoContextProviderProps['appInfo'];
   devSettings?: DevSettingsProviderProps['devSettings'];
+  menuPreferences?: MenuPreferencesProviderProps['menuPreferences'];
 };
 
-export function AppProviders({ children, appInfo, devSettings }: AppProvidersProps) {
+export function AppProviders({
+  children,
+  appInfo,
+  devSettings,
+  menuPreferences,
+}: AppProvidersProps) {
   return (
     <DevSettingsProvider devSettings={devSettings}>
       <AppInfoContextProvider appInfo={appInfo}>
-        <BottomSheetProvider>{children}</BottomSheetProvider>
+        <MenuPreferencesProvider menuPreferences={menuPreferences}>
+          <ThemePreferenceProvider theme="no-preference">
+            <BottomSheetProvider>{children}</BottomSheetProvider>
+          </ThemePreferenceProvider>
+        </MenuPreferencesProvider>
       </AppInfoContextProvider>
     </DevSettingsProvider>
   );

--- a/packages/expo-dev-menu/app/components/GestureHandlerTouchableWrapper.tsx
+++ b/packages/expo-dev-menu/app/components/GestureHandlerTouchableWrapper.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { Platform } from 'react-native';
+import { TouchableWithoutFeedback } from 'react-native-gesture-handler';
+
+export function GestureHandlerTouchableWrapper({ onPress, disabled = false, children }) {
+  if (Platform.OS === 'android') {
+    return (
+      <TouchableWithoutFeedback disabled={disabled} onPress={onPress}>
+        {children}
+      </TouchableWithoutFeedback>
+    );
+  }
+
+  return children;
+}

--- a/packages/expo-dev-menu/app/components/Main.tsx
+++ b/packages/expo-dev-menu/app/components/Main.tsx
@@ -19,15 +19,17 @@ import {
   scale,
 } from 'expo-dev-client-components';
 import * as React from 'react';
-import { Platform } from 'react-native';
-import { TouchableWithoutFeedback, Switch } from 'react-native-gesture-handler';
+import { Switch } from 'react-native-gesture-handler';
 
 import { useAppInfo } from '../hooks/useAppInfo';
+import { useBottomSheet } from '../hooks/useBottomSheet';
 import { useClipboard } from '../hooks/useClipboard';
 import { useDevSettings } from '../hooks/useDevSettings';
+import { GestureHandlerTouchableWrapper } from './GestureHandlerTouchableWrapper';
 
 export function Main() {
   const appInfo = useAppInfo();
+  const bottomSheet = useBottomSheet()
   const { devSettings, actions } = useDevSettings();
 
   const urlClipboard = useClipboard();
@@ -85,9 +87,9 @@ export function Main() {
           </Row>
 
           <Spacer.Horizontal />
-          <GestureHandlerTouchableWrapper onPress={actions.closeMenu}>
+          <GestureHandlerTouchableWrapper onPress={bottomSheet.collapse}>
             <Button.ScaleOnPressContainer
-              onPress={actions.closeMenu}
+              onPress={bottomSheet.collapse}
               bg="ghost"
               rounded="full"
               minScale={0.8}>
@@ -379,16 +381,4 @@ function AppInfoRow({ title, value }: AppInfoRowProps) {
       <Text>{value}</Text>
     </Row>
   );
-}
-
-function GestureHandlerTouchableWrapper({ onPress, disabled = false, children }) {
-  if (Platform.OS === 'android') {
-    return (
-      <TouchableWithoutFeedback disabled={disabled} onPress={onPress}>
-        {children}
-      </TouchableWithoutFeedback>
-    );
-  }
-
-  return children;
 }

--- a/packages/expo-dev-menu/app/components/Onboarding.tsx
+++ b/packages/expo-dev-menu/app/components/Onboarding.tsx
@@ -7,7 +7,7 @@ import { GestureHandlerTouchableWrapper } from './GestureHandlerTouchableWrapper
 
 const deviceMessage = Platform.select({
   ios: `Since this is your first time opening Expo Go, we wanted to show you this menu and let you know that you can shake your device or long press anywhere on the screen with three fingers to get back to it at any time.`,
-  android: `Since this is your first time opening Expo Go, we wanted to show you this menu and let you know that you can shake your device to get back to it at any time.`,
+  android: `Since this is your first time opening Expo Go, we wanted to show you this menu and let you know that you can shake your device or long press anywhere on the screen with three fingers to get back to it at any time.`,
 });
 
 const simulatorMessage = Platform.select({
@@ -16,10 +16,10 @@ const simulatorMessage = Platform.select({
 });
 
 type OnboardingProps = {
-  isSimulator?: boolean;
+  isDevice?: boolean;
 };
 
-export function Onboarding({ isSimulator }: OnboardingProps) {
+export function Onboarding({ isDevice }: OnboardingProps) {
   const { isOnboardingFinished, actions } = useMenuPreferences();
   const [isVisible, setIsVisible] = React.useState(!isOnboardingFinished);
 
@@ -41,7 +41,7 @@ export function Onboarding({ isSimulator }: OnboardingProps) {
 
             <View>
               <Text size="large" weight="medium">
-                {isSimulator ? simulatorMessage : deviceMessage}
+                {isDevice ? deviceMessage : simulatorMessage}
               </Text>
 
               <Spacer.Vertical size="medium" />

--- a/packages/expo-dev-menu/app/components/Onboarding.tsx
+++ b/packages/expo-dev-menu/app/components/Onboarding.tsx
@@ -6,13 +6,13 @@ import { useMenuPreferences } from '../hooks/useMenuPreferences';
 import { GestureHandlerTouchableWrapper } from './GestureHandlerTouchableWrapper';
 
 const deviceMessage = Platform.select({
-  ios: `Since this is your first time opening Expo Go, we wanted to show you this menu and let you know that you can shake your device or long press anywhere on the screen with three fingers to get back to it at any time.`,
-  android: `Since this is your first time opening Expo Go, we wanted to show you this menu and let you know that you can shake your device or long press anywhere on the screen with three fingers to get back to it at any time.`,
+  ios: `Since this is your first time opening this development build, we wanted to show you this menu and let you know that you can shake your device or long press anywhere on the screen with three fingers to get back to it at any time.`,
+  android: `Since this is your first time opening this development build, we wanted to show you this menu and let you know that you can shake your device or long press anywhere on the screen with three fingers to get back to it at any time.`,
 });
 
 const simulatorMessage = Platform.select({
-  ios: `Since this is your first time opening Expo Go, we wanted to show you this menu and let you know that in a simulator you can press \u2318D (make sure that 'I/O \u279E Send Keyboard Input to Device' is enabled on your simulator) to get back to it at any time.`,
-  android: `Since this is your first time opening Expo Go, we wanted to show you this menu and let you know that in an emulator you can press \u2318M on macOS or Ctrl+M on other platforms to get back to it at any time.`,
+  ios: `Since this is your first time opening this development build, we wanted to show you this menu and let you know that in a simulator you can press \u2318D (make sure that 'I/O \u279E Send Keyboard Input to Device' is enabled on your simulator) to get back to it at any time.`,
+  android: `Since this is your first time opening this development build, we wanted to show you this menu and let you know that in an emulator you can press \u2318M on macOS or Ctrl+M on other platforms to get back to it at any time.`,
 });
 
 type OnboardingProps = {

--- a/packages/expo-dev-menu/app/components/Onboarding.tsx
+++ b/packages/expo-dev-menu/app/components/Onboarding.tsx
@@ -1,0 +1,70 @@
+import { Heading, View, Text, Spacer, Button } from 'expo-dev-client-components';
+import * as React from 'react';
+import { Platform, StyleSheet } from 'react-native';
+
+import { useMenuPreferences } from '../hooks/useMenuPreferences';
+import { GestureHandlerTouchableWrapper } from './GestureHandlerTouchableWrapper';
+
+const deviceMessage = Platform.select({
+  ios: `Since this is your first time opening Expo Go, we wanted to show you this menu and let you know that you can shake your device or long press anywhere on the screen with three fingers to get back to it at any time.`,
+  android: `Since this is your first time opening Expo Go, we wanted to show you this menu and let you know that you can shake your device to get back to it at any time.`,
+});
+
+const simulatorMessage = Platform.select({
+  ios: `Since this is your first time opening Expo Go, we wanted to show you this menu and let you know that in a simulator you can press \u2318D (make sure that 'I/O \u279E Send Keyboard Input to Device' is enabled on your simulator) to get back to it at any time.`,
+  android: `Since this is your first time opening Expo Go, we wanted to show you this menu and let you know thatin a simulator you can press \u2318M on macOS or Ctrl+M on other platforms to get back to it at any time.`,
+});
+
+type OnboardingProps = {
+  isSimulator?: boolean;
+};
+
+export function Onboarding({ isSimulator }: OnboardingProps) {
+  const { isOnboardingFinished, actions } = useMenuPreferences();
+  const [isVisible, setIsVisible] = React.useState(!isOnboardingFinished);
+
+  function onOnboardingFinishedPress() {
+    actions.setOnboardingFinishedAsync(true);
+    setIsVisible(false);
+  }
+
+  return (
+    <View style={StyleSheet.absoluteFill}>
+      {isVisible && (
+        <View style={StyleSheet.absoluteFill}>
+          <View flex="1" bg="default" py="large" px="large">
+            <Heading size="large" weight="bold">
+              Hello there, friend! 👋
+            </Heading>
+
+            <Spacer.Vertical size="medium" />
+
+            <View>
+              <Text size="large" weight="medium">
+                {isSimulator ? simulatorMessage : deviceMessage}
+              </Text>
+
+              <Spacer.Vertical size="medium" />
+              <Text size="large" weight="medium">
+                Also, this menu is only available in development builds and won't be in any release
+                builds.
+              </Text>
+            </View>
+
+            <Spacer.Vertical size="xl" />
+
+            <GestureHandlerTouchableWrapper onPress={onOnboardingFinishedPress}>
+              <Button.ScaleOnPressContainer bg="primary" onPress={onOnboardingFinishedPress}>
+                <View py="small">
+                  <Button.Text align="center" size="large" color="primary" weight="medium">
+                    Got It
+                  </Button.Text>
+                </View>
+              </Button.ScaleOnPressContainer>
+            </GestureHandlerTouchableWrapper>
+          </View>
+        </View>
+      )}
+    </View>
+  );
+}

--- a/packages/expo-dev-menu/app/components/Onboarding.tsx
+++ b/packages/expo-dev-menu/app/components/Onboarding.tsx
@@ -12,7 +12,7 @@ const deviceMessage = Platform.select({
 
 const simulatorMessage = Platform.select({
   ios: `Since this is your first time opening Expo Go, we wanted to show you this menu and let you know that in a simulator you can press \u2318D (make sure that 'I/O \u279E Send Keyboard Input to Device' is enabled on your simulator) to get back to it at any time.`,
-  android: `Since this is your first time opening Expo Go, we wanted to show you this menu and let you know thatin a simulator you can press \u2318M on macOS or Ctrl+M on other platforms to get back to it at any time.`,
+  android: `Since this is your first time opening Expo Go, we wanted to show you this menu and let you know that in an emulator you can press \u2318M on macOS or Ctrl+M on other platforms to get back to it at any time.`,
 });
 
 type OnboardingProps = {

--- a/packages/expo-dev-menu/app/hooks/useDevSettings.tsx
+++ b/packages/expo-dev-menu/app/hooks/useDevSettings.tsx
@@ -81,10 +81,6 @@ export function useDevSettings() {
     bottomSheet.collapse();
   }, []);
 
-  const closeMenu = React.useCallback(async () => {
-    bottomSheet.collapse();
-  }, []);
-
   return {
     devSettings,
     actions: {
@@ -94,7 +90,6 @@ export function useDevSettings() {
       toggleFastRefresh,
       reload,
       navigateToLauncher,
-      closeMenu,
     },
   };
 }

--- a/packages/expo-dev-menu/app/hooks/useMenuPreferences.tsx
+++ b/packages/expo-dev-menu/app/hooks/useMenuPreferences.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+
+import * as DevMenu from '../native-modules/DevMenu';
+
+const defaultMenuPreferences: DevMenu.MenuPreferences = {
+  isOnboardingFinished: false,
+};
+
+const MenuPreferencesContext = React.createContext<DevMenu.MenuPreferences>(defaultMenuPreferences);
+
+export type MenuPreferencesProviderProps = {
+  children: React.ReactNode;
+  menuPreferences?: DevMenu.MenuPreferences;
+};
+
+export function MenuPreferencesProvider({
+  children,
+  menuPreferences = defaultMenuPreferences,
+}: MenuPreferencesProviderProps) {
+  return (
+    <MenuPreferencesContext.Provider value={menuPreferences}>
+      {children}
+    </MenuPreferencesContext.Provider>
+  );
+}
+
+export function useMenuPreferences() {
+  const preferences = React.useContext(MenuPreferencesContext);
+
+  function setOnboardingFinishedAsync(isFinished: boolean) {
+    return DevMenu.setOnboardingFinishedAsync(isFinished);
+  }
+
+  return {
+    ...preferences,
+    actions: {
+      setOnboardingFinishedAsync,
+    },
+  };
+}

--- a/packages/expo-dev-menu/app/native-modules/DevMenu.ts
+++ b/packages/expo-dev-menu/app/native-modules/DevMenu.ts
@@ -20,6 +20,10 @@ export type DevSettings = {
   isPerfMonitorAvailable?: boolean;
 };
 
+export type MenuPreferences = {
+  isOnboardingFinished?: boolean;
+};
+
 const DevMenu = NativeModules.ExpoDevMenuInternal;
 
 export async function dispatchCallableAsync(
@@ -71,4 +75,8 @@ export async function toggleFastRefreshAsync() {
 
 export async function copyToClipboardAsync(content: string) {
   return await DevMenu.copyToClipboardAsync(content);
+}
+
+export async function setOnboardingFinishedAsync(isFinished: boolean) {
+  return await DevMenu.setOnboardingFinished(isFinished);
 }

--- a/packages/expo-dev-menu/ios/DevMenuManager.swift
+++ b/packages/expo-dev-menu/ios/DevMenuManager.swift
@@ -82,8 +82,7 @@ open class DevMenuManager: NSObject {
   @objc
   public var currentBridge: RCTBridge? {
     didSet {
-      let prefersAutoLaunch = self.canLaunchDevMenuOnStart && DevMenuSettings.showsAtLaunch
-      guard prefersAutoLaunch || self.shouldShowOnboarding(), let bridge = currentBridge else {
+      guard self.canLaunchDevMenuOnStart && (DevMenuSettings.showsAtLaunch || self.shouldShowOnboarding()), let bridge = currentBridge else {
         return
       }
       

--- a/packages/expo-dev-menu/ios/DevMenuManager.swift
+++ b/packages/expo-dev-menu/ios/DevMenuManager.swift
@@ -82,7 +82,8 @@ open class DevMenuManager: NSObject {
   @objc
   public var currentBridge: RCTBridge? {
     didSet {
-      guard self.canLaunchDevMenuOnStart && DevMenuSettings.showsAtLaunch, let bridge = currentBridge else {
+      let prefersAutoLaunch = self.canLaunchDevMenuOnStart && DevMenuSettings.showsAtLaunch
+      guard prefersAutoLaunch || self.shouldShowOnboarding(), let bridge = currentBridge else {
         return
       }
       

--- a/packages/expo-dev-menu/ios/DevMenuViewController.swift
+++ b/packages/expo-dev-menu/ios/DevMenuViewController.swift
@@ -81,7 +81,7 @@ class DevMenuViewController: UIViewController {
       "devSettings": manager.getDevSettings(),
       "menuPreferences": DevMenuSettings.serialize(),
       "uuid": UUID.init().uuidString,
-      "isSimulator": isSimulator,
+      "isDevice": !isSimulator,
     ]
   }
 

--- a/packages/expo-dev-menu/ios/DevMenuViewController.swift
+++ b/packages/expo-dev-menu/ios/DevMenuViewController.swift
@@ -73,11 +73,15 @@ class DevMenuViewController: UIViewController {
   // MARK: private
 
   private func initialProps() -> [String: Any] {
+    let isSimulator = TARGET_IPHONE_SIMULATOR > 0
+    
     return [
       "showOnboardingView": manager.shouldShowOnboarding(),
       "appInfo": manager.getAppInfo(),
       "devSettings": manager.getDevSettings(),
+      "menuPreferences": DevMenuSettings.serialize(),
       "uuid": UUID.init().uuidString,
+      "isSimulator": isSimulator,
     ]
   }
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This PR restores the onboarding message that appears to users when they first use the dev menu. It was removed at some point during the rewrite. 

# How

Most of the functionality on the native side was already set up, it was just a matter of reenabling some things. I've passed through some additional `initialProps` to get the value of `isOnboardingFinished` in order to render this on top of the dev menu.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Tested these scenarios on iOS and Android: 

- ensured that the dev menu launches automatically on a fresh install of an app 
- onboarding is visible on top of the dev menu until the button is pressed 
- onboarding is not visible on subsequent launches, dev menu does not auto launch unless the user preference is set

Screenshots:

<img width="390" alt="Screen Shot 2022-03-11 at 12 48 53 PM" src="https://user-images.githubusercontent.com/40680668/157980296-f59d6046-3d48-40ee-afb8-5fcda020f099.png">
<img width="360" alt="Screen Shot 2022-03-11 at 12 52 26 PM" src="https://user-images.githubusercontent.com/40680668/157980300-d0d039a5-03af-4d80-9656-7e1ba340580c.png">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
