### PR TITLE
[docs] add ini snippets highlight, add few missing languages

### DIFF
--- a/docs/components/base/languages/index.ts
+++ b/docs/components/base/languages/index.ts
@@ -1,6 +1,7 @@
 import { Prism } from 'prism-react-renderer';
 
 import { installGroovy } from './groovy';
+import { installIni } from './ini';
 import { installJson5 } from './json5';
 import { installKotlin } from './kotlin';
 import { installObjectiveC } from './objectivec';
@@ -16,4 +17,5 @@ export function installLanguages(prism: typeof Prism) {
   installJson5(prism);
   installKotlin(prism);
   installSwift(prism);
+  installIni(prism);
 }

--- a/docs/components/base/languages/ini.ts
+++ b/docs/components/base/languages/ini.ts
@@ -1,0 +1,38 @@
+export function installIni(Prism: any) {
+  // https://github.com/PrismJS/prism/blob/master/components/prism-ini.js
+  Prism.languages.ini = {
+    comment: {
+      pattern: /(^[ \f\t\v]*)[#;][^\n\r]*/m,
+      lookbehind: true,
+    },
+    header: {
+      pattern: /(^[ \f\t\v]*)\[[^\n\r\]]*\]?/m,
+      lookbehind: true,
+      inside: {
+        'section-name': {
+          pattern: /(^\[[ \f\t\v]*)[^ \f\t\v\]]+(?:[ \f\t\v]+[^ \f\t\v\]]+)*/,
+          lookbehind: true,
+          alias: 'selector',
+        },
+        punctuation: /\[|\]/,
+      },
+    },
+    key: {
+      pattern: /(^[ \f\t\v]*)[^ \f\n\r\t\v=]+(?:[ \f\t\v]+[^ \f\n\r\t\v=]+)*(?=[ \f\t\v]*=)/m,
+      lookbehind: true,
+      alias: 'attr-name',
+    },
+    value: {
+      pattern: /(=[ \f\t\v]*)[^ \f\n\r\t\v]+(?:[ \f\t\v]+[^ \f\n\r\t\v]+)*/,
+      lookbehind: true,
+      alias: 'attr-value',
+      inside: {
+        'inner-value': {
+          pattern: /^("|').+(?=\1$)/,
+          lookbehind: true,
+        },
+      },
+    },
+    punctuation: /=/,
+  };
+}

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,7 +3,7 @@
   "version": "45.0.0",
   "private": true,
   "scripts": {
-    "dev": "rimraf .next/preval && export NODE_OPTIONS=--openssl-legacy-provider && next dev -p 3002",
+    "dev": "rimraf .next/preval && next dev -p 3002",
     "build": "cross-env NODE_OPTIONS=--max-old-space-size=6144 next build",
     "export": "yarn run build && next export && yarn run export-issue-404",
     "export-issue-404": "echo \"🛠  Patching https://github.com/vercel/next.js/issues/16528\"; cp out/404/index.html out/404.html",

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,7 +3,7 @@
   "version": "45.0.0",
   "private": true,
   "scripts": {
-    "dev": "rimraf .next/preval && next dev -p 3002",
+    "dev": "rimraf .next/preval && export NODE_OPTIONS=--openssl-legacy-provider && next dev -p 3002",
     "build": "cross-env NODE_OPTIONS=--max-old-space-size=6144 next build",
     "export": "yarn run build && next export && yarn run export-issue-404",
     "export-issue-404": "echo \"🛠  Patching https://github.com/vercel/next.js/issues/16528\"; cp out/404/index.html out/404.html",

--- a/docs/pages/build-reference/infrastructure.md
+++ b/docs/pages/build-reference/infrastructure.md
@@ -31,7 +31,7 @@ When selecting an image for the build you can use the full name provided below o
 - Maven cache deployed with Kubernetes. [Learn more](caching/#android-dependencies)
 - Global Gradle configuration in `~/.gradle/gradle.properties`:
 
-  ```jsx
+  ```ini
   org.gradle.jvmargs=-Xmx14g -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
   org.gradle.parallel=true
   org.gradle.configureondemand=true
@@ -40,13 +40,13 @@ When selecting an image for the build you can use the full name provided below o
 
 - `~/.npmrc`
 
-  ```
+  ```ini
   registry=http://npm-cache-service.worker-infra-production.svc.cluster.local:4873
   ```
 
 - `~/.yarnrc.yml`
 
-  ```
+  ```yml
   unsafeHttpWhitelist:
     - "*"
   npmRegistryServer: "http://npm-cache-service.worker-infra-production.svc.cluster.local:4873"
@@ -114,13 +114,13 @@ When selecting an image for the build you can use the full name provided below o
 - npm cache. [Learn more](caching/#javascript-dependencies)
 - `~/.npmrc`
 
-  ```
+  ```ini
   registry=http://10.254.24.8:4873
   ```
 
 - `~/.yarnrc.yml`
 
-  ```
+  ```yml
   unsafeHttpWhitelist:
     - "*"
   npmRegistryServer: "registry=http://10.254.24.8:4873"

--- a/docs/pages/build-reference/private-npm-packages.md
+++ b/docs/pages/build-reference/private-npm-packages.md
@@ -14,13 +14,13 @@ By default, EAS Build uses a self-hosted npm cache that speeds up installing dep
 
 #### Android
 
-```
+```ini
 registry=http://npm-cache-service.worker-infra-production.svc.cluster.local:4873
 ```
 
 #### iOS
 
-```
+```ini
 registry=http://10.254.24.8:4873
 ```
 
@@ -34,8 +34,8 @@ The recommended way is to add the `NPM_TOKEN` secret to your account or project'
 
 When EAS detects that the `NPM_TOKEN` environment variable is available during a build, it automatically creates the following `.npmrc`:
 
-```
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}
+```ini
+# registry.npmjs.org/:_authToken=${NPM_TOKEN}
 registry=https://registry.npmjs.org/
 ```
 
@@ -51,14 +51,14 @@ If you're using a private npm registry like self-hosted [verdaccio](https://verd
 
 Create an `.npmrc` file in your project's root directory with the following contents:
 
-```
+```ini
 registry=__REPLACE_WITH_REGISTRY_URL__
 ```
 
 If your registry requires authentication, you will also need to provide the token. Assuming your registry URL is `https://registry.johndoe.com/`:
 
-```
-//registry.johndoe.com/:_authToken=${NPM_TOKEN}
+```ini
+# registry.johndoe.com/:_authToken=${NPM_TOKEN}
 registry=https://registry.johndoe.com/
 ```
 
@@ -66,8 +66,8 @@ registry=https://registry.johndoe.com/
 
 This is an advanced example, and you will probably never use it. Private npm packages are always scoped ([see npm docs](https://docs.npmjs.com/about-scopes#scopes-and-package-visibility)). Let's assume that your npm username is `johndoe` and your private self-hosted registry URL is `https://registry.johndoe.com/`. If you want to install dependencies from both sources, create the following `.npmrc` in your project's root directory:
 
-```
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}
+```ini
+# registry.npmjs.org/:_authToken=${NPM_TOKEN}
 @johndoe:registry=https://registry.npmjs.org/
 registry=https://registry.johndoe.com/
 ```

--- a/docs/pages/guides/troubleshooting-proxies.md
+++ b/docs/pages/guides/troubleshooting-proxies.md
@@ -65,7 +65,7 @@ npm, git, Brew, Curl, and any other command line applications need proxy access 
 
 Open `~/.npmrc` and set:
 
-```
+```ini
 http_proxy=http://localhost:8888
 https_proxy=http://localhost:8888
 ```
@@ -74,18 +74,18 @@ https_proxy=http://localhost:8888
 
 Open `~/.gitconfig` and set
 
-```
+```ini
 [http]
- 	proxy = http://localhost:8888
+  proxy = http://localhost:8888
 [https]
-	proxy = http://localhost:8888
+  proxy = http://localhost:8888
 ```
 
 ### For Command line applications
 
 Depending on your shell, and config, Open `~/.bashrc`, `~/.bash_profile`, or `~/.zshrc` or wherever you set your shell variables, and set:
 
-```
+```bash
 export HTTP_PROXY="http://localhost:8888"
 export http_proxy="http://localhost:8888"
 export ALL_PROXY="http://localhost:8888"


### PR DESCRIPTION
# Why

Currently we do not highlight some of the code block like `.npmrc`, `.gitconfig` or `gradle.properties`. After looking at the docs for those files it looks like every of them uses `ini` syntax.

References:
* https://docs.npmjs.com/cli/v8/configuring-npm/npmrc#comments
* https://git-scm.com/docs/git-config#_syntax

# How

This PR adds the `ini` language highlight for Prism renderer and adds this language to the appropriate code blocks.

I have also added few missing languages and fixed the comments in `.npmrc` snippets.

# Test Plan

The changes have been tested by running docs website on `localhost`.

# Preview 
<img width="382" alt="Screenshot 2022-05-11 at 19 54 14" src="https://user-images.githubusercontent.com/719641/167915067-5316ffc3-4809-457d-94b5-01915256dc9c.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
