### PR TITLE
[autolinking] Fix for custom iOS build configuration types

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -12,7 +12,7 @@
 ### 🐛 Bug fixes
 
 - Fix debug-only modules weren't installed if the `DEBUG` flag wasn't present in `OTHER_SWIFT_FLAGS`. ([#17383](https://github.com/expo/expo/pull/17383) by [@lukmccall](https://github.com/lukmccall))
-- Fix ios build if project config name is other than RELEASE or DEBUG ([#17439](https://github.com/expo/expo/pull/17439) by [@uloco](https://github.com/uloco))
+- Fix iOS build if project config name is other than RELEASE or DEBUG ([#17439](https://github.com/expo/expo/pull/17439) by [@uloco](https://github.com/uloco))
 
 ### 💡 Others
 

--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### 🐛 Bug fixes
 
 - Fix debug-only modules weren't installed if the `DEBUG` flag wasn't present in `OTHER_SWIFT_FLAGS`. ([#17383](https://github.com/expo/expo/pull/17383) by [@lukmccall](https://github.com/lukmccall))
+- Fix ios build if project config name is other than RELEASE or DEBUG ([#17439](https://github.com/expo/expo/pull/17439) by [@uloco](https://github.com/uloco))
 
 ### 💡 Others
 

--- a/packages/expo-modules-autolinking/scripts/ios/project_integrator.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/project_integrator.rb
@@ -105,7 +105,6 @@ module Expo
     def self.set_autolinking_configuration(project)
       project.native_targets.each do |native_target|
         native_target.build_configurations.each do |build_configuration|
-
           configuration_flag = "-D #{CONFIGURATION_FLAG_PREFIX}#{build_configuration.debug? ? "DEBUG" : "RELEASE"}"          
           build_settings = build_configuration.build_settings
 

--- a/packages/expo-modules-autolinking/scripts/ios/project_integrator.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/project_integrator.rb
@@ -105,12 +105,8 @@ module Expo
     def self.set_autolinking_configuration(project)
       project.native_targets.each do |native_target|
         native_target.build_configurations.each do |build_configuration|
-          if build_configuration.name.upcase.include? "RELEASE"
-            build_variant = "RELEASE"
-          else
-            build_variant = "DEBUG"
-          end
-          configuration_flag = "-D #{CONFIGURATION_FLAG_PREFIX}#{build_variant}"
+
+          configuration_flag = "-D #{CONFIGURATION_FLAG_PREFIX}#{build_configuration.debug? ? "DEBUG" : "RELEASE"}"          
           build_settings = build_configuration.build_settings
 
           # For some targets it might be `nil` by default which is an equivalent to `$(inherited)`

--- a/packages/expo-modules-autolinking/scripts/ios/project_integrator.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/project_integrator.rb
@@ -105,7 +105,12 @@ module Expo
     def self.set_autolinking_configuration(project)
       project.native_targets.each do |native_target|
         native_target.build_configurations.each do |build_configuration|
-          configuration_flag = "-D #{CONFIGURATION_FLAG_PREFIX}#{build_configuration.name.upcase}"
+          if build_configuration.name.upcase.include? "RELEASE"
+            build_variant = "RELEASE"
+          else
+            build_variant = "DEBUG"
+          end
+          configuration_flag = "-D #{CONFIGURATION_FLAG_PREFIX}#{build_variant}"
           build_settings = build_configuration.build_settings
 
           # For some targets it might be `nil` by default which is an equivalent to `$(inherited)`


### PR DESCRIPTION
# Why

The current expo version (45.0.2) does not build on iOS with custom build config names other than RELEASE and DEBUG.
See #17436 

# How

I first tried it with a patch and it seems to build again for custom build variants. Afterwards I added the changes here, since they are very small and backwards compatible. I did not check out the project locally and did the changes directly in GitHub. I used the strings "RELEASE" and "DEBUG" here, but there are probably some constant declarations for them somewhere in the project. This is my first contribution to this repo and if you need me more things to do please tell me so. :)

# Test Plan

Create a new project with custom build variants other than just DEBUG and RELEASE, for example `New.Release` in podfile.
The project should build fine after this change. Before it was broken.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

I don't know if this will affect anything here...

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
