### PR TITLE
[docs] account_name is no longer part of eas build webhook payload

### DIFF
--- a/docs/pages/eas/webhooks.md
+++ b/docs/pages/eas/webhooks.md
@@ -65,7 +65,6 @@ The build webhook payload looks something like this:
       "dev_client": false,
       "project_id": "bc0a82de-65a5-4497-ad86-54ff1f53edf7",
       "tracking_id": "a3fdefa7-d129-42f2-9432-912050ab0f10",
-      "account_name": "dsokal",
       "project_type": "managed",
       "dev_client_version": "0.6.2"
     },


### PR DESCRIPTION
# Why

https://github.com/expo/universe/pull/8725 removed `account_name` from the `trackingContext`

# How

Removed the field from the example payload

# Test Plan

Mk. 1 Eyeball

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
