### PR TITLE
[github] use correct labels for invalid issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_cli.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_cli.yml
@@ -12,7 +12,7 @@ body:
     attributes:
       label: Summary
       description: Describe the issue in 1 or 2 sentences
-      placeholder: Clearly describe what the expected behavior is vs. what is actually happening. This should be as short as possible, while still communicating all the necessary information. If your summary is simply, for example: 'My device cannot connect to Wi-Fi.', then you need to continue debugging yourself and provide more information.
+      placeholder: "Clearly describe what the expected behavior is vs. what is actually happening. This should be as short as possible, while still communicating all the necessary information. If your summary is simply, for example: 'My device cannot connect to Wi-Fi.', then you need to continue debugging yourself and provide more information."
     validations:
       required: true
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: "\U0001F64B Feature Request"
 description: 'Want us to add something to Expo?'
-labels: ['stale', 'pending closure']
+labels: ['invalid issue: feature request']
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/questions.yml
+++ b/.github/ISSUE_TEMPLATE/questions.yml
@@ -1,6 +1,6 @@
 name: '❓ Questions and discussions'
 description: 'You have a question about Expo or want to discuss some aspects of Expo'
-labels: ['stale', 'pending closure']
+labels: ['invalid issue: question']
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
# Why

Lately we have added the additional information labels for the invalid issues, but now, we can use the labels which are connect to the `expo-bot` workflow and were intended for this purpose from the beginning.

# How

Replace `stale` and `pending closure` labels with new `invalid issue: XXX` labels.

I have also fixed a warning reported in one of the issues templates (if sting value includes single or double quotes the whole value must be wrapped with the opposite char).

# Test Plan

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
