### PR TITLE
[home] only dismiss AccountModal following a successful authentication

### DIFF
--- a/dev-home-config.json
+++ b/dev-home-config.json
@@ -1,3 +1,3 @@
 {
-  "url": "exp://exp.host/@expo-home-dev/expo-home-dev-61d067e0a740fcf81edaed7cf326abac6ce99deb"
+  "url": "exp://exp.host/@expo-home-dev/expo-home-dev-bf8560d68c0fd0d8c23aeaeb37a5f73335e0eb55"
 }

--- a/home/screens/AccountModal/LoggedOutAccountView.tsx
+++ b/home/screens/AccountModal/LoggedOutAccountView.tsx
@@ -1,4 +1,5 @@
 import { borderRadius, spacing } from '@expo/styleguide-native';
+import { useNavigation } from '@react-navigation/native';
 import { View, Text, Spacer, useExpoTheme } from 'expo-dev-client-components';
 import * as WebBrowser from 'expo-web-browser';
 import * as React from 'react';
@@ -8,17 +9,40 @@ import url from 'url';
 import Analytics from '../../api/Analytics';
 import ApolloClient from '../../api/ApolloClient';
 import Config from '../../api/Config';
-import { useDispatch } from '../../redux/Hooks';
+import { useDispatch, useSelector } from '../../redux/Hooks';
 import SessionActions from '../../redux/SessionActions';
 import { useAccountName } from '../../utils/AccountNameContext';
+import hasSessionSecret from '../../utils/hasSessionSecret';
 
-export function LoggedOutAccountView() {
+type Props = {
+  refetch: () => Promise<void>;
+};
+
+export function LoggedOutAccountView({ refetch }: Props) {
   const dispatch = useDispatch();
   const [isAuthenticating, setIsAuthenticating] = React.useState(false);
+  const [isFinishedAuthenticating, setIsFinishedAuthenticating] = React.useState(false);
   const [authenticationError, setAuthenticationError] = React.useState<string | null>(null);
   const mounted = React.useRef<boolean | null>(true);
   const theme = useExpoTheme();
   const { setAccountName } = useAccountName();
+  const navigation = useNavigation();
+
+  const { sessionSecretExists } = useSelector((data) => {
+    const sessionSecretExists = hasSessionSecret(data.session);
+    return {
+      sessionSecretExists,
+    };
+  });
+
+  React.useEffect(() => {
+    // wait for redux action to dispatch, refetch with new sessionSecret, then dismiss modal
+    if (sessionSecretExists && isFinishedAuthenticating) {
+      refetch().then(() => {
+        navigation.goBack();
+      });
+    }
+  }, [sessionSecretExists, isFinishedAuthenticating]);
 
   React.useEffect(() => {
     mounted.current = true;
@@ -84,6 +108,7 @@ export function LoggedOutAccountView() {
           })
         );
         setAccountName(usernameOrEmail);
+        setIsFinishedAuthenticating(true);
       }
     } catch (e) {
       // TODO(wschurman): Put this into Sentry

--- a/home/screens/AccountModal/LoggedOutAccountView.tsx
+++ b/home/screens/AccountModal/LoggedOutAccountView.tsx
@@ -36,12 +36,25 @@ export function LoggedOutAccountView({ refetch }: Props) {
   });
 
   React.useEffect(() => {
-    // after logging in, wait for redux action to dispatch, refetch with new sessionSecret, then dismiss modal
-    if (isFinishedAuthenticating && sessionSecretExists) {
-      refetch().then(() => {
-        navigation.goBack();
-      });
+    async function refetchThenGoBackAsync() {
+      // after logging in, wait for redux action to dispatch, refetch with new sessionSecret, then dismiss modal
+      if (isFinishedAuthenticating && sessionSecretExists) {
+        try {
+          await refetch();
+        } finally {
+          // in the case that it rejects, we still want to dismiss the modal
+
+          // if it's an internet issue, the user will be able to try to refresh the homepage
+
+          // if it's an issue with the sessionSecret being invalid, the user will be able to try to
+          // log in again and rewrite the sessionSecret
+
+          navigation.goBack();
+        }
+      }
     }
+
+    refetchThenGoBackAsync();
   }, [isFinishedAuthenticating, sessionSecretExists]);
 
   React.useEffect(() => {

--- a/home/screens/AccountModal/LoggedOutAccountView.tsx
+++ b/home/screens/AccountModal/LoggedOutAccountView.tsx
@@ -36,13 +36,13 @@ export function LoggedOutAccountView({ refetch }: Props) {
   });
 
   React.useEffect(() => {
-    // wait for redux action to dispatch, refetch with new sessionSecret, then dismiss modal
-    if (sessionSecretExists && isFinishedAuthenticating) {
+    // after logging in, wait for redux action to dispatch, refetch with new sessionSecret, then dismiss modal
+    if (isFinishedAuthenticating && sessionSecretExists) {
       refetch().then(() => {
         navigation.goBack();
       });
     }
-  }, [sessionSecretExists, isFinishedAuthenticating]);
+  }, [isFinishedAuthenticating, sessionSecretExists]);
 
   React.useEffect(() => {
     mounted.current = true;

--- a/home/screens/AccountModal/index.tsx
+++ b/home/screens/AccountModal/index.tsx
@@ -1,14 +1,11 @@
 import { spacing } from '@expo/styleguide-native';
 import Ionicons from '@expo/vector-icons/build/Ionicons';
-import { useNavigation } from '@react-navigation/native';
 import { Text, View, useExpoTheme, Row, Spacer } from 'expo-dev-client-components';
-import React, { useEffect } from 'react';
+import React from 'react';
 import { ActivityIndicator, Platform } from 'react-native';
 import { TouchableOpacity } from 'react-native-gesture-handler';
 
 import { useHome_CurrentUserQuery } from '../../graphql/types';
-import { useSelector } from '../../redux/Hooks';
-import isUserAuthenticated from '../../utils/isUserAuthenticated';
 import { LoggedInAccountView } from './LoggedInAccountView';
 import { LoggedOutAccountView } from './LoggedOutAccountView';
 import { ModalHeader } from './ModalHeader';
@@ -17,23 +14,6 @@ export function AccountModal() {
   const theme = useExpoTheme();
 
   const { data, loading, error, refetch } = useHome_CurrentUserQuery();
-  const navigation = useNavigation();
-  const { isAuthenticated } = useSelector((data) => {
-    const isAuthenticated = isUserAuthenticated(data.session);
-    return {
-      isAuthenticated,
-    };
-  });
-
-  useEffect(() => {
-    // wait for redux action to dispatch so other queries can be fetched
-    if (isAuthenticated && !data?.viewer) {
-      // get accounts info after logging in, then dismiss the modal
-      refetch().then(() => {
-        navigation.goBack();
-      });
-    }
-  }, [isAuthenticated]);
 
   if (loading) {
     return (
@@ -107,7 +87,11 @@ export function AccountModal() {
       {data?.viewer?.accounts ? (
         <LoggedInAccountView accounts={data.viewer.accounts} />
       ) : (
-        <LoggedOutAccountView />
+        <LoggedOutAccountView
+          refetch={async () => {
+            await refetch();
+          }}
+        />
       )}
     </View>
   );

--- a/home/screens/HomeScreen/index.tsx
+++ b/home/screens/HomeScreen/index.tsx
@@ -9,7 +9,7 @@ import { useDispatch, useSelector } from '../../redux/Hooks';
 import { HistoryList } from '../../types';
 import { useAccountName } from '../../utils/AccountNameContext';
 import { useInitialData } from '../../utils/InitialDataContext';
-import isUserAuthenticated from '../../utils/isUserAuthenticated';
+import hasSessionSecret from '../../utils/hasSessionSecret';
 import { HomeScreenView } from './HomeScreenView';
 
 type NavigationProps = StackScreenProps<HomeStackRoutes, 'Home'> & {
@@ -40,7 +40,7 @@ export function HomeScreen(props: NavigationProps) {
       return {
         recentHistory: history.take(10) as HistoryList,
         allHistory: history as HistoryList,
-        isAuthenticated: isUserAuthenticated(data.session),
+        isAuthenticated: hasSessionSecret(data.session),
       };
     }, [])
   );

--- a/home/utils/hasSessionSecret.ts
+++ b/home/utils/hasSessionSecret.ts
@@ -1,0 +1,3 @@
+export default function hasSessionSecret(session: { sessionSecret: string | null }): boolean {
+  return !!session.sessionSecret;
+}

--- a/home/utils/isUserAuthenticated.ts
+++ b/home/utils/isUserAuthenticated.ts
@@ -1,3 +1,0 @@
-export default function isUserAuthenticated(session: { sessionSecret: string | null }): boolean {
-  return !!session.sessionSecret;
-}


### PR DESCRIPTION
# Why

@jonsamp found an issue where if you have a `sessionSecret` in your keychain that's invalid, you can't open the Account modal. The only way to rewrite that secret is to log in again, but you can't do that if the modal auto-dismissed.

# How

I changed the hook that refetched data and dismissed the Account modal after a login to do exactly that. Previously it checked if there was a `sessionSecret` and no data, but now it relies on state being set directly by the login code, preventing this broken state.

# Test Plan

I replicated the bug by changing the login code locally to append some incorrect characters to the `sessionSecret`, then logged in. I then applied my patch, reloaded the app, and was able to successfully get log in working again even though the `sessionSecret` stored in my keychain was wrong.


https://user-images.githubusercontent.com/12488826/165621597-bac5f781-d0c3-4384-8653-9334f925e7f5.MP4

