### PR TITLE
[docs] expand Expo dict, fix warnings

### DIFF
--- a/docs/expo-dict.json
+++ b/docs/expo-dict.json
@@ -1,10 +1,18 @@
 {
+  "amazon appstore": "Amazon Appstore",
   "android emulator": "Android Emulator",
+  "app store": "App Store",
   "apple developer": "Apple Developer",
   "eas": "EAS",
+  "eas build": "EAS Build",
+  "eas update": "EAS Update",
+  "expo cli": "Expo CLI",
   "expo go": "Expo Go",
   "expo sdk": "Expo SDK",
   "ios simulator": "iOS Simulator",
+  "mac os": "macOS",
+  "play store": "Play Store",
   "react navigation": "React Navigation",
+  "turtle cli": "Turtle CLI",
   "unix": "Unix"
 }

--- a/docs/pages/distribution/release-channels.md
+++ b/docs/pages/distribution/release-channels.md
@@ -63,7 +63,7 @@ You can access the release channel your update is published under with the `Upda
 
 ## Example Workflow
 
-Consider a situation where you have a Staging stack for testing on Expo Go, and a Production stack for pushing through TestFlight, then promoting to the AppStore.
+Consider a situation where you have a Staging stack for testing on Expo Go, and a Production stack for pushing through TestFlight, then promoting to the App Store.
 
 On the staging stack, run `expo publish --release-channel staging`. Your test users can see the staging version of your app by specifying the release channel in the query parameter of the URL (ie)`https://exp.host/@username/yourApp?release-channel=staging`, then opening the URL in their web browser, and finally scanning the QR code with the Expo Go app. Alternatively, they can open that URL directly on their mobile device.
 

--- a/docs/pages/eas-update/faq.md
+++ b/docs/pages/eas-update/faq.md
@@ -6,7 +6,7 @@ title: FAQ
 
 One of the rules of EAS Update is that you need to follow the rules of the platforms and app stores you are building for. This means your updates need to follow the App Store and Play Store guidelines, including the content of the updates and how you use them. This usually means changes to your app’s behavior need to be reviewed.
 
-App store rules regularly change and just like how you’d need to follow them if you were writing an app without Expo, you need to follow them when you’re using Expo and EAS Update.
+App Store rules regularly change and just like how you’d need to follow them if you were writing an app without Expo, you need to follow them when you’re using Expo and EAS Update.
 
 EAS Update is a great way to quickly deliver improvements to the people who use your apps. For example, consider an app that has a critical bug that needs to be fixed. With EAS Update you can quickly get the fix out and later follow up with a new submission that includes the fix built in.
 

--- a/docs/pages/guides/troubleshooting-proxies.md
+++ b/docs/pages/guides/troubleshooting-proxies.md
@@ -2,7 +2,7 @@
 title: Troubleshooting Proxies
 ---
 
-## Mac OS Proxy Configuration (Sierra)
+## macOS Proxy Configuration (Sierra)
 
 > If anything goes wrong, you can revert back to the "Automatic Proxy settings" in System Network Preferences using Automatic Proxy Configuration `your-corporate-proxy-uri:port-number/proxy.pac`
 
@@ -10,7 +10,7 @@ title: Troubleshooting Proxies
 
 In order to run this in the local iOS Simulator while on your corporate wi-fi network, a local proxy manager is required. This local proxy application, named [Charles](http://charlesproxy.com), is what our iOS Dev Team uses. Meet Charles, get to know him. He is your friend.
 
-#### Open Mac OS Network Preferences
+#### Open macOS Network Preferences
 
 1. Open `System Preferences` for your Mac (Apple Menu > System Preferences).
 2. Go to Network.
@@ -26,7 +26,7 @@ In order to run this in the local iOS Simulator while on your corporate wi-fi ne
 ### Configure `Charles`
 
 1. Open Charles
-2. If it asks, don't allow it to manage your Mac OS Network Configuration, the previous steps do that. (If you change Charles port, update the previous step to the correct port instead of default 8888)
+2. If it asks, don't allow it to manage your macOS Network Configuration, the previous steps do that. (If you change Charles port, update the previous step to the correct port instead of default 8888)
 3. In the menu of Charles go to `Proxy > External Proxy Settings`, check `Use external proxy servers`
 4. Check `Web Proxy (HTTP)`, and enter `your-corporate-proxy-uri:port-number`
 5. Check `Proxy server requires a password`

--- a/docs/pages/workflow/already-used-react-native.md
+++ b/docs/pages/workflow/already-used-react-native.md
@@ -23,7 +23,7 @@ Managed Expo projects also offer updates and a push notification service.
 
 - If you've ever been in a situation where you find a spelling mistake in your app and have to wait for Apple to approve a change, you'll appreciate updates - these changes will appear as soon as you run `expo publish`! You aren't limited to text either, this applies to assets like images and configuration updates too!
 
-There's no need to re-build or redeploy your app to the App and Play store. It's like [Code Push](https://microsoft.github.io/code-push/) if you've used that before. There are a few limitations, however. [Read about those here](../workflow/publishing.md#limitations).
+There's no need to re-build or redeploy your app to the App Store and Play Store. It's like [Code Push](https://microsoft.github.io/code-push/) if you've used that before. There are a few limitations, however. [Read about those here](../workflow/publishing.md#limitations).
 
 Expo offers a shared configuration file we call a _manifest_.
 


### PR DESCRIPTION
# Why & How

This small PR add few new phrases to the Expo dict for `case-police` lint.

Additionally it fixes new issues reported after expanding the dict.

# Test Plan

`yarn lint-case` run in docs directory do not out any warnings.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
