### PR TITLE
[docs] EAS Update: formatting tweaks and changes

### DIFF
--- a/docs/pages/eas-update/deployment-patterns.md
+++ b/docs/pages/eas-update/deployment-patterns.md
@@ -6,22 +6,21 @@ import ImageSpotlight from '~/components/plugins/ImageSpotlight'
 
 > EAS Update is currently available only to customers with an EAS subscription plan. [Sign up](https://expo.dev/accounts/[account]/settings/subscriptions).
 
-Once we've created features and fixed bugs in our app, we want to deliver those features and bug fixes out to our users as quickly and safely as we can. Often "safe" and "fast" are opposing forces when delivering code to our users. We could push our code directly to production, which would be fast yet less safe since we never tested our code. On the other hand, we could make test builds, share them with a QA team, and release periodically, which would be safer but slower to deliver changes to our users.
+Once we've created features and fixed bugs in our app, we want to deliver those features and bug fixes out to our users as quickly and safely as we can. Often "safe" and "fast" are opposing forces when delivering code to our users. 
+We could push our code directly to production, which would be fast yet less safe since we never tested our code. On the other hand, we could make test builds, share them with a QA team, and release periodically, which would be safer but slower to deliver changes to our users.
 
 Depending on your project, you'll have some tolerance for how "fast" and how "safe" you'll need to be when delivering updates to your users.
 
 There are three parts to consider when designing a EAS Update deployment process:
 
-1. Creating builds
-
+1. **Creating builds**
    - (a) We can create builds for production use only.
    - (b) We can create builds for production use and separate builds for pre-production change testing.
-
-2. Testing changes
+2. **Testing changes**
    - (a) We can test changes with TestFlight and Play Store Internal Track.
    - (b) We can test changes with an internal distribution build.
    - (c) We can test changes with Expo Go or a development app.
-3. Publishing updates
+3. **Publishing updates**
    - (a) We can publish updates to a single branch.
    - (b) We can create update branches that are environment-based, like "production" and "staging".
    - (c) We can create update branches that are version-based, like "version-1.0", which enables us to promote updates from one channel to another.
@@ -36,28 +35,28 @@ Below, we've outlined four common patterns on how to deploy a project with Expo 
 
 This flow is the simplest and fastest flow, with the fewest amount of safety checks. It's great for trying out Expo and for smaller projects. Here are the parts of the deployment process above that make up this flow:
 
-Creating builds: (a) Create builds for production use only.
+**Creating builds:** (a) Create builds for production use only.
 
-Testing changes: (c) Test changes with Expo Go or a development app.
+**Testing changes:** (c) Test changes with Expo Go or a development app.
 
-Publishing updates: (a) Publish to a single branch.
+**Publishing updates:** (a) Publish to a single branch.
 
-Diagram of flow:
+### Diagram of flow
 
 <ImageSpotlight alt="Two command deployment diagram" src="/static/images/eas-update/deployment-two-command.png" style={{maxWidth: 1200}} />
 
-Explanation of flow:
+### Explanation of flow
 
 1. Develop a project locally and test changes in Expo Go.
 2. Run `eas build` to create builds, then submit them to app stores. These builds are for public use, and should be submitted/reviewed, and released on the app stores.
 3. When we have updates we'd like to deliver, run `eas update --branch production` to deliver updates to our users immediately.
 
-Advantages of this flow:
+#### Advantages of this flow
 
 - This flow does not require bookkeeping extra version or environment names, which makes it easy to communicate to others.
 - Delivering updates to builds is very fast.
 
-Disadvantages of this flow:
+#### Disadvantages of this flow
 
 - There are no pre-production checks to make sure the code will function as intended. We can test with Expo Go or a development app, but this is less safe than having a dedicated test environment.
 
@@ -65,17 +64,17 @@ Disadvantages of this flow:
 
 This flow is great for managing versioned releases. Here are the parts of the deployment process above that make up this flow:
 
-Creating builds: (b) Create builds for production and separate builds for testing.
+**Creating builds:** (b) Create builds for production and separate builds for testing.
 
-Testing changes: (a) Test changes on TestFlight and the Play Store Internal Track and/or (b) Test changes with internal distribution builds.
+**Testing changes:** (a) Test changes on TestFlight and the Play Store Internal Track and/or (b) Test changes with internal distribution builds.
 
-Publishing updates: (c) Create update branches that are version based, like "version-1.0".
+**Publishing updates:** (c) Create update branches that are version based, like "version-1.0".
 
-Diagram of flow:
+### Diagram of flow
 
 <ImageSpotlight alt="Branch deployment diagram" src="/static/images/eas-update/deployment-branch.png" style={{maxWidth: 1200}} />
 
-Explanation of flow:
+### Explanation of flow
 
 1. Develop a project locally and test changes in Expo Go.
 2. Create builds with channels named "production", which will eventually get reviewed and become available on app stores. Create another set of builds with channels named "staging", which will be used for testing on TestFlight and the Play Store Internal Track.
@@ -86,13 +85,14 @@ Explanation of flow:
 7. Then, create another GitHub branch named "version-1.1", and merge commits until the new features and fixes are ready. When they are, use the website or EAS CLI to point the "staging" channel at the EAS Update branch "version-1.1".
 8. When ready, use the website or EAS CLI to point the "production" channel at the EAS Update branch "version-1.1".
 
-Advantages of this flow:
+#### Advantages of this flow
 
 - This flow is safer than the other flows. All updates are tested on test builds, and branches are moved between channels, so the exact artifact tested is the one deployed to production builds.
-- This flow creates a direct mapping between GitHub branches and EAS Update branches. It also creates a mapping between GitHub commits and EAS Update updates. If you're keeping track of GitHub branches, you can create EAS Update branches for each GitHub branch and link those branches to a build's channel. In practice, this makes it so you can push to GitHub, then select the same branch name on Expo to link to builds.
+- This flow creates a direct mapping between GitHub branches and EAS Update branches. It also creates a mapping between GitHub commits and EAS Update updates. If you're keeping track of GitHub branches, you can create EAS Update branches for each GitHub branch and link those branches to a build's channel. 
+  In practice, this makes it so you can push to GitHub, then select the same branch name on Expo to link to builds.
 - Previous versions of your deployments are always preserved on GitHub. Once the "version-1.0" branch is deployed, then another version is deployed after it (like "version-1.1"), the "version-1.0" branch is forever preserved, making it easy to checkout a previous version of your project.
 
-Disadvantages of this flow:
+#### Disadvantages of this flow
 
 - Bookkeeping of branch names is required for this flow, which will mean communicating with your team which branches are currently pointed at your test builds and your production builds.
 
@@ -100,17 +100,17 @@ Disadvantages of this flow:
 
 This flow is like an un-versioned variant of the "branch promotion flow". We do not track release versions with branches. Instead, we'll have persistent "staging" and "production" branches that we can merge into forever. Here are the parts of the deployment process above that make up this flow:
 
-Creating builds: (b) Create builds for production and separate builds for testing.
+**Creating builds:** (b) Create builds for production and separate builds for testing.
 
-Testing changes: (a) Test changes on TestFlight and the Play Store Internal Track and/or (b) Test changes with internal distribution builds.
+**Testing changes:** (a) Test changes on TestFlight and the Play Store Internal Track and/or (b) Test changes with internal distribution builds.
 
-Publishing updates: (c) Create update branches that are environment-based, like "staging" and "production".
+**Publishing updates:** (c) Create update branches that are environment-based, like "staging" and "production".
 
-Diagram of flow:
+### Diagram of flow
 
 <ImageSpotlight alt="Staging deployment diagram" src="/static/images/eas-update/deployment-staging.png" style={{maxWidth: 1200}} />
 
-Explanation of flow:
+### Explanation of flow
 
 1. Develop a project locally and test changes in Expo Go.
 2. Create builds with channels named "production", which will eventually get reviewed and become available on app stores. Create another set of builds with channels named "staging", which will be used for testing on TestFlight and the Play Store Internal Track.
@@ -118,12 +118,12 @@ Explanation of flow:
 4. Merge changes into a branch named "staging". The GitHub Action will publish an update and make it available on our test builds.
 5. When ready, merge changes into the "production" branch to publish an update to our production builds.
 
-Advantages of this flow:
+#### Advantages of this flow
 
 - This flow allows you to control the pace of deploying to production independent of the pace of development. This adds an extra chance to test your app and avoids your user having to download a new update every time a PR is landed.
 - It's easy to communicate to your team, since deploying updates occurs when merging into GitHub branches named "staging" and "production".
 
-Disadvantages of this flow:
+#### Disadvantages of this flow
 
 - Checking out previous versions of your app is slightly more complex, since we'd need to check out an old commit instead of an old branch.
 - When merging to "production", the update would be re-built and re-published instead of moved from the builds with channel "staging" to the builds with channel "production".
@@ -132,27 +132,27 @@ Disadvantages of this flow:
 
 This flow is for projects that need to build and update their Android and iOS apps separately all the time. It will result in separate commands for delivering updates to the Android and iOS apps. Here are the parts of the deployment process above that make up this flow:
 
-Creating builds: (a) Create builds for production only, or (b) create builds for production and separate builds for testing.
+**Creating builds:** (a) Create builds for production only, or (b) create builds for production and separate builds for testing.
 
-Testing changes: (a) Test changes on TestFlight and the Play Store Internal Track and/or (b) Test changes with internal distribution builds.
+**Testing changes:** (a) Test changes on TestFlight and the Play Store Internal Track and/or (b) Test changes with internal distribution builds.
 
-Publishing updates: (c) Create update branches that are environment- and platform-based, like "ios-staging", "ios-production", "android-staging", and "android-production".
+**Publishing updates:** (c) Create update branches that are environment- and platform-based, like "ios-staging", "ios-production", "android-staging", and "android-production".
 
-Diagram of flow:
+### Diagram of flow
 
 <ImageSpotlight alt="Platform specific deployment diagram" src="/static/images/eas-update/deployment-platform-specific.png" style={{maxWidth: 1200}} />
 
-Explanation of flow:
+### Explanation of flow
 
 1. Develop a project locally and test changes in Expo Go.
 2. Create builds with channels named like "ios-staging", "ios-production", "android-staging", and "android-production". Then put the "ios-staging" build on TestFlight and submit the "ios-production" build to the public App Store. Likewise, put the "android-staging" build on the Play Store Internal Track, and submit the "android-production" build to the public Play Store.
 3. Set up `expo-github-action` to publish updates to the required platforms when merging commits to branches.
 4. Then, merge changes for the iOS app into the branch "ios-staging", then when ready merge changes into the "ios-production" branch. Likewise, merge changes for the Android app into the branch "android-staging" and when ready, into the branch named "android-production".
 
-Advantages of this flow:
+#### Advantages of this flow:
 
 - This flow gives you full control of which updates go to your Android and iOS builds. Updates will never apply to both platforms.
 
-Disadvantages of this flow:
+#### Disadvantages of this flow:
 
 - You'll have to run two commands instead of one to fix changes on both platforms.

--- a/docs/pages/eas-update/developing-with-eas-update.md
+++ b/docs/pages/eas-update/developing-with-eas-update.md
@@ -41,10 +41,10 @@ The process flows like this:
 
 EAS Update is still in “preview”. We are still working on features to make developing with your team easier. They include:
 
-### Previewing updates with Expo Go
+#### Previewing updates with Expo Go
 
 Expo Go does not support the modern manifest protocol needed to load updates published with EAS Update. We expect to support this with a new version of Expo Go released along with Expo SDK 45.
 
-### Generating QR codes with GitHub Actions and comments
+#### Generating QR codes with GitHub Actions and comments
 
-We plan to add support for commenting valid QR codes on PRs with expo-github-action in the future.
+We plan to add support for commenting valid QR codes on PRs with `expo-github-action` in the future.

--- a/docs/pages/eas-update/faq.md
+++ b/docs/pages/eas-update/faq.md
@@ -4,7 +4,7 @@ title: FAQ
 
 > EAS Update is currently available only to customers with an EAS subscription plan. [Sign up](https://expo.dev/accounts/[account]/settings/subscriptions).
 
-**What guidelines must I follow when publishing updates?**
+### What guidelines must I follow when publishing updates?
 
 One of the rules of EAS Update is that you need to follow the rules of the platforms and app stores you are building for. This means your updates need to follow the App Store and Play Store guidelines, including the content of the updates and how you use them. This usually means changes to your app’s behavior need to be reviewed.
 
@@ -12,6 +12,6 @@ App Store rules regularly change and just like how you’d need to follow them i
 
 EAS Update is a great way to quickly deliver improvements to the people who use your apps. For example, consider an app that has a critical bug that needs to be fixed. With EAS Update you can quickly get the fix out and later follow up with a new submission that includes the fix built in.
 
-**Are Classic Updates still supported?**
+### Are Classic Updates still supported?
 
 Expo is committed to supporting Classic Updates: the updates service available before Winter 2021. Existing apps that use Classic Updates will continue to work. With that, we are not planning on adding new features to Classic Updates other than fixing general issues and implementing security fixes as they arise. In the future, if we need to scale down or remove Classic Updates, we will ensure every developer still using the service will have ample notice to upgrade to the modern Expo Updates format so that they can use another update service like their own servers or EAS Update. Apps that use Classic Updates that are already in app stores will work forever.

--- a/docs/pages/eas-update/github-actions.md
+++ b/docs/pages/eas-update/github-actions.md
@@ -10,8 +10,8 @@ A GitHub Action is a cloud function that runs every time an event on GitHub occu
 
 We can configure GitHub Actions to run on any GitHub event. One of the most common use cases is to publish an update when code is pushed. Below are the steps to publish an update every time an update is pushed:
 
-1. Create a file path named **.github/workflows/update.yml** at the root of your project.
-2. Inside **update.yml**, copy and paste this code:
+1. Create a file path named `.github/workflows/update.yml` at the root of your project.
+2. Inside `update.yml`, copy and paste this code:
 
    ```yaml
    name: update

--- a/docs/pages/eas-update/how-eas-update-works.md
+++ b/docs/pages/eas-update/how-eas-update-works.md
@@ -21,13 +21,14 @@ To make sure the update can run on the build, we have to set a variety of proper
 
 ## Conceptual overview
 
-**Distributing builds**
+### Distributing builds
 
 When we're ready to create a build of our Expo project, we can run `eas build` to create a build. During the build, the process will include some properties inside the build that are important for updates. They are:
 
-- Channel: The channel is a name we can give to multiple builds to identify them easily. It is defined in **eas.json**. For instance, we may have an Android and an iOS build with a channel named "production", while we have another pair of builds with a channel named "staging". Then, we can distribute the builds with the "production" channel to the public app stores, while keeping the "staging" builds on the Play Store Internal Track and TestFlight. Later when we publish an update, we can make it available to the builds with the "staging" channel first; then once we test our changes, we can make the update available to the builds with the "production" channel.
-- Runtime version: The runtime version describes the JS–native interface defined by the native code layer that runs our app's update layer. It is defined in a project's app config (**app.json**/**app.config.js**). Whenever we make changes to our native code that change our app's JS–native interface, we'll need to update the runtime version. [Learn more.](/eas-update/runtime-versions)
-- Platform: Every build has a platform, such as "Android" or "iOS".
+- **Channel:** The channel is a name we can give to multiple builds to identify them easily. It is defined in `eas.json`. For instance, we may have an Android and an iOS build with a channel named "production", while we have another pair of builds with a channel named "staging". Then, we can distribute the builds with the "production" channel to the public app stores, while keeping the "staging" builds on the Play Store Internal Track and TestFlight. 
+  Later when we publish an update, we can make it available to the builds with the "staging" channel first; then once we test our changes, we can make the update available to the builds with the "production" channel.
+- **Runtime version:** The runtime version describes the JS–native interface defined by the native code layer that runs our app's update layer. It is defined in a project's app config (`app.json`/`app.config.js`). Whenever we make changes to our native code that change our app's JS–native interface, we'll need to update the runtime version. [Learn more.](/eas-update/runtime-versions)
+- **Platform:** Every build has a platform, such as "Android" or "iOS".
 
 If we made two sets of builds with the channels named "staging" and "production", we could distribute builds to four different places:
 
@@ -35,15 +36,16 @@ If we made two sets of builds with the channels named "staging" and "production"
 
 This diagram is just an example of how you could create builds and name their channels, and where you could put those builds. Ultimately it's up to you which channel names you set and where you put those builds.
 
-**Publishing an update**
+### Publishing an update
 
-Once we've created builds, we can change the update layer of our project by publishing an update. For example, we could change some text inside **App.js**, then we could publish that change as an update.
+Once we've created builds, we can change the update layer of our project by publishing an update. For example, we could change some text inside `App.js`, then we could publish that change as an update.
 
-To publish an update, we can run `eas update --auto`. This command will create a local update bundle inside the **./dist** folder in our project. Once it's created an update bundle, it will upload that bundle to EAS' servers, in a database object named a _branch_. A branch has a name, and contains a list of updates, where the most recent update is the active update on the branch. We can think of EAS branches just like Git branches. Just as Git branches contain a list of commits, EAS branches contain a list of updates.
+To publish an update, we can run `eas update --auto`. This command will create a local update bundle inside the `./dist` folder in our project. Once it's created an update bundle, it will upload that bundle to EAS' servers, in a database object named a _branch_. A branch has a name, and contains a list of updates, where the most recent update is the active update on the branch. 
+We can think of EAS branches just like Git branches. Just as Git branches contain a list of commits, EAS branches contain a list of updates.
 
 <ImageSpotlight alt="Branches with its most recent update pointed out as the active one" src="/static/images/eas-update/branch.png" />
 
-**Matching updates and builds**
+### Matching updates and builds
 
 Like builds, every update on a branch includes a target runtime version and target platform. With these fields, we can make sure that an update will run on a build with something called an _update policy_. EAS' update policy is as follows:
 
@@ -51,15 +53,19 @@ Like builds, every update on a branch includes a target runtime version and targ
 - The runtime version of the build and the target runtime version of an update must match exactly.
 - A channel can be linked to any branch. By default, a channel is linked to a branch of the same name.
 
-Let's focus on that last point. Every build has a channel, and we, as developers, can link that channel to any branch, which will make its most recent compatible update available on the branch to the linked channel. To simplify this linking, by default we auto-link channels to branches of the same name. For instance, if we created builds with the channel named "production", we could publish updates to a branch named "production" and our builds would get the updates from the branch named "production", even though we did not manually link anything.
+Let's focus on that last point. Every build has a channel, and we, as developers, can link that channel to any branch, which will make its most recent compatible update available on the branch to the linked channel. 
+To simplify this linking, by default we auto-link channels to branches of the same name. For instance, if we created builds with the channel named "production", we could publish updates to a branch named "production" and our builds would get the updates from the branch named "production", even though we did not manually link anything.
 
 <ImageSpotlight alt={`Channel "production" linked to branch "production" by default`} src="/static/images/eas-update/default-link.png" />
 
-This default linking works great if you have a deployment process where you have multiple consistent Git and EAS branches. For instance, we could have a "production" branch and a "staging" branch, both on Git and on EAS. Paired with a [GitHub Action](/eas-update/github-actions), we could make it so that every time a commit is pushed to the "staging" Git branch, we publish to the "staging" EAS Update branch, which would make that update apply to all our builds with the "staging" channel. Once we tested changes on the staging builds, then we could merge the "staging" Git branch into the "production" Git branch, which would publish an update on the "production" EAS Update branch. Finally, the latest update on the "production" EAS Update branch would apply to builds with the "production" channel.
+This default linking works great if you have a deployment process where you have multiple consistent Git and EAS branches. 
+For instance, we could have a "production" branch and a "staging" branch, both on Git and on EAS. Paired with a [GitHub Action](/eas-update/github-actions), we could make it so that every time a commit is pushed to the "staging" Git branch, we publish to the "staging" EAS Update branch, which would make that update apply to all our builds with the "staging" channel. 
+Once we tested changes on the staging builds, then we could merge the "staging" Git branch into the "production" Git branch, which would publish an update on the "production" EAS Update branch. Finally, the latest update on the "production" EAS Update branch would apply to builds with the "production" channel.
 
 This flow makes it so that we can push to GitHub, then see our builds update without any other interventions.
 
-While this flow works for many developers, there's another flow we can accomplish since we have the ability to change the link between channels and branches. Imagine we name our branches like "version-1.0", "version-2.0", and "version-3.0". We could link the "version-1.0" EAS Update branch to the "production" channel, to make it available to our "production" builds. We could also link the "version-2.0" EAS Update branch to the "staging" channel to make it available to testers. Finally, we could make a "version-3.0" EAS Update branch that is not linked to any builds yet, that only developers are testing with a development build.
+While this flow works for many developers, there's another flow we can accomplish since we have the ability to change the link between channels and branches. Imagine we name our branches like "version-1.0", "version-2.0", and "version-3.0". We could link the "version-1.0" EAS Update branch to the "production" channel, to make it available to our "production" builds. 
+We could also link the "version-2.0" EAS Update branch to the "staging" channel to make it available to testers. Finally, we could make a "version-3.0" EAS Update branch that is not linked to any builds yet, that only developers are testing with a development build.
 
 <ImageSpotlight alt={`Channel "production" linked to branch "version-1.0", channel "staging" linked to branch "version-2.0"`} src="/static/images/eas-update/custom-link-1.png" />
 
@@ -83,7 +89,8 @@ When an Expo project that includes `expo-updates` is built the included native A
 
 When the library checks for updates and when it downloads them is [configurable](/versions/latest/config/app.md#updates). By default the library will check for an update when it is opened. If an update newer than the current running update is found, it will download and run the newer update. If the library does not find a newer update, it will instead run the newest downloaded update, falling back to the update that was embedded inside the app at build time if none have been downloaded.
 
-`expo-updates` downloads updates in two phases. First, it downloads the most recent update _manifest_, which contains information about the update including a list of assets (images, JavaScript bundles, font files, etc...) that are required to run the update. Second, the library downloads the assets specified in the manifest that is has not yet downloaded from prior updates. For instance, if an update contains a new image, the library will download the new image asset before running the update. To help end-users get updates quickly and reliably, updates should be kept as small as possible.
+`expo-updates` downloads updates in two phases. First, it downloads the most recent update _manifest_, which contains information about the update including a list of assets (images, JavaScript bundles, font files, etc...) that are required to run the update. 
+Second, the library downloads the assets specified in the manifest that is has not yet downloaded from prior updates. For instance, if an update contains a new image, the library will download the new image asset before running the update. To help end-users get updates quickly and reliably, updates should be kept as small as possible.
 
 If the library is able to download the manifest (phase 1) and all the required assets (phase 2) before the `fallbackToCacheTimeout` setting, then the new update will run immediately upon launch. If the library is not able to fetch the manifest and assets within `fallbackToCacheTimeout`, it will continue to download the new update in the background and will run it upon the next launch.
 
@@ -91,4 +98,5 @@ If the library is able to download the manifest (phase 1) and all the required a
 
 ## Wrap up
 
-With EAS Update, we can quickly deliver small, critical bug fixes to our users and give users the best experience possible. This is set up with a build's runtime version, platform, and channel. With these three constraints, we can make an update available to a specific group of builds. This allows us to test our changes before going to production within a deployment process. Depending on how we set up our deployment process, we can optimize for speed. We can also optimize our deployments to be as safe a bug-free as possible. The deployment possibilities are vast and can match nearly any release process you prefer.
+With EAS Update, we can quickly deliver small, critical bug fixes to our users and give users the best experience possible. This is set up with a build's runtime version, platform, and channel. With these three constraints, we can make an update available to a specific group of builds. This allows us to test our changes before going to production within a deployment process. 
+Depending on how we set up our deployment process, we can optimize for speed. We can also optimize our deployments to be as safe a bug-free as possible. The deployment possibilities are vast and can match nearly any release process you prefer.

--- a/docs/pages/eas-update/known-issues.md
+++ b/docs/pages/eas-update/known-issues.md
@@ -8,7 +8,7 @@ EAS Update is in "preview" meaning we may still make breaking developer-facing c
 
 With our initial release of EAS Update, there are several known issues you may encounter. As we continue to iterate on EAS Update, we will address these issues.
 
-Known issues:
+### Known issues
 
 - `eas update` will not create or send source maps to Sentry. This will result in less informative error reports from Sentry.
 - When using the new manifest format with Expo Go, the project's name will appear as "Untitled experience" in the dev menu.

--- a/docs/pages/eas-update/migrate-to-eas-update.md
+++ b/docs/pages/eas-update/migrate-to-eas-update.md
@@ -50,23 +50,23 @@ You'll need to make the following changes to your project:
 
 5. To allow updates to apply to builds built with EAS, update your EAS build profiles in **eas.json** to include `channel` properties. These channels should replace any `releaseChannel` properties. We find it convenient to name the `channel` after the profile's name. For instance, the `preview` profile has a `channel` named `"preview"` and the `production` profile has a `channel` named `"production"`.
 
-```json
-{
-  "build": {
-    "development": {
-      "developmentClient": true,
-      "distribution": "internal"
-    },
-    "preview": {
-      "distribution": "internal",
-      "channel": "preview"
-    },
-    "production": {
-      "channel": "production"
+  ```json
+  {
+    "build": {
+      "development": {
+        "developmentClient": true,
+        "distribution": "internal"
+      },
+      "preview": {
+        "distribution": "internal",
+        "channel": "preview"
+      },
+      "production": {
+        "channel": "production"
+      }
     }
   }
-}
-```
+  ```
 
 6. Optional: If your project is a bare React Native project, [read the doc](/eas-update/bare-react-native) on extra configuration you may need.
 


### PR DESCRIPTION
# Why

No all of the EAS Update pages includes the headings, also there were minor display issues, like count lists, which started counting again in the middle of the listing.

# How

Add headings, tweak lists, wrap command, filenames and path with inline code.

I have also made few small changes for the readability of files for editors, some of the included very long lines, which are a bit painful to edit, so I break them up a little, without affecting the final page display.

# Test Plan

The changes have been tested by running docs website locally.

# Preview

<img width="1494" alt="Screenshot 2022-05-26 at 14 46 35" src="https://user-images.githubusercontent.com/719641/170491039-d0692781-c418-4581-9d0b-d8ad24cfe093.png">

# Checklist

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
