### PR TITLE
[cli] Fix ADB device name filtering for windows

### DIFF
--- a/packages/@expo/cli/src/start/platforms/android/__tests__/adb-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/adb-test.ts
@@ -11,6 +11,7 @@ import {
   isPackageInstalledAsync,
   launchActivityAsync,
   openAppIdAsync,
+  sanitizeAdbDeviceName,
 } from '../adb';
 
 jest.mock('../ADBServer', () => ({
@@ -245,5 +246,23 @@ describe(getDeviceABIsAsync, () => {
       ['x86,armeabi-v7a,armeabi', ''].join('\n')
     );
     await expect(isBootAnimationCompleteAsync()).resolves.toBe(false);
+  });
+});
+
+describe(sanitizeAdbDeviceName, () => {
+  it(`returns the avd device name from single line`, () => {
+    expect(sanitizeAdbDeviceName('Pixel_3_API_28')).toBe('Pixel_3_API_28');
+  });
+
+  it(`returns the avd device name from multi line with LF`, () => {
+    expect(sanitizeAdbDeviceName(`Pixel_4_API_29\nOK`)).toBe('Pixel_4_API_29');
+  });
+
+  it(`returns the avd device name from multi line with CR LF`, () => {
+    expect(sanitizeAdbDeviceName(`Pixel_5_API_30\r\nOK`)).toBe('Pixel_5_API_30');
+  });
+
+  it(`returns the avd device name from multi line with CR`, () => {
+    expect(sanitizeAdbDeviceName(`Pixel_6_API_31\rOK`)).toBe('Pixel_6_API_31');
   });
 });

--- a/packages/@expo/cli/src/start/platforms/android/adb.ts
+++ b/packages/@expo/cli/src/start/platforms/android/adb.ts
@@ -278,7 +278,7 @@ export async function getAdbNameForDeviceIdAsync(device: DeviceContext): Promise
     throw new CommandError('EMULATOR_NOT_FOUND', results);
   }
 
-  return results.trim().split(/\r?\n/).shift() ?? null;
+  return sanitizeAdbDeviceName(results) ?? null;
 }
 
 export async function isDeviceBootedAsync({
@@ -365,4 +365,15 @@ function parseAdbDeviceProperties(devicePropertiesString: string) {
     properties[match[1]] = match[2];
   }
   return properties;
+}
+
+/**
+ * Sanitize the ADB device name to only get the actual device name.
+ * On Windows, we need to do \r, \n, and \r\n filtering to get the name.
+ */
+export function sanitizeAdbDeviceName(deviceName: string) {
+  return deviceName
+    .trim()
+    .split(/[\r\n]+/)
+    .shift();
 }


### PR DESCRIPTION
# Why

Fixes ENG-4822

# How

Found out that the device names on Windows contain a trailing `\r`, and because of that were never properly matched on booted devices.

![image](https://user-images.githubusercontent.com/1203991/165989547-564fe741-f37f-4912-b484-3e2ff6bd8e05.png)

# Test Plan

- Created `sanitizeAdbDeviceName`
- Added all cases of `\r`, `\n`, and `\r\n` splitting
- Added tests to validate these combinations

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
