### PR TITLE
[e-m-c][Android Add enum auto-conversion tests

### DIFF
--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/records/RecordTypeConverterTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/records/RecordTypeConverterTest.kt
@@ -248,4 +248,44 @@ class RecordTypeConverterTest {
     Truth.assertThat(myRecord.innerRecord).isEqualTo(InnerRecord().apply { name = "value" })
     Truth.assertThat(myRecord.points).isEqualTo(listOf(1.0, 2.0, 3.0))
   }
+
+  enum class EnumWithoutParameter {
+    VALUE1, VALUE2, VALUE3
+  }
+
+  enum class EnumWithInt(val value: Int) {
+    VALUE1(1), VALUE2(2), VALUE3(3)
+  }
+
+  enum class EnumWithString(val value: String) {
+    VALUE1("value1"), VALUE2("value2"), VALUE3("value3")
+  }
+
+  @Test
+  fun `should work with enums`() {
+    class MyRecord : Record {
+      @Field
+      lateinit var enumWithoutParameter: EnumWithoutParameter
+
+      @Field
+      lateinit var enumWithInt: EnumWithInt
+
+      @Field
+      lateinit var enumWithString: EnumWithString
+    }
+
+    val map = DynamicFromObject(
+      JavaOnlyMap().apply {
+        putString("enumWithoutParameter", "VALUE2")
+        putInt("enumWithInt", 1)
+        putString("enumWithString", "value3")
+      }
+    )
+
+    val myRecord = convert<MyRecord>(map)
+
+    Truth.assertThat(myRecord.enumWithoutParameter).isEqualTo(EnumWithoutParameter.VALUE2)
+    Truth.assertThat(myRecord.enumWithInt).isEqualTo(EnumWithInt.VALUE1)
+    Truth.assertThat(myRecord.enumWithString).isEqualTo(EnumWithString.VALUE3)
+  }
 }


### PR DESCRIPTION
# Why

While working with migrating `expo-image` to `Sweet API` I've observed there's no showcase/tests how nested enums are being auto-converted.
- Extracted from #16251

# How

I've provided 3 tests:
- [x] for enums without values
- [x] for enums with string values
- [x] for enums with int values

# Test Plan

Run the test