### PR TITLE
[docs] Update iOS build infrastructure description.

### DIFF
--- a/docs/pages/build-reference/infrastructure.md
+++ b/docs/pages/build-reference/infrastructure.md
@@ -105,10 +105,10 @@ When selecting an image for the build you can use the full name provided below o
 
 ## iOS build server configurations
 
-- iOS worker VMs run on Macs Pro 6.1 in an isolated environment
+- iOS worker VMs run on Mac Mini 8.1 hosts in an isolated environment
   - Every build gets its own fresh macOS VM
-  - Hardware: Intel(R) Xeon(R) CPU E5-2697 (12 core/24 threads), 64 GB RAM
-  - Build resource limits: 6 cores, 12 GB RAM
+  - Hardware: Intel(R) Core(TM) i7-8700B CPU (6 cores/12 threads), 64 GB RAM
+  - Build resource limits: 3 cores, 12 GB RAM
 - npm cache. [Learn more](caching/#javascript-dependencies)
 - `~/.npmrc`
 


### PR DESCRIPTION
# Why

The current documentation is out of date.

# How

Updated the iOS build server description to reflect the current set up.

# Test Plan

Built docs and check on local server.

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
