### PR TITLE
[docs] additional note about xib files on eas builds

### DIFF
--- a/docs/pages/guides/splash-screens.md
+++ b/docs/pages/guides/splash-screens.md
@@ -101,7 +101,7 @@ Your app can be opened from the Expo Go app or in a standalone app, and it can b
 
 ### Using a `.xib` file as the launch screen for the standalone iOS app
 
-For iOS, you can also choose to use a `.xib` interface builder document as the splash screen of the standalone iOS app. Simply set `ios.splash.xib` in **app.json** to the path to your `.xib` file.
+For iOS, you can also choose to use a `.xib` interface builder document as the splash screen of the standalone iOS app. Simply set `ios.splash.xib` in **app.json** to the path to your `.xib` file. Using a `.xib` file is not compatible with `expo prebuild` and EAS builds.
 
 > **Note**: `.xib` file will only be used in the standalone app. The splash image will continue to be used in the Expo Go app.
 


### PR DESCRIPTION
# Why

xib splash screens don't work with expo prebuild and EAS builds. The docs didn't mention that.

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
