### PR TITLE
[expo-modules-core][expo-dev-launcher] add ReactNativeHostHandler.useDeveloperSupport

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -22,7 +22,7 @@
 - Fix `androidNavigationBar` app.json config settings having no effect at runtime ([#15030](https://github.com/expo/expo/issues/15030)). ([#16711](https://github.com/expo/expo/pull/16711) by [@esamelson](https://github.com/esamelson))
 - Removed the unused `jcenter()` maven dependencies. ([#16846](https://github.com/expo/expo/pull/16846) by [@kudo](https://github.com/kudo))
 - Fix `RCTStatusBarManager module requires that the UIViewControllerBasedStatusBarAppearance to be false.` on iOS. ([#17022](https://github.com/expo/expo/pull/17022) by [@lukmccall](https://github.com/lukmccall))
-- Fix loading published projects on Android.
+- Fix loading published projects on Android. ([#17069](https://github.com/expo/expo/pull/17069) by [@esamelson](https://github.com/esamelson))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Fix `androidNavigationBar` app.json config settings having no effect at runtime ([#15030](https://github.com/expo/expo/issues/15030)). ([#16711](https://github.com/expo/expo/pull/16711) by [@esamelson](https://github.com/esamelson))
 - Removed the unused `jcenter()` maven dependencies. ([#16846](https://github.com/expo/expo/pull/16846) by [@kudo](https://github.com/kudo))
 - Fix `RCTStatusBarManager module requires that the UIViewControllerBasedStatusBarAppearance to be false.` on iOS. ([#17022](https://github.com/expo/expo/pull/17022) by [@lukmccall](https://github.com/lukmccall))
+- Fix loading published projects on Android.
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/android/src/react-native-64/expo/modules/devlauncher/rncompatibility/DevLauncherReactNativeHostHandler.kt
+++ b/packages/expo-dev-launcher/android/src/react-native-64/expo/modules/devlauncher/rncompatibility/DevLauncherReactNativeHostHandler.kt
@@ -1,10 +1,15 @@
 package expo.modules.devlauncher.rncompatibility
 
 import expo.modules.core.interfaces.ReactNativeHostHandler
+import expo.modules.devlauncher.DevLauncherController
 
 class DevLauncherReactNativeHostHandler : ReactNativeHostHandler {
   override fun getDevSupportManagerFactory(): Any? {
     return null
+  }
+
+  override fun getUseDeveloperSupport(): Boolean? {
+    return if (DevLauncherController.wasInitialized()) DevLauncherController.instance.useDeveloperSupport else null
   }
 }
 

--- a/packages/expo-dev-launcher/android/src/react-native-65/expo/modules/devlauncher/rncompatibility/DevLauncherReactNativeHostHandler.kt
+++ b/packages/expo-dev-launcher/android/src/react-native-65/expo/modules/devlauncher/rncompatibility/DevLauncherReactNativeHostHandler.kt
@@ -1,10 +1,15 @@
 package expo.modules.devlauncher.rncompatibility
 
 import expo.modules.core.interfaces.ReactNativeHostHandler
+import expo.modules.devlauncher.DevLauncherController
 
 class DevLauncherReactNativeHostHandler : ReactNativeHostHandler {
   override fun getDevSupportManagerFactory(): Any? {
     return null
+  }
+
+  override fun getUseDeveloperSupport(): Boolean? {
+    return if (DevLauncherController.wasInitialized()) DevLauncherController.instance.useDeveloperSupport else null
   }
 }
 

--- a/packages/expo-dev-launcher/android/src/react-native-66/expo/modules/devlauncher/rncompatibility/DevLauncherReactNativeHostHandler.kt
+++ b/packages/expo-dev-launcher/android/src/react-native-66/expo/modules/devlauncher/rncompatibility/DevLauncherReactNativeHostHandler.kt
@@ -1,10 +1,15 @@
 package expo.modules.devlauncher.rncompatibility
 
 import expo.modules.core.interfaces.ReactNativeHostHandler
+import expo.modules.devlauncher.DevLauncherController
 
 class DevLauncherReactNativeHostHandler : ReactNativeHostHandler {
   override fun getDevSupportManagerFactory(): Any? {
     return null
+  }
+
+  override fun getUseDeveloperSupport(): Boolean? {
+    return if (DevLauncherController.wasInitialized()) DevLauncherController.instance.useDeveloperSupport else null
   }
 }
 

--- a/packages/expo-dev-launcher/android/src/react-native-67/expo/modules/devlauncher/rncompatibility/DevLauncherReactNativeHostHandler.kt
+++ b/packages/expo-dev-launcher/android/src/react-native-67/expo/modules/devlauncher/rncompatibility/DevLauncherReactNativeHostHandler.kt
@@ -2,9 +2,14 @@ package expo.modules.devlauncher.rncompatibility
 
 import com.facebook.react.devsupport.DevSupportManagerFactory
 import expo.modules.core.interfaces.ReactNativeHostHandler
+import expo.modules.devlauncher.DevLauncherController
 
 class DevLauncherReactNativeHostHandler : ReactNativeHostHandler {
   override fun getDevSupportManagerFactory(): DevSupportManagerFactory {
     return DevLauncherDevSupportManagerFactory()
+  }
+
+  override fun getUseDeveloperSupport(): Boolean? {
+    return if (DevLauncherController.wasInitialized()) DevLauncherController.instance.useDeveloperSupport else null
   }
 }

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Add support for automatic setup of `expo-dev-client` on Android. ([#16441](https://github.com/expo/expo/pull/16441) by [@esamelson](https://github.com/esamelson))
 - Stopped relying on deprecated `ViewPropTypes` from React Native. ([#16207](https://github.com/expo/expo/pull/16207) by [@tsapeta](https://github.com/tsapeta))
 - Added Android `ReactNativeHostHandler.getJavaScriptExecutorFactory()` for a module to override the `JavaScriptExecutorFactory`. ([#17005](https://github.com/expo/expo/pull/17005) by [@kudo](https://github.com/kudo))
+- Add `ReactNativeHostHandler.getUseDeveloperSupport()` to allow `expo-dev-launcher` to override this value at runtime.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add `ReactNativeHostHandler.getUseDeveloperSupport()` to allow `expo-dev-launcher` to override this value at runtime. ([#17069](https://github.com/expo/expo/pull/17069) by [@esamelson](https://github.com/esamelson))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others
@@ -27,7 +29,6 @@
 - Add support for automatic setup of `expo-dev-client` on Android. ([#16441](https://github.com/expo/expo/pull/16441) by [@esamelson](https://github.com/esamelson))
 - Stopped relying on deprecated `ViewPropTypes` from React Native. ([#16207](https://github.com/expo/expo/pull/16207) by [@tsapeta](https://github.com/tsapeta))
 - Added Android `ReactNativeHostHandler.getJavaScriptExecutorFactory()` for a module to override the `JavaScriptExecutorFactory`. ([#17005](https://github.com/expo/expo/pull/17005) by [@kudo](https://github.com/kudo))
-- Add `ReactNativeHostHandler.getUseDeveloperSupport()` to allow `expo-dev-launcher` to override this value at runtime. ([#17069](https://github.com/expo/expo/pull/17069) by [@esamelson](https://github.com/esamelson))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -27,7 +27,7 @@
 - Add support for automatic setup of `expo-dev-client` on Android. ([#16441](https://github.com/expo/expo/pull/16441) by [@esamelson](https://github.com/esamelson))
 - Stopped relying on deprecated `ViewPropTypes` from React Native. ([#16207](https://github.com/expo/expo/pull/16207) by [@tsapeta](https://github.com/tsapeta))
 - Added Android `ReactNativeHostHandler.getJavaScriptExecutorFactory()` for a module to override the `JavaScriptExecutorFactory`. ([#17005](https://github.com/expo/expo/pull/17005) by [@kudo](https://github.com/kudo))
-- Add `ReactNativeHostHandler.getUseDeveloperSupport()` to allow `expo-dev-launcher` to override this value at runtime.
+- Add `ReactNativeHostHandler.getUseDeveloperSupport()` to allow `expo-dev-launcher` to override this value at runtime. ([#17069](https://github.com/expo/expo/pull/17069) by [@esamelson](https://github.com/esamelson))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/core/interfaces/ReactNativeHostHandler.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/core/interfaces/ReactNativeHostHandler.java
@@ -44,6 +44,17 @@ public interface ReactNativeHostHandler {
   }
 
   /**
+   * Give modules a chance to override the value for useDeveloperSupport,
+   * e.g. for expo-dev-launcher
+   *
+   * @return value for useDeveloperSupport, or null if not to override
+   */
+  @Nullable
+  default Boolean getUseDeveloperSupport() {
+    return null;
+  }
+
+  /**
    * Given chance for modules to override react dev support manager factory.
    * e.g. for expo-dev-client
    *

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add `ReactNativeHostHandler.getUseDeveloperSupport()` to allow `expo-dev-launcher` to override this value at runtime. ([#17069](https://github.com/expo/expo/pull/17069) by [@esamelson](https://github.com/esamelson))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo/android/src/main/java/expo/modules/ReactNativeHostWrapperBase.kt
+++ b/packages/expo/android/src/main/java/expo/modules/ReactNativeHostWrapperBase.kt
@@ -76,7 +76,9 @@ open class ReactNativeHostWrapperBase(
   }
 
   override fun getUseDeveloperSupport(): Boolean {
-    return host.useDeveloperSupport
+    return reactNativeHostHandlers.asSequence()
+      .mapNotNull { it.useDeveloperSupport }
+      .firstOrNull() ?: host.useDeveloperSupport
   }
 
   override fun getPackages(): MutableList<ReactPackage> {


### PR DESCRIPTION
# Why

follow up from #16441 -- looks like there was one piece of the setup that I missed, as it wasn't properly set up in bare-expo 😮 😅 

# How

Add `ReactNativeHostHandler.getUseDeveloperSupport()` and override it in `DevLauncherReactNativeHostHandler` with the value from `DevLauncherController`.

This lets the dev client properly open published updates, and replaces [this piece](https://github.com/expo/expo/blob/a3527a58b96ed2955bf692174eb412b58a0a2fc1/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts#L153-L157) of the config plugin for SDK 44 and below projects.

# Test Plan

Build local dev client with RN 0.68 project (using local project template)
✅ can open a published project, no yellow boxes show up and all dev menu options are greyed out
✅ can still open a project in development, yellow boxes show up and all dev menu options are available and work

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
