### PR TITLE
[e-m-c][Android] Create `CurrentActivityProvider`

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🎉 New features
 
+- Create `CurrentActivityProvider` on Android. ([#17571](https://github.com/expo/expo/pull/17571) by [@bbarthec](https://github.com/bbarthec))
 - Create `AppContextProvider` on Android. ([#17546](https://github.com/expo/expo/pull/17546) by [@bbarthec](https://github.com/bbarthec))
 - Introduce dynamic properties in the Sweet API on iOS. ([#17318](https://github.com/expo/expo/pull/17318) by [@tsapeta](https://github.com/tsapeta))
 - Add basic support for sync functions in the Sweet API on Android. ([#16977](https://github.com/expo/expo/pull/16977) by [@lukmccall](https://github.com/lukmccall))

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -179,8 +179,18 @@ android {
 dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
   implementation "org.jetbrains.kotlin:kotlin-reflect:${getKotlinVersion()}"
-  implementation 'androidx.annotation:annotation:1.2.0'
+  implementation 'androidx.annotation:annotation:1.3.0'
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.0"
+  /**
+   * ReactActivity (the base activity for every React Native application) is subclassing AndroidX classes.
+   * Unfortunately until https://github.com/facebook/react-native/pull/33072 us released React Native uses "androidx.appcompat:appcompat:1.0.2".
+   * Gradle is picking the highest version of the dependency so we enforce higher version here.
+   * see https://docs.gradle.org/current/userguide/dependency_resolution.html#sec:version-conflict
+   * We're enforcing the most up-to-date versions of the dependencies here that are used in subclassing chain for ReactActivity.
+   */
+  implementation "androidx.appcompat:appcompat:1.4.1"
+  implementation "androidx.activity:activity-ktx:1.4.0" // androidx.appcompat:appcompat:1.4.1 depends on version 1.2.3, so we enforce higher one here
+  implementation "androidx.fragment:fragment-ktx:1.4.1" // androidx.appcomapt:appcompat:1.4.1 depends on version 1.3.4, so we enforce higher one here
 
   //noinspection GradleDynamicVersion
   implementation 'com.facebook.react:react-native:+'

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -183,7 +183,7 @@ dependencies {
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.0"
   /**
    * ReactActivity (the base activity for every React Native application) is subclassing AndroidX classes.
-   * Unfortunately until https://github.com/facebook/react-native/pull/33072 us released React Native uses "androidx.appcompat:appcompat:1.0.2".
+   * Unfortunately until https://github.com/facebook/react-native/pull/33072 is released React Native uses "androidx.appcompat:appcompat:1.0.2".
    * Gradle is picking the highest version of the dependency so we enforce higher version here.
    * see https://docs.gradle.org/current/userguide/dependency_resolution.html#sec:version-conflict
    * We're enforcing the most up-to-date versions of the dependencies here that are used in subclassing chain for ReactActivity.

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -5,6 +5,7 @@ package expo.modules.kotlin
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
+import com.facebook.react.ReactActivity
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.turbomodule.core.CallInvokerHolderImpl
 import expo.modules.core.errors.ContextDestroyedException
@@ -26,19 +27,21 @@ import expo.modules.kotlin.events.KModuleEventEmitterWrapper
 import expo.modules.kotlin.events.OnActivityResultPayload
 import expo.modules.kotlin.jni.JSIInteropModuleRegistry
 import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.providers.ReactActivityProvider
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.newSingleThreadContext
+import java.lang.RuntimeException
 import java.lang.ref.WeakReference
 
 class AppContext(
   modulesProvider: ModulesProvider,
   val legacyModuleRegistry: expo.modules.core.ModuleRegistry,
   private val reactContextHolder: WeakReference<ReactApplicationContext>
-) {
+) : ReactActivityProvider {
   val registry = ModuleRegistry(WeakReference(this)).apply {
     register(ErrorManagerModule())
     register(modulesProvider)
@@ -212,4 +215,20 @@ class AppContext(
       intent
     )
   }
+
+// region ReactActivityProvider
+
+  override val reactActivity: ReactActivity?
+    get() {
+      val currentActivity = this.activityProvider?.currentActivity ?: return null
+
+      if (currentActivity !is ReactActivity) {
+        throw RuntimeException("Current Activity is of incorrect class, expected ReactActivity, received ${currentActivity.localClassName}")
+      }
+
+      return currentActivity
+    }
+
+// endregion
+
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -5,7 +5,7 @@ package expo.modules.kotlin
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
-import com.facebook.react.ReactActivity
+import androidx.appcompat.app.AppCompatActivity
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.turbomodule.core.CallInvokerHolderImpl
 import expo.modules.core.errors.ContextDestroyedException
@@ -27,7 +27,7 @@ import expo.modules.kotlin.events.KModuleEventEmitterWrapper
 import expo.modules.kotlin.events.OnActivityResultPayload
 import expo.modules.kotlin.jni.JSIInteropModuleRegistry
 import expo.modules.kotlin.modules.Module
-import expo.modules.kotlin.providers.ReactActivityProvider
+import expo.modules.kotlin.providers.CurrentActivityProvider
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
@@ -41,7 +41,7 @@ class AppContext(
   modulesProvider: ModulesProvider,
   val legacyModuleRegistry: expo.modules.core.ModuleRegistry,
   private val reactContextHolder: WeakReference<ReactApplicationContext>
-) : ReactActivityProvider {
+) : CurrentActivityProvider {
   val registry = ModuleRegistry(WeakReference(this)).apply {
     register(ErrorManagerModule())
     register(modulesProvider)
@@ -216,19 +216,18 @@ class AppContext(
     )
   }
 
-// region ReactActivityProvider
+// region CurrentActivityProvider
 
-  override val reactActivity: ReactActivity?
+  override val currentActivity: AppCompatActivity?
     get() {
       val currentActivity = this.activityProvider?.currentActivity ?: return null
 
-      if (currentActivity !is ReactActivity) {
-        throw RuntimeException("Current Activity is of incorrect class, expected ReactActivity, received ${currentActivity.localClassName}")
+      if (currentActivity !is AppCompatActivity) {
+        throw RuntimeException("Current Activity is of incorrect class, expected AppCompatActivity, received ${currentActivity.localClassName}")
       }
 
       return currentActivity
     }
 
 // endregion
-
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -222,8 +222,8 @@ class AppContext(
     get() {
       val currentActivity = this.activityProvider?.currentActivity ?: return null
 
-      if (currentActivity !is AppCompatActivity) {
-        throw RuntimeException("Current Activity is of incorrect class, expected AppCompatActivity, received ${currentActivity.localClassName}")
+      check(currentActivity is AppCompatActivity) {
+        "Current Activity is of incorrect class, expected AppCompatActivity, received ${currentActivity.localClassName}"
       }
 
       return currentActivity

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/providers/CurrentActivityProvider.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/providers/CurrentActivityProvider.kt
@@ -11,10 +11,12 @@ import android.app.Activity
  * AndroidX/Android Jetpack features in Expo libraries coming from all subclassing chain:
  * [AppCompatActivity], [FragmentActivity], [ComponentActivity], [Activity]
 */
-interface ReactActivityProvider {
+interface CurrentActivityProvider {
   /**
-   * Returns the current activity that should be an instance of [ReactActivity].
+   * Returns the current [Activity] that should be an instance of [AppCompatActivity].
+   * This activity is most likely an instance of [ReactActivity], but it's been decided not to expose
+   * `react-native` symbols via `expo-module-core` public API.
    * @returns null if the [Activity] is not yet available (eg. Application has not yet fully started)
    */
-  val reactActivity: ReactActivity?
+  val currentActivity: AppCompatActivity?
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/providers/ReactActivityProvider.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/providers/ReactActivityProvider.kt
@@ -1,0 +1,20 @@
+package expo.modules.kotlin.providers
+
+import com.facebook.react.ReactActivity
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.FragmentActivity
+import androidx.core.app.ComponentActivity
+import android.app.Activity
+
+/**
+ * A class that provides the accessor to the [ReactActivity]. It enables accessing
+ * AndroidX/Android Jetpack features in Expo libraries coming from all subclassing chain:
+ * [AppCompatActivity], [FragmentActivity], [ComponentActivity], [Activity]
+*/
+interface ReactActivityProvider {
+  /**
+   * Returns the current activity that should be an instance of [ReactActivity].
+   * @returns null if the [Activity] is not yet available (eg. Application has not yet fully started)
+   */
+  val reactActivity: ReactActivity?
+}


### PR DESCRIPTION
# Why

Extracted part of #16251
Similar to https://github.com/expo/expo/pull/17551

If we want to access newer things coming from `AndroidX/Jetpack` we need to enforce higher versions of the underlying native libraries.

In this PR I'm forcing following libraries versions:
- `androidx.appcompat:appcompat:1.4.1`
- `androidx:activity:activity-ktx:1.4.0`
- `androidx.fragment:fragment-ktx:1.4.1`

# How

I've bumped `build.gradle` dependencies and took advantage of gradle dependencies resolution system that picks up the higher version available in the whole project.

# Test Plan

It's no-op