### PR TITLE
[dev-client][ios] Register as debug only module

### DIFF
--- a/packages/expo-dev-client/CHANGELOG.md
+++ b/packages/expo-dev-client/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix `no such module 'EXDevLauncher'` when compiling the release build on IOS.
+
 ### 💡 Others
 
 ## 0.9.3 — 2022-04-26

--- a/packages/expo-dev-client/CHANGELOG.md
+++ b/packages/expo-dev-client/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix `no such module 'EXDevLauncher'` when compiling the release build on IOS.
+- Fix `no such module 'EXDevLauncher'` when compiling the release build on iOS. ([#17332](https://github.com/expo/expo/pull/17332) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/expo-module.config.json
+++ b/packages/expo-dev-launcher/expo-module.config.json
@@ -5,6 +5,7 @@
     "podspecPath": "expo-dev-launcher.podspec",
     "swiftModuleName": "EXDevLauncher",
     "appDelegateSubscribers": ["ExpoDevLauncherAppDelegateSubscriber"],
-    "reactDelegateHandlers": ["ExpoDevLauncherReactDelegateHandler"]
+    "reactDelegateHandlers": ["ExpoDevLauncherReactDelegateHandler"],
+    "debugOnly": true
   }
 }

--- a/packages/expo-dev-menu/expo-module.config.json
+++ b/packages/expo-dev-menu/expo-module.config.json
@@ -4,6 +4,7 @@
   "ios": {
     "podspecPath": "expo-dev-menu.podspec",
     "swiftModuleName": "EXDevMenu",
-    "reactDelegateHandlers": ["ExpoDevMenuReactDelegateHandler"]
+    "reactDelegateHandlers": ["ExpoDevMenuReactDelegateHandler"],
+    "debugOnly": true
   }
 }


### PR DESCRIPTION
# Why

Closes https://github.com/expo/expo/issues/17246.
Needs to work https://github.com/expo/expo/pull/17331.

# How

Use `debugOnly` flag for dev-client modules. 

# Test Plan

- bare-expo ✅