### PR TITLE
[expo-updates][cli] Fix help command parsing

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- (cli) Fix help command parsing. ([#17293](https://github.com/expo/expo/pull/17293) by [@wschurman](https://github.com/wschurman))
+
 ## 0.13.0 — 2022-04-21
 
 ### 🐛 Bug fixes

--- a/packages/expo-updates/cli/cli.ts
+++ b/packages/expo-updates/cli/cli.ts
@@ -2,6 +2,8 @@
 import arg from 'arg';
 import chalk from 'chalk';
 
+import * as Log from './utils/log';
+
 export type Command = (argv?: string[]) => void;
 
 const commands: { [command: string]: () => Promise<Command> } = {
@@ -28,21 +30,23 @@ const command = args._[0];
 const commandArgs = args._.slice(1);
 
 // Handle `--help` flag
-if (args['--help'] || !command) {
-  console.log(chalk`
-    {bold Usage}
-      {bold $} expo-updates <command>
+if ((args['--help'] && !command) || !command) {
+  Log.exit(
+    chalk`
+{bold Usage}
+  {dim $} npx expo-updates <command>
 
-    {bold Available commands}
-      ${Object.keys(commands).sort().join(', ')}
+{bold Commands}
+  ${Object.keys(commands).sort().join(', ')}
 
-    {bold Options}
-      --help, -h      Displays this message
+{bold Options}
+  --help, -h      Displays this message
 
-    For more information run a command with the --help flag
-      {bold $} expo-updates codesigning:generate --help
-  `);
-  process.exit(0);
+For more information run a command with the --help flag
+  {dim $} npx expo-updates codesigning:generate --help
+  `,
+    0
+  );
 }
 
 // Push the help flag to the subcommand args.

--- a/packages/expo-updates/cli/configureCodeSigning.ts
+++ b/packages/expo-updates/cli/configureCodeSigning.ts
@@ -21,16 +21,16 @@ export const configureCodeSigning: Command = async (argv) => {
   if (args['--help']) {
     Log.exit(
       chalk`
-      {bold Description}
-      Configure and validate expo-updates code signing for this project
+{bold Description}
+Configure expo-updates code signing for this project and verify setup
 
-      {bold Usage}
-        $ npx expo-updates codesigning:configure
+{bold Usage}
+  {dim $} npx expo-updates codesigning:configure --certificate-input-directory <dir> --key-input-directory <dir>
 
-        Options
-        --certificate-input-directory <string>     Directory containing code signing certificate
-        --key-input-directory <string>             Directory containing private and public keys
-        -h, --help               Output usage information
+  Options
+  --certificate-input-directory <string>     Directory containing code signing certificate
+  --key-input-directory <string>             Directory containing private and public keys
+  -h, --help                                 Output usage information
     `,
       0
     );

--- a/packages/expo-updates/cli/generateCodeSigning.ts
+++ b/packages/expo-updates/cli/generateCodeSigning.ts
@@ -23,18 +23,18 @@ export const generateCodeSigning: Command = async (argv) => {
   if (args['--help']) {
     Log.exit(
       chalk`
-      {bold Description}
-      Generate expo-updates private key, public key, and code signing certificate using that public key (self-signed by the private key)
+{bold Description}
+Generate expo-updates private key, public key, and code signing certificate using that public key (self-signed by the private key)
 
-      {bold Usage}
-        $ npx expo-updates codesigning:generate
+{bold Usage}
+  {dim $} npx expo-updates codesigning:generate --key-output-directory <dir> --certificate-output-directory <dir> --certificate-validity-duration-years <num years> --certificate-common-name <name>
 
-        Options
-        --key-output-directory <string>                  Directory in which to put the generated private and public keys
-        --certificate-output-directory <string>          Directory in which to put the generated certificate
-        --certificate-validity-duration-years <number>   Validity duration in years
-        --certificate-common-name <string>               Common name attribute for certificate
-        -h, --help                                       Output usage information
+  Options
+  --key-output-directory <string>                  Directory in which to put the generated private and public keys
+  --certificate-output-directory <string>          Directory in which to put the generated certificate
+  --certificate-validity-duration-years <number>   Certificate validity duration in years (number of years before certificate needs rotation)
+  --certificate-common-name <string>               Common name attribute for certificate (generally the human readable name of the organization owning this application)
+  -h, --help                                       Output usage information
     `,
       0
     );


### PR DESCRIPTION
# Why

When dogfooding code signing, I noticed this CLI help needed some work.

Two issues:
- subcommand help didn't work
- docs are a bit out of date

Closes ENG-4843.

# How

Fix subcommand help and re-word things.

# Test Plan

`yarn build:cli`
`yarn expo-updates --help`
`yarn expo-updates codesigning:generate --help`
`yarn expo-updates codesigning:configure --help`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
