### PR TITLE
[expo-updates][cli] Update CLI to separate private keys from code signing certificate

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Add support for expo project information certificate extension (iOS). ([#16726](https://github.com/expo/expo/pull/16726) by [@wschurman](https://github.com/wschurman))
 - Pass EAS-Client-ID in header for asset and manifest requests. ([#16729](https://github.com/expo/expo/pull/16729) by [@wschurman](https://github.com/wschurman))
 - Validate expo project information up the certificate chain. ([#16800](https://github.com/expo/expo/pull/16800) by [@wschurman](https://github.com/wschurman))
+- Update CLI to separate private keys from code signing certificate. ([#16979](https://github.com/expo/expo/pull/16979) by [@wschurman](https://github.com/wschurman))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/cli/__tests__/configure-test.ts
+++ b/packages/expo-updates/cli/__tests__/configure-test.ts
@@ -46,7 +46,7 @@ describe('codesigning:configure', () => {
       {
         'package.json': JSON.stringify({ dependencies: { expo: '40.0.0' } }),
         'app.json': JSON.stringify({ name: 'test', slug: 'wat', sdkVersion: '40.0.0' }),
-        'keys/certificate.pem': certificatePEM,
+        'certificates/certificate.pem': certificatePEM,
         'keys/private-key.pem': keyPairPEM.privateKeyPEM,
         'keys/public-key.pem': keyPairPEM.publicKeyPEM,
         'node_modules/expo/package.json': expoPackageJson,
@@ -57,10 +57,15 @@ describe('codesigning:configure', () => {
     const configBefore = getConfig(projectRoot);
     expect((configBefore.exp.updates as any)?.codeSigningCertificate).toBeUndefined();
 
-    await configureCodeSigningAsync(projectRoot, { input: 'keys' });
+    await configureCodeSigningAsync(projectRoot, {
+      certificateInput: 'certificates',
+      keyInput: 'keys',
+    });
 
     const config = getConfig(projectRoot);
-    expect((config.exp.updates as any).codeSigningCertificate).toEqual('./keys/certificate.pem');
+    expect((config.exp.updates as any).codeSigningCertificate).toEqual(
+      './certificates/certificate.pem'
+    );
     expect((config.exp.updates as any).codeSigningMetadata).toMatchObject({
       keyid: 'main',
       alg: 'rsa-v1_5-sha256',
@@ -85,7 +90,7 @@ describe('codesigning:configure', () => {
       {
         'package.json': JSON.stringify({ dependencies: { expo: '40.0.0' } }),
         'app.json': JSON.stringify({ name: 'test', slug: 'wat', sdkVersion: '40.0.0' }),
-        'keys/certificate.pem': invalidCertificatePEM,
+        'certificates/certificate.pem': invalidCertificatePEM,
         'keys/private-key.pem': invalidPrivateKeyPEM,
         'keys/public-key.pem': invalidPublicKeyPEM,
         'node_modules/expo/package.json': expoPackageJson,
@@ -96,9 +101,9 @@ describe('codesigning:configure', () => {
     const configBefore = getConfig(projectRoot);
     expect((configBefore.exp.updates as any)?.codeSigningCertificate).toBeUndefined();
 
-    await expect(configureCodeSigningAsync(projectRoot, { input: 'keys' })).rejects.toThrow(
-      'Certificate validity expired'
-    );
+    await expect(
+      configureCodeSigningAsync(projectRoot, { certificateInput: 'certificates', keyInput: 'keys' })
+    ).rejects.toThrow('Certificate validity expired');
 
     const config = getConfig(projectRoot);
     expect((config.exp.updates as any)?.codeSigningCertificate).toBeUndefined();

--- a/packages/expo-updates/cli/__tests__/generate-test.ts
+++ b/packages/expo-updates/cli/__tests__/generate-test.ts
@@ -28,19 +28,21 @@ describe('codesigning:generate', () => {
     );
 
     await generateCodeSigningAsync(projectRoot, {
-      output: 'keys',
-      validityDurationYears: 10,
-      commonName: 'hello',
+      certificateOutput: 'certificates',
+      keyOutput: 'keys',
+      certificateValidityDurationYears: 10,
+      certificateCommonName: 'hello',
     });
 
-    const inputDir = path.resolve(projectRoot, 'keys');
+    const keysDir = path.resolve(projectRoot, 'keys');
+    const certificateDir = path.resolve(projectRoot, 'certificates');
 
     const [certificatePEM, privateKeyPEM, publicKeyPEM] = (
-      await Promise.all(
-        ['certificate.pem', 'private-key.pem', 'public-key.pem'].map((fname) =>
-          fs.readFile(`${inputDir}/${fname}`)
-        )
-      )
+      await Promise.all([
+        fs.readFile(`${certificateDir}/certificate.pem`),
+        fs.readFile(`${keysDir}/private-key.pem`),
+        fs.readFile(`${keysDir}/public-key.pem`),
+      ])
     ).map((buffer) => buffer.toString());
 
     expect(certificatePEM).toBeTruthy();

--- a/packages/expo-updates/cli/configureCodeSigning.ts
+++ b/packages/expo-updates/cli/configureCodeSigning.ts
@@ -2,7 +2,7 @@
 import chalk from 'chalk';
 
 import { Command } from './cli';
-import { assertArgs, getProjectRoot } from './utils/args';
+import { assertArg, assertArgs, getProjectRoot } from './utils/args';
 import * as Log from './utils/log';
 
 export const configureCodeSigning: Command = async (argv) => {
@@ -10,10 +10,10 @@ export const configureCodeSigning: Command = async (argv) => {
     {
       // Types
       '--help': Boolean,
-      '--input': String,
+      '--certificate-input-directory': String,
+      '--key-input-directory': String,
       // Aliases
       '-h': '--help',
-      '-i': '--input',
     },
     argv ?? []
   );
@@ -28,7 +28,8 @@ export const configureCodeSigning: Command = async (argv) => {
         $ npx expo-updates codesigning:configure
 
         Options
-        -i, --input <string>     Directory containing keys and certificate
+        --certificate-input-directory <string>     Directory containing code signing certificate
+        --key-input-directory <string>             Directory containing private and public keys
         -h, --help               Output usage information
     `,
       0
@@ -36,7 +37,12 @@ export const configureCodeSigning: Command = async (argv) => {
   }
 
   const { configureCodeSigningAsync } = await import('./configureCodeSigningAsync');
+
+  const certificateInput = assertArg(args, '--certificate-input-directory', 'string');
+  const keyInput = assertArg(args, '--key-input-directory', 'string');
+
   return await configureCodeSigningAsync(getProjectRoot(args), {
-    input: args['--input'],
+    certificateInput,
+    keyInput,
   });
 };

--- a/packages/expo-updates/cli/configureCodeSigning.ts
+++ b/packages/expo-updates/cli/configureCodeSigning.ts
@@ -2,7 +2,7 @@
 import chalk from 'chalk';
 
 import { Command } from './cli';
-import { assertArg, assertArgs, getProjectRoot } from './utils/args';
+import { requireArg, assertArgs, getProjectRoot } from './utils/args';
 import * as Log from './utils/log';
 
 export const configureCodeSigning: Command = async (argv) => {
@@ -38,8 +38,8 @@ export const configureCodeSigning: Command = async (argv) => {
 
   const { configureCodeSigningAsync } = await import('./configureCodeSigningAsync');
 
-  const certificateInput = assertArg(args, '--certificate-input-directory', 'string');
-  const keyInput = assertArg(args, '--key-input-directory', 'string');
+  const certificateInput = requireArg(args, '--certificate-input-directory');
+  const keyInput = requireArg(args, '--key-input-directory');
 
   return await configureCodeSigningAsync(getProjectRoot(args), {
     certificateInput,

--- a/packages/expo-updates/cli/generateCodeSigning.ts
+++ b/packages/expo-updates/cli/generateCodeSigning.ts
@@ -2,7 +2,7 @@
 import chalk from 'chalk';
 
 import { Command } from './cli';
-import { assertArg, assertArgs, getProjectRoot } from './utils/args';
+import { requireArg, assertArgs, getProjectRoot } from './utils/args';
 import * as Log from './utils/log';
 
 export const generateCodeSigning: Command = async (argv) => {
@@ -42,14 +42,13 @@ export const generateCodeSigning: Command = async (argv) => {
 
   const { generateCodeSigningAsync } = await import('./generateCodeSigningAsync');
 
-  const keyOutput = assertArg(args, '--key-output-directory', 'string');
-  const certificateOutput = assertArg(args, '--certificate-output-directory', 'string');
-  const certificateValidityDurationYears = assertArg(
+  const keyOutput = requireArg(args, '--key-output-directory');
+  const certificateOutput = requireArg(args, '--certificate-output-directory');
+  const certificateValidityDurationYears = requireArg(
     args,
-    '--certificate-validity-duration-years',
-    'number'
+    '--certificate-validity-duration-years'
   );
-  const certificateCommonName = assertArg(args, '--certificate-common-name', 'string');
+  const certificateCommonName = requireArg(args, '--certificate-common-name');
 
   return await generateCodeSigningAsync(getProjectRoot(args), {
     certificateValidityDurationYears,

--- a/packages/expo-updates/cli/generateCodeSigning.ts
+++ b/packages/expo-updates/cli/generateCodeSigning.ts
@@ -2,7 +2,7 @@
 import chalk from 'chalk';
 
 import { Command } from './cli';
-import { assertArgs, getProjectRoot } from './utils/args';
+import { assertArg, assertArgs, getProjectRoot } from './utils/args';
 import * as Log from './utils/log';
 
 export const generateCodeSigning: Command = async (argv) => {
@@ -10,14 +10,12 @@ export const generateCodeSigning: Command = async (argv) => {
     {
       // Types
       '--help': Boolean,
-      '--output': String,
-      '--validity-duration-years': Number,
-      '--common-name': String,
+      '--key-output-directory': String,
+      '--certificate-output-directory': String,
+      '--certificate-validity-duration-years': Number,
+      '--certificate-common-name': String,
       // Aliases
       '-h': '--help',
-      '-o': '--output',
-      '-d': '--validity-duration-years',
-      '-c': '--common-name',
     },
     argv ?? []
   );
@@ -26,25 +24,37 @@ export const generateCodeSigning: Command = async (argv) => {
     Log.exit(
       chalk`
       {bold Description}
-      Generate expo-updates code signing keys and certificates
+      Generate expo-updates private key, public key, and code signing certificate using that public key (self-signed by the private key)
 
       {bold Usage}
         $ npx expo-updates codesigning:generate
 
         Options
-        -o, --output <string>                   Directory in which to put the generated keys and certificate
-        -d, --validity-duration-years <number>  Validity duration in years
-        -c, --common-name <string>              Common name attribute for certificate
-        -h, --help                              Output usage information
+        --key-output-directory <string>                  Directory in which to put the generated private and public keys
+        --certificate-output-directory <string>          Directory in which to put the generated certificate
+        --certificate-validity-duration-years <number>   Validity duration in years
+        --certificate-common-name <string>               Common name attribute for certificate
+        -h, --help                                       Output usage information
     `,
       0
     );
   }
 
   const { generateCodeSigningAsync } = await import('./generateCodeSigningAsync');
+
+  const keyOutput = assertArg(args, '--key-output-directory', 'string');
+  const certificateOutput = assertArg(args, '--certificate-output-directory', 'string');
+  const certificateValidityDurationYears = assertArg(
+    args,
+    '--certificate-validity-duration-years',
+    'number'
+  );
+  const certificateCommonName = assertArg(args, '--certificate-common-name', 'string');
+
   return await generateCodeSigningAsync(getProjectRoot(args), {
-    validityDurationYears: args['--validity-duration-years'],
-    output: args['--output'],
-    commonName: args['--common-name'],
+    certificateValidityDurationYears,
+    keyOutput,
+    certificateOutput,
+    certificateCommonName,
   });
 };

--- a/packages/expo-updates/cli/generateCodeSigningAsync.ts
+++ b/packages/expo-updates/cli/generateCodeSigningAsync.ts
@@ -56,9 +56,9 @@ export async function generateCodeSigningAsync(
   ]);
 
   log(
-    `Generated public and private keys output to ${keyOutputDir}. Remember to add them to .gitignore or to encrypt them. (e.g. with git-crypt)`
+    `Generated public and private keys output in ${keyOutputDir}. Remember to add them to .gitignore or to encrypt them. (e.g. with git-crypt)`
   );
-  log(`Generated code signing certificate output to ${certificateOutputDir}.`);
+  log(`Generated code signing certificate output in ${certificateOutputDir}.`);
   log(
     `To automatically configure this project for code signing, run \`yarn expo-updates codesigning:configure --certificate-input-directory=${certificateOutput} --key-input-directory=${keyOutput}\`.`
   );

--- a/packages/expo-updates/cli/utils/args.ts
+++ b/packages/expo-updates/cli/utils/args.ts
@@ -40,3 +40,14 @@ export function assertArgs(schema: arg.Spec, argv: string[]): arg.Result<arg.Spe
     throw error;
   }
 }
+
+export function assertArg(args: arg.Result<arg.Spec>, name: any, type: 'string' | 'number'): any {
+  const value = args[name];
+  if (value === undefined || value === null) {
+    Log.exit(`${name} must not be null`);
+  }
+  if (typeof value !== type) {
+    Log.exit(`${name} must be a ${type}`);
+  }
+  return value;
+}

--- a/packages/expo-updates/cli/utils/args.ts
+++ b/packages/expo-updates/cli/utils/args.ts
@@ -41,13 +41,10 @@ export function assertArgs(schema: arg.Spec, argv: string[]): arg.Result<arg.Spe
   }
 }
 
-export function assertArg(args: arg.Result<arg.Spec>, name: any, type: 'string' | 'number'): any {
+export function requireArg(args: arg.Result<arg.Spec>, name: any): any {
   const value = args[name];
   if (value === undefined || value === null) {
     Log.exit(`${name} must be provided`, 1);
-  }
-  if (typeof value !== type) {
-    Log.exit(`${name} must be a ${type}`, 1);
   }
   return value;
 }

--- a/packages/expo-updates/cli/utils/args.ts
+++ b/packages/expo-updates/cli/utils/args.ts
@@ -44,10 +44,10 @@ export function assertArgs(schema: arg.Spec, argv: string[]): arg.Result<arg.Spe
 export function assertArg(args: arg.Result<arg.Spec>, name: any, type: 'string' | 'number'): any {
   const value = args[name];
   if (value === undefined || value === null) {
-    Log.exit(`${name} must not be null`);
+    Log.exit(`${name} must be provided`, 1);
   }
   if (typeof value !== type) {
-    Log.exit(`${name} must be a ${type}`);
+    Log.exit(`${name} must be a ${type}`, 1);
   }
   return value;
 }


### PR DESCRIPTION
# Why

The private key should be treated as sensitive information (somewhat like apple credentials are in the old expo-cli). Therefore, when generated, they should be encouraged to be put in a separate directory from the code signing certificate and then either added to .gitignore or encrypted with git-crypt. The user still has the option to put them anywhere they like and store them however they desire (in or out of the repo).

# How

Update the generation and configuration CLIs to take multiple paths.

# Test Plan

Run tests.

```bash
$ yarn expo-updates codesigning:generate --key-output-directory=keys --certificate-output-directory=certificates --certificate-validity-duration-years=2 --certificate-common-name=cs
Generated public and private keys output to /Users/wschurman/temp/sign-test/keys. Remember to add them to .gitignore or to encrypt them. (e.g. with git-crypt)
Generated code signing certificate output to /Users/wschurman/temp/sign-test/certificates.
To automatically configure this project for code signing, run `yarn expo-updates codesigning:configure --certificate-input-directory=certificates --key-input-directory=keys`.
✨  Done in 0.97s.

$ yarn expo-updates codesigning:configure --certificate-input-directory=certificates --key-input-directory=keys

Code signing configuration written to app.json.
✨  Done in 0.27s.
```