### PR TITLE
[web-browser] Fix `service not registered` exception on Android

### DIFF
--- a/packages/expo-web-browser/CHANGELOG.md
+++ b/packages/expo-web-browser/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - Fixed `removeListener(): Method has been deprecated` warning. ([#17645](https://github.com/expo/expo/pull/17645) by [@barthap](https://github.com/barthap))
+- Fixed `service not registered` exception on Android.
 
 ### 💡 Others
 

--- a/packages/expo-web-browser/CHANGELOG.md
+++ b/packages/expo-web-browser/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 🐛 Bug fixes
 
 - Fixed `removeListener(): Method has been deprecated` warning. ([#17645](https://github.com/expo/expo/pull/17645) by [@barthap](https://github.com/barthap))
-- Fixed `service not registered` exception on Android.
+- Fixed `service not registered` exception on Android. ([#17855](https://github.com/expo/expo/pull/17855) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-web-browser/android/src/main/java/expo/modules/webbrowser/CustomTabsConnectionHelper.kt
+++ b/packages/expo-web-browser/android/src/main/java/expo/modules/webbrowser/CustomTabsConnectionHelper.kt
@@ -15,7 +15,7 @@ internal class CustomTabsConnectionHelper(
   private val sessionActions = DeferredClientActionsQueue<CustomTabsSession?>()
 
   // region lifecycle methods
-  fun destroy() = unbindService()
+  fun destroy() = clearConnection()
   // endregion
 
   // region Actual connection helper methods
@@ -34,7 +34,7 @@ internal class CustomTabsConnectionHelper(
 
   fun coolDown(packageName: String): Boolean {
     if (isConnectionStarted(packageName)) {
-      unbindService()
+      clearConnection()
       return true
     }
     return false
@@ -83,10 +83,6 @@ internal class CustomTabsConnectionHelper(
 
   private fun isConnectionStarted(packageName: String): Boolean {
     return packageName == currentPackageName
-  }
-
-  private fun unbindService() {
-    clearConnection()
   }
 
   private fun clearConnection() {

--- a/packages/expo-web-browser/android/src/main/java/expo/modules/webbrowser/CustomTabsConnectionHelper.kt
+++ b/packages/expo-web-browser/android/src/main/java/expo/modules/webbrowser/CustomTabsConnectionHelper.kt
@@ -86,9 +86,6 @@ internal class CustomTabsConnectionHelper(
   }
 
   private fun unbindService() {
-    if (currentPackageName != null) {
-      context.unbindService(this)
-    }
     clearConnection()
   }
 

--- a/packages/expo-web-browser/android/src/main/java/expo/modules/webbrowser/CustomTabsConnectionHelper.kt
+++ b/packages/expo-web-browser/android/src/main/java/expo/modules/webbrowser/CustomTabsConnectionHelper.kt
@@ -86,11 +86,17 @@ internal class CustomTabsConnectionHelper(
   }
 
   private fun unbindService() {
-    context.unbindService(this)
+    if (currentPackageName != null) {
+      context.unbindService(this)
+    }
     clearConnection()
   }
 
   private fun clearConnection() {
+    if (currentPackageName != null) {
+      context.unbindService(this)
+    }
+
     currentPackageName = null
     clientActions.clear()
     sessionActions.clear()


### PR DESCRIPTION
# Why

Fixes:
```
java.lang.IllegalArgumentException: Service not registered: expo.modules.webbrowser.CustomTabsConnectionHelper@2d945db
at android.app.LoadedApk.forgetServiceDispatcher(LoadedApk.java:1967)
at android.app.ContextImpl.unbindService(ContextImpl.java:2028)
at android.content.ContextWrapper.unbindService(ContextWrapper.java:856)
at android.content.ContextWrapper.unbindService(ContextWrapper.java:856)
at expo.modules.webbrowser.CustomTabsConnectionHelper.unbindService(CustomTabsConnectionHelper.kt:89)
at expo.modules.webbrowser.CustomTabsConnectionHelper.destroy(CustomTabsConnectionHelper.kt:18)
at expo.modules.webbrowser.WebBrowserModule$definition$lambda-11$$inlined$OnActivityDestroys$1.invoke(ModuleDefinitionBuilder.kt:556)
at expo.modules.webbrowser.WebBrowserModule$definition$lambda-11$$inlined$OnActivityDestroys$1.invoke(ModuleDefinitionBuilder.kt:486)
at expo.modules.kotlin.events.BasicEventListener.call(EventListener.kt:13)
at expo.modules.kotlin.ModuleHolder.post(ModuleHolder.kt:64)
at expo.modules.kotlin.ModuleRegistry.post(ModuleRegistry.kt:53)
at expo.modules.kotlin.AppContext.onHostDestroy(AppContext.kt:196)
at expo.modules.kotlin.ReactLifecycleDelegate.onHostDestroy(ReactLifecycleDelegate.kt:29)
at com.facebook.react.bridge.ReactContext.onHostDestroy(ReactContext.java:305)
at com.facebook.react.ReactInstanceManager.moveToBeforeCreateLifecycleState(ReactInstanceManager.java:811)
at com.facebook.react.ReactInstanceManager.destroy(ReactInstanceManager.java:748)
at com.facebook.react.ReactNativeHost.clear(ReactNativeHost.java:62)
at expo.modules.devlauncher.DevLauncherController.clearHost(DevLauncherController.kt:262)
at expo.modules.devlauncher.DevLauncherController.access$clearHost(DevLauncherController.kt:58)
at expo.modules.devlauncher.DevLauncherController$ensureHostWasCleared$1.invoke(DevLauncherController.kt:245)
at expo.modules.devlauncher.DevLauncherController$ensureHostWasCleared$1.invoke(DevLauncherController.kt:244)
at expo.modules.devlauncher.helpers.DevLauncherCoroutinesExtensionsKt$runBlockingOnMainThread$1.invokeSuspend(DevLauncherCoroutinesExtensions.kt:19)
at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
at android.os.Handler.handleCallback(Handler.java:938)
at android.os.Handler.dispatchMessage(Handler.java:99)
at android.os.Looper.loopOnce(Looper.java:233)
at android.os.Looper.loop(Looper.java:344)
at android.app.ActivityThread.main(ActivityThread.java:8184)
at java.lang.reflect.Method.invoke(Native Method)
at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:584)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1034)
```

# How

It's turned out that we can't unbind service that wasn't bound before. So, I've added a check to make sure that the service will be unbounded only if was previously bound. 

# Test Plan

- NCL