### PR TITLE
[android] workaround release build error

### DIFF
--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -754,6 +754,20 @@ project.afterEvaluate {
   if (nativeBuildTask) {
     packageNdkLibs.dependsOn nativeBuildTask
   }
+
+  // Workaround for AGP 7 local lint aar task with errors from a library project owning another aars.
+  // In our case, it's the expoview (library project) owning hermes aar
+  // ```
+  // Error while evaluating property 'hasLocalAarDeps' of task ':expoview:bundleVersionedReleaseLocalLintAar'
+  //   > Direct local .aar file dependencies are not supported when building an AAR.
+  //     The resulting AAR would be broken because the classes and Android resources from any local .aar file dependencies would not be packaged in the resulting AAR.
+  //     Previous versions of the Android Gradle Plugin produce broken AARs in this case too (despite not throwing this error).
+  //     The following direct local .aar file dependencies of the :expoview project caused this error:
+  //     /home/runner/work/expo/expo/node_modules/hermes-engine/android/hermes-release.aar
+  // ```
+  // For the workaround, we just pretend we don't have local aar dependencies.
+  tasks.findByName("bundleVersionedReleaseLocalLintAar")?.localAarDeps?.setFrom([])
+  tasks.findByName("bundleUnversionedReleaseLocalLintAar")?.localAarDeps?.setFrom([])
 }
 
 task packageNdkLibs(type: Copy) {

--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -755,7 +755,7 @@ project.afterEvaluate {
     packageNdkLibs.dependsOn nativeBuildTask
   }
 
-  // Workaround for AGP 7 local lint aar task with errors from a library project owning another aars.
+  // Workaround for AGP 7 local lint aar task with errors from a library project owning other aars.
   // In our case, it's the expoview (library project) owning hermes aar
   // ```
   // Error while evaluating property 'hasLocalAarDeps' of task ':expoview:bundleVersionedReleaseLocalLintAar'


### PR DESCRIPTION
# Why

Fix error from [expo go release build](https://github.com/expo/expo/runs/6186358899?check_suite_focus=true).
```
Execution failed for task ':expoview:bundleVersionedReleaseLocalLintAar'.

> Error while evaluating property 'hasLocalAarDeps' of task ':expoview:bundleVersionedReleaseLocalLintAar'
   > Direct local .aar file dependencies are not supported when building an AAR. The resulting AAR would be broken because the classes and Android resources from any local .aar file dependencies would not be packaged in the resulting AAR. Previous versions of the Android Gradle Plugin produce broken AARs in this case too (despite not throwing this error). The following direct local .aar file dependencies of the :expoview project caused this error: /home/runner/work/expo/expo/node_modules/hermes-engine/android/hermes-release.aar
```

# How

add workaround to pretend we don't have local aars

# Test Plan

`./gradlew :app:assembleVersionedRelease`

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
