### PR TITLE
[dev-launcher] add kitchen sink screen for debugging / component deve…

### DIFF
--- a/packages/expo-dev-launcher/bundle/App.tsx
+++ b/packages/expo-dev-launcher/bundle/App.tsx
@@ -3,6 +3,7 @@ import { createStackNavigator } from '@react-navigation/stack';
 import {
   ExtensionsFilledIcon,
   HomeFilledIcon,
+  InfoIcon,
   SettingsFilledIcon,
   View,
 } from 'expo-dev-client-components';
@@ -14,6 +15,7 @@ import { AppProviders } from './providers/AppProviders';
 import { CrashReportScreen } from './screens/CrashReportScreen';
 import { ExtensionsStack } from './screens/ExtensionsStack';
 import { HomeScreen } from './screens/HomeScreen';
+import { KitchenSinkScreen } from './screens/KitchenSinkScreen';
 import { SettingsScreen } from './screens/SettingsScreen';
 import { UserProfileScreen } from './screens/UserProfileScreen';
 
@@ -81,6 +83,16 @@ const Main = () => {
           tabBarIcon: ({ focused }) => <SettingsFilledIcon focused={focused} />,
         }}
       />
+      {__DEV__ && (
+        <Tab.Screen
+          name="Kitchen Sink"
+          component={KitchenSinkScreen}
+          options={{
+            header: () => null,
+            tabBarIcon: () => <InfoIcon />,
+          }}
+        />
+      )}
     </Tab.Navigator>
   );
 };

--- a/packages/expo-dev-launcher/bundle/components/ActivityIndicator.tsx
+++ b/packages/expo-dev-launcher/bundle/components/ActivityIndicator.tsx
@@ -2,7 +2,9 @@ import { LoadingIndicatorIcon } from 'expo-dev-client-components';
 import * as React from 'react';
 import { Animated, Easing } from 'react-native';
 
-export function ActivityIndicator() {
+type ActivityIndicatorProps = Partial<React.ComponentProps<typeof LoadingIndicatorIcon>>;
+
+export function ActivityIndicator(props: ActivityIndicatorProps) {
   const animatedValue = React.useRef(new Animated.Value(0));
 
   React.useEffect(() => {
@@ -25,7 +27,7 @@ export function ActivityIndicator() {
 
   return (
     <Animated.View style={{ position: 'absolute', transform: [{ rotateZ: rotate }] }}>
-      <LoadingIndicatorIcon />
+      <LoadingIndicatorIcon {...props} />
     </Animated.View>
   );
 }

--- a/packages/expo-dev-launcher/bundle/components/BasicButton.tsx
+++ b/packages/expo-dev-launcher/bundle/components/BasicButton.tsx
@@ -1,0 +1,34 @@
+import { View, Button, Row, scale } from 'expo-dev-client-components';
+import * as React from 'react';
+
+type ButtonProps = React.ComponentProps<typeof Button.ScaleOnPressContainer>;
+
+type BasicButtonProps = ButtonProps & {
+  label: string;
+  type?: ButtonProps['bg'];
+};
+
+export function BasicButton({
+  label,
+  type = 'tertiary',
+  py = '2',
+  px = '3',
+  children,
+  ...props
+}: BasicButtonProps) {
+  return (
+    <View align="start">
+      <Button.ScaleOnPressContainer bg={type} {...props}>
+        <View py={py} px={px}>
+          <Row align="center" style={{ minHeight: scale.large }}>
+            <Button.Text weight="medium" color={type as any}>
+              {label}
+            </Button.Text>
+
+            {children}
+          </Row>
+        </View>
+      </Button.ScaleOnPressContainer>
+    </View>
+  );
+}

--- a/packages/expo-dev-launcher/bundle/components/FlatList.tsx
+++ b/packages/expo-dev-launcher/bundle/components/FlatList.tsx
@@ -1,6 +1,10 @@
 import { scale, View } from 'expo-dev-client-components';
 import * as React from 'react';
-import { RefreshControl, FlatListProps as RNFlatListProps, FlatList as RNFlatList } from 'react-native';
+import {
+  RefreshControl,
+  FlatListProps as RNFlatListProps,
+  FlatList as RNFlatList,
+} from 'react-native';
 
 import { useThrottle } from '../hooks/useDebounce';
 import { ActivityIndicator } from './ActivityIndicator';
@@ -11,6 +15,14 @@ type FlatListProps<T> = RNFlatListProps<T> & {
   onRefresh: () => void;
 };
 
+export function FlatListLoader() {
+  return (
+    <View margin="medium" height="44" align="centered" bg="default" rounded="large">
+      <ActivityIndicator />
+    </View>
+  );
+}
+
 export function FlatList<T>({
   isLoading,
   isRefreshing,
@@ -20,17 +32,13 @@ export function FlatList<T>({
   const throttledRefresh = useThrottle(isRefreshing, 800);
 
   if (isLoading) {
-    return (
-      <View margin="medium" height="44" align="centered" bg="default" rounded="large">
-        <ActivityIndicator />
-      </View>
-    );
+    return <FlatListLoader />;
   }
 
   return (
     <View flex="1">
       <RNFlatList
-        style={{ flex: 1  }}
+        style={{ flex: 1 }}
         refreshing={throttledRefresh}
         showsVerticalScrollIndicator={false}
         contentContainerStyle={{ paddingBottom: scale[24] }}

--- a/packages/expo-dev-launcher/bundle/components/LoadMoreButton.tsx
+++ b/packages/expo-dev-launcher/bundle/components/LoadMoreButton.tsx
@@ -1,8 +1,9 @@
-import { View, Button } from 'expo-dev-client-components';
+import { View, scale } from 'expo-dev-client-components';
 import * as React from 'react';
-import { StyleSheet } from 'react-native';
+import { Animated } from 'react-native';
 
 import { ActivityIndicator } from './ActivityIndicator';
+import { BasicButton } from './BasicButton';
 
 type LoadMoreButtonProps = {
   isLoading: boolean;
@@ -10,20 +11,36 @@ type LoadMoreButtonProps = {
 };
 
 export function LoadMoreButton({ isLoading, onPress }: LoadMoreButtonProps) {
+  const animatedValue = React.useRef(new Animated.Value(0)).current;
+
+  React.useEffect(() => {
+    Animated.spring(animatedValue, {
+      toValue: isLoading ? 1 : 0,
+      useNativeDriver: false,
+    }).start();
+  }, [isLoading]);
+
+  const extraWidth = animatedValue.interpolate({
+    inputRange: [0, 1],
+    outputRange: [0, scale.xl],
+  });
+
+  const right = animatedValue.interpolate({
+    inputRange: [0, 1],
+    outputRange: [-scale.xl * 1.5, -scale.tiny],
+  });
+
   return (
     <View py="medium" align="centered">
-      <Button.ScaleOnPressContainer bg="primary" onPress={onPress}>
-        <View px="2.5" py="2">
-          <Button.Text weight="medium" color="primary">
-            Load More
-          </Button.Text>
-          {isLoading && (
-            <View style={StyleSheet.absoluteFill} align="centered">
-              <ActivityIndicator />
-            </View>
-          )}
-        </View>
-      </Button.ScaleOnPressContainer>
+      <BasicButton label="Load More" onPress={onPress}>
+        <Animated.View style={{ width: extraWidth }} />
+
+        <Animated.View style={{ position: 'absolute', right }}>
+          <View width="large" height="large">
+            <ActivityIndicator size="large" />
+          </View>
+        </Animated.View>
+      </BasicButton>
     </View>
   );
 }

--- a/packages/expo-dev-launcher/bundle/screens/KitchenSinkScreen.tsx
+++ b/packages/expo-dev-launcher/bundle/screens/KitchenSinkScreen.tsx
@@ -1,0 +1,85 @@
+import { Heading, Row, Spacer, View } from 'expo-dev-client-components';
+import * as React from 'react';
+import { ScrollView } from 'react-native';
+
+import { BasicButton } from '../components/BasicButton';
+import { FlatListLoader } from '../components/FlatList';
+import { LoadMoreButton } from '../components/LoadMoreButton';
+import { Toasts } from '../components/Toasts';
+import { useToastStack } from '../providers/ToastStackProvider';
+
+export function KitchenSinkScreen() {
+  const toastStack = useToastStack();
+
+  const [isLoading, setIsLoading] = React.useState(false);
+
+  function onLoadMorePress() {
+    setIsLoading(true);
+
+    setTimeout(() => {
+      setIsLoading(false);
+    }, 1500);
+  }
+
+  function onWarningToastPress() {
+    toastStack.push(() => <Toasts.Warning>Hey there!</Toasts.Warning>, { durationMs: 5000 });
+  }
+
+  function onErrorToastPress() {
+    toastStack.push(() => <Toasts.Error>Hey there!</Toasts.Error>, { durationMs: 5000 });
+  }
+
+  return (
+    <ScrollView>
+      <View padding="medium">
+        <Heading size="large">Kitchen Sink</Heading>
+
+        <Spacer.Vertical size="medium" />
+
+        <Heading>Load More Button</Heading>
+        <LoadMoreButton isLoading={isLoading} onPress={onLoadMorePress} />
+
+        <Spacer.Vertical size="medium" />
+
+        <Heading>FlatList Loader</Heading>
+        <FlatListLoader />
+
+        <Spacer.Vertical size="medium" />
+
+        <Heading>Basic Buttons</Heading>
+        <Spacer.Vertical size="small" />
+
+        <Row>
+          <BasicButton label="Primary" type="primary" />
+          <Spacer.Horizontal size="small" />
+          <BasicButton label="Secondary" type="secondary" />
+          <Spacer.Horizontal size="small" />
+          <BasicButton label="Tertiary" type="tertiary" />
+        </Row>
+        <Spacer.Vertical size="small" />
+        <Row>
+          <BasicButton label="Disabled" type="disabled" />
+          <Spacer.Horizontal size="small" />
+          <BasicButton label="Ghost" type="ghost" />
+          <Spacer.Horizontal size="small" />
+          <BasicButton label="Transparent" type="transparent" />
+        </Row>
+
+        <Spacer.Vertical size="large" />
+
+        <Heading>Toasts</Heading>
+        <Spacer.Vertical size="small" />
+
+        <Row>
+          <Spacer.Vertical size="small" />
+          <BasicButton label="Warning" onPress={onWarningToastPress} />
+
+          <Spacer.Horizontal size="small" />
+
+          <Spacer.Vertical size="small" />
+          <BasicButton label="Error" onPress={onErrorToastPress} />
+        </Row>
+      </View>
+    </ScrollView>
+  );
+}

--- a/packages/expo-dev-launcher/bundle/screens/UpdatesScreen.tsx
+++ b/packages/expo-dev-launcher/bundle/screens/UpdatesScreen.tsx
@@ -16,6 +16,7 @@ import * as React from 'react';
 import { Linking } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
 
+import { BasicButton } from '../components/BasicButton';
 import { EASUpdateRow } from '../components/EASUpdatesRows';
 import { FlatList } from '../components/FlatList';
 import { LoadMoreButton } from '../components/LoadMoreButton';
@@ -202,17 +203,7 @@ function BranchDetailsHeader({ branchName, updates, onOpenPress }: BranchDetails
         </View>
 
         <Spacer.Horizontal />
-        {hasUpdates && (
-          <View>
-            <Button.ScaleOnPressContainer bg="tertiary" onPress={onOpenPress}>
-              <View px="2" py="1.5">
-                <Button.Text size="small" weight="medium" color="tertiary">
-                  Open Latest
-                </Button.Text>
-              </View>
-            </Button.ScaleOnPressContainer>
-          </View>
-        )}
+        {hasUpdates && <BasicButton label="Open Latest" onPress={onOpenPress} py="1.5" px="2" />}
       </Row>
       {availableChannels.length > 0 && (
         <>


### PR DESCRIPTION
…lopment

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This is something I've been meaning to get to - its nice to have a screen that lets you easily debug commonly used components / develop new ones. As an app grows in screen count, sometimes it's a bit tricky to get to a specific screen to work on a component, which can slow down dev work. Also new devs can have a peek at this screen to see common usage for different components / APIs in the app 

I've also improved on the load more button and created a `BasicButton` component which can be used more often throughout the app

# How

<!--
How did you build this feature or fix this bug and why?
-->

Added a screen called "Kitchen Sink" (only in `__DEV__`) which can be accessed via the tab bar

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->


<img width="364" alt="Screen Shot 2022-04-04 at 3 33 34 PM" src="https://user-images.githubusercontent.com/40680668/161643085-e222220e-2295-4097-8daa-37cf446e2e5f.png">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
