### PR TITLE
[updates-e2e] move test project setup into js

### DIFF
--- a/.github/workflows/updates-e2e.yml
+++ b/.github/workflows/updates-e2e.yml
@@ -40,7 +40,6 @@ jobs:
     timeout-minutes: 120
     env:
       UPDATES_PORT: 4747
-      EXPO_REPO_ROOT: ${{ env.GITHUB_WORKSPACE }}
     strategy:
       matrix:
         api-level: [31]

--- a/.github/workflows/updates-e2e.yml
+++ b/.github/workflows/updates-e2e.yml
@@ -40,6 +40,7 @@ jobs:
     timeout-minutes: 120
     env:
       UPDATES_PORT: 4747
+      EXPO_REPO_ROOT: ${{ env.GITHUB_WORKSPACE }}
     strategy:
       matrix:
         api-level: [31]
@@ -49,7 +50,7 @@ jobs:
       - name: ⬢ Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: '14.17'
+          node-version: '16'
       - name: 🔨 Switch to Xcode 13.2.1
         run: sudo xcode-select --switch /Applications/Xcode_13.2.1.app
       - name: 🔨 Use JDK 11
@@ -74,112 +75,27 @@ jobs:
         run: yarn build:cli
       - name: 🔧 Install Expo CLI
         run: yarn global add expo-cli
-      - name: Init new expo app
-        working-directory: ../
-        run: expo-cli init updates-e2e --yes
-      - name: Add yarn resolutions for local dependencies
-        working-directory: ../updates-e2e
-        run: |
-          # A jq filter to add a "resolutions" field
-          JQ_FILTER=$(cat << EOF
-            . + {
-              resolutions: {
-                "expo-application": "file:../expo/packages/expo-application",
-                "expo-constants": "file:../expo/packages/expo-constants",
-                "expo-eas-client": "file:../expo/packages/expo-eas-client",
-                "expo-error-recovery": "file:../expo/packages/expo-error-recovery",
-                "expo-file-system": "file:../expo/packages/expo-file-system",
-                "expo-font": "file:../expo/packages/expo-font",
-                "expo-json-utils": "file:../expo/packages/expo-json-utils",
-                "expo-keep-awake": "file:../expo/packages/expo-keep-awake",
-                "expo-manifests": "file:../expo/packages/expo-manifests",
-                "expo-modules-core": "file:../expo/packages/expo-modules-core",
-                "expo-structured-headers": "file:../expo/packages/expo-structured-headers",
-                "expo-updates-interface": "file:../expo/packages/expo-updates-interface"
-              }
-            }
-          EOF
-          )
-          jq "$JQ_FILTER" < package.json > new-package.json
-          mv new-package.json package.json
-      - name: Add local expo packages
-        working-directory: ../updates-e2e
-        run: yarn add file:../expo/packages/expo-updates file:../expo/packages/expo file:../expo/packages/expo-splash-screen file:../expo/packages/expo-status-bar
-      - name: Get local IP address
+      - name: 🌐 Get local IP address
         run: echo "UPDATES_HOST=$(ifconfig -l | xargs -n1 ipconfig getifaddr)" >> $GITHUB_ENV
-      - name: Setup app.config.json
-        working-directory: ../updates-e2e
-        run: echo "{\"name\":\"updates-e2e\",\"runtimeVersion\":\"1.0.0\",\"plugins\":[\"expo-updates\"],\"android\":{\"package\":\"dev.expo.updatese2e\"},\"ios\":{\"bundleIdentifier\":\"dev.expo.updatese2e\"},\"updates\":{\"url\":\"http://$UPDATES_HOST:$UPDATES_PORT/update\"}}" > app.config.json
-      - name: Generate code signing
-        working-directory: ../updates-e2e
-        run: yarn expo-updates codesigning:generate --key-output-directory keys --certificate-output-directory certs --certificate-validity-duration-years 1 --certificate-common-name "E2E Test App"
-      - name: Configure code signing
-        working-directory: ../updates-e2e
-        run: yarn expo-updates codesigning:configure --certificate-input-directory certs --key-input-directory keys
-      - name: Pack latest bare-minimum template as tarball for expo prebuild
-        working-directory: templates/expo-template-bare-minimum
-        run: echo "$PWD" && npm pack --pack-destination ../../../updates-e2e/
-      - name: Prebuild
-        working-directory: ../updates-e2e
-        run: expo-cli prebuild --template expo-template-bare-minimum-*.tgz
-      - name: Copy App.js from test fixtures
-        working-directory: ../updates-e2e
-        run: cp ../expo/packages/expo-updates/e2e/__tests__/fixtures/App.js .
-      - name: Set host and port in App.js
-        working-directory: ../updates-e2e
-        run: sed -i -e "s/UPDATES_HOST/$UPDATES_HOST/" ./App.js && sed -i -e "s/UPDATES_PORT/$UPDATES_PORT/" ./App.js
-      - name: 🍏 Build release app
-        working-directory: ../updates-e2e/ios
-        run: xcodebuild -workspace updatese2e.xcworkspace -scheme updatese2e -configuration Release -destination "generic/platform=iOS Simulator" -derivedDataPath ./build build
-      - name: 🍏 Copy app to working directory
-        run: cp -R ../updates-e2e/ios/build/Build/Products/Release-iphonesimulator/updatese2e.app artifact
-      - name: 🍏 Get test app path
-        id: test-app-path
-        working-directory: ../updates-e2e/ios/build/Build/Products/Release-iphonesimulator/
-        run: echo "::set-output name=dir::$(pwd)"
-      - name: 🤖 Assemble release APK
-        working-directory: ../updates-e2e/android
-        run: ./gradlew assembleRelease --stacktrace
-      - name: 🤖 Copy APK to working directory
-        run: cp -R ../updates-e2e/android/app/build/outputs/apk artifact
-      - name: 🤖 Get test APK path
-        id: test-apk-path
-        working-directory: ../updates-e2e/android/app/build/outputs/apk/release
-        run: echo "::set-output name=dir::$(pwd)"
-      - name: Upload test app artifacts
+      - name: 📦 Get artifacts path
+        run: mkdir -p artifact && echo "ARTIFACTS_DEST=$(pwd)/artifact" >> $GITHUB_ENV
+      - name: 🚀 Setup test project and build
+        run: node packages/expo-updates/e2e/__tests__/setup/index.js
+      - name: Upload test project artifacts
         uses: actions/upload-artifact@v3
         with:
           name: updates-e2e-artifacts
           path: artifact
-      - name: Export update for test server to host
-        working-directory: ../updates-e2e
-        run: expo export --public-url https://u.expo.dev/dummy-url
-      - name: Get test update dist path
-        id: test-update-dist-path
-        working-directory: ../updates-e2e/dist
-        run: echo "::set-output name=dir::$(pwd)"
-      - name: Get test code signing private key path
-        id: test-code-signing-private-key-path
-        working-directory: ../updates-e2e/keys
-        run: echo "::set-output name=dir::$(pwd)/private-key.pem"
-      - name: 🍏 Start simulator
+      - name: 🍏 Start iOS simulator
         run: |
           xcrun simctl list devices -j \
           | jq -rc '[ .[] | .[] | .[] | select( .name | contains( "iPhone" ) ) | select( .isAvailable == true ) ] | last.udid ' \
           | xargs open -a Simulator --args -CurrentDeviceUDID
-      - name: 🍏 Run tests
-        env:
-          TEST_APP_PATH: '${{ steps.test-app-path.outputs.dir }}/updatese2e.app'
-          TEST_UPDATE_DIST_PATH: '${{ steps.test-update-dist-path.outputs.dir }}'
-          TEST_PRIVATE_KEY_PATH: '${{ steps.test-code-signing-private-key-path.outputs.dir }}'
+      - name: 🍏 Run iOS tests
         timeout-minutes: 30
         working-directory: packages/expo-updates
         run: yarn test --config e2e/jest.config.ios.js
-      - name: 🤖 Start emulator and run tests
-        env:
-          TEST_APK_PATH: '${{ steps.test-apk-path.outputs.dir }}/app-release.apk'
-          TEST_UPDATE_DIST_PATH: '${{ steps.test-update-dist-path.outputs.dir }}'
-          TEST_PRIVATE_KEY_PATH: '${{ steps.test-code-signing-private-key-path.outputs.dir }}'
+      - name: 🤖 Start Android emulator and run tests
         timeout-minutes: 30
         uses: reactivecircus/android-emulator-runner@v2
         with:

--- a/.github/workflows/updates-e2e.yml
+++ b/.github/workflows/updates-e2e.yml
@@ -74,6 +74,8 @@ jobs:
         run: yarn build:cli
       - name: 🔧 Install Expo CLI
         run: yarn global add expo-cli
+      - name: 🌳 Add EXPO_REPO_ROOT to environment
+        run: echo "EXPO_REPO_ROOT=$GITHUB_WORKSPACE" >> $GITHUB_ENV
       - name: 🌐 Get local IP address
         run: echo "UPDATES_HOST=$(ifconfig -l | xargs -n1 ipconfig getifaddr)" >> $GITHUB_ENV
       - name: 📦 Get artifacts path

--- a/packages/expo-updates/e2e/__tests__/Updates-e2e.test.ts
+++ b/packages/expo-updates/e2e/__tests__/Updates-e2e.test.ts
@@ -16,7 +16,7 @@ const RUNTIME_VERSION = '1.0.0';
 
 const TIMEOUT_BIAS = process.env.CI ? 10 : 1;
 
-const repoRoot = process.env.EXPO_REPO_ROOT;
+const repoRoot = process.env.EXPO_REPO_ROOT ?? process.env.GITHUB_WORKSPACE;
 if (!repoRoot) {
   throw new Error(
     'You must provide the path to the repo root in the EXPO_REPO_ROOT environment variable'

--- a/packages/expo-updates/e2e/__tests__/Updates-e2e.test.ts
+++ b/packages/expo-updates/e2e/__tests__/Updates-e2e.test.ts
@@ -16,7 +16,7 @@ const RUNTIME_VERSION = '1.0.0';
 
 const TIMEOUT_BIAS = process.env.CI ? 10 : 1;
 
-const repoRoot = process.env.EXPO_REPO_ROOT ?? process.env.GITHUB_WORKSPACE;
+const repoRoot = process.env.EXPO_REPO_ROOT;
 if (!repoRoot) {
   throw new Error(
     'You must provide the path to the repo root in the EXPO_REPO_ROOT environment variable'

--- a/packages/expo-updates/e2e/__tests__/setup/build-android.js
+++ b/packages/expo-updates/e2e/__tests__/setup/build-android.js
@@ -1,0 +1,29 @@
+const spawnAsync = require('@expo/spawn-async');
+const fs = require('fs/promises');
+const path = require('path');
+
+async function buildAsync(projectRoot, destinationFolder) {
+  await spawnAsync('./gradlew', ['assembleRelease', '--stacktrace'], {
+    cwd: path.join(projectRoot, 'android'),
+    stdio: 'inherit',
+  });
+  const destinationPath = path.join(destinationFolder, `android-release.apk`);
+  await fs.copyFile(
+    path.join(
+      projectRoot,
+      'android',
+      'app',
+      'build',
+      'outputs',
+      'apk',
+      'release',
+      'app-release.apk'
+    ),
+    destinationPath
+  );
+  return destinationPath;
+}
+
+module.exports = {
+  buildAsync,
+};

--- a/packages/expo-updates/e2e/__tests__/setup/build-ios.js
+++ b/packages/expo-updates/e2e/__tests__/setup/build-ios.js
@@ -1,0 +1,45 @@
+const spawnAsync = require('@expo/spawn-async');
+const fs = require('fs/promises');
+const path = require('path');
+
+async function buildAsync(projectRoot, destinationFolder) {
+  await spawnAsync(
+    'xcodebuild',
+    [
+      '-workspace',
+      'updatese2e.xcworkspace',
+      '-scheme',
+      'updatese2e',
+      '-configuration',
+      'Release',
+      '-destination',
+      'generic/platform=iOS Simulator',
+      '-derivedDataPath',
+      './build',
+      'build',
+    ],
+    {
+      cwd: path.join(projectRoot, 'ios'),
+      stdio: 'inherit',
+    }
+  );
+  const destinationPath = path.join(destinationFolder, `ios-release.app`);
+  await fs.cp(
+    path.join(
+      projectRoot,
+      'ios',
+      'build',
+      'Build',
+      'Products',
+      'Release-iphonesimulator',
+      'updatese2e.app'
+    ),
+    destinationPath,
+    { recursive: true }
+  );
+  return destinationPath;
+}
+
+module.exports = {
+  buildAsync,
+};

--- a/packages/expo-updates/e2e/__tests__/setup/index.js
+++ b/packages/expo-updates/e2e/__tests__/setup/index.js
@@ -13,10 +13,6 @@ const runtimeVersion = '1.0.0';
 
 (async function () {
   const projectRoot = await setupAsync(workingDir, repoRoot, runtimeVersion);
-
-  if (!fs.existsSync(artifactsDest)) {
-    fs.mkdirSync(artifactsDest, { recursive: true });
-  }
   await buildAndroidAsync(projectRoot, artifactsDest);
   await buildIosAsync(projectRoot, artifactsDest);
 })();

--- a/packages/expo-updates/e2e/__tests__/setup/index.js
+++ b/packages/expo-updates/e2e/__tests__/setup/index.js
@@ -1,11 +1,10 @@
-const fs = require('fs');
 const path = require('path');
 
 const { buildAsync: buildAndroidAsync } = require('./build-android');
 const { buildAsync: buildIosAsync } = require('./build-ios');
 const { setupAsync } = require('./project');
 
-const repoRoot = process.env.EXPO_REPO_ROOT;
+const repoRoot = process.env.EXPO_REPO_ROOT ?? process.env.GITHUB_WORKSPACE;
 const artifactsDest = process.env.ARTIFACTS_DEST;
 
 const workingDir = path.resolve(repoRoot, '..');

--- a/packages/expo-updates/e2e/__tests__/setup/index.js
+++ b/packages/expo-updates/e2e/__tests__/setup/index.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const path = require('path');
+
+const { buildAsync: buildAndroidAsync } = require('./build-android');
+const { buildAsync: buildIosAsync } = require('./build-ios');
+const { setupAsync } = require('./project');
+
+const repoRoot = process.env.EXPO_REPO_ROOT;
+const artifactsDest = process.env.ARTIFACTS_DEST;
+
+const workingDir = path.resolve(repoRoot, '..');
+const runtimeVersion = '1.0.0';
+
+(async function () {
+  const projectRoot = await setupAsync(workingDir, repoRoot, runtimeVersion);
+
+  if (!fs.existsSync(artifactsDest)) {
+    fs.mkdirSync(artifactsDest, { recursive: true });
+  }
+  await buildAndroidAsync(projectRoot, artifactsDest);
+  await buildIosAsync(projectRoot, artifactsDest);
+})();

--- a/packages/expo-updates/e2e/__tests__/setup/index.js
+++ b/packages/expo-updates/e2e/__tests__/setup/index.js
@@ -4,7 +4,7 @@ const { buildAsync: buildAndroidAsync } = require('./build-android');
 const { buildAsync: buildIosAsync } = require('./build-ios');
 const { setupAsync } = require('./project');
 
-const repoRoot = process.env.EXPO_REPO_ROOT ?? process.env.GITHUB_WORKSPACE;
+const repoRoot = process.env.EXPO_REPO_ROOT;
 const artifactsDest = process.env.ARTIFACTS_DEST;
 
 const workingDir = path.resolve(repoRoot, '..');

--- a/packages/expo-updates/e2e/__tests__/setup/project.js
+++ b/packages/expo-updates/e2e/__tests__/setup/project.js
@@ -130,6 +130,11 @@ async function setupAsync(workingDir, repoRoot, runtimeVersion) {
     stdio: 'inherit',
   });
 
+  // copy exported update to artifacts
+  await fs.cp(path.join(projectRoot, 'dist'), path.join(process.env.ARTIFACTS_DEST, 'dist'), {
+    recursive: true,
+  });
+
   return projectRoot;
 }
 

--- a/packages/expo-updates/e2e/__tests__/setup/project.js
+++ b/packages/expo-updates/e2e/__tests__/setup/project.js
@@ -1,0 +1,138 @@
+const spawnAsync = require('@expo/spawn-async');
+const fs = require('fs/promises');
+const path = require('path');
+
+async function setupAsync(workingDir, repoRoot, runtimeVersion) {
+  // initialize project
+  await spawnAsync('expo-cli', ['init', 'updates-e2e', '--yes'], {
+    cwd: workingDir,
+    stdio: 'inherit',
+  });
+  const projectRoot = path.join(workingDir, 'updates-e2e');
+
+  // add local dependencies
+  let packageJson = JSON.parse(await fs.readFile(path.join(projectRoot, 'package.json'), 'utf-8'));
+  packageJson = {
+    ...packageJson,
+    resolutions: {
+      ...(packageJson.resolutions ?? {}),
+      'expo-application': 'file:../expo/packages/expo-application',
+      'expo-constants': 'file:../expo/packages/expo-constants',
+      'expo-eas-client': 'file:../expo/packages/expo-eas-client',
+      'expo-error-recovery': 'file:../expo/packages/expo-error-recovery',
+      'expo-file-system': 'file:../expo/packages/expo-file-system',
+      'expo-font': 'file:../expo/packages/expo-font',
+      'expo-json-utils': 'file:../expo/packages/expo-json-utils',
+      'expo-keep-awake': 'file:../expo/packages/expo-keep-awake',
+      'expo-manifests': 'file:../expo/packages/expo-manifests',
+      'expo-modules-core': 'file:../expo/packages/expo-modules-core',
+      'expo-structured-headers': 'file:../expo/packages/expo-structured-headers',
+      'expo-updates-interface': 'file:../expo/packages/expo-updates-interface',
+    },
+  };
+  await fs.writeFile(
+    path.join(projectRoot, 'package.json'),
+    JSON.stringify(packageJson, null, 2),
+    'utf-8'
+  );
+  await spawnAsync(
+    'yarn',
+    [
+      'add',
+      'file:../expo/packages/expo-updates',
+      'file:../expo/packages/expo',
+      'file:../expo/packages/expo-splash-screen',
+      'file:../expo/packages/expo-status-bar',
+    ],
+    {
+      cwd: projectRoot,
+      stdio: 'inherit',
+    }
+  );
+
+  // configure app.json
+  let appJson = JSON.parse(await fs.readFile(path.join(projectRoot, 'app.json'), 'utf-8'));
+  appJson = {
+    ...appJson,
+    expo: {
+      ...(appJson.expo ?? {}),
+      name: 'updates-e2e',
+      runtimeVersion,
+      plugins: ['expo-updates'],
+      android: { ...(appJson.android ?? {}), package: 'dev.expo.updatese2e' },
+      ios: { ...(appJson.ios ?? {}), bundleIdentifier: 'dev.expo.updatese2e' },
+      updates: {
+        ...(appJson.updates ?? {}),
+        url: `http://${process.env.UPDATES_HOST}:${process.env.UPDATES_PORT}/update`,
+      },
+    },
+  };
+  await fs.writeFile(path.join(projectRoot, 'app.json'), JSON.stringify(appJson, null, 2), 'utf-8');
+
+  // generate and configure code signing
+  await spawnAsync(
+    'yarn',
+    [
+      'expo-updates',
+      'codesigning:generate',
+      '--key-output-directory',
+      'keys',
+      '--certificate-output-directory',
+      'certs',
+      '--certificate-validity-duration-years',
+      '1',
+      '--certificate-common-name',
+      '"E2E Test App"',
+    ],
+    { cwd: projectRoot, stdio: 'inherit' }
+  );
+  await spawnAsync(
+    'yarn',
+    [
+      'expo-updates',
+      'codesigning:configure',
+      '--certificate-input-directory',
+      'certs',
+      '--key-input-directory',
+      'keys',
+    ],
+    { cwd: projectRoot, stdio: 'inherit' }
+  );
+
+  // pack local template and prebuild
+  const localTemplatePath = path.join(repoRoot, 'templates', 'expo-template-bare-minimum');
+  await spawnAsync('npm', ['pack', '--pack-destination', projectRoot], {
+    cwd: localTemplatePath,
+    stdio: 'inherit',
+  });
+  const templateVersion = require(path.join(localTemplatePath, 'package.json')).version;
+  await spawnAsync(
+    'expo-cli',
+    ['prebuild', '--template', `expo-template-bare-minimum-${templateVersion}.tgz`],
+    {
+      cwd: projectRoot,
+      stdio: 'inherit',
+    }
+  );
+
+  // copy App.js from test fixtures
+  const appJsSourcePath = path.resolve(__dirname, '..', 'fixtures', 'App.js');
+  const appJsDestinationPath = path.resolve(projectRoot, 'App.js');
+  let appJsFileContents = await fs.readFile(appJsSourcePath, 'utf-8');
+  appJsFileContents = appJsFileContents
+    .replace('UPDATES_HOST', process.env.UPDATES_HOST)
+    .replace('UPDATES_PORT', process.env.UPDATES_PORT);
+  await fs.writeFile(appJsDestinationPath, appJsFileContents, 'utf-8');
+
+  // export update for test server to host
+  await spawnAsync('expo-cli', ['export', '--public-url', 'https://u.expo.dev/dummy-url'], {
+    cwd: projectRoot,
+    stdio: 'inherit',
+  });
+
+  return projectRoot;
+}
+
+module.exports = {
+  setupAsync,
+};

--- a/packages/expo-updates/e2e/__tests__/setup/project.js
+++ b/packages/expo-updates/e2e/__tests__/setup/project.js
@@ -15,7 +15,7 @@ async function setupAsync(workingDir, repoRoot, runtimeVersion) {
   packageJson = {
     ...packageJson,
     resolutions: {
-      ...(packageJson.resolutions ?? {}),
+      ...packageJson.resolutions,
       'expo-application': 'file:../expo/packages/expo-application',
       'expo-constants': 'file:../expo/packages/expo-constants',
       'expo-eas-client': 'file:../expo/packages/expo-eas-client',
@@ -55,14 +55,14 @@ async function setupAsync(workingDir, repoRoot, runtimeVersion) {
   appJson = {
     ...appJson,
     expo: {
-      ...(appJson.expo ?? {}),
+      ...appJson.expo,
       name: 'updates-e2e',
       runtimeVersion,
       plugins: ['expo-updates'],
-      android: { ...(appJson.android ?? {}), package: 'dev.expo.updatese2e' },
-      ios: { ...(appJson.ios ?? {}), bundleIdentifier: 'dev.expo.updatese2e' },
+      android: { ...appJson.android, package: 'dev.expo.updatese2e' },
+      ios: { ...appJson.ios, bundleIdentifier: 'dev.expo.updatese2e' },
       updates: {
-        ...(appJson.updates ?? {}),
+        ...appJson.updates,
         url: `http://${process.env.UPDATES_HOST}:${process.env.UPDATES_PORT}/update`,
       },
     },
@@ -82,7 +82,7 @@ async function setupAsync(workingDir, repoRoot, runtimeVersion) {
       '--certificate-validity-duration-years',
       '1',
       '--certificate-common-name',
-      '"E2E Test App"',
+      'E2E Test App',
     ],
     { cwd: projectRoot, stdio: 'inherit' }
   );

--- a/packages/expo-updates/e2e/__tests__/utils/simulator.android.ts
+++ b/packages/expo-updates/e2e/__tests__/utils/simulator.android.ts
@@ -18,9 +18,9 @@ const ADB_PATH = (function () {
   return 'adb';
 })();
 
-const APK_PATH = process.env.TEST_APK_PATH;
 const PACKAGE_NAME = 'dev.expo.updatese2e';
 const ACTIVITY_NAME = `${PACKAGE_NAME}/${PACKAGE_NAME}.MainActivity`;
+const APK_PATH = path.join(process.env.ARTIFACTS_DEST, 'android-release.apk');
 
 export const ExportedManifestFilename = 'android-index.json';
 

--- a/packages/expo-updates/e2e/__tests__/utils/simulator.ios.ts
+++ b/packages/expo-updates/e2e/__tests__/utils/simulator.ios.ts
@@ -1,7 +1,8 @@
 import spawnAsync from '@expo/spawn-async';
+import path from 'path';
 
-const APP_PATH = process.env.TEST_APP_PATH;
 const BUNDLE_IDENTIFIER = 'dev.expo.updatese2e';
+const APP_PATH = path.join(process.env.ARTIFACTS_DEST, 'ios-release.app');
 
 export const ExportedManifestFilename = 'ios-index.json';
 

--- a/packages/expo-updates/e2e/__tests__/utils/update.ts
+++ b/packages/expo-updates/e2e/__tests__/utils/update.ts
@@ -5,28 +5,25 @@ import path from 'path';
 import * as Simulator from './simulator';
 
 const EXPORT_PUBLIC_URL = 'https://u.expo.dev/dummy-url';
-const UPDATE_DIST_PATH = process.env.TEST_UPDATE_DIST_PATH;
 let bundlePath: string | null = null;
 
-function findBundlePath(): string {
+function findBundlePath(updateDistPath: string): string {
   if (!bundlePath) {
-    const classicManifest = require(path.join(
-      UPDATE_DIST_PATH,
-      Simulator.ExportedManifestFilename
-    ));
+    const classicManifest = require(path.join(updateDistPath, Simulator.ExportedManifestFilename));
     const { bundleUrl }: { bundleUrl: string } = classicManifest;
-    bundlePath = path.join(UPDATE_DIST_PATH, bundleUrl.replace(EXPORT_PUBLIC_URL, ''));
+    bundlePath = path.join(updateDistPath, bundleUrl.replace(EXPORT_PUBLIC_URL, ''));
   }
   return bundlePath;
 }
 
 export async function copyBundleToStaticFolder(
+  updateDistPath: string,
   filename: string,
   notifyString?: string
 ): Promise<string> {
   const staticFolder = path.resolve(__dirname, '..', '.static');
   await fs.mkdir(staticFolder, { recursive: true });
-  let bundleString = await fs.readFile(findBundlePath(), 'utf-8');
+  let bundleString = await fs.readFile(findBundlePath(updateDistPath), 'utf-8');
   if (notifyString) {
     bundleString = bundleString.replace('/notify/test', `/notify/${notifyString}`);
   }


### PR DESCRIPTION
# Why

Currently, the test project used in updates-e2e is created by many individual steps in the github workflow. This PR moves all those steps to a JS script, which makes much it easier to:

- get tests running locally (in case you need to reproduce a failure)
- modify the test project further, e.g. adding more assets for future tests, and ensure it works consistently locally and on CI
- add more builds, e.g. with different Expo.plist configuration, for future tests (like the ones listed in ENG-2473)

and if we do move the Android tests back to a separate CI box at some point, this will make porting over the job much easier.

# How

- create setup/project.js and replicate each step of the test project setup from the yml file in JS
- create setup/build-ios.js and build-android.js, which right now just export functions to make a single release build (also replicating functionality from yml)
- call these scripts from github workflow
- upgrade to node 16 in order to use `fs.cp`
- modify tests to account for slightly different available env vars

# Test Plan

tests are passing locally and on CI 🎉 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
