### PR TITLE
[cli] Added Metro dev server module

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -12,7 +12,7 @@
 - [cli] Added module for updating the "development session" API. ([#16555](https://github.com/expo/expo/pull/16555) by [@EvanBacon](https://github.com/EvanBacon))
 - [cli] Added modules for creating dev server URLs, akin to `UrlUtils` in `xdl`. ([#16557](https://github.com/expo/expo/pull/16557) by [@EvanBacon](https://github.com/EvanBacon))
 - [cli] Added shim for `expo start` command and option resolvers. ([#16587](https://github.com/expo/expo/pull/16587) by [@EvanBacon](https://github.com/EvanBacon))
-- [cli] Added module for interacting with Metro bundler.
+- [cli] Added module for interacting with Metro bundler. ([#16631](https://github.com/expo/expo/pull/16631) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [cli] Added module for updating the "development session" API. ([#16555](https://github.com/expo/expo/pull/16555) by [@EvanBacon](https://github.com/EvanBacon))
 - [cli] Added modules for creating dev server URLs, akin to `UrlUtils` in `xdl`. ([#16557](https://github.com/expo/expo/pull/16557) by [@EvanBacon](https://github.com/EvanBacon))
 - [cli] Added shim for `expo start` command and option resolvers. ([#16587](https://github.com/expo/expo/pull/16587) by [@EvanBacon](https://github.com/EvanBacon))
+- [cli] Added module for interacting with Metro bundler.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo/cli/start/server/BundlerDevServer.ts
+++ b/packages/expo/cli/start/server/BundlerDevServer.ts
@@ -201,8 +201,9 @@ export abstract class BundlerDevServer {
     this.devSession?.stop?.();
 
     // Stop ngrok if running.
-    await this.ngrok?.stopAsync?.().catch((e) => {
-      Log.error(`Error stopping ngrok: ${e.message}`);
+    await this.ngrok?.stopAsync().catch((e) => {
+      Log.error(`Error stopping ngrok:`);
+      Log.exception(e);
     });
 
     return new Promise<void>((resolve, reject) => {
@@ -217,6 +218,7 @@ export abstract class BundlerDevServer {
           }
         });
       } else {
+        this.instance = null;
         resolve();
       }
     });
@@ -242,12 +244,12 @@ export abstract class BundlerDevServer {
     if (options.hostType === 'localhost') {
       return `${location.protocol}://localhost:${location.port}`;
     }
-    return location?.url ?? null;
+    return location.url ?? null;
   }
 
   /** Get the tunnel URL from ngrok. */
   public getTunnelUrl(): string | null {
-    return this.ngrok?.getActiveUrl?.() ?? null;
+    return this.ngrok?.getActiveUrl() ?? null;
   }
 
   /** Open the dev server in a runtime. */
@@ -270,9 +272,8 @@ export abstract class BundlerDevServer {
   protected shouldUseInterstitialPage(): boolean {
     return (
       env.EXPO_ENABLE_INTERSTITIAL_PAGE &&
-      // TODO: >:0
       // Checks if dev client is installed.
-      !!resolveFrom.silent(this.projectRoot, 'expo-dev-launcher/package.json')
+      !!resolveFrom.silent(this.projectRoot, 'expo-dev-launcher')
     );
   }
 
@@ -294,7 +295,7 @@ export abstract class BundlerDevServer {
       const Manager = PLATFORM_MANAGERS[platform];
       this.platformManagers[platform] = new Manager(
         this.projectRoot,
-        this.getInstance()?.location?.port,
+        this.getInstance()?.location.port,
         {
           getCustomRuntimeUrl: this.urlCreator.constructDevClientUrl.bind(this.urlCreator),
           getExpoGoUrl: this.getExpoGoUrl.bind(this, platform),

--- a/packages/expo/cli/start/server/BundlerDevServer.ts
+++ b/packages/expo/cli/start/server/BundlerDevServer.ts
@@ -138,7 +138,7 @@ export abstract class BundlerDevServer {
 
   /** Create ngrok instance and start the tunnel server. Exposed for testing. */
   public async _startTunnelAsync(): Promise<AsyncNgrok | null> {
-    const port = this.getInstance()?.location?.port;
+    const port = this.getInstance()?.location.port;
     if (!port) return null;
     Log.debug('[ngrok] connect to port: ' + port);
     this.ngrok = new AsyncNgrok(this.projectRoot, port);

--- a/packages/expo/cli/start/server/BundlerDevServer.ts
+++ b/packages/expo/cli/start/server/BundlerDevServer.ts
@@ -45,7 +45,7 @@ export interface BundlerStartOptions {
   devClient?: boolean;
   /** Should run dev servers with clean caches. */
   resetDevServer?: boolean;
-  /** Which manifest handler to use. */
+  /** Which manifest type to serve. */
   forceManifestType?: 'expo-updates' | 'classic';
 
   /** Max amount of workers (threads) to use with Metro bundler, defaults to undefined for max workers. */

--- a/packages/expo/cli/start/server/BundlerDevServer.ts
+++ b/packages/expo/cli/start/server/BundlerDevServer.ts
@@ -1,0 +1,307 @@
+import { MessageSocket } from '@expo/dev-server';
+import assert from 'assert';
+import openBrowserAsync from 'better-opn';
+import resolveFrom from 'resolve-from';
+
+import { APISettings } from '../../api/settings';
+import * as Log from '../../log';
+import { FileNotifier } from '../../utils/FileNotifier';
+import { env } from '../../utils/env';
+import { BaseResolveDeviceProps, PlatformManager } from '../platforms/PlatformManager';
+import { AndroidPlatformManager } from '../platforms/android/AndroidPlatformManager';
+import { ApplePlatformManager } from '../platforms/ios/ApplePlatformManager';
+import { AsyncNgrok } from './AsyncNgrok';
+import { DevelopmentSession } from './DevelopmentSession';
+import { CreateURLOptions, UrlCreator } from './UrlCreator';
+import { ClassicManifestMiddleware } from './middleware/ClassicManifestMiddleware';
+import { ExpoGoManifestHandlerMiddleware } from './middleware/ExpoGoManifestHandlerMiddleware';
+
+export type ServerLike = {
+  close(callback?: (err?: Error) => void);
+};
+
+export type DevServerInstance = {
+  /** Bundler dev server instance. */
+  server: ServerLike;
+  /** Dev server URL location properties. */
+  location: {
+    url: string;
+    port: number;
+    protocol: 'http' | 'https';
+    host?: string;
+  };
+  /** Additional middleware that's attached to the `server`. */
+  middleware: any;
+  /** Message socket for communicating with the runtime. */
+  messageSocket: MessageSocket;
+};
+
+export interface BundlerStartOptions {
+  /** Should the dev server use `https` protocol. */
+  https?: boolean;
+  /** Should start the dev servers in development mode (minify). */
+  mode?: 'development' | 'production';
+  /** Is dev client enabled. */
+  devClient?: boolean;
+  /** Should run dev servers with clean caches. */
+  resetDevServer?: boolean;
+  /** Which manifest handler to use. */
+  forceManifestType?: 'expo-updates' | 'classic';
+
+  /** Max amount of workers (threads) to use with Metro bundler, defaults to undefined for max workers. */
+  maxWorkers?: number;
+  /** Port to start the dev server on. */
+  port?: number;
+
+  /** Should instruct the bundler to create minified bundles. */
+  minify?: boolean;
+
+  // Webpack options
+  /** Should modify and create PWA icons. */
+  isImageEditingEnabled?: boolean;
+
+  location: CreateURLOptions;
+}
+
+const PLATFORM_MANAGERS = {
+  simulator: ApplePlatformManager,
+  emulator: AndroidPlatformManager,
+};
+
+const MIDDLEWARES = {
+  classic: ClassicManifestMiddleware,
+  'expo-updates': ExpoGoManifestHandlerMiddleware,
+};
+
+export abstract class BundlerDevServer {
+  /** Name of the bundler. */
+  abstract get name(): string;
+
+  /** Ngrok instance for managing tunnel connections. */
+  protected ngrok: AsyncNgrok | null = null;
+  /** Interfaces with the Expo 'Development Session' API. */
+  protected devSession: DevelopmentSession | null = null;
+  /** Http server and related info. */
+  protected instance: DevServerInstance | null = null;
+  /** Native platform interfaces for opening projects.  */
+  private platformManagers: Record<string, PlatformManager<any>> = {};
+  /** Manages the creation of dev server URLs. */
+  protected urlCreator?: UrlCreator | null = null;
+
+  constructor(
+    /** Project root folder. */
+    public projectRoot: string,
+    // TODO: Replace with custom scheme maybe...
+    public isDevClient?: boolean
+  ) {}
+
+  protected setInstance(instance: DevServerInstance) {
+    this.instance = instance;
+  }
+
+  /** Get the manifest middleware function. Exposed for testing. */
+  public _getManifestMiddleware(
+    options: Pick<BundlerStartOptions, 'minify' | 'mode' | 'forceManifestType'> = {}
+  ) {
+    const manifestType = options.forceManifestType || 'classic';
+    const Middleware = MIDDLEWARES[manifestType];
+    assert(Middleware, `Manifest middleware for type '${manifestType}' not found`);
+
+    const urlCreator = this.getUrlCreator();
+    const middleware = new Middleware(this.projectRoot, {
+      constructUrl: urlCreator.constructUrl.bind(urlCreator),
+      mode: options.mode,
+      minify: options.minify,
+      isNativeWebpack: this.name === 'webpack' && this.isTargetingNative(),
+    });
+    return middleware.getHandler();
+  }
+
+  /** Start the dev server using settings defined in the start command. */
+  public abstract startAsync(options: BundlerStartOptions): Promise<DevServerInstance>;
+
+  protected async postStartAsync(options: BundlerStartOptions) {
+    if (options.location.hostType === 'tunnel' && !APISettings.isOffline) {
+      await this._startTunnelAsync();
+    }
+    await this.startDevSessionAsync();
+
+    this.watchConfig();
+  }
+
+  protected abstract getConfigModuleIds(): string[];
+
+  protected watchConfig() {
+    const notifier = new FileNotifier(this.projectRoot, this.getConfigModuleIds());
+    notifier.startObserving();
+  }
+
+  /** Create ngrok instance and start the tunnel server. Exposed for testing. */
+  public async _startTunnelAsync(): Promise<AsyncNgrok | null> {
+    const port = this.getInstance()?.location?.port;
+    if (!port) return null;
+    Log.debug('[ngrok] connect to port: ' + port);
+    this.ngrok = new AsyncNgrok(this.projectRoot, port);
+    await this.ngrok.startAsync();
+    return this.ngrok;
+  }
+
+  protected async startDevSessionAsync() {
+    // This is used to make Expo Go open the project in either Expo Go, or the web browser.
+    // Must come after ngrok (`startTunnelAsync`) setup.
+
+    if (this.devSession) {
+      this.devSession.stop();
+    }
+
+    this.devSession = new DevelopmentSession(
+      this.projectRoot,
+      // This URL will be used on external devices so the computer IP won't be relevant.
+      this.isTargetingNative()
+        ? this.getNativeRuntimeUrl()
+        : this.getDevServerUrl({ hostType: 'localhost' })
+    );
+
+    await this.devSession.startAsync({
+      runtime: this.isTargetingNative() ? 'native' : 'web',
+    });
+  }
+
+  public isTargetingNative() {
+    // Temporary hack while we implement multi-bundler dev server proxy.
+    return true;
+  }
+
+  public isTargetingWeb() {
+    return false;
+  }
+
+  /**
+   * Sends a message over web sockets to any connected device,
+   * does nothing when the dev server is not running.
+   *
+   * @param method name of the command. In RN projects `reload`, and `devMenu` are available. In Expo Go, `sendDevCommand` is available.
+   * @param params
+   */
+  public broadcastMessage(
+    method: 'reload' | 'devMenu' | 'sendDevCommand',
+    params?: Record<string, any>
+  ) {
+    this.getInstance()?.messageSocket?.broadcast?.(method, params);
+  }
+
+  /** Get the running dev server instance. */
+  public getInstance() {
+    return this.instance;
+  }
+
+  /** Stop the running dev server instance. */
+  async stopAsync() {
+    // Stop the dev session timer.
+    this.devSession?.stop?.();
+
+    // Stop ngrok if running.
+    await this.ngrok?.stopAsync?.().catch((e) => {
+      Log.error(`Error stopping ngrok: ${e.message}`);
+    });
+
+    return new Promise<void>((resolve, reject) => {
+      // Close the server.
+      if (this.instance?.server) {
+        this.instance.server.close((error) => {
+          this.instance = null;
+          if (error) {
+            reject(error);
+          } else {
+            resolve();
+          }
+        });
+      } else {
+        resolve();
+      }
+    });
+  }
+
+  private getUrlCreator() {
+    assert(this.urlCreator, 'Dev server is not running.');
+    return this.urlCreator;
+  }
+
+  public getNativeRuntimeUrl(opts: Partial<CreateURLOptions> = {}) {
+    return this.isDevClient
+      ? this.getUrlCreator().constructDevClientUrl(opts) ?? this.getDevServerUrl()
+      : this.getUrlCreator().constructUrl({ ...opts, scheme: 'exp' });
+  }
+
+  /** Get the URL for the running instance of the dev server. */
+  public getDevServerUrl(options: { hostType?: 'localhost' } = {}): string | null {
+    if (!this.getInstance()?.location) {
+      return null;
+    }
+    const { location } = this.getInstance();
+    if (options.hostType === 'localhost') {
+      return `${location.protocol}://localhost:${location.port}`;
+    }
+    return location?.url ?? null;
+  }
+
+  /** Get the tunnel URL from ngrok. */
+  public getTunnelUrl(): string | null {
+    return this.ngrok?.getActiveUrl?.() ?? null;
+  }
+
+  /** Open the dev server in a runtime. */
+  public async openPlatformAsync(
+    launchTarget: keyof typeof PLATFORM_MANAGERS | 'desktop',
+    resolver: BaseResolveDeviceProps<any> = {}
+  ) {
+    if (launchTarget === 'desktop') {
+      const url = this.getDevServerUrl({ hostType: 'localhost' });
+      await openBrowserAsync(url);
+      return { url };
+    }
+
+    const runtime = this.isTargetingNative() ? (this.isDevClient ? 'custom' : 'expo') : 'web';
+    const manager = this.getPlatformManager(launchTarget);
+    return manager.openAsync({ runtime }, resolver);
+  }
+
+  /** Should use the interstitial page for selecting which runtime to use. */
+  protected shouldUseInterstitialPage(): boolean {
+    return (
+      env.EXPO_ENABLE_INTERSTITIAL_PAGE &&
+      // TODO: >:0
+      // Checks if dev client is installed.
+      !!resolveFrom.silent(this.projectRoot, 'expo-dev-launcher/package.json')
+    );
+  }
+
+  /** Get the URL for opening in Expo Go. */
+  protected getExpoGoUrl(platform: keyof typeof PLATFORM_MANAGERS) {
+    if (this.shouldUseInterstitialPage()) {
+      const loadingUrl =
+        platform === 'emulator'
+          ? this.urlCreator.constructLoadingUrl({}, 'android')
+          : this.urlCreator.constructLoadingUrl({ hostType: 'localhost' }, 'ios');
+      return loadingUrl;
+    }
+
+    return this.urlCreator.constructUrl({ scheme: 'exp' });
+  }
+
+  protected getPlatformManager(platform: keyof typeof PLATFORM_MANAGERS) {
+    if (!this.platformManagers[platform]) {
+      const Manager = PLATFORM_MANAGERS[platform];
+      this.platformManagers[platform] = new Manager(
+        this.projectRoot,
+        this.getInstance()?.location?.port,
+        {
+          getCustomRuntimeUrl: this.urlCreator.constructDevClientUrl.bind(this.urlCreator),
+          getExpoGoUrl: this.getExpoGoUrl.bind(this, platform),
+          getDevServerUrl: this.getDevServerUrl.bind(this, { hostType: 'localhost' }),
+        }
+      );
+    }
+    return this.platformManagers[platform];
+  }
+}

--- a/packages/expo/cli/start/server/BundlerDevServer.ts
+++ b/packages/expo/cli/start/server/BundlerDevServer.ts
@@ -187,7 +187,7 @@ export abstract class BundlerDevServer {
     method: 'reload' | 'devMenu' | 'sendDevCommand',
     params?: Record<string, any>
   ) {
-    this.getInstance()?.messageSocket?.broadcast?.(method, params);
+    this.getInstance()?.messageSocket.broadcast(method, params);
   }
 
   /** Get the running dev server instance. */

--- a/packages/expo/cli/start/server/BundlerDevServer.ts
+++ b/packages/expo/cli/start/server/BundlerDevServer.ts
@@ -198,7 +198,7 @@ export abstract class BundlerDevServer {
   /** Stop the running dev server instance. */
   async stopAsync() {
     // Stop the dev session timer.
-    this.devSession?.stop?.();
+    this.devSession?.stop();
 
     // Stop ngrok if running.
     await this.ngrok?.stopAsync().catch((e) => {

--- a/packages/expo/cli/start/server/DevServerManager.ts
+++ b/packages/expo/cli/start/server/DevServerManager.ts
@@ -37,6 +37,8 @@ export class DevServerManager {
   private watchBabelConfig() {
     const notifier = new FileNotifier(this.projectRoot, [
       './babel.config.js',
+      './babel.config.json',
+      './.babelrc.json',
       './.babelrc',
       './.babelrc.js',
     ]);
@@ -59,7 +61,7 @@ export class DevServerManager {
   }
 
   /**
-   * Sends a message over web sockets to any connected device,
+   * Sends a message over web sockets to all connected devices,
    * does nothing when the dev server is not running.
    *
    * @param method name of the command. In RN projects `reload`, and `devMenu` are available. In Expo Go, `sendDevCommand` is available.
@@ -134,7 +136,7 @@ export class DevServerManager {
         // Stop ADB
         AndroidDebugBridge.getServer().stopAsync(),
       ]),
-      new Promise((resolve) => setTimeout(resolve, 2000, 'stopFailed')),
+      new Promise((resolve) => setTimeout(resolve, 2000)),
     ]);
   }
 }

--- a/packages/expo/cli/start/server/DevServerManager.ts
+++ b/packages/expo/cli/start/server/DevServerManager.ts
@@ -77,7 +77,7 @@ export class DevServerManager {
   /** Get the port for the dev server (either Webpack or Metro) that is hosting code for React Native runtimes. */
   getNativeDevServerPort() {
     const server = devServers.find((server) => server.isTargetingNative());
-    return server?.getInstance?.()?.location?.port ?? null;
+    return server?.getInstance()?.location.port ?? null;
   }
 
   /** Get the first server that targets web. */

--- a/packages/expo/cli/start/server/DevServerManager.ts
+++ b/packages/expo/cli/start/server/DevServerManager.ts
@@ -1,0 +1,140 @@
+import { ExpoConfig, getConfig } from '@expo/config';
+import assert from 'assert';
+
+import * as Log from '../../log';
+import { FileNotifier } from '../../utils/FileNotifier';
+import { logEvent } from '../../utils/analytics/rudderstackClient';
+import { ProjectPrerequisite } from '../doctor/Prerequisite';
+import * as AndroidDebugBridge from '../platforms/android/adb';
+import { BundlerDevServer, BundlerStartOptions } from './BundlerDevServer';
+import { MetroBundlerDevServer } from './metro/MetroBundlerDevServer';
+
+export type MultiBundlerStartOptions = {
+  type: keyof typeof BUNDLERS;
+  options?: BundlerStartOptions;
+}[];
+
+const devServers: BundlerDevServer[] = [];
+
+const BUNDLERS = {
+  // TODO: Webpack
+  // webpack: WebpackBundlerDevServer,
+  metro: MetroBundlerDevServer,
+};
+
+/** Manages interacting with multiple dev servers. */
+export class DevServerManager {
+  private projectPrerequisites: ProjectPrerequisite[] = [];
+
+  constructor(
+    public projectRoot: string,
+    /** Keep track of the original CLI options for bundlers that are started interactively. */
+    public options: BundlerStartOptions
+  ) {
+    this.watchBabelConfig();
+  }
+
+  private watchBabelConfig() {
+    const notifier = new FileNotifier(this.projectRoot, [
+      './babel.config.js',
+      './.babelrc',
+      './.babelrc.js',
+    ]);
+
+    notifier.startObserving();
+
+    return notifier;
+  }
+
+  /** Lazily load and assert a project-level prerequisite. */
+  async ensureProjectPrerequisiteAsync(PrerequisiteClass: typeof ProjectPrerequisite) {
+    let prerequisite = this.projectPrerequisites.find(
+      (prerequisite) => prerequisite instanceof PrerequisiteClass
+    );
+    if (!prerequisite) {
+      prerequisite = new PrerequisiteClass(this.projectRoot);
+      this.projectPrerequisites.push(prerequisite);
+    }
+    await prerequisite.assertAsync();
+  }
+
+  /**
+   * Sends a message over web sockets to any connected device,
+   * does nothing when the dev server is not running.
+   *
+   * @param method name of the command. In RN projects `reload`, and `devMenu` are available. In Expo Go, `sendDevCommand` is available.
+   * @param params extra event info to send over the socket.
+   */
+  broadcastMessage(method: 'reload' | 'devMenu' | 'sendDevCommand', params?: Record<string, any>) {
+    devServers.forEach((server) => {
+      server.broadcastMessage(method, params);
+    });
+  }
+
+  /** Get the port for the dev server (either Webpack or Metro) that is hosting code for React Native runtimes. */
+  getNativeDevServerPort() {
+    const server = devServers.find((server) => server.isTargetingNative());
+    return server?.getInstance?.()?.location?.port ?? null;
+  }
+
+  /** Get the first server that targets web. */
+  getWebDevServer() {
+    const server = devServers.find((server) => server.isTargetingWeb());
+    return server ?? null;
+  }
+
+  getDefaultDevServer(): BundlerDevServer {
+    // Return the first native dev server otherwise return the first dev server.
+    const server = devServers.find((server) => server.isTargetingNative());
+    const defaultServer = server ?? devServers[0];
+    assert(defaultServer, 'No dev servers are running');
+    return defaultServer;
+  }
+
+  async ensureWebDevServerRunningAsync() {
+    const [server] = devServers.filter((server) => server.isTargetingWeb());
+    if (server) {
+      return;
+    }
+    Log.debug('Starting webpack dev server');
+    throw new Error('Not implemented');
+    // return this.startAsync([
+    //   {
+    //     type: 'webpack',
+    //     options: this.options,
+    //   },
+    // ]);
+  }
+
+  /** Start all dev servers. */
+  async startAsync(startOptions: MultiBundlerStartOptions): Promise<ExpoConfig> {
+    const { exp } = getConfig(this.projectRoot);
+
+    logEvent('Start Project', {
+      sdkVersion: exp.sdkVersion ?? null,
+    });
+
+    // Start all dev servers...
+    for (const { type, options } of startOptions) {
+      const BundlerDevServerClass = BUNDLERS[type];
+      const server = new BundlerDevServerClass(this.projectRoot, !!options?.devClient);
+      await server.startAsync(options ?? this.options);
+      devServers.push(server);
+    }
+
+    return exp;
+  }
+
+  /** Stop all servers including ADB. */
+  async stopAsync(): Promise<void> {
+    await Promise.race([
+      Promise.allSettled([
+        // Stop all dev servers
+        ...devServers.map((server) => server.stopAsync()),
+        // Stop ADB
+        AndroidDebugBridge.getServer().stopAsync(),
+      ]),
+      new Promise((resolve) => setTimeout(resolve, 2000, 'stopFailed')),
+    ]);
+  }
+}

--- a/packages/expo/cli/start/server/__tests__/BundlerDevServer-test.ts
+++ b/packages/expo/cli/start/server/__tests__/BundlerDevServer-test.ts
@@ -1,0 +1,256 @@
+import openBrowserAsync from 'better-opn';
+import { vol } from 'memfs';
+
+import { BundlerDevServer, BundlerStartOptions, DevServerInstance } from '../BundlerDevServer';
+import { UrlCreator } from '../UrlCreator';
+
+jest.mock('../AsyncNgrok');
+jest.mock('../DevelopmentSession');
+jest.mock('../../platforms/ios/ApplePlatformManager', () => {
+  class ApplePlatformManager {
+    openAsync = jest.fn(async () => ({ url: 'mock-apple-url' }));
+  }
+  return {
+    ApplePlatformManager,
+  };
+});
+jest.mock('../../platforms/android/AndroidPlatformManager', () => {
+  class AndroidPlatformManager {
+    openAsync = jest.fn(async () => ({ url: 'mock-android-url' }));
+  }
+  return {
+    AndroidPlatformManager,
+  };
+});
+
+const originalCwd = process.cwd();
+
+beforeAll(() => {
+  process.chdir('/');
+});
+
+beforeEach(() => {
+  vol.reset();
+  delete process.env.EXPO_ENABLE_INTERSTITIAL_PAGE;
+});
+
+afterAll(() => {
+  process.chdir(originalCwd);
+  delete process.env.EXPO_ENABLE_INTERSTITIAL_PAGE;
+});
+
+class MockBundlerDevServer extends BundlerDevServer {
+  get name(): string {
+    return 'fake';
+  }
+
+  public async startAsync(options: BundlerStartOptions): Promise<DevServerInstance> {
+    const port = options.port || 3000;
+    this.urlCreator = new UrlCreator(
+      {
+        scheme: options.https ? 'https' : 'http',
+        ...options.location,
+      },
+      {
+        port,
+        getTunnelUrl: this.getTunnelUrl.bind(this),
+      }
+    );
+
+    const protocol = 'http';
+    const host = 'localhost';
+    this.setInstance({
+      // Server instance
+      server: { close: jest.fn((fn) => fn()) },
+      // URL Info
+      location: {
+        url: `${protocol}://${host}:${port}`,
+        port,
+        protocol,
+        host,
+      },
+      middleware: {},
+      // Match the native protocol.
+      messageSocket: {
+        broadcast: jest.fn(),
+      },
+    });
+    await this.postStartAsync(options);
+
+    return this.getInstance();
+  }
+
+  getPublicUrlCreator() {
+    return this.urlCreator;
+  }
+  getNgrok() {
+    return this.ngrok;
+  }
+  getDevSession() {
+    return this.devSession;
+  }
+
+  protected getConfigModuleIds(): string[] {
+    return ['./fake.config.js'];
+  }
+
+  public getExpoGoUrl(platform: 'simulator' | 'emulator') {
+    return super.getExpoGoUrl(platform);
+  }
+}
+
+async function getRunningServer() {
+  const devServer = new MockBundlerDevServer('/');
+  await devServer.startAsync({ location: {} });
+  return devServer;
+}
+
+describe('broadcastMessage', () => {
+  it(`sends a message`, async () => {
+    const devServer = await getRunningServer();
+    devServer.broadcastMessage('reload', { foo: true });
+    expect(devServer.getInstance().messageSocket.broadcast).toBeCalledWith('reload', { foo: true });
+  });
+});
+
+describe('openPlatformAsync', () => {
+  it(`opens a project in the browser`, async () => {
+    const devServer = await getRunningServer();
+    const { url } = await devServer.openPlatformAsync('desktop');
+    expect(url).toBe('http://localhost:3000');
+    expect(openBrowserAsync).toBeCalledWith('http://localhost:3000');
+  });
+
+  for (const platform of ['ios', 'android']) {
+    for (const isDevClient of [false, true]) {
+      const runtime = platform === 'ios' ? 'simulator' : 'emulator';
+      it(`opens an ${platform} project in a ${runtime} (dev client: ${isDevClient})`, async () => {
+        const devServer = await getRunningServer();
+        devServer.isDevClient = isDevClient;
+        const { url } = await devServer.openPlatformAsync(runtime);
+
+        expect(devServer['getPlatformManager'](runtime).openAsync).toHaveBeenNthCalledWith(
+          1,
+          { runtime: isDevClient ? 'custom' : 'expo' },
+          {}
+        );
+
+        expect(url).toBe(platform === 'ios' ? 'mock-apple-url' : 'mock-android-url');
+      });
+    }
+  }
+});
+
+describe('stopAsync', () => {
+  it(`stops a running dev server`, async () => {
+    const server = new MockBundlerDevServer('/');
+    const instance = await server.startAsync({
+      location: {
+        hostType: 'tunnel',
+      },
+    });
+    const ngrok = server.getNgrok();
+    const devSession = server.getNgrok();
+
+    // Ensure services were started.
+    expect(ngrok.startAsync).toHaveBeenCalled();
+    expect(devSession.startAsync).toHaveBeenCalled();
+
+    // Invoke the stop function
+    await server.stopAsync();
+
+    // Ensure services were stopped.
+    expect(instance.server.close).toHaveBeenCalled();
+    expect(ngrok.stopAsync).toHaveBeenCalled();
+    expect(devSession.stopAsync).toHaveBeenCalled();
+    expect(server.getInstance()).toBeNull();
+  });
+});
+
+describe('getExpoGoUrl', () => {
+  it(`gets the interstitial page URL`, async () => {
+    process.env.EXPO_ENABLE_INTERSTITIAL_PAGE = '1';
+    vol.fromJSON(
+      {
+        'node_modules/expo-dev-launcher/package.json': '',
+      },
+      '/'
+    );
+
+    const server = new MockBundlerDevServer('/');
+    await server.startAsync({
+      location: {},
+    });
+
+    const urlCreator = server.getPublicUrlCreator();
+    urlCreator.constructLoadingUrl = jest.fn(urlCreator.constructLoadingUrl);
+
+    expect(server.getExpoGoUrl('emulator')).toBe(
+      'http://100.100.1.100:3000/_expo/loading?platform=android'
+    );
+    expect(server.getExpoGoUrl('simulator')).toBe(
+      'http://127.0.0.1:3000/_expo/loading?platform=ios'
+    );
+    expect(urlCreator.constructLoadingUrl).toBeCalledTimes(2);
+  });
+  it(`gets the native Expo Go URL`, async () => {
+    const server = new MockBundlerDevServer('/');
+    await server.startAsync({
+      location: {},
+    });
+
+    expect(server.getExpoGoUrl('emulator')).toBe('exp://100.100.1.100:3000');
+    expect(server.getExpoGoUrl('simulator')).toBe('exp://100.100.1.100:3000');
+  });
+});
+
+describe('getNativeRuntimeUrl', () => {
+  it(`gets the native runtime URL`, async () => {
+    const server = new MockBundlerDevServer('/');
+    await server.startAsync({
+      location: {},
+    });
+    expect(server.getNativeRuntimeUrl()).toBe('exp://100.100.1.100:3000');
+    expect(server.getNativeRuntimeUrl({ hostname: 'localhost' })).toBe('exp://127.0.0.1:3000');
+    expect(server.getNativeRuntimeUrl({ scheme: 'foobar' })).toBe('exp://100.100.1.100:3000');
+  });
+  it(`gets the native runtime URL for dev client`, async () => {
+    const server = new MockBundlerDevServer('/', true);
+    await server.startAsync({
+      location: {
+        scheme: 'my-app',
+      },
+    });
+    expect(server.getNativeRuntimeUrl()).toBe(
+      'my-app://expo-development-client/?url=http%3A%2F%2F100.100.1.100%3A3000'
+    );
+    expect(server.getNativeRuntimeUrl({ hostname: 'localhost' })).toBe(
+      'my-app://expo-development-client/?url=http%3A%2F%2F127.0.0.1%3A3000'
+    );
+    expect(server.getNativeRuntimeUrl({ scheme: 'foobar' })).toBe(
+      'foobar://expo-development-client/?url=http%3A%2F%2F100.100.1.100%3A3000'
+    );
+  });
+});
+
+describe('_getManifestMiddleware', () => {
+  const server = new MockBundlerDevServer('/');
+  it(`asserts invalid manifest type`, () => {
+    expect(() =>
+      server._getManifestMiddleware({
+        // @ts-expect-error
+        forceManifestType: 'foobar',
+      })
+    ).toThrow(/Manifest middleware for type 'foobar' not found/);
+  });
+  it(`asserts server is not running`, () => {
+    expect(() => server._getManifestMiddleware()).toThrow(/Dev server is not running/);
+  });
+});
+
+describe('_startTunnelAsync', () => {
+  const server = new MockBundlerDevServer('/');
+  it(`returns null when the server isn't running`, async () => {
+    expect(await server._startTunnelAsync()).toEqual(null);
+  });
+});

--- a/packages/expo/cli/start/server/__tests__/openPlatforms-test.ts
+++ b/packages/expo/cli/start/server/__tests__/openPlatforms-test.ts
@@ -8,12 +8,12 @@ const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T
 function createDevServerManager() {
   return {
     getDefaultDevServer: jest.fn(() => ({
-      openPlatformAsync: jest.fn(),
+      openPlatformAsync: jest.fn(async () => {}),
     })),
     getWebDevServer: jest.fn(() => ({
-      openPlatformAsync: jest.fn(),
+      openPlatformAsync: jest.fn(async () => {}),
     })),
-    ensureWebDevServerRunningAsync: jest.fn(() => Promise.resolve()),
+    ensureWebDevServerRunningAsync: jest.fn(async () => {}),
   } as unknown as DevServerManager;
 }
 
@@ -54,7 +54,7 @@ it(`rethrows assertions`, async () => {
   asMock(manager.getDefaultDevServer).mockImplementationOnce(
     () =>
       ({
-        openPlatformAsync() {
+        async openPlatformAsync() {
           throw new Error('Failed');
         },
       } as any)
@@ -66,21 +66,21 @@ it(`rethrows assertions`, async () => {
   };
   await expect(openPlatformsAsync(manager, options)).rejects.toThrow(/Failed/);
 
-  expect(manager.getDefaultDevServer).toHaveBeenCalledTimes(1);
-  expect(manager.getWebDevServer).toHaveBeenCalledTimes(0);
-  expect(manager.ensureWebDevServerRunningAsync).toHaveBeenCalledTimes(0);
+  expect(manager.getDefaultDevServer).toHaveBeenCalledTimes(2);
+  expect(manager.getWebDevServer).toHaveBeenCalledTimes(1);
+  expect(manager.ensureWebDevServerRunningAsync).toHaveBeenCalledTimes(1);
 });
 
 it(`surfaces aborting`, async () => {
   const manager = createDevServerManager();
   asMock(manager.getDefaultDevServer)
     .mockReturnValueOnce({
-      openPlatformAsync() {},
+      async openPlatformAsync() {},
     } as any)
     .mockImplementationOnce(
       () =>
         ({
-          openPlatformAsync() {
+          async openPlatformAsync() {
             throw new AbortCommandError();
           },
         } as any)
@@ -93,6 +93,6 @@ it(`surfaces aborting`, async () => {
   await expect(openPlatformsAsync(manager, options)).rejects.toThrow(AbortCommandError);
 
   expect(manager.getDefaultDevServer).toHaveBeenCalledTimes(2);
-  expect(manager.getWebDevServer).toHaveBeenCalledTimes(0);
-  expect(manager.ensureWebDevServerRunningAsync).toHaveBeenCalledTimes(0);
+  expect(manager.getWebDevServer).toHaveBeenCalledTimes(1);
+  expect(manager.ensureWebDevServerRunningAsync).toHaveBeenCalledTimes(1);
 });

--- a/packages/expo/cli/start/server/__tests__/openPlatforms-test.ts
+++ b/packages/expo/cli/start/server/__tests__/openPlatforms-test.ts
@@ -1,0 +1,98 @@
+import { AbortCommandError } from '../../../utils/errors';
+import { DevServerManager } from '../DevServerManager';
+import { openPlatformsAsync } from '../openPlatforms';
+
+const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
+  fn as jest.MockedFunction<T>;
+
+function createDevServerManager() {
+  return {
+    getDefaultDevServer: jest.fn(() => ({
+      openPlatformAsync: jest.fn(),
+    })),
+    getWebDevServer: jest.fn(() => ({
+      openPlatformAsync: jest.fn(),
+    })),
+    ensureWebDevServerRunningAsync: jest.fn(() => Promise.resolve()),
+  } as unknown as DevServerManager;
+}
+
+it(`opens all platforms`, async () => {
+  const options = {
+    android: true,
+    ios: true,
+    web: true,
+  };
+
+  const manager = createDevServerManager();
+  const openedNative = await openPlatformsAsync(manager, options);
+  expect(openedNative).toBe(true);
+
+  expect(manager.getDefaultDevServer).toHaveBeenCalledTimes(2);
+  expect(manager.getWebDevServer).toHaveBeenCalledTimes(1);
+  expect(manager.ensureWebDevServerRunningAsync).toHaveBeenCalledTimes(1);
+});
+
+it(`opens web only`, async () => {
+  const options = {
+    android: false,
+    ios: false,
+    web: true,
+  };
+  const manager = createDevServerManager();
+
+  const openedNative = await openPlatformsAsync(manager, options);
+  expect(openedNative).toBe(false);
+
+  expect(manager.getDefaultDevServer).toHaveBeenCalledTimes(0);
+  expect(manager.getWebDevServer).toHaveBeenCalledTimes(1);
+  expect(manager.ensureWebDevServerRunningAsync).toHaveBeenCalledTimes(1);
+});
+
+it(`rethrows assertions`, async () => {
+  const manager = createDevServerManager();
+  asMock(manager.getDefaultDevServer).mockImplementationOnce(
+    () =>
+      ({
+        openPlatformAsync() {
+          throw new Error('Failed');
+        },
+      } as any)
+  );
+  const options = {
+    android: true,
+    ios: true,
+    web: true,
+  };
+  await expect(openPlatformsAsync(manager, options)).rejects.toThrow(/Failed/);
+
+  expect(manager.getDefaultDevServer).toHaveBeenCalledTimes(1);
+  expect(manager.getWebDevServer).toHaveBeenCalledTimes(0);
+  expect(manager.ensureWebDevServerRunningAsync).toHaveBeenCalledTimes(0);
+});
+
+it(`surfaces aborting`, async () => {
+  const manager = createDevServerManager();
+  asMock(manager.getDefaultDevServer)
+    .mockReturnValueOnce({
+      openPlatformAsync() {},
+    } as any)
+    .mockImplementationOnce(
+      () =>
+        ({
+          openPlatformAsync() {
+            throw new AbortCommandError();
+          },
+        } as any)
+    );
+  const options = {
+    android: true,
+    ios: true,
+    web: true,
+  };
+  await expect(openPlatformsAsync(manager, options)).rejects.toThrow(AbortCommandError);
+
+  expect(manager.getDefaultDevServer).toHaveBeenCalledTimes(2);
+  expect(manager.getWebDevServer).toHaveBeenCalledTimes(0);
+  expect(manager.ensureWebDevServerRunningAsync).toHaveBeenCalledTimes(0);
+});

--- a/packages/expo/cli/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/expo/cli/start/server/metro/MetroBundlerDevServer.ts
@@ -28,7 +28,7 @@ export class MetroBundlerDevServer extends BundlerDevServer {
         ? // Don't check if the port is busy if we're using the dev client since most clients are hardcoded to 8081.
           Number(process.env.RCT_METRO_PORT) || DEV_CLIENT_METRO_PORT
         : // Otherwise (running in Expo Go) use a free port that falls back on the classic 19000 port.
-          await getFreePortAsync(options.port || EXPO_GO_METRO_PORT));
+          await getFreePortAsync(EXPO_GO_METRO_PORT));
 
     this.urlCreator = new UrlCreator(options.location, {
       port,

--- a/packages/expo/cli/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/expo/cli/start/server/metro/MetroBundlerDevServer.ts
@@ -70,13 +70,10 @@ export class MetroBundlerDevServer extends BundlerDevServer {
       },
       getLocation: ({ runtime }) => {
         if (runtime === 'custom') {
-          return this.urlCreator.constructDevClientUrl({
-            hostType: 'localhost',
-          });
+          return this.urlCreator.constructDevClientUrl();
         } else {
           return this.urlCreator.constructUrl({
             scheme: 'exp',
-            hostname: 'localhost',
           });
         }
       },

--- a/packages/expo/cli/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/expo/cli/start/server/metro/MetroBundlerDevServer.ts
@@ -1,0 +1,119 @@
+import { prependMiddleware } from '@expo/dev-server';
+
+import { getFreePortAsync } from '../../../utils/port';
+import { BundlerDevServer, BundlerStartOptions, DevServerInstance } from '../BundlerDevServer';
+import { UrlCreator } from '../UrlCreator';
+import { InterstitialPageMiddleware } from '../middleware/InterstitialPageMiddleware';
+import { RuntimeRedirectMiddleware } from '../middleware/RuntimeRedirectMiddleware';
+import { instantiateMetroAsync } from './instantiateMetro';
+
+/** Default port to use for apps running in Expo Go. */
+const EXPO_GO_METRO_PORT = 19000;
+
+/** Default port to use for apps that run in standard React Native projects or Expo Dev Clients. */
+const DEV_CLIENT_METRO_PORT = 8081;
+
+export class MetroBundlerDevServer extends BundlerDevServer {
+  get name(): string {
+    return 'metro';
+  }
+
+  async startAsync(options: BundlerStartOptions): Promise<DevServerInstance> {
+    await this.stopAsync();
+    const port =
+      // If the manually defined port is busy then an error should be thrown...
+      options.port ??
+      // Otherwise use the default port based on the runtime target.
+      (options.devClient
+        ? // Don't check if the port is busy if we're using the dev client since most clients are hardcoded to 8081.
+          Number(process.env.RCT_METRO_PORT) || DEV_CLIENT_METRO_PORT
+        : // Otherwise (running in Expo Go) use a free port that falls back on the classic 19000 port.
+          await getFreePortAsync(options.port || EXPO_GO_METRO_PORT));
+
+    this.urlCreator = new UrlCreator(options.location, {
+      port,
+      getTunnelUrl: this.getTunnelUrl.bind(this),
+    });
+
+    const parsedOptions = {
+      port,
+      maxWorkers: options.maxWorkers,
+      resetCache: options.resetDevServer,
+
+      // Use the unversioned metro config.
+      // TODO: Deprecate this property when expo-cli goes away.
+      unversioned: false,
+    };
+
+    const { server, middleware, messageSocket } = await instantiateMetroAsync(
+      this.projectRoot,
+      parsedOptions
+    );
+
+    const manifestMiddleware = this._getManifestMiddleware(options);
+
+    // We need the manifest handler to be the first middleware to run so our
+    // routes take precedence over static files. For example, the manifest is
+    // served from '/' and if the user has an index.html file in their project
+    // then the manifest handler will never run, the static middleware will run
+    // and serve index.html instead of the manifest.
+    // https://github.com/expo/expo/issues/13114
+    prependMiddleware(middleware, manifestMiddleware);
+
+    middleware.use(new InterstitialPageMiddleware(this.projectRoot).getHandler());
+
+    const deepLinkMiddleware = new RuntimeRedirectMiddleware(this.projectRoot, {
+      onDeepLink: ({ runtime }) => {
+        // eslint-disable-next-line no-useless-return
+        if (runtime === 'expo') return;
+        // TODO: Some heavy analytics...
+      },
+      getLocation: ({ runtime }) => {
+        if (runtime === 'custom') {
+          return this.urlCreator.constructDevClientUrl({
+            hostType: 'localhost',
+          });
+        } else {
+          return this.urlCreator.constructUrl({
+            scheme: 'exp',
+            hostname: 'localhost',
+          });
+        }
+      },
+    });
+    middleware.use(deepLinkMiddleware.getHandler());
+
+    // Extend the close method to ensure that we clean up the local info.
+    const originalClose = server.close.bind(server);
+
+    server.close = (callback?: (err?: Error) => void) => {
+      return originalClose((err?: Error) => {
+        this.instance = null;
+        callback?.(err);
+      });
+    };
+
+    this.setInstance({
+      server,
+      location: {
+        // The port is the main thing we want to send back.
+        port,
+        // localhost isn't always correct.
+        host: 'localhost',
+        // http is the only supported protocol on native.
+        url: `http://localhost:${port}`,
+        protocol: 'http',
+      },
+      middleware,
+      messageSocket,
+    });
+
+    await this.postStartAsync(options);
+
+    return this.instance;
+  }
+
+  protected getConfigModuleIds(): string[] {
+    return ['./metro.config.js', './metro.config.json', './rn-cli.config.js'];
+  }
+}

--- a/packages/expo/cli/start/server/metro/__tests__/MetroBundlerDevServer-test.ts
+++ b/packages/expo/cli/start/server/metro/__tests__/MetroBundlerDevServer-test.ts
@@ -1,0 +1,52 @@
+import { vol } from 'memfs';
+
+import { BundlerStartOptions } from '../../BundlerDevServer';
+import { MetroBundlerDevServer } from '../MetroBundlerDevServer';
+import { instantiateMetroAsync } from '../instantiateMetro';
+
+jest.mock('../instantiateMetro', () => ({
+  instantiateMetroAsync: jest.fn(async () => ({
+    middleware: { use: jest.fn() },
+    server: { listen: jest.fn(), close: jest.fn() },
+  })),
+}));
+jest.mock('../../../../log');
+
+beforeEach(() => {
+  vol.reset();
+});
+
+async function getStartedDevServer(options: Partial<BundlerStartOptions> = {}) {
+  const devServer = new MetroBundlerDevServer('/', false);
+  devServer['getAvailablePortAsync'] = jest.fn(() => Promise.resolve(3000));
+  // Tested in the superclass
+  devServer['postStartAsync'] = jest.fn(async () => {});
+  await devServer.startAsync({ location: {}, ...options });
+  return devServer;
+}
+
+describe('startAsync', () => {
+  it(`starts metro`, async () => {
+    const devServer = await getStartedDevServer();
+
+    expect(devServer['postStartAsync']).toHaveBeenCalled();
+
+    expect(devServer.getInstance()).toEqual({
+      location: {
+        host: 'localhost',
+        port: 19000,
+        protocol: 'http',
+        url: 'http://localhost:19000',
+      },
+      middleware: {
+        use: expect.any(Function),
+      },
+      server: {
+        close: expect.any(Function),
+        listen: expect.any(Function),
+      },
+    });
+
+    expect(instantiateMetroAsync).toHaveBeenCalled();
+  });
+});

--- a/packages/expo/cli/start/server/metro/instantiateMetro.ts
+++ b/packages/expo/cli/start/server/metro/instantiateMetro.ts
@@ -1,0 +1,70 @@
+import { MetroDevServerOptions } from '@expo/dev-server';
+import http from 'http';
+import Metro from 'metro';
+// import { Terminal } from 'metro-core';
+// import { MetroTerminalReporter } from './MetroTerminalReporter';
+
+import { createDevServerMiddleware } from '../middleware/createDevServerMiddleware';
+import { importExpoMetroConfigFromProject, importMetroFromProject } from './resolveFromProject';
+
+// From expo/dev-server but with ability to use custom logger.
+type MessageSocket = {
+  broadcast: (method: string, params?: Record<string, any> | undefined) => void;
+};
+
+/** The most generic possible setup for Metro bundler. */
+export async function instantiateMetroAsync(
+  projectRoot: string,
+  options: Omit<MetroDevServerOptions, 'logger'>
+): Promise<{
+  server: http.Server;
+  middleware: any;
+  messageSocket: MessageSocket;
+}> {
+  let reportEvent: ((event: any) => void) | undefined;
+
+  const Metro = importMetroFromProject(projectRoot);
+  const ExpoMetroConfig = importExpoMetroConfigFromProject(projectRoot);
+
+  // const terminal = new Terminal(process.stdout);
+  // const terminalReporter = new MetroTerminalReporter(projectRoot, terminal);
+
+  const reporter = {
+    update(event: any) {
+      // terminalReporter.update(event);
+      if (reportEvent) {
+        reportEvent(event);
+      }
+    },
+  };
+
+  const metroConfig = await ExpoMetroConfig.loadAsync(projectRoot, { reporter, ...options });
+
+  const { middleware, attachToServer } = createDevServerMiddleware({
+    port: metroConfig.server.port,
+    watchFolders: metroConfig.watchFolders,
+  });
+
+  const customEnhanceMiddleware = metroConfig.server.enhanceMiddleware;
+  // @ts-ignore can't mutate readonly config
+  metroConfig.server.enhanceMiddleware = (metroMiddleware: any, server: Metro.Server) => {
+    if (customEnhanceMiddleware) {
+      metroMiddleware = customEnhanceMiddleware(metroMiddleware, server);
+    }
+    return middleware.use(metroMiddleware);
+  };
+
+  const server = await Metro.runServer(metroConfig, {
+    // @ts-expect-error: TODO: Update the types.
+    hmrEnabled: true,
+  });
+
+  const { messageSocket, eventsSocket } = attachToServer(server);
+  reportEvent = eventsSocket.reportEvent;
+
+  return {
+    server,
+    middleware,
+    messageSocket,
+  };
+}

--- a/packages/expo/cli/start/server/metro/resolveFromProject.ts
+++ b/packages/expo/cli/start/server/metro/resolveFromProject.ts
@@ -7,7 +7,7 @@ class MetroImportError extends Error {
   constructor(projectRoot: string, moduleId: string) {
     super(
       `Missing package "${moduleId}" in the project at: ${projectRoot}\n` +
-        'This usually means `react-native` is not installed. ' +
+        'This usually means "react-native" is not installed. ' +
         'Please verify that dependencies in package.json include "react-native" ' +
         'and run `yarn` or `npm install`.'
     );

--- a/packages/expo/cli/start/server/metro/resolveFromProject.ts
+++ b/packages/expo/cli/start/server/metro/resolveFromProject.ts
@@ -1,0 +1,39 @@
+import resolveFrom from 'resolve-from';
+
+// These resolvers enable us to test the CLI in older projects.
+// We may be able to get rid of this in the future.
+// TODO: Maybe combine with AsyncResolver?
+class MetroImportError extends Error {
+  constructor(projectRoot: string, moduleId: string) {
+    super(
+      `Missing package "${moduleId}" in the project at: ${projectRoot}\n` +
+        'This usually means `react-native` is not installed. ' +
+        'Please verify that dependencies in package.json include "react-native" ' +
+        'and run `yarn` or `npm install`.'
+    );
+  }
+}
+
+function resolveFromProject(projectRoot: string, moduleId: string) {
+  const resolvedPath = resolveFrom.silent(projectRoot, moduleId);
+  if (!resolvedPath) {
+    throw new MetroImportError(projectRoot, moduleId);
+  }
+  return resolvedPath;
+}
+
+function importFromProject(projectRoot: string, moduleId: string) {
+  return require(resolveFromProject(projectRoot, moduleId));
+}
+
+/** Import `metro` from the project. */
+export function importMetroFromProject(projectRoot: string): typeof import('metro') {
+  return importFromProject(projectRoot, 'metro');
+}
+
+/** Import `@expo/metro-config` from the project. */
+export function importExpoMetroConfigFromProject(
+  projectRoot: string
+): typeof import('@expo/metro-config') {
+  return importFromProject(projectRoot, '@expo/metro-config');
+}

--- a/packages/expo/cli/start/server/middleware/createDevServerMiddleware.ts
+++ b/packages/expo/cli/start/server/middleware/createDevServerMiddleware.ts
@@ -1,0 +1,25 @@
+import { createDevServerMiddleware as originalCreate } from '@expo/dev-server';
+
+export function createDevServerMiddleware({
+  watchFolders,
+  port,
+}: {
+  watchFolders: readonly string[];
+  port: number;
+}) {
+  const shim = function () {};
+
+  return originalCreate({
+    // Attach a fake logger to the expo `/logs` middleware so we can collect devices for analytics.
+    // We utilize the WebSocket logs now so we don't need to print anything.
+    // TODO: Migrate to a system that uses WebSockets so we can detect when a device disconnects.
+    logger: {
+      info: shim,
+      warn: shim,
+      error: shim,
+      debug: shim,
+    } as any,
+    port,
+    watchFolders,
+  });
+}

--- a/packages/expo/cli/start/server/openPlatforms.ts
+++ b/packages/expo/cli/start/server/openPlatforms.ts
@@ -17,14 +17,7 @@ export async function openPlatformsAsync(
       : null,
   ]);
 
-  const errors = results
-    .reduce<Error[]>((prev, curr) => {
-      if (curr instanceof Error) {
-        prev.push(curr);
-      }
-      return prev;
-    }, [])
-    .filter(Boolean);
+  const errors = results.map(result => result.reason).filter(Boolean);
 
   if (errors.length) {
     // ctrl+c

--- a/packages/expo/cli/start/server/openPlatforms.ts
+++ b/packages/expo/cli/start/server/openPlatforms.ts
@@ -1,0 +1,39 @@
+import { AbortCommandError } from '../../utils/errors';
+import { Options } from '../resolveOptions';
+import { DevServerManager } from './DevServerManager';
+
+/** Launch the app on various platforms in parallel. */
+export async function openPlatformsAsync(
+  devServerManager: DevServerManager,
+  options: Pick<Options, 'ios' | 'android' | 'web'>
+) {
+  const results = await Promise.allSettled([
+    options.android ? devServerManager.getDefaultDevServer().openPlatformAsync('emulator') : null,
+    options.ios ? devServerManager.getDefaultDevServer().openPlatformAsync('simulator') : null,
+    options.web
+      ? devServerManager
+          .ensureWebDevServerRunningAsync()
+          .then(() => devServerManager.getWebDevServer().openPlatformAsync('desktop'))
+      : null,
+  ]);
+
+  const errors = results
+    .reduce<Error[]>((prev, curr) => {
+      if (curr instanceof Error) {
+        prev.push(curr);
+      }
+      return prev;
+    }, [])
+    .filter(Boolean);
+
+  if (errors.length) {
+    // ctrl+c
+    const isEscapedError = errors.some((error: any) => error.code === 'ABORTED');
+    if (isEscapedError) {
+      throw new AbortCommandError();
+    }
+    throw errors[0];
+  }
+
+  return !!options.android || !!options.ios;
+}

--- a/packages/expo/cli/start/server/openPlatforms.ts
+++ b/packages/expo/cli/start/server/openPlatforms.ts
@@ -17,7 +17,9 @@ export async function openPlatformsAsync(
       : null,
   ]);
 
-  const errors = results.map(result => result.reason).filter(Boolean);
+  const errors = results
+    .map((result) => (result.status === 'rejected' ? result.reason : null))
+    .filter(Boolean);
 
   if (errors.length) {
     // ctrl+c

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -130,6 +130,8 @@
   "devDependencies": {
     "@expo/ngrok": "4.1.0",
     "@swc/core": "^1.2.126",
+    "@types/metro": "~0.66.1",
+    "@types/metro-core": "~0.66.0",
     "@taskr/clear": "1.1.0",
     "@taskr/esnext": "1.1.0",
     "@taskr/watch": "1.1.0",
@@ -149,7 +151,6 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-native": "0.67.2",
-    "taskr": "1.1.0",
-    "@expo/ngrok": "4.1.0"
+    "taskr": "1.1.0"
   }
 }


### PR DESCRIPTION
# Why

- Split out of https://github.com/expo/expo/pull/16517
- Pending https://github.com/expo/expo/pull/16560

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

- Implements a general bundler dev server module which we extend to add Metro support.
- For PR simplicity the logging, and webpack parts of this PR have been omitted.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- Added tests.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
