### PR TITLE
[github] always use `ubuntu-20.04` in workflows

### DIFF
--- a/.github/workflows/android-unit-tests.yml
+++ b/.github/workflows/android-unit-tests.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 60
     env:
       ORG_GRADLE_PROJECT_reactNativeArchitectures: x86

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: 👀 Checkout a ref for the event
         uses: actions/checkout@v3

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: 👀 Checkout a ref for the event
         uses: actions/checkout@v3

--- a/.github/workflows/client-android.yml
+++ b/.github/workflows/client-android.yml
@@ -37,7 +37,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       GRADLE_OPTS: -Dorg.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=1024m
     steps:

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   code_review:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   code_review:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/commentator.yml
+++ b/.github/workflows/commentator.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   comment:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout a ref for the event
         uses: actions/checkout@v3

--- a/.github/workflows/commentator.yml
+++ b/.github/workflows/commentator.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   comment:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout a ref for the event
         uses: actions/checkout@v3

--- a/.github/workflows/development-client.yml
+++ b/.github/workflows/development-client.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   android:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/.github/workflows/development-client.yml
+++ b/.github/workflows/development-client.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   android:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   docs:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Install Node 14
         uses: actions/setup-node@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   docs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Install Node 14
         uses: actions/setup-node@v3

--- a/.github/workflows/dogfooding-clients.yml
+++ b/.github/workflows/dogfooding-clients.yml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   build-android:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/dogfooding-clients.yml
+++ b/.github/workflows/dogfooding-clients.yml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   build-android:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/expo-updates-cli.yml
+++ b/.github/workflows/expo-updates-cli.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: 👀 Checkout a ref for the event
         uses: actions/checkout@v3

--- a/.github/workflows/expo-updates-cli.yml
+++ b/.github/workflows/expo-updates-cli.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: 👀 Checkout a ref for the event
         uses: actions/checkout@v3

--- a/.github/workflows/expotools.yml
+++ b/.github/workflows/expotools.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/expotools.yml
+++ b/.github/workflows/expotools.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/home.yml
+++ b/.github/workflows/home.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:
@@ -59,7 +59,7 @@ jobs:
   publish-dogfood-home:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/home.yml
+++ b/.github/workflows/home.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
@@ -59,7 +59,7 @@ jobs:
   publish-dogfood-home:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/issue-attention.yml
+++ b/.github/workflows/issue-attention.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   issue:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: 8398a7/action-slack@v3.8.0
         if: ${{ contains( env.TRUSTED_USERS, github.event.issue.user.login ) }}

--- a/.github/workflows/issue-attention.yml
+++ b/.github/workflows/issue-attention.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   issue:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: 8398a7/action-slack@v3.8.0
         if: ${{ contains( env.TRUSTED_USERS, github.event.issue.user.login ) }}

--- a/.github/workflows/issue-stale.yml
+++ b/.github/workflows/issue-stale.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   close-issues:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/stale@v4
         with:

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   needs-repro:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: "${{ contains(github.event.label.name, 'incomplete issue: missing or invalid repro') }}"
     steps:
       - uses: actions/github-script@v3
@@ -49,7 +49,7 @@ jobs:
             })
 
   needs-info:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: "${{ contains(github.event.label.name, 'incomplete issue: missing info') }}"
     steps:
       - uses: actions/github-script@v3
@@ -78,7 +78,7 @@ jobs:
             })
 
   issue-accepted:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: github.event.label.name == 'issue accepted'
     steps:
       - uses: actions/github-script@v3
@@ -95,7 +95,7 @@ jobs:
             `})
 
   question:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: "${{ contains(github.event.label.name, 'invalid issue: question') }}"
     steps:
       - uses: actions/github-script@v3
@@ -123,7 +123,7 @@ jobs:
             })
 
   feature-request:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: "${{ contains(github.event.label.name, 'invalid issue: feature request') }}"
     steps:
       - uses: actions/github-script@v3

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   action:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: dessant/lock-threads@v3.0.0
         with:

--- a/.github/workflows/native-component-list.yml
+++ b/.github/workflows/native-component-list.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/native-component-list.yml
+++ b/.github/workflows/native-component-list.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/publish-demo.yml
+++ b/.github/workflows/publish-demo.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -33,7 +33,7 @@ concurrency:
 
 jobs:
   check-packages:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: 👀 Checkout a ref for the event
         uses: actions/checkout@v3

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -33,7 +33,7 @@ concurrency:
 
 jobs:
   check-packages:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: 👀 Checkout a ref for the event
         uses: actions/checkout@v3

--- a/.github/workflows/shell-app-android.yml
+++ b/.github/workflows/shell-app-android.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/shell-app-android.yml
+++ b/.github/workflows/shell-app-android.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/test-suite-lint.yml
+++ b/.github/workflows/test-suite-lint.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: ⬢ Setup Node
         uses: actions/setup-node@v3

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   web:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: ⬢ Setup Node
         uses: actions/setup-node@v3

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   web:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: ⬢ Setup Node
         uses: actions/setup-node@v3

--- a/.github/workflows/updates-e2e.yml
+++ b/.github/workflows/updates-e2e.yml
@@ -32,7 +32,7 @@ concurrency:
 
 jobs:
   android:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       UPDATES_PORT: 4747
     steps:

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
# Why

Currently, some of the workflow use `ubuntu-latest` as running environment, but there are also several using specific version `ubuntu-18.04`. AFAIK there should not be a reason to not use `latest` everywhere.

# How

This PR updates all Ubuntu workflows to use `ubuntu-latest` as running environment.

# Test Plan

Run the CI.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
