### PR TITLE
[docs][MapView] backport keystore clarification to v44.0.0

### DIFF
--- a/docs/pages/versions/v44.0.0/sdk/map-view.md
+++ b/docs/pages/versions/v44.0.0/sdk/map-view.md
@@ -138,7 +138,7 @@ To use this in web, add the following script to your **web/index.html**. This sc
 
 ## How to retrieve your debug keystore fingerprint (Android only)
 
-When building a debug version of your application outside of Expo Go (for example, when using a [development client](https://docs.expo.dev/development/introduction/) or a standalone debug build), your app will be signed with the debug keystore on Android.
+When building a debug version of your application outside of Expo Go (for example, when using a [development client](/development/introduction/) or a standalone debug build), your app will be signed with the debug keystore on Android.
 > All standard Expo templates use a debug keystore with fingerprint `5E:8F:16:06:2E:A3:CD:2C:4A:0D:54:78:76:BA:A6:F3:8C:AB:F6:25`, that you can enter directly in the Google Cloud Credential Manager. So if you are using one of the standard Expo templates, you don't need to perform the steps below.
 The debug keystore location and password is defined in your `android/app/build.gradle` file like this:
 ```groovy

--- a/docs/pages/versions/v44.0.0/sdk/map-view.md
+++ b/docs/pages/versions/v44.0.0/sdk/map-view.md
@@ -69,6 +69,7 @@ No additional configuration is necessary to use `react-native-maps` in Expo Go. 
   - Go to the [Google Play Console](https://play.google.com/console) → (your app) → Setup → App Integrity
   - Copy the value of _SHA-1 certificate fingerprint_
 - **If you are sideloading your APK or deploying it to another store**, you will need to have [created a standalone app](../../../distribution/building-standalone-apps.md), then run `expo fetch:android:hashes` and copy the _Google Certificate Fingerprint_.
+- **If you are running a _debug_ build (development client or local debug build)**, your Android app will be signed using the debug keystore. See the instructions [below](#how-to-retrieve-your-debug-keystore-fingerprint-android-only) on how to retrieve your fingerprint.
 
 #### 3. Create an API key
 
@@ -133,4 +134,25 @@ To use this in web, add the following script to your **web/index.html**. This sc
 
   <!-- <body /> -->
 </html>
+```
+
+## How to retrieve your debug keystore fingerprint (Android only)
+
+When building a debug version of your application outside of Expo Go (for example, when using a [development client](https://docs.expo.dev/development/introduction/) or a standalone debug build), your app will be signed with the debug keystore on Android.
+> All standard Expo templates use a debug keystore with fingerprint `5E:8F:16:06:2E:A3:CD:2C:4A:0D:54:78:76:BA:A6:F3:8C:AB:F6:25`, that you can enter directly in the Google Cloud Credential Manager. So if you are using one of the standard Expo templates, you don't need to perform the steps below.
+The debug keystore location and password is defined in your `android/app/build.gradle` file like this:
+```groovy
+signingConfigs {
+    debug {
+        storeFile file('debug.keystore')
+        storePassword 'android'
+        keyAlias 'androiddebugkey'
+        keyPassword 'android'
+    }
+}
+``` 
+You can view the fingerprint for this keystore using the `keytool` command, and entering the storePassword. Copy the value shown after `SHA1:`
+```bash
+❯ keytool -list -v -keystore ./android/app/debug.keystore
+Enter keystore password: 
 ```


### PR DESCRIPTION
# Why

https://github.com/expo/expo/pull/15883 should have been backported to v44.0.0, but I forgot.

# How

Applied the same changes from the other PR manually.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
