### PR TITLE
[docs] EAS Build - update info about default images

### DIFF
--- a/docs/pages/build-reference/infrastructure.md
+++ b/docs/pages/build-reference/infrastructure.md
@@ -17,8 +17,7 @@ When selecting an image for the build you can use the full name provided below o
 
 > **Note:**
 >
-> - If you have a bare workflow project: your build is going to use the `default` image unless you provide `image` in **eas.json**.
-> - If you have a managed workflow project: your build is going to use an automatically chosen image, unless you provide `image` in **eas.json**.
+> If you do not provide `image` in **eas.json** your build is going to use `default` image, but in some cases, we are selecting a more appropriate image based on SDK version or react-native version. You can check what image is used for a build in the "Spin up build environment" build logs section.
 
 ## Android build server configurations
 

--- a/docs/pages/build-reference/infrastructure.md
+++ b/docs/pages/build-reference/infrastructure.md
@@ -17,7 +17,7 @@ When selecting an image for the build you can use the full name provided below o
 
 > **Note:**
 >
-> If you do not provide `image` in **eas.json** your build is going to use `default` image, but in some cases, we are selecting a more appropriate image based on SDK version or react-native version. You can check what image is used for a build in the "Spin up build environment" build logs section.
+> If you do not provide `image` in **eas.json**, your build will use `default` image. However, in some cases, we select a more appropriate image based on the Expo SDK version or React Native version. You can check what image is used for a build in the "Spin up build environment" build logs section.
 
 ## Android build server configurations
 

--- a/docs/pages/build-reference/infrastructure.md
+++ b/docs/pages/build-reference/infrastructure.md
@@ -132,6 +132,7 @@ When selecting an image for the build you can use the full name provided below o
 - Xcode 13.3.1 (13E500a)
 - Node.js 16.13.2
 - Yarn 1.22.17
+- pnpm 7.0.0
 - npm 8.1.2
 - fastlane 2.205.2
 - CocoaPods 1.11.3
@@ -147,6 +148,7 @@ When selecting an image for the build you can use the full name provided below o
 - Xcode 13.2.1 (13C100)
 - Node.js 16.13.2
 - Yarn 1.22.17
+- pnpm 7.0.0
 - npm 8.1.2
 - fastlane 2.201.0
 - CocoaPods 1.11.2
@@ -162,6 +164,7 @@ When selecting an image for the build you can use the full name provided below o
 - Xcode 13.0 (13A233)
 - Node.js 16.13.2
 - Yarn 1.22.17
+- pnpm 7.0.0
 - npm 8.1.2
 - fastlane 2.185.1
 - CocoaPods 1.10.1
@@ -177,6 +180,7 @@ When selecting an image for the build you can use the full name provided below o
 - Xcode 12.5 (12E5244e)
 - Node.js 16.13.2
 - Yarn 1.22.17
+- pnpm 7.0.0
 - npm 8.1.2
 - fastlane 2.185.1
 - CocoaPods 1.10.1

--- a/docs/pages/build-reference/infrastructure.md
+++ b/docs/pages/build-reference/infrastructure.md
@@ -124,7 +124,7 @@ When selecting an image for the build you can use the full name provided below o
   enableImmutableInstalls: false
   ```
 
-#### Image `macos-monterey-12.3-xcode-13.3` (alias `latest`)
+#### Image `macos-monterey-12.3-xcode-13.3` (alias `default', `latest`)
 
 <details><summary>Details</summary>
 
@@ -154,7 +154,7 @@ When selecting an image for the build you can use the full name provided below o
 
 </details>
 
-#### Image `macos-big-sur-11.4-xcode-13.0` (alias `default`)
+#### Image `macos-big-sur-11.4-xcode-13.0`
 
 <details><summary>Details</summary>
 


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-4142/update-build-infrastructure-page-to-indicate-how-image-is-selected
https://linear.app/expo/issue/ENG-4924/switch-default-image-to-xcode-133

# How

We are always trying to make default images to work out of a box as a result selecting default image is a bit complicated so I decided to provide some generic info that we automatically detect what image is best

The current process of selecting an image is using
- for managed ios - specific image per SDK
- for all android builds - based on react-native version (0.68 uses jdk 11)

# Test Plan



# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
