### PR TITLE
[build-properties] Fix android build failure

### DIFF
--- a/.github/workflows/updates-e2e.yml
+++ b/.github/workflows/updates-e2e.yml
@@ -13,6 +13,7 @@ on:
       - packages/expo-updates/**
       - packages/expo/android/**
       - packages/expo/ios/**
+      - templates/expo-template-bare-minimum/**
   push:
     branches: [main, 'sdk-*']
     paths:
@@ -25,6 +26,7 @@ on:
       - packages/expo-updates/**
       - packages/expo/android/**
       - packages/expo/ios/**
+      - templates/expo-template-bare-minimum/**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
@@ -113,7 +115,7 @@ jobs:
         run: sed -i -e "s/UPDATES_HOST/$UPDATES_HOST/" ./App.js && sed -i -e "s/UPDATES_PORT/$UPDATES_PORT/" ./App.js
       - name: Assemble release APK
         working-directory: ../updates-e2e/android
-        run: ./gradlew assembleRelease
+        run: ./gradlew assembleRelease --stacktrace
       - name: Copy APK to working directory
         run: cp -R ../updates-e2e/android/app/build/outputs/apk artifact
       - name: Upload test APK artifact

--- a/templates/expo-template-bare-minimum/android/build.gradle
+++ b/templates/expo-template-bare-minimum/android/build.gradle
@@ -6,8 +6,8 @@ buildscript {
     ext {
         buildToolsVersion = findProperty('android.buildToolsVersion') ?: "31.0.0"
         minSdkVersion = 21
-        compileSdkVersion = Integer.parseInt(findProperty('android.compileSdkVersion') ?: 31)
-        targetSdkVersion = Integer.parseInt(findProperty('android.targetSdkVersion') ?: 31)
+        compileSdkVersion = Integer.parseInt(findProperty('android.compileSdkVersion') ?: "31")
+        targetSdkVersion = Integer.parseInt(findProperty('android.targetSdkVersion') ?: "31")
         if (hasProperty('android.kotlinVersion')) {
             kotlinVersion = findProperty('android.kotlinVersion')
         }


### PR DESCRIPTION
# Why

Blame: https://github.com/expo/expo/commit/e46083249c96983fbd12c67c1114edbea2d2ca13

Error was about `parseInt` not being able to parse an int. Example run: https://github.com/expo/expo/runs/6278432166?check_suite_focus=true

# How

Make the fallback a string. Also run the suite that depends on this template when the template is changed so this is caught sooner.

# Test Plan

Wait for CI.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
