### PR TITLE
[e-m-c][Android] Create `AppContextProvider`

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🎉 New features
 
+- Create `AppContextProvider` on Android. ([#17546](https://github.com/expo/expo/pull/17546) by [@bbarthec](https://github.com/bbarthec))
 - Introduce dynamic properties in the Sweet API on iOS. ([#17318](https://github.com/expo/expo/pull/17318) by [@tsapeta](https://github.com/tsapeta))
 - Add basic support for sync functions in the Sweet API on Android. ([#16977](https://github.com/expo/expo/pull/16977) by [@lukmccall](https://github.com/lukmccall))
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/Module.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/Module.kt
@@ -3,17 +3,23 @@ package expo.modules.kotlin.modules
 import android.os.Bundle
 import expo.modules.core.errors.ModuleDestroyedException
 import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.providers.AppContextProvider
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
 
-abstract class Module {
+abstract class Module: AppContextProvider {
+
+  // region AppContextProvider
+
   @Suppress("PropertyName")
   internal var _appContext: AppContext? = null
 
-  private val moduleEventEmitter by lazy { appContext.eventEmitter(this) }
-
-  val appContext: AppContext
+  override val appContext: AppContext
     get() = requireNotNull(_appContext) { "The module wasn't created! You can't access the app context." }
+
+  // endregion
+
+  private val moduleEventEmitter by lazy { appContext.eventEmitter(this) }
 
   @Suppress("PropertyName")
   @PublishedApi

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/Module.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/Module.kt
@@ -7,7 +7,7 @@ import expo.modules.kotlin.providers.AppContextProvider
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
 
-abstract class Module: AppContextProvider {
+abstract class Module : AppContextProvider {
 
   // region AppContextProvider
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/providers/AppContextProvider.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/providers/AppContextProvider.kt
@@ -3,11 +3,12 @@ package expo.modules.kotlin.providers
 import expo.modules.kotlin.AppContext
 
 /**
- * Provider that allows us to access [AppContext] and possibly other underlying things like [AppContext.reactContext]
+ * Provider that allows accessing [AppContext] and all it's public parts (e.g. [AppContext.reactContext]).
  */
 interface AppContextProvider {
   /**
-   * Non nullable [AppContext] reference.
+   * [AppContext] reference. If it's not possible to access the [AppContext], because it's null
+   * then it's an invalid situation and should result in throwing descriptive error.
    */
   val appContext: AppContext
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/providers/AppContextProvider.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/providers/AppContextProvider.kt
@@ -1,0 +1,13 @@
+package expo.modules.kotlin.providers
+
+import expo.modules.kotlin.AppContext
+
+/**
+ * Provider that allows us to access [AppContext] and possibly other underlying things like [AppContext.reactContext]
+ */
+interface AppContextProvider {
+  /**
+   * Non nullable [AppContext] reference.
+   */
+  val appContext: AppContext
+}


### PR DESCRIPTION
# Why

Extracted part of #16251

`AppContext` is useful gateway for many more features and (both React and Android related).
It turns out that the `Module`'s implementation might want to pass it down to some other helper classes/methods.
While passing the direct reference to the `AppContext` seems is possible the `Module`'s itself does not hold the strong reference to the `AppContext`, so it seems invalid to do so in any other class.

# How

I propose `AppContextProvider` that is just an interface that allows accessing non-nullable `AppContext` from any place in a safe, non-strongly-retaining manner.

# Test Plan

- None, as it's not testable and it's already available in `Module`.
