### PR TITLE
[module-core][Kotlin] Add basic support for sync function

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### 🎉 New features
 
 - Introduce dynamic properties in the Sweet API on iOS. ([#17318](https://github.com/expo/expo/pull/17318) by [@tsapeta](https://github.com/tsapeta))
-- Add basic support for sync functions in the Sweet API on Android.
+- Add basic support for sync functions in the Sweet API on Android. ([#16977](https://github.com/expo/expo/pull/16977) by [@lukmccall](https://github.com/lukmccall))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Introduce dynamic properties in the Sweet API on iOS. ([#17318](https://github.com/expo/expo/pull/17318) by [@tsapeta](https://github.com/tsapeta))
+- Add basic support for sync functions in the Sweet API on Android.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/android/.gitignore
+++ b/packages/expo-modules-core/android/.gitignore
@@ -259,3 +259,5 @@ gradle-app.setting
 
 
 # End of https://www.gitignore.io/api/java,maven,gradle,android,intellij,androidstudio
+
+.cxx

--- a/packages/expo-modules-core/android/CMakeLists.txt
+++ b/packages/expo-modules-core/android/CMakeLists.txt
@@ -1,16 +1,15 @@
 cmake_minimum_required(VERSION 3.4.1)
 
 set(CMAKE_VERBOSE_MAKEFILE ON)
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_FLAGS "-DFOLLY_NO_CONFIG=1 -DFOLLY_HAVE_CLOCK_GETTIME=1 -DFOLLY_HAVE_MEMRCHR=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_MOBILE=1 -O2 -frtti -fexceptions -Wall -fstack-protector-all")
+set(CMAKE_ANDROID_STL_TYPE c++_shared)
+set(CMAKE_CXX_STANDARD 17)
 set(PACKAGE_NAME "expo-modules-core")
 set(BUILD_DIR ${CMAKE_SOURCE_DIR}/build)
 
-if(${NATIVE_DEBUG})
+if (${NATIVE_DEBUG})
     set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g")
     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g")
-endif()
-
+endif ()
 
 set(SRC_DIR ${CMAKE_SOURCE_DIR}/src)
 file(GLOB sources_android "${SRC_DIR}/main/cpp/*.cpp")
@@ -95,6 +94,20 @@ find_library(
 #reactnativejni
 
 # linking
+
+target_compile_options(
+        ${PACKAGE_NAME}
+        PRIVATE -DFOLLY_NO_CONFIG=1
+        -DFOLLY_HAVE_CLOCK_GETTIME=1
+        -DFOLLY_HAVE_MEMRCHR=1
+        -DFOLLY_USE_LIBCPP=1
+        -DFOLLY_MOBILE=1
+        -O2
+        -frtti
+        -fexceptions
+        -Wall
+        -fstack-protector-all
+)
 
 target_link_libraries(
         ${PACKAGE_NAME}

--- a/packages/expo-modules-core/android/CMakeLists.txt
+++ b/packages/expo-modules-core/android/CMakeLists.txt
@@ -1,0 +1,92 @@
+cmake_minimum_required(VERSION 3.4.1)
+
+set(CMAKE_VERBOSE_MAKEFILE ON)
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_FLAGS "-DFOLLY_NO_CONFIG=1 -DFOLLY_HAVE_CLOCK_GETTIME=1 -DFOLLY_HAVE_MEMRCHR=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_MOBILE=1 -O2 -frtti -fexceptions -Wall -fstack-protector-all")
+set(PACKAGE_NAME "expomodulescore")
+set(BUILD_DIR ${CMAKE_SOURCE_DIR}/build)
+
+set(SRC_DIR ${CMAKE_SOURCE_DIR}/src)
+file(GLOB sources_android "${SRC_DIR}/main/cpp/*.cpp")
+
+# shared
+
+add_library(
+        ${PACKAGE_NAME}
+        SHARED
+        ${sources_android}
+)
+
+# Extracted AAR: ${BUILD_DIR}/react-native-0*/jni/${ANDROID_ABI}
+file(GLOB LIBRN_DIR "${REACT_NATIVE_SO_DIR}/${ANDROID_ABI}")
+if (NOT LIBRN_DIR)
+    # If /${ANDROID_ABI} dir not found, then ${REACT_NATIVE_SO_DIR} is probably:
+    # ReactAndroid/build/react-ndk/exported
+    file(GLOB LIBRN_DIR "${REACT_NATIVE_SO_DIR}")
+endif ()
+
+file(GLOB libfbjni_include_DIRS "${BUILD_DIR}/fbjni-*-headers.jar/")
+
+# includes
+
+target_include_directories(
+        ${PACKAGE_NAME}
+        PRIVATE
+        "${REACT_NATIVE_DIR}/React"
+        "${REACT_NATIVE_DIR}/React/Base"
+        "${REACT_NATIVE_DIR}/ReactAndroid/src/main/jni"
+        "${REACT_NATIVE_DIR}/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/jni"
+        "${REACT_NATIVE_DIR}/ReactCommon"
+        "${REACT_NATIVE_DIR}/ReactCommon/callinvoker"
+        "${REACT_NATIVE_DIR}/ReactCommon/jsi"
+        "${BUILD_DIR}/third-party-ndk/boost/boost_${BOOST_VERSION}"
+        "${BUILD_DIR}/third-party-ndk/double-conversion"
+        "${BUILD_DIR}/third-party-ndk/folly"
+        ${libfbjni_include_DIRS}
+)
+
+# find libraries
+
+find_library(LOG_LIB log)
+
+find_library(
+        FOLLY_JSON_LIB
+        folly_json
+        PATHS ${LIBRN_DIR}
+        NO_CMAKE_FIND_ROOT_PATH
+)
+
+find_library(
+        FBJNI_LIB
+        fbjni
+        PATHS ${LIBRN_DIR}
+        NO_CMAKE_FIND_ROOT_PATH
+)
+
+find_library(
+        JSI_LIB
+        jsi
+        PATHS ${LIBRN_DIR}
+        NO_CMAKE_FIND_ROOT_PATH
+)
+
+find_library(
+        REACT_NATIVE_JNI_LIB
+        reactnativejni
+        PATHS ${LIBRN_DIR}
+        NO_CMAKE_FIND_ROOT_PATH
+)
+
+#reactnativejni
+
+# linking
+
+target_link_libraries(
+        ${PACKAGE_NAME}
+        ${LOG_LIB}
+        ${FBJNI_LIB}
+        ${JSI_LIB}
+        ${REACT_NATIVE_JNI_LIB}
+        ${FOLLY_JSON_LIB}
+        android
+)

--- a/packages/expo-modules-core/android/CMakeLists.txt
+++ b/packages/expo-modules-core/android/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.4.1)
 set(CMAKE_VERBOSE_MAKEFILE ON)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_FLAGS "-DFOLLY_NO_CONFIG=1 -DFOLLY_HAVE_CLOCK_GETTIME=1 -DFOLLY_HAVE_MEMRCHR=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_MOBILE=1 -O2 -frtti -fexceptions -Wall -fstack-protector-all")
-set(PACKAGE_NAME "expomodulescore")
+set(PACKAGE_NAME "expo-modules-core")
 set(BUILD_DIR ${CMAKE_SOURCE_DIR}/build)
 
 set(SRC_DIR ${CMAKE_SOURCE_DIR}/src)

--- a/packages/expo-modules-core/android/CMakeLists.txt
+++ b/packages/expo-modules-core/android/CMakeLists.txt
@@ -6,6 +6,12 @@ set(CMAKE_CXX_FLAGS "-DFOLLY_NO_CONFIG=1 -DFOLLY_HAVE_CLOCK_GETTIME=1 -DFOLLY_HA
 set(PACKAGE_NAME "expo-modules-core")
 set(BUILD_DIR ${CMAKE_SOURCE_DIR}/build)
 
+if(${NATIVE_DEBUG})
+    set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g")
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g")
+endif()
+
+
 set(SRC_DIR ${CMAKE_SOURCE_DIR}/src)
 file(GLOB sources_android "${SRC_DIR}/main/cpp/*.cpp")
 
@@ -35,8 +41,10 @@ target_include_directories(
         "${REACT_NATIVE_DIR}/React"
         "${REACT_NATIVE_DIR}/React/Base"
         "${REACT_NATIVE_DIR}/ReactAndroid/src/main/jni"
+        "${REACT_NATIVE_DIR}/ReactAndroid/src/main/jni/react"
         "${REACT_NATIVE_DIR}/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/jni"
         "${REACT_NATIVE_DIR}/ReactCommon"
+        "${REACT_NATIVE_DIR}/ReactCommon/react/nativemodule/core"
         "${REACT_NATIVE_DIR}/ReactCommon/callinvoker"
         "${REACT_NATIVE_DIR}/ReactCommon/jsi"
         "${BUILD_DIR}/third-party-ndk/boost/boost_${BOOST_VERSION}"
@@ -77,6 +85,13 @@ find_library(
         NO_CMAKE_FIND_ROOT_PATH
 )
 
+find_library(
+        REACT_NATIVE_MODULES_CORE
+        react_nativemodule_core
+        PATHS ${LIBRN_DIR}
+        NO_CMAKE_FIND_ROOT_PATH
+)
+
 #reactnativejni
 
 # linking
@@ -88,5 +103,6 @@ target_link_libraries(
         ${JSI_LIB}
         ${REACT_NATIVE_JNI_LIB}
         ${FOLLY_JSON_LIB}
+        ${REACT_NATIVE_MODULES_CORE}
         android
 )

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -1,6 +1,9 @@
+import java.nio.file.Paths
+
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'maven-publish'
+apply plugin: "de.undercouch.download"
 
 group = 'host.exp.exponent'
 version = '0.9.0'
@@ -32,8 +35,27 @@ buildscript {
 
   dependencies {
     classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${getKotlinVersion()}")
+    classpath "de.undercouch:gradle-download-task:4.1.2"
   }
 }
+
+def downloadsDir = new File("$buildDir/downloads")
+def thirdPartyNdkDir = new File("$buildDir/third-party-ndk")
+
+def REACT_NATIVE_DIR = new File(["node", "--print", "require.resolve('react-native/package.json')"].execute(null, rootDir).text.trim()).parent
+def REACT_NATIVE_BUILD_FROM_SOURCE = findProject(":ReactAndroid") != null
+def REACT_NATIVE_SO_DIR = findProject(":ReactAndroid")
+  ? Paths.get(findProject(":ReactAndroid").getProjectDir().toString(), "build", "react-ndk", "exported")
+  : "${buildDir}/react-native-0*/jni"
+
+def reactProperties = new Properties()
+file("$REACT_NATIVE_DIR/ReactAndroid/gradle.properties").withInputStream { reactProperties.load(it) }
+
+def FOLLY_VERSION = reactProperties.getProperty("FOLLY_VERSION")
+def BOOST_VERSION = reactProperties.getProperty("BOOST_VERSION")
+def DOUBLE_CONVERSION_VERSION = reactProperties.getProperty("DOUBLE_CONVERSION_VERSION")
+
+def reactNativeThirdParty = new File("$REACT_NATIVE_DIR/ReactAndroid/src/main/jni/third-party")
 
 // Creating sources with comments
 task androidSourcesJar(type: Jar) {
@@ -76,7 +98,48 @@ android {
     consumerProguardFiles 'proguard-rules.pro'
     versionCode 1
     versionName "0.9.0"
+
+    externalNativeBuild {
+      cmake {
+        abiFilters(*(System.getenv('NDK_ABI_FILTERS') ?: 'armeabi-v7a x86 arm64-v8a x86_64').split(' '))
+        arguments "-DANDROID_STL=c++_shared",
+          "-DREACT_NATIVE_DIR=${REACT_NATIVE_DIR}",
+          "-DREACT_NATIVE_SO_DIR=${REACT_NATIVE_SO_DIR}",
+          "-DBOOST_VERSION=${BOOST_VERSION}"
+      }
+    }
   }
+
+  externalNativeBuild {
+    cmake {
+      path "CMakeLists.txt"
+    }
+  }
+
+  buildFeatures {
+    prefab true
+  }
+
+  packagingOptions {
+    // Gradle will add cmake target dependencies into packaging.
+    // Theses files are intermediated linking files to build reanimated and should not be in final package.
+    excludes = [
+      "**/libc++_shared.so",
+      "**/libreactnativejni.so",
+      "**/libglog.so",
+      "**/libjscexecutor.so",
+      "**/libfbjni.so",
+      "**/libfolly_json.so",
+      "**/libhermes.so",
+      "**/libjsi.so",
+    ]
+  }
+
+  configurations {
+    extractHeaders
+    extractJNI
+  }
+
   lintOptions {
     abortOnError false
   }
@@ -94,6 +157,7 @@ android {
   }
 }
 
+
 dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
   implementation "org.jetbrains.kotlin:kotlin-reflect:${getKotlinVersion()}"
@@ -109,6 +173,25 @@ dependencies {
   testImplementation "com.google.truth:truth:1.1.2"
   testImplementation "org.robolectric:robolectric:4.5.1"
   testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.0"
+
+  compileOnly 'com.facebook.fbjni:fbjni:0.2.2'
+  extractHeaders 'com.facebook.fbjni:fbjni:0.2.2:headers'
+  extractJNI 'com.facebook.fbjni:fbjni:0.2.2'
+  def rnAARs = fileTree("${REACT_NATIVE_DIR}/android").matching { include "**/*.aar" }
+  if (rnAARs.any()) {
+    // node_modules/react-native has a .aar, extract headers
+    if (rnAARs.size() > 1) {
+      logger.error("More than one React Native AAR file has been found:")
+      rnAARs.each { println(it) }
+      throw new GradleException("Multiple React Native AARs found:\n${rnAARs.join("\n")}" +
+        "\nRemove the old ones and try again")
+    }
+    def rnAAR = rnAARs.singleFile
+    extractJNI(files(rnAAR))
+  } else {
+    println("oooo")
+    // TODO(@lukmccall)
+  }
 }
 
 /**
@@ -120,3 +203,124 @@ dependencies {
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
   kotlinOptions.freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
 }
+
+// UTILS
+task createNativeDepsDirectories() {
+  downloadsDir.mkdirs()
+  thirdPartyNdkDir.mkdirs()
+}
+// END UTILS
+
+// JNI
+task extractAARHeaders {
+  doLast {
+    configurations.extractHeaders.files.each {
+      def file = it.absoluteFile
+      copy {
+        from zipTree(file)
+        into "$buildDir/$file.name"
+        include "**/*.h"
+      }
+    }
+  }
+}
+
+task extractJNIFiles {
+  doLast {
+    configurations.extractJNI.files.each {
+      def file = it.absoluteFile
+      copy {
+        from zipTree(file)
+        into "$buildDir/$file.name"
+        include "jni/**/*"
+      }
+    }
+  }
+}
+// END JNI
+
+// BOOST
+task downloadBoost(dependsOn: createNativeDepsDirectories, type: Download) {
+  src("https://github.com/react-native-community/boost-for-react-native/releases/download/v${BOOST_VERSION.replace("_", ".")}-0/boost_${BOOST_VERSION}.tar.gz")
+  onlyIfNewer(true)
+  overwrite(false)
+  dest(new File(downloadsDir, "boost_${BOOST_VERSION}.tar.gz"))
+}
+
+task prepareBoost(dependsOn: [downloadBoost], type: Copy) {
+  from(tarTree(resources.gzip(downloadBoost.dest)))
+  from("$reactNativeThirdParty/boost/Android.mk")
+  include("Android.mk", "boost_${BOOST_VERSION}/boost/**/*.hpp", "boost/boost/**/*.hpp")
+  includeEmptyDirs = false
+  into("$thirdPartyNdkDir/boost")
+  doLast {
+    file("$thirdPartyNdkDir/boost/boost").renameTo("$thirdPartyNdkDir/boost/boost_${BOOST_VERSION}")
+  }
+}
+// END BOOST
+
+// DOUBLE CONVERSION
+task downloadDoubleConversion(dependsOn: createNativeDepsDirectories, type: Download) {
+  src("https://github.com/google/double-conversion/archive/v${DOUBLE_CONVERSION_VERSION}.tar.gz")
+  onlyIfNewer(true)
+  overwrite(false)
+  dest(new File(downloadsDir, "double-conversion-${DOUBLE_CONVERSION_VERSION}.tar.gz"))
+}
+
+task prepareDoubleConversion(dependsOn: [downloadDoubleConversion], type: Copy) {
+  from(tarTree(downloadDoubleConversion.dest))
+  from("$reactNativeThirdParty/double-conversion/Android.mk")
+  include("double-conversion-${DOUBLE_CONVERSION_VERSION}/src/**/*", "Android.mk")
+  filesMatching("*/src/**/*", { fname -> fname.path = "double-conversion/${fname.name}" })
+  includeEmptyDirs = false
+  into("$thirdPartyNdkDir/double-conversion")
+}
+// END DOUBLE CONVERSION
+
+// FOLLY
+task downloadFolly(dependsOn: createNativeDepsDirectories, type: Download) {
+  src("https://github.com/facebook/folly/archive/v${FOLLY_VERSION}.tar.gz")
+  onlyIfNewer(true)
+  overwrite(false)
+  dest(new File(downloadsDir, "folly-${FOLLY_VERSION}.tar.gz"))
+}
+
+task prepareFolly(dependsOn: [downloadFolly], type: Copy) {
+  from(tarTree(downloadFolly.dest))
+  from("$reactNativeThirdParty/folly/Android.mk")
+  include("folly-${FOLLY_VERSION}/folly/**/*", "Android.mk")
+  eachFile { fname -> fname.path = (fname.path - "folly-${FOLLY_VERSION}/") }
+  // Fixes problem with Folly failing to build on certain systems. See
+  // https://github.com/software-mansion/react-native-reanimated/issues/1024
+  def follyReplaceContent = '''
+  ssize_t r;
+  do {
+    r = open(name, flags, mode);
+  } while (r == -1 && errno == EINTR);
+    return r;
+  '''
+  filter { line -> line.replaceAll("return int\\(wrapNoInt\\(open, name, flags, mode\\)\\);", follyReplaceContent) }
+  includeEmptyDirs = false
+  into("$thirdPartyNdkDir/folly")
+}
+// END FOLLy
+
+task prepareThirdPartyNdkHeaders(dependsOn: [prepareBoost, prepareDoubleConversion, prepareFolly]) {}
+
+afterEvaluate {
+  extractAARHeaders.dependsOn(prepareThirdPartyNdkHeaders)
+  extractJNIFiles.dependsOn(prepareThirdPartyNdkHeaders)
+}
+
+tasks.whenTaskAdded { task ->
+  if (task.name.contains('externalNativeBuild') || task.name.startsWith('configureCMake')) {
+    task.dependsOn(extractAARHeaders)
+    task.dependsOn(extractJNIFiles)
+    if (REACT_NATIVE_BUILD_FROM_SOURCE) {
+      task.dependsOn(":ReactAndroid:packageReactNdkLibs")
+    }
+  } else if (task.name.startsWith('generateJsonModel') && REACT_NATIVE_BUILD_FROM_SOURCE) {
+    task.dependsOn(":ReactAndroid:packageReactNdkLibs")
+  }
+}
+

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -51,7 +51,7 @@ def thirdPartyNdkDir = new File("$buildDir/third-party-ndk")
 def REACT_NATIVE_DIR = new File(["node", "--print", "require.resolve('react-native/package.json')"].execute(null, rootDir).text.trim()).parent
 def REACT_NATIVE_BUILD_FROM_SOURCE = findProject(":ReactAndroid") != null
 def REACT_NATIVE_SO_DIR = findProject(":ReactAndroid")
-  ? Paths.get(findProject(":ReactAndroid").getProjectDir().toString(), "build", "react-ndk", "exported")
+  ? Paths.get(findProject(":ReactAndroid").getProjectDir().toString(), "build", "intermediates", "library_*", "*", "jni")
   : "${buildDir}/react-native-0*/jni"
 
 def reactProperties = new Properties()
@@ -110,8 +110,7 @@ android {
     externalNativeBuild {
       cmake {
         abiFilters(*(System.getenv('NDK_ABI_FILTERS') ?: 'armeabi-v7a x86 arm64-v8a x86_64').split(' '))
-        arguments "-DANDROID_STL=c++_shared",
-          "-DREACT_NATIVE_DIR=${REACT_NATIVE_DIR}",
+        arguments "-DREACT_NATIVE_DIR=${REACT_NATIVE_DIR}",
           "-DREACT_NATIVE_SO_DIR=${REACT_NATIVE_SO_DIR}",
           "-DBOOST_VERSION=${BOOST_VERSION}"
       }

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -188,10 +188,8 @@ dependencies {
     }
     def rnAAR = rnAARs.singleFile
     extractJNI(files(rnAAR))
-  } else {
-    println("oooo")
-    // TODO(@lukmccall)
   }
+  // else - there is no prebuilt react-native.aar, this is most likely Expo Go
 }
 
 /**

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -39,6 +39,12 @@ buildscript {
   }
 }
 
+def isAndroidTest() {
+  Gradle gradle = getGradle()
+  String tskReqStr = gradle.getStartParameter().getTaskRequests().toString()
+  return tskReqStr.contains("AndroidTest")
+}
+
 def downloadsDir = new File("$buildDir/downloads")
 def thirdPartyNdkDir = new File("$buildDir/third-party-ndk")
 
@@ -99,6 +105,8 @@ android {
     versionCode 1
     versionName "0.9.0"
 
+    testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+
     externalNativeBuild {
       cmake {
         abiFilters(*(System.getenv('NDK_ABI_FILTERS') ?: 'armeabi-v7a x86 arm64-v8a x86_64').split(' '))
@@ -122,8 +130,8 @@ android {
 
   packagingOptions {
     // Gradle will add cmake target dependencies into packaging.
-    // Theses files are intermediated linking files to build reanimated and should not be in final package.
-    excludes = [
+    // Theses files are intermediated linking files to build modules-core and should not be in final package.
+    def sharedLibraries = [
       "**/libc++_shared.so",
       "**/libreactnativejni.so",
       "**/libglog.so",
@@ -131,8 +139,17 @@ android {
       "**/libfbjni.so",
       "**/libfolly_json.so",
       "**/libhermes.so",
-      "**/libjsi.so",
+      "**/libjsi.so"
     ]
+
+    // In android (instrumental) tests, we want to package all so files to enable our JSI functionality.
+    // Otherwise, those files should be excluded, because will be loaded by the application.
+    if (isAndroidTest()) {
+      excludes = ["META-INF/MANIFEST.MF"]
+      pickFirsts = sharedLibraries
+    } else {
+      excludes = sharedLibraries
+    }
   }
 
   configurations {
@@ -145,7 +162,9 @@ android {
   }
 
   testOptions {
-    unitTests.all {
+    unitTests.includeAndroidResources = true
+
+    unitTests.all { test ->
       testLogging {
         outputs.upToDateWhen { false }
         events "passed", "failed", "skipped", "standardError"
@@ -190,6 +209,10 @@ dependencies {
     extractJNI(files(rnAAR))
   }
   // else - there is no prebuilt react-native.aar, this is most likely Expo Go
+
+  androidTestImplementation 'androidx.test:runner:1.4.0'
+  androidTestImplementation 'androidx.test:core:1.4.0'
+  androidTestImplementation 'androidx.test:rules:1.4.0'
 }
 
 /**
@@ -321,4 +344,3 @@ tasks.whenTaskAdded { task ->
     task.dependsOn(":ReactAndroid:packageReactNdkLibs")
   }
 }
-

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/JSIInteropModuleRegistryTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/JSIInteropModuleRegistryTest.kt
@@ -1,0 +1,19 @@
+package expo.modules
+
+import expo.modules.kotlin.jni.JSIInteropModuleRegistry
+import org.junit.Assert
+import org.junit.Test
+import java.text.ParseException
+
+class JSIInteropModuleRegistryTest {
+  @Test
+  @Throws(ParseException::class)
+  fun ensure_static_libs_loaded() {
+    try {
+      // Using `JSIInteropModuleRegistry.Companion` ensures that static libs will be loaded.
+      JSIInteropModuleRegistry.Companion
+    } catch (e: Exception) {
+      Assert.fail("Couldn't load the `expo-modules-core` library: $e.")
+    }
+  }
+}

--- a/packages/expo-modules-core/android/src/main/cpp/ExpoModulesHostObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/ExpoModulesHostObject.cpp
@@ -29,4 +29,4 @@ void ExpoModulesHostObject::set(jsi::Runtime &runtime, const jsi::PropNameID &na
 std::vector<jsi::PropNameID> ExpoModulesHostObject::getPropertyNames(jsi::Runtime &rt) {
   return {}; // TODO(@lukmccall): get list of all modules
 }
-}
+} // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/ExpoModulesHostObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/ExpoModulesHostObject.cpp
@@ -15,6 +15,10 @@ ExpoModulesHostObject::ExpoModulesHostObject(JSIInteropModuleRegistry *installer
 jsi::Value ExpoModulesHostObject::get(jsi::Runtime &runtime, const jsi::PropNameID &name) {
   auto cName = name.utf8(runtime);
   auto module = installer->getModule(cName);
+  if (module == nullptr) {
+    return jsi::Value::undefined();
+  }
+
   module->cthis()->jsiInteropModuleRegistry = installer;
   auto jsiObject = module->cthis()->getJSIObject(runtime);
   return jsi::Value(runtime, *jsiObject);

--- a/packages/expo-modules-core/android/src/main/cpp/ExpoModulesHostObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/ExpoModulesHostObject.cpp
@@ -15,15 +15,17 @@ ExpoModulesHostObject::ExpoModulesHostObject(JSIInteropModuleRegistry *installer
 jsi::Value ExpoModulesHostObject::get(jsi::Runtime &runtime, const jsi::PropNameID &name) {
   auto cName = name.utf8(runtime);
   auto module = installer->getModule(cName);
+  module->cthis()->jsiInteropModuleRegistry = installer;
   auto jsiObject = module->cthis()->getJSIObject(runtime);
   return jsi::Value(runtime, *jsiObject);
 }
 
 void ExpoModulesHostObject::set(jsi::Runtime &runtime, const jsi::PropNameID &name,
                                 const jsi::Value &value) {
-  std::string message("RuntimeError: Cannot override the host object for expo module '");
-  message += name.utf8(runtime);
-  throw jsi::JSError(runtime, message);
+  throw jsi::JSError(
+    runtime,
+    "RuntimeError: Cannot override the host object for expo module '" + name.utf8(runtime) + "'"
+  );
 }
 
 std::vector<jsi::PropNameID> ExpoModulesHostObject::getPropertyNames(jsi::Runtime &rt) {

--- a/packages/expo-modules-core/android/src/main/cpp/ExpoModulesHostObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/ExpoModulesHostObject.cpp
@@ -1,0 +1,33 @@
+// Copyright © 2021-present 650 Industries, Inc. (aka Expo)
+
+#include "ExpoModulesHostObject.h"
+
+#include <folly/dynamic.h>
+#include <jsi/JSIDynamic.h>
+
+namespace jsi = facebook::jsi;
+
+namespace expo {
+
+ExpoModulesHostObject::ExpoModulesHostObject(JSIInteropModuleRegistry *installer) : installer(
+  installer) {}
+
+jsi::Value ExpoModulesHostObject::get(jsi::Runtime &runtime, const jsi::PropNameID &name) {
+  auto cName = name.utf8(runtime);
+  auto module = installer->getModule(cName);
+  auto jsiObject = module->cthis()->getJSIObject(runtime);
+  return jsi::Value(runtime, *jsiObject);
+}
+
+void ExpoModulesHostObject::set(jsi::Runtime &runtime, const jsi::PropNameID &name,
+                                const jsi::Value &value) {
+  std::string message("RuntimeError: Cannot override the host object for expo module '");
+  message += name.utf8(runtime);
+  message += "'.";
+  throw jsi::JSError(runtime, message);
+}
+
+std::vector<jsi::PropNameID> ExpoModulesHostObject::getPropertyNames(jsi::Runtime &rt) {
+  return {}; // TODO(@lukmccall): get list of all modules
+}
+}

--- a/packages/expo-modules-core/android/src/main/cpp/ExpoModulesHostObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/ExpoModulesHostObject.cpp
@@ -9,8 +9,8 @@ namespace jsi = facebook::jsi;
 
 namespace expo {
 
-ExpoModulesHostObject::ExpoModulesHostObject(JSIInteropModuleRegistry *installer) : installer(
-  installer) {}
+ExpoModulesHostObject::ExpoModulesHostObject(JSIInteropModuleRegistry *installer)
+  : installer(installer) {}
 
 jsi::Value ExpoModulesHostObject::get(jsi::Runtime &runtime, const jsi::PropNameID &name) {
   auto cName = name.utf8(runtime);
@@ -23,7 +23,6 @@ void ExpoModulesHostObject::set(jsi::Runtime &runtime, const jsi::PropNameID &na
                                 const jsi::Value &value) {
   std::string message("RuntimeError: Cannot override the host object for expo module '");
   message += name.utf8(runtime);
-  message += "'.";
   throw jsi::JSError(runtime, message);
 }
 

--- a/packages/expo-modules-core/android/src/main/cpp/ExpoModulesHostObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/ExpoModulesHostObject.h
@@ -11,6 +11,11 @@
 namespace jsi = facebook::jsi;
 
 namespace expo {
+/**
+ * An entry point to all exported functionalities like modules.
+ *
+ * An instance of this class will be added to the JS global object.
+ */
 class ExpoModulesHostObject : public jsi::HostObject {
 public:
   ExpoModulesHostObject(JSIInteropModuleRegistry *installer);

--- a/packages/expo-modules-core/android/src/main/cpp/ExpoModulesHostObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/ExpoModulesHostObject.h
@@ -24,4 +24,4 @@ public:
 private:
   JSIInteropModuleRegistry *installer;
 };
-}
+} // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/ExpoModulesHostObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/ExpoModulesHostObject.h
@@ -1,0 +1,27 @@
+// Copyright © 2021-present 650 Industries, Inc. (aka Expo)
+
+#pragma once
+
+#include "JSIInteropModuleRegistry.h"
+
+#include <jsi/jsi.h>
+
+#include <vector>
+
+namespace jsi = facebook::jsi;
+
+namespace expo {
+class ExpoModulesHostObject : public jsi::HostObject {
+public:
+  ExpoModulesHostObject(JSIInteropModuleRegistry *installer);
+
+  jsi::Value get(jsi::Runtime &, const jsi::PropNameID &name) override;
+
+  void set(jsi::Runtime &, const jsi::PropNameID &name, const jsi::Value &value) override;
+
+  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime &rt) override;
+
+private:
+  JSIInteropModuleRegistry *installer;
+};
+}

--- a/packages/expo-modules-core/android/src/main/cpp/JNIFunctionBody.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JNIFunctionBody.cpp
@@ -1,0 +1,29 @@
+// Copyright © 2021-present 650 Industries, Inc. (aka Expo)
+
+#include "JNIFunctionBody.h"
+
+namespace jni = facebook::jni;
+namespace react = facebook::react;
+
+namespace expo {
+jni::local_ref<react::ReadableNativeArray::javaobject>
+JNIFunctionBody::invoke(react::ReadableNativeArray::javaobject &&args) {
+  static const auto method = getClass()->getMethod<
+    react::ReadableNativeArray::javaobject(react::ReadableNativeArray::javaobject)
+  >(
+    "invoke"
+  );
+
+  return method(this->self(), args);
+}
+
+void JNIAsyncFunctionBody::invoke(react::ReadableNativeArray::javaobject &&args, jobject promise) {
+  static const auto method = getClass()->getMethod<
+    react::ReadableNativeArray::javaobject(react::ReadableNativeArray::javaobject, jobject)
+  >(
+    "invoke"
+  );
+
+  method(this->self(), args, promise);
+}
+} // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JNIFunctionBody.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JNIFunctionBody.h
@@ -1,0 +1,50 @@
+// Copyright © 2021-present 650 Industries, Inc. (aka Expo)
+
+#pragma once
+
+#include <fbjni/fbjni.h>
+#include <react/jni/ReadableNativeArray.h>
+
+namespace jni = facebook::jni;
+namespace react = facebook::react;
+
+namespace expo {
+/**
+ * A CPP part of the expo.modules.kotlin.jni.JNIFunctionBody class.
+ * It represents the Kotlin's promise-less function.
+ */
+class JNIFunctionBody : public jni::JavaClass<JNIFunctionBody> {
+public:
+  static auto constexpr kJavaDescriptor = "Lexpo/modules/kotlin/jni/JNIFunctionBody;";
+
+  /**
+   * Invokes a Kotlin's implementation of this function.
+   *
+   * @param args
+   * @return result of the Kotlin function
+   */
+  jni::local_ref<react::ReadableNativeArray::javaobject> invoke(
+    react::ReadableNativeArray::javaobject &&args
+  );
+};
+
+/**
+ * A CPP part of the expo.modules.kotlin.jni.JNIAsyncFunctionBody class.
+ * It represents the Kotlin's promise function.
+ */
+class JNIAsyncFunctionBody : public jni::JavaClass<JNIAsyncFunctionBody> {
+public:
+  static auto constexpr kJavaDescriptor = "Lexpo/modules/kotlin/jni/JNIAsyncFunctionBody;";
+
+  /**
+   * Invokes a Kotlin's implementation of this async function.
+   *
+   * @param args
+   * @param promise that will be resolve or rejected in the Kotlin's implementation
+   */
+  void invoke(
+    react::ReadableNativeArray::javaobject &&args,
+    jobject promise
+  );
+};
+} // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JNIInjector.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JNIInjector.cpp
@@ -1,0 +1,15 @@
+// Copyright © 2021-present 650 Industries, Inc. (aka Expo)
+
+#include "JSIInteropModuleRegistry.h"
+#include "JavaScriptModuleObject.h"
+
+#include <jni.h>
+#include <fbjni/fbjni.h>
+
+// Install all jni bindings
+JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *) {
+  return facebook::jni::initialize(vm, [] {
+    expo::JSIInteropModuleRegistry::registerNatives();
+    expo::JavaScriptModuleObject::registerNatives();
+  });
+}

--- a/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.cpp
@@ -1,0 +1,61 @@
+// Copyright © 2021-present 650 Industries, Inc. (aka Expo)
+
+#include "JSIInteropModuleRegistry.h"
+#include "ExpoModulesHostObject.h"
+
+#include <fbjni/detail/Meta.h>
+#include <fbjni/fbjni.h>
+
+#include <memory>
+
+namespace jni = facebook::jni;
+namespace jsi = facebook::jsi;
+
+namespace expo {
+jni::local_ref<JSIInteropModuleRegistry::jhybriddata>
+JSIInteropModuleRegistry::initHybrid(jni::alias_ref<jhybridobject> jThis) {
+  return makeCxxInstance(jThis);
+}
+
+void JSIInteropModuleRegistry::registerNatives() {
+  registerHybrid({
+                   makeNativeMethod("initHybrid", JSIInteropModuleRegistry::initHybrid),
+                   makeNativeMethod("installJSI", JSIInteropModuleRegistry::installJSI)
+                 });
+}
+
+JSIInteropModuleRegistry::JSIInteropModuleRegistry(jni::alias_ref<jhybridobject> jThis) : javaPart_(
+  jni::make_global(jThis)) {}
+
+void JSIInteropModuleRegistry::installJSI(jlong jsRuntimePointer) {
+  auto runtime = reinterpret_cast<jsi::Runtime *>(jsRuntimePointer);
+  runtimeHolder = std::make_unique<JavaScriptRuntime>(runtime);
+
+  auto expoModules = std::make_shared<ExpoModulesHostObject>(this);
+  auto expoModulesObject = jsi::Object::createFromHostObject(*runtime, expoModules);
+
+  runtime
+    ->global()
+    .setProperty(
+      *runtime,
+      "ExpoModules",
+      std::move(expoModulesObject)
+    );
+}
+
+jni::local_ref<JavaScriptModuleObject::javaobject>
+JSIInteropModuleRegistry::callGetJavaScriptModuleObjectMethod(const std::string &moduleName) const {
+  const static auto method = expo::JSIInteropModuleRegistry::javaClassLocal()
+    ->getMethod<jni::local_ref<JavaScriptModuleObject::javaobject>(
+      std::string)>(
+      "getJavaScriptModuleObject"
+    );
+
+  return method(javaPart_, moduleName);
+}
+
+jni::local_ref<JavaScriptModuleObject::javaobject>
+JSIInteropModuleRegistry::getModule(const std::string &moduleName) const {
+  return callGetJavaScriptModuleObjectMethod(moduleName);
+}
+}

--- a/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.cpp
@@ -24,12 +24,18 @@ void JSIInteropModuleRegistry::registerNatives() {
                  });
 }
 
-JSIInteropModuleRegistry::JSIInteropModuleRegistry(jni::alias_ref <jhybridobject> jThis)
+JSIInteropModuleRegistry::JSIInteropModuleRegistry(jni::alias_ref<jhybridobject> jThis)
   : javaPart_(jni::make_global(jThis)) {}
 
-void JSIInteropModuleRegistry::installJSI(jlong jsRuntimePointer) {
+void JSIInteropModuleRegistry::installJSI(
+  jlong jsRuntimePointer,
+  jni::alias_ref<react::CallInvokerHolder::javaobject> jsInvokerHolder,
+  jni::alias_ref<react::CallInvokerHolder::javaobject> nativeInvokerHolder
+) {
   auto runtime = reinterpret_cast<jsi::Runtime *>(jsRuntimePointer);
   runtimeHolder = std::make_unique<JavaScriptRuntime>(runtime);
+  jsInvoker = jsInvokerHolder->cthis()->getCallInvoker();
+  nativeInvoker = nativeInvokerHolder->cthis()->getCallInvoker();
 
   auto expoModules = std::make_shared<ExpoModulesHostObject>(this);
   auto expoModulesObject = jsi::Object::createFromHostObject(*runtime, expoModules);

--- a/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.cpp
@@ -58,4 +58,4 @@ jni::local_ref<JavaScriptModuleObject::javaobject>
 JSIInteropModuleRegistry::getModule(const std::string &moduleName) const {
   return callGetJavaScriptModuleObjectMethod(moduleName);
 }
-}
+} // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.cpp
@@ -24,8 +24,8 @@ void JSIInteropModuleRegistry::registerNatives() {
                  });
 }
 
-JSIInteropModuleRegistry::JSIInteropModuleRegistry(jni::alias_ref<jhybridobject> jThis) : javaPart_(
-  jni::make_global(jThis)) {}
+JSIInteropModuleRegistry::JSIInteropModuleRegistry(jni::alias_ref <jhybridobject> jThis)
+  : javaPart_(jni::make_global(jThis)) {}
 
 void JSIInteropModuleRegistry::installJSI(jlong jsRuntimePointer) {
   auto runtime = reinterpret_cast<jsi::Runtime *>(jsRuntimePointer);

--- a/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.h
@@ -31,11 +31,7 @@ public:
   static void registerNatives();
 
   /**
-   * Initializes the `ExpoModulesHostObject` and adds it to the globa object.
-   *
-   * @param jsRuntimePointer
-   * @param jsInvokerHolder
-   * @param nativeInvokerHolder
+   * Initializes the `ExpoModulesHostObject` and adds it to the global object.
    */
   void installJSI(
     jlong jsRuntimePointer,

--- a/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.h
@@ -38,4 +38,4 @@ private:
   inline jni::local_ref<JavaScriptModuleObject::javaobject>
   callGetJavaScriptModuleObjectMethod(const std::string &moduleName) const;
 };
-}
+} // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.h
@@ -17,6 +17,9 @@ namespace jsi = facebook::jsi;
 namespace react = facebook::react;
 
 namespace expo {
+/**
+ * A JNI wrapper to initialize CPP part of modules and access all data from the module registry.
+ */
 class JSIInteropModuleRegistry : public jni::HybridClass<JSIInteropModuleRegistry> {
 public:
   static auto constexpr
@@ -27,12 +30,25 @@ public:
 
   static void registerNatives();
 
+  /**
+   * Initializes the `ExpoModulesHostObject` and adds it to the globa object.
+   *
+   * @param jsRuntimePointer
+   * @param jsInvokerHolder
+   * @param nativeInvokerHolder
+   */
   void installJSI(
     jlong jsRuntimePointer,
     jni::alias_ref<react::CallInvokerHolder::javaobject> jsInvokerHolder,
     jni::alias_ref<react::CallInvokerHolder::javaobject> nativeInvokerHolder
   );
 
+  /**
+   * Gets a module for a given name. It will throw an exception if the module doesn't exist.
+   *
+   * @param moduleName
+   * @return An instance of `JavaScriptModuleObject`
+   */
   jni::local_ref<JavaScriptModuleObject::javaobject> getModule(const std::string &moduleName) const;
 
   std::shared_ptr<react::CallInvoker> jsInvoker;

--- a/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.h
@@ -1,0 +1,41 @@
+// Copyright © 2021-present 650 Industries, Inc. (aka Expo)
+
+#pragma once
+
+#include "JavaScriptRuntime.h"
+#include "JavaScriptModuleObject.h"
+
+#include <fbjni/fbjni.h>
+#include <jsi/jsi.h>
+
+#include <memory>
+
+namespace jni = facebook::jni;
+namespace jsi = facebook::jsi;
+
+namespace expo {
+class JSIInteropModuleRegistry : public jni::HybridClass<JSIInteropModuleRegistry> {
+public:
+  static auto constexpr
+    kJavaDescriptor = "Lexpo/modules/kotlin/jni/JSIInteropModuleRegistry;";
+  static auto constexpr TAG = "JSIInteropModuleRegistry";
+
+  static jni::local_ref<jhybriddata> initHybrid(jni::alias_ref<jhybridobject> jThis);
+
+  static void registerNatives();
+
+  void installJSI(jlong jsRuntimePointer);
+
+  jni::local_ref<JavaScriptModuleObject::javaobject> getModule(const std::string &moduleName) const;
+
+private:
+  friend HybridBase;
+  std::unique_ptr<JavaScriptRuntime> runtimeHolder;
+  jni::global_ref<JSIInteropModuleRegistry::javaobject> javaPart_;
+
+  explicit JSIInteropModuleRegistry(jni::alias_ref<jhybridobject> jThis);
+
+  inline jni::local_ref<JavaScriptModuleObject::javaobject>
+  callGetJavaScriptModuleObjectMethod(const std::string &moduleName) const;
+};
+}

--- a/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.h
@@ -7,11 +7,14 @@
 
 #include <fbjni/fbjni.h>
 #include <jsi/jsi.h>
+#include <ReactCommon/CallInvokerHolder.h>
+#include <ReactCommon/CallInvoker.h>
 
 #include <memory>
 
 namespace jni = facebook::jni;
 namespace jsi = facebook::jsi;
+namespace react = facebook::react;
 
 namespace expo {
 class JSIInteropModuleRegistry : public jni::HybridClass<JSIInteropModuleRegistry> {
@@ -24,9 +27,16 @@ public:
 
   static void registerNatives();
 
-  void installJSI(jlong jsRuntimePointer);
+  void installJSI(
+    jlong jsRuntimePointer,
+    jni::alias_ref<react::CallInvokerHolder::javaobject> jsInvokerHolder,
+    jni::alias_ref<react::CallInvokerHolder::javaobject> nativeInvokerHolder
+  );
 
   jni::local_ref<JavaScriptModuleObject::javaobject> getModule(const std::string &moduleName) const;
+
+  std::shared_ptr<react::CallInvoker> jsInvoker;
+  std::shared_ptr<react::CallInvoker> nativeInvoker;
 
 private:
   friend HybridBase;

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.cpp
@@ -115,7 +115,6 @@ JavaScriptModuleObject::HostObject::set(jsi::Runtime &runtime, const jsi::PropNa
                                         const jsi::Value &value) {
   std::string message("RuntimeError: Cannot override the host object for expo module '");
   message += name.utf8(runtime);
-  message += "'.";
   throw jsi::JSError(runtime, message);
 }
 

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.cpp
@@ -133,4 +133,4 @@ JavaScriptModuleObject::HostObject::getPropertyNames(jsi::Runtime &rt) {
 
   return result;
 }
-}
+} // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.cpp
@@ -1,10 +1,17 @@
 // Copyright © 2021-present 650 Industries, Inc. (aka Expo)
 
 #include "JavaScriptModuleObject.h"
+#include "JSIInteropModuleRegistry.h"
 
 #include <folly/dynamic.h>
 #include <jsi/JSIDynamic.h>
 #include <react/jni/ReadableNativeArray.h>
+#include <fbjni/detail/Hybrid.h>
+#include <ReactCommon/TurboModuleUtils.h>
+#include <jni/JCallback.h>
+#include <jsi/JSIDynamic.h>
+#include <fbjni/fbjni.h>
+#include <jsi/jsi.h>
 
 #include <utility>
 #include <tuple>
@@ -15,6 +22,65 @@ namespace jsi = facebook::jsi;
 namespace react = facebook::react;
 
 namespace expo {
+// Modified version of the RN implementation
+// https://github.com/facebook/react-native/blob/7dceb9b63c0bfd5b13bf6d26f9530729506e9097/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.cpp#L57
+jni::local_ref<react::JCxxCallbackImpl::JavaPart> createJavaCallbackFromJSIFunction(
+  jsi::Function &&function,
+  jsi::Runtime &rt,
+  std::shared_ptr<react::CallInvoker> jsInvoker
+) {
+  auto weakWrapper = react::CallbackWrapper::createWeak(std::move(function), rt,
+                                                        std::move(jsInvoker));
+
+  // This needs to be a shared_ptr because:
+  // 1. It cannot be unique_ptr. std::function is copyable but unique_ptr is
+  // not.
+  // 2. It cannot be weak_ptr since we need this object to live on.
+  // 3. It cannot be a value, because that would be deleted as soon as this
+  // function returns.
+  auto callbackWrapperOwner =
+    std::make_shared<react::RAIICallbackWrapperDestroyer>(weakWrapper);
+
+  std::function<void(folly::dynamic)> fn =
+    [weakWrapper, callbackWrapperOwner, wrapperWasCalled = false](
+      folly::dynamic responses) mutable {
+      if (wrapperWasCalled) {
+        throw std::runtime_error(
+          "callback 2 arg cannot be called more than once");
+      }
+
+      auto strongWrapper = weakWrapper.lock();
+      if (!strongWrapper) {
+        return;
+      }
+
+      strongWrapper->jsInvoker().invokeAsync(
+        [weakWrapper, callbackWrapperOwner, responses]() mutable {
+          auto strongWrapper2 = weakWrapper.lock();
+          if (!strongWrapper2) {
+            return;
+          }
+
+          jsi::Value args =
+            jsi::valueFromDynamic(strongWrapper2->runtime(), responses);
+          auto argsArray = args.getObject(strongWrapper2->runtime())
+            .asArray(strongWrapper2->runtime());
+          jsi::Value arg = argsArray.getValueAtIndex(strongWrapper2->runtime(), 0);
+
+          strongWrapper2->callback().call(
+            strongWrapper2->runtime(),
+            (const jsi::Value *) &arg,
+            (size_t) 1
+          );
+
+          callbackWrapperOwner.reset();
+        });
+
+      wrapperWasCalled = true;
+    };
+
+  return react::JCxxCallbackImpl::newObjectCxxArgs(fn);
+}
 
 jni::local_ref<jni::HybridClass<JavaScriptModuleObject>::jhybriddata>
 JavaScriptModuleObject::initHybrid(jni::alias_ref<jhybridobject> jThis) {
@@ -26,6 +92,8 @@ void JavaScriptModuleObject::registerNatives() {
                    makeNativeMethod("initHybrid", JavaScriptModuleObject::initHybrid),
                    makeNativeMethod("registerSyncFunction",
                                     JavaScriptModuleObject::registerSyncFunction),
+                   makeNativeMethod("registerAsyncFunction",
+                                    JavaScriptModuleObject::registerAsyncFunction),
                  });
 }
 
@@ -46,6 +114,13 @@ void JavaScriptModuleObject::registerSyncFunction(jni::alias_ref<jstring> name, 
                           std::forward_as_tuple(cName, args, false));
 }
 
+void JavaScriptModuleObject::registerAsyncFunction(jni::alias_ref<jstring> name, jint args) {
+  auto cName = name->toStdString();
+  methodsMetadata.emplace(std::piecewise_construct,
+                          std::forward_as_tuple(cName),
+                          std::forward_as_tuple(cName, args, true));
+}
+
 jni::local_ref<react::ReadableNativeArray::javaobject>
 JavaScriptModuleObject::callSyncMethod(jni::local_ref<jstring> &&name,
                                        react::ReadableNativeArray::javaobject &&args) {
@@ -57,6 +132,23 @@ JavaScriptModuleObject::callSyncMethod(jni::local_ref<jstring> &&name,
     );
 
   return method(javaPart_.get(), std::move(name), args);
+}
+
+void JavaScriptModuleObject::callAsyncMethod(
+  jni::local_ref<jstring> &&name,
+  react::ReadableNativeArray::javaobject &&args,
+  jobject promise
+) {
+  static const auto method = JavaScriptModuleObject::javaClassLocal()
+    ->getMethod<void(
+      jni::local_ref<jstring>,
+      react::ReadableNativeArray::javaobject,
+      jobject
+    )>(
+      "callAsyncMethod"
+    );
+
+  method(javaPart_.get(), std::move(name), args, promise);
 }
 
 JavaScriptModuleObject::HostObject::HostObject(
@@ -72,39 +164,14 @@ jsi::Value JavaScriptModuleObject::HostObject::get(jsi::Runtime &runtime,
   auto metadata = metadataRecord->second;
 
   if (metadata.body == nullptr) {
-    auto body = jsi::Function::createFromHostFunction(
-      runtime,
-      jsi::PropNameID::forAscii(runtime, metadata.name),
-      metadata.args,
-      [&jsModule = jsModule, cName](
-        jsi::Runtime &rt,
-        const jsi::Value &thisValue,
-        const jsi::Value *args,
-        size_t count
-      ) -> jsi::Value {
-        auto dynamicArray = folly::dynamic::array();
-        for (int i = 0; i < count; i++) {
-          auto &arg = args[i];
-          dynamicArray.push_back(jsi::dynamicFromValue(rt, arg));
-        }
-
-        auto result = jsModule->callSyncMethod(
-          jni::make_jstring(cName),
-          react::ReadableNativeArray::newObjectCxxArgs(std::move(dynamicArray)).get()
-        );
-
-        if (result == nullptr) {
-          return jsi::Value::undefined();
-        }
-
-        return jsi::valueFromDynamic(rt, result->cthis()->consume())
-          .asObject(rt)
-          .asArray(rt)
-          .getValueAtIndex(rt, 0);
-      }
-    );
-
-    metadata.body = std::make_shared<jsi::Function>(std::move(body));
+    if (!metadata.isAsync) {
+      metadata.body = std::make_shared<jsi::Function>(
+        createSyncFunctionCaller(runtime, cName, metadata.args));
+    } else {
+      metadata.body = std::make_shared<jsi::Function>(
+        createAsyncFunctionCaller(runtime, cName, metadata.args)
+      );
+    }
   }
 
   return jsi::Value(runtime, *metadata.body);
@@ -113,9 +180,10 @@ jsi::Value JavaScriptModuleObject::HostObject::get(jsi::Runtime &runtime,
 void
 JavaScriptModuleObject::HostObject::set(jsi::Runtime &runtime, const jsi::PropNameID &name,
                                         const jsi::Value &value) {
-  std::string message("RuntimeError: Cannot override the host object for expo module '");
-  message += name.utf8(runtime);
-  throw jsi::JSError(runtime, message);
+  throw jsi::JSError(
+    runtime,
+    "RuntimeError: Cannot override the host object for expo module '" + name.utf8(runtime) + "'"
+  );
 }
 
 std::vector<jsi::PropNameID>
@@ -132,5 +200,136 @@ JavaScriptModuleObject::HostObject::getPropertyNames(jsi::Runtime &rt) {
   );
 
   return result;
+}
+
+jsi::Function JavaScriptModuleObject::HostObject::createSyncFunctionCaller(
+  jsi::Runtime &runtime,
+  const std::string &name,
+  int argsNumber
+) {
+  return jsi::Function::createFromHostFunction(
+    runtime,
+    jsi::PropNameID::forAscii(runtime, name),
+    argsNumber,
+    [this, name](
+      jsi::Runtime &rt,
+      const jsi::Value &thisValue,
+      const jsi::Value *args,
+      size_t count
+    ) -> jsi::Value {
+      auto dynamicArray = folly::dynamic::array();
+      for (int i = 0; i < count; i++) {
+        auto &arg = args[i];
+        dynamicArray.push_back(jsi::dynamicFromValue(rt, arg));
+      }
+
+      auto result = jsModule->callSyncMethod(
+        jni::make_jstring(name),
+        react::ReadableNativeArray::newObjectCxxArgs(std::move(dynamicArray)).get()
+      );
+
+      if (result == nullptr) {
+        return jsi::Value::undefined();
+      }
+
+      return jsi::valueFromDynamic(rt, result->cthis()->consume())
+        .asObject(rt)
+        .asArray(rt)
+        .getValueAtIndex(rt, 0);
+    });
+}
+
+jsi::Function JavaScriptModuleObject::HostObject::createAsyncFunctionCaller(
+  jsi::Runtime &runtime,
+  const std::string &name,
+  int argsNumber
+) {
+  return jsi::Function::createFromHostFunction(
+    runtime,
+    jsi::PropNameID::forAscii(runtime, name),
+    argsNumber,
+    [this, name](
+      jsi::Runtime &rt,
+      const jsi::Value &thisValue,
+      const jsi::Value *args,
+      size_t count
+    ) -> jsi::Value {
+      auto dynamicArray = folly::dynamic::array();
+      for (int i = 0; i < count; i++) {
+        auto &arg = args[i];
+        dynamicArray.push_back(jsi::dynamicFromValue(rt, arg));
+      }
+
+      auto Promise = rt.global().getPropertyAsFunction(rt, "Promise");
+      jsi::Value promise = Promise.callAsConstructor(
+        rt,
+        createPromiseBody(rt, name, std::move(dynamicArray))
+      );
+      return promise;
+    }
+  );
+}
+
+jsi::Function JavaScriptModuleObject::HostObject::createPromiseBody(
+  jsi::Runtime &runtime,
+  const std::string &name,
+  folly::dynamic &&args
+) {
+  return jsi::Function::createFromHostFunction(
+    runtime,
+    jsi::PropNameID::forAscii(runtime, "promiseFn"),
+    2,
+    [this, args = std::move(args), name](
+      jsi::Runtime &rt,
+      const jsi::Value &thisVal,
+      const jsi::Value *promiseConstructorArgs,
+      size_t promiseConstructorArgCount
+    ) {
+      if (promiseConstructorArgCount != 2) {
+        throw std::invalid_argument("Promise fn arg count must be 2");
+      }
+
+      jsi::Function resolveJSIFn = promiseConstructorArgs[0].getObject(rt).getFunction(rt);
+      jsi::Function rejectJSIFn = promiseConstructorArgs[1].getObject(rt).getFunction(rt);
+
+      jobject resolve = createJavaCallbackFromJSIFunction(
+        std::move(resolveJSIFn),
+        rt,
+        jsModule->jsiInteropModuleRegistry->jsInvoker
+      ).release();
+
+      jobject reject = createJavaCallbackFromJSIFunction(
+        std::move(rejectJSIFn),
+        rt,
+        jsModule->jsiInteropModuleRegistry->jsInvoker
+      ).release();
+
+      JNIEnv *env = jni::Environment::current();
+
+      jclass jPromiseImpl =
+        env->FindClass("com/facebook/react/bridge/PromiseImpl");
+      jmethodID jPromiseImplConstructor = env->GetMethodID(
+        jPromiseImpl,
+        "<init>",
+        "(Lcom/facebook/react/bridge/Callback;Lcom/facebook/react/bridge/Callback;)V");
+
+      jobject promise = env->NewObject(
+        jPromiseImpl,
+        jPromiseImplConstructor,
+        resolve,
+        reject
+      );
+
+      jsModule->callAsyncMethod(
+        jni::make_jstring(name),
+        react::ReadableNativeArray::newObjectCxxArgs(args).get(),
+        promise
+      );
+
+      env->DeleteLocalRef(promise);
+
+      return jsi::Value::undefined();
+    }
+  );
 }
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.cpp
@@ -1,0 +1,137 @@
+// Copyright © 2021-present 650 Industries, Inc. (aka Expo)
+
+#include "JavaScriptModuleObject.h"
+
+#include <folly/dynamic.h>
+#include <jsi/JSIDynamic.h>
+#include <react/jni/ReadableNativeArray.h>
+
+#include <utility>
+#include <tuple>
+#include <algorithm>
+
+namespace jni = facebook::jni;
+namespace jsi = facebook::jsi;
+namespace react = facebook::react;
+
+namespace expo {
+
+jni::local_ref<jni::HybridClass<JavaScriptModuleObject>::jhybriddata>
+JavaScriptModuleObject::initHybrid(jni::alias_ref<jhybridobject> jThis) {
+  return makeCxxInstance(jThis);
+}
+
+void JavaScriptModuleObject::registerNatives() {
+  registerHybrid({
+                   makeNativeMethod("initHybrid", JavaScriptModuleObject::initHybrid),
+                   makeNativeMethod("registerSyncFunction",
+                                    JavaScriptModuleObject::registerSyncFunction),
+                 });
+}
+
+std::shared_ptr<jsi::Object> JavaScriptModuleObject::getJSIObject(jsi::Runtime &runtime) {
+  if (jsiObject == nullptr) {
+    auto hostObject = std::make_shared<JavaScriptModuleObject::HostObject>(this);
+    jsiObject = std::make_shared<jsi::Object>(
+      jsi::Object::createFromHostObject(runtime, hostObject));
+  }
+
+  return jsiObject;
+}
+
+void JavaScriptModuleObject::registerSyncFunction(jni::alias_ref<jstring> name, jint args) {
+  auto cName = name->toStdString();
+  methodsMetadata.emplace(std::piecewise_construct,
+                          std::forward_as_tuple(cName),
+                          std::forward_as_tuple(cName, args, false));
+}
+
+jni::local_ref<react::ReadableNativeArray::javaobject>
+JavaScriptModuleObject::callSyncMethod(jni::local_ref<jstring> &&name,
+                                       react::ReadableNativeArray::javaobject &&args) {
+  static const auto method = JavaScriptModuleObject::javaClassLocal()
+    ->getMethod<react::ReadableNativeArray::javaobject(
+      jni::local_ref<jstring>,
+      react::ReadableNativeArray::javaobject)>(
+      "callSyncMethod"
+    );
+
+  return method(javaPart_.get(), std::move(name), args);
+}
+
+JavaScriptModuleObject::HostObject::HostObject(
+  JavaScriptModuleObject *jsModule) : jsModule(jsModule) {}
+
+jsi::Value JavaScriptModuleObject::HostObject::get(jsi::Runtime &runtime,
+                                                   const jsi::PropNameID &name) {
+  auto cName = name.utf8(runtime);
+  auto metadataRecord = jsModule->methodsMetadata.find(cName);
+  if (metadataRecord == jsModule->methodsMetadata.end()) {
+    return jsi::Value::undefined();
+  }
+  auto metadata = metadataRecord->second;
+
+  if (metadata.body == nullptr) {
+    auto body = jsi::Function::createFromHostFunction(
+      runtime,
+      jsi::PropNameID::forAscii(runtime, metadata.name),
+      metadata.args,
+      [&jsModule = jsModule, cName](
+        jsi::Runtime &rt,
+        const jsi::Value &thisValue,
+        const jsi::Value *args,
+        size_t count
+      ) -> jsi::Value {
+        auto dynamicArray = folly::dynamic::array();
+        for (int i = 0; i < count; i++) {
+          auto &arg = args[i];
+          dynamicArray.push_back(jsi::dynamicFromValue(rt, arg));
+        }
+
+        auto result = jsModule->callSyncMethod(
+          jni::make_jstring(cName),
+          react::ReadableNativeArray::newObjectCxxArgs(std::move(dynamicArray)).get()
+        );
+
+        if (result == nullptr) {
+          return jsi::Value::undefined();
+        }
+
+        return jsi::valueFromDynamic(rt, result->cthis()->consume())
+          .asObject(rt)
+          .asArray(rt)
+          .getValueAtIndex(rt, 0);
+      }
+    );
+
+    metadata.body = std::make_shared<jsi::Function>(std::move(body));
+  }
+
+  return jsi::Value(runtime, *metadata.body);
+}
+
+void
+JavaScriptModuleObject::HostObject::set(jsi::Runtime &runtime, const jsi::PropNameID &name,
+                                        const jsi::Value &value) {
+  std::string message("RuntimeError: Cannot override the host object for expo module '");
+  message += name.utf8(runtime);
+  message += "'.";
+  throw jsi::JSError(runtime, message);
+}
+
+std::vector<jsi::PropNameID>
+JavaScriptModuleObject::HostObject::getPropertyNames(jsi::Runtime &rt) {
+  auto metadata = jsModule->methodsMetadata;
+  std::vector<jsi::PropNameID> result;
+  std::transform(
+    metadata.begin(),
+    metadata.end(),
+    std::back_inserter(result),
+    [&rt](const auto &kv) {
+      return jsi::PropNameID::forUtf8(rt, kv.first);
+    }
+  );
+
+  return result;
+}
+}

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.cpp
@@ -80,17 +80,20 @@ jsi::Value JavaScriptModuleObject::HostObject::get(jsi::Runtime &runtime,
   return jsi::Value(runtime, *metadata.toJSFunction(runtime, jsModule->jsiInteropModuleRegistry));
 }
 
-void
-JavaScriptModuleObject::HostObject::set(jsi::Runtime &runtime, const jsi::PropNameID &name,
-                                        const jsi::Value &value) {
+void JavaScriptModuleObject::HostObject::set(
+  jsi::Runtime &runtime,
+  const jsi::PropNameID &name,
+  const jsi::Value &value
+) {
   throw jsi::JSError(
     runtime,
     "RuntimeError: Cannot override the host object for expo module '" + name.utf8(runtime) + "'"
   );
 }
 
-std::vector<jsi::PropNameID>
-JavaScriptModuleObject::HostObject::getPropertyNames(jsi::Runtime &rt) {
+std::vector<jsi::PropNameID> JavaScriptModuleObject::HostObject::getPropertyNames(
+  jsi::Runtime &rt
+) {
   auto &metadata = jsModule->methodsMetadata;
   std::vector<jsi::PropNameID> result;
   std::transform(

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.cpp
@@ -109,9 +109,7 @@ std::shared_ptr<jsi::Object> JavaScriptModuleObject::getJSIObject(jsi::Runtime &
 
 void JavaScriptModuleObject::registerSyncFunction(jni::alias_ref<jstring> name, jint args) {
   auto cName = name->toStdString();
-  methodsMetadata.emplace(std::piecewise_construct,
-                          std::forward_as_tuple(cName),
-                          std::forward_as_tuple(cName, args, false));
+  methodsMetadata.try_emplace(cName, cName, args, false);
 }
 
 void JavaScriptModuleObject::registerAsyncFunction(jni::alias_ref<jstring> name, jint args) {

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.h
@@ -19,6 +19,12 @@ namespace react = facebook::react;
 namespace expo {
 class JSIInteropModuleRegistry;
 
+/**
+ * A CPP part of the module.
+ *
+ * Right now objects of this class are stored by the ModuleHolder to ensure they will live
+ * as long as the RN context.
+ */
 class JavaScriptModuleObject : public jni::HybridClass<JavaScriptModuleObject> {
 public:
   static auto constexpr
@@ -61,6 +67,17 @@ public:
     jni::alias_ref<JNIAsyncFunctionBody::javaobject> JSIAsyncFunctionBody
   );
 
+  /**
+   * An inner class of the `JavaScriptModuleObject` that is exported to the JS.
+   * It's an additional communication layer between JS and Kotlin.
+   * So the high-level view on accessing the exported function will look like this:
+   * `JS` --get function--> `JavaScriptModuleObject::HostObject` --access module metadata--> `JavaScriptModuleObject`
+   *  --create JSI function--> `MethodMetadata`
+   *
+   * This abstraction wasn't necessary. However, it makes the management of ownership much easier -
+   * `JavaScriptModuleObject` is hold by the ModuleHolder and `JavaScriptModuleObject::HostObject` is stored in the JS runtime.
+   * Without this distinction the `JavaScriptModuleObject` would have to turn into `HostObject` and `HybridObject` at the same time.
+   */
   class HostObject : public jsi::HostObject {
   public:
     HostObject(JavaScriptModuleObject *);
@@ -77,6 +94,10 @@ public:
 
 private:
   friend HybridBase;
+  /**
+   * A reference to the `JavaScriptModuleObject::HostObject`.
+   * Simple we cached that value to return the same object each time.
+   */
   std::shared_ptr<jsi::Object> jsiObject = nullptr;
   jni::global_ref<JavaScriptModuleObject::javaobject> javaPart_;
 

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.h
@@ -68,4 +68,4 @@ private:
   explicit JavaScriptModuleObject(jni::alias_ref<jhybridobject> jThis)
     : javaPart_(jni::make_global(jThis)) {}
 };
-}
+} // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.h
@@ -1,0 +1,71 @@
+// Copyright © 2021-present 650 Industries, Inc. (aka Expo)
+
+#pragma once
+
+#include "MethodMetadata.h"
+
+#include <fbjni/fbjni.h>
+#include <jsi/jsi.h>
+#include <react/jni/ReadableNativeArray.h>
+
+#include <map>
+
+namespace jni = facebook::jni;
+namespace jsi = facebook::jsi;
+namespace react = facebook::react;
+
+namespace expo {
+class JavaScriptModuleObject : public jni::HybridClass<JavaScriptModuleObject> {
+public:
+  static auto constexpr
+    kJavaDescriptor = "Lexpo/modules/kotlin/jni/JavaScriptModuleObject;";
+  static auto constexpr TAG = "JavaScriptModuleObject";
+
+  static jni::local_ref<jhybriddata> initHybrid(jni::alias_ref<jhybridobject> jThis);
+
+  static void registerNatives();
+
+  /**
+   * Returns a cached instance of jsi::Object representing this module.
+   * @param runtime
+   * @return Wrapped instance of JavaScriptModuleObject::HostObject
+   */
+  std::shared_ptr<jsi::Object> getJSIObject(jsi::Runtime &runtime);
+
+  /**
+   * Registers a sync function.
+   * That function can be called via the `JavaScriptModuleObject.callSyncMethod` method.
+   */
+  void registerSyncFunction(jni::alias_ref<jstring> name, jint args);
+
+  class HostObject : public jsi::HostObject {
+  public:
+    HostObject(JavaScriptModuleObject *);
+
+    jsi::Value get(jsi::Runtime &, const jsi::PropNameID &name) override;
+
+    void set(jsi::Runtime &, const jsi::PropNameID &name, const jsi::Value &value) override;
+
+    std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime &rt) override;
+
+  private:
+    JavaScriptModuleObject *jsModule;
+  };
+
+private:
+  friend HybridBase;
+  std::shared_ptr<jsi::Object> jsiObject = nullptr;
+  jni::global_ref<JavaScriptModuleObject::javaobject> javaPart_;
+
+  /**
+   * Metadata map that stores information about all available methods on this module.
+   */
+  std::map<std::string, MethodMetadata> methodsMetadata;
+
+  inline jni::local_ref<react::ReadableNativeArray::javaobject>
+  callSyncMethod(jni::local_ref<jstring> &&name, react::ReadableNativeArray::javaobject &&args);
+
+  explicit JavaScriptModuleObject(jni::alias_ref<jhybridobject> jThis)
+    : javaPart_(jni::make_global(jThis)) {}
+};
+}

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.h
@@ -75,7 +75,7 @@ public:
    *  --create JSI function--> `MethodMetadata`
    *
    * This abstraction wasn't necessary. However, it makes the management of ownership much easier -
-   * `JavaScriptModuleObject` is hold by the ModuleHolder and `JavaScriptModuleObject::HostObject` is stored in the JS runtime.
+   * `JavaScriptModuleObject` is held by the ModuleHolder and `JavaScriptModuleObject::HostObject` is stored in the JS runtime.
    * Without this distinction the `JavaScriptModuleObject` would have to turn into `HostObject` and `HybridObject` at the same time.
    */
   class HostObject : public jsi::HostObject {

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.cpp
@@ -11,4 +11,4 @@ JavaScriptRuntime::JavaScriptRuntime(jsi::Runtime *runtime) : runtime(runtime) {
 jsi::Runtime* JavaScriptRuntime::get() {
   return runtime;
 }
-}
+} // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.cpp
@@ -1,0 +1,14 @@
+// Copyright © 2021-present 650 Industries, Inc. (aka Expo)
+
+#include "JavaScriptRuntime.h"
+
+namespace expo {
+
+namespace jsi = facebook::jsi;
+
+JavaScriptRuntime::JavaScriptRuntime(jsi::Runtime *runtime) : runtime(runtime) {}
+
+jsi::Runtime* JavaScriptRuntime::get() {
+  return runtime;
+}
+}

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.h
@@ -17,4 +17,4 @@ public:
 private:
   jsi::Runtime *runtime;
 };
-}
+} // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.h
@@ -1,0 +1,20 @@
+// Copyright © 2021-present 650 Industries, Inc. (aka Expo)
+
+#pragma once
+
+#include <jsi/jsi.h>
+
+namespace expo {
+
+namespace jsi = facebook::jsi;
+
+class JavaScriptRuntime {
+public:
+  JavaScriptRuntime(jsi::Runtime *runtime);
+
+  jsi::Runtime *get();
+
+private:
+  jsi::Runtime *runtime;
+};
+}

--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
@@ -1,0 +1,229 @@
+#include "MethodMetadata.h"
+
+#include "JSIInteropModuleRegistry.h"
+
+namespace jni = facebook::jni;
+namespace jsi = facebook::jsi;
+namespace react = facebook::react;
+
+namespace expo {
+
+// Modified version of the RN implementation
+// https://github.com/facebook/react-native/blob/7dceb9b63c0bfd5b13bf6d26f9530729506e9097/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.cpp#L57
+jni::local_ref<react::JCxxCallbackImpl::JavaPart> createJavaCallbackFromJSIFunction(
+  jsi::Function &&function,
+  jsi::Runtime &rt,
+  std::shared_ptr<react::CallInvoker> jsInvoker
+) {
+  auto weakWrapper = react::CallbackWrapper::createWeak(std::move(function), rt,
+                                                        std::move(jsInvoker));
+
+  // This needs to be a shared_ptr because:
+  // 1. It cannot be unique_ptr. std::function is copyable but unique_ptr is
+  // not.
+  // 2. It cannot be weak_ptr since we need this object to live on.
+  // 3. It cannot be a value, because that would be deleted as soon as this
+  // function returns.
+  auto callbackWrapperOwner =
+    std::make_shared<react::RAIICallbackWrapperDestroyer>(weakWrapper);
+
+  std::function<void(folly::dynamic)> fn =
+    [weakWrapper, callbackWrapperOwner, wrapperWasCalled = false](
+      folly::dynamic responses) mutable {
+      if (wrapperWasCalled) {
+        throw std::runtime_error(
+          "callback 2 arg cannot be called more than once");
+      }
+
+      auto strongWrapper = weakWrapper.lock();
+      if (!strongWrapper) {
+        return;
+      }
+
+      strongWrapper->jsInvoker().invokeAsync(
+        [weakWrapper, callbackWrapperOwner, responses]() mutable {
+          auto strongWrapper2 = weakWrapper.lock();
+          if (!strongWrapper2) {
+            return;
+          }
+
+          jsi::Value args =
+            jsi::valueFromDynamic(strongWrapper2->runtime(), responses);
+          auto argsArray = args.getObject(strongWrapper2->runtime())
+            .asArray(strongWrapper2->runtime());
+          jsi::Value arg = argsArray.getValueAtIndex(strongWrapper2->runtime(), 0);
+
+          strongWrapper2->callback().call(
+            strongWrapper2->runtime(),
+            (const jsi::Value *) &arg,
+            (size_t) 1
+          );
+
+          callbackWrapperOwner.reset();
+        });
+
+      wrapperWasCalled = true;
+    };
+
+  return react::JCxxCallbackImpl::newObjectCxxArgs(fn);
+}
+
+MethodMetadata::MethodMetadata(
+  std::string name,
+  int args,
+  bool isAsync,
+  jni::global_ref<jobject> &&jBodyReference
+) : name(name),
+    args(args),
+    isAsync(isAsync),
+    jBodyReference(jBodyReference) {}
+
+std::shared_ptr<jsi::Function> MethodMetadata::toJSFunction(
+  jsi::Runtime &runtime,
+  JSIInteropModuleRegistry *moduleRegistry
+) {
+  if (body == nullptr) {
+    if (isAsync) {
+      body = std::make_shared<jsi::Function>(toAsyncFunction(runtime, moduleRegistry));
+    } else {
+      body = std::make_shared<jsi::Function>(toSyncFunction(runtime));
+    }
+  }
+
+  return body;
+}
+
+jsi::Function MethodMetadata::toSyncFunction(jsi::Runtime &runtime) {
+  return jsi::Function::createFromHostFunction(
+    runtime,
+    jsi::PropNameID::forAscii(runtime, name),
+    args,
+    [this](
+      jsi::Runtime &rt,
+      const jsi::Value &thisValue,
+      const jsi::Value *args,
+      size_t count
+    ) -> jsi::Value {
+      auto dynamicArray = folly::dynamic::array();
+      for (int i = 0; i < count; i++) {
+        auto &arg = args[i];
+        dynamicArray.push_back(jsi::dynamicFromValue(rt, arg));
+      }
+
+      // Cast in this place is safe, cause we know that this function is promise-less.
+      auto syncFunction = jni::static_ref_cast<JNIFunctionBody>(this->jBodyReference);
+      auto result = syncFunction->invoke(
+        react::ReadableNativeArray::newObjectCxxArgs(std::move(dynamicArray)).get()
+      );
+
+      if (result == nullptr) {
+        return jsi::Value::undefined();
+      }
+
+      return jsi::valueFromDynamic(rt, result->cthis()->consume())
+        .asObject(rt)
+        .asArray(rt)
+        .getValueAtIndex(rt, 0);
+    });
+}
+
+jsi::Function MethodMetadata::toAsyncFunction(
+  jsi::Runtime &runtime, 
+  JSIInteropModuleRegistry *moduleRegistry
+) {
+  return jsi::Function::createFromHostFunction(
+    runtime,
+    jsi::PropNameID::forAscii(runtime, name),
+    args,
+    [this, moduleRegistry](
+      jsi::Runtime &rt,
+      const jsi::Value &thisValue,
+      const jsi::Value *args,
+      size_t count
+    ) -> jsi::Value {
+      auto dynamicArray = folly::dynamic::array();
+      for (int i = 0; i < count; i++) {
+        auto &arg = args[i];
+        dynamicArray.push_back(jsi::dynamicFromValue(rt, arg));
+      }
+
+      auto Promise = rt.global().getPropertyAsFunction(rt, "Promise");
+      // Creates a JSI promise
+      jsi::Value promise = Promise.callAsConstructor(
+        rt,
+        createPromiseBody(rt, moduleRegistry, std::move(dynamicArray))
+      );
+      return promise;
+    }
+  );
+}
+
+jsi::Function MethodMetadata::createPromiseBody(
+  jsi::Runtime &runtime,
+  JSIInteropModuleRegistry *moduleRegistry,
+  folly::dynamic &&args
+) {
+  return jsi::Function::createFromHostFunction(
+    runtime,
+    jsi::PropNameID::forAscii(runtime, "promiseFn"),
+    2,
+    [this, args = std::move(args), moduleRegistry](
+      jsi::Runtime &rt,
+      const jsi::Value &thisVal,
+      const jsi::Value *promiseConstructorArgs,
+      size_t promiseConstructorArgCount
+    ) {
+      if (promiseConstructorArgCount != 2) {
+        throw std::invalid_argument("Promise fn arg count must be 2");
+      }
+
+      jsi::Function resolveJSIFn = promiseConstructorArgs[0].getObject(rt).getFunction(rt);
+      jsi::Function rejectJSIFn = promiseConstructorArgs[1].getObject(rt).getFunction(rt);
+
+      jobject resolve = createJavaCallbackFromJSIFunction(
+        std::move(resolveJSIFn),
+        rt,
+        moduleRegistry->jsInvoker
+      ).release();
+
+      jobject reject = createJavaCallbackFromJSIFunction(
+        std::move(rejectJSIFn),
+        rt,
+        moduleRegistry->jsInvoker
+      ).release();
+
+      JNIEnv *env = jni::Environment::current();
+
+      jclass jPromiseImpl =
+        env->FindClass("com/facebook/react/bridge/PromiseImpl");
+      jmethodID jPromiseImplConstructor = env->GetMethodID(
+        jPromiseImpl,
+        "<init>",
+        "(Lcom/facebook/react/bridge/Callback;Lcom/facebook/react/bridge/Callback;)V");
+
+      // Creates a promise object
+      jobject promise = env->NewObject(
+        jPromiseImpl,
+        jPromiseImplConstructor,
+        resolve,
+        reject
+      );
+
+      // Cast in this place is safe, cause we know that this function expects promise.
+      auto asyncFunction = jni::static_ref_cast<JNIAsyncFunctionBody>(this->jBodyReference);
+      asyncFunction->invoke(
+        react::ReadableNativeArray::newObjectCxxArgs(args).get(),
+        promise
+      );
+
+      // We have to remove the local reference to the promise object.
+      // It doesn't mean that the promise will be deallocated, but rather that we move
+      // the ownership to the `JNIAsyncFunctionBody`.
+      env->DeleteLocalRef(promise);
+
+      return jsi::Value::undefined();
+    }
+  );
+}
+
+} // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.h
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.h
@@ -3,19 +3,90 @@
 #pragma once
 
 #include <jsi/jsi.h>
+#include <fbjni/fbjni.h>
+#include <ReactCommon/TurboModuleUtils.h>
+#include <react/jni/ReadableNativeArray.h>
 #include <memory>
+#include <folly/dynamic.h>
+#include <jsi/JSIDynamic.h>
 
+namespace jni = facebook::jni;
 namespace jsi = facebook::jsi;
+namespace react = facebook::react;
 
 namespace expo {
-struct MethodMetadata {
+class JSIInteropModuleRegistry;
+
+/**
+ * A class that holds information about the exported function.
+ */
+class MethodMetadata {
+public:
+  /**
+   * Function name
+   */
   std::string name;
+  /**
+   * Number of arguments
+   */
   int args;
+  /*
+   * Whether this function is async
+   */
   bool isAsync;
 
+  MethodMetadata(
+    std::string name,
+    int args,
+    bool isAsync,
+    jni::global_ref<jobject> &&jBodyReference
+  );
+
+  // We deleted the copy contractor to not deal with transforming the ownership of the `jBodyReference`.
+  MethodMetadata(const MethodMetadata &) = delete;
+
+  /**
+   * MethodMetadata owns the only reference to the Kotlin function.
+   * We have to clean that, cause it's a `global_ref`.
+   */
+  ~MethodMetadata() {
+    jBodyReference.release();
+  }
+
+  /**
+   * Transforms metadata to a jsi::Function.
+   *
+   * @param runtime
+   * @param moduleRegistry
+   * @return shared ptr to the jsi::Function that wrapped the underlying Kotlin's function.
+   */
+  std::shared_ptr<jsi::Function> toJSFunction(
+    jsi::Runtime &runtime,
+    JSIInteropModuleRegistry *moduleRegistry
+  );
+
+private:
+  /**
+   * Reference to one of two java objects - `JNIFunctionBody` or `JNIAsyncFunctionBody`.
+   *
+   * In case when `isAsync` is `true`, this variable will point to `JNIAsyncFunctionBody`.
+   * Otherwise to `JNIFunctionBody`
+   */
+  jni::global_ref<jobject> jBodyReference;
+
+  /**
+   * To not create a jsi::Function always when we need it, we cached that value.
+   */
   std::shared_ptr<jsi::Function> body = nullptr;
 
-  MethodMetadata(std::string name, int args, bool isAsync)
-    : name(name), args(args), isAsync(isAsync) {};
+  jsi::Function toSyncFunction(jsi::Runtime &runtime);
+
+  jsi::Function toAsyncFunction(jsi::Runtime &runtime, JSIInteropModuleRegistry *moduleRegistry);
+
+  jsi::Function createPromiseBody(
+    jsi::Runtime &runtime,
+    JSIInteropModuleRegistry *moduleRegistry,
+    folly::dynamic &&args
+  );
 };
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.h
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.h
@@ -1,0 +1,21 @@
+// Copyright © 2021-present 650 Industries, Inc. (aka Expo)
+
+#pragma once
+
+#include <jsi/jsi.h>
+#include <memory>
+
+namespace jsi = facebook::jsi;
+
+namespace expo {
+struct MethodMetadata {
+  std::string name;
+  int args;
+  bool isAsync;
+
+  std::shared_ptr<jsi::Function> body = nullptr;
+
+  MethodMetadata(std::string name, int args, bool isAsync)
+    : name(name), args(args), isAsync(isAsync) {};
+};
+}

--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.h
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.h
@@ -18,4 +18,4 @@ struct MethodMetadata {
   MethodMetadata(std::string name, int args, bool isAsync)
     : name(name), args(args), isAsync(isAsync) {};
 };
-}
+} // namespace expo

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/NativeModulesProxy.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/NativeModulesProxy.java
@@ -92,6 +92,8 @@ public class NativeModulesProxy extends ReactContextBaseJavaModule {
   @Override
   public Map<String, Object> getConstants() {
     mModuleRegistry.ensureIsInitialized();
+    getKotlinInteropModuleRegistry().onPostCreate();
+
     Collection<ExportedModule> exportedModules = mModuleRegistry.getAllExportedModules();
     Collection<ViewManager> viewManagers = mModuleRegistry.getAllViewManagers();
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/NativeModulesProxy.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/NativeModulesProxy.java
@@ -92,7 +92,7 @@ public class NativeModulesProxy extends ReactContextBaseJavaModule {
   @Override
   public Map<String, Object> getConstants() {
     mModuleRegistry.ensureIsInitialized();
-    getKotlinInteropModuleRegistry().onPostCreate();
+    getKotlinInteropModuleRegistry().installJSIInterop();
 
     Collection<ExportedModule> exportedModules = mModuleRegistry.getAllExportedModules();
     Collection<ViewManager> viewManagers = mModuleRegistry.getAllViewManagers();

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/core/errors/ContextDestroyedException.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/core/errors/ContextDestroyedException.kt
@@ -1,0 +1,7 @@
+package expo.modules.core.errors
+
+import kotlinx.coroutines.CancellationException
+
+private const val DEFAULT_MESSAGE = "App context destroyed. All coroutines are cancelled."
+
+class ContextDestroyedException(message: String = DEFAULT_MESSAGE) : CancellationException(message)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -42,7 +42,9 @@ class AppContext(
   }
 
   fun onPostCreate() {
-    jsiInterop.installJSI(reactContextHolder.get()!!.javaScriptContextHolder.get())
+    reactContextHolder.get()?.javaScriptContextHolder?.get()?.let {
+      jsiInterop.installJSI(it)
+    }
   }
 
   /**

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -15,11 +15,8 @@ import expo.modules.interfaces.permissions.Permissions
 import expo.modules.interfaces.sensors.SensorServiceInterface
 import expo.modules.interfaces.taskManager.TaskManagerInterface
 import expo.modules.kotlin.defaultmodules.ErrorManagerModule
-import expo.modules.kotlin.events.EventEmitter
-import expo.modules.kotlin.events.EventName
-import expo.modules.kotlin.events.KEventEmitterWrapper
-import expo.modules.kotlin.events.KModuleEventEmitterWrapper
-import expo.modules.kotlin.events.OnActivityResultPayload
+import expo.modules.kotlin.events.*
+import expo.modules.kotlin.jni.JSIInteropModuleRegistry
 import expo.modules.kotlin.modules.Module
 import java.lang.ref.WeakReference
 
@@ -33,6 +30,7 @@ class AppContext(
     register(modulesProvider)
   }
   private val reactLifecycleDelegate = ReactLifecycleDelegate(this)
+  private val jsiInterop = JSIInteropModuleRegistry(this)
 
   init {
     requireNotNull(reactContextHolder.get()) {
@@ -41,6 +39,10 @@ class AppContext(
       addLifecycleEventListener(reactLifecycleDelegate)
       addActivityEventListener(reactLifecycleDelegate)
     }
+  }
+
+  fun onPostCreate() {
+    jsiInterop.installJSI(reactContextHolder.get()!!.javaScriptContextHolder.get())
   }
 
   /**

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -1,9 +1,14 @@
+@file:OptIn(DelicateCoroutinesApi::class)
+
 package expo.modules.kotlin
 
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.turbomodule.core.CallInvokerHolderImpl
+import expo.modules.BuildConfig
+import expo.modules.core.errors.ContextDestroyedException
 import expo.modules.core.interfaces.ActivityProvider
 import expo.modules.interfaces.barcodescanner.BarCodeScannerInterface
 import expo.modules.interfaces.camera.CameraViewInterface
@@ -15,9 +20,19 @@ import expo.modules.interfaces.permissions.Permissions
 import expo.modules.interfaces.sensors.SensorServiceInterface
 import expo.modules.interfaces.taskManager.TaskManagerInterface
 import expo.modules.kotlin.defaultmodules.ErrorManagerModule
-import expo.modules.kotlin.events.*
+import expo.modules.kotlin.events.EventEmitter
+import expo.modules.kotlin.events.EventName
+import expo.modules.kotlin.events.KEventEmitterWrapper
+import expo.modules.kotlin.events.KModuleEventEmitterWrapper
+import expo.modules.kotlin.events.OnActivityResultPayload
 import expo.modules.kotlin.jni.JSIInteropModuleRegistry
 import expo.modules.kotlin.modules.Module
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.newSingleThreadContext
 import java.lang.ref.WeakReference
 
 class AppContext(
@@ -30,7 +45,13 @@ class AppContext(
     register(modulesProvider)
   }
   private val reactLifecycleDelegate = ReactLifecycleDelegate(this)
-  private val jsiInterop = JSIInteropModuleRegistry(this)
+  // We postpone creating the `JSIInteropModuleRegistry` to not load so files in unit tests.
+  private lateinit var jsiInterop: JSIInteropModuleRegistry
+  internal val moduleQueue = CoroutineScope(
+    newSingleThreadContext("ExpoModulesCoreQueue") +
+      SupervisorJob() +
+      CoroutineName("ExpoModulesCoreCoroutineQueue")
+  )
 
   init {
     requireNotNull(reactContextHolder.get()) {
@@ -42,8 +63,14 @@ class AppContext(
   }
 
   fun onPostCreate() {
-    reactContextHolder.get()?.javaScriptContextHolder?.get()?.let {
-      jsiInterop.installJSI(it)
+    jsiInterop = JSIInteropModuleRegistry(this)
+    val reactContext = reactContextHolder.get() ?: return
+    reactContext.javaScriptContextHolder?.get()?.let {
+      jsiInterop.installJSI(
+        it,
+        reactContext.catalystInstance.jsCallInvokerHolder as CallInvokerHolderImpl,
+        reactContext.catalystInstance.nativeCallInvokerHolder as CallInvokerHolderImpl
+      )
     }
   }
 
@@ -153,6 +180,7 @@ class AppContext(
     reactContextHolder.get()?.removeLifecycleEventListener(reactLifecycleDelegate)
     registry.post(EventName.MODULE_DESTROY)
     registry.cleanUp()
+    moduleQueue.cancel(ContextDestroyedException())
   }
 
   fun onHostResume() {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -7,7 +7,6 @@ import android.content.Context
 import android.content.Intent
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.turbomodule.core.CallInvokerHolderImpl
-import expo.modules.BuildConfig
 import expo.modules.core.errors.ContextDestroyedException
 import expo.modules.core.interfaces.ActivityProvider
 import expo.modules.interfaces.barcodescanner.BarCodeScannerInterface
@@ -47,7 +46,7 @@ class AppContext(
   private val reactLifecycleDelegate = ReactLifecycleDelegate(this)
   // We postpone creating the `JSIInteropModuleRegistry` to not load so files in unit tests.
   private lateinit var jsiInterop: JSIInteropModuleRegistry
-  internal val moduleQueue = CoroutineScope(
+  internal val modulesQueue = CoroutineScope(
     newSingleThreadContext("ExpoModulesCoreQueue") +
       SupervisorJob() +
       CoroutineName("ExpoModulesCoreCoroutineQueue")
@@ -62,7 +61,7 @@ class AppContext(
     }
   }
 
-  fun onPostCreate() {
+  fun installJSIInterop() {
     jsiInterop = JSIInteropModuleRegistry(this)
     val reactContext = reactContextHolder.get() ?: return
     reactContext.javaScriptContextHolder?.get()?.let {
@@ -180,7 +179,7 @@ class AppContext(
     reactContextHolder.get()?.removeLifecycleEventListener(reactLifecycleDelegate)
     registry.post(EventName.MODULE_DESTROY)
     registry.cleanUp()
-    moduleQueue.cancel(ContextDestroyedException())
+    modulesQueue.cancel(ContextDestroyedException())
   }
 
   fun onHostResume() {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KotlinInteropModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KotlinInteropModuleRegistry.kt
@@ -48,12 +48,16 @@ class KotlinInteropModuleRegistry(
 
   fun exportMethods(exportKey: (String, List<ModuleMethodInfo>) -> Unit = { _, _ -> }): Map<ModuleName, List<ModuleMethodInfo>> {
     return registry.associate { holder ->
-      val methodsInfo = holder.definition.methods.filter { (_, method) -> method.isSync }.map { (name, method) ->
-        mapOf(
-          "name" to name,
-          "argumentsCount" to method.argsCount
-        )
-      }
+      val methodsInfo = holder
+        .definition
+        .methods
+        .filter { (_, method) -> method.isSync }
+        .map { (name, method) ->
+          mapOf(
+            "name" to name,
+            "argumentsCount" to method.argsCount
+          )
+        }
       exportKey(holder.name, methodsInfo)
       holder.name to methodsInfo
     }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KotlinInteropModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KotlinInteropModuleRegistry.kt
@@ -51,7 +51,7 @@ class KotlinInteropModuleRegistry(
       val methodsInfo = holder
         .definition
         .methods
-        .filter { (_, method) -> method.isSync }
+        .filter { (_, method) -> !method.isSync }
         .map { (name, method) ->
           mapOf(
             "name" to name,

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KotlinInteropModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KotlinInteropModuleRegistry.kt
@@ -111,7 +111,7 @@ class KotlinInteropModuleRegistry(
     appContext.onDestroy()
   }
 
-  fun onPostCreate() {
-    appContext.onPostCreate()
+  fun installJSIInterop() {
+    appContext.installJSIInterop()
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KotlinInteropModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KotlinInteropModuleRegistry.kt
@@ -41,26 +41,22 @@ class KotlinInteropModuleRegistry(
   }
 
   fun exportedModulesConstants(): Map<ModuleName, ModuleConstants> {
-    return registry
-      .map { holder ->
-        holder.name to holder.definition.constantsProvider()
-      }
-      .toMap()
+    return registry.associate { holder ->
+      holder.name to holder.definition.constantsProvider()
+    }
   }
 
   fun exportMethods(exportKey: (String, List<ModuleMethodInfo>) -> Unit = { _, _ -> }): Map<ModuleName, List<ModuleMethodInfo>> {
-    return registry
-      .map { holder ->
-        val methodsInfo = holder.definition.methods.map { (name, method) ->
-          mapOf(
-            "name" to name,
-            "argumentsCount" to method.argsCount
-          )
-        }
-        exportKey(holder.name, methodsInfo)
-        holder.name to methodsInfo
+    return registry.associate { holder ->
+      val methodsInfo = holder.definition.methods.filter { (_, method) -> method.isSync }.map { (name, method) ->
+        mapOf(
+          "name" to name,
+          "argumentsCount" to method.argsCount
+        )
       }
-      .toMap()
+      exportKey(holder.name, methodsInfo)
+      holder.name to methodsInfo
+    }
   }
 
   fun exportViewManagers(): List<ViewManager<*, *>> {
@@ -109,5 +105,9 @@ class KotlinInteropModuleRegistry(
 
   fun onDestroy() {
     appContext.onDestroy()
+  }
+
+  fun onPostCreate() {
+    appContext.onPostCreate()
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
@@ -22,8 +22,13 @@ class ModuleHolder(val module: Module) {
     JavaScriptModuleObject(this).apply {
       definition
         .methods
-        .filter { (_, method) -> method.isSync }
-        .forEach { (name, method) -> registerSyncFunction(name, method.argsCount) }
+        .forEach { (name, method) ->
+          if (method.isSync) {
+            registerSyncFunction(name, method.argsCount)
+          } else {
+            registerAsyncFunction(name, method.argsCount)
+          }
+        }
     }
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
@@ -19,7 +19,12 @@ class ModuleHolder(val module: Module) {
   val name get() = definition.name
 
   val jsObject by lazy {
-    JavaScriptModuleObject(this)
+    JavaScriptModuleObject(this).apply {
+      definition
+        .methods
+        .filter { (_, method) -> method.isSync }
+        .forEach { (name, method) -> registerSyncFunction(name, method.argsCount) }
+    }
   }
 
   fun call(methodName: String, args: ReadableArray, promise: Promise) = exceptionDecorator({

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AnyFunction.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AnyFunction.kt
@@ -10,13 +10,31 @@ import expo.modules.kotlin.exception.exceptionDecorator
 import expo.modules.kotlin.iterator
 import expo.modules.kotlin.recycle
 import expo.modules.kotlin.types.AnyType
+import expo.modules.kotlin.types.JSTypeConverter
 
 abstract class AnyFunction(
   protected val name: String,
   private val desiredArgsTypes: Array<AnyType>
 ) {
+  internal var isSync = false
+    private set
+
+  fun runSynchronously() = apply {
+    isSync = true
+  }
+
   @Throws(CodedException::class)
-  fun call(module: ModuleHolder, args: ReadableArray, promise: Promise) {
+  internal fun callSync(module: ModuleHolder, args: ReadableArray): Any? {
+    if (desiredArgsTypes.size != args.size()) {
+      throw InvalidArgsNumberException(args.size(), desiredArgsTypes.size)
+    }
+
+    val convertedArgs = convertArgs(args)
+    return callSyncImplementation(module, convertedArgs)
+  }
+
+  @Throws(CodedException::class)
+  internal fun call(module: ModuleHolder, args: ReadableArray, promise: Promise) {
     if (desiredArgsTypes.size != args.size()) {
       throw InvalidArgsNumberException(args.size(), desiredArgsTypes.size)
     }
@@ -28,7 +46,13 @@ abstract class AnyFunction(
   @Throws(CodedException::class)
   internal abstract fun callImplementation(holder: ModuleHolder, args: Array<out Any?>, promise: Promise)
 
-  val argsCount get() = desiredArgsTypes.size
+  @Throws(CodedException::class)
+  internal open fun callSyncImplementation(holder: ModuleHolder, args: Array<out Any?>): Any? {
+    throw UnsupportedOperationException("The sync call is not supported yet!")
+  }
+
+
+  internal val argsCount get() = desiredArgsTypes.size
 
   @Throws(CodedException::class)
   private fun convertArgs(args: ReadableArray): Array<out Any?> {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AnyFunction.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AnyFunction.kt
@@ -50,7 +50,7 @@ abstract class AnyFunction(
   internal open fun callSyncImplementation(holder: ModuleHolder, args: Array<out Any?>): Any? {
     throw UnsupportedOperationException("The sync call is not supported yet!")
   }
-  
+
   internal val argsCount get() = desiredArgsTypes.size
 
   @Throws(CodedException::class)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AnyFunction.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AnyFunction.kt
@@ -50,8 +50,7 @@ abstract class AnyFunction(
   internal open fun callSyncImplementation(holder: ModuleHolder, args: Array<out Any?>): Any? {
     throw UnsupportedOperationException("The sync call is not supported yet!")
   }
-
-
+  
   internal val argsCount get() = desiredArgsTypes.size
 
   @Throws(CodedException::class)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AnyFunction.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AnyFunction.kt
@@ -10,13 +10,13 @@ import expo.modules.kotlin.exception.exceptionDecorator
 import expo.modules.kotlin.iterator
 import expo.modules.kotlin.recycle
 import expo.modules.kotlin.types.AnyType
-import expo.modules.kotlin.types.JSTypeConverter
 
 abstract class AnyFunction(
   protected val name: String,
-  private val desiredArgsTypes: Array<AnyType>
+  private val desiredArgsTypes: Array<AnyType>,
+  isSync: Boolean = false
 ) {
-  internal var isSync = false
+  internal var isSync = isSync
     private set
 
   fun runSynchronously() = apply {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunction.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunction.kt
@@ -9,6 +9,10 @@ class AsyncFunction(
   argsType: Array<AnyType>,
   private val body: (args: Array<out Any?>) -> Any?
 ) : AnyFunction(name, argsType) {
+  override fun callSyncImplementation(holder: ModuleHolder, args: Array<out Any?>): Any? {
+    return body(args)
+  }
+
   override fun callImplementation(holder: ModuleHolder, args: Array<out Any?>, promise: Promise) {
     promise.resolve(body(args))
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunction.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunction.kt
@@ -8,7 +8,7 @@ class AsyncFunction(
   name: String,
   argsType: Array<AnyType>,
   private val body: (args: Array<out Any?>) -> Any?
-) : AnyFunction(name, argsType) {
+) : AnyFunction(name, argsType, isSync = false) {
   override fun callSyncImplementation(holder: ModuleHolder, args: Array<out Any?>): Any? {
     return body(args)
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunctionWithPromise.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunctionWithPromise.kt
@@ -8,7 +8,7 @@ class AsyncFunctionWithPromise(
   name: String,
   argsType: Array<AnyType>,
   private val body: (args: Array<out Any?>, promise: Promise) -> Unit
-) : AnyFunction(name, argsType) {
+) : AnyFunction(name, argsType, isSync = false) {
   override fun callImplementation(holder: ModuleHolder, args: Array<out Any?>, promise: Promise) {
     body(args, promise)
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncSuspendFunction.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncSuspendFunction.kt
@@ -15,7 +15,7 @@ class AsyncSuspendFunction(
   name: String,
   argsType: Array<AnyType>,
   private val body: suspend CoroutineScope.(args: Array<out Any?>) -> Any?
-) : AnyFunction(name, argsType) {
+) : AnyFunction(name, argsType, isSync = false) {
   override fun callImplementation(holder: ModuleHolder, args: Array<out Any?>, promise: Promise) {
     val scope = holder.module.coroutineScopeDelegate.value
     scope.launch {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JNIFunctionBody.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JNIFunctionBody.kt
@@ -1,12 +1,14 @@
 package expo.modules.kotlin.jni
 
 import com.facebook.react.bridge.ReadableNativeArray
+import expo.modules.core.interfaces.DoNotStrip
 
 /**
  * It's a wrapper for a promise-less function that will be invoked from JS.
  * This interface is intended to be passed to cpp code.
  * If you want to modify it, please don't forget to change the corresponding jni::JavaClass.
  */
+@DoNotStrip
 fun interface JNIFunctionBody {
   /**
    * Invokes the Kotlin part of the JNI function.
@@ -15,6 +17,7 @@ fun interface JNIFunctionBody {
    * right now it's the only object which is recognizable by those two worlds.
    * In the future, we may want to swap it for something else.
    */
+  @DoNotStrip
   fun invoke(args: ReadableNativeArray): ReadableNativeArray?
 }
 
@@ -23,6 +26,7 @@ fun interface JNIFunctionBody {
  * This interface is intended to be passed to cpp code.
  * If you want to modify it, please don't forget to change the corresponding jni::JavaClass.
  */
+@DoNotStrip
 fun interface JNIAsyncFunctionBody {
   /**
    * Invokes the Kotlin part of the JNI function.
@@ -30,5 +34,6 @@ fun interface JNIAsyncFunctionBody {
    * Note: that the `bridgePromise` has type of [Any], but it should be an instance of [com.facebook.react.bridge.Promise].
    * This is dictated by the fact that [com.facebook.react.bridge.Promise] isn't a hybrid object of jni::HybridClass.
    */
+  @DoNotStrip
   fun invoke(args: ReadableNativeArray, bridgePromise: Any)
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JNIFunctionBody.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JNIFunctionBody.kt
@@ -1,0 +1,34 @@
+package expo.modules.kotlin.jni
+
+import com.facebook.react.bridge.ReadableNativeArray
+
+/**
+ * It's a wrapper for a promise-less function that will be invoked from JS.
+ * This interface is intended to be passed to cpp code.
+ * If you want to modify it, please don't forget to change the corresponding jni::JavaClass.
+ */
+fun interface JNIFunctionBody {
+  /**
+   * Invokes the Kotlin part of the JNI function.
+   *
+   * We used a [com.facebook.react.bridge.ReadableNativeArray] to communicate with CPP, because
+   * right now it's the only object which is recognizable by those two worlds.
+   * In the future, we may want to swap it for something else.
+   */
+  fun invoke(args: ReadableNativeArray): ReadableNativeArray?
+}
+
+/**
+ * It's a wrapper for a promise function that will be invoked from JS.
+ * This interface is intended to be passed to cpp code.
+ * If you want to modify it, please don't forget to change the corresponding jni::JavaClass.
+ */
+fun interface JNIAsyncFunctionBody {
+  /**
+   * Invokes the Kotlin part of the JNI function.
+   *
+   * Note: that the `bridgePromise` has type of [Any], but it should be an instance of [com.facebook.react.bridge.Promise].
+   * This is dictated by the fact that [com.facebook.react.bridge.Promise] isn't a hybrid object of jni::HybridClass.
+   */
+  fun invoke(args: ReadableNativeArray, bridgePromise: Any)
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIInteropModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIInteropModuleRegistry.kt
@@ -1,6 +1,7 @@
 package expo.modules.kotlin.jni
 
 import com.facebook.jni.HybridData
+import com.facebook.react.turbomodule.core.CallInvokerHolderImpl
 import expo.modules.kotlin.AppContext
 import java.lang.ref.WeakReference
 
@@ -14,7 +15,11 @@ class JSIInteropModuleRegistry(appContext: AppContext) {
   private external fun initHybrid(): HybridData
 
   @Suppress("KotlinJniMissingFunction")
-  external fun installJSI(jsRuntimePointer: Long)
+  external fun installJSI(
+    jsRuntimePointer: Long,
+    jsInvokerHolder: CallInvokerHolderImpl,
+    nativeInvokerHolder: CallInvokerHolderImpl
+  )
 
   // used from cpp codebase
   fun getJavaScriptModuleObject(name: String): JavaScriptModuleObject? {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIInteropModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIInteropModuleRegistry.kt
@@ -2,13 +2,16 @@ package expo.modules.kotlin.jni
 
 import com.facebook.jni.HybridData
 import com.facebook.react.turbomodule.core.CallInvokerHolderImpl
+import expo.modules.core.interfaces.DoNotStrip
 import expo.modules.kotlin.AppContext
 import java.lang.ref.WeakReference
 
+@DoNotStrip
 class JSIInteropModuleRegistry(appContext: AppContext) {
   private val appContextHolder = WeakReference(appContext)
 
   // Has to be called "mHybridData" - fbjni uses it via reflection
+  @DoNotStrip
   private val mHybridData = initHybrid()
 
   @Suppress("KotlinJniMissingFunction")
@@ -29,6 +32,7 @@ class JSIInteropModuleRegistry(appContext: AppContext) {
    * It doesn't make sense to call it from Kotlin.
    */
   @Suppress("unused")
+  @DoNotStrip
   fun getJavaScriptModuleObject(name: String): JavaScriptModuleObject? {
     return appContextHolder.get()?.registry?.getModuleHolder(name)?.jsObject
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIInteropModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIInteropModuleRegistry.kt
@@ -21,7 +21,14 @@ class JSIInteropModuleRegistry(appContext: AppContext) {
     nativeInvokerHolder: CallInvokerHolderImpl
   )
 
-  // used from cpp codebase
+  /**
+   * Returns a `JavaScriptModuleObject` that is a bridge between [expo.modules.kotlin.modules.Module]
+   * and HostObject exported via JSI.
+   *
+   * This function will be called from the CPP implementation.
+   * It doesn't make sense to call it from Kotlin.
+   */
+  @Suppress("unused")
   fun getJavaScriptModuleObject(name: String): JavaScriptModuleObject? {
     return appContextHolder.get()?.registry?.getModuleHolder(name)?.jsObject
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIInteropModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIInteropModuleRegistry.kt
@@ -1,0 +1,34 @@
+package expo.modules.kotlin.jni
+
+import com.facebook.jni.HybridData
+import expo.modules.kotlin.AppContext
+import java.lang.ref.WeakReference
+
+class JSIInteropModuleRegistry(appContext: AppContext) {
+  private val appContextHolder = WeakReference(appContext)
+
+  // Has to be called "mHybridData" - fbjni uses it via reflection
+  private val mHybridData = initHybrid()
+
+  @Suppress("KotlinJniMissingFunction")
+  private external fun initHybrid(): HybridData
+
+  @Suppress("KotlinJniMissingFunction")
+  external fun installJSI(jsRuntimePointer: Long)
+
+  // used from cpp codebase
+  fun getJavaScriptModuleObject(name: String): JavaScriptModuleObject? {
+    return appContextHolder.get()?.registry?.getModuleHolder(name)?.jsObject
+  }
+
+  @Throws(Throwable::class)
+  protected fun finalize() {
+    mHybridData.resetNative()
+  }
+
+  companion object {
+    init {
+      System.loadLibrary("expomodulescore")
+    }
+  }
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIInteropModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIInteropModuleRegistry.kt
@@ -28,7 +28,7 @@ class JSIInteropModuleRegistry(appContext: AppContext) {
 
   companion object {
     init {
-      System.loadLibrary("expomodulescore")
+      System.loadLibrary("expo-modules-core")
     }
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptModuleObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptModuleObject.kt
@@ -1,8 +1,12 @@
 package expo.modules.kotlin.jni
 
 import com.facebook.jni.HybridData
+import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReadableNativeArray
+import expo.modules.kotlin.KPromiseWrapper
 import expo.modules.kotlin.ModuleHolder
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.launch
 import java.lang.ref.WeakReference
 
 class JavaScriptModuleObject(moduleHolder: ModuleHolder) {
@@ -16,8 +20,23 @@ class JavaScriptModuleObject(moduleHolder: ModuleHolder) {
   @Suppress("KotlinJniMissingFunction")
   external fun registerSyncFunction(name: String, args: Int)
 
+  @Suppress("KotlinJniMissingFunction")
+  external fun registerAsyncFunction(name: String, args: Int)
+
+  @Suppress("unused")
   fun callSyncMethod(name: String, args: ReadableNativeArray): ReadableNativeArray? {
     return moduleHolderRef.get()?.callSync(name, args)
+  }
+
+  @OptIn(DelicateCoroutinesApi::class)
+  @Suppress("unused")
+  fun callAsyncMethod(name: String, args: ReadableNativeArray, bridgePromise: Any) {
+    val kotlinPromise = KPromiseWrapper(bridgePromise as Promise)
+    moduleHolderRef.get()?.let { holder ->
+      holder.module.appContext.moduleQueue.launch {
+        moduleHolderRef.get()?.call(name, args, kotlinPromise)
+      }
+    }
   }
 
   @Throws(Throwable::class)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptModuleObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptModuleObject.kt
@@ -1,43 +1,34 @@
 package expo.modules.kotlin.jni
 
 import com.facebook.jni.HybridData
-import com.facebook.react.bridge.Promise
-import com.facebook.react.bridge.ReadableNativeArray
-import expo.modules.kotlin.KPromiseWrapper
-import expo.modules.kotlin.ModuleHolder
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.launch
-import java.lang.ref.WeakReference
 
-class JavaScriptModuleObject(moduleHolder: ModuleHolder) {
+/**
+ * A class to communicate with CPP part of the [expo.modules.kotlin.modules.Module] class.
+ * Used to register exported JSI functions.
+ * The lifetime of instances of this class should be in sync with the lifetime of the bridge.
+ * All exported functions/objects will have a reference to the `JavaScriptModuleObject`,
+ * so it must outlive the current RN context.
+ */
+class JavaScriptModuleObject {
   // Has to be called "mHybridData" - fbjni uses it via reflection
   private val mHybridData = initHybrid()
-  private val moduleHolderRef = WeakReference(moduleHolder)
 
   @Suppress("KotlinJniMissingFunction")
   private external fun initHybrid(): HybridData
 
+  /**
+   * Register a promise-less function on the CPP module representation.
+   * After calling this function, user can access the exported function in the JS code.
+   */
   @Suppress("KotlinJniMissingFunction")
-  external fun registerSyncFunction(name: String, args: Int)
+  external fun registerSyncFunction(name: String, args: Int, body: JNIFunctionBody)
 
+  /**
+   * Register a promise function on the CPP module representation.
+   * After calling this function, user can access the exported function in the JS code.
+   */
   @Suppress("KotlinJniMissingFunction")
-  external fun registerAsyncFunction(name: String, args: Int)
-
-  @Suppress("unused")
-  fun callSyncMethod(name: String, args: ReadableNativeArray): ReadableNativeArray? {
-    return moduleHolderRef.get()?.callSync(name, args)
-  }
-
-  @OptIn(DelicateCoroutinesApi::class)
-  @Suppress("unused")
-  fun callAsyncMethod(name: String, args: ReadableNativeArray, bridgePromise: Any) {
-    val kotlinPromise = KPromiseWrapper(bridgePromise as Promise)
-    moduleHolderRef.get()?.let { holder ->
-      holder.module.appContext.modulesQueue.launch {
-        moduleHolderRef.get()?.call(name, args, kotlinPromise)
-      }
-    }
-  }
+  external fun registerAsyncFunction(name: String, args: Int, body: JNIAsyncFunctionBody)
 
   @Throws(Throwable::class)
   protected fun finalize() {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptModuleObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptModuleObject.kt
@@ -33,7 +33,7 @@ class JavaScriptModuleObject(moduleHolder: ModuleHolder) {
   fun callAsyncMethod(name: String, args: ReadableNativeArray, bridgePromise: Any) {
     val kotlinPromise = KPromiseWrapper(bridgePromise as Promise)
     moduleHolderRef.get()?.let { holder ->
-      holder.module.appContext.moduleQueue.launch {
+      holder.module.appContext.modulesQueue.launch {
         moduleHolderRef.get()?.call(name, args, kotlinPromise)
       }
     }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptModuleObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptModuleObject.kt
@@ -1,6 +1,7 @@
 package expo.modules.kotlin.jni
 
 import com.facebook.jni.HybridData
+import expo.modules.core.interfaces.DoNotStrip
 
 /**
  * A class to communicate with CPP part of the [expo.modules.kotlin.modules.Module] class.
@@ -9,8 +10,10 @@ import com.facebook.jni.HybridData
  * All exported functions/objects will have a reference to the `JavaScriptModuleObject`,
  * so it must outlive the current RN context.
  */
+@DoNotStrip
 class JavaScriptModuleObject {
   // Has to be called "mHybridData" - fbjni uses it via reflection
+  @DoNotStrip
   private val mHybridData = initHybrid()
 
   @Suppress("KotlinJniMissingFunction")

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptModuleObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptModuleObject.kt
@@ -1,0 +1,27 @@
+package expo.modules.kotlin.jni
+
+import com.facebook.jni.HybridData
+import com.facebook.react.bridge.ReadableNativeArray
+import expo.modules.kotlin.ModuleHolder
+import java.lang.ref.WeakReference
+
+class JavaScriptModuleObject(moduleHolder: ModuleHolder) {
+  // Has to be called "mHybridData" - fbjni uses it via reflection
+  private val mHybridData = initHybrid()
+  private val moduleHolderRef = WeakReference(moduleHolder)
+
+  @Suppress("KotlinJniMissingFunction")
+  private external fun initHybrid(): HybridData
+
+  @Suppress("KotlinJniMissingFunction")
+  external fun registerSyncFunction(name: String, args: Int)
+
+  fun callSyncMethod(name: String, args: ReadableNativeArray): ReadableNativeArray? {
+    return moduleHolderRef.get()?.callSync(name, args)
+  }
+
+  @Throws(Throwable::class)
+  protected fun finalize() {
+    mHybridData.resetNative()
+  }
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionBuilder.kt
@@ -109,8 +109,10 @@ class ModuleDefinitionBuilder(@PublishedApi internal val module: Module? = null)
   inline fun function(
     name: String,
     crossinline body: () -> Any?
-  ) {
-    methods[name] = AsyncFunction(name, arrayOf()) { body() }
+  ): AnyFunction {
+    return AsyncFunction(name, arrayOf()) { body() }.also {
+      methods[name] = it
+    }
   }
 
   @Deprecated(
@@ -120,8 +122,10 @@ class ModuleDefinitionBuilder(@PublishedApi internal val module: Module? = null)
   inline fun <reified R> function(
     name: String,
     crossinline body: () -> R
-  ) {
-    methods[name] = AsyncFunction(name, arrayOf()) { body() }
+  ): AnyFunction {
+    return AsyncFunction(name, arrayOf()) { body() }.also {
+      methods[name] = it
+    }
   }
 
   @Deprecated(
@@ -131,11 +135,13 @@ class ModuleDefinitionBuilder(@PublishedApi internal val module: Module? = null)
   inline fun <reified R, reified P0> function(
     name: String,
     crossinline body: (p0: P0) -> R
-  ) {
-    methods[name] = if (P0::class == Promise::class) {
+  ): AnyFunction {
+    return if (P0::class == Promise::class) {
       AsyncFunctionWithPromise(name, arrayOf()) { _, promise -> body(promise as P0) }
     } else {
       AsyncFunction(name, arrayOf(typeOf<P0>().toAnyType())) { body(it[0] as P0) }
+    }.also {
+      methods[name] = it
     }
   }
 
@@ -146,11 +152,13 @@ class ModuleDefinitionBuilder(@PublishedApi internal val module: Module? = null)
   inline fun <reified R, reified P0, reified P1> function(
     name: String,
     crossinline body: (p0: P0, p1: P1) -> R
-  ) {
-    methods[name] = if (P1::class == Promise::class) {
+  ): AnyFunction {
+    return if (P1::class == Promise::class) {
       AsyncFunctionWithPromise(name, arrayOf(typeOf<P0>().toAnyType())) { args, promise -> body(args[0] as P0, promise as P1) }
     } else {
       AsyncFunction(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType())) { body(it[0] as P0, it[1] as P1) }
+    }.also {
+      methods[name] = it
     }
   }
 
@@ -161,11 +169,13 @@ class ModuleDefinitionBuilder(@PublishedApi internal val module: Module? = null)
   inline fun <reified R, reified P0, reified P1, reified P2> function(
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2) -> R
-  ) {
-    methods[name] = if (P2::class == Promise::class) {
+  ): AnyFunction {
+    return if (P2::class == Promise::class) {
       AsyncFunctionWithPromise(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType())) { args, promise -> body(args[0] as P0, args[1] as P1, promise as P2) }
     } else {
       AsyncFunction(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2) }
+    }.also {
+      methods[name] = it
     }
   }
 
@@ -176,11 +186,13 @@ class ModuleDefinitionBuilder(@PublishedApi internal val module: Module? = null)
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3> function(
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3) -> R
-  ) {
-    methods[name] = if (P3::class == Promise::class) {
+  ): AnyFunction {
+    return if (P3::class == Promise::class) {
       AsyncFunctionWithPromise(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, promise as P3) }
     } else {
       AsyncFunction(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3) }
+    }.also {
+      methods[name] = it
     }
   }
 
@@ -191,11 +203,13 @@ class ModuleDefinitionBuilder(@PublishedApi internal val module: Module? = null)
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4> function(
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4) -> R
-  ) {
-    methods[name] = if (P4::class == Promise::class) {
+  ): AnyFunction {
+    return if (P4::class == Promise::class) {
       AsyncFunctionWithPromise(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, promise as P4) }
     } else {
       AsyncFunction(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4) }
+    }.also {
+      methods[name] = it
     }
   }
 
@@ -206,11 +220,13 @@ class ModuleDefinitionBuilder(@PublishedApi internal val module: Module? = null)
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5> function(
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) -> R
-  ) {
-    methods[name] = if (P5::class == Promise::class) {
+  ): AnyFunction {
+    return if (P5::class == Promise::class) {
       AsyncFunctionWithPromise(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, args[4] as P4, promise as P5) }
     } else {
       AsyncFunction(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType(), typeOf<P5>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5) }
+    }.also {
+      methods[name] = it
     }
   }
 
@@ -221,11 +237,13 @@ class ModuleDefinitionBuilder(@PublishedApi internal val module: Module? = null)
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6> function(
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6) -> R
-  ) {
-    methods[name] = if (P6::class == Promise::class) {
+  ): AnyFunction {
+    return if (P6::class == Promise::class) {
       AsyncFunctionWithPromise(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType(), typeOf<P5>().toAnyType())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, args[4] as P4, args[5] as P5, promise as P6) }
     } else {
       AsyncFunction(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType(), typeOf<P5>().toAnyType(), typeOf<P6>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5, it[6] as P6) }
+    }.also {
+      methods[name] = it
     }
   }
 
@@ -236,11 +254,13 @@ class ModuleDefinitionBuilder(@PublishedApi internal val module: Module? = null)
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6, reified P7> function(
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7) -> R
-  ) {
-    methods[name] = if (P7::class == Promise::class) {
+  ): AnyFunction {
+    return if (P7::class == Promise::class) {
       AsyncFunctionWithPromise(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType(), typeOf<P5>().toAnyType(), typeOf<P6>().toAnyType())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, args[4] as P4, args[5] as P5, args[6] as P6, promise as P7) }
     } else {
       AsyncFunction(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType(), typeOf<P5>().toAnyType(), typeOf<P6>().toAnyType(), typeOf<P7>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5, it[6] as P6, it[7] as P7) }
+    }.also {
+      methods[name] = it
     }
   }
 

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/JSTypeConverterTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/JSTypeConverterTest.kt
@@ -11,8 +11,10 @@ import expo.modules.kotlin.records.Record
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
+@Config(sdk = [30])
 class JSTypeConverterTest {
   private object TestContainerProvider : JSTypeConverter.ContainerProvider {
     override fun createMap(): WritableMap = JavaOnlyMap()


### PR DESCRIPTION
# Why

Closes ENG-4608.
Adds basic support for sync function.

# How

- Created ExpoModulesHostObject that installs into the runtime as `global.ExpoModules`. A host object is an abstract object where we can define our property getter, allowing us to create JS object for each module lazily.
- Added `isAsync` property to sweet functions and `runSynchronously()` modifier - that will be changed in the future.
- Created `JavaScriptModuleObject` that represents a module in the JS world. It has a map of methods with a cached body.
- All the communication goes via two kotlin methods - `getJavaScriptModuleObject` (which returns a hybrid representation of the module) and `callMethodSync` (which is calling correct implementation). Right now, I'm not using lambdas to pass Kotlin functions into CPP, because I don't see any reason why should I.

# Test Plan

- tested with bare-expo ✅