### PR TITLE
[home] redesign settings tab

### DIFF
--- a/home/components/RedesignedSectionHeader.tsx
+++ b/home/components/RedesignedSectionHeader.tsx
@@ -6,7 +6,7 @@ type Props = {
   header: string;
 };
 
-export function TextHeader({ header }: Props) {
+export function RedesignedSectionHeader({ header }: Props) {
   return (
     <Row px="small" py="small" align="center" justify="between">
       <Heading

--- a/home/navigation/Navigation.tsx
+++ b/home/navigation/Navigation.tsx
@@ -14,6 +14,7 @@ import * as React from 'react';
 import { Platform, StyleSheet, Linking } from 'react-native';
 import { HomeScreen } from 'screens/HomeScreen';
 import { RedesignedDiagnosticsScreen } from 'screens/RedesignedDiagnosticsScreen';
+import { RedesignedSettingsScreen } from 'screens/RedesignedSettingsScreen';
 
 import FeatureFlags from '../FeatureFlags';
 import OpenProjectByURLButton from '../components/OpenProjectByURLButton.ios';
@@ -142,7 +143,14 @@ function SettingsStackScreen() {
     <SettingsStack.Navigator
       initialRouteName="Settings"
       screenOptions={defaultNavigationOptions(themeName)}>
-      <SettingsStack.Screen name="Settings" component={UserSettingsScreen} />
+      <SettingsStack.Screen
+        name="Settings"
+        component={
+          FeatureFlags.ENABLE_2022_NAVIGATION_REDESIGN
+            ? RedesignedSettingsScreen
+            : UserSettingsScreen
+        }
+      />
     </SettingsStack.Navigator>
   );
 }
@@ -177,7 +185,7 @@ function ProfileStackScreen() {
       />
       <ProfileStack.Screen
         name="UserSettings"
-        component={UserSettingsScreen}
+        component={RedesignedSettingsScreen}
         options={{ title: 'Options' }}
       />
       <ProfileStack.Screen

--- a/home/screens/HomeScreen/DevelopmentServersOpenQR.tsx
+++ b/home/screens/HomeScreen/DevelopmentServersOpenQR.tsx
@@ -1,0 +1,41 @@
+import { iconSize, QrCodeIcon, spacing } from '@expo/styleguide-native';
+import { NavigationProp, useNavigation } from '@react-navigation/native';
+import { Divider, Row, Text, useExpoTheme } from 'expo-dev-client-components';
+import * as React from 'react';
+
+import { PressableOpacity } from '../../components/PressableOpacity';
+import { ModalStackRoutes } from '../../navigation/Navigation.types';
+import {
+  alertWithCameraPermissionInstructions,
+  requestCameraPermissionsAsync,
+} from '../../utils/PermissionUtils';
+
+export function DevelopmentServersOpenQR() {
+  const theme = useExpoTheme();
+
+  const navigation = useNavigation<NavigationProp<ModalStackRoutes>>();
+
+  const handleQRPressAsync = async () => {
+    if (await requestCameraPermissionsAsync()) {
+      navigation.navigate('QRCode');
+    } else {
+      await alertWithCameraPermissionInstructions();
+    }
+  };
+
+  return (
+    <>
+      <Divider />
+      <PressableOpacity onPress={handleQRPressAsync}>
+        <Row padding="medium" align="center">
+          <QrCodeIcon
+            size={iconSize.small}
+            style={{ marginRight: spacing[2] }}
+            color={theme.icon.default}
+          />
+          <Text>Scan QR code</Text>
+        </Row>
+      </PressableOpacity>
+    </>
+  );
+}

--- a/home/screens/HomeScreen/DevelopmentServersPlaceholder.tsx
+++ b/home/screens/HomeScreen/DevelopmentServersPlaceholder.tsx
@@ -1,31 +1,13 @@
-import { iconSize, QrCodeIcon, spacing } from '@expo/styleguide-native';
-import { NavigationProp, useNavigation } from '@react-navigation/native';
+import { spacing } from '@expo/styleguide-native';
 import FeatureFlags from 'FeatureFlags';
-import { Divider, Row, Text, useExpoTheme, View } from 'expo-dev-client-components';
+import { Text, View } from 'expo-dev-client-components';
 import * as React from 'react';
 import { Platform } from 'react-native';
 
-import { PressableOpacity } from '../../components/PressableOpacity';
-import { ModalStackRoutes } from '../../navigation/Navigation.types';
-import {
-  alertWithCameraPermissionInstructions,
-  requestCameraPermissionsAsync,
-} from '../../utils/PermissionUtils';
+import { DevelopmentServersOpenQR } from './DevelopmentServersOpenQR';
 import { DevelopmentServersOpenURL } from './DevelopmentServersOpenURL';
 
 export function DevelopmentServersPlaceholder() {
-  const theme = useExpoTheme();
-
-  const navigation = useNavigation<NavigationProp<ModalStackRoutes>>();
-
-  const handleQRPressAsync = async () => {
-    if (await requestCameraPermissionsAsync()) {
-      navigation.navigate('QRCode');
-    } else {
-      await alertWithCameraPermissionInstructions();
-    }
-  };
-
   return (
     <View bg="default" rounded="large" border="hairline" overflow="hidden">
       <View padding="medium">
@@ -48,19 +30,7 @@ export function DevelopmentServersPlaceholder() {
         <DevelopmentServersOpenURL />
       ) : null}
       {FeatureFlags.ENABLE_PROJECT_TOOLS && FeatureFlags.ENABLE_QR_CODE_BUTTON ? (
-        <>
-          <Divider />
-          <PressableOpacity onPress={handleQRPressAsync}>
-            <Row padding="medium" align="center">
-              <QrCodeIcon
-                size={iconSize.small}
-                style={{ marginRight: spacing[2] }}
-                color={theme.icon.default}
-              />
-              <Text>Scan QR code</Text>
-            </Row>
-          </PressableOpacity>
-        </>
+        <DevelopmentServersOpenQR />
       ) : null}
     </View>
   );

--- a/home/screens/HomeScreen/HomeScreenView.tsx
+++ b/home/screens/HomeScreen/HomeScreenView.tsx
@@ -16,6 +16,7 @@ import ApiV2HttpClient from '../../api/ApiV2HttpClient';
 import ApolloClient from '../../api/ApolloClient';
 import Connectivity from '../../api/Connectivity';
 import ScrollView from '../../components/NavigationScrollView';
+import { RedesignedSectionHeader } from '../../components/RedesignedSectionHeader';
 import RefreshControl from '../../components/RefreshControl';
 import ThemedStatusBar from '../../components/ThemedStatusBar';
 import { HomeStackRoutes } from '../../navigation/Navigation.types';
@@ -25,13 +26,13 @@ import addListenerWithNativeCallback from '../../utils/addListenerWithNativeCall
 import getSnackId from '../../utils/getSnackId';
 import { DevelopmentServerListItem } from './DevelopmentServerListItem';
 import { DevelopmentServersHeader } from './DevelopmentServersHeader';
+import { DevelopmentServersOpenQR } from './DevelopmentServersOpenQR';
 import { DevelopmentServersOpenURL } from './DevelopmentServersOpenURL';
 import { DevelopmentServersPlaceholder } from './DevelopmentServersPlaceholder';
 import { ProjectsSection } from './ProjectsSection';
 import { RecentlyOpenedHeader } from './RecentlyOpenedHeader';
 import { RecentlyOpenedSection } from './RecentlyOpenedSection';
 import { SnacksSection } from './SnacksSection';
-import { TextHeader } from './TextHeader';
 
 const PROJECT_UPDATE_INTERVAL = 10000;
 
@@ -123,6 +124,9 @@ export class HomeScreenView extends React.Component<Props, State> {
                   {projects.length > 1 && i !== projects.length - 1 ? <Divider /> : null}
                 </React.Fragment>
               ))}
+              {FeatureFlags.ENABLE_PROJECT_TOOLS && FeatureFlags.ENABLE_QR_CODE_BUTTON ? (
+                <DevelopmentServersOpenQR />
+              ) : null}
               {FeatureFlags.ENABLE_PROJECT_TOOLS && FeatureFlags.ENABLE_CLIPBOARD_BUTTON ? (
                 <DevelopmentServersOpenURL />
               ) : null}
@@ -140,7 +144,7 @@ export class HomeScreenView extends React.Component<Props, State> {
           {currentUser?.apps.length ? (
             <>
               <Spacer.Vertical size="medium" />
-              <TextHeader header="Projects" />
+              <RedesignedSectionHeader header="Projects" />
               <ProjectsSection
                 accountName={currentUser.username}
                 apps={currentUser.apps.slice(0, 3)}
@@ -151,7 +155,7 @@ export class HomeScreenView extends React.Component<Props, State> {
           {currentUser?.snacks.length ? (
             <>
               <Spacer.Vertical size="medium" />
-              <TextHeader header="Snacks" />
+              <RedesignedSectionHeader header="Snacks" />
               <SnacksSection
                 accountName={currentUser.username}
                 snacks={currentUser.snacks.slice(0, 3)}

--- a/home/screens/RedesignedSettingsScreen/CheckListItem.tsx
+++ b/home/screens/RedesignedSettingsScreen/CheckListItem.tsx
@@ -1,0 +1,29 @@
+import { CheckIcon, iconSize } from '@expo/styleguide-native';
+import { Row, Spacer, Text, useExpoTheme } from 'expo-dev-client-components';
+import React, { ReactNode } from 'react';
+
+import { PressableOpacity } from '../../components/PressableOpacity';
+
+type Props = {
+  onPress: () => void;
+  icon?: ReactNode;
+  title: string;
+  checked?: boolean;
+};
+
+export function CheckListItem({ onPress, icon, title, checked }: Props) {
+  const theme = useExpoTheme();
+
+  return (
+    <PressableOpacity onPress={onPress} containerProps={{ bg: 'default' }}>
+      <Row align="center" justify="between" padding="medium">
+        <Row align="center">
+          {icon}
+          {icon ? <Spacer.Horizontal size="small" /> : null}
+          <Text size="medium">{title}</Text>
+        </Row>
+        {checked ? <CheckIcon size={iconSize.regular} color={theme.icon.default} /> : null}
+      </Row>
+    </PressableOpacity>
+  );
+}

--- a/home/screens/RedesignedSettingsScreen/ConstantsSection.tsx
+++ b/home/screens/RedesignedSettingsScreen/ConstantsSection.tsx
@@ -1,0 +1,62 @@
+import Constants from 'expo-constants';
+import { View, Text, Row, Divider } from 'expo-dev-client-components';
+import * as React from 'react';
+import { Clipboard } from 'react-native';
+
+import { PressableOpacity } from '../../components/PressableOpacity';
+import Environment from '../../utils/Environment';
+import getSnackId from '../../utils/getSnackId';
+
+export function ConstantsSection() {
+  const copySnackIdToClipboard = () => {
+    Clipboard.setString(getSnackId());
+
+    // Should have some integrated alert banner
+    alert('The device ID has been copied to your clipboard');
+  };
+
+  const copyClientVersionToClipboard = () => {
+    if (Constants.expoVersion) {
+      Clipboard.setString(Constants.expoVersion);
+      alert(`The app's version has been copied to your clipboard.`);
+    } else {
+      // this should not ever happen
+      alert(`Something went wrong - the app's version is not available.`);
+    }
+  };
+
+  return (
+    <View bg="default" border="hairline" overflow="hidden" rounded="large">
+      <ConstantItem title="Device ID" value={getSnackId()} onPress={copySnackIdToClipboard} />
+      <Divider />
+      {Constants.expoVersion ? (
+        <>
+          <ConstantItem
+            title="Client version"
+            value={Constants.expoVersion}
+            onPress={copyClientVersionToClipboard}
+          />
+          <Divider />
+        </>
+      ) : null}
+      <ConstantItem title="Supported SDKs" value={Environment.supportedSdksString} />
+    </View>
+  );
+}
+
+type ConstantItemProps = {
+  title: string;
+  value: string;
+  onPress?: () => void;
+};
+
+function ConstantItem({ title, value, onPress }: ConstantItemProps) {
+  return (
+    <PressableOpacity onPress={onPress}>
+      <Row justify="between" align="center" padding="medium">
+        <Text>{title}</Text>
+        <Text>{value}</Text>
+      </Row>
+    </PressableOpacity>
+  );
+}

--- a/home/screens/RedesignedSettingsScreen/DevMenuGestureSection.tsx
+++ b/home/screens/RedesignedSettingsScreen/DevMenuGestureSection.tsx
@@ -1,0 +1,67 @@
+import { iconSize } from '@expo/styleguide-native';
+import { Divider, Text, useExpoTheme, View } from 'expo-dev-client-components';
+import * as React from 'react';
+
+import { RedesignedSectionHeader } from '../../components/RedesignedSectionHeader';
+import { useDispatch, useSelector } from '../../redux/Hooks';
+import SettingsActions from '../../redux/SettingsActions';
+import { CheckListItem } from './CheckListItem';
+import { ShakeDeviceIcon } from './ShakeDeviceIcon';
+import { ThreeFingerPressIcon } from './ThreeFingerPressIcon';
+
+export function DevMenuGestureSection() {
+  const dispatch = useDispatch();
+  const devMenuSettings = useSelector((data) => data.settings.devMenuSettings);
+
+  const onToggleMotionGesture = React.useCallback(() => {
+    dispatch(
+      SettingsActions.setDevMenuSetting(
+        'motionGestureEnabled',
+        !devMenuSettings?.motionGestureEnabled
+      )
+    );
+  }, [dispatch, devMenuSettings]);
+
+  const onToggleTouchGesture = React.useCallback(() => {
+    dispatch(
+      SettingsActions.setDevMenuSetting(
+        'touchGestureEnabled',
+        !devMenuSettings?.touchGestureEnabled
+      )
+    );
+  }, [dispatch, devMenuSettings]);
+
+  const theme = useExpoTheme();
+
+  if (!devMenuSettings) {
+    return null;
+  }
+
+  return (
+    <View>
+      <RedesignedSectionHeader header="Developer Menu Gestures" />
+      <View bg="default" overflow="hidden" rounded="large" border="hairline">
+        <CheckListItem
+          icon={<ShakeDeviceIcon color={theme.icon.default} size={iconSize.regular} />}
+          title="Shake device"
+          checked={devMenuSettings.motionGestureEnabled}
+          onPress={onToggleMotionGesture}
+        />
+        <Divider />
+        <CheckListItem
+          icon={<ThreeFingerPressIcon color={theme.icon.default} size={iconSize.regular} />}
+          title="Three-finger long press"
+          checked={devMenuSettings.touchGestureEnabled}
+          onPress={onToggleTouchGesture}
+        />
+      </View>
+      <View py="small" px="medium">
+        <Text size="small" color="secondary">
+          Selected gestures will toggle the developer menu while inside an experience. The menu
+          allows you to reload or return to home in a published experience, and exposes developer
+          tools in development mode.
+        </Text>
+      </View>
+    </View>
+  );
+}

--- a/home/screens/RedesignedSettingsScreen/RadioListItem.tsx
+++ b/home/screens/RedesignedSettingsScreen/RadioListItem.tsx
@@ -1,0 +1,47 @@
+import { Row, Spacer, Text, useExpoTheme, View } from 'expo-dev-client-components';
+import React, { ReactNode } from 'react';
+
+import { PressableOpacity } from '../../components/PressableOpacity';
+
+type Props = {
+  onPress: () => void;
+  icon?: ReactNode;
+  title: string;
+  checked?: boolean;
+};
+
+export function RadioListItem({ onPress, icon, title, checked }: Props) {
+  const theme = useExpoTheme();
+
+  return (
+    <PressableOpacity onPress={onPress} containerProps={{ bg: 'default' }}>
+      <Row align="center" justify="between" padding="medium">
+        <Row align="center">
+          {icon}
+          {icon ? <Spacer.Horizontal size="small" /> : null}
+          <Text size="medium">{title}</Text>
+        </Row>
+        <View
+          style={{
+            height: 20,
+            width: 20,
+            borderRadius: 10,
+            borderWidth: 1,
+            borderColor: theme.icon.secondary,
+          }}
+          align="centered">
+          {checked ? (
+            <View
+              style={{
+                height: 12,
+                width: 12,
+                borderRadius: 10,
+                backgroundColor: theme.icon.default,
+              }}
+            />
+          ) : null}
+        </View>
+      </Row>
+    </PressableOpacity>
+  );
+}

--- a/home/screens/RedesignedSettingsScreen/ShakeDeviceIcon.tsx
+++ b/home/screens/RedesignedSettingsScreen/ShakeDeviceIcon.tsx
@@ -1,0 +1,59 @@
+import { IconProps } from '@expo/styleguide-native/dist/types';
+import { useExpoTheme } from 'expo-dev-client-components';
+import * as React from 'react';
+import Svg, { SvgProps, G, Path, Defs, ClipPath, Rect } from 'react-native-svg';
+
+export function ShakeDeviceIcon(props: SvgProps & IconProps) {
+  const { size, color, width, height } = props;
+  const theme = useExpoTheme();
+
+  return (
+    <Svg width={size || width || 20} height={size || height || 20} viewBox="0 0 20 21" fill="none">
+      <G clipPath="url(#clip0_1037_1797)">
+        <Rect
+          x="4.75"
+          y="1.25"
+          width="10.5"
+          height="18.5"
+          rx="1.25"
+          stroke={color}
+          strokeWidth="1.5"
+        />
+        <Path
+          d="M2.77246 9.16799C2.77246 7.08248 4.4631 5.39185 6.54861 5.39185C7.10089 5.39185 7.54861 4.94413 7.54861 4.39185C7.54861 3.83956 7.10089 3.39185 6.54861 3.39185C3.35853 3.39185 0.772461 5.97792 0.772461 9.16799C0.772461 12.3581 3.35853 14.9441 6.54861 14.9441C7.10089 14.9441 7.54861 14.4964 7.54861 13.9441C7.54861 13.3919 7.10089 12.9441 6.54861 12.9441C4.4631 12.9441 2.77246 11.2535 2.77246 9.16799Z"
+          fill={color}
+          stroke={theme.background.default}
+          strokeLinecap="round"
+        />
+        <Path
+          d="M5.08734 9.16803C5.08734 8.18394 5.88511 7.38617 6.86921 7.38617C7.38574 7.38617 7.80448 6.96744 7.80448 6.4509C7.80448 5.93436 7.38574 5.51562 6.86921 5.51562C4.85204 5.51562 3.2168 7.15086 3.2168 9.16803C3.2168 11.1852 4.85204 12.8204 6.86921 12.8204C7.38574 12.8204 7.80448 12.4017 7.80448 11.8852C7.80448 11.3686 7.38574 10.9499 6.86921 10.9499C5.88511 10.9499 5.08734 10.1521 5.08734 9.16803Z"
+          fill={color}
+          stroke={theme.background.default}
+          strokeLinecap="round"
+        />
+        <Path
+          d="M17.3075 12.168C17.3075 10.0825 15.6169 8.39185 13.5313 8.39185C12.9791 8.39185 12.5313 7.94413 12.5313 7.39185C12.5313 6.83956 12.9791 6.39185 13.5313 6.39185C16.7214 6.39185 19.3075 8.97792 19.3075 12.168C19.3075 15.3581 16.7214 17.9441 13.5313 17.9441C12.9791 17.9441 12.5313 17.4964 12.5313 16.9441C12.5313 16.3919 12.9791 15.9441 13.5313 15.9441C15.6169 15.9441 17.3075 14.2535 17.3075 12.168Z"
+          fill={color}
+          stroke={theme.background.default}
+          strokeLinecap="round"
+        />
+        <Path
+          d="M14.9926 12.168C14.9926 11.1839 14.1948 10.3862 13.2108 10.3862C12.6942 10.3862 12.2755 9.96744 12.2755 9.4509C12.2755 8.93436 12.6942 8.51562 13.2108 8.51562C15.2279 8.51562 16.8632 10.1509 16.8632 12.168C16.8632 14.1852 15.2279 15.8204 13.2108 15.8204C12.6942 15.8204 12.2755 15.4017 12.2755 14.8852C12.2755 14.3686 12.6942 13.9499 13.2108 13.9499C14.1948 13.9499 14.9926 13.1521 14.9926 12.168Z"
+          fill={color}
+          stroke={theme.background.default}
+          strokeLinecap="round"
+        />
+      </G>
+      <Defs>
+        <ClipPath id="clip0_1037_1797">
+          <Rect
+            width="20"
+            height="20"
+            fill={theme.background.default}
+            transform="translate(0 0.5)"
+          />
+        </ClipPath>
+      </Defs>
+    </Svg>
+  );
+}

--- a/home/screens/RedesignedSettingsScreen/SignOutSection.tsx
+++ b/home/screens/RedesignedSettingsScreen/SignOutSection.tsx
@@ -1,0 +1,27 @@
+import { useNavigation } from '@react-navigation/native';
+import { Text, View } from 'expo-dev-client-components';
+import * as React from 'react';
+
+import { PressableOpacity } from '../../components/PressableOpacity';
+import { useDispatch } from '../../redux/Hooks';
+import SessionActions from '../../redux/SessionActions';
+
+export function SignOutSection() {
+  const navigation = useNavigation();
+  const dispatch = useDispatch();
+
+  const onPress = React.useCallback(() => {
+    dispatch(SessionActions.signOut());
+    requestAnimationFrame(navigation.goBack);
+  }, [dispatch, navigation]);
+
+  return (
+    <View bg="default" overflow="hidden" rounded="large" border="hairline">
+      <PressableOpacity onPress={onPress} containerProps={{ bg: 'default' }}>
+        <View padding="medium">
+          <Text size="medium">Sign out</Text>
+        </View>
+      </PressableOpacity>
+    </View>
+  );
+}

--- a/home/screens/RedesignedSettingsScreen/ThemeSection.tsx
+++ b/home/screens/RedesignedSettingsScreen/ThemeSection.tsx
@@ -1,0 +1,59 @@
+import { iconSize, ThemeAutoIcon, ThemeDarkIcon, ThemeLightIcon } from '@expo/styleguide-native';
+import { Divider, Text, useExpoTheme, View } from 'expo-dev-client-components';
+import * as React from 'react';
+import { Appearance } from 'react-native';
+
+import { RedesignedSectionHeader } from '../../components/RedesignedSectionHeader';
+import { useDispatch, useSelector } from '../../redux/Hooks';
+import SettingsActions from '../../redux/SettingsActions';
+import { RadioListItem } from './RadioListItem';
+
+type ColorSchemeName = Appearance.AppearancePreferences['colorScheme'];
+
+export function ThemeSection() {
+  const dispatch = useDispatch();
+  const preferredAppearance = useSelector((data) => data.settings.preferredAppearance);
+
+  const onSelectAppearance = React.useCallback(
+    (preferredAppearance: ColorSchemeName) => {
+      dispatch(SettingsActions.setPreferredAppearance(preferredAppearance));
+    },
+    [dispatch]
+  );
+
+  const theme = useExpoTheme();
+
+  return (
+    <View>
+      <RedesignedSectionHeader header="Theme" />
+      <View bg="default" overflow="hidden" rounded="large" border="hairline">
+        <RadioListItem
+          icon={<ThemeAutoIcon color={theme.icon.default} size={iconSize.regular} />}
+          title="Automatic"
+          checked={preferredAppearance === undefined}
+          onPress={() => onSelectAppearance(undefined)}
+        />
+        <Divider />
+        <RadioListItem
+          icon={<ThemeLightIcon color={theme.icon.default} size={iconSize.regular} />}
+          title="Light"
+          checked={preferredAppearance === 'light'}
+          onPress={() => onSelectAppearance('light')}
+        />
+        <Divider />
+        <RadioListItem
+          icon={<ThemeDarkIcon color={theme.icon.default} size={iconSize.regular} />}
+          title="Dark"
+          checked={preferredAppearance === 'dark'}
+          onPress={() => onSelectAppearance('dark')}
+        />
+      </View>
+      <View py="small" px="medium">
+        <Text size="small" color="secondary">
+          Automatic is only supported on operating systems that allow you to control the system-wide
+          color scheme.
+        </Text>
+      </View>
+    </View>
+  );
+}

--- a/home/screens/RedesignedSettingsScreen/ThreeFingerPressIcon.tsx
+++ b/home/screens/RedesignedSettingsScreen/ThreeFingerPressIcon.tsx
@@ -1,0 +1,42 @@
+import { IconProps } from '@expo/styleguide-native/dist/types';
+import { useExpoTheme } from 'expo-dev-client-components';
+import * as React from 'react';
+import Svg, { SvgProps, G, Path, Defs, ClipPath, Circle, Rect } from 'react-native-svg';
+
+export function ThreeFingerPressIcon(props: SvgProps & IconProps) {
+  const { size, color, width, height } = props;
+
+  const theme = useExpoTheme();
+
+  return (
+    <Svg width={size || width || 20} height={size || height || 20} viewBox="0 0 20 21" fill="none">
+      <G clip-path="url(#clip0_1037_1803)">
+        <Path
+          fillRule="evenodd"
+          clipRule="evenodd"
+          d="M14.2855 2H5.71404C5.47735 2 5.28547 2.22386 5.28547 2.5V7.2436C4.88752 7.08638 4.45385 7 4 7H3.99976V2.5C3.99976 1.39543 4.76727 0.5 5.71404 0.5H14.2855C15.2322 0.5 15.9998 1.39543 15.9998 2.5V7C15.5458 7.00003 15.1121 7.08648 14.714 7.2438V2.5C14.714 2.22386 14.5222 2 14.2855 2ZM14.714 13.7562V18.5C14.714 18.7761 14.5222 19 14.2855 19H5.71404C5.47735 19 5.28547 18.7761 5.28547 18.5V13.7564C4.88752 13.9136 4.45385 14 4 14H3.99976V18.5C3.99976 19.6046 4.76727 20.5 5.71404 20.5H14.2855C15.2322 20.5 15.9998 19.6046 15.9998 18.5V14C15.5458 14 15.1121 13.9135 14.714 13.7562Z"
+          fill={color}
+        />
+        <Path
+          d="M6.5 10.5C6.5 11.8807 5.38071 13 4 13C2.61929 13 1.5 11.8807 1.5 10.5C1.5 9.11929 2.61929 8 4 8C5.38071 8 6.5 9.11929 6.5 10.5Z"
+          fill={color}
+        />
+        <Path
+          d="M18.5 10.5C18.5 11.8807 17.3807 13 16 13C14.6193 13 13.5 11.8807 13.5 10.5C13.5 9.11929 14.6193 8 16 8C17.3807 8 18.5 9.11929 18.5 10.5Z"
+          fill={color}
+        />
+        <Circle cx="10" cy="10.5" r="2.5" fill={color} />
+      </G>
+      <Defs>
+        <ClipPath id="clip0_1037_1803">
+          <Rect
+            width="20"
+            height="20"
+            fill={theme.background.default}
+            transform="translate(0 0.5)"
+          />
+        </ClipPath>
+      </Defs>
+    </Svg>
+  );
+}

--- a/home/screens/RedesignedSettingsScreen/TrackingSection.tsx
+++ b/home/screens/RedesignedSettingsScreen/TrackingSection.tsx
@@ -1,0 +1,49 @@
+import { Text, View } from 'expo-dev-client-components';
+import * as Tracking from 'expo-tracking-transparency';
+import * as WebBrowser from 'expo-web-browser';
+import * as React from 'react';
+import { TouchableOpacity } from 'react-native';
+
+import { PressableOpacity } from '../../components/PressableOpacity';
+import { RedesignedSectionHeader } from '../../components/RedesignedSectionHeader';
+
+export function TrackingSection() {
+  const [showTrackingItem, setShowTrackingItem] = React.useState(false);
+  React.useEffect(() => {
+    (async () => {
+      const { status } = await Tracking.getTrackingPermissionsAsync();
+      setShowTrackingItem(status === 'undetermined');
+    })();
+  }, [showTrackingItem]);
+
+  return showTrackingItem ? (
+    <View>
+      <RedesignedSectionHeader header="Tracking" />
+
+      <View bg="default" overflow="hidden" rounded="large" border="hairline">
+        <PressableOpacity
+          onPress={async () => {
+            const { status } = await Tracking.requestTrackingPermissionsAsync();
+            setShowTrackingItem(status === 'undetermined');
+          }}
+          containerProps={{ bg: 'default' }}>
+          <View padding="medium">
+            <Text size="medium">Allow access to app-related data for tracking</Text>
+          </View>
+        </PressableOpacity>
+      </View>
+
+      <TouchableOpacity onPress={handleLearnMorePress}>
+        <View py="small" px="medium">
+          <Text size="small" color="link">
+            Learn more about what data Expo collects and why.
+          </Text>
+        </View>
+      </TouchableOpacity>
+    </View>
+  ) : null;
+}
+
+function handleLearnMorePress() {
+  WebBrowser.openBrowserAsync('https://expo.io/privacy-explained');
+}

--- a/home/screens/RedesignedSettingsScreen/index.tsx
+++ b/home/screens/RedesignedSettingsScreen/index.tsx
@@ -1,0 +1,44 @@
+import { Spacer, View } from 'expo-dev-client-components';
+import * as Tracking from 'expo-tracking-transparency';
+import * as React from 'react';
+import { Platform, StyleSheet } from 'react-native';
+
+import ScrollView from '../../components/NavigationScrollView';
+import { DevMenuGestureSection } from './DevMenuGestureSection';
+import { SignOutSection } from './SignOutSection';
+import { ThemeSection } from './ThemeSection';
+import { TrackingSection } from './TrackingSection';
+
+export function RedesignedSettingsScreen() {
+  return (
+    <ScrollView
+      style={styles.container}
+      keyboardShouldPersistTaps="always"
+      keyboardDismissMode="on-drag">
+      <View flex="1" padding="medium">
+        <ThemeSection />
+        <Spacer.Vertical size="medium" />
+        {Platform.OS === 'ios' && (
+          <>
+            <DevMenuGestureSection />
+            <Spacer.Vertical size="medium" />
+          </>
+        )}
+        {Tracking.isAvailable() && (
+          <>
+            <TrackingSection />
+            <Spacer.Vertical size="medium" />
+          </>
+        )}
+        {/* TODO: remove signout from settings screen and move to account modal */}
+        <SignOutSection />
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+});

--- a/home/screens/RedesignedSettingsScreen/index.tsx
+++ b/home/screens/RedesignedSettingsScreen/index.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { Platform, StyleSheet } from 'react-native';
 
 import ScrollView from '../../components/NavigationScrollView';
+import { ConstantsSection } from './ConstantsSection';
 import { DevMenuGestureSection } from './DevMenuGestureSection';
 import { SignOutSection } from './SignOutSection';
 import { ThemeSection } from './ThemeSection';
@@ -30,6 +31,8 @@ export function RedesignedSettingsScreen() {
             <Spacer.Vertical size="medium" />
           </>
         )}
+        <ConstantsSection />
+        <Spacer.Vertical size="medium" />
         {/* TODO: remove signout from settings screen and move to account modal */}
         <SignOutSection />
       </View>


### PR DESCRIPTION
# Why

The 2022 Expo Redesign includes a redesign of the Settings UI.

# How

I created a duplicate settings screen behind the redesign flag and redesigned the UI there while keeping the existing logic. I also added a constants section that was new in the designs.

I used SVG icons instead of the icons in DCC because the PNG versions have some inconsistencies in the dark mode exports and also they render more crisply in SVG.

# Test Plan

Tested on iOS and Android:

![Screenshot_20220314-184254](https://user-images.githubusercontent.com/12488826/158273213-1213721b-e228-4934-98c0-2882ffeeab16.png)

![IMG_FDF5538058C2-1](https://user-images.githubusercontent.com/12488826/158273265-bfb92175-a1f4-42e4-a372-1345564fa2a5.jpeg)

