### PR TITLE
[av][android] Fix crashes caused by accessing player on wrong thread

### DIFF
--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- On Android fix crashes caused by accessing player from the wrong thread
+
 ### 💡 Others
 
 ## 11.1.0 — 2022-03-10

--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- On Android fix crashes caused by accessing player from the wrong thread
+- On Android fix crashes caused by accessing player from the wrong thread ([#16611](https://github.com/expo/expo/pull/16611) by [@mnightingale](https://github.com/mnightingale))
 
 ### 💡 Others
 

--- a/packages/expo-av/android/build.gradle
+++ b/packages/expo-av/android/build.gradle
@@ -83,6 +83,9 @@ android {
 }
 
 dependencies {
+  //noinspection GradleDynamicVersion
+  implementation 'com.facebook.react:react-native:+'
+
   implementation project(':expo-modules-core')
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"


### PR DESCRIPTION
# Why

The recent ExoPlayer upgrade changed the behaviour of accessing the player instance from a different thread than it was created on, previously it would log a warning, now by default it throws an IllegalStateException which will crash the app.

The simplest way to trigger this is to start playing a sound then open the app switcher, crashes 100% of the time.

The throws behaviour did have an opt-out via `setThrowsWhenUsingWrongThread` but it was removed in later versions, it's better to fix the issue rather than ignore it, else it'll be a blocker for upgrading ExoPlayer in the future (n.b. I started looking at that but it would require an update of `compileSdkVersion` and I wasn't sure what needs to happen to allow that).

# How

- SimpleExoPlayer instances are always created on the Native Modules Queue thread
- `onHostResume`, `onHostPause`, `onHostDestroy` and broadcasts (`ACTION_AUDIO_BECOMING_NOISY`) all run on the main thread but try to interact with the player
- I needed a way to run the methods on the same thread, the only way I could find was the cast the `Context` to a `ReactApplicationContext` - is there a better way to get the `ReactApplicationContext`? I searched through the repo and only found that the new sweet api does have a way to get it.
- Wrap the affected parts of methods in `mContext.runOnNativeModulesQueueThread(...)`

# Test Plan

Can use the examples on [docs](https://docs.expo.dev/versions/latest/sdk/audio/#playing-sounds) but need to use `expo-av@~11.0.0` (previous versions did have this issue but would warn and not crash).

Playing a sound and openning app switcher and resuming app carries on playing the audio and doesnt crash.

Also tested with `{ androidImplementation: "MediaPlayer" }`.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
