### PR TITLE
[ci][test-suite] fix android test-suite failures

### DIFF
--- a/apps/bare-expo/e2e/jest.config.json
+++ b/apps/bare-expo/e2e/jest.config.json
@@ -1,6 +1,7 @@
 {
   "setupFilesAfterEnv": ["./setup/setupSockets.js", "./setup/setupDetox.js"],
   "testEnvironment": "node",
+  "testTimeout": 120000,
   "reporters": ["detox/runners/jest/streamlineReporter"],
   "testMatch": ["**/*-test.native.js"],
   "verbose": true


### PR DESCRIPTION
# Why

yet another attempt to fix occasionally ci test-suite android failures

# How

i download the error logs and screenshots. it looks the the test did success but detox timeout. the pr tried to increase jest test timeout which is just five seconds by default. the setting is also [officially recommended by detox](https://wix.github.io/Detox/docs/next/guide/jest/#e2econfigjson) 

# Test Plan

ci test-suite passed (i tried a couple times and it seems promising so far)
the ios test failed because cocoapods cdn issue.

