### PR TITLE
[expo-av][android] Fix crash when debugging remotely

### DIFF
--- a/android/versioned-abis/expoview-abi45_0_0/src/main/java/abi45_0_0/expo/modules/av/AVManager.java
+++ b/android/versioned-abis/expoview-abi45_0_0/src/main/java/abi45_0_0/expo/modules/av/AVManager.java
@@ -180,7 +180,10 @@ public class AVManager implements LifecycleEventListener, AudioManager.OnAudioFo
       uiManager.registerLifecycleEventListener(this);
       uiManager.runOnClientCodeQueueThread(() -> {
         final JavaScriptContextProvider jsContextProvider = mModuleRegistry.getModule(JavaScriptContextProvider.class);
-        installJSIBindings(jsContextProvider.getJavaScriptContextRef(), jsContextProvider.getJSCallInvokerHolder());
+        final long jsContextRef = jsContextProvider.getJavaScriptContextRef();
+        if (jsContextRef != 0) {
+          installJSIBindings(jsContextRef, jsContextProvider.getJSCallInvokerHolder());
+        }
       });
     }
   }

--- a/packages/expo-av/android/src/main/java/expo/modules/av/AVManager.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/AVManager.java
@@ -180,7 +180,10 @@ public class AVManager implements LifecycleEventListener, AudioManager.OnAudioFo
       uiManager.registerLifecycleEventListener(this);
       uiManager.runOnClientCodeQueueThread(() -> {
         final JavaScriptContextProvider jsContextProvider = mModuleRegistry.getModule(JavaScriptContextProvider.class);
-        installJSIBindings(jsContextProvider.getJavaScriptContextRef(), jsContextProvider.getJSCallInvokerHolder());
+        final long jsContextRef = jsContextProvider.getJavaScriptContextRef();
+        if (jsContextRef != 0) {
+          installJSIBindings(jsContextRef, jsContextProvider.getJSCallInvokerHolder());
+        }
       });
     }
   }


### PR DESCRIPTION
# Why

Android app crashed when debugging remotely, there was a missing null check for JSI runtime in expo-av.

# How

Added a null check, the same way it is done in `expo-gl` (PR #10381). Backported changes to versioned SDK 45.

# Test Plan

Reproduced failure with native debug breakpoints. Applied fix. Built Android again and ensured it is no longer crashing.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
