### PR TITLE
fix(cli): prevent starting tunnel on web to ensure native works

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Fix ADB device name filtering for windows. ([#17286](https://github.com/expo/expo/pull/17286) by [@byCedric](https://github.com/byCedric))
 - Fix `export` bug failing when no assets are included. ([#17414](https://github.com/expo/expo/pull/17414) by [@EvanBacon](https://github.com/EvanBacon))
 - Add correct packages (`expo-splash-screen`) and drop incorrect required packages (`react-native-unimodules`, `expo-updates`) in prebuild. ([#17447](https://github.com/expo/expo/pull/17447) by [@EvanBacon](https://github.com/EvanBacon))
+- Fix tunnel on web breaking native.
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -23,7 +23,7 @@
 - Fix ADB device name filtering for windows. ([#17286](https://github.com/expo/expo/pull/17286) by [@byCedric](https://github.com/byCedric))
 - Fix `export` bug failing when no assets are included. ([#17414](https://github.com/expo/expo/pull/17414) by [@EvanBacon](https://github.com/EvanBacon))
 - Add correct packages (`expo-splash-screen`) and drop incorrect required packages (`react-native-unimodules`, `expo-updates`) in prebuild. ([#17447](https://github.com/expo/expo/pull/17447) by [@EvanBacon](https://github.com/EvanBacon))
-- Fix tunnel on web breaking native.
+- Fix tunnel on web breaking native. ([#17666](https://github.com/expo/expo/pull/17666) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/BundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/BundlerDevServer.ts
@@ -189,8 +189,17 @@ export abstract class BundlerDevServer {
     };
   }
 
+  /**
+   * Runs after the `startAsync` function, performing any additional common operations.
+   * You can assume the dev server is started by the time this function is called.
+   */
   protected async postStartAsync(options: BundlerStartOptions) {
-    if (options.location.hostType === 'tunnel' && !APISettings.isOffline) {
+    if (
+      options.location.hostType === 'tunnel' &&
+      !APISettings.isOffline &&
+      // This is a hack to prevent using tunnel on web since we block it upstream for some reason.
+      this.isTargetingNative()
+    ) {
       await this._startTunnelAsync();
     }
     await this.startDevSessionAsync();


### PR DESCRIPTION
# Why

- Running multiple instances of tunnel breaks all instances of tunnel, this PR prevents a user from starting tunnel on web to ensure native tunnels continue to work.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- `expo start --tunnel` open on web then on native, should work (whereas before the native tunnel wouldn't connect).

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
