### PR TITLE
fix(cli): fix web support in `expo start` command

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -29,7 +29,7 @@
 - Fix build watcher. ([#16754](https://github.com/expo/expo/pull/16754) by [@EvanBacon](https://github.com/EvanBacon))
 - Allow bailing out of Terminal UI during long processes. ([#16818](https://github.com/expo/expo/pull/16818) by [@EvanBacon](https://github.com/EvanBacon))
 - [test] Update login error message to reflect server change. ([#16932](https://github.com/expo/expo/pull/16932) by [@EvanBacon](https://github.com/EvanBacon))
-- Fix webpack imports and server timeouts.
+- Fix webpack imports and server timeouts. ([#17006](https://github.com/expo/expo/pull/17006) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Fix build watcher. ([#16754](https://github.com/expo/expo/pull/16754) by [@EvanBacon](https://github.com/EvanBacon))
 - Allow bailing out of Terminal UI during long processes. ([#16818](https://github.com/expo/expo/pull/16818) by [@EvanBacon](https://github.com/EvanBacon))
 - [test] Update login error message to reflect server change. ([#16932](https://github.com/expo/expo/pull/16932) by [@EvanBacon](https://github.com/EvanBacon))
+- Fix webpack imports and server timeouts.
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/platforms/android/ADBServer.ts
+++ b/packages/@expo/cli/src/start/platforms/android/ADBServer.ts
@@ -46,7 +46,10 @@ export class ADBServer {
 
   /** Kill the ADB server. */
   async stopAsync(): Promise<boolean> {
+    Log.debug('Stopping ADB server');
+
     if (!this.isRunning) {
+      Log.debug('ADB server is not running');
       return false;
     }
     this.removeExitHook();
@@ -57,6 +60,7 @@ export class ADBServer {
       Log.error('Failed to stop ADB server: ' + error.message);
       return false;
     } finally {
+      Log.debug('Stopped ADB server');
       this.isRunning = false;
     }
   }

--- a/packages/@expo/cli/src/start/server/BundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/BundlerDevServer.ts
@@ -6,6 +6,7 @@ import resolveFrom from 'resolve-from';
 import { APISettings } from '../../api/settings';
 import * as Log from '../../log';
 import { FileNotifier } from '../../utils/FileNotifier';
+import { resolveWithTimeout } from '../../utils/delay';
 import { env } from '../../utils/env';
 import { CommandError } from '../../utils/errors';
 import { BaseResolveDeviceProps, PlatformManager } from '../platforms/PlatformManager';
@@ -217,22 +218,34 @@ export abstract class BundlerDevServer {
       Log.exception(e);
     });
 
-    return new Promise<void>((resolve, reject) => {
-      // Close the server.
-      if (this.instance?.server) {
-        this.instance.server.close((error) => {
-          this.instance = null;
-          if (error) {
-            reject(error);
+    return resolveWithTimeout(
+      () =>
+        new Promise<void>((resolve, reject) => {
+          // Close the server.
+          Log.debug(`Stopping dev server (bundler: ${this.name})`);
+
+          if (this.instance?.server) {
+            this.instance.server.close((error) => {
+              Log.debug(`Stopped dev server (bundler: ${this.name})`);
+              this.instance = null;
+              if (error) {
+                reject(error);
+              } else {
+                resolve();
+              }
+            });
           } else {
+            Log.debug(`Stopped dev server (bundler: ${this.name})`);
+            this.instance = null;
             resolve();
           }
-        });
-      } else {
-        this.instance = null;
-        resolve();
+        }),
+      {
+        // NOTE(Bacon): Metro dev server doesn't seem to be closing in time.
+        timeout: 1000,
+        errorMessage: `Timeout waiting for '${this.name}' dev server to close`,
       }
-    });
+    );
   }
 
   private getUrlCreator() {

--- a/packages/@expo/cli/src/start/server/webpack/resolveFromProject.ts
+++ b/packages/@expo/cli/src/start/server/webpack/resolveFromProject.ts
@@ -7,7 +7,10 @@ import { CommandError } from '../../../utils/errors';
 // TODO: Maybe combine with AsyncResolver?
 class WebpackImportError extends CommandError {
   constructor(projectRoot: string, moduleId: string) {
-    super('WEBPACK_IMPORT', `Missing package "${moduleId}" in the project at: ${projectRoot}`);
+    super(
+      'WEBPACK_IMPORT',
+      `Missing package "${moduleId}" in the project. Try running the command again. (cwd: ${projectRoot})`
+    );
   }
 }
 
@@ -25,7 +28,7 @@ function importFromProject(projectRoot: string, moduleId: string) {
 
 /** Import `webpack` from the project. */
 export function importWebpackFromProject(projectRoot: string): typeof import('webpack') {
-  return importFromProject(projectRoot, 'webpack').default;
+  return importFromProject(projectRoot, 'webpack');
 }
 
 /** Import `@expo/webpack-config` from the project. */
@@ -39,5 +42,5 @@ export function importExpoWebpackConfigFromProject(
 export function importWebpackDevServerFromProject(
   projectRoot: string
 ): typeof import('webpack-dev-server') {
-  return importFromProject(projectRoot, 'webpack-dev-server').default;
+  return importFromProject(projectRoot, 'webpack-dev-server');
 }


### PR DESCRIPTION
# Why

- Fix imports from webpack.
- Fix server timeouts.
