### PR TITLE
feat(cli): serve modern manifests in multipart format

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Fixed type errors. ([#16724](https://github.com/expo/expo/pull/16724) by [@EvanBacon](https://github.com/EvanBacon))
 - Disable watch mode in CI. ([#16730](https://github.com/expo/expo/pull/16730) by [@EvanBacon](https://github.com/EvanBacon))
 - Added `install` command. ([#16756](https://github.com/expo/expo/pull/16756) by [@EvanBacon](https://github.com/EvanBacon))
+- Serve modern manifests in multipart format. ([#16804](https://github.com/expo/expo/pull/16804) by [@wschurman](https://github.com/wschurman))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -54,6 +54,7 @@
     "@expo/spawn-async": "1.5.0",
     "@urql/core": "2.3.6",
     "@urql/exchange-retry": "0.3.0",
+    "accepts": "^1.3.8",
     "arg": "4.1.0",
     "better-opn": "~3.0.2",
     "cacache": "^15.3.0",
@@ -101,7 +102,9 @@
     "@taskr/esnext": "1.1.0",
     "@taskr/watch": "1.1.0",
     "@tsconfig/node14": "^1.0.1",
+    "@types/accepts": "^1.3.5",
     "@types/cacache": "^15.0.1",
+    "@types/dicer": "^0.2.2",
     "@types/form-data": "^2.2.0",
     "@types/js-yaml": "^3.12.2",
     "@types/metro": "~0.66.1",
@@ -115,9 +118,12 @@
     "@types/webpack": "~4.41.32",
     "@types/webpack-dev-server": "3.11.0",
     "@types/wrap-ansi": "^8.0.1",
+    "dicer": "^0.3.1",
     "expo-module-scripts": "^2.0.0",
     "klaw-sync": "^6.0.0",
     "nock": "~13.2.2",
+    "nullthrows": "^1.1.1",
+    "structured-headers": "^0.4.1",
     "taskr": "1.1.0"
   }
 }

--- a/packages/@expo/cli/src/start/server/middleware/ClassicManifestMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/ClassicManifestMiddleware.ts
@@ -11,7 +11,12 @@ import { logEvent } from '../../../utils/analytics/rudderstackClient';
 import { memoize } from '../../../utils/fn';
 import { learnMore } from '../../../utils/link';
 import { stripPort } from '../../../utils/url';
-import { DEVELOPER_TOOL, HostInfo, ManifestMiddleware, ParsedHeaders } from './ManifestMiddleware';
+import {
+  DEVELOPER_TOOL,
+  HostInfo,
+  ManifestMiddleware,
+  ManifestRequestInfo,
+} from './ManifestMiddleware';
 import { assertRuntimePlatform, parsePlatformHeader } from './resolvePlatform';
 import { ServerHeaders, ServerRequest } from './server.types';
 
@@ -21,8 +26,10 @@ type SignManifestProps = {
   acceptSignature: boolean;
 };
 
-export class ClassicManifestMiddleware extends ManifestMiddleware {
-  public getParsedHeaders(req: ServerRequest): ParsedHeaders {
+interface ClassicManifestRequestInfo extends ManifestRequestInfo {}
+
+export class ClassicManifestMiddleware extends ManifestMiddleware<ClassicManifestRequestInfo> {
+  public getParsedHeaders(req: ServerRequest): ClassicManifestRequestInfo {
     const platform = parsePlatformHeader(req) || 'ios';
     assertRuntimePlatform(platform);
     return {
@@ -35,7 +42,7 @@ export class ClassicManifestMiddleware extends ManifestMiddleware {
   public async _getManifestResponseAsync({
     acceptSignature,
     ...requestOptions
-  }: ParsedHeaders): Promise<{
+  }: ClassicManifestRequestInfo): Promise<{
     body: string;
     version: string;
     headers: ServerHeaders;
@@ -54,7 +61,7 @@ export class ClassicManifestMiddleware extends ManifestMiddleware {
     // Gather packager and host info
     const hostInfo = await createHostInfoAsync();
 
-    const headers = this.getDefaultResponseHeaders();
+    const headers = new Map<string, any>();
     headers.set('Exponent-Server', hostInfo);
 
     // Create the final string

--- a/packages/@expo/cli/src/start/server/middleware/ExpoGoManifestHandlerMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/ExpoGoManifestHandlerMiddleware.ts
@@ -1,6 +1,8 @@
 import { ExpoUpdatesManifest } from '@expo/config';
 import { Updates } from '@expo/config-plugins';
+import accepts from 'accepts';
 import assert from 'assert';
+import FormData from 'form-data';
 import { v4 as uuidv4 } from 'uuid';
 
 import { getProjectAsync } from '../../../api/getProject';
@@ -12,7 +14,7 @@ import { logEvent } from '../../../utils/analytics/rudderstackClient';
 import { CommandError } from '../../../utils/errors';
 import { memoize } from '../../../utils/fn';
 import { stripPort } from '../../../utils/url';
-import { ManifestMiddleware, ParsedHeaders } from './ManifestMiddleware';
+import { ManifestMiddleware, ManifestRequestInfo } from './ManifestMiddleware';
 import {
   assertMissingRuntimePlatform,
   assertRuntimePlatform,
@@ -20,30 +22,42 @@ import {
 } from './resolvePlatform';
 import { ServerHeaders, ServerRequest } from './server.types';
 
-export class ExpoGoManifestHandlerMiddleware extends ManifestMiddleware {
-  public getParsedHeaders(req: ServerRequest): ParsedHeaders {
+interface ExpoGoManifestRequestInfo extends ManifestRequestInfo {
+  explicitlyPrefersMultipartMixed: boolean;
+}
+
+export class ExpoGoManifestHandlerMiddleware extends ManifestMiddleware<ExpoGoManifestRequestInfo> {
+  public getParsedHeaders(req: ServerRequest): ExpoGoManifestRequestInfo {
     const platform = parsePlatformHeader(req);
     assertMissingRuntimePlatform(platform);
     assertRuntimePlatform(platform);
 
+    // Expo Updates clients explicitly accept "multipart/mixed" responses while browsers implicitly
+    // accept them with "accept: */*". To make it easier to debug manifest responses by visiting their
+    // URLs in a browser, we denote the response as "text/plain" if the user agent appears not to be
+    // an Expo Updates client.
+    const accept = accepts(req);
+    const explicitlyPrefersMultipartMixed =
+      accept.types(['unknown/unknown', 'multipart/mixed']) === 'multipart/mixed';
+
     return {
+      explicitlyPrefersMultipartMixed,
       platform,
       acceptSignature: !!req.headers['expo-accept-signature'],
       hostname: stripPort(req.headers['host']),
     };
   }
 
-  protected getDefaultResponseHeaders(): Map<string, any> {
-    const headers = new Map<string, any>();
+  private getDefaultResponseHeaders(): ServerHeaders {
+    const headers = new Map<string, number | string | readonly string[]>();
     // set required headers for Expo Updates manifest specification
     headers.set('expo-protocol-version', 0);
     headers.set('expo-sfv-version', 0);
     headers.set('cache-control', 'private, max-age=0');
-    headers.set('content-type', 'application/json');
     return headers;
   }
 
-  public async _getManifestResponseAsync(requestOptions: ParsedHeaders): Promise<{
+  public async _getManifestResponseAsync(requestOptions: ExpoGoManifestRequestInfo): Promise<{
     body: string;
     version: string;
     headers: ServerHeaders;
@@ -103,11 +117,30 @@ export class ExpoGoManifestHandlerMiddleware extends ManifestMiddleware {
       headers.set('expo-manifest-signature', manifestSignature);
     }
 
+    const form = this.getFormData({
+      stringifiedManifest: JSON.stringify(expoUpdatesManifest),
+    });
+
+    headers.set(
+      'content-type',
+      requestOptions.explicitlyPrefersMultipartMixed
+        ? `multipart/mixed; boundary=${form.getBoundary()}`
+        : 'text/plain'
+    );
+
     return {
-      body: JSON.stringify(expoUpdatesManifest),
+      body: form.getBuffer().toString(),
       version: runtimeVersion,
       headers,
     };
+  }
+
+  private getFormData({ stringifiedManifest }: { stringifiedManifest: string }): FormData {
+    const form = new FormData();
+    form.append('manifest', stringifiedManifest, {
+      contentType: 'application/json',
+    });
+    return form;
   }
 
   protected trackManifest(version?: string) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3821,6 +3821,13 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.1.tgz#95f2d167ffb9b8d2068b0b235302fafd4df711f2"
   integrity sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==
 
+"@types/accepts@^1.3.5":
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/@types/accepts/-/accepts-1.3.5.tgz#c34bec115cfc746e04fe5a059df4ce7e7b391575"
+  integrity sha512-jOdnI/3qTpHABjM5cx1Hc0sKsPoYCp+DP/GJRGtDlPd7fiV9oXGGIcjW/ZOxLIvjGz8MA+uMZI9metHlgqbgwQ==
+  dependencies:
+    "@types/node" "*"
+
 "@types/aria-query@^4.2.0":
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.2.tgz#ed4e0ad92306a704f9fb132a0cfcf77486dbe2bc"
@@ -3922,6 +3929,13 @@
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@types/dedent/-/dedent-0.7.0.tgz#155f339ca404e6dd90b9ce46a3f78fd69ca9b050"
   integrity sha512-EGlKlgMhnLt/cM4DbUSafFdrkeJoC9Mvnj0PUCU7tFmTjMjNRT957kXCx0wYm3JuEq4o4ZsS5vG+NlkM2DMd2A==
+
+"@types/dicer@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@types/dicer/-/dicer-0.2.2.tgz#61e3a26ea4bf41cd003fd6f7adb9c78649f753de"
+  integrity sha512-UPLqCYey+jn5Mf57KFDwxD/7VZYDsbYUi3iyTehLFVjlbvl/JcUTPaot8uKNYLO0EoZpey+rC/s5AF3VxfeC2Q==
+  dependencies:
+    "@types/node" "*"
 
 "@types/ejs@^3.1.0":
   version "3.1.0"
@@ -5027,7 +5041,7 @@ absolute-path@^0.0.0:
   resolved "https://registry.yarnpkg.com/absolute-path/-/absolute-path-0.0.0.tgz#a78762fbdadfb5297be99b15d35a785b2f095bf7"
   integrity sha1-p4di+9rftSl76ZsV01p4Wy8JW/c=
 
-accepts@^1.3.7, accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.7, accepts@~1.3.8:
+accepts@^1.3.7, accepts@^1.3.8, accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.7, accepts@~1.3.8:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.8.tgz#0bf0be125b67014adcb0b0921e62db7bffe16b2e"
   integrity sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==
@@ -8169,6 +8183,13 @@ detox@^19.4.1:
     yargs "^16.0.3"
     yargs-unparser "^2.0.0"
 
+dicer@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/dicer/-/dicer-0.3.1.tgz#abf28921e3475bc5e801e74e0159fd94f927ba97"
+  integrity sha512-ObioMtXnmjYs3aRtpIJt9rgQSPCIhKVkFPip+E9GUDyWl8N435znUxK/JfNwGZJ2wnn5JKQ7Ly3vOK5Q5dylGA==
+  dependencies:
+    streamsearch "^1.1.0"
+
 diff-sequences@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.9.0.tgz#5715d6244e2aa65f48bba0bc972db0b0b11e95b5"
@@ -11179,6 +11200,11 @@ inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, i
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
+inherits@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
+  integrity sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=
 
 inherits@2.0.3:
   version "2.0.3"
@@ -18774,6 +18800,11 @@ stream-shift@^1.0.0:
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.1.tgz#d7088281559ab2778424279b0877da3c392d5a3d"
   integrity sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==
 
+streamsearch@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-1.1.0.tgz#404dd1e2247ca94af554e841a8ef0eaa238da764"
+  integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
+
 strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
@@ -18964,6 +18995,11 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
+
+structured-headers@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/structured-headers/-/structured-headers-0.4.1.tgz#77abd9410622c6926261c09b9d16cf10592694d1"
+  integrity sha512-0MP/Cxx5SzeeZ10p/bZI0S6MpgD+yxAhi1BOQ34jgnMXsCq3j1t6tQnZu+KdlL7dvJTLT3g9xN8tl10TqgFMcg==
 
 style-loader@~1.2.1:
   version "1.2.1"
@@ -20078,7 +20114,28 @@ util.promisify@~1.0.0:
     has-symbols "^1.0.1"
     object.getownpropertydescriptors "^2.1.0"
 
-util@0.10.3, util@^0.10.3, util@^0.11.0, util@^0.12.0, util@~0.12.4:
+util@0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/util/-/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
+  integrity sha1-evsa/lCAUkZInj23/g7TeTNqwPk=
+  dependencies:
+    inherits "2.0.1"
+
+util@^0.10.3:
+  version "0.10.4"
+  resolved "https://registry.yarnpkg.com/util/-/util-0.10.4.tgz#3aa0125bfe668a4672de58857d3ace27ecb76901"
+  integrity sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==
+  dependencies:
+    inherits "2.0.3"
+
+util@^0.11.0:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/util/-/util-0.11.1.tgz#3236733720ec64bb27f6e26f421aaa2e1b588d61"
+  integrity sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==
+  dependencies:
+    inherits "2.0.3"
+
+util@^0.12.0:
   version "0.12.4"
   resolved "https://registry.yarnpkg.com/util/-/util-0.12.4.tgz#66121a31420df8f01ca0c464be15dfa1d1850253"
   integrity sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==
@@ -20540,8 +20597,10 @@ watchpack@^1.6.1:
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.5.tgz#1267e6c55e0b9b5be44c2023aed5437a2c26c453"
   integrity sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==
   dependencies:
+    chokidar "^3.4.1"
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
+    watchpack-chokidar2 "^2.0.1"
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"


### PR DESCRIPTION
# Why

The new development manifest code signing feature uses the `certificate_chain` part in the multipart manifest response to send the development certificate chain to the client. 

All expo-updates clients using this new format should support the new format (EAS server only supports this format). The new code signing format only supports this format when additional certificates from the chain are needed. (if the embedded code signing certificate is all that is needed the old format is supported).

# How



# Test Plan

Run tests.

```
yarn build
```
Then, in an EAS project:
```
nexpo start --force-manifest-type=expo-updates
```
Load the manifest URL in a browser and in Expo Go, ensure both work.
