### PR TITLE
Fix name of release channel key for EAS builds

### DIFF
--- a/docs/scripts/schemas/unversioned/eas-json-build-common-schema.js
+++ b/docs/scripts/schemas/unversioned/eas-json-build-common-schema.js
@@ -16,7 +16,7 @@ export default [
     ],
   },
   {
-    name: 'releaseChannel',
+    name: 'channel',
     type: 'string',
     description: [
       'Name of the release channel for the `expo-updates` package ([Learn more about this](../../distribution/release-channels)). If you do not specify a channel, your binary will pull releases from the `default` channel. If you do not use `expo-updates` in your project then this property will have no effect.',


### PR DESCRIPTION
# Why

The name of the release channel setting in `eas.json` is documented incorrectly. Where the docs say `releaseChannel`, they should actually say `channel`, as mentioned in this guide to migrating from expo build to EAS: https://docs.expo.dev/eas-update/migrate-to-eas-update/

# How

I tried using `releaseChannel` in eas.json but it has no effect. Using `channel` makes it work.

# Test Plan

Build an app with `channel` set to something, then use `Updates.channel` to see the value set in the build. You should see your chosen channel name.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
