### PR TITLE
[image-picker][android] Fix failure when allowsEditing is true and non-jpeg file picked

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix failure on Android when `allowsEditing` is `true` and non-jpeg file picked.
+- Fix failure on Android when `allowsEditing` is `true` and non-jpeg file picked. ([#16615](https://github.com/expo/expo/pull/16615) by [@mnightingale](https://github.com/mnightingale))
 
 ### 💡 Others
 

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix failure on Android when `allowsEditing` is `true` and non-jpeg file picked.
+
 ### 💡 Others
 
 - Updated `@expo/config-plugins` from `4.0.2` to `4.0.14` ([#15621](https://github.com/expo/expo/pull/15621) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerUtils.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerUtils.kt
@@ -84,7 +84,7 @@ class ExifDataHandler(private val uri: Uri) {
         try {
           newExif.saveAttributes()
         } catch (e: IOException) {
-          e.message?.let { Log.e(TAG, it) }
+          Log.w(TAG, "Couldn't save Exif data: ${e.message}", e)
         }
       }
     }

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerUtils.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerUtils.kt
@@ -9,6 +9,7 @@ import androidx.core.content.FileProvider
 import androidx.exifinterface.media.ExifInterface
 import expo.modules.core.utilities.FileUtilities.generateOutputPath
 import expo.modules.core.utilities.ifNull
+import expo.modules.imagepicker.ImagePickerConstants.TAG
 import java.io.File
 import java.io.IOException
 
@@ -80,7 +81,11 @@ class ExifDataHandler(private val uri: Uri) {
             newExif.setAttribute(exifTag, value)
           }
         }
-        newExif.saveAttributes()
+        try {
+          newExif.saveAttributes()
+        } catch (e: IOException) {
+          e.message?.let { Log.e(TAG, it) }
+        }
       }
     }
   }

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/tasks/ImageResultTask.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/tasks/ImageResultTask.kt
@@ -64,7 +64,7 @@ open class ImageResultTask(
     coroutineScope.launch {
       try {
         val outputFile = getFile()
-        if (isEdited) {
+        if (isEdited && withExifData) {
           exifDataHandler?.copyExifData(uri, contentResolver)
         }
         val exif = getExifData()


### PR DESCRIPTION
# Why

Failure when non-jpeg files are selected with `allowsEditing`.

Closes #16514
Closes #15155 - already closed, perfectly clear, simple to reproduce bug report left to go stale 👀 

Not part of this PR but also suggest migrating from `androidx.legacy:legacy-support-v4` to `androidx.exifinterface:exifinterface` since it adds support for Exif on more than just JPEG images (PNG and WebP).
This PR is still relevant because formats not supported or not possible to support would still reject instead of just failing to write Exif.

Any chance this can get backported to SDK 43?

# How

- Skip copying Exif if it's not requested using `withExifData` same as `getFile` does for a non-edited files
- Catch, log and ignore the exception on failure to write Exif at `newExif.saveAttributes()`

# Test Plan

Snacks in #15155.

Select a PNG image.

```ts
let result = await ImagePicker.launchImageLibraryAsync({
  quality: 1,
  allowsEditing: true,
});

console.log(result);
```

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
