### PR TITLE
[docs] Remove obsolete workaround for exported sdk indexes

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -104,24 +104,18 @@ module.exports = {
     }
     const pathMap = Object.assign(
       ...Object.entries(defaultPathMap).map(([pathname, page]) => {
-        if (pathname.match(/\/v[1-9][^/]*$/)) {
-          // ends in "/v<version>"
-          pathname += '/index.html'; // TODO: find out why we need to do this
-        }
         if (pathname.match(/unversioned/)) {
+          // Remove unversioned pages from the exported site
           return {};
         } else {
-          // hide versions greater than the package.json version number
+          // Remove newer unreleased versions from the exported side
           const versionMatch = pathname.match(/\/v(\d\d\.\d\.\d)\//);
-          if (
-            versionMatch &&
-            versionMatch[1] &&
-            semver.gt(versionMatch[1], betaVersion || version)
-          ) {
+          if (versionMatch?.[1] && semver.gt(versionMatch[1], betaVersion || version)) {
             return {};
           }
-          return { [pathname]: page };
         }
+
+        return { [pathname]: page };
       })
     );
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "rimraf .next/preval && next dev -p 3002",
-    "build": "cross-env NODE_OPTIONS=--max-old-space-size=5120 next build",
+    "build": "cross-env NODE_OPTIONS=--max-old-space-size=6144 next build",
     "export": "yarn run build && next export && yarn run export-issue-404",
     "export-issue-404": "echo \"🛠  Patching https://github.com/vercel/next.js/issues/16528\"; cp out/404/index.html out/404.html",
     "export-server": "http-server out -p 8000",


### PR DESCRIPTION
# Why

The obsolete workaround was created 3 years ago in response to issues related to `trailingSlash` exports. It looks like this is has been fixed and is now causing issues by exporting `versions/{version}/index.html` as `versions/{version}/index.html/index.html`.

# How

Removed the obsolete workaround, and increased the limit from 5gb to 6gb. I was running into the OOM errors locally too.

# Test Plan

1. See if docs are deployable
2. Check if this link works: https://docs.expo.dev/versions/v45.0.0/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
