### PR TITLE
[tools][android] versioning expo-gl-cpp

### DIFF
--- a/packages/expo-gl-cpp/android/build.gradle
+++ b/packages/expo-gl-cpp/android/build.gradle
@@ -12,6 +12,7 @@ def RN_BUILD_FROM_SOURCE = findProject(":ReactAndroid") != null
 def RN_SO_DIR = RN_BUILD_FROM_SOURCE
     ? Paths.get(findProject(":ReactAndroid").getProjectDir().toString(), "build", "intermediates", "library_*", "*", "jni")
     : "${buildDir}/react-native-0*/jni"
+def RN_AAR_DIR = "${REACT_NATIVE_DIR}/android"
 def reactNativeArchitectures() {
     def value = project.getProperties().get("reactNativeArchitectures")
     return value ? value.split(",") : ["armeabi-v7a", "x86", "x86_64", "arm64-v8a"]
@@ -132,7 +133,7 @@ repositories {
 dependencies {
   compileOnly 'com.facebook.soloader:soloader:0.8.2'
 
-  def rnAARs = fileTree("${REACT_NATIVE_DIR}/android").matching { include "**/*.aar" }
+  def rnAARs = fileTree(RN_AAR_DIR).matching { include "**/*.aar" }
   if (rnAARs.any()) {
     // node_modules/react-native has a .aar, extract headers
     if (rnAARs.size() > 1) {

--- a/tools/src/versioning/android/android-packages-to-keep.txt
+++ b/tools/src/versioning/android/android-packages-to-keep.txt
@@ -1,4 +1,3 @@
-expo.modules.gl.cpp
 org.unimodules.apploader
 org.unimodules.core.interfaces.Consumer
 org.unimodules.core.interfaces.SingletonModule

--- a/tools/src/versioning/android/unversionablePackages.json
+++ b/tools/src/versioning/android/unversionablePackages.json
@@ -4,7 +4,6 @@
   "expo-dev-launcher",
   "expo-dev-menu",
   "expo-dev-menu-interface",
-  "expo-gl-cpp",
   "expo-image",
   "expo-in-app-purchases",
   "expo-manifests",

--- a/tools/src/versioning/android/versionCxx/index.ts
+++ b/tools/src/versioning/android/versionCxx/index.ts
@@ -189,7 +189,7 @@ async function getTransformPatchContentAsync(packageName: string, abiName: strin
 function escapeJniSymbol(symbol) {
   const mappings = {
     '/': '_',
-    '_': '_1',
+    _: '_1',
     ';': '_2',
     '[': '_3',
   };

--- a/tools/src/versioning/android/versionCxx/index.ts
+++ b/tools/src/versioning/android/versionCxx/index.ts
@@ -150,12 +150,8 @@ async function versionJavaLoadersAsync(
     versionedJavaFiles.map((file) =>
       transformFileAsync(file, [
         {
-          find: new RegExp(`\\b(System\\.loadLibrary\\("expo.*)("\\);?)`, 'g'),
-          replaceWith: `$1_${abiName}$2`,
-        },
-        {
-          find: new RegExp(`\\b(SoLoader\\.loadLibrary\\("expo.*)("\\);?)`, 'g'),
-          replaceWith: `$1_${abiName}$2`,
+          find: /\b((System|SoLoader)\.loadLibrary\("expo[^"]*)("\);?)/g,
+          replaceWith: `$1_${abiName}$3`,
         },
       ])
     )

--- a/tools/src/versioning/android/versionCxx/index.ts
+++ b/tools/src/versioning/android/versionCxx/index.ts
@@ -29,22 +29,22 @@ export async function versionCxxExpoModulesAsync(version: string) {
   const packages = await getListOfPackagesAsync();
   const versionablePackages = packages.filter((pkg) => isVersionableCxxExpoModule(pkg));
 
-  await Promise.all(
-    versionablePackages.map(async (pkg) => {
-      const { packageName } = pkg;
-      const abiName = `abi${version.replace(/\./g, '_')}`;
-      const versionedAbiRoot = path.join(ANDROID_DIR, 'versioned-abis', `expoview-${abiName}`);
+  for (const pkg of versionablePackages) {
+    const { packageName } = pkg;
+    const abiName = `abi${version.replace(/\./g, '_')}`;
+    const versionedAbiRoot = path.join(ANDROID_DIR, 'versioned-abis', `expoview-${abiName}`);
 
-      const patchContent = await getTransformPatchContentAsync(packageName, abiName);
+    const patchContent = await getTransformPatchContentAsync(packageName, abiName);
 
-      await applyPatchForPackageAsync(packageName, patchContent);
-      await buildSoLibsAsync(packageName);
-      await revertPatchForPackageAsync(packageName, patchContent);
+    await applyPatchForPackageAsync(packageName, patchContent);
+    await buildSoLibsAsync(packageName);
+    await revertPatchForPackageAsync(packageName, patchContent);
 
-      await copyPrebuiltSoLibsAsync(packageName, versionedAbiRoot);
-      await versionJavaLoadersAsync(packageName, versionedAbiRoot, abiName);
-    })
-  );
+    await copyPrebuiltSoLibsAsync(packageName, versionedAbiRoot);
+    await versionJavaLoadersAsync(packageName, versionedAbiRoot, abiName);
+
+    console.log(`   ✅  Created versioned c++ libraries for ${packageName}`);
+  }
 }
 
 /**
@@ -153,6 +153,10 @@ async function versionJavaLoadersAsync(
           find: new RegExp(`\\b(System\\.loadLibrary\\("expo.*)("\\);?)`, 'g'),
           replaceWith: `$1_${abiName}$2`,
         },
+        {
+          find: new RegExp(`\\b(SoLoader\\.loadLibrary\\("expo.*)("\\);?)`, 'g'),
+          replaceWith: `$1_${abiName}$2`,
+        },
       ])
     )
   );
@@ -169,6 +173,25 @@ async function getTransformPatchContentAsync(packageName: string, abiName: strin
       find: /\{VERSIONED_ABI_NAME\}/g,
       replaceWith: abiName,
     },
+    {
+      find: /\{VERSIONED_ABI_NAME_JNI_ESCAPED\}/g,
+      replaceWith: escapeJniSymbol(abiName),
+    },
   ]);
   return content;
+}
+
+/**
+ * Escapes special characters for java symbol -> cpp symbol mapping
+ * Reference: https://docs.oracle.com/en/java/javase/17/docs/specs/jni/design.html#resolving-native-method-names
+ * UTF-16 codes are not supported
+ */
+function escapeJniSymbol(symbol) {
+  const mappings = {
+    '/': '_',
+    '_': '_1',
+    ';': '_2',
+    '[': '_3',
+  };
+  return symbol.replace(/[/_;\[]/g, (match) => mappings[match]);
 }

--- a/tools/src/versioning/android/versionCxx/patches/expo-gl-cpp.patch
+++ b/tools/src/versioning/android/versionCxx/patches/expo-gl-cpp.patch
@@ -1,0 +1,122 @@
+diff --git a/packages/expo-gl-cpp/android/build.gradle b/packages/expo-gl-cpp/android/build.gradle
+index 118623f853..7bda5ff1aa 100644
+--- a/packages/expo-gl-cpp/android/build.gradle
++++ b/packages/expo-gl-cpp/android/build.gradle
+@@ -13,6 +13,10 @@ def RN_SO_DIR = RN_BUILD_FROM_SOURCE
+     ? Paths.get(findProject(":ReactAndroid").getProjectDir().toString(), "build", "intermediates", "library_*", "*", "jni")
+     : "${buildDir}/react-native-0*/jni"
+ def RN_AAR_DIR = "${REACT_NATIVE_DIR}/android"
++REACT_NATIVE_DIR = "${rootDir}/versioned-react-native"
++RN_BUILD_FROM_SOURCE = false
++RN_SO_DIR = "${buildDir}/reactandroid-{VERSIONED_ABI_NAME}-*/jni"
++RN_AAR_DIR = "${rootDir}/versioned-abis/expoview-{VERSIONED_ABI_NAME}/maven"
+ def reactNativeArchitectures() {
+     def value = project.getProperties().get("reactNativeArchitectures")
+     return value ? value.split(",") : ["armeabi-v7a", "x86", "x86_64", "arm64-v8a"]
+diff --git a/packages/expo-gl-cpp/cpp/CMakeLists.txt b/packages/expo-gl-cpp/cpp/CMakeLists.txt
+index 2c6948421c..eacc32ce19 100644
+--- a/packages/expo-gl-cpp/cpp/CMakeLists.txt
++++ b/packages/expo-gl-cpp/cpp/CMakeLists.txt
+@@ -5,7 +5,7 @@ set(CMAKE_ANDROID_STL_TYPE c++_shared)
+ set(CMAKE_VERBOSE_MAKEFILE ON)
+ set(CMAKE_CXX_STANDARD 17)
+ 
+-set(PACKAGE_NAME "expo-gl")
++set(PACKAGE_NAME "expo-gl_{VERSIONED_ABI_NAME}")
+ set(BUILD_DIR ${CMAKE_SOURCE_DIR}/build)
+ 
+ add_library(
+@@ -38,7 +38,7 @@ target_include_directories(${PACKAGE_NAME}
+                            PRIVATE "${REACT_NATIVE_DIR}/ReactCommon/jsi")
+ 
+ find_library(
+-    JSI_LIB jsi
++    JSI_LIB jsi_{VERSIONED_ABI_NAME}
+     PATHS ${LIBRN_DIR}
+     NO_CMAKE_FIND_ROOT_PATH)
+ 
+diff --git a/packages/expo-gl-cpp/cpp/EXGLJniApi.cpp b/packages/expo-gl-cpp/cpp/EXGLJniApi.cpp
+index 9d554969df..c2a77d1671 100644
+--- a/packages/expo-gl-cpp/cpp/EXGLJniApi.cpp
++++ b/packages/expo-gl-cpp/cpp/EXGLJniApi.cpp
+@@ -15,13 +15,13 @@ extern "C" {
+ thread_local JNIEnv* threadLocalEnv;
+ 
+ JNIEXPORT jint JNICALL
+-Java_expo_modules_gl_cpp_EXGL_EXGLContextCreate
++Java_{VERSIONED_ABI_NAME_JNI_ESCAPED}_expo_modules_gl_cpp_EXGL_EXGLContextCreate
+ (JNIEnv *env, jclass clazz) {
+   return UEXGLContextCreate();
+ }
+ 
+ JNIEXPORT void JNICALL
+-Java_expo_modules_gl_cpp_EXGL_EXGLContextPrepare
++Java_{VERSIONED_ABI_NAME_JNI_ESCAPED}_expo_modules_gl_cpp_EXGL_EXGLContextPrepare
+ (JNIEnv *env, jclass clazz, jlong jsiPtr, jint exglCtxId, jobject glContext) {
+   threadLocalEnv = env;
+   jclass GLContextClass = env->GetObjectClass(glContext);
+@@ -35,55 +35,55 @@ Java_expo_modules_gl_cpp_EXGL_EXGLContextPrepare
+ }
+ 
+ JNIEXPORT void JNICALL
+-Java_expo_modules_gl_cpp_EXGL_EXGLContextDestroy
++Java_{VERSIONED_ABI_NAME_JNI_ESCAPED}_expo_modules_gl_cpp_EXGL_EXGLContextDestroy
+ (JNIEnv *env, jclass clazz, jint exglCtxId) {
+   UEXGLContextDestroy(exglCtxId);
+ }
+ 
+ JNIEXPORT void JNICALL
+-Java_expo_modules_gl_cpp_EXGL_EXGLContextFlush
++Java_{VERSIONED_ABI_NAME_JNI_ESCAPED}_expo_modules_gl_cpp_EXGL_EXGLContextFlush
+ (JNIEnv *env, jclass clazz, jint exglCtxId) {
+   UEXGLContextFlush(exglCtxId);
+ }
+ 
+ JNIEXPORT jint JNICALL
+-Java_expo_modules_gl_cpp_EXGL_EXGLContextCreateObject
++Java_{VERSIONED_ABI_NAME_JNI_ESCAPED}_expo_modules_gl_cpp_EXGL_EXGLContextCreateObject
+ (JNIEnv *env, jclass clazz, jint exglCtxId) {
+   return UEXGLContextCreateObject(exglCtxId);
+ }
+ 
+ JNIEXPORT void JNICALL
+-Java_expo_modules_gl_cpp_EXGL_EXGLContextDestroyObject
++Java_{VERSIONED_ABI_NAME_JNI_ESCAPED}_expo_modules_gl_cpp_EXGL_EXGLContextDestroyObject
+ (JNIEnv *env, jclass clazz, jint exglCtxId, jint exglObjId) {
+   UEXGLContextDestroyObject(exglCtxId, exglObjId);
+ }
+ 
+ JNIEXPORT void JNICALL
+-Java_expo_modules_gl_cpp_EXGL_EXGLContextMapObject
++Java_{VERSIONED_ABI_NAME_JNI_ESCAPED}_expo_modules_gl_cpp_EXGL_EXGLContextMapObject
+ (JNIEnv *env, jclass clazz, jint exglCtxId, jint exglObjId, jint glObj) {
+   UEXGLContextMapObject(exglCtxId, exglObjId, glObj);
+ }
+ 
+ JNIEXPORT jint JNICALL
+-Java_expo_modules_gl_cpp_EXGL_EXGLContextGetObject
++Java_{VERSIONED_ABI_NAME_JNI_ESCAPED}_expo_modules_gl_cpp_EXGL_EXGLContextGetObject
+ (JNIEnv *env, jclass clazz, jint exglCtxId, jint exglObjId) {
+   return UEXGLContextGetObject(exglCtxId, exglObjId);
+ }
+ 
+ JNIEXPORT void JNICALL
+-Java_expo_modules_gl_cpp_EXGL_EXGLRegisterThread
++Java_{VERSIONED_ABI_NAME_JNI_ESCAPED}_expo_modules_gl_cpp_EXGL_EXGLRegisterThread
+ (JNIEnv *env, jclass clazz) {
+   threadLocalEnv = env;
+ }
+ 
+ JNIEXPORT bool JNICALL
+-Java_expo_modules_gl_cpp_EXGL_EXGLContextNeedsRedraw
++Java_{VERSIONED_ABI_NAME_JNI_ESCAPED}_expo_modules_gl_cpp_EXGL_EXGLContextNeedsRedraw
+ (JNIEnv *env, jclass clazz, jint exglCtxId) {
+   return UEXGLContextNeedsRedraw(exglCtxId);
+ }
+ 
+ JNIEXPORT void JNICALL
+-Java_expo_modules_gl_cpp_EXGL_EXGLContextDrawEnded
++Java_{VERSIONED_ABI_NAME_JNI_ESCAPED}_expo_modules_gl_cpp_EXGL_EXGLContextDrawEnded
+ (JNIEnv *env, jclass clazz, jint exglCtxId) {
+   UEXGLContextDrawEnded(exglCtxId);
+ }


### PR DESCRIPTION
# Why

for sdk 45 to version expo-gl-cpp

# How

- remove expo-gl-cpp from unversionable package list
- [tools] fine tune versionCxx script to run cxx expo-modules in sequence. that's not ideally when we run multiple gradle process in parallel 
- [tools] add `SoLoader.loadLibrary()` versioning
- [tools] add `{VERSIONED_ABI_NAME_JNI_ESCAPED}` macro for patch file to support java symbol -> cpp symbol mapping. e.g. when the java method is `abi45_0_0.expo.modules.gl.cpp.EXGL.EXGLContextCreate`, the corresponding cpp function name would be `Java_abi45_10_10_expo_modules_gl_cpp_EXGL_EXGLContextCreate`
- add versioning patch for expo-gl-cpp

# Test Plan

`et add-sdk -p android -s 45.0.0` + versioned android expo go + sdk45 NCL GL test case

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
