### PR TITLE
[sweet API][Kotlin] Add `JavaScriptRuntime.createObject`

### DIFF
--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptRuntimeTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptRuntimeTest.kt
@@ -85,4 +85,14 @@ class JavaScriptRuntimeTest {
     Truth.assertThat(number.isObject()).isTrue()
     Truth.assertThat(number.kind()).isEqualTo("function")
   }
+
+  @Test
+  fun createObject_should_return_a_valid_object() {
+    val jsObject = jsiInterop.createObject()
+
+    Truth.assertThat(jsObject.getPropertyNames()).hasLength(0)
+
+    jsObject.setProperty("foo", "bar")
+    Truth.assertThat(jsObject.getProperty("foo").getString()).isEqualTo("bar")
+  }
 }

--- a/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.cpp
@@ -25,6 +25,7 @@ void JSIInteropModuleRegistry::registerNatives() {
                                     JSIInteropModuleRegistry::installJSIForTests),
                    makeNativeMethod("evaluateScript", JSIInteropModuleRegistry::evaluateScript),
                    makeNativeMethod("global", JSIInteropModuleRegistry::global),
+                   makeNativeMethod("createObject", JSIInteropModuleRegistry::createObject),
                  });
 }
 
@@ -93,5 +94,9 @@ jni::local_ref<JavaScriptValue::javaobject> JSIInteropModuleRegistry::evaluateSc
 
 jni::local_ref<JavaScriptObject::javaobject> JSIInteropModuleRegistry::global() {
   return runtimeHolder->global();
+}
+
+jni::local_ref<JavaScriptObject::javaobject> JSIInteropModuleRegistry::createObject() {
+  return runtimeHolder->createObject();
 }
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.h
@@ -64,6 +64,11 @@ public:
    */
   jni::local_ref<JavaScriptObject::javaobject> global();
 
+  /**
+   * Exposes a `JavaScriptRuntime::createObject` function to Kotlin
+   */
+  jni::local_ref<JavaScriptObject::javaobject> createObject();
+
   std::shared_ptr<react::CallInvoker> jsInvoker;
   std::shared_ptr<react::CallInvoker> nativeInvoker;
 

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.cpp
@@ -74,4 +74,9 @@ jni::local_ref<JavaScriptObject::javaobject> JavaScriptRuntime::global() {
   auto global = std::make_shared<jsi::Object>(runtime->global());
   return JavaScriptObject::newObjectCxxArgs(weak_from_this(), global);
 }
+
+jni::local_ref<JavaScriptObject::javaobject> JavaScriptRuntime::createObject() {
+  auto newObject = std::make_shared<jsi::Object>(*runtime);
+  return JavaScriptObject::newObjectCxxArgs(weak_from_this(), newObject);
+}
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.h
@@ -54,6 +54,11 @@ public:
    */
   jni::local_ref<JavaScriptObject::javaobject> global();
 
+  /**
+   * Creates a new object for use in Kotlin.
+   */
+  jni::local_ref<jni::HybridClass<JavaScriptObject>::javaobject> createObject();
+
 private:
   std::shared_ptr<jsi::Runtime> runtime;
   std::shared_ptr<react::CallInvoker> jsInvoker;

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIInteropModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIInteropModuleRegistry.kt
@@ -45,6 +45,11 @@ class JSIInteropModuleRegistry(appContext: AppContext) {
   external fun global(): JavaScriptObject
 
   /**
+   * Returns a new instance of [JavaScriptObject]
+   */
+  external fun createObject(): JavaScriptObject
+
+  /**
    * Returns a `JavaScriptModuleObject` that is a bridge between [expo.modules.kotlin.modules.Module]
    * and HostObject exported via JSI.
    *


### PR DESCRIPTION
# Why

Adds `JavaScriptRuntime.createObject`

# How

Adds a simple method to create an empty object without running `evaluateScript`.

# Test Plan

- unit tests ✅