### PR TITLE
[home] add release channel to classic update 'recently opened' item

### DIFF
--- a/dev-home-config.json
+++ b/dev-home-config.json
@@ -1,3 +1,3 @@
 {
-  "url": "exp://exp.host/@expo-home-dev/expo-home-dev-5d686f77aa8528494f6cf374dbc3cdea44f1ee93"
+  "url": "exp://exp.host/@expo-home-dev/expo-home-dev-0622dc92c30f94b8ca1c56a443a48366b8ef82e7"
 }

--- a/home/screens/HomeScreen/RecentlyOpenedListItem/index.tsx
+++ b/home/screens/HomeScreen/RecentlyOpenedListItem/index.tsx
@@ -1,5 +1,5 @@
 import { ChevronDownIcon, spacing } from '@expo/styleguide-native';
-import { Text, useExpoTheme } from 'expo-dev-client-components';
+import { Text, useExpoPalette, useExpoTheme, View } from 'expo-dev-client-components';
 import * as React from 'react';
 import { View as RNView, StyleSheet, ViewStyle, Share } from 'react-native';
 import { TouchableOpacity } from 'react-native-gesture-handler';
@@ -14,10 +14,20 @@ type Props = {
   image?: number | string | null;
   url: string;
   onPress?: () => void;
+  releaseChannel?: string;
 };
 
-export function RecentlyOpenedListItem({ title, url, image, disabled, style, onPress }: Props) {
+export function RecentlyOpenedListItem({
+  title,
+  url,
+  image,
+  disabled,
+  style,
+  onPress,
+  releaseChannel,
+}: Props) {
   const theme = useExpoTheme();
+  const palette = useExpoPalette();
 
   const handleLongPress = () => {
     const message = UrlUtils.normalizeUrl(url);
@@ -37,9 +47,32 @@ export function RecentlyOpenedListItem({ title, url, image, disabled, style, onP
       disabled={disabled}>
       <AppIcon image={image} />
       <RNView style={[styles.contentContainer]}>
-        <Text type="InterSemiBold" ellipsizeMode="tail" numberOfLines={1}>
-          {title}
-        </Text>
+        <View>
+          <Text type="InterSemiBold" ellipsizeMode="tail" numberOfLines={1}>
+            {title}
+          </Text>
+          {releaseChannel && (
+            <View
+              style={{
+                marginTop: 8,
+                backgroundColor: palette.blue['100'],
+                borderRadius: 4,
+                paddingVertical: 2,
+                paddingHorizontal: 8,
+                flexDirection: 'row',
+                alignItems: 'center',
+              }}>
+              <Text
+                type="InterRegular"
+                style={{ color: palette.blue['800'] }}
+                size="small"
+                ellipsizeMode="tail"
+                numberOfLines={1}>
+                Channel: {releaseChannel}
+              </Text>
+            </View>
+          )}
+        </View>
         <RNView style={styles.chevronRightContainer}>
           <ChevronDownIcon
             style={{ transform: [{ rotate: '-90deg' }] }}

--- a/home/screens/HomeScreen/RecentlyOpenedSection.tsx
+++ b/home/screens/HomeScreen/RecentlyOpenedSection.tsx
@@ -33,6 +33,11 @@ export function RecentlyOpenedSection({ recentHistory }: Props) {
               onPress={() => {
                 Linking.openURL(project.url);
               }}
+              releaseChannel={
+                project.manifest && 'releaseChannel' in project.manifest
+                  ? project.manifest.releaseChannel
+                  : undefined
+              }
             />
             {i < recentHistory.count() - 1 && <Divider style={{ height: 1 }} />}
           </Fragment>


### PR DESCRIPTION
# Why

Some users found release channel differentiation in the 'recently opened' list to be important to their workflow.

# How

I added a line to the recently opened list item to show the channel for classic updates. EAS Update manifests don't support that.

# Test Plan

Open a Classic Update inside Expo Go and check the home screen to see the channel on that item:

![Screen Shot 2022-05-06 at 10 54 03](https://user-images.githubusercontent.com/12488826/167158195-a7321af5-8d62-4c97-955c-325bb193d5a5.png)

