### PR TITLE
[ci] add matrix support for slack webhook

### DIFF
--- a/.github/workflows/development-client-latest-e2e.yml
+++ b/.github/workflows/development-client-latest-e2e.yml
@@ -63,6 +63,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_dev_client }}
+          MATRIX_CONTEXT: ${{ toJson(matrix) }}
         with:
           channel: '#dev-clients'
           status: ${{ job.status }}

--- a/.github/workflows/shell-app-android.yml
+++ b/.github/workflows/shell-app-android.yml
@@ -87,6 +87,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_ANDROID }}
+          MATRIX_CONTEXT: ${{ toJson(matrix) }}
         with:
           channel: '#expo-android'
           status: ${{ job.status }}

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -203,6 +203,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_android }}
+          MATRIX_CONTEXT: ${{ toJson(matrix) }}
         with:
           channel: '#expo-android'
           status: ${{ job.status }}


### PR DESCRIPTION
# Why

fix slack bot job name error after we introduced matrix in #17162

before
![Screen Shot 2022-05-12 at 10 40 33 PM](https://user-images.githubusercontent.com/46429/168101554-9f5766ce-1a04-46ac-87a8-36ea4639aa60.png)

after
![Screen Shot 2022-05-12 at 10 40 42 PM](https://user-images.githubusercontent.com/46429/168101576-6e64a143-2a59-425e-a555-141ba713391e.png)


# How

according [the document](https://action-slack.netlify.app/fields), add the `MATRIX_CONTEXT`

