### PR TITLE
[expo-updates] add current and embedded update id headers to manifest requests

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/UpdatesBinding.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/UpdatesBinding.kt
@@ -56,6 +56,8 @@ class UpdatesBinding(context: Context, experienceProperties: Map<String, Any?>) 
     return true
   }
 
+  override val embeddedUpdate: UpdateEntity? = null
+
   override val launchedUpdate: UpdateEntity?
     get() = appLoader!!.launcher.launchedUpdate
 

--- a/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/updates/UpdatesModule.java
+++ b/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/updates/UpdatesModule.java
@@ -189,7 +189,7 @@ public class UpdatesModule extends ExportedModule {
 
       AsyncTask.execute(() -> {
         final DatabaseHolder databaseHolder = updatesService.getDatabaseHolder();
-        new RemoteLoader(getContext(), updatesService.getConfiguration(), databaseHolder.getDatabase(), updatesService.getFileDownloader(), updatesService.getDirectory())
+        new RemoteLoader(getContext(), updatesService.getConfiguration(), databaseHolder.getDatabase(), updatesService.getFileDownloader(), updatesService.getDirectory(), updatesService.getLaunchedUpdate())
           .start(
             new RemoteLoader.LoaderCallback() {
               @Override

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/updates/UpdatesModule.kt
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/updates/UpdatesModule.kt
@@ -190,7 +190,8 @@ class UpdatesModule(
           updatesServiceLocal.configuration,
           databaseHolder.database,
           updatesServiceLocal.fileDownloader,
-          updatesServiceLocal.directory
+          updatesServiceLocal.directory,
+          updatesServiceLocal.launchedUpdate
         )
           .start(
             object : Loader.LoaderCallback {

--- a/ios/Exponent/Kernel/Services/EXUpdatesManager.m
+++ b/ios/Exponent/Kernel/Services/EXUpdatesManager.m
@@ -167,7 +167,7 @@ didRequestBundleWithCompletionQueue:(dispatch_queue_t)completionQueue
   EXUpdatesDatabaseManager *databaseKernelService = [EXKernel sharedInstance].serviceRegistry.updatesDatabaseManager;
   EXAppLoader *appLoader = [self _appLoaderWithScopedModule:scopedModule];
 
-  EXUpdatesRemoteAppLoader *remoteAppLoader = [[EXUpdatesRemoteAppLoader alloc] initWithConfig:appLoader.config database:databaseKernelService.database directory:databaseKernelService.updatesDirectory completionQueue:completionQueue];
+  EXUpdatesRemoteAppLoader *remoteAppLoader = [[EXUpdatesRemoteAppLoader alloc] initWithConfig:appLoader.config database:databaseKernelService.database directory:databaseKernelService.updatesDirectory launchedUpdate:nil completionQueue:completionQueue];
   [remoteAppLoader loadUpdateFromUrl:appLoader.config.updateUrl onManifest:^BOOL(EXUpdatesUpdate * _Nonnull update) {
     BOOL shouldLoad = [appLoader.selectionPolicy shouldLoadNewUpdate:update withLaunchedUpdate:appLoader.appLauncher.launchedUpdate filters:update.manifestFilters];
     if (shouldLoad) {

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXUpdatesBinding.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXUpdatesBinding.m
@@ -46,6 +46,11 @@ NS_ASSUME_NONNULL_BEGIN
   return _databaseKernelService.updatesDirectory;
 }
 
+- (nullable EXUpdatesUpdate *)embeddedUpdate
+{
+  return nil;
+}
+
 - (nullable EXUpdatesUpdate *)launchedUpdate
 {
   return [_updatesKernelService launchedUpdateForScopeKey:_scopeKey];

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Add current and embedded update headers to manifest requests. ([#17033](https://github.com/expo/expo/pull/17033) by [@esamelson](https://github.com/esamelson))
+
 ## 0.12.0 — 2022-04-18
 
 ### 🛠 Breaking changes

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderTest.kt
@@ -7,7 +7,6 @@ import androidx.test.platform.app.InstrumentationRegistry
 import expo.modules.updates.UpdatesConfiguration
 import expo.modules.updates.db.entity.AssetEntity
 import expo.modules.updates.db.entity.UpdateEntity
-import expo.modules.updates.manifest.EmbeddedManifest
 import expo.modules.updates.manifest.ManifestMetadata
 import io.mockk.every
 import io.mockk.mockk

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/RemoteLoaderTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/RemoteLoaderTest.kt
@@ -47,7 +47,7 @@ class RemoteLoaderTest {
     configuration = UpdatesConfiguration(null, configMap)
     val context = InstrumentationRegistry.getInstrumentation().targetContext
     db = Room.inMemoryDatabaseBuilder(context, UpdatesDatabase::class.java).build()
-    mockLoaderFiles = mockk()
+    mockLoaderFiles = mockk(relaxed = true)
     mockFileDownloader = mockk()
     loader = RemoteLoader(
       context,
@@ -55,6 +55,7 @@ class RemoteLoaderTest {
       db,
       mockFileDownloader,
       File("testDirectory"),
+      null,
       mockLoaderFiles
     )
     manifest = LegacyUpdateManifest.fromLegacyManifest(

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.kt
@@ -307,7 +307,7 @@ class UpdatesController private constructor(
         }
         remoteLoadStatus = ErrorRecoveryDelegate.RemoteLoadStatus.NEW_UPDATE_LOADING
         val database = getDatabase()
-        val remoteLoader = RemoteLoader(context, updatesConfiguration, database, fileDownloader, updatesDirectory)
+        val remoteLoader = RemoteLoader(context, updatesConfiguration, database, fileDownloader, updatesDirectory, launchedUpdate)
         remoteLoader.start(object : Loader.LoaderCallback {
           override fun onFailure(e: Exception) {
             setRemoteLoadStatus(ErrorRecoveryDelegate.RemoteLoadStatus.IDLE)

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
@@ -52,7 +52,8 @@ class UpdatesDevLauncherController : UpdatesInterface {
       updatesConfiguration,
       databaseHolder.database,
       controller.fileDownloader,
-      controller.updatesDirectory
+      controller.updatesDirectory,
+      null
     )
     loader.start(object : Loader.LoaderCallback {
       override fun onFailure(e: Exception) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesInterface.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesInterface.kt
@@ -23,6 +23,7 @@ interface UpdatesInterface {
   val isEmergencyLaunch: Boolean
   val isUsingEmbeddedAssets: Boolean
   fun canRelaunch(): Boolean
+  val embeddedUpdate: UpdateEntity?
   val launchedUpdate: UpdateEntity?
   val localAssetFiles: Map<AssetEntity, String>?
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
@@ -12,17 +12,15 @@ import expo.modules.core.interfaces.ExpoMethod
 import expo.modules.updates.db.entity.AssetEntity
 import expo.modules.updates.db.entity.UpdateEntity
 import expo.modules.updates.launcher.Launcher.LauncherCallback
+import expo.modules.updates.loader.FileDownloader
 import expo.modules.updates.loader.FileDownloader.ManifestDownloadCallback
 import expo.modules.updates.loader.Loader
 import expo.modules.updates.loader.RemoteLoader
-import expo.modules.updates.manifest.ManifestMetadata
 import expo.modules.updates.manifest.UpdateManifest
 
 // these unused imports must stay because of versioning
 /* ktlint-disable no-unused-imports */
 import expo.modules.updates.UpdatesConfiguration
-import expo.modules.updates.loader.FileDownloader
-
 /* ktlint-enable no-unused-imports */
 
 class UpdatesModule(

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
@@ -21,6 +21,8 @@ import expo.modules.updates.manifest.UpdateManifest
 // these unused imports must stay because of versioning
 /* ktlint-disable no-unused-imports */
 import expo.modules.updates.UpdatesConfiguration
+import expo.modules.updates.loader.FileDownloader
+
 /* ktlint-enable no-unused-imports */
 
 class UpdatesModule(
@@ -127,8 +129,11 @@ class UpdatesModule(
         return
       }
       val databaseHolder = updatesServiceLocal.databaseHolder
-      val extraHeaders = ManifestMetadata.getServerDefinedHeaders(
-        databaseHolder.database, updatesServiceLocal.configuration
+      val extraHeaders = FileDownloader.getExtraHeaders(
+        databaseHolder.database,
+        updatesServiceLocal.configuration,
+        updatesServiceLocal.launchedUpdate,
+        updatesServiceLocal.embeddedUpdate
       )
       databaseHolder.releaseDatabase()
       updatesServiceLocal.fileDownloader.downloadManifest(
@@ -194,7 +199,8 @@ class UpdatesModule(
           updatesServiceLocal.configuration,
           databaseHolder.database,
           updatesServiceLocal.fileDownloader,
-          updatesServiceLocal.directory
+          updatesServiceLocal.directory,
+          updatesServiceLocal.launchedUpdate
         )
           .start(
             object : Loader.LoaderCallback {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesService.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesService.kt
@@ -14,6 +14,8 @@ import java.io.File
 /* ktlint-disable no-unused-imports */
 import expo.modules.updates.UpdatesConfiguration
 import expo.modules.updates.UpdatesController
+import expo.modules.updates.manifest.EmbeddedManifest
+
 /* ktlint-enable no-unused-imports */
 
 open class UpdatesService(protected var context: Context) : InternalModule, UpdatesInterface {
@@ -40,6 +42,8 @@ open class UpdatesService(protected var context: Context) : InternalModule, Upda
     return configuration.isEnabled && launchedUpdate != null
   }
 
+  override val embeddedUpdate: UpdateEntity?
+    get() = EmbeddedManifest.get(context, configuration)?.updateEntity
   override val launchedUpdate: UpdateEntity?
     get() = UpdatesController.instance.launchedUpdate
   override val localAssetFiles: Map<AssetEntity, String>?

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
@@ -7,9 +7,6 @@ import expo.modules.updates.UpdatesConfiguration
 import expo.modules.updates.UpdatesUtils
 import expo.modules.updates.db.entity.AssetEntity
 import expo.modules.updates.launcher.NoDatabaseLauncher
-import expo.modules.updates.manifest.ManifestFactory
-import expo.modules.updates.manifest.ManifestHeaderData
-import expo.modules.updates.manifest.UpdateManifest
 import expo.modules.updates.selectionpolicy.SelectionPolicies
 import okhttp3.*
 import org.json.JSONArray
@@ -27,6 +24,9 @@ import expo.modules.easclient.EASClientID
 import okhttp3.Headers.Companion.toHeaders
 import expo.modules.jsonutils.getNullable
 import expo.modules.updates.codesigning.ValidationResult
+import expo.modules.updates.db.UpdatesDatabase
+import expo.modules.updates.db.entity.UpdateEntity
+import expo.modules.updates.manifest.*
 import java.security.cert.CertificateException
 
 open class FileDownloader(private val client: OkHttpClient) {
@@ -567,6 +567,25 @@ open class FileDownloader(private val client: OkHttpClient) {
 
     private fun getCacheDirectory(context: Context): File {
       return File(context.cacheDir, "okhttp")
+    }
+
+    fun getExtraHeaders(
+      database: UpdatesDatabase,
+      configuration: UpdatesConfiguration,
+      launchedUpdate: UpdateEntity?,
+      embeddedUpdate: UpdateEntity?
+    ): JSONObject {
+      val extraHeaders =
+        ManifestMetadata.getServerDefinedHeaders(database, configuration) ?: JSONObject()
+
+      launchedUpdate?.let {
+        extraHeaders.put("Expo-Current-Update-ID", it.id.toString().lowercase())
+      }
+      embeddedUpdate?.let {
+        extraHeaders.put("Expo-Embedded-Update-ID", it.id.toString().lowercase())
+      }
+
+      return extraHeaders
     }
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.kt
@@ -274,7 +274,7 @@ class LoaderTask(
   private fun launchRemoteUpdateInBackground(context: Context, remoteUpdateCallback: Callback) {
     AsyncTask.execute {
       val database = databaseHolder.database
-      RemoteLoader(context, configuration, database, fileDownloader, directory)
+      RemoteLoader(context, configuration, database, fileDownloader, directory, candidateLauncher?.launchedUpdate)
         .start(object : LoaderCallback {
           override fun onFailure(e: Exception) {
             databaseHolder.releaseDatabase()

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.kt
@@ -7,7 +7,6 @@ import expo.modules.updates.db.entity.AssetEntity
 import expo.modules.updates.db.entity.UpdateEntity
 import expo.modules.updates.loader.FileDownloader.AssetDownloadCallback
 import expo.modules.updates.loader.FileDownloader.ManifestDownloadCallback
-import expo.modules.updates.manifest.ManifestMetadata
 import java.io.File
 
 /**

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import expo.modules.updates.UpdatesConfiguration
 import expo.modules.updates.db.UpdatesDatabase
 import expo.modules.updates.db.entity.AssetEntity
+import expo.modules.updates.db.entity.UpdateEntity
 import expo.modules.updates.loader.FileDownloader.AssetDownloadCallback
 import expo.modules.updates.loader.FileDownloader.ManifestDownloadCallback
 import expo.modules.updates.manifest.ManifestMetadata
@@ -22,15 +23,17 @@ class RemoteLoader internal constructor(
   database: UpdatesDatabase,
   private val mFileDownloader: FileDownloader,
   updatesDirectory: File?,
-  loaderFiles: LoaderFiles
+  private val launchedUpdate: UpdateEntity?,
+  private val loaderFiles: LoaderFiles
 ) : Loader(context, configuration, database, updatesDirectory, loaderFiles) {
   constructor(
     context: Context,
     configuration: UpdatesConfiguration,
     database: UpdatesDatabase,
     fileDownloader: FileDownloader,
-    updatesDirectory: File?
-  ) : this(context, configuration, database, fileDownloader, updatesDirectory, LoaderFiles())
+    updatesDirectory: File?,
+    launchedUpdate: UpdateEntity?
+  ) : this(context, configuration, database, fileDownloader, updatesDirectory, launchedUpdate, LoaderFiles())
 
   override fun loadManifest(
     context: Context,
@@ -38,7 +41,8 @@ class RemoteLoader internal constructor(
     configuration: UpdatesConfiguration,
     callback: ManifestDownloadCallback
   ) {
-    val extraHeaders = ManifestMetadata.getServerDefinedHeaders(database, configuration)
+    val embeddedUpdate = loaderFiles.readEmbeddedManifest(context, configuration)?.updateEntity
+    val extraHeaders = FileDownloader.getExtraHeaders(database, configuration, launchedUpdate, embeddedUpdate)
     mFileDownloader.downloadManifest(configuration, extraHeaders, context, callback)
   }
 

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoader+Private.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoader+Private.h
@@ -12,6 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) EXUpdatesConfig *config;
 @property (nonatomic, strong) EXUpdatesDatabase *database;
 @property (nonatomic, strong) NSURL *directory;
+@property (nonatomic, strong, nullable) EXUpdatesUpdate *launchedUpdate;
 @property (nonatomic, strong) EXUpdatesUpdate *updateManifest;
 @property (nonatomic, copy) EXUpdatesAppLoaderManifestBlock manifestBlock;
 @property (nonatomic, copy) EXUpdatesAppLoaderAssetBlock assetBlock;

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoader.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoader.h
@@ -17,6 +17,7 @@ typedef void (^EXUpdatesAppLoaderErrorBlock)(NSError *error);
 - (instancetype)initWithConfig:(EXUpdatesConfig *)config
                       database:(EXUpdatesDatabase *)database
                      directory:(NSURL *)directory
+                launchedUpdate:(nullable EXUpdatesUpdate *)launchedUpdate
                completionQueue:(dispatch_queue_t)completionQueue;
 
 /**

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoader.m
@@ -28,6 +28,7 @@ static NSString * const EXUpdatesAppLoaderErrorDomain = @"EXUpdatesAppLoader";
 - (instancetype)initWithConfig:(EXUpdatesConfig *)config
                       database:(EXUpdatesDatabase *)database
                      directory:(NSURL *)directory
+                launchedUpdate:(nullable EXUpdatesUpdate *)launchedUpdate
                completionQueue:(dispatch_queue_t)completionQueue
 {
   if (self = [super init]) {
@@ -39,6 +40,7 @@ static NSString * const EXUpdatesAppLoaderErrorDomain = @"EXUpdatesAppLoader";
     _config = config;
     _database = database;
     _directory = directory;
+    _launchedUpdate = launchedUpdate;
     _completionQueue = completionQueue;
   }
   return self;

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoaderTask.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoaderTask.m
@@ -210,7 +210,7 @@ static NSString * const EXUpdatesAppLoaderTaskErrorDomain = @"EXUpdatesAppLoader
             [self->_selectionPolicy shouldLoadNewUpdate:[EXUpdatesEmbeddedAppLoader embeddedManifestWithConfig:self->_config database:self->_database]
                                      withLaunchedUpdate:launchableUpdate
                                                 filters:manifestFilters]) {
-          self->_embeddedAppLoader = [[EXUpdatesEmbeddedAppLoader alloc] initWithConfig:self->_config database:self->_database directory:self->_directory completionQueue:self->_loaderTaskQueue];
+          self->_embeddedAppLoader = [[EXUpdatesEmbeddedAppLoader alloc] initWithConfig:self->_config database:self->_database directory:self->_directory launchedUpdate:nil completionQueue:self->_loaderTaskQueue];
           [self->_embeddedAppLoader loadUpdateFromEmbeddedManifestWithCallback:^BOOL(EXUpdatesUpdate * _Nonnull update) {
             // we already checked using selection policy, so we don't need to check again
             return YES;
@@ -238,7 +238,7 @@ static NSString * const EXUpdatesAppLoaderTaskErrorDomain = @"EXUpdatesAppLoader
 
 - (void)_loadRemoteUpdateWithCompletion:(void (^)(NSError * _Nullable error, EXUpdatesUpdate * _Nullable update))completion
 {
-  _remoteAppLoader = [[EXUpdatesRemoteAppLoader alloc] initWithConfig:_config database:_database directory:_directory completionQueue:_loaderTaskQueue];
+  _remoteAppLoader = [[EXUpdatesRemoteAppLoader alloc] initWithConfig:_config database:_database directory:_directory launchedUpdate:_candidateLauncher.launchedUpdate completionQueue:_loaderTaskQueue];
   [_remoteAppLoader loadUpdateFromUrl:_config.updateUrl onManifest:^BOOL(EXUpdatesUpdate * _Nonnull update) {
     if ([self->_selectionPolicy shouldLoadNewUpdate:update withLaunchedUpdate:self->_candidateLauncher.launchedUpdate filters:update.manifestFilters]) {
       self->_isUpToDate = NO;

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoaderTask.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoaderTask.m
@@ -210,6 +210,8 @@ static NSString * const EXUpdatesAppLoaderTaskErrorDomain = @"EXUpdatesAppLoader
             [self->_selectionPolicy shouldLoadNewUpdate:[EXUpdatesEmbeddedAppLoader embeddedManifestWithConfig:self->_config database:self->_database]
                                      withLaunchedUpdate:launchableUpdate
                                                 filters:manifestFilters]) {
+          // launchedUpdate is nil because we don't yet have one, and it doesn't matter as we won't
+          // be sending an HTTP request from EXUpdatesEmbeddedAppLoader
           self->_embeddedAppLoader = [[EXUpdatesEmbeddedAppLoader alloc] initWithConfig:self->_config database:self->_database directory:self->_directory launchedUpdate:nil completionQueue:self->_loaderTaskQueue];
           [self->_embeddedAppLoader loadUpdateFromEmbeddedManifestWithCallback:^BOOL(EXUpdatesUpdate * _Nonnull update) {
             // we already checked using selection policy, so we don't need to check again

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.h
@@ -1,6 +1,7 @@
 //  Copyright © 2019 650 Industries. All rights reserved.
 
 #import <EXUpdates/EXUpdatesConfig.h>
+#import <EXUpdates/EXUpdatesDatabase.h>
 #import <EXUpdates/EXUpdatesUpdate.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -33,6 +34,15 @@ typedef void (^EXUpdatesFileDownloaderErrorBlock)(NSError *error);
                      errorBlock:(EXUpdatesFileDownloaderErrorBlock)errorBlock;
 
 + (dispatch_queue_t)assetFilesQueue;
+
+/**
+ * Get extra (stateful) headers to pass into `downloadManifestFromURL:`
+ * Must be called on the database queue
+ */
++ (NSDictionary *)extraHeadersWithDatabase:(EXUpdatesDatabase *)database
+                                    config:(EXUpdatesConfig *)config
+                            launchedUpdate:(nullable EXUpdatesUpdate *)launchedUpdate
+                            embeddedUpdate:(nullable EXUpdatesUpdate *)embeddedUpdate;
 
 /**
  * For test purposes; shouldn't be needed in application code

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
@@ -670,6 +670,27 @@ certificateChainFromManifestResponse:(nullable NSString *)certificateChainFromMa
   }
 }
 
++ (NSDictionary *)extraHeadersWithDatabase:(EXUpdatesDatabase *)database
+                                    config:(EXUpdatesConfig *)config
+                            launchedUpdate:(nullable EXUpdatesUpdate *)launchedUpdate
+                            embeddedUpdate:(nullable EXUpdatesUpdate *)embeddedUpdate
+{
+  NSError *headersError;
+  NSMutableDictionary *extraHeaders = [database serverDefinedHeadersWithScopeKey:config.scopeKey error:&headersError].mutableCopy ?: [NSMutableDictionary new];
+  if (headersError) {
+    NSLog(@"Error selecting serverDefinedHeaders from database: %@", headersError.localizedDescription);
+  }
+
+  if (launchedUpdate) {
+    extraHeaders[@"Expo-Current-Update-ID"] = launchedUpdate.updateId.UUIDString.lowercaseString;
+  }
+  if (embeddedUpdate) {
+    extraHeaders[@"Expo-Embedded-Update-ID"] = embeddedUpdate.updateId.UUIDString.lowercaseString;
+  }
+
+  return extraHeaders.copy;
+}
+
 #pragma mark - NSURLSessionTaskDelegate
 
 - (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task willPerformHTTPRedirection:(NSHTTPURLResponse *)response newRequest:(NSURLRequest *)request completionHandler:(void (^)(NSURLRequest *))completionHandler

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
@@ -367,7 +367,7 @@ static NSString * const EXUpdatesErrorEventName = @"error";
   }
 
   _remoteLoadStatus = EXUpdatesRemoteLoadStatusLoading;
-  EXUpdatesAppLoader *remoteAppLoader = [[EXUpdatesRemoteAppLoader alloc] initWithConfig:_config database:_database directory:_updatesDirectory completionQueue:_controllerQueue];
+  EXUpdatesAppLoader *remoteAppLoader = [[EXUpdatesRemoteAppLoader alloc] initWithConfig:_config database:_database directory:_updatesDirectory launchedUpdate:self.launchedUpdate completionQueue:_controllerQueue];
   [remoteAppLoader loadUpdateFromUrl:_config.updateUrl onManifest:^BOOL(EXUpdatesUpdate *update) {
     return [self->_selectionPolicy shouldLoadNewUpdate:update withLaunchedUpdate:self.launchedUpdate filters:update.manifestFilters];
   } asset:^(EXUpdatesAsset *asset, NSUInteger successfulAssetCount, NSUInteger failedAssetCount, NSUInteger totalAssetCount) {

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesDevLauncherController.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesDevLauncherController.m
@@ -95,7 +95,7 @@ typedef NS_ENUM(NSInteger, EXUpdatesDevLauncherErrorCode) {
   [self _setDevelopmentSelectionPolicy];
   [controller setConfigurationInternal:updatesConfiguration];
 
-  EXUpdatesRemoteAppLoader *loader = [[EXUpdatesRemoteAppLoader alloc] initWithConfig:updatesConfiguration database:controller.database directory:controller.updatesDirectory completionQueue:controller.controllerQueue];
+  EXUpdatesRemoteAppLoader *loader = [[EXUpdatesRemoteAppLoader alloc] initWithConfig:updatesConfiguration database:controller.database directory:controller.updatesDirectory launchedUpdate:nil completionQueue:controller.controllerQueue];
   [loader loadUpdateFromUrl:updatesConfiguration.updateUrl onManifest:^BOOL(EXUpdatesUpdate * _Nonnull update) {
     return manifestBlock(update.manifest.rawManifestJSON);
   } asset:^(EXUpdatesAsset * _Nonnull asset, NSUInteger successfulAssetCount, NSUInteger failedAssetCount, NSUInteger totalAssetCount) {

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesModule.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesModule.m
@@ -104,11 +104,10 @@ EX_EXPORT_METHOD_AS(checkForUpdateAsync,
 
   __block NSDictionary *extraHeaders;
   dispatch_sync(_updatesService.database.databaseQueue, ^{
-    NSError *error;
-    extraHeaders = [self->_updatesService.database serverDefinedHeadersWithScopeKey:self->_updatesService.config.scopeKey error:&error];
-    if (error) {
-      NSLog(@"Error selecting serverDefinedHeaders from database: %@", error.localizedDescription);
-    }
+    extraHeaders = [EXUpdatesFileDownloader extraHeadersWithDatabase:self->_updatesService.database
+                                                              config:self->_updatesService.config
+                                                      launchedUpdate:self->_updatesService.launchedUpdate
+                                                      embeddedUpdate:self->_updatesService.embeddedUpdate];
   });
 
   EXUpdatesFileDownloader *fileDownloader = [[EXUpdatesFileDownloader alloc] initWithUpdatesConfig:_updatesService.config];
@@ -146,7 +145,7 @@ EX_EXPORT_METHOD_AS(fetchUpdateAsync,
     return;
   }
 
-  EXUpdatesRemoteAppLoader *remoteAppLoader = [[EXUpdatesRemoteAppLoader alloc] initWithConfig:_updatesService.config database:_updatesService.database directory:_updatesService.directory completionQueue:self.methodQueue];
+  EXUpdatesRemoteAppLoader *remoteAppLoader = [[EXUpdatesRemoteAppLoader alloc] initWithConfig:_updatesService.config database:_updatesService.database directory:_updatesService.directory launchedUpdate:_updatesService.launchedUpdate completionQueue:self.methodQueue];
   [remoteAppLoader loadUpdateFromUrl:_updatesService.config.updateUrl onManifest:^BOOL(EXUpdatesUpdate * _Nonnull update) {
     return [self->_updatesService.selectionPolicy shouldLoadNewUpdate:update withLaunchedUpdate:self->_updatesService.launchedUpdate filters:update.manifestFilters];
   } asset:^(EXUpdatesAsset *asset, NSUInteger successfulAssetCount, NSUInteger failedAssetCount, NSUInteger totalAssetCount) {

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesService.h
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesService.h
@@ -17,6 +17,7 @@ typedef void (^EXUpdatesAppRelaunchCompletionBlock)(BOOL success);
 @property (nonatomic, readonly) EXUpdatesSelectionPolicy *selectionPolicy;
 @property (nonatomic, readonly) NSURL *directory;
 
+@property (nullable, nonatomic, readonly, strong) EXUpdatesUpdate *embeddedUpdate;
 @property (nullable, nonatomic, readonly, strong) EXUpdatesUpdate *launchedUpdate;
 @property (nullable, nonatomic, readonly, strong) NSDictionary *assetFilesMap;
 @property (nonatomic, readonly, assign) BOOL isUsingEmbeddedAssets;

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesService.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesService.m
@@ -1,6 +1,7 @@
 // Copyright 2020-present 650 Industries. All rights reserved.
 
 #import <EXUpdates/EXUpdatesAppController.h>
+#import <EXUpdates/EXUpdatesEmbeddedAppLoader.h>
 #import <EXUpdates/EXUpdatesService.h>
 #import <ExpoModulesCore/EXUtilities.h>
 
@@ -33,6 +34,11 @@ EX_REGISTER_MODULE();
 - (NSURL *)directory
 {
   return EXUpdatesAppController.sharedInstance.updatesDirectory;
+}
+
+- (nullable EXUpdatesUpdate *)embeddedUpdate
+{
+  return [EXUpdatesEmbeddedAppLoader embeddedManifestWithConfig:self.config database:self.database];
 }
 
 - (nullable EXUpdatesUpdate *)launchedUpdate

--- a/packages/expo-updates/ios/Tests/EXUpdatesFileDownloaderTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesFileDownloaderTests.m
@@ -4,6 +4,7 @@
 
 #import <EXUpdates/EXUpdatesConfig.h>
 #import <EXUpdates/EXUpdatesFileDownloader.h>
+#import <EXUpdates/EXUpdatesUpdate.h>
 
 @interface EXUpdatesFileDownloaderTests : XCTestCase
 
@@ -78,6 +79,52 @@
   XCTAssertEqualObjects(@"ios", [actual valueForHTTPHeaderField:@"expo-platform"]);
   XCTAssertEqualObjects(@"custom", [actual valueForHTTPHeaderField:@"expo-updates-environment"]);
 }
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
+- (void)testGetExtraHeaders
+{
+  NSString *launchedUpdateUUIDString = @"7c1d2bd0-f88b-454d-998c-7fa92a924dbf";
+  EXUpdatesUpdate *launchedUpdate = [EXUpdatesUpdate updateWithId:[[NSUUID alloc] initWithUUIDString:launchedUpdateUUIDString]
+                                                         scopeKey:@"test"
+                                                       commitTime:[NSDate date]
+                                                   runtimeVersion:@"1.0"
+                                                         manifest:nil
+                                                           status:0
+                                                             keep:YES
+                                                           config:nil
+                                                         database:nil];
+  NSString *embeddedUpdateUUIDString = @"9433b1ed-4006-46b8-8aa7-fdc7eeb203fd";
+  EXUpdatesUpdate *embeddedUpdate = [EXUpdatesUpdate updateWithId:[[NSUUID alloc] initWithUUIDString:embeddedUpdateUUIDString]
+                                                         scopeKey:@"test"
+                                                       commitTime:[NSDate date]
+                                                   runtimeVersion:@"1.0"
+                                                         manifest:nil
+                                                           status:0
+                                                             keep:YES
+                                                           config:nil
+                                                         database:nil];
+  NSDictionary *extraHeaders = [EXUpdatesFileDownloader extraHeadersWithDatabase:nil
+                                                                          config:nil
+                                                                  launchedUpdate:launchedUpdate
+                                                                  embeddedUpdate:embeddedUpdate];
+  XCTAssertEqualObjects(launchedUpdateUUIDString, extraHeaders[@"Expo-Current-Update-ID"]);
+  XCTAssertEqualObjects(embeddedUpdateUUIDString, extraHeaders[@"Expo-Embedded-Update-ID"]);
+}
+#pragma clang diagnostic pop
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
+- (void)testGetExtraHeaders_NoLaunchedOrEmbeddedUpdate
+{
+  NSDictionary *extraHeaders = [EXUpdatesFileDownloader extraHeadersWithDatabase:nil
+                                                                          config:nil
+                                                                  launchedUpdate:nil
+                                                                  embeddedUpdate:nil];
+  XCTAssertNil(extraHeaders[@"Expo-Current-Update-ID"]);
+  XCTAssertNil(extraHeaders[@"Expo-Embedded-Update-ID"]);
+}
+#pragma clang diagnostic pop
 
 - (void)testAssetExtraHeaders_OverrideOrder
 {


### PR DESCRIPTION
# Why

resolves ENG-267, allows us to add some rudimentary usage analytics for EAS Update developers to use

# How

Add 2 more headers to manifest requests: `expo-current-update-id` with the ID of the update that's running (or ready to be launched) when the client sends the request, and `expo-embedded-update-id` with the ID of the update embedded in the build. This second header allows the server to determine when the client is running its embedded update (even if the server doesn't itself know about this update), and also could serve as a rough proxy for identifying the build itself.

I used the existing `extraHeaders` parameter for this to avoid needing to thread more objects through a bunch of methods; this makes the `extraHeaders` roughly correspond to stateful headers (as opposed to the rest of the headers, which mostly depend on build-time constants).

Development clients (including Expo Go) have no embedded updates, so the `expo-embedded-update-id` header is not sent in manifest requests from such clients. Currently, Expo Go and expo-dev-client builds behave differently with respect to the `expo-current-update-id` header, because of the different ways these types of builds open published updates -- Expo Go behaves like a standalone app configured for synchronous updates, so it will send this header if it has an older update on disk ready to launch (of the same project), but dev clients will not usually send this header.
- Changing this behavior is possible but is probably beyond the scope of this PR. I'm thinking this is ok because these analytics are intended for usage among users, who aren't usually using development builds. Requests from Expo Go or other development clients can be filtered out or treated differently on the server side using the `expo-updates-environment` header field.

# Test Plan

Added some unit tests for the new `getExtraHeaders` method (existing tests already cover these extra headers being added to manifest requests).

Also ran the following manual tests on both iOS and Android, to ensure things behaved as expected in the various different client scenarios.
- Set up an express server that logs requests
    - build a bare app with update URL pointing to this server, ensure headers are actually included in requests
- bare app with expo-updates enabled, release build
    - add logging to headers method
    - ensure correct headers are included in initial request, checkForUpdateAsync, fetchUpdateAsync requests
    - download an update, restart app, ensure new IDs are correct
- Development client build, opening a published update
    - add logging to headers method
    - ensure headers are not included in initial request
    - expo-current-update-id is defined in requests from checkForUpdateAsync/fetchUpdateAsync
    - expo-embedded-update-id is not included in initial, subsequent, or check/fetchAsync requests
    - expo-updates-environment value is different (DEVELOPMENT)
- Expo Go, opening a published update
    - add logging to headers method
    - ensure headers are not included in initial request (though they are included in subsequent requests)
    - expo-current-update-id is defined in requests from checkForUpdateAsync/fetchUpdateAsync
    - expo-embedded-update-id is not included in initial, subsequent, or check/fetchAsync requests
    - expo-updates-environment value is different (EXPO_DEVICE)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
