### PR TITLE
[docs] Updates @expo/styleguide

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@emotion/react": "^11.4.0",
     "@expo/spawn-async": "^1.5.0",
-    "@expo/styleguide": "^4.0.0",
+    "@expo/styleguide": "^4.0.1",
     "@mdx-js/loader": "^1.6.22",
     "@mdx-js/mdx": "^1.6.22",
     "@mdx-js/react": "^1.6.22",

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -580,10 +580,10 @@
   dependencies:
     cross-spawn "^6.0.5"
 
-"@expo/styleguide@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@expo/styleguide/-/styleguide-4.0.0.tgz#9f4f558012b7526045f53404c3eca071e1169e3e"
-  integrity sha512-Rus1GsVD5rL9/2dI7xhF8DDq9ca2J45CdO0ZcVHOqPz/NFqOVE6oH545wPuJCNrXcAaGyRpzGUbT9oEBojuq8Q==
+"@expo/styleguide@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@expo/styleguide/-/styleguide-4.0.1.tgz#10aa2fa3dd997fe39c5498b4e08dfa984b72a0e6"
+  integrity sha512-sd50snb960bPBk+RP9SWLjGl+9yoAZwT9p1WKXii4TcYwlebNH9CjPOihoZ5Imc5Z1a/KTWlwP9vruzc3BsbYA==
 
 "@hapi/accept@5.0.2":
   version "5.0.2"


### PR DESCRIPTION
# Why

I updated the colors in @expo/styleguide, so this applies those new colors to the docs.

# How

- Ran `yarn add @expo/styleguide`

# Screenshot

<img width="1834" alt="Screen Shot 2022-04-07 at 10 36 05 AM" src="https://user-images.githubusercontent.com/6455018/162224330-a2495c17-ce2d-4237-88f1-f94c7205ecf0.png">

# Test Plan

Look at the docs in dark mode and make sure that they still read/look okay.