### PR TITLE
[docs] fix breaking example of metro config

### DIFF
--- a/docs/pages/versions/unversioned/sdk/sqlite.md
+++ b/docs/pages/versions/unversioned/sdk/sqlite.md
@@ -28,11 +28,9 @@ const { getDefaultConfig } = require('expo/metro-config');
 
 const defaultConfig = getDefaultConfig(__dirname);
 
-module.exports = {
-  resolver: {
-    assetExts: [...defaultConfig.resolver.assetExts, 'db'],
-  },
-};
+defaultConfig.resolver.assetExts.push('db');
+
+module.exports = defaultConfig;
 ```
 
 - Use the following function (or similar) to open your database:


### PR DESCRIPTION
# Why

The metro config example is broken, because it incorrectly exports.

# How

-

# Test Plan

-

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
