### PR TITLE
[ios] Add JS classes to the Sweet API

### DIFF
--- a/packages/expo-modules-core/ios/JSI/EXJSIUtils.h
+++ b/packages/expo-modules-core/ios/JSI/EXJSIUtils.h
@@ -2,17 +2,31 @@
 
 #ifdef __cplusplus
 
+#import <functional>
+
 #import <jsi/jsi.h>
 #import <ReactCommon/RCTTurboModule.h>
 
-using namespace facebook;
-using namespace react;
+namespace jsi = facebook::jsi;
+namespace react = facebook::react;
 
 namespace expo {
 
+#pragma mark - Promises
+
 using PromiseInvocationBlock = void (^)(RCTPromiseResolveBlock resolveWrapper, RCTPromiseRejectBlock rejectWrapper);
 
-void callPromiseSetupWithBlock(jsi::Runtime &runtime, std::shared_ptr<CallInvoker> jsInvoker, std::shared_ptr<Promise> promise, PromiseInvocationBlock setupBlock);
+void callPromiseSetupWithBlock(jsi::Runtime &runtime, std::shared_ptr<react::CallInvoker> jsInvoker, std::shared_ptr<react::Promise> promise, PromiseInvocationBlock setupBlock);
+
+#pragma mark - Classes
+
+using ClassConstructor = std::function<void(jsi::Runtime &runtime, const jsi::Value &thisValue, jsi::Array args)>;
+
+std::shared_ptr<jsi::Function> createClass(jsi::Runtime &runtime, const char *name, ClassConstructor constructor);
+
+#pragma mark - Define property
+
+void defineProperty(jsi::Runtime &runtime, const jsi::Object *object, const char *name, jsi::Value value);
 
 } // namespace expo
 

--- a/packages/expo-modules-core/ios/JSI/EXJSIUtils.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJSIUtils.mm
@@ -1,17 +1,17 @@
 // Copyright 2022-present 650 Industries. All rights reserved.
 
+#import <sstream>
+
 #import <React/RCTUtils.h>
 #import <ExpoModulesCore/EXJSIConversions.h>
 #import <ExpoModulesCore/EXJSIUtils.h>
-
-using namespace facebook;
 
 namespace expo {
 
 void callPromiseSetupWithBlock(jsi::Runtime &runtime, std::shared_ptr<CallInvoker> jsInvoker, std::shared_ptr<Promise> promise, PromiseInvocationBlock setupBlock)
 {
-  auto weakResolveWrapper = CallbackWrapper::createWeak(promise->resolve_.getFunction(runtime), runtime, jsInvoker);
-  auto weakRejectWrapper = CallbackWrapper::createWeak(promise->reject_.getFunction(runtime), runtime, jsInvoker);
+  auto weakResolveWrapper = react::CallbackWrapper::createWeak(promise->resolve_.getFunction(runtime), runtime, jsInvoker);
+  auto weakRejectWrapper = react::CallbackWrapper::createWeak(promise->reject_.getFunction(runtime), runtime, jsInvoker);
 
   __block BOOL resolveWasCalled = NO;
   __block BOOL rejectWasCalled = NO;
@@ -84,6 +84,49 @@ void callPromiseSetupWithBlock(jsi::Runtime &runtime, std::shared_ptr<CallInvoke
   };
 
   setupBlock(resolveBlock, rejectBlock);
+}
+
+std::shared_ptr<jsi::Function> createClass(jsi::Runtime &runtime, const char *name, ClassConstructor constructor) {
+  std::string nativeConstructorKey("__native_constructor__");
+
+  // Create a string buffer of the source code to evaluate.
+  std::stringstream source;
+  source << "(function " << name << "(...args) { this." << nativeConstructorKey << "(args); return this; })";
+  std::shared_ptr<jsi::StringBuffer> sourceBuffer = std::make_shared<jsi::StringBuffer>(source.str());
+
+  // Evaluate the code and obtain returned value (the constructor function).
+  jsi::Object klass = runtime.evaluateJavaScript(sourceBuffer, "").asObject(runtime);
+
+  // Set the native constructor in the prototype.
+  jsi::Object prototype = klass.getPropertyAsObject(runtime, "prototype");
+  jsi::PropNameID nativeConstructorPropId = jsi::PropNameID::forAscii(runtime, nativeConstructorKey);
+  jsi::Function nativeConstructor = jsi::Function::createFromHostFunction(
+    runtime,
+    nativeConstructorPropId,
+    1,
+    [constructor](jsi::Runtime &runtime, const jsi::Value &thisValue, const jsi::Value *args, size_t count) -> jsi::Value {
+      constructor(runtime, thisValue, args->asObject(runtime).asArray(runtime));
+      return jsi::Value::undefined();
+    });
+
+  defineProperty(runtime, &prototype, nativeConstructorKey.c_str(), jsi::Value(runtime, nativeConstructor));
+
+  return std::make_shared<jsi::Function>(klass.asFunction(runtime));
+}
+
+void defineProperty(jsi::Runtime &runtime, const jsi::Object *object, const char *name, jsi::Value value) {
+  jsi::Object global = runtime.global();
+  jsi::Object objectClass = global.getPropertyAsObject(runtime, "Object");
+  jsi::Function definePropertyFunction = objectClass.getPropertyAsFunction(runtime, "defineProperty");
+
+  jsi::Object descriptor(runtime);
+  descriptor.setProperty(runtime, "value", value);
+
+  definePropertyFunction.callWithThis(runtime, objectClass, {
+    jsi::Value(runtime, *object),
+    jsi::String::createFromUtf8(runtime, name),
+    std::move(descriptor),
+  });
 }
 
 } // namespace expo

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.h
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.h
@@ -79,6 +79,13 @@ NS_SWIFT_NAME(JavaScriptRuntime)
                                           argsCount:(NSInteger)argsCount
                                               block:(nonnull JSAsyncFunctionBlock)block;
 
+#pragma mark - Classes
+
+typedef void (^ClassConstructorBlock)(EXJavaScriptObject * _Nonnull thisValue, NSArray<EXJavaScriptValue *> * _Nonnull arguments);
+
+- (nonnull EXJavaScriptObject *)createClass:(nonnull NSString *)name
+                                constructor:(nonnull ClassConstructorBlock)constructor;
+
 #pragma mark - Script evaluation
 
 /**

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.mm
@@ -111,6 +111,21 @@ using namespace facebook;
   }];
 }
 
+#pragma mark - Classes
+
+- (nonnull EXJavaScriptObject *)createClass:(nonnull NSString *)name
+                                constructor:(nonnull ClassConstructorBlock)constructor
+{
+  std::shared_ptr<jsi::Function> klass = expo::createClass(*_runtime, [name UTF8String], [self, constructor](jsi::Runtime &runtime, const jsi::Value &thisValue, jsi::Array args) {
+    std::shared_ptr<jsi::Object> thisPtr = std::make_shared<jsi::Object>(thisValue.asObject(runtime));
+    EXJavaScriptObject *caller = [[EXJavaScriptObject alloc] initWith:thisPtr runtime:self];
+    NSArray<EXJavaScriptValue *> *arguments = expo::convertJSIArrayToNSArray(runtime, args, self->_jsCallInvoker);
+
+    constructor(caller, arguments);
+  });
+  return [[EXJavaScriptObject alloc] initWith:klass runtime:self];
+}
+
 #pragma mark - Script evaluation
 
 - (nonnull EXJavaScriptValue *)evaluateScript:(nonnull NSString *)scriptSource

--- a/packages/expo-modules-core/ios/Swift/Classes/ClassComponent.swift
+++ b/packages/expo-modules-core/ios/Swift/Classes/ClassComponent.swift
@@ -1,0 +1,69 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+/**
+ Represents a JavaScript class.
+ */
+public final class ClassComponent: ObjectDefinition {
+  /**
+   Name of the class.
+   */
+  let name: String
+
+  /**
+   A synchronous function that gets called when the object of this class is initializing.
+   */
+  let constructor: AnySyncFunctionComponent?
+
+  init(name: String, elements: [ClassComponentElement]) {
+    self.name = name
+    self.constructor = elements.first(where: isConstructor) as? AnySyncFunctionComponent
+
+    // Constructors can't be passed down to the object component
+    // as we shouldn't override the default `<Class>.prototype.constructor`.
+    let elementsWithoutConstructors = elements.filter({ !isConstructor($0) })
+
+    super.init(definitions: elementsWithoutConstructors)
+  }
+
+  // MARK: - JavaScriptObjectBuilder
+
+  public override func build(inRuntime runtime: JavaScriptRuntime) -> JavaScriptObject {
+    let klass = runtime.createClass(name) { [weak self, weak runtime] caller, arguments in
+      guard let self = self, let runtime = runtime else {
+        // TODO: Throw an exception? (@tsapeta)
+        return
+      }
+      // The properties can't go into the prototype as they would be shared across all instances.
+      // Instead, we decorate the instance object on initialization.
+      self.decorateWithProperties(runtime: runtime, object: caller)
+
+      // Call the native constructor when defined.
+      let _ = try? self.constructor?.call(args: arguments)
+    }
+    decorate(object: klass, inRuntime: runtime)
+    return klass
+  }
+
+  public override func decorate(object: JavaScriptObject, inRuntime runtime: JavaScriptRuntime) {
+    // Here we actually don't decorate the input object (constructor) but its prototype.
+    // Properties are intentionally skipped here — they have to decorate an instance instead of the prototype.
+    let prototype = object.getProperty("prototype").getObject()
+    decorateWithConstants(runtime: runtime, object: prototype)
+    decorateWithFunctions(runtime: runtime, object: prototype)
+    decorateWithClasses(runtime: runtime, object: prototype)
+  }
+}
+
+// MARK: - Privates
+
+/**
+ Checks whether the definition item is a constructor — a synchronous function whose name is "constructor".
+
+ We do it that way for the following two reasons:
+ - It's easier to reuse existing `SyncFunctionComponent`.
+ - Redefining prototype's `constructor` is a bad idea so a function with this name
+   needs to be filtered out when decorating the prototype.
+ */
+fileprivate func isConstructor(_ item: AnyDefinition) -> Bool {
+  return (item as? AnySyncFunctionComponent)?.name == "constructor"
+}

--- a/packages/expo-modules-core/ios/Swift/Classes/ClassComponentElement.swift
+++ b/packages/expo-modules-core/ios/Swift/Classes/ClassComponentElement.swift
@@ -1,0 +1,12 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+/**
+ A protocol that must be implemented by the components passed as ``ClassComponent`` elements.
+ */
+public protocol ClassComponentElement: AnyDefinition {}
+
+// Allow some other components to be used as the class component elements.
+extension SyncFunctionComponent: ClassComponentElement {}
+extension AsyncFunctionComponent: ClassComponentElement {}
+extension PropertyComponent: ClassComponentElement {}
+extension ConstantsDefinition: ClassComponentElement {}

--- a/packages/expo-modules-core/ios/Swift/Classes/ClassComponentElementsBuilder.swift
+++ b/packages/expo-modules-core/ios/Swift/Classes/ClassComponentElementsBuilder.swift
@@ -1,0 +1,13 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+#if swift(>=5.4)
+/**
+ A result builder that captures the ``ClassComponent`` elements such as functions, constants and properties.
+ */
+@resultBuilder
+public struct ClassComponentElementsBuilder {
+  public static func buildBlock(_ elements: ClassComponentElement...) -> [ClassComponentElement] {
+    return elements
+  }
+}
+#endif

--- a/packages/expo-modules-core/ios/Swift/Classes/ClassComponentFactories.swift
+++ b/packages/expo-modules-core/ios/Swift/Classes/ClassComponentFactories.swift
@@ -1,0 +1,65 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+/**
+ Class constructor without arguments.
+ */
+public func Constructor(_ body: @escaping () throws -> ()) -> AnyFunction {
+  return Function("constructor", body)
+}
+
+/**
+ Class constructor with one argument.
+ */
+public func Constructor<A0: AnyArgument>(_ body: @escaping (A0) throws -> ()) -> AnyFunction {
+  return Function("constructor", body)
+}
+
+/**
+ Class constructor with two arguments.
+ */
+public func Constructor<A0: AnyArgument, A1: AnyArgument>(_ body: @escaping (A0, A1) throws -> ()) -> AnyFunction {
+  return Function("constructor", body)
+}
+
+/**
+ Class constructor with three arguments.
+ */
+public func Constructor<A0: AnyArgument, A1: AnyArgument, A2: AnyArgument>(
+  _ body: @escaping (A0, A1, A2) throws -> ()
+) -> AnyFunction {
+  return Function("constructor", body)
+}
+
+/**
+ Class constructor with four arguments.
+ */
+public func Constructor<A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument>(
+  _ body: @escaping (A0, A1, A2, A3) throws -> ()
+) -> AnyFunction {
+  return Function("constructor", body)
+}
+
+/**
+ Class constructor with five arguments.
+ */
+public func Constructor<A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument, A4: AnyArgument>(
+  _ body: @escaping (A0, A1, A2, A3, A4) throws -> ()
+) -> AnyFunction {
+  return Function("constructor", body)
+}
+
+/**
+ Class constructor with six arguments.
+ */
+public func Constructor<A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument, A4: AnyArgument, A5: AnyArgument>(
+  _ body: @escaping (A0, A1, A2, A3, A4, A5) throws -> ()
+) -> AnyFunction {
+  return Function("constructor", body)
+}
+
+/**
+ Creates the component describing a JavaScript class.
+ */
+public func Class(_ name: String, @ClassComponentElementsBuilder _ elements: () -> [ClassComponentElement]) -> ClassComponent {
+  return ClassComponent(name: name, elements: elements())
+}

--- a/packages/expo-modules-core/ios/Swift/Functions/AnyFunction.swift
+++ b/packages/expo-modules-core/ios/Swift/Functions/AnyFunction.swift
@@ -6,7 +6,7 @@ public typealias FunctionCallResult = Result<Any, Exception>
 /**
  A protocol for any type-erased function.
  */
-public protocol AnyFunction: AnyDefinition, JavaScriptObjectBuilder {
+public protocol AnyFunction: AnyDefinition, JavaScriptObjectBuilder, ClassComponentElement {
   /**
    Name of the function. JavaScript refers to the function by this name.
    */

--- a/packages/expo-modules-core/ios/Swift/Objects/ObjectDefinition.swift
+++ b/packages/expo-modules-core/ios/Swift/Objects/ObjectDefinition.swift
@@ -20,6 +20,11 @@ public class ObjectDefinition: AnyDefinition, JavaScriptObjectBuilder {
   let properties: [String: PropertyComponent]
 
   /**
+   A map of classes defined within the object.
+   */
+  let classes: [String: ClassComponent]
+
+  /**
    Default initializer receiving children definitions from the result builder.
    */
   init(definitions: [AnyDefinition]) {
@@ -36,6 +41,12 @@ public class ObjectDefinition: AnyDefinition, JavaScriptObjectBuilder {
       .compactMap { $0 as? PropertyComponent }
       .reduce(into: [String: PropertyComponent]()) { dict, property in
         dict[property.name] = property
+      }
+
+    self.classes = definitions
+      .compactMap { $0 as? ClassComponent }
+      .reduce(into: [String: ClassComponent]()) { dict, klass in
+        dict[klass.name] = klass
       }
   }
 
@@ -60,6 +71,7 @@ public class ObjectDefinition: AnyDefinition, JavaScriptObjectBuilder {
     decorateWithConstants(runtime: runtime, object: object)
     decorateWithFunctions(runtime: runtime, object: object)
     decorateWithProperties(runtime: runtime, object: object)
+    decorateWithClasses(runtime: runtime, object: object)
   }
 
   // MARK: - Internals
@@ -80,6 +92,12 @@ public class ObjectDefinition: AnyDefinition, JavaScriptObjectBuilder {
     for property in properties.values {
       let descriptor = property.buildDescriptor(inRuntime: runtime, withCaller: object)
       object.defineProperty(property.name, descriptor: descriptor)
+    }
+  }
+
+  internal func decorateWithClasses(runtime: JavaScriptRuntime, object: JavaScriptObject) {
+    for klass in classes.values {
+      object.setProperty(klass.name, value: klass.build(inRuntime: runtime))
     }
   }
 }

--- a/packages/expo-modules-core/ios/Tests/ClassComponentSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/ClassComponentSpec.swift
@@ -1,0 +1,108 @@
+import ExpoModulesTestCore
+
+@testable import ExpoModulesCore
+
+class ClassComponentSpec: ExpoSpec {
+  override func spec() {
+    describe("basic") {
+      it("factory returns a component") {
+        let klass = Class("") {}
+        expect(klass).to(beAnInstanceOf(ClassComponent.self))
+      }
+
+      it("has a name") {
+        let expoClassName = "ExpoClass"
+        let klass = Class(expoClassName) {}
+        expect(klass.name) == expoClassName
+      }
+
+      it("is without native constructor") {
+        let klass = Class("") {}
+        expect(klass.constructor).to(beNil())
+      }
+
+      it("has native constructor") {
+        let klass = Class("") { Constructor {} }
+        expect(klass.constructor).notTo(beNil())
+      }
+
+      it("ignores constructor as function") {
+        let klass = Class("") { Constructor {} }
+        expect(klass.functions["constructor"]).to(beNil())
+      }
+
+      it("builds a class") {
+        let runtime = JavaScriptRuntime()
+        let klass = Class("") {}
+        let object = klass.build(inRuntime: runtime)
+
+        expect(object.hasProperty("prototype")) == true
+        expect(object.getProperty("prototype").kind) == .object
+      }
+    }
+
+    describe("module") {
+      let appContext = AppContext.create()
+      let runtime = appContext.runtime
+
+      beforeSuite {
+        class ClassTestModule: Module {
+          func definition() -> ModuleDefinition {
+            Name("ClassTest")
+
+            Class("MyClass") {
+              Constructor {}
+
+              Function("myFunction") {
+                return "foobar"
+              }
+
+              Property("foo") {
+                return "bar"
+              }
+            }
+          }
+        }
+        appContext.moduleRegistry.register(moduleType: ClassTestModule.self)
+      }
+
+      it("is a function") {
+        let klass = try runtime?.eval("ExpoModules.ClassTest.MyClass")
+        expect(klass?.isFunction()) == true
+      }
+
+      it("has a name") {
+        let klass = try runtime?.eval("ExpoModules.ClassTest.MyClass.name")
+        expect(klass?.getString()) == "MyClass"
+      }
+
+      it("has a prototype") {
+        let prototype = try runtime?.eval("ExpoModules.ClassTest.MyClass.prototype")
+        expect(prototype?.isObject()) == true
+      }
+
+      it("has keys in prototype") {
+        let prototypeKeys = try runtime?.eval("Object.keys(ExpoModules.ClassTest.MyClass.prototype)")
+          .getArray()
+          .map { $0.getString() } ?? []
+
+        expect(prototypeKeys).to(contain("myFunction"))
+        expect(prototypeKeys).notTo(contain("__native_constructor__"))
+      }
+
+      it("is an instance of") {
+        try runtime?.eval("myObject = new ExpoModules.ClassTest.MyClass()")
+        let isInstanceOf = try runtime?.eval("myObject instanceof ExpoModules.ClassTest.MyClass")
+
+        expect(isInstanceOf?.getBool()) == true
+      }
+
+      it("defines properties on initialization") {
+        // The properties are not specified in the prototype, but defined during initialization.
+        let object = try runtime?.eval("new ExpoModules.ClassTest.MyClass()").asObject()
+        expect(object?.getPropertyNames()).to(contain("foo"))
+        expect(object?.getProperty("foo").getString()) == "bar"
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Why

Closes ENG-4819

# How

Right now the functionality is kinda limited and useless as we don't have any reference to some native data (and `this` can only be a representation of the JS object). However, it'll become beneficial with shared objects (PR soon). 

```swift
Class("Counter") {
  Constructor { (this: JavaScriptObject) in
    // initialize the object
    this.setProperty("value", value: 1)
  }
  Function("increment") { (this: JavaScriptObject) in
    let currentValue = this.getProperty("value").getInt()
    this.setProperty("value", value: currentValue + 1)
  }
}
```

# Test Plan

Added new unit tests to cover this functionality, all of them are passing.