### PR TITLE
[dev-launcher] feature-gate EAS Updates panel

### DIFF
--- a/packages/expo-dev-launcher/bundle/App.tsx
+++ b/packages/expo-dev-launcher/bundle/App.tsx
@@ -12,6 +12,7 @@ import * as React from 'react';
 import { LoadInitialData } from './components/LoadInitialData';
 import { Splash } from './components/Splash';
 import { AppProviders } from './providers/AppProviders';
+import { useUser } from './providers/UserContextProvider';
 import { CrashReportScreen } from './screens/CrashReportScreen';
 import { ExtensionsStack } from './screens/ExtensionsStack';
 import { HomeScreen } from './screens/HomeScreen';
@@ -55,6 +56,9 @@ export function App(props: LauncherAppProps) {
 }
 
 const Main = () => {
+  const { userData } = useUser();
+  const showExtensionsStack = userData?.isExpoAdmin || __DEV__;
+
   return (
     <Tab.Navigator screenOptions={{ tabBarHideOnKeyboard: true }}>
       <Tab.Screen
@@ -65,7 +69,7 @@ const Main = () => {
           tabBarIcon: ({ focused }) => <HomeFilledIcon focused={focused} />,
         }}
       />
-      {__DEV__ && (
+      {showExtensionsStack && (
         <Tab.Screen
           name="Extensions"
           component={ExtensionsStack}

--- a/packages/expo-dev-launcher/bundle/components/Toasts.tsx
+++ b/packages/expo-dev-launcher/bundle/components/Toasts.tsx
@@ -6,9 +6,7 @@ function ErrorToast({ children }) {
     <View mx="large">
       <View bg="error" padding="medium" rounded="medium" border="error">
         <View>
-          <Text color="error">
-            {children}
-          </Text>
+          <Text color="error">{children}</Text>
         </View>
       </View>
     </View>
@@ -32,7 +30,21 @@ function WarningToast({ children }) {
         <Spacer.Vertical size="small" />
 
         <View>
-          <Text size="small" color="warning">{children}</Text>
+          <Text size="small" color="warning">
+            {children}
+          </Text>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+function InfoToast({ children }) {
+  return (
+    <View mx="large">
+      <View bg="default" padding="medium" rounded="medium" border="default">
+        <View>
+          <Text color="default">{children}</Text>
         </View>
       </View>
     </View>
@@ -42,4 +54,5 @@ function WarningToast({ children }) {
 export const Toasts = {
   Error: ErrorToast,
   Warning: WarningToast,
+  Info: InfoToast,
 };

--- a/packages/expo-dev-launcher/bundle/functions/getInitialData.ts
+++ b/packages/expo-dev-launcher/bundle/functions/getInitialData.ts
@@ -1,4 +1,3 @@
-import { NativeModules } from 'react-native';
 import {
   getBuildInfoAsync,
   getCrashReport,
@@ -8,6 +7,7 @@ import {
 } from '../native-modules/DevLauncherInternal';
 import { getMenuPreferencesAsync } from '../native-modules/DevMenuPreferences';
 import { AppProvidersProps } from '../providers/AppProviders';
+import { defaultQueryOptions } from '../providers/QueryProvider';
 import { prefetchBranchesForApp } from '../queries/useBranchesForApp';
 import { getDevSessionsAsync } from './getDevSessionsAsync';
 import { restoreUserAsync } from './restoreUserAsync';
@@ -27,9 +27,11 @@ export async function getInitialData(): Promise<Partial<AppProvidersProps>> {
   const initialCrashReport = await getCrashReport();
 
   if (isAuthenticated && updatesConfig.usesEASUpdates) {
-    prefetchBranchesForApp(updatesConfig.appId, updatesConfig.runtimeVersion).catch((error) =>
-      console.log({ error })
-    );
+    prefetchBranchesForApp(
+      updatesConfig.appId,
+      updatesConfig.runtimeVersion,
+      defaultQueryOptions.pageSize
+    ).catch((error) => console.log({ error }));
   }
 
   return {

--- a/packages/expo-dev-launcher/bundle/functions/getUserProfileAsync.ts
+++ b/packages/expo-dev-launcher/bundle/functions/getUserProfileAsync.ts
@@ -9,6 +9,7 @@ export type UserData = {
   username: string;
   profilePhoto: string;
   accounts: UserAccount[];
+  isExpoAdmin: boolean;
 };
 
 export type UserAccount = {
@@ -29,6 +30,7 @@ const query = gql`
       email
       profilePhoto
       username
+      isExpoAdmin
 
       accounts {
         id

--- a/packages/expo-dev-launcher/bundle/providers/QueryProvider.tsx
+++ b/packages/expo-dev-launcher/bundle/providers/QueryProvider.tsx
@@ -3,6 +3,30 @@ import { QueryClient, QueryClientProvider } from 'react-query';
 
 export const queryClient = new QueryClient();
 
+type QueryOptions = {
+  pageSize: number;
+};
+
+type QueryOptionsContextProps = {
+  queryOptions: QueryOptions;
+  setQueryOptions: (options: QueryOptions) => void;
+};
+
+export const defaultQueryOptions: QueryOptions = {
+  pageSize: 10,
+};
+
+const QueryOptionsContext = React.createContext<QueryOptionsContextProps | null>(null);
+export const useQueryOptions = () => React.useContext(QueryOptionsContext);
+
 export function QueryProvider({ children }: { children: React.ReactNode }) {
-  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  const [queryOptions, setQueryOptions] = React.useState(defaultQueryOptions);
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <QueryOptionsContext.Provider value={{ queryOptions, setQueryOptions }}>
+        {children}
+      </QueryOptionsContext.Provider>
+    </QueryClientProvider>
+  );
 }

--- a/packages/expo-dev-launcher/bundle/providers/__mocks__/QueryProvider.tsx
+++ b/packages/expo-dev-launcher/bundle/providers/__mocks__/QueryProvider.tsx
@@ -16,6 +16,30 @@ setLogger({
   error: () => {},
 });
 
+type QueryOptions = {
+  pageSize: number;
+};
+
+type QueryOptionsContextProps = {
+  queryOptions: QueryOptions;
+  setQueryOptions: (options: QueryOptions) => void;
+};
+
+export const defaultQueryOptions: QueryOptions = {
+  pageSize: 10,
+};
+
+const QueryOptionsContext = React.createContext<QueryOptionsContextProps | null>(null);
+export const useQueryOptions = () => React.useContext(QueryOptionsContext);
+
 export function QueryProvider({ children }: { children: React.ReactNode }) {
-  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  const [queryOptions, setQueryOptions] = React.useState(defaultQueryOptions);
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <QueryOptionsContext.Provider value={{ queryOptions, setQueryOptions }}>
+        {children}
+      </QueryOptionsContext.Provider>
+    </QueryClientProvider>
+  );
 }

--- a/packages/expo-dev-launcher/bundle/screens/BranchesScreen.tsx
+++ b/packages/expo-dev-launcher/bundle/screens/BranchesScreen.tsx
@@ -33,13 +33,17 @@ export function BranchesScreen({ navigation }: BranchesScreenProps) {
   }
 
   function Header() {
-    return (
-      <View py="small" px="small">
-        <Heading size="small" color="secondary">
-          Recently updated branches
-        </Heading>
-      </View>
-    );
+    if (branches.length > 0) {
+      return (
+        <View py="small" px="small">
+          <Heading size="small" color="secondary">
+            Recently updated branches
+          </Heading>
+        </View>
+      );
+    }
+
+    return null;
   }
 
   function Footer() {
@@ -67,7 +71,13 @@ export function BranchesScreen({ navigation }: BranchesScreenProps) {
   }
 
   function EmptyList() {
-    return <EmptyBranchesMessage branches={branches} incompatibleBranches={incompatibleBranches} />;
+    if (emptyBranches.length === 0) {
+      return (
+        <EmptyBranchesMessage branches={branches} incompatibleBranches={incompatibleBranches} />
+      );
+    }
+
+    return null;
   }
 
   function renderBranch({ index, item: branch }: { index: number; item: Branch }) {

--- a/packages/expo-dev-launcher/bundle/screens/ExtensionsScreen.tsx
+++ b/packages/expo-dev-launcher/bundle/screens/ExtensionsScreen.tsx
@@ -16,7 +16,7 @@ import { ScrollView } from 'react-native-gesture-handler';
 
 import { ActivityIndicator } from '../components/ActivityIndicator';
 import { AppHeader } from '../components/AppHeader';
-import { EASBranchRow } from '../components/EASUpdatesRows';
+import { EASBranchRow, EASEmptyBranchRow } from '../components/EASUpdatesRows';
 import { EmptyBranchesMessage } from '../components/EmptyBranchesMessage';
 import { useUser, useUserActions } from '../providers/UserContextProvider';
 import { useUpdatesConfig } from '../providers/UpdatesConfigProvider';
@@ -154,7 +154,12 @@ export function ExtensionsScreen({ navigation }: ExtensionsScreenProps) {
 
 function EASUpdatesPreview({ navigation }: ExtensionsScreenProps) {
   const { appId } = useUpdatesConfig();
-  const { isLoading, data: branches, incompatibleBranches } = useBranchesForApp(appId);
+  const {
+    isLoading,
+    data: branches,
+    emptyBranches,
+    incompatibleBranches,
+  } = useBranchesForApp(appId);
 
   function onSeeAllBranchesPress() {
     navigation.navigate('Branches');
@@ -168,6 +173,56 @@ function EASUpdatesPreview({ navigation }: ExtensionsScreenProps) {
     return (
       <View height="44" align="centered" mx="medium" rounded="large" bg="default">
         <ActivityIndicator />
+      </View>
+    );
+  }
+
+  if (branches.length === 0 && emptyBranches.length > 0) {
+    return (
+      <View mx="medium">
+        <View py="small" px="small">
+          <Heading size="small" color="secondary">
+            EAS Update
+          </Heading>
+        </View>
+
+        {emptyBranches.slice(0, 3).map((branch, index, arr) => {
+          const isFirst = index === 0;
+          const isLast = index === arr?.length - 1;
+
+          return (
+            <View key={branch.id}>
+              <Button.ScaleOnPressContainer
+                bg="default"
+                onPress={() => onBranchPress(branch.name)}
+                roundedBottom="none"
+                roundedTop={isFirst ? 'large' : 'none'}>
+                <View
+                  bg="default"
+                  roundedTop={isFirst ? 'large' : 'none'}
+                  roundedBottom={isLast ? 'large' : 'none'}
+                  py="small"
+                  px="small">
+                  <EASEmptyBranchRow branch={branch} />
+                </View>
+              </Button.ScaleOnPressContainer>
+              <Divider />
+            </View>
+          );
+        })}
+        <Button.ScaleOnPressContainer
+          onPress={onSeeAllBranchesPress}
+          bg="default"
+          roundedTop="none"
+          roundedBottom="large">
+          <View bg="default" py="small" px="small" roundedTop="none" roundedBottom="large">
+            <Row>
+              <Text size="medium">See all branches</Text>
+              <Spacer.Horizontal />
+              <ChevronRightIcon />
+            </Row>
+          </View>
+        </Button.ScaleOnPressContainer>
       </View>
     );
   }

--- a/packages/expo-dev-launcher/bundle/screens/SettingsScreen.tsx
+++ b/packages/expo-dev-launcher/bundle/screens/SettingsScreen.tsx
@@ -13,12 +13,18 @@ import {
 } from 'expo-dev-client-components';
 import * as React from 'react';
 import { ScrollView, Switch } from 'react-native';
+import { useQueryClient } from 'react-query';
 
+import { Toasts } from '../components/Toasts';
 import { copyToClipboardAsync } from '../native-modules/DevLauncherInternal';
 import { useBuildInfo } from '../providers/BuildInfoProvider';
 import { useDevMenuPreferences } from '../providers/DevMenuPreferencesProvider';
+import { useQueryOptions } from '../providers/QueryProvider';
+import { useToastStack } from '../providers/ToastStackProvider';
+import { useUser } from '../providers/UserContextProvider';
 
 export function SettingsScreen() {
+  const { userData } = useUser();
   const [clipboardError, setClipboardError] = React.useState('');
   const [clipboardContent, setClipboardContent] = React.useState('');
 
@@ -73,7 +79,7 @@ export function SettingsScreen() {
   const hasCopiedContent = Boolean(clipboardContent);
 
   return (
-    <ScrollView testID="DevLauncherSettingsScreen">
+    <ScrollView testID="DevLauncherSettingsScreen" showsVerticalScrollIndicator={false}>
       <View px="medium" mt="8">
         <Heading size="large">Settings</Heading>
       </View>
@@ -190,8 +196,100 @@ export function SettingsScreen() {
               </Text>
             </Row>
           </Button.ScaleOnPressContainer>
+          {userData?.isExpoAdmin && (
+            <>
+              <Spacer.Vertical size="medium" />
+              <DebugSettings />
+            </>
+          )}
         </View>
       </View>
     </ScrollView>
+  );
+}
+
+function DebugSettings() {
+  const queryClient = useQueryClient();
+  const { queryOptions, setQueryOptions } = useQueryOptions();
+  const toastStack = useToastStack();
+
+  function setPageSize(pageSize: number) {
+    setQueryOptions({
+      ...queryOptions,
+      pageSize,
+    });
+  }
+
+  async function onClearQueryPress() {
+    await queryClient.resetQueries();
+    await queryClient.invalidateQueries();
+    toastStack.push(() => <Toasts.Info>Network cache was reset!</Toasts.Info>);
+  }
+
+  const pageSizeOptions = [1, 5, 10];
+
+  return (
+    <View>
+      <View padding="medium">
+        <Heading color="secondary">Debug Settings</Heading>
+      </View>
+
+      <View>
+        <View>
+          <Button.ScaleOnPressContainer
+            bg="default"
+            roundedTop="large"
+            roundedBottom="large"
+            onPress={onClearQueryPress}>
+            <Row px="medium" py="small" align="center" bg="default">
+              <Text size="large" color="default">
+                Clear network cache
+              </Text>
+              <Spacer.Horizontal />
+            </Row>
+          </Button.ScaleOnPressContainer>
+
+          <Spacer.Vertical size="large" />
+
+          <View px="medium">
+            <Heading size="small" color="secondary">
+              Default Page Size
+            </Heading>
+
+            <Text color="secondary" size="small">
+              Sets the number of items fetched for branches and updates
+            </Text>
+          </View>
+          <Spacer.Vertical size="medium" />
+          <View>
+            {pageSizeOptions.map((pageSize, index, arr) => {
+              const isSelected = queryOptions.pageSize === pageSize;
+              const isFirst = index === 0;
+              const isLast = index === arr.length - 1;
+
+              return (
+                <View key={pageSize}>
+                  <Button.ScaleOnPressContainer
+                    bg="default"
+                    roundedTop={isFirst ? 'large' : 'none'}
+                    roundedBottom={isLast ? 'large' : 'none'}
+                    onPress={() => setPageSize(pageSize)}
+                    accessibilityState={{ checked: isSelected }}>
+                    <Row px="medium" py="small" align="center" bg="default">
+                      <Text size="large" color="default">
+                        {pageSize}
+                      </Text>
+                      <Spacer.Horizontal />
+                      {isSelected && <CheckIcon />}
+                    </Row>
+                  </Button.ScaleOnPressContainer>
+                  {!isLast && <Divider />}
+                </View>
+              );
+            })}
+          </View>
+        </View>
+      </View>
+    </View>
   );
 }

--- a/packages/expo-dev-launcher/bundle/screens/__tests__/BranchesScreen.test.tsx
+++ b/packages/expo-dev-launcher/bundle/screens/__tests__/BranchesScreen.test.tsx
@@ -1,9 +1,9 @@
+import { getCompatibleBranchMessage } from '../../components/EmptyBranchesMessage';
 import { queryClient } from '../../providers/QueryProvider';
 import { Branch } from '../../queries/useBranchesForApp';
 import { Update } from '../../queries/useUpdatesForBranch';
 import { render, waitFor, act, fireEvent, mockGraphQLResponse } from '../../test-utils';
 import { BranchesScreen, getIncompatibleBranchMessage } from '../BranchesScreen';
-import { getCompatibleBranchMessage } from '../../components/EmptyBranchesMessage';
 
 jest.mock('graphql-request', () => {
   return {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This PR enable the EAS Updates panel for expo admin users 

It also adds a couple debug options on the settings screen to clear cache and set pagination size (video below demonstrating)  for admin users

This means we can put out a release with the EAS Updates panel even though the feature is not completely finished, and have our team QA / test it out


# How

<!--
How did you build this feature or fix this bug and why?
-->

Updated the user query to check for admin access, and selectively render the extensions panel if they are

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Admin user can see the extensions panel
Non admin user can't see the extensions panel

Video of debug settings: 


https://user-images.githubusercontent.com/40680668/161860604-bfd60fba-c5f8-4730-94d6-f489296b7e4c.mp4



# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
