### PR TITLE
[av][android] Fix crashes caused by accessing exoplayer from the wrong thread

### DIFF
--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- On Android fix `Video` component crashes when activity loses focus due to accessing player from the wrong thread. ([#17280](https://github.com/expo/expo/pull/17280) by [@mnightingale](https://github.com/mnightingale))
+
 ### 💡 Others
 
 ## 11.2.2 — 2022-04-27

--- a/packages/expo-av/android/build.gradle
+++ b/packages/expo-av/android/build.gradle
@@ -140,9 +140,6 @@ android {
 }
 
 dependencies {
-  //noinspection GradleDynamicVersion
-  implementation 'com.facebook.react:react-native:+'
-
   implementation project(':expo-modules-core')
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"


### PR DESCRIPTION
# Why

Closes #17236
Related #16611

The `Video` component uses a helper method `tryRunWithVideoView` for all it's calls which gets the VideoView instance and runs the callback on the main thread => ExoPlayer is initialised on the main/UI thread and all calls into it are also on the main thread.

`Audio` is initialised and interacted with on the Native Modules Queue Thread.

This causes problems because we need to always interact with ExoPlayer from the same thread, but it could have been initialised on different threads.

This PR reverts some of #16611 and ensure that all Audio calls that interact with the ExoPlayer instance are on the main/UI thread.

From the [ExoPlayer threading model](https://exoplayer.dev/doc/reference/com/google/android/exoplayer2/ExoPlayer.html) we are fine to interactive with it from the main thread.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

ExoPlayer docs recommend using the main thread, previous fix resolved problem for audio but broke video.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

- NCL
- @hirbod helped verify the changes :)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
