### PR TITLE
[doc] Remove duplication in titles

### DIFF
--- a/docs/components/DocumentationPage.tsx
+++ b/docs/components/DocumentationPage.tsx
@@ -259,7 +259,7 @@ class DocumentationPageWithApiVersion extends React.Component<Props, State> {
         isMobileSearchActive={this.state.isMobileSearchActive}
         onContentScroll={handleContentScroll}
         sidebarScrollPosition={sidebarScrollPosition}>
-        <Head title={title}>
+        <Head title={this.props.title}>
           {algoliaTag !== null && <meta name="docsearch:version" content={algoliaTag} />}
           <meta property="og:title" content={title} />
           <meta property="og:type" content="website" />

--- a/docs/pages/eas-update/code-signing.md
+++ b/docs/pages/eas-update/code-signing.md
@@ -4,7 +4,7 @@ title: Code Signing
 
 import Head from '~/components/Head'
 
-<Head title="EAS Update Code Signing - Expo Documentation" />
+<Head title="EAS Update Code Signing" />
 
 > ⚠️ Expo Updates code signing is in early beta, meaning that it is not yet ready for use in production apps. We may still make breaking changes to the developer-facing portion and the end-user portion as well.
 

--- a/docs/pages/eas-update/introduction.md
+++ b/docs/pages/eas-update/introduction.md
@@ -4,7 +4,7 @@ title: Introduction
 
 import Head from '~/components/Head'
 
-<Head title="Introduction to EAS Update - Expo Documentation" />
+<Head title="Introduction to EAS Update" />
 
 > EAS Update is currently available only to customers with an EAS subscription plan. [Sign up](https://expo.dev/accounts/[account]/settings/subscriptions).
 


### PR DESCRIPTION
# Why

The documentation contained "Expo Documentation - Expo Documentation"

# How

I passed the title prop as-is to the `Head` component instead of the title with "- Expo Documentation" tacked on the end because `Head` already appends that string.
I kept the`title` const with the suffix because it still seemed appropriate for the `og:title` and `twitter:title`.
I removed the suffix from the EAS Update Intro and Code Signing because they call `Head` which, as mentioned above, adds the suffix already.

# Test Plan

I checked the page title, `og:title`, `twitter:title` on the changed EAS Update pages and a couple of other random pages.
I also checked the links to the forums and GitHub issues on a couple of random API pages.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
