### PR TITLE
[ios] [expo-av] fix: prevent race conditions

### DIFF
--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - On Android fix crashes caused by accessing player from the wrong thread ([#16611](https://github.com/expo/expo/pull/16611) by [@mnightingale](https://github.com/mnightingale))
 
-- On iOS fix crash caused by updating `AVPlaybackStatus` from both `<Video />` props and
+- On iOS fix crash caused by updating `AVPlaybackStatus` from both `<Video />` props and ([#17036](https://github.com/expo/expo/pull/17036) by [@Pickleboyonline](https://github.com/Pickleboyonline))
   the Playback API at the same time. Also prevented a crash on iOS caused by removing the Video without unlisting its underlying native `EXAVPlayerData` as an observer. ([#17036](https://github.com/expo/expo/pull/17036) by [@Pickleboyonline](https://github.com/Pickleboyonline))
 
 ### 💡 Others

--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -13,7 +13,7 @@
 - On Android fix crashes caused by accessing player from the wrong thread ([#16611](https://github.com/expo/expo/pull/16611) by [@mnightingale](https://github.com/mnightingale))
 
 - On iOS fix crash caused by updating `AVPlaybackStatus` from both `<Video />` props and
-the Playback API at the same time. Also prevented a crash on iOS caused by removing the Video without unlisting its underlying native `EXAVPlayerData` as an observer. ([#17036])(https://github.com/expo/expo/pull/17036) by [@Pickleboyonline](https://github.com/Pickleboyonline)
+  the Playback API at the same time. Also prevented a crash on iOS caused by removing the Video without unlisting its underlying native `EXAVPlayerData` as an observer. ([#17036](https://github.com/expo/expo/pull/17036) by [@Pickleboyonline](https://github.com/Pickleboyonline))
 
 ### 💡 Others
 

--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 - On Android fix crashes caused by accessing player from the wrong thread ([#16611](https://github.com/expo/expo/pull/16611) by [@mnightingale](https://github.com/mnightingale))
 
+- On iOS fix crash caused by updating `AVPlaybackStatus` from both `<Video />` props and
+the Playback API at the same time. Also prevented a crash on iOS caused by removing the Video without unlisting its underlying native `EXAVPlayerData` as an observer. ([#17036])(https://github.com/expo/expo/pull/17036) by [@Pickleboyonline](https://github.com/Pickleboyonline)
+
 ### 💡 Others
 
 - Extract `tolerances` param type definition, used across the package methods, to the separate type `AVPlaybackTolerance`. ([#16905](https://github.com/expo/expo/pull/16905) by [@Simek](https://github.com/Simek))

--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -12,8 +12,7 @@
 
 - On Android fix crashes caused by accessing player from the wrong thread ([#16611](https://github.com/expo/expo/pull/16611) by [@mnightingale](https://github.com/mnightingale))
 
-- On iOS fix crash caused by updating `AVPlaybackStatus` from both `<Video />` props and ([#17036](https://github.com/expo/expo/pull/17036) by [@Pickleboyonline](https://github.com/Pickleboyonline))
-  the Playback API at the same time. Also prevented a crash on iOS caused by removing the Video without unlisting its underlying native `EXAVPlayerData` as an observer. ([#17036](https://github.com/expo/expo/pull/17036) by [@Pickleboyonline](https://github.com/Pickleboyonline))
+- On iOS fix crash caused by updating `AVPlaybackStatus` from both `<Video />` props and  the Playback API at the same time. Also prevented a crash on iOS caused by removing the Video without unlisting its underlying native `EXAVPlayerData` as an observer. ([#17036](https://github.com/expo/expo/pull/17036) by [@Pickleboyonline](https://github.com/Pickleboyonline))
 
 ### 💡 Others
 

--- a/packages/expo-av/ios/EXAV/EXAV.m
+++ b/packages/expo-av/ios/EXAV/EXAV.m
@@ -207,7 +207,7 @@ EX_EXPORT_MODULE(ExponentAV);
 {
   return @"ExponentAV";
 }
-// ! This might need main thread setup
+
 // Both RCTBridgeModule and EXExportedModule define `constantsToExport`. We implement
 // that method for the latter, but React Bridge displays a yellow LogBox warning:
 // "Module EXAV requires main queue setup since it overrides `constantsToExport` but doesn't implement `requiresMainQueueSetup`."
@@ -215,7 +215,9 @@ EX_EXPORT_MODULE(ExponentAV);
 // we just need this to dismiss that warning.
 + (BOOL)requiresMainQueueSetup
 {
-  return NO;
+  // We are now using main thread to avoid thread safety issues with `EXAVPlayerData` and `EXVideoView`
+  // return `YES` to avoid deadlock warnings.
+  return YES;
 }
 
 #pragma mark - RCTEventEmitter

--- a/packages/expo-av/ios/EXAV/EXAV.m
+++ b/packages/expo-av/ios/EXAV/EXAV.m
@@ -207,7 +207,7 @@ EX_EXPORT_MODULE(ExponentAV);
 {
   return @"ExponentAV";
 }
-
+// ! This might need main thread setup
 // Both RCTBridgeModule and EXExportedModule define `constantsToExport`. We implement
 // that method for the latter, but React Bridge displays a yellow LogBox warning:
 // "Module EXAV requires main queue setup since it overrides `constantsToExport` but doesn't implement `requiresMainQueueSetup`."
@@ -1049,6 +1049,11 @@ EX_EXPORT_METHOD_AS(setInput,
   } else {
     reject(@"E_AUDIO_SETINPUT_FAIL", [NSString stringWithFormat:@"Preferred input '%@' not found!", input], nil);
   }
+}
+
+- (dispatch_queue_t)methodQueue
+{
+  return dispatch_get_main_queue();
 }
 
 #pragma mark - Lifecycle

--- a/packages/expo-av/ios/EXAV/EXAV.m
+++ b/packages/expo-av/ios/EXAV/EXAV.m
@@ -823,7 +823,7 @@ EX_EXPORT_METHOD_AS(setStatusForVideo,
                     rejecter:(EXPromiseRejectBlock)reject)
 {
   [self _runBlock:^(EXVideoView *view) {
-    [view setStatus:status resolver:resolve rejecter:reject];
+    [view setStatusFromPlaybackAPI:status resolver:resolve rejecter:reject];
   } withEXVideoViewForTag:reactTag withRejecter:reject];
 }
 

--- a/packages/expo-av/ios/EXAV/EXAVPlayerData.h
+++ b/packages/expo-av/ios/EXAV/EXAVPlayerData.h
@@ -32,4 +32,6 @@
                 resolver:(EXPromiseResolveBlock)resolve
                 rejecter:(EXPromiseRejectBlock)reject;
 
+- (void)cleanup;
+
 @end

--- a/packages/expo-av/ios/EXAV/EXAVPlayerData.m
+++ b/packages/expo-av/ios/EXAV/EXAVPlayerData.m
@@ -1066,12 +1066,21 @@ void EXTapProcess(MTAudioProcessingTapRef tap, CMItemCount numberFrames, MTAudio
 
 #pragma mark - NSObject Lifecycle
 
-- (void)dealloc
+/*
+ * Call this synchronously on the main thread to remove the EXAVPlayerData
+ * as an observer before KVO messages are broadcasted on the main thread.
+ */
+- (void)cleanup
 {
   // this triggers the audio tap removal
   [self setSampleBufferCallback:nil];
   [self _removeTimeObserver];
   [self _removeObservers];
+}
+
+- (void)dealloc
+{
+  [self cleanup];
 }
 
 # pragma mark - Utilities

--- a/packages/expo-av/ios/EXAV/Video/EXVideoView.h
+++ b/packages/expo-av/ios/EXAV/Video/EXVideoView.h
@@ -45,4 +45,8 @@ typedef NS_OPTIONS(NSUInteger, EXVideoFullscreenUpdate)
              resolver:(EXPromiseResolveBlock)resolve
              rejecter:(EXPromiseRejectBlock)reject;
 
+- (void)setStatusFromPlaybackAPI:(NSDictionary *)status
+                        resolver:(EXPromiseResolveBlock)resolve
+                        rejecter:(EXPromiseRejectBlock)reject;
+
 @end

--- a/packages/expo-av/ios/EXAV/Video/EXVideoView.m
+++ b/packages/expo-av/ios/EXAV/Video/EXVideoView.m
@@ -480,6 +480,11 @@ static NSString *const EXAVFullScreenViewControllerClassName = @"AVFullScreenVie
 {
   if (![source isEqualToDictionary:_lastSetSource]) {
     EX_WEAKIFY(self);
+    // ? Why dispatch to _exAV.methodQueue rather than remain on the main thread?
+    // ? Can lead to race conditions with Imperative API being sent on the main thread.
+    // ? I've made Imperative API dispatch to _exAV.methodQueue since I do not know
+    // ? the reason for it, but ultimately I believe Prop setters should run on the main thread
+    // ? rather than move Imperative API methods to _exAV.methodQueue.
     dispatch_async(_exAV.methodQueue, ^{
       EX_ENSURE_STRONGIFY(self);
       self.lastSetSource = source;
@@ -563,6 +568,11 @@ static NSString *const EXAVFullScreenViewControllerClassName = @"AVFullScreenVie
 - (void)setStatus:(NSDictionary *)status
 {
   EX_WEAKIFY(self);
+  // ? Why dispatch to _exAV.methodQueue rather than remain on the main thread?
+  // ? Can lead to race conditions with Imperative API being sent on the main thread.
+  // ? I've made Imperative API dispatch to _exAV.methodQueue since I do not know
+  // ? the reason for it, but ultimately I believe Prop setters should run on the main thread
+  // ? rather than move Imperative API methods to _exAV.methodQueue.
   dispatch_async(_exAV.methodQueue, ^{
     EX_ENSURE_STRONGIFY(self);
     [self setStatus:status resolver:nil rejecter:nil];

--- a/packages/expo-av/ios/EXAV/Video/EXVideoView.m
+++ b/packages/expo-av/ios/EXAV/Video/EXVideoView.m
@@ -131,7 +131,8 @@ static NSString *const EXAVFullScreenViewControllerClassName = @"AVFullScreenVie
     }
   };
   // Remove EXAVPlayerData on main thread to prevent race conditions
-  // with KVO messages being sent while dealloc is running
+  // while KVO messages are dispatched on main thread while the player data is
+  // de-allocating  
   [EXUtilities performSynchronouslyOnMainThread:block];
 }
 

--- a/packages/expo-av/ios/EXAV/Video/EXVideoView.m
+++ b/packages/expo-av/ios/EXAV/Video/EXVideoView.m
@@ -373,6 +373,17 @@ static NSString *const EXAVFullScreenViewControllerClassName = @"AVFullScreenVie
   [self _tryUpdateDataStatus:resolve rejecter:reject];
 }
 
+- (void)setStatusFromPlaybackAPI:(NSDictionary *)status
+                        resolver:(EXPromiseResolveBlock)resolve
+                        rejecter:(EXPromiseRejectBlock)reject;
+{
+  EX_WEAKIFY(self);
+  dispatch_async(_exAV.methodQueue, ^{
+    EX_ENSURE_STRONGIFY(self);
+    [self setStatus:status resolver:resolve rejecter:reject];
+  });
+}
+
 - (void)replayWithStatus:(NSDictionary *)status
                 resolver:(EXPromiseResolveBlock)resolve
                 rejecter:(EXPromiseRejectBlock)reject

--- a/packages/expo-av/ios/EXAV/Video/EXVideoView.m
+++ b/packages/expo-av/ios/EXAV/Video/EXVideoView.m
@@ -131,7 +131,7 @@ static NSString *const EXAVFullScreenViewControllerClassName = @"AVFullScreenVie
     }
   };
   // Remove EXAVPlayerData on main thread to prevent race conditions
-  // while KVO messages are dispatched on main thread while the player data is
+  // while KVO messages are dispatched on main thread and the player data is
   // de-allocating  
   [EXUtilities performSynchronouslyOnMainThread:block];
 }

--- a/packages/expo-av/ios/EXAV/Video/EXVideoView.m
+++ b/packages/expo-av/ios/EXAV/Video/EXVideoView.m
@@ -118,14 +118,19 @@ static NSString *const EXAVFullScreenViewControllerClassName = @"AVFullScreenVie
   }
 }
 
-- (void)_removeData
-{
-  if (_data) {
-    [_data pauseImmediately];
-    [_data setStatusUpdateCallback:nil];
-    [_exAV demoteAudioSessionIfPossible];
-    _data = nil;
-  }
+- (void)_removeData {
+  EX_WEAKIFY(self);
+  void (^block)(void) = ^{
+    EX_ENSURE_STRONGIFY(self);
+    if (self->_data) {
+      [self->_data cleanup];
+      [self->_data pauseImmediately];
+      [self->_data setStatusUpdateCallback:nil];
+      [self->_exAV demoteAudioSessionIfPossible];
+      self->_data = nil;
+    }
+  };
+  [EXUtilities performSynchronouslyOnMainThread:block];
 }
 
 - (void)_removePlayer

--- a/packages/expo-av/ios/EXAV/Video/EXVideoView.m
+++ b/packages/expo-av/ios/EXAV/Video/EXVideoView.m
@@ -130,6 +130,8 @@ static NSString *const EXAVFullScreenViewControllerClassName = @"AVFullScreenVie
       self->_data = nil;
     }
   };
+  // Remove EXAVPlayerData on main thread to prevent race conditions
+  // with KVO messages being sent while dealloc is running
   [EXUtilities performSynchronouslyOnMainThread:block];
 }
 


### PR DESCRIPTION
# Why
To prevent race conditions when updating the video status from props and the Imperative Playback API at the same time. Also, to prevent an `An -observeValueForKeyPath:ofObject:change:context: message was received but not handled.` error when a KVO message is being sent to a EXAVPlayerData object when it is being deallocated on a background thread.
A more detailed explanation can be found here: https://github.com/expo/expo/issues/16982#issuecomment-1097515627
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->


# How

<!--
How did you build this feature or fix this bug and why?
-->
I moved status updates to the `_exAV.methodQueue` queue so as to not compete with prop setters to update the status. 

I also created a separate `cleanup` method in EXAVPlayerData to call before an instance is deallocated so that we can explicitly remove it as an observer synchronously on the main thread to prevent race conditions when messages are dispatched through KVO.

Again, please read https://github.com/expo/expo/issues/16982#issuecomment-1097515627 for a more in-depth explanation of my fix along with questions and concerns. Any improvements are welcome as we would like to get this fixed ASAP!

I believe there could be more race conditions in this package due to how memory is utilized between `_exAV.methodQueue` and the main thread so there should be more auditing done here (possibly the source and replay updates?), but this change serves as a good start.

# Test Plan
A bit difficult to test and reproduce, but one could make an app where the Expo Video repeatedly pauses and plays from a prop update while seeking using the expo-av playback API. Eventually, you'll get a crash when the _statusToSet is mutated at the same time on some background thread in `_exAV.methodQueue` and on the main thread.

Also difficult to replicate the error `An -observeValueForKeyPath:ofObject:change:context: message was received but not handled.`, but I have confirmed that the EXAVPlayerData object is now removed as an observer synchronously on the main thread before it is deallocated by placing a breakpoint in the new `cleanup` method I added.
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [X] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
