### PR TITLE
[notifications] Fix android 12 notification trampolines

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - Fixed Android 12+ runtime crash caused by `PendingIntent` misconfiguration. ([#17333](https://github.com/expo/expo/pull/17333) by [@kudo](https://github.com/kudo))
+- Fix app not bringing to foreground when clicking notification on Android 12+. ([#17686](https://github.com/expo/expo/pull/17686) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-notifications/android/src/main/AndroidManifest.xml
+++ b/packages/expo-notifications/android/src/main/AndroidManifest.xml
@@ -27,5 +27,13 @@
         <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
       </intent-filter>
     </receiver>
+
+    <activity android:name=".service.NotificationForwarderActivity"
+      android:theme="@android:style/Theme.Translucent.NoTitleBar"
+      android:exported="false"
+      android:excludeFromRecents="true"
+      android:noHistory="true"
+      android:launchMode="standard"
+      />
   </application>
 </manifest>

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationForwarderActivity.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationForwarderActivity.kt
@@ -1,0 +1,30 @@
+package expo.modules.notifications.service
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+import expo.modules.notifications.BuildConfig
+
+/**
+ * An internal Activity that passes given Intent extras from
+ * [NotificationsService.createNotificationResponseIntent]
+ * and send broadcasts to [NotificationsService].
+ */
+class NotificationForwarderActivity : Activity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    val broadcastIntent =
+      NotificationsService.createNotificationResponseBroadcastIntent(applicationContext, intent.extras)
+    sendBroadcast(broadcastIntent)
+    finish()
+  }
+
+  override fun onNewIntent(intent: Intent?) {
+    super.onNewIntent(intent)
+    // This Activity is expected to launch with new task, supposedly
+    // there's no way for `onNewIntent` to be called.
+    if (BuildConfig.DEBUG) {
+      throw AssertionError()
+    }
+  }
+}

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationsService.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationsService.kt
@@ -450,6 +450,14 @@ open class NotificationsService : BroadcastReceiver() {
         intent.putExtra(NOTIFICATION_ACTION_KEY, action as Parcelable)
       }
 
+      // Starting from Android 12,
+      // [notification trampolines](https://developer.android.com/about/versions/12/behavior-changes-12#identify-notification-trampolines)
+      // are not allowed. If the notification wants to open foreground app,
+      // we should use the dedicated Activity pendingIntent.
+      if (action.opensAppToForeground()) {
+        return ExpoHandlingDelegate.createPendingIntentForOpeningApp(context, intent)
+      }
+
       // We're defaulting to the behaviour prior API 31 (mutable) even though Android recommends immutability
       val mutableFlag = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) PendingIntent.FLAG_MUTABLE else 0
       return PendingIntent.getBroadcast(
@@ -458,6 +466,35 @@ open class NotificationsService : BroadcastReceiver() {
         intent,
         PendingIntent.FLAG_UPDATE_CURRENT or mutableFlag
       )
+    }
+
+    /**
+     * Recreate an Intent from [createNotificationResponseIntent] extras
+     * for [NotificationForwarderActivity] to send broadcasts
+     */
+    fun createNotificationResponseBroadcastIntent(context: Context, extras: Bundle?): Intent {
+      val notification = extras?.getParcelable<Notification>(NOTIFICATION_KEY)
+      val action = extras?.getParcelable<NotificationAction>(NOTIFICATION_ACTION_KEY)
+      if (notification == null || action == null) {
+        throw IllegalArgumentException("notification and action should not be null")
+      }
+      val backgroundAction = NotificationAction(action.identifier, action.title, false)
+      val intent = Intent(
+        NOTIFICATION_EVENT_ACTION,
+        getUriBuilder()
+          .appendPath(notification.notificationRequest.identifier)
+          .appendPath("actions")
+          .appendPath(backgroundAction.identifier)
+          .build()
+      ).also { intent ->
+        findDesignatedBroadcastReceiver(context, intent)?.let {
+          intent.component = ComponentName(it.packageName, it.name)
+        }
+        intent.putExtra(EVENT_TYPE_KEY, RECEIVE_RESPONSE_TYPE)
+        intent.putExtra(NOTIFICATION_KEY, notification)
+        intent.putExtra(NOTIFICATION_ACTION_KEY, backgroundAction as Parcelable)
+      }
+      return intent
     }
 
     fun getNotificationResponseFromIntent(intent: Intent): NotificationResponse? {

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoHandlingDelegate.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoHandlingDelegate.kt
@@ -1,13 +1,16 @@
 package expo.modules.notifications.service.delegates
 
+import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.util.Log
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ProcessLifecycleOwner
 import expo.modules.notifications.notifications.NotificationManager
 import expo.modules.notifications.notifications.model.Notification
 import expo.modules.notifications.notifications.model.NotificationResponse
+import expo.modules.notifications.service.NotificationForwarderActivity
 import expo.modules.notifications.service.NotificationsService
 import expo.modules.notifications.service.interfaces.HandlingDelegate
 import java.lang.ref.WeakReference
@@ -50,6 +53,41 @@ class ExpoHandlingDelegate(protected val context: Context) : HandlingDelegate {
         }
       }
     }
+
+    /**
+     * Create a PendingIntent to open app in foreground.
+     * We actually start two Activities
+     *   - the foreground main Activity
+     *   - the background [NotificationForwarderActivity] Activity that send notification clicked events through broadcast
+     */
+    fun createPendingIntentForOpeningApp(context: Context, broadcastIntent: Intent): PendingIntent {
+      var intentFlags = PendingIntent.FLAG_UPDATE_CURRENT
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        intentFlags = intentFlags or PendingIntent.FLAG_IMMUTABLE
+      }
+      val foregroundActivityIntent = getNotificationActionLauncher(context) ?: getMainActivityLauncher(context) ?: run {
+        Log.w("expo-notifications", "No launch intent found for application. Interacting with the notification won't open the app. The implementation uses `getLaunchIntentForPackage` to find appropriate activity.")
+        Intent()
+      }
+      foregroundActivityIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_MULTIPLE_TASK
+      val backgroundActivityIntent = Intent(context, NotificationForwarderActivity::class.java)
+      backgroundActivityIntent.putExtras(broadcastIntent)
+      return PendingIntent.getActivities(context, 0, arrayOf(foregroundActivityIntent, backgroundActivityIntent), intentFlags)
+    }
+
+    private fun getNotificationActionLauncher(context: Context): Intent? {
+      Intent(OPEN_APP_INTENT_ACTION).also { intent ->
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        intent.setPackage(context.applicationContext.packageName)
+        context.packageManager.resolveActivity(intent, 0)?.let {
+          return intent
+        }
+      }
+      return null
+    }
+
+    private fun getMainActivityLauncher(context: Context) =
+      context.packageManager.getLaunchIntentForPackage(context.packageName)
   }
 
   fun isAppInForeground() = ProcessLifecycleOwner.get().lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)
@@ -89,20 +127,6 @@ class ExpoHandlingDelegate(protected val context: Context) : HandlingDelegate {
 
     Log.w("expo-notifications", "No launch intent found for application. Interacting with the notification won't open the app. The implementation uses `getLaunchIntentForPackage` to find appropriate activity.")
   }
-
-  private fun getNotificationActionLauncher(context: Context): Intent? {
-    Intent(OPEN_APP_INTENT_ACTION).also { intent ->
-      intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-      intent.setPackage(context.applicationContext.packageName)
-      context.packageManager.resolveActivity(intent, 0)?.let {
-        return intent
-      }
-    }
-    return null
-  }
-
-  private fun getMainActivityLauncher(context: Context) =
-    context.packageManager.getLaunchIntentForPackage(context.packageName)
 
   override fun handleNotificationsDropped() {
     getListeners().forEach {


### PR DESCRIPTION
# Why

originally clicking a notification to launch app in foreground, our call flow is like
```
notification pendingIntent -> broadcast receiver in service -> startActivity
                                                            └> broadcast receiveResponse 
```
this is abandoned from android 12 which is called [notification trampolines](https://developer.android.com/about/versions/12/behavior-changes-12#identify-notification-trampolines).

fix #17531 

# How

reference the solution from onesignal: https://onesignal.com/blog/android-12-notification-open-changes/, the pr changes the call flow like:
```
notification pendingIntent  --> foreground Activity
                            └> hidden background Activity (NotificationForwarderActivity) -> broadcast receiveResponse 
```

# Test Plan

bare-expo + NCL "schedule notification for 10 seconds from now", pressing home key to background the app and click the notification after 10 seconds.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
