### PR TITLE
[iOS] Fix unrecognized symbol `AVMetadataObjectTypeCodabarCode` in Xcode < 13.3 (without iOS 15.4)

### DIFF
--- a/packages/expo-barcode-scanner/ios/EXBarCodeScanner/EXBarCodeScanner.m
+++ b/packages/expo-barcode-scanner/ios/EXBarCodeScanner/EXBarCodeScanner.m
@@ -317,15 +317,11 @@ didOutputSampleBuffer:(CMSampleBufferRef)sampleBuffer
       return AVMetadataObjectTypeCode39Code;
     case kBarcodeFormatCodabar:
 #ifdef __IPHONE_15_4
-      // available in iOS 15.4+
       if (@available(iOS 15.4, *)) {
         return AVMetadataObjectTypeCodabarCode;
-      } else {
-        return @"unknown";
       }
-#else
-      return @"unknown"
 #endif
+      return @"unknown";
     default:
       return @"unknown";
   }

--- a/packages/expo-barcode-scanner/ios/EXBarCodeScanner/EXBarCodeScanner.m
+++ b/packages/expo-barcode-scanner/ios/EXBarCodeScanner/EXBarCodeScanner.m
@@ -41,10 +41,12 @@ NSString *const EX_BARCODE_TYPES_KEY = @"barCodeTypes";
       // Code39 - built-in Code39 reader doesn't read non-ideal (slightly rotated) images like this - https://github.com/expo/expo/pull/5976#issuecomment-545001008
       AVMetadataObjectTypeCode39Code: [ZXCode39Reader new],
     } mutableCopy];
+#ifdef __IPHONE_15_4
     // Codabar - available in iOS 15.4+
     if (@available(iOS 15.4, *)) {
       _zxingBarcodeReaders[AVMetadataObjectTypeCodabarCode] = [ZXCodaBarReader new];
     }
+#endif
     _zxingFPSProcessed = 6;
     _zxingCaptureQueue = dispatch_queue_create("com.zxing.captureQueue", NULL);
     _zxingEnabled = YES;
@@ -314,12 +316,16 @@ didOutputSampleBuffer:(CMSampleBufferRef)sampleBuffer
     case kBarcodeFormatCode39:
       return AVMetadataObjectTypeCode39Code;
     case kBarcodeFormatCodabar:
+#ifdef __IPHONE_15_4
       // available in iOS 15.4+
       if (@available(iOS 15.4, *)) {
         return AVMetadataObjectTypeCodabarCode;
       } else {
         return @"unknown";
       }
+#else
+      return @"unknown"
+#endif
     default:
       return @"unknown";
   }

--- a/packages/expo-barcode-scanner/ios/EXBarCodeScanner/Utilities/EXBarCodeScannerUtils.m
+++ b/packages/expo-barcode-scanner/ios/EXBarCodeScanner/Utilities/EXBarCodeScannerUtils.m
@@ -145,15 +145,11 @@
       return AVMetadataObjectTypeCode39Code;
     case kBarcodeFormatCodabar:
 #ifdef __IPHONE_15_4
-      // available in iOS 15.4+
       if (@available(iOS 15.4, *)) {
         return AVMetadataObjectTypeCodabarCode;
-      } else {
-        return @"unknown";
       }
-#else
-      return @"unknown"
 #endif
+      return @"unknown";
     default:
       return @"unknown";
   }

--- a/packages/expo-barcode-scanner/ios/EXBarCodeScanner/Utilities/EXBarCodeScannerUtils.m
+++ b/packages/expo-barcode-scanner/ios/EXBarCodeScanner/Utilities/EXBarCodeScannerUtils.m
@@ -23,9 +23,11 @@
       @"itf14" : AVMetadataObjectTypeITF14Code,
       @"datamatrix" : AVMetadataObjectTypeDataMatrixCode,
     } mutableCopy];
+#ifdef __IPHONE_15_4
     if (@available(iOS 15.4, *)) {
       validTypes[@"codabar"] = AVMetadataObjectTypeCodabarCode;
     }
+#endif
     return validTypes;
 }
 
@@ -142,12 +144,16 @@
     case kBarcodeFormatCode39:
       return AVMetadataObjectTypeCode39Code;
     case kBarcodeFormatCodabar:
+#ifdef __IPHONE_15_4
       // available in iOS 15.4+
       if (@available(iOS 15.4, *)) {
         return AVMetadataObjectTypeCodabarCode;
       } else {
         return @"unknown";
       }
+#else
+      return @"unknown"
+#endif
     default:
       return @"unknown";
   }


### PR DESCRIPTION
# Why

Our CI is failing on iOS jobs, because it runs on Xcode 13 and we have some codebase that is not available prior Xcode 13.3.
https://github.com/expo/expo/runs/5840230818?check_suite_focus=true
https://exponent-internal.slack.com/archives/CNHBN8LNS/p1649193243758459

# How

I've added macros guarding wrapping the code.

# Test Plan

iOS CIs pass.
