### PR TITLE
[cli] Disable iOS unit tests for cli changes

### DIFF
--- a/.github/workflows/ios-unit-tests.yml
+++ b/.github/workflows/ios-unit-tests.yml
@@ -15,6 +15,7 @@ on:
       - fastlane/**
       - Gemfile.lock
       - .ruby-version
+      - '!packages/@expo/cli/**'
   push:
     branches: [main]
     paths:
@@ -29,6 +30,7 @@ on:
       - fastlane/**
       - Gemfile.lock
       - .ruby-version
+      - '!packages/@expo/cli/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}


### PR DESCRIPTION
# Why

See #17290, this one is for iOS instead of Android.

# How

See #17290

# Test Plan

See #17290

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
