### PR TITLE
[@expo/cli] Close development session when CLI is stopped

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -32,7 +32,9 @@
 - Fix web imports and dependency resolution. ([#16820](https://github.com/expo/expo/pull/16820) by [@EvanBacon](https://github.com/EvanBacon))
 - [test] Update login error message to reflect server change. ([#16932](https://github.com/expo/expo/pull/16932) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix webpack imports and server timeouts. ([#17006](https://github.com/expo/expo/pull/17006) by [@EvanBacon](https://github.com/EvanBacon))
-- [ci] Fix `typecheck`. ([#17145](https://github.com/expo/expo/pull/17145) by [@EvanBacon](https://github.com/EvanBacon))
+- [ci] Fix `typecheck`. ([#17145](https://github.com/expo/expo/pull/17145) by
+  [@EvanBacon](https://github.com/EvanBacon))
+- Close development session when CLI is stopped ([#17170](https://github.com/expo/expo/pull/17170) by [@FiberJW](https://github.com/FiberJW))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/api/__tests__/updateDevelopmentSession-test.ts
+++ b/packages/@expo/cli/src/api/__tests__/updateDevelopmentSession-test.ts
@@ -1,7 +1,10 @@
 import nock from 'nock';
 
 import { getExpoApiBaseUrl } from '../endpoint';
-import { updateDevelopmentSessionAsync } from '../updateDevelopmentSession';
+import {
+  updateDevelopmentSessionAsync,
+  closeDevelopmentSessionAsync,
+} from '../updateDevelopmentSession';
 
 describe(updateDevelopmentSessionAsync, () => {
   it('update development session', async () => {
@@ -17,7 +20,7 @@ describe(updateDevelopmentSessionAsync, () => {
         primaryColor: '#ffffff',
       },
       runtime: 'native',
-      url: 'https://example.com',
+      url: 'exp://192.168.1.69:19001',
     });
 
     expect(scope.isDone()).toBe(true);
@@ -36,7 +39,46 @@ describe(updateDevelopmentSessionAsync, () => {
           primaryColor: '#ffffff',
         },
         runtime: 'native',
-        url: 'https://example.com',
+        url: 'exp://192.168.1.69:19001',
+      })
+    ).rejects.toThrowError(/Expo server/);
+    expect(scope.isDone()).toBe(true);
+  });
+});
+
+describe(closeDevelopmentSessionAsync, () => {
+  it('close development session', async () => {
+    const scope = nock(getExpoApiBaseUrl())
+      .post('/v2/development-sessions/notify-close?deviceId=123')
+      .reply(200, {
+        data: {
+          deleted: [
+            {
+              username: 'fiberjw',
+              session: {
+                description: 'Goodweebs on Juwans-MacBook-Pro.local',
+                source: 'desktop',
+                url: 'exp://192.168.1.69:19001',
+              },
+            },
+          ],
+        },
+      });
+    await closeDevelopmentSessionAsync({
+      deviceIds: ['123'],
+      url: 'exp://192.168.1.69:19001',
+    });
+
+    expect(scope.isDone()).toBe(true);
+  });
+  it('fails when the servers are down', async () => {
+    const scope = nock(getExpoApiBaseUrl())
+      .post('/v2/development-sessions/notify-close?deviceId=123')
+      .reply(500, 'something went wrong');
+    await expect(
+      closeDevelopmentSessionAsync({
+        deviceIds: ['123'],
+        url: 'exp://192.168.1.69:19001',
       })
     ).rejects.toThrowError(/Expo server/);
     expect(scope.isDone()).toBe(true);

--- a/packages/@expo/cli/src/api/updateDevelopmentSession.ts
+++ b/packages/@expo/cli/src/api/updateDevelopmentSession.ts
@@ -65,3 +65,32 @@ export async function updateDevelopmentSessionAsync({
     );
   }
 }
+
+/** Send a request to Expo API to close the 'development session' for the provided devices. */
+export async function closeDevelopmentSessionAsync({
+  deviceIds,
+  url,
+}: {
+  deviceIds: string[];
+  url: string;
+}) {
+  const searchParams = new URLSearchParams();
+  deviceIds.forEach((id) => {
+    searchParams.append('deviceId', id);
+  });
+
+  const results = await fetchAsync('development-sessions/notify-close', {
+    searchParams,
+    method: 'POST',
+    body: JSON.stringify({
+      session: { url },
+    }),
+  });
+
+  if (!results.ok) {
+    throw new CommandError(
+      'API',
+      `Unexpected response when closing the development session on Expo servers: ${results.statusText}.`
+    );
+  }
+}

--- a/packages/@expo/cli/src/start/server/BundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/BundlerDevServer.ts
@@ -163,7 +163,7 @@ export abstract class BundlerDevServer {
     // Must come after ngrok (`startTunnelAsync`) setup.
 
     if (this.devSession) {
-      await this.devSession.stopNotifying();
+      this.devSession.stopNotifying();
     }
 
     this.devSession = new DevelopmentSession(

--- a/packages/@expo/cli/src/start/server/BundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/BundlerDevServer.ts
@@ -163,7 +163,7 @@ export abstract class BundlerDevServer {
     // Must come after ngrok (`startTunnelAsync`) setup.
 
     if (this.devSession) {
-      this.devSession.stop();
+      await this.devSession.stopNotifying();
     }
 
     this.devSession = new DevelopmentSession(
@@ -209,8 +209,8 @@ export abstract class BundlerDevServer {
 
   /** Stop the running dev server instance. */
   async stopAsync() {
-    // Stop the dev session timer.
-    this.devSession?.stop();
+    // Stop the dev session timer and tell Expo API to remove dev session.
+    await this.devSession?.closeAsync();
 
     // Stop ngrok if running.
     await this.ngrok?.stopAsync().catch((e) => {

--- a/packages/@expo/cli/src/start/server/__mocks__/DevelopmentSession.ts
+++ b/packages/@expo/cli/src/start/server/__mocks__/DevelopmentSession.ts
@@ -2,5 +2,6 @@ export class DevelopmentSession {
   constructor(public projectRoot: string, public url: string) {}
 
   startAsync = jest.fn(async () => ({}));
-  stop = jest.fn();
+  stopNotifying = jest.fn();
+  closeAsync = jest.fn(async () => ({}));
 }

--- a/packages/@expo/cli/src/start/server/__tests__/DevelopmentSession-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/DevelopmentSession-test.ts
@@ -31,16 +31,22 @@ describe(`startAsync`, () => {
       primaryColor: '#4630eb',
     };
     const runtime = 'native';
-    const scope = nock(getExpoApiBaseUrl())
+    const startScope = nock(getExpoApiBaseUrl())
       .post('/v2/development-sessions/notify-alive?deviceId=123&deviceId=456')
+      .reply(200, '');
+    const closeScope = nock(getExpoApiBaseUrl())
+      .post('/v2/development-sessions/notify-close?deviceId=123&deviceId=456')
       .reply(200, '');
 
     await session.startAsync({
       exp,
       runtime,
     });
-    session.stopNotifying();
-    expect(ProjectDevices.getDevicesInfoAsync).toHaveBeenCalledTimes(1);
-    expect(scope.isDone()).toBe(true);
+
+    await session.closeAsync();
+
+    expect(ProjectDevices.getDevicesInfoAsync).toHaveBeenCalledTimes(2);
+    expect(startScope.isDone()).toBe(true);
+    expect(closeScope.isDone()).toBe(true);
   });
 });

--- a/packages/@expo/cli/src/start/server/__tests__/DevelopmentSession-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/DevelopmentSession-test.ts
@@ -39,7 +39,7 @@ describe(`startAsync`, () => {
       exp,
       runtime,
     });
-    session.stop();
+    session.stopNotifying();
     expect(ProjectDevices.getDevicesInfoAsync).toHaveBeenCalledTimes(1);
     expect(scope.isDone()).toBe(true);
   });


### PR DESCRIPTION
This is a rewrite of https://github.com/expo/expo-cli/pull/4317 for the new CLI.

# Why

Development Sessions shown in Expo Go can be "stale" (saying that they show up in the app when the Expo CLI session has been closed) for up to 3 minutes.

# How

Expo CLI dev sessions can feel more up-to-date by calling `/notify-close`, which tells `www` to remove the dev session after the process is closed. This will update in Expo Go in the next polling request or when a user pull-to-refreshes like how it does for Snacks.

I also increased the force quit delay to account for the added network calls.

# Test Plan

Open a project with a locally built copy of @expo/cli (`nexpo`) on this branch, observe that it shows up in Expo Go, then close the dev server, refresh Expo Go, and see that it doesn't show up anymore:

https://user-images.githubusercontent.com/12488826/164547534-bfe83708-e272-4d4c-bd75-a6b67d942b1f.mp4


