### PR TITLE
Use static method from class directly

### DIFF
--- a/docs/pages/guides/authentication.md
+++ b/docs/pages/guides/authentication.md
@@ -1187,8 +1187,8 @@ export default function App() {
 
       /* @info Create a Google credential with the <code>id_token</code> */
       const auth = getAuth();
-      const provider = new GoogleAuthProvider();
-      const credential = provider.credential(id_token);
+      const credential = GoogleAuthProvider.credential(id_token);
+
       /* @end */
       signInWithCredential(auth, credential);
     }


### PR DESCRIPTION
The `credential` method is static in GoogleAuthProvider.
Neither static methods nor static properties can be called on instances of the class. Instead, they're called on the class itself.

# Why

Following the docs yields an error (`provider.credential' is undefined`) when trying to access the static method `credential` from the GoogleAuthProvider class.

# How

This is solved by accessing the method directly from the class.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
