### PR TITLE
[expo-updates][e2e] add tests for loading updates, update id headers

### DIFF
--- a/.github/workflows/updates-e2e.yml
+++ b/.github/workflows/updates-e2e.yml
@@ -100,7 +100,7 @@ jobs:
         run: yarn add file:../expo/packages/expo-updates file:../expo/packages/expo file:../expo/packages/expo-splash-screen file:../expo/packages/expo-status-bar
       - name: Setup app.config.json
         working-directory: ../updates-e2e
-        run: echo "{\"name\":\"updates-e2e\",\"plugins\":[\"expo-updates\"],\"android\":{\"package\":\"dev.expo.updatese2e\"},\"ios\":{\"bundleIdentifier\":\"dev.expo.updatese2e\"}}" > app.config.json
+        run: echo "{\"name\":\"updates-e2e\",\"plugins\":[\"expo-updates\"],\"android\":{\"package\":\"dev.expo.updatese2e\"},\"ios\":{\"bundleIdentifier\":\"dev.expo.updatese2e\"},\"updates\":{\"url\":\"http://10.0.2.2:$UPDATES_PORT/update\"}}" > app.config.json
       - name: Pack latest bare-minimum template as tarball for expo prebuild
         working-directory: templates/expo-template-bare-minimum
         run: npm pack --pack-destination ../../../updates-e2e/

--- a/.github/workflows/updates-e2e.yml
+++ b/.github/workflows/updates-e2e.yml
@@ -127,17 +127,17 @@ jobs:
         id: test-apk-path
         working-directory: ../updates-e2e/android/app/build/outputs/apk/release
         run: echo "::set-output name=dir::$(pwd)"
-      - name: Export update bundle for test server to host
+      - name: Export update for test server to host
         working-directory: ../updates-e2e
-        run: expo export --public-url https://expo.dev/dummy-url --platform android
-      - name: Get test bundle dist path
-        id: test-bundle-dist-path
+        run: expo export --public-url https://u.expo.dev/dummy-url --platform android
+      - name: Get test update dist path
+        id: test-update-dist-path
         working-directory: ../updates-e2e/dist
         run: echo "::set-output name=dir::$(pwd)"
       - name: Run tests
         env:
           TEST_APK_PATH: '${{ steps.test-apk-path.outputs.dir }}/app-release.apk'
-          TEST_BUNDLE_DIST_PATH: '${{ steps.test-bundle-dist-path.outputs.dir }}'
+          TEST_UPDATE_DIST_PATH: '${{ steps.test-bundle-dist-path.outputs.dir }}'
         timeout-minutes: 30
         uses: reactivecircus/android-emulator-runner@v2
         with:

--- a/.github/workflows/updates-e2e.yml
+++ b/.github/workflows/updates-e2e.yml
@@ -137,7 +137,7 @@ jobs:
       - name: Run tests
         env:
           TEST_APK_PATH: '${{ steps.test-apk-path.outputs.dir }}/app-release.apk'
-          TEST_UPDATE_DIST_PATH: '${{ steps.test-bundle-dist-path.outputs.dir }}'
+          TEST_UPDATE_DIST_PATH: '${{ steps.test-update-dist-path.outputs.dir }}'
         timeout-minutes: 30
         uses: reactivecircus/android-emulator-runner@v2
         with:

--- a/.github/workflows/updates-e2e.yml
+++ b/.github/workflows/updates-e2e.yml
@@ -100,7 +100,7 @@ jobs:
         run: yarn add file:../expo/packages/expo-updates file:../expo/packages/expo file:../expo/packages/expo-splash-screen file:../expo/packages/expo-status-bar
       - name: Setup app.config.json
         working-directory: ../updates-e2e
-        run: echo "{\"name\":\"updates-e2e\",\"plugins\":[\"expo-updates\"],\"android\":{\"package\":\"dev.expo.updatese2e\"},\"ios\":{\"bundleIdentifier\":\"dev.expo.updatese2e\"},\"updates\":{\"url\":\"http://10.0.2.2:$UPDATES_PORT/update\"}}" > app.config.json
+        run: echo "{\"name\":\"updates-e2e\",\"runtimeVersion\":\"1.0.0\",\"plugins\":[\"expo-updates\"],\"android\":{\"package\":\"dev.expo.updatese2e\"},\"ios\":{\"bundleIdentifier\":\"dev.expo.updatese2e\"},\"updates\":{\"url\":\"http://10.0.2.2:$UPDATES_PORT/update\"}}" > app.config.json
       - name: Pack latest bare-minimum template as tarball for expo prebuild
         working-directory: templates/expo-template-bare-minimum
         run: npm pack --pack-destination ../../../updates-e2e/
@@ -127,9 +127,17 @@ jobs:
         id: test-apk-path
         working-directory: ../updates-e2e/android/app/build/outputs/apk/release
         run: echo "::set-output name=dir::$(pwd)"
+      - name: Export update bundle for test server to host
+        working-directory: ../updates-e2e
+        run: expo export --public-url https://expo.dev/dummy-url --platform android
+      - name: Get test bundle dist path
+        id: test-bundle-dist-path
+        working-directory: ../updates-e2e/dist
+        run: echo "::set-output name=dir::$(pwd)"
       - name: Run tests
         env:
           TEST_APK_PATH: '${{ steps.test-apk-path.outputs.dir }}/app-release.apk'
+          TEST_BUNDLE_DIST_PATH: '${{ steps.test-bundle-dist-path.outputs.dir }}'
         timeout-minutes: 30
         uses: reactivecircus/android-emulator-runner@v2
         with:

--- a/packages/expo-updates/e2e/__tests__/Updates-e2e-android.test.ts
+++ b/packages/expo-updates/e2e/__tests__/Updates-e2e-android.test.ts
@@ -25,8 +25,8 @@ const ADB_PATH = (function () {
 
 // Keep in sync with the manifest in .github/workflows/updates-e2e.yml
 const RUNTIME_VERSION = '1.0.0';
-const EXPORT_PUBLIC_URL = 'https://expo.dev/dummy-url';
-const BUNDLE_DIST_PATH = process.env.TEST_BUNDLE_DIST_PATH;
+const EXPORT_PUBLIC_URL = 'https://u.expo.dev/dummy-url';
+const UPDATE_DIST_PATH = process.env.TEST_UPDATE_DIST_PATH;
 let bundlePath: string | null = null;
 
 const PACKAGE_NAME = 'dev.expo.updatese2e';
@@ -55,9 +55,9 @@ async function stopApplication(packageName: string) {
 
 function findBundlePath(): string {
   if (!bundlePath) {
-    const androidClassicManifest = require(path.join(BUNDLE_DIST_PATH, 'android-index.json'));
+    const androidClassicManifest = require(path.join(UPDATE_DIST_PATH, 'android-index.json'));
     const { bundleUrl }: { bundleUrl: string } = androidClassicManifest;
-    bundlePath = path.join(BUNDLE_DIST_PATH, bundleUrl.replace(EXPORT_PUBLIC_URL, ''));
+    bundlePath = path.join(UPDATE_DIST_PATH, bundleUrl.replace(EXPORT_PUBLIC_URL, ''));
   }
   return bundlePath;
 }
@@ -119,11 +119,11 @@ test('downloads and runs update, and updates current-update-id header', async ()
   const hash = await copyBundleToStaticFolder('bundle1.js', 'test-update-1');
   const manifest = {
     id: uuid(),
-    createdAt: new Date().getTime(),
+    createdAt: new Date().toISOString(),
     runtimeVersion: RUNTIME_VERSION,
     launchAsset: {
       hash,
-      key: '801599597d77b3522bf40c7021eb0313',
+      key: 'test-update-1-key',
       contentType: 'application/javascript',
       url: `http://${SERVER_HOST}:${SERVER_PORT}/static/bundle1.js`,
     },

--- a/packages/expo-updates/e2e/__tests__/Updates-e2e-android.test.ts
+++ b/packages/expo-updates/e2e/__tests__/Updates-e2e-android.test.ts
@@ -1,8 +1,13 @@
 import spawnAsync from '@expo/spawn-async';
+import crypto from 'crypto';
+import fs from 'fs/promises';
 import path from 'path';
+import { setTimeout } from 'timers/promises';
+import uuid from 'uuid/v4';
 
 import * as Server from './utils/server';
 
+const SERVER_HOST = '10.0.2.2';
 const SERVER_PORT = parseInt(process.env.UPDATES_PORT, 10);
 const APK_PATH = process.env.TEST_APK_PATH;
 const ADB_PATH = (function () {
@@ -18,9 +23,16 @@ const ADB_PATH = (function () {
   return 'adb';
 })();
 
+const RUNTIME_VERSION = '1.0.0';
+const EXPORT_PUBLIC_URL = 'https://expo.dev/dummy-url';
+const BUNDLE_DIST_PATH = process.env.TEST_BUNDLE_DIST_PATH;
+let bundlePath: string | null = null;
+
 const PACKAGE_NAME = 'dev.expo.updatese2e';
 const ACTIVITY_NAME = `${PACKAGE_NAME}/${PACKAGE_NAME}.MainActivity`;
 const TIMEOUT_BIAS = process.env.CI ? 10 : 1;
+
+// android utils
 
 async function installAndroidApk(apkPath: string) {
   await spawnAsync(ADB_PATH, ['install', apkPath]);
@@ -37,6 +49,30 @@ async function startActivity(activityName: string) {
 async function stopApplication(packageName: string) {
   await spawnAsync(ADB_PATH, ['shell', 'am', 'force-stop', packageName]);
 }
+
+// general test utils
+
+function findBundlePath(): string {
+  if (!bundlePath) {
+    const androidClassicManifest = require(path.join(BUNDLE_DIST_PATH, 'android-index.json'));
+    const { bundleUrl }: { bundleUrl: string } = androidClassicManifest;
+    bundlePath = path.join(BUNDLE_DIST_PATH, bundleUrl.replace(EXPORT_PUBLIC_URL, ''));
+  }
+  return bundlePath;
+}
+
+async function copyBundleToStaticFolder(filename: string, notifyString?: string): Promise<string> {
+  const staticFolder = path.join(__dirname, '.static');
+  await fs.mkdir(staticFolder, { recursive: true });
+  let bundleString = await fs.readFile(findBundlePath(), 'utf-8');
+  if (notifyString) {
+    bundleString = bundleString.replace('/notify/test', `/notify/${notifyString}`);
+  }
+  await fs.writeFile(path.join(staticFolder, filename), bundleString, 'utf-8');
+  return crypto.createHash('sha256').update(bundleString, 'utf-8').digest('base64url');
+}
+
+// tests
 
 beforeEach(async () => {});
 
@@ -63,7 +99,7 @@ test('starts app, stops, and starts again', async () => {
   expect(response2).toBe('test');
 });
 
-test('initial request includes correct update ID headers', async () => {
+test('initial request includes correct update-id headers', async () => {
   jest.setTimeout(300000 * TIMEOUT_BIAS);
   Server.start(SERVER_PORT);
   await installAndroidApk(APK_PATH);
@@ -75,5 +111,48 @@ test('initial request includes correct update ID headers', async () => {
   expect(request.headers['expo-current-update-id']).toEqual(
     request.headers['expo-embedded-update-id']
   );
+});
+
+test('downloads and runs update, and updates current-update-id header', async () => {
+  jest.setTimeout(300000 * TIMEOUT_BIAS);
+  const hash = await copyBundleToStaticFolder('bundle1.js', 'test-update-1');
+  const manifest = {
+    id: uuid(),
+    createdAt: new Date().getTime(),
+    runtimeVersion: RUNTIME_VERSION,
+    launchAsset: {
+      hash,
+      key: '801599597d77b3522bf40c7021eb0313',
+      contentType: 'application/javascript',
+      url: `http://${SERVER_HOST}:${SERVER_PORT}/static/bundle1.js`,
+    },
+    assets: [],
+    metadata: {},
+    extra: {},
+  };
+
+  Server.start(SERVER_PORT);
+  Server.serveManifest(manifest, { 'expo-protocol-version': '0' });
+  await installAndroidApk(APK_PATH);
+  await startActivity(ACTIVITY_NAME);
+  const firstRequest = await Server.waitForUpdateRequest(10000 * TIMEOUT_BIAS);
+  const response = await Server.waitForResponse(10000 * TIMEOUT_BIAS);
+  expect(response).toBe('test');
+
+  // give the app time to load the new update in the background
+  await setTimeout(2000 * TIMEOUT_BIAS);
+
+  // restart the app so it will launch the new update
   await stopApplication(PACKAGE_NAME);
+  await startActivity(ACTIVITY_NAME);
+  const secondRequest = await Server.waitForUpdateRequest(10000 * TIMEOUT_BIAS);
+  const updatedResponse = await Server.waitForResponse(10000 * TIMEOUT_BIAS);
+  expect(updatedResponse).toBe('test-update-1');
+
+  expect(secondRequest.headers['expo-embedded-update-id']).toBeDefined();
+  expect(secondRequest.headers['expo-embedded-update-id']).toEqual(
+    firstRequest.headers['expo-embedded-update-id']
+  );
+  expect(secondRequest.headers['expo-current-update-id']).toBeDefined();
+  expect(secondRequest.headers['expo-current-update-id']).toEqual(manifest.id);
 });

--- a/packages/expo-updates/e2e/__tests__/Updates-e2e-android.test.ts
+++ b/packages/expo-updates/e2e/__tests__/Updates-e2e-android.test.ts
@@ -54,9 +54,26 @@ test('starts app, stops, and starts again', async () => {
   expect(response).toBe('test');
   await stopApplication(PACKAGE_NAME);
 
-  await expect(Server.waitForResponse(5000 * TIMEOUT_BIAS)).rejects.toThrow('Timed out waiting for response');
+  await expect(Server.waitForResponse(5000 * TIMEOUT_BIAS)).rejects.toThrow(
+    'Timed out waiting for response'
+  );
 
   await startActivity(ACTIVITY_NAME);
   const response2 = await Server.waitForResponse(10000 * TIMEOUT_BIAS);
   expect(response2).toBe('test');
+});
+
+test('initial request includes correct update ID headers', async () => {
+  jest.setTimeout(300000 * TIMEOUT_BIAS);
+  Server.start(SERVER_PORT);
+  await installAndroidApk(APK_PATH);
+  await startActivity(ACTIVITY_NAME);
+  const request = await Server.waitForUpdateRequest(10000 * TIMEOUT_BIAS);
+  expect(request.headers['expo-embedded-update-id']).toBeDefined();
+  expect(request.headers['expo-current-update-id']).toBeDefined();
+  // before any updates, the current update ID and embedded update ID should be the same
+  expect(request.headers['expo-current-update-id']).toEqual(
+    request.headers['expo-embedded-update-id']
+  );
+  await stopApplication(PACKAGE_NAME);
 });

--- a/packages/expo-updates/e2e/__tests__/Updates-e2e-android.test.ts
+++ b/packages/expo-updates/e2e/__tests__/Updates-e2e-android.test.ts
@@ -23,6 +23,7 @@ const ADB_PATH = (function () {
   return 'adb';
 })();
 
+// Keep in sync with the manifest in .github/workflows/updates-e2e.yml
 const RUNTIME_VERSION = '1.0.0';
 const EXPORT_PUBLIC_URL = 'https://expo.dev/dummy-url';
 const BUNDLE_DIST_PATH = process.env.TEST_BUNDLE_DIST_PATH;

--- a/packages/expo-updates/e2e/__tests__/utils/server.ts
+++ b/packages/expo-updates/e2e/__tests__/utils/server.ts
@@ -4,13 +4,6 @@ import { setTimeout } from 'timers/promises';
 const app: any = express();
 let server: any;
 
-let notifyString: string | null = null;
-app.get('/notify/:string', (req: any, res: any) => {
-  notifyString = req.params.string;
-  res.set('Cache-Control', 'no-store');
-  res.send('Received request');
-})
-
 export function start(port: number) {
   if (!server) {
     server = app.listen(port);
@@ -22,19 +15,49 @@ export function stop() {
     server.close();
     server = null;
   }
+  notifyString = null;
+  updateRequest = null;
 }
 
+let notifyString: string | null = null;
+app.get('/notify/:string', (req: any, res: any) => {
+  notifyString = req.params.string;
+  res.set('Cache-Control', 'no-store');
+  res.send('Received request');
+});
+
 export async function waitForResponse(timeout: number) {
-  const finishTime = new Date().getTime() + timeout
+  const finishTime = new Date().getTime() + timeout;
   while (!notifyString) {
     const currentTime = new Date().getTime();
     if (currentTime >= finishTime) {
-      throw new Error('Timed out waiting for response')
+      throw new Error('Timed out waiting for response');
     }
     await setTimeout(50);
   }
-  
+
   const response = notifyString;
   notifyString = null;
   return response;
+}
+
+let updateRequest: any = null;
+app.get('/update', (req: any, res: any) => {
+  updateRequest = req;
+  res.send('No update available');
+});
+
+export async function waitForUpdateRequest(timeout: number) {
+  const finishTime = new Date().getTime() + timeout;
+  while (!updateRequest) {
+    const currentTime = new Date().getTime();
+    if (currentTime >= finishTime) {
+      throw new Error('Timed out waiting for update request');
+    }
+    await setTimeout(50);
+  }
+
+  const request = updateRequest;
+  updateRequest = null;
+  return request;
 }

--- a/packages/expo-updates/e2e/__tests__/utils/server.ts
+++ b/packages/expo-updates/e2e/__tests__/utils/server.ts
@@ -60,13 +60,13 @@ app.get('/update', (req: any, res: any) => {
     }
     res.json(manifestToServe);
   } else {
-    res.send('No update available');
+    res.status(404).send('No update available');
   }
 });
 
-export function serveManifest(manifest: any, headers?: any) {
+export function serveManifest(manifest: any, headers: any = null) {
   manifestToServe = manifest;
-  manifestHeadersToServe = headers ?? null;
+  manifestHeadersToServe = headers;
 }
 
 export async function waitForUpdateRequest(timeout: number) {


### PR DESCRIPTION
# Why

https://github.com/expo/expo/pull/17033#pullrequestreview-943793902

# How

Extend the e2e test runner to be able to host updates for the test client to load. This required:
- adding more config to the test app.config.json
- adding a new step to export a bundle, which the test runner can then modify & serve (this prevents us from having to commit and maintain a prebuilt bundle as a fixture)
- extending the test server to be able to host manifests and bundles (controlled by the test runner)

Finally, add two tests -- one which verifies the initial embedded-update-id and current-update-id headers are correct, and another which tests loading and running an update and that the current-update-id header updates correctly after this.

# Test Plan

Tests pass locally and should pass on CI as well. As a bonus, these tests caught the issue fixed in #17152! 🙂 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
