### PR TITLE
[expotools] add cherry-pick command

### DIFF
--- a/tools/src/Git.ts
+++ b/tools/src/Git.ts
@@ -55,6 +55,10 @@ export type GitCommitOptions = {
   body?: string;
 };
 
+export type GitCherryPickOptions = {
+  inheritStdio?: boolean;
+};
+
 export type GitFetchOptions = {
   depth?: number;
   remote?: string;
@@ -329,6 +333,14 @@ export class GitDirectory {
       args.push('--message', options.body);
     }
     await this.runAsync(args);
+  }
+
+  /**
+   * Cherry-picks the given commits onto the checked out branch.
+   */
+  async cherryPickAsync(commits: string[], options: GitCherryPickOptions = {}): Promise<void> {
+    const spawnOptions: SpawnOptions = options.inheritStdio ? { stdio: 'inherit' } : {};
+    await this.runAsync(['cherry-pick', ...commits], spawnOptions);
   }
 
   /**

--- a/tools/src/commands/CherryPick.ts
+++ b/tools/src/commands/CherryPick.ts
@@ -1,0 +1,196 @@
+import { Command } from '@expo/commander';
+import chalk from 'chalk';
+import inquirer from 'inquirer';
+import path from 'path';
+
+import Git, { GitLog } from '../Git';
+import logger from '../Logger';
+
+type ActionOptions = {
+  from?: string;
+  to?: string;
+  startDate?: string;
+  startAtLatest: boolean;
+  dry: boolean;
+};
+
+export default (program: Command) => {
+  program
+    .command('cherry-pick [packageNames...]')
+    .alias('cherrypick', 'cpk')
+    .option(
+      '-f, --from <string>',
+      'Source branch of commits to cherry-pick. Defaults to the current branch if `--to` is specified, and `main` otherwise.'
+    )
+    .option(
+      '-t, --to <string>',
+      'Destination branch for commits to cherry-pick. Defaults to the current branch.'
+    )
+    .option(
+      '-s, --start-date <string>',
+      'Date at which to start looking for commits to cherry-pick, ignoring any earlier commits. Format: YYYY-MM-DD'
+    )
+    .option(
+      '--start-at-latest',
+      'Equivalent to `--start-date <latest-date>`, where `latest-date` is the author date of the most recent commit on the destination branch across all specified packages.',
+      false
+    )
+    .option(
+      '-d, --dry',
+      'Dry run. Does not run any commands that actually modify the repository, and logs them instead',
+      false
+    )
+    .description(
+      'Interactively creates and runs a command to cherry pick commits in a specific package (or set of packages) from one branch to another.'
+    )
+    .asyncAction(main);
+};
+
+async function main(packageNames: string[], options: ActionOptions): Promise<void> {
+  if (!options.dry && (await Git.hasUnstagedChangesAsync())) {
+    throw new Error(
+      'Cannot run this command with unstaged changes. Try again with a clean working directory.'
+    );
+  }
+
+  const currentBranch = await Git.getCurrentBranchNameAsync();
+  if (!options.from && !options.to && currentBranch === 'main') {
+    throw new Error('Must specify either `--from` or `--to` branch if main is checked out.');
+  }
+  const source = options.from ?? (options.to ? currentBranch : 'main');
+  const destination = options.to ?? currentBranch;
+  if (source === destination) {
+    throw new Error(
+      'Source and destination branches cannot be the same. Try specifying both `--from` and `--to`.'
+    );
+  }
+
+  if (options.startAtLatest && options.startDate) {
+    throw new Error('Cannot specify both `--start-date` and `--start-at-latest`.');
+  }
+
+  logger.info(
+    `\nLooking for commits to cherry-pick from ${chalk.bold(chalk.blue(source))} to ${chalk.bold(
+      chalk.blue(destination)
+    )}...\n`
+  );
+
+  const packagePaths = packageNames.map((packageName) => path.join('.', 'packages', packageName));
+
+  const mergeBase = await Git.mergeBaseAsync(source, destination);
+  const commitsOnDestinationBranch = await Git.logAsync({
+    fromCommit: mergeBase,
+    toCommit: destination,
+    paths: packagePaths,
+  });
+
+  let startDate: Date | null = null;
+  if (options.startDate) {
+    startDate = new Date(options.startDate);
+  } else if (options.startAtLatest) {
+    startDate = new Date(commitsOnDestinationBranch[0].authorDate);
+  }
+
+  const commitsBeforeStartDate: GitLog[] = [];
+  const candidateCommits = (
+    await Git.logAsync({
+      fromCommit: source,
+      toCommit: destination,
+      paths: packagePaths,
+      cherryPick: 'left',
+      symmetricDifference: true,
+    })
+  )
+    .reverse()
+    .filter((srcCommit) => {
+      // Git will sometimes return commits that have already been cherry-picked if the diff is
+      // slightly different. We filter them out here if the commit name/date/author matches
+      // another commit already on the destination branch.
+      if (
+        commitsOnDestinationBranch.some(
+          (destCommit) =>
+            srcCommit.authorDate === destCommit.authorDate &&
+            srcCommit.authorName === destCommit.authorName &&
+            srcCommit.title === destCommit.title
+        )
+      ) {
+        return false;
+      }
+
+      // Filter out any commits earlier than the startDate (if we have one) but also add them to
+      // another array so we can log them.
+      if (startDate && new Date(srcCommit.authorDate).getTime() < startDate.getTime()) {
+        commitsBeforeStartDate.push(srcCommit);
+        return false;
+      }
+
+      return true;
+    });
+
+  if (commitsBeforeStartDate.length !== 0) {
+    logger.log(chalk.bold(chalk.red('Ignoring the following commits from before the start date:')));
+    logger.log(
+      commitsBeforeStartDate
+        .map(
+          (commit) =>
+            ` ❌ ${chalk.red(commit.hash.slice(0, 10))} ${commit.authorDate} ${chalk.magenta(
+              commit.authorName
+            )} ${commit.title}`
+        )
+        .join('\n')
+    );
+    logger.log(''); // new line
+  }
+
+  if (candidateCommits.length === 0) {
+    logger.success('There is nothing to cherry-pick.');
+    return;
+  }
+
+  const { commitsToCherryPick } = await inquirer.prompt<{ commitsToCherryPick: string[] }>([
+    {
+      type: 'checkbox',
+      name: 'commitsToCherryPick',
+      message: `Choose which commits to cherry-pick from ${chalk.blue(source)} to ${chalk.blue(
+        destination
+      )}\n  ${chalk.green('●')} selected  ○ unselected\n`,
+      choices: candidateCommits.map((commit) => ({
+        value: commit.hash,
+        short: commit.hash,
+        name: `${chalk.yellow(commit.hash.slice(0, 10))} ${commit.authorDate} ${chalk.magenta(
+          commit.authorName
+        )} ${commit.title}`,
+      })),
+      default: candidateCommits.map((commit) => commit.hash),
+      pageSize: Math.min(candidateCommits.length, (process.stdout.rows || 100) - 4),
+    },
+  ]);
+
+  logger.info(''); // new line
+
+  if (destination !== (await Git.getCurrentBranchNameAsync())) {
+    if (options.dry) {
+      logger.log(chalk.bold(chalk.yellow(`git checkout ${destination}`)));
+    } else {
+      logger.info(`Checking out ${chalk.bold(chalk.blue(destination))} branch...`);
+      await Git.checkoutAsync(destination);
+    }
+  }
+
+  // ensure we preserve the correct order of commits
+  const commitsToCherryPickOrdered = candidateCommits.filter((commit) =>
+    commitsToCherryPick.includes(commit.hash)
+  );
+  const gitArgs = ['cherry-pick', ...commitsToCherryPickOrdered.map((commit) => commit.hash)];
+  if (options.dry) {
+    logger.log(chalk.bold(chalk.yellow(`git ${gitArgs.join(' ')}`)));
+  } else {
+    logger.info(`Running ${chalk.yellow(`git ${gitArgs.join(' ')}`)}`);
+    // pipe output to current process stdio to emulate user running this command directly
+    await Git.runAsync(gitArgs, { stdio: 'inherit' }).catch(() =>
+      logger.error(
+        `Expotools: could not complete cherry-pick. Resolve the conflicts and continue as instructed by git above.`
+      )
+    );
+  }
+}

--- a/tools/src/commands/CherryPickCommand.ts
+++ b/tools/src/commands/CherryPickCommand.ts
@@ -180,14 +180,14 @@ async function main(packageNames: string[], options: ActionOptions): Promise<voi
   const commitsToCherryPickOrdered = candidateCommits.filter((commit) =>
     commitsToCherryPick.includes(commit.hash)
   );
-  const gitArgs = ['cherry-pick', ...commitsToCherryPickOrdered.map((commit) => commit.hash)];
+  const commitHashes = commitsToCherryPickOrdered.map((commit) => commit.hash);
   if (options.dry) {
-    logger.log(chalk.bold(chalk.yellow(`git ${gitArgs.join(' ')}`)));
+    logger.log(chalk.bold(chalk.yellow(`git cherry-pick ${commitHashes.join(' ')}`)));
   } else {
-    logger.info(`Running ${chalk.yellow(`git ${gitArgs.join(' ')}`)}`);
+    logger.info(`Running ${chalk.yellow(`git cherry-pick ${commitHashes.join(' ')}`)}`);
     try {
       // pipe output to current process stdio to emulate user running this command directly
-      await Git.runAsync(gitArgs, { stdio: 'inherit' });
+      await Git.cherryPickAsync(commitHashes, { inheritStdio: true });
     } catch {
       logger.error(
         `Expotools: could not complete cherry-pick. Resolve the conflicts and continue as instructed by git above.`


### PR DESCRIPTION
# Why

resolves ENG-4079

Turns out git can sort of already do this, with symmetric diffs and `git log --cherry-pick`. This gives a list of commits that are on branch A but not branch B (treating commits with different hashes but the same diff as equivalent).

However, we can still do better by (1) assuming that commits with the same author name, author date, and commit message are cherry-picked as well, even if the diffs are different due to conflicts, and (2) making a nice interface that allows you to get this info, choose commits to cherry pick, and run the command interactively.

# How

- use git log `--cherry-pick --left-only` with symmetric diffs (`...`) to get a list of commits that need to be cherry picked
- compare each one to the commits already on the destination branch, and discard it if there's already one with a matching author name, date, and commit message
- if a start date is provided, filter out any commits before the start date (but still log them to the console)
- allow you to interactively pick from the remaining commits to cherry-pick
- run the cherry-pick command, piped through to stdio

# Test Plan

Tested this a bunch locally with the `--dry` flag, and a couple times without it 🙂

# Screenshots

cherry picking dev-launcher and dev-menu to sdk-45 currently
<img width="598" alt="Screen Shot 2022-05-16 at 5 33 07 PM" src="https://user-images.githubusercontent.com/19958240/168703879-f7cf86cf-de73-46a1-b86a-617436f6b28a.png">

cherry picking updates to sdk-45 currently
<img width="957" alt="Screen Shot 2022-05-16 at 5 30 36 PM" src="https://user-images.githubusercontent.com/19958240/168703840-661adc0b-0949-443c-b776-cf81d841a795.png">

cherry picking with a start date (ignoring earlier commits, but they're still logged)
<img width="971" alt="Screen Shot 2022-05-16 at 5 30 53 PM" src="https://user-images.githubusercontent.com/19958240/168703844-708fc30c-4c09-4b5b-a8d3-f8a3e7a0c508.png">

actually running the cherry pick -> if it fails, you can just resolve the conflicts and continue as if you ran the git command yourself
<img width="880" alt="Screen Shot 2022-05-16 at 5 34 52 PM" src="https://user-images.githubusercontent.com/19958240/168703882-c65a0e56-46c1-4bcb-989f-4faf703cb849.png">
