### PR TITLE
[expo-dev-launcher] getApplicationIconUri code reoder to remove warning

### DIFF
--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherInternalModule.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherInternalModule.kt
@@ -257,13 +257,11 @@ class DevLauncherInternalModule(reactContext: ReactApplicationContext?) :
   }
 
   private fun getApplicationIconUri(): String {
-    var appIcon = ""
     val packageManager = reactApplicationContext.packageManager
     val packageName = reactApplicationContext.packageName
     val applicationInfo = packageManager.getApplicationInfo(packageName, 0)
-    appIcon = "" + applicationInfo.icon
 //    TODO - figure out how to get resId for AdaptiveIconDrawable icons
-    return appIcon
+    return "" + applicationInfo.icon
   }
 
   @ReactMethod


### PR DESCRIPTION
# Why

This is generating code warning, which sometimes make it more complicated to find errors

# How

?

# Test Plan

?

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
