### PR TITLE
feat(babel-preset-expo): preserve import export on webpack only

### DIFF
--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Preserve `import/export` syntax on Webpack only.
+
 ## 9.1.0 — 2022-04-18
 
 ### 📚 3rd party library updates

--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Preserve `import/export` syntax on Webpack only.
+- Preserve `import/export` syntax on Webpack only. ([#17713](https://github.com/expo/expo/pull/17713) by [@EvanBacon](https://github.com/EvanBacon))
 
 ## 9.1.0 — 2022-04-18
 

--- a/packages/babel-preset-expo/README.md
+++ b/packages/babel-preset-expo/README.md
@@ -64,7 +64,7 @@ This property is passed down to [`@babel/plugin-transform-react-jsx`](https://ba
 
 `string`, defaults to `react`
 
-This option allows specifying a custom import source for importing functions. 
+This option allows specifying a custom import source for importing functions.
 
 ```js
 [
@@ -117,7 +117,7 @@ Enabling this option will allow your project to run with older JavaScript syntax
 
 > `TypeError: Cannot assign to read only property 'exports' of object '#<Object>'`
 
-**default:** `false`
+**default:** `false` when using Webpack. `true` otherwise.
 
 ```js
 [

--- a/packages/babel-preset-expo/index.js
+++ b/packages/babel-preset-expo/index.js
@@ -17,7 +17,12 @@ module.exports = function (api, options = {}) {
 
   const platformOptions =
     platform === 'web'
-      ? { disableImportExportTransform: true, ...web }
+      ? {
+          // Only disable import/export transform when Webpack is used because
+          // Metro does not support tree-shaking.
+          disableImportExportTransform: !!isWebpack,
+          ...web,
+        }
       : { disableImportExportTransform: false, ...native };
 
   // Note that if `options.lazyImports` is not set (i.e., `null` or `undefined`),


### PR DESCRIPTION
# Why

If you're using expo web with bundlers that don't support tree shaking then you'll want import/export to be transformed.
