### PR TITLE
[android] Fix classic build errors

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,10 @@ buildscript {
     classpath 'com.google.gms:google-services:4.3.5'
     classpath "de.undercouch:gradle-download-task:$gradleDownloadTaskVersion"
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
+
+    // WHEN_DISTRIBUTING_REMOVE_FROM_HERE
     classpath "com.facebook.react:react-native-gradle-plugin"
+    // WHEN_DISTRIBUTING_REMOVE_TO_HERE
   }
 }
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -13,3 +13,9 @@ android.useAndroidX=true
 android.enableJetifier=true
 android.useNewApkCreator=false
 expo.updates.createManifest=false
+
+# Override the react-native version that expo package get from node_modules
+# https://github.com/expo/expo/blob/c30ad508e2f91ff49c82cac80ad487b4b352ed93/packages/expo/android/build.gradle#L22
+#   - Expo Go uses the react-native version from react-native-lab/react-native
+#   - Turtle builder does not install react-native from shell app
+reactNativeVersion=0.68.2

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -12,9 +12,6 @@ include ':app'
 apply from: new File(["node", "--print", "require.resolve('expo/package.json')"].execute(null, rootDir).text.trim(), "../scripts/autolinking.gradle")
 
 /* UNCOMMENT WHEN DISTRIBUTING
-
-includeBuild('../node_modules/react-native-gradle-plugin')
-
 useExpoModules([
     exclude: [
         'expo-module-template',


### PR DESCRIPTION
# Why

Fix android classic build error

# How

cherry-pick from sdk-45
  - https://github.com/expo/expo/commit/fc8e8f712075f42bbbc21c4fc432e270531d16cf
  - https://github.com/expo/expo/commit/e9f61e8833ada706ce808bdededee85e2a1cd8af
  - https://github.com/expo/expo/commit/db5944cfc76c9bb878f2b300405f93ecad8d6cec

Basically that in turtle builder, we use the prebuilt react-native aar and don't have react-native package installed.

# Test Plan

tested `expo build:android` from a sdk 45 NCL on staging

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
