### PR TITLE
[core] Fix duplicated libs build errors

### DIFF
--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -138,12 +138,13 @@ android {
     def sharedLibraries = [
       "**/libc++_shared.so",
       "**/libreactnativejni.so",
+      "**/libreact_nativemodule_core.so",
       "**/libglog.so",
       "**/libjscexecutor.so",
       "**/libfbjni.so",
       "**/libfolly_json.so",
       "**/libhermes.so",
-      "**/libjsi.so"
+      "**/libjsi.so",
     ]
 
     // In android (instrumental) tests, we want to package all so files to enable our JSI functionality.


### PR DESCRIPTION
# Why

fix android client build error: https://github.com/expo/expo/runs/6557354274?check_suite_focus=true

# How

exclude `libreact_nativemodule_core.so` that is added from cmake linked dependencies

# Test Plan

android client build passed: https://github.com/expo/expo/runs/6567318214?check_suite_focus=true

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
