### PR TITLE
[core][Kotlin] Add cpp part of async functions

### DIFF
--- a/packages/expo-modules-core/android/CMakeLists.txt
+++ b/packages/expo-modules-core/android/CMakeLists.txt
@@ -6,6 +6,12 @@ set(CMAKE_CXX_FLAGS "-DFOLLY_NO_CONFIG=1 -DFOLLY_HAVE_CLOCK_GETTIME=1 -DFOLLY_HA
 set(PACKAGE_NAME "expo-modules-core")
 set(BUILD_DIR ${CMAKE_SOURCE_DIR}/build)
 
+if(${NATIVE_DEBUG})
+    set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g")
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g")
+endif()
+
+
 set(SRC_DIR ${CMAKE_SOURCE_DIR}/src)
 file(GLOB sources_android "${SRC_DIR}/main/cpp/*.cpp")
 
@@ -35,8 +41,10 @@ target_include_directories(
         "${REACT_NATIVE_DIR}/React"
         "${REACT_NATIVE_DIR}/React/Base"
         "${REACT_NATIVE_DIR}/ReactAndroid/src/main/jni"
+        "${REACT_NATIVE_DIR}/ReactAndroid/src/main/jni/react"
         "${REACT_NATIVE_DIR}/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/jni"
         "${REACT_NATIVE_DIR}/ReactCommon"
+        "${REACT_NATIVE_DIR}/ReactCommon/react/nativemodule/core"
         "${REACT_NATIVE_DIR}/ReactCommon/callinvoker"
         "${REACT_NATIVE_DIR}/ReactCommon/jsi"
         "${BUILD_DIR}/third-party-ndk/boost/boost_${BOOST_VERSION}"
@@ -77,6 +85,13 @@ find_library(
         NO_CMAKE_FIND_ROOT_PATH
 )
 
+find_library(
+        REACT_NATIVE_MODULES_CORE
+        react_nativemodule_core
+        PATHS ${LIBRN_DIR}
+        NO_CMAKE_FIND_ROOT_PATH
+)
+
 #reactnativejni
 
 # linking
@@ -88,5 +103,6 @@ target_link_libraries(
         ${JSI_LIB}
         ${REACT_NATIVE_JNI_LIB}
         ${FOLLY_JSON_LIB}
+        ${REACT_NATIVE_MODULES_CORE}
         android
 )

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -39,6 +39,12 @@ buildscript {
   }
 }
 
+def isAndroidTest() {
+  Gradle gradle = getGradle()
+  String tskReqStr = gradle.getStartParameter().getTaskRequests().toString()
+  return tskReqStr.contains("AndroidTest")
+}
+
 def downloadsDir = new File("$buildDir/downloads")
 def thirdPartyNdkDir = new File("$buildDir/third-party-ndk")
 
@@ -95,6 +101,8 @@ android {
     versionCode 1
     versionName "0.7.0"
 
+    testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+
     externalNativeBuild {
       cmake {
         abiFilters(*(System.getenv('NDK_ABI_FILTERS') ?: 'armeabi-v7a x86 arm64-v8a x86_64').split(' '))
@@ -118,8 +126,8 @@ android {
 
   packagingOptions {
     // Gradle will add cmake target dependencies into packaging.
-    // Theses files are intermediated linking files to build reanimated and should not be in final package.
-    excludes = [
+    // Theses files are intermediated linking files to build modules-core and should not be in final package.
+    def sharedLibraries = [
       "**/libc++_shared.so",
       "**/libreactnativejni.so",
       "**/libglog.so",
@@ -127,8 +135,17 @@ android {
       "**/libfbjni.so",
       "**/libfolly_json.so",
       "**/libhermes.so",
-      "**/libjsi.so",
+      "**/libjsi.so"
     ]
+
+    // In android (instrumental) tests, we want to package all so files to enable our JSI functionality.
+    // Otherwise, those files should be excluded, because will be loaded by the application.
+    if (isAndroidTest()) {
+      excludes = ["META-INF/MANIFEST.MF"]
+      pickFirsts = sharedLibraries
+    } else {
+      excludes = sharedLibraries
+    }
   }
 
   configurations {
@@ -145,7 +162,9 @@ android {
   }
 
   testOptions {
-    unitTests.all {
+    unitTests.includeAndroidResources = true
+
+    unitTests.all { test ->
       testLogging {
         outputs.upToDateWhen { false }
         events "passed", "failed", "skipped", "standardError"
@@ -190,6 +209,10 @@ dependencies {
     extractJNI(files(rnAAR))
   }
   // else - there is no prebuilt react-native.aar, this is most likely Expo Go
+
+  androidTestImplementation 'androidx.test:runner:1.4.0'
+  androidTestImplementation 'androidx.test:core:1.4.0'
+  androidTestImplementation 'androidx.test:rules:1.4.0'
 }
 
 /**
@@ -321,4 +344,3 @@ tasks.whenTaskAdded { task ->
     task.dependsOn(":ReactAndroid:packageReactNdkLibs")
   }
 }
-

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/JSIInteropModuleRegistryTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/JSIInteropModuleRegistryTest.kt
@@ -1,0 +1,19 @@
+package expo.modules
+
+import expo.modules.kotlin.jni.JSIInteropModuleRegistry
+import org.junit.Assert
+import org.junit.Test
+import java.text.ParseException
+
+class JSIInteropModuleRegistryTest {
+  @Test
+  @Throws(ParseException::class)
+  fun ensure_static_libs_loaded() {
+    try {
+      // Using `JSIInteropModuleRegistry.Companion` ensures that static libs will be loaded.
+      JSIInteropModuleRegistry.Companion
+    } catch (e: Exception) {
+      Assert.fail("Couldn't load the `expo-modules-core` library: $e.")
+    }
+  }
+}

--- a/packages/expo-modules-core/android/src/main/cpp/ExpoModulesHostObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/ExpoModulesHostObject.cpp
@@ -15,15 +15,17 @@ ExpoModulesHostObject::ExpoModulesHostObject(JSIInteropModuleRegistry *installer
 jsi::Value ExpoModulesHostObject::get(jsi::Runtime &runtime, const jsi::PropNameID &name) {
   auto cName = name.utf8(runtime);
   auto module = installer->getModule(cName);
+  module->cthis()->jsiInteropModuleRegistry = installer;
   auto jsiObject = module->cthis()->getJSIObject(runtime);
   return jsi::Value(runtime, *jsiObject);
 }
 
 void ExpoModulesHostObject::set(jsi::Runtime &runtime, const jsi::PropNameID &name,
                                 const jsi::Value &value) {
-  std::string message("RuntimeError: Cannot override the host object for expo module '");
-  message += name.utf8(runtime);
-  throw jsi::JSError(runtime, message);
+  throw jsi::JSError(
+    runtime,
+    "RuntimeError: Cannot override the host object for expo module '" + name.utf8(runtime) + "'"
+  );
 }
 
 std::vector<jsi::PropNameID> ExpoModulesHostObject::getPropertyNames(jsi::Runtime &rt) {

--- a/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.cpp
@@ -24,12 +24,18 @@ void JSIInteropModuleRegistry::registerNatives() {
                  });
 }
 
-JSIInteropModuleRegistry::JSIInteropModuleRegistry(jni::alias_ref <jhybridobject> jThis)
+JSIInteropModuleRegistry::JSIInteropModuleRegistry(jni::alias_ref<jhybridobject> jThis)
   : javaPart_(jni::make_global(jThis)) {}
 
-void JSIInteropModuleRegistry::installJSI(jlong jsRuntimePointer) {
+void JSIInteropModuleRegistry::installJSI(
+  jlong jsRuntimePointer,
+  jni::alias_ref<react::CallInvokerHolder::javaobject> jsInvokerHolder,
+  jni::alias_ref<react::CallInvokerHolder::javaobject> nativeInvokerHolder
+) {
   auto runtime = reinterpret_cast<jsi::Runtime *>(jsRuntimePointer);
   runtimeHolder = std::make_unique<JavaScriptRuntime>(runtime);
+  jsInvoker = jsInvokerHolder->cthis()->getCallInvoker();
+  nativeInvoker = nativeInvokerHolder->cthis()->getCallInvoker();
 
   auto expoModules = std::make_shared<ExpoModulesHostObject>(this);
   auto expoModulesObject = jsi::Object::createFromHostObject(*runtime, expoModules);

--- a/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.h
@@ -7,11 +7,14 @@
 
 #include <fbjni/fbjni.h>
 #include <jsi/jsi.h>
+#include <ReactCommon/CallInvokerHolder.h>
+#include <ReactCommon/CallInvoker.h>
 
 #include <memory>
 
 namespace jni = facebook::jni;
 namespace jsi = facebook::jsi;
+namespace react = facebook::react;
 
 namespace expo {
 class JSIInteropModuleRegistry : public jni::HybridClass<JSIInteropModuleRegistry> {
@@ -24,9 +27,16 @@ public:
 
   static void registerNatives();
 
-  void installJSI(jlong jsRuntimePointer);
+  void installJSI(
+    jlong jsRuntimePointer,
+    jni::alias_ref<react::CallInvokerHolder::javaobject> jsInvokerHolder,
+    jni::alias_ref<react::CallInvokerHolder::javaobject> nativeInvokerHolder
+  );
 
   jni::local_ref<JavaScriptModuleObject::javaobject> getModule(const std::string &moduleName) const;
+
+  std::shared_ptr<react::CallInvoker> jsInvoker;
+  std::shared_ptr<react::CallInvoker> nativeInvoker;
 
 private:
   friend HybridBase;

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.cpp
@@ -1,10 +1,17 @@
 // Copyright © 2021-present 650 Industries, Inc. (aka Expo)
 
 #include "JavaScriptModuleObject.h"
+#include "JSIInteropModuleRegistry.h"
 
 #include <folly/dynamic.h>
 #include <jsi/JSIDynamic.h>
 #include <react/jni/ReadableNativeArray.h>
+#include <fbjni/detail/Hybrid.h>
+#include <ReactCommon/TurboModuleUtils.h>
+#include <jni/JCallback.h>
+#include <jsi/JSIDynamic.h>
+#include <fbjni/fbjni.h>
+#include <jsi/jsi.h>
 
 #include <utility>
 #include <tuple>
@@ -15,6 +22,65 @@ namespace jsi = facebook::jsi;
 namespace react = facebook::react;
 
 namespace expo {
+// Modified version of the RN implementation
+// https://github.com/facebook/react-native/blob/7dceb9b63c0bfd5b13bf6d26f9530729506e9097/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.cpp#L57
+jni::local_ref<react::JCxxCallbackImpl::JavaPart> createJavaCallbackFromJSIFunction(
+  jsi::Function &&function,
+  jsi::Runtime &rt,
+  std::shared_ptr<react::CallInvoker> jsInvoker
+) {
+  auto weakWrapper = react::CallbackWrapper::createWeak(std::move(function), rt,
+                                                        std::move(jsInvoker));
+
+  // This needs to be a shared_ptr because:
+  // 1. It cannot be unique_ptr. std::function is copyable but unique_ptr is
+  // not.
+  // 2. It cannot be weak_ptr since we need this object to live on.
+  // 3. It cannot be a value, because that would be deleted as soon as this
+  // function returns.
+  auto callbackWrapperOwner =
+    std::make_shared<react::RAIICallbackWrapperDestroyer>(weakWrapper);
+
+  std::function<void(folly::dynamic)> fn =
+    [weakWrapper, callbackWrapperOwner, wrapperWasCalled = false](
+      folly::dynamic responses) mutable {
+      if (wrapperWasCalled) {
+        throw std::runtime_error(
+          "callback 2 arg cannot be called more than once");
+      }
+
+      auto strongWrapper = weakWrapper.lock();
+      if (!strongWrapper) {
+        return;
+      }
+
+      strongWrapper->jsInvoker().invokeAsync(
+        [weakWrapper, callbackWrapperOwner, responses]() mutable {
+          auto strongWrapper2 = weakWrapper.lock();
+          if (!strongWrapper2) {
+            return;
+          }
+
+          jsi::Value args =
+            jsi::valueFromDynamic(strongWrapper2->runtime(), responses);
+          auto argsArray = args.getObject(strongWrapper2->runtime())
+            .asArray(strongWrapper2->runtime());
+          jsi::Value arg = argsArray.getValueAtIndex(strongWrapper2->runtime(), 0);
+
+          strongWrapper2->callback().call(
+            strongWrapper2->runtime(),
+            (const jsi::Value *) &arg,
+            (size_t) 1
+          );
+
+          callbackWrapperOwner.reset();
+        });
+
+      wrapperWasCalled = true;
+    };
+
+  return react::JCxxCallbackImpl::newObjectCxxArgs(fn);
+}
 
 jni::local_ref<jni::HybridClass<JavaScriptModuleObject>::jhybriddata>
 JavaScriptModuleObject::initHybrid(jni::alias_ref<jhybridobject> jThis) {
@@ -26,6 +92,8 @@ void JavaScriptModuleObject::registerNatives() {
                    makeNativeMethod("initHybrid", JavaScriptModuleObject::initHybrid),
                    makeNativeMethod("registerSyncFunction",
                                     JavaScriptModuleObject::registerSyncFunction),
+                   makeNativeMethod("registerAsyncFunction",
+                                    JavaScriptModuleObject::registerAsyncFunction),
                  });
 }
 
@@ -46,6 +114,13 @@ void JavaScriptModuleObject::registerSyncFunction(jni::alias_ref<jstring> name, 
                           std::forward_as_tuple(cName, args, false));
 }
 
+void JavaScriptModuleObject::registerAsyncFunction(jni::alias_ref<jstring> name, jint args) {
+  auto cName = name->toStdString();
+  methodsMetadata.emplace(std::piecewise_construct,
+                          std::forward_as_tuple(cName),
+                          std::forward_as_tuple(cName, args, true));
+}
+
 jni::local_ref<react::ReadableNativeArray::javaobject>
 JavaScriptModuleObject::callSyncMethod(jni::local_ref<jstring> &&name,
                                        react::ReadableNativeArray::javaobject &&args) {
@@ -57,6 +132,23 @@ JavaScriptModuleObject::callSyncMethod(jni::local_ref<jstring> &&name,
     );
 
   return method(javaPart_.get(), std::move(name), args);
+}
+
+void JavaScriptModuleObject::callAsyncMethod(
+  jni::local_ref<jstring> &&name,
+  react::ReadableNativeArray::javaobject &&args,
+  jobject promise
+) {
+  static const auto method = JavaScriptModuleObject::javaClassLocal()
+    ->getMethod<void(
+      jni::local_ref<jstring>,
+      react::ReadableNativeArray::javaobject,
+      jobject
+    )>(
+      "callAsyncMethod"
+    );
+
+  method(javaPart_.get(), std::move(name), args, promise);
 }
 
 JavaScriptModuleObject::HostObject::HostObject(
@@ -72,39 +164,14 @@ jsi::Value JavaScriptModuleObject::HostObject::get(jsi::Runtime &runtime,
   auto metadata = metadataRecord->second;
 
   if (metadata.body == nullptr) {
-    auto body = jsi::Function::createFromHostFunction(
-      runtime,
-      jsi::PropNameID::forAscii(runtime, metadata.name),
-      metadata.args,
-      [&jsModule = jsModule, cName](
-        jsi::Runtime &rt,
-        const jsi::Value &thisValue,
-        const jsi::Value *args,
-        size_t count
-      ) -> jsi::Value {
-        auto dynamicArray = folly::dynamic::array();
-        for (int i = 0; i < count; i++) {
-          auto &arg = args[i];
-          dynamicArray.push_back(jsi::dynamicFromValue(rt, arg));
-        }
-
-        auto result = jsModule->callSyncMethod(
-          jni::make_jstring(cName),
-          react::ReadableNativeArray::newObjectCxxArgs(std::move(dynamicArray)).get()
-        );
-
-        if (result == nullptr) {
-          return jsi::Value::undefined();
-        }
-
-        return jsi::valueFromDynamic(rt, result->cthis()->consume())
-          .asObject(rt)
-          .asArray(rt)
-          .getValueAtIndex(rt, 0);
-      }
-    );
-
-    metadata.body = std::make_shared<jsi::Function>(std::move(body));
+    if (!metadata.isAsync) {
+      metadata.body = std::make_shared<jsi::Function>(
+        createSyncFunctionCaller(runtime, cName, metadata.args));
+    } else {
+      metadata.body = std::make_shared<jsi::Function>(
+        createAsyncFunctionCaller(runtime, cName, metadata.args)
+      );
+    }
   }
 
   return jsi::Value(runtime, *metadata.body);
@@ -113,9 +180,10 @@ jsi::Value JavaScriptModuleObject::HostObject::get(jsi::Runtime &runtime,
 void
 JavaScriptModuleObject::HostObject::set(jsi::Runtime &runtime, const jsi::PropNameID &name,
                                         const jsi::Value &value) {
-  std::string message("RuntimeError: Cannot override the host object for expo module '");
-  message += name.utf8(runtime);
-  throw jsi::JSError(runtime, message);
+  throw jsi::JSError(
+    runtime,
+    "RuntimeError: Cannot override the host object for expo module '" + name.utf8(runtime) + "'"
+  );
 }
 
 std::vector<jsi::PropNameID>
@@ -132,5 +200,136 @@ JavaScriptModuleObject::HostObject::getPropertyNames(jsi::Runtime &rt) {
   );
 
   return result;
+}
+
+jsi::Function JavaScriptModuleObject::HostObject::createSyncFunctionCaller(
+  jsi::Runtime &runtime,
+  const std::string &name,
+  int argsNumber
+) {
+  return jsi::Function::createFromHostFunction(
+    runtime,
+    jsi::PropNameID::forAscii(runtime, name),
+    argsNumber,
+    [this, name](
+      jsi::Runtime &rt,
+      const jsi::Value &thisValue,
+      const jsi::Value *args,
+      size_t count
+    ) -> jsi::Value {
+      auto dynamicArray = folly::dynamic::array();
+      for (int i = 0; i < count; i++) {
+        auto &arg = args[i];
+        dynamicArray.push_back(jsi::dynamicFromValue(rt, arg));
+      }
+
+      auto result = jsModule->callSyncMethod(
+        jni::make_jstring(name),
+        react::ReadableNativeArray::newObjectCxxArgs(std::move(dynamicArray)).get()
+      );
+
+      if (result == nullptr) {
+        return jsi::Value::undefined();
+      }
+
+      return jsi::valueFromDynamic(rt, result->cthis()->consume())
+        .asObject(rt)
+        .asArray(rt)
+        .getValueAtIndex(rt, 0);
+    });
+}
+
+jsi::Function JavaScriptModuleObject::HostObject::createAsyncFunctionCaller(
+  jsi::Runtime &runtime,
+  const std::string &name,
+  int argsNumber
+) {
+  return jsi::Function::createFromHostFunction(
+    runtime,
+    jsi::PropNameID::forAscii(runtime, name),
+    argsNumber,
+    [this, name](
+      jsi::Runtime &rt,
+      const jsi::Value &thisValue,
+      const jsi::Value *args,
+      size_t count
+    ) -> jsi::Value {
+      auto dynamicArray = folly::dynamic::array();
+      for (int i = 0; i < count; i++) {
+        auto &arg = args[i];
+        dynamicArray.push_back(jsi::dynamicFromValue(rt, arg));
+      }
+
+      auto Promise = rt.global().getPropertyAsFunction(rt, "Promise");
+      jsi::Value promise = Promise.callAsConstructor(
+        rt,
+        createPromiseBody(rt, name, std::move(dynamicArray))
+      );
+      return promise;
+    }
+  );
+}
+
+jsi::Function JavaScriptModuleObject::HostObject::createPromiseBody(
+  jsi::Runtime &runtime,
+  const std::string &name,
+  folly::dynamic &&args
+) {
+  return jsi::Function::createFromHostFunction(
+    runtime,
+    jsi::PropNameID::forAscii(runtime, "promiseFn"),
+    2,
+    [this, args = std::move(args), name](
+      jsi::Runtime &rt,
+      const jsi::Value &thisVal,
+      const jsi::Value *promiseConstructorArgs,
+      size_t promiseConstructorArgCount
+    ) {
+      if (promiseConstructorArgCount != 2) {
+        throw std::invalid_argument("Promise fn arg count must be 2");
+      }
+
+      jsi::Function resolveJSIFn = promiseConstructorArgs[0].getObject(rt).getFunction(rt);
+      jsi::Function rejectJSIFn = promiseConstructorArgs[1].getObject(rt).getFunction(rt);
+
+      jobject resolve = createJavaCallbackFromJSIFunction(
+        std::move(resolveJSIFn),
+        rt,
+        jsModule->jsiInteropModuleRegistry->jsInvoker
+      ).release();
+
+      jobject reject = createJavaCallbackFromJSIFunction(
+        std::move(rejectJSIFn),
+        rt,
+        jsModule->jsiInteropModuleRegistry->jsInvoker
+      ).release();
+
+      JNIEnv *env = jni::Environment::current();
+
+      jclass jPromiseImpl =
+        env->FindClass("com/facebook/react/bridge/PromiseImpl");
+      jmethodID jPromiseImplConstructor = env->GetMethodID(
+        jPromiseImpl,
+        "<init>",
+        "(Lcom/facebook/react/bridge/Callback;Lcom/facebook/react/bridge/Callback;)V");
+
+      jobject promise = env->NewObject(
+        jPromiseImpl,
+        jPromiseImplConstructor,
+        resolve,
+        reject
+      );
+
+      jsModule->callAsyncMethod(
+        jni::make_jstring(name),
+        react::ReadableNativeArray::newObjectCxxArgs(args).get(),
+        promise
+      );
+
+      env->DeleteLocalRef(promise);
+
+      return jsi::Value::undefined();
+    }
+  );
 }
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/core/errors/ContextDestroyedException.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/core/errors/ContextDestroyedException.kt
@@ -1,0 +1,7 @@
+package expo.modules.core.errors
+
+import kotlinx.coroutines.CancellationException
+
+private const val DEFAULT_MESSAGE = "App context destroyed. All coroutines are cancelled."
+
+class ContextDestroyedException(message: String = DEFAULT_MESSAGE) : CancellationException(message)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -1,3 +1,5 @@
+@file:OptIn(DelicateCoroutinesApi::class)
+
 package expo.modules.kotlin
 
 import android.app.Activity
@@ -5,6 +7,8 @@ import android.content.Context
 import android.content.Intent
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.turbomodule.core.CallInvokerHolderImpl
+import expo.modules.BuildConfig
+import expo.modules.core.errors.ContextDestroyedException
 import expo.modules.core.interfaces.ActivityProvider
 import expo.modules.interfaces.barcodescanner.BarCodeScannerInterface
 import expo.modules.interfaces.camera.CameraViewInterface
@@ -16,9 +20,19 @@ import expo.modules.interfaces.permissions.Permissions
 import expo.modules.interfaces.sensors.SensorServiceInterface
 import expo.modules.interfaces.taskManager.TaskManagerInterface
 import expo.modules.kotlin.defaultmodules.ErrorManagerModule
-import expo.modules.kotlin.events.*
+import expo.modules.kotlin.events.EventEmitter
+import expo.modules.kotlin.events.EventName
+import expo.modules.kotlin.events.KEventEmitterWrapper
+import expo.modules.kotlin.events.KModuleEventEmitterWrapper
+import expo.modules.kotlin.events.OnActivityResultPayload
 import expo.modules.kotlin.jni.JSIInteropModuleRegistry
 import expo.modules.kotlin.modules.Module
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.newSingleThreadContext
 import java.lang.ref.WeakReference
 
 class AppContext(
@@ -31,7 +45,13 @@ class AppContext(
     register(modulesProvider)
   }
   private val reactLifecycleDelegate = ReactLifecycleDelegate(this)
-  private val jsiInterop = JSIInteropModuleRegistry(this)
+  // We postpone creating the `JSIInteropModuleRegistry` to not load so files in unit tests.
+  private lateinit var jsiInterop: JSIInteropModuleRegistry
+  internal val moduleQueue = CoroutineScope(
+    newSingleThreadContext("ExpoModulesCoreQueue") +
+      SupervisorJob() +
+      CoroutineName("ExpoModulesCoreCoroutineQueue")
+  )
 
   init {
     requireNotNull(reactContextHolder.get()) {
@@ -43,6 +63,7 @@ class AppContext(
   }
 
   fun onPostCreate() {
+    jsiInterop = JSIInteropModuleRegistry(this)
     val reactContext = reactContextHolder.get() ?: return
     reactContext.javaScriptContextHolder?.get()?.let {
       jsiInterop.installJSI(
@@ -159,6 +180,7 @@ class AppContext(
     reactContextHolder.get()?.removeLifecycleEventListener(reactLifecycleDelegate)
     registry.post(EventName.MODULE_DESTROY)
     registry.cleanUp()
+    moduleQueue.cancel(ContextDestroyedException())
   }
 
   fun onHostResume() {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.turbomodule.core.CallInvokerHolderImpl
 import expo.modules.core.interfaces.ActivityProvider
 import expo.modules.interfaces.barcodescanner.BarCodeScannerInterface
 import expo.modules.interfaces.camera.CameraViewInterface
@@ -42,8 +43,13 @@ class AppContext(
   }
 
   fun onPostCreate() {
-    reactContextHolder.get()?.javaScriptContextHolder?.get()?.let {
-      jsiInterop.installJSI(it)
+    val reactContext = reactContextHolder.get() ?: return
+    reactContext.javaScriptContextHolder?.get()?.let {
+      jsiInterop.installJSI(
+        it,
+        reactContext.catalystInstance.jsCallInvokerHolder as CallInvokerHolderImpl,
+        reactContext.catalystInstance.nativeCallInvokerHolder as CallInvokerHolderImpl
+      )
     }
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
@@ -22,8 +22,13 @@ class ModuleHolder(val module: Module) {
     JavaScriptModuleObject(this).apply {
       definition
         .methods
-        .filter { (_, method) -> method.isSync }
-        .forEach { (name, method) -> registerSyncFunction(name, method.argsCount) }
+        .forEach { (name, method) ->
+          if (method.isSync) {
+            registerSyncFunction(name, method.argsCount)
+          } else {
+            registerAsyncFunction(name, method.argsCount)
+          }
+        }
     }
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AnyFunction.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AnyFunction.kt
@@ -10,13 +10,13 @@ import expo.modules.kotlin.exception.exceptionDecorator
 import expo.modules.kotlin.iterator
 import expo.modules.kotlin.recycle
 import expo.modules.kotlin.types.AnyType
-import expo.modules.kotlin.types.JSTypeConverter
 
 abstract class AnyFunction(
   protected val name: String,
-  private val desiredArgsTypes: Array<AnyType>
+  private val desiredArgsTypes: Array<AnyType>,
+  isSync: Boolean = false
 ) {
-  internal var isSync = false
+  internal var isSync = isSync
     private set
 
   fun runSynchronously() = apply {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunction.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunction.kt
@@ -8,7 +8,7 @@ class AsyncFunction(
   name: String,
   argsType: Array<AnyType>,
   private val body: (args: Array<out Any?>) -> Any?
-) : AnyFunction(name, argsType) {
+) : AnyFunction(name, argsType, isSync = false) {
   override fun callSyncImplementation(holder: ModuleHolder, args: Array<out Any?>): Any? {
     return body(args)
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunctionWithPromise.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunctionWithPromise.kt
@@ -8,7 +8,7 @@ class AsyncFunctionWithPromise(
   name: String,
   argsType: Array<AnyType>,
   private val body: (args: Array<out Any?>, promise: Promise) -> Unit
-) : AnyFunction(name, argsType) {
+) : AnyFunction(name, argsType, isSync = false) {
   override fun callImplementation(holder: ModuleHolder, args: Array<out Any?>, promise: Promise) {
     body(args, promise)
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncSuspendFunction.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncSuspendFunction.kt
@@ -15,7 +15,7 @@ class AsyncSuspendFunction(
   name: String,
   argsType: Array<AnyType>,
   private val body: suspend CoroutineScope.(args: Array<out Any?>) -> Any?
-) : AnyFunction(name, argsType) {
+) : AnyFunction(name, argsType, isSync = false) {
   override fun callImplementation(holder: ModuleHolder, args: Array<out Any?>, promise: Promise) {
     val scope = holder.module.coroutineScopeDelegate.value
     scope.launch {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIInteropModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIInteropModuleRegistry.kt
@@ -1,6 +1,8 @@
 package expo.modules.kotlin.jni
 
 import com.facebook.jni.HybridData
+import com.facebook.react.turbomodule.core.CallInvokerHolderImpl
+import com.facebook.react.turbomodule.core.interfaces.CallInvokerHolder
 import expo.modules.kotlin.AppContext
 import java.lang.ref.WeakReference
 
@@ -14,7 +16,11 @@ class JSIInteropModuleRegistry(appContext: AppContext) {
   private external fun initHybrid(): HybridData
 
   @Suppress("KotlinJniMissingFunction")
-  external fun installJSI(jsRuntimePointer: Long)
+  external fun installJSI(
+    jsRuntimePointer: Long,
+    jsInvokerHolder: CallInvokerHolderImpl,
+    nativeInvokerHolder: CallInvokerHolderImpl
+  )
 
   // used from cpp codebase
   fun getJavaScriptModuleObject(name: String): JavaScriptModuleObject? {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIInteropModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIInteropModuleRegistry.kt
@@ -2,7 +2,6 @@ package expo.modules.kotlin.jni
 
 import com.facebook.jni.HybridData
 import com.facebook.react.turbomodule.core.CallInvokerHolderImpl
-import com.facebook.react.turbomodule.core.interfaces.CallInvokerHolder
 import expo.modules.kotlin.AppContext
 import java.lang.ref.WeakReference
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptModuleObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptModuleObject.kt
@@ -6,6 +6,7 @@ import com.facebook.react.bridge.ReadableNativeArray
 import expo.modules.kotlin.KPromiseWrapper
 import expo.modules.kotlin.ModuleHolder
 import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.launch
 import java.lang.ref.WeakReference
 
 class JavaScriptModuleObject(moduleHolder: ModuleHolder) {
@@ -31,7 +32,11 @@ class JavaScriptModuleObject(moduleHolder: ModuleHolder) {
   @Suppress("unused")
   fun callAsyncMethod(name: String, args: ReadableNativeArray, bridgePromise: Any) {
     val kotlinPromise = KPromiseWrapper(bridgePromise as Promise)
-    moduleHolderRef.get()?.call(name, args, kotlinPromise)
+    moduleHolderRef.get()?.let { holder ->
+      holder.module.appContext.moduleQueue.launch {
+        moduleHolderRef.get()?.call(name, args, kotlinPromise)
+      }
+    }
   }
 
   @Throws(Throwable::class)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptModuleObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptModuleObject.kt
@@ -1,8 +1,11 @@
 package expo.modules.kotlin.jni
 
 import com.facebook.jni.HybridData
+import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReadableNativeArray
+import expo.modules.kotlin.KPromiseWrapper
 import expo.modules.kotlin.ModuleHolder
+import kotlinx.coroutines.DelicateCoroutinesApi
 import java.lang.ref.WeakReference
 
 class JavaScriptModuleObject(moduleHolder: ModuleHolder) {
@@ -16,8 +19,19 @@ class JavaScriptModuleObject(moduleHolder: ModuleHolder) {
   @Suppress("KotlinJniMissingFunction")
   external fun registerSyncFunction(name: String, args: Int)
 
+  @Suppress("KotlinJniMissingFunction")
+  external fun registerAsyncFunction(name: String, args: Int)
+
+  @Suppress("unused")
   fun callSyncMethod(name: String, args: ReadableNativeArray): ReadableNativeArray? {
     return moduleHolderRef.get()?.callSync(name, args)
+  }
+
+  @OptIn(DelicateCoroutinesApi::class)
+  @Suppress("unused")
+  fun callAsyncMethod(name: String, args: ReadableNativeArray, bridgePromise: Any) {
+    val kotlinPromise = KPromiseWrapper(bridgePromise as Promise)
+    moduleHolderRef.get()?.call(name, args, kotlinPromise)
   }
 
   @Throws(Throwable::class)


### PR DESCRIPTION
# Why

Part of https://github.com/expo/expo/pull/16977.
Adds a cpp part of the async function support. 

# How

My implementation is very similar to the TurboModule implementation  - https://github.com/facebook/react-native/blob/main/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.cpp.

- Stored pointer to the js and native callback invoker. The second one is unused right now, but we will need it in the future. 
- Allow modules to register async function on their CPP representation.
- Allow CPP code to call module function with promise. 

# Test Plan

- bare-expo and simple app:
```kotlin
// Cellular module
function("test") { s: String -> s }.runSynchronously()
asyncFunction("testAsync") { s: String -> s }
```

```js
// App.js
const module = global.ExpoModules.ExpoCellular;
console.log(module.test);
console.log(global.ExpoModules.ExpoCellular == global.ExpoModules.ExpoCellular);
console.log(module.test == module.test);
console.log(module.test("abc"));

console.log(module.testAsync("abc").then((resutl) => console.log(resutl) ))
```
