### PR TITLE
[ci][expo-updates] Add code signing to e2e test

### DIFF
--- a/.github/workflows/updates-e2e.yml
+++ b/.github/workflows/updates-e2e.yml
@@ -63,6 +63,9 @@ jobs:
       - name: 🧶 Yarn install
         if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
+      - name: Build expo-updates CLI
+        working-directory: packages/expo-updates
+        run: yarn build:cli
       - name: 🔧 Install Expo CLI
         run: yarn global add expo-cli
       - name: Init new expo app
@@ -99,6 +102,12 @@ jobs:
       - name: Setup app.config.json
         working-directory: ../updates-e2e
         run: echo "{\"name\":\"updates-e2e\",\"runtimeVersion\":\"1.0.0\",\"plugins\":[\"expo-updates\"],\"android\":{\"package\":\"dev.expo.updatese2e\"},\"ios\":{\"bundleIdentifier\":\"dev.expo.updatese2e\"},\"updates\":{\"url\":\"http://$UPDATES_HOST:$UPDATES_PORT/update\"}}" > app.config.json
+      - name: Generate code signing
+        working-directory: ../updates-e2e
+        run: yarn expo-updates codesigning:generate --key-output-directory keys --certificate-output-directory certs --certificate-validity-duration-years 1 --certificate-common-name "E2E Test App"
+      - name: Configure code signing
+        working-directory: ../updates-e2e
+        run: yarn expo-updates codesigning:configure --certificate-input-directory certs --key-input-directory keys
       - name: Pack latest bare-minimum template as tarball for expo prebuild
         working-directory: templates/expo-template-bare-minimum
         run: echo "$PWD" && npm pack --pack-destination ../../../updates-e2e/
@@ -132,10 +141,15 @@ jobs:
         id: test-update-dist-path
         working-directory: ../updates-e2e/dist
         run: echo "::set-output name=dir::$(pwd)"
+      - name: Get test code signing private key path
+        id: test-code-signing-private-key-path
+        working-directory: ../updates-e2e/keys
+        run: echo "::set-output name=dir::$(pwd)/private-key.pem"
       - name: 🧪 Run tests
         env:
           TEST_APK_PATH: '${{ steps.test-apk-path.outputs.dir }}/app-release.apk'
           TEST_UPDATE_DIST_PATH: '${{ steps.test-update-dist-path.outputs.dir }}'
+          TEST_PRIVATE_KEY_PATH: '${{ steps.test-code-signing-private-key-path.outputs.dir }}'
         timeout-minutes: 30
         uses: reactivecircus/android-emulator-runner@v2
         with:
@@ -167,6 +181,9 @@ jobs:
       - name: 🧶 Yarn install
         if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
+      - name: Build expo-updates CLI
+        working-directory: packages/expo-updates
+        run: yarn build:cli
       - name: 🔧 Install Expo CLI
         run: yarn global add expo-cli
       - name: Init new expo app
@@ -203,6 +220,12 @@ jobs:
       - name: Setup app.config.json
         working-directory: ../updates-e2e
         run: echo "{\"name\":\"updates-e2e\",\"runtimeVersion\":\"1.0.0\",\"plugins\":[\"expo-updates\"],\"android\":{\"package\":\"dev.expo.updatese2e\"},\"ios\":{\"bundleIdentifier\":\"dev.expo.updatese2e\"},\"updates\":{\"url\":\"http://$UPDATES_HOST:$UPDATES_PORT/update\"}}" > app.config.json
+      - name: Generate code signing
+        working-directory: ../updates-e2e
+        run: yarn expo-updates codesigning:generate --key-output-directory keys --certificate-output-directory certs --certificate-validity-duration-years 1 --certificate-common-name "E2E Test App"
+      - name: Configure code signing
+        working-directory: ../updates-e2e
+        run: yarn expo-updates codesigning:configure --certificate-input-directory certs --key-input-directory keys
       - name: Pack latest bare-minimum template as tarball for expo prebuild
         working-directory: templates/expo-template-bare-minimum
         run: npm pack --pack-destination ../../../updates-e2e/
@@ -249,6 +272,10 @@ jobs:
         id: test-update-dist-path
         working-directory: ../updates-e2e/dist
         run: echo "::set-output name=dir::$(pwd)"
+      - name: Get test code signing private key path
+        id: test-code-signing-private-key-path
+        working-directory: ../updates-e2e/keys
+        run: echo "::set-output name=dir::$(pwd)/private-key.pem"
       - name: Start simulator
         run: |
           xcrun simctl list devices -j \
@@ -258,6 +285,7 @@ jobs:
         env:
           TEST_APP_PATH: '${{ steps.test-app-path.outputs.dir }}/updatese2e.app'
           TEST_UPDATE_DIST_PATH: '${{ steps.test-update-dist-path.outputs.dir }}'
+          TEST_PRIVATE_KEY_PATH: '${{ steps.test-code-signing-private-key-path.outputs.dir }}'
         timeout-minutes: 30
         working-directory: packages/expo-updates
         run: yarn test --config e2e/jest.config.ios.js


### PR DESCRIPTION
# Why

This adds code signing to the e2e test so that the full CLI -> manifest signature verification pipeline is tested.

Closes ENG-4841.

# How

Add generate and configure CLI calls to the workflow, add signing to server.

# Test Plan

Wait for CI.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
