### PR TITLE
[dev-launcher][dev-menu] add missing native fns for android

### DIFF
--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherInternalModule.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherInternalModule.kt
@@ -67,11 +67,10 @@ class DevLauncherInternalModule(reactContext: ReactApplicationContext?)
     val sdkVersion = getMetadataValue("expo.modules.updates.EXPO_SDK_VERSION")
     var updatesUrl = getMetadataValue("expo.modules.updates.EXPO_UPDATE_URL")
 
-    var appId = ""
-
-    if (updatesUrl.isNotEmpty()) {
-      var uri = Uri.parse(updatesUrl)
-      appId = uri.lastPathSegment ?: ""
+    val appId = if (updatesUrl.isNotEmpty()) {
+      Uri.parse(updatesUrl).lastPathSegment ?: ""
+    } else {
+      ""
     }
 
     var isModernManifestProtocol = Uri.parse(updatesUrl).host.equals("u.expo.dev")

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherInternalModule.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherInternalModule.kt
@@ -55,8 +55,34 @@ class DevLauncherInternalModule(reactContext: ReactApplicationContext?)
     val isRunningOnStockEmulator = Build.FINGERPRINT.contains("generic")
     return mapOf(
       "installationID" to installationIDHelper.getOrCreateInstallationID(reactApplicationContext),
-      "isDevice" to (!isRunningOnGenymotion && !isRunningOnStockEmulator)
+      "isDevice" to (!isRunningOnGenymotion && !isRunningOnStockEmulator),
+      "updatesConfig" to getUpdatesConfig(),
     )
+  }
+
+  private fun getUpdatesConfig(): WritableMap {
+    val map = Arguments.createMap()
+
+    val runtimeVersion = getMetadataValue("expo.modules.updates.EXPO_RUNTIME_VERSION")
+    val sdkVersion = getMetadataValue("expo.modules.updates.EXPO_SDK_VERSION")
+    var updatesUrl = getMetadataValue("expo.modules.updates.EXPO_UPDATE_URL")
+
+    var appId = ""
+
+    if (updatesUrl.isNotEmpty()) {
+      var uri = Uri.parse(updatesUrl)
+      appId = uri.lastPathSegment ?: ""
+    }
+
+    var isModernManifestProtocol = Uri.parse(updatesUrl).host.equals("u.expo.dev")
+    var usesEASUpdates = isModernManifestProtocol && appId.isNotEmpty()
+
+    return map.apply {
+      putString("appId", appId)
+      putString("runtimeVersion", runtimeVersion)
+      putString("sdkVersion", sdkVersion)
+      putBoolean("usesEASUpdates", usesEASUpdates)
+    }
   }
 
   @ReactMethod

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuDevSettings.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuDevSettings.kt
@@ -16,6 +16,11 @@ object DevMenuDevSettings {
         putBoolean("isElementInspectorShown", devSettings.isElementInspectorEnabled)
         putBoolean("isHotLoadingEnabled", devSettings.isHotModuleReplacementEnabled)
         putBoolean("isPerfMonitorShown", devSettings.isFpsDebugEnabled)
+        // TODO -- is this correct:
+        putBoolean("isRemoteDebuggingAvailable", devSettings.isJSDevModeEnabled)
+        putBoolean("isElementInspectorAvailable", devSettings.isJSDevModeEnabled)
+        putBoolean("isHotLoadingAvailable", devSettings.isJSDevModeEnabled)
+        putBoolean("isPerfMonitorAvailable", devSettings.isJSDevModeEnabled)
       }
     }
 
@@ -24,6 +29,10 @@ object DevMenuDevSettings {
       putBoolean("isElementInspectorShown", false)
       putBoolean("isHotLoadingEnabled", false)
       putBoolean("isPerfMonitorShown", false)
+      putBoolean("isRemoteDebuggingAvailable", false)
+      putBoolean("isElementInspectorAvailable", false)
+      putBoolean("isHotLoadingAvailable", false)
+      putBoolean("isPerfMonitorAvailable", false)
     }
   }
 }

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuDevSettings.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuDevSettings.kt
@@ -10,14 +10,15 @@ object DevMenuDevSettings {
     val devDelegate = DevMenuDevToolsDelegate(DevMenuManager, reactInstanceManager)
     val devSettings = devDelegate.devSettings as? DevInternalSettings
 
+    val jsBundleURL = reactInstanceManager.devSupportManager.jsBundleURLForRemoteDebugging
+
     if (devSettings != null) {
       return Bundle().apply {
         putBoolean("isDebuggingRemotely", devSettings.isRemoteJSDebugEnabled)
         putBoolean("isElementInspectorShown", devSettings.isElementInspectorEnabled)
         putBoolean("isHotLoadingEnabled", devSettings.isHotModuleReplacementEnabled)
         putBoolean("isPerfMonitorShown", devSettings.isFpsDebugEnabled)
-        // TODO -- is this correct:
-        putBoolean("isRemoteDebuggingAvailable", devSettings.isJSDevModeEnabled)
+        putBoolean("isRemoteDebuggingAvailable", jsBundleURL.isNotEmpty())
         putBoolean("isElementInspectorAvailable", devSettings.isJSDevModeEnabled)
         putBoolean("isHotLoadingAvailable", devSettings.isJSDevModeEnabled)
         putBoolean("isPerfMonitorAvailable", devSettings.isJSDevModeEnabled)


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

There were a couple recent additions to the native APIs for dev-launcher and dev-menu that are missing on Android

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Added the `updatesConfig` constant to DevLauncherInternal
- Updated the debug option availabilities in DevMenuDevSettings

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

- dev launcher no longer crashes and renders as expected on the extensions screen
- dev menu debug options are no longer disabled on Android for debug host

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
