### PR TITLE
chore(cli): use `nxp expo install` for recommended missing dependency check

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 - Bump `@expo/xcpretty` to link to the troubleshooting guide. ([#17576](https://github.com/expo/expo/pull/17576) by [@EvanBacon](https://github.com/EvanBacon))
 - deduplicate asMock helper function. ([#17294](https://github.com/expo/expo/pull/17294) by [@wschurman](https://github.com/wschurman))
+- Use `nxp expo install` for recommended missing dependency check.
 - Make bundler implementation more bundler agnostic. ([#17575](https://github.com/expo/expo/pull/17575) by [@EvanBacon](https://github.com/EvanBacon))
 
 ## 0.1.3 — 2022-04-28

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -28,7 +28,7 @@
 
 - Bump `@expo/xcpretty` to link to the troubleshooting guide. ([#17576](https://github.com/expo/expo/pull/17576) by [@EvanBacon](https://github.com/EvanBacon))
 - deduplicate asMock helper function. ([#17294](https://github.com/expo/expo/pull/17294) by [@wschurman](https://github.com/wschurman))
-- Use `nxp expo install` for recommended missing dependency check.
+- Use `nxp expo install` for recommended missing dependency check. ([#17665](https://github.com/expo/expo/pull/17665) by [@EvanBacon](https://github.com/EvanBacon))
 - Make bundler implementation more bundler agnostic. ([#17575](https://github.com/expo/expo/pull/17575) by [@EvanBacon](https://github.com/EvanBacon))
 
 ## 0.1.3 — 2022-04-28

--- a/packages/@expo/cli/src/start/doctor/dependencies/__tests__/ensureDependenciesAsync-test.ts
+++ b/packages/@expo/cli/src/start/doctor/dependencies/__tests__/ensureDependenciesAsync-test.ts
@@ -1,37 +1,14 @@
 import { createInstallCommand } from '../ensureDependenciesAsync';
 
 describe(createInstallCommand, () => {
-  it(`formats yarn`, () => {
+  it(`formats install`, () => {
     expect(
       createInstallCommand({
-        manager: 'yarn',
         packages: [
           { pkg: 'bacon', file: '', version: '~1.0.0' },
           { pkg: 'other', file: '' },
         ],
       })
-    ).toBe('yarn add bacon@~1.0.0 other');
-  });
-  it(`formats npm`, () => {
-    expect(
-      createInstallCommand({
-        manager: 'npm',
-        packages: [
-          { pkg: '@other/pkg', file: '' },
-          { pkg: 'bacon', file: '', version: '~1.0.0' },
-        ],
-      })
-    ).toBe('npm install @other/pkg bacon@~1.0.0');
-  });
-  it(`formats pnpm`, () => {
-    expect(
-      createInstallCommand({
-        manager: 'pnpm',
-        packages: [
-          { pkg: '@other/pkg', file: '' },
-          { pkg: 'bacon', file: '', version: '~1.0.0' },
-        ],
-      })
-    ).toBe('pnpm install @other/pkg bacon@~1.0.0');
+    ).toBe('npx expo install bacon@~1.0.0 other');
   });
 });

--- a/packages/@expo/cli/src/start/doctor/dependencies/ensureDependenciesAsync.ts
+++ b/packages/@expo/cli/src/start/doctor/dependencies/ensureDependenciesAsync.ts
@@ -1,5 +1,4 @@
 import { ExpoConfig, getConfig } from '@expo/config';
-import * as PackageManager from '@expo/package-manager';
 import chalk from 'chalk';
 import wrapAnsi from 'wrap-ansi';
 
@@ -75,10 +74,7 @@ export async function ensureDependenciesAsync(
     title = '';
   }
 
-  const managerName = PackageManager.resolvePackageManager(projectRoot);
-
   const installCommand = createInstallCommand({
-    manager: managerName ?? 'npm',
     packages: missing,
   });
 
@@ -99,10 +95,8 @@ function wrapForTerminal(message: string): string {
 
 /** Create the bash install command from a given set of packages and settings. */
 export function createInstallCommand({
-  manager,
   packages,
 }: {
-  manager: PackageManager.NodePackageManager;
   packages: {
     file: string;
     pkg: string;
@@ -110,8 +104,7 @@ export function createInstallCommand({
   }[];
 }) {
   return (
-    (manager === 'yarn' ? `${manager} add` : `${manager} install`) +
-    ' ' +
+    'npx expo install ' +
     packages
       .map(({ pkg, version }) => {
         if (version) {


### PR DESCRIPTION

# Why

- Better continuity.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# Test Plan

- Tests should cover this