### PR TITLE
[ios] Add the registry for shared objects

### DIFF
--- a/packages/expo-modules-core/ios/JSI/EXJSIConversions.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJSIConversions.mm
@@ -1,6 +1,9 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
 #import <ReactCommon/TurboModuleUtils.h>
+#import <ExpoModulesCore/EXJavaScriptValue.h>
+#import <ExpoModulesCore/EXJavaScriptObject.h>
+#import <ExpoModulesCore/EXJavaScriptWeakObject.h>
 #import <ExpoModulesCore/EXJSIConversions.h>
 #import <ExpoModulesCore/EXJavaScriptValue.h>
 #import <ExpoModulesCore/EXJavaScriptRuntime.h>
@@ -59,6 +62,9 @@ jsi::Value convertObjCObjectToJSIValue(jsi::Runtime &runtime, id value)
   }
   if ([value isKindOfClass:[EXJavaScriptObject class]]) {
     return jsi::Value(runtime, *[(EXJavaScriptObject *)value get]);
+  }
+  if ([value isKindOfClass:[EXJavaScriptWeakObject class]]) {
+    return jsi::Value(runtime, *[[(EXJavaScriptWeakObject *)value lock] get]);
   }
   if ([value isKindOfClass:[NSString class]]) {
     return convertNSStringToJSIString(runtime, (NSString *)value);

--- a/packages/expo-modules-core/ios/JSI/EXJSIUtils.h
+++ b/packages/expo-modules-core/ios/JSI/EXJSIUtils.h
@@ -54,7 +54,7 @@ void defineProperty(jsi::Runtime &runtime, const jsi::Object *object, const char
 #pragma mark - Deallocator
 
 /**
- Sets the deallocator block on given object, which is called when the object is being deallocated.
+ Sets the deallocator block on a given object, which is called when the object is being deallocated.
  */
 void setDeallocator(jsi::Runtime &runtime, std::shared_ptr<jsi::Object> object, ObjectDeallocatorBlock deallocatorBlock);
 

--- a/packages/expo-modules-core/ios/JSI/EXJSIUtils.h
+++ b/packages/expo-modules-core/ios/JSI/EXJSIUtils.h
@@ -6,6 +6,7 @@
 
 #import <jsi/jsi.h>
 #import <ReactCommon/RCTTurboModule.h>
+#import <ExpoModulesCore/EXObjectDeallocator.h>
 
 namespace jsi = facebook::jsi;
 namespace react = facebook::react;
@@ -24,9 +25,38 @@ using ClassConstructor = std::function<void(jsi::Runtime &runtime, const jsi::Va
 
 std::shared_ptr<jsi::Function> createClass(jsi::Runtime &runtime, const char *name, ClassConstructor constructor);
 
+#pragma mark - Weak objects
+
+/**
+ Checks whether the `WeakRef` class is available in the given runtime.
+ According to the docs, it is unimplemented in JSC prior to iOS 14.5.
+ As of the time of writing this comment it's also unimplemented in Hermes
+ where you should use `jsi::WeakObject` instead.
+ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakRef
+ */
+bool isWeakRefSupported(jsi::Runtime &runtime);
+
+/**
+ Creates the `WeakRef` with given JSI object. You should first use `isWeakRefSupported`
+ to check whether this feature is supported by the runtime.
+ */
+std::shared_ptr<jsi::Object> createWeakRef(jsi::Runtime &runtime, std::shared_ptr<jsi::Object> object);
+
+/**
+ Returns the `WeakRef` object's target object, or an empty pointer if the target object has been reclaimed.
+ */
+std::shared_ptr<jsi::Object> derefWeakRef(jsi::Runtime &runtime, std::shared_ptr<jsi::Object> object);
+
 #pragma mark - Define property
 
 void defineProperty(jsi::Runtime &runtime, const jsi::Object *object, const char *name, jsi::Value value);
+
+#pragma mark - Deallocator
+
+/**
+ Sets the deallocator block on given object, which is called when the object is being deallocated.
+ */
+void setDeallocator(jsi::Runtime &runtime, std::shared_ptr<jsi::Object> object, ObjectDeallocatorBlock deallocatorBlock);
 
 } // namespace expo
 

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptObject.h
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptObject.h
@@ -10,6 +10,7 @@ namespace jsi = facebook::jsi;
 
 @class EXJavaScriptRuntime;
 @class EXJavaScriptValue;
+@class EXJavaScriptWeakObject;
 
 /**
  The property descriptor options for the property being defined or modified.
@@ -77,5 +78,13 @@ NS_SWIFT_NAME(JavaScriptObject)
  Defines a new property or modifies an existing property on the object. Calls `Object.defineProperty` under the hood.
  */
 - (void)defineProperty:(nonnull NSString *)name value:(nullable id)value options:(EXJavaScriptObjectPropertyDescriptor)options;
+
+#pragma mark - WeakObject
+
+- (nonnull EXJavaScriptWeakObject *)createWeak;
+
+#pragma mark - Deallocator
+
+- (void)setObjectDeallocator:(void (^ _Nonnull)(void))deallocatorBlock;
 
 @end

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptObject.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptObject.mm
@@ -1,8 +1,11 @@
 // Copyright 2022-present 650 Industries. All rights reserved.
 
 #import <ExpoModulesCore/EXJSIConversions.h>
+#import <ExpoModulesCore/EXJavaScriptValue.h>
 #import <ExpoModulesCore/EXJavaScriptObject.h>
 #import <ExpoModulesCore/EXJavaScriptRuntime.h>
+#import <ExpoModulesCore/EXJavaScriptWeakObject.h>
+#import <ExpoModulesCore/EXJSIUtils.h>
 
 @implementation EXJavaScriptObject {
   /**
@@ -93,6 +96,33 @@
     jsi::String::createFromUtf8(*runtime, [name UTF8String]),
     std::move(descriptor),
   });
+}
+
+#pragma mark - WeakObject
+
+- (nonnull EXJavaScriptWeakObject *)createWeak
+{
+  return [[EXJavaScriptWeakObject alloc] initWith:_jsObjectPtr runtime:_runtime];
+}
+
+#pragma mark - Deallocator
+
+- (void)setObjectDeallocator:(void (^)(void))deallocatorBlock
+{
+  expo::setDeallocator(*[_runtime get], _jsObjectPtr, deallocatorBlock);
+}
+
+#pragma mark - Equality
+
+- (BOOL)isEqual:(id)object
+{
+  if ([object isKindOfClass:EXJavaScriptObject.class]) {
+    jsi::Runtime *runtime = [_runtime get];
+    jsi::Object *a = _jsObjectPtr.get();
+    jsi::Object *b = [object get];
+    return jsi::Object::strictEquals(*runtime, *a, *b);
+  }
+  return false;
 }
 
 #pragma mark - Private helpers

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.h
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.h
@@ -30,6 +30,7 @@ NS_SWIFT_NAME(JavaScriptRuntime)
 - (nonnull instancetype)init;
 
 #ifdef __cplusplus
+
 - (nonnull instancetype)initWithRuntime:(nonnull jsi::Runtime *)runtime
                             callInvoker:(std::shared_ptr<react::CallInvoker>)callInvoker;
 

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptWeakObject.h
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptWeakObject.h
@@ -1,0 +1,23 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+#import <Foundation/Foundation.h>
+#import <ExpoModulesCore/EXJavaScriptValue.h>
+#import <ExpoModulesCore/EXJavaScriptRuntime.h>
+
+#ifdef __cplusplus
+#import <jsi/jsi.h>
+
+namespace jsi = facebook::jsi;
+#endif // __cplusplus
+
+NS_SWIFT_NAME(JavaScriptWeakObject)
+@interface EXJavaScriptWeakObject : NSObject
+
+#ifdef __cplusplus
+- (nonnull instancetype)initWith:(std::shared_ptr<jsi::Object>)jsObject
+                         runtime:(nonnull EXJavaScriptRuntime *)runtime;
+#endif // __cplusplus
+
+- (nullable EXJavaScriptObject *)lock;
+
+@end

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptWeakObject.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptWeakObject.mm
@@ -1,0 +1,53 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+#import <ExpoModulesCore/EXJSIUtils.h>
+#import <ExpoModulesCore/EXJavaScriptWeakObject.h>
+
+@implementation EXJavaScriptWeakObject {
+  /**
+   Pointer to the `EXJavaScriptRuntime` wrapper.
+
+   \note It must be weak because only then the original runtime can be safely deallocated
+   when the JS engine wants to without unsetting it on each created object.
+   */
+  __weak EXJavaScriptRuntime *_runtime;
+
+  /**
+   Shared pointer to the `WeakRef` JS object.
+   */
+  std::shared_ptr<jsi::Object> _jsObject;
+}
+
+- (nonnull instancetype)initWith:(std::shared_ptr<jsi::Object>)jsObject
+                         runtime:(nonnull EXJavaScriptRuntime *)runtime
+{
+  if (self = [super init]) {
+    _runtime = runtime;
+
+    // Check whether the runtime supports `WeakRef` objects. If it does not,
+    // we consciously hold a strong reference to the object and cause memory leaks.
+    // This is the case on hermes and JSC prior to iOS 14.5.
+    // TODO: (@tsapeta) Use `jsi::WeakObject` on hermes
+    if (expo::isWeakRefSupported(*[runtime get])) {
+      _jsObject = expo::createWeakRef(*[runtime get], jsObject);
+    } else {
+      _jsObject = jsObject;
+    }
+  }
+  return self;
+}
+
+- (nullable EXJavaScriptObject *)lock
+{
+  jsi::Runtime *runtime = [_runtime get];
+  std::shared_ptr<jsi::Object> objectPtr = expo::isWeakRefSupported(*runtime)
+    ? expo::derefWeakRef(*runtime, _jsObject)
+    : _jsObject;
+
+  if (!objectPtr) {
+    return nil;
+  }
+  return [[EXJavaScriptObject alloc] initWith:objectPtr runtime:_runtime];
+}
+
+@end

--- a/packages/expo-modules-core/ios/JSI/EXObjectDeallocator.h
+++ b/packages/expo-modules-core/ios/JSI/EXObjectDeallocator.h
@@ -1,0 +1,27 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+#ifdef __cplusplus
+
+#import <jsi/jsi.h>
+
+namespace jsi = facebook::jsi;
+
+namespace expo {
+
+typedef void (^ObjectDeallocatorBlock)();
+
+class JSI_EXPORT ObjectDeallocator : public jsi::HostObject {
+public:
+  ObjectDeallocator(const ObjectDeallocatorBlock deallocator) : deallocator(deallocator) {};
+
+  virtual ~ObjectDeallocator() {
+    deallocator();
+  }
+
+  const ObjectDeallocatorBlock deallocator;
+
+}; // class ObjectDeallocator
+
+} // namespace expo
+
+#endif

--- a/packages/expo-modules-core/ios/Swift/Arguments/ArgumentType.swift
+++ b/packages/expo-modules-core/ios/Swift/Arguments/ArgumentType.swift
@@ -21,6 +21,9 @@ internal func ArgumentType<T>(_ type: T.Type) -> AnyArgumentType {
   if let EnumType = T.self as? EnumArgument.Type {
     return EnumArgumentType(innerType: EnumType)
   }
+  if let SharedObjectType = T.self as? SharedObject.Type {
+    return SharedObjectArgumentType(innerType: SharedObjectType)
+  }
   if T.self is Promise.Type {
     return PromiseArgumentType()
   }

--- a/packages/expo-modules-core/ios/Swift/Arguments/Types/SharedObjectArgumentType.swift
+++ b/packages/expo-modules-core/ios/Swift/Arguments/Types/SharedObjectArgumentType.swift
@@ -1,0 +1,23 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+internal struct SharedObjectArgumentType: AnyArgumentType {
+  let innerType: SharedObject.Type
+
+  func cast<ArgType>(_ value: ArgType) throws -> Any {
+    if let jsObject = try (value as? JavaScriptValue)?.asObject(),
+       let nativeSharedObject = SharedObjectRegistry.toNativeObject(jsObject) {
+      return nativeSharedObject
+    }
+    throw NativeSharedObjectNotFoundException()
+  }
+
+  var description: String {
+    return "SharedObject<\(innerType)>"
+  }
+}
+
+internal final class NativeSharedObjectNotFoundException: Exception {
+  override var reason: String {
+    "Unable to find the native shared object associated with given JavaScript object"
+  }
+}

--- a/packages/expo-modules-core/ios/Swift/JavaScriptUtils.swift
+++ b/packages/expo-modules-core/ios/Swift/JavaScriptUtils.swift
@@ -12,6 +12,9 @@
  */
 internal func castArgument(_ argument: Any, toType argumentType: AnyArgumentType) throws -> Any {
   // TODO: Accept JavaScriptValue and JavaScriptObject as argument types.
+  if argumentType is SharedObjectArgumentType {
+    return try argumentType.cast(argument)
+  }
   if let argument = argument as? JavaScriptValue {
     return try argumentType.cast(argument.getRaw())
   }

--- a/packages/expo-modules-core/ios/Swift/SharedObjects/SharedObject.swift
+++ b/packages/expo-modules-core/ios/Swift/SharedObjects/SharedObject.swift
@@ -1,0 +1,20 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+public protocol AnySharedObject: AnyArgument {
+  var sharedObjectId: SharedObjectId { get }
+}
+
+open class SharedObject: AnySharedObject {
+  /**
+   An identifier of the native shared object that maps to the JavaScript object.
+   When the object is not linked with any JavaScript object, its value is 0.
+   */
+  public internal(set) var sharedObjectId: SharedObjectId = 0
+
+  /**
+   Returns the JavaScript shared object associated with the native shared object.
+   */
+  public func getJavaScriptObject() -> JavaScriptObject? {
+    return SharedObjectRegistry.toJavaScriptObject(self)
+  }
+}

--- a/packages/expo-modules-core/ios/Swift/SharedObjects/SharedObjectRegistry.swift
+++ b/packages/expo-modules-core/ios/Swift/SharedObjects/SharedObjectRegistry.swift
@@ -32,7 +32,7 @@ public final class SharedObjectRegistry {
   internal static var pairs = [SharedObjectId: SharedObjectPair]()
 
   /**
-   Number of all pairs stored in the registry.
+   A number of all pairs stored in the registry.
    */
   internal static var size: Int {
     return pairs.count
@@ -76,7 +76,7 @@ public final class SharedObjectRegistry {
   }
 
   /**
-   Deletes the shared objects pair with given ID.
+   Deletes the shared objects pair with a given ID.
    */
   internal static func delete(_ id: SharedObjectId) {
     if let pair = pairs[id] {
@@ -90,7 +90,7 @@ public final class SharedObjectRegistry {
   }
 
   /**
-   Gets the native shared object that is paired with given JS object.
+   Gets the native shared object that is paired with a given JS object.
    */
   internal static func toNativeObject(_ jsObject: JavaScriptObject) -> SharedObject? {
     if let objectId = try? jsObject.getProperty(sharedObjectIdPropertyName).asInt() {
@@ -100,7 +100,7 @@ public final class SharedObjectRegistry {
   }
 
   /**
-   Gets the JS shared object that is paired with given native object.
+   Gets the JS shared object that is paired with a given native object.
    */
   internal static func toJavaScriptObject(_ nativeObject: SharedObject) -> JavaScriptObject? {
     let objectId = nativeObject.sharedObjectId
@@ -108,7 +108,7 @@ public final class SharedObjectRegistry {
   }
 
   /**
-   Creates a plain JS object and pairs it with given native object.
+   Creates a plain JS object and pairs it with a given native object.
    */
   internal static func createSharedJavaScriptObject(runtime: JavaScriptRuntime, nativeObject: SharedObject) -> JavaScriptObject {
     let object = runtime.createObject()
@@ -117,7 +117,7 @@ public final class SharedObjectRegistry {
   }
 
   /**
-   Ensures that there is a JS object paired with given native object. If not, a plain JS object is created.
+   Ensures that there is a JS object paired with a given native object. If not, a plain JS object is created.
    */
   internal static func ensureSharedJavaScriptObject(runtime: JavaScriptRuntime, nativeObject: SharedObject) -> JavaScriptObject {
     if let jsObject = toJavaScriptObject(nativeObject) {

--- a/packages/expo-modules-core/ios/Swift/SharedObjects/SharedObjectRegistry.swift
+++ b/packages/expo-modules-core/ios/Swift/SharedObjects/SharedObjectRegistry.swift
@@ -1,0 +1,129 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+/**
+ Type of the IDs of shared objects.
+ */
+public typealias SharedObjectId = Int
+
+/**
+ A tuple containing a pair of matching native and JS objects.
+ */
+internal typealias SharedObjectPair = (native: SharedObject, javaScript: JavaScriptWeakObject)
+
+/**
+ Property name of the JS object where the shared object ID is stored.
+ */
+let sharedObjectIdPropertyName = "__expo_shared_object_id__"
+
+/**
+ The registry of all shared objects used in the entire app.
+ It's been made static for simplicity.
+ */
+public final class SharedObjectRegistry {
+  /**
+   The counter of IDs to assign to the shared object pairs.
+   The next pair added to the registry will be saved using this ID.
+   */
+  internal static var nextId: SharedObjectId = 1
+
+  /**
+   A dictionary of shared object pairs.
+   */
+  internal static var pairs = [SharedObjectId: SharedObjectPair]()
+
+  /**
+   Number of all pairs stored in the registry.
+   */
+  internal static var size: Int {
+    return pairs.count
+  }
+
+  /**
+   Returns the next shared object ID and increases the counter.
+   */
+  @discardableResult
+  internal static func pullNextId() -> SharedObjectId {
+    let id = nextId
+    nextId += 1
+    return id
+  }
+
+  /**
+   Returns a pair of shared objects with given ID or `nil` when there is no such pair in the registry.
+   */
+  internal static func get(_ id: SharedObjectId) -> SharedObjectPair? {
+    return pairs[id]
+  }
+
+  /**
+   Adds a pair of native and JS shared object to the registry. Assigns a new shared object ID to these objects.
+   */
+  @discardableResult
+  internal static func add(native nativeObject: SharedObject, javaScript jsObject: JavaScriptObject) -> SharedObjectId {
+    let id = pullNextId()
+
+    // Assigns the ID to the objects.
+    nativeObject.sharedObjectId = id
+    jsObject.defineProperty(sharedObjectIdPropertyName, value: id, options: [.writable])
+
+    // Set the deallocator on the JS object that deletes the entire pair.
+    jsObject.setObjectDeallocator { delete(id) }
+
+    // Save the pair in the dictionary.
+    pairs[id] = (native: nativeObject, javaScript: jsObject.createWeak())
+
+    return id
+  }
+
+  /**
+   Deletes the shared objects pair with given ID.
+   */
+  internal static func delete(_ id: SharedObjectId) {
+    if let pair = pairs[id] {
+      // Reset an ID on the objects.
+      pair.native.sharedObjectId = 0
+      pair.javaScript.lock()?.defineProperty(sharedObjectIdPropertyName, value: 0, options: [.writable])
+
+      // Delete the pair from the dictionary.
+      pairs[id] = nil
+    }
+  }
+
+  /**
+   Gets the native shared object that is paired with given JS object.
+   */
+  internal static func toNativeObject(_ jsObject: JavaScriptObject) -> SharedObject? {
+    if let objectId = try? jsObject.getProperty(sharedObjectIdPropertyName).asInt() {
+      return pairs[objectId]?.native
+    }
+    return nil
+  }
+
+  /**
+   Gets the JS shared object that is paired with given native object.
+   */
+  internal static func toJavaScriptObject(_ nativeObject: SharedObject) -> JavaScriptObject? {
+    let objectId = nativeObject.sharedObjectId
+    return pairs[objectId]?.javaScript.lock()
+  }
+
+  /**
+   Creates a plain JS object and pairs it with given native object.
+   */
+  internal static func createSharedJavaScriptObject(runtime: JavaScriptRuntime, nativeObject: SharedObject) -> JavaScriptObject {
+    let object = runtime.createObject()
+    add(native: nativeObject, javaScript: object)
+    return object
+  }
+
+  /**
+   Ensures that there is a JS object paired with given native object. If not, a plain JS object is created.
+   */
+  internal static func ensureSharedJavaScriptObject(runtime: JavaScriptRuntime, nativeObject: SharedObject) -> JavaScriptObject {
+    if let jsObject = toJavaScriptObject(nativeObject) {
+      // JS object for this native object already exists in the registry, just return it.
+      return jsObject
+    }
+    return createSharedJavaScriptObject(runtime: runtime, nativeObject: nativeObject)
+  }
+}

--- a/packages/expo-modules-core/ios/Tests/SharedObjectRegistrySpec.swift
+++ b/packages/expo-modules-core/ios/Tests/SharedObjectRegistrySpec.swift
@@ -1,0 +1,109 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+import ExpoModulesTestCore
+
+@testable import ExpoModulesCore
+
+final class SharedObjectRegistrySpec: ExpoSpec {
+  override func spec() {
+    let appContext = AppContext.create()
+    let runtime = appContext.runtime
+
+    describe("pullNextId") {
+      it("returns nextId") {
+        let id = SharedObjectRegistry.nextId
+        expect(SharedObjectRegistry.pullNextId()) == id
+      }
+      it("increments nextId") {
+        let id = SharedObjectRegistry.nextId
+        SharedObjectRegistry.pullNextId()
+        expect(SharedObjectRegistry.nextId) == id + 1
+      }
+      it("is not increasing size") {
+        let size = SharedObjectRegistry.size
+        SharedObjectRegistry.pullNextId()
+        expect(SharedObjectRegistry.size) == size
+      }
+    }
+
+    describe("add") {
+      it("adds using nextId") {
+        let nextId = SharedObjectRegistry.nextId
+        let id = SharedObjectRegistry.add(native: TestSharedObject(), javaScript: runtime!.createObject())
+        expect(nextId) == id
+      }
+      it("is increasing size") {
+        let size = SharedObjectRegistry.size
+        SharedObjectRegistry.add(native: TestSharedObject(), javaScript: runtime!.createObject())
+        expect(SharedObjectRegistry.size) == size + 1
+      }
+      it("assigns id on native object") {
+        let nativeObject = TestSharedObject()
+        let id = SharedObjectRegistry.add(native: nativeObject, javaScript: runtime!.createObject())
+        expect(nativeObject.sharedObjectId) == id
+      }
+      it("assigns id on JS object") {
+        let jsObject = runtime!.createObject()
+        let id = SharedObjectRegistry.add(native: TestSharedObject(), javaScript: jsObject)
+        expect(jsObject.hasProperty(sharedObjectIdPropertyName)) == true
+        expect(try! jsObject.getProperty(sharedObjectIdPropertyName).asInt()) == id
+      }
+      it("saves objects pair") {
+        let nativeObject = TestSharedObject()
+        let jsObject = runtime!.createObject()
+        let id = SharedObjectRegistry.add(native: nativeObject, javaScript: jsObject)
+        let pair = SharedObjectRegistry.get(id)
+        expect(pair?.native) === nativeObject
+        expect(pair?.javaScript.lock()) == jsObject
+      }
+    }
+
+    describe("delete") {
+      it("deletes objects pair") {
+        let id = SharedObjectRegistry.add(native: TestSharedObject(), javaScript: runtime!.createObject())
+        SharedObjectRegistry.delete(id)
+        expect(SharedObjectRegistry.get(id)).to(beNil())
+      }
+      it("resets id on native object") {
+        let nativeObject = TestSharedObject()
+        let id = SharedObjectRegistry.add(native: nativeObject, javaScript: runtime!.createObject())
+        SharedObjectRegistry.delete(id)
+        expect(nativeObject.sharedObjectId) == 0
+      }
+      it("resets id on JS object") {
+        let jsObject = runtime!.createObject()
+        let id = SharedObjectRegistry.add(native: TestSharedObject(), javaScript: jsObject)
+        SharedObjectRegistry.delete(id)
+        expect(try! jsObject.getProperty(sharedObjectIdPropertyName).asInt()) == 0
+      }
+    }
+
+    describe("toNativeObject") {
+      it("returns native object") {
+        let nativeObject = TestSharedObject()
+        let jsObject = runtime!.createObject()
+        SharedObjectRegistry.add(native: nativeObject, javaScript: jsObject)
+        expect(SharedObjectRegistry.toNativeObject(jsObject)) === nativeObject
+      }
+      it("returns nil") {
+        let jsObject = runtime!.createObject()
+        expect(SharedObjectRegistry.toNativeObject(jsObject)).to(beNil())
+      }
+    }
+
+    describe("toJavaScriptObject") {
+      it("returns JS object") {
+        let nativeObject = TestSharedObject()
+        let jsObject = runtime!.createObject()
+        SharedObjectRegistry.add(native: nativeObject, javaScript: jsObject)
+        expect(SharedObjectRegistry.toJavaScriptObject(nativeObject)) == jsObject
+      }
+      it("returns nil") {
+        let nativeObject = TestSharedObject()
+        expect(SharedObjectRegistry.toJavaScriptObject(nativeObject)).to(beNil())
+      }
+    }
+  }
+}
+
+final class TestSharedObject: SharedObject {}


### PR DESCRIPTION
# Why

First step to add shared objects functionality to the modules core. It begins with the registry for shared objects, where a pair of native and JS objects will be stored by ID. 

Closes ENG-4970
Part of ENG-4541

# How

- The registry is for now fully static, because it doesn't matter too much as we usually use just one app context and making one registry for each context would need much more changes. I'll probably address this later. (ENG-4973)
- Besides the registry, I also added simple class to create JS weak objects so that we only hold weak references in the registry. The JSI has declarations for `jsi::WeakObject`, but since it's unimplemented on JSC I decided to go with [`WeakRef`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakRef) for now (which in turn is unimplemented in Hermes and JSC prior to iOS 14.5). In short, this implementation may potentially cause memory leaks in some runtimes, but I'll address this problem later as well (ENG-4971).
- Added simple `expo::ObjectDeallocator` host object that will be pinned to non-host objects (JS shared objects) and let us know when the object is deallocated.
- Added tests for the key features of the registry. I had implemented `isEqual` method on `JavaScriptObject` to do the comparisons on the objects returned by the registry. It allows us to use `==` to compare if two instances point to the same underlying object (we reinstantiate in some cases).

# Test Plan

- New iOS unit tests are passing, others are unaffected
- Locally I have some more features and tests build on top of this and it works perfectly with them (PRs soon!)