### PR TITLE
[expo] Fix js unit test error from TurboModuleRegistry

### DIFF
--- a/packages/expo/src/__tests__/Expo-test.native.ts
+++ b/packages/expo/src/__tests__/Expo-test.native.ts
@@ -123,6 +123,13 @@ jest.mock('react-native/Libraries/Core/Devtools/getDevServer', () => ({
   },
 }));
 
+jest.mock('react-native/Libraries/TurboModule/TurboModuleRegistry.js', () => ({
+  ...(jest.requireActual('react-native/Libraries/TurboModule/TurboModuleRegistry.js') as any),
+  get: () => ({
+    getConstants: () => ({}),
+  }),
+}));
+
 describe(`importing Expo`, () => {
   beforeAll(() => {
     jest.resetModules();

--- a/packages/expo/src/__tests__/__fbBatchedBridgeConfig-test.ts
+++ b/packages/expo/src/__tests__/__fbBatchedBridgeConfig-test.ts
@@ -13,6 +13,13 @@ jest.mock('react-native/Libraries/Core/Devtools/getDevServer', () => {
   };
 });
 
+jest.mock('react-native/Libraries/TurboModule/TurboModuleRegistry.js', () => ({
+  ...(jest.requireActual('react-native/Libraries/TurboModule/TurboModuleRegistry.js') as any),
+  get: () => ({
+    getConstants: () => ({}),
+  }),
+}));
+
 if (Platform.OS === 'web') {
   it('provides a helpful error message on web', () => {
     // @ts-ignore


### PR DESCRIPTION
# Why

fix sdk packages ci error: https://github.com/expo/expo/runs/6096420301?check_suite_focus=true
this is from #17091

# How

mock `TurboModuleRegistry`

# Test Plan

sdk packages ci passed

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
