### PR TITLE
[home] fix screen bg, account list sizing, text truncating

### DIFF
--- a/dev-home-config.json
+++ b/dev-home-config.json
@@ -1,3 +1,3 @@
 {
-  "url": "exp://exp.host/@expo-home-dev/expo-home-dev-c55e13b2ce24194a179034d02edc036b30e28d67"
+  "url": "exp://exp.host/@expo-home-dev/expo-home-dev-582f3931c3d3be93992c94aa5e70dd854bafb32c"
 }

--- a/home/components/ProjectsListItem.tsx
+++ b/home/components/ProjectsListItem.tsx
@@ -37,9 +37,9 @@ export function ProjectsListItem({ imageURL, name, subtitle, sdkVersion, id }: P
     <PressableOpacity onPress={onPress}>
       <View padding="medium">
         <Row align="center" justify="between">
-          <Row align="center">
+          <Row align="center" flex="1">
             <AppIcon image={imageURL} />
-            <View>
+            <View flex="1">
               <Text
                 type="InterSemiBold"
                 style={styles.titleText}

--- a/home/components/SnacksListItem.tsx
+++ b/home/components/SnacksListItem.tsx
@@ -44,7 +44,7 @@ export function SnacksListItem({ description, isDraft, name, url }: Props) {
     <PressableOpacity onPress={handlePressProject} onLongPress={handleLongPressProject}>
       <View padding="medium">
         <Row align="center" justify="between">
-          <View align="start">
+          <View align="start" flex="1">
             <Text type="InterSemiBold" ellipsizeMode="tail" numberOfLines={1}>
               {name}
             </Text>

--- a/home/navigation/Navigation.tsx
+++ b/home/navigation/Navigation.tsx
@@ -48,9 +48,7 @@ function HomeStackScreen() {
   return (
     <HomeStack.Navigator
       initialRouteName="Home"
-      screenOptions={{
-        ...defaultNavigationOptions(themeName),
-      }}>
+      screenOptions={defaultNavigationOptions(themeName)}>
       <HomeStack.Screen
         name="Home"
         component={HomeScreen}

--- a/home/screens/AccountModal/LoggedInAccountView.tsx
+++ b/home/screens/AccountModal/LoggedInAccountView.tsx
@@ -1,4 +1,5 @@
 import { borderRadius, CheckIcon, iconSize, spacing, UsersIcon } from '@expo/styleguide-native';
+import { useNavigation } from '@react-navigation/native';
 import { Text, View, Image, useExpoTheme, Row, Spacer, Divider } from 'expo-dev-client-components';
 import React from 'react';
 import { FlatList } from 'react-native';
@@ -15,9 +16,8 @@ type Props = {
 
 export function LoggedInAccountView({ accounts }: Props) {
   const { accountName, setAccountName } = useAccountName();
-
+  const navigation = useNavigation();
   const theme = useExpoTheme();
-
   const dispatch = useDispatch();
 
   const onSignOutPress = React.useCallback(() => {
@@ -26,56 +26,63 @@ export function LoggedInAccountView({ accounts }: Props) {
 
   return (
     <View flex="1" padding="medium">
-      <View bg="default" border="hairline" overflow="hidden" rounded="large">
-        <FlatList<typeof accounts[number]>
-          data={accounts}
-          keyExtractor={(account) => account.id}
-          renderItem={({ item: account }) => (
-            <PressableOpacity
-              key={account.id}
-              style={{ padding: 16 }}
-              containerProps={{ bg: 'default' }}
-              onPress={() => {
-                setAccountName(account.name);
-              }}>
-              <Row justify="between">
-                <Row align={!account.owner?.fullName ? 'center' : 'start'}>
-                  {account?.owner?.profilePhoto ? (
-                    <Image size="xl" rounded="full" source={{ uri: account.owner.profilePhoto }} />
-                  ) : (
-                    <View rounded="full" height="xl" width="xl" bg="secondary" align="centered">
-                      <UsersIcon color={theme.icon.default} size={iconSize.small} />
-                    </View>
-                  )}
-                  <Spacer.Horizontal size="small" />
-                  <View>
-                    {account.owner ? (
-                      <>
-                        {account.owner.fullName ? (
-                          <>
-                            <Text type="InterBold">{account.owner.fullName}</Text>
-                            <Spacer.Vertical size="tiny" />
-                            <Text color="secondary" type="InterRegular" size="small">
-                              {account.owner.username}
-                            </Text>
-                          </>
-                        ) : (
-                          <Text type="InterBold">{account.owner.username}</Text>
-                        )}
-                      </>
+      <View flex="1">
+        <View bg="default" border="hairline" overflow="hidden" rounded="large">
+          <FlatList<typeof accounts[number]>
+            data={accounts}
+            keyExtractor={(account) => account.id}
+            renderItem={({ item: account }) => (
+              <PressableOpacity
+                key={account.id}
+                style={{ padding: 16 }}
+                containerProps={{ bg: 'default' }}
+                onPress={() => {
+                  setAccountName(account.name);
+                  navigation.goBack();
+                }}>
+                <Row justify="between">
+                  <Row align={!account.owner?.fullName ? 'center' : 'start'}>
+                    {account?.owner?.profilePhoto ? (
+                      <Image
+                        size="xl"
+                        rounded="full"
+                        source={{ uri: account.owner.profilePhoto }}
+                      />
                     ) : (
-                      <Text type="InterBold">{account.name}</Text>
+                      <View rounded="full" height="xl" width="xl" bg="secondary" align="centered">
+                        <UsersIcon color={theme.icon.default} size={iconSize.small} />
+                      </View>
                     )}
-                  </View>
+                    <Spacer.Horizontal size="small" />
+                    <View>
+                      {account.owner ? (
+                        <>
+                          {account.owner.fullName ? (
+                            <>
+                              <Text type="InterBold">{account.owner.fullName}</Text>
+                              <Spacer.Vertical size="tiny" />
+                              <Text color="secondary" type="InterRegular" size="small">
+                                {account.owner.username}
+                              </Text>
+                            </>
+                          ) : (
+                            <Text type="InterBold">{account.owner.username}</Text>
+                          )}
+                        </>
+                      ) : (
+                        <Text type="InterBold">{account.name}</Text>
+                      )}
+                    </View>
+                  </Row>
+                  {accountName === account.name && (
+                    <CheckIcon color={theme.icon.default} size={iconSize.large} />
+                  )}
                 </Row>
-                {accountName === account.name && (
-                  <CheckIcon color={theme.icon.default} size={iconSize.large} />
-                )}
-              </Row>
-            </PressableOpacity>
-          )}
-          ItemSeparatorComponent={Divider}
-        />
+              </PressableOpacity>
+            )}
+            ItemSeparatorComponent={Divider}
+          />
+        </View>
       </View>
       <Spacer.Vertical size="large" />
       <PressableOpacity

--- a/home/screens/AccountModal/index.tsx
+++ b/home/screens/AccountModal/index.tsx
@@ -37,7 +37,7 @@ export function AccountModal() {
 
   if (loading) {
     return (
-      <View flex="1">
+      <View flex="1" style={{ backgroundColor: theme.background.screen }}>
         {Platform.OS === 'ios' && <ModalHeader />}
         <View flex="1" padding="medium" align="centered">
           <ActivityIndicator color={theme.highlight.accent} />
@@ -50,7 +50,7 @@ export function AccountModal() {
     console.error(error);
 
     return (
-      <View flex="1">
+      <View flex="1" style={{ backgroundColor: theme.background.screen }}>
         {Platform.OS === 'ios' && <ModalHeader />}
         <View padding="medium">
           <View

--- a/home/screens/BranchDetailsScreen/BranchDetailsView.tsx
+++ b/home/screens/BranchDetailsScreen/BranchDetailsView.tsx
@@ -45,7 +45,7 @@ export function BranchDetailsView({ loading, error, data }: Props) {
     );
   } else {
     contents = (
-      <View style={{ flex: 1, paddingBottom: 20 }}>
+      <View style={{ flex: 1, paddingBottom: 20, backgroundColor: theme.background.screen }}>
         <BranchHeader
           name={data.app.byId.updateBranchByName.name}
           manifestPermalink={data.app.byId.updateBranchByName.updates[0].manifestPermalink}

--- a/home/screens/BranchListScreen/BranchListView.tsx
+++ b/home/screens/BranchListScreen/BranchListView.tsx
@@ -1,4 +1,4 @@
-import { Divider, View } from 'expo-dev-client-components';
+import { Divider, useExpoTheme, View } from 'expo-dev-client-components';
 import * as React from 'react';
 import { ActivityIndicator, FlatList, View as RNView } from 'react-native';
 import InfiniteScrollView from 'react-native-infinite-scroll-view';
@@ -22,6 +22,8 @@ type Props = {
 export function BranchListView(props: Props) {
   const [isReady, setReady] = React.useState(false);
 
+  const theme = useExpoTheme();
+
   React.useEffect(() => {
     const _readyTimer = setTimeout(() => {
       setReady(true);
@@ -33,14 +35,20 @@ export function BranchListView(props: Props) {
 
   if (!isReady) {
     return (
-      <RNView style={{ flex: 1, padding: 30, alignItems: 'center' }}>
+      <RNView
+        style={{
+          flex: 1,
+          padding: 30,
+          alignItems: 'center',
+          backgroundColor: theme.background.screen,
+        }}>
         <ActivityIndicator />
       </RNView>
     );
   }
 
   if (!props.data?.length) {
-    return <RNView style={{ flex: 1 }} />;
+    return <RNView style={{ flex: 1, backgroundColor: theme.background.screen }} />;
   }
 
   return <BranchList {...props} />;
@@ -49,6 +57,7 @@ export function BranchListView(props: Props) {
 function BranchList({ data, appId, loadMoreAsync }: Props) {
   const [isLoadingMore, setLoadingMore] = React.useState(false);
   const isLoading = React.useRef<null | boolean>(false);
+  const theme = useExpoTheme();
 
   const extractKey = React.useCallback((item) => item.id, []);
 
@@ -87,7 +96,12 @@ function BranchList({ data, appId, loadMoreAsync }: Props) {
   }, []);
 
   return (
-    <View flex="1" padding="medium">
+    <View
+      flex="1"
+      padding="medium"
+      style={{
+        backgroundColor: theme.background.screen,
+      }}>
       <View bg="default" border="hairline" rounded="large" overflow="hidden">
         <FlatList
           data={data}

--- a/home/screens/HomeScreen/HomeScreenView.tsx
+++ b/home/screens/HomeScreen/HomeScreenView.tsx
@@ -311,7 +311,6 @@ const styles = StyleSheet.create({
   },
   contentContainer: {
     padding: spacing[4],
-    paddingBottom: 80,
   },
   projectImageStyle: {
     borderWidth: 1,

--- a/home/screens/ProjectScreen/ProjectView.tsx
+++ b/home/screens/ProjectScreen/ProjectView.tsx
@@ -53,7 +53,7 @@ export function ProjectView({ loading, error, data, navigation }: Props) {
     const app = data.app.byId;
 
     contents = (
-      <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingBottom: 20 }}>
+      <ScrollView style={{ flex: 1 }}>
         <ProjectHeader app={app} />
         <View padding="medium">
           {(appHasLegacyUpdate(app) || appHasEASUpdates(app)) && (

--- a/home/screens/ProjectsListScreen/ProjectList.tsx
+++ b/home/screens/ProjectsListScreen/ProjectList.tsx
@@ -51,7 +51,13 @@ export function ProjectList(props: Props) {
 
   if (!isReady) {
     return (
-      <RNView style={{ flex: 1, padding: 30, alignItems: 'center' }}>
+      <RNView
+        style={{
+          flex: 1,
+          padding: 30,
+          alignItems: 'center',
+          backgroundColor: theme.background.screen,
+        }}>
         <ActivityIndicator color={theme.highlight.accent} />
       </RNView>
     );
@@ -77,7 +83,13 @@ export function ProjectList(props: Props) {
       };
 
       return (
-        <RNView style={{ flex: 1, alignItems: 'center', paddingTop: 30 }}>
+        <RNView
+          style={{
+            flex: 1,
+            alignItems: 'center',
+            paddingTop: 30,
+            backgroundColor: theme.background.screen,
+          }}>
           <StyledText
             style={SharedStyles.noticeDescriptionText}
             lightColor="rgba(36, 44, 58, 0.7)"
@@ -92,7 +104,7 @@ export function ProjectList(props: Props) {
       );
     }
 
-    return <RNView style={{ flex: 1 }} />;
+    return <RNView style={{ flex: 1, backgroundColor: theme.background.screen }} />;
   }
 
   return <ProjectListView {...props} />;
@@ -100,7 +112,7 @@ export function ProjectList(props: Props) {
 
 function ProjectListView({ data, loadMoreAsync }: Props) {
   const isLoading = React.useRef<null | boolean>(false);
-
+  const theme = useExpoTheme();
   const extractKey = React.useCallback((item) => item.id, []);
 
   const handleLoadMoreAsync = async () => {
@@ -134,7 +146,12 @@ function ProjectListView({ data, loadMoreAsync }: Props) {
   };
 
   return (
-    <View flex="1" padding="medium">
+    <View
+      flex="1"
+      padding="medium"
+      style={{
+        backgroundColor: theme.background.screen,
+      }}>
       <View overflow="hidden" bg="default" border="hairline" rounded="large">
         <FlatList
           data={data.apps}

--- a/home/screens/SnacksListScreen/SnackList.tsx
+++ b/home/screens/SnacksListScreen/SnackList.tsx
@@ -1,4 +1,4 @@
-import { Divider, View } from 'expo-dev-client-components';
+import { Divider, useExpoTheme, View } from 'expo-dev-client-components';
 import * as React from 'react';
 import { ActivityIndicator, FlatList, View as RNView } from 'react-native';
 import InfiniteScrollView from 'react-native-infinite-scroll-view';
@@ -13,6 +13,7 @@ type Props = {
 
 export function SnackListView(props: Props) {
   const [isReady, setReady] = React.useState(false);
+  const theme = useExpoTheme();
 
   React.useEffect(() => {
     const _readyTimer = setTimeout(() => {
@@ -25,14 +26,20 @@ export function SnackListView(props: Props) {
 
   if (!isReady) {
     return (
-      <RNView style={{ flex: 1, padding: 30, alignItems: 'center' }}>
+      <RNView
+        style={{
+          flex: 1,
+          padding: 30,
+          alignItems: 'center',
+          backgroundColor: theme.background.screen,
+        }}>
         <ActivityIndicator />
       </RNView>
     );
   }
 
   if (!props.data?.length) {
-    return <RNView style={{ flex: 1 }} />;
+    return <RNView style={{ flex: 1, backgroundColor: theme.background.screen }} />;
   }
 
   return <SnackList {...props} />;
@@ -41,6 +48,7 @@ export function SnackListView(props: Props) {
 function SnackList({ data, loadMoreAsync }: Props) {
   const [isLoadingMore, setLoadingMore] = React.useState(false);
   const isLoading = React.useRef<null | boolean>(false);
+  const theme = useExpoTheme();
 
   const extractKey = React.useCallback((item) => item.slug, []);
 
@@ -84,7 +92,12 @@ function SnackList({ data, loadMoreAsync }: Props) {
   }, []);
 
   return (
-    <View flex="1" padding="medium">
+    <View
+      flex="1"
+      padding="medium"
+      style={{
+        backgroundColor: theme.background.screen,
+      }}>
       <View overflow="hidden" bg="default" border="hairline" rounded="large">
         <FlatList
           data={data}

--- a/yarn.lock
+++ b/yarn.lock
@@ -16985,11 +16985,6 @@ react-native-paper@^4.0.1:
     color "^3.1.2"
     react-native-iphone-x-helper "^1.3.1"
 
-react-native-primitives@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/react-native-primitives/-/react-native-primitives-0.1.3.tgz#ff9548adfcaacb2f2b6a34a078d2643903e17e3d"
-  integrity sha512-slhBFw6vKsq76f4G4N4cXL/g3UPq22Fgl2atmSxgGJZs5JK5SPTNbP4AvIcnt72Selj0k9/5fAMFvpUq8qsVbQ==
-
 react-native-reanimated@~2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-2.3.1.tgz#c7abad48f9e6c84610b0d5e270088ecd61750382"


### PR DESCRIPTION
# Why

Will and I found some things to fix when trying `home` out.

# How

- I fixed a problem where if your list of accounts was long or your screen was small (or both), the flatlist would push the Log Out button offscreen
- I fixed a few pages where the background color was inconsistent
- I fixed text truncation problems for list items with user-generated content
- `et publish-dev-home` so people building on main get these changes

# Test Plan

Go to the accounts modal while logged in and make sure that the log out button is visible on small screens:

![Screen Shot 2022-03-30 at 18 29 14](https://user-images.githubusercontent.com/12488826/160941599-3ca719ae-2634-45be-868e-4ce7ab3060ae.png)

Visiting the projects list page (press the "see more projects" button from the homepage) or any other page in general and it should have a consistent background color. Previously it would go from the gray-ish color on the homepage to an almost-black background color on screens that weren't properly treated.