### PR TITLE
[home] don't show SDK Version info if update hasn't been published

### DIFF
--- a/dev-home-config.json
+++ b/dev-home-config.json
@@ -1,3 +1,3 @@
 {
-  "url": "exp://exp.host/@expo-home-dev/expo-home-dev-fd824554ab19697185b27ab56235cc294bd02d59"
+  "url": "exp://exp.host/@expo-home-dev/expo-home-dev-61d067e0a740fcf81edaed7cf326abac6ce99deb"
 }

--- a/home/screens/ProjectScreen/ProjectView.tsx
+++ b/home/screens/ProjectScreen/ProjectView.tsx
@@ -61,8 +61,12 @@ export function ProjectView({ loading, error, data, navigation }: Props) {
           <Spacer.Vertical size="xl" />
           <View bg="default" border="default" overflow="hidden" rounded="large">
             <ConstantItem title="Owner" value={app.username} />
-            <Divider style={{ height: 1 }} />
-            <ConstantItem title="SDK Version" value={app.sdkVersion} />
+            {app.sdkVersion !== '0.0.0' && (
+              <>
+                <Divider style={{ height: 1 }} />
+                <ConstantItem title="SDK Version" value={app.sdkVersion} />
+              </>
+            )}
           </View>
         </View>
       </ScrollView>


### PR DESCRIPTION
# Why

Our API returns '0.0.0' as the `sdkVersion` if an app doesn't have an update. It doesn't make sense to display this in Expo Go, as it's more confusing than it is informative.

![Screen Shot 2022-04-26 at 20 10 02](https://user-images.githubusercontent.com/12488826/165413047-675f771a-e65e-4472-beae-8f1d5b169c0c.png)

# How

The project page now hides the SDK Version row if it's '0.0.0'.

# Test Plan

Visit an unpublished project in Expo Go. You can create one by creating a project from the website without running `expo publish`

![Screen Shot 2022-04-26 at 20 25 14](https://user-images.githubusercontent.com/12488826/165414179-bacd2fea-26bc-41a2-978d-43866e7df35a.png)
