### PR TITLE
Upgrade Xcode to 13.2.1 on the CI

### DIFF
--- a/.github/workflows/client-ios.yml
+++ b/.github/workflows/client-ios.yml
@@ -48,8 +48,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
-      - name: 🔨 Switch to Xcode 13.0
-        run: sudo xcode-select --switch /Applications/Xcode_13.0.app
+      - name: 🔨 Switch to Xcode 13.2.1
+        run: sudo xcode-select --switch /Applications/Xcode_13.2.1.app
       - name: 🔓 Decrypt secrets if possible
         uses: ./.github/actions/expo-git-decrypt
         with:

--- a/.github/workflows/ios-unit-tests.yml
+++ b/.github/workflows/ios-unit-tests.yml
@@ -45,8 +45,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
-      - name: 🔨 Switch to Xcode 13.0
-        run: sudo xcode-select --switch /Applications/Xcode_13.0.app
+      - name: 🔨 Switch to Xcode 13.2.1
+        run: sudo xcode-select --switch /Applications/Xcode_13.2.1.app
       - name: 🔓 Decrypt secrets if possible
         uses: ./.github/actions/expo-git-decrypt
         with:

--- a/.github/workflows/shell-app-ios.yml
+++ b/.github/workflows/shell-app-ios.yml
@@ -26,8 +26,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
-      - name: 🔨 Switch to Xcode 13.0
-        run: sudo xcode-select --switch /Applications/Xcode_13.0.app
+      - name: 🔨 Switch to Xcode 13.2.1
+        run: sudo xcode-select --switch /Applications/Xcode_13.2.1.app
       - name: ➕ Add `EXPO_ROOT_DIR` to GITHUB_ENV
         run: echo "EXPO_ROOT_DIR=$(pwd)" >> $GITHUB_ENV
       - name: ➕ Add `bin` to GITHUB_PATH

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -68,8 +68,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
-      - name: 🔨 Switch to Xcode 13.0
-        run: sudo xcode-select --switch /Applications/Xcode_13.0.app
+      - name: 🔨 Switch to Xcode 13.2.1
+        run: sudo xcode-select --switch /Applications/Xcode_13.2.1.app
       - name: 🍺 Install required tools
         run: |
           brew tap wix/brew

--- a/.github/workflows/updates-e2e.yml
+++ b/.github/workflows/updates-e2e.yml
@@ -171,8 +171,8 @@ jobs:
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v3
-      - name: 🔨 Switch to Xcode 13.0
-        run: sudo xcode-select --switch /Applications/Xcode_13.0.app
+      - name: 🔨 Switch to Xcode 13.2.1
+        run: sudo xcode-select --switch /Applications/Xcode_13.2.1.app
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(yarn global bin)" >> $GITHUB_PATH
       - name: ♻️ Restore caches

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -23,8 +23,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
-      - name: 🔨 Switch to Xcode 13.0
-        run: sudo xcode-select --switch /Applications/Xcode_13.0.app
+      - name: 🔨 Switch to Xcode 13.2.1
+        run: sudo xcode-select --switch /Applications/Xcode_13.2.1.app
       - name: 🔓 Decrypt secrets if possible
         uses: ./.github/actions/expo-git-decrypt
         with:


### PR DESCRIPTION
# Why

We use Xcode 13.0 on GitHub Actions which is kinda old already.

# How

Updated the path to Xcode app in all jobs using it

# Test Plan

CI jobs are passing except:
- Updates e2e workflow is failing due to unrelated reasons
- Versioning is broken since #17354 (I'll investigate it separately)
