### PR TITLE
[docs] APISection: use tables for methods arguments

### DIFF
--- a/docs/components/plugins/APISection.test.tsx
+++ b/docs/components/plugins/APISection.test.tsx
@@ -32,7 +32,7 @@ describe('APISection', () => {
 
     expect(screen.getAllByRole('heading', { level: 2 })).toHaveLength(5);
     expect(screen.getAllByRole('heading', { level: 3 })).toHaveLength(20);
-    expect(screen.getAllByRole('table')).toHaveLength(10);
+    expect(screen.getAllByRole('table')).toHaveLength(11);
 
     expect(screen.queryByText('Event Subscriptions'));
     expect(screen.queryByText('Components'));

--- a/docs/components/plugins/APISection.test.tsx
+++ b/docs/components/plugins/APISection.test.tsx
@@ -32,7 +32,7 @@ describe('APISection', () => {
 
     expect(screen.getAllByRole('heading', { level: 2 })).toHaveLength(5);
     expect(screen.getAllByRole('heading', { level: 3 })).toHaveLength(20);
-    expect(screen.getAllByRole('table')).toHaveLength(6);
+    expect(screen.getAllByRole('table')).toHaveLength(10);
 
     expect(screen.queryByText('Event Subscriptions'));
     expect(screen.queryByText('Components'));
@@ -81,7 +81,7 @@ describe('APISection', () => {
 
     expect(screen.getAllByRole('heading', { level: 2 })).toHaveLength(4);
     expect(screen.getAllByRole('heading', { level: 3 })).toHaveLength(11);
-    expect(screen.getAllByRole('table')).toHaveLength(3);
+    expect(screen.getAllByRole('table')).toHaveLength(6);
 
     expect(screen.queryByText('Methods'));
     expect(screen.queryByText('Enums'));

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -1026,94 +1026,83 @@ in here.
       </div>
     </h3>
     <h4
-      class="  css-838f5l-h4-h4-STYLES_H4"
-      data-components-heading="true"
+      class="css-838f5l-h4-h4-STYLES_H4"
       data-heading="true"
     >
-      <div
-        class="css-1rh3o5q-STYLES_PERMALINK"
-      >
-        <span
-          class="css-zonpcr-STYLES_PERMALINK_TARGET"
-          id="arguments"
-        />
-        <a
-          class="css-15lh5hg-STYLES_PERMALINK_LINK"
-          href="#arguments"
-        >
-          <span
-            class="css-1icvi79-STYLED_PERMALINK_CONTENT"
-          >
-            Arguments
-          </span>
-          <span
-            class="css-10vdcw8-STYLES_PERMALINK_ICON"
-          >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </div>
+      Arguments
     </h4>
-    <ul
-      class="css-1qha16q-paragraph-STYLES_UNORDERED_LIST-UL"
-      data-text="true"
+    <div
+      class="css-zdmbpy-tableWrapperStyle"
     >
-      <li
-        class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
+      <table
+        class="css-33l6in-tableStyle-Table"
       >
-        <strong
-          class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
+        <thead
+          class="css-7aq1e9-tableHeadStyle"
         >
-          user
-           (
-          <code
-            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
+          <tr
+            class="css-1ne1f2k-tableRowStyle-Row"
           >
-            string
-          </code>
-          )
-        </strong>
-         - 
-        <span>
-          The unique identifier for the user whose credential state you'd like to check.
-This should come from the user field of an 
-          <a
-            class="css-12zqqiz-STYLES_EXTERNAL_LINK"
-            href="/#appleauthenticationcredentialstate"
+            <th
+              class="css-qgy7w-tableHeadersCellStyle-HeaderCell"
+            >
+              Name
+            </th>
+            <th
+              class="css-qgy7w-tableHeadersCellStyle-HeaderCell"
+            >
+              Type
+            </th>
+            <th
+              class="css-qgy7w-tableHeadersCellStyle-HeaderCell"
+            >
+              Description
+            </th>
+          </tr>
+        </thead>
+        <tr
+          class="css-1ne1f2k-tableRowStyle-Row"
+        >
+          <td
+            class="css-yr5jng-tableCellStyle-Cell"
+          >
+            <strong
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
+            >
+              user
+            </strong>
+          </td>
+          <td
+            class="css-yr5jng-tableCellStyle-Cell"
           >
             <code
               class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
-              AppleAuthenticationCredential
+              string
             </code>
-          </a>
-           object.
-        </span>
-      </li>
-    </ul>
+          </td>
+          <td
+            class="css-yr5jng-tableCellStyle-Cell"
+          >
+            <span>
+              The unique identifier for the user whose credential state you'd like to check.
+This should come from the user field of an 
+              <a
+                class="css-12zqqiz-STYLES_EXTERNAL_LINK"
+                href="/#appleauthenticationcredentialstate"
+              >
+                <code
+                  class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
+                >
+                  AppleAuthenticationCredential
+                </code>
+              </a>
+               object.
+            </span>
+          </td>
+        </tr>
+      </table>
+    </div>
     <p
       class="css-101h856-paragraph-STYLES_PARAGRAPH"
       data-text="true"
@@ -1493,98 +1482,87 @@ value depending on the state of the credential.
       </div>
     </h3>
     <h4
-      class="  css-838f5l-h4-h4-STYLES_H4"
-      data-components-heading="true"
+      class="css-838f5l-h4-h4-STYLES_H4"
       data-heading="true"
     >
-      <div
-        class="css-1rh3o5q-STYLES_PERMALINK"
-      >
-        <span
-          class="css-zonpcr-STYLES_PERMALINK_TARGET"
-          id="arguments-1"
-        />
-        <a
-          class="css-15lh5hg-STYLES_PERMALINK_LINK"
-          href="#arguments-1"
-        >
-          <span
-            class="css-1icvi79-STYLED_PERMALINK_CONTENT"
-          >
-            Arguments
-          </span>
-          <span
-            class="css-10vdcw8-STYLES_PERMALINK_ICON"
-          >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </div>
+      Arguments
     </h4>
-    <ul
-      class="css-1qha16q-paragraph-STYLES_UNORDERED_LIST-UL"
-      data-text="true"
+    <div
+      class="css-zdmbpy-tableWrapperStyle"
     >
-      <li
-        class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
+      <table
+        class="css-33l6in-tableStyle-Table"
       >
-        <strong
-          class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
+        <thead
+          class="css-7aq1e9-tableHeadStyle"
         >
-          options
-           (
-          <code
-            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
+          <tr
+            class="css-1ne1f2k-tableRowStyle-Row"
           >
-            <a
-              class="css-12zqqiz-STYLES_EXTERNAL_LINK"
-              href="/#appleauthenticationrefreshoptions"
+            <th
+              class="css-qgy7w-tableHeadersCellStyle-HeaderCell"
             >
-              AppleAuthenticationRefreshOptions
-            </a>
-          </code>
-          )
-        </strong>
-         - 
-        <span>
-          An 
-          <a
-            class="css-12zqqiz-STYLES_EXTERNAL_LINK"
-            href="/#appleauthenticationrefreshoptions"
+              Name
+            </th>
+            <th
+              class="css-qgy7w-tableHeadersCellStyle-HeaderCell"
+            >
+              Type
+            </th>
+            <th
+              class="css-qgy7w-tableHeadersCellStyle-HeaderCell"
+            >
+              Description
+            </th>
+          </tr>
+        </thead>
+        <tr
+          class="css-1ne1f2k-tableRowStyle-Row"
+        >
+          <td
+            class="css-yr5jng-tableCellStyle-Cell"
+          >
+            <strong
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
+            >
+              options
+            </strong>
+          </td>
+          <td
+            class="css-yr5jng-tableCellStyle-Cell"
           >
             <code
               class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
-              AppleAuthenticationRefreshOptions
+              <a
+                class="css-12zqqiz-STYLES_EXTERNAL_LINK"
+                href="/#appleauthenticationrefreshoptions"
+              >
+                AppleAuthenticationRefreshOptions
+              </a>
             </code>
-          </a>
-           object
-        </span>
-      </li>
-    </ul>
+          </td>
+          <td
+            class="css-yr5jng-tableCellStyle-Cell"
+          >
+            <span>
+              An 
+              <a
+                class="css-12zqqiz-STYLES_EXTERNAL_LINK"
+                href="/#appleauthenticationrefreshoptions"
+              >
+                <code
+                  class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
+                >
+                  AppleAuthenticationRefreshOptions
+                </code>
+              </a>
+               object
+            </span>
+          </td>
+        </tr>
+      </table>
+    </div>
     <p
       class="css-101h856-paragraph-STYLES_PARAGRAPH"
       data-text="true"
@@ -1758,99 +1736,93 @@ refresh operation.
       </div>
     </h3>
     <h4
-      class="  css-838f5l-h4-h4-STYLES_H4"
-      data-components-heading="true"
+      class="css-838f5l-h4-h4-STYLES_H4"
       data-heading="true"
     >
-      <div
-        class="css-1rh3o5q-STYLES_PERMALINK"
-      >
-        <span
-          class="css-zonpcr-STYLES_PERMALINK_TARGET"
-          id="arguments-2"
-        />
-        <a
-          class="css-15lh5hg-STYLES_PERMALINK_LINK"
-          href="#arguments-2"
-        >
-          <span
-            class="css-1icvi79-STYLED_PERMALINK_CONTENT"
-          >
-            Arguments
-          </span>
-          <span
-            class="css-10vdcw8-STYLES_PERMALINK_ICON"
-          >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </div>
+      Arguments
     </h4>
-    <ul
-      class="css-1qha16q-paragraph-STYLES_UNORDERED_LIST-UL"
-      data-text="true"
+    <div
+      class="css-zdmbpy-tableWrapperStyle"
     >
-      <li
-        class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
+      <table
+        class="css-33l6in-tableStyle-Table"
       >
-        <strong
-          class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
+        <thead
+          class="css-7aq1e9-tableHeadStyle"
         >
-          options
-          ?
-           (
-          <code
-            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
+          <tr
+            class="css-1ne1f2k-tableRowStyle-Row"
           >
-            <a
-              class="css-12zqqiz-STYLES_EXTERNAL_LINK"
-              href="/#appleauthenticationsigninoptions"
+            <th
+              class="css-qgy7w-tableHeadersCellStyle-HeaderCell"
             >
-              AppleAuthenticationSignInOptions
-            </a>
-          </code>
-          )
-        </strong>
-         - 
-        <span>
-          An optional 
-          <a
-            class="css-12zqqiz-STYLES_EXTERNAL_LINK"
-            href="/#appleauthenticationsigninoptions"
+              Name
+            </th>
+            <th
+              class="css-qgy7w-tableHeadersCellStyle-HeaderCell"
+            >
+              Type
+            </th>
+            <th
+              class="css-qgy7w-tableHeadersCellStyle-HeaderCell"
+            >
+              Description
+            </th>
+          </tr>
+        </thead>
+        <tr
+          class="css-1ne1f2k-tableRowStyle-Row"
+        >
+          <td
+            class="css-yr5jng-tableCellStyle-Cell"
+          >
+            <strong
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
+            >
+              options
+            </strong>
+            <br />
+            <span
+              class="css-fbbx5x-STYLES_OPTIONAL"
+            >
+              (optional)
+            </span>
+          </td>
+          <td
+            class="css-yr5jng-tableCellStyle-Cell"
           >
             <code
               class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
-              AppleAuthenticationSignInOptions
+              <a
+                class="css-12zqqiz-STYLES_EXTERNAL_LINK"
+                href="/#appleauthenticationsigninoptions"
+              >
+                AppleAuthenticationSignInOptions
+              </a>
             </code>
-          </a>
-           object
-        </span>
-      </li>
-    </ul>
+          </td>
+          <td
+            class="css-yr5jng-tableCellStyle-Cell"
+          >
+            <span>
+              An optional 
+              <a
+                class="css-12zqqiz-STYLES_EXTERNAL_LINK"
+                href="/#appleauthenticationsigninoptions"
+              >
+                <code
+                  class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
+                >
+                  AppleAuthenticationSignInOptions
+                </code>
+              </a>
+               object
+            </span>
+          </td>
+        </tr>
+      </table>
+    </div>
     <p
       class="css-101h856-paragraph-STYLES_PARAGRAPH"
       data-text="true"
@@ -2062,98 +2034,87 @@ sign-in operation.
       </div>
     </h3>
     <h4
-      class="  css-838f5l-h4-h4-STYLES_H4"
-      data-components-heading="true"
+      class="css-838f5l-h4-h4-STYLES_H4"
       data-heading="true"
     >
-      <div
-        class="css-1rh3o5q-STYLES_PERMALINK"
-      >
-        <span
-          class="css-zonpcr-STYLES_PERMALINK_TARGET"
-          id="arguments-3"
-        />
-        <a
-          class="css-15lh5hg-STYLES_PERMALINK_LINK"
-          href="#arguments-3"
-        >
-          <span
-            class="css-1icvi79-STYLED_PERMALINK_CONTENT"
-          >
-            Arguments
-          </span>
-          <span
-            class="css-10vdcw8-STYLES_PERMALINK_ICON"
-          >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </div>
+      Arguments
     </h4>
-    <ul
-      class="css-1qha16q-paragraph-STYLES_UNORDERED_LIST-UL"
-      data-text="true"
+    <div
+      class="css-zdmbpy-tableWrapperStyle"
     >
-      <li
-        class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
+      <table
+        class="css-33l6in-tableStyle-Table"
       >
-        <strong
-          class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
+        <thead
+          class="css-7aq1e9-tableHeadStyle"
         >
-          options
-           (
-          <code
-            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
+          <tr
+            class="css-1ne1f2k-tableRowStyle-Row"
           >
-            <a
-              class="css-12zqqiz-STYLES_EXTERNAL_LINK"
-              href="/#appleauthenticationsignoutoptions"
+            <th
+              class="css-qgy7w-tableHeadersCellStyle-HeaderCell"
             >
-              AppleAuthenticationSignOutOptions
-            </a>
-          </code>
-          )
-        </strong>
-         - 
-        <span>
-          An 
-          <a
-            class="css-12zqqiz-STYLES_EXTERNAL_LINK"
-            href="/#appleauthenticationsignoutoptions"
+              Name
+            </th>
+            <th
+              class="css-qgy7w-tableHeadersCellStyle-HeaderCell"
+            >
+              Type
+            </th>
+            <th
+              class="css-qgy7w-tableHeadersCellStyle-HeaderCell"
+            >
+              Description
+            </th>
+          </tr>
+        </thead>
+        <tr
+          class="css-1ne1f2k-tableRowStyle-Row"
+        >
+          <td
+            class="css-yr5jng-tableCellStyle-Cell"
+          >
+            <strong
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
+            >
+              options
+            </strong>
+          </td>
+          <td
+            class="css-yr5jng-tableCellStyle-Cell"
           >
             <code
               class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
-              AppleAuthenticationSignOutOptions
+              <a
+                class="css-12zqqiz-STYLES_EXTERNAL_LINK"
+                href="/#appleauthenticationsignoutoptions"
+              >
+                AppleAuthenticationSignOutOptions
+              </a>
             </code>
-          </a>
-           object
-        </span>
-      </li>
-    </ul>
+          </td>
+          <td
+            class="css-yr5jng-tableCellStyle-Cell"
+          >
+            <span>
+              An 
+              <a
+                class="css-12zqqiz-STYLES_EXTERNAL_LINK"
+                href="/#appleauthenticationsignoutoptions"
+              >
+                <code
+                  class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
+                >
+                  AppleAuthenticationSignOutOptions
+                </code>
+              </a>
+               object
+            </span>
+          </td>
+        </tr>
+      </table>
+    </div>
     <p
       class="css-101h856-paragraph-STYLES_PARAGRAPH"
       data-text="true"
@@ -2406,81 +2367,7 @@ sign-out operation.
         </a>
       </div>
     </h3>
-    <h4
-      class="  css-838f5l-h4-h4-STYLES_H4"
-      data-components-heading="true"
-      data-heading="true"
-    >
-      <div
-        class="css-1rh3o5q-STYLES_PERMALINK"
-      >
-        <span
-          class="css-zonpcr-STYLES_PERMALINK_TARGET"
-          id="arguments-4"
-        />
-        <a
-          class="css-15lh5hg-STYLES_PERMALINK_LINK"
-          href="#arguments-4"
-        >
-          <span
-            class="css-1icvi79-STYLED_PERMALINK_CONTENT"
-          >
-            Arguments
-          </span>
-          <span
-            class="css-10vdcw8-STYLES_PERMALINK_ICON"
-          >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </div>
-    </h4>
-    <ul
-      class="css-1qha16q-paragraph-STYLES_UNORDERED_LIST-UL"
-      data-text="true"
-    >
-      <li
-        class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
-      >
-        <strong
-          class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
-        >
-          listener
-           (
-          <code
-            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
-          >
-            () =&gt;
-             
-            void
-          </code>
-          )
-        </strong>
-      </li>
-    </ul>
+    -
     <h4
       class="  css-838f5l-h4-h4-STYLES_H4"
       data-components-heading="true"
@@ -9264,6 +9151,7 @@ exports[`APISection expo-pedometer 1`] = `
         </a>
       </div>
     </h3>
+    -
     <h4
       class="  css-838f5l-h4-h4-STYLES_H4"
       data-components-heading="true"
@@ -9405,114 +9293,112 @@ exports[`APISection expo-pedometer 1`] = `
       </div>
     </h3>
     <h4
-      class="  css-838f5l-h4-h4-STYLES_H4"
-      data-components-heading="true"
+      class="css-838f5l-h4-h4-STYLES_H4"
       data-heading="true"
     >
-      <div
-        class="css-1rh3o5q-STYLES_PERMALINK"
-      >
-        <span
-          class="css-zonpcr-STYLES_PERMALINK_TARGET"
-          id="arguments"
-        />
-        <a
-          class="css-15lh5hg-STYLES_PERMALINK_LINK"
-          href="#arguments"
-        >
-          <span
-            class="css-1icvi79-STYLED_PERMALINK_CONTENT"
-          >
-            Arguments
-          </span>
-          <span
-            class="css-10vdcw8-STYLES_PERMALINK_ICON"
-          >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </div>
+      Arguments
     </h4>
-    <ul
-      class="css-1qha16q-paragraph-STYLES_UNORDERED_LIST-UL"
-      data-text="true"
+    <div
+      class="css-zdmbpy-tableWrapperStyle"
     >
-      <li
-        class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
+      <table
+        class="css-33l6in-tableStyle-Table"
       >
-        <strong
-          class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
+        <thead
+          class="css-7aq1e9-tableHeadStyle"
         >
-          start
-           (
-          <code
-            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
+          <tr
+            class="css-1ne1f2k-tableRowStyle-Row"
           >
-            <a
-              class="css-12zqqiz-STYLES_EXTERNAL_LINK"
-              href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date"
-              rel="noopener noreferrer"
+            <th
+              class="css-qgy7w-tableHeadersCellStyle-HeaderCell"
             >
-              Date
-            </a>
-          </code>
-          )
-        </strong>
-         - 
-        <span>
-          A date indicating the start of the range over which to measure steps.
-        </span>
-      </li>
-      <li
-        class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
-      >
-        <strong
-          class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
+              Name
+            </th>
+            <th
+              class="css-qgy7w-tableHeadersCellStyle-HeaderCell"
+            >
+              Type
+            </th>
+            <th
+              class="css-qgy7w-tableHeadersCellStyle-HeaderCell"
+            >
+              Description
+            </th>
+          </tr>
+        </thead>
+        <tr
+          class="css-1ne1f2k-tableRowStyle-Row"
         >
-          end
-           (
-          <code
-            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
+          <td
+            class="css-yr5jng-tableCellStyle-Cell"
           >
-            <a
-              class="css-12zqqiz-STYLES_EXTERNAL_LINK"
-              href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date"
-              rel="noopener noreferrer"
+            <strong
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
-              Date
-            </a>
-          </code>
-          )
-        </strong>
-         - 
-        <span>
-          A date indicating the end of the range over which to measure steps.
-        </span>
-      </li>
-    </ul>
+              start
+            </strong>
+          </td>
+          <td
+            class="css-yr5jng-tableCellStyle-Cell"
+          >
+            <code
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
+            >
+              <a
+                class="css-12zqqiz-STYLES_EXTERNAL_LINK"
+                href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date"
+                rel="noopener noreferrer"
+              >
+                Date
+              </a>
+            </code>
+          </td>
+          <td
+            class="css-yr5jng-tableCellStyle-Cell"
+          >
+            <span>
+              A date indicating the start of the range over which to measure steps.
+            </span>
+          </td>
+        </tr>
+        <tr
+          class="css-1ne1f2k-tableRowStyle-Row"
+        >
+          <td
+            class="css-yr5jng-tableCellStyle-Cell"
+          >
+            <strong
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
+            >
+              end
+            </strong>
+          </td>
+          <td
+            class="css-yr5jng-tableCellStyle-Cell"
+          >
+            <code
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
+            >
+              <a
+                class="css-12zqqiz-STYLES_EXTERNAL_LINK"
+                href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date"
+                rel="noopener noreferrer"
+              >
+                Date
+              </a>
+            </code>
+          </td>
+          <td
+            class="css-yr5jng-tableCellStyle-Cell"
+          >
+            <span>
+              A date indicating the end of the range over which to measure steps.
+            </span>
+          </td>
+        </tr>
+      </table>
+    </div>
     <p
       class="css-101h856-paragraph-STYLES_PARAGRAPH"
       data-text="true"
@@ -9897,6 +9783,7 @@ available on this device.
         </a>
       </div>
     </h3>
+    -
     <h4
       class="  css-838f5l-h4-h4-STYLES_H4"
       data-components-heading="true"
@@ -10038,99 +9925,88 @@ available on this device.
       </div>
     </h3>
     <h4
-      class="  css-838f5l-h4-h4-STYLES_H4"
-      data-components-heading="true"
+      class="css-838f5l-h4-h4-STYLES_H4"
       data-heading="true"
     >
-      <div
-        class="css-1rh3o5q-STYLES_PERMALINK"
-      >
-        <span
-          class="css-zonpcr-STYLES_PERMALINK_TARGET"
-          id="arguments-1"
-        />
-        <a
-          class="css-15lh5hg-STYLES_PERMALINK_LINK"
-          href="#arguments-1"
-        >
-          <span
-            class="css-1icvi79-STYLED_PERMALINK_CONTENT"
-          >
-            Arguments
-          </span>
-          <span
-            class="css-10vdcw8-STYLES_PERMALINK_ICON"
-          >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </div>
+      Arguments
     </h4>
-    <ul
-      class="css-1qha16q-paragraph-STYLES_UNORDERED_LIST-UL"
-      data-text="true"
+    <div
+      class="css-zdmbpy-tableWrapperStyle"
     >
-      <li
-        class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
+      <table
+        class="css-33l6in-tableStyle-Table"
       >
-        <strong
-          class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
+        <thead
+          class="css-7aq1e9-tableHeadStyle"
         >
-          callback
-           (
-          <code
-            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
+          <tr
+            class="css-1ne1f2k-tableRowStyle-Row"
           >
-            <a
-              class="css-12zqqiz-STYLES_EXTERNAL_LINK"
-              href="/#pedometerupdatecallback"
+            <th
+              class="css-qgy7w-tableHeadersCellStyle-HeaderCell"
             >
-              PedometerUpdateCallback
-            </a>
-          </code>
-          )
-        </strong>
-         - 
-        <span>
-          A callback that is invoked when new step count data is available. The callback is
-provided with a single argument that is 
-          <a
-            class="css-12zqqiz-STYLES_EXTERNAL_LINK"
-            href="/#pedometerresult"
+              Name
+            </th>
+            <th
+              class="css-qgy7w-tableHeadersCellStyle-HeaderCell"
+            >
+              Type
+            </th>
+            <th
+              class="css-qgy7w-tableHeadersCellStyle-HeaderCell"
+            >
+              Description
+            </th>
+          </tr>
+        </thead>
+        <tr
+          class="css-1ne1f2k-tableRowStyle-Row"
+        >
+          <td
+            class="css-yr5jng-tableCellStyle-Cell"
+          >
+            <strong
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
+            >
+              callback
+            </strong>
+          </td>
+          <td
+            class="css-yr5jng-tableCellStyle-Cell"
           >
             <code
               class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
             >
-              PedometerResult
+              <a
+                class="css-12zqqiz-STYLES_EXTERNAL_LINK"
+                href="/#pedometerupdatecallback"
+              >
+                PedometerUpdateCallback
+              </a>
             </code>
-          </a>
-          .
-        </span>
-      </li>
-    </ul>
+          </td>
+          <td
+            class="css-yr5jng-tableCellStyle-Cell"
+          >
+            <span>
+              A callback that is invoked when new step count data is available. The callback is
+provided with a single argument that is 
+              <a
+                class="css-12zqqiz-STYLES_EXTERNAL_LINK"
+                href="/#pedometerresult"
+              >
+                <code
+                  class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
+                >
+                  PedometerResult
+                </code>
+              </a>
+              .
+            </span>
+          </td>
+        </tr>
+      </table>
+    </div>
     <p
       class="css-101h856-paragraph-STYLES_PARAGRAPH"
       data-text="true"
@@ -10463,83 +10339,72 @@ provided with a single argument that is
     </h3>
     <div>
       <h4
-        class="  css-838f5l-h4-h4-STYLES_H4"
-        data-components-heading="true"
+        class="css-838f5l-h4-h4-STYLES_H4"
         data-heading="true"
       >
-        <div
-          class="css-1rh3o5q-STYLES_PERMALINK"
-        >
-          <span
-            class="css-zonpcr-STYLES_PERMALINK_TARGET"
-            id="arguments-2"
-          />
-          <a
-            class="css-15lh5hg-STYLES_PERMALINK_LINK"
-            href="#arguments-2"
-          >
-            <span
-              class="css-1icvi79-STYLED_PERMALINK_CONTENT"
-            >
-              Arguments
-            </span>
-            <span
-              class="css-10vdcw8-STYLES_PERMALINK_ICON"
-            >
-              <svg
-                aria-label="permalink"
-                class="anchor-icon"
-                fill="none"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-                <path
-                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-              </svg>
-            </span>
-          </a>
-        </div>
+        Arguments
       </h4>
-      <ul
-        class="css-1qha16q-paragraph-STYLES_UNORDERED_LIST-UL"
-        data-text="true"
+      <div
+        class="css-zdmbpy-tableWrapperStyle"
       >
-        <li
-          class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
+        <table
+          class="css-33l6in-tableStyle-Table"
         >
-          <strong
-            class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
+          <thead
+            class="css-7aq1e9-tableHeadStyle"
           >
-            result
-             (
-            <code
-              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
+            <tr
+              class="css-1ne1f2k-tableRowStyle-Row"
             >
-              <a
-                class="css-12zqqiz-STYLES_EXTERNAL_LINK"
-                href="/#pedometerresult"
+              <th
+                class="css-qgy7w-tableHeadersCellStyle-HeaderCell"
               >
-                PedometerResult
-              </a>
-            </code>
-            )
-          </strong>
-        </li>
-      </ul>
+                Name
+              </th>
+              <th
+                class="css-qgy7w-tableHeadersCellStyle-HeaderCell"
+              >
+                Type
+              </th>
+              <th
+                class="css-qgy7w-tableHeadersCellStyle-HeaderCell"
+              >
+                Description
+              </th>
+            </tr>
+          </thead>
+          <tr
+            class="css-1ne1f2k-tableRowStyle-Row"
+          >
+            <td
+              class="css-yr5jng-tableCellStyle-Cell"
+            >
+              <strong
+                class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
+              >
+                result
+              </strong>
+            </td>
+            <td
+              class="css-yr5jng-tableCellStyle-Cell"
+            >
+              <code
+                class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
+              >
+                <a
+                  class="css-12zqqiz-STYLES_EXTERNAL_LINK"
+                  href="/#pedometerresult"
+                >
+                  PedometerResult
+                </a>
+              </code>
+            </td>
+            <td
+              class="css-yr5jng-tableCellStyle-Cell"
+            />
+          </tr>
+        </table>
+      </div>
     </div>
   </div>
   <div>

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -2367,7 +2367,72 @@ sign-out operation.
         </a>
       </div>
     </h3>
-    -
+    <h4
+      class="css-838f5l-h4-h4-STYLES_H4"
+      data-heading="true"
+    >
+      Arguments
+    </h4>
+    <div
+      class="css-zdmbpy-tableWrapperStyle"
+    >
+      <table
+        class="css-33l6in-tableStyle-Table"
+      >
+        <thead
+          class="css-7aq1e9-tableHeadStyle"
+        >
+          <tr
+            class="css-1ne1f2k-tableRowStyle-Row"
+          >
+            <th
+              class="css-qgy7w-tableHeadersCellStyle-HeaderCell"
+            >
+              Name
+            </th>
+            <th
+              class="css-qgy7w-tableHeadersCellStyle-HeaderCell"
+            >
+              Type
+            </th>
+            <th
+              class="css-qgy7w-tableHeadersCellStyle-HeaderCell"
+            >
+              Description
+            </th>
+          </tr>
+        </thead>
+        <tr
+          class="css-1ne1f2k-tableRowStyle-Row"
+        >
+          <td
+            class="css-yr5jng-tableCellStyle-Cell"
+          >
+            <strong
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
+            >
+              listener
+            </strong>
+          </td>
+          <td
+            class="css-yr5jng-tableCellStyle-Cell"
+          >
+            <code
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
+            >
+              () =&gt;
+               
+              void
+            </code>
+          </td>
+          <td
+            class="css-yr5jng-tableCellStyle-Cell"
+          >
+            -
+          </td>
+        </tr>
+      </table>
+    </div>
     <h4
       class="  css-838f5l-h4-h4-STYLES_H4"
       data-components-heading="true"
@@ -6439,7 +6504,9 @@ Same as
           </td>
           <td
             class="css-yr5jng-tableCellStyle-Cell"
-          />
+          >
+            -
+          </td>
         </tr>
       </table>
     </div>
@@ -8031,7 +8098,9 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
             </td>
             <td
               class="css-yr5jng-tableCellStyle-Cell"
-            />
+            >
+              -
+            </td>
           </tr>
         </table>
       </div>
@@ -9151,7 +9220,6 @@ exports[`APISection expo-pedometer 1`] = `
         </a>
       </div>
     </h3>
-    -
     <h4
       class="  css-838f5l-h4-h4-STYLES_H4"
       data-components-heading="true"
@@ -9783,7 +9851,6 @@ available on this device.
         </a>
       </div>
     </h3>
-    -
     <h4
       class="  css-838f5l-h4-h4-STYLES_H4"
       data-components-heading="true"
@@ -10401,7 +10468,9 @@ provided with a single argument that is
             </td>
             <td
               class="css-yr5jng-tableCellStyle-Cell"
-            />
+            >
+              -
+            </td>
           </tr>
         </table>
       </div>

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -6479,89 +6479,83 @@ Same as
       </div>
     </h3>
     <h4
-      class="  css-838f5l-h4-h4-STYLES_H4"
-      data-components-heading="true"
+      class="css-838f5l-h4-h4-STYLES_H4"
       data-heading="true"
     >
-      <div
-        class="css-1rh3o5q-STYLES_PERMALINK"
-      >
-        <span
-          class="css-zonpcr-STYLES_PERMALINK_TARGET"
-          id="arguments"
-        />
-        <a
-          class="css-15lh5hg-STYLES_PERMALINK_LINK"
-          href="#arguments"
-        >
-          <span
-            class="css-1icvi79-STYLED_PERMALINK_CONTENT"
-          >
-            Arguments
-          </span>
-          <span
-            class="css-10vdcw8-STYLES_PERMALINK_ICON"
-          >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </div>
+      Arguments
     </h4>
-    <ul
-      class="css-1qha16q-paragraph-STYLES_UNORDERED_LIST-UL"
-      data-text="true"
+    <div
+      class="css-zdmbpy-tableWrapperStyle"
     >
-      <li
-        class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
+      <table
+        class="css-33l6in-tableStyle-Table"
       >
-        <strong
-          class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
+        <thead
+          class="css-7aq1e9-tableHeadStyle"
         >
-          options
-          ?
-           (
-          <code
-            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
+          <tr
+            class="css-1ne1f2k-tableRowStyle-Row"
           >
-            <a
-              class="css-12zqqiz-STYLES_EXTERNAL_LINK"
-              href="/#permissionhookoptions"
+            <th
+              class="css-qgy7w-tableHeadersCellStyle-HeaderCell"
             >
-              PermissionHookOptions
-            </a>
-            &lt;
-            <span>
-              object
+              Name
+            </th>
+            <th
+              class="css-qgy7w-tableHeadersCellStyle-HeaderCell"
+            >
+              Type
+            </th>
+            <th
+              class="css-qgy7w-tableHeadersCellStyle-HeaderCell"
+            >
+              Description
+            </th>
+          </tr>
+        </thead>
+        <tr
+          class="css-1ne1f2k-tableRowStyle-Row"
+        >
+          <td
+            class="css-yr5jng-tableCellStyle-Cell"
+          >
+            <strong
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
+            >
+              options
+            </strong>
+            <br />
+            <span
+              class="css-fbbx5x-STYLES_OPTIONAL"
+            >
+              (optional)
             </span>
-            &gt;
-          </code>
-          )
-        </strong>
-      </li>
-    </ul>
+          </td>
+          <td
+            class="css-yr5jng-tableCellStyle-Cell"
+          >
+            <code
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
+            >
+              <a
+                class="css-12zqqiz-STYLES_EXTERNAL_LINK"
+                href="/#permissionhookoptions"
+              >
+                PermissionHookOptions
+              </a>
+              &lt;
+              <span>
+                object
+              </span>
+              &gt;
+            </code>
+          </td>
+          <td
+            class="css-yr5jng-tableCellStyle-Cell"
+          />
+        </tr>
+      </table>
+    </div>
     <p
       class="css-101h856-paragraph-STYLES_PARAGRAPH"
       data-text="true"
@@ -7134,158 +7128,156 @@ This can be used to quickly create specific permission hooks in every module.
       </div>
     </h3>
     <h4
-      class="  css-838f5l-h4-h4-STYLES_H4"
-      data-components-heading="true"
+      class="css-838f5l-h4-h4-STYLES_H4"
       data-heading="true"
     >
-      <div
-        class="css-1rh3o5q-STYLES_PERMALINK"
-      >
-        <span
-          class="css-zonpcr-STYLES_PERMALINK_TARGET"
-          id="arguments-1"
-        />
-        <a
-          class="css-15lh5hg-STYLES_PERMALINK_LINK"
-          href="#arguments-1"
-        >
-          <span
-            class="css-1icvi79-STYLED_PERMALINK_CONTENT"
-          >
-            Arguments
-          </span>
-          <span
-            class="css-10vdcw8-STYLES_PERMALINK_ICON"
-          >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </div>
+      Arguments
     </h4>
-    <ul
-      class="css-1qha16q-paragraph-STYLES_UNORDERED_LIST-UL"
-      data-text="true"
+    <div
+      class="css-zdmbpy-tableWrapperStyle"
     >
-      <li
-        class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
+      <table
+        class="css-33l6in-tableStyle-Table"
       >
-        <strong
-          class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
+        <thead
+          class="css-7aq1e9-tableHeadStyle"
         >
-          url
-           (
-          <code
-            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
+          <tr
+            class="css-1ne1f2k-tableRowStyle-Row"
           >
-            string
-          </code>
-          )
-        </strong>
-         - 
-        <span>
-          URL to get the image from.
-        </span>
-      </li>
-      <li
-        class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
-      >
-        <strong
-          class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
-        >
-          barCodeTypes
-           (
-          <code
-            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
-          >
-            string[]
-          </code>
-          )
-        </strong>
-         - 
-        <span>
-          An array of bar code types. Defaults to all supported bar code types on
-the platform.
-        </span>
-        
-
-        <blockquote
-          class="css-13jwbau-paragraph-STYLES_BLOCKQUOTE"
-          data-text="true"
-        >
-          <div>
-            <div
-              style="margin-top: 2px;"
+            <th
+              class="css-qgy7w-tableHeadersCellStyle-HeaderCell"
             >
-              <svg
-                fill="none"
-                height="16"
-                role="img"
-                size="16"
-                viewBox="0 0 20 20"
-                width="16"
-              >
-                <title>
-                  Info-icon
-                </title>
-                <g
-                  clip-path="url(#info-icon_svg__info-icon_svg__clip0)"
-                >
-                  <path
-                    d="M10 1a9 9 0 100 18 9 9 0 000-18zm-.01 4.064a.962.962 0 01.73-.33c.229 0 .43.082.582.238.152.155.23.354.23.59 0 .295-.104.558-.308.78-.209.23-.453.347-.726.347a.777.777 0 01-.576-.244.844.844 0 01-.227-.607c0-.3.099-.561.295-.774zm1.499 8.48c-.746.7-1.279 1.138-1.628 1.337-.372.213-.679.317-.937.317a.814.814 0 01-.622-.254c-.152-.162-.23-.382-.23-.652 0-.69.392-2.293 1.197-4.9.013-.044.024-.086.031-.125a.814.814 0 00-.105.056c-.066.042-.267.2-.854.773a.25.25 0 01-.329.02l-.347-.27a.25.25 0 01-.033-.367c.542-.596 1.047-1.029 1.502-1.286.477-.269.88-.4 1.232-.4.227 0 .411.057.547.17a.621.621 0 01.225.492c0 .132-.063.474-.522 2.015-.657 2.203-.814 3.003-.825 3.28.125-.074.419-.283 1.046-.873a.25.25 0 01.347.003l.308.3a.25.25 0 01-.003.363z"
-                    fill="var(--expo-theme-icon-default)"
-                  />
-                </g>
-                <defs>
-                  <clippath
-                    id="info-icon_svg__info-icon_svg__clip0"
-                  >
-                    <path
-                      d="M0 0h20v20H0z"
-                      fill="#fff"
-                    />
-                  </clippath>
-                </defs>
-              </svg>
-            </div>
-          </div>
-          <div>
-            
-
+              Name
+            </th>
+            <th
+              class="css-qgy7w-tableHeadersCellStyle-HeaderCell"
+            >
+              Type
+            </th>
+            <th
+              class="css-qgy7w-tableHeadersCellStyle-HeaderCell"
+            >
+              Description
+            </th>
+          </tr>
+        </thead>
+        <tr
+          class="css-1ne1f2k-tableRowStyle-Row"
+        >
+          <td
+            class="css-yr5jng-tableCellStyle-Cell"
+          >
             <strong
               class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
             >
-              Note:
+              url
             </strong>
-             Only QR codes are supported on iOS.
+          </td>
+          <td
+            class="css-yr5jng-tableCellStyle-Cell"
+          >
+            <code
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
+            >
+              string
+            </code>
+          </td>
+          <td
+            class="css-yr5jng-tableCellStyle-Cell"
+          >
+            <span>
+              URL to get the image from.
+            </span>
+          </td>
+        </tr>
+        <tr
+          class="css-1ne1f2k-tableRowStyle-Row"
+        >
+          <td
+            class="css-yr5jng-tableCellStyle-Cell"
+          >
+            <strong
+              class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
+            >
+              barCodeTypes
+            </strong>
+          </td>
+          <td
+            class="css-yr5jng-tableCellStyle-Cell"
+          >
+            <code
+              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
+            >
+              string[]
+            </code>
+          </td>
+          <td
+            class="css-yr5jng-tableCellStyle-Cell"
+          >
+            <span>
+              An array of bar code types. Defaults to all supported bar code types on
+the platform.
+            </span>
             
 
-          </div>
-        </blockquote>
-      </li>
-    </ul>
+            <blockquote
+              class="css-13jwbau-paragraph-STYLES_BLOCKQUOTE"
+              data-text="true"
+            >
+              <div>
+                <div
+                  style="margin-top: 2px;"
+                >
+                  <svg
+                    fill="none"
+                    height="16"
+                    role="img"
+                    size="16"
+                    viewBox="0 0 20 20"
+                    width="16"
+                  >
+                    <title>
+                      Info-icon
+                    </title>
+                    <g
+                      clip-path="url(#info-icon_svg__info-icon_svg__clip0)"
+                    >
+                      <path
+                        d="M10 1a9 9 0 100 18 9 9 0 000-18zm-.01 4.064a.962.962 0 01.73-.33c.229 0 .43.082.582.238.152.155.23.354.23.59 0 .295-.104.558-.308.78-.209.23-.453.347-.726.347a.777.777 0 01-.576-.244.844.844 0 01-.227-.607c0-.3.099-.561.295-.774zm1.499 8.48c-.746.7-1.279 1.138-1.628 1.337-.372.213-.679.317-.937.317a.814.814 0 01-.622-.254c-.152-.162-.23-.382-.23-.652 0-.69.392-2.293 1.197-4.9.013-.044.024-.086.031-.125a.814.814 0 00-.105.056c-.066.042-.267.2-.854.773a.25.25 0 01-.329.02l-.347-.27a.25.25 0 01-.033-.367c.542-.596 1.047-1.029 1.502-1.286.477-.269.88-.4 1.232-.4.227 0 .411.057.547.17a.621.621 0 01.225.492c0 .132-.063.474-.522 2.015-.657 2.203-.814 3.003-.825 3.28.125-.074.419-.283 1.046-.873a.25.25 0 01.347.003l.308.3a.25.25 0 01-.003.363z"
+                        fill="var(--expo-theme-icon-default)"
+                      />
+                    </g>
+                    <defs>
+                      <clippath
+                        id="info-icon_svg__info-icon_svg__clip0"
+                      >
+                        <path
+                          d="M0 0h20v20H0z"
+                          fill="#fff"
+                        />
+                      </clippath>
+                    </defs>
+                  </svg>
+                </div>
+              </div>
+              <div>
+                
+
+                <strong
+                  class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
+                >
+                  Note:
+                </strong>
+                 Only QR codes are supported on iOS.
+                
+
+              </div>
+            </blockquote>
+          </td>
+        </tr>
+      </table>
+    </div>
     <p
       class="css-101h856-paragraph-STYLES_PARAGRAPH"
       data-text="true"
@@ -8090,83 +8082,72 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
     </h3>
     <div>
       <h4
-        class="  css-838f5l-h4-h4-STYLES_H4"
-        data-components-heading="true"
+        class="css-838f5l-h4-h4-STYLES_H4"
         data-heading="true"
       >
-        <div
-          class="css-1rh3o5q-STYLES_PERMALINK"
-        >
-          <span
-            class="css-zonpcr-STYLES_PERMALINK_TARGET"
-            id="arguments-2"
-          />
-          <a
-            class="css-15lh5hg-STYLES_PERMALINK_LINK"
-            href="#arguments-2"
-          >
-            <span
-              class="css-1icvi79-STYLED_PERMALINK_CONTENT"
-            >
-              Arguments
-            </span>
-            <span
-              class="css-10vdcw8-STYLES_PERMALINK_ICON"
-            >
-              <svg
-                aria-label="permalink"
-                class="anchor-icon"
-                fill="none"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-                <path
-                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-              </svg>
-            </span>
-          </a>
-        </div>
+        Arguments
       </h4>
-      <ul
-        class="css-1qha16q-paragraph-STYLES_UNORDERED_LIST-UL"
-        data-text="true"
+      <div
+        class="css-zdmbpy-tableWrapperStyle"
       >
-        <li
-          class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
+        <table
+          class="css-33l6in-tableStyle-Table"
         >
-          <strong
-            class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
+          <thead
+            class="css-7aq1e9-tableHeadStyle"
           >
-            params
-             (
-            <code
-              class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
+            <tr
+              class="css-1ne1f2k-tableRowStyle-Row"
             >
-              <a
-                class="css-12zqqiz-STYLES_EXTERNAL_LINK"
-                href="/#barcodeevent"
+              <th
+                class="css-qgy7w-tableHeadersCellStyle-HeaderCell"
               >
-                BarCodeEvent
-              </a>
-            </code>
-            )
-          </strong>
-        </li>
-      </ul>
+                Name
+              </th>
+              <th
+                class="css-qgy7w-tableHeadersCellStyle-HeaderCell"
+              >
+                Type
+              </th>
+              <th
+                class="css-qgy7w-tableHeadersCellStyle-HeaderCell"
+              >
+                Description
+              </th>
+            </tr>
+          </thead>
+          <tr
+            class="css-1ne1f2k-tableRowStyle-Row"
+          >
+            <td
+              class="css-yr5jng-tableCellStyle-Cell"
+            >
+              <strong
+                class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
+              >
+                params
+              </strong>
+            </td>
+            <td
+              class="css-yr5jng-tableCellStyle-Cell"
+            >
+              <code
+                class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
+              >
+                <a
+                  class="css-12zqqiz-STYLES_EXTERNAL_LINK"
+                  href="/#barcodeevent"
+                >
+                  BarCodeEvent
+                </a>
+              </code>
+            </td>
+            <td
+              class="css-yr5jng-tableCellStyle-Cell"
+            />
+          </tr>
+        </table>
+      </div>
     </div>
   </div>
   <div>

--- a/docs/components/plugins/api/APISectionInterfaces.tsx
+++ b/docs/components/plugins/api/APISectionInterfaces.tsx
@@ -15,11 +15,12 @@ import {
   getTagData,
   mdInlineComponents,
   renderFlags,
-  renderParam,
+  renderParamRow,
+  renderTableHeadRow,
   renderTypeOrSignatureType,
   resolveTypeName,
 } from '~/components/plugins/api/APISectionUtils';
-import { Cell, HeaderCell, Row, Table, TableHead } from '~/ui/components/Table';
+import { Cell, Row, Table } from '~/ui/components/Table';
 
 export type APISectionInterfacesProps = {
   data: InterfaceDefinitionData[];
@@ -40,7 +41,7 @@ const renderInterfaceComment = (comment?: CommentData, signatures?: MethodSignat
     const defaultValue = getTagData('default', signatureComment);
     return (
       <>
-        {parameters?.length ? parameters.map(param => renderParam(param)) : null}
+        {parameters?.length ? parameters.map(param => renderParamRow(param)) : null}
         <B>Returns: </B>
         <InlineCode>{resolveTypeName(type)}</InlineCode>
         {signatureComment && (
@@ -57,14 +58,13 @@ const renderInterfaceComment = (comment?: CommentData, signatures?: MethodSignat
     );
   } else {
     const defaultValue = getTagData('default', comment);
-    return comment ? (
+    return (
       <CommentTextBlock
         comment={comment}
         components={mdInlineComponents}
         afterContent={renderDefaultValue(defaultValue)}
+        emptyCommentFallback="-"
       />
-    ) : (
-      '-'
     );
   }
 };
@@ -112,13 +112,7 @@ const renderInterface = ({
       )}
       <CommentTextBlock comment={comment} />
       <Table>
-        <TableHead>
-          <Row>
-            <HeaderCell>Name</HeaderCell>
-            <HeaderCell>Type</HeaderCell>
-            <HeaderCell>Description</HeaderCell>
-          </Row>
-        </TableHead>
+        {renderTableHeadRow()}
         <tbody>
           {children.filter(child => !child?.inheritedFrom).map(renderInterfacePropertyRow)}
         </tbody>

--- a/docs/components/plugins/api/APISectionMethods.tsx
+++ b/docs/components/plugins/api/APISectionMethods.tsx
@@ -45,12 +45,8 @@ export const renderMethod = (
         </InlineCode>
       </HeaderComponent>
       {getPlatformTags(comment)}
-      <CommentTextBlock
-        comment={comment}
-        beforeContent={parameters && renderParams(parameters)}
-        includePlatforms={false}
-        emptyCommentFallback="-"
-      />
+      {parameters && renderParams(parameters)}
+      <CommentTextBlock comment={comment} includePlatforms={false} />
       {resolveTypeName(type) !== 'undefined' ? (
         <>
           <H4>Returns</H4>

--- a/docs/components/plugins/api/APISectionMethods.tsx
+++ b/docs/components/plugins/api/APISectionMethods.tsx
@@ -15,7 +15,7 @@ import {
   getPlatformTags,
   listParams,
   mdComponents,
-  renderParam,
+  renderParams,
   resolveTypeName,
 } from '~/components/plugins/api/APISectionUtils';
 
@@ -47,15 +47,9 @@ export const renderMethod = (
       {getPlatformTags(comment)}
       <CommentTextBlock
         comment={comment}
-        beforeContent={
-          parameters && (
-            <>
-              <H4>Arguments</H4>
-              <UL>{parameters?.map(renderParam)}</UL>
-            </>
-          )
-        }
+        beforeContent={parameters && renderParams(parameters)}
         includePlatforms={false}
+        emptyCommentFallback="-"
       />
       {resolveTypeName(type) !== 'undefined' ? (
         <>

--- a/docs/components/plugins/api/APISectionTypes.tsx
+++ b/docs/components/plugins/api/APISectionTypes.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { InlineCode } from '~/components/base/code';
 import { UL, LI } from '~/components/base/list';
 import { B, P } from '~/components/base/paragraph';
-import { H2, H3Code, H4 } from '~/components/plugins/Headings';
+import { H2, H3Code } from '~/components/plugins/Headings';
 import {
   PropData,
   TypeDeclarationContentData,
@@ -15,14 +15,16 @@ import {
   mdInlineComponents,
   resolveTypeName,
   renderFlags,
-  renderParam,
   CommentTextBlock,
   parseCommentContent,
   renderTypeOrSignatureType,
   getCommentOrSignatureComment,
   getTagData,
+  renderParams,
+  renderTableHeadRow,
+  renderDefaultValue,
 } from '~/components/plugins/api/APISectionUtils';
-import { Cell, HeaderCell, Row, Table, TableHead } from '~/ui/components/Table';
+import { Cell, Row, Table } from '~/ui/components/Table';
 
 export type APISectionTypesProps = {
   data: TypeGeneralData[];
@@ -45,26 +47,10 @@ const defineLiteralType = (types: TypeDefinitionData[]): JSX.Element | null => {
 
 const renderTypeDeclarationTable = ({ children }: TypeDeclarationContentData): JSX.Element => (
   <Table key={`type-declaration-table-${children?.map(child => child.name).join('-')}`}>
-    <TableHead>
-      <Row>
-        <HeaderCell>Name</HeaderCell>
-        <HeaderCell>Type</HeaderCell>
-        <HeaderCell>Description</HeaderCell>
-      </Row>
-    </TableHead>
+    {renderTableHeadRow()}
     <tbody>{children?.map(renderTypePropertyRow)}</tbody>
   </Table>
 );
-
-const renderDefaultValue = (initValue?: string) =>
-  initValue ? (
-    <>
-      <br />
-      <br />
-      <B>Default: </B>
-      <InlineCode>{initValue}</InlineCode>
-    </>
-  ) : null;
 
 const renderTypePropertyRow = ({
   name,
@@ -84,15 +70,12 @@ const renderTypePropertyRow = ({
       </Cell>
       <Cell fitContent>{renderTypeOrSignatureType(type, signatures)}</Cell>
       <Cell fitContent>
-        {commentData ? (
-          <CommentTextBlock
-            comment={commentData}
-            components={mdInlineComponents}
-            afterContent={renderDefaultValue(initValue)}
-          />
-        ) : (
-          '-'
-        )}
+        <CommentTextBlock
+          comment={commentData}
+          components={mdInlineComponents}
+          afterContent={renderDefaultValue(initValue)}
+          emptyCommentFallback="-"
+        />
       </Cell>
     </Row>
   );
@@ -120,8 +103,7 @@ const renderType = ({
           ? type.declaration.signatures.map(({ parameters, comment }: TypeSignaturesData) => (
               <div key={`type-definition-signature-${name}`}>
                 <CommentTextBlock comment={comment} />
-                {parameters ? <H4>Arguments</H4> : null}
-                {parameters ? <UL>{parameters?.map(renderParam)}</UL> : null}
+                {parameters && renderParams(parameters)}
               </div>
             ))
           : null}

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -17,6 +17,7 @@ import {
   TypeDefinitionData,
   TypePropertyDataFlags,
 } from '~/components/plugins/api/APIDataTypes';
+import { Row, Cell, Table, TableHead, HeaderCell } from '~/ui/components/Table';
 
 const isDev = process.env.NODE_ENV === 'development';
 
@@ -310,18 +311,60 @@ export const resolveTypeName = ({
 
 export const parseParamName = (name: string) => (name.startsWith('__') ? name.substr(2) : name);
 
-export const renderParam = ({ comment, name, type, flags }: MethodParamData): JSX.Element => (
-  <LI key={`param-${name}`}>
-    <B>
-      {parseParamName(name)}
-      {flags?.isOptional && '?'} (<InlineCode>{resolveTypeName(type)}</InlineCode>)
-    </B>
-    <CommentTextBlock comment={comment} components={mdInlineComponents} withDash />
-  </LI>
+export const renderParamRow = ({ comment, name, type, flags }: MethodParamData): JSX.Element => {
+  const defaultValue = parseCommentContent(getTagData('default', comment)?.text);
+  return (
+    <Row key={`param-${name}`}>
+      <Cell>
+        <B>{parseParamName(name)}</B>
+        {renderFlags(flags)}
+      </Cell>
+      <Cell>
+        <InlineCode>{resolveTypeName(type)}</InlineCode>
+      </Cell>
+      <Cell>
+        <CommentTextBlock
+          comment={comment}
+          components={mdInlineComponents}
+          afterContent={renderDefaultValue(defaultValue)}
+        />
+      </Cell>
+    </Row>
+  );
+};
+
+export const renderTableHeadRow = () => (
+  <TableHead>
+    <Row>
+      <HeaderCell>Name</HeaderCell>
+      <HeaderCell>Type</HeaderCell>
+      <HeaderCell>Description</HeaderCell>
+    </Row>
+  </TableHead>
+);
+
+export const renderParams = (parameters: MethodParamData[]) => (
+  <>
+    <H4>Arguments</H4>
+    <Table>
+      {renderTableHeadRow()}
+      {parameters?.map(renderParamRow)}
+    </Table>
+  </>
 );
 
 export const listParams = (parameters: MethodParamData[]) =>
   parameters ? parameters?.map(param => parseParamName(param.name)).join(', ') : '';
+
+export const renderDefaultValue = (defaultValue?: string) =>
+  defaultValue ? (
+    <>
+      <br />
+      <br />
+      <B>Default: </B>
+      <InlineCode>{defaultValue}</InlineCode>
+    </>
+  ) : undefined;
 
 export const renderTypeOrSignatureType = (
   type?: TypeDefinitionData,
@@ -364,6 +407,7 @@ export type CommentTextBlockProps = {
   beforeContent?: JSX.Element | null;
   afterContent?: JSX.Element | null;
   includePlatforms?: boolean;
+  emptyCommentFallback?: string;
 };
 
 export const parseCommentContent = (content?: string): string =>
@@ -412,6 +456,7 @@ export const CommentTextBlock = ({
   beforeContent,
   afterContent,
   includePlatforms = true,
+  emptyCommentFallback
 }: CommentTextBlockProps) => {
   const shortText = comment?.shortText?.trim().length ? (
     <ReactMarkdown components={components} remarkPlugins={[remarkGfm]}>
@@ -423,6 +468,8 @@ export const CommentTextBlock = ({
       {parseCommentContent(comment.text)}
     </ReactMarkdown>
   ) : null;
+
+  if (emptyCommentFallback && (!comment || (!shortText && !text))) return <>{emptyCommentFallback}</>;
 
   const examples = getAllTagData('example', comment);
   const exampleText = examples?.map((example, index) => (

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -327,6 +327,7 @@ export const renderParamRow = ({ comment, name, type, flags }: MethodParamData):
           comment={comment}
           components={mdInlineComponents}
           afterContent={renderDefaultValue(defaultValue)}
+          emptyCommentFallback="-"
         />
       </Cell>
     </Row>
@@ -456,7 +457,7 @@ export const CommentTextBlock = ({
   beforeContent,
   afterContent,
   includePlatforms = true,
-  emptyCommentFallback
+  emptyCommentFallback,
 }: CommentTextBlockProps) => {
   const shortText = comment?.shortText?.trim().length ? (
     <ReactMarkdown components={components} remarkPlugins={[remarkGfm]}>
@@ -469,7 +470,9 @@ export const CommentTextBlock = ({
     </ReactMarkdown>
   ) : null;
 
-  if (emptyCommentFallback && (!comment || (!shortText && !text))) return <>{emptyCommentFallback}</>;
+  if (emptyCommentFallback && (!comment || (!shortText && !text))) {
+    return <>{emptyCommentFallback}</>;
+  }
 
   const examples = getAllTagData('example', comment);
   const exampleText = examples?.map((example, index) => (


### PR DESCRIPTION
# Why

Currently we use the list with inline comments to display the methods arguments in `APISection` components.

This works great for the short names and descriptions, however when there is more content, the readability suffers a bit.

# How

Replace the `APISection` components method arguments list with table, add `emptyCommentFallback` prop for the `CommentBlock` for the simplification and reuse a bit more of common code.

# Test Plan

Changes have been tested by running the docs website locally.

# Preview

<img width="874" alt="Screenshot 2022-06-03 120406" src="https://user-images.githubusercontent.com/719641/171839599-90e5082a-6120-4448-be1f-10d4a059ac9c.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
