### PR TITLE
[android] Fix more FLAG_MUTABLE exception in PendingIntent

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/notifications/ExponentNotificationManager.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/notifications/ExponentNotificationManager.kt
@@ -219,7 +219,9 @@ class ExponentNotificationManager(private val context: Context) {
       putExtra(KernelConstants.NOTIFICATION_OBJECT_KEY, details)
     }
 
-    val pendingIntent = PendingIntent.getBroadcast(context, 0, notificationIntent, PendingIntent.FLAG_UPDATE_CURRENT)
+    // We're defaulting to the behaviour prior API 31 (mutable) even though Android recommends immutability
+    val mutableFlag = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) PendingIntent.FLAG_MUTABLE else 0
+    val pendingIntent = PendingIntent.getBroadcast(context, 0, notificationIntent, PendingIntent.FLAG_UPDATE_CURRENT or mutableFlag)
     val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
     if (interval != null) {
       alarmManager.setRepeating(AlarmManager.ELAPSED_REALTIME_WAKEUP, time, interval, pendingIntent)
@@ -244,7 +246,9 @@ class ExponentNotificationManager(private val context: Context) {
       type = experienceKey.scopeKey
       action = id.toString()
     }
-    val pendingIntent = PendingIntent.getBroadcast(context, 0, notificationIntent, PendingIntent.FLAG_UPDATE_CURRENT)
+    // We're defaulting to the behaviour prior API 31 (mutable) even though Android recommends immutability
+    val mutableFlag = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) PendingIntent.FLAG_MUTABLE else 0
+    val pendingIntent = PendingIntent.getBroadcast(context, 0, notificationIntent, PendingIntent.FLAG_UPDATE_CURRENT or mutableFlag)
     val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
     alarmManager.cancel(pendingIntent)
     cancel(experienceKey, id)

--- a/android/expoview/src/main/java/host/exp/exponent/notifications/NotificationActionCenter.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/notifications/NotificationActionCenter.kt
@@ -3,6 +3,7 @@ package host.exp.exponent.notifications
 import android.app.Notification
 import android.app.PendingIntent
 import android.content.Context
+import android.os.Build
 import android.os.Looper
 import androidx.core.app.NotificationCompat
 import androidx.core.app.RemoteInput
@@ -68,11 +69,13 @@ object NotificationActionCenter {
     val intent = intentProvider.provide().apply {
       putExtra(KernelConstants.NOTIFICATION_ACTION_TYPE_KEY, actionObject.actionId)
     }
+    // We're defaulting to the behaviour prior API 31 (mutable) even though Android recommends immutability
+    val mutableFlag = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) PendingIntent.FLAG_MUTABLE else 0
     val pendingIntent = PendingIntent.getActivity(
       context,
       UUID.randomUUID().hashCode(),
       intent,
-      PendingIntent.FLAG_UPDATE_CURRENT
+      PendingIntent.FLAG_UPDATE_CURRENT or mutableFlag
     )
     val actionBuilder = NotificationCompat.Action.Builder(
       0,

--- a/android/expoview/src/main/java/host/exp/exponent/notifications/NotificationHelper.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/notifications/NotificationHelper.kt
@@ -500,7 +500,9 @@ object NotificationHelper {
               intent.putExtra(KernelConstants.NOTIFICATION_KEY, body) // deprecated
               intent.putExtra(KernelConstants.NOTIFICATION_OBJECT_KEY, notificationEvent.toJSONObject(null).toString())
 
-              val contentIntent = PendingIntent.getActivity(context, id, intent, PendingIntent.FLAG_UPDATE_CURRENT)
+              // We're defaulting to the behaviour prior API 31 (mutable) even though Android recommends immutability
+              val mutableFlag = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) PendingIntent.FLAG_MUTABLE else 0
+              val contentIntent = PendingIntent.getActivity(context, id, intent, PendingIntent.FLAG_UPDATE_CURRENT or mutableFlag)
               builder.setContentIntent(contentIntent)
 
               if (data.containsKey("categoryId")) {

--- a/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/appauth/AppAuthModule.java
+++ b/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/appauth/AppAuthModule.java
@@ -5,6 +5,8 @@ import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
+import android.os.Build;
+
 import androidx.annotation.Nullable;
 
 import net.openid.appauth.AppAuthConfiguration;
@@ -327,7 +329,9 @@ public class AppAuthModule extends ExportedModule {
 
       AuthorizationRequest authorizationRequest = authReqBuilder.build();
       int hash = authorizationRequest.hashCode();
-      PendingIntent pendingIntent = PendingIntent.getActivity(activity, hash, postAuthIntent, 0);
+      // We're defaulting to the behaviour prior API 31 (mutable) even though Android recommends immutability
+      int mutableFlag = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? PendingIntent.FLAG_MUTABLE : 0;
+      PendingIntent pendingIntent = PendingIntent.getActivity(activity, hash, postAuthIntent, mutableFlag);
       AuthorizationService authorizationService = new AuthorizationService(activity, authConfig);
       authorizationService.performAuthorizationRequest(authorizationRequest, pendingIntent, pendingIntent);
     } catch (Exception e) {

--- a/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/location/services/LocationTaskService.java
+++ b/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/location/services/LocationTaskService.java
@@ -12,6 +12,7 @@ import android.content.Intent;
 import android.graphics.Color;
 import android.net.Uri;
 import android.os.Binder;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.IBinder;
 import androidx.annotation.Nullable;
@@ -101,7 +102,9 @@ public class LocationTaskService extends Service {
 
     if (intent != null) {
       intent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
-      PendingIntent contentIntent = PendingIntent.getActivity(this, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+      // We're defaulting to the behaviour prior API 31 (mutable) even though Android recommends immutability
+      int mutableFlag = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? PendingIntent.FLAG_MUTABLE : 0;
+      PendingIntent contentIntent = PendingIntent.getActivity(this, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT | mutableFlag);
       builder.setContentIntent(contentIntent);
     }
 

--- a/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/notifications/service/NotificationsService.kt
+++ b/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/notifications/service/NotificationsService.kt
@@ -7,10 +7,6 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.ActivityInfo
 import android.net.Uri
-import android.os.Bundle
-import android.os.Parcel
-import android.os.Parcelable
-import android.os.ResultReceiver
 import android.util.Log
 import androidx.core.app.RemoteInput
 import expo.modules.notifications.notifications.model.Notification
@@ -29,6 +25,7 @@ import abi43_0_0.expo.modules.notifications.service.interfaces.CategoriesDelegat
 import abi43_0_0.expo.modules.notifications.service.interfaces.HandlingDelegate
 import abi43_0_0.expo.modules.notifications.service.interfaces.PresentationDelegate
 import abi43_0_0.expo.modules.notifications.service.interfaces.SchedulingDelegate
+import android.os.*
 import kotlin.concurrent.thread
 
 /**
@@ -424,11 +421,13 @@ open class NotificationsService : BroadcastReceiver() {
         intent.putExtra(IDENTIFIER_KEY, identifier)
       }
 
+      // We're defaulting to the behaviour prior API 31 (mutable) even though Android recommends immutability
+      val mutableFlag = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) PendingIntent.FLAG_MUTABLE else 0
       return PendingIntent.getBroadcast(
         context,
         intent.component?.className?.hashCode() ?: NotificationsService::class.java.hashCode(),
         intent,
-        PendingIntent.FLAG_UPDATE_CURRENT
+        PendingIntent.FLAG_UPDATE_CURRENT or mutableFlag
       )
     }
 
@@ -458,11 +457,13 @@ open class NotificationsService : BroadcastReceiver() {
         intent.putExtra(NOTIFICATION_ACTION_KEY, action as Parcelable)
       }
 
+      // We're defaulting to the behaviour prior API 31 (mutable) even though Android recommends immutability
+      val mutableFlag = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) PendingIntent.FLAG_MUTABLE else 0
       return PendingIntent.getBroadcast(
         context,
         intent.component?.className?.hashCode() ?: NotificationsService::class.java.hashCode(),
         intent,
-        PendingIntent.FLAG_UPDATE_CURRENT
+        PendingIntent.FLAG_UPDATE_CURRENT or mutableFlag
       )
     }
 

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/appauth/AppAuthModule.java
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/appauth/AppAuthModule.java
@@ -5,6 +5,8 @@ import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
+import android.os.Build;
+
 import androidx.annotation.Nullable;
 
 import net.openid.appauth.AppAuthConfiguration;
@@ -327,7 +329,9 @@ public class AppAuthModule extends ExportedModule {
 
       AuthorizationRequest authorizationRequest = authReqBuilder.build();
       int hash = authorizationRequest.hashCode();
-      PendingIntent pendingIntent = PendingIntent.getActivity(activity, hash, postAuthIntent, 0);
+      // We're defaulting to the behaviour prior API 31 (mutable) even though Android recommends immutability
+      int mutableFlag = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? PendingIntent.FLAG_MUTABLE : 0;
+      PendingIntent pendingIntent = PendingIntent.getActivity(activity, hash, postAuthIntent, mutableFlag);
       AuthorizationService authorizationService = new AuthorizationService(activity, authConfig);
       authorizationService.performAuthorizationRequest(authorizationRequest, pendingIntent, pendingIntent);
     } catch (Exception e) {

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/location/services/LocationTaskService.java
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/location/services/LocationTaskService.java
@@ -12,6 +12,7 @@ import android.content.Intent;
 import android.graphics.Color;
 import android.net.Uri;
 import android.os.Binder;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.IBinder;
 import androidx.annotation.Nullable;
@@ -101,7 +102,9 @@ public class LocationTaskService extends Service {
 
     if (intent != null) {
       intent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
-      PendingIntent contentIntent = PendingIntent.getActivity(this, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+      // We're defaulting to the behaviour prior API 31 (mutable) even though Android recommends immutability
+      int mutableFlag = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? PendingIntent.FLAG_MUTABLE : 0;
+      PendingIntent contentIntent = PendingIntent.getActivity(this, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT | mutableFlag);
       builder.setContentIntent(contentIntent);
     }
 

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/notifications/service/NotificationsService.kt
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/notifications/service/NotificationsService.kt
@@ -7,10 +7,6 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.ActivityInfo
 import android.net.Uri
-import android.os.Bundle
-import android.os.Parcel
-import android.os.Parcelable
-import android.os.ResultReceiver
 import android.util.Log
 import androidx.core.app.RemoteInput
 import expo.modules.notifications.notifications.model.Notification
@@ -29,6 +25,7 @@ import abi44_0_0.expo.modules.notifications.service.interfaces.CategoriesDelegat
 import abi44_0_0.expo.modules.notifications.service.interfaces.HandlingDelegate
 import abi44_0_0.expo.modules.notifications.service.interfaces.PresentationDelegate
 import abi44_0_0.expo.modules.notifications.service.interfaces.SchedulingDelegate
+import android.os.*
 import kotlin.concurrent.thread
 
 /**
@@ -424,11 +421,13 @@ open class NotificationsService : BroadcastReceiver() {
         intent.putExtra(IDENTIFIER_KEY, identifier)
       }
 
+      // We're defaulting to the behaviour prior API 31 (mutable) even though Android recommends immutability
+      val mutableFlag = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) PendingIntent.FLAG_MUTABLE else 0
       return PendingIntent.getBroadcast(
         context,
         intent.component?.className?.hashCode() ?: NotificationsService::class.java.hashCode(),
         intent,
-        PendingIntent.FLAG_UPDATE_CURRENT
+        PendingIntent.FLAG_UPDATE_CURRENT or mutableFlag
       )
     }
 
@@ -458,11 +457,13 @@ open class NotificationsService : BroadcastReceiver() {
         intent.putExtra(NOTIFICATION_ACTION_KEY, action as Parcelable)
       }
 
+      // We're defaulting to the behaviour prior API 31 (mutable) even though Android recommends immutability
+      val mutableFlag = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) PendingIntent.FLAG_MUTABLE else 0
       return PendingIntent.getBroadcast(
         context,
         intent.component?.className?.hashCode() ?: NotificationsService::class.java.hashCode(),
         intent,
-        PendingIntent.FLAG_UPDATE_CURRENT
+        PendingIntent.FLAG_UPDATE_CURRENT or mutableFlag
       )
     }
 

--- a/android/versioned-abis/expoview-abi45_0_0/src/main/java/abi45_0_0/expo/modules/location/services/LocationTaskService.java
+++ b/android/versioned-abis/expoview-abi45_0_0/src/main/java/abi45_0_0/expo/modules/location/services/LocationTaskService.java
@@ -11,6 +11,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.graphics.Color;
 import android.os.Binder;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.IBinder;
 import androidx.annotation.Nullable;
@@ -103,7 +104,9 @@ public class LocationTaskService extends Service {
 
     if (intent != null) {
       intent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
-      PendingIntent contentIntent = PendingIntent.getActivity(this, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+      // We're defaulting to the behaviour prior API 31 (mutable) even though Android recommends immutability
+      int mutableFlag = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? PendingIntent.FLAG_MUTABLE : 0;
+      PendingIntent contentIntent = PendingIntent.getActivity(this, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT | mutableFlag);
       builder.setContentIntent(contentIntent);
     }
 

--- a/android/versioned-abis/expoview-abi45_0_0/src/main/java/abi45_0_0/expo/modules/notifications/service/NotificationsService.kt
+++ b/android/versioned-abis/expoview-abi45_0_0/src/main/java/abi45_0_0/expo/modules/notifications/service/NotificationsService.kt
@@ -7,10 +7,6 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.ActivityInfo
 import android.net.Uri
-import android.os.Bundle
-import android.os.Parcel
-import android.os.Parcelable
-import android.os.ResultReceiver
 import android.util.Log
 import androidx.core.app.RemoteInput
 import expo.modules.notifications.notifications.model.Notification
@@ -29,6 +25,7 @@ import abi45_0_0.expo.modules.notifications.service.interfaces.CategoriesDelegat
 import abi45_0_0.expo.modules.notifications.service.interfaces.HandlingDelegate
 import abi45_0_0.expo.modules.notifications.service.interfaces.PresentationDelegate
 import abi45_0_0.expo.modules.notifications.service.interfaces.SchedulingDelegate
+import android.os.*
 import kotlin.concurrent.thread
 
 /**
@@ -424,11 +421,13 @@ open class NotificationsService : BroadcastReceiver() {
         intent.putExtra(IDENTIFIER_KEY, identifier)
       }
 
+      // We're defaulting to the behaviour prior API 31 (mutable) even though Android recommends immutability
+      val mutableFlag = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) PendingIntent.FLAG_MUTABLE else 0
       return PendingIntent.getBroadcast(
         context,
         intent.component?.className?.hashCode() ?: NotificationsService::class.java.hashCode(),
         intent,
-        PendingIntent.FLAG_UPDATE_CURRENT
+        PendingIntent.FLAG_UPDATE_CURRENT or mutableFlag
       )
     }
 
@@ -458,11 +457,13 @@ open class NotificationsService : BroadcastReceiver() {
         intent.putExtra(NOTIFICATION_ACTION_KEY, action as Parcelable)
       }
 
+      // We're defaulting to the behaviour prior API 31 (mutable) even though Android recommends immutability
+      val mutableFlag = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) PendingIntent.FLAG_MUTABLE else 0
       return PendingIntent.getBroadcast(
         context,
         intent.component?.className?.hashCode() ?: NotificationsService::class.java.hashCode(),
         intent,
-        PendingIntent.FLAG_UPDATE_CURRENT
+        PendingIntent.FLAG_UPDATE_CURRENT or mutableFlag
       )
     }
 

--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed Android 12+ runtime crash caused by `PendingIntent` misconfiguration. ([#17333](https://github.com/expo/expo/pull/17333) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 14.2.1 — 2022-04-20

--- a/packages/expo-location/android/src/main/java/expo/modules/location/services/LocationTaskService.java
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/services/LocationTaskService.java
@@ -11,6 +11,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.graphics.Color;
 import android.os.Binder;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.IBinder;
 import androidx.annotation.Nullable;
@@ -103,7 +104,9 @@ public class LocationTaskService extends Service {
 
     if (intent != null) {
       intent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
-      PendingIntent contentIntent = PendingIntent.getActivity(this, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+      // We're defaulting to the behaviour prior API 31 (mutable) even though Android recommends immutability
+      int mutableFlag = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? PendingIntent.FLAG_MUTABLE : 0;
+      PendingIntent contentIntent = PendingIntent.getActivity(this, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT | mutableFlag);
       builder.setContentIntent(contentIntent);
     }
 

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed Android 12+ runtime crash caused by `PendingIntent` misconfiguration. ([#17333](https://github.com/expo/expo/pull/17333) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 0.15.1 — 2022-04-27

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationsService.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationsService.kt
@@ -7,20 +7,10 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.ActivityInfo
 import android.net.Uri
-import android.os.Bundle
-import android.os.Parcel
-import android.os.Parcelable
-import android.os.ResultReceiver
+import android.os.*
 import android.util.Log
 import androidx.core.app.RemoteInput
-import expo.modules.notifications.notifications.model.Notification
-import expo.modules.notifications.notifications.model.NotificationAction
-import expo.modules.notifications.notifications.model.NotificationBehavior
-import expo.modules.notifications.notifications.model.NotificationCategory
-import expo.modules.notifications.notifications.model.NotificationRequest
-import expo.modules.notifications.notifications.model.NotificationResponse
-import expo.modules.notifications.notifications.model.TextInputNotificationAction
-import expo.modules.notifications.notifications.model.TextInputNotificationResponse
+import expo.modules.notifications.notifications.model.*
 import expo.modules.notifications.service.delegates.ExpoCategoriesDelegate
 import expo.modules.notifications.service.delegates.ExpoHandlingDelegate
 import expo.modules.notifications.service.delegates.ExpoPresentationDelegate
@@ -424,11 +414,13 @@ open class NotificationsService : BroadcastReceiver() {
         intent.putExtra(IDENTIFIER_KEY, identifier)
       }
 
+      // We're defaulting to the behaviour prior API 31 (mutable) even though Android recommends immutability
+      val mutableFlag = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) PendingIntent.FLAG_MUTABLE else 0
       return PendingIntent.getBroadcast(
         context,
         intent.component?.className?.hashCode() ?: NotificationsService::class.java.hashCode(),
         intent,
-        PendingIntent.FLAG_UPDATE_CURRENT
+        PendingIntent.FLAG_UPDATE_CURRENT or mutableFlag
       )
     }
 
@@ -458,11 +450,13 @@ open class NotificationsService : BroadcastReceiver() {
         intent.putExtra(NOTIFICATION_ACTION_KEY, action as Parcelable)
       }
 
+      // We're defaulting to the behaviour prior API 31 (mutable) even though Android recommends immutability
+      val mutableFlag = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) PendingIntent.FLAG_MUTABLE else 0
       return PendingIntent.getBroadcast(
         context,
         intent.component?.className?.hashCode() ?: NotificationsService::class.java.hashCode(),
         intent,
-        PendingIntent.FLAG_UPDATE_CURRENT
+        PendingIntent.FLAG_UPDATE_CURRENT or mutableFlag
       )
     }
 


### PR DESCRIPTION
# Why

fix #17276

# How

basically follow #17164 but search all `PendingIntent.g` across all code in expo/expo repository.

# Test Plan

on Android S devices, use android unversioned expo go + NCL for the following test cases:

1. BackgroundNotification
2. Notifications

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
