### PR TITLE
[github] add Updates e2e workflow that builds a test APK

### DIFF
--- a/.github/workflows/updates-e2e.yml
+++ b/.github/workflows/updates-e2e.yml
@@ -11,7 +11,8 @@ on:
       - packages/expo-structured-headers/**
       - packages/expo-updates-interface/**
       - packages/expo-updates/**
-      - packages/expo/**
+      - packages/expo/android/**
+      - packages/expo/ios/**
   push:
     branches: [main, 'sdk-*']
     paths:
@@ -22,7 +23,8 @@ on:
       - packages/expo-structured-headers/**
       - packages/expo-updates-interface/**
       - packages/expo-updates/**
-      - packages/expo/**
+      - packages/expo/android/**
+      - packages/expo/ios/**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
@@ -69,7 +71,7 @@ jobs:
       # TODO: remove once the local template projects are using SDK 45 packages
       - name: Manually bump kotlin version (workaround)
         working-directory: ../updates-e2e
-        run: sed -i -e 's/\(buildToolsVersion\ =\ \"[0-9.]*\"\)/\1\nkotlinVersion\ =\ \"1\.6\.10\"/' ./android/build.gradle
+        run: sed -i -e 's/\(buildToolsVersion = "[0-9.]*"\)/\1\nkotlinVersion = "1.6.10"/' ./android/build.gradle
       - name: Assemble release APK
         working-directory: ../updates-e2e/android
         run: ./gradlew assembleRelease

--- a/.github/workflows/updates-e2e.yml
+++ b/.github/workflows/updates-e2e.yml
@@ -1,0 +1,82 @@
+name: Updates e2e
+
+on:
+  workflow_dispatch: {}
+  pull_request:
+    paths:
+      - .github/workflows/updates-e2e.yml
+      - packages/expo-json-utils/**
+      - packages/expo-manifests/**
+      - packages/expo-modules-core/**
+      - packages/expo-structured-headers/**
+      - packages/expo-updates-interface/**
+      - packages/expo-updates/**
+      - packages/expo/**
+  push:
+    branches: [main, 'sdk-*']
+    paths:
+      - .github/workflows/updates-e2e.yml
+      - packages/expo-json-utils/**
+      - packages/expo-manifests/**
+      - packages/expo-modules-core/**
+      - packages/expo-structured-headers/**
+      - packages/expo-updates-interface/**
+      - packages/expo-updates/**
+      - packages/expo/**
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  android:
+    runs-on: macos-11
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+        with:
+          submodules: false
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v2
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - run: yarn install --frozen-lockfile
+      - uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('android/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - run: yarn global add expo-cli
+      - run: echo "$(yarn global bin)" >> $GITHUB_PATH
+      - name: Init new expo app
+        working-directory: ../
+        run: expo-cli init updates-e2e --yes
+      - name: Add local expo-updates and dependencies
+        working-directory: ../updates-e2e
+        run: yarn add file:../expo/packages/expo-updates file:../expo/packages/expo file:../expo/packages/expo-modules-core file:../expo/packages/expo-json-utils file:../expo/packages/expo-manifests file:../expo/packages/expo-structured-headers file:../expo/packages/expo-updates-interface
+      - name: Setup app.config.json
+        working-directory: ../updates-e2e
+        run: echo "{\"name\":\"updates-e2e\",\"plugins\":[\"expo-updates\"],\"android\":{\"package\":\"dev.expo.updatese2e\"},\"ios\":{\"bundleIdentifier\":\"dev.expo.updatese2e\"}}" > app.config.json
+      - name: Prebuild
+        working-directory: ../updates-e2e
+        run: expo-cli prebuild
+      # TODO: remove once the local template projects are using SDK 45 packages
+      - name: Manually bump kotlin version (workaround)
+        working-directory: ../updates-e2e
+        run: sed -i -e 's/\(buildToolsVersion\ =\ \"[0-9.]*\"\)/\1\nkotlinVersion\ =\ \"1\.6\.10\"/' ./android/build.gradle
+      - name: Assemble release APK
+        working-directory: ../updates-e2e/android
+        run: ./gradlew assembleRelease
+      - name: Copy APK to working directory
+        run: cp -R ../updates-e2e/android/app/build/outputs/apk artifact
+      - name: Upload test APK artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: updates-e2e-android-apk
+          path: artifact


### PR DESCRIPTION
# Why

First step of ENG-2473 for Android

# How

Add a simple GHA workflow which creates a new project outside of the repo, adds local versions of expo-updates and its dependencies, and builds a release APK suitable for using in e2e tests (next PR in stack).

Since none of the template projects (either released or locally in the repo) are currently compatible with packages from `main`, I added one workaround to manually bump the kotlin version, which fixes the problem. Once we have new templates that are updated to use this kotlin version across all packages, we can remove this workaround.

# Test Plan

New job should pass

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
