### PR TITLE
fix(jest-expo): update `@jest/create-cache-key-function` to match upstream

### DIFF
--- a/packages/jest-expo/package.json
+++ b/packages/jest-expo/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@expo/config": "^6.0.14",
-    "@jest/create-cache-key-function": "^26.6.2",
+    "@jest/create-cache-key-function": "^27.0.1",
     "babel-jest": "^26.6.3",
     "find-up": "^5.0.0",
     "jest-watch-select-projects": "^2.0.0",


### PR DESCRIPTION
# Why

Matches upstream: https://github.com/facebook/react-native/blob/0c4c6ca319fa9dfb23d047e0c7d2a81281d1d8a3/package.json#L96

See https://github.com/facebook/react-native/pull/30637

semi-related, thoughts on updating `babel-jest` to v27 (or even the fresh v28)?

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

GH Editor

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

CI?

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
