### PR TITLE
[expo-structured-headers] Stop prebuilding xcframework

### DIFF
--- a/tools/src/prebuilds/Prebuilder.ts
+++ b/tools/src/prebuilds/Prebuilder.ts
@@ -76,7 +76,7 @@ export const PACKAGES_TO_PREBUILD = [
   'expo-splash-screen',
   // 'expo-sqlite',
   // 'expo-store-review',
-  'expo-structured-headers',
+  // 'expo-structured-headers',
   // 'expo-task-manager',
   // 'expo-updates',
   // 'expo-video-thumbnails',


### PR DESCRIPTION
# Why

When this setting is enabled, an `xcframework` is generated and included in the npm package. This causes the cocoapods install step to not generate an umbrella header for the framework. Without the umbrella header, the code cannot be imported in swift via https://github.com/expo/expo/blob/main/packages/expo-updates/ios/EXUpdates/CodeSigning/EXUpdatesSignatureHeaderInfo.swift#L4.

I may be missing something, or maybe the preferred solution is to have both a xcframework and manual bridging header, but I'm not sure.

Reported at https://exponent-internal.slack.com/archives/C1QLJDKDZ/p1650490945090609.

Closes ENG-4733.

# How

Remove this from xcframework prebuild list. We'll need to republish the package and ensure the most recent version of `expo-updates` depends on this new version.

# Test Plan

Not really sure how to test this since `expo-modules prebuild` doesn't run this prebuilder. Any advice would be appreciated.

The overall test is:
1. Clone https://github.com/ajsmth/dev-client-test
2. yarn
3. cd ios && pod install
4. Manually remove the built xcframework from `node_modules/expo-structured-headers/ios`
5. expo run:ios

(without step 4 it fails. I'm assuming this PR will be the equivalent of step 4)