### PR TITLE
feat(cli): added custom metro terminal reporter to dev server

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [cli] Added modules for creating dev server URLs, akin to `UrlUtils` in `xdl`. ([#16557](https://github.com/expo/expo/pull/16557) by [@EvanBacon](https://github.com/EvanBacon))
 - [cli] Added shim for `expo start` command and option resolvers. ([#16587](https://github.com/expo/expo/pull/16587) by [@EvanBacon](https://github.com/EvanBacon))
 - [cli] Added module for interacting with Metro bundler. ([#16631](https://github.com/expo/expo/pull/16631) by [@EvanBacon](https://github.com/EvanBacon))
+- [cli] Added a custom terminal logger for Metro dev server. ([#16658](https://github.com/expo/expo/pull/16658) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo/cli/start/server/metro/MetroTerminalReporter.ts
+++ b/packages/expo/cli/start/server/metro/MetroTerminalReporter.ts
@@ -17,6 +17,11 @@ export class MetroTerminalReporter extends TerminalReporter {
   constructor(public projectRoot: string, terminal: Terminal) {
     super(terminal);
   }
+
+  // Used for testing
+  _getElapsedTime(startTime: number): number {
+    return Date.now() - startTime;
+  }
   /**
    * Extends the bundle progress to include the current platform that we're bundling.
    *
@@ -31,7 +36,7 @@ export class MetroTerminalReporter extends TerminalReporter {
       const color = phase === 'done' ? chalk.green : chalk.red;
 
       const startTime = this._bundleTimers.get(progress.bundleDetails.buildID);
-      const time = chalk.dim(Date.now() - startTime + 'ms');
+      const time = chalk.dim(this._getElapsedTime(startTime) + 'ms');
       // iOS Bundling complete 150ms
       return color(platform + status) + time;
     }
@@ -42,8 +47,12 @@ export class MetroTerminalReporter extends TerminalReporter {
     const _progress = inProgress
       ? chalk.green.bgGreen(DARK_BLOCK_CHAR.repeat(filledBar)) +
         chalk.bgWhite.white(LIGHT_BLOCK_CHAR.repeat(MAX_PROGRESS_BAR_CHAR_WIDTH - filledBar)) +
-        chalk.bold(` ${(100 * progress.ratio).toFixed(1)}% `) +
-        chalk.dim(`(${progress.transformedFileCount}/${progress.totalFileCount})`)
+        chalk.bold(` ${(100 * progress.ratio).toFixed(1).padStart(4)}% `) +
+        chalk.dim(
+          `(${progress.transformedFileCount
+            .toString()
+            .padStart(progress.totalFileCount.toString().length)}/${progress.totalFileCount})`
+        )
       : '';
 
     return (
@@ -80,10 +89,13 @@ export class MetroTerminalReporter extends TerminalReporter {
   dependencyGraphLoading(hasReducedPerformance: boolean): void {
     // this.terminal.log('Dependency graph is loading...');
     if (hasReducedPerformance) {
+      // Extends https://github.com/facebook/metro/blob/347b1d7ed87995d7951aaa9fd597c04b06013dac/packages/metro/src/lib/TerminalReporter.js#L283-L290
       this.terminal.log(
         chalk.red(
-          'Metro is operating with reduced performance.\n' +
-            'Please fix the problem above and restart Metro.\n\n'
+          [
+            'Metro is operating with reduced performance.',
+            'Please fix the problem above and restart Metro.',
+          ].join('\n')
         )
       );
     }

--- a/packages/expo/cli/start/server/metro/MetroTerminalReporter.ts
+++ b/packages/expo/cli/start/server/metro/MetroTerminalReporter.ts
@@ -68,6 +68,7 @@ export class MetroTerminalReporter extends TerminalReporter {
     return isAppRegistryStartupMessage(event.data);
   }
 
+  /** Print the cache clear message. */
   transformCacheReset(): void {
     logWarning(
       this.terminal,
@@ -141,6 +142,7 @@ export function formatUsingNodeStandardLibraryError(projectRoot: string, error: 
   return `Unable to resolve "${targetModuleName}" from "${relativePath}"`;
 }
 
+/** If the code frame can be found then append it to the existing message.  */
 function maybeAppendCodeFrame(message: string, rawMessage: string): string {
   const codeFrame = stripMetroInfo(rawMessage);
   if (codeFrame) {
@@ -149,6 +151,11 @@ function maybeAppendCodeFrame(message: string, rawMessage: string): string {
   return message;
 }
 
+/**
+ * Remove the Metro cache clearing steps if they exist.
+ * In future versions we won't need this.
+ * Returns the remaining code frame logs.
+ */
 export function stripMetroInfo(errorMessage: string): string {
   // Newer versions of Metro don't include the list.
   if (!errorMessage.includes('4. Remove the cache')) {
@@ -162,6 +169,7 @@ export function stripMetroInfo(errorMessage: string): string {
   return lines.slice(index + 1).join('\n');
 }
 
+/** @returns if the message matches the initial startup log */
 function isAppRegistryStartupMessage(body: any[]): boolean {
   return (
     body.length === 1 &&
@@ -170,7 +178,8 @@ function isAppRegistryStartupMessage(body: any[]): boolean {
   );
 }
 
-function getPlatformTagForBuildDetails(bundleDetails?: BundleDetails | null) {
+/** @returns platform specific tag for a `BundleDetails` object */
+function getPlatformTagForBuildDetails(bundleDetails?: BundleDetails | null): string {
   const platform = bundleDetails?.platform ?? null;
   if (platform) {
     const formatted = { ios: 'iOS', android: 'Android', web: 'Web' }[platform] || platform;
@@ -180,6 +189,7 @@ function getPlatformTagForBuildDetails(bundleDetails?: BundleDetails | null) {
   return '';
 }
 
+// A list of the Node.js standard library modules.
 const NODE_STDLIB_MODULES = [
   'assert',
   'async_hooks',

--- a/packages/expo/cli/start/server/metro/MetroTerminalReporter.ts
+++ b/packages/expo/cli/start/server/metro/MetroTerminalReporter.ts
@@ -1,0 +1,213 @@
+import chalk from 'chalk';
+import { Terminal } from 'metro-core';
+import path from 'path';
+
+import { learnMore } from '../../../utils/link';
+import { logWarning, TerminalReporter } from './TerminalReporter';
+import { BuildPhase, BundleDetails, BundleProgress, SnippetError } from './TerminalReporter.types';
+
+const MAX_PROGRESS_BAR_CHAR_WIDTH = 16;
+const DARK_BLOCK_CHAR = '\u2593';
+const LIGHT_BLOCK_CHAR = '\u2591';
+/**
+ * Extends the default Metro logger and adds some additional features.
+ * Also removes the giant Metro logo from the output.
+ */
+export class MetroTerminalReporter extends TerminalReporter {
+  constructor(public projectRoot: string, terminal: Terminal) {
+    super(terminal);
+  }
+  /**
+   * Extends the bundle progress to include the current platform that we're bundling.
+   *
+   * @returns `iOS path/to/bundle.js ▓▓▓▓▓░░░░░░░░░░░ 36.6% (4790/7922)`
+   */
+  _getBundleStatusMessage(progress: BundleProgress, phase: BuildPhase): string {
+    const platform = getPlatformTagForBuildDetails(progress.bundleDetails);
+    const inProgress = phase === 'in_progress';
+
+    if (!inProgress) {
+      const status = phase === 'done' ? `Bundling complete ` : `Bundling failed `;
+      const color = phase === 'done' ? chalk.green : chalk.red;
+
+      const startTime = this._bundleTimers.get(progress.bundleDetails.buildID);
+      const time = chalk.dim(Date.now() - startTime + 'ms');
+      // iOS Bundling complete 150ms
+      return color(platform + status) + time;
+    }
+
+    const localPath = path.relative('.', progress.bundleDetails.entryFile);
+    const filledBar = Math.floor(progress.ratio * MAX_PROGRESS_BAR_CHAR_WIDTH);
+
+    const _progress = inProgress
+      ? chalk.green.bgGreen(DARK_BLOCK_CHAR.repeat(filledBar)) +
+        chalk.bgWhite.white(LIGHT_BLOCK_CHAR.repeat(MAX_PROGRESS_BAR_CHAR_WIDTH - filledBar)) +
+        chalk.bold(` ${(100 * progress.ratio).toFixed(1)}% `) +
+        chalk.dim(`(${progress.transformedFileCount}/${progress.totalFileCount})`)
+      : '';
+
+    return (
+      platform +
+      chalk.reset.dim(`${path.dirname(localPath)}/`) +
+      chalk.bold(path.basename(localPath)) +
+      ' ' +
+      _progress
+    );
+  }
+
+  _logInitializing(port: number, hasReducedPerformance: boolean): void {
+    // Don't print a giant logo...
+    this.terminal.log('Starting Metro Bundler');
+  }
+
+  shouldFilterClientLog(event: {
+    type: 'client_log';
+    level: 'trace' | 'info' | 'warn' | 'log' | 'group' | 'groupCollapsed' | 'groupEnd' | 'debug';
+    data: unknown[];
+  }): boolean {
+    return isAppRegistryStartupMessage(event.data);
+  }
+
+  transformCacheReset(): void {
+    logWarning(
+      this.terminal,
+      chalk`Bundler cache is empty, rebuilding {dim (this may take a minute)}`
+    );
+  }
+
+  /** One of the first logs that will be printed */
+  dependencyGraphLoading(hasReducedPerformance: boolean): void {
+    // this.terminal.log('Dependency graph is loading...');
+    if (hasReducedPerformance) {
+      this.terminal.log(
+        chalk.red(
+          'Metro is operating with reduced performance.\n' +
+            'Please fix the problem above and restart Metro.\n\n'
+        )
+      );
+    }
+  }
+
+  _logBundlingError(error: SnippetError): void {
+    const moduleResolutionError = formatUsingNodeStandardLibraryError(this.projectRoot, error);
+    if (moduleResolutionError) {
+      return this.terminal.log(maybeAppendCodeFrame(moduleResolutionError, error.message));
+    }
+    return super._logBundlingError(error);
+  }
+}
+
+/**
+ * Formats an error where the user is attempting to import a module from the Node.js standard library.
+ * Exposed for testing.
+ *
+ * @param error
+ * @returns error message or null if not a module resolution error
+ */
+export function formatUsingNodeStandardLibraryError(projectRoot: string, error: SnippetError) {
+  if (!error.message) {
+    return null;
+  }
+  const { targetModuleName, originModulePath } = error;
+  if (!targetModuleName || !originModulePath) {
+    return null;
+  }
+  const relativePath = path.relative(projectRoot, originModulePath);
+
+  const DOCS_PAGE_URL =
+    'https://docs.expo.dev/workflow/using-libraries/#using-third-party-libraries';
+
+  if (NODE_STDLIB_MODULES.includes(targetModuleName)) {
+    if (originModulePath.includes('node_modules')) {
+      return [
+        `The package at "${chalk.bold(
+          relativePath
+        )}" attempted to import the Node standard library module "${chalk.bold(
+          targetModuleName
+        )}".`,
+        `It failed because the native React runtime does not include the Node standard library.`,
+        learnMore(DOCS_PAGE_URL),
+      ].join('\n');
+    } else {
+      return [
+        `You attempted attempted to import the Node standard library module "${chalk.bold(
+          targetModuleName
+        )}" from "${chalk.bold(relativePath)}".`,
+        `It failed because the native React runtime does not include the Node standard library.`,
+        learnMore(DOCS_PAGE_URL),
+      ].join('\n');
+    }
+  }
+  return `Unable to resolve "${targetModuleName}" from "${relativePath}"`;
+}
+
+function maybeAppendCodeFrame(message: string, rawMessage: string): string {
+  const codeFrame = stripMetroInfo(rawMessage);
+  if (codeFrame) {
+    message += '\n' + codeFrame;
+  }
+  return message;
+}
+
+export function stripMetroInfo(errorMessage: string): string {
+  // Newer versions of Metro don't include the list.
+  if (!errorMessage.includes('4. Remove the cache')) {
+    return null;
+  }
+  const lines = errorMessage.split('\n');
+  const index = lines.findIndex((line) => line.includes('4. Remove the cache'));
+  if (index === -1) {
+    return null;
+  }
+  return lines.slice(index + 1).join('\n');
+}
+
+function isAppRegistryStartupMessage(body: any[]): boolean {
+  return (
+    body.length === 1 &&
+    (/^Running application "main" with appParams:/.test(body[0]) ||
+      /^Running "main" with \{/.test(body[0]))
+  );
+}
+
+function getPlatformTagForBuildDetails(bundleDetails?: BundleDetails | null) {
+  const platform = bundleDetails?.platform ?? null;
+  if (platform) {
+    const formatted = { ios: 'iOS', android: 'Android', web: 'Web' }[platform] || platform;
+    return `${chalk.bold(formatted)} `;
+  }
+
+  return '';
+}
+
+const NODE_STDLIB_MODULES = [
+  'assert',
+  'async_hooks',
+  'buffer',
+  'child_process',
+  'cluster',
+  'crypto',
+  'dgram',
+  'dns',
+  'domain',
+  'events',
+  'fs',
+  'http',
+  'https',
+  'net',
+  'os',
+  'path',
+  'punycode',
+  'querystring',
+  'readline',
+  'repl',
+  'stream',
+  'string_decoder',
+  'tls',
+  'tty',
+  'url',
+  'util',
+  'v8',
+  'vm',
+  'zlib',
+];

--- a/packages/expo/cli/start/server/metro/MetroTerminalReporter.ts
+++ b/packages/expo/cli/start/server/metro/MetroTerminalReporter.ts
@@ -105,7 +105,10 @@ export class MetroTerminalReporter extends TerminalReporter {
  * @param error
  * @returns error message or null if not a module resolution error
  */
-export function formatUsingNodeStandardLibraryError(projectRoot: string, error: SnippetError) {
+export function formatUsingNodeStandardLibraryError(
+  projectRoot: string,
+  error: SnippetError
+): string | null {
   if (!error.message) {
     return null;
   }
@@ -118,7 +121,7 @@ export function formatUsingNodeStandardLibraryError(projectRoot: string, error: 
   const DOCS_PAGE_URL =
     'https://docs.expo.dev/workflow/using-libraries/#using-third-party-libraries';
 
-  if (NODE_STDLIB_MODULES.includes(targetModuleName)) {
+  if (isNodeStdLibraryModule(targetModuleName)) {
     if (originModulePath.includes('node_modules')) {
       return [
         `The package at "${chalk.bold(
@@ -140,6 +143,10 @@ export function formatUsingNodeStandardLibraryError(projectRoot: string, error: 
     }
   }
   return `Unable to resolve "${targetModuleName}" from "${relativePath}"`;
+}
+
+export function isNodeStdLibraryModule(moduleName: string): boolean {
+  return /^node:/.test(moduleName) || NODE_STDLIB_MODULES.includes(moduleName);
 }
 
 /** If the code frame can be found then append it to the existing message.  */
@@ -202,6 +209,7 @@ const NODE_STDLIB_MODULES = [
   'domain',
   'events',
   'fs',
+  'fs/promises',
   'http',
   'https',
   'net',

--- a/packages/expo/cli/start/server/metro/TerminalReporter.ts
+++ b/packages/expo/cli/start/server/metro/TerminalReporter.ts
@@ -82,8 +82,13 @@ export class TerminalReporter extends XTerminalReporter implements TerminalRepor
   /** One of the first logs that will be printed. */
   dependencyGraphLoading(hasReducedPerformance: boolean): void {}
 
-  /** Custom log event representing the end of the bundling. */
-  bundleBuildEnded(event: TerminalReportableEvent, duration: number) {}
+  /**
+   * Custom log event representing the end of the bundling.
+   *
+   * @param event event object.
+   * @param duration duration of the build in milliseconds.
+   */
+  bundleBuildEnded(event: TerminalReportableEvent, duration: number): void {}
 
   /**
    * This function is exclusively concerned with updating the internal state.

--- a/packages/expo/cli/start/server/metro/TerminalReporter.ts
+++ b/packages/expo/cli/start/server/metro/TerminalReporter.ts
@@ -1,0 +1,114 @@
+// This file represents an abstraction on the metro TerminalReporter.
+// We use this abstraction to safely extend the TerminalReporter for our own custom logging.
+import chalk from 'chalk';
+import { Terminal } from 'metro-core';
+import UpstreamTerminalReporter from 'metro/src/lib/TerminalReporter';
+import util from 'util';
+
+import { stripAnsi } from '../../../utils/ansi';
+import {
+  BundleDetails,
+  TerminalReportableEvent,
+  TerminalReporterInterface,
+} from './TerminalReporter.types';
+
+/**
+ * A standard way to log a warning to the terminal. This should not be called
+ * from some arbitrary Metro logic, only from the reporters. Instead of
+ * calling this, add a new type of ReportableEvent instead, and implement a
+ * proper handler in the reporter(s).
+ */
+export function logWarning(terminal: Terminal, format: string, ...args: any[]): void {
+  const str = util.format(format, ...args);
+  terminal.log('%s: %s', chalk.yellow('warning'), str);
+}
+
+/**
+ * Similar to `logWarning`, but for messages that require the user to act.
+ */
+export function logError(terminal: Terminal, format: string, ...args: any[]): void {
+  terminal.log(
+    '%s: %s',
+    chalk.red('error'),
+    // Syntax errors may have colors applied for displaying code frames
+    // in various places outside of where Metro is currently running.
+    // If the current terminal does not support color, we'll strip the colors
+    // here.
+    util.format(chalk.supportsColor ? format : stripAnsi(format), ...args)
+  );
+}
+
+const XTerminalReporter = UpstreamTerminalReporter as unknown as TerminalReporterInterface;
+
+/** Extended TerminalReporter class but with proper types and extra functionality to avoid using the `_log` method directly in subclasses. */
+export class TerminalReporter extends XTerminalReporter implements TerminalReporterInterface {
+  /**
+   * A cache of { [buildID]: BundleDetails } which can be used to
+   * add more contextual logs. BundleDetails is currently only sent with `bundle_build_started`
+   * so we need to cache the details in order to print the platform info with other event types.
+   */
+  _bundleDetails: Map<string, BundleDetails> = new Map();
+
+  /** Keep track of how long a bundle takes to complete */
+  _bundleTimers: Map<string, number> = new Map();
+
+  _log(event: TerminalReportableEvent): void {
+    switch (event.type) {
+      case 'transform_cache_reset':
+        return this.transformCacheReset();
+      case 'dep_graph_loading':
+        return this.dependencyGraphLoading(event.hasReducedPerformance);
+      case 'client_log':
+        if (this.shouldFilterClientLog(event)) {
+          return;
+        }
+        break;
+    }
+    return super._log(event);
+  }
+
+  /** Gives subclasses an easy interface for filtering out logs. Return `true` to skip. */
+  shouldFilterClientLog(event: {
+    type: 'client_log';
+    level: 'trace' | 'info' | 'warn' | 'log' | 'group' | 'groupCollapsed' | 'groupEnd' | 'debug';
+    data: unknown[];
+  }): boolean {
+    return false;
+  }
+
+  /** Cache has been reset. */
+  transformCacheReset(): void {}
+
+  /** One of the first logs that will be printed. */
+  dependencyGraphLoading(hasReducedPerformance: boolean): void {}
+
+  /** Custom log event representing the end of the bundling. */
+  bundleBuildEnded(event: TerminalReportableEvent, duration: number) {}
+
+  /**
+   * This function is exclusively concerned with updating the internal state.
+   * No logging or status updates should be done at this point.
+   */
+  _updateState(
+    event: TerminalReportableEvent & { bundleDetails?: BundleDetails; buildID?: string }
+  ) {
+    // Append the buildID to the bundleDetails.
+    if (event.bundleDetails) {
+      event.bundleDetails.buildID = event.buildID;
+    }
+
+    super._updateState(event);
+    switch (event.type) {
+      case 'bundle_build_done':
+      case 'bundle_build_failed':
+        this.bundleBuildEnded(event, Date.now() - this._bundleTimers.get(event.buildID));
+        this._bundleTimers.delete(event.buildID);
+        break;
+
+      case 'bundle_build_started':
+        this._bundleDetails.set(event.buildID, event.bundleDetails);
+        this._bundleTimers.set(event.buildID, Date.now());
+        break;
+    }
+  }
+}

--- a/packages/expo/cli/start/server/metro/TerminalReporter.types.ts
+++ b/packages/expo/cli/start/server/metro/TerminalReporter.types.ts
@@ -1,0 +1,151 @@
+import type { ReportableEvent } from 'metro';
+import type { Terminal } from 'metro-core';
+import type { TerminalReportableEvent } from 'metro/src/lib/TerminalReporter';
+
+export type GlobalCacheDisabledReason = 'too_many_errors' | 'too_many_misses';
+
+export type BundleDetails = {
+  buildID?: string;
+  bundleType: string;
+  dev: boolean;
+  entryFile: string;
+  minify: boolean;
+  platform: string | null | undefined;
+  runtimeBytecodeVersion: number | null | undefined;
+};
+
+export type BundleProgress = {
+  bundleDetails: BundleDetails;
+  transformedFileCount: number;
+  totalFileCount: number;
+  ratio: number;
+};
+
+export { TerminalReportableEvent };
+
+export type BuildPhase = 'in_progress' | 'done' | 'failed';
+
+/**
+ * Code across the application takes a reporter as an option and calls the
+ * update whenever one of the ReportableEvent happens. Code does not directly
+ * write to the standard output, because a build would be:
+ *
+ *   1. ad-hoc, embedded into another tool, in which case we do not want to
+ *   pollute that tool's own output. The tool is free to present the
+ *   warnings/progress we generate any way they want, by specifying a custom
+ *   reporter.
+ *   2. run as a background process from another tool, in which case we want
+ *   to expose updates in a way that is easily machine-readable, for example
+ *   a JSON-stream. We don't want to pollute it with textual messages.
+ *
+ * We centralize terminal reporting into a single place because we want the
+ * output to be robust and consistent. The most common reporter is
+ * TerminalReporter, that should be the only place in the application should
+ * access the `terminal` module (nor the `console`).
+ */
+export type Reporter = { update(event: ReportableEvent): void };
+
+export interface SnippetError extends Error {
+  code?: string;
+  filename?: string;
+  snippet?: string;
+
+  /** Module that failed to load ex 'fs' */
+  targetModuleName?: string;
+  originModulePath?: string;
+
+  errors?: any[];
+}
+
+export interface TerminalReporterInterface {
+  new (terminal: Terminal): TerminalReporterInterface;
+
+  /**
+   * The bundle builds for which we are actively maintaining the status on the
+   * terminal, ie. showing a progress bar. There can be several bundles being
+   * built at the same time.
+   */
+  _activeBundles: Map<string, BundleProgress>;
+
+  _scheduleUpdateBundleProgress: {
+    (data: { buildID: string; transformedFileCount: number; totalFileCount: number }): void;
+    cancel(): void;
+  };
+
+  /** Set in super type */
+  terminal: Terminal;
+
+  /**
+   * Construct a message that represents the progress of a
+   * single bundle build, for example:
+   *
+   *     BUNDLE path/to/bundle.js ▓▓▓▓▓░░░░░░░░░░░ 36.6% (4790/7922)
+   */
+  _getBundleStatusMessage(
+    {
+      bundleDetails: { entryFile, bundleType, runtimeBytecodeVersion },
+      transformedFileCount,
+      totalFileCount,
+      ratio,
+    }: BundleProgress,
+    phase: BuildPhase
+  ): string;
+
+  /**
+   * This function is only concerned with logging and should not do state
+   * or terminal status updates.
+   */
+  _log(event: TerminalReportableEvent): void;
+
+  _logCacheDisabled(reason: GlobalCacheDisabledReason): void;
+
+  _logBundleBuildDone(buildID: string): void;
+
+  _logBundleBuildFailed(buildID: string): void;
+
+  _logInitializing(port: number, hasReducedPerformance: boolean): void;
+
+  _logInitializingFailed(port: number, error: SnippetError): void;
+
+  /**
+   * We do not want to log the whole stacktrace for bundling error, because
+   * these are operational errors, not programming errors, and the stacktrace
+   * is not actionable to end users.
+   */
+  _logBundlingError(error: SnippetError): void;
+
+  /**
+   * We use Math.pow(ratio, 2) to as a conservative measure of progress because
+   * we know the `totalCount` is going to progressively increase as well. We
+   * also prevent the ratio from going backwards.
+   */
+  _updateBundleProgress({
+    buildID,
+    transformedFileCount,
+    totalFileCount,
+  }: {
+    buildID: string;
+    transformedFileCount: number;
+    totalFileCount: number;
+  }): void;
+
+  /**
+   * This function is exclusively concerned with updating the internal state.
+   * No logging or status updates should be done at this point.
+   */
+  _updateState(event: TerminalReportableEvent): void;
+  /**
+   * Return a status message that is always consistent with the current state
+   * of the application. Having this single function ensures we don't have
+   * different callsites overriding each other status messages.
+   */
+  _getStatusMessage(): string;
+
+  _logHmrClientError(e: Error): void;
+
+  /**
+   * Single entry point for reporting events. That allows us to implement the
+   * corresponding JSON reporter easily and have a consistent repor∏ting.
+   */
+  update(event: TerminalReportableEvent): void;
+}

--- a/packages/expo/cli/start/server/metro/__tests__/MetroTerminalReporter-test.ts
+++ b/packages/expo/cli/start/server/metro/__tests__/MetroTerminalReporter-test.ts
@@ -1,5 +1,9 @@
 import { stripAnsi } from '../../../../utils/ansi';
-import { stripMetroInfo, formatUsingNodeStandardLibraryError } from '../MetroTerminalReporter';
+import {
+  stripMetroInfo,
+  formatUsingNodeStandardLibraryError,
+  isNodeStdLibraryModule,
+} from '../MetroTerminalReporter';
 
 describe(stripMetroInfo, () => {
   it(`sanitizes`, () => {
@@ -27,6 +31,19 @@ describe(stripMetroInfo, () => {
            |         ^
         80 |"
     `);
+  });
+});
+
+describe(isNodeStdLibraryModule, () => {
+  it(`returns true for node standard library modules`, () => {
+    for (const moduleName of ['node:fs', 'fs/promises', 'net']) {
+      expect(isNodeStdLibraryModule(moduleName)).toBe(true);
+    }
+  });
+  it(`returns false for etc modules`, () => {
+    for (const moduleName of ['expo', '@expo/config', 'uuid']) {
+      expect(isNodeStdLibraryModule(moduleName)).toBe(false);
+    }
   });
 });
 

--- a/packages/expo/cli/start/server/metro/__tests__/MetroTerminalReporter-test.ts
+++ b/packages/expo/cli/start/server/metro/__tests__/MetroTerminalReporter-test.ts
@@ -1,0 +1,46 @@
+import { stripAnsi } from '../../../../utils/ansi';
+import { stripMetroInfo, formatUsingNodeStandardLibraryError } from '../MetroTerminalReporter';
+
+describe(stripMetroInfo, () => {
+  it(`sanitizes`, () => {
+    const input = [
+      'Unable to resolve module path from /Users/evanbacon/Documents/GitHub/examples/with-apple-auth/App.js: path could not be found within the project or in these directories:',
+      '  node_modules',
+      '  ../../node_modules',
+      '  ../../../../node_modules',
+      '',
+      'If you are sure the module exists, try these steps:',
+      ' 1. Clear watchman watches: watchman watch-del-all',
+      ' 2. Delete node_modules and run yarn install',
+      " 3. Reset Metro's cache: yarn start --reset-cache",
+      ' 4. Remove the cache: rm -rf /tmp/metro-*',
+      '\x1B[0m \x1B[90m 77 |\x1B[39m }\x1B[0m',
+      '\x1B[0m \x1B[90m 78 |\x1B[39m\x1B[0m',
+      '\x1B[0m\x1B[31m\x1B[1m>\x1B[22m\x1B[39m\x1B[90m 79 |\x1B[39m \x1B[36mimport\x1B[39m \x1B[32m"path"\x1B[39m\x1B[33m;\x1B[39m\x1B[0m',
+      '\x1B[0m \x1B[90m    |\x1B[39m         \x1B[31m\x1B[1m^\x1B[22m\x1B[39m\x1B[0m',
+      '\x1B[0m \x1B[90m 80 |\x1B[39m\x1B[0m',
+    ].join('\n');
+    expect(stripAnsi(stripMetroInfo(input))).toMatchInlineSnapshot(`
+      "  77 | }
+        78 |
+      > 79 | import \\"path\\";
+           |         ^
+        80 |"
+    `);
+  });
+});
+
+describe(formatUsingNodeStandardLibraryError, () => {
+  it(`formats node standard library error`, () => {
+    const format = formatUsingNodeStandardLibraryError('/Users/evanbacon/my-app', {
+      message: 'foobar',
+      originModulePath: '/Users/evanbacon/my-app/App.js',
+      targetModuleName: 'path',
+    } as any);
+    expect(stripAnsi(format)).toMatchInlineSnapshot(`
+      "You attempted attempted to import the Node standard library module \\"path\\" from \\"App.js\\".
+      It failed because the native React runtime does not include the Node standard library.
+      Learn more: https://docs.expo.dev/workflow/using-libraries/#using-third-party-libraries"
+    `);
+  });
+});

--- a/packages/expo/cli/start/server/metro/__tests__/MetroTerminalReporter-test.ts
+++ b/packages/expo/cli/start/server/metro/__tests__/MetroTerminalReporter-test.ts
@@ -1,9 +1,102 @@
 import { stripAnsi } from '../../../../utils/ansi';
 import {
-  stripMetroInfo,
   formatUsingNodeStandardLibraryError,
   isNodeStdLibraryModule,
+  MetroTerminalReporter,
+  stripMetroInfo,
 } from '../MetroTerminalReporter';
+import { BundleDetails } from '../TerminalReporter.types';
+
+const asBundleDetails = (value: any) => value as BundleDetails;
+
+describe('_getBundleStatusMessage', () => {
+  const buildID = '1';
+  const reporter = new MetroTerminalReporter('/', {
+    log: jest.fn(),
+    persistStatus: jest.fn(),
+    status: jest.fn(),
+  });
+  reporter._getElapsedTime = jest.fn(() => 100);
+  reporter._bundleTimers.set(buildID, 0);
+
+  it(`should format standard progress`, () => {
+    expect(
+      stripAnsi(
+        reporter._getBundleStatusMessage(
+          {
+            bundleDetails: asBundleDetails({
+              entryFile: './index.js',
+              platform: 'ios',
+              buildID,
+            }),
+            ratio: 0.5,
+            totalFileCount: 100,
+            transformedFileCount: 50,
+          },
+          'in_progress'
+        )
+      )
+    ).toMatchInlineSnapshot(`"iOS ./index.js ▓▓▓▓▓▓▓▓░░░░░░░░ 50.0% ( 50/100)"`);
+  });
+
+  it(`should format standard progress at 0%`, () => {
+    expect(
+      stripAnsi(
+        reporter._getBundleStatusMessage(
+          {
+            bundleDetails: asBundleDetails({
+              entryFile: './index.js',
+              platform: 'android',
+              buildID,
+            }),
+            ratio: 0,
+            totalFileCount: 100,
+            transformedFileCount: 0,
+          },
+          'in_progress'
+        )
+      )
+    ).toMatchInlineSnapshot(`"Android ./index.js ░░░░░░░░░░░░░░░░  0.0% (  0/100)"`);
+  });
+  it(`should format complete loading`, () => {
+    expect(
+      stripAnsi(
+        reporter._getBundleStatusMessage(
+          {
+            bundleDetails: asBundleDetails({
+              entryFile: './index.js',
+              platform: 'android',
+              buildID,
+            }),
+            ratio: 1.0,
+            totalFileCount: 100,
+            transformedFileCount: 100,
+          },
+          'done'
+        )
+      )
+    ).toMatchInlineSnapshot(`"Android Bundling complete 100ms"`);
+  });
+  it(`should format failed loading`, () => {
+    expect(
+      stripAnsi(
+        reporter._getBundleStatusMessage(
+          {
+            bundleDetails: asBundleDetails({
+              entryFile: './index.js',
+              platform: 'android',
+              buildID,
+            }),
+            ratio: 1.0,
+            totalFileCount: 100,
+            transformedFileCount: 100,
+          },
+          'failed'
+        )
+      )
+    ).toMatchInlineSnapshot(`"Android Bundling failed 100ms"`);
+  });
+});
 
 describe(stripMetroInfo, () => {
   it(`sanitizes`, () => {

--- a/packages/expo/cli/start/server/metro/__tests__/TerminalReporter-test.ts
+++ b/packages/expo/cli/start/server/metro/__tests__/TerminalReporter-test.ts
@@ -1,0 +1,55 @@
+import { TerminalReporter } from '../TerminalReporter';
+import { TerminalReportableEvent } from '../TerminalReporter.types';
+
+function createReporter() {
+  const reporter = new TerminalReporter({
+    log: jest.fn(),
+    persistStatus: jest.fn(),
+    status: jest.fn(),
+  });
+  return reporter;
+}
+
+it(`invokes utility transform cache reset function`, () => {
+  const reporter = createReporter();
+  reporter.transformCacheReset = jest.fn();
+  reporter._log({
+    type: 'transform_cache_reset',
+  });
+  expect(reporter.transformCacheReset).toHaveBeenCalled();
+});
+it(`invokes utility graph loading function`, () => {
+  const reporter = createReporter();
+  reporter.dependencyGraphLoading = jest.fn();
+  reporter._log({
+    type: 'dep_graph_loading',
+    hasReducedPerformance: true,
+  });
+  expect(reporter.dependencyGraphLoading).toHaveBeenCalledWith(true);
+});
+it(`invokes utility filter function`, () => {
+  const reporter = createReporter();
+
+  reporter.shouldFilterClientLog = jest.fn();
+  const event: TerminalReportableEvent = {
+    type: 'client_log',
+    level: 'trace',
+    data: [],
+  };
+  reporter._log(event);
+  expect(reporter.shouldFilterClientLog).toHaveBeenCalledWith(event);
+  expect(reporter.terminal.log).toBeCalled();
+});
+it(`skips logging if the filter function returns true`, () => {
+  const reporter = createReporter();
+
+  reporter.shouldFilterClientLog = jest.fn(() => true);
+  const event: TerminalReportableEvent = {
+    type: 'client_log',
+    level: 'trace',
+    data: [],
+  };
+  reporter._log(event);
+  expect(reporter.shouldFilterClientLog).toHaveBeenCalledWith(event);
+  expect(reporter.terminal.log).not.toBeCalled();
+});

--- a/packages/expo/cli/start/server/metro/instantiateMetro.ts
+++ b/packages/expo/cli/start/server/metro/instantiateMetro.ts
@@ -1,8 +1,8 @@
 import { MetroDevServerOptions } from '@expo/dev-server';
 import http from 'http';
 import Metro from 'metro';
-// import { Terminal } from 'metro-core';
-// import { MetroTerminalReporter } from './MetroTerminalReporter';
+import { Terminal } from 'metro-core';
+import { MetroTerminalReporter } from './MetroTerminalReporter';
 
 import { createDevServerMiddleware } from '../middleware/createDevServerMiddleware';
 import { importExpoMetroConfigFromProject, importMetroFromProject } from './resolveFromProject';
@@ -26,12 +26,12 @@ export async function instantiateMetroAsync(
   const Metro = importMetroFromProject(projectRoot);
   const ExpoMetroConfig = importExpoMetroConfigFromProject(projectRoot);
 
-  // const terminal = new Terminal(process.stdout);
-  // const terminalReporter = new MetroTerminalReporter(projectRoot, terminal);
+  const terminal = new Terminal(process.stdout);
+  const terminalReporter = new MetroTerminalReporter(projectRoot, terminal);
 
   const reporter = {
     update(event: any) {
-      // terminalReporter.update(event);
+      terminalReporter.update(event);
       if (reportEvent) {
         reportEvent(event);
       }

--- a/packages/expo/cli/start/server/metro/instantiateMetro.ts
+++ b/packages/expo/cli/start/server/metro/instantiateMetro.ts
@@ -2,9 +2,9 @@ import { MetroDevServerOptions } from '@expo/dev-server';
 import http from 'http';
 import Metro from 'metro';
 import { Terminal } from 'metro-core';
-import { MetroTerminalReporter } from './MetroTerminalReporter';
 
 import { createDevServerMiddleware } from '../middleware/createDevServerMiddleware';
+import { MetroTerminalReporter } from './MetroTerminalReporter';
 import { importExpoMetroConfigFromProject, importMetroFromProject } from './resolveFromProject';
 
 // From expo/dev-server but with ability to use custom logger.


### PR DESCRIPTION
# Why

- Split out of https://github.com/expo/expo/pull/16517

We use a custom Metro log formatter in Expo CLI which serializes the data, passes it over a child process, then parses the data and passes it through a reimplementation of the Metro TerminalReporter ([ref](https://github.com/expo/expo-cli/blob/17f9c72/packages/xdl/src/logs/PackagerLogsStream.ts)).

This PR reimplements that system by cutting out all of the extra steps. Here we simply extend the default Metro TerminalReporter and add the extra customizations as minimal function changes.

The result is far less code, but the logging will look much more like the default Metro logging system. This has some benefits and drawbacks.

Pros:
- K.I.S.S -- Less dead code and missing events ([example dead code](https://github.com/expo/expo-cli/blob/d1df936babfa3164a415e7f1627bcee264b0c3f3/packages/xdl/src/logs/PackagerLogsStream.ts#L82)).
- Multiple bundle loading bars -- expo-cli currently just supports a single loading bar at a time, i.e. if android and ios are both bundling, only one will show.
- The few customizations we did add (like [node import errors](https://github.com/expo/expo-cli/blob/d1df936babfa3164a415e7f1627bcee264b0c3f3/packages/xdl/src/logs/PackagerLogsStream.ts#L475-L498)) were broken in expo-cli anyways and we had no tests or system to catch this.
- Automatically adds Metro features without us needing to manually understand and add them.
- Utilizes the versioned metro runtime code and websockets (expo-cli uses endpoints) so we can cut down on bundler specific client side boilerplate code (`expo/src/logs`).
- Websockets know when the terminal has connected and cache pending logs until then, this means we never miss any logging events.

Cons:
- The logging endpoint sends warning stack trace info whereas the websocket only sends stack traces on errors. This is somewhat tolerable since Metro symbolication is lackluster and often points to internal files only.
- Metro is written in flow so we needed to reimplement many of the types locally.

# Test Plan

- Added some basic unit tests for our customizations, leans heavily on existing metro tests for other logging cases.