### PR TITLE
[core][iOS] Register data component for the `EXViewManagerAdapter`

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - Fix modules have not been deallocated during the application reload on iOS. ([#17285](https://github.com/expo/expo/pull/17285) by [@lukmccall](https://github.com/lukmccall))
+- Fix view props weren't recognized in the bare workflow on iOS.
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 🐛 Bug fixes
 
 - Fix modules have not been deallocated during the application reload on iOS. ([#17285](https://github.com/expo/expo/pull/17285) by [@lukmccall](https://github.com/lukmccall))
-- Fix view props weren't recognized in the bare workflow on iOS.
+- Fix view props weren't recognized in the bare workflow on iOS. ([#17411](https://github.com/expo/expo/pull/17411) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.mm
+++ b/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.mm
@@ -244,7 +244,7 @@ RCT_EXPORT_METHOD(callMethod:(NSString *)moduleName methodNameOrKey:(id)methodNa
     // Otherwise, React Native may treat these props as invalid in subclassing views.
     [additionalModuleClasses addObject:[EXViewManagerAdapter class]];
     // Also, we have to register component data for the View Adapter.
-    // Otherwise, it won't be recognised by the UIManager.
+    // Otherwise, it won't be recognized by the UIManager.
     [self registerLegacyComponentData:[EXViewManagerAdapter class] inBridge:bridge];
 
     // Some modules might need access to the bridge.

--- a/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.mm
+++ b/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.mm
@@ -247,7 +247,6 @@ RCT_EXPORT_METHOD(callMethod:(NSString *)moduleName methodNameOrKey:(id)methodNa
     // Otherwise, it won't be recognised by the UIManager.
     [self registerLegacyComponentData:[EXViewManagerAdapter class] inBridge:bridge];
 
-
     // Some modules might need access to the bridge.
     for (id module in [_exModuleRegistry getAllInternalModules]) {
       if ([module conformsToProtocol:@protocol(RCTBridgeModule)]) {

--- a/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.mm
+++ b/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.mm
@@ -243,6 +243,10 @@ RCT_EXPORT_METHOD(callMethod:(NSString *)moduleName methodNameOrKey:(id)methodNa
     // their base view managers that provides common props such as `proxiedProperties`.
     // Otherwise, React Native may treat these props as invalid in subclassing views.
     [additionalModuleClasses addObject:[EXViewManagerAdapter class]];
+    // Also, we have to register component data for the View Adapter.
+    // Otherwise, it won't be recognised by the UIManager.
+    [self registerLegacyComponentData:[EXViewManagerAdapter class] inBridge:bridge];
+
 
     // Some modules might need access to the bridge.
     for (id module in [_exModuleRegistry getAllInternalModules]) {


### PR DESCRIPTION
# Why

Closes https://linear.app/expo/issue/ENG-4905/expo-blur-props-regression
Closes https://github.com/expo/expo/issues/17395.

# How

It turns out that `EXViewManagerAdapter` wasn't properly registered. It wasn't recognized by the `UIManager`.
Our modules won't work unless they're processed by the UIManager here:
https://github.com/facebook/react-native/blob/e07a7eb16b97e1222e23f935a3d4bb3dac848ef2/Libraries/ReactNative/PaperUIManager.js#L153-L162
But to add a module to that list, it has to be registered using a data component to UIManager. We missed that step for the `EXViewManagerAdapter`. 

# Test Plan

- https://github.com/brentvatne/blur-fourfive-regression ✅
- expo go (with similar example) ✅