### PR TITLE
[cli] Disable Android unit tests for cli changes

### DIFF
--- a/.github/workflows/android-unit-tests.yml
+++ b/.github/workflows/android-unit-tests.yml
@@ -11,6 +11,7 @@ on:
       - packages/**/android/**
       - tools/**
       - yarn.lock
+      - '!packages/@expo/cli/**'
   pull_request:
     paths:
       - .github/workflows/android-unit-tests.yml
@@ -19,6 +20,7 @@ on:
       - packages/**/android/**
       - tools/**
       - yarn.lock
+      - '!packages/@expo/cli/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}


### PR DESCRIPTION
# Why

I noticed CLI only PRs and merges are triggering the Android unit tests. That's because we use an `android` folder inside `packages/@expo/cli` 🤷 

# How

Added an exception for the greedy `packages/**/android/**` lookup, [according to the docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-and-excluding-paths)

# Test Plan

See if the next PR changing only `packages/@expo/cli/**/android`.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
