### PR TITLE
[docs] layout issue in gatsby docs

### DIFF
--- a/docs/pages/guides/using-gatsby.md
+++ b/docs/pages/guides/using-gatsby.md
@@ -39,7 +39,8 @@ For using the Gatsby tools in a universal app with the Expo SDK.
   - using npm - `npm install --save gatsby gatsby-plugin-react-native-web`
 - Create a `gatsby-config.js` and use the plugin - `touch gatsby-config.js`
 
-  `gatsby-config.js`
+
+  **gatsby-config.js**
 
   ```js
   module.exports = {
@@ -66,7 +67,8 @@ For using the Expo SDK in a web-only Gatsby project.
   - using npm - `npm install --save react-native-web gatsby-plugin-react-native-web`
 - Create a `gatsby-config.js` and use the plugin - `touch gatsby-config.js`
 
-  `gatsby-config.js`
+
+  **gatsby-config.js**
 
   ```js
   module.exports = {


### PR DESCRIPTION
# Why

Layout issue displaying filename

![image](https://user-images.githubusercontent.com/852069/169951125-323eaf51-77b9-4368-a1df-a7413a1dbd53.png)


# How

Fixed layout issue

![chrome_1rZyn3TLc0](https://user-images.githubusercontent.com/852069/169951199-6d2601b1-552a-48da-892a-578aa1e1fc5a.png)

# Test Plan

Mk.1 Eyeball

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
