### PR TITLE
[ios] Add implementation of the native logger

### DIFF
--- a/packages/expo-modules-core/ios/Swift/Exceptions/CodedError.swift
+++ b/packages/expo-modules-core/ios/Swift/Exceptions/CodedError.swift
@@ -3,7 +3,7 @@ import Foundation
 /**
  A protocol for errors specyfing its `code` and providing the `description`.
  */
-public protocol CodedError: Error {
+public protocol CodedError: Error, CustomStringConvertible {
   var code: String { get }
   var description: String { get }
 }

--- a/packages/expo-modules-core/ios/Swift/Logging/LogHandlers.swift
+++ b/packages/expo-modules-core/ios/Swift/Logging/LogHandlers.swift
@@ -1,0 +1,39 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+import os.log
+
+/**
+ The protocol that needs to be implemented by log handlers.
+ */
+internal protocol LogHandler {
+  init(category: String)
+
+  func log(type: LogType, _ message: String)
+}
+
+/**
+ The log handler that uses the new `os.Logger` API.
+ */
+@available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+internal class OSLogHandler: LogHandler {
+  private let osLogger: os.Logger
+
+  required init(category: String) {
+    osLogger = os.Logger(subsystem: "dev.expo.modules", category: category)
+  }
+
+  func log(type: LogType, _ message: String) {
+    osLogger.log(level: type.toOSLogType(), "\(message)")
+  }
+}
+
+/**
+ Simple log handler that forwards all logs to `print` function.
+ */
+internal class PrintLogHandler: LogHandler {
+  required init(category: String) {}
+
+  func log(type: LogType, _ message: String) {
+    print(message)
+  }
+}

--- a/packages/expo-modules-core/ios/Swift/Logging/LogType.swift
+++ b/packages/expo-modules-core/ios/Swift/Logging/LogType.swift
@@ -16,7 +16,7 @@ public enum LogType: Int {
   case fatal = 7
 
   /**
-   The string used to prefix the messages of this log type.
+   The string that is used to prefix the messages of this log type.
    Logs in Xcode and Console apps are always with the white text,
    so we use colored circle emojis to distinguish different types of logs.
    */

--- a/packages/expo-modules-core/ios/Swift/Logging/LogType.swift
+++ b/packages/expo-modules-core/ios/Swift/Logging/LogType.swift
@@ -1,0 +1,62 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+import os.log
+
+/**
+ An enum with available log types.
+ */
+public enum LogType: Int {
+  case trace = 0
+  case timer = 1
+  case stacktrace = 2
+  case debug = 3
+  case info = 4
+  case warn = 5
+  case error = 6
+  case fatal = 7
+
+  /**
+   The string used to prefix the messages of this log type.
+   Logs in Xcode and Console apps are always with the white text,
+   so we use colored circle emojis to distinguish different types of logs.
+   */
+  var prefix: String {
+    switch self {
+    case .trace:
+      return "⚪️"
+    case .timer:
+      return "🟤"
+    case .stacktrace:
+      return "🟣"
+    case .debug:
+      return "🔵"
+    case .info:
+      return "🟢"
+    case .warn:
+      return "🟡"
+    case .error:
+      return "🟠"
+    case .fatal:
+      return "🔴"
+    }
+  }
+
+  /**
+   Maps the log types to the log types used by the `os.log` logger.
+   */
+  @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+  func toOSLogType() -> OSLogType {
+    switch self {
+    case .trace, .timer, .stacktrace, .debug:
+      return .debug
+    case .info:
+      return .info
+    case .warn:
+      return .default
+    case .error:
+      return .error
+    case .fatal:
+      return .fault
+    }
+  }
+}

--- a/packages/expo-modules-core/ios/Swift/Logging/Logger.swift
+++ b/packages/expo-modules-core/ios/Swift/Logging/Logger.swift
@@ -45,7 +45,7 @@ public class Logger {
   }
 
   /**
-   Used to log diagnostically helpful informations. As opposed to `trace`,
+   Used to log diagnostically helpful information. As opposed to `trace`,
    it is acceptable to commit these logs to the repository. Ignored in the release builds.
    */
   public func debug(_ items: Any...) {
@@ -53,7 +53,7 @@ public class Logger {
   }
 
   /**
-   For informations that should be logged under normal conditions such as successful initialization
+   For information that should be logged under normal conditions such as successful initialization
    and notable events that are not considered an error but might be useful for debugging purposes in the release builds.
    */
   public func info(_ items: Any...) {
@@ -68,7 +68,7 @@ public class Logger {
   }
 
   /**
-   Logs unwanted state that has impact on the currently running process, but the entire app can continue to run.
+   Logs unwanted state that has an impact on the currently running process, but the entire app can continue to run.
    */
   public func error(_ items: Any...) {
     log(type: .error, items)

--- a/packages/expo-modules-core/ios/Swift/Logging/Logger.swift
+++ b/packages/expo-modules-core/ios/Swift/Logging/Logger.swift
@@ -1,0 +1,187 @@
+// Copyright 2021-present 650 Industries. All rights reserved.
+
+import Dispatch
+
+public let log = Logger(category: "expo")
+
+public class Logger {
+  #if DEBUG || EXPO_CONFIGURATION_DEBUG
+  private var minLevel: LogType = .trace
+  #else
+  private var minLevel: LogType = .info
+  #endif
+
+  private let category: String
+
+  private var handlers: [LogHandler] = []
+
+  init(category: String = "main") {
+    self.category = category
+
+    if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+      addHandler(withType: OSLogHandler.self)
+    } else {
+      addHandler(withType: PrintLogHandler.self)
+    }
+  }
+
+  internal func addHandler<LogHandlerType: LogHandler>(_ handler: LogHandlerType) {
+    handlers.append(handler)
+  }
+
+  internal func addHandler<LogHandlerType: LogHandler>(withType: LogHandlerType.Type) {
+    addHandler(LogHandlerType(category: category))
+  }
+
+  // MARK: - Public logging functions
+
+  /**
+   The most verbose log level that captures all the details about the behavior of the implementation.
+   It is mostly diagnostic and is more granular and finer than `debug` log level.
+   These logs should not be committed to the repository and are ignored in the release builds.
+   */
+  public func trace(_ items: Any...) {
+    log(type: .trace, items)
+  }
+
+  /**
+   Used to log diagnostically helpful informations. As opposed to `trace`,
+   it is acceptable to commit these logs to the repository. Ignored in the release builds.
+   */
+  public func debug(_ items: Any...) {
+    log(type: .debug, items)
+  }
+
+  /**
+   For informations that should be logged under normal conditions such as successful initialization
+   and notable events that are not considered an error but might be useful for debugging purposes in the release builds.
+   */
+  public func info(_ items: Any...) {
+    log(type: .info, items)
+  }
+
+  /**
+   Used to log an unwanted state that has not much impact on the process so it can be continued, but could potentially become an error.
+   */
+  public func warn(_ items: Any...) {
+    log(type: .warn, items)
+  }
+
+  /**
+   Logs unwanted state that has impact on the currently running process, but the entire app can continue to run.
+   */
+  public func error(_ items: Any...) {
+    log(type: .error, items)
+  }
+
+  /**
+   Logs critical error due to which the entire app cannot continue to run.
+   */
+  public func fatal(_ items: Any...) {
+    log(type: .fatal, items)
+  }
+
+  /**
+   Logs the stack of symbols on the current thread.
+   */
+  public func stacktrace(type: LogType = .stacktrace, file: String = #fileID, line: UInt = #line) {
+    guard type.rawValue >= minLevel.rawValue else {
+      return
+    }
+    let queueName = OperationQueue.current?.underlyingQueue?.label ?? "<unknown>"
+
+    // Get the call stack symbols without the first symbol as it points right here.
+    let symbols = Thread.callStackSymbols.dropFirst()
+
+    log(type: type, "The stacktrace from '\(file):\(line)' on queue '\(queueName)':")
+
+    symbols.forEach { symbol in
+      let formattedSymbol = reformatStackSymbol(symbol)
+      log(type: type, "≫ \(formattedSymbol)")
+    }
+  }
+
+  /**
+   Allows the logger instance to be called as a function. The same as `logger.debug(...)`.
+   */
+  public func callAsFunction(_ items: Any...) {
+    log(type: .debug, items)
+  }
+
+  // MARK: - Timers
+
+  /**
+   Stores the timers created by `timeStart` function.
+   */
+  private var timers: [String: DispatchTime] = [:]
+
+  /**
+   Starts the timer to measure how much time the following operations take.
+   */
+  public func timeStart(_ id: String) {
+    guard LogType.timer.rawValue >= minLevel.rawValue else {
+      return
+    }
+    log(type: .timer, "Starting timer '\(id)'")
+    timers[id] = DispatchTime.now()
+  }
+
+  /**
+   Stops the timer and logs how much time elapsed since it started.
+   */
+  public func timeEnd(_ id: String) {
+    guard LogType.timer.rawValue >= minLevel.rawValue else {
+      return
+    }
+    guard let startTime = timers[id] else {
+      log(type: .timer, "Timer '\(id)' has not been started!")
+      return
+    }
+    let endTime = DispatchTime.now()
+    let diff = Double(endTime.uptimeNanoseconds - startTime.uptimeNanoseconds) / 1_000_000
+    log(type: .timer, "Timer '\(id)' has finished in: \(diff) seconds")
+    timers.removeValue(forKey: id)
+  }
+
+  /**
+   Measures how much time it takes to run given closure. Returns the same value as the closure returned.
+   */
+  public func time<ReturnType>(_ id: String, _ closure: () -> ReturnType) -> ReturnType {
+    timeStart(id)
+    let result = closure()
+    timeEnd(id)
+    return result
+  }
+
+  // MARK: - Changing the category
+
+  public func category(_ category: String) -> Logger {
+    return Logger(category: category)
+  }
+
+  // MARK: - Private logging functions
+
+  private func log(type: LogType = .trace, _ items: [Any]) {
+    guard type.rawValue >= minLevel.rawValue else {
+      return
+    }
+    let message = items
+      .map { String(describing: $0) }
+      .joined(separator: " ")
+      .split(whereSeparator: \.isNewline)
+      .map { "\(type.prefix) \($0)" }
+      .joined()
+
+    handlers.forEach { handler in
+      handler.log(type: type, message)
+    }
+  }
+
+  private func log(type: LogType = .trace, _ items: Any...) {
+    log(type: type, items)
+  }
+}
+
+private func reformatStackSymbol(_ symbol: String) -> String {
+  return symbol.replacingOccurrences(of: #"^\d+\s+"#, with: "", options: .regularExpression)
+}

--- a/packages/expo-modules-core/ios/Swift/ModuleRegistry.swift
+++ b/packages/expo-modules-core/ios/Swift/ModuleRegistry.swift
@@ -13,6 +13,7 @@ public final class ModuleRegistry: Sequence {
    Registers an instance of module holder.
    */
   internal func register(holder: ModuleHolder) {
+    log.info("Registering module '\(holder.name)'")
     registry[holder.name] = holder
   }
 
@@ -47,7 +48,10 @@ public final class ModuleRegistry: Sequence {
   }
 
   public func unregister(moduleName: String) {
-    registry[moduleName] = nil
+    if registry[moduleName] != nil {
+      log.info("Unregistering module '\(moduleName)'")
+      registry[moduleName] = nil
+    }
   }
 
   public func has(moduleWithName moduleName: String) -> Bool {
@@ -71,12 +75,14 @@ public final class ModuleRegistry: Sequence {
   }
 
   internal func post(event: EventName) {
+    log.info("Posting '\(event)' event to registered modules")
     forEach { holder in
       holder.post(event: event)
     }
   }
 
   internal func post<PayloadType>(event: EventName, payload: PayloadType? = nil) {
+    log.info("Posting '\(event)' event to registered modules")
     forEach { holder in
       holder.post(event: event, payload: payload)
     }


### PR DESCRIPTION
# Why

Closes ENG-2718

# How

Implemented a Logger class that we will use for logging, measure execution times or dumping the stracktraces. For now it uses the new iOS API https://developer.apple.com/documentation/os/logger but only in iOS >= 14.0, on older platforms we just use `print`.
As the next step, I'm going to add another handler that will pass warns and errors to JS, so they will be visible in the terminal in development.

# Test Plan

Added `log.info` in a few places, things seem to work as expected

![Screen Shot 2022-05-11 at 14 50 52](https://user-images.githubusercontent.com/1714764/167853929-522f5066-10a2-42e4-a150-6a7f71cb1a73.png)