### PR TITLE
source-login-scripts.sh - better nvm support

### DIFF
--- a/packages/expo-constants/CHANGELOG.md
+++ b/packages/expo-constants/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Improved support of nvm sourcing in iOS shell scripts. ([#17109](https://github.com/expo/expo/pull/17109) by [@liamronancb](https://github.com/liamronancb))
+
 ### 💡 Others
 
 ## 13.1.0 — 2022-04-18

--- a/packages/expo-constants/scripts/get-app-config-ios.sh
+++ b/packages/expo-constants/scripts/get-app-config-ios.sh
@@ -8,18 +8,10 @@ RESOURCE_BUNDLE_NAME="EXConstants.bundle"
 # Path to expo-constants folder inside node_modules
 EXPO_CONSTANTS_PACKAGE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-
-export NVM_DIR=$HOME/.nvm;
-NVM_SH_FILE=$NVM_DIR/nvm.sh
-# first attempt to source via nvm and fallback to sourcing via login scripts
-if test -f "$NVM_SH_FILE"; then
-  source $NVM_SH_FILE
-else
-  # Suppress environment errors from sourcing the login scripts
-  set +e
-  source "$EXPO_CONSTANTS_PACKAGE_DIR/scripts/source-login-scripts.sh"
-  set -e
-fi
+# Suppress environment errors from sourcing the login scripts
+set +e
+source "$EXPO_CONSTANTS_PACKAGE_DIR/scripts/source-login-scripts.sh"
+set -e
 
 NODE_BINARY=${NODE_BINARY:-node}
 

--- a/packages/expo-constants/scripts/get-app-config-ios.sh
+++ b/packages/expo-constants/scripts/get-app-config-ios.sh
@@ -11,7 +11,7 @@ EXPO_CONSTANTS_PACKAGE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 export NVM_DIR=$HOME/.nvm;
 NVM_SH_FILE=$NVM_DIR/nvm.sh
-# first attempt to source via nvm and fallback to sourcing via nvm
+# first attempt to source via nvm and fallback to sourcing via login scripts
 if test -f "$NVM_SH_FILE"; then
   source $NVM_SH_FILE
 else

--- a/packages/expo-constants/scripts/get-app-config-ios.sh
+++ b/packages/expo-constants/scripts/get-app-config-ios.sh
@@ -8,10 +8,19 @@ RESOURCE_BUNDLE_NAME="EXConstants.bundle"
 # Path to expo-constants folder inside node_modules
 EXPO_CONSTANTS_PACKAGE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-# Suppress environment errors from sourcing the login scripts
-set +e
-source "$EXPO_CONSTANTS_PACKAGE_DIR/scripts/source-login-scripts.sh"
-set -e
+
+export NVM_DIR=$HOME/.nvm;
+NVM_SH_FILE=$NVM_DIR/nvm.sh
+# first attempt to source via nvm and fallback to sourcing via nvm
+if test -f "$NVM_SH_FILE"; then
+  
+  source $NVM_SH_FILE
+else
+  # Suppress environment errors from sourcing the login scripts
+  set +e
+  source "$EXPO_CONSTANTS_PACKAGE_DIR/scripts/source-login-scripts.sh"
+  set -e
+fi
 
 NODE_BINARY=${NODE_BINARY:-node}
 

--- a/packages/expo-constants/scripts/get-app-config-ios.sh
+++ b/packages/expo-constants/scripts/get-app-config-ios.sh
@@ -13,7 +13,6 @@ export NVM_DIR=$HOME/.nvm;
 NVM_SH_FILE=$NVM_DIR/nvm.sh
 # first attempt to source via nvm and fallback to sourcing via nvm
 if test -f "$NVM_SH_FILE"; then
-  
   source $NVM_SH_FILE
 else
   # Suppress environment errors from sourcing the login scripts

--- a/packages/expo-constants/scripts/source-login-scripts.sh
+++ b/packages/expo-constants/scripts/source-login-scripts.sh
@@ -9,12 +9,12 @@
 
 current_shell=$(ps -cp "$$" -o comm='' | sed 's/^-//')
 
-export NVM_DIR=$HOME/.nvm;
-NVM_SH_FILE=$NVM_DIR/nvm.sh
-# first attempt to source via nvm and fallback to sourcing via zsh or bash
-if test -f "$NVM_SH_FILE"; then
-  source $NVM_SH_FILE
-elif [[ "$current_shell" == zsh ]]; then
+# attempt to source via nvm
+if test -f "$HOME/.nvm/nvm.sh"; then
+  source "$HOME/.nvm/nvm.sh"
+fi
+
+if [[ "$current_shell" == zsh ]]; then
    # Zsh's setup script order is:
    #   /etc/zshenv
    #   ~/.zshenv

--- a/packages/expo-constants/scripts/source-login-scripts.sh
+++ b/packages/expo-constants/scripts/source-login-scripts.sh
@@ -9,7 +9,12 @@
 
 current_shell=$(ps -cp "$$" -o comm='' | sed 's/^-//')
 
-if [[ "$current_shell" == zsh ]]; then
+export NVM_DIR=$HOME/.nvm;
+NVM_SH_FILE=$NVM_DIR/nvm.sh
+# first attempt to source via nvm and fallback to sourcing via zsh or bash
+if test -f "$NVM_SH_FILE"; then
+  source $NVM_SH_FILE
+else if [[ "$current_shell" == zsh ]]; then
    # Zsh's setup script order is:
    #   /etc/zshenv
    #   ~/.zshenv

--- a/packages/expo-constants/scripts/source-login-scripts.sh
+++ b/packages/expo-constants/scripts/source-login-scripts.sh
@@ -14,7 +14,7 @@ NVM_SH_FILE=$NVM_DIR/nvm.sh
 # first attempt to source via nvm and fallback to sourcing via zsh or bash
 if test -f "$NVM_SH_FILE"; then
   source $NVM_SH_FILE
-else if [[ "$current_shell" == zsh ]]; then
+elif [[ "$current_shell" == zsh ]]; then
    # Zsh's setup script order is:
    #   /etc/zshenv
    #   ~/.zshenv

--- a/packages/expo-module-scripts/CHANGELOG.md
+++ b/packages/expo-module-scripts/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Add `templates/scripts/source-login-scripts.sh` vendoring tool for node binary resolution in Xcode build phases scripts. ([#15336](https://github.com/expo/expo/pull/15336) by [@kudo](https://github.com/kudo))
 
 ### 🐛 Bug fixes
-
+- Improved support of nvm sourcing in iOS shell scripts. ([#17109](https://github.com/expo/expo/pull/17109) by [@liamronancb](https://github.com/liamronancb))
 - Fixed `source-login-scripts.sh` error when `extendedglob` is enabled in zsh config. ([#17024](https://github.com/expo/expo/pull/17024) by [@kudo](https://github.com/kudo))
 - Fixed `expo-module prepare` error if target packages contain temporary kotlin build files. ([#17023](https://github.com/expo/expo/pull/17023) by [@kudo](https://github.com/kudo))
 

--- a/packages/expo-module-scripts/templates/scripts/source-login-scripts.sh
+++ b/packages/expo-module-scripts/templates/scripts/source-login-scripts.sh
@@ -9,12 +9,12 @@
 
 current_shell=$(ps -cp "$$" -o comm='' | sed 's/^-//')
 
-export NVM_DIR=$HOME/.nvm;
-NVM_SH_FILE=$NVM_DIR/nvm.sh
-# first attempt to source via nvm and fallback to sourcing via zsh or bash
-if test -f "$NVM_SH_FILE"; then
-  source $NVM_SH_FILE
-elif [[ "$current_shell" == zsh ]]; then
+# attempt to source via nvm
+if test -f "$HOME/.nvm/nvm.sh"; then
+  source "$HOME/.nvm/nvm.sh"
+fi
+
+if [[ "$current_shell" == zsh ]]; then
    # Zsh's setup script order is:
    #   /etc/zshenv
    #   ~/.zshenv

--- a/packages/expo-module-scripts/templates/scripts/source-login-scripts.sh
+++ b/packages/expo-module-scripts/templates/scripts/source-login-scripts.sh
@@ -9,7 +9,12 @@
 
 current_shell=$(ps -cp "$$" -o comm='' | sed 's/^-//')
 
-if [[ "$current_shell" == zsh ]]; then
+export NVM_DIR=$HOME/.nvm;
+NVM_SH_FILE=$NVM_DIR/nvm.sh
+# first attempt to source via nvm and fallback to sourcing via zsh or bash
+if test -f "$NVM_SH_FILE"; then
+  source $NVM_SH_FILE
+else if [[ "$current_shell" == zsh ]]; then
    # Zsh's setup script order is:
    #   /etc/zshenv
    #   ~/.zshenv

--- a/packages/expo-module-scripts/templates/scripts/source-login-scripts.sh
+++ b/packages/expo-module-scripts/templates/scripts/source-login-scripts.sh
@@ -14,7 +14,7 @@ NVM_SH_FILE=$NVM_DIR/nvm.sh
 # first attempt to source via nvm and fallback to sourcing via zsh or bash
 if test -f "$NVM_SH_FILE"; then
   source $NVM_SH_FILE
-else if [[ "$current_shell" == zsh ]]; then
+elif [[ "$current_shell" == zsh ]]; then
    # Zsh's setup script order is:
    #   /etc/zshenv
    #   ~/.zshenv

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 ### 🐛 Bug fixes
+- Improved support of nvm sourcing in iOS shell scripts. ([#17109](https://github.com/expo/expo/pull/17109) by [@liamronancb](https://github.com/liamronancb))
 
 ### 💡 Others
 

--- a/packages/expo-updates/scripts/source-login-scripts.sh
+++ b/packages/expo-updates/scripts/source-login-scripts.sh
@@ -9,12 +9,12 @@
 
 current_shell=$(ps -cp "$$" -o comm='' | sed 's/^-//')
 
-export NVM_DIR=$HOME/.nvm;
-NVM_SH_FILE=$NVM_DIR/nvm.sh
-# first attempt to source via nvm and fallback to sourcing via zsh or bash
-if test -f "$NVM_SH_FILE"; then
-  source $NVM_SH_FILE
-elif [[ "$current_shell" == zsh ]]; then
+# attempt to source via nvm
+if test -f "$HOME/.nvm/nvm.sh"; then
+  source "$HOME/.nvm/nvm.sh"
+fi
+
+if [[ "$current_shell" == zsh ]]; then
    # Zsh's setup script order is:
    #   /etc/zshenv
    #   ~/.zshenv

--- a/packages/expo-updates/scripts/source-login-scripts.sh
+++ b/packages/expo-updates/scripts/source-login-scripts.sh
@@ -9,7 +9,12 @@
 
 current_shell=$(ps -cp "$$" -o comm='' | sed 's/^-//')
 
-if [[ "$current_shell" == zsh ]]; then
+export NVM_DIR=$HOME/.nvm;
+NVM_SH_FILE=$NVM_DIR/nvm.sh
+# first attempt to source via nvm and fallback to sourcing via zsh or bash
+if test -f "$NVM_SH_FILE"; then
+  source $NVM_SH_FILE
+else if [[ "$current_shell" == zsh ]]; then
    # Zsh's setup script order is:
    #   /etc/zshenv
    #   ~/.zshenv

--- a/packages/expo-updates/scripts/source-login-scripts.sh
+++ b/packages/expo-updates/scripts/source-login-scripts.sh
@@ -14,7 +14,7 @@ NVM_SH_FILE=$NVM_DIR/nvm.sh
 # first attempt to source via nvm and fallback to sourcing via zsh or bash
 if test -f "$NVM_SH_FILE"; then
   source $NVM_SH_FILE
-else if [[ "$current_shell" == zsh ]]; then
+elif [[ "$current_shell" == zsh ]]; then
    # Zsh's setup script order is:
    #   /etc/zshenv
    #   ~/.zshenv


### PR DESCRIPTION
in response to this issue: https://github.com/expo/expo/issues/15809#issuecomment-1068629517

This PR updates the `get-app-config-ios.sh` in `expo-constants` to first attempt to source via nvm (if detected) before falling back to sourcing via the `source-login-scripts.sh`. 

# Why
This approach resolves sourcing-issues for nvm users. People are using a workaround of creating a `bash_profile` with `nvm` setup or removing nvm altogether. `nvm` is a heavily-used tool in the community and so this setup should accommodate it.

examples of people running into this issue with `nvm`:
<img width="400" alt="image" src="https://user-images.githubusercontent.com/65248094/158641814-6da86059-3cc1-4cb1-803d-57ebbc9f9bc9.png">
<img width="400" alt="image" src="https://user-images.githubusercontent.com/65248094/158641978-0bbd373f-61cf-4622-ad87-a50103686974.png">

<img width="400" alt="image" src="https://user-images.githubusercontent.com/65248094/163872350-a21723f0-9c03-44e1-b8e1-0e52f2ca2154.png">


<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
I've tested this with nvm setup and without to ensure the sourcing works as intended. 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
