### PR TITLE
[sweet][iOS] Handle `JSIException` in the `evaluateScript` function

### DIFF
--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.mm
@@ -143,6 +143,12 @@ using namespace facebook;
       @"message": reason,
       @"stack": stack,
     }];
+  } catch (jsi::JSIException &error) {
+    NSString *reason = [NSString stringWithUTF8String:error.what()];
+    
+    @throw [NSException exceptionWithName:@"ScriptEvaluationException" reason:reason userInfo:@{
+      @"message": reason
+    }];
   }
   return [[EXJavaScriptValue alloc] initWithRuntime:self value:result];
 }


### PR DESCRIPTION
# Why

`evaluateJavaScript` may also throw `jsi::JSIException` that is a base class of the `jsi::JSError` when there were a syntax error in the script. Right now, it won't be caught by the try-catch block.  

# Test Plan

I didn't test that on iOS, but on Android, I have to do a similar thing. 