### PR TITLE
[dev-launcher][plugin] Remove error handling injection

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -31,7 +31,7 @@
 - Remove initialization side effects. ([#16522](https://github.com/expo/expo/pull/16522) by [@esamelson](https://github.com/esamelson))
 - Use expo-manifests `logUrl` getter instead of accessing raw JSON. ([#16709](https://github.com/expo/expo/pull/16709) by [@esamelson](https://github.com/esamelson))
 - Add ability for to launch a specific update through expo-updates-interface. ([#16865](https://github.com/expo/expo/pull/16865) by [@esamelson](https://github.com/esamelson))
-- Remove config plugin for better error handling in index.js
+- Remove config plugin for better error handling in index.js ([#17025](https://github.com/expo/expo/pull/17025) by [@lukmccall](https://github.com/lukmccall))
 
 ### ⚠️ Notices
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -31,7 +31,7 @@
 - Remove initialization side effects. ([#16522](https://github.com/expo/expo/pull/16522) by [@esamelson](https://github.com/esamelson))
 - Use expo-manifests `logUrl` getter instead of accessing raw JSON. ([#16709](https://github.com/expo/expo/pull/16709) by [@esamelson](https://github.com/esamelson))
 - Add ability for to launch a specific update through expo-updates-interface. ([#16865](https://github.com/expo/expo/pull/16865) by [@esamelson](https://github.com/esamelson))
-- Remove the automatical better error handling injection.
+- Remove config plugin for better error handling in index.js
 
 ### ⚠️ Notices
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Remove initialization side effects. ([#16522](https://github.com/expo/expo/pull/16522) by [@esamelson](https://github.com/esamelson))
 - Use expo-manifests `logUrl` getter instead of accessing raw JSON. ([#16709](https://github.com/expo/expo/pull/16709) by [@esamelson](https://github.com/esamelson))
 - Add ability for to launch a specific update through expo-updates-interface. ([#16865](https://github.com/expo/expo/pull/16865) by [@esamelson](https://github.com/esamelson))
+- Remove the automatical better error handling injection.
 
 ### ⚠️ Notices
 

--- a/packages/expo-dev-launcher/plugin/build/withDevLauncher.js
+++ b/packages/expo-dev-launcher/plugin/build/withDevLauncher.js
@@ -197,23 +197,6 @@ const withDevLauncherPodfile = (config) => {
         },
     ]);
 };
-const withErrorHandling = (config) => {
-    const injectErrorHandlers = async (config) => {
-        await editIndex(config, (index) => {
-            if (!DEV_LAUNCHER_JS_REGISTER_ERROR_HANDLERS_REGEX.test(index)) {
-                index = `import 'expo-dev-client';\n\n${index}`;
-            }
-            return index;
-        });
-        return config;
-    };
-    // We need to run the same task twice to ensure it will work on both platforms,
-    // because if someone runs `expo run:ios`, it will trigger only dangerous mode for that specific platform.
-    // Note: after the first execution, the second one won't change anything.
-    config = (0, config_plugins_1.withDangerousMod)(config, ['android', injectErrorHandlers]);
-    config = (0, config_plugins_1.withDangerousMod)(config, ['ios', injectErrorHandlers]);
-    return config;
-};
 const withDevLauncher = (config) => {
     // projects using SDKs before 45 need the old regex-based integration
     // TODO: remove these once we drop support for SDK 44
@@ -223,7 +206,6 @@ const withDevLauncher = (config) => {
         config = withDevLauncherPodfile(config);
         config = (0, withDevLauncherAppDelegate_1.withDevLauncherAppDelegate)(config);
     }
-    config = withErrorHandling(config);
     return config;
 };
 exports.default = (0, config_plugins_1.createRunOncePlugin)(withDevLauncher, pkg.name, pkg.version);

--- a/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
+++ b/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
@@ -271,26 +271,6 @@ const withDevLauncherPodfile: ConfigPlugin = (config) => {
   ]);
 };
 
-const withErrorHandling: ConfigPlugin = (config) => {
-  const injectErrorHandlers = async (config: ExportedConfigWithProps) => {
-    await editIndex(config, (index) => {
-      if (!DEV_LAUNCHER_JS_REGISTER_ERROR_HANDLERS_REGEX.test(index)) {
-        index = `import 'expo-dev-client';\n\n${index}`;
-      }
-      return index;
-    });
-    return config;
-  };
-
-  // We need to run the same task twice to ensure it will work on both platforms,
-  // because if someone runs `expo run:ios`, it will trigger only dangerous mode for that specific platform.
-  // Note: after the first execution, the second one won't change anything.
-  config = withDangerousMod(config, ['android', injectErrorHandlers]);
-  config = withDangerousMod(config, ['ios', injectErrorHandlers]);
-
-  return config;
-};
-
 const withDevLauncher = (config: ExpoConfig) => {
   // projects using SDKs before 45 need the old regex-based integration
   // TODO: remove these once we drop support for SDK 44
@@ -300,7 +280,6 @@ const withDevLauncher = (config: ExpoConfig) => {
     config = withDevLauncherPodfile(config);
     config = withDevLauncherAppDelegate(config);
   }
-  config = withErrorHandling(config);
   return config;
 };
 


### PR DESCRIPTION
# Why

Closes ENG-4413.

# How

- Remove error handling automatic injection from a config plugin. 

> Note: 
The documentation was changed a long time ago. 


# Test Plan

- run plugin in new project ✅