### PR TITLE
[docs] Improve code snippets for dynamic config

### DIFF
--- a/docs/pages/build-reference/variables.md
+++ b/docs/pages/build-reference/variables.md
@@ -146,14 +146,18 @@ When you define environment variables on build profiles in **eas.json**, they wi
 In **app.config.js**, we may be using the API URL like this:
 
 ```js
-export default {
+export default ({ config }) => {
+  // app.json config provided in the arguments
   // ...
-  extra: {
-    // Fall back to development URL when not set
-    apiUrl: process.env.API_URL ?? 'https://localhost:3000'
-    enableHiddenFeatures: process.env.ENABLE_HIDDEN_FEATURES ? Boolean(process.env.ENABLE_HIDDEN_FEATURES) : true,
+  return {
+    ...config,
+    extra: {
+      // Fall back to development URL when not set
+      apiUrl: process.env.API_URL ?? 'https://localhost:3000'
+      enableHiddenFeatures: process.env.ENABLE_HIDDEN_FEATURES ? Boolean(process.env.ENABLE_HIDDEN_FEATURES) : true,
+    }
   }
-}
+};
 ```
 
 Using this approach, we would always need to remember to run `API_URL=https://api.staging.com ENABLE_HIDDEN_FEATURES=1 expo publish` when updating staging, and something similar for production. If we forgot the `ENABLE_HIDDEN_FEATURES=0` flag when publishing to production, we might end up rolling out untested features to production, and if we forgot the `API_URL` value, then users would be pointed to `https://localhost:3000`!
@@ -213,29 +217,31 @@ The following are two possible alternative approaches, each with different trade
   <Collapsible summary="app.config.js">
 
   ```js
-  let Config = {
+  let extraConfig = {
     apiUrl: 'https://localhost:3000',
     enableHiddenFeatures: true,
   };
 
   if (process.env.APP_ENV === 'production') {
-    Config.apiUrl = 'https://api.production.com';
-    Config.enableHiddenFeatures = false;
+    extraConfig.apiUrl = 'https://api.production.com';
+    extraConfig.enableHiddenFeatures = false;
   } else if (process.env.APP_ENV === 'staging') {
-    Config.apiUrl = 'https://api.staging.com';
-    Config.enableHiddenFeatures = true;
+    extraConfig.apiUrl = 'https://api.staging.com';
+    extraConfig.enableHiddenFeatures = true;
   }
 
-  export default {
-    // ...
-    extra: {
-      ...Config,
-    },
+  export default ({ config }) => {
+    // app.json config provided in the arguments
+    return {
+      ...config,
+      extra: {
+        ...extraConfig,
+      },
+    };
   };
   ```
 
   </Collapsible>
-
 
 ### How are naming collisions between secrets and the `env` field in eas.json handled?
 


### PR DESCRIPTION
# Why

When using code snippets for the _app.config.js_ from the documentation [here](https://docs.expo.dev/build-reference/variables/), it caught me by surprise that all existing configuration from the _app.json_ was not working anymore. Rather, all values were all reset to their defaults.

After some investigation, it turned out that those code snippets have overwritten all existing _app.json_ configuration values. This behavior is apparently expected due to the order of how files are parsed, but that is not mentioned on that page, only [here](https://docs.expo.dev/workflow/configuration/#dynamic-configuration-with-appconfigjs) 


# How

Improving the _./docs/pages/build-reference/variables.md_ documentation by adding code comments and parsing in the _app.json_ configuration parameter into the relevant snippets

# Test Plan

Tested with the documentation setup

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
