### PR TITLE
[expo-updates][expo-dev-launcher] add ability to launch a specific update

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Compatibility with expo-dev-menu auto-setup on iOS. ([#16496](https://github.com/expo/expo/pull/16496) by [@esamelson](https://github.com/esamelson))
 - Remove initialization side effects. ([#16522](https://github.com/expo/expo/pull/16522) by [@esamelson](https://github.com/esamelson))
 - Use expo-manifests `logUrl` getter instead of accessing raw JSON. ([#16709](https://github.com/expo/expo/pull/16709) by [@esamelson](https://github.com/esamelson))
+- Add ability for to launch a specific update through expo-updates-interface. ([#16865](https://github.com/expo/expo/pull/16865) by [@esamelson](https://github.com/esamelson))
 
 ## 0.10.4 — 2022-02-07
 

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherAppLoaderFactory.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherAppLoaderFactory.kt
@@ -45,7 +45,7 @@ class DevLauncherAppLoaderFactory : DevLauncherKoinComponent, DevLauncherAppLoad
         }
         DevLauncherLocalAppLoader(manifest!!, appHost, context, controller)
       } else {
-        val configuration = createUpdatesConfigurationWithUrl(url, installationIDHelper.getOrCreateInstallationID(context))
+        val configuration = createUpdatesConfigurationWithUrl(url, url, installationIDHelper.getOrCreateInstallationID(context))
         val update = updatesInterface!!.loadUpdate(configuration, context) {
           manifest = Manifest.fromManifestJson(it) // TODO: might be able to pass actual manifest object in here
           return@loadUpdate !manifest!!.isUsingDeveloperTool()

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/helpers/DevLauncherUpdatesHelper.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/helpers/DevLauncherUpdatesHelper.kt
@@ -40,7 +40,7 @@ suspend fun UpdatesInterface.loadUpdate(
     })
   }
 
-fun createUpdatesConfigurationWithUrl(url: Uri, installationID: String?): HashMap<String, Any> {
+fun createUpdatesConfigurationWithUrl(url: Uri, projectUrl: Uri, installationID: String?): HashMap<String, Any> {
   val requestHeaders = hashMapOf(
     "Expo-Updates-Environment" to "DEVELOPMENT"
   )
@@ -49,7 +49,7 @@ fun createUpdatesConfigurationWithUrl(url: Uri, installationID: String?): HashMa
   }
   return hashMapOf(
     "updateUrl" to url,
-    "scopeKey" to url.toString(),
+    "scopeKey" to projectUrl.toString(),
     "hasEmbeddedUpdate" to false,
     "launchWaitMs" to 60000,
     "checkOnLaunch" to "ALWAYS",

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParser.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParser.kt
@@ -20,7 +20,7 @@ class DevLauncherManifestParser(
     // published projects may respond unsuccessfully to HEAD requests sent with no headers
     return !response.isSuccessful
         || response.header("Exponent-Server", null) != null
-        || (contentType != null && contentType.startsWith("application/json"))
+        || (contentType != null && !contentType.startsWith("text/html") && !contentType.contains("/javascript"))
   }
 
   private suspend fun downloadManifest(): Reader {

--- a/packages/expo-dev-launcher/android/src/test/java/expo/modules/devlauncher/helpers/DevLauncherUpdatesHelperTest.kt
+++ b/packages/expo-dev-launcher/android/src/test/java/expo/modules/devlauncher/helpers/DevLauncherUpdatesHelperTest.kt
@@ -18,7 +18,8 @@ import org.robolectric.RobolectricTestRunner
 internal class DevLauncherUpdatesHelperTest {
 
   private val context: Context = ApplicationProvider.getApplicationContext()
-  private val configuration = createUpdatesConfigurationWithUrl(Uri.parse("https://exp.host/@esamelson/sdk42updates"), null)
+  private val url = Uri.parse("https://exp.host/@esamelson/sdk42updates")
+  private val configuration = createUpdatesConfigurationWithUrl(url, url, null)
   private val mockManifest = JSONObject("{\"icon\":\"./assets/icon.png\",\"name\":\"sdk42updates\",\"slug\":\"sdk42updates\",\"splash\":{\"image\":\"./assets/splash.png\",\"imageUrl\":\"https://classic-assets.eascdn.net/~assets/201a91bd1740bb1d6a1dbad049310724\",\"resizeMode\":\"contain\",\"backgroundColor\":\"#ffffff\"},\"iconUrl\":\"https://classic-assets.eascdn.net/~assets/4e3f888fc8475f69fd5fa32f1ad5216a\",\"version\":\"1.0.0\",\"sdkVersion\":\"42.0.0\",\"orientation\":\"portrait\",\"currentFullName\":\"@esamelson/sdk42updates\",\"originalFullName\":\"@esamelson/sdk42updates\",\"id\":\"@esamelson/sdk42updates\",\"projectId\":\"04e1e9f2-b297-44da-a11c-90a6a27859bc\",\"scopeKey\":\"@esamelson/sdk42updates\",\"releaseId\":\"a2b0a544-40f0-4fd6-9972-19f094380681\",\"publishedTime\":\"2021-07-13T22:29:24.170Z\",\"commitTime\":\"2021-07-13T22:29:24.209Z\",\"bundleUrl\":\"https://classic-assets.eascdn.net/%40esamelson%2Fsdk42updates%2F1.0.0%2F8c3e605420e77ba9fe35a0a7ef8459a9-42.0.0-ios.js\",\"bundleKey\":\"8c3e605420e77ba9fe35a0a7ef8459a9\",\"releaseChannel\":\"default\",\"hostUri\":\"exp.host/@esamelson/sdk42updates\"}")
   private val mockUpdate = object : UpdatesInterface.Update {
     override fun getManifest(): JSONObject = mockManifest
@@ -65,10 +66,12 @@ internal class DevLauncherUpdatesHelperTest {
   @Test
   fun `createUpdatesConfiguration sets the correct value for scopeKey`() {
     val urlString1 = "https://exp.host/@test/first-app"
-    val configuration1 = createUpdatesConfigurationWithUrl(Uri.parse(urlString1), null)
+    val url1 = Uri.parse(urlString1)
+    val configuration1 = createUpdatesConfigurationWithUrl(url1, url1, null)
 
     val urlString2 = "https://exp.host/@test/second-app"
-    val configuration2 = createUpdatesConfigurationWithUrl(Uri.parse(urlString2), null)
+    val url2 = Uri.parse(urlString2)
+    val configuration2 = createUpdatesConfigurationWithUrl(url2, url2, null)
 
     val scopeKey1 = configuration1["scopeKey"]
     val scopeKey2 = configuration2["scopeKey"]
@@ -78,9 +81,23 @@ internal class DevLauncherUpdatesHelperTest {
   }
 
   @Test
+  fun `createUpdatesConfiguration sets the correct scopeKey if projectUrl is different`() {
+    val url = Uri.parse("https://u.expo.dev/update/421ba616-9145-4236-8fe8-7be9f2782a30")
+    val projectUrlString = "https://u.expo.dev/2f662161-8616-4f16-9f88-911dfb2d3cd6?channel-name=production"
+    val configuration = createUpdatesConfigurationWithUrl(url, Uri.parse(projectUrlString), "test")
+
+    val configuredUrl = configuration["updateUrl"]
+    val configuredScopeKey = configuration["scopeKey"]
+    Truth.assertThat(configuredUrl).isNotEqualTo(configuredScopeKey)
+    Truth.assertThat(configuredUrl).isEqualTo(url)
+    Truth.assertThat(configuredScopeKey).isEqualTo(projectUrlString)
+  }
+
+  @Test
   fun `createUpdatesConfiguration sets the correct header for installationID`() {
     val installationID = "test-installation-id"
-    val configuration = createUpdatesConfigurationWithUrl(Uri.parse("https://exp.host/@test/test"), installationID)
+    val url = Uri.parse("https://exp.host/@test/test")
+    val configuration = createUpdatesConfigurationWithUrl(url, url, installationID)
 
     Truth.assertThat((configuration["requestHeaders"] as HashMap<*, *>)["Expo-Dev-Client-ID"]).isEqualTo(installationID)
   }

--- a/packages/expo-dev-launcher/android/src/test/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParserTest.kt
+++ b/packages/expo-dev-launcher/android/src/test/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParserTest.kt
@@ -63,6 +63,15 @@ internal class DevLauncherManifestParserTest {
     Truth.assertThat(manifestParser.isManifestUrl()).isTrue()
 
     server.enqueue(MockResponse().setResponseCode(200)
+      .setHeader("Content-Type", "multipart/mixed"))
+    Truth.assertThat(manifestParser.isManifestUrl()).isTrue()
+
+    // content-type from EAS Update manifest
+    server.enqueue(MockResponse().setResponseCode(200)
+      .setHeader("Content-Type", "text/plain; charset=utf-8"))
+    Truth.assertThat(manifestParser.isManifestUrl()).isTrue()
+
+    server.enqueue(MockResponse().setResponseCode(200)
         .setHeader("Content-Type", "application/javascript"))
     Truth.assertThat(manifestParser.isManifestUrl()).isFalse()
 

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -297,6 +297,7 @@
   expoUrl = [EXDevLauncherURLHelper replaceEXPScheme:expoUrl to:@"http"];
 
   NSDictionary *updatesConfiguration = [EXDevLauncherUpdatesHelper createUpdatesConfigurationWithURL:expoUrl
+                                                                                          projectURL:expoUrl
                                                                                       installationID:installationID];
 
   void (^launchReactNativeApp)(void) = ^{

--- a/packages/expo-dev-launcher/ios/EXDevLauncherUpdatesHelper.h
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherUpdatesHelper.h
@@ -7,6 +7,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface EXDevLauncherUpdatesHelper : NSObject
 
 + (NSDictionary *)createUpdatesConfigurationWithURL:(NSURL *)url
+                                         projectURL:(NSURL *)projectURL
                                      installationID:(NSString *)installationID;
 
 @end

--- a/packages/expo-dev-launcher/ios/EXDevLauncherUpdatesHelper.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherUpdatesHelper.m
@@ -7,6 +7,7 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation EXDevLauncherUpdatesHelper
 
 + (NSDictionary *)createUpdatesConfigurationWithURL:(NSURL *)url
+                                         projectURL:(NSURL *)projectURL
                                      installationID:(NSString *)installationID
 {
   NSMutableDictionary *requestHeaders = @{@"Expo-Updates-Environment": @"DEVELOPMENT"}.mutableCopy;
@@ -14,10 +15,9 @@ NS_ASSUME_NONNULL_BEGIN
     requestHeaders[@"Expo-Dev-Client-ID"] = installationID;
   }
 
-  NSString *urlString = url.absoluteString;
   return @{
-    @"EXUpdatesURL": urlString,
-    @"EXUpdatesScopeKey": urlString,
+    @"EXUpdatesURL": url.absoluteString,
+    @"EXUpdatesScopeKey": projectURL.absoluteString,
     @"EXUpdatesLaunchWaitMs": @(60000),
     @"EXUpdatesCheckOnLaunch": @"ALWAYS",
     @"EXUpdatesHasEmbeddedUpdate": @(NO),

--- a/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestParser.m
+++ b/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestParser.m
@@ -55,7 +55,8 @@ typedef void (^CompletionHandler)(NSData *data, NSURLResponse *response);
       return;
     }
 
-    if ([headers[@"Content-Type"] hasPrefix:@"application/json"]) {
+    NSString *contentType = headers[@"Content-Type"];
+    if (contentType && ![contentType hasPrefix:@"text/html"] && ![contentType containsString:@"/javascript"]) {
       completion(YES);
       return;
     }

--- a/packages/expo-dev-launcher/ios/Tests/EXDevLauncherManifestParserTests.m
+++ b/packages/expo-dev-launcher/ios/Tests/EXDevLauncherManifestParserTests.m
@@ -58,6 +58,16 @@
     return [HTTPStubsResponse responseWithData:[NSData new] statusCode:200 headers:@{@"Content-Type": @"application/json; charset=UTF-8"}];
   }];
   [HTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest * _Nonnull request) {
+    return [request.URL.host isEqualToString:@"ohhttpstubs"] && [request.URL.path isEqualToString:@"/multipart"];
+  } withStubResponse:^HTTPStubsResponse * _Nonnull(NSURLRequest * _Nonnull request) {
+    return [HTTPStubsResponse responseWithData:[NSData new] statusCode:200 headers:@{@"Content-Type": @"multipart/mixed"}];
+  }];
+  [HTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest * _Nonnull request) {
+    return [request.URL.host isEqualToString:@"ohhttpstubs"] && [request.URL.path isEqualToString:@"/plaintext"];
+  } withStubResponse:^HTTPStubsResponse * _Nonnull(NSURLRequest * _Nonnull request) {
+    return [HTTPStubsResponse responseWithData:[NSData new] statusCode:200 headers:@{@"Content-Type": @"text/plain; charset=utf-8"}];
+  }];
+  [HTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest * _Nonnull request) {
     return [request.URL.host isEqualToString:@"ohhttpstubs"] && [request.URL.path isEqualToString:@"/js1"];
   } withStubResponse:^HTTPStubsResponse * _Nonnull(NSURLRequest * _Nonnull request) {
     return [HTTPStubsResponse responseWithData:[NSData new] statusCode:200 headers:@{@"Content-Type": @"application/javascript"}];
@@ -75,6 +85,8 @@
 
   [self _testIsManifestURLString:@"http://ohhttpstubs/json1" expected:YES description:@"should assume a JSON content-type indicates a manifest URL"];
   [self _testIsManifestURLString:@"http://ohhttpstubs/json2" expected:YES description:@"should assume a JSON content-type indicates a manifest URL"];
+  [self _testIsManifestURLString:@"http://ohhttpstubs/multipart" expected:YES description:@"should assume a multipart content-type indicates a manifest URL"];
+  [self _testIsManifestURLString:@"http://ohhttpstubs/plaintext" expected:YES description:@"should assume a plaintext content-type indicates a (multipart) manifest URL"];
   [self _testIsManifestURLString:@"http://ohhttpstubs/js1" expected:NO description:@"should assume a javascript content-type indicates a bundler server"];
   [self _testIsManifestURLString:@"http://ohhttpstubs/js2" expected:NO description:@"should assume a javascript content-type indicates a bundler server"];
 

--- a/packages/expo-dev-launcher/ios/Tests/EXDevLauncherUpdatesHelperTests.m
+++ b/packages/expo-dev-launcher/ios/Tests/EXDevLauncherUpdatesHelperTests.m
@@ -13,10 +13,12 @@
 - (void)testCreateUpdatesConfiguration_scopeKey
 {
   NSString *urlString1 = @"https://exp.host/@test/first-app";
-  NSDictionary *configuration1 = [EXDevLauncherUpdatesHelper createUpdatesConfigurationWithURL:[NSURL URLWithString:urlString1] installationID:@"test-installation-id"];
+  NSURL *url1 = [NSURL URLWithString:urlString1];
+  NSDictionary *configuration1 = [EXDevLauncherUpdatesHelper createUpdatesConfigurationWithURL:url1 projectURL:url1 installationID:@"test-installation-id"];
 
   NSString *urlString2 = @"https://exp.host/@test/second-app";
-  NSDictionary *configuration2 = [EXDevLauncherUpdatesHelper createUpdatesConfigurationWithURL:[NSURL URLWithString:urlString2] installationID:@"test-installation-id"];
+  NSURL *url2 = [NSURL URLWithString:urlString2];
+  NSDictionary *configuration2 = [EXDevLauncherUpdatesHelper createUpdatesConfigurationWithURL:url2 projectURL:url2 installationID:@"test-installation-id"];
 
   NSString *scopeKey1 = configuration1[@"EXUpdatesScopeKey"];
   NSString *scopeKey2 = configuration2[@"EXUpdatesScopeKey"];
@@ -25,10 +27,25 @@
   XCTAssertEqualObjects(urlString2, scopeKey2);
 }
 
+- (void)testCreateUpdatesConfiguration_differentProjectURL
+{
+  NSString *urlString = @"https://u.expo.dev/update/421ba616-9145-4236-8fe8-7be9f2782a30";
+  NSString *projectURLString = @"https://u.expo.dev/2f662161-8616-4f16-9f88-911dfb2d3cd6?channel-name=production";
+  NSDictionary *configuration = [EXDevLauncherUpdatesHelper createUpdatesConfigurationWithURL:[NSURL URLWithString:urlString] projectURL:[NSURL URLWithString:projectURLString] installationID:@"test"];
+
+  NSString *updatesURL = configuration[@"EXUpdatesURL"];
+  NSString *updatesScopeKey = configuration[@"EXUpdatesScopeKey"];
+
+  XCTAssertNotEqualObjects(updatesURL, updatesScopeKey);
+  XCTAssertEqualObjects(urlString, updatesURL);
+  XCTAssertEqualObjects(projectURLString, updatesScopeKey);
+}
+
 - (void)testCreateUpdatesConfiguration_installationID
 {
   NSString *installationID = @"test-installation-id";
-  NSDictionary *configuration = [EXDevLauncherUpdatesHelper createUpdatesConfigurationWithURL:[NSURL URLWithString:@"https://exp.host/@test/test"] installationID:installationID];
+  NSURL *url = [NSURL URLWithString:@"https://exp.host/@test/test"];
+  NSDictionary *configuration = [EXDevLauncherUpdatesHelper createUpdatesConfigurationWithURL:url projectURL:url installationID:installationID];
 
   NSDictionary *requestHeaders = configuration[@"EXUpdatesRequestHeaders"];
   XCTAssertNotNil(requestHeaders);

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 - Updated `@expo/config-plugins` from `4.0.2` to `4.0.14`, `@expo/config` from `^6.0.6` to `^6.0.14` and `@expo/metro-config` from `~0.2.6` to `~0.3.7` ([#15621](https://github.com/expo/expo/pull/15621) by [@EvanBacon](https://github.com/EvanBacon))
 - Swap out Cloudfront CDN for `classic-assets.eascdn.net`. ([#15781](https://github.com/expo/expo/pull/15781)) by [@quinlanj](https://github.com/quinlanj)
+- Add ability for expo-dev-launcher to launch a specific update through UpdatesDevLauncherController. ([#16865](https://github.com/expo/expo/pull/16865) by [@esamelson](https://github.com/esamelson))
 
 ## 0.11.7 — 2022-03-07
 


### PR DESCRIPTION
# Why

resolves ENG-4112

# How

expo-updates:
- use the `LauncherSelectionPolicySingleUpdate`, which was previously added for this purpose, to ensure that when the dev launcher instructs updates to download a new update, we then subsequently launch that same update. (This wasn't needed previously because we could always assume that the manifest we received from the server was the newest one; now we might explicitly want to load/launch an older update.)

expo-dev-launcher:
- add a separate `projectURL` parameter to the updates configuration helper. This is needed to ensure that manifests downloaded from the `manifestPermalink` endpoint have the same scope key as manifests downloaded from the normal endpoint. (for now the value is the same, but that won't be the case for requests from the new EAS Update UI.)
- fix compatibility with EAS Update multipart manifests, which have a content-type we hadn't yet considered. I inverted the logic so that only requests with a `text/html` or `.../javascript` header are assumed to be from `react-native start`, rather than assuming that by default.

# Test Plan

All existing unit tests pass, and added a few more test cases.

Tested manually by loading some EAS updates in a dev client (both platforms):
✅ Can load a published update using a normal EAS Update URL (`https://u.expo.dev/2f662161-8616-4f16-9f88-911dfb2d3cd6?channel-name=production`)
✅ Can load a published update using an EAS Update `manifestPermalink` (`https://u.expo.dev/update/6ac4d910-840f-4fff-8bd9-ec60e762cb86` for android)
✅ Using the `manifestPermalink` results in the correct update loading even if a newer update from the same channel/branch has already been published and loaded on the device
✅ When using the normal EAS Update URL, Updates module methods can be used to check, fetch, and reload with a new update (published after the initial update is running on the device)
❌ When using the `manifestPermalink`, Updates module methods do not work properly (always fail) --> this edge case will require some more work, tracking in ENG-4517

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
