### PR TITLE
[modules] Create ObjC wrapper for JSI values

### DIFF
--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.h
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.h
@@ -1,5 +1,6 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
+#import <ExpoModulesCore/EXJavaScriptValue.h>
 #import <ExpoModulesCore/EXJavaScriptObject.h>
 
 #ifdef __cplusplus
@@ -20,7 +21,7 @@ NS_SWIFT_NAME(JavaScriptRuntime)
 #ifdef __cplusplus
 typedef jsi::Value (^JSHostFunctionBlock)(jsi::Runtime &runtime, std::shared_ptr<react::CallInvoker> callInvoker, NSArray * _Nonnull arguments);
 
-- (nonnull instancetype)initWithRuntime:(jsi::Runtime *)runtime
+- (nonnull instancetype)initWithRuntime:(nonnull jsi::Runtime *)runtime
                             callInvoker:(std::shared_ptr<react::CallInvoker>)callInvoker;
 
 /**
@@ -62,6 +63,6 @@ typedef jsi::Value (^JSHostFunctionBlock)(jsi::Runtime &runtime, std::shared_ptr
 /**
  Evaluates given JavaScript source code.
  */
-- (nullable id)evaluateScript:(nonnull NSString *)scriptSource;
+- (nonnull EXJavaScriptValue *)evaluateScript:(nonnull NSString *)scriptSource;
 
 @end

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.mm
@@ -36,7 +36,8 @@ using namespace facebook;
   return self;
 }
 
-- (nonnull instancetype)initWithRuntime:(jsi::Runtime *)runtime callInvoker:(std::shared_ptr<react::CallInvoker>)callInvoker
+- (nonnull instancetype)initWithRuntime:(nonnull jsi::Runtime *)runtime
+                            callInvoker:(std::shared_ptr<react::CallInvoker>)callInvoker
 {
   if (self = [super init]) {
     // Creating a shared pointer that points to the runtime but doesn't own it, thus doesn't release it.
@@ -102,11 +103,11 @@ using namespace facebook;
 
 #pragma mark - Script evaluation
 
-- (nullable id)evaluateScript:(nonnull NSString *)scriptSource
+- (nonnull EXJavaScriptValue *)evaluateScript:(nonnull NSString *)scriptSource
 {
-  auto scriptBuffer = std::make_shared<jsi::StringBuffer>([[NSString stringWithFormat:@"(%@)", scriptSource] UTF8String]);
-  auto result = _runtime->evaluateJavaScript(scriptBuffer, "<<evaluated>>");
-  return expo::convertJSIValueToObjCObject(*_runtime, result, _jsCallInvoker);
+  std::shared_ptr<jsi::StringBuffer> scriptBuffer = std::make_shared<jsi::StringBuffer>([[NSString stringWithFormat:@"(%@)", scriptSource] UTF8String]);
+  std::shared_ptr<jsi::Value> result = std::make_shared<jsi::Value>(_runtime->evaluateJavaScript(scriptBuffer, "<<evaluated>>"));
+  return [[EXJavaScriptValue alloc] initWithRuntime:self value:result];
 }
 
 #pragma mark - Private

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptValue.h
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptValue.h
@@ -1,0 +1,52 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+#import <Foundation/Foundation.h>
+#import <ExpoModulesCore/EXJavaScriptObject.h>
+
+#ifdef __cplusplus
+#import <jsi/jsi.h>
+namespace jsi = facebook::jsi;
+#endif // __cplusplus
+
+@class EXJavaScriptRuntime;
+
+/**
+ Represents any JavaScript value. Its purpose is to exposes `facebook::jsi::Value` API back to Swift.
+ */
+NS_SWIFT_NAME(JavaScriptValue)
+@interface EXJavaScriptValue : NSObject
+
+#ifdef __cplusplus
+- (nonnull instancetype)initWithRuntime:(nonnull EXJavaScriptRuntime *)runtime
+                                  value:(std::shared_ptr<jsi::Value>)value;
+#endif // __cplusplus
+
+#pragma mark - Type checking
+
+- (BOOL)isUndefined;
+- (BOOL)isNull;
+- (BOOL)isBool;
+- (BOOL)isNumber;
+- (BOOL)isString;
+- (BOOL)isSymbol;
+- (BOOL)isObject;
+- (BOOL)isFunction;
+
++ (nonnull NSString *)kindOf:(nonnull EXJavaScriptValue *)value;
+
+#pragma mark - Type casting
+
+- (nullable id)getRaw;
+- (BOOL)getBool;
+- (NSInteger)getInt;
+- (double)getDouble;
+- (nonnull NSString *)getString;
+- (nonnull NSArray<EXJavaScriptValue *> *)getArray;
+- (nonnull NSDictionary<NSString *, id> *)getDictionary;
+- (nonnull EXJavaScriptObject *)getObject;
+
+#pragma mark - Helpers
+
+- (nonnull NSString *)toString;
+
+@end

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptValue.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptValue.mm
@@ -1,0 +1,161 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+#import <ExpoModulesCore/EXJSIConversions.h>
+#import <ExpoModulesCore/EXJavaScriptValue.h>
+#import <ExpoModulesCore/EXJavaScriptRuntime.h>
+
+@implementation EXJavaScriptValue {
+  __weak EXJavaScriptRuntime *_runtime;
+  std::shared_ptr<jsi::Value> _value;
+}
+
+- (nonnull instancetype)initWithRuntime:(nonnull EXJavaScriptRuntime *)runtime
+                                  value:(std::shared_ptr<jsi::Value>)value
+{
+  if (self = [super init]) {
+    _runtime = runtime;
+    _value = value;
+  }
+  return self;
+}
+
+#pragma mark - Type checking
+
+- (BOOL)isUndefined
+{
+  return _value->isUndefined();
+}
+
+- (BOOL)isNull
+{
+  return _value->isNull();
+}
+
+- (BOOL)isBool
+{
+  return _value->isBool();
+}
+
+- (BOOL)isNumber
+{
+  return _value->isNumber();
+}
+
+- (BOOL)isString
+{
+  return _value->isString();
+}
+
+- (BOOL)isSymbol
+{
+  return _value->isSymbol();
+}
+
+- (BOOL)isObject
+{
+  return _value->isObject();
+}
+
+- (BOOL)isFunction
+{
+  if (_value->isObject()) {
+    jsi::Runtime *runtime = [_runtime get];
+    return _value->getObject(*runtime).isFunction(*runtime);
+  }
+  return false;
+}
+
++ (nonnull NSString *)kindOf:(nonnull EXJavaScriptValue *)value
+{
+  if ([value isUndefined]) {
+    return @"undefined";
+  }
+  if ([value isNull]) {
+    return @"null";
+  }
+  if ([value isBool]) {
+    return @"boolean";
+  }
+  if ([value isNumber]) {
+    return @"number";
+  }
+  if ([value isString]) {
+    return @"string";
+  }
+  if ([value isFunction]) {
+    return @"function";
+  }
+  assert([value isObject] && "Expecting object.");
+  return @"object";
+}
+
+#pragma mark - Type casting
+
+- (nullable id)getRaw
+{
+  return expo::convertJSIValueToObjCObject(*[_runtime get], *_value, [_runtime callInvoker]);
+}
+
+- (BOOL)getBool
+{
+  return _value->getBool();
+}
+
+- (NSInteger)getInt
+{
+  return _value->getNumber();
+}
+
+- (double)getDouble
+{
+  return _value->getNumber();
+}
+
+- (nonnull NSString *)getString
+{
+  jsi::Runtime *runtime = [_runtime get];
+  return expo::convertJSIStringToNSString(*runtime, _value->getString(*runtime));
+}
+
+- (nonnull NSArray<EXJavaScriptValue *> *)getArray
+{
+  jsi::Runtime *runtime = [_runtime get];
+  jsi::Array jsiArray = _value->getObject(*runtime).getArray(*runtime);
+  size_t arraySize = jsiArray.size(*runtime);
+  NSMutableArray *result = [NSMutableArray arrayWithCapacity:arraySize];
+
+  for (size_t i = 0; i < arraySize; i++) {
+    jsi::Value item = jsiArray.getValueAtIndex(*runtime, i);
+
+    if (item.isUndefined() || item.isNull()) {
+      [result addObject:(id)kCFNull];
+    } else {
+      std::shared_ptr<jsi::Value> valuePtr = std::make_shared<jsi::Value>(*runtime, item);
+      [result addObject:[[EXJavaScriptValue alloc] initWithRuntime:_runtime value:valuePtr]];
+    }
+  }
+  return result;
+}
+
+- (nonnull NSDictionary<NSString *, id> *)getDictionary
+{
+  jsi::Runtime *runtime = [_runtime get];
+  return expo::convertJSIObjectToNSDictionary(*runtime, _value->getObject(*runtime), [_runtime callInvoker]);
+}
+
+- (nonnull EXJavaScriptObject *)getObject
+{
+  jsi::Runtime *runtime = [_runtime get];
+  std::shared_ptr<jsi::Object> objectPtr = std::make_shared<jsi::Object>(_value->asObject(*runtime));
+  return [[EXJavaScriptObject alloc] initWith:objectPtr runtime:_runtime];
+}
+
+#pragma mark - Helpers
+
+- (nonnull NSString *)toString
+{
+  jsi::Runtime *runtime = [_runtime get];
+  return expo::convertJSIStringToNSString(*runtime, _value->toString(*runtime));
+}
+
+@end

--- a/packages/expo-modules-core/ios/JSI/JavaScriptRuntime.swift
+++ b/packages/expo-modules-core/ios/JSI/JavaScriptRuntime.swift
@@ -1,0 +1,16 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+public extension JavaScriptRuntime {
+  /**
+   Evaluates JavaScript code represented as a string.
+
+   - Parameter source: A string representing a JavaScript expression, statement, or sequence of statements.
+                       The expression can include variables and properties of existing objects.
+   - Returns: The completion value of evaluating the given code represented as `JavaScriptValue`.
+              If the completion value is empty, `undefined` is returned.
+   - Note: It wraps the original `evaluateScript` to better handle and rethrow exceptions.
+   */
+  func eval(_ source: String) throws -> JavaScriptValue {
+    return try evaluateScript(source)
+  }
+}

--- a/packages/expo-modules-core/ios/JSI/JavaScriptValue.swift
+++ b/packages/expo-modules-core/ios/JSI/JavaScriptValue.swift
@@ -1,0 +1,94 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+/**
+ Enum with available kinds of values. It's almost the same as a result of "typeof"
+ in JavaScript, however `null` has its own kind (typeof null == "object").
+ */
+public enum JavaScriptValueKind: String {
+  case undefined
+  case null
+  case bool
+  case number
+  case symbol
+  case string
+  case function
+  case object
+}
+
+public extension JavaScriptValue {
+  var kind: JavaScriptValueKind {
+    switch true {
+    case isUndefined():
+      return .undefined
+    case isNull():
+      return .null
+    case isBool():
+      return .bool
+    case isNumber():
+      return .number
+    case isSymbol():
+      return .symbol
+    case isString():
+      return .string
+    case isFunction():
+      return .function
+    default:
+      return .object
+    }
+  }
+
+  func asBool() throws -> Bool {
+    if isBool() {
+      return getBool()
+    }
+    throw JavaScriptValueConversionException((kind: kind, target: "Bool"))
+  }
+
+  func asInt() throws -> Int {
+    if isNumber() {
+      return getInt()
+    }
+    throw JavaScriptValueConversionException((kind: kind, target: "Int"))
+  }
+
+  func asDouble() throws -> Double {
+    if isNumber() {
+      return getDouble()
+    }
+    throw JavaScriptValueConversionException((kind: kind, target: "Double"))
+  }
+
+  func asString() throws -> String {
+    if isString() {
+      return getString()
+    }
+    throw JavaScriptValueConversionException((kind: kind, target: "String"))
+  }
+
+  func asArray() throws -> [JavaScriptValue?] {
+    if isObject() {
+      return getArray()
+    }
+    throw JavaScriptValueConversionException((kind: kind, target: "Array"))
+  }
+
+  func asDict() throws -> [String: Any?] {
+    if isObject() {
+      return getDictionary()
+    }
+    throw JavaScriptValueConversionException((kind: kind, target: "Dict"))
+  }
+
+  func asObject() throws -> JavaScriptObject {
+    if isObject() {
+      return getObject()
+    }
+    throw JavaScriptValueConversionException((kind: kind, target: "Object"))
+  }
+}
+
+internal final class JavaScriptValueConversionException: GenericException<(kind: JavaScriptValueKind, target: String)> {
+  override var reason: String {
+    "Cannot represent a value of kind '\(param.kind)' as \(param.target)"
+  }
+}

--- a/packages/expo-modules-core/ios/Tests/JavaScriptRuntimeSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/JavaScriptRuntimeSpec.swift
@@ -11,24 +11,77 @@ class JavaScriptRuntimeSpec: QuickSpec {
       expect(runtime.global) !== nil
     }
 
-    describe("evaluateScript") {
-      it("returns primitive types") {
-        expect(runtime.evaluateScript("null")).to(beNil())
-        expect(runtime.evaluateScript("undefined")).to(beNil())
-        expect(runtime.evaluateScript("true") as? Bool) == true
-        expect(runtime.evaluateScript("false") as? Bool) == false
-        expect(runtime.evaluateScript("123") as? Int) == 123
-        expect(runtime.evaluateScript("1.23") as? Double) == 1.23
-        expect(runtime.evaluateScript("'foobar'") as? String) == "foobar"
+    describe("eval") {
+      it("returns undefined") {
+        let undefined = try! runtime.eval("undefined")
+        expect(undefined.isUndefined()) == true
+        expect(undefined.kind) == .undefined
+        expect(undefined.isNull()) == false
+        expect(undefined.getRaw()).to(beNil())
       }
 
-      it("returns arrays") {
-        expect(runtime.evaluateScript("['foo', 'bar']") as? [String]) == ["foo", "bar"]
+      it("returns null") {
+        let null = try! runtime.eval("null")
+        expect(null.isNull()) == true
+        expect(null.kind) == .null
+        expect(null.getRaw()).to(beNil())
       }
 
-      it("returns dicts") {
-        expect(runtime.evaluateScript("{ 'foo': 123 }") as? [String: Int]) == ["foo": 123]
-        expect(runtime.evaluateScript("{ 'foo': 'bar' }") as? [String: String]) == ["foo": "bar"]
+      it("returns bool") {
+        let boolTrue = try! runtime.eval("true")
+        let boolFalse = try! runtime.eval("false")
+        expect(boolTrue.isBool()) == true
+        expect(boolFalse.isBool()) == true
+        expect(boolTrue.kind) == .bool
+        expect(boolFalse.kind) == .bool
+        expect(try! boolTrue.asBool()) == true
+        expect(try! boolFalse.asBool()) == false
+      }
+
+      it("returns number") {
+        let number = try! runtime.eval("1.23")
+        expect(number.isNumber()) == true
+        expect(number.kind) == .number
+        expect(try! number.asInt()) == 1
+        expect(try! number.asDouble()) == 1.23
+      }
+
+      it("returns string") {
+        let string = try! runtime.eval("'foobar'")
+        expect(string.isString()) == true
+        expect(string.kind) == .string
+        expect(try! string.asString()) == "foobar"
+      }
+
+      it("returns array") {
+        let array = try! runtime.eval("['foo', 'bar']")
+        expect(array.isObject()) == true
+        expect(array.kind) == .object
+        expect(try! array.asArray().map { try $0?.asString() }) == ["foo", "bar"]
+      }
+
+      it("returns dict") {
+        let dict1 = try! runtime.eval("{ 'foo': 123 }")
+        let dict2 = try! runtime.eval("{ 'foo': 'bar' }")
+        expect(dict1.isObject()) == true
+        expect(dict2.isObject()) == true
+        expect(dict1.kind) == .object
+        expect(dict2.kind) == .object
+        expect(try! dict1.asDict() as? [String: Int]) == ["foo": 123]
+        expect(try! dict2.asDict() as? [String: String]) == ["foo": "bar"]
+      }
+
+      it("returns function") {
+        let function = try! runtime.eval("function() {}")
+        expect(function.isObject()) == true
+        expect(function.isFunction()) == true
+        expect(function.kind) == .function
+      }
+
+      it("returns symbol") {
+        let symbol = try! runtime.eval("Symbol('foo')")
+        expect(symbol.isSymbol()) == true
+        expect(symbol.kind) == .symbol
       }
     }
   }


### PR DESCRIPTION
# Why

`jsi::Value` needs to be wrapped by Objective-C class (`JavaScriptValue`) to expose its functionality in Swift. As part of that, the `eval` function should return an instance of this class instead of converting the evaluation result to native Objective-C types.

# How

- Created `EXJavaScriptValue` (`JavaScriptValue` in Swift) class to wrap `jsi::Value`. I intentionally use `JavaScript` prefix over `JS` not to be confused with similar classes from `JavaScriptCore` framework.
- Improved tests for `eval`.

# Test Plan

Unit tests are passing
