### PR TITLE
[android][av] Fix cast exceptions on ReactContext in Expo Go

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/services/UIManagerModuleWrapper.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/services/UIManagerModuleWrapper.java
@@ -6,6 +6,7 @@ import android.util.Log;
 import android.view.View;
 
 import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.turbomodule.core.CallInvokerHolderImpl;
 import com.facebook.react.uimanager.IllegalViewOperationException;
 import com.facebook.react.uimanager.NativeViewHierarchyManager;
 import com.facebook.react.uimanager.UIManagerModule;
@@ -115,6 +116,14 @@ public class UIManagerModuleWrapper implements
     }
   }
 
+  public void runOnNativeModulesQueueThread(Runnable runnable) {
+    if (mReactContext.isOnNativeModulesQueueThread()) {
+      runnable.run();
+    } else {
+      mReactContext.runOnNativeModulesQueueThread(runnable);
+    }
+  }
+
 
   @Override
   public void registerLifecycleEventListener(final LifecycleEventListener listener) {
@@ -186,6 +195,10 @@ public class UIManagerModuleWrapper implements
 
   public long getJavaScriptContextRef() {
     return mReactContext.getJavaScriptContextHolder().get();
+  }
+
+  public CallInvokerHolderImpl getJSCallInvokerHolder() {
+    return (CallInvokerHolderImpl) mReactContext.getCatalystInstance().getJSCallInvokerHolder();
   }
 
   @Override

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/core/interfaces/JavaScriptContextProvider.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/core/interfaces/JavaScriptContextProvider.java
@@ -1,5 +1,9 @@
 package expo.modules.core.interfaces;
 
+import com.facebook.react.turbomodule.core.CallInvokerHolderImpl;
+
 public interface JavaScriptContextProvider {
   long getJavaScriptContextRef();
+
+  CallInvokerHolderImpl getJSCallInvokerHolder();
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/core/interfaces/services/UIManager.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/core/interfaces/services/UIManager.java
@@ -28,6 +28,8 @@ public interface UIManager {
 
   void runOnClientCodeQueueThread(Runnable runnable);
 
+  void runOnNativeModulesQueueThread(Runnable runnable);
+
   void registerLifecycleEventListener(LifecycleEventListener listener);
 
   void unregisterLifecycleEventListener(LifecycleEventListener listener);


### PR DESCRIPTION
# Why

#16611 and #16075 needed to cast `Context` to `ReactContext`, however in Expo Go the context that is passed to the native modules is a `ScopedContext` that doesn't extend `ReactContext`. Those PRs would work only outside of Expo Go then.

# How

Added necessary methods to `UIManager` and `JavaScriptContextProvider` so we no longer need to cast the context.

# Test Plan

Expo Go compiles, runs and expo-av examples in NCL seem to work as expected
