### PR TITLE
[test-core][android] Support testing sync functions

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
@@ -67,7 +67,9 @@ class ModuleHolder(val module: Module) {
    * Invokes a function without promise.
    * `callSync` was added only for test purpose and shouldn't be used anywhere else.
    */
-  internal fun callSync(methodName: String, args: ReadableArray): ReadableNativeArray {
+  fun callSync(methodName: String, args: ReadableArray): Any? = exceptionDecorator({
+    FunctionCallException(methodName, definition.name, it)
+  }) {
     val method = definition.methods[methodName]
       ?: throw MethodNotFoundException()
 
@@ -76,9 +78,7 @@ class ModuleHolder(val module: Module) {
     }
 
     val result = method.callSync(this, args)
-    val convertedResult = JSTypeConverter.convertToJSValue(result)
-
-    return Arguments.fromJavaArgs(arrayOf(convertedResult))
+    JSTypeConverter.convertToJSValue(result)
   }
 
   fun post(eventName: EventName) {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
@@ -2,7 +2,6 @@ package expo.modules.kotlin
 
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReadableArray
-import com.facebook.react.bridge.ReadableNativeArray
 import expo.modules.kotlin.events.BasicEventListener
 import expo.modules.kotlin.events.EventListenerWithPayload
 import expo.modules.kotlin.events.EventListenerWithSenderAndPayload

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AnyFunction.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AnyFunction.kt
@@ -16,7 +16,7 @@ abstract class AnyFunction(
   private val desiredArgsTypes: Array<AnyType>,
   isSync: Boolean = false
 ) {
-  internal var isSync = isSync
+  var isSync = isSync
     private set
 
   fun runSynchronously() = apply {

--- a/packages/expo-modules-test-core/android/build.gradle
+++ b/packages/expo-modules-test-core/android/build.gradle
@@ -98,3 +98,13 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
   implementation "org.jetbrains.kotlin:kotlin-reflect:${getKotlinVersion()}"
 }
+
+/**
+ * To make the users of annotations @OptIn and @RequiresOptIn aware of their experimental status,
+ * the compiler raises warnings when compiling the code with these annotations:
+ * This class can only be used with the compiler argument '-Xopt-in=kotlin.RequiresOptIn'
+ * To remove the warnings, we add the compiler argument -Xopt-in=kotlin.RequiresOptIn.
+ */
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+  kotlinOptions.freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
+}

--- a/packages/expo-modules-test-core/android/src/main/java/expo/modules/test/core/PromiseMock.kt
+++ b/packages/expo-modules-test-core/android/src/main/java/expo/modules/test/core/PromiseMock.kt
@@ -10,6 +10,11 @@ enum class PromiseState {
   ILLEGAL
 }
 
+/**
+ * The [Promise] mock that should be used in conjunction with promise-mapped functions
+ * in the module test interface. See [ModuleMockInvocationHandler] documentation for more details
+ * @see ModuleMockInvocationHandler
+ */
 class PromiseMock : Promise {
 
   var state = PromiseState.NONE

--- a/packages/expo-modules-test-core/android/src/main/java/expo/modules/test/core/TestJSContainerProvider.kt
+++ b/packages/expo-modules-test-core/android/src/main/java/expo/modules/test/core/TestJSContainerProvider.kt
@@ -6,7 +6,7 @@ import com.facebook.react.bridge.WritableArray
 import com.facebook.react.bridge.WritableMap
 import expo.modules.kotlin.types.JSTypeConverter
 
-object TestJSContainerProvider : JSTypeConverter.ContainerProvider {
+internal object TestJSContainerProvider : JSTypeConverter.ContainerProvider {
   override fun createMap(): WritableMap = JavaOnlyMap()
   override fun createArray(): WritableArray = JavaOnlyArray()
 }

--- a/packages/expo-modules-test-core/android/src/main/java/expo/modules/test/core/TestUtils.kt
+++ b/packages/expo-modules-test-core/android/src/main/java/expo/modules/test/core/TestUtils.kt
@@ -3,51 +3,45 @@ package expo.modules.test.core
 import expo.modules.kotlin.exception.CodedException
 import org.junit.Assert
 import java.lang.reflect.UndeclaredThrowableException
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 
-fun assertResolved(promise: PromiseMock) {
-  Assert.assertEquals(PromiseState.RESOLVED, promise.state)
-}
-
-fun assertRejected(promise: PromiseMock) {
-  Assert.assertEquals(PromiseState.REJECTED, promise.state)
-}
-
-inline fun <reified ResolveType> promiseResolved(promise: PromiseMock, with: (ResolveType) -> Unit) {
-  assertResolved(promise)
-  Assert.assertTrue(
-    "Promise resolved with incorrect type: ${ResolveType::class.simpleName}",
-    promise.resolveValue is ResolveType
-  )
-  with(promise.resolveValue as ResolveType)
-}
-
-fun promiseRejected(promise: PromiseMock, with: (PromiseMock) -> Unit) {
-  assertRejected(promise)
-  with(promise)
-}
-
-fun assertRejectedWithCode(promise: PromiseMock, rejectCode: String) {
-  promiseRejected(promise) {
-    Assert.assertTrue("Promise has no rejection code", it.rejectCodeSet)
-    Assert.assertEquals(it.rejectCode, rejectCode)
+/**
+ * Asserts that provided [exception] is a [CodedException] and
+ */
+@OptIn(ExperimentalContracts::class)
+fun assertCodedException(exception: Throwable?) {
+  contract {
+    returns() implies (exception is CodedException)
   }
-}
 
-inline fun assertCodedException(exception: Throwable?, block: (exception: CodedException) -> Unit = {}) {
   Assert.assertNotNull("Expected exception, received null", exception)
 
   if (exception is UndeclaredThrowableException) {
     Assert.fail(
-      "Expected CodedException, got UndeclaredThrowableException. " +
-        "Did you forget to add '@Throws' annotations to module test interface methods?"
+            "Expected CodedException, got UndeclaredThrowableException. " +
+                    "Did you forget to add '@Throws' annotations to module test interface methods?"
     )
   }
 
   if (exception !is CodedException) {
     Assert.fail(
-      "Expected CodedException, got ${exception!!::class.simpleName}. " +
-        "Full stack trace:\n${exception.stackTraceToString()}"
+            "Expected CodedException, got ${exception!!::class.simpleName}. " +
+                    "Full stack trace:\n${exception.stackTraceToString()}"
     )
   }
-  block(exception as CodedException)
+}
+
+/**
+ * Asserts that provided [exception] is a [CodedException] and then executes a block with
+ * the [exception] as an argument
+ */
+@OptIn(ExperimentalContracts::class)
+inline fun assertCodedException(exception: Throwable?, block: (exception: CodedException) -> Unit) {
+  contract {
+    callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+  }
+  assertCodedException(exception)
+  block(exception)
 }

--- a/packages/expo-modules-test-core/android/src/main/java/expo/modules/test/core/TestUtils.kt
+++ b/packages/expo-modules-test-core/android/src/main/java/expo/modules/test/core/TestUtils.kt
@@ -8,7 +8,7 @@ import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
 /**
- * Asserts that provided [exception] is a [CodedException] and
+ * Asserts that provided [exception] is a [CodedException]
  */
 @OptIn(ExperimentalContracts::class)
 fun assertCodedException(exception: Throwable?) {

--- a/packages/expo-modules-test-core/android/src/main/java/expo/modules/test/core/TestUtils.kt
+++ b/packages/expo-modules-test-core/android/src/main/java/expo/modules/test/core/TestUtils.kt
@@ -20,15 +20,15 @@ fun assertCodedException(exception: Throwable?) {
 
   if (exception is UndeclaredThrowableException) {
     Assert.fail(
-            "Expected CodedException, got UndeclaredThrowableException. " +
-                    "Did you forget to add '@Throws' annotations to module test interface methods?"
+      "Expected CodedException, got UndeclaredThrowableException. " +
+        "Did you forget to add '@Throws' annotations to module test interface methods?"
     )
   }
 
   if (exception !is CodedException) {
     Assert.fail(
-            "Expected CodedException, got ${exception!!::class.simpleName}. " +
-                    "Full stack trace:\n${exception.stackTraceToString()}"
+      "Expected CodedException, got ${exception!!::class.simpleName}. " +
+        "Full stack trace:\n${exception.stackTraceToString()}"
     )
   }
 }


### PR DESCRIPTION
# Why

Resolves ENG-5058

# How

- `ModuleHolder` already had support for test sync calls, but it was unused
- Adopted `ModuleMockInvocationHandler` to support sync calls
- Deleted unused utils code from tests-core. We prefer to use a promise-less testing approach, but still not sure if deleting it is a good move.
- Leveraged Kotlin [Contracts API](https://www.baeldung.com/kotlin/contracts) in some test utils to make testing more convenient:
  ```kt
  val exception: Throwable? = runCatching { ... }.exceptionOrNull()
  assertCodedException(exception) // contract inside this assert
  exception.code // compiles, now Kotlin knows that `exception` is a `CodedException` instance
  ```

# Test Plan

```kt
// inside module
function("doubleSync") { num: Int ->
  num * 2
}.runSynchronously()

// test interface
private interface MyModuleTestInterface {
  @Throws(CodedException::class)
  fun doubleSync(input: Int): Int
}

// test
@Test
fun syncFnTest() = withMyModuleMock {
  val result = module.doubleSync(3)
  assertEquals(6, result)
}
```

<!-- disable:changelog-checks -->
