### PR TITLE
chore(cli): downgrade fs-extra to 8.1.0

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### 💡 Others
 
+- Downgrade `fs-extra` to `8.1.0`.
+
 ## 0.1.0 — 2022-04-25
 
 ### 🎉 New features

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### 💡 Others
 
-- Downgrade `fs-extra` to `8.1.0`.
+- Downgrade `fs-extra` to `8.1.0`. ([#17234](https://github.com/expo/expo/pull/17234) by [@EvanBacon](https://github.com/EvanBacon))
 
 ## 0.1.0 — 2022-04-25
 

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -63,7 +63,7 @@
     "env-editor": "^0.4.1",
     "form-data": "^3.0.1",
     "freeport-async": "2.0.0",
-    "fs-extra": "9.0.0",
+    "fs-extra": "~8.1.0",
     "getenv": "^1.0.0",
     "graphql": "15.8.0",
     "graphql-tag": "^2.10.1",

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -78,7 +78,6 @@
     "node-forge": "^1.3.1",
     "npm-package-arg": "^7.0.0",
     "ora": "3.4.0",
-    "pretty-format": "^26.5.2",
     "progress": "2.0.3",
     "prompts": "^2.3.2",
     "qrcode-terminal": "0.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10177,7 +10177,7 @@ fs-extra@^7.0.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^8.1.0:
+fs-extra@^8.1.0, fs-extra@~8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
   integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==


### PR DESCRIPTION
# Why

This is the only node module that is hoisted in SDK 45, downgrading should improve install size by some nominal amount of time.