### PR TITLE
[go][Android] Do not show the RN dev menu when shaking

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/VersionedUtils.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/VersionedUtils.kt
@@ -241,6 +241,7 @@ object VersionedUtils {
           instanceManagerBuilderProperties.manifest
         )
       )
+      .setMinNumShakes(100) // disable the RN dev menu
       .setInitialLifecycleState(LifecycleState.BEFORE_CREATE)
       .setCustomPackagerCommandHandlers(createPackagerCommandHelpers())
       .setJavaScriptExecutorFactory(createJSExecutorFactory(instanceManagerBuilderProperties))

--- a/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/host/exp/exponent/VersionedUtils.kt
+++ b/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/host/exp/exponent/VersionedUtils.kt
@@ -238,6 +238,7 @@ object VersionedUtils {
           instanceManagerBuilderProperties.manifest
         )
       )
+      .setMinNumShakes(100) // disable the RN dev menu
       .setInitialLifecycleState(LifecycleState.BEFORE_CREATE)
       .setCustomPackagerCommandHandlers(createPackagerCommandHelpers())
       .setJavaScriptExecutorFactory(createJSExecutorFactory(instanceManagerBuilderProperties))

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/host/exp/exponent/VersionedUtils.kt
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/host/exp/exponent/VersionedUtils.kt
@@ -238,6 +238,7 @@ object VersionedUtils {
           instanceManagerBuilderProperties.manifest
         )
       )
+      .setMinNumShakes(100) // disable the RN dev menu
       .setInitialLifecycleState(LifecycleState.BEFORE_CREATE)
       .setCustomPackagerCommandHandlers(createPackagerCommandHelpers())
       .setJavaScriptExecutorFactory(createJSExecutorFactory(instanceManagerBuilderProperties))


### PR DESCRIPTION
# Why

Right now, when you are using Expo Go and start shaking your device, you will see an RN dev menu pop-up. I think that isn't the desired behaviour. 

# How

Unfortunately, react-native doesn't provide any API to deal with the menu. However, we can set the number of shakes to the open menu. It isn't the best solution, but it's doing the job.

# Test Plan

- Expo Go ✅