### PR TITLE
[expo-updates] Trim whitespace for expo project information embedded in code signing certificate

### DIFF
--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/codesigning/CertificateChain.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/codesigning/CertificateChain.kt
@@ -66,7 +66,7 @@ class CertificateChain(private val certificateStrings: List<String>) {
           it.octets.decodeToString()
         } else null
       }?.let {
-        val components = it.split(',')
+        val components = it.split(',').map { component -> component.trim() }
         if (components.size != 2) {
           throw CertificateException("Invalid Expo project information extension value")
         }

--- a/packages/expo-updates/ios/EXUpdates/CodeSigning/EXUpdatesCertificateChain.swift
+++ b/packages/expo-updates/ios/EXUpdates/CodeSigning/EXUpdatesCertificateChain.swift
@@ -155,7 +155,11 @@ extension X509Certificate {
       return nil
     }
     
-    let components = (projectInformationExtensionValue as! String).components(separatedBy: ",")
+    let components = (projectInformationExtensionValue as! String)
+      .components(separatedBy: ",")
+      .map { it in
+        it.trimmingCharacters(in: CharacterSet.whitespaces)
+      }
     if (components.count != 2) {
       throw EXUpdatesCodeSigningError.InvalidExpoProjectInformationExtensionValue
     }


### PR DESCRIPTION
# Why

Closes ENG-4441. This should help in the case that these are generated by the developer instead of with the @expo/code-signing-certificates library.

# How

Trim

# Test Plan

Run tests. Note that this case isn't tested explicitly though if requested I can generate another certificate with whitespace.