### PR TITLE
[android] fix Android S PendingIntent mutable flag exception

### DIFF
--- a/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/taskManager/TaskManagerUtils.java
+++ b/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/taskManager/TaskManagerUtils.java
@@ -44,9 +44,7 @@ public class TaskManagerUtils implements TaskManagerUtilsInterface {
 
   @Override
   public PendingIntent createTaskIntent(Context context, TaskInterface task) {
-    // We're defaulting to the behaviour prior API 31 (mutable) even though Android recommends immutability
-    int mutableFlag = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? PendingIntent.FLAG_MUTABLE : 0;
-    return createTaskIntent(context, task, PendingIntent.FLAG_UPDATE_CURRENT | mutableFlag);
+    return createTaskIntent(context, task, PendingIntent.FLAG_UPDATE_CURRENT);
   }
 
   @Override
@@ -188,7 +186,9 @@ public class TaskManagerUtils implements TaskManagerUtilsInterface {
 
     intent.setData(dataUri);
 
-    return PendingIntent.getBroadcast(context, PENDING_INTENT_REQUEST_CODE, intent, flags);
+    // We're defaulting to the behaviour prior API 31 (mutable) even though Android recommends immutability
+    int mutableFlag = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? PendingIntent.FLAG_MUTABLE : 0;
+    return PendingIntent.getBroadcast(context, PENDING_INTENT_REQUEST_CODE, intent, flags | mutableFlag);
   }
 
   private PendingIntent createTaskIntent(Context context, TaskInterface task, int flags) {

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/taskManager/TaskManagerUtils.java
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/taskManager/TaskManagerUtils.java
@@ -44,9 +44,7 @@ public class TaskManagerUtils implements TaskManagerUtilsInterface {
 
   @Override
   public PendingIntent createTaskIntent(Context context, TaskInterface task) {
-    // We're defaulting to the behaviour prior API 31 (mutable) even though Android recommends immutability
-    int mutableFlag = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? PendingIntent.FLAG_MUTABLE : 0;
-    return createTaskIntent(context, task, PendingIntent.FLAG_UPDATE_CURRENT | mutableFlag);
+    return createTaskIntent(context, task, PendingIntent.FLAG_UPDATE_CURRENT);
   }
 
   @Override
@@ -188,7 +186,9 @@ public class TaskManagerUtils implements TaskManagerUtilsInterface {
 
     intent.setData(dataUri);
 
-    return PendingIntent.getBroadcast(context, PENDING_INTENT_REQUEST_CODE, intent, flags);
+    // We're defaulting to the behaviour prior API 31 (mutable) even though Android recommends immutability
+    int mutableFlag = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? PendingIntent.FLAG_MUTABLE : 0;
+    return PendingIntent.getBroadcast(context, PENDING_INTENT_REQUEST_CODE, intent, flags | mutableFlag);
   }
 
   private PendingIntent createTaskIntent(Context context, TaskInterface task, int flags) {

--- a/android/versioned-abis/expoview-abi45_0_0/src/main/java/abi45_0_0/expo/modules/taskManager/TaskManagerUtils.java
+++ b/android/versioned-abis/expoview-abi45_0_0/src/main/java/abi45_0_0/expo/modules/taskManager/TaskManagerUtils.java
@@ -44,9 +44,7 @@ public class TaskManagerUtils implements TaskManagerUtilsInterface {
 
   @Override
   public PendingIntent createTaskIntent(Context context, TaskInterface task) {
-    // We're defaulting to the behaviour prior API 31 (mutable) even though Android recommends immutability
-    int mutableFlag = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? PendingIntent.FLAG_MUTABLE : 0;
-    return createTaskIntent(context, task, PendingIntent.FLAG_UPDATE_CURRENT | mutableFlag);
+    return createTaskIntent(context, task, PendingIntent.FLAG_UPDATE_CURRENT);
   }
 
   @Override
@@ -188,7 +186,9 @@ public class TaskManagerUtils implements TaskManagerUtilsInterface {
 
     intent.setData(dataUri);
 
-    return PendingIntent.getBroadcast(context, PENDING_INTENT_REQUEST_CODE, intent, flags);
+    // We're defaulting to the behaviour prior API 31 (mutable) even though Android recommends immutability
+    int mutableFlag = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? PendingIntent.FLAG_MUTABLE : 0;
+    return PendingIntent.getBroadcast(context, PENDING_INTENT_REQUEST_CODE, intent, flags | mutableFlag);
   }
 
   private PendingIntent createTaskIntent(Context context, TaskInterface task, int flags) {

--- a/packages/expo-task-manager/CHANGELOG.md
+++ b/packages/expo-task-manager/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed another Android 12+ runtime crash caused by `PendingIntent` misconfiguration. ([#17164](https://github.com/expo/expo/pull/17164) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 10.2.0 — 2022-04-18

--- a/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskManagerUtils.java
+++ b/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskManagerUtils.java
@@ -44,9 +44,7 @@ public class TaskManagerUtils implements TaskManagerUtilsInterface {
 
   @Override
   public PendingIntent createTaskIntent(Context context, TaskInterface task) {
-    // We're defaulting to the behaviour prior API 31 (mutable) even though Android recommends immutability
-    int mutableFlag = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? PendingIntent.FLAG_MUTABLE : 0;
-    return createTaskIntent(context, task, PendingIntent.FLAG_UPDATE_CURRENT | mutableFlag);
+    return createTaskIntent(context, task, PendingIntent.FLAG_UPDATE_CURRENT);
   }
 
   @Override
@@ -188,7 +186,9 @@ public class TaskManagerUtils implements TaskManagerUtilsInterface {
 
     intent.setData(dataUri);
 
-    return PendingIntent.getBroadcast(context, PENDING_INTENT_REQUEST_CODE, intent, flags);
+    // We're defaulting to the behaviour prior API 31 (mutable) even though Android recommends immutability
+    int mutableFlag = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? PendingIntent.FLAG_MUTABLE : 0;
+    return PendingIntent.getBroadcast(context, PENDING_INTENT_REQUEST_CODE, intent, flags | mutableFlag);
   }
 
   private PendingIntent createTaskIntent(Context context, TaskInterface task, int flags) {


### PR DESCRIPTION
# Why

an android exception happening from TaskManager:

```
         AndroidRuntime  D  Shutting down VM
                         E  FATAL EXCEPTION: main
                         E  Process: host.exp.exponent, PID: 15838
                         E  java.lang.RuntimeException: Unable to start receiver expo.modules.taskManager.TaskBroadcastReceiver: java.lang.IllegalArgumentException: host.exp.exponent: Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.
                         E  Strongly consider using FLAG_IMMUTABLE, only use FLAG_MUTABLE if some functionality depends on the PendingIntent being mutable, e.g. if it needs to be used with inline replies or bubbles.
                         E      at android.app.ActivityThread.handleReceiver(ActivityThread.java:4384)
                         E      at android.app.ActivityThread.access$1600(ActivityThread.java:256)
                         E      at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2102)
                         E      at android.os.Handler.dispatchMessage(Handler.java:106)
                         E      at android.os.Looper.loopOnce(Looper.java:201)
                         E      at android.os.Looper.loop(Looper.java:288)
                         E      at android.app.ActivityThread.main(ActivityThread.java:7870)
                         E      at java.lang.reflect.Method.invoke(Native Method)
                         E      at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
                         E      at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003)
                         E  Caused by: java.lang.IllegalArgumentException: host.exp.exponent: Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.
                         E  Strongly consider using FLAG_IMMUTABLE, only use FLAG_MUTABLE if some functionality depends on the PendingIntent being mutable, e.g. if it needs to be used with inline replies or bubbles.
                         E      at android.app.PendingIntent.checkFlags(PendingIntent.java:375)
                         E      at android.app.PendingIntent.getBroadcastAsUser(PendingIntent.java:645)
                         E      at android.app.PendingIntent.getBroadcast(PendingIntent.java:632)
                         E      at expo.modules.taskManager.TaskManagerUtils.createTaskIntent(TaskManagerUtils.java:191)
                         E      at expo.modules.taskManager.TaskManagerUtils.cancelTaskIntent(TaskManagerUtils.java:54)
                         E      at expo.modules.taskManager.TaskService.handleIntent(TaskService.java:310)
                         E      at expo.modules.taskManager.TaskBroadcastReceiver.onReceive(TaskBroadcastReceiver.java:15)
                         E      at android.app.ActivityThread.handleReceiver(ActivityThread.java:4375)
                         E      ... 9 more
```

it was partial fixed in #17052, but there's another call path from `TaskManagerUtils.cancelTaskIntent -> TaskManagerUtils.createTaskIntent`

close ENG-4736

# How

- move the `PendingIntent.FLAG_MUTABLE` code to the final shared `createTaskIntent()`
- backport the changes to sdk versioned code

# Test Plan

NCL → Notification → Schedule notification for 10 seconds from now

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
