### PR TITLE
[docs] fix firebase analytics screen_view param key

### DIFF
--- a/docs/pages/versions/unversioned/sdk/firebase-analytics.md
+++ b/docs/pages/versions/unversioned/sdk/firebase-analytics.md
@@ -118,6 +118,7 @@ import React from 'react';
 import { createBottomTabNavigator } from 'react-navigation';
 // Import Firebase
 import * as Analytics from 'expo-firebase-analytics';
+import { DEFAULT_APP_NAME } from 'expo-firebase-core';
 // Import some screens
 import HomeScreen from '../screens/HomeScreen';
 import ProfileScreen from '../screens/ProfileScreen';

--- a/docs/pages/versions/unversioned/sdk/firebase-analytics.md
+++ b/docs/pages/versions/unversioned/sdk/firebase-analytics.md
@@ -143,7 +143,9 @@ export default () => (
       const prevScreen = getActiveRouteName(prevState);
       if (prevScreen !== currentScreen) {
         // Update Firebase with the name of your screen
-        await Analytics.logEvent('screen_view', { currentScreen });
+        await Analytics.logEvent('screen_view', {
+          firebase_screen: currentScreen,
+        });
       }
     }}
   />

--- a/docs/pages/versions/unversioned/sdk/firebase-analytics.md
+++ b/docs/pages/versions/unversioned/sdk/firebase-analytics.md
@@ -143,8 +143,13 @@ export default () => (
       const prevScreen = getActiveRouteName(prevState);
       if (prevScreen !== currentScreen) {
         // Update Firebase with the name of your screen
+        // Use "firebase_screen" for Expo Go client, "screen_name" for dev-client and production
+        const paramKey =
+          DEFAULT_APP_NAME !== '[DEFAULT]'
+            ? 'firebase_screen'
+            : 'screen_name';
         await Analytics.logEvent('screen_view', {
-          firebase_screen: currentScreen,
+          [paramKey]: currentScreen,
         });
       }
     }}

--- a/docs/pages/versions/v45.0.0/sdk/firebase-analytics.md
+++ b/docs/pages/versions/v45.0.0/sdk/firebase-analytics.md
@@ -118,6 +118,7 @@ import React from 'react';
 import { createBottomTabNavigator } from 'react-navigation';
 // Import Firebase
 import * as Analytics from 'expo-firebase-analytics';
+import { DEFAULT_APP_NAME } from 'expo-firebase-core';
 // Import some screens
 import HomeScreen from '../screens/HomeScreen';
 import ProfileScreen from '../screens/ProfileScreen';

--- a/docs/pages/versions/v45.0.0/sdk/firebase-analytics.md
+++ b/docs/pages/versions/v45.0.0/sdk/firebase-analytics.md
@@ -143,7 +143,9 @@ export default () => (
       const prevScreen = getActiveRouteName(prevState);
       if (prevScreen !== currentScreen) {
         // Update Firebase with the name of your screen
-        await Analytics.logEvent('screen_view', { currentScreen });
+        await Analytics.logEvent('screen_view', {
+          firebase_screen: currentScreen,
+        });
       }
     }}
   />

--- a/docs/pages/versions/v45.0.0/sdk/firebase-analytics.md
+++ b/docs/pages/versions/v45.0.0/sdk/firebase-analytics.md
@@ -143,8 +143,13 @@ export default () => (
       const prevScreen = getActiveRouteName(prevState);
       if (prevScreen !== currentScreen) {
         // Update Firebase with the name of your screen
+        // Use "firebase_screen" for Expo Go client, "screen_name" for dev-client and production
+        const paramKey =
+          DEFAULT_APP_NAME !== '[DEFAULT]'
+            ? 'firebase_screen'
+            : 'screen_name';
         await Analytics.logEvent('screen_view', {
-          firebase_screen: currentScreen,
+          [paramKey]: currentScreen,
         });
       }
     }}


### PR DESCRIPTION
# Why

This is a follow-up to my previous PR #17638

The param key for `screen_view` is also wrong (not getting screen names in my dashboard). 

For Expo Go client, since it is using Firebase analytics web version, it should be `firebase_screen`.

For other clients (dev-client, production), since it is using Firebase analytics native version, it should be `screen_name`

Official Firebase docs: 

- Web: https://firebase.google.com/docs/analytics/screenviews#manually_track_screens
- Andriod: https://firebase.google.com/docs/reference/android/com/google/firebase/analytics/FirebaseAnalytics.Param#public-static-final-string-screen_name
- iOS: https://firebase.google.com/docs/reference/ios/firebaseanalytics/api/reference/Constants#declaration_94

# How

Fix the param key.

# Test Plan

Tested locally the new param key and screen names are showing up correctly in my Google Analytics dashboard.

Tested in production and all screen views are displayed correctly in Google Analytics dashboard.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
