### PR TITLE
[docs] recommend local EAS builds instead of Turtle CLI

### DIFF
--- a/docs/pages/distribution/security.md
+++ b/docs/pages/distribution/security.md
@@ -109,4 +109,4 @@ You won't be able to send notifications to users until they open your app again.
 
 ## Need more control?
 
-If the above information doesn't satisfy your security requirements, you may wish to run your standalone app builds on your own computer or CI servers. To do so, you may want to invest in using [Turtle CLI](https://github.com/expo/turtle), which is the open source project that runs our build servers. Note that you will still need to provide your push notification credentials in order to use the push notification service. If that is also not possible, we recommend investigating the bare workflow and handling push notifications on your own.
+If the above information doesn't satisfy your security requirements, you may wish to run your standalone app builds [on your own infrastructure](../build-reference/local-builds/). Note that you will still need to provide your push notification credentials in order to use the push notification service. If that is also not possible, we recommend handling push notifications on your own.


### PR DESCRIPTION
# Why

- Recommend EAS builds
- Bare workflow is not required for rolling your own push notifications anymore

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
