### PR TITLE
[docs] clarify docs on platform-specific opts

### DIFF
--- a/docs/pages/build-reference/eas-json.md
+++ b/docs/pages/build-reference/eas-json.md
@@ -145,13 +145,16 @@ This document is a reference that outlines the schema for the `"build"` key in *
   },
   "build": {
     /* @info any arbitrary name - used as an identifier */"BUILD_PROFILE_NAME_1"/* @end */: {
-      /* @info Options common to both platforms*/...COMMON_OPTIONS/* @end */
+      /* @info Options common to both platforms*/...COMMON_OPTIONS/* @end */,
 
       "android": {
+        /* @info Options common to both platforms*/...COMMON_OPTIONS/* @end */,
         /* @info Options specific for Android and common to both platforms*/...ANDROID_OPTIONS/* @end */
 
       },
+
       "ios": {
+        /* @info Options common to both platforms*/...COMMON_OPTIONS/* @end */,
         /* @info Options specific for iOS and common to both platforms*/...IOS_OPTIONS/* @end */
 
       }
@@ -161,6 +164,8 @@ This document is a reference that outlines the schema for the `"build"` key in *
   }
 }
 ```
+
+> You can specify common options both in the platform-specific configuration object or at the profile's root. The platform-specific options take precedence over globally-defined ones.
 
 > EAS Submit is also configured in **eas.json**. You can find the reference for the `"submit"` fields in ["Configuring EAS Submit with eas.json"](/submit/eas-json.md).
 

--- a/docs/pages/build/eas-json.md
+++ b/docs/pages/build/eas-json.md
@@ -30,7 +30,7 @@ To run a build with a specific profile, execute `eas build --profile <profile-na
 
 ### Platform-specific and common options
 
-Inside each build profile you can specify `android` and `ios` fields that contain platform-specific configuration for the build. Fields that are available to both platforms can provided on the platform-specific configuration object or on the root of the profile.
+Inside each build profile you can specify `android` and `ios` fields that contain platform-specific configuration for the build. Fields that are available to both platforms can be provided on the platform-specific configuration object or on the root of the profile.
 
 ### Sharing configuration between profiles
 


### PR DESCRIPTION
Clarify docs on platform-specific opts in eas.json.