### PR TITLE
[expo-updates] fix return value in AppDelegateSubscriber

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - Add current and embedded update headers to manifest requests. ([#17033](https://github.com/expo/expo/pull/17033) by [@esamelson](https://github.com/esamelson))
+- Fix return value in AppDelegateSubscriber (used with expo-dev-client).
 
 ## 0.12.0 — 2022-04-18
 

--- a/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesAppDelegateSubscriber.swift
+++ b/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesAppDelegateSubscriber.swift
@@ -8,6 +8,6 @@ public class ExpoUpdatesAppDelegateSubscriber: ExpoAppDelegateSubscriber {
     if EXAppDefines.APP_DEBUG {
       EXUpdatesControllerRegistry.sharedInstance().controller = EXUpdatesDevLauncherController.sharedInstance()
     }
-    return false
+    return true
   }
 }


### PR DESCRIPTION
# Why

This was originally added in https://github.com/expo/expo/pull/16230, but returning false from this method may have unintended side effects, such as preventing the app from opening deep links it should be able to

# How

Return true

# Test Plan

Build a test iOS dev client using local packages:
✅ while dev client is running, `expo start --dev-client` and press `i`; project should open via deep link
✅ with dev client closed, `expo start --dev-client` and press `i`; project should open via deep link
✅ while dev client is running, `xcrun simctl openurl booted 'com.esamelson.dc4112test0411://expo-development-client/?url=https%3A%2F%2Fexp.host%2F%40esamelson%2Fdc-4112-test-0411'`; published project should open via deep link
✅ with dev client closed, `xcrun simctl openurl booted 'com.esamelson.dc4112test0411://expo-development-client/?url=https%3A%2F%2Fexp.host%2F%40esamelson%2Fdc-4112-test-0411'`; published project should open via deep link

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
