### PR TITLE
[expo-dev-menu] fix gradle buildscript compatibility with flavors

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -17,7 +17,7 @@
 - Fix compatibility with react-native 0.66. ([#15914](https://github.com/expo/expo/pull/15914) by [@kudo](https://github.com/kudo))
 - Fix Android crash when using Hermes on react-native 0.67. ([#16099](https://github.com/expo/expo/pull/16099) by [@kudo](https://github.com/kudo))
 - Fix backwards compatibility with AppDelegate in existing projects. ([#16497](https://github.com/expo/expo/pull/16497) by [@esamelson](https://github.com/esamelson))
-- Fix gradle buildscript compatibility with flavors.
+- Fix gradle buildscript compatibility with flavors ([#16686](https://github.com/expo/expo/issues/16686)). ([#16799](https://github.com/expo/expo/pull/16799) by [@esamelson](https://github.com/esamelson))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -17,14 +17,13 @@
 - Fix compatibility with react-native 0.66. ([#15914](https://github.com/expo/expo/pull/15914) by [@kudo](https://github.com/kudo))
 - Fix Android crash when using Hermes on react-native 0.67. ([#16099](https://github.com/expo/expo/pull/16099) by [@kudo](https://github.com/kudo))
 - Fix backwards compatibility with AppDelegate in existing projects. ([#16497](https://github.com/expo/expo/pull/16497) by [@esamelson](https://github.com/esamelson))
+- Fix gradle buildscript compatibility with flavors.
 
 ### 💡 Others
-
 
 - Move unrelated dev-menu functions into dev-launcher. ([#16124](https://github.com/expo/expo/pull/16124) by [@ajsmth](https://github.com/ajsmth))
 - Simplify dev-launcher / dev-menu relationship on iOS. ([#16067](https://github.com/expo/expo/pull/16067) by [@ajsmth](https://github.com/ajsmth))
 - Simplify dev-launcher / dev-menu relationship on Android. ([#16228](https://github.com/expo/expo/pull/16228) by [@ajsmth](https://github.com/ajsmth))
-
 
 ## 0.9.3 — 2022-02-01
 
@@ -35,6 +34,7 @@
 ## 0.9.2 — 2022-01-18
 
 _This version does not introduce any user-facing changes._
+
 ## 0.9.1 — 2022-01-17
 
 ### 🐛 Bug fixes

--- a/packages/expo-dev-menu/android/build.gradle
+++ b/packages/expo-dev-menu/android/build.gradle
@@ -68,7 +68,7 @@ def getCurrentFlavor() {
   Matcher matcher = pattern.matcher(taskRequestName)
 
   if (matcher.find()) {
-    return matcher.group(1).toLowerCase()
+    return matcher.group(1)
   }
   return ""
 }
@@ -96,26 +96,26 @@ rootProject.getSubprojects().forEach({ project ->
       if (!projectProperties.get("reanimated")
           || (projectProperties.get("reanimated") && projectProperties.get("reanimated").get("enablePackagingOptions"))
       ) {
-        def flavorString = getCurrentFlavor()
+        def flavorNameCapitalized = getCurrentFlavor()
         replaceSoTask.appName = project.getProperties().path
         replaceSoTask.buildDir = project.getProperties().buildDir
         def appName = project.getProperties().path
 
         def tasks = project.getTasks()
         replaceSoTaskDebug.dependsOn(
-            tasks.getByPath("${appName}:merge${flavorString}DebugNativeLibs"),
-            tasks.getByPath("${appName}:strip${flavorString}DebugDebugSymbols")
+            tasks.getByPath("${appName}:merge${flavorNameCapitalized}DebugNativeLibs"),
+            tasks.getByPath("${appName}:strip${flavorNameCapitalized}DebugDebugSymbols")
         )
-        tasks.getByPath("${appName}:package${flavorString}Debug").dependsOn(replaceSoTaskDebug)
+        tasks.getByPath("${appName}:package${flavorNameCapitalized}Debug").dependsOn(replaceSoTaskDebug)
 
-        if (tasks.findByPath("${appName}:merge${flavorString}ReleaseWithDevMenuNativeLibs")
-            && tasks.findByPath("${appName}:strip${flavorString}ReleaseWithDevMenuDebugSymbols")
-            && tasks.findByPath("${appName}:package${flavorString}ReleaseWithDevMenu")) {
+        if (tasks.findByPath("${appName}:merge${flavorNameCapitalized}ReleaseWithDevMenuNativeLibs")
+            && tasks.findByPath("${appName}:strip${flavorNameCapitalized}ReleaseWithDevMenuDebugSymbols")
+            && tasks.findByPath("${appName}:package${flavorNameCapitalized}ReleaseWithDevMenu")) {
           replaceSoTaskReleaseWithDevMenu.dependsOn(
-              task.getByPath("${appName}:merge${flavorString}ReleaseWithDevMenuNativeLibs"),
-              task.getByPath("${appName}:strip${flavorString}ReleaseWithDevMenuDebugSymbols")
+              task.getByPath("${appName}:merge${flavorNameCapitalized}ReleaseWithDevMenuNativeLibs"),
+              task.getByPath("${appName}:strip${flavorNameCapitalized}ReleaseWithDevMenuDebugSymbols")
           )
-          tasks.getByPath("${appName}:package${flavorString}ReleaseWithDevMenu").dependsOn(replaceSoTaskReleaseWithDevMenu)
+          tasks.getByPath("${appName}:package${flavorNameCapitalized}ReleaseWithDevMenu").dependsOn(replaceSoTaskReleaseWithDevMenu)
         }
       }
     }


### PR DESCRIPTION
# Why

ref #16686

The `getCurrentFlavor` method returns a lowercase string, but in all the places it's used we actually need a capitalized string -- e.g. we try to add a dependency on a task named `mergedevelopmentDebugNativeLibs` but the name of the actual task is `mergeDevelopmentDebugNativeLibs`. This causes the build to fail.

# How

Remove the `toLowerCase()` call from the `getCurrentFlavor` implementation, since without this the string is already capitalized like we need.

Renamed the variable everywhere it's used for clarity's sake.

# Test Plan

Tested with the repo provided in #16686 -- cloned, yarn install, cd android, ./gradlew :app:assembleDevelopmentDebug.

Before this change, the build failed with the error indicated by OP; after this change, the build succeeded.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
