### PR TITLE
fix: correct required packages in prebuild

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -17,7 +17,7 @@
 - add missing `--platform` flag to `export` command. ([#17338](https://github.com/expo/expo/pull/17338) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix ADB device name filtering for windows. ([#17286](https://github.com/expo/expo/pull/17286) by [@byCedric](https://github.com/byCedric))
 - Fix `export` bug failing when no assets are included. ([#17414](https://github.com/expo/expo/pull/17414) by [@EvanBacon](https://github.com/EvanBacon))
-- Add correct packages (`expo-splash-screen`) and drop incorrect required packages (`react-native-unimodules`, `expo-updates`) in prebuild.
+- Add correct packages (`expo-splash-screen`) and drop incorrect required packages (`react-native-unimodules`, `expo-updates`) in prebuild. ([#17447](https://github.com/expo/expo/pull/17447) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -17,6 +17,7 @@
 - add missing `--platform` flag to `export` command. ([#17338](https://github.com/expo/expo/pull/17338) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix ADB device name filtering for windows. ([#17286](https://github.com/expo/expo/pull/17286) by [@byCedric](https://github.com/byCedric))
 - Fix `export` bug failing when no assets are included. ([#17414](https://github.com/expo/expo/pull/17414) by [@EvanBacon](https://github.com/EvanBacon))
+- Add correct packages (`expo-splash-screen`) and drop incorrect required packages (`react-native-unimodules`, `expo-updates`) in prebuild.
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/prebuild/updatePackageJson.ts
+++ b/packages/@expo/cli/src/prebuild/updatePackageJson.ts
@@ -21,7 +21,7 @@ export type DependenciesModificationResults = {
   hasNewDevDependencies: boolean;
 };
 
-/** Modifies the `package.json` with `_modifyPackageJson` and format/displays the results. */
+/** Modifies the `package.json` with `modifyPackageJson` and format/displays the results. */
 export async function updatePackageJSONAsync(
   projectRoot: string,
   {
@@ -40,7 +40,7 @@ export async function updatePackageJSONAsync(
 
   const templatePkg = getPackageJson(templateDirectory);
 
-  const results = _modifyPackageJson(projectRoot, {
+  const results = modifyPackageJson(projectRoot, {
     templatePkg,
     pkg,
     skipDependencyUpdate,
@@ -81,7 +81,7 @@ export async function updatePackageJSONAsync(
  * @param props.skipDependencyUpdate Array of dependencies to skip updating.
  * @returns
  */
-function _modifyPackageJson(
+function modifyPackageJson(
   projectRoot: string,
   {
     templatePkg,
@@ -143,12 +143,9 @@ export function updatePkgDependencies(
     ...pkg.dependencies,
   });
 
-  const requiredDependencies = [
-    'react',
-    'react-native-unimodules',
-    'react-native',
-    'expo-updates',
-  ].filter((depKey) => !!defaultDependencies[depKey]);
+  const requiredDependencies = ['expo', 'expo-splash-screen', 'react', 'react-native'].filter(
+    (depKey) => !!defaultDependencies[depKey]
+  );
 
   const symlinkedPackages: string[] = [];
 


### PR DESCRIPTION
# Why

- `react-native-unimodules` and `expo-updates` are not required for prebuild.
- `expo-splash-screen` is required.