### PR TITLE
[expoview][Android] Fix reloading from notification crashes the application

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/ExponentIntentService.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/ExponentIntentService.kt
@@ -51,8 +51,14 @@ class ExponentIntentService : IntentService("ExponentIntentService") {
 
   private fun handleActionReloadExperience(manifestUrl: String) {
     kernel.reloadVisibleExperience(manifestUrl)
-    val intent = Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS)
-    sendBroadcast(intent)
+
+    // Application can't close system dialogs on Android 31 or higher.
+    // See https://developer.android.com/about/versions/12/behavior-changes-all#close-system-dialogs
+    if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.S) {
+      val intent = Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS)
+      sendBroadcast(intent)
+    }
+
     Analytics.logEventWithManifestUrl(Analytics.AnalyticsEvent.RELOAD_EXPERIENCE, manifestUrl)
     stopSelf()
   }


### PR DESCRIPTION
# Why

Fixes ENG-4727.
Fixes:
```
2022-04-19 12:22:32.874 30943-31161/host.exp.exponent E/AndroidRuntime: FATAL EXCEPTION: IntentService[ExponentIntentService]
    Process: host.exp.exponent, PID: 30943
    java.lang.SecurityException: Permission Denial: android.intent.action.CLOSE_SYSTEM_DIALOGS broadcast from host.exp.exponent (pid=30943, uid=10256) requires android.permission.BROADCAST_CLOSE_SYSTEM_DIALOGS.
        at android.os.Parcel.createExceptionOrNull(Parcel.java:2441)
        at android.os.Parcel.createException(Parcel.java:2425)
        at android.os.Parcel.readException(Parcel.java:2408)
        at android.os.Parcel.readException(Parcel.java:2350)
        at android.app.IActivityManager$Stub$Proxy.broadcastIntentWithFeature(IActivityManager.java:5763)
        at android.app.ContextImpl.sendBroadcast(ContextImpl.java:1179)
        at android.content.ContextWrapper.sendBroadcast(ContextWrapper.java:489)
        at host.exp.exponent.ExponentIntentService.handleActionReloadExperience(ExponentIntentService.kt:55)
        at host.exp.exponent.ExponentIntentService.onHandleIntent(ExponentIntentService.kt:40)
        at android.app.IntentService$ServiceHandler.handleMessage(IntentService.java:78)
        at android.os.Handler.dispatchMessage(Handler.java:106)
        at android.os.Looper.loopOnce(Looper.java:233)
        at android.os.Looper.loop(Looper.java:344)
        at android.os.HandlerThread.run(HandlerThread.java:67)
     Caused by: android.os.RemoteException: Remote stack trace:
        at com.android.server.wm.ActivityTaskManagerService.checkCanCloseSystemDialogs(ActivityTaskManagerService.java:3038)
        at com.android.server.wm.ActivityTaskManagerService.access$900(ActivityTaskManagerService.java:308)
        at com.android.server.wm.ActivityTaskManagerService$LocalService.checkCanCloseSystemDialogs(ActivityTaskManagerService.java:5472)
        at com.android.server.am.ActivityManagerService.broadcastIntentLocked(ActivityManagerService.java:13869)
        at com.android.server.am.ActivityManagerService.broadcastIntentLocked(ActivityManagerService.java:13423)
```

# How

From API 31 apps can't close system dialogs. See https://developer.android.com/about/versions/12/behavior-changes-all#close-system-dialogs.

# Test Plan

- run expo go on API 31