### PR TITLE
[Android][Expo Go][task-manager] Fix Android API 31+ runtime crash

### DIFF
--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -395,7 +395,7 @@ dependencies {
   implementation 'org.bouncycastle:bcutil-jdk15to18:1.70'
 
   // react-native-maps
-  implementation "androidx.work:work-runtime:2.5.0"
+  implementation "androidx.work:work-runtime:2.7.1"
 }
 
 

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.kt
@@ -8,6 +8,7 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import android.text.TextUtils
 import android.view.KeyEvent
@@ -24,8 +25,8 @@ import com.facebook.react.bridge.UiThreadUtil
 import com.facebook.soloader.SoLoader
 import de.greenrobot.event.EventBus
 import expo.modules.core.interfaces.Package
-import expo.modules.splashscreen.singletons.SplashScreen
 import expo.modules.manifests.core.Manifest
+import expo.modules.splashscreen.singletons.SplashScreen
 import host.exp.exponent.*
 import host.exp.exponent.ExpoUpdatesAppLoader.AppLoaderCallback
 import host.exp.exponent.ExpoUpdatesAppLoader.AppLoaderStatus
@@ -673,13 +674,16 @@ open class ExperienceActivity : BaseExperienceActivity(), StartReactInstanceDele
     val remoteViews = RemoteViews(packageName, R.layout.notification)
     remoteViews.setCharSequence(R.id.home_text_button, "setText", name)
 
+    // We're defaulting to the behaviour prior API 31 (mutable) even though Android recommends immutability
+    val mutableFlag = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) PendingIntent.FLAG_MUTABLE else 0
+
     // Home
     val homeIntent = Intent(this, LauncherActivity::class.java)
     remoteViews.setOnClickPendingIntent(
       R.id.home_image_button,
       PendingIntent.getActivity(
         this, 0,
-        homeIntent, 0
+        homeIntent, mutableFlag
       )
     )
 
@@ -688,7 +692,7 @@ open class ExperienceActivity : BaseExperienceActivity(), StartReactInstanceDele
       R.id.reload_button,
       PendingIntent.getService(
         this, 0,
-        ExponentIntentService.getActionReloadExperience(this, manifestUrl!!), PendingIntent.FLAG_UPDATE_CURRENT
+        ExponentIntentService.getActionReloadExperience(this, manifestUrl!!), PendingIntent.FLAG_UPDATE_CURRENT or mutableFlag
       )
     )
 

--- a/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/taskManager/TaskManagerUtils.java
+++ b/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/taskManager/TaskManagerUtils.java
@@ -8,6 +8,7 @@ import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Parcelable;
 import android.os.PersistableBundle;
@@ -43,7 +44,9 @@ public class TaskManagerUtils implements TaskManagerUtilsInterface {
 
   @Override
   public PendingIntent createTaskIntent(Context context, TaskInterface task) {
-    return createTaskIntent(context, task, PendingIntent.FLAG_UPDATE_CURRENT);
+    // We're defaulting to the behaviour prior API 31 (mutable) even though Android recommends immutability
+    int mutableFlag = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? PendingIntent.FLAG_MUTABLE : 0;
+    return createTaskIntent(context, task, PendingIntent.FLAG_UPDATE_CURRENT | mutableFlag);
   }
 
   @Override

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/taskManager/TaskManagerUtils.java
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/taskManager/TaskManagerUtils.java
@@ -8,6 +8,7 @@ import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Parcelable;
 import android.os.PersistableBundle;
@@ -43,7 +44,9 @@ public class TaskManagerUtils implements TaskManagerUtilsInterface {
 
   @Override
   public PendingIntent createTaskIntent(Context context, TaskInterface task) {
-    return createTaskIntent(context, task, PendingIntent.FLAG_UPDATE_CURRENT);
+    // We're defaulting to the behaviour prior API 31 (mutable) even though Android recommends immutability
+    int mutableFlag = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? PendingIntent.FLAG_MUTABLE : 0;
+    return createTaskIntent(context, task, PendingIntent.FLAG_UPDATE_CURRENT | mutableFlag);
   }
 
   @Override

--- a/packages/expo-task-manager/CHANGELOG.md
+++ b/packages/expo-task-manager/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed Android 12+ runtime crash caused by `PendingIntent` misconfiguration. ([#17052](https://github.com/expo/expo/pull/17052) by [@bbarthec](https://github.com/bbarthec))
+
 ### 💡 Others
 
 - Updated `@expo/config-plugins` from `4.0.2` to `4.0.14` ([#15621](https://github.com/expo/expo/pull/15621) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskManagerUtils.java
+++ b/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskManagerUtils.java
@@ -8,6 +8,7 @@ import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Parcelable;
 import android.os.PersistableBundle;
@@ -43,7 +44,9 @@ public class TaskManagerUtils implements TaskManagerUtilsInterface {
 
   @Override
   public PendingIntent createTaskIntent(Context context, TaskInterface task) {
-    return createTaskIntent(context, task, PendingIntent.FLAG_UPDATE_CURRENT);
+    // We're defaulting to the behaviour prior API 31 (mutable) even though Android recommends immutability
+    int mutableFlag = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? PendingIntent.FLAG_MUTABLE : 0;
+    return createTaskIntent(context, task, PendingIntent.FLAG_UPDATE_CURRENT | mutableFlag);
   }
 
   @Override


### PR DESCRIPTION
# Why

I was trying to start QA process on Android using Android emulator running Android API 32 and every time the app crashed.

# How

Since Android API 31 (Android 12) `PendingIntent` has to have either `FLAG_MUTABLE` or `FLAG_IMMUTABLE` set otherwise RuntimeError is thrown and the app crashes.
Prior Android API 31 the default behaviour was mutability so I've added the corresponding flag in every `PendingIntent` I've found.

I've read the `PendingIntent` warning message and adjusted the code and the suggestion from the error:
```
java.lang.IllegalArgumentException: host.exp.exponent: Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.
    Strongly consider using FLAG_IMMUTABLE, only use FLAG_MUTABLE if some functionality depends on the PendingIntent being mutable, e.g. if it needs to be used with inline replies or bubbles.
        at android.app.PendingIntent.checkFlags(PendingIntent.java:375)
        at android.app.PendingIntent.getBroadcastAsUser(PendingIntent.java:645)
        at android.app.PendingIntent.getBroadcast(PendingIntent.java:632)
        at androidx.work.impl.utils.ForceStopRunnable.getPendingIntent(ForceStopRunnable.java:273)
        at androidx.work.impl.utils.ForceStopRunnable.isForceStopped(ForceStopRunnable.java:151)
        at androidx.work.impl.utils.ForceStopRunnable.forceStopRunnable(ForceStopRunnable.java:171)
        at androidx.work.impl.utils.ForceStopRunnable.run(ForceStopRunnable.java:102)
        at androidx.work.impl.utils.SerialExecutor$Task.run(SerialExecutor.java:91)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
        at java.lang.Thread.run(Thread.java:920)
```

Additionally I had to bump `androidx.work:work-runtime` dependency (required by `react-native-maps`) to `2.7.1` to handle this new requirement properly.

# Test Plan

- [x] `Expo Go` compiles and runs
- [x] `Expo Go` opens `UNVERSIONED` project
- [x] `Expo Go` opens versioned projects
- [ ] `bare-expo` compiles and runs

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
