### PR TITLE
[cli] Enable file watchers for `yarn build` only with a TTY attached

### DIFF
--- a/packages/@expo/cli/taskfile.js
+++ b/packages/@expo/cli/taskfile.js
@@ -1,4 +1,5 @@
 const { boolish } = require('getenv');
+const process = require('process');
 
 export async function bin(task, opts) {
   await task
@@ -33,7 +34,7 @@ export default async function (task) {
   const opts = { dev: true };
   await task.clear('build');
   await task.start('build', opts);
-  if (!boolish('CI', false)) {
+  if (process.stdout.isTTY && !boolish('CI', false)) {
     await task.watch('bin/*', 'bin', opts);
     await task.watch('src/**/*.+(js|ts)', 'src', opts);
   }

--- a/packages/@expo/cli/taskfile.js
+++ b/packages/@expo/cli/taskfile.js
@@ -34,7 +34,7 @@ export default async function (task) {
   const opts = { dev: true };
   await task.clear('build');
   await task.start('build', opts);
-  if (process.stdout.isTTY && !boolish('CI', false)) {
+  if (process.stdout.isTTY && !boolish('CI', false) && !boolish('EXPO_NONINTERACTIVE', false)) {
     await task.watch('bin/*', 'bin', opts);
     await task.watch('src/**/*.+(js|ts)', 'src', opts);
   }


### PR DESCRIPTION
Why
---
`expotools check-packages` was hanging when run outside of CI. Fix this by replicating the logic in `expo-module-scripts`'s build script that checks for a TTY.

How
---
Watch only if a TTY is attached. See https://nodejs.org/api/tty.html

Test Plan
---
Run `et check-packages @expo/cli` locally and make sure it passes instead of hanging.
