### PR TITLE
[expo-updates][android] Allow non-codesigned manifests for Expo Go

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### 🐛 Bug fixes
 
 - Update `fbemitter` to v3. ([#16245](https://github.com/expo/expo/pull/16245) by [@SimenB](https://github.com/SimenB))
+- Allow non-codesigned manifests for Expo Go. ([#16649](https://github.com/expo/expo/pull/16649) by [@wschurman](https://github.com/wschurman))
 
 ### 💡 Others
 

--- a/packages/expo-updates/android/build.gradle
+++ b/packages/expo-updates/android/build.gradle
@@ -130,12 +130,14 @@ dependencies {
   testImplementation 'junit:junit:4.13.1'
   testImplementation 'androidx.test:core:1.4.0'
   testImplementation 'io.mockk:mockk:1.12.0'
+  testImplementation "org.jetbrains.kotlin:kotlin-test-junit:${getKotlinVersion()}"
 
   androidTestImplementation 'androidx.test:runner:1.4.0'
   androidTestImplementation 'androidx.test:core:1.4.0'
   androidTestImplementation 'androidx.test:rules:1.4.0'
   androidTestImplementation 'io.mockk:mockk-android:1.12.0'
   androidTestImplementation "androidx.room:room-testing:$room_version"
+  androidTestImplementation "org.jetbrains.kotlin:kotlin-test-junit:${getKotlinVersion()}"
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
   implementation "org.jetbrains.kotlin:kotlin-reflect:${getKotlinVersion()}"

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/codesigning/CertificateFixtures.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/codesigning/CertificateFixtures.kt
@@ -25,6 +25,8 @@ fun getTestCertificate(testCertificateType: TestCertificateType): String {
 }
 
 object CertificateFixtures {
+  const val testClassicBody = "{\"sdkVersion\":\"39.0.0\",\"releaseId\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"commitTime\":\"2020-11-11T00:17:54.797Z\",\"bundleUrl\":\"https://url.to/bundle.js\"}"
+
   const val testBody = "{\"id\":\"0754dad0-d200-d634-113c-ef1f26106028\",\"createdAt\":\"2021-11-23T00:57:14.437Z\",\"runtimeVersion\":\"1\",\"assets\":[{\"hash\":\"cb65fafb5ed456fc3ed8a726cf4087d37b875184eba96f33f6d99104e6e2266d\",\"key\":\"489ea2f19fa850b65653ab445637a181.jpg\",\"contentType\":\"image/jpeg\",\"url\":\"http://192.168.64.1:3000/api/assets?asset=updates/1/assets/489ea2f19fa850b65653ab445637a181&runtimeVersion=1&platform=android\",\"fileExtension\":\".jpg\"}],\"launchAsset\":{\"hash\":\"323ddd1968ee76d4ddbb16b04fb2c3f1b6d1ab9b637d819699fecd6fa0ffb1a8\",\"key\":\"696a70cf7035664c20ea86f67dae822b.bundle\",\"contentType\":\"application/javascript\",\"url\":\"http://192.168.64.1:3000/api/assets?asset=updates/1/bundles/android-696a70cf7035664c20ea86f67dae822b.js&runtimeVersion=1&platform=android\",\"fileExtension\":\".bundle\"}}"
   const val testSignature = "sig=\"rPpJN0SpXTlKfN9aUnEmz4llO0nQT/B1xqRd3e5E6iVseEp3W55BnAelGM7SRr8A/Tyb5qz/efUzpHL/N1FcQCZn6l1XKsCNLbrafsfePK+hH6gR+5cb+zSGv7F0hFMKxVerS/iZKP25GdLXejEsyq24gCMrDkbobsTxIKKMw/RDIuLfxs5BsLacKZNf5YklBsLXTOFUYKps8auTiWKBvowwTF2koCwXGuXsPZqJKpOZfjqQLXI5xIunpKwJSo0gZUIp/euyWqiqaBfN3BXOaXBtasXuQeCKZQ14G54b1d8ntPqC1jx+ILg0t5awAybD5iqR+9a6eMhWoDXHXDpdfg==\""
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderManifestParsingTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderManifestParsingTest.kt
@@ -5,6 +5,9 @@ import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
 import androidx.test.platform.app.InstrumentationRegistry
 import expo.modules.updates.UpdatesConfiguration
 import expo.modules.updates.manifest.UpdateManifest
+import expo.modules.updates.codesigning.CertificateFixtures
+import expo.modules.updates.codesigning.TestCertificateType
+import expo.modules.updates.codesigning.getTestCertificate
 import io.mockk.every
 import io.mockk.mockk
 import okhttp3.*
@@ -16,12 +19,6 @@ import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
 
-private const val classicJSON = "{\"sdkVersion\":\"39.0.0\",\"releaseId\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"commitTime\":\"2020-11-11T00:17:54.797Z\",\"bundleUrl\":\"https://url.to/bundle.js\"}"
-
-private const val newJSON = "{\"id\":\"0754dad0-d200-d634-113c-ef1f26106028\",\"createdAt\":\"2021-11-23T00:57:14.437Z\",\"runtimeVersion\":\"1\",\"assets\":[{\"hash\":\"cb65fafb5ed456fc3ed8a726cf4087d37b875184eba96f33f6d99104e6e2266d\",\"key\":\"489ea2f19fa850b65653ab445637a181.jpg\",\"contentType\":\"image/jpeg\",\"url\":\"http://192.168.64.1:3000/api/assets?asset=updates/1/assets/489ea2f19fa850b65653ab445637a181&runtimeVersion=1&platform=android\",\"fileExtension\":\".jpg\"}],\"launchAsset\":{\"hash\":\"323ddd1968ee76d4ddbb16b04fb2c3f1b6d1ab9b637d819699fecd6fa0ffb1a8\",\"key\":\"696a70cf7035664c20ea86f67dae822b.bundle\",\"contentType\":\"application/javascript\",\"url\":\"http://192.168.64.1:3000/api/assets?asset=updates/1/bundles/android-696a70cf7035664c20ea86f67dae822b.js&runtimeVersion=1&platform=android\",\"fileExtension\":\".bundle\"}}"
-private const val newJSONCertificate = "-----BEGIN CERTIFICATE-----\nMIIDfzCCAmegAwIBAgIJLGiqnjmA9JmpMA0GCSqGSIb3DQEBCwUAMGkxFDASBgNV\nBAMTC2V4YW1wbGUub3JnMQswCQYDVQQGEwJVUzERMA8GA1UECBMIVmlyZ2luaWEx\nEzARBgNVBAcTCkJsYWNrc2J1cmcxDTALBgNVBAoTBFRlc3QxDTALBgNVBAsTBFRl\nc3QwHhcNMjExMTIyMTc0NzQzWhcNMjIxMTIyMTc0NzQzWjBpMRQwEgYDVQQDEwtl\neGFtcGxlLm9yZzELMAkGA1UEBhMCVVMxETAPBgNVBAgTCFZpcmdpbmlhMRMwEQYD\nVQQHEwpCbGFja3NidXJnMQ0wCwYDVQQKEwRUZXN0MQ0wCwYDVQQLEwRUZXN0MIIB\nIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAucg/fRwgYLxO4fDG1W/ew4Wu\nkqp2+j9mLyA18sd8noCT0eSJwxMTLJJq4biNx6kJEVSQdodN3e/qSJndz+ZHA7b1\n6Do3Ecg5oRvl3HEwaH4AkM2Lj87VjgfxPUsiSHtPd+RTbxnOy9lGupQa/j71WrAq\nzJpNmhP70vzkY4EVejn52kzRPZB3kTxkjggFrG/f18Bcf4VYxN3aLML32jih+UC0\n6fv57HNZZ3ewGSJrLcUdEgctBWiz1gzwF6YdXtEJ14eQbgHgsLsXaEQeg2ncGGxF\n/3rIhsnlWjeIIya7TS0nvqZHNKznZV9EWpZQBFVoLGGrvOdU3pTmP39qbmY0nwID\nAQABoyowKDAOBgNVHQ8BAf8EBAMCB4AwFgYDVR0lAQH/BAwwCgYIKwYBBQUHAwMw\nDQYJKoZIhvcNAQELBQADggEBAALcH9Jb3wq64YkNxUIa25T9umhr4uRe94ESHujM\nIRrBbbqu1p3Vs8N3whZNhcL6Djb4ob18m/aGKbF+UQBMvhn23qRCG6KKzIeDY6Os\n8tYyIwush2XeOFA7S5syPqVBI6PrRBDMCLmAJO4qTM2p0f+zyFXFuytCXOv2fA3M\n88aYVmU7NIfBTFdqNIgSt1yj7FKvd5zgoUyu7mTVdzY59xQzkzYTsnobY2XrTcvY\n6wyRqOAQ86wR8OvDjHB5y/YN2Pdg7d9jUFBCX6Ohr7W3GHrjAadKwq+kbH1aP0oB\nQTFLQQfl3gtJ3Dl/5iBQD38sCIkA54FPSsKTRw3mC4DImBQ=\n-----END CERTIFICATE-----"
-private const val newJSONSignature = "sig=\"VpuLfRlB0DizR+hRWmedPGHdx/nzNJ8OomMZNGHwqx64zrx1XezriBoItup/icOlXFrqs6FHaul4g5m41JfEWCUbhXC4x+iNk//bxozEYJHmjbcAtC6xhWbMMYQQaUjuYk7rEL987AbOWyUI2lMhrhK7LNzBaT8RGqBcpEyAqIOMuEKcK0faySnWJylc7IzxHmO8jlx5ufzio8301wej8mNW5dZd7PFOX8Dz015tIpF00VGi29ShDNFbpnalch7f92NFs08Z0g9LXndmrGjNL84Wqd4kq5awRGQObrCuDHU4uFdZjtr4ew0JaNlVuyUrrjyDloBdq0aR804vuDXacQ==\""
-
 @RunWith(AndroidJUnit4ClassRunner::class)
 class FileDownloaderManifestParsingTest {
   @Test
@@ -32,7 +29,7 @@ class FileDownloaderManifestParsingTest {
     val response = mockk<Response>().apply {
       every { header("content-type") } returns contentType
       every { headers } returns mapOf("content-type" to contentType).toHeaders()
-      every { body } returns ResponseBody.create("application/json; charset=utf-8".toMediaTypeOrNull(), classicJSON)
+      every { body } returns ResponseBody.create("application/json; charset=utf-8".toMediaTypeOrNull(), CertificateFixtures.testClassicBody)
     }
 
     val configuration = UpdatesConfiguration(
@@ -79,7 +76,7 @@ class FileDownloaderManifestParsingTest {
       )
       .addPart(
         mapOf("Content-Disposition" to "form-data; name=\"manifest\"; filename=\"hello2\"").toHeaders(),
-        RequestBody.create("application/json; charset=utf-8".toMediaTypeOrNull(), classicJSON)
+        RequestBody.create("application/json; charset=utf-8".toMediaTypeOrNull(), CertificateFixtures.testClassicBody)
       )
       .addPart(
         mapOf("Content-Disposition" to "form-data; name=\"extensions\"; filename=\"hello3\"").toHeaders(),
@@ -130,7 +127,7 @@ class FileDownloaderManifestParsingTest {
       "expo-protocol-version" to "0",
       "expo-sfv-version" to "0",
       "content-type" to contentType,
-      "expo-signature" to newJSONSignature
+      "expo-signature" to CertificateFixtures.testSignature
     )
 
     val context = InstrumentationRegistry.getInstrumentation().targetContext
@@ -140,14 +137,14 @@ class FileDownloaderManifestParsingTest {
         every { header(it.key) } returns it.value
       }
       every { headers } returns headersMap.toHeaders()
-      every { body } returns ResponseBody.create("application/json; charset=utf-8".toMediaTypeOrNull(), newJSON)
+      every { body } returns ResponseBody.create("application/json; charset=utf-8".toMediaTypeOrNull(), CertificateFixtures.testBody)
     }
 
     val configuration = UpdatesConfiguration(
       null,
       mapOf(
         UpdatesConfiguration.UPDATES_CONFIGURATION_UPDATE_URL_KEY to Uri.parse("https://exp.host/@test/test"),
-        UpdatesConfiguration.UPDATES_CONFIGURATION_CODE_SIGNING_CERTIFICATE to newJSONCertificate,
+        UpdatesConfiguration.UPDATES_CONFIGURATION_CODE_SIGNING_CERTIFICATE to getTestCertificate(TestCertificateType.VALID),
         UpdatesConfiguration.UPDATES_CONFIGURATION_CODE_SIGNING_METADATA to mapOf<String, String>(),
       )
     )
@@ -196,10 +193,10 @@ class FileDownloaderManifestParsingTest {
       .addPart(
         mapOf(
           "Content-Disposition" to "form-data; name=\"manifest\"; filename=\"hello2\"",
-          "expo-signature" to newJSONSignature
+          "expo-signature" to CertificateFixtures.testSignature
         )
           .toHeaders(),
-        RequestBody.create("application/json; charset=utf-8".toMediaTypeOrNull(), newJSON)
+        RequestBody.create("application/json; charset=utf-8".toMediaTypeOrNull(), CertificateFixtures.testBody)
       )
       .addPart(
         mapOf("Content-Disposition" to "form-data; name=\"extensions\"; filename=\"hello3\"").toHeaders(),
@@ -221,7 +218,7 @@ class FileDownloaderManifestParsingTest {
       null,
       mapOf(
         UpdatesConfiguration.UPDATES_CONFIGURATION_UPDATE_URL_KEY to Uri.parse("https://exp.host/@test/test"),
-        UpdatesConfiguration.UPDATES_CONFIGURATION_CODE_SIGNING_CERTIFICATE to newJSONCertificate,
+        UpdatesConfiguration.UPDATES_CONFIGURATION_CODE_SIGNING_CERTIFICATE to getTestCertificate(TestCertificateType.VALID),
         UpdatesConfiguration.UPDATES_CONFIGURATION_CODE_SIGNING_METADATA to mapOf<String, String>(),
       )
     )
@@ -262,14 +259,14 @@ class FileDownloaderManifestParsingTest {
         every { header(it.key) } returns it.value
       }
       every { headers } returns headersMap.toHeaders()
-      every { body } returns ResponseBody.create("application/json; charset=utf-8".toMediaTypeOrNull(), newJSON)
+      every { body } returns ResponseBody.create("application/json; charset=utf-8".toMediaTypeOrNull(), CertificateFixtures.testBody)
     }
 
     val configuration = UpdatesConfiguration(
       null,
       mapOf(
         UpdatesConfiguration.UPDATES_CONFIGURATION_UPDATE_URL_KEY to Uri.parse("https://exp.host/@test/test"),
-        UpdatesConfiguration.UPDATES_CONFIGURATION_CODE_SIGNING_CERTIFICATE to newJSONCertificate,
+        UpdatesConfiguration.UPDATES_CONFIGURATION_CODE_SIGNING_CERTIFICATE to getTestCertificate(TestCertificateType.VALID),
         UpdatesConfiguration.UPDATES_CONFIGURATION_CODE_SIGNING_METADATA to mapOf<String, String>(),
       )
     )
@@ -292,5 +289,55 @@ class FileDownloaderManifestParsingTest {
 
     Assert.assertEquals(errorOccurred!!.message, "No expo-signature header specified")
     Assert.assertNull(resultUpdateManifest)
+  }
+
+  @Test
+  @Throws(JSONException::class)
+  fun testManifestParsing_JSONBodySigned_UnsignedRequest_ManifestSignatureOptional() {
+    val contentType = "application/json"
+    val headersMap = mapOf(
+      "expo-protocol-version" to "0",
+      "expo-sfv-version" to "0",
+      "content-type" to contentType
+    )
+
+    val context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    val response = mockk<Response>().apply {
+      headersMap.forEach {
+        every { header(it.key) } returns it.value
+      }
+      every { headers } returns headersMap.toHeaders()
+      every { body } returns ResponseBody.create("application/json; charset=utf-8".toMediaTypeOrNull(), CertificateFixtures.testBody)
+    }
+
+    val configuration = UpdatesConfiguration(
+      null,
+      mapOf(
+        UpdatesConfiguration.UPDATES_CONFIGURATION_UPDATE_URL_KEY to Uri.parse("https://exp.host/@test/test"),
+        UpdatesConfiguration.UPDATES_CONFIGURATION_CODE_SIGNING_CERTIFICATE to getTestCertificate(TestCertificateType.VALID),
+        UpdatesConfiguration.UPDATES_CONFIGURATION_CODE_SIGNING_METADATA to mapOf<String, String>(),
+        UpdatesConfiguration.UPDATES_CONFIGURATION_CODE_SIGNING_ALLOW_UNSIGNED_MANIFESTS to true,
+      )
+    )
+
+    var errorOccurred = false
+    var resultUpdateManifest: UpdateManifest? = null
+
+    FileDownloader(context).parseManifestResponse(
+      response, configuration,
+      object : FileDownloader.ManifestDownloadCallback {
+        override fun onFailure(message: String, e: Exception) {
+          errorOccurred = true
+        }
+
+        override fun onSuccess(updateManifest: UpdateManifest) {
+          resultUpdateManifest = updateManifest
+        }
+      }
+    )
+
+    Assert.assertFalse(errorOccurred)
+    Assert.assertNotNull(resultUpdateManifest)
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.kt
@@ -21,6 +21,7 @@ class UpdatesConfiguration private constructor (
   val codeSigningCertificate: String?,
   val codeSigningMetadata: Map<String, String>?,
   val codeSigningIncludeManifestResponseCertificateChain: Boolean,
+  val codeSigningAllowUnsignedManifests: Boolean,
 ) {
   enum class CheckAutomaticallyConfiguration {
     NEVER, ERROR_RECOVERY_ONLY, WIFI_ONLY, ALWAYS
@@ -66,6 +67,9 @@ class UpdatesConfiguration private constructor (
     codeSigningIncludeManifestResponseCertificateChain = overrideMap?.readValueCheckingType<Boolean>(
       UPDATES_CONFIGURATION_CODE_SIGNING_INCLUDE_MANIFEST_RESPONSE_CERTIFICATE_CHAIN
     ) ?: context?.getMetadataValue("expo.modules.updates.CODE_SIGNING_INCLUDE_MANIFEST_RESPONSE_CERTIFICATE_CHAIN") ?: false,
+    codeSigningAllowUnsignedManifests = overrideMap?.readValueCheckingType<Boolean>(
+      UPDATES_CONFIGURATION_CODE_SIGNING_ALLOW_UNSIGNED_MANIFESTS
+    ) ?: context?.getMetadataValue("expo.modules.updates.CODE_SIGNING_ALLOW_UNSIGNED_MANIFESTS") ?: false,
   )
 
   val isMissingRuntimeVersion: Boolean
@@ -74,7 +78,7 @@ class UpdatesConfiguration private constructor (
 
   val codeSigningConfiguration: CodeSigningConfiguration? by lazy {
     codeSigningCertificate?.let {
-      CodeSigningConfiguration(it, codeSigningMetadata, codeSigningIncludeManifestResponseCertificateChain)
+      CodeSigningConfiguration(it, codeSigningMetadata, codeSigningIncludeManifestResponseCertificateChain, codeSigningAllowUnsignedManifests)
     }
   }
 
@@ -96,6 +100,7 @@ class UpdatesConfiguration private constructor (
     const val UPDATES_CONFIGURATION_CODE_SIGNING_CERTIFICATE = "codeSigningCertificate"
     const val UPDATES_CONFIGURATION_CODE_SIGNING_METADATA = "codeSigningMetadata"
     const val UPDATES_CONFIGURATION_CODE_SIGNING_INCLUDE_MANIFEST_RESPONSE_CERTIFICATE_CHAIN = "codeSigningIncludeManifestResponseCertificateChain"
+    const val UPDATES_CONFIGURATION_CODE_SIGNING_ALLOW_UNSIGNED_MANIFESTS = "codeSigningAllowUnsignedManifests"
 
     private const val UPDATES_CONFIGURATION_RELEASE_CHANNEL_DEFAULT_VALUE = "default"
     private const val UPDATES_CONFIGURATION_LAUNCH_WAIT_MS_DEFAULT_VALUE = 0

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/codesigning/CodeSigningConfiguration.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/codesigning/CodeSigningConfiguration.kt
@@ -40,7 +40,7 @@ class CodeSigningConfiguration(
       if (!allowUnsignedManifests) {
         throw Exception("No expo-signature header specified")
       } else {
-        // approve this
+        // no-op
         return
       }
     }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/codesigning/SignatureHeaderInfo.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/codesigning/SignatureHeaderInfo.kt
@@ -9,11 +9,7 @@ const val CODE_SIGNING_SIGNATURE_STRUCTURED_FIELD_KEY_ALGORITHM = "alg"
 
 data class SignatureHeaderInfo(val signature: String, val keyId: String, val algorithm: CodeSigningAlgorithm) {
   companion object {
-    fun parseSignatureHeader(signatureHeader: String?): SignatureHeaderInfo {
-      if (signatureHeader == null) {
-        throw Exception("No expo-signature header specified")
-      }
-
+    fun parseSignatureHeader(signatureHeader: String): SignatureHeaderInfo {
       val signatureMap = Parser(signatureHeader).parseDictionary().get()
 
       val sigFieldValue = signatureMap[CODE_SIGNING_SIGNATURE_STRUCTURED_FIELD_KEY_SIGNATURE]

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
@@ -25,7 +25,6 @@ import java.io.ByteArrayOutputStream
 import android.util.Base64
 import okhttp3.Headers.Companion.toHeaders
 import expo.modules.jsonutils.getNullable
-import expo.modules.updates.codesigning.SignatureHeaderInfo
 
 open class FileDownloader(private val client: OkHttpClient) {
   constructor(context: Context) : this(OkHttpClient.Builder().cache(getCache(context)).build())
@@ -386,14 +385,10 @@ open class FileDownloader(private val client: OkHttpClient) {
       callback: ManifestDownloadCallback
     ) {
       configuration.codeSigningConfiguration?.validateSignature(
-        SignatureHeaderInfo.parseSignatureHeader(manifestHeaderData.signature),
+        manifestHeaderData.signature,
         bodyString.toByteArray(),
-        certificateChainFromManifestResponse,
-      )?.let {
-        if (!it) {
-          throw IOException("Manifest download was successful, but signature was incorrect")
-        }
-      }
+        certificateChainFromManifestResponse
+      )
 
       if (configuration.expectsSignedManifest) {
         preManifest.put("isVerified", isVerified)


### PR DESCRIPTION
# Why

Previously, if a code signing certificate was supplied (set in configuration) it was assumed that all manifests needed to be signed. This was fine for EAS on the server since the server supports code signing.

https://github.com/expo/expo/pull/16375 added a certificate for Expo Go, but didn't relax the constraint. Expo Go may be talking to servers that don't yet support code signing (for example, the Expo dev server) or old versions of servers (old Expo dev servers).

This PR adds a config flag used by Expo Go to allow responses to not have a code signing signature even if one was requested. For now, this just skips verification in that case. In a future PR (re-revert of https://github.com/expo/expo/pull/16607), when a signature is not return yet one is requested, the new code signing mechanism won't set the `isVerified` flag on the manifest (and will rely upon the legacy manifest signature mechanism). This will allow a graceful and safe transition from the old manifest signing to the new manifest signing.

# How

Add flag, add tests. 

# Test Plan

Run tests, Load locally-served manifest in locally-built Expo Go, ensure it loads.