### PR TITLE
[updates-e2e] use yarn resolutions for local transitive dependencies

### DIFF
--- a/.github/workflows/updates-e2e.yml
+++ b/.github/workflows/updates-e2e.yml
@@ -70,10 +70,34 @@ jobs:
       - name: Init new expo app
         working-directory: ../
         run: expo-cli init updates-e2e --yes
-      - name: Add local expo-updates and dependencies
+      - name: Add yarn resolutions for local dependencies
         working-directory: ../updates-e2e
-        # install expo packages (including transitive packages) locally
-        run: yarn add file:../expo/packages/expo-updates file:../expo/packages/expo file:../expo/packages/expo-eas-client file:../expo/packages/expo-modules-core file:../expo/packages/expo-json-utils file:../expo/packages/expo-manifests file:../expo/packages/expo-structured-headers file:../expo/packages/expo-updates-interface file:../expo/packages/expo-constants file:../expo/packages/expo-file-system file:../expo/packages/expo-font file:../expo/packages/expo-keep-awake file:../expo/packages/expo-splash-screen file:../expo/packages/expo-status-bar file:../expo/packages/expo-application file:../expo/packages/expo-error-recovery
+        run: |
+          # A jq filter to add a "resolutions" field
+          JQ_FILTER=$(cat << EOF
+            . + {
+              resolutions: {
+                "expo-application": "file:../expo/packages/expo-application",
+                "expo-constants": "file:../expo/packages/expo-constants",
+                "expo-eas-client": "file:../expo/packages/expo-eas-client",
+                "expo-error-recovery": "file:../expo/packages/expo-error-recovery",
+                "expo-file-system": "file:../expo/packages/expo-file-system",
+                "expo-font": "file:../expo/packages/expo-font",
+                "expo-json-utils": "file:../expo/packages/expo-json-utils",
+                "expo-keep-awake": "file:../expo/packages/expo-keep-awake",
+                "expo-manifests": "file:../expo/packages/expo-manifests",
+                "expo-modules-core": "file:../expo/packages/expo-modules-core",
+                "expo-structured-headers": "file:../expo/packages/expo-structured-headers",
+                "expo-updates-interface": "file:../expo/packages/expo-updates-interface"
+              }
+            }
+          EOF
+          )
+          jq "$JQ_FILTER" < package.json > new-package.json
+          mv new-package.json package.json
+      - name: Add local expo packages
+        working-directory: ../updates-e2e
+        run: yarn add file:../expo/packages/expo-updates file:../expo/packages/expo file:../expo/packages/expo-splash-screen file:../expo/packages/expo-status-bar
       - name: Setup app.config.json
         working-directory: ../updates-e2e
         run: echo "{\"name\":\"updates-e2e\",\"plugins\":[\"expo-updates\"],\"android\":{\"package\":\"dev.expo.updatese2e\"},\"ios\":{\"bundleIdentifier\":\"dev.expo.updatese2e\"}}" > app.config.json


### PR DESCRIPTION
# Why

follow up from https://github.com/expo/expo/pull/16802#issuecomment-1081284073

# How

Add local dependencies in two steps -- (1) add resolutions for transitive dependencies that should come from local sources, and then (2) add explicit dependencies on local expo-updates and expo (the packages we should be directly depending on).

# Test Plan

Tried both the old flow and the new flow in a local test project.

With the old flow:
- yarn.lock included two separate entries for each transitive dependency -- one resolved locally and one with a yarn registry url.
- there were two copies of each transitive dependency installed, one in root node_modules and the other in node_modules/{expo,expo-updates}/node_modules.

With the new flow:
- yarn.lock only includes one entry for each transitive dependency, and it does not have a yarn registry url
- node_modules/{expo,expo-updates}/node_modules does not include any of the resolved transitive dependencies (i.e. there is only one copy of each in node_modules).

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
