### PR TITLE
[module-core][Kotlin] register JSI functions using lambdas instead of using a dispatcher

### DIFF
--- a/packages/expo-modules-core/android/src/main/cpp/JNIFunctionBody.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JNIFunctionBody.cpp
@@ -8,8 +8,9 @@ namespace react = facebook::react;
 namespace expo {
 jni::local_ref<react::ReadableNativeArray::javaobject>
 JNIFunctionBody::invoke(react::ReadableNativeArray::javaobject &&args) {
-  static const auto method = getClass()->getMethod<react::ReadableNativeArray::javaobject(
-    react::ReadableNativeArray::javaobject)>(
+  static const auto method = getClass()->getMethod<
+    react::ReadableNativeArray::javaobject(react::ReadableNativeArray::javaobject)
+  >(
     "invoke"
   );
 
@@ -17,9 +18,9 @@ JNIFunctionBody::invoke(react::ReadableNativeArray::javaobject &&args) {
 }
 
 void JNIAsyncFunctionBody::invoke(react::ReadableNativeArray::javaobject &&args, jobject promise) {
-  static const auto method = getClass()->getMethod<react::ReadableNativeArray::javaobject(
-    react::ReadableNativeArray::javaobject,
-    jobject)>(
+  static const auto method = getClass()->getMethod<
+    react::ReadableNativeArray::javaobject(react::ReadableNativeArray::javaobject, jobject)
+  >(
     "invoke"
   );
 

--- a/packages/expo-modules-core/android/src/main/cpp/JNIFunctionBody.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JNIFunctionBody.cpp
@@ -1,0 +1,28 @@
+// Copyright © 2021-present 650 Industries, Inc. (aka Expo)
+
+#include "JNIFunctionBody.h"
+
+namespace jni = facebook::jni;
+namespace react = facebook::react;
+
+namespace expo {
+jni::local_ref<react::ReadableNativeArray::javaobject>
+JNIFunctionBody::invoke(react::ReadableNativeArray::javaobject &&args) {
+  static const auto method = getClass()->getMethod<react::ReadableNativeArray::javaobject(
+    react::ReadableNativeArray::javaobject)>(
+    "invoke"
+  );
+
+  return method(this->self(), args);
+}
+
+void JNIAsyncFunctionBody::invoke(react::ReadableNativeArray::javaobject &&args, jobject promise) {
+  static const auto method = getClass()->getMethod<react::ReadableNativeArray::javaobject(
+    react::ReadableNativeArray::javaobject,
+    jobject)>(
+    "invoke"
+  );
+
+  method(this->self(), args, promise);
+}
+} // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JNIFunctionBody.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JNIFunctionBody.h
@@ -1,0 +1,50 @@
+// Copyright © 2021-present 650 Industries, Inc. (aka Expo)
+
+#pragma once
+
+#include <fbjni/fbjni.h>
+#include <react/jni/ReadableNativeArray.h>
+
+namespace jni = facebook::jni;
+namespace react = facebook::react;
+
+namespace expo {
+/**
+ * A CPP part of the expo.modules.kotlin.jni.JNIFunctionBody class.
+ * It represents the Kotlin's promise-less function.
+ */
+class JNIFunctionBody : public jni::JavaClass<JNIFunctionBody> {
+public:
+  static auto constexpr kJavaDescriptor = "Lexpo/modules/kotlin/jni/JNIFunctionBody;";
+
+  /**
+   * Invokes a Kotlin's implementation of this function.
+   *
+   * @param args
+   * @return result of the Kotlin function
+   */
+  jni::local_ref<react::ReadableNativeArray::javaobject> invoke(
+    react::ReadableNativeArray::javaobject &&args
+  );
+};
+
+/**
+ * A CPP part of the expo.modules.kotlin.jni.JNIAsyncFunctionBody class.
+ * It represents the Kotlin's promise function.
+ */
+class JNIAsyncFunctionBody : public jni::JavaClass<JNIAsyncFunctionBody> {
+public:
+  static auto constexpr kJavaDescriptor = "Lexpo/modules/kotlin/jni/JNIAsyncFunctionBody;";
+
+  /**
+   * Invokes a Kotlin's implementation of this async function.
+   *
+   * @param args
+   * @param promise that will be resolve or rejected in the Kotlin's implementation
+   */
+  void invoke(
+    react::ReadableNativeArray::javaobject &&args,
+    jobject promise
+  );
+};
+} // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
@@ -1,0 +1,227 @@
+#include "MethodMetadata.h"
+
+#include "JSIInteropModuleRegistry.h"
+
+namespace jni = facebook::jni;
+namespace jsi = facebook::jsi;
+namespace react = facebook::react;
+
+namespace expo {
+
+// Modified version of the RN implementation
+// https://github.com/facebook/react-native/blob/7dceb9b63c0bfd5b13bf6d26f9530729506e9097/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.cpp#L57
+jni::local_ref<react::JCxxCallbackImpl::JavaPart> createJavaCallbackFromJSIFunction(
+  jsi::Function &&function,
+  jsi::Runtime &rt,
+  std::shared_ptr<react::CallInvoker> jsInvoker
+) {
+  auto weakWrapper = react::CallbackWrapper::createWeak(std::move(function), rt,
+                                                        std::move(jsInvoker));
+
+  // This needs to be a shared_ptr because:
+  // 1. It cannot be unique_ptr. std::function is copyable but unique_ptr is
+  // not.
+  // 2. It cannot be weak_ptr since we need this object to live on.
+  // 3. It cannot be a value, because that would be deleted as soon as this
+  // function returns.
+  auto callbackWrapperOwner =
+    std::make_shared<react::RAIICallbackWrapperDestroyer>(weakWrapper);
+
+  std::function<void(folly::dynamic)> fn =
+    [weakWrapper, callbackWrapperOwner, wrapperWasCalled = false](
+      folly::dynamic responses) mutable {
+      if (wrapperWasCalled) {
+        throw std::runtime_error(
+          "callback 2 arg cannot be called more than once");
+      }
+
+      auto strongWrapper = weakWrapper.lock();
+      if (!strongWrapper) {
+        return;
+      }
+
+      strongWrapper->jsInvoker().invokeAsync(
+        [weakWrapper, callbackWrapperOwner, responses]() mutable {
+          auto strongWrapper2 = weakWrapper.lock();
+          if (!strongWrapper2) {
+            return;
+          }
+
+          jsi::Value args =
+            jsi::valueFromDynamic(strongWrapper2->runtime(), responses);
+          auto argsArray = args.getObject(strongWrapper2->runtime())
+            .asArray(strongWrapper2->runtime());
+          jsi::Value arg = argsArray.getValueAtIndex(strongWrapper2->runtime(), 0);
+
+          strongWrapper2->callback().call(
+            strongWrapper2->runtime(),
+            (const jsi::Value *) &arg,
+            (size_t) 1
+          );
+
+          callbackWrapperOwner.reset();
+        });
+
+      wrapperWasCalled = true;
+    };
+
+  return react::JCxxCallbackImpl::newObjectCxxArgs(fn);
+}
+
+MethodMetadata::MethodMetadata(
+  std::string name,
+  int args,
+  bool isAsync,
+  jni::global_ref<jobject> &&jBodyReference
+) : name(name),
+    args(args),
+    isAsync(isAsync),
+    jBodyReference(jBodyReference) {}
+
+std::shared_ptr<jsi::Function> MethodMetadata::toJSFunction(
+  jsi::Runtime &runtime,
+  JSIInteropModuleRegistry *moduleRegistry
+) {
+  if (body == nullptr) {
+    if (isAsync) {
+      body = std::make_shared<jsi::Function>(toAsyncFunction(runtime, moduleRegistry));
+    } else {
+      body = std::make_shared<jsi::Function>(toSyncFunction(runtime));
+    }
+  }
+
+  return body;
+}
+
+jsi::Function MethodMetadata::toSyncFunction(jsi::Runtime &runtime) {
+  return jsi::Function::createFromHostFunction(
+    runtime,
+    jsi::PropNameID::forAscii(runtime, name),
+    args,
+    [this](
+      jsi::Runtime &rt,
+      const jsi::Value &thisValue,
+      const jsi::Value *args,
+      size_t count
+    ) -> jsi::Value {
+      auto dynamicArray = folly::dynamic::array();
+      for (int i = 0; i < count; i++) {
+        auto &arg = args[i];
+        dynamicArray.push_back(jsi::dynamicFromValue(rt, arg));
+      }
+
+      // Cast in this place is safe, cause we know that this function is promise-less.
+      auto syncFunction = jni::static_ref_cast<JNIFunctionBody>(this->jBodyReference);
+      auto result = syncFunction->invoke(
+        react::ReadableNativeArray::newObjectCxxArgs(std::move(dynamicArray)).get()
+      );
+
+      if (result == nullptr) {
+        return jsi::Value::undefined();
+      }
+
+      return jsi::valueFromDynamic(rt, result->cthis()->consume())
+        .asObject(rt)
+        .asArray(rt)
+        .getValueAtIndex(rt, 0);
+    });
+}
+
+jsi::Function
+MethodMetadata::toAsyncFunction(jsi::Runtime &runtime, JSIInteropModuleRegistry *moduleRegistry) {
+  return jsi::Function::createFromHostFunction(
+    runtime,
+    jsi::PropNameID::forAscii(runtime, name),
+    args,
+    [this, moduleRegistry](
+      jsi::Runtime &rt,
+      const jsi::Value &thisValue,
+      const jsi::Value *args,
+      size_t count
+    ) -> jsi::Value {
+      auto dynamicArray = folly::dynamic::array();
+      for (int i = 0; i < count; i++) {
+        auto &arg = args[i];
+        dynamicArray.push_back(jsi::dynamicFromValue(rt, arg));
+      }
+
+      auto Promise = rt.global().getPropertyAsFunction(rt, "Promise");
+      // Creates a JSI promise
+      jsi::Value promise = Promise.callAsConstructor(
+        rt,
+        createPromiseBody(rt, moduleRegistry, std::move(dynamicArray))
+      );
+      return promise;
+    }
+  );
+}
+
+jsi::Function MethodMetadata::createPromiseBody(
+  jsi::Runtime &runtime,
+  JSIInteropModuleRegistry *moduleRegistry,
+  folly::dynamic &&args
+) {
+  return jsi::Function::createFromHostFunction(
+    runtime,
+    jsi::PropNameID::forAscii(runtime, "promiseFn"),
+    2,
+    [this, args = std::move(args), moduleRegistry](
+      jsi::Runtime &rt,
+      const jsi::Value &thisVal,
+      const jsi::Value *promiseConstructorArgs,
+      size_t promiseConstructorArgCount
+    ) {
+      if (promiseConstructorArgCount != 2) {
+        throw std::invalid_argument("Promise fn arg count must be 2");
+      }
+
+      jsi::Function resolveJSIFn = promiseConstructorArgs[0].getObject(rt).getFunction(rt);
+      jsi::Function rejectJSIFn = promiseConstructorArgs[1].getObject(rt).getFunction(rt);
+
+      jobject resolve = createJavaCallbackFromJSIFunction(
+        std::move(resolveJSIFn),
+        rt,
+        moduleRegistry->jsInvoker
+      ).release();
+
+      jobject reject = createJavaCallbackFromJSIFunction(
+        std::move(rejectJSIFn),
+        rt,
+        moduleRegistry->jsInvoker
+      ).release();
+
+      JNIEnv *env = jni::Environment::current();
+
+      jclass jPromiseImpl =
+        env->FindClass("com/facebook/react/bridge/PromiseImpl");
+      jmethodID jPromiseImplConstructor = env->GetMethodID(
+        jPromiseImpl,
+        "<init>",
+        "(Lcom/facebook/react/bridge/Callback;Lcom/facebook/react/bridge/Callback;)V");
+
+      // Creates a promise object
+      jobject promise = env->NewObject(
+        jPromiseImpl,
+        jPromiseImplConstructor,
+        resolve,
+        reject
+      );
+
+      // Cast in this place is safe, cause we know that this function expects promise.
+      auto asyncFunction = jni::static_ref_cast<JNIAsyncFunctionBody>(this->jBodyReference);
+      asyncFunction->invoke(
+        react::ReadableNativeArray::newObjectCxxArgs(args).get(),
+        promise
+      );
+
+      // We have to remove the local reference to the promise object.
+      // It doesn't mean that the promise will be deallocated, but rather that we move
+      // the ownership to the `JNIAsyncFunctionBody`.
+      env->DeleteLocalRef(promise);
+
+      return jsi::Value::undefined();
+    }
+  );
+}
+
+} // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
@@ -127,8 +127,10 @@ jsi::Function MethodMetadata::toSyncFunction(jsi::Runtime &runtime) {
     });
 }
 
-jsi::Function
-MethodMetadata::toAsyncFunction(jsi::Runtime &runtime, JSIInteropModuleRegistry *moduleRegistry) {
+jsi::Function MethodMetadata::toAsyncFunction(
+  jsi::Runtime &runtime, 
+  JSIInteropModuleRegistry *moduleRegistry
+) {
   return jsi::Function::createFromHostFunction(
     runtime,
     jsi::PropNameID::forAscii(runtime, name),

--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.h
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.h
@@ -3,19 +3,90 @@
 #pragma once
 
 #include <jsi/jsi.h>
+#include <fbjni/fbjni.h>
+#include <ReactCommon/TurboModuleUtils.h>
+#include <react/jni/ReadableNativeArray.h>
 #include <memory>
+#include <folly/dynamic.h>
+#include <jsi/JSIDynamic.h>
 
+namespace jni = facebook::jni;
 namespace jsi = facebook::jsi;
+namespace react = facebook::react;
 
 namespace expo {
-struct MethodMetadata {
+class JSIInteropModuleRegistry;
+
+/**
+ * A class that holds information about the exported function.
+ */
+class MethodMetadata {
+public:
+  /**
+   * Function name
+   */
   std::string name;
+  /**
+   * Number of arguments
+   */
   int args;
+  /*
+   * Whether this function is async
+   */
   bool isAsync;
 
+  MethodMetadata(
+    std::string name,
+    int args,
+    bool isAsync,
+    jni::global_ref<jobject> &&jBodyReference
+  );
+
+  // We deleted the copy contractor to not deal with transforming the ownership of the `jBodyReference`.
+  MethodMetadata(const MethodMetadata &) = delete;
+
+  /**
+   * MethodMetadata owns the only reference to the Kotlin function.
+   * We have to clean that, cause it's a `global_ref`.
+   */
+  ~MethodMetadata() {
+    jBodyReference.release();
+  }
+
+  /**
+   * Transforms metadata to a jsi::Function.
+   *
+   * @param runtime
+   * @param moduleRegistry
+   * @return shared ptr to the jsi::Function that wrapped the underlying Kotlin's function.
+   */
+  std::shared_ptr<jsi::Function> toJSFunction(
+    jsi::Runtime &runtime,
+    JSIInteropModuleRegistry *moduleRegistry
+  );
+
+private:
+  /**
+   * Reference to one of two java objects - `JNIFunctionBody` or `JNIAsyncFunctionBody`.
+   *
+   * In case when `isAsync` is `true`, this variable will point to `JNIAsyncFunctionBody`.
+   * Otherwise to `JNIFunctionBody`
+   */
+  jni::global_ref<jobject> jBodyReference;
+
+  /**
+   * To not create a jsi::Function always when we need it, we cached that value.
+   */
   std::shared_ptr<jsi::Function> body = nullptr;
 
-  MethodMetadata(std::string name, int args, bool isAsync)
-    : name(name), args(args), isAsync(isAsync) {};
+  jsi::Function toSyncFunction(jsi::Runtime &runtime);
+
+  jsi::Function toAsyncFunction(jsi::Runtime &runtime, JSIInteropModuleRegistry *moduleRegistry);
+
+  jsi::Function createPromiseBody(
+    jsi::Runtime &runtime,
+    JSIInteropModuleRegistry *moduleRegistry,
+    folly::dynamic &&args
+  );
 };
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
@@ -48,7 +48,7 @@ class ModuleHolder(val module: Module) {
   }
 
   /**
-   * Invokes a function with promise. Is used in the bridge implementation of the Sweat API.
+   * Invokes a function with promise. Is used in the bridge implementation of the Sweet API.
    */
   fun call(methodName: String, args: ReadableArray, promise: Promise) = exceptionDecorator({
     FunctionCallException(methodName, definition.name, it)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
@@ -13,32 +13,49 @@ import expo.modules.kotlin.exception.exceptionDecorator
 import expo.modules.kotlin.jni.JavaScriptModuleObject
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.types.JSTypeConverter
+import kotlinx.coroutines.launch
 
 class ModuleHolder(val module: Module) {
   val definition = module.definition()
   val name get() = definition.name
 
+  /**
+   * Cached instance of HybridObject used by CPP to interact with underlying [expo.modules.kotlin.modules.Module] object.
+   */
   val jsObject by lazy {
-    JavaScriptModuleObject(this).apply {
-      definition
-        .methods
-        .forEach { (name, method) ->
-          if (method.isSync) {
-            registerSyncFunction(name, method.argsCount)
-          } else {
-            registerAsyncFunction(name, method.argsCount)
+    JavaScriptModuleObject()
+      .apply {
+        definition
+          .methods
+          .forEach { (name, method) ->
+            val moduleHolder = this@ModuleHolder
+            if (method.isSync) {
+              registerSyncFunction(name, method.argsCount) { args ->
+                val result = method.callSync(moduleHolder, args)
+                val convertedResult = JSTypeConverter.convertToJSValue(result)
+                return@registerSyncFunction Arguments.fromJavaArgs(arrayOf(convertedResult))
+              }
+            } else {
+              registerAsyncFunction(name, method.argsCount) { args, bridgePromise ->
+                val kotlinPromise = KPromiseWrapper(bridgePromise as com.facebook.react.bridge.Promise)
+                moduleHolder.module.appContext.modulesQueue.launch {
+                  method.call(moduleHolder, args, kotlinPromise)
+                }
+              }
+            }
           }
-        }
-    }
+      }
   }
 
+  /**
+   * Invokes a function with promise. Is used in the bridge implementation of the Sweat API.
+   */
   fun call(methodName: String, args: ReadableArray, promise: Promise) = exceptionDecorator({
     FunctionCallException(methodName, definition.name, it)
   }) {
     val method = definition.methods[methodName]
       ?: throw MethodNotFoundException()
 
-    // TODO(@lukmccall): handle sync call
     if (method.isSync) {
       throw MethodNotFoundException()
     }
@@ -46,11 +63,14 @@ class ModuleHolder(val module: Module) {
     method.call(this, args, promise)
   }
 
-  fun callSync(methodName: String, args: ReadableArray): ReadableNativeArray {
+  /**
+   * Invokes a function without promise.
+   * `callSync` was added only for test purpose and shouldn't be used anywhere else.
+   */
+  internal fun callSync(methodName: String, args: ReadableArray): ReadableNativeArray {
     val method = definition.methods[methodName]
       ?: throw MethodNotFoundException()
 
-    // TODO(@lukmccall): handle async call
     if (!method.isSync) {
       throw MethodNotFoundException()
     }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JNIFunctionBody.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JNIFunctionBody.kt
@@ -1,0 +1,34 @@
+package expo.modules.kotlin.jni
+
+import com.facebook.react.bridge.ReadableNativeArray
+
+/**
+ * It's a wrapper for a promise-less function that will be invoked from JS.
+ * This interface is intended to be passed to cpp code.
+ * If you want to modify it, please don't forget to change the corresponding jni::JavaClass.
+ */
+fun interface JNIFunctionBody {
+  /**
+   * Invokes the Kotlin part of the JNI function.
+   *
+   * We used a [com.facebook.react.bridge.ReadableNativeArray] to communicate with CPP, because
+   * right now it's the only object which is recognizable by those two worlds.
+   * In the future, we may want to swap it for something else.
+   */
+  fun invoke(args: ReadableNativeArray): ReadableNativeArray?
+}
+
+/**
+ * It's a wrapper for a promise function that will be invoked from JS.
+ * This interface is intended to be passed to cpp code.
+ * If you want to modify it, please don't forget to change the corresponding jni::JavaClass.
+ */
+fun interface JNIAsyncFunctionBody {
+  /**
+   * Invokes the Kotlin part of the JNI function.
+   *
+   * Note: that the `bridgePromise` has type of [Any], but it should be an instance of [com.facebook.react.bridge.Promise].
+   * This is dictated by the fact that [com.facebook.react.bridge.Promise] isn't a hybrid object of jni::HybridClass.
+   */
+  fun invoke(args: ReadableNativeArray, bridgePromise: Any)
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIInteropModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIInteropModuleRegistry.kt
@@ -21,7 +21,14 @@ class JSIInteropModuleRegistry(appContext: AppContext) {
     nativeInvokerHolder: CallInvokerHolderImpl
   )
 
-  // used from cpp codebase
+  /**
+   * Returns a `JavaScriptModuleObject` that is a bridge between [expo.modules.kotlin.modules.Module]
+   * and HostObject exported via JSI.
+   *
+   * This function will be called from the CPP implementation.
+   * It doesn't make sense to call it from Kotlin.
+   */
+  @Suppress("unused")
   fun getJavaScriptModuleObject(name: String): JavaScriptModuleObject? {
     return appContextHolder.get()?.registry?.getModuleHolder(name)?.jsObject
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptModuleObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptModuleObject.kt
@@ -1,43 +1,34 @@
 package expo.modules.kotlin.jni
 
 import com.facebook.jni.HybridData
-import com.facebook.react.bridge.Promise
-import com.facebook.react.bridge.ReadableNativeArray
-import expo.modules.kotlin.KPromiseWrapper
-import expo.modules.kotlin.ModuleHolder
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.launch
-import java.lang.ref.WeakReference
 
-class JavaScriptModuleObject(moduleHolder: ModuleHolder) {
+/**
+ * A class to communicate with CPP part of the [expo.modules.kotlin.modules.Module] class.
+ * Used to register exported JSI functions.
+ * The lifetime of instances of this class should be in sync with the lifetime of the bridge.
+ * All exported functions/objects will have a reference to the `JavaScriptModuleObject`,
+ * so it must outlive the current RN context.
+ */
+class JavaScriptModuleObject {
   // Has to be called "mHybridData" - fbjni uses it via reflection
   private val mHybridData = initHybrid()
-  private val moduleHolderRef = WeakReference(moduleHolder)
 
   @Suppress("KotlinJniMissingFunction")
   private external fun initHybrid(): HybridData
 
+  /**
+   * Register a promise-less function on the CPP module representation.
+   * After calling this function, user can access the exported function in the JS code.
+   */
   @Suppress("KotlinJniMissingFunction")
-  external fun registerSyncFunction(name: String, args: Int)
+  external fun registerSyncFunction(name: String, args: Int, body: JNIFunctionBody)
 
+  /**
+   * Register a promise function on the CPP module representation.
+   * After calling this function, user can access the exported function in the JS code.
+   */
   @Suppress("KotlinJniMissingFunction")
-  external fun registerAsyncFunction(name: String, args: Int)
-
-  @Suppress("unused")
-  fun callSyncMethod(name: String, args: ReadableNativeArray): ReadableNativeArray? {
-    return moduleHolderRef.get()?.callSync(name, args)
-  }
-
-  @OptIn(DelicateCoroutinesApi::class)
-  @Suppress("unused")
-  fun callAsyncMethod(name: String, args: ReadableNativeArray, bridgePromise: Any) {
-    val kotlinPromise = KPromiseWrapper(bridgePromise as Promise)
-    moduleHolderRef.get()?.let { holder ->
-      holder.module.appContext.modulesQueue.launch {
-        moduleHolderRef.get()?.call(name, args, kotlinPromise)
-      }
-    }
-  }
+  external fun registerAsyncFunction(name: String, args: Int, body: JNIAsyncFunctionBody)
 
   @Throws(Throwable::class)
   protected fun finalize() {


### PR DESCRIPTION
# Why

Part of #16977.
To match Swift implementation, we want to register JSI functions using lambdas instead of using a dispatcher. 
Also, it will help in the further when we want to add support for multiple JSI objects.

# How

- Adds a `JNIFunctionBody` and `JNIAsyncFunctionBody` which encapsulates Kotlin's implementation of the exported function and can be recognized by the CPP code.
- Used passed lambdas instead of calling `JavaScriptModuleObject` directly. 

# Test Plan

- bare-expo and simple app:
```kotlin
// Cellular module
function("test") { s: String -> s }.runSynchronously()
asyncFunction("testAsync") { s: String -> s }
```

```js
// App.js
const module = global.ExpoModules.ExpoCellular;
console.log(module.test);
console.log(global.ExpoModules.ExpoCellular == global.ExpoModules.ExpoCellular);
console.log(module.test == module.test);
console.log(module.test("abc"));

console.log(module.testAsync("abc").then((resutl) => console.log(resutl) ))