### PR TITLE
[NCL] Fix ScrollViewScreen inner vertical scrolling broken

### DIFF
--- a/apps/native-component-list/src/screens/ScrollViewScreen.tsx
+++ b/apps/native-component-list/src/screens/ScrollViewScreen.tsx
@@ -64,6 +64,7 @@ export default function ScrollViewScreen() {
           }}
           scrollEventThrottle={200}
           scrollEnabled={isEnabled}
+          nestedScrollEnabled
           horizontal={isHorizontal}
           ref={scrollView}
           style={styles.scrollView}>


### PR DESCRIPTION
# Why

close ENG-4712

# How

add `nestedScrollEnabled` for nesting scroll on android.

# Test Plan

- unversioned android expo go + NCL ScrollViewScreen
- i also double check this vertical scrolling is also broken from sdk-43 and sdk-44 NCL, so it's not a regression.

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
