### PR TITLE
fix(cli): allow bail out from TerminalUI

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -25,5 +25,6 @@
 
 - Fix process memory leak warning in `expo start`. ([#16753](https://github.com/expo/expo/pull/16753) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix build watcher. ([#16754](https://github.com/expo/expo/pull/16754) by [@EvanBacon](https://github.com/EvanBacon))
+- Allow bailing out of Terminal UI during long processes.
 
 ### 💡 Others

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -25,6 +25,6 @@
 
 - Fix process memory leak warning in `expo start`. ([#16753](https://github.com/expo/expo/pull/16753) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix build watcher. ([#16754](https://github.com/expo/expo/pull/16754) by [@EvanBacon](https://github.com/EvanBacon))
-- Allow bailing out of Terminal UI during long processes.
+- Allow bailing out of Terminal UI during long processes. ([#16818](https://github.com/expo/expo/pull/16818) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others

--- a/packages/@expo/cli/src/start/interface/KeyPressHandler.ts
+++ b/packages/@expo/cli/src/start/interface/KeyPressHandler.ts
@@ -1,6 +1,8 @@
 import * as Log from '../../log';
 import { logCmdError } from '../../utils/errors';
 
+const CTRL_C = '\u0003';
+
 /** An abstract key stroke interceptor. */
 export class KeyPressHandler {
   private isInterceptingKeyStrokes = false;
@@ -30,7 +32,7 @@ export class KeyPressHandler {
 
   private handleKeypress = async (key: string) => {
     // Prevent sending another event until the previous event has finished.
-    if (this.isHandlingKeyPress) {
+    if (this.isHandlingKeyPress && key !== CTRL_C) {
       return;
     }
     this.isHandlingKeyPress = true;

--- a/packages/@expo/cli/src/start/server/DevServerManager.ts
+++ b/packages/@expo/cli/src/start/server/DevServerManager.ts
@@ -4,7 +4,6 @@ import assert from 'assert';
 import * as Log from '../../log';
 import { FileNotifier } from '../../utils/FileNotifier';
 import { logEvent } from '../../utils/analytics/rudderstackClient';
-import { resolveWithTimeout } from '../../utils/delay';
 import { ProjectPrerequisite } from '../doctor/Prerequisite';
 import * as AndroidDebugBridge from '../platforms/android/adb';
 import { BundlerDevServer, BundlerStartOptions } from './BundlerDevServer';
@@ -131,17 +130,11 @@ export class DevServerManager {
 
   /** Stop all servers including ADB. */
   async stopAsync(): Promise<void> {
-    await resolveWithTimeout(
-      () =>
-        Promise.allSettled([
-          // Stop all dev servers
-          ...devServers.map((server) => server.stopAsync()),
-          // Stop ADB
-          AndroidDebugBridge.getServer().stopAsync(),
-        ]),
-      {
-        timeout: 3000,
-      }
-    );
+    await Promise.allSettled([
+      // Stop all dev servers
+      ...devServers.map((server) => server.stopAsync()),
+      // Stop ADB
+      AndroidDebugBridge.getServer().stopAsync(),
+    ]);
   }
 }


### PR DESCRIPTION
# Why

If a process was taking too long (like opening a simulator) you couldn't bail out, now you can.

# Test Plan

- Run a long process like pressing `i` while the simulator is closed -- then press `ctrl+c`.
