### PR TITLE
[tools] Add ability to disable bot comments

### DIFF
--- a/packages/expo-clipboard/src/Clipboard.ts
+++ b/packages/expo-clipboard/src/Clipboard.ts
@@ -9,6 +9,8 @@ import {
 } from './Clipboard.types';
 import ExpoClipboard from './ExpoClipboard';
 
+// dummy change 1
+
 const emitter = new EventEmitter(ExpoClipboard);
 
 const onClipboardEventName = 'onClipboardChanged';

--- a/packages/expo-clipboard/src/Clipboard.ts
+++ b/packages/expo-clipboard/src/Clipboard.ts
@@ -9,8 +9,6 @@ import {
 } from './Clipboard.types';
 import ExpoClipboard from './ExpoClipboard';
 
-// dummy change 1
-
 const emitter = new EventEmitter(ExpoClipboard);
 
 const onClipboardEventName = 'onClipboardChanged';

--- a/tools/src/code-review/index.ts
+++ b/tools/src/code-review/index.ts
@@ -61,7 +61,7 @@ export async function reviewPullRequestAsync(prNumber: number) {
   logger.info('🕵️‍♀️  Reviewing changes');
   const reviewActions = REVIEWERS.filter(
     ({ magicCommentToDisable }) =>
-      !magicCommentToDisable || pr.body?.includes(magicCommentToDisable) === false
+      !magicCommentToDisable || !pr.body?.includes(magicCommentToDisable)
   ).map(({ action }) => action(input));
   const outputs = (await Promise.all(reviewActions)).filter(Boolean) as ReviewOutput[];
 

--- a/tools/src/code-review/index.ts
+++ b/tools/src/code-review/index.ts
@@ -7,27 +7,38 @@ import { COMMENT_HEADER, generateReportFromOutputs } from './reports';
 import checkMissingChangelogs from './reviewers/checkMissingChangelogs';
 import reviewChangelogEntries from './reviewers/reviewChangelogEntries';
 import reviewForbiddenFiles from './reviewers/reviewForbiddenFiles';
-import { ReviewEvent, ReviewComment, ReviewInput, ReviewOutput, ReviewStatus } from './types';
-
-const DISABLE_CHANGELOG_MAGIC_COMMENT = '<!-- disable:changelog-checks -->';
+import {
+  ReviewEvent,
+  ReviewComment,
+  ReviewInput,
+  ReviewOutput,
+  ReviewStatus,
+  Reviewer,
+} from './types';
 
 /**
  * An array with functions whose purpose is to check and review the diff.
  */
-const REVIEWERS = [
+const REVIEWERS: Reviewer[] = [
   {
+    id: 'changelog-checks',
     action: checkMissingChangelogs,
-    magicCommentToDisable: DISABLE_CHANGELOG_MAGIC_COMMENT,
   },
   {
+    id: 'changelog-review',
     action: reviewChangelogEntries,
-    magicCommentToDisable: DISABLE_CHANGELOG_MAGIC_COMMENT,
   },
   {
+    id: 'file-checks',
     action: reviewForbiddenFiles,
-    magicCommentToDisable: null,
   },
 ];
+
+/**
+ * A magic comment template for a reviewer. Magic comments are used to disable specific reviewers.
+ * Available reviewers: {@link REVIEWERS}
+ */
+const getMagicCommentForReviewer = (reviewer: Reviewer) => `<!-- disable:${reviewer.id} -->`;
 
 enum Label {
   PASSED_CHECKS = 'bot: passed checks',
@@ -57,11 +68,10 @@ export async function reviewPullRequestAsync(prNumber: number) {
     diff,
   };
 
-  // Run all the checks asynchronously and collects their outputs.
+  // Filter out the disabled checks, run the checks asynchronously and collects their outputs.
   logger.info('🕵️‍♀️  Reviewing changes');
   const reviewActions = REVIEWERS.filter(
-    ({ magicCommentToDisable }) =>
-      !magicCommentToDisable || !pr.body?.includes(magicCommentToDisable)
+    (reviewer) => !pr.body?.includes(getMagicCommentForReviewer(reviewer))
   ).map(({ action }) => action(input));
   const outputs = (await Promise.all(reviewActions)).filter(Boolean) as ReviewOutput[];
 

--- a/tools/src/code-review/types.ts
+++ b/tools/src/code-review/types.ts
@@ -12,6 +12,15 @@ export type ReviewComment = {
 };
 
 /**
+ * The type representing a single pull request reviewer.
+ * An `action` is a function whose purpose is to check and review the diff.
+ */
+export type Reviewer = {
+  id: string;
+  action: (input: ReviewInput) => Promise<ReviewOutput | null>;
+};
+
+/**
  * The result of code reviews that is being used to generate the final review comment/report.
  */
 export type ReviewOutput = {


### PR DESCRIPTION
# Why

Bot spamming with missing changelog might be annoying when you know what you're doing and intentionally skip changelog update

# How

Added a possibility to disable changelog checks. To do it, you need to paste `<!-- disable:changelog-checks -->` magic comment anywhere in the PR description.

# Test Plan

`et review` in this PR adds a `bot: passed checks` label even if there are changes in the `packages/` dir

<!-- disable:changelog-checks -->