### PR TITLE
[ios] Fix compilation issues in iOS shell apps

### DIFF
--- a/ios/ExpoKit.podspec
+++ b/ios/ExpoKit.podspec
@@ -11,6 +11,7 @@ Pod::Spec.new do |s|
   s.author = "650 Industries, Inc."
   s.requires_arc = true
   s.platform = :ios, "12.0"
+  s.swift_version  = '5.4'
   s.default_subspec = "Core"
   s.source = { :git => "http://github.com/expo/expo.git" }
   s.xcconfig = {
@@ -24,10 +25,15 @@ Pod::Spec.new do |s|
     ]
   }
 
+  s.pod_target_xcconfig = {
+    'USE_HEADERMAP' => 'YES',
+    'DEFINES_MODULE' => 'YES',
+  }
+
   s.subspec "Core" do |ss|
-    ss.source_files = "Exponent/**/*.{h,m,mm,cpp}", "../template-files/keys.json"
-    ss.preserve_paths = "Exponent/**/*.{h,m,mm,cpp}"
-    ss.exclude_files = "Exponent/Supporting/**", "Exponent/Versioned/Optional/**/*.{h,m}"
+    ss.source_files = "Exponent/**/*.{h,m,mm,cpp,swift}", "../template-files/keys.json"
+    ss.preserve_paths = "Exponent/**/*.{h,m,mm,cpp,swift}"
+    ss.exclude_files = "Exponent/Supporting/**", "Exponent/Versioned/Optional/**/*.{h,m,swift}"
 
     ss.dependency 'Amplitude', '~> 6.0.0'
     ss.dependency 'CocoaLumberjack', '~> 3.5.3'

--- a/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
@@ -13,9 +13,11 @@
 #import "EXUpdatesDatabaseManager.h"
 #import "EXVersions.h"
 
-#if !defined(EX_DETACHED)
+#if defined(EX_DETACHED)
+#import "ExpoKit-Swift.h"
+#else
 #import "Expo_Go-Swift.h"
-#endif // !defined(EX_DETACHED)
+#endif // defined(EX_DETACHED)
 
 #import <EXUpdates/EXUpdatesAppLauncherNoDatabase.h>
 #import <EXUpdates/EXUpdatesAppLoaderTask.h>

--- a/ios/Exponent/Kernel/AppLoader/EXAppLoaderHelpers.swift
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoaderHelpers.swift
@@ -4,14 +4,14 @@ import Foundation
 import CommonCrypto
 
 @objc
-extension NSString {
+public extension NSString {
   @objc func hexEncodedSHA256() -> String {
     let digest = (self as String).data(using:String.Encoding.utf8)!.sha256()
     return digest.reduce("") { $0 + String(format: "%02x", $1) }
   }
 }
 
-extension Data {
+public extension Data {
   func sha256() -> Data {
     var digest = Data(count: Int(CC_SHA256_DIGEST_LENGTH))
     withUnsafeBytes { bytes in

--- a/ios/Exponent/Versioned/Core/Api/Cognito/RNAWSCognito.h
+++ b/ios/Exponent/Versioned/Core/Api/Cognito/RNAWSCognito.h
@@ -9,7 +9,7 @@
 #import <React/RCTLog.h>
 #import <React/RCTUtils.h>
 
-#import <JKBigInteger.h>
+#import <JKBigInteger/JKBigInteger.h>
 
 @interface RNAWSCognito : NSObject <RCTBridgeModule>
 -(NSString*)getRandomBase64:(NSUInteger)byteLength;

--- a/ios/Exponent/Versioned/Core/Internal/DevSupport/EXDisabledDevMenu.h
+++ b/ios/Exponent/Versioned/Core/Internal/DevSupport/EXDisabledDevMenu.h
@@ -1,10 +1,9 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 #import <React/RCTBridgeModule.h>
-#import <ReactCommon/RCTTurboModule.h>
 #import <React/RCTDevMenu.h>
 
-@interface EXDisabledDevMenu : NSObject <RCTBridgeModule, RCTTurboModule>
+@interface EXDisabledDevMenu : NSObject <RCTBridgeModule>
 
 @property (nonatomic) BOOL shakeToShow;
 @property (nonatomic) BOOL profilingEnabled;

--- a/ios/Exponent/Versioned/Core/Internal/DevSupport/EXDisabledRedBox.h
+++ b/ios/Exponent/Versioned/Core/Internal/DevSupport/EXDisabledRedBox.h
@@ -1,9 +1,8 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
-#import <ReactCommon/RCTTurboModule.h>
 #import <React/RCTRedBox.h>
 
-@interface EXDisabledRedBox : RCTRedBox <RCTTurboModule>
+@interface EXDisabledRedBox : RCTRedBox
 
 - (void)showError:(NSError *)message;
 - (void)showErrorMessage:(NSString *)message;

--- a/template-files/ios/ExpoKit-Podfile
+++ b/template-files/ios/ExpoKit-Podfile
@@ -30,12 +30,17 @@ target 'ExpoKitApp' do
     ],
   )
 
+  pod 'Amplitude', :modular_headers => true
+  pod 'CocoaLumberjack', :modular_headers => true
+  pod 'Google-Maps-iOS-Utils', :modular_headers => true
+  pod 'JKBigInteger', :modular_headers => true, :podspec => '../../../ios/vendored/common/JKBigInteger.podspec.json'
+  pod 'MBProgressHUD', :modular_headers => true
+
   # Install React Native and its dependencies
   require_relative '../node_modules/react-native/scripts/react_native_pods'
   use_react_native!(production: true)
 
   # Install vendored pods.
-  pod 'JKBigInteger', :podspec => '../../../ios/vendored/common/JKBigInteger.podspec.json'
   require_relative '../../../ios/podfile_helpers.rb'
   excluded_pods = ['stripe-react-native']
   use_pods!('../../../ios/vendored/unversioned/**/*.podspec.json', nil, excluded_pods)

--- a/template-files/ios/ExpoKit.podspec
+++ b/template-files/ios/ExpoKit.podspec
@@ -11,6 +11,7 @@ Pod::Spec.new do |s|
   s.author = "650 Industries, Inc."
   s.requires_arc = true
   s.platform = :ios, "12.0"
+  s.swift_version  = '5.4'
   s.default_subspec = "Core"
   s.source = { :git => "http://github.com/expo/expo.git" }
   s.xcconfig = {
@@ -24,10 +25,15 @@ Pod::Spec.new do |s|
     ]
   }
 
+  s.pod_target_xcconfig = {
+    'USE_HEADERMAP' => 'YES',
+    'DEFINES_MODULE' => 'YES',
+  }
+
   s.subspec "Core" do |ss|
-    ss.source_files = "Exponent/**/*.{h,m,mm,cpp}", "../template-files/keys.json"
-    ss.preserve_paths = "Exponent/**/*.{h,m,mm,cpp}"
-    ss.exclude_files = "Exponent/Supporting/**", "Exponent/Versioned/Optional/**/*.{h,m}"
+    ss.source_files = "Exponent/**/*.{h,m,mm,cpp,swift}", "../template-files/keys.json"
+    ss.preserve_paths = "Exponent/**/*.{h,m,mm,cpp,swift}"
+    ss.exclude_files = "Exponent/Supporting/**", "Exponent/Versioned/Optional/**/*.{h,m,swift}"
 
 ${IOS_EXPOKIT_DEPS}
     ss.dependency 'React-Core' # explicit dependency required for CocoaPods >= 1.5.0


### PR DESCRIPTION
# Why

Fixes several compilation issues in iOS shell apps. Failing job: https://github.com/expo/expo/runs/6301193483
Followup of #17354 — `react-native-safe-area-context` now depends on more React-* pods and so it imports from pods that don't define the module, so moving it out of `ExpoKit` pod was the most crucial thing to solve the problem, but we also need to adjust a few things to make ExpoKit working with Swift files.

# How

See file changes and my comments

# Test Plan

Building the shell app locally works fine. I tried to run NCL for SDK45 on the simulator build and it worked as well.
Also manually dispatched the CI job: https://github.com/expo/expo/runs/6308527510