### PR TITLE
chore(cli): deduplicate asMock helper function

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### 💡 Others
 
+- deduplicate asMock helper function. ([#17294](https://github.com/expo/expo/pull/17294) by [@wschurman](https://github.com/wschurman))
+
 ## 0.1.3 — 2022-04-28
 
 ### 🐛 Bug fixes

--- a/packages/@expo/cli/src/__tests__/asMock.ts
+++ b/packages/@expo/cli/src/__tests__/asMock.ts
@@ -1,3 +1,3 @@
-// TODO: replace with jest.mocked when jest 28 is upgraded to
+// TODO: replace with jest.mocked when jest 27+ is upgraded to
 export const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
   fn as jest.MockedFunction<T>;

--- a/packages/@expo/cli/src/__tests__/asMock.ts
+++ b/packages/@expo/cli/src/__tests__/asMock.ts
@@ -1,0 +1,3 @@
+// TODO: replace with jest.mocked when jest 28 is upgraded to
+export const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
+  fn as jest.MockedFunction<T>;

--- a/packages/@expo/cli/src/api/__tests__/signManifest-test.ts
+++ b/packages/@expo/cli/src/api/__tests__/signManifest-test.ts
@@ -1,10 +1,9 @@
 import nock from 'nock';
 
+import { asMock } from '../../__tests__/asMock';
 import { getExpoApiBaseUrl } from '../endpoint';
 import { signClassicExpoGoManifestAsync, signExpoGoManifestAsync } from '../signManifest';
 import { ensureLoggedInAsync } from '../user/actions';
-
-const asMock = (fn: any): jest.Mock => fn;
 
 jest.mock('../user/actions', () => ({
   ensureLoggedInAsync: jest.fn(),

--- a/packages/@expo/cli/src/api/rest/__tests__/client-test.ts
+++ b/packages/@expo/cli/src/api/rest/__tests__/client-test.ts
@@ -3,13 +3,12 @@ import nock from 'nock';
 import { FetchError } from 'node-fetch';
 import { URLSearchParams } from 'url';
 
+import { asMock } from '../../../__tests__/asMock';
 import { getExpoApiBaseUrl } from '../../endpoint';
 import UserSettings from '../../user/UserSettings';
 import { ApiV2Error, fetchAsync } from '../client';
 
 jest.mock('../../user/UserSettings');
-
-const asMock = (fn: any): jest.Mock => fn;
 
 it('converts Expo APIv2 error to ApiV2Error', async () => {
   const scope = nock(getExpoApiBaseUrl())
@@ -127,7 +126,12 @@ it('makes an authenticated request with access token', async () => {
 });
 
 it('makes an authenticated request with session secret', async () => {
-  asMock(UserSettings.getSession).mockClear().mockReturnValue({ sessionSecret: 'my-secret-token' });
+  asMock(UserSettings.getSession).mockClear().mockReturnValue({
+    sessionSecret: 'my-secret-token',
+    userId: '',
+    username: '',
+    currentConnection: 'Username-Password-Authentication',
+  });
   asMock(UserSettings.getAccessToken).mockReturnValue(null);
 
   nock(getExpoApiBaseUrl())
@@ -142,7 +146,12 @@ it('makes an authenticated request with session secret', async () => {
 
 it('only uses access token when both authentication methods are available', async () => {
   asMock(UserSettings.getAccessToken).mockClear().mockReturnValue('my-access-token');
-  asMock(UserSettings.getSession).mockClear().mockReturnValue({ sessionSecret: 'my-secret-token' });
+  asMock(UserSettings.getSession).mockClear().mockReturnValue({
+    sessionSecret: 'my-secret-token',
+    userId: '',
+    username: '',
+    currentConnection: 'Username-Password-Authentication',
+  });
 
   nock(getExpoApiBaseUrl())
     .matchHeader('authorization', (val) => val.length === 1 && val[0] === 'Bearer my-access-token')

--- a/packages/@expo/cli/src/api/rest/__tests__/wrapFetchWithProgress-test.ts
+++ b/packages/@expo/cli/src/api/rest/__tests__/wrapFetchWithProgress-test.ts
@@ -4,14 +4,12 @@ import path from 'path';
 import { Stream } from 'stream';
 import { promisify } from 'util';
 
+import { asMock } from '../../../__tests__/asMock';
 import * as Log from '../../../log';
 import { wrapFetchWithProgress } from '../wrapFetchWithProgress';
 
 const fs = jest.requireActual('fs') as typeof import('fs');
 const pipeline = promisify(Stream.pipeline);
-
-const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
-  fn as jest.MockedFunction<T>;
 
 jest.mock(`../../../log`);
 

--- a/packages/@expo/cli/src/api/user/__tests__/actions-test.ts
+++ b/packages/@expo/cli/src/api/user/__tests__/actions-test.ts
@@ -1,3 +1,4 @@
+import { asMock } from '../../../__tests__/asMock';
 import { promptAsync } from '../../../utils/prompts';
 import { ApiV2Error } from '../../rest/client';
 import { showLoginPromptAsync } from '../actions';
@@ -15,8 +16,6 @@ jest.mock('../../rest/client', () => {
 jest.mock('../otp');
 jest.mock('../user');
 
-const asMock = (fn: any): jest.Mock => fn;
-
 beforeEach(() => {
   asMock(promptAsync).mockClear();
   asMock(promptAsync).mockImplementation(() => {
@@ -29,8 +28,8 @@ beforeEach(() => {
 describe(showLoginPromptAsync, () => {
   it('prompts for OTP when 2FA is enabled', async () => {
     asMock(promptAsync)
-      .mockImplementationOnce(() => ({ username: 'hello', password: 'world' }))
-      .mockImplementationOnce(() => ({ otp: '123456' }))
+      .mockImplementationOnce(async () => ({ username: 'hello', password: 'world' }))
+      .mockImplementationOnce(async () => ({ otp: '123456' }))
       .mockImplementation(() => {
         throw new Error("shouldn't happen");
       });
@@ -52,7 +51,7 @@ describe(showLoginPromptAsync, () => {
           },
         });
       })
-      .mockImplementation(() => {});
+      .mockImplementation(async () => {});
 
     await showLoginPromptAsync();
 
@@ -73,7 +72,7 @@ describe(showLoginPromptAsync, () => {
     asMock(promptAsync).mockImplementation(() => {
       throw new Error("shouldn't happen");
     });
-    asMock(loginAsync).mockImplementation(() => {});
+    asMock(loginAsync).mockImplementation(async () => {});
 
     await showLoginPromptAsync({ username: 'hello', password: 'world' });
   });

--- a/packages/@expo/cli/src/api/user/__tests__/otp-test.ts
+++ b/packages/@expo/cli/src/api/user/__tests__/otp-test.ts
@@ -1,5 +1,6 @@
 import nock from 'nock';
 
+import { asMock } from '../../../__tests__/asMock';
 import * as Log from '../../../log';
 import { promptAsync, selectAsync } from '../../../utils/prompts';
 import { getExpoApiBaseUrl } from '../../endpoint';
@@ -9,8 +10,6 @@ import { loginAsync } from '../user';
 jest.mock('../../../utils/prompts');
 jest.mock('../user');
 jest.mock('../../../log');
-
-const asMock = (fn: any): jest.Mock => fn;
 
 beforeEach(() => {
   asMock(promptAsync).mockImplementation(() => {
@@ -26,7 +25,7 @@ beforeEach(() => {
 describe(retryUsernamePasswordAuthWithOTPAsync, () => {
   it('shows SMS OTP prompt when SMS is primary and code was automatically sent', async () => {
     asMock(promptAsync)
-      .mockImplementationOnce(() => ({ otp: 'hello' }))
+      .mockImplementationOnce(async () => ({ otp: 'hello' }))
       .mockImplementation(() => {
         throw new Error("shouldn't happen");
       });
@@ -52,7 +51,7 @@ describe(retryUsernamePasswordAuthWithOTPAsync, () => {
 
   it('shows authenticator OTP prompt when authenticator is primary', async () => {
     asMock(promptAsync)
-      .mockImplementationOnce(() => ({ otp: 'hello' }))
+      .mockImplementationOnce(async () => ({ otp: 'hello' }))
       .mockImplementation(() => {
         throw new Error("shouldn't happen");
       });
@@ -75,15 +74,15 @@ describe(retryUsernamePasswordAuthWithOTPAsync, () => {
 
   it('shows menu when user bails on primary', async () => {
     asMock(promptAsync)
-      .mockImplementationOnce(() => ({ otp: null }))
-      .mockImplementationOnce(() => ({ otp: 'hello' })) // second time it is prompted after selecting backup code
+      .mockImplementationOnce(async () => ({ otp: null }))
+      .mockImplementationOnce(async () => ({ otp: 'hello' })) // second time it is prompted after selecting backup code
       .mockImplementation(() => {
         throw new Error("shouldn't happen");
       });
 
     asMock(selectAsync)
-      .mockImplementationOnce(() => -1)
-      .mockImplementation(() => {
+      .mockImplementationOnce(async () => -1)
+      .mockImplementation(async () => {
         throw new Error("shouldn't happen");
       });
 
@@ -111,7 +110,7 @@ describe(retryUsernamePasswordAuthWithOTPAsync, () => {
 
   it('shows a warning when when user bails on primary and does not have any secondary set up', async () => {
     asMock(promptAsync)
-      .mockImplementationOnce(() => ({ otp: null }))
+      .mockImplementationOnce(async () => ({ otp: null }))
       .mockImplementation(() => {
         throw new Error("shouldn't happen");
       });
@@ -135,15 +134,15 @@ describe(retryUsernamePasswordAuthWithOTPAsync, () => {
 
   it('prompts for authenticator OTP when user selects authenticator secondary', async () => {
     asMock(promptAsync)
-      .mockImplementationOnce(() => ({ otp: null }))
-      .mockImplementationOnce(() => ({ otp: 'hello' })) // second time it is prompted after selecting backup code
+      .mockImplementationOnce(async () => ({ otp: null }))
+      .mockImplementationOnce(async () => ({ otp: 'hello' })) // second time it is prompted after selecting backup code
       .mockImplementation(() => {
         throw new Error("shouldn't happen");
       });
 
     asMock(selectAsync)
-      .mockImplementationOnce(() => -1)
-      .mockImplementation(() => {
+      .mockImplementationOnce(async () => -1)
+      .mockImplementation(async () => {
         throw new Error("shouldn't happen");
       });
 
@@ -170,15 +169,15 @@ describe(retryUsernamePasswordAuthWithOTPAsync, () => {
 
   it('requests SMS OTP and prompts for SMS OTP when user selects SMS secondary', async () => {
     asMock(promptAsync)
-      .mockImplementationOnce(() => ({ otp: null }))
-      .mockImplementationOnce(() => ({ otp: 'hello' })) // second time it is prompted after selecting backup code
+      .mockImplementationOnce(async () => ({ otp: null }))
+      .mockImplementationOnce(async () => ({ otp: 'hello' })) // second time it is prompted after selecting backup code
       .mockImplementation(() => {
         throw new Error("shouldn't happen");
       });
 
     asMock(selectAsync)
-      .mockImplementationOnce(() => 0)
-      .mockImplementation(() => {
+      .mockImplementationOnce(async () => 0)
+      .mockImplementation(async () => {
         throw new Error("shouldn't happen");
       });
 
@@ -214,14 +213,14 @@ describe(retryUsernamePasswordAuthWithOTPAsync, () => {
 
   it('exits when user bails on primary and backup', async () => {
     asMock(promptAsync)
-      .mockImplementationOnce(() => ({ otp: null }))
+      .mockImplementationOnce(async () => ({ otp: null }))
       .mockImplementation(() => {
         throw new Error("shouldn't happen");
       });
 
     asMock(selectAsync)
-      .mockImplementationOnce(() => -2)
-      .mockImplementation(() => {
+      .mockImplementationOnce(async () => -2)
+      .mockImplementation(async () => {
         throw new Error("shouldn't happen");
       });
 

--- a/packages/@expo/cli/src/install/__tests__/checkPackages-test.ts
+++ b/packages/@expo/cli/src/install/__tests__/checkPackages-test.ts
@@ -1,3 +1,4 @@
+import { asMock } from '../../__tests__/asMock';
 import { Log } from '../../log';
 import {
   getVersionedDependenciesAsync,
@@ -6,9 +7,6 @@ import {
 import { confirmAsync } from '../../utils/prompts';
 import { checkPackagesAsync } from '../checkPackages';
 import { installPackagesAsync } from '../installAsync';
-
-const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
-  fn as jest.MockedFunction<T>;
 
 jest.mock('../../log');
 

--- a/packages/@expo/cli/src/run/android/__tests__/resolveInstallApkName-test.ts
+++ b/packages/@expo/cli/src/run/android/__tests__/resolveInstallApkName-test.ts
@@ -1,10 +1,8 @@
 import { vol } from 'memfs';
 
+import { asMock } from '../../../__tests__/asMock';
 import { DeviceABI, getDeviceABIsAsync } from '../../../start/platforms/android/adb';
 import { resolveInstallApkNameAsync } from '../resolveInstallApkName';
-
-const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
-  fn as jest.MockedFunction<T>;
 
 jest.mock('../../../start/platforms/android/adb', () => ({
   DeviceABI: jest.requireActual('../../../start/platforms/android/adb').DeviceABI,

--- a/packages/@expo/cli/src/start/__tests__/resolveOptions-test.ts
+++ b/packages/@expo/cli/src/start/__tests__/resolveOptions-test.ts
@@ -1,7 +1,6 @@
+import { asMock } from '../../__tests__/asMock';
 import { resolvePortAsync } from '../../utils/port';
 import { resolveHostType, resolvePortsAsync } from '../resolveOptions';
-
-const asMock = (fn: any): jest.Mock => fn as jest.Mock;
 
 jest.mock('../../utils/port', () => {
   return {
@@ -35,9 +34,14 @@ describe(resolveHostType, () => {
 
 describe(resolvePortsAsync, () => {
   beforeEach(() => {
-    asMock(resolvePortAsync).mockImplementation((root, { defaultPort, fallbackPort }) =>
-      Promise.resolve(defaultPort ?? fallbackPort)
-    );
+    asMock(resolvePortAsync).mockImplementation(async (root, { defaultPort, fallbackPort }) => {
+      if (typeof defaultPort === 'string' && defaultPort) {
+        return parseInt(defaultPort, 10);
+      } else if (typeof defaultPort === 'number' && defaultPort) {
+        return defaultPort;
+      }
+      return fallbackPort;
+    });
   });
   it(`resolves default port for metro`, async () => {
     await expect(resolvePortsAsync('/noop', {}, { webOnly: false })).resolves.toStrictEqual({

--- a/packages/@expo/cli/src/start/doctor/apple/__tests__/SimulatorAppPrerequisite-test.ts
+++ b/packages/@expo/cli/src/start/doctor/apple/__tests__/SimulatorAppPrerequisite-test.ts
@@ -1,10 +1,8 @@
 import { execAsync } from '@expo/osascript';
 import spawnAsync from '@expo/spawn-async';
 
+import { asMock } from '../../../../__tests__/asMock';
 import { SimulatorAppPrerequisite } from '../SimulatorAppPrerequisite';
-
-const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
-  fn as jest.MockedFunction<T>;
 
 jest.mock(`../../../../log`);
 

--- a/packages/@expo/cli/src/start/doctor/apple/__tests__/XcodePrerequisite-test.ts
+++ b/packages/@expo/cli/src/start/doctor/apple/__tests__/XcodePrerequisite-test.ts
@@ -1,11 +1,9 @@
 import { execSync } from 'child_process';
 
+import { asMock } from '../../../../__tests__/asMock';
 import * as Log from '../../../../log';
 import { confirmAsync } from '../../../../utils/prompts';
 import { getXcodeVersionAsync, XcodePrerequisite } from '../XcodePrerequisite';
-
-const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
-  fn as jest.MockedFunction<T>;
 
 jest.mock(`../../../../log`);
 jest.mock('../../../../utils/prompts');

--- a/packages/@expo/cli/src/start/doctor/apple/__tests__/XcrunPrerequisite-test.ts
+++ b/packages/@expo/cli/src/start/doctor/apple/__tests__/XcrunPrerequisite-test.ts
@@ -1,11 +1,9 @@
 import spawnAsync from '@expo/spawn-async';
 import { execSync } from 'child_process';
 
+import { asMock } from '../../../../__tests__/asMock';
 import { confirmAsync } from '../../../../utils/prompts';
 import { XcrunPrerequisite } from '../XcrunPrerequisite';
-
-const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
-  fn as jest.MockedFunction<T>;
 
 jest.mock(`../../../../log`);
 jest.mock('../../../../utils/prompts');

--- a/packages/@expo/cli/src/start/doctor/dependencies/__tests__/getMissingPackages-test.ts
+++ b/packages/@expo/cli/src/start/doctor/dependencies/__tests__/getMissingPackages-test.ts
@@ -1,14 +1,12 @@
 import { vol } from 'memfs';
 
+import { asMock } from '../../../../__tests__/asMock';
 import {
   collectMissingPackages,
   getMissingPackagesAsync,
   versionSatisfiesRequiredPackage,
 } from '../getMissingPackages';
 import { getCombinedKnownVersionsAsync } from '../getVersionedPackages';
-
-const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
-  fn as jest.MockedFunction<T>;
 
 jest.mock('../getVersionedPackages', () => ({
   getCombinedKnownVersionsAsync: jest.fn(() => []),

--- a/packages/@expo/cli/src/start/doctor/dependencies/__tests__/getVersionedPackages-test.ts
+++ b/packages/@expo/cli/src/start/doctor/dependencies/__tests__/getVersionedPackages-test.ts
@@ -1,3 +1,4 @@
+import { asMock } from '../../../../__tests__/asMock';
 import { getReleasedVersionsAsync } from '../../../../api/getVersions';
 import { getVersionedNativeModulesAsync } from '../bundledNativeModules';
 import {
@@ -5,9 +6,6 @@ import {
   getRemoteVersionsForSdkAsync,
   getVersionedPackagesAsync,
 } from '../getVersionedPackages';
-
-const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
-  fn as jest.MockedFunction<T>;
 
 jest.mock('../../../../api/getVersions', () => ({
   getVersionsAsync: jest.fn(),

--- a/packages/@expo/cli/src/start/doctor/dependencies/__tests__/validateDependenciesVersions-test.ts
+++ b/packages/@expo/cli/src/start/doctor/dependencies/__tests__/validateDependenciesVersions-test.ts
@@ -2,14 +2,12 @@ import { vol } from 'memfs';
 import path from 'path';
 import resolveFrom from 'resolve-from';
 
+import { asMock } from '../../../../__tests__/asMock';
 import * as Log from '../../../../log';
 import {
   logIncorrectDependencies,
   validateDependenciesVersionsAsync,
 } from '../validateDependenciesVersions';
-
-const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
-  fn as jest.MockedFunction<T>;
 
 jest.mock(`../../../../log`);
 jest.mock('../bundledNativeModules', () => ({

--- a/packages/@expo/cli/src/start/doctor/ngrok/__tests__/ExternalModule-test.ts
+++ b/packages/@expo/cli/src/start/doctor/ngrok/__tests__/ExternalModule-test.ts
@@ -1,11 +1,9 @@
 import * as PackageManager from '@expo/package-manager';
 
+import { asMock } from '../../../../__tests__/asMock';
 import { delayAsync } from '../../../../utils/delay';
 import { confirmAsync } from '../../../../utils/prompts';
 import { ExternalModule, ExternalModuleVersionError } from '../ExternalModule';
-
-const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
-  fn as jest.MockedFunction<T>;
 
 jest.mock('../../../../utils/prompts');
 jest.mock('../../../../log');

--- a/packages/@expo/cli/src/start/doctor/web/__tests__/WebSupportProjectPrerequisite-test.ts
+++ b/packages/@expo/cli/src/start/doctor/web/__tests__/WebSupportProjectPrerequisite-test.ts
@@ -1,13 +1,12 @@
-import { getConfig, getProjectConfigDescriptionWithPaths } from '@expo/config';
+import { getConfig, getProjectConfigDescriptionWithPaths, ProjectConfig } from '@expo/config';
 
+import { asMock } from '../../../../__tests__/asMock';
 import * as Log from '../../../../log';
 import { stripAnsi } from '../../../../utils/ansi';
 import {
   isWebPlatformExcluded,
   WebSupportProjectPrerequisite,
 } from '../WebSupportProjectPrerequisite';
-
-const asMock = (fn: any): jest.Mock => fn;
 
 jest.mock('../../../../log');
 jest.mock('@expo/config', () => ({
@@ -83,7 +82,7 @@ describe('_shouldSetupWebSupportAsync', () => {
           platforms: ['ios', 'android'],
         },
       },
-    });
+    } as ProjectConfig);
 
     const prerequisite = new WebSupportProjectPrerequisite(projectRoot);
     await expectThrowsErrorStrippedMessageMatching(
@@ -99,7 +98,7 @@ describe('_shouldSetupWebSupportAsync', () => {
       rootConfig: {
         expo: {},
       },
-    });
+    } as ProjectConfig);
     const prerequisite = new WebSupportProjectPrerequisite(projectRoot);
     await expect(prerequisite._shouldSetupWebSupportAsync()).resolves.toEqual(expect.anything());
   });

--- a/packages/@expo/cli/src/start/platforms/__tests__/AppIdResolver-test.ts
+++ b/packages/@expo/cli/src/start/platforms/__tests__/AppIdResolver-test.ts
@@ -1,5 +1,6 @@
 import { getConfig } from '@expo/config';
 
+import { asMock } from '../../../__tests__/asMock';
 import { AppIdResolver } from '../AppIdResolver';
 
 jest.mock('@expo/config', () => ({
@@ -13,9 +14,6 @@ jest.mock('@expo/config', () => ({
     },
   })),
 }));
-
-const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
-  fn as jest.MockedFunction<T>;
 
 function createAppIdResolver() {
   return new AppIdResolver('/', 'ios', 'foo.bar');

--- a/packages/@expo/cli/src/start/platforms/__tests__/ExpoGoInstaller-test.ts
+++ b/packages/@expo/cli/src/start/platforms/__tests__/ExpoGoInstaller-test.ts
@@ -1,4 +1,5 @@
-import { getVersionsAsync, Versions } from '../../../api/getVersions';
+import { asMock } from '../../../__tests__/asMock';
+import { getVersionsAsync, SDKVersion, Versions } from '../../../api/getVersions';
 import { downloadExpoGoAsync } from '../../../utils/downloadExpoGoAsync';
 import { confirmAsync } from '../../../utils/prompts';
 import { ExpoGoInstaller } from '../ExpoGoInstaller';
@@ -14,9 +15,6 @@ beforeEach(() => {
   // Reset global memo...
   ExpoGoInstaller.cache = {};
 });
-
-const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
-  fn as jest.MockedFunction<T>;
 
 function createInstaller(platform: 'ios' | 'android') {
   return new ExpoGoInstaller(platform, 'host.fake.expo', '44.0.0');
@@ -42,7 +40,7 @@ describe('_getExpectedClientVersionAsync', () => {
         sdkVersions: {
           '44.0.0': {
             androidClientVersion: '1.0.0',
-          },
+          } as SDKVersion,
         },
       });
       await expect(createInstaller('android')._getExpectedClientVersionAsync()).resolves.toBe(
@@ -66,7 +64,7 @@ describe('_getExpectedClientVersionAsync', () => {
         sdkVersions: {
           '44.0.0': {
             iosClientVersion: '1.0.0',
-          },
+          } as SDKVersion,
         },
       });
 

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/ADBServer-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/ADBServer-test.ts
@@ -1,6 +1,7 @@
 import spawnAsync from '@expo/spawn-async';
 import { execFileSync } from 'child_process';
 
+import { asMock } from '../../../../__tests__/asMock';
 import * as Log from '../../../../log';
 import { AbortCommandError } from '../../../../utils/errors';
 import { installExitHooks } from '../../../../utils/exit';
@@ -10,9 +11,6 @@ jest.mock('../../../../log');
 jest.mock('../../../../utils/exit', () => ({
   installExitHooks: jest.fn(),
 }));
-
-const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
-  fn as jest.MockedFunction<T>;
 
 const env = process.env;
 

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/AndroidAppIdResolver-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/AndroidAppIdResolver-test.ts
@@ -1,6 +1,7 @@
 import { getConfig } from '@expo/config';
 import { AndroidConfig } from '@expo/config-plugins';
 
+import { asMock } from '../../../../__tests__/asMock';
 import { AndroidAppIdResolver } from '../AndroidAppIdResolver';
 
 jest.mock('@expo/config-plugins', () => ({
@@ -23,9 +24,6 @@ jest.mock('@expo/config', () => ({
     },
   })),
 }));
-
-const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
-  fn as jest.MockedFunction<T>;
 
 // Most cases are tested in the superclass.
 

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/AndroidDeviceManager-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/AndroidDeviceManager-test.ts
@@ -1,3 +1,4 @@
+import { asMock } from '../../../../__tests__/asMock';
 import { CommandError } from '../../../../utils/errors';
 import { AndroidDeviceManager } from '../AndroidDeviceManager';
 import {
@@ -18,9 +19,6 @@ jest.mock('../adb', () => ({
   openAppIdAsync: jest.fn(),
   openUrlAsync: jest.fn(),
 }));
-
-const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
-  fn as jest.MockedFunction<T>;
 
 const asDevice = (device: Partial<Device>): Device => device as Device;
 

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/activateWindow-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/activateWindow-test.ts
@@ -2,12 +2,10 @@
 import { execAsync } from '@expo/osascript';
 import { execFileSync } from 'child_process';
 
+import { asMock } from '../../../../__tests__/asMock';
 import { activateWindowAsync } from '../activateWindow';
 
 const platform = process.platform;
-
-const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
-  fn as jest.MockedFunction<T>;
 
 function mockPlatform(value: typeof process.platform) {
   Object.defineProperty(process, 'platform', {

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/adb-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/adb-test.ts
@@ -1,3 +1,4 @@
+import { asMock } from '../../../../__tests__/asMock';
 import { CommandError } from '../../../../utils/errors';
 import {
   Device,
@@ -19,9 +20,6 @@ jest.mock('../ADBServer', () => ({
     getFileOutputAsync: jest.fn(async () => ''),
   })),
 }));
-
-const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
-  fn as jest.MockedFunction<T>;
 
 const asDevice = (device: Partial<Device>): Device => device as Device;
 

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/adbReverse-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/adbReverse-test.ts
@@ -1,3 +1,4 @@
+import { asMock } from '../../../../__tests__/asMock';
 import * as Log from '../../../../log';
 import { getAttachedDevicesAsync, getServer } from '../adb';
 import { startAdbReverseAsync, stopAdbReverseAsync } from '../adbReverse';
@@ -17,9 +18,6 @@ jest.mock('../adb', () => {
 jest.mock('../../../../utils/exit', () => ({
   installExitHooks: jest.fn(),
 }));
-
-const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
-  fn as jest.MockedFunction<T>;
 
 describe(startAdbReverseAsync, () => {
   it(`reverses devices`, async () => {

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/emulator-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/emulator-test.ts
@@ -1,6 +1,7 @@
 import spawnAsync from '@expo/spawn-async';
 import { spawn } from 'child_process';
 
+import { asMock } from '../../../../__tests__/asMock';
 import * as ADB from '../adb';
 import { listAvdsAsync, startDeviceAsync } from '../emulator';
 
@@ -12,9 +13,6 @@ jest.mock('../adb', () => ({
   listDevicesAsync: jest.fn(async () => []),
   startDeviceAsync: jest.fn(async () => {}),
 }));
-
-const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
-  fn as jest.MockedFunction<T>;
 
 describe(listAvdsAsync, () => {
   it(`returns list of avds`, async () => {

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/getDevices-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/getDevices-test.ts
@@ -1,3 +1,4 @@
+import { asMock } from '../../../../__tests__/asMock';
 import { CommandError } from '../../../../utils/errors';
 import { getAttachedDevicesAsync } from '../adb';
 import { listAvdsAsync } from '../emulator';
@@ -9,9 +10,6 @@ jest.mock('../adb', () => ({
 jest.mock('../emulator', () => ({
   listAvdsAsync: jest.fn(),
 }));
-
-const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
-  fn as jest.MockedFunction<T>;
 
 it(`asserts no devices are available`, async () => {
   asMock(getAttachedDevicesAsync).mockResolvedValueOnce([]);

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/gradle-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/gradle-test.ts
@@ -1,10 +1,8 @@
 import spawnAsync from '@expo/spawn-async';
 
+import { asMock } from '../../../../__tests__/asMock';
 import { AbortCommandError } from '../../../../utils/errors';
 import { assembleAsync, formatGradleArguments, installAsync, spawnGradleAsync } from '../gradle';
-
-const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
-  fn as jest.MockedFunction<T>;
 
 jest.mock('../../../../utils/env', () => ({
   env: {

--- a/packages/@expo/cli/src/start/platforms/ios/__tests__/AppleAppIdResolver-test.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/__tests__/AppleAppIdResolver-test.ts
@@ -1,6 +1,7 @@
 import { getConfig } from '@expo/config';
 import { IOSConfig } from '@expo/config-plugins';
 
+import { asMock } from '../../../../__tests__/asMock';
 import { AppleAppIdResolver } from '../AppleAppIdResolver';
 
 jest.mock('@expo/config-plugins', () => ({
@@ -24,9 +25,6 @@ jest.mock('@expo/config', () => ({
     },
   })),
 }));
-
-const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
-  fn as jest.MockedFunction<T>;
 
 // Most cases are tested in the superclass.
 

--- a/packages/@expo/cli/src/start/platforms/ios/__tests__/AppleDeviceManager-test.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/__tests__/AppleDeviceManager-test.ts
@@ -1,3 +1,4 @@
+import { asMock } from '../../../../__tests__/asMock';
 import { CommandError } from '../../../../utils/errors';
 import { AppleDeviceManager } from '../AppleDeviceManager';
 import { Device, getInfoPlistValueAsync, openAppIdAsync, openUrlAsync } from '../simctl';
@@ -7,9 +8,6 @@ jest.mock('../simctl', () => ({
   openUrlAsync: jest.fn(),
   getInfoPlistValueAsync: jest.fn(),
 }));
-
-const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
-  fn as jest.MockedFunction<T>;
 
 const asDevice = (device: Partial<Device>): Device => device as Device;
 

--- a/packages/@expo/cli/src/start/platforms/ios/__tests__/getBestSimulator-test.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/__tests__/getBestSimulator-test.ts
@@ -1,10 +1,8 @@
 import spawnAsync from '@expo/spawn-async';
 import { execSync } from 'child_process';
 
+import { asMock } from '../../../../__tests__/asMock';
 import { getBestUnbootedSimulatorAsync } from '../getBestSimulator';
-
-const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
-  fn as jest.MockedFunction<T>;
 
 beforeEach(() => {
   asMock(spawnAsync).mockResolvedValueOnce({

--- a/packages/@expo/cli/src/start/platforms/ios/__tests__/promptAppleDevice-test.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/__tests__/promptAppleDevice-test.ts
@@ -1,10 +1,8 @@
+import { asMock } from '../../../../__tests__/asMock';
 import { getBestSimulatorAsync } from '../getBestSimulator';
 import { sortDefaultDeviceToBeginningAsync } from '../promptAppleDevice';
 
 jest.mock('../getBestSimulator');
-
-const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
-  fn as jest.MockedFunction<T>;
 
 describe(sortDefaultDeviceToBeginningAsync, () => {
   it(`sorts default to the beginning`, async () => {

--- a/packages/@expo/cli/src/start/platforms/ios/__tests__/simctl-test.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/__tests__/simctl-test.ts
@@ -1,12 +1,10 @@
 import spawnAsync from '@expo/spawn-async';
 
+import { asMock } from '../../../../__tests__/asMock';
 import * as Log from '../../../../log';
 import { getContainerPathAsync, getDevicesAsync, getInfoPlistValueAsync } from '../simctl';
 
 jest.mock(`../../../../log`);
-
-const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
-  fn as jest.MockedFunction<T>;
 
 describe(getDevicesAsync, () => {
   it(`returns a list of malformed devices`, async () => {

--- a/packages/@expo/cli/src/start/platforms/ios/__tests__/xcrun-test.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/__tests__/xcrun-test.ts
@@ -1,9 +1,7 @@
 import spawnAsync from '@expo/spawn-async';
 
+import { asMock } from '../../../../__tests__/asMock';
 import { xcrunAsync } from '../xcrun';
-
-const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
-  fn as jest.MockedFunction<T>;
 
 it(`throws on invalid license`, async () => {
   // Mock Simulator.app installed for CI

--- a/packages/@expo/cli/src/start/server/__tests__/AsyncNgrok-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/AsyncNgrok-test.ts
@@ -1,5 +1,6 @@
 import { vol } from 'memfs';
 
+import { asMock } from '../../../__tests__/asMock';
 import { NgrokInstance } from '../../doctor/ngrok/NgrokResolver';
 import { startAdbReverseAsync } from '../../platforms/android/adbReverse';
 import { AsyncNgrok } from '../AsyncNgrok';
@@ -28,9 +29,6 @@ jest.mock('../../platforms/android/adbReverse', () => ({
   startAdbReverseAsync: jest.fn(async () => true),
 }));
 jest.mock('../../../utils/exit');
-
-const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
-  fn as jest.MockedFunction<T>;
 
 function createNgrokInstance() {
   const projectRoot = '/';

--- a/packages/@expo/cli/src/start/server/__tests__/UrlCreator-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/UrlCreator-test.ts
@@ -1,3 +1,4 @@
+import { asMock } from '../../../__tests__/asMock';
 import * as Log from '../../../log';
 import { UrlCreator } from '../UrlCreator';
 
@@ -7,9 +8,6 @@ beforeEach(() => {
   delete process.env.EXPO_PACKAGER_PROXY_URL;
   delete process.env.REACT_NATIVE_PACKAGER_HOSTNAME;
 });
-
-const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
-  fn as jest.MockedFunction<T>;
 
 function createDefaultCreator() {
   return new UrlCreator({}, { port: 8081, getTunnelUrl: () => `http://tunnel.dev/` });

--- a/packages/@expo/cli/src/start/server/__tests__/openPlatforms-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/openPlatforms-test.ts
@@ -1,9 +1,7 @@
+import { asMock } from '../../../__tests__/asMock';
 import { AbortCommandError } from '../../../utils/errors';
 import { DevServerManager } from '../DevServerManager';
 import { openPlatformsAsync } from '../openPlatforms';
-
-const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
-  fn as jest.MockedFunction<T>;
 
 function createDevServerManager() {
   return {

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/ClassicManifestMiddleware-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/ClassicManifestMiddleware-test.ts
@@ -1,3 +1,4 @@
+import { asMock } from '../../../../__tests__/asMock';
 import { APISettings } from '../../../../api/settings';
 import { signClassicExpoGoManifestAsync } from '../../../../api/signManifest';
 import { getUserAsync } from '../../../../api/user/user';
@@ -36,9 +37,6 @@ jest.mock('../resolveEntryPoint', () => ({
 }));
 
 const asReq = (req: Partial<ServerRequest>) => req as ServerRequest;
-
-const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
-  fn as jest.MockedFunction<T>;
 
 beforeEach(() => {
   APISettings.isOffline = false;

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/ExpoGoManifestHandlerMiddleware-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/ExpoGoManifestHandlerMiddleware-test.ts
@@ -6,6 +6,7 @@ import {
 } from '@expo/multipart-body-parser';
 import { vol } from 'memfs';
 
+import { asMock } from '../../../../__tests__/asMock';
 import { getProjectAsync } from '../../../../api/getProject';
 import { APISettings } from '../../../../api/settings';
 import { getUserAsync } from '../../../../api/user/user';
@@ -80,9 +81,6 @@ jest.mock('@expo/config', () => ({
 }));
 
 const asReq = (req: Partial<ServerRequest>) => req as ServerRequest;
-
-const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
-  fn as jest.MockedFunction<T>;
 
 async function getMultipartPartAsync(
   partName: string,

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/InterstitialPageMiddleware-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/InterstitialPageMiddleware-test.ts
@@ -2,6 +2,7 @@ import { getConfig, getNameFromConfig } from '@expo/config';
 import { getRuntimeVersionNullable } from '@expo/config-plugins/build/utils/Updates';
 import { vol } from 'memfs';
 
+import { asMock } from '../../../../__tests__/asMock';
 import { InterstitialPageMiddleware } from '../InterstitialPageMiddleware';
 import { ServerRequest, ServerResponse } from '../server.types';
 
@@ -22,9 +23,6 @@ jest.mock('@expo/config-plugins/build/utils/Updates', () => ({
 }));
 
 const asReq = (req: Partial<ServerRequest>) => req as ServerRequest;
-
-const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
-  fn as jest.MockedFunction<T>;
 
 const originalCwd = process.cwd();
 

--- a/packages/@expo/cli/src/start/server/webpack/__tests__/tls-test.ts
+++ b/packages/@expo/cli/src/start/server/webpack/__tests__/tls-test.ts
@@ -1,13 +1,11 @@
 import { certificateFor } from '@expo/devcert';
 import { vol } from 'memfs';
 
+import { asMock } from '../../../../__tests__/asMock';
 import * as Log from '../../../../log';
 import { ensureEnvironmentSupportsTLSAsync, getTLSCertAsync } from '../tls';
 
 jest.mock('../../../../log');
-
-const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
-  fn as jest.MockedFunction<T>;
 
 const originalEnv = process.env;
 

--- a/packages/@expo/cli/src/utils/__tests__/FileNotifier-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/FileNotifier-test.ts
@@ -1,12 +1,11 @@
 import { fs, vol } from 'memfs';
 
+import { asMock } from '../../__tests__/asMock';
 import * as Log from '../../log';
 import { FileNotifier } from '../FileNotifier';
 
 jest.mock('../../log');
 
-const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
-  fn as jest.MockedFunction<T>;
 const originalCwd = process.cwd();
 
 beforeEach(() => {

--- a/packages/@expo/cli/src/utils/__tests__/codesigning-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/codesigning-test.ts
@@ -1,12 +1,10 @@
 import { vol } from 'memfs';
 
+import { asMock } from '../../__tests__/asMock';
 import { getProjectDevelopmentCertificateAsync } from '../../api/getProjectDevelopmentCertificate';
 import { APISettings } from '../../api/settings';
 import { getCodeSigningInfoAsync, signManifestString } from '../codesigning';
 import { mockExpoRootChain, mockSelfSigned } from './fixtures/certificates';
-
-const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
-  fn as jest.MockedFunction<T>;
 
 jest.mock('../../log');
 jest.mock('@expo/code-signing-certificates', () => ({

--- a/packages/@expo/cli/src/utils/__tests__/editor-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/editor-test.ts
@@ -1,10 +1,8 @@
 import spawnAsync from '@expo/spawn-async';
 import editors from 'env-editor';
 
+import { asMock } from '../../__tests__/asMock';
 import { guessEditor, openInEditorAsync } from '../editor';
-
-const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
-  fn as jest.MockedFunction<T>;
 
 jest.mock('../../log');
 


### PR DESCRIPTION
# Why

Noticed that this code could be deduplicated and better typed in the loosely-typed cases while working on the cli previously.

Closes ENG-4845.

# How

Move to file, update.

# Test Plan

`yarn test`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
