### PR TITLE
[image-manipulator][ios] Fix rotation on iOS may cause a border around the image

### DIFF
--- a/packages/expo-image-manipulator/CHANGELOG.md
+++ b/packages/expo-image-manipulator/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 🐛 Bug fixes
 
 - Remove `data:image` part in web base64 result. ([#16191](https://github.com/expo/expo/pull/16191) by [@AllanChain](https://github.com/AllanChain))
-- Fix rotation on iOS may cause a border around the image.
+- Fix rotation on iOS may cause a border around the image. ([#16669](https://github.com/expo/expo/pull/16669) by [@mnightingale](https://github.com/mnightingale))
 
 ### 💡 Others
 

--- a/packages/expo-image-manipulator/CHANGELOG.md
+++ b/packages/expo-image-manipulator/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 🐛 Bug fixes
 
 - Remove `data:image` part in web base64 result. ([#16191](https://github.com/expo/expo/pull/16191) by [@AllanChain](https://github.com/AllanChain))
-- Fix rotation on iOS may cause a border around the image. ([#16669](https://github.com/expo/expo/pull/16669) by [@mnightingale](https://github.com/mnightingale))
+- On iOS fix rotation causing extra image borders. ([#16669](https://github.com/expo/expo/pull/16669) by [@mnightingale](https://github.com/mnightingale))
 
 ### 💡 Others
 

--- a/packages/expo-image-manipulator/CHANGELOG.md
+++ b/packages/expo-image-manipulator/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - Remove `data:image` part in web base64 result. ([#16191](https://github.com/expo/expo/pull/16191) by [@AllanChain](https://github.com/AllanChain))
+- Fix rotation on iOS may cause a border around the image.
 
 ### 💡 Others
 

--- a/packages/expo-image-manipulator/ios/ImageManipulations.swift
+++ b/packages/expo-image-manipulator/ios/ImageManipulations.swift
@@ -67,7 +67,7 @@ internal func manipulate(image: UIImage, rotate: Double) throws -> UIImage {
 
   rotatedView.transform = CGAffineTransform(rotationAngle: rads)
 
-  let rotatedSize = rotatedView.frame.size
+  let rotatedSize = CGSize(width: rotatedView.frame.size.width.rounded(.down), height: rotatedView.frame.size.height.rounded(.down))
   let origin = CGPoint(x: -image.size.width / 2, y: -image.size.height / 2)
 
   return try drawInNewContext(size: rotatedSize) { context in


### PR DESCRIPTION
# Why

Closes #7325 

# How

Root cause identified by @akempe >18 months ago.

A `1200 x 2000` image rotated `90 degrees` produces a `2000 x 1201` image (then after a few more rotations `2000 x 1202`).

`rotatedView.frame.size` is what is currently used which gets rounded up, then the image wont cover it leaving undrawn areas that'll be transparent for PNGs or white for JPEGs.
`rotatedSize` is with the `rounded(.down)` - probably could have used `Int(...width)` or `floor(...width)` but decided the rounded method is clearer about what is going on.

```console
po rotatedView.frame.size
▿ (2000.0, 1200.0000000000002)
  - width : 2000.0
  - height : 1200.0000000000002

po rotatedSize
▿ (2000.0, 1200.0)
  - width : 2000.0
  - height : 1200.0
```

# Test Plan

NCL and checking output image size

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
