### PR TITLE
[ios] try to fix ios client occasional build error

### DIFF
--- a/ios/Exponent/Kernel/Views/Loading/EXAppLoadingProgressWindowController.m
+++ b/ios/Exponent/Kernel/Views/Loading/EXAppLoadingProgressWindowController.m
@@ -1,10 +1,13 @@
+#import "EXAppLoadingProgressWindowController.h"
+
+#import <React/React-Core-umbrella.h> // Keeps this import to fix the error from building React module: `error: definition of 'RCTBridge' must be imported from module 'React' before it is required`
+
 #import <ExpoModulesCore/EXDefines.h>
 
 #if !defined(EX_DETACHED)
 #import "Expo_Go-Swift.h"
 #endif // !defined(EX_DETACHED)
 
-#import "EXAppLoadingProgressWindowController.h"
 #import "EXUtil.h"
 
 @interface EXAppLoadingProgressWindowController ()


### PR DESCRIPTION
# Why

try to fix the ios client ci error: https://github.com/expo/expo/runs/5998304310?check_suite_focus=true

# How

i cannot repro locally, but just tried to fix the error as far as i can tell. tried it on ci and getting successful for [three times](https://github.com/expo/expo/runs/6021294826?check_suite_focus=true).

# Test Plan

ios client ci green

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
