### PR TITLE
Update reanimated.md

### DIFF
--- a/docs/pages/versions/unversioned/sdk/reanimated.md
+++ b/docs/pages/versions/unversioned/sdk/reanimated.md
@@ -15,7 +15,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 <APIInstallSection href="https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation" />
 
-**In all cases,** after the installation completes, you must also add the Babel plugin to **babel.config.js**:
+**In all cases,** after the installation completes, you must also add the Babel plugin to either **.babelrc** and/or **babel.config.js**:
 
 ```jsx
 module.exports = function(api) {


### PR DESCRIPTION
I spent a few days on this issue because I forgot about .babelrc and had both files in my project babel can use one, the other, or both files. I've seen on the reanimated repo and expo issues that some people could not resolve this issue and likely it was due to the same mistake overlooking one file or the other. I think adding this can save some people a lot of time.

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
