### PR TITLE
[home] fix missing border, don't show feedback on borders when pressed, show feedback on HELP/CLEAR text buttons 

### DIFF
--- a/dev-home-config.json
+++ b/dev-home-config.json
@@ -1,3 +1,3 @@
 {
-  "url": "exp://exp.host/@expo-home-dev/expo-home-dev-0412efb4eeb7d7fe6f3f5f08a1dd78d60b02fabc"
+  "url": "exp://exp.host/@expo-home-dev/expo-home-dev-F9O0C1Vv"
 }

--- a/home/components/BranchListItem.tsx
+++ b/home/components/BranchListItem.tsx
@@ -42,63 +42,67 @@ export function BranchListItem({
   };
 
   return (
-    <TouchableOpacity onPress={handlePressBranch}>
-      <View
-        padding="medium"
-        bg="default"
-        border="default"
-        roundedTop={first ? 'large' : undefined}
-        roundedBottom={last ? 'large' : undefined}
-        style={{
-          borderBottomWidth: last ? 1 : 0,
-          borderTopWidth: first ? 1 : 0,
-        }}>
-        <Row align="center" justify="between">
-          <View align="start" flex="1">
-            <Row align="center">
-              <BranchIcon color={theme.icon.default} size={iconSize.small} />
-              <Spacer.Horizontal size="tiny" />
-              <Text ellipsizeMode="tail" numberOfLines={1} type="InterMedium">
-                Branch: {name}
-              </Text>
-            </Row>
-            {message && (
-              <>
-                <View flex="0" height="2" />
-                <Row flex="1">
-                  <Spacer.Horizontal size="medium" />
-                  <UpdateIcon color={theme.icon.secondary} size={iconSize.small} />
-                  <Spacer.Horizontal size="tiny" />
-                  <View flex="1">
-                    <Text
-                      type="InterRegular"
-                      color="secondary"
-                      size="small"
-                      ellipsizeMode="middle"
-                      numberOfLines={1}>
-                      "{message}"
-                    </Text>
-                    <Spacer.Vertical size="tiny" />
-                    <Text
-                      type="InterRegular"
-                      color="secondary"
-                      size="small"
-                      ellipsizeMode="tail"
-                      numberOfLines={1}>
-                      Published {format(new Date(createdAt), DateFormats.timestamp)}
-                    </Text>
-                  </View>
-                </Row>
-              </>
-            )}
-          </View>
-          <Spacer.Horizontal size="tiny" />
-          <ChevronDownIcon
-            style={{ transform: [{ rotate: '-90deg' }] }}
-            color={theme.icon.secondary}
-          />
-        </Row>
-      </View>
-    </TouchableOpacity>
+    <View
+      border="default"
+      roundedTop={first ? 'large' : undefined}
+      roundedBottom={last ? 'large' : undefined}
+      style={{
+        borderBottomWidth: last ? 1 : 0,
+        borderTopWidth: first ? 1 : 0,
+      }}>
+      <TouchableOpacity onPress={handlePressBranch}>
+        <View
+          padding="medium"
+          bg="default"
+          roundedTop={first ? 'large' : undefined}
+          roundedBottom={last ? 'large' : undefined}>
+          <Row align="center" justify="between">
+            <View align="start" flex="1">
+              <Row align="center">
+                <BranchIcon color={theme.icon.default} size={iconSize.small} />
+                <Spacer.Horizontal size="tiny" />
+                <Text ellipsizeMode="tail" numberOfLines={1} type="InterMedium">
+                  Branch: {name}
+                </Text>
+              </Row>
+              {message && (
+                <>
+                  <View flex="0" height="2" />
+                  <Row flex="1">
+                    <Spacer.Horizontal size="medium" />
+                    <UpdateIcon color={theme.icon.secondary} size={iconSize.small} />
+                    <Spacer.Horizontal size="tiny" />
+                    <View flex="1">
+                      <Text
+                        type="InterRegular"
+                        color="secondary"
+                        size="small"
+                        ellipsizeMode="middle"
+                        numberOfLines={1}>
+                        "{message}"
+                      </Text>
+                      <Spacer.Vertical size="tiny" />
+                      <Text
+                        type="InterRegular"
+                        color="secondary"
+                        size="small"
+                        ellipsizeMode="tail"
+                        numberOfLines={1}>
+                        Published {format(new Date(createdAt), DateFormats.timestamp)}
+                      </Text>
+                    </View>
+                  </Row>
+                </>
+              )}
+            </View>
+            <Spacer.Horizontal size="tiny" />
+            <ChevronDownIcon
+              style={{ transform: [{ rotate: '-90deg' }] }}
+              color={theme.icon.secondary}
+            />
+          </Row>
+        </View>
+      </TouchableOpacity>
+    </View>
   );
 }

--- a/home/components/ProjectsListItem.tsx
+++ b/home/components/ProjectsListItem.tsx
@@ -36,64 +36,69 @@ export function ProjectsListItem({ imageURL, name, subtitle, sdkVersion, id, fir
   }
 
   return (
-    <TouchableOpacity onPress={onPress}>
-      <View
-        padding="medium"
-        bg="default"
-        border="default"
-        roundedTop={first ? 'large' : undefined}
-        roundedBottom={last ? 'large' : undefined}
-        style={{
-          borderBottomWidth: last ? 1 : 0,
-          borderTopWidth: first ? 1 : 0,
-        }}>
-        <Row align="center" justify="between">
-          <Row align="center" flex="1">
-            <AppIcon image={imageURL} />
-            <View flex="1">
-              <Text
-                type="InterSemiBold"
-                style={styles.titleText}
-                ellipsizeMode="tail"
-                numberOfLines={1}>
-                {name}
-              </Text>
-              {subtitle ? (
-                <>
-                  <Spacer.Vertical size="tiny" />
-                  <Text
-                    type="InterRegular"
-                    size="small"
-                    color="secondary"
-                    ellipsizeMode="tail"
-                    numberOfLines={1}>
-                    {subtitle}
-                  </Text>
-                </>
-              ) : null}
-              {sdkVersionNumber ? (
-                <>
-                  <Spacer.Vertical size="tiny" />
-                  <Text
-                    type="InterRegular"
-                    size="small"
-                    color="secondary"
-                    ellipsizeMode="tail"
-                    numberOfLines={1}>
-                    SDK {sdkVersionNumber}
-                    {isExpired ? ': Not supported' : ''}
-                  </Text>
-                </>
-              ) : null}
-            </View>
+    <View
+      border="default"
+      roundedTop={first ? 'large' : undefined}
+      roundedBottom={last ? 'large' : undefined}
+      overflow="hidden"
+      style={{
+        borderBottomWidth: last ? 1 : 0,
+        borderTopWidth: first ? 1 : 0,
+      }}>
+      <TouchableOpacity onPress={onPress}>
+        <View
+          padding="medium"
+          bg="default"
+          roundedTop={first ? 'large' : undefined}
+          roundedBottom={last ? 'large' : undefined}>
+          <Row align="center" justify="between">
+            <Row align="center" flex="1">
+              <AppIcon image={imageURL} />
+              <View flex="1">
+                <Text
+                  type="InterSemiBold"
+                  style={styles.titleText}
+                  ellipsizeMode="tail"
+                  numberOfLines={1}>
+                  {name}
+                </Text>
+                {subtitle ? (
+                  <>
+                    <Spacer.Vertical size="tiny" />
+                    <Text
+                      type="InterRegular"
+                      size="small"
+                      color="secondary"
+                      ellipsizeMode="tail"
+                      numberOfLines={1}>
+                      {subtitle}
+                    </Text>
+                  </>
+                ) : null}
+                {sdkVersionNumber ? (
+                  <>
+                    <Spacer.Vertical size="tiny" />
+                    <Text
+                      type="InterRegular"
+                      size="small"
+                      color="secondary"
+                      ellipsizeMode="tail"
+                      numberOfLines={1}>
+                      SDK {sdkVersionNumber}
+                      {isExpired ? ': Not supported' : ''}
+                    </Text>
+                  </>
+                ) : null}
+              </View>
+            </Row>
+            <ChevronDownIcon
+              style={{ transform: [{ rotate: '-90deg' }] }}
+              color={theme.icon.secondary}
+            />
           </Row>
-          <ChevronDownIcon
-            style={{ transform: [{ rotate: '-90deg' }] }}
-            color={theme.icon.secondary}
-          />
-        </Row>
-      </View>
-    </TouchableOpacity>
+        </View>
+      </TouchableOpacity>
+    </View>
   );
 }
 

--- a/home/components/SnacksListItem.tsx
+++ b/home/components/SnacksListItem.tsx
@@ -43,47 +43,52 @@ export function SnacksListItem({ description, isDraft, name, url, first, last }:
   const normalizedDescription = normalizeDescription(description);
 
   return (
-    <TouchableOpacity onPress={handlePressProject} onLongPress={handleLongPressProject}>
-      <View
-        padding="medium"
-        bg="default"
-        border="default"
-        roundedTop={first ? 'large' : undefined}
-        roundedBottom={last ? 'large' : undefined}
-        style={{
-          borderBottomWidth: last ? 1 : 0,
-          borderTopWidth: first ? 1 : 0,
-        }}>
-        <Row align="center" justify="between">
-          <View align="start" flex="1">
-            <Text type="InterSemiBold" ellipsizeMode="tail" numberOfLines={1}>
-              {name}
-            </Text>
-            {normalizedDescription && (
-              <>
-                <Spacer.Vertical size="tiny" />
-                <Text type="InterSemiBold" size="small" ellipsizeMode="tail" numberOfLines={1}>
-                  {normalizedDescription}
-                </Text>
-              </>
-            )}
-            {isDraft && (
-              <>
-                <Spacer.Vertical size="tiny" />
-                <View bg="secondary" rounded="medium" flex="0" padding="tiny" border="default">
-                  <Text size="small" type="InterRegular">
-                    Draft
+    <View
+      border="default"
+      roundedTop={first ? 'large' : undefined}
+      roundedBottom={last ? 'large' : undefined}
+      overflow="hidden"
+      style={{
+        borderBottomWidth: last ? 1 : 0,
+        borderTopWidth: first ? 1 : 0,
+      }}>
+      <TouchableOpacity onPress={handlePressProject} onLongPress={handleLongPressProject}>
+        <View
+          padding="medium"
+          bg="default"
+          roundedTop={first ? 'large' : undefined}
+          roundedBottom={last ? 'large' : undefined}>
+          <Row align="center" justify="between">
+            <View align="start" flex="1">
+              <Text type="InterSemiBold" ellipsizeMode="tail" numberOfLines={1}>
+                {name}
+              </Text>
+              {normalizedDescription && (
+                <>
+                  <Spacer.Vertical size="tiny" />
+                  <Text type="InterSemiBold" size="small" ellipsizeMode="tail" numberOfLines={1}>
+                    {normalizedDescription}
                   </Text>
-                </View>
-              </>
-            )}
-          </View>
-          <ChevronDownIcon
-            style={{ transform: [{ rotate: '-90deg' }] }}
-            color={theme.icon.secondary}
-          />
-        </Row>
-      </View>
-    </TouchableOpacity>
+                </>
+              )}
+              {isDraft && (
+                <>
+                  <Spacer.Vertical size="tiny" />
+                  <View bg="secondary" rounded="medium" flex="0" padding="tiny" border="default">
+                    <Text size="small" type="InterRegular">
+                      Draft
+                    </Text>
+                  </View>
+                </>
+              )}
+            </View>
+            <ChevronDownIcon
+              style={{ transform: [{ rotate: '-90deg' }] }}
+              color={theme.icon.secondary}
+            />
+          </Row>
+        </View>
+      </TouchableOpacity>
+    </View>
   );
 }

--- a/home/components/UpdateListItem.tsx
+++ b/home/components/UpdateListItem.tsx
@@ -29,13 +29,16 @@ export function UpdateListItem({ id, message, createdAt, manifestPermalink, firs
       border="default"
       roundedTop={first ? 'large' : undefined}
       roundedBottom={last ? 'large' : undefined}
-      overflow="hidden"
       style={{
         borderBottomWidth: last ? 1 : 0,
         borderTopWidth: first ? 1 : 0,
       }}>
       <TouchableOpacity onPress={handlePress}>
-        <View padding="medium" bg="default" roundedTop={first ? 'large' : undefined}>
+        <View
+          padding="medium"
+          bg="default"
+          roundedTop={first ? 'large' : undefined}
+          roundedBottom={last ? 'large' : undefined}>
           <Row align="center" justify="between">
             <View align="start" flex="1">
               <Row flex="1">

--- a/home/components/UpdateListItem.tsx
+++ b/home/components/UpdateListItem.tsx
@@ -25,45 +25,46 @@ export function UpdateListItem({ id, message, createdAt, manifestPermalink, firs
   };
 
   return (
-    <TouchableOpacity onPress={handlePress}>
-      <View
-        padding="medium"
-        bg="default"
-        border="default"
-        roundedTop={first ? 'large' : undefined}
-        roundedBottom={last ? 'large' : undefined}
-        style={{
-          borderBottomWidth: last ? 1 : 0,
-          borderTopWidth: first ? 1 : 0,
-        }}>
-        <Row align="center" justify="between">
-          <View align="start" flex="1">
-            <Row flex="1">
-              <UpdateIcon color={theme.icon.default} size={iconSize.small} />
-              <Spacer.Horizontal size="tiny" />
-              <View flex="1">
-                <Text type="InterSemiBold" ellipsizeMode="middle" numberOfLines={1}>
-                  {message ? `"${message}"` : id}
-                </Text>
-                <Spacer.Vertical size="tiny" />
-                <Text
-                  type="InterRegular"
-                  color="secondary"
-                  size="small"
-                  ellipsizeMode="tail"
-                  numberOfLines={1}>
-                  Published {format(new Date(createdAt), DateFormats.timestamp)}
-                </Text>
-              </View>
-            </Row>
-          </View>
-          <Spacer.Horizontal size="tiny" />
-          <ChevronDownIcon
-            style={{ transform: [{ rotate: '-90deg' }] }}
-            color={theme.icon.secondary}
-          />
-        </Row>
-      </View>
-    </TouchableOpacity>
+    <View
+      border="default"
+      roundedTop={first ? 'large' : undefined}
+      roundedBottom={last ? 'large' : undefined}
+      overflow="hidden"
+      style={{
+        borderBottomWidth: last ? 1 : 0,
+        borderTopWidth: first ? 1 : 0,
+      }}>
+      <TouchableOpacity onPress={handlePress}>
+        <View padding="medium" bg="default" roundedTop={first ? 'large' : undefined}>
+          <Row align="center" justify="between">
+            <View align="start" flex="1">
+              <Row flex="1">
+                <UpdateIcon color={theme.icon.default} size={iconSize.small} />
+                <Spacer.Horizontal size="tiny" />
+                <View flex="1">
+                  <Text type="InterSemiBold" ellipsizeMode="middle" numberOfLines={1}>
+                    {message ? `"${message}"` : id}
+                  </Text>
+                  <Spacer.Vertical size="tiny" />
+                  <Text
+                    type="InterRegular"
+                    color="secondary"
+                    size="small"
+                    ellipsizeMode="tail"
+                    numberOfLines={1}>
+                    Published {format(new Date(createdAt), DateFormats.timestamp)}
+                  </Text>
+                </View>
+              </Row>
+            </View>
+            <Spacer.Horizontal size="tiny" />
+            <ChevronDownIcon
+              style={{ transform: [{ rotate: '-90deg' }] }}
+              color={theme.icon.secondary}
+            />
+          </Row>
+        </View>
+      </TouchableOpacity>
+    </View>
   );
 }

--- a/home/screens/HomeScreen/DevelopmentServersHeader.tsx
+++ b/home/screens/HomeScreen/DevelopmentServersHeader.tsx
@@ -1,6 +1,7 @@
 import { spacing } from '@expo/styleguide-native';
-import { Button, Heading, Row, TerminalIcon, View, Text } from 'expo-dev-client-components';
+import { Heading, Row, TerminalIcon, View, Text } from 'expo-dev-client-components';
 import * as React from 'react';
+import { TouchableOpacity } from 'react-native-gesture-handler';
 
 type DevelopmentServersHeaderProps = {
   onHelpPress: () => void;
@@ -21,17 +22,18 @@ export function DevelopmentServersHeader({ onHelpPress }: DevelopmentServersHead
           Development servers
         </Heading>
       </Row>
-      <Button.Container onPress={onHelpPress}>
+      <TouchableOpacity onPress={onHelpPress}>
         <Text
           type="InterSemiBold"
           color="secondary"
+          size="small"
           style={{
             fontSize: 11,
             letterSpacing: 0.92,
           }}>
           HELP
         </Text>
-      </Button.Container>
+      </TouchableOpacity>
     </Row>
   );
 }

--- a/home/screens/HomeScreen/ProjectsSection.tsx
+++ b/home/screens/HomeScreen/ProjectsSection.tsx
@@ -45,17 +45,19 @@ export function ProjectsSection({ apps, showMore, accountName }: Props) {
         );
       })}
       {showMore && (
-        <TouchableOpacity onPress={onSeeAllProjectsPress}>
-          <View padding="medium" bg="default" border="default" roundedBottom="large">
-            <Row align="center" justify="between">
-              <Text type="InterRegular">See all projects</Text>
-              <ChevronDownIcon
-                style={{ transform: [{ rotate: '-90deg' }] }}
-                color={theme.icon.secondary}
-              />
-            </Row>
-          </View>
-        </TouchableOpacity>
+        <View border="default" roundedBottom="large">
+          <TouchableOpacity onPress={onSeeAllProjectsPress}>
+            <View padding="medium" bg="default" roundedBottom="large">
+              <Row align="center" justify="between">
+                <Text type="InterRegular">See all projects</Text>
+                <ChevronDownIcon
+                  style={{ transform: [{ rotate: '-90deg' }] }}
+                  color={theme.icon.secondary}
+                />
+              </Row>
+            </View>
+          </TouchableOpacity>
+        </View>
       )}
     </View>
   );

--- a/home/screens/HomeScreen/RecentlyOpenedHeader.tsx
+++ b/home/screens/HomeScreen/RecentlyOpenedHeader.tsx
@@ -1,6 +1,7 @@
 import { spacing } from '@expo/styleguide-native';
-import { Button, Heading, Row, Text } from 'expo-dev-client-components';
+import { Heading, Row, Text } from 'expo-dev-client-components';
 import * as React from 'react';
+import { TouchableOpacity } from 'react-native-gesture-handler';
 
 type Props = {
   onClearPress: () => void;
@@ -16,7 +17,7 @@ export function RecentlyOpenedHeader({ onClearPress }: Props) {
         type="InterSemiBold">
         Recently opened
       </Heading>
-      <Button.Container onPress={onClearPress}>
+      <TouchableOpacity onPress={onClearPress}>
         <Text
           type="InterSemiBold"
           color="secondary"
@@ -26,7 +27,7 @@ export function RecentlyOpenedHeader({ onClearPress }: Props) {
           }}>
           CLEAR
         </Text>
-      </Button.Container>
+      </TouchableOpacity>
     </Row>
   );
 }

--- a/home/screens/HomeScreen/SnacksSection.tsx
+++ b/home/screens/HomeScreen/SnacksSection.tsx
@@ -44,17 +44,19 @@ export function SnacksSection({ snacks, showMore, accountName }: Props) {
         );
       })}
       {showMore && (
-        <TouchableOpacity onPress={onSeeAllSnacksPress}>
-          <View padding="medium" bg="default" border="default" roundedBottom="large">
-            <Row align="center" justify="between">
-              <Text type="InterRegular">See all snacks</Text>
-              <ChevronDownIcon
-                style={{ transform: [{ rotate: '-90deg' }] }}
-                color={theme.icon.secondary}
-              />
-            </Row>
-          </View>
-        </TouchableOpacity>
+        <View border="default" roundedBottom="large">
+          <TouchableOpacity onPress={onSeeAllSnacksPress}>
+            <View padding="medium" bg="default" roundedBottom="large">
+              <Row align="center" justify="between">
+                <Text type="InterRegular">See all snacks</Text>
+                <ChevronDownIcon
+                  style={{ transform: [{ rotate: '-90deg' }] }}
+                  color={theme.icon.secondary}
+                />
+              </Row>
+            </View>
+          </TouchableOpacity>
+        </View>
       )}
     </View>
   );

--- a/home/screens/ProjectScreen/EASUpdateLaunchSection.tsx
+++ b/home/screens/ProjectScreen/EASUpdateLaunchSection.tsx
@@ -63,7 +63,7 @@ export function EASUpdateLaunchSection({ app }: { app: ProjectPageApp }) {
           <Fragment key={branch.id}>
             <BranchListItem
               first={i === 0}
-              last={i === 2 && branchesToRender.length <= 3}
+              last={i === branchesToRender.length - 1}
               appId={app.id}
               name={branch.name}
               latestUpdate={branch.latestUpdate}

--- a/home/screens/ProjectScreen/EASUpdateLaunchSection.tsx
+++ b/home/screens/ProjectScreen/EASUpdateLaunchSection.tsx
@@ -73,15 +73,9 @@ export function EASUpdateLaunchSection({ app }: { app: ProjectPageApp }) {
         );
       })}
       {branchesToRender.length > 3 && (
-        <>
-          <Divider style={{ height: 1 }} />
+        <View border="default" roundedBottom="large">
           <TouchableOpacity onPress={onSeeAllBranchesPress}>
-            <View
-              padding="medium"
-              border="default"
-              bg="default"
-              style={{ borderTopWidth: 0 }}
-              roundedBottom="large">
+            <View padding="medium" bg="default" roundedBottom="large">
               <Row align="center" justify="between">
                 <Text type="InterRegular">See all branches</Text>
                 <ChevronDownIcon
@@ -91,7 +85,7 @@ export function EASUpdateLaunchSection({ app }: { app: ProjectPageApp }) {
               </Row>
             </View>
           </TouchableOpacity>
-        </>
+        </View>
       )}
     </View>
   );


### PR DESCRIPTION
# Why

@ide pointed out some UX issues when using the new `home` UI. This includes a missing bottom border on the Branches section of the project details page when there are 1 or 2 items, borders being included in the touch feedback, and a lack of feedback when pressing the text buttons on the Home screen.

# Test Plan

 ## "HELP" button feedback:
![IMG_4932](https://user-images.githubusercontent.com/12488826/163264375-a539a33c-6012-4a91-805e-2b9d27d2a191.PNG)

## Fixed branches section bottom border:
![IMG_4931](https://user-images.githubusercontent.com/12488826/163264376-3ce37739-16c2-4232-8630-7efb90d494ff.PNG)

## Pressing a list item doesn't also change the opacity of the border:`
![IMG_4930](https://user-images.githubusercontent.com/12488826/163264377-d148870e-fc86-4365-8ace-f4d9b8e75acc.PNG)

