### PR TITLE
[menu] Fix integration between reanimated and gesture handler

### DIFF
--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -85,7 +85,7 @@
 - (NSArray<id<RCTBridgeModule>> *)extraModulesForBridge:(RCTBridge *)bridge
 {
   
-  NSMutableArray *modules = [[DevMenuVendoredModulesUtils vendoredModules] mutableCopy];
+  NSMutableArray *modules = [[DevMenuVendoredModulesUtils vendoredModules:bridge addReanimated2:FALSE] mutableCopy];
   
   [modules addObject:[RCTDevMenu new]];
   [modules addObject:[RCTAsyncLocalStorage new]];

--- a/packages/expo-dev-menu/ios/DevMenuAppInstance.swift
+++ b/packages/expo-dev-menu/ios/DevMenuAppInstance.swift
@@ -51,7 +51,7 @@ class DevMenuAppInstance: DevMenuBaseAppInstance, RCTBridgeDelegate {
 
   func extraModules(for bridge: RCTBridge!) -> [RCTBridgeModule]! {
     var modules: [RCTBridgeModule] = [DevMenuInternalModule(manager: manager)]
-    modules.append(contentsOf: DevMenuVendoredModulesUtils.vendoredModules())
+    modules.append(contentsOf: DevMenuVendoredModulesUtils.vendoredModules(bridge, addReanimated2: true))
     modules.append(DevMenuLoadingView.init())
     modules.append(DevMenuRCTDevSettings.init())
     return modules

--- a/packages/expo-dev-menu/ios/DevMenuVendoredModulesUtils.h
+++ b/packages/expo-dev-menu/ios/DevMenuVendoredModulesUtils.h
@@ -6,7 +6,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface DevMenuVendoredModulesUtils : NSObject
 
-+ (NSArray<id<RCTBridgeModule>> *)vendoredModules;
++ (NSArray<id<RCTBridgeModule>> *)vendoredModules:(RCTBridge *)bridge addReanimated2:(BOOL)addReanimated2;
 
 @end
 

--- a/packages/expo-dev-menu/ios/DevMenuVendoredModulesUtils.m
+++ b/packages/expo-dev-menu/ios/DevMenuVendoredModulesUtils.m
@@ -2,11 +2,14 @@
 
 #import "DevMenuVendoredModulesUtils.h"
 
+#import <React/RCTBridge+Private.h>
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Weverything"
 
 #if __has_include("DevMenuREAModule.h")
 #import "DevMenuREAModule.h"
+#import "DevMenuREAEventDispatcher.h"
 #endif
 
 #if __has_include("DevMenuRNGestureHandlerModule.h")
@@ -25,10 +28,16 @@
 
 @implementation DevMenuVendoredModulesUtils
 
-+ (NSArray<id<RCTBridgeModule>>*)vendoredModules
++ (NSArray<id<RCTBridgeModule>>*)vendoredModules:(RCTBridge *)bridge addReanimated2:(BOOL)addReanimated2
 {
   NSMutableArray<id<RCTBridgeModule>> *modules = [NSMutableArray new];
 #if __has_include("DevMenuREAModule.h")
+  if (addReanimated2) {
+    // Creates a `DevMenuREAEventDispatcher`
+    // It was moved from the `REAJSIExecutorRuntimeInstaller` function
+    [modules addObject:[DevMenuREAEventDispatcher new]];
+  }
+  
   [modules addObject:[DevMenuREAModule new]];
 #endif
 #if __has_include("DevMenuRNGestureHandlerModule.h")

--- a/packages/expo-dev-menu/vendored/react-native-reanimated/ios/native/REAInitializer.mm
+++ b/packages/expo-dev-menu/vendored/react-native-reanimated/ios/native/REAInitializer.mm
@@ -1,5 +1,10 @@
 #import "REAInitializer.h"
 
+
+#if __has_include("DevMenuRNGestureHandlerModule.h")
+#import "DevMenuRNGestureHandlerModule.h"
+#endif
+
 @interface RCTEventDispatcher(Reanimated)
 
 - (void)setBridge:(RCTBridge*)bridge;
@@ -15,8 +20,9 @@ JSIExecutor::RuntimeInstaller REAJSIExecutorRuntimeInstaller(
     RCTBridge* bridge,
     JSIExecutor::RuntimeInstaller runtimeInstallerToWrap)
 {
-    [bridge moduleForClass:[RCTEventDispatcher class]];
-    RCTEventDispatcher *eventDispatcher = [DevMenuREAEventDispatcher new];
+    // The creation of the DevMenuREAEventDispatcher was moved to the DevMenuVendoredModulesUtils.vendoredModules
+    // because it has to be set up before creating the gesture handler module.
+    RCTEventDispatcher *eventDispatcher = bridge.eventDispatcher;
 #if RNVERSION >= 66
     RCTCallableJSModules *callableJSModules = [RCTCallableJSModules new];
     [bridge setValue:callableJSModules forKey:@"_callableJSModules"];
@@ -27,7 +33,6 @@ JSIExecutor::RuntimeInstaller REAJSIExecutorRuntimeInstaller(
 #else
     [eventDispatcher setBridge:bridge];
 #endif
-    [bridge updateModuleWithInstance:eventDispatcher];
     _devmenu_bridge_reanimated = bridge;
     const auto runtimeInstaller = [bridge, runtimeInstallerToWrap](facebook::jsi::Runtime &runtime) {
       if (!bridge) {

--- a/tools/src/commands/Vendor.ts
+++ b/tools/src/commands/Vendor.ts
@@ -26,6 +26,9 @@ const CONFIGURATIONS = {
 };
 
 function getReanimatedPipe() {
+  console.warn(
+    'You have to adjust the installation steps of the react-native-reanimated to work well with the react-native-gesture-handler. For more information go to the https://github.com/expo/expo/pull/17878'
+  );
   const destination = 'packages/expo-dev-menu/vendored/react-native-reanimated';
 
   // prettier-ignore


### PR DESCRIPTION
# Why

Fixes integration between reanimated and gesture handler. For instance, `useAnimatedGestureHandler` wasn't working in the `dev-menu`. 

# How

It turned out that we have a different module installation order. In the bare RN app, the reanimated will be installed before the gesture handler. Unfortunately, in the dev menu, the gesture handler will be installed first, cause we're using the `extraModulesForBridge` to attach vendored modules. That breaks the integration between rea and GH. GH requires reanimated to be installed in advance. 

# Test Plan

- bare-expo ✅
