### PR TITLE
[expo][docs] additional 0.68.2 references in docs and bundled versioned file

### DIFF
--- a/docs/pages/versions/unversioned/index.md
+++ b/docs/pages/versions/unversioned/index.md
@@ -32,7 +32,7 @@ Every quarter there is a new Expo SDK release that typically updates to the late
 
 | Expo SDK Version | React Native Version |
 | ---------------- | -------------------- |
-| 45.0.0           |        0.68.1        |
+| 45.0.0           |        0.68.2        |
 | 44.0.0           |        0.64.3        |
 | 43.0.0           |        0.64.3        |
 | 42.0.0           |        0.63.3        |

--- a/docs/pages/versions/v45.0.0/index.md
+++ b/docs/pages/versions/v45.0.0/index.md
@@ -32,7 +32,7 @@ Every quarter there is a new Expo SDK release that typically updates to the late
 
 | Expo SDK Version | React Native Version |
 | ---------------- | -------------------- |
-| 45.0.0           |        0.68.1        |
+| 45.0.0           |        0.68.2        |
 | 44.0.0           |        0.64.3        |
 | 43.0.0           |        0.64.3        |
 | 42.0.0           |        0.63.3        |

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -91,7 +91,7 @@
   "lottie-react-native": "5.0.1",
   "react": "17.0.2",
   "react-dom": "17.0.2",
-  "react-native": "0.68.1",
+  "react-native": "0.68.2",
   "react-native-web": "0.17.1",
   "react-native-branch": "5.0.0",
   "react-native-gesture-handler": "~2.2.0",


### PR DESCRIPTION
# Why

The update to 0.68.2 didn't update the bundled versions json that is used for `expo doctor` etc., as well as some references in the docs.

# How

Manually updated the places I knew needed to be updated. There's a few more deeper references to 0.68.1 in some bundle files in the repo, but I don't know enough about those to touch those.

# Test Plan

NA

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
