### PR TITLE
fix(cli): build watcher

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -21,6 +21,6 @@
 
 ### 🐛 Bug fixes
 
-- Fix build watcher.
+- Fix build watcher. ([#16754](https://github.com/expo/expo/pull/16754) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -21,4 +21,6 @@
 
 ### 🐛 Bug fixes
 
+- Fix build watcher.
+
 ### 💡 Others

--- a/packages/@expo/cli/taskfile.js
+++ b/packages/@expo/cli/taskfile.js
@@ -21,22 +21,13 @@ export async function build(task, opts) {
   await task.parallel(['cli', 'bin'], opts);
 }
 
-export async function src(task, opts) {
-  await task
-    .source(opts.src || 'src/**/*.+(js|ts|tsx)', {
-      ignore: ['**/__tests__/**', '**/__mocks__/**'],
-    })
-    .swc('sdk', { dev: opts.dev })
-    .target('build');
-}
-
 export default async function (task) {
   const opts = { dev: true };
   await task.clear('build');
   await task.start('build', opts);
   if (process.stdout.isTTY && !boolish('CI', false) && !boolish('EXPO_NONINTERACTIVE', false)) {
     await task.watch('bin/*', 'bin', opts);
-    await task.watch('src/**/*.+(js|ts)', 'src', opts);
+    await task.watch('src/**/*.+(js|ts)', 'cli', opts);
   }
 }
 


### PR DESCRIPTION
# Why

`yarn build` wasn't watching build files