### PR TITLE
[sweet API][Kotlin] Export constants via JSI

### DIFF
--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIInteropModuleRegistryTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIInteropModuleRegistryTest.kt
@@ -105,4 +105,33 @@ class JSIInteropModuleRegistryTest {
     Truth.assertThat(jsPromiseClass.isString()).isTrue()
     Truth.assertThat(jsPromiseClass.getString()).isEqualTo("Promise")
   }
+
+  @Test
+  fun constants_should_be_exported() = withJSIInterop(
+    inlineModule {
+      Name("TestModule")
+      Constants(
+        "c1" to 123,
+        "c2" to "string",
+        "c3" to mapOf("i1" to 123)
+      )
+    }
+  ) {
+
+    val c1Value = evaluateScript("ExpoModules.TestModule.c1")
+    val c2Value = evaluateScript("ExpoModules.TestModule.c2")
+    val i1Value = evaluateScript("ExpoModules.TestModule.c3.i1")
+
+    Truth.assertThat(c1Value.isNumber()).isTrue()
+    val unboxedC1Value = c1Value.getDouble().toInt()
+    Truth.assertThat(unboxedC1Value).isEqualTo(123)
+
+    Truth.assertThat(c2Value.isString()).isTrue()
+    val unboxedC2Value = c2Value.getString()
+    Truth.assertThat(unboxedC2Value).isEqualTo("string")
+
+    Truth.assertThat(i1Value.isNumber()).isTrue()
+    val unboxedI1Value = i1Value.getDouble().toInt()
+    Truth.assertThat(unboxedI1Value).isEqualTo(123)
+  }
 }

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.cpp
@@ -49,9 +49,8 @@ std::shared_ptr<jsi::Object> JavaScriptModuleObject::getJSIObject(jsi::Runtime &
   return jsiObject;
 }
 
-void JavaScriptModuleObject::exportConstants(
-  jni::alias_ref<react::NativeMap::javaobject> constants
-) {
+void JavaScriptModuleObject::exportConstants(jni::alias_ref<react::NativeMap::javaobject>
+  constants) {
   auto dynamic = constants->cthis()->consume();
   assert(dynamic.isObject());
 

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.h
@@ -48,6 +48,11 @@ public:
   std::shared_ptr<jsi::Object> getJSIObject(jsi::Runtime &runtime);
 
   /**
+   * Exports constants that will be assigned to the underlying HostObject.
+   */
+  void exportConstants(jni::alias_ref<react::NativeMap::javaobject> constants);
+
+  /**
    * Registers a sync function.
    * That function can be called via the `JavaScriptModuleObject.callSyncMethod` method.
    */
@@ -105,6 +110,11 @@ private:
    * Metadata map that stores information about all available methods on this module.
    */
   std::map<std::string, MethodMetadata> methodsMetadata;
+
+  /**
+   * A constants map.
+   */
+  std::map<std::string, folly::dynamic> constants;
 
   explicit JavaScriptModuleObject(jni::alias_ref<jhybridobject> jThis)
     : javaPart_(jni::make_global(jThis)) {}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
@@ -1,5 +1,6 @@
 package expo.modules.kotlin
 
+import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReadableArray
 import expo.modules.kotlin.events.BasicEventListener
 import expo.modules.kotlin.events.EventListenerWithPayload
@@ -23,6 +24,10 @@ class ModuleHolder(val module: Module) {
   val jsObject by lazy {
     JavaScriptModuleObject()
       .apply {
+        val constants = definition.constantsProvider()
+        val convertedConstants = Arguments.makeNativeMap(constants)
+        exportConstants(convertedConstants)
+
         definition
           .functions
           .forEach { function ->

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptModuleObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptModuleObject.kt
@@ -1,9 +1,7 @@
 package expo.modules.kotlin.jni
 
 import com.facebook.jni.HybridData
-import com.facebook.react.bridge.NativeArray
 import com.facebook.react.bridge.NativeMap
-import com.facebook.react.bridge.ReadableArray
 import expo.modules.core.interfaces.DoNotStrip
 
 /**

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptModuleObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptModuleObject.kt
@@ -1,6 +1,9 @@
 package expo.modules.kotlin.jni
 
 import com.facebook.jni.HybridData
+import com.facebook.react.bridge.NativeArray
+import com.facebook.react.bridge.NativeMap
+import com.facebook.react.bridge.ReadableArray
 import expo.modules.core.interfaces.DoNotStrip
 
 /**
@@ -18,6 +21,11 @@ class JavaScriptModuleObject {
   private val mHybridData = initHybrid()
 
   private external fun initHybrid(): HybridData
+
+  /**
+   * Exports constants
+   */
+  external fun exportConstants(constants: NativeMap)
 
   /**
    * Register a promise-less function on the CPP module representation.


### PR DESCRIPTION
# Why

Exports constatns via JSI. 

Resolves ENG-5251

# How

One of the essential functionalities that had to be added before the RC release. 
> Note: 
The way of converting Java constants to a jsi object isn't final and will be replaced in the future by our custom converter.

# Test Plan

- unit tests ✅
