### PR TITLE
[core][android] add `getJavaScriptExecutorFactory` for js executor factory overriding

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Add `getDevSupportManagerFactory` support to `ReactNativeHostHandler`. ([#16434](https://github.com/expo/expo/pull/16434) by [@lukmccall](https://github.com/lukmccall))
 - Add support for automatic setup of `expo-dev-client` on Android. ([#16441](https://github.com/expo/expo/pull/16441) by [@esamelson](https://github.com/esamelson))
 - Stopped relying on deprecated `ViewPropTypes` from React Native. ([#16207](https://github.com/expo/expo/pull/16207) by [@tsapeta](https://github.com/tsapeta))
+- Added Android `ReactNativeHostHandler.getJavaScriptExecutorFactory()` for a module to override the `JavaScriptExecutorFactory`. ([#17005](https://github.com/expo/expo/pull/17005) by [@kudo](https://github.com/kudo))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/core/interfaces/ReactNativeHostHandler.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/core/interfaces/ReactNativeHostHandler.java
@@ -2,8 +2,8 @@ package expo.modules.core.interfaces;
 
 import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.bridge.JavaScriptContextHolder;
+import com.facebook.react.bridge.JavaScriptExecutorFactory;
 import com.facebook.react.bridge.ReactApplicationContext;
-import com.facebook.react.devsupport.DevSupportManagerFactory;
 
 import androidx.annotation.Nullable;
 
@@ -54,6 +54,12 @@ public interface ReactNativeHostHandler {
    */
   @Nullable
   default Object getDevSupportManagerFactory() { return null; }
+
+  /**
+   * Given chance for modules to override the javascript executor factory.
+   */
+  @Nullable
+  default JavaScriptExecutorFactory getJavaScriptExecutorFactory() { return null; }
 
   //region event listeners
 

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Add `EXPO_USE_BETA_CLI` to utilize the new `@expo/cli` versioned package. ([#17007](https://github.com/expo/expo/pull/17007) by [@EvanBacon](https://github.com/EvanBacon))
+- Added Android `ReactNativeHostHandler.getJavaScriptExecutorFactory()` for a module to override the `JavaScriptExecutorFactory`. ([#17005](https://github.com/expo/expo/pull/17005) by [@kudo](https://github.com/kudo))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo/android/src/main/java/expo/modules/ReactNativeHostWrapperBase.kt
+++ b/packages/expo/android/src/main/java/expo/modules/ReactNativeHostWrapperBase.kt
@@ -44,7 +44,9 @@ open class ReactNativeHostWrapperBase(
   }
 
   override fun getJavaScriptExecutorFactory(): JavaScriptExecutorFactory? {
-    return invokeDelegateMethod("getJavaScriptExecutorFactory")
+    return reactNativeHostHandlers.asSequence()
+      .mapNotNull { it.javaScriptExecutorFactory }
+      .firstOrNull() ?: invokeDelegateMethod("getJavaScriptExecutorFactory")
   }
 
   @Suppress("DEPRECATION")


### PR DESCRIPTION
# Why

for modules to override the javascript executor factory, e.g. v8

# How

add `getJavaScriptExecutorFactory` to our `ReactNativeHostHandler`

# Test Plan

1. bare-expo launch
2. bare-expo + a module implements `getJavaScriptExecutorFactory()` and returns `JSCExecutorFactory`. that would be an expected crash because bare-expo doesn't include libjsc.so

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
