### PR TITLE
[docs] Add some useful redirects for Expo Modules API

### DIFF
--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -112,6 +112,10 @@ redirects[clients/installation]=development/installation/
 redirects[clients/introduction]=development/introduction/
 redirects[clients/troubleshooting]=development/troubleshooting/
 redirects[clients/upgrading]=development/upgrading/
+# Expo Modules
+redirects[modules]=modules/overview/
+redirects[module-api]=modules/module-api/
+redirects[module-config]=modules/module-config/
 
 echo "::group::[5/6] Add custom redirects"
 for i in "${!redirects[@]}" # iterate over keys

--- a/docs/pages/modules/index.js
+++ b/docs/pages/modules/index.js
@@ -1,0 +1,3 @@
+import redirect from '~/common/redirect';
+
+export default redirect('/modules/overview');


### PR DESCRIPTION
# Why

I thought it might be useful to have redirects for the most common resources we have in the Expo Modules guide. I'm also going to use one in my presentation on App.js conf

# How

Added some redirects for the modules API guides
- `/modules` -> `/modules/overview`
- `/module-api` -> `/modules/module-api`
- `/module-config` -> `/modules/module-config`

# Test Plan

Let's deploy and check 😄 