### PR TITLE
Remove the word "create" in line 32

### DIFF
--- a/docs/pages/workflow/publishing.md
+++ b/docs/pages/workflow/publishing.md
@@ -29,7 +29,7 @@ To publish a project, click the Publish button in Expo Dev Tools. (It’s in the
 `expo publish`. No setup is required, go ahead and create a new project
 and publish it without any changes and you will see that it works.
 
-When you do this, the bundler will create minify all your code and generate
+When you do this, the bundler will minify all your code and generate
 two versions of your code (one for iOS, one for Android) and then upload
 those to a free hosting service provided by Expo. You’ll get a link like [https://exp.host/@ccheever/an-example](https://exp.host/@ccheever/an-example)
 that anyone can load your project from.


### PR DESCRIPTION
The line (line 32) reads "When you do this, the bundler will create minify all your code and generate ..." It confused me initially. I think it should simply read,  "When you do this, the bundler will minify all your code and generate ..."

# Why

<!--
I think this a simple mistake
-->

# How

<!--
This is not a feature.
-->

# Test Plan

<!--
This does not require testing, since it is documentation
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
