### PR TITLE
[expo-updates][cli] Fix success message

### DIFF
--- a/packages/expo-updates/cli/configureCodeSigningAsync.ts
+++ b/packages/expo-updates/cli/configureCodeSigningAsync.ts
@@ -53,5 +53,5 @@ export async function configureCodeSigningAsync(
     }
   );
 
-  log(`Code signing configuration written to app.json.`);
+  log(`Code signing configuration written to app configuration.`);
 }


### PR DESCRIPTION
# Why

The configuration isn't always stored in `app.json`. Sometimes it's stored in `app.config.json` or *.js` files of the same prefix. This updates the success message to be more generic.

# How

Change success message.

# Test Plan

Inspect.