### PR TITLE
[local-authentication][Android] Fix fixed `BiometricPrompt.ERROR_CANCELED` returned when fallbacking to PIN/Pattern/Password

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -17,7 +17,8 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 30)
+  // compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion 31 // TODO: migrate to the commented syntax in the whole project
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_1_8

--- a/packages/expo-local-authentication/CHANGELOG.md
+++ b/packages/expo-local-authentication/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 - Updated `@expo/config-plugins` from `4.0.2` to `4.0.14` ([#15621](https://github.com/expo/expo/pull/15621) by [@EvanBacon](https://github.com/EvanBacon))
 - Updated `androix.biometric.biometric` from `1.1.0` to `1.2.0-alphas04`. ([#16927](https://github.com/expo/expo/pull/16927) by [@bbarthec](https://github.com/bbarthec), ([#16927](https://github.com/expo/expo/pull/16927) by [@bbarthec](https://github.com/bbarthec), [@Polidoro-root](https://github.com/Polidoro-root))
+- Bumped `compileSdkVersion` from `30` to `31`. ([#16927](https://github.com/expo/expo/pull/16927) by [@bbarthec](https://github.com/bbarthec), ([#16927](https://github.com/expo/expo/pull/16927) by [@bbarthec](https://github.com/bbarthec), [@Polidoro-root](https://github.com/Polidoro-root))
+
 
 ## 12.1.1 - 2022-02-01
 

--- a/packages/expo-local-authentication/CHANGELOG.md
+++ b/packages/expo-local-authentication/CHANGELOG.md
@@ -10,9 +10,12 @@
 
 ### 🐛 Bug fixes
 
+- On Android fixed `BiometricPrompt.ERROR_CANCELED` returned when fallbacking to PIN/Pattern/Password authentication method.
+
 ### 💡 Others
 
 - Updated `@expo/config-plugins` from `4.0.2` to `4.0.14` ([#15621](https://github.com/expo/expo/pull/15621) by [@EvanBacon](https://github.com/EvanBacon))
+- Updated `androix.biometric.biometric` from `1.1.0` to `1.2.0-alphas04`.
 
 ## 12.1.1 - 2022-02-01
 

--- a/packages/expo-local-authentication/CHANGELOG.md
+++ b/packages/expo-local-authentication/CHANGELOG.md
@@ -10,12 +10,12 @@
 
 ### 🐛 Bug fixes
 
-- On Android fixed `BiometricPrompt.ERROR_CANCELED` returned when fallbacking to PIN/Pattern/Password authentication method.
+- On Android fixed `BiometricPrompt.ERROR_CANCELED` returned when fallbacking to PIN/Pattern/Password authentication method. ([#16927](https://github.com/expo/expo/pull/16927) by [@bbarthec](https://github.com/bbarthec), [@Polidoro-root](https://github.com/Polidoro-root))
 
 ### 💡 Others
 
 - Updated `@expo/config-plugins` from `4.0.2` to `4.0.14` ([#15621](https://github.com/expo/expo/pull/15621) by [@EvanBacon](https://github.com/EvanBacon))
-- Updated `androix.biometric.biometric` from `1.1.0` to `1.2.0-alphas04`.
+- Updated `androix.biometric.biometric` from `1.1.0` to `1.2.0-alphas04`. ([#16927](https://github.com/expo/expo/pull/16927) by [@bbarthec](https://github.com/bbarthec), ([#16927](https://github.com/expo/expo/pull/16927) by [@bbarthec](https://github.com/bbarthec), [@Polidoro-root](https://github.com/Polidoro-root))
 
 ## 12.1.1 - 2022-02-01
 

--- a/packages/expo-local-authentication/android/build.gradle
+++ b/packages/expo-local-authentication/android/build.gradle
@@ -84,7 +84,7 @@ android {
 dependencies {
   implementation project(':expo-modules-core')
 
-  api "androidx.biometric:biometric:1.1.0"
+  implementation "androidx.biometric:biometric:1.2.0-alpha04"
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
 }

--- a/packages/expo-local-authentication/android/build.gradle
+++ b/packages/expo-local-authentication/android/build.gradle
@@ -59,7 +59,8 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 30)
+  // compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion 31 // TODO: migrate to the commented syntax in the whole project
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
# Why

Supersedes https://github.com/expo/expo/pull/16774
Supersedes https://github.com/expo/expo/pull/16614
Fixes https://github.com/expo/expo/issues/9846
Fixes https://github.com/expo/expo/issues/10451 (this issue is autoclosed by bot despite being not resolved)

# How

I was using this [app code](https://snack.expo.dev/@bbarthec/localauthentication-demo) to test the behaviour.
I've confirmed that prior this change the problem was occurring on certain devices (eg. Android Emulator running Android 29).

Steps to fix the problem:
1. [`androidx.biometric:biometric:1.2.0-alpha04`](https://developer.android.com/jetpack/androidx/releases/biometric#1.2.0-alpha04) fixed the problem.
2. I've bumped `androidx.biometric:biometric@1.1.0 ➡️ 1.2.0-alpha04`
3. I had to bump `compileSdkTarget@30 ➡️ 31` in both `expo-local-authentication` and `Expo Go`, because `androidx.biometric:biometric@1.2.0-alpha04` is compiled using SDK 31, so we need to propagate this version to the top of the project.

# Test Plan

I was using Android emulator running Android API 29 and I've confirmed these works:
- [x] I've used `bare-expo` with the app code from [this snack](https://snack.expo.dev/@bbarthec/localauthentication-demo)
- [x] I've used `Expo Go` and tried to run [this snack](https://snack.expo.dev/@bbarthec/localauthentication-demo) with `UNVERSIONED` sdk

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).

# Acknowledgements 

- @Polidoro-root for original PRs that aimed to solve the problem