### PR TITLE
[tools] Fix versioning on iOS

### DIFF
--- a/tools/src/versioning/ios/transforms/expoModulesTransforms.ts
+++ b/tools/src/versioning/ios/transforms/expoModulesTransforms.ts
@@ -14,7 +14,7 @@ export function expoModulesTransforms(prefix: string): FileTransforms {
       // Files starting with `Expo` needs to be prefixed though,
       // for umbrella headers (e.g. `ExpoModulesCore.h`).
       {
-        find: /\b(Expo|EX|UM)([^/]*\.)(h|m|mm|cpp)\b/,
+        find: /\b(Expo|EX|UM|EAS)([^/]*\.)(h|m|mm|cpp)\b/,
         replaceWith: `${prefix}$1$2$3`,
       },
       {
@@ -38,12 +38,12 @@ export function expoModulesTransforms(prefix: string): FileTransforms {
 
       {
         paths: swiftFilesPattern,
-        find: /\bimport (Expo|EX)(\w+)/g,
+        find: /\bimport (Expo|EX|EAS)(\w+)/g,
         replaceWith: `import ${prefix}$1$2`,
       },
       {
         paths: swiftFilesPattern,
-        find: /@objc\((Expo|EX)\)/g,
+        find: /@objc\((Expo|EX|EAS)\)/g,
         replaceWith: `@objc(${prefix}$1)`,
       },
       {
@@ -57,25 +57,30 @@ export function expoModulesTransforms(prefix: string): FileTransforms {
       {
         // Prefix `Expo*` frameworks in imports.
         paths: objcFilesPattern,
-        find: /#import <(Expo.*?)\//g,
-        replaceWith: `#import <${prefix}$1/`,
+        find: /#import <(Expo|EAS)(.*?)\//g,
+        replaceWith: `#import <${prefix}$1$2/`,
       },
       {
         paths: objcFilesPattern,
-        find: /#import <(.*?)\/(Expo.*?)\.h>/g,
-        replaceWith: `#import <$1/${prefix}$2.h>`,
+        find: /#import <(.*?)\/(Expo|EAS)(.*?)\.h>/g,
+        replaceWith: `#import <$1/${prefix}$2$3.h>`,
       },
       {
         // Rename Swift compatibility headers from frameworks starting with `Expo`.
         paths: objcFilesPattern,
-        find: /#import "(Expo.+?)-Swift\.h"/g,
-        replaceWith: `#import "${prefix}$1-Swift.h"`,
+        find: /#import "(Expo|EAS)(.+?)-Swift\.h"/g,
+        replaceWith: `#import "${prefix}$1$2-Swift.h"`,
       },
       {
         // Unprefix imports to unversionable (e.g. expo-gl-cpp) modules.
         paths: [objcFilesPattern, 'EXGL'],
         find: new RegExp(`#import <${prefix}(EXGL_CPP)\\b`),
         replaceWith: '#import <$1',
+      },
+      {
+        paths: objcFilesPattern,
+        find: /@import (Expo|EX|EAS)(\w+)/g,
+        replaceWith: `@import ${prefix}$1$2`,
       },
       {
         // Prefixes Objective-C name of the Swift modules provider.

--- a/tools/src/versioning/ios/transforms/postTransforms.ts
+++ b/tools/src/versioning/ios/transforms/postTransforms.ts
@@ -71,6 +71,11 @@ export function postTransforms(versionName: string): TransformPipeline {
         replace: /(\(name\.compare\(\d+, \d+, ")([^"]+)(RCT"\))/,
         with: '$1$3',
       },
+      {
+        paths: ['RCTSRWebSocket.h', 'UIView+Private.h'],
+        replace: /@interface (\w+) \((CertificateAdditions|Private)\)/g,
+        with: `@interface $1 (${versionName}$2)`
+      },
 
       // Universal modules
       {

--- a/tools/src/versioning/ios/versionExpoModules.ts
+++ b/tools/src/versioning/ios/versionExpoModules.ts
@@ -15,7 +15,7 @@ import { getVersionPrefix, getVersionedDirectory } from './utils';
 const TIMER_LABEL = 'Versioning expo modules finished in';
 
 // The pattern that matches the dependency pods that need to be renamed in `*.podspec.json`.
-const PODSPEC_DEPS_TO_RENAME_PATTERN = /^(Expo|EX(?!GL_CPP)|UM|React|RCT|Yoga)/;
+const PODSPEC_DEPS_TO_RENAME_PATTERN = /^(Expo|EX(?!GL_CPP)|UM|EAS|React|RCT|Yoga)/;
 
 /**
  * Function that versions expo modules.

--- a/tools/src/versioning/ios/versionExpoModulesProvider.ts
+++ b/tools/src/versioning/ios/versionExpoModulesProvider.ts
@@ -37,12 +37,12 @@ export async function versionExpoModulesProviderAsync(sdkNumber: number) {
     transforms: {
       content: [
         {
-          find: /\bimport (Expo|EX)/g,
+          find: /\bimport (Expo|EX|EAS)/g,
           replaceWith: `import ${prefix}$1`,
         },
         {
-          find: /@objc\((Expo.*?)\)/g,
-          replaceWith: `@objc(${prefix}$1)`,
+          find: /@objc\((Expo|EAS)(.*?)\)/g,
+          replaceWith: `@objc(${prefix}$1$2)`,
         },
       ],
     },


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/runs/5707752876

# How

- Symbols starting with `EAS` are now prefixed during versioning. I was thinking about renaming `EASClientID` pod to `ExpoEASClientID` but it sounds a bit off to me.
- Prefixing interface categories as we cannot have the same categories defined across different modules. There are two such categories in React Native: `CertificateAdditions` and `Private` on `UIView`.

# Test Plan

`et add-sdk -p ios -s 45.0.0` works, versioned Expo Go builds and runs as expected.