### PR TITLE
[docs] Update Expo Module API docs

### DIFF
--- a/docs/pages/modules/module-api.md
+++ b/docs/pages/modules/module-api.md
@@ -134,14 +134,14 @@ Constants {
 
 ### `Function`
 
-Defines a native synchronous function that will be exported to JavaScript. Synchronous means that when the function is executed in JavaScript, its native code is run on the same thread and is blocking further execution of the script until the native function returns.
+Defines a native synchronous function that will be exported to JavaScript. Synchronous means that when the function is executed in JavaScript, its native code is run on the same thread and blocks further execution of the script until the native function returns.
 
 #### Arguments
 
 - **name**: `String` — Name of the function that you'll call from JavaScript.
 - **body**: `(args...) -> ReturnType` — The closure to run when the function is called.
 
-The function can receive up to 8 arguments. This is due to the limitations of generics in both Swift and Kotlin, because this component must be implemented separately for each number of arguments.
+The function can receive up to 8 arguments. This is due to the limitations of generics in both Swift and Kotlin, because this component must be implemented separately for each arity.
 
 <CodeBlocksTable>
 
@@ -172,7 +172,7 @@ function getMessage() {
 
 ### `AsyncFunction`
 
-Defines a JavaScript function that always returns a `Promise` and whose native code is by default dispatched on the different thread that the JavaScript runtime runs on.
+Defines a JavaScript function that always returns a `Promise` and whose native code is by default dispatched on the different thread than the JavaScript runtime runs on.
 
 #### Arguments
 
@@ -375,7 +375,7 @@ Fundamentally, only primitive and serializable data can be passed back and forth
 
 ### Convertibles
 
-_Convertibles_ are native types that can be initialized from certain specific kinds of data received from JavaScript. Such types are allowed to be used as an argument type in `Function`'s body. As a good example, when the `CGPoint` type is used as a function argument type, its instance can be created from an array of two numbers (_x_, _y_) or a JavaScript object with numeric `x` and `y` properties.
+_Convertibles_ are native types that can be initialized from certain specific kinds of data received from JavaScript. Such types are allowed to be used as an argument type in `Function`'s body. For example, when the `CGPoint` type is used as a function argument type, its instance can be created from an array of two numbers `(_x_, _y_)` or a JavaScript object with numeric `x` and `y` properties.
 
 Some common iOS types from `CoreGraphics` and `UIKit` system frameworks are already made convertible.
 

--- a/docs/pages/modules/module-api.md
+++ b/docs/pages/modules/module-api.md
@@ -55,17 +55,17 @@ class MyModule : Module() {
 
 ### 2. Set up module config
 
-Add your classes to iOS and/or Android `modulesClassNames` in the [module config](module-config).
+Add your classes to iOS and/or Android `modules` in the [module config](module-config).
 
 <CodeBlocksTable tabs={["expo-module.config.json"]}>
 
 ```json
 {
   "ios": {
-    "modulesClassNames": ["MyModule"]
+    "modules": ["MyModule"]
   },
   "android": {
-    "modulesClassNames": ["my.module.package.MyModule"]
+    "modules": ["my.module.package.MyModule"]
   }
 }
 ```
@@ -84,19 +84,19 @@ Now that the class is set up and linked, you can start to add functionality. The
 
 As you might have noticed in the snippets above, each module class must implement the `definition` function. The definition consists of components that describe the module's functionality and behavior.
 
-### `name`
+### `Name`
 
 Sets the name of the module that JavaScript code will use to refer to the module. Takes a string as an argument. Can be inferred from module's class name, but it's recommended to set it explicitly for clarity.
 
 <CodeBlocksTable tabs={["Swift / Kotlin"]}>
 
 ```swift
-name("MyModuleName")
+Name("MyModuleName")
 ```
 
 </CodeBlocksTable>
 
-### `constants`
+### `Constants`
 
 Sets constant properties on the module. Can take a dictionary or a closure that returns a dictionary.
 
@@ -104,12 +104,12 @@ Sets constant properties on the module. Can take a dictionary or a closure that 
 
 ```swift
 // Created from the dictionary
-constants([
+Constants([
   "PI": Double.pi
 ])
 
 // or returned by the closure
-constants {
+Constants {
   return [
     "PI": Double.pi
   ]
@@ -118,13 +118,13 @@ constants {
 
 ```kotlin
 // Passed as arguments
-constants(
+Constants(
   "PI" to kotlin.math.PI
 )
 
 // or returned by the closure
-constants {
-  return@constants mapOf(
+Constants {
+  return@Constants mapOf(
     "PI" to kotlin.math.PI
   )
 }
@@ -132,27 +132,66 @@ constants {
 
 </CodeBlocksTable>
 
-### `function`
+### `Function`
 
-Defines a native function that will be exported to JavaScript.
+Defines a native synchronous function that will be exported to JavaScript. Synchronous means that when the function is executed in JavaScript, its native code is run on the same thread and is blocking further execution of the script until the native function returns.
 
 #### Arguments
 
 - **name**: `String` — Name of the function that you'll call from JavaScript.
 - **body**: `(args...) -> ReturnType` — The closure to run when the function is called.
 
-All functions return a `Promise` to JavaScript and are asynchronous from the perspective of the JavaScript runtime. However, if the type of the last argument is `Promise`, the function is considered to be asynchronous on the native side and it will wait for the promise to be resolved or rejected before the response is passed back to JavaScript. Otherwise, the function is immediately resolved with the returned value or rejected if it throws an error. Note that this is different than synchronous/asynchronous calls in JavaScript — at this moment all functions are _asynchronous_ from the JavaScript perspective.
-
-The function can receive up to 8 arguments (including the promise). This is due to the limitations of generics in both Swift and Kotlin, because this component must be implemented separately for each number of arguments.
+The function can receive up to 8 arguments. This is due to the limitations of generics in both Swift and Kotlin, because this component must be implemented separately for each number of arguments.
 
 <CodeBlocksTable>
 
 ```swift
-function("syncFunction") { (message: String) in
+Function("syncFunction") { (message: String) in
   return message
 }
+```
 
-function("asyncFunction") { (message: String, promise: Promise) in
+```kotlin
+Function("syncFunction") { message: String ->
+  return@Function message
+}
+```
+
+```javascript
+import { requireNativeModule } from 'expo-modules-core';
+
+// Assume that we have named the module "MyModule"
+const MyModule = requireNativeModule('MyModule');
+
+function getMessage() {
+  return MyModule.syncFunction('bar');
+}
+```
+
+</CodeBlocksTable>
+
+### `AsyncFunction`
+
+Defines a JavaScript function that always returns a `Promise` and whose native code is by default dispatched on the different thread that the JavaScript runtime runs on.
+
+#### Arguments
+
+- **name**: `String` — Name of the function that you'll call from JavaScript.
+- **body**: `(args...) -> ReturnType` — The closure to run when the function is called.
+
+If the type of the last argument is `Promise`, the function will wait for the promise to be resolved or rejected before the response is passed back to JavaScript. Otherwise, the function is immediately resolved with the returned value or rejected if it throws an exception.
+The function can receive up to 8 arguments (including the promise).
+
+It is recommended to use `AsyncFunction` over `Function` when it:
+
+- does I/O bound tasks such as sending network requests or interacting with the file system
+- needs to be run on different thread, e.g. the main UI thread for UI-related tasks
+- is an extensive or long-lasting operation that would block the JavaScript thread which in turn would reduce the responsiveness of the application
+
+<CodeBlocksTable>
+
+```swift
+AsyncFunction("asyncFunction") { (message: String, promise: Promise) in
   DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
     promise.resolve(message)
   }
@@ -160,11 +199,7 @@ function("asyncFunction") { (message: String, promise: Promise) in
 ```
 
 ```kotlin
-function("syncFunction") { message: String ->
-  return@function message
-}
-
-function("asyncFunction") { message: String, promise: Promise ->
+AsyncFunction("asyncFunction") { message: String, promise: Promise ->
   launch(Dispatchers.Main) {
     promise.resolve(message)
   }
@@ -172,39 +207,35 @@ function("asyncFunction") { message: String, promise: Promise ->
 ```
 
 ```javascript
-import { NativeModulesProxy } from 'expo-modules-core';
+import { requireNativeModule } from 'expo-modules-core';
 
 // Assume that we have named the module "MyModule"
-const { MyModule } = NativeModulesProxy;
+const MyModule = requireNativeModule('MyModule');
 
-async function getMessage() {
-  // Functions that are synchronous on the native side are still asynchronous to
-  // JavaScript and return a promise
-  const message = await MyModule.syncFunction('foo');
-  const otherMessage = await MyModule.asyncFunction('bar');
-  console.log(`${message} ${otherMessage}); // foo bar
+async function getMessageAsync() {
+  return await MyModule.asyncFunction('bar');
 }
 ```
 
 </CodeBlocksTable>
 
-### `events`
+### `Events`
 
 Defines event names that the module can send to JavaScript.
 
 <CodeBlocksTable>
 
 ```swift
-events("onCameraReady", "onPictureSaved", "onBarCodeScanned")
+Events("onCameraReady", "onPictureSaved", "onBarCodeScanned")
 ```
 
 ```kotlin
-events("onCameraReady", "onPictureSaved", "onBarCodeScanned")
+Events("onCameraReady", "onPictureSaved", "onBarCodeScanned")
 ```
 
 </CodeBlocksTable>
 
-### `view`
+### `View`
 
 Defines the factory creating a native view, when the module is used as a view.
 On Android, the factory function also receives [Android Context](https://developer.android.com/reference/android/content/Context) which is required to create any view.
@@ -212,20 +243,20 @@ On Android, the factory function also receives [Android Context](https://develop
 <CodeBlocksTable>
 
 ```swift
-view {
+View {
   UITextView()
 }
 ```
 
 ```kotlin
-view { context ->
+View { context ->
   TextView(context)
 }
 ```
 
 </CodeBlocksTable>
 
-### `prop`
+### `Prop`
 
 Defines a setter for the view prop of given name.
 
@@ -234,18 +265,18 @@ Defines a setter for the view prop of given name.
 - **name**: `String` — Name of view prop that you want to define a setter.
 - **setter**: `(view: ViewType, value: ValueType) -> ()` — Closure that is invoked when the view rerenders.
 
-This property can only be used within a [`viewManager`](#viewmanager) closure.
+This property can only be used within a [`ViewManager`](#viewmanager) closure.
 
 <CodeBlocksTable>
 
 ```swift
-prop("background") { (view: UIView, color: UIColor) in
+Prop("background") { (view: UIView, color: UIColor) in
   view.backgroundColor = color
 }
 ```
 
 ```kotlin
-prop("background") { view: View, @ColorInt color: Int ->
+Prop("background") { view: View, @ColorInt color: Int ->
   view.setBackgroundColor(color)
 }
 ```
@@ -254,31 +285,31 @@ prop("background") { view: View, @ColorInt color: Int ->
 
 > Note: Props of function type (callbacks) are not supported yet.
 
-### `viewManager`
+### `ViewManager`
 
-Enables the module to be used as a view manager. The view manager definition is built from the definition components used in the closure passed to `viewManager`. Definition components that are accepted as part of the view manager definition: [`view`](#view), [`prop`](#prop).
+Enables the module to be used as a view manager. The view manager definition is built from the definition components used in the closure passed to `viewManager`. Definition components that are accepted as part of the view manager definition: [`View`](#view), [`Prop`](#prop).
 
 <CodeBlocksTable>
 
 ```swift
-viewManager {
-  view {
+ViewManager {
+  View {
     UIView()
   }
 
-  prop("isHidden") { (view: UIView, hidden: Bool) in
+  Prop("isHidden") { (view: UIView, hidden: Bool) in
     view.isHidden = hidden
   }
 }
 ```
 
 ```kotlin
-viewManager {
-  view { context ->
+ViewManager {
+  View { context ->
     View(context)
   }
 
-  prop("isHidden") { view: View, hidden: Bool ->
+  Prop("isHidden") { view: View, hidden: Bool ->
     view.isVisible = !hidden
   }
 }
@@ -286,57 +317,57 @@ viewManager {
 
 </CodeBlocksTable>
 
-### `onCreate`
+### `OnCreate`
 
 Defines module's lifecycle listener that is called right after module initialization. If you need to set up something when the module gets initialized, use this instead of module's class initializer.
 
-### `onDestroy`
+### `OnDestroy`
 
 Defines module's lifecycle listener that is called when the module is about to be deallocated. Use it instead of module's class destructor.
 
-### `onStartObserving`
+### `OnStartObserving`
 
 Defines the function that is invoked when the first event listener is added.
 
-### `onStopObserving`
+### `OnStopObserving`
 
 Defines the function that is invoked when all event listeners are removed.
 
-### `onAppContextDestroys`
+### `OnAppContextDestroys`
 
 Defines module's lifecycle listener that is called when the app context owning the module is about to be deallocated.
 
-### `onAppEntersForeground` 🍏
+### `OnAppEntersForeground` 🍏
 
 Defines the listener that is called when the app is about to enter the foreground mode.
 
-> Note: This function is not available on Android — you may want to use [`onActivityEntersForeground`](#onactivityentersforeground--) instead.
+> Note: This function is not available on Android — you may want to use [`OnActivityEntersForeground`](#onactivityentersforeground--) instead.
 
-### `onAppEntersBackground` 🍏
+### `OnAppEntersBackground` 🍏
 
 Defines the listener that is called when the app enters the background mode.
 
-> Note: This function is not available on Android — you may want to use [`onActivityEntersBackground`](#onactivityentersbackground--) instead.
+> Note: This function is not available on Android — you may want to use [`OnActivityEntersBackground`](#onactivityentersbackground--) instead.
 
-### `onAppBecomesActive` 🍏
+### `OnAppBecomesActive` 🍏
 
-Defines the listener that is called when the app becomes active again (after `onAppEntersForeground`).
+Defines the listener that is called when the app becomes active again (after `OnAppEntersForeground`).
 
-> Note: This function is not available on Android — you may want to use [`onActivityEntersForeground`](#onactivityentersforeground--) instead.
+> Note: This function is not available on Android — you may want to use [`OnActivityEntersForeground`](#onactivityentersforeground--) instead.
 
-### `onActivityEntersForeground` 🤖
+### `OnActivityEntersForeground` 🤖
 
-> Note: This function is not available on iOS — you may want to use [`onAppEntersForeground`](#onappentersforeground--) instead.
+> Note: This function is not available on iOS — you may want to use [`OnAppEntersForeground`](#onappentersforeground--) instead.
 
-### `onActivityEntersBackground` 🤖
+### `OnActivityEntersBackground` 🤖
 
-> Note: This function is not available on iOS — you may want to use [`onAppEntersBackground`](#onappentersbackground--) instead.
+> Note: This function is not available on iOS — you may want to use [`OnAppEntersBackground`](#onappentersbackground--) instead.
 
-### `onActivityDestroys` 🤖
+### `OnActivityDestroys` 🤖
 
 Defines the listener that is called when the activity owning the JavaScript context is about to be destroyed.
 
-> Note: This function is not available on iOS — you may want to use [`onAppEntersBackground`](#onappentersbackground--) instead.
+> Note: This function is not available on iOS — you may want to use [`OnAppEntersBackground`](#onappentersbackground--) instead.
 
 ## Argument Types
 
@@ -344,7 +375,7 @@ Fundamentally, only primitive and serializable data can be passed back and forth
 
 ### Convertibles
 
-_Convertibles_ are native types that can be initialized from certain specific kinds of data received from JavaScript. Such types are allowed to be used as an argument type in `function`'s body. As a good example, when the `CGPoint` type is used as a function argument type, its instance can be created from an array of two numbers (_x_, _y_) or a JavaScript object with numeric `x` and `y` properties.
+_Convertibles_ are native types that can be initialized from certain specific kinds of data received from JavaScript. Such types are allowed to be used as an argument type in `Function`'s body. As a good example, when the `CGPoint` type is used as a function argument type, its instance can be created from an array of two numbers (_x_, _y_) or a JavaScript object with numeric `x` and `y` properties.
 
 Some common iOS types from `CoreGraphics` and `UIKit` system frameworks are already made convertible.
 
@@ -378,7 +409,7 @@ struct FileReadOptions: Record {
 }
 
 // Now this record can be used as an argument of the functions or the view prop setters.
-function("readFile") { (path: String, options: FileReadOptions) -> String in
+Function("readFile") { (path: String, options: FileReadOptions) -> String in
   // Read the file using given `options`
 }
 ```
@@ -396,7 +427,7 @@ class FileReadOptions : Record {
 }
 
 // Now this record can be used as an argument of the functions or the view prop setters.
-function("readFile") { path: String, options: FileReadOptions ->
+Function("readFile") { path: String, options: FileReadOptions ->
   // Read the file using given `options`
 }
 ```
@@ -445,9 +476,9 @@ class FileReadOptions : Record {
 ```swift
 public class MyModule: Module {
   public func definition() -> ModuleDefinition {
-    name("MyFirstExpoModule")
+    Name("MyFirstExpoModule")
 
-    function("hello") { (name: String) in
+    Function("hello") { (name: String) in
       return "Hello \(name)!"
     }
   }
@@ -457,9 +488,9 @@ public class MyModule: Module {
 ```kotlin
 class MyModule : Module() {
   override fun definition() = ModuleDefinition {
-    name("MyFirstExpoModule")
+    Name("MyFirstExpoModule")
 
-    function("hello") { name: String ->
+    Function("hello") { name: String ->
       return "Hello $name!"
     }
   }

--- a/docs/pages/modules/module-config.md
+++ b/docs/pages/modules/module-config.md
@@ -6,7 +6,7 @@ Expo modules are configured in **expo-module.config.json**. This file currently 
 
 - `platforms` — An array of supported platforms.
 - `ios` — Config with options specific to iOS platform
-  - `modulesClassNames` — Names of Swift native modules classes to put to the generated modules provider file.
+  - `modules` — Names of Swift native modules classes to put to the generated modules provider file.
   - `appDelegateSubscribers` — Names of Swift classes that hooks into `ExpoAppDelegate` to receive AppDelegate life-cycle events.
 - `android` — Config with options specific to Android platform
-  - `modulesClassNames` — Full names (package + class name) of Kotlin native modules classes to put to the generated package provider file.
+  - `modules` — Full names (package + class name) of Kotlin native modules classes to put to the generated package provider file.


### PR DESCRIPTION
# Why

Things have changed in SDK45

# How

- Renamed Expo Module config property `modulesClassNames` to `modules`
- Renamed definition components to start with the uppercase letter
- Added `AsyncFunction` component
- Updated JS examples to use `requireNativeModule` instead of `NativeModulesProxy`

# Test Plan

Tested locally that it renders well