### PR TITLE
[ios][tools] Fix versioning react-native-reanimated and expo-modules-test-core

### DIFF
--- a/tools/src/versioning/ios/index.ts
+++ b/tools/src/versioning/ios/index.ts
@@ -49,6 +49,10 @@ const EXTERNAL_REACT_ABI_DEPENDENCIES = [
   'RCT-Folly',
 ];
 
+const EXCLUDED_POD_DEPENDENCIES = [
+  'ExpoModulesTestCore'
+];
+
 /**
  *  Transform and rename the given react native source code files.
  *  @param filenames list of files to transform
@@ -437,7 +441,11 @@ async function generateExpoKitPodspecAsync(
     // `universalModulesPodNames` contains only versioned unimodules,
     // so we fall back to the original name if the module is not there
     const universalModulesDependencies = (await getListOfPackagesAsync())
-      .filter((pkg) => pkg.isIncludedInExpoClientOnPlatform('ios') && pkg.podspecName)
+      .filter((pkg) =>
+        pkg.isIncludedInExpoClientOnPlatform('ios') &&
+        pkg.podspecName &&
+        !EXCLUDED_POD_DEPENDENCIES.includes(pkg.podspecName)
+      )
       .map(
         ({ podspecName }) =>
           `ss.dependency         "${universalModulesPodNames[podspecName!] || podspecName}"`

--- a/tools/src/versioning/ios/index.ts
+++ b/tools/src/versioning/ios/index.ts
@@ -49,9 +49,7 @@ const EXTERNAL_REACT_ABI_DEPENDENCIES = [
   'RCT-Folly',
 ];
 
-const EXCLUDED_POD_DEPENDENCIES = [
-  'ExpoModulesTestCore'
-];
+const EXCLUDED_POD_DEPENDENCIES = ['ExpoModulesTestCore'];
 
 /**
  *  Transform and rename the given react native source code files.
@@ -441,10 +439,11 @@ async function generateExpoKitPodspecAsync(
     // `universalModulesPodNames` contains only versioned unimodules,
     // so we fall back to the original name if the module is not there
     const universalModulesDependencies = (await getListOfPackagesAsync())
-      .filter((pkg) =>
-        pkg.isIncludedInExpoClientOnPlatform('ios') &&
-        pkg.podspecName &&
-        !EXCLUDED_POD_DEPENDENCIES.includes(pkg.podspecName)
+      .filter(
+        (pkg) =>
+          pkg.isIncludedInExpoClientOnPlatform('ios') &&
+          pkg.podspecName &&
+          !EXCLUDED_POD_DEPENDENCIES.includes(pkg.podspecName)
       )
       .map(
         ({ podspecName }) =>

--- a/tools/src/versioning/ios/transforms/vendoredModulesTransforms.ts
+++ b/tools/src/versioning/ios/transforms/vendoredModulesTransforms.ts
@@ -60,6 +60,12 @@ export default function vendoredModulesTransformsFactory(prefix: string): Config
       ],
     },
     'react-native-reanimated': {
+      path: [
+        {
+          find: /\b(ReanimatedSensor)/g,
+          replaceWith: `${prefix}$1`,
+        },
+      ],
       content: [
         {
           find: 'namespace reanimated',
@@ -105,6 +111,16 @@ export default function vendoredModulesTransformsFactory(prefix: string): Config
           // the RCTComponentData internal view name is not versioned
           find: new RegExp(`(RCTComponentData .+)\\[@"${prefix}(RCT.+)"\\];`, 'g'),
           replaceWith: '$1[@"$2"];',
+        },
+        {
+          paths: ['**/sensor/**', 'NativeProxy.mm'],
+          find: /\b(ReanimatedSensor)/g,
+          replaceWith: `${prefix}$1`,
+        },
+        {
+          paths: 'REANodesManager.m',
+          find: /\b(ComponentUpdate)\b/g,
+          replaceWith: `${prefix}$1`,
         },
       ],
     },


### PR DESCRIPTION
# Why

The iOS versioning job on the CI is failing again, after upgrading `react-native-reanimated` and introducing `expo-modules-test-core`, with the following errors (and more):

```
duplicate symbol '_NDR_record' in:
    /Users/runner/work/expo/expo/ios/simulator-build/Build/Products/Release-iphonesimulator/Nimble/libNimble.a(AdapterProtocols.o)
    /Users/runner/work/expo/expo/ios/simulator-build/Build/Products/Release-iphonesimulator/Nimble/libNimble.a(CwlCatchBadInstruction.o)
duplicate symbol '_OBJC_CLASS_$_ReanimatedSensor' in:
    /Users/runner/work/expo/expo/ios/simulator-build/Build/Products/Release-iphonesimulator/ABI45_0_0RNReanimated/libABI45_0_0RNReanimated.a(ReanimatedSensor.o)
    /Users/runner/work/expo/expo/ios/simulator-build/Build/Products/Release-iphonesimulator/RNReanimated/libRNReanimated.a(ReanimatedSensor.o)
duplicate symbol '_OBJC_METACLASS_$_ReanimatedSensor' in:
    /Users/runner/work/expo/expo/ios/simulator-build/Build/Products/Release-iphonesimulator/ABI45_0_0RNReanimated/libABI45_0_0RNReanimated.a(ReanimatedSensor.o)
    /Users/runner/work/expo/expo/ios/simulator-build/Build/Products/Release-iphonesimulator/RNReanimated/libRNReanimated.a(ReanimatedSensor.o)
```

# How

- Updated versioning configs for `react-native-reanimated` to properly prefix `ReanimatedSensor*` and `ComponentUpdate` symbols.
- Removed `ExpoModulesTestCore` from the generated ExpoKit podspec (otherwise Quick and Nimble would be included in the binary)

# Test Plan

- `et add-sdk -p ios -s 45.0.0`
- Versioned flavor of Expo Go compiles and launches
- CI job fails, but that's because the Podfile.lock is outdated on the main branch, will fix it separately