### PR TITLE
[docs] authenticating to apple in eas build via asc token

### DIFF
--- a/docs/pages/build/building-on-ci.md
+++ b/docs/pages/build/building-on-ci.md
@@ -49,6 +49,19 @@ Next, we need to ensure that we can authenticate ourselves on CI as the owner of
 
 See [the guide for personal access tokens](/accounts/programmatic-access.md#personal-account-personal-access-tokens) to learn how to create access tokens.
 
+### (Optional) Provide an ASC Api Token for your Apple Team
+
+In the event your iOS credentials need to be repaired, we will need an ASC API key to authenticate ourselves to Apple in CI. A common case is when your provisioning profile needs to be re-signed.
+
+You will need to create an [API Key](https://expo.fyi/creating-asc-api-key). Next, you will need to gather information about your [Apple Team](https://expo.fyi/apple-team). 
+
+Using the information you've gathered, pass it into the build command through environment variables. You will need to pass in the following:
+- `EXPO_ASC_API_KEY_PATH`: the path to your ASC API Key .p8 file (e.g.) /path/to/key/AuthKey_SFB993FB5F.p8
+- `EXPO_ASC_KEY_ID`: the key ID of your ASC API Key (e.g.) SFB993FB5F.
+- `EXPO_ASC_ISSUER_ID`: the issuer ID of your ASC API Key (e.g.) f9675cff-f45d-4116-bd2c-2372142cee09.
+- `EXPO_APPLE_TEAM_ID`: your Apple Team ID (e.g.) 77KQ969CHE.
+- `EXPO_APPLE_TEAM_TYPE`: your Apple Team Type. Valid types are `IN_HOUSE`, `COMPANY_OR_ORGANIZATION` or `INDIVIDUAL`. 
+
 ### Trigger new builds
 
 Now that we're authenticated with Expo CLI, we can create the build step.

--- a/docs/pages/build/building-on-ci.md
+++ b/docs/pages/build/building-on-ci.md
@@ -56,11 +56,11 @@ In the event your iOS credentials need to be repaired, we will need an ASC API k
 You will need to create an [API Key](https://expo.fyi/creating-asc-api-key). Next, you will need to gather information about your [Apple Team](https://expo.fyi/apple-team). 
 
 Using the information you've gathered, pass it into the build command through environment variables. You will need to pass in the following:
-- `EXPO_ASC_API_KEY_PATH`: the path to your ASC API Key .p8 file (e.g.) /path/to/key/AuthKey_SFB993FB5F.p8
-- `EXPO_ASC_KEY_ID`: the key ID of your ASC API Key (e.g.) SFB993FB5F.
-- `EXPO_ASC_ISSUER_ID`: the issuer ID of your ASC API Key (e.g.) f9675cff-f45d-4116-bd2c-2372142cee09.
-- `EXPO_APPLE_TEAM_ID`: your Apple Team ID (e.g.) 77KQ969CHE.
-- `EXPO_APPLE_TEAM_TYPE`: your Apple Team Type. Valid types are `IN_HOUSE`, `COMPANY_OR_ORGANIZATION` or `INDIVIDUAL`. 
+- `EXPO_ASC_API_KEY_PATH`: the path to your ASC API Key .p8 file, e.g. /path/to/key/AuthKey_SFB993FB5F.p8
+- `EXPO_ASC_KEY_ID`: the key ID of your ASC API Key, e.g. SFB993FB5F.
+- `EXPO_ASC_ISSUER_ID`: the issuer ID of your ASC API Key, e.g. f9675cff-f45d-4116-bd2c-2372142cee09.
+- `EXPO_APPLE_TEAM_ID`: your Apple Team ID, e.g. 77KQ969CHE.
+- `EXPO_APPLE_TEAM_TYPE`: your Apple Team Type. Valid types are `IN_HOUSE`, `COMPANY_OR_ORGANIZATION`, or `INDIVIDUAL`. 
 
 ### Trigger new builds
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Add documentation to authenticate to Apple in `eas build` for CI mode from https://github.com/expo/eas-cli/pull/1051

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).

