### PR TITLE
[dev-launcher][iOS] Improve handling of LAN permission crash

### DIFF
--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -345,24 +345,24 @@
       if (manifest) {
         launchExpoApp(self->_updatesInterface.launchAssetURL, [EXManifestsManifestFactory manifestForManifestJSON:manifest]);
       }
-    } error:^(NSError * _Nonnull error) {
-      if (@available(iOS 14, *)) {
-        // Try to retry if the network connection was rejected because of the luck of the lan network permission.
-        static BOOL shouldRetry = true;
-        NSString *host = expoUrl.host;
-
-        if (shouldRetry && ([host hasPrefix:@"192.168."] || [host hasPrefix:@"172."] || [host hasPrefix:@"10."])) {
-          shouldRetry = false;
-          [manifestParser isManifestURLWithCompletion:onIsManifestURL onError:onError];
-          return;
-        }
-      }
-      
-      onError(error);
-    }];
+    } error:onError];
   };
   
-  [manifestParser isManifestURLWithCompletion:onIsManifestURL onError:onError];
+  [manifestParser isManifestURLWithCompletion:onIsManifestURL onError:^(NSError * _Nonnull error) {
+    if (@available(iOS 14, *)) {
+      // Try to retry if the network connection was rejected because of the luck of the lan network permission.
+      static BOOL shouldRetry = true;
+      NSString *host = expoUrl.host;
+
+      if (shouldRetry && ([host hasPrefix:@"192.168."] || [host hasPrefix:@"172."] || [host hasPrefix:@"10."])) {
+        shouldRetry = false;
+        [manifestParser isManifestURLWithCompletion:onIsManifestURL onError:onError];
+        return;
+      }
+    }
+    
+    onError(error);
+  }];
 }
 
 - (void)_initAppWithUrl:(NSURL *)appUrl bundleUrl:(NSURL *)bundleUrl manifest:(EXManifestsManifest * _Nullable)manifest


### PR DESCRIPTION
# Why

Closes ENG-4203.

# How

Try to retry if the network connection was rejected due to the lack of lan permission.
My code will only retry once per app process - in my opinion, we shouldn't save that information in the shared preferences. Retrying one network call isn't that painful even if the failure wasn't connected with the lan permission. That solution was the best, in my opinion, when I was playing with different versions. 

Also, sometimes when the network call was rejected due to the lack of lan permission, retrying it doesn't help, cause the prompt didn't appear in time, but we can't detect that. However, in that case, the app won't longer crash and also the user will be delegated to the error screen. After all, it seems like pretty good UX. 

# Test Plan

- run bare-expo locally ✅