### PR TITLE
[clipboard][android] Fix event content type for image

### DIFF
--- a/packages/expo-clipboard/CHANGELOG.md
+++ b/packages/expo-clipboard/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed clipboard listener returning invalid `contentTypes` value for images on Android.
+
 ### 💡 Others
 
 - Migrated Expo modules definitions to the new naming convention. ([#17193](https://github.com/expo/expo/pull/17193) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo-clipboard/CHANGELOG.md
+++ b/packages/expo-clipboard/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed clipboard listener returning invalid `contentTypes` value for images on Android.
+- Fixed clipboard listener returning invalid `contentTypes` value for images on Android. ([#17644](https://github.com/expo/expo/pull/17644) by [@barthap](https://github.com/barthap))
 
 ### 💡 Others
 

--- a/packages/expo-clipboard/android/src/main/java/expo/modules/clipboard/ClipboardModule.kt
+++ b/packages/expo-clipboard/android/src/main/java/expo/modules/clipboard/ClipboardModule.kt
@@ -188,7 +188,7 @@ class ClipboardModule : Module() {
               "contentTypes" to listOfNotNull(
                 ContentType.PLAIN_TEXT.takeIf { clip.hasTextContent },
                 ContentType.HTML.takeIf { clip.hasMimeType(ClipDescription.MIMETYPE_TEXT_HTML) },
-                ContentType.HTML.takeIf { clip.hasMimeType("image/*") }
+                ContentType.IMAGE.takeIf { clip.hasMimeType("image/*") }
               ).map { it.jsName }
             )
           )


### PR DESCRIPTION
# Why

Noticed that the `IMAGE` enum value was unused, turned out to be a "copy monkey" bug 🐵 

# How

Used a correct enum value in the listener

# Test Plan

None