### PR TITLE
Support Facebook sdk version 12.1.0 and greater

### DIFF
--- a/packages/expo-facebook/ios/EXFacebook.podspec
+++ b/packages/expo-facebook/ios/EXFacebook.podspec
@@ -15,8 +15,13 @@ Pod::Spec.new do |s|
   s.static_framework = true
 
   s.dependency 'ExpoModulesCore'
-  s.dependency 'FacebookSDK/CoreKit', $FacebookSDKVersion || '9.2.0'
-  s.dependency 'FacebookSDK/LoginKit', $FacebookSDKVersion || '9.2.0'
+  if $FacebookSDKVersion && Pod::Version.new($FacebookSDKVersion) >= Pod::Version.new('12.1.0')
+    s.dependency 'FBSDKCoreKit', $FacebookSDKVersion
+    s.dependency 'FBSDKLoginKit', $FacebookSDKVersion
+  else
+    s.dependency 'FacebookSDK/CoreKit', $FacebookSDKVersion || '9.2.0'
+    s.dependency 'FacebookSDK/LoginKit', $FacebookSDKVersion || '9.2.0'
+  end
 
   # FacebookSDK is written in Swift, so must use this flag to import from it.
   s.pod_target_xcconfig = { 'CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES' => 'YES' }


### PR DESCRIPTION
# Why

The aggregate target(FacebookSDK) was deprecated(and removed) with version 12.1.0

# How

Make a version check to switch between using the Aggregate target and the individual targets. Technically could switch to just using `FBSDKCoreKit` and `FBSDKLoginKit`, but it may cause build issues if users were pinning `FacebookSDK` to a version in their Podfile's manually.

# Test Plan

Tested by locally modifying this file within node_modules and running `bundle exec pod update FBSDKCoreKit FBSDKLoginKit` inside the `ios` directory for a react native project using expo-facebook.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).

I would expect these expo builds to work correctly, but I didn't test it.
