### PR TITLE
[sweet][android] Decorator support for legacy `CodedException`

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/ExceptionDecorator.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/ExceptionDecorator.kt
@@ -5,6 +5,8 @@ internal inline fun <T> exceptionDecorator(decoratorBlock: (e: CodedException) -
     block()
   } catch (e: CodedException) {
     throw decoratorBlock(e)
+  } catch (e: expo.modules.core.errors.CodedException) {
+    throw decoratorBlock(CodedException(e.code, e.message, e.cause))
   } catch (e: Throwable) {
     throw decoratorBlock(UnexpectedException(e))
   }


### PR DESCRIPTION
# Why

Some common exceptions are widely used across modules, like [`CurrentActivityNotFoundException`](https://github.com/expo/expo/blob/main/packages/expo-modules-core/android/src/main/java/expo/modules/core/errors/CurrentActivityNotFoundException.java) which inherit from legacy `expo.modules.core.errors.CodedException`.

When such exceptions are thrown from expo-module Sweet API, their error code information is lost, as they're wrapped in `UnexpectedException`. 

# How

Until all modules using these common exceptions are migrated to sweet API, I made them supported by `ExceptionDecorator` to make stack traces a bit cleaner.

> Alternative approach would be to duplicate these exceptions somewhere in `expo.modules.kotlin.exception` package for Sweet API only, but IMO it's a bit messy approach 🤷 

# Test Plan

I threw it from Sweet API `AsyncFunction` block and compared the stack trace results.
