### PR TITLE
[iOS][BarCodeScanner] Add support for Codabar

### DIFF
--- a/docs/pages/versions/unversioned/sdk/bar-code-scanner.md
+++ b/docs/pages/versions/unversioned/sdk/bar-code-scanner.md
@@ -28,7 +28,7 @@ In managed apps, scanning barcodes with the camera requires the [`Permission.CAM
 | Bar code format | iOS   | Android     |
 | --------------- | ----- | ----------- |
 | aztec           | Yes   | Yes         |
-| codabar         | No    | Yes         |
+| codabar         | Yes   | Yes         |
 | code39          | Yes   | Yes         |
 | code93          | Yes   | Yes         |
 | code128         | Yes   | Yes         |

--- a/packages/expo-barcode-scanner/CHANGELOG.md
+++ b/packages/expo-barcode-scanner/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Added support for Codabar barcode type on iOS. ([#16703](https://github.com/expo/expo/pull/16703) by [@7nohe](https://github.com/7nohe))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-barcode-scanner/CHANGELOG.md
+++ b/packages/expo-barcode-scanner/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Added support for Codabar barcode type on iOS. ([#16703](https://github.com/expo/expo/pull/16703) by [@7nohe](https://github.com/7nohe))
+-  On iOS 15.4+ added support for `Codabar` barcode type. ([#16703](https://github.com/expo/expo/pull/16703) by [@7nohe](https://github.com/7nohe))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-barcode-scanner/ios/EXBarCodeScanner/EXBarCodeScanner.m
+++ b/packages/expo-barcode-scanner/ios/EXBarCodeScanner/EXBarCodeScanner.m
@@ -43,7 +43,7 @@ NSString *const EX_BARCODE_TYPES_KEY = @"barCodeTypes";
     };
     // Codabar - available in iOS 15.4+
     if (@available(iOS 15.4, *)) {
-        [_zxingBarcodeReaders setObject: [ZXCodaBarReader new] forKey:@"AVMetadataObjectTypeCodabarCode"];
+      [_zxingBarcodeReaders setObject: [ZXCodaBarReader new] forKey: AVMetadataObjectTypeCodabarCode];
     }
     _zxingFPSProcessed = 6;
     _zxingCaptureQueue = dispatch_queue_create("com.zxing.captureQueue", NULL);

--- a/packages/expo-barcode-scanner/ios/EXBarCodeScanner/EXBarCodeScanner.m
+++ b/packages/expo-barcode-scanner/ios/EXBarCodeScanner/EXBarCodeScanner.m
@@ -17,7 +17,7 @@
 @property (nonatomic, strong) NSDictionary<NSString *, id> *settings;
 @property (nonatomic, weak) AVCaptureVideoPreviewLayer *previewLayer;
 
-@property (nonatomic, strong) NSDictionary<NSString *, id<ZXReader>> *zxingBarcodeReaders;
+@property (nonatomic, strong) NSMutableDictionary<NSString *, id<ZXReader>> *zxingBarcodeReaders;
 @property (nonatomic, assign) CGFloat zxingFPSProcessed;
 @property (nonatomic, strong) AVCaptureVideoDataOutput* videoDataOutput;
 @property (nonatomic, strong) dispatch_queue_t zxingCaptureQueue;
@@ -35,15 +35,15 @@ NSString *const EX_BARCODE_TYPES_KEY = @"barCodeTypes";
     _settings = [[NSMutableDictionary alloc] initWithDictionary:[[self class] _getDefaultSettings]];
 
     // zxing handles barcodes reading of following types:
-      NSMutableDictionary *_zxingBarcodeReaders = @{
+    _zxingBarcodeReaders = [@{
       // PDF417 - built-in PDF417 reader doesn't handle u'\0' (null) character - https://github.com/expo/expo/issues/4817
       AVMetadataObjectTypePDF417Code: [ZXPDF417Reader new],
       // Code39 - built-in Code39 reader doesn't read non-ideal (slightly rotated) images like this - https://github.com/expo/expo/pull/5976#issuecomment-545001008
       AVMetadataObjectTypeCode39Code: [ZXCode39Reader new],
-    };
+    } mutableCopy];
     // Codabar - available in iOS 15.4+
     if (@available(iOS 15.4, *)) {
-      [_zxingBarcodeReaders setObject: [ZXCodaBarReader new] forKey: AVMetadataObjectTypeCodabarCode];
+      _zxingBarcodeReaders[AVMetadataObjectTypeCodabarCode] = [ZXCodaBarReader new];
     }
     _zxingFPSProcessed = 6;
     _zxingCaptureQueue = dispatch_queue_create("com.zxing.captureQueue", NULL);

--- a/packages/expo-barcode-scanner/ios/EXBarCodeScanner/EXBarCodeScanner.m
+++ b/packages/expo-barcode-scanner/ios/EXBarCodeScanner/EXBarCodeScanner.m
@@ -35,14 +35,16 @@ NSString *const EX_BARCODE_TYPES_KEY = @"barCodeTypes";
     _settings = [[NSMutableDictionary alloc] initWithDictionary:[[self class] _getDefaultSettings]];
 
     // zxing handles barcodes reading of following types:
-    _zxingBarcodeReaders = @{
+      NSMutableDictionary *_zxingBarcodeReaders = @{
       // PDF417 - built-in PDF417 reader doesn't handle u'\0' (null) character - https://github.com/expo/expo/issues/4817
       AVMetadataObjectTypePDF417Code: [ZXPDF417Reader new],
       // Code39 - built-in Code39 reader doesn't read non-ideal (slightly rotated) images like this - https://github.com/expo/expo/pull/5976#issuecomment-545001008
       AVMetadataObjectTypeCode39Code: [ZXCode39Reader new],
-      // Codabar
-      AVMetadataObjectTypeCodabarCode: [ZXCodaBarReader new],
     };
+    // Codabar - available in iOS 15.4+
+    if (@available(iOS 15.4, *)) {
+        [_zxingBarcodeReaders setObject: [ZXCodaBarReader new] forKey:@"AVMetadataObjectTypeCodabarCode"];
+    }
     _zxingFPSProcessed = 6;
     _zxingCaptureQueue = dispatch_queue_create("com.zxing.captureQueue", NULL);
     _zxingEnabled = YES;
@@ -312,7 +314,12 @@ didOutputSampleBuffer:(CMSampleBufferRef)sampleBuffer
     case kBarcodeFormatCode39:
       return AVMetadataObjectTypeCode39Code;
     case kBarcodeFormatCodabar:
-      return AVMetadataObjectTypeCodabarCode;
+      // available in iOS 15.4+
+      if (@available(iOS 15.4, *)) {
+        return AVMetadataObjectTypeCodabarCode;
+      } else {
+        return @"unknown";
+      }
     default:
       return @"unknown";
   }

--- a/packages/expo-barcode-scanner/ios/EXBarCodeScanner/EXBarCodeScanner.m
+++ b/packages/expo-barcode-scanner/ios/EXBarCodeScanner/EXBarCodeScanner.m
@@ -40,6 +40,8 @@ NSString *const EX_BARCODE_TYPES_KEY = @"barCodeTypes";
       AVMetadataObjectTypePDF417Code: [ZXPDF417Reader new],
       // Code39 - built-in Code39 reader doesn't read non-ideal (slightly rotated) images like this - https://github.com/expo/expo/pull/5976#issuecomment-545001008
       AVMetadataObjectTypeCode39Code: [ZXCode39Reader new],
+      // Codabar
+      AVMetadataObjectTypeCodabarCode: [ZXCodaBarReader new],
     };
     _zxingFPSProcessed = 6;
     _zxingCaptureQueue = dispatch_queue_create("com.zxing.captureQueue", NULL);
@@ -309,6 +311,8 @@ didOutputSampleBuffer:(CMSampleBufferRef)sampleBuffer
       return AVMetadataObjectTypePDF417Code;
     case kBarcodeFormatCode39:
       return AVMetadataObjectTypeCode39Code;
+    case kBarcodeFormatCodabar:
+      return AVMetadataObjectTypeCodabarCode;
     default:
       return @"unknown";
   }

--- a/packages/expo-barcode-scanner/ios/EXBarCodeScanner/Utilities/EXBarCodeScannerUtils.m
+++ b/packages/expo-barcode-scanner/ios/EXBarCodeScanner/Utilities/EXBarCodeScannerUtils.m
@@ -8,22 +8,26 @@
 
 + (NSDictionary *)validBarCodeTypes
 {
-  return @{
-           @"upc_e" : AVMetadataObjectTypeUPCECode,
-           @"codabar" : AVMetadataObjectTypeCodabarCode,
-           @"code39" : AVMetadataObjectTypeCode39Code,
-           @"code39mod43" : AVMetadataObjectTypeCode39Mod43Code,
-           @"ean13" : AVMetadataObjectTypeEAN13Code,
-           @"ean8" : AVMetadataObjectTypeEAN8Code,
-           @"code93" : AVMetadataObjectTypeCode93Code,
-           @"code128" : AVMetadataObjectTypeCode128Code,
-           @"pdf417" : AVMetadataObjectTypePDF417Code,
-           @"qr" : AVMetadataObjectTypeQRCode,
-           @"aztec" : AVMetadataObjectTypeAztecCode,
-           @"interleaved2of5" : AVMetadataObjectTypeInterleaved2of5Code,
-           @"itf14" : AVMetadataObjectTypeITF14Code,
-           @"datamatrix" : AVMetadataObjectTypeDataMatrixCode,
-           };
+    NSMutableDictionary *_validBarcodeTypes = @{
+      @"upc_e" : AVMetadataObjectTypeUPCECode,
+      @"code39" : AVMetadataObjectTypeCode39Code,
+      @"code39mod43" : AVMetadataObjectTypeCode39Mod43Code,
+      @"ean13" : AVMetadataObjectTypeEAN13Code,
+      @"ean8" : AVMetadataObjectTypeEAN8Code,
+      @"code93" : AVMetadataObjectTypeCode93Code,
+      @"code128" : AVMetadataObjectTypeCode128Code,
+      @"pdf417" : AVMetadataObjectTypePDF417Code,
+      @"qr" : AVMetadataObjectTypeQRCode,
+      @"aztec" : AVMetadataObjectTypeAztecCode,
+      @"interleaved2of5" : AVMetadataObjectTypeInterleaved2of5Code,
+      @"itf14" : AVMetadataObjectTypeITF14Code,
+      @"datamatrix" : AVMetadataObjectTypeDataMatrixCode,
+    };
+    // available in iOS 15.4+
+    if (@available(iOS 15.4, *)) {
+      [_validBarcodeTypes setObject: AVMetadataObjectTypeCodabarCode forKey:@"codabar"];
+    }
+    return _validBarcodeTypes;
 }
 
 + (AVCaptureVideoOrientation)videoOrientationForInterfaceOrientation:(UIInterfaceOrientation)orientation
@@ -139,7 +143,12 @@
     case kBarcodeFormatCode39:
       return AVMetadataObjectTypeCode39Code;
     case kBarcodeFormatCodabar:
-      return AVMetadataObjectTypeCodabarCode;
+      // available in iOS 15.4+
+      if (@available(iOS 15.4, *)) {
+        return AVMetadataObjectTypeCodabarCode;
+      } else {
+        return @"unknown";
+      }
     default:
       return @"unknown";
   }

--- a/packages/expo-barcode-scanner/ios/EXBarCodeScanner/Utilities/EXBarCodeScannerUtils.m
+++ b/packages/expo-barcode-scanner/ios/EXBarCodeScanner/Utilities/EXBarCodeScannerUtils.m
@@ -10,6 +10,7 @@
 {
   return @{
            @"upc_e" : AVMetadataObjectTypeUPCECode,
+           @"codabar" : AVMetadataObjectTypeCodabarCode,
            @"code39" : AVMetadataObjectTypeCode39Code,
            @"code39mod43" : AVMetadataObjectTypeCode39Mod43Code,
            @"ean13" : AVMetadataObjectTypeEAN13Code,
@@ -137,6 +138,8 @@
       return AVMetadataObjectTypePDF417Code;
     case kBarcodeFormatCode39:
       return AVMetadataObjectTypeCode39Code;
+    case kBarcodeFormatCodabar:
+      return AVMetadataObjectTypeCodabarCode;
     default:
       return @"unknown";
   }

--- a/packages/expo-barcode-scanner/ios/EXBarCodeScanner/Utilities/EXBarCodeScannerUtils.m
+++ b/packages/expo-barcode-scanner/ios/EXBarCodeScanner/Utilities/EXBarCodeScannerUtils.m
@@ -8,7 +8,7 @@
 
 + (NSDictionary *)validBarCodeTypes
 {
-    NSMutableDictionary *_validBarcodeTypes = @{
+    NSMutableDictionary *validTypes = [@{
       @"upc_e" : AVMetadataObjectTypeUPCECode,
       @"code39" : AVMetadataObjectTypeCode39Code,
       @"code39mod43" : AVMetadataObjectTypeCode39Mod43Code,
@@ -22,12 +22,11 @@
       @"interleaved2of5" : AVMetadataObjectTypeInterleaved2of5Code,
       @"itf14" : AVMetadataObjectTypeITF14Code,
       @"datamatrix" : AVMetadataObjectTypeDataMatrixCode,
-    };
-    // available in iOS 15.4+
+    } mutableCopy];
     if (@available(iOS 15.4, *)) {
-      [_validBarcodeTypes setObject: AVMetadataObjectTypeCodabarCode forKey:@"codabar"];
+      validTypes[@"codabar"] = AVMetadataObjectTypeCodabarCode;
     }
-    return _validBarcodeTypes;
+    return validTypes;
 }
 
 + (AVCaptureVideoOrientation)videoOrientationForInterfaceOrientation:(UIInterfaceOrientation)orientation


### PR DESCRIPTION
# Why

Added support for Codabar barcode type, since iOS SDK does not support it.

# How

I've added zxing's`ZXCodaBarReader` for scanning Codebar barcode type.

# Test Plan

- Ran the `bare-expo` project on a physical device, scanned a Codabar barcode (e.g. image from https://en.wikipedia.org/wiki/Codabar)

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
