### PR TITLE
[android] fix prebuilt reanimated versioned lib with debug info

### DIFF
--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -744,18 +744,17 @@ task extractSOFiles {
 }
 
 project.afterEvaluate {
-  def nativeBuildTask = tasks.findByName("externalNativeBuildRelease")
+  def nativeBuildTask = tasks.findByName("copyUnversionedReleaseJniLibsProjectOnly")  // for expoview
+                        ?: tasks.findByName("copyReleaseJniLibsProjectOnly") // for expoview-${abiName}
   if (nativeBuildTask) {
     packageNdkLibs.dependsOn nativeBuildTask
   }
 }
 
 task packageNdkLibs(type: Copy) {
-  from("$buildDir/reanimated-ndk/all")
-  include("**/lib*reanimated*.so")
-  if (REACT_VERSION < 64) {
-    include("**/lib*turbomodulejsijni*.so")
-  }
+  from("$buildDir/intermediates/library_jni/unversionedRelease/jni") // for expoview
+  from("$buildDir/intermediates/library_jni/release/jni") // for expoview-${abiName}
+  include("**/libreanimated*.so")
   into("$projectDir/src/main/jniLibs")
 }
 


### PR DESCRIPTION
# Why

even for gradle release build, the current cmake build type is `RelWithDebInfo`. with debug information, the output libs take huge size and it's not ideal to commit the libs to git.

# How

gradle will strip the debug information, we can use the stripped libs directly. they are from `copy${variant}JniLibsProjectOnly` task

# Test Plan

`et add-sdk -p android -s 45.0.0`
`file 'android/versioned-abis/expoview-abi45_0_0/src/main/jniLibs/arm64-v8a/libreanimated_abi45_0_0.so'` to check whether it contains debug information

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
