### PR TITLE
[expo-manifests][expo-dev-launcher] add logUrl getter to manifest classes

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Simplify dev-launcher / dev-menu relationship on Android. ([#16228](https://github.com/expo/expo/pull/16228) by [@ajsmth](https://github.com/ajsmth))
 - Compatibility with expo-dev-menu auto-setup on iOS. ([#16496](https://github.com/expo/expo/pull/16496) by [@esamelson](https://github.com/esamelson))
 - Remove initialization side effects. ([#16522](https://github.com/expo/expo/pull/16522) by [@esamelson](https://github.com/esamelson))
+- Use expo-manifests `logUrl` getter instead of accessing raw JSON.
 
 ## 0.10.4 — 2022-02-07
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -26,7 +26,7 @@
 - Simplify dev-launcher / dev-menu relationship on Android. ([#16228](https://github.com/expo/expo/pull/16228) by [@ajsmth](https://github.com/ajsmth))
 - Compatibility with expo-dev-menu auto-setup on iOS. ([#16496](https://github.com/expo/expo/pull/16496) by [@esamelson](https://github.com/esamelson))
 - Remove initialization side effects. ([#16522](https://github.com/expo/expo/pull/16522) by [@esamelson](https://github.com/esamelson))
-- Use expo-manifests `logUrl` getter instead of accessing raw JSON.
+- Use expo-manifests `logUrl` getter instead of accessing raw JSON. ([#16709](https://github.com/expo/expo/pull/16709) by [@esamelson](https://github.com/esamelson))
 
 ## 0.10.4 — 2022-02-07
 

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/errors/DevLauncherUncaughtExceptionHandler.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/errors/DevLauncherUncaughtExceptionHandler.kt
@@ -123,7 +123,7 @@ class DevLauncherUncaughtExceptionHandler(
   }
 
   private fun getLogsUrl(): Uri {
-    val logsUrlFromManifest = controller.manifest?.getRawJson()?.optString("logUrl")
+    val logsUrlFromManifest = controller.manifest?.getLogUrl()
     if (logsUrlFromManifest.isNullOrEmpty()) {
       return Uri.parse(logsUrlFromManifest)
     }

--- a/packages/expo-dev-launcher/ios/Errors/EXDevLauncherUncaughtExceptionHandler.swift
+++ b/packages/expo-dev-launcher/ios/Errors/EXDevLauncherUncaughtExceptionHandler.swift
@@ -52,7 +52,7 @@ public class EXDevLauncherUncaughtExceptionHandler: NSObject {
   }
   
   static func getLogsUrl(_ controller: EXDevLauncherController) -> URL? {
-    let logsUrlFromManifest = controller.appManifest()?.rawManifestJSON()["logUrl"] as? String
+    let logsUrlFromManifest = controller.appManifest()?.logUrl()
     if (logsUrlFromManifest != nil) {
       return URL.init(string: logsUrlFromManifest!)
     }

--- a/packages/expo-manifests/CHANGELOG.md
+++ b/packages/expo-manifests/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add `logUrl` getter to both platforms.
+
 ### 🐛 Bug fixes
 
 - Add support for expo project information certificate extension. ([#16607](https://github.com/expo/expo/pull/16607) by [@wschurman](https://github.com/wschurman))

--- a/packages/expo-manifests/CHANGELOG.md
+++ b/packages/expo-manifests/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Add `logUrl` getter to both platforms.
+- Add `logUrl` getter to both platforms. ([#16709](https://github.com/expo/expo/pull/16709) by [@esamelson](https://github.com/esamelson))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/Manifest.kt
+++ b/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/Manifest.kt
@@ -101,6 +101,7 @@ abstract class Manifest(protected val json: JSONObject) {
 
   fun getDebuggerHost(): String = getExpoGoConfigRootObject()!!.require("debuggerHost")
   fun getMainModuleName(): String = getExpoGoConfigRootObject()!!.require("mainModuleName")
+  fun getLogUrl(): String? = getExpoGoConfigRootObject()?.getNullable("logUrl")
   fun getHostUri(): String? = getExpoGoConfigRootObject()?.getNullable("hostUri")
 
   fun isVerified(): Boolean = json.getNullable("isVerified") ?: false

--- a/packages/expo-manifests/ios/EXManifests/EXManifestsBaseManifest.h
+++ b/packages/expo-manifests/ios/EXManifests/EXManifestsBaseManifest.h
@@ -26,6 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSString *)orientation;
 - (nullable NSDictionary *)experiments;
 - (nullable NSDictionary *)developer;
+- (nullable NSString *)logUrl;
 - (nullable NSString *)facebookAppId;
 - (nullable NSString *)facebookApplicationName;
 - (BOOL)facebookAutoInitEnabled;

--- a/packages/expo-manifests/ios/EXManifests/EXManifestsBaseManifest.m
+++ b/packages/expo-manifests/ios/EXManifests/EXManifestsBaseManifest.m
@@ -119,6 +119,14 @@
   return [expoGoConfig nullableDictionaryForKey:@"developer"];
 }
 
+- (nullable NSString *)logUrl {
+  NSDictionary *expoGoConfig = self.expoGoConfigRootObject;
+  if (!expoGoConfig) {
+    return nil;
+  }
+  return [expoGoConfig nullableStringForKey:@"logUrl"];
+}
+
 - (nullable NSString *)facebookAppId {
   NSDictionary *expoClientConfig = self.expoClientConfigRootObject;
   if (!expoClientConfig) {

--- a/packages/expo-manifests/ios/EXManifests/EXManifestsManifest.h
+++ b/packages/expo-manifests/ios/EXManifests/EXManifestsManifest.h
@@ -56,6 +56,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSString *)orientation;
 - (nullable NSDictionary *)experiments;
 - (nullable NSDictionary *)developer;
+- (nullable NSString *)logUrl;
 - (nullable NSString *)facebookAppId;
 - (nullable NSString *)facebookApplicationName;
 - (BOOL)facebookAutoInitEnabled;


### PR DESCRIPTION
# Why

resolves ENG-4080

# How

Added `logUrl` getters to base manifest classes on both platforms, replaced usages from #15964 and #15938.

# Test Plan

Made a build on each platform, and opened app using `expo start --dev-client` and `expo start --dev-client --force-manifest-type=expo-updates`, logged the new `logUrl` property on manifest to ensure it was nonnull and correct.

Was not able to verify that the actual logging functionality of the dev client still works; I tried to follow the test plans from #15964 and #15938 but did not figure out the right place to throw an exception (it either showed me a redbox or just showed the error as an alert in the dev launcher UI) to trigger the logging. I can try this out again if you could provide more details about how to test this!

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
