### PR TITLE
[facebook][android] Fix facebook SDK initialization

### DIFF
--- a/apps/test-suite/tests/Facebook.js
+++ b/apps/test-suite/tests/Facebook.js
@@ -28,6 +28,7 @@ export async function test(
     beforeAll(async () => {
       await Facebook.initializeAsync({
         appId: '1696089354000816',
+        appName: 'Expo APIs',
         version: Platform.select({
           web: 'v5.0',
         }),

--- a/packages/expo-facebook/CHANGELOG.md
+++ b/packages/expo-facebook/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix an issue on Android that appName cannot be set with Facebook.initializeAsync(). ([#16809](https://github.com/expo/expo/pull/16809) by [@dacer](https://github.com/dacer))
+
 ### 💡 Others
 
 - Updated `@expo/config-plugins` from `4.0.2` to `4.0.14` ([#15621](https://github.com/expo/expo/pull/15621) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/expo-facebook/android/src/main/java/expo/modules/facebook/FacebookModule.kt
+++ b/packages/expo-facebook/android/src/main/java/expo/modules/facebook/FacebookModule.kt
@@ -125,7 +125,7 @@ open class FacebookModule(
       }
       options.getString("appName")?.let {
         appName = it
-        FacebookSdk.setApplicationId(appName)
+        FacebookSdk.setApplicationName(appName)
       }
       options.getString("version")?.let {
         FacebookSdk.setGraphApiVersion(it)


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
There is an issue in this PR (https://github.com/expo/expo/commit/30432ba8105098f3dc4d2644bddcae94824758bd) that converted `FacebookSdk.setApplicationName(mAppName);` to `FacebookSdk.setApplicationId(appName)` in FacebookModule.kt. 

So the application id will be overwrited if we set the appName in the Facebook.initializeAsync() like this:

```
await Facebook.initializeAsync({
    appId: '111',
    appName: 'Expo APIs',
})
```


# How

<!--
How did you build this feature or fix this bug and why?
-->
* Use the `setApplicationName(mAppName)` in FacebookModule.kt.
* Add `appName: 'Expo APIs'` in the test suite's Facebook.initializeAsync() for testing.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
* Test suite

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).