### PR TITLE
[home] enable redesign and publish to expo-home-dev for dogfooding

### DIFF
--- a/dev-home-config.json
+++ b/dev-home-config.json
@@ -1,3 +1,3 @@
 {
-  "url": "exp://expo.io/@expo-home-dev/expo-home-dev-481a6d30ded08a7f00630e7f6ecddb1325d778cb"
+  "url": "exp://exp.host/@expo-home-dev/expo-home-dev-481a6d30ded08a7f00630e7f6ecddb1325d778cb"
 }

--- a/dev-home-config.json
+++ b/dev-home-config.json
@@ -1,3 +1,3 @@
 {
-  "url": "exp://expo.io/@expo-home-dev/expo-home-dev-db2a78be19f92e56e0f7357dfe0d39a326c73ca3"
+  "url": "exp://expo.io/@expo-home-dev/expo-home-dev-481a6d30ded08a7f00630e7f6ecddb1325d778cb"
 }

--- a/home/FeatureFlags.ts
+++ b/home/FeatureFlags.ts
@@ -10,6 +10,6 @@ export default {
   ENABLE_CLIPBOARD_BUTTON: !Environment.IsIOSRestrictedBuild,
 
   // Flags for the 2022 Expo Go redesign
-  ENABLE_2022_NAVIGATION_REDESIGN: __DEV__,
-  ENABLE_2022_DIAGNOSTICS_REDESIGN: __DEV__,
+  ENABLE_2022_NAVIGATION_REDESIGN: true,
+  ENABLE_2022_DIAGNOSTICS_REDESIGN: true,
 };


### PR DESCRIPTION
# Why

We want to dogfood the new `home` changes internally.

# How

- enabled the feature flag
- `et publish-dev-home`

# Test Plan

Build Expo Go on this branch to get the changes.