### PR TITLE
feat(expo): add `EXPO_USE_CLI` environment variable

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Add `EXPO_USE_CLI` to utilize the new `@expo/cli` versioned package. ([#17007](https://github.com/expo/expo/pull/17007) by [@EvanBacon](https://github.com/EvanBacon))
+- Add `EXPO_USE_BETA_CLI` to utilize the new `@expo/cli` versioned package. ([#17007](https://github.com/expo/expo/pull/17007) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Add `EXPO_USE_CLI` to utilize the new `@expo/cli` versioned package.
+- Add `EXPO_USE_CLI` to utilize the new `@expo/cli` versioned package. ([#17007](https://github.com/expo/expo/pull/17007) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add `EXPO_USE_CLI` to utilize the new `@expo/cli` versioned package.
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo/bin/cli.js
+++ b/packages/expo/bin/cli.js
@@ -7,7 +7,7 @@ run();
 
 function run() {
   // Use new beta CLI.
-  if (boolish('EXPO_USE_CLI', false)) {
+  if (boolish('EXPO_USE_BETA_CLI', false)) {
     return spawn(require.resolve('@expo/cli'), process.argv.slice(2), { stdio: 'inherit' });
   }
 

--- a/packages/expo/bin/cli.js
+++ b/packages/expo/bin/cli.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+'use strict';
+const spawn = require('cross-spawn').spawn;
+const { boolish } = require('getenv');
+
+run();
+
+function run() {
+  // Use new beta CLI.
+  if (boolish('EXPO_USE_CLI', false)) {
+    return spawn(require.resolve('@expo/cli'), process.argv.slice(2), { stdio: 'inherit' });
+  }
+
+  spawn('expo-cli', process.argv.slice(2), { stdio: 'inherit' })
+    .on('exit', function (code) {
+      process.exit(code);
+    })
+    .on('error', function () {
+      console.warn('This command requires Expo CLI.');
+      const rl = require('readline').createInterface({
+        input: process.stdin,
+        output: process.stdout,
+      });
+      rl.question('Do you want to install it globally [Y/n]? ', function (answer) {
+        rl.close();
+        if (/^n/i.test(answer.trim())) {
+          process.exit(1);
+        } else {
+          console.log("Installing the package 'expo-cli'...");
+          spawn('npm', ['install', '--global', '--loglevel', 'error', 'expo-cli'], {
+            stdio: ['inherit', 'ignore', 'inherit'],
+          }).on('close', function (code) {
+            if (code !== 0) {
+              console.error('Installing Expo CLI failed. You can install it manually with:');
+              console.error('  npm install --global expo-cli');
+              process.exit(code);
+            } else {
+              console.log('Expo CLI installed. You can run `expo --help` for instructions.');
+              run();
+            }
+          });
+        }
+      });
+    });
+}

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -9,6 +9,9 @@
     "*.fx.js",
     "*.fx.web.js"
   ],
+  "bin": {
+    "expo": "bin/cli.js"
+  },
   "files": [
     "android",
     "bin",
@@ -54,6 +57,7 @@
     "@expo/cli": "0.0.0",
     "@expo/vector-icons": "^12.0.4",
     "babel-preset-expo": "~9.0.1",
+    "cross-spawn": "^6.0.5",
     "expo-application": "~4.0.1",
     "expo-asset": "~8.4.5",
     "expo-constants": "~13.0.0",
@@ -63,6 +67,7 @@
     "expo-modules-autolinking": "0.6.0",
     "expo-modules-core": "0.7.0",
     "fbemitter": "^3.0.0",
+    "getenv": "^1.0.0",
     "invariant": "^2.2.4",
     "md5-file": "^3.2.3",
     "node-fetch": "^2.6.7",


### PR DESCRIPTION
# Why

@brentvatne mentioned adding the `npx expo` global CLI redirect script back to keep EAS CLI working for `expo export` [here](https://github.com/expo/eas-cli/blob/9278b3c17db5cb7c2eeb07d902161255770ea5e9/packages/eas-cli/src/utils/expoCli.ts#L12).

# How

- Default to making `npx expo` use `expo-cli`
- When `EXPO_USE_CLI=1` is enabled, use the new `@expo/cli` package. 

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

In a project, run something like: `EXPO_USE_CLI=1 node ../expo/packages/expo/bin/cli.js` to use the new CLI.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
