### PR TITLE
Update logging.md

### DIFF
--- a/docs/pages/workflow/logging.md
+++ b/docs/pages/workflow/logging.md
@@ -26,6 +26,8 @@ The following instructions apply to macOS.
 - Press accept on your device
 - Run `idevicesyslog`
 
+To view logs for a specific app, run `idevicesyslog --process [APP_PROCESS_NAME]`.
+
 ### View logs for an iOS simulator
 
 #### Option 1: Use GUI log


### PR DESCRIPTION
Add instructions on filtering device logs. Unfiltered logs are tough to handle.

Options for `idevicesyslog` can be found on https://www.mankier.com/1/idevicesyslog.
It will be helpful to help users find the logs they're looking for.
One concern I have is that the process ID cannot (really) be found on the expo config file. I believe it's `expo.name` but spaces are dropped. Sure, one can run xCode and check what processes are present, but we don't want the instructions to get too long.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).