### PR TITLE
[dev-client][e2e] Update test runner to `0.0.9`

### DIFF
--- a/.github/workflows/development-client-latest-e2e.yml
+++ b/.github/workflows/development-client-latest-e2e.yml
@@ -27,6 +27,8 @@ jobs:
           bundler-cache: true
       - name: 💎 Install cocoapods
         run: sudo gem install cocoapods
+      - name: 🤖 Use Java 11
+        run: export JAVA_HOME=$JAVA_HOME_11_X64
       - name: 🤖 Set up android emulator
         uses: reactivecircus/android-emulator-runner@v2
         with:

--- a/packages/expo-dev-client/.detoxrc.js
+++ b/packages/expo-dev-client/.detoxrc.js
@@ -37,9 +37,9 @@ module.exports = {
     },
     'ios.debug': {
       type: 'ios.app',
-      binaryPath: 'ios/build/Build/Products/Debug-iphonesimulator/dev-client-latest-e2e.app',
+      binaryPath: 'ios/build/Build/Products/Debug-iphonesimulator/{{= it.name }}.app',
       build:
-        'xcodebuild -workspace ios/dev-client-latest-e2e.xcworkspace -scheme dev-client-latest-e2e -configuration Debug -sdk iphonesimulator -arch x86_64 -derivedDataPath ios/build',
+        'xcodebuild -workspace ios/{{= it.name }}.xcworkspace -scheme {{= it.name }} -configuration Debug -sdk iphonesimulator -arch x86_64 -derivedDataPath ios/build',
     },
   },
   configurations: {

--- a/packages/expo-dev-client/package.json
+++ b/packages/expo-dev-client/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0",
-    "expo-test-runner": "0.0.8"
+    "expo-test-runner": "0.0.9"
   },
   "peerDependencies": {
     "expo": "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9248,10 +9248,10 @@ expo-pwa@0.0.114:
     commander "2.20.0"
     update-check "1.5.3"
 
-expo-test-runner@0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/expo-test-runner/-/expo-test-runner-0.0.8.tgz#f4dbed5c72a86236fe10d0f2519d3497f7abba27"
-  integrity sha512-ff5HsoelDmutNmTTApbjrYrKNGpPx8bPQ+oLLu4+RRxBuCjsHf577TjFQa8Suz/grc9f7VK7Nh4doIgukolZHg==
+expo-test-runner@0.0.9:
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/expo-test-runner/-/expo-test-runner-0.0.9.tgz#f5af2800450ac0f7af9c8752c1afc8d82dfc98d8"
+  integrity sha512-BtFPDIyYJhQRi+pvH1xM5YiVdaPDdayIFNmwM9JRrvVzeCWlGOS43Nhh4p6tV3o+IPGwEfAYSMi6EKbVGCPhqw==
   dependencies:
     "@babel/runtime" "7.9.0"
     "@expo/spawn-async" "^1.5.0"


### PR DESCRIPTION
# Why

Updates `expo-test-runner` to version `0.0.9` & use java 11 in dev-client-latest-e2e job.