### PR TITLE
[dev-launcher][Android] Fix the error screen is empty

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed the error screen is sometimes empty on Android.
+
 ### 💡 Others
 
 ## 1.0.0 — 2022-06-09

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed the error screen is sometimes empty on Android.
+- Fixed the error screen is sometimes empty on Android. ([#17857](https://github.com/expo/expo/pull/17857) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/errors/DevLauncherErrorActivity.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/errors/DevLauncherErrorActivity.kt
@@ -28,8 +28,14 @@ class DevLauncherErrorActivity :
     binding.reloadButton.setOnClickListener { this.reload() }
 
     synchronized(DevLauncherErrorActivity) {
-      displayError(currentError!!)
-      currentError = null
+      val error = currentError
+      if (error != null) {
+        displayError(currentError!!)
+        currentError = null
+      } else {
+        finish()
+        return
+      }
     }
 
     setContentView(binding.root)
@@ -89,6 +95,11 @@ class DevLauncherErrorActivity :
   companion object {
     private var openedErrorActivity = WeakReference<DevLauncherErrorActivity?>(null)
     private var currentError: DevLauncherAppError? = null
+
+    fun isVisible(): Boolean {
+      val errorActivity = openedErrorActivity.get()
+      return !(errorActivity == null || errorActivity.isDestroyed || errorActivity.isFinishing)
+    }
 
     fun showErrorIfNotVisible(activity: Activity, error: DevLauncherAppError) {
       val errorActivity = openedErrorActivity.get()

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/errors/DevLauncherUncaughtExceptionHandler.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/errors/DevLauncherUncaughtExceptionHandler.kt
@@ -52,7 +52,7 @@ class DevLauncherUncaughtExceptionHandler(
   override fun uncaughtException(thread: Thread, exception: Throwable) {
     // The same exception can be reported multiple times.
     // We handle only the first one.
-    if (exceptionWasReported) {
+    if (exceptionWasReported || DevLauncherErrorActivity.isVisible()) {
       return
     }
 


### PR DESCRIPTION
# Why

Fixes the error screen is sometimes empty on Android.  

# How

I've added a couple of checks to ensure that the error is present when we want to open an error screen and also to check if only the one error activity is visible. Without those checks, the app may be stuck in the infinity cycle if the uncached error causes another one. Let's assume that the app crashes with the X exception. It's handled by our code, so we are starting to present an error view. However, the X exception is causing the Y exception shortly after it was thrown (on a different thread). The Y exception is also handled by our code. We save the exception to the static registry and present another error view. But that static registry may be cleaned up by the invocation of the first error view - the null ptr exception will be thrown in that case in the `DevLauncherErrorActivity.onCreate` method of the second error view instance. It leads to a situation where we're getting an infinite loop of exceptions - when we're trying to handle one, we introduce another because the register was cleared and we want to show an error view that requires a value there. 

# Test Plan

- bare-expo ✅