### PR TITLE
[reanimated][Android] Fix `JSCRuntime destroyed with a dangling API object`

### DIFF
--- a/android/expoview/src/main/cpp/headers/NativeProxy.h
+++ b/android/expoview/src/main/cpp/headers/NativeProxy.h
@@ -131,6 +131,8 @@ class NativeProxy : public jni::HybridClass<NativeProxy> {
       jni::alias_ref<LayoutAnimations::javaobject> layoutAnimations);
   static void registerNatives();
 
+ ~NativeProxy();
+
  private:
   friend HybridBase;
   jni::global_ref<NativeProxy::javaobject> javaPart_;


### PR DESCRIPTION
# Why

Fixes ENG-4713.
Fixes:
```
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG: Abort message: '/Users/lukasz/work/expo/android/ReactAndroid/../ReactCommon/jsi/JSCRuntime.cpp:394: virtual facebook::jsc::JSCRuntime::~JSCRuntime(): assertion "objectCounter_ == 0 && "JSCRuntime destroyed with a dangling API object"" failed'
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:     x0  0000000000000000  x1  0000000000005cd1  x2  0000000000000006  x3  0000006f7acdc3f0
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:     x4  0080808080808080  x5  0080808080808080  x6  0080808080808080  x7  8080808080808000
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:     x8  00000000000000f0  x9  57ea5f66b3577129  x10 0000000000000000  x11 ffffff80fffffbdf
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:     x12 0000000000000001  x13 0000001614a34420  x14 002a651836a2a326  x15 0000000000000050
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:     x16 00000070183b0ba8  x17 000000701838bc10  x18 0000000000000001  x19 0000000000005ae4
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:     x20 0000000000005cd1  x21 00000000ffffffff  x22 000000001406cdd8  x23 000000001406cdd8
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:     x24 0000006f90c00880  x25 0000006f7acdcc90  x26 0000000018380001  x27 0000000000000000
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:     x28 0000006f7acdcb30  x29 0000006f7acdc470
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:     lr  000000701833bf30  sp  0000006f7acdc3d0  pc  000000701833bf5c  pst 0000000000001000
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG: backtrace:
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #00 pc 0000000000078f5c  /apex/com.android.runtime/lib64/bionic/libc.so (abort+168) (BuildId: 86c2e03db5ccf75a523a17b3ca80de5c)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #01 pc 0000000000079328  /apex/com.android.runtime/lib64/bionic/libc.so (__assert2+40) (BuildId: 86c2e03db5ccf75a523a17b3ca80de5c)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #02 pc 0000000000053b90  /data/app/~~Rzw_hzRTWeyDEjVSTjfOHA==/host.exp.exponent-iMghO3MvMe7o86t03WvFVg==/lib/arm64/libjscexecutor.so (facebook::jsc::JSCRuntime::~JSCRuntime()+136) (BuildId: ca89a6ba66281f0321d6776ea6996fc7c4a2d232)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #03 pc 0000000000053be0  /data/app/~~Rzw_hzRTWeyDEjVSTjfOHA==/host.exp.exponent-iMghO3MvMe7o86t03WvFVg==/lib/arm64/libjscexecutor.so (facebook::jsc::JSCRuntime::~JSCRuntime()+16) (BuildId: ca89a6ba66281f0321d6776ea6996fc7c4a2d232)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #04 pc 0000000000040018  /data/app/~~Rzw_hzRTWeyDEjVSTjfOHA==/host.exp.exponent-iMghO3MvMe7o86t03WvFVg==/lib/arm64/libjscexecutor.so (BuildId: ca89a6ba66281f0321d6776ea6996fc7c4a2d232)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #05 pc 000000000003fd44  /data/app/~~Rzw_hzRTWeyDEjVSTjfOHA==/host.exp.exponent-iMghO3MvMe7o86t03WvFVg==/lib/arm64/libjscexecutor.so (BuildId: ca89a6ba66281f0321d6776ea6996fc7c4a2d232)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #06 pc 000000000004de4c  /data/app/~~Rzw_hzRTWeyDEjVSTjfOHA==/host.exp.exponent-iMghO3MvMe7o86t03WvFVg==/lib/arm64/libjscexecutor.so (facebook::react::JSIExecutor::~JSIExecutor()+476) (BuildId: ca89a6ba66281f0321d6776ea6996fc7c4a2d232)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #07 pc 000000000004de7c  /data/app/~~Rzw_hzRTWeyDEjVSTjfOHA==/host.exp.exponent-iMghO3MvMe7o86t03WvFVg==/lib/arm64/libjscexecutor.so (facebook::react::JSIExecutor::~JSIExecutor()+16) (BuildId: ca89a6ba66281f0321d6776ea6996fc7c4a2d232)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #08 pc 0000000000217a0c  /data/app/~~Rzw_hzRTWeyDEjVSTjfOHA==/host.exp.exponent-iMghO3MvMe7o86t03WvFVg==/lib/arm64/libreactnativejni.so (BuildId: 8045280c95324fd7b2b53ee996c58fc1cf663d2c)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #09 pc 0000000000217978  /data/app/~~Rzw_hzRTWeyDEjVSTjfOHA==/host.exp.exponent-iMghO3MvMe7o86t03WvFVg==/lib/arm64/libreactnativejni.so (BuildId: 8045280c95324fd7b2b53ee996c58fc1cf663d2c)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #10 pc 0000000000226d14  /data/app/~~Rzw_hzRTWeyDEjVSTjfOHA==/host.exp.exponent-iMghO3MvMe7o86t03WvFVg==/lib/arm64/libreactnativejni.so (BuildId: 8045280c95324fd7b2b53ee996c58fc1cf663d2c)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #11 pc 0000000000226cdc  /data/app/~~Rzw_hzRTWeyDEjVSTjfOHA==/host.exp.exponent-iMghO3MvMe7o86t03WvFVg==/lib/arm64/libreactnativejni.so (BuildId: 8045280c95324fd7b2b53ee996c58fc1cf663d2c)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #12 pc 0000000000226c4c  /data/app/~~Rzw_hzRTWeyDEjVSTjfOHA==/host.exp.exponent-iMghO3MvMe7o86t03WvFVg==/lib/arm64/libreactnativejni.so (BuildId: 8045280c95324fd7b2b53ee996c58fc1cf663d2c)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #13 pc 0000000000226c00  /data/app/~~Rzw_hzRTWeyDEjVSTjfOHA==/host.exp.exponent-iMghO3MvMe7o86t03WvFVg==/lib/arm64/libreactnativejni.so (BuildId: 8045280c95324fd7b2b53ee996c58fc1cf663d2c)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #14 pc 0000000000226bd8  /data/app/~~Rzw_hzRTWeyDEjVSTjfOHA==/host.exp.exponent-iMghO3MvMe7o86t03WvFVg==/lib/arm64/libreactnativejni.so (BuildId: 8045280c95324fd7b2b53ee996c58fc1cf663d2c)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #15 pc 000000000022591c  /data/app/~~Rzw_hzRTWeyDEjVSTjfOHA==/host.exp.exponent-iMghO3MvMe7o86t03WvFVg==/lib/arm64/libreactnativejni.so (BuildId: 8045280c95324fd7b2b53ee996c58fc1cf663d2c)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #16 pc 00000000001913f4  /data/app/~~Rzw_hzRTWeyDEjVSTjfOHA==/host.exp.exponent-iMghO3MvMe7o86t03WvFVg==/lib/arm64/libreactnativejni.so (BuildId: 8045280c95324fd7b2b53ee996c58fc1cf663d2c)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #17 pc 000000000018c64c  /data/app/~~Rzw_hzRTWeyDEjVSTjfOHA==/host.exp.exponent-iMghO3MvMe7o86t03WvFVg==/lib/arm64/libreactnativejni.so (std::__ndk1::function<void ()>::operator()() const+20) (BuildId: 8045280c95324fd7b2b53ee996c58fc1cf663d2c)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #18 pc 00000000001951c8  /data/app/~~Rzw_hzRTWeyDEjVSTjfOHA==/host.exp.exponent-iMghO3MvMe7o86t03WvFVg==/lib/arm64/libreactnativejni.so (BuildId: 8045280c95324fd7b2b53ee996c58fc1cf663d2c)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #19 pc 0000000000195164  /data/app/~~Rzw_hzRTWeyDEjVSTjfOHA==/host.exp.exponent-iMghO3MvMe7o86t03WvFVg==/lib/arm64/libreactnativejni.so (BuildId: 8045280c95324fd7b2b53ee996c58fc1cf663d2c)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #20 pc 0000000000195118  /data/app/~~Rzw_hzRTWeyDEjVSTjfOHA==/host.exp.exponent-iMghO3MvMe7o86t03WvFVg==/lib/arm64/libreactnativejni.so (BuildId: 8045280c95324fd7b2b53ee996c58fc1cf663d2c)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #21 pc 00000000001950f0  /data/app/~~Rzw_hzRTWeyDEjVSTjfOHA==/host.exp.exponent-iMghO3MvMe7o86t03WvFVg==/lib/arm64/libreactnativejni.so (BuildId: 8045280c95324fd7b2b53ee996c58fc1cf663d2c)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #22 pc 0000000000194034  /data/app/~~Rzw_hzRTWeyDEjVSTjfOHA==/host.exp.exponent-iMghO3MvMe7o86t03WvFVg==/lib/arm64/libreactnativejni.so (BuildId: 8045280c95324fd7b2b53ee996c58fc1cf663d2c)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #23 pc 00000000001913f4  /data/app/~~Rzw_hzRTWeyDEjVSTjfOHA==/host.exp.exponent-iMghO3MvMe7o86t03WvFVg==/lib/arm64/libreactnativejni.so (BuildId: 8045280c95324fd7b2b53ee996c58fc1cf663d2c)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #24 pc 000000000018c64c  /data/app/~~Rzw_hzRTWeyDEjVSTjfOHA==/host.exp.exponent-iMghO3MvMe7o86t03WvFVg==/lib/arm64/libreactnativejni.so (std::__ndk1::function<void ()>::operator()() const+20) (BuildId: 8045280c95324fd7b2b53ee996c58fc1cf663d2c)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #25 pc 000000000018e938  /data/app/~~Rzw_hzRTWeyDEjVSTjfOHA==/host.exp.exponent-iMghO3MvMe7o86t03WvFVg==/lib/arm64/libreactnativejni.so (BuildId: 8045280c95324fd7b2b53ee996c58fc1cf663d2c)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #26 pc 000000000018e894  /data/app/~~Rzw_hzRTWeyDEjVSTjfOHA==/host.exp.exponent-iMghO3MvMe7o86t03WvFVg==/lib/arm64/libreactnativejni.so (BuildId: 8045280c95324fd7b2b53ee996c58fc1cf663d2c)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #27 pc 000000000018e848  /data/app/~~Rzw_hzRTWeyDEjVSTjfOHA==/host.exp.exponent-iMghO3MvMe7o86t03WvFVg==/lib/arm64/libreactnativejni.so (BuildId: 8045280c95324fd7b2b53ee996c58fc1cf663d2c)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #28 pc 000000000018e820  /data/app/~~Rzw_hzRTWeyDEjVSTjfOHA==/host.exp.exponent-iMghO3MvMe7o86t03WvFVg==/lib/arm64/libreactnativejni.so (BuildId: 8045280c95324fd7b2b53ee996c58fc1cf663d2c)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #29 pc 000000000018d528  /data/app/~~Rzw_hzRTWeyDEjVSTjfOHA==/host.exp.exponent-iMghO3MvMe7o86t03WvFVg==/lib/arm64/libreactnativejni.so (BuildId: 8045280c95324fd7b2b53ee996c58fc1cf663d2c)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #30 pc 00000000001913f4  /data/app/~~Rzw_hzRTWeyDEjVSTjfOHA==/host.exp.exponent-iMghO3MvMe7o86t03WvFVg==/lib/arm64/libreactnativejni.so (BuildId: 8045280c95324fd7b2b53ee996c58fc1cf663d2c)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #31 pc 000000000018c64c  /data/app/~~Rzw_hzRTWeyDEjVSTjfOHA==/host.exp.exponent-iMghO3MvMe7o86t03WvFVg==/lib/arm64/libreactnativejni.so (std::__ndk1::function<void ()>::operator()() const+20) (BuildId: 8045280c95324fd7b2b53ee996c58fc1cf663d2c)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #32 pc 00000000001c9d2c  /data/app/~~Rzw_hzRTWeyDEjVSTjfOHA==/host.exp.exponent-iMghO3MvMe7o86t03WvFVg==/lib/arm64/libreactnativejni.so (facebook::react::JNativeRunnable::run()+28) (BuildId: 8045280c95324fd7b2b53ee996c58fc1cf663d2c)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #33 pc 00000000001c9ee4  /data/app/~~Rzw_hzRTWeyDEjVSTjfOHA==/host.exp.exponent-iMghO3MvMe7o86t03WvFVg==/lib/arm64/libreactnativejni.so (facebook::jni::detail::MethodWrapper<void (facebook::react::JNativeRunnable::)(), &(facebook::react::JNativeRunnable::run()), facebook::react::JNativeRunnable, void>::dispatch(facebook::jni::alias_ref<facebook::jni::detail::JTypeFor<facebook::jni::HybridClass<facebook::react::JNativeRunnable, facebook::react::Runnable>::JavaPart, facebook::react::Runnable, void>::_javaobject>)+180) (BuildId: 8045280c95324fd7b2b53ee996c58fc1cf663d2c)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #34 pc 00000000001c9f64  /data/app/~~Rzw_hzRTWeyDEjVSTjfOHA==/host.exp.exponent-iMghO3MvMe7o86t03WvFVg==/lib/arm64/libreactnativejni.so (facebook::jni::detail::CallWithJniConversions<void ()(facebook::jni::alias_ref<facebook::jni::detail::JTypeFor<facebook::jni::HybridClass<facebook::react::JNativeRunnable, facebook::react::Runnable>::JavaPart, facebook::react::Runnable, void>::_javaobject>), void, facebook::jni::detail::JTypeFor<facebook::jni::HybridClass<facebook::react::JNativeRunnable, facebook::react::Runnable>::JavaPart, facebook::react::Runnable, void>::_javaobject*>::call(facebook::jni::detail::JTypeFor<facebook::jni::HybridClass<facebook::react::JNativeRunnable, facebook::react::Runnable>::JavaPart, facebook::react::Runnable, void>::_javaobject*, void ()(facebook::jni::alias_ref<facebook::jni::detail::JTypeFor<facebook::jni::HybridClass<facebook::react::JNativeRunnable, facebook::react::Runnable>::JavaPart, facebook::react::Runnable, void>::_javaobject>))+72) (BuildId: 8045280c95324fd7b2b53ee996c58fc1cf663d2c)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #35 pc 00000000001c9d74  /data/app/~~Rzw_hzRTWeyDEjVSTjfOHA==/host.exp.exponent-iMghO3MvMe7o86t03WvFVg==/lib/arm64/libreactnativejni.so (facebook::jni::detail::FunctionWrapper<void ()(facebook::jni::alias_ref<facebook::jni::detail::JTypeFor<facebook::jni::HybridClass<facebook::react::JNativeRunnable, facebook::react::Runnable>::JavaPart, facebook::react::Runnable, void>::_javaobject>), facebook::jni::detail::JTypeFor<facebook::jni::HybridClass<facebook::react::JNativeRunnable, facebook::react::Runnable>::JavaPart, facebook::react::Runnable, void>::_javaobject*, void>::call(_JNIEnv*, _jobject*, void ()(facebook::jni::alias_ref<facebook::jni::detail::JTypeFor<facebook::jni::HybridClass<facebook::react::JNativeRunnable, facebook::react::Runnable>::JavaPart, facebook::react::Runnable, void>::_javaobject>))+56) (BuildId: 8045280c95324fd7b2b53ee996c58fc1cf663d2c)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #36 pc 00000000001c9cfc  /data/app/~~Rzw_hzRTWeyDEjVSTjfOHA==/host.exp.exponent-iMghO3MvMe7o86t03WvFVg==/lib/arm64/libreactnativejni.so (facebook::jni::detail::MethodWrapper<void (facebook::react::JNativeRunnable::)(), &(facebook::react::JNativeRunnable::run()), facebook::react::JNativeRunnable, void>::call(_JNIEnv, _jobject*)+36) (BuildId: 8045280c95324fd7b2b53ee996c58fc1cf663d2c)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #37 pc 00000000002d4044  /apex/com.android.art/lib64/libart.so (art_quick_generic_jni_trampoline+148) (BuildId: 34e3dd028e2e682b63a512d6a4f1b5eb)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #38 pc 00000000020580ec  /memfd:jit-cache (deleted) (android.os.Handler.handleCallback+140)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #39 pc 0000000002056b68  /memfd:jit-cache (deleted) (android.os.Handler.dispatchMessage+104)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #40 pc 000000000020a0a0  /apex/com.android.art/lib64/libart.so (nterp_helper+4016) (BuildId: 34e3dd028e2e682b63a512d6a4f1b5eb)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #41 pc 00000000000174e4  [anon:dalvik-classes2.dex extracted in memory from /data/app/~~Rzw_hzRTWeyDEjVSTjfOHA==/host.exp.exponent-iMghO3MvMe7o86t03WvFVg==/base.apk!classes2.dex] (com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage+0)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #42 pc 0000000002024b88  /memfd:jit-cache (deleted) (android.os.Looper.loopOnce+1832)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #43 pc 0000000002024274  /memfd:jit-cache (deleted) (android.os.Looper.loop+532)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #44 pc 00000000002caa7c  /apex/com.android.art/lib64/libart.so (art_quick_osr_stub+60) (BuildId: 34e3dd028e2e682b63a512d6a4f1b5eb)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #45 pc 0000000000779fb0  /apex/com.android.art/lib64/libart.so (MterpMaybeDoOnStackReplacement+860) (BuildId: 34e3dd028e2e682b63a512d6a4f1b5eb)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #46 pc 00000000002c99d0  /apex/com.android.art/lib64/libart.so (MterpHelpers+240) (BuildId: 34e3dd028e2e682b63a512d6a4f1b5eb)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #47 pc 000000000046c392  /system/framework/framework.jar (android.os.Looper.loop+186)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #48 pc 000000000076ce1c  /apex/com.android.art/lib64/libart.so (MterpInvokeStatic+2120) (BuildId: 34e3dd028e2e682b63a512d6a4f1b5eb)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #49 pc 00000000002c5014  /apex/com.android.art/lib64/libart.so (mterp_op_invoke_static+20) (BuildId: 34e3dd028e2e682b63a512d6a4f1b5eb)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #50 pc 0000000000017672  [anon:dalvik-classes2.dex extracted in memory from /data/app/~~Rzw_hzRTWeyDEjVSTjfOHA==/host.exp.exponent-iMghO3MvMe7o86t03WvFVg==/base.apk!classes2.dex] (com.facebook.react.bridge.queue.MessageQueueThreadImpl$4.run+74)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #51 pc 000000000027d840  /apex/com.android.art/lib64/libart.so (art::interpreter::Execute(art::Thread*, art::CodeItemDataAccessor const&, art::ShadowFrame&, art::JValue, bool, bool) (.llvm.3351068054637636664)+644) (BuildId: 34e3dd028e2e682b63a512d6a4f1b5eb)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #52 pc 000000000035a9e4  /apex/com.android.art/lib64/libart.so (art::interpreter::ArtInterpreterToInterpreterBridge(art::Thread*, art::CodeItemDataAccessor const&, art::ShadowFrame*, art::JValue*)+148) (BuildId: 34e3dd028e2e682b63a512d6a4f1b5eb)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #53 pc 000000000040b05c  /apex/com.android.art/lib64/libart.so (bool art::interpreter::DoCall<false, false>(art::ArtMethod*, art::Thread*, art::ShadowFrame&, art::Instruction const*, unsigned short, art::JValue*)+1452) (BuildId: 34e3dd028e2e682b63a512d6a4f1b5eb)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #54 pc 00000000003d537c  /apex/com.android.art/lib64/libart.so (MterpInvokeInterface+4912) (BuildId: 34e3dd028e2e682b63a512d6a4f1b5eb)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #55 pc 00000000002c5094  /apex/com.android.art/lib64/libart.so (mterp_op_invoke_interface+20) (BuildId: 34e3dd028e2e682b63a512d6a4f1b5eb)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #56 pc 00000000000eda70  /apex/com.android.art/javalib/core-oj.jar (java.lang.Thread.run+8)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #57 pc 000000000027d840  /apex/com.android.art/lib64/libart.so (art::interpreter::Execute(art::Thread*, art::CodeItemDataAccessor const&, art::ShadowFrame&, art::JValue, bool, bool) (.llvm.3351068054637636664)+644) (BuildId: 34e3dd028e2e682b63a512d6a4f1b5eb)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #58 pc 000000000027c9e8  /apex/com.android.art/lib64/libart.so (artQuickToInterpreterBridge+1176) (BuildId: 34e3dd028e2e682b63a512d6a4f1b5eb)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #59 pc 00000000002d4178  /apex/com.android.art/lib64/libart.so (art_quick_to_interpreter_bridge+88) (BuildId: 34e3dd028e2e682b63a512d6a4f1b5eb)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #60 pc 00000000002ca764  /apex/com.android.art/lib64/libart.so (art_quick_invoke_stub+548) (BuildId: 34e3dd028e2e682b63a512d6a4f1b5eb)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #61 pc 000000000030e980  /apex/com.android.art/lib64/libart.so (art::ArtMethod::Invoke(art::Thread*, unsigned int*, unsigned int, art::JValue*, char const*)+156) (BuildId: 34e3dd028e2e682b63a512d6a4f1b5eb)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #62 pc 00000000003c1db4  /apex/com.android.art/lib64/libart.so (art::JValue art::InvokeVirtualOrInterfaceWithJValuesart::ArtMethod*(art::ScopedObjectAccessAlreadyRunnable const&, _jobject*, art::ArtMethod*, jvalue const*)+380) (BuildId: 34e3dd028e2e682b63a512d6a4f1b5eb)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #63 pc 00000000004578ec  /apex/com.android.art/lib64/libart.so (art::Thread::CreateCallback(void*)+992) (BuildId: 34e3dd028e2e682b63a512d6a4f1b5eb)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #64 pc 00000000000de0d4  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start(void*)+264) (BuildId: 86c2e03db5ccf75a523a17b3ca80de5c)
2022-04-19 12:01:12.545 23863-23863/? A/DEBUG:       #65 pc 000000000007a890  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+68) (BuildId: 86c2e03db5ccf75a523a17b3ca80de5c)
```

# How

The reanimated codebase contains a reference cycle between the `NativeReanimatedModule` and the runtime which makes deallocation of the  `NativeReanimatedModule` impossible. Also, the event handler is storing a reference to the `NativeReanimatedModule` that isn't ever cleaned. 

# Test Plan

- NCL ✅
