### PR TITLE
[gesture-handler][iOS][Android] Upgrade `react-native-gesture-handler@2.1.0 ➡️ 2.2.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Package-specific changes not released in any SDK will be added here just before 
 - Updated `@react-native-community/slider` from `4.1.12` to `4.2.1`. ([#16901](https://github.com/expo/expo/pull/16901) by [@tsapeta](https://github.com/tsapeta))
 - Updated `react-native-svg` from `12.1.1` to `12.3.0`. ([#16874](https://github.com/expo/expo/pull/16874) by [@bbarthec](https://github.com/bbarthec))
 - Updated `react-native-screens` from `3.10.1` to `3.11.1`. ([#16913](https://github.com/expo/expo/pull/16913) by [@bbarthec](https://github.com/bbarthec))
+- Updated `react-native-gesture-handler` from `2.1.0` to `2.2.0`. ([#16922](https://github.com/expo/expo/pull/16922) by [@bbarthec](https://github.com/bbarthec))
 
 ### 🛠 Breaking changes
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/gesturehandler/Extensions.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/gesturehandler/Extensions.kt
@@ -5,7 +5,7 @@ import com.facebook.react.modules.core.DeviceEventManagerModule
 import com.facebook.react.uimanager.UIManagerModule
 
 val ReactContext.deviceEventEmitter: DeviceEventManagerModule.RCTDeviceEventEmitter
-  get() = this.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+    get() = this.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
 
 val ReactContext.UIManager: UIManagerModule
-  get() = this.getNativeModule(UIManagerModule::class.java)!!
+    get() = this.getNativeModule(UIManagerModule::class.java)!!

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/gesturehandler/FlingGestureHandler.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/gesturehandler/FlingGestureHandler.kt
@@ -36,17 +36,14 @@ class FlingGestureHandler : GestureHandler<FlingGestureHandler>() {
 
   private fun tryEndFling(event: MotionEvent) = if (
     maxNumberOfPointersSimultaneously == numberOfPointersRequired &&
-    (
-      direction and DIRECTION_RIGHT != 0 &&
-        event.rawX - startX > minAcceptableDelta ||
-        direction and DIRECTION_LEFT != 0 &&
-        startX - event.rawX > minAcceptableDelta ||
-        direction and DIRECTION_UP != 0 &&
-        startY - event.rawY > minAcceptableDelta ||
-        direction and DIRECTION_DOWN != 0 &&
-        event.rawY - startY > minAcceptableDelta
-      )
-  ) {
+    (direction and DIRECTION_RIGHT != 0 &&
+      event.rawX - startX > minAcceptableDelta ||
+      direction and DIRECTION_LEFT != 0 &&
+      startX - event.rawX > minAcceptableDelta ||
+      direction and DIRECTION_UP != 0 &&
+      startY - event.rawY > minAcceptableDelta ||
+      direction and DIRECTION_DOWN != 0 &&
+      event.rawY - startY > minAcceptableDelta)) {
     handler!!.removeCallbacksAndMessages(null)
     activate()
     true

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/gesturehandler/GestureHandlerOrchestrator.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/gesturehandler/GestureHandlerOrchestrator.kt
@@ -142,8 +142,16 @@ class GestureHandlerOrchestrator(
     } else if (prevState == GestureHandler.STATE_ACTIVE || prevState == GestureHandler.STATE_END) {
       if (handler.isActive) {
         handler.dispatchStateChange(newState, prevState)
+      } else if (prevState == GestureHandler.STATE_ACTIVE) {
+        // handle edge case where handler awaiting for another one tries to activate but finishes
+        // before the other would not send state change event upon ending
+        handler.dispatchStateChange(newState, GestureHandler.STATE_BEGAN)
       }
-    } else {
+    } else if (prevState != GestureHandler.STATE_UNDETERMINED || newState != GestureHandler.STATE_CANCELLED) {
+      // If handler is changing state from UNDETERMINED to CANCELLED, the state change event shouldn't
+      // be sent. Handler hasn't yet began so it may not be initialized which results in crashes.
+      // If it doesn't crash, there may be some weird behavior on JS side, as `onFinalize` will be
+      // called without calling `onBegin` first.
       handler.dispatchStateChange(newState, prevState)
     }
     handlingChangeSemaphore -= 1
@@ -155,6 +163,7 @@ class GestureHandlerOrchestrator(
     with(handler) {
       isAwaiting = false
       isActive = true
+      shouldResetProgress = true
       activationIndex = this@GestureHandlerOrchestrator.activationIndex++
     }
     var toCancelCount = 0
@@ -242,14 +251,39 @@ class GestureHandlerOrchestrator(
     // approach when we want to use pointer coordinates to calculate velocity or distance
     // for pinch so I don't know yet if we should transform or not...
     event.setLocation(coords[0], coords[1])
-    if (handler.needsPointerData) {
+    
+    // Touch events are sent before the handler itself has a chance to process them,
+    // mainly because `onTouchesUp` shoul be send befor gesture finishes. This means that
+    // the first `onTouchesDown` event is sent before a gesture begins, activation in 
+    // callback for this event causes problems because the handler doesn't have a chance
+    // to initialize itself with starting values of pointer (in pan this causes translation
+    // to be equal to the coordinates of the pointer). The simplest solution is to send
+    // the first `onTouchesDown` event after the handler processes it and changes state
+    // to `BEGAN`.
+    if (handler.needsPointerData && handler.state != 0) {
       handler.updatePointerData(event)
     }
 
     if (!handler.isAwaiting || action != MotionEvent.ACTION_MOVE) {
+      val isFirstEvent = handler.state == 0
       handler.handle(event)
       if (handler.isActive) {
+        // After handler is done waiting for other one to fail its progress should be
+        // reset, otherwise there may be a visible jump in values sent by the handler.
+        // When handler is waiting it's already activated but the `isAwaiting` flag
+        // prevents it from receiving touch stream. When the flag is changed, the
+        // difference between this event and the last one may be large enough to be
+        // visible in interactions based on this gesture. This makes it consistent with
+        // the behavior on iOS.
+        if (handler.shouldResetProgress) {
+          handler.shouldResetProgress = false
+          handler.resetProgress()
+        }
         handler.dispatchHandlerUpdate(event)
+      }
+
+      if (handler.needsPointerData && isFirstEvent) {
+        handler.updatePointerData(event)
       }
 
       // if event was of type UP or POINTER_UP we request handler to stop tracking now that
@@ -381,10 +415,9 @@ class GestureHandlerOrchestrator(
 
     // if the pointer is inside the view but it overflows its parent, handlers attached to the parent
     // might not have been extracted (pointer might be in a child, but may be outside parent)
-    if (coords[0] in 0f..view.width.toFloat() && coords[1] in 0f..view.height.toFloat() &&
-      isViewOverflowingParent(view) && extractAncestorHandlers(view, coords, pointerId)
-    ) {
-      found = true
+    if (coords[0] in 0f..view.width.toFloat() && coords[1] in 0f..view.height.toFloat()
+      && isViewOverflowingParent(view) && extractAncestorHandlers(view, coords, pointerId)) {
+        found = true
     }
 
     return found
@@ -434,10 +467,8 @@ class GestureHandlerOrchestrator(
       }
       PointerEventsConfig.BOX_ONLY -> {
         // This view is the target, its children don't matter
-        (
-          recordViewHandlersForPointer(view, coords, pointerId) ||
-            shouldHandlerlessViewBecomeTouchTarget(view, coords)
-          )
+        (recordViewHandlersForPointer(view, coords, pointerId)
+          || shouldHandlerlessViewBecomeTouchTarget(view, coords))
       }
       PointerEventsConfig.BOX_NONE -> {
         // This view can't be the target, but its children might
@@ -451,10 +482,8 @@ class GestureHandlerOrchestrator(
           extractGestureHandlers(view, coords, pointerId)
         } else false
 
-        (
-          recordViewHandlersForPointer(view, coords, pointerId) ||
-            found || shouldHandlerlessViewBecomeTouchTarget(view, coords)
-          )
+        (recordViewHandlersForPointer(view, coords, pointerId)
+          || found || shouldHandlerlessViewBecomeTouchTarget(view, coords))
       }
     }
 
@@ -465,6 +494,7 @@ class GestureHandlerOrchestrator(
   // be turned on and also confirm with the ViewConfigHelper implementation
   private fun isClipping(view: View) =
     view !is ViewGroup || viewConfigHelper.isViewClippingChildren(view)
+
 
   companion object {
     // The limit doesn't necessarily need to exists, it was just simpler to implement it that way
@@ -532,14 +562,13 @@ class GestureHandlerOrchestrator(
       x in 0f..child.width.toFloat() && y in 0f..child.height.toFloat()
 
     private fun shouldHandlerWaitForOther(handler: GestureHandler<*>, other: GestureHandler<*>): Boolean {
-      return handler !== other && (
-        handler.shouldWaitForHandlerFailure(other) ||
-          other.shouldRequireToWaitForFailure(handler)
-        )
+      return handler !== other && (handler.shouldWaitForHandlerFailure(other)
+        || other.shouldRequireToWaitForFailure(handler))
     }
 
     private fun canRunSimultaneously(a: GestureHandler<*>, b: GestureHandler<*>) =
       a === b || a.shouldRecognizeSimultaneously(b) || b.shouldRecognizeSimultaneously(a)
+
 
     private fun shouldHandlerBeCancelledBy(handler: GestureHandler<*>, other: GestureHandler<*>): Boolean {
       if (!handler.hasCommonPointers(other)) {
@@ -552,8 +581,7 @@ class GestureHandlerOrchestrator(
         return false
       }
       return if (handler !== other &&
-        (handler.isAwaiting || handler.state == GestureHandler.STATE_ACTIVE)
-      ) {
+        (handler.isAwaiting || handler.state == GestureHandler.STATE_ACTIVE)) {
         // in every other case as long as the handler is about to be activated or already in active
         // state, we delegate the decision to the implementation of GestureHandler#shouldBeCancelledBy
         handler.shouldBeCancelledBy(other)
@@ -561,8 +589,8 @@ class GestureHandlerOrchestrator(
     }
 
     private fun isFinished(state: Int) =
-      state == GestureHandler.STATE_CANCELLED ||
-        state == GestureHandler.STATE_FAILED ||
-        state == GestureHandler.STATE_END
+      state == GestureHandler.STATE_CANCELLED
+        || state == GestureHandler.STATE_FAILED
+        || state == GestureHandler.STATE_END
   }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/gesturehandler/NativeViewGestureHandler.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/gesturehandler/NativeViewGestureHandler.kt
@@ -4,6 +4,7 @@ import android.os.SystemClock
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
+import versioned.host.exp.exponent.modules.api.components.gesturehandler.react.RNGestureHandlerButtonViewManager
 
 class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
   private var shouldActivateOnStart = false
@@ -111,7 +112,7 @@ class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
   override fun onCancel() {
     val time = SystemClock.uptimeMillis()
     val event = MotionEvent.obtain(time, time, MotionEvent.ACTION_CANCEL, 0f, 0f, 0).apply {
-      action = MotionEvent.ACTION_CANCEL
+      action =  MotionEvent.ACTION_CANCEL
     }
     view!!.onTouchEvent(event)
   }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/gesturehandler/PanGestureHandler.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/gesturehandler/PanGestureHandler.kt
@@ -163,14 +163,12 @@ class PanGestureHandler(context: Context?) : GestureHandler<PanGestureHandler>()
     }
     val vx = velocityX
     if (minVelocityX != MIN_VALUE_IGNORE &&
-      (minVelocityX < 0 && vx <= minVelocityX || minVelocityX in 0.0f..vx)
-    ) {
+      (minVelocityX < 0 && vx <= minVelocityX || minVelocityX in 0.0f..vx)) {
       return true
     }
     val vy = velocityY
     if (minVelocityY != MIN_VALUE_IGNORE &&
-      (minVelocityY < 0 && vx <= minVelocityY || minVelocityY in 0.0f..vx)
-    ) {
+      (minVelocityY < 0 && vx <= minVelocityY || minVelocityY in 0.0f..vx)) {
       return true
     }
     val velocitySq = vx * vx + vy * vy
@@ -210,8 +208,7 @@ class PanGestureHandler(context: Context?) : GestureHandler<PanGestureHandler>()
       lastY = getLastPointerY(event, averageTouches)
     }
     if (state == STATE_UNDETERMINED && event.pointerCount >= minPointers) {
-      startX = lastX
-      startY = lastY
+      resetProgress()
       offsetX = 0f
       offsetY = 0f
       velocityX = 0f
@@ -255,8 +252,7 @@ class PanGestureHandler(context: Context?) : GestureHandler<PanGestureHandler>()
   override fun activate(force: Boolean) {
     // reset starting point if the handler has not yet activated
     if (state != STATE_ACTIVE) {
-      startX = lastX
-      startY = lastY
+      resetProgress()
     }
     super.activate(force)
   }
@@ -266,6 +262,11 @@ class PanGestureHandler(context: Context?) : GestureHandler<PanGestureHandler>()
       it.recycle()
       velocityTracker = null
     }
+  }
+
+  override fun resetProgress() {
+    startX = lastX
+    startY = lastY
   }
 
   companion object {

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/gesturehandler/PinchGestureHandler.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/gesturehandler/PinchGestureHandler.kt
@@ -27,9 +27,8 @@ class PinchGestureHandler : GestureHandler<PinchGestureHandler>() {
       if (delta > 0) {
         velocity = (scale - prevScaleFactor) / delta
       }
-      if (abs(startingSpan - detector.currentSpan) >= spanSlop &&
-        state == STATE_BEGAN
-      ) {
+      if (abs(startingSpan - detector.currentSpan) >= spanSlop
+        && state == STATE_BEGAN) {
         activate()
       }
       return true
@@ -53,8 +52,7 @@ class PinchGestureHandler : GestureHandler<PinchGestureHandler>() {
   override fun onHandle(event: MotionEvent) {
     if (state == STATE_UNDETERMINED) {
       val context = view!!.context
-      velocity = 0.0
-      scale = 1.0
+      resetProgress()
       scaleGestureDetector = ScaleGestureDetector(context, gestureListener)
       val configuration = ViewConfiguration.get(context)
       spanSlop = configuration.scaledTouchSlop.toFloat()
@@ -75,14 +73,17 @@ class PinchGestureHandler : GestureHandler<PinchGestureHandler>() {
   override fun activate(force: Boolean) {
     // reset scale if the handler has not yet activated
     if (state != STATE_ACTIVE) {
-      velocity = 0.0
-      scale = 1.0
+      resetProgress()
     }
     super.activate(force)
   }
 
   override fun onReset() {
     scaleGestureDetector = null
+    resetProgress()
+  }
+
+  override fun resetProgress() {
     velocity = 0.0
     scale = 1.0
   }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/gesturehandler/RotationGestureHandler.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/gesturehandler/RotationGestureHandler.kt
@@ -43,8 +43,7 @@ class RotationGestureHandler : GestureHandler<RotationGestureHandler>() {
 
   override fun onHandle(event: MotionEvent) {
     if (state == STATE_UNDETERMINED) {
-      velocity = 0.0
-      rotation = 0.0
+      resetProgress()
       rotationGestureDetector = RotationGestureDetector(gestureListener)
       begin()
     }
@@ -61,14 +60,17 @@ class RotationGestureHandler : GestureHandler<RotationGestureHandler>() {
   override fun activate(force: Boolean) {
     // reset rotation if the handler has not yet activated
     if (state != STATE_ACTIVE) {
-      rotation = 0.0
-      velocity = 0.0
+      resetProgress()
     }
     super.activate(force)
   }
 
   override fun onReset() {
     rotationGestureDetector = null
+    resetProgress()
+  }
+
+  override fun resetProgress() {
     velocity = 0.0
     rotation = 0.0
   }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/gesturehandler/common/GestureHandlerStateManager.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/gesturehandler/common/GestureHandlerStateManager.kt
@@ -1,5 +1,0 @@
-package versioned.host.exp.exponent.modules.api.components.gesturehandler
-
-interface GestureHandlerStateManager {
-  fun setGestureHandlerState(handlerTag: Int, newState: Int)
-}

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/gesturehandler/common/GestureHandlerStateManager.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/gesturehandler/common/GestureHandlerStateManager.kt
@@ -1,0 +1,5 @@
+package versioned.host.exp.exponent.modules.api.components.gesturehandler
+
+interface GestureHandlerStateManager {
+  fun setGestureHandlerState(handlerTag: Int, newState: Int)
+}

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -71,8 +71,7 @@ class RNGestureHandlerButtonViewManager : ViewGroupManager<ButtonViewGroup>() {
     view.updateBackground()
   }
 
-  class ButtonViewGroup(context: Context?) :
-    ViewGroup(context),
+  class ButtonViewGroup(context: Context?) : ViewGroup(context),
     NativeViewGestureHandler.StateChangeHook {
     // Using object because of handling null representing no value set.
     var rippleColor: Int? = null
@@ -208,9 +207,8 @@ class RNGestureHandlerButtonViewManager : ViewGroupManager<ButtonViewGroup>() {
           // 1. ReactViewManager is not a generic class with a possibility to handle another ViewGroup
           // 2. There's no way to force native behavior of ReactViewGroup's superclass's onTouchEvent
           colorDrawable.setCornerRadius(borderRadius)
-          if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP &&
-            selectable is RippleDrawable
-          ) {
+          if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
+            && selectable is RippleDrawable) {
             val mask = PaintDrawable(Color.WHITE)
             mask.setCornerRadius(borderRadius)
             selectable.setDrawableByLayerId(android.R.id.mask, mask)

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/gesturehandler/react/RNGestureHandlerEnabledRootView.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/gesturehandler/react/RNGestureHandlerEnabledRootView.kt
@@ -36,8 +36,7 @@ class RNGestureHandlerEnabledRootView : ReactRootView {
   fun initialize() {
     check(gestureRootHelper == null) { "GestureHandler already initialized for root view $this" }
     gestureRootHelper = RNGestureHandlerRootHelper(
-      _reactInstanceManager.currentReactContext!!, this
-    )
+      _reactInstanceManager.currentReactContext!!, this)
   }
 
   fun tearDown() {

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/gesturehandler/react/RNGestureHandlerEvent.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/gesturehandler/react/RNGestureHandlerEvent.kt
@@ -47,13 +47,13 @@ class RNGestureHandlerEvent private constructor() : Event<RNGestureHandlerEvent>
         init(handler, dataExtractor)
       }
 
-    fun <T : GestureHandler<T>> createEventData(
+    fun <T: GestureHandler<T>> createEventData(
       handler: T,
       dataExtractor: RNGestureHandlerEventDataExtractor<T>?
     ): WritableMap = Arguments.createMap().apply {
-      dataExtractor?.extractEventData(handler, this)
-      putInt("handlerTag", handler.tag)
-      putInt("state", handler.state)
-    }
+        dataExtractor?.extractEventData(handler, this)
+        putInt("handlerTag", handler.tag)
+        putInt("state", handler.state)
+      }
   }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/gesturehandler/react/RNGestureHandlerPackage.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/gesturehandler/react/RNGestureHandlerPackage.kt
@@ -13,6 +13,5 @@ class RNGestureHandlerPackage : ReactPackage {
   override fun createViewManagers(reactContext: ReactApplicationContext) =
     listOf<ViewManager<*, *>>(
       RNGestureHandlerRootViewManager(),
-      RNGestureHandlerButtonViewManager()
-    )
+      RNGestureHandlerButtonViewManager())
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/gesturehandler/react/RNGestureHandlerRootHelper.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/gesturehandler/react/RNGestureHandlerRootHelper.kt
@@ -9,6 +9,7 @@ import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.UiThreadUtil
 import com.facebook.react.common.ReactConstants
 import com.facebook.react.uimanager.RootView
+import com.facebook.react.views.modal.ReactModalHostView
 import versioned.host.exp.exponent.modules.api.components.gesturehandler.GestureHandler
 import versioned.host.exp.exponent.modules.api.components.gesturehandler.GestureHandlerOrchestrator
 
@@ -28,11 +29,9 @@ class RNGestureHandlerRootHelper(private val context: ReactContext, wrappedView:
     rootView = findRootViewTag(wrappedView)
     Log.i(
       ReactConstants.TAG,
-      "[GESTURE HANDLER] Initialize gesture handler for root view $rootView"
-    )
+      "[GESTURE HANDLER] Initialize gesture handler for root view $rootView")
     orchestrator = GestureHandlerOrchestrator(
-      wrappedView, registry, RNViewConfigurationHelper()
-    ).apply {
+      wrappedView, registry, RNViewConfigurationHelper()).apply {
       minimumAlphaForTraversal = MIN_ALPHA_FOR_TOUCH
     }
     jsGestureHandler = RootViewGestureHandler().apply { tag = -wrappedViewTag }
@@ -46,8 +45,7 @@ class RNGestureHandlerRootHelper(private val context: ReactContext, wrappedView:
   fun tearDown() {
     Log.i(
       ReactConstants.TAG,
-      "[GESTURE HANDLER] Tearing down gesture handler registered for root view $rootView"
-    )
+      "[GESTURE HANDLER] Tearing down gesture handler registered for root view $rootView")
     val module = context.getNativeModule(RNGestureHandlerModule::class.java)!!
     with(module) {
       registry.dropHandler(jsGestureHandler!!.tag)

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/gesturehandler/react/RNGestureHandlerRootView.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/gesturehandler/react/RNGestureHandlerRootView.kt
@@ -4,10 +4,12 @@ import android.content.Context
 import android.util.Log
 import android.view.MotionEvent
 import android.view.ViewGroup
+import android.view.ViewParent
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.UiThreadUtil
 import com.facebook.react.common.ReactConstants
 import com.facebook.react.uimanager.RootView
+import com.facebook.react.views.modal.ReactModalHostView
 import com.facebook.react.views.view.ReactViewGroup
 
 class RNGestureHandlerRootView(context: Context?) : ReactViewGroup(context) {

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/gesturehandler/react/RNGestureHandlerRootViewManager.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/gesturehandler/react/RNGestureHandlerRootViewManager.kt
@@ -26,8 +26,7 @@ class RNGestureHandlerRootViewManager : ViewGroupManager<RNGestureHandlerRootVie
     RNGestureHandlerEvent.EVENT_NAME to
       mutableMapOf("registrationName" to RNGestureHandlerEvent.EVENT_NAME),
     RNGestureHandlerStateChangeEvent.EVENT_NAME to
-      mutableMapOf("registrationName" to RNGestureHandlerStateChangeEvent.EVENT_NAME)
-  )
+      mutableMapOf("registrationName" to RNGestureHandlerStateChangeEvent.EVENT_NAME))
 
   companion object {
     const val REACT_CLASS = "GestureHandlerRootView"

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/gesturehandler/react/RNGestureHandlerStateChangeEvent.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/gesturehandler/react/RNGestureHandlerStateChangeEvent.kt
@@ -51,16 +51,16 @@ class RNGestureHandlerStateChangeEvent private constructor() : Event<RNGestureHa
         init(handler, newState, oldState, dataExtractor)
       }
 
-    fun <T : GestureHandler<T>> createEventData(
+    fun <T: GestureHandler<T>> createEventData(
       handler: T,
       dataExtractor: RNGestureHandlerEventDataExtractor<T>?,
       newState: Int,
       oldState: Int,
     ): WritableMap = Arguments.createMap().apply {
-      dataExtractor?.extractEventData(handler, this)
-      putInt("handlerTag", handler.tag)
-      putInt("state", newState)
-      putInt("oldState", oldState)
-    }
+        dataExtractor?.extractEventData(handler, this)
+        putInt("handlerTag", handler.tag)
+        putInt("state", newState)
+        putInt("oldState", oldState)
+      }
   }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/gesturehandler/react/RNGestureHandlerTouchEvent.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/gesturehandler/react/RNGestureHandlerTouchEvent.kt
@@ -43,11 +43,11 @@ class RNGestureHandlerTouchEvent private constructor() : Event<RNGestureHandlerT
     private val EVENTS_POOL = Pools.SynchronizedPool<RNGestureHandlerTouchEvent>(TOUCH_EVENTS_POOL_SIZE)
 
     fun <T : GestureHandler<T>> obtain(handler: T): RNGestureHandlerTouchEvent =
-      (EVENTS_POOL.acquire() ?: RNGestureHandlerTouchEvent()).apply {
-        init(handler)
-      }
+        (EVENTS_POOL.acquire() ?: RNGestureHandlerTouchEvent()).apply {
+          init(handler)
+        }
 
-    fun <T : GestureHandler<T>> createEventData(handler: T,): WritableMap = Arguments.createMap().apply {
+    fun <T: GestureHandler<T>> createEventData(handler: T,): WritableMap = Arguments.createMap().apply {
       putInt("handlerTag", handler.tag)
       putInt("state", handler.state)
       putInt("numberOfTouches", handler.trackedPointersCount)

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -767,7 +767,7 @@ PODS:
     - React-Core
   - RNDateTimePicker (4.0.0):
     - React-Core
-  - RNGestureHandler (2.1.3):
+  - RNGestureHandler (2.2.0):
     - React-Core
   - RNReanimated (2.4.1):
     - DoubleConversion
@@ -1462,7 +1462,7 @@ SPEC CHECKSUMS:
   RNCMaskedView: c298b644a10c0c142055b3ae24d83879ecb13ccd
   RNCPicker: 6d5d64e7b90c240c779ee0938ec433c11e2dd758
   RNDateTimePicker: 2224ee77a86b7123377597a015502435e2e49957
-  RNGestureHandler: e1099204721a17a89c81fcd1cc2e92143dc040fb
+  RNGestureHandler: bf572f552ea324acd5b5464b8d30755b2d8c1de6
   RNReanimated: 3d1432ce7b6b7fc31f375dcabe5b4585e0634a43
   RNScreens: 4d83613b50b74ed277026375dc0810893b0c347f
   RNSharedElement: eb7d506733952d58634f34c82ec17e82f557e377

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -112,7 +112,7 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-native": "0.68.0",
-    "react-native-gesture-handler": "~2.1.0",
+    "react-native-gesture-handler": "~2.2.0",
     "react-native-reanimated": "~2.4.1",
     "react-native-safe-area-context": "3.3.2",
     "react-native-screens": "~3.11.1",

--- a/apps/bare-sandbox/package.json
+++ b/apps/bare-sandbox/package.json
@@ -18,7 +18,7 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-native": "0.68.0",
-    "react-native-gesture-handler": "~2.1.0",
+    "react-native-gesture-handler": "~2.2.0",
     "react-native-reanimated": "~2.4.1",
     "react-native-screens": "~3.11.1",
     "react-native-web": "~0.17.1"

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -147,7 +147,7 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-native": "0.68.0",
-    "react-native-gesture-handler": "~2.1.0",
+    "react-native-gesture-handler": "~2.2.0",
     "react-native-iphone-x-helper": "^1.3.0",
     "react-native-maps": "0.29.4",
     "react-native-pager-view": "5.4.15",

--- a/apps/test-suite/package.json
+++ b/apps/test-suite/package.json
@@ -55,7 +55,7 @@
     "lodash": "^4.17.19",
     "react": "17.0.2",
     "react-native": "0.68.0",
-    "react-native-gesture-handler": "~2.1.0",
+    "react-native-gesture-handler": "~2.2.0",
     "react-native-safe-area-view": "^0.14.8",
     "sinon": "^7.1.1"
   },

--- a/home/package.json
+++ b/home/package.json
@@ -56,7 +56,7 @@
     "react": "17.0.2",
     "react-native": "0.68.0",
     "react-native-fade-in-image": "^1.6.1",
-    "react-native-gesture-handler": "~2.1.0",
+    "react-native-gesture-handler": "~2.2.0",
     "react-native-infinite-scroll-view": "^0.4.5",
     "react-native-maps": "0.29.4",
     "react-native-paper": "^4.0.1",

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1872,7 +1872,7 @@ PODS:
     - React-logger (= 0.67.2)
     - React-perflogger (= 0.67.2)
     - ReactCommon/turbomodule/core (= 0.67.2)
-  - RNGestureHandler (2.1.0):
+  - RNGestureHandler (2.2.0):
     - React-Core
   - RNReanimated (2.3.1):
     - DoubleConversion
@@ -3339,7 +3339,7 @@ SPEC CHECKSUMS:
   React-RCTVibration: 99c7f67fba7a5ade46e98e870c6ff2444484f995
   React-runtimeexecutor: 2450b43df7ffe8e805a0b3dcb2abd4282f1f1836
   ReactCommon: d98c6c96b567f9b3a15f9fd4cc302c1eda8e3cf2
-  RNGestureHandler: e5c7cab5f214503dcefd6b2b0cefb050e1f51c4a
+  RNGestureHandler: bf572f552ea324acd5b5464b8d30755b2d8c1de6
   RNReanimated: 1326679461fa5d2399d54c18ca1432ba3e816b9e
   RNScreens: 4d83613b50b74ed277026375dc0810893b0c347f
   Stripe: 22c1b8da5ee20a1aaf40fd198160efa72e71644a

--- a/ios/vendored/unversioned/react-native-gesture-handler/RNGestureHandler.podspec.json
+++ b/ios/vendored/unversioned/react-native-gesture-handler/RNGestureHandler.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "RNGestureHandler",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "summary": "Experimental implementation of a new declarative API for gesture handling in react-native",
   "homepage": "https://github.com/software-mansion/react-native-gesture-handler",
   "license": "MIT",
@@ -13,7 +13,7 @@
   },
   "source": {
     "git": "https://github.com/software-mansion/react-native-gesture-handler",
-    "tag": "2.1.0"
+    "tag": "2.2.0"
   },
   "source_files": "ios/**/*.{h,m}",
   "dependencies": {

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -92,7 +92,7 @@
   "expo-web-browser": "~10.1.0",
   "lottie-react-native": "5.0.1",
   "react-native-branch": "5.0.0",
-  "react-native-gesture-handler": "~2.1.0",
+  "react-native-gesture-handler": "~2.2.0",
   "react-native-get-random-values": "~1.7.0",
   "react-native-maps": "0.29.4",
   "react-native-pager-view": "5.4.15",

--- a/tools/src/vendoring/legacy.ts
+++ b/tools/src/vendoring/legacy.ts
@@ -253,7 +253,7 @@ const vendoredModulesConfig: { [key: string]: VendoredModuleConfig } = {
         targetAndroidPackage: 'versioned.host.exp.exponent.modules.api.components.gesturehandler',
       },
       {
-        sourceAndroidPath: 'android/src/main/java/com/swmansion/common',
+        sourceAndroidPath: 'android/common/src/main/java/com/swmansion/common',
         targetAndroidPath: 'modules/api/components/gesturehandler/common',
         sourceAndroidPackage: 'com.swmansion.common',
         targetAndroidPackage: 'versioned.host.exp.exponent.modules.api.components.gesturehandler',

--- a/yarn.lock
+++ b/yarn.lock
@@ -16853,10 +16853,10 @@ react-native-fade-in-image@^1.6.1:
     react-mixin "^3.0.5"
     react-timer-mixin "^0.13.3"
 
-react-native-gesture-handler@~2.1.0:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-2.1.3.tgz#b96f1e61932d5062cb1023259e1649d65f78338b"
-  integrity sha512-y5W2MVB+J6vjIT/mUidDv0BqVRbWXn0cP7R2o6fsSYsHh9M0btT979+bCI7nPuhmRHjkhg5xCm4HNMIH0IQO4w==
+react-native-gesture-handler@~2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-2.2.0.tgz#a551f9ca33d8766d0a24268f49e0f1b05191b105"
+  integrity sha512-WF25CNgn164bF9juW8N/jICIFXiEOgsxCuY7DRlnFdiH5ZfvMYtZHRC+zr1fFMap2ty1f2HWDQNVVSo0FDXP4A==
   dependencies:
     "@egjs/hammerjs" "^2.0.17"
     hoist-non-react-statics "^3.3.0"


### PR DESCRIPTION
# Why

Resolves [ENG-4500](https://linear.app/expo/issue/ENG-4500/react-native-gesture-handler-210-220)

[Full changelog `2.1.0...2.2.0`](https://github.com/software-mansion/react-native-gesture-handler/compare/2.1.0...2.2.0)

We're upgrading to the version `2.2.0`, because that's the most up-to-date version without `Fabric` included (the most up-to-date version with Fabric is `2.3.2`)

# How

1. `et uvm --module "react-native-gesture-handler" --commit "2.2.0" --target "expo-go"`
2. `yarn`
3. fixed vendoring script and rerun vendoring command

# Test Plan

Tested `gesture-handler` screen:

- [x] on Android and iOS using `bare-expo`
- [x] on Android and iOS using `UNVERSIONED` `ncl` in `Expo Go`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
