### PR TITLE
[segment] Bump analytics Android library

### DIFF
--- a/packages/expo-analytics-segment/CHANGELOG.md
+++ b/packages/expo-analytics-segment/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Bump `com.segment.analytics.android:analytics` from `4.9.4` to `4.10.4` to resolve Google Play rejections. ([#17841](https://github.com/expo/expo/pull/17841) by [@brentvatne](https://github.com/brentvatne))
+
 ## 11.2.0 — 2022-04-18
 
 ### ⚠️ Notices

--- a/packages/expo-analytics-segment/android/build.gradle
+++ b/packages/expo-analytics-segment/android/build.gradle
@@ -84,7 +84,7 @@ android {
 dependencies {
   implementation project(':expo-modules-core')
 
-  api 'com.segment.analytics.android:analytics:4.9.4'
+  api 'com.segment.analytics.android:analytics:4.10.4'
   api 'com.segment.analytics.android.integrations:firebase:2.+@aar'
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"


### PR DESCRIPTION
# Why

This should fix an issue with Google Play rejecting submissions based on the Segment Analytics library version.

# How

Bump the version based on guidance from @kbrandwijk 