### PR TITLE
[ci][updates-e2e] Fix build error from outdated project setup

### DIFF
--- a/.github/workflows/updates-e2e.yml
+++ b/.github/workflows/updates-e2e.yml
@@ -67,17 +67,17 @@ jobs:
         run: expo-cli init updates-e2e --yes
       - name: Add local expo-updates and dependencies
         working-directory: ../updates-e2e
-        run: yarn add file:../expo/packages/expo-updates file:../expo/packages/expo file:../expo/packages/expo-eas-client file:../expo/packages/expo-modules-core file:../expo/packages/expo-json-utils file:../expo/packages/expo-manifests file:../expo/packages/expo-structured-headers file:../expo/packages/expo-updates-interface
+        # install expo packages (including transitive packages) locally
+        run: yarn add file:../expo/packages/expo-updates file:../expo/packages/expo file:../expo/packages/expo-eas-client file:../expo/packages/expo-modules-core file:../expo/packages/expo-json-utils file:../expo/packages/expo-manifests file:../expo/packages/expo-structured-headers file:../expo/packages/expo-updates-interface file:../expo/packages/expo-constants file:../expo/packages/expo-file-system file:../expo/packages/expo-font file:../expo/packages/expo-keep-awake file:../expo/packages/expo-splash-screen file:../expo/packages/expo-status-bar file:../expo/packages/expo-application file:../expo/packages/expo-error-recovery
       - name: Setup app.config.json
         working-directory: ../updates-e2e
         run: echo "{\"name\":\"updates-e2e\",\"plugins\":[\"expo-updates\"],\"android\":{\"package\":\"dev.expo.updatese2e\"},\"ios\":{\"bundleIdentifier\":\"dev.expo.updatese2e\"}}" > app.config.json
+      - name: Pack latest bare-minimal template as tarball for expo prebuild
+        working-directory: templates/expo-template-bare-minimum
+        run: npm pack --pack-destination ../../../updates-e2e/
       - name: Prebuild
         working-directory: ../updates-e2e
-        run: expo-cli prebuild
-      # TODO: remove once the local template projects are using SDK 45 packages
-      - name: Manually bump kotlin version (workaround)
-        working-directory: ../updates-e2e
-        run: sed -i -e 's/\(buildToolsVersion = "[0-9.]*"\)/\1\nkotlinVersion = "1.6.10"/' ./android/build.gradle
+        run: expo-cli prebuild --template expo-template-bare-minimum-*.tgz
       - name: Copy App.js from test fixtures
         working-directory: ../updates-e2e
         run: cp ../expo/packages/expo-updates/e2e/__tests__/fixtures/App.js .

--- a/.github/workflows/updates-e2e.yml
+++ b/.github/workflows/updates-e2e.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Setup app.config.json
         working-directory: ../updates-e2e
         run: echo "{\"name\":\"updates-e2e\",\"plugins\":[\"expo-updates\"],\"android\":{\"package\":\"dev.expo.updatese2e\"},\"ios\":{\"bundleIdentifier\":\"dev.expo.updatese2e\"}}" > app.config.json
-      - name: Pack latest bare-minimal template as tarball for expo prebuild
+      - name: Pack latest bare-minimum template as tarball for expo prebuild
         working-directory: templates/expo-template-bare-minimum
         run: npm pack --pack-destination ../../../updates-e2e/
       - name: Prebuild


### PR DESCRIPTION
# Why

fix updates-e2e ci error after #16941 landed. the error job is like this one: https://github.com/expo/expo/runs/5883741338?check_suite_focus=true.

the root cause is that updates-e2e uses sdk-44 template which is far away from latest main, e.g. AGP version, `compileSdkVersion` and `targetSdkVersion`.

# How

use latest expo-template-bare-minimal for expo prebuild

# Test Plan

updates-e2e ci green
