### PR TITLE
[docs] add clarification to development getting started page

### DIFF
--- a/docs/pages/development/getting-started.md
+++ b/docs/pages/development/getting-started.md
@@ -48,7 +48,7 @@ Once you have registered all of the iOS devices you would like to develop on, yo
 
 </Tabs>
 
-and installing the resulting build on your device.
+and installing the resulting build on your device via the build page on https://expo.dev.
 
 
 ## Developing your app


### PR DESCRIPTION
# Why

ENG-4785

# How

As per our conversation, add a small clarification to suggest the method of installing the dev build on the device (i.e. internal distribution rather than testflight).

# Test Plan

<img width="1250" alt="Screen Shot 2022-04-25 at 7 40 31 PM" src="https://user-images.githubusercontent.com/19958240/165210191-b96e5979-3a37-484b-9363-6a9b56a2334b.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
