### PR TITLE
[dev-menu][Android] Fix unresolved reference: loadFonts

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix `unresolved reference: loadFonts` in the release build on Android.
+- Fix `unresolved reference: loadFonts` in the release build on Android. ([#17241](https://github.com/expo/expo/pull/17241) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix `unresolved reference: loadFonts` in the release build on Android.
+
 ### 💡 Others
 
 ## 0.10.4 — 2022-04-26

--- a/packages/expo-dev-menu/android/src/release/java/expo/modules/devmenu/DevMenuManager.kt
+++ b/packages/expo-dev-menu/android/src/release/java/expo/modules/devmenu/DevMenuManager.kt
@@ -7,6 +7,7 @@ import android.view.MotionEvent
 import com.facebook.react.ReactInstanceManager
 import com.facebook.react.ReactNativeHost
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.ReactApplicationContext
 import expo.interfaces.devmenu.DevMenuDelegateInterface
 import expo.interfaces.devmenu.DevMenuManagerInterface
 import expo.interfaces.devmenu.DevMenuPreferencesInterface

--- a/packages/expo-dev-menu/android/src/release/java/expo/modules/devmenu/DevMenuManager.kt
+++ b/packages/expo-dev-menu/android/src/release/java/expo/modules/devmenu/DevMenuManager.kt
@@ -114,6 +114,10 @@ object DevMenuManager : DevMenuManagerInterface {
     throw IllegalStateException(DEV_MENU_IS_NOT_AVAILABLE)
   }
 
+  fun loadFonts(applicationContext: ReactApplicationContext) {
+    throw IllegalStateException(DEV_MENU_IS_NOT_AVAILABLE)
+  }
+
   override val coroutineScope: CoroutineScope
     get() = throw IllegalStateException(DEV_MENU_IS_NOT_AVAILABLE)
 }


### PR DESCRIPTION
# Why

Fixes:
```
e: /Users/runner/work/expo/expo/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/modules/internals/DevMenuInternalFontManagerModule.kt: (11, 20): Unresolved reference: loadFonts
```
