### PR TITLE
Inherit environment variables of caller

### DIFF
--- a/packages/expo-updates/scripts/create-manifest-android.gradle
+++ b/packages/expo-updates/scripts/create-manifest-android.gradle
@@ -3,7 +3,7 @@
 import org.apache.tools.ant.taskdefs.condition.Os
 import org.gradle.util.GradleVersion
 
-def expoUpdatesDir = ["node", "-e", "console.log(require('path').dirname(require.resolve('expo-updates/package.json')));"].execute([], projectDir).text.trim()
+def expoUpdatesDir = ['node', '-e', "console.log(require('path').dirname(require.resolve('expo-updates/package.json')));"].execute(null, projectDir).text.trim()
 
 // From a library project role to reference app project settings such as `targetName.toLowerCase().contains("release")`,
 // we extract the `appProject` from all projects here.


### PR DESCRIPTION
# Why

When using asdf with a local environment, the build fails because the script cannot be found. The script is not found because the expoUpdatesDir ends up being empty.

# How

To inherit environment variables of the caller, we must pass in null, not an empty array.

This is needed in cases where node is not available on the global PATH, but rather just the environment in which gradle is being called. For instance, this could happen if using asdf with a local/project environment.

# Test Plan

Remove any globally installed/available versions of node. 
Set up asdf so that it brings in nodejs into the project.
Kick off a build and observe that it fails when the an empty array is used in execute. The script cannot be found.
Replace the empty array with null, and notice that the script can now be found.

# Checklist

I do not use `expo build`, nor do I use `expo prebuild` and EAS build.

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
