### PR TITLE
[dev-launcher] handle experience id error in extensions preview

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fix crash on initial deep link ([#17268](https://github.com/expo/expo/pull/17268) by [@ajsmth](https://github.com/ajsmth))
 - Fix remote debugging crashing the application on iOS. ([#17248](https://github.com/expo/expo/pull/17248) by [@lukmccall](https://github.com/lukmccall))
 - Fix reload button on iOS native error screen in certain cases. ([#17272](https://github.com/expo/expo/pull/17272) by [@esamelson](https://github.com/esamelson))
+- Fix infinite query refetching on extensions panel. ([#17314](https://github.com/expo/expo/pull/17314) by [@ajsmth](https://github.com/ajsmth))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/bundle/components/Toasts.tsx
+++ b/packages/expo-dev-launcher/bundle/components/Toasts.tsx
@@ -6,7 +6,9 @@ function ErrorToast({ children }) {
     <View mx="large">
       <View bg="error" padding="medium" rounded="medium" border="error">
         <View>
-          <Text color="error">{children}</Text>
+          <Text color="error" numberOfLines={4}>
+            {children}
+          </Text>
         </View>
       </View>
     </View>

--- a/packages/expo-dev-launcher/bundle/hooks/useDebounce.tsx
+++ b/packages/expo-dev-launcher/bundle/hooks/useDebounce.tsx
@@ -24,7 +24,7 @@ export function useDebounce(value: any, delay: number) {
 
 export function useThrottle<T>(value: T, interval = 500): T {
   const [throttledValue, setThrottledValue] = React.useState<T>(value);
-  const lastExecuted = React.useRef<number>(Date.now());
+  const lastExecuted = React.useRef<number>(Date.now() - interval);
 
   React.useEffect(() => {
     if (Date.now() >= lastExecuted.current + interval) {

--- a/packages/expo-dev-launcher/bundle/queries/useBranchesForApp.tsx
+++ b/packages/expo-dev-launcher/bundle/queries/useBranchesForApp.tsx
@@ -165,8 +165,7 @@ export function useBranchesForApp(appId: string) {
         toastStack.push(() => (
           <Toasts.Error>
             <Text color="error" size="small">
-              {errorMessage?.slice(0, 80) ||
-                `Something went wrong trying to fetch branches for this app`}
+              {errorMessage || `Something went wrong trying to fetch branches for this app`}
             </Text>
           </Toasts.Error>
         ));

--- a/packages/expo-dev-launcher/bundle/screens/ExtensionsScreen.tsx
+++ b/packages/expo-dev-launcher/bundle/screens/ExtensionsScreen.tsx
@@ -37,6 +37,7 @@ export function ExtensionsScreen({ navigation }: ExtensionsScreenProps) {
   const { usesEASUpdates, appId } = useUpdatesConfig();
   const {
     isLoading,
+    error,
     data: branches,
     emptyBranches,
     incompatibleBranches,
@@ -55,8 +56,9 @@ export function ExtensionsScreen({ navigation }: ExtensionsScreenProps) {
   }
 
   const compatibleExtensions: string[] = [];
+  const hasError = error != null && !isLoading;
 
-  if (usesEASUpdates) {
+  if (usesEASUpdates && !hasError) {
     compatibleExtensions.push('EASUpdates');
   }
 
@@ -123,8 +125,8 @@ export function ExtensionsScreen({ navigation }: ExtensionsScreenProps) {
             </>
           )}
 
-          {usesEASUpdates && isAuthenticated && (
-            <>
+          {usesEASUpdates && isAuthenticated && !hasError && (
+            <View>
               <Spacer.Vertical size="medium" />
               <EASUpdatesPreview
                 navigation={navigation}
@@ -134,11 +136,11 @@ export function ExtensionsScreen({ navigation }: ExtensionsScreenProps) {
                 incompatibleBranches={incompatibleBranches}
               />
               <Spacer.Vertical size="medium" />
-            </>
+            </View>
           )}
 
-          {usesEASUpdates && !isAuthenticated && (
-            <>
+          {usesEASUpdates && !isAuthenticated && !hasError && (
+            <View>
               <Spacer.Vertical size="medium" />
               <View mx="medium" padding="medium" bg="default" rounded="large">
                 <Text color="secondary" size="small">
@@ -176,7 +178,7 @@ export function ExtensionsScreen({ navigation }: ExtensionsScreenProps) {
                 </View>
               </View>
               <Spacer.Vertical size="medium" />
-            </>
+            </View>
           )}
 
           {compatibleExtensions.length > 0 && (
@@ -195,6 +197,18 @@ export function ExtensionsScreen({ navigation }: ExtensionsScreenProps) {
                 </Text>
               </View>
             </>
+          )}
+
+          {isLoading && (
+            <View
+              mt="medium"
+              inset="full"
+              align="centered"
+              mx="medium"
+              rounded="large"
+              bg="default">
+              <ActivityIndicator />
+            </View>
           )}
         </View>
       </ScrollView>
@@ -220,14 +234,6 @@ function EASUpdatesPreview({
 
   function onSeeAllBranchesPress() {
     navigation.navigate('Branches');
-  }
-
-  if (isLoading) {
-    return (
-      <View height="44" align="centered" mx="medium" rounded="large" bg="default">
-        <ActivityIndicator />
-      </View>
-    );
   }
 
   const branchCount = branches.length + emptyBranches.length;


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This is just a small improvement for handling errors when an update id is misconfigured - I ran into this while working on a separate issue and thought it was a bit confusing before because the query would show a loading indicator infinitely instead of showing the user an error

# How

<!--
How did you build this feature or fix this bug and why?
-->

Set the query retry amount to a finite number
Updated the error toast to render one item and applied some formatting on the message

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Remove / add an invalid id to the `Expo.plist` or `AndroidManifest.xml` - the error toast should display immediate and the activity indicator the query should still retry a few times, then showing the error toast again after failing:

 
<img width="545" alt="Screen Shot 2022-05-02 at 12 37 58 PM" src="https://user-images.githubusercontent.com/40680668/166314387-88bdd6e4-08a3-489b-80ef-6dcfb879b835.png">



# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
