### PR TITLE
[ios] Add more functionalities to dynamic argument types

### DIFF
--- a/packages/expo-modules-core/ios/Swift/Arguments/AnyArgumentType.swift
+++ b/packages/expo-modules-core/ios/Swift/Arguments/AnyArgumentType.swift
@@ -6,8 +6,38 @@
  */
 public protocol AnyArgumentType: CustomStringConvertible {
   /**
+   Checks whether the inner type is the same as the given type.
+   */
+  func wraps<InnerType>(_ type: InnerType.Type) -> Bool
+
+  /**
+   Checks whether the argument type is equal to another.
+   */
+  func equals(_ type: AnyArgumentType) -> Bool
+
+  /**
    Casts given any value to the wrapped type and returns as `Any`.
    NOTE: It may not be just simple type-casting (e.g. when the wrapped type conforms to `ConvertibleArgument`).
    */
   func cast<ArgType>(_ value: ArgType) throws -> Any
+}
+
+// MARK: - Operators
+
+infix operator ~>
+public func ~> <T>(lhs: AnyArgumentType, rhs: T.Type) -> Bool {
+  return lhs.wraps(rhs)
+}
+
+infix operator !~>
+public func !~> <T>(lhs: AnyArgumentType, rhs: T.Type) -> Bool {
+  return !lhs.wraps(rhs)
+}
+
+public func == (lhs: AnyArgumentType, rhs: AnyArgumentType) -> Bool {
+  return lhs.equals(rhs)
+}
+
+public func != (lhs: AnyArgumentType, rhs: AnyArgumentType) -> Bool {
+  return !lhs.equals(rhs)
 }

--- a/packages/expo-modules-core/ios/Swift/Arguments/Types/ArrayArgumentType.swift
+++ b/packages/expo-modules-core/ios/Swift/Arguments/Types/ArrayArgumentType.swift
@@ -7,6 +7,20 @@
 internal struct ArrayArgumentType: AnyArgumentType {
   let elementType: AnyArgumentType
 
+  func wraps<InnerType>(_ type: InnerType.Type) -> Bool {
+    if let ArrayType = InnerType.self as? AnyArrayArgument.Type {
+      return elementType.equals(ArrayType.getElementArgumentType())
+    }
+    return false
+  }
+
+  func equals(_ type: AnyArgumentType) -> Bool {
+    if let arrayType = type as? Self {
+      return arrayType.elementType.equals(elementType)
+    }
+    return false
+  }
+
   func cast<ArgType>(_ value: ArgType) throws -> Any {
     if let value = value as? [Any] {
       return try value.map { try elementType.cast($0) }

--- a/packages/expo-modules-core/ios/Swift/Arguments/Types/ConvertibleArgumentType.swift
+++ b/packages/expo-modules-core/ios/Swift/Arguments/Types/ConvertibleArgumentType.swift
@@ -6,6 +6,17 @@
 internal struct ConvertibleArgumentType: AnyArgumentType {
   let innerType: ConvertibleArgument.Type
 
+  func wraps<InnerType>(_ type: InnerType.Type) -> Bool {
+    return innerType == InnerType.self
+  }
+
+  func equals(_ type: AnyArgumentType) -> Bool {
+    if let convertibleType = type as? Self {
+      return convertibleType.innerType == innerType
+    }
+    return false
+  }
+
   func cast<ArgType>(_ value: ArgType) throws -> Any {
     return try innerType.convert(from: value)
   }

--- a/packages/expo-modules-core/ios/Swift/Arguments/Types/EnumArgumentType.swift
+++ b/packages/expo-modules-core/ios/Swift/Arguments/Types/EnumArgumentType.swift
@@ -6,6 +6,17 @@
 internal struct EnumArgumentType: AnyArgumentType {
   let innerType: EnumArgument.Type
 
+  func wraps<InnerType>(_ type: InnerType.Type) -> Bool {
+    return innerType == InnerType.self
+  }
+
+  func equals(_ type: AnyArgumentType) -> Bool {
+    if let enumType = type as? Self {
+      return enumType.innerType == innerType
+    }
+    return false
+  }
+
   func cast<ArgType>(_ value: ArgType) throws -> Any {
     return try innerType.create(fromRawValue: value)
   }

--- a/packages/expo-modules-core/ios/Swift/Arguments/Types/OptionalArgumentType.swift
+++ b/packages/expo-modules-core/ios/Swift/Arguments/Types/OptionalArgumentType.swift
@@ -7,6 +7,17 @@
 internal struct OptionalArgumentType: AnyArgumentType {
   let wrappedType: AnyArgumentType
 
+  func wraps<InnerType>(_ type: InnerType.Type) -> Bool {
+    return wrappedType.wraps(InnerType.self)
+  }
+
+  func equals(_ type: AnyArgumentType) -> Bool {
+    if let optionalType = type as? Self {
+      return optionalType.wrappedType.equals(wrappedType)
+    }
+    return false
+  }
+
   func cast<ArgType>(_ value: ArgType) throws -> Any {
     if Optional.isNil(value) {
       return Optional<Any>.none as Any

--- a/packages/expo-modules-core/ios/Swift/Arguments/Types/PromiseArgumentType.swift
+++ b/packages/expo-modules-core/ios/Swift/Arguments/Types/PromiseArgumentType.swift
@@ -4,6 +4,14 @@
  An argument type that represents the `Promise` argument.
  */
 internal struct PromiseArgumentType: AnyArgumentType {
+  func wraps<InnerType>(_ type: InnerType.Type) -> Bool {
+    return type == Promise.self
+  }
+
+  func equals(_ type: AnyArgumentType) -> Bool {
+    return type is Self
+  }
+
   func cast<ArgType>(_ value: ArgType) throws -> Any {
     if let value = value as? Promise {
       return value

--- a/packages/expo-modules-core/ios/Swift/Arguments/Types/RawArgumentType.swift
+++ b/packages/expo-modules-core/ios/Swift/Arguments/Types/RawArgumentType.swift
@@ -7,6 +7,14 @@
 internal struct RawArgumentType<InnerType>: AnyArgumentType {
   let innerType: InnerType.Type
 
+  func wraps<InnerType>(_ type: InnerType.Type) -> Bool {
+    return type == innerType
+  }
+
+  func equals(_ type: AnyArgumentType) -> Bool {
+    return type is Self
+  }
+
   func cast<ArgType>(_ value: ArgType) throws -> Any {
     if let value = value as? InnerType {
       return value

--- a/packages/expo-modules-core/ios/Swift/Arguments/Types/SharedObjectArgumentType.swift
+++ b/packages/expo-modules-core/ios/Swift/Arguments/Types/SharedObjectArgumentType.swift
@@ -3,6 +3,17 @@
 internal struct SharedObjectArgumentType: AnyArgumentType {
   let innerType: SharedObject.Type
 
+  func wraps<InnerType>(_ type: InnerType.Type) -> Bool {
+    return innerType == InnerType.self
+  }
+
+  func equals(_ type: AnyArgumentType) -> Bool {
+    if let sharedObjectType = type as? Self {
+      return sharedObjectType.innerType == innerType
+    }
+    return false
+  }
+
   func cast<ArgType>(_ value: ArgType) throws -> Any {
     if let jsObject = try (value as? JavaScriptValue)?.asObject(),
        let nativeSharedObject = SharedObjectRegistry.toNativeObject(jsObject) {

--- a/packages/expo-modules-core/ios/Tests/ArgumentTypeSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/ArgumentTypeSpec.swift
@@ -119,6 +119,30 @@ class ArgumentTypeSpec: ExpoSpec {
         expect(StringTestEnum.allRawValues as? [String]) == ["hello", "expo"]
         expect(IntTestEnum.allRawValues as? [Int]) == [-1, 1]
       }
+
+      describe("wraps") {
+        it("is wrapped") {
+          expect(ArgumentType(StringTestEnum.self) ~> StringTestEnum.self) == true
+          expect(ArgumentType(IntTestEnum.self) ~> IntTestEnum.self) == true
+        }
+        it("is not wrapped") {
+          expect(ArgumentType(StringTestEnum.self) !~> IntTestEnum.self) == true
+          expect(ArgumentType(IntTestEnum.self) !~> StringTestEnum.self) == true
+        }
+      }
+
+      describe("equals") {
+        it("is equal") {
+          expect(ArgumentType(StringTestEnum.self) == ArgumentType(StringTestEnum.self)) == true
+          expect(ArgumentType(IntTestEnum.self) == ArgumentType(IntTestEnum.self)) == true
+        }
+        it("is not equal") {
+          expect(ArgumentType(StringTestEnum.self) != ArgumentType(IntTestEnum.self)) == true
+          expect(ArgumentType(IntTestEnum.self) != ArgumentType(StringTestEnum.self)) == true
+          expect(ArgumentType(StringTestEnum.self) != ArgumentType(Double.self)) == true
+          expect(ArgumentType(IntTestEnum.self) != ArgumentType(Int.self)) == true
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
# Why

Extracting some stuff from #17525 where I'll need to check whether the dynamic `ArgumentType` wraps another static type or equals to another `ArgumentType`.

# How

Simply added `wraps` and `equals` functions to each type of the argument types

# Test Plan

Added some tests to existing tests for `EnumArgumentType`. Other types will need some tests, but I'll address them later.
I tested it locally as part of the work on #17525 