### PR TITLE
[cli] Add CI info to telemtry

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add CI context to telemetry to help determine support on used CI providers ([#17284](https://github.com/expo/expo/pull/17284) by [@byCedric](https://github.com/byCedric))
+
 ### 🐛 Bug fixes
 
 - Fix bug where autocomplete prompts crash when escape characters are used. ([#17271](https://github.com/expo/expo/pull/17271) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -60,6 +60,7 @@
     "better-opn": "~3.0.2",
     "cacache": "^15.3.0",
     "chalk": "^4.0.0",
+    "ci-info": "^3.3.0",
     "env-editor": "^0.4.1",
     "form-data": "^3.0.1",
     "freeport-async": "2.0.0",

--- a/packages/@expo/cli/src/utils/analytics/__tests__/rudderstackClient-test.ts
+++ b/packages/@expo/cli/src/utils/analytics/__tests__/rudderstackClient-test.ts
@@ -1,0 +1,51 @@
+import os from 'os';
+
+import { getContext } from '../rudderstackClient';
+
+jest.mock('ci-info', () => ({ isCI: true, isPR: true, name: 'GitHub Actions' }));
+
+describe(getContext, () => {
+  const originalVersion = process.env.__EXPO_VERSION;
+  const knownPlatformNames = {
+    darwin: 'Mac',
+    linux: 'Linux',
+    win32: 'Windows',
+  };
+
+  beforeEach(() => {
+    delete process.env.__EXPO_VERSION;
+  });
+
+  afterAll(() => {
+    process.env.__EXPO_VERSION = originalVersion;
+  });
+
+  it('contains os name and version', () => {
+    expect(getContext().os).toMatchObject({
+      name: knownPlatformNames[os.platform()] || os.platform(),
+      version: os.release(),
+    });
+  });
+
+  it('contains device type and model', () => {
+    expect(getContext().device).toMatchObject({
+      type: knownPlatformNames[os.platform()] || os.platform(),
+      model: knownPlatformNames[os.platform()] || os.platform(),
+    });
+  });
+
+  it('contains app name and version', () => {
+    process.env.__EXPO_VERSION = '1337';
+    expect(getContext().app).toMatchObject({
+      name: 'expo',
+      version: '1337',
+    });
+  });
+
+  it('contains ci name and if its executed from PR', () => {
+    expect(getContext().ci).toMatchObject({
+      name: 'GitHub Actions',
+      isPr: true,
+    });
+  });
+});

--- a/packages/@expo/cli/src/utils/analytics/rudderstackClient.ts
+++ b/packages/@expo/cli/src/utils/analytics/rudderstackClient.ts
@@ -1,4 +1,5 @@
 import RudderAnalytics from '@expo/rudder-sdk-node';
+import * as ciInfo from 'ci-info';
 import os from 'os';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -97,11 +98,13 @@ function ensureIdentified(): void {
   identified = true;
 }
 
-function getContext(): Record<string, any> {
+/** Exposed for testing only */
+export function getContext(): Record<string, any> {
   const platform = PLATFORM_TO_ANALYTICS_PLATFORM[os.platform()] || os.platform();
   return {
     os: { name: platform, version: os.release() },
     device: { type: platform, model: platform },
     app: { name: 'expo', version: process.env.__EXPO_VERSION },
+    ci: ciInfo.isCI ? { name: ciInfo.name, isPr: ciInfo.isPR } : undefined,
   };
 }


### PR DESCRIPTION
# Why

Fixes ENG-4044

# How

Just like [`jest-util`](https://github.com/facebook/jest/blob/c8c32d3704469557ecfc3d4a9e81002f11e2075d/packages/jest-util/package.json#L23), this uses ci-info to find the name of the CI provider used.

# Test Plan

See added test

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
