### PR TITLE
[docs][audio] Backport JSI Audio docs

### DIFF
--- a/docs/pages/versions/unversioned/sdk/audio.md
+++ b/docs/pages/versions/unversioned/sdk/audio.md
@@ -340,6 +340,13 @@ On the `soundObject` reference, the following API is provided:
 
   - **onMetadataUpdate (_function_)** -- A function taking a single object of type `AVMetadata` (described below) as a parameter.
 
+- `soundObject.setOnAudioSampleReceived(callback)`
+  Sets a function to be called during playback, receiving the audio sample as parameter.
+
+  #### Parameters
+
+  - **callback (_function_)** - A function taking a single object of type `AudioSample` (described below) as a parameter.
+
 The rest of the API for `Audio.Sound` is the same as the imperative playback API for `Video`-- see the [AV documentation](av.md) for further information:
 
 - `soundObject.loadAsync(source, initialStatus = {}, downloadFirst = true)`
@@ -377,6 +384,14 @@ The rest of the API for `Audio.Sound` is the same as the imperative playback API
 Object passed to the `onMetadataUpdate` function. It has the following keys:
 
 - `title`: a string with the title of the sound object. This key is optional.
+
+## `AudioSample`
+
+Object passed to the `onAudioSampleReceived` function. Represents a single sample from an audio source. The sample contains all frames (PCM Buffer values) for each channel of the audio, so if the audio is _stereo_ (interleaved), there will be two channels, one for left and one for right audio.
+
+- `channels` - an array representing the data from each channel in PCM Buffer format. Array elements are objects in the following format: `{ frames: number[] }`, where each frame is a number in PCM Buffer format (`-1` to `1` range).
+- `timestamp` - a number representing the timestamp of the current sample in seconds, relative to the audio track's timeline.
+  > **Known issue:** When using the `ExoPlayer` Android implementation, the timestamp is always `-1`.
 
 ## Recording sounds
 
@@ -514,9 +529,10 @@ A static convenience method to construct and start a recording is also provided:
 
   A `Promise` that is fulfilled when the recorder is loaded and prepared, or rejects if this failed. If another `Recording` exists in your experience that is currently prepared to record, the `Promise` will reject. If the `RecordingOptions` provided are invalid, the `Promise` will also reject. The promise is resolved with the `status` of the recording (see `getStatusAsync()` for details).
 
-- `recordingInstance.getAvailableInputs()` 
+- `recordingInstance.getAvailableInputs()`
 
   Returns a list of available recording inputs. This method can only be called if the `Recording` has been prepared.
+
   #### Returns
 
   A `Promise` that is fulfilled with an array of `RecordingInput` objects with `name`, `uid` and `type` params.
@@ -529,13 +545,14 @@ A static convenience method to construct and start a recording is also provided:
 
   A `Promise` that is fulfilled with a `RecordingInput` objects with `name`, `uid` and `type` params.
 
-- `recordingInstance.setInput(inputUid)` 
+- `recordingInstance.setInput(inputUid)`
 
   Sets the current recording input.
 
   #### Parameters
 
   - **inputUid (_string_)** -- The uid of a `RecordingInput`.
+
   #### Returns
 
   A `Promise` that is resolved if successful or rejected if not.


### PR DESCRIPTION
# Why

Resolves ENG-4497

The docs for the new `onAudioSampleReceived` functionality were initially written as _js doc comments_ (see [`Sound.ts`](https://github.com/expo/expo/blob/e712b0bc3ba79b33eb500be751d4a89549acaa8e/packages/expo-av/src/Audio/Sound.ts)), but the `Audio` module docs aren't autogenerated yet.

# How

Backported JS Docs from [`Sound.ts`](https://github.com/expo/expo/blob/e712b0bc3ba79b33eb500be751d4a89549acaa8e/packages/expo-av/src/Audio/Sound.ts) to the legacy `audio.md`. Mostly copy-pasted with very little rewording.

# Test Plan

Ran docs locally to check if rendered correctly.
