### PR TITLE
fix(cli): prevent failing when no hashes are included on export

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -15,7 +15,7 @@
 - Fix bug where autocomplete prompts crash when escape characters are used. ([#17271](https://github.com/expo/expo/pull/17271) by [@EvanBacon](https://github.com/EvanBacon))
 - add missing `--platform` flag to `export` command. ([#17338](https://github.com/expo/expo/pull/17338) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix ADB device name filtering for windows. ([#17286](https://github.com/expo/expo/pull/17286) by [@byCedric](https://github.com/byCedric))
-- Fix `export` bug failing when no assets are included.
+- Fix `export` bug failing when no assets are included. ([#17414](https://github.com/expo/expo/pull/17414) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fix bug where autocomplete prompts crash when escape characters are used. ([#17271](https://github.com/expo/expo/pull/17271) by [@EvanBacon](https://github.com/EvanBacon))
 - add missing `--platform` flag to `export` command. ([#17338](https://github.com/expo/expo/pull/17338) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix ADB device name filtering for windows. ([#17286](https://github.com/expo/expo/pull/17286) by [@byCedric](https://github.com/byCedric))
+- Fix `export` bug failing when no assets are included.
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/export/__tests__/createMetadataJson-test.ts
+++ b/packages/@expo/cli/src/export/__tests__/createMetadataJson-test.ts
@@ -1,6 +1,19 @@
 import { createMetadataJson } from '../createMetadataJson';
 
 describe(createMetadataJson, () => {
+  it(`writes metadata without file hashes`, async () => {
+    // Should not throw
+    await createMetadataJson({
+      fileNames: {
+        ios: 'ios-xxfooxxbarxx.js',
+      },
+      bundles: {
+        ios: {
+          assets: [{ type: 'font' } as any],
+        },
+      },
+    });
+  });
   it(`writes metadata manifest`, async () => {
     const metadata = await createMetadataJson({
       fileNames: {

--- a/packages/@expo/cli/src/export/createMetadataJson.ts
+++ b/packages/@expo/cli/src/export/createMetadataJson.ts
@@ -36,11 +36,12 @@ export function createMetadataJson({
           assets: bundle.assets
             .map((asset) =>
               // Each asset has multiple hashes which we convert and then flatten.
-              asset.fileHashes.map((hash) => ({
+              asset.fileHashes?.map((hash) => ({
                 path: path.join('assets', hash),
                 ext: asset.type,
               }))
             )
+            .filter(Boolean)
             .flat(),
         },
       }),


### PR DESCRIPTION
# Why

- `expo export` fails in projects that have assets without hashes.

# How

- Handle undefined array.
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- Added tests.