### PR TITLE
[ncl] Move to EAS Update

### DIFF
--- a/.github/workflows/publish-demo.yml
+++ b/.github/workflows/publish-demo.yml
@@ -1,4 +1,4 @@
-name: Publish Native Component List Website
+name: Publish Native Component List Website & Update
 on:
   workflow_dispatch: {}
   push:
@@ -36,30 +36,20 @@ jobs:
           git-lfs: 'true'
       - name: 🚚 Pull Git LFS files
         run: git lfs pull
-
-      #  Setup Expo CLI action
-      # - name: Setup Expo
-      #   uses: expo/expo-github-action@v5
-      #   with:
-      #     expo-version: 3.x
-      #     expo-username: ${{ secrets.EXPO_CLI_USERNAME }}
-      #     expo-password: ${{ secrets.EXPO_CLI_PASSWORD }}
-      #     expo-cache: true
-
+      - name: Setup Expo
+        uses: expo/expo-github-action@v7
+        with:
+          expo-version: latest
+          eas-version: latest
+          token: ${{ secrets.COMMUNITY_EXPO_ACCESS_TOKEN }}
       - name: 🧶 Install workspace node modules
         if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
       - name: 🔧 Install Expo CLI v3
         run: yarn global add expo-cli@3
-
-      # - name: Publish Expo app
-      #   working-directory: ./apps/native-component-list
-      #   run: expo publish --release-channel=pr-${{ github.event.number }}
-      # # Get Expo link for the comment
-      # - name: Get expo link
-      #   id: expo
-      #   run: echo "::set-output name=path::@community/native-component-list?release-channel=pr-${{ github.event.number }}"
-
+      - name: Publish Expo app
+        working-directory: ./apps/native-component-list
+        run: EXPO_SDK_VERSION=43.0.0 eas update --branch main --message "initial publish"
       - name: 🏗️ Build the NCL website
         working-directory: ./apps/native-component-list
         run: yarn build:web

--- a/.github/workflows/publish-demo.yml
+++ b/.github/workflows/publish-demo.yml
@@ -45,11 +45,9 @@ jobs:
       - name: 🧶 Install workspace node modules
         if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
-      - name: 🔧 Install Expo CLI v3
-        run: yarn global add expo-cli@3
-      - name: Publish Expo app
+      - name: Publish update
         working-directory: ./apps/native-component-list
-        run: EXPO_SDK_VERSION=43.0.0 eas update --branch main --message "initial publish"
+        run: EXPO_SDK_VERSION=45.0.0 eas update --branch main --message "Publishing ${{ github.sha }}"
       - name: 🏗️ Build the NCL website
         working-directory: ./apps/native-component-list
         run: yarn build:web

--- a/apps/native-component-list/app.json
+++ b/apps/native-component-list/app.json
@@ -3,6 +3,7 @@
     "name": "Expo APIs",
     "description": "This demonstrates a bunch of the native components that you can use in React Native core and Expo.",
     "slug": "native-component-list",
+    "owner": "community",
     "sdkVersion": "UNVERSIONED",
     "version": "UNVERSIONED",
     "githubUrl": "https://github.com/expo/native-component-list",

--- a/apps/native-component-list/app.json
+++ b/apps/native-component-list/app.json
@@ -23,6 +23,12 @@
       "silentLaunch": true
     },
     "platforms": ["android", "ios", "web"],
+    "runtimeVersion": {
+      "policy": "sdkVersion"
+    },
+    "updates": {
+      "url": "https://u.expo.dev/2c28de10-a2cd-11e6-b8ce-59d1587e6774"
+    },
     "facebookScheme": "fb1696089354000816",
     "facebookAppId": "1696089354000816",
     "facebookDisplayName": "Expo APIs",


### PR DESCRIPTION
# Why

https://github.com/expo/expo/pull/17466 exposed a need for `expo start` to default to the new style manifest for dogfooding. One way to do that is to set the `updates.url` key to an EAS url.

Closes ENG-4937.

# How

`eas update:configure` while logged-into the community account.

Initial EAS Update publish done with `EXPO_SDK_VERSION=43.0.0 eas update --branch main --message "initial publish"`

# Test Plan

Wait for CI. (might need to manually trigger the workflow or temporarily change it to run on PRs)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
