### PR TITLE
[home] Get name from EAS Update Manifests to show in 'recently opened' section and dev menu

### DIFF
--- a/home/menu/DevMenuTaskInfo.tsx
+++ b/home/menu/DevMenuTaskInfo.tsx
@@ -29,19 +29,22 @@ class DevMenuTaskInfo extends React.PureComponent<Props, any> {
     const taskUrl = task.manifestUrl ? FriendlyUrls.toFriendlyString(task.manifestUrl) : '';
     const manifest = task.manifestString && JSON.parse(task.manifestString);
     const iconUrl = manifest && manifest.iconUrl;
-    const taskName = manifest && manifest.name;
+    const taskName = manifest && (manifest.name ?? manifest.extra.expoClient.name);
     const taskNameStyles = taskName ? styles.taskName : [styles.taskName, { color: '#c5c6c7' }];
     const sdkVersion = manifest && manifest.sdkVersion;
 
     return (
       <View style={styles.taskMetaRow}>
-        <View style={styles.taskIconColumn}>
-          {iconUrl ? (
-            <Image source={{ uri: iconUrl }} style={styles.taskIcon} />
-          ) : (
-            <View style={[styles.taskIcon, { backgroundColor: '#eee' }]} />
-          )}
-        </View>
+        {!manifest?.metadata?.branchName ? (
+          // EAS Updates don't have icons
+          <View style={styles.taskIconColumn}>
+            {iconUrl ? (
+              <Image source={{ uri: iconUrl }} style={styles.taskIcon} />
+            ) : (
+              <View style={[styles.taskIcon, { backgroundColor: '#eee' }]} />
+            )}
+          </View>
+        ) : null}
         <View style={styles.taskInfoColumn}>
           <StyledText style={taskNameStyles} numberOfLines={1} lightColor="#595c68">
             {taskName ? taskName : 'Untitled Experience'}

--- a/home/screens/HomeScreen/HomeScreenView.tsx
+++ b/home/screens/HomeScreen/HomeScreenView.tsx
@@ -99,11 +99,6 @@ export class HomeScreenView extends React.Component<Props, State> {
   render() {
     const { projects, isRefreshing, data } = this.state;
 
-    // TODO: update to show EAS Updates when we get data for that
-    const recentHistory = this.props.recentHistory.filter(
-      (project) => project.manifest && 'name' in project.manifest
-    );
-
     return (
       <View style={styles.container}>
         <HomeScreenHeader currentUser={data} loading={this.state.loading} />
@@ -144,11 +139,11 @@ export class HomeScreenView extends React.Component<Props, State> {
           ) : (
             <DevelopmentServersPlaceholder />
           )}
-          {recentHistory.count() ? (
+          {this.props.recentHistory.count() ? (
             <>
               <Spacer.Vertical size="medium" />
               <RecentlyOpenedHeader onClearPress={this._handlePressClearHistory} />
-              <RecentlyOpenedSection recentHistory={recentHistory} />
+              <RecentlyOpenedSection recentHistory={this.props.recentHistory} />
             </>
           ) : null}
           {this.props.accountName ? (

--- a/home/screens/HomeScreen/RecentlyOpenedSection.tsx
+++ b/home/screens/HomeScreen/RecentlyOpenedSection.tsx
@@ -26,11 +26,11 @@ export function RecentlyOpenedSection({ recentHistory }: Props) {
                   : undefined
               }
               title={
-                // TODO(wschurman): audit for new manifests
-                project.manifest && 'name' in project.manifest ? project.manifest.name : undefined
+                // EAS Update app names are under the extra.expoClient.name key
+                project.manifest?.extra?.expoClient?.name ??
+                (project.manifest && 'name' in project.manifest ? project.manifest.name : undefined)
               }
               onPress={() => {
-                // TODO(fiberjw): navigate to the project details screen
                 Linking.openURL(project.url);
               }}
             />


### PR DESCRIPTION
# Why

While testing opening EAS Updates in Expo go, I realized that our code wasn't handling the change in manifests, which is why I couldn't see the project name in the dev menu.

# How

I updated the spots in the Dev Menu and the Recently opened section of the homescreen to use `manifest.extra.expoClient.name` to get the name of EAS Updates. I also hid the icon entirely when we detect that a user is running an EAS Update in the dev menu, because we don't have that information anywhere in the manifest AFAIK.

# Test Plan

Open an EAS update in Expo Go, then open the Dev Menu to see the correct project. When you navigate back to the home screen, you should see the app you just launched in the Recently opened list.

![IMG_4866](https://user-images.githubusercontent.com/12488826/160296945-4ffc1af0-7c7e-4337-ae8f-a963101c3a89.PNG)

![IMG_4865](https://user-images.githubusercontent.com/12488826/160296946-2add5b4c-88d6-4058-9cc8-11d3f4cf0322.PNG)

## Reviewers

I'm requesting @jonsamp because the JS changes are super simple and you probably have the biggest understanding of EAS Update manifests and where we should be pulling info from.

