### PR TITLE
[ios] Fix JS values being accessed from non-JS thread

### DIFF
--- a/packages/expo-modules-core/ios/Swift/Functions/ConcreteFunction.swift
+++ b/packages/expo-modules-core/ios/Swift/Functions/ConcreteFunction.swift
@@ -109,7 +109,7 @@ public class ConcreteFunction<Args, ReturnType>: AnyFunction {
 
       do {
         // It's safe to unwrap since the arguments count matches.
-        return try expectedType!.cast(unpackIfJavaScriptValue(arg))
+        return try expectedType!.cast(arg)
       } catch {
         throw ArgumentCastException((index: index, type: expectedType!)).causedBy(error)
       }

--- a/packages/expo-modules-core/ios/Swift/ModuleHolder.swift
+++ b/packages/expo-modules-core/ios/Swift/ModuleHolder.swift
@@ -70,8 +70,16 @@ public final class ModuleHolder {
       }
       let queue = function.queue ?? DispatchQueue.global(qos: .default)
 
+      // Given arguments can be:
+      // - Swift primitives when invoked through the bridge and in unit tests
+      // - `JavaScriptValue`s when the function is called through the JSI
+      // The latter need to be unpacked to Swift primitives on the JS thread,
+      // so before the function call is scheduled on the queue.
+      // TODO: Move arguments conversion mechanism to JS thread and allow JS types as function arguments.
+      let unpackedArgs = args.map { arg in unpackIfJavaScriptValue(arg) }
+
       queue.async {
-        function.call(args: args, promise: promise)
+        function.call(args: unpackedArgs, promise: promise)
       }
     } catch let error as CodedError {
       promise.reject(error)
@@ -92,7 +100,10 @@ public final class ModuleHolder {
   @discardableResult
   func callSync(function functionName: String, args: [Any]) -> Any? {
     if let function = definition.functions[functionName] {
-      return function.callSync(args: args)
+      // The comment in `call(function:args:promise)` is partially applicable here as well.
+      // TODO: Move unpacking JS values to `callSync` in function's instance
+      let unpackedArgs = args.map { arg in unpackIfJavaScriptValue(arg) }
+      return function.callSync(args: unpackedArgs)
     }
     return nil
   }


### PR DESCRIPTION
# Why

Fixes bad access crashes in bare-expo (the cause of CI failures in test-suite)

# How

Moved unpacking function arguments to JS thread (so to run it before the call is delegated to non-JS queue)

# Test Plan

These failing tests are passing locally and on the CI
