### PR TITLE
[notifications] remove observer on RCTBridge reload

### DIFF
--- a/packages/expo-notifications/ios/EXNotifications/PushToken/EXPushTokenModule.m
+++ b/packages/expo-notifications/ios/EXNotifications/PushToken/EXPushTokenModule.m
@@ -4,6 +4,7 @@
 #import <EXNotifications/EXPushTokenManager.h>
 
 #import <ExpoModulesCore/EXEventEmitterService.h>
+#import <React/RCTBridge.h>
 
 static NSString * const onDevicePushTokenEventName = @"onDevicePushToken";
 
@@ -51,6 +52,8 @@ EX_EXPORT_METHOD_AS(getDevicePushTokenAsync,
 {
   _eventEmitter = [moduleRegistry getModuleImplementingProtocol:@protocol(EXEventEmitterService)];
   _pushTokenManager = [moduleRegistry getSingletonModuleForName:@"PushTokenManager"];
+
+  [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(stopObserving) name:RCTBridgeWillReloadNotification object:nil];
 }
 
 # pragma mark - EXEventEmitter


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Closes https://github.com/expo/expo/issues/15788

The Expo Notifications module registers a listener to `EXTokenManager` but does not unregister their listeners when a reload happens. This leads to a crash from `RCTEventEmitter` because the `EXTokenManager` is listening for app life cycle events and would trigger this stale listener that is pointing to a bridge that was no longer valid. 

# How

<!--
How did you build this feature or fix this bug and why?
-->

Added a notification observer for the reload bridge event and invoked the `stopObserving` method to unregister the listener

When the bridge is rebuilt / restored, the event emitter is reassigned via ExpoModulesCore calling`setModuleRegistry`, so these properties are properly reset on reload

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

The example I was using was to call `await Notifications.getDevicePushTokenAsync();` in App.js somewhere which would trigger a crash on reload. After applying these changes this method no longer crashes, and I verified that the `onDidRegisterWithDeviceToken` method is called 

I'm wondering if this is one of potentially many places where an issue like this might occur - i.e should we be accounting for this somewhere in ExpoModulesCore rather than at the individual module levels? I would appreciate some feedback on this!

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
