### PR TITLE
[autolinking] add some unit tests for findModules in workspace

### DIFF
--- a/packages/expo-modules-autolinking/src/__tests__/mockHelpers.ts
+++ b/packages/expo-modules-autolinking/src/__tests__/mockHelpers.ts
@@ -1,4 +1,5 @@
 import minimatch from 'minimatch';
+import path from 'path';
 
 export function registerGlobMock(globFunction: Function, files: string[], cwd: string) {
   (globFunction as jest.MockedFunction<any>).mockImplementation((patterns, inputOptions) => {
@@ -8,10 +9,7 @@ export function registerGlobMock(globFunction: Function, files: string[], cwd: s
     // E.g. inputCwd='/path/to/expo' and cwd='/path/to',
     // -> `prefix`: 'expo/'
     // -> glob pattern would like something like `expo/*/*`
-    let prefix = '';
-    if (inputCwd.startsWith(`${cwd}/`)) {
-      prefix = `${inputCwd.substring(cwd.length + 1)}/`;
-    }
+    const prefix = path.relative(inputCwd, cwd);
 
     const patternList = Array.isArray(patterns) ? patterns : [patterns];
     return files

--- a/packages/expo-modules-autolinking/src/autolinking/__tests__/findModules-test.ts
+++ b/packages/expo-modules-autolinking/src/autolinking/__tests__/findModules-test.ts
@@ -14,64 +14,239 @@ jest.mock('fs-extra');
 
 // mock findUp.sync to fix `mergeLinkingOptions` package.json resolution when requiring `findModules`.
 (findUp.sync as jest.MockedFunction<any>).mockReturnValueOnce(path.join(expoRoot, 'package.json'));
+const mockProjectPackageJsonPath = jest.fn();
+jest.mock('../mergeLinkingOptions', () => {
+  const actualModule = jest.requireActual('../mergeLinkingOptions');
+  return {
+    ...actualModule,
+    get projectPackageJsonPath() {
+      return mockProjectPackageJsonPath();
+    },
+  };
+});
+
 const {
   findModulesAsync,
 }: { findModulesAsync: typeof findModulesAsyncType } = require('../findModules');
 
 describe(findModulesAsync, () => {
+  let globMockedPathMap: Record<string, string[]>;
+
   beforeEach(() => {
+    globMockedPathMap = {};
     (fs.realpath as jest.MockedFunction<any>).mockImplementation((path) => Promise.resolve(path));
   });
 
   afterEach(() => {
+    jest.resetModules();
     jest.resetAllMocks();
   });
 
-  function addMockedModule(name: string) {
-    const pkgDir = path.join('node_modules', name);
+  function addMockedModule(
+    name: string,
+    options: {
+      globCwd: string;
+      nodeModulesRoot?: string;
+      pkgVersion?: string;
+      pkgDependencies?: Record<string, string>;
+    }
+  ) {
+    const nodeModulesRoot = options.nodeModulesRoot ?? path.join(expoRoot, 'node_modules');
+    const pkgDir = path.join(nodeModulesRoot, name);
 
     // mock require() call to module's package.json
-    registerRequireMock(path.join(expoRoot, pkgDir, 'package.json'), {
+    registerRequireMock(path.join(pkgDir, 'package.json'), {
       name,
-      version: '0.0.1',
+      version: options.pkgVersion ?? '0.0.1',
+      dependencies: options.pkgDependencies ?? {},
     });
 
+    // mock glob call to return expo-module.config.json
+    if (!globMockedPathMap[options.globCwd]) {
+      globMockedPathMap[options.globCwd] = [];
+    }
+    globMockedPathMap[options.globCwd].push(`${name}/expo-module.config.json`);
+    registerGlobMock(glob, globMockedPathMap[options.globCwd], options.globCwd);
+
     // mock require() call to module's expo-module.config.json
-    registerRequireMock(path.join(expoRoot, pkgDir, 'expo-module.config.json'), {
+    registerRequireMock(path.join(pkgDir, 'expo-module.config.json'), {
       platforms: ['ios'],
     });
   }
 
+  /**
+   * /app
+   *   └── /app/node_modules/react-native-third-party
+   */
   it('should link top level package', async () => {
     const searchPath = path.join(expoRoot, 'node_modules');
-    addMockedModule('react-native-third-party');
-
-    registerGlobMock(glob, ['react-native-third-party/expo-module.config.json'], searchPath);
+    addMockedModule('react-native-third-party', { globCwd: searchPath });
 
     const result = await findModulesAsync({
       searchPaths: [searchPath],
       platform: 'ios',
     });
-    expect(result['react-native-third-party']).not.toBeNull();
+    expect(result['react-native-third-party']).not.toBeUndefined();
   });
 
+  /**
+   * /app
+   *   ├── /app/node_modules/react-native-third-party
+   *   └── /app/node_modules/@expo/expo-test
+   */
   it('should link scoped level package', async () => {
     const searchPath = path.join(expoRoot, 'node_modules');
     const mockedModules = ['react-native-third-party', '@expo/expo-test'];
     for (const mockedModule of mockedModules) {
-      addMockedModule(mockedModule);
+      addMockedModule(mockedModule, { globCwd: searchPath });
     }
-
-    registerGlobMock(
-      glob,
-      mockedModules.map((module) => `${module}/expo-module.config.json`),
-      searchPath
-    );
 
     const result = await findModulesAsync({
       searchPaths: [searchPath],
       platform: 'ios',
     });
     expect(Object.keys(result).length).toBe(2);
+  });
+
+  /**
+   * /workspace
+   *   │ ╚══ /workspace/packages/app
+   *   │
+   *   └── /workspace/node_modules/pkg
+   */
+  [
+    'should link hoisted package in workspace',
+    'should not link hoisted package which are not in app project dependencies',
+  ].forEach((testCaseName) => {
+    it(testCaseName, async () => {
+      const isNegativeTest = testCaseName.search('not');
+      const appPackageJsonPath = path.join(expoRoot, 'packages', 'app', 'package.json');
+      const appNodeModules = path.join(expoRoot, 'packages', 'app', 'node_modules');
+
+      // mock app project package.json
+      const appDependencies = isNegativeTest ? {} : { pkg: '*' };
+      mockProjectPackageJsonPath.mockReturnValue(appPackageJsonPath);
+      registerRequireMock(appPackageJsonPath, {
+        name: 'app',
+        version: '0.0.1',
+        dependencies: appDependencies,
+      });
+
+      // add mocked pkg
+      const workspaceNodeModules = path.join(expoRoot, 'node_modules');
+      const searchPaths = [appNodeModules, workspaceNodeModules];
+      addMockedModule('pkg', {
+        globCwd: workspaceNodeModules,
+        nodeModulesRoot: workspaceNodeModules,
+      });
+
+      const result = await findModulesAsync({
+        searchPaths,
+        platform: 'ios',
+      });
+      if (isNegativeTest) {
+        expect(result['pkg']).toBeUndefined();
+      } else {
+        expect(result['pkg']).not.toBeUndefined();
+      }
+    });
+  });
+
+  /**
+   * /workspace
+   *   │ ╚══ /workspace/packages/app
+   *   │
+   *   ├── /workspace/node_modules/dep-pkg
+   *   └── /workspace/node_modules/pkg
+   */
+  [
+    'should link packages which are in app project transitive dependencies',
+    'should not link packages which are not in app project transitive dependencies',
+  ].forEach((testCaseName) => {
+    it(testCaseName, async () => {
+      const isNegativeTest = testCaseName.search('not');
+      const appPackageJsonPath = path.join(expoRoot, 'packages', 'app', 'package.json');
+      const appNodeModules = path.join(expoRoot, 'packages', 'app', 'node_modules');
+
+      // mock app project package.json
+
+      const appDependencies = isNegativeTest ? {} : { 'dpk-pkg': '*' };
+      mockProjectPackageJsonPath.mockReturnValue(appPackageJsonPath);
+      registerRequireMock(appPackageJsonPath, {
+        name: 'app',
+        version: '0.0.1',
+        dependencies: appDependencies,
+      });
+
+      // add mocked pkgs
+      const workspaceNodeModules = path.join(expoRoot, 'node_modules');
+      const searchPaths = [appNodeModules, workspaceNodeModules];
+      addMockedModule('pkg', {
+        globCwd: workspaceNodeModules,
+        nodeModulesRoot: workspaceNodeModules,
+        pkgVersion: '0.0.0',
+      });
+      addMockedModule('dep-pkg', {
+        globCwd: workspaceNodeModules,
+        nodeModulesRoot: workspaceNodeModules,
+        pkgVersion: '0.0.1',
+        pkgDependencies: {
+          pkg: '*',
+        },
+      });
+
+      const result = await findModulesAsync({
+        searchPaths,
+        platform: 'ios',
+      });
+      if (isNegativeTest) {
+        expect(result['pkg']).toBeUndefined();
+      } else {
+        expect(result['pkg']).not.toBeUndefined();
+      }
+    });
+  });
+
+  /**
+   * /workspace
+   *   │ ╚══ /workspace/packages/app
+   *   │       └── /workspace/packages/app/node_modules/pkg@1.0.0
+   *   │
+   *   └── /workspace/node_modules/pkg@0.0.0
+   */
+  it('should link non-hoisted package first if there are multiple versions', async () => {
+    const appPackageJsonPath = path.join(expoRoot, 'packages', 'app', 'package.json');
+    const appNodeModules = path.join(expoRoot, 'packages', 'app', 'node_modules');
+
+    // mock app project package.json
+    mockProjectPackageJsonPath.mockReturnValue(appPackageJsonPath);
+    registerRequireMock(appPackageJsonPath, {
+      name: 'app',
+      version: '0.0.1',
+      dependencies: {
+        pkg: '1.0.0',
+      },
+    });
+
+    // add mocked pkgs
+    const workspaceNodeModules = path.join(expoRoot, 'node_modules');
+    const searchPaths = [appNodeModules, workspaceNodeModules];
+    addMockedModule('pkg', {
+      globCwd: workspaceNodeModules,
+      nodeModulesRoot: workspaceNodeModules,
+      pkgVersion: '0.0.0',
+    });
+    addMockedModule('pkg', {
+      globCwd: appNodeModules,
+      nodeModulesRoot: appNodeModules,
+      pkgVersion: '1.0.0',
+    });
+
+    const result = await findModulesAsync({
+      searchPaths,
+      platform: 'ios',
+    });
+    expect(result['pkg']).not.toBeUndefined();
+    expect(result['pkg'].version).toEqual('1.0.0');
   });
 });


### PR DESCRIPTION
# Why

it's not clear how the transitive packages are linked in expo-modules-autolinking

# How

add some unit tests for `findModulesAsync`. hopefully to increase test coverage as well as write down use cases we supported.

# Test Plan

```
 PASS  src/autolinking/__tests__/findModules-test.ts
  findModulesAsync
    ✓ should link hoisted package in workspace (1 ms)
    ✓ should not link hoisted package which are not in app project dependencies
    ✓ should link packages which are in app project transitive dependencies (1 ms)
    ✓ should not link packages which are not in app project transitive dependencies (1 ms)
    ✓ should link non-hoisted package first if there are multiple versions
```

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
