### PR TITLE
docs: add migration guide for expo-cli

### DIFF
--- a/docs/pages/workflow/expo-cli.md
+++ b/docs/pages/workflow/expo-cli.md
@@ -1011,13 +1011,15 @@ In Expo SDK 46, we're migrating to a new suite of tooling that is versioned in t
 | Legacy                        | Notes                           |
 | ----------------------------- | ------------------------------- |
 | `expo client:ios`             | Removed in favor of Dev Clients |
-| `expo send`                   | Unimplemented                   |
+| `expo send`                   | Removed                         |
 | `expo client:install:ios`     | Unimplemented                   |
 | `expo client:install:android` | Unimplemented                   |
 | `expo doctor`                 | Undecided                       |
 | `expo upgrade`                | Undecided                       |
 
 ### Services
+
+> The new `expo update` command uses a different hosting service than the legacy `expo publish` command.
 
 | Legacy                           | New                     | Notes              |
 | -------------------------------- | ----------------------- | ------------------ |
@@ -1027,20 +1029,20 @@ In Expo SDK 46, we're migrating to a new suite of tooling that is versioned in t
 | `expo publish:history`           | `eas update`            | Moved to `eas-cli` |
 | `expo publish:details`           | `eas update`            | Moved to `eas-cli` |
 | `expo credentials:manager`       | `eas credentials`       | Moved to `eas-cli` |
-| `expo fetch:ios:certs`           | `eas XXX`               | Moved to `eas-cli` |
-| `expo fetch:android:keystore`    | `eas XXX`               | Moved to `eas-cli` |
-| `expo fetch:android:hashes`      | `eas XXX`               | Moved to `eas-cli` |
-| `expo fetch:android:upload-cert` | `eas XXX`               | Moved to `eas-cli` |
-| `expo push:android:upload`       | `eas XXX`               | Moved to `eas-cli` |
-| `expo push:android:show`         | `eas XXX`               | Moved to `eas-cli` |
-| `expo push:android:clear`        | `eas XXX`               | Moved to `eas-cli` |
-| `expo url`                       | `eas XXX`               | Moved to `eas-cli` |
-| `expo url:ipa`                   | `eas XXX`               | Moved to `eas-cli` |
-| `expo url:apk`                   | `eas XXX`               | Moved to `eas-cli` |
-| `expo webhooks`                  | `eas XXX`               | Moved to `eas-cli` |
-| `expo webhooks:add`              | `eas XXX`               | Moved to `eas-cli` |
-| `expo webhooks:remove`           | `eas XXX`               | Moved to `eas-cli` |
-| `expo webhooks:update`           | `eas XXX`               | Moved to `eas-cli` |
+| `expo fetch:ios:certs`           | `eas credentials`       | Moved to `eas-cli` |
+| `expo fetch:android:keystore`    | `eas credentials`       | Moved to `eas-cli` |
+| `expo fetch:android:hashes`      | `eas credentials`       | Moved to `eas-cli` |
+| `expo fetch:android:upload-cert` | `eas credentials`       | Moved to `eas-cli` |
+| `expo push:android:upload`       | `eas credentials`       | Moved to `eas-cli` |
+| `expo push:android:show`         | `eas credentials`       | Moved to `eas-cli` |
+| `expo push:android:clear`        | `eas credentials`       | Moved to `eas-cli` |
+| `expo url`                       | `eas build:list`        | Moved to `eas-cli` |
+| `expo url:ipa`                   | `eas build:list`        | Moved to `eas-cli` |
+| `expo url:apk`                   | `eas build:list`        | Moved to `eas-cli` |
+| `expo webhooks`                  | `eas webhook`           | Moved to `eas-cli` |
+| `expo webhooks:add`              | `eas webhook:create`    | Moved to `eas-cli` |
+| `expo webhooks:remove`           | `eas webhook:delete`    | Moved to `eas-cli` |
+| `expo webhooks:update`           | `eas webhook:update`    | Moved to `eas-cli` |
 | `expo build:ios`                 | `eas build -p ios`      | Moved to `eas-cli` |
 | `expo build:android`             | `eas build -p android`  | Moved to `eas-cli` |
 | `expo build:status`              | `eas build:list`        | Moved to `eas-cli` |

--- a/docs/pages/workflow/expo-cli.md
+++ b/docs/pages/workflow/expo-cli.md
@@ -44,24 +44,23 @@ The commands listed below are derived from the latest version of Expo CLI. You c
 </summary>
 <p>
 
-| Option         | Description             |
-| -------------- | ----------------------- |
-| `--platform [all\|android\|ios]` | Platforms: android, ios, all |
-| `-p, --public-url [url]` | The public url that will host the static files (required) |
-| `-c, --clear` | Clear the Metro bundler cache |
-| `--output-dir [dir]` | The directory to export the static files to |
-| `-a, --asset-url [url]` | The absolute or relative url that will host the asset files |
-| `-d, --dump-assetmap` | Dump the asset map for further processing |
-| `--dev` | Configure static files for developing locally using a non-https server |
-| `-s, --dump-sourcemap` | Dump the source map for debugging the JS bundle |
-| `-q, --quiet` | Suppress verbose output |
-| `-t, --target [managed\|bare]` | Target environment for which this export is intended |
-| `--merge-src-dir [dir]` | A repeatable source dir to merge in |
-| `--merge-src-url [url]` | A repeatable source tar.gz file URL to merge in |
-| `--max-workers [num]` | Maximum number of tasks to allow Metro to spawn |
-| `--experimental-bundle` | export bundles for use with EAS updates |
-| `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
-
+| Option                           | Description                                                            |
+| -------------------------------- | ---------------------------------------------------------------------- |
+| `--platform [all\|android\|ios]` | Platforms: android, ios, all                                           |
+| `-p, --public-url [url]`         | The public url that will host the static files (required)              |
+| `-c, --clear`                    | Clear the Metro bundler cache                                          |
+| `--output-dir [dir]`             | The directory to export the static files to                            |
+| `-a, --asset-url [url]`          | The absolute or relative url that will host the asset files            |
+| `-d, --dump-assetmap`            | Dump the asset map for further processing                              |
+| `--dev`                          | Configure static files for developing locally using a non-https server |
+| `-s, --dump-sourcemap`           | Dump the source map for debugging the JS bundle                        |
+| `-q, --quiet`                    | Suppress verbose output                                                |
+| `-t, --target [managed\|bare]`   | Target environment for which this export is intended                   |
+| `--merge-src-dir [dir]`          | A repeatable source dir to merge in                                    |
+| `--merge-src-url [url]`          | A repeatable source tar.gz file URL to merge in                        |
+| `--max-workers [num]`            | Maximum number of tasks to allow Metro to spawn                        |
+| `--experimental-bundle`          | export bundles for use with EAS updates                                |
+| `--config [file]`                | Deprecated: Use app.config.js to switch config files instead.          |
 
 </p>
 </details>
@@ -75,15 +74,14 @@ The commands listed below are derived from the latest version of Expo CLI. You c
 
 Alias: `expo i`
 
-| Option         | Description             |
-| -------------- | ----------------------- |
+| Option                  | Description                                                                                                                                                                      |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `-t, --template [name]` | Specify which template to use. Valid options are "blank", "tabs", "bare-minimum" or a package on npm (e.g. "expo-template-bare-minimum") that includes an Expo project template. |
-| `--npm` | Use npm to install dependencies. (default when Yarn is not installed) |
-| `--yarn` | Use Yarn to install dependencies. (default when Yarn is installed) |
-| `--no-install` | Skip installing npm packages or CocoaPods. |
-| `--name [name]` | The name of your app visible on the home screen. |
-| `--yes` | Use default options. Same as "expo init . --template blank |
-
+| `--npm`                 | Use npm to install dependencies. (default when Yarn is not installed)                                                                                                            |
+| `--yarn`                | Use Yarn to install dependencies. (default when Yarn is installed)                                                                                                               |
+| `--no-install`          | Skip installing npm packages or CocoaPods.                                                                                                                                       |
+| `--name [name]`         | The name of your app visible on the home screen.                                                                                                                                 |
+| `--yes`                 | Use default options. Same as "expo init . --template blank                                                                                                                       |
 
 </p>
 </details>
@@ -97,11 +95,10 @@ Alias: `expo i`
 
 Alias: `expo add`
 
-| Option         | Description             |
-| -------------- | ----------------------- |
-| `--npm` | Use npm to install dependencies. (default when package-lock.json exists) |
-| `--yarn` | Use Yarn to install dependencies. (default when yarn.lock exists) |
-
+| Option   | Description                                                              |
+| -------- | ------------------------------------------------------------------------ |
+| `--npm`  | Use npm to install dependencies. (default when package-lock.json exists) |
+| `--yarn` | Use Yarn to install dependencies. (default when yarn.lock exists)        |
 
 </p>
 </details>
@@ -113,14 +110,13 @@ Alias: `expo add`
 </summary>
 <p>
 
-| Option         | Description             |
-| -------------- | ----------------------- |
-| `--no-bundler` | Skip starting the Metro bundler |
-| `-d, --device [device]` | Device name to build the app on |
-| `-p, --port [port]` | Port to start the Metro bundler on. Default: 8081 |
-| `--variant [name]` | (Android) build variant |
-| `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
-
+| Option                  | Description                                                   |
+| ----------------------- | ------------------------------------------------------------- |
+| `--no-bundler`          | Skip starting the Metro bundler                               |
+| `-d, --device [device]` | Device name to build the app on                               |
+| `-p, --port [port]`     | Port to start the Metro bundler on. Default: 8081             |
+| `--variant [name]`      | (Android) build variant                                       |
+| `--config [file]`       | Deprecated: Use app.config.js to switch config files instead. |
 
 </p>
 </details>
@@ -132,17 +128,16 @@ Alias: `expo add`
 </summary>
 <p>
 
-| Option         | Description             |
-| -------------- | ----------------------- |
-| `--no-build-cache` | Clear the native derived data before building |
-| `--no-install` | Skip installing dependencies |
-| `--no-bundler` | Skip starting the Metro bundler |
-| `-d, --device [device]` | Device name or UDID to build the app on |
-| `-p, --port [port]` | Port to start the Metro bundler on. Default: 8081 |
-| `--scheme [scheme]` | Scheme to build |
-| `--configuration [configuration]` | Xcode configuration to use. Debug or Release. Default: Debug |
-| `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
-
+| Option                            | Description                                                   |
+| --------------------------------- | ------------------------------------------------------------- |
+| `--no-build-cache`                | Clear the native derived data before building                 |
+| `--no-install`                    | Skip installing dependencies                                  |
+| `--no-bundler`                    | Skip starting the Metro bundler                               |
+| `-d, --device [device]`           | Device name or UDID to build the app on                       |
+| `-p, --port [port]`               | Port to start the Metro bundler on. Default: 8081             |
+| `--scheme [scheme]`               | Scheme to build                                               |
+| `--configuration [configuration]` | Xcode configuration to use. Debug or Release. Default: Debug  |
+| `--config [file]`                 | Deprecated: Use app.config.js to switch config files instead. |
 
 </p>
 </details>
@@ -154,20 +149,19 @@ Alias: `expo add`
 </summary>
 <p>
 
-| Option         | Description             |
-| -------------- | ----------------------- |
-| `-s, --send-to [dest]` | Email address to send the URL to |
-| `--dev-client` | Experimental: Starts the bundler for use with the expo-development-client |
-| `--scheme [scheme]` | Custom URI protocol to use with a development build |
-| `-a, --android` | Opens your app in Expo Go on a connected Android device |
-| `-i, --ios` | Opens your app in Expo Go in a currently running iOS simulator on your computer |
-| `-w, --web` | Opens your app in a web browser |
-| `-m, --host [mode]` | lan (default), tunnel, localhost. Type of host to use. "tunnel" allows you to view your link on other networks |
-| `--tunnel` | Same as --host tunnel |
-| `--lan` | Same as --host lan |
-| `--localhost` | Same as --host localhost |
-| `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
-
+| Option                 | Description                                                                                                    |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `-s, --send-to [dest]` | Email address to send the URL to                                                                               |
+| `--dev-client`         | Experimental: Starts the bundler for use with the expo-development-client                                      |
+| `--scheme [scheme]`    | Custom URI protocol to use with a development build                                                            |
+| `-a, --android`        | Opens your app in Expo Go on a connected Android device                                                        |
+| `-i, --ios`            | Opens your app in Expo Go in a currently running iOS simulator on your computer                                |
+| `-w, --web`            | Opens your app in a web browser                                                                                |
+| `-m, --host [mode]`    | lan (default), tunnel, localhost. Type of host to use. "tunnel" allows you to view your link on other networks |
+| `--tunnel`             | Same as --host tunnel                                                                                          |
+| `--lan`                | Same as --host lan                                                                                             |
+| `--localhost`          | Same as --host localhost                                                                                       |
+| `--config [file]`      | Deprecated: Use app.config.js to switch config files instead.                                                  |
 
 </p>
 </details>
@@ -181,31 +175,30 @@ Alias: `expo add`
 
 Alias: `expo r`
 
-| Option         | Description             |
-| -------------- | ----------------------- |
-| `-s, --send-to [dest]` | An email address to send a link to |
-| `-c, --clear` | Clear the Metro bundler cache |
-| `--max-workers [num]` | Maximum number of tasks to allow Metro to spawn. |
-| `--no-dev` | Turn development mode off |
-| `--minify` | Minify code |
-| `--https` | To start webpack with https protocol |
-| `--force-manifest-type [manifest-type]` | Override auto detection of manifest type |
-| `-p, --port [port]` | Port to start the native Metro bundler on (does not apply to web or tunnel). Default: 19000 |
-| `--dev-client` | Experimental: Starts the bundler for use with the expo-development-client |
-| `--scheme [scheme]` | Custom URI protocol to use with a development build |
-| `-a, --android` | Opens your app in Expo Go on a connected Android device |
-| `-i, --ios` | Opens your app in Expo Go in a currently running iOS simulator on your computer |
-| `-w, --web` | Opens your app in a web browser |
-| `-m, --host [mode]` | lan (default), tunnel, localhost. Type of host to use. "tunnel" allows you to view your link on other networks |
-| `--tunnel` | Same as --host tunnel |
-| `--lan` | Same as --host lan |
-| `--localhost` | Same as --host localhost |
-| `--offline` | Allows this command to run while offline |
-| `--dev` | Deprecated: Dev mode is used by default |
-| `--no-minify` | Deprecated: Minify is disabled by default |
-| `--no-https` | Deprecated: https is disabled by default |
-| `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
-
+| Option                                  | Description                                                                                                    |
+| --------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `-s, --send-to [dest]`                  | An email address to send a link to                                                                             |
+| `-c, --clear`                           | Clear the Metro bundler cache                                                                                  |
+| `--max-workers [num]`                   | Maximum number of tasks to allow Metro to spawn.                                                               |
+| `--no-dev`                              | Turn development mode off                                                                                      |
+| `--minify`                              | Minify code                                                                                                    |
+| `--https`                               | To start webpack with https protocol                                                                           |
+| `--force-manifest-type [manifest-type]` | Override auto detection of manifest type                                                                       |
+| `-p, --port [port]`                     | Port to start the native Metro bundler on (does not apply to web or tunnel). Default: 19000                    |
+| `--dev-client`                          | Experimental: Starts the bundler for use with the expo-development-client                                      |
+| `--scheme [scheme]`                     | Custom URI protocol to use with a development build                                                            |
+| `-a, --android`                         | Opens your app in Expo Go on a connected Android device                                                        |
+| `-i, --ios`                             | Opens your app in Expo Go in a currently running iOS simulator on your computer                                |
+| `-w, --web`                             | Opens your app in a web browser                                                                                |
+| `-m, --host [mode]`                     | lan (default), tunnel, localhost. Type of host to use. "tunnel" allows you to view your link on other networks |
+| `--tunnel`                              | Same as --host tunnel                                                                                          |
+| `--lan`                                 | Same as --host lan                                                                                             |
+| `--localhost`                           | Same as --host localhost                                                                                       |
+| `--offline`                             | Allows this command to run while offline                                                                       |
+| `--dev`                                 | Deprecated: Dev mode is used by default                                                                        |
+| `--no-minify`                           | Deprecated: Minify is disabled by default                                                                      |
+| `--no-https`                            | Deprecated: https is disabled by default                                                                       |
+| `--config [file]`                       | Deprecated: Use app.config.js to switch config files instead.                                                  |
 
 </p>
 </details>
@@ -219,29 +212,28 @@ Alias: `expo r`
 
 Alias: `expo web`
 
-| Option         | Description             |
-| -------------- | ----------------------- |
-| `--no-dev` | Turn development mode off |
-| `--minify` | Minify code |
-| `--https` | To start webpack with https protocol |
-| `--force-manifest-type [manifest-type]` | Override auto detection of manifest type |
-| `-p, --port [port]` | Port to start the Webpack bundler on. Default: 19006 |
-| `-s, --send-to [dest]` | An email address to send a link to |
-| `--dev-client` | Experimental: Starts the bundler for use with the expo-development-client |
-| `--scheme [scheme]` | Custom URI protocol to use with a development build |
-| `-a, --android` | Opens your app in Expo Go on a connected Android device |
-| `-i, --ios` | Opens your app in Expo Go in a currently running iOS simulator on your computer |
-| `-w, --web` | Opens your app in a web browser |
-| `-m, --host [mode]` | lan (default), tunnel, localhost. Type of host to use. "tunnel" allows you to view your link on other networks |
-| `--tunnel` | Same as --host tunnel |
-| `--lan` | Same as --host lan |
-| `--localhost` | Same as --host localhost |
-| `--offline` | Allows this command to run while offline |
-| `--dev` | Deprecated: Dev mode is used by default |
-| `--no-minify` | Deprecated: Minify is disabled by default |
-| `--no-https` | Deprecated: https is disabled by default |
-| `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
-
+| Option                                  | Description                                                                                                    |
+| --------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `--no-dev`                              | Turn development mode off                                                                                      |
+| `--minify`                              | Minify code                                                                                                    |
+| `--https`                               | To start webpack with https protocol                                                                           |
+| `--force-manifest-type [manifest-type]` | Override auto detection of manifest type                                                                       |
+| `-p, --port [port]`                     | Port to start the Webpack bundler on. Default: 19006                                                           |
+| `-s, --send-to [dest]`                  | An email address to send a link to                                                                             |
+| `--dev-client`                          | Experimental: Starts the bundler for use with the expo-development-client                                      |
+| `--scheme [scheme]`                     | Custom URI protocol to use with a development build                                                            |
+| `-a, --android`                         | Opens your app in Expo Go on a connected Android device                                                        |
+| `-i, --ios`                             | Opens your app in Expo Go in a currently running iOS simulator on your computer                                |
+| `-w, --web`                             | Opens your app in a web browser                                                                                |
+| `-m, --host [mode]`                     | lan (default), tunnel, localhost. Type of host to use. "tunnel" allows you to view your link on other networks |
+| `--tunnel`                              | Same as --host tunnel                                                                                          |
+| `--lan`                                 | Same as --host lan                                                                                             |
+| `--localhost`                           | Same as --host localhost                                                                                       |
+| `--offline`                             | Allows this command to run while offline                                                                       |
+| `--dev`                                 | Deprecated: Dev mode is used by default                                                                        |
+| `--no-minify`                           | Deprecated: Minify is disabled by default                                                                      |
+| `--no-https`                            | Deprecated: https is disabled by default                                                                       |
+| `--config [file]`                       | Deprecated: Use app.config.js to switch config files instead.                                                  |
 
 </p>
 </details>
@@ -259,12 +251,11 @@ Alias: `expo web`
 
 Alias: `expo signin`
 
-| Option         | Description             |
-| -------------- | ----------------------- |
-| `-u, --username [string]` | Username |
-| `-p, --password [string]` | Password |
-| `--otp [string]` | One-time password from your 2FA device |
-
+| Option                    | Description                            |
+| ------------------------- | -------------------------------------- |
+| `-u, --username [string]` | Username                               |
+| `-p, --password [string]` | Password                               |
+| `--otp [string]`          | One-time password from your 2FA device |
 
 </p>
 </details>
@@ -318,10 +309,9 @@ This command does not take any options.
 </summary>
 <p>
 
-| Option         | Description             |
-| -------------- | ----------------------- |
+| Option     | Description                                                                  |
+| ---------- | ---------------------------------------------------------------------------- |
 | `--latest` | Install the latest version of Expo Go, ignoring the current project version. |
-
 
 </p>
 </details>
@@ -333,11 +323,10 @@ This command does not take any options.
 </summary>
 <p>
 
-| Option         | Description             |
-| -------------- | ----------------------- |
-| `-d, --device [device]` | Device name to install the client on |
-| `--latest` | Install the latest version of Expo Go, ignore the current project version. |
-
+| Option                  | Description                                                                |
+| ----------------------- | -------------------------------------------------------------------------- |
+| `-d, --device [device]` | Device name to install the client on                                       |
+| `--latest`              | Install the latest version of Expo Go, ignore the current project version. |
 
 </p>
 </details>
@@ -353,13 +342,12 @@ This command does not take any options.
 </summary>
 <p>
 
-| Option         | Description             |
-| -------------- | ----------------------- |
-| `-t, --type [public\|prebuild\|introspect]` | Type of config to show. |
-| `--full` | Include all project config data |
-| `--json` | Output in JSON format |
-| `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
-
+| Option                                      | Description                                                   |
+| ------------------------------------------- | ------------------------------------------------------------- |
+| `-t, --type [public\|prebuild\|introspect]` | Type of config to show.                                       |
+| `--full`                                    | Include all project config data                               |
+| `--json`                                    | Output in JSON format                                         |
+| `--config [file]`                           | Deprecated: Use app.config.js to switch config files instead. |
 
 </p>
 </details>
@@ -371,10 +359,9 @@ This command does not take any options.
 </summary>
 <p>
 
-| Option         | Description             |
-| -------------- | ----------------------- |
+| Option            | Description                                                   |
+| ----------------- | ------------------------------------------------------------- |
 | `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
-
 
 </p>
 </details>
@@ -386,11 +373,10 @@ This command does not take any options.
 </summary>
 <p>
 
-| Option         | Description             |
-| -------------- | ----------------------- |
-| `--fix-dependencies` | Fix incompatible dependency versions |
-| `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
-
+| Option               | Description                                                   |
+| -------------------- | ------------------------------------------------------------- |
+| `--fix-dependencies` | Fix incompatible dependency versions                          |
+| `--config [file]`    | Deprecated: Use app.config.js to switch config files instead. |
 
 </p>
 </details>
@@ -404,11 +390,10 @@ This command does not take any options.
 
 Alias: `expo update`
 
-| Option         | Description             |
-| -------------- | ----------------------- |
-| `--npm` | Use npm to install dependencies. (default when package-lock.json exists) |
-| `--yarn` | Use Yarn to install dependencies. (default when yarn.lock exists) |
-
+| Option   | Description                                                              |
+| -------- | ------------------------------------------------------------------------ |
+| `--npm`  | Use npm to install dependencies. (default when package-lock.json exists) |
+| `--yarn` | Use Yarn to install dependencies. (default when yarn.lock exists)        |
 
 </p>
 </details>
@@ -424,12 +409,11 @@ Alias: `expo update`
 </summary>
 <p>
 
-| Option         | Description             |
-| -------------- | ----------------------- |
-| `-f, --force` | Allows replacing existing files |
-| `--offline` | Allows this command to run while offline |
+| Option            | Description                                                   |
+| ----------------- | ------------------------------------------------------------- |
+| `-f, --force`     | Allows replacing existing files                               |
+| `--offline`       | Allows this command to run while offline                      |
 | `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
-
 
 </p>
 </details>
@@ -441,13 +425,12 @@ Alias: `expo update`
 </summary>
 <p>
 
-| Option         | Description             |
-| -------------- | ----------------------- |
-| `--no-install` | Skip installing npm packages and CocoaPods. |
-| `--npm` | Use npm to install dependencies. (default when Yarn is not installed) |
-| `-p, --platform [all\|android\|ios]` | Platforms to sync: ios, android, all. Default: all |
-| `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
-
+| Option                               | Description                                                           |
+| ------------------------------------ | --------------------------------------------------------------------- |
+| `--no-install`                       | Skip installing npm packages and CocoaPods.                           |
+| `--npm`                              | Use npm to install dependencies. (default when Yarn is not installed) |
+| `-p, --platform [all\|android\|ios]` | Platforms to sync: ios, android, all. Default: all                    |
+| `--config [file]`                    | Deprecated: Use app.config.js to switch config files instead.         |
 
 </p>
 </details>
@@ -459,16 +442,15 @@ Alias: `expo update`
 </summary>
 <p>
 
-| Option         | Description             |
-| -------------- | ----------------------- |
-| `--no-install` | Skip installing npm packages and CocoaPods. |
-| `--clean` | Delete the native folders and regenerate them before applying changes |
-| `--npm` | Use npm to install dependencies. (default when Yarn is not installed) |
-| `--template [template]` | Project template to clone from. File path pointing to a local tar file or a github repo |
-| `-p, --platform [all\|android\|ios]` | Platforms to sync: ios, android, all. Default: all |
-| `--skip-dependency-update [dependencies]` | Preserves versions of listed packages in package.json (comma separated list) |
-| `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
-
+| Option                                    | Description                                                                             |
+| ----------------------------------------- | --------------------------------------------------------------------------------------- |
+| `--no-install`                            | Skip installing npm packages and CocoaPods.                                             |
+| `--clean`                                 | Delete the native folders and regenerate them before applying changes                   |
+| `--npm`                                   | Use npm to install dependencies. (default when Yarn is not installed)                   |
+| `--template [template]`                   | Project template to clone from. File path pointing to a local tar file or a github repo |
+| `-p, --platform [all\|android\|ios]`      | Platforms to sync: ios, android, all. Default: all                                      |
+| `--skip-dependency-update [dependencies]` | Preserves versions of listed packages in package.json (comma separated list)            |
+| `--config [file]`                         | Deprecated: Use app.config.js to switch config files instead.                           |
 
 </p>
 </details>
@@ -486,16 +468,15 @@ Alias: `expo update`
 
 Alias: `expo p`
 
-| Option         | Description             |
-| -------------- | ----------------------- |
-| `-q, --quiet` | Suppress verbose output from the Metro bundler. |
-| `-s, --send-to [dest]` | A phone number or email address to send a link to |
-| `-c, --clear` | Clear the Metro bundler cache |
+| Option                         | Description                                                                             |
+| ------------------------------ | --------------------------------------------------------------------------------------- |
+| `-q, --quiet`                  | Suppress verbose output from the Metro bundler.                                         |
+| `-s, --send-to [dest]`         | A phone number or email address to send a link to                                       |
+| `-c, --clear`                  | Clear the Metro bundler cache                                                           |
 | `-t, --target [managed\|bare]` | Target environment for which this publish is intended. Options are `managed` or `bare`. |
-| `--max-workers [num]` | Maximum number of tasks to allow Metro to spawn. |
-| `--release-channel [name]` | The release channel to publish to. Default is 'default'. |
-| `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
-
+| `--max-workers [num]`          | Maximum number of tasks to allow Metro to spawn.                                        |
+| `--release-channel [name]`     | The release channel to publish to. Default is 'default'.                                |
+| `--config [file]`              | Deprecated: Use app.config.js to switch config files instead.                           |
 
 </p>
 </details>
@@ -509,12 +490,11 @@ Alias: `expo p`
 
 Alias: `expo ps`
 
-| Option         | Description             |
-| -------------- | ----------------------- |
-| `-c, --release-channel [name]` | The channel to set the published release. (Required) |
+| Option                          | Description                                                           |
+| ------------------------------- | --------------------------------------------------------------------- |
+| `-c, --release-channel [name]`  | The channel to set the published release. (Required)                  |
 | `-p, --publish-id [publish-id]` | The id of the published release to serve from the channel. (Required) |
-| `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
-
+| `--config [file]`               | Deprecated: Use app.config.js to switch config files instead.         |
 
 </p>
 </details>
@@ -528,14 +508,13 @@ Alias: `expo ps`
 
 Alias: `expo pr`
 
-| Option         | Description             |
-| -------------- | ----------------------- |
-| `--channel-id [channel-id]` | This flag is deprecated. |
-| `-c, --release-channel [name]` | The channel to rollback from. (Required) |
-| `-s, --sdk-version [version]` | The sdk version to rollback. (Required) |
-| `-p, --platform [android\|ios]` | The platform to rollback. |
-| `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
-
+| Option                          | Description                                                   |
+| ------------------------------- | ------------------------------------------------------------- |
+| `--channel-id [channel-id]`     | This flag is deprecated.                                      |
+| `-c, --release-channel [name]`  | The channel to rollback from. (Required)                      |
+| `-s, --sdk-version [version]`   | The sdk version to rollback. (Required)                       |
+| `-p, --platform [android\|ios]` | The platform to rollback.                                     |
+| `--config [file]`               | Deprecated: Use app.config.js to switch config files instead. |
 
 </p>
 </details>
@@ -549,15 +528,14 @@ Alias: `expo pr`
 
 Alias: `expo ph`
 
-| Option         | Description             |
-| -------------- | ----------------------- |
-| `-c, --release-channel [name]` | Filter by release channel. If this flag is not included, the most recent publications will be shown. |
-| `--count [number-of-logs]` | Number of logs to view, maximum 100, default 5. |
-| `-p, --platform [android\|ios]` | Filter by platform, android or ios. Defaults to both platforms. |
-| `-s, --sdk-version [version]` | Filter by SDK version e.g. 35.0.0 |
-| `-r, --raw` | Produce some raw output. |
-| `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
-
+| Option                          | Description                                                                                          |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `-c, --release-channel [name]`  | Filter by release channel. If this flag is not included, the most recent publications will be shown. |
+| `--count [number-of-logs]`      | Number of logs to view, maximum 100, default 5.                                                      |
+| `-p, --platform [android\|ios]` | Filter by platform, android or ios. Defaults to both platforms.                                      |
+| `-s, --sdk-version [version]`   | Filter by SDK version e.g. 35.0.0                                                                    |
+| `-r, --raw`                     | Produce some raw output.                                                                             |
+| `--config [file]`               | Deprecated: Use app.config.js to switch config files instead.                                        |
 
 </p>
 </details>
@@ -571,12 +549,11 @@ Alias: `expo ph`
 
 Alias: `expo pd`
 
-| Option         | Description             |
-| -------------- | ----------------------- |
-| `--publish-id [publish-id]` | Publication id. (Required) |
-| `-r, --raw` | Produce some raw output. |
-| `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
-
+| Option                      | Description                                                   |
+| --------------------------- | ------------------------------------------------------------- |
+| `--publish-id [publish-id]` | Publication id. (Required)                                    |
+| `-r, --raw`                 | Produce some raw output.                                      |
+| `--config [file]`           | Deprecated: Use app.config.js to switch config files instead. |
 
 </p>
 </details>
@@ -592,13 +569,12 @@ Alias: `expo pd`
 </summary>
 <p>
 
-| Option         | Description             |
-| -------------- | ----------------------- |
-| `-c, --clear` | Clear all cached build files and assets. |
-| `--no-pwa` | Prevent webpack from generating the manifest.json and injecting meta into the index.html head. |
-| `-d, --dev` | Turns dev flag on before bundling |
-| `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
-
+| Option            | Description                                                                                    |
+| ----------------- | ---------------------------------------------------------------------------------------------- |
+| `-c, --clear`     | Clear all cached build files and assets.                                                       |
+| `--no-pwa`        | Prevent webpack from generating the manifest.json and injecting meta into the index.html head. |
+| `-d, --dev`       | Turns dev flag on before bundling                                                              |
+| `--config [file]` | Deprecated: Use app.config.js to switch config files instead.                                  |
 
 </p>
 </details>
@@ -614,11 +590,10 @@ Alias: `expo pd`
 </summary>
 <p>
 
-| Option         | Description             |
-| -------------- | ----------------------- |
-| `-p --platform [android\|ios]` | Platform: [android\|ios] |
-| `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
-
+| Option                         | Description                                                   |
+| ------------------------------ | ------------------------------------------------------------- |
+| `-p --platform [android\|ios]` | Platform: [android\|ios]                                      |
+| `--config [file]`              | Deprecated: Use app.config.js to switch config files instead. |
 
 </p>
 </details>
@@ -630,10 +605,9 @@ Alias: `expo pd`
 </summary>
 <p>
 
-| Option         | Description             |
-| -------------- | ----------------------- |
+| Option            | Description                                                   |
+| ----------------- | ------------------------------------------------------------- |
 | `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
-
 
 </p>
 </details>
@@ -645,10 +619,9 @@ Alias: `expo pd`
 </summary>
 <p>
 
-| Option         | Description             |
-| -------------- | ----------------------- |
+| Option            | Description                                                   |
+| ----------------- | ------------------------------------------------------------- |
 | `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
-
 
 </p>
 </details>
@@ -660,10 +633,9 @@ Alias: `expo pd`
 </summary>
 <p>
 
-| Option         | Description             |
-| -------------- | ----------------------- |
+| Option            | Description                                                   |
+| ----------------- | ------------------------------------------------------------- |
 | `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
-
 
 </p>
 </details>
@@ -675,10 +647,9 @@ Alias: `expo pd`
 </summary>
 <p>
 
-| Option         | Description             |
-| -------------- | ----------------------- |
+| Option            | Description                                                   |
+| ----------------- | ------------------------------------------------------------- |
 | `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
-
 
 </p>
 </details>
@@ -694,11 +665,10 @@ Alias: `expo pd`
 </summary>
 <p>
 
-| Option         | Description             |
-| -------------- | ----------------------- |
-| `--api-key [api-key]` | Server API key for FCM. |
-| `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
-
+| Option                | Description                                                   |
+| --------------------- | ------------------------------------------------------------- |
+| `--api-key [api-key]` | Server API key for FCM.                                       |
+| `--config [file]`     | Deprecated: Use app.config.js to switch config files instead. |
 
 </p>
 </details>
@@ -710,10 +680,9 @@ Alias: `expo pd`
 </summary>
 <p>
 
-| Option         | Description             |
-| -------------- | ----------------------- |
+| Option            | Description                                                   |
+| ----------------- | ------------------------------------------------------------- |
 | `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
-
 
 </p>
 </details>
@@ -725,10 +694,9 @@ Alias: `expo pd`
 </summary>
 <p>
 
-| Option         | Description             |
-| -------------- | ----------------------- |
+| Option            | Description                                                   |
+| ----------------- | ------------------------------------------------------------- |
 | `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
-
 
 </p>
 </details>
@@ -746,20 +714,19 @@ Alias: `expo pd`
 
 Alias: `expo u`
 
-| Option         | Description             |
-| -------------- | ----------------------- |
-| `--dev-client` | Experimental: Starts the bundler for use with the expo-development-client |
-| `--scheme [scheme]` | Custom URI protocol to use with a development build |
-| `-a, --android` | Opens your app in Expo Go on a connected Android device |
-| `-i, --ios` | Opens your app in Expo Go in a currently running iOS simulator on your computer |
-| `-w, --web` | Opens your app in a web browser |
+| Option              | Description                                                                                                    |
+| ------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `--dev-client`      | Experimental: Starts the bundler for use with the expo-development-client                                      |
+| `--scheme [scheme]` | Custom URI protocol to use with a development build                                                            |
+| `-a, --android`     | Opens your app in Expo Go on a connected Android device                                                        |
+| `-i, --ios`         | Opens your app in Expo Go in a currently running iOS simulator on your computer                                |
+| `-w, --web`         | Opens your app in a web browser                                                                                |
 | `-m, --host [mode]` | lan (default), tunnel, localhost. Type of host to use. "tunnel" allows you to view your link on other networks |
-| `--tunnel` | Same as --host tunnel |
-| `--lan` | Same as --host lan |
-| `--localhost` | Same as --host localhost |
-| `--offline` | Allows this command to run while offline |
-| `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
-
+| `--tunnel`          | Same as --host tunnel                                                                                          |
+| `--lan`             | Same as --host lan                                                                                             |
+| `--localhost`       | Same as --host localhost                                                                                       |
+| `--offline`         | Allows this command to run while offline                                                                       |
+| `--config [file]`   | Deprecated: Use app.config.js to switch config files instead.                                                  |
 
 </p>
 </details>
@@ -771,11 +738,10 @@ Alias: `expo u`
 </summary>
 <p>
 
-| Option         | Description             |
-| -------------- | ----------------------- |
+| Option               | Description                                                     |
+| -------------------- | --------------------------------------------------------------- |
 | `--public-url [url]` | The URL of an externally hosted manifest (for self-hosted apps) |
-| `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
-
+| `--config [file]`    | Deprecated: Use app.config.js to switch config files instead.   |
 
 </p>
 </details>
@@ -787,11 +753,10 @@ Alias: `expo u`
 </summary>
 <p>
 
-| Option         | Description             |
-| -------------- | ----------------------- |
+| Option               | Description                                                     |
+| -------------------- | --------------------------------------------------------------- |
 | `--public-url [url]` | The URL of an externally hosted manifest (for self-hosted apps) |
-| `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
-
+| `--config [file]`    | Deprecated: Use app.config.js to switch config files instead.   |
 
 </p>
 </details>
@@ -807,10 +772,9 @@ Alias: `expo u`
 </summary>
 <p>
 
-| Option         | Description             |
-| -------------- | ----------------------- |
+| Option            | Description                                                   |
+| ----------------- | ------------------------------------------------------------- |
 | `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
-
 
 </p>
 </details>
@@ -822,13 +786,12 @@ Alias: `expo u`
 </summary>
 <p>
 
-| Option         | Description             |
-| -------------- | ----------------------- |
-| `--url [url]` | URL to request. (Required) |
-| `--event [event-type]` | Event type that triggers the webhook. [build] (Required) |
-| `--secret [secret]` | Secret used to create a hash signature of the request payload, provided in the 'Expo-Signature' header. |
-| `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
-
+| Option                 | Description                                                                                             |
+| ---------------------- | ------------------------------------------------------------------------------------------------------- |
+| `--url [url]`          | URL to request. (Required)                                                                              |
+| `--event [event-type]` | Event type that triggers the webhook. [build] (Required)                                                |
+| `--secret [secret]`    | Secret used to create a hash signature of the request payload, provided in the 'Expo-Signature' header. |
+| `--config [file]`      | Deprecated: Use app.config.js to switch config files instead.                                           |
 
 </p>
 </details>
@@ -840,11 +803,10 @@ Alias: `expo u`
 </summary>
 <p>
 
-| Option         | Description             |
-| -------------- | ----------------------- |
-| `--id [id]` | ID of the webhook to remove. |
+| Option            | Description                                                   |
+| ----------------- | ------------------------------------------------------------- |
+| `--id [id]`       | ID of the webhook to remove.                                  |
 | `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
-
 
 </p>
 </details>
@@ -856,18 +818,16 @@ Alias: `expo u`
 </summary>
 <p>
 
-| Option         | Description             |
-| -------------- | ----------------------- |
-| `--id [id]` | ID of the webhook to update. |
-| `--url [url]` | URL the webhook will request. |
-| `--event [event-type]` | Event type that triggers the webhook. [build] |
-| `--secret [secret]` | Secret used to create a hash signature of the request payload, provided in the 'Expo-Signature' header. |
-| `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
-
+| Option                 | Description                                                                                             |
+| ---------------------- | ------------------------------------------------------------------------------------------------------- |
+| `--id [id]`            | ID of the webhook to update.                                                                            |
+| `--url [url]`          | URL the webhook will request.                                                                           |
+| `--event [event-type]` | Event type that triggers the webhook. [build]                                                           |
+| `--secret [secret]`    | Secret used to create a hash signature of the request payload, provided in the 'Expo-Signature' header. |
+| `--config [file]`      | Deprecated: Use app.config.js to switch config files instead.                                           |
 
 </p>
 </details>
-
 
 ---
 
@@ -882,29 +842,28 @@ Alias: `expo u`
 
 Alias: `expo bi`
 
-| Option         | Description             |
-| -------------- | ----------------------- |
-| `-c, --clear-credentials` | Clear all credentials stored on Expo servers. |
-| `--clear-dist-cert` | Remove Distribution Certificate stored on Expo servers. |
-| `--clear-push-key` | Remove Push Notifications Key stored on Expo servers. |
-| `--clear-push-cert` | Remove Push Notifications Certificate stored on Expo servers. Use of Push Notifications Certificates is deprecated. |
-| `--clear-provisioning-profile` | Remove Provisioning Profile stored on Expo servers. |
-| `-r --revoke-credentials` | Revoke credentials on developer.apple.com, select appropriate using --clear-* options. |
-| `--apple-id [login]` | Apple ID username (please also set the Apple ID password as EXPO_APPLE_PASSWORD environment variable). |
-| `-t --type [archive\|simulator]` | Type of build: [archive\|simulator]. |
-| `--release-channel [name]` | Pull from specified release channel. |
-| `--no-publish` | Disable automatic publishing before building. |
-| `--no-wait` | Exit immediately after scheduling build. |
-| `--team-id [apple-teamId]` | Apple Team ID. |
-| `--dist-p12-path [path]` | Path to your Distribution Certificate P12 (set password as EXPO_IOS_DIST_P12_PASSWORD environment variable). |
-| `--push-id [push-id]` | Push Key ID (ex: 123AB4C56D). |
-| `--push-p8-path [path]` | Path to your Push Key .p8 file. |
-| `--provisioning-profile-path [path]` | Path to your Provisioning Profile. |
-| `--public-url [url]` | The URL of an externally hosted manifest (for self-hosted apps). |
-| `--skip-credentials-check` | Skip checking credentials. |
-| `--skip-workflow-check` | Skip warning about build service bare workflow limitations. |
-| `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
-
+| Option                               | Description                                                                                                         |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------- |
+| `-c, --clear-credentials`            | Clear all credentials stored on Expo servers.                                                                       |
+| `--clear-dist-cert`                  | Remove Distribution Certificate stored on Expo servers.                                                             |
+| `--clear-push-key`                   | Remove Push Notifications Key stored on Expo servers.                                                               |
+| `--clear-push-cert`                  | Remove Push Notifications Certificate stored on Expo servers. Use of Push Notifications Certificates is deprecated. |
+| `--clear-provisioning-profile`       | Remove Provisioning Profile stored on Expo servers.                                                                 |
+| `-r --revoke-credentials`            | Revoke credentials on developer.apple.com, select appropriate using --clear-\* options.                             |
+| `--apple-id [login]`                 | Apple ID username (please also set the Apple ID password as EXPO_APPLE_PASSWORD environment variable).              |
+| `-t --type [archive\|simulator]`     | Type of build: [archive\|simulator].                                                                                |
+| `--release-channel [name]`           | Pull from specified release channel.                                                                                |
+| `--no-publish`                       | Disable automatic publishing before building.                                                                       |
+| `--no-wait`                          | Exit immediately after scheduling build.                                                                            |
+| `--team-id [apple-teamId]`           | Apple Team ID.                                                                                                      |
+| `--dist-p12-path [path]`             | Path to your Distribution Certificate P12 (set password as EXPO_IOS_DIST_P12_PASSWORD environment variable).        |
+| `--push-id [push-id]`                | Push Key ID (ex: 123AB4C56D).                                                                                       |
+| `--push-p8-path [path]`              | Path to your Push Key .p8 file.                                                                                     |
+| `--provisioning-profile-path [path]` | Path to your Provisioning Profile.                                                                                  |
+| `--public-url [url]`                 | The URL of an externally hosted manifest (for self-hosted apps).                                                    |
+| `--skip-credentials-check`           | Skip checking credentials.                                                                                          |
+| `--skip-workflow-check`              | Skip warning about build service bare workflow limitations.                                                         |
+| `--config [file]`                    | Deprecated: Use app.config.js to switch config files instead.                                                       |
 
 </p>
 </details>
@@ -918,20 +877,19 @@ Alias: `expo bi`
 
 Alias: `expo ba`
 
-| Option         | Description             |
-| -------------- | ----------------------- |
-| `-c, --clear-credentials` | Clear stored credentials. |
-| `--release-channel [name]` | Pull from specified release channel. |
-| `--no-publish` | Disable automatic publishing before building. |
-| `--no-wait` | Exit immediately after triggering build. |
-| `--keystore-path [path]` | Path to your Keystore: *.jks. |
-| `--keystore-alias [alias]` | Keystore Alias |
-| `--generate-keystore` | [deprecated] Generate Keystore if one does not exist |
-| `--public-url [url]` | The URL of an externally hosted manifest (for self-hosted apps) |
-| `--skip-workflow-check` | Skip warning about build service bare workflow limitations. |
-| `-t --type [app-bundle\|apk]` | Type of build: [app-bundle\|apk]. |
-| `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
-
+| Option                        | Description                                                     |
+| ----------------------------- | --------------------------------------------------------------- |
+| `-c, --clear-credentials`     | Clear stored credentials.                                       |
+| `--release-channel [name]`    | Pull from specified release channel.                            |
+| `--no-publish`                | Disable automatic publishing before building.                   |
+| `--no-wait`                   | Exit immediately after triggering build.                        |
+| `--keystore-path [path]`      | Path to your Keystore: \*.jks.                                  |
+| `--keystore-alias [alias]`    | Keystore Alias                                                  |
+| `--generate-keystore`         | [deprecated] Generate Keystore if one does not exist            |
+| `--public-url [url]`          | The URL of an externally hosted manifest (for self-hosted apps) |
+| `--skip-workflow-check`       | Skip warning about build service bare workflow limitations.     |
+| `-t --type [app-bundle\|apk]` | Type of build: [app-bundle\|apk].                               |
+| `--config [file]`             | Deprecated: Use app.config.js to switch config files instead.   |
 
 </p>
 </details>
@@ -945,11 +903,10 @@ Alias: `expo ba`
 
 Alias: `expo bs`
 
-| Option         | Description             |
-| -------------- | ----------------------- |
+| Option               | Description                                                      |
+| -------------------- | ---------------------------------------------------------------- |
 | `--public-url [url]` | The URL of an externally hosted manifest (for self-hosted apps). |
-| `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
-
+| `--config [file]`    | Deprecated: Use app.config.js to switch config files instead.    |
 
 </p>
 </details>
@@ -963,20 +920,19 @@ Alias: `expo bs`
 
 Alias: `expo ua`
 
-| Option         | Description             |
-| -------------- | ----------------------- |
-| `--verbose` | Migrate to eas submit --verbose |
-| `--latest` | Migrate to eas submit --latest |
-| `--id [id]` | Migrate to eas submit --id [id] |
-| `--path [path]` | Migrate to eas submit --path [path] |
-| `--url [url]` | Migrate to eas submit --url [url] |
-| `--android-package [android-package]` | Migrate to eas submit (android-package is auto inferred) |
-| `--type [archive-type]` | Migrate to eas submit (type is auto inferred) |
-| `--key [key]` | Migrate to eas.json's serviceAccountKeyPath property |
-| `--track [track]` | Migrate to eas.json's track property |
-| `--release-status [release-status]` | Migrate to eas.json's releaseStatus property |
-| `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
-
+| Option                                | Description                                                   |
+| ------------------------------------- | ------------------------------------------------------------- |
+| `--verbose`                           | Migrate to eas submit --verbose                               |
+| `--latest`                            | Migrate to eas submit --latest                                |
+| `--id [id]`                           | Migrate to eas submit --id [id]                               |
+| `--path [path]`                       | Migrate to eas submit --path [path]                           |
+| `--url [url]`                         | Migrate to eas submit --url [url]                             |
+| `--android-package [android-package]` | Migrate to eas submit (android-package is auto inferred)      |
+| `--type [archive-type]`               | Migrate to eas submit (type is auto inferred)                 |
+| `--key [key]`                         | Migrate to eas.json's serviceAccountKeyPath property          |
+| `--track [track]`                     | Migrate to eas.json's track property                          |
+| `--release-status [release-status]`   | Migrate to eas.json's releaseStatus property                  |
+| `--config [file]`                     | Deprecated: Use app.config.js to switch config files instead. |
 
 </p>
 </details>
@@ -990,21 +946,20 @@ Alias: `expo ua`
 
 Alias: `expo ui`
 
-| Option         | Description             |
-| -------------- | ----------------------- |
-| `--verbose` | Migrate to eas submit --verbose |
-| `--latest` | Migrate to eas submit --latest |
-| `--id [id]` | Migrate to eas submit --id [id] |
-| `--path [path]` | Migrate to eas submit --path [path] |
-| `--url [url]` | Migrate to eas submit --url [url] |
-| `--apple-id [apple-id]` | Migrate to eas.json's appleId property |
-| `--itc-team-id [itc-team-id]` | Migrate to eas.json's appleTeamId property |
-| `--app-name [app-name]` | Migrate to eas.json's appName property |
-| `--company-name [company-name]` | Migrate to eas.json's companyName property |
-| `--sku [sku]` | Migrate to eas.json's sku property |
-| `--language [language]` | Migrate to eas.json's language property |
-| `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
-
+| Option                          | Description                                                   |
+| ------------------------------- | ------------------------------------------------------------- |
+| `--verbose`                     | Migrate to eas submit --verbose                               |
+| `--latest`                      | Migrate to eas submit --latest                                |
+| `--id [id]`                     | Migrate to eas submit --id [id]                               |
+| `--path [path]`                 | Migrate to eas submit --path [path]                           |
+| `--url [url]`                   | Migrate to eas submit --url [url]                             |
+| `--apple-id [apple-id]`         | Migrate to eas.json's appleId property                        |
+| `--itc-team-id [itc-team-id]`   | Migrate to eas.json's appleTeamId property                    |
+| `--app-name [app-name]`         | Migrate to eas.json's appName property                        |
+| `--company-name [company-name]` | Migrate to eas.json's companyName property                    |
+| `--sku [sku]`                   | Migrate to eas.json's sku property                            |
+| `--language [language]`         | Migrate to eas.json's language property                       |
+| `--config [file]`               | Deprecated: Use app.config.js to switch config files instead. |
 
 </p>
 </details>
@@ -1016,13 +971,104 @@ Alias: `expo ui`
 </summary>
 <p>
 
-| Option         | Description             |
-| -------------- | ----------------------- |
+| Option               | Description                                                                                            |
+| -------------------- | ------------------------------------------------------------------------------------------------------ |
 | `--apple-id [login]` | Apple ID username (please also set the Apple ID password as EXPO_APPLE_PASSWORD environment variable). |
-| `--config [file]` | Deprecated: Use app.config.js to switch config files instead. |
-
+| `--config [file]`    | Deprecated: Use app.config.js to switch config files instead.                                          |
 
 </p>
 </details>
 
 <!-- END GENERATED BLOCK. DO NOT MODIFY MANUALLY. -->
+
+## Expo CLI Migration
+
+In Expo SDK 46, we're migrating to a new suite of tooling that is versioned in the `expo` package. Below is a migration guide showing where the legacy `expo-cli` commands live now.
+
+> Legacy `expo-cli` will be in maintenance mode and continue to work while we migrate to the new tooling.
+
+| Legacy               | New                    | Notes                                         |
+| -------------------- | ---------------------- | --------------------------------------------- |
+| `expo init`          | `npx create-expo-app`  | New CLI                                       |
+| `expo start`         | `npx expo start`       | Versioned                                     |
+| `expo export`        | `npx expo export`      | Versioned, `--experimental-bundle` is default |
+| `expo install`       | `npx expo install`     | Versioned                                     |
+| `expo run:android`   | `npx expo run:android` | Versioned                                     |
+| `expo run:ios`       | `npx expo run:ios`     | Versioned                                     |
+| `expo login`         | `npx expo login`       | Versioned                                     |
+| `expo logout`        | `npx expo logout`      | Versioned                                     |
+| `expo register`      | `npx expo register`    | Versioned                                     |
+| `expo whoami`        | `npx expo whoami`      | Versioned                                     |
+| `expo config`        | `npx expo config`      | Versioned                                     |
+| `expo prebuild`      | `npx expo prebuild`    | Versioned                                     |
+| `expo customize:web` | `npx expo customize`   | Versioned, and renamed                        |
+| `expo build:web`     | `npx expo export:web`  | Versioned, and renamed                        |
+| `expo eject`         | `npx expo prebuild`    | Merged into `npx expo prebuild`               |
+| `expo start:web`     | `npx expo start`       | Merged into `npx expo start`                  |
+
+### Deprecated
+
+| Legacy                        | Notes                           |
+| ----------------------------- | ------------------------------- |
+| `expo client:ios`             | Removed in favor of Dev Clients |
+| `expo send`                   | Unimplemented                   |
+| `expo client:install:ios`     | Unimplemented                   |
+| `expo client:install:android` | Unimplemented                   |
+| `expo doctor`                 | Undecided                       |
+| `expo upgrade`                | Undecided                       |
+
+### Services
+
+| Legacy                           | New                     | Notes              |
+| -------------------------------- | ----------------------- | ------------------ |
+| `expo publish`                   | `eas update`            | Moved to `eas-cli` |
+| `expo publish:set`               | `eas update`            | Moved to `eas-cli` |
+| `expo publish:rollback`          | `eas update`            | Moved to `eas-cli` |
+| `expo publish:history`           | `eas update`            | Moved to `eas-cli` |
+| `expo publish:details`           | `eas update`            | Moved to `eas-cli` |
+| `expo credentials:manager`       | `eas credentials`       | Moved to `eas-cli` |
+| `expo fetch:ios:certs`           | `eas XXX`               | Moved to `eas-cli` |
+| `expo fetch:android:keystore`    | `eas XXX`               | Moved to `eas-cli` |
+| `expo fetch:android:hashes`      | `eas XXX`               | Moved to `eas-cli` |
+| `expo fetch:android:upload-cert` | `eas XXX`               | Moved to `eas-cli` |
+| `expo push:android:upload`       | `eas XXX`               | Moved to `eas-cli` |
+| `expo push:android:show`         | `eas XXX`               | Moved to `eas-cli` |
+| `expo push:android:clear`        | `eas XXX`               | Moved to `eas-cli` |
+| `expo url`                       | `eas XXX`               | Moved to `eas-cli` |
+| `expo url:ipa`                   | `eas XXX`               | Moved to `eas-cli` |
+| `expo url:apk`                   | `eas XXX`               | Moved to `eas-cli` |
+| `expo webhooks`                  | `eas XXX`               | Moved to `eas-cli` |
+| `expo webhooks:add`              | `eas XXX`               | Moved to `eas-cli` |
+| `expo webhooks:remove`           | `eas XXX`               | Moved to `eas-cli` |
+| `expo webhooks:update`           | `eas XXX`               | Moved to `eas-cli` |
+| `expo build:ios`                 | `eas build -p ios`      | Moved to `eas-cli` |
+| `expo build:android`             | `eas build -p android`  | Moved to `eas-cli` |
+| `expo build:status`              | `eas build:list`        | Moved to `eas-cli` |
+| `expo upload:android`            | `eas submit -p android` | Moved to `eas-cli` |
+| `expo upload:ios`                | `eas submit -p ios`     | Moved to `eas-cli` |
+
+### Other Notes
+
+- Dev Tools UI has been deprecated in favor of the the CLI's Terminal UI, Flipper, and Remote Debugging.
+- `npx expo install` now supports installing the correct version of `react-native`, `react`, `react-dom` automatically.
+- Tooling now supports `pnpm` along with Yarn and npm, the default is still Yarn.
+- Dropped the deprecated `--config` argument across all commands. Use `app.config.js` instead.
+- No longer shipping `adb` in the CLI. Users must manually install `adb` to interact with connected Android devices.
+- Experimental `$EXPO_USE_APPLE_DEVICE` feature (`expo run:ios -d`) is now the default behavior. Global `ios-deploy` package is no longer required.
+- `npx expo export` works like `expo export --experimental-bundle`, i.e. exports for `eas update` and not `expo publish`. [PR](https://github.com/expo/expo/pull/17034).
+  - Dropped arguments: `--public-url`, `--asset-url`, `--merge-src-url`, `--merge-src-dir`, `-t, --target`, `--experimental-bundle`, `--config`, `-q, --quiet`
+  - Dropped aliases for `--dump-assetmap` (`-d`) and `--dump-sourcemap` (`-s`).
+  - Dropped warning about clearing `dist` folder that is shown between runs, this is akin to all other bundler commands across web tooling.
+  - Dropped all merging code because experimental bundle does not support index files so we don't need to support merging index files.
+  - Dropped the quiet flag as this appears to do nothing anymore.
+- Parts of `expo upgrade` and `expo doctor` have been merged into `npx expo install` via the `--fix` and `--check` flags. [PR](https://github.com/expo/expo/pull/17048).
+- Dropped unused generated `.exprc`, `.expo/packager-info.json` files.
+- Dropped all deprecated support for `*.expo.js` files.
+- Reduced usage of `.expo/settings.json` to provide a more sandboxed state between processes.
+
+#### Environment Variables
+
+- Dropped `$XDL_PORT`, `$XDL_HOST`, `$XDL_SCHEME`, `$SERVER_URL` in favor of `$EXPO_STAGING` and `$EXPO_LOCAL` environment variables.
+- Dropped `$EXPO_PACKAGER_HOSTNAME`, `$EXPO_MANIFEST_PROXY_URL` environment variables.
+- Dropped `$EXPO_EDITOR` in favor of `$EDITOR` environment variable.
+- Utilize `$DEBUG=expo:*` more and `$EXPO_DEBUG` less (more control).


### PR DESCRIPTION
# Why

Help users know how to migrate to the new tooling in SDK 46.