### PR TITLE
[android] fix versioning on linux

### DIFF
--- a/tools/src/versioning/android/android-build-aar.sh
+++ b/tools/src/versioning/android/android-build-aar.sh
@@ -9,6 +9,11 @@ ABI_VERSION_NUMBER=`echo $1 | sed 's/\./_/g'`
 ABI_VERSION="abi$ABI_VERSION_NUMBER"
 TOOLS_DIR=`pwd`
 
+SED_PREFIX="sed -i ''"
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  SED_PREFIX="sed -i"
+fi
+
 pushd $EXPO_ROOT_DIR/android
 
 # Clean aar
@@ -68,7 +73,7 @@ while read FILE
 do
   while read PACKAGE
   do
-    sed -i '' "s/$PACKAGE/$ABI_VERSION.$PACKAGE/g" $FILE
+    $SED_PREFIX "s/$PACKAGE/$ABI_VERSION.$PACKAGE/g" $FILE
   done < $TOOLS_DIR/android-packages-to-rename.txt
 done < annotations_xmls
 rm annotations_xmls
@@ -91,7 +96,7 @@ java -jar $TOOLS_DIR/jarjar-1.4.1.jar process jarjar-rules.txt expoview/libs/Rea
 
 pushd expoview/libs/ReactAndroid-temp
 # Update the manifest. This is used for deduping in the build process
-sed -i '' "s/com\.facebook\.react/$ABI_VERSION\.com\.facebook\.react/g" AndroidManifest.xml
+$SED_PREFIX "s/com\.facebook\.react/$ABI_VERSION\.com\.facebook\.react/g" AndroidManifest.xml
 
 # Can't rename libc++_shared so remove. We share the copy from ReactAndroid.
 rm -rf jni/*/libc++_shared.so
@@ -117,11 +122,11 @@ NEWLINE='\
 SED_APPEND_COMMAND=" a$NEWLINE"
 REPLACE_TEXT='DO NOT MODIFY'
 ADD_NEW_SDKS_HERE='ADD_NEW_SDKS_HERE'
-sed -i '' "/$ADD_NEW_SDKS_HERE/$SED_APPEND_COMMAND$NEWLINE$NEWLINE\ \ \/\/ BEGIN_SDK_$MAJOR_ABI_VERSION$NEWLINE\ \ versionedImplementation(project(':expoview-$ABI_VERSION'))$NEWLINE\ \ \/\/ END_SDK_$MAJOR_ABI_VERSION$NEWLINE" app/build.gradle
-sed -i '' "/$REPLACE_TEXT/$SED_APPEND_COMMAND\ \ \/\/ BEGIN_SDK_$MAJOR_ABI_VERSION$NEWLINE\ \ versionedApi 'host.exp:reactandroid-$ABI_VERSION:1.0.0'$NEWLINE\ \ \/\/ END_SDK_$MAJOR_ABI_VERSION$NEWLINE" expoview/build.gradle
+$SED_PREFIX "/$ADD_NEW_SDKS_HERE/$SED_APPEND_COMMAND$NEWLINE$NEWLINE\ \ \/\/ BEGIN_SDK_$MAJOR_ABI_VERSION$NEWLINE\ \ versionedImplementation(project(':expoview-$ABI_VERSION'))$NEWLINE\ \ \/\/ END_SDK_$MAJOR_ABI_VERSION$NEWLINE" app/build.gradle
+$SED_PREFIX "/$REPLACE_TEXT/$SED_APPEND_COMMAND\ \ \/\/ BEGIN_SDK_$MAJOR_ABI_VERSION$NEWLINE\ \ versionedApi 'host.exp:reactandroid-$ABI_VERSION:1.0.0'$NEWLINE\ \ \/\/ END_SDK_$MAJOR_ABI_VERSION$NEWLINE" expoview/build.gradle
 
 # Update Constants.java
-sed -i '' "/$REPLACE_TEXT/$SED_APPEND_COMMAND\ \ \ \ \/\/ BEGIN_SDK_$MAJOR_ABI_VERSION$NEWLINE\ \ \ \ abiVersions.add(\"$ORIGINAL_ABI_VERSION\");$NEWLINE\ \ \ \ \/\/ END_SDK_$MAJOR_ABI_VERSION$NEWLINE" expoview/src/main/java/host/exp/exponent/Constants.java
+$SED_PREFIX "/$REPLACE_TEXT/$SED_APPEND_COMMAND\ \ \ \ \/\/ BEGIN_SDK_$MAJOR_ABI_VERSION$NEWLINE\ \ \ \ abiVersions.add(\"$ORIGINAL_ABI_VERSION\");$NEWLINE\ \ \ \ \/\/ END_SDK_$MAJOR_ABI_VERSION$NEWLINE" expoview/src/main/java/host/exp/exponent/Constants.java
 
 # Add new version
 
@@ -132,8 +137,8 @@ sed -i '' "/$REPLACE_TEXT/$SED_APPEND_COMMAND\ \ \ \ \/\/ BEGIN_SDK_$MAJOR_ABI_V
 BACK_BUTTON_HANDLER_CLASS='com.facebook.react.modules.core.DefaultHardwareBackBtnHandler'
 PERMISSION_AWARE_ACTIVITY_CLASS='com.facebook.react.modules.core.PermissionAwareActivity'
 PERMISSION_LISTENER_CLASS='com.facebook.react.modules.core.PermissionListener'
-find expoview/src/versioned/java/host/exp/exponent -iname '*.java' -type f -print0 | xargs -0 sed -i '' -e "s/ADD_NEW_SDKS_HERE/BEGIN_SDK_$MAJOR_ABI_VERSION$NEWLINE\ \ \ \ $ABI_VERSION\.$BACK_BUTTON_HANDLER_CLASS,$NEWLINE\ \ \ \ $ABI_VERSION\.$PERMISSION_AWARE_ACTIVITY_CLASS,$NEWLINE\ \ \ \ \/\/ END_SDK_$MAJOR_ABI_VERSION$NEWLINE\ \ \ \ \/\/ ADD_NEW_SDKS_HERE/" 
+find expoview/src/versioned/java/host/exp/exponent -iname '*.java' -type f -print0 | xargs -0 $SED_PREFIX -e "s/ADD_NEW_SDKS_HERE/BEGIN_SDK_$MAJOR_ABI_VERSION$NEWLINE\ \ \ \ $ABI_VERSION\.$BACK_BUTTON_HANDLER_CLASS,$NEWLINE\ \ \ \ $ABI_VERSION\.$PERMISSION_AWARE_ACTIVITY_CLASS,$NEWLINE\ \ \ \ \/\/ END_SDK_$MAJOR_ABI_VERSION$NEWLINE\ \ \ \ \/\/ ADD_NEW_SDKS_HERE/"
 # Add implementation of PermissionAwareActivity.requestPermissions
-find expoview/src/versioned/java/host/exp/exponent -iname '*.java' -type f -print0 | xargs -0 sed -i '' "s/ADD_NEW_PERMISSION_AWARE_ACTIVITY_IMPLEMENTATION_HERE/BEGIN_SDK_$MAJOR_ABI_VERSION$NEWLINE\ \ \ \ @Override$NEWLINE\ \ \ \ public\ void\ requestPermissions(String\[\]\ strings\,\ int\ i\,\ $ABI_VERSION\.$PERMISSION_LISTENER_CLASS\ permissionListener)\ {$NEWLINE\ \ \ \ \ \ super\.requestPermissions(strings\,\ i\,\ permissionListener::onRequestPermissionsResult);$NEWLINE\ \ \ \ }$NEWLINE\ \ \ \ \/\/ END_SDK_$MAJOR_ABI_VERSION$NEWLINE\ \ \ \ \/\/ ADD_NEW_PERMISSION_AWARE_ACTIVITY_IMPLEMENTATION_HERE/"
+find expoview/src/versioned/java/host/exp/exponent -iname '*.java' -type f -print0 | xargs -0 $SED_PREFIX "s/ADD_NEW_PERMISSION_AWARE_ACTIVITY_IMPLEMENTATION_HERE/BEGIN_SDK_$MAJOR_ABI_VERSION$NEWLINE\ \ \ \ @Override$NEWLINE\ \ \ \ public\ void\ requestPermissions(String\[\]\ strings\,\ int\ i\,\ $ABI_VERSION\.$PERMISSION_LISTENER_CLASS\ permissionListener)\ {$NEWLINE\ \ \ \ \ \ super\.requestPermissions(strings\,\ i\,\ permissionListener::onRequestPermissionsResult);$NEWLINE\ \ \ \ }$NEWLINE\ \ \ \ \/\/ END_SDK_$MAJOR_ABI_VERSION$NEWLINE\ \ \ \ \/\/ ADD_NEW_PERMISSION_AWARE_ACTIVITY_IMPLEMENTATION_HERE/"
 
 popd

--- a/tools/src/versioning/android/android-copy-expo-module.sh
+++ b/tools/src/versioning/android/android-copy-expo-module.sh
@@ -9,6 +9,11 @@ VERSIONED_ABI_PATH=versioned-abis/expoview-$ABI_VERSION
 TOOLS_DIR=`pwd`
 EXPOMODULE_MANIFEST_PATH=$VERSIONED_ABI_PATH/src/main/ExpoModuleAndroidManifest.xml
 
+SED_PREFIX="sed -i ''"
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  SED_PREFIX="sed -i"
+fi
+
 pushd $EXPO_ROOT_DIR/android
 
 cp -r $3/src/main/java/* $VERSIONED_ABI_PATH/src/main/java/$ABI_VERSION
@@ -28,25 +33,25 @@ done < $TOOLS_DIR/android-packages-to-keep.txt
 
 while read PACKAGE
 do
-  find $VERSIONED_ABI_PATH/src/main/java/$ABI_VERSION \( -iname '*.java' -or -iname '*.kt' \) -type f -print0 | xargs -0 sed -i '' "s/\([, ^\(<]\)$PACKAGE/\1temporarydonotversion.$PACKAGE/g"
-  sed -i '' "s/\([, ^\(<]\)$PACKAGE/\1temporarydonotversion.$PACKAGE/g" $EXPOMODULE_MANIFEST_PATH
+  find $VERSIONED_ABI_PATH/src/main/java/$ABI_VERSION \( -iname '*.java' -or -iname '*.kt' \) -type f -print0 | xargs -0 $SED_PREFIX "s/\([, ^\(<]\)$PACKAGE/\1temporarydonotversion.$PACKAGE/g"
+  $SED_PREFIX "s/\([, ^\(<]\)$PACKAGE/\1temporarydonotversion.$PACKAGE/g" $EXPOMODULE_MANIFEST_PATH
 done < $TOOLS_DIR/android-packages-to-keep.txt
 
 while read PACKAGE
 do
-  find $VERSIONED_ABI_PATH/src/main/java/$ABI_VERSION \( -iname '*.java' -or -iname '*.kt' \) -type f -print0 | xargs -0 sed -i '' "s/\([, ^\(<]\)$PACKAGE/\1$ABI_VERSION.$PACKAGE/g"
-  sed -i '' "s/\([, ^\(<]\)$PACKAGE/\1$ABI_VERSION.$PACKAGE/g" $EXPOMODULE_MANIFEST_PATH
+  find $VERSIONED_ABI_PATH/src/main/java/$ABI_VERSION \( -iname '*.java' -or -iname '*.kt' \) -type f -print0 | xargs -0 $SED_PREFIX "s/\([, ^\(<]\)$PACKAGE/\1$ABI_VERSION.$PACKAGE/g"
+  $SED_PREFIX "s/\([, ^\(<]\)$PACKAGE/\1$ABI_VERSION.$PACKAGE/g" $EXPOMODULE_MANIFEST_PATH
 done < $TOOLS_DIR/android-packages-to-rename.txt
 
 while read PACKAGE
 do
-  find $VERSIONED_ABI_PATH/src/main/java/$ABI_VERSION \( -iname '*.java' -or -iname '*.kt' \) -type f -print0 | xargs -0 sed -i '' "s/\([, ^\(<]\)temporarydonotversion.$PACKAGE/\1$PACKAGE/g"
-  sed -i '' "s/\([, ^\(<]\)temporarydonotversion.$PACKAGE/\1$PACKAGE/g" $EXPOMODULE_MANIFEST_PATH
+  find $VERSIONED_ABI_PATH/src/main/java/$ABI_VERSION \( -iname '*.java' -or -iname '*.kt' \) -type f -print0 | xargs -0 $SED_PREFIX "s/\([, ^\(<]\)temporarydonotversion.$PACKAGE/\1$PACKAGE/g"
+  $SED_PREFIX "s/\([, ^\(<]\)temporarydonotversion.$PACKAGE/\1$PACKAGE/g" $EXPOMODULE_MANIFEST_PATH
 done < $TOOLS_DIR/android-packages-to-keep.txt
 
 # Transform `// EXPO_VERSIONING_NEEDS_EXPOVIEW_R` comment as `import abiN_N_N.host.exp.expoview.R`
-find $VERSIONED_ABI_PATH/src/main/java/$ABI_VERSION -iname '*.java' -type f -print0 | xargs -0 sed -i '' "s/^\/\/ *EXPO_VERSIONING_NEEDS_EXPOVIEW_R/import $ABI_VERSION.host.exp.expoview.R;/g"
-find $VERSIONED_ABI_PATH/src/main/java/$ABI_VERSION -iname '*.kt' -type f -print0 | xargs -0 sed -i '' "s/^\/\/ *EXPO_VERSIONING_NEEDS_EXPOVIEW_R/import $ABI_VERSION.host.exp.expoview.R/g"
+find $VERSIONED_ABI_PATH/src/main/java/$ABI_VERSION -iname '*.java' -type f -print0 | xargs -0 $SED_PREFIX "s/^\/\/ *EXPO_VERSIONING_NEEDS_EXPOVIEW_R/import $ABI_VERSION.host.exp.expoview.R;/g"
+find $VERSIONED_ABI_PATH/src/main/java/$ABI_VERSION -iname '*.kt' -type f -print0 | xargs -0 $SED_PREFIX "s/^\/\/ *EXPO_VERSIONING_NEEDS_EXPOVIEW_R/import $ABI_VERSION.host.exp.expoview.R/g"
 
 # Special modules transform
 PACKAGE_JAVA_BASE_DIR="$VERSIONED_ABI_PATH/src/main/java/$ABI_VERSION"

--- a/tools/src/versioning/android/android-copy-expoview.sh
+++ b/tools/src/versioning/android/android-copy-expoview.sh
@@ -7,6 +7,11 @@ ABI_VERSION="abi$ABI_VERSION"
 VERSIONED_ABI_PATH=versioned-abis/expoview-$ABI_VERSION
 TOOLS_DIR=`pwd`
 
+SED_PREFIX="sed -i ''"
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  SED_PREFIX="sed -i"
+fi
+
 pushd $EXPO_ROOT_DIR/android
 
 mkdir -p $VERSIONED_ABI_PATH/src/main/java
@@ -19,9 +24,9 @@ awk '
   // { if (stopRemoving == 1) removing = 0 }
   // { if (removing == 0) stopRemoving = 0 }
 ' expoview/build.gradle > $VERSIONED_ABI_PATH/build.gradle
-sed -i '' "s/\/\/ WHEN_VERSIONING_REPLACE_WITH_DEPENDENCIES/implementation project(\":expoview\")/g" $VERSIONED_ABI_PATH/build.gradle
-sed -i '' "/\/\* WHEN_VERSIONING_UNCOMMENT_FROM_HERE/d" $VERSIONED_ABI_PATH/build.gradle
-sed -i '' "/WHEN_VERSIONING_UNCOMMENT_TO_HERE \*\//d" $VERSIONED_ABI_PATH/build.gradle
+$SED_PREFIX "s/\/\/ WHEN_VERSIONING_REPLACE_WITH_DEPENDENCIES/implementation project(\":expoview\")/g" $VERSIONED_ABI_PATH/build.gradle
+$SED_PREFIX "/\/\* WHEN_VERSIONING_UNCOMMENT_FROM_HERE/d" $VERSIONED_ABI_PATH/build.gradle
+$SED_PREFIX "/WHEN_VERSIONING_UNCOMMENT_TO_HERE \*\//d" $VERSIONED_ABI_PATH/build.gradle
 
 # Prepare an empty AndroidManifest.xml of the new project
 awk '
@@ -31,14 +36,14 @@ awk '
   // { if (stopRemoving == 1) removing = 0 }
   // { if (removing == 0) stopRemoving = 0 }
 ' expoview/src/main/AndroidManifest.xml > $VERSIONED_ABI_PATH/src/main/AndroidManifest.xml
-sed -i '' "s/host.exp.expoview/$ABI_VERSION.host.exp.expoview/g" $VERSIONED_ABI_PATH/src/main/AndroidManifest.xml
-sed -i '' "s/versioned.host.exp.exponent/$ABI_VERSION.host.exp.exponent/g" $VERSIONED_ABI_PATH/src/main/AndroidManifest.xml
+$SED_PREFIX "s/host.exp.expoview/$ABI_VERSION.host.exp.expoview/g" $VERSIONED_ABI_PATH/src/main/AndroidManifest.xml
+$SED_PREFIX "s/versioned.host.exp.exponent/$ABI_VERSION.host.exp.exponent/g" $VERSIONED_ABI_PATH/src/main/AndroidManifest.xml
 
 # Add the new expoview-abiXX_X_X subproject to root project
 NEWLINE='\
 '
 SED_APPEND_COMMAND=" a$NEWLINE"
-sed -i '' "/ADD_NEW_SUPPORTED_ABIS_HERE/$SED_APPEND_COMMAND\ \ \ \ \"$ABI_VERSION\",$NEWLINE" settings.gradle
+$SED_PREFIX "/ADD_NEW_SUPPORTED_ABIS_HERE/$SED_APPEND_COMMAND\ \ \ \ \"$ABI_VERSION\",$NEWLINE" settings.gradle
 
 # Copy all the versioned code
 cp -r expoview/src/main/cpp $VERSIONED_ABI_PATH/src/main/cpp
@@ -53,27 +58,27 @@ cp expoview/empty.cpp $VERSIONED_ABI_PATH
 
 while read PACKAGE
 do
-  find $VERSIONED_ABI_PATH/src/main/java/$ABI_VERSION \( -iname '*.java' -or -iname '*.kt' \) -type f -print0 | xargs -0 sed -i '' "s/\([, ^\(<]\)$PACKAGE/\1temporarydonotversion.$PACKAGE/g"
+  find $VERSIONED_ABI_PATH/src/main/java/$ABI_VERSION \( -iname '*.java' -or -iname '*.kt' \) -type f -print0 | xargs -0 $SED_PREFIX "s/\([, ^\(<]\)$PACKAGE/\1temporarydonotversion.$PACKAGE/g"
 done < $TOOLS_DIR/android-packages-to-keep.txt
 
 # Rename references to other packages previously under versioned.host.exp.exponent
-find $VERSIONED_ABI_PATH/src/main/java/$ABI_VERSION \( -iname '*.java' -or -iname '*.kt' \) -type f -print0 | xargs -0 sed -i '' "s/import versioned\.host\.exp\.exponent/import $ABI_VERSION\.host\.exp\.exponent/g"
-find $VERSIONED_ABI_PATH/src/main/java/$ABI_VERSION \( -iname '*.java' -or -iname '*.kt' \) -type f -print0 | xargs -0 sed -i '' "s/import expo\./import $ABI_VERSION\.expo\./g"
-find $VERSIONED_ABI_PATH/src/main/java/$ABI_VERSION \( -iname '*.java' -or -iname '*.kt' \) -type f -print0 | xargs -0 sed -i '' "s/import static versioned\.host\.exp\.exponent/import static $ABI_VERSION\.host\.exp\.exponent/g"
-find $VERSIONED_ABI_PATH/src/main/java/$ABI_VERSION \( -iname '*.java' -or -iname '*.kt' \) -type f -print0 | xargs -0 sed -i '' "s/import static expo\./import static $ABI_VERSION\.expo\./g"
-find $VERSIONED_ABI_PATH/src/main/java/$ABI_VERSION \( -iname '*.java' -or -iname '*.kt' \) -type f -print0 | xargs -0 sed -i '' "s/package versioned\.host\.exp\.exponent/package $ABI_VERSION\.host\.exp\.exponent/g"
-find $VERSIONED_ABI_PATH/src/main/java/$ABI_VERSION \( -iname '*.java' -or -iname '*.kt' \) -type f -print0 | xargs -0 sed -i '' "s/versioned\.host\.exp\.exponent/$ABI_VERSION\.host\.exp\.exponent/g"
+find $VERSIONED_ABI_PATH/src/main/java/$ABI_VERSION \( -iname '*.java' -or -iname '*.kt' \) -type f -print0 | xargs -0 $SED_PREFIX "s/import versioned\.host\.exp\.exponent/import $ABI_VERSION\.host\.exp\.exponent/g"
+find $VERSIONED_ABI_PATH/src/main/java/$ABI_VERSION \( -iname '*.java' -or -iname '*.kt' \) -type f -print0 | xargs -0 $SED_PREFIX "s/import expo\./import $ABI_VERSION\.expo\./g"
+find $VERSIONED_ABI_PATH/src/main/java/$ABI_VERSION \( -iname '*.java' -or -iname '*.kt' \) -type f -print0 | xargs -0 $SED_PREFIX "s/import static versioned\.host\.exp\.exponent/import static $ABI_VERSION\.host\.exp\.exponent/g"
+find $VERSIONED_ABI_PATH/src/main/java/$ABI_VERSION \( -iname '*.java' -or -iname '*.kt' \) -type f -print0 | xargs -0 $SED_PREFIX "s/import static expo\./import static $ABI_VERSION\.expo\./g"
+find $VERSIONED_ABI_PATH/src/main/java/$ABI_VERSION \( -iname '*.java' -or -iname '*.kt' \) -type f -print0 | xargs -0 $SED_PREFIX "s/package versioned\.host\.exp\.exponent/package $ABI_VERSION\.host\.exp\.exponent/g"
+find $VERSIONED_ABI_PATH/src/main/java/$ABI_VERSION \( -iname '*.java' -or -iname '*.kt' \) -type f -print0 | xargs -0 $SED_PREFIX "s/versioned\.host\.exp\.exponent/$ABI_VERSION\.host\.exp\.exponent/g"
 
 # Rename references to react native
 while read PACKAGE
 do
-  find $VERSIONED_ABI_PATH/src/main/java/$ABI_VERSION \( -iname '*.java' -or -iname '*.kt' \) -type f -print0 | xargs -0 sed -i '' "s/import $PACKAGE/import $ABI_VERSION.$PACKAGE/g"
-  find $VERSIONED_ABI_PATH/src/main/java/$ABI_VERSION \( -iname '*.java' -or -iname '*.kt' \) -type f -print0 | xargs -0 sed -i '' "s/import static $PACKAGE/import static $ABI_VERSION.$PACKAGE/g"
+  find $VERSIONED_ABI_PATH/src/main/java/$ABI_VERSION \( -iname '*.java' -or -iname '*.kt' \) -type f -print0 | xargs -0 $SED_PREFIX "s/import $PACKAGE/import $ABI_VERSION.$PACKAGE/g"
+  find $VERSIONED_ABI_PATH/src/main/java/$ABI_VERSION \( -iname '*.java' -or -iname '*.kt' \) -type f -print0 | xargs -0 $SED_PREFIX "s/import static $PACKAGE/import static $ABI_VERSION.$PACKAGE/g"
 done < $TOOLS_DIR/android-packages-to-rename.txt
 
 while read PACKAGE
 do
-  find $VERSIONED_ABI_PATH/src/main/java/$ABI_VERSION \( -iname '*.java' -or -iname '*.kt' \) -type f -print0 | xargs -0 sed -i '' "s/\([, ^\(<]\)temporarydonotversion.$PACKAGE/\1$PACKAGE/g"
+  find $VERSIONED_ABI_PATH/src/main/java/$ABI_VERSION \( -iname '*.java' -or -iname '*.kt' \) -type f -print0 | xargs -0 $SED_PREFIX "s/\([, ^\(<]\)temporarydonotversion.$PACKAGE/\1$PACKAGE/g"
 done < $TOOLS_DIR/android-packages-to-keep.txt
 
 popd

--- a/tools/src/versioning/android/index.ts
+++ b/tools/src/versioning/android/index.ts
@@ -16,6 +16,7 @@ const EXPO_DIR = Directories.getExpoRepositoryRootDir();
 const ANDROID_DIR = Directories.getAndroidDir();
 const EXPOTOOLS_DIR = Directories.getExpotoolsDir();
 const SCRIPT_DIR = path.join(EXPOTOOLS_DIR, 'src/versioning/android');
+const SED_PREFIX = process.platform === 'darwin' ? "sed -i ''" : 'sed -i';
 
 const appPath = path.join(ANDROID_DIR, 'app');
 const expoviewPath = path.join(ANDROID_DIR, 'expoview');
@@ -308,7 +309,7 @@ async function processJavaCodeAsync(libName: string, abiVersion: string) {
     `find ${versionedReactAndroidJavaPath} ${versionedExpoviewAbiPath(
       abiName
     )} -iname '*.java' -type f -print0 | ` +
-      `xargs -0 sed -i '' 's/"${libName}"/"${libName}_abi${abiVersion}"/g'`,
+      `xargs -0 ${SED_PREFIX} 's/"${libName}"/"${libName}_abi${abiVersion}"/g'`,
     [],
     { shell: true }
   );
@@ -339,7 +340,7 @@ async function renameJniLibsAsync(version: string) {
     await spawnAsync(
       `find ${versionedReactCommonPath} ${versionedReactAndroidJniPath} ${codegenOutputRoot} -type f ` +
         `\\( -name \*.java -o -name \*.h -o -name \*.cpp -o -name \*.mk \\) -print0 | ` +
-        `xargs -0 sed -i '' 's/${pathForPackage}/abi${abiVersion}\\/${pathForPackage}/g'`,
+        `xargs -0 ${SED_PREFIX} 's/${pathForPackage}/abi${abiVersion}\\/${pathForPackage}/g'`,
       [],
       { shell: true }
     );
@@ -351,7 +352,7 @@ async function renameJniLibsAsync(version: string) {
     await spawnAsync(
       `find ${versionedAbiPath} -type f ` +
         `\\( -name \*.java -o -name \*.h -o -name \*.cpp -o -name \*.mk \\) -print0 | ` +
-        `xargs -0 sed -i '' 's/${oldJNIReanimatedPackage}/abi${abiVersion}\\/${newJNIReanimatedPackage}/g'`,
+        `xargs -0 ${SED_PREFIX} 's/${oldJNIReanimatedPackage}/abi${abiVersion}\\/${newJNIReanimatedPackage}/g'`,
       [],
       { shell: true }
     );
@@ -537,13 +538,13 @@ async function cleanUpAsync(version: string) {
   // replace abixx_x_x...R with abixx_x_x.host.exp.expoview.R
   await spawnAsync(
     `find ${versionedAbiSrcPath} -iname '*.java' -type f -print0 | ` +
-      `xargs -0 sed -i '' 's/import ${abiName}\.[^;]*\.R;/import ${abiName}.host.exp.expoview.R;/g'`,
+      `xargs -0 ${SED_PREFIX} 's/import ${abiName}\.[^;]*\.R;/import ${abiName}.host.exp.expoview.R;/g'`,
     [],
     { shell: true }
   );
   await spawnAsync(
     `find ${versionedAbiSrcPath} -iname '*.kt' -type f -print0 | ` +
-      `xargs -0 sed -i '' 's/import ${abiName}\\..*\\.R$/import ${abiName}.host.exp.expoview.R/g'`,
+      `xargs -0 ${SED_PREFIX} 's/import ${abiName}\\..*\\.R$/import ${abiName}.host.exp.expoview.R/g'`,
     [],
     { shell: true }
   );


### PR DESCRIPTION
# Why

sed on macOS and linux take slightly different  arguments

# How


# Test Plan

run versioning on linux

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
