### PR TITLE
Clarify that Expo uses the Original API for iOS

### DIFF
--- a/docs/pages/versions/unversioned/sdk/in-app-purchases.md
+++ b/docs/pages/versions/unversioned/sdk/in-app-purchases.md
@@ -46,6 +46,8 @@ Now you can create a [sandbox account](https://help.apple.com/app-store-connect/
 
 For more information, see Apple's workflow for configuring In-App Purchases [here](https://help.apple.com/app-store-connect/#/devb57be10e7).
 
+Note that Expo implements the ["Original API for In-App Purchase"](https://developer.apple.com/documentation/storekit/original_api_for_in-app_purchase) and not the alternative StoreKit API.
+
 ### Android
 
 On Android, you must first create an entry for your app and upload a release APK in the [Google Play Console](https://developer.android.com/distribute/console/). From there, you can configure your in-app purchases and their details under `Store Presence > In-app products`.


### PR DESCRIPTION
# Why

I was researching what I needed to do for handling iOS subscriptions, and the docs on the Apple developer site make a differentiation between the Original and StoreKit APIs. We should explicitly note which one Expo implements so as to point developers at the correct docs.

# How

Confirm the implementation in the Expo codebase.

# Test Plan

Manual review.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
