### PR TITLE
[ios][android] Migrate names of module definition components

### DIFF
--- a/packages/expo-cellular/CHANGELOG.md
+++ b/packages/expo-cellular/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Migrated Expo modules definitions to the new naming convention. ([#17193](https://github.com/expo/expo/pull/17193) by [@tsapeta](https://github.com/tsapeta))
+
 ## 4.2.0 — 2022-04-18
 
 ### ⚠️ Notices

--- a/packages/expo-cellular/android/src/main/java/expo/modules/cellular/CellularModule.kt
+++ b/packages/expo-cellular/android/src/main/java/expo/modules/cellular/CellularModule.kt
@@ -13,8 +13,8 @@ const val moduleName = "ExpoCellular"
 
 class CellularModule : Module() {
   override fun definition() = ModuleDefinition {
-    name(moduleName)
-    constants {
+    Name(moduleName)
+    Constants {
       val telephonyManager = telephonyManager()
       mapOf(
         "allowsVoip" to SipManager.isVoipSupported(context),
@@ -25,7 +25,7 @@ class CellularModule : Module() {
       )
     }
 
-    function("getCellularGenerationAsync") {
+    AsyncFunction("getCellularGenerationAsync" ) {
       try {
         getCurrentGeneration()
       } catch (e: SecurityException) {
@@ -34,23 +34,23 @@ class CellularModule : Module() {
       }
     }
 
-    function("allowsVoipAsync") {
+    AsyncFunction("allowsVoipAsync" ) {
       SipManager.isVoipSupported(context)
     }
 
-    function("getIsoCountryCodeAsync") {
+    AsyncFunction("getIsoCountryCodeAsync" ) {
       telephonyManager()?.simCountryIso
     }
 
-    function("getCarrierNameAsync") {
+    AsyncFunction("getCarrierNameAsync" ) {
       telephonyManager()?.simOperatorName
     }
 
-    function("getMobileCountryCodeAsync") {
+    AsyncFunction("getMobileCountryCodeAsync" ) {
       telephonyManager()?.simOperator?.substring(0, 3)
     }
 
-    function("getMobileNetworkCodeAsync") {
+    AsyncFunction("getMobileNetworkCodeAsync" ) {
       telephonyManager()?.simOperator?.substring(3)
     }
   }

--- a/packages/expo-cellular/android/src/main/java/expo/modules/cellular/CellularModule.kt
+++ b/packages/expo-cellular/android/src/main/java/expo/modules/cellular/CellularModule.kt
@@ -25,7 +25,7 @@ class CellularModule : Module() {
       )
     }
 
-    AsyncFunction("getCellularGenerationAsync" ) {
+    AsyncFunction("getCellularGenerationAsync") {
       try {
         getCurrentGeneration()
       } catch (e: SecurityException) {
@@ -34,23 +34,23 @@ class CellularModule : Module() {
       }
     }
 
-    AsyncFunction("allowsVoipAsync" ) {
+    AsyncFunction("allowsVoipAsync") {
       SipManager.isVoipSupported(context)
     }
 
-    AsyncFunction("getIsoCountryCodeAsync" ) {
+    AsyncFunction("getIsoCountryCodeAsync") {
       telephonyManager()?.simCountryIso
     }
 
-    AsyncFunction("getCarrierNameAsync" ) {
+    AsyncFunction("getCarrierNameAsync") {
       telephonyManager()?.simOperatorName
     }
 
-    AsyncFunction("getMobileCountryCodeAsync" ) {
+    AsyncFunction("getMobileCountryCodeAsync") {
       telephonyManager()?.simOperator?.substring(0, 3)
     }
 
-    AsyncFunction("getMobileNetworkCodeAsync" ) {
+    AsyncFunction("getMobileNetworkCodeAsync") {
       telephonyManager()?.simOperator?.substring(3)
     }
   }

--- a/packages/expo-cellular/ios/CellularModule.swift
+++ b/packages/expo-cellular/ios/CellularModule.swift
@@ -3,33 +3,33 @@ import ExpoModulesCore
 
 public class CellularModule: Module {
   public func definition() -> ModuleDefinition {
-    name("ExpoCellular")
+    Name("ExpoCellular")
 
-    constants {
+    Constants {
       Self.getCurrentCellularInfo()
     }
 
-    function("getCellularGenerationAsync") { () -> Int in
+    AsyncFunction("getCellularGenerationAsync") { () -> Int in
       Self.currentCellularGeneration().rawValue
     }
 
-    function("allowsVoipAsync") { () -> Bool? in
+    AsyncFunction("allowsVoipAsync") { () -> Bool? in
       Self.currentCarrier()?.allowsVOIP
     }
 
-    function("getIsoCountryCodeAsync") { () -> String? in
+    AsyncFunction("getIsoCountryCodeAsync") { () -> String? in
       Self.currentCarrier()?.isoCountryCode
     }
 
-    function("getCarrierNameAsync") { () -> String? in
+    AsyncFunction("getCarrierNameAsync") { () -> String? in
       Self.currentCarrier()?.carrierName
     }
 
-    function("getMobileCountryCodeAsync") { () -> String? in
+    AsyncFunction("getMobileCountryCodeAsync") { () -> String? in
       Self.currentCarrier()?.mobileCountryCode
     }
 
-    function("getMobileNetworkCodeAsync") { () -> String? in
+    AsyncFunction("getMobileNetworkCodeAsync") { () -> String? in
       Self.currentCarrier()?.mobileNetworkCode
     }
   }

--- a/packages/expo-clipboard/CHANGELOG.md
+++ b/packages/expo-clipboard/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Migrated Expo modules definitions to the new naming convention. ([#17193](https://github.com/expo/expo/pull/17193) by [@tsapeta](https://github.com/tsapeta))
+
 ## 3.0.1 — 2022-04-20
 
 ### 🐛 Bug fixes

--- a/packages/expo-clipboard/android/src/main/java/expo/modules/clipboard/ClipboardModule.kt
+++ b/packages/expo-clipboard/android/src/main/java/expo/modules/clipboard/ClipboardModule.kt
@@ -44,7 +44,7 @@ class ClipboardModule : Module() {
     Name(moduleName)
 
     // region Strings
-    AsyncFunction("getStringAsync" ) { options: GetStringOptions ->
+    AsyncFunction("getStringAsync") { options: GetStringOptions ->
       val item = clipboardManager.firstItem
       when (options.preferredFormat) {
         StringFormat.PLAIN -> item?.coerceToPlainText(context)
@@ -52,7 +52,7 @@ class ClipboardModule : Module() {
       } ?: ""
     }
 
-    AsyncFunction("setStringAsync" ) { content: String, options: SetStringOptions ->
+    AsyncFunction("setStringAsync") { content: String, options: SetStringOptions ->
       val clip = when (options.inputFormat) {
         StringFormat.PLAIN -> ClipData.newPlainText(null, content)
         StringFormat.HTML -> {
@@ -65,7 +65,7 @@ class ClipboardModule : Module() {
       return@AsyncFunction true
     }
 
-    AsyncFunction("hasStringAsync" ) {
+    AsyncFunction("hasStringAsync") {
       clipboardManager
         .primaryClipDescription
         ?.hasTextContent
@@ -74,7 +74,7 @@ class ClipboardModule : Module() {
     // endregion
 
     // region Images
-    AsyncFunction("getImageAsync" ) { options: GetImageOptions, promise: Promise ->
+    AsyncFunction("getImageAsync") { options: GetImageOptions, promise: Promise ->
       val imageUri = clipboardManager
         .takeIf { clipboardHasItemWithType("image/*") }
         ?.firstItem
@@ -100,7 +100,7 @@ class ClipboardModule : Module() {
       }
     }
 
-    AsyncFunction("setImageAsync" ) { imageData: String, promise: Promise ->
+    AsyncFunction("setImageAsync") { imageData: String, promise: Promise ->
       val exceptionHandler = CoroutineExceptionHandler { _, err ->
         err.printStackTrace()
         val rejectionCause = when (err) {
@@ -117,7 +117,7 @@ class ClipboardModule : Module() {
       }
     }
 
-    AsyncFunction("hasImageAsync" ) {
+    AsyncFunction("hasImageAsync") {
       clipboardManager.primaryClipDescription?.hasMimeType("image/*") == true
     }
     //endregion

--- a/packages/expo-clipboard/android/src/main/java/expo/modules/clipboard/ClipboardModule.kt
+++ b/packages/expo-clipboard/android/src/main/java/expo/modules/clipboard/ClipboardModule.kt
@@ -41,10 +41,10 @@ private enum class ContentType(val jsName: String) {
 
 class ClipboardModule : Module() {
   override fun definition() = ModuleDefinition {
-    name(moduleName)
+    Name(moduleName)
 
     // region Strings
-    function("getStringAsync") { options: GetStringOptions ->
+    AsyncFunction("getStringAsync" ) { options: GetStringOptions ->
       val item = clipboardManager.firstItem
       when (options.preferredFormat) {
         StringFormat.PLAIN -> item?.coerceToPlainText(context)
@@ -52,7 +52,7 @@ class ClipboardModule : Module() {
       } ?: ""
     }
 
-    function("setStringAsync") { content: String, options: SetStringOptions ->
+    AsyncFunction("setStringAsync" ) { content: String, options: SetStringOptions ->
       val clip = when (options.inputFormat) {
         StringFormat.PLAIN -> ClipData.newPlainText(null, content)
         StringFormat.HTML -> {
@@ -62,10 +62,10 @@ class ClipboardModule : Module() {
         }
       }
       clipboardManager.setPrimaryClip(clip)
-      return@function true
+      return@AsyncFunction true
     }
 
-    function("hasStringAsync") {
+    AsyncFunction("hasStringAsync" ) {
       clipboardManager
         .primaryClipDescription
         ?.hasTextContent
@@ -74,14 +74,14 @@ class ClipboardModule : Module() {
     // endregion
 
     // region Images
-    function("getImageAsync") { options: GetImageOptions, promise: Promise ->
+    AsyncFunction("getImageAsync" ) { options: GetImageOptions, promise: Promise ->
       val imageUri = clipboardManager
         .takeIf { clipboardHasItemWithType("image/*") }
         ?.firstItem
         ?.uri
         .ifNull {
           promise.resolve(null)
-          return@function
+          return@AsyncFunction
         }
 
       val exceptionHandler = CoroutineExceptionHandler { _, err ->
@@ -100,7 +100,7 @@ class ClipboardModule : Module() {
       }
     }
 
-    function("setImageAsync") { imageData: String, promise: Promise ->
+    AsyncFunction("setImageAsync" ) { imageData: String, promise: Promise ->
       val exceptionHandler = CoroutineExceptionHandler { _, err ->
         err.printStackTrace()
         val rejectionCause = when (err) {
@@ -117,20 +117,20 @@ class ClipboardModule : Module() {
       }
     }
 
-    function("hasImageAsync") {
+    AsyncFunction("hasImageAsync" ) {
       clipboardManager.primaryClipDescription?.hasMimeType("image/*") == true
     }
     //endregion
 
     // region Events
-    events(CLIPBOARD_CHANGED_EVENT_NAME)
+    Events(CLIPBOARD_CHANGED_EVENT_NAME)
 
-    onCreate {
+    OnCreate {
       clipboardEventEmitter = ClipboardEventEmitter()
       clipboardEventEmitter.attachListener()
     }
 
-    onDestroy {
+    OnDestroy {
       clipboardEventEmitter.detachListener()
       try {
         moduleCoroutineScope.cancel(ModuleDestroyedException())
@@ -139,11 +139,11 @@ class ClipboardModule : Module() {
       }
     }
 
-    onActivityEntersBackground {
+    OnActivityEntersBackground {
       clipboardEventEmitter.pauseListening()
     }
 
-    onActivityEntersForeground {
+    OnActivityEntersForeground {
       clipboardEventEmitter.resumeListening()
     }
     // endregion

--- a/packages/expo-clipboard/ios/ClipboardModule.swift
+++ b/packages/expo-clipboard/ios/ClipboardModule.swift
@@ -7,11 +7,11 @@ let onClipboardChanged = "onClipboardChanged"
 
 public class ClipboardModule: Module {
   public func definition() -> ModuleDefinition {
-    name("ExpoClipboard")
+    Name("ExpoClipboard")
 
     // MARK: Strings
 
-    function("getStringAsync") { (options: GetStringOptions) -> String in
+    AsyncFunction("getStringAsync") { (options: GetStringOptions) -> String in
       switch options.preferredFormat {
       case .plainText:
         return UIPasteboard.general.string ?? ""
@@ -20,7 +20,7 @@ public class ClipboardModule: Module {
       }
     }
 
-    function("setStringAsync") { (content: String?, options: SetStringOptions) -> Bool in
+    AsyncFunction("setStringAsync") { (content: String?, options: SetStringOptions) -> Bool in
       switch options.inputFormat {
       case .plainText:
         UIPasteboard.general.string = content
@@ -31,27 +31,27 @@ public class ClipboardModule: Module {
       return true
     }
 
-    function("hasStringAsync") { () -> Bool in
+    AsyncFunction("hasStringAsync") { () -> Bool in
       return UIPasteboard.general.hasStrings || UIPasteboard.general.hasHTML
     }
 
     // MARK: URLs
 
-    function("getUrlAsync") { () -> String? in
+    AsyncFunction("getUrlAsync") { () -> String? in
       return UIPasteboard.general.url?.absoluteString
     }
 
-    function("setUrlAsync") { (url: URL) in
+    AsyncFunction("setUrlAsync") { (url: URL) in
       UIPasteboard.general.url = url
     }
 
-    function("hasUrlAsync") { () -> Bool in
+    AsyncFunction("hasUrlAsync") { () -> Bool in
       return UIPasteboard.general.hasURLs
     }
 
     // MARK: Images
 
-    function("setImageAsync") { (content: String) in
+    AsyncFunction("setImageAsync") { (content: String) in
       guard let data = Data(base64Encoded: content),
             let image = UIImage(data: data) else {
         throw InvalidImageException(content)
@@ -59,11 +59,11 @@ public class ClipboardModule: Module {
       UIPasteboard.general.image = image
     }
 
-    function("hasImageAsync") { () -> Bool in
+    AsyncFunction("hasImageAsync") { () -> Bool in
       return UIPasteboard.general.hasImages
     }
 
-    function("getImageAsync") { (options: GetImageOptions) -> [String: Any]? in
+    AsyncFunction("getImageAsync") { (options: GetImageOptions) -> [String: Any]? in
       guard let image = UIPasteboard.general.image else {
         return nil
       }
@@ -84,9 +84,9 @@ public class ClipboardModule: Module {
 
     // MARK: Events
 
-    events(onClipboardChanged)
+    Events(onClipboardChanged)
 
-    onStartObserving {
+    OnStartObserving {
       NotificationCenter.default.removeObserver(self, name: UIPasteboard.changedNotification, object: nil)
       NotificationCenter.default.addObserver(
         self,
@@ -96,7 +96,7 @@ public class ClipboardModule: Module {
       )
     }
 
-    onStopObserving {
+    OnStopObserving {
       NotificationCenter.default.removeObserver(self, name: UIPasteboard.changedNotification, object: nil)
     }
   }

--- a/packages/expo-crypto/CHANGELOG.md
+++ b/packages/expo-crypto/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Migrated Expo modules definitions to the new naming convention. ([#17193](https://github.com/expo/expo/pull/17193) by [@tsapeta](https://github.com/tsapeta))
+
 ## 10.2.0 — 2022-04-18
 
 ### 🎉 New features

--- a/packages/expo-crypto/ios/CryptoModule.swift
+++ b/packages/expo-crypto/ios/CryptoModule.swift
@@ -5,12 +5,11 @@ import ExpoModulesCore
 
 public class CryptoModule: Module {
   public func definition() -> ModuleDefinition {
-    name("ExpoCrypto")
+    Name("ExpoCrypto")
 
-    function("digestStringAsync", digestString)
+    AsyncFunction("digestStringAsync", digestString)
 
-    function("digestString", digestString)
-      .runSynchronously()
+    Function("digestString", digestString)
   }
 }
 

--- a/packages/expo-eas-client/CHANGELOG.md
+++ b/packages/expo-eas-client/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Migrated Expo modules definitions to the new naming convention. ([#17193](https://github.com/expo/expo/pull/17193) by [@tsapeta](https://github.com/tsapeta))
+
 ## 0.2.1 — 2022-04-20
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-eas-client/android/src/main/java/expo/modules/easclient/EASClientModule.kt
+++ b/packages/expo-eas-client/android/src/main/java/expo/modules/easclient/EASClientModule.kt
@@ -10,9 +10,9 @@ class EASClientModule : Module() {
     }
 
   override fun definition() = ModuleDefinition {
-    name("EASClient")
+    Name("EASClient")
 
-    constants {
+    Constants {
       mapOf("clientID" to EASClientID(context).uuid.toString())
     }
   }

--- a/packages/expo-eas-client/ios/EASClient/EASClientModule.swift
+++ b/packages/expo-eas-client/ios/EASClient/EASClientModule.swift
@@ -4,9 +4,9 @@ import ExpoModulesCore
 
 public class EASClientModule: Module {
   public func definition() -> ModuleDefinition {
-    name("EASClient")
+    Name("EASClient")
 
-    constants([
+    Constants([
       "clientID": EASClientID.uuid().uuidString
     ])
   }

--- a/packages/expo-haptics/CHANGELOG.md
+++ b/packages/expo-haptics/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Migrated Expo modules definitions to the new naming convention. ([#17193](https://github.com/expo/expo/pull/17193) by [@tsapeta](https://github.com/tsapeta))
+
 ## 11.2.0 — 2022-04-18
 
 ### 🎉 New features

--- a/packages/expo-haptics/ios/HapticsModule.swift
+++ b/packages/expo-haptics/ios/HapticsModule.swift
@@ -2,21 +2,21 @@ import ExpoModulesCore
 
 public class HapticsModule: Module {
   public func definition() -> ModuleDefinition {
-    name("ExpoHaptics")
+    Name("ExpoHaptics")
 
-    function("notificationAsync") { (notificationType: NotificationType) in
+    AsyncFunction("notificationAsync") { (notificationType: NotificationType) in
       let generator = UINotificationFeedbackGenerator()
       generator.prepare()
       generator.notificationOccurred(notificationType.toFeedbackType())
     }
 
-    function("impactAsync") { (style: ImpactStyle) in
+    AsyncFunction("impactAsync") { (style: ImpactStyle) in
       let generator = UIImpactFeedbackGenerator(style: style.toFeedbackStyle())
       generator.prepare()
       generator.impactOccurred()
     }
 
-    function("selectionAsync") {
+    AsyncFunction("selectionAsync") {
       let generator = UISelectionFeedbackGenerator()
       generator.prepare()
       generator.selectionChanged()

--- a/packages/expo-image-manipulator/CHANGELOG.md
+++ b/packages/expo-image-manipulator/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Migrated Expo modules definitions to the new naming convention. ([#17193](https://github.com/expo/expo/pull/17193) by [@tsapeta](https://github.com/tsapeta))
+
 ## 10.3.1 — 2022-04-20
 
 ### 🐛 Bug fixes

--- a/packages/expo-image-manipulator/ios/ImageManipulatorModule.swift
+++ b/packages/expo-image-manipulator/ios/ImageManipulatorModule.swift
@@ -10,9 +10,9 @@ public class ImageManipulatorModule: Module {
   typealias SaveImageResult = (url: URL, data: Data)
 
   public func definition() -> ModuleDefinition {
-    name("ExpoImageManipulator")
+    Name("ExpoImageManipulator")
 
-    function("manipulateAsync", manipulateImage)
+    AsyncFunction("manipulateAsync", manipulateImage)
       .runOnQueue(.main)
   }
 

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Migrated Expo modules definitions to the new naming convention. ([#17193](https://github.com/expo/expo/pull/17193) by [@tsapeta](https://github.com/tsapeta))
+
 ## 13.1.1 — 2022-04-27
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-image-picker/ios/ImagePickerModule.swift
+++ b/packages/expo-image-picker/ios/ImagePickerModule.swift
@@ -22,9 +22,9 @@ enum OperationType {
 public class ImagePickerModule: Module, OnMediaPickingResultHandler {
   public func definition() -> ModuleDefinition {
     // TODO: (@bbarthec) change to "ExpoImagePicker" and propagate to other platforms
-    name("ExponentImagePicker")
+    Name("ExponentImagePicker")
 
-    onCreate {
+    OnCreate {
       self.appContext?.permissions?.register([
         CameraPermissionRequester(),
         MediaLibraryPermissionRequester(),
@@ -32,23 +32,23 @@ public class ImagePickerModule: Module, OnMediaPickingResultHandler {
       ])
     }
 
-    function("getCameraPermissionsAsync", { (promise: Promise) in
+    AsyncFunction("getCameraPermissionsAsync", { (promise: Promise) in
       self.handlePermissionRequest(requesterClass: CameraPermissionRequester.self, operationType: .get, promise: promise)
     })
 
-    function("getMediaLibraryPermissionsAsync", { (writeOnly: Bool, promise: Promise) in
+    AsyncFunction("getMediaLibraryPermissionsAsync", { (writeOnly: Bool, promise: Promise) in
       self.handlePermissionRequest(requesterClass: self.getMediaLibraryPermissionRequester(writeOnly), operationType: .get, promise: promise)
     })
 
-    function("requestCameraPermissionsAsync", { (promise: Promise) in
+    AsyncFunction("requestCameraPermissionsAsync", { (promise: Promise) in
       self.handlePermissionRequest(requesterClass: CameraPermissionRequester.self, operationType: .ask, promise: promise)
     })
 
-    function("requestMediaLibraryPermissionsAsync", { (writeOnly: Bool, promise: Promise) in
+    AsyncFunction("requestMediaLibraryPermissionsAsync", { (writeOnly: Bool, promise: Promise) in
       self.handlePermissionRequest(requesterClass: self.getMediaLibraryPermissionRequester(writeOnly), operationType: .ask, promise: promise)
     })
 
-    function("launchCameraAsync", { (options: ImagePickerOptions, promise: Promise) -> Void in
+    AsyncFunction("launchCameraAsync", { (options: ImagePickerOptions, promise: Promise) -> Void in
       guard let permissions = self.appContext?.permissions else {
         return promise.reject(PermissionsModuleNotFoundException())
       }
@@ -58,11 +58,13 @@ public class ImagePickerModule: Module, OnMediaPickingResultHandler {
       }
 
       self.launchImagePicker(sourceType: .camera, options: options, promise: promise)
-    }).runOnQueue(DispatchQueue.main)
+    })
+    .runOnQueue(DispatchQueue.main)
 
-    function("launchImageLibraryAsync", { (options: ImagePickerOptions, promise: Promise) in
+    AsyncFunction("launchImageLibraryAsync", { (options: ImagePickerOptions, promise: Promise) in
       self.launchImagePicker(sourceType: .photoLibrary, options: options, promise: promise)
-    }).runOnQueue(DispatchQueue.main)
+    })
+    .runOnQueue(DispatchQueue.main)
   }
 
   private var currentPickingContext: PickingContext?

--- a/packages/expo-keep-awake/CHANGELOG.md
+++ b/packages/expo-keep-awake/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Migrated Expo modules definitions to the new naming convention. ([#17193](https://github.com/expo/expo/pull/17193) by [@tsapeta](https://github.com/tsapeta))
+
 ## 10.1.0 — 2022-04-18
 
 ### 🎉 New features

--- a/packages/expo-keep-awake/ios/KeepAwakeModule.swift
+++ b/packages/expo-keep-awake/ios/KeepAwakeModule.swift
@@ -6,18 +6,18 @@ public final class KeepAwakeModule: Module {
   private var activeTags = Set<String>()
 
   public func definition() -> ModuleDefinition {
-    name("ExpoKeepAwake")
+    Name("ExpoKeepAwake")
 
-    function("activate", activate)
-    function("deactivate", deactivate)
-    function("isActivated", isActivated)
+    AsyncFunction("activate", activate)
+    AsyncFunction("deactivate", deactivate)
+    AsyncFunction("isActivated", isActivated)
 
-    onAppEntersForeground {
+    OnAppEntersForeground {
       if !self.activeTags.isEmpty {
         setActivated(true)
       }
     }
-    onAppEntersBackground {
+    OnAppEntersBackground {
       if !self.activeTags.isEmpty {
         setActivated(false)
       }

--- a/packages/expo-linear-gradient/CHANGELOG.md
+++ b/packages/expo-linear-gradient/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Migrated Expo modules definitions to the new naming convention. ([#17193](https://github.com/expo/expo/pull/17193) by [@tsapeta](https://github.com/tsapeta))
+
 ## 11.3.0 — 2022-04-18
 
 ### 🐛 Bug fixes

--- a/packages/expo-linear-gradient/android/src/main/java/expo/modules/lineargradient/LinearGradientModule.kt
+++ b/packages/expo-linear-gradient/android/src/main/java/expo/modules/lineargradient/LinearGradientModule.kt
@@ -7,31 +7,31 @@ typealias ViewType = LinearGradientView
 
 class LinearGradientModule : Module() {
   override fun definition() = ModuleDefinition {
-    name("ExpoLinearGradient")
-    viewManager {
-      view { context ->
+    Name("ExpoLinearGradient")
+    ViewManager {
+      View { context ->
         LinearGradientView(context)
       }
 
-      prop("colors") { view: ViewType, colors: IntArray ->
+      Prop("colors") { view: ViewType, colors: IntArray ->
         view.setColors(colors)
       }
 
-      prop("locations") { view: ViewType, locations: FloatArray? ->
+      Prop("locations") { view: ViewType, locations: FloatArray? ->
         locations?.let {
           view.setLocations(it)
         }
       }
 
-      prop("startPoint") { view: ViewType, startPoint: Pair<Float, Float>? ->
+      Prop("startPoint") { view: ViewType, startPoint: Pair<Float, Float>? ->
         view.setStartPosition(startPoint?.first ?: 0.5f, startPoint?.second ?: 0f)
       }
 
-      prop("endPoint") { view: ViewType, endPoint: Pair<Float, Float>? ->
+      Prop("endPoint") { view: ViewType, endPoint: Pair<Float, Float>? ->
         view.setEndPosition(endPoint?.first ?: 0.5f, endPoint?.second ?: 1f)
       }
 
-      prop("borderRadii") { view: ViewType, borderRadii: FloatArray? ->
+      Prop("borderRadii") { view: ViewType, borderRadii: FloatArray? ->
         view.setBorderRadii(borderRadii ?: FloatArray(8) { 0f })
       }
     }

--- a/packages/expo-linear-gradient/ios/LinearGradientModule.swift
+++ b/packages/expo-linear-gradient/ios/LinearGradientModule.swift
@@ -5,26 +5,26 @@ import ExpoModulesCore
 
 public class LinearGradientModule: Module {
   public func definition() -> ModuleDefinition {
-    name("ExpoLinearGradient")
+    Name("ExpoLinearGradient")
 
-    viewManager {
-      view {
+    ViewManager {
+      View {
         LinearGradientView()
       }
 
-      prop("colors") { (view: LinearGradientView, colors: [CGColor]) in
+      Prop("colors") { (view: LinearGradientView, colors: [CGColor]) in
         view.gradientLayer.setColors(colors)
       }
 
-      prop("startPoint") { (view: LinearGradientView, startPoint: CGPoint?) in
+      Prop("startPoint") { (view: LinearGradientView, startPoint: CGPoint?) in
         view.gradientLayer.setStartPoint(startPoint)
       }
 
-      prop("endPoint") { (view: LinearGradientView, endPoint: CGPoint?) in
+      Prop("endPoint") { (view: LinearGradientView, endPoint: CGPoint?) in
         view.gradientLayer.setEndPoint(endPoint)
       }
 
-      prop("locations") { (view: LinearGradientView, locations: [CGFloat]?) in
+      Prop("locations") { (view: LinearGradientView, locations: [CGFloat]?) in
         view.gradientLayer.setLocations(locations)
       }
     }

--- a/packages/expo-localization/CHANGELOG.md
+++ b/packages/expo-localization/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Migrated Expo modules definitions to the new naming convention. ([#17193](https://github.com/expo/expo/pull/17193) by [@tsapeta](https://github.com/tsapeta))
+
 ## 13.0.0 — 2022-04-18
 
 ### 🛠 Breaking changes

--- a/packages/expo-localization/ios/LocalizationModule.swift
+++ b/packages/expo-localization/ios/LocalizationModule.swift
@@ -5,13 +5,13 @@ import ExpoModulesCore
 
 public class LocalizationModule: Module {
   public func definition() -> ModuleDefinition {
-    name("ExpoLocalization")
+    Name("ExpoLocalization")
 
-    constants {
+    Constants {
       return Self.getCurrentLocalization()
     }
 
-    function("getLocalizationAsync") {
+    AsyncFunction("getLocalizationAsync") {
       return Self.getCurrentLocalization()
     }
   }

--- a/packages/expo-module-template/android/src/main/java/{%= project.package %}/{%- project.name %}Module.kt
+++ b/packages/expo-module-template/android/src/main/java/{%= project.package %}/{%- project.name %}Module.kt
@@ -5,18 +5,18 @@ import expo.modules.kotlin.modules.ModuleDefinition
 
 class <%- project.name %>Module : Module() {
   override fun definition() = ModuleDefinition {
-    name("<%- project.name %>")
+    Name("<%- project.name %>")
 
-    function("helloAsync") { options: Map<String, String> ->
+    AsyncFunction("helloAsync") { options: Map<String, String> ->
       println("Hello 👋")
     }
 
-    viewManager {
-      view { context -> 
+    ViewManager {
+      View { context -> 
         <%- project.name %>View(context) 
       }
 
-      prop("name") { view: <%- project.name %>View, prop: String ->
+      Prop("name") { view: <%- project.name %>View, prop: String ->
         println(prop)
       }
     }

--- a/packages/expo-module-template/ios/{%- project.name %}Module.swift
+++ b/packages/expo-module-template/ios/{%- project.name %}Module.swift
@@ -2,18 +2,18 @@ import ExpoModulesCore
 
 public class <%- project.name %>Module: Module {
   public func definition() -> ModuleDefinition {
-    name("<%- project.name %>")
+    Name("<%- project.name %>")
 
-    function("helloAsync") { (options: [String: String]) in
+    AsyncFunction("helloAsync") { (options: [String: String]) in
       print("Hello 👋")
     }
 
-    viewManager {
-      view {
+    ViewManager {
+      View {
         <%- project.name %>View()
       }
 
-      prop("name") { (view: <%- project.name %>View, prop: String) in
+      Prop("name") { (view: <%- project.name %>View, prop: String) in
         print(prop)
       }
     }

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Migrated Expo modules definitions to the new naming convention. ([#17193](https://github.com/expo/expo/pull/17193) by [@tsapeta](https://github.com/tsapeta))
+
 ## 0.9.0 — 2022-04-21
 
 ### ⚠️ Notices

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/defaultmodules/ErrorManagerModule.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/defaultmodules/ErrorManagerModule.kt
@@ -9,8 +9,8 @@ private const val onNewException = "ExpoModulesCoreErrorManager.onNewException"
 
 class ErrorManagerModule : Module() {
   override fun definition() = ModuleDefinition {
-    name("ExpoModulesCoreErrorManager")
-    events(onNewException)
+    Name("ExpoModulesCoreErrorManager")
+    Events(onNewException)
   }
 
   fun reportExceptionToLogBox(codedException: CodedException) {

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/benchmarks/NewArchitectureBenchmark.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/benchmarks/NewArchitectureBenchmark.kt
@@ -22,11 +22,11 @@ class NewArchitectureBenchmark {
     }
 
     override fun definition() = ModuleDefinition {
-      name("MyModule")
-      function("m1") { -> retNull() }
-      function("m2") { _: Int, _: Int -> retNull() }
-      function("m3") { _: IntArray -> retNull() }
-      function("m4") { _: String -> retNull() }
+      Name("MyModule")
+      AsyncFunction("m1" ) { -> retNull() }
+      AsyncFunction("m2" ) { _: Int, _: Int -> retNull() }
+      AsyncFunction("m3" ) { _: IntArray -> retNull() }
+      AsyncFunction("m4" ) { _: String -> retNull() }
     }
   }
 

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/benchmarks/NewArchitectureBenchmark.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/benchmarks/NewArchitectureBenchmark.kt
@@ -23,10 +23,10 @@ class NewArchitectureBenchmark {
 
     override fun definition() = ModuleDefinition {
       Name("MyModule")
-      AsyncFunction("m1" ) { -> retNull() }
-      AsyncFunction("m2" ) { _: Int, _: Int -> retNull() }
-      AsyncFunction("m3" ) { _: IntArray -> retNull() }
-      AsyncFunction("m4" ) { _: String -> retNull() }
+      AsyncFunction("m1") { -> retNull() }
+      AsyncFunction("m2") { _: Int, _: Int -> retNull() }
+      AsyncFunction("m3") { _: IntArray -> retNull() }
+      AsyncFunction("m4") { _: String -> retNull() }
     }
   }
 

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/KotlinInteropModuleRegistryTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/KotlinInteropModuleRegistryTest.kt
@@ -23,14 +23,14 @@ private class TestRecord : Record {
 
 private class TestModule_1 : Module() {
   override fun definition() = ModuleDefinition {
-    name("test-1")
-    function("f1") {
+    Name("test-1")
+    AsyncFunction("f1") {
       throw NullPointerException()
     }
-    function<Int, TestRecord>("f2") {
+    AsyncFunction<Int, TestRecord>("f2") {
       throw NullPointerException()
     }
-    constants {
+    Constants {
       mapOf(
         "c1" to 123,
         "c2" to "123"
@@ -41,15 +41,15 @@ private class TestModule_1 : Module() {
 
 private class TestModule_2 : Module() {
   override fun definition() = ModuleDefinition {
-    name("test-2")
-    function("f1") {
+    Name("test-2")
+    AsyncFunction("f1") {
       throw TestException()
     }
-    function("f2") { arg1: Int ->
+    AsyncFunction("f2" ) { arg1: Int ->
       arg1
     }
-    viewManager {
-      view { mockk() }
+    ViewManager {
+      View { mockk() }
     }
   }
 }

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/KotlinInteropModuleRegistryTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/KotlinInteropModuleRegistryTest.kt
@@ -45,7 +45,7 @@ private class TestModule_2 : Module() {
     AsyncFunction("f1") {
       throw TestException()
     }
-    AsyncFunction("f2" ) { arg1: Int ->
+    AsyncFunction("f2") { arg1: Int ->
       arg1
     }
     ViewManager {

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/ModuleHolderTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/ModuleHolderTest.kt
@@ -12,7 +12,7 @@ import org.junit.Test
 
 class EmptyModule : Module() {
   override fun definition() = ModuleDefinition {
-    name("empty-module")
+    Name("empty-module")
   }
 }
 

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/ModuleRegistryTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/ModuleRegistryTest.kt
@@ -10,13 +10,13 @@ import java.lang.ref.WeakReference
 
 class M1 : Module() {
   override fun definition() = ModuleDefinition {
-    name("m1")
+    Name("m1")
   }
 }
 
 class M2 : Module() {
   override fun definition() = ModuleDefinition {
-    name("m2")
+    Name("m2")
   }
 }
 

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/modules/ModuleDefinitionBuilderTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/modules/ModuleDefinitionBuilderTest.kt
@@ -18,7 +18,7 @@ class ModuleDefinitionBuilderTest {
 
   private class TestModuleWithName : Module() {
     override fun definition() = ModuleDefinition {
-      name("OverriddenName")
+      Name("OverriddenName")
     }
   }
 
@@ -30,7 +30,7 @@ class ModuleDefinitionBuilderTest {
 
     Assert.assertThrows(IllegalArgumentException::class.java) {
       unboundModuleDefinition {
-        function("method") { _: Int, _: Int -> }
+        AsyncFunction("method") { _: Int, _: Int -> }
       }
     }
   }
@@ -41,12 +41,12 @@ class ModuleDefinitionBuilderTest {
     val moduleConstants = emptyMap<String, Any?>()
 
     val moduleDefinition = unboundModuleDefinition {
-      name(moduleName)
-      constants {
+      Name(moduleName)
+      Constants {
         moduleConstants
       }
-      function("m1") { _: Int -> }
-      function("m2") { _: Int, _: Promise -> }
+      AsyncFunction("m1") { _: Int -> }
+      AsyncFunction("m2") { _: Int, _: Promise -> }
     }
 
     Truth.assertThat(moduleDefinition.name).isEqualTo(moduleName)
@@ -60,9 +60,9 @@ class ModuleDefinitionBuilderTest {
     val moduleName = "Module"
 
     val moduleDefinition = unboundModuleDefinition {
-      name(moduleName)
-      viewManager {
-        view { mockk() }
+      Name(moduleName)
+      ViewManager {
+        View { mockk() }
       }
     }
 
@@ -75,12 +75,12 @@ class ModuleDefinitionBuilderTest {
     val moduleName = "Module"
 
     val moduleDefinition = unboundModuleDefinition {
-      name(moduleName)
-      onCreate { }
-      onDestroy { }
-      onActivityDestroys { }
-      onActivityEntersForeground { }
-      onActivityEntersBackground { }
+      Name(moduleName)
+      OnCreate { }
+      OnDestroy { }
+      OnActivityDestroys { }
+      OnActivityEntersForeground { }
+      OnActivityEntersBackground { }
     }
 
     Truth.assertThat(moduleDefinition.name).isEqualTo(moduleName)
@@ -94,8 +94,8 @@ class ModuleDefinitionBuilderTest {
   @Test
   fun `onStartObserving should be translated into method`() {
     val moduleDefinition = unboundModuleDefinition {
-      name("module")
-      onStartObserving { }
+      Name("module")
+      OnStartObserving { }
     }
 
     Truth.assertThat(moduleDefinition.methods).containsKey("startObserving")
@@ -104,8 +104,8 @@ class ModuleDefinitionBuilderTest {
   @Test
   fun `onStopObserving should be translated into method`() {
     val moduleDefinition = unboundModuleDefinition {
-      name("module")
-      onStopObserving { }
+      Name("module")
+      OnStopObserving { }
     }
 
     Truth.assertThat(moduleDefinition.methods).containsKey("stopObserving")

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/modules/ModuleHolderTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/modules/ModuleHolderTest.kt
@@ -14,9 +14,9 @@ class ModuleHolderTest {
 
     class MyModule : Module() {
       override fun definition() = ModuleDefinition {
-        name("my-module")
-        onCreate { onCreateCalls++ }
-        onDestroy { onDestroyCalls++ }
+        Name("my-module")
+        OnCreate { onCreateCalls++ }
+        OnDestroy { onDestroyCalls++ }
       }
     }
 

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/views/ViewManagerDefinitionBuilderTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/views/ViewManagerDefinitionBuilderTest.kt
@@ -14,7 +14,7 @@ class ViewManagerDefinitionBuilderTest {
   fun `builder should fail without view factory`() {
     val builder = ViewManagerDefinitionBuilder()
       .apply {
-        prop("only-prop") { _: View, _: Int -> }
+        Prop("only-prop") { _: View, _: Int -> }
       }
 
     try {
@@ -32,13 +32,13 @@ class ViewManagerDefinitionBuilderTest {
 
     val definition = ViewManagerDefinitionBuilder()
       .apply {
-        view {
+        View {
           viewFactoryCalls++
           mockk<ListView>()
         }
 
-        prop<ListView, Int>("p1") { _, _ -> p1Calls++ }
-        prop<ListView, Int>("p2") { _, _ -> p2Calls++ }
+        Prop<ListView, Int>("p1") { _, _ -> p1Calls++ }
+        Prop<ListView, Int>("p2") { _, _ -> p2Calls++ }
       }
       .build()
 

--- a/packages/expo-modules-core/ios/Swift/Modules/AnyModule.swift
+++ b/packages/expo-modules-core/ios/Swift/Modules/AnyModule.swift
@@ -16,8 +16,8 @@ public protocol AnyModule: AnyObject, AnyArgument {
 
    ```
    public func definition() -> ModuleDefinition {
-     name("MyModule")
-     function("myFunction") { (a: String, b: String) in
+     Name("MyModule")
+     AsyncFunction("myFunction") { (a: String, b: String) in
        "\(a) \(b)"
      }
    }
@@ -37,7 +37,7 @@ public protocol AnyModule: AnyObject, AnyArgument {
    just specify an argument of type `Promise` as the last one and use its `resolve` or `reject` functions.
 
    ```
-   function("myFunction") { (promise: Promise) in
+   AsyncFunction("myFunction") { (promise: Promise) in
      DispatchQueue.main.async {
        promise.resolve("return value obtained in async callback")
      }

--- a/packages/expo-modules-test-core/android/src/main/java/expo/modules/test/core/ModuleMockInvocationHandler.kt
+++ b/packages/expo-modules-test-core/android/src/main/java/expo/modules/test/core/ModuleMockInvocationHandler.kt
@@ -22,11 +22,11 @@ class TestCodedException(
  * exported function or to the module controller if the method doesn't exist in the module definition.
  *
  * Methods mapping:
- *   function("name") { args: ArgsType -> return ReturnType } can be invoked using one of the following methods mapping rules:
+ *   AsyncFunction("name") { args: ArgsType -> return ReturnType } can be invoked using one of the following methods mapping rules:
  *     - [non-promise mapping] fun ModuleTestInterface.name(args: ArgsType): ReturnType
  *     - [promise mapping] fun ModuleTestInterface.name(args: ArgsType, promise: Promise): Unit
  *
- *   function("name") { args: ArgsType, promise: Promise -> promise.resolve(ReturnType) } can be invoked using one of the following methods mapping rules:
+ *   AsyncFunction("name") { args: ArgsType, promise: Promise -> promise.resolve(ReturnType) } can be invoked using one of the following methods mapping rules:
  *     - [non-promise mapping] fun ModuleTestInterface.name(args: ArgsType): ReturnType
  *     - [promise mapping] fun ModuleTestInterface.name(args: ArgsType, promise: Promise): Unit
  *

--- a/packages/expo-random/CHANGELOG.md
+++ b/packages/expo-random/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Migrated Expo modules definitions to the new naming convention. ([#17193](https://github.com/expo/expo/pull/17193) by [@tsapeta](https://github.com/tsapeta))
+
 ## 12.2.0 — 2022-04-18
 
 ### 🎉 New features

--- a/packages/expo-random/ios/RandomModule.swift
+++ b/packages/expo-random/ios/RandomModule.swift
@@ -5,12 +5,11 @@ import ExpoModulesCore
 
 public class RandomModule: Module {
   public func definition() -> ModuleDefinition {
-    name("ExpoRandom")
+    Name("ExpoRandom")
 
-    function("getRandomBase64StringAsync", getRandomBase64String)
+    AsyncFunction("getRandomBase64StringAsync", getRandomBase64String)
 
-    function("getRandomBase64String", getRandomBase64String)
-      .runSynchronously()
+    Function("getRandomBase64String", getRandomBase64String)
   }
 }
 

--- a/packages/expo-system-ui/CHANGELOG.md
+++ b/packages/expo-system-ui/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Migrated Expo modules definitions to the new naming convention. ([#17193](https://github.com/expo/expo/pull/17193) by [@tsapeta](https://github.com/tsapeta))
+
 ## 1.2.0 — 2022-04-18
 
 ### 💡 Others

--- a/packages/expo-system-ui/ios/ExpoSystemUI/ExpoSystemUIModule.swift
+++ b/packages/expo-system-ui/ios/ExpoSystemUI/ExpoSystemUIModule.swift
@@ -4,20 +4,20 @@ import ExpoModulesCore
 
 public class ExpoSystemUIModule: Module {
   public func definition() -> ModuleDefinition {
-    name("ExpoSystemUI")
+    Name("ExpoSystemUI")
 
-    onCreate {
+    OnCreate {
       // TODO: Maybe read from the app manifest instead of from Info.plist.
       // Set / reset the initial color on reload and app start.
       let color = Bundle.main.object(forInfoDictionaryKey: "RCTRootViewBackgroundColor") as? Int
       Self.setBackgroundColorAsync(color: color)
     }
 
-    function("getBackgroundColorAsync") { () -> String? in
+    AsyncFunction("getBackgroundColorAsync") { () -> String? in
       Self.getBackgroundColor()
     }
 
-    function("setBackgroundColorAsync") { (color: Int) in
+    AsyncFunction("setBackgroundColorAsync") { (color: Int) in
       Self.setBackgroundColorAsync(color: color)
     }
   }

--- a/packages/expo-tracking-transparency/CHANGELOG.md
+++ b/packages/expo-tracking-transparency/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Migrated Expo modules definitions to the new naming convention. ([#17193](https://github.com/expo/expo/pull/17193) by [@tsapeta](https://github.com/tsapeta))
+
 ## 2.2.0 — 2022-04-18
 
 ### 💡 Others

--- a/packages/expo-tracking-transparency/ios/EXTrackingTransparency/TrackingTransparencyModule.swift
+++ b/packages/expo-tracking-transparency/ios/EXTrackingTransparency/TrackingTransparencyModule.swift
@@ -2,13 +2,13 @@ import ExpoModulesCore
 
 public class TrackingTransparencyModule: Module {
   public func definition() -> ModuleDefinition {
-    name("ExpoTrackingTransparency")
+    Name("ExpoTrackingTransparency")
 
-    onCreate {
+    OnCreate {
       EXPermissionsMethodsDelegate.register([EXTrackingPermissionRequester()], withPermissionsManager: self.appContext?.permissions)
     }
 
-    function("getPermissionsAsync") { (promise: Promise) in
+    AsyncFunction("getPermissionsAsync") { (promise: Promise) in
       EXPermissionsMethodsDelegate.getPermissionWithPermissionsManager(
         self.appContext?.permissions,
         withRequester: EXTrackingPermissionRequester.self,
@@ -17,7 +17,7 @@ public class TrackingTransparencyModule: Module {
       )
     }
 
-    function("requestPermissionsAsync") { (promise: Promise) in
+    AsyncFunction("requestPermissionsAsync") { (promise: Promise) in
       EXPermissionsMethodsDelegate.askForPermission(
         withPermissionsManager: self.appContext?.permissions,
         withRequester: EXTrackingPermissionRequester.self,

--- a/packages/expo-web-browser/CHANGELOG.md
+++ b/packages/expo-web-browser/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Migrated Expo modules definitions to the new naming convention. ([#17193](https://github.com/expo/expo/pull/17193) by [@tsapeta](https://github.com/tsapeta))
+
 ## 10.2.0 — 2022-04-18
 
 ### 🎉 New features

--- a/packages/expo-web-browser/ios/WebBrowserModule.swift
+++ b/packages/expo-web-browser/ios/WebBrowserModule.swift
@@ -9,9 +9,9 @@ final public class WebBrowserModule: Module {
   private var currentAuthSession: WebAuthSession?
 
   public func definition() -> ModuleDefinition {
-    name("ExpoWebBrowser")
+    Name("ExpoWebBrowser")
 
-    function("openBrowserAsync") { (url: URL, options: WebBrowserOptions, promise: Promise) throws in
+    AsyncFunction("openBrowserAsync") { (url: URL, options: WebBrowserOptions, promise: Promise) throws in
       guard self.currentWebBrowserSession?.isOpen != true else {
         throw WebBrowserAlreadyOpenException()
       }
@@ -20,7 +20,7 @@ final public class WebBrowserModule: Module {
     }
     .runOnQueue(.main)
 
-    function("dismissBrowser") {
+    AsyncFunction("dismissBrowser") {
       self.currentWebBrowserSession?.dismiss()
       self.currentWebBrowserSession = nil
     }
@@ -28,7 +28,7 @@ final public class WebBrowserModule: Module {
 
     // MARK: - AuthSession
 
-    function("openAuthSessionAsync") { (authUrl: URL, redirectUrl: URL, options: AuthSessionOptions, promise: Promise) throws in
+    AsyncFunction("openAuthSessionAsync") { (authUrl: URL, redirectUrl: URL, options: AuthSessionOptions, promise: Promise) throws in
       guard self.currentAuthSession?.isOpen != true else {
         throw WebBrowserAlreadyOpenException()
       }
@@ -37,7 +37,7 @@ final public class WebBrowserModule: Module {
     }
     .runOnQueue(.main)
 
-    function("dismissAuthSession") {
+    AsyncFunction("dismissAuthSession") {
       self.currentAuthSession?.dismiss()
       self.currentAuthSession = nil
     }
@@ -45,9 +45,9 @@ final public class WebBrowserModule: Module {
 
     // MARK: - Stubs for jest-expo-mock-generator
 
-    function("warmUpAsync") {}
-    function("coolDownAsync") {}
-    function("mayInitWithUrlAsync") {}
-    function("getCustomTabsSupportingBrowsers") {}
+    AsyncFunction("warmUpAsync") {}
+    AsyncFunction("coolDownAsync") {}
+    AsyncFunction("mayInitWithUrlAsync") {}
+    AsyncFunction("getCustomTabsSupportingBrowsers") {}
   }
 }


### PR DESCRIPTION
# Why

Follow up on #17098 and #17153 
The packages for SDK45 used the deprecated names for compatibility reasons, but now we can migrate them to use the new names of the components.

# How

Migrated the definition components on iOS and Android with the following rule:
- `function` -> `AsyncFunction`, or `Function` if it had `.runSynchronously()`
- capitalized all other components

Also updated the `expo-module-template`

# Test Plan

Tests are passing
Manually checked NCL and test-suite
