### PR TITLE
[updates-e2e] combine ios and android tests into a single job

### DIFF
--- a/.github/workflows/updates-e2e.yml
+++ b/.github/workflows/updates-e2e.yml
@@ -33,11 +33,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  android:
+  # (2022-05): we run both iOS and Android tests in a single job in order to avoid taking up 2 macOS
+  # runners each time this workflow runs
+  build:
     runs-on: macos-11
-    timeout-minutes: 60
+    timeout-minutes: 120
     env:
-      UPDATES_HOST: 10.0.2.2 # special IP that Android emulators map to host machine's localhost
       UPDATES_PORT: 4747
     strategy:
       matrix:
@@ -49,6 +50,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '14.17'
+      - name: 🔨 Switch to Xcode 13.2.1
+        run: sudo xcode-select --switch /Applications/Xcode_13.2.1.app
       - name: 🔨 Use JDK 11
         uses: actions/setup-java@v3
         with:
@@ -102,9 +105,11 @@ jobs:
       - name: Add local expo packages
         working-directory: ../updates-e2e
         run: yarn add file:../expo/packages/expo-updates file:../expo/packages/expo file:../expo/packages/expo-splash-screen file:../expo/packages/expo-status-bar
+      - name: Get local IP address
+        run: echo "UPDATES_HOST=$(ifconfig -l | xargs -n1 ipconfig getifaddr)" >> $GITHUB_ENV
       - name: Setup app.config.json
         working-directory: ../updates-e2e
-        run: echo "{\"name\":\"updates-e2e\",\"runtimeVersion\":\"1.0.0\",\"plugins\":[\"expo-updates\"],\"android\":{\"package\":\"dev.expo.updatese2e\"},\"ios\":{\"bundleIdentifier\":\"dev.expo.updatese2e\"},\"updates\":{\"url\":\"http://$UPDATES_HOST:$UPDATES_PORT/update\"}}" > app.config.json
+        run: echo "{\"name\":\"updates-e2e\",\"runtimeVersion\":\"1.0.0\",\"plugins\":[\"expo-updates\"],\"android\":{\"package\":\"dev.expo.updatese2e\"},\"ios\":{\"bundleIdentifier\":\"dev.expo.updatese2e\"},\"updates\":{\"url\":\"http://${{ env.UPDATES_HOST }}:$UPDATES_PORT/update\"}}" > app.config.json
       - name: Generate code signing
         working-directory: ../updates-e2e
         run: yarn expo-updates codesigning:generate --key-output-directory keys --certificate-output-directory certs --certificate-validity-duration-years 1 --certificate-common-name "E2E Test App"
@@ -122,24 +127,33 @@ jobs:
         run: cp ../expo/packages/expo-updates/e2e/__tests__/fixtures/App.js .
       - name: Set host and port in App.js
         working-directory: ../updates-e2e
-        run: sed -i -e "s/UPDATES_HOST/$UPDATES_HOST/" ./App.js && sed -i -e "s/UPDATES_PORT/$UPDATES_PORT/" ./App.js
-      - name: Assemble release APK
+        run: sed -i -e "s/UPDATES_HOST/${{ env.UPDATES_HOST }}/" ./App.js && sed -i -e "s/UPDATES_PORT/$UPDATES_PORT/" ./App.js
+      - name: 🍏 Build release app
+        working-directory: ../updates-e2e/ios
+        run: xcodebuild -workspace updatese2e.xcworkspace -scheme updatese2e -configuration Release -destination "generic/platform=iOS Simulator" -derivedDataPath ./build build
+      - name: 🍏 Copy app to working directory
+        run: cp -R ../updates-e2e/ios/build/Build/Products/Release-iphonesimulator/updatese2e.app artifact
+      - name: 🍏 Get test app path
+        id: test-app-path
+        working-directory: ../updates-e2e/ios/build/Build/Products/Release-iphonesimulator/
+        run: echo "::set-output name=dir::$(pwd)"
+      - name: 🤖 Assemble release APK
         working-directory: ../updates-e2e/android
         run: ./gradlew assembleRelease --stacktrace
-      - name: Copy APK to working directory
+      - name: 🤖 Copy APK to working directory
         run: cp -R ../updates-e2e/android/app/build/outputs/apk artifact
-      - name: Upload test APK artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: updates-e2e-android-apk
-          path: artifact
-      - name: Get test APK path
+      - name: 🤖 Get test APK path
         id: test-apk-path
         working-directory: ../updates-e2e/android/app/build/outputs/apk/release
         run: echo "::set-output name=dir::$(pwd)"
+      - name: Upload test app artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: updates-e2e-artifacts
+          path: artifact
       - name: Export update for test server to host
         working-directory: ../updates-e2e
-        run: expo export --public-url https://u.expo.dev/dummy-url --platform android
+        run: expo export --public-url https://u.expo.dev/dummy-url
       - name: Get test update dist path
         id: test-update-dist-path
         working-directory: ../updates-e2e/dist
@@ -148,11 +162,26 @@ jobs:
         id: test-code-signing-private-key-path
         working-directory: ../updates-e2e/keys
         run: echo "::set-output name=dir::$(pwd)/private-key.pem"
-      - name: 🧪 Run tests
+      - name: 🍏 Start simulator
+        run: |
+          xcrun simctl list devices -j \
+          | jq -rc '[ .[] | .[] | .[] | select( .name | contains( "iPhone" ) ) | select( .isAvailable == true ) ] | last.udid ' \
+          | xargs open -a Simulator --args -CurrentDeviceUDID
+      - name: 🍏 Run tests
+        env:
+          TEST_APP_PATH: '${{ steps.test-app-path.outputs.dir }}/updatese2e.app'
+          TEST_UPDATE_DIST_PATH: '${{ steps.test-update-dist-path.outputs.dir }}'
+          TEST_PRIVATE_KEY_PATH: '${{ steps.test-code-signing-private-key-path.outputs.dir }}'
+          UPDATES_HOST: '${{ env.UPDATES_HOST }}' # not sure if this is needed?
+        timeout-minutes: 30
+        working-directory: packages/expo-updates
+        run: yarn test --config e2e/jest.config.ios.js
+      - name: 🤖 Start emulator and run tests
         env:
           TEST_APK_PATH: '${{ steps.test-apk-path.outputs.dir }}/app-release.apk'
           TEST_UPDATE_DIST_PATH: '${{ steps.test-update-dist-path.outputs.dir }}'
           TEST_PRIVATE_KEY_PATH: '${{ steps.test-code-signing-private-key-path.outputs.dir }}'
+          UPDATES_HOST: '${{ env.UPDATES_HOST }}' # not sure if this is needed?
         timeout-minutes: 30
         uses: reactivecircus/android-emulator-runner@v2
         with:
@@ -162,133 +191,3 @@ jobs:
           force-avd-creation: false
           script: yarn test --config e2e/jest.config.android.js
           working-directory: packages/expo-updates
-
-  ios:
-    runs-on: macos-11
-    timeout-minutes: 60
-    env:
-      UPDATES_HOST: localhost
-      UPDATES_PORT: 4747
-    steps:
-      - name: 👀 Checkout
-        uses: actions/checkout@v3
-      - name: 🔨 Switch to Xcode 13.2.1
-        run: sudo xcode-select --switch /Applications/Xcode_13.2.1.app
-      - name: ➕ Add `bin` to GITHUB_PATH
-        run: echo "$(yarn global bin)" >> $GITHUB_PATH
-      - name: ♻️ Restore caches
-        uses: ./.github/actions/expo-caches
-        id: expo-caches
-        with:
-          yarn-workspace: 'true'
-      - name: 🧶 Yarn install
-        if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
-        run: yarn install --frozen-lockfile
-      - name: Build expo-updates CLI
-        working-directory: packages/expo-updates
-        run: yarn build:cli
-      - name: 🔧 Install Expo CLI
-        run: yarn global add expo-cli
-      - name: Init new expo app
-        working-directory: ../
-        run: expo-cli init updates-e2e --yes
-      - name: Add yarn resolutions for local dependencies
-        working-directory: ../updates-e2e
-        run: |
-          # A jq filter to add a "resolutions" field
-          JQ_FILTER=$(cat << EOF
-            . + {
-              resolutions: {
-                "expo-application": "file:../expo/packages/expo-application",
-                "expo-constants": "file:../expo/packages/expo-constants",
-                "expo-eas-client": "file:../expo/packages/expo-eas-client",
-                "expo-error-recovery": "file:../expo/packages/expo-error-recovery",
-                "expo-file-system": "file:../expo/packages/expo-file-system",
-                "expo-font": "file:../expo/packages/expo-font",
-                "expo-json-utils": "file:../expo/packages/expo-json-utils",
-                "expo-keep-awake": "file:../expo/packages/expo-keep-awake",
-                "expo-manifests": "file:../expo/packages/expo-manifests",
-                "expo-modules-core": "file:../expo/packages/expo-modules-core",
-                "expo-structured-headers": "file:../expo/packages/expo-structured-headers",
-                "expo-updates-interface": "file:../expo/packages/expo-updates-interface"
-              }
-            }
-          EOF
-          )
-          jq "$JQ_FILTER" < package.json > new-package.json
-          mv new-package.json package.json
-      - name: Add local expo packages
-        working-directory: ../updates-e2e
-        run: yarn add file:../expo/packages/expo-updates file:../expo/packages/expo file:../expo/packages/expo-splash-screen file:../expo/packages/expo-status-bar
-      - name: Setup app.config.json
-        working-directory: ../updates-e2e
-        run: echo "{\"name\":\"updates-e2e\",\"runtimeVersion\":\"1.0.0\",\"plugins\":[\"expo-updates\"],\"android\":{\"package\":\"dev.expo.updatese2e\"},\"ios\":{\"bundleIdentifier\":\"dev.expo.updatese2e\"},\"updates\":{\"url\":\"http://$UPDATES_HOST:$UPDATES_PORT/update\"}}" > app.config.json
-      - name: Generate code signing
-        working-directory: ../updates-e2e
-        run: yarn expo-updates codesigning:generate --key-output-directory keys --certificate-output-directory certs --certificate-validity-duration-years 1 --certificate-common-name "E2E Test App"
-      - name: Configure code signing
-        working-directory: ../updates-e2e
-        run: yarn expo-updates codesigning:configure --certificate-input-directory certs --key-input-directory keys
-      - name: Pack latest bare-minimum template as tarball for expo prebuild
-        working-directory: templates/expo-template-bare-minimum
-        run: npm pack --pack-destination ../../../updates-e2e/
-      - name: Prebuild --no-install
-        working-directory: ../updates-e2e
-        run: expo-cli prebuild --template expo-template-bare-minimum-*.tgz --no-install && yarn
-      # TODO: not caching pods for now as we don't have a lockfile with which to use in the key
-      #       and as this is a minimal project, time savings is not much anyway (~3.5 mins at most)
-      # - name: Restore updates-e2e/ios/Pods from cache
-      #   uses: actions/cache@v2
-      #   id: pods-cache
-      #   with:
-      #     path: '../updates-e2e/ios/Pods'
-      #     key: ${{ runner.os }}-pods-updatese2e-${{ hashFiles('../updates-e2e/ios/Podfile.lock') }}
-      #     # restore-keys: |
-      #     #   ${{ runner.os }}-pods-updatese2e-
-      - name: 🥥 Install CocoaPods in `updates-e2e/ios`
-        run: pod install
-        working-directory: ../updates-e2e/ios
-      - name: Copy App.js from test fixtures
-        working-directory: ../updates-e2e
-        run: cp ../expo/packages/expo-updates/e2e/__tests__/fixtures/App.js .
-      - name: Set host and port in App.js
-        working-directory: ../updates-e2e
-        run: sed -i -e "s/UPDATES_HOST/$UPDATES_HOST/" ./App.js && sed -i -e "s/UPDATES_PORT/$UPDATES_PORT/" ./App.js
-      - name: Build release app
-        working-directory: ../updates-e2e/ios
-        run: xcodebuild -workspace updatese2e.xcworkspace -scheme updatese2e -configuration Release -destination "generic/platform=iOS Simulator" -derivedDataPath ./build build
-      - name: Copy app to working directory
-        run: cp -R ../updates-e2e/ios/build/Build/Products/Release-iphonesimulator/updatese2e.app artifact
-      - name: Upload test app artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: updates-e2e-ios-app
-          path: artifact
-      - name: Get test app path
-        id: test-app-path
-        working-directory: ../updates-e2e/ios/build/Build/Products/Release-iphonesimulator/
-        run: echo "::set-output name=dir::$(pwd)"
-      - name: Export update for test server to host
-        working-directory: ../updates-e2e
-        run: expo export --public-url https://u.expo.dev/dummy-url --platform ios
-      - name: Get test update dist path
-        id: test-update-dist-path
-        working-directory: ../updates-e2e/dist
-        run: echo "::set-output name=dir::$(pwd)"
-      - name: Get test code signing private key path
-        id: test-code-signing-private-key-path
-        working-directory: ../updates-e2e/keys
-        run: echo "::set-output name=dir::$(pwd)/private-key.pem"
-      - name: Start simulator
-        run: |
-          xcrun simctl list devices -j \
-          | jq -rc '[ .[] | .[] | .[] | select( .name | contains( "iPhone" ) ) | select( .isAvailable == true ) ] | last.udid ' \
-          | xargs open -a Simulator --args -CurrentDeviceUDID
-      - name: 🧪 Run tests
-        env:
-          TEST_APP_PATH: '${{ steps.test-app-path.outputs.dir }}/updatese2e.app'
-          TEST_UPDATE_DIST_PATH: '${{ steps.test-update-dist-path.outputs.dir }}'
-          TEST_PRIVATE_KEY_PATH: '${{ steps.test-code-signing-private-key-path.outputs.dir }}'
-        timeout-minutes: 30
-        working-directory: packages/expo-updates
-        run: yarn test --config e2e/jest.config.ios.js

--- a/.github/workflows/updates-e2e.yml
+++ b/.github/workflows/updates-e2e.yml
@@ -109,7 +109,7 @@ jobs:
         run: echo "UPDATES_HOST=$(ifconfig -l | xargs -n1 ipconfig getifaddr)" >> $GITHUB_ENV
       - name: Setup app.config.json
         working-directory: ../updates-e2e
-        run: echo "{\"name\":\"updates-e2e\",\"runtimeVersion\":\"1.0.0\",\"plugins\":[\"expo-updates\"],\"android\":{\"package\":\"dev.expo.updatese2e\"},\"ios\":{\"bundleIdentifier\":\"dev.expo.updatese2e\"},\"updates\":{\"url\":\"http://${{ env.UPDATES_HOST }}:$UPDATES_PORT/update\"}}" > app.config.json
+        run: echo "{\"name\":\"updates-e2e\",\"runtimeVersion\":\"1.0.0\",\"plugins\":[\"expo-updates\"],\"android\":{\"package\":\"dev.expo.updatese2e\"},\"ios\":{\"bundleIdentifier\":\"dev.expo.updatese2e\"},\"updates\":{\"url\":\"http://$UPDATES_HOST:$UPDATES_PORT/update\"}}" > app.config.json
       - name: Generate code signing
         working-directory: ../updates-e2e
         run: yarn expo-updates codesigning:generate --key-output-directory keys --certificate-output-directory certs --certificate-validity-duration-years 1 --certificate-common-name "E2E Test App"
@@ -127,7 +127,7 @@ jobs:
         run: cp ../expo/packages/expo-updates/e2e/__tests__/fixtures/App.js .
       - name: Set host and port in App.js
         working-directory: ../updates-e2e
-        run: sed -i -e "s/UPDATES_HOST/${{ env.UPDATES_HOST }}/" ./App.js && sed -i -e "s/UPDATES_PORT/$UPDATES_PORT/" ./App.js
+        run: sed -i -e "s/UPDATES_HOST/$UPDATES_HOST/" ./App.js && sed -i -e "s/UPDATES_PORT/$UPDATES_PORT/" ./App.js
       - name: 🍏 Build release app
         working-directory: ../updates-e2e/ios
         run: xcodebuild -workspace updatese2e.xcworkspace -scheme updatese2e -configuration Release -destination "generic/platform=iOS Simulator" -derivedDataPath ./build build
@@ -172,7 +172,6 @@ jobs:
           TEST_APP_PATH: '${{ steps.test-app-path.outputs.dir }}/updatese2e.app'
           TEST_UPDATE_DIST_PATH: '${{ steps.test-update-dist-path.outputs.dir }}'
           TEST_PRIVATE_KEY_PATH: '${{ steps.test-code-signing-private-key-path.outputs.dir }}'
-          UPDATES_HOST: '${{ env.UPDATES_HOST }}' # not sure if this is needed?
         timeout-minutes: 30
         working-directory: packages/expo-updates
         run: yarn test --config e2e/jest.config.ios.js
@@ -181,7 +180,6 @@ jobs:
           TEST_APK_PATH: '${{ steps.test-apk-path.outputs.dir }}/app-release.apk'
           TEST_UPDATE_DIST_PATH: '${{ steps.test-update-dist-path.outputs.dir }}'
           TEST_PRIVATE_KEY_PATH: '${{ steps.test-code-signing-private-key-path.outputs.dir }}'
-          UPDATES_HOST: '${{ env.UPDATES_HOST }}' # not sure if this is needed?
         timeout-minutes: 30
         uses: reactivecircus/android-emulator-runner@v2
         with:


### PR DESCRIPTION
# Why

https://github.com/expo/expo/pull/17374#issuecomment-1121749600 since both jobs are now run on macOS, combine them to save on our limited macOS runners

# How

Manually combine jobs, including all steps from each individual platform job. Label platform-specific steps with emojis. Add an additional step to get the host machine's local ip address to have a single UPDATES_HOST (rather than using localhost or 10.0.2.2 per platform).

I put the iOS steps first because the Android tests take a little longer to run (and the emulator is a little less reliable) so real failures will hopefully be caught a little bit sooner.

# Test Plan

New job passes in CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
