### PR TITLE
[ios] Fix event emitter not having access to the new module registry

### DIFF
--- a/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.mm
+++ b/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.mm
@@ -295,13 +295,13 @@ RCT_EXPORT_METHOD(callMethod:(NSString *)moduleName methodNameOrKey:(id)methodNa
   // Register the view managers as additional modules.
   [self registerAdditionalModuleClasses:additionalModuleClasses inBridge:bridge];
 
+  // Get the instance of `EXReactEventEmitter` bridge module and give it access to the interop bridge.
+  EXReactNativeEventEmitter *eventEmitter = [bridge moduleForClass:[EXReactNativeEventEmitter class]];
+  [eventEmitter setSwiftInteropBridge:_swiftInteropBridge];
+
   // As the last step, when the registry is owned,
   // register the event emitter and initialize the registry.
   if (ownsModuleRegistry) {
-    // Get the newly created instance of `EXReactEventEmitter` bridge module,
-    // pass event names supported by Swift modules and register it in legacy modules registry.
-    EXReactNativeEventEmitter *eventEmitter = [bridge moduleForClass:[EXReactNativeEventEmitter class]];
-    [eventEmitter setSwiftInteropBridge:_swiftInteropBridge];
     [_exModuleRegistry registerInternalModule:eventEmitter];
 
     // Let the modules consume the registry :)


### PR DESCRIPTION
# Why

Some recent changes made in the NCL examples for `expo-clipboard` revealed an issue that `EXReactNativeEventEmitter` have no access to the new module registry, but only when the `EXNativeModulesProxy` doesn't own the module registry — that's the case in the old Expo modules setup that is still used in Expo Go). Everything worked just fine in bare-expo.
Clipboard is the only affected module because it's the only sweet module that can emit events.

# How

Just moved the `[eventEmitter setSwiftInteropBridge:]` invocation so it's invoked in both setups.

# Test Plan

Opening clipboard examples in NCL doesn't cause any errors, the examples are working as expected.
