### PR TITLE
[templates] Support `pod install --project-directory=ios`

### DIFF
--- a/templates/expo-template-bare-minimum/ios/Podfile
+++ b/templates/expo-template-bare-minimum/ios/Podfile
@@ -3,7 +3,7 @@ require File.join(File.dirname(`node --print "require.resolve('react-native/pack
 require File.join(File.dirname(`node --print "require.resolve('@react-native-community/cli-platform-ios/package.json')"`), "native_modules")
 
 require 'json'
-podfile_properties = JSON.parse(File.read('./Podfile.properties.json')) rescue {}
+podfile_properties = JSON.parse(File.read(File.join(__dir__, 'Podfile.properties.json'))) rescue {}
 
 platform :ios, podfile_properties['ios.deploymentTarget'] || '12.0'
 install! 'cocoapods',


### PR DESCRIPTION
# Why

when running `pod install --project-directory=ios` out from ios/ directory, `Podfile.properties.json` is not correctly read.

# How

instead of using current directory, we should use the path relative to Podfile

# Test Plan

having a /app/ios/Podfile.properties.json

```json
{
  "expo.jsEngine": "hermes"
}
```

make sure hermes-engine is installed
```
$ cd /app
$ pod install --project-directory=ios
```


# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
