### PR TITLE
[dev-client][e2e] Fix `Module was compiled with an incompatible version of Kotlin`

### DIFF
--- a/packages/expo-dev-client/android/build.gradle
+++ b/packages/expo-dev-client/android/build.gradle
@@ -122,4 +122,8 @@ dependencies {
 
   androidTestImplementation "com.google.truth:truth:1.1.2"
   androidTestImplementation 'io.mockk:mockk-android:1.10.6'
+
+  // Fixes "e: java.lang.AssertionError: No such enum entry LIBRARY_GROUP_PREFIX in org.jetbrains.kotlin.ir.types.impl.IrSimpleTypeImpl@b254b575"
+  // According to the https://stackoverflow.com/a/67736351
+  implementation 'androidx.annotation:annotation:1.2.0'
 }

--- a/packages/expo-dev-client/package.json
+++ b/packages/expo-dev-client/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0",
-    "expo-test-runner": "0.0.9"
+    "expo-test-runner": "0.0.10"
   },
   "peerDependencies": {
     "expo": "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9234,10 +9234,10 @@ expo-pwa@0.0.114:
     commander "2.20.0"
     update-check "1.5.3"
 
-expo-test-runner@0.0.9:
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/expo-test-runner/-/expo-test-runner-0.0.9.tgz#f5af2800450ac0f7af9c8752c1afc8d82dfc98d8"
-  integrity sha512-BtFPDIyYJhQRi+pvH1xM5YiVdaPDdayIFNmwM9JRrvVzeCWlGOS43Nhh4p6tV3o+IPGwEfAYSMi6EKbVGCPhqw==
+expo-test-runner@0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/expo-test-runner/-/expo-test-runner-0.0.10.tgz#44bb22b8db4bf3c933809f7afd0461665e4dacfa"
+  integrity sha512-w5bU77ea1TStUE4rtVT6lcp9JpcyEHVZNWKTzqClxERyAWMfpCUAM+bhqDkYW0l+Ku53n9h7ZW5sa5qqK15MSQ==
   dependencies:
     "@babel/runtime" "7.9.0"
     "@expo/spawn-async" "^1.5.0"


### PR DESCRIPTION
# Why

 Fix `Module was compiled with an incompatible version of Kotlin`

> Task :expo-modules-core:generateDebugBuildConfig
e: Incompatible classes were found in dependencies. Remove them from the classpath or use '-Xskip-metadata-version-check' to suppress errors
e: /Users/runner/.gradle/caches/transforms-3/148df20143c07bf6c362eab6367c8fb2/transformed/jetified-kotlin-stdlib-common-1.6.0.jar!/META-INF/kotlin-stdlib-common.kotlin_module: Module was compiled with an incompatible version of Kotlin. The binary version of its metadata is 1.6.0, expected version is 1.4.1.