### PR TITLE
[dev-launcher][android] pass correct property for updates url to dev …

### DIFF
--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherInternalModule.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherInternalModule.kt
@@ -83,7 +83,7 @@ class DevLauncherInternalModule(reactContext: ReactApplicationContext?)
       putString("runtimeVersion", runtimeVersion)
       putString("sdkVersion", sdkVersion)
       putBoolean("usesEASUpdates", usesEASUpdates)
-      putString("projectUrl", projectUrl)
+      putString("updatesUrl", projectUrl)
     }
   }
 


### PR DESCRIPTION
…launcher app

# Why

Closes ENG-4753
I mistakenly put the wrong property on `constantsToExport` for the dev launcher - it should be `updatesUrl` not `projectUrl`  - this lead to issues loading updates on android

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update the name of the property to `updatesUrl` to match iOS implementation

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Loading an update w/ Android on the latest branch works

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
