### PR TITLE
[docs] make Location doc accessible & correct

### DIFF
--- a/docs/pages/versions/unversioned/sdk/location.md
+++ b/docs/pages/versions/unversioned/sdk/location.md
@@ -60,7 +60,7 @@ export default function App() {
   const [errorMsg, setErrorMsg] = useState(null);
 
   useEffect(() => {
-    (async () => {
+    const grabCurrentLocation = async () => {
       /* @hide */
       if (Platform.OS === 'android' && !Device.isDevice) {
         setErrorMsg(
@@ -77,7 +77,9 @@ export default function App() {
 
       let location = await Location.getCurrentPositionAsync({});
       setLocation(location);
-    })();
+    })
+  
+    grabCurrentLocation();
   }, []);
 
   let text = 'Waiting..';

--- a/docs/pages/versions/unversioned/sdk/location.md
+++ b/docs/pages/versions/unversioned/sdk/location.md
@@ -77,7 +77,7 @@ export default function App() {
 
       let location = await Location.getCurrentPositionAsync({});
       setLocation(location);
-    })
+    });
   
     grabCurrentLocation();
   }, []);

--- a/docs/pages/versions/v44.0.0/sdk/location.md
+++ b/docs/pages/versions/v44.0.0/sdk/location.md
@@ -59,7 +59,7 @@ export default function App() {
   const [errorMsg, setErrorMsg] = useState(null);
 
   useEffect(() => {
-    (async () => {
+    const grabCurrentLocation = async () => {
       /* @hide */
       if (Platform.OS === 'android' && !Constants.isDevice) {
         setErrorMsg(
@@ -76,7 +76,9 @@ export default function App() {
 
       let location = await Location.getCurrentPositionAsync({});
       setLocation(location);
-    })();
+    });
+  
+    grabCurrentLocation();
   }, []);
 
   let text = 'Waiting..';

--- a/packages/expo-location/src/Location.ts
+++ b/packages/expo-location/src/Location.ts
@@ -246,7 +246,7 @@ export async function requestPermissionsAsync(): Promise<LocationPermissionRespo
 // @needsAudit
 /**
  * Checks user's permissions for accessing location while the app is in the foreground.
- * @return A promise that fulfills with an object of type [PermissionResponse](#permissionresponse).
+ * @return A promise that fulfills with an object of type [LocationPermissionResponse](#locationpermissionresponse).
  */
 export async function getForegroundPermissionsAsync(): Promise<LocationPermissionResponse> {
   return await ExpoLocation.getForegroundPermissionsAsync();
@@ -255,7 +255,7 @@ export async function getForegroundPermissionsAsync(): Promise<LocationPermissio
 // @needsAudit
 /**
  * Asks the user to grant permissions for location while the app is in the foreground.
- * @return A promise that fulfills with an object of type [PermissionResponse](#permissionresponse).
+ * @return A promise that fulfills with an object of type [LocationPermissionResponse](#locationpermissionresponse).
  */
 export async function requestForegroundPermissionsAsync(): Promise<LocationPermissionResponse> {
   return await ExpoLocation.requestForegroundPermissionsAsync();


### PR DESCRIPTION
Removing the use of [IIFE](https://developer.mozilla.org/en-US/docs/Glossary/IIFE) as it is hard for many newcomers to wrap their heads around.  This approach is far more understandable to junior developers (and seniors....only intermediate developers get all excited by such TIMTOWTDI constructs).

Terse is Worse
     - Greg Fenton

# Why

Location documentation has some inconsistencies with code, and is hard(er) to read for newcomers to JS, RN and Expo.

# How

Only updates to .md and to JSDoc

# Test Plan

Review the docs.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
