### PR TITLE
[dev-menu] Remove dev tools workaround for Hermes

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix dev menu will reload the application when open for the first time while using Hermes.
+
 ### 💡 Others
 
 ## 0.10.5 — 2022-05-05

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix dev menu will reload the application when open for the first time while using Hermes.
+- Fix dev menu will reload the application when open for the first time while using Hermes. ([#17377](https://github.com/expo/expo/pull/17377) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
@@ -174,17 +174,6 @@ object DevMenuManager : DevMenuManagerInterface, LifecycleEventListener {
       devMenuHost = DevMenuHost(application)
       UiThreadUtil.runOnUiThread {
         devMenuHost.reactInstanceManager.createReactContextInBackground()
-
-        if (currentReactInstanceManager.get()?.jsExecutorName?.contains("Hermes") == true) {
-          // We have to switch thread to js queue to unload the event loop, otherwise, the app will crash.
-          currentReactInstanceManager.get()?.currentReactContext?.runOnJSQueueThread {
-            // Hermes inspector will use latest executed script for Chrome DevTools Protocol.
-            // It will be EXDevMenuApp.android.js in our case.
-            // To let Hermes aware target bundle, we try to reload here as a workaround solution.
-            // @see <a href="https://github.com/facebook/react-native/blob/0.63-stable/ReactCommon/hermes/inspector/Inspector.cpp#L231>code here</a>
-            currentReactInstanceManager.get()?.devSupportManager?.handleReloadJS()
-          }
-        }
       }
     }
   }

--- a/packages/expo-dev-menu/ios/DevMenuAppInstance.swift
+++ b/packages/expo-dev-menu/ios/DevMenuAppInstance.swift
@@ -17,7 +17,6 @@ class DevMenuAppInstance: DevMenuBaseAppInstance, RCTBridgeDelegate {
     super.init()
 
     self.bridge = DevMenuRCTBridge.init(delegate: self, launchOptions: nil)
-    fixChromeDevTools()
   }
 
   init(manager: DevMenuManager, bridge: RCTBridge) {
@@ -26,22 +25,6 @@ class DevMenuAppInstance: DevMenuBaseAppInstance, RCTBridgeDelegate {
     super.init()
 
     self.bridge = bridge
-    fixChromeDevTools()
-  }
-
-  private func fixChromeDevTools() {
-    // Hermes inspector will use latest executed script for Chrome DevTools Protocol.
-    // It will be EXDevMenuApp.ios.js in our case.
-    // To let Hermes aware target bundle, we try to reload here as a workaround solution.
-    // See https://github.com/facebook/react-native/blob/ec614c16b331bf3f793fda5780fa273d181a8492/ReactCommon/hermes/inspector/Inspector.cpp#L291
-    if let appBridge = manager.currentBridge,
-       let batchedBridge = appBridge.batched {
-      if (batchedBridge.bridgeDescription?.contains("Hermes") == true) {
-        batchedBridge.dispatchBlock({
-          appBridge.requestReload()
-        }, queue: RCTJSThread)
-      }
-    }
   }
 
   /**


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/17355.
Remove reload workaround for the Hermes debugger. 

> Note:
if a user needs to inspect the right js bundle in flipper or devtools, they could reload manually.