### PR TITLE
[expo-updates][android] Fix asset hash storage

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Improved support of nvm sourcing in iOS shell scripts. ([#17109](https://github.com/expo/expo/pull/17109) by [@liamronancb](https://github.com/liamronancb))
 - Android: Allow null asset hash in new manifests. ([#17466](https://github.com/expo/expo/pull/17466) by [@wschurman](https://github.com/wschurman))
 - Fixed `source-login-scripts.sh` ~/zlogin typo. ([#17622](https://github.com/expo/expo/pull/17622) by [@vrgimael](https://github.com/vrgimael))
+- Android: Fix asset hash storage. ([#17732](https://github.com/expo/expo/pull/17732) by [@wschurman](https://github.com/wschurman))
 
 ### 💡 Others
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/db/UpdatesDatabaseMigrationTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/db/UpdatesDatabaseMigrationTest.kt
@@ -373,7 +373,7 @@ class UpdatesDatabaseMigrationTest {
     // Prepare for the next version.
     db.close()
 
-    // Re-open the database with version 8 and provide
+    // Re-open the database with version 9 and provide
     // MIGRATION_8_9 as the migration process.
     db = helper.runMigrationsAndValidate(TEST_DB, 9, true, UpdatesDatabase.MIGRATION_8_9)
     db.execSQL("PRAGMA foreign_keys=ON")
@@ -395,7 +395,7 @@ class UpdatesDatabaseMigrationTest {
   fun testMigrate9To10() {
     var db = helper.createDatabase(TEST_DB, 9)
 
-    // db has schema version 8. insert some data using SQL queries.
+    // db has schema version 9. insert some data using SQL queries.
     // cannot use DAO classes because they expect the latest schema.
     db.execSQL(
       """INSERT INTO "assets" ("id","url","key","headers","type","metadata","download_time","relative_path","hash","hash_type","marked_for_deletion","extra_request_headers") VALUES (2,'https://url.to/b56cf690e0afa93bd4dc7756d01edd3e','b56cf690e0afa93bd4dc7756d01edd3e.png',NULL,'image/png',NULL,1614137309295,'b56cf690e0afa93bd4dc7756d01edd3e.png',NULL,0,0,NULL),
@@ -406,8 +406,8 @@ class UpdatesDatabaseMigrationTest {
     // Prepare for the next version.
     db.close()
 
-    // Re-open the database with version 8 and provide
-    // MIGRATION_8_9 as the migration process.
+    // Re-open the database with version 10 and provide
+    // MIGRATION_9_10 as the migration process.
     db = helper.runMigrationsAndValidate(TEST_DB, 10, true, UpdatesDatabase.MIGRATION_9_10)
     db.execSQL("PRAGMA foreign_keys=ON")
 
@@ -421,6 +421,36 @@ class UpdatesDatabaseMigrationTest {
     val cursorAssets3 =
       db.query("SELECT * FROM `assets` WHERE `id` = 4 AND `url` IS NULL AND `key` IS NULL AND `headers` IS NULL AND `type` = 'js' AND `metadata` IS NULL AND `download_time` = 1614137406588 AND `relative_path` = 'bundle-1614137401950' AND `hash` IS NULL AND `hash_type` = 0 AND `marked_for_deletion` = 0 AND `extra_request_headers` IS NULL AND `expected_hash` IS NULL")
     Assert.assertEquals(1, cursorAssets3.count.toLong())
+  }
+
+  @Test
+  @Throws(IOException::class)
+  fun testMigrate10To11() {
+    var db = helper.createDatabase(TEST_DB, 10)
+
+    // db has schema version 10. insert some data using SQL queries.
+    // cannot use DAO classes because they expect the latest schema.
+    db.execSQL(
+      """INSERT INTO "assets" ("id","url","key","headers","type","metadata","download_time","relative_path","hash","hash_type","marked_for_deletion","extra_request_headers","expected_hash") VALUES (2,'https://url.to/b56cf690e0afa93bd4dc7756d01edd3e','b56cf690e0afa93bd4dc7756d01edd3e.png',NULL,'image/png',NULL,1614137309295,'b56cf690e0afa93bd4dc7756d01edd3e.png',NULL,0,0,NULL,'testhash2'),
+    (3,'https://url.to/bundle-1614137308871','bundle-1614137308871',NULL,'application/javascript',NULL,1614137309513,'bundle-1614137308871',NULL,0,0,NULL,'testhash3'),
+    (4,NULL,NULL,NULL,'js',NULL,1614137406588,'bundle-1614137401950',NULL,0,0,NULL,'testhash4')"""
+    )
+
+    // Prepare for the next version.
+    db.close()
+
+    // Re-open the database with version 11 and provide
+    // MIGRATION_10_11 as the migration process.
+    db = helper.runMigrationsAndValidate(TEST_DB, 11, true, UpdatesDatabase.MIGRATION_10_11)
+    db.execSQL("PRAGMA foreign_keys=ON")
+
+    // schema changes automatically verified, we just need to verify data integrity
+    val cursorAssets1 =
+      db.query("SELECT * FROM `assets`")
+    Assert.assertEquals(3, cursorAssets1.count.toLong())
+    val cursorAssets2 =
+      db.query("SELECT * FROM `assets` WHERE `expected_hash` IS NULL")
+    Assert.assertEquals(3, cursorAssets2.count.toLong())
   }
 
   private fun execSQLExpectingException(db: SupportSQLiteDatabase, sql: String): Boolean {

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/db/UpdatesDatabaseMigrationTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/db/UpdatesDatabaseMigrationTest.kt
@@ -436,6 +436,11 @@ class UpdatesDatabaseMigrationTest {
     (4,NULL,NULL,NULL,'js',NULL,1614137406588,'bundle-1614137401950',NULL,0,0,NULL,'testhash4')"""
     )
 
+    val cursorAssetsPrecondition1 = db.query("SELECT * FROM `assets`")
+    Assert.assertEquals(3, cursorAssetsPrecondition1.count.toLong())
+    val cursorAssetsPrecondition2 = db.query("SELECT * FROM `assets` WHERE `expected_hash` IS NULL")
+    Assert.assertEquals(0, cursorAssetsPrecondition2.count.toLong())
+
     // Prepare for the next version.
     db.close()
 
@@ -445,11 +450,9 @@ class UpdatesDatabaseMigrationTest {
     db.execSQL("PRAGMA foreign_keys=ON")
 
     // schema changes automatically verified, we just need to verify data integrity
-    val cursorAssets1 =
-      db.query("SELECT * FROM `assets`")
+    val cursorAssets1 = db.query("SELECT * FROM `assets`")
     Assert.assertEquals(3, cursorAssets1.count.toLong())
-    val cursorAssets2 =
-      db.query("SELECT * FROM `assets` WHERE `expected_hash` IS NULL")
+    val cursorAssets2 = db.query("SELECT * FROM `assets` WHERE `expected_hash` IS NULL")
     Assert.assertEquals(3, cursorAssets2.count.toLong())
   }
 

--- a/packages/expo-updates/android/src/androidTest/schemas/expo.modules.updates.db.UpdatesDatabase/11.json
+++ b/packages/expo-updates/android/src/androidTest/schemas/expo.modules.updates.db.UpdatesDatabase/11.json
@@ -1,0 +1,344 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 11,
+    "identityHash": "31dd21ebb478946b3d4dde78b2bccf6f",
+    "entities": [
+      {
+        "tableName": "updates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `commit_time` INTEGER NOT NULL, `runtime_version` TEXT NOT NULL, `scope_key` TEXT NOT NULL, `launch_asset_id` INTEGER, `manifest` TEXT, `status` INTEGER NOT NULL, `keep` INTEGER NOT NULL, `last_accessed` INTEGER NOT NULL, `successful_launch_count` INTEGER NOT NULL DEFAULT 0, `failed_launch_count` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`), FOREIGN KEY(`launch_asset_id`) REFERENCES `assets`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "commitTime",
+            "columnName": "commit_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "runtimeVersion",
+            "columnName": "runtime_version",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scopeKey",
+            "columnName": "scope_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "launchAssetId",
+            "columnName": "launch_asset_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "manifest",
+            "columnName": "manifest",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "keep",
+            "columnName": "keep",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessed",
+            "columnName": "last_accessed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "successfulLaunchCount",
+            "columnName": "successful_launch_count",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "failedLaunchCount",
+            "columnName": "failed_launch_count",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_updates_launch_asset_id",
+            "unique": false,
+            "columnNames": [
+              "launch_asset_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_updates_launch_asset_id` ON `${TABLE_NAME}` (`launch_asset_id`)"
+          },
+          {
+            "name": "index_updates_scope_key_commit_time",
+            "unique": true,
+            "columnNames": [
+              "scope_key",
+              "commit_time"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_updates_scope_key_commit_time` ON `${TABLE_NAME}` (`scope_key`, `commit_time`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "assets",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "launch_asset_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "updates_assets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`update_id` BLOB NOT NULL, `asset_id` INTEGER NOT NULL, PRIMARY KEY(`update_id`, `asset_id`), FOREIGN KEY(`update_id`) REFERENCES `updates`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`asset_id`) REFERENCES `assets`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "updateId",
+            "columnName": "update_id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "assetId",
+            "columnName": "asset_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "update_id",
+            "asset_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_updates_assets_asset_id",
+            "unique": false,
+            "columnNames": [
+              "asset_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_updates_assets_asset_id` ON `${TABLE_NAME}` (`asset_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "updates",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "update_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "assets",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "asset_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "assets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT, `type` TEXT, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `url` TEXT, `headers` TEXT, `extra_request_headers` TEXT, `metadata` TEXT, `download_time` INTEGER, `relative_path` TEXT, `hash` BLOB, `hash_type` INTEGER NOT NULL, `expected_hash` TEXT, `marked_for_deletion` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "headers",
+            "columnName": "headers",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "extraRequestHeaders",
+            "columnName": "extra_request_headers",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "metadata",
+            "columnName": "metadata",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "downloadTime",
+            "columnName": "download_time",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "relativePath",
+            "columnName": "relative_path",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "hash",
+            "columnName": "hash",
+            "affinity": "BLOB",
+            "notNull": false
+          },
+          {
+            "fieldPath": "hashType",
+            "columnName": "hash_type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expectedHash",
+            "columnName": "expected_hash",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "markedForDeletion",
+            "columnName": "marked_for_deletion",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_assets_key",
+            "unique": true,
+            "columnNames": [
+              "key"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_assets_key` ON `${TABLE_NAME}` (`key`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "json_data",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `value` TEXT NOT NULL, `last_updated` INTEGER NOT NULL, `scope_key` TEXT NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "last_updated",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scopeKey",
+            "columnName": "scope_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_json_data_scope_key",
+            "unique": false,
+            "columnNames": [
+              "scope_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_json_data_scope_key` ON `${TABLE_NAME}` (`scope_key`)"
+          }
+        ],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '31dd21ebb478946b3d4dde78b2bccf6f')"
+    ]
+  }
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewUpdateManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewUpdateManifest.kt
@@ -86,7 +86,7 @@ class NewUpdateManifest private constructor(
               url = Uri.parse(assetObject.getString("url"))
               extraRequestHeaders = assetHeaders[assetObject.getString("key")]
               embeddedAssetFilename = assetObject.getNullable("embeddedAssetFilename")
-              expectedHash = mLaunchAsset.getNullable("hash")
+              expectedHash = assetObject.getNullable("hash")
             }
           )
         } catch (e: JSONException) {


### PR DESCRIPTION
# Why

There is a typo in asset expected_hash storage in SQL on Android. This isn't present on iOS.

A separate bug was noticed: These assets are stored to disk whether or not the hash is valid (hash validation is done after storage) which means that upon second launch the hashes won't be verified and the update will launch. This will be fixed in separate PRs since it exists on both platforms.

Closes ENG-5122.

# How

Fix typo. Clear out all corrupted data (all `expected_hash` column values) by adding a migration to null out the column (following https://www.notion.so/expo/expo-updates-SQLite-migrations-b62aa6a5502b4b5eb4667bb4761d007b#4649d937bf0441c0ad41f8f01b50ad1f).

# Test Plan

Run test, inspect change. 

Note that I can't get the repo to build so testing this manually is proving to be a challenge, so @esamelson checked manually.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
