### PR TITLE
[core][ios] Evaluating JavaScript code from Swift

### DIFF
--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.h
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.h
@@ -12,10 +12,15 @@ namespace react = facebook::react;
 NS_SWIFT_NAME(JavaScriptRuntime)
 @interface EXJavaScriptRuntime : NSObject
 
+/**
+ Creates a new JavaScript runtime.
+ */
+- (nonnull instancetype)init;
+
 #ifdef __cplusplus
 typedef jsi::Value (^JSHostFunctionBlock)(jsi::Runtime &runtime, std::shared_ptr<react::CallInvoker> callInvoker, NSArray * _Nonnull arguments);
 
-- (nonnull instancetype)initWithRuntime:(jsi::Runtime &)runtime
+- (nonnull instancetype)initWithRuntime:(std::shared_ptr<jsi::Runtime>)runtime
                             callInvoker:(std::shared_ptr<react::CallInvoker>)callInvoker;
 
 /**
@@ -51,5 +56,12 @@ typedef jsi::Value (^JSHostFunctionBlock)(jsi::Runtime &runtime, std::shared_ptr
  Creates a new object for use in Swift.
  */
 - (nonnull EXJavaScriptObject *)createObject;
+
+#pragma mark - Script evaluation
+
+/**
+ Evaluates given JavaScript source code.
+ */
+- (nullable id)evaluateScript:(nonnull NSString *)scriptSource;
 
 @end

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.mm
@@ -1,9 +1,9 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
 #import <jsi/jsi.h>
+#import <jsi/JSCRuntime.h>
 
 #import <ExpoModulesCore/EXJavaScriptRuntime.h>
-
 #import <ExpoModulesCore/ExpoModulesHostObject.h>
 #import <ExpoModulesCore/ExpoModulesProxySpec.h>
 #import <ExpoModulesCore/EXJSIConversions.h>
@@ -12,27 +12,31 @@
 using namespace facebook;
 
 @implementation EXJavaScriptRuntime {
-  jsi::Runtime *_runtime;
+  std::shared_ptr<jsi::Runtime> _runtime;
   std::shared_ptr<react::CallInvoker> _jsCallInvoker;
-
-  EXJavaScriptObject *_global;
 }
 
-- (nonnull instancetype)initWithRuntime:(jsi::Runtime &)runtime callInvoker:(std::shared_ptr<react::CallInvoker>)callInvoker
+- (nonnull instancetype)init
 {
   if (self = [super init]) {
-    _runtime = &runtime;
-    _jsCallInvoker = callInvoker;
+    _runtime = jsc::makeJSCRuntime();
+    _jsCallInvoker = nil;
+  }
+  return self;
+}
 
-    auto jsGlobalPtr = std::make_shared<jsi::Object>(_runtime->global());
-    _global = [[EXJavaScriptObject alloc] initWith:jsGlobalPtr runtime:self];
+- (nonnull instancetype)initWithRuntime:(std::shared_ptr<jsi::Runtime>)runtime callInvoker:(std::shared_ptr<react::CallInvoker>)callInvoker
+{
+  if (self = [super init]) {
+    _runtime = runtime;
+    _jsCallInvoker = callInvoker;
   }
   return self;
 }
 
 - (nonnull jsi::Runtime *)get
 {
-  return _runtime;
+  return _runtime.get();
 }
 
 - (std::shared_ptr<react::CallInvoker>)callInvoker
@@ -54,7 +58,8 @@ using namespace facebook;
 
 - (nonnull EXJavaScriptObject *)global
 {
-  return _global;
+  auto jsGlobalPtr = std::make_shared<jsi::Object>(_runtime->global());
+  return [[EXJavaScriptObject alloc] initWith:jsGlobalPtr runtime:self];
 }
 
 - (jsi::Function)createSyncFunction:(nonnull NSString *)name
@@ -79,6 +84,15 @@ using namespace facebook;
     };
     return createPromiseAsJSIValue(runtime, promiseSetup);
   }];
+}
+
+#pragma mark - Script evaluation
+
+- (nullable id)evaluateScript:(nonnull NSString *)scriptSource
+{
+  auto scriptBuffer = std::make_shared<jsi::StringBuffer>([[NSString stringWithFormat:@"(%@)", scriptSource] UTF8String]);
+  auto result = _runtime->evaluateJavaScript(scriptBuffer, "<<evaluated>>");
+  return expo::convertJSIValueToObjCObject(*_runtime, result, _jsCallInvoker);
 }
 
 #pragma mark - Private

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.mm
@@ -1,7 +1,14 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
 #import <jsi/jsi.h>
+
+#if __has_include(<reacthermes/HermesExecutorFactory.h>)
+#import <reacthermes/HermesExecutorFactory.h>
+#elif __has_include(<hermes/hermes.h>)
+#import <hermes/hermes.h>
+#else
 #import <jsi/JSCRuntime.h>
+#endif
 
 #import <ExpoModulesCore/EXJavaScriptRuntime.h>
 #import <ExpoModulesCore/ExpoModulesHostObject.h>
@@ -19,7 +26,11 @@ using namespace facebook;
 - (nonnull instancetype)init
 {
   if (self = [super init]) {
+#if __has_include(<reacthermes/HermesExecutorFactory.h>) || __has_include(<hermes/hermes.h>)
+    _runtime = hermes::makeHermesRuntime();
+#else
     _runtime = jsc::makeJSCRuntime();
+#endif
     _jsCallInvoker = nil;
   }
   return self;

--- a/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.mm
+++ b/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.mm
@@ -409,7 +409,8 @@ RCT_EXPORT_METHOD(callMethod:(NSString *)moduleName methodNameOrKey:(id)methodNa
   facebook::jsi::Runtime *jsiRuntime = [_bridge respondsToSelector:@selector(runtime)] ? reinterpret_cast<facebook::jsi::Runtime *>(_bridge.runtime) : nullptr;
 
   if (jsiRuntime) {
-    EXJavaScriptRuntime *runtime = [[EXJavaScriptRuntime alloc] initWithRuntime:*jsiRuntime callInvoker:_bridge.jsCallInvoker];
+    std::shared_ptr<jsi::Runtime> jsiRuntimePtr(jsiRuntime);
+    EXJavaScriptRuntime *runtime = [[EXJavaScriptRuntime alloc] initWithRuntime:jsiRuntimePtr callInvoker:_bridge.jsCallInvoker];
 
     [EXJavaScriptRuntimeManager installExpoModulesToRuntime:runtime withSwiftInterop:_swiftInteropBridge];
     [_swiftInteropBridge setRuntime:runtime];

--- a/packages/expo-modules-core/ios/Swift/AppContext.swift
+++ b/packages/expo-modules-core/ios/Swift/AppContext.swift
@@ -3,6 +3,13 @@ import UIKit
  The app context is an interface to a single Expo app.
  */
 public final class AppContext {
+  internal static func create() -> AppContext {
+    let appContext = AppContext()
+
+    appContext.runtime = JavaScriptRuntime()
+    return appContext
+  }
+
   /**
    The module registry for the app context.
    */

--- a/packages/expo-modules-core/ios/Tests/JavaScriptRuntimeSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/JavaScriptRuntimeSpec.swift
@@ -1,0 +1,35 @@
+import Quick
+import Nimble
+
+@testable import ExpoModulesCore
+
+class JavaScriptRuntimeSpec: QuickSpec {
+  override func spec() {
+    let runtime = JavaScriptRuntime()
+
+    it("has global object accessible") {
+      expect(runtime.global) !== nil
+    }
+
+    describe("evaluateScript") {
+      it("returns primitive types") {
+        expect(runtime.evaluateScript("null")).to(beNil())
+        expect(runtime.evaluateScript("undefined")).to(beNil())
+        expect(runtime.evaluateScript("true") as? Bool) == true
+        expect(runtime.evaluateScript("false") as? Bool) == false
+        expect(runtime.evaluateScript("123") as? Int) == 123
+        expect(runtime.evaluateScript("1.23") as? Double) == 1.23
+        expect(runtime.evaluateScript("'foobar'") as? String) == "foobar"
+      }
+
+      it("returns arrays") {
+        expect(runtime.evaluateScript("['foo', 'bar']") as? [String]) == ["foo", "bar"]
+      }
+
+      it("returns dicts") {
+        expect(runtime.evaluateScript("{ 'foo': 123 }") as? [String: Int]) == ["foo": 123]
+        expect(runtime.evaluateScript("{ 'foo': 'bar' }") as? [String: String]) == ["foo": "bar"]
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Why

For further Swift & JSI integration, we will need to evaluate JS scripts from Swift. This feature will also be helpful for integration tests (native modules ↔ JS runtime).

# How

- Implemented `evaluateScript` in `JavaScriptRuntime` class (basic tests included)
- Made it possible to initialize the app context and runtime without the bridge (for tests)
- Used shared pointer for the underlying C++ `jsi::Runtime` (fixes a crash when the runtime is initialized not by the bridge)

# Test Plan

Added unit tests — all are passing
