### PR TITLE
[guides] Update QA guide to include new manifest local development

### DIFF
--- a/guides/releasing/Quality Assurance.md
+++ b/guides/releasing/Quality Assurance.md
@@ -2,7 +2,7 @@
 
 ## 1. Checking packages
 
-- Run `et check-packages` to make sure every package build successfully, `build` folder is up to date and all unit tests pass. 
+- Run `et check-packages` to make sure every package build successfully, `build` folder is up to date and all unit tests pass.
 
 ## 2. React Native dev tools
 
@@ -36,12 +36,14 @@ Unversioned QA: Test in native-component-list.
 - Go to `apps/test-suite`.
 - Update its `sdkVersion` in `app.json`. Use `UNVERSIONED` for unversioned QA and the new SDK version for versioned QA.
 - Run `expo start` and test each module.
+- Run `expo start --force-manifest-type=expo-updates` and sanity check one or two modules (mainly just checking that project opens).
 
 ## 4. Inspecting native-component-list examples
 
 - Go to `apps/native-component-list`.
 - Update its `sdkVersion` in `app.json`. Use `UNVERSIONED` for unversioned QA and the new SDK version for versioned QA.
 - Run `expo start` and check every example, including React Native components.
+- Run `expo start --force-manifest-type=expo-updates` and sanity check one or two examples (mainly just checking that project opens).
 
 ### 5. Smoke test Expo Home
 
@@ -55,4 +57,6 @@ Unversioned QA: Test in native-component-list.
 
 > Make sure to use the "Expo Go (versioned)" target on iOS.
 
-- Run `expo init -t blank@sdk-x` for each supported SDK version and ensure the project loads without crashing.
+- Run `expo init -t blank@sdk-x` for each supported SDK version.
+- Run `expo start` and ensure the project loads without crashing.
+- Run `expo start --force-manifest-type=expo-updates` and ensure the project loads without crashing.


### PR DESCRIPTION
# Why

https://github.com/expo/expo/pull/17466 was a hotfix due to missing testing (QA directions, dogfooding, unit, and integration). While the long term fixes here are the following, QA can be fixed in the short term while the other fixes are built:
- Somehow make `expo start` default to the new manifest type, either for everyone or for just employees or something.
- Add integration test or e2e test for expo go that runs in CI. Can be as basic as just loading an experience.

# How

Add instructions to QA.

# Test Plan

Inspect.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
