### PR TITLE
[github] update most of GitHub actions used in workflows

### DIFF
--- a/.github/workflows/android-unit-tests.yml
+++ b/.github/workflows/android-unit-tests.yml
@@ -33,15 +33,15 @@ jobs:
       GRADLE_OPTS: -Dorg.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=1024m
     steps:
       - name: ⬢ Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '14.17'
       - name: 👀 Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
       - name: 🔨 Use JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: '11'
@@ -93,7 +93,7 @@ jobs:
             bin/expotools android-native-unit-tests --type instrumented
       - name: 💿 Save test results
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: test-results
           path: packages/**/build/test-results/**/*xml

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: 👀 Checkout a ref for the event
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 100
       - name: ⬇️ Fetch commits from base branch

--- a/.github/workflows/client-android.yml
+++ b/.github/workflows/client-android.yml
@@ -42,11 +42,11 @@ jobs:
       GRADLE_OPTS: -Dorg.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=1024m
     steps:
       - name: 👀 Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
       - name: 🔨 Use JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: '11'
@@ -136,13 +136,13 @@ jobs:
             bin/fastlane android build build_type:$BUILD_TYPE flavor:$FLAVOR aab:$IS_APP_BUNDLE
           fi
       - name: 💾 Upload APK artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: android-apk
           path: android/app/build/outputs/apk
       - name: 💾 Store daemon logs for debugging crashes
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: gradle-daemon-logs
           path: ~/.gradle/daemon

--- a/.github/workflows/client-ios.yml
+++ b/.github/workflows/client-ios.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: macos-11
     steps:
       - name: 👀 Checkout a ref for the event
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
       - name: 🔨 Switch to Xcode 13.0
@@ -122,7 +122,7 @@ jobs:
           IS_VERSIONED_FLAVOR: ${{ github.event_name == 'schedule' || steps.flavor.outputs.versioned == 'true' }}
       - name: 💾 Save test results
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: fastlane-logs
           path: ~/Library/Logs/fastlane

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: 👀 Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: ♻️ Restore node modules in tools
         uses: actions/cache@v2
         id: tools-modules-cache

--- a/.github/workflows/commentator.yml
+++ b/.github/workflows/commentator.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout a ref for the event
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 1
       - name: Comment on GitHub issues as github-actions bot

--- a/.github/workflows/development-client-e2e.yml
+++ b/.github/workflows/development-client-e2e.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: macos-11
     steps:
       - name: 👀 Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: 🍺 Install required tools
         run: |
           brew tap wix/brew
@@ -50,7 +50,7 @@ jobs:
         working-directory: packages/expo-dev-client
       - name: Store artifacts of build failures
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: expo-dev-client-e2e-artifacts
           path: packages/expo-dev-client/artifacts

--- a/.github/workflows/development-client-latest-e2e.yml
+++ b/.github/workflows/development-client-latest-e2e.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: macos-11
     steps:
       - name: 👀 Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: 🍺 Install required tools
         run: |
           brew tap wix/brew
@@ -28,7 +28,7 @@ jobs:
       - name: 💎 Install cocoapods
         run: sudo gem install cocoapods
       - name: 🔨 Use JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: '11'
@@ -48,7 +48,7 @@ jobs:
         working-directory: packages/expo-dev-client
       - name: Store artifacts of build failures
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: expo-dev-client-latest-e2e-artifacts
           path: packages/expo-dev-client/artifacts

--- a/.github/workflows/development-client.yml
+++ b/.github/workflows/development-client.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: false
       - name: Get yarn cache directory path
@@ -99,7 +99,7 @@ jobs:
     runs-on: macos-11
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: false
       - name: Get yarn cache directory path

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,11 +26,11 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: Install Node 14
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '14.17'
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
       - name: Get yarn cache directory path

--- a/.github/workflows/dogfooding-clients.yml
+++ b/.github/workflows/dogfooding-clients.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: 👀 Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: '14.17'
       - name: Get yarn cache directory path
@@ -90,13 +90,13 @@ jobs:
             bin/fastlane android build build_type:$BUILD_TYPE flavor:$FLAVOR
           fi
       - name: 💾 Upload APK artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: android-apk
           path: android/app/build/outputs/apk
       - name: 💾 Store daemon logs for debugging crashes
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: gradle-daemon-logs
           path: ~/.gradle/daemon

--- a/.github/workflows/expo-updates-cli.yml
+++ b/.github/workflows/expo-updates-cli.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: 👀 Checkout a ref for the event
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 100
       - name: ♻️ Restore workspace node modules

--- a/.github/workflows/expotools.yml
+++ b/.github/workflows/expotools.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: 👀 Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: ♻️ Restore node modules in tools
         uses: actions/cache@v2
         id: tools-modules-cache

--- a/.github/workflows/home.yml
+++ b/.github/workflows/home.yml
@@ -22,10 +22,10 @@ jobs:
   build:
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: '14.17'
       - name: Get yarn cache directory path
@@ -61,10 +61,10 @@ jobs:
     needs: build
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: '14.17'
       - name: Get yarn cache directory path

--- a/.github/workflows/ios-unit-tests.yml
+++ b/.github/workflows/ios-unit-tests.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: macos-11
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
       - name: 🔨 Switch to Xcode 13.0

--- a/.github/workflows/native-component-list.yml
+++ b/.github/workflows/native-component-list.yml
@@ -26,10 +26,10 @@ jobs:
   build:
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: '14.17'
       - name: Get yarn cache directory path

--- a/.github/workflows/publish-demo.yml
+++ b/.github/workflows/publish-demo.yml
@@ -20,7 +20,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
       - name: Get cache key of git lfs files
@@ -31,7 +31,7 @@ jobs:
           path: .git/lfs
           key: ${{ steps.git-lfs.outputs.sha256 }}
       - run: git lfs pull
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: '14.17'
       - run: yarn global add expo-cli@3

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: 👀 Checkout a ref for the event
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 100
       - name: ⬇️ Fetch commits from base branch

--- a/.github/workflows/shell-app-android.yml
+++ b/.github/workflows/shell-app-android.yml
@@ -16,11 +16,11 @@ jobs:
   build:
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
       - name: 🔨 Use JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: '11'
@@ -73,7 +73,7 @@ jobs:
       - name: Build shell app tarball
         run: ./buildAndroidTarballLocally.sh
       - name: Make an artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: android-shell-app
           path: artifacts/android-shell-builder.tar.gz

--- a/.github/workflows/shell-app-ios.yml
+++ b/.github/workflows/shell-app-ios.yml
@@ -22,7 +22,7 @@ jobs:
   build:
     runs-on: macos-11
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
       - name: 🔨 Switch to Xcode 13.0

--- a/.github/workflows/test-suite-lint.yml
+++ b/.github/workflows/test-suite-lint.yml
@@ -19,11 +19,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ⬢ Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '14.17'
       - name: 👀 Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
       - name: ♻️ Restore workspace node modules

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -29,11 +29,11 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: ⬢ Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '14.17'
       - name: 👀 Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
       - name: ♻️ Restore workspace node modules
@@ -72,7 +72,7 @@ jobs:
     runs-on: macos-11
     steps:
       - name: 👀 Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
       - name: 🔨 Switch to Xcode 13.0
@@ -137,7 +137,7 @@ jobs:
         working-directory: apps/bare-expo
       - name: Store images of build failures
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: bare-expo-artifacts
           path: apps/bare-expo/artifacts
@@ -160,15 +160,15 @@ jobs:
       GRADLE_OPTS: -Dorg.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=2048m
     steps:
       - name: ⬢ Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '14.17'
       - name: 👀 Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
       - name: 🔨 Use JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: '11'
@@ -221,7 +221,7 @@ jobs:
           working-directory: ./apps/bare-expo
       - name: Store images of build failures
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: bare-expo-artifacts
           path: apps/bare-expo/artifacts

--- a/.github/workflows/updates-e2e.yml
+++ b/.github/workflows/updates-e2e.yml
@@ -37,15 +37,15 @@ jobs:
       UPDATES_PORT: 4747
     steps:
       - name: ⬢ Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '14.17'
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: false
       - name: 🔨 Use JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: '11'
@@ -95,7 +95,7 @@ jobs:
       - name: Copy APK to working directory
         run: cp -R ../updates-e2e/android/app/build/outputs/apk artifact
       - name: Upload test APK artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: updates-e2e-android-apk
           path: artifact

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: macos-11
     steps:
       - name: 👀 Checkout a ref for the event
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
       - name: 🔨 Switch to Xcode 13.0

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -16,7 +16,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
       - name: Get cache key of git lfs files
@@ -27,7 +27,7 @@ jobs:
           path: .git/lfs
           key: ${{ steps.git-lfs.outputs.sha256 }}
       - run: git lfs pull
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: '14.17'
       - run: yarn global add expo-cli@3


### PR DESCRIPTION
# Why & How

Most of the actions uses previous major version, there is no breaking changes AFAIK, only security fixes and old Node versions drop.

Only `actions/github-script` left to bump, but here we are few major versions behind, and there are breaking changes, so I plan to updated those steps in the separate PR.

# Test Plan

Run the CI.

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
