### PR TITLE
[android][sensors] Fix high sampling rate exception on Android S

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/kernel/services/sensors/BaseSensorKernelService.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/services/sensors/BaseSensorKernelService.kt
@@ -33,16 +33,15 @@ abstract class BaseSensorKernelService internal constructor(reactContext: Contex
 
   private fun hasHighSamplingRateSensorsPermission(): Boolean {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
-      return false
+      return true
     }
 
-    try {
+    return try {
       context.packageManager.getPackageInfo(context.packageName, PackageManager.GET_PERMISSIONS)?.run {
-        return requestedPermissions.contains(Manifest.permission.HIGH_SAMPLING_RATE_SENSORS)
-      }
-      return false
+        requestedPermissions.contains(Manifest.permission.HIGH_SAMPLING_RATE_SENSORS)
+      } ?: false
     } catch (e: PackageManager.NameNotFoundException) {
-      return false
+      false
     }
   }
 

--- a/android/expoview/src/main/java/host/exp/exponent/kernel/services/sensors/BaseSensorKernelService.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/services/sensors/BaseSensorKernelService.kt
@@ -1,16 +1,21 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 package host.exp.exponent.kernel.services.sensors
 
+import android.Manifest
 import android.content.Context
+import android.content.pm.PackageManager
 import android.hardware.Sensor
 import android.hardware.SensorEvent
 import android.hardware.SensorEventListener
 import android.hardware.SensorManager
+import android.os.Build
 import host.exp.exponent.kernel.services.BaseKernelService
 
 abstract class BaseSensorKernelService internal constructor(reactContext: Context) : BaseKernelService(reactContext), SensorEventListener {
   private var sensor: Sensor? = null
   private val sensorManager: SensorManager = context.getSystemService(Context.SENSOR_SERVICE) as SensorManager
+  private val samplingPeriodUs: Int
+    get() = if (hasHighSamplingRateSensorsPermission()) SensorManager.SENSOR_DELAY_FASTEST else SensorManager.SENSOR_DELAY_NORMAL
 
   abstract val sensorType: Int
   abstract fun onSensorDataChanged(sensorEvent: SensorEvent)
@@ -18,12 +23,27 @@ abstract class BaseSensorKernelService internal constructor(reactContext: Contex
   protected fun startObserving() {
     sensor = sensorManager.getDefaultSensor(sensorType)
     if (sensor != null) {
-      sensorManager.registerListener(this, sensor, SensorManager.SENSOR_DELAY_FASTEST)
+      sensorManager.registerListener(this, sensor, samplingPeriodUs)
     }
   }
 
   protected fun stopObserving() {
     sensorManager.unregisterListener(this)
+  }
+
+  private fun hasHighSamplingRateSensorsPermission(): Boolean {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+      return false
+    }
+
+    try {
+      context.packageManager.getPackageInfo(context.packageName, PackageManager.GET_PERMISSIONS)?.run {
+        return requestedPermissions.contains(Manifest.permission.HIGH_SAMPLING_RATE_SENSORS)
+      }
+      return false
+    } catch (e: PackageManager.NameNotFoundException) {
+      return false
+    }
   }
 
   // android.hardware.SensorEventListener

--- a/docs/pages/versions/unversioned/sdk/accelerometer.md
+++ b/docs/pages/versions/unversioned/sdk/accelerometer.md
@@ -174,3 +174,5 @@ Subscribe for updates to the accelerometer.
 
 - **intervalMs (_number_)** Desired interval in milliseconds between
   accelerometer updates.
+
+  > Starting in Android 12 (API level 31), the system has a 200ms limit for each sensor updates. If you need a update interval less than 200ms, you should add `<uses-permission android:name="android.permission.HIGH_SAMPLING_RATE_SENSORS"/>` to **AndroidManifest.xml**.

--- a/docs/pages/versions/unversioned/sdk/gyroscope.md
+++ b/docs/pages/versions/unversioned/sdk/gyroscope.md
@@ -168,3 +168,5 @@ Subscribe for updates to the gyroscope.
 #### Arguments
 
 - **intervalMs (_number_)** -- Desired interval in milliseconds between gyroscope updates.
+
+  > Starting in Android 12 (API level 31), the system has a 200ms limit for each sensor updates. If you need a update interval less than 200ms, you should add `<uses-permission android:name="android.permission.HIGH_SAMPLING_RATE_SENSORS"/>` to **AndroidManifest.xml**.

--- a/docs/pages/versions/unversioned/sdk/magnetometer.md
+++ b/docs/pages/versions/unversioned/sdk/magnetometer.md
@@ -175,3 +175,5 @@ Subscribe for updates to the Magnetometer.
 
 - **intervalMs (_number_)** Desired interval in milliseconds between
   Magnetometer updates.
+
+  > Starting in Android 12 (API level 31), the system has a 200ms limit for each sensor updates. If you need a update interval less than 200ms, you should add `<uses-permission android:name="android.permission.HIGH_SAMPLING_RATE_SENSORS"/>` to **AndroidManifest.xml**.

--- a/docs/pages/versions/unversioned/sdk/sensors.md
+++ b/docs/pages/versions/unversioned/sdk/sensors.md
@@ -15,6 +15,10 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 <APIInstallSection />
 
+## Configuration
+
+Starting in Android 12 (API level 31), the system has a 200ms limit for each sensor updates. If you need a update interval less than 200ms, you should add `<uses-permission android:name="android.permission.HIGH_SAMPLING_RATE_SENSORS"/>` to **AndroidManifest.xml**.
+
 ## API
 
 ```js

--- a/packages/expo-sensors/CHANGELOG.md
+++ b/packages/expo-sensors/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### 💡 Others
 
+### ⚠️ Notices
+
+- Fixed exception on Android S+ devices for missing `HIGH_SAMPLING_RATE_SENSORS` permission. If the sensor update interval needs to be lower than 200ms, `HIGH_SAMPLING_RATE_SENSORS` should be explicitly added to **AndroidManifest.xml**. ([#17177](https://github.com/expo/expo/pull/17177) by [@kudo](https://github.com/kudo))
+
 ## 11.2.0 — 2022-04-18
 
 ### 💡 Others

--- a/packages/expo-sensors/README.md
+++ b/packages/expo-sensors/README.md
@@ -29,7 +29,9 @@ Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 
-No additional set up necessary.
+No additional set up necessary for basic usage.
+
+**Note:** Starting in Android 12 (API level 31), the system has a 200ms limit for each sensor updates. If you need a update interval less than 200ms, you should add `<uses-permission android:name="android.permission.HIGH_SAMPLING_RATE_SENSORS"/>` to **AndroidManifest.xml**.
 
 # Contributing
 

--- a/packages/expo-sensors/android/src/main/java/expo/modules/sensors/services/BaseSensorService.kt
+++ b/packages/expo-sensors/android/src/main/java/expo/modules/sensors/services/BaseSensorService.kt
@@ -1,14 +1,19 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 package expo.modules.sensors.services
 
+import android.Manifest
 import android.content.Context
+import android.content.pm.PackageManager
 import android.hardware.Sensor
 import android.hardware.SensorEventListener2
 import android.hardware.SensorManager
+import android.os.Build
 
 abstract class BaseSensorService internal constructor(reactContext: Context?) : BaseService(reactContext!!), SensorEventListener2 {
   private var mSensor: Sensor? = null
   private val mSensorManager: SensorManager = context.getSystemService(Context.SENSOR_SERVICE) as SensorManager
+  private val samplingPeriodUs: Int
+    get() = if (hasHighSamplingRateSensorsPermission()) SensorManager.SENSOR_DELAY_FASTEST else SensorManager.SENSOR_DELAY_NORMAL
 
   // Abstract methods that subclasses should implement
   abstract val sensorType: Int
@@ -16,11 +21,26 @@ abstract class BaseSensorService internal constructor(reactContext: Context?) : 
   // Public API
   protected fun startObserving() {
     if (mSensorManager.getDefaultSensor(sensorType).also { mSensor = it } != null) {
-      mSensorManager.registerListener(this, mSensor, SensorManager.SENSOR_DELAY_FASTEST)
+      mSensorManager.registerListener(this, mSensor, samplingPeriodUs)
     }
   }
 
   protected fun stopObserving() {
     mSensorManager.unregisterListener(this)
+  }
+
+  private fun hasHighSamplingRateSensorsPermission(): Boolean {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+      return false
+    }
+
+    try {
+      context.packageManager.getPackageInfo(context.packageName, PackageManager.GET_PERMISSIONS)?.run {
+        return requestedPermissions.contains(Manifest.permission.HIGH_SAMPLING_RATE_SENSORS)
+      }
+      return false
+    } catch (e: PackageManager.NameNotFoundException) {
+      return false
+    }
   }
 }

--- a/packages/expo-sensors/android/src/main/java/expo/modules/sensors/services/BaseSensorService.kt
+++ b/packages/expo-sensors/android/src/main/java/expo/modules/sensors/services/BaseSensorService.kt
@@ -31,16 +31,15 @@ abstract class BaseSensorService internal constructor(reactContext: Context?) : 
 
   private fun hasHighSamplingRateSensorsPermission(): Boolean {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
-      return false
+      return true
     }
 
-    try {
+    return try {
       context.packageManager.getPackageInfo(context.packageName, PackageManager.GET_PERMISSIONS)?.run {
-        return requestedPermissions.contains(Manifest.permission.HIGH_SAMPLING_RATE_SENSORS)
-      }
-      return false
+        requestedPermissions.contains(Manifest.permission.HIGH_SAMPLING_RATE_SENSORS)
+      } ?: false
     } catch (e: PackageManager.NameNotFoundException) {
-      return false
+      false
     }
   }
 }

--- a/template-files/android/AndroidManifest.xml
+++ b/template-files/android/AndroidManifest.xml
@@ -25,6 +25,7 @@
   <uses-permission android:name="android.permission.VIBRATE" />
   <uses-permission android:name="com.android.launcher.permission.INSTALL_SHORTCUT" />
   <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
+  <uses-permission android:name="android.permission.HIGH_SAMPLING_RATE_SENSORS" />
 
   <!-- These require runtime permissions on M -->
   <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />


### PR DESCRIPTION
# Why

starting in android S (API level 31), [to use the `SensorManager.SENSOR_DELAY_FASTEST` update interval, `HIGH_SAMPLING_RATE_SENSORS` is required.](https://developer.android.com/about/versions/12/reference/compat-framework-changes#change_id_sampling_rate_sensors_permission)

close ENG-4735

# How

- if AndroidManifest.xml has the `HIGH_SAMPLING_RATE_SENSORS` permission, we keep to use the `SENSOR_DELAY_FASTEST`. otherwise, we fallback to use the `SENSOR_DELAY_NORMAL` (around 200ms).
- add `HIGH_SAMPLING_RATE_SENSORS` to expo go.
- for standalone apps, to remove `HIGH_SAMPLING_RATE_SENSORS` as optional permission. i will have a separated pr for xdl.

# Test Plan

Android S + expo go + NCL AccelerometerScreen

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
