### PR TITLE
feat(cli): add experimental internal command for installing Expo Go

### DIFF
--- a/packages/@expo/cli/bin/cli.ts
+++ b/packages/@expo/cli/bin/cli.ts
@@ -18,6 +18,7 @@ const commands: { [command: string]: () => Promise<Command> } = {
 
   // Auxiliary commands
   install: () => import('../src/install').then((i) => i.expoInstall),
+  aux: () => import('../src/aux').then((i) => i.expoAux),
 
   // Auth
   login: () => import('../src/login').then((i) => i.expoLogin),
@@ -64,6 +65,8 @@ if (!isSubcommand && args['--help']) {
     prebuild,
     'run:ios': runIos,
     'run:android': runAndroid,
+    // Don't add aux to the help message
+    expoAux,
     ...others
   } = commands;
 

--- a/packages/@expo/cli/src/aux/client/clientAsync.ts
+++ b/packages/@expo/cli/src/aux/client/clientAsync.ts
@@ -1,0 +1,8 @@
+import { Log } from '../../log';
+import { Options } from './resolveOptions';
+
+export async function clientAsync(projectRoot: string, { version, device }: Options) {
+  Log.log('Installing Expo Go on "%s" (SDK: %s)', device.name, version);
+  await device.ensureExpoGoAsync(version);
+  await device.activateWindowAsync();
+}

--- a/packages/@expo/cli/src/aux/client/index.ts
+++ b/packages/@expo/cli/src/aux/client/index.ts
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+import arg from 'arg';
+import chalk from 'chalk';
+import path from 'path';
+
+import { Command } from '../../../bin/cli';
+import { assertWithOptionsArgs, printHelp } from '../../utils/args';
+import { logCmdError } from '../../utils/errors';
+
+export const expoAuxClient: Command = async (argv) => {
+  const rawArgsMap: arg.Spec = {
+    // Types
+    '--help': Boolean,
+    '--sdk-version': String,
+    '--platform': String,
+
+    // Aliases
+    '-p': '--platform',
+    '-h': '--help',
+  };
+  const args = assertWithOptionsArgs(rawArgsMap, {
+    argv,
+    permissive: true,
+  });
+
+  if (args['--help']) {
+    printHelp(
+      `Install the Expo Go app on a device`,
+      `npx expo run:ios`,
+      [
+        chalk`-p, --platform <platform>     Platform to install on: android, ios`,
+        chalk`--sdk-version <string>        Expo Go SDK version to install on device. {dim Default: installed {bold expo} version}`,
+        `-d, --device [device]         Device name or ID to build the app on`,
+
+        `-h, --help                    Usage info`,
+      ].join('\n')
+    );
+  }
+
+  (async () => {
+    const { resolveStringOrBooleanArgsAsync } = await import('../../utils/resolveArgs');
+    const parsed = await resolveStringOrBooleanArgsAsync(argv ?? [], rawArgsMap, {
+      '--device': Boolean,
+      '-d': '--device',
+    }).catch(logCmdError);
+
+    const { resolveOptionsAsync } = await import('./resolveOptions');
+    const { clientAsync } = await import('./clientAsync');
+    const projectRoot = path.resolve(parsed.projectRoot);
+
+    const options = await resolveOptionsAsync(projectRoot, {
+      ...args,
+      ...parsed.args,
+    });
+
+    return clientAsync(projectRoot, options);
+  })().catch(logCmdError);
+};

--- a/packages/@expo/cli/src/aux/client/resolveOptions.ts
+++ b/packages/@expo/cli/src/aux/client/resolveOptions.ts
@@ -1,0 +1,57 @@
+import { getConfig } from '@expo/config';
+
+import { AndroidDeviceManager } from '../../start/platforms/android/AndroidDeviceManager';
+import { AppleDeviceManager } from '../../start/platforms/ios/AppleDeviceManager';
+import { CommandError } from '../../utils/errors';
+
+export type Options = {
+  version: string;
+  platform: 'ios' | 'android';
+  device: AppleDeviceManager | AndroidDeviceManager;
+};
+
+export async function resolveDeviceAsync(
+  platform: 'ios' | 'android',
+  deviceHint?: string | boolean
+) {
+  if (platform === 'ios') {
+    const { isSimulatorDevice, resolveDeviceAsync } = await import(
+      '../../run/ios/options/resolveDevice'
+    );
+    const { AppleDeviceManager } = await import('../../start/platforms/ios/AppleDeviceManager');
+
+    const device = await resolveDeviceAsync(deviceHint);
+    if (!isSimulatorDevice(device)) {
+      throw new CommandError('Cannot install on a physical Apple device');
+    }
+    return AppleDeviceManager.resolveAsync({ device });
+  } else {
+    const { resolveDeviceAsync } = await import('../../run/android/resolveDevice');
+    return resolveDeviceAsync(deviceHint);
+  }
+}
+
+export async function resolveOptionsAsync(projectRoot: string, args: any): Promise<Options> {
+  const device = args['--device'];
+  const platform = args['--platform'];
+  if (!platform || !['ios', 'android'].includes(platform)) {
+    throw new CommandError('BAD_ARGS', 'You must specify a platform to install Expo Go on');
+  }
+  let version = args['--sdk-version'];
+  // Default to the currently installed version
+  if (!version) {
+    // This will throw if expo is not installed
+    version = getConfig(projectRoot).exp.sdkVersion!;
+  } else if (version.match(/^\d+$/)) {
+    // Support `45` and convert to a value like `45.0.0`
+    version = version + '.0.0';
+  }
+
+  return {
+    // Parsed options
+    platform,
+    version,
+    // Resolve the device manager for installing Expo Go
+    device: await resolveDeviceAsync(platform, device),
+  };
+}

--- a/packages/@expo/cli/src/aux/index.ts
+++ b/packages/@expo/cli/src/aux/index.ts
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+import arg from 'arg';
+import chalk from 'chalk';
+
+import { Command } from '../../bin/cli';
+
+export const expoAux: Command = async (argv) => {
+  const commands: { [command: string]: () => Promise<Command> } = {
+    // Add a new command here
+    client: () => import('./client').then((i) => i.expoAuxClient),
+  };
+
+  const args = arg(
+    {
+      // Types
+      '--help': Boolean,
+
+      // Aliases
+      '-h': '--help',
+    },
+    {
+      argv,
+      permissive: true,
+    }
+  );
+
+  // Check if we are running `npx expo aux <subcommand>` or `npx expo`
+  const isSubcommand = Boolean(commands[args._[0]]);
+
+  // Handle `--help` flag
+  if (!isSubcommand && args['--help']) {
+    console.log(chalk`
+    {bold Usage}
+      {dim $} npx expo aux <command>
+  
+    {bold Commands}
+      ${Object.keys(commands).join(', ')}
+  
+    {bold Options}
+      --help, -h      Usage info
+  
+    For more info run a command with the {bold --help} flag
+      {dim $} npx expo aux client --help
+  `);
+    process.exit(0);
+  }
+
+  const command = isSubcommand ? args._[0] : 'client';
+  const commandArgs = isSubcommand ? args._.slice(1) : args._;
+
+  // Push the help flag to the subcommand args.
+  if (args['--help']) {
+    commandArgs.push('--help');
+  }
+
+  commands[command]().then((exec) => exec(commandArgs));
+};

--- a/packages/@expo/cli/src/start/platforms/ExpoGoInstaller.ts
+++ b/packages/@expo/cli/src/start/platforms/ExpoGoInstaller.ts
@@ -28,7 +28,7 @@ export class ExpoGoInstaller<IDevice> {
     }
     const version = await this._getExpectedClientVersionAsync();
     Log.debug(`Expected Expo Go version: ${version}, installed version: ${installedVersion}`);
-    return version ? semver.lt(installedVersion, version) : true;
+    return version ? !semver.eq(installedVersion, version) : true;
   }
 
   /** Returns the expected version of Expo Go given the project SDK Version. Exposed for testing. */

--- a/packages/@expo/cli/src/utils/resolveArgs.ts
+++ b/packages/@expo/cli/src/utils/resolveArgs.ts
@@ -26,7 +26,7 @@ export async function resolveStringOrBooleanArgsAsync(
   );
 
   // Collapse aliases into fully qualified arguments.
-  args = collapseAliases(extraArgs, args);
+  args = collapseAliases({ ...rawMap, ...extraArgs }, args);
 
   // Resolve all of the string or boolean arguments and the project root.
   return _resolveStringOrBooleanArgs({ ...rawMap, ...extraArgs }, args);


### PR DESCRIPTION
# Why

- In expo-cli we have `expo client:install:ios` and `expo client:install:android`.
- In versioned cli we automatically install the client based on the `expo` package version when the user starts a project (we do this in global CLI too).
- I don't want to publicly surface this command because it's auxiliary and clutters the CLI surface area.
- In this PR I propose adding a small sub-cli `npx expo aux <subcommand>` which can be used for things like Expo Go installation, TypeScript setup, Web support setup, etc.
- Alternatively we could create actual commands like `expo typecheck` which would work more like the proposed `expo lint`. We also already have an `expo customize` command which has similar functionality -- adding files and installing versioned packages.
- Ultimately we don't want commands like this in the versioned CLI because it has access to other SDK versions. We want each version of the CLI to be limited to the capabilities of that particular SDK version.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# Test Plan

- `expo aux client -p ios`
  - Pick device with `--device`
  - Pick version with `--sdk-version`

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
