### PR TITLE
make jest-expo compatible with jest@28.x

### DIFF
--- a/packages/jest-expo/CHANGELOG.md
+++ b/packages/jest-expo/CHANGELOG.md
@@ -10,6 +10,6 @@
 
 ### 🐛 Bug fixes
 
-- Makes jest-expo compatible with `jest@28.x`
+- Makes jest-expo compatible with `jest@28.x` ([#17874](https://github.com/expo/expo/pull/17874) by [@madhums](https://github.com/madhums))
 
 ### 💡 Others

--- a/packages/jest-expo/CHANGELOG.md
+++ b/packages/jest-expo/CHANGELOG.md
@@ -8,8 +8,8 @@
 
 ### 🎉 New features
 
-### 🐛 Bug fixes
+- Make `jest-expo` compatible with Jest 28. ([#17874](https://github.com/expo/expo/pull/17874) by [@madhums](https://github.com/madhums))
 
-- Makes jest-expo compatible with `jest@28.x` ([#17874](https://github.com/expo/expo/pull/17874) by [@madhums](https://github.com/madhums))
+### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/jest-expo/CHANGELOG.md
+++ b/packages/jest-expo/CHANGELOG.md
@@ -10,4 +10,6 @@
 
 ### 🐛 Bug fixes
 
+- Makes jest-expo compatible with `jest@28.x`
+
 ### 💡 Others

--- a/packages/jest-expo/src/preset/assetFileTransformer.js
+++ b/packages/jest-expo/src/preset/assetFileTransformer.js
@@ -1,6 +1,6 @@
 const createCacheKeyFunction = require('@jest/create-cache-key-function').default;
 
 module.exports = {
-  process: (_, filename) => `module.exports = 1;`,
+  process: (_, filename) => ({ code: `module.exports = 1;` }),
   getCacheKey: createCacheKeyFunction([__filename]),
 };


### PR DESCRIPTION
As per latest jest (v28.1), process function should return an object or a promise resolving to an object.

https://jestjs.io/docs/upgrading-to-jest28#transformer

# Why

Jest throws the following error when using with jest < 28.x. 

```
 FAIL  __tests__/Main.test.js
  ● Test suite failed to run

    ● Invalid return value:
      `process()` or/and `processAsync()` method of code transformer found at
      "/Users/madhu/code/questionmark/questionmark-scanapp/node_modules/jest-expo/src/preset/assetFileTransformer.js"
      should return an object or a Promise resolving to an object. The object
      must have `code` property with a string of processed code.
      This error may be caused by a breaking change in Jest 28:
      https://jestjs.io/docs/upgrading-to-jest28#transformer
      Code Transformation Documentation:
      https://jestjs.io/docs/code-transformation


      at ScriptTransformer._buildTransformResult (node_modules/jest-runner/node_modules/@jest/transform/build/ScriptTransformer.js:507:15)
      at Object.require (node_modules/@react-navigation/elements/lib/commonjs/index.tsx:20:3)

```

This PR fixes the above issue and introduces compatibility with jest@28.1
