### PR TITLE
[docs] Add channel field to eas.json

### DIFF
--- a/docs/scripts/schemas/unversioned/eas-json-build-common-schema.js
+++ b/docs/scripts/schemas/unversioned/eas-json-build-common-schema.js
@@ -19,7 +19,14 @@ export default [
     name: 'releaseChannel',
     type: 'string',
     description: [
-      'Name of the release channel for the `expo-updates` package ([Learn more about this](../../distribution/release-channels)). If you do not specify a channel, your binary will pull releases from the `default` channel. If you do not use `expo-updates` in your project then this property will have no effect.',
+      'Name of the release channel for the `expo-updates` package ([Learn more about this](../../distribution/release-channels)). If you do not specify a channel, your binary will pull releases from the `default` channel. If you do not use `expo-updates` in your project then this property will have no effect. **This field only applies to the Classic Update service**; if you use EAS Update, use the [channel](#channel) field instead.',
+    ]
+  },
+  {
+    name: 'channel',
+    type: 'string',
+    description: [
+      'The channel is a name we can give to multiple builds to identify them easily. [Learn more](../../eas-update/how-eas-update-works). **This field only applies to the EAS Update service**, if your project still uses Classic Updates then use the [releaseChannel](#releasechannel) field instead.',
     ]
   },
   {


### PR DESCRIPTION
# Why

releaseChannel and channel both need to be documented in the eas.json schema. Thanks to #17598 for pointing this out.

# How

Add a brief and probably not sufficiently good description of the channel field, try to explain inline which field to use.

# Test Plan

Run docs locally, visit http://localhost:3002/build-reference/eas-json/

<img width="1173" alt="image" src="https://user-images.githubusercontent.com/90494/169680152-ff06d066-3449-40be-8756-afe08e71bc1d.png">