### PR TITLE
feat(cli): add `export:web` command

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Add CI context to telemetry to help determine support on used CI providers ([#17284](https://github.com/expo/expo/pull/17284) by [@byCedric](https://github.com/byCedric))
+- Added `export:web` command.
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### 🎉 New features
 
 - Add CI context to telemetry to help determine support on used CI providers ([#17284](https://github.com/expo/expo/pull/17284) by [@byCedric](https://github.com/byCedric))
-- Added `export:web` command.
+- Added `export:web` command. ([#17363](https://github.com/expo/expo/pull/17363) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/__mocks__/webpack.ts
+++ b/packages/@expo/cli/__mocks__/webpack.ts
@@ -1,1 +1,6 @@
-export default jest.fn();
+const webpack = jest.fn();
+
+// @ts-expect-error
+webpack.ProgressPlugin = jest.fn();
+
+export default webpack;

--- a/packages/@expo/cli/bin/cli.ts
+++ b/packages/@expo/cli/bin/cli.ts
@@ -14,6 +14,7 @@ const commands: { [command: string]: () => Promise<Command> } = {
   prebuild: () => import('../src/prebuild').then((i) => i.expoPrebuild),
   config: () => import('../src/config').then((i) => i.expoConfig),
   export: () => import('../src/export').then((i) => i.expoExport),
+  'export:web': () => import('../src/export/web').then((i) => i.expoExportWeb),
 
   // Auxiliary commands
   install: () => import('../src/install').then((i) => i.expoInstall),

--- a/packages/@expo/cli/e2e/__tests__/export-web-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export-web-test.ts
@@ -1,0 +1,158 @@
+/* eslint-env jest */
+import JsonFile from '@expo/json-file';
+import execa from 'execa';
+import fs from 'fs-extra';
+import klawSync from 'klaw-sync';
+import path from 'path';
+
+import { execute, projectRoot, getLoadedModulesAsync, setupTestProjectAsync, bin } from './utils';
+
+const originalForceColor = process.env.FORCE_COLOR;
+const originalCI = process.env.CI;
+
+beforeAll(async () => {
+  await fs.mkdir(projectRoot, { recursive: true });
+  process.env.FORCE_COLOR = '0';
+  process.env.CI = '1';
+});
+
+afterAll(() => {
+  process.env.FORCE_COLOR = originalForceColor;
+  process.env.CI = originalCI;
+});
+
+it('loads expected modules by default', async () => {
+  const modules = await getLoadedModulesAsync(
+    `require('../../build/src/export/web').expoExportWeb`
+  );
+  expect(modules).toStrictEqual([
+    '../node_modules/ansi-styles/index.js',
+    '../node_modules/arg/index.js',
+    '../node_modules/chalk/source/index.js',
+    '../node_modules/chalk/source/util.js',
+    '../node_modules/has-flag/index.js',
+    '../node_modules/supports-color/index.js',
+    '@expo/cli/build/src/export/web/index.js',
+    '@expo/cli/build/src/log.js',
+    '@expo/cli/build/src/utils/args.js',
+    '@expo/cli/build/src/utils/errors.js',
+  ]);
+});
+
+it('runs `npx expo export:web --help`', async () => {
+  const results = await execute('export:web', '--help');
+  expect(results.stdout).toMatchInlineSnapshot(`
+    "
+      Info
+        Export the static files of the web app for hosting on a web server
+
+      Usage
+        $ npx expo export:web <dir>
+
+      Options
+        <dir>                         Directory of the Expo project. Default: Current working directory
+        --dev                         Bundle in development mode
+        -c, --clear                   Clear the bundler cache
+        -h, --help                    Usage info
+    "
+  `);
+});
+
+it(
+  'runs `npx expo export:web`',
+  async () => {
+    const projectRoot = await setupTestProjectAsync('basic-export-web', 'with-web');
+    // `npx expo export:web`
+    await execa('node', [bin, 'export:web'], {
+      cwd: projectRoot,
+    });
+
+    const outputDir = path.join(projectRoot, 'web-build');
+    // List output files with sizes for snapshotting.
+    // This is to make sure that any changes to the output are intentional.
+    // Posix path formatting is used to make paths the same across OSes.
+    const files = klawSync(outputDir)
+      .map((entry) => {
+        if (entry.path.includes('node_modules') || !entry.stats.isFile()) {
+          return null;
+        }
+        return path.posix.relative(outputDir, entry.path);
+      })
+      .filter(Boolean);
+
+    expect(await JsonFile.readAsync(path.resolve(outputDir, 'asset-manifest.json'))).toEqual({
+      entrypoints: [
+        expect.stringMatching(/static\/js\/runtime~app\.[a-z\d]+\.js/),
+        expect.stringMatching(/static\/js\/\d\.[a-z\d]+\.chunk\.js/),
+        expect.stringMatching(/static\/js\/app\.[a-z\d]+\.chunk\.js/),
+      ],
+      files: {
+        'app.js': expect.stringMatching(/static\/js\/app\.[a-z\d]+\.chunk\.js/),
+        'app.js.map': expect.stringMatching(/static\/js\/app\.[a-z\d]+\.chunk\.js\.map/),
+        'index.html': '/index.html',
+        'manifest.json': '/manifest.json',
+        'runtime~app.js': expect.stringMatching(/static\/js\/runtime~app\.[a-z\d]+\.js/),
+        'runtime~app.js.map': expect.stringMatching(/static\/js\/runtime~app\.[a-z\d]+\.js\.map/),
+        'serve.json': '/serve.json',
+        'static/js/2.6566e185.chunk.js': expect.stringMatching(
+          /static\/js\/\d\.[a-z\d]+\.chunk\.js/
+        ),
+        'static/js/2.6566e185.chunk.js.LICENSE.txt': expect.stringMatching(
+          /static\/js\/\d\.[a-z\d]+\.chunk\.js\.LICENSE\.txt/
+        ),
+        'static/js/2.6566e185.chunk.js.map': expect.stringMatching(
+          /static\/js\/\d\.[a-z\d]+\.chunk\.js\.map/
+        ),
+      },
+    });
+    expect(await JsonFile.readAsync(path.resolve(outputDir, 'manifest.json'))).toEqual({
+      display: 'standalone',
+      lang: 'en',
+      name: 'basic-export-web',
+      prefer_related_applications: true,
+      related_applications: [
+        {
+          id: 'com.example.minimal',
+          platform: 'itunes',
+        },
+        {
+          id: 'com.example.minimal',
+          platform: 'play',
+          url: 'http://play.google.com/store/apps/details?id=com.example.minimal',
+        },
+      ],
+      short_name: 'basic-export-web',
+      start_url: '/?utm_source=web_app_manifest',
+    });
+    expect(await JsonFile.readAsync(path.resolve(outputDir, 'serve.json'))).toEqual({
+      headers: [
+        {
+          headers: [
+            {
+              key: 'Cache-Control',
+              value: 'public, max-age=31536000, immutable',
+            },
+          ],
+          source: 'static/**/*.js',
+        },
+      ],
+    });
+
+    // If this changes then everything else probably changed as well.
+    expect(files).toEqual([
+      'asset-manifest.json',
+      'index.html',
+      'manifest.json',
+      'serve.json',
+      expect.stringMatching(/static\/js\/\d\.[a-z\d]+\.chunk\.js/),
+      expect.stringMatching(/static\/js\/\d\.[a-z\d]+\.chunk\.js\.LICENSE\.txt/),
+      expect.stringMatching(/static\/js\/\d\.[a-z\d]+\.chunk\.js\.map/),
+      expect.stringMatching(/static\/js\/app\.[a-z\d]+\.chunk\.js/),
+      expect.stringMatching(/static\/js\/app\.[a-z\d]+\.chunk\.js\.map/),
+      expect.stringMatching(/static\/js\/runtime~app\.[a-z\d]+\.js/),
+      expect.stringMatching(/static\/js\/runtime~app\.[a-z\d]+\.js\.map/),
+    ]);
+  },
+  // Could take 45s depending on how fast npm installs
+  120 * 1000
+);

--- a/packages/@expo/cli/e2e/__tests__/index-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/index-test.ts
@@ -29,7 +29,7 @@ it('runs `npx expo --help`', async () => {
       $ npx expo <command>
 
     Commands
-      start, install, export, config
+      start, install, export, config, export:web
       run:ios, run:android, prebuild
       login, logout, whoami, register
 

--- a/packages/@expo/cli/e2e/fixtures/with-web/App.js
+++ b/packages/@expo/cli/e2e/fixtures/with-web/App.js
@@ -1,0 +1,3 @@
+import React from 'react';
+import { View } from 'react-native';
+export default () => <View />;

--- a/packages/@expo/cli/e2e/fixtures/with-web/app.json
+++ b/packages/@expo/cli/e2e/fixtures/with-web/app.json
@@ -1,0 +1,10 @@
+{
+    "expo": {
+        "android": {
+            "package": "com.example.minimal"
+        },
+        "ios": {
+            "bundleIdentifier": "com.example.minimal"
+        }
+    }
+}

--- a/packages/@expo/cli/e2e/fixtures/with-web/package.json
+++ b/packages/@expo/cli/e2e/fixtures/with-web/package.json
@@ -1,0 +1,14 @@
+{
+    "main": "node_modules/expo/AppEntry.js",
+    "dependencies": {
+        "expo": "~44.0.0",
+        "react": "17.0.1",
+        "react-dom": "17.0.1",
+        "react-native-web": "0.17.1",
+        "react-native": "0.64.3"
+    },
+    "devDependencies": {
+        "@babel/core": "^7.12.9",
+        "@expo/webpack-config": "~0.16.23"
+    }
+}

--- a/packages/@expo/cli/src/export/web/exportWebAsync.ts
+++ b/packages/@expo/cli/src/export/web/exportWebAsync.ts
@@ -1,0 +1,18 @@
+import { Log } from '../../log';
+import { WebSupportProjectPrerequisite } from '../../start/doctor/web/WebSupportProjectPrerequisite';
+import { WebpackBundlerDevServer } from '../../start/server/webpack/WebpackBundlerDevServer';
+import { Options } from './resolveOptions';
+
+export async function exportWebAsync(projectRoot: string, options: Options) {
+  // Ensure webpack is available
+  await new WebSupportProjectPrerequisite(projectRoot).assertAsync();
+
+  // Create a bundler interface
+  const bundler = new WebpackBundlerDevServer(projectRoot, false);
+  Log.log(`Exporting the web app...`);
+  // Bundle the app
+  await bundler.bundleAsync({
+    mode: options.dev ? 'development' : 'production',
+    clear: options.clear,
+  });
+}

--- a/packages/@expo/cli/src/export/web/exportWebAsync.ts
+++ b/packages/@expo/cli/src/export/web/exportWebAsync.ts
@@ -9,7 +9,9 @@ export async function exportWebAsync(projectRoot: string, options: Options) {
 
   // Create a bundler interface
   const bundler = new WebpackBundlerDevServer(projectRoot, false);
-  Log.log(`Exporting the web app...`);
+
+  Log.log(`Exporting with Webpack...`);
+
   // Bundle the app
   await bundler.bundleAsync({
     mode: options.dev ? 'development' : 'production',

--- a/packages/@expo/cli/src/export/web/index.ts
+++ b/packages/@expo/cli/src/export/web/index.ts
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+import chalk from 'chalk';
+
+import { Command } from '../../../bin/cli';
+import { assertArgs, getProjectRoot, printHelp } from '../../utils/args';
+import { logCmdError } from '../../utils/errors';
+
+export const expoExportWeb: Command = async (argv) => {
+  const args = assertArgs(
+    {
+      // Types
+      '--help': Boolean,
+      '--clear': Boolean,
+      '--dev': Boolean,
+      // Aliases
+      '-h': '--help',
+      '-c': '--clear',
+    },
+    argv
+  );
+
+  if (args['--help']) {
+    printHelp(
+      `Export the static files of the web app for hosting on a web server`,
+      chalk`npx expo export:web {dim <dir>}`,
+      [
+        chalk`<dir>                         Directory of the Expo project. {dim Default: Current working directory}`,
+        `--dev                         Bundle in development mode`,
+        `-c, --clear                   Clear the bundler cache`,
+        `-h, --help                    Usage info`,
+      ].join('\n')
+    );
+  }
+
+  const projectRoot = getProjectRoot(args);
+  const { resolveOptionsAsync } = await import('./resolveOptions');
+  const options = await resolveOptionsAsync(args).catch(logCmdError);
+
+  const { exportWebAsync } = await import('./exportWebAsync');
+  return exportWebAsync(projectRoot, options).catch(logCmdError);
+};

--- a/packages/@expo/cli/src/export/web/resolveOptions.ts
+++ b/packages/@expo/cli/src/export/web/resolveOptions.ts
@@ -1,0 +1,11 @@
+export type Options = {
+  dev: boolean;
+  clear: boolean;
+};
+
+export async function resolveOptionsAsync(args: any): Promise<Options> {
+  return {
+    clear: !!args['--clear'],
+    dev: !!args['--dev'],
+  };
+}

--- a/packages/@expo/cli/src/start/doctor/web/WebSupportProjectPrerequisite.ts
+++ b/packages/@expo/cli/src/start/doctor/web/WebSupportProjectPrerequisite.ts
@@ -58,14 +58,6 @@ export class WebSupportProjectPrerequisite extends ProjectPrerequisite {
           { file: 'react-native-web/package.json', pkg: 'react-native-web', version: '~0.17.1' },
           { file: 'react-dom/package.json', pkg: 'react-dom', version: '^17.0.1' },
           // `webpack` and `webpack-dev-server` should be installed in the `@expo/webpack-config`
-          // package, but just in case we'll do the check now.
-          {
-            file: 'webpack-dev-server/package.json',
-            // https://github.com/expo/expo-cli/pull/4282
-            pkg: 'webpack-dev-server',
-            version: '~3.11.0',
-            dev: true,
-          },
           {
             file: '@expo/webpack-config/package.json',
             pkg: '@expo/webpack-config',

--- a/packages/@expo/cli/src/start/server/webpack/WebpackBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/webpack/WebpackBundlerDevServer.ts
@@ -4,6 +4,7 @@ import type { Application } from 'express';
 import fs from 'fs';
 import http from 'http';
 import * as path from 'path';
+import ProgressBar from 'progress';
 import resolveFrom from 'resolve-from';
 import type webpack from 'webpack';
 import type WebpackDevServer from 'webpack-dev-server';
@@ -13,8 +14,10 @@ import { env } from '../../../utils/env';
 import { CommandError } from '../../../utils/errors';
 import { getIpAddress } from '../../../utils/ip';
 import { choosePortAsync } from '../../../utils/port';
+import { createProgressBar } from '../../../utils/progress';
 import { ensureDotExpoProjectDirectoryInitialized } from '../../project/dotExpo';
 import { BundlerDevServer, BundlerStartOptions, DevServerInstance } from '../BundlerDevServer';
+import { compileAsync } from './compile';
 import {
   importExpoWebpackConfigFromProject,
   importWebpackDevServerFromProject,
@@ -165,6 +168,59 @@ export class WebpackBundlerDevServer extends BundlerDevServer {
     }
   }
 
+  async bundleAsync({ mode, clear }: { mode: 'development' | 'production'; clear: boolean }) {
+    // Do this first to fail faster.
+    const webpack = importWebpackFromProject(this.projectRoot);
+
+    if (clear) {
+      await this.clearWebProjectCacheAsync(this.projectRoot, mode);
+    }
+
+    const config = await this.loadConfigAsync({
+      isImageEditingEnabled: true,
+      mode,
+    });
+
+    if (!config.plugins) {
+      config.plugins = [];
+    }
+
+    let bar: ProgressBar | null = null;
+
+    // NOTE(EvanBacon): Prevent breaking in CI.
+    if (process.stderr.clearLine != null) {
+      bar = createProgressBar(chalk`{bold Web} Bundling Javascript [:bar] :percent`, {
+        width: 64,
+        total: 100,
+        clear: true,
+        complete: '=',
+        incomplete: ' ',
+      });
+
+      // Add a progress bar to the webpack logger.
+      config.plugins.push(
+        new webpack.ProgressPlugin((percent: number) => {
+          bar?.update(percent);
+          if (percent === 1) {
+            bar?.terminate();
+          }
+        })
+      );
+    }
+
+    // Create a webpack compiler that is configured with custom messages.
+    const compiler = webpack(config);
+
+    try {
+      await compileAsync(compiler);
+    } catch (error: any) {
+      Log.error(chalk.red('Failed to compile'));
+      throw error;
+    } finally {
+      bar?.terminate();
+    }
+  }
+
   protected async startImplementationAsync(
     options: BundlerStartOptions
   ): Promise<DevServerInstance> {
@@ -189,7 +245,7 @@ export class WebpackBundlerDevServer extends BundlerDevServer {
     Log.debug('Starting webpack on port: ' + port);
 
     if (resetDevServer) {
-      await clearWebProjectCacheAsync(this.projectRoot, mode);
+      await this.clearWebProjectCacheAsync(this.projectRoot, mode);
     }
 
     if (https) {
@@ -292,7 +348,7 @@ export class WebpackBundlerDevServer extends BundlerDevServer {
   }
 
   async loadConfigAsync(
-    options: BundlerStartOptions,
+    options: Pick<BundlerStartOptions, 'mode' | 'isImageEditingEnabled' | 'https'>,
     argv?: string[]
   ): Promise<WebpackConfiguration> {
     // let bar: ProgressBar | null = null;
@@ -330,6 +386,21 @@ export class WebpackBundlerDevServer extends BundlerDevServer {
   protected getConfigModuleIds(): string[] {
     return ['./webpack.config.js'];
   }
+
+  protected async clearWebProjectCacheAsync(
+    projectRoot: string,
+    mode: string = 'development'
+  ): Promise<void> {
+    Log.log(chalk.dim(`Clearing Webpack ${mode} cache directory...`));
+
+    const dir = await ensureDotExpoProjectDirectoryInitialized(projectRoot);
+    const cacheFolder = path.join(dir, 'web/cache', mode);
+    try {
+      await fs.promises.rm(cacheFolder, { recursive: true, force: true });
+    } catch (error: any) {
+      Log.error(`Could not clear ${mode} web cache directory: ${error.message}`);
+    }
+  }
 }
 
 function setMode(mode: 'development' | 'production' | 'test' | 'none'): void {
@@ -339,19 +410,4 @@ function setMode(mode: 'development' | 'production' | 'test' | 'none'): void {
 
 export function getProjectWebpackConfigFilePath(projectRoot: string) {
   return resolveFrom.silent(projectRoot, './webpack.config.js');
-}
-
-async function clearWebProjectCacheAsync(
-  projectRoot: string,
-  mode: string = 'development'
-): Promise<void> {
-  Log.log(chalk.dim(`Clearing Webpack ${mode} cache directory...`));
-
-  const dir = await ensureDotExpoProjectDirectoryInitialized(projectRoot);
-  const cacheFolder = path.join(dir, 'web/cache', mode);
-  try {
-    await fs.promises.rm(cacheFolder, { recursive: true, force: true });
-  } catch (error: any) {
-    Log.error(`Could not clear ${mode} web cache directory: ${error.message}`);
-  }
 }

--- a/packages/@expo/cli/src/start/server/webpack/WebpackBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/webpack/WebpackBundlerDevServer.ts
@@ -185,19 +185,16 @@ export class WebpackBundlerDevServer extends BundlerDevServer {
       config.plugins = [];
     }
 
-    let bar: ProgressBar | null = null;
+    const bar = createProgressBar(chalk`{bold Web} Bundling Javascript [:bar] :percent`, {
+      width: 64,
+      total: 100,
+      clear: true,
+      complete: '=',
+      incomplete: ' ',
+    });
 
-    // NOTE(EvanBacon): Prevent breaking in CI.
-    if (process.stderr.clearLine != null) {
-      bar = createProgressBar(chalk`{bold Web} Bundling Javascript [:bar] :percent`, {
-        width: 64,
-        total: 100,
-        clear: true,
-        complete: '=',
-        incomplete: ' ',
-      });
-
-      // Add a progress bar to the webpack logger.
+    // NOTE(EvanBacon): Add a progress bar to the webpack logger if defined (e.g. not in CI).
+    if (bar != null) {
       config.plugins.push(
         new webpack.ProgressPlugin((percent: number) => {
           bar?.update(percent);

--- a/packages/@expo/cli/src/start/server/webpack/WebpackBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/webpack/WebpackBundlerDevServer.ts
@@ -4,7 +4,6 @@ import type { Application } from 'express';
 import fs from 'fs';
 import http from 'http';
 import * as path from 'path';
-import ProgressBar from 'progress';
 import resolveFrom from 'resolve-from';
 import type webpack from 'webpack';
 import type WebpackDevServer from 'webpack-dev-server';

--- a/packages/@expo/cli/src/start/server/webpack/__tests__/WebpackBundlerDevServer-test.ts
+++ b/packages/@expo/cli/src/start/server/webpack/__tests__/WebpackBundlerDevServer-test.ts
@@ -7,6 +7,10 @@ import { WebpackBundlerDevServer } from '../WebpackBundlerDevServer';
 jest.mock('../../../../log');
 jest.mock('../resolveFromProject');
 
+jest.mock('../compile', () => ({
+  compileAsync: jest.fn(),
+}));
+
 const originalCwd = process.cwd();
 
 beforeEach(() => {
@@ -25,6 +29,22 @@ async function getStartedDevServer(options: Partial<BundlerStartOptions> = {}) {
   await devServer.startAsync({ location: {}, ...options });
   return devServer;
 }
+
+describe('bundleAsync', () => {
+  it(`bundles in dev mode`, async () => {
+    const devServer = new WebpackBundlerDevServer('/', false);
+
+    devServer['clearWebProjectCacheAsync'] = jest.fn();
+    devServer['loadConfigAsync'] = jest.fn(async () => ({}));
+
+    await devServer.bundleAsync({ mode: 'development', clear: true });
+    expect(devServer['clearWebProjectCacheAsync']).toBeCalled();
+    expect(devServer['loadConfigAsync']).toHaveBeenCalledWith({
+      isImageEditingEnabled: true,
+      mode: 'development',
+    });
+  });
+});
 
 describe('startAsync', () => {
   it(`starts webpack`, async () => {

--- a/packages/@expo/cli/src/start/server/webpack/__tests__/compile-test.ts
+++ b/packages/@expo/cli/src/start/server/webpack/__tests__/compile-test.ts
@@ -1,0 +1,23 @@
+import { Log } from '../../../../log';
+import { compileAsync } from '../compile';
+
+jest.mock('../../../../log');
+
+describe(compileAsync, () => {
+  it(`compiles successfully`, async () => {
+    await compileAsync({
+      run: jest.fn(async (callback) => {
+        callback(null, {
+          toJson() {
+            return {
+              warnings: [],
+              errors: [],
+            };
+          },
+        });
+      }),
+    } as any);
+
+    expect(Log.warn).not.toBeCalled();
+  });
+});

--- a/packages/@expo/cli/src/start/server/webpack/compile.ts
+++ b/packages/@expo/cli/src/start/server/webpack/compile.ts
@@ -8,7 +8,7 @@ import { formatWebpackMessages } from './formatWebpackMessages';
 
 /** Run the `webpack` compiler and format errors/warnings. */
 export async function compileAsync(compiler: webpack.Compiler) {
-  const stats = await promisify(compiler.run)();
+  const stats = await promisify(compiler.run.bind(compiler))();
   const { errors, warnings } = formatWebpackMessages(
     stats.toJson({ all: false, warnings: true, errors: true })
   );

--- a/packages/@expo/cli/src/start/server/webpack/compile.ts
+++ b/packages/@expo/cli/src/start/server/webpack/compile.ts
@@ -1,12 +1,14 @@
 import chalk from 'chalk';
+import { promisify } from 'util';
 import type webpack from 'webpack';
 
 import * as Log from '../../../log';
 import { CommandError } from '../../../utils/errors';
 import { formatWebpackMessages } from './formatWebpackMessages';
 
-export async function compileAsync(compiler: webpack.Compiler): Promise<any> {
-  const stats = await compilerRunAsync(compiler);
+/** Run the `webpack` compiler and format errors/warnings. */
+export async function compileAsync(compiler: webpack.Compiler) {
+  const stats = await promisify(compiler.run)();
   const { errors, warnings } = formatWebpackMessages(
     stats.toJson({ all: false, warnings: true, errors: true })
   );
@@ -25,17 +27,5 @@ export async function compileAsync(compiler: webpack.Compiler): Promise<any> {
     Log.log(chalk.green('Compiled successfully'));
   }
 
-  return warnings;
-}
-
-async function compilerRunAsync(compiler: webpack.Compiler): Promise<webpack.Stats> {
-  return new Promise((resolve, reject) =>
-    compiler.run((error, stats) => {
-      if (error) {
-        return reject(error);
-      } else {
-        return resolve(stats);
-      }
-    })
-  );
+  return { errors, warnings };
 }

--- a/packages/@expo/cli/src/start/server/webpack/compile.ts
+++ b/packages/@expo/cli/src/start/server/webpack/compile.ts
@@ -1,0 +1,41 @@
+import chalk from 'chalk';
+import type webpack from 'webpack';
+
+import * as Log from '../../../log';
+import { CommandError } from '../../../utils/errors';
+import { formatWebpackMessages } from './formatWebpackMessages';
+
+export async function compileAsync(compiler: webpack.Compiler): Promise<any> {
+  const stats = await compilerRunAsync(compiler);
+  const { errors, warnings } = formatWebpackMessages(
+    stats.toJson({ all: false, warnings: true, errors: true })
+  );
+  if (errors?.length) {
+    // Only keep the first error. Others are often indicative
+    // of the same problem, but confuse the reader with noise.
+    if (errors.length > 1) {
+      errors.length = 1;
+    }
+    throw new CommandError('WEBPACK_BUNDLE', errors.join('\n\n'));
+  }
+  if (warnings?.length) {
+    Log.warn(chalk.yellow('Compiled with warnings\n'));
+    Log.warn(warnings.join('\n\n'));
+  } else {
+    Log.log(chalk.green('Compiled successfully'));
+  }
+
+  return warnings;
+}
+
+async function compilerRunAsync(compiler: webpack.Compiler): Promise<webpack.Stats> {
+  return new Promise((resolve, reject) =>
+    compiler.run((error, stats) => {
+      if (error) {
+        return reject(error);
+      } else {
+        return resolve(stats);
+      }
+    })
+  );
+}

--- a/packages/@expo/cli/src/utils/downloadExpoGoAsync.ts
+++ b/packages/@expo/cli/src/utils/downloadExpoGoAsync.ts
@@ -1,13 +1,12 @@
 import { getExpoHomeDirectory } from '@expo/config/build/getUserState';
 import path from 'path';
-import ProgressBar from 'progress';
 
 import { getReleasedVersionsAsync, SDKVersion } from '../api/getVersions';
 import * as Log from '../log';
 import { downloadAppAsync } from './downloadAppAsync';
 import { CommandError } from './errors';
 import { profile } from './profile';
-import { setProgressBar } from './progress';
+import { createProgressBar } from './progress';
 
 const platformSettings: Record<
   string,
@@ -44,15 +43,13 @@ export async function downloadExpoGoAsync(
 ): Promise<string> {
   const { getFilePath, versionsKey, shouldExtractResults } = platformSettings[platform];
 
-  const bar = new ProgressBar('Downloading the Expo Go app [:bar] :percent :etas', {
+  const bar = createProgressBar('Downloading the Expo Go app [:bar] :percent :etas', {
     width: 64,
     total: 100,
     clear: true,
     complete: '=',
     incomplete: ' ',
   });
-  // TODO: Auto track progress
-  setProgressBar(bar);
 
   if (!url) {
     if (!sdkVersion) {
@@ -88,7 +85,6 @@ export async function downloadExpoGoAsync(
     });
     return outputPath;
   } finally {
-    bar.terminate();
-    setProgressBar(null);
+    bar?.terminate();
   }
 }

--- a/packages/@expo/cli/src/utils/ora.ts
+++ b/packages/@expo/cli/src/utils/ora.ts
@@ -4,13 +4,9 @@ import oraReal, { Ora } from 'ora';
 // import * as Log from '../log';
 import { env } from './env';
 
-// eslint-disable-next-line no-console
 const logReal = console.log;
-// eslint-disable-next-line no-console
 const infoReal = console.info;
-// eslint-disable-next-line no-console
 const warnReal = console.warn;
-// eslint-disable-next-line no-console
 const errorReal = console.error;
 
 const runningSpinners: oraReal.Ora[] = [];
@@ -47,26 +43,18 @@ export function ora(options?: oraReal.Options | string): oraReal.Ora {
   };
 
   const wrapNativeLogs = (): void => {
-    // eslint-disable-next-line no-console
     console.log = (...args: any) => logWrap(logReal, args);
-    // eslint-disable-next-line no-console
     console.info = (...args: any) => logWrap(infoReal, args);
-    // eslint-disable-next-line no-console
     console.warn = (...args: any) => logWrap(warnReal, args);
-    // eslint-disable-next-line no-console
     console.error = (...args: any) => logWrap(errorReal, args);
 
     runningSpinners.push(spinner);
   };
 
   const resetNativeLogs = (): void => {
-    // eslint-disable-next-line no-console
     console.log = logReal;
-    // eslint-disable-next-line no-console
-    console.info = logReal;
-    // eslint-disable-next-line no-console
+    console.info = infoReal;
     console.warn = warnReal;
-    // eslint-disable-next-line no-console
     console.error = errorReal;
 
     const index = runningSpinners.indexOf(spinner);

--- a/packages/@expo/cli/src/utils/progress.ts
+++ b/packages/@expo/cli/src/utils/progress.ts
@@ -11,6 +11,10 @@ export function getProgressBar(): ProgressBar | null {
 }
 
 export function createProgressBar(barFormat: string, options: ProgressBar.ProgressBarOptions) {
+  if (process.stderr.clearLine == null) {
+    return null;
+  }
+
   const bar = new ProgressBar(barFormat, options);
 
   const logReal = console.log;

--- a/packages/@expo/cli/src/utils/progress.ts
+++ b/packages/@expo/cli/src/utils/progress.ts
@@ -9,3 +9,41 @@ export function setProgressBar(bar: ProgressBar | null): void {
 export function getProgressBar(): ProgressBar | null {
   return currentProgress;
 }
+
+export function createProgressBar(barFormat: string, options: ProgressBar.ProgressBarOptions) {
+  const bar = new ProgressBar(barFormat, options);
+
+  const logReal = console.log;
+  const infoReal = console.info;
+  const warnReal = console.warn;
+  const errorReal = console.error;
+
+  const wrapNativeLogs = (): void => {
+    // @ts-expect-error
+    console.log = (...args: any) => bar.interrupt(...args);
+    // @ts-expect-error
+    console.info = (...args: any) => bar.interrupt(...args);
+    // @ts-expect-error
+    console.warn = (...args: any) => bar.interrupt(...args);
+    // @ts-expect-error
+    console.error = (...args: any) => bar.interrupt(...args);
+  };
+
+  const resetNativeLogs = (): void => {
+    console.log = logReal;
+    console.info = infoReal;
+    console.warn = warnReal;
+    console.error = errorReal;
+  };
+
+  const originalTerminate = bar.terminate.bind(bar);
+  bar.terminate = () => {
+    resetNativeLogs();
+    setProgressBar(null);
+    originalTerminate();
+  };
+
+  wrapNativeLogs();
+  setProgressBar(bar);
+  return bar;
+}


### PR DESCRIPTION
# Why

- Resolve ENG-4764
- Create `npx expo export:web` as a replacement for `expo build:web`. Ideally we'd have something else like `npx expo bundle -p web` but I don't think we're ready for that at the moment.
- Inject a progress bar in the webpack config.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# Test Plan

- unit tests
- e2e tests
- ran in a project `nexpo export:web`
