### PR TITLE
[home][ios] fixed typo

### DIFF
--- a/home/screens/DiagnosticsScreen/index.tsx
+++ b/home/screens/DiagnosticsScreen/index.tsx
@@ -34,7 +34,7 @@ function AudioDiagnostic({
   return (
     <DiagnosticButton
       title="Audio"
-      description={`On iOS you can play audio ${
+      description={`On iOS you can play audio${
         !Environment.IsIOSRestrictedBuild ? ` in the foreground and background` : ``
       }, choose whether it plays when the device is on silent, and set how the audio interacts with audio from other apps. This diagnostic allows you to see the available options.`}
       onPress={() => navigation.navigate('Audio', {})}


### PR DESCRIPTION
Removed space from  "On iOS you can play audio , choose whether..." on the diagnostics page.

# Why
It annoyed me.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How
The backspace key.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
Yes.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).

i don't know?