### PR TITLE
[docs] Move development builds to guides

### DIFF
--- a/docs/components/DocumentationSidebarCollapsible.tsx
+++ b/docs/components/DocumentationSidebarCollapsible.tsx
@@ -61,7 +61,7 @@ export default class DocumentationSidebarCollapsible extends React.Component<Pro
 
     // default to always open
     this.state = {
-      isOpen: !props.info.collapsed || isOpen,
+      isOpen: props.info.expanded || isOpen,
     };
   }
 

--- a/docs/components/DocumentationSidebarCollapsible.tsx
+++ b/docs/components/DocumentationSidebarCollapsible.tsx
@@ -61,7 +61,7 @@ export default class DocumentationSidebarCollapsible extends React.Component<Pro
 
     // default to always open
     this.state = {
-      isOpen: props.info.collapsed ? isOpen : true,
+      isOpen: !props.info.collapsed || isOpen,
     };
   }
 

--- a/docs/constants/navigation-deprecated.js
+++ b/docs/constants/navigation-deprecated.js
@@ -257,47 +257,51 @@ const eas = [
     [makeGroup('EAS', [makePage('eas/index.md'), makePage('eas/webhooks.md')], './pages/eas/')],
     { collapsed: false }
   ),
-  makeSection('EAS Build', [
-    makeGroup(
-      'Start Building',
-      [
-        makePage('build/introduction.md'),
-        makePage('build/setup.md'),
-        makePage('build/eas-json.md'),
-        makePage('build/internal-distribution.md'),
-        makePage('build/automating-submissions.md'),
-        makePage('build/updates.md'),
-        makePage('build/building-on-ci.md'),
-      ],
-      './pages/build/'
-    ),
-    makeGroup('App Signing', [
-      makePage('app-signing/app-credentials.md'),
-      makePage('app-signing/managed-credentials.md'),
-      makePage('app-signing/local-credentials.md'),
-      makePage('app-signing/existing-credentials.md'),
-      makePage('app-signing/syncing-credentials.md'),
-    ]),
-    makeGroup('Reference', [
-      makePage('build-reference/eas-json.md'),
-      makePage('build-reference/migrating.md'),
-      makePage('build-reference/how-tos.md'),
-      makePage('build-reference/private-npm-packages.md'),
-      makePage('build-reference/variables.md'),
-      makePage('build-reference/apk.md'),
-      makePage('build-reference/simulators.md'),
-      makePage('build-reference/troubleshooting.md'),
-      makePage('build-reference/local-builds.md'),
-      makePage('build-reference/variants.md'),
-      makePage('build-reference/caching.md'),
-      makePage('build-reference/android-builds.md'),
-      makePage('build-reference/ios-builds.md'),
-      makePage('build-reference/limitations.md'),
-      makePage('build-reference/build-configuration.md'),
-      makePage('build-reference/infrastructure.md'),
-      makePage('build-reference/ios-capabilities.md'),
-    ]),
-  ]),
+  makeSection(
+    'EAS Build',
+    [
+      makeGroup(
+        'Start Building',
+        [
+          makePage('build/introduction.md'),
+          makePage('build/setup.md'),
+          makePage('build/eas-json.md'),
+          makePage('build/internal-distribution.md'),
+          makePage('build/automating-submissions.md'),
+          makePage('build/updates.md'),
+          makePage('build/building-on-ci.md'),
+        ],
+        './pages/build/'
+      ),
+      makeGroup('App Signing', [
+        makePage('app-signing/app-credentials.md'),
+        makePage('app-signing/managed-credentials.md'),
+        makePage('app-signing/local-credentials.md'),
+        makePage('app-signing/existing-credentials.md'),
+        makePage('app-signing/syncing-credentials.md'),
+      ]),
+      makeGroup('Reference', [
+        makePage('build-reference/eas-json.md'),
+        makePage('build-reference/migrating.md'),
+        makePage('build-reference/how-tos.md'),
+        makePage('build-reference/private-npm-packages.md'),
+        makePage('build-reference/variables.md'),
+        makePage('build-reference/apk.md'),
+        makePage('build-reference/simulators.md'),
+        makePage('build-reference/troubleshooting.md'),
+        makePage('build-reference/local-builds.md'),
+        makePage('build-reference/variants.md'),
+        makePage('build-reference/caching.md'),
+        makePage('build-reference/android-builds.md'),
+        makePage('build-reference/ios-builds.md'),
+        makePage('build-reference/limitations.md'),
+        makePage('build-reference/build-configuration.md'),
+        makePage('build-reference/infrastructure.md'),
+        makePage('build-reference/ios-capabilities.md'),
+      ]),
+    ],
+    { collapsed: false }
+  ),
   makeSection(
     'EAS Submit',
     [

--- a/docs/constants/navigation-deprecated.js
+++ b/docs/constants/navigation-deprecated.js
@@ -39,35 +39,39 @@ const generalDirectories = fs
 // --- Navigation ---
 
 const starting = [
-  makeSection('The Basics', [
-    makeGroup('Get Started', [
-      makePage('get-started/installation.md'),
-      makePage('get-started/create-a-new-app.md'),
-      makePage('get-started/errors.md'),
-    ]),
-    makeGroup('Tutorial', [
-      makePage('tutorial/planning.md'),
-      makePage('tutorial/text.md'),
-      makePage('tutorial/image.md'),
-      makePage('tutorial/button.md'),
-      makePage('tutorial/image-picker.md'),
-      makePage('tutorial/sharing.md'),
-      makePage('tutorial/platform-differences.md'),
-      makePage('tutorial/configuration.md'),
-      makePage('tutorial/follow-up.md'),
-    ]),
-    makeGroup('Conceptual Overview', [
-      makePage('introduction/managed-vs-bare.md'),
-      makePage('introduction/walkthrough.md'),
-      makePage('introduction/why-not-expo.md'),
-      makePage('introduction/faq.md'),
-    ]),
-    makeGroup('Next Steps', [
-      makePage('next-steps/using-the-documentation.md'),
-      makePage('next-steps/community.md'),
-      makePage('next-steps/additional-resources.md'),
-    ]),
-  ]),
+  makeSection(
+    'The Basics',
+    [
+      makeGroup('Get Started', [
+        makePage('get-started/installation.md'),
+        makePage('get-started/create-a-new-app.md'),
+        makePage('get-started/errors.md'),
+      ]),
+      makeGroup('Tutorial', [
+        makePage('tutorial/planning.md'),
+        makePage('tutorial/text.md'),
+        makePage('tutorial/image.md'),
+        makePage('tutorial/button.md'),
+        makePage('tutorial/image-picker.md'),
+        makePage('tutorial/sharing.md'),
+        makePage('tutorial/platform-differences.md'),
+        makePage('tutorial/configuration.md'),
+        makePage('tutorial/follow-up.md'),
+      ]),
+      makeGroup('Conceptual Overview', [
+        makePage('introduction/managed-vs-bare.md'),
+        makePage('introduction/walkthrough.md'),
+        makePage('introduction/why-not-expo.md'),
+        makePage('introduction/faq.md'),
+      ]),
+      makeGroup('Next Steps', [
+        makePage('next-steps/using-the-documentation.md'),
+        makePage('next-steps/community.md'),
+        makePage('next-steps/additional-resources.md'),
+      ]),
+    ],
+    { collapsed: false }
+  ),
 ];
 
 const general = [
@@ -168,15 +172,6 @@ const general = [
       makePage('guides/using-preact.md'),
     ]),
   ]),
-  makeSection('Expo Modules', [
-    makeGroup('Expo Modules', [
-      makePage('modules/overview.md'),
-      makePage('modules/module-api.md'),
-      makePage('modules/android-lifecycle-listeners.md'),
-      makePage('modules/appdelegate-subscribers.md'),
-      makePage('modules/module-config.md'),
-    ]),
-  ]),
   makeSection('Expo Accounts', [
     makeGroup('Expo Accounts', [
       makePage('accounts/account-types.md'),
@@ -217,54 +212,51 @@ const general = [
     makeGroup('Classic Services', sortAlphabetical(pagesFromDir('classic'))),
   ]),
   makeSection('UI Programming', [
-    makeGroup(
-      'UI Programming',
-      [
-        makePage('ui-programming/image-background.md'),
-        makePage('ui-programming/implementing-a-checkbox.md'),
-        makePage('ui-programming/z-index.md'),
-        makePage('ui-programming/using-svgs.md'),
-        makePage('ui-programming/react-native-toast.md'),
-        makePage('ui-programming/react-native-styling-buttons.md'),
-      ],
-      { collapsed: true }
-    ),
+    makeGroup('UI Programming', [
+      makePage('ui-programming/image-background.md'),
+      makePage('ui-programming/implementing-a-checkbox.md'),
+      makePage('ui-programming/z-index.md'),
+      makePage('ui-programming/using-svgs.md'),
+      makePage('ui-programming/react-native-toast.md'),
+      makePage('ui-programming/react-native-styling-buttons.md'),
+    ]),
   ]),
-  makeSection(
-    'Regulatory Compliance',
-    [makeGroup('Regulatory Compliance', sortAlphabetical(pagesFromDir('regulatory-compliance')))],
-    { collapsed: true }
-  ),
-  makeSection(
-    'Technical Specs',
-    [
-      makeGroup('Technical Specs', [
-        makePage('technical-specs/expo-updates-0.md'),
-        makePage('technical-specs/expo-sfv-0.md'),
-      ]),
-    ],
-    { collapsed: true }
-  ),
-  makeSection(
-    'Deprecated',
-    [
-      makeGroup('ExpoKit', [
-        makePage('expokit/overview.md'),
-        makePage('expokit/eject.md'),
-        makePage('expokit/expokit.md'),
-        makePage('expokit/advanced-expokit-topics.md'),
-        makePage('expokit/universal-modules-and-expokit.md'),
-      ]),
-      makeGroup('Archived', sortAlphabetical(pagesFromDir('archived'))),
-    ],
-    { collapsed: true }
-  ),
+  makeSection('Expo Module API (Alpha)', [
+    makeGroup('Expo Module API (Alpha)', [
+      makePage('modules/overview.md'),
+      makePage('modules/module-api.md'),
+      makePage('modules/android-lifecycle-listeners.md'),
+      makePage('modules/appdelegate-subscribers.md'),
+      makePage('modules/module-config.md'),
+    ]),
+  ]),
+  makeSection('Regulatory Compliance', [
+    makeGroup('Regulatory Compliance', sortAlphabetical(pagesFromDir('regulatory-compliance'))),
+  ]),
+  makeSection('Technical Specs', [
+    makeGroup('Technical Specs', [
+      makePage('technical-specs/expo-updates-0.md'),
+      makePage('technical-specs/expo-sfv-0.md'),
+    ]),
+  ]),
+  makeSection('Deprecated', [
+    makeGroup('ExpoKit', [
+      makePage('expokit/overview.md'),
+      makePage('expokit/eject.md'),
+      makePage('expokit/expokit.md'),
+      makePage('expokit/advanced-expokit-topics.md'),
+      makePage('expokit/universal-modules-and-expokit.md'),
+    ]),
+    makeGroup('Archived', sortAlphabetical(pagesFromDir('archived'))),
+  ]),
 ];
 
 const eas = [
-  makeSection('EAS', [
-    makeGroup('EAS', [makePage('eas/index.md'), makePage('eas/webhooks.md')], './pages/eas/'),
-  ]),
+  makeSection(
+    'EAS',
+    [makeGroup('EAS', [makePage('eas/index.md'), makePage('eas/webhooks.md')], './pages/eas/')],
+    { collapsed: false }
+  ),
   makeSection('EAS Build', [
     makeGroup(
       'Start Building',
@@ -306,15 +298,19 @@ const eas = [
       makePage('build-reference/ios-capabilities.md'),
     ]),
   ]),
-  makeSection('EAS Submit', [
-    makeGroup('EAS Submit', [
-      makePage('submit/introduction.md'),
-      makePage('submit/eas-json.md'),
-      makePage('submit/android.md'),
-      makePage('submit/ios.md'),
-      makePage('submit/classic-builds.md'),
-    ]),
-  ]),
+  makeSection(
+    'EAS Submit',
+    [
+      makeGroup('EAS Submit', [
+        makePage('submit/introduction.md'),
+        makePage('submit/eas-json.md'),
+        makePage('submit/android.md'),
+        makePage('submit/ios.md'),
+        makePage('submit/classic-builds.md'),
+      ]),
+    ],
+    { collapsed: false }
+  ),
 ];
 
 const preview = [
@@ -324,43 +320,55 @@ const preview = [
 ];
 
 const featurePreview = [
-  makeSection('EAS Update', [
-    makeGroup('EAS Update', [
-      makePage('eas-update/introduction.md'),
-      makePage('eas-update/getting-started.md'),
-      makePage('eas-update/github-actions.md'),
-      makePage('eas-update/developing-with-eas-update.md'),
-      makePage('eas-update/how-eas-update-works.md'),
-      makePage('eas-update/deployment-patterns.md'),
-      makePage('eas-update/debug-updates.md'),
-      makePage('eas-update/eas-update-and-eas-cli.md'),
-      makePage('eas-update/optimize-assets.md'),
-      makePage('eas-update/custom-updates-server.md'),
-      makePage('eas-update/migrate-to-eas-update.md'),
-      makePage('eas-update/bare-react-native.md'),
-      makePage('eas-update/runtime-versions.md'),
-      makePage('eas-update/environment-variables.md'),
-      makePage('eas-update/expo-dev-client.md'),
-      makePage('eas-update/known-issues.md'),
-      makePage('eas-update/faq.md'),
-    ]),
-  ]),
+  makeSection(
+    'EAS Update',
+    [
+      makeGroup('EAS Update', [
+        makePage('eas-update/introduction.md'),
+        makePage('eas-update/getting-started.md'),
+        makePage('eas-update/github-actions.md'),
+        makePage('eas-update/developing-with-eas-update.md'),
+        makePage('eas-update/how-eas-update-works.md'),
+        makePage('eas-update/deployment-patterns.md'),
+        makePage('eas-update/debug-updates.md'),
+        makePage('eas-update/eas-update-and-eas-cli.md'),
+        makePage('eas-update/optimize-assets.md'),
+        makePage('eas-update/custom-updates-server.md'),
+        makePage('eas-update/migrate-to-eas-update.md'),
+        makePage('eas-update/bare-react-native.md'),
+        makePage('eas-update/runtime-versions.md'),
+        makePage('eas-update/environment-variables.md'),
+        makePage('eas-update/expo-dev-client.md'),
+        makePage('eas-update/known-issues.md'),
+        makePage('eas-update/faq.md'),
+      ]),
+    ],
+    { collapsed: false }
+  ),
 ];
 
 const reference = VERSIONS.reduce(
   (all, version) => ({
     ...all,
     [version]: [
-      makeSection('Configuration Files', [
-        makeGroup('Configuration Files', pagesFromDir(`versions/${version}/config`)),
-      ]),
-      makeSection('Expo SDK', [makeGroup('Expo SDK', pagesFromDir(`versions/${version}/sdk`))]),
-      makeSection('React Native', [
-        makeGroup(
-          'React Native',
-          sortLegacyReactNative(pagesFromDir(`versions/${version}/react-native`))
-        ),
-      ]),
+      makeSection(
+        'Configuration Files',
+        [makeGroup('Configuration Files', pagesFromDir(`versions/${version}/config`))],
+        { collapsed: false }
+      ),
+      makeSection('Expo SDK', [makeGroup('Expo SDK', pagesFromDir(`versions/${version}/sdk`))], {
+        collapsed: false,
+      }),
+      makeSection(
+        'React Native',
+        [
+          makeGroup(
+            'React Native',
+            sortLegacyReactNative(pagesFromDir(`versions/${version}/react-native`))
+          ),
+        ],
+        { collapsed: false }
+      ),
     ],
   }),
   {}
@@ -384,7 +392,7 @@ module.exports = {
 // --- MDX methods ---
 
 function makeSection(name, children = [], props = {}) {
-  return make('section', { name, ...props }, children);
+  return make('section', { name, ...{ collapsed: true, ...props } }, children);
 }
 
 function makeGroup(name, children = [], props = {}) {

--- a/docs/constants/navigation-deprecated.js
+++ b/docs/constants/navigation-deprecated.js
@@ -70,7 +70,7 @@ const starting = [
         makePage('next-steps/additional-resources.md'),
       ]),
     ],
-    { collapsed: false }
+    { expanded: true }
   ),
 ];
 
@@ -255,7 +255,7 @@ const eas = [
   makeSection(
     'EAS',
     [makeGroup('EAS', [makePage('eas/index.md'), makePage('eas/webhooks.md')], './pages/eas/')],
-    { collapsed: false }
+    { expanded: true }
   ),
   makeSection(
     'EAS Build',
@@ -300,7 +300,7 @@ const eas = [
         makePage('build-reference/ios-capabilities.md'),
       ]),
     ],
-    { collapsed: false }
+    { expanded: true }
   ),
   makeSection(
     'EAS Submit',
@@ -313,7 +313,7 @@ const eas = [
         makePage('submit/classic-builds.md'),
       ]),
     ],
-    { collapsed: false }
+    { expanded: true }
   ),
 ];
 
@@ -347,7 +347,7 @@ const featurePreview = [
         makePage('eas-update/faq.md'),
       ]),
     ],
-    { collapsed: false }
+    { expanded: true }
   ),
 ];
 
@@ -358,10 +358,10 @@ const reference = VERSIONS.reduce(
       makeSection(
         'Configuration Files',
         [makeGroup('Configuration Files', pagesFromDir(`versions/${version}/config`))],
-        { collapsed: false }
+        { expanded: true }
       ),
       makeSection('Expo SDK', [makeGroup('Expo SDK', pagesFromDir(`versions/${version}/sdk`))], {
-        collapsed: false,
+        expanded: true,
       }),
       makeSection(
         'React Native',
@@ -371,7 +371,7 @@ const reference = VERSIONS.reduce(
             sortLegacyReactNative(pagesFromDir(`versions/${version}/react-native`))
           ),
         ],
-        { collapsed: false }
+        { expanded: true }
       ),
     ],
   }),
@@ -396,7 +396,7 @@ module.exports = {
 // --- MDX methods ---
 
 function makeSection(name, children = [], props = {}) {
-  return make('section', { name, ...{ collapsed: true, ...props } }, children);
+  return make('section', { name, ...{ expanded: false, ...props } }, children);
 }
 
 function makeGroup(name, children = [], props = {}) {

--- a/docs/constants/navigation-deprecated.js
+++ b/docs/constants/navigation-deprecated.js
@@ -18,7 +18,7 @@ const easDirectories = ['eas', 'build', 'app-signing', 'build-reference', 'submi
 /** Private preview section which isn't linked in the documentation */
 const previewDirectories = ['preview'];
 /** Public preview section which is linked under `Feature Preview` */
-const featurePreviewDirectories = ['feature-preview', 'development', 'eas-update'];
+const featurePreviewDirectories = ['feature-preview', 'eas-update'];
 /** All other unlisted directories */
 const generalDirectories = fs
   .readdirSync(PAGES_DIR, { withFileTypes: true })
@@ -104,6 +104,19 @@ const general = [
       makePage('distribution/security.md'),
       makePage('distribution/optimizing-updates.md'),
       makePage('distribution/publishing-websites.md'),
+    ]),
+  ]),
+  makeSection('Development Builds', [
+    makeGroup('Development Builds', [
+      makePage('development/introduction.md'),
+      makePage('development/getting-started.md'),
+      makePage('development/build.md'),
+      makePage('development/installation.md'),
+      makePage('development/development-workflows.md'),
+      makePage('development/extensions.md'),
+      makePage('development/compatibility.md'),
+      makePage('development/upgrading.md'),
+      makePage('development/troubleshooting.md'),
     ]),
   ]),
   makeSection('Assorted Guides', [
@@ -311,19 +324,6 @@ const preview = [
 ];
 
 const featurePreview = [
-  makeSection('Development Builds', [
-    makeGroup('Development Builds', [
-      makePage('development/introduction.md'),
-      makePage('development/getting-started.md'),
-      makePage('development/build.md'),
-      makePage('development/installation.md'),
-      makePage('development/development-workflows.md'),
-      makePage('development/extensions.md'),
-      makePage('development/compatibility.md'),
-      makePage('development/upgrading.md'),
-      makePage('development/troubleshooting.md'),
-    ]),
-  ]),
   makeSection('EAS Update', [
     makeGroup('EAS Update', [
       makePage('eas-update/introduction.md'),

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -39,33 +39,49 @@ const generalDirectories = fs
 // --- Navigation ---
 
 const starting = [
-  makeSection('Get Started', [
-    makePage('get-started/installation.md'),
-    makePage('get-started/create-a-new-app.md'),
-    makePage('get-started/errors.md'),
-  ]),
-  makeSection('Tutorial', [
-    makePage('tutorial/planning.md'),
-    makePage('tutorial/text.md'),
-    makePage('tutorial/image.md'),
-    makePage('tutorial/button.md'),
-    makePage('tutorial/image-picker.md'),
-    makePage('tutorial/sharing.md'),
-    makePage('tutorial/platform-differences.md'),
-    makePage('tutorial/configuration.md'),
-    makePage('tutorial/follow-up.md'),
-  ]),
-  makeSection('Conceptual Overview', [
-    makePage('introduction/managed-vs-bare.md'),
-    makePage('introduction/walkthrough.md'),
-    makePage('introduction/why-not-expo.md'),
-    makePage('introduction/faq.md'),
-  ]),
-  makeSection('Next Steps', [
-    makePage('next-steps/using-the-documentation.md'),
-    makePage('next-steps/community.md'),
-    makePage('next-steps/additional-resources.md'),
-  ]),
+  makeSection(
+    'Get Started',
+    [
+      makePage('get-started/installation.md'),
+      makePage('get-started/create-a-new-app.md'),
+      makePage('get-started/errors.md'),
+    ],
+    { expanded: true }
+  ),
+  makeSection(
+    'Tutorial',
+    [
+      makePage('tutorial/planning.md'),
+      makePage('tutorial/text.md'),
+      makePage('tutorial/image.md'),
+      makePage('tutorial/button.md'),
+      makePage('tutorial/image-picker.md'),
+      makePage('tutorial/sharing.md'),
+      makePage('tutorial/platform-differences.md'),
+      makePage('tutorial/configuration.md'),
+      makePage('tutorial/follow-up.md'),
+    ],
+    { expanded: true }
+  ),
+  makeSection(
+    'Conceptual Overview',
+    [
+      makePage('introduction/managed-vs-bare.md'),
+      makePage('introduction/walkthrough.md'),
+      makePage('introduction/why-not-expo.md'),
+      makePage('introduction/faq.md'),
+    ],
+    { expanded: true }
+  ),
+  makeSection(
+    'Next Steps',
+    [
+      makePage('next-steps/using-the-documentation.md'),
+      makePage('next-steps/community.md'),
+      makePage('next-steps/additional-resources.md'),
+    ],
+    { expanded: true }
+  ),
 ];
 
 const general = [
@@ -99,6 +115,17 @@ const general = [
     makePage('distribution/security.md'),
     makePage('distribution/optimizing-updates.md'),
     makePage('distribution/publishing-websites.md'),
+  ]),
+  makeSection('Development Builds', [
+    makePage('development/introduction.md'),
+    makePage('development/getting-started.md'),
+    makePage('development/build.md'),
+    makePage('development/installation.md'),
+    makePage('development/development-workflows.md'),
+    makePage('development/extensions.md'),
+    makePage('development/compatibility.md'),
+    makePage('development/upgrading.md'),
+    makePage('development/troubleshooting.md'),
   ]),
   makeSection('Assorted Guides', [
     makePage('guides/assets.md'),
@@ -147,7 +174,7 @@ const general = [
     makePage('guides/using-nextjs.md'),
     makePage('guides/using-preact.md'),
   ]),
-  makeSection('Expo Modules', [
+  makeSection('Expo Module API (Alpha)', [
     makePage('modules/overview.md'),
     makePage('modules/module-api.md'),
     makePage('modules/android-lifecycle-listeners.md'),
@@ -185,129 +212,123 @@ const general = [
     makePage('push-notifications/faq.md'),
   ]),
   makeSection('Classic Services', sortAlphabetical(pagesFromDir('classic'))),
-  makeSection(
-    'UI Programming',
-    [
-      makePage('ui-programming/image-background.md'),
-      makePage('ui-programming/implementing-a-checkbox.md'),
-      makePage('ui-programming/z-index.md'),
-      makePage('ui-programming/using-svgs.md'),
-      makePage('ui-programming/react-native-toast.md'),
-      makePage('ui-programming/react-native-styling-buttons.md'),
-    ],
-    { collapsed: true }
-  ),
-  makeSection('Regulatory Compliance', sortAlphabetical(pagesFromDir('regulatory-compliance')), {
-    collapsed: true,
-  }),
-  makeSection(
-    'Technical Specs',
-    [makePage('technical-specs/expo-updates-0.md'), makePage('technical-specs/expo-sfv-0.md')],
-    { collapsed: true }
-  ),
-  makeSection(
-    'Deprecated',
-    [
-      makeGroup('ExpoKit', [
-        makePage('expokit/overview.md'),
-        makePage('expokit/eject.md'),
-        makePage('expokit/expokit.md'),
-        makePage('expokit/advanced-expokit-topics.md'),
-        makePage('expokit/universal-modules-and-expokit.md'),
-      ]),
-      makeGroup('Archived', sortAlphabetical(pagesFromDir('archived'))),
-    ],
-    { collapsed: true }
-  ),
+  makeSection('UI Programming', [
+    makePage('ui-programming/image-background.md'),
+    makePage('ui-programming/implementing-a-checkbox.md'),
+    makePage('ui-programming/z-index.md'),
+    makePage('ui-programming/using-svgs.md'),
+    makePage('ui-programming/react-native-toast.md'),
+    makePage('ui-programming/react-native-styling-buttons.md'),
+  ]),
+  makeSection('Regulatory Compliance', sortAlphabetical(pagesFromDir('regulatory-compliance')), {}),
+  makeSection('Technical Specs', [
+    makePage('technical-specs/expo-updates-0.md'),
+    makePage('technical-specs/expo-sfv-0.md'),
+  ]),
+  makeSection('Deprecated', [
+    makeGroup('ExpoKit', [
+      makePage('expokit/overview.md'),
+      makePage('expokit/eject.md'),
+      makePage('expokit/expokit.md'),
+      makePage('expokit/advanced-expokit-topics.md'),
+      makePage('expokit/universal-modules-and-expokit.md'),
+    ]),
+    makeGroup('Archived', sortAlphabetical(pagesFromDir('archived'))),
+  ]),
 ];
 
 const eas = [
-  makeSection('EAS', [makePage('eas/index.md'), makePage('eas/webhooks.md')]),
-  makeSection('EAS Build', [
-    makeGroup(
-      'Start Building',
-      [
-        makePage('build/introduction.md'),
-        makePage('build/setup.md'),
-        makePage('build/eas-json.md'),
-        makePage('build/internal-distribution.md'),
-        makePage('build/automating-submissions.md'),
-        makePage('build/updates.md'),
-        makePage('build/building-on-ci.md'),
-      ],
-      './pages/build/'
-    ),
-    makeGroup('App Signing', [
-      makePage('app-signing/app-credentials.md'),
-      makePage('app-signing/managed-credentials.md'),
-      makePage('app-signing/local-credentials.md'),
-      makePage('app-signing/existing-credentials.md'),
-      makePage('app-signing/syncing-credentials.md'),
-    ]),
-    makeGroup('Reference', [
-      makePage('build-reference/eas-json.md'),
-      makePage('build-reference/migrating.md'),
-      makePage('build-reference/how-tos.md'),
-      makePage('build-reference/private-npm-packages.md'),
-      makePage('build-reference/variables.md'),
-      makePage('build-reference/apk.md'),
-      makePage('build-reference/simulators.md'),
-      makePage('build-reference/troubleshooting.md'),
-      makePage('build-reference/local-builds.md'),
-      makePage('build-reference/variants.md'),
-      makePage('build-reference/caching.md'),
-      makePage('build-reference/android-builds.md'),
-      makePage('build-reference/ios-builds.md'),
-      makePage('build-reference/limitations.md'),
-      makePage('build-reference/build-configuration.md'),
-      makePage('build-reference/infrastructure.md'),
-      makePage('build-reference/ios-capabilities.md'),
-    ]),
-  ]),
-  makeSection('EAS Submit', [
-    makePage('submit/introduction.md'),
-    makePage('submit/eas-json.md'),
-    makePage('submit/android.md'),
-    makePage('submit/ios.md'),
-    makePage('submit/classic-builds.md'),
-  ]),
+  makeSection('EAS', [makePage('eas/index.md'), makePage('eas/webhooks.md')], { expanded: true }),
+  makeSection(
+    'EAS Build',
+    [
+      makeGroup(
+        'Start Building',
+        [
+          makePage('build/introduction.md'),
+          makePage('build/setup.md'),
+          makePage('build/eas-json.md'),
+          makePage('build/internal-distribution.md'),
+          makePage('build/automating-submissions.md'),
+          makePage('build/updates.md'),
+          makePage('build/building-on-ci.md'),
+        ],
+        './pages/build/'
+      ),
+      makeGroup('App Signing', [
+        makePage('app-signing/app-credentials.md'),
+        makePage('app-signing/managed-credentials.md'),
+        makePage('app-signing/local-credentials.md'),
+        makePage('app-signing/existing-credentials.md'),
+        makePage('app-signing/syncing-credentials.md'),
+      ]),
+      makeGroup('Reference', [
+        makePage('build-reference/eas-json.md'),
+        makePage('build-reference/migrating.md'),
+        makePage('build-reference/how-tos.md'),
+        makePage('build-reference/private-npm-packages.md'),
+        makePage('build-reference/variables.md'),
+        makePage('build-reference/apk.md'),
+        makePage('build-reference/simulators.md'),
+        makePage('build-reference/troubleshooting.md'),
+        makePage('build-reference/local-builds.md'),
+        makePage('build-reference/variants.md'),
+        makePage('build-reference/caching.md'),
+        makePage('build-reference/android-builds.md'),
+        makePage('build-reference/ios-builds.md'),
+        makePage('build-reference/limitations.md'),
+        makePage('build-reference/build-configuration.md'),
+        makePage('build-reference/infrastructure.md'),
+        makePage('build-reference/ios-capabilities.md'),
+      ]),
+    ],
+    { expanded: true }
+  ),
+  makeSection(
+    'EAS Submit',
+    [
+      makePage('submit/introduction.md'),
+      makePage('submit/eas-json.md'),
+      makePage('submit/android.md'),
+      makePage('submit/ios.md'),
+      makePage('submit/classic-builds.md'),
+    ],
+    { expanded: true }
+  ),
 ];
 
 const preview = [
-  makeSection('Preview', [makePage('preview/introduction.md'), makePage('preview/support.md')]),
+  makeSection('Preview', [
+    makePage('preview/introduction.md'),
+    makePage('preview/support.md'),
+    { expanded: true },
+  ]),
 ];
 
 const featurePreview = [
-  makeSection('Development Builds', [
-    makePage('development/introduction.md'),
-    makePage('development/getting-started.md'),
-    makePage('development/build.md'),
-    makePage('development/installation.md'),
-    makePage('development/development-workflows.md'),
-    makePage('development/extensions.md'),
-    makePage('development/compatibility.md'),
-    makePage('development/upgrading.md'),
-    makePage('development/troubleshooting.md'),
-  ]),
-  makeSection('EAS Update', [
-    makePage('eas-update/introduction.md'),
-    makePage('eas-update/getting-started.md'),
-    makePage('eas-update/github-actions.md'),
-    makePage('eas-update/developing-with-eas-update.md'),
-    makePage('eas-update/how-eas-update-works.md'),
-    makePage('eas-update/deployment-patterns.md'),
-    makePage('eas-update/debug-updates.md'),
-    makePage('eas-update/eas-update-and-eas-cli.md'),
-    makePage('eas-update/optimize-assets.md'),
-    makePage('eas-update/custom-updates-server.md'),
-    makePage('eas-update/migrate-to-eas-update.md'),
-    makePage('eas-update/bare-react-native.md'),
-    makePage('eas-update/runtime-versions.md'),
-    makePage('eas-update/environment-variables.md'),
-    makePage('eas-update/expo-dev-client.md'),
-    makePage('eas-update/known-issues.md'),
-    makePage('eas-update/faq.md'),
-  ]),
+  makeSection(
+    'EAS Update',
+    [
+      makePage('eas-update/introduction.md'),
+      makePage('eas-update/getting-started.md'),
+      makePage('eas-update/github-actions.md'),
+      makePage('eas-update/developing-with-eas-update.md'),
+      makePage('eas-update/how-eas-update-works.md'),
+      makePage('eas-update/deployment-patterns.md'),
+      makePage('eas-update/debug-updates.md'),
+      makePage('eas-update/eas-update-and-eas-cli.md'),
+      makePage('eas-update/optimize-assets.md'),
+      makePage('eas-update/custom-updates-server.md'),
+      makePage('eas-update/migrate-to-eas-update.md'),
+      makePage('eas-update/bare-react-native.md'),
+      makePage('eas-update/runtime-versions.md'),
+      makePage('eas-update/environment-variables.md'),
+      makePage('eas-update/expo-dev-client.md'),
+      makePage('eas-update/known-issues.md'),
+      makePage('eas-update/faq.md'),
+    ],
+    { expanded: true }
+  ),
 ];
 
 const reference = VERSIONS.reduce(
@@ -343,7 +364,7 @@ module.exports = {
 // --- MDX methods ---
 
 function makeSection(name, children = [], props = {}) {
-  return make('section', { name, ...props }, children);
+  return make('section', { name, ...{ expanded: false, ...props } }, children);
 }
 
 function makeGroup(name, children = [], props = {}) {

--- a/docs/pages/development/development-workflows.md
+++ b/docs/pages/development/development-workflows.md
@@ -52,9 +52,11 @@ Developers on your team with expertise working with Xcode and Android Studio can
 
 ### Side by side installation
 
-If you need to look at release builds of your project, it is convenient to not overwrite the development build of your app every time you do so. You can accomplish this by using [**app.config.js**](../workflow/configuration.md) to set the bundle identifier or package name based on an environment variable. When changing the ID of your project, be aware that some modules will expect you to perform installation steps for each bundle identifier or package name you use.
+If you need to look at release builds of your project, it is convenient to not overwrite the development build of your app every time you do so. You can accomplish this by using [**app.config.js**](../workflow/configuration.md) to set the bundle identifier or package name based on an environment variable. When changing the ID of your project, be aware that some modules will expect you to perform installation steps for each bundle identifier or package name you use. [Learn more about how to use this pattern on EAS Build with build variants](/build-reference/variants.md).
 
 ```js
+// Example app.config.js where the bundle identifier and package name are
+// swapped out depending on an environment variable
 module.exports = () => {
   if (process.env.MY_ENVIRONMENT === 'production') {
     return {
@@ -69,6 +71,7 @@ module.exports = () => {
   }
 };
 ```
+
 
 ### PR Previews
 

--- a/docs/pages/guides.md
+++ b/docs/pages/guides.md
@@ -20,11 +20,18 @@ In this section we cover the fundamentals of developing with Expo's tools. Some 
 
 ### Distributing Your App
 
-In this section we cover topics related to building, shipping, and updating your app with Expo's tools. Some popular topics are:
+In this section we cover topics related to building, shipping, and updating your app with Expo's tools and services like [EAS Build](/build/introduction.md) and [EAS Submit](/submit/introduction.md). Some popular topics are:
 
 - [Distributing your App on the App Store and Play Store](distribution/introduction.md)
 - [App Signing](app-signing/app-credentials.md)
 - [Release Channels](distribution/release-channels.md)
+
+### Development Builds
+
+This section covers creating Development Builds with customizations beyond what is possible within the Expo Go app.
+
+- [Introduction to Development Builds](development/introduction.md)
+- [Getting Started with Development Builds](development/getting-started.md)
 
 ### Expo Accounts
 

--- a/docs/types/common.ts
+++ b/docs/types/common.ts
@@ -35,7 +35,7 @@ export type NavigationRoute = {
   href: string;
   as?: string;
   hidden?: boolean;
-  collapsed?: boolean;
+  expanded?: boolean;
   sidebarTitle?: string;
   weight?: number;
   children?: NavigationRoute[];

--- a/docs/ui/components/Navigation/SectionList.tsx
+++ b/docs/ui/components/Navigation/SectionList.tsx
@@ -16,7 +16,7 @@ export function SectionList({ route, isActive, children }: SectionListProps) {
   }
 
   return (
-    <details css={detailsStyle} open={isActive || route.collapsed !== true}>
+    <details css={detailsStyle} open={isActive || route.expanded}>
       <summary css={summaryStyle}>
         <ChevronDownIcon css={iconStyle} size={iconSize.small} />
         <CALLOUT css={textStyle} tag="span">

--- a/docs/ui/components/Navigation/types.ts
+++ b/docs/ui/components/Navigation/types.ts
@@ -23,8 +23,8 @@ export type Section = Node<
   {
     /** The groups or pages it should render within the collapsible section */
     children: (Group | Page)[];
-    /** If the section should be rendered as "closed" by default */
-    collapsed?: boolean;
+    /** If the section should be rendered as "closed" by default. Defaults to false. */
+    expanded?: boolean;
   }
 >;
 


### PR DESCRIPTION
# Why

Development builds currently lives under "Feature Preview" - and while we aren't quite ready yet to make a 1.0 announcement, this feature has slowly become an essential part of more advanced development workflows, and we've begun to point to it from other places in our docs. We should move it under "Guides" to improve discoverability and better reflect the current maturity and extent to which we recommend using it.

# How

- Move "Development Builds" to "Guides"
- Collapse all of the sections in "Guides" by default, in order to account for the fact that there are 13 sections and when they are expanded it is difficult to grok what all is available here

<img width="1672" alt="Screen Shot 2022-05-04 at 4 22 44 PM" src="https://user-images.githubusercontent.com/90494/166841380-9994e655-e2ef-467c-b6dc-7954446695a7.png">

<img width="1672" alt="image" src="https://user-images.githubusercontent.com/90494/166842827-4be11386-bb22-444a-b633-c1469bfc47d7.png">

# Test Plan

Run docs locally, click around it.
