### PR TITLE
Fix JSI runtime being unexpectedly deallocated by shared pointer

### DIFF
--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.h
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.h
@@ -20,7 +20,7 @@ NS_SWIFT_NAME(JavaScriptRuntime)
 #ifdef __cplusplus
 typedef jsi::Value (^JSHostFunctionBlock)(jsi::Runtime &runtime, std::shared_ptr<react::CallInvoker> callInvoker, NSArray * _Nonnull arguments);
 
-- (nonnull instancetype)initWithRuntime:(std::shared_ptr<jsi::Runtime>)runtime
+- (nonnull instancetype)initWithRuntime:(jsi::Runtime *)runtime
                             callInvoker:(std::shared_ptr<react::CallInvoker>)callInvoker;
 
 /**

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.mm
@@ -36,10 +36,13 @@ using namespace facebook;
   return self;
 }
 
-- (nonnull instancetype)initWithRuntime:(std::shared_ptr<jsi::Runtime>)runtime callInvoker:(std::shared_ptr<react::CallInvoker>)callInvoker
+- (nonnull instancetype)initWithRuntime:(jsi::Runtime *)runtime callInvoker:(std::shared_ptr<react::CallInvoker>)callInvoker
 {
   if (self = [super init]) {
-    _runtime = runtime;
+    // Creating a shared pointer that points to the runtime but doesn't own it, thus doesn't release it.
+    // In this code flow, the runtime should be owned by something else like the RCTBridge.
+    // See explanation for constructor (8): https://en.cppreference.com/w/cpp/memory/shared_ptr/shared_ptr
+    _runtime = std::shared_ptr<jsi::Runtime>(std::shared_ptr<jsi::Runtime>(), runtime);
     _jsCallInvoker = callInvoker;
   }
   return self;

--- a/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.mm
+++ b/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.mm
@@ -410,8 +410,7 @@ RCT_EXPORT_METHOD(callMethod:(NSString *)moduleName methodNameOrKey:(id)methodNa
   facebook::jsi::Runtime *jsiRuntime = [_bridge respondsToSelector:@selector(runtime)] ? reinterpret_cast<facebook::jsi::Runtime *>(_bridge.runtime) : nullptr;
 
   if (jsiRuntime) {
-    std::shared_ptr<jsi::Runtime> jsiRuntimePtr(jsiRuntime);
-    EXJavaScriptRuntime *runtime = [[EXJavaScriptRuntime alloc] initWithRuntime:jsiRuntimePtr callInvoker:_bridge.jsCallInvoker];
+    EXJavaScriptRuntime *runtime = [[EXJavaScriptRuntime alloc] initWithRuntime:jsiRuntime callInvoker:_bridge.jsCallInvoker];
 
     [EXJavaScriptRuntimeManager installExpoModulesToRuntime:runtime withSwiftInterop:_swiftInteropBridge];
     [_swiftInteropBridge setRuntime:runtime];


### PR DESCRIPTION
# Why

Fixes a crash on launch in bare-expo, introduced in #16777 

# How

Keeping the runtime unique pointer to prevent the runtime from being deallocated when the pointer gets out of scope.

# Test Plan

bare-expo launches without crashes, `JavaScriptRuntimeSpec` tests are passing