### PR TITLE
[github] Add timeout to the `Code Review` workflow

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   code_review:
     runs-on: ubuntu-20.04
+    timeout-minutes: 30
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
# Why

Add a timeout to the `Code Review` workflow to avoid situations like this: https://github.com/expo/expo/actions/runs/2201188900.