### PR TITLE
[ios] Pass function args to Swift as array of JS values

### DIFF
--- a/packages/expo-modules-core/ios/JSI/EXJSIConversions.h
+++ b/packages/expo-modules-core/ios/JSI/EXJSIConversions.h
@@ -11,6 +11,9 @@
 using namespace facebook;
 using namespace react;
 
+@class EXJavaScriptValue;
+@class EXJavaScriptRuntime;
+
 namespace expo {
 
 jsi::Value convertNSNumberToJSIBoolean(jsi::Runtime &runtime, NSNumber *value);
@@ -31,7 +34,7 @@ NSString *convertJSIStringToNSString(jsi::Runtime &runtime, const jsi::String &v
 
 NSArray *convertJSIArrayToNSArray(jsi::Runtime &runtime, const jsi::Array &value, std::shared_ptr<CallInvoker> jsInvoker);
 
-NSArray *convertJSIValuesToNSArray(jsi::Runtime &runtime, const jsi::Value *values, size_t count, std::shared_ptr<CallInvoker> jsInvoker);
+NSArray<EXJavaScriptValue *> *convertJSIValuesToNSArray(EXJavaScriptRuntime *runtime, const jsi::Value *values, size_t count);
 
 NSDictionary *convertJSIObjectToNSDictionary(jsi::Runtime &runtime, const jsi::Object &value, std::shared_ptr<CallInvoker> jsInvoker);
 

--- a/packages/expo-modules-core/ios/JSI/EXJSIConversions.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJSIConversions.mm
@@ -2,6 +2,8 @@
 
 #import <ReactCommon/TurboModuleUtils.h>
 #import <ExpoModulesCore/EXJSIConversions.h>
+#import <ExpoModulesCore/EXJavaScriptValue.h>
+#import <ExpoModulesCore/EXJavaScriptRuntime.h>
 
 namespace expo {
 
@@ -86,13 +88,16 @@ NSArray *convertJSIArrayToNSArray(jsi::Runtime &runtime, const jsi::Array &value
   return [result copy];
 }
 
-NSArray *convertJSIValuesToNSArray(jsi::Runtime &runtime, const jsi::Value *values, size_t count, std::shared_ptr<CallInvoker> jsInvoker)
+NSArray<EXJavaScriptValue *> *convertJSIValuesToNSArray(EXJavaScriptRuntime *runtime, const jsi::Value *values, size_t count)
 {
-  NSMutableArray *result = [NSMutableArray arrayWithCapacity:count];
+  NSMutableArray<EXJavaScriptValue *> *array = [NSMutableArray arrayWithCapacity:count];
+  jsi::Runtime *jsiRuntime = [runtime get];
+
   for (int i = 0; i < count; i++) {
-    result[i] = convertJSIValueToObjCObject(runtime, values[i], jsInvoker);
+    std::shared_ptr<jsi::Value> value = std::make_shared<jsi::Value>(*jsiRuntime, values[i]);
+    array[i] = [[EXJavaScriptValue alloc] initWithRuntime:runtime value:value];
   }
-  return result;
+  return array;
 }
 
 NSDictionary *convertJSIObjectToNSDictionary(jsi::Runtime &runtime, const jsi::Object &value, std::shared_ptr<CallInvoker> jsInvoker)

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.h
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.h
@@ -10,6 +10,13 @@ namespace jsi = facebook::jsi;
 namespace react = facebook::react;
 #endif // __cplusplus
 
+@class EXJavaScriptValue;
+@class EXJavaScriptObject;
+
+#ifdef __cplusplus
+typedef jsi::Value (^JSHostFunctionBlock)(jsi::Runtime &runtime, std::shared_ptr<react::CallInvoker> callInvoker, NSArray<EXJavaScriptValue *> * _Nonnull arguments);
+#endif // __cplusplus
+
 NS_SWIFT_NAME(JavaScriptRuntime)
 @interface EXJavaScriptRuntime : NSObject
 
@@ -19,8 +26,6 @@ NS_SWIFT_NAME(JavaScriptRuntime)
 - (nonnull instancetype)init;
 
 #ifdef __cplusplus
-typedef jsi::Value (^JSHostFunctionBlock)(jsi::Runtime &runtime, std::shared_ptr<react::CallInvoker> callInvoker, NSArray * _Nonnull arguments);
-
 - (nonnull instancetype)initWithRuntime:(nonnull jsi::Runtime *)runtime
                             callInvoker:(std::shared_ptr<react::CallInvoker>)callInvoker;
 

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.mm
@@ -134,19 +134,17 @@ using namespace facebook;
 
 #pragma mark - Private
 
-typedef jsi::Value (^JSHostFunctionBlock)(jsi::Runtime &runtime, std::shared_ptr<react::CallInvoker> callInvoker, NSArray * _Nonnull arguments);
-
 - (jsi::Function)createHostFunction:(nonnull NSString *)name
                           argsCount:(NSInteger)argsCount
                               block:(nonnull JSHostFunctionBlock)block
 {
   jsi::PropNameID propNameId = jsi::PropNameID::forAscii(*_runtime, [name UTF8String], [name length]);
   std::weak_ptr<react::CallInvoker> weakCallInvoker = _jsCallInvoker;
-  jsi::HostFunctionType function = [weakCallInvoker, block](jsi::Runtime &runtime, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
+  jsi::HostFunctionType function = [weakCallInvoker, block, self](jsi::Runtime &runtime, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
     // Theoretically should check here whether the call invoker isn't null, but in mocked environment
     // there is no need to care about that for synchronous calls, so it's ensured in `createAsyncFunction` instead.
     auto callInvoker = weakCallInvoker.lock();
-    NSArray *arguments = expo::convertJSIValuesToNSArray(runtime, args, count, callInvoker);
+    NSArray<EXJavaScriptValue *> *arguments = expo::convertJSIValuesToNSArray(self, args, count);
     return block(runtime, callInvoker, arguments);
   };
   return jsi::Function::createFromHostFunction(*_runtime, propNameId, (unsigned int)argsCount, function);

--- a/packages/expo-modules-core/ios/Swift/Functions/ConcreteFunction.swift
+++ b/packages/expo-modules-core/ios/Swift/Functions/ConcreteFunction.swift
@@ -109,7 +109,7 @@ public class ConcreteFunction<Args, ReturnType>: AnyFunction {
 
       do {
         // It's safe to unwrap since the arguments count matches.
-        return try expectedType!.cast(arg)
+        return try expectedType!.cast(unpackIfJavaScriptValue(arg))
       } catch {
         throw ArgumentCastException((index: index, type: expectedType!)).causedBy(error)
       }

--- a/packages/expo-modules-core/ios/Swift/JavaScriptUtils.swift
+++ b/packages/expo-modules-core/ios/Swift/JavaScriptUtils.swift
@@ -36,6 +36,17 @@ internal func createSyncFunctionBlock(holder: ModuleHolder, name functionName: S
   }
 }
 
+/**
+ If given argument is a JavaScriptValue, it's unpacked and converted to corresponding Foundation type.
+ Otherwise, the argument is returned as is.
+ */
+internal func unpackIfJavaScriptValue(_ value: Any) -> Any {
+  if let value = value as? JavaScriptValue {
+    return value.getRaw() as Any
+  }
+  return value
+}
+
 private class ModuleUnavailableException: GenericException<String> {
   override var reason: String {
     "Module '\(param)' is no longer available"


### PR DESCRIPTION
# Why

So far the host function arguments (`jsi::Value`s) were immediately converted to Foundation types before they were passed to Swift's closure. Now, as we have our own `JavaScriptValue` wrapper, it seems better to wrap those arguments and pass them to Swift layer without conversion (yet). So, basically, this moves the conversion to Swift (`unpackIfJavaScriptValue`).
We'll need this change for at least these planned features where the conversion will be unnecessary:
- make `JavaScriptValue` and `JavaScriptObject` valid function argument types
- for shared objects, the JS object will be exchanged with the native shared object

# How

Instead of converting host function arguments to Foundation types in Objective-C++ layer, I wrap them into `JavaScriptValue`s so we can do the conversion later in Swift and when necessary.

# Test Plan

- iOS unit tests are passing
- tested NCL examples for modules using the Sweet API
