### PR TITLE
[templates] Fix android.kotlinVersion support for expo-build-properties

### DIFF
--- a/templates/expo-template-bare-minimum/android/build.gradle
+++ b/templates/expo-template-bare-minimum/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         minSdkVersion = 21
         compileSdkVersion = Integer.parseInt(findProperty('android.compileSdkVersion') ?: "31")
         targetSdkVersion = Integer.parseInt(findProperty('android.targetSdkVersion') ?: "31")
-        if (hasProperty('android.kotlinVersion')) {
+        if (findProperty('android.kotlinVersion')) {
             kotlinVersion = findProperty('android.kotlinVersion')
         }
 


### PR DESCRIPTION
# Why

fix the `android.kotlinVersion` override from gradle.properties doesn't work.
fix #17564

# How

`hasProperty` is quite different from `findProperty` where hasProperty only queries in current project scope but findProperty can traverse to ancestors.

https://docs.gradle.org/current/javadoc/org/gradle/api/Project.html#findProperty-java.lang.String-

> Returns the value of the given property or null if not found. This method locates a property as follows:
> 
> 1. If this project object has a property with the given name, return the value of the property.
> 2. If this project has an extension with the given name, return the extension.
> 3. If this project's convention object has a property with the given name, return the value of the property.
> 4. If this project has an extra property with the given name, return the value of the property.
> 5. If this project has a task with the given name, return the task.
> 6. Search up through this project's ancestor projects for a convention property or extra property with the given name.
> 7. If not found, null value is returned.

*Search up through this project's ancestor projects for a convention property or extra property with the given name.*

# Test Plan

add `android.kotlinVersion=1.6.21` to android/gradle.properties and check whether the kotlin version is overrode by `./gradlew :app:dependencies | grep 'kotlin'`

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
