### PR TITLE
[dev-launcher] remove safe-area-provider shim in favor of rn-safe-area

### DIFF
--- a/packages/expo-dev-launcher/bundle/App.tsx
+++ b/packages/expo-dev-launcher/bundle/App.tsx
@@ -31,12 +31,12 @@ export function App(props: LauncherAppProps) {
     <LoadInitialData loader={<Splash />}>
       <AppProviders>
         <Stack.Navigator initialRouteName="Main" mode="modal">
-          <Stack.Screen name="Main" component={Main} options={{ header: () => null }} />
+          <Stack.Screen name="Main" component={Main} options={{ headerShown: false }} />
 
           <Stack.Screen
             name="User Profile"
             component={UserProfileScreen}
-            options={{ header: () => null }}
+            options={{ headerShown: false }}
           />
 
           <Stack.Screen name="Crash Report" component={CrashReportScreen} />
@@ -56,7 +56,7 @@ const Main = () => {
         name="Home"
         component={HomeScreen}
         options={{
-          header: () => null,
+          headerShown: false,
           tabBarIcon: ({ focused }) => <HomeFilledIcon focused={focused} />,
         }}
       />

--- a/packages/expo-dev-launcher/bundle/App.tsx
+++ b/packages/expo-dev-launcher/bundle/App.tsx
@@ -5,7 +5,6 @@ import {
   HomeFilledIcon,
   InfoIcon,
   SettingsFilledIcon,
-  View,
 } from 'expo-dev-client-components';
 import * as React from 'react';
 
@@ -25,20 +24,12 @@ const Stack = createStackNavigator();
 
 type LauncherAppProps = {
   isSimulator?: boolean;
-  insets: {
-    top: number;
-    left: number;
-    bottom: number;
-    right: number;
-  };
 };
 
 export function App(props: LauncherAppProps) {
   return (
     <LoadInitialData loader={<Splash />}>
       <AppProviders>
-        {/* TODO -- remove this when safe area context provider is vendored */}
-        <View style={{ height: props.insets?.top || 10 }} bg="default" />
         <Stack.Navigator initialRouteName="Main" mode="modal">
           <Stack.Screen name="Main" component={Main} options={{ header: () => null }} />
 
@@ -74,7 +65,7 @@ const Main = () => {
           name="Extensions"
           component={ExtensionsStack}
           options={{
-            header: () => null,
+            headerShown: false,
             tabBarIcon: ({ focused }) => <ExtensionsFilledIcon focused={focused} />,
           }}
         />
@@ -83,7 +74,7 @@ const Main = () => {
         name="Settings"
         component={SettingsScreen}
         options={{
-          header: () => null,
+          headerShown: false,
           tabBarIcon: ({ focused }) => <SettingsFilledIcon focused={focused} />,
         }}
       />
@@ -92,7 +83,7 @@ const Main = () => {
           name="Kitchen Sink"
           component={KitchenSinkScreen}
           options={{
-            header: () => null,
+            headerShown: false,
             tabBarIcon: () => <InfoIcon />,
           }}
         />

--- a/packages/expo-dev-launcher/bundle/components/AppHeader.tsx
+++ b/packages/expo-dev-launcher/bundle/components/AppHeader.tsx
@@ -11,6 +11,7 @@ import {
 } from 'expo-dev-client-components';
 import * as React from 'react';
 
+import { SafeAreaTop } from '../components/SafeAreaTop';
 import { useBuildInfo } from '../providers/BuildInfoProvider';
 import { useUser } from '../providers/UserContextProvider';
 
@@ -29,6 +30,7 @@ export function AppHeader({ navigation }) {
 
   return (
     <View bg="default">
+      <SafeAreaTop />
       <Row align="center" pb="small">
         <Spacer.Horizontal size="medium" />
         <View flex="1" shrink="1">

--- a/packages/expo-dev-launcher/bundle/components/SafeAreaTop.tsx
+++ b/packages/expo-dev-launcher/bundle/components/SafeAreaTop.tsx
@@ -1,0 +1,8 @@
+import { View } from 'expo-dev-client-components';
+import * as React from 'react';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+export function SafeAreaTop() {
+  const { top } = useSafeAreaInsets();
+  return <View style={{ height: top }} />;
+}

--- a/packages/expo-dev-launcher/bundle/screens/ExtensionsStack.tsx
+++ b/packages/expo-dev-launcher/bundle/screens/ExtensionsStack.tsx
@@ -1,4 +1,5 @@
 import { createStackNavigator } from '@react-navigation/stack';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { BranchesScreen } from './BranchesScreen';
 import { ExtensionsScreen } from './ExtensionsScreen';
@@ -15,21 +16,23 @@ export type ExtensionsStackParamList = {
 const Extensions = createStackNavigator<ExtensionsStackParamList>();
 
 export function ExtensionsStack() {
+  const safeAreaInsets = useSafeAreaInsets();
+
   return (
-    <Extensions.Navigator>
+    <Extensions.Navigator headerMode="float">
       <Extensions.Screen
         name="Extensions"
         component={ExtensionsScreen}
-        options={{ header: () => null }}
+        options={{ headerShown: false }}
       />
       <Extensions.Screen
         name="Branches"
-        options={{ headerTitle: 'EAS Update' }}
+        options={{ headerTitle: 'EAS Update', headerStatusBarHeight: safeAreaInsets.top }}
         component={BranchesScreen}
       />
       <Extensions.Screen
         name="Updates"
-        options={{ headerTitle: 'Branch' }}
+        options={{ headerTitle: 'Branch', headerStatusBarHeight: safeAreaInsets.top }}
         component={UpdatesScreen}
       />
     </Extensions.Navigator>

--- a/packages/expo-dev-launcher/bundle/screens/ExtensionsStack.tsx
+++ b/packages/expo-dev-launcher/bundle/screens/ExtensionsStack.tsx
@@ -1,5 +1,4 @@
 import { createStackNavigator } from '@react-navigation/stack';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { BranchesScreen } from './BranchesScreen';
 import { ExtensionsScreen } from './ExtensionsScreen';
@@ -16,8 +15,6 @@ export type ExtensionsStackParamList = {
 const Extensions = createStackNavigator<ExtensionsStackParamList>();
 
 export function ExtensionsStack() {
-  const safeAreaInsets = useSafeAreaInsets();
-
   return (
     <Extensions.Navigator headerMode="float">
       <Extensions.Screen
@@ -27,12 +24,12 @@ export function ExtensionsStack() {
       />
       <Extensions.Screen
         name="Branches"
-        options={{ headerTitle: 'EAS Update', headerStatusBarHeight: safeAreaInsets.top }}
+        options={{ headerTitle: 'EAS Update' }}
         component={BranchesScreen}
       />
       <Extensions.Screen
         name="Updates"
-        options={{ headerTitle: 'Branch', headerStatusBarHeight: safeAreaInsets.top }}
+        options={{ headerTitle: 'Branch' }}
         component={UpdatesScreen}
       />
     </Extensions.Navigator>

--- a/packages/expo-dev-launcher/bundle/screens/KitchenSinkScreen.tsx
+++ b/packages/expo-dev-launcher/bundle/screens/KitchenSinkScreen.tsx
@@ -5,6 +5,7 @@ import { ScrollView } from 'react-native';
 import { BasicButton } from '../components/BasicButton';
 import { FlatListLoader } from '../components/FlatList';
 import { LoadMoreButton } from '../components/LoadMoreButton';
+import { SafeAreaTop } from '../components/SafeAreaTop';
 import { Toasts } from '../components/Toasts';
 import { useToastStack } from '../providers/ToastStackProvider';
 
@@ -31,6 +32,7 @@ export function KitchenSinkScreen() {
 
   return (
     <ScrollView>
+      <SafeAreaTop />
       <View padding="medium">
         <Heading size="large">Kitchen Sink</Heading>
 

--- a/packages/expo-dev-launcher/bundle/screens/SettingsScreen.tsx
+++ b/packages/expo-dev-launcher/bundle/screens/SettingsScreen.tsx
@@ -14,6 +14,7 @@ import {
 import * as React from 'react';
 import { ScrollView, Switch } from 'react-native';
 import { useQueryClient } from 'react-query';
+import { SafeAreaTop } from '../components/SafeAreaTop';
 
 import { Toasts } from '../components/Toasts';
 import { copyToClipboardAsync } from '../native-modules/DevLauncherInternal';
@@ -80,7 +81,8 @@ export function SettingsScreen() {
 
   return (
     <ScrollView testID="DevLauncherSettingsScreen" showsVerticalScrollIndicator={false}>
-      <View px="medium" mt="8">
+      <SafeAreaTop />
+      <View px="medium">
         <Heading size="large">Settings</Heading>
       </View>
 

--- a/packages/expo-dev-launcher/bundle/screens/UpdatesScreen.tsx
+++ b/packages/expo-dev-launcher/bundle/screens/UpdatesScreen.tsx
@@ -1,6 +1,5 @@
 import { RouteProp } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
-
 import {
   Heading,
   View,


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The debug build was using a temporary hardcoded value to get the right behaviour with notches - this PR removes that shim and uses `react-native-safe-area-context` instead

# How

<!--
How did you build this feature or fix this bug and why?
-->

Updated the stack navigators to properly account for nested headers
Added padding to the `<AppHeader /> ` component to ensure it was accounting for the notch

# Test Plan

The  updates and branches screens should have headers that are visible and accessible, and the main app header should be visible and accessible as well

<img width="389" alt="Screen Shot 2022-04-07 at 1 58 11 PM" src="https://user-images.githubusercontent.com/40680668/162304882-a90bd5de-bf16-42a9-b7b3-42bf1ef188fb.png">


(Before this PR, these headers would end up behind the notch and be inaccessible) 

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
