### PR TITLE
[image-picker] Ensure genrated url is scoped within ImagePicker directory

### DIFF
--- a/packages/expo-image-picker/ios/MediaHandler.swift
+++ b/packages/expo-image-picker/ios/MediaHandler.swift
@@ -104,7 +104,9 @@ internal struct MediaHandler {
     guard let fileSystem = self.fileSystem else {
       throw FileSystemModuleNotFoundException()
     }
-    let directory = fileSystem.cachesDirectory.appending("ImagePicker")
+    let directory =  fileSystem.cachesDirectory.appending(
+      fileSystem.cachesDirectory.hasSuffix("/") ? "" : "/" + "ImagePicker"
+    );
     let path = fileSystem.generatePath(inDirectory: directory, withExtension: withFileExtension)
     let url = URL(fileURLWithPath: path)
     return url


### PR DESCRIPTION
# Why

This partially fixes ENG-4702. Prior to the changes in this PR, the FaceDetector example in NCL will error with `E_FILESYSTEM_PERMISSIONS` because FaceDetector isn't unable to read the selected image path. This PR fixes the path generated from expo-image-picker from:

```
file:///var/mobile/Containers/Data/Application/176FC7EC-02CC-44A3-9793-C173EC3A256B/Library/Caches/ExponentExperienceData/%2540notbrent%252Fnative-component-listImagePicker/5E814012-18BF-4AC9-9746-29E0F9091FBC.jpg
```

to

```
file:///var/mobile/Containers/Data/Application/176FC7EC-02CC-44A3-9793-C173EC3A256B/Library/Caches/ExponentExperienceData/%2540notbrent%252Fnative-component-list/ImagePicker/5E814012-18BF-4AC9-9746-29E0F9091FBC.jpg
```

This fixes the NCL example.

# Test Plan

Run FaceDetector in NCL. Ensure that it's able to detect a face (and doesn't throw `E_FILESYSTEM_PERMISSIONS`).

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
