### PR TITLE
[ncl] Add examples for ExpoModules host object

### DIFF
--- a/apps/native-component-list/src/navigation/ExpoApisStackNavigator.tsx
+++ b/apps/native-component-list/src/navigation/ExpoApisStackNavigator.tsx
@@ -12,6 +12,12 @@ const Stack = createStackNavigator();
 export const Screens = [
   {
     getComponent() {
+      return optionalRequire(() => require('../screens/ExpoModulesScreen'));
+    },
+    name: 'ExpoModules',
+  },
+  {
+    getComponent() {
       return optionalRequire(() => require('../screens/StatusBarScreen'));
     },
     name: 'StatusBar',

--- a/apps/native-component-list/src/screens/ExpoApisScreen.tsx
+++ b/apps/native-component-list/src/screens/ExpoApisScreen.tsx
@@ -55,6 +55,7 @@ const screens = [
   'FirebaseRecaptcha',
   'Font',
   'Errors',
+  'ExpoModules',
   'Geocoding',
   'GoogleSignIn',
   'Haptics',

--- a/apps/native-component-list/src/screens/ExpoModulesScreen.tsx
+++ b/apps/native-component-list/src/screens/ExpoModulesScreen.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { ScrollView, StyleSheet, View } from 'react-native';
+
+import HeadingText from '../components/HeadingText';
+import MonoText from '../components/MonoText';
+
+// Custom JSON replacer that can stringify functions.
+const customJsonReplacer = (_: string, value: any) => {
+  return typeof value === 'function' ? value.toString().replace(/\s+/g, ' ') : value;
+};
+
+export default class ExpoModulesScreen extends React.PureComponent<any, any> {
+  render() {
+    const modules = { ...global.ExpoModules };
+    const moduleNames = Object.keys(modules);
+
+    return (
+      <ScrollView style={styles.scrollView}>
+        <HeadingText>Host object is installed</HeadingText>
+        <MonoText>{`'ExpoModules' in global => ${'ExpoModules' in global}`}</MonoText>
+
+        <HeadingText>Available Expo modules</HeadingText>
+        <MonoText>
+          {`Object.keys(global.ExpoModules) => [\n  ${moduleNames.join(',\n  ')}\n]`}
+        </MonoText>
+
+        {moduleNames.map((moduleName) => {
+          return (
+            <View key={moduleName}>
+              <HeadingText>Module: {moduleName}</HeadingText>
+              <MonoText>{JSON.stringify(modules[moduleName], customJsonReplacer, 2)}</MonoText>
+            </View>
+          );
+        })}
+      </ScrollView>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  scrollView: {
+    paddingHorizontal: 10,
+  },
+});


### PR DESCRIPTION
# Why

Native unit tests are sometimes not enough to properly check the real scenarios. Simple checks on NCL would be helpful. I'm going to add some tests to test-suite as well.

# How

Added a new screen to NCL that checks the `global.ExpoModules` object that we install through the JSI.

# Test Plan

These examples return expected stuff
