### PR TITLE
feat(cli)!: change `expo` bin to `expo-internal` (DO NOT USE)

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Change `expo` to `expo-internal` (DO NOT USE) for `@expo/cli`.
+
 ### 🎉 New features
 
 - Validate Android SDK configuration before using ([#17259](https://github.com/expo/expo/pull/17259) by [@byCedric](https://github.com/byCedric))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🛠 Breaking changes
 
-- Change `expo` to `expo-internal` (DO NOT USE) for `@expo/cli`.
+- Change `expo` to `expo-internal` (DO NOT USE) for `@expo/cli`. ([#17468](https://github.com/expo/expo/pull/17468) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🎉 New features
 

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -4,7 +4,7 @@
   "description": "The Expo CLI",
   "main": "build/bin/cli",
   "bin": {
-    "expo": "build/bin/cli"
+    "expo-internal": "build/bin/cli"
   },
   "files": [
     "static",


### PR DESCRIPTION
# Why

- Fix undiagnosed issue https://github.com/expo/expo-cli/issues/4364#issuecomment-1124088171
- I'm not sure, but perhaps we could change the `expo/expo/package.json` bin to `@expo/cli`.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# Test Plan

- `EXPO_USE_BETA_CLI=1 ../../expo/packages/expo/bin/cli.js -h` continues to work

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
