### PR TITLE
[sweet API][Kotlin] Export property names in the expo modules host object

### DIFF
--- a/packages/expo-modules-core/android/src/main/cpp/ExpoModulesHostObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/ExpoModulesHostObject.cpp
@@ -35,8 +35,7 @@ void ExpoModulesHostObject::set(jsi::Runtime &runtime, const jsi::PropNameID &na
 std::vector<jsi::PropNameID> ExpoModulesHostObject::getPropertyNames(jsi::Runtime &rt) {
   auto names = installer->getModulesName();
   size_t size = names->size();
-  std::vector<jsi::PropNameID> result;
-  result.reserve(size);
+  std::vector<jsi::PropNameID> result(size);
   for (int i = 0; i < size; i++) {
     result.push_back(
       jsi::PropNameID::forUtf8(rt, names->getElement(i)->toStdString())

--- a/packages/expo-modules-core/android/src/main/cpp/ExpoModulesHostObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/ExpoModulesHostObject.cpp
@@ -33,6 +33,15 @@ void ExpoModulesHostObject::set(jsi::Runtime &runtime, const jsi::PropNameID &na
 }
 
 std::vector<jsi::PropNameID> ExpoModulesHostObject::getPropertyNames(jsi::Runtime &rt) {
-  return {}; // TODO(@lukmccall): get list of all modules
+  auto names = installer->getModulesName();
+  size_t size = names->size();
+  std::vector<jsi::PropNameID> result;
+  result.reserve(size);
+  for (int i = 0; i < size; i++) {
+    result.push_back(
+      jsi::PropNameID::forUtf8(rt, names->getElement(i)->toStdString())
+    );
+  }
+  return result;
 }
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.cpp
@@ -83,9 +83,22 @@ JSIInteropModuleRegistry::callGetJavaScriptModuleObjectMethod(const std::string 
   return method(javaPart_, moduleName);
 }
 
+jni::local_ref<jni::JArrayClass<jni::JString>>
+JSIInteropModuleRegistry::callGetJavaScriptModulesNames() const {
+  const static auto method = expo::JSIInteropModuleRegistry::javaClassLocal()
+    ->getMethod<jni::local_ref<jni::JArrayClass<jni::JString>>()>(
+      "getJavaScriptModulesName"
+    );
+  return method(javaPart_);
+}
+
 jni::local_ref<JavaScriptModuleObject::javaobject>
 JSIInteropModuleRegistry::getModule(const std::string &moduleName) const {
   return callGetJavaScriptModuleObjectMethod(moduleName);
+}
+
+jni::local_ref<jni::JArrayClass<jni::JString>> JSIInteropModuleRegistry::getModulesName() const {
+  return callGetJavaScriptModulesNames();
 }
 
 jni::local_ref<JavaScriptValue::javaobject> JSIInteropModuleRegistry::evaluateScript(

--- a/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.h
@@ -55,6 +55,11 @@ public:
   jni::local_ref<JavaScriptModuleObject::javaobject> getModule(const std::string &moduleName) const;
 
   /**
+   * Gets names of all available modules.
+   */
+  jni::local_ref<jni::JArrayClass<jni::JString>> getModulesName() const;
+
+  /**
    * Exposes a `JavaScriptRuntime::evaluateScript` function to Kotlin
    */
   jni::local_ref<JavaScriptValue::javaobject> evaluateScript(jni::JString script);
@@ -80,5 +85,7 @@ private:
 
   inline jni::local_ref<JavaScriptModuleObject::javaobject>
   callGetJavaScriptModuleObjectMethod(const std::string &moduleName) const;
+
+  inline jni::local_ref<jni::JArrayClass<jni::JString>> callGetJavaScriptModulesNames() const;
 };
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIInteropModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIInteropModuleRegistry.kt
@@ -62,6 +62,15 @@ class JSIInteropModuleRegistry(appContext: AppContext) {
     return appContextHolder.get()?.registry?.getModuleHolder(name)?.jsObject
   }
 
+  /**
+   * Returns an array that contains names of available modules.
+   */
+  @Suppress("unused")
+  @DoNotStrip
+  fun getJavaScriptModulesName(): Array<String> {
+    return appContextHolder.get()?.registry?.registry?.keys?.toTypedArray() ?: emptyArray()
+  }
+
   @Throws(Throwable::class)
   protected fun finalize() {
     mHybridData.resetNative()


### PR DESCRIPTION
# Why

Makes sure that `getPropertyNames` function inside `ExpoModulesHostObject` works.

# How

Exports all modules names.

# Test Plan

- NCL and `ExpoModules` screen ✅