### PR TITLE
[expo] add missing expo-screen-capture version

### DIFF
--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -72,6 +72,7 @@
   "expo-permissions": "~13.2.0",
   "expo-print": "~11.2.0",
   "expo-random": "~12.2.0",
+  "expo-screen-capture": "~4.2.0",
   "expo-screen-orientation": "~4.2.0",
   "expo-secure-store": "~11.2.0",
   "expo-sensors": "~11.3.0",


### PR DESCRIPTION
# Why

`expo-screen-capture` is missing in the versions endpoint, potentially causing the wrong version to be installed by `expo install` (this happens on SDK 43 and 44), or future changes breaking, because it will now always install the latest version.

# How

Added to `bundledNativeModules.json`

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
