### PR TITLE
[dev-launcher] add debug settings for EAS Updates extension

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add debug settings for EAS Updates (admin only) ([#17842](https://github.com/expo/expo/pull/17842) by [@ajsmth](https://github.com/ajsmth))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-dev-launcher/bundle/providers/QueryProvider.tsx
+++ b/packages/expo-dev-launcher/bundle/providers/QueryProvider.tsx
@@ -17,7 +17,15 @@ export const defaultQueryOptions: QueryOptions = {
 };
 
 const QueryOptionsContext = React.createContext<QueryOptionsContextProps | null>(null);
-export const useQueryOptions = () => React.useContext(QueryOptionsContext);
+export const useQueryOptions = () => {
+  const context = React.useContext(QueryOptionsContext);
+
+  if (!context) {
+    throw new Error(`useQueryOptions() was called outside of a <QueryOptionsContext /> provider`);
+  }
+
+  return context;
+};
 
 export function QueryProvider({ children }: { children: React.ReactNode }) {
   const [queryOptions, setQueryOptions] = React.useState(defaultQueryOptions);

--- a/packages/expo-dev-launcher/bundle/providers/ToastStackProvider.tsx
+++ b/packages/expo-dev-launcher/bundle/providers/ToastStackProvider.tsx
@@ -34,7 +34,15 @@ type ToastStackContextProps = {
 };
 
 const ToastStackContext = React.createContext<ToastStackContextProps | null>(null);
-export const useToastStack = () => React.useContext(ToastStackContext);
+export const useToastStack = () => {
+  const context = React.useContext(ToastStackContext);
+
+  if (!context) {
+    throw new Error(`useToastStack() was called outside of a <ToastStackContext /> provider`);
+  }
+
+  return context;
+};
 
 export function ToastStackProvider({ children }) {
   const toastStack = React.useRef(createAsyncStack<ToastStackItem>()).current;

--- a/packages/expo-dev-launcher/bundle/providers/UpdatesConfigProvider.tsx
+++ b/packages/expo-dev-launcher/bundle/providers/UpdatesConfigProvider.tsx
@@ -1,8 +1,19 @@
 import * as React from 'react';
 
-import { EXUpdatesConfig, updatesConfig } from '../native-modules/DevLauncherInternal';
+import {
+  EXUpdatesConfig,
+  updatesConfig as initialUpdatesConfig,
+} from '../native-modules/DevLauncherInternal';
 
-const Context = React.createContext<EXUpdatesConfig | null>(null);
+const defaultUpdatesConfg: EXUpdatesConfig = {
+  runtimeVersion: '',
+  sdkVersion: '',
+  appId: '',
+  usesEASUpdates: false,
+  updatesUrl: '',
+};
+
+const Context = React.createContext<EXUpdatesConfig>(defaultUpdatesConfg);
 export const useUpdatesConfig = () => React.useContext(Context);
 
 type UpdatesConfigProviderProps = {
@@ -10,6 +21,26 @@ type UpdatesConfigProviderProps = {
   initialUpdatesConfig?: EXUpdatesConfig;
 };
 
+type SetUpdatesConfigContext = (config: Partial<EXUpdatesConfig>) => void;
+const SetConfigContext = React.createContext<SetUpdatesConfigContext>(() => {});
+
+export const useSetUpdatesConfig = () => React.useContext(SetConfigContext);
+
 export function UpdatesConfigProvider({ children }: UpdatesConfigProviderProps) {
-  return <Context.Provider value={updatesConfig}>{children}</Context.Provider>;
+  const [updatesConfig, setUpdatesConfig] = React.useState(initialUpdatesConfig);
+
+  function onSetUpdatesConfig(updates: Partial<EXUpdatesConfig>) {
+    setUpdatesConfig((previousConfig) => {
+      return {
+        ...previousConfig,
+        ...updates,
+      };
+    });
+  }
+
+  return (
+    <SetConfigContext.Provider value={onSetUpdatesConfig}>
+      <Context.Provider value={updatesConfig}>{children}</Context.Provider>
+    </SetConfigContext.Provider>
+  );
 }

--- a/packages/expo-dev-launcher/bundle/providers/UpdatesConfigProvider.tsx
+++ b/packages/expo-dev-launcher/bundle/providers/UpdatesConfigProvider.tsx
@@ -5,7 +5,7 @@ import {
   updatesConfig as initialUpdatesConfig,
 } from '../native-modules/DevLauncherInternal';
 
-const defaultUpdatesConfg: EXUpdatesConfig = {
+const defaultUpdatesConfig: EXUpdatesConfig = {
   runtimeVersion: '',
   sdkVersion: '',
   appId: '',
@@ -13,7 +13,7 @@ const defaultUpdatesConfg: EXUpdatesConfig = {
   updatesUrl: '',
 };
 
-const Context = React.createContext<EXUpdatesConfig>(defaultUpdatesConfg);
+const Context = React.createContext<EXUpdatesConfig>(defaultUpdatesConfig);
 export const useUpdatesConfig = () => React.useContext(Context);
 
 type UpdatesConfigProviderProps = {

--- a/packages/expo-dev-launcher/bundle/queries/useBranchesForApp.tsx
+++ b/packages/expo-dev-launcher/bundle/queries/useBranchesForApp.tsx
@@ -10,6 +10,7 @@ import { Toasts } from '../components/Toasts';
 import { useBuildInfo } from '../providers/BuildInfoProvider';
 import { queryClient, useQueryOptions } from '../providers/QueryProvider';
 import { useToastStack } from '../providers/ToastStackProvider';
+import { useUpdatesConfig } from '../providers/UpdatesConfigProvider';
 import { primeCacheWithUpdates, Update } from './useUpdatesForBranch';
 
 const query = gql`
@@ -123,7 +124,7 @@ async function getBranchesAsync({
 }
 
 export function useBranchesForApp(appId: string, isAuthenticated: boolean) {
-  const { runtimeVersion } = useBuildInfo();
+  const { runtimeVersion } = useUpdatesConfig();
   const toastStack = useToastStack();
   const { queryOptions } = useQueryOptions();
   const isEnabled = appId != null && isAuthenticated;

--- a/packages/expo-dev-launcher/bundle/screens/SettingsScreen.tsx
+++ b/packages/expo-dev-launcher/bundle/screens/SettingsScreen.tsx
@@ -346,9 +346,11 @@ function UpdatesDebugSettings() {
         <Spacer.Vertical size="medium" />
       </View>
 
-      <View bg="default" px="medium">
+      <View bg="default" padding="medium" rounded="large">
         <Text type="mono">{JSON.stringify(updatesConfig, null, 2)}</Text>
       </View>
+
+      <Spacer.Vertical size="medium" />
 
       <View px="medium">
         <Heading size="small" color="secondary">

--- a/packages/expo-dev-launcher/bundle/screens/SettingsScreen.tsx
+++ b/packages/expo-dev-launcher/bundle/screens/SettingsScreen.tsx
@@ -10,6 +10,7 @@ import {
   ShowMenuIcon,
   ThreeFingerPressIcon,
   CheckIcon,
+  TextInput,
 } from 'expo-dev-client-components';
 import * as React from 'react';
 import { ScrollView, Switch } from 'react-native';
@@ -17,11 +18,12 @@ import { useQueryClient } from 'react-query';
 import { SafeAreaTop } from '../components/SafeAreaTop';
 
 import { Toasts } from '../components/Toasts';
-import { copyToClipboardAsync } from '../native-modules/DevLauncherInternal';
+import { copyToClipboardAsync, updatesConfig } from '../native-modules/DevLauncherInternal';
 import { useBuildInfo } from '../providers/BuildInfoProvider';
 import { useDevMenuPreferences } from '../providers/DevMenuPreferencesProvider';
 import { useQueryOptions } from '../providers/QueryProvider';
 import { useToastStack } from '../providers/ToastStackProvider';
+import { useSetUpdatesConfig, useUpdatesConfig } from '../providers/UpdatesConfigProvider';
 import { useUser } from '../providers/UserContextProvider';
 
 export function SettingsScreen() {
@@ -204,6 +206,8 @@ export function SettingsScreen() {
             <>
               <Spacer.Vertical size="medium" />
               <DebugSettings />
+              <Spacer.Vertical size="medium" />
+              <UpdatesDebugSettings />
             </>
           )}
         </View>
@@ -227,7 +231,7 @@ function DebugSettings() {
   async function onClearQueryPress() {
     await queryClient.resetQueries();
     await queryClient.invalidateQueries();
-    toastStack.push(() => <Toasts.Info>Network cache was reset!</Toasts.Info>);
+    toastStack?.push(() => <Toasts.Info>Network cache was reset!</Toasts.Info>);
   }
 
   const pageSizeOptions = [1, 5, 10];
@@ -294,6 +298,93 @@ function DebugSettings() {
           </View>
         </View>
       </View>
+    </View>
+  );
+}
+
+function UpdatesDebugSettings() {
+  const updatesConfig = useUpdatesConfig();
+  const defaultUpdatesConfig = React.useRef(updatesConfig).current;
+  const setUpdatesConfig = useSetUpdatesConfig();
+  const toastStack = useToastStack();
+
+  function onUrlChange({ nativeEvent: { text: appId } }) {
+    let appliedAppId = appId;
+    let usesEASUpdates = true;
+
+    if (appId.length === 0) {
+      appliedAppId = defaultUpdatesConfig.appId;
+      usesEASUpdates = false;
+    }
+
+    setUpdatesConfig({ appId, usesEASUpdates });
+    toastStack.push(() => <Toasts.Info>{`Updated appId to ${appliedAppId}`}</Toasts.Info>);
+  }
+
+  function onRuntimeVersionChange({ nativeEvent: { text: runtimeVersion } }) {
+    let appliedRuntimeVersion = runtimeVersion;
+
+    if (runtimeVersion.length === 0) {
+      appliedRuntimeVersion = defaultUpdatesConfig.runtimeVersion;
+    }
+
+    setUpdatesConfig({ runtimeVersion });
+    toastStack.push(() => (
+      <Toasts.Info>{`Updated runtimeVersion to ${appliedRuntimeVersion}`}</Toasts.Info>
+    ));
+  }
+
+  return (
+    <View my="medium">
+      <View px="medium">
+        <Heading color="secondary">EAS Update Debug Settings</Heading>
+        <Spacer.Vertical size="medium" />
+      </View>
+
+      <View px="medium">
+        <Heading color="secondary">Current Settings</Heading>
+        <Spacer.Vertical size="medium" />
+      </View>
+
+      <View bg="default" px="medium">
+        <Text type="mono">{JSON.stringify(updatesConfig, null, 2)}</Text>
+      </View>
+
+      <View px="medium">
+        <Heading size="small" color="secondary">
+          EAS Updates App ID
+        </Heading>
+        <Spacer.Vertical size="small" />
+      </View>
+
+      <View bg="default" rounded="large" py="small" px="small">
+        <TextInput
+          blurOnSubmit
+          autoCapitalize="none"
+          keyboardType="url"
+          placeholder="Set App Id"
+          defaultValue={updatesConfig?.appId ?? ''}
+          onSubmitEditing={onUrlChange}
+        />
+      </View>
+      <Spacer.Vertical size="small" />
+      <View px="medium">
+        <Heading size="small" color="secondary">
+          Runtime Version
+        </Heading>
+      </View>
+      <View bg="default" rounded="large" py="small" px="small">
+        <TextInput
+          blurOnSubmit
+          autoCapitalize="none"
+          keyboardType="url"
+          placeholder="Set Runtime Version"
+          defaultValue={updatesConfig?.runtimeVersion ?? ''}
+          onSubmitEditing={onRuntimeVersionChange}
+        />
+      </View>
+
+      <Spacer.Vertical size="large" />
     </View>
   );
 }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This PR adds some helpful debug options for admin users 

It can be a bit of a pain to update the EAS Updates appId and runtime version because it requires a new native build  - this addition lets us modify these values via the Settings panel as well 

If the values entered are empty strings, then the settings are reset to the default ones configured via `Expo.plist` and `AndroidManifest.xml`

# How

<!--
How did you build this feature or fix this bug and why?
-->

I added a context that lets us set `updatesConfig` values from the text inputs and made sure that empty values reverted to whatever value was set on the native side, as well as added a text element that shows the current settings just for extra clarity

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Try different runtime versions and appIds - note that the updates fetched correspond with the settings you've updated. 
Add empty values and ensure that the settings are restored to their native configuration


Screenshot: 

<img width="395" alt="Screen Shot 2022-06-13 at 11 59 31 AM" src="https://user-images.githubusercontent.com/40680668/173425441-459a9b1c-88aa-4273-a2b2-743bb47de57a.png">



# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
