### PR TITLE
[android] Exclude vendored libs from linting

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -125,6 +125,7 @@ subprojects {
     }
     kotlin {
       target(ktlintTarget)
+      targetExclude("**/versioned/host/exp/exponent/modules/api/**/*.kt")
       ktlint("0.41.0").userData([
         "disabled_rules"           : "no-wildcard-imports,import-ordering",
         "charset"                  : "utf-8",


### PR DESCRIPTION
# Why

Upgrading `react-native-webview` caused some ktlint issues that broke the CI: https://github.com/expo/expo/runs/5776761840
I think we shouldn't really care about the code style in the code that is pulled in from external repos.

# How

Added Gradle rule to exclude `**/versioned/host/exp/exponent/modules/api/**/*.kt` from being linted

# Test Plan

`./gradlew :expoview:spotlessKotlinCheck` passes
