### PR TITLE
[updates] bump android `room` library version

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -35,6 +35,10 @@
 
 - On Android bump `compileSdkVersion` to `31`, `targetSdkVersion` to `31` and `Java` version to `11`. ([#16941](https://github.com/expo/expo/pull/16941) by [@bbarthec](https://github.com/bbarthec))
 
+### 📚 3rd party library updates
+
+- Upgrade Android `Room` library version to 2.4.2. ([#16970](https://github.com/expo/expo/pull/16970) by [@kudo](https://github.com/kudo))
+
 ## 0.11.7 — 2022-03-07
 
 ### 🐛 Bug fixes

--- a/packages/expo-updates/android/build.gradle
+++ b/packages/expo-updates/android/build.gradle
@@ -111,14 +111,10 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
 
-  def room_version = "2.3.0"
+  def room_version = "2.4.2"
 
   implementation "androidx.room:room-runtime:$room_version"
   kapt "androidx.room:room-compiler:$room_version"
-
-  // force upgrade sqlite-jdbc to support building on aarch64 jdk of macos m1.
-  // https://issuetracker.google.com/issues/174695268
-  kapt "org.xerial:sqlite-jdbc:3.36.0"
 
   implementation("com.squareup.okhttp3:okhttp:4.9.2")
   implementation("com.squareup.okhttp3:okhttp-urlconnection:4.9.2")


### PR DESCRIPTION
# Why

close ENG-2749

# How

bump room to 2.4.2

# Test Plan

- updates e2e ci passed
- verify eas update on sdk44 project, then patch `targetSdkVersion`, `compileSdkVersion`, `buildToolsVersion` and the `room` version. published an eas update again and confirmed that room upgrade does not break.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
