### PR TITLE
[docs] fix few docs internal links

### DIFF
--- a/docs/pages/guides/monorepos.md
+++ b/docs/pages/guides/monorepos.md
@@ -73,8 +73,9 @@ Metro doesn't come with monorepo support by default (yet). That's why we need to
 
 We can configure that by creating a **metro.config.js** with the following content.
 
+> Learn more about customizing Metro in [our guide](/guides/customizing-metro).
+
 ```js
-// Learn more https://docs.expo.io/guides/customizing-metro
 const { getDefaultConfig } = require('expo/metro-config');
 const path = require('path');
 

--- a/docs/pages/ui-programming/implementing-a-checkbox.md
+++ b/docs/pages/ui-programming/implementing-a-checkbox.md
@@ -11,7 +11,7 @@ One fairly common component that is not offered out of the box by Expo is the mi
 
 A checkbox is basically a button that exists in one of two states — it is checked or it isn't. This makes it a perfect candidate for the `useState()` hook. Our first iteration will render a button that toggles between checked and unchecked states. When the checkbox is checked, we'll render a checkmark icon in the center of the button.
 
-_Note: You can find more information about using icons in your Expo project here: https://docs.expo.dev/guides/icons/_
+> You can find more information about using icons in your Expo project in [Icons guide](/guides/icons/).
 
 <SnackInline>
 

--- a/docs/pages/ui-programming/implementing-a-checkbox.md
+++ b/docs/pages/ui-programming/implementing-a-checkbox.md
@@ -11,7 +11,7 @@ One fairly common component that is not offered out of the box by Expo is the mi
 
 A checkbox is basically a button that exists in one of two states — it is checked or it isn't. This makes it a perfect candidate for the `useState()` hook. Our first iteration will render a button that toggles between checked and unchecked states. When the checkbox is checked, we'll render a checkmark icon in the center of the button.
 
-> You can find more information about using icons in your Expo project in [Icons guide](/guides/icons/).
+> You can find more information about using icons in your Expo project in our [Icons guide](/guides/icons/).
 
 <SnackInline>
 

--- a/docs/pages/versions/unversioned/sdk/map-view.md
+++ b/docs/pages/versions/unversioned/sdk/map-view.md
@@ -139,7 +139,7 @@ To use this in web, add the following script to your **web/index.html**. This sc
 
 ## How to retrieve your debug keystore fingerprint (Android only)
  
-When building a debug version of your application outside of Expo Go (for example, when using a [development client](https://docs.expo.dev/development/introduction/) or a standalone debug build), your app will be signed with the debug keystore on Android.
+When building a debug version of your application outside of Expo Go (for example, when using a [development client](/development/introduction/) or a standalone debug build), your app will be signed with the debug keystore on Android.
 > All standard Expo templates use a debug keystore with fingerprint `5E:8F:16:06:2E:A3:CD:2C:4A:0D:54:78:76:BA:A6:F3:8C:AB:F6:25`, that you can enter directly in the Google Cloud Credential Manager. So if you are using one of the standard Expo templates, you don't need to perform the steps below.
 
 The debug keystore location and password is defined in your `android/app/build.gradle` file like this:

--- a/docs/pages/versions/v45.0.0/sdk/map-view.md
+++ b/docs/pages/versions/v45.0.0/sdk/map-view.md
@@ -139,7 +139,7 @@ To use this in web, add the following script to your **web/index.html**. This sc
 
 ## How to retrieve your debug keystore fingerprint (Android only)
  
-When building a debug version of your application outside of Expo Go (for example, when using a [development client](https://docs.expo.dev/development/introduction/) or a standalone debug build), your app will be signed with the debug keystore on Android.
+When building a debug version of your application outside of Expo Go (for example, when using a [development client](/development/introduction/) or a standalone debug build), your app will be signed with the debug keystore on Android.
 > All standard Expo templates use a debug keystore with fingerprint `5E:8F:16:06:2E:A3:CD:2C:4A:0D:54:78:76:BA:A6:F3:8C:AB:F6:25`, that you can enter directly in the Google Cloud Credential Manager. So if you are using one of the standard Expo templates, you don't need to perform the steps below.
 
 The debug keystore location and password is defined in your `android/app/build.gradle` file like this:


### PR DESCRIPTION
# Why

In the future we want to signify the external links in docs in some way. Let's fix the instances where we can use internal link instead, so we don't incorrectly mark the links in the future.

# How

Replace few external links to docs with the internal ones. 

Move two link out of the code comments to the note boxes, for ease of use.

# Test Plan

I have check that every change link works correctly on the website run locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
