### PR TITLE
[docs] remove several of the global styles

### DIFF
--- a/docs/components/plugins/AuthSessionElements.tsx
+++ b/docs/components/plugins/AuthSessionElements.tsx
@@ -35,7 +35,7 @@ export const CreateAppButton: React.FC<{ href: string; name: string }> = ({ href
     css={STYLES_BUTTON}
     href={href}
     target="_blank"
-    iconRight={<ArrowUpRightIcon color={theme.palette.white} />}>
+    iconRight={<ArrowUpRightIcon color={theme.button.primary.foreground} />}>
     Create {name} App
   </Button>
 );

--- a/docs/components/plugins/AuthSessionElements.tsx
+++ b/docs/components/plugins/AuthSessionElements.tsx
@@ -1,6 +1,8 @@
 import { css } from '@emotion/react';
-import { theme } from '@expo/styleguide';
+import { theme, spacing, ArrowUpRightIcon } from '@expo/styleguide';
 import * as React from 'react';
+
+import { Button } from '~/ui/components/Button';
 
 const STYLES_LINK = css`
   text-decoration: none;
@@ -25,18 +27,17 @@ const STYLES_LINK = css`
 `;
 
 const STYLES_BUTTON = css`
-  display: inline-flex;
+  margin-bottom: ${spacing[4]}px;
 `;
 
 export const CreateAppButton: React.FC<{ href: string; name: string }> = ({ href, name }) => (
-  <a
+  <Button
     css={STYLES_BUTTON}
-    className="snack-inline-example-button"
     href={href}
     target="_blank"
-    rel="noreferrer">
+    iconRight={<ArrowUpRightIcon color={theme.palette.white} />}>
     Create {name} App
-  </a>
+  </Button>
 );
 
 export const SocialGrid: React.FC = ({ children }) => (

--- a/docs/components/plugins/ConfigurationDiff.tsx
+++ b/docs/components/plugins/ConfigurationDiff.tsx
@@ -1,35 +1,28 @@
 import { css } from '@emotion/react';
-import { theme } from '@expo/styleguide';
-import React, { useEffect, useState } from 'react';
+import { borderRadius, spacing, theme, typography } from '@expo/styleguide';
+import React, { useEffect, useState, PropsWithChildren } from 'react';
 import { parseDiff, Diff, Hunk } from 'react-diff-view';
 
-const TITLE_CONTAINER = css`
-  padding: 15px;
-  background-color: ${theme.background.secondary};
-  border-bottom: 1px solid ${theme.border.default};
-  font-family: monospace;
-  font-size: 0.9rem;
-  color: ${theme.text.default};
-`;
-
-const Title: React.FC = ({ children }) => (
-  <div css={TITLE_CONTAINER}>
+const DiffTitle = ({ children }: PropsWithChildren<object>) => (
+  <div css={titleContainerStyles}>
     <span>{children}</span>
   </div>
 );
 
 // These types come from `react-diff-view` library
-type RenderFile = (_arg0: {
+type RenderLine = {
   oldRevision: string;
   newRevision: string;
   type: 'unified' | 'split';
   hunks: object[];
   newPath: string;
   oldPath: string;
-}) => JSX.Element;
+};
 
-const ConfigurationDiff: React.FC<{ source: string }> = ({ source }) => {
-  const [diff, setDiff] = useState<any[] | null>(null);
+type RenderFile = (_arg0: RenderLine) => JSX.Element;
+
+const ConfigurationDiff = ({ source }: PropsWithChildren<{ source: string }>) => {
+  const [diff, setDiff] = useState<RenderLine[] | null>(null);
   useEffect(() => {
     async function fetchDiffAsync() {
       const response = await fetch(source);
@@ -45,8 +38,8 @@ const ConfigurationDiff: React.FC<{ source: string }> = ({ source }) => {
   }
 
   const renderFile: RenderFile = ({ oldRevision, newRevision, type, hunks, newPath }) => (
-    <div className="diff-container">
-      <Title>{newPath}</Title>
+    <div css={diffContainerStyles}>
+      <DiffTitle>{newPath}</DiffTitle>
       <Diff key={oldRevision + '-' + newRevision} viewType="unified" diffType={type} hunks={hunks}>
         {(hunks: any[]) => hunks.map(hunk => <Hunk key={hunk.content} hunk={hunk} />)}
       </Diff>
@@ -55,5 +48,48 @@ const ConfigurationDiff: React.FC<{ source: string }> = ({ source }) => {
 
   return <div>{diff.map(renderFile)}</div>;
 };
+
+const diffContainerStyles = css`
+  font-family: ${typography.fontFaces.mono};
+  color: ${theme.text.default};
+  border: 1px solid ${theme.border.default};
+  background-color: ${theme.background.screen};
+  border-radius: ${borderRadius.small}px;
+  margin-bottom: ${spacing[2.5]}px;
+
+  table {
+    ${typography.fontSizes[14]}
+    border: none;
+  }
+
+  td,
+  th {
+    border-bottom: none;
+  }
+
+  .diff-gutter-normal {
+    color: ${theme.text.secondary};
+  }
+
+  .diff-gutter-insert,
+  .diff-code-insert {
+    background: ${theme.background.success};
+    color: ${theme.text.success};
+  }
+
+  .diff-gutter-delete,
+  .diff-code-delete {
+    background: ${theme.background.error};
+    color: ${theme.text.error};
+  }
+`;
+
+const titleContainerStyles = css`
+  padding: ${spacing[3.5]}px;
+  background-color: ${theme.background.default};
+  border-bottom: 1px solid ${theme.border.default};
+  font-size: 0.9rem;
+  color: ${theme.text.default};
+`;
 
 export default ConfigurationDiff;

--- a/docs/global-styles/extras.ts
+++ b/docs/global-styles/extras.ts
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { theme, palette, typography } from '@expo/styleguide';
+import { theme } from '@expo/styleguide';
 
 export const globalExtras = css`
   img.wide-image {
@@ -14,78 +14,6 @@ export const globalExtras = css`
 
   .react-player > video {
     outline: none;
-  }
-
-  .snack-inline-example-button {
-    display: grid;
-    grid-template-columns: 16px 1fr;
-    grid-gap: 8px;
-    align-items: center;
-    border: none;
-    border-radius: 4px;
-    padding: 0 16px;
-    height: 40px;
-    margin: 0;
-    margin-bottom: 0.5rem;
-    text-decoration: none;
-    background: ${theme.button.primary.background};
-    color: ${palette.dark.white};
-    font-family: ${typography.fontFaces.regular};
-    font-size: 1rem;
-    cursor: pointer;
-    -webkit-appearance: none;
-    -moz-appearance: none;
-    transition: all 170ms linear;
-  }
-
-  .snack-inline-example-button:hover,
-  .snack-inline-example-button:focus {
-    box-shadow: 0 2px 8px rgba(0, 1, 0, 0.2);
-    opacity: 0.85;
-  }
-
-  .snack-inline-example-button:focus {
-    outline: 0;
-    border: 0;
-  }
-
-  .snack-inline-example-button:active {
-    outline: 0;
-    border: 0;
-  }
-
-  .diff-container {
-    border: 1px solid ${theme.border.default};
-    border-radius: 2px;
-    margin-bottom: 10px;
-  }
-
-  .diff-container table {
-    font-size: 0.9rem;
-    border-radius: none;
-    border: none;
-  }
-
-  .diff-container td,
-  .diff-container th {
-    border-bottom: none;
-    border-right: none;
-  }
-
-  .diff-container .diff-gutter-insert {
-    background: ${theme.background.success};
-  }
-
-  .diff-container .diff-gutter-delete {
-    background: ${theme.background.error};
-  }
-
-  .diff-container .diff-code-insert {
-    background: ${theme.background.success};
-  }
-
-  .diff-container .diff-code-delete {
-    background: ${theme.background.error};
   }
 
   .strike {


### PR DESCRIPTION
# Why

Refs ENG-4045

# How

This PR removes the global styles used by `ConfigurationDiff` and `CreateAppButton`, and replaces them with local in-component styles.

I have also adjusted a bit the appearance of diff block, to align it more with upcoming `CodeBlock` design and ensured that the used monospace font is correct. And the button now includes the arrow icon, which indicates external link.

# Test Plan

The changes have been tested by running the website locally.

# Preview

### `ConfigurationDiff`

<img width="827" alt="Screenshot 2022-06-03 000235" src="https://user-images.githubusercontent.com/719641/171823890-437f8303-0a72-4d96-b83e-5b71c5aadcb8.png">

<img width="827" alt="Screenshot 2022-06-03 000252" src="https://user-images.githubusercontent.com/719641/171823892-721b287d-4f58-435c-a6f1-609cdc50a521.png">

### `CreateAppButton`

<img width="217" alt="Screenshot 2022-06-03 005026" src="https://user-images.githubusercontent.com/719641/171823945-578566cd-e134-42ef-b074-e70efc9dbd1a.png">

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
