### PR TITLE
[sweet api][Kotlin] Add `asyncFunction` component and deprecate `function` component

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AnyFunction.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AnyFunction.kt
@@ -1,4 +1,4 @@
-package expo.modules.kotlin.methods
+package expo.modules.kotlin.functions
 
 import com.facebook.react.bridge.ReadableArray
 import expo.modules.kotlin.Promise
@@ -10,7 +10,7 @@ import expo.modules.kotlin.iterator
 import expo.modules.kotlin.recycle
 import expo.modules.kotlin.types.AnyType
 
-abstract class AnyMethod(
+abstract class AnyFunction(
   protected val name: String,
   private val desiredArgsTypes: Array<AnyType>
 ) {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunction.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunction.kt
@@ -1,15 +1,14 @@
-package expo.modules.kotlin.methods
+package expo.modules.kotlin.functions
 
 import expo.modules.kotlin.Promise
 import expo.modules.kotlin.types.AnyType
 
-class PromiseMethod(
+class AsyncFunction(
   name: String,
   argsType: Array<AnyType>,
-  private val body: (args: Array<out Any?>, promise: Promise) -> Unit
-) : AnyMethod(name, argsType) {
-
+  private val body: (args: Array<out Any?>) -> Any?
+) : AnyFunction(name, argsType) {
   override fun callImplementation(args: Array<out Any?>, promise: Promise) {
-    body(args, promise)
+    promise.resolve(body(args))
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunctionWithPromise.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunctionWithPromise.kt
@@ -1,14 +1,14 @@
-package expo.modules.kotlin.methods
+package expo.modules.kotlin.functions
 
 import expo.modules.kotlin.Promise
 import expo.modules.kotlin.types.AnyType
 
-class Method(
+class AsyncFunctionWithPromise(
   name: String,
   argsType: Array<AnyType>,
-  private val body: (args: Array<out Any?>) -> Any?
-) : AnyMethod(name, argsType) {
+  private val body: (args: Array<out Any?>, promise: Promise) -> Unit
+) : AnyFunction(name, argsType) {
   override fun callImplementation(args: Array<out Any?>, promise: Promise) {
-    promise.resolve(body(args))
+    body(args, promise)
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionBuilder.kt
@@ -23,9 +23,9 @@ import expo.modules.kotlin.events.EventListenerWithSenderAndPayload
 import expo.modules.kotlin.events.EventName
 import expo.modules.kotlin.events.EventsDefinition
 import expo.modules.kotlin.events.OnActivityResultPayload
-import expo.modules.kotlin.methods.AnyMethod
-import expo.modules.kotlin.methods.Method
-import expo.modules.kotlin.methods.PromiseMethod
+import expo.modules.kotlin.functions.AnyFunction
+import expo.modules.kotlin.functions.AsyncFunction
+import expo.modules.kotlin.functions.AsyncFunctionWithPromise
 import expo.modules.kotlin.types.toAnyType
 import expo.modules.kotlin.views.ViewManagerDefinition
 import expo.modules.kotlin.views.ViewManagerDefinitionBuilder
@@ -38,7 +38,7 @@ class ModuleDefinitionBuilder(private val module: Module? = null) {
   private var eventsDefinition: EventsDefinition? = null
 
   @PublishedApi
-  internal var methods = mutableMapOf<String, AnyMethod>()
+  internal var methods = mutableMapOf<String, AnyFunction>()
 
   @PublishedApi
   internal var viewManagerDefinition: ViewManagerDefinition? = null
@@ -80,106 +80,249 @@ class ModuleDefinitionBuilder(private val module: Module? = null) {
     constantsProvider = { constants.toMap() }
   }
 
-  @JvmName("methodWithoutArgs")
+  @Deprecated(
+    message = "The 'function' component was deprecated and will be removed in the future.",
+    replaceWith = ReplaceWith("asyncFunction(name, body)")
+  )
+  @JvmName("functionWithoutArgs")
   inline fun function(
     name: String,
     crossinline body: () -> Any?
   ) {
-    methods[name] = Method(name, arrayOf()) { body() }
+    methods[name] = AsyncFunction(name, arrayOf()) { body() }
   }
 
+  @Deprecated(
+    message = "The 'function' component was deprecated and will be removed in the future.",
+    replaceWith = ReplaceWith("asyncFunction(name, body)")
+  )
   inline fun <reified R> function(
     name: String,
     crossinline body: () -> R
   ) {
-    methods[name] = Method(name, arrayOf()) { body() }
+    methods[name] = AsyncFunction(name, arrayOf()) { body() }
   }
 
+  @Deprecated(
+    message = "The 'function' component was deprecated and will be removed in the future.",
+    replaceWith = ReplaceWith("asyncFunction(name, body)")
+  )
   inline fun <reified R, reified P0> function(
     name: String,
     crossinline body: (p0: P0) -> R
   ) {
     methods[name] = if (P0::class == Promise::class) {
-      PromiseMethod(name, arrayOf()) { _, promise -> body(promise as P0) }
+      AsyncFunctionWithPromise(name, arrayOf()) { _, promise -> body(promise as P0) }
     } else {
-      Method(name, arrayOf(typeOf<P0>().toAnyType())) { body(it[0] as P0) }
+      AsyncFunction(name, arrayOf(typeOf<P0>().toAnyType())) { body(it[0] as P0) }
     }
   }
 
+  @Deprecated(
+    message = "The 'function' component was deprecated and will be removed in the future.",
+    replaceWith = ReplaceWith("asyncFunction(name, body)")
+  )
   inline fun <reified R, reified P0, reified P1> function(
     name: String,
     crossinline body: (p0: P0, p1: P1) -> R
   ) {
     methods[name] = if (P1::class == Promise::class) {
-      PromiseMethod(name, arrayOf(typeOf<P0>().toAnyType())) { args, promise -> body(args[0] as P0, promise as P1) }
+      AsyncFunctionWithPromise(name, arrayOf(typeOf<P0>().toAnyType())) { args, promise -> body(args[0] as P0, promise as P1) }
     } else {
-      Method(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType())) { body(it[0] as P0, it[1] as P1) }
+      AsyncFunction(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType())) { body(it[0] as P0, it[1] as P1) }
     }
   }
 
+  @Deprecated(
+    message = "The 'function' component was deprecated and will be removed in the future.",
+    replaceWith = ReplaceWith("asyncFunction(name, body)")
+  )
   inline fun <reified R, reified P0, reified P1, reified P2> function(
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2) -> R
   ) {
     methods[name] = if (P2::class == Promise::class) {
-      PromiseMethod(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType())) { args, promise -> body(args[0] as P0, args[1] as P1, promise as P2) }
+      AsyncFunctionWithPromise(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType())) { args, promise -> body(args[0] as P0, args[1] as P1, promise as P2) }
     } else {
-      Method(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2) }
+      AsyncFunction(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2) }
     }
   }
 
+  @Deprecated(
+    message = "The 'function' component was deprecated and will be removed in the future.",
+    replaceWith = ReplaceWith("asyncFunction(name, body)")
+  )
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3> function(
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3) -> R
   ) {
     methods[name] = if (P3::class == Promise::class) {
-      PromiseMethod(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, promise as P3) }
+      AsyncFunctionWithPromise(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, promise as P3) }
     } else {
-      Method(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3) }
+      AsyncFunction(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3) }
     }
   }
 
+  @Deprecated(
+    message = "The 'function' component was deprecated and will be removed in the future.",
+    replaceWith = ReplaceWith("asyncFunction(name, body)")
+  )
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4> function(
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4) -> R
   ) {
     methods[name] = if (P4::class == Promise::class) {
-      PromiseMethod(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, promise as P4) }
+      AsyncFunctionWithPromise(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, promise as P4) }
     } else {
-      Method(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4) }
+      AsyncFunction(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4) }
     }
   }
 
+  @Deprecated(
+    message = "The 'function' component was deprecated and will be removed in the future.",
+    replaceWith = ReplaceWith("asyncFunction(name, body)")
+  )
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5> function(
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) -> R
   ) {
     methods[name] = if (P5::class == Promise::class) {
-      PromiseMethod(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, args[4] as P4, promise as P5) }
+      AsyncFunctionWithPromise(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, args[4] as P4, promise as P5) }
     } else {
-      Method(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType(), typeOf<P5>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5) }
+      AsyncFunction(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType(), typeOf<P5>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5) }
     }
   }
 
+  @Deprecated(
+    message = "The 'function' component was deprecated and will be removed in the future.",
+    replaceWith = ReplaceWith("asyncFunction(name, body)")
+  )
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6> function(
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6) -> R
   ) {
     methods[name] = if (P6::class == Promise::class) {
-      PromiseMethod(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType(), typeOf<P5>().toAnyType())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, args[4] as P4, args[5] as P5, promise as P6) }
+      AsyncFunctionWithPromise(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType(), typeOf<P5>().toAnyType())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, args[4] as P4, args[5] as P5, promise as P6) }
     } else {
-      Method(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType(), typeOf<P5>().toAnyType(), typeOf<P6>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5, it[6] as P6) }
+      AsyncFunction(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType(), typeOf<P5>().toAnyType(), typeOf<P6>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5, it[6] as P6) }
     }
   }
 
+  @Deprecated(
+    message = "The 'function' component was deprecated and will be removed in the future.",
+    replaceWith = ReplaceWith("asyncFunction(name, body)")
+  )
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6, reified P7> function(
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7) -> R
   ) {
     methods[name] = if (P7::class == Promise::class) {
-      PromiseMethod(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType(), typeOf<P5>().toAnyType(), typeOf<P6>().toAnyType())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, args[4] as P4, args[5] as P5, args[6] as P6, promise as P7) }
+      AsyncFunctionWithPromise(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType(), typeOf<P5>().toAnyType(), typeOf<P6>().toAnyType())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, args[4] as P4, args[5] as P5, args[6] as P6, promise as P7) }
     } else {
-      Method(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType(), typeOf<P5>().toAnyType(), typeOf<P6>().toAnyType(), typeOf<P7>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5, it[6] as P6, it[7] as P7) }
+      AsyncFunction(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType(), typeOf<P5>().toAnyType(), typeOf<P6>().toAnyType(), typeOf<P7>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5, it[6] as P6, it[7] as P7) }
+    }
+  }
+
+  @JvmName("asyncFunctionWithoutArgs")
+  inline fun asyncFunction(
+    name: String,
+    crossinline body: () -> Any?
+  ) {
+    methods[name] = AsyncFunction(name, arrayOf()) { body() }
+  }
+
+  inline fun <reified R> asyncFunction(
+    name: String,
+    crossinline body: () -> R
+  ) {
+    methods[name] = AsyncFunction(name, arrayOf()) { body() }
+  }
+
+  inline fun <reified R, reified P0> asyncFunction(
+    name: String,
+    crossinline body: (p0: P0) -> R
+  ) {
+    methods[name] = if (P0::class == Promise::class) {
+      AsyncFunctionWithPromise(name, arrayOf()) { _, promise -> body(promise as P0) }
+    } else {
+      AsyncFunction(name, arrayOf(typeOf<P0>().toAnyType())) { body(it[0] as P0) }
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1> asyncFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1) -> R
+  ) {
+    methods[name] = if (P1::class == Promise::class) {
+      AsyncFunctionWithPromise(name, arrayOf(typeOf<P0>().toAnyType())) { args, promise -> body(args[0] as P0, promise as P1) }
+    } else {
+      AsyncFunction(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType())) { body(it[0] as P0, it[1] as P1) }
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1, reified P2> asyncFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2) -> R
+  ) {
+    methods[name] = if (P2::class == Promise::class) {
+      AsyncFunctionWithPromise(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType())) { args, promise -> body(args[0] as P0, args[1] as P1, promise as P2) }
+    } else {
+      AsyncFunction(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2) }
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3> asyncFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3) -> R
+  ) {
+    methods[name] = if (P3::class == Promise::class) {
+      AsyncFunctionWithPromise(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, promise as P3) }
+    } else {
+      AsyncFunction(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3) }
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4> asyncFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4) -> R
+  ) {
+    methods[name] = if (P4::class == Promise::class) {
+      AsyncFunctionWithPromise(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, promise as P4) }
+    } else {
+      AsyncFunction(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4) }
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5> asyncFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) -> R
+  ) {
+    methods[name] = if (P5::class == Promise::class) {
+      AsyncFunctionWithPromise(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, args[4] as P4, promise as P5) }
+    } else {
+      AsyncFunction(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType(), typeOf<P5>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5) }
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6> asyncFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6) -> R
+  ) {
+    methods[name] = if (P6::class == Promise::class) {
+      AsyncFunctionWithPromise(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType(), typeOf<P5>().toAnyType())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, args[4] as P4, args[5] as P5, promise as P6) }
+    } else {
+      AsyncFunction(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType(), typeOf<P5>().toAnyType(), typeOf<P6>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5, it[6] as P6) }
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6, reified P7> asyncFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7) -> R
+  ) {
+    methods[name] = if (P7::class == Promise::class) {
+      AsyncFunctionWithPromise(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType(), typeOf<P5>().toAnyType(), typeOf<P6>().toAnyType())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, args[4] as P4, args[5] as P5, args[6] as P6, promise as P7) }
+    } else {
+      AsyncFunction(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType(), typeOf<P5>().toAnyType(), typeOf<P6>().toAnyType(), typeOf<P7>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5, it[6] as P6, it[7] as P7) }
     }
   }
 
@@ -240,14 +383,14 @@ class ModuleDefinitionBuilder(private val module: Module? = null) {
    * Creates module's lifecycle listener that is called right after the first event listener is added.
    */
   inline fun onStartObserving(crossinline body: () -> Unit) {
-    function("startObserving", body)
+    asyncFunction("startObserving", body)
   }
 
   /**
    * Creates module's lifecycle listener that is called right after all event listeners are removed.
    */
   inline fun onStopObserving(crossinline body: () -> Unit) {
-    function("stopObserving", body)
+    asyncFunction("stopObserving", body)
   }
 
   /**

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionBuilder.kt
@@ -81,7 +81,7 @@ class ModuleDefinitionBuilder(private val module: Module? = null) {
   }
 
   @Deprecated(
-    message = "The 'function' component was deprecated and will be removed in the future.",
+    message = "The 'function' component was deprecated and will change its behavior in the future.",
     replaceWith = ReplaceWith("asyncFunction(name, body)")
   )
   @JvmName("functionWithoutArgs")
@@ -93,7 +93,7 @@ class ModuleDefinitionBuilder(private val module: Module? = null) {
   }
 
   @Deprecated(
-    message = "The 'function' component was deprecated and will be removed in the future.",
+    message = "The 'function' component was deprecated and will change its behavior in the future.",
     replaceWith = ReplaceWith("asyncFunction(name, body)")
   )
   inline fun <reified R> function(
@@ -104,7 +104,7 @@ class ModuleDefinitionBuilder(private val module: Module? = null) {
   }
 
   @Deprecated(
-    message = "The 'function' component was deprecated and will be removed in the future.",
+    message = "The 'function' component was deprecated and will change its behavior in the future.",
     replaceWith = ReplaceWith("asyncFunction(name, body)")
   )
   inline fun <reified R, reified P0> function(
@@ -119,7 +119,7 @@ class ModuleDefinitionBuilder(private val module: Module? = null) {
   }
 
   @Deprecated(
-    message = "The 'function' component was deprecated and will be removed in the future.",
+    message = "The 'function' component was deprecated and will change its behavior in the future.",
     replaceWith = ReplaceWith("asyncFunction(name, body)")
   )
   inline fun <reified R, reified P0, reified P1> function(
@@ -134,7 +134,7 @@ class ModuleDefinitionBuilder(private val module: Module? = null) {
   }
 
   @Deprecated(
-    message = "The 'function' component was deprecated and will be removed in the future.",
+    message = "The 'function' component was deprecated and will change its behavior in the future.",
     replaceWith = ReplaceWith("asyncFunction(name, body)")
   )
   inline fun <reified R, reified P0, reified P1, reified P2> function(
@@ -149,7 +149,7 @@ class ModuleDefinitionBuilder(private val module: Module? = null) {
   }
 
   @Deprecated(
-    message = "The 'function' component was deprecated and will be removed in the future.",
+    message = "The 'function' component was deprecated and will change its behavior in the future.",
     replaceWith = ReplaceWith("asyncFunction(name, body)")
   )
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3> function(
@@ -164,7 +164,7 @@ class ModuleDefinitionBuilder(private val module: Module? = null) {
   }
 
   @Deprecated(
-    message = "The 'function' component was deprecated and will be removed in the future.",
+    message = "The 'function' component was deprecated and will change its behavior in the future.",
     replaceWith = ReplaceWith("asyncFunction(name, body)")
   )
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4> function(
@@ -179,7 +179,7 @@ class ModuleDefinitionBuilder(private val module: Module? = null) {
   }
 
   @Deprecated(
-    message = "The 'function' component was deprecated and will be removed in the future.",
+    message = "The 'function' component was deprecated and will change its behavior in the future.",
     replaceWith = ReplaceWith("asyncFunction(name, body)")
   )
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5> function(
@@ -194,7 +194,7 @@ class ModuleDefinitionBuilder(private val module: Module? = null) {
   }
 
   @Deprecated(
-    message = "The 'function' component was deprecated and will be removed in the future.",
+    message = "The 'function' component was deprecated and will change its behavior in the future.",
     replaceWith = ReplaceWith("asyncFunction(name, body)")
   )
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6> function(
@@ -209,7 +209,7 @@ class ModuleDefinitionBuilder(private val module: Module? = null) {
   }
 
   @Deprecated(
-    message = "The 'function' component was deprecated and will be removed in the future.",
+    message = "The 'function' component was deprecated and will change its behavior in the future.",
     replaceWith = ReplaceWith("asyncFunction(name, body)")
   )
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6, reified P7> function(

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionData.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionData.kt
@@ -3,13 +3,13 @@ package expo.modules.kotlin.modules
 import expo.modules.kotlin.events.EventListener
 import expo.modules.kotlin.events.EventName
 import expo.modules.kotlin.events.EventsDefinition
-import expo.modules.kotlin.methods.AnyMethod
+import expo.modules.kotlin.functions.AnyFunction
 import expo.modules.kotlin.views.ViewManagerDefinition
 
 class ModuleDefinitionData(
   val name: String,
   val constantsProvider: () -> Map<String, Any?>,
-  val methods: Map<String, AnyMethod>,
+  val methods: Map<String, AnyFunction>,
   val viewManagerDefinition: ViewManagerDefinition? = null,
   val eventListeners: Map<EventName, EventListener> = emptyMap(),
   val eventsDefinition: EventsDefinition? = null

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/functions/AnyFunctionTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/functions/AnyFunctionTest.kt
@@ -1,6 +1,6 @@
 @file:OptIn(ExperimentalStdlibApi::class)
 
-package expo.modules.kotlin.methods
+package expo.modules.kotlin.functions
 
 import com.facebook.react.bridge.JavaOnlyArray
 import com.google.common.truth.Truth
@@ -15,10 +15,10 @@ import org.junit.Test
 import kotlin.reflect.KType
 import kotlin.reflect.typeOf
 
-class AnyMethodTest {
-  class MockedAnyMethod(
+class AnyFunctionTest {
+  class MockedAnyFunction(
     desiredArgsTypes: Array<KType>
-  ) : AnyMethod("my-method", desiredArgsTypes.map { it.toAnyType() }.toTypedArray()) {
+  ) : AnyFunction("my-method", desiredArgsTypes.map { it.toAnyType() }.toTypedArray()) {
     override fun callImplementation(args: Array<out Any?>, promise: Promise) {
       throw NullPointerException()
     }
@@ -26,7 +26,7 @@ class AnyMethodTest {
 
   @Test
   fun `call should throw if pass more arguments then expected`() {
-    val method = MockedAnyMethod(arrayOf(typeOf<Int>()))
+    val method = MockedAnyFunction(arrayOf(typeOf<Int>()))
     val promise = PromiseMock()
 
     assertThrows<InvalidArgsNumberException>("Received 2 arguments, but 1 was expected.") {
@@ -44,7 +44,7 @@ class AnyMethodTest {
 
   @Test
   fun `call should throw if pass less arguments then expected`() {
-    val method = MockedAnyMethod(arrayOf(typeOf<Int>(), typeOf<Int>()))
+    val method = MockedAnyFunction(arrayOf(typeOf<Int>(), typeOf<Int>()))
     val promise = PromiseMock()
 
     assertThrows<InvalidArgsNumberException>("Received 1 arguments, but 2 was expected.") {
@@ -61,7 +61,7 @@ class AnyMethodTest {
 
   @Test
   fun `call should throw if cannot convert args`() {
-    val method = MockedAnyMethod(arrayOf(typeOf<Int>()))
+    val method = MockedAnyFunction(arrayOf(typeOf<Int>()))
     val promise = PromiseMock()
 
     assertThrows<ArgumentCastException>(
@@ -83,7 +83,7 @@ class AnyMethodTest {
 
   @Test
   fun `sync exception shouldn't be converter into promise rejection`() {
-    val method = MockedAnyMethod(emptyArray())
+    val method = MockedAnyFunction(emptyArray())
     val promise = PromiseMock()
 
     assertThrows<NullPointerException> {

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/functions/TypeConverterHelperTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/functions/TypeConverterHelperTest.kt
@@ -1,6 +1,6 @@
 @file:OptIn(ExperimentalStdlibApi::class)
 
-package expo.modules.kotlin.methods
+package expo.modules.kotlin.functions
 
 import com.facebook.react.bridge.DynamicFromObject
 import com.facebook.react.bridge.JavaOnlyArray


### PR DESCRIPTION
# Why

Part of https://linear.app/expo/issue/ENG-4358/migrate-function-asyncfunction-in-sweet-modules

# How

- Create an `asyncFunction` component.
- Rename `AnyMethod` -> `AnyFunction`
- Rename `AsyncMethod` -> `AsyncFunction`
- Rename `PromiseMethod` -> `AsyncFunctionWithPromise`
- Deprecate a `function` component.

