### PR TITLE
[docs] add autolinking error to dev client troubleshooting page

### DIFF
--- a/docs/pages/development/troubleshooting.md
+++ b/docs/pages/development/troubleshooting.md
@@ -9,3 +9,21 @@ If you're not able to resolve your issue, please [let us know!](https://github.c
 ### The keyboard shortcuts for the Dev Menu don't work reliably in my iOS simulator
 
 Make sure you have "Send keyboard input to device" enabled for the simulator. This option can be found under I/O > Input in the menu.
+
+### I am getting a build error from Swift on the line `import expo-dev-launcher`
+
+If you are building for iOS and getting an error that looks something like this:
+
+```
+❌  (ios/Pods/Target Support Files/Pods-yourproject/ExpoModulesProvider.swift:11:12)
+
+> 11 | import expo-dev-launcher
+     |            ^ consecutive statements on a line must be separated by ';'
+  12 | import expo-dev-menu
+```
+
+you have an outdated version of `expo-modules-autolinking` (below 0.7.x) installed as a transitive dependency in your project.
+
+A common reason for this is installing `expo-cli` or `eas-cli` as dependencies of your project, rather than globally as we recommend; removing those packages should fix the error.
+
+Otherwise, run `yarn why expo-modules-autolinking` to see where the outdated version is coming from, and upgrade that package to the latest version.


### PR DESCRIPTION
# Why

We've now seen this error come up a few times, document it so the solution is at least discoverable somewhere.

# How

Add the error message (so it's google-able) and the resolution steps to the dev client troubleshooting page.

# Test Plan

`yarn run dev`
<img width="1268" alt="Screen Shot 2022-05-25 at 11 05 42 AM" src="https://user-images.githubusercontent.com/19958240/170334469-1460b2f4-52f4-423c-be9b-99a2c3b7165b.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
