### PR TITLE
[home] center checkmark in account switcher

### DIFF
--- a/dev-home-config.json
+++ b/dev-home-config.json
@@ -1,3 +1,3 @@
 {
-  "url": "exp://exp.host/@expo-home-dev/expo-home-dev-2d7ba438a402b489986bade32db4d79ff297f359"
+  "url": "exp://exp.host/@expo-home-dev/expo-home-dev-762e79f4a89e99d875b0ce6953b83746f57a2c03"
 }

--- a/home/screens/AccountModal/LoggedInAccountView.tsx
+++ b/home/screens/AccountModal/LoggedInAccountView.tsx
@@ -63,6 +63,7 @@ export function LoggedInAccountView({ accounts }: Props) {
               <Row
                 justify="between"
                 padding="medium"
+                align="center"
                 bg="default"
                 border="default"
                 roundedTop={index === 0 ? 'large' : undefined}


### PR DESCRIPTION
# Why

As pointed out in a tweet, the checkmark in the account selector is ever so slightly off-center vertically: https://twitter.com/_UchennaOkafor/status/1523798051030134785

![Screen Shot 2022-05-09 at 19 11 42](https://user-images.githubusercontent.com/12488826/167513143-d6978eaa-ae44-4f2e-993f-5143e40ccfd4.png)


# How

Vertically align the content of the row center.

# Test Plan

Open the account selector and select a project without a display name:

## Before

![Screen Shot 2022-05-09 at 19 07 53](https://user-images.githubusercontent.com/12488826/167513003-52821a6c-e95c-44ac-ad63-480116340a62.png)

## After

![Screen Shot 2022-05-09 at 19 08 00](https://user-images.githubusercontent.com/12488826/167513001-eabaeed1-8a0e-41d4-8675-428a7c32a73e.png)

