### PR TITLE
[expo-splash-screen] [ios] Fix expo-splash-screen when reloading with expo-updates

### DIFF
--- a/packages/expo-splash-screen/CHANGELOG.md
+++ b/packages/expo-splash-screen/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed issue in `expo-splash-screen` where it would not show the splash screen again when reloading the app via `reloadAsync` in `expo-updates` ([#17592](https://github.com/expo/expo/pull/17592) by [@ilyausorov](https://github.com/ilyausorov))
+
 ### 💡 Others
 
 ## 0.15.1 — 2022-04-27

--- a/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenService.m
+++ b/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenService.m
@@ -20,6 +20,7 @@ static NSString * const kView = @"view";
  * That's why we keep a weak reference here but not a boolean flag.
  */
 @property (nonatomic, weak) UIViewController *observingRootViewController;
+@property (nonatomic, assign) BOOL showSplashScreenAgain;
 
 @end
 
@@ -71,8 +72,12 @@ EX_REGISTER_SINGLETON_MODULE(SplashScreen);
             successCallback:(void (^)(void))successCallback
             failureCallback:(void (^)(NSString * _Nonnull))failureCallback
 {
-  if ([self.splashScreenControllers objectForKey:viewController]) {
+  if (!_showSplashScreenAgain && [self.splashScreenControllers objectForKey:viewController]) {
     return failureCallback(@"'SplashScreen.show' has already been called for given view controller.");
+  }
+  
+  if (_showSplashScreenAgain) {
+    _showSplashScreenAgain = NO;
   }
   
   [self.splashScreenControllers setObject:splashScreenController forKey:viewController];
@@ -125,6 +130,7 @@ EX_REGISTER_SINGLETON_MODULE(SplashScreen);
   }
   BOOL needsShow = [[self.splashScreenControllers objectForKey:viewController] needsShowOnAppContentWillReload];
   if (needsShow) {
+    _showSplashScreenAgain = YES;
     [self showSplashScreenFor:viewController
        splashScreenController:[self.splashScreenControllers objectForKey:viewController]
               successCallback:^{}


### PR DESCRIPTION
# Why

In the current implementation of expo-splash-screen@0.15.1, when you reload the app with expo-updates reloadAsync, the lifecycle method onAppContentWillReload correctly catches the reload event, and calls self showSplashScreenFor:viewController, however it returns the failureCallback because [self.splashScreenControllers objectForKey:viewController] already exists.

In the case when I am reloading via expo-updates I think we do want the splash screen to show again. This behavior of the splash screen showing during reload was definitely present in SDK <= 42, and I realized this regression when my team upgraded our app from SDK 42 to SDK 45 in the recent days. Currently, when the app reloads it just shows a blank white screen, which is I'm assuming the native white background.

I believe [this issue #12000](https://github.com/expo/expo/issues/12000) is fixed by this PR.

# How

To solve this regression, I modified EXSplashScreenService.m by adding a new BOOL showSplashScreenAgain and set it to YES if needsShow is true in the onAppContentWillReload lifecycle method. Then when self showSplashScreenFor:viewController is called, if _showSplashScreenAgain is YES, it skips the check for [self.splashScreenControllers objectForKey:viewController] and continues to show the splash screen. I immediately clean up _showSplashScreenAgain by setting it to NO before the splash screen is called to show.

# Test Plan

I made a demo repo to demo the fix: https://github.com/ilyausorov/expo-splash-screen-updates-fix-demo. This PR is included in that repo as a patch package to expo-splash-screen.

# Checklist

This isn't a user facing feature, rather a bugfix so I don't think we need to add anything explicit to the documentation. If this PR is accepted, I can add a note to the changelog.

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
