### PR TITLE
Upgrade react-native-picker/picker to 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Package-specific changes not released in any SDK will be added here just before 
 - Updated `react-native-shared-element` from `0.8.3` to `0.8.4`. ([#16866](https://github.com/expo/expo/pull/16866) by [@brentvatne](https://github.com/brentvatne))
 - Updated `react-native-pager-view` from `5.4.9` to `5.4.15`. ([#16890](https://github.com/expo/expo/pull/16890) by [@brentvatne](https://github.com/brentvatne))
 - Updated `react-native-webview` from `11.15.0` to `11.18.1`. ([#16826](https://github.com/expo/expo/pull/16826) by [@tsapeta](https://github.com/tsapeta))
+- Updated `@react-native-picker/picker` from `2.2.1` to `2.4.0`. ([#16876](https://github.com/expo/expo/pull/16876) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🛠 Breaking changes
 

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -97,7 +97,7 @@
     "@react-native-community/slider": "4.1.12",
     "@react-native-community/viewpager": "5.0.11",
     "@react-native-masked-view/masked-view": "0.2.6",
-    "@react-native-picker/picker": "2.2.1",
+    "@react-native-picker/picker": "2.4.0",
     "@react-native-segmented-control/segmented-control": "2.4.0",
     "expo": "~44.0.0-alpha.0",
     "expo-camera": "~12.1.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -46,7 +46,7 @@
     "@react-native-community/netinfo": "7.1.3",
     "@react-native-community/slider": "4.1.12",
     "@react-native-masked-view/masked-view": "0.2.6",
-    "@react-native-picker/picker": "2.2.1",
+    "@react-native-picker/picker": "2.4.0",
     "@react-native-segmented-control/segmented-control": "2.4.0",
     "@react-navigation/bottom-tabs": "~5.11.1",
     "@react-navigation/drawer": "5.11.4",

--- a/ios/Exponent/Versioned/Core/Api/Components/Picker/RNCPickerManager.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/Picker/RNCPickerManager.m
@@ -42,5 +42,18 @@ RCT_CUSTOM_VIEW_PROPERTY(fontFamily, NSString, RNCPicker)
 {
   view.font = [RCTFont updateFont:view.font withFamily:json ?: defaultView.font.familyName];
 }
+RCT_CUSTOM_VIEW_PROPERTY(themeVariant, NSString, RNCPicker)
+{
+    if (@available(iOS 13.4, *)) {
+            if (json) {
+                if ([json isEqual:@"dark"])
+                    view.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
+                else if ([json isEqual:@"light"])
+                    view.overrideUserInterfaceStyle = UIUserInterfaceStyleLight;
+                else
+                    view.overrideUserInterfaceStyle = UIUserInterfaceStyleUnspecified;
+            }
+        }
+}
 
 @end

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -6,7 +6,7 @@
   "@react-native-community/netinfo": "7.1.3",
   "@react-native-community/slider": "4.1.12",
   "@react-native-community/viewpager": "5.0.11",
-  "@react-native-picker/picker": "2.2.1",
+  "@react-native-picker/picker": "2.4.0",
   "@react-native-segmented-control/segmented-control": "2.4.0",
   "@stripe/stripe-react-native": "0.2.3",
   "@unimodules/core": "~7.2.0",


### PR DESCRIPTION
# Why

Preparation for SDK45 release
Closes ENG-4510

# How

`et uvm -m @react-native-picker/picker -c 6047402737cb55592f658ca0db922bdb79b6b56f`

# Test Plan

Everything seem to work as expected in NCL