### PR TITLE
[ncl] Fix open and dismiss example for WebBrowser

### DIFF
--- a/apps/native-component-list/src/screens/WebBrowser/OpenBrowserAsyncDemo.tsx
+++ b/apps/native-component-list/src/screens/WebBrowser/OpenBrowserAsyncDemo.tsx
@@ -133,9 +133,10 @@ const FUNCTIONS_DESCRIPTION: FunctionDescription = {
     { name: 'Open', action: WebBrowser.openBrowserAsync },
     {
       name: 'Open and dismiss',
-      action: async (url: string, openOptions: WebBrowser.WebBrowserOpenOptions) => {
-        await WebBrowser.openBrowserAsync(url, openOptions);
-        return WebBrowser.dismissBrowser();
+      action: (url: string, openOptions: WebBrowser.WebBrowserOpenOptions) => {
+        const openBrowserPromise = WebBrowser.openBrowserAsync(url, openOptions);
+        WebBrowser.dismissBrowser();
+        return openBrowserPromise;
       },
     },
     {


### PR DESCRIPTION
# Why

The "Open and dismiss" example for WebBrowser has been broken since the recent refactor (#16411)

# How

`WebBrowser.openBrowserAsync` resolves when the browser closes, so if we want to dismiss it when it's open, we can't await on it.

# Test Plan

The example is working now
