### PR TITLE
[expo-dev-launcher] Remove unnecessary safe call

### DIFF
--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherInternalModule.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherInternalModule.kt
@@ -87,7 +87,7 @@ class DevLauncherInternalModule(reactContext: ReactApplicationContext?) :
   }
 
   private fun sanitizeUrlString(url: String): Uri {
-    val parsedUrl = Uri.parse(url?.trim())
+    val parsedUrl = Uri.parse(url.trim())
     val appUrl = if (isDevLauncherUrl(parsedUrl)) {
       requireNotNull(getAppUrlFromDevLauncherUrl(parsedUrl)) { "The provided url doesn't contain the app url." }
     } else {


### PR DESCRIPTION
# Why

This is generating warning in console, should be safe to remove or we need to add the parameter as optional String.

# How

-

# Test Plan

-

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
