### PR TITLE
[build-properties] add missing enableProguardInReleaseBuilds property

### DIFF
--- a/packages/expo-build-properties/build/android.js
+++ b/packages/expo-build-properties/build/android.js
@@ -42,6 +42,10 @@ exports.withAndroidBuildProperties = createBuildGradlePropsConfigPlugin([
         propName: 'android.packagingOptions.doNotStrip',
         propValueGetter: (config) => { var _a, _b, _c; return (_c = (_b = (_a = config.android) === null || _a === void 0 ? void 0 : _a.packagingOptions) === null || _b === void 0 ? void 0 : _b.doNotStrip) === null || _c === void 0 ? void 0 : _c.join(','); },
     },
+    {
+        propName: 'android.enableProguardInReleaseBuilds',
+        propValueGetter: (config) => { var _a, _b; return (_b = (_a = config.android) === null || _a === void 0 ? void 0 : _a.enableProguardInReleaseBuilds) === null || _b === void 0 ? void 0 : _b.toString(); },
+    },
 ], 'withAndroidBuildProperties');
 /**
  * Appends `props.android.extraProguardRules` content into `android/app/proguard-rules.pro`

--- a/packages/expo-build-properties/src/android.ts
+++ b/packages/expo-build-properties/src/android.ts
@@ -45,6 +45,10 @@ export const withAndroidBuildProperties = createBuildGradlePropsConfigPlugin<Plu
       propName: 'android.packagingOptions.doNotStrip',
       propValueGetter: (config) => config.android?.packagingOptions?.doNotStrip?.join(','),
     },
+    {
+      propName: 'android.enableProguardInReleaseBuilds',
+      propValueGetter: (config) => config.android?.enableProguardInReleaseBuilds?.toString(),
+    },
   ],
   'withAndroidBuildProperties'
 );


### PR DESCRIPTION
# Why

last minute test and found `enableProguardInReleaseBuilds` is missing 

# How

add `enableProguardInReleaseBuilds` support

# Test Plan

test on a local sdk45 project

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
