### PR TITLE
[notifications] Fix opening wrong activity for expo go

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
@@ -29,7 +29,7 @@ import com.facebook.react.modules.network.ReactCookieJarContainer
 import com.facebook.react.shell.MainReactPackage
 import com.facebook.soloader.SoLoader
 import de.greenrobot.event.EventBus
-import expo.modules.notifications.service.NotificationsService.Companion.getNotificationResponseFromIntent
+import expo.modules.notifications.service.NotificationsService.Companion.getNotificationResponseFromOpenIntent
 import expo.modules.notifications.service.delegates.ExpoHandlingDelegate
 import expo.modules.manifests.core.Manifest
 import host.exp.exponent.*
@@ -527,7 +527,7 @@ class Kernel : KernelInterface() {
   }
 
   private fun openExperienceFromNotificationIntent(intent: Intent): Boolean {
-    val response = getNotificationResponseFromIntent(intent)
+    val response = getNotificationResponseFromOpenIntent(intent)
     val experienceScopeKey = ScopedNotificationsUtils.getExperienceScopeKey(response) ?: return false
     val exponentDBObject = try {
       val exponentDBObjectInner = ExponentDB.experienceScopeKeyToExperienceSync(experienceScopeKey)

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationsService.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationsService.kt
@@ -498,9 +498,9 @@ open class NotificationsService : BroadcastReceiver() {
       return intent
     }
 
-    fun getNotificationResponseFromBroadcastIntent(intent: Intent): NotificationResponse {
-      val notification = intent.getParcelableExtra<Notification>(NOTIFICATION_KEY)!!
-      val action = intent.getParcelableExtra<NotificationAction>(NOTIFICATION_ACTION_KEY)!!
+    fun getNotificationResponseFromBroadcastIntent(intent: Intent): NotificationResponse? {
+      val notification = intent.getParcelableExtra<Notification>(NOTIFICATION_KEY) ?: throw IllegalArgumentException("$NOTIFICATION_KEY not found in the intent extras.")
+      val action = intent.getParcelableExtra<NotificationAction>(NOTIFICATION_ACTION_KEY) ?: throw IllegalArgumentException("$NOTIFICATION_ACTION_KEY not found in the intent extras.")
       val response = if (action is TextInputNotificationAction) {
         TextInputNotificationResponse(action, notification, RemoteInput.getResultsFromIntent(intent).getString(USER_TEXT_RESPONSE_KEY))
       } else {

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationsService.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationsService.kt
@@ -498,7 +498,7 @@ open class NotificationsService : BroadcastReceiver() {
       return intent
     }
 
-    fun getNotificationResponseFromBroadcastIntent(intent: Intent): NotificationResponse? {
+    fun getNotificationResponseFromBroadcastIntent(intent: Intent): NotificationResponse {
       val notification = intent.getParcelableExtra<Notification>(NOTIFICATION_KEY) ?: throw IllegalArgumentException("$NOTIFICATION_KEY not found in the intent extras.")
       val action = intent.getParcelableExtra<NotificationAction>(NOTIFICATION_ACTION_KEY) ?: throw IllegalArgumentException("$NOTIFICATION_ACTION_KEY not found in the intent extras.")
       val response = if (action is TextInputNotificationAction) {

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoHandlingDelegate.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoHandlingDelegate.kt
@@ -60,7 +60,7 @@ class ExpoHandlingDelegate(protected val context: Context) : HandlingDelegate {
      *   - the foreground main Activity
      *   - the background [NotificationForwarderActivity] Activity that send notification clicked events through broadcast
      */
-    fun createPendingIntentForOpeningApp(context: Context, broadcastIntent: Intent): PendingIntent {
+    fun createPendingIntentForOpeningApp(context: Context, broadcastIntent: Intent, notificationResponse: NotificationResponse): PendingIntent {
       var intentFlags = PendingIntent.FLAG_UPDATE_CURRENT
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
         intentFlags = intentFlags or PendingIntent.FLAG_IMMUTABLE
@@ -70,6 +70,7 @@ class ExpoHandlingDelegate(protected val context: Context) : HandlingDelegate {
         Intent()
       }
       foregroundActivityIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_MULTIPLE_TASK
+      NotificationsService.setNotificationResponseToIntent(foregroundActivityIntent, notificationResponse)
       val backgroundActivityIntent = Intent(context, NotificationForwarderActivity::class.java)
       backgroundActivityIntent.putExtras(broadcastIntent)
       return PendingIntent.getActivities(context, 0, arrayOf(foregroundActivityIntent, backgroundActivityIntent), intentFlags)


### PR DESCRIPTION
# Why

fix #17686 for expo go to open wrong activity

# How

from #17686 the PendingIntent for foreground activity missed some intent extra. we should also call `NotificationsService.setNotificationResponseToIntent` like the original implementation:
https://github.com/expo/expo/blob/6097718a9a1b69c672a3845336c42fb86da13c61/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoHandlingDelegate.kt#L123

# Test Plan

unversioned expo go + NCL "schedule notification for 10 seconds from now", pressing home key to background the app and click the notification after 10 seconds.

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
