### PR TITLE
[home] reduce line spacing in project list item and don't show slug if name and slug are the same

### DIFF
--- a/dev-home-config.json
+++ b/dev-home-config.json
@@ -1,3 +1,3 @@
 {
-  "url": "exp://exp.host/@expo-home-dev/expo-home-dev-2d7ba438a402b489986bade32db4d79ff297f359"
+  "url": "exp://exp.host/@expo-home-dev/expo-home-dev-80ac16b86299dd938ce3b12e170731d6012b6b42"
 }

--- a/home/components/ProjectsListItem.tsx
+++ b/home/components/ProjectsListItem.tsx
@@ -35,6 +35,8 @@ export function ProjectsListItem({ imageURL, name, subtitle, sdkVersion, id, fir
     navigation.push('ProjectDetails', { id });
   }
 
+  const showSubtitle = subtitle && name.toLowerCase() !== subtitle.toLowerCase();
+
   return (
     <View
       border="default"
@@ -62,9 +64,9 @@ export function ProjectsListItem({ imageURL, name, subtitle, sdkVersion, id, fir
                   numberOfLines={1}>
                   {name}
                 </Text>
-                {subtitle ? (
+                {showSubtitle ? (
                   <>
-                    <Spacer.Vertical size="tiny" />
+                    <Spacer.Vertical size="micro" />
                     <Text
                       type="InterRegular"
                       size="small"
@@ -77,7 +79,7 @@ export function ProjectsListItem({ imageURL, name, subtitle, sdkVersion, id, fir
                 ) : null}
                 {sdkVersionNumber ? (
                   <>
-                    <Spacer.Vertical size="tiny" />
+                    <Spacer.Vertical size="micro" />
                     <Text
                       type="InterRegular"
                       size="small"


### PR DESCRIPTION
# Why

I saw a tweet screenshot of the new Expo Go UI with a project list with all icons, slug, name, and SDK version. I didn't like how the text was spaced vertically.

![Screen Shot 2022-05-09 at 18 48 36](https://user-images.githubusercontent.com/12488826/167510929-d4a8a095-1eeb-4a4e-a95a-0e4b5ea09cec.png)

# How

I changed the vertical spacing to be "micro" instead of "tiny" and hid the slug if the name is the same, which reduces duplication in the UI.

# Test Plan

Open the projects list in Expo Go:

## Before

![Screen Shot 2022-05-09 at 18 53 00](https://user-images.githubusercontent.com/12488826/167511477-c7518b70-226d-40b0-b88d-434b06101d1a.png)

## After

![Screen Shot 2022-05-09 at 18 53 22](https://user-images.githubusercontent.com/12488826/167511512-d05a45a3-472f-48ab-8879-b2775b611c57.png)

