### PR TITLE
[ios] Convenience function to evaluate multiline source code

### DIFF
--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.h
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.h
@@ -102,6 +102,6 @@ typedef void (^ClassConstructorBlock)(EXJavaScriptObject * _Nonnull thisValue, N
 /**
  Evaluates given JavaScript source code.
  */
-- (nonnull EXJavaScriptValue *)evaluateScript:(nonnull NSString *)scriptSource;
+- (nonnull EXJavaScriptValue *)evaluateScript:(nonnull NSString *)scriptSource NS_REFINED_FOR_SWIFT;
 
 @end

--- a/packages/expo-modules-core/ios/JSI/JavaScriptRuntime.swift
+++ b/packages/expo-modules-core/ios/JSI/JavaScriptRuntime.swift
@@ -21,13 +21,22 @@ public extension JavaScriptRuntime {
     do {
       var result: JavaScriptValue?
       try EXUtilities.catchException {
-        result = self.evaluateScript(source)
+        result = self.__evaluateScript(source)
       }
       // There is no risk to force unwrapping as long as the `evaluateScript` returns nonnull value.
       return result!
     } catch {
       throw JavaScriptEvalException(error as NSError)
     }
+  }
+
+  /**
+   Evaluates the JavaScript code made by joining an array of strings with a newline separator.
+   See the other ``eval(_:)`` for more details.
+   */
+  @discardableResult
+  func eval(_ source: [String]) throws -> JavaScriptValue {
+    try eval(source.joined(separator: "\n"))
   }
 
   /**

--- a/packages/expo-modules-core/ios/Tests/ClassComponentSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/ClassComponentSpec.swift
@@ -91,8 +91,10 @@ class ClassComponentSpec: ExpoSpec {
       }
 
       it("is an instance of") {
-        try runtime?.eval("myObject = new ExpoModules.ClassTest.MyClass()")
-        let isInstanceOf = try runtime?.eval("myObject instanceof ExpoModules.ClassTest.MyClass")
+        let isInstanceOf = try runtime?.eval([
+          "myObject = new ExpoModules.ClassTest.MyClass()",
+          "myObject instanceof ExpoModules.ClassTest.MyClass",
+        ])
 
         expect(isInstanceOf?.getBool()) == true
       }
@@ -130,21 +132,27 @@ class ClassComponentSpec: ExpoSpec {
         expect(SharedObjectRegistry.size) == oldSize + 1
       }
       it("calls function with owner") {
-        try runtime?.eval("object = new ExpoModules.TestModule.Counter(0)")
-        try runtime?.eval("object.increment(1)")
+        try runtime?.eval([
+          "object = new ExpoModules.TestModule.Counter(0)",
+          "object.increment(1)",
+        ])
         // no expectations, just checking if it doesn't fail
       }
       it("creates with initial value") {
         let initialValue = Int.random(in: 1..<100)
-        try runtime?.eval("object = new ExpoModules.TestModule.Counter(\(initialValue))")
-        let value = try runtime!.eval("object.getValue()")
+        let value = try runtime!.eval([
+          "object = new ExpoModules.TestModule.Counter(\(initialValue))",
+          "object.getValue()",
+        ])
 
         expect(value.kind) == .number
         expect(value.getInt()) == initialValue
       }
       it("gets shared object value") {
-        try! runtime?.eval("object = new ExpoModules.TestModule.Counter(0)")
-        let value = try runtime!.eval("object.getValue()")
+        let value = try runtime!.eval([
+          "object = new ExpoModules.TestModule.Counter(0)",
+          "object.getValue()",
+        ])
 
         expect(value.kind) == .number
         expect(value.isNumber()) == true
@@ -153,8 +161,10 @@ class ClassComponentSpec: ExpoSpec {
         try! runtime?.eval("object = new ExpoModules.TestModule.Counter(0)")
         let incrementBy = Int.random(in: 1..<100)
         let value = try runtime!.eval("object.getValue()").asInt()
-        try runtime?.eval("object.increment(\(incrementBy))")
-        let newValue = try runtime!.eval("object.getValue()")
+        let newValue = try runtime!.eval([
+          "object.increment(\(incrementBy))",
+          "object.getValue()",
+        ])
 
         expect(newValue.kind) == .number
         expect(newValue.getInt()) == value + incrementBy


### PR DESCRIPTION
# Why

It seems to be handy for some tests that require more complex source code to evaluate

# How

- Added a convenient `eval(_ source: [String])` function that joins the array with a newline separator and runs `eval(_ source: String)`.
- Marked `evaluateScript` with `NS_REFINED_FOR_SWIFT` to hide the Objective-C implementation from Swift.
- Updated some tests to use this function.

# Test Plan

Unit tests are passing
