### PR TITLE
Update and backport react-native-reanimated to 2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Package-specific changes not released in any SDK will be added here just before 
 - Updated `@react-native-community/react-native-datetimepicker` from `4.0.0` to `6.1.2` ([#16951](https://github.com/expo/expo/pull/16951) by [@brentvatne](https://github.com/brentvatne))
 - Updated `react-native-safe-area-context` from `3.3.2` to `4.2.4`. ([#16939](https://github.com/expo/expo/pull/16939) by [@kudo](https://github.com/kudo))
 - Updated `@stripe/stripe-react-native` from `0.2.3` to `0.6.0`. ([#16938](https://github.com/expo/expo/pull/16938) by [@kudo](https://github.com/kudo))
-- Updated `react-native-reanimated` from `2.4.1` to `2.8.0`. ([#16956](https://github.com/expo/expo/pull/16956) by [@tsapeta](https://github.com/tsapeta))
+- Updated `react-native-reanimated` from `2.4.1` to `2.8.0`. ([#16956](https://github.com/expo/expo/pull/16956), [#17159](https://github.com/expo/expo/pull/17159) by [@tsapeta](https://github.com/tsapeta))
 - Updated `react-native-maps` from `0.29.4` to `0.30.1`. ([#16944](https://github.com/expo/expo/pull/16944) by [@bycedric](https://github.com/bycedric))
 
 ### 🛠 Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Package-specific changes not released in any SDK will be added here just before 
 - Updated `@react-native-community/react-native-datetimepicker` from `4.0.0` to `6.1.2` ([#16951](https://github.com/expo/expo/pull/16951) by [@brentvatne](https://github.com/brentvatne))
 - Updated `react-native-safe-area-context` from `3.3.2` to `4.2.4`. ([#16939](https://github.com/expo/expo/pull/16939) by [@kudo](https://github.com/kudo))
 - Updated `@stripe/stripe-react-native` from `0.2.3` to `0.6.0`. ([#16938](https://github.com/expo/expo/pull/16938) by [@kudo](https://github.com/kudo))
-- Updated `react-native-reanimated` from `2.4.1` to `2.7.0`. ([#16956](https://github.com/expo/expo/pull/16956) by [@tsapeta](https://github.com/tsapeta))
+- Updated `react-native-reanimated` from `2.4.1` to `2.8.0`. ([#16956](https://github.com/expo/expo/pull/16956) by [@tsapeta](https://github.com/tsapeta))
 - Updated `react-native-maps` from `0.29.4` to `0.30.1`. ([#16944](https://github.com/expo/expo/pull/16944) by [@bycedric](https://github.com/bycedric))
 
 ### 🛠 Breaking changes

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -798,7 +798,7 @@ PODS:
     - React-Core
   - RNGestureHandler (2.2.0):
     - React-Core
-  - RNReanimated (2.7.0):
+  - RNReanimated (2.8.0):
     - DoubleConversion
     - FBLazyVector
     - FBReactNativeSpec
@@ -1491,7 +1491,7 @@ SPEC CHECKSUMS:
   RNCPicker: 6d5d64e7b90c240c779ee0938ec433c11e2dd758
   RNDateTimePicker: 6f1f0b4cf7c71b6e2aea7a3aa62969111084bbd1
   RNGestureHandler: bf572f552ea324acd5b5464b8d30755b2d8c1de6
-  RNReanimated: e42de406edd11350af29016cf6802ef16ee364d0
+  RNReanimated: 64573e25e078ae6bec03b891586d50b9ec284393
   RNScreens: 4d83613b50b74ed277026375dc0810893b0c347f
   RNSharedElement: eb7d506733952d58634f34c82ec17e82f557e377
   RNSVG: 302bfc9905bd8122f08966dc2ce2d07b7b52b9f8

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -113,7 +113,7 @@
     "react-dom": "17.0.2",
     "react-native": "0.68.1",
     "react-native-gesture-handler": "~2.2.0",
-    "react-native-reanimated": "~2.7.0",
+    "react-native-reanimated": "~2.8.0",
     "react-native-safe-area-context": "4.2.4",
     "react-native-screens": "~3.11.1",
     "react-native-shared-element": "0.8.4",

--- a/apps/bare-sandbox/package.json
+++ b/apps/bare-sandbox/package.json
@@ -19,7 +19,7 @@
     "react-dom": "17.0.2",
     "react-native": "0.68.1",
     "react-native-gesture-handler": "~2.2.0",
-    "react-native-reanimated": "~2.7.0",
+    "react-native-reanimated": "~2.8.0",
     "react-native-screens": "~3.11.1",
     "react-native-web": "~0.17.1"
   },

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -152,7 +152,7 @@
     "react-native-maps": "0.30.1",
     "react-native-pager-view": "5.4.15",
     "react-native-paper": "^4.0.1",
-    "react-native-reanimated": "~2.7.0",
+    "react-native-reanimated": "~2.8.0",
     "react-native-redash": "^14.1.1",
     "react-native-safe-area-context": "4.2.4",
     "react-native-safe-area-view": "^0.14.8",

--- a/home/package.json
+++ b/home/package.json
@@ -60,7 +60,7 @@
     "react-native-infinite-scroll-view": "^0.4.5",
     "react-native-maps": "0.30.1",
     "react-native-paper": "^4.0.1",
-    "react-native-reanimated": "~2.7.0",
+    "react-native-reanimated": "~2.8.0",
     "react-native-safe-area-context": "4.2.4",
     "react-native-screens": "~3.11.1",
     "react-redux": "^7.2.0",

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1793,7 +1793,7 @@ PODS:
     - RCT-Folly (= 2021.06.28.00-v2)
   - ABI45_0_0RNGestureHandler (2.2.0):
     - ABI45_0_0React-Core
-  - ABI45_0_0RNReanimated (2.7.0):
+  - ABI45_0_0RNReanimated (2.8.0):
     - ABI45_0_0RCTRequired
     - ABI45_0_0RCTTypeSafety
     - ABI45_0_0React-callinvoker
@@ -2544,7 +2544,7 @@ PODS:
     - ReactCommon/turbomodule/core (= 0.68.1)
   - RNGestureHandler (2.2.0):
     - React-Core
-  - RNReanimated (2.7.0):
+  - RNReanimated (2.8.0):
     - DoubleConversion
     - FBLazyVector
     - FBReactNativeSpec
@@ -4311,7 +4311,7 @@ SPEC CHECKSUMS:
   ABI45_0_0React-runtimeexecutor: 7dd7445730dd195b9bee105bf1570791db1d2141
   ABI45_0_0ReactCommon: a58687f02ac5d9965e41409f609ddc0d9a6fc4e5
   ABI45_0_0RNGestureHandler: c6a3399e797896b51aaafa5ffd9ef3217a965554
-  ABI45_0_0RNReanimated: f2ab5aea994f428c293531550c4b89ad5d0e4288
+  ABI45_0_0RNReanimated: 7dbc4ffd288bfbb8657e5d28d8c633108a4fbc7a
   ABI45_0_0RNScreens: 09474fa5b21fada696fcfda7029ea1de53af363b
   ABI45_0_0stripe-react-native: e1b513432e7250da1ee14983879c3954a5d535f1
   ABI45_0_0UMAppLoader: 9f4f8ab793e254030a3e1986ce2d75b89308168b
@@ -4466,7 +4466,7 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: 7285b499d0339104b2813a1f58ad1ada4adbd6c0
   ReactCommon: bf2888a826ceedf54b99ad1b6182d1bc4a8a3984
   RNGestureHandler: bf572f552ea324acd5b5464b8d30755b2d8c1de6
-  RNReanimated: e42de406edd11350af29016cf6802ef16ee364d0
+  RNReanimated: 64573e25e078ae6bec03b891586d50b9ec284393
   RNScreens: 4d83613b50b74ed277026375dc0810893b0c347f
   Stripe: ee32e594fa4dee4bdf2a8a3039f7fb07a21075dc
   stripe-react-native: bd992665f71c5233d62719c4031351f3f3b769fe

--- a/ios/vendored/sdk45/react-native-reanimated/ABI45_0_0RNReanimated.podspec.json
+++ b/ios/vendored/sdk45/react-native-reanimated/ABI45_0_0RNReanimated.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "ABI45_0_0RNReanimated",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "summary": "More powerful alternative to Animated library for ABI45_0_0React Native.",
   "description": "ABI45_0_0RNReanimated",
   "homepage": "https://github.com/software-mansion/react-native-reanimated",
@@ -14,7 +14,7 @@
   },
   "source": {
     "git": "https://github.com/software-mansion/react-native-reanimated.git",
-    "tag": "2.7.0"
+    "tag": "2.8.0"
   },
   "source_files": [
     "ios/**/*.{mm,h,m}",

--- a/ios/vendored/sdk45/react-native-reanimated/ios/native/NativeProxy.mm
+++ b/ios/vendored/sdk45/react-native-reanimated/ios/native/NativeProxy.mm
@@ -162,8 +162,12 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(
     scrollTo(viewTag, uiManager, x, y, animated);
   };
 
-  id<ABI45_0_0RNGestureHandlerStateManager> gestureHandlerStateManager = [bridge moduleForName:@"ABI45_0_0RNGestureHandlerModule"];
-  auto setGestureStateFunction = [gestureHandlerStateManager](int handlerTag, int newState) {
+  id<ABI45_0_0RNGestureHandlerStateManager> gestureHandlerStateManager = nil;
+  auto setGestureStateFunction = [gestureHandlerStateManager, bridge](int handlerTag, int newState) mutable {
+    if (gestureHandlerStateManager == nil) {
+      gestureHandlerStateManager = [bridge moduleForName:@"ABI45_0_0RNGestureHandlerModule"];
+    }
+
     setGestureState(gestureHandlerStateManager, handlerTag, newState);
   };
 

--- a/ios/vendored/unversioned/react-native-reanimated/RNReanimated.podspec.json
+++ b/ios/vendored/unversioned/react-native-reanimated/RNReanimated.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "RNReanimated",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "summary": "More powerful alternative to Animated library for React Native.",
   "description": "RNReanimated",
   "homepage": "https://github.com/software-mansion/react-native-reanimated",
@@ -14,7 +14,7 @@
   },
   "source": {
     "git": "https://github.com/software-mansion/react-native-reanimated.git",
-    "tag": "2.7.0"
+    "tag": "2.8.0"
   },
   "source_files": [
     "ios/**/*.{mm,h,m}",

--- a/ios/vendored/unversioned/react-native-reanimated/ios/native/NativeProxy.mm
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/native/NativeProxy.mm
@@ -162,8 +162,12 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(
     scrollTo(viewTag, uiManager, x, y, animated);
   };
 
-  id<RNGestureHandlerStateManager> gestureHandlerStateManager = [bridge moduleForName:@"RNGestureHandlerModule"];
-  auto setGestureStateFunction = [gestureHandlerStateManager](int handlerTag, int newState) {
+  id<RNGestureHandlerStateManager> gestureHandlerStateManager = nil;
+  auto setGestureStateFunction = [gestureHandlerStateManager, bridge](int handlerTag, int newState) mutable {
+    if (gestureHandlerStateManager == nil) {
+      gestureHandlerStateManager = [bridge moduleForName:@"RNGestureHandlerModule"];
+    }
+
     setGestureState(gestureHandlerStateManager, handlerTag, newState);
   };
 

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -98,7 +98,7 @@
   "react-native-get-random-values": "~1.7.0",
   "react-native-maps": "0.30.1",
   "react-native-pager-view": "5.4.15",
-  "react-native-reanimated": "~2.7.0",
+  "react-native-reanimated": "~2.8.0",
   "react-native-safe-area-context": "4.2.4",
   "react-native-screens": "~3.11.1",
   "react-native-shared-element": "0.8.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16857,10 +16857,10 @@ react-native-paper@^4.0.1:
     color "^3.1.2"
     react-native-iphone-x-helper "^1.3.1"
 
-react-native-reanimated@~2.7.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-2.7.0.tgz#2cebf9bddaf87a4b364079b40e9099ec0d7ce247"
-  integrity sha512-wPKqOGdC/XAqPZU+fNkpHM9B76QHmYCIeAcOQcOqMV2kS3mbZ4ZMe5veM7pdaMZs3tCnNgCqGPIbmMNQUE0bOw==
+react-native-reanimated@~2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-2.8.0.tgz#93c06ca84d91fb3865110b0857c49a24e316130e"
+  integrity sha512-kJvf/UWLBMaGCs9X66MKq5zdFMgwx8D0nHnolbHR7s8ZnbLdb7TlQ/yuzIXqn/9wABfnwtNRI3CyaP1aHWMmZg==
   dependencies:
     "@babel/plugin-transform-object-assign" "^7.16.7"
     "@babel/preset-typescript" "^7.16.7"


### PR DESCRIPTION
# Why

Reanimated v2.8.0 has been released: https://github.com/software-mansion/react-native-reanimated/releases/tag/2.8.0

# How

- `et update-vendored-module -m react-native-reanimated -c main`
- `et add-sdk -p ios -s 45.0.0 -v react-native-reanimated` to backport changes to SDK45

# Test Plan

- Tested in project templates, the warning about possible deadlocks no longer shows up