### PR TITLE
[expo-updates][ios] Allow non-codesigned manifests for Expo Go

### DIFF
--- a/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
@@ -385,6 +385,7 @@ NS_ASSUME_NONNULL_BEGIN
       @"alg": @"rsa-v1_5-sha256",
     };
     updatesConfig[EXUpdatesConfigCodeSigningIncludeManifestResponseCertificateChainKey] = @YES;
+    updatesConfig[EXUpdatesConfigCodeSigningAllowUnsignedManifestsKey] = @YES;
   }
 
   _config = [EXUpdatesConfig configWithDictionary:updatesConfig];

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -20,7 +20,8 @@
 ### 🐛 Bug fixes
 
 - Update `fbemitter` to v3. ([#16245](https://github.com/expo/expo/pull/16245) by [@SimenB](https://github.com/SimenB))
-- Allow non-codesigned manifests for Expo Go. ([#16649](https://github.com/expo/expo/pull/16649) by [@wschurman](https://github.com/wschurman))
+- Allow non-codesigned manifests for Expo Go (Android). ([#16649](https://github.com/expo/expo/pull/16649) by [@wschurman](https://github.com/wschurman))
+- Allow non-codesigned manifests for Expo Go (iOS). ([#16682](https://github.com/expo/expo/pull/16682) by [@wschurman](https://github.com/wschurman))
 - Fix issue where default values for primitive-typed configuration values were not correctly set. ([#16644](https://github.com/expo/expo/pull/16644) by [@esamelson](https://github.com/esamelson))
 
 ### 💡 Others

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
@@ -432,33 +432,16 @@ certificateChainFromManifestResponse:(nullable NSString *)certificateChainFromMa
   EXUpdatesCodeSigningConfiguration *codeSigningConfiguration = _config.codeSigningConfiguration;
   if (codeSigningConfiguration) {
     NSError *error;
-    EXUpdatesSignatureHeaderInfo *signatureHeaderInfo = [EXUpdatesSignatureHeaderInfo parseSignatureHeaderWithSignatureHeader:manifestHeaders.signature
-                                                                                                                        error:&error];
-    if (error) {
-      NSString *message = [EXUpdatesCodeSigningErrorUtils messageForError:error.code];
-      errorBlock([NSError errorWithDomain:EXUpdatesFileDownloaderErrorDomain
-                                     code:EXUpdatesFileDownloaderErrorCodeCodeSigningSignatureError
-                                 userInfo:@{NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Downloaded manifest signature is invalid: %@", message]}]);
-      return;
-    }
-    
-    BOOL isSignatureValid = [codeSigningConfiguration validateSignatureWithSignatureHeaderInfo:signatureHeaderInfo
-                                                                                    signedData:manifestBodyData
-                                                              manifestResponseCertificateChain:certificateChainFromManifestResponse
-                                                                                         error:&error].boolValue;
+    [codeSigningConfiguration validateSignatureWithSignature:manifestHeaders.signature
+                                                  signedData:manifestBodyData
+                            manifestResponseCertificateChain:certificateChainFromManifestResponse
+                                                       error:&error];
     
     if (error) {
       NSString *message = [EXUpdatesCodeSigningErrorUtils messageForError:error.code];
       errorBlock([NSError errorWithDomain:EXUpdatesFileDownloaderErrorDomain
                                      code:EXUpdatesFileDownloaderErrorCodeCodeSigningSignatureError
                                  userInfo:@{NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Downloaded manifest signature is invalid: %@", message]}]);
-      return;
-    }
-    
-    if (!isSignatureValid) {
-      errorBlock([NSError errorWithDomain:EXUpdatesFileDownloaderErrorDomain
-                                     code:EXUpdatesFileDownloaderErrorCodeCodeSigningSignatureError
-                                 userInfo:@{NSLocalizedDescriptionKey: @"Manifest download was successful, but signature was incorrect"}]);
       return;
     }
   }

--- a/packages/expo-updates/ios/EXUpdates/CodeSigning/EXUpdatesCodeSigningError.swift
+++ b/packages/expo-updates/ios/EXUpdates/CodeSigning/EXUpdatesCodeSigningError.swift
@@ -20,6 +20,7 @@ import Foundation
   case SignatureHeaderSignatureEncodingError
   case SignatureEncodingError
   case AlgorithmParseError
+  case InvalidSignature
 }
 
 @objc public class EXUpdatesCodeSigningErrorUtils : NSObject {
@@ -59,6 +60,8 @@ import Foundation
       return "Invalid signature encoding"
     case .AlgorithmParseError:
       return "Invalid algorithm"
+    case .InvalidSignature:
+      return "Manifest download was successful, but signature was incorrect"
     }
   }
 }

--- a/packages/expo-updates/ios/EXUpdates/CodeSigning/EXUpdatesSignatureHeaderInfo.swift
+++ b/packages/expo-updates/ios/EXUpdates/CodeSigning/EXUpdatesSignatureHeaderInfo.swift
@@ -9,8 +9,7 @@ struct EXUpdatesSignatureHeaderFields {
   static let AlgorithmFieldKey = "alg"
 }
 
-@objc
-public final class EXUpdatesSignatureHeaderInfo : NSObject {
+public final class EXUpdatesSignatureHeaderInfo {
   static let DefaultKeyId = "root"
   
   let signature: String
@@ -23,12 +22,7 @@ public final class EXUpdatesSignatureHeaderInfo : NSObject {
     self.algorithm = algorithm
   }
   
-  @objc
-  public static func parseSignatureHeader(signatureHeader: String?) throws -> EXUpdatesSignatureHeaderInfo {
-    guard let signatureHeader = signatureHeader else {
-      throw EXUpdatesCodeSigningError.SignatureHeaderMissing
-    }
-    
+  public static func parseSignatureHeader(signatureHeader: String) throws -> EXUpdatesSignatureHeaderInfo {    
     let parser = EXStructuredHeadersParser.init(rawInput: signatureHeader,
                                                 fieldType: EXStructuredHeadersParserFieldType.dictionary,
                                                 ignoringParameters: true)

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.h
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.h
@@ -30,6 +30,7 @@ FOUNDATION_EXPORT NSString * const EXUpdatesConfigExpectsSignedManifestKey;
 FOUNDATION_EXPORT NSString * const EXUpdatesConfigCodeSigningCertificateKey;
 FOUNDATION_EXPORT NSString * const EXUpdatesConfigCodeSigningMetadataKey;
 FOUNDATION_EXPORT NSString * const EXUpdatesConfigCodeSigningIncludeManifestResponseCertificateChainKey;
+FOUNDATION_EXPORT NSString * const EXUpdatesConfigCodeSigningAllowUnsignedManifestsKey;
 
 FOUNDATION_EXPORT NSString * const EXUpdatesConfigCheckOnLaunchValueAlways;
 FOUNDATION_EXPORT NSString * const EXUpdatesConfigCheckOnLaunchValueWifiOnly;

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.m
@@ -45,6 +45,7 @@ NSString * const EXUpdatesConfigExpectsSignedManifestKey = @"EXUpdatesExpectsSig
 NSString * const EXUpdatesConfigCodeSigningCertificateKey = @"EXUpdatesCodeSigningCertificate";
 NSString * const EXUpdatesConfigCodeSigningMetadataKey = @"EXUpdatesCodeSigningMetadata";
 NSString * const EXUpdatesConfigCodeSigningIncludeManifestResponseCertificateChainKey = @"EXUpdatesCodeSigningIncludeManifestResponseCertificateChain";
+NSString * const EXUpdatesConfigCodeSigningAllowUnsignedManifestsKey = @"EXUpdatesConfigCodeSigningAllowUnsignedManifests";
 
 NSString * const EXUpdatesConfigReleaseChannelDefaultValue = @"default";
 
@@ -207,10 +208,17 @@ NSString * const EXUpdatesConfigCheckOnLaunchValueNever = @"NEVER";
     codeSigningIncludeManifestResponseCertificateChain = [(NSNumber *)codeSigningIncludeManifestResponseCertificateChainRaw boolValue];
   }
   
+  BOOL codeSigningAllowUnsignedManifests = NO;
+  id codeSigningAllowUnsignedManifestsRaw = config[EXUpdatesConfigCodeSigningAllowUnsignedManifestsKey];
+  if (codeSigningAllowUnsignedManifestsRaw && [codeSigningAllowUnsignedManifestsRaw isKindOfClass:[NSNumber class]]) {
+    codeSigningAllowUnsignedManifests = [(NSNumber *)codeSigningAllowUnsignedManifestsRaw boolValue];
+  }
+  
   if (codeSigningCertificate) {
     _codeSigningConfiguration = [EXUpdatesConfig codeSigningConfigurationForCodeSigningCertificate:codeSigningCertificate
                                                                                codeSigningMetadata:codeSigningMetadata
-                                                codeSigningIncludeManifestResponseCertificateChain:codeSigningIncludeManifestResponseCertificateChain];
+                                                codeSigningIncludeManifestResponseCertificateChain:codeSigningIncludeManifestResponseCertificateChain
+                                                                 codeSigningAllowUnsignedManifests:codeSigningAllowUnsignedManifests];
   }
 }
 
@@ -221,11 +229,13 @@ NSString * const EXUpdatesConfigCheckOnLaunchValueNever = @"NEVER";
 
 + (nullable EXUpdatesCodeSigningConfiguration *)codeSigningConfigurationForCodeSigningCertificate:(NSString *)codeSigningCertificate
                                                                               codeSigningMetadata:(nullable NSDictionary *)codeSigningMetadata
-                                               codeSigningIncludeManifestResponseCertificateChain:(BOOL)codeSigningIncludeManifestResponseCertificateChain {
+                                               codeSigningIncludeManifestResponseCertificateChain:(BOOL)codeSigningIncludeManifestResponseCertificateChain
+                                                                codeSigningAllowUnsignedManifests:(BOOL)codeSigningAllowUnsignedManifests {
   NSError *error;
   EXUpdatesCodeSigningConfiguration *codeSigningConfiguration = [[EXUpdatesCodeSigningConfiguration alloc] initWithEmbeddedCertificateString:codeSigningCertificate
                                                                                                                                     metadata:codeSigningMetadata
                                                                                                      includeManifestResponseCertificateChain:codeSigningIncludeManifestResponseCertificateChain
+                                                                                                                      allowUnsignedManifests:codeSigningAllowUnsignedManifests
                                                                                                                                        error:&error];
   if (error) {
     NSString *message = [EXUpdatesCodeSigningErrorUtils messageForError:error.code];

--- a/packages/expo-updates/ios/Tests/EXUpdatesFileDownloaderManifestParsingTest.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesFileDownloaderManifestParsingTest.m
@@ -213,4 +213,39 @@
   XCTAssertNil(resultUpdateManifest);
 }
 
+- (void)testManifestParsing_JSONBodySigned_UnsignedRequest_ManifestSignatureOptional {
+  EXUpdatesConfig *config = [EXUpdatesConfig configWithDictionary:@{
+    EXUpdatesConfigUpdateUrlKey: @"https://exp.host/@test/test",
+    EXUpdatesConfigCodeSigningCertificateKey: _modernJSONCertificate,
+    EXUpdatesConfigCodeSigningMetadataKey: @{},
+    EXUpdatesConfigCodeSigningAllowUnsignedManifestsKey: @YES,
+  }];
+  EXUpdatesFileDownloader *downloader = [[EXUpdatesFileDownloader alloc] initWithUpdatesConfig:config];
+  
+  NSString *contentType = @"application/json";
+  
+  NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:@"https://exp.host/@test/test"]
+                                                            statusCode:200
+                                                           HTTPVersion:@"HTTP/1.1"
+                                                          headerFields:@{
+    @"expo-protocol-version": @"0",
+    @"expo-sfv-version": @"0",
+    @"content-type": contentType,
+  }];
+  
+  NSData *bodyData = [_modernJSON dataUsingEncoding:NSUTF8StringEncoding];
+  
+  __block BOOL errorOccurred;
+  __block EXUpdatesUpdate *resultUpdateManifest;
+  
+  [downloader parseManifestResponse:response withData:bodyData database:nil successBlock:^(EXUpdatesUpdate * _Nonnull update) {
+    resultUpdateManifest = update;
+  } errorBlock:^(NSError * _Nonnull error) {
+    errorOccurred = true;
+  }];
+  
+  XCTAssertFalse(errorOccurred);
+  XCTAssertNotNil(resultUpdateManifest);
+}
+
 @end

--- a/packages/expo-updates/ios/Tests/EXUpdatesSignatureHeaderInfoTests.swift
+++ b/packages/expo-updates/ios/Tests/EXUpdatesSignatureHeaderInfoTests.swift
@@ -19,11 +19,7 @@ class EXUpdatesSignatureHeaderInfoTests : XCTestCase {
       XCTAssertEqual(codeSigningInfo.algorithm, EXUpdatesCodeSigningAlgorithm.RSA_SHA256)
     }
 
-    func test_parseSignatureHeader_ThrowsForInvalidAlg() {
-      XCTAssertThrowsError(try EXUpdatesSignatureHeaderInfo.parseSignatureHeader(signatureHeader: nil)) { error in
-        XCTAssertEqual(error as? EXUpdatesCodeSigningError, EXUpdatesCodeSigningError.SignatureHeaderMissing)
-      }
-      
+    func test_parseSignatureHeader_ThrowsForInvalidAlg() {      
       XCTAssertThrowsError(try EXUpdatesSignatureHeaderInfo.parseSignatureHeader(signatureHeader: "fake=\"12345\"")) { error in
         XCTAssertEqual(error as? EXUpdatesCodeSigningError, EXUpdatesCodeSigningError.SignatureHeaderSigMissing)
       }

--- a/packages/expo-updates/ios/Tests/TestHelper.swift
+++ b/packages/expo-updates/ios/Tests/TestHelper.swift
@@ -35,8 +35,11 @@ struct TestHelper {
     return try String(contentsOfFile: certPath)
   }
   
+  static let testClassicBody = "{\"sdkVersion\":\"39.0.0\",\"releaseId\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"commitTime\":\"2020-11-11T00:17:54.797Z\",\"bundleUrl\":\"https://url.to/bundle.js\"}"
+  
   static let testBody =
   "{\"id\":\"0754dad0-d200-d634-113c-ef1f26106028\",\"createdAt\":\"2021-11-23T00:57:14.437Z\",\"runtimeVersion\":\"1\",\"assets\":[{\"hash\":\"cb65fafb5ed456fc3ed8a726cf4087d37b875184eba96f33f6d99104e6e2266d\",\"key\":\"489ea2f19fa850b65653ab445637a181.jpg\",\"contentType\":\"image/jpeg\",\"url\":\"http://192.168.64.1:3000/api/assets?asset=updates/1/assets/489ea2f19fa850b65653ab445637a181&runtimeVersion=1&platform=android\",\"fileExtension\":\".jpg\"}],\"launchAsset\":{\"hash\":\"323ddd1968ee76d4ddbb16b04fb2c3f1b6d1ab9b637d819699fecd6fa0ffb1a8\",\"key\":\"696a70cf7035664c20ea86f67dae822b.bundle\",\"contentType\":\"application/javascript\",\"url\":\"http://192.168.64.1:3000/api/assets?asset=updates/1/bundles/android-696a70cf7035664c20ea86f67dae822b.js&runtimeVersion=1&platform=android\",\"fileExtension\":\".bundle\"}}"
+  
   static let testSignature =
     "sig=\"rPpJN0SpXTlKfN9aUnEmz4llO0nQT/B1xqRd3e5E6iVseEp3W55BnAelGM7SRr8A/Tyb5qz/efUzpHL/N1FcQCZn6l1XKsCNLbrafsfePK+hH6gR+5cb+zSGv7F0hFMKxVerS/iZKP25GdLXejEsyq24gCMrDkbobsTxIKKMw/RDIuLfxs5BsLacKZNf5YklBsLXTOFUYKps8auTiWKBvowwTF2koCwXGuXsPZqJKpOZfjqQLXI5xIunpKwJSo0gZUIp/euyWqiqaBfN3BXOaXBtasXuQeCKZQ14G54b1d8ntPqC1jx+ILg0t5awAybD5iqR+9a6eMhWoDXHXDpdfg==\""
 


### PR DESCRIPTION
# Why

iOS equivalent of https://github.com/expo/expo/pull/16649 and https://github.com/expo/expo/pull/16679.

Depends on https://github.com/expo/expo/pull/16634.

# How

Pretty much just copy the code and translate to swift/objc.

# Test Plan

Run all tests. Load development experience in local expo go.