### PR TITLE
[ios] Fix build error on Xcode 13.2

### DIFF
--- a/ios/Exponent/Versioned/Core/Internal/EXScopedModuleRegistry.h
+++ b/ios/Exponent/Versioned/Core/Internal/EXScopedModuleRegistry.h
@@ -1,6 +1,5 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
-#import <React/RCTAccessibilityManager.h> // Keeps this import before RCTBridge.h to fix the error from building React module: `error: definition of 'RCTBridge' must be imported from module 'React.RCTAccessibilityManager' before it is required`
 #import <React/RCTBridge.h>
 #import <React/RCTBridgeModule.h>
 
@@ -54,6 +53,8 @@ RCT_EXTERN void EXRegisterScopedModule(Class, ...); \
 @interface EXScopedModuleRegistry : NSObject <RCTBridgeModule>
 
 @end
+
+@class RCTBridge;
 
 @interface RCTBridge (EXScopedModuleRegistry)
 


### PR DESCRIPTION
# Why

This happens on both Xcode 13.3 and 13.2 👇 
![Screen Shot 2022-04-07 at 11 18 20](https://user-images.githubusercontent.com/1714764/162174640-5d1eab97-4cc5-4ba2-b468-9a5a0dbdfbe9.png)

# How

I noticed there was `#import <React/RCTAccessibilityManager.h>` added to fix similar issue, but I think forwarding declaration of the `RCTBridge` class would be better and it fixes the issue on the latest Xcode.

# Test Plan

Expo Go builds without errors on Xcode 13.2
