### PR TITLE
[doc] Add link to "Internal Distribution" doc

### DIFF
--- a/docs/pages/development/getting-started.md
+++ b/docs/pages/development/getting-started.md
@@ -48,7 +48,7 @@ Once you have registered all of the iOS devices you would like to develop on, yo
 
 </Tabs>
 
-and installing the resulting build on your device.
+and [installing the resulting build on your device](/build/internal-distribution.md).
 
 
 ## Developing your app


### PR DESCRIPTION
Closes #17073

# Why
Because documentation mentions to install the app in the device, but doesn't explain how to do it.

# Checklist
- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).