### PR TITLE
event fire intervall correction

### DIFF
--- a/docs/pages/versions/unversioned/sdk/background-fetch.md
+++ b/docs/pages/versions/unversioned/sdk/background-fetch.md
@@ -50,7 +50,7 @@ TaskManager.defineTask(BACKGROUND_FETCH_TASK, async () => {
 // Note: This does NOT need to be in the global scope and CAN be used in your React components!
 async function registerBackgroundFetchAsync() {
   return BackgroundFetch.registerTaskAsync(BACKGROUND_FETCH_TASK, {
-    minimumInterval: 60 * 15, // 15 minutes
+    minimumInterval: 15, // 15 minutes
     stopOnTerminate: false, // android only,
     startOnBoot: true, // android only
   });


### PR DESCRIPTION
The interval is in minutes not seconds. Multiply to 60 will fire the task in 15 hours.
https://snack.expo.dev/@g1sm0/background-fetch-usage

# Why

15 hours waiting is a little bit to long

# How

by pressing backspace

# Test Plan

visit the expo snack https://snack.expo.dev/@g1sm0/background-fetch-usage and change the intervall

# Checklist

- [?] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [X] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
