### PR TITLE
[ios] Classes with associated shared object type

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Create `AppContextProvider` on Android. ([#17546](https://github.com/expo/expo/pull/17546) by [@bbarthec](https://github.com/bbarthec))
 - Introduce dynamic properties in the Sweet API on iOS. ([#17318](https://github.com/expo/expo/pull/17318) by [@tsapeta](https://github.com/tsapeta))
+- Implemented classes in the Sweet API on iOS. ([#17514](https://github.com/expo/expo/pull/17514), [#17525](https://github.com/expo/expo/pull/17525) by [@tsapeta](https://github.com/tsapeta))
 - Add basic support for sync functions in the Sweet API on Android. ([#16977](https://github.com/expo/expo/pull/16977) by [@lukmccall](https://github.com/lukmccall))
 
 ### 🐛 Bug fixes

--- a/packages/expo-modules-core/ios/JSI/EXJSIUtils.h
+++ b/packages/expo-modules-core/ios/JSI/EXJSIUtils.h
@@ -21,7 +21,7 @@ void callPromiseSetupWithBlock(jsi::Runtime &runtime, std::shared_ptr<react::Cal
 
 #pragma mark - Classes
 
-using ClassConstructor = std::function<void(jsi::Runtime &runtime, const jsi::Value &thisValue, jsi::Array args)>;
+using ClassConstructor = std::function<void(jsi::Runtime &runtime, const jsi::Value &thisValue, const jsi::Value *args, size_t count)>;
 
 std::shared_ptr<jsi::Function> createClass(jsi::Runtime &runtime, const char *name, ClassConstructor constructor);
 

--- a/packages/expo-modules-core/ios/JSI/EXJSIUtils.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJSIUtils.mm
@@ -91,7 +91,7 @@ std::shared_ptr<jsi::Function> createClass(jsi::Runtime &runtime, const char *na
 
   // Create a string buffer of the source code to evaluate.
   std::stringstream source;
-  source << "(function " << name << "(...args) { this." << nativeConstructorKey << "(args); return this; })";
+  source << "(function " << name << "(...args) { this." << nativeConstructorKey << "(...args); return this; })";
   std::shared_ptr<jsi::StringBuffer> sourceBuffer = std::make_shared<jsi::StringBuffer>(source.str());
 
   // Evaluate the code and obtain returned value (the constructor function).
@@ -103,9 +103,9 @@ std::shared_ptr<jsi::Function> createClass(jsi::Runtime &runtime, const char *na
   jsi::Function nativeConstructor = jsi::Function::createFromHostFunction(
     runtime,
     nativeConstructorPropId,
-    1,
+    0,
     [constructor](jsi::Runtime &runtime, const jsi::Value &thisValue, const jsi::Value *args, size_t count) -> jsi::Value {
-      constructor(runtime, thisValue, args->asObject(runtime).asArray(runtime));
+      constructor(runtime, thisValue, args, count);
       return jsi::Value::undefined();
     });
 

--- a/packages/expo-modules-core/ios/JSI/EXJSIUtils.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJSIUtils.mm
@@ -103,6 +103,7 @@ std::shared_ptr<jsi::Function> createClass(jsi::Runtime &runtime, const char *na
   jsi::Function nativeConstructor = jsi::Function::createFromHostFunction(
     runtime,
     nativeConstructorPropId,
+    // The paramCount is not obligatory to match, it only affects the `length` property of the function.
     0,
     [constructor](jsi::Runtime &runtime, const jsi::Value &thisValue, const jsi::Value *args, size_t count) -> jsi::Value {
       constructor(runtime, thisValue, args, count);

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.h
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.h
@@ -14,11 +14,19 @@ namespace react = facebook::react;
 @class EXJavaScriptValue;
 @class EXJavaScriptObject;
 
-typedef void (^JSAsyncFunctionBlock)(NSArray * _Nonnull, RCTPromiseResolveBlock _Nonnull, RCTPromiseRejectBlock _Nonnull);
-typedef id _Nullable (^JSSyncFunctionBlock)(NSArray * _Nonnull);
+typedef void (^JSAsyncFunctionBlock)(EXJavaScriptValue * _Nonnull thisValue,
+                                     NSArray<EXJavaScriptValue *> * _Nonnull arguments,
+                                     RCTPromiseResolveBlock _Nonnull resolve,
+                                     RCTPromiseRejectBlock _Nonnull reject);
+
+typedef id _Nullable (^JSSyncFunctionBlock)(EXJavaScriptValue * _Nonnull thisValue,
+                                            NSArray<EXJavaScriptValue *> * _Nonnull arguments);
 
 #ifdef __cplusplus
-typedef jsi::Value (^JSHostFunctionBlock)(jsi::Runtime &runtime, std::shared_ptr<react::CallInvoker> callInvoker, NSArray<EXJavaScriptValue *> * _Nonnull arguments);
+typedef jsi::Value (^JSHostFunctionBlock)(jsi::Runtime &runtime,
+                                          std::shared_ptr<react::CallInvoker> callInvoker,
+                                          EXJavaScriptValue * _Nonnull thisValue,
+                                          NSArray<EXJavaScriptValue *> * _Nonnull arguments);
 #endif // __cplusplus
 
 NS_SWIFT_NAME(JavaScriptRuntime)

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.mm
@@ -86,29 +86,41 @@ using namespace facebook;
                                          argsCount:(NSInteger)argsCount
                                              block:(nonnull JSSyncFunctionBlock)block
 {
-  return [self createHostFunction:name argsCount:argsCount block:^jsi::Value(jsi::Runtime &runtime, std::shared_ptr<react::CallInvoker> callInvoker, NSArray * _Nonnull arguments) {
-    return expo::convertObjCObjectToJSIValue(runtime, block(arguments));
-  }];
+  JSHostFunctionBlock hostFunctionBlock = ^jsi::Value(
+    jsi::Runtime &runtime,
+    std::shared_ptr<react::CallInvoker> callInvoker,
+    EXJavaScriptValue * _Nonnull thisValue,
+    NSArray<EXJavaScriptValue *> * _Nonnull arguments) {
+    @autoreleasepool {
+      return expo::convertObjCObjectToJSIValue(runtime, block(thisValue, arguments));
+    }
+  };
+  return [self createHostFunction:name argsCount:argsCount block:hostFunctionBlock];
 }
 
 - (nonnull EXJavaScriptObject *)createAsyncFunction:(nonnull NSString *)name
                                           argsCount:(NSInteger)argsCount
                                               block:(nonnull JSAsyncFunctionBlock)block
 {
-  return [self createHostFunction:name argsCount:argsCount block:^jsi::Value(jsi::Runtime &runtime, std::shared_ptr<react::CallInvoker> callInvoker, NSArray *arguments) {
+  JSHostFunctionBlock hostFunctionBlock = ^jsi::Value(
+    jsi::Runtime &runtime,
+    std::shared_ptr<react::CallInvoker> callInvoker,
+    EXJavaScriptValue * _Nonnull thisValue,
+    NSArray<EXJavaScriptValue *> * _Nonnull arguments) {
     if (!callInvoker) {
       // In mocked environment the call invoker may be null so it's not supported to call async functions.
       // Testing async functions is a bit more complicated anyway. See `init` description for more.
       throw jsi::JSError(runtime, "Calling async functions is not supported when the call invoker is unavailable");
     }
     // The function that is invoked as a setup of the EXJavaScript `Promise`.
-    auto promiseSetup = [callInvoker, block, arguments](jsi::Runtime &runtime, std::shared_ptr<Promise> promise) {
+    auto promiseSetup = [callInvoker, block, thisValue, arguments](jsi::Runtime &runtime, std::shared_ptr<Promise> promise) {
       expo::callPromiseSetupWithBlock(runtime, callInvoker, promise, ^(RCTPromiseResolveBlock resolver, RCTPromiseRejectBlock rejecter) {
-        block(arguments, resolver, rejecter);
+        block(thisValue, arguments, resolver, rejecter);
       });
     };
     return createPromiseAsJSIValue(runtime, promiseSetup);
-  }];
+  };
+  return [self createHostFunction:name argsCount:argsCount block:hostFunctionBlock];
 }
 
 #pragma mark - Classes
@@ -116,13 +128,14 @@ using namespace facebook;
 - (nonnull EXJavaScriptObject *)createClass:(nonnull NSString *)name
                                 constructor:(nonnull ClassConstructorBlock)constructor
 {
-  std::shared_ptr<jsi::Function> klass = expo::createClass(*_runtime, [name UTF8String], [self, constructor](jsi::Runtime &runtime, const jsi::Value &thisValue, jsi::Array args) {
+  expo::ClassConstructor jsConstructor = [self, constructor](jsi::Runtime &runtime, const jsi::Value &thisValue, const jsi::Value *args, size_t count) {
     std::shared_ptr<jsi::Object> thisPtr = std::make_shared<jsi::Object>(thisValue.asObject(runtime));
     EXJavaScriptObject *caller = [[EXJavaScriptObject alloc] initWith:thisPtr runtime:self];
-    NSArray<EXJavaScriptValue *> *arguments = expo::convertJSIArrayToNSArray(runtime, args, self->_jsCallInvoker);
+    NSArray<EXJavaScriptValue *> *arguments = expo::convertJSIValuesToNSArray(self, args, count);
 
     constructor(caller, arguments);
-  });
+  };
+  std::shared_ptr<jsi::Function> klass = expo::createClass(*_runtime, [name UTF8String], jsConstructor);
   return [[EXJavaScriptObject alloc] initWith:klass runtime:self];
 }
 
@@ -160,7 +173,10 @@ using namespace facebook;
     // there is no need to care about that for synchronous calls, so it's ensured in `createAsyncFunction` instead.
     auto callInvoker = weakCallInvoker.lock();
     NSArray<EXJavaScriptValue *> *arguments = expo::convertJSIValuesToNSArray(self, args, count);
-    return block(runtime, callInvoker, arguments);
+    std::shared_ptr<jsi::Value> thisValPtr = std::make_shared<jsi::Value>(runtime, std::move(thisVal));
+    EXJavaScriptValue *thisValue = [[EXJavaScriptValue alloc] initWithRuntime:self value:thisValPtr];
+
+    return block(runtime, callInvoker, thisValue, arguments);
   };
   std::shared_ptr<jsi::Object> fnPtr = std::make_shared<jsi::Object>(jsi::Function::createFromHostFunction(*_runtime, propNameId, (unsigned int)argsCount, function));
   return [[EXJavaScriptObject alloc] initWith:fnPtr runtime:self];

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.mm
@@ -91,10 +91,8 @@ using namespace facebook;
     std::shared_ptr<react::CallInvoker> callInvoker,
     EXJavaScriptValue * _Nonnull thisValue,
     NSArray<EXJavaScriptValue *> * _Nonnull arguments) {
-    @autoreleasepool {
       return expo::convertObjCObjectToJSIValue(runtime, block(thisValue, arguments));
-    }
-  };
+    };
   return [self createHostFunction:name argsCount:argsCount block:hostFunctionBlock];
 }
 
@@ -107,19 +105,19 @@ using namespace facebook;
     std::shared_ptr<react::CallInvoker> callInvoker,
     EXJavaScriptValue * _Nonnull thisValue,
     NSArray<EXJavaScriptValue *> * _Nonnull arguments) {
-    if (!callInvoker) {
-      // In mocked environment the call invoker may be null so it's not supported to call async functions.
-      // Testing async functions is a bit more complicated anyway. See `init` description for more.
-      throw jsi::JSError(runtime, "Calling async functions is not supported when the call invoker is unavailable");
-    }
-    // The function that is invoked as a setup of the EXJavaScript `Promise`.
-    auto promiseSetup = [callInvoker, block, thisValue, arguments](jsi::Runtime &runtime, std::shared_ptr<Promise> promise) {
-      expo::callPromiseSetupWithBlock(runtime, callInvoker, promise, ^(RCTPromiseResolveBlock resolver, RCTPromiseRejectBlock rejecter) {
-        block(thisValue, arguments, resolver, rejecter);
-      });
+      if (!callInvoker) {
+        // In mocked environment the call invoker may be null so it's not supported to call async functions.
+        // Testing async functions is a bit more complicated anyway. See `init` description for more.
+        throw jsi::JSError(runtime, "Calling async functions is not supported when the call invoker is unavailable");
+      }
+      // The function that is invoked as a setup of the EXJavaScript `Promise`.
+      auto promiseSetup = [callInvoker, block, thisValue, arguments](jsi::Runtime &runtime, std::shared_ptr<Promise> promise) {
+        expo::callPromiseSetupWithBlock(runtime, callInvoker, promise, ^(RCTPromiseResolveBlock resolver, RCTPromiseRejectBlock rejecter) {
+          block(thisValue, arguments, resolver, rejecter);
+        });
+      };
+      return createPromiseAsJSIValue(runtime, promiseSetup);
     };
-    return createPromiseAsJSIValue(runtime, promiseSetup);
-  };
   return [self createHostFunction:name argsCount:argsCount block:hostFunctionBlock];
 }
 

--- a/packages/expo-modules-core/ios/Swift/Classes/ClassComponentElement.swift
+++ b/packages/expo-modules-core/ios/Swift/Classes/ClassComponentElement.swift
@@ -1,12 +1,33 @@
 // Copyright 2022-present 650 Industries. All rights reserved.
 
 /**
- A protocol that must be implemented by the components passed as ``ClassComponent`` elements.
+ A type-erased protocol that must be implemented by the components passed as ``ClassComponent`` elements.
  */
-public protocol ClassComponentElement: AnyDefinition {}
+public protocol AnyClassComponentElement: AnyDefinition {}
 
+/**
+ Class component element with an associated owner type. The `OwnerType` should refer to
+ the type that the parent `Class` component is associated with (e.g. the shared object type).
+ */
+public protocol ClassComponentElement: AnyClassComponentElement {
+  associatedtype OwnerType
+}
+
+// MARK: - Conformance
 // Allow some other components to be used as the class component elements.
-extension SyncFunctionComponent: ClassComponentElement {}
-extension AsyncFunctionComponent: ClassComponentElement {}
-extension PropertyComponent: ClassComponentElement {}
-extension ConstantsDefinition: ClassComponentElement {}
+
+extension SyncFunctionComponent: ClassComponentElement {
+  public typealias OwnerType = FirstArgType
+}
+
+extension AsyncFunctionComponent: ClassComponentElement {
+  public typealias OwnerType = FirstArgType
+}
+
+extension PropertyComponent: ClassComponentElement {
+  public typealias OwnerType = Void
+}
+
+extension ConstantsDefinition: ClassComponentElement {
+  public typealias OwnerType = Void
+}

--- a/packages/expo-modules-core/ios/Swift/Classes/ClassComponentElementsBuilder.swift
+++ b/packages/expo-modules-core/ios/Swift/Classes/ClassComponentElementsBuilder.swift
@@ -1,13 +1,34 @@
 // Copyright 2022-present 650 Industries. All rights reserved.
 
-#if swift(>=5.4)
 /**
  A result builder that captures the ``ClassComponent`` elements such as functions, constants and properties.
  */
 @resultBuilder
-public struct ClassComponentElementsBuilder {
-  public static func buildBlock(_ elements: ClassComponentElement...) -> [ClassComponentElement] {
+public struct ClassComponentElementsBuilder<OwnerType> {
+  public static func buildBlock(_ elements: AnyClassComponentElement...) -> [AnyClassComponentElement] {
     return elements
   }
+
+  /**
+   Default implementation without any constraints that just returns type-erased element.
+   */
+  static func buildExpression<ElementType: ClassComponentElement>(
+    _ element: ElementType
+  ) -> AnyClassComponentElement {
+    return element
+  }
+
+  /**
+   In case the element's owner type matches builder's generic type,
+   we need to instruct the function to pass `this` to the closure
+   as the first argument and deduct it from `argumentsCount`.
+   */
+  static func buildExpression<ElementType: ClassComponentElement>(
+    _ element: ElementType
+  ) -> AnyClassComponentElement where ElementType.OwnerType == OwnerType {
+    if var function = element as? AnyFunction {
+      function.takesOwner = true
+    }
+    return element
+  }
 }
-#endif

--- a/packages/expo-modules-core/ios/Swift/Classes/ClassComponentFactories.swift
+++ b/packages/expo-modules-core/ios/Swift/Classes/ClassComponentFactories.swift
@@ -3,63 +3,94 @@
 /**
  Class constructor without arguments.
  */
-public func Constructor(_ body: @escaping () throws -> ()) -> AnyFunction {
+public func Constructor<R>(
+  _ body: @escaping () throws -> R
+) -> SyncFunctionComponent<(), Void, R> {
   return Function("constructor", body)
 }
 
 /**
  Class constructor with one argument.
  */
-public func Constructor<A0: AnyArgument>(_ body: @escaping (A0) throws -> ()) -> AnyFunction {
+public func Constructor<R, A0: AnyArgument>(
+  _ body: @escaping (A0) throws -> R
+) -> SyncFunctionComponent<(A0), A0, R> {
   return Function("constructor", body)
 }
 
 /**
  Class constructor with two arguments.
  */
-public func Constructor<A0: AnyArgument, A1: AnyArgument>(_ body: @escaping (A0, A1) throws -> ()) -> AnyFunction {
+public func Constructor<R, A0: AnyArgument, A1: AnyArgument>(
+  _ body: @escaping (A0, A1) throws -> R
+) -> SyncFunctionComponent<(A0, A1), A0, R> {
   return Function("constructor", body)
 }
 
 /**
  Class constructor with three arguments.
  */
-public func Constructor<A0: AnyArgument, A1: AnyArgument, A2: AnyArgument>(
-  _ body: @escaping (A0, A1, A2) throws -> ()
-) -> AnyFunction {
+public func Constructor<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument>(
+  _ body: @escaping (A0, A1, A2) throws -> R
+) -> SyncFunctionComponent<(A0, A1, A2), A0, R> {
   return Function("constructor", body)
 }
 
 /**
  Class constructor with four arguments.
  */
-public func Constructor<A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument>(
-  _ body: @escaping (A0, A1, A2, A3) throws -> ()
-) -> AnyFunction {
+public func Constructor<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument>(
+  _ body: @escaping (A0, A1, A2, A3) throws -> R
+) -> SyncFunctionComponent<(A0, A1, A2, A3), A0, R> {
   return Function("constructor", body)
 }
 
 /**
  Class constructor with five arguments.
  */
-public func Constructor<A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument, A4: AnyArgument>(
-  _ body: @escaping (A0, A1, A2, A3, A4) throws -> ()
-) -> AnyFunction {
+public func Constructor<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument, A4: AnyArgument>(
+  _ body: @escaping (A0, A1, A2, A3, A4) throws -> R
+) -> SyncFunctionComponent<(A0, A1, A2, A3, A4), A0, R> {
   return Function("constructor", body)
 }
 
 /**
  Class constructor with six arguments.
  */
-public func Constructor<A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument, A4: AnyArgument, A5: AnyArgument>(
-  _ body: @escaping (A0, A1, A2, A3, A4, A5) throws -> ()
-) -> AnyFunction {
+public func Constructor<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument, A4: AnyArgument, A5: AnyArgument>(
+  _ body: @escaping (A0, A1, A2, A3, A4, A5) throws -> R
+) -> SyncFunctionComponent<(A0, A1, A2, A3, A4, A5), A0, R> {
   return Function("constructor", body)
 }
 
 /**
  Creates the component describing a JavaScript class.
  */
-public func Class(_ name: String, @ClassComponentElementsBuilder _ elements: () -> [ClassComponentElement]) -> ClassComponent {
-  return ClassComponent(name: name, elements: elements())
+public func Class(
+  _ name: String,
+  @ClassComponentElementsBuilder<JavaScriptObject> _ elements: () -> [AnyClassComponentElement]
+) -> ClassComponent {
+  return ClassComponent(name: name, associatedType: JavaScriptObject.self, elements: elements())
+}
+
+/**
+ Creates the component describing a JavaScript class with an associated native shared object class.
+ */
+public func Class<SharedObjectType: SharedObject>(
+  _ name: String = String(describing: SharedObjectType.self),
+  _ sharedObjectType: SharedObjectType.Type,
+  @ClassComponentElementsBuilder<SharedObjectType> _ elements: () -> [AnyClassComponentElement]
+) -> ClassComponent {
+  return ClassComponent(name: name, associatedType: SharedObjectType.self, elements: elements())
+}
+
+/**
+ Creates the component describing a JavaScript class with an associated native shared object class
+ and with the name that is inferred from the shared object type.
+ */
+public func Class<SharedObjectType: SharedObject>(
+  _ sharedObjectType: SharedObjectType.Type,
+  @ClassComponentElementsBuilder<SharedObjectType> _ elements: () -> [AnyClassComponentElement]
+) -> ClassComponent {
+  return ClassComponent(name: String(describing: SharedObjectType.self), associatedType: SharedObjectType.self, elements: elements())
 }

--- a/packages/expo-modules-core/ios/Swift/Functions/AsyncFunctionComponent.swift
+++ b/packages/expo-modules-core/ios/Swift/Functions/AsyncFunctionComponent.swift
@@ -5,7 +5,7 @@ import Dispatch
 /**
  Type-erased protocol for asynchronous functions.
  */
-public protocol AnyAsyncFunctionComponent: AnyFunction {
+internal protocol AnyAsyncFunctionComponent: AnyFunction {
   /**
    Specifies on which queue the function should run.
    */
@@ -15,7 +15,7 @@ public protocol AnyAsyncFunctionComponent: AnyFunction {
 /**
  Represents a function that can only be called asynchronously, thus its JavaScript equivalent returns a Promise.
  */
-internal final class AsyncFunctionComponent<Args, ReturnType>: AnyAsyncFunctionComponent {
+public final class AsyncFunctionComponent<Args, FirstArgType, ReturnType>: AnyAsyncFunctionComponent {
   typealias ClosureType = (Args) throws -> ReturnType
 
   /**
@@ -33,13 +33,18 @@ internal final class AsyncFunctionComponent<Args, ReturnType>: AnyAsyncFunctionC
    */
   var queue: DispatchQueue?
 
-  init(_ name: String, dynamicArgumentTypes argTypes: [AnyDynamicType], _ body: @escaping ClosureType) {
+  init(
+    _ name: String,
+    firstArgType: FirstArgType.Type,
+    dynamicArgumentTypes: [AnyDynamicType],
+    _ body: @escaping ClosureType
+  ) {
     self.name = name
-    self.takesPromise = argTypes.last?.wraps(Promise.self) ?? false
+    self.takesPromise = dynamicArgumentTypes.last?.wraps(Promise.self) ?? false
     self.body = body
 
     // Drop the last argument type if it's the `Promise`.
-    self.dynamicArgumentTypes = takesPromise ? argTypes.dropLast(1) : argTypes
+    self.dynamicArgumentTypes = takesPromise ? dynamicArgumentTypes.dropLast(1) : dynamicArgumentTypes
   }
 
   // MARK: - AnyFunction
@@ -49,10 +54,12 @@ internal final class AsyncFunctionComponent<Args, ReturnType>: AnyAsyncFunctionC
   let dynamicArgumentTypes: [AnyDynamicType]
 
   var argumentsCount: Int {
-    return dynamicArgumentTypes.count
+    return dynamicArgumentTypes.count - (takesOwner ? 1 : 0)
   }
 
-  func call(args: [Any], callback: @escaping (FunctionCallResult) -> ()) {
+  var takesOwner: Bool = false
+
+  func call(by owner: AnyObject?, withArguments args: [Any], callback: @escaping (FunctionCallResult) -> ()) {
     let promise = Promise { value in
       callback(.success(value as Any))
     } rejecter: { exception in
@@ -61,7 +68,11 @@ internal final class AsyncFunctionComponent<Args, ReturnType>: AnyAsyncFunctionC
     var arguments: [Any] = []
 
     do {
-      arguments = try castArguments(args, toTypes: dynamicArgumentTypes)
+      arguments = concat(
+        arguments: try cast(arguments: args, forFunction: self),
+        withOwner: owner,
+        forFunction: self
+      )
     } catch let error as Exception {
       callback(.failure(error))
       return
@@ -99,12 +110,12 @@ internal final class AsyncFunctionComponent<Args, ReturnType>: AnyAsyncFunctionC
   // MARK: - JavaScriptObjectBuilder
 
   func build(inRuntime runtime: JavaScriptRuntime) -> JavaScriptObject {
-    return runtime.createAsyncFunction(name, argsCount: argumentsCount) { [weak self, name] args, resolve, reject in
+    return runtime.createAsyncFunction(name, argsCount: argumentsCount) { [weak self, name] this, args, resolve, reject in
       guard let self = self else {
         let exception = NativeFunctionUnavailableException(name)
         return reject(exception.code, exception.description, nil)
       }
-      self.call(args: args) { result in
+      self.call(by: this, withArguments: args) { result in
         switch result {
         case .failure(let error):
           reject(error.code, error.description, nil)
@@ -139,9 +150,10 @@ internal final class NativeFunctionUnavailableException: GenericException<String
 public func AsyncFunction<R>(
   _ name: String,
   _ closure: @escaping () throws -> R
-) -> AnyAsyncFunctionComponent {
+) -> AsyncFunctionComponent<(), Void, R> {
   return AsyncFunctionComponent(
     name,
+    firstArgType: Void.self,
     dynamicArgumentTypes: [],
     closure
   )
@@ -153,9 +165,10 @@ public func AsyncFunction<R>(
 public func AsyncFunction<R, A0: AnyArgument>(
   _ name: String,
   _ closure: @escaping (A0) throws -> R
-) -> AnyAsyncFunctionComponent {
+) -> AsyncFunctionComponent<(A0), A0, R> {
   return AsyncFunctionComponent(
     name,
+    firstArgType: A0.self,
     dynamicArgumentTypes: [~A0.self],
     closure
   )
@@ -167,9 +180,10 @@ public func AsyncFunction<R, A0: AnyArgument>(
 public func AsyncFunction<R, A0: AnyArgument, A1: AnyArgument>(
   _ name: String,
   _ closure: @escaping (A0, A1) throws -> R
-) -> AnyAsyncFunctionComponent {
+) -> AsyncFunctionComponent<(A0, A1), A0, R> {
   return AsyncFunctionComponent(
     name,
+    firstArgType: A0.self,
     dynamicArgumentTypes: [~A0.self, ~A1.self],
     closure
   )
@@ -181,9 +195,10 @@ public func AsyncFunction<R, A0: AnyArgument, A1: AnyArgument>(
 public func AsyncFunction<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument>(
   _ name: String,
   _ closure: @escaping (A0, A1, A2) throws -> R
-) -> AnyAsyncFunctionComponent {
+) -> AsyncFunctionComponent<(A0, A1, A2), A0, R> {
   return AsyncFunctionComponent(
     name,
+    firstArgType: A0.self,
     dynamicArgumentTypes: [
       ~A0.self,
       ~A1.self,
@@ -199,9 +214,10 @@ public func AsyncFunction<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument>(
 public func AsyncFunction<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument>(
   _ name: String,
   _ closure: @escaping (A0, A1, A2, A3) throws -> R
-) -> AnyAsyncFunctionComponent {
+) -> AsyncFunctionComponent<(A0, A1, A2, A3), A0, R> {
   return AsyncFunctionComponent(
     name,
+    firstArgType: A0.self,
     dynamicArgumentTypes: [
       ~A0.self,
       ~A1.self,
@@ -218,9 +234,10 @@ public func AsyncFunction<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, 
 public func AsyncFunction<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument, A4: AnyArgument>(
   _ name: String,
   _ closure: @escaping (A0, A1, A2, A3, A4) throws -> R
-) -> AnyAsyncFunctionComponent {
+) -> AsyncFunctionComponent<(A0, A1, A2, A3, A4), A0, R> {
   return AsyncFunctionComponent(
     name,
+    firstArgType: A0.self,
     dynamicArgumentTypes: [
       ~A0.self,
       ~A1.self,
@@ -238,9 +255,10 @@ public func AsyncFunction<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, 
 public func AsyncFunction<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument, A4: AnyArgument, A5: AnyArgument>(
   _ name: String,
   _ closure: @escaping (A0, A1, A2, A3, A4, A5) throws -> R
-) -> AnyAsyncFunctionComponent {
+) -> AsyncFunctionComponent<(A0, A1, A2, A3, A4, A5), A0, R> {
   return AsyncFunctionComponent(
     name,
+    firstArgType: A0.self,
     dynamicArgumentTypes: [
       ~A0.self,
       ~A1.self,
@@ -259,9 +277,10 @@ public func AsyncFunction<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, 
 public func AsyncFunction<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument, A4: AnyArgument, A5: AnyArgument, A6: AnyArgument>(
   _ name: String,
   _ closure: @escaping (A0, A1, A2, A3, A4, A5, A6) throws -> R
-) -> AnyAsyncFunctionComponent {
+) -> AsyncFunctionComponent<(A0, A1, A2, A3, A4, A5, A6), A0, R> {
   return AsyncFunctionComponent(
     name,
+    firstArgType: A0.self,
     dynamicArgumentTypes: [
       ~A0.self,
       ~A1.self,
@@ -281,9 +300,10 @@ public func AsyncFunction<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, 
 public func AsyncFunction<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument, A4: AnyArgument, A5: AnyArgument, A6: AnyArgument, A7: AnyArgument>(
   _ name: String,
   _ closure: @escaping (A0, A1, A2, A3, A4, A5, A6, A7) throws -> R
-) -> AnyAsyncFunctionComponent {
+) -> AsyncFunctionComponent<(A0, A1, A2, A3, A4, A5, A6, A7), A0, R> {
   return AsyncFunctionComponent(
     name,
+    firstArgType: A0.self,
     dynamicArgumentTypes: [
       ~A0.self,
       ~A1.self,

--- a/packages/expo-modules-core/ios/Swift/Objects/JavaScriptObjectBuilder.swift
+++ b/packages/expo-modules-core/ios/Swift/Objects/JavaScriptObjectBuilder.swift
@@ -3,7 +3,7 @@
 /**
  A type that can decorate a `JavaScriptObject` with some properties.
  */
-public protocol JavaScriptObjectDecorator {
+internal protocol JavaScriptObjectDecorator {
   /**
    Decorates an existing `JavaScriptObject`.
    */
@@ -13,7 +13,7 @@ public protocol JavaScriptObjectDecorator {
 /**
  A type that can build and decorate a `JavaScriptObject` based on its attributes.
  */
-public protocol JavaScriptObjectBuilder: JavaScriptObjectDecorator {
+internal protocol JavaScriptObjectBuilder: JavaScriptObjectDecorator {
   /**
    Creates a decorated `JavaScriptObject` in the given runtime.
    */

--- a/packages/expo-modules-core/ios/Swift/Objects/ObjectDefinitionComponents.swift
+++ b/packages/expo-modules-core/ios/Swift/Objects/ObjectDefinitionComponents.swift
@@ -42,9 +42,10 @@ public func Constants(_ body: @autoclosure @escaping () -> [String: Any?]) -> An
 public func function<R>(
   _ name: String,
   _ closure: @escaping () throws -> R
-) -> AnyAsyncFunctionComponent {
+) -> AsyncFunctionComponent<(), Void, R> {
   return AsyncFunctionComponent(
     name,
+    firstArgType: Void.self,
     dynamicArgumentTypes: [],
     closure
   )
@@ -57,9 +58,10 @@ public func function<R>(
 public func function<R, A0: AnyArgument>(
   _ name: String,
   _ closure: @escaping (A0) throws -> R
-) -> AnyAsyncFunctionComponent {
+) -> AsyncFunctionComponent<(A0), A0, R> {
   return AsyncFunctionComponent(
     name,
+    firstArgType: A0.self,
     dynamicArgumentTypes: [~A0.self],
     closure
   )
@@ -72,9 +74,10 @@ public func function<R, A0: AnyArgument>(
 public func function<R, A0: AnyArgument, A1: AnyArgument>(
   _ name: String,
   _ closure: @escaping (A0, A1) throws -> R
-) -> AnyAsyncFunctionComponent {
+) -> AsyncFunctionComponent<(A0, A1), A0, R> {
   return AsyncFunctionComponent(
     name,
+    firstArgType: A0.self,
     dynamicArgumentTypes: [~A0.self, ~A1.self],
     closure
   )
@@ -87,9 +90,10 @@ public func function<R, A0: AnyArgument, A1: AnyArgument>(
 public func function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument>(
   _ name: String,
   _ closure: @escaping (A0, A1, A2) throws -> R
-) -> AnyAsyncFunctionComponent {
+) -> AsyncFunctionComponent<(A0, A1, A2), A0, R> {
   return AsyncFunctionComponent(
     name,
+    firstArgType: A0.self,
     dynamicArgumentTypes: [
       ~A0.self,
       ~A1.self,
@@ -106,9 +110,10 @@ public func function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument>(
 public func function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument>(
   _ name: String,
   _ closure: @escaping (A0, A1, A2, A3) throws -> R
-) -> AnyAsyncFunctionComponent {
+) -> AsyncFunctionComponent<(A0, A1, A2, A3), A0, R> {
   return AsyncFunctionComponent(
     name,
+    firstArgType: A0.self,
     dynamicArgumentTypes: [
       ~A0.self,
       ~A1.self,
@@ -126,9 +131,10 @@ public func function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: A
 public func function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument, A4: AnyArgument>(
   _ name: String,
   _ closure: @escaping (A0, A1, A2, A3, A4) throws -> R
-) -> AnyAsyncFunctionComponent {
+) -> AsyncFunctionComponent<(A0, A1, A2, A3, A4), A0, R> {
   return AsyncFunctionComponent(
     name,
+    firstArgType: A0.self,
     dynamicArgumentTypes: [
       ~A0.self,
       ~A1.self,
@@ -147,9 +153,10 @@ public func function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: A
 public func function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument, A4: AnyArgument, A5: AnyArgument>(
   _ name: String,
   _ closure: @escaping (A0, A1, A2, A3, A4, A5) throws -> R
-) -> AnyAsyncFunctionComponent {
+) -> AsyncFunctionComponent<(A0, A1, A2, A3, A4, A5), A0, R> {
   return AsyncFunctionComponent(
     name,
+    firstArgType: A0.self,
     dynamicArgumentTypes: [
       ~A0.self,
       ~A1.self,
@@ -169,9 +176,10 @@ public func function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: A
 public func function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument, A4: AnyArgument, A5: AnyArgument, A6: AnyArgument>(
   _ name: String,
   _ closure: @escaping (A0, A1, A2, A3, A4, A5, A6) throws -> R
-) -> AnyAsyncFunctionComponent {
+) -> AsyncFunctionComponent<(A0, A1, A2, A3, A4, A5, A6), A0, R> {
   return AsyncFunctionComponent(
     name,
+    firstArgType: A0.self,
     dynamicArgumentTypes: [
       ~A0.self,
       ~A1.self,
@@ -192,9 +200,10 @@ public func function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: A
 public func function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument, A4: AnyArgument, A5: AnyArgument, A6: AnyArgument, A7: AnyArgument>(
   _ name: String,
   _ closure: @escaping (A0, A1, A2, A3, A4, A5, A6, A7) throws -> R
-) -> AnyAsyncFunctionComponent {
+) -> AsyncFunctionComponent<(A0, A1, A2, A3, A4, A5, A6, A7), A0, R> {
   return AsyncFunctionComponent(
     name,
+    firstArgType: A0.self,
     dynamicArgumentTypes: [
       ~A0.self,
       ~A1.self,
@@ -230,28 +239,28 @@ public func Events(_ names: String...) -> AnyDefinition {
  Function that is invoked when the first event listener is added.
  */
 @available(*, deprecated, renamed: "OnStartObserving")
-public func onStartObserving(_ body: @escaping () -> Void) -> AnyFunction {
-  return AsyncFunctionComponent("startObserving", dynamicArgumentTypes: [], body)
+public func onStartObserving(_ body: @escaping () -> Void) -> AsyncFunctionComponent<(), Void, Void> {
+  return AsyncFunctionComponent("startObserving", firstArgType: Void.self, dynamicArgumentTypes: [], body)
 }
 
 /**
  Function that is invoked when the first event listener is added.
  */
-public func OnStartObserving(_ body: @escaping () -> Void) -> AnyFunction {
-  return AsyncFunctionComponent("startObserving", dynamicArgumentTypes: [], body)
+public func OnStartObserving(_ body: @escaping () -> Void) -> AsyncFunctionComponent<(), Void, Void> {
+  return AsyncFunctionComponent("startObserving", firstArgType: Void.self, dynamicArgumentTypes: [], body)
 }
 
 /**
  Function that is invoked when all event listeners are removed.
  */
 @available(*, deprecated, renamed: "OnStopObserving")
-public func onStopObserving(_ body: @escaping () -> Void) -> AnyFunction {
-  return AsyncFunctionComponent("stopObserving", dynamicArgumentTypes: [], body)
+public func onStopObserving(_ body: @escaping () -> Void) -> AsyncFunctionComponent<(), Void, Void> {
+  return AsyncFunctionComponent("stopObserving", firstArgType: Void.self, dynamicArgumentTypes: [], body)
 }
 
 /**
  Function that is invoked when all event listeners are removed.
  */
-public func OnStopObserving(_ body: @escaping () -> Void) -> AnyFunction {
-  return AsyncFunctionComponent("stopObserving", dynamicArgumentTypes: [], body)
+public func OnStopObserving(_ body: @escaping () -> Void) -> AsyncFunctionComponent<(), Void, Void> {
+  return AsyncFunctionComponent("stopObserving", firstArgType: Void.self, dynamicArgumentTypes: [], body)
 }

--- a/packages/expo-modules-core/ios/Tests/ClassComponentSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/ClassComponentSpec.swift
@@ -104,5 +104,97 @@ class ClassComponentSpec: ExpoSpec {
         expect(object?.getProperty("foo").getString()) == "bar"
       }
     }
+
+    describe("class with associated type") {
+      let appContext = AppContext.create()
+      let runtime = appContext.runtime
+
+      beforeSuite {
+        appContext.moduleRegistry.register(moduleType: ModuleWithCounterClass.self)
+      }
+      it("is defined") {
+        let isDefined = try! runtime!.eval("'Counter' in ExpoModules.TestModule")
+
+        expect(isDefined.getBool()) == true
+      }
+      it("creates shared object") {
+        let jsObject = try! runtime!.eval("new ExpoModules.TestModule.Counter(0)").getObject()
+        let nativeObject = SharedObjectRegistry.toNativeObject(jsObject)
+
+        expect(nativeObject).notTo(beNil())
+      }
+      it("registers shared object") {
+        let oldSize = SharedObjectRegistry.size
+        try! runtime?.eval("object = new ExpoModules.TestModule.Counter(0)")
+
+        expect(SharedObjectRegistry.size) == oldSize + 1
+      }
+      it("calls function with owner") {
+        try runtime?.eval("object = new ExpoModules.TestModule.Counter(0)")
+        try runtime?.eval("object.increment(1)")
+        // no expectations, just checking if it doesn't fail
+      }
+      it("creates with initial value") {
+        let initialValue = Int.random(in: 1..<100)
+        try runtime?.eval("object = new ExpoModules.TestModule.Counter(\(initialValue))")
+        let value = try runtime!.eval("object.getValue()")
+
+        expect(value.kind) == .number
+        expect(value.getInt()) == initialValue
+      }
+      it("gets shared object value") {
+        try! runtime?.eval("object = new ExpoModules.TestModule.Counter(0)")
+        let value = try runtime!.eval("object.getValue()")
+
+        expect(value.kind) == .number
+        expect(value.isNumber()) == true
+      }
+      it("changes shared object") {
+        try! runtime?.eval("object = new ExpoModules.TestModule.Counter(0)")
+        let incrementBy = Int.random(in: 1..<100)
+        let value = try runtime!.eval("object.getValue()").asInt()
+        try runtime?.eval("object.increment(\(incrementBy))")
+        let newValue = try runtime!.eval("object.getValue()")
+
+        expect(newValue.kind) == .number
+        expect(newValue.getInt()) == value + incrementBy
+      }
+    }
+  }
+}
+
+/**
+ A module that exposes a Counter class with an associated shared object class.
+ */
+fileprivate final class ModuleWithCounterClass: Module {
+  func definition() -> ModuleDefinition {
+    Name("TestModule")
+
+    Class(Counter.self) {
+      Constructor { (initialValue: Int) in
+        return Counter(initialValue: initialValue)
+      }
+      Function("increment") { (counter, value: Int) in
+        counter.increment(by: value)
+      }
+      Function("getValue") { counter in
+        return counter.currentValue
+      }
+    }
+  }
+}
+
+/**
+ A shared object class that stores some native value and can be used as an associated type of the JS class.
+ */
+fileprivate final class Counter: SharedObject {
+  var currentValue = 0
+
+  init(initialValue: Int = 0) {
+    self.currentValue = initialValue
+  }
+
+  func increment(by value: Int = 1) {
+    currentValue += value
   }
 }

--- a/packages/expo-modules-core/ios/Tests/SharedObjectRegistrySpec.swift
+++ b/packages/expo-modules-core/ios/Tests/SharedObjectRegistrySpec.swift
@@ -106,4 +106,4 @@ final class SharedObjectRegistrySpec: ExpoSpec {
   }
 }
 
-final class TestSharedObject: SharedObject {}
+fileprivate final class TestSharedObject: SharedObject {}


### PR DESCRIPTION
# Why

Follows up #17514 
Part of ENG-4541
Closes ENG-4972

# How

In this PR I implemented one of the key features of the Sweet API that allows the developers to write more object-oriented modules. The module can now define a JS class that is associated with the native shared object. Each time the JS instance of the class is created, an associated native object is created and the pair of these objects is added to `SharedObjectsRegistry`. It's a one-to-one relationship between the JS and native objects.

Functions specified within the class can access the native instance using the first argument (you can think of it like a `this` object) and do some operations on it. This argument can be declared as untyped (Swift infers the type) or typed with the same type as passed to the `Class` component.

As you can see in the test spec, something like will be possible 👇 
```swift
// Swift
class SomeModule: Module {
  func definition() -> ModuleDefinition {
    Class(Counter.self) {
      Constructor { (initialValue: Int) in
        return Counter(initialValue: initialValue)
      }
      Function("increment") { (counter, value: Int) in
        counter.increment(by: value)
      }
      Function("getValue") { counter in
        return counter.currentValue
      }
    }
  }
}

class Counter: SharedObject {
  var currentValue = 0

  init(initialValue: Int = 0) {
    self.currentValue = initialValue
  }

  func increment(by value: Int = 1) {
    currentValue += value
  }
}
```

```javascript
// JavaScript
const counter = new SomeModule.Counter(0)
myObject.getValue() // => 0
myObject.increment(3)
myObject.getValue() // => 3
```

# Test Plan

Added a bunch of new unit tests that covers the new functionality