### PR TITLE
Fix test snapshots after removing ViewPropTypes

### DIFF
--- a/packages/expo-barcode-scanner/src/__tests__/__snapshots__/BarCodeScanner-test.tsx.snap.android
+++ b/packages/expo-barcode-scanner/src/__tests__/__snapshots__/BarCodeScanner-test.tsx.snap.android
@@ -2,10 +2,10 @@
 
 exports[`renders correctly 1`] = `
 <ViewManagerAdapter_ExpoBarCodeScannerView
+  onBarCodeScanned={[Function]}
   proxiedProperties={
     Object {
       "barCodeTypes": Array [],
-      "onBarCodeScanned": [Function],
       "type": undefined,
     }
   }

--- a/packages/expo-barcode-scanner/src/__tests__/__snapshots__/BarCodeScanner-test.tsx.snap.ios
+++ b/packages/expo-barcode-scanner/src/__tests__/__snapshots__/BarCodeScanner-test.tsx.snap.ios
@@ -2,10 +2,10 @@
 
 exports[`renders correctly 1`] = `
 <ViewManagerAdapter_ExpoBarCodeScannerView
+  onBarCodeScanned={[Function]}
   proxiedProperties={
     Object {
       "barCodeTypes": Array [],
-      "onBarCodeScanned": [Function],
       "type": undefined,
     }
   }

--- a/packages/expo-gl/src/__tests__/__snapshots__/GLView-test.tsx.snap.android
+++ b/packages/expo-gl/src/__tests__/__snapshots__/GLView-test.tsx.snap.android
@@ -3,10 +3,10 @@
 exports[`renders static 1`] = `
 <View>
   <ViewManagerAdapter_ExponentGLView
+    onSurfaceCreate={[Function]}
     proxiedProperties={
       Object {
         "msaaSamples": undefined,
-        "onSurfaceCreate": [Function],
       }
     }
     style={

--- a/packages/expo-gl/src/__tests__/__snapshots__/GLView-test.tsx.snap.ios
+++ b/packages/expo-gl/src/__tests__/__snapshots__/GLView-test.tsx.snap.ios
@@ -3,10 +3,10 @@
 exports[`renders static 1`] = `
 <View>
   <ViewManagerAdapter_ExponentGLView
+    onSurfaceCreate={[Function]}
     proxiedProperties={
       Object {
         "msaaSamples": 4,
-        "onSurfaceCreate": [Function],
       }
     }
     style={

--- a/packages/expo-linear-gradient/src/__tests__/__snapshots__/LinearGradient-test.native.tsx.snap.android
+++ b/packages/expo-linear-gradient/src/__tests__/__snapshots__/LinearGradient-test.native.tsx.snap.android
@@ -2,16 +2,6 @@
 
 exports[`renders a complex gradient 1`] = `
 Object {
-  "borderRadii": Array [
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-  ],
   "colors": Array [
     -65536,
     -16776961,


### PR DESCRIPTION
# Why

Fixes failures in `et check-packages` (SDK workflow on the CI)

# How

- Removed event props from the snapshots (they are now passed as a standard prop instead of within `proxiedProperties`)
- `LinearGradient` view also doesn't need `borderRadii` in the snapshot

# Test Plan

`et check-packages expo-gl expo-barcode-scanner expo-linear-gradient` passes now
