### PR TITLE
[test-suite] FirebaseAnalytics: remove test for the removed method

### DIFF
--- a/apps/test-suite/tests/FirebaseAnalytics.js
+++ b/apps/test-suite/tests/FirebaseAnalytics.js
@@ -84,26 +84,6 @@ export async function test({ describe, beforeAll, afterAll, it, xit, expect }) {
         expect(error).not.toBeNull();
       });
     });
-    describe('setCurrentScreen()', async () => {
-      itWhenConfigured(`runs`, async () => {
-        let error = null;
-        try {
-          await Analytics.setCurrentScreen('test-screen');
-        } catch (e) {
-          error = e;
-        }
-        expect(error).toBeNull();
-      });
-      itWhenNotConfigured(`fails when not configured`, async () => {
-        let error = null;
-        try {
-          await Analytics.setCurrentScreen('test-screen');
-        } catch (e) {
-          error = e;
-        }
-        expect(error).not.toBeNull();
-      });
-    });
     describe('setSessionTimeoutDuration()', async () => {
       itWhenConfigured('runs', async () => {
         let error = null;


### PR DESCRIPTION
# Why

Refs:
* #17002

# How

This small PR removes no longer valid FirebaseAnalytics test from the `test-suite` app. The test also is a source of the warning on some of PRs. 

Since the `logEvent` have test with parameter already I think we do not need to test this again.

<img width="597" alt="Screenshot 2022-04-14 at 19 02 20" src="https://user-images.githubusercontent.com/719641/163438167-eb71cabc-7e88-4e20-afb9-99ad838fb95d.png">

# Test Plan

Test Suite builds and lints with no errors reported. Analytics tests also seems to run fine.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
