### PR TITLE
[docs] Fix source url for versioned AppLoading

### DIFF
--- a/docs/pages/versions/v40.0.0/sdk/app-loading.md
+++ b/docs/pages/versions/v40.0.0/sdk/app-loading.md
@@ -1,6 +1,6 @@
 ---
 title: AppLoading
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-40/packages/expo/src/launch'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-40/packages/expo-app-loading'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v41.0.0/sdk/app-loading.md
+++ b/docs/pages/versions/v41.0.0/sdk/app-loading.md
@@ -1,6 +1,6 @@
 ---
 title: AppLoading
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-41/packages/expo/src/launch'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-41/packages/expo-app-loading'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v42.0.0/sdk/app-loading.md
+++ b/docs/pages/versions/v42.0.0/sdk/app-loading.md
@@ -1,6 +1,6 @@
 ---
 title: AppLoading
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-42/packages/expo/src/launch'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-42/packages/expo-app-loading'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v43.0.0/sdk/app-loading.md
+++ b/docs/pages/versions/v43.0.0/sdk/app-loading.md
@@ -1,6 +1,6 @@
 ---
 title: AppLoading
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-43/packages/expo/src/launch'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-43/packages/expo-app-loading'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/v44.0.0/sdk/app-loading.md
+++ b/docs/pages/versions/v44.0.0/sdk/app-loading.md
@@ -1,6 +1,6 @@
 ---
 title: AppLoading
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-44/packages/expo/src/launch'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-44/packages/expo-app-loading'
 ---
 
 import APISection from '~/components/plugins/APISection';


### PR DESCRIPTION
# Why

It redirected to the wrong page.

# How

Fixed package URL in versioned pages. The unversioned one was correct

# Test Plan

None