### PR TITLE
[ios] Augment manifest with random scopeKey and id when not isVerified

### DIFF
--- a/ios/Exponent.xcodeproj/project.pbxproj
+++ b/ios/Exponent.xcodeproj/project.pbxproj
@@ -201,6 +201,8 @@
 		B22BB0342366F3F400EE04EC /* EXScopedErrorRecoveryModule.m in Sources */ = {isa = PBXBuildFile; fileRef = B22BB0322366F3F400EE04EC /* EXScopedErrorRecoveryModule.m */; };
 		B236C4F324740C1E00D0CB66 /* EXScopedNotificationSchedulerModule.m in Sources */ = {isa = PBXBuildFile; fileRef = B236C4F224740C1E00D0CB66 /* EXScopedNotificationSchedulerModule.m */; };
 		B23D9AA324758C6600D09AC8 /* EXScopedNotificationPresentationModule.m in Sources */ = {isa = PBXBuildFile; fileRef = B23D9AA224758C6600D09AC8 /* EXScopedNotificationPresentationModule.m */; };
+		B26DF25628048DB80071B0CD /* EXAppLoaderHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B26DF25528048DB80071B0CD /* EXAppLoaderHelpers.swift */; };
+		B26DF25728048EBB0071B0CD /* EXAppLoaderHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B26DF25528048DB80071B0CD /* EXAppLoaderHelpers.swift */; };
 		B287BB2427DD909C008DA282 /* expo-root.pem in Resources */ = {isa = PBXBuildFile; fileRef = B287BB2327DD909B008DA282 /* expo-root.pem */; };
 		B287BB2627DD90AF008DA282 /* expo-root.pem in Resources */ = {isa = PBXBuildFile; fileRef = B287BB2527DD90AF008DA282 /* expo-root.pem */; };
 		B2B492172462F5EF001576D8 /* EXScopedNotificationsEmitter.m in Sources */ = {isa = PBXBuildFile; fileRef = B2B492162462F5EF001576D8 /* EXScopedNotificationsEmitter.m */; };
@@ -1043,6 +1045,7 @@
 		B236C4F224740C1E00D0CB66 /* EXScopedNotificationSchedulerModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EXScopedNotificationSchedulerModule.m; sourceTree = "<group>"; };
 		B23D9AA124758C6600D09AC8 /* EXScopedNotificationPresentationModule.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EXScopedNotificationPresentationModule.h; sourceTree = "<group>"; };
 		B23D9AA224758C6600D09AC8 /* EXScopedNotificationPresentationModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EXScopedNotificationPresentationModule.m; sourceTree = "<group>"; };
+		B26DF25528048DB80071B0CD /* EXAppLoaderHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EXAppLoaderHelpers.swift; sourceTree = "<group>"; };
 		B27236FEB631478AB1A6C384 /* RNSharedElementDelegate.h */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.c.h; path = RNSharedElementDelegate.h; sourceTree = "<group>"; };
 		B287BB2327DD909B008DA282 /* expo-root.pem */ = {isa = PBXFileReference; lastKnownFileType = text; name = "expo-root.pem"; path = "Exponent/Supporting/expo-root.pem"; sourceTree = "<group>"; };
 		B287BB2527DD90AF008DA282 /* expo-root.pem */ = {isa = PBXFileReference; lastKnownFileType = text; name = "expo-root.pem"; path = "Exponent/Supporting/expo-root.pem"; sourceTree = "<group>"; };
@@ -2149,6 +2152,7 @@
 				B5D0D66B204F4C0400DDFC99 /* EXFileDownloader.m */,
 				B5A72C2320A0D1BF00974CCE /* AppFetcher */,
 				B5A72C1920A0D13E00974CCE /* CachedResource */,
+				B26DF25528048DB80071B0CD /* EXAppLoaderHelpers.swift */,
 			);
 			path = AppLoader;
 			sourceTree = "<group>";
@@ -3068,6 +3072,7 @@
 				7043DF9B2283303800272D74 /* RNSVGRadialGradient.m in Sources */,
 				31AD9A4F2285B53100F19090 /* AIRMapCallout.m in Sources */,
 				7043DF8E2283303800272D74 /* RNSVGTSpanManager.m in Sources */,
+				B26DF25628048DB80071B0CD /* EXAppLoaderHelpers.swift in Sources */,
 				B5A72C2220A0D13E00974CCE /* EXJavaScriptResource.m in Sources */,
 				7043DF772283303800272D74 /* RNSVGBrush.m in Sources */,
 				31E6D48020B845830082B09F /* EXSensorsManagerBinding.m in Sources */,
@@ -3362,6 +3367,7 @@
 				F14217FE262CB68600BB97E6 /* EXKernelAppRecord.m in Sources */,
 				F14217FF262CB68600BB97E6 /* RNSVGSvgView.m in Sources */,
 				F1421800262CB68600BB97E6 /* EXReactAppManager.mm in Sources */,
+				B26DF25728048EBB0071B0CD /* EXAppLoaderHelpers.swift in Sources */,
 				F1421800262CB68600BB97E6 /* EXReactAppManager.mm in Sources */,
 				F1421801262CB68600BB97E6 /* AIRGoogleMapCalloutManager.m in Sources */,
 				F1421802262CB68600BB97E6 /* AIRGoogleMapMarkerManager.m in Sources */,

--- a/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
@@ -27,6 +27,7 @@
 #import <EXUpdates/EXUpdatesUtils.h>
 #import <EXManifests/EXManifestsManifestFactory.h>
 #import <EXManifests/EXManifestsLegacyManifest.h>
+#import <EXManifests/EXManifestsNewManifest.h>
 #import <React/RCTUtils.h>
 #import <sys/utsname.h>
 
@@ -536,6 +537,19 @@ NS_ASSUME_NONNULL_BEGIN
     // scope key, automatically verify it
     if (![mutableManifest[@"isVerified"] boolValue] && (EXEnvironment.sharedEnvironment.isManifestVerificationBypassed || [EXAppLoaderExpoUpdates _isAnonymousExperience:manifest])) {
       mutableManifest[@"isVerified"] = @(YES);
+    }
+    
+    // when the manifest is not verified at this point, make the scope key and id a random value
+    if (![mutableManifest[@"isVerified"] boolValue]) {
+      NSString *randomValue = [[NSUUID UUID] UUIDString];
+      if ([manifest isKindOfClass:EXManifestsNewManifest.class]) {
+        NSMutableDictionary *mutableExtra = [mutableManifest[@"extra"] mutableCopy];
+        mutableExtra[@"scopeKey"] = randomValue;
+        mutableManifest[@"extra"] = mutableExtra;
+      } else {
+        mutableManifest[@"scopeKey"] = randomValue;
+        mutableManifest[@"id"] = randomValue;
+      }
     }
 
     return [EXManifestsManifestFactory manifestForManifestJSON:[mutableManifest copy]];

--- a/ios/Exponent/Kernel/AppLoader/EXAppLoaderHelpers.swift
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoaderHelpers.swift
@@ -1,0 +1,24 @@
+// Copyright 2020-present 650 Industries. All rights reserved.
+
+import Foundation
+import CommonCrypto
+
+@objc
+extension NSString {
+  @objc func hexEncodedSHA256() -> String {
+    let digest = (self as String).data(using:String.Encoding.utf8)!.sha256()
+    return digest.reduce("") { $0 + String(format: "%02x", $1) }
+  }
+}
+
+extension Data {
+  func sha256() -> Data {
+    var digest = Data(count: Int(CC_SHA256_DIGEST_LENGTH))
+    withUnsafeBytes { bytes in
+      digest.withUnsafeMutableBytes { mutableBytes in
+        _ = CC_SHA256(bytes.baseAddress, CC_LONG(count), mutableBytes.bindMemory(to: UInt8.self).baseAddress)
+      }
+    }
+    return digest
+  }
+}


### PR DESCRIPTION
# Why

Full context (internal): https://exponent-internal.slack.com/archives/C1QLJDKDZ/p1647564337585779

To summarize:

On android, there are mechanisms in place that read the `isVerified` field of the (augmented) manifest and fork module implementation or module instantiation based upon it:
- https://github.com/expo/expo/blob/main/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentPackage.kt#L121
- https://github.com/expo/expo/blob/main/android/expoview/src/main/java/versioned/host/exp/exponent/ExpoTurboPackage.kt#L60

This is done to prevent spoofing a `scopeKey` in an experience loaded in Expo Go, which could result in data exfiltration of another experience's data.

On iOS, the `isVerified` field is not used, and has never been used as far as I can tell (probably an oversight). One can verify this via grep. Manifest signing on iOS was originally added in https://github.com/expo/expo/commit/64fefa17b168cb5559b6c69470ea020a033eb6ff.

The hypothetical attack steps are as follows:
1. Disable manifest signing in expo-cli (locally comment out code)
2. Create new expo project, add `id` key to app.json with `@fake/key` value.
3. Serve that project with modified expo-cli (`expo start`).
4. Add a breakpoint in `EXScopedSecureStore` to inspect `scopeKey` value.
5. Load the project in Expo Go (iOS)
6. See breakpoint is hit and scopeKey is `@fake/key` and data exfiltration is possible.

Closes ENG-4587.

# How

When a manifest `isVerified` is false and it is being loaded in Expo Go, substitute the `scopeKey` with a random UUID for both legacy and new manifests.

# Test Plan

Follow attack steps from above, no longer see a spoofed `scopeKey` when loading experience.