### PR TITLE
[dev-menu] add label for disabled devsettings

### DIFF
--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherInternalModule.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherInternalModule.kt
@@ -67,11 +67,10 @@ class DevLauncherInternalModule(reactContext: ReactApplicationContext?)
     val sdkVersion = getMetadataValue("expo.modules.updates.EXPO_SDK_VERSION")
     var updatesUrl = getMetadataValue("expo.modules.updates.EXPO_UPDATE_URL")
 
-    var appId = ""
-
-    if (updatesUrl.isNotEmpty()) {
-      var uri = Uri.parse(updatesUrl)
-      appId = uri.lastPathSegment ?: ""
+    val appId = if (updatesUrl.isNotEmpty()) {
+      Uri.parse(updatesUrl).lastPathSegment ?: ""
+    } else {
+      ""
     }
 
     var isModernManifestProtocol = Uri.parse(updatesUrl).host.equals("u.expo.dev")

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherInternalModule.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherInternalModule.kt
@@ -55,8 +55,34 @@ class DevLauncherInternalModule(reactContext: ReactApplicationContext?)
     val isRunningOnStockEmulator = Build.FINGERPRINT.contains("generic")
     return mapOf(
       "installationID" to installationIDHelper.getOrCreateInstallationID(reactApplicationContext),
-      "isDevice" to (!isRunningOnGenymotion && !isRunningOnStockEmulator)
+      "isDevice" to (!isRunningOnGenymotion && !isRunningOnStockEmulator),
+      "updatesConfig" to getUpdatesConfig(),
     )
+  }
+
+  private fun getUpdatesConfig(): WritableMap {
+    val map = Arguments.createMap()
+
+    val runtimeVersion = getMetadataValue("expo.modules.updates.EXPO_RUNTIME_VERSION")
+    val sdkVersion = getMetadataValue("expo.modules.updates.EXPO_SDK_VERSION")
+    var updatesUrl = getMetadataValue("expo.modules.updates.EXPO_UPDATE_URL")
+
+    var appId = ""
+
+    if (updatesUrl.isNotEmpty()) {
+      var uri = Uri.parse(updatesUrl)
+      appId = uri.lastPathSegment ?: ""
+    }
+
+    var isModernManifestProtocol = Uri.parse(updatesUrl).host.equals("u.expo.dev")
+    var usesEASUpdates = isModernManifestProtocol && appId.isNotEmpty()
+
+    return map.apply {
+      putString("appId", appId)
+      putString("runtimeVersion", runtimeVersion)
+      putString("sdkVersion", sdkVersion)
+      putBoolean("usesEASUpdates", usesEASUpdates)
+    }
   }
 
   @ReactMethod

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuDevSettings.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuDevSettings.kt
@@ -16,6 +16,11 @@ object DevMenuDevSettings {
         putBoolean("isElementInspectorShown", devSettings.isElementInspectorEnabled)
         putBoolean("isHotLoadingEnabled", devSettings.isHotModuleReplacementEnabled)
         putBoolean("isPerfMonitorShown", devSettings.isFpsDebugEnabled)
+        // TODO -- is this correct:
+        putBoolean("isRemoteDebuggingAvailable", devSettings.isJSDevModeEnabled)
+        putBoolean("isElementInspectorAvailable", devSettings.isJSDevModeEnabled)
+        putBoolean("isHotLoadingAvailable", devSettings.isJSDevModeEnabled)
+        putBoolean("isPerfMonitorAvailable", devSettings.isJSDevModeEnabled)
       }
     }
 
@@ -24,6 +29,10 @@ object DevMenuDevSettings {
       putBoolean("isElementInspectorShown", false)
       putBoolean("isHotLoadingEnabled", false)
       putBoolean("isPerfMonitorShown", false)
+      putBoolean("isRemoteDebuggingAvailable", false)
+      putBoolean("isElementInspectorAvailable", false)
+      putBoolean("isHotLoadingAvailable", false)
+      putBoolean("isPerfMonitorAvailable", false)
     }
   }
 }

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuDevSettings.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuDevSettings.kt
@@ -10,14 +10,15 @@ object DevMenuDevSettings {
     val devDelegate = DevMenuDevToolsDelegate(DevMenuManager, reactInstanceManager)
     val devSettings = devDelegate.devSettings as? DevInternalSettings
 
+    val jsBundleURL = reactInstanceManager.devSupportManager.jsBundleURLForRemoteDebugging
+
     if (devSettings != null) {
       return Bundle().apply {
         putBoolean("isDebuggingRemotely", devSettings.isRemoteJSDebugEnabled)
         putBoolean("isElementInspectorShown", devSettings.isElementInspectorEnabled)
         putBoolean("isHotLoadingEnabled", devSettings.isHotModuleReplacementEnabled)
         putBoolean("isPerfMonitorShown", devSettings.isFpsDebugEnabled)
-        // TODO -- is this correct:
-        putBoolean("isRemoteDebuggingAvailable", devSettings.isJSDevModeEnabled)
+        putBoolean("isRemoteDebuggingAvailable", jsBundleURL.isNotEmpty())
         putBoolean("isElementInspectorAvailable", devSettings.isJSDevModeEnabled)
         putBoolean("isHotLoadingAvailable", devSettings.isJSDevModeEnabled)
         putBoolean("isPerfMonitorAvailable", devSettings.isJSDevModeEnabled)

--- a/packages/expo-dev-menu/app/components/Main.tsx
+++ b/packages/expo-dev-menu/app/components/Main.tsx
@@ -365,7 +365,7 @@ function SettingsRowSwitch({
           <Switch
             testID={testID}
             disabled={disabled}
-            value={isEnabled}
+            value={isEnabled && !disabled}
             onValueChange={() => setIsEnabled(!isEnabled)}
           />
         </View>

--- a/packages/expo-dev-menu/app/components/Main.tsx
+++ b/packages/expo-dev-menu/app/components/Main.tsx
@@ -206,7 +206,7 @@ export function Main() {
         <>
           <Spacer.Vertical size="large" />
           <Text size="small" color="secondary" align="center">
-            Some development settings are unavailable for this build.
+            Some development settings are unavailable for this development build.
           </Text>
         </>
       )}

--- a/packages/expo-dev-menu/app/components/Main.tsx
+++ b/packages/expo-dev-menu/app/components/Main.tsx
@@ -47,6 +47,20 @@ export function Main() {
 
   const hasCopiedAppInfoContent = Boolean(appInfoClipboard.clipboardContent);
 
+  const {
+    isElementInspectorAvailable,
+    isHotLoadingAvailable,
+    isPerfMonitorAvailable,
+    isRemoteDebuggingAvailable,
+  } = devSettings;
+  const hasDisabledDevSettingOption =
+    [
+      isElementInspectorAvailable,
+      isHotLoadingAvailable,
+      isPerfMonitorAvailable,
+      isRemoteDebuggingAvailable,
+    ].filter((value) => value === false).length > 0;
+
   return (
     <View flex="1" bg="secondary">
       <View padding="medium" bg="default">
@@ -187,6 +201,15 @@ export function Main() {
           />
         </View>
       </View>
+
+      {!hasDisabledDevSettingOption && (
+        <>
+          <Spacer.Vertical size="large" />
+          <Text size="small" color="secondary" align="center">
+            Some development settings are unavailable for this build.
+          </Text>
+        </>
+      )}
 
       <Spacer.Vertical size="large" />
 

--- a/packages/expo-dev-menu/app/components/Main.tsx
+++ b/packages/expo-dev-menu/app/components/Main.tsx
@@ -206,7 +206,7 @@ export function Main() {
         <>
           <Spacer.Vertical size="large" />
           <Text size="small" color="secondary" align="center">
-            Some development settings are unavailable for this development build.
+            Some settings are unavailable for this development build.
           </Text>
         </>
       )}


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

We currently disable dev settings buttons that are not available for a given bundle but offer no explanation or indicator why they are disabled. 

This PR adds a message below the dev settings button when one or more options are unavailable

# How

<!--
How did you build this feature or fix this bug and why?
-->

Added a check for available dev setting features and a label below the buttons in the case that one or more options is unavailable

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Load an update and confirm that the label appears (the dev settings should be disabled on updates as they are not a local packager)

Ref: 

<img width="652" alt="Screen Shot 2022-04-07 at 11 29 19 AM" src="https://user-images.githubusercontent.com/40680668/162272817-f5550a25-ca06-47fa-b5c9-663af69241b4.png">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x]  Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
