### PR TITLE
[ios] Building and decorating JS objects by definition components

### DIFF
--- a/packages/expo-modules-core/ios/Swift/Functions/AnyFunction.swift
+++ b/packages/expo-modules-core/ios/Swift/Functions/AnyFunction.swift
@@ -6,7 +6,7 @@ public typealias FunctionCallResult = Result<Any, Exception>
 /**
  A protocol for any type-erased function.
  */
-public protocol AnyFunction: AnyDefinition {
+public protocol AnyFunction: AnyDefinition, JavaScriptObjectBuilder {
   /**
    Name of the function. JavaScript refers to the function by this name.
    */

--- a/packages/expo-modules-core/ios/Swift/JavaScriptUtils.swift
+++ b/packages/expo-modules-core/ios/Swift/JavaScriptUtils.swift
@@ -1,42 +1,5 @@
 // Copyright 2022-present 650 Industries. All rights reserved.
 
-// FIXME: Calling module's functions needs solid refactoring to not reference the module holder.
-// Instead, it should be possible to directly call the function instance from here. (added by @tsapeta)
-
-/**
- Creates a block that is executed when the module's async function is called.
- */
-internal func createAsyncFunctionBlock(holder: ModuleHolder, name functionName: String) -> JSAsyncFunctionBlock {
-  let moduleName = holder.name
-  return { [weak holder, moduleName] args, resolve, reject in
-    guard let holder = holder else {
-      let exception = ModuleUnavailableException(moduleName)
-      reject(exception.code, exception.description, exception)
-      return
-    }
-    holder.call(function: functionName, args: args) { result in
-      switch result {
-      case .failure(let error):
-        reject(error.code, error.description, nil)
-      case .success(let value):
-        resolve(value)
-      }
-    }
-  }
-}
-
-/**
- Creates a block that is executed when the module's sync function is called.
- */
-internal func createSyncFunctionBlock(holder: ModuleHolder, name functionName: String) -> JSSyncFunctionBlock {
-  return { [weak holder] args in
-    guard let holder = holder else {
-      return nil
-    }
-    return holder.callSync(function: functionName, args: args)
-  }
-}
-
 // MARK: - Arguments
 
 /**

--- a/packages/expo-modules-core/ios/Swift/ModuleHolder.swift
+++ b/packages/expo-modules-core/ios/Swift/ModuleHolder.swift
@@ -56,9 +56,7 @@ public final class ModuleHolder {
    Merges all `constants` definitions into one dictionary.
    */
   func getConstants() -> [String: Any?] {
-    return definition.constants.reduce(into: [String: Any?]()) { dict, definition in
-      dict.merge(definition.body()) { $1 }
-    }
+    return definition.getConstants()
   }
 
   // MARK: Calling functions
@@ -97,22 +95,7 @@ public final class ModuleHolder {
     guard let runtime = appContext?.runtime else {
       return nil
     }
-    let object = runtime.createObject()
-
-    // Fill in with constants
-    for (key, value) in getConstants() {
-      object.setProperty(key, value: value)
-    }
-
-    // Fill in with functions
-    for fn in definition.functions.values {
-      if fn is AnyAsyncFunctionComponent {
-        object.setProperty(fn.name, value: runtime.createAsyncFunction(fn.name, argsCount: fn.argumentsCount, block: createAsyncFunctionBlock(holder: self, name: fn.name)))
-      } else {
-        object.setProperty(fn.name, value: runtime.createSyncFunction(fn.name, argsCount: fn.argumentsCount, block: createSyncFunctionBlock(holder: self, name: fn.name)))
-      }
-    }
-    return object
+    return definition.build(inRuntime: runtime)
   }
 
   // MARK: Listening to native events

--- a/packages/expo-modules-core/ios/Swift/Objects/JavaScriptObjectBuilder.swift
+++ b/packages/expo-modules-core/ios/Swift/Objects/JavaScriptObjectBuilder.swift
@@ -1,0 +1,37 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+/**
+ A type that can decorate a `JavaScriptObject` with some properties.
+ */
+public protocol JavaScriptObjectDecorator {
+  /**
+   Decorates an existing `JavaScriptObject`.
+   */
+  func decorate(object: JavaScriptObject, inRuntime runtime: JavaScriptRuntime)
+}
+
+/**
+ A type that can build and decorate a `JavaScriptObject` based on its attributes.
+ */
+public protocol JavaScriptObjectBuilder: JavaScriptObjectDecorator {
+  /**
+   Creates a decorated `JavaScriptObject` in the given runtime.
+   */
+  func build(inRuntime runtime: JavaScriptRuntime) -> JavaScriptObject
+}
+
+/**
+ Provides the default behavior of `JavaScriptObjectBuilder`.
+ The `build(inRuntime:)` creates a plain object and uses `decorate(object:)` for decoration.
+ */
+extension JavaScriptObjectBuilder {
+  func build(inRuntime runtime: JavaScriptRuntime) -> JavaScriptObject {
+    let object = runtime.createObject()
+    decorate(object: object, inRuntime: runtime)
+    return object
+  }
+
+  func decorate(object: JavaScriptObject, inRuntime runtime: JavaScriptRuntime) {
+    // no-op by default
+  }
+}


### PR DESCRIPTION
# Why

Simplifying things by moving the creation of JS objects to object definition components.
In the future, classes and dynamic properties will need their own logic for building the JS object for the component instance and this is the next step to achieve that goal.
Fixes ENG-4818

# How

- Added `JavaScriptObjectBuilder` and `JavaScriptObjectDecorator` protocols
- Moved the creation of the module object and functions to the component classes

Note: created objects are not cached — we need to build them once per component and can forget about them on the native side, they only exist in VM memory

# Test Plan

iOS unit tests are passing
ExpoModules example in NCL seems to show expected results