### PR TITLE
[github] switch Updates E2E runner to macOS

### DIFF
--- a/.github/workflows/updates-e2e.yml
+++ b/.github/workflows/updates-e2e.yml
@@ -34,7 +34,8 @@ concurrency:
 
 jobs:
   android:
-    runs-on: ubuntu-20.04
+    runs-on: macos-11
+    timeout-minutes: 60
     env:
       UPDATES_HOST: 10.0.2.2 # special IP that Android emulators map to host machine's localhost
       UPDATES_PORT: 4747


### PR DESCRIPTION
# Why

This is an attempt to improve the workflow stability.

# How

Change runner to macOS from Linux, which is recommended when using AVDs:
* https://github.com/ReactiveCircus/android-emulator-runner

# Test Plan

Run the CI.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
