### PR TITLE
[tools] Remove semver-regex dependency

### DIFF
--- a/tools/package.json
+++ b/tools/package.json
@@ -61,7 +61,6 @@
     "qrcode-terminal": "^0.12.0",
     "recursive-omit-by": "^2.0.0",
     "semver": "^7.3.6",
-    "semver-regex": "^3.1.3",
     "sharp": "^0.30.3",
     "strip-ansi": "^6.0.0",
     "terminal-link": "^2.1.1",

--- a/tools/src/Changelogs.ts
+++ b/tools/src/Changelogs.ts
@@ -1,7 +1,6 @@
 import assert from 'assert';
 import fs from 'fs-extra';
 import semver from 'semver';
-import semverRegex from 'semver-regex';
 
 import * as Markdown from './Markdown';
 import { execAll } from './Utils';
@@ -568,7 +567,7 @@ function parseVersion(text: string): string | null {
   if (text === UNPUBLISHED_VERSION_NAME) {
     return text;
   }
-  const match = semverRegex().exec(text);
+  const match = /(\d+\.\d+\.\d+)([-+][\w\.]+)?/.exec(text);
   return match?.[0] ?? null;
 }
 

--- a/tools/yarn.lock
+++ b/tools/yarn.lock
@@ -10605,11 +10605,6 @@ selfsigned@^1.10.7:
   dependencies:
     node-forge "0.9.0"
 
-semver-regex@^3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-3.1.3.tgz#b2bcc6f97f63269f286994e297e229b6245d0dc3"
-  integrity sha512-Aqi54Mk9uYTjVexLnR67rTyBusmwd04cLkHy9hNvk3+G3nT2Oyg7E0l4XVbOaNwIvQ3hHeYxGcyEy+mKreyBFQ==
-
 semver@7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"


### PR DESCRIPTION
# Why

Looks like upgrading `semver-regex` by dependabot (https://github.com/expo/expo/commit/e9dab92beb531f7619025dfb8a66849c424cd76d) from `3.1.1` to `3.1.3` broke parsing changelog headers, which is needed for the publish script to work properly. The regexp matched only `45.0.0-beta` version where it should match the entire `45.0.0-beta.1`. This bug caused an unnecessary change made by the publish script: https://github.com/expo/expo/commit/e9dab92beb531f7619025dfb8a66849c424cd76d
Probably this bug has been fixed in newer versions, but they all use ESM which we can't use in expotools.

# How

Replaced `semver-regex` with our own regexp that matches our cases and conventions (we don't need anything more sophisticated)
Removed `semver-regex` dependency

# Test Plan

I played with this a little bit to check if the publish script would do the same change as in (https://github.com/expo/expo/commit/e9dab92beb531f7619025dfb8a66849c424cd76d)
