### PR TITLE
[modules] Catch C++ exceptions thrown by evaluateScript and rethrow as Swift exception

### DIFF
--- a/packages/expo-modules-core/ios/EXUtilities.h
+++ b/packages/expo-modules-core/ios/EXUtilities.h
@@ -20,6 +20,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable UIViewController *)currentViewController;
 - (nullable NSDictionary *)launchOptions;
 
++ (BOOL)catchException:(void(^)(void))tryBlock error:(__autoreleasing NSError **)error;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/expo-modules-core/ios/EXUtilities.m
+++ b/packages/expo-modules-core/ios/EXUtilities.m
@@ -206,6 +206,18 @@ EX_REGISTER_MODULE();
   }
 }
 
++ (BOOL)catchException:(void(^)(void))tryBlock error:(__autoreleasing NSError **)error
+{
+  @try {
+    tryBlock();
+    return YES;
+  }
+  @catch (NSException *exception) {
+    *error = [[NSError alloc] initWithDomain:exception.name code:0 userInfo:exception.userInfo];
+    return NO;
+  }
+}
+
 @end
 
 UIApplication * EXSharedApplication(void)

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.mm
@@ -106,7 +106,19 @@ using namespace facebook;
 - (nonnull EXJavaScriptValue *)evaluateScript:(nonnull NSString *)scriptSource
 {
   std::shared_ptr<jsi::StringBuffer> scriptBuffer = std::make_shared<jsi::StringBuffer>([[NSString stringWithFormat:@"(%@)", scriptSource] UTF8String]);
-  std::shared_ptr<jsi::Value> result = std::make_shared<jsi::Value>(_runtime->evaluateJavaScript(scriptBuffer, "<<evaluated>>"));
+  std::shared_ptr<jsi::Value> result;
+
+  try {
+    result = std::make_shared<jsi::Value>(_runtime->evaluateJavaScript(scriptBuffer, "<<evaluated>>"));
+  } catch (jsi::JSError &error) {
+    NSString *reason = [NSString stringWithUTF8String:error.getMessage().c_str()];
+    NSString *stack = [NSString stringWithUTF8String:error.getStack().c_str()];
+
+    @throw [NSException exceptionWithName:@"ScriptEvaluationException" reason:reason userInfo:@{
+      @"message": reason,
+      @"stack": stack,
+    }];
+  }
   return [[EXJavaScriptValue alloc] initWithRuntime:self value:result];
 }
 

--- a/packages/expo-modules-core/ios/JSI/JavaScriptRuntime.swift
+++ b/packages/expo-modules-core/ios/JSI/JavaScriptRuntime.swift
@@ -8,9 +8,25 @@ public extension JavaScriptRuntime {
                        The expression can include variables and properties of existing objects.
    - Returns: The completion value of evaluating the given code represented as `JavaScriptValue`.
               If the completion value is empty, `undefined` is returned.
+   - Throws: `JavaScriptEvalException` when evaluated code has invalid syntax or throws an error.
    - Note: It wraps the original `evaluateScript` to better handle and rethrow exceptions.
    */
   func eval(_ source: String) throws -> JavaScriptValue {
-    return try evaluateScript(source)
+    do {
+      var result: JavaScriptValue?
+      try EXUtilities.catchException {
+        result = self.evaluateScript(source)
+      }
+      // There is no risk to force unwrapping as long as the `evaluateScript` returns nonnull value.
+      return result!
+    } catch {
+      throw JavaScriptEvalException(error as NSError)
+    }
+  }
+}
+
+internal final class JavaScriptEvalException: GenericException<NSError> {
+  override var reason: String {
+    return param.userInfo["message"] as? String ?? "unknown reason"
   }
 }

--- a/packages/expo-modules-core/ios/Tests/JavaScriptRuntimeSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/JavaScriptRuntimeSpec.swift
@@ -82,6 +82,13 @@ class JavaScriptRuntimeSpec: ExpoSpec {
         expect(symbol.isSymbol()) == true
         expect(symbol.kind) == .symbol
       }
+
+      it("throws evaluation exception") {
+        expect({ try runtime.eval("foo") }).to(throwError { error in
+          expect(error).to(beAKindOf(JavaScriptEvalException.self))
+          expect((error as! JavaScriptEvalException).reason).to(contain("Can't find variable: foo"))
+        })
+      }
     }
   }
 }


### PR DESCRIPTION
# Why

`evaluateScript` on the JSI runtime may throw `jsi::JSError` when the provided code cannot be parsed or throws errors. However, it's of course uncatchable when called from Swift.
Closes ENG-4539

# How

- Added simple helper to catch errors thrown by Objective-C methods
- Rethrow `jsi::JSError` from `evaluateScript` as a native `NSException` so make it catchable by the helper
- `JavaScriptRuntime.eval` now catches the Objective-C error and rethrows as Swift exception
- Added simple test

Shortly, the original error flows that way: `jsi::JSError` -> `NSException` -> `NSError` -> `JavaScriptEvalException`
So many turns in here, but there is no other way to catch C++ errors in Swift 🤷‍♂️ 

# Test Plan

Existing and new tests are passing (`eval` is used only in tests right now)
