### PR TITLE
[sweet][iOS] Remove`EXJavaScriptValue.kindOf`

### DIFF
--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptValue.h
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptValue.h
@@ -37,8 +37,6 @@ NS_SWIFT_NAME(JavaScriptValue)
 - (BOOL)isObject;
 - (BOOL)isFunction;
 
-+ (nonnull NSString *)kindOf:(nonnull EXJavaScriptValue *)value;
-
 #pragma mark - Type casting
 
 - (nullable id)getRaw;

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptValue.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptValue.mm
@@ -87,6 +87,9 @@
   if ([value isString]) {
     return @"string";
   }
+  if ([value isSymbol]) {
+    return @"symbol";
+  }
   if ([value isFunction]) {
     return @"function";
   }

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptValue.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptValue.mm
@@ -70,33 +70,6 @@
   return false;
 }
 
-+ (nonnull NSString *)kindOf:(nonnull EXJavaScriptValue *)value
-{
-  if ([value isUndefined]) {
-    return @"undefined";
-  }
-  if ([value isNull]) {
-    return @"null";
-  }
-  if ([value isBool]) {
-    return @"boolean";
-  }
-  if ([value isNumber]) {
-    return @"number";
-  }
-  if ([value isString]) {
-    return @"string";
-  }
-  if ([value isSymbol]) {
-    return @"symbol";
-  }
-  if ([value isFunction]) {
-    return @"function";
-  }
-  assert([value isObject] && "Expecting object.");
-  return @"object";
-}
-
 #pragma mark - Type casting
 
 - (nullable id)getRaw


### PR DESCRIPTION
# Why

Remove unused `kindOf` method 
