### PR TITLE
[docs] redesign: switch to new Terminal component

### DIFF
--- a/docs/components/plugins/InstallSection.tsx
+++ b/docs/components/plugins/InstallSection.tsx
@@ -2,9 +2,8 @@ import { css } from '@emotion/react';
 import { theme, typography } from '@expo/styleguide';
 import * as React from 'react';
 
-import TerminalBlock from './TerminalBlock';
-
 import { usePageMetadata } from '~/providers/page-metadata';
+import { Terminal } from '~/ui/components/Snippet';
 
 const STYLES_P = css`
   line-height: 1.8rem;
@@ -43,11 +42,11 @@ const getPackageLink = (packageNames: string) =>
 const InstallSection: React.FC<Props> = ({
   packageName,
   hideBareInstructions = false,
-  cmd = [`expo install ${packageName}`],
+  cmd = [`$ expo install ${packageName}`],
   href = getPackageLink(packageName),
 }) => (
   <div>
-    <TerminalBlock cmd={cmd} />
+    <Terminal cmd={cmd} cmdCopy={cmd[0].slice(2)} />
     {hideBareInstructions ? null : (
       <p css={STYLES_P}>
         If you're installing this in a{' '}

--- a/docs/pages/bare/hello-world.md
+++ b/docs/pages/bare/hello-world.md
@@ -3,7 +3,7 @@ title: Up and Running
 sidebar_label: Up and Running
 ---
 
-import TerminalBlock from '~/components/plugins/TerminalBlock';
+import { Terminal } from '~/ui/components/Snippet';
 
 > This guide assumes that you have Xcode and/or Android Studio installed and working. It also assumes that you want to create a new project. If you have an existing app that you would like to integrate the Expo SDK in an existing app, read the [existing apps guide](../bare/existing-apps.md).
 
@@ -11,12 +11,13 @@ Before you get started with a bare React Native project, make sure you set up yo
 
 After this, let's get started with a bare project. Run `expo init` and choose one of the bare templates. We'll use the minimum template here.
 
-```sh
-# If you don't have expo-cli yet, get it
-npm i -g expo-cli
-# This is a shortcut to skip the UI for picking the template
-expo init --template bare-minimum
-```
+<Terminal cmd={[
+  "# If you don't have expo-cli yet, get it",
+  "$ npm i -g expo-cli",
+  "",
+  "# This is a shortcut to skip the UI for picking the template",
+  "$ expo init --template bare-minimum"
+]} cmdCopy="npm i -g expo-cli && expo init --template bare-minimum" />
 
 Next, let's get the project running. Go into your project directory and run `expo run:ios` or `expo run:android` &mdash; hurray! Your project is working.
 
@@ -26,11 +27,9 @@ Bare template projects come with `expo` installed and configured, so you're read
 
 ## Install an Expo SDK package
 
-We're going to install [`expo-web-browser`](https://github.com/expo/expo/tree/main/packages/expo-web-browser), it's a useful little package for showing a modal web browser using the appropriate native APIs on each platform.
+We're going to install [`expo-web-browser`](/versions/latest/sdk/webbrowser/), it's a useful little package for showing a modal web browser using the appropriate native APIs on each platform.
 
-```sh
-expo install expo-web-browser
-```
+<Terminal cmd={['expo install expo-web-browser']} cmdCopy="expo install expo-web-browser" />
 
 Open up **App.js** and add a button that, when pressed, opens up a web browser. Here's some code for you.
 
@@ -57,13 +56,19 @@ This will not yet work because we haven't linked the native code that powers it.
 
 ### iOS configuration
 
-<TerminalBlock cmd={['# Build your native iOS project', 'expo run:ios']} />
+<Terminal cmd={[
+  '# Build your native iOS project',
+  '$ expo run:ios'
+]} cmdCopy="expo run:ios" />
 
 You may need to run `npx pod-install` to link the native iOS packages using [CocoaPods](https://cocoapods.org/), this is like running `yarn` or `npm install` in an Expo project. `expo run:ios` does this automatically when the **package.json** changes.
 
 ### Android configuration
 
-<TerminalBlock cmd={['# Build your native Android project', 'expo run:android']} />
+<Terminal cmd={[
+  '# Build your native Android project',
+  '$ expo run:android'
+]} cmdCopy="expo run:android" />
 
 Once the app is built, press the "Open a web browser" button and watch the browser open. Success! Happy times.
 

--- a/docs/pages/build-reference/troubleshooting.md
+++ b/docs/pages/build-reference/troubleshooting.md
@@ -2,9 +2,9 @@
 title: Troubleshooting build errors and crashes
 ---
 
-> This document is under active development; the topic it covers is expansive and finding the right way to explain how to troubleshoot issues will take some trial and error. Your suggestions for improvements are welcome as pull requests.
+import { Terminal } from '~/ui/components/Snippet';
 
-import TerminalBlock from '~/components/plugins/TerminalBlock';
+> This document is under active development; the topic it covers is expansive and finding the right way to explain how to troubleshoot issues will take some trial and error. Your suggestions for improvements are welcome as pull requests.
 
 When something goes wrong, it probably will go wrong in one of two ways: 1) your build will fail, or 2) the build will succeed but encounter a runtime error, eg: it crashes or hangs when you run it.
 
@@ -26,7 +26,7 @@ Regardless of the phase, **it's common to see log entries prefixed with `[stderr
 
 For example, you might see something like this on your Android builds:
 
-<TerminalBlock cmd={[
+<Terminal cmd={[
 `[stderr] Note: /build/workingdir/build/app/node_modules/@react-native-async-storage/async-storage/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStorageModule.java uses or overrides a deprecated API.`,
 `[stderr] Note: Recompile with -Xlint:deprecation for details.`
 ]} />
@@ -35,7 +35,7 @@ While you may or may not be interested in following up on that warning, it is no
 
 A good path forward is to **determine if the build failed due to a native or JavaScript error**. When your build fails due to a JavaScript build error, you will usually see something like this:
 
-<TerminalBlock cmd={[
+<Terminal cmd={[
 `❌ Metro encountered an error:`,
 `Unable to resolve module ./src/Routes from /Users/expo/workingdir/build/App.js`,
 ]} />
@@ -83,11 +83,17 @@ If the logs weren't enough to immediately help you understand and fix the root c
 
 - Relevant Build tool versions (eg: Xcode, Node, npm, Yarn) are the same in both environments. [Learn more](/build/eas-json.md#configuring-your-build-tools).
 - Relevant environment variables are the same in both environments. [Learn more](/build-reference/variables.md).
-- The archive that is uploaded to EAS Build includes the same relevant source files. [Learn more](https://github.com/expo/fyi/blob/master/eas-build-archive.md).
+- The archive that is uploaded to EAS Build includes the same relevant source files. [Learn more](https://expo.fyi/eas-build-archive).
 
 You can verify that your project builds on your local machine with the `expo run` commands with variant/configuration flags set to release to most faithfully reproduce what executes on EAS Build. (Learn more about the [iOS build process](/build-reference/ios-builds.md) and [Android build process](/build-reference/android-builds.md)).
 
-<TerminalBlock cmd={['# Locally compile and run the Android app in release mode', 'expo run:android --variant release', '', '# Locally compile and run the iOS app in release mode', 'expo run:ios --configuration Release']} />
+<Terminal cmd={[
+  '# Locally compile and run the Android app in release mode',
+  '$ expo run:android --variant release',
+  '',
+  '# Locally compile and run the iOS app in release mode',
+  '$ expo run:ios --configuration Release'
+]} />
 
 > In managed projects, these commands will run `expo prebuild` to generate native projects &mdash; you likely want to [clean up the changes](https://expo.fyi/prebuild-cleanup) once you are done troubleshooting.
 

--- a/docs/pages/build/internal-distribution.md
+++ b/docs/pages/build/internal-distribution.md
@@ -2,7 +2,7 @@
 title: Internal distribution
 ---
 
-import TerminalBlock from '~/components/plugins/TerminalBlock';
+import { Terminal } from '~/ui/components/Snippet';
 import { theme } from '@expo/styleguide'
 
 Uploading your app to TestFlight and Google Play beta can be time consuming (e.g. waiting for the build to run through static analysis before becoming available to testers) and limiting (e.g. TestFlight can only have one active build at a time). Both Android and iOS provide alternative mechanisms to distribute apps directly to testers, so they can download and install them to physical devices directly from a web browser as soon as the builds are completed.
@@ -10,8 +10,6 @@ Uploading your app to TestFlight and Google Play beta can be time consuming (e.g
 EAS Build can help you with this by providing sharable URLs for your builds with instructions on how to get them running, so you can share a single URL with a teammate that'll include all of the information they need to test the app.
 
 > 😅 Installing an app on iOS is a bit trickier than on Android, but it's possible thanks to ad hoc and enterprise provisioning profiles. We'll talk more about this later in this doc.
-
-<div style={{marginTop: 30}} />
 
 <h1>Setting up internal distribution</h1>
 
@@ -40,8 +38,6 @@ Please note that if you override the `gradleCommand` on Android, you should ensu
 ### iOS
 
 The configuration above tells EAS Build that you would like to use ad hoc distribution, which is available for all paid Apple developer accounts. It is not available for free accounts.
-
-<div style={{marginTop: -10}} />
 
 <details><summary><h4>🏙 Do you have an Apple Developer Enterprise Program membership?</h4></summary>
 <p>
@@ -84,7 +80,10 @@ Apps signed with an ad hoc provisioning profile can be installed by any iOS devi
 
 Setting up ad hoc provisioning consists of two steps. In the first step, you'll register devices that you want to be able to install your app. Run the following command to generate a URL (and QR code, for convenience) that you can open on your devices, and then follow the instructions on the registration page.
 
-<TerminalBlock cmd={['# Register Apple Devices for internal distribution', 'eas device:create']} />
+<Terminal cmd={[
+  '# Register Apple Devices for internal distribution',
+  '$ eas device:create'
+]} cmdCopy="eas device:create" />
 
 You can register new devices at any time, but builds that were created before the device was registered will not run on newly registered devices; only builds that are created after the device is registered will be installable.
 
@@ -105,8 +104,6 @@ If you distribute your app both through enterprise provisioning and the App Stor
 </p>
 </details>
 
-<div style={{marginTop: -20}} />
-
 <details><summary><h4>🔐 Are you using manual local credentials?</h4></summary>
 <p>
 
@@ -120,7 +117,10 @@ If so, make sure to point your **credentials.json** to an ad hoc or enterprise p
 
 Now that we have set up our build profile and app signing, running a build for internal distribution is just like any other build.
 
-<TerminalBlock cmd={['# Create iOS and Android builds for internal distribution', 'eas build --profile preview --platform all']} />
+<Terminal cmd={[
+  '# Create iOS and Android builds for internal distribution',
+  '$ eas build --profile preview --platform all'
+]} cmdCopy="eas build --profile preview --platform all" />
 
 > If you're using ad hoc provisioning but you haven't registered any devices yet, you'll be asked to register them now (or exit the current command and run `eas device:add` again). The build command will wait for the new device to register. Scan the QR code that is presented in the terminal and follow the instructions on that page to register your device. When you're done, return to the terminal and continue.
 
@@ -130,7 +130,7 @@ When the build completes, you will be given a URL that you can share with your t
 
 Press the "Install" button on the build page and follow the instructions presented in the modal.
 
-## 5. Automation on CI (_optional_)
+## 5. Automation on CI (optional)
 
 It's possible to run internal distribution builds non-interactively in CI using the `--non-interactive` flag; however, if you are using ad hoc provisioning on iOS you will not be able to add new devices to your provisioning profile when using this flag. After registering a device through `eas device:create`, you need to run `eas build` interactively and authenticate with Apple in order for EAS to add the device to your provisioning profile. [Learn more about triggering builds from CI](/build/building-on-ci.md).
 

--- a/docs/pages/development/build.md
+++ b/docs/pages/development/build.md
@@ -3,14 +3,15 @@ title: Creating Development Builds
 ---
 
 import { Tab, Tabs } from '~/components/plugins/Tabs';
-import TerminalBlock from '~/components/plugins/TerminalBlock';
+import { Terminal } from '~/ui/components/Snippet';
 
 ## With EAS
 
 ### Setting up EAS
 
-You can set up your project to use EAS by running
-<TerminalBlock cmd={[`eas build:configure`]} />
+You can set up your project to use EAS by running:
+
+<Terminal cmd={['$ eas build:configure']} cmdCopy="eas build:configure" />
 
 If you have not installed EAS CLI yet, you can do so by running `npm install -g eas-cli`.
 
@@ -37,11 +38,11 @@ This profile has two options set:
 
 <Tabs tabs={["For Android", "For iOS"]}>
 
-<Tab >
+<Tab>
 
 To create and share a development build with your team, you can run the following:
 
-<TerminalBlock cmd={["eas build --profile development --platform android"]} />
+<Terminal cmd={["$ eas build --profile development --platform android"]} cmdCopy="eas build --profile development --platform android" />
 
 To share the build with your team, direct them to the build page on https://expo.dev. There, they'll be able to download the app directly on their device.
 
@@ -51,10 +52,10 @@ To share the build with your team, direct them to the build page on https://expo
 To allow iOS devices to run a build built for internal distribution, you'll have to register each iOS device you'd like to install your development build on.
 
 You can register an iOS device and install a provisioning profile with the following command:
-<TerminalBlock cmd={["eas device:create"]} />
+<Terminal cmd={["$ eas device:create"]} cmdCopy="eas device:create" />
 
 Once you've registered all iOS devices you'll want to run your development build on, you can run the following to create a build ready for internal distribution:
-<TerminalBlock cmd={["eas build --profile development --platform ios"]} />
+<Terminal cmd={["$ eas build --profile development --platform ios"]} cmdCopy="eas build --profile development --platform ios" />
 
 To share the build with your team, direct them to the build page on https://expo.dev. There, they'll be able to download the app directly on their device.
 
@@ -69,24 +70,31 @@ If you are comfortable setting up Xcode, Android Studio, and related dependencie
 
 The `expo run` commands will create a new build, install it on to your emulator or device, and start it running.
 
-<Tabs tabs={["For Android", "For iOS (MacOS Only)"]}>
+<Tabs tabs={["For Android", "For iOS (macOS Only)"]}>
 
-<Tab >
+<Tab>
+<br/>
 
-To build and run on an emulator
-<TerminalBlock cmd={["expo run:android"]} />
+To build and run on an emulator:
 
-To build and run on a connected device
-<TerminalBlock cmd={["expo run:android -d"]} />
+<Terminal cmd={["$ expo run:android"]} cmdCopy="expo run:android" />
+
+To build and run on a connected device:
+
+<Terminal cmd={["$ expo run:android -d"]} cmdCopy="expo run:android -d" />
 
 </Tab>
-<Tab >
+<Tab>
+<br/>
 
-To build and run on a simulator
-<TerminalBlock cmd={["expo run:ios"]} />
+To build and run on a simulator:
 
-To build and run on a connected device
-<TerminalBlock cmd={["expo run:ios -d"]} />
+<Terminal cmd={["$ expo run:ios"]} cmdCopy="expo run:ios" />
+
+To build and run on a connected device:
+
+<Terminal cmd={["$ expo run:ios -d"]} cmdCopy="expo run:ios -d" />
+
 </Tab>
 
 </Tabs>

--- a/docs/pages/development/getting-started.md
+++ b/docs/pages/development/getting-started.md
@@ -2,10 +2,10 @@
 title: Getting Started
 ---
 
-import ImageSpotlight from '~/components/plugins/ImageSpotlight'
-import TerminalBlock from '~/components/plugins/TerminalBlock';
+import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 import SnackInline from '~/components/plugins/SnackInline';
 import { Tab, Tabs } from '~/components/plugins/Tabs';
+import { Terminal } from '~/ui/components/Snippet';
 
 Development builds of your app are Debug builds of your project that include the [`expo-dev-client`](https://www.npmjs.com/package/expo-dev-client) library, which allows you to develop and debug projects from expo-cli or a compatible server.
 
@@ -15,10 +15,15 @@ Development builds of your app are Debug builds of your project that include the
 
 If you have used Expo before, especially with the Managed workflow, [config plugins](/guides/config-plugins.md) will let you customize your project from JavaScript without ever needing to directly modify Xcode or Android Studio projects.
 
-<TerminalBlock cmd={["expo init # if you don't already have a Managed Workflow project", "expo install expo-dev-client"]}  />
+<Terminal cmd={[
+  "# Only if you don't already have a Managed Workflow project",
+  "$ expo init",
+  "",
+  "# Install development client",
+  "$ expo install expo-dev-client"
+]} cmdCopy="expo init && expo install expo-dev-client" />
 
 > You can also improve error messages to be helpful during the development process. To do so, add `import 'expo-dev-client';` to the top of your `App.{js|tsx}` file. [Learn more](installation.md#add-better-error-handlers).
-
 
 ## Creating and installing your first development build
 
@@ -28,21 +33,21 @@ After you configure your project as covered by the [Building with EAS guide](eas
 
 <Tabs tabs={["For iOS Devices", "For Android Devices"]}>
 
-<Tab >
+<Tab>
 
 > Apple Developer membership required
 
 Register any devices you would like to develop on to your ad hoc provisioning profile:
-<TerminalBlock cmd={["eas device:create"]} />
+<Terminal cmd={["$ eas device:create"]} cmdCopy="eas device:create" />
 
 Once you have registered all of the iOS devices you would like to develop on, you can build your app with:
-<TerminalBlock cmd={["eas build --profile development --platform ios"]} />
+<Terminal cmd={["$ eas build --profile development --platform ios"]} cmdCopy="eas build --profile development --platform ios" />
 
 </Tab>
 
-<Tab >
+<Tab>
 
-<TerminalBlock cmd={["eas build --profile development --platform android"]} />
+<Terminal cmd={["$ eas build --profile development --platform android"]} cmdCopy="eas build --profile development --platform android" />
 
 </Tab>
 
@@ -59,7 +64,7 @@ But now that you have a development build of your project installed on your devi
 
 Instead, all you need to do to start developing is to run:
 
-<TerminalBlock packageName="expo-dev-client" cmd={["expo start --dev-client"]} />
+<Terminal cmd={["$ expo start --dev-client"]} cmdCopy="expo start --dev-client" />
 
 and scanning the resulting QR code with your system camera or QR code reader (if you want to develop against a physical device)
 
@@ -81,12 +86,12 @@ In Expo Go, you can already convert text to audio with [expo-speech](/versions/l
 
 First, install the library as you normally would:
 
-<TerminalBlock cmd={["yarn add @react-native-voice/voice"]} />
+<Terminal cmd={["$ yarn add @react-native-voice/voice"]} cmdCopy="yarn add @react-native-voice/voice" />
 
-then register the plugin in your app.json. Using this module will require new permissions, and the plugin can optionally customize the message displayed to users in the permission prompt.
+then register the plugin in your `app.json`. Using this module will require new permissions, and the plugin can optionally customize the message displayed to users in the permission prompt.
 
 <!-- prettier-ignore -->
-```js
+```json
 "expo": {
   "plugins": [
     [
@@ -116,7 +121,7 @@ import Voice, {
 } from "@react-native-voice/voice";
 
 export default function App() {
-  const [results, setResults] = useState([] as string[]);
+  const [results, setResults] = useState([]);
   const [isListening, setIsListening] = useState(false);
 
   useEffect(() => {

--- a/docs/pages/development/installation.md
+++ b/docs/pages/development/installation.md
@@ -4,15 +4,15 @@ sidebar_title: Bare React Native Installation
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';
-import TerminalBlock from '~/components/plugins/TerminalBlock';
 import ConfigurationDiff from '~/components/plugins/ConfigurationDiff';
 import { Tab, Tabs } from '~/components/plugins/Tabs';
+import { Terminal } from '~/ui/components/Snippet';
 
 The installation steps on this page are only required to add the `expo-dev-client` library to a React Native or Bare project. To add a the `expo-dev-client` library to an existing managed project, see our [Getting Started guide](getting-started.md).
 
 If you're just starting your project, you can create a new project from our template with:
 
-<TerminalBlock cmd={["npx crna -t with-dev-client"]} />
+<Terminal cmd={["$ npx crna -t with-dev-client"]} cmdCopy="npx crna -t with-dev-client" />
 
 If you have an existing project, you'll need to [install the package and make a few changes](installation.md) to your **AppDelegate.m**, **MainActivity.java** and **MainApplication.java**.
 

--- a/docs/pages/distribution/release-channels.md
+++ b/docs/pages/distribution/release-channels.md
@@ -3,7 +3,7 @@ title: Release channels
 ---
 
 import { InlineCode } from '~/components/base/code';
-import TerminalBlock from '~/components/plugins/TerminalBlock';
+import { Terminal } from '~/ui/components/Snippet';
 
 > Release channels are used for our Classic Updates service. As of Dec 2021, we started previewing the next generation of our updates service: EAS Update. [Learn more](/eas-update).
 
@@ -18,7 +18,10 @@ Use release channels in Expo to send out different versions of your application 
 
 Publish your update on a release channel by running:
 
-<TerminalBlock cmd={['# Publish to release channel <your-channel>', 'expo publish --release-channel <your-channel>']} />
+<Terminal cmd={[
+  '# Publish to release channel <your-channel>',
+  '$ expo publish --release-channel <your-channel>'
+]} cmdCopy="expo publish --release-channel <your-channel>" />
 
 Your team can see this release channel in the Expo Go app with a parameterized URL `https://exp.host/@username/yourApp?release-channel=<your-release-channel>`. If you do not specify a release channel, you will publish to the `default` channel.
 
@@ -105,7 +108,7 @@ Environment variables don't exist explicitly, but you can utilize release channe
 
 Say you have a workflow of releasing builds like this:
 
-<TerminalBlock cmd={[
+<Terminal cmd={[
 '# Publish to release channel prod-v1',
 'expo publish --release-channel prod-v1',
 '',

--- a/docs/pages/get-started/create-a-new-app.md
+++ b/docs/pages/get-started/create-a-new-app.md
@@ -3,17 +3,23 @@ title: Create a new app
 sidebar_title: Create a new app
 ---
 
-import TerminalBlock from '~/components/plugins/TerminalBlock';
+import { Terminal } from '~/ui/components/Snippet';
 
-At this point we should have Expo CLI installed on our development machine and the Expo Go app on an iOS or Android physical device or emulator. If not, go back to the [Installation](../get-started/installation.md) guide before proceeding.
+At this point we should have Expo CLI installed on our development machine and the Expo Go app on an iOS or Android physical device or emulator. If not, go back to the [Installation](/get-started/installation.md) guide before proceeding.
 
 ## Initializing the project
 
-<TerminalBlock cmd={['# Create a project named my-app. Select the "blank" template when prompted', 'expo init my-app', '', '# Navigate to the project directory', 'cd my-app']} />
+<Terminal cmd={[
+  '# Create a project named my-app. Select the "blank" template when prompted',
+  '$ expo init my-app',
+  '',
+  '# Navigate to the project directory',
+  '$ cd my-app'
+]} cmdCopy="expo init my-app && cd my-app" />
 
 ## Starting the development server
 
-<TerminalBlock cmd={['expo start']} />
+<Terminal cmd={['$ expo start']} cmdCopy="expo start" />
 
 When you run `expo start` (or `npm start`), Expo CLI starts Metro Bundler, which is an HTTP server that compiles the JavaScript code of our app using [Babel](https://babeljs.io/) and serves it to the Expo app. It also pops up Expo Dev Tools, a graphical interface for Expo CLI.
 
@@ -62,7 +68,7 @@ Expo Go is configured by default to automatically reload the app whenever a file
 - First, make sure you have [development mode enabled in Expo CLI](../workflow/development-mode.md#development-mode).
 - Next, close the app and reopen it.
 - Once the app is open again, shake your device to reveal the developer menu. If you are using an emulator, press `⌘+d` for iOS or `ctrl+m` for Android.
-- If you see `Enable Fast Refresh`, press it. If you see `Disable Fast Refresh`, then dismiss the developer menu. Now try making another change.<br/><br/>
+- If you see `Enable Fast Refresh`, press it. If you see `Disable Fast Refresh`, then dismiss the developer menu. Now try making another change.
 
   ![In-app developer menu](/static/images/developer-menu.png)
 

--- a/docs/pages/get-started/installation.md
+++ b/docs/pages/get-started/installation.md
@@ -2,7 +2,7 @@
 title: Installation
 ---
 
-import TerminalBlock from '~/components/plugins/TerminalBlock';
+import { Terminal } from '~/ui/components/Snippet';
 
 There are two tools that you need to develop apps with Expo: a command line app called Expo CLI to initialize and serve your project and a mobile client app called Expo Go to open it on iOS and Android. Any web browser will work for opening the project on the web.
 
@@ -29,7 +29,10 @@ Expo CLI is a command line app that is the main interface between a developer an
 
 ### Installing Expo CLI
 
-<TerminalBlock cmd={['# Install the command line tools', 'npm install --global expo-cli']} />
+<Terminal cmd={[
+  '# Install the command line tools',
+  '$ npm install --global expo-cli'
+]} cmdCopy="npm install --global expo-cli" />
 
 Verify that the installation was successful by running `expo whoami`. You're not logged in yet, so you will see "Not logged in". You can create an account by running `expo register` if you like, or if you have one already run `expo login`, but you also don't need an account to get started.
 

--- a/docs/pages/guides/monorepos.md
+++ b/docs/pages/guides/monorepos.md
@@ -2,7 +2,7 @@
 title: Working with Monorepos
 ---
 
-import TerminalBlock from '~/components/plugins/TerminalBlock';
+import { Terminal } from '~/ui/components/Snippet';
 
 Monorepos, or _"monolithic repositories"_, are single repositories containing multiple apps or packages. It can help speed up development for larger projects, makes it easier to share code, and act as a single source of truth. This guide will set up a simple monorepo with an Expo project. We currently have first-class support for yarn workspaces. If you want to use another tool, make sure you know how to configure it.
 
@@ -57,7 +57,7 @@ Yarn and other tooling have a concept called _"workspaces"_. Every package and a
 
 Now that we have the basic monorepo structure set up, let's add our first app. Before we can create our app, we have to create the **apps/** folder. This folder can contain all separate apps or websites that belong to this monorepo. Inside this **apps/** folder, we can create a subfolder that contains the actual Expo app. 
 
-<TerminalBlock cmd={["expo init apps/cool-app"]} />
+<Terminal cmd={["$ expo init apps/cool-app"]} cmdCopy="expo init apps/cool-app" />
 
 > If you have an existing app, you can copy all those files inside a subfolder.
 
@@ -120,14 +120,14 @@ Monorepos can help us group code in a single repository. That includes apps but 
 Let's go back to the root and create the **packages/** folder. This folder can contain all the separate packages that you want to make. Once you are inside this folder, we need to add a new subfolder. The subfolder is a separate package that we can use inside our app. In the example below, we named it **cool-package**.
 
 
-<TerminalBlock cmd={[
+<Terminal cmd={[
   "# Create our new package folder",
   "mkdir -p packages/cool-package",
   "cd packages/cool-package",
   "",
   "# And create the new package",
   "yarn init"
-]} />
+]} cmdCopy="mkdir -p packages/cool-package && cd packages/cool-package && yarn init" />
 
 We won't go into too much detail in creating a package. If you are not familiar with this, please consider using a simple app without monorepos. But, to make the example complete, let's add an **index.js** file with the following content:
 

--- a/docs/pages/guides/typescript.md
+++ b/docs/pages/guides/typescript.md
@@ -2,7 +2,7 @@
 title: TypeScript
 ---
 
-import TerminalBlock from '~/components/plugins/TerminalBlock';
+import { Terminal } from '~/ui/components/Snippet';
 
 > 💡 Example project: [with-typescript](https://github.com/expo/examples/tree/master/with-typescript)
 
@@ -10,13 +10,13 @@ Expo has first-class support for [TypeScript](https://www.typescriptlang.org/). 
 
 To get started, create a **tsconfig.json** in your project root:
 
-<TerminalBlock cmd={['touch tsconfig.json']} />
+<Terminal cmd={['$ touch tsconfig.json']} cmdCopy="touch tsconfig.json" />
 
 Running `expo start` will prompt you to install the required dependencies (`typescript`, `@types/react`, `@types/react-native`), and automatically configure your **tsconfig.json**.
 
 Rename files to convert them to TypeScript. For example, you would rename **App.js** to **App.tsx**. Use the **.tsx** extension if the file includes React components (JSX). If the file did not include any JSX, you can use the **.ts** file extension.
 
-<TerminalBlock cmd={['mv App.js App.tsx']} />
+<Terminal cmd={['$ mv App.js App.tsx']} cmdCopy="mv App.js App.tsx" />
 
 You can now run `yarn tsc` or `npx tsc` to typecheck the project.
 
@@ -66,7 +66,7 @@ Certain language features may require additional configuration, for example if y
 
 ## Starting from scratch: using a TypeScript template
 
-<TerminalBlock cmd={['expo init -t expo-template-blank-typescript']} />
+<Terminal cmd={['$ expo init -t expo-template-blank-typescript']} cmdCopy="expo init -t expo-template-blank-typescript" />
 
 The easiest way to get started is to initialize your new project using a TypeScript template. When you run `expo init` choose one of the templates with TypeScript in the name and then run `yarn tsc` or `npx tsc` to typecheck the project.
 
@@ -76,7 +76,7 @@ When you create new source files in your project you should use the **.ts** exte
 
 You may find that you want to use TypeScript for the config files in your project, like the **webpack.config.js**, **metro.config.js**, or **app.config.js**. These will require a little extra setup. You can utilize the [`ts-node` require hook](https://github.com/TypeStrong/ts-node#programmatic) to _import_ TypeScript files into your JS config file, meaning any import can be TypeScript, but the root file will still need to be JavaScript.
 
-<TerminalBlock cmd={['yarn add -D ts-node typescript']} />
+<Terminal cmd={['$ yarn add -D ts-node typescript']} cmdCopy="yarn add -D ts-node typescript" />
 
 ### webpack.config.js
 

--- a/docs/pages/guides/using-sentry.md
+++ b/docs/pages/guides/using-sentry.md
@@ -3,7 +3,7 @@ title: Using Sentry
 ---
 
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import TerminalBlock from '~/components/plugins/TerminalBlock';
+import { Terminal } from '~/ui/components/Snippet';
 
 [Sentry](http://getsentry.com/) is a crash reporting platform that provides you with "real-time insight into production deployments with info to reproduce and fix crashes".
 
@@ -42,13 +42,16 @@ Once you have each of these: organization name, project name, DSN, and auth toke
 
 In your project directory, run:
 
-<TerminalBlock cmd={['expo install sentry-expo']} />
+<Terminal cmd={['$ expo install sentry-expo']} cmdCopy="expo install sentry-expo" />
 
 > If you're using SDK 39 or lower, run `yarn add sentry-expo@~3.0.0`
 
 `sentry-expo` also requires some additional dependencies, otherwise it won't work properly. To install them, run:
 
-<TerminalBlock cmd={['expo install expo-application expo-constants expo-device expo-updates @sentry/react-native']} />
+<Terminal 
+  cmd={['$ expo install expo-application expo-constants expo-device expo-updates @sentry/react-native']}
+  cmdCopy="expo install expo-application expo-constants expo-device expo-updates @sentry/react-native"
+/>
 
 ### Step 2: Code
 

--- a/docs/pages/index.md
+++ b/docs/pages/index.md
@@ -3,7 +3,7 @@ title: Introduction to Expo
 hideTOC: true
 ---
 
-import TerminalBlock from '~/components/plugins/TerminalBlock';
+import { Terminal } from '~/ui/components/Snippet';
 
 [Expo](https://expo.dev) is a framework and a platform for universal React applications. It is a set of tools and services built around React Native and native platforms that help you develop, build, deploy, and quickly iterate on iOS, Android, and web apps from the same JavaScript/TypeScript codebase.
 
@@ -11,7 +11,13 @@ import TerminalBlock from '~/components/plugins/TerminalBlock';
 
 If you are already experienced with React and JavaScript tooling and want to dive right in and figure things out as you go, this is the quickest way to get started:
 
-<TerminalBlock cmd={['# Install the command line tools', 'npm install --global expo-cli','', '# Create a new project', 'expo init my-project']} />
+<Terminal cmd={[
+  '# Install the command line tools',
+  '$ npm install --global expo-cli',
+  '',
+  '# Create a new project',
+  '$ expo init my-project'
+]} cmdCopy="npm install --global expo-cli && expo init my-project" />
 
 ## Slow start
 

--- a/docs/pages/ui-programming/using-svgs.md
+++ b/docs/pages/ui-programming/using-svgs.md
@@ -4,7 +4,7 @@ sidebar_title: Using SVGs
 ---
 
 import SnackEmbed from '~/components/plugins/SnackEmbed';
-import TerminalBlock from '~/components/plugins/TerminalBlock';
+import { Terminal } from '~/ui/components/Snippet';
 
 SVGs (Scalable Vector Graphics) are a great way to present icons and other visual elements in a flexible, crisp, and performant way. Using SVGs on the web is straightforward, since we can copy an SVG and place it inline in an HTML file. This works because browsers understand how to parse and present SVGs. Expo does not understand how to parse and present SVG out of the box on Android and iOS, so we'll need to use a React Native package and an SVG converter to do so.
 
@@ -38,7 +38,7 @@ To automate this process, React-SVGR also [provides a CLI](https://react-svgr.co
 
 Once we have a compatible SVG, we'll need to add [react-native-svg](https://github.com/react-native-svg/react-native-svg) to our project. We can do so with:
 
-<TerminalBlock cmd={['expo install react-native-svg']} />
+<Terminal cmd={['$ expo install react-native-svg']} cmdCopy="expo install react-native-svg" />
 
 Then we can add code like the following to our project:
 

--- a/docs/pages/versions/unversioned/index.md
+++ b/docs/pages/versions/unversioned/index.md
@@ -4,15 +4,13 @@ hideTOC: true
 ---
 
 import VersionedRedirectNotification from '~/components/plugins/VersionedRedirectNotification';
-import TerminalBlock from '~/components/plugins/TerminalBlock';
+import { Terminal } from '~/ui/components/Snippet';
 
 <VersionedRedirectNotification />
 
 The Expo SDK provides access to device and system functionality such as contacts, camera, and GPS location. You install modules from the Expo SDK using `expo-cli` with the `expo install` command:
 
-<TerminalBlock cmd={['expo install expo-camera expo-contacts expo-sensors']} />
-
-<br />
+<Terminal  cmd={['$ expo install expo-camera expo-contacts expo-sensors']} cmdCopy="expo install expo-camera expo-contacts expo-sensors" />
 
 You can import modules from it in your JavaScript code as follows:
 

--- a/docs/pages/versions/unversioned/sdk/auth-session.md
+++ b/docs/pages/versions/unversioned/sdk/auth-session.md
@@ -9,9 +9,9 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 import {APIInstallSection} from '~/components/plugins/InstallSection';
 
 import { SocialGrid, SocialGridItem, CreateAppButton } from '~/components/plugins/AuthSessionElements';
-import TerminalBlock from '~/components/plugins/TerminalBlock';
 import SnackInline from '~/components/plugins/SnackInline';
 import { InlineCode } from '~/components/base/code';
+import { Terminal } from '~/ui/components/Snippet';
 
 `AuthSession` is the easiest way to add web browser based authentication (for example, browser-based OAuth flows) to your app, built on top of [WebBrowser](webbrowser.md), [Crypto](crypto.md), and [Random](random.md). If you would like to understand how it does this, read this document from top to bottom. If you just want to use it, jump to the [Authentication Guide](../../../guides/authentication.md).
 
@@ -29,26 +29,26 @@ In **bare-workflow** you can use the [`uri-scheme` package][n-uri-scheme] to eas
 
 To make your native app handle `mycoolredirect://` simply run:
 
-<TerminalBlock cmd={['npx uri-scheme add mycoolredirect']} />
+<Terminal cmd={['$ npx uri-scheme add mycoolredirect']} cmdCopy="npx uri-scheme add mycoolredirect" />
 
 <br />
 
 You should now be able to see a list of all your project's schemes by running:
 
-<TerminalBlock cmd={['npx uri-scheme list']} />
+<Terminal cmd={['$ npx uri-scheme list']} cmdCopy="npx uri-scheme list" />
 
 <br />
 
 You can test it to ensure it works like this:
 
-<TerminalBlock cmd={[
+<Terminal cmd={[
 '# Rebuild the native apps, be sure to use an emulator',
-'yarn ios',
 'yarn android',
+'yarn ios',
 '',
 '# Open a URI scheme',
 'npx uri-scheme open mycoolredirect://some/redirect'
-]} />
+]} cmdCopy="yarn android && yarn ios && npx uri-scheme open mycoolredirect://some/redirect" />
 
 ### Usage in standalone apps
 

--- a/docs/pages/versions/unversioned/sdk/background-fetch.md
+++ b/docs/pages/versions/unversioned/sdk/background-fetch.md
@@ -4,7 +4,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-background-
 packageName: 'expo-background-fetch'
 ---
 
-import APISection from '~/components/plugins/APISection';
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
 import ImageSpotlight from '~/components/plugins/ImageSpotlight'
@@ -19,7 +19,7 @@ import ImageSpotlight from '~/components/plugins/ImageSpotlight'
 
 ## Installation
 
-For [managed](../../../introduction/managed-vs-bare.md#managed-workflow) apps, you'll need to run `expo install expo-background-fetch`. To use it in [bare](../../../introduction/managed-vs-bare.md#bare-workflow) React Native app, follow its [installation instructions](https://github.com/expo/expo/tree/main/packages/expo-background-fetch);
+<APIInstallSection />
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/background-fetch.md
+++ b/docs/pages/versions/unversioned/sdk/background-fetch.md
@@ -4,7 +4,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-background-
 packageName: 'expo-background-fetch'
 ---
 
-import {APIInstallSection} from '~/components/plugins/InstallSection';
+import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
 import ImageSpotlight from '~/components/plugins/ImageSpotlight'

--- a/docs/pages/versions/v44.0.0/index.md
+++ b/docs/pages/versions/v44.0.0/index.md
@@ -4,13 +4,13 @@ hideTOC: true
 ---
 
 import VersionedRedirectNotification from '~/components/plugins/VersionedRedirectNotification';
-import TerminalBlock from '~/components/plugins/TerminalBlock';
+import { Terminal } from '~/ui/components/Snippet';
 
 <VersionedRedirectNotification />
 
 The Expo SDK provides access to device and system functionality such as contacts, camera, and GPS location. You install modules from the Expo SDK using `expo-cli` with the `expo install` command:
 
-<TerminalBlock cmd={['expo install expo-camera expo-contacts expo-sensors']} />
+<Terminal cmd={['$ expo install expo-camera expo-contacts expo-sensors']} cmdCopy="expo install expo-camera expo-contacts expo-sensors" />
 
 <br />
 

--- a/docs/pages/versions/v44.0.0/sdk/auth-session.md
+++ b/docs/pages/versions/v44.0.0/sdk/auth-session.md
@@ -7,9 +7,9 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 import InstallSection from '~/components/plugins/InstallSection';
 
 import { SocialGrid, SocialGridItem, CreateAppButton } from '~/components/plugins/AuthSessionElements';
-import TerminalBlock from '~/components/plugins/TerminalBlock';
 import SnackInline from '~/components/plugins/SnackInline';
 import { InlineCode } from '~/components/base/code';
+import { Terminal } from '~/ui/components/Snippet';
 
 `AuthSession` is the easiest way to add web browser based authentication (for example, browser-based OAuth flows) to your app, built on top of [WebBrowser](webbrowser.md), [Crypto](crypto.md), and [Random](random.md). If you would like to understand how it does this, read this document from top to bottom. If you just want to use it, jump to the [Authentication Guide](../../../guides/authentication.md).
 
@@ -27,26 +27,26 @@ In **bare-workflow** you can use the [`uri-scheme` package][n-uri-scheme] to eas
 
 To make your native app handle `mycoolredirect://` simply run:
 
-<TerminalBlock cmd={['npx uri-scheme add mycoolredirect']} />
+<Terminal cmd={['$ npx uri-scheme add mycoolredirect']} cmdCopy="npx uri-scheme add mycoolredirect" />
 
 <br />
 
 You should now be able to see a list of all your project's schemes by running:
 
-<TerminalBlock cmd={['npx uri-scheme list']} />
+<Terminal cmd={['$ npx uri-scheme list']} cmdCopy="npx uri-scheme list" />
 
 <br />
 
 You can test it to ensure it works like this:
 
-<TerminalBlock cmd={[
+<Terminal cmd={[
 '# Rebuild the native apps, be sure to use an emulator',
-'yarn ios',
 'yarn android',
+'yarn ios',
 '',
 '# Open a URI scheme',
 'npx uri-scheme open mycoolredirect://some/redirect'
-]} />
+]} cmdCopy="yarn android && yarn ios && npx uri-scheme open mycoolredirect://some/redirect" />
 
 ### Usage in standalone apps
 

--- a/docs/pages/versions/v44.0.0/sdk/background-fetch.md
+++ b/docs/pages/versions/v44.0.0/sdk/background-fetch.md
@@ -4,7 +4,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-44/packages/expo-backgroun
 packageName: 'expo-background-fetch'
 ---
 
-import {APIInstallSection} from '~/components/plugins/InstallSection';
+import { APIInstallSection } from '~/components/plugins/InstallSection';
 import APISection from '~/components/plugins/APISection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';

--- a/docs/pages/versions/v44.0.0/sdk/background-fetch.md
+++ b/docs/pages/versions/v44.0.0/sdk/background-fetch.md
@@ -1,8 +1,10 @@
 ---
 title: BackgroundFetch
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-44/packages/expo-background-fetch'
+packageName: 'expo-background-fetch'
 ---
 
+import {APIInstallSection} from '~/components/plugins/InstallSection';
 import APISection from '~/components/plugins/APISection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
@@ -18,7 +20,7 @@ import ImageSpotlight from '~/components/plugins/ImageSpotlight'
 
 ## Installation
 
-For [managed](../../../introduction/managed-vs-bare.md#managed-workflow) apps, you'll need to run `expo install expo-background-fetch`. To use it in [bare](../../../introduction/managed-vs-bare.md#bare-workflow) React Native app, follow its [installation instructions](https://github.com/expo/expo/tree/main/packages/expo-background-fetch);
+<APIInstallSection />
 
 ## Usage
 

--- a/docs/pages/workflow/customizing.md
+++ b/docs/pages/workflow/customizing.md
@@ -2,13 +2,19 @@
 title: Adding custom native code
 ---
 
-import TerminalBlock from '~/components/plugins/TerminalBlock';
+import { Terminal } from '~/ui/components/Snippet';
 
 The Expo Go app enables you to move quickly by building on a feature rich native runtime that is well suited for developing many types of apps. If you want to use custom native code that isn't already in the Expo Go app, you will need to generate the native iOS and Android projects that are typically hidden in the managed workflow, then build and run them.
 
 You can do this in a single command on each platform:
 
-<TerminalBlock cmd={['# Build your native iOS project', 'expo run:ios', '', '# Build your native Android project', 'expo run:android']} />
+<Terminal cmd={[
+  '# Build your native Android project',
+  '$ expo run:android',
+  '',
+  '# Build your native iOS project',
+  '$ expo run:ios'
+]} cmdCopy="expo run:android && expo run:ios" />
 
 > Run commands were introduced in SDK 41, prebuilding and running in earlier SDKs may not work as well.
 
@@ -45,4 +51,10 @@ Once you have customized the native code in your project, you can use the [`expo
 
 The classic `expo build` command does not support custom native code. When you're ready to ship your app, you can [build it with EAS Build](/build/introduction) or archive and sign it locally.
 
-<TerminalBlock cmd={['# Install the CLI', 'npm i -g eas-cli', '', '# Build your app!', 'eas build -p all']} />
+<Terminal cmd={[
+  '# Install the CLI',
+  '$ npm i -g eas-cli',
+  '',
+  '# Build your app!',
+  '$ eas build -p all'
+]} cmdCopy="npm i -g eas-cli && eas build -p all" />

--- a/docs/pages/workflow/development-mode.md
+++ b/docs/pages/workflow/development-mode.md
@@ -4,7 +4,7 @@ sidebar_title: Development and Production
 ---
 
 import Video from '~/components/plugins/Video'
-import TerminalBlock from '~/components/plugins/TerminalBlock';
+import { Terminal } from '~/ui/components/Snippet';
 
 Your project will always run in one of two modes: development or production. By default, running your project locally with `expo start` runs it in development mode, whereas a published project (via `expo publish`), or any standalone apps, will run in production mode.
 
@@ -47,6 +47,6 @@ Production mode is most useful for two things:
 
 The easiest way to simulate how your project will run on end users' devices is with the command
 
-<TerminalBlock cmd={['expo start --no-dev --minify']} />
+<Terminal cmd={['$ expo start --no-dev --minify']} cmdCopy="expo start --no-dev --minify" />
 
 Besides running in production mode (which tells the Metro bundler to set the `__DEV__` environment variable to `false`, among a few other things) the `--minify` flag will minify your app, meaning it will get rid of any unnecessary data (comments, formatting, unused code). If you're getting an error or crash in your standalone app, running your project with this command can save you a lot of time in finding the root cause.

--- a/docs/pages/workflow/expo-cli.md
+++ b/docs/pages/workflow/expo-cli.md
@@ -3,7 +3,7 @@ title: Expo CLI
 maxHeadingDepth: 4
 ---
 
-import TerminalBlock from '~/components/plugins/TerminalBlock';
+import { Terminal } from '~/ui/components/Snippet';
 
 Expo CLI is a command line app that is the main interface between a developer and Expo tools. You'll use it for a variety of tasks, such as:
 
@@ -17,7 +17,7 @@ You may use the CLI in your terminal or use the web based interface (it opens au
 
 ## Installation
 
-<TerminalBlock cmd={['npm install -g expo-cli']} />
+<Terminal cmd={['$ npm install -g expo-cli']} cmdCopy="npm install -g expo-cli" />
 
 ## Checking CLI Version
 
@@ -27,7 +27,7 @@ Run `expo --version` to determine what version you are currently working with.
 
 The commands listed below are derived from the latest version of Expo CLI. You can view the list of commands available with your version in your terminal using `expo --help`. To learn more about a specific command and its options use `expo [command] --help`.
 
-<TerminalBlock cmd={[`# Usage: expo [command] [options]`]} />
+<Terminal cmd={[`# Usage: expo [command] [options]`]} />
 
 <!-- BEGIN GENERATED BLOCK. DO NOT MODIFY MANUALLY. https://github.com/expo/expo-cli/blob/main/packages/expo-cli/scripts/introspect.ts -->
 

--- a/docs/ui/components/Snippet/Snippet.tsx
+++ b/docs/ui/components/Snippet/Snippet.tsx
@@ -1,4 +1,5 @@
 import { css, SerializedStyles } from '@emotion/react';
+import { spacing } from '@expo/styleguide';
 import React, { PropsWithChildren } from 'react';
 
 type SnippetProps = {
@@ -12,5 +13,5 @@ export const Snippet = ({ children, style }: PropsWithChildren<SnippetProps>) =>
 const containerStyle = css`
   display: flex;
   flex-direction: column;
-  margin-bottom: 1ch;
+  margin-bottom: ${spacing[4]}px;
 `;

--- a/docs/ui/components/Snippet/SnippetContent.tsx
+++ b/docs/ui/components/Snippet/SnippetContent.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { borderRadius, theme } from '@expo/styleguide';
+import { borderRadius, theme, spacing } from '@expo/styleguide';
 import React, { PropsWithChildren } from 'react';
 
 type SnippetContentProps = PropsWithChildren<{
@@ -22,7 +22,7 @@ const contentStyle = css`
   border: 1px solid ${theme.border.default};
   border-bottom-left-radius: ${borderRadius.medium}px;
   border-bottom-right-radius: ${borderRadius.medium}px;
-  padding: 1rem;
+  padding: ${spacing[4]}px;
   overflow-x: auto;
 
   code {

--- a/docs/ui/components/Snippet/blocks/Terminal.tsx
+++ b/docs/ui/components/Snippet/blocks/Terminal.tsx
@@ -60,16 +60,21 @@ function cmdMapper(line: string, index: number) {
   if (line.startsWith('$')) {
     return (
       <div key={key}>
-        <CODE css={[codeStyle, unselectableStyle, { color: darkTheme.text.secondary }]}>
+        <CODE
+          css={[
+            codeStyle,
+            unselectableStyle,
+            { display: 'inline', color: darkTheme.text.secondary },
+          ]}>
           →&nbsp;
         </CODE>
-        <CODE css={[codeStyle, { display: 'inline' }]}>{line.substring(1).trim()}</CODE>
+        <CODE css={codeStyle}>{line.substring(1).trim()}</CODE>
       </div>
     );
   }
 
   return (
-    <CODE key={key} css={codeStyle}>
+    <CODE key={key} css={[codeStyle, { display: 'inherit' }]}>
       {line}
     </CODE>
   );


### PR DESCRIPTION
# Why

This PR switches the all Terminal blocks already used in the docs to the new component. This is a part of docs redesign.

# How

`TerminalBlock` has been replaced with `Terminal` from new Snippets. Since the new component supports command copy, I had to add the copy friendly string in `cmdCopy` prop.

There was an issue, when lines without the prefix characters were incorrectly rendered (inline with previous lines), but I was able to fix this, but altering the `Terminal` styles a bit.

In this changeset I have also correct few links and clean up few HTML/JSX tags on the edited pages.

# Test Plan

The changes have been tested by running docs website locally.

# Preview

<img width="1160" alt="Screenshot 2022-04-19 at 13 07 43" src="https://user-images.githubusercontent.com/719641/163990773-c6357853-56b4-4e8f-b5c4-63e37352347e.png">
<img width="1160" alt="Screenshot 2022-04-19 at 13 07 52" src="https://user-images.githubusercontent.com/719641/163990761-e6b845e0-353e-487d-9db1-d91eb9a1bcac.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
