### PR TITLE
[docs] fix CodeBlockTable appearance on Windows

### DIFF
--- a/docs/components/plugins/CodeBlocksTable.tsx
+++ b/docs/components/plugins/CodeBlocksTable.tsx
@@ -16,24 +16,24 @@ const CodeSamplesCSS = css`
   display: flex;
   flex-direction: row;
   max-width: 100%;
-  margin: 20px 0px;
+  margin: 20px 0;
 
   .code-block-column {
     display: flex;
     flex-direction: column;
     flex: 1;
     margin-right: -1px;
-    min-width: 0px;
+    min-width: 0;
 
     pre {
-      border-top-left-radius: 0px;
-      border-top-right-radius: 0px;
+      border-top-left-radius: 0;
+      border-top-right-radius: 0;
     }
     &:not(:first-child) pre {
-      border-bottom-left-radius: 0px;
+      border-bottom-left-radius: 0;
     }
     &:not(:last-child) pre {
-      border-bottom-right-radius: 0px;
+      border-bottom-right-radius: 0;
     }
     &:first-child .code-block-header {
       border-top-left-radius: 4px;
@@ -49,18 +49,32 @@ const CodeSamplesCSS = css`
     border-bottom-width: 0px;
 
     span {
+      ${typography.fontSizes[15]}
       color: ${theme.text.default};
       font-family: ${typography.fontFaces.mono};
-      font-size: 15px;
     }
   }
   .code-block-content {
     flex: 1;
-    overflow-x: scroll;
+    overflow-x: auto;
 
     pre {
       height: 100%;
-      margin: 0px;
+      margin: 0;
+
+      ::-webkit-scrollbar {
+        height: 6px;
+      }
+      ::-webkit-scrollbar-track {
+        background: ${theme.background.secondary};
+      }
+      ::-webkit-scrollbar-thumb {
+        background: ${theme.background.tertiary};
+        border-radius: 10px;
+      }
+      ::-webkit-scrollbar-thumb:hover {
+        background: ${theme.background.quaternary};
+      }
     }
   }
 `;


### PR DESCRIPTION
# Why & how

This small PR fixes the appearance of `CodeBlockTable` component on Windows.

I have also tweaked the the header typography a bit.

# Test Plan

The changes have been tested and verified by running docs website locally and then accessing it from macOS and Windows machines.

# Preview

### Before
<img width="863" alt="Screenshot 2022-05-11 114234" src="https://user-images.githubusercontent.com/719641/167822076-b1587d20-35e5-4ca5-9f22-7803026ce3fb.png">

### After
<img width="862" alt="Screenshot 2022-05-11 114403" src="https://user-images.githubusercontent.com/719641/167822123-4ef480ad-303e-487f-b78d-33dfd093fdaa.png">

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
