### PR TITLE
[ios] Implement more functionalities to JavaScriptObject

### DIFF
--- a/packages/expo-modules-core/ios/JSI/EXJSIConversions.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJSIConversions.mm
@@ -54,6 +54,12 @@ std::vector<jsi::Value> convertNSArrayToStdVector(jsi::Runtime &runtime, NSArray
 
 jsi::Value convertObjCObjectToJSIValue(jsi::Runtime &runtime, id value)
 {
+  if ([value isKindOfClass:[EXJavaScriptValue class]]) {
+    return jsi::Value(runtime, *[(EXJavaScriptValue *)value get]);
+  }
+  if ([value isKindOfClass:[EXJavaScriptObject class]]) {
+    return jsi::Value(runtime, *[(EXJavaScriptObject *)value get]);
+  }
   if ([value isKindOfClass:[NSString class]]) {
     return convertNSStringToJSIString(runtime, (NSString *)value);
   } else if ([value isKindOfClass:[NSNumber class]]) {

--- a/packages/expo-modules-core/ios/JSI/EXJSIInstaller.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJSIInstaller.mm
@@ -4,9 +4,6 @@
 #import <ExpoModulesCore/ExpoModulesHostObject.h>
 #import <ExpoModulesCore/Swift.h>
 
-using namespace facebook;
-using namespace react;
-
 @implementation EXJavaScriptRuntimeManager
 
 + (void)installExpoModulesToRuntime:(nonnull EXJavaScriptRuntime *)runtime withSwiftInterop:(nonnull SwiftInteropBridge *)swiftInterop
@@ -14,7 +11,7 @@ using namespace react;
   std::shared_ptr<expo::ExpoModulesHostObject> hostObjectPtr = std::make_shared<expo::ExpoModulesHostObject>(swiftInterop);
   EXJavaScriptObject *global = [runtime global];
 
-  global[@"ExpoModules"] = [runtime createHostObject:hostObjectPtr];
+  [global setProperty:@"ExpoModules" value:[runtime createHostObject:hostObjectPtr]];
 }
 
 @end

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptObject.h
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptObject.h
@@ -14,6 +14,25 @@ typedef void (^JSAsyncFunctionBlock)(NSArray * _Nonnull, RCTPromiseResolveBlock 
 typedef id _Nullable (^JSSyncFunctionBlock)(NSArray * _Nonnull);
 
 @class EXJavaScriptRuntime;
+@class EXJavaScriptValue;
+
+/**
+ The property descriptor options for the property being defined or modified.
+ */
+typedef NS_OPTIONS(NSInteger, EXJavaScriptObjectPropertyDescriptor) {
+  /**
+   If set, the type of this property descriptor may be changed and if the property may be deleted from the corresponding object.
+   */
+  EXJavaScriptObjectPropertyDescriptorConfigurable = 1 << 0,
+  /**
+   If set, the property shows up during enumeration of the properties on the corresponding object.
+   */
+  EXJavaScriptObjectPropertyDescriptorEnumerable = 1 << 1,
+  /**
+   If set, the value associated with the property may be changed with an assignment operator.
+   */
+  EXJavaScriptObjectPropertyDescriptorWritable = 1 << 2,
+} NS_SWIFT_NAME(JavaScriptObjectPropertyDescriptor);
 
 NS_SWIFT_NAME(JavaScriptObject)
 @interface EXJavaScriptObject : NSObject
@@ -29,18 +48,35 @@ NS_SWIFT_NAME(JavaScriptObject)
 - (nonnull jsi::Object *)get;
 #endif // __cplusplus
 
-#pragma mark - Subscripting
+#pragma mark - Accessing object properties
 
 /**
- Subscript getter. Supports only values convertible to Foundation types, otherwise `nil` is returned.
+ \return a bool whether the object has a property with the given name.
  */
-- (nullable id)objectForKeyedSubscript:(nonnull NSString *)key;
+- (BOOL)hasProperty:(nonnull NSString *)name;
 
 /**
- Subscript setter. Only `EXJavaScriptObject` and Foundation object convertible to JSI values can be used as a value,
- otherwise the property is set to `undefined`.
+ \return the property of the object with the given name.
+ If the name isn't a property on the object, returns the `undefined` value.
  */
-- (void)setObject:(nullable id)obj forKeyedSubscript:(nonnull NSString *)key;
+- (nonnull EXJavaScriptValue *)getProperty:(nonnull NSString *)name;
+
+/**
+ \return an array consisting of all enumerable property names in the object and its prototype chain.
+ */
+- (nonnull NSArray<NSString *> *)getPropertyNames;
+
+#pragma mark - Modifying object properties
+
+/**
+ Sets the value for the property with the given name.
+ */
+- (void)setProperty:(nonnull NSString *)name value:(nullable id)value;
+
+/**
+ Defines a new property or modifies an existing property on the object. Calls `Object.defineProperty` under the hood.
+ */
+- (void)defineProperty:(nonnull NSString *)name value:(nullable id)value options:(EXJavaScriptObjectPropertyDescriptor)options;
 
 #pragma mark - Functions
 

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptObject.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptObject.mm
@@ -72,7 +72,7 @@
 
   descriptor.setProperty(*runtime, "value", expo::convertObjCObjectToJSIValue(*runtime, value));
 
-  // Object.defineProperty(object, name, descriptor)
+  // This call is basically the same as `Object.defineProperty(object, name, descriptor)` in JS
   definePropertyFunction.callWithThis(*runtime, objectClass, {
     jsi::Value(*runtime, *_jsObjectPtr.get()),
     jsi::String::createFromUtf8(*runtime, [name UTF8String]),

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptObject.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptObject.mm
@@ -34,33 +34,50 @@
   return _jsObjectPtr.get();
 }
 
-#pragma mark - Subscripting
+#pragma mark - Accessing object properties
 
-- (nullable id)objectForKeyedSubscript:(nonnull NSString *)key
+- (BOOL)hasProperty:(nonnull NSString *)name
 {
-  auto runtime = [_runtime get];
-  auto callInvoker = [_runtime callInvoker];
-
-  if (runtime && callInvoker) {
-    auto value = _jsObjectPtr->getProperty(*runtime, [key UTF8String]);
-    return expo::convertJSIValueToObjCObject(*runtime, value, callInvoker);
-  }
-  return nil;
+  return _jsObjectPtr->hasProperty(*[_runtime get], [name UTF8String]);
 }
 
-- (void)setObject:(nullable id)obj forKeyedSubscript:(nonnull NSString *)key
+- (nonnull EXJavaScriptValue *)getProperty:(nonnull NSString *)name
 {
-  auto runtime = [_runtime get];
+  std::shared_ptr<jsi::Value> value = std::make_shared<jsi::Value>(_jsObjectPtr->getProperty(*[_runtime get], [name UTF8String]));
+  return [[EXJavaScriptValue alloc] initWithRuntime:_runtime value:value];
+}
 
-  if (!runtime) {
-    NSLog(@"Cannot set '%@' property when the EXJavaScript runtime is no longer available.", key);
-    return;
-  }
-  if ([obj isKindOfClass:[EXJavaScriptObject class]]) {
-    _jsObjectPtr->setProperty(*runtime, [key UTF8String], *[obj get]);
-  } else {
-    _jsObjectPtr->setProperty(*runtime, [key UTF8String], expo::convertObjCObjectToJSIValue(*runtime, obj));
-  }
+- (nonnull NSArray<NSString *> *)getPropertyNames
+{
+  jsi::Runtime *runtime = [_runtime get];
+  jsi::Array propertyNamesArray = _jsObjectPtr->getPropertyNames(*[_runtime get]);
+  return expo::convertJSIArrayToNSArray(*runtime, propertyNamesArray, nullptr);
+}
+
+#pragma mark - Modifying object properties
+
+- (void)setProperty:(nonnull NSString *)name value:(nullable id)value
+{
+  jsi::Value jsiValue = expo::convertObjCObjectToJSIValue(*[_runtime get], value);
+  _jsObjectPtr->setProperty(*[_runtime get], [name UTF8String], jsiValue);
+}
+
+- (void)defineProperty:(nonnull NSString *)name value:(nullable id)value options:(EXJavaScriptObjectPropertyDescriptor)options
+{
+  jsi::Runtime *runtime = [_runtime get];
+  jsi::Object global = runtime->global();
+  jsi::Object objectClass = global.getPropertyAsObject(*runtime, "Object");
+  jsi::Function definePropertyFunction = objectClass.getPropertyAsFunction(*runtime, "defineProperty");
+  jsi::Object descriptor = [self preparePropertyDescriptorWithOptions:options];
+
+  descriptor.setProperty(*runtime, "value", expo::convertObjCObjectToJSIValue(*runtime, value));
+
+  // Object.defineProperty(object, name, descriptor)
+  definePropertyFunction.callWithThis(*runtime, objectClass, {
+    jsi::Value(*runtime, *_jsObjectPtr.get()),
+    jsi::String::createFromUtf8(*runtime, [name UTF8String]),
+    std::move(descriptor),
+  });
 }
 
 #pragma mark - Functions
@@ -87,6 +104,18 @@
   }
   jsi::Function function = [_runtime createSyncFunction:name argsCount:argsCount block:block];
   _jsObjectPtr->setProperty(*[_runtime get], [name UTF8String], function);
+}
+
+#pragma mark - Private helpers
+
+- (jsi::Object)preparePropertyDescriptorWithOptions:(EXJavaScriptObjectPropertyDescriptor)options
+{
+  jsi::Runtime *runtime = [_runtime get];
+  jsi::Object descriptor(*runtime);
+  descriptor.setProperty(*runtime, "configurable", (bool)(options & EXJavaScriptObjectPropertyDescriptorConfigurable));
+  descriptor.setProperty(*runtime, "enumerable", (bool)(options & EXJavaScriptObjectPropertyDescriptorEnumerable));
+  descriptor.setProperty(*runtime, "writable", (bool)(options & EXJavaScriptObjectPropertyDescriptorWritable));
+  return descriptor;
 }
 
 @end

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptValue.h
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptValue.h
@@ -19,6 +19,11 @@ NS_SWIFT_NAME(JavaScriptValue)
 #ifdef __cplusplus
 - (nonnull instancetype)initWithRuntime:(nonnull EXJavaScriptRuntime *)runtime
                                   value:(std::shared_ptr<jsi::Value>)value;
+
+/**
+ \return the underlying `jsi::Value`.
+ */
+- (nonnull jsi::Value *)get;
 #endif // __cplusplus
 
 #pragma mark - Type checking

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptValue.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptValue.mm
@@ -19,6 +19,11 @@
   return self;
 }
 
+- (nonnull jsi::Value *)get
+{
+  return _value.get();
+}
+
 #pragma mark - Type checking
 
 - (BOOL)isUndefined

--- a/packages/expo-modules-core/ios/Swift/ModuleHolder.swift
+++ b/packages/expo-modules-core/ios/Swift/ModuleHolder.swift
@@ -124,7 +124,7 @@ public final class ModuleHolder {
 
     // Fill in with constants
     for (key, value) in getConstants() {
-      object[key] = value
+      object.setProperty(key, value: value)
     }
 
     // Fill in with functions

--- a/packages/expo-modules-core/ios/Tests/JavaScriptObjectSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/JavaScriptObjectSpec.swift
@@ -1,0 +1,97 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+import ExpoModulesTestCore
+
+@testable import ExpoModulesCore
+
+final class JavaScriptObjectSpec: ExpoSpec {
+  override func spec() {
+    let runtime = JavaScriptRuntime()
+    var object: JavaScriptObject?
+
+    let key = "expo"
+    let value1 = "💙"
+    let value2 = "💛"
+
+    beforeEach {
+      object = runtime.createObject()
+    }
+
+    describe("hasProperty") {
+      it("returns false when the property is missing") {
+        expect(object?.hasProperty(key)) == false
+      }
+
+      it("returns true when the property exists") {
+        object?.setProperty(key, value: value1)
+        expect(object?.hasProperty(key)) == true
+      }
+
+      it("returns true when the property is explicitly set to undefined") {
+        object?.setProperty(key, value: nil)
+        expect(object?.hasProperty(key)) == true
+        expect(object?.getProperty(key).isUndefined()) == true
+      }
+    }
+
+    describe("getProperty") {
+      it("returns correct value") {
+        object?.setProperty(key, value: value1)
+        expect(try! object?.getProperty(key).asString()) == value1
+      }
+
+      it("returns undefined") {
+        expect(object?.getProperty("bar").isUndefined()) == true
+      }
+    }
+
+    describe("setProperty") {
+      it("sets") {
+        object?.setProperty(key, value: value1)
+        expect(try! object?.getProperty(key).asString()) == value1
+      }
+
+      it("overrides") {
+        object?.setProperty(key, value: value1)
+        object?.setProperty(key, value: value2)
+        expect(try! object?.getProperty(key).asString()) == value2
+      }
+
+      it("unsets") {
+        object?.setProperty(key, value: nil)
+        expect(object?.getProperty(key).isUndefined()) == true
+      }
+    }
+
+    describe("defineProperty") {
+      it("defines non-enumerable property") {
+        object?.defineProperty(key, value: value1, options: [])
+        expect(try! object?.getProperty(key).asString()) == value1
+        expect(object?.getPropertyNames()).notTo(contain(key))
+      }
+
+      it("defines enumerable property") {
+        // When the property is enumerable, it is listed in the property names
+        object?.defineProperty(key, value: value1, options: .enumerable)
+        expect(try! object?.getProperty(key).asString()) == value1
+        expect(object?.getPropertyNames()).to(contain(key))
+      }
+
+      it("defines configurable property") {
+        // Configurable allows to redefine the property
+        object?.defineProperty(key, value: value1, options: .configurable)
+        expect(try! object?.getProperty(key).asString()) == value1
+        object?.defineProperty(key, value: value2, options: [])
+        expect(try! object?.getProperty(key).asString()) == value2
+      }
+
+      it("defines writable property") {
+        // Writable allows changing the property
+        object?.defineProperty(key, value: value1, options: .writable)
+        expect(try! object?.getProperty(key).asString()) == value1
+        object?.setProperty(key, value: value2)
+        expect(try! object?.getProperty(key).asString()) == value2
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Why

Preparation for shared objects and computed properties. It exposes more JSI functionalities to Swift.

# How

- Removed subscripting on `JavaScriptObject` instances in favor of `hasProperty`, `getProperty` and `defineProperty`
- Added test spec for `JavaScriptObject`

# Test Plan

iOS unit tests are passing, NCL examples of modules written in Sweet API work as expected
