### PR TITLE
[expo-updates] Validate asset hash against expected hash before writing file to disk

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Android: Allow null asset hash in new manifests. ([#17466](https://github.com/expo/expo/pull/17466) by [@wschurman](https://github.com/wschurman))
 - Fixed `source-login-scripts.sh` ~/zlogin typo. ([#17622](https://github.com/expo/expo/pull/17622) by [@vrgimael](https://github.com/vrgimael))
 - Android: Fix asset hash storage. ([#17732](https://github.com/expo/expo/pull/17732) by [@wschurman](https://github.com/wschurman))
+- Validate asset hash against expected hash before writing file to disk. ([#17745](https://github.com/expo/expo/pull/17745) by [@wschurman](https://github.com/wschurman))
 
 ### 💡 Others
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderTest.kt
@@ -200,7 +200,7 @@ class FileDownloaderTest {
       }
     )
 
-    Assert.assertTrue(error!!.message!!.contains("Asset hash invalid"))
+    Assert.assertTrue(error!!.message!!.contains("File download was successful but base64url-encoded SHA-256 did not match expected"))
     Assert.assertFalse(didSucceed)
   }
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.kt
@@ -114,19 +114,21 @@ object UpdatesUtils {
   @Throws(NoSuchAlgorithmException::class, IOException::class)
   fun verifySHA256AndWriteToFile(inputStream: InputStream, destination: File, expectedBase64URLEncodedHash: String?): ByteArray {
     DigestInputStream(inputStream, MessageDigest.getInstance("SHA-256")).use { digestInputStream ->
+      // write file atomically by writing it to a temporary path and then renaming
+      // this protects us against partially written files if the process is interrupted
+      val tmpFile = File(destination.absolutePath + ".tmp")
+      FileUtils.copyInputStreamToFile(digestInputStream, tmpFile)
+
+      // this message digest must be read after the input stream has been consumed in order to get the hash correctly
       val md = digestInputStream.messageDigest
       val hash = md.digest()
-
       // base64url - https://datatracker.ietf.org/doc/html/rfc4648#section-5
       val hashBase64String = Base64.encodeToString(hash, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP)
       if (expectedBase64URLEncodedHash != null && expectedBase64URLEncodedHash != hashBase64String) {
         throw IOException("File download was successful but base64url-encoded SHA-256 did not match expected; expected: $expectedBase64URLEncodedHash; actual: $hashBase64String")
       }
 
-      // write file atomically by writing it to a temporary path and then renaming
-      // this protects us against partially written files if the process is interrupted
-      val tmpFile = File(destination.absolutePath + ".tmp")
-      FileUtils.copyInputStreamToFile(digestInputStream, tmpFile)
+      // only rename after the hash has been verified
       if (!tmpFile.renameTo(destination)) {
         throw IOException("File download was successful, but failed to move from temporary to permanent location " + destination.absolutePath)
       }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.kt
@@ -5,6 +5,7 @@ import expo.modules.updates.UpdatesConfiguration.CheckAutomaticallyConfiguration
 import expo.modules.updates.db.entity.AssetEntity
 import android.os.AsyncTask
 import android.net.ConnectivityManager
+import android.util.Base64
 import android.util.Log
 import com.facebook.react.ReactNativeHost
 import com.facebook.react.bridge.Arguments
@@ -111,8 +112,17 @@ object UpdatesUtils {
   }
 
   @Throws(NoSuchAlgorithmException::class, IOException::class)
-  fun sha256AndWriteToFile(inputStream: InputStream, destination: File): ByteArray {
+  fun verifySHA256AndWriteToFile(inputStream: InputStream, destination: File, expectedBase64URLEncodedHash: String?): ByteArray {
     DigestInputStream(inputStream, MessageDigest.getInstance("SHA-256")).use { digestInputStream ->
+      val md = digestInputStream.messageDigest
+      val hash = md.digest()
+
+      // base64url - https://datatracker.ietf.org/doc/html/rfc4648#section-5
+      val hashBase64String = Base64.encodeToString(hash, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP)
+      if (expectedBase64URLEncodedHash != null && expectedBase64URLEncodedHash != hashBase64String) {
+        throw IOException("File download was successful but base64url-encoded SHA-256 did not match expected; expected: $expectedBase64URLEncodedHash; actual: $hashBase64String")
+      }
+
       // write file atomically by writing it to a temporary path and then renaming
       // this protects us against partially written files if the process is interrupted
       val tmpFile = File(destination.absolutePath + ".tmp")
@@ -120,8 +130,8 @@ object UpdatesUtils {
       if (!tmpFile.renameTo(destination)) {
         throw IOException("File download was successful, but failed to move from temporary to permanent location " + destination.absolutePath)
       }
-      val md = digestInputStream.messageDigest
-      return md.digest()
+
+      return hash
     }
   }
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderFiles.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderFiles.kt
@@ -45,7 +45,7 @@ open class LoaderFiles {
   ): ByteArray {
     try {
       context.assets.open(asset.embeddedAssetFilename!!)
-        .use { inputStream -> return UpdatesUtils.sha256AndWriteToFile(inputStream, destination) }
+        .use { inputStream -> return UpdatesUtils.verifySHA256AndWriteToFile(inputStream, destination, null) }
     } catch (e: Exception) {
       Log.e(TAG, "Failed to copy asset " + asset.embeddedAssetFilename, e)
       throw e
@@ -65,7 +65,7 @@ open class LoaderFiles {
     )
     try {
       context.resources.openRawResource(id)
-        .use { inputStream -> return UpdatesUtils.sha256AndWriteToFile(inputStream, destination) }
+        .use { inputStream -> return UpdatesUtils.verifySHA256AndWriteToFile(inputStream, destination, null) }
     } catch (e: Exception) {
       Log.e(TAG, "Failed to copy asset " + asset.embeddedAssetFilename, e)
       throw e

--- a/packages/expo-updates/e2e/__tests__/utils/update.ts
+++ b/packages/expo-updates/e2e/__tests__/utils/update.ts
@@ -1,4 +1,4 @@
-import crypto, { BinaryToTextEncoding } from 'crypto';
+import crypto from 'crypto';
 import { createReadStream } from 'fs';
 import fs from 'fs/promises';
 import path from 'path';
@@ -18,14 +18,6 @@ function findBundlePath(updateDistPath: string): string {
   return bundlePath;
 }
 
-function createHash(file: string, hashingAlgorithm: string, encoding: BinaryToTextEncoding) {
-  return crypto.createHash(hashingAlgorithm).update(file).digest(encoding);
-}
-
-function getBase64URLEncoding(base64EncodedString: string): string {
-  return base64EncodedString.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
-}
-
 export async function copyBundleToStaticFolder(
   updateDistPath: string,
   filename: string,
@@ -37,7 +29,7 @@ export async function copyBundleToStaticFolder(
     bundleString = bundleString.replace('/notify/test', `/notify/${notifyString}`);
   }
   await fs.writeFile(path.join(STATIC_FOLDER_PATH, filename), bundleString, 'utf-8');
-  return getBase64URLEncoding(createHash(bundleString, 'sha256', 'base64'));
+  return crypto.createHash('sha256').update(bundleString, 'utf-8').digest('base64url');
 }
 
 export async function copyAssetToStaticFolder(
@@ -53,6 +45,6 @@ export async function copyAssetToStaticFolder(
   return new Promise((resolve, reject) => {
     stream.on('error', (err) => reject(err));
     stream.on('data', (chunk) => hash.update(chunk));
-    stream.on('end', () => resolve(getBase64URLEncoding(hash.digest('base64'))));
+    stream.on('end', () => resolve(hash.digest('base64url')));
   });
 }

--- a/packages/expo-updates/e2e/__tests__/utils/update.ts
+++ b/packages/expo-updates/e2e/__tests__/utils/update.ts
@@ -21,7 +21,7 @@ function findBundlePath(updateDistPath: string): string {
 export async function copyBundleToStaticFolder(
   updateDistPath: string,
   filename: string,
-  notifyString?: string
+  notifyString: string
 ): Promise<string> {
   await fs.mkdir(STATIC_FOLDER_PATH, { recursive: true });
   let bundleString = await fs.readFile(findBundlePath(updateDistPath), 'utf-8');

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAsset.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAsset.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nullable, nonatomic, strong) NSDate *downloadTime;
 @property (nullable, nonatomic, strong) NSString *filename;
-@property (nullable, nonatomic, strong) NSString *contentHash; // hex-encoded sha-256
+@property (nullable, nonatomic, strong) NSString *contentHash; // base64url-encoded sha-256
 @property (nullable, nonatomic, strong) NSDictionary *headers;
 
 /**

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.h
@@ -7,6 +7,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 typedef void (^EXUpdatesFileDownloaderSuccessBlock)(NSData *data, NSURLResponse *response);
+typedef void (^EXUpdatesFileDownloaderWithHashSuccessBlock)(NSData *data, NSURLResponse *response, NSString *base64URLEncodedSHA256Hash);
 typedef void (^EXUpdatesFileDownloaderManifestSuccessBlock)(EXUpdatesUpdate *update);
 typedef void (^EXUpdatesFileDownloaderErrorBlock)(NSError *error);
 
@@ -22,9 +23,10 @@ typedef void (^EXUpdatesFileDownloaderErrorBlock)(NSError *error);
                  errorBlock:(EXUpdatesFileDownloaderErrorBlock)errorBlock;
 
 - (void)downloadFileFromURL:(NSURL *)url
+              verifyingHash:(nullable NSString *)expectedBase64URLEncodedSHA256Hash
                      toPath:(NSString *)destinationPath
                extraHeaders:(NSDictionary *)extraHeaders
-               successBlock:(EXUpdatesFileDownloaderSuccessBlock)successBlock
+               successBlock:(EXUpdatesFileDownloaderWithHashSuccessBlock)successBlock
                  errorBlock:(EXUpdatesFileDownloaderErrorBlock)errorBlock;
 
 - (void)downloadManifestFromURL:(NSURL *)url

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesRemoteAppLoader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesRemoteAppLoader.m
@@ -101,19 +101,12 @@ static NSString * const EXUpdatesRemoteAppLoaderErrorDomain = @"EXUpdatesRemoteA
       }
 
       [self->_downloader downloadFileFromURL:asset.url
+                               verifyingHash:asset.expectedHash
                                       toPath:[urlOnDisk path]
                                 extraHeaders:asset.extraRequestHeaders ?: @{}
-                                successBlock:^(NSData *data, NSURLResponse *response) {
+                                successBlock:^(NSData *data, NSURLResponse *response, NSString *base64URLEncodedSHA256Hash) {
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-          NSString *hashBase64String = [EXUpdatesUtils base64UrlEncodedSHA256WithData:data];
-          if (asset.expectedHash && ![asset.expectedHash isEqualToString:hashBase64String]) {
-            NSError *error = [NSError errorWithDomain:EXUpdatesRemoteAppLoaderErrorDomain
-                                                 code:1016
-                                             userInfo:@{NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Asset hash invalid: %@; expectedHash: %@; actualHash: %@", asset.key, asset.expectedHash, hashBase64String]}];
-            [self handleAssetDownloadWithError:error asset:asset];
-          } else {
-            [self handleAssetDownloadWithData:data response:response asset:asset];
-          }
+          [self handleAssetDownloadWithData:data response:response asset:asset];
         });
       }
                                   errorBlock:^(NSError *error) {


### PR DESCRIPTION
# Why

This fixes the following bug/vuln: If an asset hash doesn't match the expected hash, the file is still written to disk before the error is thrown, and upon second launch the asset is loaded (we don't check hash upon load from disk, only upon download).

# How

Verify hash before writing file to disk.

# Test Plan

Load an update in expo go (add breakpoint to ensure it works). Note that I was only able to test this on iOS since my android build is still broken due to #17509.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
