### PR TITLE
[expotool] add utility scripts for generate-bare-app

### DIFF
--- a/template-files/generate-bare-app/scripts/addPackages.js
+++ b/template-files/generate-bare-app/scripts/addPackages.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+function symlinkPackages(expoDirectory, projectDirectory, packageNames) {
+  const pkgJson = require(path.resolve(projectDirectory, './package.json'));
+  const symlinks = pkgJson.expo.symlinks;
+
+  packageNames.forEach((packageName) => {
+    if (!symlinks.includes(packageName)) {
+      symlinks.push(packageName);
+    }
+  });
+
+  symlinks.forEach((packageName) => {
+    const pathToPackage = path.resolve(expoDirectory, 'packages', packageName);
+
+    const nodeModulesPackage = path.resolve(projectDirectory, 'node_modules', packageName);
+
+    const pkg = require(path.resolve(pathToPackage, 'package.json'));
+    const version = pkg.version || '*';
+
+    pkgJson.dependencies[packageName] = version;
+
+    if (fs.existsSync(nodeModulesPackage)) {
+      fs.rmSync(nodeModulesPackage, { recursive: true });
+    }
+
+    fs.symlinkSync(pathToPackage, nodeModulesPackage);
+  });
+
+  fs.writeFileSync(
+    path.resolve(projectDirectory, './package.json'),
+    JSON.stringify(pkgJson, null, 2),
+    { encoding: 'utf-8' }
+  );
+
+  console.log('Symlinking packages complete');
+}
+
+const [expoDirectory, projectDirectory, ...packageNames] = process.argv.slice(2);
+symlinkPackages(expoDirectory, projectDirectory, packageNames);

--- a/template-files/generate-bare-app/scripts/removePackages.js
+++ b/template-files/generate-bare-app/scripts/removePackages.js
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+function removePackages(expoDirectory, projectDirectory, packagesToRemove) {
+  const pkgJson = require(path.resolve(projectDirectory, './package.json'));
+  const symlinks = pkgJson.expo.symlinks;
+  const nextSymlinks = [];
+
+  symlinks.forEach((packageName) => {
+    if (!packagesToRemove.includes(packageName)) {
+      nextSymlinks.push(packageName);
+    } else {
+      delete pkgJson.dependencies[packageName];
+
+      const nodeModulesPackage = path.resolve(projectDirectory, 'node_modules', packageName);
+
+      fs.rmSync(nodeModulesPackage, { recursive: true });
+    }
+  });
+
+  nextSymlinks.forEach((packageName) => {
+    const pathToPackage = path.resolve(expoDirectory, 'packages', packageName);
+
+    const nodeModulesPackage = path.resolve(projectDirectory, 'node_modules', packageName);
+
+    const pkg = require(path.resolve(pathToPackage, 'package.json'));
+    const version = pkg.version || '*';
+
+    pkgJson.dependencies[packageName] = version;
+
+    if (fs.existsSync(nodeModulesPackage)) {
+      fs.rmSync(nodeModulesPackage, { recursive: true });
+    }
+
+    fs.symlinkSync(pathToPackage, nodeModulesPackage);
+  });
+
+  pkgJson.expo.symlinks = nextSymlinks;
+
+  fs.writeFileSync(
+    path.resolve(projectDirectory, './package.json'),
+    JSON.stringify(pkgJson, null, 2),
+    { encoding: 'utf-8' }
+  );
+
+  console.log('Removing packages complete');
+}
+
+const [expoDirectory, projectDirectory, ...packageNames] = process.argv.slice(2);
+removePackages(expoDirectory, projectDirectory, packageNames);

--- a/tools/src/commands/GenerateBareApp.ts
+++ b/tools/src/commands/GenerateBareApp.ts
@@ -305,7 +305,7 @@ async function createScripts({ projectDir }) {
   pkgJson.scripts['ios'] = 'expo run:ios';
   pkgJson.scripts['android'] = 'expo run:android';
 
-  await fs.writeJSON(pkgJsonPath, pkgJson);
+  await fs.writeJSON(pkgJsonPath, pkgJson, { spaces: 2 });
 
   console.log('Added package scripts!');
 }

--- a/tools/src/commands/GenerateBareApp.ts
+++ b/tools/src/commands/GenerateBareApp.ts
@@ -280,26 +280,13 @@ async function createScripts({ projectDir }) {
   const scriptsDir = path.resolve(projectDir, 'scripts');
   await fs.mkdir(scriptsDir);
 
-  await fs.writeFile(
-    path.resolve(scriptsDir, 'addPackages.js'),
-    addPackagesScriptTemplate(projectDir),
-    {
-      encoding: 'utf-8',
-    }
-  );
-
-  await fs.writeFile(
-    path.resolve(scriptsDir, 'removePackages.js'),
-    removePackagesScriptTemplate(projectDir),
-    {
-      encoding: 'utf-8',
-    }
-  );
+  const scriptsToCopy = path.resolve(EXPO_DIR, 'template-files/generate-bare-app/scripts');
+  await fs.copy(scriptsToCopy, scriptsDir, { recursive: true });
 
   const pkgJsonPath = path.resolve(projectDir, 'package.json');
   const pkgJson = await fs.readJSON(pkgJsonPath);
-  pkgJson.scripts['package:add'] = 'node scripts/addPackages.js';
-  pkgJson.scripts['package:remove'] = 'node scripts/removePackages.js';
+  pkgJson.scripts['package:add'] = `node scripts/addPackages.js ${EXPO_DIR} ${projectDir}`;
+  pkgJson.scripts['package:remove'] = `node scripts/removePackages.js ${EXPO_DIR} ${projectDir}`;
   pkgJson.scripts['clean'] =
     'watchman watch-del-all &&  rm -fr $TMPDIR/metro-cache && rm $TMPDIR/haste-map-*';
   pkgJson.scripts['ios'] = 'expo run:ios';
@@ -309,123 +296,6 @@ async function createScripts({ projectDir }) {
 
   console.log('Added package scripts!');
 }
-
-const addPackagesScriptTemplate = (projectDir: string) => `#!/usr/bin/env node
-
-const path = require("path");
-const fs = require("fs");
-
-const expoDirectory = "${EXPO_DIR}";
-const projectDirectory = "${projectDir}";
-
-function symlinkPackages(packageNames) {
-  const pkgJson = require(path.resolve(projectDirectory, "./package.json"));
-  const symlinks = pkgJson.expo.symlinks;
-
-  packageNames.forEach((packageName) => {
-    if (!symlinks.includes(packageName)) {
-      symlinks.push(packageName);
-    }
-  });
-
-  symlinks.forEach((packageName) => {
-    const pathToPackage = path.resolve(expoDirectory, "packages", packageName);
-
-    const nodeModulesPackage = path.resolve(
-      projectDirectory,
-      "node_modules",
-      packageName
-    );
-
-    const pkg = require(path.resolve(pathToPackage, "package.json"));
-    const version = pkg.version || "*";
-
-    pkgJson.dependencies[packageName] = version;
-
-    if (fs.existsSync(nodeModulesPackage)) {
-      fs.rmSync(nodeModulesPackage, { recursive: true });
-    }
-
-    fs.symlinkSync(pathToPackage, nodeModulesPackage);
-  });
-
-  fs.writeFileSync(
-    path.resolve(projectDirectory, "./package.json"),
-    JSON.stringify(pkgJson, null, 2),
-    { encoding: "utf-8" }
-  );
-
-  console.log('Symlinking packages complete');
-}
-
-const packageNames = process.argv.slice(2);
-symlinkPackages(packageNames);
-`;
-
-const removePackagesScriptTemplate = (projectDir: string) => `#!/usr/bin/env node
-
-const path = require("path");
-const fs = require("fs");
-
-const expoDirectory = "${EXPO_DIR}";
-const projectDirectory = "${projectDir}";
-
-function removePackages(packagesToRemove) {
-  const pkgJson = require(path.resolve(projectDirectory, "./package.json"));
-  const symlinks = pkgJson.expo.symlinks;
-  const nextSymlinks = [];
-
-  symlinks.forEach((packageName) => {
-    if (!packagesToRemove.includes(packageName)) {
-      nextSymlinks.push(packageName);
-    } else {
-      delete pkgJson.dependencies[packageName];
-
-      const nodeModulesPackage = path.resolve(
-        projectDirectory,
-        "node_modules",
-        packageName
-      );
-
-      fs.rmSync(nodeModulesPackage, { recursive: true });
-    }
-  });
-
-  nextSymlinks.forEach((packageName) => {
-    const pathToPackage = path.resolve(expoDirectory, "packages", packageName);
-
-    const nodeModulesPackage = path.resolve(
-      projectDirectory,
-      "node_modules",
-      packageName
-    );
-
-    const pkg = require(path.resolve(pathToPackage, "package.json"));
-    const version = pkg.version || "*";
-
-    pkgJson.dependencies[packageName] = version;
-
-    if (fs.existsSync(nodeModulesPackage)) {
-      fs.rmSync(nodeModulesPackage, { recursive: true });
-    }
-
-    fs.symlinkSync(pathToPackage, nodeModulesPackage);
-  });
-
-  pkgJson.expo.symlinks = nextSymlinks;
-
-  fs.writeFileSync(
-    path.resolve(projectDirectory, "./package.json"),
-    JSON.stringify(pkgJson, null, 2),
-    { encoding: "utf-8" }
-  );
-
-  console.log('Removing packages complete');
-}
-
-const packageNames = process.argv.slice(2);
-removePackages(packageNames);
-`;
 
 export default (program: Command) => {
   program


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This PR adds a couple utility scripts to projects that are generated via the `generate-bare-app` expotool, namely simplifying adding and removing expo packages (symlinked packages) via npm scripts

Example:
`yarn package:add [...packageNames]`  will symlink any expo packages specified 
`yarn package:remove [...packageNames]` will remove any symlinked expo packages
 
# How

<!--
How did you build this feature or fix this bug and why?
-->

Used the `expo.symlinks` property in `package.json` as a reference for determining which packages in `node_modules` should be symlinked and wrote a couple node scripts that operate on this list


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

- `et generate-bare-app --name my-bare-app --outDir ~/tmp`
- `yarn package:add expo-checkbox`
- `yarn package:remove expo-checkbox` should remove the package
- `yarn ios` 

Should symlink the `expo-checkbox` package from your local `expo` repo

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
