### PR TITLE
[ios][core] align the expo modules registration

### DIFF
--- a/ios/Exponent/Versioned/Core/EXVersionManager.mm
+++ b/ios/Exponent/Versioned/Core/EXVersionManager.mm
@@ -38,6 +38,7 @@
 #import <ExpoModulesCore/EXDefines.h>
 #import <ExpoModulesCore/EXModuleRegistry.h>
 #import <ExpoModulesCore/EXModuleRegistryDelegate.h>
+#import <ExpoModulesCore/EXModuleRegistryHolderReactModule.h>
 #import <ExpoModulesCore/EXNativeModulesProxy.h>
 #import <EXMediaLibrary/EXMediaLibraryImageLoader.h>
 #import <EXFileSystem/EXFileSystem.h>
@@ -378,8 +379,13 @@ RCT_EXTERN void EXRegisterScopedModule(Class, ...);
                                                                            scopeKey:self.manifest.scopeKey
                                                                            manifest:self.manifest
                                                                  withKernelServices:services];
-  NSArray<id<RCTBridgeModule>> *expoModules = [moduleRegistryAdapter extraModulesForModuleRegistry:moduleRegistry];
-  [extraModules addObjectsFromArray:expoModules];
+
+  // Adding EXNativeModulesProxy with the custom moduleRegistry.
+  EXNativeModulesProxy *expoNativeModulesProxy = [[EXNativeModulesProxy alloc] initWithCustomModuleRegistry:moduleRegistry];
+  [extraModules addObject:expoNativeModulesProxy];
+
+  // Adding the way to access the module registry from RCTBridgeModules.
+  [extraModules addObject:[[EXModuleRegistryHolderReactModule alloc] initWithModuleRegistry:moduleRegistry]];
 
   if (!RCTTurboModuleEnabled()) {
     [extraModules addObject:[self getModuleInstanceFromClass:[self getModuleClassFromName:"DevSettings"]]];

--- a/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.h
+++ b/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.h
@@ -14,6 +14,7 @@ NS_SWIFT_NAME(NativeModulesProxy)
 
 - (nonnull instancetype)init;
 - (nonnull instancetype)initWithModuleRegistry:(nullable EXModuleRegistry *)moduleRegistry;
+- (nonnull instancetype)initWithCustomModuleRegistry:(nonnull EXModuleRegistry *)moduleRegistry;
 
 - (void)callMethod:(NSString *)moduleName methodNameOrKey:(id)methodNameOrKey arguments:(NSArray *)arguments resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject;
 

--- a/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.mm
+++ b/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.mm
@@ -75,7 +75,7 @@ RCT_EXPORT_MODULE(NativeUnimoduleProxy)
 }
 
 /**
- The designated initializer is for Expo Go to pass a custom `EXModuleRegistry`
+ The initializer for Expo Go to pass a custom `EXModuleRegistry`
  other than the default one from `EXModuleRegistryProvider`.
  The `EXModuleRegistry` is still owned by this class.
  */

--- a/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.mm
+++ b/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.mm
@@ -75,6 +75,18 @@ RCT_EXPORT_MODULE(NativeUnimoduleProxy)
 }
 
 /**
+ The designated initializer is for Expo Go to pass a custom `EXModuleRegistry`
+ other than the default one from `EXModuleRegistryProvider`.
+ The `EXModuleRegistry` is still owned by this class.
+ */
+- (instancetype)initWithCustomModuleRegistry:(nonnull EXModuleRegistry *)moduleRegistry
+{
+  self = [self initWithModuleRegistry:moduleRegistry];
+  self.ownsModuleRegistry = YES;
+  return self;
+}
+
+/**
  Convenience initializer used by React Native in the new setup, where the modules are registered automatically.
  */
 - (instancetype)init


### PR DESCRIPTION
# Why

expo go still uses the legacy native modules registration (`EXModuleRegistryAdapter` in `extraModulesForBridge:`). this flow is different from a bare project.

react-native 0.69 has a different native modules setup flow that would breaks expo go's setup.
`- (void)setModuleRegistry:(EXModuleRegistry *)expoModuleRegistry` in EXAV.m would be called with RCTModuleRegistryy but not EXModuleRegistry.

# How

add a `initWithCustomModuleRegistry:` in EXNativeModulesProxy designated initializer for expo go to pass its EXModuleRegistry. specifically, we need to use [the shared call flow](https://github.com/expo/expo/blob/19db64c8db1d6dd4c062426cd4fbe87eaa37d90e/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.mm#L228-L256)

# Test Plan

- unversioned expo go + NCL
- bare-expo
- unversioned expo go (based on react-native 0.69) + NCL

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
