### PR TITLE
[ios] Add @shopify/react-native-skia vendoring support for Expo Go

### DIFF
--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -53,6 +53,7 @@
     "@react-navigation/material-bottom-tabs": "~5.3.9",
     "@react-navigation/native": "~5.8.9",
     "@react-navigation/stack": "~5.12.6",
+    "@shopify/react-native-skia": "0.1.130",
     "@use-expo/permissions": "^2.0.0",
     "date-format": "^2.0.0",
     "deep-object-diff": "^1.1.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -53,7 +53,7 @@
     "@react-navigation/material-bottom-tabs": "~5.3.9",
     "@react-navigation/native": "~5.8.9",
     "@react-navigation/stack": "~5.12.6",
-    "@shopify/react-native-skia": "0.1.130",
+    "@shopify/react-native-skia": "^0.1.133",
     "@use-expo/permissions": "^2.0.0",
     "date-format": "^2.0.0",
     "deep-object-diff": "^1.1.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -53,7 +53,7 @@
     "@react-navigation/material-bottom-tabs": "~5.3.9",
     "@react-navigation/native": "~5.8.9",
     "@react-navigation/stack": "~5.12.6",
-    "@shopify/react-native-skia": "^0.1.133",
+    "@shopify/react-native-skia": "0.1.134",
     "@use-expo/permissions": "^2.0.0",
     "date-format": "^2.0.0",
     "deep-object-diff": "^1.1.0",

--- a/apps/native-component-list/src/navigation/ExpoComponentsStackNavigator.tsx
+++ b/apps/native-component-list/src/navigation/ExpoComponentsStackNavigator.tsx
@@ -365,6 +365,12 @@ export const Screens = [
   },
   {
     getComponent() {
+      return optionalRequire(() => require('../screens/Skia/SkiaScreen'));
+    },
+    name: 'Skia',
+  },
+  {
+    getComponent() {
       return optionalRequire(() => require('../screens/SVG/SVGScreen'));
     },
     name: 'SVG',

--- a/apps/native-component-list/src/screens/ExpoComponentsScreen.tsx
+++ b/apps/native-component-list/src/screens/ExpoComponentsScreen.tsx
@@ -32,6 +32,7 @@ const screens = [
   'ProgressViewIOS',
   'QRCode',
   'Reanimated',
+  'Skia',
   'SVG',
   'Screens',
   'ScrollView',

--- a/apps/native-component-list/src/screens/Skia/SkiaScreen.tsx
+++ b/apps/native-component-list/src/screens/Skia/SkiaScreen.tsx
@@ -1,4 +1,4 @@
-import type { SkiaReadonlyValue } from '@shopify/react-native-skia';
+import type { SkiaValue } from '@shopify/react-native-skia';
 import {
   useDerivedValue,
   useLoop,
@@ -23,7 +23,7 @@ const center = vec(width / 2, height / 2 - 64);
 
 interface RingProps {
   index: number;
-  progress: SkiaReadonlyValue<number>;
+  progress: SkiaValue<number>;
 }
 
 const Ring = ({ index, progress }: RingProps) => {

--- a/apps/native-component-list/src/screens/Skia/SkiaScreen.tsx
+++ b/apps/native-component-list/src/screens/Skia/SkiaScreen.tsx
@@ -1,0 +1,76 @@
+import type { SkiaReadonlyValue } from '@shopify/react-native-skia';
+import {
+  useDerivedValue,
+  useLoop,
+  BlurMask,
+  vec,
+  Canvas,
+  Circle,
+  Fill,
+  Group,
+  polar2Canvas,
+  Easing,
+  mix,
+} from '@shopify/react-native-skia';
+import React from 'react';
+import { Dimensions, StyleSheet } from 'react-native';
+
+const { width, height } = Dimensions.get('window');
+const c1 = '#61bea2';
+const c2 = '#529ca0';
+const R = width / 4;
+const center = vec(width / 2, height / 2 - 64);
+
+interface RingProps {
+  index: number;
+  progress: SkiaReadonlyValue<number>;
+}
+
+const Ring = ({ index, progress }: RingProps) => {
+  const theta = (index * (2 * Math.PI)) / 6;
+  const transform = useDerivedValue(() => {
+    const { x, y } = polar2Canvas({ theta, radius: progress.current * R }, { x: 0, y: 0 });
+    const scale = mix(progress.current, 0.3, 1);
+    return [{ translateX: x }, { translateY: y }, { scale }];
+  }, [progress]);
+
+  return (
+    <Group origin={center} transform={transform}>
+      <Circle c={center} r={R} color={index % 2 ? c1 : c2} />
+    </Group>
+  );
+};
+
+export default function SkiaScreen() {
+  const progress = useLoop({
+    duration: 3000,
+    easing: Easing.inOut(Easing.ease),
+  });
+
+  const transform = useDerivedValue(
+    () => [{ rotate: mix(progress.current, -Math.PI, 0) }],
+    [progress]
+  );
+
+  return (
+    <Canvas style={styles.container}>
+      <Fill color="rgb(36,43,56)" />
+      <Group origin={center} transform={transform} blendMode="screen">
+        <BlurMask style="solid" blur={40} />
+        {new Array(6).fill(0).map((_, index) => {
+          return <Ring key={index} index={index} progress={progress} />;
+        })}
+      </Group>
+    </Canvas>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+});
+
+SkiaScreen.navigationOptions = {
+  title: 'Skia',
+};

--- a/tools/src/CocoaPods.ts
+++ b/tools/src/CocoaPods.ts
@@ -15,11 +15,14 @@ export type Podspec = {
   preserve_paths: string | string[];
   compiler_flags: string;
   frameworks: string | string[];
+  vendored_frameworks: string | string[];
   pod_target_xcconfig: Record<string, string>;
   xcconfig: Record<string, string>;
   dependencies: Record<string, any>;
   info_plist: Record<string, string>;
   ios?: Podspec;
+  default_subspecs: string[];
+  subspecs: Podspec[];
 };
 
 /**

--- a/tools/src/CocoaPods.ts
+++ b/tools/src/CocoaPods.ts
@@ -21,7 +21,7 @@ export type Podspec = {
   dependencies: Record<string, any>;
   info_plist: Record<string, string>;
   ios?: Podspec;
-  default_subspecs: string[];
+  default_subspecs: string | string[];
   subspecs: Podspec[];
 };
 

--- a/tools/src/commands/UpdateVendoredModule.ts
+++ b/tools/src/commands/UpdateVendoredModule.ts
@@ -147,7 +147,7 @@ async function action(options: ActionOptions) {
 }
 
 /**
- *
+ * Downloads vendoring module source code either from git repository or npm
  */
 async function downloadSourceAsync(
   sourceDirectory: string,

--- a/tools/src/vendoring/IosVendoring.ts
+++ b/tools/src/vendoring/IosVendoring.ts
@@ -4,7 +4,7 @@ import glob from 'glob-promise';
 import inquirer from 'inquirer';
 import path from 'path';
 
-import { podInstallAsync, readPodspecAsync } from '../CocoaPods';
+import { podInstallAsync, Podspec, readPodspecAsync } from '../CocoaPods';
 import { IOS_DIR } from '../Constants';
 import logger from '../Logger';
 import { searchFilesAsync } from '../Utils';
@@ -31,12 +31,7 @@ export async function vendorAsync(
   const podspec = await readPodspecAsync(podspecPath);
 
   // Get a list of source files specified by the podspec.
-  const filesPatterns = ([] as string[]).concat(
-    podspec.source_files,
-    podspec.ios?.source_files ?? [],
-    podspec.preserve_paths ?? []
-  );
-
+  const filesPatterns = createFilesPatterns(podspec);
   const files = await searchFilesAsync(sourceDirectory, filesPatterns);
 
   await copyVendoredFilesAsync(files, {
@@ -47,7 +42,7 @@ export async function vendorAsync(
 
   // We may need to transform the podspec as well. As we have an access to its JSON representation,
   // it seems better to modify the object directly instead of string-transforming.
-  config.mutatePodspec?.(podspec);
+  await config.mutatePodspec?.(podspec, sourceDirectory, targetDirectory);
 
   // Save the dynamic ruby podspec as a static JSON file, so there is no need
   // to copy `package.json` files, which are often being read by the podspecs.
@@ -82,4 +77,26 @@ async function promptToReinstallPodsAsync(): Promise<boolean> {
     },
   ]);
   return reinstall;
+}
+
+function createFilesPatterns(podspec: Podspec): string[] {
+  let result = ([] as string[]).concat(
+    podspec.source_files,
+    podspec.ios?.source_files ?? [],
+    podspec.preserve_paths ?? []
+  );
+
+  const subspecs = podspec.subspecs ?? [];
+  const defaultSubspecs = podspec.default_subspecs
+    ? subspecs.filter((spec) => podspec.default_subspecs.includes(spec.name))
+    : subspecs;
+  for (const spec of defaultSubspecs) {
+    result = result.concat(
+      spec.source_files,
+      spec.ios?.source_files ?? [],
+      spec.preserve_paths ?? []
+    );
+  }
+
+  return result;
 }

--- a/tools/src/vendoring/IosVendoring.ts
+++ b/tools/src/vendoring/IosVendoring.ts
@@ -7,7 +7,7 @@ import path from 'path';
 import { podInstallAsync, Podspec, readPodspecAsync } from '../CocoaPods';
 import { IOS_DIR } from '../Constants';
 import logger from '../Logger';
-import { searchFilesAsync } from '../Utils';
+import { arrayize, searchFilesAsync } from '../Utils';
 import { copyVendoredFilesAsync } from './common';
 import { VendoringModuleConfig } from './types';
 
@@ -87,8 +87,11 @@ function createFilesPatterns(podspec: Podspec): string[] {
   );
 
   const subspecs = podspec.subspecs ?? [];
-  const defaultSubspecs = podspec.default_subspecs
-    ? subspecs.filter((spec) => podspec.default_subspecs.includes(spec.name))
+  const podspecDefaultSubspecsArray = podspec.default_subspecs
+    ? arrayize(podspec.default_subspecs)
+    : null;
+  const defaultSubspecs = podspecDefaultSubspecsArray
+    ? subspecs.filter((spec) => podspecDefaultSubspecsArray.includes(spec.name))
     : subspecs;
   for (const spec of defaultSubspecs) {
     result = result.concat(

--- a/tools/src/vendoring/config/expoGoConfig.ts
+++ b/tools/src/vendoring/config/expoGoConfig.ts
@@ -298,6 +298,13 @@ const config: VendoringTargetConfig = {
               symlinkFrameworkPath
             );
           }
+
+          // Workaround React-bridging header search path for react-native 0.69 with `generate_multiple_pod_projects=true`
+          if (!podspec.pod_target_xcconfig) {
+            podspec.pod_target_xcconfig = {};
+          }
+          podspec.pod_target_xcconfig['HEADER_SEARCH_PATHS'] =
+            '"$(PODS_ROOT)/Headers/Private/React-bridging/react/bridging" "$(PODS_CONFIGURATION_BUILD_DIR)/React-bridging/react_bridging.framework/Headers"';
         },
       },
     },

--- a/tools/src/vendoring/types.ts
+++ b/tools/src/vendoring/types.ts
@@ -9,12 +9,19 @@ export type VendoringModuleConfig = {
   source: string;
   semverPrefix?: string;
   packageJsonPath?: string;
+
+  sourceType?: 'git' | 'npm';
+
   ios?: VendoringModulePlatformConfig<{
     // this hook can do some transformation before running `pod ipc spec ...`.
     // use this hook as a workaround for some podspecs showing errors and violating json format.
     preReadPodspecHookAsync?: (podspecPath: string) => Promise<string>;
 
-    mutatePodspec?: (podspec: Podspec) => void;
+    mutatePodspec?: (
+      podspec: Podspec,
+      sourceDirectory: string,
+      targetDirectory: string
+    ) => Promise<void>;
   }>;
   android?: VendoringModulePlatformConfig<{
     includeFiles?: string | string[];

--- a/tools/src/versioning/ios/transforms/vendoredModulesTransforms.ts
+++ b/tools/src/versioning/ios/transforms/vendoredModulesTransforms.ts
@@ -174,5 +174,38 @@ export default function vendoredModulesTransformsFactory(prefix: string): Config
     'react-native-screens': {
       content: [],
     },
+    '@shopify/react-native-skia': {
+      path: [
+        {
+          find: /\b(DisplayLink|PlatformContext|SkiaDrawView|SkiaDrawViewManager|SkiaManager)/g,
+          replaceWith: `${prefix}$1`,
+        },
+      ],
+      content: [
+        {
+          paths: '*.h',
+          find: new RegExp(`ReactCommon/(?!${prefix})`, 'g'),
+          replaceWith: `ReactCommon/${prefix}`,
+        },
+        {
+          find: /\b(DisplayLink|PlatformContext|SkiaDrawView|SkiaDrawViewManager|SkiaManager)/g,
+          replaceWith: `${prefix}$1`,
+        },
+        {
+          // The module name in bridge should be unversioned `RNSkia`
+          paths: 'SkiaDrawViewManager.mm',
+          find: new RegExp(`(\\smoduleForName:@")${prefix}(RNSkia")`, 'g'),
+          replaceWith: '$1$2',
+        },
+        {
+          // __typename__ exposed to js should be unversioned
+          find: new RegExp(
+            `(\\bJSI_PROPERTY_GET\\(__typename__\\) \\{\\n\\s*return jsi::String::createFromUtf8\\(runtime, ")${prefix}(.*")`,
+            'gm'
+          ),
+          replaceWith: '$1$2',
+        },
+      ],
+    },
   };
 }

--- a/tools/src/versioning/ios/transforms/vendoredModulesTransforms.ts
+++ b/tools/src/versioning/ios/transforms/vendoredModulesTransforms.ts
@@ -188,7 +188,7 @@ export default function vendoredModulesTransformsFactory(prefix: string): Config
           replaceWith: `ReactCommon/${prefix}`,
         },
         {
-          find: /\b(DisplayLink|PlatformContext|SkiaDrawView|SkiaDrawViewManager|SkiaManager)/g,
+          find: /\b(DisplayLink|PlatformContext|SkiaDrawView|SkiaDrawViewManager|SkiaManager|RNJsi)/g,
           replaceWith: `${prefix}$1`,
         },
         {

--- a/tools/src/versioning/ios/versionVendoredModules.ts
+++ b/tools/src/versioning/ios/versionVendoredModules.ts
@@ -1,3 +1,4 @@
+import JsonFile from '@expo/json-file';
 import chalk from 'chalk';
 import fs from 'fs-extra';
 import glob from 'glob-promise';
@@ -50,6 +51,7 @@ export async function versionVendoredModulesAsync(
         },
       });
     }
+    await postTransformHooks[name]?.(sourceDirectory, targetDirectory);
   }
 }
 
@@ -181,6 +183,20 @@ function baseTransformsFactory(prefix: string): Required<FileTransforms> {
     ],
   };
 }
+
+/**
+ * Provides a hook for vendored module to do some custom tasks after transforming files
+ */
+type PostTramsformHook = (sourceDirectory: string, targetDirectory: string) => Promise<void>;
+const postTransformHooks: Record<string, PostTramsformHook> = {
+  '@shopify/react-native-skia': async (sourceDirectory: string, targetDirectory: string) => {
+    const podspecPath = (await glob('*.podspec.json', { cwd: targetDirectory, absolute: true }))[0];
+    const podspec = await JsonFile.readAsync(podspecPath);
+    // remove the shared vendored_frameworks
+    delete podspec?.['ios']?.['vendored_frameworks'];
+    await JsonFile.writeAsync(podspecPath, podspec);
+  },
+};
 
 /**
  * Returns the vendored directory for given SDK number.

--- a/yarn.lock
+++ b/yarn.lock
@@ -3417,6 +3417,13 @@
     component-type "^1.2.1"
     join-component "^1.1.0"
 
+"@shopify/react-native-skia@0.1.130":
+  version "0.1.130"
+  resolved "https://registry.yarnpkg.com/@shopify/react-native-skia/-/react-native-skia-0.1.130.tgz#a3db74db128f6c521d189397ba93afea2216f994"
+  integrity sha512-g/A3TtDdy3Fo17okrKLbQKbbFt4StodEYtwqnvrLiu5RU5MjHNWXGZR7QTQSxrggQsUUOSxX3ZRxzf/pt2g9EQ==
+  dependencies:
+    react-reconciler "^0.26.2"
+
 "@sideway/address@^4.1.3":
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.4.tgz#03dccebc6ea47fdc226f7d3d1ad512955d4783f0"
@@ -17227,6 +17234,15 @@ react-query@^3.34.16:
     "@babel/runtime" "^7.5.5"
     broadcast-channel "^3.4.1"
     match-sorter "^6.0.2"
+
+react-reconciler@^0.26.2:
+  version "0.26.2"
+  resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.26.2.tgz#bbad0e2d1309423f76cf3c3309ac6c96e05e9d91"
+  integrity sha512-nK6kgY28HwrMNwDnMui3dvm3rCFjZrcGiuwLc5COUipBK5hWHLOxMJhSnSomirqWwjPBJKV1QcbkI0VJr7Gl1Q==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    scheduler "^0.20.2"
 
 react-redux@^7.2.0:
   version "7.2.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3417,11 +3417,12 @@
     component-type "^1.2.1"
     join-component "^1.1.0"
 
-"@shopify/react-native-skia@0.1.130":
-  version "0.1.130"
-  resolved "https://registry.yarnpkg.com/@shopify/react-native-skia/-/react-native-skia-0.1.130.tgz#a3db74db128f6c521d189397ba93afea2216f994"
-  integrity sha512-g/A3TtDdy3Fo17okrKLbQKbbFt4StodEYtwqnvrLiu5RU5MjHNWXGZR7QTQSxrggQsUUOSxX3ZRxzf/pt2g9EQ==
+"@shopify/react-native-skia@^0.1.133":
+  version "0.1.133"
+  resolved "https://registry.yarnpkg.com/@shopify/react-native-skia/-/react-native-skia-0.1.133.tgz#9ed8e2fabdabdbd49ecb9ba2bf403a81bfec906d"
+  integrity sha512-H6s89wEkIWCQHfe3F8qjoEDsVErmkldWlsvLmg+YI60VcllEB8E00s8SUb+h4H//1oSvG/8T+YHLnJJ3qdc3sQ==
   dependencies:
+    canvaskit-wasm "^0.34.0"
     react-reconciler "^0.26.2"
 
 "@sideway/address@^4.1.3":
@@ -6468,6 +6469,11 @@ caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001358:
   version "1.0.30001358"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001358.tgz#473d35dabf5e448b463095cab7924e96ccfb8c00"
   integrity sha512-hvp8PSRymk85R20bsDra7ZTCpSVGN/PAz9pSAjPSjKC+rNmnUk5vCRgJwiTT/O4feQ/yu/drvZYpKxxhbFuChw==
+
+canvaskit-wasm@^0.34.0:
+  version "0.34.1"
+  resolved "https://registry.yarnpkg.com/canvaskit-wasm/-/canvaskit-wasm-0.34.1.tgz#dc8a4c0378e92d9541be8b9dd1c4abe69354cf4d"
+  integrity sha512-8qdrp0RO8wRUGTpn2JyfbBxsc5auSSTcHu4p2aazbmL7n15PzSpuZR5TKIg8xuVqqezclzLY2x/HEDSAuxmIxQ==
 
 capital-case@^1.0.4:
   version "1.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3417,10 +3417,10 @@
     component-type "^1.2.1"
     join-component "^1.1.0"
 
-"@shopify/react-native-skia@^0.1.133":
-  version "0.1.133"
-  resolved "https://registry.yarnpkg.com/@shopify/react-native-skia/-/react-native-skia-0.1.133.tgz#9ed8e2fabdabdbd49ecb9ba2bf403a81bfec906d"
-  integrity sha512-H6s89wEkIWCQHfe3F8qjoEDsVErmkldWlsvLmg+YI60VcllEB8E00s8SUb+h4H//1oSvG/8T+YHLnJJ3qdc3sQ==
+"@shopify/react-native-skia@0.1.134":
+  version "0.1.134"
+  resolved "https://registry.yarnpkg.com/@shopify/react-native-skia/-/react-native-skia-0.1.134.tgz#9ecfbe8298b206bb02e94e07aa4301fe55583cc1"
+  integrity sha512-VXyAKOkIwgo5d7zuwh0upAAs7klm7A4YTThx8bwzh+FOHar9mPzdT8vitBQzzrqkOqCcc80jfH8xZ5ePrVgTIQ==
   dependencies:
     canvaskit-wasm "^0.34.0"
     react-reconciler "^0.26.2"


### PR DESCRIPTION
# Why

close ENG-4889

# How

- add skia example in ncl
- update vendoring tools to support react-native-skia that will download files from npm, because prebuilt skia libraries are only accessible from npm.
- update versioning tools to support react-native-skia.

considering react-native-skia is still actively changed, i will update vendoring code later in separated pr.


# Test Plan

- `et uvm -m @shopify/react-native-skia -p ios -c 0.1.130` + unversioned skia ncl example
- `et add-sdk -p ios -s 45.0.0 -v '@shopify/react-native-skia'` + sdk 45 skia ncl example

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
