### PR TITLE
[dev-launcher][dev-menu] fix `RCTBridge.currentBridge` to be override

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed the singleton `RCTBridge.currentBridge` instance value be override by expo-dev-launcher bridge instance on iOS. ([#17780](https://github.com/expo/expo/pull/17780) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 0.11.7 — 2022-06-07

--- a/packages/expo-dev-launcher/ios/ReactNative/EXDevLauncherRCTBridge.m
+++ b/packages/expo-dev-launcher/ios/ReactNative/EXDevLauncherRCTBridge.m
@@ -1,6 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 #import "EXDevLauncherRCTBridge.h"
+#import "EXDevLauncherController.h"
 #import "RCTCxxBridge+Private.h"
 
 #import <React/RCTPerformanceLogger.h>
@@ -10,6 +11,16 @@
 @import EXDevMenuInterface;
 
 @implementation EXDevLauncherRCTCxxBridge
+
+- (instancetype)initWithParentBridge:(RCTBridge *)bridge
+{
+  if ((self = [super initWithParentBridge:bridge])) {
+    RCTBridge *appBridge = [EXDevLauncherController sharedInstance].appBridge;
+    // reset the singleton `RCTBridge.currentBridge` to app bridge instance
+    RCTBridge.currentBridge = appBridge != nil ? appBridge.batchedBridge : nil;
+  }
+  return self;
+}
 
 /**
  * Theoretically, we could overwrite the `RCTDevSettings` module by exporting our version through the bridge.

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed the singleton `RCTBridge.currentBridge` instance value be override by expo-dev-menu bridge instance on iOS. ([#17780](https://github.com/expo/expo/pull/17780) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 0.11.0 — 2022-06-07

--- a/packages/expo-dev-menu/ios/DevMenuRCTBridge.m
+++ b/packages/expo-dev-menu/ios/DevMenuRCTBridge.m
@@ -1,6 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 #import <EXDevMenu/DevMenuRCTBridge.h>
+#import <EXDevMenu-Swift.h>
 #import <RCTCxxBridge+Private.h>
 
 #import <React/RCTPerformanceLogger.h>
@@ -11,6 +12,16 @@
 @import EXDevMenuInterface;
 
 @implementation DevMenuRCTCxxBridge
+
+- (instancetype)initWithParentBridge:(RCTBridge *)bridge
+{
+  if ((self = [super initWithParentBridge:bridge])) {
+    RCTBridge *appBridge = DevMenuManager.shared.currentBridge;
+    // reset the singleton `RCTBridge.currentBridge` to app bridge instance
+    RCTBridge.currentBridge = appBridge != nil ? appBridge.batchedBridge : nil;
+  }
+  return self;
+}
 
 /**
  * Theoretically, we could overwrite the `RCTDevSettings` module by exporting our version through the bridge.


### PR DESCRIPTION
# Why

some third party libraries would use `[RCTBridge currentBridge]` to access the bridge instance. because dev-menu and dev-launcher would also create a RCTCxxBridge, the singleton bridge instance value would be override then.
fix https://github.com/Shopify/react-native-skia/issues/106

# How

right after dev-menu and dev-launcher bridge creation, reset the singleton bridge instance value to the app bridge instance.

# Test Plan

```sh
$ expo init exposkia
$ expo install expo-dev-client @shopify/react-native-skia
$ expo run:ios
# after dev-menu appears from first launch, click the reload ui button.
```

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- n/a This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
