### PR TITLE
Update react-native-reanimated to 2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Package-specific changes not released in any SDK will be added here just before 
 - Updated `@react-native-community/react-native-datetimepicker` from `4.0.0` to `6.1.2` ([#16951](https://github.com/expo/expo/pull/16951) by [@brentvatne](https://github.com/brentvatne))
 - Updated `react-native-safe-area-context` from `3.3.2` to `4.2.4`. ([#16939](https://github.com/expo/expo/pull/16939) by [@kudo](https://github.com/kudo))
 - Updated `@stripe/stripe-react-native` from `0.2.3` to `0.6.0`. ([#16938](https://github.com/expo/expo/pull/16938) by [@kudo](https://github.com/kudo))
-- Updated `react-native-reanimated` from `2.4.1` to `2.6.0`.
+- Updated `react-native-reanimated` from `2.4.1` to `2.6.0`. ([#16956](https://github.com/expo/expo/pull/16956) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🛠 Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Package-specific changes not released in any SDK will be added here just before 
 - Updated `@react-native-community/react-native-datetimepicker` from `4.0.0` to `6.1.2` ([#16951](https://github.com/expo/expo/pull/16951) by [@brentvatne](https://github.com/brentvatne))
 - Updated `react-native-safe-area-context` from `3.3.2` to `4.2.4`. ([#16939](https://github.com/expo/expo/pull/16939) by [@kudo](https://github.com/kudo))
 - Updated `@stripe/stripe-react-native` from `0.2.3` to `0.6.0`. ([#16938](https://github.com/expo/expo/pull/16938) by [@kudo](https://github.com/kudo))
-- Updated `react-native-reanimated` from `2.4.1` to `2.6.0`. ([#16956](https://github.com/expo/expo/pull/16956) by [@tsapeta](https://github.com/tsapeta))
+- Updated `react-native-reanimated` from `2.4.1` to `2.7.0`. ([#16956](https://github.com/expo/expo/pull/16956) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🛠 Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Package-specific changes not released in any SDK will be added here just before 
 - Updated `@react-native-community/react-native-datetimepicker` from `4.0.0` to `6.1.2` ([#16951](https://github.com/expo/expo/pull/16951) by [@brentvatne](https://github.com/brentvatne))
 - Updated `react-native-safe-area-context` from `3.3.2` to `4.2.4`. ([#16939](https://github.com/expo/expo/pull/16939) by [@kudo](https://github.com/kudo))
 - Updated `@stripe/stripe-react-native` from `0.2.3` to `0.6.0`. ([#16938](https://github.com/expo/expo/pull/16938) by [@kudo](https://github.com/kudo))
+- Updated `react-native-reanimated` from `2.4.1` to `2.6.0`.
 
 ### 🛠 Breaking changes
 

--- a/android/expoview/CMakeLists.txt
+++ b/android/expoview/CMakeLists.txt
@@ -50,6 +50,7 @@ add_library(
         "./src/main/Common/cpp/Tools/WorkletEventHandler.cpp"
         "./src/main/Common/cpp/Tools/FeaturesConfig.cpp"
         "./src/main/Common/cpp/LayoutAnimations/LayoutAnimationsProxy.cpp"
+        "./src/main/Common/cpp/AnimatedSensor/AnimatedSensorModule.cpp"
 )
 
 # includes
@@ -79,6 +80,7 @@ target_include_directories(
         "./src/main/Common/cpp/headers/NativeModules"
         "./src/main/Common/cpp/headers/SharedItems"
         "./src/main/Common/cpp/headers/Registries"
+        "./src/main/Common/cpp/headers/AnimatedSensor"
         "./src/main/Common/cpp/headers/LayoutAnimations"
         "./src/main/Common/cpp/hidden_headers"
         "./src/main/cpp/headers"

--- a/android/expoview/src/main/Common/cpp/AnimatedSensor/AnimatedSensorModule.cpp
+++ b/android/expoview/src/main/Common/cpp/AnimatedSensor/AnimatedSensorModule.cpp
@@ -1,0 +1,72 @@
+#include "AnimatedSensorModule.h"
+#include "MutableValue.h"
+#include "ValueWrapper.h"
+
+namespace reanimated {
+
+AnimatedSensorModule::AnimatedSensorModule(
+    const PlatformDepMethodsHolder &platformDepMethodsHolder,
+    RuntimeManager *runtimeManager)
+    : platformRegisterSensorFunction_(platformDepMethodsHolder.registerSensor),
+      platformUnregisterSensorFunction_(
+          platformDepMethodsHolder.unregisterSensor),
+      runtimeManager_(runtimeManager) {}
+
+AnimatedSensorModule::~AnimatedSensorModule() {
+  // It is called during app reload because app reload doesn't call hooks
+  // unmounting
+  for (auto sensorId : sensorsIds_) {
+    platformUnregisterSensorFunction_(sensorId);
+  }
+}
+
+jsi::Value AnimatedSensorModule::registerSensor(
+    jsi::Runtime &rt,
+    const jsi::Value &sensorType,
+    const jsi::Value &interval,
+    const jsi::Value &sensorDataContainer) {
+  std::shared_ptr<ShareableValue> sensorsData = ShareableValue::adapt(
+      rt, sensorDataContainer.getObject(rt), runtimeManager_);
+  auto &mutableObject =
+      ValueWrapper::asMutableValue(sensorsData->valueContainer);
+
+  std::function<void(double[])> setter;
+  if (sensorType.asNumber() == SensorType::ROTATION_VECTOR) {
+    setter = [&, mutableObject](double newValues[]) {
+      jsi::Runtime &runtime = *runtimeManager_->runtime.get();
+      jsi::Object value(runtime);
+      value.setProperty(runtime, "qw", newValues[0]);
+      value.setProperty(runtime, "qx", newValues[1]);
+      value.setProperty(runtime, "qy", newValues[2]);
+      value.setProperty(runtime, "qz", newValues[3]);
+      value.setProperty(runtime, "yaw", newValues[4]);
+      value.setProperty(runtime, "pitch", newValues[5]);
+      value.setProperty(runtime, "roll", newValues[6]);
+      mutableObject->setValue(runtime, std::move(value));
+    };
+  } else {
+    setter = [&, mutableObject](double newValues[]) {
+      jsi::Runtime &runtime = *runtimeManager_->runtime.get();
+      jsi::Object value(runtime);
+      value.setProperty(runtime, "x", newValues[0]);
+      value.setProperty(runtime, "y", newValues[1]);
+      value.setProperty(runtime, "z", newValues[2]);
+      mutableObject->setValue(runtime, std::move(value));
+    };
+  }
+
+  int sensorId = platformRegisterSensorFunction_(
+      sensorType.asNumber(), interval.asNumber(), setter);
+  if (sensorId != -1) {
+    sensorsIds_.insert(sensorId);
+  }
+  return jsi::Value(sensorId);
+}
+
+void AnimatedSensorModule::unregisterSensor(const jsi::Value &sensorId) {
+  // It is called during sensor hook unmounting
+  sensorsIds_.erase(sensorId.getNumber());
+  platformUnregisterSensorFunction_(sensorId.asNumber());
+}
+
+} // namespace reanimated

--- a/android/expoview/src/main/Common/cpp/NativeModules/NativeReanimatedModuleSpec.cpp
+++ b/android/expoview/src/main/Common/cpp/NativeModules/NativeReanimatedModuleSpec.cpp
@@ -1,9 +1,10 @@
 #include "NativeReanimatedModuleSpec.h"
 
+#define SPEC_PREFIX(FN_NAME) __hostFunction_NativeReanimatedModuleSpec_##FN_NAME
+
 namespace reanimated {
 
-static jsi::Value
-__hostFunction_NativeReanimatedModuleSpec_installCoreFunctions(
+static jsi::Value SPEC_PREFIX(installCoreFunctions)(
     jsi::Runtime &rt,
     TurboModule &turboModule,
     const jsi::Value *args,
@@ -15,7 +16,7 @@ __hostFunction_NativeReanimatedModuleSpec_installCoreFunctions(
 
 // SharedValue
 
-static jsi::Value __hostFunction_NativeReanimatedModuleSpec_makeShareable(
+static jsi::Value SPEC_PREFIX(makeShareable)(
     jsi::Runtime &rt,
     TurboModule &turboModule,
     const jsi::Value *args,
@@ -24,7 +25,7 @@ static jsi::Value __hostFunction_NativeReanimatedModuleSpec_makeShareable(
       ->makeShareable(rt, std::move(args[0]));
 }
 
-static jsi::Value __hostFunction_NativeReanimatedModuleSpec_makeMutable(
+static jsi::Value SPEC_PREFIX(makeMutable)(
     jsi::Runtime &rt,
     TurboModule &turboModule,
     const jsi::Value *args,
@@ -33,7 +34,7 @@ static jsi::Value __hostFunction_NativeReanimatedModuleSpec_makeMutable(
       ->makeMutable(rt, std::move(args[0]));
 }
 
-static jsi::Value __hostFunction_NativeReanimatedModuleSpec_makeRemote(
+static jsi::Value SPEC_PREFIX(makeRemote)(
     jsi::Runtime &rt,
     TurboModule &turboModule,
     const jsi::Value *args,
@@ -42,7 +43,7 @@ static jsi::Value __hostFunction_NativeReanimatedModuleSpec_makeRemote(
       ->makeRemote(rt, std::move(args[0]));
 }
 
-static jsi::Value __hostFunction_NativeReanimatedModuleSpec_startMapper(
+static jsi::Value SPEC_PREFIX(startMapper)(
     jsi::Runtime &rt,
     TurboModule &turboModule,
     const jsi::Value *args,
@@ -57,7 +58,7 @@ static jsi::Value __hostFunction_NativeReanimatedModuleSpec_startMapper(
           std::move(args[4]));
 }
 
-static jsi::Value __hostFunction_NativeReanimatedModuleSpec_stopMapper(
+static jsi::Value SPEC_PREFIX(stopMapper)(
     jsi::Runtime &rt,
     TurboModule &turboModule,
     const jsi::Value *args,
@@ -67,8 +68,7 @@ static jsi::Value __hostFunction_NativeReanimatedModuleSpec_stopMapper(
   return jsi::Value::undefined();
 }
 
-static jsi::Value
-__hostFunction_NativeReanimatedModuleSpec_registerEventHandler(
+static jsi::Value SPEC_PREFIX(registerEventHandler)(
     jsi::Runtime &rt,
     TurboModule &turboModule,
     const jsi::Value *args,
@@ -77,8 +77,7 @@ __hostFunction_NativeReanimatedModuleSpec_registerEventHandler(
       ->registerEventHandler(rt, std::move(args[0]), std::move(args[1]));
 }
 
-static jsi::Value
-__hostFunction_NativeReanimatedModuleSpec_unregisterEventHandler(
+static jsi::Value SPEC_PREFIX(unregisterEventHandler)(
     jsi::Runtime &rt,
     TurboModule &turboModule,
     const jsi::Value *args,
@@ -88,7 +87,7 @@ __hostFunction_NativeReanimatedModuleSpec_unregisterEventHandler(
   return jsi::Value::undefined();
 }
 
-static jsi::Value __hostFunction_NativeReanimatedModuleSpec_getViewProp(
+static jsi::Value SPEC_PREFIX(getViewProp)(
     jsi::Runtime &rt,
     TurboModule &turboModule,
     const jsi::Value *args,
@@ -99,8 +98,7 @@ static jsi::Value __hostFunction_NativeReanimatedModuleSpec_getViewProp(
   return jsi::Value::undefined();
 }
 
-static jsi::Value
-__hostFunction_NativeReanimatedModuleSpec_enableLayoutAnimations(
+static jsi::Value SPEC_PREFIX(enableLayoutAnimations)(
     jsi::Runtime &rt,
     TurboModule &turboModule,
     const jsi::Value *args,
@@ -110,33 +108,60 @@ __hostFunction_NativeReanimatedModuleSpec_enableLayoutAnimations(
   return jsi::Value::undefined();
 }
 
+static jsi::Value SPEC_PREFIX(registerSensor)(
+    jsi::Runtime &rt,
+    TurboModule &turboModule,
+    const jsi::Value *args,
+    size_t count) {
+  return static_cast<NativeReanimatedModuleSpec *>(&turboModule)
+      ->registerSensor(
+          rt, std::move(args[0]), std::move(args[1]), std::move(args[2]));
+}
+
+static jsi::Value SPEC_PREFIX(unregisterSensor)(
+    jsi::Runtime &rt,
+    TurboModule &turboModule,
+    const jsi::Value *args,
+    size_t count) {
+  static_cast<NativeReanimatedModuleSpec *>(&turboModule)
+      ->unregisterSensor(rt, std::move(args[0]));
+  return jsi::Value::undefined();
+}
+
+static jsi::Value SPEC_PREFIX(configureProps)(
+    jsi::Runtime &rt,
+    TurboModule &turboModule,
+    const jsi::Value *args,
+    size_t count) {
+  static_cast<NativeReanimatedModuleSpec *>(&turboModule)
+      ->configureProps(rt, std::move(args[0]), std::move(args[1]));
+  return jsi::Value::undefined();
+}
+
 NativeReanimatedModuleSpec::NativeReanimatedModuleSpec(
     std::shared_ptr<CallInvoker> jsInvoker)
     : TurboModule("NativeReanimated", jsInvoker) {
-  methodMap_["installCoreFunctions"] = MethodMetadata{
-      1, __hostFunction_NativeReanimatedModuleSpec_installCoreFunctions};
+  methodMap_["installCoreFunctions"] =
+      MethodMetadata{1, SPEC_PREFIX(installCoreFunctions)};
 
-  methodMap_["makeShareable"] = MethodMetadata{
-      1, __hostFunction_NativeReanimatedModuleSpec_makeShareable};
-  methodMap_["makeMutable"] =
-      MethodMetadata{1, __hostFunction_NativeReanimatedModuleSpec_makeMutable};
-  methodMap_["makeRemote"] =
-      MethodMetadata{1, __hostFunction_NativeReanimatedModuleSpec_makeRemote};
+  methodMap_["makeShareable"] = MethodMetadata{1, SPEC_PREFIX(makeShareable)};
+  methodMap_["makeMutable"] = MethodMetadata{1, SPEC_PREFIX(makeMutable)};
+  methodMap_["makeRemote"] = MethodMetadata{1, SPEC_PREFIX(makeRemote)};
 
-  methodMap_["startMapper"] =
-      MethodMetadata{5, __hostFunction_NativeReanimatedModuleSpec_startMapper};
-  methodMap_["stopMapper"] =
-      MethodMetadata{1, __hostFunction_NativeReanimatedModuleSpec_stopMapper};
+  methodMap_["startMapper"] = MethodMetadata{5, SPEC_PREFIX(startMapper)};
+  methodMap_["stopMapper"] = MethodMetadata{1, SPEC_PREFIX(stopMapper)};
 
-  methodMap_["registerEventHandler"] = MethodMetadata{
-      2, __hostFunction_NativeReanimatedModuleSpec_registerEventHandler};
-  methodMap_["unregisterEventHandler"] = MethodMetadata{
-      1, __hostFunction_NativeReanimatedModuleSpec_unregisterEventHandler};
+  methodMap_["registerEventHandler"] =
+      MethodMetadata{2, SPEC_PREFIX(registerEventHandler)};
+  methodMap_["unregisterEventHandler"] =
+      MethodMetadata{1, SPEC_PREFIX(unregisterEventHandler)};
 
-  methodMap_["getViewProp"] =
-      MethodMetadata{3, __hostFunction_NativeReanimatedModuleSpec_getViewProp};
-  methodMap_["enableLayoutAnimations"] = MethodMetadata{
-      2, __hostFunction_NativeReanimatedModuleSpec_enableLayoutAnimations};
+  methodMap_["getViewProp"] = MethodMetadata{3, SPEC_PREFIX(getViewProp)};
+  methodMap_["enableLayoutAnimations"] =
+      MethodMetadata{2, SPEC_PREFIX(enableLayoutAnimations)};
+  methodMap_["registerSensor"] = MethodMetadata{3, SPEC_PREFIX(registerSensor)};
+  methodMap_["unregisterSensor"] =
+      MethodMetadata{1, SPEC_PREFIX(unregisterSensor)};
+  methodMap_["configureProps"] = MethodMetadata{2, SPEC_PREFIX(configureProps)};
 }
-
 } // namespace reanimated

--- a/android/expoview/src/main/Common/cpp/SharedItems/ShareableValue.cpp
+++ b/android/expoview/src/main/Common/cpp/SharedItems/ShareableValue.cpp
@@ -64,7 +64,7 @@ void ShareableValue::adapt(
       jsi::Object hiddenProperty = hiddenValue.asObject(rt);
       if (hiddenProperty.isHostObject<FrozenObject>(rt)) {
         type = ValueType::FrozenObjectType;
-        if (object.hasProperty(rt, "__worklet") && object.isFunction(rt)) {
+        if (object.hasProperty(rt, "__workletHash") && object.isFunction(rt)) {
           type = ValueType::WorkletFunctionType;
         }
         valueContainer = std::make_unique<FrozenObjectWrapper>(
@@ -99,7 +99,7 @@ void ShareableValue::adapt(
   } else if (value.isObject()) {
     auto object = value.asObject(rt);
     if (object.isFunction(rt)) {
-      if (object.getProperty(rt, "__worklet").isUndefined()) {
+      if (object.getProperty(rt, "__workletHash").isUndefined()) {
         // not a worklet, we treat this as a host function
         type = ValueType::HostFunctionType;
         containsHostFunction = true;

--- a/android/expoview/src/main/Common/cpp/Tools/RuntimeDecorator.cpp
+++ b/android/expoview/src/main/Common/cpp/Tools/RuntimeDecorator.cpp
@@ -31,20 +31,6 @@ void RuntimeDecorator::decorateRuntime(
       rt, "_LABEL", jsi::String::createFromAscii(rt, label));
 
   jsi::Object dummyGlobal(rt);
-  auto dummyFunction = [](jsi::Runtime &rt,
-                          const jsi::Value &thisValue,
-                          const jsi::Value *args,
-                          size_t count) -> jsi::Value {
-    return jsi::Value::undefined();
-  };
-  jsi::Function __reanimatedWorkletInit = jsi::Function::createFromHostFunction(
-      rt,
-      jsi::PropNameID::forAscii(rt, "__reanimatedWorkletInit"),
-      1,
-      dummyFunction);
-
-  dummyGlobal.setProperty(
-      rt, "__reanimatedWorkletInit", __reanimatedWorkletInit);
   rt.global().setProperty(rt, "global", dummyGlobal);
 
   rt.global().setProperty(rt, "jsThis", jsi::Value::undefined());

--- a/android/expoview/src/main/Common/cpp/Tools/RuntimeDecorator.cpp
+++ b/android/expoview/src/main/Common/cpp/Tools/RuntimeDecorator.cpp
@@ -109,6 +109,8 @@ void RuntimeDecorator::decorateUIRuntime(
     const ScrollToFunction scrollTo,
     const MeasuringFunction measure,
     const TimeProviderFunction getCurrentTime,
+    const RegisterSensorFunction registerSensor,
+    const UnregisterSensorFunction unregisterSensor,
     const SetGestureStateFunction setGestureState,
     std::shared_ptr<LayoutAnimationsProxy> layoutAnimationsProxy) {
   RuntimeDecorator::decorateRuntime(rt, "UI");

--- a/android/expoview/src/main/Common/cpp/headers/AnimatedSensor/AnimatedSensorModule.h
+++ b/android/expoview/src/main/Common/cpp/headers/AnimatedSensor/AnimatedSensorModule.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <jsi/jsi.h>
+#include <unordered_set>
+
+#include "PlatformDepMethodsHolder.h"
+#include "RuntimeManager.h"
+
+namespace reanimated {
+
+using namespace facebook;
+
+enum SensorType {
+  ACCELEROMETER = 1,
+  GYROSCOPE = 2,
+  GRAVITY = 3,
+  MAGNETIC_FIELD = 4,
+  ROTATION_VECTOR = 5,
+};
+
+class AnimatedSensorModule {
+  std::unordered_set<int> sensorsIds_;
+  RegisterSensorFunction platformRegisterSensorFunction_;
+  UnregisterSensorFunction platformUnregisterSensorFunction_;
+  RuntimeManager *runtimeManager_;
+
+ public:
+  AnimatedSensorModule(
+      const PlatformDepMethodsHolder &platformDepMethodsHolder,
+      RuntimeManager *runtimeManager);
+  ~AnimatedSensorModule();
+
+  jsi::Value registerSensor(
+      jsi::Runtime &rt,
+      const jsi::Value &sensorType,
+      const jsi::Value &interval,
+      const jsi::Value &sensorDataContainer);
+  void unregisterSensor(const jsi::Value &sensorId);
+};
+
+} // namespace reanimated

--- a/android/expoview/src/main/Common/cpp/headers/NativeModules/NativeReanimatedModule.h
+++ b/android/expoview/src/main/Common/cpp/headers/NativeModules/NativeReanimatedModule.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 
+#include "AnimatedSensorModule.h"
 #include "ErrorHandler.h"
 #include "LayoutAnimationsProxy.h"
 #include "NativeReanimatedModuleSpec.h"
@@ -70,6 +71,10 @@ class NativeReanimatedModule : public NativeReanimatedModuleSpec,
 
   jsi::Value enableLayoutAnimations(jsi::Runtime &rt, const jsi::Value &config)
       override;
+  jsi::Value configureProps(
+      jsi::Runtime &rt,
+      const jsi::Value &uiProps,
+      const jsi::Value &nativeProps) override;
 
   void onRender(double timestampMs);
   void onEvent(std::string eventName, std::string eventAsString);
@@ -77,6 +82,13 @@ class NativeReanimatedModule : public NativeReanimatedModuleSpec,
 
   void maybeRequestRender();
   UpdaterFunction updaterFunction;
+
+  jsi::Value registerSensor(
+      jsi::Runtime &rt,
+      const jsi::Value &sensorType,
+      const jsi::Value &interval,
+      const jsi::Value &sensorDataContainer) override;
+  void unregisterSensor(jsi::Runtime &rt, const jsi::Value &sensorId) override;
 
  private:
   std::shared_ptr<MapperRegistry> mapperRegistry;
@@ -89,6 +101,8 @@ class NativeReanimatedModule : public NativeReanimatedModuleSpec,
       propObtainer;
   std::function<void(double)> onRenderCallback;
   std::shared_ptr<LayoutAnimationsProxy> layoutAnimationsProxy;
+  AnimatedSensorModule animatedSensorModule;
+  ConfigurePropsFunction configurePropsPlatformFunction;
 };
 
 } // namespace reanimated

--- a/android/expoview/src/main/Common/cpp/headers/NativeModules/NativeReanimatedModuleSpec.h
+++ b/android/expoview/src/main/Common/cpp/headers/NativeModules/NativeReanimatedModuleSpec.h
@@ -59,10 +59,24 @@ class JSI_EXPORT NativeReanimatedModuleSpec : public TurboModule {
       const jsi::Value &propName,
       const jsi::Value &callback) = 0;
 
+  // sensors
+  virtual jsi::Value registerSensor(
+      jsi::Runtime &rt,
+      const jsi::Value &sensorType,
+      const jsi::Value &interval,
+      const jsi::Value &sensorDataContainer) = 0;
+  virtual void unregisterSensor(
+      jsi::Runtime &rt,
+      const jsi::Value &sensorId) = 0;
+
   // other
   virtual jsi::Value enableLayoutAnimations(
       jsi::Runtime &rt,
       const jsi::Value &config) = 0;
+  virtual jsi::Value configureProps(
+      jsi::Runtime &rt,
+      const jsi::Value &uiProps,
+      const jsi::Value &nativeProps) = 0;
 };
 
 } // namespace reanimated

--- a/android/expoview/src/main/Common/cpp/headers/SharedItems/MutableValue.h
+++ b/android/expoview/src/main/Common/cpp/headers/SharedItems/MutableValue.h
@@ -20,13 +20,16 @@ class MutableValue : public jsi::HostObject,
                      public StoreUser {
  private:
   friend MutableValueSetterProxy;
-  RuntimeManager *runtimeManager;
   friend LayoutAnimationsProxy;
+
+ private:
+  RuntimeManager *runtimeManager;
   std::mutex readWriteMutex;
   std::shared_ptr<ShareableValue> value;
   std::weak_ptr<jsi::Value> animation;
   std::map<unsigned long, std::function<void()>> listeners;
 
+ public:
   void setValue(jsi::Runtime &rt, const jsi::Value &newValue);
   jsi::Value getValue(jsi::Runtime &rt);
 

--- a/android/expoview/src/main/Common/cpp/headers/SharedItems/ShareableValue.h
+++ b/android/expoview/src/main/Common/cpp/headers/SharedItems/ShareableValue.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include "AnimatedSensorModule.h"
 #include "HostFunctionHandler.h"
 #include "JSIStoreValueUser.h"
 #include "LayoutAnimationsProxy.h"
@@ -24,6 +25,8 @@ class ShareableValue : public std::enable_shared_from_this<ShareableValue>,
   friend WorkletsCache;
   friend FrozenObject;
   friend LayoutAnimationsProxy;
+  friend NativeReanimatedModule;
+  friend AnimatedSensorModule;
   friend void extractMutables(
       jsi::Runtime &rt,
       std::shared_ptr<ShareableValue> sv,

--- a/android/expoview/src/main/Common/cpp/headers/SharedItems/ValueWrapper.h
+++ b/android/expoview/src/main/Common/cpp/headers/SharedItems/ValueWrapper.h
@@ -12,8 +12,11 @@
 namespace reanimated {
 
 class HostFunctionWrapper;
+class AnimatedSensorModule;
 
 class ValueWrapper {
+  friend AnimatedSensorModule;
+
  public:
   ValueWrapper() {}
   explicit ValueWrapper(ValueType _type) : type(_type) {}

--- a/android/expoview/src/main/Common/cpp/headers/Tools/PlatformDepMethodsHolder.h
+++ b/android/expoview/src/main/Common/cpp/headers/Tools/PlatformDepMethodsHolder.h
@@ -21,7 +21,15 @@ using ScrollToFunction = std::function<void(int, double, double, bool)>;
 using MeasuringFunction =
     std::function<std::vector<std::pair<std::string, double>>(int)>;
 using TimeProviderFunction = std::function<double(void)>;
+
+using RegisterSensorFunction =
+    std::function<int(int, int, std::function<void(double[])>)>;
+using UnregisterSensorFunction = std::function<void(int)>;
 using SetGestureStateFunction = std::function<void(int, int)>;
+using ConfigurePropsFunction = std::function<void(
+    jsi::Runtime &rt,
+    const jsi::Value &uiProps,
+    const jsi::Value &nativeProps)>;
 
 struct PlatformDepMethodsHolder {
   RequestRender requestRender;
@@ -29,7 +37,10 @@ struct PlatformDepMethodsHolder {
   ScrollToFunction scrollToFunction;
   MeasuringFunction measuringFunction;
   TimeProviderFunction getCurrentTime;
+  RegisterSensorFunction registerSensor;
+  UnregisterSensorFunction unregisterSensor;
   SetGestureStateFunction setGestureStateFunction;
+  ConfigurePropsFunction configurePropsFunction;
 };
 
 } // namespace reanimated

--- a/android/expoview/src/main/Common/cpp/headers/Tools/RuntimeDecorator.h
+++ b/android/expoview/src/main/Common/cpp/headers/Tools/RuntimeDecorator.h
@@ -36,6 +36,8 @@ class RuntimeDecorator {
       const ScrollToFunction scrollTo,
       const MeasuringFunction measure,
       const TimeProviderFunction getCurrentTime,
+      const RegisterSensorFunction registerSensor,
+      const UnregisterSensorFunction unregisterSensor,
       const SetGestureStateFunction setGestureState,
       std::shared_ptr<LayoutAnimationsProxy> layoutAnimationsProxy);
 

--- a/android/expoview/src/main/cpp/NativeProxy.cpp
+++ b/android/expoview/src/main/cpp/NativeProxy.cpp
@@ -67,7 +67,7 @@ void NativeProxy::installJSIBindings() {
 
   auto getCurrentTime = [this]() {
     auto method =
-        javaPart_->getClass()->getMethod<local_ref<JString>()>("getUpTime");
+        javaPart_->getClass()->getMethod<local_ref<JString>()>("getUptime");
     local_ref<JString> output = method(javaPart_.get());
     return static_cast<double>(
         std::strtoll(output->toStdString().c_str(), NULL, 10));
@@ -117,13 +117,23 @@ void NativeProxy::installJSIBindings() {
     scrollTo(viewTag, x, y, animated);
   };
 
+  auto registerSensorFunction =
+      [this](int sensorType, int interval, std::function<void(double[])> setter)
+      -> int {
+    return this->registerSensor(sensorType, interval, std::move(setter));
+  };
+  auto unregisterSensorFunction = [this](int sensorId) {
+    unregisterSensor(sensorId);
+  };
+
   auto setGestureStateFunction = [this](int handlerTag, int newState) -> void {
     setGestureState(handlerTag, newState);
   };
-
 #if FOR_HERMES
+  auto config =
+      ::hermes::vm::RuntimeConfig::Builder().withEnableSampleProfiling(false);
   std::shared_ptr<jsi::Runtime> animatedRuntime =
-      jsc::makeJSCRuntime();
+      facebook::hermes::makeHermesRuntime(config.build());
 #else
   std::shared_ptr<jsi::Runtime> animatedRuntime =
       facebook::jsc::makeJSCRuntime();
@@ -147,6 +157,12 @@ void NativeProxy::installJSIBindings() {
     this->layoutAnimations->cthis()->notifyAboutEnd(tag, (isCancelled) ? 1 : 0);
   };
 
+  auto configurePropsFunction = [=](jsi::Runtime &rt,
+                                    const jsi::Value &uiProps,
+                                    const jsi::Value &nativeProps) {
+    this->configureProps(rt, uiProps, nativeProps);
+  };
+
   std::shared_ptr<LayoutAnimationsProxy> layoutAnimationsProxy =
       std::make_shared<LayoutAnimationsProxy>(
           notifyAboutProgress, notifyAboutEnd);
@@ -161,8 +177,10 @@ void NativeProxy::installJSIBindings() {
       scrollToFunction,
       measuringFunction,
       getCurrentTime,
+      registerSensorFunction,
+      unregisterSensorFunction,
       setGestureStateFunction,
-  };
+      configurePropsFunction};
 
   auto module = std::make_shared<NativeReanimatedModule>(
       jsCallInvoker_,
@@ -264,10 +282,46 @@ std::vector<std::pair<std::string, double>> NativeProxy::measure(int viewTag) {
   return result;
 }
 
+int NativeProxy::registerSensor(
+    int sensorType,
+    int interval,
+    std::function<void(double[])> setter) {
+  static auto method =
+      javaPart_->getClass()->getMethod<int(int, int, SensorSetter::javaobject)>(
+          "registerSensor");
+  return method(
+      javaPart_.get(),
+      sensorType,
+      interval,
+      SensorSetter::newObjectCxxArgs(std::move(setter)).get());
+}
+void NativeProxy::unregisterSensor(int sensorId) {
+  auto method = javaPart_->getClass()->getMethod<void(int)>("unregisterSensor");
+  method(javaPart_.get(), sensorId);
+}
+
 void NativeProxy::setGestureState(int handlerTag, int newState) {
   auto method =
       javaPart_->getClass()->getMethod<void(int, int)>("setGestureState");
   method(javaPart_.get(), handlerTag, newState);
+}
+
+void NativeProxy::configureProps(
+    jsi::Runtime &rt,
+    const jsi::Value &uiProps,
+    const jsi::Value &nativeProps) {
+  auto method = javaPart_->getClass()
+                    ->getMethod<void(
+                        ReadableNativeArray::javaobject,
+                        ReadableNativeArray::javaobject)>("configureProps");
+  method(
+      javaPart_.get(),
+      ReadableNativeArray::newObjectCxxArgs(
+          std::move(jsi::dynamicFromValue(rt, uiProps)))
+          .get(),
+      ReadableNativeArray::newObjectCxxArgs(
+          std::move(jsi::dynamicFromValue(rt, nativeProps)))
+          .get());
 }
 
 } // namespace reanimated

--- a/android/expoview/src/main/cpp/OnLoad.cpp
+++ b/android/expoview/src/main/cpp/OnLoad.cpp
@@ -12,5 +12,6 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *) {
     reanimated::EventHandler::registerNatives();
     reanimated::AndroidScheduler::registerNatives();
     reanimated::LayoutAnimations::registerNatives();
+    reanimated::SensorSetter::registerNatives();
   });
 }

--- a/android/expoview/src/main/cpp/headers/NativeProxy.h
+++ b/android/expoview/src/main/cpp/headers/NativeProxy.h
@@ -60,7 +60,15 @@ class EventHandler : public HybridClass<EventHandler> {
       jni::alias_ref<react::WritableMap> event) {
     std::string eventAsString = "{NativeMap:null}";
     if (event != nullptr) {
-      eventAsString = event->toString();
+      try {
+        eventAsString = event->toString();
+      } catch (std::exception &) {
+        // Events from other libraries may contain NaN or INF values which
+        // cannot be represented in JSON. See
+        // https://github.com/software-mansion/react-native-reanimated/issues/1776
+        // for details.
+        return;
+      }
     }
     handler_(eventKey->toString(), eventAsString);
   }
@@ -78,6 +86,36 @@ class EventHandler : public HybridClass<EventHandler> {
       : handler_(std::move(handler)) {}
 
   std::function<void(std::string, std::string)> handler_;
+};
+
+class SensorSetter : public HybridClass<SensorSetter> {
+ public:
+  static auto constexpr kJavaDescriptor =
+      "Lversioned/host/exp/exponent/modules/api/reanimated/NativeProxy$SensorSetter;";
+
+  void sensorSetter(jni::alias_ref<JArrayFloat> value) {
+    size_t size = value->size();
+    auto elements = value->getRegion(0, size);
+    double array[7];
+    for (int i = 0; i < size; i++) {
+      array[i] = elements[i];
+    }
+    callback_(array);
+  }
+
+  static void registerNatives() {
+    javaClassStatic()->registerNatives({
+        makeNativeMethod("sensorSetter", SensorSetter::sensorSetter),
+    });
+  }
+
+ private:
+  friend HybridBase;
+
+  explicit SensorSetter(std::function<void(double[])> callback)
+      : callback_(std::move(callback)) {}
+
+  std::function<void(double[])> callback_;
 };
 
 class NativeProxy : public jni::HybridClass<NativeProxy> {
@@ -111,6 +149,15 @@ class NativeProxy : public jni::HybridClass<NativeProxy> {
   void scrollTo(int viewTag, double x, double y, bool animated);
   void setGestureState(int handlerTag, int newState);
   std::vector<std::pair<std::string, double>> measure(int viewTag);
+  int registerSensor(
+      int sensorType,
+      int interval,
+      std::function<void(double[])> setter);
+  void unregisterSensor(int sensorId);
+  void configureProps(
+      jsi::Runtime &rt,
+      const jsi::Value &uiProps,
+      const jsi::Value &nativeProps);
 
   explicit NativeProxy(
       jni::alias_ref<NativeProxy::jhybridobject> jThis,

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/reanimated/NativeProxy.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/reanimated/NativeProxy.java
@@ -1,13 +1,17 @@
 package versioned.host.exp.exponent.modules.api.reanimated;
 
 import android.os.SystemClock;
+import android.util.Log;
 import androidx.annotation.Nullable;
 import com.facebook.jni.HybridData;
 import com.facebook.proguard.annotations.DoNotStrip;
+import com.facebook.react.ReactApplication;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReadableNativeArray;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.devsupport.interfaces.DevSupportManager;
 import com.facebook.react.turbomodule.core.CallInvokerHolderImpl;
 import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
@@ -15,9 +19,14 @@ import versioned.host.exp.exponent.modules.api.components.gesturehandler.Gesture
 import versioned.host.exp.exponent.modules.api.reanimated.layoutReanimation.AnimationsManager;
 import versioned.host.exp.exponent.modules.api.reanimated.layoutReanimation.LayoutAnimations;
 import versioned.host.exp.exponent.modules.api.reanimated.layoutReanimation.NativeMethodsHolder;
+import versioned.host.exp.exponent.modules.api.reanimated.sensor.ReanimatedSensorContainer;
+import versioned.host.exp.exponent.modules.api.reanimated.sensor.ReanimatedSensorType;
 import java.lang.ref.WeakReference;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 public class NativeProxy {
 
@@ -66,13 +75,29 @@ public class NativeProxy {
   }
 
   @DoNotStrip
+  public static class SensorSetter {
+
+    @DoNotStrip private final HybridData mHybridData;
+
+    @DoNotStrip
+    private SensorSetter(HybridData hybridData) {
+      mHybridData = hybridData;
+    }
+
+    public native void sensorSetter(float[] value);
+  }
+
+  @DoNotStrip
   @SuppressWarnings("unused")
   private final HybridData mHybridData;
 
   private NodesManager mNodesManager;
   private final WeakReference<ReactApplicationContext> mContext;
   private Scheduler mScheduler = null;
+  private ReanimatedSensorContainer reanimatedSensorContainer;
   private final GestureHandlerStateManager gestureHandlerStateManager;
+  private Long firstUptime = SystemClock.uptimeMillis();
+  private boolean slowAnimationsEnabled = false;
 
   public NativeProxy(ReactApplicationContext context) {
     CallInvokerHolderImpl holder =
@@ -84,6 +109,8 @@ public class NativeProxy {
             context.getJavaScriptContextHolder().get(), holder, mScheduler, LayoutAnimations);
     mContext = new WeakReference<>(context);
     prepare(LayoutAnimations);
+    reanimatedSensorContainer = new ReanimatedSensorContainer(mContext);
+    addDevMenuOption();
 
     GestureHandlerStateManager tempHandlerStateManager;
     try {
@@ -110,6 +137,24 @@ public class NativeProxy {
 
   public Scheduler getScheduler() {
     return mScheduler;
+  }
+
+  private void toggleSlowAnimations() {
+    slowAnimationsEnabled = !slowAnimationsEnabled;
+    if (slowAnimationsEnabled) {
+      firstUptime = SystemClock.uptimeMillis();
+    }
+  }
+
+  private void addDevMenuOption() {
+    final DevSupportManager devSupportManager =
+        ((ReactApplication) mContext.get().getApplicationContext())
+            .getReactNativeHost()
+            .getReactInstanceManager()
+            .getDevSupportManager();
+
+    devSupportManager.addCustomDevOption(
+        "Toggle slow animations (Reanimated)", this::toggleSlowAnimations);
   }
 
   @DoNotStrip
@@ -140,8 +185,15 @@ public class NativeProxy {
   }
 
   @DoNotStrip
-  private String getUpTime() {
-    return Long.toString(SystemClock.uptimeMillis());
+  private String getUptime() {
+    if (slowAnimationsEnabled) {
+      final long ANIMATIONS_DRAG_FACTOR = 10;
+      return Long.toString(
+          this.firstUptime
+              + (SystemClock.uptimeMillis() - this.firstUptime) / ANIMATIONS_DRAG_FACTOR);
+    } else {
+      return Long.toString(SystemClock.uptimeMillis());
+    }
   }
 
   @DoNotStrip
@@ -150,9 +202,36 @@ public class NativeProxy {
   }
 
   @DoNotStrip
+  private void configureProps(ReadableNativeArray uiProps, ReadableNativeArray nativeProps) {
+    Set<String> uiPropsSet = convertProps(uiProps);
+    Set<String> nativePropsSet = convertProps(nativeProps);
+    mNodesManager.configureProps(uiPropsSet, nativePropsSet);
+  }
+
+  private Set<String> convertProps(ReadableNativeArray props) {
+    Set<String> propsSet = new HashSet<>();
+    ArrayList<Object> propsList = props.toArrayList();
+    for (int i = 0; i < propsList.size(); i++) {
+      propsSet.add((String) propsList.get(i));
+    }
+    return propsSet;
+  }
+
+  @DoNotStrip
   private void registerEventHandler(EventHandler handler) {
     handler.mCustomEventNamesResolver = mNodesManager.getEventNameResolver();
     mNodesManager.registerEventHandler(handler);
+  }
+
+  @DoNotStrip
+  private int registerSensor(int sensorType, int interval, SensorSetter setter) {
+    return reanimatedSensorContainer.registerSensor(
+        ReanimatedSensorType.getInstanceById(sensorType), interval, setter);
+  }
+
+  @DoNotStrip
+  private void unregisterSensor(int sensorId) {
+    reanimatedSensorContainer.unregisterSensor(sensorId);
   }
 
   public void onCatalystInstanceDestroy() {
@@ -161,6 +240,10 @@ public class NativeProxy {
   }
 
   public void prepare(LayoutAnimations LayoutAnimations) {
+    if (Utils.isChromeDebugger) {
+      Log.w("[REANIMATED]", "You can not use LayoutAnimation with enabled Chrome Debugger");
+      return;
+    }
     mNodesManager = mContext.get().getNativeModule(ReanimatedModule.class).getNodesManager();
     installJSIBindings();
     AnimationsManager animationsManager =

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/reanimated/NativeProxy.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/reanimated/NativeProxy.java
@@ -147,14 +147,17 @@ public class NativeProxy {
   }
 
   private void addDevMenuOption() {
-    final DevSupportManager devSupportManager =
-        ((ReactApplication) mContext.get().getApplicationContext())
-            .getReactNativeHost()
-            .getReactInstanceManager()
-            .getDevSupportManager();
+    // In Expo, `ApplicationContext` is not an instance of `ReactApplication`
+    if (mContext.get().getApplicationContext() instanceof ReactApplication) {
+      final DevSupportManager devSupportManager =
+          ((ReactApplication) mContext.get().getApplicationContext())
+              .getReactNativeHost()
+              .getReactInstanceManager()
+              .getDevSupportManager();
 
-    devSupportManager.addCustomDevOption(
-        "Toggle slow animations (Reanimated)", this::toggleSlowAnimations);
+      devSupportManager.addCustomDevOption(
+          "Toggle slow animations (Reanimated)", this::toggleSlowAnimations);
+    }
   }
 
   @DoNotStrip

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/reanimated/NodesManager.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/reanimated/NodesManager.java
@@ -11,7 +11,9 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.ReadableType;
 import com.facebook.react.bridge.UiThreadUtil;
+import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.facebook.react.modules.core.ReactChoreographer;
@@ -462,9 +464,9 @@ public class NodesManager implements EventDispatcherListener {
     mEventMapping.remove(key);
   }
 
-  public void configureProps(Set<String> nativePropsSet, Set<String> uiPropsSet) {
-    nativeProps = nativePropsSet;
+  public void configureProps(Set<String> uiPropsSet, Set<String> nativePropsSet) {
     uiProps = uiPropsSet;
+    nativeProps = nativePropsSet;
   }
 
   public void getValue(int nodeID, Callback callback) {
@@ -612,6 +614,42 @@ public class NodesManager implements EventDispatcherListener {
     return result;
   }
 
+  private static WritableMap copyReadableMap(ReadableMap map) {
+    WritableMap copy = Arguments.createMap();
+    copy.merge(map);
+    return copy;
+  }
+
+  private static WritableArray copyReadableArray(ReadableArray array) {
+    WritableArray copy = Arguments.createArray();
+    for (int i = 0; i < array.size(); i++) {
+      ReadableType type = array.getType(i);
+      switch (type) {
+        case Boolean:
+          copy.pushBoolean(array.getBoolean(i));
+          break;
+        case String:
+          copy.pushString(array.getString(i));
+          break;
+        case Null:
+          copy.pushNull();
+          break;
+        case Number:
+          copy.pushDouble(array.getDouble(i));
+          break;
+        case Map:
+          copy.pushMap(copyReadableMap(array.getMap(i)));
+          break;
+        case Array:
+          copy.pushArray(copyReadableArray(array.getArray(i)));
+          break;
+        default:
+          throw new IllegalStateException("Unknown type of ReadableArray");
+      }
+    }
+    return copy;
+  }
+
   private static void addProp(WritableMap propMap, String key, Object value) {
     if (value == null) {
       propMap.putNull(key);
@@ -626,9 +664,17 @@ public class NodesManager implements EventDispatcherListener {
     } else if (value instanceof String) {
       propMap.putString(key, (String) value);
     } else if (value instanceof ReadableArray) {
-      propMap.putArray(key, (ReadableArray) value);
+      if (!(value instanceof WritableArray)) {
+        propMap.putArray(key, copyReadableArray((ReadableArray) value));
+      } else {
+        propMap.putArray(key, (ReadableArray) value);
+      }
     } else if (value instanceof ReadableMap) {
-      propMap.putMap(key, (ReadableMap) value);
+      if (!(value instanceof WritableMap)) {
+        propMap.putMap(key, copyReadableMap((ReadableMap) value));
+      } else {
+        propMap.putMap(key, (ReadableMap) value);
+      }
     } else {
       throw new IllegalStateException("Unknown type of animated value");
     }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/reanimated/ReanimatedJSIModulePackage.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/reanimated/ReanimatedJSIModulePackage.java
@@ -1,5 +1,6 @@
 package versioned.host.exp.exponent.modules.api.reanimated;
 
+import android.util.Log;
 import com.facebook.react.bridge.JSIModulePackage;
 import com.facebook.react.bridge.JSIModuleSpec;
 import com.facebook.react.bridge.JavaScriptContextHolder;
@@ -8,14 +9,21 @@ import java.util.Arrays;
 import java.util.List;
 
 public class ReanimatedJSIModulePackage implements JSIModulePackage {
+  /**
+   * @deprecated Since 2.5.0, Reanimated autoinstalls on Android - you can remove
+   *     getJSIModulePackage() override in MainApplication.java.
+   */
+  @Deprecated
+  public ReanimatedJSIModulePackage() {
+    super();
+  }
 
   @Override
   public List<JSIModuleSpec> getJSIModules(
       ReactApplicationContext reactApplicationContext, JavaScriptContextHolder jsContext) {
-
-    NodesManager nodesManager =
-        reactApplicationContext.getNativeModule(ReanimatedModule.class).getNodesManager();
-    nodesManager.initWithContext(reactApplicationContext);
+    Log.w(
+        "[REANIMATED]",
+        "Since 2.5.0, Reanimated autoinstalls on Android - you can remove getJSIModulePackage() override in MainApplication.java.");
     return Arrays.<JSIModuleSpec>asList();
   }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/reanimated/ReanimatedModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/reanimated/ReanimatedModule.java
@@ -1,11 +1,11 @@
 package versioned.host.exp.exponent.modules.api.reanimated;
 
+import android.util.Log;
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
-import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.uimanager.NativeViewHierarchyManager;
@@ -14,8 +14,6 @@ import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.UIManagerModuleListener;
 import versioned.host.exp.exponent.modules.api.reanimated.transitions.TransitionModule;
 import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.Set;
 import javax.annotation.Nullable;
 
 @ReactModule(name = ReanimatedModule.NAME)
@@ -100,6 +98,21 @@ public class ReanimatedModule extends ReactContextBaseJavaModule
     }
 
     return mNodesManager;
+  }
+
+  @ReactMethod(isBlockingSynchronousMethod = true)
+  public void installTurboModule() {
+    // When debugging in chrome the JS context is not available.
+    // https://github.com/facebook/react-native/blob/v0.67.0-rc.6/ReactAndroid/src/main/java/com/facebook/react/modules/blob/BlobCollector.java#L25
+    Utils.isChromeDebugger = getReactApplicationContext().getJavaScriptContextHolder().get() == 0;
+
+    if (!Utils.isChromeDebugger) {
+      this.getNodesManager().initWithContext(getReactApplicationContext());
+    } else {
+      Log.w(
+          "[REANIMATED]",
+          "Unable to create Reanimated Native Module. You can ignore this message if you are using Chrome Debugger now.");
+    }
   }
 
   @ReactMethod
@@ -191,28 +204,6 @@ public class ReanimatedModule extends ReactContextBaseJavaModule
           @Override
           public void execute(NodesManager nodesManager) {
             nodesManager.detachEvent(viewTag, eventName, eventNodeID);
-          }
-        });
-  }
-
-  @ReactMethod
-  public void configureProps(ReadableArray nativePropsArray, ReadableArray uiPropsArray) {
-    int size = nativePropsArray.size();
-    final Set<String> nativeProps = new HashSet<>(size);
-    for (int i = 0; i < size; i++) {
-      nativeProps.add(nativePropsArray.getString(i));
-    }
-
-    size = uiPropsArray.size();
-    final Set<String> uiProps = new HashSet<>(size);
-    for (int i = 0; i < size; i++) {
-      uiProps.add(uiPropsArray.getString(i));
-    }
-    mOperations.add(
-        new UIThreadOperation() {
-          @Override
-          public void execute(NodesManager nodesManager) {
-            nodesManager.configureProps(nativeProps, uiProps);
           }
         });
   }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/reanimated/ReanimatedPackage.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/reanimated/ReanimatedPackage.java
@@ -5,6 +5,7 @@ import static com.facebook.react.bridge.ReactMarkerConstants.CREATE_UI_MANAGER_M
 
 import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactInstanceManager;
+import com.facebook.react.ReactPackage;
 import com.facebook.react.TurboReactPackage;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -19,7 +20,7 @@ import com.facebook.systrace.Systrace;
 import java.util.HashMap;
 import java.util.Map;
 
-public class ReanimatedPackage extends TurboReactPackage {
+public class ReanimatedPackage extends TurboReactPackage implements ReactPackage {
 
   @Override
   public NativeModule getModule(String name, ReactApplicationContext reactContext) {
@@ -66,10 +67,7 @@ public class ReanimatedPackage extends TurboReactPackage {
   private UIManagerModule createUIManager(final ReactApplicationContext reactContext) {
     ReactMarker.logMarker(CREATE_UI_MANAGER_MODULE_START);
     Systrace.beginSection(Systrace.TRACE_TAG_REACT_JAVA_BRIDGE, "createUIManagerModule");
-    final ReactInstanceManager reactInstanceManager =
-        ((ReactApplication) reactContext.getApplicationContext())
-            .getReactNativeHost()
-            .getReactInstanceManager();
+    final ReactInstanceManager reactInstanceManager = getReactInstanceManager(reactContext);
     int minTimeLeftInFrameForNonBatchedOperationMs = -1;
     try {
       return new ReanimatedUIManager(
@@ -80,5 +78,19 @@ public class ReanimatedPackage extends TurboReactPackage {
       Systrace.endSection(Systrace.TRACE_TAG_REACT_JAVA_BRIDGE);
       ReactMarker.logMarker(CREATE_UI_MANAGER_MODULE_END);
     }
+  }
+
+  /**
+   * Get the {@link ReactInstanceManager} used by this app. By default, assumes {@link
+   * ReactApplicationContext#getApplicationContext()} is an instance of {@link ReactApplication} and
+   * calls {@link ReactApplication#getReactNativeHost().getReactInstanceManager()}. Override this
+   * method if your application class does not implement {@code ReactApplication} or you simply have
+   * a different mechanism for storing a {@code ReactInstanceManager}, e.g. as a static field
+   * somewhere.
+   */
+  public ReactInstanceManager getReactInstanceManager(ReactApplicationContext reactContext) {
+    return ((ReactApplication) reactContext.getApplicationContext())
+        .getReactNativeHost()
+        .getReactInstanceManager();
   }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/reanimated/Utils.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/reanimated/Utils.java
@@ -8,6 +8,8 @@ import java.util.Map;
 
 public class Utils {
 
+  protected static boolean isChromeDebugger = false;
+
   public static Map<String, Integer> processMapping(ReadableMap style) {
     ReadableMapKeySetIterator iter = style.keySetIterator();
     HashMap<String, Integer> mapping = new HashMap<>();

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/reanimated/layoutReanimation/AnimationsManager.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/reanimated/layoutReanimation/AnimationsManager.java
@@ -61,10 +61,10 @@ public class AnimationsManager implements ViewHierarchyObserver {
   }
 
   public enum ViewState {
+    Inactive,
     Appearing,
     Disappearing,
     Layout,
-    Inactive,
     ToRemove;
   }
 
@@ -107,11 +107,11 @@ public class AnimationsManager implements ViewHierarchyObserver {
     HashMap<String, Object> currentValues = before.toCurrentMap();
     ViewState state = mStates.get(view.getId());
 
-    if (state == null || state == ViewState.Disappearing || state == ViewState.ToRemove) {
+    if (state == ViewState.Disappearing || state == ViewState.ToRemove) {
       return;
     }
     mCallbacks.put(tag, callback);
-    if (state == ViewState.Inactive) {
+    if (state == ViewState.Inactive || state == null) {
       if (currentValues != null) {
         mStates.put(view.getId(), ViewState.ToRemove);
         mToRemove.add(view.getId());
@@ -232,6 +232,14 @@ public class AnimationsManager implements ViewHierarchyObserver {
     // go through ready to remove from bottom to top
     for (int tag : mToRemove) {
       View view = mViewForTag.get(tag);
+      if (view == null) {
+        try {
+          view = mUIManager.resolveView(tag);
+          mViewForTag.put(tag, view);
+        } catch (IllegalViewOperationException ignored) {
+          continue;
+        }
+      }
       findRoot(view, roots);
     }
     for (int tag : roots) {
@@ -504,6 +512,6 @@ public class AnimationsManager implements ViewHierarchyObserver {
   }
 
   public boolean isLayoutAnimationEnabled() {
-    return mNativeMethodsHolder.isLayoutAnimationEnabled();
+    return mNativeMethodsHolder != null && mNativeMethodsHolder.isLayoutAnimationEnabled();
   }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/reanimated/layoutReanimation/AnimationsManager.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/reanimated/layoutReanimation/AnimationsManager.java
@@ -1,5 +1,6 @@
 package versioned.host.exp.exponent.modules.api.reanimated.layoutReanimation;
 
+import android.app.Activity;
 import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.View;
@@ -368,12 +369,18 @@ public class AnimationsManager implements ViewHierarchyObserver {
       preparedValues.put(key, PixelUtil.toDIPFromPixel((int) values.get(key)));
     }
 
-    DisplayMetrics displaymetrics = new DisplayMetrics();
-    mContext.getCurrentActivity().getWindowManager().getDefaultDisplay().getMetrics(displaymetrics);
-    int height = displaymetrics.heightPixels;
-    int width = displaymetrics.widthPixels;
-    preparedValues.put("windowWidth", PixelUtil.toDIPFromPixel(width));
-    preparedValues.put("windowHeight", PixelUtil.toDIPFromPixel(height));
+    DisplayMetrics displayMetrics = new DisplayMetrics();
+    Activity currentActivity = mContext.getCurrentActivity();
+    if (currentActivity != null) {
+      currentActivity.getWindowManager().getDefaultDisplay().getMetrics(displayMetrics);
+      int height = displayMetrics.heightPixels;
+      int width = displayMetrics.widthPixels;
+      preparedValues.put("windowWidth", PixelUtil.toDIPFromPixel(width));
+      preparedValues.put("windowHeight", PixelUtil.toDIPFromPixel(height));
+    } else {
+      preparedValues.put("windowWidth", PixelUtil.toDIPFromPixel(0));
+      preparedValues.put("windowHeight", PixelUtil.toDIPFromPixel(0));
+    }
     return preparedValues;
   }
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/reanimated/sensor/ReanimatedSensor.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/reanimated/sensor/ReanimatedSensor.java
@@ -1,0 +1,41 @@
+package versioned.host.exp.exponent.modules.api.reanimated.sensor;
+
+import android.hardware.Sensor;
+import android.hardware.SensorManager;
+import com.facebook.react.bridge.ReactApplicationContext;
+import versioned.host.exp.exponent.modules.api.reanimated.NativeProxy;
+import java.lang.ref.WeakReference;
+
+public class ReanimatedSensor {
+
+  ReanimatedSensorListener listener;
+  SensorManager sensorManager;
+  Sensor sensor;
+  ReanimatedSensorType sensorType;
+  int interval;
+
+  ReanimatedSensor(
+      WeakReference<ReactApplicationContext> reactContext,
+      ReanimatedSensorType sensorType,
+      int interval,
+      NativeProxy.SensorSetter setter) {
+    listener = new ReanimatedSensorListener(setter, interval);
+    sensorManager =
+        (SensorManager) reactContext.get().getSystemService(reactContext.get().SENSOR_SERVICE);
+    this.sensorType = sensorType;
+    this.interval = interval;
+  }
+
+  boolean initialize() {
+    sensor = sensorManager.getDefaultSensor(sensorType.getType());
+    if (sensor != null) {
+      sensorManager.registerListener(listener, sensor, interval * 1000);
+      return true;
+    }
+    return false;
+  }
+
+  void cancel() {
+    sensorManager.unregisterListener(listener, sensor);
+  }
+}

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/reanimated/sensor/ReanimatedSensorContainer.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/reanimated/sensor/ReanimatedSensorContainer.java
@@ -1,0 +1,40 @@
+package versioned.host.exp.exponent.modules.api.reanimated.sensor;
+
+import android.util.Log;
+import com.facebook.react.bridge.ReactApplicationContext;
+import versioned.host.exp.exponent.modules.api.reanimated.NativeProxy;
+import java.lang.ref.WeakReference;
+import java.util.HashMap;
+
+public class ReanimatedSensorContainer {
+
+  private int nextSensorId = 0;
+  private final WeakReference<ReactApplicationContext> reactContext;
+  private final HashMap<Integer, ReanimatedSensor> sensors = new HashMap<>();
+
+  public ReanimatedSensorContainer(WeakReference<ReactApplicationContext> reactContext) {
+    this.reactContext = reactContext;
+  }
+
+  public int registerSensor(
+      ReanimatedSensorType sensorType, int interval, NativeProxy.SensorSetter setter) {
+    ReanimatedSensor sensor = new ReanimatedSensor(reactContext, sensorType, interval, setter);
+    int sensorId = -1;
+    if (sensor.initialize()) {
+      sensorId = nextSensorId;
+      nextSensorId++;
+      sensors.put(sensorId, new ReanimatedSensor(reactContext, sensorType, interval, setter));
+    }
+    return sensorId;
+  }
+
+  public void unregisterSensor(int sensorId) {
+    ReanimatedSensor sensor = sensors.get(sensorId);
+    if (sensor != null) {
+      sensor.cancel();
+      sensors.remove(sensorId);
+    } else {
+      Log.e("Reanimated", "Tried to unregister nonexistent sensor");
+    }
+  }
+}

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/reanimated/sensor/ReanimatedSensorListener.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/reanimated/sensor/ReanimatedSensorListener.java
@@ -1,0 +1,31 @@
+package versioned.host.exp.exponent.modules.api.reanimated.sensor;
+
+import android.hardware.Sensor;
+import android.hardware.SensorEvent;
+import android.hardware.SensorEventListener;
+import versioned.host.exp.exponent.modules.api.reanimated.NativeProxy;
+
+public class ReanimatedSensorListener implements SensorEventListener {
+
+  private NativeProxy.SensorSetter setter;
+  private double lastRead = (double) System.currentTimeMillis();
+  private final double interval;
+
+  ReanimatedSensorListener(NativeProxy.SensorSetter setter, double interval) {
+    this.setter = setter;
+    this.interval = interval;
+  }
+
+  @Override
+  public void onSensorChanged(SensorEvent event) {
+    double current = (double) System.currentTimeMillis();
+    if (current - lastRead < interval) {
+      return;
+    }
+    lastRead = current;
+    setter.sensorSetter(event.values);
+  }
+
+  @Override
+  public void onAccuracyChanged(Sensor sensor, int accuracy) {}
+}

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/reanimated/sensor/ReanimatedSensorType.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/reanimated/sensor/ReanimatedSensorType.java
@@ -1,0 +1,35 @@
+package versioned.host.exp.exponent.modules.api.reanimated.sensor;
+
+public enum ReanimatedSensorType {
+  ACCELEROMETER(1),
+  GYROSCOPE(2),
+  GRAVITY(3),
+  MAGNETIC_FIELD(4),
+  ROTATION_VECTOR(5);
+
+  private final int type;
+
+  ReanimatedSensorType(int type) {
+    this.type = type;
+  }
+
+  public int getType() {
+    return type;
+  }
+
+  public static ReanimatedSensorType getInstanceById(int typeId) {
+    switch (typeId) {
+      case 1:
+        return ReanimatedSensorType.ACCELEROMETER;
+      case 2:
+        return ReanimatedSensorType.GYROSCOPE;
+      case 3:
+        return ReanimatedSensorType.GRAVITY;
+      case 4:
+        return ReanimatedSensorType.MAGNETIC_FIELD;
+      case 5:
+        return ReanimatedSensorType.ROTATION_VECTOR;
+    }
+    throw new IllegalArgumentException("[Reanimated] Unknown sensor type");
+  }
+}

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -773,7 +773,7 @@ PODS:
     - React-Core
   - RNGestureHandler (2.2.0):
     - React-Core
-  - RNReanimated (2.4.1):
+  - RNReanimated (2.6.0):
     - DoubleConversion
     - FBLazyVector
     - FBReactNativeSpec
@@ -781,7 +781,6 @@ PODS:
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
-    - React
     - React-callinvoker
     - React-Core
     - React-Core/DevSupport
@@ -1467,7 +1466,7 @@ SPEC CHECKSUMS:
   RNCPicker: 6d5d64e7b90c240c779ee0938ec433c11e2dd758
   RNDateTimePicker: 6f1f0b4cf7c71b6e2aea7a3aa62969111084bbd1
   RNGestureHandler: bf572f552ea324acd5b5464b8d30755b2d8c1de6
-  RNReanimated: 3d1432ce7b6b7fc31f375dcabe5b4585e0634a43
+  RNReanimated: 89a32ebf01d2dac2eb35b3b1628952f626db93d7
   RNScreens: 4d83613b50b74ed277026375dc0810893b0c347f
   RNSharedElement: eb7d506733952d58634f34c82ec17e82f557e377
   RNSVG: 302bfc9905bd8122f08966dc2ce2d07b7b52b9f8

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -773,7 +773,7 @@ PODS:
     - React-Core
   - RNGestureHandler (2.2.0):
     - React-Core
-  - RNReanimated (2.6.0):
+  - RNReanimated (2.7.0):
     - DoubleConversion
     - FBLazyVector
     - FBReactNativeSpec
@@ -1466,7 +1466,7 @@ SPEC CHECKSUMS:
   RNCPicker: 6d5d64e7b90c240c779ee0938ec433c11e2dd758
   RNDateTimePicker: 6f1f0b4cf7c71b6e2aea7a3aa62969111084bbd1
   RNGestureHandler: bf572f552ea324acd5b5464b8d30755b2d8c1de6
-  RNReanimated: 89a32ebf01d2dac2eb35b3b1628952f626db93d7
+  RNReanimated: e42de406edd11350af29016cf6802ef16ee364d0
   RNScreens: 4d83613b50b74ed277026375dc0810893b0c347f
   RNSharedElement: eb7d506733952d58634f34c82ec17e82f557e377
   RNSVG: 302bfc9905bd8122f08966dc2ce2d07b7b52b9f8

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -113,7 +113,7 @@
     "react-dom": "17.0.2",
     "react-native": "0.68.0",
     "react-native-gesture-handler": "~2.2.0",
-    "react-native-reanimated": "~2.4.1",
+    "react-native-reanimated": "~2.6.0",
     "react-native-safe-area-context": "4.2.4",
     "react-native-screens": "~3.11.1",
     "react-native-shared-element": "0.8.4",

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -113,7 +113,7 @@
     "react-dom": "17.0.2",
     "react-native": "0.68.0",
     "react-native-gesture-handler": "~2.2.0",
-    "react-native-reanimated": "~2.6.0",
+    "react-native-reanimated": "~2.7.0",
     "react-native-safe-area-context": "4.2.4",
     "react-native-screens": "~3.11.1",
     "react-native-shared-element": "0.8.4",

--- a/apps/bare-sandbox/package.json
+++ b/apps/bare-sandbox/package.json
@@ -19,7 +19,7 @@
     "react-dom": "17.0.2",
     "react-native": "0.68.0",
     "react-native-gesture-handler": "~2.2.0",
-    "react-native-reanimated": "~2.4.1",
+    "react-native-reanimated": "~2.6.0",
     "react-native-screens": "~3.11.1",
     "react-native-web": "~0.17.1"
   },

--- a/apps/bare-sandbox/package.json
+++ b/apps/bare-sandbox/package.json
@@ -19,7 +19,7 @@
     "react-dom": "17.0.2",
     "react-native": "0.68.0",
     "react-native-gesture-handler": "~2.2.0",
-    "react-native-reanimated": "~2.6.0",
+    "react-native-reanimated": "~2.7.0",
     "react-native-screens": "~3.11.1",
     "react-native-web": "~0.17.1"
   },

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -152,7 +152,7 @@
     "react-native-maps": "0.29.4",
     "react-native-pager-view": "5.4.15",
     "react-native-paper": "^4.0.1",
-    "react-native-reanimated": "~2.6.0",
+    "react-native-reanimated": "~2.7.0",
     "react-native-redash": "^14.1.1",
     "react-native-safe-area-context": "4.2.4",
     "react-native-safe-area-view": "^0.14.8",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -152,7 +152,7 @@
     "react-native-maps": "0.29.4",
     "react-native-pager-view": "5.4.15",
     "react-native-paper": "^4.0.1",
-    "react-native-reanimated": "~2.4.1",
+    "react-native-reanimated": "~2.6.0",
     "react-native-redash": "^14.1.1",
     "react-native-safe-area-context": "4.2.4",
     "react-native-safe-area-view": "^0.14.8",

--- a/dev-home-config.json
+++ b/dev-home-config.json
@@ -1,3 +1,3 @@
 {
-  "url": "exp://exp.host/@expo-home-dev/expo-home-dev-0eb2d56ea530261bad2e2b6509991c14438e43d4"
+  "url": "exp://exp.host/@expo-home-dev/expo-home-dev-0412efb4eeb7d7fe6f3f5f08a1dd78d60b02fabc"
 }

--- a/home/package.json
+++ b/home/package.json
@@ -60,7 +60,7 @@
     "react-native-infinite-scroll-view": "^0.4.5",
     "react-native-maps": "0.29.4",
     "react-native-paper": "^4.0.1",
-    "react-native-reanimated": "~2.4.1",
+    "react-native-reanimated": "~2.6.0",
     "react-native-safe-area-context": "4.2.4",
     "react-native-screens": "~3.11.1",
     "react-redux": "^7.2.0",

--- a/home/package.json
+++ b/home/package.json
@@ -60,7 +60,7 @@
     "react-native-infinite-scroll-view": "^0.4.5",
     "react-native-maps": "0.29.4",
     "react-native-paper": "^4.0.1",
-    "react-native-reanimated": "~2.6.0",
+    "react-native-reanimated": "~2.7.0",
     "react-native-safe-area-context": "4.2.4",
     "react-native-screens": "~3.11.1",
     "react-redux": "^7.2.0",

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1884,7 +1884,7 @@ PODS:
     - ReactCommon/turbomodule/core (= 0.68.0)
   - RNGestureHandler (2.2.0):
     - React-Core
-  - RNReanimated (2.3.1):
+  - RNReanimated (2.6.0):
     - DoubleConversion
     - FBLazyVector
     - FBReactNativeSpec
@@ -1892,7 +1892,6 @@ PODS:
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
-    - React
     - React-callinvoker
     - React-Core
     - React-Core/DevSupport
@@ -3364,7 +3363,7 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: 9b1304f48e344c55bb3c36e13bf11461cb4da5d8
   ReactCommon: fab89a13b52f1ac42b59a0e4b4f76f21aea9eebe
   RNGestureHandler: bf572f552ea324acd5b5464b8d30755b2d8c1de6
-  RNReanimated: 1326679461fa5d2399d54c18ca1432ba3e816b9e
+  RNReanimated: 89a32ebf01d2dac2eb35b3b1628952f626db93d7
   RNScreens: 4d83613b50b74ed277026375dc0810893b0c347f
   Stripe: ee32e594fa4dee4bdf2a8a3039f7fb07a21075dc
   stripe-react-native: bd992665f71c5233d62719c4031351f3f3b769fe

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1884,7 +1884,7 @@ PODS:
     - ReactCommon/turbomodule/core (= 0.68.0)
   - RNGestureHandler (2.2.0):
     - React-Core
-  - RNReanimated (2.6.0):
+  - RNReanimated (2.7.0):
     - DoubleConversion
     - FBLazyVector
     - FBReactNativeSpec
@@ -3363,7 +3363,7 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: 9b1304f48e344c55bb3c36e13bf11461cb4da5d8
   ReactCommon: fab89a13b52f1ac42b59a0e4b4f76f21aea9eebe
   RNGestureHandler: bf572f552ea324acd5b5464b8d30755b2d8c1de6
-  RNReanimated: 89a32ebf01d2dac2eb35b3b1628952f626db93d7
+  RNReanimated: e42de406edd11350af29016cf6802ef16ee364d0
   RNScreens: 4d83613b50b74ed277026375dc0810893b0c347f
   Stripe: ee32e594fa4dee4bdf2a8a3039f7fb07a21075dc
   stripe-react-native: bd992665f71c5233d62719c4031351f3f3b769fe

--- a/ios/vendored/unversioned/react-native-reanimated/Common/cpp/AnimatedSensor/AnimatedSensorModule.cpp
+++ b/ios/vendored/unversioned/react-native-reanimated/Common/cpp/AnimatedSensor/AnimatedSensorModule.cpp
@@ -1,0 +1,72 @@
+#include "AnimatedSensorModule.h"
+#include "MutableValue.h"
+#include "ValueWrapper.h"
+
+namespace reanimated {
+
+AnimatedSensorModule::AnimatedSensorModule(
+    const PlatformDepMethodsHolder &platformDepMethodsHolder,
+    RuntimeManager *runtimeManager)
+    : platformRegisterSensorFunction_(platformDepMethodsHolder.registerSensor),
+      platformUnregisterSensorFunction_(
+          platformDepMethodsHolder.unregisterSensor),
+      runtimeManager_(runtimeManager) {}
+
+AnimatedSensorModule::~AnimatedSensorModule() {
+  // It is called during app reload because app reload doesn't call hooks
+  // unmounting
+  for (auto sensorId : sensorsIds_) {
+    platformUnregisterSensorFunction_(sensorId);
+  }
+}
+
+jsi::Value AnimatedSensorModule::registerSensor(
+    jsi::Runtime &rt,
+    const jsi::Value &sensorType,
+    const jsi::Value &interval,
+    const jsi::Value &sensorDataContainer) {
+  std::shared_ptr<ShareableValue> sensorsData = ShareableValue::adapt(
+      rt, sensorDataContainer.getObject(rt), runtimeManager_);
+  auto &mutableObject =
+      ValueWrapper::asMutableValue(sensorsData->valueContainer);
+
+  std::function<void(double[])> setter;
+  if (sensorType.asNumber() == SensorType::ROTATION_VECTOR) {
+    setter = [&, mutableObject](double newValues[]) {
+      jsi::Runtime &runtime = *runtimeManager_->runtime.get();
+      jsi::Object value(runtime);
+      value.setProperty(runtime, "qw", newValues[0]);
+      value.setProperty(runtime, "qx", newValues[1]);
+      value.setProperty(runtime, "qy", newValues[2]);
+      value.setProperty(runtime, "qz", newValues[3]);
+      value.setProperty(runtime, "yaw", newValues[4]);
+      value.setProperty(runtime, "pitch", newValues[5]);
+      value.setProperty(runtime, "roll", newValues[6]);
+      mutableObject->setValue(runtime, std::move(value));
+    };
+  } else {
+    setter = [&, mutableObject](double newValues[]) {
+      jsi::Runtime &runtime = *runtimeManager_->runtime.get();
+      jsi::Object value(runtime);
+      value.setProperty(runtime, "x", newValues[0]);
+      value.setProperty(runtime, "y", newValues[1]);
+      value.setProperty(runtime, "z", newValues[2]);
+      mutableObject->setValue(runtime, std::move(value));
+    };
+  }
+
+  int sensorId = platformRegisterSensorFunction_(
+      sensorType.asNumber(), interval.asNumber(), setter);
+  if (sensorId != -1) {
+    sensorsIds_.insert(sensorId);
+  }
+  return jsi::Value(sensorId);
+}
+
+void AnimatedSensorModule::unregisterSensor(const jsi::Value &sensorId) {
+  // It is called during sensor hook unmounting
+  sensorsIds_.erase(sensorId.getNumber());
+  platformUnregisterSensorFunction_(sensorId.asNumber());
+}
+
+} // namespace reanimated

--- a/ios/vendored/unversioned/react-native-reanimated/Common/cpp/NativeModules/NativeReanimatedModuleSpec.cpp
+++ b/ios/vendored/unversioned/react-native-reanimated/Common/cpp/NativeModules/NativeReanimatedModuleSpec.cpp
@@ -1,9 +1,10 @@
 #include "NativeReanimatedModuleSpec.h"
 
+#define SPEC_PREFIX(FN_NAME) __hostFunction_NativeReanimatedModuleSpec_##FN_NAME
+
 namespace reanimated {
 
-static jsi::Value
-__hostFunction_NativeReanimatedModuleSpec_installCoreFunctions(
+static jsi::Value SPEC_PREFIX(installCoreFunctions)(
     jsi::Runtime &rt,
     TurboModule &turboModule,
     const jsi::Value *args,
@@ -15,7 +16,7 @@ __hostFunction_NativeReanimatedModuleSpec_installCoreFunctions(
 
 // SharedValue
 
-static jsi::Value __hostFunction_NativeReanimatedModuleSpec_makeShareable(
+static jsi::Value SPEC_PREFIX(makeShareable)(
     jsi::Runtime &rt,
     TurboModule &turboModule,
     const jsi::Value *args,
@@ -24,7 +25,7 @@ static jsi::Value __hostFunction_NativeReanimatedModuleSpec_makeShareable(
       ->makeShareable(rt, std::move(args[0]));
 }
 
-static jsi::Value __hostFunction_NativeReanimatedModuleSpec_makeMutable(
+static jsi::Value SPEC_PREFIX(makeMutable)(
     jsi::Runtime &rt,
     TurboModule &turboModule,
     const jsi::Value *args,
@@ -33,7 +34,7 @@ static jsi::Value __hostFunction_NativeReanimatedModuleSpec_makeMutable(
       ->makeMutable(rt, std::move(args[0]));
 }
 
-static jsi::Value __hostFunction_NativeReanimatedModuleSpec_makeRemote(
+static jsi::Value SPEC_PREFIX(makeRemote)(
     jsi::Runtime &rt,
     TurboModule &turboModule,
     const jsi::Value *args,
@@ -42,7 +43,7 @@ static jsi::Value __hostFunction_NativeReanimatedModuleSpec_makeRemote(
       ->makeRemote(rt, std::move(args[0]));
 }
 
-static jsi::Value __hostFunction_NativeReanimatedModuleSpec_startMapper(
+static jsi::Value SPEC_PREFIX(startMapper)(
     jsi::Runtime &rt,
     TurboModule &turboModule,
     const jsi::Value *args,
@@ -57,7 +58,7 @@ static jsi::Value __hostFunction_NativeReanimatedModuleSpec_startMapper(
           std::move(args[4]));
 }
 
-static jsi::Value __hostFunction_NativeReanimatedModuleSpec_stopMapper(
+static jsi::Value SPEC_PREFIX(stopMapper)(
     jsi::Runtime &rt,
     TurboModule &turboModule,
     const jsi::Value *args,
@@ -67,8 +68,7 @@ static jsi::Value __hostFunction_NativeReanimatedModuleSpec_stopMapper(
   return jsi::Value::undefined();
 }
 
-static jsi::Value
-__hostFunction_NativeReanimatedModuleSpec_registerEventHandler(
+static jsi::Value SPEC_PREFIX(registerEventHandler)(
     jsi::Runtime &rt,
     TurboModule &turboModule,
     const jsi::Value *args,
@@ -77,8 +77,7 @@ __hostFunction_NativeReanimatedModuleSpec_registerEventHandler(
       ->registerEventHandler(rt, std::move(args[0]), std::move(args[1]));
 }
 
-static jsi::Value
-__hostFunction_NativeReanimatedModuleSpec_unregisterEventHandler(
+static jsi::Value SPEC_PREFIX(unregisterEventHandler)(
     jsi::Runtime &rt,
     TurboModule &turboModule,
     const jsi::Value *args,
@@ -88,7 +87,7 @@ __hostFunction_NativeReanimatedModuleSpec_unregisterEventHandler(
   return jsi::Value::undefined();
 }
 
-static jsi::Value __hostFunction_NativeReanimatedModuleSpec_getViewProp(
+static jsi::Value SPEC_PREFIX(getViewProp)(
     jsi::Runtime &rt,
     TurboModule &turboModule,
     const jsi::Value *args,
@@ -99,8 +98,7 @@ static jsi::Value __hostFunction_NativeReanimatedModuleSpec_getViewProp(
   return jsi::Value::undefined();
 }
 
-static jsi::Value
-__hostFunction_NativeReanimatedModuleSpec_enableLayoutAnimations(
+static jsi::Value SPEC_PREFIX(enableLayoutAnimations)(
     jsi::Runtime &rt,
     TurboModule &turboModule,
     const jsi::Value *args,
@@ -110,33 +108,60 @@ __hostFunction_NativeReanimatedModuleSpec_enableLayoutAnimations(
   return jsi::Value::undefined();
 }
 
+static jsi::Value SPEC_PREFIX(registerSensor)(
+    jsi::Runtime &rt,
+    TurboModule &turboModule,
+    const jsi::Value *args,
+    size_t count) {
+  return static_cast<NativeReanimatedModuleSpec *>(&turboModule)
+      ->registerSensor(
+          rt, std::move(args[0]), std::move(args[1]), std::move(args[2]));
+}
+
+static jsi::Value SPEC_PREFIX(unregisterSensor)(
+    jsi::Runtime &rt,
+    TurboModule &turboModule,
+    const jsi::Value *args,
+    size_t count) {
+  static_cast<NativeReanimatedModuleSpec *>(&turboModule)
+      ->unregisterSensor(rt, std::move(args[0]));
+  return jsi::Value::undefined();
+}
+
+static jsi::Value SPEC_PREFIX(configureProps)(
+    jsi::Runtime &rt,
+    TurboModule &turboModule,
+    const jsi::Value *args,
+    size_t count) {
+  static_cast<NativeReanimatedModuleSpec *>(&turboModule)
+      ->configureProps(rt, std::move(args[0]), std::move(args[1]));
+  return jsi::Value::undefined();
+}
+
 NativeReanimatedModuleSpec::NativeReanimatedModuleSpec(
     std::shared_ptr<CallInvoker> jsInvoker)
     : TurboModule("NativeReanimated", jsInvoker) {
-  methodMap_["installCoreFunctions"] = MethodMetadata{
-      1, __hostFunction_NativeReanimatedModuleSpec_installCoreFunctions};
+  methodMap_["installCoreFunctions"] =
+      MethodMetadata{1, SPEC_PREFIX(installCoreFunctions)};
 
-  methodMap_["makeShareable"] = MethodMetadata{
-      1, __hostFunction_NativeReanimatedModuleSpec_makeShareable};
-  methodMap_["makeMutable"] =
-      MethodMetadata{1, __hostFunction_NativeReanimatedModuleSpec_makeMutable};
-  methodMap_["makeRemote"] =
-      MethodMetadata{1, __hostFunction_NativeReanimatedModuleSpec_makeRemote};
+  methodMap_["makeShareable"] = MethodMetadata{1, SPEC_PREFIX(makeShareable)};
+  methodMap_["makeMutable"] = MethodMetadata{1, SPEC_PREFIX(makeMutable)};
+  methodMap_["makeRemote"] = MethodMetadata{1, SPEC_PREFIX(makeRemote)};
 
-  methodMap_["startMapper"] =
-      MethodMetadata{5, __hostFunction_NativeReanimatedModuleSpec_startMapper};
-  methodMap_["stopMapper"] =
-      MethodMetadata{1, __hostFunction_NativeReanimatedModuleSpec_stopMapper};
+  methodMap_["startMapper"] = MethodMetadata{5, SPEC_PREFIX(startMapper)};
+  methodMap_["stopMapper"] = MethodMetadata{1, SPEC_PREFIX(stopMapper)};
 
-  methodMap_["registerEventHandler"] = MethodMetadata{
-      2, __hostFunction_NativeReanimatedModuleSpec_registerEventHandler};
-  methodMap_["unregisterEventHandler"] = MethodMetadata{
-      1, __hostFunction_NativeReanimatedModuleSpec_unregisterEventHandler};
+  methodMap_["registerEventHandler"] =
+      MethodMetadata{2, SPEC_PREFIX(registerEventHandler)};
+  methodMap_["unregisterEventHandler"] =
+      MethodMetadata{1, SPEC_PREFIX(unregisterEventHandler)};
 
-  methodMap_["getViewProp"] =
-      MethodMetadata{3, __hostFunction_NativeReanimatedModuleSpec_getViewProp};
-  methodMap_["enableLayoutAnimations"] = MethodMetadata{
-      2, __hostFunction_NativeReanimatedModuleSpec_enableLayoutAnimations};
+  methodMap_["getViewProp"] = MethodMetadata{3, SPEC_PREFIX(getViewProp)};
+  methodMap_["enableLayoutAnimations"] =
+      MethodMetadata{2, SPEC_PREFIX(enableLayoutAnimations)};
+  methodMap_["registerSensor"] = MethodMetadata{3, SPEC_PREFIX(registerSensor)};
+  methodMap_["unregisterSensor"] =
+      MethodMetadata{1, SPEC_PREFIX(unregisterSensor)};
+  methodMap_["configureProps"] = MethodMetadata{2, SPEC_PREFIX(configureProps)};
 }
-
 } // namespace reanimated

--- a/ios/vendored/unversioned/react-native-reanimated/Common/cpp/SharedItems/ShareableValue.cpp
+++ b/ios/vendored/unversioned/react-native-reanimated/Common/cpp/SharedItems/ShareableValue.cpp
@@ -64,7 +64,7 @@ void ShareableValue::adapt(
       jsi::Object hiddenProperty = hiddenValue.asObject(rt);
       if (hiddenProperty.isHostObject<FrozenObject>(rt)) {
         type = ValueType::FrozenObjectType;
-        if (object.hasProperty(rt, "__worklet") && object.isFunction(rt)) {
+        if (object.hasProperty(rt, "__workletHash") && object.isFunction(rt)) {
           type = ValueType::WorkletFunctionType;
         }
         valueContainer = std::make_unique<FrozenObjectWrapper>(
@@ -99,7 +99,7 @@ void ShareableValue::adapt(
   } else if (value.isObject()) {
     auto object = value.asObject(rt);
     if (object.isFunction(rt)) {
-      if (object.getProperty(rt, "__worklet").isUndefined()) {
+      if (object.getProperty(rt, "__workletHash").isUndefined()) {
         // not a worklet, we treat this as a host function
         type = ValueType::HostFunctionType;
         containsHostFunction = true;

--- a/ios/vendored/unversioned/react-native-reanimated/Common/cpp/Tools/RuntimeDecorator.cpp
+++ b/ios/vendored/unversioned/react-native-reanimated/Common/cpp/Tools/RuntimeDecorator.cpp
@@ -31,20 +31,6 @@ void RuntimeDecorator::decorateRuntime(
       rt, "_LABEL", jsi::String::createFromAscii(rt, label));
 
   jsi::Object dummyGlobal(rt);
-  auto dummyFunction = [](jsi::Runtime &rt,
-                          const jsi::Value &thisValue,
-                          const jsi::Value *args,
-                          size_t count) -> jsi::Value {
-    return jsi::Value::undefined();
-  };
-  jsi::Function __reanimatedWorkletInit = jsi::Function::createFromHostFunction(
-      rt,
-      jsi::PropNameID::forAscii(rt, "__reanimatedWorkletInit"),
-      1,
-      dummyFunction);
-
-  dummyGlobal.setProperty(
-      rt, "__reanimatedWorkletInit", __reanimatedWorkletInit);
   rt.global().setProperty(rt, "global", dummyGlobal);
 
   rt.global().setProperty(rt, "jsThis", jsi::Value::undefined());

--- a/ios/vendored/unversioned/react-native-reanimated/Common/cpp/Tools/RuntimeDecorator.cpp
+++ b/ios/vendored/unversioned/react-native-reanimated/Common/cpp/Tools/RuntimeDecorator.cpp
@@ -109,6 +109,8 @@ void RuntimeDecorator::decorateUIRuntime(
     const ScrollToFunction scrollTo,
     const MeasuringFunction measure,
     const TimeProviderFunction getCurrentTime,
+    const RegisterSensorFunction registerSensor,
+    const UnregisterSensorFunction unregisterSensor,
     const SetGestureStateFunction setGestureState,
     std::shared_ptr<LayoutAnimationsProxy> layoutAnimationsProxy) {
   RuntimeDecorator::decorateRuntime(rt, "UI");

--- a/ios/vendored/unversioned/react-native-reanimated/Common/cpp/headers/AnimatedSensor/AnimatedSensorModule.h
+++ b/ios/vendored/unversioned/react-native-reanimated/Common/cpp/headers/AnimatedSensor/AnimatedSensorModule.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <jsi/jsi.h>
+#include <unordered_set>
+
+#include "PlatformDepMethodsHolder.h"
+#include "RuntimeManager.h"
+
+namespace reanimated {
+
+using namespace facebook;
+
+enum SensorType {
+  ACCELEROMETER = 1,
+  GYROSCOPE = 2,
+  GRAVITY = 3,
+  MAGNETIC_FIELD = 4,
+  ROTATION_VECTOR = 5,
+};
+
+class AnimatedSensorModule {
+  std::unordered_set<int> sensorsIds_;
+  RegisterSensorFunction platformRegisterSensorFunction_;
+  UnregisterSensorFunction platformUnregisterSensorFunction_;
+  RuntimeManager *runtimeManager_;
+
+ public:
+  AnimatedSensorModule(
+      const PlatformDepMethodsHolder &platformDepMethodsHolder,
+      RuntimeManager *runtimeManager);
+  ~AnimatedSensorModule();
+
+  jsi::Value registerSensor(
+      jsi::Runtime &rt,
+      const jsi::Value &sensorType,
+      const jsi::Value &interval,
+      const jsi::Value &sensorDataContainer);
+  void unregisterSensor(const jsi::Value &sensorId);
+};
+
+} // namespace reanimated

--- a/ios/vendored/unversioned/react-native-reanimated/Common/cpp/headers/NativeModules/NativeReanimatedModule.h
+++ b/ios/vendored/unversioned/react-native-reanimated/Common/cpp/headers/NativeModules/NativeReanimatedModule.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 
+#include "AnimatedSensorModule.h"
 #include "ErrorHandler.h"
 #include "LayoutAnimationsProxy.h"
 #include "NativeReanimatedModuleSpec.h"
@@ -70,6 +71,10 @@ class NativeReanimatedModule : public NativeReanimatedModuleSpec,
 
   jsi::Value enableLayoutAnimations(jsi::Runtime &rt, const jsi::Value &config)
       override;
+  jsi::Value configureProps(
+      jsi::Runtime &rt,
+      const jsi::Value &uiProps,
+      const jsi::Value &nativeProps) override;
 
   void onRender(double timestampMs);
   void onEvent(std::string eventName, std::string eventAsString);
@@ -77,6 +82,13 @@ class NativeReanimatedModule : public NativeReanimatedModuleSpec,
 
   void maybeRequestRender();
   UpdaterFunction updaterFunction;
+
+  jsi::Value registerSensor(
+      jsi::Runtime &rt,
+      const jsi::Value &sensorType,
+      const jsi::Value &interval,
+      const jsi::Value &sensorDataContainer) override;
+  void unregisterSensor(jsi::Runtime &rt, const jsi::Value &sensorId) override;
 
  private:
   std::shared_ptr<MapperRegistry> mapperRegistry;
@@ -89,6 +101,8 @@ class NativeReanimatedModule : public NativeReanimatedModuleSpec,
       propObtainer;
   std::function<void(double)> onRenderCallback;
   std::shared_ptr<LayoutAnimationsProxy> layoutAnimationsProxy;
+  AnimatedSensorModule animatedSensorModule;
+  ConfigurePropsFunction configurePropsPlatformFunction;
 };
 
 } // namespace reanimated

--- a/ios/vendored/unversioned/react-native-reanimated/Common/cpp/headers/NativeModules/NativeReanimatedModuleSpec.h
+++ b/ios/vendored/unversioned/react-native-reanimated/Common/cpp/headers/NativeModules/NativeReanimatedModuleSpec.h
@@ -59,10 +59,24 @@ class JSI_EXPORT NativeReanimatedModuleSpec : public TurboModule {
       const jsi::Value &propName,
       const jsi::Value &callback) = 0;
 
+  // sensors
+  virtual jsi::Value registerSensor(
+      jsi::Runtime &rt,
+      const jsi::Value &sensorType,
+      const jsi::Value &interval,
+      const jsi::Value &sensorDataContainer) = 0;
+  virtual void unregisterSensor(
+      jsi::Runtime &rt,
+      const jsi::Value &sensorId) = 0;
+
   // other
   virtual jsi::Value enableLayoutAnimations(
       jsi::Runtime &rt,
       const jsi::Value &config) = 0;
+  virtual jsi::Value configureProps(
+      jsi::Runtime &rt,
+      const jsi::Value &uiProps,
+      const jsi::Value &nativeProps) = 0;
 };
 
 } // namespace reanimated

--- a/ios/vendored/unversioned/react-native-reanimated/Common/cpp/headers/SharedItems/MutableValue.h
+++ b/ios/vendored/unversioned/react-native-reanimated/Common/cpp/headers/SharedItems/MutableValue.h
@@ -20,13 +20,16 @@ class MutableValue : public jsi::HostObject,
                      public StoreUser {
  private:
   friend MutableValueSetterProxy;
-  RuntimeManager *runtimeManager;
   friend LayoutAnimationsProxy;
+
+ private:
+  RuntimeManager *runtimeManager;
   std::mutex readWriteMutex;
   std::shared_ptr<ShareableValue> value;
   std::weak_ptr<jsi::Value> animation;
   std::map<unsigned long, std::function<void()>> listeners;
 
+ public:
   void setValue(jsi::Runtime &rt, const jsi::Value &newValue);
   jsi::Value getValue(jsi::Runtime &rt);
 

--- a/ios/vendored/unversioned/react-native-reanimated/Common/cpp/headers/SharedItems/ShareableValue.h
+++ b/ios/vendored/unversioned/react-native-reanimated/Common/cpp/headers/SharedItems/ShareableValue.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include "AnimatedSensorModule.h"
 #include "HostFunctionHandler.h"
 #include "JSIStoreValueUser.h"
 #include "LayoutAnimationsProxy.h"
@@ -24,6 +25,8 @@ class ShareableValue : public std::enable_shared_from_this<ShareableValue>,
   friend WorkletsCache;
   friend FrozenObject;
   friend LayoutAnimationsProxy;
+  friend NativeReanimatedModule;
+  friend AnimatedSensorModule;
   friend void extractMutables(
       jsi::Runtime &rt,
       std::shared_ptr<ShareableValue> sv,

--- a/ios/vendored/unversioned/react-native-reanimated/Common/cpp/headers/SharedItems/ValueWrapper.h
+++ b/ios/vendored/unversioned/react-native-reanimated/Common/cpp/headers/SharedItems/ValueWrapper.h
@@ -12,8 +12,11 @@
 namespace reanimated {
 
 class HostFunctionWrapper;
+class AnimatedSensorModule;
 
 class ValueWrapper {
+  friend AnimatedSensorModule;
+
  public:
   ValueWrapper() {}
   explicit ValueWrapper(ValueType _type) : type(_type) {}

--- a/ios/vendored/unversioned/react-native-reanimated/Common/cpp/headers/Tools/PlatformDepMethodsHolder.h
+++ b/ios/vendored/unversioned/react-native-reanimated/Common/cpp/headers/Tools/PlatformDepMethodsHolder.h
@@ -21,7 +21,15 @@ using ScrollToFunction = std::function<void(int, double, double, bool)>;
 using MeasuringFunction =
     std::function<std::vector<std::pair<std::string, double>>(int)>;
 using TimeProviderFunction = std::function<double(void)>;
+
+using RegisterSensorFunction =
+    std::function<int(int, int, std::function<void(double[])>)>;
+using UnregisterSensorFunction = std::function<void(int)>;
 using SetGestureStateFunction = std::function<void(int, int)>;
+using ConfigurePropsFunction = std::function<void(
+    jsi::Runtime &rt,
+    const jsi::Value &uiProps,
+    const jsi::Value &nativeProps)>;
 
 struct PlatformDepMethodsHolder {
   RequestRender requestRender;
@@ -29,7 +37,10 @@ struct PlatformDepMethodsHolder {
   ScrollToFunction scrollToFunction;
   MeasuringFunction measuringFunction;
   TimeProviderFunction getCurrentTime;
+  RegisterSensorFunction registerSensor;
+  UnregisterSensorFunction unregisterSensor;
   SetGestureStateFunction setGestureStateFunction;
+  ConfigurePropsFunction configurePropsFunction;
 };
 
 } // namespace reanimated

--- a/ios/vendored/unversioned/react-native-reanimated/Common/cpp/headers/Tools/RuntimeDecorator.h
+++ b/ios/vendored/unversioned/react-native-reanimated/Common/cpp/headers/Tools/RuntimeDecorator.h
@@ -36,6 +36,8 @@ class RuntimeDecorator {
       const ScrollToFunction scrollTo,
       const MeasuringFunction measure,
       const TimeProviderFunction getCurrentTime,
+      const RegisterSensorFunction registerSensor,
+      const UnregisterSensorFunction unregisterSensor,
       const SetGestureStateFunction setGestureState,
       std::shared_ptr<LayoutAnimationsProxy> layoutAnimationsProxy);
 

--- a/ios/vendored/unversioned/react-native-reanimated/RNReanimated.podspec.json
+++ b/ios/vendored/unversioned/react-native-reanimated/RNReanimated.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "RNReanimated",
-  "version": "2.3.1",
+  "version": "2.6.0",
   "summary": "More powerful alternative to Animated library for React Native.",
   "description": "RNReanimated",
   "homepage": "https://github.com/software-mansion/react-native-reanimated",
@@ -14,7 +14,7 @@
   },
   "source": {
     "git": "https://github.com/software-mansion/react-native-reanimated.git",
-    "tag": "2.3.1"
+    "tag": "2.6.0"
   },
   "source_files": [
     "ios/**/*.{mm,h,m}",
@@ -28,20 +28,19 @@
     "USE_HEADERMAP": "YES",
     "HEADER_SEARCH_PATHS": "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_TARGET_SRCROOT)\" \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/Headers/Private/React-Core\" "
   },
-  "compiler_flags": "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DRNVERSION=67 -Wno-comma -Wno-shorten-64-to-32 -Wno-documentation",
+  "compiler_flags": "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DRNVERSION=68 -Wno-comma -Wno-shorten-64-to-32 -Wno-documentation",
   "xcconfig": {
     "CLANG_CXX_LANGUAGE_STANDARD": "c++14",
     "HEADER_SEARCH_PATHS": "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/glog\" \"$(PODS_ROOT)/RCT-Folly\" \"${PODS_ROOT}/Headers/Public/React-hermes\" \"${PODS_ROOT}/Headers/Public/hermes-engine\"",
-    "OTHER_CFLAGS": "$(inherited) -DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DRNVERSION=67"
+    "OTHER_CFLAGS": "$(inherited) -DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DRNVERSION=68"
   },
   "requires_arc": true,
   "dependencies": {
-    "React": [],
+    "React-Core": [],
     "FBLazyVector": [],
     "FBReactNativeSpec": [],
     "RCTRequired": [],
     "RCTTypeSafety": [],
-    "React-Core": [],
     "React-CoreModules": [],
     "React-Core/DevSupport": [],
     "React-RCTActionSheet": [],

--- a/ios/vendored/unversioned/react-native-reanimated/RNReanimated.podspec.json
+++ b/ios/vendored/unversioned/react-native-reanimated/RNReanimated.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "RNReanimated",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "summary": "More powerful alternative to Animated library for React Native.",
   "description": "RNReanimated",
   "homepage": "https://github.com/software-mansion/react-native-reanimated",
@@ -14,7 +14,7 @@
   },
   "source": {
     "git": "https://github.com/software-mansion/react-native-reanimated.git",
-    "tag": "2.6.0"
+    "tag": "2.7.0"
   },
   "source_files": [
     "ios/**/*.{mm,h,m}",

--- a/ios/vendored/unversioned/react-native-reanimated/ios/LayoutReanimation/REAAnimationsManager.h
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/LayoutReanimation/REAAnimationsManager.h
@@ -1,6 +1,6 @@
 #import <Foundation/Foundation.h>
+#import <RNReanimated/REASnapshot.h>
 #import <React/RCTUIManager.h>
-#import "REASnapshot.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/ios/vendored/unversioned/react-native-reanimated/ios/LayoutReanimation/REAAnimationsManager.h
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/LayoutReanimation/REAAnimationsManager.h
@@ -5,10 +5,10 @@
 NS_ASSUME_NONNULL_BEGIN
 
 typedef NS_ENUM(NSInteger, ViewState) {
+  Inactive,
   Appearing,
   Disappearing,
   Layout,
-  Inactive,
   ToRemove,
 };
 

--- a/ios/vendored/unversioned/react-native-reanimated/ios/LayoutReanimation/REAAnimationsManager.m
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/LayoutReanimation/REAAnimationsManager.m
@@ -14,6 +14,7 @@ typedef NS_ENUM(NSInteger, FrameConfigType) { EnteringFrame, ExitingFrame };
 
 - (void)removeLeftovers;
 - (void)scheduleCleaning;
+- (double)getDoubleOrZero:(NSNumber *)number;
 
 @end
 
@@ -150,6 +151,10 @@ typedef NS_ENUM(NSInteger, FrameConfigType) { EnteringFrame, ExitingFrame };
   NSMutableSet<NSNumber *> *roots = [NSMutableSet new];
   for (NSNumber *viewTag in _toRemove) {
     UIView *view = _viewForTag[viewTag];
+    if (view == nil) {
+      view = [_reaUiManager viewForReactTag:viewTag];
+      _viewForTag[viewTag] = view;
+    }
     [self findRoot:view roots:roots];
   }
   for (NSNumber *viewTag in roots) {
@@ -190,31 +195,40 @@ typedef NS_ENUM(NSInteger, FrameConfigType) { EnteringFrame, ExitingFrame };
   [self setNewProps:[newStyle mutableCopy] forView:_viewForTag[tag] withComponentData:componentData];
 }
 
+- (double)getDoubleOrZero:(NSNumber *)number
+{
+  double doubleValue = [number doubleValue];
+  if (doubleValue != doubleValue) { // NaN != NaN
+    return 0;
+  }
+  return doubleValue;
+}
+
 - (void)setNewProps:(NSMutableDictionary *)newProps
               forView:(UIView *)view
     withComponentData:(RCTComponentData *)componentData
 {
   if (newProps[@"height"]) {
-    double height = [newProps[@"height"] doubleValue];
+    double height = [self getDoubleOrZero:newProps[@"height"]];
     double oldHeight = view.bounds.size.height;
     view.bounds = CGRectMake(0, 0, view.bounds.size.width, height);
     view.center = CGPointMake(view.center.x, view.center.y - oldHeight / 2.0 + view.bounds.size.height / 2.0);
     [newProps removeObjectForKey:@"height"];
   }
   if (newProps[@"width"]) {
-    double width = [newProps[@"width"] doubleValue];
+    double width = [self getDoubleOrZero:newProps[@"width"]];
     double oldWidth = view.bounds.size.width;
     view.bounds = CGRectMake(0, 0, width, view.bounds.size.height);
     view.center = CGPointMake(view.center.x + view.bounds.size.width / 2.0 - oldWidth / 2.0, view.center.y);
     [newProps removeObjectForKey:@"width"];
   }
   if (newProps[@"originX"]) {
-    double originX = [newProps[@"originX"] doubleValue];
+    double originX = [self getDoubleOrZero:newProps[@"originX"]];
     view.center = CGPointMake(originX + view.bounds.size.width / 2.0, view.center.y);
     [newProps removeObjectForKey:@"originX"];
   }
   if (newProps[@"originY"]) {
-    double originY = [newProps[@"originY"] doubleValue];
+    double originY = [self getDoubleOrZero:newProps[@"originY"]];
     view.center = CGPointMake(view.center.x, originY + view.bounds.size.height / 2.0);
     [newProps removeObjectForKey:@"originY"];
   }

--- a/ios/vendored/unversioned/react-native-reanimated/ios/LayoutReanimation/REAAnimationsManager.m
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/LayoutReanimation/REAAnimationsManager.m
@@ -1,9 +1,9 @@
-#import "REAAnimationsManager.h"
+#import <RNReanimated/REAAnimationsManager.h>
+#import <RNReanimated/REAUIManager.h>
 #import <React/RCTComponentData.h>
 #import <React/RCTTextView.h>
 #import <React/UIView+Private.h>
 #import <React/UIView+React.h>
-#import "REAUIManager.h"
 
 @interface REAAnimationsManager ()
 

--- a/ios/vendored/unversioned/react-native-reanimated/ios/LayoutReanimation/REASnapshot.m
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/LayoutReanimation/REASnapshot.m
@@ -1,5 +1,5 @@
-#import "REASnapshot.h"
 #import <Foundation/Foundation.h>
+#import <RNReanimated/REASnapshot.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/ios/vendored/unversioned/react-native-reanimated/ios/LayoutReanimation/REAUIManager.h
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/LayoutReanimation/REAUIManager.h
@@ -1,7 +1,7 @@
+#import <RNReanimated/REAAnimationsManager.h>
 #import <React/RCTBridge+Private.h>
 #import <React/RCTDefines.h>
 #import <React/RCTUIManager.h>
-#import "REAAnimationsManager.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/ios/vendored/unversioned/react-native-reanimated/ios/LayoutReanimation/REAUIManager.mm
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/LayoutReanimation/REAUIManager.mm
@@ -1,9 +1,8 @@
-#import "REAUIManager.h"
 #import <Foundation/Foundation.h>
-#include "FeaturesConfig.h"
-#import "REAIOSScheduler.h"
-#include "Scheduler.h"
-
+#import <RNReanimated/FeaturesConfig.h>
+#import <RNReanimated/REAIOSScheduler.h>
+#import <RNReanimated/REAUIManager.h>
+#import <RNReanimated/Scheduler.h>
 #import <React/RCTComponentData.h>
 #import <React/RCTLayoutAnimation.h>
 #import <React/RCTLayoutAnimationGroup.h>

--- a/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REAAlwaysNode.h
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REAAlwaysNode.h
@@ -1,4 +1,4 @@
-#import "REANode.h"
+#import <RNReanimated/REANode.h>
 
 @interface REAAlwaysNode : REANode <REAFinalNode>
 @end

--- a/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REAAlwaysNode.m
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REAAlwaysNode.m
@@ -1,11 +1,11 @@
-#import "REAAlwaysNode.h"
+#import <RNReanimated/REAAlwaysNode.h>
+#import <RNReanimated/REAModule.h>
+#import <RNReanimated/REANodesManager.h>
+#import <RNReanimated/REAStyleNode.h>
+#import <RNReanimated/REAUtils.h>
 #import <React/RCTConvert.h>
 #import <React/RCTLog.h>
 #import <React/RCTUIManager.h>
-#import "REAModule.h"
-#import "REANodesManager.h"
-#import "REAStyleNode.h"
-#import "REAUtils.h"
 
 @implementation REAAlwaysNode {
   NSNumber *_nodeToBeEvaluated;

--- a/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REABezierNode.h
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REABezierNode.h
@@ -1,4 +1,4 @@
-#import "REANode.h"
+#import <RNReanimated/REANode.h>
 
 @interface REABezierNode : REANode
 

--- a/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REABezierNode.m
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REABezierNode.m
@@ -1,10 +1,9 @@
-#include <tgmath.h>
-
+#import <RNReanimated/REABezierNode.h>
+#import <RNReanimated/REANodesManager.h>
+#import <RNReanimated/REAUtils.h>
 #import <React/RCTConvert.h>
 #import <React/RCTLog.h>
-#import "REABezierNode.h"
-#import "REANodesManager.h"
-#import "REAUtils.h"
+#include <tgmath.h>
 
 #define EPS 1e-5
 

--- a/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REABlockNode.h
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REABlockNode.h
@@ -1,4 +1,4 @@
-#import "REANode.h"
+#import <RNReanimated/REANode.h>
 
 @interface REABlockNode : REANode
 

--- a/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REABlockNode.m
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REABlockNode.m
@@ -1,5 +1,5 @@
-#import "REABlockNode.h"
-#import "REANodesManager.h"
+#import <RNReanimated/REABlockNode.h>
+#import <RNReanimated/REANodesManager.h>
 
 @implementation REABlockNode {
   NSArray<NSNumber *> *_block;

--- a/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REACallFuncNode.h
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REACallFuncNode.h
@@ -1,5 +1,5 @@
 
-#import "REANode.h"
+#import <RNReanimated/REANode.h>
 
 @interface REACallFuncNode : REANode
 

--- a/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REACallFuncNode.m
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REACallFuncNode.m
@@ -1,10 +1,10 @@
 
 
-#import "REACallFuncNode.h"
-#import "REAFunctionNode.h"
-#import "REANodesManager.h"
-#import "REAParamNode.h"
-#import "REAUtils.h"
+#import <RNReanimated/REACallFuncNode.h>
+#import <RNReanimated/REAFunctionNode.h>
+#import <RNReanimated/REANodesManager.h>
+#import <RNReanimated/REAParamNode.h>
+#import <RNReanimated/REAUtils.h>
 
 @implementation REACallFuncNode {
   NSNumber *_whatNodeID;

--- a/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REAClockNodes.h
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REAClockNodes.h
@@ -1,4 +1,4 @@
-#import "REANode.h"
+#import <RNReanimated/REANode.h>
 
 @interface REAClockNode : REANode
 @property (nonatomic, readonly) BOOL isRunning;

--- a/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REAClockNodes.m
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REAClockNodes.m
@@ -1,9 +1,9 @@
-#import "REAClockNodes.h"
+#import <RNReanimated/REAClockNodes.h>
+#import <RNReanimated/REANodesManager.h>
+#import <RNReanimated/REAParamNode.h>
+#import <RNReanimated/REAUtils.h>
 #import <React/RCTConvert.h>
 #import <React/RCTLog.h>
-#import "REANodesManager.h"
-#import "REAParamNode.h"
-#import "REAUtils.h"
 
 @interface REAClockNode ()
 

--- a/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REAConcatNode.h
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REAConcatNode.h
@@ -1,4 +1,4 @@
-#import "REANode.h"
+#import <RNReanimated/REANode.h>
 
 @interface REAConcatNode : REANode
 

--- a/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REAConcatNode.m
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REAConcatNode.m
@@ -1,6 +1,6 @@
-#import "REAConcatNode.h"
-#import "REANodesManager.h"
-#import "REAValueNode.h"
+#import <RNReanimated/REAConcatNode.h>
+#import <RNReanimated/REANodesManager.h>
+#import <RNReanimated/REAValueNode.h>
 
 @implementation REAConcatNode {
   NSArray<NSNumber *> *_input;

--- a/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REACondNode.h
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REACondNode.h
@@ -1,4 +1,4 @@
-#import "REANode.h"
+#import <RNReanimated/REANode.h>
 
 @interface REACondNode : REANode
 

--- a/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REACondNode.m
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REACondNode.m
@@ -1,8 +1,8 @@
-#import "REACondNode.h"
+#import <RNReanimated/REACondNode.h>
+#import <RNReanimated/REANodesManager.h>
+#import <RNReanimated/REAUtils.h>
 #import <React/RCTConvert.h>
 #import <React/RCTLog.h>
-#import "REANodesManager.h"
-#import "REAUtils.h"
 
 @implementation REACondNode {
   NSNumber *_condNodeID;

--- a/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/READebugNode.h
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/READebugNode.h
@@ -1,4 +1,4 @@
-#import "REANode.h"
+#import <RNReanimated/REANode.h>
 
 @interface READebugNode : REANode
 

--- a/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/READebugNode.m
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/READebugNode.m
@@ -1,8 +1,8 @@
-#import "READebugNode.h"
+#import <RNReanimated/READebugNode.h>
+#import <RNReanimated/REANodesManager.h>
+#import <RNReanimated/REAUtils.h>
 #import <React/RCTConvert.h>
 #import <React/RCTLog.h>
-#import "REANodesManager.h"
-#import "REAUtils.h"
 
 @implementation READebugNode {
   NSNumber *_valueNodeID;

--- a/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REAEventNode.h
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REAEventNode.h
@@ -1,5 +1,4 @@
-#import "REANode.h"
-
+#import <RNReanimated/REANode.h>
 #import <React/RCTEventDispatcher.h>
 
 @interface REAEventNode : REANode

--- a/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REAEventNode.m
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REAEventNode.m
@@ -1,6 +1,6 @@
-#import "REAEventNode.h"
-#import "REANodesManager.h"
-#import "REAValueNode.h"
+#import <RNReanimated/REAEventNode.h>
+#import <RNReanimated/REANodesManager.h>
+#import <RNReanimated/REAValueNode.h>
 
 @implementation REAEventNode {
   NSArray *_argMapping;

--- a/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REAFunctionNode.h
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REAFunctionNode.h
@@ -1,5 +1,5 @@
 
-#import "REANode.h"
+#import <RNReanimated/REANode.h>
 
 @interface REAFunctionNode : REANode
 

--- a/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REAFunctionNode.m
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REAFunctionNode.m
@@ -1,7 +1,7 @@
 
-#import "REAFunctionNode.h"
-#import "REANodesManager.h"
-#import "REAParamNode.h"
+#import <RNReanimated/REAFunctionNode.h>
+#import <RNReanimated/REANodesManager.h>
+#import <RNReanimated/REAParamNode.h>
 
 @implementation REAFunctionNode {
   NSNumber *_nodeToBeEvaluated;

--- a/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REAJSCallNode.h
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REAJSCallNode.h
@@ -1,4 +1,4 @@
-#import "REANode.h"
+#import <RNReanimated/REANode.h>
 
 @interface REAJSCallNode : REANode
 

--- a/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REAJSCallNode.m
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REAJSCallNode.m
@@ -1,6 +1,6 @@
-#import "REAJSCallNode.h"
-#import "REAModule.h"
-#import "REANodesManager.h"
+#import <RNReanimated/REAJSCallNode.h>
+#import <RNReanimated/REAModule.h>
+#import <RNReanimated/REANodesManager.h>
 
 @implementation REAJSCallNode {
   NSArray<NSNumber *> *_input;

--- a/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REANode.m
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REANode.m
@@ -1,5 +1,5 @@
-#import "REANode.h"
-#import "REANodesManager.h"
+#import <RNReanimated/REANode.h>
+#import <RNReanimated/REANodesManager.h>
 
 #import <React/RCTDefines.h>
 

--- a/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REAOperatorNode.h
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REAOperatorNode.h
@@ -1,4 +1,4 @@
-#import "REANode.h"
+#import <RNReanimated/REANode.h>
 
 @interface REAOperatorNode : REANode
 

--- a/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REAOperatorNode.m
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REAOperatorNode.m
@@ -1,7 +1,6 @@
+#import <RNReanimated/REANodesManager.h>
+#import <RNReanimated/REAOperatorNode.h>
 #include <tgmath.h>
-
-#import "REANodesManager.h"
-#import "REAOperatorNode.h"
 
 typedef id (^REAOperatorBlock)(NSArray<REANode *> *inputNodes);
 

--- a/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REAParamNode.h
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REAParamNode.h
@@ -1,4 +1,4 @@
-#import "REAValueNode.h"
+#import <RNReanimated/REAValueNode.h>
 
 @interface REAParamNode : REAValueNode
 

--- a/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REAParamNode.m
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REAParamNode.m
@@ -1,7 +1,7 @@
-#import "REAParamNode.h"
-#import "REAClockNodes.h"
-#import "REANodesManager.h"
-#import "REAValueNode.h"
+#import <RNReanimated/REAClockNodes.h>
+#import <RNReanimated/REANodesManager.h>
+#import <RNReanimated/REAParamNode.h>
+#import <RNReanimated/REAValueNode.h>
 
 @implementation REAParamNode {
   NSMutableArray<REANodeID> *_argstack;

--- a/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REAPropsNode.h
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REAPropsNode.h
@@ -1,4 +1,4 @@
-#import "REANode.h"
+#import <RNReanimated/REANode.h>
 
 @interface REAPropsNode : REANode <REAFinalNode>
 

--- a/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REAPropsNode.m
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REAPropsNode.m
@@ -1,9 +1,7 @@
-#import "REAPropsNode.h"
-
-#import "REAModule.h"
-#import "REANodesManager.h"
-#import "REAStyleNode.h"
-
+#import <RNReanimated/REAModule.h>
+#import <RNReanimated/REANodesManager.h>
+#import <RNReanimated/REAPropsNode.h>
+#import <RNReanimated/REAStyleNode.h>
 #import <React/RCTComponentData.h>
 #import <React/RCTLog.h>
 #import <React/RCTUIManager.h>

--- a/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REASetNode.h
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REASetNode.h
@@ -1,4 +1,4 @@
-#import "REANode.h"
+#import <RNReanimated/REANode.h>
 
 @interface REASetNode : REANode
 

--- a/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REASetNode.m
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REASetNode.m
@@ -1,9 +1,9 @@
-#import "REASetNode.h"
+#import <RNReanimated/REANodesManager.h>
+#import <RNReanimated/REASetNode.h>
+#import <RNReanimated/REAUtils.h>
+#import <RNReanimated/REAValueNode.h>
 #import <React/RCTConvert.h>
 #import <React/RCTLog.h>
-#import "REANodesManager.h"
-#import "REAUtils.h"
-#import "REAValueNode.h"
 
 @implementation REASetNode {
   NSNumber *_whatNodeID;

--- a/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REAStyleNode.h
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REAStyleNode.h
@@ -1,4 +1,4 @@
-#import "REANode.h"
+#import <RNReanimated/REANode.h>
 
 @interface REAStyleNode : REANode
 

--- a/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REAStyleNode.m
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REAStyleNode.m
@@ -1,6 +1,5 @@
-#import "REAStyleNode.h"
-
-#import "REANodesManager.h"
+#import <RNReanimated/REANodesManager.h>
+#import <RNReanimated/REAStyleNode.h>
 
 @implementation REAStyleNode {
   NSMutableDictionary<NSString *, REANodeID> *_styleConfig;

--- a/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REATransformNode.h
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REATransformNode.h
@@ -1,4 +1,4 @@
-#import "REANode.h"
+#import <RNReanimated/REANode.h>
 
 @interface REATransformNode : REANode
 

--- a/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REATransformNode.m
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REATransformNode.m
@@ -1,6 +1,6 @@
-#import "REATransformNode.h"
+#import <RNReanimated/REANodesManager.h>
+#import <RNReanimated/REATransformNode.h>
 #import <React/RCTConvert.h>
-#import "REANodesManager.h"
 
 @implementation REATransformNode {
   NSArray<id> *_transformConfigs;

--- a/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REAValueNode.h
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REAValueNode.h
@@ -1,6 +1,4 @@
-#import <UIKit/UIKit.h>
-
-#import "REANode.h"
+#import <RNReanimated/REANode.h>
 
 @class REAValueNode;
 

--- a/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REAValueNode.m
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/Nodes/REAValueNode.m
@@ -1,4 +1,4 @@
-#import "REAValueNode.h"
+#import <RNReanimated/REAValueNode.h>
 
 @implementation REAValueNode {
   NSNumber *_value;

--- a/ios/vendored/unversioned/react-native-reanimated/ios/REAEventDispatcher.m
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/REAEventDispatcher.m
@@ -1,4 +1,4 @@
-#import "REAEventDispatcher.h"
+#import <RNReanimated/REAEventDispatcher.h>
 #import <RNReanimated/REAModule.h>
 #import <React/RCTBridge+Private.h>
 #import <React/RCTDefines.h>

--- a/ios/vendored/unversioned/react-native-reanimated/ios/REAModule.h
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/REAModule.h
@@ -5,7 +5,7 @@
 #import <React/RCTUIManagerObserverCoordinator.h>
 #import <React/RCTUIManagerUtils.h>
 
-#import "REAValueNode.h"
+#import <RNReanimated/REAValueNode.h>
 
 @interface REAModule : RCTEventEmitter <RCTBridgeModule, RCTEventDispatcherObserver, RCTUIManagerObserver>
 

--- a/ios/vendored/unversioned/react-native-reanimated/ios/REAModule.m
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/REAModule.m
@@ -28,6 +28,8 @@ RCT_EXPORT_MODULE(ReanimatedModule);
   return RCTGetUIManagerQueue();
 }
 
+#pragma mark-- Initialize
+
 - (void)setBridge:(RCTBridge *)bridge
 {
   [super setBridge:bridge];
@@ -38,6 +40,11 @@ RCT_EXPORT_MODULE(ReanimatedModule);
   _transitionManager = [[REATransitionManager alloc] initWithUIManager:self.bridge.uiManager];
 
   [bridge.uiManager.observerCoordinator addObserver:self];
+}
+
+RCT_EXPORT_METHOD(installTurboModule)
+{
+  // TODO: Move initialization from UIResponder+Reanimated to here
 }
 
 #pragma mark-- Transitioning API
@@ -119,15 +126,6 @@ RCT_EXPORT_METHOD(detachEvent
   }];
 }
 
-RCT_EXPORT_METHOD(configureProps
-                  : (nonnull NSArray<NSString *> *)nativeProps uiProps
-                  : (nonnull NSArray<NSString *> *)uiProps)
-{
-  [self addOperationBlock:^(REANodesManager *nodesManager) {
-    [nodesManager configureProps:[NSSet setWithArray:nativeProps] uiProps:[NSSet setWithArray:uiProps]];
-  }];
-}
-
 RCT_EXPORT_METHOD(setValue : (nonnull NSNumber *)nodeID newValue : (nonnull NSNumber *)newValue)
 {
   [self addOperationBlock:^(REANodesManager *nodesManager) {
@@ -153,6 +151,7 @@ RCT_EXPORT_METHOD(triggerRender)
 
 - (void)uiManagerWillPerformMounting:(RCTUIManager *)uiManager
 {
+  [_nodesManager maybeFlushUpdateBuffer];
   if (_operations.count == 0) {
     return;
   }

--- a/ios/vendored/unversioned/react-native-reanimated/ios/REAModule.m
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/REAModule.m
@@ -1,8 +1,7 @@
-#import "REAModule.h"
-
-#import "REANodesManager.h"
-#import "Transitioning/REATransitionManager.h"
-#import "native/NativeProxy.h"
+#import <RNReanimated/NativeProxy.h>
+#import <RNReanimated/REAModule.h>
+#import <RNReanimated/REANodesManager.h>
+#import <RNReanimated/REATransitionManager.h>
 
 typedef void (^AnimatedOperation)(REANodesManager *nodesManager);
 

--- a/ios/vendored/unversioned/react-native-reanimated/ios/REANodesManager.h
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/REANodesManager.h
@@ -64,7 +64,8 @@ typedef void (^REAEventHandler)(NSString *eventName, id<RCTEvent> event);
 
 // configuration
 
-- (void)configureProps:(nonnull NSSet<NSString *> *)nativeProps uiProps:(nonnull NSSet<NSString *> *)uiProps;
+- (void)configureUiProps:(nonnull NSSet<NSString *> *)uiPropsSet
+          andNativeProps:(nonnull NSSet<NSString *> *)nativePropsSet;
 
 - (void)updateProps:(nonnull NSDictionary *)props
       ofViewWithTag:(nonnull NSNumber *)viewTag
@@ -77,5 +78,7 @@ typedef void (^REAEventHandler)(NSString *eventName, id<RCTEvent> event);
 - (void)dispatchEvent:(id<RCTEvent>)event;
 
 - (void)setValueForNodeID:(nonnull NSNumber *)nodeID value:(nonnull NSNumber *)newValue;
+
+- (void)maybeFlushUpdateBuffer;
 
 @end

--- a/ios/vendored/unversioned/react-native-reanimated/ios/REANodesManager.h
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/REANodesManager.h
@@ -1,8 +1,7 @@
 #import <Foundation/Foundation.h>
-
+#import <RNReanimated/REANode.h>
 #import <React/RCTBridgeModule.h>
 #import <React/RCTUIManager.h>
-#import "REANode.h"
 
 @class REAModule;
 

--- a/ios/vendored/unversioned/react-native-reanimated/ios/REANodesManager.m
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/REANodesManager.m
@@ -1,29 +1,27 @@
-#import "REANodesManager.h"
-
+#import <RNReanimated/REAAlwaysNode.h>
+#import <RNReanimated/REABezierNode.h>
+#import <RNReanimated/REABlockNode.h>
+#import <RNReanimated/REACallFuncNode.h>
+#import <RNReanimated/REAClockNodes.h>
+#import <RNReanimated/REAConcatNode.h>
+#import <RNReanimated/REACondNode.h>
+#import <RNReanimated/READebugNode.h>
+#import <RNReanimated/REAEventNode.h>
+#import <RNReanimated/REAFunctionNode.h>
+#import <RNReanimated/REAJSCallNode.h>
+#import <RNReanimated/REAModule.h>
+#import <RNReanimated/REANode.h>
+#import <RNReanimated/REANodesManager.h>
+#import <RNReanimated/REAOperatorNode.h>
+#import <RNReanimated/REAParamNode.h>
+#import <RNReanimated/REAPropsNode.h>
+#import <RNReanimated/REASetNode.h>
+#import <RNReanimated/REAStyleNode.h>
+#import <RNReanimated/REATransformNode.h>
+#import <RNReanimated/REAValueNode.h>
 #import <React/RCTConvert.h>
-
 #import <React/RCTShadowView.h>
 #import <stdatomic.h>
-#import "Nodes/REAAlwaysNode.h"
-#import "Nodes/REABezierNode.h"
-#import "Nodes/REABlockNode.h"
-#import "Nodes/REACallFuncNode.h"
-#import "Nodes/REAClockNodes.h"
-#import "Nodes/REAConcatNode.h"
-#import "Nodes/REACondNode.h"
-#import "Nodes/READebugNode.h"
-#import "Nodes/REAEventNode.h"
-#import "Nodes/REAFunctionNode.h"
-#import "Nodes/REAJSCallNode.h"
-#import "Nodes/REANode.h"
-#import "Nodes/REAOperatorNode.h"
-#import "Nodes/REAParamNode.h"
-#import "Nodes/REAPropsNode.h"
-#import "Nodes/REASetNode.h"
-#import "Nodes/REAStyleNode.h"
-#import "Nodes/REATransformNode.h"
-#import "Nodes/REAValueNode.h"
-#import "REAModule.h"
 
 // Interface below has been added in order to use private methods of RCTUIManager,
 // RCTUIManager#UpdateView is a React Method which is exported to JS but in

--- a/ios/vendored/unversioned/react-native-reanimated/ios/Transitioning/RCTConvert+REATransition.h
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/Transitioning/RCTConvert+REATransition.h
@@ -1,6 +1,5 @@
+#import <RNReanimated/REATransition.h>
 #import <React/RCTConvert.h>
-
-#import "REATransition.h"
 
 @interface RCTConvert (REATransition)
 

--- a/ios/vendored/unversioned/react-native-reanimated/ios/Transitioning/RCTConvert+REATransition.m
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/Transitioning/RCTConvert+REATransition.m
@@ -1,4 +1,4 @@
-#import "RCTConvert+REATransition.h"
+#import <RNReanimated/RCTConvert+REATransition.h>
 
 @implementation RCTConvert (REATransition)
 

--- a/ios/vendored/unversioned/react-native-reanimated/ios/Transitioning/REAAllTransitions.h
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/Transitioning/REAAllTransitions.h
@@ -1,4 +1,4 @@
-#import "REATransition.h"
+#import <RNReanimated/REATransition.h>
 
 @interface REATransitionGroup : REATransition
 @property (nonatomic) BOOL sequence;

--- a/ios/vendored/unversioned/react-native-reanimated/ios/Transitioning/REAAllTransitions.m
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/Transitioning/REAAllTransitions.m
@@ -1,7 +1,6 @@
+#import <RNReanimated/RCTConvert+REATransition.h>
+#import <RNReanimated/REAAllTransitions.h>
 #import <React/RCTViewManager.h>
-
-#import "RCTConvert+REATransition.h"
-#import "REAAllTransitions.h"
 
 @interface REASnapshotRemover : NSObject <CAAnimationDelegate>
 @end

--- a/ios/vendored/unversioned/react-native-reanimated/ios/Transitioning/REATransition.h
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/Transitioning/REATransition.h
@@ -1,9 +1,8 @@
 #import <QuartzCore/QuartzCore.h>
+#import <RNReanimated/REATransitionAnimation.h>
+#import <RNReanimated/REATransitionValues.h>
 #import <React/RCTView.h>
 #import <UIKit/UIKit.h>
-
-#import "REATransitionAnimation.h"
-#import "REATransitionValues.h"
 
 // TODO: fix below implementation
 #define IS_LAYOUT_ONLY(view) ([view isKindOfClass:[RCTView class]] && view.backgroundColor == nil)

--- a/ios/vendored/unversioned/react-native-reanimated/ios/Transitioning/REATransition.m
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/Transitioning/REATransition.m
@@ -1,11 +1,10 @@
 #import <QuartzCore/QuartzCore.h>
+#import <RNReanimated/RCTConvert+REATransition.h>
+#import <RNReanimated/REATransition.h>
+#import <RNReanimated/REATransitionValues.h>
 #import <React/RCTConvert.h>
 #import <React/RCTViewManager.h>
 #import <UIKit/UIKit.h>
-
-#import "RCTConvert+REATransition.h"
-#import "REATransition.h"
-#import "REATransitionValues.h"
 
 #define DEFAULT_PROPAGATION_SPEED 3
 

--- a/ios/vendored/unversioned/react-native-reanimated/ios/Transitioning/REATransitionAnimation.m
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/Transitioning/REATransitionAnimation.m
@@ -1,6 +1,5 @@
+#import <RNReanimated/REATransitionAnimation.h>
 #import <UIKit/UIKit.h>
-
-#import "REATransitionAnimation.h"
 
 #define DEFAULT_DURATION 0.25
 

--- a/ios/vendored/unversioned/react-native-reanimated/ios/Transitioning/REATransitionManager.m
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/Transitioning/REATransitionManager.m
@@ -1,9 +1,7 @@
-#import "REATransitionManager.h"
-
+#import <RNReanimated/REATransition.h>
+#import <RNReanimated/REATransitionManager.h>
 #import <React/RCTUIManager.h>
 #import <React/RCTUIManagerObserverCoordinator.h>
-
-#import "REATransition.h"
 
 @interface REATransitionManager () <RCTUIManagerObserver>
 @end

--- a/ios/vendored/unversioned/react-native-reanimated/ios/Transitioning/REATransitionValues.m
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/Transitioning/REATransitionValues.m
@@ -1,8 +1,7 @@
+#import <RNReanimated/REATransition.h>
+#import <RNReanimated/REATransitionValues.h>
 #import <React/RCTView.h>
 #import <React/RCTViewManager.h>
-
-#import "REATransition.h"
-#import "REATransitionValues.h"
 
 @implementation REATransitionValues
 

--- a/ios/vendored/unversioned/react-native-reanimated/ios/native/NativeMethods.h
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/native/NativeMethods.h
@@ -1,11 +1,9 @@
 #import <Foundation/Foundation.h>
-#import <RNGestureHandlerStateManager.h>
+#import <RNReanimated/RNGestureHandlerStateManager.h>
 #import <React/RCTUIManager.h>
 #include <string>
-#import <string>
 #include <utility>
 #include <vector>
-#import <vector>
 
 namespace reanimated {
 

--- a/ios/vendored/unversioned/react-native-reanimated/ios/native/NativeMethods.h
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/native/NativeMethods.h
@@ -1,11 +1,11 @@
 #import <Foundation/Foundation.h>
+#import <RNGestureHandlerStateManager.h>
 #import <React/RCTUIManager.h>
 #include <string>
 #import <string>
 #include <utility>
 #include <vector>
 #import <vector>
-#import "RNGestureHandlerStateManager.h"
 
 namespace reanimated {
 

--- a/ios/vendored/unversioned/react-native-reanimated/ios/native/NativeMethods.mm
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/native/NativeMethods.mm
@@ -1,4 +1,4 @@
-#import "NativeMethods.h"
+#import <RNReanimated/NativeMethods.h>
 #import <React/RCTEventDispatcher.h>
 #import <React/RCTScrollView.h>
 

--- a/ios/vendored/unversioned/react-native-reanimated/ios/native/NativeProxy.h
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/native/NativeProxy.h
@@ -1,7 +1,7 @@
-#import <React/RCTEventDispatcher.h>
-
 #if __cplusplus
+
 #import <RNReanimated/NativeReanimatedModule.h>
+#import <React/RCTEventDispatcher.h>
 #include <memory>
 
 namespace reanimated {

--- a/ios/vendored/unversioned/react-native-reanimated/ios/native/NativeProxy.mm
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/native/NativeProxy.mm
@@ -1,22 +1,21 @@
-#if TARGET_IPHONE_SIMULATOR
-#import <dlfcn.h>
-#endif
-
+#import <RNReanimated/LayoutAnimationsProxy.h>
+#import <RNReanimated/NativeMethods.h>
+#import <RNReanimated/NativeProxy.h>
+#import <RNReanimated/REAAnimationsManager.h>
+#import <RNReanimated/REAIOSErrorHandler.h>
+#import <RNReanimated/REAIOSScheduler.h>
+#import <RNReanimated/REAModule.h>
+#import <RNReanimated/REANodesManager.h>
+#import <RNReanimated/REAUIManager.h>
+#import <RNReanimated/RNGestureHandlerStateManager.h>
+#import <RNReanimated/ReanimatedSensorContainer.h>
 #import <React/RCTFollyConvert.h>
 #import <React/RCTUIManager.h>
 #import <folly/json.h>
 
-#import <RNGestureHandlerStateManager.h>
-#import "LayoutAnimationsProxy.h"
-#import "NativeMethods.h"
-#import "NativeProxy.h"
-#import "REAAnimationsManager.h"
-#import "REAIOSErrorHandler.h"
-#import "REAIOSScheduler.h"
-#import "REAModule.h"
-#import "REANodesManager.h"
-#import "REAUIManager.h"
-#import "ReanimatedSensorContainer.h"
+#if TARGET_IPHONE_SIMULATOR
+#import <dlfcn.h>
+#endif
 
 #if __has_include(<reacthermes/HermesExecutorFactory.h>)
 #import <reacthermes/HermesExecutorFactory.h>

--- a/ios/vendored/unversioned/react-native-reanimated/ios/native/NativeProxy.mm
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/native/NativeProxy.mm
@@ -1,8 +1,12 @@
+#if TARGET_IPHONE_SIMULATOR
+#import <dlfcn.h>
+#endif
 
 #import <React/RCTFollyConvert.h>
 #import <React/RCTUIManager.h>
 #import <folly/json.h>
 
+#import <RNGestureHandlerStateManager.h>
 #import "LayoutAnimationsProxy.h"
 #import "NativeMethods.h"
 #import "NativeProxy.h"
@@ -12,7 +16,7 @@
 #import "REAModule.h"
 #import "REANodesManager.h"
 #import "REAUIManager.h"
-#import "RNGestureHandlerStateManager.h"
+#import "ReanimatedSensorContainer.h"
 
 #if __has_include(<reacthermes/HermesExecutorFactory.h>)
 #import <reacthermes/HermesExecutorFactory.h>
@@ -26,6 +30,41 @@ namespace reanimated {
 
 using namespace facebook;
 using namespace react;
+
+static CGFloat SimAnimationDragCoefficient(void)
+{
+  static float (*UIAnimationDragCoefficient)(void) = NULL;
+#if TARGET_IPHONE_SIMULATOR
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    UIAnimationDragCoefficient = (float (*)(void))dlsym(RTLD_DEFAULT, "UIAnimationDragCoefficient");
+  });
+#endif
+  return UIAnimationDragCoefficient ? UIAnimationDragCoefficient() : 1.f;
+}
+
+static CFTimeInterval calculateTimestampWithSlowAnimations(CFTimeInterval currentTimestamp)
+{
+#if TARGET_IPHONE_SIMULATOR
+  static CFTimeInterval dragCoefChangedTimestamp = CACurrentMediaTime();
+  static CGFloat previousDragCoef = SimAnimationDragCoefficient();
+
+  const CGFloat dragCoef = SimAnimationDragCoefficient();
+  if (previousDragCoef != dragCoef) {
+    previousDragCoef = dragCoef;
+    dragCoefChangedTimestamp = CACurrentMediaTime();
+  }
+
+  const bool areSlowAnimationsEnabled = dragCoef != 1.f;
+  if (areSlowAnimationsEnabled) {
+    return (dragCoefChangedTimestamp + (currentTimestamp - dragCoefChangedTimestamp) / dragCoef);
+  } else {
+    return currentTimestamp;
+  }
+#else
+  return currentTimestamp;
+#endif
+}
 
 // COPIED FROM RCTTurboModule.mm
 static id convertJSIValueToObjCObject(jsi::Runtime &runtime, const jsi::Value &value);
@@ -85,6 +124,17 @@ static id convertJSIValueToObjCObject(jsi::Runtime &runtime, const jsi::Value &v
   }
 
   throw std::runtime_error("Unsupported jsi::jsi::Value kind");
+}
+
+static NSSet *convertProps(jsi::Runtime &rt, const jsi::Value &props)
+{
+  NSMutableSet *propsSet = [[NSMutableSet alloc] init];
+  jsi::Array propsNames = props.asObject(rt).asArray(rt);
+  for (int i = 0; i < propsNames.size(rt); i++) {
+    NSString *propName = @(propsNames.getValueAtIndex(rt, i).asString(rt).utf8(rt).c_str());
+    [propsSet addObject:propName];
+  }
+  return propsSet;
 }
 
 std::shared_ptr<NativeReanimatedModule> createReanimatedModule(
@@ -149,7 +199,7 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(
 
   auto requestRender = [reanimatedModule, &module](std::function<void(double)> onRender, jsi::Runtime &rt) {
     [reanimatedModule.nodesManager postOnAnimation:^(CADisplayLink *displayLink) {
-      double frameTimestamp = displayLink.targetTimestamp * 1000;
+      double frameTimestamp = calculateTimestampWithSlowAnimations(displayLink.targetTimestamp) * 1000;
       jsi::Object global = rt.global();
       jsi::String frameTimestampName = jsi::String::createFromAscii(rt, "_frameTimestamp");
       global.setProperty(rt, frameTimestampName, frameTimestamp);
@@ -158,7 +208,7 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(
     }];
   };
 
-  auto getCurrentTime = []() { return CACurrentMediaTime() * 1000; };
+  auto getCurrentTime = []() { return calculateTimestampWithSlowAnimations(CACurrentMediaTime()) * 1000; };
 
   // Layout Animations start
   REAUIManager *reaUiManagerNoCast = [bridge moduleForClass:[REAUIManager class]];
@@ -177,6 +227,13 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(
     if (animationsManager) {
       [animationsManager notifyAboutEnd:[NSNumber numberWithInt:tag] cancelled:isCancelled];
     }
+  };
+
+  auto configurePropsFunction = [reanimatedModule](
+                                    jsi::Runtime &rt, const jsi::Value &uiProps, const jsi::Value &nativeProps) {
+    NSSet *uiPropsSet = convertProps(rt, uiProps);
+    NSSet *nativePropsSet = convertProps(rt, nativeProps);
+    [reanimatedModule.nodesManager configureUiProps:uiPropsSet andNativeProps:nativePropsSet];
   };
 
   std::shared_ptr<LayoutAnimationsProxy> layoutAnimationsProxy =
@@ -224,14 +281,29 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(
 
   // Layout Animations end
 
+  // sensors
+  ReanimatedSensorContainer *reanimatedSensorContainer = [[ReanimatedSensorContainer alloc] init];
+  auto registerSensorFunction = [=](int sensorType, int interval, std::function<void(double[])> setter) -> int {
+    return [reanimatedSensorContainer registerSensor:(ReanimatedSensorType)sensorType
+                                            interval:interval
+                                              setter:^(double *data) {
+                                                setter(data);
+                                              }];
+  };
+
+  auto unregisterSensorFunction = [=](int sensorId) { [reanimatedSensorContainer unregisterSensor:sensorId]; };
+  // end sensors
+
   PlatformDepMethodsHolder platformDepMethodsHolder = {
       requestRender,
       propUpdater,
       scrollToFunction,
       measuringFunction,
       getCurrentTime,
+      registerSensorFunction,
+      unregisterSensorFunction,
       setGestureStateFunction,
-  };
+      configurePropsFunction};
 
   module = std::make_shared<NativeReanimatedModule>(
       jsInvoker,
@@ -246,7 +318,15 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(
 
   [reanimatedModule.nodesManager registerEventHandler:^(NSString *eventName, id<RCTEvent> event) {
     std::string eventNameString([eventName UTF8String]);
-    std::string eventAsString = folly::toJson(convertIdToFollyDynamic([event arguments][2]));
+
+    std::string eventAsString;
+    try {
+      eventAsString = folly::toJson(convertIdToFollyDynamic([event arguments][2]));
+    } catch (std::exception &) {
+      // Events from other libraries may contain NaN or INF values which cannot be represented in JSON.
+      // See https://github.com/software-mansion/react-native-reanimated/issues/1776 for details.
+      return;
+    }
 
     eventAsString = "{ NativeMap:" + eventAsString + "}";
     jsi::Object global = module->runtime->global();

--- a/ios/vendored/unversioned/react-native-reanimated/ios/native/REAIOSErrorHandler.h
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/native/REAIOSErrorHandler.h
@@ -1,9 +1,7 @@
-#pragma once
-
+#import <RNReanimated/ErrorHandler.h>
+#import <RNReanimated/Scheduler.h>
 #include <memory>
 #include <string>
-#include "ErrorHandler.h"
-#include "Scheduler.h"
 
 namespace reanimated {
 

--- a/ios/vendored/unversioned/react-native-reanimated/ios/native/REAIOSErrorHandler.mm
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/native/REAIOSErrorHandler.mm
@@ -1,5 +1,5 @@
-#include "REAIOSErrorHandler.h"
 #import <Foundation/Foundation.h>
+#import <RNReanimated/REAIOSErrorHandler.h>
 #import <React/RCTLog.h>
 
 namespace reanimated {

--- a/ios/vendored/unversioned/react-native-reanimated/ios/native/REAIOSLogger.h
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/native/REAIOSLogger.h
@@ -1,7 +1,5 @@
-#pragma once
-
+#import <RNReanimated/ReanimatedHiddenHeaders.h>
 #include <stdio.h>
-#include "ReanimatedHiddenHeaders.h"
 
 namespace reanimated {
 

--- a/ios/vendored/unversioned/react-native-reanimated/ios/native/REAIOSLogger.mm
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/native/REAIOSLogger.mm
@@ -1,5 +1,5 @@
-#include "REAIOSLogger.h"
 #import <Foundation/Foundation.h>
+#import <RNReanimated/REAIOSLogger.h>
 
 namespace reanimated {
 

--- a/ios/vendored/unversioned/react-native-reanimated/ios/native/REAIOSScheduler.h
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/native/REAIOSScheduler.h
@@ -1,10 +1,8 @@
-#pragma once
-
+#import <RNReanimated/Scheduler.h>
 #import <React/RCTUIManager.h>
 #import <ReactCommon/CallInvoker.h>
 #include <stdio.h>
 #include <memory>
-#include "Scheduler.h"
 
 namespace reanimated {
 

--- a/ios/vendored/unversioned/react-native-reanimated/ios/native/REAIOSScheduler.mm
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/native/REAIOSScheduler.mm
@@ -1,5 +1,5 @@
-#include "REAIOSScheduler.h"
-#include "RuntimeManager.h"
+#import <RNReanimated/REAIOSScheduler.h>
+#import <RNReanimated/RuntimeManager.h>
 
 namespace reanimated {
 

--- a/ios/vendored/unversioned/react-native-reanimated/ios/native/REAInitializer.h
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/native/REAInitializer.h
@@ -1,10 +1,3 @@
-//
-//  REAInitializer.h
-//  RNReanimated
-//
-//  Created by Szymon Kapala on 27/07/2021.
-//
-
 #import <Foundation/Foundation.h>
 #import <RNReanimated/NativeProxy.h>
 #import <RNReanimated/REAEventDispatcher.h>

--- a/ios/vendored/unversioned/react-native-reanimated/ios/native/REAInitializer.mm
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/native/REAInitializer.mm
@@ -1,5 +1,5 @@
-#import "REAInitializer.h"
-#import "REAUIManager.h"
+#import <RNReanimated/REAInitializer.h>
+#import <RNReanimated/REAUIManager.h>
 
 @interface RCTEventDispatcher (Reanimated)
 

--- a/ios/vendored/unversioned/react-native-reanimated/ios/native/UIResponder+Reanimated.mm
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/native/UIResponder+Reanimated.mm
@@ -1,6 +1,6 @@
-#import "REAInitializer.h"
-#import "REAUIManager.h"
-#import "UIResponder+Reanimated.h"
+#import <RNReanimated/REAInitializer.h>
+#import <RNReanimated/REAUIManager.h>
+#import <RNReanimated/UIResponder+Reanimated.h>
 
 #if __has_include(<reacthermes/HermesExecutorFactory.h>)
 #import <reacthermes/HermesExecutorFactory.h>

--- a/ios/vendored/unversioned/react-native-reanimated/ios/sensor/ReanimatedSensor.h
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/sensor/ReanimatedSensor.h
@@ -1,0 +1,25 @@
+#if __has_include(<CoreMotion/CoreMotion.h>)
+#import <CoreMotion/CoreMotion.h>
+#endif
+#import "ReanimatedSensorType.h"
+
+@interface ReanimatedSensor : NSObject {
+  ReanimatedSensorType _sensorType;
+  double _interval;
+  double _lastTimestamp;
+#if !TARGET_OS_TV
+  CMMotionManager *_motionManager;
+#endif
+  void (^_setter)(double[]);
+}
+
+- (instancetype)init:(ReanimatedSensorType)sensorType interval:(int)interval setter:(void (^)(double[]))setter;
+- (bool)initialize;
+- (bool)initializeGyroscope;
+- (bool)initializeAccelerometer;
+- (bool)initializeGravity;
+- (bool)initializeMagnetometer;
+- (bool)initializeOrientation;
+- (void)cancel;
+
+@end

--- a/ios/vendored/unversioned/react-native-reanimated/ios/sensor/ReanimatedSensor.h
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/sensor/ReanimatedSensor.h
@@ -1,7 +1,7 @@
 #if __has_include(<CoreMotion/CoreMotion.h>)
 #import <CoreMotion/CoreMotion.h>
 #endif
-#import "ReanimatedSensorType.h"
+#import <RNReanimated/ReanimatedSensorType.h>
 
 @interface ReanimatedSensor : NSObject {
   ReanimatedSensorType _sensorType;

--- a/ios/vendored/unversioned/react-native-reanimated/ios/sensor/ReanimatedSensor.m
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/sensor/ReanimatedSensor.m
@@ -1,0 +1,217 @@
+#import "ReanimatedSensor.h"
+
+#if __has_include(<CoreMotion/CoreMotion.h>)
+@implementation ReanimatedSensor
+
+- (instancetype)init:(ReanimatedSensorType)sensorType interval:(int)interval setter:(void (^)(double[]))setter
+{
+  self = [super init];
+  _sensorType = sensorType;
+  _interval = interval / 1000; // in seconds
+  _setter = setter;
+  _motionManager = [[CMMotionManager alloc] init];
+  return self;
+}
+
+- (bool)initialize
+{
+  if (_sensorType == ACCELEROMETER) {
+    return [self initializeAccelerometer];
+  } else if (_sensorType == GYROSCOPE) {
+    return [self initializeGyroscope];
+  } else if (_sensorType == GRAVITY) {
+    return [self initializeGravity];
+  } else if (_sensorType == MAGNETIC_FIELD) {
+    return [self initializeMagnetometer];
+  } else if (_sensorType == ROTATION_VECTOR) {
+    return [self initializeOrientation];
+  }
+
+  return false;
+}
+
+- (bool)initializeGyroscope
+{
+  if (![_motionManager isGyroAvailable]) {
+    return false;
+  }
+  [_motionManager setGyroUpdateInterval:_interval];
+  [_motionManager startGyroUpdates];
+  [_motionManager
+      startGyroUpdatesToQueue:[NSOperationQueue mainQueue]
+                  withHandler:^(CMGyroData *sensorData, NSError *error) {
+                    double currentTime = [[NSProcessInfo processInfo] systemUptime];
+                    if (currentTime - self->_lastTimestamp < self->_interval) {
+                      return;
+                    }
+                    double data[] = {sensorData.rotationRate.x, sensorData.rotationRate.y, sensorData.rotationRate.z};
+                    self->_setter(data);
+                    self->_lastTimestamp = currentTime;
+                  }];
+
+  return true;
+}
+
+- (bool)initializeAccelerometer
+{
+  if (![_motionManager isAccelerometerAvailable]) {
+    return false;
+  }
+  [_motionManager setAccelerometerUpdateInterval:_interval];
+  [_motionManager startAccelerometerUpdates];
+  [_motionManager
+      startAccelerometerUpdatesToQueue:[NSOperationQueue mainQueue]
+                           withHandler:^(CMAccelerometerData *sensorData, NSError *error) {
+                             double currentTime = [[NSProcessInfo processInfo] systemUptime];
+                             if (currentTime - self->_lastTimestamp < self->_interval) {
+                               return;
+                             }
+                             double data[] = {
+                                 sensorData.acceleration.x, sensorData.acceleration.y, sensorData.acceleration.z};
+                             self->_setter(data);
+                             self->_lastTimestamp = currentTime;
+                           }];
+
+  return true;
+}
+
+- (bool)initializeGravity
+{
+  if (![_motionManager isDeviceMotionAvailable]) {
+    return false;
+  }
+  [_motionManager setDeviceMotionUpdateInterval:_interval];
+  [_motionManager setShowsDeviceMovementDisplay:YES];
+  [_motionManager
+      startDeviceMotionUpdatesToQueue:[NSOperationQueue mainQueue]
+                          withHandler:^(CMDeviceMotion *sensorData, NSError *error) {
+                            double currentTime = [[NSProcessInfo processInfo] systemUptime];
+                            if (currentTime - self->_lastTimestamp < self->_interval) {
+                              return;
+                            }
+                            double data[] = {sensorData.gravity.x, sensorData.gravity.y, sensorData.gravity.z};
+                            self->_setter(data);
+                            self->_lastTimestamp = currentTime;
+                          }];
+
+  return true;
+}
+
+- (bool)initializeMagnetometer
+{
+  if (![_motionManager isMagnetometerAvailable]) {
+    return false;
+  }
+  [_motionManager setMagnetometerUpdateInterval:_interval];
+  [_motionManager startMagnetometerUpdates];
+  [_motionManager
+      startMagnetometerUpdatesToQueue:[NSOperationQueue mainQueue]
+                          withHandler:^(CMMagnetometerData *sensorData, NSError *error) {
+                            double currentTime = [[NSProcessInfo processInfo] systemUptime];
+                            if (currentTime - self->_lastTimestamp < self->_interval) {
+                              return;
+                            }
+                            double data[] = {
+                                sensorData.magneticField.x, sensorData.magneticField.y, sensorData.magneticField.z};
+                            self->_setter(data);
+                            self->_lastTimestamp = currentTime;
+                          }];
+
+  return true;
+}
+
+- (bool)initializeOrientation
+{
+  if (![_motionManager isDeviceMotionAvailable]) {
+    return false;
+  }
+  [_motionManager setDeviceMotionUpdateInterval:_interval];
+
+  [_motionManager setShowsDeviceMovementDisplay:YES];
+  [_motionManager startDeviceMotionUpdatesUsingReferenceFrame:CMAttitudeReferenceFrameXTrueNorthZVertical
+                                                      toQueue:[NSOperationQueue mainQueue]
+                                                  withHandler:^(CMDeviceMotion *sensorData, NSError *error) {
+                                                    double currentTime = [[NSProcessInfo processInfo] systemUptime];
+                                                    if (currentTime - self->_lastTimestamp < self->_interval) {
+                                                      return;
+                                                    }
+                                                    CMAttitude *attitude = sensorData.attitude;
+                                                    double data[] = {
+                                                        attitude.quaternion.x,
+                                                        attitude.quaternion.y,
+                                                        attitude.quaternion.z,
+                                                        attitude.quaternion.w,
+                                                        attitude.pitch,
+                                                        attitude.roll,
+                                                        attitude.yaw,
+                                                    };
+                                                    self->_setter(data);
+                                                    self->_lastTimestamp = currentTime;
+                                                  }];
+
+  return true;
+}
+
+- (void)cancel
+{
+  if (_sensorType == ACCELEROMETER) {
+    [_motionManager stopAccelerometerUpdates];
+  } else if (_sensorType == GYROSCOPE) {
+    [_motionManager stopGyroUpdates];
+  } else if (_sensorType == GRAVITY) {
+    [_motionManager stopDeviceMotionUpdates];
+  } else if (_sensorType == MAGNETIC_FIELD) {
+    [_motionManager stopMagnetometerUpdates];
+  } else if (_sensorType == ROTATION_VECTOR) {
+    [_motionManager stopDeviceMotionUpdates];
+  }
+}
+
+@end
+
+#else
+
+@implementation ReanimatedSensor
+
+- (instancetype)init:(ReanimatedSensorType)sensorType interval:(int)interval setter:(void (^)(double[]))setter
+{
+  self = [super init];
+  return self;
+}
+
+- (bool)initialize
+{
+  return false;
+}
+
+- (bool)initializeGyroscope
+{
+  return false;
+}
+
+- (bool)initializeAccelerometer
+{
+  return false;
+}
+
+- (bool)initializeGravity
+{
+  return false;
+}
+
+- (bool)initializeMagnetometer
+{
+  return false;
+}
+
+- (bool)initializeOrientation
+{
+  return false;
+}
+
+- (void)cancel
+{
+}
+
+@end
+#endif

--- a/ios/vendored/unversioned/react-native-reanimated/ios/sensor/ReanimatedSensor.m
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/sensor/ReanimatedSensor.m
@@ -1,4 +1,4 @@
-#import "ReanimatedSensor.h"
+#import <RNReanimated/ReanimatedSensor.h>
 
 #if __has_include(<CoreMotion/CoreMotion.h>)
 @implementation ReanimatedSensor

--- a/ios/vendored/unversioned/react-native-reanimated/ios/sensor/ReanimatedSensorContainer.h
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/sensor/ReanimatedSensorContainer.h
@@ -1,4 +1,4 @@
-#import "ReanimatedSensorType.h"
+#import <RNReanimated/ReanimatedSensorType.h>
 
 @interface ReanimatedSensorContainer : NSObject {
   NSNumber *_nextSensorId;

--- a/ios/vendored/unversioned/react-native-reanimated/ios/sensor/ReanimatedSensorContainer.h
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/sensor/ReanimatedSensorContainer.h
@@ -1,0 +1,12 @@
+#import "ReanimatedSensorType.h"
+
+@interface ReanimatedSensorContainer : NSObject {
+  NSNumber *_nextSensorId;
+  NSMutableDictionary *_sensors;
+}
+
+- (instancetype)init;
+- (int)registerSensor:(ReanimatedSensorType)sensorType interval:(int)interval setter:(void (^)(double[]))setter;
+- (void)unregisterSensor:(int)sensorId;
+
+@end

--- a/ios/vendored/unversioned/react-native-reanimated/ios/sensor/ReanimatedSensorContainer.m
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/sensor/ReanimatedSensorContainer.m
@@ -1,6 +1,6 @@
-#import "ReanimatedSensorContainer.h"
 #import <Foundation/Foundation.h>
-#import "ReanimatedSensor.h"
+#import <RNReanimated/ReanimatedSensor.h>
+#import <RNReanimated/ReanimatedSensorContainer.h>
 
 static NSNumber *_nextSensorId = nil;
 

--- a/ios/vendored/unversioned/react-native-reanimated/ios/sensor/ReanimatedSensorContainer.m
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/sensor/ReanimatedSensorContainer.m
@@ -1,0 +1,40 @@
+#import "ReanimatedSensorContainer.h"
+#import <Foundation/Foundation.h>
+#import "ReanimatedSensor.h"
+
+static NSNumber *_nextSensorId = nil;
+
+@implementation ReanimatedSensorContainer
+
+- (instancetype)init
+{
+  self = [super init];
+  _sensors = [[NSMutableDictionary alloc] init];
+  _nextSensorId = @0;
+  return self;
+}
+
+- (int)registerSensor:(ReanimatedSensorType)sensorType interval:(int)interval setter:(void (^)(double[]))setter
+{
+  ReanimatedSensor *sensor = [[ReanimatedSensor alloc] init:sensorType interval:interval setter:setter];
+  if ([sensor initialize]) {
+    NSNumber *sensorId = [_nextSensorId copy];
+    _nextSensorId = [NSNumber numberWithInt:[_nextSensorId intValue] + 1];
+    [_sensors setObject:sensor forKey:sensorId];
+    return [sensorId intValue];
+  } else {
+    return -1;
+  }
+}
+
+- (void)unregisterSensor:(int)sensorId
+{
+  NSNumber *_sensorId = [NSNumber numberWithInt:sensorId];
+  if (_sensors[_sensorId] == nil) {
+    return;
+  }
+  [_sensors[_sensorId] cancel];
+  [_sensors removeObjectForKey:_sensorId];
+}
+
+@end

--- a/ios/vendored/unversioned/react-native-reanimated/ios/sensor/ReanimatedSensorType.h
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/sensor/ReanimatedSensorType.h
@@ -1,0 +1,7 @@
+typedef NS_ENUM(NSUInteger, ReanimatedSensorType) {
+  ACCELEROMETER = 1,
+  GYROSCOPE = 2,
+  GRAVITY = 3,
+  MAGNETIC_FIELD = 4,
+  ROTATION_VECTOR = 5,
+};

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -96,7 +96,7 @@
   "react-native-get-random-values": "~1.7.0",
   "react-native-maps": "0.29.4",
   "react-native-pager-view": "5.4.15",
-  "react-native-reanimated": "~2.6.0",
+  "react-native-reanimated": "~2.7.0",
   "react-native-safe-area-context": "4.2.4",
   "react-native-screens": "~3.11.1",
   "react-native-shared-element": "0.8.4",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -96,7 +96,7 @@
   "react-native-get-random-values": "~1.7.0",
   "react-native-maps": "0.29.4",
   "react-native-pager-view": "5.4.15",
-  "react-native-reanimated": "~2.4.1",
+  "react-native-reanimated": "~2.6.0",
   "react-native-safe-area-context": "4.2.4",
   "react-native-screens": "~3.11.1",
   "react-native-shared-element": "0.8.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14539,12 +14539,7 @@ mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.4, mkdirp@^0.5.5, mkdir
   dependencies:
     minimist "^1.2.6"
 
-moment@^2.19.3:
-  version "2.29.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
-  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
-
-moment@^2.29.2:
+moment@^2.19.3, moment@^2.29.2:
   version "2.29.2"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.2.tgz#00910c60b20843bcba52d37d58c628b47b1f20e4"
   integrity sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -817,7 +817,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.16.7"
 
-"@babel/plugin-transform-object-assign@^7.0.0", "@babel/plugin-transform-object-assign@^7.10.4":
+"@babel/plugin-transform-object-assign@^7.0.0", "@babel/plugin-transform-object-assign@^7.16.7":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-assign/-/plugin-transform-object-assign-7.16.7.tgz#5fe08d63dccfeb6a33aa2638faf98e5c584100f8"
   integrity sha512-R8mawvm3x0COTJtveuoqZIjNypn2FjfvXZr4pSQ8VhEFBuQGBz4XhHasZtHXjgXU4XptZ4HtGof3NoYc93ZH9Q==
@@ -14539,12 +14539,12 @@ mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.4, mkdirp@^0.5.5, mkdir
   dependencies:
     minimist "^1.2.6"
 
-mockdate@^3.0.2:
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/mockdate/-/mockdate-3.0.5.tgz#789be686deb3149e7df2b663d2bc4392bc3284fb"
-  integrity sha512-iniQP4rj1FhBdBYS/+eQv7j1tadJ9lJtdzgOpvsOHng/GbcDh2Fhdeq+ZRldrPYdXvCyfFUmFeEwEGXZB5I/AQ==
+moment@^2.19.3:
+  version "2.29.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
+  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
 
-moment@^2.19.3, moment@^2.29.2:
+moment@^2.29.2:
   version "2.29.2"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.2.tgz#00910c60b20843bcba52d37d58c628b47b1f20e4"
   integrity sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==
@@ -16916,17 +16916,17 @@ react-native-paper@^4.0.1:
     color "^3.1.2"
     react-native-iphone-x-helper "^1.3.1"
 
-react-native-reanimated@~2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-2.4.1.tgz#4e33876fba525ce60ac13ab3c81fc3a9f8b132fe"
-  integrity sha512-kvf7ylGlwa5hxMQ+wpPFjQrI2c6eexf53/xRo+dvXBNefGmSYaYR5sFtD0XMMzIPQlkCB9tJ0Pu9+2WCQUY7Cg==
+react-native-reanimated@~2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-2.6.0.tgz#500497339bec2d18fd4979dc07c831997c9aee82"
+  integrity sha512-TG7u0d1iTx6BRQXhUp9DKEW/9K6169qiX9vweC+qOcVffGSZvjDZ+OyyI0faXIDvcf5LRHAud3mNtO3ANaHRhQ==
   dependencies:
-    "@babel/plugin-transform-object-assign" "^7.10.4"
+    "@babel/plugin-transform-object-assign" "^7.16.7"
     "@types/invariant" "^2.2.35"
     invariant "^2.2.4"
     lodash.isequal "^4.5.0"
-    mockdate "^3.0.2"
-    react-native-screens "^3.4.0"
+    react-native-screens "^3.11.1"
+    setimmediate "^1.0.5"
     string-hash-64 "^1.0.3"
 
 react-native-redash@^14.1.1:
@@ -16957,7 +16957,7 @@ react-native-safe-modules@^1.0.3:
   dependencies:
     dedent "^0.6.0"
 
-react-native-screens@^3.4.0:
+react-native-screens@^3.11.1:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-3.13.1.tgz#b3b1c5788dca25a71668909f66d87fb35c5c5241"
   integrity sha512-xcrnuUs0qUrGpc2gOTDY4VgHHADQwp80mwR1prU/Q0JqbZN5W3koLhuOsT6FkSRKjR5t40l+4LcjhHdpqRB2HA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1064,7 +1064,7 @@
     "@babel/types" "^7.4.4"
     esutils "^2.0.2"
 
-"@babel/preset-typescript@^7.13.0", "@babel/preset-typescript@^7.7.4":
+"@babel/preset-typescript@^7.13.0", "@babel/preset-typescript@^7.16.7", "@babel/preset-typescript@^7.7.4":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.16.7.tgz#ab114d68bb2020afc069cd51b37ff98a046a70b9"
   integrity sha512-WbVEmgXdIyvzB77AQjGBEyYPZx+8tTsO50XtfozQrkW8QB2rLJpH2lgx0TRw5EJrBxOZQ+wCcyPVQvS8tjEHpQ==
@@ -16916,16 +16916,16 @@ react-native-paper@^4.0.1:
     color "^3.1.2"
     react-native-iphone-x-helper "^1.3.1"
 
-react-native-reanimated@~2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-2.6.0.tgz#500497339bec2d18fd4979dc07c831997c9aee82"
-  integrity sha512-TG7u0d1iTx6BRQXhUp9DKEW/9K6169qiX9vweC+qOcVffGSZvjDZ+OyyI0faXIDvcf5LRHAud3mNtO3ANaHRhQ==
+react-native-reanimated@~2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-2.7.0.tgz#2cebf9bddaf87a4b364079b40e9099ec0d7ce247"
+  integrity sha512-wPKqOGdC/XAqPZU+fNkpHM9B76QHmYCIeAcOQcOqMV2kS3mbZ4ZMe5veM7pdaMZs3tCnNgCqGPIbmMNQUE0bOw==
   dependencies:
     "@babel/plugin-transform-object-assign" "^7.16.7"
+    "@babel/preset-typescript" "^7.16.7"
     "@types/invariant" "^2.2.35"
     invariant "^2.2.4"
     lodash.isequal "^4.5.0"
-    react-native-screens "^3.11.1"
     setimmediate "^1.0.5"
     string-hash-64 "^1.0.3"
 
@@ -16956,14 +16956,6 @@ react-native-safe-modules@^1.0.3:
   integrity sha512-DUxti4Z+AgJ/ZsO5U7p3uSCUBko8JT8GvFlCeOXk9bMd+4qjpoDvMYpfbixXKgL88M+HwmU/KI1YFN6gsQZyBA==
   dependencies:
     dedent "^0.6.0"
-
-react-native-screens@^3.11.1:
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-3.13.1.tgz#b3b1c5788dca25a71668909f66d87fb35c5c5241"
-  integrity sha512-xcrnuUs0qUrGpc2gOTDY4VgHHADQwp80mwR1prU/Q0JqbZN5W3koLhuOsT6FkSRKjR5t40l+4LcjhHdpqRB2HA==
-  dependencies:
-    react-freeze "^1.0.0"
-    warn-once "^0.1.0"
 
 react-native-screens@~3.11.1:
   version "3.11.1"


### PR DESCRIPTION
# Why

Preparation for SDK45 release
Closes ENG-4512

# How

- `et uvm -m react-native-reanimated -c 08b43819213e8f8d4d2ac521a939bd6a1f025220`
- Updated CMakeLists according to the changes made in reanimated
- `et publish-dev-home` because the old JS in home is incompatible with the new native layer

# Test Plan

- NCL works
- CI failures are not related to this PR
