### PR TITLE
[ios][expo go] don't set appearancePreferene to light when userInterfaceStyle is undefined

### DIFF
--- a/ios/Exponent/Kernel/Views/EXAppViewController.m
+++ b/ios/Exponent/Kernel/Views/EXAppViewController.m
@@ -611,7 +611,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
   NSString *userInterfaceStyle = [self _readUserInterfaceStyleFromManifest:_appRecord.appLoader.manifest];
   NSString *appearancePreference = nil;
-  if (!userInterfaceStyle || [userInterfaceStyle isEqualToString:@"light"]) {
+  if ([userInterfaceStyle isEqualToString:@"light"]) {
     appearancePreference = @"light";
   } else if ([userInterfaceStyle isEqualToString:@"dark"]) {
     appearancePreference = @"dark";
@@ -650,7 +650,11 @@ NS_ASSUME_NONNULL_BEGIN
   if ([userInterfaceStyleString isEqualToString:@"automatic"]) {
     return UIUserInterfaceStyleUnspecified;
   }
-  return UIUserInterfaceStyleLight;
+  if ([userInterfaceStyleString isEqualToString:@"light"]) {
+    return UIUserInterfaceStyleLight;
+  }
+
+  return UIUserInterfaceStyleUnspecified;
 }
 
 #pragma mark - root view and window background color


### PR DESCRIPTION
## Reviewers

I'm not sure who to request a review from, but I got a GitHub suggestion to add @tsapeta, and I'm also adding @Kudo because I know he's knowledgeable about this native stuff.

# Why

When a user has their iOS theme set to dark, but their Expo Go theme set to automatic, closing the app after launching an Expo app and going back to the Home UI results in the theme coming from the native side becoming "light". See the attached linear issue for a video reproduction and more details.

# How

I dug in and realized that we're reading the manifest for a `userInterfaceStyle`, and if it's not defined, then we set the theme to light. This then gets passed in as a `sColorSchemeOverride` in `RCTAppearance`, and can't be changed after this happens.

By not setting "light" when the style is automatic/undefined, a `sColorSchemeOverride` doesn't get set, and this bug ceases to exist.

This all seems to be triggered by the fact that iOS toggles the theme when you task switch/lock the phone to capture a themed screenshot: https://linear.app/expo/issue/ENG-4572#comment-dc7a8284

We used to have a workaround for this in RN Appearance, but RN upstream doesn't have it: https://github.com/expo/react-native-appearance/commit/e1896d9128905b2f10790a2e82d887bc706e10c5

We can pick this change into our RN fork to prevent any potential flashes after a user locks their phone or they open up the app switcher.

# Test Plan

Set your device theme to dark and your Expo Go theme to automatic. Launch a project, go back to Home using the dev menu, and lock your device. The theme when you unlock your device should still be dark. 

Video repro:

https://user-images.githubusercontent.com/12488826/163491061-d18b48d4-9365-4981-aea8-a882fbf9ebc3.mov

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
