### PR TITLE
[github] test-suite: attempt to cache AVD to speed up workflow

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -225,15 +225,14 @@ jobs:
           api-level: ${{ matrix.api-level }}
           arch: x86_64
           force-avd-creation: false
-          emulator-options: -no-window -gpu swiftshader_indirect -no-boot-anim
           script: echo "Generated AVD snapshot for caching."
       - name: 🧪 Run tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
+          avd-name: avd-${{ matrix.api-level }}
           arch: x86_64
           force-avd-creation: false
-          emulator-options: -no-window -gpu swiftshader_indirect -no-boot-anim
           disable-animations: true
           script: yarn android:detox:test:release
           working-directory: ./apps/bare-expo

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -158,6 +158,9 @@ jobs:
     env:
       ORG_GRADLE_PROJECT_reactNativeArchitectures: x86_64
       GRADLE_OPTS: -Dorg.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=2048m
+    strategy:
+      matrix:
+        api-level: [29]
     steps:
       - name: ⬢ Setup Node
         uses: actions/setup-node@v3
@@ -193,12 +196,16 @@ jobs:
           key: ${{ runner.os }}-modules-${{ hashFiles('yarn.lock') }}
       - name: 🧶 Install node modules in root dir
         run: yarn install --frozen-lockfile
-      - uses: actions/cache@v2
+      - name: 🧺 Gradle cache
+        uses: gradle/gradle-build-action@v2
+      - name: 🧺 AVD cache
+        uses: actions/cache@v3
+        id: avd-cache
         with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-v20210625-${{ hashFiles('android/*.gradle*') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-v20210625
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-${{ matrix.api-level }}
       - name: ⚛️ Display React Native config
         run: yarn react-native config
         working-directory: apps/bare-expo
@@ -211,15 +218,26 @@ jobs:
         timeout-minutes: 35
         env:
           GRADLE_OPTS: '-Dorg.gradle.internal.http.connectionTimeout=180000 -Dorg.gradle.internal.http.socketTimeout=180000 -Dorg.gradle.internal.network.retry.max.attempts=18 -Dorg.gradle.internal.network.retry.initial.backOff=2000'
-      - name: Run tests
+      - name: 📱 Create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 29
+          api-level: ${{ matrix.api-level }}
           arch: x86_64
-          avd-name: bare-expo
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -no-boot-anim
+          script: echo "Generated AVD snapshot for caching."
+      - name: 🧪 Run tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          arch: x86_64
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -no-boot-anim
+          disable-animations: true
           script: yarn android:detox:test:release
           working-directory: ./apps/bare-expo
-      - name: Store images of build failures
+      - name: 📸 Store images of build failures
         if: always()
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -233,7 +233,6 @@ jobs:
           avd-name: avd-${{ matrix.api-level }}
           arch: x86_64
           force-avd-creation: false
-          disable-animations: true
           script: yarn android:detox:test:release
           working-directory: ./apps/bare-expo
       - name: 📸 Store images of build failures

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -67,14 +67,12 @@
       "android.emu.debug": {
         "binaryPath": "android/app/build/outputs/apk/debug/app-debug.apk",
         "build": "cd android && ./gradlew :app:assembleDebug :app:assembleAndroidTest -DtestBuildType=debug && cd ..",
-        "type": "android.emulator",
-        "name": "bare-expo"
+        "type": "android.emulator"
       },
       "android.emu.release": {
         "binaryPath": "android/app/build/outputs/apk/release/app-release.apk",
         "build": "cd android && ./gradlew :app:assembleRelease :app:assembleAndroidTest -DtestBuildType=release && cd ..",
-        "type": "android.emulator",
-        "name": "bare-expo"
+        "type": "android.emulator"
       }
     },
     "runner-config": "./e2e/jest.config.json",

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -67,12 +67,14 @@
       "android.emu.debug": {
         "binaryPath": "android/app/build/outputs/apk/debug/app-debug.apk",
         "build": "cd android && ./gradlew :app:assembleDebug :app:assembleAndroidTest -DtestBuildType=debug && cd ..",
-        "type": "android.emulator"
+        "type": "android.emulator",
+        "name": "avd-29"
       },
       "android.emu.release": {
         "binaryPath": "android/app/build/outputs/apk/release/app-release.apk",
         "build": "cd android && ./gradlew :app:assembleRelease :app:assembleAndroidTest -DtestBuildType=release && cd ..",
-        "type": "android.emulator"
+        "type": "android.emulator",
+        "name": "avd-29"
       }
     },
     "runner-config": "./e2e/jest.config.json",


### PR DESCRIPTION
# Why

Currently, the test-suite workflow took a while to run on the CI, this PR is an attempt to optimize a bit this workflow.

# How

The changes are based on the instruction and guides found in:
* https://github.com/ReactiveCircus/android-emulator-runner
* https://github.com/gradle/gradle-build-action#why-use-the-gradle-build-action

And the goal is to better cache Grade files, cache AVDs and speed up tests run on the AVD.

# Test Plan

Run the CI.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
