### PR TITLE
[expo-dev-launcher] fix opening published update from URL on android

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix opening published EAS Update from URL on Android.
+- Fix opening published EAS Update from URL on Android. ([#17734](https://github.com/expo/expo/pull/17734) by [@esamelson](https://github.com/esamelson))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix opening published EAS Update from URL on Android.
+
 ### 💡 Others
 
 - Stop persisting remote debugging setting between app loads on iOS. ([#17650](https://github.com/expo/expo/pull/17650) by [@esamelson](https://github.com/esamelson))

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -119,7 +119,7 @@ class DevLauncherController private constructor() :
 
       // default to the EXPO_UPDATE_URL value configured in AndroidManifest.xml when project url is unspecified for an EAS update
       if (isEASUpdate && projectUrl == null) {
-        val projectUrlString = appHost.reactInstanceManager?.currentReactContext?.let { getMetadataValue(it, "expo.modules.updates.EXPO_UPDATE_URL") }
+        val projectUrlString = getMetadataValue(context, "expo.modules.updates.EXPO_UPDATE_URL")
         parsedProjectUrl = Uri.parse(projectUrlString)
       }
 
@@ -329,9 +329,9 @@ class DevLauncherController private constructor() :
     internal var sAdditionalPackages: List<ReactPackage>? = null
 
     @JvmStatic
-    fun getMetadataValue(reactApplicationContext: ReactContext, key: String): String {
-      val packageManager = reactApplicationContext.packageManager
-      val packageName = reactApplicationContext.packageName
+    fun getMetadataValue(context: Context, key: String): String {
+      val packageManager = context.packageManager
+      val packageName = context.packageName
       val applicationInfo = packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA)
       var metaDataValue = ""
 


### PR DESCRIPTION
# Why

I noticed this issue when trying to reproduce an unrelated one. If I launch a dev client and immediately try to open a published EAS update via URL, I get a perplexing error: "Error loading app: uriString`

I think what is happening is that the host ReactInstanceManager hasn't been created yet, and so `projectUrlString` is null, and then for some reason `Uri.parse(null)` throws the very unhelpful error message "uriString".

# How

Use the main application context to get the metadata value (it doesn't need to be ReactApplicationContext) which takes away the possibility of a null value.

# Test Plan

expo init test && cd test
expo install expo-dev-client expo-updates
expo prebuild
cd android && ./gradlew installDebug
open app on device, open published EAS update

Before this change, I get an alert that says "Error loading app: uriString"; after this change, the update proceeds to load correctly.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
