### PR TITLE
[docs] Specify SDK 45 for EAS Update

### DIFF
--- a/docs/pages/eas-update/bare-react-native.md
+++ b/docs/pages/eas-update/bare-react-native.md
@@ -56,7 +56,7 @@ Inside **eas.json**, we'll want to add `channel` properties to each build profil
 Inside **AndroidManifest.xml**, we'll see the following additions:
 
 ```xml
-<meta-data android:name="expo.modules.updates.EXPO_UPDATE_URL" android:value="<https://u.expo.dev/your-project-id>"/>
+<meta-data android:name="expo.modules.updates.EXPO_UPDATE_URL" android:value="https://u.expo.dev/your-project-id"/>
 <meta-data android:name="expo.modules.updates.EXPO_RUNTIME_VERSION" android:value="1.0.0"/>
 ```
 
@@ -68,7 +68,7 @@ Inside **Expo.plist**, we'll see the following additions:
 <key>EXUpdatesRuntimeVersion</key>
 <string>1.0.0</string>
 <key>EXUpdatesURL</key>
-<string><https://u.expo.dev/your-project-id></string>
+<string>https://u.expo.dev/your-project-id</string>
 ```
 
 The `EXUpdatesURL` value should contain your project's ID.

--- a/docs/pages/eas-update/getting-started.md
+++ b/docs/pages/eas-update/getting-started.md
@@ -8,10 +8,10 @@ Setting up EAS Update allows you to push critical bug fixes and improvements tha
 
 EAS Update requires the following versions or greater:
 
-- Expo CLI 5.0.0
-- EAS CLI 0.41.1
-- Expo SDK 44.0.1
-- expo-updates 0.11.2
+- Expo CLI >= 5.3.0
+- EAS CLI >= 0.50.0
+- Expo SDK >= 45.0.0
+- expo-updates >= 0.11.6
 
 ## Install Expo CLI and EAS CLI
 

--- a/docs/pages/eas-update/getting-started.md
+++ b/docs/pages/eas-update/getting-started.md
@@ -11,7 +11,7 @@ EAS Update requires the following versions or greater:
 - Expo CLI >= 5.3.0
 - EAS CLI >= 0.50.0
 - Expo SDK >= 45.0.0
-- expo-updates >= 0.11.6
+- expo-updates >= 0.13.0
 
 ## Install Expo CLI and EAS CLI
 

--- a/docs/pages/eas-update/migrate-to-eas-update.md
+++ b/docs/pages/eas-update/migrate-to-eas-update.md
@@ -13,7 +13,7 @@ EAS Update requires the following versions or greater:
 - Expo CLI >= 5.3.0
 - EAS CLI >= 0.50.0
 - Expo SDK >= 45.0.0
-- expo-updates >= 0.11.6
+- expo-updates >= 0.13.0
 
 ## Install Expo CLI and EAS CLI
 

--- a/docs/pages/eas-update/migrate-to-eas-update.md
+++ b/docs/pages/eas-update/migrate-to-eas-update.md
@@ -10,10 +10,10 @@ EAS Update is the next generation of Expo's updates service. If you're using Cla
 
 EAS Update requires the following versions or greater:
 
-- Expo CLI 5.0.0
-- EAS CLI 0.41.1
-- Expo SDK 44.0.1
-- expo-updates 0.11.2
+- Expo CLI >= 5.3.0
+- EAS CLI >= 0.50.0
+- Expo SDK >= 45.0.0
+- expo-updates >= 0.11.6
 
 ## Install Expo CLI and EAS CLI
 
@@ -36,7 +36,7 @@ You'll need to make the following changes to your project:
 1. Install the latest `expo-updates` library with:
 
    ```bash
-   yarn add expo-updates@0.11.2
+   yarn add expo-updates
    ```
 
 2. Initialize your project with EAS Update:
@@ -55,7 +55,7 @@ You'll need to make the following changes to your project:
    eas build:configure
    ```
 
-5. To allow updates to apply to builds built with EAS, update your EAS build profiles in **eas.json** to include channel properties. These channels should replace any `releaseChannel` properties. We find it convenient to name the `channel` after the profile's name. For instance, the `preview` profile has a `channel` named `"preview"` and the `production` profile has a `channel` named `"production"`.
+5. To allow updates to apply to builds built with EAS, update your EAS build profiles in **eas.json** to include `channel` properties. These channels should replace any `releaseChannel` properties. We find it convenient to name the `channel` after the profile's name. For instance, the `preview` profile has a `channel` named `"preview"` and the `production` profile has a `channel` named `"production"`.
 
 ```json
 {


### PR DESCRIPTION
EAS Update requires newer versions of packages and also SDK 45, so updating the docs to say that.