### PR TITLE
[sweet api][Kotlin] Dispatch async cpp calls through the native module queue

### DIFF
--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -39,6 +39,12 @@ buildscript {
   }
 }
 
+def isAndroidTest() {
+  Gradle gradle = getGradle()
+  String tskReqStr = gradle.getStartParameter().getTaskRequests().toString()
+  return tskReqStr.contains("AndroidTest")
+}
+
 def downloadsDir = new File("$buildDir/downloads")
 def thirdPartyNdkDir = new File("$buildDir/third-party-ndk")
 
@@ -95,6 +101,8 @@ android {
     versionCode 1
     versionName "0.7.0"
 
+    testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+
     externalNativeBuild {
       cmake {
         abiFilters(*(System.getenv('NDK_ABI_FILTERS') ?: 'armeabi-v7a x86 arm64-v8a x86_64').split(' '))
@@ -118,8 +126,8 @@ android {
 
   packagingOptions {
     // Gradle will add cmake target dependencies into packaging.
-    // Theses files are intermediated linking files to build reanimated and should not be in final package.
-    excludes = [
+    // Theses files are intermediated linking files to build modules-core and should not be in final package.
+    def sharedLibraries = [
       "**/libc++_shared.so",
       "**/libreactnativejni.so",
       "**/libglog.so",
@@ -127,8 +135,17 @@ android {
       "**/libfbjni.so",
       "**/libfolly_json.so",
       "**/libhermes.so",
-      "**/libjsi.so",
+      "**/libjsi.so"
     ]
+
+    // In android (instrumental) tests, we want to package all so files to enable our JSI functionality.
+    // Otherwise, those files should be excluded, because will be loaded by the application.
+    if (isAndroidTest()) {
+      excludes = ["META-INF/MANIFEST.MF"]
+      pickFirsts = sharedLibraries
+    } else {
+      excludes = sharedLibraries
+    }
   }
 
   configurations {
@@ -145,7 +162,9 @@ android {
   }
 
   testOptions {
-    unitTests.all {
+    unitTests.includeAndroidResources = true
+
+    unitTests.all { test ->
       testLogging {
         outputs.upToDateWhen { false }
         events "passed", "failed", "skipped", "standardError"
@@ -190,6 +209,10 @@ dependencies {
     extractJNI(files(rnAAR))
   }
   // else - there is no prebuilt react-native.aar, this is most likely Expo Go
+
+  androidTestImplementation 'androidx.test:runner:1.4.0'
+  androidTestImplementation 'androidx.test:core:1.4.0'
+  androidTestImplementation 'androidx.test:rules:1.4.0'
 }
 
 /**
@@ -321,4 +344,3 @@ tasks.whenTaskAdded { task ->
     task.dependsOn(":ReactAndroid:packageReactNdkLibs")
   }
 }
-

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/JSIInteropModuleRegistryTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/JSIInteropModuleRegistryTest.kt
@@ -1,0 +1,19 @@
+package expo.modules
+
+import expo.modules.kotlin.jni.JSIInteropModuleRegistry
+import org.junit.Assert
+import org.junit.Test
+import java.text.ParseException
+
+class JSIInteropModuleRegistryTest {
+  @Test
+  @Throws(ParseException::class)
+  fun ensure_static_libs_loaded() {
+    try {
+      // Using `JSIInteropModuleRegistry.Companion` ensures that static libs will be loaded.
+      JSIInteropModuleRegistry.Companion
+    } catch (e: Exception) {
+      Assert.fail("Couldn't load the `expo-modules-core` library: $e.")
+    }
+  }
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/core/errors/ContextDestroyedException.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/core/errors/ContextDestroyedException.kt
@@ -1,0 +1,7 @@
+package expo.modules.core.errors
+
+import kotlinx.coroutines.CancellationException
+
+private const val DEFAULT_MESSAGE = "App context destroyed. All coroutines are cancelled."
+
+class ContextDestroyedException(message: String = DEFAULT_MESSAGE) : CancellationException(message)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -50,7 +50,7 @@ class AppContext(
   internal val moduleQueue = CoroutineScope(
     newSingleThreadContext("ExpoModulesCoreQueue") +
       SupervisorJob() +
-      CoroutineName("ExpoModuleCoreCoroutineQueue")
+      CoroutineName("ExpoModulesCoreCoroutineQueue")
   )
 
   init {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -7,6 +7,7 @@ import android.content.Context
 import android.content.Intent
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.turbomodule.core.CallInvokerHolderImpl
+import expo.modules.BuildConfig
 import expo.modules.core.errors.ContextDestroyedException
 import expo.modules.core.interfaces.ActivityProvider
 import expo.modules.interfaces.barcodescanner.BarCodeScannerInterface
@@ -44,7 +45,8 @@ class AppContext(
     register(modulesProvider)
   }
   private val reactLifecycleDelegate = ReactLifecycleDelegate(this)
-  private val jsiInterop = JSIInteropModuleRegistry(this)
+  // We postpone creating the `JSIInteropModuleRegistry` to not load so files in unit tests.
+  private lateinit var jsiInterop: JSIInteropModuleRegistry
   internal val moduleQueue = CoroutineScope(
     newSingleThreadContext("ExpoModulesCoreQueue") +
       SupervisorJob() +
@@ -61,6 +63,7 @@ class AppContext(
   }
 
   fun onPostCreate() {
+    jsiInterop = JSIInteropModuleRegistry(this)
     val reactContext = reactContextHolder.get() ?: return
     reactContext.javaScriptContextHolder?.get()?.let {
       jsiInterop.installJSI(

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIInteropModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIInteropModuleRegistry.kt
@@ -2,7 +2,6 @@ package expo.modules.kotlin.jni
 
 import com.facebook.jni.HybridData
 import com.facebook.react.turbomodule.core.CallInvokerHolderImpl
-import com.facebook.react.turbomodule.core.interfaces.CallInvokerHolder
 import expo.modules.kotlin.AppContext
 import java.lang.ref.WeakReference
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptModuleObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptModuleObject.kt
@@ -6,6 +6,7 @@ import com.facebook.react.bridge.ReadableNativeArray
 import expo.modules.kotlin.KPromiseWrapper
 import expo.modules.kotlin.ModuleHolder
 import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.launch
 import java.lang.ref.WeakReference
 
 class JavaScriptModuleObject(moduleHolder: ModuleHolder) {
@@ -31,7 +32,11 @@ class JavaScriptModuleObject(moduleHolder: ModuleHolder) {
   @Suppress("unused")
   fun callAsyncMethod(name: String, args: ReadableNativeArray, bridgePromise: Any) {
     val kotlinPromise = KPromiseWrapper(bridgePromise as Promise)
-    moduleHolderRef.get()?.call(name, args, kotlinPromise)
+    moduleHolderRef.get()?.let { holder ->
+      holder.module.appContext.moduleQueue.launch {
+        moduleHolderRef.get()?.call(name, args, kotlinPromise)
+      }
+    }
   }
 
   @Throws(Throwable::class)


### PR DESCRIPTION
# Why

a follow up to the https://github.com/expo/expo/pull/17020.

# How

- Created a single thread queue for dispatching the functions of the native module. 
- Dispatch CPP async call to the created queue

# Test Plan

- bare-expo ✅