### PR TITLE
[docs] Added Expo plugin to install Native Firebase

### DIFF
--- a/docs/pages/guides/setup-native-firebase.md
+++ b/docs/pages/guides/setup-native-firebase.md
@@ -18,8 +18,8 @@ which is otherwise unavailable in react-native using the Firebase JavaScript SDK
 
 ### Adding the Native Firebase Plugin
 
-- To being using Native Firebase with Expo, you will start using the plugin `@react-native-firebase/app`.
-- **Note: By doing this you will convert your project into a semi-managed project and will need to rebuild it if any native code changes.**
+- To being using Native Firebase with Expo, you will start using the plugin `@react-native-firebase/app`. You can reference the [React Native Firebase docs](https://rnfirebase.io/#expo) for more details as needed.
+- **Note: By doing this you will convert your project into a semi-managed project and will need to rebuild it if any native code changes. For more information on adding custom native code, see [here](https://docs.expo.dev/workflow/customizing/).**
 
 ```json
 {

--- a/docs/pages/guides/setup-native-firebase.md
+++ b/docs/pages/guides/setup-native-firebase.md
@@ -16,6 +16,27 @@ This will guide you through a series of steps to create your own Firebase projec
 Some (but not all) native Firebase features can be used with the Managed Workflow. The most notable native feature is Firebase Analytics,
 which is otherwise unavailable in react-native using the Firebase JavaScript SDK.
 
+### Adding the Native Firebase Plugin
+
+- To being using Native Firebase with Expo, you will start using the plugin `@react-native-firebase/app`.
+- **Note: By doing this you will convert your project into a semi-managed project and will need to rebuild it if any native code changes.**
+
+```json
+{
+  "expo": {
+    "plugins": [
+      "@react-native-firebase/app"
+    ]
+  }
+}
+```
+
+- Once the plugin is in use you will need to:
+  - To **prebuild** your project, you will run `expo prebuild`. This will need to be done after every native code change.
+  - To **run** your project on a **local simulator** you will run `expo run [ios:android]`
+  - To **run** your project on a **external device** you will need to build a [development client](https://docs.expo.dev/development/getting-started/) and install it on your external device. This development client will act as a custom version of Expo Go built with your native code. To start the developemnt client you will run `expo start --dev-client`
+  - To **build** your project you will use `eas build`
+
 ### Android
 
 - Open **Project overview** in the firebase console and click on the Android icon or + button to **Add Firebase to your Android app**.


### PR DESCRIPTION
# Why
I was confused about how to use Native Firebase with Expo, so I wanted to make it easier for those after me looking to do the same. Link to [issue](https://github.com/expo/expo/issues/17777).

# How
I used what I did to install Native Firebase from multiple sources and combined the instructions into a clear and concise summary.

# Test Plan
This is a docs only change. No code changes to test.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
