### PR TITLE
[eas-client] Allow module versioning on android

### DIFF
--- a/tools/src/versioning/android/android-packages-to-keep.txt
+++ b/tools/src/versioning/android/android-packages-to-keep.txt
@@ -6,7 +6,6 @@ expo.modules.apploader
 expo.modules.interfaces.taskManager
 expo.modules.core.interfaces.Consumer
 expo.modules.core.interfaces.SingletonModule
-expo.modules.easclient
 expo.modules.jsonutils
 expo.modules.manifests
 expo.modules.notifications.notifications.model

--- a/tools/src/versioning/android/unversionablePackages.json
+++ b/tools/src/versioning/android/unversionablePackages.json
@@ -4,7 +4,6 @@
   "expo-dev-launcher",
   "expo-dev-menu",
   "expo-dev-menu-interface",
-  "expo-eas-client",
   "expo-gl-cpp",
   "expo-image",
   "expo-in-app-purchases",


### PR DESCRIPTION
# Why

Concern raised by @Kudo about this package using the new kotlin/swift module definition yet also specifying that it should not be versioned (be a singleton) on android.

Rather than change this to use singleton module, I think the easiest thing is just to allow it to be versioned.

Context (internal): https://exponent-internal.slack.com/archives/C013ZK4SA12/p1649085765357989

# How

Remove it from `android-packages-to-keep.txt`.

# Test Plan

Wait for versioning CI job.