### PR TITLE
[android] Fix shell app gradle error

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -125,7 +125,9 @@ subprojects {
     }
     kotlin {
       target(ktlintTarget)
-      targetExclude("**/versioned/host/exp/exponent/modules/api/**/*.kt")
+      // TODO: (barthap) Replace this with raw string when dropped shell app macros
+      // The star "*" signs interferes with slash "/" and treated wildcard path as comment ¯\_(ツ)_/¯
+      targetExclude(["**", "versioned/host/exp/exponent/modules/api", "**", "*.kt"].join("/"))
       ktlint("0.41.0").userData([
         "disabled_rules"           : "no-wildcard-imports,import-ordering",
         "charset"                  : "utf-8",


### PR DESCRIPTION
# Why

Changes introduced in #16869 caused shell app to fail, because wildcard path was treated as a comment after shell app macros were applied:

<img width="1325" alt="Screenshot 2022-04-05 at 10 55 35" src="https://user-images.githubusercontent.com/278340/161721818-61c90697-f961-45fd-9d2b-787f9f652471.png">


# How

Replaced path string with an array joined to a string, to avoid `*` and `/` characters stand next to each other 😅 

# Test Plan

CI:
- PR checks
- Unit test failure unrelated (Spotless step passed) ✅ 
- Shell app (manual trigger): https://github.com/expo/expo/runs/5830788411?check_suite_focus=true ✅ 
