### PR TITLE
[home][android] show QR/URL button when logged out on android and non-app store builds

### DIFF
--- a/dev-home-config.json
+++ b/dev-home-config.json
@@ -1,3 +1,3 @@
 {
-  "url": "exp://exp.host/@expo-home-dev/expo-home-dev-0622dc92c30f94b8ca1c56a443a48366b8ef82e7"
+  "url": "exp://exp.host/@expo-home-dev/expo-home-dev-2d7ba438a402b489986bade32db4d79ff297f359"
 }

--- a/home/screens/HomeScreen/DevelopmentServersPlaceholder.tsx
+++ b/home/screens/HomeScreen/DevelopmentServersPlaceholder.tsx
@@ -46,10 +46,19 @@ export function DevelopmentServersPlaceholder({ isAuthenticated }: Props) {
     <TouchableOpacity
       onPress={() => navigation.navigate('Account')}
       hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
-      <View bg="default" padding="medium" border="default" rounded="large">
-        <Text type="InterRegular" style={{ lineHeight: 20 }}>
-          Sign in to your Expo account to see the projects you have recently been working on.
-        </Text>
+      <View bg="default" border="default" rounded="large">
+        <View padding="medium">
+          <Text type="InterRegular" style={{ lineHeight: 20 }}>
+            Press here to sign in to your Expo account and see the projects you have recently been
+            working on.
+          </Text>
+        </View>
+        {FeatureFlags.ENABLE_PROJECT_TOOLS && FeatureFlags.ENABLE_CLIPBOARD_BUTTON ? (
+          <DevelopmentServersOpenURL />
+        ) : null}
+        {FeatureFlags.ENABLE_PROJECT_TOOLS && FeatureFlags.ENABLE_QR_CODE_BUTTON ? (
+          <DevelopmentServersOpenQR />
+        ) : null}
       </View>
     </TouchableOpacity>
   );

--- a/home/screens/HomeScreen/RecentlyOpenedListItem/index.tsx
+++ b/home/screens/HomeScreen/RecentlyOpenedListItem/index.tsx
@@ -61,6 +61,7 @@ export function RecentlyOpenedListItem({
                 paddingHorizontal: 8,
                 flexDirection: 'row',
                 alignItems: 'center',
+                alignSelf: 'flex-start',
               }}>
               <Text
                 type="InterRegular"


### PR DESCRIPTION
# Why

Users can't scan QR codes on Android without logging in, which is a regression.

# How

I added this functionality back to the unauthenticated view on non-app store clients. I also fixed a layout issue with the release channel tag expanding to the size of the parent unnecessarily.

# Test Plan

Open Expo Go with a local build on iOS or Android:

![Screenshot_20220506-153153](https://user-images.githubusercontent.com/12488826/167205463-21cb6d2e-e724-4bda-acf2-821d67f874ed.png)

![IMG_0077](https://user-images.githubusercontent.com/12488826/167205229-2e6357a6-26a7-4ffa-825c-fc6e47b85fc3.PNG)

