### PR TITLE
[expo-updates] Document new code signing configuration fields

### DIFF
--- a/packages/expo-updates/README.md
+++ b/packages/expo-updates/README.md
@@ -93,12 +93,16 @@ The number of milliseconds `expo-updates` should delay the app launch and stay o
 | --------------------------------- | ------------------------ | -------------------------------------------------- | ------- | --------- |
 | `EXUpdatesCodeSigningCertificate` | `codeSigningCertificate` | `expo.modules.updates.CODE_SIGNING_CERTIFICATE`    | (none)  | ❌        |
 | `EXUpdatesCodeSigningMetadata`    | `codeSigningMetadata`    | `expo.modules.updates.CODE_SIGNING_METADATA`       | (none)  | ❌        |
+| `EXUpdatesCodeSigningIncludeManifestResponseCertificateChain` | `codeSigningIncludeManifestResponseCertificateChain` | `expo.modules.updates.CODE_SIGNING_INCLUDE_MANIFEST_RESPONSE_CERTIFICATE_CHAIN` | false | ❌        |
+| `EXUpdatesConfigCodeSigningAllowUnsignedManifests` | `codeSigningAllowUnsignedManifests` | `expo.modules.updates.CODE_SIGNING_ALLOW_UNSIGNED_MANIFESTS` | false | ❌        |
 
 If `codeSigningCertificate` is present, `expo-updates` will enforce manifest code signing using the certificate and any metadata associated with it.
 - `codeSigningCertificate` must be a valid PEM formatted X.509 certificate with code signing extended key usage.
 - `codeSigningMetadata` (optional) must be a JSON object containing:
     - `alg` - Algorithm used to generate manifest signature. Only `rsa-v1_5-sha256` is currently supported.
     - `keyid` - Identifier for the key in `codeSigningCertificate`. Used to instruct signing mechanisms when signing or verifying signatures.
+- `codeSigningIncludeManifestResponseCertificateChain` (optional) instructs `expo-updates` to evaluate certificates included in a multipart manifest response (under the `certificate_chain` multipart part) as part of the code signing certificate chain with the embedded `codeSigningCertificate` as the implicitly trusted root certificate of the chain. The leaf certificate in the chain must be valid for code signing.
+- `codeSigningAllowUnsignedManifests` (optional) instructs `expo-updates` to treat a missing signature in the response as if code signing weren't enabled rather than as invalid as it normally would.
 
 ## Customizing automatic setup
 


### PR DESCRIPTION
# Why

These fields were recently added to the configuration. This adds documentation.

Closes ENG-4356.

# How

Add documentation.

# Test Plan

Proofread.