### PR TITLE
[ios][expo go] improve error/"go home" screen design

### DIFF
--- a/ios/Exponent.xcodeproj/project.pbxproj
+++ b/ios/Exponent.xcodeproj/project.pbxproj
@@ -181,6 +181,8 @@
 		8353B820277A17FC00AFCBDA /* EXStandaloneViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8353B81E277A17FB00AFCBDA /* EXStandaloneViewController.m */; };
 		8353B821277A17FC00AFCBDA /* EXStandaloneViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8353B81E277A17FB00AFCBDA /* EXStandaloneViewController.m */; };
 		837259A9280671D200E204C1 /* AIRMapUrlTileCachedOverlay.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A35BDC646C64B7988CCD0CA /* AIRMapUrlTileCachedOverlay.m */; };
+		84713BFB28584A0100E86B56 /* EXErrorView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 84713BFA28584A0100E86B56 /* EXErrorView.xib */; };
+		84713BFC28584A0100E86B56 /* EXErrorView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 84713BFA28584A0100E86B56 /* EXErrorView.xib */; };
 		8746D75E24D04B2300BFAD22 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8746D75C24D04B2300BFAD22 /* LaunchScreen.storyboard */; };
 		8764788D270F1AF30076CA5F /* EXAppLoadingProgressWindowViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8764788C270F1AF30076CA5F /* EXAppLoadingProgressWindowViewController.swift */; };
 		8764788E270F1AF30076CA5F /* EXAppLoadingProgressWindowViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8764788C270F1AF30076CA5F /* EXAppLoadingProgressWindowViewController.swift */; };
@@ -993,6 +995,7 @@
 		80598B49D2DB4720B1935D89 /* RNSharedElementNodeManager.m */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.c.objc; path = RNSharedElementNodeManager.m; sourceTree = "<group>"; };
 		8353B81E277A17FB00AFCBDA /* EXStandaloneViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EXStandaloneViewController.m; sourceTree = "<group>"; };
 		8353B81F277A17FC00AFCBDA /* EXStandaloneViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EXStandaloneViewController.h; sourceTree = "<group>"; };
+		84713BFA28584A0100E86B56 /* EXErrorView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = EXErrorView.xib; sourceTree = "<group>"; };
 		8746D75D24D04B2300BFAD22 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		8764788C270F1AF30076CA5F /* EXAppLoadingProgressWindowViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EXAppLoadingProgressWindowViewController.swift; sourceTree = "<group>"; };
 		8767F5B624D177AD009F9372 /* EXManagedAppSplashScreenConfigurationBuilder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EXManagedAppSplashScreenConfigurationBuilder.h; sourceTree = "<group>"; };
@@ -1949,6 +1952,7 @@
 				B5A473D4204A66F60035C61C /* EXAppViewController.m */,
 				B5A473D9204A66F60035C61C /* EXErrorView.h */,
 				B5A473D6204A66F60035C61C /* EXErrorView.m */,
+				84713BFA28584A0100E86B56 /* EXErrorView.xib */,
 				B5A473DD204A673E0035C61C /* Loading */,
 			);
 			path = Views;
@@ -2654,6 +2658,7 @@
 				B5E49B691D1348E800AA6436 /* EXShell.plist in Resources */,
 				F12A1AB922ABD4BA008542C6 /* generate-dynamic-macros.sh in Resources */,
 				78CEE2D11ACD07D70095B124 /* Images.xcassets in Resources */,
+				84713BFB28584A0100E86B56 /* EXErrorView.xib in Resources */,
 				B5EF826F1F55B8F100FC7424 /* launch_icon.png in Resources */,
 				B5CFBF4D1EDE398D00B4BE24 /* EXBuildConstants.plist in Resources */,
 				B5E49B751D134F0700AA6436 /* kernel.ios.bundle in Resources */,
@@ -2690,6 +2695,7 @@
 				F1421911262CB68600BB97E6 /* EXShell.plist in Resources */,
 				F1421912262CB68600BB97E6 /* generate-dynamic-macros.sh in Resources */,
 				F1421913262CB68600BB97E6 /* Images.xcassets in Resources */,
+				84713BFC28584A0100E86B56 /* EXErrorView.xib in Resources */,
 				F1421914262CB68600BB97E6 /* launch_icon.png in Resources */,
 				F1421915262CB68600BB97E6 /* EXBuildConstants.plist in Resources */,
 				F1421916262CB68600BB97E6 /* kernel.ios.bundle in Resources */,

--- a/ios/Exponent/Kernel/Views/EXErrorView.m
+++ b/ios/Exponent/Kernel/Views/EXErrorView.m
@@ -7,14 +7,37 @@
 #import "EXKernelAppRecord.h"
 #import "EXUtil.h"
 
+// for creating a filled button background in iOS <15
+@interface UIImage (Utils)
+
++ (UIImage *)imageWithSize:(CGSize)size color:(UIColor *)color;
+
+@end
+
+@implementation UIImage (Utils)
+
++ (UIImage *)imageWithSize:(CGSize)size color:(UIColor *)color
+{
+    UIGraphicsBeginImageContextWithOptions(size, true, 0.0);
+    [color setFill];
+    UIRectFill(CGRectMake(0.0, 0.0, size.width, size.height));
+    UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+    return image;
+}
+
+@end
+
 @interface EXErrorView ()
 
-@property (nonatomic, strong) UILabel *lblError;
-@property (nonatomic, strong) UIButton *btnRetry;
-@property (nonatomic, strong) UIButton *btnBack;
-@property (nonatomic, strong) UILabel *lblUrl;
-@property (nonatomic, strong) UILabel *lblErrorDetail;
-@property (nonatomic, strong) UIScrollView *vContainer;
+@property (nonatomic, strong) IBOutlet UILabel *lblError;
+@property (nonatomic, strong) IBOutlet UIButton *btnRetry;
+@property (nonatomic, strong) IBOutlet UIButton *btnBack;
+@property (nonatomic, strong) IBOutlet UIStackView *btnStack;
+@property (nonatomic, strong) IBOutlet UIView *btnStackContainer;
+@property (nonatomic, strong) IBOutlet UILabel *lblUrl;
+@property (nonatomic, strong) IBOutlet UILabel *lblErrorDetail;
+@property (nonatomic, strong) IBOutlet UIScrollView *vContainer;
 
 - (void)_onTapRetry;
 
@@ -25,51 +48,15 @@
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if (self = [super initWithFrame:frame]) {
-    self.backgroundColor = [UIColor whiteColor];
-    
-    self.vContainer = [[UIScrollView alloc] init];
+    [[NSBundle mainBundle] loadNibNamed:@"EXErrorView" owner:self options:nil];
     [self addSubview:_vContainer];
-
-    // error description label
-    self.lblError = [[UILabel alloc] init];
-    _lblError.numberOfLines = 0;
-    _lblError.textAlignment = NSTextAlignmentCenter;
-    _lblError.font = [UIFont systemFontOfSize:14.0f];
-    _lblError.textColor = [UIColor blackColor];
-    [_vContainer addSubview:_lblError];
     
-    // retry button
-    self.btnRetry = [UIButton buttonWithType:UIButtonTypeRoundedRect];
-    [_btnRetry setTitle:@"Try again" forState:UIControlStateNormal];
     [_btnRetry addTarget:self action:@selector(_onTapRetry) forControlEvents:UIControlEventTouchUpInside];
-    [_vContainer addSubview:_btnRetry];
-    
-    // back button
-    self.btnBack = [UIButton buttonWithType:UIButtonTypeRoundedRect];
-    [_btnBack setTitle:@"Go back to Expo Home" forState:UIControlStateNormal];
-    [_btnBack addTarget:self action:@selector(_onTapBack) forControlEvents:UIControlEventTouchUpInside];
-    [_vContainer addSubview:_btnBack];
+   [_btnBack addTarget:self action:@selector(_onTapBack) forControlEvents:UIControlEventTouchUpInside];
     
     for (UIButton *btnToStyle in @[ _btnRetry, _btnBack ]) {
-      [btnToStyle setTintColor:[EXUtil colorWithRGB:0x49a7e8]];
-      [btnToStyle.titleLabel setFont:[UIFont boldSystemFontOfSize:14.0f]];
-    }
-    
-    // url label
-    self.lblUrl = [[UILabel alloc] init];
-    _lblUrl.numberOfLines = 0;
-    _lblUrl.textAlignment = NSTextAlignmentCenter;
-    [_vContainer addSubview:_lblUrl];
-
-    // error detail label
-    self.lblErrorDetail = [[UILabel alloc] init];
-    _lblErrorDetail.numberOfLines = 0;
-    _lblErrorDetail.textAlignment = NSTextAlignmentCenter;
-    _lblErrorDetail.textColor = [UIColor darkGrayColor];
-    [_vContainer addSubview:_lblErrorDetail];
-    
-    for (UILabel *lblToStyle in @[ _lblUrl, _lblErrorDetail ]) {
-      lblToStyle.font = [UIFont systemFontOfSize:14.0f];
+      btnToStyle.layer.cornerRadius = 4.0;
+      btnToStyle.layer.masksToBounds = YES;
     }
   }
   return self;
@@ -90,20 +77,6 @@
   switch (type) {
     case kEXFatalErrorTypeLoading: {
       _lblError.text = [NSString stringWithFormat:@"There was a problem loading %@.", appOwnerName];
-      if (_error.code == kCFURLErrorNotConnectedToInternet) {
-        _lblError.text = [NSString stringWithFormat:@"%@ Make sure you're connected to the internet.", _lblError.text];
-      } else if (_appRecord.appLoader.manifestUrl) {
-        NSString *url = _appRecord.appLoader.manifestUrl.absoluteString;
-        if ([self _urlLooksLikeLAN:url]) {
-          NSString *extraLANPermissionText = @"";
-          if (@available(iOS 14, *)) {
-            extraLANPermissionText = @", and that you have granted Expo Go the Local Network permission in the Settings app,";
-          }
-          _lblError.text = [NSString stringWithFormat:
-                            @"%@\n\nIt looks like you may be using a LAN URL. "
-                            "Make sure your device is on the same network as the server%@ or try using the tunnel connection type.", _lblError.text, extraLANPermissionText];
-        }
-      }
       break;
     }
     case kEXFatalErrorTypeException: {
@@ -118,6 +91,28 @@
 {
   _error = error;
   _lblErrorDetail.text = [error localizedDescription];
+  switch (_type) {
+    case kEXFatalErrorTypeLoading: {
+      if (_error.code == kCFURLErrorNotConnectedToInternet) {
+        _lblErrorDetail.text = [NSString stringWithFormat:@"%@ Make sure you're connected to the internet.", _lblErrorDetail.text];
+      } else if (_appRecord.appLoader.manifestUrl) {
+        NSString *url = _appRecord.appLoader.manifestUrl.absoluteString;
+        if ([self _urlLooksLikeLAN:url]) {
+          NSString *extraLANPermissionText = @"";
+          if (@available(iOS 14, *)) {
+            extraLANPermissionText = @", and that you have granted Expo Go the Local Network permission in the Settings app,";
+          }
+          _lblErrorDetail.text = [NSString stringWithFormat:
+                            @"%@\n\nIt looks like you may be using a LAN URL. "
+                            "Make sure your device is on the same network as the server%@ or try using the tunnel connection type.", _lblErrorDetail.text, extraLANPermissionText];
+        }
+      }
+      break;
+    }
+    case kEXFatalErrorTypeException: {
+      break;
+    }
+  }
   [self _resetUIState];
 }
 
@@ -130,30 +125,33 @@
 - (void)layoutSubviews
 {
   [super layoutSubviews];
-
-  _vContainer.frame = self.bounds;
-  CGFloat maxLabelWidth = self.bounds.size.width - 32.0f;
-
-  _lblError.frame = CGRectMake(0, 0, maxLabelWidth, CGFLOAT_MAX);
-  [_lblError sizeToFit];
-  _lblError.center = CGPointMake(self.bounds.size.width * 0.5f, self.bounds.size.height * 0.25f);
-
-  _btnRetry.frame = CGRectMake(0, 0, self.bounds.size.width, 24.0f);
-  _btnRetry.center = CGPointMake(_lblError.center.x, CGRectGetMaxY(_lblError.frame) + 32.0f);
+ 
+  if (@available(iOS 12.0, *)) {
+    switch (UIScreen.mainScreen.traitCollection.userInterfaceStyle) {
+      case UIUserInterfaceStyleDark:
+        self.backgroundColor = [EXUtil colorWithRGB:0x25292E];
+        break;
+      case UIUserInterfaceStyleLight:
+      case UIUserInterfaceStyleUnspecified:
+        break;
+      default:
+        break;
+    }
+  }
   
-  _btnBack.frame = CGRectMake(0, 0, self.bounds.size.width, 24.0f);
-  _btnBack.center = CGPointMake(_lblError.center.x, CGRectGetMaxY(_btnRetry.frame) + 24);
+  _vContainer.translatesAutoresizingMaskIntoConstraints = NO;
+
+  UILayoutGuide *guide = self.safeAreaLayoutGuide;
+  [_vContainer.leadingAnchor constraintEqualToAnchor:guide.leadingAnchor].active = YES;
+  [_vContainer.trailingAnchor constraintEqualToAnchor:guide.trailingAnchor].active = YES;
+  [_vContainer.topAnchor constraintEqualToAnchor:guide.topAnchor].active = YES;
+  [_vContainer.bottomAnchor constraintEqualToAnchor:guide.bottomAnchor].active = YES;
+
+  UIImage *btnRetryBgImage = [UIImage imageWithSize:_btnRetry.frame.size color:  [EXUtil colorWithRGB:0x25292E]];
+  [_btnRetry setBackgroundImage:btnRetryBgImage forState:UIControlStateNormal];
   
-  _lblUrl.frame = CGRectMake(0, 0, self.bounds.size.width - 48.0f, CGFLOAT_MAX);
-  [_lblUrl sizeToFit];
-  _lblUrl.center = CGPointMake(_lblError.center.x, CGRectGetMaxY(_btnBack.frame) + 12.0f + CGRectGetMidY(_lblUrl.bounds));
-
-  _lblErrorDetail.frame = CGRectMake(0, 0, maxLabelWidth, CGFLOAT_MAX);
-  [_lblErrorDetail sizeToFit];
-
-  _lblErrorDetail.center = CGPointMake(_lblError.center.x, CGRectGetMaxY(_lblUrl.frame) + 24.0f + CGRectGetMidY(_lblErrorDetail.bounds));
-
-  _vContainer.contentSize = CGSizeMake(_vContainer.bounds.size.width, CGRectGetMaxY(_lblErrorDetail.frame) + 12.0f);
+  UIImage *btnBackBgImage = [UIImage imageWithSize:_btnBack.frame.size color:  [EXUtil colorWithRGB:0xF0F1F2]];
+  [_btnBack setBackgroundImage:btnBackBgImage forState:UIControlStateNormal];
 }
 
 #pragma mark - Internal

--- a/ios/Exponent/Kernel/Views/EXErrorView.m
+++ b/ios/Exponent/Kernel/Views/EXErrorView.m
@@ -7,27 +7,6 @@
 #import "EXKernelAppRecord.h"
 #import "EXUtil.h"
 
-// for creating a filled button background in iOS <15
-@interface UIImage (Utils)
-
-+ (UIImage *)imageWithSize:(CGSize)size color:(UIColor *)color;
-
-@end
-
-@implementation UIImage (Utils)
-
-+ (UIImage *)imageWithSize:(CGSize)size color:(UIColor *)color
-{
-    UIGraphicsBeginImageContextWithOptions(size, true, 0.0);
-    [color setFill];
-    UIRectFill(CGRectMake(0.0, 0.0, size.width, size.height));
-    UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
-    UIGraphicsEndImageContext();
-    return image;
-}
-
-@end
-
 @interface EXErrorView ()
 
 @property (nonatomic, strong) IBOutlet UILabel *lblError;
@@ -52,7 +31,7 @@
     [self addSubview:_vContainer];
     
     [_btnRetry addTarget:self action:@selector(_onTapRetry) forControlEvents:UIControlEventTouchUpInside];
-   [_btnBack addTarget:self action:@selector(_onTapBack) forControlEvents:UIControlEventTouchUpInside];
+    [_btnBack addTarget:self action:@selector(_onTapBack) forControlEvents:UIControlEventTouchUpInside];
     
     for (UIButton *btnToStyle in @[ _btnRetry, _btnBack ]) {
       btnToStyle.layer.cornerRadius = 4.0;
@@ -147,10 +126,10 @@
   [_vContainer.topAnchor constraintEqualToAnchor:guide.topAnchor].active = YES;
   [_vContainer.bottomAnchor constraintEqualToAnchor:guide.bottomAnchor].active = YES;
 
-  UIImage *btnRetryBgImage = [UIImage imageWithSize:_btnRetry.frame.size color:  [EXUtil colorWithRGB:0x25292E]];
+  UIImage *btnRetryBgImage = [self imageWithSize:_btnRetry.frame.size color:  [EXUtil colorWithRGB:0x25292E]];
   [_btnRetry setBackgroundImage:btnRetryBgImage forState:UIControlStateNormal];
   
-  UIImage *btnBackBgImage = [UIImage imageWithSize:_btnBack.frame.size color:  [EXUtil colorWithRGB:0xF0F1F2]];
+  UIImage *btnBackBgImage = [self imageWithSize:_btnBack.frame.size color:  [EXUtil colorWithRGB:0xF0F1F2]];
   [_btnBack setBackgroundImage:btnBackBgImage forState:UIControlStateNormal];
 }
 
@@ -195,6 +174,17 @@
 - (BOOL)_isDevDetached
 {
   return [EXEnvironment sharedEnvironment].isDetached && [EXEnvironment sharedEnvironment].isDebugXCodeScheme;
+}
+
+// for creating a filled button background in iOS < 15
+- (UIImage *)imageWithSize:(CGSize)size color:(UIColor *)color
+{
+  UIGraphicsBeginImageContextWithOptions(size, true, 0.0);
+  [color setFill];
+  UIRectFill(CGRectMake(0.0, 0.0, size.width, size.height));
+  UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
+  UIGraphicsEndImageContext();
+  return image;
 }
 
 @end

--- a/ios/Exponent/Kernel/Views/EXErrorView.xib
+++ b/ios/Exponent/Kernel/Views/EXErrorView.xib
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="dark"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="EXErrorView" customModule="Expo_Go" customModuleProvider="target">
+            <connections>
+                <outlet property="btnBack" destination="1zt-0v-fnw" id="cso-y1-Ucb"/>
+                <outlet property="btnRetry" destination="YsF-A3-kQ1" id="arK-wt-HDc"/>
+                <outlet property="btnStack" destination="Mh8-u0-LCN" id="0eD-IY-253"/>
+                <outlet property="btnStackContainer" destination="3xg-me-cwE" id="Gyu-3k-RG8"/>
+                <outlet property="lblError" destination="iXc-4d-VpK" id="1Sa-Te-jkb"/>
+                <outlet property="lblErrorDetail" destination="r66-il-5GR" id="dH1-WC-3LD"/>
+                <outlet property="lblUrl" destination="uZA-n9-0bf" id="jvM-WQ-o0R"/>
+                <outlet property="vContainer" destination="zz8-rt-yG1" id="V5Q-DG-oIp"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zz8-rt-yG1">
+                    <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                    <subviews>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Error Title" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iXc-4d-VpK">
+                            <rect key="frame" x="16" y="24" width="382" height="29"/>
+                            <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="24"/>
+                            <color key="textColor" red="0.14117647059999999" green="0.16078431369999999" blue="0.1843137255" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Error Detail" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="r66-il-5GR">
+                            <rect key="frame" x="16" y="69" width="382" height="19.5"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                            <color key="textColor" red="0.14117647059999999" green="0.16078431369999999" blue="0.1843137255" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3xg-me-cwE">
+                            <rect key="frame" x="0.0" y="706" width="414" height="112"/>
+                            <subviews>
+                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Mh8-u0-LCN">
+                                    <rect key="frame" x="16" y="16" width="382" height="80"/>
+                                    <subviews>
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YsF-A3-kQ1">
+                                            <rect key="frame" x="0.0" y="0.0" width="382" height="36"/>
+                                            <constraints>
+                                                <constraint firstAttribute="height" constant="36" id="IBQ-Hh-Ax9"/>
+                                            </constraints>
+                                            <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
+                                            <color key="tintColor" red="0.14117647059999999" green="0.16078431369999999" blue="0.1843137255" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                            <state key="normal" title="Try Again">
+                                                <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            </state>
+                                        </button>
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1zt-0v-fnw">
+                                            <rect key="frame" x="0.0" y="44" width="382" height="36"/>
+                                            <constraints>
+                                                <constraint firstAttribute="height" constant="36" id="082-ip-q06"/>
+                                            </constraints>
+                                            <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
+                                            <color key="tintColor" red="0.94117647059999998" green="0.94509803920000002" blue="0.94901960780000005" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                            <state key="normal" title="Go Home">
+                                                <color key="titleColor" red="0.14117647059999999" green="0.16078431369999999" blue="0.1843137255" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            </state>
+                                        </button>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstAttribute="trailing" secondItem="1zt-0v-fnw" secondAttribute="trailing" id="4o6-kR-OOK"/>
+                                        <constraint firstAttribute="bottom" secondItem="1zt-0v-fnw" secondAttribute="bottom" id="9DR-lN-mHl"/>
+                                        <constraint firstAttribute="trailing" secondItem="YsF-A3-kQ1" secondAttribute="trailing" id="AlF-NZ-NJq"/>
+                                        <constraint firstItem="1zt-0v-fnw" firstAttribute="leading" secondItem="Mh8-u0-LCN" secondAttribute="leading" id="Sk9-Lx-Gbk"/>
+                                        <constraint firstItem="YsF-A3-kQ1" firstAttribute="top" secondItem="Mh8-u0-LCN" secondAttribute="top" id="bVs-VW-hFk"/>
+                                        <constraint firstItem="YsF-A3-kQ1" firstAttribute="leading" secondItem="Mh8-u0-LCN" secondAttribute="leading" id="bv3-aR-HGp"/>
+                                    </constraints>
+                                </stackView>
+                            </subviews>
+                            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <constraints>
+                                <constraint firstAttribute="trailing" secondItem="Mh8-u0-LCN" secondAttribute="trailing" constant="16" id="2si-xy-CTa"/>
+                                <constraint firstAttribute="bottom" secondItem="Mh8-u0-LCN" secondAttribute="bottom" constant="16" id="Jxo-k5-Gsw"/>
+                                <constraint firstItem="Mh8-u0-LCN" firstAttribute="top" secondItem="3xg-me-cwE" secondAttribute="top" constant="16" id="azv-eZ-u0Z"/>
+                                <constraint firstItem="Mh8-u0-LCN" firstAttribute="leading" secondItem="3xg-me-cwE" secondAttribute="leading" constant="16" id="h5v-QT-WL1"/>
+                            </constraints>
+                        </view>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="https::/expo.dev" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uZA-n9-0bf" userLabel="URL">
+                            <rect key="frame" x="16" y="104.5" width="382" height="17"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                            <color key="textColor" red="0.34509803919999998" green="0.37254901959999998" blue="0.41176470590000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                    </subviews>
+                    <color key="backgroundColor" red="0.97254901959999995" green="0.97254901959999995" blue="0.98039215690000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    <constraints>
+                        <constraint firstItem="uZA-n9-0bf" firstAttribute="leading" secondItem="fm7-WM-hm7" secondAttribute="leading" constant="16" id="Cui-bY-DKE"/>
+                        <constraint firstItem="fm7-WM-hm7" firstAttribute="trailing" secondItem="uZA-n9-0bf" secondAttribute="trailing" constant="16" id="FZ2-yM-eP7"/>
+                        <constraint firstItem="3xg-me-cwE" firstAttribute="leading" secondItem="fm7-WM-hm7" secondAttribute="leading" id="Ipc-jE-LO6"/>
+                        <constraint firstItem="3xg-me-cwE" firstAttribute="bottom" secondItem="fm7-WM-hm7" secondAttribute="bottom" id="NS7-5p-s0o"/>
+                        <constraint firstItem="iXc-4d-VpK" firstAttribute="leading" secondItem="fm7-WM-hm7" secondAttribute="leading" constant="16" id="TT1-8U-uOh"/>
+                        <constraint firstItem="r66-il-5GR" firstAttribute="leading" secondItem="fm7-WM-hm7" secondAttribute="leading" constant="16" id="TgA-n3-l2G"/>
+                        <constraint firstItem="fm7-WM-hm7" firstAttribute="trailing" secondItem="r66-il-5GR" secondAttribute="trailing" constant="16" id="Tq3-gM-vtx"/>
+                        <constraint firstItem="fm7-WM-hm7" firstAttribute="trailing" secondItem="iXc-4d-VpK" secondAttribute="trailing" constant="16" id="UGR-Hv-DvO"/>
+                        <constraint firstItem="r66-il-5GR" firstAttribute="top" secondItem="iXc-4d-VpK" secondAttribute="bottom" constant="16" id="Z0L-Hb-G0n"/>
+                        <constraint firstItem="iXc-4d-VpK" firstAttribute="top" secondItem="fm7-WM-hm7" secondAttribute="top" constant="24" id="a35-DY-9eM"/>
+                        <constraint firstItem="fm7-WM-hm7" firstAttribute="trailing" secondItem="3xg-me-cwE" secondAttribute="trailing" id="mbs-0b-6Ha"/>
+                        <constraint firstItem="uZA-n9-0bf" firstAttribute="top" secondItem="r66-il-5GR" secondAttribute="bottom" constant="16" id="rYw-Zp-Xid"/>
+                    </constraints>
+                    <viewLayoutGuide key="contentLayoutGuide" id="ipk-Hz-A80"/>
+                    <viewLayoutGuide key="frameLayoutGuide" id="fm7-WM-hm7"/>
+                </scrollView>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="ACV-IM-no8"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <point key="canvasLocation" x="131.8840579710145" y="118.52678571428571"/>
+        </view>
+    </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>


### PR DESCRIPTION
# Why

The error screen we show when a user can't load a project or it crashes on iOS is a bit spartan and outdated:

![IMG_5403](https://user-images.githubusercontent.com/12488826/173562841-95b38f6b-0422-4085-9035-76309d9ee6b4.PNG)

# How

- I set up a `.xib` based on @jonsamp's designs for a dev client error screen and hooked it up to the existing `EXErrorView` class
- I deleted a lot of the programmatic layout code because the view is using auto layout/constraints
- I added an image utility to make background fills for buttons compatible with older versions of iOS
- I split out the error title/detail messages properly for loading errors

![Screen Shot 2022-06-14 at 07 04 28](https://user-images.githubusercontent.com/12488826/173563454-3da107e1-d0b8-4cc1-9476-47ee202b9b00.png)

# Test Plan

I started a dev server with `expo-cli`, refreshed Expo Go to get the dev server to show up, then I killed the dev server and tried to open it in the app to get this error screen:

![IMG_5431](https://user-images.githubusercontent.com/12488826/173563652-9d78eafb-47ca-4a96-a795-837d3b2e6996.PNG)

# Reviewers

@jonsamp to sign off on the design
@tsapeta for code review
