### PR TITLE
[ios] remove old unused code from EXUpdatesManager

### DIFF
--- a/ios/Exponent/Kernel/AppLoader/EXAppLoader+Updates.h
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoader+Updates.h
@@ -19,16 +19,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, nullable) id<EXUpdatesAppLauncher> appLauncher;
 @property (nonatomic, readonly, assign) BOOL isEmergencyLaunch;
 
-/**
- * Fetch JS bundle without any side effects or interaction with the timer.
- */
-- (void)fetchJSBundleWithManifest:(NSDictionary *)manifest
-                    cacheBehavior:(EXCachedResourceBehavior)cacheBehavior
-                  timeoutInterval:(NSTimeInterval)timeoutInterval
-                         progress:(void (^ _Nullable )(EXLoadingProgress *))progressBlock
-                          success:(void (^)(NSData *))successBlock
-                            error:(void (^)(NSError *))errorBlock;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/Exponent/Kernel/AppLoader/EXAppLoader.m
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoader.m
@@ -432,17 +432,6 @@ NSTimeInterval const kEXJSBundleTimeout = 60 * 5;
   }];
 }
 
-- (void)fetchJSBundleWithManifest:(EXManifestsManifest *)manifest
-                     cacheBehavior:(EXCachedResourceBehavior)cacheBehavior
-                   timeoutInterval:(NSTimeInterval)timeoutInterval
-                          progress:(void (^ _Nullable )(EXLoadingProgress *))progressBlock
-                           success:(void (^)(NSData *))successBlock
-                             error:(void (^)(NSError *))errorBlock
-{
-  RCTAssert(_appFetcher != nil, @"Tried to fetch a JS Bundle before appFetcher was initialized");
-  [_appFetcher fetchJSBundleWithManifest:manifest cacheBehavior:cacheBehavior timeoutInterval:timeoutInterval progress:progressBlock success:successBlock error:errorBlock];
-}
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/Exponent/Kernel/Services/EXUpdatesManager.m
+++ b/ios/Exponent/Kernel/Services/EXUpdatesManager.m
@@ -1,11 +1,9 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 #import "EXAppLoader+Updates.h"
-#import "EXEnvironment.h"
 #import "EXKernel.h"
 #import "EXKernelAppRecord.h"
 #import "EXReactAppManager.h"
-#import "EXScopedModuleRegistry.h"
 #import "EXUpdatesDatabaseManager.h"
 #import "EXUpdatesManager.h"
 
@@ -13,18 +11,11 @@
 #import <EXUpdates/EXUpdatesRemoteAppLoader.h>
 
 #import <React/RCTBridge.h>
-#import <React/RCTUtils.h>
 
 NSString * const EXUpdatesEventName = @"Expo.nativeUpdatesEvent";
 NSString * const EXUpdatesErrorEventType = @"error";
 NSString * const EXUpdatesUpdateAvailableEventType = @"updateAvailable";
 NSString * const EXUpdatesNotAvailableEventType = @"noUpdateAvailable";
-
-@interface EXUpdatesManager ()
-
-@property (nonatomic, strong) EXAppLoader *manifestAppLoader;
-
-@end
 
 @implementation EXUpdatesManager
 
@@ -58,12 +49,6 @@ ofDownloadWithManifest:(EXManifestsManifest * _Nullable)manifest
 }
 
 # pragma mark - internal
-
-- (EXAppLoader *)_appLoaderWithScopedModule:(id)scopedModule
-{
-  NSString *scopeKey = ((EXScopedBridgeModule *)scopedModule).scopeKey;
-  return [self _appLoaderWithScopeKey:scopeKey];
-}
 
 - (EXAppLoader *)_appLoaderWithScopeKey:(NSString *)scopeKey
 {
@@ -112,79 +97,6 @@ ofDownloadWithManifest:(EXManifestsManifest * _Nullable)manifest
 {
   [[EXKernel sharedInstance] reloadAppFromCacheWithScopeKey:scopeKey];
   completion(YES);
-}
-
-# pragma mark - EXUpdatesScopedModuleDelegate
-
-- (void)updatesModuleDidSelectReload:(id)scopedModule
-{
-  NSString *scopeKey = ((EXScopedBridgeModule *)scopedModule).scopeKey;
-  [[EXKernel sharedInstance] reloadAppWithScopeKey:scopeKey];
-}
-
-- (void)updatesModuleDidSelectReloadFromCache:(id)scopedModule
-{
-  NSString *scopeKey = ((EXScopedBridgeModule *)scopedModule).scopeKey;
-  [[EXKernel sharedInstance] reloadAppFromCacheWithScopeKey:scopeKey];
-}
-
-- (void)updatesModule:(id)scopedModule
-didRequestManifestWithCacheBehavior:(EXManifestCacheBehavior)cacheBehavior
-              success:(void (^)(EXManifestsManifest * _Nonnull))success
-              failure:(void (^)(NSError * _Nonnull))failure
-{
-  if ([EXEnvironment sharedEnvironment].isDetached && ![EXEnvironment sharedEnvironment].areRemoteUpdatesEnabled) {
-    failure(RCTErrorWithMessage(@"Remote updates are disabled in app.json"));
-    return;
-  }
-
-  EXUpdatesDatabaseManager *databaseKernelService = [EXKernel sharedInstance].serviceRegistry.updatesDatabaseManager;
-  EXAppLoader *appLoader = [self _appLoaderWithScopedModule:scopedModule];
-
-  EXUpdatesFileDownloader *fileDownloader = [[EXUpdatesFileDownloader alloc] initWithUpdatesConfig:appLoader.config];
-  [fileDownloader downloadManifestFromURL:appLoader.config.updateUrl
-                             withDatabase:databaseKernelService.database
-                             extraHeaders:nil
-                             successBlock:^(EXUpdatesUpdate *update) {
-    success(update.manifest);
-  } errorBlock:^(NSError *error) {
-    failure(error);
-  }];
-}
-
-
-- (void)updatesModule:(id)scopedModule
-didRequestBundleWithCompletionQueue:(dispatch_queue_t)completionQueue
-                start:(void (^)(void))startBlock
-              success:(void (^)(EXManifestsManifest * _Nullable))success
-              failure:(void (^)(NSError * _Nonnull))failure
-{
-  if ([EXEnvironment sharedEnvironment].isDetached && ![EXEnvironment sharedEnvironment].areRemoteUpdatesEnabled) {
-    failure(RCTErrorWithMessage(@"Remote updates are disabled in app.json"));
-    return;
-  }
-
-  EXUpdatesDatabaseManager *databaseKernelService = [EXKernel sharedInstance].serviceRegistry.updatesDatabaseManager;
-  EXAppLoader *appLoader = [self _appLoaderWithScopedModule:scopedModule];
-
-  EXUpdatesRemoteAppLoader *remoteAppLoader = [[EXUpdatesRemoteAppLoader alloc] initWithConfig:appLoader.config database:databaseKernelService.database directory:databaseKernelService.updatesDirectory launchedUpdate:nil completionQueue:completionQueue];
-  [remoteAppLoader loadUpdateFromUrl:appLoader.config.updateUrl onManifest:^BOOL(EXUpdatesUpdate * _Nonnull update) {
-    BOOL shouldLoad = [appLoader.selectionPolicy shouldLoadNewUpdate:update withLaunchedUpdate:appLoader.appLauncher.launchedUpdate filters:update.manifestFilters];
-    if (shouldLoad) {
-      startBlock();
-    }
-    return shouldLoad;
-  } asset:^(EXUpdatesAsset *asset, NSUInteger successfulAssetCount, NSUInteger failedAssetCount, NSUInteger totalAssetCount) {
-    // do nothing for now
-  } success:^(EXUpdatesUpdate * _Nullable update) {
-    if (update) {
-      success(update.manifest);
-    } else {
-      success(nil);
-    }
-  } error:^(NSError * _Nonnull error) {
-    failure(error);
-  }];
 }
 
 @end


### PR DESCRIPTION
# Why

https://github.com/expo/expo/pull/17033#discussion_r851555720

EXUpdatesManager still has some code related to the old updates implementation from ExpoKit, and it can now be fully removed since no supported SDK versions rely on it.

This PR can be landed at any time, does not need to make it into SDK 45

# How

Grep to confirm there are no other references to `EXUpdatesScopedModuleDelegate`, remove implementation, removed a few other unused methods and references from related classes

# Test Plan

Versioned Expo Go builds, runs, and can open published projects. Also sanity checked the SDK 44 Updates module by doing the following:
1. publish SDK 44 project with the same code from #17113 
2. open in Expo Go (versioned)
3. check for updates -> no update, fetch update -> no update, reload -> reloads same update
4. make a change in App.js, publish new update
5. check for updates -> new update, fetch update -> success, reload -> loads new update

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
