### PR TITLE
[docs] versionCode on Android is a number, not a string

### DIFF
--- a/docs/pages/eas-update/runtime-versions.md
+++ b/docs/pages/eas-update/runtime-versions.md
@@ -16,7 +16,7 @@ Since updates must be compatible with a build's native code, any time native cod
 
 ## Setting `"runtimeVersion"`
 
-To make managing the `"runtimeVerison"` property easier between builds and updates, we've created runtime version policies that will update automatically based on other fields inside the app config (**app.json**/**app.config.js**). If these policies do not match the development flow of a project, there's also an option to set the `"runtimeVersion"` manually.
+To make managing the `"runtimeVersion"` property easier between builds and updates, we've created runtime version policies that will update automatically based on other fields inside the app config (**app.json**/**app.config.js**). If these policies do not match the development flow of a project, there's also an option to set the `"runtimeVersion"` manually.
 
 ### `"sdkVersion"` runtime version policy
 

--- a/docs/pages/eas-update/runtime-versions.md
+++ b/docs/pages/eas-update/runtime-versions.md
@@ -63,7 +63,7 @@ The `"nativeVersion"` policy will set the runtime version to the projects curren
       "buildNumber": "1"
     },
     "android": {
-      "versionCode": "1"
+      "versionCode": 1
     }
   }
 }


### PR DESCRIPTION
# Why

See title

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
