### PR TITLE
feat(cli): automatically enable `DEBUG` when `EXPO_DEBUG` is enabled

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Added `export:web` command. ([#17363](https://github.com/expo/expo/pull/17363) by [@EvanBacon](https://github.com/EvanBacon))
 - Bail out on missing web dependencies. ([#17448](https://github.com/expo/expo/pull/17448) by [@EvanBacon](https://github.com/EvanBacon))
 - Add info about using the `--clear` flag when the `babel.config.js` file changes during `expo start`. ([#17560](https://github.com/expo/expo/pull/17560) by [@EvanBacon](https://github.com/EvanBacon))
-- Automatically enable `DEBUG` when `EXPO_DEBUG` is enabled.
+- Automatically enable `DEBUG` when `EXPO_DEBUG` is enabled. ([#17856](https://github.com/expo/expo/pull/17856) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Added `export:web` command. ([#17363](https://github.com/expo/expo/pull/17363) by [@EvanBacon](https://github.com/EvanBacon))
 - Bail out on missing web dependencies. ([#17448](https://github.com/expo/expo/pull/17448) by [@EvanBacon](https://github.com/EvanBacon))
 - Add info about using the `--clear` flag when the `babel.config.js` file changes during `expo start`. ([#17560](https://github.com/expo/expo/pull/17560) by [@EvanBacon](https://github.com/EvanBacon))
+- Automatically enable `DEBUG` when `EXPO_DEBUG` is enabled.
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/bin/cli.ts
+++ b/packages/@expo/cli/bin/cli.ts
@@ -1,17 +1,14 @@
 #!/usr/bin/env node
 import arg from 'arg';
 import chalk from 'chalk';
+import Debug from 'debug';
 import { boolish } from 'getenv';
 
 // Setup before requiring `debug`.
 if (boolish('EXPO_DEBUG', false)) {
-  if (!process.env.DEBUG) {
-    process.env.DEBUG = '';
-  } else {
-    // Ensure we stack our debug calls on top of the existing debug calls.
-    process.env.DEBUG += ',';
-  }
-  process.env.DEBUG += 'expo:*';
+  Debug.enable('expo:*');
+} else if (Debug.enabled('expo:')) {
+  process.env.EXPO_DEBUG = '1';
 }
 
 const defaultCmd = 'start';

--- a/packages/@expo/cli/bin/cli.ts
+++ b/packages/@expo/cli/bin/cli.ts
@@ -1,6 +1,18 @@
 #!/usr/bin/env node
 import arg from 'arg';
 import chalk from 'chalk';
+import { boolish } from 'getenv';
+
+// Setup before requiring `debug`.
+if (boolish('EXPO_DEBUG', false)) {
+  if (!process.env.DEBUG) {
+    process.env.DEBUG = '';
+  } else {
+    // Ensure we stack our debug calls on top of the existing debug calls.
+    process.env.DEBUG += ',';
+  }
+  process.env.DEBUG += 'expo:*';
+}
 
 const defaultCmd = 'start';
 


### PR DESCRIPTION
# Why

We do something similar in `create-expo-app` to ensure `debug` logs are shown when the user opts-in to `EXPO_DEBUG`

