### PR TITLE
[ncl] Configure NCL for EAS, make notifications work

### DIFF
--- a/apps/native-component-list/app.json
+++ b/apps/native-component-list/app.json
@@ -88,6 +88,11 @@
       "assets/**",
       "node_modules/react-navigation/src/**/*.png",
       "node_modules/@expo/vector-icons/fonts/*.ttf"
-    ]
+    ],
+    "extra": {
+      "eas": {
+        "projectId": "2c28de10-a2cd-11e6-b8ce-59d1587e6774"
+      }
+    }
   }
 }


### PR DESCRIPTION
Why
---
NCL uses the modern manifest format but was not configured for EAS, which meant that it could not register for notifications.

How
---
Added the extra->eas section (ran `eas init` while logged in with the community account).

Test Plan
---
Opened NCL in Expo Go, went to Notifications, sent myself a push notification. Instead of getting an unhandled promise rejection warning, I received a notification.