### PR TITLE
[docs] Fix duplicate key in side bar rendering

### DIFF
--- a/docs/components/DocumentationSidebar.tsx
+++ b/docs/components/DocumentationSidebar.tsx
@@ -62,7 +62,7 @@ function DocumentationSidebarSection(props: SidebarNodeProps) {
 
   return (
     <DocumentationSidebarCollapsible
-      key={`group-${props.route.name}`}
+      key={`section-${props.route.name}`}
       router={props.router}
       info={props.route}>
       {props.route.children.map(group => (


### PR DESCRIPTION
# Why

![image](https://user-images.githubusercontent.com/1203991/160234246-8c1984e5-a0fd-410c-b7cd-ef4eaba688ea.png)

# How

Updated the section component to use the `section-` as key prefix, instead of `group-`.

# Test Plan

- Check if console doesn't show an error

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
