### PR TITLE
[workspace] replace git.io links

### DIFF
--- a/android/ReactCommon/react/nativemodule/core/platform/ios/RCTTurboModule.mm
+++ b/android/ReactCommon/react/nativemodule/core/platform/ios/RCTTurboModule.mm
@@ -625,7 +625,7 @@ NSInvocation *ObjCTurboModule::getMethodInvocation(
       if ([objCArg isKindOfClass:[NSDictionary class]] && hasMethodArgConversionSelector(methodNameNSString, i)) {
         SEL methodArgConversionSelector = getMethodArgConversionSelector(methodNameNSString, i);
 
-        // Message dispatch logic from old infra (link: https://git.io/fjf3U)
+        // Message dispatch logic from old infra (link: https://github.com/facebook/react-native/commit/6783694158057662fd7b11fc123c339b2b21bfe6#diff-263fc157dfce55895cdc16495b55d190R350)
         RCTManagedPointer *(*convert)(id, SEL, id) = (__typeof__(convert))objc_msgSend;
         RCTManagedPointer *box = convert([RCTCxxConvert class], methodArgConversionSelector, objCArg);
 

--- a/docs/pages/versions/unversioned/sdk/imagepicker.md
+++ b/docs/pages/versions/unversioned/sdk/imagepicker.md
@@ -65,7 +65,10 @@ Learn how to configure the native projects in the [installation instructions in 
 
 </ConfigPluginExample>
 
-<!-- look in the plugin directory for the library and see what the options are, then fill in the below table as needed. here's an example plugin: https://git.io/JKlrN -->
+<!-- 
+  Look in the plugin directory for the library and see what the options are, then fill in the below table as needed. 
+  Here's an example plugin: https://github.com/expo/expo/blob/main/packages/expo-image-picker/plugin/src/withImagePicker.ts#L70-L73
+-->
 
 <ConfigPluginProperties properties={[
 { name: 'photosPermission', platform: 'ios', description: 'A string to set the NSPhotoLibraryUsageDescription permission message.', default: '"Allow $(PRODUCT_NAME) to access your photos"' },

--- a/docs/pages/versions/v43.0.0/sdk/imagepicker.md
+++ b/docs/pages/versions/v43.0.0/sdk/imagepicker.md
@@ -63,7 +63,10 @@ Learn how to configure the native projects in the [installation instructions in 
 
 </ConfigPluginExample>
 
-<!-- look in the plugin directory for the library and see what the options are, then fill in the below table as needed. here's an example plugin: https://git.io/JKlrN -->
+<!-- 
+  Look in the plugin directory for the library and see what the options are, then fill in the below table as needed. 
+  Here's an example plugin: https://github.com/expo/expo/blob/main/packages/expo-image-picker/plugin/src/withImagePicker.ts#L70-L73
+-->
 
 <ConfigPluginProperties properties={[
 { name: 'photosPermission', platform: 'ios', description: 'A string to set the NSPhotoLibraryUsageDescription permission message.', default: '"Allow $(PRODUCT_NAME) to access your photos"' },

--- a/docs/pages/versions/v44.0.0/sdk/imagepicker.md
+++ b/docs/pages/versions/v44.0.0/sdk/imagepicker.md
@@ -64,7 +64,10 @@ Learn how to configure the native projects in the [installation instructions in 
 
 </ConfigPluginExample>
 
-<!-- look in the plugin directory for the library and see what the options are, then fill in the below table as needed. here's an example plugin: https://git.io/JKlrN -->
+<!-- 
+  Look in the plugin directory for the library and see what the options are, then fill in the below table as needed. 
+  Here's an example plugin: https://github.com/expo/expo/blob/main/packages/expo-image-picker/plugin/src/withImagePicker.ts#L70-L73
+-->
 
 <ConfigPluginProperties properties={[
 { name: 'photosPermission', platform: 'ios', description: 'A string to set the NSPhotoLibraryUsageDescription permission message.', default: '"Allow $(PRODUCT_NAME) to access your photos"' },

--- a/docs/pages/versions/v45.0.0/sdk/imagepicker.md
+++ b/docs/pages/versions/v45.0.0/sdk/imagepicker.md
@@ -65,7 +65,10 @@ Learn how to configure the native projects in the [installation instructions in 
 
 </ConfigPluginExample>
 
-<!-- look in the plugin directory for the library and see what the options are, then fill in the below table as needed. here's an example plugin: https://git.io/JKlrN -->
+<!-- 
+  Look in the plugin directory for the library and see what the options are, then fill in the below table as needed. 
+  Here's an example plugin: https://github.com/expo/expo/blob/main/packages/expo-image-picker/plugin/src/withImagePicker.ts#L70-L73
+-->
 
 <ConfigPluginProperties properties={[
 { name: 'photosPermission', platform: 'ios', description: 'A string to set the NSPhotoLibraryUsageDescription permission message.', default: '"Allow $(PRODUCT_NAME) to access your photos"' },


### PR DESCRIPTION
# Why

Fixes #17242

# How

This PR replaces link from deprecated git.io service with origin links (without the shortener).

# Test Plan

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
