### PR TITLE
[docs] update build steps

### DIFF
--- a/docs/pages/build-reference/android-builds.md
+++ b/docs/pages/build-reference/android-builds.md
@@ -31,7 +31,8 @@ Next, this is what happens when EAS Build picks up your request:
 1. Download the project tarball from a private AWS S3 bucket and unpack it.
 1. Create `.npmrc` if `NPM_TOKEN` is set. ([Learn more](/build-reference/private-npm-packages).)
 1. Run the `eas-build-pre-install` script from package.json if defined.
-1. Run `yarn install` in the project root (or `npm install` if `yarn.lock` does not exist).
+1. Run `npm install` in the project root (or `yarn install` if `yarn.lock` exists).
+1. Run `expo doctor` to diagnose potential issues with your project configuration.
 1. Additional step for **managed** projects: Run `expo prebuild` to convert the project to a bare one.
 1. Restore a previously saved cache identified by the `cache.key` value in the build profile. ([Learn more](../build/eas-json/).)
 1. Run the `eas-build-post-install` script from package.json if defined.

--- a/docs/pages/build-reference/ios-builds.md
+++ b/docs/pages/build-reference/ios-builds.md
@@ -32,7 +32,8 @@ In this next phase, this is what happens when EAS Build picks up your request:
 1. Download the project tarball from a private AWS S3 bucket and unpack it.
 1. Create `.npmrc` if `NPM_TOKEN` is set. ([Learn more](/build-reference/private-npm-packages).)
 1. Run the `eas-build-pre-install` script from package.json if defined.
-1. Run `yarn install` in the project root (or `npm install` if `yarn.lock` does not exist).
+1. Run `npm install` in the project root (or `yarn install` if `yarn.lock` exists).
+1. Run `expo doctor` to diagnose potential issues with your project configuration.
 1. Restore the credentials
 
    - Create a new keychain.


### PR DESCRIPTION
# Why

- EAS runs npm if no lockfile is found to install dependencies, it only runs yarn if there's a yarn.lock file
- Added `expo doctor` step

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
