### PR TITLE
[github] fix docs issues label, require link

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,7 +1,7 @@
 name: "\U0001F4C3 Documentation Bug"
 description: 'You want to report something that is wrong or missing from the documentation.'
 title: '[docs] '
-labels: 'project: docs'
+labels: 'docs'
 body:
   - type: markdown
     attributes:
@@ -15,6 +15,8 @@ body:
   - type: input
     attributes:
       label: Link to the related docs page
+    validations:
+      required: true
   - type: markdown
     attributes:
       value: If this is a typo, or something you feel up to fixing, please do so! You can edit any page in our docs by scrolling to the bottom and selecting `Edit this page`.


### PR DESCRIPTION
# Why

Currently, documentation issues do not have any label attached. 

It looks like the label name have been changed with time.

# How

This PR fixes the documentation issues label and adds requirement for filling the docs page URL.

# Test Plan

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
