### PR TITLE
[docs] fix sample code for firebase analytics screen view

### DIFF
--- a/docs/pages/versions/unversioned/sdk/firebase-analytics.md
+++ b/docs/pages/versions/unversioned/sdk/firebase-analytics.md
@@ -143,7 +143,7 @@ export default () => (
       const prevScreen = getActiveRouteName(prevState);
       if (prevScreen !== currentScreen) {
         // Update Firebase with the name of your screen
-        Analytics.logEvent('screen view', { currentScreen });
+        await Analytics.logEvent('screen_view', { currentScreen });
       }
     }}
   />

--- a/docs/pages/versions/v45.0.0/sdk/firebase-analytics.md
+++ b/docs/pages/versions/v45.0.0/sdk/firebase-analytics.md
@@ -143,7 +143,7 @@ export default () => (
       const prevScreen = getActiveRouteName(prevState);
       if (prevScreen !== currentScreen) {
         // Update Firebase with the name of your screen
-        Analytics.logEvent('screen view', { currentScreen });
+        await Analytics.logEvent('screen_view', { currentScreen });
       }
     }}
   />


### PR DESCRIPTION
# Why

The existing sample throws an error:

> [Unhandled promise rejection: Error: Invalid event-name (screen view) specified. Should contain 1 to 40 alphanumeric characters or underscores. The name must start with an alphabetic character.]


# How

- After checking the my report from existing implementation, I found `screen_view` to be the correct key instead of `screen view`.
- Also added `await` to be consistent with the docs from `React Navigation`: https://reactnavigation.org/docs/screen-tracking/


# Test Plan

N.A.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
