### PR TITLE
fix(cli): update login error message to reflect server change

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -28,6 +28,6 @@
 - Fix process memory leak warning in `expo start`. ([#16753](https://github.com/expo/expo/pull/16753) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix build watcher. ([#16754](https://github.com/expo/expo/pull/16754) by [@EvanBacon](https://github.com/EvanBacon))
 - Allow bailing out of Terminal UI during long processes. ([#16818](https://github.com/expo/expo/pull/16818) by [@EvanBacon](https://github.com/EvanBacon))
-- [test] Update login error message to reflect server change.
+- [test] Update login error message to reflect server change. ([#16932](https://github.com/expo/expo/pull/16932) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -28,5 +28,6 @@
 - Fix process memory leak warning in `expo start`. ([#16753](https://github.com/expo/expo/pull/16753) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix build watcher. ([#16754](https://github.com/expo/expo/pull/16754) by [@EvanBacon](https://github.com/EvanBacon))
 - Allow bailing out of Terminal UI during long processes. ([#16818](https://github.com/expo/expo/pull/16818) by [@EvanBacon](https://github.com/EvanBacon))
+- [test] Update login error message to reflect server change.
 
 ### 💡 Others

--- a/packages/@expo/cli/e2e/__tests__/login-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/login-test.ts
@@ -74,6 +74,6 @@ it('runs `npx expo login` and throws due to invalid credentials', async () => {
   try {
     console.log(await execute('login', '--username', 'bacon', '--password', 'invalid'));
   } catch (e) {
-    expect(e.stderr).toMatch(/Invalid username\/password. Please try again/);
+    expect(e.stderr).toMatch(/Your username, email, or password was incorrect/);
   }
 });

--- a/packages/@expo/cli/e2e/__tests__/start-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/start-test.ts
@@ -74,7 +74,7 @@ it('runs `npx expo start --help`', async () => {
 
         --dev-client                           Experimental: Starts the bundler for use with the expo-development-client
         --force-manifest-type <manifest-type>  Override auto detection of manifest type
-        --private-key-path <path>              Path to private key for code signing. Default: "private-key.pem" in the same directory as the certificate specified by the expo-updates configuration in app.json.
+        --private-key-path <path>              Path to private key for code signing. Default: \\"private-key.pem\\" in the same directory as the certificate specified by the expo-updates configuration in app.json.
         -h, --help                             output usage information
     "
   `);

--- a/packages/@expo/cli/src/api/rest/__tests__/client-test.ts
+++ b/packages/@expo/cli/src/api/rest/__tests__/client-test.ts
@@ -51,7 +51,7 @@ it('converts Expo APIv2 error to ApiV2Error (invalid password)', async () => {
       errors: [
         {
           code: 'AUTHENTICATION_ERROR',
-          message: 'Invalid username/password. Please try again.',
+          message: 'Your username, email, or password was incorrect.',
           isTransient: false,
         },
       ],
@@ -66,7 +66,7 @@ it('converts Expo APIv2 error to ApiV2Error (invalid password)', async () => {
   } catch (error: any) {
     assert(error instanceof ApiV2Error);
 
-    expect(error.message).toEqual('Invalid username/password. Please try again.');
+    expect(error.message).toEqual('Your username, email, or password was incorrect.');
     expect(error.expoApiV2ErrorCode).toEqual('AUTHENTICATION_ERROR');
   }
   expect(scope.isDone()).toBe(true);


### PR DESCRIPTION
# Why

CI started failing as the error message no longer matched the server results. This updates the error message.

# Test Plan

- `yarn test:e2e --watch login` should work locally and in CI.