### PR TITLE
[notifications] Fix issues from push notifications

### DIFF
--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -376,7 +376,7 @@ dependencies {
   api 'com.google.android.material:material:1.1.0'
 
   api 'com.google.firebase:firebase-core:17.2.3'
-  api 'com.google.firebase:firebase-messaging:21.1.0'
+  api 'com.google.firebase:firebase-messaging:22.0.0'
   api 'com.google.maps.android:android-maps-utils:0.5'
   // Remember to update DetachAppTemplate build.gradle if you add any excludes or transitive = false here!
 

--- a/android/expoview/src/main/java/host/exp/exponent/fcm/FcmRegistrationIntentService.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/fcm/FcmRegistrationIntentService.kt
@@ -2,7 +2,7 @@ package host.exp.exponent.fcm
 
 import android.content.Context
 import android.util.Log
-import com.google.firebase.iid.FirebaseInstanceId
+import com.google.firebase.messaging.FirebaseMessaging
 import host.exp.exponent.notifications.ExponentNotificationIntentService
 import host.exp.exponent.storage.ExponentSharedPreferences
 import java.io.IOException
@@ -31,16 +31,16 @@ class FcmRegistrationIntentService : ExponentNotificationIntentService(TAG) {
     private val TAG = FcmRegistrationIntentService::class.java.simpleName
 
     fun getTokenAndRegister(context: Context) {
-      FirebaseInstanceId.getInstance().instanceId.addOnSuccessListener { instanceIdResult ->
+      FirebaseMessaging.getInstance().token.addOnSuccessListener { instanceIdResult ->
         registerForeground(
           context,
-          instanceIdResult.token
+          instanceIdResult
         )
       }
         .addOnFailureListener { e ->
           Log.e(
             "FCM Device Token",
-            "Error calling getInstanceId " + e.localizedMessage
+            "Error calling getToken " + e.localizedMessage
           )
         }
     }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/notifications/NotificationsModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/notifications/NotificationsModule.java
@@ -11,7 +11,7 @@ import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
-import com.google.firebase.iid.FirebaseInstanceId;
+import com.google.firebase.messaging.FirebaseMessaging;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -114,7 +114,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
     }
     try {
       if (Constants.FCM_ENABLED) {
-        String token = FirebaseInstanceId.getInstance().getToken();
+        String token = FirebaseMessaging.getInstance().getToken().getResult();
         if (token == null) {
           promise.reject("FCM token has not been set");
         } else {

--- a/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/notifications/service/NotificationsService.kt
+++ b/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/notifications/service/NotificationsService.kt
@@ -509,7 +509,8 @@ open class NotificationsService : BroadcastReceiver() {
       val notification = intent.getParcelableExtra<Notification>(NOTIFICATION_KEY) ?: throw IllegalArgumentException("$NOTIFICATION_KEY not found in the intent extras.")
       val action = intent.getParcelableExtra<NotificationAction>(NOTIFICATION_ACTION_KEY) ?: throw IllegalArgumentException("$NOTIFICATION_ACTION_KEY not found in the intent extras.")
       val response = if (action is TextInputNotificationAction) {
-        TextInputNotificationResponse(action, notification, RemoteInput.getResultsFromIntent(intent).getString(USER_TEXT_RESPONSE_KEY))
+        val userText = action.placeholder ?: RemoteInput.getResultsFromIntent(intent).getString(USER_TEXT_RESPONSE_KEY)
+        TextInputNotificationResponse(action, notification, userText)
       } else {
         NotificationResponse(action, notification)
       }

--- a/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/notifications/service/delegates/ExpoHandlingDelegate.kt
+++ b/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/notifications/service/delegates/ExpoHandlingDelegate.kt
@@ -63,7 +63,9 @@ class ExpoHandlingDelegate(protected val context: Context) : HandlingDelegate {
     fun createPendingIntentForOpeningApp(context: Context, broadcastIntent: Intent, notificationResponse: NotificationResponse): PendingIntent {
       var intentFlags = PendingIntent.FLAG_UPDATE_CURRENT
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-        intentFlags = intentFlags or PendingIntent.FLAG_IMMUTABLE
+        // The intent may include `RemoteInput` from `TextInputNotificationAction`.
+        // For intent with RemoteInput, it should be mutable.
+        intentFlags = intentFlags or PendingIntent.FLAG_MUTABLE
       }
       val foregroundActivityIntent = getNotificationActionLauncher(context) ?: getMainActivityLauncher(context) ?: run {
         Log.w("expo-notifications", "No launch intent found for application. Interacting with the notification won't open the app. The implementation uses `getLaunchIntentForPackage` to find appropriate activity.")

--- a/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/host/exp/exponent/modules/api/notifications/NotificationsModule.java
+++ b/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/host/exp/exponent/modules/api/notifications/NotificationsModule.java
@@ -11,7 +11,7 @@ import abi43_0_0.com.facebook.react.bridge.ReactMethod;
 import abi43_0_0.com.facebook.react.bridge.ReadableArray;
 import abi43_0_0.com.facebook.react.bridge.ReadableMap;
 import abi43_0_0.com.facebook.react.bridge.WritableMap;
-import com.google.firebase.iid.FirebaseInstanceId;
+import com.google.firebase.messaging.FirebaseMessaging;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -114,7 +114,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
     }
     try {
       if (Constants.FCM_ENABLED) {
-        String token = FirebaseInstanceId.getInstance().getToken();
+        String token = FirebaseMessaging.getInstance().getToken().getResult();
         if (token == null) {
           promise.reject("FCM token has not been set");
         } else {

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/notifications/service/NotificationsService.kt
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/notifications/service/NotificationsService.kt
@@ -509,7 +509,8 @@ open class NotificationsService : BroadcastReceiver() {
       val notification = intent.getParcelableExtra<Notification>(NOTIFICATION_KEY) ?: throw IllegalArgumentException("$NOTIFICATION_KEY not found in the intent extras.")
       val action = intent.getParcelableExtra<NotificationAction>(NOTIFICATION_ACTION_KEY) ?: throw IllegalArgumentException("$NOTIFICATION_ACTION_KEY not found in the intent extras.")
       val response = if (action is TextInputNotificationAction) {
-        TextInputNotificationResponse(action, notification, RemoteInput.getResultsFromIntent(intent).getString(USER_TEXT_RESPONSE_KEY))
+        val userText = action.placeholder ?: RemoteInput.getResultsFromIntent(intent).getString(USER_TEXT_RESPONSE_KEY)
+        TextInputNotificationResponse(action, notification, userText)
       } else {
         NotificationResponse(action, notification)
       }

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/notifications/service/delegates/ExpoHandlingDelegate.kt
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/notifications/service/delegates/ExpoHandlingDelegate.kt
@@ -63,7 +63,9 @@ class ExpoHandlingDelegate(protected val context: Context) : HandlingDelegate {
     fun createPendingIntentForOpeningApp(context: Context, broadcastIntent: Intent, notificationResponse: NotificationResponse): PendingIntent {
       var intentFlags = PendingIntent.FLAG_UPDATE_CURRENT
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-        intentFlags = intentFlags or PendingIntent.FLAG_IMMUTABLE
+        // The intent may include `RemoteInput` from `TextInputNotificationAction`.
+        // For intent with RemoteInput, it should be mutable.
+        intentFlags = intentFlags or PendingIntent.FLAG_MUTABLE
       }
       val foregroundActivityIntent = getNotificationActionLauncher(context) ?: getMainActivityLauncher(context) ?: run {
         Log.w("expo-notifications", "No launch intent found for application. Interacting with the notification won't open the app. The implementation uses `getLaunchIntentForPackage` to find appropriate activity.")

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/host/exp/exponent/modules/api/notifications/NotificationsModule.java
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/host/exp/exponent/modules/api/notifications/NotificationsModule.java
@@ -11,7 +11,7 @@ import abi44_0_0.com.facebook.react.bridge.ReactMethod;
 import abi44_0_0.com.facebook.react.bridge.ReadableArray;
 import abi44_0_0.com.facebook.react.bridge.ReadableMap;
 import abi44_0_0.com.facebook.react.bridge.WritableMap;
-import com.google.firebase.iid.FirebaseInstanceId;
+import com.google.firebase.messaging.FirebaseMessaging;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -114,7 +114,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
     }
     try {
       if (Constants.FCM_ENABLED) {
-        String token = FirebaseInstanceId.getInstance().getToken();
+        String token = FirebaseMessaging.getInstance().getToken().getResult();
         if (token == null) {
           promise.reject("FCM token has not been set");
         } else {

--- a/android/versioned-abis/expoview-abi45_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi45_0_0/build.gradle
@@ -167,7 +167,7 @@ dependencies {
   api 'com.google.android.material:material:1.1.0'
 
   api 'com.google.firebase:firebase-core:17.2.3'
-  api 'com.google.firebase:firebase-messaging:21.1.0'
+  api 'com.google.firebase:firebase-messaging:22.0.0'
   api 'com.google.maps.android:android-maps-utils:0.5'
   // Remember to update DetachAppTemplate build.gradle if you add any excludes or transitive = false here!
 

--- a/android/versioned-abis/expoview-abi45_0_0/src/main/java/abi45_0_0/expo/modules/notifications/service/NotificationsService.kt
+++ b/android/versioned-abis/expoview-abi45_0_0/src/main/java/abi45_0_0/expo/modules/notifications/service/NotificationsService.kt
@@ -509,7 +509,8 @@ open class NotificationsService : BroadcastReceiver() {
       val notification = intent.getParcelableExtra<Notification>(NOTIFICATION_KEY) ?: throw IllegalArgumentException("$NOTIFICATION_KEY not found in the intent extras.")
       val action = intent.getParcelableExtra<NotificationAction>(NOTIFICATION_ACTION_KEY) ?: throw IllegalArgumentException("$NOTIFICATION_ACTION_KEY not found in the intent extras.")
       val response = if (action is TextInputNotificationAction) {
-        TextInputNotificationResponse(action, notification, RemoteInput.getResultsFromIntent(intent).getString(USER_TEXT_RESPONSE_KEY))
+        val userText = action.placeholder ?: RemoteInput.getResultsFromIntent(intent).getString(USER_TEXT_RESPONSE_KEY)
+        TextInputNotificationResponse(action, notification, userText)
       } else {
         NotificationResponse(action, notification)
       }

--- a/android/versioned-abis/expoview-abi45_0_0/src/main/java/abi45_0_0/expo/modules/notifications/service/delegates/ExpoHandlingDelegate.kt
+++ b/android/versioned-abis/expoview-abi45_0_0/src/main/java/abi45_0_0/expo/modules/notifications/service/delegates/ExpoHandlingDelegate.kt
@@ -63,7 +63,9 @@ class ExpoHandlingDelegate(protected val context: Context) : HandlingDelegate {
     fun createPendingIntentForOpeningApp(context: Context, broadcastIntent: Intent, notificationResponse: NotificationResponse): PendingIntent {
       var intentFlags = PendingIntent.FLAG_UPDATE_CURRENT
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-        intentFlags = intentFlags or PendingIntent.FLAG_IMMUTABLE
+        // The intent may include `RemoteInput` from `TextInputNotificationAction`.
+        // For intent with RemoteInput, it should be mutable.
+        intentFlags = intentFlags or PendingIntent.FLAG_MUTABLE
       }
       val foregroundActivityIntent = getNotificationActionLauncher(context) ?: getMainActivityLauncher(context) ?: run {
         Log.w("expo-notifications", "No launch intent found for application. Interacting with the notification won't open the app. The implementation uses `getLaunchIntentForPackage` to find appropriate activity.")

--- a/android/versioned-abis/expoview-abi45_0_0/src/main/java/abi45_0_0/host/exp/exponent/modules/api/notifications/NotificationsModule.java
+++ b/android/versioned-abis/expoview-abi45_0_0/src/main/java/abi45_0_0/host/exp/exponent/modules/api/notifications/NotificationsModule.java
@@ -11,7 +11,7 @@ import abi45_0_0.com.facebook.react.bridge.ReactMethod;
 import abi45_0_0.com.facebook.react.bridge.ReadableArray;
 import abi45_0_0.com.facebook.react.bridge.ReadableMap;
 import abi45_0_0.com.facebook.react.bridge.WritableMap;
-import com.google.firebase.iid.FirebaseInstanceId;
+import com.google.firebase.messaging.FirebaseMessaging;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -114,7 +114,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
     }
     try {
       if (Constants.FCM_ENABLED) {
-        String token = FirebaseInstanceId.getInstance().getToken();
+        String token = FirebaseMessaging.getInstance().getToken().getResult();
         if (token == null) {
           promise.reject("FCM token has not been set");
         } else {

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fix app not bringing to foreground when clicking notification on Android 12+. ([#17686](https://github.com/expo/expo/pull/17686) by [@kudo](https://github.com/kudo))
 - Fixed Android data-only FCM notifications (i.e. notifications without a title and message) appearing in the notification drawer ([#17707](https://github.com/expo/expo/pull/17707) by [@sausti](https://github.com/sausti))
 - Add support for unregistering from push notifications on Android and iOS ([#17812](https://github.com/expo/expo/pull/17812) by [@sausti](https://github.com/sausti))
+- Fix another Android 12+ trampoline issue from push notifications. ([#17871](https://github.com/expo/expo/pull/17871) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-notifications/android/build.gradle
+++ b/packages/expo-notifications/android/build.gradle
@@ -92,7 +92,7 @@ dependencies {
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
 
-  api 'com.google.firebase:firebase-messaging:21.1.0'
+  api 'com.google.firebase:firebase-messaging:22.0.0'
 
   api 'me.leolin:ShortcutBadger:1.1.22@aar'
 

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationsService.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationsService.kt
@@ -502,7 +502,8 @@ open class NotificationsService : BroadcastReceiver() {
       val notification = intent.getParcelableExtra<Notification>(NOTIFICATION_KEY) ?: throw IllegalArgumentException("$NOTIFICATION_KEY not found in the intent extras.")
       val action = intent.getParcelableExtra<NotificationAction>(NOTIFICATION_ACTION_KEY) ?: throw IllegalArgumentException("$NOTIFICATION_ACTION_KEY not found in the intent extras.")
       val response = if (action is TextInputNotificationAction) {
-        TextInputNotificationResponse(action, notification, RemoteInput.getResultsFromIntent(intent).getString(USER_TEXT_RESPONSE_KEY))
+        val userText = action.placeholder ?: RemoteInput.getResultsFromIntent(intent).getString(USER_TEXT_RESPONSE_KEY)
+        TextInputNotificationResponse(action, notification, userText)
       } else {
         NotificationResponse(action, notification)
       }

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoHandlingDelegate.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoHandlingDelegate.kt
@@ -63,7 +63,9 @@ class ExpoHandlingDelegate(protected val context: Context) : HandlingDelegate {
     fun createPendingIntentForOpeningApp(context: Context, broadcastIntent: Intent, notificationResponse: NotificationResponse): PendingIntent {
       var intentFlags = PendingIntent.FLAG_UPDATE_CURRENT
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-        intentFlags = intentFlags or PendingIntent.FLAG_IMMUTABLE
+        // The intent may include `RemoteInput` from `TextInputNotificationAction`.
+        // For intent with RemoteInput, it should be mutable.
+        intentFlags = intentFlags or PendingIntent.FLAG_MUTABLE
       }
       val foregroundActivityIntent = getNotificationActionLauncher(context) ?: getMainActivityLauncher(context) ?: run {
         Log.w("expo-notifications", "No launch intent found for application. Interacting with the notification won't open the app. The implementation uses `getLaunchIntentForPackage` to find appropriate activity.")


### PR DESCRIPTION
# Why

another fix for android 12 notification trampoline issue

# How

1. text input notification category is a broken regression from #17686 where to get the text input placeholder from `RemoteInput` has NPE. we can get the placeholder from `NotificationAction.placeholder` now.
2. update FCM version for https://github.com/expo/expo/pull/17686#issuecomment-1154700811. originally there was [some blocker from updating to cloud messaging 22.0 because from other firebase sdk versions](https://github.com/expo/expo/pull/15010#issuecomment-1079194697). thank to @bbarthec upgrade firebase sdks in sdk 45, we can now update cloud messaging successfully. checked to [the changelog](https://firebase.google.com/support/release-notes/android#messaging_v22-0-0), there're no other breaking changes. it should be safe to upgrade to the version.
3. there're still some `FirebaseInstanceId` in expo go, migrate these code as #15010

# Test Plan

bare-expo + NCL Notifications `send me a push notification` test case

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
