### PR TITLE
[notifications] update build file

### DIFF
--- a/packages/expo-notifications/plugin/build/withNotifications.d.ts
+++ b/packages/expo-notifications/plugin/build/withNotifications.d.ts
@@ -1,14 +1,16 @@
 import { ConfigPlugin } from '@expo/config-plugins';
 export declare type NotificationsPluginProps = {
     /**
-     * (Android only) Local path to an image to use as the icon for push notifications.
+     * Local path to an image to use as the icon for push notifications.
      * 96x96 all-white png with transparency. We recommend following
      * [Google's design guidelines](https://material.io/design/iconography/product-icons.html#design-principles).
+     * @platform android
      */
     icon?: string;
     /**
-     * (Android only) Tint color for the push notification image when it appears in the notification tray.
+     * Tint color for the push notification image when it appears in the notification tray.
      * @default '#ffffff'
+     * @platform android
      */
     color?: string;
     /**
@@ -16,8 +18,9 @@ export declare type NotificationsPluginProps = {
      */
     sounds?: string[];
     /**
-     * (iOS only) Environment of the app: either 'development' or 'production'. Defaults to 'development'.
+     * Environment of the app: either 'development' or 'production'.
      * @default 'development'
+     * @platform ios
      */
     mode?: 'development' | 'production';
 };


### PR DESCRIPTION
> This is invalid PR, I have not stashed a part of other PR...

# Why

It looks like one of the Notification build file is not updated. 

# How

This change is a result of running `check-packages` locally, with build included.

# Test Plan

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
