### PR TITLE
Add uuid dependency back to the expo package

### DIFF
--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -71,7 +71,8 @@
     "invariant": "^2.2.4",
     "md5-file": "^3.2.3",
     "node-fetch": "^2.6.7",
-    "pretty-format": "^26.5.2"
+    "pretty-format": "^26.5.2",
+    "uuid": "^3.4.0"
   },
   "optionalDependencies": {
     "expo-error-recovery": "~3.1.0"


### PR DESCRIPTION
# Why

In https://github.com/expo/expo/pull/16717 we accidentally removed the uuid dependency from the expo package, where it is required for [`getInstallationIdAsync()`](https://github.com/expo/expo/blob/main/packages/expo/src/environment/getInstallationIdAsync.ts).

This PR fixes https://github.com/expo/expo/issues/17261

# How

Add the dependency back after determining that it is indeed still needed.

# Test Plan

The reproducible example from https://github.com/expo/expo/issues/17261 will work with this change.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
