### PR TITLE
[android][camera] fix barcode scanned only once

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### 🐛 Bug fixes
 
+- Fix bug on Android that would only allow you to scan one bar code. ([#17655](https://github.com/expo/expo/pull/17655) by [@witheroux](https://github.com/witheroux))
+
+
 ### 💡 Others
 
 ## 12.2.0 — 2022-04-18

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -10,7 +10,6 @@
 
 - Fix bug on Android that would only allow you to scan one bar code. ([#17655](https://github.com/expo/expo/pull/17655) by [@witheroux](https://github.com/witheroux))
 
-
 ### 💡 Others
 
 ## 12.2.0 — 2022-04-18

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/tasks/BarCodeScannerAsyncTask.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/tasks/BarCodeScannerAsyncTask.kt
@@ -21,6 +21,7 @@ class BarCodeScannerAsyncTask(
     super.onPostExecute(result)
     result?.let {
       delegate.onBarCodeScanned(result)
-    } ?: delegate.onBarCodeScanningTaskCompleted()
+    }
+    delegate.onBarCodeScanningTaskCompleted()
   }
 }


### PR DESCRIPTION
# Why

Ever since the rewrite to kotlin, the bar code scanning functionality of the camera package stops after one successful scan instead of being continuous. The previous version of the package was working with multiple continuous scans. This was also reported in GitHub issue #16126.

# How

Knowing that the previous version in Java was working as intended, I compared the java code to the kotlin code and noticed that the conversion changed the way the lock was handled after a successful scan. This was noted in [a comment in the previously mentioned issue](https://github.com/expo/expo/issues/16126#issuecomment-1136311273 ).

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
