### PR TITLE
[templates] fix out of sync template from react-native 0.68

### DIFF
--- a/apps/bare-expo/ios/Podfile
+++ b/apps/bare-expo/ios/Podfile
@@ -70,11 +70,9 @@ abstract_target 'BareExpoMain' do
     # Enables Flipper.
 
     # Uncomment to opt-in to using Flipper
-    # Note that we don't call `flipper_post_install`.
-    # It causes problems with cocoapods. We add the FB_SONARKIT_ENABLED manually instead.
-
+    #
     # if !ENV['CI']
-    #   use_flipper!({ 'Flipper-Folly' => '2.5.3', 'Flipper' => '0.87.0', 'Flipper-RSocket' => '1.3.1' })
+    #   use_flipper!()
     # end
   end
 

--- a/apps/bare-sandbox/ios/Podfile
+++ b/apps/bare-sandbox/ios/Podfile
@@ -26,6 +26,7 @@ target 'bare-sandbox' do
 
   post_install do |installer|
     react_native_post_install(installer)
+    __apply_Xcode_12_5_M1_post_install_workaround(installer)
   end
 
   post_integrate do |installer|

--- a/templates/expo-template-bare-minimum/ios/Podfile
+++ b/templates/expo-template-bare-minimum/ios/Podfile
@@ -25,13 +25,15 @@ target 'HelloWorld' do
   )
 
   # Uncomment to opt-in to using Flipper
+  # Note that if you have use_frameworks! enabled, Flipper will not work
   #
   # if !ENV['CI']
-  #   use_flipper!('Flipper' => '0.75.1', 'Flipper-Folly' => '2.5.3', 'Flipper-RSocket' => '1.3.1')
+  #   use_flipper!()
   # end
 
   post_install do |installer|
     react_native_post_install(installer)
+    __apply_Xcode_12_5_M1_post_install_workaround(installer)
   end
 
   post_integrate do |installer|


### PR DESCRIPTION
# Why

`__apply_Xcode_12_5_M1_post_install_workaround` was missing when i did #15914. that may introduced some build issue on m1 machine when flipper is enabled.

# How

- add missing `__apply_Xcode_12_5_M1_post_install_workaround` as from [react-native 0.68 template](https://github.com/facebook/react-native/blob/b5f1b26a8ff4014e45bbb95c5956ba2c2cf286db/template/ios/Podfile#L35)
- also update `use_flipper!()` statement as from [react-native 0.68 template](https://github.com/facebook/react-native/blob/b5f1b26a8ff4014e45bbb95c5956ba2c2cf286db/template/ios/Podfile#L31). i think the old flipper issue should be already resolved.

# Test Plan

tested on m1 macos

```sh
$ EXPO_BETA=1 expo init sdk45 # select bare
# update ios/Podfile with the change and uncomment use_flipper!()
$ expo run:ios
# test with flipper
```

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
