### PR TITLE
[android] Set Badge Count Number Based on Notification Payload

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- On Android, fix the `badge count number` not being read from the notification payload content. ([#17171](https://github.com/expo/expo/pull/17171) by [@danstepanov](https://github.com/danstepanov))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🛠 Breaking changes
 
-- On Android, fix the `badge count number` not being read from the notification payload content. ([#17171](https://github.com/expo/expo/pull/17171) by [@danstepanov](https://github.com/danstepanov))
+- [android] Set the "notification number" (sometimes used to increment badge count on some launchers) from the notification payload `badge` field. ([#17171](https://github.com/expo/expo/pull/17171) by [@danstepanov](https://github.com/danstepanov))
 
 ### 🎉 New features
 

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/presentation/builders/CategoryAwareNotificationBuilder.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/presentation/builders/CategoryAwareNotificationBuilder.java
@@ -36,6 +36,10 @@ public class CategoryAwareNotificationBuilder extends ExpoNotificationBuilder {
     if (categoryIdentifier != null) {
       addActionsToBuilder(builder, categoryIdentifier);
     }
+
+    if (content.getBadgeCount() != null) {
+      builder.setNumber(content.getBadgeCount().intValue());
+    }
     
     return builder;
   }


### PR DESCRIPTION
# Why

The badge field set in notification payload is ignored on Android. This PR updates it so that it is passed via the notification badge field, which different launchers treat differently.

# How

Set badge count number by fetching the value from the payload content.

# Test Plan

1. Install microsoft launcher on android device and turn on badges: https://www.windowscentral.com/how-turn-notification-badges-microsoft-launcher
2. Patch PR
3. Build & Debug Expo Go in android studio on device
4. Load `native-component-list` app running locally
5. Open Notifications screen, take note of push token printed to console
6. Start www pointing at production locally, modified to pass the `badge` field through to FCM.
7. Send curl to local prod with token:
```
curl --request POST \
  --url http://localhost:3000/--/api/v2/push/send \
  --header 'Content-Type: application/json' \
  --data '{
	"to": "ExponentPushToken[...]",
	"data": {"hello": "world"},
	"badge": 10
}'
```
8. See notification is received on device and badge is incremented by specified value.

![screen](https://user-images.githubusercontent.com/189568/167515786-64250510-82e5-46c0-8d23-1f339531a092.png)


# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
