### PR TITLE
[github] Disable publish-dogfood-home workflow for now

### DIFF
--- a/.github/workflows/home.yml
+++ b/.github/workflows/home.yml
@@ -59,42 +59,42 @@ jobs:
           fields: job,message,ref,eventName,author,took
           author_name: Home app
 
-  publish-dogfood-home:
-    if: ${{ false }} && github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: build
-    runs-on: ubuntu-20.04
-    steps:
-      - name: 👀 Checkout
-        uses: actions/checkout@v3
-        with:
-          submodules: true
-      - name: ⬢ Setup Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: '14.17'
-      - name: ♻️ Restore caches
-        uses: ./.github/actions/expo-caches
-        id: expo-caches
-        with:
-          yarn-tools: 'true'
-      - name: 🧶 Yarn install /tools
-        if: steps.expo-caches.outputs.yarn-tools-hit != 'true'
-        run: yarn install --frozen-lockfile
-        working-directory: tools
-      - name: 🔧 Install Expo CLI
-        run: yarn global add expo-cli
-      - name: 🦴 Publish dogfood Home
-        run: bin/expotools publish-dogfood-home
-        env:
-          EXPO_DOGFOOD_HOME_ACCESS_TOKEN: ${{ secrets.EXPO_DOGFOOD_HOME_ACCESS_TOKEN }}
-      - name: 🔔 Notify on Slack
-        uses: 8398a7/action-slack@v3
-        if: failure()
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_api }}
-        with:
-          channel: '#expo-sdk'
-          status: ${{ job.status }}
-          fields: job,message,ref,eventName,author,took
-          author_name: Home app
+  # publish-dogfood-home:
+  #   if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+  #   needs: build
+  #   runs-on: ubuntu-20.04
+  #   steps:
+  #     - name: 👀 Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         submodules: true
+  #     - name: ⬢ Setup Node
+  #       uses: actions/setup-node@v3
+  #       with:
+  #         node-version: '14.17'
+  #     - name: ♻️ Restore caches
+  #       uses: ./.github/actions/expo-caches
+  #       id: expo-caches
+  #       with:
+  #         yarn-tools: 'true'
+  #     - name: 🧶 Yarn install /tools
+  #       if: steps.expo-caches.outputs.yarn-tools-hit != 'true'
+  #       run: yarn install --frozen-lockfile
+  #       working-directory: tools
+  #     - name: 🔧 Install Expo CLI
+  #       run: yarn global add expo-cli
+  #     - name: 🦴 Publish dogfood Home
+  #       run: bin/expotools publish-dogfood-home
+  #       env:
+  #         EXPO_DOGFOOD_HOME_ACCESS_TOKEN: ${{ secrets.EXPO_DOGFOOD_HOME_ACCESS_TOKEN }}
+  #     - name: 🔔 Notify on Slack
+  #       uses: 8398a7/action-slack@v3
+  #       if: failure()
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #         SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_api }}
+  #       with:
+  #         channel: '#expo-sdk'
+  #         status: ${{ job.status }}
+  #         fields: job,message,ref,eventName,author,took
+  #         author_name: Home app

--- a/.github/workflows/home.yml
+++ b/.github/workflows/home.yml
@@ -60,7 +60,7 @@ jobs:
           author_name: Home app
 
   publish-dogfood-home:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: ${{ false }} && github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
# Why

[It's failing](https://github.com/expo/expo/runs/6361394765?check_suite_focus=true) and not currently in use.

# How

(self explanatory in diff)

# Test Plan

See results of this PR