### PR TITLE
[tools] fix android versioning sed command on macos added '' filename

### DIFF
--- a/tools/src/versioning/android/android-build-aar.sh
+++ b/tools/src/versioning/android/android-build-aar.sh
@@ -9,9 +9,9 @@ ABI_VERSION_NUMBER=`echo $1 | sed 's/\./_/g'`
 ABI_VERSION="abi$ABI_VERSION_NUMBER"
 TOOLS_DIR=`pwd`
 
-SED_PREFIX="sed -i ''"
+SED_INPLACE_OPT=(-i '')
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-  SED_PREFIX="sed -i"
+  SED_INPLACE_OPT=(-i)
 fi
 
 pushd $EXPO_ROOT_DIR/android
@@ -73,7 +73,7 @@ while read FILE
 do
   while read PACKAGE
   do
-    $SED_PREFIX "s/$PACKAGE/$ABI_VERSION.$PACKAGE/g" $FILE
+    sed "${SED_INPLACE_OPT[@]}" "s/$PACKAGE/$ABI_VERSION.$PACKAGE/g" $FILE
   done < $TOOLS_DIR/android-packages-to-rename.txt
 done < annotations_xmls
 rm annotations_xmls
@@ -96,7 +96,7 @@ java -jar $TOOLS_DIR/jarjar-1.4.1.jar process jarjar-rules.txt expoview/libs/Rea
 
 pushd expoview/libs/ReactAndroid-temp
 # Update the manifest. This is used for deduping in the build process
-$SED_PREFIX "s/com\.facebook\.react/$ABI_VERSION\.com\.facebook\.react/g" AndroidManifest.xml
+sed "${SED_INPLACE_OPT[@]}" "s/com\.facebook\.react/$ABI_VERSION\.com\.facebook\.react/g" AndroidManifest.xml
 
 # Can't rename libc++_shared so remove. We share the copy from ReactAndroid.
 rm -rf jni/*/libc++_shared.so
@@ -122,11 +122,11 @@ NEWLINE='\
 SED_APPEND_COMMAND=" a$NEWLINE"
 REPLACE_TEXT='DO NOT MODIFY'
 ADD_NEW_SDKS_HERE='ADD_NEW_SDKS_HERE'
-$SED_PREFIX "/$ADD_NEW_SDKS_HERE/$SED_APPEND_COMMAND$NEWLINE$NEWLINE\ \ \/\/ BEGIN_SDK_$MAJOR_ABI_VERSION$NEWLINE\ \ versionedImplementation(project(':expoview-$ABI_VERSION'))$NEWLINE\ \ \/\/ END_SDK_$MAJOR_ABI_VERSION$NEWLINE" app/build.gradle
-$SED_PREFIX "/$REPLACE_TEXT/$SED_APPEND_COMMAND\ \ \/\/ BEGIN_SDK_$MAJOR_ABI_VERSION$NEWLINE\ \ versionedApi 'host.exp:reactandroid-$ABI_VERSION:1.0.0'$NEWLINE\ \ \/\/ END_SDK_$MAJOR_ABI_VERSION$NEWLINE" expoview/build.gradle
+sed "${SED_INPLACE_OPT[@]}" "/$ADD_NEW_SDKS_HERE/$SED_APPEND_COMMAND$NEWLINE$NEWLINE\ \ \/\/ BEGIN_SDK_$MAJOR_ABI_VERSION$NEWLINE\ \ versionedImplementation(project(':expoview-$ABI_VERSION'))$NEWLINE\ \ \/\/ END_SDK_$MAJOR_ABI_VERSION$NEWLINE" app/build.gradle
+sed "${SED_INPLACE_OPT[@]}" "/$REPLACE_TEXT/$SED_APPEND_COMMAND\ \ \/\/ BEGIN_SDK_$MAJOR_ABI_VERSION$NEWLINE\ \ versionedApi 'host.exp:reactandroid-$ABI_VERSION:1.0.0'$NEWLINE\ \ \/\/ END_SDK_$MAJOR_ABI_VERSION$NEWLINE" expoview/build.gradle
 
 # Update Constants.java
-$SED_PREFIX "/$REPLACE_TEXT/$SED_APPEND_COMMAND\ \ \ \ \/\/ BEGIN_SDK_$MAJOR_ABI_VERSION$NEWLINE\ \ \ \ abiVersions.add(\"$ORIGINAL_ABI_VERSION\");$NEWLINE\ \ \ \ \/\/ END_SDK_$MAJOR_ABI_VERSION$NEWLINE" expoview/src/main/java/host/exp/exponent/Constants.java
+sed "${SED_INPLACE_OPT[@]}" "/$REPLACE_TEXT/$SED_APPEND_COMMAND\ \ \ \ \/\/ BEGIN_SDK_$MAJOR_ABI_VERSION$NEWLINE\ \ \ \ abiVersions.add(\"$ORIGINAL_ABI_VERSION\");$NEWLINE\ \ \ \ \/\/ END_SDK_$MAJOR_ABI_VERSION$NEWLINE" expoview/src/main/java/host/exp/exponent/Constants.java
 
 # Add new version
 
@@ -137,8 +137,8 @@ $SED_PREFIX "/$REPLACE_TEXT/$SED_APPEND_COMMAND\ \ \ \ \/\/ BEGIN_SDK_$MAJOR_ABI
 BACK_BUTTON_HANDLER_CLASS='com.facebook.react.modules.core.DefaultHardwareBackBtnHandler'
 PERMISSION_AWARE_ACTIVITY_CLASS='com.facebook.react.modules.core.PermissionAwareActivity'
 PERMISSION_LISTENER_CLASS='com.facebook.react.modules.core.PermissionListener'
-find expoview/src/versioned/java/host/exp/exponent -iname '*.java' -type f -print0 | xargs -0 $SED_PREFIX -e "s/ADD_NEW_SDKS_HERE/BEGIN_SDK_$MAJOR_ABI_VERSION$NEWLINE\ \ \ \ $ABI_VERSION\.$BACK_BUTTON_HANDLER_CLASS,$NEWLINE\ \ \ \ $ABI_VERSION\.$PERMISSION_AWARE_ACTIVITY_CLASS,$NEWLINE\ \ \ \ \/\/ END_SDK_$MAJOR_ABI_VERSION$NEWLINE\ \ \ \ \/\/ ADD_NEW_SDKS_HERE/"
+find expoview/src/versioned/java/host/exp/exponent -iname '*.java' -type f -print0 | xargs -0 sed "${SED_INPLACE_OPT[@]}" -e "s/ADD_NEW_SDKS_HERE/BEGIN_SDK_$MAJOR_ABI_VERSION$NEWLINE\ \ \ \ $ABI_VERSION\.$BACK_BUTTON_HANDLER_CLASS,$NEWLINE\ \ \ \ $ABI_VERSION\.$PERMISSION_AWARE_ACTIVITY_CLASS,$NEWLINE\ \ \ \ \/\/ END_SDK_$MAJOR_ABI_VERSION$NEWLINE\ \ \ \ \/\/ ADD_NEW_SDKS_HERE/"
 # Add implementation of PermissionAwareActivity.requestPermissions
-find expoview/src/versioned/java/host/exp/exponent -iname '*.java' -type f -print0 | xargs -0 $SED_PREFIX "s/ADD_NEW_PERMISSION_AWARE_ACTIVITY_IMPLEMENTATION_HERE/BEGIN_SDK_$MAJOR_ABI_VERSION$NEWLINE\ \ \ \ @Override$NEWLINE\ \ \ \ public\ void\ requestPermissions(String\[\]\ strings\,\ int\ i\,\ $ABI_VERSION\.$PERMISSION_LISTENER_CLASS\ permissionListener)\ {$NEWLINE\ \ \ \ \ \ super\.requestPermissions(strings\,\ i\,\ permissionListener::onRequestPermissionsResult);$NEWLINE\ \ \ \ }$NEWLINE\ \ \ \ \/\/ END_SDK_$MAJOR_ABI_VERSION$NEWLINE\ \ \ \ \/\/ ADD_NEW_PERMISSION_AWARE_ACTIVITY_IMPLEMENTATION_HERE/"
+find expoview/src/versioned/java/host/exp/exponent -iname '*.java' -type f -print0 | xargs -0 sed "${SED_INPLACE_OPT[@]}" "s/ADD_NEW_PERMISSION_AWARE_ACTIVITY_IMPLEMENTATION_HERE/BEGIN_SDK_$MAJOR_ABI_VERSION$NEWLINE\ \ \ \ @Override$NEWLINE\ \ \ \ public\ void\ requestPermissions(String\[\]\ strings\,\ int\ i\,\ $ABI_VERSION\.$PERMISSION_LISTENER_CLASS\ permissionListener)\ {$NEWLINE\ \ \ \ \ \ super\.requestPermissions(strings\,\ i\,\ permissionListener::onRequestPermissionsResult);$NEWLINE\ \ \ \ }$NEWLINE\ \ \ \ \/\/ END_SDK_$MAJOR_ABI_VERSION$NEWLINE\ \ \ \ \/\/ ADD_NEW_PERMISSION_AWARE_ACTIVITY_IMPLEMENTATION_HERE/"
 
 popd

--- a/tools/src/versioning/android/android-copy-expo-module.sh
+++ b/tools/src/versioning/android/android-copy-expo-module.sh
@@ -9,9 +9,9 @@ VERSIONED_ABI_PATH=versioned-abis/expoview-$ABI_VERSION
 TOOLS_DIR=`pwd`
 EXPOMODULE_MANIFEST_PATH=$VERSIONED_ABI_PATH/src/main/ExpoModuleAndroidManifest.xml
 
-SED_PREFIX="sed -i ''"
+SED_INPLACE_OPT=(-i '')
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-  SED_PREFIX="sed -i"
+  SED_INPLACE_OPT=(-i)
 fi
 
 pushd $EXPO_ROOT_DIR/android
@@ -33,25 +33,25 @@ done < $TOOLS_DIR/android-packages-to-keep.txt
 
 while read PACKAGE
 do
-  find $VERSIONED_ABI_PATH/src/main/java/$ABI_VERSION \( -iname '*.java' -or -iname '*.kt' \) -type f -print0 | xargs -0 $SED_PREFIX "s/\([, ^\(<]\)$PACKAGE/\1temporarydonotversion.$PACKAGE/g"
-  $SED_PREFIX "s/\([, ^\(<]\)$PACKAGE/\1temporarydonotversion.$PACKAGE/g" $EXPOMODULE_MANIFEST_PATH
+  find $VERSIONED_ABI_PATH/src/main/java/$ABI_VERSION \( -iname '*.java' -or -iname '*.kt' \) -type f -print0 | xargs -0 sed "${SED_INPLACE_OPT[@]}" "s/\([, ^\(<]\)$PACKAGE/\1temporarydonotversion.$PACKAGE/g"
+  sed "${SED_INPLACE_OPT[@]}" "s/\([, ^\(<]\)$PACKAGE/\1temporarydonotversion.$PACKAGE/g" $EXPOMODULE_MANIFEST_PATH
 done < $TOOLS_DIR/android-packages-to-keep.txt
 
 while read PACKAGE
 do
-  find $VERSIONED_ABI_PATH/src/main/java/$ABI_VERSION \( -iname '*.java' -or -iname '*.kt' \) -type f -print0 | xargs -0 $SED_PREFIX "s/\([, ^\(<]\)$PACKAGE/\1$ABI_VERSION.$PACKAGE/g"
-  $SED_PREFIX "s/\([, ^\(<]\)$PACKAGE/\1$ABI_VERSION.$PACKAGE/g" $EXPOMODULE_MANIFEST_PATH
+  find $VERSIONED_ABI_PATH/src/main/java/$ABI_VERSION \( -iname '*.java' -or -iname '*.kt' \) -type f -print0 | xargs -0 sed "${SED_INPLACE_OPT[@]}" "s/\([, ^\(<]\)$PACKAGE/\1$ABI_VERSION.$PACKAGE/g"
+  sed "${SED_INPLACE_OPT[@]}" "s/\([, ^\(<]\)$PACKAGE/\1$ABI_VERSION.$PACKAGE/g" $EXPOMODULE_MANIFEST_PATH
 done < $TOOLS_DIR/android-packages-to-rename.txt
 
 while read PACKAGE
 do
-  find $VERSIONED_ABI_PATH/src/main/java/$ABI_VERSION \( -iname '*.java' -or -iname '*.kt' \) -type f -print0 | xargs -0 $SED_PREFIX "s/\([, ^\(<]\)temporarydonotversion.$PACKAGE/\1$PACKAGE/g"
-  $SED_PREFIX "s/\([, ^\(<]\)temporarydonotversion.$PACKAGE/\1$PACKAGE/g" $EXPOMODULE_MANIFEST_PATH
+  find $VERSIONED_ABI_PATH/src/main/java/$ABI_VERSION \( -iname '*.java' -or -iname '*.kt' \) -type f -print0 | xargs -0 sed "${SED_INPLACE_OPT[@]}" "s/\([, ^\(<]\)temporarydonotversion.$PACKAGE/\1$PACKAGE/g"
+  sed "${SED_INPLACE_OPT[@]}" "s/\([, ^\(<]\)temporarydonotversion.$PACKAGE/\1$PACKAGE/g" $EXPOMODULE_MANIFEST_PATH
 done < $TOOLS_DIR/android-packages-to-keep.txt
 
 # Transform `// EXPO_VERSIONING_NEEDS_EXPOVIEW_R` comment as `import abiN_N_N.host.exp.expoview.R`
-find $VERSIONED_ABI_PATH/src/main/java/$ABI_VERSION -iname '*.java' -type f -print0 | xargs -0 $SED_PREFIX "s/^\/\/ *EXPO_VERSIONING_NEEDS_EXPOVIEW_R/import $ABI_VERSION.host.exp.expoview.R;/g"
-find $VERSIONED_ABI_PATH/src/main/java/$ABI_VERSION -iname '*.kt' -type f -print0 | xargs -0 $SED_PREFIX "s/^\/\/ *EXPO_VERSIONING_NEEDS_EXPOVIEW_R/import $ABI_VERSION.host.exp.expoview.R/g"
+find $VERSIONED_ABI_PATH/src/main/java/$ABI_VERSION -iname '*.java' -type f -print0 | xargs -0 sed "${SED_INPLACE_OPT[@]}" "s/^\/\/ *EXPO_VERSIONING_NEEDS_EXPOVIEW_R/import $ABI_VERSION.host.exp.expoview.R;/g"
+find $VERSIONED_ABI_PATH/src/main/java/$ABI_VERSION -iname '*.kt' -type f -print0 | xargs -0 sed "${SED_INPLACE_OPT[@]}" "s/^\/\/ *EXPO_VERSIONING_NEEDS_EXPOVIEW_R/import $ABI_VERSION.host.exp.expoview.R/g"
 
 # Special modules transform
 PACKAGE_JAVA_BASE_DIR="$VERSIONED_ABI_PATH/src/main/java/$ABI_VERSION"


### PR DESCRIPTION
# Why

from #17074, the android versioning tool will add two single quotes at the end of filename. e.g.
`android/expoview/src/main/java/host/exp/exponent/Constants.java` -> `android/expoview/src/main/java/host/exp/exponent/Constants.java''`

# How

solution refer from https://stackoverflow.com/a/51060063

# Test Plan

`et add-sdk -p android -s 45.0.0`

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
