### PR TITLE
[et] Remove root option from publish project

### DIFF
--- a/tools/src/ExpoCLI.ts
+++ b/tools/src/ExpoCLI.ts
@@ -1,12 +1,10 @@
 import spawnAsync from '@expo/spawn-async';
-import path from 'path';
 import process from 'process';
 
 import { EXPO_DIR } from './Constants';
 
 type Options = {
   cwd?: string;
-  root?: string;
   stdio?: 'inherit' | 'pipe' | 'ignore';
 };
 
@@ -15,14 +13,12 @@ export async function runExpoCliAsync(
   args: string[] = [],
   options: Options = {}
 ): Promise<void> {
-  const configArgs = options.root ? ['--config', path.resolve(options.root, 'app.json')] : [];
-
   // Don't handle SIGINT/SIGTERM in this process...defer to expo-cli
   process.on('SIGINT', () => {});
   process.on('SIGTERM', () => {});
 
-  await spawnAsync('expo', [command, ...args, ...configArgs], {
-    cwd: options.cwd || options.root || EXPO_DIR,
+  await spawnAsync('expo', [command, ...args], {
+    cwd: options.cwd || EXPO_DIR,
     stdio: options.stdio || 'inherit',
     env: {
       ...process.env,

--- a/tools/src/XDL.ts
+++ b/tools/src/XDL.ts
@@ -43,6 +43,6 @@ export async function publishProjectWithExpoCliAsync(
   }
 
   await ExpoCLI.runExpoCliAsync('publish', publishArgs, {
-    root: projectRoot,
+    cwd: projectRoot,
   });
 }


### PR DESCRIPTION
# Why

The CI is failing with:

```
Publishing...
[23:49:43] › --config flag is deprecated. Use app.config.js instead. Learn more: https://expo.fyi/config-flag-migration

[23:49:43] Input is required, but Expo CLI is in non-interactive mode.
Required input:
> In order to publish an update, expo-updates needs to be installed. Do you want to install it now?
Restoring app.json file from backup...
There was an error running publish-dogfood-home command: expo exited with non-zero code: 1
```

That's because we don't support `--config` anymore.

# How

Used `cwd` property instead of `root` to avoid adding the `--config` flag.

# Test Plan

Check if CI passes

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
