### PR TITLE
[home] fix Android pull-to-refresh

### DIFF
--- a/dev-home-config.json
+++ b/dev-home-config.json
@@ -1,3 +1,3 @@
 {
-  "url": "exp://exp.host/@expo-home-dev/expo-home-dev-F9O0C1Vv"
+  "url": "exp://exp.host/@expo-home-dev/expo-home-dev-fde3610f197fe35b81991a68e410ecdc097f7787"
 }

--- a/home/components/FlatList.tsx
+++ b/home/components/FlatList.tsx
@@ -1,0 +1,4 @@
+import { FlatList as RNFlatList, Platform } from 'react-native';
+import { FlatList as RNGHFlatList } from 'react-native-gesture-handler';
+
+export const FlatList = Platform.OS === 'android' ? RNFlatList : RNGHFlatList;

--- a/home/components/NavigationScrollView.tsx
+++ b/home/components/NavigationScrollView.tsx
@@ -1,7 +1,10 @@
 import { useTheme, useScrollToTop } from '@react-navigation/native';
 import React, { PropsWithChildren, useRef } from 'react';
-import { ScrollViewProps } from 'react-native';
-import { NativeViewGestureHandlerProps, ScrollView } from 'react-native-gesture-handler';
+import { ScrollViewProps, ScrollView as RNScrollView, Platform } from 'react-native';
+import {
+  NativeViewGestureHandlerProps,
+  ScrollView as RNGHScrollView,
+} from 'react-native-gesture-handler';
 
 import Colors, { ColorTheme } from '../constants/Colors';
 
@@ -28,12 +31,14 @@ function useThemeBackgroundColor(props: StyledScrollViewProps, colorName: Themed
   }
 }
 
-export default (props: StyledScrollViewProps) => {
+export default function NavigationScrollView(props: StyledScrollViewProps) {
   const ref = useRef(null);
   const { style, ...otherProps } = props;
   const backgroundColor = useThemeBackgroundColor(props, 'bodyBackground');
 
   useScrollToTop(ref);
 
+  const ScrollView = Platform.OS === 'android' ? RNScrollView : RNGHScrollView;
+
   return <ScrollView style={[{ backgroundColor }, style]} {...otherProps} ref={ref} />;
-};
+}

--- a/home/components/RefreshControl.tsx
+++ b/home/components/RefreshControl.tsx
@@ -1,10 +1,18 @@
 import { useTheme } from '@react-navigation/native';
 import * as React from 'react';
-import { RefreshControl } from 'react-native';
+import { RefreshControl as RNRefreshControl, Platform } from 'react-native';
+import { createNativeWrapper } from 'react-native-gesture-handler';
 
 import Colors from '../constants/Colors';
 
-type Props = React.ComponentProps<typeof RefreshControl>;
+type Props = React.ComponentProps<typeof RNRefreshControl>;
+
+const RNGHRefreshControl = createNativeWrapper(RNRefreshControl, {
+  disallowInterruption: true,
+  shouldCancelWhenOutside: false,
+});
+
+const RefreshControl = Platform.OS === 'android' ? RNRefreshControl : RNGHRefreshControl;
 
 export default function StyledRefreshControl(props: Props) {
   const theme = useTheme();

--- a/home/screens/AccountModal/LoggedInAccountView.tsx
+++ b/home/screens/AccountModal/LoggedInAccountView.tsx
@@ -3,8 +3,9 @@ import { useNavigation } from '@react-navigation/native';
 import { SectionHeader } from 'components/SectionHeader';
 import { Text, View, Image, useExpoTheme, Row, Spacer, Divider } from 'expo-dev-client-components';
 import React from 'react';
-import { TouchableOpacity, FlatList } from 'react-native-gesture-handler';
+import { TouchableOpacity } from 'react-native-gesture-handler';
 
+import { FlatList } from '../../components/FlatList';
 import { Home_CurrentUserQuery } from '../../graphql/types';
 import { useDispatch } from '../../redux/Hooks';
 import SessionActions from '../../redux/SessionActions';

--- a/home/screens/BranchDetailsScreen/BranchDetailsView.tsx
+++ b/home/screens/BranchDetailsScreen/BranchDetailsView.tsx
@@ -5,8 +5,8 @@ import dedent from 'dedent';
 import { Divider, Text, useExpoTheme, View } from 'expo-dev-client-components';
 import * as React from 'react';
 import { ActivityIndicator, RefreshControl } from 'react-native';
-import { FlatList } from 'react-native-gesture-handler';
 
+import { FlatList } from '../../components/FlatList';
 import { SectionHeader } from '../../components/SectionHeader';
 import { UpdateListItem } from '../../components/UpdateListItem';
 import { BranchDetailsQuery } from '../../graphql/types';

--- a/home/screens/BranchListScreen/BranchListView.tsx
+++ b/home/screens/BranchListScreen/BranchListView.tsx
@@ -2,10 +2,10 @@ import { spacing } from '@expo/styleguide-native';
 import { Divider, useExpoTheme, View } from 'expo-dev-client-components';
 import * as React from 'react';
 import { ActivityIndicator, View as RNView } from 'react-native';
-import { FlatList } from 'react-native-gesture-handler';
 import InfiniteScrollView from 'react-native-infinite-scroll-view';
 
 import { BranchListItem } from '../../components/BranchListItem';
+import { FlatList } from '../../components/FlatList';
 import { BranchesForProjectQuery } from '../../graphql/types';
 
 type BranchManifest = {

--- a/home/screens/HomeScreen/HomeScreenView.tsx
+++ b/home/screens/HomeScreen/HomeScreenView.tsx
@@ -119,7 +119,7 @@ export class HomeScreenView extends React.Component<Props, State> {
           {projects?.length ? (
             <View bg="default" rounded="large" border="default" overflow="hidden">
               {projects.map((project, i) => (
-                <React.Fragment key={project.url}>
+                <React.Fragment key={project.description + project.url}>
                   <DevelopmentServerListItem
                     url={project.url}
                     image={
@@ -251,8 +251,6 @@ export class HomeScreenView extends React.Component<Props, State> {
               resolve(undefined);
             }),
       ]);
-
-      console.log({ projects });
 
       this.setState({ projects, data: graphQLResponse?.data.account.byName });
     } catch (e) {

--- a/home/screens/HomeScreen/HomeScreenView.tsx
+++ b/home/screens/HomeScreen/HomeScreenView.tsx
@@ -3,14 +3,20 @@ import { StackScreenProps } from '@react-navigation/stack';
 import Constants from 'expo-constants';
 import { View, Divider, Spacer } from 'expo-dev-client-components';
 import * as React from 'react';
-import { Alert, AppState, NativeEventSubscription, Platform, StyleSheet } from 'react-native';
+import {
+  Alert,
+  AppState,
+  NativeEventSubscription,
+  Platform,
+  StyleSheet,
+  RefreshControl,
+} from 'react-native';
 
 import FeatureFlags from '../../FeatureFlags';
 import ApiV2HttpClient from '../../api/ApiV2HttpClient';
 import ApolloClient from '../../api/ApolloClient';
 import Connectivity from '../../api/Connectivity';
 import ScrollView from '../../components/NavigationScrollView';
-import RefreshControl from '../../components/RefreshControl';
 import { SectionHeader } from '../../components/SectionHeader';
 import ThemedStatusBar from '../../components/ThemedStatusBar';
 import {
@@ -105,6 +111,7 @@ export class HomeScreenView extends React.Component<Props, State> {
           refreshControl={
             <RefreshControl refreshing={isRefreshing} onRefresh={this._handleRefreshAsync} />
           }
+          bounces
           key={Platform.OS === 'ios' ? this.props.allHistory.count() : 'scroll-view'}
           style={styles.container}
           contentContainerStyle={[styles.contentContainer]}>
@@ -244,6 +251,8 @@ export class HomeScreenView extends React.Component<Props, State> {
               resolve(undefined);
             }),
       ]);
+
+      console.log({ projects });
 
       this.setState({ projects, data: graphQLResponse?.data.account.byName });
     } catch (e) {

--- a/home/screens/HomeScreen/HomeScreenView.tsx
+++ b/home/screens/HomeScreen/HomeScreenView.tsx
@@ -119,7 +119,7 @@ export class HomeScreenView extends React.Component<Props, State> {
           {projects?.length ? (
             <View bg="default" rounded="large" border="default" overflow="hidden">
               {projects.map((project, i) => (
-                <React.Fragment key={project.description + project.url}>
+                <React.Fragment key={`${project.description}${project.url}`}>
                   <DevelopmentServerListItem
                     url={project.url}
                     image={

--- a/home/screens/ProjectsListScreen/ProjectList.tsx
+++ b/home/screens/ProjectsListScreen/ProjectList.tsx
@@ -3,9 +3,9 @@ import dedent from 'dedent';
 import { Divider, useExpoTheme, View } from 'expo-dev-client-components';
 import * as React from 'react';
 import { ActivityIndicator, ListRenderItem, View as RNView } from 'react-native';
-import { FlatList } from 'react-native-gesture-handler';
 import InfiniteScrollView from 'react-native-infinite-scroll-view';
 
+import { FlatList } from '../../components/FlatList';
 import PrimaryButton from '../../components/PrimaryButton';
 import { ProjectsListItem } from '../../components/ProjectsListItem';
 import { StyledText } from '../../components/Text';

--- a/home/screens/SnacksListScreen/SnackList.tsx
+++ b/home/screens/SnacksListScreen/SnackList.tsx
@@ -2,9 +2,9 @@ import { spacing } from '@expo/styleguide-native';
 import { Divider, useExpoTheme, View } from 'expo-dev-client-components';
 import * as React from 'react';
 import { ActivityIndicator, View as RNView } from 'react-native';
-import { FlatList } from 'react-native-gesture-handler';
 import InfiniteScrollView from 'react-native-infinite-scroll-view';
 
+import { FlatList } from '../../components/FlatList';
 import { SnacksListItem } from '../../components/SnacksListItem';
 import { CommonSnackDataFragment } from '../../graphql/types';
 


### PR DESCRIPTION
# Why

Switching to RNGH's FlatList/ScrollView resulted in a better UX on iOS, but for android, this bug prevented pull-to-refresh from working: https://github.com/software-mansion/react-native-gesture-handler/issues/1067

# How

- I added some conditional code to use RN's ScrollView and FlatList on Android.
- I also updated the dev servers list React `key`s to make sure that we wouldn't get stale values because the key (server URL) is the same as another project a user recently had running.

This does not fix the problem where updating dev-servers is delayed. That seems to be an API problem because the responses I'm getting back from WWW are incorrect at some points in time. It seems to go from not running -> running quickly, but it holds onto that server after it's killed for a while.

# Test Plan

`fastlane android start` and try refreshing on the home page or Branch details page to make sure that PTR works:

https://user-images.githubusercontent.com/12488826/163625992-9f89cebd-5072-47be-a9a8-bda28d09abdd.mp4


