### PR TITLE
[jest-expo] Fix auth-session tests

### DIFF
--- a/packages/expo-web-browser/src/__tests__/WebBrowser-test.native.ts
+++ b/packages/expo-web-browser/src/__tests__/WebBrowser-test.native.ts
@@ -1,5 +1,4 @@
-import { unmockAllProperties } from 'jest-expo';
-import { Linking, EmitterSubscription } from 'react-native';
+import { unmockAllProperties, mockLinking } from 'jest-expo';
 
 import ExpoWebBrowser from '../ExpoWebBrowser';
 import * as WebBrowser from '../WebBrowser';
@@ -8,22 +7,8 @@ const fakeReturnValue = {
   type: 'cancel',
 };
 
-// we need a mock subscription, because original Linking.addEventListener returns undefined in tests
-class MockSubscription implements Pick<EmitterSubscription, 'remove'> {
-  private _isCancelled = false;
-
-  remove = jest.fn().mockImplementation(() => {
-    if (this._isCancelled) {
-      throw new Error(
-        'MockSubscription: Cannot remove a subscription that has already been cancelled'
-      );
-    }
-    this._isCancelled = true;
-  });
-}
-
 function applyMocks() {
-  Linking.addEventListener = jest.fn().mockImplementation(() => new MockSubscription());
+  mockLinking();
   ExpoWebBrowser.openBrowserAsync.mockImplementation(async () => fakeReturnValue);
 }
 

--- a/packages/jest-expo/src/index.js
+++ b/packages/jest-expo/src/index.js
@@ -70,6 +70,7 @@ export function mockLinking() {
       const subscription = emitter.addListener(type, cb);
       subscriptions[type] = subscriptions[type] || new Map();
       subscriptions[type].set(cb, subscription);
+      return subscription;
     })
   );
 


### PR DESCRIPTION
# Why

Fixes `expo-auth-session` unit tests and thus _SDK / Check Packages_ CI job.

I think I made a regression in #17645 

# How

- In #17645 I made a separate mock for linking event listener because I was unaware of `mockLinking()` from `jest-expo`
- Updated the `jest-expo` mock to return the actual subscription object. Auth session tests started to pass
- Replaced my web-browser mock with `mockLinking`. 

# Test Plan

- `et check-packages expo-auth-session jest-expo expo-web-browser` passes ✅ 

<!-- disable:changelog-checks -->