### PR TITLE
[template] Fix LinkingConfiguration usage

### DIFF
--- a/templates/expo-template-tabs/navigation/LinkingConfiguration.ts
+++ b/templates/expo-template-tabs/navigation/LinkingConfiguration.ts
@@ -10,7 +10,7 @@ import * as Linking from 'expo-linking';
 import { RootStackParamList } from '../types';
 
 const linking: LinkingOptions<RootStackParamList> = {
-  prefixes: [Linking.makeUrl('/')],
+  prefixes: [Linking.createURL('/')],
   config: {
     screens: {
       Root: {


### PR DESCRIPTION
Change makeURL to createURL of Linking provided from expo-linking

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

There is a problem that the deprecated API is being used in the expo template

`makeURL` is deprecated API according to docs ([v42.0.0 change log](https://github.com/expo/expo/blob/168ee43f71f005baa11edf98e518593443e1807a/docs/pages/versions/v42.0.0/sdk/linking.md#linkingmakeurlpath-options-scheme))


<img width="927" alt="image" src="https://user-images.githubusercontent.com/17924127/169682891-e4cad102-8ba4-4369-839b-da9db53315f1.png">


# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

1. Scaffold new project by expo-cli

```
expo init
```
2. Select `tabs (TypeScript)`

![image](https://user-images.githubusercontent.com/17924127/169683005-3c468b3c-884f-4079-9085-99f3284f7f14.png)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
