### PR TITLE
chore(cli): lazy load all env vars

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -36,4 +36,4 @@
 
 - Improve contributing. ([#16917](https://github.com/expo/expo/pull/16917) by [@EvanBacon](https://github.com/EvanBacon))
 - Reduce mock clearing and add `Log` import/export. ([#17046](https://github.com/expo/expo/pull/17046) by [@EvanBacon](https://github.com/EvanBacon))
-- Lazily evaluate all environment variables.
+- Lazily evaluate all environment variables. ([#17082](https://github.com/expo/expo/pull/17082) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -36,3 +36,4 @@
 
 - Improve contributing. ([#16917](https://github.com/expo/expo/pull/16917) by [@EvanBacon](https://github.com/EvanBacon))
 - Reduce mock clearing and add `Log` import/export. ([#17046](https://github.com/expo/expo/pull/17046) by [@EvanBacon](https://github.com/EvanBacon))
+- Lazily evaluate all environment variables.

--- a/packages/@expo/cli/src/api/endpoint.ts
+++ b/packages/@expo/cli/src/api/endpoint.ts
@@ -1,10 +1,10 @@
-import { EXPO_LOCAL, EXPO_STAGING } from '../utils/env';
+import { env } from '../utils/env';
 
 /** Get the URL for the expo.dev API. */
 export function getExpoApiBaseUrl(): string {
-  if (EXPO_STAGING) {
+  if (env.EXPO_STAGING) {
     return `https://staging-api.expo.dev`;
-  } else if (EXPO_LOCAL) {
+  } else if (env.EXPO_LOCAL) {
     return `http://127.0.0.1:3000`;
   } else {
     return `https://api.expo.dev`;

--- a/packages/@expo/cli/src/api/getExpoSchema.ts
+++ b/packages/@expo/cli/src/api/getExpoSchema.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import schemaDerefSync from 'json-schema-deref-sync';
 import path from 'path';
 
-import { EXPO_UNIVERSE_DIR } from '../utils/env';
+import { env } from '../utils/env';
 import { CommandError } from '../utils/errors';
 import { createCachedFetch } from './rest/client';
 
@@ -48,11 +48,17 @@ export async function getAssetSchemasAsync(sdkVersion: string = 'UNVERSIONED'): 
 }
 
 async function getSchemaJSONAsync(sdkVersion: string): Promise<{ schema: Schema }> {
-  if (EXPO_UNIVERSE_DIR) {
+  if (env.EXPO_UNIVERSE_DIR) {
     return JSON.parse(
       fs
         .readFileSync(
-          path.join(EXPO_UNIVERSE_DIR, 'server', 'www', 'xdl-schemas', 'UNVERSIONED-schema.json')
+          path.join(
+            env.EXPO_UNIVERSE_DIR,
+            'server',
+            'www',
+            'xdl-schemas',
+            'UNVERSIONED-schema.json'
+          )
         )
         .toString()
     );

--- a/packages/@expo/cli/src/api/getVersions.ts
+++ b/packages/@expo/cli/src/api/getVersions.ts
@@ -1,4 +1,4 @@
-import { EXPO_BETA } from '../utils/env';
+import { env } from '../utils/env';
 import { CommandError } from '../utils/errors';
 import { pickBy } from '../utils/obj';
 import { createCachedFetch } from './rest/client';
@@ -70,6 +70,6 @@ export async function getReleasedVersionsAsync({
   const { sdkVersions } = await getVersionsAsync({ skipCache });
   return pickBy(
     sdkVersions,
-    (data, _sdkVersionString) => !!data.releaseNoteUrl || (EXPO_BETA && data.beta)
+    (data, _sdkVersionString) => !!data.releaseNoteUrl || (env.EXPO_BETA && data.beta)
   );
 }

--- a/packages/@expo/cli/src/api/rest/client.ts
+++ b/packages/@expo/cli/src/api/rest/client.ts
@@ -3,7 +3,7 @@ import { JSONValue } from '@expo/json-file';
 import fetchInstance from 'node-fetch';
 import path from 'path';
 
-import { EXPO_BETA, env } from '../../utils/env';
+import { env } from '../../utils/env';
 import { getExpoApiBaseUrl } from '../endpoint';
 import UserSettings from '../user/UserSettings';
 import { FileSystemCache } from './cache/FileSystemCache';
@@ -109,7 +109,7 @@ export function createCachedFetch({
   skipCache?: boolean;
 }): FetchLike {
   // Disable all caching in EXPO_BETA.
-  if (skipCache || EXPO_BETA || env.EXPO_NO_CACHE) {
+  if (skipCache || env.EXPO_BETA || env.EXPO_NO_CACHE) {
     return fetch ?? fetchWithCredentials;
   }
 

--- a/packages/@expo/cli/src/log.ts
+++ b/packages/@expo/cli/src/log.ts
@@ -14,8 +14,8 @@ export function error(...message: string[]): void {
 
 /** Print an error and provide additional info (the stack trace) in debug mode. */
 export function exception(e: Error): void {
-  const { EXPO_DEBUG } = require('./utils/env');
-  error(chalk.red(e.toString()) + (EXPO_DEBUG ? '\n' + chalk.gray(e.stack) : ''));
+  const { env } = require('./utils/env');
+  error(chalk.red(e.toString()) + (env.EXPO_DEBUG ? '\n' + chalk.gray(e.stack) : ''));
 }
 
 export function warn(...message: string[]): void {
@@ -27,7 +27,7 @@ export function log(...message: string[]): void {
 }
 
 export function debug(...message: any[]): void {
-  if (require('./utils/env').EXPO_DEBUG) console.log(...message);
+  if (require('./utils/env').env.EXPO_DEBUG) console.log(...message);
 }
 
 /** Clear the terminal of all text. */

--- a/packages/@expo/cli/src/prebuild/clearNativeFolder.ts
+++ b/packages/@expo/cli/src/prebuild/clearNativeFolder.ts
@@ -5,7 +5,7 @@ import path from 'path';
 
 import * as Log from '../log';
 import { directoryExistsAsync } from '../utils/dir';
-import { CI } from '../utils/env';
+import { env } from '../utils/env';
 import { logNewSection } from '../utils/ora';
 import { confirmAsync } from '../utils/prompts';
 
@@ -130,7 +130,7 @@ export async function promptToClearMalformedNativeProjectsAsync(
   if (
     // If the process is non-interactive, default to clearing the malformed native project.
     // This would only happen on re-running eject.
-    CI ||
+    env.CI ||
     // Prompt to clear the native folders.
     (await confirmAsync({
       message: `${message}, would you like to clear the project files and reinitialize them?`,

--- a/packages/@expo/cli/src/prebuild/configureProjectAsync.ts
+++ b/packages/@expo/cli/src/prebuild/configureProjectAsync.ts
@@ -4,7 +4,7 @@ import { getPrebuildConfigAsync } from '@expo/prebuild-config';
 
 import { logConfig } from '../config/configAsync';
 import * as Log from '../log';
-import { EXPO_DEBUG } from '../utils/env';
+import { env } from '../utils/env';
 import {
   getOrPromptForBundleIdentifier,
   getOrPromptForPackage,
@@ -45,7 +45,7 @@ export async function configureProjectAsync(
     assertMissingModProviders: false,
   });
 
-  if (EXPO_DEBUG) {
+  if (env.EXPO_DEBUG) {
     Log.log();
     Log.log('Evaluated config:');
     logConfig(config);

--- a/packages/@expo/cli/src/register/registerAsync.ts
+++ b/packages/@expo/cli/src/register/registerAsync.ts
@@ -1,12 +1,12 @@
 import openBrowserAsync from 'better-opn';
 
-import { CI } from '../utils/env';
+import { env } from '../utils/env';
 import { CommandError } from '../utils/errors';
 import { learnMore } from '../utils/link';
 import { ora } from '../utils/ora';
 
 export async function registerAsync() {
-  if (CI) {
+  if (env.CI) {
     throw new CommandError(
       'NON_INTERACTIVE',
       `Cannot register an account in CI. Use the EXPO_TOKEN environment variable to authenticate in CI (${learnMore(

--- a/packages/@expo/cli/src/start/doctor/dependencies/ensureDependenciesAsync.ts
+++ b/packages/@expo/cli/src/start/doctor/dependencies/ensureDependenciesAsync.ts
@@ -4,7 +4,7 @@ import chalk from 'chalk';
 import wrapAnsi from 'wrap-ansi';
 
 import * as Log from '../../../log';
-import { CI, EXPO_DEBUG } from '../../../utils/env';
+import { env } from '../../../utils/env';
 import { CommandError } from '../../../utils/errors';
 import { logNewSection } from '../../../utils/ora';
 import { confirmAsync } from '../../../utils/prompts';
@@ -18,7 +18,7 @@ export async function ensureDependenciesAsync(
     warningMessage,
     installMessage,
     // Don't prompt in CI
-    skipPrompt = CI,
+    skipPrompt = env.CI,
   }: {
     exp?: ExpoConfig;
     installMessage: string;
@@ -128,7 +128,7 @@ async function installPackagesAsync(
   const packageManager = PackageManager.createForProject(projectRoot, {
     yarn: isYarn,
     log: Log.log,
-    silent: !EXPO_DEBUG,
+    silent: !env.EXPO_DEBUG,
   });
 
   const packagesStr = chalk.bold(packages.join(', '));

--- a/packages/@expo/cli/src/start/doctor/ngrok/ExternalModule.ts
+++ b/packages/@expo/cli/src/start/doctor/ngrok/ExternalModule.ts
@@ -5,7 +5,7 @@ import semver from 'semver';
 
 import * as Log from '../../../log';
 import { delayAsync } from '../../../utils/delay';
-import { EXPO_DEBUG } from '../../../utils/env';
+import { env } from '../../../utils/env';
 import { CommandError } from '../../../utils/errors';
 import { confirmAsync } from '../../../utils/prompts';
 
@@ -106,10 +106,10 @@ export class ExternalModule<TModule> {
         ? new PackageManager.NpmPackageManager({
             cwd: this.projectRoot,
             log: Log.log,
-            silent: !EXPO_DEBUG,
+            silent: !env.EXPO_DEBUG,
           })
         : PackageManager.createForProject(this.projectRoot, {
-            silent: !EXPO_DEBUG,
+            silent: !env.EXPO_DEBUG,
           });
 
       try {

--- a/packages/@expo/cli/src/start/server/webpack/WebpackBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/webpack/WebpackBundlerDevServer.ts
@@ -9,7 +9,7 @@ import type webpack from 'webpack';
 import type WebpackDevServer from 'webpack-dev-server';
 
 import * as Log from '../../../log';
-import { WEB_HOST } from '../../../utils/env';
+import { env } from '../../../utils/env';
 import { CommandError } from '../../../utils/errors';
 import { getIpAddress } from '../../../utils/ip';
 import { choosePortAsync } from '../../../utils/port';
@@ -155,7 +155,7 @@ export class WebpackBundlerDevServer extends BundlerDevServer {
       const defaultPort = options?.defaultPort ?? 19006;
       const port = await choosePortAsync(this.projectRoot, {
         defaultPort,
-        host: WEB_HOST,
+        host: env.WEB_HOST,
       });
       if (!port) {
         throw new CommandError('NO_PORT_FOUND', `Port ${defaultPort} not available.`);
@@ -241,7 +241,7 @@ export class WebpackBundlerDevServer extends BundlerDevServer {
       config.devServer
     );
     // Launch WebpackDevServer.
-    server.listen(port, WEB_HOST, function (this: http.Server, error) {
+    server.listen(port, env.WEB_HOST, function (this: http.Server, error) {
       if (nativeMiddleware) {
         attachNativeDevServerMiddlewareToDevServer({
           server: this,

--- a/packages/@expo/cli/src/start/startAsync.ts
+++ b/packages/@expo/cli/src/start/startAsync.ts
@@ -4,7 +4,7 @@ import chalk from 'chalk';
 import * as Log from '../log';
 import getDevClientProperties from '../utils/analytics/getDevClientProperties';
 import { logEvent } from '../utils/analytics/rudderstackClient';
-import { CI } from '../utils/env';
+import { env } from '../utils/env';
 import { installExitHooks } from '../utils/exit';
 import { profile } from '../utils/profile';
 import { validateDependenciesVersionsAsync } from './doctor/dependencies/validateDependenciesVersions';
@@ -109,7 +109,7 @@ export async function startAsync(
   await profile(openPlatformsAsync)(devServerManager, options);
 
   // Present the Terminal UI.
-  if (!CI) {
+  if (!env.CI) {
     await profile(startInterfaceAsync)(devServerManager, {
       platforms: exp.platforms ?? ['ios', 'android', 'web'],
     });
@@ -125,7 +125,7 @@ export async function startAsync(
   const logLocation = settings.webOnly ? 'in the browser console' : 'below';
   Log.log(
     chalk`Logs for your project will appear ${logLocation}.${
-      CI ? '' : chalk.dim(` Press Ctrl+C to exit.`)
+      env.CI ? '' : chalk.dim(` Press Ctrl+C to exit.`)
     }`
   );
 }

--- a/packages/@expo/cli/src/utils/analytics/rudderstackClient.ts
+++ b/packages/@expo/cli/src/utils/analytics/rudderstackClient.ts
@@ -3,7 +3,7 @@ import os from 'os';
 import { v4 as uuidv4 } from 'uuid';
 
 import UserSettings from '../../api/user/UserSettings';
-import { EXPO_LOCAL, EXPO_STAGING, EXPO_NO_TELEMETRY } from '../env';
+import { env } from '../env';
 
 const PLATFORM_TO_ANALYTICS_PLATFORM: { [platform: string]: string } = {
   darwin: 'Mac',
@@ -25,7 +25,9 @@ function getClient(): RudderAnalytics {
   }
 
   client = new RudderAnalytics(
-    EXPO_STAGING || EXPO_LOCAL ? '24TKICqYKilXM480mA7ktgVDdea' : '24TKR7CQAaGgIrLTgu3Fp4OdOkI', // expo unified
+    env.EXPO_STAGING || env.EXPO_LOCAL
+      ? '24TKICqYKilXM480mA7ktgVDdea'
+      : '24TKR7CQAaGgIrLTgu3Fp4OdOkI', // expo unified
     'https://cdp.expo.dev/v1/batch',
     {
       flushInterval: 300,
@@ -40,7 +42,7 @@ function getClient(): RudderAnalytics {
 }
 
 export async function setUserDataAsync(userId: string, traits: Record<string, any>): Promise<void> {
-  if (EXPO_NO_TELEMETRY) {
+  if (env.EXPO_NO_TELEMETRY) {
     return;
   }
 
@@ -65,7 +67,7 @@ export function logEvent(
     | 'Serve Expo Updates Manifest',
   properties: Record<string, any> = {}
 ): void {
-  if (EXPO_NO_TELEMETRY) {
+  if (env.EXPO_NO_TELEMETRY) {
     return;
   }
   ensureIdentified();
@@ -83,7 +85,7 @@ export function logEvent(
 }
 
 function ensureIdentified(): void {
-  if (EXPO_NO_TELEMETRY || identified || !identifyData) {
+  if (env.EXPO_NO_TELEMETRY || identified || !identifyData) {
     return;
   }
 

--- a/packages/@expo/cli/src/utils/cocoapods.ts
+++ b/packages/@expo/cli/src/utils/cocoapods.ts
@@ -8,7 +8,7 @@ import path from 'path';
 import * as Log from '../log';
 import { hashForDependencyMap } from '../prebuild/updatePackageJson';
 import { ensureDirectoryAsync } from './dir';
-import { EXPO_DEBUG } from './env';
+import { env } from './env';
 import { logNewSection } from './ora';
 
 type PackageChecksums = {
@@ -76,7 +76,7 @@ export async function installCocoaPodsAsync(projectRoot: string): Promise<boolea
 
   const packageManager = new PackageManager.CocoaPodsPackageManager({
     cwd: path.join(projectRoot, 'ios'),
-    silent: !EXPO_DEBUG,
+    silent: !env.EXPO_DEBUG,
   });
 
   if (!(await packageManager.isCLIInstalledAsync())) {

--- a/packages/@expo/cli/src/utils/env.ts
+++ b/packages/@expo/cli/src/utils/env.ts
@@ -1,40 +1,59 @@
 import { boolish, int, string } from 'getenv';
 
-/** Skip warning users about a dirty git status */
-export const EXPO_NO_GIT_STATUS = boolish('EXPO_NO_GIT_STATUS', false);
-
-/** Enable profiling metrics */
-export const EXPO_PROFILE = boolish('EXPO_PROFILE', false);
-
-/** Enable debug logging */
-export const EXPO_DEBUG = boolish('EXPO_DEBUG', false);
-
-/** Enable the beta version of Expo (TODO: Should this just be in the beta version of expo releases?) */
-export const EXPO_BETA = boolish('EXPO_BETA', false);
-
-/** Enable staging API environment */
-export const EXPO_STAGING = boolish('EXPO_STAGING', false);
-
-/** Enable local API environment */
-export const EXPO_LOCAL = boolish('EXPO_LOCAL', false);
-
-/** Is running in non-interactive CI mode */
-export const CI = boolish('CI', false);
-
-/** Disable telemetry (analytics) */
-export const EXPO_NO_TELEMETRY = boolish('EXPO_NO_TELEMETRY', false);
-
-/** local directory to the universe repo for testing locally */
-export const EXPO_UNIVERSE_DIR = string('EXPO_UNIVERSE_DIR', '');
-
-/** @deprecated Default Webpack host string */
-export const WEB_HOST = string('WEB_HOST', '0.0.0.0');
-
 // @expo/webpack-config -> expo-pwa -> @expo/image-utils: EXPO_IMAGE_UTILS_NO_SHARP
 
 // TODO: EXPO_CLI_USERNAME, EXPO_CLI_PASSWORD
 
 class Env {
+  /** Enable profiling metrics */
+  get EXPO_PROFILE() {
+    return boolish('EXPO_PROFILE', false);
+  }
+
+  /** Enable debug logging */
+  get EXPO_DEBUG() {
+    return boolish('EXPO_DEBUG', false);
+  }
+
+  /** Enable the beta version of Expo (TODO: Should this just be in the beta version of expo releases?) */
+  get EXPO_BETA() {
+    return boolish('EXPO_BETA', false);
+  }
+
+  /** Enable staging API environment */
+  get EXPO_STAGING() {
+    return boolish('EXPO_STAGING', false);
+  }
+
+  /** Enable local API environment */
+  get EXPO_LOCAL() {
+    return boolish('EXPO_LOCAL', false);
+  }
+
+  /** Is running in non-interactive CI mode */
+  get CI() {
+    return boolish('CI', false);
+  }
+
+  /** Disable telemetry (analytics) */
+  get EXPO_NO_TELEMETRY() {
+    return boolish('EXPO_NO_TELEMETRY', false);
+  }
+
+  /** local directory to the universe repo for testing locally */
+  get EXPO_UNIVERSE_DIR() {
+    return string('EXPO_UNIVERSE_DIR', '');
+  }
+
+  /** @deprecated Default Webpack host string */
+  get WEB_HOST() {
+    return string('WEB_HOST', '0.0.0.0');
+  }
+
+  /** Skip warning users about a dirty git status */
+  get EXPO_NO_GIT_STATUS() {
+    return boolish('EXPO_NO_GIT_STATUS', false);
+  }
   /** Disable auto web setup */
   get EXPO_NO_WEB_SETUP() {
     return boolish('EXPO_NO_WEB_SETUP', false);

--- a/packages/@expo/cli/src/utils/git.ts
+++ b/packages/@expo/cli/src/utils/git.ts
@@ -2,11 +2,11 @@ import spawnAsync from '@expo/spawn-async';
 import chalk from 'chalk';
 
 import * as Log from '../log';
-import { CI, EXPO_NO_GIT_STATUS } from './env';
+import { env } from './env';
 import { confirmAsync } from './prompts';
 
 export async function maybeBailOnGitStatusAsync(): Promise<boolean> {
-  if (EXPO_NO_GIT_STATUS) {
+  if (env.EXPO_NO_GIT_STATUS) {
     Log.warn(
       'Git status is dirty but the command will continue because EXPO_NO_GIT_STATUS is enabled...'
     );
@@ -16,7 +16,7 @@ export async function maybeBailOnGitStatusAsync(): Promise<boolean> {
 
   // Give people a chance to bail out if git working tree is dirty
   if (!isGitStatusClean) {
-    if (CI) {
+    if (env.CI) {
       Log.warn(
         `Git status is dirty but the command will continue because the terminal is not interactive.`
       );

--- a/packages/@expo/cli/src/utils/nodeModules.ts
+++ b/packages/@expo/cli/src/utils/nodeModules.ts
@@ -6,7 +6,7 @@ import path from 'path';
 import semver from 'semver';
 
 import * as Log from '../log';
-import { EXPO_DEBUG } from './env';
+import { env } from './env';
 import { SilentError } from './errors';
 import { logNewSection } from './ora';
 
@@ -40,7 +40,7 @@ export async function installNodeDependenciesAsync(
   flags: { silent?: boolean; clean?: boolean } = {}
 ) {
   // Default to silent unless debugging.
-  const isSilent = flags.silent ?? !EXPO_DEBUG;
+  const isSilent = flags.silent ?? !env.EXPO_DEBUG;
   if (flags.clean && packageManager !== 'yarn') {
     // This step can take a couple seconds, if the installation logs are enabled (with EXPO_DEBUG) then it
     // ends up looking odd to see "Installing JavaScript dependencies" for ~5 seconds before the logs start showing up.

--- a/packages/@expo/cli/src/utils/ora.ts
+++ b/packages/@expo/cli/src/utils/ora.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import oraReal, { Ora } from 'ora';
 
 // import * as Log from '../log';
-import { CI, EXPO_DEBUG } from './env';
+import { env } from './env';
 
 // eslint-disable-next-line no-console
 const logReal = console.log;
@@ -27,7 +27,7 @@ export function getAllSpinners() {
  */
 export function ora(options?: oraReal.Options | string): oraReal.Ora {
   const inputOptions = typeof options === 'string' ? { text: options } : options || {};
-  const disabled = CI || EXPO_DEBUG;
+  const disabled = env.CI || env.EXPO_DEBUG;
   const spinner = oraReal({
     // Ensure our non-interactive mode emulates CI mode.
     isEnabled: !disabled,

--- a/packages/@expo/cli/src/utils/profile.ts
+++ b/packages/@expo/cli/src/utils/profile.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 
 import * as Log from '../log';
-import { EXPO_PROFILE } from './env';
+import { env } from './env';
 
 /**
  * Wrap a method and profile the time it takes to execute the method using `EXPO_PROFILE`.
@@ -14,7 +14,7 @@ export function profile<IArgs extends any[], T extends (...args: IArgs) => any>(
   fn: T,
   functionName: string = fn.name
 ): T {
-  if (!EXPO_PROFILE) {
+  if (!env.EXPO_PROFILE) {
     return fn;
   }
 

--- a/packages/@expo/cli/src/utils/prompts.ts
+++ b/packages/@expo/cli/src/utils/prompts.ts
@@ -2,7 +2,7 @@ import assert from 'assert';
 import prompts, { Choice, Options, PromptObject, PromptType } from 'prompts';
 
 import * as Log from '../log';
-import { CI } from './env';
+import { env } from './env';
 import { AbortCommandError, CommandError } from './errors';
 
 export type Question<V extends string = string> = PromptObject<V> & {
@@ -31,7 +31,7 @@ export default async function prompt(
   { nonInteractiveHelp, ...options }: PromptOptions = {}
 ) {
   questions = Array.isArray(questions) ? questions : [questions];
-  if (CI && questions.length !== 0) {
+  if (env.CI && questions.length !== 0) {
     let message = `Input is required, but 'npx expo' is in non-interactive mode.\n`;
     if (nonInteractiveHelp) {
       message += nonInteractiveHelp;


### PR DESCRIPTION

# Why

lazily loading all environment variables makes it easier to test different cases since you can change the value of things like `CI` between tests.

# Test Plan

Tests should continue to pass.