### PR TITLE
[module-template] Fix creating expo modules

### DIFF
--- a/packages/expo-module-template/$package.json
+++ b/packages/expo-module-template/$package.json
@@ -5,8 +5,13 @@
   "main": "build/<%- project.name %>.js",
   "types": "build/<%- project.name %>.d.ts",
   "scripts": {
-    "build": "tsc",
-    "lint": "eslint ."
+    "build": "expo-module build",
+    "clean": "expo-module clean",
+    "lint": "expo-module lint",
+    "test": "expo-module test",
+    "prepare": "expo-module prepare",
+    "prepublishOnly": "expo-module prepublishOnly",
+    "expo-module": "expo-module"
   },
   "keywords": ["react-native", "expo", "<%- project.slug %>", "<%- project.name %>"],
   "repository": "<%- repo %>",
@@ -18,7 +23,8 @@
   "homepage": "<%- repo %>#readme",
   "dependencies": {},
   "devDependencies": {
-    "expo-module-scripts": "^2.0.0"
+    "expo-module-scripts": "^2.0.0",
+    "expo-modules-core": "^0.9.0"
   },
   "peerDependencies": {
     "expo": "*"

--- a/packages/expo-module-template/package.json
+++ b/packages/expo-module-template/package.json
@@ -22,10 +22,6 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/latest/sdk/module-template",
   "dependencies": {},
-  "devDependencies": {
-    "expo-module-scripts": "^2.0.0"
-  },
-  "peerDependencies": {
-    "expo": "*"
-  }
+  "devDependencies": {},
+  "peerDependencies": {}
 }


### PR DESCRIPTION
# Why

Supersedes https://github.com/expo/expo/pull/16547
Fixes https://github.com/expo/expo-cli/issues/4266

# How

- Added package scripts using `expo-module-scripts`
- Added `expo-modules-core` to dev dependencies

# Test Plan

Tested with `npx create-expo-module -s <local/path/to/expo-module-template>`