### PR TITLE
[docs] remove link to customize dev menu

### DIFF
--- a/docs/pages/development/getting-started.md
+++ b/docs/pages/development/getting-started.md
@@ -180,4 +180,4 @@ const styles = StyleSheet.create({
 
 ## Debugging your app
 
-When you need to, you can access the menu by pressing Cmd-d in Expo CLI or by shaking your phone or tablet. Here you'll be able to access all of the functions of your development build, access any debugging functionality you need, switch to a different version of your app, or [any capabilities you have added yourself](extending-the-dev-menu.md).
+When you need to, you can access the menu by pressing Cmd-d in Expo CLI or by shaking your phone or tablet. Here you'll be able to access all of the functions of your development build, access any debugging functionality you need, or switch to a different version of your app.


### PR DESCRIPTION
# Why

Pending the reintroduction of dev menu customization (https://github.com/expo/expo/pull/17528), the page to customize the dev menu was taken down, but the link to it was still active.

# How

Removed the part of the sentence that referenced it. 

# Test Plan

Mk-1 Eyeball.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
