### PR TITLE
[iOS][modules-core][image-picker] Remove `EXLogger`

### DIFF
--- a/packages/expo-image-picker/ios/ImagePickerModule.swift
+++ b/packages/expo-image-picker/ios/ImagePickerModule.swift
@@ -140,21 +140,17 @@ public class ImagePickerModule: Module, OnMediaPickingResultHandler {
   func didPickMedia(mediaInfo: MediaInfo) {
     guard let options = self.currentPickingContext?.options,
           let promise = self.currentPickingContext?.promise else {
-      self.appContext?.logger?.warn("Picking operation context has been lost.")
+      NSLog("Picking operation context has been lost.")
       return
     }
     guard let fileSystem = self.appContext?.fileSystem else {
       return promise.reject(FileSystemModuleNotFoundException())
-    }
-    guard let logger = self.appContext?.logger else {
-      return promise.reject(LoggerModuleNotFoundException())
     }
 
     // Cleanup the currently stored picking context
     self.currentPickingContext = nil
 
     let mediaHandler = MediaHandler(fileSystem: fileSystem,
-                                    logger: logger,
                                     options: options)
     mediaHandler.handleMedia(mediaInfo) { result -> Void in
       switch result {

--- a/packages/expo-image-picker/ios/MediaHandler.swift
+++ b/packages/expo-image-picker/ios/MediaHandler.swift
@@ -6,7 +6,6 @@ import Photos
 
 internal struct MediaHandler {
   internal weak var fileSystem: EXFileSystemInterface?
-  internal weak var logger: EXLogManager?
   internal let options: ImagePickerOptions
 
   internal func handleMedia(_ mediaInfo: MediaInfo, completion: @escaping (AsyncResult) -> Void) {
@@ -48,7 +47,7 @@ internal struct MediaHandler {
                                                            tryReadingFile: fileWasCopied,
                                                            shouldReadBase64: self.options.base64)
 
-      ImageUtils.optionallyReadExifFrom(mediaInfo: mediaInfo, logger: self.logger, shouldReadExif: self.options.exif) { exif in
+      ImageUtils.optionallyReadExifFrom(mediaInfo: mediaInfo, shouldReadExif: self.options.exif) { exif in
         let result: ImagePickerResponse = .image(ImageInfo(uri: targetUrl.absoluteString,
                                                            width: image.size.width,
                                                            height: image.size.height,
@@ -254,7 +253,6 @@ private struct ImageUtils {
 
   static func optionallyReadExifFrom(
     mediaInfo: MediaInfo,
-    logger: EXLogManager?,
     shouldReadExif: Bool,
     completion: @escaping (_ result: [String: Any]?) -> Void
   ) {
@@ -270,14 +268,14 @@ private struct ImageUtils {
     }
 
     guard let imageUrl = mediaInfo[.referenceURL] as? URL else {
-      logger?.info("Could not fetch metadata for image")
+      NSLog("Could not fetch metadata for image")
       return completion(nil)
     }
 
     let assets = PHAsset.fetchAssets(withALAssetURLs: [imageUrl], options: nil)
 
     guard let asset = assets.firstObject else {
-      logger?.info("Could not fetch metadata for image '\(imageUrl.absoluteString)'.")
+      NSLog("Could not fetch metadata for image '\(imageUrl.absoluteString)'.")
       return completion(nil)
     }
 
@@ -287,7 +285,7 @@ private struct ImageUtils {
       guard let imageUrl = input?.fullSizeImageURL,
             let properties = CIImage(contentsOf: imageUrl)?.properties
       else {
-        logger?.info("Could not fetch metadata for '\(imageUrl.absoluteString)'.")
+        NSLog("Could not fetch metadata for '\(imageUrl.absoluteString)'.")
         return completion(nil)
       }
       let exif = ImageUtils.readExifFrom(imageMetadata: properties)

--- a/packages/expo-modules-core/ios/Swift/AppContext.swift
+++ b/packages/expo-modules-core/ios/Swift/AppContext.swift
@@ -105,13 +105,6 @@ public final class AppContext {
   }
 
   /**
-   Provides access to the logger from legacy module registry.
-   */
-  public var logger: EXLogManager? {
-    return legacyModuleRegistry?.getSingletonModule(forName: EXLogManager.name()) as? EXLogManager
-  }
-
-  /**
    Starts listening to `UIApplication` notifications.
    */
   private func listenToClientAppNotifications() {


### PR DESCRIPTION
`EXLogger` used in Swift is not versionalble at this moment, so for now it's being removed copletely.

# Why

`EXLogger` used in Swift is not versionable properly on iOS.
Operator `as?` is not working as simple type casting.

# Test Plan

- [x] `Expo Go` compiles and runs
