### PR TITLE
[constants][updates] Fix ios script phase error from zsh extendedglob

### DIFF
--- a/packages/expo-constants/CHANGELOG.md
+++ b/packages/expo-constants/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed iOS script phase build error when `extendedglob` is enabled in zsh config. ([#17024](https://github.com/expo/expo/pull/17024) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 - Updated `@expo/config` from `6.0.6` to `6.0.14` ([#15621](https://github.com/expo/expo/pull/15621) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/expo-constants/scripts/source-login-scripts.sh
+++ b/packages/expo-constants/scripts/source-login-scripts.sh
@@ -7,7 +7,7 @@
 # script is intended for Xcode build phase scripts on macOS and does not have
 # a shebang so it inherits the current shell.
 
-current_shell=$(ps -cp "$$" -o comm="" | sed s/^-//)
+current_shell=$(ps -cp "$$" -o comm="" | sed "s/^-//")
 
 if [[ "$current_shell" == zsh ]]; then
    # Zsh's setup script order is:

--- a/packages/expo-constants/scripts/source-login-scripts.sh
+++ b/packages/expo-constants/scripts/source-login-scripts.sh
@@ -7,7 +7,7 @@
 # script is intended for Xcode build phase scripts on macOS and does not have
 # a shebang so it inherits the current shell.
 
-current_shell=$(ps -cp "$$" -o comm="" | sed "s/^-//")
+current_shell=$(ps -cp "$$" -o comm='' | sed 's/^-//')
 
 if [[ "$current_shell" == zsh ]]; then
    # Zsh's setup script order is:

--- a/packages/expo-module-scripts/CHANGELOG.md
+++ b/packages/expo-module-scripts/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `source-login-scripts.sh` error when `extendedglob` is enabled in zsh config. ([#17024](https://github.com/expo/expo/pull/17024) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 - Updated `@testing-library/react-hooks` to version `7.0.1`. ([#14552](https://github.com/expo/expo/pull/14552)) by [@Simek](https://github.com/Simek))

--- a/packages/expo-module-scripts/templates/scripts/source-login-scripts.sh
+++ b/packages/expo-module-scripts/templates/scripts/source-login-scripts.sh
@@ -7,7 +7,7 @@
 # script is intended for Xcode build phase scripts on macOS and does not have
 # a shebang so it inherits the current shell.
 
-current_shell=$(ps -cp "$$" -o comm="" | sed s/^-//)
+current_shell=$(ps -cp "$$" -o comm="" | sed "s/^-//")
 
 if [[ "$current_shell" == zsh ]]; then
    # Zsh's setup script order is:

--- a/packages/expo-module-scripts/templates/scripts/source-login-scripts.sh
+++ b/packages/expo-module-scripts/templates/scripts/source-login-scripts.sh
@@ -7,7 +7,7 @@
 # script is intended for Xcode build phase scripts on macOS and does not have
 # a shebang so it inherits the current shell.
 
-current_shell=$(ps -cp "$$" -o comm="" | sed "s/^-//")
+current_shell=$(ps -cp "$$" -o comm='' | sed 's/^-//')
 
 if [[ "$current_shell" == zsh ]]; then
    # Zsh's setup script order is:

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Allow non-codesigned manifests for Expo Go (Android). ([#16649](https://github.com/expo/expo/pull/16649) by [@wschurman](https://github.com/wschurman))
 - Allow non-codesigned manifests for Expo Go (iOS). ([#16682](https://github.com/expo/expo/pull/16682) by [@wschurman](https://github.com/wschurman))
 - Fix issue where default values for primitive-typed configuration values were not correctly set. ([#16644](https://github.com/expo/expo/pull/16644) by [@esamelson](https://github.com/esamelson))
+- Fixed iOS script phase build error when `extendedglob` is enabled in zsh config. ([#17024](https://github.com/expo/expo/pull/17024) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-updates/scripts/source-login-scripts.sh
+++ b/packages/expo-updates/scripts/source-login-scripts.sh
@@ -7,7 +7,7 @@
 # script is intended for Xcode build phase scripts on macOS and does not have
 # a shebang so it inherits the current shell.
 
-current_shell=$(ps -cp "$$" -o comm="" | sed s/^-//)
+current_shell=$(ps -cp "$$" -o comm="" | sed "s/^-//")
 
 if [[ "$current_shell" == zsh ]]; then
    # Zsh's setup script order is:

--- a/packages/expo-updates/scripts/source-login-scripts.sh
+++ b/packages/expo-updates/scripts/source-login-scripts.sh
@@ -7,7 +7,7 @@
 # script is intended for Xcode build phase scripts on macOS and does not have
 # a shebang so it inherits the current shell.
 
-current_shell=$(ps -cp "$$" -o comm="" | sed "s/^-//")
+current_shell=$(ps -cp "$$" -o comm='' | sed 's/^-//')
 
 if [[ "$current_shell" == zsh ]]; then
    # Zsh's setup script order is:


### PR DESCRIPTION
# Why

fix #16525
fix #17004

# How

add single-quotes to the sed statement

# Test Plan

```
$ zsh

$ cat test.sh
unsetopt extendedglob
current_shell=$(ps -cp "$$" -o comm="" | sed s/^-//)
echo "test case1: $current_shell"

setopt extendedglob
current_shell=$(ps -cp "$$" -o comm="" | sed s/^-//)
echo "test case2: $current_shell"

setopt extendedglob
current_shell=$(ps -cp "$$" -o comm='' | sed 's/^-//')
echo "test case3: $current_shell"

$ source test.sh
test case1: zsh
test.sh:6: no matches found: s/^-//
test case2:
test case3: zsh
```

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
