### PR TITLE
[Android][Expo Go] Fix building on Apple Silicon

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,6 +12,14 @@ buildscript {
     gradlePluginVersion = '7.0.4'
     gradleDownloadTaskVersion = '4.1.2'
     repositoryUrl = "file:${System.env.HOME}/.m2/repository/"
+
+    if (System.properties['os.arch'] == "aarch64") {
+      // For M1 Users we need to use the NDK 24 which added support for aarch64
+      ndkVersion = "24.0.8215888"
+    } else {
+      // Otherwise we default to the side-by-side NDK version from AGP.
+      ndkVersion = "21.4.7075529"
+    }
   }
   repositories {
     google()


### PR DESCRIPTION
# Why

`Expo Go` is failing to be built on Android using MacBook with Apple Silicon.
The same as https://github.com/expo/expo/commit/1176ea91d43863edbbb704b9bf225cbd88d46cdd, but for `Expo Go`

# How

- Copied https://github.com/expo/expo/blob/b723e966977743e07980b9c9e29d76c4074d0a51/apps/bare-expo/android/build.gradle#L21-L27
- Build the `Expo Go`

# Test Plan

- `Expo Go` compiles and runs and Android

