### PR TITLE
[expo-updates] Add expo-eas-client-id to package.json

### DIFF
--- a/packages/expo-updates/package.json
+++ b/packages/expo-updates/package.json
@@ -44,6 +44,7 @@
     "@expo/config-plugins": "^4.0.14",
     "@expo/metro-config": "~0.3.7",
     "arg": "4.1.0",
+    "expo-eas-client-id": "~0.1.0",
     "expo-manifests": "~0.2.2",
     "expo-structured-headers": "~2.1.0",
     "expo-updates-interface": "~0.5.0",


### PR DESCRIPTION
# Why

Noticed by @ajsmth. I forgot to add the dependency here.

# How

Add the dependency, `yarn`

# Test Plan

`yarn`