### PR TITLE
[sweet API][Kotlin] Add a way to pass `Map` as a payload to the `sendEvent` method

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/Module.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/Module.kt
@@ -26,11 +26,7 @@ abstract class Module : AppContextProvider {
   internal lateinit var coroutineScopeDelegate: Lazy<CoroutineScope>
   val coroutineScope get() = coroutineScopeDelegate.value
 
-  fun sendEvent(name: String) {
-    moduleEventEmitter?.emit(name, Bundle.EMPTY)
-  }
-
-  fun sendEvent(name: String, body: Bundle?) {
+  fun sendEvent(name: String, body: Bundle? = Bundle.EMPTY) {
     moduleEventEmitter?.emit(name, body)
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/Module.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/Module.kt
@@ -26,7 +26,15 @@ abstract class Module : AppContextProvider {
   internal lateinit var coroutineScopeDelegate: Lazy<CoroutineScope>
   val coroutineScope get() = coroutineScopeDelegate.value
 
+  fun sendEvent(name: String) {
+    moduleEventEmitter?.emit(name, Bundle.EMPTY)
+  }
+
   fun sendEvent(name: String, body: Bundle?) {
+    moduleEventEmitter?.emit(name, body)
+  }
+
+  fun sendEvent(name: String, body: Map<String, Any?>?) {
     moduleEventEmitter?.emit(name, body)
   }
 

--- a/packages/expo-modules-test-core/android/src/main/java/expo/modules/test/core/ModuleMock.kt
+++ b/packages/expo-modules-test-core/android/src/main/java/expo/modules/test/core/ModuleMock.kt
@@ -49,7 +49,7 @@ data class ModuleMock<TestInterfaceType : Any, ModuleType : Module>(
       // prepare module spy
       val moduleSpy = convertToSpy(module, recordPrivateCalls = true)
       every { moduleSpy getProperty "appContext" } returns appContext
-      every { moduleSpy.sendEvent(any(), any()) } answers { call ->
+      every { moduleSpy.sendEvent(any(), any<Bundle>()) } answers { call ->
         val (eventName, eventBody) = call.invocation.args
         eventEmitter.emit(eventName as String, eventBody as? Bundle)
       }


### PR DESCRIPTION
# Why

Adds a way to pass `Map<String, Any?>` as a payload to the `sendEvent` method.

# How

Add two new versions of `sendEvent` method:
- with empty payload 
- with `Map<String, Any?> as a payload 