### PR TITLE
[docs] improvements for new tables

### DIFF
--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -333,7 +333,7 @@ for more details.
     <br />
     <div>
       <ul
-        class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
+        class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
         data-text="true"
       >
         <li
@@ -881,7 +881,7 @@ in here.
         </div>
       </h4>
       <ul
-        class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
+        class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
         data-text="true"
       >
         <li
@@ -1061,7 +1061,7 @@ in here.
       </div>
     </h4>
     <ul
-      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
       data-text="true"
     >
       <li
@@ -1194,7 +1194,7 @@ This should come from the user field of an
       </div>
     </h4>
     <ul
-      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
       data-text="true"
     >
       <li
@@ -1358,7 +1358,7 @@ value depending on the state of the credential.
       </div>
     </h4>
     <ul
-      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
       data-text="true"
     >
       <li
@@ -1511,7 +1511,7 @@ value depending on the state of the credential.
       </div>
     </h4>
     <ul
-      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
       data-text="true"
     >
       <li
@@ -1611,7 +1611,7 @@ Calling this method will show the sign in modal before actually refreshing the u
       </div>
     </h4>
     <ul
-      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
       data-text="true"
     >
       <li
@@ -1776,7 +1776,7 @@ refresh operation.
       </div>
     </h4>
     <ul
-      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
       data-text="true"
     >
       <li
@@ -1915,7 +1915,7 @@ the user, since this remains the same for apps released by the same developer.
       </div>
     </h4>
     <ul
-      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
       data-text="true"
     >
       <li
@@ -2080,7 +2080,7 @@ sign-in operation.
       </div>
     </h4>
     <ul
-      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
       data-text="true"
     >
       <li
@@ -2210,7 +2210,7 @@ from using
       </div>
     </h4>
     <ul
-      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
       data-text="true"
     >
       <li
@@ -2425,7 +2425,7 @@ sign-out operation.
       </div>
     </h4>
     <ul
-      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
       data-text="true"
     >
       <li
@@ -2500,7 +2500,7 @@ sign-out operation.
       </div>
     </h4>
     <ul
-      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
       data-text="true"
     >
       <li
@@ -2712,7 +2712,7 @@ for more details.
       </div>
     </blockquote>
     <div
-      class="css-gxs0zd-tableWrapperStyle"
+      class="css-zdmbpy-tableWrapperStyle"
     >
       <table
         class="css-33l6in-tableStyle-Table"
@@ -2745,7 +2745,7 @@ for more details.
             class="css-1ne1f2k-tableRowStyle-Row"
           >
             <td
-              class="css-1rwbqei-tableCellStyle-fitContentStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <strong
                 class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -2754,7 +2754,7 @@ for more details.
               </strong>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <code
                 class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -2769,7 +2769,7 @@ for more details.
               </code>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <span>
                 A short-lived session token used by your app for proof of authorization when interacting with
@@ -2787,7 +2787,7 @@ the app's server counterpart. Unlike
             class="css-1ne1f2k-tableRowStyle-Row"
           >
             <td
-              class="css-1rwbqei-tableCellStyle-fitContentStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <strong
                 class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -2796,7 +2796,7 @@ the app's server counterpart. Unlike
               </strong>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <code
                 class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -2811,7 +2811,7 @@ the app's server counterpart. Unlike
               </code>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <span>
                 The user's email address. Might not be present if you didn't request the 
@@ -2831,7 +2831,7 @@ an Apple domain.
             class="css-1ne1f2k-tableRowStyle-Row"
           >
             <td
-              class="css-1rwbqei-tableCellStyle-fitContentStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <strong
                 class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -2840,7 +2840,7 @@ an Apple domain.
               </strong>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <code
                 class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -2860,7 +2860,7 @@ an Apple domain.
               </code>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <span>
                 The user's name. May be 
@@ -2891,7 +2891,7 @@ your app.
             class="css-1ne1f2k-tableRowStyle-Row"
           >
             <td
-              class="css-1rwbqei-tableCellStyle-fitContentStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <strong
                 class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -2900,7 +2900,7 @@ your app.
               </strong>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <code
                 class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -2915,7 +2915,7 @@ your app.
               </code>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <span>
                 A JSON Web Token (JWT) that securely communicates information about the user to your app.
@@ -2926,7 +2926,7 @@ your app.
             class="css-1ne1f2k-tableRowStyle-Row"
           >
             <td
-              class="css-1rwbqei-tableCellStyle-fitContentStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <strong
                 class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -2935,7 +2935,7 @@ your app.
               </strong>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <code
                 class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -2949,7 +2949,7 @@ your app.
               </code>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <span>
                 A value that indicates whether the user appears to the system to be a real person.
@@ -2960,7 +2960,7 @@ your app.
             class="css-1ne1f2k-tableRowStyle-Row"
           >
             <td
-              class="css-1rwbqei-tableCellStyle-fitContentStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <strong
                 class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -2969,7 +2969,7 @@ your app.
               </strong>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <code
                 class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -2984,7 +2984,7 @@ your app.
               </code>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <span>
                 An arbitrary string that your app provided as 
@@ -3016,7 +3016,7 @@ will be
             class="css-1ne1f2k-tableRowStyle-Row"
           >
             <td
-              class="css-1rwbqei-tableCellStyle-fitContentStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <strong
                 class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -3025,7 +3025,7 @@ will be
               </strong>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <code
                 class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -3034,7 +3034,7 @@ will be
               </code>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <span>
                 An identifier associated with the authenticated user. You can use this to check if the user is
@@ -3119,7 +3119,7 @@ may be
       . Only applicable fields that the user has allowed your app to access will be nonnull.
     </p>
     <div
-      class="css-gxs0zd-tableWrapperStyle"
+      class="css-zdmbpy-tableWrapperStyle"
     >
       <table
         class="css-33l6in-tableStyle-Table"
@@ -3152,7 +3152,7 @@ may be
             class="css-1ne1f2k-tableRowStyle-Row"
           >
             <td
-              class="css-1rwbqei-tableCellStyle-fitContentStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <strong
                 class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -3161,7 +3161,7 @@ may be
               </strong>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <code
                 class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -3176,7 +3176,7 @@ may be
               </code>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               -
             </td>
@@ -3185,7 +3185,7 @@ may be
             class="css-1ne1f2k-tableRowStyle-Row"
           >
             <td
-              class="css-1rwbqei-tableCellStyle-fitContentStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <strong
                 class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -3194,7 +3194,7 @@ may be
               </strong>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <code
                 class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -3209,7 +3209,7 @@ may be
               </code>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               -
             </td>
@@ -3218,7 +3218,7 @@ may be
             class="css-1ne1f2k-tableRowStyle-Row"
           >
             <td
-              class="css-1rwbqei-tableCellStyle-fitContentStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <strong
                 class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -3227,7 +3227,7 @@ may be
               </strong>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <code
                 class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -3242,7 +3242,7 @@ may be
               </code>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               -
             </td>
@@ -3251,7 +3251,7 @@ may be
             class="css-1ne1f2k-tableRowStyle-Row"
           >
             <td
-              class="css-1rwbqei-tableCellStyle-fitContentStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <strong
                 class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -3260,7 +3260,7 @@ may be
               </strong>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <code
                 class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -3275,7 +3275,7 @@ may be
               </code>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               -
             </td>
@@ -3284,7 +3284,7 @@ may be
             class="css-1ne1f2k-tableRowStyle-Row"
           >
             <td
-              class="css-1rwbqei-tableCellStyle-fitContentStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <strong
                 class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -3293,7 +3293,7 @@ may be
               </strong>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <code
                 class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -3308,7 +3308,7 @@ may be
               </code>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               -
             </td>
@@ -3317,7 +3317,7 @@ may be
             class="css-1ne1f2k-tableRowStyle-Row"
           >
             <td
-              class="css-1rwbqei-tableCellStyle-fitContentStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <strong
                 class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -3326,7 +3326,7 @@ may be
               </strong>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <code
                 class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -3341,7 +3341,7 @@ may be
               </code>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               -
             </td>
@@ -3469,7 +3469,7 @@ for more details.
       </div>
     </blockquote>
     <div
-      class="css-gxs0zd-tableWrapperStyle"
+      class="css-zdmbpy-tableWrapperStyle"
     >
       <table
         class="css-33l6in-tableStyle-Table"
@@ -3502,7 +3502,7 @@ for more details.
             class="css-1ne1f2k-tableRowStyle-Row"
           >
             <td
-              class="css-1rwbqei-tableCellStyle-fitContentStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <strong
                 class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -3517,7 +3517,7 @@ for more details.
               </span>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <code
                 class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -3532,7 +3532,7 @@ for more details.
               </code>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <span>
                 Array of user information scopes to which your app is requesting access. Note that the user can
@@ -3565,7 +3565,7 @@ requests they will be
             class="css-1ne1f2k-tableRowStyle-Row"
           >
             <td
-              class="css-1rwbqei-tableCellStyle-fitContentStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <strong
                 class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -3580,7 +3580,7 @@ requests they will be
               </span>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <code
                 class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -3589,7 +3589,7 @@ requests they will be
               </code>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <span>
                 An arbitrary string that is returned unmodified in the corresponding credential after a
@@ -3611,7 +3611,7 @@ OAuth 2.0 protocol
             class="css-1ne1f2k-tableRowStyle-Row"
           >
             <td
-              class="css-1rwbqei-tableCellStyle-fitContentStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <strong
                 class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -3620,7 +3620,7 @@ OAuth 2.0 protocol
               </strong>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <code
                 class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -3629,7 +3629,7 @@ OAuth 2.0 protocol
               </code>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               -
             </td>
@@ -3757,7 +3757,7 @@ for more details.
       </div>
     </blockquote>
     <div
-      class="css-gxs0zd-tableWrapperStyle"
+      class="css-zdmbpy-tableWrapperStyle"
     >
       <table
         class="css-33l6in-tableStyle-Table"
@@ -3790,7 +3790,7 @@ for more details.
             class="css-1ne1f2k-tableRowStyle-Row"
           >
             <td
-              class="css-1rwbqei-tableCellStyle-fitContentStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <strong
                 class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -3805,7 +3805,7 @@ for more details.
               </span>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <code
                 class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -3814,7 +3814,7 @@ for more details.
               </code>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <span>
                 An arbitrary string that is used to prevent replay attacks. See more information on this in the
@@ -3834,7 +3834,7 @@ for more details.
             class="css-1ne1f2k-tableRowStyle-Row"
           >
             <td
-              class="css-1rwbqei-tableCellStyle-fitContentStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <strong
                 class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -3849,7 +3849,7 @@ for more details.
               </span>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <code
                 class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -3864,7 +3864,7 @@ for more details.
               </code>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <span>
                 Array of user information scopes to which your app is requesting access. Note that the user can
@@ -3897,7 +3897,7 @@ requests they will be
             class="css-1ne1f2k-tableRowStyle-Row"
           >
             <td
-              class="css-1rwbqei-tableCellStyle-fitContentStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <strong
                 class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -3912,7 +3912,7 @@ requests they will be
               </span>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <code
                 class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -3921,7 +3921,7 @@ requests they will be
               </code>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <span>
                 An arbitrary string that is returned unmodified in the corresponding credential after a
@@ -4062,7 +4062,7 @@ for more details.
       </div>
     </blockquote>
     <div
-      class="css-gxs0zd-tableWrapperStyle"
+      class="css-zdmbpy-tableWrapperStyle"
     >
       <table
         class="css-33l6in-tableStyle-Table"
@@ -4095,7 +4095,7 @@ for more details.
             class="css-1ne1f2k-tableRowStyle-Row"
           >
             <td
-              class="css-1rwbqei-tableCellStyle-fitContentStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <strong
                 class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -4110,7 +4110,7 @@ for more details.
               </span>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <code
                 class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -4119,7 +4119,7 @@ for more details.
               </code>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <span>
                 An arbitrary string that is returned unmodified in the corresponding credential after a
@@ -4141,7 +4141,7 @@ OAuth 2.0 protocol
             class="css-1ne1f2k-tableRowStyle-Row"
           >
             <td
-              class="css-1rwbqei-tableCellStyle-fitContentStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <strong
                 class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -4150,7 +4150,7 @@ OAuth 2.0 protocol
               </strong>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <code
                 class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -4159,7 +4159,7 @@ OAuth 2.0 protocol
               </code>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               -
             </td>
@@ -4226,7 +4226,7 @@ OAuth 2.0 protocol
       </div>
     </h3>
     <div
-      class="css-gxs0zd-tableWrapperStyle"
+      class="css-zdmbpy-tableWrapperStyle"
     >
       <table
         class="css-33l6in-tableStyle-Table"
@@ -4259,7 +4259,7 @@ OAuth 2.0 protocol
             class="css-1ne1f2k-tableRowStyle-Row"
           >
             <td
-              class="css-1rwbqei-tableCellStyle-fitContentStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <strong
                 class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -4268,7 +4268,7 @@ OAuth 2.0 protocol
               </strong>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <code
                 class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -4280,7 +4280,7 @@ OAuth 2.0 protocol
               </code>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <span>
                 A method to unsubscribe the listener.
@@ -4416,7 +4416,7 @@ OAuth 2.0 protocol
       .
     </p>
     <ul
-      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
       data-text="true"
     >
       <li
@@ -4588,7 +4588,7 @@ OAuth 2.0 protocol
       .
     </p>
     <ul
-      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
       data-text="true"
     >
       <li
@@ -4806,7 +4806,7 @@ for more details.
       </div>
     </blockquote>
     <ul
-      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
       data-text="true"
     >
       <li
@@ -4976,7 +4976,7 @@ for more details.
       </div>
     </h3>
     <ul
-      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
       data-text="true"
     >
       <li
@@ -5242,7 +5242,7 @@ for more details.
       </div>
     </blockquote>
     <ul
-      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
       data-text="true"
     >
       <li
@@ -5407,7 +5407,7 @@ for more details.
       </div>
     </blockquote>
     <ul
-      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
       data-text="true"
     >
       <li
@@ -5701,7 +5701,7 @@ exports[`APISection expo-barcode-scanner 1`] = `
     <br />
     <div>
       <ul
-        class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
+        class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
         data-text="true"
       >
         <li
@@ -6164,7 +6164,7 @@ Same as
         </div>
       </h4>
       <ul
-        class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
+        class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
         data-text="true"
       >
         <li
@@ -6344,7 +6344,7 @@ Same as
       </div>
     </h4>
     <ul
-      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
       data-text="true"
     >
       <li
@@ -6435,7 +6435,7 @@ This can be used to quickly create specific permission hooks in every module.
       </div>
     </h4>
     <ul
-      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
       data-text="true"
     >
       <li
@@ -6659,7 +6659,7 @@ This can be used to quickly create specific permission hooks in every module.
       </div>
     </h4>
     <ul
-      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
       data-text="true"
     >
       <li
@@ -6841,7 +6841,7 @@ This can be used to quickly create specific permission hooks in every module.
       </div>
     </h4>
     <ul
-      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
       data-text="true"
     >
       <li
@@ -6999,7 +6999,7 @@ This can be used to quickly create specific permission hooks in every module.
       </div>
     </h4>
     <ul
-      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
       data-text="true"
     >
       <li
@@ -7141,7 +7141,7 @@ the platform.
       </div>
     </h4>
     <ul
-      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
       data-text="true"
     >
       <li
@@ -7295,7 +7295,7 @@ code.
       </div>
     </h3>
     <div
-      class="css-gxs0zd-tableWrapperStyle"
+      class="css-zdmbpy-tableWrapperStyle"
     >
       <table
         class="css-33l6in-tableStyle-Table"
@@ -7328,7 +7328,7 @@ code.
             class="css-1ne1f2k-tableRowStyle-Row"
           >
             <td
-              class="css-1rwbqei-tableCellStyle-fitContentStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <strong
                 class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -7337,7 +7337,7 @@ code.
               </strong>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <code
                 class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -7351,7 +7351,7 @@ code.
               </code>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <span>
                 The origin point of the bounding box.
@@ -7362,7 +7362,7 @@ code.
             class="css-1ne1f2k-tableRowStyle-Row"
           >
             <td
-              class="css-1rwbqei-tableCellStyle-fitContentStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <strong
                 class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -7371,7 +7371,7 @@ code.
               </strong>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <code
                 class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -7385,7 +7385,7 @@ code.
               </code>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <span>
                 The size of the bounding box.
@@ -7470,7 +7470,7 @@ code.
       extended by:
     </p>
     <div
-      class="css-gxs0zd-tableWrapperStyle"
+      class="css-zdmbpy-tableWrapperStyle"
     >
       <table
         class="css-33l6in-tableStyle-Table"
@@ -7503,7 +7503,7 @@ code.
             class="css-1ne1f2k-tableRowStyle-Row"
           >
             <td
-              class="css-1rwbqei-tableCellStyle-fitContentStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <strong
                 class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -7518,7 +7518,7 @@ code.
               </span>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <code
                 class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -7527,7 +7527,7 @@ code.
               </code>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               -
             </td>
@@ -7594,7 +7594,7 @@ code.
       </div>
     </h3>
     <div
-      class="css-gxs0zd-tableWrapperStyle"
+      class="css-zdmbpy-tableWrapperStyle"
     >
       <table
         class="css-33l6in-tableStyle-Table"
@@ -7627,7 +7627,7 @@ code.
             class="css-1ne1f2k-tableRowStyle-Row"
           >
             <td
-              class="css-1rwbqei-tableCellStyle-fitContentStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <strong
                 class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -7636,7 +7636,7 @@ code.
               </strong>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <code
                 class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -7650,7 +7650,7 @@ code.
               </code>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               -
             </td>
@@ -7724,7 +7724,7 @@ code.
 are using the barcode scanner view, these values are adjusted to the dimensions of the view).
     </p>
     <div
-      class="css-gxs0zd-tableWrapperStyle"
+      class="css-zdmbpy-tableWrapperStyle"
     >
       <table
         class="css-33l6in-tableStyle-Table"
@@ -7757,7 +7757,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
             class="css-1ne1f2k-tableRowStyle-Row"
           >
             <td
-              class="css-1rwbqei-tableCellStyle-fitContentStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <strong
                 class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -7766,7 +7766,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               </strong>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <code
                 class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -7775,7 +7775,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               </code>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <span>
                 The 
@@ -7792,7 +7792,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
             class="css-1ne1f2k-tableRowStyle-Row"
           >
             <td
-              class="css-1rwbqei-tableCellStyle-fitContentStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <strong
                 class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -7801,7 +7801,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               </strong>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <code
                 class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -7810,7 +7810,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               </code>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <span>
                 The 
@@ -7938,7 +7938,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
         </div>
       </h4>
       <ul
-        class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
+        class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
         data-text="true"
       >
         <li
@@ -8085,7 +8085,7 @@ For some types, they will represent the area used by the scanner.
       </div>
     </blockquote>
     <div
-      class="css-gxs0zd-tableWrapperStyle"
+      class="css-zdmbpy-tableWrapperStyle"
     >
       <table
         class="css-33l6in-tableStyle-Table"
@@ -8118,7 +8118,7 @@ For some types, they will represent the area used by the scanner.
             class="css-1ne1f2k-tableRowStyle-Row"
           >
             <td
-              class="css-1rwbqei-tableCellStyle-fitContentStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <strong
                 class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -8133,7 +8133,7 @@ For some types, they will represent the area used by the scanner.
               </span>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <code
                 class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -8147,7 +8147,7 @@ For some types, they will represent the area used by the scanner.
               </code>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <span>
                 The 
@@ -8165,7 +8165,7 @@ For some types, they will represent the area used by the scanner.
             class="css-1ne1f2k-tableRowStyle-Row"
           >
             <td
-              class="css-1rwbqei-tableCellStyle-fitContentStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <strong
                 class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -8180,7 +8180,7 @@ For some types, they will represent the area used by the scanner.
               </span>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <code
                 class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -8195,7 +8195,7 @@ For some types, they will represent the area used by the scanner.
               </code>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <span>
                 Corner points of the bounding box.
@@ -8206,7 +8206,7 @@ For some types, they will represent the area used by the scanner.
             class="css-1ne1f2k-tableRowStyle-Row"
           >
             <td
-              class="css-1rwbqei-tableCellStyle-fitContentStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <strong
                 class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -8215,7 +8215,7 @@ For some types, they will represent the area used by the scanner.
               </strong>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <code
                 class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -8224,7 +8224,7 @@ For some types, they will represent the area used by the scanner.
               </code>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <span>
                 The information encoded in the bar code.
@@ -8235,7 +8235,7 @@ For some types, they will represent the area used by the scanner.
             class="css-1ne1f2k-tableRowStyle-Row"
           >
             <td
-              class="css-1rwbqei-tableCellStyle-fitContentStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <strong
                 class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -8244,7 +8244,7 @@ For some types, they will represent the area used by the scanner.
               </strong>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <code
                 class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -8253,7 +8253,7 @@ For some types, they will represent the area used by the scanner.
               </code>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <span>
                 The barcode type.
@@ -8322,7 +8322,7 @@ For some types, they will represent the area used by the scanner.
       </div>
     </h3>
     <div
-      class="css-gxs0zd-tableWrapperStyle"
+      class="css-zdmbpy-tableWrapperStyle"
     >
       <table
         class="css-33l6in-tableStyle-Table"
@@ -8355,7 +8355,7 @@ For some types, they will represent the area used by the scanner.
             class="css-1ne1f2k-tableRowStyle-Row"
           >
             <td
-              class="css-1rwbqei-tableCellStyle-fitContentStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <strong
                 class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -8364,7 +8364,7 @@ For some types, they will represent the area used by the scanner.
               </strong>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <code
                 class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -8373,7 +8373,7 @@ For some types, they will represent the area used by the scanner.
               </code>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <span>
                 The height value.
@@ -8384,7 +8384,7 @@ For some types, they will represent the area used by the scanner.
             class="css-1ne1f2k-tableRowStyle-Row"
           >
             <td
-              class="css-1rwbqei-tableCellStyle-fitContentStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <strong
                 class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -8393,7 +8393,7 @@ For some types, they will represent the area used by the scanner.
               </strong>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <code
                 class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -8402,7 +8402,7 @@ For some types, they will represent the area used by the scanner.
               </code>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <span>
                 The width value.
@@ -8601,7 +8601,7 @@ For some types, they will represent the area used by the scanner.
       </div>
     </h3>
     <div
-      class="css-gxs0zd-tableWrapperStyle"
+      class="css-zdmbpy-tableWrapperStyle"
     >
       <table
         class="css-33l6in-tableStyle-Table"
@@ -8634,7 +8634,7 @@ For some types, they will represent the area used by the scanner.
             class="css-1ne1f2k-tableRowStyle-Row"
           >
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <strong
                 class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -8644,7 +8644,7 @@ For some types, they will represent the area used by the scanner.
               </strong>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <code
                 class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -8653,7 +8653,7 @@ For some types, they will represent the area used by the scanner.
               </code>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               -
             </td>
@@ -8662,7 +8662,7 @@ For some types, they will represent the area used by the scanner.
             class="css-1ne1f2k-tableRowStyle-Row"
           >
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <strong
                 class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -8672,7 +8672,7 @@ For some types, they will represent the area used by the scanner.
               </strong>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <code
                 class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -8686,7 +8686,7 @@ For some types, they will represent the area used by the scanner.
               </code>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               -
             </td>
@@ -8695,7 +8695,7 @@ For some types, they will represent the area used by the scanner.
             class="css-1ne1f2k-tableRowStyle-Row"
           >
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <strong
                 class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -8705,7 +8705,7 @@ For some types, they will represent the area used by the scanner.
               </strong>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <code
                 class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -8714,7 +8714,7 @@ For some types, they will represent the area used by the scanner.
               </code>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               -
             </td>
@@ -8723,7 +8723,7 @@ For some types, they will represent the area used by the scanner.
             class="css-1ne1f2k-tableRowStyle-Row"
           >
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <strong
                 class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -8733,7 +8733,7 @@ For some types, they will represent the area used by the scanner.
               </strong>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <code
                 class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -8747,7 +8747,7 @@ For some types, they will represent the area used by the scanner.
               </code>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               -
             </td>
@@ -8864,7 +8864,7 @@ For some types, they will represent the area used by the scanner.
       </div>
     </h3>
     <ul
-      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
       data-text="true"
     >
       <li
@@ -9115,7 +9115,7 @@ exports[`APISection expo-pedometer 1`] = `
       </div>
     </h4>
     <ul
-      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
       data-text="true"
     >
       <li
@@ -9255,7 +9255,7 @@ exports[`APISection expo-pedometer 1`] = `
       </div>
     </h4>
     <ul
-      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
       data-text="true"
     >
       <li
@@ -9370,7 +9370,7 @@ exports[`APISection expo-pedometer 1`] = `
       </div>
     </h4>
     <ul
-      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
       data-text="true"
     >
       <li
@@ -9583,7 +9583,7 @@ a start date that is more than seven days in the past returns only the available
       </div>
     </h4>
     <ul
-      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
       data-text="true"
     >
       <li
@@ -9731,7 +9731,7 @@ available on this device.
       </div>
     </h4>
     <ul
-      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
       data-text="true"
     >
       <li
@@ -9871,7 +9871,7 @@ available on this device.
       </div>
     </h4>
     <ul
-      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
       data-text="true"
     >
       <li
@@ -9971,7 +9971,7 @@ provided with a single argument that is
       </div>
     </h4>
     <ul
-      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
       data-text="true"
     >
       <li
@@ -10123,7 +10123,7 @@ provided with a single argument that is
       </div>
     </h3>
     <div
-      class="css-gxs0zd-tableWrapperStyle"
+      class="css-zdmbpy-tableWrapperStyle"
     >
       <table
         class="css-33l6in-tableStyle-Table"
@@ -10156,7 +10156,7 @@ provided with a single argument that is
             class="css-1ne1f2k-tableRowStyle-Row"
           >
             <td
-              class="css-1rwbqei-tableCellStyle-fitContentStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <strong
                 class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -10165,7 +10165,7 @@ provided with a single argument that is
               </strong>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <code
                 class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -10174,7 +10174,7 @@ provided with a single argument that is
               </code>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <span>
                 Number of steps taken between the given dates.
@@ -10296,7 +10296,7 @@ provided with a single argument that is
         </div>
       </h4>
       <ul
-        class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
+        class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
         data-text="true"
       >
         <li
@@ -10461,7 +10461,7 @@ provided with a single argument that is
       </div>
     </h3>
     <div
-      class="css-gxs0zd-tableWrapperStyle"
+      class="css-zdmbpy-tableWrapperStyle"
     >
       <table
         class="css-33l6in-tableStyle-Table"
@@ -10494,7 +10494,7 @@ provided with a single argument that is
             class="css-1ne1f2k-tableRowStyle-Row"
           >
             <td
-              class="css-1rwbqei-tableCellStyle-fitContentStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <strong
                 class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -10503,7 +10503,7 @@ provided with a single argument that is
               </strong>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <code
                 class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -10514,7 +10514,7 @@ provided with a single argument that is
               </code>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <span>
                 A method to unsubscribe the listener.
@@ -10633,7 +10633,7 @@ provided with a single argument that is
       </div>
     </h3>
     <div
-      class="css-gxs0zd-tableWrapperStyle"
+      class="css-zdmbpy-tableWrapperStyle"
     >
       <table
         class="css-33l6in-tableStyle-Table"
@@ -10666,7 +10666,7 @@ provided with a single argument that is
             class="css-1ne1f2k-tableRowStyle-Row"
           >
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <strong
                 class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -10676,7 +10676,7 @@ provided with a single argument that is
               </strong>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <code
                 class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -10685,7 +10685,7 @@ provided with a single argument that is
               </code>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               -
             </td>
@@ -10694,7 +10694,7 @@ provided with a single argument that is
             class="css-1ne1f2k-tableRowStyle-Row"
           >
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <strong
                 class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -10704,7 +10704,7 @@ provided with a single argument that is
               </strong>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <code
                 class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -10718,7 +10718,7 @@ provided with a single argument that is
               </code>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               -
             </td>
@@ -10727,7 +10727,7 @@ provided with a single argument that is
             class="css-1ne1f2k-tableRowStyle-Row"
           >
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <strong
                 class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -10737,7 +10737,7 @@ provided with a single argument that is
               </strong>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <code
                 class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -10746,7 +10746,7 @@ provided with a single argument that is
               </code>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               -
             </td>
@@ -10755,7 +10755,7 @@ provided with a single argument that is
             class="css-1ne1f2k-tableRowStyle-Row"
           >
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <strong
                 class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -10765,7 +10765,7 @@ provided with a single argument that is
               </strong>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               <code
                 class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -10779,7 +10779,7 @@ provided with a single argument that is
               </code>
             </td>
             <td
-              class="css-1sp938g-tableCellStyle-Cell"
+              class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
               -
             </td>
@@ -10896,7 +10896,7 @@ provided with a single argument that is
       </div>
     </h3>
     <ul
-      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
       data-text="true"
     >
       <li

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -333,7 +333,7 @@ for more details.
     <br />
     <div>
       <ul
-        class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
+        class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
         data-text="true"
       >
         <li
@@ -881,7 +881,7 @@ in here.
         </div>
       </h4>
       <ul
-        class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
+        class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
         data-text="true"
       >
         <li
@@ -1061,7 +1061,7 @@ in here.
       </div>
     </h4>
     <ul
-      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
+      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
       data-text="true"
     >
       <li
@@ -1194,7 +1194,7 @@ This should come from the user field of an
       </div>
     </h4>
     <ul
-      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
+      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
       data-text="true"
     >
       <li
@@ -1358,7 +1358,7 @@ value depending on the state of the credential.
       </div>
     </h4>
     <ul
-      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
+      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
       data-text="true"
     >
       <li
@@ -1511,7 +1511,7 @@ value depending on the state of the credential.
       </div>
     </h4>
     <ul
-      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
+      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
       data-text="true"
     >
       <li
@@ -1611,7 +1611,7 @@ Calling this method will show the sign in modal before actually refreshing the u
       </div>
     </h4>
     <ul
-      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
+      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
       data-text="true"
     >
       <li
@@ -1776,7 +1776,7 @@ refresh operation.
       </div>
     </h4>
     <ul
-      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
+      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
       data-text="true"
     >
       <li
@@ -1915,7 +1915,7 @@ the user, since this remains the same for apps released by the same developer.
       </div>
     </h4>
     <ul
-      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
+      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
       data-text="true"
     >
       <li
@@ -2080,7 +2080,7 @@ sign-in operation.
       </div>
     </h4>
     <ul
-      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
+      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
       data-text="true"
     >
       <li
@@ -2210,7 +2210,7 @@ from using
       </div>
     </h4>
     <ul
-      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
+      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
       data-text="true"
     >
       <li
@@ -2425,7 +2425,7 @@ sign-out operation.
       </div>
     </h4>
     <ul
-      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
+      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
       data-text="true"
     >
       <li
@@ -2500,7 +2500,7 @@ sign-out operation.
       </div>
     </h4>
     <ul
-      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
+      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
       data-text="true"
     >
       <li
@@ -4416,7 +4416,7 @@ OAuth 2.0 protocol
       .
     </p>
     <ul
-      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
+      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
       data-text="true"
     >
       <li
@@ -4588,7 +4588,7 @@ OAuth 2.0 protocol
       .
     </p>
     <ul
-      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
+      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
       data-text="true"
     >
       <li
@@ -4806,7 +4806,7 @@ for more details.
       </div>
     </blockquote>
     <ul
-      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
+      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
       data-text="true"
     >
       <li
@@ -4976,7 +4976,7 @@ for more details.
       </div>
     </h3>
     <ul
-      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
+      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
       data-text="true"
     >
       <li
@@ -5242,7 +5242,7 @@ for more details.
       </div>
     </blockquote>
     <ul
-      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
+      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
       data-text="true"
     >
       <li
@@ -5407,7 +5407,7 @@ for more details.
       </div>
     </blockquote>
     <ul
-      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
+      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
       data-text="true"
     >
       <li
@@ -5701,7 +5701,7 @@ exports[`APISection expo-barcode-scanner 1`] = `
     <br />
     <div>
       <ul
-        class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
+        class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
         data-text="true"
       >
         <li
@@ -6164,7 +6164,7 @@ Same as
         </div>
       </h4>
       <ul
-        class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
+        class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
         data-text="true"
       >
         <li
@@ -6344,7 +6344,7 @@ Same as
       </div>
     </h4>
     <ul
-      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
+      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
       data-text="true"
     >
       <li
@@ -6435,7 +6435,7 @@ This can be used to quickly create specific permission hooks in every module.
       </div>
     </h4>
     <ul
-      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
+      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
       data-text="true"
     >
       <li
@@ -6659,7 +6659,7 @@ This can be used to quickly create specific permission hooks in every module.
       </div>
     </h4>
     <ul
-      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
+      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
       data-text="true"
     >
       <li
@@ -6841,7 +6841,7 @@ This can be used to quickly create specific permission hooks in every module.
       </div>
     </h4>
     <ul
-      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
+      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
       data-text="true"
     >
       <li
@@ -6999,7 +6999,7 @@ This can be used to quickly create specific permission hooks in every module.
       </div>
     </h4>
     <ul
-      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
+      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
       data-text="true"
     >
       <li
@@ -7141,7 +7141,7 @@ the platform.
       </div>
     </h4>
     <ul
-      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
+      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
       data-text="true"
     >
       <li
@@ -7938,7 +7938,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
         </div>
       </h4>
       <ul
-        class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
+        class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
         data-text="true"
       >
         <li
@@ -8864,7 +8864,7 @@ For some types, they will represent the area used by the scanner.
       </div>
     </h3>
     <ul
-      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
+      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
       data-text="true"
     >
       <li
@@ -9115,7 +9115,7 @@ exports[`APISection expo-pedometer 1`] = `
       </div>
     </h4>
     <ul
-      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
+      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
       data-text="true"
     >
       <li
@@ -9255,7 +9255,7 @@ exports[`APISection expo-pedometer 1`] = `
       </div>
     </h4>
     <ul
-      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
+      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
       data-text="true"
     >
       <li
@@ -9370,7 +9370,7 @@ exports[`APISection expo-pedometer 1`] = `
       </div>
     </h4>
     <ul
-      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
+      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
       data-text="true"
     >
       <li
@@ -9583,7 +9583,7 @@ a start date that is more than seven days in the past returns only the available
       </div>
     </h4>
     <ul
-      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
+      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
       data-text="true"
     >
       <li
@@ -9731,7 +9731,7 @@ available on this device.
       </div>
     </h4>
     <ul
-      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
+      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
       data-text="true"
     >
       <li
@@ -9871,7 +9871,7 @@ available on this device.
       </div>
     </h4>
     <ul
-      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
+      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
       data-text="true"
     >
       <li
@@ -9971,7 +9971,7 @@ provided with a single argument that is
       </div>
     </h4>
     <ul
-      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
+      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
       data-text="true"
     >
       <li
@@ -10296,7 +10296,7 @@ provided with a single argument that is
         </div>
       </h4>
       <ul
-        class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
+        class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
         data-text="true"
       >
         <li
@@ -10896,7 +10896,7 @@ provided with a single argument that is
       </div>
     </h3>
     <ul
-      class="css-1h2n3le-paragraph-STYLES_UNORDERED_LIST"
+      class="css-1oe4yj6-paragraph-STYLES_UNORDERED_LIST-UL"
       data-text="true"
     >
       <li

--- a/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
 <div>
   <div
-    class="css-gxs0zd-tableWrapperStyle"
+    class="css-zdmbpy-tableWrapperStyle"
   >
     <table
       class="css-33l6in-tableStyle-Table"
@@ -31,7 +31,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           class="css-1ne1f2k-tableRowStyle-Row"
         >
           <td
-            class="css-1rwbqei-tableCellStyle-fitContentStyle-Cell"
+            class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
           >
             <div
               data-testid="<propertyAnchor level={0}><inlineCode>name</inlineCode></propertyAnchor>"
@@ -95,7 +95,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </div>
           </td>
           <td
-            class="css-1sp938g-tableCellStyle-Cell"
+            class="css-yr5jng-tableCellStyle-Cell"
           >
             <div
               class=" css-pb2q8c-paragraph-STYLES_PARAGRAPH_DIV"
@@ -157,7 +157,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           class="css-1ne1f2k-tableRowStyle-Row"
         >
           <td
-            class="css-1rwbqei-tableCellStyle-fitContentStyle-Cell"
+            class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
           >
             <div
               data-testid="<propertyAnchor level={0}><inlineCode>androidNavigationBar</inlineCode></propertyAnchor>"
@@ -221,7 +221,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </div>
           </td>
           <td
-            class="css-1sp938g-tableCellStyle-Cell"
+            class="css-yr5jng-tableCellStyle-Cell"
           >
             <div
               class=" css-pb2q8c-paragraph-STYLES_PARAGRAPH_DIV"
@@ -326,7 +326,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           class="css-1ne1f2k-tableRowStyle-Row"
         >
           <td
-            class="css-1rwbqei-tableCellStyle-fitContentStyle-Cell"
+            class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
           >
             <div
               data-testid="<subpropertyAnchor level={1}><inlineCode>visible</inlineCode></subpropertyAnchor>"
@@ -390,7 +390,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </div>
           </td>
           <td
-            class="css-1sp938g-tableCellStyle-Cell"
+            class="css-yr5jng-tableCellStyle-Cell"
           >
             <div
               class=" css-pb2q8c-paragraph-STYLES_PARAGRAPH_DIV"
@@ -452,7 +452,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           class="css-1ne1f2k-tableRowStyle-Row"
         >
           <td
-            class="css-1rwbqei-tableCellStyle-fitContentStyle-Cell"
+            class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
           >
             <div
               data-testid="<subpropertyAnchor level={2}><inlineCode>always</inlineCode></subpropertyAnchor>"
@@ -516,7 +516,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </div>
           </td>
           <td
-            class="css-1sp938g-tableCellStyle-Cell"
+            class="css-yr5jng-tableCellStyle-Cell"
           >
             <div
               class=" css-pb2q8c-paragraph-STYLES_PARAGRAPH_DIV"
@@ -535,7 +535,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           class="css-1ne1f2k-tableRowStyle-Row"
         >
           <td
-            class="css-1rwbqei-tableCellStyle-fitContentStyle-Cell"
+            class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
           >
             <div
               data-testid="<subpropertyAnchor level={1}><inlineCode>backgroundColor</inlineCode></subpropertyAnchor>"
@@ -599,7 +599,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </div>
           </td>
           <td
-            class="css-1sp938g-tableCellStyle-Cell"
+            class="css-yr5jng-tableCellStyle-Cell"
           >
             <div
               class=" css-pb2q8c-paragraph-STYLES_PARAGRAPH_DIV"
@@ -629,7 +629,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           class="css-1ne1f2k-tableRowStyle-Row"
         >
           <td
-            class="css-1rwbqei-tableCellStyle-fitContentStyle-Cell"
+            class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
           >
             <div
               data-testid="<propertyAnchor level={0}><inlineCode>intentFilters</inlineCode></propertyAnchor>"
@@ -693,7 +693,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </div>
           </td>
           <td
-            class="css-1sp938g-tableCellStyle-Cell"
+            class="css-yr5jng-tableCellStyle-Cell"
           >
             <div
               class=" css-pb2q8c-paragraph-STYLES_PARAGRAPH_DIV"
@@ -792,7 +792,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           class="css-1ne1f2k-tableRowStyle-Row"
         >
           <td
-            class="css-1rwbqei-tableCellStyle-fitContentStyle-Cell"
+            class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
           >
             <div
               data-testid="<subpropertyAnchor level={1}><inlineCode>autoVerify</inlineCode></subpropertyAnchor>"
@@ -856,7 +856,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </div>
           </td>
           <td
-            class="css-1sp938g-tableCellStyle-Cell"
+            class="css-yr5jng-tableCellStyle-Cell"
           >
             <div
               class=" css-pb2q8c-paragraph-STYLES_PARAGRAPH_DIV"
@@ -875,7 +875,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           class="css-1ne1f2k-tableRowStyle-Row"
         >
           <td
-            class="css-1rwbqei-tableCellStyle-fitContentStyle-Cell"
+            class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
           >
             <div
               data-testid="<subpropertyAnchor level={1}><inlineCode>data</inlineCode></subpropertyAnchor>"
@@ -939,7 +939,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </div>
           </td>
           <td
-            class="css-1sp938g-tableCellStyle-Cell"
+            class="css-yr5jng-tableCellStyle-Cell"
           >
             <div
               class=" css-pb2q8c-paragraph-STYLES_PARAGRAPH_DIV"
@@ -957,7 +957,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           class="css-1ne1f2k-tableRowStyle-Row"
         >
           <td
-            class="css-1rwbqei-tableCellStyle-fitContentStyle-Cell"
+            class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
           >
             <div
               data-testid="<subpropertyAnchor level={2}><inlineCode>host</inlineCode></subpropertyAnchor>"
@@ -1021,7 +1021,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </div>
           </td>
           <td
-            class="css-1sp938g-tableCellStyle-Cell"
+            class="css-yr5jng-tableCellStyle-Cell"
           >
             <div
               class=" css-pb2q8c-paragraph-STYLES_PARAGRAPH_DIV"

--- a/docs/components/plugins/api/APISectionInterfaces.tsx
+++ b/docs/components/plugins/api/APISectionInterfaces.tsx
@@ -77,15 +77,15 @@ const renderInterfacePropertyRow = ({
   signatures,
 }: PropData): JSX.Element => (
   <Row key={name}>
-    <Cell>
+    <Cell fitContent>
       <B>
         {name}
         {signatures && signatures.length ? '()' : ''}
       </B>
       {renderFlags(flags)}
     </Cell>
-    <Cell>{renderTypeOrSignatureType(type, signatures)}</Cell>
-    <Cell>{renderInterfaceComment(comment, signatures)}</Cell>
+    <Cell fitContent>{renderTypeOrSignatureType(type, signatures)}</Cell>
+    <Cell fitContent>{renderInterfaceComment(comment, signatures)}</Cell>
   </Row>
 );
 

--- a/docs/components/plugins/api/APISectionTypes.tsx
+++ b/docs/components/plugins/api/APISectionTypes.tsx
@@ -82,8 +82,8 @@ const renderTypePropertyRow = ({
         <B>{name}</B>
         {renderFlags(flags)}
       </Cell>
-      <Cell>{renderTypeOrSignatureType(type, signatures)}</Cell>
-      <Cell>
+      <Cell fitContent>{renderTypeOrSignatureType(type, signatures)}</Cell>
+      <Cell fitContent>
         {commentData ? (
           <CommentTextBlock
             comment={commentData}

--- a/docs/ui/components/Table/Cell.tsx
+++ b/docs/ui/components/Table/Cell.tsx
@@ -16,7 +16,6 @@ export const Cell = ({ children, fitContent = false, textAlign = TextAlign.Left 
 const tableCellStyle = css({
   padding: spacing[4],
   verticalAlign: 'middle',
-  wordBreak: 'break-word',
   borderRight: `1px solid ${theme.border.default}`,
 
   '&:last-child': {
@@ -26,5 +25,4 @@ const tableCellStyle = css({
 
 const fitContentStyle = css({
   width: 'fit-content',
-  wordBreak: 'initial',
 });

--- a/docs/ui/components/Table/Table.tsx
+++ b/docs/ui/components/Table/Table.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { theme, borderRadius, typography, spacing } from '@expo/styleguide';
+import {theme, borderRadius, typography, spacing, shadows} from '@expo/styleguide';
 import React, { PropsWithChildren } from 'react';
 
 import { TableHeaders } from './TableHeaders';
@@ -34,8 +34,28 @@ export const Table = ({
 const tableWrapperStyle = css({
   border: `1px solid ${theme.border.default}`,
   borderRadius: borderRadius.medium,
-  overflow: 'hidden',
+  overflowY: 'hidden',
+  overflowX: 'auto',
   marginBottom: spacing[4],
+
+  '::-webkit-scrollbar': {
+    height: 6,
+  },
+
+  '::-webkit-scrollbar-track': {
+    background: theme.background.default,
+    borderBottomLeftRadius: borderRadius.medium,
+    borderBottomRightRadius: borderRadius.medium,
+  },
+
+  '::-webkit-scrollbar-thumb': {
+    background: theme.background.tertiary,
+    borderRadius: borderRadius.medium,
+
+    ':hover': {
+      background: theme.background.quaternary,
+    },
+  },
 });
 
 const tableStyle = css({

--- a/docs/ui/components/Table/Table.tsx
+++ b/docs/ui/components/Table/Table.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import {theme, borderRadius, typography, spacing, shadows} from '@expo/styleguide';
+import { theme, borderRadius, typography, spacing, shadows } from '@expo/styleguide';
 import React, { PropsWithChildren } from 'react';
 
 import { TableHeaders } from './TableHeaders';

--- a/docs/ui/components/Table/Table.tsx
+++ b/docs/ui/components/Table/Table.tsx
@@ -37,6 +37,7 @@ const tableWrapperStyle = css({
   overflowY: 'hidden',
   overflowX: 'auto',
   marginBottom: spacing[4],
+  boxShadow: shadows.micro,
 
   '::-webkit-scrollbar': {
     height: 6,


### PR DESCRIPTION
# Why

Currently, new tables are really hard to read on mobile, this is due to the the word break property and attempt to force the columns to fit in the container. It was a good idea, but in some edge cases it leads to unreadable content, let's fix this.

# How

This PR adds an ability to scroll the tables content horizontally on mobile and smaller viewports, which allowed the removal of the problematic in there word break rule. The appearance and readability is a bit better now, but still there is a room to improve. I will look on that soon.

I have also improved the API sections tables columns distribution and added the tiny shadow for all the tables (design tweak approved by Jon).

# Test Plan

The changes have been tested by running docs website locally.

# Preview

### Before
<img width="329" alt="Screenshot 2022-05-26 164331" src="https://user-images.githubusercontent.com/719641/170513430-b9da847b-9b30-476b-9d1a-438f97c02ab6.png">

<img width="857" alt="Screenshot 2022-05-26 164009" src="https://user-images.githubusercontent.com/719641/170513410-50e71d7a-6572-4991-90ec-6f6f4c941728.png">


### After
<img width="311" alt="Screenshot 2022-05-26 164203" src="https://user-images.githubusercontent.com/719641/170513932-9ece1731-b99d-4b17-ad49-8cfbcebf50ad.png">

<img width="853" alt="Screenshot 2022-05-26 165644" src="https://user-images.githubusercontent.com/719641/170514907-716e97aa-a243-4095-815f-6901fd0b88f7.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
