### PR TITLE
[expo-dev-menu] fix buildscript flavors using 'bundle*' tasks

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fix Android crash when using Hermes on react-native 0.67. ([#16099](https://github.com/expo/expo/pull/16099) by [@kudo](https://github.com/kudo))
 - Fix backwards compatibility with AppDelegate in existing projects. ([#16497](https://github.com/expo/expo/pull/16497) by [@esamelson](https://github.com/esamelson))
 - Fix gradle buildscript compatibility with flavors ([#16686](https://github.com/expo/expo/issues/16686)). ([#16799](https://github.com/expo/expo/pull/16799) by [@esamelson](https://github.com/esamelson))
+- Fix gradle buildscript compatibility for flavors using bundle keyword ([#16686](https://github.com/expo/expo/issues/16686#issuecomment-1088282480)). ([#16936](https://github.com/expo/expo/pull/16936) by [@dogfootruler-kr](https://github.com/dogfootruler-kr))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/android/build.gradle
+++ b/packages/expo-dev-menu/android/build.gradle
@@ -62,6 +62,8 @@ def getCurrentFlavor() {
 
   if (taskRequestName.contains("assemble")) {
     pattern = Pattern.compile("assemble(\\w+)(Release|Debug)")
+  } else if (taskRequestName.contains("bundle")) {
+    pattern = Pattern.compile("bundle(\\w+)(Release|Debug)")
   } else {
     pattern = Pattern.compile("generate(\\w+)(Release|Debug)")
   }


### PR DESCRIPTION
# Why

ref https://github.com/expo/expo/issues/16686#issuecomment-1088282480

The getCurrentFlavor method does not return the flavor if the gradleCommand is using the bundle command instead of assemble or generate

# How

Adding if case for the bundle keyword.

# Test Plan

Tested with the repo provided in https://github.com/expo/expo/issues/16686 -- cloned, yarn install, cd android, ./gradlew :app:bundleDevelopmentDebug.

Before this change, the build failed with the error indicated by OP; after this change, the build succeeded.

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
