### PR TITLE
[test-core][android] Improve module mocking

### DIFF
--- a/packages/expo-clipboard/android/src/test/java/expo/modules/clipboard/ClipboardModuleTest.kt
+++ b/packages/expo-clipboard/android/src/test/java/expo/modules/clipboard/ClipboardModuleTest.kt
@@ -16,7 +16,6 @@ import io.mockk.confirmVerified
 import io.mockk.verify
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/packages/expo-clipboard/android/src/test/java/expo/modules/clipboard/ClipboardModuleTest.kt
+++ b/packages/expo-clipboard/android/src/test/java/expo/modules/clipboard/ClipboardModuleTest.kt
@@ -11,6 +11,7 @@ import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.exception.errorCodeOf
 import expo.modules.test.core.ModuleMock
 import expo.modules.test.core.ModuleMockHolder
+import expo.modules.test.core.assertCodedException
 import io.mockk.confirmVerified
 import io.mockk.verify
 import org.junit.Assert.assertEquals
@@ -37,7 +38,7 @@ private interface ClipboardModuleTestInterface {
 }
 
 private inline fun withClipboardMock(
-  block: ModuleMockHolder<ClipboardModuleTestInterface>.() -> Unit
+  block: ModuleMockHolder<ClipboardModuleTestInterface, ClipboardModule>.() -> Unit
 ) = ModuleMock.createMock(ClipboardModuleTestInterface::class, ClipboardModule(), block = block)
 
 @RunWith(RobolectricTestRunner::class)
@@ -158,10 +159,10 @@ class ClipboardModuleTest {
   @Config(shadows = [ContextWithoutClipboardService::class])
   fun `should throw when ClipboardManager is unavailable`() = withClipboardMock {
     val exception = runCatching { module.hasStringAsync() }.exceptionOrNull()
-    assertNotNull(exception)
-    assertTrue(exception is CodedException)
-    exception as CodedException
-    assertEquals(errorCodeOf<ClipboardUnavailableException>(), exception.code)
+
+    assertCodedException(exception) {
+      assertEquals(errorCodeOf<ClipboardUnavailableException>(), it.code)
+    }
   }
 
   private val clipboardManager: ClipboardManager

--- a/packages/expo-modules-test-core/android/src/main/java/expo/modules/test/core/ModuleMock.kt
+++ b/packages/expo-modules-test-core/android/src/main/java/expo/modules/test/core/ModuleMock.kt
@@ -8,6 +8,8 @@ import expo.modules.core.interfaces.services.EventEmitter
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.ModuleHolder
 import expo.modules.kotlin.modules.Module
+import io.mockk.MockK
+import io.mockk.MockKGateway
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
@@ -15,19 +17,37 @@ import java.lang.ref.WeakReference
 import java.lang.reflect.Proxy
 import kotlin.reflect.KClass
 
-class ModuleMock {
+/**
+ * This class shouldn't be used directly. Instead use
+ * ```kotlin
+ * ModuleMock.createMock(MyModuleTestInterface::class, MyModule()) {
+ *   // module test code here
+ * }
+ * ```
+ */
+data class ModuleMock<TestInterfaceType : Any, ModuleType : Module>(
+  val testInterface: TestInterfaceType,
+  val appContext: AppContext,
+  val eventEmitter: EventEmitter,
+  val moduleSpy: ModuleType
+) {
   companion object {
-    fun <T : Any> createMock(
-      moduleTestInterface: KClass<T>,
-      module: Module,
+    /**
+     * This overload shouldn't be used directly. Instead use
+     * the inline overload with `block` being the last argument:
+     * `ModuleMock.createMock(..., block: (...) -> Unit)` instead
+     */
+    fun <TestInterfaceType : Any, ModuleType : Module> createMock(
+      moduleTestInterface: KClass<TestInterfaceType>,
+      module: ModuleType,
       customAppContext: AppContext? = null,
-      customEventEmitter: EventEmitter? = null,
-    ): Triple<T, AppContext, EventEmitter> {
+      customEventEmitter: EventEmitter? = null
+    ): ModuleMock<TestInterfaceType, ModuleType> {
       val appContext = prepareMockAppContext(customAppContext)
       val eventEmitter: EventEmitter = customEventEmitter ?: mockk(relaxed = true)
 
       // prepare module spy
-      val moduleSpy = spyk(module)
+      val moduleSpy = convertToSpy(module, recordPrivateCalls = true)
       every { moduleSpy getProperty "appContext" } returns appContext
       every { moduleSpy.sendEvent(any(), any()) } answers { call ->
         val (eventName, eventBody) = call.invocation.args
@@ -43,34 +63,48 @@ class ModuleMock {
         holder
       )
       @Suppress("UNCHECKED_CAST")
-      return Triple(
+      return ModuleMock(
         Proxy
           .newProxyInstance(
             moduleTestInterface.java.classLoader,
             arrayOf(moduleTestInterface.java, ModuleController::class.java),
             invocationHandler
-          ) as T,
+          ) as TestInterfaceType,
         appContext,
-        eventEmitter
+        eventEmitter,
+        moduleSpy
       )
     }
 
-    inline fun <T : Any> createMock(
-      moduleTestInterface: KClass<T>,
-      module: Module,
+    /**
+     * Executes the given [block] in the mocked module scope.
+     * Example usage:
+     * ```kotlin
+     * ModuleMock.createMock(MyModuleTestInterface::class, MyModule()) {
+     *   every { moduleSpy.someModulePrivateFn() } returns 5
+     *   val result = module.someFunctionAsync()
+     *   assertEquals(result, 5)
+     * }
+     * ```
+     */
+    inline fun <TestInterfaceType : Any, ModuleType : Module> createMock(
+      moduleTestInterface: KClass<TestInterfaceType>,
+      module: ModuleType,
       autoOnCreate: Boolean = true,
       customAppContext: AppContext? = null,
       customEventEmitter: EventEmitter? = null,
-      block: ModuleMockHolder<T>.() -> Unit
+      block: ModuleMockHolder<TestInterfaceType, ModuleType>.() -> Unit
     ) {
-      val (mock, appContext, eventEmitter) = createMock(
+      val (mock, appContext, eventEmitter, moduleSpy) = createMock(
         moduleTestInterface,
         module,
         customAppContext,
         customEventEmitter
       )
       val controller = mock as ModuleController
-      val holder = ModuleMockHolder<T>(mock, controller, appContext, eventEmitter)
+      val holder = ModuleMockHolder<TestInterfaceType, ModuleType>(
+        mock, controller, appContext, eventEmitter, moduleSpy
+      )
 
       if (autoOnCreate) {
         controller.onCreate()
@@ -91,8 +125,28 @@ private fun prepareMockAppContext(customAppContext: AppContext?): AppContext {
 
   // as AppContext holds only weak reference to Android Context which can be destroyed too early
   // we need to override it to return actual strong reference (held by mockk internals)
-  val appContextSpy = spyk(appContext)
+  val appContextSpy = convertToSpy(appContext)
   every { appContextSpy getProperty "reactContext" } returns reactContext
 
   return appContextSpy
 }
+
+/**
+ * Creates a spy from given object or returns it as-is if it's already a spy
+ */
+private fun <T : Any> convertToSpy(obj: T, recordPrivateCalls: Boolean = false): T =
+  MockK.useImpl {
+    return@useImpl if (MockKGateway.implementation().mockTypeChecker.isSpy(obj)) {
+      obj
+    } else {
+      // this is actually spyk<T>(obj) but without syntax sugar
+      // because we're already inside MockK.useImpl { } which is part of that sugar
+      MockKGateway.implementation().mockFactory.spyk(
+        mockType = null, // this should be null if objToCopy is provided
+        objToCopy = obj,
+        name = null,
+        moreInterfaces = emptyArray(),
+        recordPrivateCalls = recordPrivateCalls
+      )
+    }
+  }

--- a/packages/expo-modules-test-core/android/src/main/java/expo/modules/test/core/ModuleMock.kt
+++ b/packages/expo-modules-test-core/android/src/main/java/expo/modules/test/core/ModuleMock.kt
@@ -132,7 +132,7 @@ private fun prepareMockAppContext(customAppContext: AppContext?): AppContext {
 }
 
 /**
- * Creates a spy from given object or returns it as-is if it's already a spy
+ * Creates a spy from a given object or returns it as-is if it's already a spy
  */
 private fun <T : Any> convertToSpy(obj: T, recordPrivateCalls: Boolean = false): T =
   MockK.useImpl {

--- a/packages/expo-modules-test-core/android/src/main/java/expo/modules/test/core/ModuleMockHolder.kt
+++ b/packages/expo-modules-test-core/android/src/main/java/expo/modules/test/core/ModuleMockHolder.kt
@@ -2,10 +2,12 @@ package expo.modules.test.core
 
 import expo.modules.core.interfaces.services.EventEmitter
 import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.modules.Module
 
-data class ModuleMockHolder<T>(
-  val module: T,
+data class ModuleMockHolder<TestInterfaceType, ModuleType : Module>(
+  val module: TestInterfaceType,
   val controller: ModuleController,
   val appContext: AppContext,
-  val eventEmitter: EventEmitter
+  val eventEmitter: EventEmitter,
+  val moduleSpy: ModuleType
 )

--- a/packages/expo-modules-test-core/android/src/main/java/expo/modules/test/core/TestUtils.kt
+++ b/packages/expo-modules-test-core/android/src/main/java/expo/modules/test/core/TestUtils.kt
@@ -1,6 +1,8 @@
 package expo.modules.test.core
 
+import expo.modules.kotlin.exception.CodedException
 import org.junit.Assert
+import java.lang.reflect.UndeclaredThrowableException
 
 fun assertResolved(promise: PromiseMock) {
   Assert.assertEquals(PromiseState.RESOLVED, promise.state)
@@ -29,4 +31,23 @@ fun assertRejectedWithCode(promise: PromiseMock, rejectCode: String) {
     Assert.assertTrue("Promise has no rejection code", it.rejectCodeSet)
     Assert.assertEquals(it.rejectCode, rejectCode)
   }
+}
+
+inline fun assertCodedException(exception: Throwable?, block: (exception: CodedException) -> Unit = {}) {
+  Assert.assertNotNull("Expected exception, received null", exception)
+
+  if (exception is UndeclaredThrowableException) {
+    Assert.fail(
+      "Expected CodedException, got UndeclaredThrowableException. " +
+        "Did you forget to add '@Throws' annotations to module test interface methods?"
+    )
+  }
+
+  if (exception !is CodedException) {
+    Assert.fail(
+      "Expected CodedException, got ${exception!!::class.simpleName}. " +
+        "Full stack trace:\n${exception.stackTraceToString()}"
+    )
+  }
+  block(exception as CodedException)
 }


### PR DESCRIPTION
# Why

Extracted from #17454 as these are significant changes not directly related to expo-web-browser.

Some of these changes are necessary to migrate more sophisticated unit tests to be compatible with sweet api.

# How

- Exposed a spy object of actual `Module` instance (as a `moduleSpy` variable available in the test block scope). This adds a possibility to mock module class members:
   ```kt
   class MyModule : Module() {
     private fun someModulePrivateFn() = 2
     // ...
     AsyncFunction("someFunctionAsync") { someModulePrivateFn() }
   }
  
   @Test
   fun someTest() = ModuleMock.createMock(MyModuleTestInterface::class, MyModule()) {
     every { moduleSpy.someModulePrivateFn() } returns 5
     val result = module.someFunctionAsync()
     assertEquals(result, 5)
   }
   ```
- Added a possibility to provide both `Module` and `AppContext` instances to `ModuleMock.createMock` already as a `spyk()` objects. This makes additional mock setup possible.
- Added a utility function `assertCodedException` to perform some common assertions of exceptions thrown by module methods.
  ```kt
   val exception = runCatching { module.hasStringAsync() }.exceptionOrNull()
   assertCodedException(exception) {
     // implicitly checks if exception is a non-null CodedException
     assertEquals(errorCodeOf<ClipboardUnavailableException>(), it.code)
   }
   ```
# Test Plan

Clipboard and WebBrowser unit tests
