### PR TITLE
[Android][expoview][react-native] Align native dependencies versions with `react-native@0.68.1`

### DIFF
--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -306,24 +306,26 @@ dependencies {
   // WHEN_DISTRIBUTING_REMOVE_TO_HERE
 
   // React native dependencies
+  api 'androidx.appcompat:appcompat:1.2.0'
+  api 'androidx.autofill:autofill:1.1.0'
   api 'androidx.swiperefreshlayout:swiperefreshlayout:1.0.0'
-  api 'com.facebook.fresco:fresco:2.0.0'
-  api 'com.facebook.fresco:animated-gif:2.0.0'
-  api 'com.facebook.fresco:animated-webp:2.0.0'
-  api 'com.facebook.fresco:webpsupport:2.0.0'
-  api 'com.facebook.fresco:imagepipeline-okhttp3:2.0.0'
-  api 'com.facebook.stetho:stetho:1.3.1' // do we need this?
-  api 'com.facebook.stetho:stetho-okhttp3:1.3.1' // do we need this?
-  compileOnly 'com.facebook.soloader:soloader:0.8.2'
+  api 'com.facebook.fbjni:fbjni-java-only:0.2.2'
+  api 'com.facebook.fresco:fresco:2.5.0'
+  api 'com.facebook.fresco:animated-gif:2.5.0'
+  api 'com.facebook.fresco:animated-webp:2.5.0'
+  api 'com.facebook.fresco:webpsupport:2.5.0'
+  api 'com.facebook.fresco:imagepipeline-okhttp3:2.5.0'
+  api 'com.facebook.fresco:ui-common:2.5.0'
+  api 'com.facebook.infer.annotation:infer-annotation:0.18.0'
+  api 'com.facebook.soloader:soloader:0.10.3'
+  api 'com.facebook.yoga:proguard-annotations:1.19.0'
   api 'com.google.code.findbugs:jsr305:3.0.2'
-  api 'com.squareup.okhttp3:okhttp:3.12.1'
-  api 'com.squareup.okhttp3:okhttp-urlconnection:3.12.1'
-  api 'com.squareup.okio:okio:1.15.0'
-  api 'com.facebook.infer.annotation:infer-annotation:0.11.2'
+  api 'com.squareup.okhttp3:okhttp-urlconnection:4.9.2'
+  api 'com.squareup.okhttp3:okhttp:4.9.2'
+  api 'com.squareup.okio:okio:2.9.0'
   api 'javax.inject:javax.inject:1'
 
   // Our dependencies
-  api "androidx.appcompat:appcompat:1.2.0"
   compileOnly 'org.glassfish:javax.annotation:3.1.1'
   api 'de.greenrobot:eventbus:2.4.0'
   api "androidx.room:room-runtime:2.1.0"

--- a/android/expoview/src/main/java/host/exp/expoview/Exponent.kt
+++ b/android/expoview/src/main/java/host/exp/expoview/Exponent.kt
@@ -13,7 +13,6 @@ import android.os.StrictMode.ThreadPolicy
 import android.os.UserManager
 import com.facebook.common.internal.ByteStreams
 import com.facebook.drawee.backends.pipeline.Fresco
-import com.facebook.stetho.Stetho
 import com.raizlabs.android.dbflow.config.DatabaseConfig
 import com.raizlabs.android.dbflow.config.FlowConfig
 import com.raizlabs.android.dbflow.config.FlowManager
@@ -452,10 +451,6 @@ class Exponent private constructor(val context: Context, val application: Applic
         )
         .build()
     )
-
-    if (ExpoViewBuildConfig.DEBUG) {
-      Stetho.initializeWithDefaults(context)
-    }
 
     if (!ExpoViewBuildConfig.DEBUG) {
       // There are a few places in RN code that throw NetworkOnMainThreadException.


### PR DESCRIPTION
During migration to `react-native@0.68.1` we skipped native dependencies upgrades on Android.

I've bumped:
- `com.facebook.fresco:fresco:2.0.0 ➡️ 2.5.0`
- `com.facebook.fresco:animated-gif:2.0.0 ➡️ 2.5.0`
- `com.facebook.fresco:animated-webp:2.0.0 ➡️ 2.5.0`
- `com.facebook.fresco:webpsupport:2.0.0 ➡️ 2.5.0`
- `com.facebook.fresco:imagepipeline-okhttp3:2.0.0 ➡️ 2.5.0`
- `com.facebook.infer.annotation:infer-annotation:0.11.2 ➡️ 0.18.0`
- `com.facebook.soloader:soloader:0.8.2 ➡️ 0.10.3`
- `com.squareup.okhttp3:okhttp-urlconnection:3.12.1 ➡️ 4.9.2`
- `com.squareup.okhttp3:okhttp:3.12.1 ➡️ 4.9.2`
- `com.squareup.okio:okio:1.15.0 ➡️ 2.9.0`

I've added:
- `com.facebook.yoga:proguard-annotations:1.19.0`
- `com.facebook.fbjni:fbjni-java-only:0.2.2`
- `com.facebook.fresco:ui-common:2.5.0`
- `androidx.autofill:autofill:1.1.0`

I've removed:
- `com.facebook.stetho:stetho:1.3.1`
- `com.facebook.stetho:stetho-okhttp:1.3.1`

I've also removed `Stetho` library that was serving to inspect Android app using web browser DevTools (nobody actually ever used it).

# Why

Continues work started in [#16040 ](https://github.com/expo/expo/pull/17063)
Fixes [ENG-4711](https://linear.app/expo/issue/ENG-4711/gif-is-not-animating-on-android)

# How

I've copied over dependencies from [`react-native/ReactAndroid/build.gradle#L387-L401`](https://github.com/facebook/react-native/blob/v0.68.1/ReactAndroid/build.gradle#L387-L401).

# Test Plan

- [x] `Expo Go` on Android compiles and run
    - [x] `Gif` screen is working