### PR TITLE
Upgrade react-native-community/slider to 4.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Package-specific changes not released in any SDK will be added here just before 
 - Updated `react-native-pager-view` from `5.4.9` to `5.4.15`. ([#16890](https://github.com/expo/expo/pull/16890) by [@brentvatne](https://github.com/brentvatne))
 - Updated `react-native-webview` from `11.15.0` to `11.18.1`. ([#16826](https://github.com/expo/expo/pull/16826) by [@tsapeta](https://github.com/tsapeta))
 - Updated `@react-native-picker/picker` from `2.2.1` to `2.4.0`. ([#16876](https://github.com/expo/expo/pull/16876) by [@tsapeta](https://github.com/tsapeta))
+- Updated `@react-native-community/slider` from `4.1.12` to `4.2.1`.
 
 ### 🛠 Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Package-specific changes not released in any SDK will be added here just before 
 - Updated `react-native-pager-view` from `5.4.9` to `5.4.15`. ([#16890](https://github.com/expo/expo/pull/16890) by [@brentvatne](https://github.com/brentvatne))
 - Updated `react-native-webview` from `11.15.0` to `11.18.1`. ([#16826](https://github.com/expo/expo/pull/16826) by [@tsapeta](https://github.com/tsapeta))
 - Updated `@react-native-picker/picker` from `2.2.1` to `2.4.0`. ([#16876](https://github.com/expo/expo/pull/16876) by [@tsapeta](https://github.com/tsapeta))
-- Updated `@react-native-community/slider` from `4.1.12` to `4.2.1`.
+- Updated `@react-native-community/slider` from `4.1.12` to `4.2.1`. ([#16901](https://github.com/expo/expo/pull/16901) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🛠 Breaking changes
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/slider/ReactSlider.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/slider/ReactSlider.java
@@ -12,7 +12,6 @@ import android.graphics.BitmapFactory;
 import android.graphics.drawable.BitmapDrawable;
 import android.os.Build;
 import android.util.AttributeSet;
-import android.view.MotionEvent;
 import android.view.accessibility.AccessibilityEvent;
 import android.view.accessibility.AccessibilityManager;
 import androidx.appcompat.widget.AppCompatSeekBar;
@@ -55,6 +54,8 @@ public class ReactSlider extends AppCompatSeekBar {
    * component).
    */
   private double mValue = 0;
+
+  private boolean isSliding = false;
 
   /** If zero it's determined automatically. */
   private double mStep = 0;
@@ -99,6 +100,14 @@ public class ReactSlider extends AppCompatSeekBar {
     updateAll();
   }
 
+  boolean isSliding() {
+    return isSliding;
+  }
+
+  void isSliding(boolean isSliding) {
+    this.isSliding = isSliding;
+  }
+
   void setAccessibilityUnits(String accessibilityUnits) {
     mAccessibilityUnits = accessibilityUnits;
   }
@@ -141,17 +150,6 @@ public class ReactSlider extends AppCompatSeekBar {
       Timer timer = new Timer();
       timer.schedule(task, 1000);
     }
-  }
-
-  @Override
-  public boolean onTouchEvent(MotionEvent arg0) {
-    super.onTouchEvent(arg0);
-
-    if (arg0.getActionMasked() == MotionEvent.ACTION_DOWN && this.isEnabled() == false) {
-      announceForAccessibility("slider disabled");
-    }
-    // Returns: True if the view handled the hover event
-    return true;
   }
 
   public void setupAccessibility(int index) {

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/slider/ReactSliderManager.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/slider/ReactSliderManager.java
@@ -35,8 +35,6 @@ import javax.annotation.Nullable;
 
 /**
  * Manages instances of {@code ReactSlider}.
- *
- * Note that the slider is _not_ a controlled component.
  */
 public class ReactSliderManager extends SimpleViewManager<ReactSlider> {
 
@@ -87,26 +85,31 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> {
           reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(
               new ReactSliderEvent(
                   seekbar.getId(),
-                  ((ReactSlider) seekbar).toRealProgress(progress),
-                  fromUser));
+                  ((ReactSlider)seekbar).toRealProgress(progress), fromUser));
         }
 
         @Override
         public void onStartTrackingTouch(SeekBar seekbar) {
           ReactContext reactContext = (ReactContext) seekbar.getContext();
+          ((ReactSlider)seekbar).isSliding(true);
           reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(
               new ReactSlidingStartEvent(
                   seekbar.getId(),
-                  ((ReactSlider) seekbar).toRealProgress(seekbar.getProgress())));
+                  ((ReactSlider)seekbar).toRealProgress(seekbar.getProgress())));
         }
 
         @Override
         public void onStopTrackingTouch(SeekBar seekbar) {
           ReactContext reactContext = (ReactContext) seekbar.getContext();
+          ((ReactSlider)seekbar).isSliding(false);
           reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(
               new ReactSlidingCompleteEvent(
                   seekbar.getId(),
-                  ((ReactSlider) seekbar).toRealProgress(seekbar.getProgress())));
+                  ((ReactSlider)seekbar).toRealProgress(seekbar.getProgress())));
+          reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(
+              new ReactSliderEvent(
+                  seekbar.getId(),
+                  ((ReactSlider)seekbar).toRealProgress(seekbar.getProgress()), false));
         }
       };
 
@@ -147,11 +150,13 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> {
 
   @ReactProp(name = "value", defaultDouble = 0d)
   public void setValue(ReactSlider view, double value) {
-    view.setOnSeekBarChangeListener(null);
-    view.setValue(value);
-    view.setOnSeekBarChangeListener(ON_CHANGE_LISTENER);
-    if (view.isAccessibilityFocused() && Build.VERSION.SDK_INT > Build.VERSION_CODES.Q) {
-      view.setupAccessibility((int)value);
+    if (view.isSliding() == false) {
+      view.setOnSeekBarChangeListener(null);
+      view.setValue(value);
+      view.setOnSeekBarChangeListener(ON_CHANGE_LISTENER);
+      if (view.isAccessibilityFocused() && Build.VERSION.SDK_INT > Build.VERSION_CODES.Q) {
+        view.setupAccessibility((int)value);
+      }
     }
   }
 

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -657,7 +657,7 @@ PODS:
     - React-Core
   - react-native-segmented-control (2.4.0):
     - React-Core
-  - react-native-slider (4.1.12):
+  - react-native-slider (4.2.1):
     - React-Core
   - react-native-view-shot (3.1.2):
     - React
@@ -1442,7 +1442,7 @@ SPEC CHECKSUMS:
   react-native-netinfo: 42c0965fca99069b92e3f7360ab2d425985e5104
   react-native-safe-area-context: 584dc04881deb49474363f3be89e4ca0e854c057
   react-native-segmented-control: 06607462630512ff8eef652ec560e6235a30cc3e
-  react-native-slider: 6e9b86e76cce4b9e35b3403193a6432ed07e0c81
+  react-native-slider: 241935e3ea8e47599c317f512f96ee8de607d4cb
   react-native-view-shot: 4475fde003fe8a210053d1f98fb9e06c1d834e1c
   react-native-viewpager: b99b53127d830885917ef84809c5065edd614a78
   react-native-webview: 0b7bd2bffced115aefd393e1841babd9b9a557b1

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -94,7 +94,7 @@
     "@react-native-async-storage/async-storage": "~1.15.0",
     "@react-native-community/datetimepicker": "4.0.0",
     "@react-native-community/netinfo": "7.1.3",
-    "@react-native-community/slider": "4.1.12",
+    "@react-native-community/slider": "4.2.1",
     "@react-native-community/viewpager": "5.0.11",
     "@react-native-masked-view/masked-view": "0.2.6",
     "@react-native-picker/picker": "2.4.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -44,7 +44,7 @@
     "@react-native-async-storage/async-storage": "~1.15.0",
     "@react-native-community/datetimepicker": "4.0.0",
     "@react-native-community/netinfo": "7.1.3",
-    "@react-native-community/slider": "4.1.12",
+    "@react-native-community/slider": "4.2.1",
     "@react-native-masked-view/masked-view": "0.2.6",
     "@react-native-picker/picker": "2.4.0",
     "@react-native-segmented-control/segmented-control": "2.4.0",

--- a/ios/Exponent/Versioned/Core/Api/Components/Slider/RNCSlider.h
+++ b/ios/Exponent/Versioned/Core/Api/Components/Slider/RNCSlider.h
@@ -17,6 +17,7 @@
 
 @property (nonatomic, assign) float step;
 @property (nonatomic, assign) float lastValue;
+@property (nonatomic, assign) bool isSliding;
 
 @property (nonatomic, strong) UIImage *trackImage;
 @property (nonatomic, strong) UIImage *minimumTrackImage;

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -4,7 +4,7 @@
   "@react-native-community/datetimepicker": "4.0.0",
   "@react-native-masked-view/masked-view": "0.2.6",
   "@react-native-community/netinfo": "7.1.3",
-  "@react-native-community/slider": "4.1.12",
+  "@react-native-community/slider": "4.2.1",
   "@react-native-community/viewpager": "5.0.11",
   "@react-native-picker/picker": "2.4.0",
   "@react-native-segmented-control/segmented-control": "2.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3212,10 +3212,10 @@
   resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-7.1.3.tgz#518d753a9ac08f1e59562c5d4168193584fd7329"
   integrity sha512-E8q3yuges6NYhrXBDQdzwCnG0bBQXATRjs6fpTjRJ37nURmdpe4HLq1awvooG4ymGTpZhrx4elcs/aUM7PTgrA==
 
-"@react-native-community/slider@4.1.12":
-  version "4.1.12"
-  resolved "https://registry.yarnpkg.com/@react-native-community/slider/-/slider-4.1.12.tgz#279ff7bbe487af92ad95ec758a029a54569e2a62"
-  integrity sha512-CiuLZ2orueBiWHYxfaJF57jQY6HY2Q3z5pdAE4MKH8EqIImr/jgDJrJ/UxOVZHK1Ng9P+XlGIKfVIcuWZ6guuA==
+"@react-native-community/slider@4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@react-native-community/slider/-/slider-4.2.1.tgz#8f1c8cf62de1bd91ce1e32585f7eb666f21e5025"
+  integrity sha512-6HUS5HbB9bvEN4GiwBlxECgPWQIugHE+kfnxqX2jHUl1SE57MRpw00m1qVs4hXtEPQndBl6mAQiGbKCOtLPVbg==
 
 "@react-native-community/viewpager@5.0.11":
   version "5.0.11"


### PR DESCRIPTION
# Why

Preparation for SDK45 release
Closes ENG-4511

# How

`et uvm -m @react-native-community/slider -c 470288ca40b77cd538ed1c8101fe63f332d47d02`

# Test Plan

NCL examples seem to work as expected
