### PR TITLE
[docs] Add beta documentation for EAS Update Code Signing

### DIFF
--- a/docs/pages/eas-update/code-signing.md
+++ b/docs/pages/eas-update/code-signing.md
@@ -19,24 +19,24 @@ The `expo-updates` library supports end-to-end code signing. Code signing allows
 1. Generate a private key and corresponding code signing certificate for your app:
 
     ```bash
-    yarn expo-updates codesigning:generate \
+    npx expo-updates codesigning:generate \
       --key-output-directory keys \
       --certificate-output-directory certs \
       --certificate-validity-duration-years 10 \
       --certificate-common-name "My App"
     ```
 
-    The generated private key should be kept private and secure.
+    The generated private key must be kept private and secure.
 
 2. Configure your app's builds to use code signing:
 
     ```bash
-    yarn expo-updates codesigning:configure \
+    npx expo-updates codesigning:configure \
       --certificate-input-directory certs \
       --key-input-directory keys
     ```
 
-    After this step, a new build (with a new runtime version) should be created. The code signing certificate will be embedded in this new build.
+    After this step, create a new build with a new runtime version. The code signing certificate will be embedded in this new build.
 
 3. Publish a signed update for your app:
 

--- a/docs/pages/eas-update/code-signing.md
+++ b/docs/pages/eas-update/code-signing.md
@@ -1,0 +1,57 @@
+---
+title: Code Signing
+---
+
+import Head from '~/components/Head'
+
+<Head title="EAS Update Code Signing - Expo Documentation" />
+
+> ⚠️ Expo Updates code signing is in early beta, meaning that it is not yet ready for use in production apps. We may still make breaking changes to the developer-facing portion and the end-user portion as well.
+
+> EAS Update Code Signing is only available to accounts subscribed to the EAS Enterprise plan. [Sign up](https://expo.dev/pricing).
+
+## Introduction
+
+The `expo-updates` library supports end-to-end code signing. Code signing allows developers to cryptographically sign their updates with their own keys. The signatures are then verified on the client before the update is applied, which ensures ISPs, CDNs, cloud providers, and even EAS itself cannot tamper with updates run by apps.
+
+## Code Signing with EAS Update
+
+1. Generate a private key and corresponding code signing certificate for your app:
+
+    ```bash
+    yarn expo-updates codesigning:generate \
+      --key-output-directory keys \
+      --certificate-output-directory certs \
+      --certificate-validity-duration-years 10 \
+      --certificate-common-name "My App"
+    ```
+
+    The generated private key should be kept private and secure.
+
+2. Configure your app's builds to use code signing:
+
+    ```bash
+    yarn expo-updates codesigning:configure \
+      --certificate-input-directory certs \
+      --key-input-directory keys
+    ```
+
+    After this step, a new build (with a new runtime version) should be created. The code signing certificate will be embedded in this new build.
+
+3. Publish a signed update for your app:
+
+    ```bash
+    eas update --private-key-path keys/private-key.pem
+    ```
+
+    During `eas update`, the EAS CLI automatically detects that code signing is configured for your app. It then verifies the integrity of the update and creates a digital signature using your private key. This process is performed locally so that your private key never leaves your machine. The generated signature is automatically sent to EAS to store alongside the update.
+4. Download the update on the client (this step is done automatically by the library). The build from step (2) that is configured for code signing checks if there is a new update available. The server responds with the update published in step (3) and its generated signature. After being downloaded but before being applied, the update is verified against the embedded certificate and included signature. The update is applied if the signature is valid, and rejected otherwise.
+
+## Key Rotation
+
+Key rotation is the process by which the key pair used for signing updates is changed. This is most commonly done in a few cases:
+- Key expiration. In step (1) from the section above, we set `certificate-validity-duration-years` to 10 years (though it can be configured to any value). This means that after 10 years, updates signed with the private key corresponding to the certificate will no longer be valid.
+- Private key compromise. If the private key used to sign updates is accidentally exposed to the public, it can no longer be considered secure and therefore can no longer guarantee itegrity of updates it signed. For example, a malicious actor could craft a malicious update and sign it with the leaked private key.
+- Key rotation for security best practices. It is best practice to rotate keys periodically to ensure that a system is resilient to manual key rotation in response to one of the other reasons above.
+
+In any of these cases, a new key must be generated and new updates must be signed with the new key. To do this, backup the old key and certificate generated in step (1) and re-run the full set of steps above. A new runtime version must be used for the new build to ensure that only updates signed with the new key are run in the new build.

--- a/docs/pages/eas-update/custom-updates-server.md
+++ b/docs/pages/eas-update/custom-updates-server.md
@@ -4,6 +4,4 @@ title: Using expo-updates with a custom updates server
 
 EAS (Expo Application Services) is the Expo team's cloud service that can host and serve updates for an Expo app using the `expo-updates` library. In some cases, you may prefer to use your own servers and control how updates are sent to your app. To accomplish this, it's possible to implement your own custom Expo Updates server that will provide update manifests and assets to your end-users' apps.
 
-The only requirement is that your custom server adheres to the [Expo Updates Protocol](https://github.com/expo/expo/pull/12461). To help get you started, we created a demo repo that implements the protocol that you could deploy and test.
-
-[Custom Expo Updates Server](https://github.com/expo/custom-expo-updates-server)
+The only requirement is that your custom server adheres to the [Expo Updates Protocol](/technical-specs/expo-updates-0). To help get you started, we created a demo repo that implements the protocol that you could deploy and test: [Custom Expo Updates Server](https://github.com/expo/custom-expo-updates-server).

--- a/docs/pages/eas-update/introduction.md
+++ b/docs/pages/eas-update/introduction.md
@@ -8,7 +8,7 @@ import Head from '~/components/Head'
 
 > ⚠️ EAS Update is in "preview", meaning that we may still make breaking developer-facing changes. With that, EAS Update is ready for production apps. While we do not intend to make end-user facing changes, we may require you to make new builds of your project before EAS Update is publicly available. Read through the [known issues](/eas-update/known-issues) to ensure EAS Update is ready for your project.
 
-> EAS Update is currently only available to users subscribed to the Legacy Priority, EAS Production, or EAS Enterprise plans. [Sign up](https://expo.dev/pricing).
+> EAS Update is currently only available to accounts subscribed to the Legacy Priority, EAS Production, or EAS Enterprise plans. [Sign up](https://expo.dev/pricing).
 
 **EAS Update** is a hosted service that serves updates for projects using the `expo-updates` library.
 


### PR DESCRIPTION
# Why

This PR adds documentation for setting up code signing with EAS Update. The feature itself is not yet ready for production, but this will be useful for dogfooding and discussing the feature with interested partners.

Closes ENG-4853.

# How

Add docs.

# Test Plan

Proofread.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
