### PR TITLE
[expo-gl-cpp] Use array buffer to reanimated worklet runtime

### DIFF
--- a/ios/Exponent/Versioned/Core/EXVersionManager.mm
+++ b/ios/Exponent/Versioned/Core/EXVersionManager.mm
@@ -548,10 +548,19 @@ RCT_EXTERN void EXRegisterScopedModule(Class, ...);
     }
     EX_ENSURE_STRONGIFY(self);
     auto reanimatedModule = reanimated::createReanimatedModule(bridge, bridge.jsCallInvoker);
+    auto workletRuntimeValue = runtime
+        .global()
+        .getProperty(runtime, "ArrayBuffer")
+        .asObject(runtime)
+        .asFunction(runtime)
+        .callAsConstructor(runtime, {static_cast<double>(sizeof(void*))});
+    uintptr_t* workletRuntimeData = reinterpret_cast<uintptr_t*>(
+        workletRuntimeValue.getObject(runtime).getArrayBuffer(runtime).data(runtime));
+    workletRuntimeData[0] = reinterpret_cast<uintptr_t>(reanimatedModule->runtime.get());
     runtime.global().setProperty(
         runtime,
         "_WORKLET_RUNTIME",
-        static_cast<double>(reinterpret_cast<std::uintptr_t>(reanimatedModule->runtime.get())));
+        workletRuntimeValue);
 
     runtime.global().setProperty(
          runtime,

--- a/ios/vendored/sdk44/react-native-reanimated/ios/native/ABI44_0_0REAInitializer.mm
+++ b/ios/vendored/sdk44/react-native-reanimated/ios/native/ABI44_0_0REAInitializer.mm
@@ -45,10 +45,19 @@ JSIExecutor::RuntimeInstaller ABI44_0_0REAJSIExecutorRuntimeInstaller(
     auto callInvoker = std::make_shared<ABI44_0_0React::BridgeJSCallInvoker>(bridge.reactInstance);
     auto reanimatedModule = ABI44_0_0reanimated::createReanimatedModule(bridge, callInvoker);
 #endif
+    auto workletRuntimeValue = runtime
+        .global()
+        .getProperty(runtime, "ArrayBuffer")
+        .asObject(runtime)
+        .asFunction(runtime)
+        .callAsConstructor(runtime, {static_cast<double>(sizeof(void*))});
+    uintptr_t* workletRuntimeData = reinterpret_cast<uintptr_t*>(
+        workletRuntimeValue.getObject(runtime).getArrayBuffer(runtime).data(runtime));
+    workletRuntimeData[0] = reinterpret_cast<uintptr_t>(reanimatedModule->runtime.get());
     runtime.global().setProperty(
         runtime,
         "_WORKLET_RUNTIME",
-        static_cast<double>(reinterpret_cast<std::uintptr_t>(reanimatedModule->runtime.get())));
+        workletRuntimeValue);
 
     runtime.global().setProperty(
         runtime,

--- a/ios/vendored/sdk45/react-native-reanimated/ios/native/ABI45_0_0REAInitializer.mm
+++ b/ios/vendored/sdk45/react-native-reanimated/ios/native/ABI45_0_0REAInitializer.mm
@@ -45,10 +45,19 @@ JSIExecutor::RuntimeInstaller ABI45_0_0REAJSIExecutorRuntimeInstaller(
     auto callInvoker = std::make_shared<ABI45_0_0React::BridgeJSCallInvoker>(bridge.reactInstance);
     auto reanimatedModule = ABI45_0_0reanimated::createReanimatedModule(bridge, callInvoker);
 #endif
+    auto workletRuntimeValue = runtime
+        .global()
+        .getProperty(runtime, "ArrayBuffer")
+        .asObject(runtime)
+        .asFunction(runtime)
+        .callAsConstructor(runtime, {static_cast<double>(sizeof(void*))});
+    uintptr_t* workletRuntimeData = reinterpret_cast<uintptr_t*>(
+        workletRuntimeValue.getObject(runtime).getArrayBuffer(runtime).data(runtime));
+    workletRuntimeData[0] = reinterpret_cast<uintptr_t>(reanimatedModule->runtime.get());
     runtime.global().setProperty(
         runtime,
         "_WORKLET_RUNTIME",
-        static_cast<double>(reinterpret_cast<std::uintptr_t>(reanimatedModule->runtime.get())));
+        workletRuntimeValue);
 
     runtime.global().setProperty(
         runtime,

--- a/ios/vendored/unversioned/react-native-reanimated/ios/native/REAInitializer.mm
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/native/REAInitializer.mm
@@ -45,10 +45,19 @@ JSIExecutor::RuntimeInstaller REAJSIExecutorRuntimeInstaller(
     auto callInvoker = std::make_shared<react::BridgeJSCallInvoker>(bridge.reactInstance);
     auto reanimatedModule = reanimated::createReanimatedModule(bridge, callInvoker);
 #endif
+    auto workletRuntimeValue = runtime
+        .global()
+        .getProperty(runtime, "ArrayBuffer")
+        .asObject(runtime)
+        .asFunction(runtime)
+        .callAsConstructor(runtime, {static_cast<double>(sizeof(void*))});
+    uintptr_t* workletRuntimeData = reinterpret_cast<uintptr_t*>(
+        workletRuntimeValue.getObject(runtime).getArrayBuffer(runtime).data(runtime));
+    workletRuntimeData[0] = reinterpret_cast<uintptr_t>(reanimatedModule->runtime.get());
     runtime.global().setProperty(
         runtime,
         "_WORKLET_RUNTIME",
-        static_cast<double>(reinterpret_cast<std::uintptr_t>(reanimatedModule->runtime.get())));
+        workletRuntimeValue);
 
     runtime.global().setProperty(
         runtime,

--- a/ios/versioned-react-native/ABI44_0_0/Expo/ExpoKit/Core/ABI44_0_0EXVersionManager.mm
+++ b/ios/versioned-react-native/ABI44_0_0/Expo/ExpoKit/Core/ABI44_0_0EXVersionManager.mm
@@ -543,10 +543,19 @@ ABI44_0_0RCT_EXTERN void ABI44_0_0EXRegisterScopedModule(Class, ...);
     }
     ABI44_0_0EX_ENSURE_STRONGIFY(self);
     auto reanimatedModule = ABI44_0_0reanimated::createReanimatedModule(bridge, bridge.jsCallInvoker);
+    auto workletRuntimeValue = runtime
+        .global()
+        .getProperty(runtime, "ArrayBuffer")
+        .asObject(runtime)
+        .asFunction(runtime)
+        .callAsConstructor(runtime, {static_cast<double>(sizeof(void*))});
+    uintptr_t* workletRuntimeData = reinterpret_cast<uintptr_t*>(
+        workletRuntimeValue.getObject(runtime).getArrayBuffer(runtime).data(runtime));
+    workletRuntimeData[0] = reinterpret_cast<uintptr_t>(reanimatedModule->runtime.get());
     runtime.global().setProperty(
         runtime,
         "_WORKLET_RUNTIME",
-        static_cast<double>(reinterpret_cast<std::uintptr_t>(reanimatedModule->runtime.get())));
+        workletRuntimeValue);
 
     runtime.global().setProperty(
          runtime,

--- a/ios/versioned-react-native/ABI45_0_0/Expo/ExpoKit/Core/ABI45_0_0EXVersionManager.mm
+++ b/ios/versioned-react-native/ABI45_0_0/Expo/ExpoKit/Core/ABI45_0_0EXVersionManager.mm
@@ -548,10 +548,19 @@ ABI45_0_0RCT_EXTERN void ABI45_0_0EXRegisterScopedModule(Class, ...);
     }
     ABI45_0_0EX_ENSURE_STRONGIFY(self);
     auto reanimatedModule = ABI45_0_0reanimated::createReanimatedModule(bridge, bridge.jsCallInvoker);
+    auto workletRuntimeValue = runtime
+        .global()
+        .getProperty(runtime, "ArrayBuffer")
+        .asObject(runtime)
+        .asFunction(runtime)
+        .callAsConstructor(runtime, {static_cast<double>(sizeof(void*))});
+    uintptr_t* workletRuntimeData = reinterpret_cast<uintptr_t*>(
+        workletRuntimeValue.getObject(runtime).getArrayBuffer(runtime).data(runtime));
+    workletRuntimeData[0] = reinterpret_cast<uintptr_t>(reanimatedModule->runtime.get());
     runtime.global().setProperty(
         runtime,
         "_WORKLET_RUNTIME",
-        static_cast<double>(reinterpret_cast<std::uintptr_t>(reanimatedModule->runtime.get())));
+        workletRuntimeValue);
 
     runtime.global().setProperty(
          runtime,

--- a/packages/expo-gl-cpp/cpp/EXGLContext.h
+++ b/packages/expo-gl-cpp/cpp/EXGLContext.h
@@ -52,6 +52,7 @@ class EXGLContext {
  public:
   EXGLContext(UEXGLContextId ctxId): ctxId(ctxId) {}
   void prepareContext(jsi::Runtime &runtime, std::function<void(void)> flushMethod);
+  void maybePrepareWorkletContext(jsi::Runtime &runtime, initGlesContext viewport);
 
   // --- Queue handling --------------------------------------------------------
 

--- a/packages/expo-gl/CHANGELOG.md
+++ b/packages/expo-gl/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix crash on android 11 by packaging worklet `jsi:Runtime*` inside ArrayBuffer. ([#17194](https://github.com/expo/expo/pull/17194) by [@wkozyra95](https://github.com/wkozyra95))
+
 ### 💡 Others
 
 ## 11.2.2 — 2022-04-21

--- a/packages/expo-gl/README.md
+++ b/packages/expo-gl/README.md
@@ -35,6 +35,13 @@ To use version `11.2.0` or newer of `expo-gl` you will need to use at least vers
 | >=9.0.0 && <11.2.0 | >=0.63.1 &&  <0.65.0 |
 | >=11.2.0           | >=0.68.0             |
 
+To use reanimated worklets you will need compatible version of `react-native-reanimated`.
+
+| expo-gl            | react-native-reanimated |
+| ------------------ | ----------------------- |
+| <11.3.0            | <=2.8.0                 |
+| >=11.3.0           | >2.8.0                  |
+
 ### Configure for iOS
 
 Run `npx pod-install` after installing the npm package.


### PR DESCRIPTION
# Why

jsi:Runtime pointer sometimes have large enough value that static cast to double is modifying the value

We can't use retinterpret_cast because JSC is tagging values when the number is passed to the js

# How

Use ArrayBuffer to store pointer

This is a breaking change because _WORKLET_RUNTIME from now on has a different pointer. I modified the versioned reanimated code locally, but the same changes will be upstreamed in reanimated

# Test Plan

versioned and unversioned ios client run gl example
unversioned android run gl example

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
