### PR TITLE
[docs] Add ESLint Rule to Prevent Usage of localStorage and sessionStorage

### DIFF
--- a/docs/.eslintrc.js
+++ b/docs/.eslintrc.js
@@ -1,9 +1,10 @@
 module.exports = {
   root: true,
   extends: ['universe/node', 'universe/web', 'plugin:@next/next/recommended'],
-  plugins: ['lodash'],
+  plugins: ['lodash', 'no-storage'],
   rules: {
     'lodash/import-scope': [2, 'method'],
     '@next/next/no-img-element': 0,
+    'no-storage/no-browser-storage': 2,
   },
 };

--- a/docs/common/sentry-utilities.ts
+++ b/docs/common/sentry-utilities.ts
@@ -1,3 +1,6 @@
+// As we need to use localStorage here but want to prevent further use, implement the
+// ESLint rule no-storage/no-browser-storage but ignore this file, in particular.
+/* eslint-disable no-storage/no-browser-storage */
 import { Event } from '@sentry/types';
 /*
  * Error logging filtering - prevent users from submitting errors we do not care about,
@@ -7,10 +10,6 @@ import { Event } from '@sentry/types';
 
 // These exact error messages may be different depending on the browser!
 const ERRORS_TO_DISCARD = [
-  // Filter out errors from extensions
-  'chrome-extension://',
-  'moz-extension://',
-  'safari-extension://',
   // This error only appears in Safari
   "undefined is not an object (evaluating 'window.__pad.performLoop')",
   // This error appears in Firefox related to local storage and flooded our Sentry bandwidth

--- a/docs/package.json
+++ b/docs/package.json
@@ -87,6 +87,7 @@
     "eslint-config-next": "^10.2.3",
     "eslint-config-universe": "^10.0.0",
     "eslint-plugin-lodash": "^7.3.0",
+    "eslint-plugin-no-storage": "^1.0.2",
     "http-server": "^0.12.3",
     "jest": "^27.4.7",
     "js-yaml": "^4.1.0",

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -3696,6 +3696,11 @@ eslint-plugin-lodash@^7.3.0:
   dependencies:
     lodash "^4.17.21"
 
+eslint-plugin-no-storage@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-no-storage/-/eslint-plugin-no-storage-1.0.2.tgz#b32b2f00c4084f8e70c6c4ea79704ffe28b6caad"
+  integrity sha1-sysvAMQIT45wxsTqeXBP/ii2yq0=
+
 eslint-plugin-node@^11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz#c95544416ee4ada26740a30474eefc5402dc671d"


### PR DESCRIPTION
# Why

Sentry is getting spammed with the [an error](https://sentry.io/organizations/expoio/issues/2555130033/events/2e1e7325f7e94ef6863d85281a716613/?frontend_events=%7B%22event_name%22%3A%22Sign+Up%22%2C%22event_label%22%3A%22google%22%7D&project=1526800) when attempting to access localStorage.getItem(). This leads to a 404 page which is a poor user experience.

Here's how reporting errors to Sentry works, that is how we use `localStorage` when talking to Sentry (`sentry-utilities.ts`)
![Screen Shot 2022-04-27 at 11 42 38 PM](https://user-images.githubusercontent.com/5482800/165692905-1ede4dc6-32ff-46f0-8688-581ae626c1bd.png)

# How

Add ESLint rule that prevents the usage of localStorage and sessionStorage. 

A few questions/concerns:
- With this approach, do we want to completely get rid of our use of `localStorage` in `./docs/common/sentry-utilities.ts`?
  -  Answer: No, just eslint ignore the file and prevent future use of `localStorage`
- Given the above error from Sentry, it seems like we should just check whether `localStorage.getItem` exists before calling it, rather than removing `localStorage`, altogether.
  - Answer: Ideally we would do without `localStorage` as it is a fairly hacky solution and was implemented as a hotfix to spam problem in the past. However, based on an initial review of the docs, Sentry does not currently offer this desired type of filtration of events. If we do use `localStorage.getItem`, I do still think we should check for it in the places that it is invoked.
- If we'd like to commit to disabling `localStorage` and `sessionsStorage` then should the relevant code in `sentry-utilities` be removed or ignored? Ignoring the existing code will not resolve the current issue so we'd have to completely remove all of how we currently filter Sentry methods. A further alternative would be to use a persistent state that does everything that we use `localStorage` for atm.
  - Answer: Ignore it. 
- Lastly, why does `isLocalStorageAvailable` contain a try/catch block? There is nothing async or promise-based in the method definition. Perhaps I'm missing something?
  - Answer: localStorage is pretty wonky to detect across browsers. 

# Test Plan

1. Create a new Sentry account and replace the dsn, try spamming a thrown error.
2. Try putting in a use of localStorage anywhere in the code and run `yarn lint`
3. ~As a note, `yarn lint` will currently fail as all instance of localStorage have not yet been removed from `sentry-utilities.ts`. This will be resolved once the desired approach is selected.~

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
