### PR TITLE
[docs] remove note about dev-client from preview

### DIFF
--- a/docs/pages/feature-preview/index.md
+++ b/docs/pages/feature-preview/index.md
@@ -9,5 +9,4 @@ We decided to publish some of our new features as a preview to get feedback from
 
 ### Features in preview
 
-- **expo-dev-client**: When you need to customize your project beyond the standard runtime provided in Expo Go, you can create a development build of your app, install it on your phone, and continue developing. [Learn more](/development/introduction.md).
 - **EAS Update**: EAS Update makes fixing small bugs and pushing quick fixes a snap in between app store submissions. It accomplishes this by allowing an end-user's app to swap out the non-native parts of their app (for example, JS, styling, and image changes) with a new update that contains bug fixes and other updates. [Learn more](/eas-update/introduction.md).


### PR DESCRIPTION
# Why

`expo-dev-client` is no longer in preview.

# How

Remove the note from Feature Preview index page.

# Test Plan
Change has been tested by running docs website locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
