### PR TITLE
[media-library][ios] Use any subtype to avoid Recently Deleted album to show up

### DIFF
--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Use `PHAssetCollectionSubtypeAny` subtype to avoid Recently Deleted album to show up ([#17561](https://github.com/expo/expo/pull/17561) by [@chuganzy](https://github.com/chuganzy))
+
 ## 14.1.0 — 2022-04-18
 
 ### 🐛 Bug fixes

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -8,9 +8,9 @@
 
 ### 🐛 Bug fixes
 
-### 💡 Others
-
 - Use `PHAssetCollectionSubtypeAny` subtype to avoid Recently Deleted album to show up ([#17561](https://github.com/expo/expo/pull/17561) by [@chuganzy](https://github.com/chuganzy))
+
+### 💡 Others
 
 ## 14.1.0 — 2022-04-18
 

--- a/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m
+++ b/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m
@@ -323,7 +323,7 @@ EX_EXPORT_METHOD_AS(getAlbumsAsync,
     if ([options[@"includeSmartAlbums"] boolValue]) {
       PHFetchResult<PHAssetCollection *> *smartAlbumsFetchResult =
       [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeSmartAlbum
-                                               subtype:PHAssetCollectionSubtypeAlbumRegular
+                                               subtype:PHAssetCollectionSubtypeAny
                                                options:fetchOptions];
       [albums addObjectsFromArray:[EXMediaLibrary _exportCollections:smartAlbumsFetchResult withFetchOptions:fetchOptions inFolder:nil]];
     }
@@ -750,7 +750,7 @@ EX_EXPORT_METHOD_AS(getAssetsAsync,
   
   PHFetchResult *fetchResult = [PHAssetCollection
                                 fetchAssetCollectionsWithType:PHAssetCollectionTypeAlbum
-                                subtype:PHAssetCollectionSubtypeAlbumRegular
+                                subtype:PHAssetCollectionSubtypeAny
                                 options:options];
 
   return fetchResult.firstObject;


### PR DESCRIPTION
# Why

`PHAssetCollectionSubtypeAlbumRegular` also seems to include Recently Deleted album. However from the app it is impossible to access any assets in this album. Also by looking at `getAlbumsAsync`, the intention seems like it want to exclude hidden assets (`includeHiddenAssets` is set to false).

According to Apple's documentation it says,

> When fetching asset collections, use this value to fetch collections of any subtype.

https://developer.apple.com/documentation/photokit/phassetcollectionsubtype/phassetcollectionsubtypeany?language=objc

while `regular` does not have any detailed doc available. But probably this matches with what we want to do here.

# How

"Why" section mentions it.

# Test Plan

Observe the list of albums with `includeSmartAlbums` enabled.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
