### PR TITLE
[launcher][ios] Fix the error screen sometimes not showing on iOS

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix the error screen sometimes not showing on iOS.
+- Fix the error screen sometimes not showing on iOS. ([#17216](https://github.com/expo/expo/pull/17216) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix the error screen sometimes not showing on iOS.
+
 ### 💡 Others
 
 ## 0.11.2 — 2022-04-25

--- a/packages/expo-dev-launcher/ios/Errors/EXDevLauncherErrorManager.swift
+++ b/packages/expo-dev-launcher/ios/Errors/EXDevLauncherErrorManager.swift
@@ -7,7 +7,8 @@ public class EXDevLauncherErrorManager: NSObject {
   internal weak var controller: EXDevLauncherController?
   private weak var currentVC: EXDevLauncherErrorViewController?
   private var error: EXDevLauncherAppError?
-
+  private static let VIEW_TAG = 6634
+  
   @objc
   public init(controller: EXDevLauncherController) {
     self.controller = controller
@@ -34,7 +35,11 @@ public class EXDevLauncherErrorManager: NSObject {
     controller?.currentWindow()?.makeKeyAndVisible()
     
     // remove splash screen
-    currentVC?.view.subviews.last?.removeFromSuperview()
+    currentVC?.view.subviews.forEach {
+      if ($0.tag != EXDevLauncherErrorManager.VIEW_TAG) {
+        $0.removeFromSuperview()
+      }
+    }
   }
 
   private func getNextErrorViewController() -> EXDevLauncherErrorViewController? {

--- a/packages/expo-dev-launcher/ios/Views/EXDevLauncherErrorView.storyboard
+++ b/packages/expo-dev-launcher/ios/Views/EXDevLauncherErrorView.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -17,7 +17,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="18" translatesAutoresizingMaskIntoConstraints="NO" id="GM9-4h-o48" userLabel="Main View">
+                            <stackView opaque="NO" tag="6634" contentMode="scaleToFill" axis="vertical" spacing="18" translatesAutoresizingMaskIntoConstraints="NO" id="GM9-4h-o48" userLabel="Main View">
                                 <rect key="frame" x="20" y="64" width="335" height="594"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="1Bh-aT-q2c" userLabel="Header Stack View">
@@ -104,7 +104,7 @@
                                     </stackView>
                                 </subviews>
                             </stackView>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zFL-lG-zl9" userLabel="Footer View">
+                            <view tag="6634" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zFL-lG-zl9" userLabel="Footer View">
                                 <rect key="frame" x="0.0" y="658" width="375" height="120"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="C4a-fX-PLy">


### PR DESCRIPTION
# Why

Connected to ENG-4754.

# How

The current solution which removes the splash screen doesn't work. When the splash screen isn't there, it will remove the last view from the hierarchy. To fix that, I've added a special tag to error screen views. 

# Test Plan

- bare-expo ✅
