### PR TITLE
[docs][linking] fix expo-linking documentation

### DIFF
--- a/docs/pages/guides/linking.md
+++ b/docs/pages/guides/linking.md
@@ -221,14 +221,14 @@ When [handling the URL that is used to open/foreground your app](#handling-urls-
 ```javascript
 _handleUrl = ({ url }) => {
   this.setState({ url });
-  let { path, queryParams } = Linking.parse(url);
-  alert(`Linked to app with path: ${path} and data: ${JSON.stringify(queryParams)}`);
+  let { hostname, path, queryParams } = Linking.parse(url);
+  alert(`Linked to app with hostname: ${hostname}, path: ${path} and data: ${JSON.stringify(queryParams)}`);
 };
 ```
 
 If you opened a URL like
-`myapp://path/into/app?hello=world`, this would alert
-`Linked to app with path: path/into/app and data: {hello: 'world'}`.
+`myapp://somepath/into/app?hello=world`, this would alert
+`Linked to app with hostname: somepath, path: into/app and data: {"hello":"world"}`.
 
 ### Example: linking back to your app from WebBrowser
 


### PR DESCRIPTION
Update docs for guides/Linking(expo-linking) https://docs.expo.dev/guides/linking/#passing-data-to-your-app-through-the


# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
in expo SDK 36 'parse()' method changed its behavior as described https://github.com/expo/expo/issues/6497

# How

<!--
How did you build this feature or fix this bug and why?
-->
just docs

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
