### PR TITLE
[image-manipulator][ios] Fix base64 result

### DIFF
--- a/packages/expo-image-manipulator/CHANGELOG.md
+++ b/packages/expo-image-manipulator/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix `base64` result of `manipulateAsync` being always `null` on iOS.
+- Fix `base64` result of `manipulateAsync` being always `null` on iOS. ([#17122](https://github.com/expo/expo/pull/17122) by [@barthap](https://github.com/barthap))
 
 ### 💡 Others
 

--- a/packages/expo-image-manipulator/CHANGELOG.md
+++ b/packages/expo-image-manipulator/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix `base64` result of `manipulateAsync` being always `null` on iOS.
+
 ### 💡 Others
 
 ## 10.3.0 — 2022-04-18

--- a/packages/expo-image-manipulator/ios/ImageManipulatorModule.swift
+++ b/packages/expo-image-manipulator/ios/ImageManipulatorModule.swift
@@ -30,7 +30,7 @@ public class ImageManipulatorModule: Module {
             "uri": saveResult.url.absoluteString,
             "width": newImage.cgImage?.width ?? 0,
             "height": newImage.cgImage?.height ?? 0,
-            "base64": options.base64 ? saveResult.data.base64EncodedData() : nil
+            "base64": options.base64 ? saveResult.data.base64EncodedString() : nil
           ])
         } catch {
           promise.reject(error)


### PR DESCRIPTION
# Why

Resolves ENG-4719

Test suite was failing on base64 result test - had `object` (`null` to be specific), expected `string`.

# How

Replaced `base64EncodedData()` with `base64EncodedString()`. The former returned the `Data` object while we intended to get the string representation.

# Test Plan

ImageManipulator Test suite on iOS ✅ 
