### PR TITLE
[expo-dev-launcher] fix iOS native error screen reload button

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fix crash on initial deep link ([#17268](https://github.com/expo/expo/pull/17268) by [@ajsmth](https://github.com/ajsmth))
 - Fix remote debugging crashing the application on iOS. ([#17248](https://github.com/expo/expo/pull/17248) by [@lukmccall](https://github.com/lukmccall))
+- Fix reload button on iOS native error screen in certain cases.
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - Fix crash on initial deep link ([#17268](https://github.com/expo/expo/pull/17268) by [@ajsmth](https://github.com/ajsmth))
 - Fix remote debugging crashing the application on iOS. ([#17248](https://github.com/expo/expo/pull/17248) by [@lukmccall](https://github.com/lukmccall))
-- Fix reload button on iOS native error screen in certain cases.
+- Fix reload button on iOS native error screen in certain cases. ([#17272](https://github.com/expo/expo/pull/17272) by [@esamelson](https://github.com/esamelson))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.h
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.h
@@ -54,6 +54,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSURL * _Nullable)appManifestURL;
 
+- (nullable NSURL *)appManifestURLWithFallback;
+
 - (BOOL)isAppRunning;
 
 - (BOOL)isStarted;

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -50,6 +50,7 @@
 @property (nonatomic, strong) EXDevLauncherRecentlyOpenedAppsRegistry *recentlyOpenedAppsRegistry;
 @property (nonatomic, strong) EXManifestsManifest *manifest;
 @property (nonatomic, strong) NSURL *manifestURL;
+@property (nonatomic, strong) NSURL *possibleManifestURL;
 @property (nonatomic, strong) EXDevLauncherErrorManager *errorManager;
 @property (nonatomic, strong) EXDevLauncherInstallationIDHelper *installationIDHelper;
 @property (nonatomic, assign) BOOL isStarted;
@@ -140,6 +141,14 @@
 - (NSURL * _Nullable)appManifestURL
 {
   return self.manifestURL;
+}
+
+- (nullable NSURL *)appManifestURLWithFallback
+{
+  if (_manifestURL) {
+    return _manifestURL;
+  }
+  return _possibleManifestURL;
 }
 
 - (UIWindow *)currentWindow
@@ -318,6 +327,7 @@
 
 - (void)loadApp:(NSURL *)expoUrl withProjectUrl:(NSURL * _Nullable)projectUrl onSuccess:(void (^ _Nullable)(void))onSuccess onError:(void (^ _Nullable)(NSError *error))onError
 {
+  _possibleManifestURL = expoUrl;
   BOOL isEASUpdate = [self isEASUpdateURL:expoUrl];
   
   // an update url requires a matching projectUrl
@@ -425,6 +435,7 @@
 {
   self.manifest = manifest;
   self.manifestURL = appUrl;
+  _possibleManifestURL = nil;
   __block UIInterfaceOrientation orientation = [EXDevLauncherManifestHelper exportManifestOrientation:manifest.orientation];
   __block UIColor *backgroundColor = [EXDevLauncherManifestHelper hexStringToColor:manifest.iosOrRootBackgroundColor];
   

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -325,6 +325,13 @@
   [self loadApp:url withProjectUrl:nil onSuccess:onSuccess onError:onError];
 }
 
+/**
+ * This method is the external entry point into loading an app with the dev launcher (e.g. via the
+ * dev launcher UI or a deep link). It takes a URL, determines what type of server it points to
+ * (react-native-cli, expo-cli, or published project), downloads a manifest if there is one,
+ * downloads all the project's assets (via expo-updates) in the case of a published project, and
+ * then calls `_initAppWithUrl:bundleUrl:manifest:` if successful.
+ */
 - (void)loadApp:(NSURL *)expoUrl withProjectUrl:(NSURL * _Nullable)projectUrl onSuccess:(void (^ _Nullable)(void))onSuccess onError:(void (^ _Nullable)(NSError *error))onError
 {
   _possibleManifestURL = expoUrl;
@@ -431,6 +438,13 @@
   }];
 }
 
+/**
+ * Internal helper method for this class, which takes a bundle URL and (optionally) a manifest and
+ * launches the app in the bridge and UI.
+ *
+ * The bundle URL may point to a locally downloaded file (for published projects) or a remote
+ * packager server (for locally hosted projects in development).
+ */
 - (void)_initAppWithUrl:(NSURL *)appUrl bundleUrl:(NSURL *)bundleUrl manifest:(EXManifestsManifest * _Nullable)manifest
 {
   self.manifest = manifest;

--- a/packages/expo-dev-launcher/ios/Errors/EXDevLauncherErrorViewController.swift
+++ b/packages/expo-dev-launcher/ios/Errors/EXDevLauncherErrorViewController.swift
@@ -11,7 +11,7 @@ public class EXDevLauncherErrorViewController: UIViewController, UITableViewData
   @IBOutlet weak var errorStack: UITableView!
 
   @IBAction func reload(_ sender: Any) {
-    guard let appUrl = manager?.controller?.sourceUrl() else {
+    guard let appUrl = manager?.controller?.appManifestURLWithFallback() else {
       // We don't have app url. So we fallback to launcher.
       // Shoudn't happen.
       navigateToLauncher()


### PR DESCRIPTION
# Why

In testing #17268 we discovered that the reload button doesn't work correctly in the case where the dev client was opened via a deep link.

# How

At the beginning of the `loadApp` method, store the URL in local state in case we need to retry before we get further (to the point where we have a manifest / `sourceUrl` is set). Fall back to this URL in the error screen's reload method if we don't yet have a manifest / confirmed `manifestURL`.

This also fixed another lurking bug; the reload button eventually calls `loadApp` but it should always call this method with the `manifestURL` and not the `sourceUrl` (which sometimes points directly to the bundle itself).

# Test Plan

- create new SDK 45 app with dev client
- pull in @ajsmth 's changes from #17268 
- either build onto a real device, or add the following code to EXDevLauncherController.m (to simulate the first load failure / local network permissions dialog showing up) and build onto simulator:
```diff
@@ -378,6 +378,12 @@
   EXDevLauncherManifestParser *manifestParser = [[EXDevLauncherManifestParser alloc] initWithURL:expoUrl installationID:installationID session:[NSURLSession sharedSession]];

   void (^onIsManifestURL)(BOOL) = ^(BOOL isManifestURL) {
+    static BOOL isFirstTry = YES;
+    if (isFirstTry) {
+      isFirstTry = NO;
+      onError([NSError errorWithDomain:@"eric" code:47 userInfo:@{NSLocalizedDescriptionKey: @"Test"}]);
+      return;
+    }
     if (!isManifestURL) {
       // assume this is a direct URL to a bundle hosted by metro
       launchReactNativeApp();
```
- ensure the dev launcher app is closed, not backgrounded
- `expo start --dev-client`, press `i`
- native error screen should show, press Reload
- app should load and show up

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
