### PR TITLE
[docs] Update vector icons imports

### DIFF
--- a/docs/pages/guides/icons.md
+++ b/docs/pages/guides/icons.md
@@ -16,7 +16,7 @@ This library is installed by default on the template project that get through `e
 ```jsx
 import * as React from 'react';
 import { View, StyleSheet } from 'react-native';
-import { Ionicons } from '@expo/vector-icons';
+import { Ionicons } from '@expo/vector-icons/Ionicons';
 
 export default function App() {
   return (
@@ -43,7 +43,7 @@ const styles = StyleSheet.create({
 
 This component loads the Ionicons font if it hasn't been loaded already, and renders a checkmark icon that I found through the vector-icons directory mentioned above. `@expo/vector-icons` is built on top of [react-native-vector-icons](https://github.com/oblador/react-native-vector-icons) and uses a similar API. The only difference is `@expo/vector-icons` uses a more idiomatic `import` style:
 
-`import { Ionicons } from '@expo/vector-icons';` instead of.. `import Ionicons from 'react-native-vector-icons/Ionicons';`.
+`import { Ionicons } from '@expo/vector-icons/Ionicons';` instead of.. `import Ionicons from 'react-native-vector-icons/Ionicons';`.
 
 > **Note:** As with [any custom font](using-custom-fonts.md#using-custom-fonts) in Expo, you may want to preload icon fonts before rendering your app. The font object is available as a static property on the font component, so in the case above it is `Ionicons.font`, which evaluates to `{ionicons: require('path/to/ionicons.ttf')}`. [Read more about preloading assets](preloading-and-caching-assets.md).
 
@@ -192,7 +192,7 @@ A convenience component for creating buttons with an icon on the left side.
 ```jsx
 import * as React from 'react';
 import { View, StyleSheet } from 'react-native';
-import { FontAwesome } from '@expo/vector-icons';
+import { FontAwesome } from '@expo/vector-icons/FontAwesome';
 
 export default function App() {
   /* @hide const loginWithFacebook = () => { ... } */
@@ -205,7 +205,7 @@ export default function App() {
     <View style={styles.container}>
       /* @info */
       <FontAwesome.Button name="facebook" backgroundColor="#3b5998" onPress={loginWithFacebook}>/* @end */
-      
+
         Login with Facebook
       /* @info */</FontAwesome.Button>/* @end */
 
@@ -230,11 +230,11 @@ const styles = StyleSheet.create({
 
 Any [`Text`](http://reactnative.dev/docs/text), [`TouchableHighlight`](http://reactnative.dev/docs/touchablehighlight) or [`TouchableWithoutFeedback`](http://reactnative.dev/docs/touchablewithoutfeedback) property in addition to these:
 
-| Prop                  | Description                                                                                                                                       | Default               |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- |
-| **`color`**           | Text and icon color, use `iconStyle` or nest a `Text` component if you need different colors.                                                     | `white`               |
-| **`size`**            | Icon size.                                                                                                                                        | `20`                  |
+| Prop                  | Description                                                                                                                                       | Default             |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
+| **`color`**           | Text and icon color, use `iconStyle` or nest a `Text` component if you need different colors.                                                     | `white`             |
+| **`size`**            | Icon size.                                                                                                                                        | `20`                |
 | **`iconStyle`**       | Styles applied to the icon only, good for setting margins or a different color. _Note: use `iconStyle` for margins or expect unstable behaviour._ | `{marginRight: 10}` |
-| **`backgroundColor`** | Background color of the button.                                                                                                                   | `#007AFF`             |
-| **`borderRadius`**    | Border radius of the button, set to `0` to disable.                                                                                               | `5`                   |
-| **`onPress`**         | A function called when the button is pressed.                                                                                                     | _None_                |
+| **`backgroundColor`** | Background color of the button.                                                                                                                   | `#007AFF`           |
+| **`borderRadius`**    | Border radius of the button, set to `0` to disable.                                                                                               | `5`                 |
+| **`onPress`**         | A function called when the button is pressed.                                                                                                     | _None_              |

--- a/docs/pages/guides/icons.md
+++ b/docs/pages/guides/icons.md
@@ -16,7 +16,7 @@ This library is installed by default on the template project that get through `e
 ```jsx
 import * as React from 'react';
 import { View, StyleSheet } from 'react-native';
-import { Ionicons } from '@expo/vector-icons/Ionicons';
+import Ionicons from '@expo/vector-icons/Ionicons';
 
 export default function App() {
   return (
@@ -41,9 +41,7 @@ const styles = StyleSheet.create({
 
 </SnackInline>
 
-This component loads the Ionicons font if it hasn't been loaded already, and renders a checkmark icon that I found through the vector-icons directory mentioned above. `@expo/vector-icons` is built on top of [react-native-vector-icons](https://github.com/oblador/react-native-vector-icons) and uses a similar API. The only difference is `@expo/vector-icons` uses a more idiomatic `import` style:
-
-`import { Ionicons } from '@expo/vector-icons/Ionicons';` instead of.. `import Ionicons from 'react-native-vector-icons/Ionicons';`.
+This component loads the Ionicons font if it hasn't been loaded already, and renders a checkmark icon that I found through the vector-icons directory mentioned above. `@expo/vector-icons` is built on top of [react-native-vector-icons](https://github.com/oblador/react-native-vector-icons) and uses a similar API.
 
 > **Note:** As with [any custom font](using-custom-fonts.md#using-custom-fonts) in Expo, you may want to preload icon fonts before rendering your app. The font object is available as a static property on the font component, so in the case above it is `Ionicons.font`, which evaluates to `{ionicons: require('path/to/ionicons.ttf')}`. [Read more about preloading assets](preloading-and-caching-assets.md).
 
@@ -192,7 +190,7 @@ A convenience component for creating buttons with an icon on the left side.
 ```jsx
 import * as React from 'react';
 import { View, StyleSheet } from 'react-native';
-import { FontAwesome } from '@expo/vector-icons/FontAwesome';
+import FontAwesome from '@expo/vector-icons/FontAwesome';
 
 export default function App() {
   /* @hide const loginWithFacebook = () => { ... } */

--- a/docs/pages/guides/preloading-and-caching-assets.md
+++ b/docs/pages/guides/preloading-and-caching-assets.md
@@ -44,7 +44,7 @@ import { View, Text, Image } from 'react-native';
 import AppLoading from 'expo-app-loading';
 import * as Font from 'expo-font';
 import { Asset } from 'expo-asset';
-import { FontAwesome } from '@expo/vector-icons';
+import { FontAwesome } from '@expo/vector-icons/FontAwesome';
 
 function cacheImages(images) {
   return images.map(image => {

--- a/docs/pages/guides/preloading-and-caching-assets.md
+++ b/docs/pages/guides/preloading-and-caching-assets.md
@@ -44,7 +44,7 @@ import { View, Text, Image } from 'react-native';
 import AppLoading from 'expo-app-loading';
 import * as Font from 'expo-font';
 import { Asset } from 'expo-asset';
-import { FontAwesome } from '@expo/vector-icons/FontAwesome';
+import FontAwesome from '@expo/vector-icons/FontAwesome';
 
 function cacheImages(images) {
   return images.map(image => {

--- a/docs/pages/ui-programming/implementing-a-checkbox.md
+++ b/docs/pages/ui-programming/implementing-a-checkbox.md
@@ -18,7 +18,7 @@ _Note: You can find more information about using icons in your Expo project here
 ```jsx
 import React, { useState } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
-import { Ionicons } from '@expo/vector-icons';
+import Ionicons from '@expo/vector-icons';
 
 function MyCheckbox() {
   const [checked, onChange] = useState(false);
@@ -102,7 +102,7 @@ This checkbox isn't useful in this state because the `checked` value is accessib
 ```jsx
 import React, { useState } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
-import { Ionicons } from '@expo/vector-icons/Ionicons';
+import Ionicons from '@expo/vector-icons/Ionicons';
 
 function MyCheckbox({
   /* @info Define checked and onChange as props instead of state */ checked,
@@ -196,7 +196,7 @@ It's common enough to need to render different styles when the checkmark is `che
 ```jsx
 import React, { useState } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
-import { Ionicons } from '@expo/vector-icons/Ionicons';
+import Ionicons from '@expo/vector-icons/Ionicons';
 
 function MyCheckbox({
   checked,

--- a/docs/pages/ui-programming/implementing-a-checkbox.md
+++ b/docs/pages/ui-programming/implementing-a-checkbox.md
@@ -102,7 +102,7 @@ This checkbox isn't useful in this state because the `checked` value is accessib
 ```jsx
 import React, { useState } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
-import { Ionicons } from '@expo/vector-icons';
+import { Ionicons } from '@expo/vector-icons/Ionicons';
 
 function MyCheckbox({
   /* @info Define checked and onChange as props instead of state */ checked,
@@ -196,7 +196,7 @@ It's common enough to need to render different styles when the checkmark is `che
 ```jsx
 import React, { useState } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
-import { Ionicons } from '@expo/vector-icons';
+import { Ionicons } from '@expo/vector-icons/Ionicons';
 
 function MyCheckbox({
   checked,

--- a/docs/pages/versions/unversioned/sdk/splash-screen.md
+++ b/docs/pages/versions/unversioned/sdk/splash-screen.md
@@ -25,7 +25,7 @@ This example shows how to keep the splash screen visible while loading app resou
 ```js
 import React, { useCallback, useEffect, useState } from 'react';
 import { Text, View } from 'react-native';
-import { Entypo } from '@expo/vector-icons';
+import { Entypo } from '@expo/vector-icons/Entypo';
 import * as SplashScreen from 'expo-splash-screen';
 import * as Font from 'expo-font';
 

--- a/docs/pages/versions/unversioned/sdk/splash-screen.md
+++ b/docs/pages/versions/unversioned/sdk/splash-screen.md
@@ -25,7 +25,7 @@ This example shows how to keep the splash screen visible while loading app resou
 ```js
 import React, { useCallback, useEffect, useState } from 'react';
 import { Text, View } from 'react-native';
-import { Entypo } from '@expo/vector-icons/Entypo';
+import Entypo from '@expo/vector-icons/Entypo';
 import * as SplashScreen from 'expo-splash-screen';
 import * as Font from 'expo-font';
 

--- a/docs/pages/versions/v40.0.0/sdk/splash-screen.md
+++ b/docs/pages/versions/v40.0.0/sdk/splash-screen.md
@@ -23,7 +23,7 @@ This example shows how to keep the splash screen visible while loading app resou
 ```js
 import React, { useCallback, useEffect, useState } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
-import { Entypo } from '@expo/vector-icons';
+import { Entypo } from '@expo/vector-icons/Entypo';
 import * as SplashScreen from 'expo-splash-screen';
 import * as Font from 'expo-font';
 

--- a/docs/pages/versions/v40.0.0/sdk/splash-screen.md
+++ b/docs/pages/versions/v40.0.0/sdk/splash-screen.md
@@ -23,7 +23,7 @@ This example shows how to keep the splash screen visible while loading app resou
 ```js
 import React, { useCallback, useEffect, useState } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
-import { Entypo } from '@expo/vector-icons/Entypo';
+import Entypo from '@expo/vector-icons/Entypo';
 import * as SplashScreen from 'expo-splash-screen';
 import * as Font from 'expo-font';
 

--- a/docs/pages/versions/v41.0.0/sdk/splash-screen.md
+++ b/docs/pages/versions/v41.0.0/sdk/splash-screen.md
@@ -24,7 +24,7 @@ This example shows how to keep the splash screen visible while loading app resou
 ```js
 import React, { useCallback, useEffect, useState } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
-import { Entypo } from '@expo/vector-icons/Entypo';
+import Entypo from '@expo/vector-icons/Entypo';
 import * as SplashScreen from 'expo-splash-screen';
 import * as Font from 'expo-font';
 

--- a/docs/pages/versions/v41.0.0/sdk/splash-screen.md
+++ b/docs/pages/versions/v41.0.0/sdk/splash-screen.md
@@ -24,7 +24,7 @@ This example shows how to keep the splash screen visible while loading app resou
 ```js
 import React, { useCallback, useEffect, useState } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
-import { Entypo } from '@expo/vector-icons';
+import { Entypo } from '@expo/vector-icons/Entypo';
 import * as SplashScreen from 'expo-splash-screen';
 import * as Font from 'expo-font';
 

--- a/docs/pages/versions/v42.0.0/sdk/splash-screen.md
+++ b/docs/pages/versions/v42.0.0/sdk/splash-screen.md
@@ -24,7 +24,7 @@ This example shows how to keep the splash screen visible while loading app resou
 ```js
 import React, { useCallback, useEffect, useState } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
-import { Entypo } from '@expo/vector-icons';
+import Entypo from '@expo/vector-icons';
 import * as SplashScreen from 'expo-splash-screen';
 import * as Font from 'expo-font';
 

--- a/docs/pages/versions/v43.0.0/sdk/splash-screen.md
+++ b/docs/pages/versions/v43.0.0/sdk/splash-screen.md
@@ -24,7 +24,7 @@ This example shows how to keep the splash screen visible while loading app resou
 ```js
 import React, { useCallback, useEffect, useState } from 'react';
 import { Text, View } from 'react-native';
-import { Entypo } from '@expo/vector-icons';
+import { Entypo } from '@expo/vector-icons/Entypo';
 import * as SplashScreen from 'expo-splash-screen';
 import * as Font from 'expo-font';
 

--- a/docs/pages/versions/v43.0.0/sdk/splash-screen.md
+++ b/docs/pages/versions/v43.0.0/sdk/splash-screen.md
@@ -24,7 +24,7 @@ This example shows how to keep the splash screen visible while loading app resou
 ```js
 import React, { useCallback, useEffect, useState } from 'react';
 import { Text, View } from 'react-native';
-import { Entypo } from '@expo/vector-icons/Entypo';
+import Entypo from '@expo/vector-icons/Entypo';
 import * as SplashScreen from 'expo-splash-screen';
 import * as Font from 'expo-font';
 

--- a/docs/pages/versions/v44.0.0/sdk/splash-screen.md
+++ b/docs/pages/versions/v44.0.0/sdk/splash-screen.md
@@ -24,7 +24,7 @@ This example shows how to keep the splash screen visible while loading app resou
 ```js
 import React, { useCallback, useEffect, useState } from 'react';
 import { Text, View } from 'react-native';
-import { Entypo } from '@expo/vector-icons';
+import { Entypo } from '@expo/vector-icons/Entypo';
 import * as SplashScreen from 'expo-splash-screen';
 import * as Font from 'expo-font';
 

--- a/docs/pages/versions/v44.0.0/sdk/splash-screen.md
+++ b/docs/pages/versions/v44.0.0/sdk/splash-screen.md
@@ -24,7 +24,7 @@ This example shows how to keep the splash screen visible while loading app resou
 ```js
 import React, { useCallback, useEffect, useState } from 'react';
 import { Text, View } from 'react-native';
-import { Entypo } from '@expo/vector-icons/Entypo';
+import Entypo from '@expo/vector-icons/Entypo';
 import * as SplashScreen from 'expo-splash-screen';
 import * as Font from 'expo-font';
 


### PR DESCRIPTION
Updating all the vector icons imports to directly import the specific library so that the app does not bundle all the icon sets, only the one that is needed. The app would require all the icon sets if imported like before this PR because there's an inline require at the root of the vector icons package, and metro does not support tree shaking/removing unused assets.