### PR TITLE
[dev-launcher][android] load updates by manifestPermalink

### DIFF
--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -49,7 +49,7 @@ import org.koin.dsl.module
 
 // Use this to load from a development server for the development client launcher UI
 //  private final String DEV_LAUNCHER_HOST = "10.0.0.175:8090";
-private val DEV_LAUNCHER_HOST: String? = "192.168.1.67:8090"
+private val DEV_LAUNCHER_HOST: String? = null
 
 private const val NEW_ACTIVITY_FLAGS = Intent.FLAG_ACTIVITY_NEW_TASK or
   Intent.FLAG_ACTIVITY_CLEAR_TASK or

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -3,6 +3,7 @@ package expo.modules.devlauncher
 import android.app.Application
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.net.Uri
 import androidx.annotation.UiThread
 import com.facebook.react.ReactActivity
@@ -48,7 +49,7 @@ import org.koin.dsl.module
 
 // Use this to load from a development server for the development client launcher UI
 //  private final String DEV_LAUNCHER_HOST = "10.0.0.175:8090";
-private val DEV_LAUNCHER_HOST: String? = null
+private val DEV_LAUNCHER_HOST: String? = "192.168.1.67:8090"
 
 private const val NEW_ACTIVITY_FLAGS = Intent.FLAG_ACTIVITY_NEW_TASK or
   Intent.FLAG_ACTIVITY_CLEAR_TASK or
@@ -92,7 +93,11 @@ class DevLauncherController private constructor()
 
   private var appIsLoading = false
 
-  override suspend fun loadApp(url: Uri, mainActivity: ReactActivity?) {
+  private fun isEASUpdateURL(url: Uri): Boolean {
+    return url.host.equals("u.expo.dev")
+  }
+
+  override suspend fun loadApp(url: Uri, projectUrl: Uri?, mainActivity: ReactActivity?) {
     synchronized(this) {
       if (appIsLoading) {
         return
@@ -104,13 +109,23 @@ class DevLauncherController private constructor()
       ensureHostWasCleared(appHost, activityToBeInvalidated = mainActivity)
 
       val parsedUrl = replaceEXPScheme(url, "http")
+      var parsedProjectUrl = projectUrl ?: url
+
+      val isEASUpdate = isEASUpdateURL(url)
+
+      // default to the EXPO_UPDATE_URL value configured in AndroidManifest.xml when project url is unspecified for an EAS update
+      if (isEASUpdate && projectUrl == null) {
+        val projectUrlString = appHost.reactInstanceManager?.currentReactContext?.let { getMetadataValue(it, "expo.modules.updates.EXPO_UPDATE_URL") }
+        parsedProjectUrl = Uri.parse(projectUrlString)
+      }
+
       val manifestParser = DevLauncherManifestParser(httpClient, parsedUrl, installationIDHelper.getOrCreateInstallationID(context))
       val appIntent = createAppIntent()
 
       internalUpdatesInterface?.reset()
 
       val appLoaderFactory = get<DevLauncherAppLoaderFactoryInterface>()
-      val appLoader = appLoaderFactory.createAppLoader(parsedUrl, manifestParser)
+      val appLoader = appLoaderFactory.createAppLoader(parsedUrl, parsedProjectUrl, manifestParser)
       useDeveloperSupport = appLoaderFactory.shouldUseDeveloperSupport()
       manifest = appLoaderFactory.getManifest()
       manifestURL = parsedUrl
@@ -140,6 +155,10 @@ class DevLauncherController private constructor()
       }
       throw e
     }
+  }
+
+  override suspend fun loadApp(url: Uri, mainActivity: ReactActivity?) {
+    loadApp(url, null, mainActivity)
   }
 
   override fun onAppLoaded(context: ReactContext) {
@@ -304,6 +323,24 @@ class DevLauncherController private constructor()
     private var sErrorHandlerWasInitialized = false
     private var sLauncherClass: Class<*>? = null
     internal var sAdditionalPackages: List<ReactPackage>? = null
+
+    @JvmStatic
+    fun getMetadataValue(reactApplicationContext: ReactContext, key: String): String {
+      val packageManager = reactApplicationContext.packageManager
+      val packageName = reactApplicationContext.packageName
+      val applicationInfo = packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA)
+      var metaDataValue = ""
+
+      if (applicationInfo.metaData != null) {
+        val value = applicationInfo.metaData.get(key)
+
+        if (value != null) {
+          metaDataValue = value.toString()
+        }
+      }
+
+      return metaDataValue
+    }
 
     @JvmStatic
     fun wasInitialized() =

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherAppLoaderFactory.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherAppLoaderFactory.kt
@@ -16,7 +16,7 @@ import org.koin.core.component.inject
 import java.lang.IllegalStateException
 
 interface DevLauncherAppLoaderFactoryInterface {
-  suspend fun createAppLoader(url: Uri, manifestParser: DevLauncherManifestParser): DevLauncherAppLoader
+  suspend fun createAppLoader(url: Uri, projectUrl: Uri, manifestParser: DevLauncherManifestParser): DevLauncherAppLoader
   fun getManifest(): Manifest?
   fun shouldUseDeveloperSupport(): Boolean
 }
@@ -32,7 +32,7 @@ class DevLauncherAppLoaderFactory : DevLauncherKoinComponent, DevLauncherAppLoad
   private var manifest: Manifest? = null
   private var useDeveloperSupport = true
 
-  override suspend fun createAppLoader(url: Uri, manifestParser: DevLauncherManifestParser): DevLauncherAppLoader {
+  override suspend fun createAppLoader(url: Uri, projectUrl: Uri, manifestParser: DevLauncherManifestParser): DevLauncherAppLoader {
     instanceWasCreated = true
     return if (!manifestParser.isManifestUrl()) {
       // It's (maybe) a raw React Native bundle
@@ -45,7 +45,7 @@ class DevLauncherAppLoaderFactory : DevLauncherKoinComponent, DevLauncherAppLoad
         }
         DevLauncherLocalAppLoader(manifest!!, appHost, context, controller)
       } else {
-        val configuration = createUpdatesConfigurationWithUrl(url, url, installationIDHelper.getOrCreateInstallationID(context))
+        val configuration = createUpdatesConfigurationWithUrl(url, projectUrl, installationIDHelper.getOrCreateInstallationID(context))
         val update = updatesInterface!!.loadUpdate(configuration, context) {
           manifest = Manifest.fromManifestJson(it) // TODO: might be able to pass actual manifest object in here
           return@loadUpdate !manifest!!.isUsingDeveloperTool()

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/DevLauncherControllerInterface.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/DevLauncherControllerInterface.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.CoroutineScope
 
 interface DevLauncherControllerInterface {
   suspend fun loadApp(url: Uri, mainActivity: ReactActivity? = null)
+  suspend fun loadApp(url: Uri, projectUrl: Uri?, mainActivity: ReactActivity? = null)
   fun onAppLoaded(context: ReactContext)
   fun onAppLoadedWithError()
   fun getRecentlyOpenedApps(): Map<String, String?>

--- a/packages/expo-dev-launcher/android/src/release/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/release/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -63,6 +63,10 @@ class DevLauncherController private constructor() : DevLauncherControllerInterfa
     throw IllegalStateException(DEV_LAUNCHER_IS_NOT_AVAILABLE)
   }
 
+  override suspend fun loadApp(url: Uri, projectUrl: Uri?, mainActivity: ReactActivity?) {
+    throw IllegalStateException(DEV_LAUNCHER_IS_NOT_AVAILABLE)
+  }
+
   override fun onAppLoaded(context: ReactContext) {
     throw IllegalStateException(DEV_LAUNCHER_IS_NOT_AVAILABLE)
   }

--- a/packages/expo-dev-launcher/android/src/testDebug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherAppLoaderFactoryTest.kt
+++ b/packages/expo-dev-launcher/android/src/testDebug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherAppLoaderFactoryTest.kt
@@ -56,7 +56,7 @@ internal class DevLauncherAppLoaderFactoryTest {
     val manifestParser = mockk<DevLauncherManifestParser>()
     coEvery { manifestParser.isManifestUrl() } returns false
 
-    val appLoader = appLoaderFactory.createAppLoader(developmentManifestURL, manifestParser)
+    val appLoader = appLoaderFactory.createAppLoader(developmentManifestURL, developmentManifestURL, manifestParser)
     Truth.assertThat(appLoader).isInstanceOf(DevLauncherReactNativeAppLoader::class.java)
     Truth.assertThat(appLoaderFactory.shouldUseDeveloperSupport()).isTrue()
   }
@@ -70,7 +70,7 @@ internal class DevLauncherAppLoaderFactoryTest {
     coEvery { manifestParser.isManifestUrl() } returns true
     coEvery { manifestParser.parseManifest() } returns manifest
 
-    val appLoader = appLoaderFactory.createAppLoader(developmentManifestURL, manifestParser)
+    val appLoader = appLoaderFactory.createAppLoader(developmentManifestURL, developmentManifestURL, manifestParser)
     Truth.assertThat(appLoader).isInstanceOf(DevLauncherLocalAppLoader::class.java)
     Truth.assertThat(appLoaderFactory.shouldUseDeveloperSupport()).isTrue()
   }
@@ -85,7 +85,7 @@ internal class DevLauncherAppLoaderFactoryTest {
     coEvery { manifestParser.parseManifest() } returns manifest
 
     Assert.assertThrows(Exception::class.java) {
-      runBlocking { appLoaderFactory.createAppLoader(publishedManifestURL, manifestParser) }
+      runBlocking { appLoaderFactory.createAppLoader(publishedManifestURL, developmentManifestURL, manifestParser) }
     }
   }
 
@@ -99,7 +99,7 @@ internal class DevLauncherAppLoaderFactoryTest {
     val manifestParser = mockk<DevLauncherManifestParser>()
     coEvery { manifestParser.isManifestUrl() } returns true
 
-    val appLoader = appLoaderFactory.createAppLoader(developmentManifestURL, manifestParser)
+    val appLoader = appLoaderFactory.createAppLoader(developmentManifestURL, developmentManifestURL, manifestParser)
     Truth.assertThat(appLoader).isInstanceOf(DevLauncherLocalAppLoader::class.java)
     Truth.assertThat(appLoaderFactory.shouldUseDeveloperSupport()).isTrue()
   }
@@ -114,7 +114,7 @@ internal class DevLauncherAppLoaderFactoryTest {
     val manifestParser = mockk<DevLauncherManifestParser>()
     coEvery { manifestParser.isManifestUrl() } returns true
 
-    val appLoader = appLoaderFactory.createAppLoader(publishedManifestURL, manifestParser)
+    val appLoader = appLoaderFactory.createAppLoader(publishedManifestURL,developmentManifestURL, manifestParser)
     Truth.assertThat(appLoader).isInstanceOf(DevLauncherPublishedAppLoader::class.java)
     Truth.assertThat(appLoaderFactory.shouldUseDeveloperSupport()).isFalse()
   }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This is the Android PR for parity w/  #17031, which enabled loading EAS Updates via manifestPermalink

# How

<!--
How did you build this feature or fix this bug and why?
-->

Added a `loadUpdate` method to the dev launcher which makes use of loading EAS Updates via manifestPermalink - the implementation is quite similar to the iOS implementation, although I had to do some minor refactoring on this one

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Ensure an update can be loaded on Android

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
