### PR TITLE
Fix deprecated placeholder `diagnostics` in dev-client issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/dev_client_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/dev_client_bug_report.yml
@@ -42,7 +42,7 @@ body:
   - type: textarea
     attributes:
       label: Environment
-      placeholder: Run `expo diagnostics` and paste the output here
+      placeholder: Run `npx expo-env-info` and paste the output here
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
# Why

The issue template for dev-client has an outdated textarea placeholder

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Changed to the correct one

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
