### PR TITLE
fix classic-builds href

### DIFF
--- a/docs/pages/submit/introduction.md
+++ b/docs/pages/submit/introduction.md
@@ -18,7 +18,7 @@ import { BoxLink } from '~/ui/components/BoxLink';
 <BoxLink 
   title={'Learn how to use EAS Submit with "expo build"'} 
   description="EAS Submit works with EAS Build projects by default, but it's easy to use EAS Submit to submit apps built with Classic Builds too."
-  href="/submit/ios"
+  href="/submit/classic-builds"
 />
 
 <BoxLink 


### PR DESCRIPTION
# docs/pages/submit/introduction.md

# Why

fix /classic-builds link that was pointing to /ios

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [X] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
