### PR TITLE
[expo-go][ios] Show better error message when SDK version is missing or incompatible

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.kt
@@ -242,7 +242,7 @@ class ExpoUpdatesAppLoader @JvmOverloads constructor(
           // so we need to check the compatibility here
           val sdkVersion = updateManifest.manifest.getSDKVersion()
           if (!isValidSdkVersion(sdkVersion)) {
-            callback.onError(formatExceptionForIncompatibleSdk(sdkVersion ?: "null"))
+            callback.onError(formatExceptionForIncompatibleSdk(sdkVersion))
             didAbort = true
             return
           }
@@ -437,11 +437,13 @@ class ExpoUpdatesAppLoader @JvmOverloads constructor(
     return false
   }
 
-  private fun formatExceptionForIncompatibleSdk(sdkVersion: String): ManifestException {
+  private fun formatExceptionForIncompatibleSdk(sdkVersion: String?): ManifestException {
     val errorJson = JSONObject()
     try {
       errorJson.put("message", "Invalid SDK version")
-      if (ABIVersion.toNumber(sdkVersion) > ABIVersion.toNumber(Constants.SDK_VERSIONS_LIST[0])) {
+      if (sdkVersion == null) {
+        errorJson.put("errorCode", "NO_SDK_VERSION_SPECIFIED")
+      } else if (ABIVersion.toNumber(sdkVersion) > ABIVersion.toNumber(Constants.SDK_VERSIONS_LIST[0])) {
         errorJson.put("errorCode", "EXPERIENCE_SDK_VERSION_TOO_NEW")
       } else {
         errorJson.put("errorCode", "EXPERIENCE_SDK_VERSION_OUTDATED")

--- a/android/expoview/src/main/java/host/exp/exponent/exceptions/ManifestException.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/exceptions/ManifestException.kt
@@ -16,7 +16,7 @@ class ManifestException : ExponentException {
     this.errorJSON = null
   }
 
-  constructor(originalException: Exception?, manifestUrl: String, errorJSON: JSONObject) : super(
+  constructor(originalException: Exception?, manifestUrl: String, errorJSON: JSONObject?) : super(
     originalException
   ) {
     this.errorJSON = errorJSON
@@ -51,6 +51,9 @@ class ManifestException : ExponentException {
                 val sdkVersionRequired = availableSDKVersions.getString(0)
                 formattedMessage =
                   "This project uses SDK " + sdkVersionRequired + " , but this version of Expo Go only supports the following SDKs: " + Constants.SDK_VERSIONS_LIST.joinToString() + ". To load the project, it must be updated to a supported SDK version or an older version of Expo Go must be used."
+              }
+              "NO_SDK_VERSION_SPECIFIED" -> {
+                formattedMessage = "Incompatible SDK version or no SDK version specified. This version of Expo Go only supports the following SDKs (runtimes): " + Constants.SDK_VERSIONS_LIST.joinToString() + ". A custom development build must be used to load other runtimes."
               }
               "EXPERIENCE_SDK_VERSION_TOO_NEW" ->
                 formattedMessage =

--- a/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
+++ b/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
@@ -422,7 +422,8 @@ NSString * const EXRuntimeErrorDomain = @"incompatible-runtime";
     
     formattedMessage = [NSString stringWithFormat:@"This project uses SDK %@, but this version of Expo Go only supports the following SDKs: %@. To load the project, it must be updated to a supported SDK version or an older version of Expo Go must be used.", sdkVersionRequired, supportedSDKVersions];
   } else if ([errorCode isEqualToString:@"NO_SDK_VERSION_SPECIFIED"]) {
-    formattedMessage = @"Incompatible SDK version or no SDK version specified.";
+    NSString *supportedSDKVersions = [[EXVersions sharedInstance].versions[@"sdkVersions"] componentsJoinedByString:@", "];
+    formattedMessage = [NSString stringWithFormat:@"Incompatible SDK version or no SDK version specified. This version of Expo Go only supports the following SDKs (runtimes): %@. A custom development build must be used to load other runtimes.", supportedSDKVersions];
   } else if ([errorCode isEqualToString:@"EXPERIENCE_SDK_VERSION_TOO_NEW"]) {
     formattedMessage = @"The project you requested requires a newer version of Expo Go. Please download the latest version from the App Store.";
   } else if ([errorCode isEqualToString:@"NO_COMPATIBLE_EXPERIENCE_FOUND"]){

--- a/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
+++ b/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
@@ -421,6 +421,8 @@ NSString * const EXRuntimeErrorDomain = @"incompatible-runtime";
     NSString *supportedSDKVersions = [[EXVersions sharedInstance].versions[@"sdkVersions"] componentsJoinedByString:@", "];
     
     formattedMessage = [NSString stringWithFormat:@"This project uses SDK %@, but this version of Expo Go only supports the following SDKs: %@. To load the project, it must be updated to a supported SDK version or an older version of Expo Go must be used.", sdkVersionRequired, supportedSDKVersions];
+  } else if ([errorCode isEqualToString:@"NO_SDK_VERSION_SPECIFIED"]) {
+    formattedMessage = @"Incompatible SDK version or no SDK version specified.";
   } else if ([errorCode isEqualToString:@"EXPERIENCE_SDK_VERSION_TOO_NEW"]) {
     formattedMessage = @"The project you requested requires a newer version of Expo Go. Please download the latest version from the App Store.";
   } else if ([errorCode isEqualToString:@"NO_COMPATIBLE_EXPERIENCE_FOUND"]){


### PR DESCRIPTION
# Why

Expo Go only supports SDK-version runtime versions by design.

On Android, the error message used to looks like the following when `runtimeVersion` was not an SDK version:
<img width="369" alt="Screen Shot 2022-06-08 at 5 09 47 PM" src="https://user-images.githubusercontent.com/189568/172741473-a1f12741-3b3f-4467-abab-2d7972f7d6fb.png">

On iOS, there was no descriptive error message. 

Closes ENG-5223.

# How

Add descriptive error messages to both Android and iOS:

<img width="392" alt="Screen Shot 2022-06-13 at 3 46 53 PM" src="https://user-images.githubusercontent.com/189568/173460063-9e192117-721b-4e7d-a278-65b1f35c8fbe.png">
<img width="375" alt="Screen Shot 2022-06-13 at 3 34 37 PM" src="https://user-images.githubusercontent.com/189568/173460072-502bc53e-bf84-4235-b94e-8aa1f9d650d9.png">


# Test Plan

```
expo init kjdajhdashjkdas
cd kjdajhdashjkdas
eas init
eas update:configure
expo start
```

Load in Expo Go on iOS, see message from screenshot above rather than a generic message.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
