### PR TITLE
[tools] Prebuilding expo-modules-core

### DIFF
--- a/packages/expo-modules-core/ios/AppDelegates/EXLegacyAppDelegateWrapper.h
+++ b/packages/expo-modules-core/ios/AppDelegates/EXLegacyAppDelegateWrapper.h
@@ -1,6 +1,6 @@
 // Copyright © 2018 650 Industries. All rights reserved.
 
-#import <Foundation/Foundation.h>
+#import <ExpoModulesCore/Platform.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/packages/expo-modules-core/ios/Core/Protocols/AnyExpoView.swift
+++ b/packages/expo-modules-core/ios/Core/Protocols/AnyExpoView.swift
@@ -1,3 +1,5 @@
+import React
+
 public protocol AnyExpoView: RCTView {
   var appContext: AppContext? { get }
 

--- a/packages/expo-modules-core/ios/EXDefines.h
+++ b/packages/expo-modules-core/ios/EXDefines.h
@@ -1,5 +1,7 @@
 // Copyright © 2018 650 Industries. All rights reserved.
 
+#import <ExpoModulesCore/Platform.h>
+
 #if defined(__cplusplus)
 #define EX_EXTERN extern "C" __attribute__((visibility("default")))
 #define EX_EXTERN_C_BEGIN extern "C" {

--- a/packages/expo-modules-core/ios/Platform.h
+++ b/packages/expo-modules-core/ios/Platform.h
@@ -1,5 +1,7 @@
 // Copyright 2024-present 650 Industries. All rights reserved.
 
+#include <TargetConditionals.h>
+
 #if TARGET_OS_IOS || TARGET_OS_TV
 
 #import <UIKit/UIKit.h>

--- a/tools/package.json
+++ b/tools/package.json
@@ -72,6 +72,7 @@
     "semver": "^7.5.4",
     "sharp": "^0.32.6",
     "strip-ansi": "^6.0.0",
+    "temp-dir": "^2.0.0",
     "terminal-link": "^2.1.1",
     "typedoc": "0.25.7",
     "uuid": "^9.0.0",

--- a/tools/src/commands/PrebuildPackages.ts
+++ b/tools/src/commands/PrebuildPackages.ts
@@ -44,10 +44,11 @@ async function main(packageNames: string[], options: ActionOptions) {
 
     const startTime = performance.now();
     const xcodeProject = await generateXcodeProjectSpecAsync(pkg);
+    const podspec = await pkg.getPodspecAsync();
 
-    if (!options.generateSpecs) {
-      await buildFrameworksForProjectAsync(xcodeProject);
-      await cleanTemporaryFilesAsync(xcodeProject);
+    if (!options.generateSpecs && podspec) {
+      await buildFrameworksForProjectAsync(podspec, xcodeProject);
+      await cleanTemporaryFilesAsync(podspec, xcodeProject);
     }
 
     const endTime = performance.now();

--- a/tools/src/commands/Vendor.ts
+++ b/tools/src/commands/Vendor.ts
@@ -437,7 +437,7 @@ function getSafeAreaConfig() {
         - (NSDictionary *)constantsToExport
  {
    __block NSDictionary *constants;
-  
+
    dispatch_sync(dispatch_get_main_queue(), ^{
      UIWindow* window = [[UIApplication sharedApplication] keyWindow];
      if (@available(iOS 11.0, *)) {
@@ -476,7 +476,7 @@ function getSafeAreaConfig() {
        } ;
      }
    });
-  
+
   return constants;
 }
 
@@ -547,8 +547,8 @@ async function action({ configuration, platform, onlyPrebuild }: ActionOptions) 
         podspec,
         toRepoPath(output)
       );
-      await buildFrameworksForProjectAsync(xcodeProject);
-      await cleanTemporaryFilesAsync(xcodeProject);
+      await buildFrameworksForProjectAsync(podspec, xcodeProject);
+      await cleanTemporaryFilesAsync(podspec, xcodeProject);
       console.log();
     }
   }

--- a/tools/src/prebuilds/ExpoModulesCorePrebuilder.ts
+++ b/tools/src/prebuilds/ExpoModulesCorePrebuilder.ts
@@ -1,0 +1,201 @@
+import assert from 'assert';
+import fs from 'fs-extra';
+import glob from 'glob-promise';
+import path from 'path';
+
+import * as XcodeGen from './XcodeGen';
+import { ProjectSpec } from './XcodeGen.types';
+import XcodeProject, {
+  flavorToFrameworkPath,
+  spreadArgs,
+  SHARED_DERIVED_DATA_DIR,
+} from './XcodeProject';
+import { Flavor, Framework, XcodebuildSettings } from './XcodeProject.types';
+import { podInstallAsync, Podspec } from '../CocoaPods';
+import { EXPO_DIR } from '../Constants';
+import logger from '../Logger';
+import { transformFilesAsync } from '../Transforms';
+
+// Generates working files out from expo-modules-core folder and prevents CocoaPods generates unnecessary files inside expo-modules-core folder
+const OUT_OF_TREE_WORKING_DIR = path.join(EXPO_DIR, 'prebuild-ExpoModulesCore');
+const MODULEMAP_FILE = 'ExpoModulesCore.modulemap';
+const UMBRELLA_HEADER = 'ExpoModulesCore-umbrella.h';
+
+export function isExpoModulesCore(podspec: Podspec) {
+  return podspec.name === 'ExpoModulesCore';
+}
+
+export async function generateXcodeProjectAsync(dir: string, spec: ProjectSpec): Promise<string> {
+  const workingDir = OUT_OF_TREE_WORKING_DIR;
+  await fs.ensureDir(workingDir);
+  logger.log(`   Prebuilding expo-modules-core from ${workingDir}`);
+
+  // Links to expo-modules-core source
+  if (typeof spec.targets?.['ExpoModulesCore'].sources?.[0].path === 'string') {
+    spec.targets['ExpoModulesCore'].sources[0].path = path.join(
+      EXPO_DIR,
+      'packages',
+      'expo-modules-core'
+    );
+  }
+  // Links to generated header from prebuilder script
+  spec.targets?.['ExpoModulesCore']?.sources?.push({
+    path: '',
+    createIntermediateGroups: true,
+    name: 'ExpoModulesCore-umbrella',
+    includes: ['**/*.h'],
+  });
+
+  // Override header search paths from base to target
+  if (
+    spec.settings?.base['HEADER_SEARCH_PATHS'] &&
+    spec.targets?.['ExpoModulesCore'].settings?.base
+  ) {
+    spec.targets['ExpoModulesCore'].settings.base['HEADER_SEARCH_PATHS'] =
+      spec.settings.base['HEADER_SEARCH_PATHS'];
+  }
+
+  if (spec.settings?.base) {
+    spec.settings.base['MODULEMAP_FILE'] = MODULEMAP_FILE;
+    spec.settings.base['BUILD_LIBRARY_FOR_DISTRIBUTION'] = 'YES';
+  }
+
+  await createModulemapAsync(workingDir);
+  await createGeneratedHeaderAsync(workingDir);
+
+  const result = await XcodeGen.generateXcodeProjectAsync(workingDir, spec);
+
+  logger.log('   Installing Pods');
+  await createPodfileAsync(workingDir);
+  await podInstallAsync(workingDir);
+
+  return result;
+}
+
+export async function buildFrameworkAsync(
+  xcodeProject: XcodeProject,
+  target: string,
+  flavor: Flavor,
+  options?: XcodebuildSettings
+): Promise<Framework> {
+  await xcodeProject.xcodebuildAsync(
+    [
+      'build',
+      '-workspace',
+      `${xcodeProject.name}.xcworkspace`,
+      '-scheme',
+      `${target}_iOS`,
+      '-configuration',
+      flavor.configuration,
+      '-sdk',
+      flavor.sdk,
+      ...spreadArgs('-arch', flavor.archs),
+      '-derivedDataPath',
+      SHARED_DERIVED_DATA_DIR,
+    ],
+    options
+  );
+
+  const frameworkPath = flavorToFrameworkPath(target, flavor);
+  const stat = await fs.lstat(path.join(frameworkPath, target));
+
+  // `_CodeSignature` is apparently generated only for simulator, afaik we don't need it.
+  await fs.remove(path.join(frameworkPath, '_CodeSignature'));
+
+  return {
+    target,
+    flavor,
+    frameworkPath,
+    binarySize: stat.size,
+  };
+}
+
+export async function cleanTemporaryFilesAsync(xcodeProject: XcodeProject) {
+  // Moves created xcframework to package folder
+  const xcFrameworkFilename = 'ExpoModulesCore.xcframework';
+  await fs.move(
+    path.join(OUT_OF_TREE_WORKING_DIR, xcFrameworkFilename),
+    path.join(EXPO_DIR, 'packages', 'expo-modules-core', 'ios', xcFrameworkFilename)
+  );
+
+  // Cleanups working directory
+  await fs.remove(OUT_OF_TREE_WORKING_DIR);
+}
+
+async function createPodfileAsync(workDir: string) {
+  const content = `\
+require 'pathname'
+react_native_dir = File.dirname(\`node --print "require.resolve('react-native/package.json')"\`)
+relative_react_native_dir = Pathname.new(react_native_dir).relative_path_from(Pathname.pwd).to_s
+require File.join(react_native_dir, "scripts/react_native_pods")
+require File.join(File.dirname(\`node --print "require.resolve('expo/package.json')"\`), "scripts/autolinking")
+
+platform :ios, min_ios_version_supported
+prepare_react_native_project!
+
+target 'ExpoModulesCore_iOS' do
+  use_react_native!(
+    :path => relative_react_native_dir,
+    # An absolute path to your application root.
+    :app_path => "#{Pod::Config.instance.installation_root}/..",
+  )
+
+  post_install do |installer|
+    react_native_post_install(
+      installer,
+      relative_react_native_dir,
+      :mac_catalyst_enabled => false,
+    )
+  end
+end`;
+
+  await fs.writeFile(path.join(workDir, 'Podfile'), content);
+}
+
+async function createModulemapAsync(workDir: string) {
+  const content = `\
+framework module ExpoModulesCore {
+  umbrella header "ExpoModulesCore.h"
+
+  export *
+  module * { export * }
+}`;
+  await fs.writeFile(path.join(workDir, MODULEMAP_FILE), content);
+}
+
+async function createGeneratedHeaderAsync(workDir: string) {
+  const srcUmbrellaHeader = path.join(
+    EXPO_DIR,
+    'apps',
+    'bare-expo',
+    'ios',
+    'Pods',
+    'Target Support Files',
+    'ExpoModulesCore',
+    UMBRELLA_HEADER
+  );
+  assert(
+    await fs.pathExists(srcUmbrellaHeader),
+    `Cannot find ${UMBRELLA_HEADER}. Make sure to run \`et pods -f\` before prebuilding.`
+  );
+
+  let content = await fs.readFile(srcUmbrellaHeader, 'utf-8');
+  content = content.replace(/^#import "ExpoModulesCore\//gm, '#import "');
+
+  await fs.writeFile(path.join(workDir, UMBRELLA_HEADER), content);
+}
+
+export async function postActionsAsync(xcframeworkOutputPath: string) {
+  const swiftInterfaceFiles = await glob('**/*.swiftinterface', {
+    cwd: xcframeworkOutputPath,
+    absolute: true,
+  });
+
+  await transformFilesAsync(swiftInterfaceFiles, [
+    {
+      find: /^(\/\/ swift-module-flags: .+)$/gm,
+      replaceWith:
+        '$1 -Xcc -fmodule-map-file="$(PROJECT_DIR)/Pods/Headers/Public/React-Core/React/React-Core.modulemap"',
+    },
+  ]);
+}

--- a/tools/src/prebuilds/Prebuilder.ts
+++ b/tools/src/prebuilds/Prebuilder.ts
@@ -3,6 +3,7 @@ import fs from 'fs-extra';
 import glob from 'glob-promise';
 import path from 'path';
 
+import * as ExpoModulesCorePrebuilder from './ExpoModulesCorePrebuilder';
 import {
   createSpecFromPodspecAsync,
   generateXcodeProjectAsync,
@@ -20,6 +21,7 @@ const PODS_DIR = path.join(EXPO_GO_IOS_DIR, 'Pods');
 // We will be increasing this list slowly. Once all are enabled,
 // find a better way to ignore some packages that shouldn't be prebuilt (like interfaces).
 export const PACKAGES_TO_PREBUILD = [
+  'expo-modules-core',
   // 'expo-app-auth',
   // 'expo-apple-authentication',
   // 'expo-application',
@@ -87,14 +89,16 @@ export async function prebuildPackageAsync(
   pkg: Package,
   settings?: XcodebuildSettings
 ): Promise<void> {
-  if (canPrebuildPackage(pkg)) {
+  const podspec = await pkg.getPodspecAsync();
+  if (canPrebuildPackage(pkg) && podspec) {
     const xcodeProject = await generateXcodeProjectSpecAsync(pkg);
-    await buildFrameworksForProjectAsync(xcodeProject, settings);
-    await cleanTemporaryFilesAsync(xcodeProject);
+    await buildFrameworksForProjectAsync(podspec, xcodeProject, settings);
+    await cleanTemporaryFilesAsync(podspec, xcodeProject);
   }
 }
 
 export async function buildFrameworksForProjectAsync(
+  podspec: Podspec,
   xcodeProject: XcodeProject,
   settings?: XcodebuildSettings
 ) {
@@ -113,11 +117,15 @@ export async function buildFrameworksForProjectAsync(
 
   // Builds frameworks from flavors.
   const frameworks: Framework[] = [];
+  const functor = ExpoModulesCorePrebuilder.isExpoModulesCore(podspec)
+    ? (...args: Parameters<XcodeProject['buildFrameworkAsync']>) =>
+        ExpoModulesCorePrebuilder.buildFrameworkAsync(xcodeProject, ...args)
+    : xcodeProject.buildFrameworkAsync;
   for (const flavor of flavors) {
     logger.log('   Building framework for %s', chalk.yellow(flavor.sdk));
 
     frameworks.push(
-      await xcodeProject.buildFrameworkAsync(xcodeProject.name, flavor, {
+      await functor(xcodeProject.name, flavor, {
         ONLY_ACTIVE_ARCH: false,
         BITCODE_GENERATION_MODE: 'bitcode',
         BUILD_LIBRARY_FOR_DISTRIBUTION: true,
@@ -141,13 +149,17 @@ export async function buildFrameworksForProjectAsync(
   logger.log('   Merging frameworks to', chalk.magenta(`${xcodeProject.name}.xcframework`));
 
   // Merge frameworks into universal xcframework
-  await xcodeProject.buildXcframeworkAsync(frameworks, settings);
+  const xcframeworkOutputPath = await xcodeProject.buildXcframeworkAsync(frameworks, settings);
+
+  if (ExpoModulesCorePrebuilder.isExpoModulesCore(podspec)) {
+    await ExpoModulesCorePrebuilder.postActionsAsync(xcframeworkOutputPath);
+  }
 }
 
 /**
  * Removes all temporary files that we generated in order to create `.xcframework` file.
  */
-export async function cleanTemporaryFilesAsync(xcodeProject: XcodeProject) {
+export async function cleanTemporaryFilesAsync(podspec: Podspec, xcodeProject: XcodeProject) {
   logger.log('   Cleaning up temporary files');
 
   const pathsToRemove = [`${xcodeProject.name}.xcodeproj`, INFO_PLIST_FILENAME];
@@ -155,6 +167,10 @@ export async function cleanTemporaryFilesAsync(xcodeProject: XcodeProject) {
   await Promise.all(
     pathsToRemove.map((pathToRemove) => fs.remove(path.join(xcodeProject.rootDir, pathToRemove)))
   );
+
+  if (ExpoModulesCorePrebuilder.isExpoModulesCore(podspec)) {
+    await ExpoModulesCorePrebuilder.cleanTemporaryFilesAsync(xcodeProject);
+  }
 }
 
 /**
@@ -195,7 +211,11 @@ export async function generateXcodeProjectSpecFromPodspecAsync(
     return null;
   });
 
-  const xcodeprojPath = await generateXcodeProjectAsync(dir, spec);
+  const functor = ExpoModulesCorePrebuilder.isExpoModulesCore(podspec)
+    ? ExpoModulesCorePrebuilder.generateXcodeProjectAsync
+    : generateXcodeProjectAsync;
+  const xcodeprojPath = await functor(dir, spec);
+
   return await XcodeProject.fromXcodeprojPathAsync(xcodeprojPath);
 }
 

--- a/tools/src/prebuilds/XcodeGen.ts
+++ b/tools/src/prebuilds/XcodeGen.ts
@@ -9,10 +9,10 @@ import {
   XcodeConfig,
 } from './XcodeGen.types';
 import { Podspec } from '../CocoaPods';
-import { EXPOTOOLS_DIR, EXPO_GO_IOS_DIR } from '../Constants';
+import { EXPOTOOLS_DIR, EXPO_DIR } from '../Constants';
 import { arrayize, spawnAsync } from '../Utils';
 
-const PODS_DIR = path.join(EXPO_GO_IOS_DIR, 'Pods');
+const PODS_DIR = path.join(EXPO_DIR, 'apps/bare-expo', 'ios', 'Pods');
 const PODS_PUBLIC_HEADERS_DIR = path.join(PODS_DIR, 'Headers', 'Public');
 const PODS_PRIVATE_HEADERS_DIR = path.join(PODS_DIR, 'Headers', 'Private');
 const PLATFORMS_MAPPING: Record<string, ProjectSpecPlatform> = {

--- a/tools/src/prebuilds/XcodeProject.ts
+++ b/tools/src/prebuilds/XcodeProject.ts
@@ -1,5 +1,4 @@
 import fs from 'fs-extra';
-import os from 'os';
 import path from 'path';
 
 import { generateXcodeProjectAsync } from './XcodeGen';
@@ -11,7 +10,7 @@ import { spawnAsync } from '../Utils';
 /**
  * Path to the shared derived data directory.
  */
-const SHARED_DERIVED_DATA_DIR = path.join(os.tmpdir(), 'Expo/DerivedData');
+export const SHARED_DERIVED_DATA_DIR = path.join(require('temp-dir'), 'Expo/DerivedData');
 
 /**
  * Path to the products in derived data directory. We pick `.framework` files from there.
@@ -172,7 +171,7 @@ export default class XcodeProject {
 /**
  * Returns a path to the prebuilt framework for given flavor.
  */
-function flavorToFrameworkPath(target: string, flavor: Flavor): string {
+export function flavorToFrameworkPath(target: string, flavor: Flavor): string {
   return path.join(PRODUCTS_DIR, `${flavor.configuration}-${flavor.sdk}`, `${target}.framework`);
 }
 
@@ -180,7 +179,7 @@ function flavorToFrameworkPath(target: string, flavor: Flavor): string {
  * Spreads given args under specific flag.
  * Example: `spreadArgs('-arch', ['arm64', 'x86_64'])` returns `['-arch', 'arm64', '-arch', 'x86_64']`
  */
-function spreadArgs(argName: string, args: string[]): string[] {
+export function spreadArgs(argName: string, args: string[]): string[] {
   return ([] as string[]).concat(...args.map((arg) => [argName, arg]));
 }
 

--- a/tools/yarn.lock
+++ b/tools/yarn.lock
@@ -13468,6 +13468,11 @@ temp-dir@^1.0.0:
   resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-1.0.0.tgz#0a7c0ea26d3a39afa7e0ebea9c1fc0bc4daa011d"
   integrity sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=
 
+temp-dir@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-2.0.0.tgz#bde92b05bdfeb1516e804c9c00ad45177f31321e"
+  integrity sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==
+
 tempy@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/tempy/-/tempy-0.3.0.tgz#6f6c5b295695a16130996ad5ab01a8bd726e8bf8"


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

- [x] integrate prebuilt expo-modules-core for `use_frameworks!` enabled apps.
- [ ] integrate prebuild expo-modules-core for non-frameworks builds.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
