### PR TITLE
[ios] Fix BlurView and LinearGradientView not rendering when the border radius is set

### DIFF
--- a/packages/expo-blur/CHANGELOG.md
+++ b/packages/expo-blur/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed the component not rendering correctly when the border radius style is set.
+- Fixed the component not rendering correctly when the border radius style is set. ([#16671](https://github.com/expo/expo/pull/16671) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-blur/CHANGELOG.md
+++ b/packages/expo-blur/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed the component not rendering correctly when the border radius style is set.
+
 ### 💡 Others
 
 ## 11.0.0 — 2021-12-03

--- a/packages/expo-blur/ios/EXBlur/BlurView.swift
+++ b/packages/expo-blur/ios/EXBlur/BlurView.swift
@@ -1,9 +1,10 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 import UIKit
+import ExpoModulesCore
 
 @objc(EXBlurView)
-public class BlurView: UIView {
+public class BlurView: ExpoView {
   private var blurEffectView: BlurEffectView
 
   override init(frame: CGRect) {

--- a/packages/expo-linear-gradient/CHANGELOG.md
+++ b/packages/expo-linear-gradient/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Extract `react-native-web` internals into package to minimize bundler setup. ([#16098](https://github.com/expo/expo/pull/16098) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix `Plugin with id 'maven' not found` build error from Android Gradle 7. ([#16080](https://github.com/expo/expo/pull/16080) by [@kudo](https://github.com/kudo))
+- Fixed the component not rendering correctly when the border radius style is set.
 
 ### 💡 Others
 

--- a/packages/expo-linear-gradient/CHANGELOG.md
+++ b/packages/expo-linear-gradient/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - Extract `react-native-web` internals into package to minimize bundler setup. ([#16098](https://github.com/expo/expo/pull/16098) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix `Plugin with id 'maven' not found` build error from Android Gradle 7. ([#16080](https://github.com/expo/expo/pull/16080) by [@kudo](https://github.com/kudo))
-- Fixed the component not rendering correctly when the border radius style is set.
+- Fixed the component not rendering correctly when the border radius style is set. ([#16671](https://github.com/expo/expo/pull/16671) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-linear-gradient/ios/LinearGradientView.swift
+++ b/packages/expo-linear-gradient/ios/LinearGradientView.swift
@@ -1,8 +1,9 @@
 // Copyright 2021-present 650 Industries. All rights reserved.
 
 import UIKit
+import ExpoModulesCore
 
-final class LinearGradientView: UIView {
+final class LinearGradientView: ExpoView {
   override class var layerClass: AnyClass {
     return LinearGradientLayer.self
   }


### PR DESCRIPTION
# Why

Fixes #9701
Fixes #15118
Fixes ENG-4022

# How

Changed `BlurView` and `LinearGradientView` to inherit from `ExpoView` instead of `UIView`. `ExpoView` inherits from `RCTView` which implements how the border radius is handled.

# Test Plan

Tested on `LinearGradient` examples in NCL with big border radius set.

![Screen Shot 2022-03-17 at 11 18 16](https://user-images.githubusercontent.com/1714764/158801045-17216824-593e-411f-8592-c3eb7f8a9469.png)
