### PR TITLE
[core] fix error for building react-native from source

### DIFF
--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -337,9 +337,11 @@ tasks.whenTaskAdded { task ->
     task.dependsOn(extractAARHeaders)
     task.dependsOn(extractJNIFiles)
     if (REACT_NATIVE_BUILD_FROM_SOURCE) {
-      task.dependsOn(":ReactAndroid:packageReactNdkLibs")
+      def buildType = task.name.endsWith('Debug') ? 'Debug' : 'Release'
+      task.dependsOn(":ReactAndroid:copy${buildType}JniLibsProjectOnly")
     }
   } else if (task.name.startsWith('generateJsonModel') && REACT_NATIVE_BUILD_FROM_SOURCE) {
-    task.dependsOn(":ReactAndroid:packageReactNdkLibs")
+    def buildType = task.name.endsWith('Debug') ? 'Debug' : 'Release'
+    task.dependsOn(":ReactAndroid:copy${buildType}JniLibsProjectOnly")
   }
 }

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -63,6 +63,11 @@ def DOUBLE_CONVERSION_VERSION = reactProperties.getProperty("DOUBLE_CONVERSION_V
 
 def reactNativeThirdParty = new File("$REACT_NATIVE_DIR/ReactAndroid/src/main/jni/third-party")
 
+def reactNativeArchitectures() {
+    def value = project.getProperties().get("reactNativeArchitectures")
+    return value ? value.split(",") : ["armeabi-v7a", "x86", "x86_64", "arm64-v8a"]
+}
+
 // Creating sources with comments
 task androidSourcesJar(type: Jar) {
   classifier = 'sources'
@@ -109,7 +114,7 @@ android {
 
     externalNativeBuild {
       cmake {
-        abiFilters(*(System.getenv('NDK_ABI_FILTERS') ?: 'armeabi-v7a x86 arm64-v8a x86_64').split(' '))
+        abiFilters (*reactNativeArchitectures())
         arguments "-DREACT_NATIVE_DIR=${REACT_NATIVE_DIR}",
           "-DREACT_NATIVE_SO_DIR=${REACT_NATIVE_SO_DIR}",
           "-DBOOST_VERSION=${BOOST_VERSION}"


### PR DESCRIPTION
# Why

fix the build error in ci like [this job](https://github.com/expo/expo/runs/6484397159?check_suite_focus=true)

```
* What went wrong:
Could not determine the dependencies of task ':expo-modules-core:externalNativeBuildDebug'.
> Task with path ':ReactAndroid:packageReactNdkLibs' not found in project ':expo-modules-core'.
```

# How

- `packageReactNdkLibs` was removed in react-native 0.68. i found `copyDebugJniLibsProjectOnly` and `copyReleaseJniLibsProjectOnly` is good enough and we also used in expo-av.
- support new abi filter from react-native 0.68 by gradle property

# Test Plan

android ci passed
android instrumented test ci job: https://github.com/expo/expo/runs/6509031533?check_suite_focus=true

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
