### PR TITLE
[expo-dev-launcher] stop persisting remote debugging on iOS

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Stop persisting remote debugging setting between app loads on iOS.
+- Stop persisting remote debugging setting between app loads on iOS. ([#17650](https://github.com/expo/expo/pull/17650) by [@esamelson](https://github.com/esamelson))
 
 ## 0.11.6 — 2022-05-19
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Stop persisting remote debugging setting between app loads on iOS.
+
 ## 0.11.6 — 2022-05-19
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -334,6 +334,7 @@
  */
 - (void)loadApp:(NSURL *)expoUrl withProjectUrl:(NSURL * _Nullable)projectUrl onSuccess:(void (^ _Nullable)(void))onSuccess onError:(void (^ _Nullable)(NSError *error))onError
 {
+  [self _resetRemoteDebuggingForAppLoad];
   _possibleManifestURL = expoUrl;
   BOOL isEASUpdate = [self isEASUpdateURL:expoUrl];
   
@@ -688,6 +689,25 @@
   [updatesConfig setObject:@(usesEASUpdates) forKey:@"usesEASUpdates"];
     
   return updatesConfig;
+}
+
+/**
+ * Reset remote debugging to its initial setting. Relies on behavior from react-native's
+ * RCTDevSettings.mm and must be kept in sync there.
+ */
+- (void)_resetRemoteDebuggingForAppLoad
+{
+  // Must be kept in sync with RCTDevSettings.mm
+  NSString *kRCTDevSettingsUserDefaultsKey = @"RCTDevMenu";
+  NSString *kRCTDevSettingIsDebuggingRemotely = @"isDebuggingRemotely";
+
+  NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
+  NSMutableDictionary *existingSettings = ((NSDictionary *)[userDefaults objectForKey:kRCTDevSettingsUserDefaultsKey]).mutableCopy;
+  if (!existingSettings) {
+    return;
+  }
+  [existingSettings removeObjectForKey:kRCTDevSettingIsDebuggingRemotely];
+  [userDefaults setObject:existingSettings forKey:kRCTDevSettingsUserDefaultsKey];
 }
 
 


### PR DESCRIPTION
# Why

resolves ENG-5008

This fixes the issue in 5008, as well as a related issue I discovered (turning on remote debugging and then just going back & forth between the launcher screen and a development bundle causes frequent failures) by just turning remote debugging off before every app load.

This change is iOS only for now, as I was not able to reproduce 5008 on Android, and making this change on Android actually made remote debugging a **worse** experience.

# How

Remove the `isDebuggingRemotely` setting from NSUserDefaults before each app load.

# Test Plan

- open a locally served app in development, turn on remote debugging
- toggle it off and on a few times, then leave it on
- go back to launcher
- open the same app again
- remote debugging should be off (you can tell from expo-cli logs)
- go back to launcher
- open a published update, see that it loads

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
