### PR TITLE
[sweet API][Kotlin] Add `JavaScriptObject.setProperty`

### DIFF
--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptObjectTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptObjectTest.kt
@@ -8,6 +8,10 @@ import org.junit.Test
 class JavaScriptObjectTest {
   private lateinit var jsiInterop: JSIInteropModuleRegistry
 
+  private fun emptyObject(): JavaScriptObject {
+    return jsiInterop.evaluateScript("({ })").getObject()
+  }
+
   @Before
   fun before() {
     jsiInterop = JSIInteropModuleRegistry(mockk()).apply {
@@ -17,7 +21,7 @@ class JavaScriptObjectTest {
 
   @Test
   fun hasProperty_should_return_false_when_the_property_is_missing() {
-    val jsObject = jsiInterop.evaluateScript("({})").getObject()
+    val jsObject = emptyObject()
     Truth.assertThat(jsObject.hasProperty("prop")).isFalse()
   }
 
@@ -40,5 +44,78 @@ class JavaScriptObjectTest {
     val jsObject = jsiInterop.evaluateScript("({ 'prop': 123 })").getObject()
     val property = jsObject.getProperty("foo")
     Truth.assertThat(property.isUndefined()).isTrue()
+  }
+
+  @Test
+  fun setProperty_should_work_with_bool() {
+    val jsObject = jsiInterop.evaluateScript("({ })").getObject()
+    jsObject.setProperty("foo", true)
+    jsObject.setProperty("bar", false)
+
+    val foo = jsObject.getProperty("foo").getBool()
+    val bar = jsObject.getProperty("bar").getBool()
+
+    Truth.assertThat(foo).isTrue()
+    Truth.assertThat(bar).isFalse()
+  }
+
+
+  @Test
+  fun setProperty_should_work_with_int() = with(emptyObject()) {
+    setProperty("foo", 123)
+    val foo = getProperty("foo").getDouble()
+    Truth.assertThat(foo).isEqualTo(123)
+  }
+
+  @Test
+  fun setProperty_should_work_with_double() = with(emptyObject()) {
+    setProperty("foo", 20.43)
+    val foo = getProperty("foo").getDouble()
+    Truth.assertThat(foo).isEqualTo(20.43)
+  }
+
+  @Test
+  fun setProperty_should_work_with_string() = with(emptyObject()) {
+    setProperty("foo", "bar")
+    setProperty("bar", null as String?)
+
+    val foo = getProperty("foo").getString()
+    val bar = getProperty("bar")
+
+    Truth.assertThat(foo).isEqualTo("bar")
+    Truth.assertThat(bar.isUndefined()).isTrue()
+  }
+
+  @Test
+  fun setProperty_should_work_with_js_value() = with(emptyObject()) {
+    val jsValue = jsiInterop.evaluateScript("123")
+
+    setProperty("foo", jsValue)
+
+    val foo = getProperty("foo").getDouble()
+
+    Truth.assertThat(foo).isEqualTo(123)
+  }
+
+  @Test
+  fun setProperty_should_work_with_js_object() = with(emptyObject()) {
+    val jsObject = jsiInterop.evaluateScript("({ 'bar': 10 })").getObject()
+
+    setProperty("foo", jsObject)
+
+    val foo = getProperty("foo").getObject()
+    val bar = foo.getProperty("bar").getDouble()
+
+    Truth.assertThat(bar).isEqualTo(10)
+  }
+
+  @Test
+  fun setProperty_should_work_with_untyped_null() {
+    val jsObject = jsiInterop.evaluateScript("({ 'foo': 10 })").getObject()
+
+    jsObject.setProperty("foo", null)
+    val foo = jsObject.getProperty("foo")
+
+    Truth.assertThat(foo.isUndefined()).isTrue()
   }
 }

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptObjectTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptObjectTest.kt
@@ -59,7 +59,6 @@ class JavaScriptObjectTest {
     Truth.assertThat(bar).isFalse()
   }
 
-
   @Test
   fun setProperty_should_work_with_int() = with(emptyObject()) {
     setProperty("foo", 123)

--- a/packages/expo-modules-core/android/src/main/cpp/JSIObjectWrapper.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIObjectWrapper.h
@@ -15,7 +15,7 @@ namespace expo {
 class JSIObjectWrapper {
 public:
   /**
-   * @return an pointer to the underlying jsi::Object.
+   * @return a pointer to the underlying jsi::Object.
    */
   virtual std::shared_ptr<jsi::Object> get() = 0;
 };
@@ -26,7 +26,7 @@ public:
 class JSIValueWrapper {
 public:
   /**
-   * @return an pointer to the underlying jsi::Value.
+   * @return a pointer to the underlying jsi::Value.
    */
   virtual std::shared_ptr<jsi::Value> get() = 0;
 };

--- a/packages/expo-modules-core/android/src/main/cpp/JSIObjectWrapper.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIObjectWrapper.h
@@ -1,0 +1,33 @@
+// Copyright © 2021-present 650 Industries, Inc. (aka Expo)
+
+#pragma once
+
+#include <jsi/jsi.h>
+
+#include <memory>
+
+namespace jsi = facebook::jsi;
+
+namespace expo {
+/**
+ * An interface for classes which wrap jsi::Object.
+ */
+class JSIObjectWrapper {
+public:
+  /**
+   * @return an pointer to the underlying jsi::Object.
+   */
+  virtual std::shared_ptr<jsi::Object> get() = 0;
+};
+
+/**
+ * An interface for classes which wrap jsi::Value.
+ */
+class JSIValueWrapper {
+public:
+  /**
+   * @return an pointer to the underlying jsi::Value.
+   */
+  virtual std::shared_ptr<jsi::Value> get() = 0;
+};
+} // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JSITypeConverter.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JSITypeConverter.h
@@ -1,0 +1,84 @@
+// Copyright © 2021-present 650 Industries, Inc. (aka Expo)
+
+#pragma once
+
+#include "JSIObjectWrapper.h"
+
+#include <fbjni/fbjni.h>
+#include <jsi/jsi.h>
+
+#include <type_traits>
+
+namespace jni = facebook::jni;
+namespace jsi = facebook::jsi;
+
+namespace expo {
+/**
+ * A base template of the jni to jsi types converter.
+ * To make this conversion as fast and easy as possible we used the type trait technic.
+ */
+template<class T, typename = void>
+struct jsi_type_converter {
+  static const bool isDefined = false;
+};
+
+/**
+ * Conversion from jni::alias_ref<T::javaobject> to jsi::Value where T extends JSIValueWrapper or JSIObjectWrapper.
+ */
+template<class T>
+struct jsi_type_converter<
+  jni::alias_ref<T>,
+  std::enable_if_t<
+    // jni::ReprType<T>::HybridType>::value if T looks like `R::javaobject`, it will return R
+    std::is_base_of<JSIValueWrapper, typename jni::ReprType<T>::HybridType>::value ||
+    std::is_base_of<JSIObjectWrapper, typename jni::ReprType<T>::HybridType>::value
+  >
+> {
+  static const bool isDefined = true;
+
+  inline static jsi::Value convert(
+    jsi::Runtime &runtime,
+    jni::alias_ref<T> &value) {
+    if (value == nullptr) {
+      return jsi::Value::undefined();
+    }
+    return jsi::Value(runtime, *value->cthis()->get());
+  }
+};
+
+/**
+ * Conversion from primitive types from which jsi::Value can be constructed (like bool, double) to jsi::Value.
+ */
+template<class T>
+struct jsi_type_converter<
+  T,
+  std::enable_if_t<std::is_fundamental_v<T> && std::is_constructible_v<jsi::Value, T>>
+> {
+  static const bool isDefined = true;
+
+  inline static jsi::Value convert(jsi::Runtime &runtime, T value) {
+    return jsi::Value(value);
+  }
+};
+
+/**
+ * Conversion from jni::alias_ref<jstring> to jsi::Value.
+ */
+template<>
+struct jsi_type_converter<jni::alias_ref<jstring>> {
+  static const bool isDefined = true;
+
+  inline static jsi::Value convert(jsi::Runtime &runtime, jni::alias_ref<jstring> &value) {
+    if (value == nullptr) {
+      return jsi::Value::undefined();
+    }
+    return jsi::Value(jsi::String::createFromUtf8(runtime, value->toStdString()));
+  }
+};
+
+/**
+ * Helper that checks if the type converter was defined for the given type.
+ */
+template<class T>
+inline constexpr bool is_jsi_type_converter_defined = jsi_type_converter<T>::isDefined;
+} // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptObject.h
@@ -2,6 +2,10 @@
 
 #pragma once
 
+#include "JSIObjectWrapper.h"
+#include "JSITypeConverter.h"
+#include "JavaScriptRuntime.h"
+
 #include <fbjni/fbjni.h>
 #include <jsi/jsi.h>
 
@@ -18,7 +22,7 @@ class JavaScriptRuntime;
 /**
  * Represents any JavaScript object. Its purpose is to exposes `jsi::Object` API back to Kotlin.
  */
-class JavaScriptObject : public jni::HybridClass<JavaScriptObject> {
+class JavaScriptObject : public jni::HybridClass<JavaScriptObject>, JSIObjectWrapper {
 public:
   static auto constexpr
     kJavaDescriptor = "Lexpo/modules/kotlin/jni/JavaScriptObject;";
@@ -30,6 +34,8 @@ public:
     std::weak_ptr<JavaScriptRuntime> runtime,
     std::shared_ptr<jsi::Object> jsObject
   );
+
+  std::shared_ptr<jsi::Object> get() override;
 
   /**
    * @return a bool whether the object has a property with the given name
@@ -47,6 +53,8 @@ public:
    */
   std::vector<std::string> getPropertyNames();
 
+  void setProperty(const std::string &name, jsi::Value value);
+
 private:
   friend HybridBase;
   std::weak_ptr<JavaScriptRuntime> runtimeHolder;
@@ -59,5 +67,36 @@ private:
   );
 
   jni::local_ref<jni::JArrayClass<jstring>> jniGetPropertyNames();
+
+  /**
+   * Unsets property with the given name.
+   */
+  void unsetProperty(jni::alias_ref<jstring> name);
+
+  /**
+   * A template to generate different versions of the `setProperty` method based on the `jsi_type_converter` trait.
+   * Those generated methods will be exported and visible in the Kotlin codebase.
+   * On the other hand, we could just make one function that would take a generic Java Object,
+   * but then we would have to decide what to do with it and how to convert it to jsi::Value
+   * in cpp. That would be expensive. So it's easier to ensure that
+   * we call the correct version of `setProperty` in the Kotlin code.
+   *
+   * This template will work only if the jsi_type_converter exists for a given type.
+   */
+  template<
+    class T,
+    typename = std::enable_if_t<is_jsi_type_converter_defined<T>>
+  >
+  void setProperty(jni::alias_ref<jstring> name, T value) {
+    auto runtime = runtimeHolder.lock();
+    assert(runtime != nullptr);
+    auto cName = name->toStdString();
+
+    jsObject->setProperty(
+      *runtime->get(),
+      cName.c_str(),
+      jsi_type_converter<T>::convert(*runtime->get(), value)
+    );
+  }
 };
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.cpp
@@ -1,6 +1,8 @@
 // Copyright © 2021-present 650 Industries, Inc. (aka Expo)
 
 #include "JavaScriptRuntime.h"
+#include "JavaScriptValue.h"
+#include "JavaScriptObject.h"
 #include "Exceptions.h"
 
 #if FOR_HERMES

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.h
@@ -2,18 +2,18 @@
 
 #pragma once
 
-#include "JavaScriptValue.h"
-#include "JavaScriptObject.h"
-
 #include <jsi/jsi.h>
 #include <fbjni/fbjni.h>
 #include <ReactCommon/CallInvoker.h>
 
-namespace expo {
 
 namespace jsi = facebook::jsi;
 namespace jni = facebook::jni;
 namespace react = facebook::react;
+
+namespace expo {
+class JavaScriptValue;
+class JavaScriptObject;
 
 /**
  * A wrapper for the jsi::Runtime.
@@ -47,12 +47,12 @@ public:
    * @throws if the input format is unknown, or evaluation causes an error,
    * a jni::JniException<JavaScriptEvaluateException> will be thrown.
    */
-  jni::local_ref<JavaScriptValue::javaobject> evaluateScript(const std::string &script);
+  jni::local_ref<jni::HybridClass<JavaScriptValue>::javaobject> evaluateScript(const std::string &script);
 
   /**
    * Returns the runtime global object for use in Kotlin.
    */
-  jni::local_ref<JavaScriptObject::javaobject> global();
+  jni::local_ref<jni::HybridClass<JavaScriptObject>::javaobject> global();
 
 private:
   std::shared_ptr<jsi::Runtime> runtime;

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptValue.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptValue.cpp
@@ -31,6 +31,10 @@ JavaScriptValue::JavaScriptValue(
   assert(runtimeHolder.lock() != nullptr);
 }
 
+std::shared_ptr<jsi::Value> JavaScriptValue::get() {
+  return jsValue;
+}
+
 std::string JavaScriptValue::kind() {
   if (isNull()) {
     return "null";

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptValue.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptValue.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "JavaScriptObject.h"
+#include "JSIObjectWrapper.h"
 
 #include <fbjni/fbjni.h>
 #include <jsi/jsi.h>
@@ -15,10 +15,12 @@ namespace jsi = facebook::jsi;
 namespace expo {
 class JavaScriptRuntime;
 
+class JavaScriptObject;
+
 /**
  * Represents any JavaScript value. Its purpose is to expose the `jsi::Value` API back to Kotlin.
  */
-class JavaScriptValue : public jni::HybridClass<JavaScriptValue> {
+class JavaScriptValue : public jni::HybridClass<JavaScriptValue>, JSIValueWrapper {
 public:
   static auto constexpr
     kJavaDescriptor = "Lexpo/modules/kotlin/jni/JavaScriptValue;";
@@ -31,28 +33,42 @@ public:
     std::shared_ptr<jsi::Value> jsValue
   );
 
+  std::shared_ptr<jsi::Value> get() override;
+
   std::string kind();
 
   bool isNull();
+
   bool isUndefined();
+
   bool isBool();
+
   bool isNumber();
+
   bool isString();
+
   bool isSymbol();
+
   bool isFunction();
+
   bool isObject();
 
   bool getBool();
+
   double getDouble();
+
   std::string getString();
-  jni::local_ref<JavaScriptObject::javaobject> getObject();
+
+  jni::local_ref<jni::HybridClass<JavaScriptObject>::javaobject> getObject();
 
 private:
   friend HybridBase;
+
   std::weak_ptr<JavaScriptRuntime> runtimeHolder;
   std::shared_ptr<jsi::Value> jsValue;
 
   jni::local_ref<jstring> jniKind();
+
   jni::local_ref<jstring> jniGetString();
 };
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptObject.kt
@@ -15,6 +15,24 @@ class JavaScriptObject @DoNotStrip private constructor(@DoNotStrip private val m
   external fun getProperty(name: String): JavaScriptValue
   external fun getPropertyNames(): Array<String>
 
+  private external fun setBoolProperty(name: String, value: Boolean)
+  private external fun setDoubleProperty(name: String, value: Double)
+  private external fun setStringProperty(name: String, value: String?)
+  private external fun setJSValueProperty(name: String, value: JavaScriptValue?)
+  private external fun setJSObjectProperty(name: String, value: JavaScriptObject?)
+  private external fun unsetProperty(name: String)
+
+  fun setProperty(name: String, value: Boolean) = setBoolProperty(name, value)
+  fun setProperty(name: String, value: Int) = setDoubleProperty(name, value.toDouble())
+  fun setProperty(name: String, value: Double) = setDoubleProperty(name, value)
+  fun setProperty(name: String, value: String?) = setStringProperty(name, value)
+  fun setProperty(name: String, value: JavaScriptValue?) = setJSValueProperty(name, value)
+  fun setProperty(name: String, value: JavaScriptObject?) = setJSObjectProperty(name, value)
+
+  // Needed to handle untyped null value
+  // Without it setProperty(name, null) won't work
+  fun setProperty(name: String, `null`: Nothing?) = unsetProperty(name)
+
   @Throws(Throwable::class)
   protected fun finalize() {
     mHybridData.resetNative()


### PR DESCRIPTION
# Why

Adds `setProperty` to the `JavaScriptObject`.

# How

- Adds a base interface to indicate if the derived class wrap a jsi::Value or jsi::Object.
- Adds a conversion between JNI and jsi objects based on the type traits.
- Hides raw JNI API in the `JavaScriptObject` using methods overload.
- Adds unit tests

# Test Plan

- unit tests ✅