### PR TITLE
[ios] Dynamic properties in the Sweet API

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Introduce dynamic properties in the Sweet API on iOS. ([#17318](https://github.com/expo/expo/pull/17318) by [@tsapeta](https://github.com/tsapeta))
+
 ### 🐛 Bug fixes
 
 - Fix modules have not been deallocated during the application reload on iOS. ([#17285](https://github.com/expo/expo/pull/17285) by [@lukmccall](https://github.com/lukmccall))

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptObject.h
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptObject.h
@@ -69,6 +69,11 @@ NS_SWIFT_NAME(JavaScriptObject)
 - (void)setProperty:(nonnull NSString *)name value:(nullable id)value;
 
 /**
+ Defines a new property or modifies an existing property on the object using the property descriptor.
+ */
+- (void)defineProperty:(nonnull NSString *)name descriptor:(nonnull EXJavaScriptObject *)descriptor;
+
+/**
  Defines a new property or modifies an existing property on the object. Calls `Object.defineProperty` under the hood.
  */
 - (void)defineProperty:(nonnull NSString *)name value:(nullable id)value options:(EXJavaScriptObjectPropertyDescriptor)options;

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptObject.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptObject.mm
@@ -62,6 +62,21 @@
   _jsObjectPtr->setProperty(*[_runtime get], [name UTF8String], jsiValue);
 }
 
+- (void)defineProperty:(nonnull NSString *)name descriptor:(nonnull EXJavaScriptObject *)descriptor
+{
+  jsi::Runtime *runtime = [_runtime get];
+  jsi::Object global = runtime->global();
+  jsi::Object objectClass = global.getPropertyAsObject(*runtime, "Object");
+  jsi::Function definePropertyFunction = objectClass.getPropertyAsFunction(*runtime, "defineProperty");
+
+  // This call is basically the same as `Object.defineProperty(object, name, descriptor)` in JS
+  definePropertyFunction.callWithThis(*runtime, objectClass, {
+    jsi::Value(*runtime, *_jsObjectPtr.get()),
+    jsi::String::createFromUtf8(*runtime, [name UTF8String]),
+    std::move(*[descriptor get]),
+  });
+}
+
 - (void)defineProperty:(nonnull NSString *)name value:(nullable id)value options:(EXJavaScriptObjectPropertyDescriptor)options
 {
   jsi::Runtime *runtime = [_runtime get];

--- a/packages/expo-modules-core/ios/JSI/JavaScriptRuntime.swift
+++ b/packages/expo-modules-core/ios/JSI/JavaScriptRuntime.swift
@@ -11,6 +11,7 @@ public extension JavaScriptRuntime {
    - Throws: `JavaScriptEvalException` when evaluated code has invalid syntax or throws an error.
    - Note: It wraps the original `evaluateScript` to better handle and rethrow exceptions.
    */
+  @discardableResult
   func eval(_ source: String) throws -> JavaScriptValue {
     do {
       var result: JavaScriptValue?

--- a/packages/expo-modules-core/ios/Swift/Functions/SyncFunctionComponent.swift
+++ b/packages/expo-modules-core/ios/Swift/Functions/SyncFunctionComponent.swift
@@ -55,7 +55,8 @@ internal final class SyncFunctionComponent<Args, ReturnType>: AnySyncFunctionCom
 
   func call(args: [Any]) throws -> Any {
     do {
-      let argumentsTuple = try Conversions.toTuple(args) as! Args
+      let arguments = try castArguments(args, toTypes: argumentTypes)
+      let argumentsTuple = try Conversions.toTuple(arguments) as! Args
       return try body(argumentsTuple)
     } catch let error as Exception {
       throw FunctionCallException(name).causedBy(error)
@@ -72,8 +73,7 @@ internal final class SyncFunctionComponent<Args, ReturnType>: AnySyncFunctionCom
         return NativeFunctionUnavailableException(name)
       }
       do {
-        let arguments = try castArguments(args, toTypes: self.argumentTypes)
-        return try self.call(args: arguments)
+        return try self.call(args: args)
       } catch {
         return error
       }

--- a/packages/expo-modules-core/ios/Swift/Objects/PropertyComponent.swift
+++ b/packages/expo-modules-core/ios/Swift/Objects/PropertyComponent.swift
@@ -1,0 +1,143 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+public final class PropertyComponent: AnyDefinition {
+  /**
+   Name of the property.
+   */
+  let name: String
+
+  /**
+   Synchronous function that is called when the property is being accessed.
+   */
+  var getter: AnySyncFunctionComponent?
+
+  /**
+   Synchronous function that is called when the property is being set.
+   */
+  var setter: AnySyncFunctionComponent?
+
+  init(name: String) {
+    self.name = name
+  }
+
+  // MARK: - Modifiers
+
+  /**
+   Modifier that sets property getter that has no arguments (the caller is not used).
+   */
+  public func get<Value>(_ getter: @escaping () -> Value) -> Self {
+    self.getter = SyncFunctionComponent(
+      "get",
+      argTypes: [ArgumentType(Any.self)],
+      { (caller: Any) in getter() }
+    )
+    return self
+  }
+
+  /**
+   Modifier that sets property setter that receives only the new value as an argument.
+   */
+  public func set<Value>(_ setter: @escaping (_ newValue: Value) -> ()) -> Self {
+    self.setter = SyncFunctionComponent(
+      "set",
+      argTypes: [ArgumentType(Any.self), ArgumentType(Value.self)],
+      { (caller: Any, value: Value) in setter(value) }
+    )
+    return self
+  }
+
+  /**
+   Modifier that sets property getter that receives the caller as an argument.
+   The caller is an object on which the function is called, like `this` in JavaScript.
+   */
+  public func get<Value, Caller>(_ getter: @escaping (_ this: Caller) -> Value) -> Self {
+    self.getter = SyncFunctionComponent(
+      "get",
+      argTypes: [ArgumentType(Caller.self)],
+      getter
+    )
+    return self
+  }
+
+  /**
+   Modifier that sets property setter that receives the caller and the new value as arguments.
+   The caller is an object on which the function is called, like `this` in JavaScript.
+   */
+  public func set<Value, Caller>(_ setter: @escaping (_ this: Caller, _ newValue: Value) -> ()) -> Self {
+    self.setter = SyncFunctionComponent(
+      "set",
+      argTypes: [ArgumentType(Caller.self), ArgumentType(Value.self)],
+      setter
+    )
+    return self
+  }
+
+  // MARK: - Internals
+
+  internal func getValue<Value>(caller: Any? = nil) -> Value? {
+    let value = try? getter?.call(args: [caller as Any])
+    return value as? Value
+  }
+
+  internal func setValue(_ value: Any, caller: Any? = nil) {
+    let _ = try? setter?.call(args: [caller as Any, value])
+  }
+
+  /**
+   Creates the JavaScript function that will be used as a getter of the property.
+   */
+  internal func buildGetter(inRuntime runtime: JavaScriptRuntime, withCaller caller: AnyObject?) -> JavaScriptObject {
+    return runtime.createSyncFunction(name, argsCount: 0) { [weak self, weak caller] args in
+      return self?.getValue(caller: caller)
+    }
+  }
+
+  /**
+   Creates the JavaScript function that will be used as a setter of the property.
+   */
+  internal func buildSetter(inRuntime runtime: JavaScriptRuntime, withCaller caller: AnyObject?) -> JavaScriptObject {
+    return runtime.createSyncFunction(name, argsCount: 1) { [weak self, weak caller] args in
+      return self?.setValue(args.first as Any, caller: caller)
+    }
+  }
+
+  /**
+   Creates the JavaScript object representing the property descriptor.
+   */
+  internal func buildDescriptor(inRuntime runtime: JavaScriptRuntime, withCaller caller: AnyObject?) -> JavaScriptObject {
+    let descriptor = runtime.createObject()
+
+    descriptor.setProperty("enumerable", value: true)
+
+    if getter != nil {
+      descriptor.setProperty("get", value: buildGetter(inRuntime: runtime, withCaller: caller))
+    }
+    if setter != nil {
+      descriptor.setProperty("set", value: buildSetter(inRuntime: runtime, withCaller: caller))
+    }
+    return descriptor
+  }
+}
+
+// MARK: - Factory functions
+
+/**
+ Creates the property with given name. The component is basically no-op if you don't call `.get(_:)` or `.set(_:)` on it.
+ */
+public func Property(_ name: String) -> PropertyComponent {
+  return PropertyComponent(name: name)
+}
+
+/**
+ Creates the read-only property whose getter doesn't take the caller as an argument.
+ */
+public func Property<Value: AnyArgument>(_ name: String, get: @escaping () -> Value) -> PropertyComponent {
+  return PropertyComponent(name: name).get(get)
+}
+
+/**
+ Creates the read-only property whose getter takes the caller as an argument.
+ */
+public func Property<Value: AnyArgument, Caller>(_ name: String, get: @escaping (Caller) -> Value) -> PropertyComponent {
+  return PropertyComponent(name: name).get(get)
+}

--- a/packages/expo-modules-core/ios/Tests/PropertyComponentSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/PropertyComponentSpec.swift
@@ -1,0 +1,95 @@
+import ExpoModulesTestCore
+
+@testable import ExpoModulesCore
+
+class PropertyComponentSpec: ExpoSpec {
+  override func spec() {
+    describe("property") {
+      it("gets the value") {
+        let property = Property("test") { return "expo" }
+        expect(property.getValue()) == "expo"
+      }
+
+      it("sets the value") {
+        var value = Int.random(in: 0..<100)
+        let property = Property("test")
+          .get { value }
+          .set { (newValue: Int) in
+            value = newValue
+          }
+
+        let newValue = Int.random(in: 0..<100)
+        property.setValue(newValue)
+
+        expect(property.getValue()) == value
+        expect(value) == newValue
+      }
+    }
+
+    describe("module property") {
+      let appContext = AppContext.create()
+      let runtime = appContext.runtime
+
+      beforeSuite {
+        class PropertyTestModule: Module {
+          func definition() -> ModuleDefinition {
+            Name("PropertyTest")
+
+            Property("readOnly") {
+              return "foo"
+            }
+
+            var writablePropertyValue = 444
+            Property("writable")
+              .get {
+                return writablePropertyValue
+              }
+              .set { value in
+                writablePropertyValue = value
+              }
+
+            Property("withCaller") { (caller: JavaScriptObject) -> String in
+              // Here, the caller is a JS object of the module.
+              // Return another property of itself.
+              return caller.getProperty("readOnly").getString()
+            }
+
+            Property("undefined")
+          }
+        }
+        appContext.moduleRegistry.register(moduleType: PropertyTestModule.self)
+      }
+
+      it("gets read-only property") {
+        let value = try runtime?.eval("ExpoModules.PropertyTest.readOnly")
+        expect(value?.getString()) == "foo"
+      }
+
+      it("gets writable property") {
+        let value = try runtime?.eval("ExpoModules.PropertyTest.writable")
+        expect(value?.getInt()) == 444
+      }
+
+      it("sets writable property") {
+        try runtime?.eval("ExpoModules.PropertyTest.writable = 777")
+        let value = try runtime?.eval("ExpoModules.PropertyTest.writable")
+        expect(value?.getInt()) == 777
+      }
+
+      it("is enumerable") {
+        let keys = try runtime?.eval("Object.keys(ExpoModules.PropertyTest)").getArray().map { $0.getString() } ?? []
+        expect(keys).to(contain("readOnly", "writable", "withCaller", "undefined"))
+      }
+
+      it("is called with the caller") {
+        let value = try runtime?.eval("ExpoModules.PropertyTest.withCaller")
+        expect(value?.getString()) == "foo"
+      }
+
+      it("returns undefined when getter is not specified") {
+        let value = try runtime?.eval("ExpoModules.PropertyTest.undefined")
+        expect(value?.isUndefined()) == true
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Why

Provide an API for object properties with native getter and setter. There are some cases, where the module's constants are not the best solution, because they are constants and evaluated only when the module is loading. `expo-cellular` was a good example in the past, it exposed some values as constants that can actually change over time on the native side.
Of course, you can always use a function instead, but isn't an object property more natural for devs?

In the future, we'll use the `Property` component inside JS classes as well and for this reason I added the second version of getter and setter that takes the "caller" as the first argument. It would work like `this` in JS.

Closes ENG-4540

# How

This basically works like `Object.defineProperty` in JS.
You can find some examples in the test spec. Just a quick demo below:

```swift
// shorthand style for read-only dynamic property
Property("expo") {
  return "modules"
}

// property with getter and setter
Property("expo")
  .get {
    return "modules"
  }
  .set { (newValue: String) in
    // set something
  }
```

# Test Plan

Added some tests that cover this functionality. All tests are passing.