### PR TITLE
[ios] Move arguments conversion mechanism to JS thread

### DIFF
--- a/packages/expo-modules-core/ios/Swift/Arguments/AnyArgumentType.swift
+++ b/packages/expo-modules-core/ios/Swift/Arguments/AnyArgumentType.swift
@@ -4,7 +4,7 @@
  A protocol whose intention is to wrap function's argument type
  to keep its real signature and not type-erase it by the compiler.
  */
-internal protocol AnyArgumentType: CustomStringConvertible {
+public protocol AnyArgumentType: CustomStringConvertible {
   /**
    Casts given any value to the wrapped type and returns as `Any`.
    NOTE: It may not be just simple type-casting (e.g. when the wrapped type conforms to `ConvertibleArgument`).

--- a/packages/expo-modules-core/ios/Swift/Functions/AnyFunction.swift
+++ b/packages/expo-modules-core/ios/Swift/Functions/AnyFunction.swift
@@ -15,6 +15,11 @@ public protocol AnyFunction: AnyDefinition {
   var takesPromise: Bool { get }
 
   /**
+   An array of argument types that the function takes. If the last type is `Promise`, it's not included.
+   */
+  var argumentTypes: [AnyArgumentType] { get }
+
+  /**
    A number of arguments the function takes. If the last argument is of type `Promise`, it is not counted.
    */
   var argumentsCount: Int { get }

--- a/packages/expo-modules-core/ios/Swift/Functions/ConcreteFunction.swift
+++ b/packages/expo-modules-core/ios/Swift/Functions/ConcreteFunction.swift
@@ -5,12 +5,10 @@ public class ConcreteFunction<Args, ReturnType>: AnyFunction {
 
   public let name: String
 
-  public var takesPromise: Bool {
-    return argTypes.last is PromiseArgumentType
-  }
+  public var takesPromise: Bool
 
   public var argumentsCount: Int {
-    return argTypes.count - (takesPromise ? 1 : 0)
+    return argumentTypes.count
   }
 
   public var queue: DispatchQueue?
@@ -19,7 +17,7 @@ public class ConcreteFunction<Args, ReturnType>: AnyFunction {
 
   let closure: ClosureType
 
-  let argTypes: [AnyArgumentType]
+  public let argumentTypes: [AnyArgumentType]
 
   init(
     _ name: String,
@@ -27,8 +25,11 @@ public class ConcreteFunction<Args, ReturnType>: AnyFunction {
     _ closure: @escaping ClosureType
   ) {
     self.name = name
-    self.argTypes = argTypes
+    self.takesPromise = argTypes.last is PromiseArgumentType
     self.closure = closure
+
+    // Drop the last argument type if it's the `Promise`.
+    self.argumentTypes = takesPromise ? argTypes.dropLast(1) : argTypes
 
     // This is temporary solution to keep backwards compatibility for existing functions — they all end with "Async".
     // `function` component that we've used so far was async by default, but we decided to replace it with `asyncFunction`
@@ -36,19 +37,21 @@ public class ConcreteFunction<Args, ReturnType>: AnyFunction {
     self.isAsync = name.hasSuffix("Async")
   }
 
+  /**
+   Calls the function with given arguments.
+   - Parameters:
+     - args: An array of arguments to pass to the function. The arguments must be of the same type as in the underlying ``closure``.
+     - promise: A promise to resolve or reject by the async ``closure`` when it finishes execution.
+   - ToDo: Make it internal.
+   */
   public func call(args: [Any], promise: Promise) {
-    let takesPromise = self.takesPromise
+    // Add promise to the array of arguments if necessary.
+    let arguments = takesPromise ? args + [promise] : args
     let returnedValue: ReturnType?
 
     do {
-      var finalArgs = try castArguments(args)
-
-      if takesPromise {
-        finalArgs.append(promise)
-      }
-
-      let tuple = try Conversions.toTuple(finalArgs) as! Args
-      returnedValue = try closure(tuple)
+      let argumentsTuple = try Conversions.toTuple(arguments) as! Args
+      returnedValue = try closure(argumentsTuple)
     } catch let error as CodedError {
       promise.reject(FunctionCallException(name).causedBy(error))
       return
@@ -61,28 +64,24 @@ public class ConcreteFunction<Args, ReturnType>: AnyFunction {
     }
   }
 
+  /**
+   Calls the function synchronously with given arguments.
+   - Parameters:
+     - args: An array of arguments to pass to the function. The arguments must be of the same type as in the underlying ``closure``.
+   - Returns: A value returned by the called function when succeeded or an error when it failed.
+   - ToDo: Make it internal.
+   */
   public func callSync(args: [Any]) -> Any {
     if takesPromise {
-      var result: Any?
-      let semaphore = DispatchSemaphore(value: 0)
-
-      let promise = Promise {
-        result = $0
-        semaphore.signal()
-      } rejecter: { _ in
-        semaphore.signal()
-      }
-      call(args: args, promise: promise)
-      semaphore.wait()
-      return result as Any
-    } else {
-      do {
-        let finalArgs = try castArguments(args)
-        let tuple = try Conversions.toTuple(finalArgs) as! Args
-        return try closure(tuple)
-      } catch let error {
-        return error
-      }
+      // Using `Promise` in the synchronous function is prohibited. Probably should throw an exception here,
+      // but for now let's return nil until we split async and sync functions.
+      return Optional<Any>.none as Any
+    }
+    do {
+      let argumentsTuple = try Conversions.toTuple(args) as! Args
+      return try closure(argumentsTuple)
+    } catch let error {
+      return error
     }
   }
 
@@ -94,38 +93,6 @@ public class ConcreteFunction<Args, ReturnType>: AnyFunction {
   public func runSynchronously() -> Self {
     self.isAsync = false
     return self
-  }
-
-  private func argumentType(atIndex index: Int) -> AnyArgumentType? {
-    return (0..<argTypes.count).contains(index) ? argTypes[index] : nil
-  }
-
-  private func castArguments(_ args: [Any]) throws -> [Any] {
-    if args.count != argumentsCount {
-      throw InvalidArgsNumberException((received: args.count, expected: argumentsCount))
-    }
-    return try args.enumerated().map { index, arg in
-      let expectedType = argumentType(atIndex: index)
-
-      do {
-        // It's safe to unwrap since the arguments count matches.
-        return try expectedType!.cast(arg)
-      } catch {
-        throw ArgumentCastException((index: index, type: expectedType!)).causedBy(error)
-      }
-    }
-  }
-}
-
-internal class InvalidArgsNumberException: GenericException<(received: Int, expected: Int)> {
-  override var reason: String {
-    "Received \(param.received) arguments, but \(param.expected) was expected"
-  }
-}
-
-internal class ArgumentCastException: GenericException<(index: Int, type: AnyArgumentType)> {
-  override var reason: String {
-    "Argument at index '\(param.index)' couldn't be cast to type \(param.type.description)"
   }
 }
 

--- a/packages/expo-modules-core/ios/Swift/JavaScriptUtils.swift
+++ b/packages/expo-modules-core/ios/Swift/JavaScriptUtils.swift
@@ -36,16 +36,61 @@ internal func createSyncFunctionBlock(holder: ModuleHolder, name functionName: S
   }
 }
 
+// MARK: - Arguments
+
 /**
- If given argument is a JavaScriptValue, it's unpacked and converted to corresponding Foundation type.
- Otherwise, the argument is returned as is.
+ Tries to cast given argument to the type that is wrapped by the argument type.
+ - Parameters:
+  - argument: A value to be cast. If it's a ``JavaScriptValue``, it's first unpacked to the raw value.
+  - argumentType: Something that implements ``AnyArgumentType`` and knows how to cast the argument.
+ - Returns: A new value converted according to the argument type.
+ - Throws: Rethrows various exceptions that could be thrown by the argument type wrappers.
  */
-internal func unpackIfJavaScriptValue(_ value: Any) -> Any {
-  if let value = value as? JavaScriptValue {
-    return value.getRaw() as Any
+internal func castArgument(_ argument: Any, toType argumentType: AnyArgumentType) throws -> Any {
+  // TODO: Accept JavaScriptValue and JavaScriptObject as argument types.
+  if let argument = argument as? JavaScriptValue {
+    return try argumentType.cast(argument.getRaw())
   }
-  return value
+  return try argumentType.cast(argument)
 }
+
+/**
+ Same as ``castArgument(_:argumentType:)`` but for an array of arguments.
+ - Parameters:
+   - arguments: An array of arguments to be cast.
+   - argumentTypes: An array of argument types in the same order as the array of arguments.
+ - Returns: An array of arguments after casting. Its size is the same as the input arrays.
+ - Throws: ``InvalidArgsNumberException`` when the sizes of arrays passed as parameters are not equal.
+   Rethrows exceptions thrown by ``castArgument(_:argumentType:)``.
+ */
+internal func castArguments(_ arguments: [Any], toTypes argumentTypes: [AnyArgumentType]) throws -> [Any] {
+  if arguments.count != argumentTypes.count {
+    throw InvalidArgsNumberException((received: arguments.count, expected: argumentTypes.count))
+  }
+  return try arguments.enumerated().map { index, argument in
+    let argumentType = argumentTypes[index]
+
+    do {
+      return try castArgument(argument, toType: argumentType)
+    } catch {
+      throw ArgumentCastException((index: index, type: argumentType)).causedBy(error)
+    }
+  }
+}
+
+internal class InvalidArgsNumberException: GenericException<(received: Int, expected: Int)> {
+  override var reason: String {
+    "Received \(param.received) arguments, but \(param.expected) was expected"
+  }
+}
+
+internal class ArgumentCastException: GenericException<(index: Int, type: AnyArgumentType)> {
+  override var reason: String {
+    "Argument at index '\(param.index)' couldn't be cast to type \(param.type.description)"
+  }
+}
+
+// MARK: - Exceptions
 
 private class ModuleUnavailableException: GenericException<String> {
   override var reason: String {

--- a/packages/expo-modules-core/ios/Tests/FunctionSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/FunctionSpec.swift
@@ -151,8 +151,7 @@ class FunctionSpec: ExpoSpec {
         // Function expects one argument, let's give it more.
         .call(function: functionName, args: [1, 2]) { _, error in
           expect(error).notTo(beNil())
-          expect(error).to(beAKindOf(FunctionCallException.self))
-          expect((error as! Exception).isCausedBy(InvalidArgsNumberException.self)) == true
+          expect(error).to(beAKindOf(InvalidArgsNumberException.self))
           done()
         }
       }
@@ -168,7 +167,7 @@ class FunctionSpec: ExpoSpec {
         // Function expects a string, let's give it a number.
         .call(function: functionName, args: [1]) { value, error in
           expect(error).notTo(beNil())
-          expect(error).to(beAKindOf(FunctionCallException.self))
+          expect(error).to(beAKindOf(ArgumentCastException.self))
           expect((error as! Exception).isCausedBy(Conversions.CastingException<String>.self)) == true
           done()
         }


### PR DESCRIPTION
# Why

Follow up on #17017 
Closes ENG-4640
In the future we'll want to allow `JavaScriptValue`, `JavaScriptObject` and shared objects as function arguments, but to do so, the conversion needs to be done before the call is queued (async functions only). It would be an unsafe operation to read/modify them on non-JS thread.

# How

- Moved arguments conversion out of the `ConcreteFunction` to its caller `ModuleHolder`. The general rule is that the arguments passed to function's `call(args:)` must already match the argument types the function expects.
- Exposed function's `argumentTypes` so that the caller can know how to convert input arguments.
- Took the opportunity to remove unnecessary implementation of `callSync` that uses the semaphore to block the JS thread — we won't support calls like this.
- Small changes in tests as the exceptions chain is different now

# Test Plan

- iOS unit tests are passing
- Tested in test-suite and NCL