### PR TITLE
[expo-updates] add more test coverage around older updates

### DIFF
--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/selectionpolicy/SelectionPolicyFilterAwareTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/selectionpolicy/SelectionPolicyFilterAwareTest.kt
@@ -92,6 +92,13 @@ class SelectionPolicyFilterAwareTest {
   }
 
   @Test
+  fun testShouldLoadNewUpdate_NormalCase_OlderUpdate() {
+    // this could happen if the embedded update is newer than the most recently published update
+    val actual = selectionPolicy.shouldLoadNewUpdate(updateRollout1, updateRollout2, manifestFilters)
+    Assert.assertFalse(actual)
+  }
+
+  @Test
   fun testShouldLoadNewUpdate_NoneMatchingFilters() {
     // should choose to load an older update if the current update doesn't match the manifest filters
     val actual = selectionPolicy.shouldLoadNewUpdate(updateRollout1, updateDefault2, manifestFilters)

--- a/packages/expo-updates/e2e/__tests__/Updates-e2e.test.ts
+++ b/packages/expo-updates/e2e/__tests__/Updates-e2e.test.ts
@@ -38,6 +38,18 @@ function convertToDictionaryItemsRepresentation(obj: { [key: string]: string }):
   );
 }
 
+async function serveUpdateWithManifest(manifest: any) {
+  const privateKey = await getPrivateKeyAsync();
+  const manifestString = JSON.stringify(manifest);
+  const hashSignature = signRSASHA256(manifestString, privateKey);
+  const dictionary = convertToDictionaryItemsRepresentation({
+    sig: hashSignature,
+    keyid: 'main',
+  });
+  const signature = serializeDictionary(dictionary);
+  Server.serveManifest(manifest, { 'expo-protocol-version': '0', 'expo-signature': signature });
+}
+
 beforeEach(async () => {});
 
 afterEach(async () => {
@@ -79,7 +91,9 @@ test('initial request includes correct update-id headers', async () => {
 
 test('downloads and runs update, and updates current-update-id header', async () => {
   jest.setTimeout(300000 * TIMEOUT_BIAS);
-  const hash = await copyBundleToStaticFolder('bundle1.js', 'test-update-1');
+  const bundleFilename = 'bundle1.js';
+  const newNotifyString = 'test-update-1';
+  const hash = await copyBundleToStaticFolder(bundleFilename, newNotifyString);
   const manifest = {
     id: uuid(),
     createdAt: new Date().toISOString(),
@@ -88,24 +102,15 @@ test('downloads and runs update, and updates current-update-id header', async ()
       hash,
       key: 'test-update-1-key',
       contentType: 'application/javascript',
-      url: `http://${SERVER_HOST}:${SERVER_PORT}/static/bundle1.js`,
+      url: `http://${SERVER_HOST}:${SERVER_PORT}/static/${bundleFilename}`,
     },
     assets: [],
     metadata: {},
     extra: {},
   };
 
-  const privateKey = await getPrivateKeyAsync();
-  const manifestString = JSON.stringify(manifest);
-  const hashSignature = signRSASHA256(manifestString, privateKey);
-  const dictionary = convertToDictionaryItemsRepresentation({
-    sig: hashSignature,
-    keyid: 'main',
-  });
-  const signature = serializeDictionary(dictionary);
-
   Server.start(SERVER_PORT);
-  Server.serveManifest(manifest, { 'expo-protocol-version': '0', 'expo-signature': signature });
+  await serveUpdateWithManifest(manifest);
   await Simulator.installApp();
   await Simulator.startApp();
   const firstRequest = await Server.waitForUpdateRequest(10000 * TIMEOUT_BIAS);
@@ -114,13 +119,14 @@ test('downloads and runs update, and updates current-update-id header', async ()
 
   // give the app time to load the new update in the background
   await setTimeout(2000 * TIMEOUT_BIAS);
+  expect(Server.consumeRequestedStaticFiles().length).toBe(1);
 
   // restart the app so it will launch the new update
   await Simulator.stopApp();
   await Simulator.startApp();
   const secondRequest = await Server.waitForUpdateRequest(10000 * TIMEOUT_BIAS);
   const updatedResponse = await Server.waitForResponse(10000 * TIMEOUT_BIAS);
-  expect(updatedResponse).toBe('test-update-1');
+  expect(updatedResponse).toBe(newNotifyString);
 
   expect(secondRequest.headers['expo-embedded-update-id']).toBeDefined();
   expect(secondRequest.headers['expo-embedded-update-id']).toEqual(
@@ -128,4 +134,43 @@ test('downloads and runs update, and updates current-update-id header', async ()
   );
   expect(secondRequest.headers['expo-current-update-id']).toBeDefined();
   expect(secondRequest.headers['expo-current-update-id']).toEqual(manifest.id);
+});
+
+// important for billing accuracy
+test('does not download any assets for an older update', async () => {
+  jest.setTimeout(300000 * TIMEOUT_BIAS);
+  const bundleFilename = 'bundle-old.js';
+  const hash = await copyBundleToStaticFolder(bundleFilename, 'test-update-older');
+  const manifest = {
+    id: uuid(),
+    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24).toISOString(), // yesterday
+    runtimeVersion: RUNTIME_VERSION,
+    launchAsset: {
+      hash,
+      key: 'test-update-old-key',
+      contentType: 'application/javascript',
+      url: `http://${SERVER_HOST}:${SERVER_PORT}/static/${bundleFilename}`,
+    },
+    assets: [],
+    metadata: {},
+    extra: {},
+  };
+
+  Server.start(SERVER_PORT);
+  await serveUpdateWithManifest(manifest);
+  await Simulator.installApp();
+  await Simulator.startApp();
+  await Server.waitForUpdateRequest(10000 * TIMEOUT_BIAS);
+  const firstResponse = await Server.waitForResponse(10000 * TIMEOUT_BIAS);
+  expect(firstResponse).toBe('test');
+
+  // give the app time to load the new update in the background (i.e. to make sure it doesn't)
+  await setTimeout(3000 * TIMEOUT_BIAS);
+  expect(Server.consumeRequestedStaticFiles().length).toBe(0);
+
+  // restart the app and make sure it's still running the initial update
+  await Simulator.stopApp();
+  await Simulator.startApp();
+  const secondResponse = await Server.waitForResponse(10000 * TIMEOUT_BIAS);
+  expect(secondResponse).toBe('test');
 });

--- a/packages/expo-updates/e2e/__tests__/Updates-e2e.test.ts
+++ b/packages/expo-updates/e2e/__tests__/Updates-e2e.test.ts
@@ -136,7 +136,7 @@ test('downloads and runs update, and updates current-update-id header', async ()
   expect(secondRequest.headers['expo-current-update-id']).toEqual(manifest.id);
 });
 
-// important for billing accuracy
+// important for usage accuracy
 test('does not download any assets for an older update', async () => {
   jest.setTimeout(300000 * TIMEOUT_BIAS);
   const bundleFilename = 'bundle-old.js';

--- a/packages/expo-updates/e2e/__tests__/utils/server.ts
+++ b/packages/expo-updates/e2e/__tests__/utils/server.ts
@@ -9,6 +9,7 @@ let notifyString: string | null = null;
 let updateRequest: any = null;
 let manifestToServe: any = null;
 let manifestHeadersToServe: any = null;
+let requestedStaticFiles: string[] = [];
 
 export function start(port: number) {
   if (!server) {
@@ -25,8 +26,19 @@ export function stop() {
   updateRequest = null;
   manifestToServe = null;
   manifestHeadersToServe = null;
+  requestedStaticFiles = [];
 }
 
+export function consumeRequestedStaticFiles() {
+  const returnArray = requestedStaticFiles;
+  requestedStaticFiles = [];
+  return returnArray;
+}
+
+app.use('/static', (req: any, res: any, next: any) => {
+  requestedStaticFiles.push(path.basename(req.url));
+  next();
+});
 app.use('/static', express.static(path.resolve(__dirname, '..', '.static')));
 
 app.get('/notify/:string', (req: any, res: any) => {

--- a/packages/expo-updates/ios/Tests/EXUpdatesSelectionPolicyFilterAwareTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesSelectionPolicyFilterAwareTests.m
@@ -163,6 +163,12 @@
   XCTAssertFalse([_selectionPolicy shouldLoadNewUpdate:_updateRollout1 withLaunchedUpdate:_updateRollout1 filters:_manifestFilters]);
 }
 
+- (void)testShouldLoadNewUpdate_NormalCase_OlderUpdate
+{
+  // this could happen if the embedded update is newer than the most recently published update
+  XCTAssertFalse([_selectionPolicy shouldLoadNewUpdate:_updateRollout1 withLaunchedUpdate:_updateRollout2 filters:_manifestFilters]);
+}
+
 - (void)testShouldLoadNewUpdate_NoneMatchingFilters
 {
   XCTAssertTrue([_selectionPolicy shouldLoadNewUpdate:_updateRollout1 withLaunchedUpdate:_updateDefault2 filters:_manifestFilters], @"should choose to load an older update if the current update doesn't match the manifest filters");


### PR DESCRIPTION
# Why

It's important that the client doesn't download updates that it doesn't use, because (among other reasons) this would result in developers being billed for updates that aren't actually being applied.

One common case where this might occur is in a build whose embedded update is newer than the most recently published update. In this case, we do not and should not download the update's assets. While we have some unit test coverage around this, this is a great case to ensure we have e2e coverage around as well.

# How

Added another e2e test which hosts an update with an older `createdAt` timestamp and ensures that no request is made for the bundle asset.

Also, added one more unit test on each platform that explicitly covers this case (even though we should be ok with the unit tests that are already there).

# Test Plan

Let's see if CI passes with the latest changes pulled in...

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
