### PR TITLE
[expotool] add rn version option to generate-bare-app

### DIFF
--- a/tools/src/commands/GenerateBareApp.ts
+++ b/tools/src/commands/GenerateBareApp.ts
@@ -189,19 +189,26 @@ async function symlinkPackages({
   }
 }
 
-async function updateRNVersion({ projectDir, rnVersion }: { projectDir: string, rnVersion?: string }) {
-  if (!rnVersion) {
-    const mainPkg = require(path.resolve(EXPO_DIR, 'package.json'));
-    const rnVersionOnMain = mainPkg.resolutions?.['react-native'];
-    rnVersion = rnVersionOnMain
-  }
-  
+async function updateRNVersion({
+  projectDir,
+  rnVersion,
+}: {
+  projectDir: string;
+  rnVersion?: string;
+}) {
+  const reactNativeVersion = rnVersion || getLocalReactNativeVersion();
+
   const pkgPath = path.resolve(projectDir, 'package.json');
   const pkg = await fs.readJSON(pkgPath);
-  pkg.dependencies['react-native'] = rnVersion;
+  pkg.dependencies['react-native'] = reactNativeVersion;
 
   await fs.outputJson(path.resolve(projectDir, 'package.json'), pkg, { spaces: 2 });
   await spawnAsync('yarn', [], { cwd: projectDir });
+}
+
+function getLocalReactNativeVersion() {
+  const mainPkg = require(path.resolve(EXPO_DIR, 'package.json'));
+  return mainPkg.resolutions?.['react-native'];
 }
 
 async function runExpoPrebuild({ projectDir }: { projectDir: string }) {

--- a/tools/src/commands/GenerateBareApp.ts
+++ b/tools/src/commands/GenerateBareApp.ts
@@ -192,7 +192,7 @@ async function symlinkPackages({
 async function updateRNVersion({ projectDir, rnVersion }: { projectDir: string, rnVersion?: string }) {
   if (!rnVersion) {
     const mainPkg = require(path.resolve(EXPO_DIR, 'package.json'));
-    const rnVersionOnMain = mainPkg.resolutions['react-native'];
+    const rnVersionOnMain = mainPkg.resolutions?.['react-native'];
     rnVersion = rnVersionOnMain
   }
   


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The current iteration of this tool manually sets the version of react-native based on whatever is specified in `resolutions` of our monorepo - its likely that people will want to be able to use other versions of RN to test functionality as well

# How

<!--
How did you build this feature or fix this bug and why?
-->

Added `--rnVersion` option which takes a string that specifies which version of RN to install in the bare app

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Specify rnVersion, verify that this version is installed in a generated app

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
