### PR TITLE
[ci][android-unit-test] fix emulator connection failures

### DIFF
--- a/.github/workflows/android-instrumentation-tests.yml
+++ b/.github/workflows/android-instrumentation-tests.yml
@@ -1,24 +1,30 @@
-name: Android Unit Tests
+name: Android Instrumentation Tests
 
 on:
   workflow_dispatch: {}
   push:
     branches: [main]
     paths:
-      - .github/workflows/android-unit-tests.yml
+      - .github/workflows/android-instrumentation-tests.yml
       - android/**
       - fastlane/**
-      - packages/**/android/**
-      - tools/**
+      # - packages/**/android/**
+      - packages/expo-eas-client/android/**
+      - packages/expo-json-utils/android/**
+      - packages/expo-manifests/android/**
+      - packages/expo-updates/android/**
       - yarn.lock
       - '!packages/@expo/cli/**'
   pull_request:
     paths:
-      - .github/workflows/android-unit-tests.yml
+      - .github/workflows/android-instrumentation-tests.yml
       - android/**
       - fastlane/**
-      - packages/**/android/**
-      - tools/**
+      # - packages/**/android/**
+      - packages/expo-eas-client/android/**
+      - packages/expo-json-utils/android/**
+      - packages/expo-manifests/android/**
+      - packages/expo-updates/android/**
       - yarn.lock
       - '!packages/@expo/cli/**'
 
@@ -28,11 +34,14 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: macos-11
     timeout-minutes: 60
     env:
       ORG_GRADLE_PROJECT_reactNativeArchitectures: x86_64
       GRADLE_OPTS: -Dorg.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=1024m
+    strategy:
+      matrix:
+        api-level: [31]
     steps:
       - name: ⬢ Setup Node
         uses: actions/setup-node@v3
@@ -53,20 +62,25 @@ jobs:
         with:
           yarn-workspace: 'true'
           yarn-tools: 'true'
+          avd: 'true'
+          avd-api: ${{ matrix.api-level }}
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: 🧶 Install node modules in root dir
         if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
-      - name: 🚨 Run Spotless lint check
-        working-directory: android
-        run: ./gradlew spotlessCheck || { echo '::error Spotless lint failed. Run `./gradlew spotlessApply` to automatically fix formatting.' && exit 1; }
-      - name: 🎸 Run native Android unit tests
-        timeout-minutes: 30
-        run: expotools native-unit-tests --platform android
+      - name: 📱 Run instrumented unit tests
+        timeout-minutes: 40
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          avd-name: avd-${{ matrix.api-level }}
+          arch: x86_64
+          force-avd-creation: false
+          script: expotools android-native-unit-tests --type instrumented
       - name: 💾 Save test results
         if: always()
         uses: actions/upload-artifact@v3
         with:
           name: test-results
-          path: packages/**/build/test-results/**/*xml
+          path: packages/**/build/test-reports/**/*xml


### PR DESCRIPTION
# Why

close ENG-4807

# How

running android instrumented tests on linux runners are not very stable. the root cause is from the fixed timeout in gradle and i [responded the issue in upstream](https://issuetracker.google.com/issues/111260497).

to make ci stable, i decided to revert my changes in #16862. so far we only have instrumented test in four packages, it doesn't make sense to waste 40 minutes macos runner time for any expo modules changes. so i narrow down the scope a little bit:

```yaml
  pull_request:
    paths:
      - .github/workflows/android-instrumentation-tests.yml
      - android/**
      - fastlane/**
      # - packages/**/android/**
      - packages/expo-eas-client/android/**
      - packages/expo-json-utils/android/**
      - packages/expo-manifests/android/**
      - packages/expo-updates/android/**
      - yarn.lock
      - '!packages/@expo/cli/**'
```

# Test Plan

android tests ci passed
