### PR TITLE
[docs] update Slider docs for renamed package

### DIFF
--- a/docs/pages/versions/unversioned/sdk/slider.md
+++ b/docs/pages/versions/unversioned/sdk/slider.md
@@ -1,7 +1,7 @@
 ---
 title: Slider
-sourceCodeUrl: 'https://github.com/react-native-community/react-native-slider'
-packageName: 'react-native-slider'
+sourceCodeUrl: 'https://github.com/callstack/react-native-slider'
+packageName: '@react-native-community/slider'
 ---
 
 import {APIInstallSection} from '~/components/plugins/InstallSection';
@@ -16,8 +16,8 @@ A component that provides access to the system UI for a slider control, that all
 
 ## Installation
 
-<APIInstallSection href="https://github.com/react-native-community/react-native-slider#getting-started" />
+<APIInstallSection href="https://github.com/callstack/react-native-slider#installation--usage" />
 
 ## Usage
 
-See full documentation at [react-native-community/react-native-slider](https://github.com/react-native-community/react-native-slider).
+See full documentation at [callstack/react-native-slider](https://github.com/callstack/react-native-slider).

--- a/docs/pages/versions/v45.0.0/sdk/slider.md
+++ b/docs/pages/versions/v45.0.0/sdk/slider.md
@@ -1,7 +1,7 @@
 ---
 title: Slider
-sourceCodeUrl: 'https://github.com/react-native-community/react-native-slider'
-packageName: 'react-native-slider'
+sourceCodeUrl: 'https://github.com/callstack/react-native-slider'
+packageName: '@react-native-community/slider'
 ---
 
 import {APIInstallSection} from '~/components/plugins/InstallSection';
@@ -16,8 +16,8 @@ A component that provides access to the system UI for a slider control, that all
 
 ## Installation
 
-<APIInstallSection href="https://github.com/react-native-community/react-native-slider#getting-started" />
+<APIInstallSection href="https://github.com/callstack/react-native-slider#installation--usage" />
 
 ## Usage
 
-See full documentation at [react-native-community/react-native-slider](https://github.com/react-native-community/react-native-slider).
+See full documentation at [callstack/react-native-slider](https://github.com/callstack/react-native-slider).


### PR DESCRIPTION
# Why

The package name was outdated.

# How

Manually updated

![image](https://user-images.githubusercontent.com/852069/172952049-3943a633-6751-4636-bcdd-d3b7943cf321.png)


# Test Plan

Tested locally

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
