### PR TITLE
[docs] Adds AppJS banner

### DIFF
--- a/docs/components/AppJSBanner.tsx/Background.tsx
+++ b/docs/components/AppJSBanner.tsx/Background.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+export function Background() {
+  return (
+    <svg width="220" viewBox="0 0 180 91" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M66.4685 1.34497L39.5154 24.121C46.5154 38.121 60.0154 68.121 60.0154 68.121L23.0154 90.2211M8.77063 2.0617L120.224 19.383L179.5 1.80193M48.9083 2.0617L91.0154 41.621L1.51537 24.121L22.5082 2.0617M3.01537 72.121L23.0154 41.621L53.0154 81.621L23.0154 63.121L3.01537 72.121Z"
+        stroke="#3246CC"
+        strokeLinejoin="round"
+      />
+      <circle cx="52.5154" cy="81.121" r="2" fill="#8490E1" />
+      <circle cx="23.0597" cy="41.371" r="2" fill="#8490E1" />
+      <circle cx="39.5154" cy="24.121" r="2" fill="#8490E1" />
+      <circle cx="56.5154" cy="9.52374" r="2" fill="#8490E1" />
+      <circle cx="90.5154" cy="41.371" r="2" fill="#8490E1" />
+      <circle cx="119.555" cy="19.4351" r="2" fill="#8490E1" />
+      <circle cx="2.51537" cy="72.121" r="2" fill="#8490E1" />
+    </svg>
+  );
+}

--- a/docs/components/AppJSBanner.tsx/index.tsx
+++ b/docs/components/AppJSBanner.tsx/index.tsx
@@ -61,12 +61,6 @@ const backgroundStyle = css({
   left: -4,
 });
 
-const buttonContainerStyle = css({
-  display: 'flex',
-  alignItems: 'center',
-  gap: spacing[3],
-});
-
 const headlineStyle = css({
   position: 'relative',
   color: theme.palette.white,
@@ -81,14 +75,4 @@ const descriptionStyle = css({
 const learnMoreButtonStyle = css({
   backgroundColor: theme.palette.white,
   color: '#0019C1',
-});
-
-const hideButtonStyle = css({
-  backgroundColor: '#0019C1',
-  color: theme.palette.white,
-
-  ':hover': {
-    boxShadow: 'none',
-    backgroundColor: '#2945FF',
-  },
 });

--- a/docs/components/AppJSBanner.tsx/index.tsx
+++ b/docs/components/AppJSBanner.tsx/index.tsx
@@ -27,8 +27,7 @@ export function AppJSBanner() {
       <div>
         <HEADLINE css={headlineStyle}>App.js Conf 2022</HEADLINE>
         <CALLOUT css={descriptionStyle}>
-          The first Expo &amp; React Native conference in Europe is back, June 8 - 10 in Kraków,
-          Poland!
+          An Expo &amp; React Native conference in Europe is back, June 8 - 10 in Kraków, Poland!
         </CALLOUT>
       </div>
       <Button size="mini" href="https://appjs.co" openInNewTab css={learnMoreButtonStyle}>

--- a/docs/components/AppJSBanner.tsx/index.tsx
+++ b/docs/components/AppJSBanner.tsx/index.tsx
@@ -1,0 +1,95 @@
+import { css } from '@emotion/react';
+import { borderRadius, breakpoints, shadows, spacing, theme } from '@expo/styleguide';
+import isBefore from 'date-fns/isBefore';
+import { useRouter } from 'next/router';
+import React from 'react';
+
+import { Background } from './Background';
+
+import { Button } from '~/ui/components/Button';
+import { CALLOUT, HEADLINE } from '~/ui/components/Text';
+
+export function AppJSBanner() {
+  const router = useRouter();
+  const appJSConfEndDate = new Date('2022-06-08');
+  const showAppJSConfShoutout = isBefore(new Date(), appJSConfEndDate);
+  const isHomePage = router.pathname === '/';
+
+  if (!showAppJSConfShoutout || !isHomePage) {
+    return null;
+  }
+
+  return (
+    <div css={containerStyle}>
+      <div css={backgroundStyle}>
+        <Background />
+      </div>
+      <div>
+        <HEADLINE css={headlineStyle}>App.js Conf 2022</HEADLINE>
+        <CALLOUT css={descriptionStyle}>
+          The first Expo &amp; React Native conference in Europe is back, June 8 - 10 in Kraków,
+          Poland!
+        </CALLOUT>
+      </div>
+      <Button size="mini" href="https://appjs.co" openInNewTab css={learnMoreButtonStyle}>
+        Learn more
+      </Button>
+    </div>
+  );
+}
+
+const containerStyle = css({
+  position: 'relative',
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  backgroundColor: '#0019C1',
+  padding: `${spacing[4]}px ${spacing[6]}px ${spacing[4]}px ${spacing[4]}px`,
+  borderRadius: borderRadius.medium,
+  overflow: 'hidden',
+  gap: spacing[3],
+  boxShadow: shadows.micro,
+  marginBottom: spacing[10],
+
+  [`@media (max-width: ${breakpoints.medium}px)`]: {
+    flexWrap: 'wrap',
+  },
+});
+
+const backgroundStyle = css({
+  position: 'absolute',
+  top: -4,
+  left: -4,
+});
+
+const buttonContainerStyle = css({
+  display: 'flex',
+  alignItems: 'center',
+  gap: spacing[3],
+});
+
+const headlineStyle = css({
+  position: 'relative',
+  color: theme.palette.white,
+  marginBottom: spacing[1],
+});
+
+const descriptionStyle = css({
+  position: 'relative',
+  color: '#CCD3FF',
+});
+
+const learnMoreButtonStyle = css({
+  backgroundColor: theme.palette.white,
+  color: '#0019C1',
+});
+
+const hideButtonStyle = css({
+  backgroundColor: '#0019C1',
+  color: theme.palette.white,
+
+  ':hover': {
+    boxShadow: 'none',
+    backgroundColor: '#2945FF',
+  },
+});

--- a/docs/components/DocumentationPage.tsx
+++ b/docs/components/DocumentationPage.tsx
@@ -4,6 +4,8 @@ import some from 'lodash/some';
 import Router, { NextRouter } from 'next/router';
 import * as React from 'react';
 
+import { AppJSBanner } from './AppJSBanner.tsx';
+
 import * as Utilities from '~/common/utilities';
 import * as WindowUtils from '~/common/window';
 import DocumentationFooter from '~/components/DocumentationFooter';
@@ -278,6 +280,7 @@ class DocumentationPageWithApiVersion extends React.Component<Props, State> {
 
         {!this.state.isMenuActive ? (
           <div css={STYLES_DOCUMENT}>
+            <AppJSBanner />
             <H1>{this.props.title}</H1>
             {this.props.children}
             <DocumentationFooter

--- a/docs/package.json
+++ b/docs/package.json
@@ -31,6 +31,7 @@
     "@mdx-js/runtime": "^1.6.22",
     "@reach/tabs": "^0.15.0",
     "@sentry/browser": "^5.6.1",
+    "date-fns": "^2.28.0",
     "docsearch.js": "^2.5.2",
     "emoji-regex": "^9.2.2",
     "front-matter": "^2.3.0",

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -3068,6 +3068,11 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
+date-fns@^2.28.0:
+  version "2.28.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.28.0.tgz#9570d656f5fc13143e50c975a3b6bbeb46cd08b2"
+  integrity sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==
+
 debug@2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"


### PR DESCRIPTION
# Why

Adds a banner to advertise AppJS on the home page of the docs.

# Screenshots

<img width="1376" alt="Screen Shot 2022-04-15 at 1 43 16 PM" src="https://user-images.githubusercontent.com/6455018/163603468-f7c801e6-e055-446f-810e-d64397e164a7.png">

# Test Plan

Go to the docs and make sure you see the banner as pictured above. Make sure it looks good on mobile. Also, make sure it only appears on the home page (no other pages).