### PR TITLE
[core][ios] Introduce asyncFunction definition component

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Remove backward compatible workaround and drop react-native 0.64 support. ([#16446](https://github.com/expo/expo/pull/16446) by [@kudo](https://github.com/kudo))
 
+### ⚠️ Notices
+
+- Deprecated current behavior of `function` module definition component in favor of `asyncFunction` to emphasize that it's being executed asynchronously in JavaScript. In the future release `function` will become synchronous. ([#16630](https://github.com/expo/expo/pull/16630) by [@tsapeta](https://github.com/tsapeta), [#16656](https://github.com/expo/expo/pull/16656) by [@lukmccall](https://github.com/lukmccall))
+
 ### 🎉 New features
 
 - Add `getDevSupportManagerFactory` support to `ReactNativeHostHandler`. ([#16434](https://github.com/expo/expo/pull/16434) by [@lukmccall](https://github.com/lukmccall))

--- a/packages/expo-modules-core/ios/Swift/Functions/AsyncFunction.swift
+++ b/packages/expo-modules-core/ios/Swift/Functions/AsyncFunction.swift
@@ -1,0 +1,17 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+/**
+ Represents a function that can only be called asynchronously, thus its JavaScript equivalent returns a Promise.
+
+ - ToDo: Move some asynchronous logic from `ConcreteFunction` (like `call(args:promise:)`) to this class and drop the `isAsync` property.
+ */
+public final class AsyncFunction<Args, ReturnType>: ConcreteFunction<Args, ReturnType> {
+  override init(
+    _ name: String,
+    argTypes: [AnyArgumentType],
+    _ closure: @escaping ConcreteFunction<Args, ReturnType>.ClosureType
+  ) {
+    super.init(name, argTypes: argTypes, closure)
+    self.isAsync = true
+  }
+}

--- a/packages/expo-modules-core/ios/Swift/Functions/ConcreteFunction.swift
+++ b/packages/expo-modules-core/ios/Swift/Functions/ConcreteFunction.swift
@@ -1,6 +1,6 @@
 import Dispatch
 
-public final class ConcreteFunction<Args, ReturnType>: AnyFunction {
+public class ConcreteFunction<Args, ReturnType>: AnyFunction {
   public typealias ClosureType = (Args) throws -> ReturnType
 
   public let name: String
@@ -29,6 +29,11 @@ public final class ConcreteFunction<Args, ReturnType>: AnyFunction {
     self.name = name
     self.argTypes = argTypes
     self.closure = closure
+
+    // This is temporary solution to keep backwards compatibility for existing functions — they all end with "Async".
+    // `function` component that we've used so far was async by default, but we decided to replace it with `asyncFunction`
+    // and make `function`s synchronous. Introduced in SDK45, can be removed in SDK46 after migrating all modules.
+    self.isAsync = name.hasSuffix("Async")
   }
 
   public func call(args: [Any], promise: Promise) {

--- a/packages/expo-modules-core/ios/Swift/Objects/ObjectDefinitionComponents.swift
+++ b/packages/expo-modules-core/ios/Swift/Objects/ObjectDefinitionComponents.swift
@@ -22,6 +22,7 @@ public func constants(_ body: @autoclosure @escaping () -> [String: Any?]) -> An
 /**
  Function without arguments.
  */
+@available(*, deprecated, renamed: "asyncFunction")
 public func function<R>(
   _ name: String,
   _ closure: @escaping () throws -> R
@@ -36,6 +37,7 @@ public func function<R>(
 /**
  Function with one argument.
  */
+@available(*, deprecated, renamed: "asyncFunction")
 public func function<R, A0: AnyArgument>(
   _ name: String,
   _ closure: @escaping (A0) throws -> R
@@ -50,6 +52,7 @@ public func function<R, A0: AnyArgument>(
 /**
  Function with two arguments.
  */
+@available(*, deprecated, renamed: "asyncFunction")
 public func function<R, A0: AnyArgument, A1: AnyArgument>(
   _ name: String,
   _ closure: @escaping (A0, A1) throws -> R
@@ -64,6 +67,7 @@ public func function<R, A0: AnyArgument, A1: AnyArgument>(
 /**
  Function with three arguments.
  */
+@available(*, deprecated, renamed: "asyncFunction")
 public func function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument>(
   _ name: String,
   _ closure: @escaping (A0, A1, A2) throws -> R
@@ -82,6 +86,7 @@ public func function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument>(
 /**
  Function with four arguments.
  */
+@available(*, deprecated, renamed: "asyncFunction")
 public func function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument>(
   _ name: String,
   _ closure: @escaping (A0, A1, A2, A3) throws -> R
@@ -101,6 +106,7 @@ public func function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: A
 /**
  Function with five arguments.
  */
+@available(*, deprecated, renamed: "asyncFunction")
 public func function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument, A4: AnyArgument>(
   _ name: String,
   _ closure: @escaping (A0, A1, A2, A3, A4) throws -> R
@@ -121,6 +127,7 @@ public func function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: A
 /**
  Function with six arguments.
  */
+@available(*, deprecated, renamed: "asyncFunction")
 public func function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument, A4: AnyArgument, A5: AnyArgument>(
   _ name: String,
   _ closure: @escaping (A0, A1, A2, A3, A4, A5) throws -> R
@@ -142,6 +149,7 @@ public func function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: A
 /**
  Function with seven arguments.
  */
+@available(*, deprecated, renamed: "asyncFunction")
 public func function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument, A4: AnyArgument, A5: AnyArgument, A6: AnyArgument>(
   _ name: String,
   _ closure: @escaping (A0, A1, A2, A3, A4, A5, A6) throws -> R
@@ -164,6 +172,7 @@ public func function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: A
 /**
  Function with eight arguments.
  */
+@available(*, deprecated, renamed: "asyncFunction")
 public func function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument, A4: AnyArgument, A5: AnyArgument, A6: AnyArgument, A7: AnyArgument>(
   _ name: String,
   _ closure: @escaping (A0, A1, A2, A3, A4, A5, A6, A7) throws -> R

--- a/packages/expo-modules-core/ios/Swift/Objects/ObjectDefinitionComponents.swift
+++ b/packages/expo-modules-core/ios/Swift/Objects/ObjectDefinitionComponents.swift
@@ -184,6 +184,173 @@ public func function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: A
   )
 }
 
+// MARK: - Asynchronous functions
+
+/**
+ Asynchronous function without arguments.
+ */
+public func asyncFunction<R>(
+  _ name: String,
+  _ closure: @escaping () throws -> R
+) -> AnyFunction {
+  return AsyncFunction(
+    name,
+    argTypes: [],
+    closure
+  )
+}
+
+/**
+ Asynchronous function with one argument.
+ */
+public func asyncFunction<R, A0: AnyArgument>(
+  _ name: String,
+  _ closure: @escaping (A0) throws -> R
+) -> AnyFunction {
+  return AsyncFunction(
+    name,
+    argTypes: [ArgumentType(A0.self)],
+    closure
+  )
+}
+
+/**
+ Asynchronous function with two arguments.
+ */
+public func asyncFunction<R, A0: AnyArgument, A1: AnyArgument>(
+  _ name: String,
+  _ closure: @escaping (A0, A1) throws -> R
+) -> AnyFunction {
+  return AsyncFunction(
+    name,
+    argTypes: [ArgumentType(A0.self), ArgumentType(A1.self)],
+    closure
+  )
+}
+
+/**
+ Asynchronous function with three arguments.
+ */
+public func asyncFunction<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument>(
+  _ name: String,
+  _ closure: @escaping (A0, A1, A2) throws -> R
+) -> AnyFunction {
+  return AsyncFunction(
+    name,
+    argTypes: [
+      ArgumentType(A0.self),
+      ArgumentType(A1.self),
+      ArgumentType(A2.self)
+    ],
+    closure
+  )
+}
+
+/**
+ Asynchronous function with four arguments.
+ */
+public func asyncFunction<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument>(
+  _ name: String,
+  _ closure: @escaping (A0, A1, A2, A3) throws -> R
+) -> AnyFunction {
+  return AsyncFunction(
+    name,
+    argTypes: [
+      ArgumentType(A0.self),
+      ArgumentType(A1.self),
+      ArgumentType(A2.self),
+      ArgumentType(A3.self)
+    ],
+    closure
+  )
+}
+
+/**
+ Asynchronous function with five arguments.
+ */
+public func asyncFunction<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument, A4: AnyArgument>(
+  _ name: String,
+  _ closure: @escaping (A0, A1, A2, A3, A4) throws -> R
+) -> AnyFunction {
+  return AsyncFunction(
+    name,
+    argTypes: [
+      ArgumentType(A0.self),
+      ArgumentType(A1.self),
+      ArgumentType(A2.self),
+      ArgumentType(A3.self),
+      ArgumentType(A4.self)
+    ],
+    closure
+  )
+}
+
+/**
+ Asynchronous function with six arguments.
+ */
+public func asyncFunction<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument, A4: AnyArgument, A5: AnyArgument>(
+  _ name: String,
+  _ closure: @escaping (A0, A1, A2, A3, A4, A5) throws -> R
+) -> AnyFunction {
+  return AsyncFunction(
+    name,
+    argTypes: [
+      ArgumentType(A0.self),
+      ArgumentType(A1.self),
+      ArgumentType(A2.self),
+      ArgumentType(A3.self),
+      ArgumentType(A4.self),
+      ArgumentType(A5.self)
+    ],
+    closure
+  )
+}
+
+/**
+ Asynchronous function with seven arguments.
+ */
+public func asyncFunction<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument, A4: AnyArgument, A5: AnyArgument, A6: AnyArgument>(
+  _ name: String,
+  _ closure: @escaping (A0, A1, A2, A3, A4, A5, A6) throws -> R
+) -> AnyFunction {
+  return AsyncFunction(
+    name,
+    argTypes: [
+      ArgumentType(A0.self),
+      ArgumentType(A1.self),
+      ArgumentType(A2.self),
+      ArgumentType(A3.self),
+      ArgumentType(A4.self),
+      ArgumentType(A5.self),
+      ArgumentType(A6.self)
+    ],
+    closure
+  )
+}
+
+/**
+ Asynchronous function with eight arguments.
+ */
+public func asyncFunction<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument, A4: AnyArgument, A5: AnyArgument, A6: AnyArgument, A7: AnyArgument>(
+  _ name: String,
+  _ closure: @escaping (A0, A1, A2, A3, A4, A5, A6, A7) throws -> R
+) -> AnyFunction {
+  return AsyncFunction(
+    name,
+    argTypes: [
+      ArgumentType(A0.self),
+      ArgumentType(A1.self),
+      ArgumentType(A2.self),
+      ArgumentType(A3.self),
+      ArgumentType(A4.self),
+      ArgumentType(A5.self),
+      ArgumentType(A6.self),
+      ArgumentType(A7.self)
+    ],
+    closure
+  )
+}
+
 // MARK: - Events
 
 /**


### PR DESCRIPTION
# Why

As we're going to have more synchronous functions exported to JS, we need to have different component for synchronous and asynchronous functions in Sweet API. 

# How

So far the `function` component was returning an asynchronous function as it was the only option (bridge). However, it seems more natural to use `function` as synchronous and `asyncFunction` as asynchronous (like you write it in JS). Existing `ConcreteFunction` can be both sync and async, but async functions may have a little bit different logic in the future, so I've made a separate `AsyncFunction` class for them.

Unfortunately, this is a breaking change for all modules using Sweet API. To partially keep backwards compatibility, all `function`s whose name ends with `Async` will be async too (at least in SDK45). To simplify the compatibility layer, the `AsyncFunction` class is just a simple subclass of `ConcreteFunction` that ensures the `isAsync` property is true.

# Test Plan

I changed some `function` to `asyncFunction` locally and confirmed they work as expected. Also the "Async" suffix in function's name works just fine.