### PR TITLE
[android][local-authentication] compileSdkVersion 30->31 and biometri…

### DIFF
--- a/packages/expo-local-authentication/CHANGELOG.md
+++ b/packages/expo-local-authentication/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `error: user_cancel` when try to use PIN/Pattern/Password to authenticate by changing android sdk version to 31 and androix.biometric.biometric:1.2.0-alpha04. ([#16612](https://github.com/expo/expo/pull/16612) by [@PolidoroRoot](https://github.com/Polidoro-root))
+
 ### 💡 Others
 
 - Updated `@expo/config-plugins` from `4.0.2` to `4.0.14` ([#15621](https://github.com/expo/expo/pull/15621) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/expo-local-authentication/android/build.gradle
+++ b/packages/expo-local-authentication/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 30)
+  compileSdkVersion safeExtGet("compileSdkVersion", 31)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
…c API 1.1.0->1.2.0-alpha04

# Why
The current version of `expo-local-authentication` in android uses `androix.biometric.biometric:1.1.0` api, which throws `error: user_cancel` when try to use PIN/Pattern/Password to authenticate, blocking any user interactions with authentication.

## Issues
- [androidx:biometric:biometric version 1.2.0](https://developer.android.com/jetpack/androidx/releases/biometric#version_120_2)
- [expo-local-authentication] LocalAuthentication.authenticateAsync [#9846](https://github.com/expo/expo/issues/9846)
- [expo-local-authentication] Failed to unlock using device pin code in MIUI 12  [#10451](https://github.com/expo/expo/issues/10451)
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How
- compileSdkVersion 30 -> 31
- api "androidx.biometric:biometric:1.1.0" -> "androidx.biometric:biometric:1.2.0-alpha04"

To use the version that solves `androidx.biometric:biometric` issue, the minimum sdk version necessary is 31
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
I tested many times with Redmi Note 9s switching the changes between the builds to compare if it worked, that one who do not apply these changes are unstable and volatile, sometimes works, sometimes not.
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

-  [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
-  [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
-  [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
