### PR TITLE
Link typo

### DIFF
--- a/docs/pages/ui-programming/react-native-toast.md
+++ b/docs/pages/ui-programming/react-native-toast.md
@@ -113,5 +113,5 @@ setTimeout(function hideToast() {
 <Toast visible={this.state.visible}>Thanks for subscribing!</Toast>
 ```
 
-This library has many options for [customizing the appearance and behavior](https://github.com/crazycodeboy/react-native-easy-toast#api) of your toast.
-See the [docs](https://github.com/magicismight/react-native-root-toast) to learn more.
+This library has many options for [customizing the appearance and behavior](https://github.com/magicismight/react-native-root-toast#reference) of your toast.
+See the package [repository](https://github.com/magicismight/react-native-root-toast) to learn more.

--- a/docs/pages/ui-programming/react-native-toast.md
+++ b/docs/pages/ui-programming/react-native-toast.md
@@ -114,4 +114,4 @@ setTimeout(function hideToast() {
 ```
 
 This library has many options for [customizing the appearance and behavior](https://github.com/crazycodeboy/react-native-easy-toast#api) of your toast.
-docs](https://github.com/magicismight/react-native-root-toast) to learn more.
+See the [docs](https://github.com/magicismight/react-native-root-toast) to learn more.


### PR DESCRIPTION
# Why

Just a Markdown typo for the link

# How

`:)`

# Test Plan

`:)`

# Checklist

`:)`

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
