### PR TITLE
[bare-expo][Android] Solution for `rn-screens` problem https://github.com/software-mansion/react-native-screens/issues/17#issuecomment-424704067

### DIFF
--- a/apps/bare-expo/android/app/src/main/java/dev/expo/payments/MainActivity.java
+++ b/apps/bare-expo/android/app/src/main/java/dev/expo/payments/MainActivity.java
@@ -1,6 +1,5 @@
 package dev.expo.payments;
 
-import android.app.Activity;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.net.Uri;
@@ -23,8 +22,14 @@ public class MainActivity extends ReactActivity {
   }
 
   @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    // https://github.com/software-mansion/react-native-screens/issues/17#issuecomment-424704067
+    // https://reactnavigation.org/docs/getting-started/#installing-dependencies-into-a-bare-react-native-project
+    super.onCreate(null);
+  }
+
+  @Override
   protected ReactActivityDelegate createReactActivityDelegate() {
-    Activity activity = this;
     ReactActivityDelegate delegate = new ReactActivityDelegateWrapper(this, BuildConfig.IS_NEW_ARCHITECTURE_ENABLED,
       new ReactActivityDelegate(this, getMainComponentName()) {
       @Override


### PR DESCRIPTION
# Why

`rn-screens` and thus `react-navigation` disallow restoring `savedInstanceState` in `onCreate` lifecycle method on Android:
- https://github.com/software-mansion/react-native-screens/issues/17#issuecomment-424704067
- https://reactnavigation.org/docs/getting-started/#installing-dependencies-into-a-bare-react-native-project

# How

Applied suggestion from:
https://reactnavigation.org/docs/getting-started/#installing-dependencies-into-a-bare-react-native-project

# Test Plan

1. Go to Android settings -> Developer options -> turn on `Don't keep activities` that forces Android OS to kill every activity that looses focus (when `onStop` lifecycle method happens `onDestroy` is forced as well)
2. Background and then foreground the `bare-expo`
  - crashes without this change
  - is properly resumed with this change