### PR TITLE
[expo-updates] fix primitive type default values in UpdatesConfiguration

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 - Update `fbemitter` to v3. ([#16245](https://github.com/expo/expo/pull/16245) by [@SimenB](https://github.com/SimenB))
 - Allow non-codesigned manifests for Expo Go. ([#16649](https://github.com/expo/expo/pull/16649) by [@wschurman](https://github.com/wschurman))
+- Fix issue where default values for primitive-typed configuration values were not correctly set.
 
 ### 💡 Others
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 - Update `fbemitter` to v3. ([#16245](https://github.com/expo/expo/pull/16245) by [@SimenB](https://github.com/SimenB))
 - Allow non-codesigned manifests for Expo Go. ([#16649](https://github.com/expo/expo/pull/16649) by [@wschurman](https://github.com/wschurman))
-- Fix issue where default values for primitive-typed configuration values were not correctly set.
+- Fix issue where default values for primitive-typed configuration values were not correctly set. ([#16644](https://github.com/expo/expo/pull/16644) by [@esamelson](https://github.com/esamelson))
 
 ### 💡 Others
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/UpdatesConfigurationInstrumentationTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/UpdatesConfigurationInstrumentationTest.kt
@@ -55,6 +55,52 @@ class UpdatesConfigurationInstrumentationTest {
   }
 
   @Test
+  fun test_defaultValues() {
+    val testPackageName = "test"
+    val context = mockk<Context> {
+      every { packageName } returns testPackageName
+      every { packageManager } returns mockk {
+        every { getApplicationInfo(testPackageName, PackageManager.GET_META_DATA) } returns mockk {
+          metaData = Bundle()
+        }
+      }
+    }
+
+    val config = UpdatesConfiguration(context, null)
+    Assert.assertEquals(true, config.isEnabled)
+    Assert.assertEquals(false, config.expectsSignedManifest)
+    Assert.assertEquals("default", config.releaseChannel)
+    Assert.assertEquals(0, config.launchWaitMs)
+    Assert.assertEquals(UpdatesConfiguration.CheckAutomaticallyConfiguration.ALWAYS, config.checkOnLaunch)
+    Assert.assertEquals(true, config.hasEmbeddedUpdate)
+    Assert.assertEquals(false, config.codeSigningIncludeManifestResponseCertificateChain)
+  }
+
+  @Test
+  fun test_primitiveTypeFields_nonDefaultValues() {
+    val testPackageName = "test"
+    val context = mockk<Context> {
+      every { packageName } returns testPackageName
+      every { packageManager } returns mockk {
+        every { getApplicationInfo(testPackageName, PackageManager.GET_META_DATA) } returns mockk {
+          metaData = Bundle().apply {
+            putBoolean("expo.modules.updates.ENABLED", false)
+            putInt("expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS", 1000)
+            putBoolean("expo.modules.updates.HAS_EMBEDDED_UPDATE", false)
+            putBoolean("expo.modules.updates.CODE_SIGNING_INCLUDE_MANIFEST_RESPONSE_CERTIFICATE_CHAIN", true)
+          }
+        }
+      }
+    }
+
+    val config = UpdatesConfiguration(context, null)
+    Assert.assertEquals(false, config.isEnabled)
+    Assert.assertEquals(1000, config.launchWaitMs)
+    Assert.assertEquals(false, config.hasEmbeddedUpdate)
+    Assert.assertEquals(true, config.codeSigningIncludeManifestResponseCertificateChain)
+  }
+
+  @Test
   fun test_initialization_mapTakesPrecedenceOverContext() {
     val testPackageName = "test"
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.kt
@@ -28,7 +28,7 @@ class UpdatesConfiguration private constructor (
   }
 
   constructor(context: Context?, overrideMap: Map<String, Any>?) : this(
-    isEnabled = overrideMap?.readValueCheckingType<Boolean>(UPDATES_CONFIGURATION_ENABLED_KEY) ?: context?.getMetadataValue("expo.modules.updates.ENABLED") ?: true,
+    isEnabled = overrideMap?.readValueCheckingType<Boolean>(UPDATES_CONFIGURATION_ENABLED_KEY) ?: context?.getMetadataValue("expo.modules.updates.ENABLED", true) ?: true,
     expectsSignedManifest = overrideMap?.readValueCheckingType(UPDATES_CONFIGURATION_EXPECTS_EXPO_SIGNED_MANIFEST) ?: false,
     scopeKey = maybeGetDefaultScopeKey(
       overrideMap?.readValueCheckingType<String>(UPDATES_CONFIGURATION_SCOPE_KEY_KEY) ?: context?.getMetadataValue("expo.modules.updates.EXPO_SCOPE_KEY"),
@@ -38,7 +38,7 @@ class UpdatesConfiguration private constructor (
     sdkVersion = overrideMap?.readValueCheckingType<String>(UPDATES_CONFIGURATION_SDK_VERSION_KEY) ?: context?.getMetadataValue("expo.modules.updates.EXPO_SDK_VERSION"),
     runtimeVersion = overrideMap?.readValueCheckingType<String>(UPDATES_CONFIGURATION_RUNTIME_VERSION_KEY) ?: context?.getMetadataValue<Any>("expo.modules.updates.EXPO_RUNTIME_VERSION")?.toString()?.replaceFirst("^string:".toRegex(), ""),
     releaseChannel = overrideMap?.readValueCheckingType<String>(UPDATES_CONFIGURATION_RELEASE_CHANNEL_KEY) ?: context?.getMetadataValue("expo.modules.updates.EXPO_RELEASE_CHANNEL") ?: UPDATES_CONFIGURATION_RELEASE_CHANNEL_DEFAULT_VALUE,
-    launchWaitMs = overrideMap?.readValueCheckingType<Int>(UPDATES_CONFIGURATION_LAUNCH_WAIT_MS_KEY) ?: context?.getMetadataValue("expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS") ?: UPDATES_CONFIGURATION_LAUNCH_WAIT_MS_DEFAULT_VALUE,
+    launchWaitMs = overrideMap?.readValueCheckingType<Int>(UPDATES_CONFIGURATION_LAUNCH_WAIT_MS_KEY) ?: context?.getMetadataValue("expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS", UPDATES_CONFIGURATION_LAUNCH_WAIT_MS_DEFAULT_VALUE) ?: UPDATES_CONFIGURATION_LAUNCH_WAIT_MS_DEFAULT_VALUE,
     checkOnLaunch = overrideMap?.readValueCheckingType<String>(UPDATES_CONFIGURATION_CHECK_ON_LAUNCH_KEY)?.let {
       try {
         CheckAutomaticallyConfiguration.valueOf(it)
@@ -56,7 +56,7 @@ class UpdatesConfiguration private constructor (
         CheckAutomaticallyConfiguration.ALWAYS
       }
     },
-    hasEmbeddedUpdate = overrideMap?.readValueCheckingType<Boolean>(UPDATES_CONFIGURATION_HAS_EMBEDDED_UPDATE_KEY) ?: context?.getMetadataValue("expo.modules.updates.HAS_EMBEDDED_UPDATE") ?: true,
+    hasEmbeddedUpdate = overrideMap?.readValueCheckingType<Boolean>(UPDATES_CONFIGURATION_HAS_EMBEDDED_UPDATE_KEY) ?: context?.getMetadataValue("expo.modules.updates.HAS_EMBEDDED_UPDATE", true) ?: true,
     requestHeaders = overrideMap?.readValueCheckingType<Map<String, String>>(UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY) ?: (context?.getMetadataValue<String>("expo.modules.updates.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY") ?: "{}").let {
       UpdatesUtils.getMapFromJSONString(it)
     },
@@ -66,10 +66,10 @@ class UpdatesConfiguration private constructor (
     },
     codeSigningIncludeManifestResponseCertificateChain = overrideMap?.readValueCheckingType<Boolean>(
       UPDATES_CONFIGURATION_CODE_SIGNING_INCLUDE_MANIFEST_RESPONSE_CERTIFICATE_CHAIN
-    ) ?: context?.getMetadataValue("expo.modules.updates.CODE_SIGNING_INCLUDE_MANIFEST_RESPONSE_CERTIFICATE_CHAIN") ?: false,
+    ) ?: context?.getMetadataValue("expo.modules.updates.CODE_SIGNING_INCLUDE_MANIFEST_RESPONSE_CERTIFICATE_CHAIN", false) ?: false,
     codeSigningAllowUnsignedManifests = overrideMap?.readValueCheckingType<Boolean>(
       UPDATES_CONFIGURATION_CODE_SIGNING_ALLOW_UNSIGNED_MANIFESTS
-    ) ?: context?.getMetadataValue("expo.modules.updates.CODE_SIGNING_ALLOW_UNSIGNED_MANIFESTS") ?: false,
+    ) ?: context?.getMetadataValue("expo.modules.updates.CODE_SIGNING_ALLOW_UNSIGNED_MANIFESTS", false) ?: false,
   )
 
   val isMissingRuntimeVersion: Boolean
@@ -114,6 +114,16 @@ private inline fun <reified T : Any> Context.getMetadataValue(key: String): T? {
     Boolean::class -> ai.getBoolean(key) as T?
     Int::class -> ai.getInt(key) as T?
     else -> ai[key] as T?
+  }
+}
+
+private inline fun <reified T : Any> Context.getMetadataValue(key: String, defaultValue: T): T {
+  val ai = packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA).metaData
+  return when (T::class) {
+    String::class -> ai.getString(key) as T? ?: defaultValue
+    Boolean::class -> ai.getBoolean(key, defaultValue as Boolean) as T
+    Int::class -> ai.getInt(key, defaultValue as Int) as T
+    else -> ai[key] as T? ?: defaultValue
   }
 }
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.kt
@@ -28,7 +28,7 @@ class UpdatesConfiguration private constructor (
   }
 
   constructor(context: Context?, overrideMap: Map<String, Any>?) : this(
-    isEnabled = overrideMap?.readValueCheckingType<Boolean>(UPDATES_CONFIGURATION_ENABLED_KEY) ?: context?.getMetadataValue("expo.modules.updates.ENABLED", true) ?: true,
+    isEnabled = overrideMap?.readValueCheckingType<Boolean>(UPDATES_CONFIGURATION_ENABLED_KEY) ?: context?.getMetadataValue("expo.modules.updates.ENABLED") ?: true,
     expectsSignedManifest = overrideMap?.readValueCheckingType(UPDATES_CONFIGURATION_EXPECTS_EXPO_SIGNED_MANIFEST) ?: false,
     scopeKey = maybeGetDefaultScopeKey(
       overrideMap?.readValueCheckingType<String>(UPDATES_CONFIGURATION_SCOPE_KEY_KEY) ?: context?.getMetadataValue("expo.modules.updates.EXPO_SCOPE_KEY"),
@@ -38,7 +38,7 @@ class UpdatesConfiguration private constructor (
     sdkVersion = overrideMap?.readValueCheckingType<String>(UPDATES_CONFIGURATION_SDK_VERSION_KEY) ?: context?.getMetadataValue("expo.modules.updates.EXPO_SDK_VERSION"),
     runtimeVersion = overrideMap?.readValueCheckingType<String>(UPDATES_CONFIGURATION_RUNTIME_VERSION_KEY) ?: context?.getMetadataValue<Any>("expo.modules.updates.EXPO_RUNTIME_VERSION")?.toString()?.replaceFirst("^string:".toRegex(), ""),
     releaseChannel = overrideMap?.readValueCheckingType<String>(UPDATES_CONFIGURATION_RELEASE_CHANNEL_KEY) ?: context?.getMetadataValue("expo.modules.updates.EXPO_RELEASE_CHANNEL") ?: UPDATES_CONFIGURATION_RELEASE_CHANNEL_DEFAULT_VALUE,
-    launchWaitMs = overrideMap?.readValueCheckingType<Int>(UPDATES_CONFIGURATION_LAUNCH_WAIT_MS_KEY) ?: context?.getMetadataValue("expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS", UPDATES_CONFIGURATION_LAUNCH_WAIT_MS_DEFAULT_VALUE) ?: UPDATES_CONFIGURATION_LAUNCH_WAIT_MS_DEFAULT_VALUE,
+    launchWaitMs = overrideMap?.readValueCheckingType<Int>(UPDATES_CONFIGURATION_LAUNCH_WAIT_MS_KEY) ?: context?.getMetadataValue("expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS") ?: UPDATES_CONFIGURATION_LAUNCH_WAIT_MS_DEFAULT_VALUE,
     checkOnLaunch = overrideMap?.readValueCheckingType<String>(UPDATES_CONFIGURATION_CHECK_ON_LAUNCH_KEY)?.let {
       try {
         CheckAutomaticallyConfiguration.valueOf(it)
@@ -56,7 +56,7 @@ class UpdatesConfiguration private constructor (
         CheckAutomaticallyConfiguration.ALWAYS
       }
     },
-    hasEmbeddedUpdate = overrideMap?.readValueCheckingType<Boolean>(UPDATES_CONFIGURATION_HAS_EMBEDDED_UPDATE_KEY) ?: context?.getMetadataValue("expo.modules.updates.HAS_EMBEDDED_UPDATE", true) ?: true,
+    hasEmbeddedUpdate = overrideMap?.readValueCheckingType<Boolean>(UPDATES_CONFIGURATION_HAS_EMBEDDED_UPDATE_KEY) ?: context?.getMetadataValue("expo.modules.updates.HAS_EMBEDDED_UPDATE") ?: true,
     requestHeaders = overrideMap?.readValueCheckingType<Map<String, String>>(UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY) ?: (context?.getMetadataValue<String>("expo.modules.updates.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY") ?: "{}").let {
       UpdatesUtils.getMapFromJSONString(it)
     },
@@ -66,10 +66,10 @@ class UpdatesConfiguration private constructor (
     },
     codeSigningIncludeManifestResponseCertificateChain = overrideMap?.readValueCheckingType<Boolean>(
       UPDATES_CONFIGURATION_CODE_SIGNING_INCLUDE_MANIFEST_RESPONSE_CERTIFICATE_CHAIN
-    ) ?: context?.getMetadataValue("expo.modules.updates.CODE_SIGNING_INCLUDE_MANIFEST_RESPONSE_CERTIFICATE_CHAIN", false) ?: false,
+    ) ?: context?.getMetadataValue("expo.modules.updates.CODE_SIGNING_INCLUDE_MANIFEST_RESPONSE_CERTIFICATE_CHAIN") ?: false,
     codeSigningAllowUnsignedManifests = overrideMap?.readValueCheckingType<Boolean>(
       UPDATES_CONFIGURATION_CODE_SIGNING_ALLOW_UNSIGNED_MANIFESTS
-    ) ?: context?.getMetadataValue("expo.modules.updates.CODE_SIGNING_ALLOW_UNSIGNED_MANIFESTS", false) ?: false,
+    ) ?: context?.getMetadataValue("expo.modules.updates.CODE_SIGNING_ALLOW_UNSIGNED_MANIFESTS") ?: false,
   )
 
   val isMissingRuntimeVersion: Boolean
@@ -109,21 +109,14 @@ class UpdatesConfiguration private constructor (
 
 private inline fun <reified T : Any> Context.getMetadataValue(key: String): T? {
   val ai = packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA).metaData
+  if (!ai.containsKey(key)) {
+    return null
+  }
   return when (T::class) {
     String::class -> ai.getString(key) as T?
     Boolean::class -> ai.getBoolean(key) as T?
     Int::class -> ai.getInt(key) as T?
     else -> ai[key] as T?
-  }
-}
-
-private inline fun <reified T : Any> Context.getMetadataValue(key: String, defaultValue: T): T {
-  val ai = packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA).metaData
-  return when (T::class) {
-    String::class -> ai.getString(key) as T? ?: defaultValue
-    Boolean::class -> ai.getBoolean(key, defaultValue as Boolean) as T
-    Int::class -> ai.getInt(key, defaultValue as Int) as T
-    else -> ai[key] as T? ?: defaultValue
   }
 }
 


### PR DESCRIPTION
# Why

Discovered while working on e2e tests for updates (later PRs in this stack) that there is a bug in the new kotlin code for UpdatesConfiguration; `hasEmbeddedUpdate` is false by default (if nothing is specified in context metadata) when it should be true. This makes release APKs crash on launch unless there is a published update to pull.

It looks like this bug exists for all fields which are primitive types in context metadata; the `Bundle.getBoolean` and `getInt` getters always return primitive `bool` and `int` types, but our new kotlin code assumes they return the nullable object wrappers.

# How

Created a new `Context.getMetadataValue` method with a `defaultValue` field to allow us to use the corresponding [`getBoolean`](https://developer.android.com/reference/android/os/BaseBundle#getBoolean(java.lang.String,%20boolean)) and [`getInt`](https://developer.android.com/reference/android/os/BaseBundle#getInt(java.lang.String,%20int)) getters with a defaultValue parameter.

# Test Plan

Empirically, `hasEmbeddedUpdate` is now true by default if nothing is specified in metadata. Also added some unit tests for these cases.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
