### PR TITLE
fix(cli): require private-key-path arg when using developer code signing certificate

### DIFF
--- a/packages/@expo/cli/src/start/server/middleware/__tests__/ExpoGoManifestHandlerMiddleware-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/ExpoGoManifestHandlerMiddleware-test.ts
@@ -295,67 +295,14 @@ describe('_getManifestResponseAsync', () => {
 
   it('returns a code signed manifest with developers own key when requested', async () => {
     vol.fromJSON({
-      'keys/cert.pem': mockSelfSigned.certificate,
-      'keys/private-key.pem': mockSelfSigned.privateKey,
-    });
-
-    const middleware = createMiddleware({
-      updates: {
-        codeSigningCertificate: 'keys/cert.pem',
-        codeSigningMetadata: {
-          keyid: 'testkeyid',
-          alg: 'rsa-v1_5-sha256',
-        },
-      },
-    });
-
-    const results = await middleware._getManifestResponseAsync({
-      explicitlyPrefersMultipartMixed: true,
-      platform: 'android',
-      acceptSignature: false,
-      expectSignature: 'sig, keyid="testkeyid", alg="rsa-v1_5-sha256"',
-      hostname: 'localhost',
-    });
-    expect(results.version).toBe('45.0.0');
-
-    const { body, headers } = await getMultipartPartAsync('manifest', results);
-    expect(headers.get('expo-signature')).toContain('keyid="expo-go"');
-
-    expect(JSON.parse(body)).toEqual({
-      id: expect.any(String),
-      createdAt: expect.any(String),
-      runtimeVersion: '45.0.0',
-      launchAsset: {
-        key: 'bundle',
-        contentType: 'application/javascript',
-        url: 'https://localhost:8081/bundle.js',
-      },
-      assets: [],
-      metadata: {},
-      extra: {
-        eas: {
-          projectId: 'projectId',
-        },
-        expoClient: expect.anything(),
-        expoGo: {},
-        scopeKey: expect.not.stringMatching(/@anonymous\/.*/),
-      },
-    });
-
-    const certificateChainMultipartPart = await getMultipartPartAsync('certificate_chain', results);
-    expect(certificateChainMultipartPart).toBeNull();
-  });
-
-  it('returns a code signed manifest with developers own key when requested and private-key-path arg is supplied', async () => {
-    vol.fromJSON({
-      'keys/cert.pem': mockSelfSigned.certificate,
+      'certs/cert.pem': mockSelfSigned.certificate,
       'custom/private/key/path/private-key.pem': mockSelfSigned.privateKey,
     });
 
     const middleware = createMiddleware(
       {
         updates: {
-          codeSigningCertificate: 'keys/cert.pem',
+          codeSigningCertificate: 'certs/cert.pem',
           codeSigningMetadata: {
             keyid: 'testkeyid',
             alg: 'rsa-v1_5-sha256',

--- a/packages/@expo/cli/src/utils/__tests__/codesigning-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/codesigning-test.ts
@@ -104,31 +104,45 @@ describe(getCodeSigningInfoAsync, () => {
   describe('non expo-root certificate keyid requested', () => {
     it('normal case gets the configured certificate', async () => {
       vol.fromJSON({
-        'keys/cert.pem': mockSelfSigned.certificate,
+        'certs/cert.pem': mockSelfSigned.certificate,
         'keys/private-key.pem': mockSelfSigned.privateKey,
       });
 
       const result = await getCodeSigningInfoAsync(
         {
           updates: {
-            codeSigningCertificate: 'keys/cert.pem',
+            codeSigningCertificate: 'certs/cert.pem',
             codeSigningMetadata: { keyid: 'test', alg: 'rsa-v1_5-sha256' },
           },
         } as any,
         'keyid="test", alg="rsa-v1_5-sha256"',
-        undefined
+        'keys/private-key.pem'
       );
       expect(result).toMatchSnapshot();
+    });
+
+    it('throws when private key path is not supplied', async () => {
+      await expect(
+        getCodeSigningInfoAsync(
+          {
+            updates: { codeSigningCertificate: 'certs/cert.pem' },
+          } as any,
+          'keyid="test", alg="rsa-v1_5-sha256"',
+          undefined
+        )
+      ).rejects.toThrowError(
+        'Must specify --private-key-path argument to sign development manifest for requested code signing key'
+      );
     });
 
     it('throws when it cannot generate the requested keyid due to no code signing configuration in app.json', async () => {
       await expect(
         getCodeSigningInfoAsync(
           {
-            updates: { codeSigningCertificate: 'keys/cert.pem' },
+            updates: { codeSigningCertificate: 'certs/cert.pem' },
           } as any,
           'keyid="test", alg="rsa-v1_5-sha256"',
-          undefined
+          'keys/private-key.pem'
         )
       ).rejects.toThrowError(
         'Must specify "codeSigningMetadata" under the "updates" field of your app config file to use EAS code signing'
@@ -140,12 +154,12 @@ describe(getCodeSigningInfoAsync, () => {
         getCodeSigningInfoAsync(
           {
             updates: {
-              codeSigningCertificate: 'keys/cert.pem',
+              codeSigningCertificate: 'certs/cert.pem',
               codeSigningMetadata: { keyid: 'test2', alg: 'rsa-v1_5-sha256' },
             },
           } as any,
           'keyid="test", alg="rsa-v1_5-sha256"',
-          undefined
+          'keys/private-key.pem'
         )
       ).rejects.toThrowError('keyid mismatch: client=test, project=test2');
 
@@ -153,12 +167,12 @@ describe(getCodeSigningInfoAsync, () => {
         getCodeSigningInfoAsync(
           {
             updates: {
-              codeSigningCertificate: 'keys/cert.pem',
+              codeSigningCertificate: 'certs/cert.pem',
               codeSigningMetadata: { keyid: 'test', alg: 'fake' },
             },
           } as any,
           'keyid="test", alg="fake2"',
-          undefined
+          'keys/private-key.pem'
         )
       ).rejects.toThrowError('"alg" field mismatch (client=fake2, project=fake)');
     });
@@ -168,14 +182,14 @@ describe(getCodeSigningInfoAsync, () => {
         getCodeSigningInfoAsync(
           {
             updates: {
-              codeSigningCertificate: 'keys/cert.pem',
+              codeSigningCertificate: 'certs/cert.pem',
               codeSigningMetadata: { keyid: 'test', alg: 'rsa-v1_5-sha256' },
             },
           } as any,
           'keyid="test", alg="rsa-v1_5-sha256"',
-          undefined
+          'keys/private-key.pem'
         )
-      ).rejects.toThrowError('Code signing certificate cannot be read from path: keys/cert.pem');
+      ).rejects.toThrowError('Code signing certificate cannot be read from path: certs/cert.pem');
     });
   });
 });

--- a/packages/@expo/cli/src/utils/codesigning.ts
+++ b/packages/@expo/cli/src/utils/codesigning.ts
@@ -211,7 +211,9 @@ async function getProjectCodeSigningCertificateAsync(
   }
 
   if (!privateKeyPath) {
-    privateKeyPath = path.join(path.dirname(codeSigningCertificatePath), 'private-key.pem');
+    throw new CommandError(
+      'Must specify --private-key-path argument to sign development manifest for requested code signing key'
+    );
   }
 
   const codeSigningMetadata = exp.updates?.codeSigningMetadata;


### PR DESCRIPTION
# Why

expo cli equivalent of https://github.com/expo/eas-cli/pull/1059

Related PR: https://github.com/expo/expo/pull/16979.

Now that private code signing keys are encouraged to be kept offline or encrypted in a separate directory from the certificate, this argument needs to be required when code signing is configured to know how to locate the private key to use to sign the manifest when the developer certificate is requested.

# How

Require the argument.

# Test Plan

Run tests.