### PR TITLE
[menu][Android] Fix crashes when the app was launched from a deep link and the react-native-reanimated were installed

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fix `unresolved reference: loadFonts` in the release build on Android. ([#17241](https://github.com/expo/expo/pull/17241) by [@lukmccall](https://github.com/lukmccall))
 - Fix remote debugging crashing the application on iOS. ([#17248](https://github.com/expo/expo/pull/17248) by [@lukmccall](https://github.com/lukmccall))
+- Fix crashes when the app was launched from a deep link and the react-native-reanimated were installed on Android.
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - Fix `unresolved reference: loadFonts` in the release build on Android. ([#17241](https://github.com/expo/expo/pull/17241) by [@lukmccall](https://github.com/lukmccall))
 - Fix remote debugging crashing the application on iOS. ([#17248](https://github.com/expo/expo/pull/17248) by [@lukmccall](https://github.com/lukmccall))
-- Fix crashes when the app was launched from a deep link and the react-native-reanimated were installed on Android.
+- Fix crashes when the app was launched from a deep link and the react-native-reanimated were installed on Android. ([#17282](https://github.com/expo/expo/pull/17282) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
@@ -175,11 +175,16 @@ object DevMenuManager : DevMenuManagerInterface, LifecycleEventListener {
       UiThreadUtil.runOnUiThread {
         devMenuHost.reactInstanceManager.createReactContextInBackground()
 
-        // Hermes inspector will use latest executed script for Chrome DevTools Protocol.
-        // It will be EXDevMenuApp.android.js in our case.
-        // To let Hermes aware target bundle, we try to reload here as a workaround solution.
-        // @see <a href="https://github.com/facebook/react-native/blob/0.63-stable/ReactCommon/hermes/inspector/Inspector.cpp#L231>code here</a>
-        currentReactInstanceManager.get()?.devSupportManager?.handleReloadJS()
+        if (currentReactInstanceManager.get()?.jsExecutorName?.contains("Hermes") == true) {
+          // We have to switch thread to js queue to unload the event loop, otherwise, the app will crash.
+          currentReactInstanceManager.get()?.currentReactContext?.runOnJSQueueThread {
+            // Hermes inspector will use latest executed script for Chrome DevTools Protocol.
+            // It will be EXDevMenuApp.android.js in our case.
+            // To let Hermes aware target bundle, we try to reload here as a workaround solution.
+            // @see <a href="https://github.com/facebook/react-native/blob/0.63-stable/ReactCommon/hermes/inspector/Inspector.cpp#L231>code here</a>
+            currentReactInstanceManager.get()?.devSupportManager?.handleReloadJS()
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
# Why

Closes ENG-4831.

# How

I'm not certain if that patch will cover all crashes, but after applying those changes everything was working as intended. 
I've moved the reload request to the js queue to unload the event loop. I think that the application was doing something very important on the js thread that shouldn't be interrupted. However, in the long run, we should somehow remove that double reload thing in our codebase. 

# Test Plan

- https://github.com/brentvatne/reanimated-four-four ✅
- a project with reanimated and SDK 45 ✅