### PR TITLE
[ios] Add missing React imports to expo-dev-menu

### DIFF
--- a/packages/expo-dev-menu/ios/DevMenuAppInstance.swift
+++ b/packages/expo-dev-menu/ios/DevMenuAppInstance.swift
@@ -1,5 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
+import React
+
 @objc
 class DevMenuAppInstance: DevMenuBaseAppInstance, RCTBridgeDelegate {
   static private var CloseEventName = "closeDevMenu"

--- a/packages/expo-dev-menu/ios/DevMenuDevOptionsDelegate.swift
+++ b/packages/expo-dev-menu/ios/DevMenuDevOptionsDelegate.swift
@@ -1,6 +1,6 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
-import Foundation
+import React
 
 class DevMenuDevOptionsDelegate {
   internal private(set) weak var bridge: RCTBridge?

--- a/packages/expo-dev-menu/ios/DevMenuManager.swift
+++ b/packages/expo-dev-menu/ios/DevMenuManager.swift
@@ -1,5 +1,6 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
+import React
 import EXDevMenuInterface
 import EXManifests
 import CoreGraphics

--- a/packages/expo-dev-menu/ios/Modules/DevMenuInternalModule.swift
+++ b/packages/expo-dev-menu/ios/Modules/DevMenuInternalModule.swift
@@ -1,5 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
+
 import SafariServices
+import React
 
 @objc(DevMenuInternalModule)
 public class DevMenuInternalModule: NSObject, RCTBridgeModule {

--- a/packages/expo-dev-menu/ios/ReactDelegateHandler/ExpoDevMenuReactDelegateHandler.swift
+++ b/packages/expo-dev-menu/ios/ReactDelegateHandler/ExpoDevMenuReactDelegateHandler.swift
@@ -1,5 +1,6 @@
 // Copyright 2022-present 650 Industries. All rights reserved.
 
+import React
 import ExpoModulesCore
 
 public class ExpoDevMenuReactDelegateHandler: ExpoReactDelegateHandler {

--- a/packages/expo-modules-core/ios/ReactDelegates/ExpoReactDelegateHandler.swift
+++ b/packages/expo-modules-core/ios/ReactDelegates/ExpoReactDelegateHandler.swift
@@ -1,6 +1,6 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
-import Foundation
+import React
 
 /**
  The handler for `ExpoReactDelegate`. A module can implement a handler to process react instance creation.


### PR DESCRIPTION
# Why

I've been playing around with the unit tests and encountered some compilation errors (when building for testing) in `expo-dev-menu`. The compiler was complaining about missing React imports.

# How

Added `import React` everywhere where the compiler told me 😄 In a few places, `import Foundation` was unnecessary so I removed that

# Test Plan

I was able to build bare expo for testing with these changes
