### PR TITLE
Upgrade react-native-webview to 11.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Package-specific changes not released in any SDK will be added here just before 
 - Removed `react-native-appearance` that is deprecated since SDK 43. Migrate to [`Appearance` API](https://reactnative.dev/docs/appearance). ([#16436](https://github.com/expo/expo/pull/16436) by [@kudo](https://github.com/kudo))
 - Updated `react-native-shared-element` from `0.8.3` to `0.8.4`. ([#16866](https://github.com/expo/expo/pull/16866) by [@brentvatne](https://github.com/brentvatne))
 - Updated `react-native-pager-view` from `5.4.9` to `5.4.15`. ([#16890](https://github.com/expo/expo/pull/16890) by [@brentvatne](https://github.com/brentvatne))
-- Updated `react-native-webview` from `11.15.0` to `11.18.0`. ([#16826](https://github.com/expo/expo/pull/16826) by [@tsapeta](https://github.com/tsapeta))
+- Updated `react-native-webview` from `11.15.0` to `11.18.1`. ([#16826](https://github.com/expo/expo/pull/16826) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🛠 Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Package-specific changes not released in any SDK will be added here just before 
 - Removed `react-native-appearance` that is deprecated since SDK 43. Migrate to [`Appearance` API](https://reactnative.dev/docs/appearance). ([#16436](https://github.com/expo/expo/pull/16436) by [@kudo](https://github.com/kudo))
 - Updated `react-native-shared-element` from `0.8.3` to `0.8.4`. ([#16866](https://github.com/expo/expo/pull/16866) by [@brentvatne](https://github.com/brentvatne))
 - Updated `react-native-pager-view` from `5.4.9` to `5.4.15`. ([#16890](https://github.com/expo/expo/pull/16890) by [@brentvatne](https://github.com/brentvatne))
+- Updated `react-native-webview` from `11.15.0` to `11.18.0`.
 
 ### 🛠 Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Package-specific changes not released in any SDK will be added here just before 
 - Removed `react-native-appearance` that is deprecated since SDK 43. Migrate to [`Appearance` API](https://reactnative.dev/docs/appearance). ([#16436](https://github.com/expo/expo/pull/16436) by [@kudo](https://github.com/kudo))
 - Updated `react-native-shared-element` from `0.8.3` to `0.8.4`. ([#16866](https://github.com/expo/expo/pull/16866) by [@brentvatne](https://github.com/brentvatne))
 - Updated `react-native-pager-view` from `5.4.9` to `5.4.15`. ([#16890](https://github.com/expo/expo/pull/16890) by [@brentvatne](https://github.com/brentvatne))
-- Updated `react-native-webview` from `11.15.0` to `11.18.0`.
+- Updated `react-native-webview` from `11.15.0` to `11.18.0`. ([#16826](https://github.com/expo/expo/pull/16826) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🛠 Breaking changes
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/webview/RNCWebViewPackage.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/webview/RNCWebViewPackage.kt
@@ -3,7 +3,8 @@ package versioned.host.exp.exponent.modules.api.components.webview
 import com.facebook.react.ReactPackage
 import com.facebook.react.bridge.ReactApplicationContext
 
-class RNCWebViewPackage : ReactPackage {
+
+class RNCWebViewPackage: ReactPackage {
   override fun createNativeModules(reactContext: ReactApplicationContext) = listOf(
     RNCWebViewModule(reactContext)
   )

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/webview/events/TopHttpErrorEvent.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/webview/events/TopHttpErrorEvent.kt
@@ -21,4 +21,5 @@ class TopHttpErrorEvent(viewId: Int, private val mEventData: WritableMap) :
 
   override fun dispatch(rctEventEmitter: RCTEventEmitter) =
     rctEventEmitter.receiveEvent(viewTag, eventName, mEventData)
+
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/webview/events/TopLoadingErrorEvent.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/webview/events/TopLoadingErrorEvent.kt
@@ -21,4 +21,5 @@ class TopLoadingErrorEvent(viewId: Int, private val mEventData: WritableMap) :
 
   override fun dispatch(rctEventEmitter: RCTEventEmitter) =
     rctEventEmitter.receiveEvent(viewTag, eventName, mEventData)
+
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/webview/events/TopLoadingStartEvent.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/webview/events/TopLoadingStartEvent.kt
@@ -21,4 +21,5 @@ class TopLoadingStartEvent(viewId: Int, private val mEventData: WritableMap) :
 
   override fun dispatch(rctEventEmitter: RCTEventEmitter) =
     rctEventEmitter.receiveEvent(viewTag, eventName, mEventData)
+
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/webview/events/TopRenderProcessGoneEvent.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/webview/events/TopRenderProcessGoneEvent.kt
@@ -6,7 +6,7 @@ import com.facebook.react.uimanager.events.RCTEventEmitter
 
 /**
  * Event emitted when the WebView's process has crashed or
- was killed by the OS.
+   was killed by the OS.
  */
 class TopRenderProcessGoneEvent(viewId: Int, private val mEventData: WritableMap) :
   Event<TopRenderProcessGoneEvent>(viewId) {
@@ -22,4 +22,5 @@ class TopRenderProcessGoneEvent(viewId: Int, private val mEventData: WritableMap
 
   override fun dispatch(rctEventEmitter: RCTEventEmitter) =
     rctEventEmitter.receiveEvent(viewTag, eventName, mEventData)
+
 }

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -654,8 +654,6 @@ PODS:
     - React
   - react-native-viewpager (5.0.11):
     - React-Core
-  - react-native-webview (11.15.0):
-    - React-Core
   - React-perflogger (0.67.2)
   - React-RCTActionSheet (0.67.2):
     - React-Core/RCTActionSheetHeaders (= 0.67.2)
@@ -921,7 +919,6 @@ DEPENDENCIES:
   - "react-native-slider (from `../../../node_modules/@react-native-community/slider`)"
   - react-native-view-shot (from `../../../node_modules/react-native-view-shot`)
   - "react-native-viewpager (from `../../../node_modules/@react-native-community/viewpager`)"
-  - react-native-webview (from `../../../node_modules/react-native-webview`)
   - React-perflogger (from `../../../node_modules/react-native/ReactCommon/reactperflogger`)
   - React-RCTActionSheet (from `../../../node_modules/react-native/Libraries/ActionSheetIOS`)
   - React-RCTAnimation (from `../../../node_modules/react-native/Libraries/NativeAnimation`)
@@ -1252,8 +1249,6 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/react-native-view-shot"
   react-native-viewpager:
     :path: "../../../node_modules/@react-native-community/viewpager"
-  react-native-webview:
-    :path: "../../../node_modules/react-native-webview"
   React-perflogger:
     :path: "../../../node_modules/react-native/ReactCommon/reactperflogger"
   React-RCTActionSheet:
@@ -1432,7 +1427,6 @@ SPEC CHECKSUMS:
   react-native-slider: 6e9b86e76cce4b9e35b3403193a6432ed07e0c81
   react-native-view-shot: 4475fde003fe8a210053d1f98fb9e06c1d834e1c
   react-native-viewpager: b99b53127d830885917ef84809c5065edd614a78
-  react-native-webview: e89bf2dba26a04cda967814df3ed1be99f291233
   React-perflogger: 3c9bb7372493e49036f07a82c44c8cf65cbe88db
   React-RCTActionSheet: 052606483045a408693aa7e864410b4a052f541a
   React-RCTAnimation: 08d4cac13222bb1348c687a0158dfd3b577cdb63

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -119,7 +119,7 @@
     "react-native-shared-element": "0.8.4",
     "react-native-svg": "12.1.1",
     "react-native-view-shot": "3.1.2",
-    "react-native-webview": "11.15.0",
+    "react-native-webview": "11.18.0",
     "test-suite": "*"
   },
   "devDependencies": {

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -119,7 +119,7 @@
     "react-native-shared-element": "0.8.4",
     "react-native-svg": "12.1.1",
     "react-native-view-shot": "3.1.2",
-    "react-native-webview": "11.18.0",
+    "react-native-webview": "11.18.1",
     "test-suite": "*"
   },
   "devDependencies": {

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -161,7 +161,7 @@
     "react-native-svg": "^12.1.1",
     "react-native-view-shot": "3.1.2",
     "react-native-web": "~0.17.1",
-    "react-native-webview": "11.15.0",
+    "react-native-webview": "11.18.0",
     "react-navigation": "^4.4.0",
     "react-navigation-shared-element": "^3.1.2",
     "react-navigation-stack": "^2.8.2",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -161,7 +161,7 @@
     "react-native-svg": "^12.1.1",
     "react-native-view-shot": "3.1.2",
     "react-native-web": "~0.17.1",
-    "react-native-webview": "11.18.0",
+    "react-native-webview": "11.18.1",
     "react-navigation": "^4.4.0",
     "react-navigation-shared-element": "^3.1.2",
     "react-navigation-stack": "^2.8.2",

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1773,7 +1773,7 @@ PODS:
     - React-Core
   - react-native-segmented-control (2.4.0):
     - React-Core
-  - react-native-webview (11.18.0):
+  - react-native-webview (11.18.1):
     - React-Core
   - React-perflogger (0.67.2)
   - React-RCTActionSheet (0.67.2):
@@ -3319,7 +3319,7 @@ SPEC CHECKSUMS:
   react-native-netinfo: 42c0965fca99069b92e3f7360ab2d425985e5104
   react-native-pager-view: b1914469643f40042e65d78cbf3d3dfebd6fb0d9
   react-native-segmented-control: 06607462630512ff8eef652ec560e6235a30cc3e
-  react-native-webview: b07bc0bc16fa9d855df07530faccbb0a3475cb88
+  react-native-webview: 0b7bd2bffced115aefd393e1841babd9b9a557b1
   React-perflogger: 3c9bb7372493e49036f07a82c44c8cf65cbe88db
   React-RCTActionSheet: 052606483045a408693aa7e864410b4a052f541a
   React-RCTAnimation: 08d4cac13222bb1348c687a0158dfd3b577cdb63

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1773,7 +1773,7 @@ PODS:
     - React-Core
   - react-native-segmented-control (2.4.0):
     - React-Core
-  - react-native-webview (11.15.0):
+  - react-native-webview (11.18.0):
     - React-Core
   - React-perflogger (0.67.2)
   - React-RCTActionSheet (0.67.2):
@@ -3319,7 +3319,7 @@ SPEC CHECKSUMS:
   react-native-netinfo: 42c0965fca99069b92e3f7360ab2d425985e5104
   react-native-pager-view: b1914469643f40042e65d78cbf3d3dfebd6fb0d9
   react-native-segmented-control: 06607462630512ff8eef652ec560e6235a30cc3e
-  react-native-webview: e89bf2dba26a04cda967814df3ed1be99f291233
+  react-native-webview: b07bc0bc16fa9d855df07530faccbb0a3475cb88
   React-perflogger: 3c9bb7372493e49036f07a82c44c8cf65cbe88db
   React-RCTActionSheet: 052606483045a408693aa7e864410b4a052f541a
   React-RCTAnimation: 08d4cac13222bb1348c687a0158dfd3b577cdb63

--- a/ios/vendored/unversioned/react-native-webview/apple/RNCWebView.h
+++ b/ios/vendored/unversioned/react-native-webview/apple/RNCWebView.h
@@ -93,6 +93,10 @@ typedef enum RNCWebViewPermissionGrantType : NSUInteger {
 @property (nonatomic, assign) BOOL limitsNavigationsToAppBoundDomains;
 #endif
 
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 140500 /* iOS 14.5 */
+@property (nonatomic, assign) BOOL textInteractionEnabled;
+#endif
+
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 150000 /* iOS 15 */
 @property (nonatomic, assign) RNCWebViewPermissionGrantType mediaCapturePermissionGrantType;
 #endif

--- a/ios/vendored/unversioned/react-native-webview/apple/RNCWebView.m
+++ b/ios/vendored/unversioned/react-native-webview/apple/RNCWebView.m
@@ -149,7 +149,9 @@ NSString *const CUSTOM_SELECTOR = @"_CUSTOM_SELECTOR_";
     _savedAutomaticallyAdjustsScrollIndicatorInsets = NO;
 #endif
     _enableApplePay = NO;
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 150000 /* iOS 15 */
     _mediaCapturePermissionGrantType = RNCWebViewPermissionGrantType_Prompt;
+#endif
   }
 
 #if !TARGET_OS_OSX
@@ -333,6 +335,14 @@ NSString *const CUSTOM_SELECTOR = @"_CUSTOM_SELECTOR_";
     [prefs setValue:@TRUE forKey:@"javaScriptCanOpenWindowsAutomatically"];
     _prefsUsed = YES;
   }
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 140500 /* iOS 14.5 */
+  if (@available(iOS 14.5, *)) {
+    if (!_textInteractionEnabled) {
+      [prefs setValue:@FALSE forKey:@"textInteractionEnabled"];
+      _prefsUsed = YES;
+    }
+  }
+#endif
   if (_prefsUsed) {
     wkWebViewConfig.preferences = prefs;
   }
@@ -673,38 +683,39 @@ NSString *const CUSTOM_SELECTOR = @"_CUSTOM_SELECTOR_";
         }
         [_webView loadHTMLString:html baseURL:baseURL];
         return;
-    } 
-    //Add cookie for subsequent resource requests sent by page itself, if cookie was set in headers on WebView
-    NSString *headerCookie = [RCTConvert NSString:_source[@"headers"][@"cookie"]]; 
+    }
+    // Add cookie for subsequent resource requests sent by page itself, if cookie was set in headers on WebView
+    NSString *headerCookie = [RCTConvert NSString:_source[@"headers"][@"cookie"]];
     if(headerCookie) {
       NSDictionary *headers = [NSDictionary dictionaryWithObjectsAndKeys:headerCookie,@"Set-Cookie",nil];
       NSURL *urlString = [NSURL URLWithString:_source[@"uri"]];
       NSArray *httpCookies = [NSHTTPCookie cookiesWithResponseHeaderFields:headers forURL:urlString];
-      for (NSHTTPCookie *httpCookie in httpCookies) {
-          [_webView.configuration.websiteDataStore.httpCookieStore setCookie:httpCookie completionHandler:nil];
-      }
+      [self writeCookiesToWebView:httpCookies completion:nil];
     }
 
     NSURLRequest *request = [self requestForSource:_source];
-    // Because of the way React works, as pages redirect, we actually end up
-    // passing the redirect urls back here, so we ignore them if trying to load
-    // the same url. We'll expose a call to 'reload' to allow a user to load
-    // the existing page.
-    if ([request.URL isEqual:_webView.URL]) {
-        return;
-    }
-    if (!request.URL) {
-        // Clear the webview
-        [_webView loadHTMLString:@"" baseURL:nil];
-        return;
-    }
-    if (request.URL.host) {
-        [_webView loadRequest:request];
-    }
-    else {
-        NSURL* readAccessUrl = _allowingReadAccessToURL ? [RCTConvert NSURL:_allowingReadAccessToURL] : request.URL;
-        [_webView loadFileURL:request.URL allowingReadAccessToURL:readAccessUrl];
-    }
+
+    [self syncCookiesToWebView:^{
+      // Because of the way React works, as pages redirect, we actually end up
+      // passing the redirect urls back here, so we ignore them if trying to load
+      // the same url. We'll expose a call to 'reload' to allow a user to load
+      // the existing page.
+      if ([request.URL isEqual:_webView.URL]) {
+          return;
+      }
+      if (!request.URL) {
+          // Clear the webview
+          [_webView loadHTMLString:@"" baseURL:nil];
+          return;
+      }
+      if (request.URL.host) {
+          [_webView loadRequest:request];
+      }
+      else {
+          NSURL* readAccessUrl = _allowingReadAccessToURL ? [RCTConvert NSURL:_allowingReadAccessToURL] : request.URL;
+          [_webView loadFileURL:request.URL allowingReadAccessToURL:readAccessUrl];
+      }
+    }];
 }
 
 #if !TARGET_OS_OSX
@@ -1308,6 +1319,15 @@ NSString *const CUSTOM_SELECTOR = @"_CUSTOM_SELECTOR_";
 - (void)webView:(WKWebView *)webView
   didFinishNavigation:(WKNavigation *)navigation
 {
+  if(_sharedCookiesEnabled && @available(iOS 11.0, *)) {
+    // Write all cookies from WKWebView back to sharedHTTPCookieStorage
+    [webView.configuration.websiteDataStore.httpCookieStore getAllCookies:^(NSArray* cookies) {
+      for (NSHTTPCookie *cookie in cookies) {
+        [[NSHTTPCookieStorage sharedHTTPCookieStorage] setCookie:cookie];
+      }
+    }];
+  }
+
   if (_ignoreSilentHardwareSwitch) {
     [self forceIgnoreSilentHardwareSwitch:true];
   }
@@ -1453,6 +1473,33 @@ NSString *const CUSTOM_SELECTOR = @"_CUSTOM_SELECTOR_";
   }
 }
 
+- (void)writeCookiesToWebView:(NSArray<NSHTTPCookie *>*)cookies completion:(void (^)(void))completion {
+  // The required cookie APIs only became available on iOS 11
+  if(_sharedCookiesEnabled && @available(iOS 11.0, *)) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+      dispatch_group_t group = dispatch_group_create();
+      for (NSHTTPCookie *cookie in cookies) {
+        dispatch_group_enter(group);
+        [_webView.configuration.websiteDataStore.httpCookieStore setCookie:cookie completionHandler:^{
+          dispatch_group_leave(group);
+        }];
+      }
+      dispatch_group_notify(group, dispatch_get_main_queue(), ^{
+        if (completion) {
+          completion();
+        }
+      });
+    });
+  } else if (completion) {
+    completion();
+  }
+}
+
+- (void)syncCookiesToWebView:(void (^)(void))completion {
+  NSArray<NSHTTPCookie *> *cookies = [[NSHTTPCookieStorage sharedHTTPCookieStorage] cookies];
+  [self writeCookiesToWebView:cookies completion:completion];
+}
+
 - (void)resetupScripts:(WKWebViewConfiguration *)wkWebViewConfig {
   [wkWebViewConfig.userContentController removeAllUserScripts];
   [wkWebViewConfig.userContentController removeScriptMessageHandlerForName:MessageHandlerName];
@@ -1497,9 +1544,7 @@ NSString *const CUSTOM_SELECTOR = @"_CUSTOM_SELECTOR_";
       if(!_incognito && !_cacheEnabled) {
         wkWebViewConfig.websiteDataStore = [WKWebsiteDataStore nonPersistentDataStore];
       }
-      for (NSHTTPCookie *cookie in [[NSHTTPCookieStorage sharedHTTPCookieStorage] cookies]) {
-        [wkWebViewConfig.websiteDataStore.httpCookieStore setCookie:cookie completionHandler:nil];
-      }
+      [self syncCookiesToWebView:nil];
     } else {
       NSMutableString *script = [NSMutableString string];
 

--- a/ios/vendored/unversioned/react-native-webview/apple/RNCWebViewManager.m
+++ b/ios/vendored/unversioned/react-native-webview/apple/RNCWebViewManager.m
@@ -115,6 +115,10 @@ RCT_EXPORT_VIEW_PROPERTY(contentMode, WKContentMode)
 RCT_EXPORT_VIEW_PROPERTY(limitsNavigationsToAppBoundDomains, BOOL)
 #endif
 
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 140500 /* iOS 14.5 */
+RCT_EXPORT_VIEW_PROPERTY(textInteractionEnabled, BOOL)
+#endif
+
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 150000 /* iOS 15 */
 RCT_EXPORT_VIEW_PROPERTY(mediaCapturePermissionGrantType, RNCWebViewPermissionGrantType)
 #endif

--- a/ios/vendored/unversioned/react-native-webview/react-native-webview.podspec.json
+++ b/ios/vendored/unversioned/react-native-webview/react-native-webview.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-webview",
-  "version": "11.15.0",
+  "version": "11.18.0",
   "summary": "React Native WebView component for iOS, Android, macOS, and Windows",
   "license": "MIT",
   "authors": "Jamon Holmgren <jamon@infinite.red>",
@@ -11,7 +11,7 @@
   },
   "source": {
     "git": "https://github.com/react-native-webview/react-native-webview.git",
-    "tag": "v11.15.0"
+    "tag": "v11.18.0"
   },
   "source_files": "apple/**/*.{h,m}",
   "dependencies": {

--- a/ios/vendored/unversioned/react-native-webview/react-native-webview.podspec.json
+++ b/ios/vendored/unversioned/react-native-webview/react-native-webview.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-webview",
-  "version": "11.18.0",
+  "version": "11.18.1",
   "summary": "React Native WebView component for iOS, Android, macOS, and Windows",
   "license": "MIT",
   "authors": "Jamon Holmgren <jamon@infinite.red>",
@@ -11,7 +11,7 @@
   },
   "source": {
     "git": "https://github.com/react-native-webview/react-native-webview.git",
-    "tag": "v11.18.0"
+    "tag": "v11.18.1"
   },
   "source_files": "apple/**/*.{h,m}",
   "dependencies": {

--- a/packages/expo-dev-menu/package.json
+++ b/packages/expo-dev-menu/package.json
@@ -43,7 +43,7 @@
       "@testing-library/jest-native/extend-expect",
       "./setupTests.ts"
     ],
-    "transformIgnorePatterns": []  
+    "transformIgnorePatterns": []
   },
   "dependencies": {
     "@expo/config-plugins": "^4.0.14",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -103,7 +103,7 @@
   "react-native-svg": "12.1.1",
   "react-native-unimodules": "~0.15.0",
   "react-native-view-shot": "3.1.2",
-  "react-native-webview": "11.18.0",
+  "react-native-webview": "11.18.1",
   "sentry-expo": "^4.0.0",
   "unimodules-app-loader": "~3.0.0",
   "unimodules-image-loader-interface": "~6.1.0"

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -103,7 +103,7 @@
   "react-native-svg": "12.1.1",
   "react-native-unimodules": "~0.15.0",
   "react-native-view-shot": "3.1.2",
-  "react-native-webview": "11.15.0",
+  "react-native-webview": "11.18.0",
   "sentry-expo": "^4.0.0",
   "unimodules-app-loader": "~3.0.0",
   "unimodules-image-loader-interface": "~6.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -17091,10 +17091,10 @@ react-native-web@~0.17.1:
     normalize-css-color "^1.0.2"
     prop-types "^15.6.0"
 
-react-native-webview@11.15.0:
-  version "11.15.0"
-  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-11.15.0.tgz#b5aea9da579ca17fb9fd324e5202b1b5b8ce9fa8"
-  integrity sha512-0Wv+8qu8XuACx1xZwzc2Yfl+rOvxUouLcPxUKdkhaMVNpwoM5/ePpczCQZ3LpiRnSoEtjaUkfyQHbJQ+x4dDJQ==
+react-native-webview@11.18.0:
+  version "11.18.0"
+  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-11.18.0.tgz#4536bf55d2bda28ed0e6662690f0e997e5630647"
+  integrity sha512-S7GXNZuM7jqBOY6R3Pp0KNRwpL8JJdbUB7f8J2WLlU++TOaUXDmsn5tlGnoycwyHotX5al5LypRgOPVFzrPxBA==
   dependencies:
     escape-string-regexp "2.0.0"
     invariant "2.2.4"


### PR DESCRIPTION
# Why

Preparation for SDK45 release
Closes ENG-4505

# How

`et update-vendored-module -m react-native-webview -c 5e73b2089fc80c2be7aa6eff291b18c81ad4030d` (commit from which `11.18.1` was released)

# Test Plan

NCL examples seem to work as expected on iOS and Android
