### PR TITLE
[home] ensure `theme` is 'light' or 'dark' to make sure DCC and React Navigation are in Sync

### DIFF
--- a/dev-home-config.json
+++ b/dev-home-config.json
@@ -1,3 +1,3 @@
 {
-  "url": "exp://exp.host/@expo-home-dev/expo-home-dev-c94831adff12e845ff3500100b98e397181fce3c"
+  "url": "exp://exp.host/@expo-home-dev/expo-home-dev-5d686f77aa8528494f6cf374dbc3cdea44f1ee93"
 }

--- a/home/HomeApp.tsx
+++ b/home/HomeApp.tsx
@@ -188,7 +188,7 @@ export default function HomeApp() {
   }
 
   let theme = !preferredAppearance ? colorScheme : preferredAppearance;
-  if (theme === undefined) {
+  if (theme === undefined || theme === null || (theme !== 'dark' && theme !== 'light')) {
     theme = 'light';
   }
 


### PR DESCRIPTION
# Why

@EvanBacon pointed out a state where React Navigation and our custom themed components' theme weren't in sync:

![Image from iOS](https://user-images.githubusercontent.com/12488826/167058931-d4349bf9-1ab0-4324-8b80-8023164161d1.png)

To reproduce, `expo client:install:ios` in both an SDK 45 and 44 project sequentially. Once the SDK 44 Expo Go is installed, toggle the theme in-app from dark to automatic. This sets `'no-preference'` as your preferredAppearance in async storage.

Drag the SDK 45 client from ~/.expo/ios-simulator-app-cache to simulate an App Store update (deleting wipes the async storage value).

Opening the SDK 45 client with that appearance preference from SDK 44 results in the state shown above.

# How

This might be caused by `theme` being a value that isn't 'light' or `undefined`, which would mean that the navigation theme could end up being `dark`:

![Screen Shot 2022-05-05 at 22 47 56](https://user-images.githubusercontent.com/12488826/167058727-e7179cae-7665-4980-9d4a-62da19106ead.png)

By filtering out all of the options for `ColorSchemeName` and defaulting to `light` correctly, this state shouldn't happen.

`type ColorSchemeName = 'light' | 'dark' | null | undefined;`

# Test Plan

Follow the reproduction steps in #How. Then, build Expo Go on this branch (or sdk-45 with this patch applied) and see that this is now fixed: 

![Screen Shot 2022-05-05 at 23 51 10](https://user-images.githubusercontent.com/12488826/167064398-ff30a784-99d3-4799-ab60-b2fa8fbfda96.png)

