### PR TITLE
[docs] Fix inline snack submit buttons

### DIFF
--- a/docs/components/plugins/SnackInline.tsx
+++ b/docs/components/plugins/SnackInline.tsx
@@ -105,9 +105,9 @@ export default class SnackInline extends React.Component<Props> {
             />
           )}
           <Button
-            type="submit"
             disabled={!this.state.ready}
-            iconRight={<ArrowUpRightIcon color={theme.palette.white} />}>
+            iconRight={<ArrowUpRightIcon color={theme.palette.white} />}
+            type="submit">
             {this.props.buttonTitle || 'Try this example on Snack'}
           </Button>
         </form>

--- a/docs/components/plugins/SnackInline.tsx
+++ b/docs/components/plugins/SnackInline.tsx
@@ -105,6 +105,7 @@ export default class SnackInline extends React.Component<Props> {
             />
           )}
           <Button
+            type="submit"
             disabled={!this.state.ready}
             iconRight={<ArrowUpRightIcon color={theme.palette.white} />}>
             {this.props.buttonTitle || 'Try this example on Snack'}


### PR DESCRIPTION
# Why

Button type should be `submit`, the new **ui/components/Button** defaults to `button`. 

# How

We assume buttons aren't used in forms, since usually, we use them to link to other pages. But the snack inline is an exception to this, so we need to add it.

# Test Plan

Open [this docs](https://docs.expo.dev/versions/v45.0.0/sdk/battery/) and click the try snack button.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
