### PR TITLE
[docs] Add deprecation warnings to third party service wrapper docs

### DIFF
--- a/docs/pages/versions/unversioned/sdk/admob.md
+++ b/docs/pages/versions/unversioned/sdk/admob.md
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
+> **Deprecated.** This module will be removed in SDK 46. There will be no replacement that works with the classic build service (`expo build`) because [the classic build service has been superseded by **EAS Build**](https://blog.expo.dev/turtle-goes-out-to-sea-d334db2a6b60). With **EAS Build**, you should use [react-native-google-mobile-ads](https://github.com/invertase/react-native-google-mobile-ads) instead.
+
 Expo includes support for the [Google AdMob SDK](https://www.google.com/admob/) for mobile advertising, including components for banner ads and imperative APIs for interstitial and rewarded video ads. **`expo-ads-admob`** is largely based of the [react-native-admob](https://github.com/sbugert/react-native-admob) module, as the documentation and questions surrounding that module may prove helpful. A simple example implementing AdMob SDK can be found [here](https://github.com/deadcoder0904/expo-google-admob).
 
 <PlatformsSection android emulator ios simulator />

--- a/docs/pages/versions/unversioned/sdk/amplitude.md
+++ b/docs/pages/versions/unversioned/sdk/amplitude.md
@@ -8,6 +8,8 @@ import APISection from '~/components/plugins/APISection';
 import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
+> **Deprecated.** This module will be removed in SDK 46. There will be no replacement that works with the classic build service (`expo build`) because [the classic build service has been superseded by **EAS Build**](https://blog.expo.dev/turtle-goes-out-to-sea-d334db2a6b60). With **EAS Build**, you should use the official [@amplitude/react-native](https://github.com/amplitude/Amplitude-ReactNative) instead.
+
 **`expo-analytics-amplitude`** provides access to [Amplitude](https://amplitude.com/) mobile analytics which allows you track and log various events and data. This module wraps Amplitude's [iOS](https://github.com/amplitude/Amplitude-iOS) and [Android](https://github.com/amplitude/Amplitude-Android) SDKs. For a great example of usage, see the [Expo app source code](https://github.com/expo/expo/tree/main/home/api/Analytics.ts).
 
 **Please note:** Session tracking may not work correctly when running Experiences in the main Expo app. It will work correctly if you create a standalone app. For example, the version logged when running experiences in the Expo app will be the [Expo app version](constants.md#constantsexpoversion). Whereas in standalone apps, the version set in **app.json** is used. For more information see [this issue on GitHub](https://github.com/expo/expo/issues/4720).

--- a/docs/pages/versions/unversioned/sdk/facebook-ads.md
+++ b/docs/pages/versions/unversioned/sdk/facebook-ads.md
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
+> **Deprecated.** This module will be removed in SDK 46. There will be no replacement that works with the classic build service (`expo build`) because [the classic build service has been superseded by **EAS Build**](https://blog.expo.dev/turtle-goes-out-to-sea-d334db2a6b60). With **EAS Build**, you should use [react-native-fbads](https://github.com/callstack/react-native-fbads) instead.
+
 **`expo-ads-facebook`** provides access to the Facebook Audience SDK, allowing you to monetize your app with targeted ads.
 
 <PlatformsSection android ios />

--- a/docs/pages/versions/unversioned/sdk/facebook.md
+++ b/docs/pages/versions/unversioned/sdk/facebook.md
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
+> **Deprecated.** This module will be removed in SDK 46. There will be no replacement that works with the classic build service (`expo build`) because [the classic build service has been superseded by **EAS Build**](https://blog.expo.dev/turtle-goes-out-to-sea-d334db2a6b60). With **EAS Build**, you should use [react-native-fbsdk-next](https://github.com/thebergamo/react-native-fbsdk-next/#expo-installation) instead.
+
 **`expo-facebook`** provides Facebook integration, such as logging in through Facebook, for React Native apps. Expo exposes a minimal native API since you can access Facebook's [Graph API](https://developers.facebook.com/docs/graph-api) directly through HTTP (using [fetch](https://reactnative.dev/docs/network.html#fetch), for example).
 
 <PlatformsSection android emulator ios simulator />

--- a/docs/pages/versions/unversioned/sdk/google-sign-in.md
+++ b/docs/pages/versions/unversioned/sdk/google-sign-in.md
@@ -6,7 +6,7 @@ packageName: 'expo-google-sign-in'
 
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-> This package has been deprecated in favor of [`expo-auth-session`](auth-session.md)'s Google provider. Users can also create custom development clients with the native community package [`@react-native-google-signin/google-signin`](https://www.npmjs.com/package/@react-native-google-signin/google-signin).
+> **Deprecated.** This package has been deprecated in favor of [`expo-auth-session`](auth-session.md)'s Google provider (for web-browser based authentication) and [@react-native-google-signin/google-signin](https://github.com/react-native-google-signin/google-signin#expo-installation) for authentication using Google's native APIs.
 
 `expo-google-sign-in` provides native Google authentication for **standalone** Expo apps or bare React Native apps. It cannot be used in Expo Go as the native `GoogleSignIn` library expects your `REVERSED_CLIENT_ID` in the **Info.plist** at build-time. To use Google authentication in the Expo Go, and on web, check out [`expo-auth-session`](../../../guides/authentication.md#google).
 

--- a/docs/pages/versions/unversioned/sdk/segment.md
+++ b/docs/pages/versions/unversioned/sdk/segment.md
@@ -8,7 +8,7 @@ import APISection from '~/components/plugins/APISection';
 import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-> We recommend using the official [@segment/analytics-react-native](https://github.com/segmentio/analytics-react-native) instead of **`expo-analytics-segment`**.
+> **Deprecated.** This module will be removed in SDK 46. We recommend using the official [@segment/analytics-react-native](https://github.com/segmentio/analytics-react-native) instead.
 
 **`expo-analytics-segment`** provides access to <https://segment.com/> mobile analytics. Wraps Segment's [iOS](https://segment.com/docs/sources/mobile/ios/) and [Android](https://segment.com/docs/sources/mobile/android/) sources.
 


### PR DESCRIPTION
# Why

Related to ENG-2643

# How

Add consistent messages to docs pages for third party API wrappers that we are dropping support for in favor of better alternatives