### PR TITLE
[docs] Added information on region codes to localization instructions

### DIFF
--- a/docs/pages/distribution/app-stores.md
+++ b/docs/pages/distribution/app-stores.md
@@ -118,7 +118,7 @@ If you plan on shipping your app to different countries, regions, or just want i
   }
 ```
 
-The keys provided to `locales` should be the [2-letter language code](https://www.loc.gov/standards/iso639-2/php/code_list.php) of your desired language, and the value should point to a JSON file that looks something like this:
+The keys provided to `locales` should be the [language identifier](https://developer.apple.com/documentation/xcode/choosing-localization-regions-and-scripts), made up of a [2-letter language code](https://www.loc.gov/standards/iso639-2/php/code_list.php) of your desired language, with an optional region code (e.g. `en-US` or `en-GB`), and the value should point to a JSON file that looks something like this:
 
 ```json
 // japanese.json


### PR DESCRIPTION
# Why

The documentation was lacking information on using region codes for localization, leading to user questions.

# How

Added a mention of region code, along with the reference to the official Apple docs for Language Identifiers.

# Test Plan

👀 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
