### PR TITLE
[expo-dev-launcher] respect androidNavigationBar app.json settings at runtime

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -19,6 +19,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix `androidNavigationBar` app.json config settings having no effect at runtime ([#15030](https://github.com/expo/expo/issues/15030)).
+
 ### 💡 Others
 
 - Move unrelated dev-menu functions into dev-launcher. ([#16124](https://github.com/expo/expo/pull/16124) by [@ajsmth](https://github.com/ajsmth))

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix `androidNavigationBar` app.json config settings having no effect at runtime ([#15030](https://github.com/expo/expo/issues/15030)).
+- Fix `androidNavigationBar` app.json config settings having no effect at runtime ([#15030](https://github.com/expo/expo/issues/15030)). ([#16711](https://github.com/expo/expo/pull/16711) by [@esamelson](https://github.com/esamelson))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherExpoAppLoader.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherExpoAppLoader.kt
@@ -27,6 +27,7 @@ abstract class DevLauncherExpoAppLoader(
     applyOrientation(activity)
     applyStatusBarConfiguration(activity)
     applyTaskDescription(activity)
+    applyNavigationBarConfiguration(activity)
   }
 
   override fun onReactContext(context: ReactContext) {

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/configurators/DevLauncherExpoActivityConfigurator.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/configurators/DevLauncherExpoActivityConfigurator.kt
@@ -185,17 +185,10 @@ class DevLauncherExpoActivityConfigurator(
       // Hide both the navigation bar and the status bar. The Android docs recommend, "you should
       // design your app to hide the status bar whenever you hide the navigation bar."
       val decorView = activity.window.decorView
-      var flags = decorView.systemUiVisibility
-      when (navBarVisible) {
-        DevLauncherNavigationBarVisibility.LEANBACK ->
-          flags =
-            flags or (View.SYSTEM_UI_FLAG_HIDE_NAVIGATION or View.SYSTEM_UI_FLAG_FULLSCREEN)
-        DevLauncherNavigationBarVisibility.IMMERSIVE ->
-          flags =
-            flags or (View.SYSTEM_UI_FLAG_HIDE_NAVIGATION or View.SYSTEM_UI_FLAG_FULLSCREEN or View.SYSTEM_UI_FLAG_IMMERSIVE)
-        DevLauncherNavigationBarVisibility.STICKY_IMMERSIVE ->
-          flags =
-            flags or (View.SYSTEM_UI_FLAG_HIDE_NAVIGATION or View.SYSTEM_UI_FLAG_FULLSCREEN or View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY)
+      val flags = decorView.systemUiVisibility or when (navBarVisible) {
+        DevLauncherNavigationBarVisibility.LEANBACK -> (View.SYSTEM_UI_FLAG_HIDE_NAVIGATION or View.SYSTEM_UI_FLAG_FULLSCREEN)
+        DevLauncherNavigationBarVisibility.IMMERSIVE -> (View.SYSTEM_UI_FLAG_HIDE_NAVIGATION or View.SYSTEM_UI_FLAG_FULLSCREEN or View.SYSTEM_UI_FLAG_IMMERSIVE)
+        DevLauncherNavigationBarVisibility.STICKY_IMMERSIVE -> (View.SYSTEM_UI_FLAG_HIDE_NAVIGATION or View.SYSTEM_UI_FLAG_FULLSCREEN or View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY)
       }
       decorView.systemUiVisibility = flags
     }

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/configurators/DevLauncherExpoActivityConfigurator.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/configurators/DevLauncherExpoActivityConfigurator.kt
@@ -7,6 +7,7 @@ import android.content.pm.ActivityInfo
 import android.graphics.BitmapFactory
 import android.graphics.Color
 import android.os.Build
+import android.util.Log
 import android.view.View
 import android.view.WindowInsets
 import android.view.WindowManager
@@ -15,6 +16,8 @@ import androidx.core.view.ViewCompat
 import com.facebook.react.ReactActivity
 import expo.modules.devlauncher.helpers.RGBAtoARGB
 import expo.modules.devlauncher.helpers.isValidColor
+import expo.modules.devlauncher.launcher.manifest.DevLauncherNavigationBarStyle
+import expo.modules.devlauncher.launcher.manifest.DevLauncherNavigationBarVisibility
 import expo.modules.devlauncher.launcher.manifest.DevLauncherOrientation
 import expo.modules.devlauncher.launcher.manifest.DevLauncherStatusBarStyle
 import expo.modules.manifests.core.Manifest
@@ -143,5 +146,62 @@ class DevLauncherExpoActivityConfigurator(
       .addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
     activity
       .window.statusBarColor = color
+  }
+
+  fun applyNavigationBarConfiguration(activity: ReactActivity) {
+    val navBarOptions = manifest.getAndroidNavigationBarOptions() ?: return
+
+    // Set background color of navigation bar
+    val navBarColor = navBarOptions.optString("backgroundColor")
+    if (isValidColor(navBarColor)) {
+      try {
+        activity.window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION)
+        activity.window.navigationBarColor = Color.parseColor(navBarColor)
+      } catch (e: Throwable) {
+        Log.e(TAG, "Failed to configure androidNavigationBar.backgroundColor", e)
+      }
+    }
+
+    // Set icon color of navigation bar
+    val navBarAppearance = navBarOptions.optString("barStyle")
+    if (navBarAppearance != "" && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      try {
+        activity.window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION)
+        activity.window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
+        if (navBarAppearance == DevLauncherNavigationBarStyle.DARK) {
+          val decorView = activity.window.decorView
+          var flags = decorView.systemUiVisibility
+          flags = flags or View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR
+          decorView.systemUiVisibility = flags
+        }
+      } catch (e: Throwable) {
+        Log.e(TAG, "Failed to configure androidNavigationBar.barStyle", e)
+      }
+    }
+
+    // Set visibility of navigation bar
+    val navBarVisible = navBarOptions.optString("visible")
+    if (navBarVisible != "") {
+      // Hide both the navigation bar and the status bar. The Android docs recommend, "you should
+      // design your app to hide the status bar whenever you hide the navigation bar."
+      val decorView = activity.window.decorView
+      var flags = decorView.systemUiVisibility
+      when (navBarVisible) {
+        DevLauncherNavigationBarVisibility.LEANBACK ->
+          flags =
+            flags or (View.SYSTEM_UI_FLAG_HIDE_NAVIGATION or View.SYSTEM_UI_FLAG_FULLSCREEN)
+        DevLauncherNavigationBarVisibility.IMMERSIVE ->
+          flags =
+            flags or (View.SYSTEM_UI_FLAG_HIDE_NAVIGATION or View.SYSTEM_UI_FLAG_FULLSCREEN or View.SYSTEM_UI_FLAG_IMMERSIVE)
+        DevLauncherNavigationBarVisibility.STICKY_IMMERSIVE ->
+          flags =
+            flags or (View.SYSTEM_UI_FLAG_HIDE_NAVIGATION or View.SYSTEM_UI_FLAG_FULLSCREEN or View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY)
+      }
+      decorView.systemUiVisibility = flags
+    }
+  }
+
+  companion object {
+    private val TAG = DevLauncherExpoActivityConfigurator::class.java.simpleName
   }
 }

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/configurators/DevLauncherExpoActivityConfigurator.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/configurators/DevLauncherExpoActivityConfigurator.kt
@@ -189,6 +189,7 @@ class DevLauncherExpoActivityConfigurator(
         DevLauncherNavigationBarVisibility.LEANBACK -> (View.SYSTEM_UI_FLAG_HIDE_NAVIGATION or View.SYSTEM_UI_FLAG_FULLSCREEN)
         DevLauncherNavigationBarVisibility.IMMERSIVE -> (View.SYSTEM_UI_FLAG_HIDE_NAVIGATION or View.SYSTEM_UI_FLAG_FULLSCREEN or View.SYSTEM_UI_FLAG_IMMERSIVE)
         DevLauncherNavigationBarVisibility.STICKY_IMMERSIVE -> (View.SYSTEM_UI_FLAG_HIDE_NAVIGATION or View.SYSTEM_UI_FLAG_FULLSCREEN or View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY)
+        else -> 0
       }
       decorView.systemUiVisibility = flags
     }

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestTypes.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestTypes.kt
@@ -16,3 +16,14 @@ object DevLauncherStatusBarStyle {
   const val DARK = "dark-content"
   const val LIGHT = "light-content"
 }
+
+object DevLauncherNavigationBarStyle {
+  const val DARK = "dark-content"
+  const val LIGHT = "light-content"
+}
+
+object DevLauncherNavigationBarVisibility {
+  const val LEANBACK = "leanback"
+  const val IMMERSIVE = "immersive"
+  const val STICKY_IMMERSIVE = "sticky-immersive"
+}


### PR DESCRIPTION
# Why

resolves ENG-2341

related #15030

# How

Copied the relevant code from expoview's ExperienceActivityUtils class to modify the navigation bar settings at runtime based on the app.json config, and adapted it for use here.

It's worth noting a couple of alternative approaches I chose _not_ to do:
- did not add the `expo-navigation-bar` package as a dependency (could have delegated this functionality to that package, but did not think that removing one method was worth adding a whole unimodule dependency to every user's project).
- did not use the `WindowInsetsControllerCompat`-based implementation that `expo-navigation-bar` favors, instead opting to duplicate the implementation in Expo Go. I tried using `WindowInsetsControllerCompat` for the button style but ran into some issues when testing (it would sometimes reset itself).
- opted to include the implementation of the deprecated `visible` field since it's still included in both Expo Go and expo-navigation-bar. We'll probably need to remove this at some point, when we remove it from the other two places.

# Test Plan

Manually tested in a dummy project:
✅ all 3 fields from app.json are respected
✅ both `barStyle` values and all 3 `visible` values have the correct effect
✅ all settings revert to normal when going back to the launcher

Also added unit tests that verify the correct flags are set in each case.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
