### PR TITLE
fix(build-configuration): typo on step number

### DIFF
--- a/docs/pages/build-reference/build-configuration.md
+++ b/docs/pages/build-reference/build-configuration.md
@@ -57,7 +57,7 @@ In the example above, we defined exactly the same Android application id and iOS
 
 There are no additional steps for bare workflow projects.
 
-#### 5. Next steps
+#### 4. Next steps
 
 That's all there is to configuring a project to be compatible with EAS Build.
 There is one final step if you set `cli.requireCommit` to `true` in your **eas.json** — you'll be prompted to commit all the changes we made for you. You can choose to review them before committing, and you can either specify the git commit message or use a default message.


### PR DESCRIPTION
# Why

Reading the documentation without a step 4 is confusing to the person reading.

# How

Just a text update :)

# Test Plan

N/A

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
