### PR TITLE
[github] fix docs deploy and other AWS related workflows

### DIFF
--- a/.github/workflows/client-android.yml
+++ b/.github/workflows/client-android.yml
@@ -152,6 +152,7 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: AKIAJ3SWUQ4QLNQC7FXA
           AWS_SECRET_ACCESS_KEY: ${{ secrets.android_client_build_aws_secret_key }}
+          AWS_DEFAULT_REGION: 'us-east-1'
           EXPO_VERSIONS_SECRET: ${{ secrets.expo_versions_secret }}
       - name: 📤 Upload APK to Google Play and release to production
         if: ${{ github.event.inputs.releaseGooglePlay == 'release-google-play' }}

--- a/.github/workflows/client-ios.yml
+++ b/.github/workflows/client-ios.yml
@@ -119,6 +119,7 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: 'us-east-1'
           IS_VERSIONED_FLAVOR: ${{ github.event_name == 'schedule' || steps.flavor.outputs.versioned == 'true' }}
       - name: 💾 Save test results
         if: always()
@@ -132,6 +133,7 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: 'us-east-1'
           EXPO_VERSIONS_SECRET: ${{ secrets.EXPO_VERSIONS_SECRET }}
       - name: 🔔 Notify on Slack
         uses: 8398a7/action-slack@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -77,7 +77,7 @@ jobs:
           yarn test-links http://127.0.0.1:8000
         timeout-minutes: 1
       - run: ./deploy.sh
-#        if: ${{ github.event.ref == 'refs/heads/main' }}
+        if: ${{ github.event.ref == 'refs/heads/main' }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -77,7 +77,7 @@ jobs:
           yarn test-links http://127.0.0.1:8000
         timeout-minutes: 1
       - run: ./deploy.sh
-        if: ${{ github.event.ref == 'refs/heads/main' }}
+#        if: ${{ github.event.ref == 'refs/heads/main' }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -81,6 +81,7 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: 'us-east-2'
       - name: 🔔 Notify on Slack
         uses: 8398a7/action-slack@v3
         if: failure() && github.event.ref == 'refs/heads/main'

--- a/.github/workflows/shell-app-android.yml
+++ b/.github/workflows/shell-app-android.yml
@@ -82,6 +82,7 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: 'us-east-1'
           S3_URI: s3://exp-artifacts/android-shell-builder-${{ github.sha }}.tar.gz
         run: |
           aws s3 cp --acl public-read artifacts/android-shell-builder.tar.gz $S3_URI

--- a/.github/workflows/shell-app-ios.yml
+++ b/.github/workflows/shell-app-ios.yml
@@ -85,6 +85,7 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: 'us-east-1'
         run: |
           aws s3 cp --acl public-read ${{ steps.tarball.outputs.filename }} s3://exp-artifacts
           echo "Release tarball uploaded to s3://exp-artifacts/${{ steps.tarball.outputs.filename }}"

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -84,6 +84,7 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: 'us-east-1'
       - name: 🗑 Removing SDK version
         run: expotools remove-sdk-version --platform ios --sdkVersion latest
       - name: 🐙 Git working dir is clean


### PR DESCRIPTION
# Why

Should fix:
* https://github.com/expo/expo/runs/6037012263?check_suite_focus=true#step:14:10

Refs:
* https://github.community/t/aws-cli-behavior-change/166884/2

# How

It looks like after the VENVs bump, new AWS CLI version is used, which require user to set `AWS_DEFAULT_REGION`:
* https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html

# Test Plan

Docs deploy on push did not fail.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
