### PR TITLE
[templates] workaround expo-notifications broken when there's firebase sdk

### DIFF
--- a/templates/expo-template-bare-minimum/ios/HelloWorld/AppDelegate.mm
+++ b/templates/expo-template-bare-minimum/ios/HelloWorld/AppDelegate.mm
@@ -83,19 +83,19 @@
   return [super application:application continueUserActivity:userActivity restorationHandler:restorationHandler] || result;
 }
 
-// Leaves remote notification delegates for firebase ios sdk swizzling
+// Explicitly define remote notification delegates to ensure compatibility with some third-party libraries
 - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
 {
   return [super application:application didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
 }
 
-// Leaves remote notification delegates for firebase ios sdk swizzling
+// Explicitly define remote notification delegates to ensure compatibility with some third-party libraries
 - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error
 {
   return [super application:application didFailToRegisterForRemoteNotificationsWithError:error];
 }
 
-// Leaves remote notification delegates for firebase ios sdk swizzling
+// Explicitly define remote notification delegates to ensure compatibility with some third-party libraries
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler
 {
   return [super application:application didReceiveRemoteNotification:userInfo fetchCompletionHandler:completionHandler];

--- a/templates/expo-template-bare-minimum/ios/HelloWorld/AppDelegate.mm
+++ b/templates/expo-template-bare-minimum/ios/HelloWorld/AppDelegate.mm
@@ -83,6 +83,24 @@
   return [super application:application continueUserActivity:userActivity restorationHandler:restorationHandler] || result;
 }
 
+// Leaves remote notification delegates for firebase ios sdk swizzling
+- (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
+{
+  return [super application:application didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
+}
+
+// Leaves remote notification delegates for firebase ios sdk swizzling
+- (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error
+{
+  return [super application:application didFailToRegisterForRemoteNotificationsWithError:error];
+}
+
+// Leaves remote notification delegates for firebase ios sdk swizzling
+- (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler
+{
+  return [super application:application didReceiveRemoteNotification:userInfo fetchCompletionHandler:completionHandler];
+}
+
 #if RCT_NEW_ARCH_ENABLED
 
 #pragma mark - RCTCxxBridgeDelegate


### PR DESCRIPTION
# Why

from ios firebase sdk `[FIRApp configure];`, this call will do the swizzling internally. they use it to intercept `application:didRegisterForRemoteNotificationsWithDeviceToken:` . even though their implementation will [proxy the handler back to original AppDelegate](https://github.com/google/GoogleUtilities/blob/f4abe56ce62a779e64b525eb133c8fc2a84bbc1f/GoogleUtilities/AppDelegateSwizzler/GULAppDelegateSwizzler.m#L289-L311). unfortunately, our AppDelegate doesn't have `application:didRegisterForRemoteNotificationsWithDeviceToken:` , so the swizzling lib will not proxy the handler back. however, we did handle the callback in the AppDelegate base class - the [`ExpoAppDelegate`](https://github.com/expo/expo/blob/13a016812ca0569feb2ec805663d4b8a047402ec/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegate.swift#L102-L140). the problem is basically from firebase where their swizzling lib doesn't lookup AppDelegate's base class.

fix #15990
close ENG-4757

# How

workaround to add explicit remote notification delegates to AppDelegate

# Test Plan

1. expo init project # select blank
2. expo install expo-notifications @react-native-firebase/app
3. add `expo-notifications` and `@react-native-firebase/app` to the plugins in app.json
4. expo run:ios
5. check whether `token = (await Notifications.getExpoPushTokenAsync()).data;
    console.log("token", token);` returns

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
