### PR TITLE
[sweet API][Kotlin] Remove references to invokers in `JSIInteropModuleRegistry`

### DIFF
--- a/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.cpp
@@ -38,9 +38,11 @@ void JSIInteropModuleRegistry::installJSI(
   jni::alias_ref<react::CallInvokerHolder::javaobject> nativeInvokerHolder
 ) {
   auto runtime = reinterpret_cast<jsi::Runtime *>(jsRuntimePointer);
-  jsInvoker = jsInvokerHolder->cthis()->getCallInvoker();
-  nativeInvoker = nativeInvokerHolder->cthis()->getCallInvoker();
-  runtimeHolder = std::make_shared<JavaScriptRuntime>(runtime, jsInvoker, nativeInvoker);
+  runtimeHolder = std::make_shared<JavaScriptRuntime>(
+    runtime,
+    jsInvokerHolder->cthis()->getCallInvoker(),
+    nativeInvokerHolder->cthis()->getCallInvoker()
+  );
 
   auto expoModules = std::make_shared<ExpoModulesHostObject>(this);
   auto expoModulesObject = jsi::Object::createFromHostObject(*runtime, expoModules);

--- a/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.h
@@ -71,10 +71,9 @@ public:
 
   std::shared_ptr<react::CallInvoker> jsInvoker;
   std::shared_ptr<react::CallInvoker> nativeInvoker;
-
+  std::shared_ptr<JavaScriptRuntime> runtimeHolder;
 private:
   friend HybridBase;
-  std::shared_ptr<JavaScriptRuntime> runtimeHolder;
   jni::global_ref<JSIInteropModuleRegistry::javaobject> javaPart_;
 
   explicit JSIInteropModuleRegistry(jni::alias_ref<jhybridobject> jThis);

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.h
@@ -59,9 +59,9 @@ public:
    */
   jni::local_ref<jni::HybridClass<JavaScriptObject>::javaobject> createObject();
 
-private:
-  std::shared_ptr<jsi::Runtime> runtime;
   std::shared_ptr<react::CallInvoker> jsInvoker;
   std::shared_ptr<react::CallInvoker> nativeInvoker;
+private:
+  std::shared_ptr<jsi::Runtime> runtime;
 };
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
@@ -183,13 +183,13 @@ jsi::Function MethodMetadata::createPromiseBody(
       jobject resolve = createJavaCallbackFromJSIFunction(
         std::move(resolveJSIFn),
         rt,
-        moduleRegistry->jsInvoker
+        moduleRegistry->runtimeHolder->jsInvoker
       ).release();
 
       jobject reject = createJavaCallbackFromJSIFunction(
         std::move(rejectJSIFn),
         rt,
-        moduleRegistry->jsInvoker
+        moduleRegistry->runtimeHolder->nativeInvoker
       ).release();
 
       JNIEnv *env = jni::Environment::current();

--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
@@ -180,16 +180,17 @@ jsi::Function MethodMetadata::createPromiseBody(
       jsi::Function resolveJSIFn = promiseConstructorArgs[0].getObject(rt).getFunction(rt);
       jsi::Function rejectJSIFn = promiseConstructorArgs[1].getObject(rt).getFunction(rt);
 
+      auto &runtimeHolder = moduleRegistry->runtimeHolder;
       jobject resolve = createJavaCallbackFromJSIFunction(
         std::move(resolveJSIFn),
         rt,
-        moduleRegistry->runtimeHolder->jsInvoker
+        runtimeHolder->jsInvoker
       ).release();
 
       jobject reject = createJavaCallbackFromJSIFunction(
         std::move(rejectJSIFn),
         rt,
-        moduleRegistry->runtimeHolder->nativeInvoker
+        runtimeHolder->jsInvoker
       ).release();
 
       JNIEnv *env = jni::Environment::current();


### PR DESCRIPTION
# Why

The invokers were stored in two places - in the `JSIInteropModuleRegistry` and in the `JavaScriptRuntime`. It doesn't look like a clean solution. So I've decided to make the `JavaScriptRuntime` class the only place which stores those references.

# How

Removed invokers from `JSIInteropModuleRegistry`.

# Test Plan

- unit tests ✅