### PR TITLE
update source-login-scripts for preferred shell

### DIFF
--- a/packages/expo-constants/scripts/source-login-scripts.sh
+++ b/packages/expo-constants/scripts/source-login-scripts.sh
@@ -7,9 +7,9 @@
 # script is intended for Xcode build phase scripts on macOS and does not have
 # a shebang so it inherits the current shell.
 
-current_shell=$(ps -cp "$$" -o comm="" | sed s/^-//)
+preferred_shell=$SHELL
 
-if [[ "$current_shell" == zsh ]]; then
+if [[ "$preferred_shell" == '/bin/zsh' ]]; then
    # Zsh's setup script order is:
    #   /etc/zshenv
    #   ~/.zshenv


### PR DESCRIPTION
https://github.com/expo/expo/issues/15809#issuecomment-1068629517

# Why
This PR updates the `source-login-shell.sh` in `expo-constants` to check for the user's preferred shell (instead of the current running shell). 

This approach resolves issues for users with `.zsh` profiles; the current `main` branch code seems to always resolve `current_shell` to bash (via `ps -cp "$$" -o comm="" | sed s/^-//)`). People are using a workaround of creating a bash_profile but that is inconvenient and it breaks nvm setup (if user has nvm setup in zsh profile):

<img width="619" alt="image" src="https://user-images.githubusercontent.com/65248094/158641814-6da86059-3cc1-4cb1-803d-57ebbc9f9bc9.png">
<img width="693" alt="image" src="https://user-images.githubusercontent.com/65248094/158641978-0bbd373f-61cf-4622-ad87-a50103686974.png">


<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

Updated code to point to `$SELL` [per this discussion](https://stackoverflow.com/questions/16943685/determine-the-current-users-shell) and result of testing.


<img width="562" alt="image" src="https://user-images.githubusercontent.com/65248094/158641686-733e09cd-3093-4b53-a4f3-9d633493c2cc.png">



# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Tested locally on a couple different mac environments and in our CI. This is hard to test but from what I can see this approach seems like a reasonable improvement due to environment differences 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ x ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
