### PR TITLE
Fix formatting and add clarifying link to transaction complection section

### DIFF
--- a/packages/expo-in-app-purchases/src/InAppPurchases.ts
+++ b/packages/expo-in-app-purchases/src/InAppPurchases.ts
@@ -258,10 +258,7 @@ export function setPurchaseListener(
  * non-consumable in its product entry in App Store Connect, whereas on Android you indicate an item
  * is consumable at runtime.
  *
- * > Make sure that you verify each purchase to prevent faulty transactions and protect against
- * > fraud _before_ you call `finishTransactionAsync`. On iOS, you can validate the purchase's
- * > `transactionReceipt` with the App Store as described [here](https://developer.apple.com/library/archive/releasenotes/General/ValidateAppStoreReceipt/Chapters/ValidateRemotely.html).
- * > On Android, you can verify your purchase using the Google Play Developer API as described [here](https://developer.android.com/google/play/billing/billing_best_practices#validating-purchase).
+ * > Make sure that you verify each purchase to prevent faulty transactions and protect against fraud _before_ you call `finishTransactionAsync`. On iOS, you can validate the purchase's `transactionReceipt` with the App Store as described [here](https://developer.apple.com/library/archive/releasenotes/General/ValidateAppStoreReceipt/Chapters/ValidateRemotely.html). On Android, you can verify your purchase using the Google Play Developer API as described [here](https://developer.android.com/google/play/billing/billing_best_practices#validating-purchase).
  *
  * @example
  * ```ts

--- a/packages/expo-in-app-purchases/src/InAppPurchases.ts
+++ b/packages/expo-in-app-purchases/src/InAppPurchases.ts
@@ -251,7 +251,7 @@ export function setPurchaseListener(
  * processing the transaction. If you do not acknowledge or consume a purchase within three days,
  * the user automatically receives a refund, and Google Play revokes the purchase.
  *
- * On iOS, this will mark the transaction as finished and prevent it from reappearing in the
+ * On iOS, this will [mark the transaction as finished](https://developer.apple.com/documentation/storekit/skpaymentqueue/1506003-finishtransaction#discussion) and prevent it from reappearing in the
  * purchase listener callback. It will also let the user know their purchase was successful.
  *
  * `consumeItem` is ignored on iOS because you must specify whether an item is a consumable or
@@ -259,9 +259,9 @@ export function setPurchaseListener(
  * is consumable at runtime.
  *
  * > Make sure that you verify each purchase to prevent faulty transactions and protect against
- * fraud _before_ you call `finishTransactionAsync`. On iOS, you can validate the purchase's
- * `transactionReceipt` with the App Store as described [here](https://developer.apple.com/library/archive/releasenotes/General/ValidateAppStoreReceipt/Chapters/ValidateRemotely.html).
- * On Android, you can verify your purchase using the Google Play Developer API as described [here](https://developer.android.com/google/play/billing/billing_best_practices#validating-purchase).
+ * > fraud _before_ you call `finishTransactionAsync`. On iOS, you can validate the purchase's
+ * > `transactionReceipt` with the App Store as described [here](https://developer.apple.com/library/archive/releasenotes/General/ValidateAppStoreReceipt/Chapters/ValidateRemotely.html).
+ * > On Android, you can verify your purchase using the Google Play Developer API as described [here](https://developer.android.com/google/play/billing/billing_best_practices#validating-purchase).
  *
  * @example
  * ```ts


### PR DESCRIPTION
# Why

This is more or less a companion to https://github.com/expo/expo/pull/17556 but they could be addressed/handled separately. Adds a link to some helpful documentation on the Apple documentation site about what "finishing" a transaction does. Also adds missing blockquote formatting that seems to have been accidentally cut off mid-sentence, in the same section.

# How

Personal research.

# Test Plan

Manual review.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
