### PR TITLE
Add bash style syntax highlighting

### DIFF
--- a/docs/pages/workflow/android-studio-emulator.md
+++ b/docs/pages/workflow/android-studio-emulator.md
@@ -65,14 +65,19 @@ This is because the adb version on your system is different from the adb version
 
 - Open the terminal and check the `adb` version on the system:
 
-`$adb version`
+```bash
+$adb version
+```
 
 - And from the Android SDK platform-tool directory:
 
-`$cd ~/Library/Android/sdk/platform-tools`
-
-`$./adb version`
+```bash
+$ cd ~/Library/Android/sdk/platform-tools
+$ ./adb version
+```
 
 - Copy `adb` from Android SDK directory to `usr/bin` directory:
 
-`$sudo cp ~/Library/Android/sdk/platform-tools/adb /usr/bin`
+```bash
+$ sudo cp ~/Library/Android/sdk/platform-tools/adb /usr/bin
+```

--- a/docs/pages/workflow/android-studio-emulator.md
+++ b/docs/pages/workflow/android-studio-emulator.md
@@ -66,18 +66,18 @@ This is because the adb version on your system is different from the adb version
 - Open the terminal and check the `adb` version on the system:
 
 ```bash
-$adb version
+adb version
 ```
 
 - And from the Android SDK platform-tool directory:
 
 ```bash
-$ cd ~/Library/Android/sdk/platform-tools
-$ ./adb version
+cd ~/Library/Android/sdk/platform-tools
+./adb version
 ```
 
 - Copy `adb` from Android SDK directory to `usr/bin` directory:
 
 ```bash
-$ sudo cp ~/Library/Android/sdk/platform-tools/adb /usr/bin
+sudo cp ~/Library/Android/sdk/platform-tools/adb /usr/bin
 ```


### PR DESCRIPTION
This converts a few shell example commands into full bash-style syntax
blocks. Improves the syntax highlighting and makes the code samples
consistent with the rest of the page.
