### PR TITLE
feat(cli): add info about using the `--clear` flag

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -13,6 +13,7 @@
 - add `--pnpm` option to `install` command. ([#17366](https://github.com/expo/expo/pull/17366) by [@EvanBacon](https://github.com/EvanBacon))
 - Added `export:web` command. ([#17363](https://github.com/expo/expo/pull/17363) by [@EvanBacon](https://github.com/EvanBacon))
 - Bail out on missing web dependencies. ([#17448](https://github.com/expo/expo/pull/17448) by [@EvanBacon](https://github.com/EvanBacon))
+- Add info about using the `--clear` flag when the `babel.config.js` file changes during `expo start`.
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -13,7 +13,7 @@
 - add `--pnpm` option to `install` command. ([#17366](https://github.com/expo/expo/pull/17366) by [@EvanBacon](https://github.com/EvanBacon))
 - Added `export:web` command. ([#17363](https://github.com/expo/expo/pull/17363) by [@EvanBacon](https://github.com/EvanBacon))
 - Bail out on missing web dependencies. ([#17448](https://github.com/expo/expo/pull/17448) by [@EvanBacon](https://github.com/EvanBacon))
-- Add info about using the `--clear` flag when the `babel.config.js` file changes during `expo start`.
+- Add info about using the `--clear` flag when the `babel.config.js` file changes during `expo start`. ([#17560](https://github.com/expo/expo/pull/17560) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/src/start/server/DevServerManager.ts
+++ b/packages/@expo/cli/src/start/server/DevServerManager.ts
@@ -1,5 +1,6 @@
 import { ExpoConfig, getConfig } from '@expo/config';
 import assert from 'assert';
+import chalk from 'chalk';
 
 import * as Log from '../../log';
 import { FileNotifier } from '../../utils/FileNotifier';
@@ -37,13 +38,19 @@ export class DevServerManager {
   }
 
   private watchBabelConfig() {
-    const notifier = new FileNotifier(this.projectRoot, [
-      './babel.config.js',
-      './babel.config.json',
-      './.babelrc.json',
-      './.babelrc',
-      './.babelrc.js',
-    ]);
+    const notifier = new FileNotifier(
+      this.projectRoot,
+      [
+        './babel.config.js',
+        './babel.config.json',
+        './.babelrc.json',
+        './.babelrc',
+        './.babelrc.js',
+      ],
+      {
+        additionalWarning: chalk` You may need to clear the bundler cache with the {bold --clear} flag for your changes to take effect.`,
+      }
+    );
 
     notifier.startObserving();
 

--- a/packages/@expo/cli/src/utils/FileNotifier.ts
+++ b/packages/@expo/cli/src/utils/FileNotifier.ts
@@ -12,7 +12,11 @@ export class FileNotifier {
     /** Project root to resolve the module IDs relative to. */
     private projectRoot: string,
     /** List of module IDs sorted by priority. Only the first file that exists will be observed. */
-    private moduleIds: string[]
+    private moduleIds: string[],
+    private settings: {
+      /** An additional warning message to add to the notice. */
+      additionalWarning?: string;
+    } = {}
   ) {}
 
   /** Get the file in the project. */
@@ -44,7 +48,7 @@ export class FileNotifier {
         Log.log(
           `\u203A Detected a change in ${chalk.bold(
             configName
-          )}. Restart the server to see the new results.`
+          )}. Restart the server to see the new results.` + (this.settings.additionalWarning || '')
         );
       }
     });

--- a/packages/@expo/cli/src/utils/__tests__/FileNotifier-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/FileNotifier-test.ts
@@ -42,15 +42,20 @@ it('observes the first existing file', () => {
     },
     '/'
   );
-  const fileNotifier = new FileNotifier('./', [
-    // Skips this file
-    '.babelrc',
-    // Starts observing
-    'babel.config.js',
-  ]);
+  const fileNotifier = new FileNotifier(
+    './',
+    [
+      // Skips this file
+      '.babelrc',
+      // Starts observing
+      'babel.config.js',
+    ],
+    { additionalWarning: ' foobar' }
+  );
   expect(fileNotifier.startObserving()).toBe('babel.config.js');
 
   // We mock out the callback firing and test that a warning was logged.
   expect(Log.log).toBeCalledTimes(1);
   expect(Log.log).toBeCalledWith(expect.stringContaining('babel.config.js'));
+  expect(Log.log).toBeCalledWith(expect.stringContaining('foobar'));
 });


### PR DESCRIPTION
# Why

- Feature request from partner gluroo
- Add increased clarity about how to reset the Metro cache.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# Test Plan

- nexpo start  -> modify and save `babel.config.js` -> better warning will show.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
