### PR TITLE
[document-picker] Update to use codesigning variables in entitlements

### DIFF
--- a/packages/expo-document-picker/CHANGELOG.md
+++ b/packages/expo-document-picker/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- [plugin] Update to use codesigning variables in entitlements.
+- [plugin] Update to use codesigning variables in entitlements. ([#17158](https://github.com/expo/expo/pull/17158) by [@EvanBacon](https://github.com/EvanBacon))
 
 ## 10.2.0 — 2022-04-18
 

--- a/packages/expo-document-picker/CHANGELOG.md
+++ b/packages/expo-document-picker/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- [plugin] Update to use codesigning variables in entitlements.
+
 ## 10.2.0 — 2022-04-18
 
 ### 💡 Others

--- a/packages/expo-document-picker/README.md
+++ b/packages/expo-document-picker/README.md
@@ -31,7 +31,7 @@ No additional set up necessary.
 
 ### Plugin
 
-In order to enable Apple iCloud storage in managed EAS builds, you'll need to define the `appleTeamId` property in the config plugin:
+You can change the `com.apple.developer.icloud-container-environment` entitlement using the `iCloudContainerEnvironment` property.
 
 `app.json`
 
@@ -41,18 +41,11 @@ In order to enable Apple iCloud storage in managed EAS builds, you'll need to de
     "usesIcloudStorage": true,
     "bundleIdentifier": "com.yourname.yourapp"
   },
-  "plugins": [
-    [
-      "expo-document-picker",
-      {
-        "appleTeamId": "YOUR_TEAM_ID"
-      }
-    ]
-  ]
+  "plugins": ["expo-document-picker"]
 }
 ```
 
-> Running `expo eject` will generate a the native project locally with the applied changes in your iOS Entitlements file.
+> Running `expo prebuild` will generate a the [native project locally](https://docs.expo.io/workflow/customizing/) with the applied changes in your iOS Entitlements file.
 
 # Contributing
 

--- a/packages/expo-document-picker/plugin/build/withDocumentPicker.d.ts
+++ b/packages/expo-document-picker/plugin/build/withDocumentPicker.d.ts
@@ -1,4 +1,2 @@
-import { ConfigPlugin } from '@expo/config-plugins';
-import { IosProps } from './withDocumentPickerIOS';
-declare const _default: ConfigPlugin<void | IosProps>;
+declare const _default: import("@expo/config-plugins").ConfigPlugin<import("./withDocumentPickerIOS").IosProps>;
 export default _default;

--- a/packages/expo-document-picker/plugin/build/withDocumentPicker.js
+++ b/packages/expo-document-picker/plugin/build/withDocumentPicker.js
@@ -3,8 +3,4 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const config_plugins_1 = require("@expo/config-plugins");
 const withDocumentPickerIOS_1 = require("./withDocumentPickerIOS");
 const pkg = require('expo-document-picker/package.json');
-const withDocumentPicker = (config, { appleTeamId = process.env.EXPO_APPLE_TEAM_ID, iCloudContainerEnvironment } = {}) => {
-    config = (0, withDocumentPickerIOS_1.withDocumentPickerIOS)(config, { appleTeamId, iCloudContainerEnvironment });
-    return config;
-};
-exports.default = (0, config_plugins_1.createRunOncePlugin)(withDocumentPicker, pkg.name, pkg.version);
+exports.default = (0, config_plugins_1.createRunOncePlugin)(withDocumentPickerIOS_1.withDocumentPickerIOS, pkg.name, pkg.version);

--- a/packages/expo-document-picker/plugin/build/withDocumentPickerIOS.d.ts
+++ b/packages/expo-document-picker/plugin/build/withDocumentPickerIOS.d.ts
@@ -1,7 +1,6 @@
 import { ConfigPlugin } from '@expo/config-plugins';
 import { ExpoConfig } from '@expo/config-types';
 export declare type IosProps = {
-    appleTeamId?: string;
     /**
      * Sets the `com.apple.developer.icloud-container-environment` entitlement which is read by EAS CLI to set
      * the `iCloudContainerEnvironment` in the `xcodebuild` `exportOptionsPlist`.
@@ -11,4 +10,4 @@ export declare type IosProps = {
     iCloudContainerEnvironment?: 'Development' | 'Production';
 };
 export declare const withDocumentPickerIOS: ConfigPlugin<IosProps>;
-export declare function setICloudEntitlements(config: Pick<ExpoConfig, 'ios'>, { appleTeamId, iCloudContainerEnvironment }: IosProps, { 'com.apple.developer.icloud-container-environment': _env, ...entitlements }: Record<string, any>): Record<string, any>;
+export declare function setICloudEntitlements(config: Pick<ExpoConfig, 'ios'>, { iCloudContainerEnvironment }: IosProps, { 'com.apple.developer.icloud-container-environment': _env, ...entitlements }: Record<string, any>): Record<string, any>;

--- a/packages/expo-document-picker/plugin/build/withDocumentPickerIOS.js
+++ b/packages/expo-document-picker/plugin/build/withDocumentPickerIOS.js
@@ -2,7 +2,7 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.setICloudEntitlements = exports.withDocumentPickerIOS = void 0;
 const config_plugins_1 = require("@expo/config-plugins");
-const withDocumentPickerIOS = (config, { iCloudContainerEnvironment }) => {
+const withDocumentPickerIOS = (config, { iCloudContainerEnvironment } = {}) => {
     return (0, config_plugins_1.withEntitlementsPlist)(config, (config) => {
         config.modResults = setICloudEntitlements(config, { iCloudContainerEnvironment }, config.modResults);
         return config;
@@ -16,13 +16,12 @@ function setICloudEntitlements(config, { iCloudContainerEnvironment }, { 'com.ap
         // https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_icloud-container-environment
         entitlements['com.apple.developer.icloud-container-environment'] = iCloudContainerEnvironment;
         entitlements['com.apple.developer.icloud-container-identifiers'] = [
-            'iCloud.$(CFBundleIdentifier)',
+            `iCloud.${config.ios.bundleIdentifier}`,
         ];
         entitlements['com.apple.developer.ubiquity-container-identifiers'] = [
-            'iCloud.$(CFBundleIdentifier)',
+            `iCloud.${config.ios.bundleIdentifier}`,
         ];
-        entitlements['com.apple.developer.ubiquity-kvstore-identifier'] =
-            '$(TeamIdentifierPrefix)$(CFBundleIdentifier)';
+        entitlements['com.apple.developer.ubiquity-kvstore-identifier'] = `$(TeamIdentifierPrefix)${config.ios.bundleIdentifier}`;
         entitlements['com.apple.developer.icloud-services'] = ['CloudDocuments'];
     }
     return entitlements;

--- a/packages/expo-document-picker/plugin/build/withDocumentPickerIOS.js
+++ b/packages/expo-document-picker/plugin/build/withDocumentPickerIOS.js
@@ -2,32 +2,27 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.setICloudEntitlements = exports.withDocumentPickerIOS = void 0;
 const config_plugins_1 = require("@expo/config-plugins");
-const withDocumentPickerIOS = (config, { appleTeamId, iCloudContainerEnvironment }) => {
+const withDocumentPickerIOS = (config, { iCloudContainerEnvironment }) => {
     return (0, config_plugins_1.withEntitlementsPlist)(config, (config) => {
-        if (appleTeamId) {
-            config.modResults = setICloudEntitlements(config, { appleTeamId, iCloudContainerEnvironment }, config.modResults);
-        }
-        else {
-            config_plugins_1.WarningAggregator.addWarningIOS('expo-document-picker', 'Cannot configure iOS entitlements because neither the appleTeamId property, nor the environment variable EXPO_APPLE_TEAM_ID were defined.');
-        }
+        config.modResults = setICloudEntitlements(config, { iCloudContainerEnvironment }, config.modResults);
         return config;
     });
 };
 exports.withDocumentPickerIOS = withDocumentPickerIOS;
-function setICloudEntitlements(config, { appleTeamId, iCloudContainerEnvironment }, { 'com.apple.developer.icloud-container-environment': _env, ...entitlements }) {
+function setICloudEntitlements(config, { iCloudContainerEnvironment }, { 'com.apple.developer.icloud-container-environment': _env, ...entitlements }) {
     var _a;
     if ((_a = config.ios) === null || _a === void 0 ? void 0 : _a.usesIcloudStorage) {
         // Used for AdHoc iOS builds: https://github.com/expo/eas-cli/issues/693
         // https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_icloud-container-environment
         entitlements['com.apple.developer.icloud-container-environment'] = iCloudContainerEnvironment;
         entitlements['com.apple.developer.icloud-container-identifiers'] = [
-            'iCloud.' + config.ios.bundleIdentifier,
+            'iCloud.$(CFBundleIdentifier)',
         ];
         entitlements['com.apple.developer.ubiquity-container-identifiers'] = [
-            'iCloud.' + config.ios.bundleIdentifier,
+            'iCloud.$(CFBundleIdentifier)',
         ];
         entitlements['com.apple.developer.ubiquity-kvstore-identifier'] =
-            appleTeamId + '.' + config.ios.bundleIdentifier;
+            '$(TeamIdentifierPrefix)$(CFBundleIdentifier)';
         entitlements['com.apple.developer.icloud-services'] = ['CloudDocuments'];
     }
     return entitlements;

--- a/packages/expo-document-picker/plugin/src/__tests__/withDocumentPickerIOS-test.ts
+++ b/packages/expo-document-picker/plugin/src/__tests__/withDocumentPickerIOS-test.ts
@@ -2,21 +2,24 @@ import { setICloudEntitlements } from '../withDocumentPickerIOS';
 
 describe(setICloudEntitlements, () => {
   it(`skips setting the iCloud entitlements if the flag isn't enabled`, () => {
-    expect(setICloudEntitlements({ ios: {} }, { appleTeamId: 'X1X2X3X4X' }, {})).toStrictEqual({});
+    expect(
+      setICloudEntitlements({ ios: {} }, { iCloudContainerEnvironment: 'Production' }, {})
+    ).toStrictEqual({});
   });
   it(`sets the iCloud entitlements`, () => {
     expect(
       setICloudEntitlements(
         { ios: { usesIcloudStorage: true, bundleIdentifier: 'com.bacon.foobar' } },
-        { appleTeamId: 'X1X2X3X4X', iCloudContainerEnvironment: 'Production' },
+        { iCloudContainerEnvironment: 'Production' },
         {}
       )
     ).toStrictEqual({
       'com.apple.developer.icloud-container-environment': 'Production',
-      'com.apple.developer.icloud-container-identifiers': ['iCloud.com.bacon.foobar'],
+      'com.apple.developer.icloud-container-identifiers': ['iCloud.$(CFBundleIdentifier)'],
       'com.apple.developer.icloud-services': ['CloudDocuments'],
-      'com.apple.developer.ubiquity-container-identifiers': ['iCloud.com.bacon.foobar'],
-      'com.apple.developer.ubiquity-kvstore-identifier': 'X1X2X3X4X.com.bacon.foobar',
+      'com.apple.developer.ubiquity-container-identifiers': ['iCloud.$(CFBundleIdentifier)'],
+      'com.apple.developer.ubiquity-kvstore-identifier':
+        '$(TeamIdentifierPrefix)$(CFBundleIdentifier)',
     });
   });
 });

--- a/packages/expo-document-picker/plugin/src/__tests__/withDocumentPickerIOS-test.ts
+++ b/packages/expo-document-picker/plugin/src/__tests__/withDocumentPickerIOS-test.ts
@@ -15,11 +15,10 @@ describe(setICloudEntitlements, () => {
       )
     ).toStrictEqual({
       'com.apple.developer.icloud-container-environment': 'Production',
-      'com.apple.developer.icloud-container-identifiers': ['iCloud.$(CFBundleIdentifier)'],
+      'com.apple.developer.icloud-container-identifiers': ['iCloud.com.bacon.foobar'],
       'com.apple.developer.icloud-services': ['CloudDocuments'],
-      'com.apple.developer.ubiquity-container-identifiers': ['iCloud.$(CFBundleIdentifier)'],
-      'com.apple.developer.ubiquity-kvstore-identifier':
-        '$(TeamIdentifierPrefix)$(CFBundleIdentifier)',
+      'com.apple.developer.ubiquity-container-identifiers': ['iCloud.com.bacon.foobar'],
+      'com.apple.developer.ubiquity-kvstore-identifier': '$(TeamIdentifierPrefix)com.bacon.foobar',
     });
   });
 });

--- a/packages/expo-document-picker/plugin/src/withDocumentPicker.ts
+++ b/packages/expo-document-picker/plugin/src/withDocumentPicker.ts
@@ -1,15 +1,7 @@
-import { ConfigPlugin, createRunOncePlugin } from '@expo/config-plugins';
+import { createRunOncePlugin } from '@expo/config-plugins';
 
-import { withDocumentPickerIOS, IosProps } from './withDocumentPickerIOS';
+import { withDocumentPickerIOS } from './withDocumentPickerIOS';
 
 const pkg = require('expo-document-picker/package.json');
 
-const withDocumentPicker: ConfigPlugin<IosProps | void> = (
-  config,
-  { appleTeamId = process.env.EXPO_APPLE_TEAM_ID, iCloudContainerEnvironment } = {}
-) => {
-  config = withDocumentPickerIOS(config, { appleTeamId, iCloudContainerEnvironment });
-  return config;
-};
-
-export default createRunOncePlugin(withDocumentPicker, pkg.name, pkg.version);
+export default createRunOncePlugin(withDocumentPickerIOS, pkg.name, pkg.version);

--- a/packages/expo-document-picker/plugin/src/withDocumentPickerIOS.ts
+++ b/packages/expo-document-picker/plugin/src/withDocumentPickerIOS.ts
@@ -1,8 +1,7 @@
-import { ConfigPlugin, WarningAggregator, withEntitlementsPlist } from '@expo/config-plugins';
+import { ConfigPlugin, withEntitlementsPlist } from '@expo/config-plugins';
 import { ExpoConfig } from '@expo/config-types';
 
 export type IosProps = {
-  appleTeamId?: string;
   /**
    * Sets the `com.apple.developer.icloud-container-environment` entitlement which is read by EAS CLI to set
    * the `iCloudContainerEnvironment` in the `xcodebuild` `exportOptionsPlist`.
@@ -14,28 +13,21 @@ export type IosProps = {
 
 export const withDocumentPickerIOS: ConfigPlugin<IosProps> = (
   config,
-  { appleTeamId, iCloudContainerEnvironment }
+  { iCloudContainerEnvironment }
 ) => {
   return withEntitlementsPlist(config, (config) => {
-    if (appleTeamId) {
-      config.modResults = setICloudEntitlements(
-        config,
-        { appleTeamId, iCloudContainerEnvironment },
-        config.modResults
-      );
-    } else {
-      WarningAggregator.addWarningIOS(
-        'expo-document-picker',
-        'Cannot configure iOS entitlements because neither the appleTeamId property, nor the environment variable EXPO_APPLE_TEAM_ID were defined.'
-      );
-    }
+    config.modResults = setICloudEntitlements(
+      config,
+      { iCloudContainerEnvironment },
+      config.modResults
+    );
     return config;
   });
 };
 
 export function setICloudEntitlements(
   config: Pick<ExpoConfig, 'ios'>,
-  { appleTeamId, iCloudContainerEnvironment }: IosProps,
+  { iCloudContainerEnvironment }: IosProps,
   { 'com.apple.developer.icloud-container-environment': _env, ...entitlements }: Record<string, any>
 ): Record<string, any> {
   if (config.ios?.usesIcloudStorage) {
@@ -44,13 +36,14 @@ export function setICloudEntitlements(
     entitlements['com.apple.developer.icloud-container-environment'] = iCloudContainerEnvironment;
 
     entitlements['com.apple.developer.icloud-container-identifiers'] = [
-      'iCloud.' + config.ios.bundleIdentifier,
+      'iCloud.$(CFBundleIdentifier)',
     ];
     entitlements['com.apple.developer.ubiquity-container-identifiers'] = [
-      'iCloud.' + config.ios.bundleIdentifier,
+      'iCloud.$(CFBundleIdentifier)',
     ];
     entitlements['com.apple.developer.ubiquity-kvstore-identifier'] =
-      appleTeamId + '.' + config.ios.bundleIdentifier;
+      '$(TeamIdentifierPrefix)$(CFBundleIdentifier)';
+
     entitlements['com.apple.developer.icloud-services'] = ['CloudDocuments'];
   }
   return entitlements;

--- a/packages/expo-document-picker/plugin/src/withDocumentPickerIOS.ts
+++ b/packages/expo-document-picker/plugin/src/withDocumentPickerIOS.ts
@@ -13,7 +13,7 @@ export type IosProps = {
 
 export const withDocumentPickerIOS: ConfigPlugin<IosProps> = (
   config,
-  { iCloudContainerEnvironment }
+  { iCloudContainerEnvironment } = {}
 ) => {
   return withEntitlementsPlist(config, (config) => {
     config.modResults = setICloudEntitlements(
@@ -36,13 +36,14 @@ export function setICloudEntitlements(
     entitlements['com.apple.developer.icloud-container-environment'] = iCloudContainerEnvironment;
 
     entitlements['com.apple.developer.icloud-container-identifiers'] = [
-      'iCloud.$(CFBundleIdentifier)',
+      `iCloud.${config.ios.bundleIdentifier}`,
     ];
     entitlements['com.apple.developer.ubiquity-container-identifiers'] = [
-      'iCloud.$(CFBundleIdentifier)',
+      `iCloud.${config.ios.bundleIdentifier}`,
     ];
-    entitlements['com.apple.developer.ubiquity-kvstore-identifier'] =
-      '$(TeamIdentifierPrefix)$(CFBundleIdentifier)';
+    entitlements[
+      'com.apple.developer.ubiquity-kvstore-identifier'
+    ] = `$(TeamIdentifierPrefix)${config.ios.bundleIdentifier}`;
 
     entitlements['com.apple.developer.icloud-services'] = ['CloudDocuments'];
   }


### PR DESCRIPTION
# Why

Utilize the codesigning variables in the entitlements file to dynamically link credentials at build time. [Discovered here](AppIdentifierPrefix is different in main app and extension - https://developer.apple.com/forums/thread/118773?answerId=674983022#674983022). I searched around github and found that others have used this same technique in their iOS projects. 

# How

Utilize variables `$(TeamIdentifierPrefix)$(CFBundleIdentifier)`
- Change `process.env.EXPO_APPLE_TEAM_ID` -> `$(TeamIdentifierPrefix)` -(Xcode converts to)-> `XXXXXX.`
- ~~Change `config.ios.bundleIdentifier` -> `$(CFBundleIdentifier)` -(Xcode converts to)-> `foo.bar.app`~~ This one didn't work for capability identifier registration.


<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- [x] [EAS Build](https://expo.dev/accounts/bacon/projects/yolo87/builds/febf55c2-7340-425b-ae40-db160934e3e2)
- [x] [EAS Submit](https://expo.dev/accounts/bacon/projects/yolo87/submissions/169ebfa8-280c-4ec6-aea1-ad4c5b4078c2)


Resolved entitlements use the correct team ID

<img width="951" alt="Screen Shot 2022-04-23 at 2 12 03 PM" src="https://user-images.githubusercontent.com/9664363/164943046-55c8525b-286e-49fa-8607-c4e5a2ec2227.png">



# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
