### PR TITLE
Bump @expo/config-plugins minimum version

### DIFF
--- a/packages/expo-ads-admob/package.json
+++ b/packages/expo-ads-admob/package.json
@@ -35,7 +35,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/config-plugins": "^4.0.14"
+    "@expo/config-plugins": "^4.1.4"
   },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"

--- a/packages/expo-ads-facebook/package.json
+++ b/packages/expo-ads-facebook/package.json
@@ -31,7 +31,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/latest/sdk/facebook-ads/",
   "dependencies": {
-    "@expo/config-plugins": "^4.0.14",
+    "@expo/config-plugins": "^4.1.4",
     "fbemitter": "^3.0.0",
     "nullthrows": "^1.1.1"
   },

--- a/packages/expo-apple-authentication/package.json
+++ b/packages/expo-apple-authentication/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/latest/sdk/apple-authentication/",
   "dependencies": {
-    "@expo/config-plugins": "^4.0.14"
+    "@expo/config-plugins": "^4.1.4"
   },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"

--- a/packages/expo-av/package.json
+++ b/packages/expo-av/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/latest/sdk/av/",
   "dependencies": {
-    "@expo/config-plugins": "^4.0.14"
+    "@expo/config-plugins": "^4.1.4"
   },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"

--- a/packages/expo-background-fetch/package.json
+++ b/packages/expo-background-fetch/package.json
@@ -33,7 +33,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/latest/sdk/background-fetch/",
   "dependencies": {
-    "@expo/config-plugins": "^4.0.14",
+    "@expo/config-plugins": "^4.1.4",
     "expo-task-manager": "~10.2.0"
   },
   "devDependencies": {

--- a/packages/expo-barcode-scanner/package.json
+++ b/packages/expo-barcode-scanner/package.json
@@ -35,7 +35,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/config-plugins": "^4.0.14",
+    "@expo/config-plugins": "^4.1.4",
     "expo-image-loader": "~3.2.0"
   },
   "devDependencies": {

--- a/packages/expo-branch/package.json
+++ b/packages/expo-branch/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/latest/sdk/branch/",
   "dependencies": {
-    "@expo/config-plugins": "^4.0.14",
+    "@expo/config-plugins": "^4.1.4",
     "react-native-branch": "5.0.0"
   },
   "devDependencies": {

--- a/packages/expo-brightness/package.json
+++ b/packages/expo-brightness/package.json
@@ -35,7 +35,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/config-plugins": "^4.0.14"
+    "@expo/config-plugins": "^4.1.4"
   },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"

--- a/packages/expo-calendar/package.json
+++ b/packages/expo-calendar/package.json
@@ -35,7 +35,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/config-plugins": "^4.0.14"
+    "@expo/config-plugins": "^4.1.4"
   },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"

--- a/packages/expo-camera/package.json
+++ b/packages/expo-camera/package.json
@@ -34,7 +34,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/config-plugins": "^4.0.14",
+    "@expo/config-plugins": "^4.1.4",
     "@koale/useworker": "^4.0.2",
     "invariant": "^2.2.4"
   },

--- a/packages/expo-contacts/package.json
+++ b/packages/expo-contacts/package.json
@@ -34,7 +34,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/config-plugins": "^4.0.14",
+    "@expo/config-plugins": "^4.1.4",
     "uuid": "^3.4.0"
   },
   "devDependencies": {

--- a/packages/expo-dev-client/package.json
+++ b/packages/expo-dev-client/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev/clients/introduction/",
   "dependencies": {
-    "@expo/config-plugins": "^4.0.14",
+    "@expo/config-plugins": "^4.1.4",
     "expo-dev-launcher": "0.11.4",
     "expo-dev-menu": "0.10.5",
     "expo-dev-menu-interface": "0.6.0",

--- a/packages/expo-dev-launcher/package.json
+++ b/packages/expo-dev-launcher/package.json
@@ -29,7 +29,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev",
   "dependencies": {
-    "@expo/config-plugins": "^4.0.14",
+    "@expo/config-plugins": "^4.1.4",
     "expo-dev-menu": "0.10.5",
     "resolve-from": "^5.0.0",
     "semver": "^7.3.5"

--- a/packages/expo-dev-menu/package.json
+++ b/packages/expo-dev-menu/package.json
@@ -46,7 +46,7 @@
     "transformIgnorePatterns": []
   },
   "dependencies": {
-    "@expo/config-plugins": "^4.0.14",
+    "@expo/config-plugins": "^4.1.4",
     "expo-dev-menu-interface": "0.6.0",
     "semver": "^7.3.5"
   },

--- a/packages/expo-document-picker/package.json
+++ b/packages/expo-document-picker/package.json
@@ -35,7 +35,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/config-plugins": "^4.0.14",
+    "@expo/config-plugins": "^4.1.4",
     "uuid": "^3.3.2"
   },
   "devDependencies": {

--- a/packages/expo-facebook/package.json
+++ b/packages/expo-facebook/package.json
@@ -34,7 +34,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/config-plugins": "^4.0.14"
+    "@expo/config-plugins": "^4.1.4"
   },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"

--- a/packages/expo-file-system/package.json
+++ b/packages/expo-file-system/package.json
@@ -35,7 +35,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/config-plugins": "^4.0.14",
+    "@expo/config-plugins": "^4.1.4",
     "uuid": "^3.4.0"
   },
   "devDependencies": {

--- a/packages/expo-google-sign-in/package.json
+++ b/packages/expo-google-sign-in/package.json
@@ -41,7 +41,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/config-plugins": "^4.0.14",
+    "@expo/config-plugins": "^4.1.4",
     "invariant": "^2.2.4"
   },
   "devDependencies": {

--- a/packages/expo-image-picker/package.json
+++ b/packages/expo-image-picker/package.json
@@ -36,7 +36,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/config-plugins": "^4.0.14",
+    "@expo/config-plugins": "^4.1.4",
     "expo-image-loader": "~3.2.0",
     "uuid": "7.0.2"
   },

--- a/packages/expo-local-authentication/package.json
+++ b/packages/expo-local-authentication/package.json
@@ -38,7 +38,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/config-plugins": "^4.0.14",
+    "@expo/config-plugins": "^4.1.4",
     "invariant": "^2.2.4"
   },
   "devDependencies": {

--- a/packages/expo-location/package.json
+++ b/packages/expo-location/package.json
@@ -42,7 +42,7 @@
     "expo-module-scripts": "^2.0.0"
   },
   "dependencies": {
-    "@expo/config-plugins": "^4.0.14"
+    "@expo/config-plugins": "^4.1.4"
   },
   "peerDependencies": {
     "expo": "*"

--- a/packages/expo-media-library/package.json
+++ b/packages/expo-media-library/package.json
@@ -38,7 +38,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/config-plugins": "^4.0.14"
+    "@expo/config-plugins": "^4.1.4"
   },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"

--- a/packages/expo-navigation-bar/package.json
+++ b/packages/expo-navigation-bar/package.json
@@ -33,7 +33,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/latest/sdk/navigation-bar",
   "dependencies": {
-    "@expo/config-plugins": "^4.0.14",
+    "@expo/config-plugins": "^4.1.4",
     "@react-native/normalize-color": "^2.0.0",
     "debug": "^4.3.2"
   },

--- a/packages/expo-notifications/package.json
+++ b/packages/expo-notifications/package.json
@@ -37,7 +37,7 @@
     "preset": "expo-module-scripts/ios"
   },
   "dependencies": {
-    "@expo/config-plugins": "^4.0.14",
+    "@expo/config-plugins": "^4.1.4",
     "@expo/image-utils": "^0.3.18",
     "@ide/backoff": "^1.0.0",
     "abort-controller": "^3.0.0",

--- a/packages/expo-screen-orientation/package.json
+++ b/packages/expo-screen-orientation/package.json
@@ -36,7 +36,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/config-plugins": "^4.0.14"
+    "@expo/config-plugins": "^4.1.4"
   },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"

--- a/packages/expo-sensors/package.json
+++ b/packages/expo-sensors/package.json
@@ -40,7 +40,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/config-plugins": "^4.0.14",
+    "@expo/config-plugins": "^4.1.4",
     "invariant": "^2.2.4"
   },
   "devDependencies": {

--- a/packages/expo-system-ui/package.json
+++ b/packages/expo-system-ui/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/latest/sdk/system-ui",
   "dependencies": {
-    "@expo/config-plugins": "^4.0.14",
+    "@expo/config-plugins": "^4.1.4",
     "@react-native/normalize-color": "^2.0.0",
     "debug": "^4.3.2"
   },

--- a/packages/expo-task-manager/package.json
+++ b/packages/expo-task-manager/package.json
@@ -33,7 +33,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/latest/sdk/task-manager/",
   "dependencies": {
-    "@expo/config-plugins": "^4.0.14",
+    "@expo/config-plugins": "^4.1.4",
     "unimodules-app-loader": "~3.1.0"
   },
   "devDependencies": {

--- a/packages/expo-tracking-transparency/package.json
+++ b/packages/expo-tracking-transparency/package.json
@@ -30,7 +30,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/latest/sdk/module-template",
   "dependencies": {
-    "@expo/config-plugins": "^4.0.14"
+    "@expo/config-plugins": "^4.1.4"
   },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"

--- a/packages/expo-updates/package.json
+++ b/packages/expo-updates/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@expo/code-signing-certificates": "0.0.1",
     "@expo/config": "^6.0.14",
-    "@expo/config-plugins": "^4.0.14",
+    "@expo/config-plugins": "^4.1.4",
     "@expo/metro-config": "~0.3.7",
     "arg": "4.1.0",
     "expo-eas-client": "~0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1229,7 +1229,7 @@
     node-forge "^1.2.1"
     nullthrows "^1.1.1"
 
-"@expo/config-plugins@4.1.4", "@expo/config-plugins@^4.0.14", "@expo/config-plugins@~4.1.4":
+"@expo/config-plugins@4.1.4", "@expo/config-plugins@^4.1.4", "@expo/config-plugins@~4.1.4":
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/@expo/config-plugins/-/config-plugins-4.1.4.tgz#08e1a6314dc0f96cd165a748b5997b5ec75a84d0"
   integrity sha512-fkOjXnSieQfVSWVLKhst0DnCAyeHksvWky1CldFCQllhDB1HHBiP09Z8pamVB783n3qr/1HNZiSp6k2iUcaSoA==
@@ -6662,7 +6662,7 @@ ci-info@^2.0.0:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
   integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
 
-ci-info@^3.2.0:
+ci-info@^3.2.0, ci-info@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.3.0.tgz#b4ed1fb6818dea4803a55c623041f9165d2066b2"
   integrity sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==


### PR DESCRIPTION
# Why

`>= 4.1` is required in SDK 45 for the changes to AppDelegate.mm

# How

Bump it everywhere

# Test Plan

Wait for CI to run

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
