### PR TITLE
[android] remove jcenter

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -56,7 +56,6 @@ allprojects {
         excludeGroup "com.facebook.react"
       }
     }
-    jcenter()
     maven {
       // Local Maven repo containing AARs with JSC built for Android
       url "$rootDir/../node_modules/jsc-android/dist"

--- a/apps/bare-expo/android/build.gradle
+++ b/apps/bare-expo/android/build.gradle
@@ -84,7 +84,6 @@ allprojects {
                 excludeGroup "com.facebook.react"
             }
         }
-        jcenter()
         maven { url 'https://jitpack.io' }
     }
 }

--- a/packages/expo-ads-facebook/CHANGELOG.md
+++ b/packages/expo-ads-facebook/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Update `fbemitter` to v3. ([#16245](https://github.com/expo/expo/pull/16245) by [@SimenB](https://github.com/SimenB))
+- Removed the unused `jcenter()` maven dependencies. ([#16846](https://github.com/expo/expo/pull/16846) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-ads-facebook/android/build.gradle
+++ b/packages/expo-ads-facebook/android/build.gradle
@@ -79,7 +79,6 @@ android {
 
 repositories {
   mavenCentral()
-  jcenter()
 }
 
 dependencies {

--- a/packages/expo-dev-client/CHANGELOG.md
+++ b/packages/expo-dev-client/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Removed the unused `jcenter()` maven dependencies. ([#16846](https://github.com/expo/expo/pull/16846) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 0.8.4 — 2022-02-07

--- a/packages/expo-dev-client/android/build.gradle
+++ b/packages/expo-dev-client/android/build.gradle
@@ -88,7 +88,6 @@ repositories {
     url "$rootDir/../node_modules/jsc-android/dist"
   }
   google()
-  jcenter()
 }
 
 dependencies {

--- a/packages/expo-dev-client/android/build.gradle
+++ b/packages/expo-dev-client/android/build.gradle
@@ -120,7 +120,7 @@ dependencies {
   androidTestImplementation "androidx.appcompat:appcompat:1.1.0"
 
   androidTestImplementation "com.google.truth:truth:1.1.2"
-  androidTestImplementation 'io.mockk:mockk-android:1.10.6'
+  androidTestImplementation 'io.mockk:mockk-android:1.12.3'
 
   // Fixes "e: java.lang.AssertionError: No such enum entry LIBRARY_GROUP_PREFIX in org.jetbrains.kotlin.ir.types.impl.IrSimpleTypeImpl@b254b575"
   // According to the https://stackoverflow.com/a/67736351

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -20,6 +20,7 @@
 ### 🐛 Bug fixes
 
 - Fix `androidNavigationBar` app.json config settings having no effect at runtime ([#15030](https://github.com/expo/expo/issues/15030)). ([#16711](https://github.com/expo/expo/pull/16711) by [@esamelson](https://github.com/esamelson))
+- Removed the unused `jcenter()` maven dependencies. ([#16846](https://github.com/expo/expo/pull/16846) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/android/build.gradle
+++ b/packages/expo-dev-launcher/android/build.gradle
@@ -120,7 +120,6 @@ repositories {
     url "$rootDir/../node_modules/jsc-android/dist"
   }
   google()
-  jcenter()
 }
 
 dependencies {

--- a/packages/expo-eas-client-id/android/build.gradle
+++ b/packages/expo-eas-client-id/android/build.gradle
@@ -98,5 +98,5 @@ dependencies {
   androidTestImplementation 'androidx.test:runner:1.1.0'
   androidTestImplementation 'androidx.test:core:1.0.0'
   androidTestImplementation 'androidx.test:rules:1.1.0'
-  androidTestImplementation 'io.mockk:mockk-android:1.10.6'
+  androidTestImplementation 'io.mockk:mockk-android:1.12.3'
 }

--- a/packages/expo-image/android/build.gradle
+++ b/packages/expo-image/android/build.gradle
@@ -38,7 +38,6 @@ buildscript {
   if (project == rootProject) {
     repositories {
       google()
-      jcenter()
     }
     dependencies {
       classpath 'com.android.tools.build:gradle:4.2.2'

--- a/packages/expo-in-app-purchases/CHANGELOG.md
+++ b/packages/expo-in-app-purchases/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Removed the unused `jcenter()` maven dependencies. ([#16846](https://github.com/expo/expo/pull/16846) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 12.1.1 - 2022-02-01

--- a/packages/expo-in-app-purchases/android/build.gradle
+++ b/packages/expo-in-app-purchases/android/build.gradle
@@ -81,7 +81,6 @@ android {
 allprojects {
   repositories {
     google()
-    jcenter()
   }
 }
 

--- a/packages/expo-json-utils/android/build.gradle
+++ b/packages/expo-json-utils/android/build.gradle
@@ -85,14 +85,14 @@ dependencies {
   testImplementation 'junit:junit:4.12'
   testImplementation 'androidx.test:core:1.0.0'
   testImplementation 'org.mockito:mockito-core:1.10.19'
-  testImplementation 'io.mockk:mockk:1.10.6'
+  testImplementation 'io.mockk:mockk:1.12.3'
 
   androidTestImplementation 'org.amshove.kluent:kluent-android:1.68'
   androidTestImplementation 'androidx.test:runner:1.1.0'
   androidTestImplementation 'androidx.test:core:1.0.0'
   androidTestImplementation 'androidx.test:rules:1.1.0'
   androidTestImplementation 'org.mockito:mockito-android:3.7.7'
-  androidTestImplementation 'io.mockk:mockk-android:1.10.6'
+  androidTestImplementation 'io.mockk:mockk-android:1.12.3'
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
 }

--- a/packages/expo-manifests/android/build.gradle
+++ b/packages/expo-manifests/android/build.gradle
@@ -90,13 +90,13 @@ dependencies {
   testImplementation 'junit:junit:4.12'
   testImplementation 'androidx.test:core:1.0.0'
   testImplementation 'org.mockito:mockito-core:1.10.19'
-  testImplementation 'io.mockk:mockk:1.10.6'
+  testImplementation 'io.mockk:mockk:1.12.3'
 
   androidTestImplementation 'androidx.test:runner:1.1.0'
   androidTestImplementation 'androidx.test:core:1.0.0'
   androidTestImplementation 'androidx.test:rules:1.1.0'
   androidTestImplementation 'org.mockito:mockito-android:3.7.7'
-  androidTestImplementation 'io.mockk:mockk-android:1.10.6'
+  androidTestImplementation 'io.mockk:mockk-android:1.12.3'
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
 }

--- a/packages/expo-updates/android/build.gradle
+++ b/packages/expo-updates/android/build.gradle
@@ -131,13 +131,13 @@ dependencies {
 
   testImplementation 'junit:junit:4.13.1'
   testImplementation 'androidx.test:core:1.4.0'
-  testImplementation 'io.mockk:mockk:1.12.0'
+  testImplementation 'io.mockk:mockk:1.12.3'
   testImplementation "org.jetbrains.kotlin:kotlin-test-junit:${getKotlinVersion()}"
 
   androidTestImplementation 'androidx.test:runner:1.4.0'
   androidTestImplementation 'androidx.test:core:1.4.0'
   androidTestImplementation 'androidx.test:rules:1.4.0'
-  androidTestImplementation 'io.mockk:mockk-android:1.12.0'
+  androidTestImplementation 'io.mockk:mockk-android:1.12.3'
   androidTestImplementation "androidx.room:room-testing:$room_version"
   androidTestImplementation "org.jetbrains.kotlin:kotlin-test-junit:${getKotlinVersion()}"
 

--- a/templates/expo-template-bare-minimum/android/build.gradle
+++ b/templates/expo-template-bare-minimum/android/build.gradle
@@ -11,7 +11,6 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
     dependencies {
         classpath("com.android.tools.build:gradle:4.2.2")
@@ -41,7 +40,6 @@ allprojects {
                 excludeGroup "com.facebook.react"
             }
         }
-        jcenter()
         maven { url 'https://www.jitpack.io' }
     }
 }


### PR DESCRIPTION
# Why

jcenter caused some downtime issues, let's remove it.

# How

remove all `jcenter()` from gradles files.

# Test Plan

- android bare-expo build
- android versioned expo-go build

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
