### PR TITLE
[tools] Support custom paths to package.json of vendored libs

### DIFF
--- a/tools/src/commands/UpdateVendoredModule.ts
+++ b/tools/src/commands/UpdateVendoredModule.ts
@@ -136,7 +136,8 @@ async function action(options: ActionOptions) {
 
     // Update dependency versions only for Expo Go target.
     if (options.updateDependencies !== false && target === EXPO_GO_TARGET) {
-      const packageJson = require(path.join(sourceDirectory, 'package.json')) as PackageJson;
+      const packageJsonPath = path.join(sourceDirectory, moduleConfig.packageJsonPath ?? 'package.json');
+      const packageJson = require(packageJsonPath) as PackageJson;
       const semverPrefix =
         (options.semverPrefix != null ? options.semverPrefix : moduleConfig.semverPrefix) || '';
       const newVersionRange = `${semverPrefix}${packageJson.version}`;

--- a/tools/src/vendoring/config/expoGoConfig.ts
+++ b/tools/src/vendoring/config/expoGoConfig.ts
@@ -251,6 +251,7 @@ const config: VendoringTargetConfig = {
     },
     '@react-native-community/slider': {
       source: 'https://github.com/callstack/react-native-slider',
+      packageJsonPath: 'src/package.json',
     },
   },
 };

--- a/tools/src/vendoring/types.ts
+++ b/tools/src/vendoring/types.ts
@@ -8,6 +8,7 @@ export type VendoringModulePlatformConfig<T = {}> = T & {
 export type VendoringModuleConfig = {
   source: string;
   semverPrefix?: string;
+  packageJsonPath?: string;
   ios?: VendoringModulePlatformConfig<{
     // this hook can do some transformation before running `pod ipc spec ...`.
     // use this hook as a workaround for some podspecs showing errors and violating json format.


### PR DESCRIPTION
# Why

Our vendoring script uses the root **package.json** to get the package version. Looks like `@react-native-community/slider` has moved it to [**src/package.json**](https://github.com/callstack/react-native-slider/blob/main/src/package.json). The root json no longer includes the package version.
This resulted in using `undefined` version by the vendoring script 😅

# How

Added `packageJsonPath` field to vendoring module config and used it to construct the path to **package.json**

# Test Plan

Ran `et uvm -m @react-native-community/slider` and confirmed it uses the newest version (that is set in repository's **src/package.json**)