### PR TITLE
[ios] Implement sweet typed arrays

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -1375,7 +1375,7 @@ SPEC CHECKSUMS:
   ExpoLinearGradient: 0debcf7d6cd7fea3050c218544f0db2de9a64f42
   ExpoLocalization: 8f619bb6eec64575cd5220bfabbd7b4e2d6f33f8
   ExpoMailComposer: 9eaf63bec7ec619ca84b30d7f8eb7169ed12db8b
-  ExpoModulesCore: 4093531a41eb8b2e3b508ee519afbd84b09de727
+  ExpoModulesCore: 72ed9a7a84b8184e3bffc3e4739d4ecc038de08b
   ExpoRandom: 14df0976aa363a71a730ceb7655250f3047c0e42
   ExpoSystemUI: 6175204b809d9598d56e5a711480415d28c9fb5b
   ExpoWebBrowser: 818c519c3519cdd79780228039938fbd8236c885

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -4375,7 +4375,7 @@ SPEC CHECKSUMS:
   ExpoLinearGradient: 0debcf7d6cd7fea3050c218544f0db2de9a64f42
   ExpoLocalization: 8f619bb6eec64575cd5220bfabbd7b4e2d6f33f8
   ExpoMailComposer: 9eaf63bec7ec619ca84b30d7f8eb7169ed12db8b
-  ExpoModulesCore: 4093531a41eb8b2e3b508ee519afbd84b09de727
+  ExpoModulesCore: 72ed9a7a84b8184e3bffc3e4739d4ecc038de08b
   ExpoModulesTestCore: 200e6d0280f7842d915eab63d0c6b298b4dff530
   ExpoRandom: 14df0976aa363a71a730ceb7655250f3047c0e42
   ExpoSystemUI: 6175204b809d9598d56e5a711480415d28c9fb5b

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Implemented classes in the Sweet API on iOS. ([#17514](https://github.com/expo/expo/pull/17514), [#17525](https://github.com/expo/expo/pull/17525) by [@tsapeta](https://github.com/tsapeta))
 - Add basic support for sync functions in the Sweet API on Android. ([#16977](https://github.com/expo/expo/pull/16977) by [@lukmccall](https://github.com/lukmccall))
 - Better error handling in the synchronous functions on iOS. ([#17628](https://github.com/expo/expo/pull/17628) by [@tsapeta](https://github.com/tsapeta))
+- Experimental support for typed arrays on iOS. ([#17667](https://github.com/expo/expo/pull/17667) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/ExpoModulesCore.podspec
+++ b/packages/expo-modules-core/ios/ExpoModulesCore.podspec
@@ -34,7 +34,7 @@ Pod::Spec.new do |s|
     s.source_files = '**/*.h'
     s.vendored_frameworks = "#{s.name}.xcframework"
   else
-    s.source_files = '**/*.{h,m,mm,swift}'
+    s.source_files = '**/*.{h,m,mm,swift,cpp}'
   end
 
   s.exclude_files = 'Tests/'

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptTypedArray.h
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptTypedArray.h
@@ -1,0 +1,30 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+#import <Foundation/Foundation.h>
+#import <ExpoModulesCore/EXJavaScriptObject.h>
+#import <ExpoModulesCore/EXJavaScriptRuntime.h>
+
+// We need to redefine the C++ enum (see TypedArray.h) in an Objective-C way to expose it to Swift.
+// Please keep them in-sync!
+typedef NS_ENUM(NSInteger, EXTypedArrayKind) {
+  Int8Array = 1,
+  Int16Array = 2,
+  Int32Array = 3,
+  Uint8Array = 4,
+  Uint8ClampedArray = 5,
+  Uint16Array = 6,
+  Uint32Array = 7,
+  Float32Array = 8,
+  Float64Array = 9,
+  BigInt64Array = 10,
+  BigUint64Array = 11,
+} NS_SWIFT_NAME(TypedArrayKind);
+
+NS_SWIFT_NAME(JavaScriptTypedArray)
+@interface EXJavaScriptTypedArray : EXJavaScriptObject
+
+@property (nonatomic) EXTypedArrayKind kind;
+
+- (nonnull void *)getUnsafeMutableRawPointer;
+
+@end

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptTypedArray.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptTypedArray.mm
@@ -1,0 +1,29 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+#import <ExpoModulesCore/EXJavaScriptTypedArray.h>
+#import <ExpoModulesCore/TypedArray.h>
+
+@implementation EXJavaScriptTypedArray {
+  __weak EXJavaScriptRuntime *_runtime;
+
+  std::shared_ptr<expo::TypedArray> _typedArrayPtr;
+}
+
+- (nonnull instancetype)initWith:(std::shared_ptr<jsi::Object>)jsObjectPtr
+                         runtime:(EXJavaScriptRuntime *)runtime
+{
+  if (self = [super initWith:jsObjectPtr runtime:runtime]) {
+    jsi::Runtime *rt = [runtime get];
+    _runtime = runtime;
+    _typedArrayPtr = std::make_shared<expo::TypedArray>(*rt, *jsObjectPtr.get());
+    _kind = (EXTypedArrayKind)_typedArrayPtr->getKind(*rt);
+  }
+  return self;
+}
+
+- (nonnull void *)getUnsafeMutableRawPointer
+{
+  return _typedArrayPtr->getRawPointer(*[_runtime get]);
+}
+
+@end

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptValue.h
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptValue.h
@@ -9,6 +9,7 @@ namespace jsi = facebook::jsi;
 #endif // __cplusplus
 
 @class EXJavaScriptRuntime;
+@class EXJavaScriptTypedArray;
 
 /**
  Represents any JavaScript value. Its purpose is to exposes `facebook::jsi::Value` API back to Swift.
@@ -36,6 +37,7 @@ NS_SWIFT_NAME(JavaScriptValue)
 - (BOOL)isSymbol;
 - (BOOL)isObject;
 - (BOOL)isFunction;
+- (BOOL)isTypedArray;
 
 #pragma mark - Type casting
 
@@ -47,6 +49,7 @@ NS_SWIFT_NAME(JavaScriptValue)
 - (nonnull NSArray<EXJavaScriptValue *> *)getArray;
 - (nonnull NSDictionary<NSString *, id> *)getDictionary;
 - (nonnull EXJavaScriptObject *)getObject;
+- (nullable EXJavaScriptTypedArray *)getTypedArray;
 
 #pragma mark - Helpers
 

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptValue.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptValue.mm
@@ -3,6 +3,8 @@
 #import <ExpoModulesCore/EXJSIConversions.h>
 #import <ExpoModulesCore/EXJavaScriptValue.h>
 #import <ExpoModulesCore/EXJavaScriptRuntime.h>
+#import <ExpoModulesCore/EXJavaScriptTypedArray.h>
+#import <ExpoModulesCore/TypedArray.h>
 
 @implementation EXJavaScriptValue {
   __weak EXJavaScriptRuntime *_runtime;
@@ -70,6 +72,15 @@
   return false;
 }
 
+- (BOOL)isTypedArray
+{
+  if (_value->isObject()) {
+    jsi::Runtime *runtime = [_runtime get];
+    return expo::isTypedArray(*runtime, _value->getObject(*runtime));
+  }
+  return false;
+}
+
 #pragma mark - Type casting
 
 - (nullable id)getRaw
@@ -129,6 +140,16 @@
   jsi::Runtime *runtime = [_runtime get];
   std::shared_ptr<jsi::Object> objectPtr = std::make_shared<jsi::Object>(_value->asObject(*runtime));
   return [[EXJavaScriptObject alloc] initWith:objectPtr runtime:_runtime];
+}
+
+- (nullable EXJavaScriptTypedArray *)getTypedArray
+{
+  if (![self isTypedArray]) {
+    return nil;
+  }
+  jsi::Runtime *runtime = [_runtime get];
+  std::shared_ptr<jsi::Object> objectPtr = std::make_shared<jsi::Object>(_value->asObject(*runtime));
+  return [[EXJavaScriptTypedArray alloc] initWith:objectPtr runtime:_runtime];
 }
 
 #pragma mark - Helpers

--- a/packages/expo-modules-core/ios/JSI/JavaScriptValue.swift
+++ b/packages/expo-modules-core/ios/JSI/JavaScriptValue.swift
@@ -85,6 +85,13 @@ public extension JavaScriptValue {
     }
     throw JavaScriptValueConversionException((kind: kind, target: "Object"))
   }
+
+  func asTypedArray() throws -> JavaScriptTypedArray {
+    if let typedArray = getTypedArray() {
+      return typedArray
+    }
+    throw JavaScriptValueConversionException((kind: kind, target: "TypedArray"))
+  }
 }
 
 internal final class JavaScriptValueConversionException: GenericException<(kind: JavaScriptValueKind, target: String)> {

--- a/packages/expo-modules-core/ios/JSI/TypedArray.cpp
+++ b/packages/expo-modules-core/ios/JSI/TypedArray.cpp
@@ -1,0 +1,70 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+#include <unordered_map>
+#include "TypedArray.h"
+
+namespace expo {
+
+std::unordered_map<std::string, TypedArrayKind> nameToKindMap = {
+    {"Int8Array", TypedArrayKind::Int8Array},
+    {"Int16Array", TypedArrayKind::Int16Array},
+    {"Int32Array", TypedArrayKind::Int32Array},
+    {"Uint8Array", TypedArrayKind::Uint8Array},
+    {"Uint8ClampedArray", TypedArrayKind::Uint8ClampedArray},
+    {"Uint16Array", TypedArrayKind::Uint16Array},
+    {"Uint32Array", TypedArrayKind::Uint32Array},
+    {"Float32Array", TypedArrayKind::Float32Array},
+    {"Float64Array", TypedArrayKind::Float64Array},
+    {"BigInt64Array", TypedArrayKind::BigInt64Array},
+    {"BigUint64Array", TypedArrayKind::BigUint64Array},
+};
+
+TypedArrayKind getTypedArrayKindForName(const std::string &name) {
+  return nameToKindMap.at(name);
+}
+
+TypedArray::TypedArray(jsi::Runtime &runtime, const jsi::Object &obj)
+    : jsi::Object(jsi::Value(runtime, obj).asObject(runtime)) {}
+
+TypedArrayKind TypedArray::getKind(jsi::Runtime &runtime) const {
+  auto constructorName = this->getPropertyAsObject(runtime, "constructor")
+                             .getProperty(runtime, "name")
+                             .asString(runtime)
+                             .utf8(runtime);
+  return getTypedArrayKindForName(constructorName);
+};
+
+size_t TypedArray::byteOffset(jsi::Runtime &runtime) const {
+  return getProperty(runtime, "byteOffset").asNumber();
+}
+
+jsi::ArrayBuffer TypedArray::getBuffer(jsi::Runtime &runtime) const {
+  auto buffer = getProperty(runtime, "buffer");
+  if (buffer.isObject() && buffer.asObject(runtime).isArrayBuffer(runtime)) {
+    return buffer.asObject(runtime).getArrayBuffer(runtime);
+  } else {
+    throw std::runtime_error("no ArrayBuffer attached");
+  }
+}
+
+void* TypedArray::getRawPointer(jsi::Runtime &runtime) {
+  return reinterpret_cast<void *>(getBuffer(runtime).data(runtime) + byteOffset(runtime));
+}
+
+bool isTypedArray(jsi::Runtime &runtime, const jsi::Object &jsObj) {
+  jsi::Object ArrayBuffer = runtime
+    .global()
+    .getPropertyAsObject(runtime, "ArrayBuffer");
+
+  jsi::Value isViewResult = ArrayBuffer
+    .getPropertyAsFunction(runtime, "isView")
+    .callWithThis(runtime, ArrayBuffer, {jsi::Value(runtime, jsObj)});
+
+  if (isViewResult.isBool()) {
+    return isViewResult.getBool();
+  } else {
+    throw std::runtime_error("value is not a boolean");
+  }
+}
+
+} // namespace expo

--- a/packages/expo-modules-core/ios/JSI/TypedArray.cpp
+++ b/packages/expo-modules-core/ios/JSI/TypedArray.cpp
@@ -60,11 +60,8 @@ bool isTypedArray(jsi::Runtime &runtime, const jsi::Object &jsObj) {
     .getPropertyAsFunction(runtime, "isView")
     .callWithThis(runtime, ArrayBuffer, {jsi::Value(runtime, jsObj)});
 
-  if (isViewResult.isBool()) {
-    return isViewResult.getBool();
-  } else {
-    throw std::runtime_error("value is not a boolean");
-  }
+  assert(isViewResult.isBool())
+  return isViewResult.getBool();
 }
 
 } // namespace expo

--- a/packages/expo-modules-core/ios/JSI/TypedArray.h
+++ b/packages/expo-modules-core/ios/JSI/TypedArray.h
@@ -1,0 +1,46 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+#ifdef __cplusplus
+
+#include <jsi/jsi.h>
+
+namespace jsi = facebook::jsi;
+
+namespace expo {
+
+// Please keep it in-sync with the `EXTypedArrayKind` in Objective-C.
+// We need to maintain two implementations to expose this enum to Swift.
+enum class TypedArrayKind {
+  Int8Array = 1,
+  Int16Array = 2,
+  Int32Array = 3,
+  Uint8Array = 4,
+  Uint8ClampedArray = 5,
+  Uint16Array = 6,
+  Uint32Array = 7,
+  Float32Array = 8,
+  Float64Array = 9,
+  BigInt64Array = 10,
+  BigUint64Array = 11,
+};
+
+class TypedArray : public jsi::Object {
+ public:
+  TypedArray(jsi::Runtime &, const jsi::Object &);
+  TypedArray(TypedArray &&) = default;
+  TypedArray &operator=(TypedArray &&) = default;
+
+  TypedArrayKind getKind(jsi::Runtime &runtime) const;
+
+  size_t byteOffset(jsi::Runtime &runtime) const;
+
+  jsi::ArrayBuffer getBuffer(jsi::Runtime &runtime) const;
+
+  void* getRawPointer(jsi::Runtime &runtime);
+};
+
+bool isTypedArray(jsi::Runtime &runtime, const jsi::Object &jsObj);
+
+} // namespace expo
+
+#endif // __cplusplus

--- a/packages/expo-modules-core/ios/Swift/Arguments/AnyArgument.swift
+++ b/packages/expo-modules-core/ios/Swift/Arguments/AnyArgument.swift
@@ -7,8 +7,23 @@ public protocol AnyArgument {}
 
 // Extend the primitive types — these may come from React Native bridge.
 extension Bool: AnyArgument {}
+
 extension Int: AnyArgument {}
+extension Int8: AnyArgument {}
+extension Int16: AnyArgument {}
+extension Int32: AnyArgument {}
+extension Int64: AnyArgument {}
+
+extension UInt: AnyArgument {}
+extension UInt8: AnyArgument {}
+extension UInt16: AnyArgument {}
+extension UInt32: AnyArgument {}
+extension UInt64: AnyArgument {}
+
+extension Float32: AnyArgument {}
 extension Double: AnyArgument {}
+
 extension String: AnyArgument {}
 extension Array: AnyArgument {}
 extension Dictionary: AnyArgument {}
+

--- a/packages/expo-modules-core/ios/Swift/DynamicTypes/DynamicType.swift
+++ b/packages/expo-modules-core/ios/Swift/DynamicTypes/DynamicType.swift
@@ -24,6 +24,9 @@ internal func DynamicType<T>(_ type: T.Type) -> AnyDynamicType {
   if let SharedObjectType = T.self as? SharedObject.Type {
     return DynamicSharedObjectType(innerType: SharedObjectType)
   }
+  if let TypedArrayType = T.self as? AnyTypedArray.Type {
+    return DynamicTypedArrayType(innerType: TypedArrayType)
+  }
   return DynamicRawType(innerType: T.self)
 }
 

--- a/packages/expo-modules-core/ios/Swift/DynamicTypes/DynamicTypedArrayType.swift
+++ b/packages/expo-modules-core/ios/Swift/DynamicTypes/DynamicTypedArrayType.swift
@@ -1,0 +1,46 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+internal struct DynamicTypedArrayType: AnyDynamicType {
+  let innerType: AnyTypedArray.Type
+
+  func wraps<InnerType>(_ type: InnerType.Type) -> Bool {
+    return innerType == InnerType.self
+  }
+
+  func equals(_ type: AnyDynamicType) -> Bool {
+    if let typedArrayType = type as? Self {
+      return typedArrayType.innerType == innerType
+    }
+    return false
+  }
+
+  func cast<ValueType>(_ value: ValueType) throws -> Any {
+    // It must be a JavaScript typed array.
+    guard let value = value as? JavaScriptValue, let jsTypedArray = value.getTypedArray() else {
+      throw NotTypedArrayException(innerType)
+    }
+    let typedArray = TypedArray.create(from: jsTypedArray)
+
+    // Concrete typed arrays must be the same as the inner type.
+    guard innerType == TypedArray.self || type(of: typedArray) == innerType else {
+      throw ArrayTypeMismatchException((received: type(of: typedArray), expected: innerType))
+    }
+    return typedArray
+  }
+
+  var description: String {
+    return String(describing: innerType)
+  }
+}
+
+internal final class ArrayTypeMismatchException: GenericException<(received: Any.Type, expected: Any.Type)> {
+  override var reason: String {
+    "Received a typed array of type \(param.received), expected \(param.expected)"
+  }
+}
+
+internal final class NotTypedArrayException: GenericException<AnyTypedArray.Type> {
+  override var reason: String {
+    "Given argument is not an instance of \(param)"
+  }
+}

--- a/packages/expo-modules-core/ios/Swift/JavaScriptUtils.swift
+++ b/packages/expo-modules-core/ios/Swift/JavaScriptUtils.swift
@@ -12,7 +12,7 @@
  */
 internal func cast(_ value: Any, toType type: AnyDynamicType) throws -> Any {
   // TODO: Accept JavaScriptValue and JavaScriptObject as argument types.
-  if let value = value as? JavaScriptValue {
+  if !(type is DynamicTypedArrayType), let value = value as? JavaScriptValue {
     return try type.cast(value.getRaw())
   }
   return try type.cast(value)

--- a/packages/expo-modules-core/ios/Swift/TypedArrays/AnyTypedArray.swift
+++ b/packages/expo-modules-core/ios/Swift/TypedArrays/AnyTypedArray.swift
@@ -1,0 +1,11 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+/**
+ A protocol for all typed arrays.
+ */
+internal protocol AnyTypedArray: AnyArgument {
+  /**
+   Initializes a typed array from the given JavaScript representation.
+   */
+  init(_ jsTypedArray: JavaScriptTypedArray)
+}

--- a/packages/expo-modules-core/ios/Swift/TypedArrays/ConcreteTypedArrays.swift
+++ b/packages/expo-modules-core/ios/Swift/TypedArrays/ConcreteTypedArrays.swift
@@ -1,0 +1,56 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+/**
+ Native equivalent of `Int8Array` in JavaScript, an array of two's-complement 8-bit signed integers.
+ */
+public final class Int8Array: GenericTypedArray<Int8> {}
+
+/**
+ Native equivalent of `Int16Array` in JavaScript, an array of two's-complement 16-bit signed integers.
+ */
+public final class Int16Array: GenericTypedArray<Int16> {}
+
+/**
+ Native equivalent of `Int32Array` in JavaScript, an array of two's-complement 32-bit signed integers.
+ */
+public final class Int32Array: GenericTypedArray<Int32> {}
+
+/**
+ Native equivalent of `Uint8Array` in JavaScript, an array of 8-bit unsigned integers.
+ */
+public final class Uint8Array: GenericTypedArray<UInt8> {}
+
+/**
+ Native equivalent of `Uint8ClampedArray` in JavaScript, an array of 8-bit unsigned integers clamped to 0-255.
+ */
+public final class Uint8ClampedArray: GenericTypedArray<UInt8> {}
+
+/**
+ Native equivalent of `Uint16Array` in JavaScript, an array of 16-bit unsigned integers.
+ */
+public final class Uint16Array: GenericTypedArray<UInt16> {}
+
+/**
+ Native equivalent of `Uint32Array` in JavaScript, an array of 32-bit unsigned integers.
+ */
+public final class Uint32Array: GenericTypedArray<UInt32> {}
+
+/**
+ Native equivalent of `Float32Array` in JavaScript, an array of 32-bit floating point numbers.
+ */
+public final class Float32Array: GenericTypedArray<Float32> {}
+
+/**
+ Native equivalent of `Float64Array` in JavaScript, an array of 64-bit floating point numbers.
+ */
+public final class Float64Array: GenericTypedArray<Float64> {}
+
+/**
+ Native equivalent of `BigInt64Array` in JavaScript, an array of 64-bit signed integers.
+ */
+public final class BigInt64Array: GenericTypedArray<Int64> {}
+
+/**
+ Native equivalent of `BigUint64Array` in JavaScript, an array of 64-bit unsigned integers.
+ */
+public final class BigUint64Array: GenericTypedArray<UInt64> {}

--- a/packages/expo-modules-core/ios/Swift/TypedArrays/GenericTypedArray.swift
+++ b/packages/expo-modules-core/ios/Swift/TypedArrays/GenericTypedArray.swift
@@ -1,0 +1,49 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+/**
+ Generic TypedArray with an associated numeric ContentType (e.g. UInt8, Int16, Double).
+ */
+public class GenericTypedArray<ContentType: Numeric>: TypedArray {
+  /**
+   The unsafe mutable typed buffer that shares the same memory as the underlying JavaScript `ArrayBuffer`.
+   */
+  lazy var buffer = UnsafeMutableBufferPointer<ContentType>(start: pointer, count: length)
+
+  /**
+   The unsafe mutable typed pointer to the start of the array buffer.
+   */
+  lazy var pointer = rawPointer.bindMemory(to: ContentType.self, capacity: length)
+
+  public subscript(index: Int) -> ContentType {
+    get {
+      return buffer[index]
+    }
+    set {
+      buffer[index] = newValue
+    }
+  }
+
+  subscript(range: Range<Int>) -> [ContentType] {
+    get {
+      return Array(buffer[range])
+    }
+    set {
+      var newValues = newValue
+      newValues.withUnsafeMutableBufferPointer { newValuesBuffer in
+        buffer[range] = newValuesBuffer[0..<(range.upperBound - range.lowerBound)]
+      }
+    }
+  }
+
+  subscript(range: ClosedRange<Int>) -> [ContentType] {
+    get {
+      return Array(buffer[range])
+    }
+    set {
+      var newValues = newValue
+      newValues.withUnsafeMutableBufferPointer { newValuesBuffer in
+        buffer[range] = newValuesBuffer[0...(range.upperBound - range.lowerBound)]
+      }
+    }
+  }
+}

--- a/packages/expo-modules-core/ios/Swift/TypedArrays/TypedArray.swift
+++ b/packages/expo-modules-core/ios/Swift/TypedArrays/TypedArray.swift
@@ -1,0 +1,80 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+/**
+ The base class for any type of the typed array.
+ */
+public class TypedArray: AnyTypedArray {
+  /**
+   Creates a concrete TypedArray from the given JavaScriptTypedArray
+   */
+  internal static func create(from jsTypedArray: JavaScriptTypedArray) -> TypedArray {
+    switch jsTypedArray.kind {
+    case .Int8Array:
+      return Int8Array(jsTypedArray)
+    case .Int16Array:
+      return Int16Array(jsTypedArray)
+    case .Int32Array:
+      return Int32Array(jsTypedArray)
+    case .Uint8Array:
+      return Uint8Array(jsTypedArray)
+    case .Uint8ClampedArray:
+      return Uint8ClampedArray(jsTypedArray)
+    case .Uint16Array:
+      return Uint16Array(jsTypedArray)
+    case .Uint32Array:
+      return Uint32Array(jsTypedArray)
+    case .Float32Array:
+      return Float32Array(jsTypedArray)
+    case .Float64Array:
+      return Float64Array(jsTypedArray)
+    case .BigInt64Array:
+      return BigInt64Array(jsTypedArray)
+    case .BigUint64Array:
+      return BigUint64Array(jsTypedArray)
+    @unknown default:
+      fatalError("Unknown kind of the TypedArray")
+    }
+  }
+
+  /**
+   A JavaScript object of the underlying typed array.
+   */
+  let jsTypedArray: JavaScriptTypedArray
+
+  /**
+   The length in bytes from the start of the underlying ArrayBuffer.
+   Fixed at construction time and thus read-only.
+   */
+  public lazy var byteLength: Int = jsTypedArray.getProperty("byteLength").getInt()
+
+  /**
+   The offset in bytes from the start of the underlying ArrayBuffer.
+   Fixed at construction time and thus read-only.
+   */
+  public lazy var byteOffset: Int = jsTypedArray.getProperty("byteOffset").getInt()
+
+  /**
+   Returns the number of elements held in the typed array.
+   Fixed at construction time and thus read only.
+   */
+  public lazy var length: Int = jsTypedArray.getProperty("length").getInt()
+
+  /**
+   The unsafe mutable raw pointer to the start of the array buffer.
+   */
+  public lazy var rawPointer: UnsafeMutableRawPointer = jsTypedArray.getUnsafeMutableRawPointer()
+
+  /**
+   Returns the kind of the typed array, such as `Int8Array` or `Float32Array`.
+   */
+  public var kind: TypedArrayKind {
+    return jsTypedArray.kind
+  }
+
+  /**
+   Initializes the typed array with the given JS typed array.
+   */
+  required init(_ jsTypedArray: JavaScriptTypedArray) {
+    self.jsTypedArray = jsTypedArray
+  }
+}

--- a/packages/expo-modules-core/ios/Tests/TypedArraysSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/TypedArraysSpec.swift
@@ -1,0 +1,136 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+import ExpoModulesTestCore
+
+@testable import ExpoModulesCore
+
+final class TypedArraysSpec: ExpoSpec {
+  override func spec() {
+    describe("module") {
+      let appContext = AppContext.create()
+      let runtime = appContext.runtime!
+
+      beforeSuite {
+        appContext.moduleRegistry.register(moduleType: TypedArraysModule.self)
+      }
+
+      // Gets the value at index 3 from the array
+      it("reads from Int8Array") {
+        let intValue = try runtime
+          .eval([
+            "typedArray = new Int8Array([2, 1, 3, 7])",
+            "ExpoModules.TypedArrays.int8_subscript_get(typedArray, 3)",
+          ])
+          .asInt()
+
+        expect(intValue) == 7
+      }
+
+      // Sets the value at index 1 to the random int
+      it("writes to Int8Array") {
+        let randomInt = Int.random(in: -128...127)
+        let array = try runtime
+          .eval([
+            "typedArray = new Int8Array(3)",
+            "ExpoModules.TypedArrays.int8_subscript_set(typedArray, 1, \(randomInt))",
+            "Array.from(typedArray)",
+          ])
+          .asArray()
+
+        expect(array[0]?.getInt()) == 0 // Remains unset
+        expect(array[1]?.getInt()) == randomInt
+        expect(array[2]?.getInt()) == 0 // Remains unset
+      }
+
+      // Gets a slice from the array from index 1 to 3
+      it("reads from UInt16Array slice") {
+        let values = try runtime
+          .eval([
+            "typedArray = new Uint16Array([0, 8, 4, 1])",
+            "ExpoModules.TypedArrays.uint16_subscript_range_get(typedArray, 1, 3)"
+          ])
+          .asArray()
+          .map({ try $0?.asInt() })
+
+        expect(values.count) == 3
+        expect(values[0]) == 8
+        expect(values[1]) == 4
+        expect(values[2]) == 1
+      }
+
+      // Sets a slice of the array from index x to y
+      it("writes to UInt16Array slice") {
+        let random1 = Int.random(in: 0...65535)
+        let random2 = Int.random(in: 0...65535)
+        let values = try runtime
+          .eval([
+            "typedArray = new Uint16Array(4)",
+            "ExpoModules.TypedArrays.uint16_subscript_range_set(typedArray, 1, 2, [\(random1), \(random2)])",
+            "Array.from(typedArray)",
+          ])
+          .asArray()
+
+        expect(values[0]?.getInt()) == 0 // Remains unset
+        expect(values[1]?.getInt()) == random1
+        expect(values[2]?.getInt()) == random2
+        expect(values[3]?.getInt()) == 0 // Remains unset
+      }
+
+      it("returns itself") {
+        let input = try runtime.eval("typedArray = new Float32Array([1.2, 3.4]); typedArray").asTypedArray()
+        let output = try runtime.eval("ExpoModules.TypedArrays.return(typedArray)").asTypedArray()
+
+        expect(input.getProperty("0").getDouble()) == output.getProperty("0").getDouble()
+        expect(input.getProperty("1").getDouble()) == output.getProperty("1").getDouble()
+        expect(input.getUnsafeMutableRawPointer()) == output.getUnsafeMutableRawPointer()
+      }
+
+      it("writes to unsafe raw pointer") {
+        let count = 6
+        let values = try runtime
+          .eval([
+            "typedArray = new Uint8Array(\(count))",
+            "Array.from(ExpoModules.TypedArrays.writeToUnsafeRawPointer(typedArray))",
+          ])
+          .asArray()
+          .map({ $0?.getInt() ?? 0 })
+
+        // Assume that at least one element should have changed
+        expect(values.filter({ $0 != 0 }).count) >= 1
+      }
+
+      // TODO: Test throwing NotTypedArrayException and ArrayTypeMismatchException
+    }
+  }
+}
+
+fileprivate final class TypedArraysModule: Module {
+  func definition() -> ModuleDefinition {
+    Name("TypedArrays")
+
+    Function("int8_subscript_get") { (array: Int8Array, index: Int) in
+      return array[index]
+    }
+
+    Function("int8_subscript_set") { (array: Int8Array, index: Int, value: Int8) in
+      array[index] = value
+    }
+
+    Function("uint16_subscript_range_get") { (array: Uint16Array, start: Int, end: Int) in
+      return array[start...end]
+    }
+
+    Function("uint16_subscript_range_set") { (array: Uint16Array, start: Int, end: Int, values: [UInt16]) in
+      array[start...end] = values
+    }
+
+    Function("return") { (array: TypedArray) -> JavaScriptTypedArray in
+      return array.jsTypedArray
+    }
+
+    Function("writeToUnsafeRawPointer") { (array: TypedArray) -> JavaScriptTypedArray in
+      let _ = SecRandomCopyBytes(kSecRandomDefault, array.byteLength, array.rawPointer)
+      return array.jsTypedArray
+    }
+  }
+}


### PR DESCRIPTION
# Why

Closes ENG-4821

# How

- Some C++ utils to deal with typed arrays (it's missing in JSI)
- Made classes for typed arrays on both sides: native and JS
- Added a new dynamic type — `DynamicTypedArrayType`
- Added new test spec

# Test Plan

All tests (including new ones) are passing
