### PR TITLE
[docs] Fix wrong Android sdk environment variable

### DIFF
--- a/docs/pages/workflow/android-studio-emulator.md
+++ b/docs/pages/workflow/android-studio-emulator.md
@@ -20,17 +20,17 @@ If you don't have an Android device available to test with, we recommend using t
 
 <ImageSpotlight alt="Android SDK location" src="/static/images/android-studio-sdk-location.png" containerStyle={{ paddingBottom: 0 }} />
 
-- If you are on macOS or Linux, add an environment variable pointing to the Android SDK location in `~/.bash_profile` (or `~/.zshenv` if you use Zsh) - eg. `export ANDROID_SDK=/your/path/here`. Copy and paste these two lines to do this automatically for Bash and Zsh:
+- If you are on macOS or Linux, add an [environment variable](https://developer.android.com/studio/command-line/variables#envar) pointing to the Android SDK location in `~/.bash_profile` (or `~/.zshenv` if you use Zsh) - eg. `export ANDROID_HOME=/your/path/here`. Copy and paste these two lines to do this automatically for Bash and Zsh:
 
 ```bash
-[ -d "$HOME/Library/Android/sdk" ] && ANDROID_SDK=$HOME/Library/Android/sdk || ANDROID_SDK=$HOME/Android/Sdk
-echo "export ANDROID_SDK=$ANDROID_SDK" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bash_profile'`
+[ -d "$HOME/Library/Android/sdk" ] && ANDROID_HOME=$HOME/Library/Android/sdk || ANDROID_HOME=$HOME/Android/Sdk
+echo "export ANDROID_HOME=$ANDROID_HOME" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bash_profile'`
 ```
 
 - On macOS, you will also need to add `platform-tools` to your `~/.bash_profile` (or `~/.zshenv` if you use Zsh) - eg. `export PATH=/your/path/here:$PATH`. Copy and paste this line to do this automatically for Bash and Zsh:
 
 ```bash
-echo "export PATH=$HOME/Library/Android/sdk/platform-tools:\$PATH" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bash_profile'`
+echo "export PATH=$ANDROID_HOME/platform-tools:\$PATH" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bash_profile'`
 ```
 
 - Reload the path environment variables by running:


### PR DESCRIPTION
# Why

People might be running into this, so let's fix it :)

# How

Google has been going back and forth with these envvars. As of now, both `ANDROID_HOME` and `ANDROID_SDK_ROOT` seems to be working both. But, on their docs, [they mention `_SDK_ROOT` is deprecated in favor of `_HOME`](https://developer.android.com/studio/command-line/variables#envar)

![image](https://user-images.githubusercontent.com/1203991/169423081-676d014a-e034-4e72-ac25-5f7360c84b86.png)


# Test Plan

Docs change only

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
