### PR TITLE
[docs] fix link to build server infrastructure

### DIFF
--- a/docs/pages/build-reference/limitations.md
+++ b/docs/pages/build-reference/limitations.md
@@ -9,7 +9,7 @@ EAS Build is a new service and we plan to address many of the current limitation
 <details><summary><h4>Fixed memory and CPU limits on build worker servers.</h4></summary>
 <p>
 
-The ["Server infrastructure" reference](../server-infrastructure.md) contains the most up-to-date information about the current specifications of the Android (Ubuntu) and iOS  (macOS) build servers. You may find that the resources available are not sufficient to build your app if your build process requires more than 12GB RAM. In the future we will be adding more powerful configurations to increase memory limits and speed up build times.
+The ["Server infrastructure" reference](./infrastructure.md) contains the most up-to-date information about the current specifications of the Android (Ubuntu) and iOS  (macOS) build servers. You may find that the resources available are not sufficient to build your app if your build process requires more than 12GB RAM. In the future we will be adding more powerful configurations to increase memory limits and speed up build times.
 
 </p>
 </details>


### PR DESCRIPTION
# Why

The current link is broken.

# How

# Test Plan

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
