### PR TITLE
[docs] don't display empty tooltips for code highlights

### DIFF
--- a/docs/components/base/code.tsx
+++ b/docs/components/base/code.tsx
@@ -29,7 +29,7 @@ const STYLES_CODE_BLOCK = css`
       ${theme.highlight.emphasis} 0px 0px 10px, ${theme.highlight.emphasis} 0px 0px 10px;
   }
 
-  .code-annotation:hover {
+  .code-annotation.with-tooltip:hover {
     cursor: pointer;
     animation: none;
     opacity: 0.8;
@@ -93,7 +93,7 @@ export class Code extends React.Component<Props> {
   }
 
   private runTippy() {
-    tippy('.code-annotation', {
+    tippy('.code-annotation.with-tooltip', {
       allowHTML: true,
       theme: 'expo',
       placement: 'top',
@@ -114,7 +114,7 @@ export class Code extends React.Component<Props> {
         /<span class="token comment">&lt;!-- @info (.*?)--><\/span>\s*/g,
         (match, content) => {
           return content
-            ? `<span class="code-annotation" data-tippy-content="${this.escapeHtml(content)}">`
+            ? `<span class="code-annotation with-tooltip" data-tippy-content="${this.escapeHtml(content)}">`
             : '<span class="code-annotation">';
         }
       )
@@ -133,7 +133,7 @@ export class Code extends React.Component<Props> {
     return value
       .replace(/<span class="token comment"># @info (.*?)#<\/span>\s*/g, (match, content) => {
         return content
-          ? `<span class="code-annotation" data-tippy-content="${this.escapeHtml(content)}">`
+          ? `<span class="code-annotation with-tooltip" data-tippy-content="${this.escapeHtml(content)}">`
           : '<span class="code-annotation">';
       })
       .replace(/<span class="token comment"># @hide (.*?)#<\/span>\s*/g, (match, content) => {
@@ -148,7 +148,7 @@ export class Code extends React.Component<Props> {
     return value
       .replace(/<span class="token comment">\/\* @info (.*?)\*\/<\/span>\s*/g, (match, content) => {
         return content
-          ? `<span class="code-annotation" data-tippy-content="${this.escapeHtml(content)}">`
+          ? `<span class="code-annotation with-tooltip" data-tippy-content="${this.escapeHtml(content)}">`
           : '<span class="code-annotation">';
       })
       .replace(/<span class="token comment">\/\* @hide (.*?)\*\/<\/span>\s*/g, (match, content) => {

--- a/docs/components/base/code.tsx
+++ b/docs/components/base/code.tsx
@@ -115,7 +115,7 @@ export class Code extends React.Component<Props> {
         (match, content) => {
           return content
             ? `<span class="code-annotation" data-tippy-content="${this.escapeHtml(content)}">`
-            : '<span>';
+            : '<span class="code-annotation">';
         }
       )
       .replace(
@@ -134,7 +134,7 @@ export class Code extends React.Component<Props> {
       .replace(/<span class="token comment"># @info (.*?)#<\/span>\s*/g, (match, content) => {
         return content
           ? `<span class="code-annotation" data-tippy-content="${this.escapeHtml(content)}">`
-          : '<span>';
+          : '<span class="code-annotation">';
       })
       .replace(/<span class="token comment"># @hide (.*?)#<\/span>\s*/g, (match, content) => {
         return `<span><span class="code-hidden">%%placeholder-start%%</span><span class="code-placeholder">${this.escapeHtml(
@@ -149,7 +149,7 @@ export class Code extends React.Component<Props> {
       .replace(/<span class="token comment">\/\* @info (.*?)\*\/<\/span>\s*/g, (match, content) => {
         return content
           ? `<span class="code-annotation" data-tippy-content="${this.escapeHtml(content)}">`
-          : '<span>';
+          : '<span class="code-annotation">';
       })
       .replace(/<span class="token comment">\/\* @hide (.*?)\*\/<\/span>\s*/g, (match, content) => {
         return `<span><span class="code-hidden">%%placeholder-start%%</span><span class="code-placeholder">${this.escapeHtml(

--- a/docs/components/base/code.tsx
+++ b/docs/components/base/code.tsx
@@ -114,7 +114,9 @@ export class Code extends React.Component<Props> {
         /<span class="token comment">&lt;!-- @info (.*?)--><\/span>\s*/g,
         (match, content) => {
           return content
-            ? `<span class="code-annotation with-tooltip" data-tippy-content="${this.escapeHtml(content)}">`
+            ? `<span class="code-annotation with-tooltip" data-tippy-content="${this.escapeHtml(
+                content
+              )}">`
             : '<span class="code-annotation">';
         }
       )
@@ -133,7 +135,9 @@ export class Code extends React.Component<Props> {
     return value
       .replace(/<span class="token comment"># @info (.*?)#<\/span>\s*/g, (match, content) => {
         return content
-          ? `<span class="code-annotation with-tooltip" data-tippy-content="${this.escapeHtml(content)}">`
+          ? `<span class="code-annotation with-tooltip" data-tippy-content="${this.escapeHtml(
+              content
+            )}">`
           : '<span class="code-annotation">';
       })
       .replace(/<span class="token comment"># @hide (.*?)#<\/span>\s*/g, (match, content) => {
@@ -148,7 +152,9 @@ export class Code extends React.Component<Props> {
     return value
       .replace(/<span class="token comment">\/\* @info (.*?)\*\/<\/span>\s*/g, (match, content) => {
         return content
-          ? `<span class="code-annotation with-tooltip" data-tippy-content="${this.escapeHtml(content)}">`
+          ? `<span class="code-annotation with-tooltip" data-tippy-content="${this.escapeHtml(
+              content
+            )}">`
           : '<span class="code-annotation">';
       })
       .replace(/<span class="token comment">\/\* @hide (.*?)\*\/<\/span>\s*/g, (match, content) => {

--- a/docs/components/base/code.tsx
+++ b/docs/components/base/code.tsx
@@ -113,7 +113,9 @@ export class Code extends React.Component<Props> {
       .replace(
         /<span class="token comment">&lt;!-- @info (.*?)--><\/span>\s*/g,
         (match, content) => {
-          return `<span class="code-annotation" data-tippy-content="${this.escapeHtml(content)}">`;
+          return content
+            ? `<span class="code-annotation" data-tippy-content="${this.escapeHtml(content)}">`
+            : '<span>';
         }
       )
       .replace(
@@ -130,7 +132,9 @@ export class Code extends React.Component<Props> {
   private replaceHashCommentsWithAnnotations(value: string) {
     return value
       .replace(/<span class="token comment"># @info (.*?)#<\/span>\s*/g, (match, content) => {
-        return `<span class="code-annotation" data-tippy-content="${this.escapeHtml(content)}">`;
+        return content
+          ? `<span class="code-annotation" data-tippy-content="${this.escapeHtml(content)}">`
+          : '<span>';
       })
       .replace(/<span class="token comment"># @hide (.*?)#<\/span>\s*/g, (match, content) => {
         return `<span><span class="code-hidden">%%placeholder-start%%</span><span class="code-placeholder">${this.escapeHtml(
@@ -143,7 +147,9 @@ export class Code extends React.Component<Props> {
   private replaceSlashCommentsWithAnnotations(value: string) {
     return value
       .replace(/<span class="token comment">\/\* @info (.*?)\*\/<\/span>\s*/g, (match, content) => {
-        return `<span class="code-annotation" data-tippy-content="${this.escapeHtml(content)}">`;
+        return content
+          ? `<span class="code-annotation" data-tippy-content="${this.escapeHtml(content)}">`
+          : '<span>';
       })
       .replace(/<span class="token comment">\/\* @hide (.*?)\*\/<\/span>\s*/g, (match, content) => {
         return `<span><span class="code-hidden">%%placeholder-start%%</span><span class="code-placeholder">${this.escapeHtml(

--- a/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
+++ b/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
@@ -58,7 +58,7 @@ from the Google Play Store. In practice, the referrer URL may not be a complete,
       data-text="true"
     >
       <code
-        class="css-149nz3h-STYLES_CODE_BLOCK"
+        class="css-16ve5fg-STYLES_CODE_BLOCK"
       >
         <span
           class="token keyword"


### PR DESCRIPTION
# Why

Code annotated with `@info`, but without a description, renders an empty tooltip. This change hides the tooltip.
This applies to 97 out of the total 367 uses of `@info`, so it seems a relevant fix.

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Have not tested this locally, because I do not have the docs website running locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
