### PR TITLE
Update app-stores.md

### DIFF
--- a/docs/pages/distribution/app-stores.md
+++ b/docs/pages/distribution/app-stores.md
@@ -123,9 +123,9 @@ The keys provided to `locales` should be the [2-letter language code](https://ww
 ```json
 // japanese.json
 {
-  "CFBundleDisplayName": "おい",
+  "CFBundleDisplayName": "こんにちは",
   "NSContactsUsageDescription": "日本語のこれらの言葉"
 }
 ```
 
-Now, iOS knows to set the display name of your app to `おい` whenever it's installed on a device with the language set to Japanese.
+Now, iOS knows to set the display name of your app to `こんにちは` whenever it's installed on a device with the language set to Japanese.

--- a/docs/pages/distribution/app-stores.md
+++ b/docs/pages/distribution/app-stores.md
@@ -113,7 +113,7 @@ If you plan on shipping your app to different countries, regions, or just want i
       }
     },
     "locales": {
-      "ru": "./languages/russian.json"
+      "ja": "./languages/japanese.json"
     }
   }
 ```
@@ -121,11 +121,11 @@ If you plan on shipping your app to different countries, regions, or just want i
 The keys provided to `locales` should be the [2-letter language code](https://www.loc.gov/standards/iso639-2/php/code_list.php) of your desired language, and the value should point to a JSON file that looks something like this:
 
 ```json
-// russian.json
+// japanese.json
 {
-  "CFBundleDisplayName": "Привет",
-  "NSContactsUsageDescription": "Эти слова по русски"
+  "CFBundleDisplayName": "おい",
+  "NSContactsUsageDescription": "日本語のこれらの言葉"
 }
 ```
 
-Now, iOS knows to set the display name of your app to `Привет` whenever it's installed on a device with the language set to Russian.
+Now, iOS knows to set the display name of your app to `おい` whenever it's installed on a device with the language set to Japanese.


### PR DESCRIPTION
Changing the russian locales to Japanese.

# Why

Obvious reasons.

# How
Translating 'Hello' and 'These words in japanase' to japanese and adding them to the file.



# Checklist
- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
