### PR TITLE
[tools] publish-dev-home: fix slug hash encoding

### DIFF
--- a/tools/src/commands/PublishDevExpoHomeCommand.ts
+++ b/tools/src/commands/PublishDevExpoHomeCommand.ts
@@ -149,6 +149,7 @@ async function action(options: ActionOptions): Promise<void> {
   }
 
   const expoHomeHashNode = await hashElement(EXPO_HOME_PATH, {
+    encoding: 'hex',
     folders: { exclude: ['.expo', 'node_modules'] },
   });
   const appJsonFilePath = path.join(EXPO_HOME_PATH, 'app.json');


### PR DESCRIPTION
# Why

* https://github.com/expo/expo/pull/17027#issuecomment-1098463233

# How

This PR changes the generated hash encoding, which was the reason for generating invalid slugs.

# Test Plan

`et publish-dev-home` generates the valid slug:

<img width="665" alt="Screenshot 2022-04-13 at 22 56 20" src="https://user-images.githubusercontent.com/719641/163269041-b072e1b7-acce-4216-aec9-03ac1459bdfe.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
