### PR TITLE
[android] pin appcompat to 1.3.1

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -123,11 +123,23 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.6.10')}"
 
   // Our dependencies
-  implementation 'androidx.appcompat:appcompat:1.2.0'
+  implementation ('androidx.appcompat:appcompat:1.3.1') {
+    // Workaround for https://github.com/expo/expo/issues/17372
+    // Remove this version pinning when we drop sdk 44
+    version {
+      strictly '1.3.1'
+    }
+  }
 
   // Our dependencies from ExpoView
   // DON'T ADD ANYTHING HERE THAT ISN'T IN EXPOVIEW. ONLY COPY THINGS FROM EXPOVIEW TO HERE.
-  implementation 'androidx.appcompat:appcompat:1.2.0'
+  implementation ('androidx.appcompat:appcompat:1.3.1') {
+    // Workaround for https://github.com/expo/expo/issues/17372
+    // Remove this version pinning when we drop sdk 44
+    version {
+      strictly '1.3.1'
+    }
+  }
   compileOnly 'org.glassfish:javax.annotation:3.1.1'
   implementation 'com.jakewharton:butterknife:10.2.1'
   implementation 'de.greenrobot:eventbus:2.4.0'


### PR DESCRIPTION
# Why

stripe sdk promotes the appcompat to version 1.4 which breaks TextInput for expo sdk 43 and 44 (react-native 0.64). the issue is fixed in 0.68 from [this commit](https://github.com/facebook/react-native/commit/e21f8ec34984551f87a306672160cc88e67e4793).
fix #17372
close ENG-4898

# How

referenced from [the solution](https://github.com/facebook/react-native/issues/31572#issuecomment-912017067) to downgrade the appcompat version to 1.3.1.

i'm leaving an alternative solution here. we can also backport [this commit](https://github.com/facebook/react-native/commit/e21f8ec34984551f87a306672160cc88e67e4793) to sdk 43/44. but this takes extra effort because we should backport the change to our react-native fork and to rebuild the react-native versioned aar.

# Test Plan

- test android versioned expo go + sdk44 project with TextInput
- test android versioned expo go + sdk45 project with TextInput
- test stripe example doesn't break when we downgrade the appcompat version

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
