### PR TITLE
[updates-e2e] add iOS CI job

### DIFF
--- a/.github/workflows/updates-e2e.yml
+++ b/.github/workflows/updates-e2e.yml
@@ -244,11 +244,11 @@ jobs:
         id: test-app-path
         working-directory: ../updates-e2e/ios/build/Build/Products/Release-iphonesimulator/
         run: echo "::set-output name=dir::$(pwd)"
-      - name: Export update bundle for test server to host
+      - name: Export update for test server to host
         working-directory: ../updates-e2e
-        run: expo export --public-url https://expo.dev/dummy-url --platform ios
-      - name: Get test bundle dist path
-        id: test-bundle-dist-path
+        run: expo export --public-url https://u.expo.dev/dummy-url --platform ios
+      - name: Get test update dist path
+        id: test-update-dist-path
         working-directory: ../updates-e2e/dist
         run: echo "::set-output name=dir::$(pwd)"
       - name: Start simulator
@@ -259,7 +259,7 @@ jobs:
       - name: Run tests
         env:
           TEST_APP_PATH: '${{ steps.test-app-path.outputs.dir }}/updatese2e.app'
-          TEST_BUNDLE_DIST_PATH: '${{ steps.test-bundle-dist-path.outputs.dir }}'
+          TEST_UPDATE_DIST_PATH: '${{ steps.test-update-dist-path.outputs.dir }}'
         timeout-minutes: 30
         working-directory: packages/expo-updates
         run: yarn test --config e2e/jest.config.ios.js

--- a/.github/workflows/updates-e2e.yml
+++ b/.github/workflows/updates-e2e.yml
@@ -146,3 +146,120 @@ jobs:
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -no-snapshot-save
           script: yarn test --config e2e/jest.config.android.js
           working-directory: packages/expo-updates
+
+  ios:
+    runs-on: macos-11
+    timeout-minutes: 60
+    env:
+      UPDATES_HOST: localhost
+      UPDATES_PORT: 4747
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: false
+      - name: 🔨 Switch to Xcode 13.0
+        run: sudo xcode-select --switch /Applications/Xcode_13.0.app
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: ♻️ Restore yarn cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: 🧶 Yarn install
+        run: yarn install --frozen-lockfile
+      - run: yarn global add expo-cli
+      - run: echo "$(yarn global bin)" >> $GITHUB_PATH
+      - name: Init new expo app
+        working-directory: ../
+        run: expo-cli init updates-e2e --yes
+      - name: Add yarn resolutions for local dependencies
+        working-directory: ../updates-e2e
+        run: |
+          # A jq filter to add a "resolutions" field
+          JQ_FILTER=$(cat << EOF
+            . + {
+              resolutions: {
+                "expo-application": "file:../expo/packages/expo-application",
+                "expo-constants": "file:../expo/packages/expo-constants",
+                "expo-eas-client": "file:../expo/packages/expo-eas-client",
+                "expo-error-recovery": "file:../expo/packages/expo-error-recovery",
+                "expo-file-system": "file:../expo/packages/expo-file-system",
+                "expo-font": "file:../expo/packages/expo-font",
+                "expo-json-utils": "file:../expo/packages/expo-json-utils",
+                "expo-keep-awake": "file:../expo/packages/expo-keep-awake",
+                "expo-manifests": "file:../expo/packages/expo-manifests",
+                "expo-modules-core": "file:../expo/packages/expo-modules-core",
+                "expo-structured-headers": "file:../expo/packages/expo-structured-headers",
+                "expo-updates-interface": "file:../expo/packages/expo-updates-interface"
+              }
+            }
+          EOF
+          )
+          jq "$JQ_FILTER" < package.json > new-package.json
+          mv new-package.json package.json
+      - name: Add local expo packages
+        working-directory: ../updates-e2e
+        run: yarn add file:../expo/packages/expo-updates file:../expo/packages/expo file:../expo/packages/expo-splash-screen file:../expo/packages/expo-status-bar
+      - name: Setup app.config.json
+        working-directory: ../updates-e2e
+        run: echo "{\"name\":\"updates-e2e\",\"runtimeVersion\":\"1.0.0\",\"plugins\":[\"expo-updates\"],\"android\":{\"package\":\"dev.expo.updatese2e\"},\"ios\":{\"bundleIdentifier\":\"dev.expo.updatese2e\"},\"updates\":{\"url\":\"http://$UPDATES_HOST:$UPDATES_PORT/update\"}}" > app.config.json
+      - name: Pack latest bare-minimum template as tarball for expo prebuild
+        working-directory: templates/expo-template-bare-minimum
+        run: npm pack --pack-destination ../../../updates-e2e/
+      - name: Prebuild --no-install
+        working-directory: ../updates-e2e
+        run: expo-cli prebuild --template expo-template-bare-minimum-*.tgz --no-install && yarn
+      # - name: Restore updates-e2e/ios/Pods from cache
+      #   uses: actions/cache@v2
+      #   id: pods-cache
+      #   with:
+      #     path: '../updates-e2e/ios/Pods'
+      #     key: ${{ runner.os }}-pods-updatese2e-${{ hashFiles('../updates-e2e/ios/Podfile.lock') }}
+      #     # restore-keys: |
+      #     #   ${{ runner.os }}-pods-updatese2e-
+      - name: 🥥 Install CocoaPods in `updates-e2e/ios`
+        run: pod install
+        working-directory: ../updates-e2e/ios
+      - name: Copy App.js from test fixtures
+        working-directory: ../updates-e2e
+        run: cp ../expo/packages/expo-updates/e2e/__tests__/fixtures/App.js .
+      - name: Set host and port in App.js
+        working-directory: ../updates-e2e
+        run: sed -i -e "s/UPDATES_HOST/$UPDATES_HOST/" ./App.js && sed -i -e "s/UPDATES_PORT/$UPDATES_PORT/" ./App.js
+      - name: Build release app
+        working-directory: ../updates-e2e/ios
+        run: xcodebuild -workspace updatese2e.xcworkspace -scheme updatese2e -configuration Release -destination "generic/platform=iOS Simulator" -derivedDataPath ./build build
+      - name: Copy app to working directory
+        run: cp -R ../updates-e2e/ios/build/Build/Products/Release-iphonesimulator/updatese2e.app artifact
+      - name: Upload test app artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: updates-e2e-ios-app
+          path: artifact
+      - name: Get test app path
+        id: test-app-path
+        working-directory: ../updates-e2e/ios/build/Build/Products/Release-iphonesimulator/
+        run: echo "::set-output name=dir::$(pwd)"
+      - name: Export update bundle for test server to host
+        working-directory: ../updates-e2e
+        run: expo export --public-url https://expo.dev/dummy-url --platform ios
+      - name: Get test bundle dist path
+        id: test-bundle-dist-path
+        working-directory: ../updates-e2e/dist
+        run: echo "::set-output name=dir::$(pwd)"
+      - name: Start simulator
+        run: |
+          xcrun simctl list devices -j \
+          | jq -rc '[ .[] | .[] | .[] | select( .name | contains( "iPhone" ) ) | select( .isAvailable == true ) ] | last.udid ' \
+          | xargs open -a Simulator --args -CurrentDeviceUDID
+      - name: Run tests
+        env:
+          TEST_APP_PATH: '${{ steps.test-app-path.outputs.dir }}/updatese2e.app'
+          TEST_BUNDLE_DIST_PATH: '${{ steps.test-bundle-dist-path.outputs.dir }}'
+        timeout-minutes: 30
+        working-directory: packages/expo-updates
+        run: yarn test --config e2e/jest.config.ios.js

--- a/.github/workflows/updates-e2e.yml
+++ b/.github/workflows/updates-e2e.yml
@@ -213,6 +213,8 @@ jobs:
       - name: Prebuild --no-install
         working-directory: ../updates-e2e
         run: expo-cli prebuild --template expo-template-bare-minimum-*.tgz --no-install && yarn
+      # TODO: not caching pods for now as we don't have a lockfile with which to use in the key
+      #       and as this is a minimal project, time savings is not much anyway (~3.5 mins at most)
       # - name: Restore updates-e2e/ios/Pods from cache
       #   uses: actions/cache@v2
       #   id: pods-cache


### PR DESCRIPTION
# Why

follow-up to #17173, add a CI job for the iOS tests to run in

# How

This new job basically replicates the Android equivalent, with a few iOS specific things (xcode-select, using xcrun and jq to select and start a simulator).

One missing piece here is any sort of native build/deps cache; in most iOS jobs we cache Pods keyed by a hash of the Podfile.lock, but as we're creating a project from scratch here we don't have a Podfile.lock to use in the key. We could use the project's yarn.lock file, but I'm guessing that would change so frequently as to be unhelpful. I'm not sure it's a good idea to cache DerivedData, which would be another option. Ideas are welcome!

# Test Plan

New job should pass in CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
