### PR TITLE
[expo-structured-headers] Update changelog

### DIFF
--- a/packages/expo-structured-headers/CHANGELOG.md
+++ b/packages/expo-structured-headers/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Stop prebuilding xcframework. ([#17161](https://github.com/expo/expo/pull/17161) by [@wschurman](https://github.com/wschurman))
+
 ### 💡 Others
 
 ## 2.2.0 — 2022-04-18


### PR DESCRIPTION
# Why

Changelog bot didn't trigger for https://github.com/expo/expo/pull/17161 since it didn't modify the package files, so I forgot about the changelog. This adds an entry so that the package can be published (currently `et pp expo-structured-headers` doesn't do anything).

# How

Add entry.

# Test Plan

Inspect.