### PR TITLE
[sceens][iOS][Android] Upgrade `react-native-screens@3.10.1 ➡️ 3.11.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Package-specific changes not released in any SDK will be added here just before 
 - Updated `@react-native-picker/picker` from `2.2.1` to `2.4.0`. ([#16876](https://github.com/expo/expo/pull/16876) by [@tsapeta](https://github.com/tsapeta))
 - Updated `@react-native-community/slider` from `4.1.12` to `4.2.1`. ([#16901](https://github.com/expo/expo/pull/16901) by [@tsapeta](https://github.com/tsapeta))
 - Updated `react-native-svg` from `12.1.1` to `12.3.0`. ([#16874](https://github.com/expo/expo/pull/16874) by [@bbarthec](https://github.com/bbarthec))
+- Updated `react-native-screens` from `3.10.1` to `3.11.1`. ([#16913](https://github.com/expo/expo/pull/16913) by [@bbarthec](https://github.com/bbarthec))
 
 ### 🛠 Breaking changes
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/CustomSearchView.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/CustomSearchView.kt
@@ -13,59 +13,59 @@ class CustomSearchView(context: Context, fragment: Fragment) : SearchView(contex
         setOnSearchClickListener - https://developer.android.com/reference/android/widget/SearchView#setOnSearchClickListener(android.view.View.OnClickListener)
         setOnCloseListener - https://developer.android.com/reference/android/widget/SearchView#setOnCloseListener(android.widget.SearchView.OnCloseListener)
     */
-  private var mCustomOnCloseListener: OnCloseListener? = null
-  private var mCustomOnSearchClickedListener: OnClickListener? = null
+    private var mCustomOnCloseListener: OnCloseListener? = null
+    private var mCustomOnSearchClickedListener: OnClickListener? = null
 
-  private var mOnBackPressedCallback: OnBackPressedCallback =
-    object : OnBackPressedCallback(true) {
-      override fun handleOnBackPressed() {
-        isIconified = true
-      }
-    }
-  private val backPressOverrider = FragmentBackPressOverrider(fragment, mOnBackPressedCallback)
-  var overrideBackAction: Boolean
-    set(value) {
-      backPressOverrider.overrideBackAction = value
-    }
-    get() = backPressOverrider.overrideBackAction
+    private var mOnBackPressedCallback: OnBackPressedCallback =
+        object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                isIconified = true
+            }
+        }
+    private val backPressOverrider = FragmentBackPressOverrider(fragment, mOnBackPressedCallback)
+    var overrideBackAction: Boolean
+        set(value) {
+            backPressOverrider.overrideBackAction = value
+        }
+        get() = backPressOverrider.overrideBackAction
 
-  fun focus() {
-    isIconified = false
-    requestFocusFromTouch()
-  }
-
-  override fun setOnCloseListener(listener: OnCloseListener?) {
-    mCustomOnCloseListener = listener
-  }
-
-  override fun setOnSearchClickListener(listener: OnClickListener?) {
-    mCustomOnSearchClickedListener = listener
-  }
-
-  override fun onAttachedToWindow() {
-    super.onAttachedToWindow()
-    if (!isIconified) {
-      backPressOverrider.maybeAddBackCallback()
-    }
-  }
-
-  override fun onDetachedFromWindow() {
-    super.onDetachedFromWindow()
-    backPressOverrider.removeBackCallbackIfAdded()
-  }
-
-  init {
-    super.setOnSearchClickListener { v ->
-      mCustomOnSearchClickedListener?.onClick(v)
-      backPressOverrider.maybeAddBackCallback()
+    fun focus() {
+        isIconified = false
+        requestFocusFromTouch()
     }
 
-    super.setOnCloseListener {
-      val result = mCustomOnCloseListener?.onClose() ?: false
-      backPressOverrider.removeBackCallbackIfAdded()
-      result
+    override fun setOnCloseListener(listener: OnCloseListener?) {
+        mCustomOnCloseListener = listener
     }
 
-    maxWidth = Integer.MAX_VALUE
-  }
+    override fun setOnSearchClickListener(listener: OnClickListener?) {
+        mCustomOnSearchClickedListener = listener
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        if (!isIconified) {
+            backPressOverrider.maybeAddBackCallback()
+        }
+    }
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        backPressOverrider.removeBackCallbackIfAdded()
+    }
+
+    init {
+        super.setOnSearchClickListener { v ->
+            mCustomOnSearchClickedListener?.onClick(v)
+            backPressOverrider.maybeAddBackCallback()
+        }
+
+        super.setOnCloseListener {
+            val result = mCustomOnCloseListener?.onClose() ?: false
+            backPressOverrider.removeBackCallbackIfAdded()
+            result
+        }
+
+        maxWidth = Integer.MAX_VALUE
+    }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/FragmentBackPressOverrider.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/FragmentBackPressOverrider.kt
@@ -4,26 +4,26 @@ import androidx.activity.OnBackPressedCallback
 import androidx.fragment.app.Fragment
 
 class FragmentBackPressOverrider(
-  private val fragment: Fragment,
-  private val mOnBackPressedCallback: OnBackPressedCallback
+    private val fragment: Fragment,
+    private val mOnBackPressedCallback: OnBackPressedCallback
 ) {
-  private var mIsBackCallbackAdded: Boolean = false
-  var overrideBackAction: Boolean = true
+    private var mIsBackCallbackAdded: Boolean = false
+    var overrideBackAction: Boolean = true
 
-  fun maybeAddBackCallback() {
-    if (!mIsBackCallbackAdded && overrideBackAction) {
-      fragment.activity?.onBackPressedDispatcher?.addCallback(
-        fragment,
-        mOnBackPressedCallback
-      )
-      mIsBackCallbackAdded = true
+    fun maybeAddBackCallback() {
+        if (!mIsBackCallbackAdded && overrideBackAction) {
+            fragment.activity?.onBackPressedDispatcher?.addCallback(
+                fragment,
+                mOnBackPressedCallback
+            )
+            mIsBackCallbackAdded = true
+        }
     }
-  }
 
-  fun removeBackCallbackIfAdded() {
-    if (mIsBackCallbackAdded) {
-      mOnBackPressedCallback.remove()
-      mIsBackCallbackAdded = false
+    fun removeBackCallbackIfAdded() {
+        if (mIsBackCallbackAdded) {
+            mOnBackPressedCallback.remove()
+            mIsBackCallbackAdded = false
+        }
     }
-  }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/LifecycleHelper.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/LifecycleHelper.kt
@@ -6,56 +6,56 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleObserver
 
 class LifecycleHelper {
-  private val mViewToLifecycleMap: MutableMap<View, Lifecycle> = HashMap()
-  private val mRegisterOnLayoutChange: View.OnLayoutChangeListener = object : View.OnLayoutChangeListener {
-    override fun onLayoutChange(
-      view: View,
-      i: Int,
-      i1: Int,
-      i2: Int,
-      i3: Int,
-      i4: Int,
-      i5: Int,
-      i6: Int,
-      i7: Int
-    ) {
-      registerViewWithLifecycleOwner(view)
-      view.removeOnLayoutChangeListener(this)
+    private val mViewToLifecycleMap: MutableMap<View, Lifecycle> = HashMap()
+    private val mRegisterOnLayoutChange: View.OnLayoutChangeListener = object : View.OnLayoutChangeListener {
+        override fun onLayoutChange(
+            view: View,
+            i: Int,
+            i1: Int,
+            i2: Int,
+            i3: Int,
+            i4: Int,
+            i5: Int,
+            i6: Int,
+            i7: Int
+        ) {
+            registerViewWithLifecycleOwner(view)
+            view.removeOnLayoutChangeListener(this)
+        }
     }
-  }
 
-  private fun registerViewWithLifecycleOwner(view: View) {
-    val parent = findNearestScreenFragmentAncestor(view)
-    if (parent != null && view is LifecycleObserver) {
-      val lifecycle = parent.lifecycle
-      lifecycle.addObserver((view as LifecycleObserver))
-      mViewToLifecycleMap[view] = lifecycle
+    private fun registerViewWithLifecycleOwner(view: View) {
+        val parent = findNearestScreenFragmentAncestor(view)
+        if (parent != null && view is LifecycleObserver) {
+            val lifecycle = parent.lifecycle
+            lifecycle.addObserver((view as LifecycleObserver))
+            mViewToLifecycleMap[view] = lifecycle
+        }
     }
-  }
 
-  fun <T> register(view: T) where T : View, T : LifecycleObserver? {
-    // we need to wait until view is mounted in the hierarchy as this method is called only at the
-    // moment of the view creation. In order to register lifecycle observer we need to find ancestor
-    // of type Screen and this can only happen when the view is properly attached. We rely on
-    // Android's onLayout callback being triggered when the view gets added to the hierarchy and
-    // only then we attempt to locate lifecycle owner ancestor.
-    view.addOnLayoutChangeListener(mRegisterOnLayoutChange)
-  }
-
-  fun <T> unregister(view: T) where T : View, T : LifecycleObserver? {
-    val lifecycle = mViewToLifecycleMap[view]
-    lifecycle?.removeObserver(view)
-  }
-
-  companion object {
-    fun findNearestScreenFragmentAncestor(view: View): Fragment? {
-      var parent = view.parent
-      while (parent != null && parent !is Screen) {
-        parent = parent.parent
-      }
-      return if (parent != null) {
-        (parent as Screen).fragment
-      } else null
+    fun <T> register(view: T) where T : View, T : LifecycleObserver? {
+        // we need to wait until view is mounted in the hierarchy as this method is called only at the
+        // moment of the view creation. In order to register lifecycle observer we need to find ancestor
+        // of type Screen and this can only happen when the view is properly attached. We rely on
+        // Android's onLayout callback being triggered when the view gets added to the hierarchy and
+        // only then we attempt to locate lifecycle owner ancestor.
+        view.addOnLayoutChangeListener(mRegisterOnLayoutChange)
     }
-  }
+
+    fun <T> unregister(view: T) where T : View, T : LifecycleObserver? {
+        val lifecycle = mViewToLifecycleMap[view]
+        lifecycle?.removeObserver(view)
+    }
+
+    companion object {
+        fun findNearestScreenFragmentAncestor(view: View): Fragment? {
+            var parent = view.parent
+            while (parent != null && parent !is Screen) {
+                parent = parent.parent
+            }
+            return if (parent != null) {
+                (parent as Screen).fragment
+            } else null
+        }
+    }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/RNScreensPackage.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/RNScreensPackage.kt
@@ -6,16 +6,16 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.uimanager.ViewManager
 
 class RNScreensPackage : ReactPackage {
-  override fun createNativeModules(reactContext: ReactApplicationContext) =
-    emptyList<NativeModule>()
+    override fun createNativeModules(reactContext: ReactApplicationContext) =
+        emptyList<NativeModule>()
 
-  override fun createViewManagers(reactContext: ReactApplicationContext) =
-    listOf<ViewManager<*, *>>(
-      ScreenContainerViewManager(),
-      ScreenViewManager(),
-      ScreenStackViewManager(),
-      ScreenStackHeaderConfigViewManager(),
-      ScreenStackHeaderSubviewManager(),
-      SearchBarManager()
-    )
+    override fun createViewManagers(reactContext: ReactApplicationContext) =
+        listOf<ViewManager<*, *>>(
+            ScreenContainerViewManager(),
+            ScreenViewManager(),
+            ScreenStackViewManager(),
+            ScreenStackHeaderConfigViewManager(),
+            ScreenStackHeaderSubviewManager(),
+            SearchBarManager()
+        )
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/Screen.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/Screen.kt
@@ -14,224 +14,241 @@ import com.facebook.react.uimanager.UIManagerModule
 
 @SuppressLint("ViewConstructor")
 class Screen constructor(context: ReactContext?) : ViewGroup(context) {
-  var fragment: ScreenFragment? = null
-  var container: ScreenContainer<*>? = null
-  var activityState: ActivityState? = null
-    private set
-  private var mTransitioning = false
-  var stackPresentation = StackPresentation.PUSH
-  var replaceAnimation = ReplaceAnimation.POP
-  var stackAnimation = StackAnimation.DEFAULT
-  var isGestureEnabled = true
-  var screenOrientation: Int? = null
-    private set
-  private var mStatusBarStyle: String? = null
-  private var mStatusBarHidden: Boolean? = null
-  private var mStatusBarTranslucent: Boolean? = null
-  private var mStatusBarColor: Int? = null
-  var isStatusBarAnimated: Boolean? = null
-  private var mNativeBackButtonDismissalEnabled = true
+    var fragment: ScreenFragment? = null
+    var container: ScreenContainer<*>? = null
+    var activityState: ActivityState? = null
+        private set
+    private var mTransitioning = false
+    var stackPresentation = StackPresentation.PUSH
+    var replaceAnimation = ReplaceAnimation.POP
+    var stackAnimation = StackAnimation.DEFAULT
+    var isGestureEnabled = true
+    var screenOrientation: Int? = null
+        private set
+    private var mStatusBarStyle: String? = null
+    private var mStatusBarHidden: Boolean? = null
+    private var mStatusBarTranslucent: Boolean? = null
+    private var mStatusBarColor: Int? = null
+    private var mNavigationBarColor: Int? = null
+    private var mNavigationBarHidden: Boolean? = null
+    var isStatusBarAnimated: Boolean? = null
+    private var mNativeBackButtonDismissalEnabled = true
 
-  init {
-    // we set layout params as WindowManager.LayoutParams to workaround the issue with TextInputs
-    // not displaying modal menus (e.g., copy/paste or selection). The missing menus are due to the
-    // fact that TextView implementation is expected to be attached to window when layout happens.
-    // Then, at the moment of layout it checks whether window type is in a reasonable range to tell
-    // whether it should enable selection controls (see Editor.java#prepareCursorControllers).
-    // With screens, however, the text input component can be laid out before it is attached, in
-    // that case TextView tries to get window type property from the oldest existing parent, which
-    // in this case is a Screen class, as it is the root of the screen that is about to be attached.
-    // Setting params this way is not the most elegant way to solve this problem but workarounds it
-    // for the time being
-    layoutParams = WindowManager.LayoutParams(WindowManager.LayoutParams.TYPE_APPLICATION)
-  }
-
-  override fun onAnimationStart() {
-    super.onAnimationStart()
-    fragment?.onViewAnimationStart()
-  }
-
-  override fun onAnimationEnd() {
-    super.onAnimationEnd()
-    fragment?.onViewAnimationEnd()
-  }
-
-  override fun dispatchSaveInstanceState(container: SparseArray<Parcelable>) {
-    // do nothing, react native will keep the view hierarchy so no need to serialize/deserialize
-    // view's states. The side effect of restoring is that TextInput components would trigger
-    // set-text events which may confuse text input handling.
-  }
-
-  override fun dispatchRestoreInstanceState(container: SparseArray<Parcelable>) {
-    // ignore restoring instance state too as we are not saving anything anyways.
-  }
-
-  override fun onLayout(changed: Boolean, l: Int, t: Int, r: Int, b: Int) {
-    if (changed) {
-      val width = r - l
-      val height = b - t
-      val reactContext = context as ReactContext
-      reactContext.runOnNativeModulesQueueThread(
-        object : GuardedRunnable(reactContext) {
-          override fun runGuarded() {
-            reactContext
-              .getNativeModule(UIManagerModule::class.java)
-              ?.updateNodeSize(id, width, height)
-          }
-        })
-    }
-  }
-
-  val headerConfig: ScreenStackHeaderConfig?
-    get() {
-      val child = getChildAt(0)
-      return if (child is ScreenStackHeaderConfig) {
-        child
-      } else null
+    init {
+        // we set layout params as WindowManager.LayoutParams to workaround the issue with TextInputs
+        // not displaying modal menus (e.g., copy/paste or selection). The missing menus are due to the
+        // fact that TextView implementation is expected to be attached to window when layout happens.
+        // Then, at the moment of layout it checks whether window type is in a reasonable range to tell
+        // whether it should enable selection controls (see Editor.java#prepareCursorControllers).
+        // With screens, however, the text input component can be laid out before it is attached, in
+        // that case TextView tries to get window type property from the oldest existing parent, which
+        // in this case is a Screen class, as it is the root of the screen that is about to be attached.
+        // Setting params this way is not the most elegant way to solve this problem but workarounds it
+        // for the time being
+        layoutParams = WindowManager.LayoutParams(WindowManager.LayoutParams.TYPE_APPLICATION)
     }
 
-  /**
-   * While transitioning this property allows to optimize rendering behavior on Android and provide
-   * a correct blending options for the animated screen. It is turned on automatically by the
-   * container when transitioning is detected and turned off immediately after
-   */
-  fun setTransitioning(transitioning: Boolean) {
-    if (mTransitioning == transitioning) {
-      return
+    override fun dispatchSaveInstanceState(container: SparseArray<Parcelable>) {
+        // do nothing, react native will keep the view hierarchy so no need to serialize/deserialize
+        // view's states. The side effect of restoring is that TextInput components would trigger
+        // set-text events which may confuse text input handling.
     }
-    mTransitioning = transitioning
-    val isWebViewInScreen = hasWebView(this)
-    if (isWebViewInScreen && layerType != LAYER_TYPE_HARDWARE) {
-      return
-    }
-    super.setLayerType(
-      if (transitioning && !isWebViewInScreen) LAYER_TYPE_HARDWARE else LAYER_TYPE_NONE,
-      null
-    )
-  }
 
-  private fun hasWebView(viewGroup: ViewGroup): Boolean {
-    for (i in 0 until viewGroup.childCount) {
-      val child = viewGroup.getChildAt(i)
-      if (child is WebView) {
-        return true
-      } else if (child is ViewGroup) {
-        if (hasWebView(child)) {
-          return true
+    override fun dispatchRestoreInstanceState(container: SparseArray<Parcelable>) {
+        // ignore restoring instance state too as we are not saving anything anyways.
+    }
+
+    override fun onLayout(changed: Boolean, l: Int, t: Int, r: Int, b: Int) {
+        if (changed) {
+            val width = r - l
+            val height = b - t
+            val reactContext = context as ReactContext
+            reactContext.runOnNativeModulesQueueThread(
+                object : GuardedRunnable(reactContext) {
+                    override fun runGuarded() {
+                        reactContext
+                            .getNativeModule(UIManagerModule::class.java)
+                            ?.updateNodeSize(id, width, height)
+                    }
+                })
         }
-      }
-    }
-    return false
-  }
-
-  override fun setLayerType(layerType: Int, paint: Paint?) {
-    // ignore - layer type is controlled by `transitioning` prop
-  }
-
-  fun setActivityState(activityState: ActivityState) {
-    if (activityState == this.activityState) {
-      return
-    }
-    this.activityState = activityState
-    container?.notifyChildUpdate()
-  }
-
-  fun setScreenOrientation(screenOrientation: String?) {
-    if (screenOrientation == null) {
-      this.screenOrientation = null
-      return
-    }
-    ScreenWindowTraits.applyDidSetOrientation()
-    this.screenOrientation = when (screenOrientation) {
-      "all" -> ActivityInfo.SCREEN_ORIENTATION_FULL_SENSOR
-      "portrait" -> ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT
-      "portrait_up" -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-      "portrait_down" -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT
-      "landscape" -> ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
-      "landscape_left" -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE
-      "landscape_right" -> ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
-      else -> ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
     }
 
-    fragment?.let { ScreenWindowTraits.setOrientation(this, it.tryGetActivity()) }
-  }
+    val headerConfig: ScreenStackHeaderConfig?
+        get() {
+            val child = getChildAt(0)
+            return if (child is ScreenStackHeaderConfig) {
+                child
+            } else null
+        }
 
-  // Accepts one of 4 accessibility flags
-  // developer.android.com/reference/android/view/View#attr_android:importantForAccessibility
-  fun changeAccessibilityMode(mode: Int) {
-    this.importantForAccessibility = mode
-    this.headerConfig?.toolbar?.importantForAccessibility = mode
-  }
-
-  var statusBarStyle: String?
-    get() = mStatusBarStyle
-    set(statusBarStyle) {
-      if (statusBarStyle != null) {
-        ScreenWindowTraits.applyDidSetStatusBarAppearance()
-      }
-      mStatusBarStyle = statusBarStyle
-      fragment?.let { ScreenWindowTraits.setStyle(this, it.tryGetActivity(), it.tryGetContext()) }
-    }
-
-  var isStatusBarHidden: Boolean?
-    get() = mStatusBarHidden
-    set(statusBarHidden) {
-      if (statusBarHidden != null) {
-        ScreenWindowTraits.applyDidSetStatusBarAppearance()
-      }
-      mStatusBarHidden = statusBarHidden
-      fragment?.let { ScreenWindowTraits.setHidden(this, it.tryGetActivity()) }
-    }
-
-  var isStatusBarTranslucent: Boolean?
-    get() = mStatusBarTranslucent
-    set(statusBarTranslucent) {
-      if (statusBarTranslucent != null) {
-        ScreenWindowTraits.applyDidSetStatusBarAppearance()
-      }
-      mStatusBarTranslucent = statusBarTranslucent
-      fragment?.let {
-        ScreenWindowTraits.setTranslucent(
-          this,
-          it.tryGetActivity(),
-          it.tryGetContext()
+    /**
+     * While transitioning this property allows to optimize rendering behavior on Android and provide
+     * a correct blending options for the animated screen. It is turned on automatically by the
+     * container when transitioning is detected and turned off immediately after
+     */
+    fun setTransitioning(transitioning: Boolean) {
+        if (mTransitioning == transitioning) {
+            return
+        }
+        mTransitioning = transitioning
+        val isWebViewInScreen = hasWebView(this)
+        if (isWebViewInScreen && layerType != LAYER_TYPE_HARDWARE) {
+            return
+        }
+        super.setLayerType(
+            if (transitioning && !isWebViewInScreen) LAYER_TYPE_HARDWARE else LAYER_TYPE_NONE,
+            null
         )
-      }
     }
 
-  var statusBarColor: Int?
-    get() = mStatusBarColor
-    set(statusBarColor) {
-      if (statusBarColor != null) {
-        ScreenWindowTraits.applyDidSetStatusBarAppearance()
-      }
-      mStatusBarColor = statusBarColor
-      fragment?.let { ScreenWindowTraits.setColor(this, it.tryGetActivity(), it.tryGetContext()) }
+    private fun hasWebView(viewGroup: ViewGroup): Boolean {
+        for (i in 0 until viewGroup.childCount) {
+            val child = viewGroup.getChildAt(i)
+            if (child is WebView) {
+                return true
+            } else if (child is ViewGroup) {
+                if (hasWebView(child)) {
+                    return true
+                }
+            }
+        }
+        return false
     }
 
-  var nativeBackButtonDismissalEnabled: Boolean
-    get() = mNativeBackButtonDismissalEnabled
-    set(enableNativeBackButtonDismissal) {
-      mNativeBackButtonDismissalEnabled = enableNativeBackButtonDismissal
+    override fun setLayerType(layerType: Int, paint: Paint?) {
+        // ignore - layer type is controlled by `transitioning` prop
     }
 
-  enum class StackPresentation {
-    PUSH, MODAL, TRANSPARENT_MODAL
-  }
+    fun setActivityState(activityState: ActivityState) {
+        if (activityState == this.activityState) {
+            return
+        }
+        this.activityState = activityState
+        container?.notifyChildUpdate()
+    }
 
-  enum class StackAnimation {
-    DEFAULT, NONE, FADE, SLIDE_FROM_BOTTOM, SLIDE_FROM_RIGHT, SLIDE_FROM_LEFT, FADE_FROM_BOTTOM
-  }
+    fun setScreenOrientation(screenOrientation: String?) {
+        if (screenOrientation == null) {
+            this.screenOrientation = null
+            return
+        }
+        ScreenWindowTraits.applyDidSetOrientation()
+        this.screenOrientation = when (screenOrientation) {
+            "all" -> ActivityInfo.SCREEN_ORIENTATION_FULL_SENSOR
+            "portrait" -> ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT
+            "portrait_up" -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+            "portrait_down" -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT
+            "landscape" -> ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
+            "landscape_left" -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE
+            "landscape_right" -> ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+            else -> ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
+        }
 
-  enum class ReplaceAnimation {
-    PUSH, POP
-  }
+        fragment?.let { ScreenWindowTraits.setOrientation(this, it.tryGetActivity()) }
+    }
 
-  enum class ActivityState {
-    INACTIVE, TRANSITIONING_OR_BELOW_TOP, ON_TOP
-  }
+    // Accepts one of 4 accessibility flags
+    // developer.android.com/reference/android/view/View#attr_android:importantForAccessibility
+    fun changeAccessibilityMode(mode: Int) {
+        this.importantForAccessibility = mode
+        this.headerConfig?.toolbar?.importantForAccessibility = mode
+    }
 
-  enum class WindowTraits {
-    ORIENTATION, COLOR, STYLE, TRANSLUCENT, HIDDEN, ANIMATED
-  }
+    var statusBarStyle: String?
+        get() = mStatusBarStyle
+        set(statusBarStyle) {
+            if (statusBarStyle != null) {
+                ScreenWindowTraits.applyDidSetStatusBarAppearance()
+            }
+            mStatusBarStyle = statusBarStyle
+            fragment?.let { ScreenWindowTraits.setStyle(this, it.tryGetActivity(), it.tryGetContext()) }
+        }
+
+    var isStatusBarHidden: Boolean?
+        get() = mStatusBarHidden
+        set(statusBarHidden) {
+            if (statusBarHidden != null) {
+                ScreenWindowTraits.applyDidSetStatusBarAppearance()
+            }
+            mStatusBarHidden = statusBarHidden
+            fragment?.let { ScreenWindowTraits.setHidden(this, it.tryGetActivity()) }
+        }
+
+    var isStatusBarTranslucent: Boolean?
+        get() = mStatusBarTranslucent
+        set(statusBarTranslucent) {
+            if (statusBarTranslucent != null) {
+                ScreenWindowTraits.applyDidSetStatusBarAppearance()
+            }
+            mStatusBarTranslucent = statusBarTranslucent
+            fragment?.let {
+                ScreenWindowTraits.setTranslucent(
+                    this,
+                    it.tryGetActivity(),
+                    it.tryGetContext()
+                )
+            }
+        }
+
+    var statusBarColor: Int?
+        get() = mStatusBarColor
+        set(statusBarColor) {
+            if (statusBarColor != null) {
+                ScreenWindowTraits.applyDidSetStatusBarAppearance()
+            }
+            mStatusBarColor = statusBarColor
+            fragment?.let { ScreenWindowTraits.setColor(this, it.tryGetActivity(), it.tryGetContext()) }
+        }
+
+    var navigationBarColor: Int?
+        get() = mNavigationBarColor
+        set(navigationBarColor) {
+            if (navigationBarColor != null) {
+                ScreenWindowTraits.applyDidSetNavigationBarAppearance()
+            }
+            mNavigationBarColor = navigationBarColor
+            fragment?.let { ScreenWindowTraits.setNavigationBarColor(this, it.tryGetActivity()) }
+        }
+
+    var isNavigationBarHidden: Boolean?
+        get() = mNavigationBarHidden
+        set(navigationBarHidden) {
+            if (navigationBarHidden != null) {
+                ScreenWindowTraits.applyDidSetNavigationBarAppearance()
+            }
+            mNavigationBarHidden = navigationBarHidden
+            fragment?.let {
+                ScreenWindowTraits.setNavigationBarHidden(
+                    this,
+                    it.tryGetActivity(),
+                )
+            }
+        }
+
+    var nativeBackButtonDismissalEnabled: Boolean
+        get() = mNativeBackButtonDismissalEnabled
+        set(enableNativeBackButtonDismissal) {
+            mNativeBackButtonDismissalEnabled = enableNativeBackButtonDismissal
+        }
+
+    enum class StackPresentation {
+        PUSH, MODAL, TRANSPARENT_MODAL
+    }
+
+    enum class StackAnimation {
+        DEFAULT, NONE, FADE, SLIDE_FROM_BOTTOM, SLIDE_FROM_RIGHT, SLIDE_FROM_LEFT, FADE_FROM_BOTTOM
+    }
+
+    enum class ReplaceAnimation {
+        PUSH, POP
+    }
+
+    enum class ActivityState {
+        INACTIVE, TRANSITIONING_OR_BELOW_TOP, ON_TOP
+    }
+
+    enum class WindowTraits {
+        ORIENTATION, COLOR, STYLE, TRANSLUCENT, HIDDEN, ANIMATED, NAVIGATION_BAR_COLOR, NAVIGATION_BAR_HIDDEN
+    }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenContainer.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenContainer.kt
@@ -17,341 +17,341 @@ import com.facebook.react.modules.core.ReactChoreographer
 import versioned.host.exp.exponent.modules.api.screens.Screen.ActivityState
 
 open class ScreenContainer<T : ScreenFragment>(context: Context?) : ViewGroup(context) {
-  @JvmField
-  protected val mScreenFragments = ArrayList<T>()
-  @JvmField
-  protected var mFragmentManager: FragmentManager? = null
-  private var mIsAttached = false
-  private var mNeedUpdate = false
-  private var mLayoutEnqueued = false
-  private val mLayoutCallback: ChoreographerCompat.FrameCallback = object : ChoreographerCompat.FrameCallback() {
-    override fun doFrame(frameTimeNanos: Long) {
-      mLayoutEnqueued = false
-      measure(
-        MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
-        MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY)
-      )
-      layout(left, top, right, bottom)
-    }
-  }
-  private var mParentScreenFragment: ScreenFragment? = null
-  override fun onLayout(changed: Boolean, l: Int, t: Int, r: Int, b: Int) {
-    var i = 0
-    val size = childCount
-    while (i < size) {
-      getChildAt(i).layout(0, 0, width, height)
-      i++
-    }
-  }
-
-  override fun removeView(view: View) {
-    // The below block is a workaround for an issue with keyboard handling within fragments. Despite
-    // Android handles input focus on the fragments that leave the screen, the keyboard stays open
-    // in a number of cases. The issue can be best reproduced on Android 5 devices, before some
-    // changes in Android's InputMethodManager have been introduced (specifically around dismissing
-    // the keyboard in onDetachedFromWindow). However, we also noticed the keyboard issue happen
-    // intermittently on recent versions of Android as well. The issue hasn't been previously
-    // noticed as in React Native <= 0.61 there was a logic that'd trigger keyboard dismiss upon a
-    // blur event (the blur even gets dispatched properly, the keyboard just stays open despite
-    // that) – note the change in RN core here:
-    // https://github.com/facebook/react-native/commit/e9b4928311513d3cbbd9d875827694eab6cfa932
-    // The workaround is to force-hide keyboard when the screen that has focus is dismissed (we
-    // detect that in removeView as super.removeView causes the input view to un focus while keeping
-    // the keyboard open).
-    if (view === focusedChild) {
-      (context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager)
-        .hideSoftInputFromWindow(windowToken, InputMethodManager.HIDE_NOT_ALWAYS)
-    }
-    super.removeView(view)
-  }
-
-  override fun requestLayout() {
-    super.requestLayout()
-    @Suppress("SENSELESS_COMPARISON") // mLayoutCallback can be null here since this method can be called in init
-    if (!mLayoutEnqueued && mLayoutCallback != null) {
-      mLayoutEnqueued = true
-      // we use NATIVE_ANIMATED_MODULE choreographer queue because it allows us to catch the current
-      // looper loop instead of enqueueing the update in the next loop causing a one frame delay.
-      ReactChoreographer.getInstance()
-        .postFrameCallback(
-          ReactChoreographer.CallbackType.NATIVE_ANIMATED_MODULE, mLayoutCallback
-        )
-    }
-  }
-
-  val isNested: Boolean
-    get() = mParentScreenFragment != null
-
-  fun notifyChildUpdate() {
-    performUpdatesNow()
-  }
-
-  protected open fun adapt(screen: Screen): T {
-    @Suppress("UNCHECKED_CAST")
-    return ScreenFragment(screen) as T
-  }
-
-  fun addScreen(screen: Screen, index: Int) {
-    val fragment = adapt(screen)
-    screen.fragment = fragment
-    mScreenFragments.add(index, fragment)
-    screen.container = this
-    onScreenChanged()
-  }
-
-  open fun removeScreenAt(index: Int) {
-    mScreenFragments[index].screen.container = null
-    mScreenFragments.removeAt(index)
-    onScreenChanged()
-  }
-
-  open fun removeAllScreens() {
-    for (screenFragment in mScreenFragments) {
-      screenFragment.screen.container = null
-    }
-    mScreenFragments.clear()
-    onScreenChanged()
-  }
-
-  val screenCount: Int
-    get() = mScreenFragments.size
-
-  fun getScreenAt(index: Int): Screen {
-    return mScreenFragments[index].screen
-  }
-
-  open val topScreen: Screen?
-    get() {
-      for (screenFragment in mScreenFragments) {
-        if (getActivityState(screenFragment) === ActivityState.ON_TOP) {
-          return screenFragment.screen
+    @JvmField
+    protected val mScreenFragments = ArrayList<T>()
+    @JvmField
+    protected var mFragmentManager: FragmentManager? = null
+    private var mIsAttached = false
+    private var mNeedUpdate = false
+    private var mLayoutEnqueued = false
+    private val mLayoutCallback: ChoreographerCompat.FrameCallback = object : ChoreographerCompat.FrameCallback() {
+        override fun doFrame(frameTimeNanos: Long) {
+            mLayoutEnqueued = false
+            measure(
+                MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
+                MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY)
+            )
+            layout(left, top, right, bottom)
         }
-      }
-      return null
     }
-
-  private fun setFragmentManager(fm: FragmentManager) {
-    mFragmentManager = fm
-    performUpdatesNow()
-  }
-
-  private fun setupFragmentManager() {
-    var parent: ViewParent = this
-    // We traverse view hierarchy up until we find screen parent or a root view
-    while (!(parent is ReactRootView || parent is Screen) &&
-      parent.parent != null
-    ) {
-      parent = parent.parent
-    }
-    // If parent is of type Screen it means we are inside a nested fragment structure.
-    // Otherwise we expect to connect directly with root view and get root fragment manager
-    if (parent is Screen) {
-      val screenFragment = parent.fragment
-      check(screenFragment != null) { "Parent Screen does not have its Fragment attached" }
-      mParentScreenFragment = screenFragment
-      screenFragment.registerChildScreenContainer(this)
-      setFragmentManager(screenFragment.childFragmentManager)
-      return
-    }
-
-    // we expect top level view to be of type ReactRootView, this isn't really necessary but in
-    // order to find root view we test if parent is null. This could potentially happen also when
-    // the view is detached from the hierarchy and that test would not correctly indicate the root
-    // view. So in order to make sure we indeed reached the root we test if it is of a correct type.
-    // This allows us to provide a more descriptive error message for the aforementioned case.
-    check(parent is ReactRootView) { "ScreenContainer is not attached under ReactRootView" }
-    // ReactRootView is expected to be initialized with the main React Activity as a context but
-    // in case of Expo the activity is wrapped in ContextWrapper and we need to unwrap it
-    var context = parent.context
-    while (context !is FragmentActivity && context is ContextWrapper) {
-      context = context.baseContext
-    }
-    check(context is FragmentActivity) { "In order to use RNScreens components your app's activity need to extend ReactFragmentActivity or ReactCompatActivity" }
-    setFragmentManager(context.supportFragmentManager)
-  }
-
-  protected fun createTransaction(): FragmentTransaction {
-    val fragmentManager = requireNotNull(mFragmentManager, { "mFragmentManager is null when creating transaction" })
-    val transaction = fragmentManager.beginTransaction()
-    transaction.setReorderingAllowed(true)
-    return transaction
-  }
-
-  private fun attachScreen(transaction: FragmentTransaction, screenFragment: ScreenFragment) {
-    transaction.add(id, screenFragment)
-  }
-
-  private fun detachScreen(transaction: FragmentTransaction, screenFragment: ScreenFragment) {
-    transaction.remove(screenFragment)
-  }
-
-  private fun getActivityState(screenFragment: ScreenFragment): ActivityState? {
-    return screenFragment.screen.activityState
-  }
-
-  open fun hasScreen(screenFragment: ScreenFragment?): Boolean {
-    return mScreenFragments.contains(screenFragment)
-  }
-
-  override fun onAttachedToWindow() {
-    super.onAttachedToWindow()
-    mIsAttached = true
-    setupFragmentManager()
-  }
-
-  /** Removes fragments from fragment manager that are attached to this container  */
-  private fun removeMyFragments(fragmentManager: FragmentManager) {
-    val transaction = fragmentManager.beginTransaction()
-    var hasFragments = false
-    for (fragment in fragmentManager.fragments) {
-      if (fragment is ScreenFragment &&
-        fragment.screen.container === this
-      ) {
-        transaction.remove(fragment)
-        hasFragments = true
-      }
-    }
-
-    if (hasFragments) {
-      transaction.commitNowAllowingStateLoss()
-    }
-  }
-
-  override fun onDetachedFromWindow() {
-    // if there are pending transactions and this view is about to get detached we need to perform
-    // them here as otherwise fragment manager will crash because it won't be able to find container
-    // view. We also need to make sure all the fragments attached to the given container are removed
-    // from fragment manager as in some cases fragment manager may be reused and in such case it'd
-    // attempt to reattach previously registered fragments that are not removed
-    mFragmentManager?.let {
-      if (!it.isDestroyed) {
-        removeMyFragments(it)
-        it.executePendingTransactions()
-      }
-    }
-
-    mParentScreenFragment?.unregisterChildScreenContainer(this)
-    mParentScreenFragment = null
-
-    super.onDetachedFromWindow()
-    mIsAttached = false
-    // When fragment container view is detached we force all its children to be removed.
-    // It is because children screens are controlled by their fragments, which can often have a
-    // delayed lifecycle (due to transitions). As a result due to ongoing transitions the fragment
-    // may choose not to remove the view despite the parent container being completely detached
-    // from the view hierarchy until the transition is over. In such a case when the container gets
-    // re-attached while the transition is ongoing, the child view would still be there and we'd
-    // attempt to re-attach it to with a misconfigured fragment. This would result in a crash. To
-    // avoid it we clear all the children here as we attach all the child fragments when the
-    // container is reattached anyways. We don't use `removeAllViews` since it does not check if the
-    // children are not already detached, which may lead to calling `onDetachedFromWindow` on them
-    // twice.
-    // We also get the size earlier, because we will be removing child views in `for` loop.
-    val size = childCount
-    for (i in size - 1 downTo 0) {
-      removeViewAt(i)
-    }
-  }
-
-  override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
-    super.onMeasure(widthMeasureSpec, heightMeasureSpec)
-    var i = 0
-    val size = childCount
-    while (i < size) {
-      getChildAt(i).measure(widthMeasureSpec, heightMeasureSpec)
-      i++
-    }
-  }
-
-  private fun onScreenChanged() {
-    // we perform update in `onBeforeLayout` of `ScreensShadowNode` by adding an UIBlock
-    // which is called after updating children of the ScreenContainer.
-    // We do it there because `onUpdate` logic requires all changes of children to be already
-    // made in order to provide proper animation for fragment transition for ScreenStack
-    // and this in turn makes nested ScreenContainers detach too early and disappear
-    // before transition if also not dispatched after children updates.
-    // The exception to this rule is `updateImmediately` which is triggered by actions
-    // not connected to React view hierarchy changes, but rather internal events
-    mNeedUpdate = true
-    (context as? ReactContext)?.runOnUiQueueThread {
-      // We schedule the update here because LayoutAnimations of `react-native-reanimated`
-      // sometimes attach/detach screens after the layout block of `ScreensShadowNode` has
-      // already run, and we want to update the container then too. In the other cases,
-      // this code will do nothing since it will run after the UIBlock when `mNeedUpdate`
-      // will already be false.
-      performUpdates()
-    }
-  }
-
-  protected fun performUpdatesNow() {
-    // we want to update immediately when the fragment manager is set or native back button
-    // dismiss is dispatched or Screen's activityState changes since it is not connected to React
-    // view hierarchy changes and will not trigger `onBeforeLayout` method of `ScreensShadowNode`
-    mNeedUpdate = true
-    performUpdates()
-  }
-
-  fun performUpdates() {
-    if (!mNeedUpdate || !mIsAttached || mFragmentManager == null || mFragmentManager?.isDestroyed == true) {
-      return
-    }
-    mNeedUpdate = false
-    onUpdate()
-    notifyContainerUpdate()
-  }
-
-  open fun onUpdate() {
-    createTransaction().let {
-      // detach screens that are no longer active
-      val orphaned: MutableSet<Fragment> = HashSet(requireNotNull(mFragmentManager, { "mFragmentManager is null when performing update in ScreenContainer" }).fragments)
-      for (screenFragment in mScreenFragments) {
-        if (getActivityState(screenFragment) === ActivityState.INACTIVE &&
-          screenFragment.isAdded
-        ) {
-          detachScreen(it, screenFragment)
+    private var mParentScreenFragment: ScreenFragment? = null
+    override fun onLayout(changed: Boolean, l: Int, t: Int, r: Int, b: Int) {
+        var i = 0
+        val size = childCount
+        while (i < size) {
+            getChildAt(i).layout(0, 0, width, height)
+            i++
         }
-        orphaned.remove(screenFragment)
-      }
-      if (orphaned.isNotEmpty()) {
-        val orphanedAry = orphaned.toTypedArray()
-        for (fragment in orphanedAry) {
-          if (fragment is ScreenFragment) {
-            if (fragment.screen.container == null) {
-              detachScreen(it, fragment)
+    }
+
+    override fun removeView(view: View) {
+        // The below block is a workaround for an issue with keyboard handling within fragments. Despite
+        // Android handles input focus on the fragments that leave the screen, the keyboard stays open
+        // in a number of cases. The issue can be best reproduced on Android 5 devices, before some
+        // changes in Android's InputMethodManager have been introduced (specifically around dismissing
+        // the keyboard in onDetachedFromWindow). However, we also noticed the keyboard issue happen
+        // intermittently on recent versions of Android as well. The issue hasn't been previously
+        // noticed as in React Native <= 0.61 there was a logic that'd trigger keyboard dismiss upon a
+        // blur event (the blur even gets dispatched properly, the keyboard just stays open despite
+        // that) – note the change in RN core here:
+        // https://github.com/facebook/react-native/commit/e9b4928311513d3cbbd9d875827694eab6cfa932
+        // The workaround is to force-hide keyboard when the screen that has focus is dismissed (we
+        // detect that in removeView as super.removeView causes the input view to un focus while keeping
+        // the keyboard open).
+        if (view === focusedChild) {
+            (context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager)
+                .hideSoftInputFromWindow(windowToken, InputMethodManager.HIDE_NOT_ALWAYS)
+        }
+        super.removeView(view)
+    }
+
+    override fun requestLayout() {
+        super.requestLayout()
+        @Suppress("SENSELESS_COMPARISON") // mLayoutCallback can be null here since this method can be called in init
+        if (!mLayoutEnqueued && mLayoutCallback != null) {
+            mLayoutEnqueued = true
+            // we use NATIVE_ANIMATED_MODULE choreographer queue because it allows us to catch the current
+            // looper loop instead of enqueueing the update in the next loop causing a one frame delay.
+            ReactChoreographer.getInstance()
+                .postFrameCallback(
+                    ReactChoreographer.CallbackType.NATIVE_ANIMATED_MODULE, mLayoutCallback
+                )
+        }
+    }
+
+    val isNested: Boolean
+        get() = mParentScreenFragment != null
+
+    fun notifyChildUpdate() {
+        performUpdatesNow()
+    }
+
+    protected open fun adapt(screen: Screen): T {
+        @Suppress("UNCHECKED_CAST")
+        return ScreenFragment(screen) as T
+    }
+
+    fun addScreen(screen: Screen, index: Int) {
+        val fragment = adapt(screen)
+        screen.fragment = fragment
+        mScreenFragments.add(index, fragment)
+        screen.container = this
+        onScreenChanged()
+    }
+
+    open fun removeScreenAt(index: Int) {
+        mScreenFragments[index].screen.container = null
+        mScreenFragments.removeAt(index)
+        onScreenChanged()
+    }
+
+    open fun removeAllScreens() {
+        for (screenFragment in mScreenFragments) {
+            screenFragment.screen.container = null
+        }
+        mScreenFragments.clear()
+        onScreenChanged()
+    }
+
+    val screenCount: Int
+        get() = mScreenFragments.size
+
+    fun getScreenAt(index: Int): Screen {
+        return mScreenFragments[index].screen
+    }
+
+    open val topScreen: Screen?
+        get() {
+            for (screenFragment in mScreenFragments) {
+                if (getActivityState(screenFragment) === ActivityState.ON_TOP) {
+                    return screenFragment.screen
+                }
             }
-          }
+            return null
         }
-      }
 
-      // if there is an "onTop" screen it means the transition has ended
-      val transitioning = topScreen == null
-
-      // attach newly activated screens
-      var addedBefore = false
-      val pendingFront: ArrayList<T> = ArrayList()
-
-      for (screenFragment in mScreenFragments) {
-        val activityState = getActivityState(screenFragment)
-        if (activityState !== ActivityState.INACTIVE && !screenFragment.isAdded) {
-          addedBefore = true
-          attachScreen(it, screenFragment)
-        } else if (activityState !== ActivityState.INACTIVE && addedBefore) {
-          // we detach the screen and then reattach it later to make it appear on front
-          detachScreen(it, screenFragment)
-          pendingFront.add(screenFragment)
-        }
-        screenFragment.screen.setTransitioning(transitioning)
-      }
-
-      for (screenFragment in pendingFront) {
-        attachScreen(it, screenFragment)
-      }
-
-      it.commitNowAllowingStateLoss()
+    private fun setFragmentManager(fm: FragmentManager) {
+        mFragmentManager = fm
+        performUpdatesNow()
     }
-  }
 
-  protected open fun notifyContainerUpdate() {
-    topScreen?.fragment?.onContainerUpdate()
-  }
+    private fun setupFragmentManager() {
+        var parent: ViewParent = this
+        // We traverse view hierarchy up until we find screen parent or a root view
+        while (!(parent is ReactRootView || parent is Screen) &&
+            parent.parent != null
+        ) {
+            parent = parent.parent
+        }
+        // If parent is of type Screen it means we are inside a nested fragment structure.
+        // Otherwise we expect to connect directly with root view and get root fragment manager
+        if (parent is Screen) {
+            val screenFragment = parent.fragment
+            check(screenFragment != null) { "Parent Screen does not have its Fragment attached" }
+            mParentScreenFragment = screenFragment
+            screenFragment.registerChildScreenContainer(this)
+            setFragmentManager(screenFragment.childFragmentManager)
+            return
+        }
+
+        // we expect top level view to be of type ReactRootView, this isn't really necessary but in
+        // order to find root view we test if parent is null. This could potentially happen also when
+        // the view is detached from the hierarchy and that test would not correctly indicate the root
+        // view. So in order to make sure we indeed reached the root we test if it is of a correct type.
+        // This allows us to provide a more descriptive error message for the aforementioned case.
+        check(parent is ReactRootView) { "ScreenContainer is not attached under ReactRootView" }
+        // ReactRootView is expected to be initialized with the main React Activity as a context but
+        // in case of Expo the activity is wrapped in ContextWrapper and we need to unwrap it
+        var context = parent.context
+        while (context !is FragmentActivity && context is ContextWrapper) {
+            context = context.baseContext
+        }
+        check(context is FragmentActivity) { "In order to use RNScreens components your app's activity need to extend ReactActivity" }
+        setFragmentManager(context.supportFragmentManager)
+    }
+
+    protected fun createTransaction(): FragmentTransaction {
+        val fragmentManager = requireNotNull(mFragmentManager, { "mFragmentManager is null when creating transaction" })
+        val transaction = fragmentManager.beginTransaction()
+        transaction.setReorderingAllowed(true)
+        return transaction
+    }
+
+    private fun attachScreen(transaction: FragmentTransaction, screenFragment: ScreenFragment) {
+        transaction.add(id, screenFragment)
+    }
+
+    private fun detachScreen(transaction: FragmentTransaction, screenFragment: ScreenFragment) {
+        transaction.remove(screenFragment)
+    }
+
+    private fun getActivityState(screenFragment: ScreenFragment): ActivityState? {
+        return screenFragment.screen.activityState
+    }
+
+    open fun hasScreen(screenFragment: ScreenFragment?): Boolean {
+        return mScreenFragments.contains(screenFragment)
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        mIsAttached = true
+        setupFragmentManager()
+    }
+
+    /** Removes fragments from fragment manager that are attached to this container  */
+    private fun removeMyFragments(fragmentManager: FragmentManager) {
+        val transaction = fragmentManager.beginTransaction()
+        var hasFragments = false
+        for (fragment in fragmentManager.fragments) {
+            if (fragment is ScreenFragment &&
+                fragment.screen.container === this
+            ) {
+                transaction.remove(fragment)
+                hasFragments = true
+            }
+        }
+
+        if (hasFragments) {
+            transaction.commitNowAllowingStateLoss()
+        }
+    }
+
+    override fun onDetachedFromWindow() {
+        // if there are pending transactions and this view is about to get detached we need to perform
+        // them here as otherwise fragment manager will crash because it won't be able to find container
+        // view. We also need to make sure all the fragments attached to the given container are removed
+        // from fragment manager as in some cases fragment manager may be reused and in such case it'd
+        // attempt to reattach previously registered fragments that are not removed
+        mFragmentManager?.let {
+            if (!it.isDestroyed) {
+                removeMyFragments(it)
+                it.executePendingTransactions()
+            }
+        }
+
+        mParentScreenFragment?.unregisterChildScreenContainer(this)
+        mParentScreenFragment = null
+
+        super.onDetachedFromWindow()
+        mIsAttached = false
+        // When fragment container view is detached we force all its children to be removed.
+        // It is because children screens are controlled by their fragments, which can often have a
+        // delayed lifecycle (due to transitions). As a result due to ongoing transitions the fragment
+        // may choose not to remove the view despite the parent container being completely detached
+        // from the view hierarchy until the transition is over. In such a case when the container gets
+        // re-attached while the transition is ongoing, the child view would still be there and we'd
+        // attempt to re-attach it to with a misconfigured fragment. This would result in a crash. To
+        // avoid it we clear all the children here as we attach all the child fragments when the
+        // container is reattached anyways. We don't use `removeAllViews` since it does not check if the
+        // children are not already detached, which may lead to calling `onDetachedFromWindow` on them
+        // twice.
+        // We also get the size earlier, because we will be removing child views in `for` loop.
+        val size = childCount
+        for (i in size - 1 downTo 0) {
+            removeViewAt(i)
+        }
+    }
+
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        super.onMeasure(widthMeasureSpec, heightMeasureSpec)
+        var i = 0
+        val size = childCount
+        while (i < size) {
+            getChildAt(i).measure(widthMeasureSpec, heightMeasureSpec)
+            i++
+        }
+    }
+
+    private fun onScreenChanged() {
+        // we perform update in `onBeforeLayout` of `ScreensShadowNode` by adding an UIBlock
+        // which is called after updating children of the ScreenContainer.
+        // We do it there because `onUpdate` logic requires all changes of children to be already
+        // made in order to provide proper animation for fragment transition for ScreenStack
+        // and this in turn makes nested ScreenContainers detach too early and disappear
+        // before transition if also not dispatched after children updates.
+        // The exception to this rule is `updateImmediately` which is triggered by actions
+        // not connected to React view hierarchy changes, but rather internal events
+        mNeedUpdate = true
+        (context as? ReactContext)?.runOnUiQueueThread {
+            // We schedule the update here because LayoutAnimations of `react-native-reanimated`
+            // sometimes attach/detach screens after the layout block of `ScreensShadowNode` has
+            // already run, and we want to update the container then too. In the other cases,
+            // this code will do nothing since it will run after the UIBlock when `mNeedUpdate`
+            // will already be false.
+            performUpdates()
+        }
+    }
+
+    protected fun performUpdatesNow() {
+        // we want to update immediately when the fragment manager is set or native back button
+        // dismiss is dispatched or Screen's activityState changes since it is not connected to React
+        // view hierarchy changes and will not trigger `onBeforeLayout` method of `ScreensShadowNode`
+        mNeedUpdate = true
+        performUpdates()
+    }
+
+    fun performUpdates() {
+        if (!mNeedUpdate || !mIsAttached || mFragmentManager == null || mFragmentManager?.isDestroyed == true) {
+            return
+        }
+        mNeedUpdate = false
+        onUpdate()
+        notifyContainerUpdate()
+    }
+
+    open fun onUpdate() {
+        createTransaction().let {
+            // detach screens that are no longer active
+            val orphaned: MutableSet<Fragment> = HashSet(requireNotNull(mFragmentManager, { "mFragmentManager is null when performing update in ScreenContainer" }).fragments)
+            for (screenFragment in mScreenFragments) {
+                if (getActivityState(screenFragment) === ActivityState.INACTIVE &&
+                    screenFragment.isAdded
+                ) {
+                    detachScreen(it, screenFragment)
+                }
+                orphaned.remove(screenFragment)
+            }
+            if (orphaned.isNotEmpty()) {
+                val orphanedAry = orphaned.toTypedArray()
+                for (fragment in orphanedAry) {
+                    if (fragment is ScreenFragment) {
+                        if (fragment.screen.container == null) {
+                            detachScreen(it, fragment)
+                        }
+                    }
+                }
+            }
+
+            // if there is an "onTop" screen it means the transition has ended
+            val transitioning = topScreen == null
+
+            // attach newly activated screens
+            var addedBefore = false
+            val pendingFront: ArrayList<T> = ArrayList()
+
+            for (screenFragment in mScreenFragments) {
+                val activityState = getActivityState(screenFragment)
+                if (activityState !== ActivityState.INACTIVE && !screenFragment.isAdded) {
+                    addedBefore = true
+                    attachScreen(it, screenFragment)
+                } else if (activityState !== ActivityState.INACTIVE && addedBefore) {
+                    // we detach the screen and then reattach it later to make it appear on front
+                    detachScreen(it, screenFragment)
+                    pendingFront.add(screenFragment)
+                }
+                screenFragment.screen.setTransitioning(transitioning)
+            }
+
+            for (screenFragment in pendingFront) {
+                attachScreen(it, screenFragment)
+            }
+
+            it.commitNowAllowingStateLoss()
+        }
+    }
+
+    protected open fun notifyContainerUpdate() {
+        topScreen?.fragment?.onContainerUpdate()
+    }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenContainerViewManager.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenContainerViewManager.kt
@@ -9,44 +9,44 @@ import com.facebook.react.uimanager.ViewGroupManager
 
 @ReactModule(name = ScreenContainerViewManager.REACT_CLASS)
 class ScreenContainerViewManager : ViewGroupManager<ScreenContainer<*>>() {
-  override fun getName(): String {
-    return REACT_CLASS
-  }
+    override fun getName(): String {
+        return REACT_CLASS
+    }
 
-  override fun createViewInstance(reactContext: ThemedReactContext): ScreenContainer<ScreenFragment> {
-    return ScreenContainer(reactContext)
-  }
+    override fun createViewInstance(reactContext: ThemedReactContext): ScreenContainer<ScreenFragment> {
+        return ScreenContainer(reactContext)
+    }
 
-  override fun addView(parent: ScreenContainer<*>, child: View, index: Int) {
-    require(child is Screen) { "Attempt attach child that is not of type RNScreens" }
-    parent.addScreen(child, index)
-  }
+    override fun addView(parent: ScreenContainer<*>, child: View, index: Int) {
+        require(child is Screen) { "Attempt attach child that is not of type RNScreens" }
+        parent.addScreen(child, index)
+    }
 
-  override fun removeViewAt(parent: ScreenContainer<*>, index: Int) {
-    parent.removeScreenAt(index)
-  }
+    override fun removeViewAt(parent: ScreenContainer<*>, index: Int) {
+        parent.removeScreenAt(index)
+    }
 
-  override fun removeAllViews(parent: ScreenContainer<*>) {
-    parent.removeAllScreens()
-  }
+    override fun removeAllViews(parent: ScreenContainer<*>) {
+        parent.removeAllScreens()
+    }
 
-  override fun getChildCount(parent: ScreenContainer<*>): Int {
-    return parent.screenCount
-  }
+    override fun getChildCount(parent: ScreenContainer<*>): Int {
+        return parent.screenCount
+    }
 
-  override fun getChildAt(parent: ScreenContainer<*>, index: Int): View {
-    return parent.getScreenAt(index)
-  }
+    override fun getChildAt(parent: ScreenContainer<*>, index: Int): View {
+        return parent.getScreenAt(index)
+    }
 
-  override fun createShadowNodeInstance(context: ReactApplicationContext): LayoutShadowNode {
-    return ScreensShadowNode(context)
-  }
+    override fun createShadowNodeInstance(context: ReactApplicationContext): LayoutShadowNode {
+        return ScreensShadowNode(context)
+    }
 
-  override fun needsCustomLayoutForChildren(): Boolean {
-    return true
-  }
+    override fun needsCustomLayoutForChildren(): Boolean {
+        return true
+    }
 
-  companion object {
-    const val REACT_CLASS = "RNSScreenContainer"
-  }
+    companion object {
+        const val REACT_CLASS = "RNSScreenContainer"
+    }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenFragment.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenFragment.kt
@@ -25,278 +25,309 @@ import kotlin.math.max
 import kotlin.math.min
 
 open class ScreenFragment : Fragment {
-  enum class ScreenLifecycleEvent {
-    Appear, WillAppear, Disappear, WillDisappear
-  }
-
-  // if we call empty constructor, there is no screen to be assigned so not sure why it is suggested
-  @Suppress("JoinDeclarationAndAssignment")
-  lateinit var screen: Screen
-  private val mChildScreenContainers: MutableList<ScreenContainer<*>> = ArrayList()
-  private var shouldUpdateOnResume = false
-  // if we don't set it, it will be 0.0f at the beginning so the progress will not be sent
-  // due to progress value being already 0.0f
-  private var mProgress = -1f
-
-  constructor() {
-    throw IllegalStateException(
-      "Screen fragments should never be restored. Follow instructions from https://github.com/software-mansion/react-native-screens/issues/17#issuecomment-424704067 to properly configure your main activity."
-    )
-  }
-
-  @SuppressLint("ValidFragment")
-  constructor(screenView: Screen) : super() {
-    screen = screenView
-  }
-
-  override fun onResume() {
-    super.onResume()
-    if (shouldUpdateOnResume) {
-      shouldUpdateOnResume = false
-      ScreenWindowTraits.trySetWindowTraits(screen, tryGetActivity(), tryGetContext())
+    enum class ScreenLifecycleEvent {
+        Appear, WillAppear, Disappear, WillDisappear
     }
-  }
 
-  override fun onCreateView(
-    inflater: LayoutInflater,
-    container: ViewGroup?,
-    savedInstanceState: Bundle?
-  ): View? {
-    val wrapper = context?.let { ScreensFrameLayout(it) }
+    // if we call empty constructor, there is no screen to be assigned so not sure why it is suggested
+    @Suppress("JoinDeclarationAndAssignment")
+    lateinit var screen: Screen
+    private val mChildScreenContainers: MutableList<ScreenContainer<*>> = ArrayList()
+    private var shouldUpdateOnResume = false
+    // if we don't set it, it will be 0.0f at the beginning so the progress will not be sent
+    // due to progress value being already 0.0f
+    private var mProgress = -1f
 
-    val params = FrameLayout.LayoutParams(
-      ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT
-    )
-    screen.layoutParams = params
-    wrapper?.addView(recycleView(screen))
-    return wrapper
-  }
+    // those 2 vars are needed since sometimes the events would be dispatched twice in child containers
+    // (should only happen if parent has `NONE` animation) and we don't need too complicated logic.
+    // We just check if, after the event was dispatched, its "counter-event" has been also dispatched before sending the same event again.
+    // We do it for 'willAppear' -> 'willDisappear' and 'appear' -> 'disappear'
+    private var canDispatchWillAppear = true
+    private var canDispatchAppear = true
 
-  private class ScreensFrameLayout(
-    context: Context,
-  ) : FrameLayout(context) {
-    /**
-     * This method implements a workaround for RN's autoFocus functionality. Because of the way
-     * autoFocus is implemented it dismisses soft keyboard in fragment transition
-     * due to change of visibility of the view at the start of the transition. Here we override the
-     * call to `clearFocus` when the visibility of view is `INVISIBLE` since `clearFocus` triggers the
-     * hiding of the keyboard in `ReactEditText.java`.
-     */
-    override fun clearFocus() {
-      if (visibility != INVISIBLE) {
-        super.clearFocus()
-      }
+    // we want to know if we are currently transitioning in order not to fire lifecycle events
+    // in nested fragments. See more explanation in dispatchViewAnimationEvent
+    private var isTransitioning = false
+
+    constructor() {
+        throw IllegalStateException(
+            "Screen fragments should never be restored. Follow instructions from https://github.com/software-mansion/react-native-screens/issues/17#issuecomment-424704067 to properly configure your main activity."
+        )
     }
-  }
 
-  open fun onContainerUpdate() {
-    updateWindowTraits()
-  }
+    @SuppressLint("ValidFragment")
+    constructor(screenView: Screen) : super() {
+        screen = screenView
+    }
 
-  private fun updateWindowTraits() {
-    val activity: Activity? = activity
-    if (activity == null) {
-      shouldUpdateOnResume = true
-      return
-    }
-    ScreenWindowTraits.trySetWindowTraits(screen, activity, tryGetContext())
-  }
-
-  fun tryGetActivity(): Activity? {
-    activity?.let { return it }
-    val context = screen.context
-    if (context is ReactContext && context.currentActivity != null) {
-      return context.currentActivity
-    }
-    var parent: ViewParent? = screen.container
-    while (parent != null) {
-      if (parent is Screen) {
-        val fragment = parent.fragment
-        fragment?.activity?.let { return it }
-      }
-      parent = parent.parent
-    }
-    return null
-  }
-
-  fun tryGetContext(): ReactContext? {
-    if (context is ReactContext) {
-      return context as ReactContext
-    }
-    if (screen.context is ReactContext) {
-      return screen.context as ReactContext
-    }
-    var parent: ViewParent? = screen.container
-    while (parent != null) {
-      if (parent is Screen) {
-        if (parent.context is ReactContext) {
-          return parent.context as ReactContext
+    override fun onResume() {
+        super.onResume()
+        if (shouldUpdateOnResume) {
+            shouldUpdateOnResume = false
+            ScreenWindowTraits.trySetWindowTraits(screen, tryGetActivity(), tryGetContext())
         }
-      }
-      parent = parent.parent
     }
-    return null
-  }
 
-  val childScreenContainers: List<ScreenContainer<*>>
-    get() = mChildScreenContainers
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        val wrapper = context?.let { ScreensFrameLayout(it) }
 
-  fun dispatchOnWillAppear() {
-    dispatchEvent(ScreenLifecycleEvent.WillAppear, this)
+        val params = FrameLayout.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT
+        )
+        screen.layoutParams = params
+        wrapper?.addView(recycleView(screen))
+        return wrapper
+    }
 
-    dispatchTransitionProgress(0.0f, false)
-  }
-
-  fun dispatchOnAppear() {
-    dispatchEvent(ScreenLifecycleEvent.Appear, this)
-
-    dispatchTransitionProgress(1.0f, false)
-  }
-
-  protected fun dispatchOnWillDisappear() {
-    dispatchEvent(ScreenLifecycleEvent.WillDisappear, this)
-
-    dispatchTransitionProgress(0.0f, true)
-  }
-
-  protected fun dispatchOnDisappear() {
-    dispatchEvent(ScreenLifecycleEvent.Disappear, this)
-
-    dispatchTransitionProgress(1.0f, true)
-  }
-
-  private fun dispatchEvent(event: ScreenLifecycleEvent, fragment: ScreenFragment) {
-    if (fragment is ScreenStackFragment) {
-      fragment.screen.let {
-        val lifecycleEvent: Event<*> = when (event) {
-          ScreenLifecycleEvent.WillAppear -> ScreenWillAppearEvent(it.id)
-          ScreenLifecycleEvent.Appear -> ScreenAppearEvent(it.id)
-          ScreenLifecycleEvent.WillDisappear -> ScreenWillDisappearEvent(it.id)
-          ScreenLifecycleEvent.Disappear -> ScreenDisappearEvent(it.id)
+    private class ScreensFrameLayout(
+        context: Context,
+    ) : FrameLayout(context) {
+        /**
+         * This method implements a workaround for RN's autoFocus functionality. Because of the way
+         * autoFocus is implemented it dismisses soft keyboard in fragment transition
+         * due to change of visibility of the view at the start of the transition. Here we override the
+         * call to `clearFocus` when the visibility of view is `INVISIBLE` since `clearFocus` triggers the
+         * hiding of the keyboard in `ReactEditText.java`.
+         */
+        override fun clearFocus() {
+            if (visibility != INVISIBLE) {
+                super.clearFocus()
+            }
         }
-        (it.context as ReactContext)
-          .getNativeModule(UIManagerModule::class.java)
-          ?.eventDispatcher
-          ?.dispatchEvent(lifecycleEvent)
-        fragment.dispatchEventInChildContainers(event)
-      }
     }
-  }
 
-  private fun dispatchEventInChildContainers(event: ScreenLifecycleEvent) {
-    for (sc in mChildScreenContainers) {
-      if (sc.screenCount > 0) {
-        sc.topScreen?.let {
-          if (it.stackAnimation !== Screen.StackAnimation.NONE || isRemoving) {
-            // we do not dispatch events in child when it has `none` animation
-            // and we are going forward since then they will be dispatched in child via
-            // `onCreateAnimation` of ScreenStackFragment
-            sc.topScreen?.fragment?.let { fragment -> dispatchEvent(event, fragment) }
-          }
+    open fun onContainerUpdate() {
+        updateWindowTraits()
+    }
+
+    private fun updateWindowTraits() {
+        val activity: Activity? = activity
+        if (activity == null) {
+            shouldUpdateOnResume = true
+            return
         }
-      }
+        ScreenWindowTraits.trySetWindowTraits(screen, activity, tryGetContext())
     }
-  }
 
-  fun dispatchHeaderBackButtonClickedEvent() {
-    (screen.context as ReactContext)
-      .getNativeModule(UIManagerModule::class.java)
-      ?.eventDispatcher
-      ?.dispatchEvent(HeaderBackButtonClickedEvent(screen.id))
-  }
+    fun tryGetActivity(): Activity? {
+        activity?.let { return it }
+        val context = screen.context
+        if (context is ReactContext && context.currentActivity != null) {
+            return context.currentActivity
+        }
+        var parent: ViewParent? = screen.container
+        while (parent != null) {
+            if (parent is Screen) {
+                val fragment = parent.fragment
+                fragment?.activity?.let { return it }
+            }
+            parent = parent.parent
+        }
+        return null
+    }
 
-  fun dispatchTransitionProgress(alpha: Float, closing: Boolean) {
-    if (this is ScreenStackFragment) {
-      if (mProgress != alpha) {
-        mProgress = max(0.0f, min(1.0f, alpha))
+    fun tryGetContext(): ReactContext? {
+        if (context is ReactContext) {
+            return context as ReactContext
+        }
+        if (screen.context is ReactContext) {
+            return screen.context as ReactContext
+        }
+        var parent: ViewParent? = screen.container
+        while (parent != null) {
+            if (parent is Screen) {
+                if (parent.context is ReactContext) {
+                    return parent.context as ReactContext
+                }
+            }
+            parent = parent.parent
+        }
+        return null
+    }
+
+    val childScreenContainers: List<ScreenContainer<*>>
+        get() = mChildScreenContainers
+
+    private fun canDispatchEvent(event: ScreenLifecycleEvent): Boolean {
+        return when (event) {
+            ScreenLifecycleEvent.WillAppear -> canDispatchWillAppear
+            ScreenLifecycleEvent.Appear -> canDispatchAppear
+            ScreenLifecycleEvent.WillDisappear -> !canDispatchWillAppear
+            ScreenLifecycleEvent.Disappear -> !canDispatchAppear
+        }
+    }
+
+    private fun setLastEventDispatched(event: ScreenLifecycleEvent) {
+        when (event) {
+            ScreenLifecycleEvent.WillAppear -> canDispatchWillAppear = false
+            ScreenLifecycleEvent.Appear -> canDispatchAppear = false
+            ScreenLifecycleEvent.WillDisappear -> canDispatchWillAppear = true
+            ScreenLifecycleEvent.Disappear -> canDispatchAppear = true
+        }
+    }
+
+    private fun dispatchOnWillAppear() {
+        dispatchEvent(ScreenLifecycleEvent.WillAppear, this)
+
+        dispatchTransitionProgress(0.0f, false)
+    }
+
+    private fun dispatchOnAppear() {
+        dispatchEvent(ScreenLifecycleEvent.Appear, this)
+
+        dispatchTransitionProgress(1.0f, false)
+    }
+
+    private fun dispatchOnWillDisappear() {
+        dispatchEvent(ScreenLifecycleEvent.WillDisappear, this)
+
+        dispatchTransitionProgress(0.0f, true)
+    }
+
+    private fun dispatchOnDisappear() {
+        dispatchEvent(ScreenLifecycleEvent.Disappear, this)
+
+        dispatchTransitionProgress(1.0f, true)
+    }
+
+    private fun dispatchEvent(event: ScreenLifecycleEvent, fragment: ScreenFragment) {
+        if (fragment is ScreenStackFragment && fragment.canDispatchEvent(event)) {
+            fragment.screen.let {
+                fragment.setLastEventDispatched(event)
+                val lifecycleEvent: Event<*> = when (event) {
+                    ScreenLifecycleEvent.WillAppear -> ScreenWillAppearEvent(it.id)
+                    ScreenLifecycleEvent.Appear -> ScreenAppearEvent(it.id)
+                    ScreenLifecycleEvent.WillDisappear -> ScreenWillDisappearEvent(it.id)
+                    ScreenLifecycleEvent.Disappear -> ScreenDisappearEvent(it.id)
+                }
+                (it.context as ReactContext)
+                    .getNativeModule(UIManagerModule::class.java)
+                    ?.eventDispatcher
+                    ?.dispatchEvent(lifecycleEvent)
+                fragment.dispatchEventInChildContainers(event)
+            }
+        }
+    }
+
+    private fun dispatchEventInChildContainers(event: ScreenLifecycleEvent) {
+        for (sc in mChildScreenContainers) {
+            if (sc.screenCount > 0) {
+                sc.topScreen?.let {
+                    sc.topScreen?.fragment?.let { fragment -> dispatchEvent(event, fragment) }
+                }
+            }
+        }
+    }
+
+    fun dispatchHeaderBackButtonClickedEvent() {
+        (screen.context as ReactContext)
+            .getNativeModule(UIManagerModule::class.java)
+            ?.eventDispatcher
+            ?.dispatchEvent(HeaderBackButtonClickedEvent(screen.id))
+    }
+
+    fun dispatchTransitionProgress(alpha: Float, closing: Boolean) {
+        if (this is ScreenStackFragment) {
+            if (mProgress != alpha) {
+                mProgress = max(0.0f, min(1.0f, alpha))
                 /* We want value of 0 and 1 to be always dispatched so we base coalescing key on the progress:
                  - progress is 0 -> key 1
                  - progress is 1 -> key 2
                  - progress is between 0 and 1 -> key 3
              */
-        val coalescingKey = (if (mProgress == 0.0f) 1 else if (mProgress == 1.0f) 2 else 3).toShort()
-        val container: ScreenContainer<*>? = screen.container
-        val goingForward = if (container is ScreenStack) container.goingForward else false
-        (screen.context as ReactContext)
-          .getNativeModule(UIManagerModule::class.java)
-          ?.eventDispatcher
-          ?.dispatchEvent(
-            ScreenTransitionProgressEvent(
-              screen.id, mProgress, closing, goingForward, coalescingKey
-            )
-          )
-      }
+                val coalescingKey = (if (mProgress == 0.0f) 1 else if (mProgress == 1.0f) 2 else 3).toShort()
+                val container: ScreenContainer<*>? = screen.container
+                val goingForward = if (container is ScreenStack) container.goingForward else false
+                (screen.context as ReactContext)
+                    .getNativeModule(UIManagerModule::class.java)
+                    ?.eventDispatcher
+                    ?.dispatchEvent(
+                        ScreenTransitionProgressEvent(
+                            screen.id, mProgress, closing, goingForward, coalescingKey
+                        )
+                    )
+            }
+        }
     }
-  }
 
-  fun registerChildScreenContainer(screenContainer: ScreenContainer<*>) {
-    mChildScreenContainers.add(screenContainer)
-  }
-
-  fun unregisterChildScreenContainer(screenContainer: ScreenContainer<*>) {
-    mChildScreenContainers.remove(screenContainer)
-  }
-
-  fun onViewAnimationStart() {
-    // onViewAnimationStart is triggered from View#onAnimationStart method of the fragment's root
-    // view. We override Screen#onAnimationStart and an appropriate method of the StackFragment's
-    // root view in order to achieve this.
-    if (isResumed) {
-      // Android dispatches the animation start event for the fragment that is being added first
-      // however we want the one being dismissed first to match iOS. It also makes more sense from
-      // a navigation point of view to have the disappear event first.
-      // Since there are no explicit relationships between the fragment being added / removed the
-      // practical way to fix this is delaying dispatching the appear events at the end of the
-      // frame.
-      UiThreadUtil.runOnUiThread { dispatchOnWillAppear() }
-    } else {
-      dispatchOnWillDisappear()
+    fun registerChildScreenContainer(screenContainer: ScreenContainer<*>) {
+        mChildScreenContainers.add(screenContainer)
     }
-  }
 
-  open fun onViewAnimationEnd() {
-    // onViewAnimationEnd is triggered from View#onAnimationEnd method of the fragment's root view.
-    // We override Screen#onAnimationEnd and an appropriate method of the StackFragment's root view
-    // in order to achieve this.
-    if (isResumed) {
-      // See the comment in onViewAnimationStart for why this event is delayed.
-      UiThreadUtil.runOnUiThread { dispatchOnAppear() }
-    } else {
-      dispatchOnDisappear()
+    fun unregisterChildScreenContainer(screenContainer: ScreenContainer<*>) {
+        mChildScreenContainers.remove(screenContainer)
     }
-  }
 
-  override fun onDestroy() {
-    super.onDestroy()
-    val container = screen.container
-    if (container == null || !container.hasScreen(this)) {
-      // we only send dismissed even when the screen has been removed from its container
-      if (screen.context is ReactContext) {
-        (screen.context as ReactContext)
-          .getNativeModule(UIManagerModule::class.java)
-          ?.eventDispatcher
-          ?.dispatchEvent(ScreenDismissedEvent(screen.id))
-      }
+    fun onViewAnimationStart() {
+        dispatchViewAnimationEvent(false)
     }
-    mChildScreenContainers.clear()
-  }
 
-  companion object {
-    @JvmStatic
-    protected fun recycleView(view: View): View {
-      // screen fragments reuse view instances instead of creating new ones. In order to reuse a given
-      // view it needs to be detached from the view hierarchy to allow the fragment to attach it back.
-      val parent = view.parent
-      if (parent != null) {
-        (parent as ViewGroup).endViewTransition(view)
-        parent.removeView(view)
-      }
-
-      // view detached from fragment manager get their visibility changed to GONE after their state is
-      // dumped. Since we don't restore the state but want to reuse the view we need to change
-      // visibility back to VISIBLE in order for the fragment manager to animate in the view.
-      view.visibility = View.VISIBLE
-      return view
+    open fun onViewAnimationEnd() {
+        dispatchViewAnimationEvent(true)
     }
-  }
+
+    private fun dispatchViewAnimationEvent(animationEnd: Boolean) {
+        isTransitioning = !animationEnd
+        // if parent fragment is transitioning, we do not want the events dispatched from the child,
+        // since we subscribe to parent's animation start/end and dispatch events in child from there
+        // check for `isTransitioning` should be enough since the child's animation should take only
+        // 20ms due to always being `StackAnimation.NONE` when nested stack being pushed
+        val parent = parentFragment
+        if (parent == null || (parent is ScreenFragment && !parent.isTransitioning)) {
+            // onViewAnimationStart/End is triggered from View#onAnimationStart/End method of the fragment's root
+            // view. We override an appropriate method of the StackFragment's
+            // root view in order to achieve this.
+            if (isResumed) {
+                // Android dispatches the animation start event for the fragment that is being added first
+                // however we want the one being dismissed first to match iOS. It also makes more sense from
+                // a navigation point of view to have the disappear event first.
+                // Since there are no explicit relationships between the fragment being added / removed the
+                // practical way to fix this is delaying dispatching the appear events at the end of the
+                // frame.
+                UiThreadUtil.runOnUiThread {
+                    if (animationEnd) dispatchOnAppear() else dispatchOnWillAppear()
+                }
+            } else {
+                if (animationEnd) dispatchOnDisappear() else dispatchOnWillDisappear()
+            }
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        val container = screen.container
+        if (container == null || !container.hasScreen(this)) {
+            // we only send dismissed even when the screen has been removed from its container
+            if (screen.context is ReactContext) {
+                (screen.context as ReactContext)
+                    .getNativeModule(UIManagerModule::class.java)
+                    ?.eventDispatcher
+                    ?.dispatchEvent(ScreenDismissedEvent(screen.id))
+            }
+        }
+        mChildScreenContainers.clear()
+    }
+
+    companion object {
+        @JvmStatic
+        protected fun recycleView(view: View): View {
+            // screen fragments reuse view instances instead of creating new ones. In order to reuse a given
+            // view it needs to be detached from the view hierarchy to allow the fragment to attach it back.
+            val parent = view.parent
+            if (parent != null) {
+                (parent as ViewGroup).endViewTransition(view)
+                parent.removeView(view)
+            }
+
+            // view detached from fragment manager get their visibility changed to GONE after their state is
+            // dumped. Since we don't restore the state but want to reuse the view we need to change
+            // visibility back to VISIBLE in order for the fragment manager to animate in the view.
+            view.visibility = View.VISIBLE
+            return view
+        }
+    }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenStack.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenStack.kt
@@ -3,7 +3,6 @@ package versioned.host.exp.exponent.modules.api.screens
 import android.content.Context
 import android.graphics.Canvas
 import android.view.View
-import androidx.fragment.app.FragmentTransaction
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.uimanager.UIManagerModule
 import versioned.host.exp.exponent.modules.api.screens.Screen.StackAnimation
@@ -15,357 +14,336 @@ import kotlin.collections.HashSet
 import host.exp.expoview.R
 
 class ScreenStack(context: Context?) : ScreenContainer<ScreenStackFragment>(context) {
-  private val mStack = ArrayList<ScreenStackFragment>()
-  private val mDismissed: MutableSet<ScreenStackFragment> = HashSet()
-  private val drawingOpPool: MutableList<DrawingOp> = ArrayList()
-  private val drawingOps: MutableList<DrawingOp> = ArrayList()
-  private var mTopScreen: ScreenStackFragment? = null
-  private var mRemovalTransitionStarted = false
-  private var isDetachingCurrentScreen = false
-  private var reverseLastTwoChildren = false
-  private var previousChildrenCount = 0
-  var goingForward = false
-  fun dismiss(screenFragment: ScreenStackFragment) {
-    mDismissed.add(screenFragment)
-    performUpdatesNow()
-  }
-
-  override val topScreen: Screen?
-    get() = mTopScreen?.screen
-  val rootScreen: Screen
-    get() {
-      var i = 0
-      val size = screenCount
-      while (i < size) {
-        val screen = getScreenAt(i)
-        if (!mDismissed.contains(screen.fragment)) {
-          return screen
-        }
-        i++
-      }
-      throw IllegalStateException("Stack has no root screen set")
+    private val mStack = ArrayList<ScreenStackFragment>()
+    private val mDismissed: MutableSet<ScreenStackFragment> = HashSet()
+    private val drawingOpPool: MutableList<DrawingOp> = ArrayList()
+    private val drawingOps: MutableList<DrawingOp> = ArrayList()
+    private var mTopScreen: ScreenStackFragment? = null
+    private var mRemovalTransitionStarted = false
+    private var isDetachingCurrentScreen = false
+    private var reverseLastTwoChildren = false
+    private var previousChildrenCount = 0
+    var goingForward = false
+    fun dismiss(screenFragment: ScreenStackFragment) {
+        mDismissed.add(screenFragment)
+        performUpdatesNow()
     }
 
-  override fun adapt(screen: Screen): ScreenStackFragment {
-    return ScreenStackFragment(screen)
-  }
-
-  override fun startViewTransition(view: View) {
-    super.startViewTransition(view)
-    mRemovalTransitionStarted = true
-  }
-
-  override fun endViewTransition(view: View) {
-    super.endViewTransition(view)
-    if (mRemovalTransitionStarted) {
-      mRemovalTransitionStarted = false
-      dispatchOnFinishTransitioning()
-    }
-  }
-
-  fun onViewAppearTransitionEnd() {
-    if (!mRemovalTransitionStarted) {
-      dispatchOnFinishTransitioning()
-    }
-  }
-
-  private fun dispatchOnFinishTransitioning() {
-    (context as ReactContext)
-      .getNativeModule(UIManagerModule::class.java)
-      ?.eventDispatcher
-      ?.dispatchEvent(StackFinishTransitioningEvent(id))
-  }
-
-  override fun removeScreenAt(index: Int) {
-    val toBeRemoved = getScreenAt(index)
-    mDismissed.remove(toBeRemoved.fragment)
-    super.removeScreenAt(index)
-  }
-
-  override fun removeAllScreens() {
-    mDismissed.clear()
-    super.removeAllScreens()
-  }
-
-  override fun hasScreen(screenFragment: ScreenFragment?): Boolean {
-    return super.hasScreen(screenFragment) && !mDismissed.contains(screenFragment)
-  }
-
-  override fun onUpdate() {
-    // When going back from a nested stack with a single screen on it, we may hit an edge case
-    // when all screens are dismissed and no screen is to be displayed on top. We need to gracefully
-    // handle the case of newTop being NULL, which happens in several places below
-    var newTop: ScreenStackFragment? = null // newTop is nullable, see the above comment ^
-    var visibleBottom: ScreenStackFragment? = null // this is only set if newTop has TRANSPARENT_MODAL presentation mode
-    isDetachingCurrentScreen = false // we reset it so the previous value is not used by mistake
-    for (i in mScreenFragments.indices.reversed()) {
-      val screen = mScreenFragments[i]
-      if (!mDismissed.contains(screen)) {
-        if (newTop == null) {
-          newTop = screen
-        } else {
-          visibleBottom = screen
-        }
-        if (!isTransparent(screen)) {
-          break
-        }
-      }
-    }
-    var shouldUseOpenAnimation = true
-    var transition = FragmentTransaction.TRANSIT_FRAGMENT_OPEN
-    var stackAnimation: StackAnimation? = null
-    if (!mStack.contains(newTop)) {
-      // if new top screen wasn't on stack we do "open animation" so long it is not the very first
-      // screen on stack
-      if (mTopScreen != null && newTop != null) {
-        // there was some other screen attached before
-        // if the previous top screen does not exist anymore and the new top was not on the stack
-        // before, probably replace or reset was called, so we play the "close animation".
-        // Otherwise it's open animation
-        val containsTopScreen = mTopScreen?.let { mScreenFragments.contains(it) } == true
-        val isPushReplace = newTop.screen.replaceAnimation === Screen.ReplaceAnimation.PUSH
-        shouldUseOpenAnimation = containsTopScreen || isPushReplace
-        // if the replace animation is `push`, the new top screen provides the animation, otherwise the previous one
-        stackAnimation = if (shouldUseOpenAnimation) newTop.screen.stackAnimation else mTopScreen?.screen?.stackAnimation
-      } else if (mTopScreen == null && newTop != null) {
-        // mTopScreen was not present before so newTop is the first screen added to a stack
-        // and we don't want the animation when it is entering, but we want to send the
-        // willAppear and Appear events to the user, which won't be sent by default if Screen's
-        // stack animation is not NONE (see check for stackAnimation in onCreateAnimation in
-        // ScreenStackFragment).
-        // We don't do it if the stack is nested since the parent will trigger these events in child
-        stackAnimation = StackAnimation.NONE
-        if (newTop.screen.stackAnimation !== StackAnimation.NONE && !isNested) {
-          goingForward = true
-          newTop.dispatchOnWillAppear()
-          newTop.dispatchOnAppear()
-        }
-      }
-    } else if (mTopScreen != null && mTopScreen != newTop) {
-      // otherwise if we are performing top screen change we do "close animation"
-      shouldUseOpenAnimation = false
-      stackAnimation = mTopScreen?.screen?.stackAnimation
-    }
-
-    createTransaction().let {
-      // animation logic start
-      if (stackAnimation != null) {
-        if (shouldUseOpenAnimation) {
-          transition = FragmentTransaction.TRANSIT_FRAGMENT_OPEN
-          when (stackAnimation) {
-            StackAnimation.SLIDE_FROM_RIGHT -> it.setCustomAnimations(R.anim.rns_slide_in_from_right, R.anim.rns_slide_out_to_left)
-            StackAnimation.SLIDE_FROM_LEFT -> it.setCustomAnimations(R.anim.rns_slide_in_from_left, R.anim.rns_slide_out_to_right)
-            StackAnimation.SLIDE_FROM_BOTTOM -> it.setCustomAnimations(
-              R.anim.rns_slide_in_from_bottom, R.anim.rns_no_animation_medium
-            )
-            StackAnimation.FADE_FROM_BOTTOM -> it.setCustomAnimations(R.anim.rns_fade_from_bottom, R.anim.rns_no_animation_350)
-            else -> {
+    override val topScreen: Screen?
+        get() = mTopScreen?.screen
+    val rootScreen: Screen
+        get() {
+            var i = 0
+            val size = screenCount
+            while (i < size) {
+                val screen = getScreenAt(i)
+                if (!mDismissed.contains(screen.fragment)) {
+                    return screen
+                }
+                i++
             }
-          }
-        } else {
-          transition = FragmentTransaction.TRANSIT_FRAGMENT_CLOSE
-          when (stackAnimation) {
-            StackAnimation.SLIDE_FROM_RIGHT -> it.setCustomAnimations(R.anim.rns_slide_in_from_left, R.anim.rns_slide_out_to_right)
-            StackAnimation.SLIDE_FROM_LEFT -> it.setCustomAnimations(R.anim.rns_slide_in_from_right, R.anim.rns_slide_out_to_left)
-            StackAnimation.SLIDE_FROM_BOTTOM -> it.setCustomAnimations(
-              R.anim.rns_no_animation_medium, R.anim.rns_slide_out_to_bottom
-            )
-            StackAnimation.FADE_FROM_BOTTOM -> it.setCustomAnimations(R.anim.rns_no_animation_250, R.anim.rns_fade_to_bottom)
-            else -> {
+            throw IllegalStateException("Stack has no root screen set")
+        }
+
+    override fun adapt(screen: Screen): ScreenStackFragment {
+        return ScreenStackFragment(screen)
+    }
+
+    override fun startViewTransition(view: View) {
+        super.startViewTransition(view)
+        mRemovalTransitionStarted = true
+    }
+
+    override fun endViewTransition(view: View) {
+        super.endViewTransition(view)
+        if (mRemovalTransitionStarted) {
+            mRemovalTransitionStarted = false
+            dispatchOnFinishTransitioning()
+        }
+    }
+
+    fun onViewAppearTransitionEnd() {
+        if (!mRemovalTransitionStarted) {
+            dispatchOnFinishTransitioning()
+        }
+    }
+
+    private fun dispatchOnFinishTransitioning() {
+        (context as ReactContext)
+            .getNativeModule(UIManagerModule::class.java)
+            ?.eventDispatcher
+            ?.dispatchEvent(StackFinishTransitioningEvent(id))
+    }
+
+    override fun removeScreenAt(index: Int) {
+        val toBeRemoved = getScreenAt(index)
+        mDismissed.remove(toBeRemoved.fragment)
+        super.removeScreenAt(index)
+    }
+
+    override fun removeAllScreens() {
+        mDismissed.clear()
+        super.removeAllScreens()
+    }
+
+    override fun hasScreen(screenFragment: ScreenFragment?): Boolean {
+        return super.hasScreen(screenFragment) && !mDismissed.contains(screenFragment)
+    }
+
+    override fun onUpdate() {
+        // When going back from a nested stack with a single screen on it, we may hit an edge case
+        // when all screens are dismissed and no screen is to be displayed on top. We need to gracefully
+        // handle the case of newTop being NULL, which happens in several places below
+        var newTop: ScreenStackFragment? = null // newTop is nullable, see the above comment ^
+        var visibleBottom: ScreenStackFragment? = null // this is only set if newTop has TRANSPARENT_MODAL presentation mode
+        isDetachingCurrentScreen = false // we reset it so the previous value is not used by mistake
+        for (i in mScreenFragments.indices.reversed()) {
+            val screen = mScreenFragments[i]
+            if (!mDismissed.contains(screen)) {
+                if (newTop == null) {
+                    newTop = screen
+                } else {
+                    visibleBottom = screen
+                }
+                if (!isTransparent(screen)) {
+                    break
+                }
             }
-          }
         }
-      }
-      if (stackAnimation === StackAnimation.NONE) {
-        transition = FragmentTransaction.TRANSIT_NONE
-      }
-      if (stackAnimation === StackAnimation.FADE) {
-        transition = FragmentTransaction.TRANSIT_FRAGMENT_FADE
-      }
-      if (stackAnimation != null && isSystemAnimation(stackAnimation)) {
-        it.setTransition(transition)
-      }
-      // animation logic end
-      goingForward = shouldUseOpenAnimation
-
-      if (shouldUseOpenAnimation &&
-        newTop != null && needsDrawReordering(newTop) &&
-        visibleBottom == null
-      ) {
-        // When using an open animation in which two screens overlap (eg. fade_from_bottom or
-        // slide_from_bottom), we want to draw the previous screen under the new one,
-        // which is apparently not the default option. Android always draws the disappearing view
-        // on top of the appearing one. We then reverse the order of the views so the new screen
-        // appears on top of the previous one. You can read more about in the comment
-        // for the code we use to change that behavior:
-        // https://github.com/airbnb/native-navigation/blob/9cf50bf9b751b40778f473f3b19fcfe2c4d40599/lib/android/src/main/java/com/airbnb/android/react/navigation/ScreenCoordinatorLayout.java#L18
-        isDetachingCurrentScreen = true
-      }
-
-      // remove all screens previously on stack
-      for (screen in mStack) {
-        if (!mScreenFragments.contains(screen) || mDismissed.contains(screen)) {
-          it.remove(screen)
-        }
-      }
-      for (screen in mScreenFragments) {
-        // Stop detaching screens when reaching visible bottom. All screens above bottom should be
-        // visible.
-        if (screen === visibleBottom) {
-          break
-        }
-        // detach all screens that should not be visible
-        if (screen !== newTop && !mDismissed.contains(screen)) {
-          it.remove(screen)
-        }
-      }
-
-      // attach screens that just became visible
-      if (visibleBottom != null && !visibleBottom.isAdded) {
-        val top = newTop
-        var beneathVisibleBottom = true
-        for (screen in mScreenFragments) {
-          // ignore all screens beneath the visible bottom
-          if (beneathVisibleBottom) {
-            beneathVisibleBottom = if (screen === visibleBottom) {
-              false
-            } else continue
-          }
-          // when first visible screen found, make all screens after that visible
-          it.add(id, screen).runOnCommit { top?.screen?.bringToFront() }
-        }
-      } else if (newTop != null && !newTop.isAdded) {
-        it.add(id, newTop)
-      }
-      mTopScreen = newTop
-      mStack.clear()
-      mStack.addAll(mScreenFragments)
-
-      turnOffA11yUnderTransparentScreen(visibleBottom)
-
-      it.commitNowAllowingStateLoss()
-    }
-  }
-
-  // only top visible screen should be accessible
-  private fun turnOffA11yUnderTransparentScreen(visibleBottom: ScreenStackFragment?) {
-    if (mScreenFragments.size > 1 && visibleBottom != null) {
-      mTopScreen?.let {
-        if (isTransparent(it)) {
-          val screenFragmentsBeneathTop = mScreenFragments.slice(0 until mScreenFragments.size - 1).asReversed()
-          // go from the top of the stack excluding the top screen
-          for (screenFragment in screenFragmentsBeneathTop) {
-            screenFragment.screen.changeAccessibilityMode(IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS)
-
-            // don't change a11y below non-transparent screens
-            if (screenFragment == visibleBottom) {
-              break
+        var shouldUseOpenAnimation = true
+        var stackAnimation: StackAnimation? = null
+        if (!mStack.contains(newTop)) {
+            // if new top screen wasn't on stack we do "open animation" so long it is not the very first
+            // screen on stack
+            if (mTopScreen != null && newTop != null) {
+                // there was some other screen attached before
+                // if the previous top screen does not exist anymore and the new top was not on the stack
+                // before, probably replace or reset was called, so we play the "close animation".
+                // Otherwise it's open animation
+                val containsTopScreen = mTopScreen?.let { mScreenFragments.contains(it) } == true
+                val isPushReplace = newTop.screen.replaceAnimation === Screen.ReplaceAnimation.PUSH
+                shouldUseOpenAnimation = containsTopScreen || isPushReplace
+                // if the replace animation is `push`, the new top screen provides the animation, otherwise the previous one
+                stackAnimation = if (shouldUseOpenAnimation) newTop.screen.stackAnimation else mTopScreen?.screen?.stackAnimation
+            } else if (mTopScreen == null && newTop != null) {
+                // mTopScreen was not present before so newTop is the first screen added to a stack
+                // and we don't want the animation when it is entering
+                stackAnimation = StackAnimation.NONE
+                goingForward = true
             }
-          }
+        } else if (mTopScreen != null && mTopScreen != newTop) {
+            // otherwise if we are performing top screen change we do "close animation"
+            shouldUseOpenAnimation = false
+            stackAnimation = mTopScreen?.screen?.stackAnimation
         }
-      }
+
+        createTransaction().let {
+            // animation logic start
+            if (stackAnimation != null) {
+                if (shouldUseOpenAnimation) {
+                    when (stackAnimation) {
+                        StackAnimation.DEFAULT -> it.setCustomAnimations(R.anim.rns_default_enter_in, R.anim.rns_default_enter_out)
+                        StackAnimation.NONE -> it.setCustomAnimations(R.anim.rns_no_animation_20, R.anim.rns_no_animation_20)
+                        StackAnimation.FADE -> it.setCustomAnimations(R.anim.rns_fade_in, R.anim.rns_fade_out)
+                        StackAnimation.SLIDE_FROM_RIGHT -> it.setCustomAnimations(R.anim.rns_slide_in_from_right, R.anim.rns_slide_out_to_left)
+                        StackAnimation.SLIDE_FROM_LEFT -> it.setCustomAnimations(R.anim.rns_slide_in_from_left, R.anim.rns_slide_out_to_right)
+                        StackAnimation.SLIDE_FROM_BOTTOM -> it.setCustomAnimations(
+                            R.anim.rns_slide_in_from_bottom, R.anim.rns_no_animation_medium
+                        )
+                        StackAnimation.FADE_FROM_BOTTOM -> it.setCustomAnimations(R.anim.rns_fade_from_bottom, R.anim.rns_no_animation_350)
+                    }
+                } else {
+                    when (stackAnimation) {
+                        StackAnimation.DEFAULT -> it.setCustomAnimations(R.anim.rns_default_exit_in, R.anim.rns_default_exit_out)
+                        StackAnimation.NONE -> it.setCustomAnimations(R.anim.rns_no_animation_20, R.anim.rns_no_animation_20)
+                        StackAnimation.FADE -> it.setCustomAnimations(R.anim.rns_fade_in, R.anim.rns_fade_out)
+                        StackAnimation.SLIDE_FROM_RIGHT -> it.setCustomAnimations(R.anim.rns_slide_in_from_left, R.anim.rns_slide_out_to_right)
+                        StackAnimation.SLIDE_FROM_LEFT -> it.setCustomAnimations(R.anim.rns_slide_in_from_right, R.anim.rns_slide_out_to_left)
+                        StackAnimation.SLIDE_FROM_BOTTOM -> it.setCustomAnimations(
+                            R.anim.rns_no_animation_medium, R.anim.rns_slide_out_to_bottom
+                        )
+                        StackAnimation.FADE_FROM_BOTTOM -> it.setCustomAnimations(R.anim.rns_no_animation_250, R.anim.rns_fade_to_bottom)
+                    }
+                }
+            }
+
+            // animation logic end
+            goingForward = shouldUseOpenAnimation
+
+            if (shouldUseOpenAnimation &&
+                newTop != null && needsDrawReordering(newTop) &&
+                visibleBottom == null
+            ) {
+                // When using an open animation in which two screens overlap (eg. fade_from_bottom or
+                // slide_from_bottom), we want to draw the previous screen under the new one,
+                // which is apparently not the default option. Android always draws the disappearing view
+                // on top of the appearing one. We then reverse the order of the views so the new screen
+                // appears on top of the previous one. You can read more about in the comment
+                // for the code we use to change that behavior:
+                // https://github.com/airbnb/native-navigation/blob/9cf50bf9b751b40778f473f3b19fcfe2c4d40599/lib/android/src/main/java/com/airbnb/android/react/navigation/ScreenCoordinatorLayout.java#L18
+                isDetachingCurrentScreen = true
+            }
+
+            // remove all screens previously on stack
+            for (screen in mStack) {
+                if (!mScreenFragments.contains(screen) || mDismissed.contains(screen)) {
+                    it.remove(screen)
+                }
+            }
+            for (screen in mScreenFragments) {
+                // Stop detaching screens when reaching visible bottom. All screens above bottom should be
+                // visible.
+                if (screen === visibleBottom) {
+                    break
+                }
+                // detach all screens that should not be visible
+                if (screen !== newTop && !mDismissed.contains(screen)) {
+                    it.remove(screen)
+                }
+            }
+
+            // attach screens that just became visible
+            if (visibleBottom != null && !visibleBottom.isAdded) {
+                val top = newTop
+                var beneathVisibleBottom = true
+                for (screen in mScreenFragments) {
+                    // ignore all screens beneath the visible bottom
+                    if (beneathVisibleBottom) {
+                        beneathVisibleBottom = if (screen === visibleBottom) {
+                            false
+                        } else continue
+                    }
+                    // when first visible screen found, make all screens after that visible
+                    it.add(id, screen).runOnCommit { top?.screen?.bringToFront() }
+                }
+            } else if (newTop != null && !newTop.isAdded) {
+                it.add(id, newTop)
+            }
+            mTopScreen = newTop
+            mStack.clear()
+            mStack.addAll(mScreenFragments)
+
+            turnOffA11yUnderTransparentScreen(visibleBottom)
+
+            it.commitNowAllowingStateLoss()
+        }
     }
 
-    topScreen?.changeAccessibilityMode(IMPORTANT_FOR_ACCESSIBILITY_AUTO)
-  }
+    // only top visible screen should be accessible
+    private fun turnOffA11yUnderTransparentScreen(visibleBottom: ScreenStackFragment?) {
+        if (mScreenFragments.size > 1 && visibleBottom != null) {
+            mTopScreen?.let {
+                if (isTransparent(it)) {
+                    val screenFragmentsBeneathTop = mScreenFragments.slice(0 until mScreenFragments.size - 1).asReversed()
+                    // go from the top of the stack excluding the top screen
+                    for (screenFragment in screenFragmentsBeneathTop) {
+                        screenFragment.screen.changeAccessibilityMode(IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS)
 
-  override fun notifyContainerUpdate() {
-    for (screen in mStack) {
-      screen.onContainerUpdate()
-    }
-  }
+                        // don't change a11y below non-transparent screens
+                        if (screenFragment == visibleBottom) {
+                            break
+                        }
+                    }
+                }
+            }
+        }
 
-  // below methods are taken from
-  // https://github.com/airbnb/native-navigation/blob/9cf50bf9b751b40778f473f3b19fcfe2c4d40599/lib/android/src/main/java/com/airbnb/android/react/navigation/ScreenCoordinatorLayout.java#L43
-  // and are used to swap the order of drawing views when navigating forward with the transitions
-  // that are making transitioning fragments appear one on another. See more info in the comment to
-  // the linked class.
-  override fun removeView(view: View) {
-    // we set this property to reverse the order of drawing views
-    // when we want to push new fragment on top of the previous one and their animations collide.
-    // More information in:
-    // https://github.com/airbnb/native-navigation/blob/9cf50bf9b751b40778f473f3b19fcfe2c4d40599/lib/android/src/main/java/com/airbnb/android/react/navigation/ScreenCoordinatorLayout.java#L17
-    if (isDetachingCurrentScreen) {
-      isDetachingCurrentScreen = false
-      reverseLastTwoChildren = true
-    }
-    super.removeView(view)
-  }
-
-  private fun drawAndRelease() {
-    for (i in drawingOps.indices) {
-      val op = drawingOps[i]
-      op.draw()
-      drawingOpPool.add(op)
-    }
-    drawingOps.clear()
-  }
-
-  override fun dispatchDraw(canvas: Canvas) {
-    super.dispatchDraw(canvas)
-
-    // check the view removal is completed (by comparing the previous children count)
-    if (drawingOps.size < previousChildrenCount) {
-      reverseLastTwoChildren = false
-    }
-    previousChildrenCount = drawingOps.size
-    if (reverseLastTwoChildren && drawingOps.size >= 2) {
-      Collections.swap(drawingOps, drawingOps.size - 1, drawingOps.size - 2)
-    }
-    drawAndRelease()
-  }
-
-  override fun drawChild(canvas: Canvas, child: View, drawingTime: Long): Boolean {
-    drawingOps.add(obtainDrawingOp().set(canvas, child, drawingTime))
-    return true
-  }
-
-  private fun performDraw(op: DrawingOp) {
-    super.drawChild(op.canvas, op.child, op.drawingTime)
-  }
-
-  private fun obtainDrawingOp(): DrawingOp {
-    return if (drawingOpPool.isEmpty()) {
-      DrawingOp()
-    } else drawingOpPool.removeAt(drawingOpPool.size - 1)
-  }
-
-  private inner class DrawingOp {
-    var canvas: Canvas? = null
-    var child: View? = null
-    var drawingTime: Long = 0
-    operator fun set(canvas: Canvas?, child: View?, drawingTime: Long): DrawingOp {
-      this.canvas = canvas
-      this.child = child
-      this.drawingTime = drawingTime
-      return this
+        topScreen?.changeAccessibilityMode(IMPORTANT_FOR_ACCESSIBILITY_AUTO)
     }
 
-    fun draw() {
-      performDraw(this)
-      canvas = null
-      child = null
-      drawingTime = 0
-    }
-  }
-
-  companion object {
-    private fun isSystemAnimation(stackAnimation: StackAnimation): Boolean {
-      return stackAnimation === StackAnimation.DEFAULT || stackAnimation === StackAnimation.FADE || stackAnimation === StackAnimation.NONE
+    override fun notifyContainerUpdate() {
+        for (screen in mStack) {
+            screen.onContainerUpdate()
+        }
     }
 
-    private fun isTransparent(fragment: ScreenStackFragment): Boolean {
-      return (
-        fragment.screen.stackPresentation
-          === Screen.StackPresentation.TRANSPARENT_MODAL
-        )
+    // below methods are taken from
+    // https://github.com/airbnb/native-navigation/blob/9cf50bf9b751b40778f473f3b19fcfe2c4d40599/lib/android/src/main/java/com/airbnb/android/react/navigation/ScreenCoordinatorLayout.java#L43
+    // and are used to swap the order of drawing views when navigating forward with the transitions
+    // that are making transitioning fragments appear one on another. See more info in the comment to
+    // the linked class.
+    override fun removeView(view: View) {
+        // we set this property to reverse the order of drawing views
+        // when we want to push new fragment on top of the previous one and their animations collide.
+        // More information in:
+        // https://github.com/airbnb/native-navigation/blob/9cf50bf9b751b40778f473f3b19fcfe2c4d40599/lib/android/src/main/java/com/airbnb/android/react/navigation/ScreenCoordinatorLayout.java#L17
+        if (isDetachingCurrentScreen) {
+            isDetachingCurrentScreen = false
+            reverseLastTwoChildren = true
+        }
+        super.removeView(view)
     }
 
-    private fun needsDrawReordering(fragment: ScreenStackFragment): Boolean {
-      return (
-        fragment.screen.stackAnimation === StackAnimation.SLIDE_FROM_BOTTOM ||
-          fragment.screen.stackAnimation === StackAnimation.FADE_FROM_BOTTOM
-        )
+    private fun drawAndRelease() {
+        for (i in drawingOps.indices) {
+            val op = drawingOps[i]
+            op.draw()
+            drawingOpPool.add(op)
+        }
+        drawingOps.clear()
     }
-  }
+
+    override fun dispatchDraw(canvas: Canvas) {
+        super.dispatchDraw(canvas)
+
+        // check the view removal is completed (by comparing the previous children count)
+        if (drawingOps.size < previousChildrenCount) {
+            reverseLastTwoChildren = false
+        }
+        previousChildrenCount = drawingOps.size
+        if (reverseLastTwoChildren && drawingOps.size >= 2) {
+            Collections.swap(drawingOps, drawingOps.size - 1, drawingOps.size - 2)
+        }
+        drawAndRelease()
+    }
+
+    override fun drawChild(canvas: Canvas, child: View, drawingTime: Long): Boolean {
+        drawingOps.add(obtainDrawingOp().set(canvas, child, drawingTime))
+        return true
+    }
+
+    private fun performDraw(op: DrawingOp) {
+        super.drawChild(op.canvas, op.child, op.drawingTime)
+    }
+
+    private fun obtainDrawingOp(): DrawingOp {
+        return if (drawingOpPool.isEmpty()) {
+            DrawingOp()
+        } else drawingOpPool.removeAt(drawingOpPool.size - 1)
+    }
+
+    private inner class DrawingOp {
+        var canvas: Canvas? = null
+        var child: View? = null
+        var drawingTime: Long = 0
+        operator fun set(canvas: Canvas?, child: View?, drawingTime: Long): DrawingOp {
+            this.canvas = canvas
+            this.child = child
+            this.drawingTime = drawingTime
+            return this
+        }
+
+        fun draw() {
+            performDraw(this)
+            canvas = null
+            child = null
+            drawingTime = 0
+        }
+    }
+
+    companion object {
+        private fun isTransparent(fragment: ScreenStackFragment): Boolean {
+            return (
+                fragment.screen.stackPresentation
+                    === Screen.StackPresentation.TRANSPARENT_MODAL
+                )
+        }
+
+        private fun needsDrawReordering(fragment: ScreenStackFragment): Boolean {
+            return (
+                fragment.screen.stackAnimation === StackAnimation.SLIDE_FROM_BOTTOM ||
+                    fragment.screen.stackAnimation === StackAnimation.FADE_FROM_BOTTOM
+                )
+        }
+    }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenStackFragment.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenStackFragment.kt
@@ -16,267 +16,237 @@ import android.view.animation.Transformation
 import android.widget.LinearLayout
 import androidx.appcompat.widget.Toolbar
 import androidx.coordinatorlayout.widget.CoordinatorLayout
-import com.facebook.react.bridge.UiThreadUtil
 import com.facebook.react.uimanager.PixelUtil
 import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.appbar.AppBarLayout.ScrollingViewBehavior
 
 class ScreenStackFragment : ScreenFragment {
-  private var mAppBarLayout: AppBarLayout? = null
-  private var mToolbar: Toolbar? = null
-  private var mShadowHidden = false
-  private var mIsTranslucent = false
+    private var mAppBarLayout: AppBarLayout? = null
+    private var mToolbar: Toolbar? = null
+    private var mShadowHidden = false
+    private var mIsTranslucent = false
 
-  var searchView: CustomSearchView? = null
-  var onSearchViewCreate: ((searchView: CustomSearchView) -> Unit)? = null
+    var searchView: CustomSearchView? = null
+    var onSearchViewCreate: ((searchView: CustomSearchView) -> Unit)? = null
 
-  @SuppressLint("ValidFragment")
-  constructor(screenView: Screen) : super(screenView)
+    @SuppressLint("ValidFragment")
+    constructor(screenView: Screen) : super(screenView)
 
-  constructor() {
-    throw IllegalStateException(
-      "ScreenStack fragments should never be restored. Follow instructions from https://github.com/software-mansion/react-native-screens/issues/17#issuecomment-424704067 to properly configure your main activity."
-    )
-  }
+    constructor() {
+        throw IllegalStateException(
+            "ScreenStack fragments should never be restored. Follow instructions from https://github.com/software-mansion/react-native-screens/issues/17#issuecomment-424704067 to properly configure your main activity."
+        )
+    }
 
-  fun removeToolbar() {
-    mAppBarLayout?.let {
-      mToolbar?.let { toolbar ->
-        if (toolbar.parent === it) {
-          it.removeView(toolbar)
+    fun removeToolbar() {
+        mAppBarLayout?.let {
+            mToolbar?.let { toolbar ->
+                if (toolbar.parent === it) {
+                    it.removeView(toolbar)
+                }
+            }
         }
-      }
+        mToolbar = null
     }
-    mToolbar = null
-  }
 
-  fun setToolbar(toolbar: Toolbar) {
-    mAppBarLayout?.addView(toolbar)
-    val params = AppBarLayout.LayoutParams(
-      AppBarLayout.LayoutParams.MATCH_PARENT, AppBarLayout.LayoutParams.WRAP_CONTENT
-    )
-    params.scrollFlags = 0
-    toolbar.layoutParams = params
-    mToolbar = toolbar
-  }
-
-  fun setToolbarShadowHidden(hidden: Boolean) {
-    if (mShadowHidden != hidden) {
-      mAppBarLayout?.targetElevation = if (hidden) 0f else PixelUtil.toPixelFromDIP(4f)
-      mShadowHidden = hidden
+    fun setToolbar(toolbar: Toolbar) {
+        mAppBarLayout?.addView(toolbar)
+        val params = AppBarLayout.LayoutParams(
+            AppBarLayout.LayoutParams.MATCH_PARENT, AppBarLayout.LayoutParams.WRAP_CONTENT
+        )
+        params.scrollFlags = 0
+        toolbar.layoutParams = params
+        mToolbar = toolbar
     }
-  }
 
-  fun setToolbarTranslucent(translucent: Boolean) {
-    if (mIsTranslucent != translucent) {
-      val params = screen.layoutParams
-      (params as CoordinatorLayout.LayoutParams).behavior =
-        if (translucent) null else ScrollingViewBehavior()
-      mIsTranslucent = translucent
-    }
-  }
-
-  override fun onContainerUpdate() {
-    val headerConfig = screen.headerConfig
-    headerConfig?.onUpdate()
-  }
-
-  override fun onViewAnimationEnd() {
-    super.onViewAnimationEnd()
-    notifyViewAppearTransitionEnd()
-  }
-
-  override fun onCreateAnimation(transit: Int, enter: Boolean, nextAnim: Int): Animation? {
-    // this means that the fragment will appear with a custom transition, in the case
-    // of animation: 'none', onViewAnimationStart and onViewAnimationEnd
-    // won't be called and we need to notify stack directly from here.
-    // When using the Toolbar back button this is called an extra time with transit = 0 but in
-    // this case we don't want to notify. The way I found to detect is case is check isHidden.
-    if (transit == 0 && !isHidden &&
-      screen.stackAnimation === Screen.StackAnimation.NONE
-    ) {
-      if (enter) {
-        // Android dispatches the animation start event for the fragment that is being added first
-        // however we want the one being dismissed first to match iOS. It also makes more sense
-        // from  a navigation point of view to have the disappear event first.
-        // Since there are no explicit relationships between the fragment being added / removed
-        // the practical way to fix this is delaying dispatching the appear events at the end of
-        // the frame.
-        UiThreadUtil.runOnUiThread {
-          dispatchOnWillAppear()
-          dispatchOnAppear()
+    fun setToolbarShadowHidden(hidden: Boolean) {
+        if (mShadowHidden != hidden) {
+            mAppBarLayout?.targetElevation = if (hidden) 0f else PixelUtil.toPixelFromDIP(4f)
+            mShadowHidden = hidden
         }
-      } else {
-        dispatchOnWillDisappear()
-        dispatchOnDisappear()
+    }
+
+    fun setToolbarTranslucent(translucent: Boolean) {
+        if (mIsTranslucent != translucent) {
+            val params = screen.layoutParams
+            (params as CoordinatorLayout.LayoutParams).behavior =
+                if (translucent) null else ScrollingViewBehavior()
+            mIsTranslucent = translucent
+        }
+    }
+
+    override fun onContainerUpdate() {
+        val headerConfig = screen.headerConfig
+        headerConfig?.onUpdate()
+    }
+
+    override fun onViewAnimationEnd() {
+        super.onViewAnimationEnd()
         notifyViewAppearTransitionEnd()
-      }
     }
-    return null
-  }
 
-  private fun notifyViewAppearTransitionEnd() {
-    val screenStack = view?.parent
-    if (screenStack is ScreenStack) {
-      screenStack.onViewAppearTransitionEnd()
-    }
-  }
-
-  override fun onCreateView(
-    inflater: LayoutInflater,
-    container: ViewGroup?,
-    savedInstanceState: Bundle?
-  ): View? {
-    val view: ScreensCoordinatorLayout? =
-      context?.let { ScreensCoordinatorLayout(it, this) }
-    val params = CoordinatorLayout.LayoutParams(
-      LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.MATCH_PARENT
-    )
-    params.behavior = if (mIsTranslucent) null else ScrollingViewBehavior()
-    screen.layoutParams = params
-    view?.addView(recycleView(screen))
-
-    mAppBarLayout = context?.let { AppBarLayout(it) }
-    // By default AppBarLayout will have a background color set but since we cover the whole layout
-    // with toolbar (that can be semi-transparent) the bar layout background color does not pay a
-    // role. On top of that it breaks screens animations when alfa offscreen compositing is off
-    // (which is the default)
-    mAppBarLayout?.setBackgroundColor(Color.TRANSPARENT)
-    mAppBarLayout?.layoutParams = AppBarLayout.LayoutParams(
-      AppBarLayout.LayoutParams.MATCH_PARENT, AppBarLayout.LayoutParams.WRAP_CONTENT
-    )
-    view?.addView(mAppBarLayout)
-    if (mShadowHidden) {
-      mAppBarLayout?.targetElevation = 0f
-    }
-    mToolbar?.let { mAppBarLayout?.addView(recycleView(it)) }
-    setHasOptionsMenu(true)
-    return view
-  }
-
-  override fun onPrepareOptionsMenu(menu: Menu) {
-    updateToolbarMenu(menu)
-    return super.onPrepareOptionsMenu(menu)
-  }
-
-  override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-    updateToolbarMenu(menu)
-    return super.onCreateOptionsMenu(menu, inflater)
-  }
-
-  private fun shouldShowSearchBar(): Boolean {
-    val config = screen.headerConfig
-    val numberOfSubViews = config?.configSubviewsCount ?: 0
-    if (config != null && numberOfSubViews > 0) {
-      for (i in 0 until numberOfSubViews) {
-        val subView = config.getConfigSubview(i)
-        if (subView.type == ScreenStackHeaderSubview.Type.SEARCH_BAR) {
-          return true
+    private fun notifyViewAppearTransitionEnd() {
+        val screenStack = view?.parent
+        if (screenStack is ScreenStack) {
+            screenStack.onViewAppearTransitionEnd()
         }
-      }
     }
-    return false
-  }
 
-  private fun updateToolbarMenu(menu: Menu) {
-    menu.clear()
-    if (shouldShowSearchBar()) {
-      val currentContext = context
-      if (searchView == null && currentContext != null) {
-        val newSearchView = CustomSearchView(currentContext, this)
-        searchView = newSearchView
-        onSearchViewCreate?.invoke(newSearchView)
-      }
-      val item = menu.add("")
-      item.setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS)
-      item.actionView = searchView
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        val view: ScreensCoordinatorLayout? =
+            context?.let { ScreensCoordinatorLayout(it, this) }
+        val params = CoordinatorLayout.LayoutParams(
+            LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.MATCH_PARENT
+        )
+        params.behavior = if (mIsTranslucent) null else ScrollingViewBehavior()
+        screen.layoutParams = params
+        view?.addView(recycleView(screen))
+
+        mAppBarLayout = context?.let { AppBarLayout(it) }
+        // By default AppBarLayout will have a background color set but since we cover the whole layout
+        // with toolbar (that can be semi-transparent) the bar layout background color does not pay a
+        // role. On top of that it breaks screens animations when alfa offscreen compositing is off
+        // (which is the default)
+        mAppBarLayout?.setBackgroundColor(Color.TRANSPARENT)
+        mAppBarLayout?.layoutParams = AppBarLayout.LayoutParams(
+            AppBarLayout.LayoutParams.MATCH_PARENT, AppBarLayout.LayoutParams.WRAP_CONTENT
+        )
+        view?.addView(mAppBarLayout)
+        if (mShadowHidden) {
+            mAppBarLayout?.targetElevation = 0f
+        }
+        mToolbar?.let { mAppBarLayout?.addView(recycleView(it)) }
+        setHasOptionsMenu(true)
+        return view
     }
-  }
 
-  fun canNavigateBack(): Boolean {
-    val container: ScreenContainer<*>? = screen.container
-    check(container is ScreenStack) { "ScreenStackFragment added into a non-stack container" }
-    return if (container.rootScreen == screen) {
-      // this screen is the root of the container, if it is nested we can check parent container
-      // if it is also a root or not
-      val parentFragment = parentFragment
-      if (parentFragment is ScreenStackFragment) {
-        parentFragment.canNavigateBack()
-      } else {
-        false
-      }
-    } else {
-      true
+    override fun onPrepareOptionsMenu(menu: Menu) {
+        updateToolbarMenu(menu)
+        return super.onPrepareOptionsMenu(menu)
     }
-  }
 
-  fun dismiss() {
-    val container: ScreenContainer<*>? = screen.container
-    check(container is ScreenStack) { "ScreenStackFragment added into a non-stack container" }
-    container.dismiss(this)
-  }
+    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
+        updateToolbarMenu(menu)
+        return super.onCreateOptionsMenu(menu, inflater)
+    }
 
-  private class ScreensCoordinatorLayout(
-    context: Context,
-    private val mFragment: ScreenFragment
-  ) : CoordinatorLayout(context) {
-    private val mAnimationListener: Animation.AnimationListener =
-      object : Animation.AnimationListener {
-        override fun onAnimationStart(animation: Animation) {
-          mFragment.onViewAnimationStart()
+    private fun shouldShowSearchBar(): Boolean {
+        val config = screen.headerConfig
+        val numberOfSubViews = config?.configSubviewsCount ?: 0
+        if (config != null && numberOfSubViews > 0) {
+            for (i in 0 until numberOfSubViews) {
+                val subView = config.getConfigSubview(i)
+                if (subView.type == ScreenStackHeaderSubview.Type.SEARCH_BAR) {
+                    return true
+                }
+            }
+        }
+        return false
+    }
+
+    private fun updateToolbarMenu(menu: Menu) {
+        menu.clear()
+        if (shouldShowSearchBar()) {
+            val currentContext = context
+            if (searchView == null && currentContext != null) {
+                val newSearchView = CustomSearchView(currentContext, this)
+                searchView = newSearchView
+                onSearchViewCreate?.invoke(newSearchView)
+            }
+            val item = menu.add("")
+            item.setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS)
+            item.actionView = searchView
+        }
+    }
+
+    fun canNavigateBack(): Boolean {
+        val container: ScreenContainer<*>? = screen.container
+        check(container is ScreenStack) { "ScreenStackFragment added into a non-stack container" }
+        return if (container.rootScreen == screen) {
+            // this screen is the root of the container, if it is nested we can check parent container
+            // if it is also a root or not
+            val parentFragment = parentFragment
+            if (parentFragment is ScreenStackFragment) {
+                parentFragment.canNavigateBack()
+            } else {
+                false
+            }
+        } else {
+            true
+        }
+    }
+
+    fun dismiss() {
+        val container: ScreenContainer<*>? = screen.container
+        check(container is ScreenStack) { "ScreenStackFragment added into a non-stack container" }
+        container.dismiss(this)
+    }
+
+    private class ScreensCoordinatorLayout(
+        context: Context,
+        private val mFragment: ScreenFragment
+    ) : CoordinatorLayout(context) {
+        private val mAnimationListener: Animation.AnimationListener =
+            object : Animation.AnimationListener {
+                override fun onAnimationStart(animation: Animation) {
+                    mFragment.onViewAnimationStart()
+                }
+
+                override fun onAnimationEnd(animation: Animation) {
+                    mFragment.onViewAnimationEnd()
+                }
+
+                override fun onAnimationRepeat(animation: Animation) {}
+            }
+
+        override fun startAnimation(animation: Animation) {
+            // For some reason View##onAnimationEnd doesn't get called for
+            // exit transitions so we explicitly attach animation listener.
+            // We also have some animations that are an AnimationSet, so we don't wrap them
+            // in another set since it causes some visual glitches when going forward.
+            // We also set the listener only when going forward, since when going back,
+            // there is already a listener for dismiss action added, which would be overridden
+            // and also this is not necessary when going back since the lifecycle methods
+            // are correctly dispatched then.
+            // We also add fakeAnimation to the set of animations, which sends the progress of animation
+            val fakeAnimation = ScreensAnimation(mFragment)
+            fakeAnimation.duration = animation.duration
+            if (animation is AnimationSet && !mFragment.isRemoving) {
+                animation.addAnimation(fakeAnimation)
+                animation.setAnimationListener(mAnimationListener)
+                super.startAnimation(animation)
+            } else {
+                val set = AnimationSet(true)
+                set.addAnimation(animation)
+                set.addAnimation(fakeAnimation)
+                set.setAnimationListener(mAnimationListener)
+                super.startAnimation(set)
+            }
         }
 
-        override fun onAnimationEnd(animation: Animation) {
-          mFragment.onViewAnimationEnd()
+        /**
+         * This method implements a workaround for RN's autoFocus functionality. Because of the way
+         * autoFocus is implemented it dismisses soft keyboard in fragment transition
+         * due to change of visibility of the view at the start of the transition. Here we override the
+         * call to `clearFocus` when the visibility of view is `INVISIBLE` since `clearFocus` triggers the
+         * hiding of the keyboard in `ReactEditText.java`.
+         */
+        override fun clearFocus() {
+            if (visibility != INVISIBLE) {
+                super.clearFocus()
+            }
         }
-
-        override fun onAnimationRepeat(animation: Animation) {}
-      }
-
-    override fun startAnimation(animation: Animation) {
-      // For some reason View##onAnimationEnd doesn't get called for
-      // exit transitions so we explicitly attach animation listener.
-      // We also have some animations that are an AnimationSet, so we don't wrap them
-      // in another set since it causes some visual glitches when going forward.
-      // We also set the listener only when going forward, since when going back,
-      // there is already a listener for dismiss action added, which would be overridden
-      // and also this is not necessary when going back since the lifecycle methods
-      // are correctly dispatched then.
-      // We also add fakeAnimation to the set of animations, which sends the progress of animation
-      val fakeAnimation = ScreensAnimation(mFragment)
-      fakeAnimation.duration = animation.duration
-      if (animation is AnimationSet && !mFragment.isRemoving) {
-        animation.addAnimation(fakeAnimation)
-        animation.setAnimationListener(mAnimationListener)
-        super.startAnimation(animation)
-      } else {
-        val set = AnimationSet(true)
-        set.addAnimation(animation)
-        set.addAnimation(fakeAnimation)
-        set.setAnimationListener(mAnimationListener)
-        super.startAnimation(set)
-      }
     }
 
-    /**
-     * This method implements a workaround for RN's autoFocus functionality. Because of the way
-     * autoFocus is implemented it dismisses soft keyboard in fragment transition
-     * due to change of visibility of the view at the start of the transition. Here we override the
-     * call to `clearFocus` when the visibility of view is `INVISIBLE` since `clearFocus` triggers the
-     * hiding of the keyboard in `ReactEditText.java`.
-     */
-    override fun clearFocus() {
-      if (visibility != INVISIBLE) {
-        super.clearFocus()
-      }
+    private class ScreensAnimation(private val mFragment: ScreenFragment) : Animation() {
+        override fun applyTransformation(interpolatedTime: Float, t: Transformation) {
+            super.applyTransformation(interpolatedTime, t)
+            // interpolated time should be the progress of the current transition
+            mFragment.dispatchTransitionProgress(interpolatedTime, !mFragment.isResumed)
+        }
     }
-  }
-
-  private class ScreensAnimation(private val mFragment: ScreenFragment) : Animation() {
-    override fun applyTransformation(interpolatedTime: Float, t: Transformation) {
-      super.applyTransformation(interpolatedTime, t)
-      // interpolated time should be the progress of the current transition
-      mFragment.dispatchTransitionProgress(interpolatedTime, !mFragment.isResumed)
-    }
-  }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenStackHeaderConfig.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenStackHeaderConfig.kt
@@ -25,383 +25,390 @@ import host.exp.expoview.BuildConfig
 import host.exp.expoview.R
 
 class ScreenStackHeaderConfig(context: Context) : ViewGroup(context) {
-  private val mConfigSubviews = ArrayList<ScreenStackHeaderSubview>(3)
-  val toolbar: CustomToolbar
-  private var mTitle: String? = null
-  private var mTitleColor = 0
-  private var mTitleFontFamily: String? = null
-  private var mDirection: String? = null
-  private var mTitleFontSize = 0f
-  private var mTitleFontWeight = 0
-  private var mBackgroundColor: Int? = null
-  private var mIsHidden = false
-  private var mIsBackButtonHidden = false
-  private var mIsShadowHidden = false
-  private var mDestroyed = false
-  private var mBackButtonInCustomView = false
-  private var mIsTopInsetEnabled = true
-  private var mIsTranslucent = false
-  private var mTintColor = 0
-  private var mIsAttachedToWindow = false
-  private val mDefaultStartInset: Int
-  private val mDefaultStartInsetWithNavigation: Int
-  private val mBackClickListener = OnClickListener {
-    screenFragment?.let {
-      val stack = screenStack
-      if (stack != null && stack.rootScreen == it.screen) {
-        val parentFragment = it.parentFragment
-        if (parentFragment is ScreenStackFragment) {
-          if (parentFragment.screen.nativeBackButtonDismissalEnabled) {
-            parentFragment.dismiss()
-          } else {
-            parentFragment.dispatchHeaderBackButtonClickedEvent()
-          }
+    private val mConfigSubviews = ArrayList<ScreenStackHeaderSubview>(3)
+    val toolbar: CustomToolbar
+    private var headerTopInset: Int? = null
+    private var mTitle: String? = null
+    private var mTitleColor = 0
+    private var mTitleFontFamily: String? = null
+    private var mDirection: String? = null
+    private var mTitleFontSize = 0f
+    private var mTitleFontWeight = 0
+    private var mBackgroundColor: Int? = null
+    private var mIsHidden = false
+    private var mIsBackButtonHidden = false
+    private var mIsShadowHidden = false
+    private var mDestroyed = false
+    private var mBackButtonInCustomView = false
+    private var mIsTopInsetEnabled = true
+    private var mIsTranslucent = false
+    private var mTintColor = 0
+    private var mIsAttachedToWindow = false
+    private val mDefaultStartInset: Int
+    private val mDefaultStartInsetWithNavigation: Int
+    private val mBackClickListener = OnClickListener {
+        screenFragment?.let {
+            val stack = screenStack
+            if (stack != null && stack.rootScreen == it.screen) {
+                val parentFragment = it.parentFragment
+                if (parentFragment is ScreenStackFragment) {
+                    if (parentFragment.screen.nativeBackButtonDismissalEnabled) {
+                        parentFragment.dismiss()
+                    } else {
+                        parentFragment.dispatchHeaderBackButtonClickedEvent()
+                    }
+                }
+            } else {
+                if (it.screen.nativeBackButtonDismissalEnabled) {
+                    it.dismiss()
+                } else {
+                    it.dispatchHeaderBackButtonClickedEvent()
+                }
+            }
         }
-      } else {
-        if (it.screen.nativeBackButtonDismissalEnabled) {
-          it.dismiss()
+    }
+
+    private fun sendEvent(eventName: String, eventContent: WritableMap?) {
+        (context as ReactContext).getJSModule(RCTEventEmitter::class.java)
+            ?.receiveEvent(id, eventName, eventContent)
+    }
+
+    override fun onLayout(changed: Boolean, l: Int, t: Int, r: Int, b: Int) {
+        // no-op
+    }
+
+    fun destroy() {
+        mDestroyed = true
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        mIsAttachedToWindow = true
+        sendEvent("onAttached", null)
+        // we want to save the top inset before the status bar can be hidden, which would resolve in
+        // inset being 0
+        if (headerTopInset == null) {
+            headerTopInset = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
+                rootWindowInsets.systemWindowInsetTop
+            else
+            // Hacky fallback for old android. Before Marshmallow, the status bar height was always 25
+                (25 * resources.displayMetrics.density).toInt()
+        }
+        onUpdate()
+    }
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        mIsAttachedToWindow = false
+        sendEvent("onDetached", null)
+    }
+
+    private val screen: Screen?
+        get() {
+            val screen = parent
+            return if (screen is Screen) {
+                screen
+            } else null
+        }
+    private val screenStack: ScreenStack?
+        get() {
+            val screen = screen
+            if (screen != null) {
+                val container = screen.container
+                if (container is ScreenStack) {
+                    return container
+                }
+            }
+            return null
+        }
+    val screenFragment: ScreenStackFragment?
+        get() {
+            val screen = parent
+            if (screen is Screen) {
+                val fragment: Fragment? = screen.fragment
+                if (fragment is ScreenStackFragment) {
+                    return fragment
+                }
+            }
+            return null
+        }
+
+    @SuppressLint("ObsoleteSdkInt") // to be removed when support for < 0.64 is dropped
+    fun onUpdate() {
+        val stack = screenStack
+        val isTop = stack == null || stack.topScreen == parent
+        if (!mIsAttachedToWindow || !isTop || mDestroyed) {
+            return
+        }
+        val activity = screenFragment?.activity as AppCompatActivity? ?: return
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1 && mDirection != null) {
+            if (mDirection == "rtl") {
+                toolbar.layoutDirection = LAYOUT_DIRECTION_RTL
+            } else if (mDirection == "ltr") {
+                toolbar.layoutDirection = LAYOUT_DIRECTION_LTR
+            }
+        }
+
+        // orientation and status bar management
+        screen?.let {
+            // we set the traits here too, not only when the prop for Screen is passed
+            // because sometimes we don't have the Fragment and Activity available then yet, e.g. on the
+            // first setting of props. Similar thing is done for Screens of ScreenContainers, but in
+            // `onContainerUpdate` of their Fragment
+            val reactContext = if (context is ReactContext) {
+                context as ReactContext
+            } else {
+                it.fragment?.tryGetContext()
+            }
+            ScreenWindowTraits.trySetWindowTraits(it, activity, reactContext)
+        }
+        if (mIsHidden) {
+            if (toolbar.parent != null) {
+                screenFragment?.removeToolbar()
+            }
+            return
+        }
+        if (toolbar.parent == null) {
+            screenFragment?.setToolbar(toolbar)
+        }
+        if (mIsTopInsetEnabled) {
+            headerTopInset.let {
+                toolbar.setPadding(0, it ?: 0, 0, 0)
+            }
         } else {
-          it.dispatchHeaderBackButtonClickedEvent()
+            if (toolbar.paddingTop > 0) {
+                toolbar.setPadding(0, 0, 0, 0)
+            }
         }
-      }
-    }
-  }
+        activity.setSupportActionBar(toolbar)
+        // non-null toolbar is set in the line above and it is used here
+        val actionBar = requireNotNull(activity.supportActionBar)
 
-  private fun sendEvent(eventName: String, eventContent: WritableMap?) {
-    (context as ReactContext).getJSModule(RCTEventEmitter::class.java)
-      ?.receiveEvent(id, eventName, eventContent)
-  }
+        // Reset toolbar insets. By default we set symmetric inset for start and end to match iOS
+        // implementation where both right and left icons are offset from the edge by default. We also
+        // reset startWithNavigation inset which corresponds to the distance between navigation icon and
+        // title. If title isn't set we clear that value few lines below to give more space to custom
+        // center-mounted views.
+        toolbar.contentInsetStartWithNavigation = mDefaultStartInsetWithNavigation
+        toolbar.setContentInsetsRelative(mDefaultStartInset, mDefaultStartInset)
 
-  override fun onLayout(changed: Boolean, l: Int, t: Int, r: Int, b: Int) {
-    // no-op
-  }
-
-  fun destroy() {
-    mDestroyed = true
-  }
-
-  override fun onAttachedToWindow() {
-    super.onAttachedToWindow()
-    mIsAttachedToWindow = true
-    sendEvent("onAttached", null)
-    onUpdate()
-  }
-
-  override fun onDetachedFromWindow() {
-    super.onDetachedFromWindow()
-    mIsAttachedToWindow = false
-    sendEvent("onDetached", null)
-  }
-
-  private val screen: Screen?
-    get() {
-      val screen = parent
-      return if (screen is Screen) {
-        screen
-      } else null
-    }
-  private val screenStack: ScreenStack?
-    get() {
-      val screen = screen
-      if (screen != null) {
-        val container = screen.container
-        if (container is ScreenStack) {
-          return container
-        }
-      }
-      return null
-    }
-  val screenFragment: ScreenStackFragment?
-    get() {
-      val screen = parent
-      if (screen is Screen) {
-        val fragment: Fragment? = screen.fragment
-        if (fragment is ScreenStackFragment) {
-          return fragment
-        }
-      }
-      return null
-    }
-
-  @SuppressLint("ObsoleteSdkInt") // to be removed when support for < 0.64 is dropped
-  fun onUpdate() {
-    val stack = screenStack
-    val isTop = stack == null || stack.topScreen == parent
-    if (!mIsAttachedToWindow || !isTop || mDestroyed) {
-      return
-    }
-    val activity = screenFragment?.activity as AppCompatActivity? ?: return
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1 && mDirection != null) {
-      if (mDirection == "rtl") {
-        toolbar.layoutDirection = LAYOUT_DIRECTION_RTL
-      } else if (mDirection == "ltr") {
-        toolbar.layoutDirection = LAYOUT_DIRECTION_LTR
-      }
-    }
-
-    // orientation and status bar management
-    screen?.let {
-      // we set the traits here too, not only when the prop for Screen is passed
-      // because sometimes we don't have the Fragment and Activity available then yet, e.g. on the
-      // first setting of props. Similar thing is done for Screens of ScreenContainers, but in
-      // `onContainerUpdate` of their Fragment
-      val reactContext = if (context is ReactContext) {
-        context as ReactContext
-      } else {
-        it.fragment?.tryGetContext()
-      }
-      ScreenWindowTraits.trySetWindowTraits(it, activity, reactContext)
-    }
-    if (mIsHidden) {
-      if (toolbar.parent != null) {
-        screenFragment?.removeToolbar()
-      }
-      return
-    }
-    if (toolbar.parent == null) {
-      screenFragment?.setToolbar(toolbar)
-    }
-    if (mIsTopInsetEnabled) {
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-        toolbar.setPadding(0, rootWindowInsets.systemWindowInsetTop, 0, 0)
-      } else {
-        // Hacky fallback for old android. Before Marshmallow, the status bar height was always 25
-        toolbar.setPadding(0, (25 * resources.displayMetrics.density).toInt(), 0, 0)
-      }
-    } else {
-      if (toolbar.paddingTop > 0) {
-        toolbar.setPadding(0, 0, 0, 0)
-      }
-    }
-    activity.setSupportActionBar(toolbar)
-    // non-null toolbar is set in the line above and it is used here
-    val actionBar = requireNotNull(activity.supportActionBar)
-
-    // Reset toolbar insets. By default we set symmetric inset for start and end to match iOS
-    // implementation where both right and left icons are offset from the edge by default. We also
-    // reset startWithNavigation inset which corresponds to the distance between navigation icon and
-    // title. If title isn't set we clear that value few lines below to give more space to custom
-    // center-mounted views.
-    toolbar.contentInsetStartWithNavigation = mDefaultStartInsetWithNavigation
-    toolbar.setContentInsetsRelative(mDefaultStartInset, mDefaultStartInset)
-
-    // hide back button
-    actionBar.setDisplayHomeAsUpEnabled(
-      screenFragment?.canNavigateBack() == true && !mIsBackButtonHidden
-    )
-
-    // when setSupportActionBar is called a toolbar wrapper gets initialized that overwrites
-    // navigation click listener. The default behavior set in the wrapper is to call into
-    // menu options handlers, but we prefer the back handling logic to stay here instead.
-    toolbar.setNavigationOnClickListener(mBackClickListener)
-
-    // shadow
-    screenFragment?.setToolbarShadowHidden(mIsShadowHidden)
-
-    // translucent
-    screenFragment?.setToolbarTranslucent(mIsTranslucent)
-
-    // title
-    actionBar.title = mTitle
-    if (TextUtils.isEmpty(mTitle)) {
-      // if title is empty we set start  navigation inset to 0 to give more space to custom rendered
-      // views. When it is set to default it'd take up additional distance from the back button
-      // which would impact the position of custom header views rendered at the center.
-      toolbar.contentInsetStartWithNavigation = 0
-    }
-    val titleTextView = titleTextView
-    if (mTitleColor != 0) {
-      toolbar.setTitleTextColor(mTitleColor)
-    }
-    if (titleTextView != null) {
-      if (mTitleFontFamily != null || mTitleFontWeight > 0) {
-        val titleTypeface = ReactTypefaceUtils.applyStyles(
-          null, 0, mTitleFontWeight, mTitleFontFamily, context.assets
+        // hide back button
+        actionBar.setDisplayHomeAsUpEnabled(
+            screenFragment?.canNavigateBack() == true && !mIsBackButtonHidden
         )
-        titleTextView.typeface = titleTypeface
-      }
-      if (mTitleFontSize > 0) {
-        titleTextView.textSize = mTitleFontSize
-      }
-    }
 
-    // background
-    mBackgroundColor?.let { toolbar.setBackgroundColor(it) }
+        // when setSupportActionBar is called a toolbar wrapper gets initialized that overwrites
+        // navigation click listener. The default behavior set in the wrapper is to call into
+        // menu options handlers, but we prefer the back handling logic to stay here instead.
+        toolbar.setNavigationOnClickListener(mBackClickListener)
 
-    // color
-    if (mTintColor != 0) {
-      val navigationIcon = toolbar.navigationIcon
-      navigationIcon?.setColorFilter(mTintColor, PorterDuff.Mode.SRC_ATOP)
-    }
+        // shadow
+        screenFragment?.setToolbarShadowHidden(mIsShadowHidden)
 
-    // subviews
-    for (i in toolbar.childCount - 1 downTo 0) {
-      if (toolbar.getChildAt(i) is ScreenStackHeaderSubview) {
-        toolbar.removeViewAt(i)
-      }
-    }
-    var i = 0
-    val size = mConfigSubviews.size
-    while (i < size) {
-      val view = mConfigSubviews[i]
-      val type = view.type
-      if (type === ScreenStackHeaderSubview.Type.BACK) {
-        // we special case BACK button header config type as we don't add it as a view into toolbar
-        // but instead just copy the drawable from imageview that's added as a first child to it.
-        val firstChild = view.getChildAt(0) as? ImageView
-          ?: throw JSApplicationIllegalArgumentException(
-            "Back button header config view should have Image as first child"
-          )
-        actionBar.setHomeAsUpIndicator(firstChild.drawable)
-        i++
-        continue
-      }
-      val params = Toolbar.LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.MATCH_PARENT)
-      when (type) {
-        ScreenStackHeaderSubview.Type.LEFT -> {
-          // when there is a left item we need to disable navigation icon by default
-          // we also hide title as there is no other way to display left side items
-          if (!mBackButtonInCustomView) {
-            toolbar.navigationIcon = null
-          }
-          toolbar.title = null
-          params.gravity = Gravity.START
+        // translucent
+        screenFragment?.setToolbarTranslucent(mIsTranslucent)
+
+        // title
+        actionBar.title = mTitle
+        if (TextUtils.isEmpty(mTitle)) {
+            // if title is empty we set start  navigation inset to 0 to give more space to custom rendered
+            // views. When it is set to default it'd take up additional distance from the back button
+            // which would impact the position of custom header views rendered at the center.
+            toolbar.contentInsetStartWithNavigation = 0
         }
-        ScreenStackHeaderSubview.Type.RIGHT -> params.gravity = Gravity.END
-        ScreenStackHeaderSubview.Type.CENTER -> {
-          params.width = LayoutParams.MATCH_PARENT
-          params.gravity = Gravity.CENTER_HORIZONTAL
-          toolbar.title = null
+        val titleTextView = titleTextView
+        if (mTitleColor != 0) {
+            toolbar.setTitleTextColor(mTitleColor)
         }
-        else -> {}
-      }
-      view.layoutParams = params
-      toolbar.addView(view)
-      i++
-    }
-  }
-
-  private fun maybeUpdate() {
-    if (parent != null && !mDestroyed) {
-      onUpdate()
-    }
-  }
-
-  fun getConfigSubview(index: Int): ScreenStackHeaderSubview {
-    return mConfigSubviews[index]
-  }
-
-  val configSubviewsCount: Int
-    get() = mConfigSubviews.size
-
-  fun removeConfigSubview(index: Int) {
-    mConfigSubviews.removeAt(index)
-    maybeUpdate()
-  }
-
-  fun removeAllConfigSubviews() {
-    mConfigSubviews.clear()
-    maybeUpdate()
-  }
-
-  fun addConfigSubview(child: ScreenStackHeaderSubview, index: Int) {
-    mConfigSubviews.add(index, child)
-    maybeUpdate()
-  }
-
-  private val titleTextView: TextView?
-    get() {
-      var i = 0
-      val size = toolbar.childCount
-      while (i < size) {
-        val view = toolbar.getChildAt(i)
-        if (view is TextView) {
-          if (view.text == toolbar.title) {
-            return view
-          }
+        if (titleTextView != null) {
+            if (mTitleFontFamily != null || mTitleFontWeight > 0) {
+                val titleTypeface = ReactTypefaceUtils.applyStyles(
+                    null, 0, mTitleFontWeight, mTitleFontFamily, context.assets
+                )
+                titleTextView.typeface = titleTypeface
+            }
+            if (mTitleFontSize > 0) {
+                titleTextView.textSize = mTitleFontSize
+            }
         }
-        i++
-      }
-      return null
+
+        // background
+        mBackgroundColor?.let { toolbar.setBackgroundColor(it) }
+
+        // color
+        if (mTintColor != 0) {
+            val navigationIcon = toolbar.navigationIcon
+            navigationIcon?.setColorFilter(mTintColor, PorterDuff.Mode.SRC_ATOP)
+        }
+
+        // subviews
+        for (i in toolbar.childCount - 1 downTo 0) {
+            if (toolbar.getChildAt(i) is ScreenStackHeaderSubview) {
+                toolbar.removeViewAt(i)
+            }
+        }
+        var i = 0
+        val size = mConfigSubviews.size
+        while (i < size) {
+            val view = mConfigSubviews[i]
+            val type = view.type
+            if (type === ScreenStackHeaderSubview.Type.BACK) {
+                // we special case BACK button header config type as we don't add it as a view into toolbar
+                // but instead just copy the drawable from imageview that's added as a first child to it.
+                val firstChild = view.getChildAt(0) as? ImageView
+                    ?: throw JSApplicationIllegalArgumentException(
+                        "Back button header config view should have Image as first child"
+                    )
+                actionBar.setHomeAsUpIndicator(firstChild.drawable)
+                i++
+                continue
+            }
+            val params = Toolbar.LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.MATCH_PARENT)
+            when (type) {
+                ScreenStackHeaderSubview.Type.LEFT -> {
+                    // when there is a left item we need to disable navigation icon by default
+                    // we also hide title as there is no other way to display left side items
+                    if (!mBackButtonInCustomView) {
+                        toolbar.navigationIcon = null
+                    }
+                    toolbar.title = null
+                    params.gravity = Gravity.START
+                }
+                ScreenStackHeaderSubview.Type.RIGHT -> params.gravity = Gravity.END
+                ScreenStackHeaderSubview.Type.CENTER -> {
+                    params.width = LayoutParams.MATCH_PARENT
+                    params.gravity = Gravity.CENTER_HORIZONTAL
+                    toolbar.title = null
+                }
+                else -> {}
+            }
+            view.layoutParams = params
+            toolbar.addView(view)
+            i++
+        }
     }
 
-  fun setTitle(title: String?) {
-    mTitle = title
-  }
-
-  fun setTitleFontFamily(titleFontFamily: String?) {
-    mTitleFontFamily = titleFontFamily
-  }
-
-  fun setTitleFontWeight(fontWeightString: String?) {
-    mTitleFontWeight = ReactTypefaceUtils.parseFontWeight(fontWeightString)
-  }
-
-  fun setTitleFontSize(titleFontSize: Float) {
-    mTitleFontSize = titleFontSize
-  }
-
-  fun setTitleColor(color: Int) {
-    mTitleColor = color
-  }
-
-  fun setTintColor(color: Int) {
-    mTintColor = color
-  }
-
-  fun setTopInsetEnabled(topInsetEnabled: Boolean) {
-    mIsTopInsetEnabled = topInsetEnabled
-  }
-
-  fun setBackgroundColor(color: Int?) {
-    mBackgroundColor = color
-  }
-
-  fun setHideShadow(hideShadow: Boolean) {
-    mIsShadowHidden = hideShadow
-  }
-
-  fun setHideBackButton(hideBackButton: Boolean) {
-    mIsBackButtonHidden = hideBackButton
-  }
-
-  fun setHidden(hidden: Boolean) {
-    mIsHidden = hidden
-  }
-
-  fun setTranslucent(translucent: Boolean) {
-    mIsTranslucent = translucent
-  }
-
-  fun setBackButtonInCustomView(backButtonInCustomView: Boolean) {
-    mBackButtonInCustomView = backButtonInCustomView
-  }
-
-  fun setDirection(direction: String?) {
-    mDirection = direction
-  }
-
-  private class DebugMenuToolbar(context: Context, config: ScreenStackHeaderConfig) : CustomToolbar(context, config) {
-    override fun showOverflowMenu(): Boolean {
-      (context.applicationContext as ReactApplication)
-        .reactNativeHost
-        .reactInstanceManager
-        .showDevOptionsDialog()
-      return true
+    private fun maybeUpdate() {
+        if (parent != null && !mDestroyed) {
+            onUpdate()
+        }
     }
-  }
 
-  init {
-    visibility = GONE
-    toolbar = if (BuildConfig.DEBUG) DebugMenuToolbar(context, this) else CustomToolbar(context, this)
-    mDefaultStartInset = toolbar.contentInsetStart
-    mDefaultStartInsetWithNavigation = toolbar.contentInsetStartWithNavigation
-
-    // set primary color as background by default
-    val tv = TypedValue()
-    if (context.theme.resolveAttribute(R.attr.colorPrimary, tv, true)) {
-      toolbar.setBackgroundColor(tv.data)
+    fun getConfigSubview(index: Int): ScreenStackHeaderSubview {
+        return mConfigSubviews[index]
     }
-    toolbar.clipChildren = false
-  }
+
+    val configSubviewsCount: Int
+        get() = mConfigSubviews.size
+
+    fun removeConfigSubview(index: Int) {
+        mConfigSubviews.removeAt(index)
+        maybeUpdate()
+    }
+
+    fun removeAllConfigSubviews() {
+        mConfigSubviews.clear()
+        maybeUpdate()
+    }
+
+    fun addConfigSubview(child: ScreenStackHeaderSubview, index: Int) {
+        mConfigSubviews.add(index, child)
+        maybeUpdate()
+    }
+
+    private val titleTextView: TextView?
+        get() {
+            var i = 0
+            val size = toolbar.childCount
+            while (i < size) {
+                val view = toolbar.getChildAt(i)
+                if (view is TextView) {
+                    if (view.text == toolbar.title) {
+                        return view
+                    }
+                }
+                i++
+            }
+            return null
+        }
+
+    fun setTitle(title: String?) {
+        mTitle = title
+    }
+
+    fun setTitleFontFamily(titleFontFamily: String?) {
+        mTitleFontFamily = titleFontFamily
+    }
+
+    fun setTitleFontWeight(fontWeightString: String?) {
+        mTitleFontWeight = ReactTypefaceUtils.parseFontWeight(fontWeightString)
+    }
+
+    fun setTitleFontSize(titleFontSize: Float) {
+        mTitleFontSize = titleFontSize
+    }
+
+    fun setTitleColor(color: Int) {
+        mTitleColor = color
+    }
+
+    fun setTintColor(color: Int) {
+        mTintColor = color
+    }
+
+    fun setTopInsetEnabled(topInsetEnabled: Boolean) {
+        mIsTopInsetEnabled = topInsetEnabled
+    }
+
+    fun setBackgroundColor(color: Int?) {
+        mBackgroundColor = color
+    }
+
+    fun setHideShadow(hideShadow: Boolean) {
+        mIsShadowHidden = hideShadow
+    }
+
+    fun setHideBackButton(hideBackButton: Boolean) {
+        mIsBackButtonHidden = hideBackButton
+    }
+
+    fun setHidden(hidden: Boolean) {
+        mIsHidden = hidden
+    }
+
+    fun setTranslucent(translucent: Boolean) {
+        mIsTranslucent = translucent
+    }
+
+    fun setBackButtonInCustomView(backButtonInCustomView: Boolean) {
+        mBackButtonInCustomView = backButtonInCustomView
+    }
+
+    fun setDirection(direction: String?) {
+        mDirection = direction
+    }
+
+    private class DebugMenuToolbar(context: Context, config: ScreenStackHeaderConfig) : CustomToolbar(context, config) {
+        override fun showOverflowMenu(): Boolean {
+            (context.applicationContext as ReactApplication)
+                .reactNativeHost
+                .reactInstanceManager
+                .showDevOptionsDialog()
+            return true
+        }
+    }
+
+    init {
+        visibility = GONE
+        toolbar = if (BuildConfig.DEBUG) DebugMenuToolbar(context, this) else CustomToolbar(context, this)
+        mDefaultStartInset = toolbar.contentInsetStart
+        mDefaultStartInsetWithNavigation = toolbar.contentInsetStartWithNavigation
+
+        // set primary color as background by default
+        val tv = TypedValue()
+        if (context.theme.resolveAttribute(R.attr.colorPrimary, tv, true)) {
+            toolbar.setBackgroundColor(tv.data)
+        }
+        toolbar.clipChildren = false
+    }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenStackHeaderConfigViewManager.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenStackHeaderConfigViewManager.kt
@@ -11,133 +11,133 @@ import javax.annotation.Nonnull
 
 @ReactModule(name = ScreenStackHeaderConfigViewManager.REACT_CLASS)
 class ScreenStackHeaderConfigViewManager : ViewGroupManager<ScreenStackHeaderConfig>() {
-  override fun getName(): String {
-    return REACT_CLASS
-  }
-
-  override fun createViewInstance(reactContext: ThemedReactContext): ScreenStackHeaderConfig {
-    return ScreenStackHeaderConfig(reactContext)
-  }
-
-  override fun addView(parent: ScreenStackHeaderConfig, child: View, index: Int) {
-    if (child !is ScreenStackHeaderSubview) {
-      throw JSApplicationCausedNativeException(
-        "Config children should be of type " + ScreenStackHeaderSubviewManager.REACT_CLASS
-      )
+    override fun getName(): String {
+        return REACT_CLASS
     }
-    parent.addConfigSubview(child, index)
-  }
 
-  override fun onDropViewInstance(@Nonnull view: ScreenStackHeaderConfig) {
-    view.destroy()
-  }
+    override fun createViewInstance(reactContext: ThemedReactContext): ScreenStackHeaderConfig {
+        return ScreenStackHeaderConfig(reactContext)
+    }
 
-  override fun removeAllViews(parent: ScreenStackHeaderConfig) {
-    parent.removeAllConfigSubviews()
-  }
+    override fun addView(parent: ScreenStackHeaderConfig, child: View, index: Int) {
+        if (child !is ScreenStackHeaderSubview) {
+            throw JSApplicationCausedNativeException(
+                "Config children should be of type " + ScreenStackHeaderSubviewManager.REACT_CLASS
+            )
+        }
+        parent.addConfigSubview(child, index)
+    }
 
-  override fun removeViewAt(parent: ScreenStackHeaderConfig, index: Int) {
-    parent.removeConfigSubview(index)
-  }
+    override fun onDropViewInstance(@Nonnull view: ScreenStackHeaderConfig) {
+        view.destroy()
+    }
 
-  override fun getChildCount(parent: ScreenStackHeaderConfig): Int {
-    return parent.configSubviewsCount
-  }
+    override fun removeAllViews(parent: ScreenStackHeaderConfig) {
+        parent.removeAllConfigSubviews()
+    }
 
-  override fun getChildAt(parent: ScreenStackHeaderConfig, index: Int): View {
-    return parent.getConfigSubview(index)
-  }
+    override fun removeViewAt(parent: ScreenStackHeaderConfig, index: Int) {
+        parent.removeConfigSubview(index)
+    }
 
-  override fun needsCustomLayoutForChildren(): Boolean {
-    return true
-  }
+    override fun getChildCount(parent: ScreenStackHeaderConfig): Int {
+        return parent.configSubviewsCount
+    }
 
-  override fun onAfterUpdateTransaction(parent: ScreenStackHeaderConfig) {
-    super.onAfterUpdateTransaction(parent)
-    parent.onUpdate()
-  }
+    override fun getChildAt(parent: ScreenStackHeaderConfig, index: Int): View {
+        return parent.getConfigSubview(index)
+    }
 
-  @ReactProp(name = "title")
-  fun setTitle(config: ScreenStackHeaderConfig, title: String?) {
-    config.setTitle(title)
-  }
+    override fun needsCustomLayoutForChildren(): Boolean {
+        return true
+    }
 
-  @ReactProp(name = "titleFontFamily")
-  fun setTitleFontFamily(config: ScreenStackHeaderConfig, titleFontFamily: String?) {
-    config.setTitleFontFamily(titleFontFamily)
-  }
+    override fun onAfterUpdateTransaction(parent: ScreenStackHeaderConfig) {
+        super.onAfterUpdateTransaction(parent)
+        parent.onUpdate()
+    }
 
-  @ReactProp(name = "titleFontSize")
-  fun setTitleFontSize(config: ScreenStackHeaderConfig, titleFontSize: Float) {
-    config.setTitleFontSize(titleFontSize)
-  }
+    @ReactProp(name = "title")
+    fun setTitle(config: ScreenStackHeaderConfig, title: String?) {
+        config.setTitle(title)
+    }
 
-  @ReactProp(name = "titleFontWeight")
-  fun setTitleFontWeight(config: ScreenStackHeaderConfig, titleFontWeight: String?) {
-    config.setTitleFontWeight(titleFontWeight)
-  }
+    @ReactProp(name = "titleFontFamily")
+    fun setTitleFontFamily(config: ScreenStackHeaderConfig, titleFontFamily: String?) {
+        config.setTitleFontFamily(titleFontFamily)
+    }
 
-  @ReactProp(name = "titleColor", customType = "Color")
-  fun setTitleColor(config: ScreenStackHeaderConfig, titleColor: Int) {
-    config.setTitleColor(titleColor)
-  }
+    @ReactProp(name = "titleFontSize")
+    fun setTitleFontSize(config: ScreenStackHeaderConfig, titleFontSize: Float) {
+        config.setTitleFontSize(titleFontSize)
+    }
 
-  @ReactProp(name = "backgroundColor", customType = "Color")
-  fun setBackgroundColor(config: ScreenStackHeaderConfig, backgroundColor: Int?) {
-    config.setBackgroundColor(backgroundColor)
-  }
+    @ReactProp(name = "titleFontWeight")
+    fun setTitleFontWeight(config: ScreenStackHeaderConfig, titleFontWeight: String?) {
+        config.setTitleFontWeight(titleFontWeight)
+    }
 
-  @ReactProp(name = "hideShadow")
-  fun setHideShadow(config: ScreenStackHeaderConfig, hideShadow: Boolean) {
-    config.setHideShadow(hideShadow)
-  }
+    @ReactProp(name = "titleColor", customType = "Color")
+    fun setTitleColor(config: ScreenStackHeaderConfig, titleColor: Int) {
+        config.setTitleColor(titleColor)
+    }
 
-  @ReactProp(name = "hideBackButton")
-  fun setHideBackButton(config: ScreenStackHeaderConfig, hideBackButton: Boolean) {
-    config.setHideBackButton(hideBackButton)
-  }
+    @ReactProp(name = "backgroundColor", customType = "Color")
+    fun setBackgroundColor(config: ScreenStackHeaderConfig, backgroundColor: Int?) {
+        config.setBackgroundColor(backgroundColor)
+    }
 
-  @ReactProp(name = "topInsetEnabled")
-  fun setTopInsetEnabled(config: ScreenStackHeaderConfig, topInsetEnabled: Boolean) {
-    config.setTopInsetEnabled(topInsetEnabled)
-  }
+    @ReactProp(name = "hideShadow")
+    fun setHideShadow(config: ScreenStackHeaderConfig, hideShadow: Boolean) {
+        config.setHideShadow(hideShadow)
+    }
 
-  @ReactProp(name = "color", customType = "Color")
-  fun setColor(config: ScreenStackHeaderConfig, color: Int) {
-    config.setTintColor(color)
-  }
+    @ReactProp(name = "hideBackButton")
+    fun setHideBackButton(config: ScreenStackHeaderConfig, hideBackButton: Boolean) {
+        config.setHideBackButton(hideBackButton)
+    }
 
-  @ReactProp(name = "hidden")
-  fun setHidden(config: ScreenStackHeaderConfig, hidden: Boolean) {
-    config.setHidden(hidden)
-  }
+    @ReactProp(name = "topInsetEnabled")
+    fun setTopInsetEnabled(config: ScreenStackHeaderConfig, topInsetEnabled: Boolean) {
+        config.setTopInsetEnabled(topInsetEnabled)
+    }
 
-  @ReactProp(name = "translucent")
-  fun setTranslucent(config: ScreenStackHeaderConfig, translucent: Boolean) {
-    config.setTranslucent(translucent)
-  }
+    @ReactProp(name = "color", customType = "Color")
+    fun setColor(config: ScreenStackHeaderConfig, color: Int) {
+        config.setTintColor(color)
+    }
 
-  @ReactProp(name = "backButtonInCustomView")
-  fun setBackButtonInCustomView(
-    config: ScreenStackHeaderConfig,
-    backButtonInCustomView: Boolean
-  ) {
-    config.setBackButtonInCustomView(backButtonInCustomView)
-  }
+    @ReactProp(name = "hidden")
+    fun setHidden(config: ScreenStackHeaderConfig, hidden: Boolean) {
+        config.setHidden(hidden)
+    }
 
-  @ReactProp(name = "direction")
-  fun setDirection(config: ScreenStackHeaderConfig, direction: String?) {
-    config.setDirection(direction)
-  }
+    @ReactProp(name = "translucent")
+    fun setTranslucent(config: ScreenStackHeaderConfig, translucent: Boolean) {
+        config.setTranslucent(translucent)
+    }
 
-  override fun getExportedCustomDirectEventTypeConstants(): Map<String, Any>? {
-    return MapBuilder.builder<String, Any>()
-      .put("onAttached", MapBuilder.of("registrationName", "onAttached"))
-      .put("onDetached", MapBuilder.of("registrationName", "onDetached"))
-      .build()
-  }
+    @ReactProp(name = "backButtonInCustomView")
+    fun setBackButtonInCustomView(
+        config: ScreenStackHeaderConfig,
+        backButtonInCustomView: Boolean
+    ) {
+        config.setBackButtonInCustomView(backButtonInCustomView)
+    }
 
-  companion object {
-    const val REACT_CLASS = "RNSScreenStackHeaderConfig"
-  }
+    @ReactProp(name = "direction")
+    fun setDirection(config: ScreenStackHeaderConfig, direction: String?) {
+        config.setDirection(direction)
+    }
+
+    override fun getExportedCustomDirectEventTypeConstants(): Map<String, Any>? {
+        return MapBuilder.builder<String, Any>()
+            .put("onAttached", MapBuilder.of("registrationName", "onAttached"))
+            .put("onDetached", MapBuilder.of("registrationName", "onDetached"))
+            .build()
+    }
+
+    companion object {
+        const val REACT_CLASS = "RNSScreenStackHeaderConfig"
+    }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenStackHeaderSubview.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenStackHeaderSubview.kt
@@ -7,36 +7,36 @@ import com.facebook.react.views.view.ReactViewGroup
 
 @SuppressLint("ViewConstructor")
 class ScreenStackHeaderSubview(context: ReactContext?) : ReactViewGroup(context) {
-  private var mReactWidth = 0
-  private var mReactHeight = 0
-  var type = Type.RIGHT
+    private var mReactWidth = 0
+    private var mReactHeight = 0
+    var type = Type.RIGHT
 
-  val config: ScreenStackHeaderConfig?
-    get() {
-      return (parent as? CustomToolbar)?.config
+    val config: ScreenStackHeaderConfig?
+        get() {
+            return (parent as? CustomToolbar)?.config
+        }
+
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        if (MeasureSpec.getMode(widthMeasureSpec) == MeasureSpec.EXACTLY &&
+            MeasureSpec.getMode(heightMeasureSpec) == MeasureSpec.EXACTLY
+        ) {
+            // dimensions provided by react
+            mReactWidth = MeasureSpec.getSize(widthMeasureSpec)
+            mReactHeight = MeasureSpec.getSize(heightMeasureSpec)
+            val parent = parent
+            if (parent != null) {
+                forceLayout()
+                (parent as View).requestLayout()
+            }
+        }
+        setMeasuredDimension(mReactWidth, mReactHeight)
     }
 
-  override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
-    if (MeasureSpec.getMode(widthMeasureSpec) == MeasureSpec.EXACTLY &&
-      MeasureSpec.getMode(heightMeasureSpec) == MeasureSpec.EXACTLY
-    ) {
-      // dimensions provided by react
-      mReactWidth = MeasureSpec.getSize(widthMeasureSpec)
-      mReactHeight = MeasureSpec.getSize(heightMeasureSpec)
-      val parent = parent
-      if (parent != null) {
-        forceLayout()
-        (parent as View).requestLayout()
-      }
+    override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
+        // no-op
     }
-    setMeasuredDimension(mReactWidth, mReactHeight)
-  }
 
-  override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
-    // no-op
-  }
-
-  enum class Type {
-    LEFT, CENTER, RIGHT, BACK, SEARCH_BAR
-  }
+    enum class Type {
+        LEFT, CENTER, RIGHT, BACK, SEARCH_BAR
+    }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenStackHeaderSubviewManager.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenStackHeaderSubviewManager.kt
@@ -9,27 +9,27 @@ import com.facebook.react.views.view.ReactViewManager
 
 @ReactModule(name = ScreenStackHeaderSubviewManager.REACT_CLASS)
 class ScreenStackHeaderSubviewManager : ReactViewManager() {
-  override fun getName(): String {
-    return REACT_CLASS
-  }
-
-  override fun createViewInstance(context: ThemedReactContext): ReactViewGroup {
-    return ScreenStackHeaderSubview(context)
-  }
-
-  @ReactProp(name = "type")
-  fun setType(view: ScreenStackHeaderSubview, type: String) {
-    view.type = when (type) {
-      "left" -> ScreenStackHeaderSubview.Type.LEFT
-      "center" -> ScreenStackHeaderSubview.Type.CENTER
-      "right" -> ScreenStackHeaderSubview.Type.RIGHT
-      "back" -> ScreenStackHeaderSubview.Type.BACK
-      "searchBar" -> ScreenStackHeaderSubview.Type.SEARCH_BAR
-      else -> throw JSApplicationIllegalArgumentException("Unknown type $type")
+    override fun getName(): String {
+        return REACT_CLASS
     }
-  }
 
-  companion object {
-    const val REACT_CLASS = "RNSScreenStackHeaderSubview"
-  }
+    override fun createViewInstance(context: ThemedReactContext): ReactViewGroup {
+        return ScreenStackHeaderSubview(context)
+    }
+
+    @ReactProp(name = "type")
+    fun setType(view: ScreenStackHeaderSubview, type: String) {
+        view.type = when (type) {
+            "left" -> ScreenStackHeaderSubview.Type.LEFT
+            "center" -> ScreenStackHeaderSubview.Type.CENTER
+            "right" -> ScreenStackHeaderSubview.Type.RIGHT
+            "back" -> ScreenStackHeaderSubview.Type.BACK
+            "searchBar" -> ScreenStackHeaderSubview.Type.SEARCH_BAR
+            else -> throw JSApplicationIllegalArgumentException("Unknown type $type")
+        }
+    }
+
+    companion object {
+        const val REACT_CLASS = "RNSScreenStackHeaderSubview"
+    }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenStackViewManager.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenStackViewManager.kt
@@ -10,65 +10,65 @@ import com.facebook.react.uimanager.ViewGroupManager
 
 @ReactModule(name = ScreenStackViewManager.REACT_CLASS)
 class ScreenStackViewManager : ViewGroupManager<ScreenStack>() {
-  override fun getName(): String {
-    return REACT_CLASS
-  }
-
-  override fun createViewInstance(reactContext: ThemedReactContext): ScreenStack {
-    return ScreenStack(reactContext)
-  }
-
-  override fun addView(parent: ScreenStack, child: View, index: Int) {
-    require(child is Screen) { "Attempt attach child that is not of type RNScreen" }
-    parent.addScreen(child, index)
-  }
-
-  override fun removeViewAt(parent: ScreenStack, index: Int) {
-    prepareOutTransition(parent.getScreenAt(index))
-    parent.removeScreenAt(index)
-  }
-
-  private fun prepareOutTransition(screen: Screen?) {
-    startTransitionRecursive(screen)
-  }
-
-  private fun startTransitionRecursive(parent: ViewGroup?) {
-    var i = 0
-    parent?.let {
-      val size = it.childCount
-      while (i < size) {
-        val child = it.getChildAt(i)
-        child?.let { view -> it.startViewTransition(view) }
-        if (child is ScreenStackHeaderConfig) {
-          // we want to start transition on children of the toolbar too,
-          // which is not a child of ScreenStackHeaderConfig
-          startTransitionRecursive(child.toolbar)
-        }
-        if (child is ViewGroup) {
-          startTransitionRecursive(child)
-        }
-        i++
-      }
+    override fun getName(): String {
+        return REACT_CLASS
     }
-  }
 
-  override fun getChildCount(parent: ScreenStack): Int {
-    return parent.screenCount
-  }
+    override fun createViewInstance(reactContext: ThemedReactContext): ScreenStack {
+        return ScreenStack(reactContext)
+    }
 
-  override fun getChildAt(parent: ScreenStack, index: Int): View {
-    return parent.getScreenAt(index)
-  }
+    override fun addView(parent: ScreenStack, child: View, index: Int) {
+        require(child is Screen) { "Attempt attach child that is not of type RNScreen" }
+        parent.addScreen(child, index)
+    }
 
-  override fun createShadowNodeInstance(context: ReactApplicationContext): LayoutShadowNode {
-    return ScreensShadowNode(context)
-  }
+    override fun removeViewAt(parent: ScreenStack, index: Int) {
+        prepareOutTransition(parent.getScreenAt(index))
+        parent.removeScreenAt(index)
+    }
 
-  override fun needsCustomLayoutForChildren(): Boolean {
-    return true
-  }
+    private fun prepareOutTransition(screen: Screen?) {
+        startTransitionRecursive(screen)
+    }
 
-  companion object {
-    const val REACT_CLASS = "RNSScreenStack"
-  }
+    private fun startTransitionRecursive(parent: ViewGroup?) {
+        var i = 0
+        parent?.let {
+            val size = it.childCount
+            while (i < size) {
+                val child = it.getChildAt(i)
+                child?.let { view -> it.startViewTransition(view) }
+                if (child is ScreenStackHeaderConfig) {
+                    // we want to start transition on children of the toolbar too,
+                    // which is not a child of ScreenStackHeaderConfig
+                    startTransitionRecursive(child.toolbar)
+                }
+                if (child is ViewGroup) {
+                    startTransitionRecursive(child)
+                }
+                i++
+            }
+        }
+    }
+
+    override fun getChildCount(parent: ScreenStack): Int {
+        return parent.screenCount
+    }
+
+    override fun getChildAt(parent: ScreenStack, index: Int): View {
+        return parent.getScreenAt(index)
+    }
+
+    override fun createShadowNodeInstance(context: ReactApplicationContext): LayoutShadowNode {
+        return ScreensShadowNode(context)
+    }
+
+    override fun needsCustomLayoutForChildren(): Boolean {
+        return true
+    }
+
+    companion object {
+        const val REACT_CLASS = "RNSScreenStack"
+    }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenViewManager.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenViewManager.kt
@@ -17,132 +17,142 @@ import versioned.host.exp.exponent.modules.api.screens.events.StackFinishTransit
 
 @ReactModule(name = ScreenViewManager.REACT_CLASS)
 class ScreenViewManager : ViewGroupManager<Screen>() {
-  override fun getName(): String {
-    return REACT_CLASS
-  }
-
-  override fun createViewInstance(reactContext: ThemedReactContext): Screen {
-    return Screen(reactContext)
-  }
-
-  @ReactProp(name = "activityState")
-  fun setActivityState(view: Screen, activityState: Int?) {
-    if (activityState == null) {
-      // Null will be provided when activityState is set as an animated value and we change
-      // it from JS to be a plain value (non animated).
-      // In case when null is received, we want to ignore such value and not make
-      // any updates as the actual non-null value will follow immediately.
-      return
+    override fun getName(): String {
+        return REACT_CLASS
     }
-    when (activityState) {
-      0 -> view.setActivityState(Screen.ActivityState.INACTIVE)
-      1 -> view.setActivityState(Screen.ActivityState.TRANSITIONING_OR_BELOW_TOP)
-      2 -> view.setActivityState(Screen.ActivityState.ON_TOP)
+
+    override fun createViewInstance(reactContext: ThemedReactContext): Screen {
+        return Screen(reactContext)
     }
-  }
 
-  @ReactProp(name = "stackPresentation")
-  fun setStackPresentation(view: Screen, presentation: String) {
-    view.stackPresentation = when (presentation) {
-      "push" -> Screen.StackPresentation.PUSH
-      "modal", "containedModal", "fullScreenModal", "formSheet" ->
-        Screen.StackPresentation.MODAL
-      "transparentModal", "containedTransparentModal" ->
-        Screen.StackPresentation.TRANSPARENT_MODAL
-      else -> throw JSApplicationIllegalArgumentException("Unknown presentation type $presentation")
+    @ReactProp(name = "activityState")
+    fun setActivityState(view: Screen, activityState: Int?) {
+        if (activityState == null) {
+            // Null will be provided when activityState is set as an animated value and we change
+            // it from JS to be a plain value (non animated).
+            // In case when null is received, we want to ignore such value and not make
+            // any updates as the actual non-null value will follow immediately.
+            return
+        }
+        when (activityState) {
+            0 -> view.setActivityState(Screen.ActivityState.INACTIVE)
+            1 -> view.setActivityState(Screen.ActivityState.TRANSITIONING_OR_BELOW_TOP)
+            2 -> view.setActivityState(Screen.ActivityState.ON_TOP)
+        }
     }
-  }
 
-  @ReactProp(name = "stackAnimation")
-  fun setStackAnimation(view: Screen, animation: String?) {
-    view.stackAnimation = when (animation) {
-      null, "default", "flip", "simple_push" -> Screen.StackAnimation.DEFAULT
-      "none" -> Screen.StackAnimation.NONE
-      "fade" -> Screen.StackAnimation.FADE
-      "slide_from_right" -> Screen.StackAnimation.SLIDE_FROM_RIGHT
-      "slide_from_left" -> Screen.StackAnimation.SLIDE_FROM_LEFT
-      "slide_from_bottom" -> Screen.StackAnimation.SLIDE_FROM_BOTTOM
-      "fade_from_bottom" -> Screen.StackAnimation.FADE_FROM_BOTTOM
-      else -> throw JSApplicationIllegalArgumentException("Unknown animation type $animation")
+    @ReactProp(name = "stackPresentation")
+    fun setStackPresentation(view: Screen, presentation: String) {
+        view.stackPresentation = when (presentation) {
+            "push" -> Screen.StackPresentation.PUSH
+            "modal", "containedModal", "fullScreenModal", "formSheet" ->
+                Screen.StackPresentation.MODAL
+            "transparentModal", "containedTransparentModal" ->
+                Screen.StackPresentation.TRANSPARENT_MODAL
+            else -> throw JSApplicationIllegalArgumentException("Unknown presentation type $presentation")
+        }
     }
-  }
 
-  @ReactProp(name = "gestureEnabled", defaultBoolean = true)
-  fun setGestureEnabled(view: Screen, gestureEnabled: Boolean) {
-    view.isGestureEnabled = gestureEnabled
-  }
-
-  @ReactProp(name = "replaceAnimation")
-  fun setReplaceAnimation(view: Screen, animation: String?) {
-    view.replaceAnimation = when (animation) {
-      null, "pop" -> Screen.ReplaceAnimation.POP
-      "push" -> Screen.ReplaceAnimation.PUSH
-      else -> throw JSApplicationIllegalArgumentException("Unknown replace animation type $animation")
+    @ReactProp(name = "stackAnimation")
+    fun setStackAnimation(view: Screen, animation: String?) {
+        view.stackAnimation = when (animation) {
+            null, "default", "flip", "simple_push" -> Screen.StackAnimation.DEFAULT
+            "none" -> Screen.StackAnimation.NONE
+            "fade" -> Screen.StackAnimation.FADE
+            "slide_from_right" -> Screen.StackAnimation.SLIDE_FROM_RIGHT
+            "slide_from_left" -> Screen.StackAnimation.SLIDE_FROM_LEFT
+            "slide_from_bottom" -> Screen.StackAnimation.SLIDE_FROM_BOTTOM
+            "fade_from_bottom" -> Screen.StackAnimation.FADE_FROM_BOTTOM
+            else -> throw JSApplicationIllegalArgumentException("Unknown animation type $animation")
+        }
     }
-  }
 
-  @ReactProp(name = "screenOrientation")
-  fun setScreenOrientation(view: Screen, screenOrientation: String?) {
-    view.setScreenOrientation(screenOrientation)
-  }
+    @ReactProp(name = "gestureEnabled", defaultBoolean = true)
+    fun setGestureEnabled(view: Screen, gestureEnabled: Boolean) {
+        view.isGestureEnabled = gestureEnabled
+    }
 
-  @ReactProp(name = "statusBarAnimation")
-  fun setStatusBarAnimation(view: Screen, statusBarAnimation: String?) {
-    val animated = statusBarAnimation != null && "none" != statusBarAnimation
-    view.isStatusBarAnimated = animated
-  }
+    @ReactProp(name = "replaceAnimation")
+    fun setReplaceAnimation(view: Screen, animation: String?) {
+        view.replaceAnimation = when (animation) {
+            null, "pop" -> Screen.ReplaceAnimation.POP
+            "push" -> Screen.ReplaceAnimation.PUSH
+            else -> throw JSApplicationIllegalArgumentException("Unknown replace animation type $animation")
+        }
+    }
 
-  @ReactProp(name = "statusBarColor")
-  fun setStatusBarColor(view: Screen, statusBarColor: Int?) {
-    view.statusBarColor = statusBarColor
-  }
+    @ReactProp(name = "screenOrientation")
+    fun setScreenOrientation(view: Screen, screenOrientation: String?) {
+        view.setScreenOrientation(screenOrientation)
+    }
 
-  @ReactProp(name = "statusBarStyle")
-  fun setStatusBarStyle(view: Screen, statusBarStyle: String?) {
-    view.statusBarStyle = statusBarStyle
-  }
+    @ReactProp(name = "statusBarAnimation")
+    fun setStatusBarAnimation(view: Screen, statusBarAnimation: String?) {
+        val animated = statusBarAnimation != null && "none" != statusBarAnimation
+        view.isStatusBarAnimated = animated
+    }
 
-  @ReactProp(name = "statusBarTranslucent")
-  fun setStatusBarTranslucent(view: Screen, statusBarTranslucent: Boolean?) {
-    view.isStatusBarTranslucent = statusBarTranslucent
-  }
+    @ReactProp(name = "statusBarColor")
+    fun setStatusBarColor(view: Screen, statusBarColor: Int?) {
+        view.statusBarColor = statusBarColor
+    }
 
-  @ReactProp(name = "statusBarHidden")
-  fun setStatusBarHidden(view: Screen, statusBarHidden: Boolean?) {
-    view.isStatusBarHidden = statusBarHidden
-  }
+    @ReactProp(name = "statusBarStyle")
+    fun setStatusBarStyle(view: Screen, statusBarStyle: String?) {
+        view.statusBarStyle = statusBarStyle
+    }
 
-  @ReactProp(name = "nativeBackButtonDismissalEnabled")
-  fun setNativeBackButtonDismissalEnabled(
-    view: Screen,
-    nativeBackButtonDismissalEnabled: Boolean
-  ) {
-    view.nativeBackButtonDismissalEnabled = nativeBackButtonDismissalEnabled
-  }
+    @ReactProp(name = "statusBarTranslucent")
+    fun setStatusBarTranslucent(view: Screen, statusBarTranslucent: Boolean?) {
+        view.isStatusBarTranslucent = statusBarTranslucent
+    }
 
-  override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any> {
-    val map: MutableMap<String, Any> = MapBuilder.of(
-      ScreenDismissedEvent.EVENT_NAME,
-      MapBuilder.of("registrationName", "onDismissed"),
-      ScreenWillAppearEvent.EVENT_NAME,
-      MapBuilder.of("registrationName", "onWillAppear"),
-      ScreenAppearEvent.EVENT_NAME,
-      MapBuilder.of("registrationName", "onAppear"),
-      ScreenWillDisappearEvent.EVENT_NAME,
-      MapBuilder.of("registrationName", "onWillDisappear"),
-      ScreenDisappearEvent.EVENT_NAME,
-      MapBuilder.of("registrationName", "onDisappear"),
-      StackFinishTransitioningEvent.EVENT_NAME,
-      MapBuilder.of("registrationName", "onFinishTransitioning"),
-      ScreenTransitionProgressEvent.EVENT_NAME,
-      MapBuilder.of("registrationName", "onTransitionProgress")
-    )
-    // there is no `MapBuilder.of` with more than 7 items
-    map[HeaderBackButtonClickedEvent.EVENT_NAME] = MapBuilder.of("registrationName", "onHeaderBackButtonClicked")
-    return map
-  }
+    @ReactProp(name = "statusBarHidden")
+    fun setStatusBarHidden(view: Screen, statusBarHidden: Boolean?) {
+        view.isStatusBarHidden = statusBarHidden
+    }
 
-  companion object {
-    const val REACT_CLASS = "RNSScreen"
-  }
+    @ReactProp(name = "navigationBarColor", customType = "Color")
+    fun setNavigationBarColor(view: Screen, navigationBarColor: Int) {
+        view.navigationBarColor = navigationBarColor
+    }
+
+    @ReactProp(name = "navigationBarHidden")
+    fun setNavigationBarHidden(view: Screen, navigationBarHidden: Boolean?) {
+        view.isNavigationBarHidden = navigationBarHidden
+    }
+
+    @ReactProp(name = "nativeBackButtonDismissalEnabled")
+    fun setNativeBackButtonDismissalEnabled(
+        view: Screen,
+        nativeBackButtonDismissalEnabled: Boolean
+    ) {
+        view.nativeBackButtonDismissalEnabled = nativeBackButtonDismissalEnabled
+    }
+
+    override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any> {
+        val map: MutableMap<String, Any> = MapBuilder.of(
+            ScreenDismissedEvent.EVENT_NAME,
+            MapBuilder.of("registrationName", "onDismissed"),
+            ScreenWillAppearEvent.EVENT_NAME,
+            MapBuilder.of("registrationName", "onWillAppear"),
+            ScreenAppearEvent.EVENT_NAME,
+            MapBuilder.of("registrationName", "onAppear"),
+            ScreenWillDisappearEvent.EVENT_NAME,
+            MapBuilder.of("registrationName", "onWillDisappear"),
+            ScreenDisappearEvent.EVENT_NAME,
+            MapBuilder.of("registrationName", "onDisappear"),
+            StackFinishTransitioningEvent.EVENT_NAME,
+            MapBuilder.of("registrationName", "onFinishTransitioning"),
+            ScreenTransitionProgressEvent.EVENT_NAME,
+            MapBuilder.of("registrationName", "onTransitionProgress")
+        )
+        // there is no `MapBuilder.of` with more than 7 items
+        map[HeaderBackButtonClickedEvent.EVENT_NAME] = MapBuilder.of("registrationName", "onHeaderBackButtonClicked")
+        return map
+    }
+
+    companion object {
+        const val REACT_CLASS = "RNSScreen"
+    }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenWindowTraits.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenWindowTraits.kt
@@ -6,211 +6,272 @@ import android.annotation.SuppressLint
 import android.annotation.TargetApi
 import android.app.Activity
 import android.content.pm.ActivityInfo
+import android.graphics.Color
 import android.os.Build
 import android.view.View
 import android.view.ViewParent
 import android.view.WindowManager
 import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
 import com.facebook.react.bridge.GuardedRunnable
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.UiThreadUtil
 import versioned.host.exp.exponent.modules.api.screens.Screen.WindowTraits
 
 object ScreenWindowTraits {
-  // Methods concerning statusBar management were taken from `react-native`'s status bar module:
-  // https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/modules/statusbar/StatusBarModule.java
-  private var mDidSetOrientation = false
-  private var mDidSetStatusBarAppearance = false
-  private var mDefaultStatusBarColor: Int? = null
-  internal fun applyDidSetOrientation() {
-    mDidSetOrientation = true
-  }
-
-  internal fun applyDidSetStatusBarAppearance() {
-    mDidSetStatusBarAppearance = true
-  }
-
-  internal fun setOrientation(screen: Screen, activity: Activity?) {
-    if (activity == null) {
-      return
+    // Methods concerning statusBar management were taken from `react-native`'s status bar module:
+    // https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/modules/statusbar/StatusBarModule.java
+    private var mDidSetOrientation = false
+    private var mDidSetStatusBarAppearance = false
+    private var mDidSetNavigationBarAppearance = false
+    private var mDefaultStatusBarColor: Int? = null
+    internal fun applyDidSetOrientation() {
+        mDidSetOrientation = true
     }
-    val screenForOrientation = findScreenForTrait(screen, WindowTraits.ORIENTATION)
-    val orientation = screenForOrientation?.screenOrientation ?: ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
-    activity.requestedOrientation = orientation
-  }
 
-  @SuppressLint("ObsoleteSdkInt") // to be removed when support for < 0.64 is dropped
-  internal fun setColor(screen: Screen, activity: Activity?, context: ReactContext?) {
-    if (activity == null || context == null || Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-      return
+    internal fun applyDidSetStatusBarAppearance() {
+        mDidSetStatusBarAppearance = true
     }
-    if (mDefaultStatusBarColor == null) {
-      mDefaultStatusBarColor = activity.window.statusBarColor
-    }
-    val screenForColor = findScreenForTrait(screen, WindowTraits.COLOR)
-    val screenForAnimated = findScreenForTrait(screen, WindowTraits.ANIMATED)
-    val color = screenForColor?.statusBarColor ?: mDefaultStatusBarColor
-    val animated = screenForAnimated?.isStatusBarAnimated ?: false
 
-    UiThreadUtil.runOnUiThread(
-      object : GuardedRunnable(context) {
-        override fun runGuarded() {
-          activity
-            .window
-            .addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
-          val curColor = activity.window.statusBarColor
-          val colorAnimation = ValueAnimator.ofObject(ArgbEvaluator(), curColor, color)
-          colorAnimation.addUpdateListener { animator -> activity.window.statusBarColor = (animator.animatedValue as Int) }
-          if (animated) {
-            colorAnimation.setDuration(300).startDelay = 0
-          } else {
-            colorAnimation.setDuration(0).startDelay = 300
-          }
-          colorAnimation.start()
+    internal fun applyDidSetNavigationBarAppearance() {
+        mDidSetNavigationBarAppearance = true
+    }
+
+    internal fun setOrientation(screen: Screen, activity: Activity?) {
+        if (activity == null) {
+            return
         }
-      })
-  }
-
-  internal fun setStyle(screen: Screen, activity: Activity?, context: ReactContext?) {
-    if (activity == null || context == null) {
-      return
+        val screenForOrientation = findScreenForTrait(screen, WindowTraits.ORIENTATION)
+        val orientation = screenForOrientation?.screenOrientation ?: ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
+        activity.requestedOrientation = orientation
     }
-    val screenForStyle = findScreenForTrait(screen, WindowTraits.STYLE)
-    val style = screenForStyle?.statusBarStyle ?: "light"
 
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-      UiThreadUtil.runOnUiThread {
-        val decorView = activity.window.decorView
-        var systemUiVisibilityFlags = decorView.systemUiVisibility
-        systemUiVisibilityFlags = if ("dark" == style) {
-          systemUiVisibilityFlags or View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
-        } else {
-          systemUiVisibilityFlags and View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR.inv()
+    @SuppressLint("ObsoleteSdkInt") // to be removed when support for < 0.64 is dropped
+    internal fun setColor(screen: Screen, activity: Activity?, context: ReactContext?) {
+        if (activity == null || context == null || Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            return
         }
-        decorView.systemUiVisibility = systemUiVisibilityFlags
-      }
-    }
-  }
+        if (mDefaultStatusBarColor == null) {
+            mDefaultStatusBarColor = activity.window.statusBarColor
+        }
+        val screenForColor = findScreenForTrait(screen, WindowTraits.COLOR)
+        val screenForAnimated = findScreenForTrait(screen, WindowTraits.ANIMATED)
+        val color = screenForColor?.statusBarColor ?: mDefaultStatusBarColor
+        val animated = screenForAnimated?.isStatusBarAnimated ?: false
 
-  internal fun setTranslucent(
-    screen: Screen,
-    activity: Activity?,
-    context: ReactContext?
-  ) {
-    if (activity == null || context == null) {
-      return
+        UiThreadUtil.runOnUiThread(
+            object : GuardedRunnable(context) {
+                override fun runGuarded() {
+                    activity
+                        .window
+                        .addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
+                    val curColor = activity.window.statusBarColor
+                    val colorAnimation = ValueAnimator.ofObject(ArgbEvaluator(), curColor, color)
+                    colorAnimation.addUpdateListener { animator -> activity.window.statusBarColor = (animator.animatedValue as Int) }
+                    if (animated) {
+                        colorAnimation.setDuration(300).startDelay = 0
+                    } else {
+                        colorAnimation.setDuration(0).startDelay = 300
+                    }
+                    colorAnimation.start()
+                }
+            })
     }
-    val screenForTranslucent = findScreenForTrait(screen, WindowTraits.TRANSLUCENT)
-    val translucent = screenForTranslucent?.isStatusBarTranslucent ?: false
-    UiThreadUtil.runOnUiThread(
-      object : GuardedRunnable(context) {
-        @TargetApi(Build.VERSION_CODES.LOLLIPOP)
-        override fun runGuarded() {
-          // If the status bar is translucent hook into the window insets calculations
-          // and consume all the top insets so no padding will be added under the status bar.
-          val decorView = activity.window.decorView
-          if (translucent) {
-            decorView.setOnApplyWindowInsetsListener { v, insets ->
-              val defaultInsets = v.onApplyWindowInsets(insets)
-              defaultInsets.replaceSystemWindowInsets(
-                defaultInsets.systemWindowInsetLeft,
-                0,
-                defaultInsets.systemWindowInsetRight,
-                defaultInsets.systemWindowInsetBottom
-              )
+
+    internal fun setStyle(screen: Screen, activity: Activity?, context: ReactContext?) {
+        if (activity == null || context == null || Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            return
+        }
+        val screenForStyle = findScreenForTrait(screen, WindowTraits.STYLE)
+        val style = screenForStyle?.statusBarStyle ?: "light"
+
+        UiThreadUtil.runOnUiThread {
+            val decorView = activity.window.decorView
+            var systemUiVisibilityFlags = decorView.systemUiVisibility
+            systemUiVisibilityFlags = if ("dark" == style) {
+                systemUiVisibilityFlags or View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
+            } else {
+                systemUiVisibilityFlags and View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR.inv()
             }
-          } else {
-            decorView.setOnApplyWindowInsetsListener(null)
-          }
-          ViewCompat.requestApplyInsets(decorView)
+            decorView.systemUiVisibility = systemUiVisibilityFlags
         }
-      })
-  }
+    }
 
-  internal fun setHidden(screen: Screen, activity: Activity?) {
-    if (activity == null) {
-      return
-    }
-    val screenForHidden = findScreenForTrait(screen, WindowTraits.HIDDEN)
-    val hidden = screenForHidden?.isStatusBarHidden ?: false
-    UiThreadUtil.runOnUiThread {
-      if (hidden) {
-        activity.window.addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN)
-        activity.window.clearFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN)
-      } else {
-        activity.window.addFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN)
-        activity.window.clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN)
-      }
-    }
-  }
-
-  internal fun trySetWindowTraits(screen: Screen, activity: Activity?, context: ReactContext?) {
-    if (mDidSetOrientation) {
-      setOrientation(screen, activity)
-    }
-    if (mDidSetStatusBarAppearance) {
-      setColor(screen, activity, context)
-      setStyle(screen, activity, context)
-      setTranslucent(screen, activity, context)
-      setHidden(screen, activity)
-    }
-  }
-
-  private fun findScreenForTrait(screen: Screen, trait: WindowTraits): Screen? {
-    val childWithTrait = childScreenWithTraitSet(screen, trait)
-    if (childWithTrait != null) {
-      return childWithTrait
-    }
-    return if (checkTraitForScreen(screen, trait)) {
-      screen
-    } else {
-      // if there is no child with trait set and this screen has no trait set, we look for a parent
-      // that has the trait set
-      findParentWithTraitSet(screen, trait)
-    }
-  }
-
-  private fun findParentWithTraitSet(screen: Screen, trait: WindowTraits): Screen? {
-    var parent: ViewParent? = screen.container
-    while (parent != null) {
-      if (parent is Screen) {
-        if (checkTraitForScreen(parent, trait)) {
-          return parent
+    internal fun setTranslucent(
+        screen: Screen,
+        activity: Activity?,
+        context: ReactContext?
+    ) {
+        if (activity == null || context == null) {
+            return
         }
-      }
-      parent = parent.parent
+        val screenForTranslucent = findScreenForTrait(screen, WindowTraits.TRANSLUCENT)
+        val translucent = screenForTranslucent?.isStatusBarTranslucent ?: false
+        UiThreadUtil.runOnUiThread(
+            object : GuardedRunnable(context) {
+                @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+                override fun runGuarded() {
+                    // If the status bar is translucent hook into the window insets calculations
+                    // and consume all the top insets so no padding will be added under the status bar.
+                    val decorView = activity.window.decorView
+                    if (translucent) {
+                        decorView.setOnApplyWindowInsetsListener { v, insets ->
+                            val defaultInsets = v.onApplyWindowInsets(insets)
+                            defaultInsets.replaceSystemWindowInsets(
+                                defaultInsets.systemWindowInsetLeft,
+                                0,
+                                defaultInsets.systemWindowInsetRight,
+                                defaultInsets.systemWindowInsetBottom
+                            )
+                        }
+                    } else {
+                        decorView.setOnApplyWindowInsetsListener(null)
+                    }
+                    ViewCompat.requestApplyInsets(decorView)
+                }
+            })
     }
-    return null
-  }
 
-  private fun childScreenWithTraitSet(
-    screen: Screen?,
-    trait: WindowTraits
-  ): Screen? {
-    screen?.fragment?.let {
-      for (sc in it.childScreenContainers) {
-        // we check only the top screen for the trait
-        val topScreen = sc.topScreen
-        val child = childScreenWithTraitSet(topScreen, trait)
-        if (child != null) {
-          return child
+    internal fun setHidden(screen: Screen, activity: Activity?) {
+        if (activity == null) {
+            return
         }
-        if (topScreen != null && checkTraitForScreen(topScreen, trait)) {
-          return topScreen
+        val screenForHidden = findScreenForTrait(screen, WindowTraits.HIDDEN)
+        val hidden = screenForHidden?.isStatusBarHidden ?: false
+        UiThreadUtil.runOnUiThread {
+            if (hidden) {
+                activity.window.addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN)
+                activity.window.clearFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN)
+            } else {
+                activity.window.addFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN)
+                activity.window.clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN)
+            }
         }
-      }
     }
-    return null
-  }
 
-  private fun checkTraitForScreen(screen: Screen, trait: WindowTraits): Boolean {
-    return when (trait) {
-      WindowTraits.ORIENTATION -> screen.screenOrientation != null
-      WindowTraits.COLOR -> screen.statusBarColor != null
-      WindowTraits.STYLE -> screen.statusBarStyle != null
-      WindowTraits.TRANSLUCENT -> screen.isStatusBarTranslucent != null
-      WindowTraits.HIDDEN -> screen.isStatusBarHidden != null
-      WindowTraits.ANIMATED -> screen.isStatusBarAnimated != null
+    // Methods concerning navigationBar management were taken from `react-native-navigation`'s repo:
+    // https://github.com/wix/react-native-navigation/blob/9bb70d81700692141a2c505c081c2d86c7f9c66e/lib/android/app/src/main/java/com/reactnativenavigation/utils/SystemUiUtils.kt
+    internal fun setNavigationBarColor(screen: Screen, activity: Activity?) {
+        if (activity == null) {
+            return
+        }
+
+        val window = activity.window
+
+        val screenForNavBarColor = findScreenForTrait(screen, WindowTraits.NAVIGATION_BAR_COLOR)
+        val color = screenForNavBarColor?.navigationBarColor ?: window.navigationBarColor
+
+        WindowInsetsControllerCompat(window, window.decorView).isAppearanceLightNavigationBars =
+            isColorLight(color)
+        window.navigationBarColor = color
     }
-  }
+
+    internal fun setNavigationBarHidden(screen: Screen, activity: Activity?) {
+        if (activity == null) {
+            return
+        }
+
+        val window = activity.window
+
+        val screenForNavBarHidden = findScreenForTrait(screen, WindowTraits.NAVIGATION_BAR_HIDDEN)
+        val hidden = screenForNavBarHidden?.isNavigationBarHidden ?: false
+
+        WindowCompat.setDecorFitsSystemWindows(window, hidden)
+        if (hidden) {
+            WindowInsetsControllerCompat(window, window.decorView).let { controller ->
+                controller.hide(WindowInsetsCompat.Type.navigationBars())
+                controller.systemBarsBehavior =
+                    WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+            }
+        } else {
+            WindowInsetsControllerCompat(
+                window,
+                window.decorView
+            ).show(WindowInsetsCompat.Type.navigationBars())
+        }
+    }
+
+    internal fun trySetWindowTraits(screen: Screen, activity: Activity?, context: ReactContext?) {
+        if (mDidSetOrientation) {
+            setOrientation(screen, activity)
+        }
+        if (mDidSetStatusBarAppearance) {
+            setColor(screen, activity, context)
+            setStyle(screen, activity, context)
+            setTranslucent(screen, activity, context)
+            setHidden(screen, activity)
+        }
+        if (mDidSetNavigationBarAppearance) {
+            setNavigationBarColor(screen, activity)
+            setNavigationBarHidden(screen, activity)
+        }
+    }
+
+    private fun findScreenForTrait(screen: Screen, trait: WindowTraits): Screen? {
+        val childWithTrait = childScreenWithTraitSet(screen, trait)
+        if (childWithTrait != null) {
+            return childWithTrait
+        }
+        return if (checkTraitForScreen(screen, trait)) {
+            screen
+        } else {
+            // if there is no child with trait set and this screen has no trait set, we look for a parent
+            // that has the trait set
+            findParentWithTraitSet(screen, trait)
+        }
+    }
+
+    private fun findParentWithTraitSet(screen: Screen, trait: WindowTraits): Screen? {
+        var parent: ViewParent? = screen.container
+        while (parent != null) {
+            if (parent is Screen) {
+                if (checkTraitForScreen(parent, trait)) {
+                    return parent
+                }
+            }
+            parent = parent.parent
+        }
+        return null
+    }
+
+    private fun childScreenWithTraitSet(
+        screen: Screen?,
+        trait: WindowTraits
+    ): Screen? {
+        screen?.fragment?.let {
+            for (sc in it.childScreenContainers) {
+                // we check only the top screen for the trait
+                val topScreen = sc.topScreen
+                val child = childScreenWithTraitSet(topScreen, trait)
+                if (child != null) {
+                    return child
+                }
+                if (topScreen != null && checkTraitForScreen(topScreen, trait)) {
+                    return topScreen
+                }
+            }
+        }
+        return null
+    }
+
+    private fun checkTraitForScreen(screen: Screen, trait: WindowTraits): Boolean {
+        return when (trait) {
+            WindowTraits.ORIENTATION -> screen.screenOrientation != null
+            WindowTraits.COLOR -> screen.statusBarColor != null
+            WindowTraits.STYLE -> screen.statusBarStyle != null
+            WindowTraits.TRANSLUCENT -> screen.isStatusBarTranslucent != null
+            WindowTraits.HIDDEN -> screen.isStatusBarHidden != null
+            WindowTraits.ANIMATED -> screen.isStatusBarAnimated != null
+            WindowTraits.NAVIGATION_BAR_COLOR -> screen.navigationBarColor != null
+            WindowTraits.NAVIGATION_BAR_HIDDEN -> screen.isNavigationBarHidden != null
+        }
+    }
+
+    private fun isColorLight(color: Int): Boolean {
+        val darkness: Double =
+            1 - (0.299 * Color.red(color) + 0.587 * Color.green(color) + 0.114 * Color.blue(color)) / 255
+        return darkness < 0.5
+    }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreensShadowNode.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreensShadowNode.kt
@@ -7,13 +7,13 @@ import com.facebook.react.uimanager.NativeViewHierarchyOptimizer
 import com.facebook.react.uimanager.UIManagerModule
 
 internal class ScreensShadowNode(private var mContext: ReactContext) : LayoutShadowNode() {
-  override fun onBeforeLayout(nativeViewHierarchyOptimizer: NativeViewHierarchyOptimizer) {
-    super.onBeforeLayout(nativeViewHierarchyOptimizer)
-    (mContext.getNativeModule(UIManagerModule::class.java))?.addUIBlock { nativeViewHierarchyManager: NativeViewHierarchyManager ->
-      val view = nativeViewHierarchyManager.resolveView(reactTag)
-      if (view is ScreenContainer<*>) {
-        view.performUpdates()
-      }
+    override fun onBeforeLayout(nativeViewHierarchyOptimizer: NativeViewHierarchyOptimizer) {
+        super.onBeforeLayout(nativeViewHierarchyOptimizer)
+        (mContext.getNativeModule(UIManagerModule::class.java))?.addUIBlock { nativeViewHierarchyManager: NativeViewHierarchyManager ->
+            val view = nativeViewHierarchyManager.resolveView(reactTag)
+            if (view is ScreenContainer<*>) {
+                view.performUpdates()
+            }
+        }
     }
-  }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/SearchBarManager.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/SearchBarManager.kt
@@ -9,82 +9,99 @@ import com.facebook.react.uimanager.annotations.ReactProp
 
 @ReactModule(name = SearchBarManager.REACT_CLASS)
 class SearchBarManager : ViewGroupManager<SearchBarView>() {
-  override fun getName(): String {
-    return REACT_CLASS
-  }
-
-  override fun createViewInstance(context: ThemedReactContext): SearchBarView {
-    return SearchBarView(context)
-  }
-
-  override fun onAfterUpdateTransaction(view: SearchBarView) {
-    super.onAfterUpdateTransaction(view)
-    view.onUpdate()
-  }
-
-  @ReactProp(name = "autoCapitalize")
-  fun setAutoCapitalize(view: SearchBarView, autoCapitalize: String?) {
-    view.autoCapitalize = when (autoCapitalize) {
-      null, "none" -> SearchBarView.SearchBarAutoCapitalize.NONE
-      "words" -> SearchBarView.SearchBarAutoCapitalize.WORDS
-      "sentences" -> SearchBarView.SearchBarAutoCapitalize.SENTENCES
-      "characters" -> SearchBarView.SearchBarAutoCapitalize.CHARACTERS
-      else -> throw JSApplicationIllegalArgumentException(
-        "Forbidden auto capitalize value passed"
-      )
+    override fun getName(): String {
+        return REACT_CLASS
     }
-  }
 
-  @ReactProp(name = "autoFocus")
-  fun setAutoFocus(view: SearchBarView, autoFocus: Boolean?) {
-    view.autoFocus = autoFocus ?: false
-  }
-
-  @ReactProp(name = "barTintColor", customType = "Color")
-  fun setTintColor(view: SearchBarView, color: Int?) {
-    view.tintColor = color
-  }
-
-  @ReactProp(name = "disableBackButtonOverride")
-  fun setDisableBackButtonOverride(view: SearchBarView, disableBackButtonOverride: Boolean?) {
-    view.shouldOverrideBackButton = disableBackButtonOverride != true
-  }
-
-  @ReactProp(name = "inputType")
-  fun setInputType(view: SearchBarView, inputType: String?) {
-    view.inputType = when (inputType) {
-      null, "text" -> SearchBarView.SearchBarInputTypes.TEXT
-      "phone" -> SearchBarView.SearchBarInputTypes.PHONE
-      "number" -> SearchBarView.SearchBarInputTypes.NUMBER
-      "email" -> SearchBarView.SearchBarInputTypes.EMAIL
-      else -> throw JSApplicationIllegalArgumentException(
-        "Forbidden input type value"
-      )
+    override fun createViewInstance(context: ThemedReactContext): SearchBarView {
+        return SearchBarView(context)
     }
-  }
 
-  @ReactProp(name = "placeholder")
-  fun setPlaceholder(view: SearchBarView, placeholder: String?) {
-    view.placeholder = placeholder
-  }
+    override fun onAfterUpdateTransaction(view: SearchBarView) {
+        super.onAfterUpdateTransaction(view)
+        view.onUpdate()
+    }
 
-  @ReactProp(name = "textColor", customType = "Color")
-  fun setTextColor(view: SearchBarView, color: Int?) {
-    view.textColor = color
-  }
+    @ReactProp(name = "autoCapitalize")
+    fun setAutoCapitalize(view: SearchBarView, autoCapitalize: String?) {
+        view.autoCapitalize = when (autoCapitalize) {
+            null, "none" -> SearchBarView.SearchBarAutoCapitalize.NONE
+            "words" -> SearchBarView.SearchBarAutoCapitalize.WORDS
+            "sentences" -> SearchBarView.SearchBarAutoCapitalize.SENTENCES
+            "characters" -> SearchBarView.SearchBarAutoCapitalize.CHARACTERS
+            else -> throw JSApplicationIllegalArgumentException(
+                "Forbidden auto capitalize value passed"
+            )
+        }
+    }
 
-  override fun getExportedCustomDirectEventTypeConstants(): Map<String, Any>? {
-    return MapBuilder.builder<String, Any>()
-      .put("onChangeText", MapBuilder.of("registrationName", "onChangeText"))
-      .put("onSearchButtonPress", MapBuilder.of("registrationName", "onSearchButtonPress"))
-      .put("onFocus", MapBuilder.of("registrationName", "onFocus"))
-      .put("onBlur", MapBuilder.of("registrationName", "onBlur"))
-      .put("onClose", MapBuilder.of("registrationName", "onClose"))
-      .put("onOpen", MapBuilder.of("registrationName", "onOpen"))
-      .build()
-  }
+    @ReactProp(name = "autoFocus")
+    fun setAutoFocus(view: SearchBarView, autoFocus: Boolean?) {
+        view.autoFocus = autoFocus ?: false
+    }
 
-  companion object {
-    const val REACT_CLASS = "RNSSearchBar"
-  }
+    @ReactProp(name = "barTintColor", customType = "Color")
+    fun setTintColor(view: SearchBarView, color: Int?) {
+        view.tintColor = color
+    }
+
+    @ReactProp(name = "disableBackButtonOverride")
+    fun setDisableBackButtonOverride(view: SearchBarView, disableBackButtonOverride: Boolean?) {
+        view.shouldOverrideBackButton = disableBackButtonOverride != true
+    }
+
+    @ReactProp(name = "inputType")
+    fun setInputType(view: SearchBarView, inputType: String?) {
+        view.inputType = when (inputType) {
+            null, "text" -> SearchBarView.SearchBarInputTypes.TEXT
+            "phone" -> SearchBarView.SearchBarInputTypes.PHONE
+            "number" -> SearchBarView.SearchBarInputTypes.NUMBER
+            "email" -> SearchBarView.SearchBarInputTypes.EMAIL
+            else -> throw JSApplicationIllegalArgumentException(
+                "Forbidden input type value"
+            )
+        }
+    }
+
+    @ReactProp(name = "placeholder")
+    fun setPlaceholder(view: SearchBarView, placeholder: String?) {
+        if (placeholder != null) {
+            view.placeholder = placeholder
+        }
+    }
+
+    @ReactProp(name = "textColor", customType = "Color")
+    fun setTextColor(view: SearchBarView, color: Int?) {
+        view.textColor = color
+    }
+
+    @ReactProp(name = "headerIconColor", customType = "Color")
+    fun setHeaderIconColor(view: SearchBarView, color: Int?) {
+        view.headerIconColor = color
+    }
+
+    @ReactProp(name = "hintTextColor", customType = "Color")
+    fun setHintTextColor(view: SearchBarView, color: Int?) {
+        view.hintTextColor = color
+    }
+
+    @ReactProp(name = "shouldShowHintSearchIcon")
+    fun setShouldShowHintSearchIcon(view: SearchBarView, shouldShowHintSearchIcon: Boolean?) {
+        view.shouldShowHintSearchIcon = shouldShowHintSearchIcon ?: true
+    }
+
+    override fun getExportedCustomDirectEventTypeConstants(): Map<String, Any>? {
+        return MapBuilder.builder<String, Any>()
+            .put("onChangeText", MapBuilder.of("registrationName", "onChangeText"))
+            .put("onSearchButtonPress", MapBuilder.of("registrationName", "onSearchButtonPress"))
+            .put("onFocus", MapBuilder.of("registrationName", "onFocus"))
+            .put("onBlur", MapBuilder.of("registrationName", "onBlur"))
+            .put("onClose", MapBuilder.of("registrationName", "onClose"))
+            .put("onOpen", MapBuilder.of("registrationName", "onOpen"))
+            .build()
+    }
+
+    companion object {
+        const val REACT_CLASS = "RNSSearchBar"
+    }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/SearchBarView.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/SearchBarView.kt
@@ -11,140 +11,145 @@ import com.facebook.react.views.view.ReactViewGroup
 
 @SuppressLint("ViewConstructor")
 class SearchBarView(reactContext: ReactContext?) : ReactViewGroup(reactContext) {
-  var inputType: SearchBarInputTypes = SearchBarInputTypes.TEXT
-  var autoCapitalize: SearchBarAutoCapitalize = SearchBarAutoCapitalize.NONE
-  var textColor: Int? = null
-  var tintColor: Int? = null
-  var placeholder: String? = null
-  var shouldOverrideBackButton: Boolean = true
-  var autoFocus: Boolean = false
+    var inputType: SearchBarInputTypes = SearchBarInputTypes.TEXT
+    var autoCapitalize: SearchBarAutoCapitalize = SearchBarAutoCapitalize.NONE
+    var textColor: Int? = null
+    var tintColor: Int? = null
+    var headerIconColor: Int? = null
+    var hintTextColor: Int? = null
+    var placeholder: String = ""
+    var shouldOverrideBackButton: Boolean = true
+    var autoFocus: Boolean = false
+    var shouldShowHintSearchIcon: Boolean = true
 
-  private var mSearchViewFormatter: SearchViewFormatter? = null
+    private var mSearchViewFormatter: SearchViewFormatter? = null
 
-  private var mAreListenersSet: Boolean = false
+    private var mAreListenersSet: Boolean = false
 
-  private val screenStackFragment: ScreenStackFragment?
-    get() {
-      val currentParent = parent
-      if (currentParent is ScreenStackHeaderSubview) {
-        return currentParent.config?.screenFragment
-      }
-      return null
-    }
-
-  fun onUpdate() {
-    setSearchViewProps()
-  }
-
-  private fun setSearchViewProps() {
-    val searchView = screenStackFragment?.searchView
-    if (searchView != null) {
-      if (!mAreListenersSet) {
-        setSearchViewListeners(searchView)
-        mAreListenersSet = true
-      }
-
-      searchView.inputType = inputType.toAndroidInputType(autoCapitalize)
-      searchView.queryHint = placeholder
-      mSearchViewFormatter?.setTextColor(textColor)
-      mSearchViewFormatter?.setTintColor(tintColor)
-      searchView.overrideBackAction = shouldOverrideBackButton
-    }
-  }
-
-  override fun onAttachedToWindow() {
-    super.onAttachedToWindow()
-
-    screenStackFragment?.onSearchViewCreate = { newSearchView ->
-      if (mSearchViewFormatter == null) mSearchViewFormatter =
-        SearchViewFormatter(newSearchView)
-      setSearchViewProps()
-      if (autoFocus) {
-        screenStackFragment?.searchView?.focus()
-      }
-    }
-  }
-
-  private fun setSearchViewListeners(searchView: SearchView) {
-    searchView.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
-      override fun onQueryTextChange(newText: String?): Boolean {
-        handleTextChange(newText)
-        return true
-      }
-
-      override fun onQueryTextSubmit(query: String?): Boolean {
-        handleTextSubmit(query)
-        return true
-      }
-    })
-    searchView.setOnQueryTextFocusChangeListener { _, hasFocus ->
-      handleFocusChange(hasFocus)
-    }
-    searchView.setOnCloseListener {
-      handleClose()
-      false
-    }
-    searchView.setOnSearchClickListener {
-      handleOpen()
-    }
-  }
-
-  private fun handleTextChange(newText: String?) {
-    val event = Arguments.createMap()
-    event.putString("text", newText)
-    sendEvent("onChangeText", event)
-  }
-
-  private fun handleFocusChange(hasFocus: Boolean) {
-    sendEvent(if (hasFocus) "onFocus" else "onBlur", null)
-  }
-
-  private fun handleClose() {
-    sendEvent("onClose", null)
-  }
-
-  private fun handleOpen() {
-    sendEvent("onOpen", null)
-  }
-
-  private fun handleTextSubmit(newText: String?) {
-    val event = Arguments.createMap()
-    event.putString("text", newText)
-    sendEvent("onSearchButtonPress", event)
-  }
-
-  private fun sendEvent(eventName: String, eventContent: WritableMap?) {
-    (context as ReactContext).getJSModule(RCTEventEmitter::class.java)
-      ?.receiveEvent(id, eventName, eventContent)
-  }
-
-  enum class SearchBarAutoCapitalize {
-    NONE, WORDS, SENTENCES, CHARACTERS
-  }
-
-  enum class SearchBarInputTypes {
-    TEXT {
-      override fun toAndroidInputType(capitalize: SearchBarAutoCapitalize) =
-        when (capitalize) {
-          SearchBarAutoCapitalize.NONE -> InputType.TYPE_CLASS_TEXT
-          SearchBarAutoCapitalize.WORDS -> InputType.TYPE_TEXT_FLAG_CAP_WORDS
-          SearchBarAutoCapitalize.SENTENCES -> InputType.TYPE_TEXT_FLAG_CAP_SENTENCES
-          SearchBarAutoCapitalize.CHARACTERS -> InputType.TYPE_TEXT_FLAG_CAP_CHARACTERS
+    private val screenStackFragment: ScreenStackFragment?
+        get() {
+            val currentParent = parent
+            if (currentParent is ScreenStackHeaderSubview) {
+                return currentParent.config?.screenFragment
+            }
+            return null
         }
-    },
-    PHONE {
-      override fun toAndroidInputType(capitalize: SearchBarAutoCapitalize) =
-        InputType.TYPE_CLASS_PHONE
-    },
-    NUMBER {
-      override fun toAndroidInputType(capitalize: SearchBarAutoCapitalize) =
-        InputType.TYPE_CLASS_NUMBER
-    },
-    EMAIL {
-      override fun toAndroidInputType(capitalize: SearchBarAutoCapitalize) =
-        InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS
-    };
 
-    abstract fun toAndroidInputType(capitalize: SearchBarAutoCapitalize): Int
-  }
+    fun onUpdate() {
+        setSearchViewProps()
+    }
+
+    private fun setSearchViewProps() {
+        val searchView = screenStackFragment?.searchView
+        if (searchView != null) {
+            if (!mAreListenersSet) {
+                setSearchViewListeners(searchView)
+                mAreListenersSet = true
+            }
+
+            searchView.inputType = inputType.toAndroidInputType(autoCapitalize)
+            mSearchViewFormatter?.setTextColor(textColor)
+            mSearchViewFormatter?.setTintColor(tintColor)
+            mSearchViewFormatter?.setHeaderIconColor(headerIconColor)
+            mSearchViewFormatter?.setHintTextColor(hintTextColor)
+            mSearchViewFormatter?.setPlaceholder(placeholder, shouldShowHintSearchIcon)
+            searchView.overrideBackAction = shouldOverrideBackButton
+        }
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+
+        screenStackFragment?.onSearchViewCreate = { newSearchView ->
+            if (mSearchViewFormatter == null) mSearchViewFormatter =
+                SearchViewFormatter(newSearchView)
+            setSearchViewProps()
+            if (autoFocus) {
+                screenStackFragment?.searchView?.focus()
+            }
+        }
+    }
+
+    private fun setSearchViewListeners(searchView: SearchView) {
+        searchView.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
+            override fun onQueryTextChange(newText: String?): Boolean {
+                handleTextChange(newText)
+                return true
+            }
+
+            override fun onQueryTextSubmit(query: String?): Boolean {
+                handleTextSubmit(query)
+                return true
+            }
+        })
+        searchView.setOnQueryTextFocusChangeListener { _, hasFocus ->
+            handleFocusChange(hasFocus)
+        }
+        searchView.setOnCloseListener {
+            handleClose()
+            false
+        }
+        searchView.setOnSearchClickListener {
+            handleOpen()
+        }
+    }
+
+    private fun handleTextChange(newText: String?) {
+        val event = Arguments.createMap()
+        event.putString("text", newText)
+        sendEvent("onChangeText", event)
+    }
+
+    private fun handleFocusChange(hasFocus: Boolean) {
+        sendEvent(if (hasFocus) "onFocus" else "onBlur", null)
+    }
+
+    private fun handleClose() {
+        sendEvent("onClose", null)
+    }
+
+    private fun handleOpen() {
+        sendEvent("onOpen", null)
+    }
+
+    private fun handleTextSubmit(newText: String?) {
+        val event = Arguments.createMap()
+        event.putString("text", newText)
+        sendEvent("onSearchButtonPress", event)
+    }
+
+    private fun sendEvent(eventName: String, eventContent: WritableMap?) {
+        (context as ReactContext).getJSModule(RCTEventEmitter::class.java)
+            ?.receiveEvent(id, eventName, eventContent)
+    }
+
+    enum class SearchBarAutoCapitalize {
+        NONE, WORDS, SENTENCES, CHARACTERS
+    }
+
+    enum class SearchBarInputTypes {
+        TEXT {
+            override fun toAndroidInputType(capitalize: SearchBarAutoCapitalize) =
+                when (capitalize) {
+                    SearchBarAutoCapitalize.NONE -> InputType.TYPE_CLASS_TEXT
+                    SearchBarAutoCapitalize.WORDS -> InputType.TYPE_TEXT_FLAG_CAP_WORDS
+                    SearchBarAutoCapitalize.SENTENCES -> InputType.TYPE_TEXT_FLAG_CAP_SENTENCES
+                    SearchBarAutoCapitalize.CHARACTERS -> InputType.TYPE_TEXT_FLAG_CAP_CHARACTERS
+                }
+        },
+        PHONE {
+            override fun toAndroidInputType(capitalize: SearchBarAutoCapitalize) =
+                InputType.TYPE_CLASS_PHONE
+        },
+        NUMBER {
+            override fun toAndroidInputType(capitalize: SearchBarAutoCapitalize) =
+                InputType.TYPE_CLASS_NUMBER
+        },
+        EMAIL {
+            override fun toAndroidInputType(capitalize: SearchBarAutoCapitalize) =
+                InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS
+        };
+
+        abstract fun toAndroidInputType(capitalize: SearchBarAutoCapitalize): Int
+    }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/SearchViewFormatter.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/SearchViewFormatter.kt
@@ -3,38 +3,65 @@ package versioned.host.exp.exponent.modules.api.screens
 import android.graphics.drawable.Drawable
 import android.view.View
 import android.widget.EditText
+import android.widget.ImageView
+import androidx.appcompat.R
 import androidx.appcompat.widget.SearchView
 
 class SearchViewFormatter(var searchView: SearchView) {
-  private var mDefaultTextColor: Int? = null
-  private var mDefaultTintBackground: Drawable? = null
+    private var mDefaultTextColor: Int? = null
+    private var mDefaultTintBackground: Drawable? = null
 
-  private val searchEditText
-    get() = searchView.findViewById<View>(androidx.appcompat.R.id.search_src_text) as? EditText
-  private val searchTextPlate
-    get() = searchView.findViewById<View>(androidx.appcompat.R.id.search_plate)
+    private val searchEditText
+        get() = searchView.findViewById<View>(R.id.search_src_text) as? EditText
+    private val searchTextPlate
+        get() = searchView.findViewById<View>(R.id.search_plate)
+    private val searchIcon
+        get() = searchView.findViewById<ImageView>(R.id.search_button)
+    private val searchCloseIcon
+        get() = searchView.findViewById<ImageView>(R.id.search_close_btn)
 
-  fun setTextColor(textColor: Int?) {
-    val currentDefaultTextColor = mDefaultTextColor
-    if (textColor != null) {
-      if (mDefaultTextColor == null) {
-        mDefaultTextColor = searchEditText?.textColors?.defaultColor
-      }
-      searchEditText?.setTextColor(textColor)
-    } else if (currentDefaultTextColor != null) {
-      searchEditText?.setTextColor(currentDefaultTextColor)
+    fun setTextColor(textColor: Int?) {
+        val currentDefaultTextColor = mDefaultTextColor
+        if (textColor != null) {
+            if (mDefaultTextColor == null) {
+                mDefaultTextColor = searchEditText?.textColors?.defaultColor
+            }
+            searchEditText?.setTextColor(textColor)
+        } else if (currentDefaultTextColor != null) {
+            searchEditText?.setTextColor(currentDefaultTextColor)
+        }
     }
-  }
 
-  fun setTintColor(tintColor: Int?) {
-    val currentDefaultTintColor = mDefaultTintBackground
-    if (tintColor != null) {
-      if (mDefaultTintBackground == null) {
-        mDefaultTintBackground = searchTextPlate.background
-      }
-      searchTextPlate.setBackgroundColor(tintColor)
-    } else if (currentDefaultTintColor != null) {
-      searchTextPlate.background = currentDefaultTintColor
+    fun setTintColor(tintColor: Int?) {
+        val currentDefaultTintColor = mDefaultTintBackground
+        if (tintColor != null) {
+            if (mDefaultTintBackground == null) {
+                mDefaultTintBackground = searchTextPlate.background
+            }
+            searchTextPlate.setBackgroundColor(tintColor)
+        } else if (currentDefaultTintColor != null) {
+            searchTextPlate.background = currentDefaultTintColor
+        }
     }
-  }
+
+    fun setHeaderIconColor(headerIconColor: Int?) {
+        headerIconColor?.let {
+            searchIcon.setColorFilter(it)
+            searchCloseIcon.setColorFilter(it)
+        }
+    }
+
+    fun setHintTextColor(hintTextColor: Int?) {
+        hintTextColor?.let {
+            searchEditText?.setHintTextColor(it)
+        }
+    }
+
+    fun setPlaceholder(placeholder: String, shouldShowHintSearchIcon: Boolean) {
+        if (shouldShowHintSearchIcon) {
+            searchView.queryHint = placeholder
+        } else {
+            searchEditText?.hint = placeholder
+        }
+    }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/events/HeaderBackButtonClickedEvent.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/events/HeaderBackButtonClickedEvent.kt
@@ -5,20 +5,20 @@ import com.facebook.react.uimanager.events.Event
 import com.facebook.react.uimanager.events.RCTEventEmitter
 
 class HeaderBackButtonClickedEvent(viewId: Int) : Event<ScreenAppearEvent>(viewId) {
-  override fun getEventName(): String {
-    return EVENT_NAME
-  }
+    override fun getEventName(): String {
+        return EVENT_NAME
+    }
 
-  override fun getCoalescingKey(): Short {
-    // All events for a given view can be coalesced.
-    return 0
-  }
+    override fun getCoalescingKey(): Short {
+        // All events for a given view can be coalesced.
+        return 0
+    }
 
-  override fun dispatch(rctEventEmitter: RCTEventEmitter) {
-    rctEventEmitter.receiveEvent(viewTag, eventName, Arguments.createMap())
-  }
+    override fun dispatch(rctEventEmitter: RCTEventEmitter) {
+        rctEventEmitter.receiveEvent(viewTag, eventName, Arguments.createMap())
+    }
 
-  companion object {
-    const val EVENT_NAME = "topHeaderBackButtonClickedEvent"
-  }
+    companion object {
+        const val EVENT_NAME = "topHeaderBackButtonClickedEvent"
+    }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/events/ScreenAppearEvent.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/events/ScreenAppearEvent.kt
@@ -5,16 +5,16 @@ import com.facebook.react.uimanager.events.Event
 import com.facebook.react.uimanager.events.RCTEventEmitter
 
 class ScreenAppearEvent(viewId: Int) : Event<ScreenAppearEvent>(viewId) {
-  override fun getEventName() = EVENT_NAME
+    override fun getEventName() = EVENT_NAME
 
-  // All events for a given view can be coalesced.
-  override fun getCoalescingKey(): Short = 0
+    // All events for a given view can be coalesced.
+    override fun getCoalescingKey(): Short = 0
 
-  override fun dispatch(rctEventEmitter: RCTEventEmitter) {
-    rctEventEmitter.receiveEvent(viewTag, eventName, Arguments.createMap())
-  }
+    override fun dispatch(rctEventEmitter: RCTEventEmitter) {
+        rctEventEmitter.receiveEvent(viewTag, eventName, Arguments.createMap())
+    }
 
-  companion object {
-    const val EVENT_NAME = "topAppear"
-  }
+    companion object {
+        const val EVENT_NAME = "topAppear"
+    }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/events/ScreenDisappearEvent.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/events/ScreenDisappearEvent.kt
@@ -5,16 +5,16 @@ import com.facebook.react.uimanager.events.Event
 import com.facebook.react.uimanager.events.RCTEventEmitter
 
 class ScreenDisappearEvent(viewId: Int) : Event<ScreenDisappearEvent>(viewId) {
-  override fun getEventName() = EVENT_NAME
+    override fun getEventName() = EVENT_NAME
 
-  // All events for a given view can be coalesced.
-  override fun getCoalescingKey(): Short = 0
+    // All events for a given view can be coalesced.
+    override fun getCoalescingKey(): Short = 0
 
-  override fun dispatch(rctEventEmitter: RCTEventEmitter) {
-    rctEventEmitter.receiveEvent(viewTag, eventName, Arguments.createMap())
-  }
+    override fun dispatch(rctEventEmitter: RCTEventEmitter) {
+        rctEventEmitter.receiveEvent(viewTag, eventName, Arguments.createMap())
+    }
 
-  companion object {
-    const val EVENT_NAME = "topDisappear"
-  }
+    companion object {
+        const val EVENT_NAME = "topDisappear"
+    }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/events/ScreenDismissedEvent.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/events/ScreenDismissedEvent.kt
@@ -5,19 +5,19 @@ import com.facebook.react.uimanager.events.Event
 import com.facebook.react.uimanager.events.RCTEventEmitter
 
 class ScreenDismissedEvent(viewId: Int) : Event<ScreenDismissedEvent>(viewId) {
-  override fun getEventName() = EVENT_NAME
+    override fun getEventName() = EVENT_NAME
 
-  // All events for a given view can be coalesced.
-  override fun getCoalescingKey(): Short = 0
+    // All events for a given view can be coalesced.
+    override fun getCoalescingKey(): Short = 0
 
-  override fun dispatch(rctEventEmitter: RCTEventEmitter) {
-    val args = Arguments.createMap()
-    // on Android we always dismiss one screen at a time
-    args.putInt("dismissCount", 1)
-    rctEventEmitter.receiveEvent(viewTag, eventName, args)
-  }
+    override fun dispatch(rctEventEmitter: RCTEventEmitter) {
+        val args = Arguments.createMap()
+        // on Android we always dismiss one screen at a time
+        args.putInt("dismissCount", 1)
+        rctEventEmitter.receiveEvent(viewTag, eventName, args)
+    }
 
-  companion object {
-    const val EVENT_NAME = "topDismissed"
-  }
+    companion object {
+        const val EVENT_NAME = "topDismissed"
+    }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/events/ScreenTransitionProgressEvent.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/events/ScreenTransitionProgressEvent.kt
@@ -5,29 +5,29 @@ import com.facebook.react.uimanager.events.Event
 import com.facebook.react.uimanager.events.RCTEventEmitter
 
 class ScreenTransitionProgressEvent(
-  viewId: Int,
-  private val mProgress: Float,
-  private val mClosing: Boolean,
-  private val mGoingForward: Boolean,
-  private val mCoalescingKey: Short
+    viewId: Int,
+    private val mProgress: Float,
+    private val mClosing: Boolean,
+    private val mGoingForward: Boolean,
+    private val mCoalescingKey: Short
 ) : Event<ScreenAppearEvent?>(viewId) {
-  override fun getEventName(): String {
-    return EVENT_NAME
-  }
+    override fun getEventName(): String {
+        return EVENT_NAME
+    }
 
-  override fun getCoalescingKey(): Short {
-    return mCoalescingKey
-  }
+    override fun getCoalescingKey(): Short {
+        return mCoalescingKey
+    }
 
-  override fun dispatch(rctEventEmitter: RCTEventEmitter) {
-    val map = Arguments.createMap()
-    map.putDouble("progress", mProgress.toDouble())
-    map.putInt("closing", if (mClosing) 1 else 0)
-    map.putInt("goingForward", if (mGoingForward) 1 else 0)
-    rctEventEmitter.receiveEvent(viewTag, eventName, map)
-  }
+    override fun dispatch(rctEventEmitter: RCTEventEmitter) {
+        val map = Arguments.createMap()
+        map.putDouble("progress", mProgress.toDouble())
+        map.putInt("closing", if (mClosing) 1 else 0)
+        map.putInt("goingForward", if (mGoingForward) 1 else 0)
+        rctEventEmitter.receiveEvent(viewTag, eventName, map)
+    }
 
-  companion object {
-    const val EVENT_NAME = "topTransitionProgress"
-  }
+    companion object {
+        const val EVENT_NAME = "topTransitionProgress"
+    }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/events/ScreenWillAppearEvent.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/events/ScreenWillAppearEvent.kt
@@ -5,16 +5,16 @@ import com.facebook.react.uimanager.events.Event
 import com.facebook.react.uimanager.events.RCTEventEmitter
 
 class ScreenWillAppearEvent(viewId: Int) : Event<ScreenWillAppearEvent>(viewId) {
-  override fun getEventName() = EVENT_NAME
+    override fun getEventName() = EVENT_NAME
 
-  // All events for a given view can be coalesced.
-  override fun getCoalescingKey(): Short = 0
+    // All events for a given view can be coalesced.
+    override fun getCoalescingKey(): Short = 0
 
-  override fun dispatch(rctEventEmitter: RCTEventEmitter) {
-    rctEventEmitter.receiveEvent(viewTag, eventName, Arguments.createMap())
-  }
+    override fun dispatch(rctEventEmitter: RCTEventEmitter) {
+        rctEventEmitter.receiveEvent(viewTag, eventName, Arguments.createMap())
+    }
 
-  companion object {
-    const val EVENT_NAME = "topWillAppear"
-  }
+    companion object {
+        const val EVENT_NAME = "topWillAppear"
+    }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/events/ScreenWillDisappearEvent.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/events/ScreenWillDisappearEvent.kt
@@ -5,16 +5,16 @@ import com.facebook.react.uimanager.events.Event
 import com.facebook.react.uimanager.events.RCTEventEmitter
 
 class ScreenWillDisappearEvent(viewId: Int) : Event<ScreenWillDisappearEvent>(viewId) {
-  override fun getEventName() = EVENT_NAME
+    override fun getEventName() = EVENT_NAME
 
-  // All events for a given view can be coalesced.
-  override fun getCoalescingKey(): Short = 0
+    // All events for a given view can be coalesced.
+    override fun getCoalescingKey(): Short = 0
 
-  override fun dispatch(rctEventEmitter: RCTEventEmitter) {
-    rctEventEmitter.receiveEvent(viewTag, eventName, Arguments.createMap())
-  }
+    override fun dispatch(rctEventEmitter: RCTEventEmitter) {
+        rctEventEmitter.receiveEvent(viewTag, eventName, Arguments.createMap())
+    }
 
-  companion object {
-    const val EVENT_NAME = "topWillDisappear"
-  }
+    companion object {
+        const val EVENT_NAME = "topWillDisappear"
+    }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/events/StackFinishTransitioningEvent.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/events/StackFinishTransitioningEvent.kt
@@ -5,16 +5,16 @@ import com.facebook.react.uimanager.events.Event
 import com.facebook.react.uimanager.events.RCTEventEmitter
 
 class StackFinishTransitioningEvent(viewId: Int) : Event<StackFinishTransitioningEvent>(viewId) {
-  override fun getEventName() = EVENT_NAME
+    override fun getEventName() = EVENT_NAME
 
-  // All events for a given view can be coalesced.
-  override fun getCoalescingKey(): Short = 0
+    // All events for a given view can be coalesced.
+    override fun getCoalescingKey(): Short = 0
 
-  override fun dispatch(rctEventEmitter: RCTEventEmitter) {
-    rctEventEmitter.receiveEvent(viewTag, eventName, Arguments.createMap())
-  }
+    override fun dispatch(rctEventEmitter: RCTEventEmitter) {
+        rctEventEmitter.receiveEvent(viewTag, eventName, Arguments.createMap())
+    }
 
-  companion object {
-    const val EVENT_NAME = "topFinishTransitioning"
-  }
+    companion object {
+        const val EVENT_NAME = "topFinishTransitioning"
+    }
 }

--- a/android/expoview/src/main/res/anim/rns_default_enter_in.xml
+++ b/android/expoview/src/main/res/anim/rns_default_enter_in.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <alpha
+        android:interpolator="@android:interpolator/accelerate_decelerate"
+        android:fromAlpha="0"
+        android:toAlpha="1.0"
+        android:startOffset="100"
+        android:duration="100"/>
+    <scale
+        android:interpolator="@android:interpolator/accelerate_decelerate"
+        android:fromXScale="0.85"
+        android:toXScale="1"
+        android:fromYScale="0.85"
+        android:toYScale="1"
+        android:pivotX="50%"
+        android:pivotY="50%"
+        android:duration="200"/>
+</set>

--- a/android/expoview/src/main/res/anim/rns_default_enter_out.xml
+++ b/android/expoview/src/main/res/anim/rns_default_enter_out.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <alpha
+        android:fromAlpha="1"
+        android:toAlpha="0.4"
+        android:startOffset="100"
+        android:duration="100"
+        android:interpolator="@android:interpolator/accelerate_decelerate" />
+
+    <scale
+        android:interpolator="@android:interpolator/accelerate_decelerate"
+        android:fromXScale="1"
+        android:toXScale="1.15"
+        android:fromYScale="1"
+        android:toYScale="1.15"
+        android:pivotX="50%"
+        android:pivotY="50%"
+        android:duration="200"/>
+</set>

--- a/android/expoview/src/main/res/anim/rns_default_exit_in.xml
+++ b/android/expoview/src/main/res/anim/rns_default_exit_in.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shareInterpolator="false">
+    <alpha
+        android:fromAlpha="0.0"
+        android:toAlpha="1"
+        android:startOffset="50"
+        android:duration="100"/>
+    <scale
+        android:fromXScale="1.15"
+        android:toXScale="1"
+        android:fromYScale="1.15"
+        android:toYScale="1"
+        android:pivotX="50%"
+        android:pivotY="50%"
+        android:duration="200"/>
+</set>

--- a/android/expoview/src/main/res/anim/rns_default_exit_out.xml
+++ b/android/expoview/src/main/res/anim/rns_default_exit_out.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shareInterpolator="false"
+    android:zAdjustment="top">
+    <alpha
+        android:fromAlpha="1"
+        android:toAlpha="0.0"
+        android:startOffset="50"
+        android:duration="100"/>
+    <scale
+        android:fromXScale="1"
+        android:toXScale="0.85"
+        android:fromYScale="1"
+        android:toYScale="0.85"
+        android:pivotX="50%"
+        android:pivotY="50%"
+        android:duration="200"/>
+</set>

--- a/android/expoview/src/main/res/anim/rns_fade_in.xml
+++ b/android/expoview/src/main/res/anim/rns_fade_in.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--Duration taken from debugging source code-->
+<alpha xmlns:android="http://schemas.android.com/apk/res/android"
+    android:fromAlpha="0.0"
+    android:toAlpha="1.0"
+    android:duration="150"
+    />  <!--Remember to change duration in the corresponding xml when modifying it-->

--- a/android/expoview/src/main/res/anim/rns_fade_out.xml
+++ b/android/expoview/src/main/res/anim/rns_fade_out.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--Duration taken from debugging source code-->
+<alpha xmlns:android="http://schemas.android.com/apk/res/android"
+    android:fromAlpha="1.0"
+    android:toAlpha="0.0"
+    android:duration="150"
+    />  <!--Remember to change duration in the corresponding xml when modifying it-->

--- a/android/expoview/src/main/res/anim/rns_no_animation_20.xml
+++ b/android/expoview/src/main/res/anim/rns_no_animation_20.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<alpha xmlns:android="http://schemas.android.com/apk/res/android"
+    android:fromAlpha="1.0"
+    android:toAlpha="1.0"
+    android:duration="20"
+    />  <!-- non-zero duration ensures transition events are triggered correctly -->

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -797,7 +797,7 @@ PODS:
     - React-RCTText
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNScreens (3.10.2):
+  - RNScreens (3.11.1):
     - React-Core
     - React-RCTImage
   - RNSharedElement (0.8.4):
@@ -1464,7 +1464,7 @@ SPEC CHECKSUMS:
   RNDateTimePicker: 2224ee77a86b7123377597a015502435e2e49957
   RNGestureHandler: e1099204721a17a89c81fcd1cc2e92143dc040fb
   RNReanimated: 3d1432ce7b6b7fc31f375dcabe5b4585e0634a43
-  RNScreens: d6da2b9e29cf523832c2542f47bf1287318b1868
+  RNScreens: 4d83613b50b74ed277026375dc0810893b0c347f
   RNSharedElement: eb7d506733952d58634f34c82ec17e82f557e377
   RNSVG: 302bfc9905bd8122f08966dc2ce2d07b7b52b9f8
   SDWebImage: 240e5c12b592fb1268c1d03b8c90d90e8c2ffe82

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -115,7 +115,7 @@
     "react-native-gesture-handler": "~2.1.0",
     "react-native-reanimated": "~2.4.1",
     "react-native-safe-area-context": "3.3.2",
-    "react-native-screens": "~3.10.1",
+    "react-native-screens": "~3.11.1",
     "react-native-shared-element": "0.8.4",
     "react-native-svg": "12.3.0",
     "react-native-view-shot": "3.1.2",

--- a/apps/bare-sandbox/package.json
+++ b/apps/bare-sandbox/package.json
@@ -20,7 +20,7 @@
     "react-native": "0.68.0",
     "react-native-gesture-handler": "~2.1.0",
     "react-native-reanimated": "~2.4.1",
-    "react-native-screens": "~3.10.1",
+    "react-native-screens": "~3.11.1",
     "react-native-web": "~0.17.1"
   },
   "devDependencies": {

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -156,7 +156,7 @@
     "react-native-redash": "^14.1.1",
     "react-native-safe-area-context": "3.3.2",
     "react-native-safe-area-view": "^0.14.8",
-    "react-native-screens": "~3.10.1",
+    "react-native-screens": "~3.11.1",
     "react-native-shared-element": "0.8.4",
     "react-native-svg": "12.3.0",
     "react-native-view-shot": "3.1.2",

--- a/home/package.json
+++ b/home/package.json
@@ -62,7 +62,7 @@
     "react-native-paper": "^4.0.1",
     "react-native-reanimated": "~2.4.1",
     "react-native-safe-area-context": "3.3.2",
-    "react-native-screens": "~3.10.1",
+    "react-native-screens": "~3.11.1",
     "react-redux": "^7.2.0",
     "react-string-replace": "^0.4.4",
     "reanimated-bottom-sheet": "^1.0.0-alpha.18",

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1902,7 +1902,7 @@ PODS:
     - React-RCTText
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNScreens (3.10.1):
+  - RNScreens (3.11.1):
     - React-Core
     - React-RCTImage
   - Stripe (21.9.1):
@@ -3341,7 +3341,7 @@ SPEC CHECKSUMS:
   ReactCommon: d98c6c96b567f9b3a15f9fd4cc302c1eda8e3cf2
   RNGestureHandler: e5c7cab5f214503dcefd6b2b0cefb050e1f51c4a
   RNReanimated: 1326679461fa5d2399d54c18ca1432ba3e816b9e
-  RNScreens: 522705f2e5c9d27efb17f24aceb2bf8335bc7b8e
+  RNScreens: 4d83613b50b74ed277026375dc0810893b0c347f
   Stripe: 22c1b8da5ee20a1aaf40fd198160efa72e71644a
   stripe-react-native: a5fcf07b49f1208bdc939e31a07320b35a88209f
   StripeCore: 91ea038ac0abbb72f11014044dfd1e5d39089714

--- a/ios/vendored/unversioned/react-native-screens/RNScreens.podspec.json
+++ b/ios/vendored/unversioned/react-native-screens/RNScreens.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "RNScreens",
-  "version": "3.10.1",
+  "version": "3.11.1",
   "summary": "Native navigation primitives for your React Native app.",
   "description": "RNScreens - first incomplete navigation solution for your React Native app",
   "homepage": "https://github.com/software-mansion/react-native-screens",
@@ -14,7 +14,7 @@
   },
   "source": {
     "git": "https://github.com/software-mansion/react-native-screens.git",
-    "tag": "3.10.1"
+    "tag": "3.11.1"
   },
   "source_files": "ios/**/*.{h,m}",
   "requires_arc": true,

--- a/ios/vendored/unversioned/react-native-screens/ios/RNSScreen.h
+++ b/ios/vendored/unversioned/react-native-screens/ios/RNSScreen.h
@@ -29,6 +29,11 @@ typedef NS_ENUM(NSInteger, RNSScreenReplaceAnimation) {
   RNSScreenReplaceAnimationPush,
 };
 
+typedef NS_ENUM(NSInteger, RNSScreenSwipeDirection) {
+  RNSScreenSwipeDirectionHorizontal,
+  RNSScreenSwipeDirectionVertical,
+};
+
 typedef NS_ENUM(NSInteger, RNSActivityState) {
   RNSActivityStateInactive = 0,
   RNSActivityStateTransitioningOrBelowTop = 1,
@@ -47,6 +52,7 @@ typedef NS_ENUM(NSInteger, RNSWindowTrait) {
   RNSWindowTraitAnimation,
   RNSWindowTraitHidden,
   RNSWindowTraitOrientation,
+  RNSWindowTraitHomeIndicatorHidden,
 };
 
 @interface RCTConvert (RNSScreen)
@@ -91,19 +97,23 @@ typedef NS_ENUM(NSInteger, RNSWindowTrait) {
 @property (nonatomic) RNSScreenStackAnimation stackAnimation;
 @property (nonatomic) RNSScreenStackPresentation stackPresentation;
 @property (nonatomic) RNSScreenReplaceAnimation replaceAnimation;
+@property (nonatomic) RNSScreenSwipeDirection swipeDirection;
 @property (nonatomic) BOOL preventNativeDismiss;
 @property (nonatomic) BOOL hasOrientationSet;
 @property (nonatomic) BOOL hasStatusBarStyleSet;
 @property (nonatomic) BOOL hasStatusBarAnimationSet;
 @property (nonatomic) BOOL hasStatusBarHiddenSet;
+@property (nonatomic) BOOL hasHomeIndicatorHiddenSet;
 @property (nonatomic) BOOL customAnimationOnSwipe;
 @property (nonatomic) BOOL fullScreenSwipeEnabled;
+@property (nonatomic, retain) NSNumber *transitionDuration;
 
 #if !TARGET_OS_TV
 @property (nonatomic) RNSStatusBarStyle statusBarStyle;
 @property (nonatomic) UIStatusBarAnimation statusBarAnimation;
 @property (nonatomic) BOOL statusBarHidden;
 @property (nonatomic) UIInterfaceOrientationMask screenOrientation;
+@property (nonatomic) BOOL homeIndicatorHidden;
 #endif
 
 - (void)notifyFinishTransitioning;

--- a/ios/vendored/unversioned/react-native-screens/ios/RNSScreen.m
+++ b/ios/vendored/unversioned/react-native-screens/ios/RNSScreen.m
@@ -34,6 +34,7 @@
     _hasStatusBarAnimationSet = NO;
     _hasStatusBarHiddenSet = NO;
     _hasOrientationSet = NO;
+    _hasHomeIndicatorHiddenSet = NO;
   }
 
   return self;
@@ -205,6 +206,13 @@
   _hasOrientationSet = YES;
   _screenOrientation = screenOrientation;
   [RNSScreenWindowTraits enforceDesiredDeviceOrientation];
+}
+
+- (void)setHomeIndicatorHidden:(BOOL)homeIndicatorHidden
+{
+  _hasHomeIndicatorHiddenSet = YES;
+  _homeIndicatorHidden = homeIndicatorHidden;
+  [RNSScreenWindowTraits updateHomeIndicatorAutoHidden];
 }
 #endif
 
@@ -436,6 +444,17 @@
   return UIInterfaceOrientationMaskAllButUpsideDown;
 }
 
+- (UIViewController *)childViewControllerForHomeIndicatorAutoHidden
+{
+  UIViewController *vc = [self findChildVCForConfigAndTrait:RNSWindowTraitHomeIndicatorHidden includingModals:YES];
+  return vc == self ? nil : vc;
+}
+
+- (BOOL)prefersHomeIndicatorAutoHidden
+{
+  return ((RNSScreenView *)self.view).homeIndicatorHidden;
+}
+
 // if the returned vc is a child, it means that it can provide config;
 // if the returned vc is self, it means that there is no child for config and self has config to provide,
 // so we return self which results in asking self for preferredStatusBarStyle/Animation etc.;
@@ -494,6 +513,9 @@
     }
     case RNSWindowTraitOrientation: {
       return ((RNSScreenView *)self.view).hasOrientationSet;
+    }
+    case RNSWindowTraitHomeIndicatorHidden: {
+      return ((RNSScreenView *)self.view).hasHomeIndicatorHiddenSet;
     }
     default: {
       RCTLogError(@"Unknown trait passed: %d", (int)trait);
@@ -771,6 +793,8 @@ RCT_EXPORT_VIEW_PROPERTY(preventNativeDismiss, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(replaceAnimation, RNSScreenReplaceAnimation)
 RCT_EXPORT_VIEW_PROPERTY(stackPresentation, RNSScreenStackPresentation)
 RCT_EXPORT_VIEW_PROPERTY(stackAnimation, RNSScreenStackAnimation)
+RCT_EXPORT_VIEW_PROPERTY(swipeDirection, RNSScreenSwipeDirection)
+RCT_EXPORT_VIEW_PROPERTY(transitionDuration, NSNumber)
 
 RCT_EXPORT_VIEW_PROPERTY(onAppear, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onDisappear, RCTDirectEventBlock);
@@ -785,6 +809,7 @@ RCT_EXPORT_VIEW_PROPERTY(screenOrientation, UIInterfaceOrientationMask)
 RCT_EXPORT_VIEW_PROPERTY(statusBarAnimation, UIStatusBarAnimation)
 RCT_EXPORT_VIEW_PROPERTY(statusBarHidden, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(statusBarStyle, RNSStatusBarStyle)
+RCT_EXPORT_VIEW_PROPERTY(homeIndicatorHidden, BOOL)
 #endif
 
 - (UIView *)view
@@ -833,6 +858,15 @@ RCT_ENUM_CONVERTER(
       @"pop" : @(RNSScreenReplaceAnimationPop),
     }),
     RNSScreenReplaceAnimationPop,
+    integerValue)
+
+RCT_ENUM_CONVERTER(
+    RNSScreenSwipeDirection,
+    (@{
+      @"vertical" : @(RNSScreenSwipeDirectionVertical),
+      @"horizontal" : @(RNSScreenSwipeDirectionHorizontal),
+    }),
+    RNSScreenSwipeDirectionHorizontal,
     integerValue)
 
 #if !TARGET_OS_TV

--- a/ios/vendored/unversioned/react-native-screens/ios/RNSScreenContainer.m
+++ b/ios/vendored/unversioned/react-native-screens/ios/RNSScreenContainer.m
@@ -23,6 +23,11 @@
 {
   return [self findActiveChildVC].supportedInterfaceOrientations;
 }
+
+- (UIViewController *)childViewControllerForHomeIndicatorAutoHidden
+{
+  return [self findActiveChildVC];
+}
 #endif
 
 - (UIViewController *)findActiveChildVC

--- a/ios/vendored/unversioned/react-native-screens/ios/RNSScreenStack.m
+++ b/ios/vendored/unversioned/react-native-screens/ios/RNSScreenStack.m
@@ -45,6 +45,11 @@
 {
   return [self topViewController].supportedInterfaceOrientations;
 }
+
+- (UIViewController *)childViewControllerForHomeIndicatorAutoHidden
+{
+  return [self topViewController];
+}
 #endif
 
 @end
@@ -645,13 +650,23 @@
 
 - (void)handleSwipe:(UIPanGestureRecognizer *)gestureRecognizer
 {
-  float translation = [gestureRecognizer translationInView:gestureRecognizer.view].x;
-  float velocity = [gestureRecognizer velocityInView:gestureRecognizer.view].x;
-  float distance = gestureRecognizer.view.bounds.size.width;
-  BOOL isRTL = _controller.view.semanticContentAttribute == UISemanticContentAttributeForceRightToLeft;
-  if (isRTL) {
-    translation = -translation;
-    velocity = -velocity;
+  RNSScreenView *topScreen = (RNSScreenView *)_controller.viewControllers.lastObject.view;
+  float translation;
+  float velocity;
+  float distance;
+  if (topScreen.swipeDirection == RNSScreenSwipeDirectionVertical) {
+    translation = [gestureRecognizer translationInView:gestureRecognizer.view].y;
+    velocity = [gestureRecognizer velocityInView:gestureRecognizer.view].y;
+    distance = gestureRecognizer.view.bounds.size.height;
+  } else {
+    translation = [gestureRecognizer translationInView:gestureRecognizer.view].x;
+    velocity = [gestureRecognizer velocityInView:gestureRecognizer.view].x;
+    distance = gestureRecognizer.view.bounds.size.width;
+    BOOL isRTL = _controller.view.semanticContentAttribute == UISemanticContentAttributeForceRightToLeft;
+    if (isRTL) {
+      translation = -translation;
+      velocity = -velocity;
+    }
   }
 
   float transitionProgress = (translation / distance);

--- a/ios/vendored/unversioned/react-native-screens/ios/RNSScreenStackHeaderConfig.m
+++ b/ios/vendored/unversioned/react-native-screens/ios/RNSScreenStackHeaderConfig.m
@@ -152,9 +152,12 @@
     nextVC = nav.topViewController;
   }
 
+  // we want updates sent to the VC below modal too since it is also visible
+  BOOL isPresentingVC = vc.presentedViewController == nextVC;
+
   BOOL isInFullScreenModal = nav == nil && _screenView.stackPresentation == RNSScreenStackPresentationFullScreenModal;
   // if nav is nil, it means we can be in a fullScreen modal, so there is no nextVC, but we still want to update
-  if (vc != nil && (nextVC == vc || isInFullScreenModal)) {
+  if (vc != nil && (nextVC == vc || isInFullScreenModal || isPresentingVC)) {
     [RNSScreenStackHeaderConfig updateViewController:self.screenView.controller withConfig:self animated:YES];
   }
 }

--- a/ios/vendored/unversioned/react-native-screens/ios/RNSScreenWindowTraits.h
+++ b/ios/vendored/unversioned/react-native-screens/ios/RNSScreenWindowTraits.h
@@ -9,6 +9,7 @@
 #endif
 + (void)updateStatusBarAppearance;
 + (void)enforceDesiredDeviceOrientation;
++ (void)updateHomeIndicatorAutoHidden;
 
 #if !TARGET_OS_TV
 + (UIStatusBarStyle)statusBarStyleForRNSStatusBarStyle:(RNSStatusBarStyle)statusBarStyle;

--- a/ios/vendored/unversioned/react-native-screens/ios/RNSScreenWindowTraits.m
+++ b/ios/vendored/unversioned/react-native-screens/ios/RNSScreenWindowTraits.m
@@ -42,6 +42,25 @@
 #endif
 }
 
++ (void)updateHomeIndicatorAutoHidden
+{
+#if !TARGET_OS_TV
+
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
+  if (@available(iOS 13, *)) {
+    UIWindow *firstWindow = [[[UIApplication sharedApplication] windows] firstObject];
+    if (firstWindow != nil) {
+      [[firstWindow rootViewController] setNeedsUpdateOfHomeIndicatorAutoHidden];
+    }
+  } else
+#endif
+  {
+    [UIApplication.sharedApplication.keyWindow.rootViewController setNeedsUpdateOfHomeIndicatorAutoHidden];
+  }
+#endif
+}
+
 #if !TARGET_OS_TV
 + (UIStatusBarStyle)statusBarStyleForRNSStatusBarStyle:(RNSStatusBarStyle)statusBarStyle
 {
@@ -165,6 +184,7 @@
 {
   [RNSScreenWindowTraits updateStatusBarAppearance];
   [RNSScreenWindowTraits enforceDesiredDeviceOrientation];
+  [RNSScreenWindowTraits updateHomeIndicatorAutoHidden];
 }
 
 #if !TARGET_OS_TV

--- a/ios/vendored/unversioned/react-native-screens/ios/UIViewController+RNScreens.m
+++ b/ios/vendored/unversioned/react-native-screens/ios/UIViewController+RNScreens.m
@@ -31,6 +31,12 @@
   return childVC ? childVC.supportedInterfaceOrientations : [self reactNativeScreensSupportedInterfaceOrientations];
 }
 
+- (UIViewController *)reactNativeScreensChildViewControllerForHomeIndicatorAutoHidden
+{
+  UIViewController *childVC = [self findChildRNScreensViewController];
+  return childVC ?: [self reactNativeScreensChildViewControllerForHomeIndicatorAutoHidden];
+}
+
 - (UIViewController *)findChildRNScreensViewController
 {
   UIViewController *lastViewController = [[self childViewControllers] lastObject];
@@ -61,6 +67,10 @@
     method_exchangeImplementations(
         class_getInstanceMethod(uiVCClass, @selector(supportedInterfaceOrientations)),
         class_getInstanceMethod(uiVCClass, @selector(reactNativeScreensSupportedInterfaceOrientations)));
+
+    method_exchangeImplementations(
+        class_getInstanceMethod(uiVCClass, @selector(childViewControllerForHomeIndicatorAutoHidden)),
+        class_getInstanceMethod(uiVCClass, @selector(reactNativeScreensChildViewControllerForHomeIndicatorAutoHidden)));
   });
 }
 #endif

--- a/packages/expo-stories/package.json
+++ b/packages/expo-stories/package.json
@@ -33,7 +33,7 @@
     "fs-extra": "^9.1.0",
     "glob": "^7.1.7",
     "react-native-safe-area-context": "3.3.2",
-    "react-native-screens": "~3.10.1",
+    "react-native-screens": "~3.11.1",
     "react-native-svg": "12.3.0",
     "sane": "^5.0.1"
   }

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -98,7 +98,7 @@
   "react-native-pager-view": "5.4.15",
   "react-native-reanimated": "~2.4.1",
   "react-native-safe-area-context": "3.3.2",
-  "react-native-screens": "~3.10.1",
+  "react-native-screens": "~3.11.1",
   "react-native-shared-element": "0.8.4",
   "react-native-svg": "12.3.0",
   "react-native-unimodules": "~0.15.0",

--- a/tools/src/vendoring/config/expoGoConfig.ts
+++ b/tools/src/vendoring/config/expoGoConfig.ts
@@ -96,6 +96,23 @@ const config: VendoringTargetConfig = {
       source: 'https://github.com/software-mansion/react-native-screens.git',
       semverPrefix: '~',
       ios: {},
+      // TODO: Uncomment once the new vendoring scripts supports Android
+      // android: {
+      //   transforms: {
+      //     content: [
+      //       {
+      //         paths: 'ScreenStack.kt',
+      //         find: /(?=^class ScreenStack\()/m,
+      //         replaceWith: `import host.exp.expoview.R\n\n`,
+      //       },
+      //       {
+      //         paths: 'ScreenStackHeaderConfig.kt',
+      //         find: /(?=^class ScreenStackHeaderConfig\()/m,
+      //         replaceWith: `import host.exp.expoview.BuildConfig\nimport host.exp.expoview.R\n\n`,
+      //       },
+      //     ],
+      //   },
+      // },
     },
     'amazon-cognito-identity-js': {
       source: 'https://github.com/aws-amplify/amplify-js.git',

--- a/tools/src/vendoring/legacy.ts
+++ b/tools/src/vendoring/legacy.ts
@@ -320,7 +320,7 @@ const vendoredModulesConfig: { [key: string]: VendoredModuleConfig } = {
       `NOTE: Any files in ${chalk.magenta(
         'com.facebook.react'
       )} will not be updated -- you'll need to add these to expoview manually!`,
-      `NOTE: Some imports have to be changed from ${chalk.magenta('<>')} form to 
+      `NOTE: Some imports have to be changed from ${chalk.magenta('<>')} form to
       ${chalk.magenta('""')}`,
     ],
   },
@@ -336,6 +336,31 @@ const vendoredModulesConfig: { [key: string]: VendoredModuleConfig } = {
         targetAndroidPath: 'modules/api/screens',
         sourceAndroidPackage: 'com.swmansion.rnscreens',
         targetAndroidPackage: 'versioned.host.exp.exponent.modules.api.screens',
+        onDidVendorAndroidFile: async (file: string) => {
+          const filename = path.basename(file);
+          const CHANGES = {
+            'ScreenStack.kt': {
+              find: /(?=^class ScreenStack\()/m,
+              replaceWith: `import host.exp.expoview.R\n\n`,
+            },
+            'ScreenStackHeaderConfig.kt': {
+              find: /(?=^class ScreenStackHeaderConfig\()/m,
+              replaceWith: `import host.exp.expoview.BuildConfig\nimport host.exp.expoview.R\n\n`,
+            },
+          };
+
+          const fileConfig = CHANGES[filename];
+          if (!fileConfig) {
+            return;
+          }
+
+          const originalFileContent = await fs.readFile(file, 'utf8');
+          const newFileContent = originalFileContent.replace(
+            fileConfig.find,
+            fileConfig.replaceWith
+          );
+          await fs.writeFile(file, newFileContent, 'utf8');
+        },
       },
     ],
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -16955,10 +16955,10 @@ react-native-screens@^3.4.0:
     react-freeze "^1.0.0"
     warn-once "^0.1.0"
 
-react-native-screens@~3.10.1:
-  version "3.10.2"
-  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-3.10.2.tgz#cbf505d61c09e29ad5b335309951a3bd81f0df19"
-  integrity sha512-bMKSpwMeqAoXBqTJiDEG1ogM1cMk66sEmpp/4dGqdX59v+OwMqPeTuBk37qaSuS7gPOFFKsNW2X3ymGvBT4iEw==
+react-native-screens@~3.11.1:
+  version "3.11.1"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-3.11.1.tgz#9bca9968986ca9195cb1e7e6fca37543bde64ecb"
+  integrity sha512-ziQqVm97tNtovacyHwNmDwJPb8n9CqwsfttXx2p5Hk7wUWemDcPAX0ZJ/nNnGMSq2p2QPhPjjUpr3qKXuES0sQ==
   dependencies:
     react-freeze "^1.0.0"
     warn-once "^0.1.0"


### PR DESCRIPTION
# Why

Resolves [ENG-4501](https://linear.app/expo/issue/ENG-4501/react-native-screens-3101-3131)

[Full changelog `3.10.1...3.11.1`](https://github.com/software-mansion/react-native-screens/compare/3.10.1...3.11.1)

We're upgrading to the version `3.11.1`, because that's the most up-to-date version without `Fabric` included (the most up-to-date version with Fabric is `3.13.1`)

# How

1. `et uvm --module "react-native-screens" --commit "3.11.1" --target "expo-go"`
2. `yarn`
3. Copied missing native animations resources.


# Test Plan

Tested `screens` screen:

- [x] on Android and iOS using `bare-expo`
- [x] on Android and iOS using `UNVERSIONED` `ncl` in `Expo Go`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
