### PR TITLE
[ios] Better error handling in the synchronous functions

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Introduce dynamic properties in the Sweet API on iOS. ([#17318](https://github.com/expo/expo/pull/17318) by [@tsapeta](https://github.com/tsapeta))
 - Implemented classes in the Sweet API on iOS. ([#17514](https://github.com/expo/expo/pull/17514), [#17525](https://github.com/expo/expo/pull/17525) by [@tsapeta](https://github.com/tsapeta))
 - Add basic support for sync functions in the Sweet API on Android. ([#16977](https://github.com/expo/expo/pull/16977) by [@lukmccall](https://github.com/lukmccall))
+- Better error handling in the synchronous functions on iOS. ([#17628](https://github.com/expo/expo/pull/17628) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.h
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.h
@@ -1,5 +1,6 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
+#import <Foundation/Foundation.h>
 #import <ExpoModulesCore/EXJavaScriptValue.h>
 #import <ExpoModulesCore/EXJavaScriptObject.h>
 #import <React/RCTBridgeModule.h>
@@ -20,7 +21,8 @@ typedef void (^JSAsyncFunctionBlock)(EXJavaScriptValue * _Nonnull thisValue,
                                      RCTPromiseRejectBlock _Nonnull reject);
 
 typedef id _Nullable (^JSSyncFunctionBlock)(EXJavaScriptValue * _Nonnull thisValue,
-                                            NSArray<EXJavaScriptValue *> * _Nonnull arguments);
+                                            NSArray<EXJavaScriptValue *> * _Nonnull arguments,
+                                            NSError * _Nullable __autoreleasing * _Nullable error);
 
 #ifdef __cplusplus
 typedef jsi::Value (^JSHostFunctionBlock)(jsi::Runtime &runtime,
@@ -76,7 +78,7 @@ NS_SWIFT_NAME(JavaScriptRuntime)
  */
 - (nonnull EXJavaScriptObject *)createSyncFunction:(nonnull NSString *)name
                                          argsCount:(NSInteger)argsCount
-                                             block:(nonnull JSSyncFunctionBlock)block;
+                                             block:(nonnull JSSyncFunctionBlock)block NS_REFINED_FOR_SWIFT;
 
 /**
  Creates an asynchronous host function that runs given block when it's called.

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.mm
@@ -91,7 +91,14 @@ using namespace facebook;
     std::shared_ptr<react::CallInvoker> callInvoker,
     EXJavaScriptValue * _Nonnull thisValue,
     NSArray<EXJavaScriptValue *> * _Nonnull arguments) {
-      return expo::convertObjCObjectToJSIValue(runtime, block(thisValue, arguments));
+      NSError *error;
+      id result = block(thisValue, arguments, &error);
+
+      if (error == nil) {
+        return expo::convertObjCObjectToJSIValue(runtime, result);
+      } else {
+        throw jsi::JSError(runtime, [error.userInfo[@"message"] UTF8String]);
+      }
     };
   return [self createHostFunction:name argsCount:argsCount block:hostFunctionBlock];
 }

--- a/packages/expo-modules-core/ios/JSI/JavaScriptRuntime.swift
+++ b/packages/expo-modules-core/ios/JSI/JavaScriptRuntime.swift
@@ -2,6 +2,11 @@
 
 public extension JavaScriptRuntime {
   /**
+   A type of the closure that you pass to the `createSyncFunction` function.
+   */
+  typealias SyncFunctionClosure = (_ this: JavaScriptValue, _ arguments: [JavaScriptValue]) throws -> Any
+
+  /**
    Evaluates JavaScript code represented as a string.
 
    - Parameter source: A string representing a JavaScript expression, statement, or sequence of statements.
@@ -22,6 +27,28 @@ public extension JavaScriptRuntime {
       return result!
     } catch {
       throw JavaScriptEvalException(error as NSError)
+    }
+  }
+
+  /**
+   Creates a synchronous host function that runs the given closure when it's called.
+   The value returned by the closure is synchronously returned to JS.
+   - Returns: A JavaScript function represented as a `JavaScriptObject`.
+   - Note: It refines the ObjC implementation from `EXJavaScriptRuntime` to properly catch Swift errors and rethrow them as ObjC `NSError`.
+   */
+  func createSyncFunction(_ name: String, argsCount: Int = 0, closure: @escaping SyncFunctionClosure) -> JavaScriptObject {
+    return __createSyncFunction(name, argsCount: argsCount) { this, args, errorPointer in
+      do {
+        return try runWithErrorPointer(errorPointer) {
+          return try closure(this, args)
+        }
+      } catch {
+        // Nicely log all errors to the console.
+        log.error(error)
+
+        // Can return anything as the error will be caught through the error pointer already.
+        return nil
+      }
     }
   }
 }

--- a/packages/expo-modules-core/ios/Swift/Functions/SyncFunctionComponent.swift
+++ b/packages/expo-modules-core/ios/Swift/Functions/SyncFunctionComponent.swift
@@ -83,7 +83,7 @@ public final class SyncFunctionComponent<Args, FirstArgType, ReturnType>: AnySyn
   func build(inRuntime runtime: JavaScriptRuntime) -> JavaScriptObject {
     return runtime.createSyncFunction(name, argsCount: argumentsCount) { [weak self, name] this, args in
       guard let self = self else {
-        return NativeFunctionUnavailableException(name)
+        throw NativeFunctionUnavailableException(name)
       }
       return try self.call(by: this, withArguments: args)
     }

--- a/packages/expo-modules-core/ios/Swift/Functions/SyncFunctionComponent.swift
+++ b/packages/expo-modules-core/ios/Swift/Functions/SyncFunctionComponent.swift
@@ -85,11 +85,7 @@ public final class SyncFunctionComponent<Args, FirstArgType, ReturnType>: AnySyn
       guard let self = self else {
         return NativeFunctionUnavailableException(name)
       }
-      do {
-        return try self.call(by: this, withArguments: args)
-      } catch {
-        return error
-      }
+      return try self.call(by: this, withArguments: args)
     }
   }
 }

--- a/packages/expo-modules-core/ios/Swift/Logging/Logger.swift
+++ b/packages/expo-modules-core/ios/Swift/Logging/Logger.swift
@@ -165,15 +165,16 @@ public class Logger {
     guard type.rawValue >= minLevel.rawValue else {
       return
     }
-    let message = items
-      .map { String(describing: $0) }
+    let messages = items
+      .map { describe(value: $0) }
       .joined(separator: " ")
       .split(whereSeparator: \.isNewline)
       .map { "\(type.prefix) \($0)" }
-      .joined()
 
     handlers.forEach { handler in
-      handler.log(type: type, message)
+      messages.forEach { message in
+        handler.log(type: type, message)
+      }
     }
   }
 
@@ -182,6 +183,16 @@ public class Logger {
   }
 }
 
-private func reformatStackSymbol(_ symbol: String) -> String {
+fileprivate func reformatStackSymbol(_ symbol: String) -> String {
   return symbol.replacingOccurrences(of: #"^\d+\s+"#, with: "", options: .regularExpression)
+}
+
+fileprivate func describe(value: Any) -> String {
+  if let value = value as? CustomDebugStringConvertible {
+    return value.debugDescription
+  }
+  if let value = value as? CustomStringConvertible {
+    return value.description
+  }
+  return String(describing: value)
 }

--- a/packages/expo-modules-core/ios/Swift/Utilities.swift
+++ b/packages/expo-modules-core/ios/Swift/Utilities.swift
@@ -1,0 +1,28 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+/**
+ Executes the given Swift closure and if it throws, the `NSError` is set on the given `NSErrorPointer` and the original error is rethrown.
+ This is especially useful for ObjC<->Swift interop, specifically when the ObjC needs to catch errors thrown by Swift closure.
+ */
+internal func runWithErrorPointer<R>(_ errorPointer: NSErrorPointer, _ closure: () throws -> R) rethrows -> R? {
+  do {
+    return try closure()
+  } catch {
+    errorPointer?.pointee = toNSError(error)
+    throw error
+  }
+}
+
+/**
+ Converts Swift errors to `NSError` so that they can be handled from the ObjC code.
+ */
+internal func toNSError(_ error: Error) -> NSError {
+  if let error = error as? Exception {
+    return NSError(domain: "dev.expo.modules", code: 0, userInfo: [
+      "name": error.name,
+      "code": error.code,
+      "message": error.debugDescription,
+    ])
+  }
+  return error as NSError
+}


### PR DESCRIPTION
# Why

The errors throw from synchronous functions were not passed back to JS

# How

The biggest challenge was to handle errors thrown from Swift closures that are invoked in Objective-C. When Swift functions are translated to Objective-C, the "throws" keyword is replaced by additional argument of type `NSError **`, but this works only for functions that return `void` or `BOOL` values, otherwise the closure needs to take the `NSErrorPointer` argument instead of throwing.
I don't want to do this work for each `createSyncFunction` call, so I decided to use the [`NS_REFINED_FOR_SWIFT` macro](https://developer.apple.com/documentation/swift/objective-c_and_c_code_customization/improving_objective-c_api_declarations_for_swift) and redefine the `createSyncFunction` in Swift as part of the `JavaScriptRuntime` extension.

# Test Plan

Added simple test to check if the synchronous function throws a JS error. Also checked this locally by throwing an error from `expo-random`:

![Screen Shot 2022-05-24 at 11 46 33](https://user-images.githubusercontent.com/1714764/170044516-601a7071-256a-4c17-82ef-38c3de1ca0be.png)
