### PR TITLE
Update setup-native-firebase.md

### DIFF
--- a/docs/pages/guides/setup-native-firebase.md
+++ b/docs/pages/guides/setup-native-firebase.md
@@ -120,6 +120,8 @@ You are free to use any native Firebase packages such as [react-native-firebase]
     ```objc
     @import Firebase;
     ```
+    
+  Note that following the upgrade to Expo SDK 45, your AppDelegate file will have the `.mm` extension as opposed to the `.m` extension.
 - At the top of the `didFinishLaunchingWithOptions` method:
   ```objc
   - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {

--- a/docs/pages/guides/setup-native-firebase.md
+++ b/docs/pages/guides/setup-native-firebase.md
@@ -112,7 +112,11 @@ You are free to use any native Firebase packages such as [react-native-firebase]
   - Be sure to enable **'Copy items if needed'**.
 
 - Initialize the default Firebase app by opening the AppDelegate file in your project `ios/{projectName}/AppDelegate.m`.
-- At the top of the file:
+- If you're using Expo SDK 45 or later, add the following to the top of the file:
+  ```objc
+  #import <Firebase/Firebase.h>
+  ```
+- For versions prior to Expo SDK 45, add the following to the top of the file:
   ```objc
   @import Firebase;
   ```

--- a/docs/pages/guides/setup-native-firebase.md
+++ b/docs/pages/guides/setup-native-firebase.md
@@ -111,15 +111,15 @@ You are free to use any native Firebase packages such as [react-native-firebase]
 
   - Be sure to enable **'Copy items if needed'**.
 
-- Initialize the default Firebase app by opening the AppDelegate file in your project `ios/{projectName}/AppDelegate.m`.
-- If you're using Expo SDK 45 or later, add the following to the top of the file:
-  ```objc
-  #import <Firebase/Firebase.h>
-  ```
-- For versions prior to Expo SDK 45, add the following to the top of the file:
-  ```objc
-  @import Firebase;
-  ```
+- Initialize the default Firebase app by opening the AppDelegate file in your project.
+  - If you're using Expo SDK 45 or later, add the following to the top of the `ios/{projectName}/AppDelegate.mm` file:
+    ```objc
+    #import <Firebase/Firebase.h>
+    ```
+  - For versions prior to Expo SDK 45, add the following to the top of `ios/{projectName}/AppDelegate.m` file:
+    ```objc
+    @import Firebase;
+    ```
 - At the top of the `didFinishLaunchingWithOptions` method:
   ```objc
   - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {


### PR DESCRIPTION
# Why

Since Expo SDK 45, I noticed the following error when running my app. It appears that you may have to import Firebase to your `AppDelegate.mm` slightly differently to how is shown in the current documentation.

This is the error I see when running my project, which I just upgraded to SDK 45.

```
❌  (ios/MyApp/AppDelegate.mm:1:1)

> 1 | @import Firebase;
    | ^ use of '@import' when C++ modules are disabled, consider using -fmodules and -fcxx-modules
  2 |
  3 | #import "AppDelegate.h"
  4 |


❌  (ios/MyApp/AppDelegate.mm:36:4)

  34 | - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
  35 | {
> 36 |   [FIRApp configure];
     |    ^ use of undeclared identifier 'FIRApp'
  37 |   RCTAppSetupPrepareApp(application);
  38 |
  39 |   RCTBridge *bridge = [self.reactDelegate createBridgeWithDelegate:self launchOptions:launchOptions];

› 2 error(s), and 0 warning(s)

Failed to build iOS project. "xcodebuild" exited with error code 65.
```

# How

After doing some research, I came across [this](https://github.com/invertase/react-native-firebase/pull/6223) `react-native-firebase` Pull Request, suggesting to instead import Firebase with `#import <Firebase/Firebase.h>` as opposed to `@import Firebase;`. I tested this locally and no longer saw the issue. The app built and ran as expected.

I'm not sure exactly how you'd like to handle this or if any documentation needs changing elsewhere but hopefully this is a start, and a little more helpful than an issue.