### PR TITLE
[templates] Update outdated fresco versions on android

### DIFF
--- a/templates/expo-template-bare-minimum/android/app/build.gradle
+++ b/templates/expo-template-bare-minimum/android/app/build.gradle
@@ -294,25 +294,25 @@ dependencies {
     def isGifEnabled = (findProperty('expo.gif.enabled') ?: "") == "true";
     def isWebpEnabled = (findProperty('expo.webp.enabled') ?: "") == "true";
     def isWebpAnimatedEnabled = (findProperty('expo.webp.animated') ?: "") == "true";
+    def frescoVersion = rootProject.ext.frescoVersion
 
     // If your app supports Android versions before Ice Cream Sandwich (API level 14)
-    // All fresco packages should use the same version
     if (isGifEnabled || isWebpEnabled) {
-        implementation 'com.facebook.fresco:fresco:2.0.0'
-        implementation 'com.facebook.fresco:imagepipeline-okhttp3:2.0.0'
+        implementation "com.facebook.fresco:fresco:${frescoVersion}"
+        implementation "com.facebook.fresco:imagepipeline-okhttp3:${frescoVersion}"
     }
 
     if (isGifEnabled) {
         // For animated gif support
-        implementation 'com.facebook.fresco:animated-gif:2.0.0'
+        implementation "com.facebook.fresco:animated-gif:${frescoVersion}"
     }
 
     if (isWebpEnabled) {
         // For webp support
-        implementation 'com.facebook.fresco:webpsupport:2.0.0'
+        implementation "com.facebook.fresco:webpsupport:${frescoVersion}"
         if (isWebpAnimatedEnabled) {
             // Animated webp support
-            implementation 'com.facebook.fresco:animated-webp:2.0.0'
+            implementation "com.facebook.fresco:animated-webp:${frescoVersion}"
         }
     }
 

--- a/templates/expo-template-bare-minimum/android/build.gradle
+++ b/templates/expo-template-bare-minimum/android/build.gradle
@@ -4,20 +4,21 @@ import org.apache.tools.ant.taskdefs.condition.Os
 
 buildscript {
     ext {
-        buildToolsVersion = findProperty('android.buildToolsVersion') ?: "31.0.0"
+        buildToolsVersion = findProperty('android.buildToolsVersion') ?: '31.0.0'
         minSdkVersion = 21
-        compileSdkVersion = Integer.parseInt(findProperty('android.compileSdkVersion') ?: "31")
-        targetSdkVersion = Integer.parseInt(findProperty('android.targetSdkVersion') ?: "31")
+        compileSdkVersion = Integer.parseInt(findProperty('android.compileSdkVersion') ?: '31')
+        targetSdkVersion = Integer.parseInt(findProperty('android.targetSdkVersion') ?: '31')
         if (findProperty('android.kotlinVersion')) {
             kotlinVersion = findProperty('android.kotlinVersion')
         }
+        frescoVersion = findProperty('expo.frescoVersion') ?: '2.5.0'
 
-        if (System.properties['os.arch'] == "aarch64") {
+        if (System.properties['os.arch'] == 'aarch64') {
             // For M1 Users we need to use the NDK 24 which added support for aarch64
-            ndkVersion = "24.0.8215888"
+            ndkVersion = '24.0.8215888'
         } else {
             // Otherwise we default to the side-by-side NDK version from AGP.
-            ndkVersion = "21.4.7075529"
+            ndkVersion = '21.4.7075529'
         }
     }
     repositories {
@@ -25,9 +26,9 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:7.0.4")
-        classpath("com.facebook.react:react-native-gradle-plugin")
-        classpath("de.undercouch:gradle-download-task:4.1.2")
+        classpath('com.android.tools.build:gradle:7.0.4')
+        classpath('com.facebook.react:react-native-gradle-plugin')
+        classpath('de.undercouch:gradle-download-task:4.1.2')
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
@@ -38,11 +39,11 @@ allprojects {
         mavenLocal()
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-            url(new File(["node", "--print", "require.resolve('react-native/package.json')"].execute(null, rootDir).text.trim(), "../android"))
+            url(new File(['node', '--print', "require.resolve('react-native/package.json')"].execute(null, rootDir).text.trim(), '../android'))
         }
         maven {
             // Android JSC is installed from npm
-            url(new File(["node", "--print", "require.resolve('jsc-android/package.json')"].execute(null, rootDir).text.trim(), "../dist"))
+            url(new File(['node', '--print', "require.resolve('jsc-android/package.json')"].execute(null, rootDir).text.trim(), '../dist'))
         }
 
         google()
@@ -50,7 +51,7 @@ allprojects {
             // We don't want to fetch react-native from Maven Central as there are
             // older versions over there.
             content {
-                excludeGroup "com.facebook.react"
+                excludeGroup 'com.facebook.react'
             }
         }
         maven { url 'https://www.jitpack.io' }


### PR DESCRIPTION
# Why

fix broken gif animation
fix #17627
close ENG-5104

# How

- update fresco version align with react-native 0.68 (fresco 2.5.0)
- add `expo.frescoVersion` for overriding the default version if needed
- use single quote as much as possible in android/build.gradle

# Test Plan

clone https://github.com/Chrissi2812/expo-issue-repro/tree/eas-gif-not-animated and apply the template patches after prebuilding.

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
