### PR TITLE
[expo-updates][android] Allow null asset hash in new manifests

### DIFF
--- a/docs/pages/technical-specs/expo-updates-0.md
+++ b/docs/pages/technical-specs/expo-updates-0.md
@@ -108,7 +108,7 @@ type Manifest = {
 }
 
 type Asset = {
-  hash: string;
+  hash?: string;
   key: string;
   contentType: string;
   fileExtension?: string;

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Improved support of nvm sourcing in iOS shell scripts. ([#17109](https://github.com/expo/expo/pull/17109) by [@liamronancb](https://github.com/liamronancb))
+- Android: Allow null asset hash in new manifests. ([#17466](https://github.com/expo/expo/pull/17466) by [@wschurman](https://github.com/wschurman))
 
 ### 💡 Others
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewUpdateManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewUpdateManifest.kt
@@ -68,7 +68,7 @@ class NewUpdateManifest private constructor(
           extraRequestHeaders = assetHeaders[mLaunchAsset.getString("key")]
           isLaunchAsset = true
           embeddedAssetFilename = EmbeddedLoader.BUNDLE_FILENAME
-          expectedHash = mLaunchAsset.getString("hash")
+          expectedHash = mLaunchAsset.getNullable("hash")
         }
       )
     } catch (e: JSONException) {
@@ -86,7 +86,7 @@ class NewUpdateManifest private constructor(
               url = Uri.parse(assetObject.getString("url"))
               extraRequestHeaders = assetHeaders[assetObject.getString("key")]
               embeddedAssetFilename = assetObject.getNullable("embeddedAssetFilename")
-              expectedHash = mLaunchAsset.getString("hash")
+              expectedHash = mLaunchAsset.getNullable("hash")
             }
           )
         } catch (e: JSONException) {


### PR DESCRIPTION
# Why

The CLIs (old expo-cli and new @expo/cli) don't serve this field (and can't since they don't compute the bundle before serving the manifest).

That this wasn't caught is probably the result of a couple issues that need following-up:
- Incorrect specification (fixed in this PR). This spec is supposed to be the source of truth.
- Non-obvious nullability of JSONObject methods on android (due to them being in Java vs Kotlin). `expo-json-utils` tries to address this, but we should probably add a lint to disallow the non-kotlin methods or something, or just move off of JSONObject altogether since this isn't the first time this has bitten us.
- Lacking test coverage in general in the client. `expo-updates` itself is decently-covered, but Expo Go has 0 coverage.
- Non-default dogfooding of this type of manifest. This type of manifest is only served if explicitly asked for using the `--force-manifest-type` flag in the CLIs or if the `updates.url` field is an EAS update URL. Neither of these are generally true for any of our dogfooding.

This is not present on iOS since the JSON library used there (built-in NSDictionary) has nullable by default: https://github.com/expo/expo/blob/main/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.m#L51

Blame: https://github.com/expo/expo/commit/22bb96e5dadd5eeca312fd8496dafc6b0cb7d68e

Closes ENG-4935
https://github.com/expo/expo/issues/17461

# How

Use the new kotlin nullable method to explicitly specify nullability. Fix spec. Add test.

# Test Plan

`expo start` https://github.com/GregAtFramework/eas-update-breaks-expo-go-on-android, load in locally-built Expo Go with these fixes applied, see it loads.

Run test.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
