### PR TITLE
[dev-client][iOS] Fix remote debugging crashes the application

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix remote debugging crashing the application on iOS.
+
 ### 💡 Others
 
 ## 0.11.3 — 2022-04-26

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix remote debugging crashing the application on iOS.
+- Fix remote debugging crashing the application on iOS. ([#17248](https://github.com/expo/expo/pull/17248) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -13,6 +13,7 @@
 #import "EXDevLauncherRCTBridge.h"
 #import "EXDevLauncherManifestParser.h"
 #import "EXDevLauncherLoadingView.h"
+#import "EXDevLauncherRCTDevSettings.h"
 #import "EXDevLauncherInternal.h"
 #import "EXDevLauncherUpdatesHelper.h"
 #import "EXDevLauncherAuth.h"
@@ -89,6 +90,7 @@
   [modules addObject:[RCTDevMenu new]];
   [modules addObject:[RCTAsyncLocalStorage new]];
   [modules addObject:[EXDevLauncherLoadingView new]];
+  [modules addObject:[EXDevLauncherRCTDevSettings new]];
   [modules addObject:[EXDevLauncherInternal new]];
   [modules addObject:[EXDevLauncherAuth new]];
   

--- a/packages/expo-dev-launcher/ios/ReactNative/EXDevLauncherRCTDevSettings.h
+++ b/packages/expo-dev-launcher/ios/ReactNative/EXDevLauncherRCTDevSettings.h
@@ -1,0 +1,12 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+#import <Foundation/Foundation.h>
+#import <React/RCTDevSettings.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface EXDevLauncherRCTDevSettings : RCTDevSettings
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-dev-launcher/ios/ReactNative/EXDevLauncherRCTDevSettings.m
+++ b/packages/expo-dev-launcher/ios/ReactNative/EXDevLauncherRCTDevSettings.m
@@ -1,0 +1,59 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+#import "EXDevLauncherRCTDevSettings.h"
+
+@implementation EXDevLauncherRCTDevSettings
+
++ (NSString *)moduleName
+{
+  return @"DevSettings";
+}
+
+- (NSArray<NSString *> *)supportedEvents
+{
+  return @[];
+}
+
+- (BOOL)isHotLoadingAvailable
+{
+  return NO;
+}
+
+- (BOOL)isRemoteDebuggingAvailable
+{
+  return NO;
+}
+
++ (BOOL)requiresMainQueueSetup
+{
+  return NO;
+}
+
+- (id)settingForKey:(NSString *)key
+{
+  return nil;
+}
+
+- (void)reload {}
+
+- (void)reloadWithReason:(NSString *)reason {}
+
+- (void)onFastRefresh {}
+
+- (void)setHotLoadingEnabled:(BOOL)isHotLoadingEnabled {}
+
+- (void)setIsDebuggingRemotely:(BOOL)isDebuggingRemotelyEnabled {}
+
+- (void)setProfilingEnabled:(BOOL)isProfilingEnabled {}
+
+- (void)toggleElementInspector {}
+
+- (void)setupHMRClientWithBundleURL:(NSURL *)bundleURL {}
+
+- (void)setupHMRClientWithAdditionalBundleURL:(NSURL *)bundleURL {}
+
+- (void)addMenuItem:(NSString *)title {}
+
+- (void)setIsShakeToShowDevMenuEnabled:(BOOL)enabled {}
+
+@end

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fix `unresolved reference: loadFonts` in the release build on Android. ([#17241](https://github.com/expo/expo/pull/17241) by [@lukmccall](https://github.com/lukmccall))
-- Fix remote debugging crashing the application on iOS.
+- Fix remote debugging crashing the application on iOS. ([#17248](https://github.com/expo/expo/pull/17248) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fix `unresolved reference: loadFonts` in the release build on Android. ([#17241](https://github.com/expo/expo/pull/17241) by [@lukmccall](https://github.com/lukmccall))
+- Fix remote debugging crashing the application on iOS.
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/ios/DevMenuAppInstance.swift
+++ b/packages/expo-dev-menu/ios/DevMenuAppInstance.swift
@@ -65,6 +65,7 @@ class DevMenuAppInstance: DevMenuBaseAppInstance, RCTBridgeDelegate {
     var modules: [RCTBridgeModule] = [DevMenuInternalModule(manager: manager)]
     modules.append(contentsOf: DevMenuVendoredModulesUtils.vendoredModules())
     modules.append(DevMenuLoadingView.init())
+    modules.append(DevMenuRCTDevSettings.init())
     return modules
   }
 

--- a/packages/expo-dev-menu/ios/DevMenuDevOptionsDelegate.swift
+++ b/packages/expo-dev-menu/ios/DevMenuDevOptionsDelegate.swift
@@ -36,8 +36,11 @@ class DevMenuDevOptionsDelegate {
       return
     }
 
+    DevMenuManager.shared.hideMenu()
+    
     DispatchQueue.main.async {
       devSettings.isDebuggingRemotely = !devSettings.isDebuggingRemotely
+      (DevMenuManager.shared.window?.rootViewController as? DevMenuViewController)?.updateProps() // We have to force props to reflect changes on the UI
     }
   }
 

--- a/packages/expo-dev-menu/ios/DevMenuRCTDevSettings.h
+++ b/packages/expo-dev-menu/ios/DevMenuRCTDevSettings.h
@@ -1,0 +1,12 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+#import <Foundation/Foundation.h>
+#import <React/RCTDevSettings.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface DevMenuRCTDevSettings : RCTDevSettings
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-dev-menu/ios/DevMenuRCTDevSettings.m
+++ b/packages/expo-dev-menu/ios/DevMenuRCTDevSettings.m
@@ -1,0 +1,59 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+#import "DevMenuRCTDevSettings.h"
+
+@implementation DevMenuRCTDevSettings
+
++ (NSString *)moduleName
+{
+  return @"DevSettings";
+}
+
+- (NSArray<NSString *> *)supportedEvents
+{
+  return @[];
+}
+
+- (BOOL)isHotLoadingAvailable
+{
+  return NO;
+}
+
+- (BOOL)isRemoteDebuggingAvailable
+{
+  return NO;
+}
+
++ (BOOL)requiresMainQueueSetup
+{
+  return NO;
+}
+
+- (id)settingForKey:(NSString *)key
+{
+  return nil;
+}
+
+- (void)reload {}
+
+- (void)reloadWithReason:(NSString *)reason {}
+
+- (void)onFastRefresh {}
+
+- (void)setHotLoadingEnabled:(BOOL)isHotLoadingEnabled {}
+
+- (void)setIsDebuggingRemotely:(BOOL)isDebuggingRemotelyEnabled {}
+
+- (void)setProfilingEnabled:(BOOL)isProfilingEnabled {}
+
+- (void)toggleElementInspector {}
+
+- (void)setupHMRClientWithBundleURL:(NSURL *)bundleURL {}
+
+- (void)setupHMRClientWithAdditionalBundleURL:(NSURL *)bundleURL {}
+
+- (void)addMenuItem:(NSString *)title {}
+
+- (void)setIsShakeToShowDevMenuEnabled:(BOOL)enabled {}
+
+@end


### PR DESCRIPTION
# Why

Closes ENG-4755.

# How

It turns out that we have to override the `RTCDevSettings` module, otherwise, some places in the CPP codebase will think that we turn on the remote debugging for the menu/launcher bridges. 
Also, I have to force props to update when `isDebuggingRemotely`was changed. 

# Test Plan

- bare-expo on both platforms ✅