### PR TITLE
[updates][e2e][ci] Use Java 11

### DIFF
--- a/.github/workflows/updates-e2e.yml
+++ b/.github/workflows/updates-e2e.yml
@@ -44,6 +44,11 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: false
+      - name: 🔨 Use JDK 11
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: '11'
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"


### PR DESCRIPTION
# Why

Uses Java 11 on CI.
https://github.com/expo/expo/runs/5850613943?check_suite_focus=true