### PR TITLE
[expo-gl] Stop rendering when app is in background

### DIFF
--- a/packages/expo-gl/CHANGELOG.md
+++ b/packages/expo-gl/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Stop rendering when app is backgrounded on iOS. ([#17463](https://github.com/expo/expo/pull/17463) by [@wkozyra95](https://github.com/wkozyra95))
+
 ### 💡 Others
 
 ## 11.3.0 — 2022-04-27


### PR DESCRIPTION
# Why

https://github.com/expo/expo/issues/7367

# How

Based on patch provided by the author of the issue(https://gist.github.com/danmaas/4f3341b75a147d0c3ffc588a0f4c9b92)

# Test Plan

verified that app delegate applicationDidEnterBackground executes after callback from onApplicationWillResignActive executes
I was testing it with a debugger, so I'm not sure how reliable those findings were

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
