### PR TITLE
[notifications] handle SCHEDULE_EXACT_ALARM for android 12

### DIFF
--- a/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/notifications/service/delegates/ExpoSchedulingDelegate.kt
+++ b/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/notifications/service/delegates/ExpoSchedulingDelegate.kt
@@ -1,7 +1,9 @@
 package abi43_0_0.expo.modules.notifications.service.delegates
 
 import android.app.AlarmManager
+import android.app.PendingIntent
 import android.content.Context
+import android.os.Build
 import android.util.Log
 import androidx.core.app.AlarmManagerCompat
 import expo.modules.notifications.notifications.interfaces.SchedulableNotificationTrigger
@@ -57,12 +59,7 @@ class ExpoSchedulingDelegate(protected val context: Context) : SchedulingDelegat
         NotificationsService.removeScheduledNotification(context, request.identifier)
       } else {
         store.saveNotificationRequest(request)
-        AlarmManagerCompat.setExactAndAllowWhileIdle(
-          alarmManager,
-          AlarmManager.RTC_WAKEUP,
-          nextTriggerDate.time,
-          NotificationsService.createNotificationTrigger(context, request.identifier)
-        )
+        setupAlarm(nextTriggerDate.time, expo.modules.notifications.service.NotificationsService.createNotificationTrigger(context, request.identifier))
       }
     }
   }
@@ -97,6 +94,24 @@ class ExpoSchedulingDelegate(protected val context: Context) : SchedulingDelegat
   override fun removeAllScheduledNotifications() {
     store.removeAllNotificationRequests().forEach {
       alarmManager.cancel(NotificationsService.createNotificationTrigger(context, it))
+    }
+  }
+
+  private fun setupAlarm(triggerAtMillis: Long, operation: PendingIntent) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S || alarmManager.canScheduleExactAlarms()) {
+      AlarmManagerCompat.setExactAndAllowWhileIdle(
+        alarmManager,
+        AlarmManager.RTC_WAKEUP,
+        triggerAtMillis,
+        operation
+      )
+    } else {
+      AlarmManagerCompat.setAndAllowWhileIdle(
+        alarmManager,
+        AlarmManager.RTC_WAKEUP,
+        triggerAtMillis,
+        operation
+      )
     }
   }
 }

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/notifications/service/delegates/ExpoSchedulingDelegate.kt
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/notifications/service/delegates/ExpoSchedulingDelegate.kt
@@ -1,7 +1,9 @@
 package abi44_0_0.expo.modules.notifications.service.delegates
 
 import android.app.AlarmManager
+import android.app.PendingIntent
 import android.content.Context
+import android.os.Build
 import android.util.Log
 import androidx.core.app.AlarmManagerCompat
 import expo.modules.notifications.notifications.interfaces.SchedulableNotificationTrigger
@@ -57,12 +59,7 @@ class ExpoSchedulingDelegate(protected val context: Context) : SchedulingDelegat
         NotificationsService.removeScheduledNotification(context, request.identifier)
       } else {
         store.saveNotificationRequest(request)
-        AlarmManagerCompat.setExactAndAllowWhileIdle(
-          alarmManager,
-          AlarmManager.RTC_WAKEUP,
-          nextTriggerDate.time,
-          NotificationsService.createNotificationTrigger(context, request.identifier)
-        )
+        setupAlarm(nextTriggerDate.time, expo.modules.notifications.service.NotificationsService.createNotificationTrigger(context, request.identifier))
       }
     }
   }
@@ -97,6 +94,24 @@ class ExpoSchedulingDelegate(protected val context: Context) : SchedulingDelegat
   override fun removeAllScheduledNotifications() {
     store.removeAllNotificationRequests().forEach {
       alarmManager.cancel(NotificationsService.createNotificationTrigger(context, it))
+    }
+  }
+
+  private fun setupAlarm(triggerAtMillis: Long, operation: PendingIntent) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S || alarmManager.canScheduleExactAlarms()) {
+      AlarmManagerCompat.setExactAndAllowWhileIdle(
+        alarmManager,
+        AlarmManager.RTC_WAKEUP,
+        triggerAtMillis,
+        operation
+      )
+    } else {
+      AlarmManagerCompat.setAndAllowWhileIdle(
+        alarmManager,
+        AlarmManager.RTC_WAKEUP,
+        triggerAtMillis,
+        operation
+      )
     }
   }
 }

--- a/android/versioned-abis/expoview-abi45_0_0/src/main/java/abi45_0_0/expo/modules/notifications/service/delegates/ExpoSchedulingDelegate.kt
+++ b/android/versioned-abis/expoview-abi45_0_0/src/main/java/abi45_0_0/expo/modules/notifications/service/delegates/ExpoSchedulingDelegate.kt
@@ -1,7 +1,9 @@
 package abi45_0_0.expo.modules.notifications.service.delegates
 
 import android.app.AlarmManager
+import android.app.PendingIntent
 import android.content.Context
+import android.os.Build
 import android.util.Log
 import androidx.core.app.AlarmManagerCompat
 import expo.modules.notifications.notifications.interfaces.SchedulableNotificationTrigger
@@ -57,12 +59,7 @@ class ExpoSchedulingDelegate(protected val context: Context) : SchedulingDelegat
         NotificationsService.removeScheduledNotification(context, request.identifier)
       } else {
         store.saveNotificationRequest(request)
-        AlarmManagerCompat.setExactAndAllowWhileIdle(
-          alarmManager,
-          AlarmManager.RTC_WAKEUP,
-          nextTriggerDate.time,
-          NotificationsService.createNotificationTrigger(context, request.identifier)
-        )
+        setupAlarm(nextTriggerDate.time, expo.modules.notifications.service.NotificationsService.createNotificationTrigger(context, request.identifier))
       }
     }
   }
@@ -97,6 +94,24 @@ class ExpoSchedulingDelegate(protected val context: Context) : SchedulingDelegat
   override fun removeAllScheduledNotifications() {
     store.removeAllNotificationRequests().forEach {
       alarmManager.cancel(NotificationsService.createNotificationTrigger(context, it))
+    }
+  }
+
+  private fun setupAlarm(triggerAtMillis: Long, operation: PendingIntent) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S || alarmManager.canScheduleExactAlarms()) {
+      AlarmManagerCompat.setExactAndAllowWhileIdle(
+        alarmManager,
+        AlarmManager.RTC_WAKEUP,
+        triggerAtMillis,
+        operation
+      )
+    } else {
+      AlarmManagerCompat.setAndAllowWhileIdle(
+        alarmManager,
+        AlarmManager.RTC_WAKEUP,
+        triggerAtMillis,
+        operation
+      )
     }
   }
 }

--- a/docs/pages/versions/unversioned/sdk/notifications.md
+++ b/docs/pages/versions/unversioned/sdk/notifications.md
@@ -101,7 +101,7 @@ Learn how push notification credentials can be automatically generated or upload
 
 - On Android, this module requires permission to subscribe to device boot. It's used to setup scheduled notifications when the device (re)starts. The `RECEIVE_BOOT_COMPLETED` permission is added automatically through the library **AndroidManifest.xml**.
 
-- Starting from Android 12 (API level 31), this module requires the `SCHEDULE_EXACT_ALARM` permission for `scheduleNotificationAsync` to schedule notifications from a precise timer. If you need a precise time for `scheduleNotificationAsync` notifications, please add `<uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"/>` to **AndroidManifest.xml**.
+- Starting from Android 12 (API level 31), to schedule the notification that triggers at the exact time, you need to add `<uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"/>` to **AndroidManifest.xml**. You can read more about the exact alarm permission [here](https://developer.android.com/about/versions/12/behavior-changes-12#exact-alarm-permission).
 
 <AndroidPermissions permissions={['RECEIVE_BOOT_COMPLETED', 'SCHEDULE_EXACT_ALARM']} />
 

--- a/docs/pages/versions/unversioned/sdk/notifications.md
+++ b/docs/pages/versions/unversioned/sdk/notifications.md
@@ -99,9 +99,11 @@ Learn how push notification credentials can be automatically generated or upload
 
 ### Android
 
-On Android, this module requires permission to subscribe to device boot. It's used to setup scheduled notifications when the device (re)starts. The `RECEIVE_BOOT_COMPLETED` permission is added automatically through the library **AndroidManifest.xml**.
+- On Android, this module requires permission to subscribe to device boot. It's used to setup scheduled notifications when the device (re)starts. The `RECEIVE_BOOT_COMPLETED` permission is added automatically through the library **AndroidManifest.xml**.
 
-<AndroidPermissions permissions={['RECEIVE_BOOT_COMPLETED']} />
+- Starting from Android 12 (API level 31), this module requires the `SCHEDULE_EXACT_ALARM` permission for `scheduleNotificationAsync` to schedule notifications from a precise timer. If you need a precise time for `scheduleNotificationAsync` notifications, please add `<uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"/>` to **AndroidManifest.xml**.
+
+<AndroidPermissions permissions={['RECEIVE_BOOT_COMPLETED', 'SCHEDULE_EXACT_ALARM']} />
 
 ### iOS
 

--- a/docs/pages/versions/v45.0.0/sdk/notifications.md
+++ b/docs/pages/versions/v45.0.0/sdk/notifications.md
@@ -101,7 +101,7 @@ Learn how push notification credentials can be automatically generated or upload
 
 - On Android, this module requires permission to subscribe to device boot. It's used to setup scheduled notifications when the device (re)starts. The `RECEIVE_BOOT_COMPLETED` permission is added automatically through the library **AndroidManifest.xml**.
 
-- Starting from Android 12 (API level 31), this module requires the `SCHEDULE_EXACT_ALARM` permission for `scheduleNotificationAsync` to schedule notifications from a precise timer. If you need a precise time for `scheduleNotificationAsync` notifications, please add `<uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"/>` to **AndroidManifest.xml**.
+- Starting from Android 12 (API level 31), to schedule the notification that triggers at the exact time, you need to add `<uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"/>` to **AndroidManifest.xml**. You can read more about the exact alarm permission [here](https://developer.android.com/about/versions/12/behavior-changes-12#exact-alarm-permission).
 
 <AndroidPermissions permissions={['RECEIVE_BOOT_COMPLETED', 'SCHEDULE_EXACT_ALARM']} />
 

--- a/docs/pages/versions/v45.0.0/sdk/notifications.md
+++ b/docs/pages/versions/v45.0.0/sdk/notifications.md
@@ -99,9 +99,11 @@ Learn how push notification credentials can be automatically generated or upload
 
 ### Android
 
-On Android, this module requires permission to subscribe to device boot. It's used to setup scheduled notifications when the device (re)starts. The `RECEIVE_BOOT_COMPLETED` permission is added automatically through the library **AndroidManifest.xml**.
+- On Android, this module requires permission to subscribe to device boot. It's used to setup scheduled notifications when the device (re)starts. The `RECEIVE_BOOT_COMPLETED` permission is added automatically through the library **AndroidManifest.xml**.
 
-<AndroidPermissions permissions={['RECEIVE_BOOT_COMPLETED']} />
+- Starting from Android 12 (API level 31), this module requires the `SCHEDULE_EXACT_ALARM` permission for `scheduleNotificationAsync` to schedule notifications from a precise timer. If you need a precise time for `scheduleNotificationAsync` notifications, please add `<uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"/>` to **AndroidManifest.xml**.
+
+<AndroidPermissions permissions={['RECEIVE_BOOT_COMPLETED', 'SCHEDULE_EXACT_ALARM']} />
 
 ### iOS
 

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### 💡 Others
 
+### ⚠️ Notices
+
+- Fixed exception on Android 12+ devices for missing `SCHEDULE_EXACT_ALARM` permission. If `scheduleNotificationAsync` needs a precise timer, the `SCHEDULE_EXACT_ALARM` should be explicitly added to **AndroidManifest.xml**. ([#17334](https://github.com/expo/expo/pull/17334) by [@kudo](https://github.com/kudo))
+
 ## 0.15.1 — 2022-04-27
 
 ### 💡 Others

--- a/packages/expo-notifications/README.md
+++ b/packages/expo-notifications/README.md
@@ -47,6 +47,8 @@ In order to be able to receive push notifications on the device ensure that your
 
 This module requires permission to subscribe to device boot. It's used to setup the scheduled notifications right after the device (re)starts. The `RECEIVE_BOOT_COMPLETED` permission is added automatically.
 
+**Note:** Starting in Android 12 (API level 31), this module requires the `SCHEDULE_EXACT_ALARM` permission for `scheduleNotificationAsync` to schedule notifications from a precise timer. If you need a precise time for `scheduleNotificationAsync` notifications, please add `<uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"/>` to **AndroidManifest.xml**.
+
 <details><summary><strong>Expand to view how the notification icon and the default color can be customized in a plain React Native app</strong></summary> <p>
 
 - **To customize the icon**:

--- a/packages/expo-notifications/README.md
+++ b/packages/expo-notifications/README.md
@@ -47,7 +47,7 @@ In order to be able to receive push notifications on the device ensure that your
 
 This module requires permission to subscribe to device boot. It's used to setup the scheduled notifications right after the device (re)starts. The `RECEIVE_BOOT_COMPLETED` permission is added automatically.
 
-**Note:** Starting in Android 12 (API level 31), this module requires the `SCHEDULE_EXACT_ALARM` permission for `scheduleNotificationAsync` to schedule notifications from a precise timer. If you need a precise time for `scheduleNotificationAsync` notifications, please add `<uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"/>` to **AndroidManifest.xml**.
+**Note:** Starting from Android 12 (API level 31), to schedule the notification that triggers at the exact time, you need to add `<uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"/>` to **AndroidManifest.xml**. You can read more about the exact alarm permission [here](https://developer.android.com/about/versions/12/behavior-changes-12#exact-alarm-permission).
 
 <details><summary><strong>Expand to view how the notification icon and the default color can be customized in a plain React Native app</strong></summary> <p>
 

--- a/template-files/android/AndroidManifest.xml
+++ b/template-files/android/AndroidManifest.xml
@@ -26,6 +26,7 @@
   <uses-permission android:name="com.android.launcher.permission.INSTALL_SHORTCUT" />
   <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
   <uses-permission android:name="android.permission.HIGH_SAMPLING_RATE_SENSORS" />
+  <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
 
   <!-- These require runtime permissions on M -->
   <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />


### PR DESCRIPTION
# Why

fix #17276

# How

- If the app has the `SCHEDULE_EXACT_ALARM` permission, call `setExactAndAllowWhileIdle`. otherwise, call `setAndAllowWhileIdle` instead.
- add `SCHEDULE_EXACT_ALARM` permission to expo go's AndroidManifest.xml

# Test Plan

on android 12 devices, test unversioned expo go + Notifications schedule 10s local notification test

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
