### PR TITLE
[github] add `pending closure` label to invalid issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_cli.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_cli.yml
@@ -1,6 +1,6 @@
 name: "\U0001F41B CLI Bug Report"
 description: 'You want to report an issue with Expo CLI, our command line tool'
-labels: 'pending closure'
+labels: ['stale', 'pending closure']
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report_cli.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_cli.yml
@@ -1,5 +1,6 @@
 name: "\U0001F41B CLI Bug Report"
 description: 'You want to report an issue with Expo CLI, our command line tool'
+labels: 'pending closure'
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: "\U0001F64B Feature Request"
 description: 'Want us to add something to Expo?'
-labels: 'pending closure'
+labels: ['stale', 'pending closure']
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,6 @@
 name: "\U0001F64B Feature Request"
 description: 'Want us to add something to Expo?'
+labels: 'pending closure'
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/questions.yml
+++ b/.github/ISSUE_TEMPLATE/questions.yml
@@ -1,6 +1,6 @@
 name: '❓ Questions and discussions'
 description: 'You have a question about Expo or want to discuss some aspects of Expo'
-labels: 'pending closure'
+labels: ['stale', 'pending closure']
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/questions.yml
+++ b/.github/ISSUE_TEMPLATE/questions.yml
@@ -1,5 +1,6 @@
 name: '❓ Questions and discussions'
 description: 'You have a question about Expo or want to discuss some aspects of Expo'
+labels: 'pending closure'
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
# Why

Currently invalid issues doesn't have any label associated to them, so it's hard to distinguish them on the issues list.

# How

Add `pending closure` label to invalid issues automatically at creation.

# Test Plan

N/A
