### PR TITLE
[docs] add note to reanimated page about setup steps with EAS build/dev clients

### DIFF
--- a/docs/pages/versions/unversioned/sdk/reanimated.md
+++ b/docs/pages/versions/unversioned/sdk/reanimated.md
@@ -15,6 +15,8 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 <APIInstallSection href="https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation" />
 
+> If you are using EAS Build to build your app or building locally (including development builds with `expo-dev-client`), you must also follow the [additional installation instructions](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation).
+
 After the installation completed, add the Babel plugin to **babel.config.js**:
 
 ```jsx

--- a/docs/pages/versions/unversioned/sdk/reanimated.md
+++ b/docs/pages/versions/unversioned/sdk/reanimated.md
@@ -15,9 +15,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 <APIInstallSection href="https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation" />
 
-> If you are using EAS Build to build your app or building locally (including development builds with `expo-dev-client`), you must also follow the [additional installation instructions](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation).
-
-After the installation completed, add the Babel plugin to **babel.config.js**:
+**In all cases,** after the installation completes, you must also add the Babel plugin to **babel.config.js**:
 
 ```jsx
 module.exports = function(api) {

--- a/docs/pages/versions/v44.0.0/sdk/reanimated.md
+++ b/docs/pages/versions/v44.0.0/sdk/reanimated.md
@@ -14,6 +14,8 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 <InstallSection packageName="react-native-reanimated" href="https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation" />
 
+> If you are using EAS Build to build your app or building locally (including development builds with `expo-dev-client`), you must also follow the [additional installation instructions](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation).
+
 After the installation completed, add the Babel plugin to **babel.config.js**:
 
 ```jsx

--- a/docs/pages/versions/v44.0.0/sdk/reanimated.md
+++ b/docs/pages/versions/v44.0.0/sdk/reanimated.md
@@ -14,9 +14,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 <InstallSection packageName="react-native-reanimated" href="https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation" />
 
-> If you are using EAS Build to build your app or building locally (including development builds with `expo-dev-client`), you must also follow the [additional installation instructions](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation).
-
-After the installation completed, add the Babel plugin to **babel.config.js**:
+**In all cases,** after the installation completes, you must also add the Babel plugin to **babel.config.js**:
 
 ```jsx
 module.exports = function(api) {


### PR DESCRIPTION
# Why

ENG-4784, may at least head off some confusion (see #17102) as it seems reanimated does not yet have an official config plugin

# How

Add an extra note to reanimated API page noting that the additional setup instructions must also be followed for projects made with EAS Build (including dev client builds)

# Test Plan

<img width="1173" alt="Screen Shot 2022-04-25 at 7 41 24 PM" src="https://user-images.githubusercontent.com/19958240/165209897-cf202af5-d1ad-4bf8-bd6f-4de4d18bb2e1.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
