### PR TITLE
[bare-expo] fix release build error

### DIFF
--- a/apps/bare-expo/ios/BareExpo/AppDelegate.mm
+++ b/apps/bare-expo/ios/BareExpo/AppDelegate.mm
@@ -11,8 +11,11 @@
 #import <React/RCTAppSetupUtils.h>
 
 #import <ExpoModulesCore-Swift.h>
+
+#if DEBUG
 #import <EXDevLauncher/EXDevLauncherController.h>
 #import <EXDevLauncher-Swift.h>
+#endif
 
 #if RCT_NEW_ARCH_ENABLED
 #import <React/CoreModulesPlugins.h>
@@ -37,13 +40,15 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
-  BOOL useDevClient = NO;
-
   RCTAppSetupPrepareApp(application);
+
+#if DEBUG
+  BOOL useDevClient = YES;
 
   if (!useDevClient) {
     ExpoDevLauncherReactDelegateHandler.enableAutoSetup = NO;
   }
+#endif
 
   RCTBridge *bridge = [self.reactDelegate createBridgeWithDelegate:self launchOptions:launchOptions];
 


### PR DESCRIPTION
# Why

fix ci error in bare-expo release build: https://github.com/expo/expo/runs/6293429345?check_suite_focus=true

```
❌  /Users/runner/work/expo/expo/apps/bare-expo/ios/BareExpo/AppDelegate.mm:15:9: 'EXDevLauncher-Swift.h' file not found

#import <EXDevLauncher-Swift.h>
        ^
```


# How

from #17332, dev launcher is exposing only in debug build. this pr wraps the related code with `#if DEBUG`

# Test Plan

test suite ios ci job green

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
