### PR TITLE
[docs] update SDK versions table

### DIFF
--- a/docs/pages/versions/unversioned/index.md
+++ b/docs/pages/versions/unversioned/index.md
@@ -32,11 +32,10 @@ Every quarter there is a new Expo SDK release that typically updates to the late
 
 | Expo SDK Version | React Native Version |
 | ---------------- | -------------------- |
+| 45.0.0           |        0.68.1        |
 | 44.0.0           |        0.64.3        |
 | 43.0.0           |        0.64.3        |
 | 42.0.0           |        0.63.3        |
-| 41.0.0           |        0.63.3        |
-| 40.0.0           |        0.63.3        |
 
 ### Support for other React Native versions
 

--- a/docs/pages/versions/v45.0.0/index.md
+++ b/docs/pages/versions/v45.0.0/index.md
@@ -34,11 +34,10 @@ Every quarter there is a new Expo SDK release that typically updates to the late
 
 | Expo SDK Version | React Native Version |
 | ---------------- | -------------------- |
+| 45.0.0           |        0.68.1        |
 | 44.0.0           |        0.64.3        |
 | 43.0.0           |        0.64.3        |
 | 42.0.0           |        0.63.3        |
-| 41.0.0           |        0.63.3        |
-| 40.0.0           |        0.63.3        |
 
 ### Support for other React Native versions
 


### PR DESCRIPTION
# Why

Let's update docs for SDK 45 and unversioned ones, to contain information about latest SDK release.

# How

Add SDK 45 row, remove old SDKs 40 & 41 rows.

# Test Plan

The change has been tested by running docs website locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
