### PR TITLE
[github] update Android API version for AVDs on CI

### DIFF
--- a/.github/actions/expo-caches/action.yml
+++ b/.github/actions/expo-caches/action.yml
@@ -25,7 +25,7 @@ inputs:
     required: false
   avd-api:
     description: 'API version used in AVD'
-    default: '29'
+    default: '31'
     required: false
   ndk:
     description: 'Restore NDK cache'

--- a/.github/actions/expo-caches/action.yml
+++ b/.github/actions/expo-caches/action.yml
@@ -144,6 +144,7 @@ runs:
       uses: reactivecircus/android-emulator-runner@v2
       with:
         api-level: ${{ inputs.avd-api }}
+        avd-name: avd-${{ matrix.api-level }}
         arch: x86_64
         force-avd-creation: false
         script: echo "Generated AVD snapshot for caching."

--- a/.github/actions/expo-caches/action.yml
+++ b/.github/actions/expo-caches/action.yml
@@ -132,7 +132,7 @@ runs:
 
     - name: ♻️ Restore AVD cache
       if: inputs.avd == 'true'
-      uses: actions/cache@v3
+      uses: actions/cache@v2
       id: avd-cache
       with:
         path: |

--- a/.github/workflows/android-unit-tests.yml
+++ b/.github/workflows/android-unit-tests.yml
@@ -33,7 +33,7 @@ jobs:
       GRADLE_OPTS: -Dorg.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=1024m
     strategy:
       matrix:
-        api-level: [29]
+        api-level: [31]
     steps:
       - name: ⬢ Setup Node
         uses: actions/setup-node@v3

--- a/.github/workflows/development-client-e2e.yml
+++ b/.github/workflows/development-client-e2e.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: macos-11
     strategy:
       matrix:
-        api-level: [ 31 ]
+        api-level: [31]
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/development-client-e2e.yml
+++ b/.github/workflows/development-client-e2e.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: macos-11
     strategy:
       matrix:
-        api-level: [ 29 ]
+        api-level: [ 31 ]
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/development-client-latest-e2e.yml
+++ b/.github/workflows/development-client-latest-e2e.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: macos-11
     strategy:
       matrix:
-        api-level: [ 31 ]
+        api-level: [31]
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/development-client-latest-e2e.yml
+++ b/.github/workflows/development-client-latest-e2e.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: macos-11
     strategy:
       matrix:
-        api-level: [ 29 ]
+        api-level: [ 31 ]
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/development-client.yml
+++ b/.github/workflows/development-client.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        ndk-version: [ 21.4.7075529 ]
+        ndk-version: [21.4.7075529]
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/shell-app-android.yml
+++ b/.github/workflows/shell-app-android.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        ndk-version: [ 21.4.7075529 ]
+        ndk-version: [21.4.7075529]
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -140,7 +140,7 @@ jobs:
       GRADLE_OPTS: -Dorg.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=2048m
     strategy:
       matrix:
-        api-level: [29]
+        api-level: [31]
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/updates-e2e.yml
+++ b/.github/workflows/updates-e2e.yml
@@ -38,7 +38,7 @@ jobs:
       UPDATES_PORT: 4747
     strategy:
       matrix:
-        api-level: [ 29 ]
+        api-level: [ 31 ]
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/updates-e2e.yml
+++ b/.github/workflows/updates-e2e.yml
@@ -38,7 +38,7 @@ jobs:
       UPDATES_PORT: 4747
     strategy:
       matrix:
-        api-level: [ 31 ]
+        api-level: [31]
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v3

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -68,13 +68,13 @@
         "binaryPath": "android/app/build/outputs/apk/debug/app-debug.apk",
         "build": "cd android && ./gradlew :app:assembleDebug :app:assembleAndroidTest -DtestBuildType=debug && cd ..",
         "type": "android.emulator",
-        "name": "avd-29"
+        "name": "avd-31"
       },
       "android.emu.release": {
         "binaryPath": "android/app/build/outputs/apk/release/app-release.apk",
         "build": "cd android && ./gradlew :app:assembleRelease :app:assembleAndroidTest -DtestBuildType=release && cd ..",
         "type": "android.emulator",
-        "name": "avd-29"
+        "name": "avd-31"
       }
     },
     "runner-config": "./e2e/jest.config.json",

--- a/packages/expo-dev-client/.detoxrc.js
+++ b/packages/expo-dev-client/.detoxrc.js
@@ -18,7 +18,7 @@ module.exports = {
     emulator: {
       type: 'android.emulator',
       device: {
-        avdName: 'avd-29',
+        avdName: 'avd-31',
       },
     },
     simulator: {

--- a/packages/expo-json-utils/android/build.gradle
+++ b/packages/expo-json-utils/android/build.gradle
@@ -86,6 +86,12 @@ android {
 }
 
 dependencies {
+  implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
+
+  if (project.findProject(':expo-modules-test-core')) {
+    testImplementation project(':expo-modules-test-core')
+  }
+
   testImplementation 'junit:junit:4.12'
   testImplementation 'androidx.test:core:1.4.0'
   testImplementation 'org.mockito:mockito-core:1.10.19'
@@ -97,8 +103,6 @@ dependencies {
   androidTestImplementation 'androidx.test:rules:1.4.0'
   androidTestImplementation 'org.mockito:mockito-android:3.7.7'
   androidTestImplementation 'io.mockk:mockk-android:1.12.3'
-
-  implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
 }
 repositories {
   mavenCentral()

--- a/packages/expo-json-utils/android/build.gradle
+++ b/packages/expo-json-utils/android/build.gradle
@@ -86,12 +86,6 @@ android {
 }
 
 dependencies {
-  implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
-
-  if (project.findProject(':expo-modules-test-core')) {
-    testImplementation project(':expo-modules-test-core')
-  }
-
   testImplementation 'junit:junit:4.12'
   testImplementation 'androidx.test:core:1.4.0'
   testImplementation 'org.mockito:mockito-core:1.10.19'
@@ -103,6 +97,8 @@ dependencies {
   androidTestImplementation 'androidx.test:rules:1.4.0'
   androidTestImplementation 'org.mockito:mockito-android:3.7.7'
   androidTestImplementation 'io.mockk:mockk-android:1.12.3'
+
+  implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
 }
 repositories {
   mavenCentral()


### PR DESCRIPTION
# Why

Refs #17162

During the work on workflows refactor we discussed that Android API used on the CI can be updated, but we decided to do this in separate PR.

# How

This PR updates the Android API version used for AVDs on CI tests.

# Test Plan

Run the CI.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
