### PR TITLE
[android] backport #17686 #17751

### DIFF
--- a/android/versioned-abis/expoview-abi43_0_0/src/main/AndroidManifest.xml
+++ b/android/versioned-abis/expoview-abi43_0_0/src/main/AndroidManifest.xml
@@ -317,6 +317,14 @@
             </intent-filter>
         </receiver>
 
+        <activity android:name="abi43_0_0.expo.modules.notifications.service.NotificationForwarderActivity"
+          android:theme="@android:style/Theme.Translucent.NoTitleBar"
+          android:exported="false"
+          android:excludeFromRecents="true"
+          android:noHistory="true"
+          android:launchMode="standard"
+          />
+
         <provider
             android:name="abi43_0_0.expo.modules.sharing.SharingFileProvider"
             android:authorities="${applicationId}.SharingFileProvider"

--- a/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/notifications/service/NotificationForwarderActivity.kt
+++ b/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/notifications/service/NotificationForwarderActivity.kt
@@ -1,0 +1,30 @@
+package abi43_0_0.expo.modules.notifications.service
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+import expo.modules.notifications.BuildConfig
+
+/**
+ * An internal Activity that passes given Intent extras from
+ * [NotificationsService.createNotificationResponseIntent]
+ * and send broadcasts to [NotificationsService].
+ */
+class NotificationForwarderActivity : Activity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    val broadcastIntent =
+      NotificationsService.createNotificationResponseBroadcastIntent(applicationContext, intent.extras)
+    sendBroadcast(broadcastIntent)
+    finish()
+  }
+
+  override fun onNewIntent(intent: Intent?) {
+    super.onNewIntent(intent)
+    // This Activity is expected to launch with new task, supposedly
+    // there's no way for `onNewIntent` to be called.
+    if (BuildConfig.DEBUG) {
+      throw AssertionError()
+    }
+  }
+}

--- a/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/notifications/service/delegates/ExpoHandlingDelegate.kt
+++ b/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/notifications/service/delegates/ExpoHandlingDelegate.kt
@@ -1,13 +1,16 @@
 package abi43_0_0.expo.modules.notifications.service.delegates
 
+import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.util.Log
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ProcessLifecycleOwner
 import expo.modules.notifications.notifications.NotificationManager
 import expo.modules.notifications.notifications.model.Notification
 import expo.modules.notifications.notifications.model.NotificationResponse
+import abi43_0_0.expo.modules.notifications.service.NotificationForwarderActivity
 import abi43_0_0.expo.modules.notifications.service.NotificationsService
 import abi43_0_0.expo.modules.notifications.service.interfaces.HandlingDelegate
 import java.lang.ref.WeakReference
@@ -50,6 +53,42 @@ class ExpoHandlingDelegate(protected val context: Context) : HandlingDelegate {
         }
       }
     }
+
+    /**
+     * Create a PendingIntent to open app in foreground.
+     * We actually start two Activities
+     *   - the foreground main Activity
+     *   - the background [NotificationForwarderActivity] Activity that send notification clicked events through broadcast
+     */
+    fun createPendingIntentForOpeningApp(context: Context, broadcastIntent: Intent, notificationResponse: NotificationResponse): PendingIntent {
+      var intentFlags = PendingIntent.FLAG_UPDATE_CURRENT
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        intentFlags = intentFlags or PendingIntent.FLAG_IMMUTABLE
+      }
+      val foregroundActivityIntent = getNotificationActionLauncher(context) ?: getMainActivityLauncher(context) ?: run {
+        Log.w("expo-notifications", "No launch intent found for application. Interacting with the notification won't open the app. The implementation uses `getLaunchIntentForPackage` to find appropriate activity.")
+        Intent()
+      }
+      foregroundActivityIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_MULTIPLE_TASK
+      NotificationsService.setNotificationResponseToIntent(foregroundActivityIntent, notificationResponse)
+      val backgroundActivityIntent = Intent(context, NotificationForwarderActivity::class.java)
+      backgroundActivityIntent.putExtras(broadcastIntent)
+      return PendingIntent.getActivities(context, 0, arrayOf(foregroundActivityIntent, backgroundActivityIntent), intentFlags)
+    }
+
+    private fun getNotificationActionLauncher(context: Context): Intent? {
+      Intent(OPEN_APP_INTENT_ACTION).also { intent ->
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        intent.setPackage(context.applicationContext.packageName)
+        context.packageManager.resolveActivity(intent, 0)?.let {
+          return intent
+        }
+      }
+      return null
+    }
+
+    private fun getMainActivityLauncher(context: Context) =
+      context.packageManager.getLaunchIntentForPackage(context.packageName)
   }
 
   fun isAppInForeground() = ProcessLifecycleOwner.get().lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)
@@ -89,20 +128,6 @@ class ExpoHandlingDelegate(protected val context: Context) : HandlingDelegate {
 
     Log.w("expo-notifications", "No launch intent found for application. Interacting with the notification won't open the app. The implementation uses `getLaunchIntentForPackage` to find appropriate activity.")
   }
-
-  private fun getNotificationActionLauncher(context: Context): Intent? {
-    Intent(OPEN_APP_INTENT_ACTION).also { intent ->
-      intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-      intent.setPackage(context.applicationContext.packageName)
-      context.packageManager.resolveActivity(intent, 0)?.let {
-        return intent
-      }
-    }
-    return null
-  }
-
-  private fun getMainActivityLauncher(context: Context) =
-    context.packageManager.getLaunchIntentForPackage(context.packageName)
 
   override fun handleNotificationsDropped() {
     getListeners().forEach {

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/AndroidManifest.xml
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/AndroidManifest.xml
@@ -318,6 +318,14 @@
             </intent-filter>
         </receiver>
 
+        <activity android:name="abi44_0_0.expo.modules.notifications.service.NotificationForwarderActivity"
+          android:theme="@android:style/Theme.Translucent.NoTitleBar"
+          android:exported="false"
+          android:excludeFromRecents="true"
+          android:noHistory="true"
+          android:launchMode="standard"
+          />
+
         <provider
             android:name="abi44_0_0.expo.modules.sharing.SharingFileProvider"
             android:authorities="${applicationId}.SharingFileProvider"

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/notifications/service/NotificationForwarderActivity.kt
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/notifications/service/NotificationForwarderActivity.kt
@@ -1,0 +1,30 @@
+package abi44_0_0.expo.modules.notifications.service
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+import expo.modules.notifications.BuildConfig
+
+/**
+ * An internal Activity that passes given Intent extras from
+ * [NotificationsService.createNotificationResponseIntent]
+ * and send broadcasts to [NotificationsService].
+ */
+class NotificationForwarderActivity : Activity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    val broadcastIntent =
+      NotificationsService.createNotificationResponseBroadcastIntent(applicationContext, intent.extras)
+    sendBroadcast(broadcastIntent)
+    finish()
+  }
+
+  override fun onNewIntent(intent: Intent?) {
+    super.onNewIntent(intent)
+    // This Activity is expected to launch with new task, supposedly
+    // there's no way for `onNewIntent` to be called.
+    if (BuildConfig.DEBUG) {
+      throw AssertionError()
+    }
+  }
+}

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/notifications/service/delegates/ExpoHandlingDelegate.kt
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/notifications/service/delegates/ExpoHandlingDelegate.kt
@@ -1,13 +1,16 @@
 package abi44_0_0.expo.modules.notifications.service.delegates
 
+import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.util.Log
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ProcessLifecycleOwner
 import expo.modules.notifications.notifications.NotificationManager
 import expo.modules.notifications.notifications.model.Notification
 import expo.modules.notifications.notifications.model.NotificationResponse
+import abi44_0_0.expo.modules.notifications.service.NotificationForwarderActivity
 import abi44_0_0.expo.modules.notifications.service.NotificationsService
 import abi44_0_0.expo.modules.notifications.service.interfaces.HandlingDelegate
 import java.lang.ref.WeakReference
@@ -50,6 +53,42 @@ class ExpoHandlingDelegate(protected val context: Context) : HandlingDelegate {
         }
       }
     }
+
+    /**
+     * Create a PendingIntent to open app in foreground.
+     * We actually start two Activities
+     *   - the foreground main Activity
+     *   - the background [NotificationForwarderActivity] Activity that send notification clicked events through broadcast
+     */
+    fun createPendingIntentForOpeningApp(context: Context, broadcastIntent: Intent, notificationResponse: NotificationResponse): PendingIntent {
+      var intentFlags = PendingIntent.FLAG_UPDATE_CURRENT
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        intentFlags = intentFlags or PendingIntent.FLAG_IMMUTABLE
+      }
+      val foregroundActivityIntent = getNotificationActionLauncher(context) ?: getMainActivityLauncher(context) ?: run {
+        Log.w("expo-notifications", "No launch intent found for application. Interacting with the notification won't open the app. The implementation uses `getLaunchIntentForPackage` to find appropriate activity.")
+        Intent()
+      }
+      foregroundActivityIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_MULTIPLE_TASK
+      NotificationsService.setNotificationResponseToIntent(foregroundActivityIntent, notificationResponse)
+      val backgroundActivityIntent = Intent(context, NotificationForwarderActivity::class.java)
+      backgroundActivityIntent.putExtras(broadcastIntent)
+      return PendingIntent.getActivities(context, 0, arrayOf(foregroundActivityIntent, backgroundActivityIntent), intentFlags)
+    }
+
+    private fun getNotificationActionLauncher(context: Context): Intent? {
+      Intent(OPEN_APP_INTENT_ACTION).also { intent ->
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        intent.setPackage(context.applicationContext.packageName)
+        context.packageManager.resolveActivity(intent, 0)?.let {
+          return intent
+        }
+      }
+      return null
+    }
+
+    private fun getMainActivityLauncher(context: Context) =
+      context.packageManager.getLaunchIntentForPackage(context.packageName)
   }
 
   fun isAppInForeground() = ProcessLifecycleOwner.get().lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)
@@ -89,20 +128,6 @@ class ExpoHandlingDelegate(protected val context: Context) : HandlingDelegate {
 
     Log.w("expo-notifications", "No launch intent found for application. Interacting with the notification won't open the app. The implementation uses `getLaunchIntentForPackage` to find appropriate activity.")
   }
-
-  private fun getNotificationActionLauncher(context: Context): Intent? {
-    Intent(OPEN_APP_INTENT_ACTION).also { intent ->
-      intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-      intent.setPackage(context.applicationContext.packageName)
-      context.packageManager.resolveActivity(intent, 0)?.let {
-        return intent
-      }
-    }
-    return null
-  }
-
-  private fun getMainActivityLauncher(context: Context) =
-    context.packageManager.getLaunchIntentForPackage(context.packageName)
 
   override fun handleNotificationsDropped() {
     getListeners().forEach {

--- a/android/versioned-abis/expoview-abi45_0_0/src/main/AndroidManifest.xml
+++ b/android/versioned-abis/expoview-abi45_0_0/src/main/AndroidManifest.xml
@@ -317,6 +317,14 @@
             </intent-filter>
         </receiver>
 
+        <activity android:name="abi45_0_0.expo.modules.notifications.service.NotificationForwarderActivity"
+          android:theme="@android:style/Theme.Translucent.NoTitleBar"
+          android:exported="false"
+          android:excludeFromRecents="true"
+          android:noHistory="true"
+          android:launchMode="standard"
+          />
+
         <provider
             android:name="expo.modules.sharing.SharingFileProvider"
             android:authorities="${applicationId}.SharingFileProvider"

--- a/android/versioned-abis/expoview-abi45_0_0/src/main/java/abi45_0_0/expo/modules/notifications/service/NotificationForwarderActivity.kt
+++ b/android/versioned-abis/expoview-abi45_0_0/src/main/java/abi45_0_0/expo/modules/notifications/service/NotificationForwarderActivity.kt
@@ -1,0 +1,30 @@
+package abi45_0_0.expo.modules.notifications.service
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+import expo.modules.notifications.BuildConfig
+
+/**
+ * An internal Activity that passes given Intent extras from
+ * [NotificationsService.createNotificationResponseIntent]
+ * and send broadcasts to [NotificationsService].
+ */
+class NotificationForwarderActivity : Activity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    val broadcastIntent =
+      NotificationsService.createNotificationResponseBroadcastIntent(applicationContext, intent.extras)
+    sendBroadcast(broadcastIntent)
+    finish()
+  }
+
+  override fun onNewIntent(intent: Intent?) {
+    super.onNewIntent(intent)
+    // This Activity is expected to launch with new task, supposedly
+    // there's no way for `onNewIntent` to be called.
+    if (BuildConfig.DEBUG) {
+      throw AssertionError()
+    }
+  }
+}

--- a/android/versioned-abis/expoview-abi45_0_0/src/main/java/abi45_0_0/expo/modules/notifications/service/delegates/ExpoHandlingDelegate.kt
+++ b/android/versioned-abis/expoview-abi45_0_0/src/main/java/abi45_0_0/expo/modules/notifications/service/delegates/ExpoHandlingDelegate.kt
@@ -1,13 +1,16 @@
 package abi45_0_0.expo.modules.notifications.service.delegates
 
+import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.util.Log
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ProcessLifecycleOwner
 import expo.modules.notifications.notifications.NotificationManager
 import expo.modules.notifications.notifications.model.Notification
 import expo.modules.notifications.notifications.model.NotificationResponse
+import abi45_0_0.expo.modules.notifications.service.NotificationForwarderActivity
 import abi45_0_0.expo.modules.notifications.service.NotificationsService
 import abi45_0_0.expo.modules.notifications.service.interfaces.HandlingDelegate
 import java.lang.ref.WeakReference
@@ -50,6 +53,42 @@ class ExpoHandlingDelegate(protected val context: Context) : HandlingDelegate {
         }
       }
     }
+
+    /**
+     * Create a PendingIntent to open app in foreground.
+     * We actually start two Activities
+     *   - the foreground main Activity
+     *   - the background [NotificationForwarderActivity] Activity that send notification clicked events through broadcast
+     */
+    fun createPendingIntentForOpeningApp(context: Context, broadcastIntent: Intent, notificationResponse: NotificationResponse): PendingIntent {
+      var intentFlags = PendingIntent.FLAG_UPDATE_CURRENT
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        intentFlags = intentFlags or PendingIntent.FLAG_IMMUTABLE
+      }
+      val foregroundActivityIntent = getNotificationActionLauncher(context) ?: getMainActivityLauncher(context) ?: run {
+        Log.w("expo-notifications", "No launch intent found for application. Interacting with the notification won't open the app. The implementation uses `getLaunchIntentForPackage` to find appropriate activity.")
+        Intent()
+      }
+      foregroundActivityIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_MULTIPLE_TASK
+      NotificationsService.setNotificationResponseToIntent(foregroundActivityIntent, notificationResponse)
+      val backgroundActivityIntent = Intent(context, NotificationForwarderActivity::class.java)
+      backgroundActivityIntent.putExtras(broadcastIntent)
+      return PendingIntent.getActivities(context, 0, arrayOf(foregroundActivityIntent, backgroundActivityIntent), intentFlags)
+    }
+
+    private fun getNotificationActionLauncher(context: Context): Intent? {
+      Intent(OPEN_APP_INTENT_ACTION).also { intent ->
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        intent.setPackage(context.applicationContext.packageName)
+        context.packageManager.resolveActivity(intent, 0)?.let {
+          return intent
+        }
+      }
+      return null
+    }
+
+    private fun getMainActivityLauncher(context: Context) =
+      context.packageManager.getLaunchIntentForPackage(context.packageName)
   }
 
   fun isAppInForeground() = ProcessLifecycleOwner.get().lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)
@@ -89,20 +128,6 @@ class ExpoHandlingDelegate(protected val context: Context) : HandlingDelegate {
 
     Log.w("expo-notifications", "No launch intent found for application. Interacting with the notification won't open the app. The implementation uses `getLaunchIntentForPackage` to find appropriate activity.")
   }
-
-  private fun getNotificationActionLauncher(context: Context): Intent? {
-    Intent(OPEN_APP_INTENT_ACTION).also { intent ->
-      intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-      intent.setPackage(context.applicationContext.packageName)
-      context.packageManager.resolveActivity(intent, 0)?.let {
-        return intent
-      }
-    }
-    return null
-  }
-
-  private fun getMainActivityLauncher(context: Context) =
-    context.packageManager.getLaunchIntentForPackage(context.packageName)
 
   override fun handleNotificationsDropped() {
     getListeners().forEach {


### PR DESCRIPTION
# Why

fix the #17531 crash in expo go.

# How

backport #17686 #17751 to android versioned code

# Test Plan

android versioned expo go + sdk {43,44,45} [notification example](https://docs.expo.dev/versions/v45.0.0/sdk/notifications/#api). should press home button to backport the app and click the notifications.

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
