### PR TITLE
[docs] Add EAS Metadata docs

### DIFF
--- a/docs/constants/navigation-deprecated.js
+++ b/docs/constants/navigation-deprecated.js
@@ -329,6 +329,17 @@ const eas = [
     ],
     { expanded: true }
   ),
+  makeSection(
+    'EAS Metadata',
+    [
+      makeGroup('EAS Metadata', [
+        makePage('eas-metadata/introduction.md'),
+        makePage('eas-metadata/getting-started.md'),
+        makePage('eas-metadata/store-json.md'),
+      ]),
+    ],
+    { expanded: true }
+  ),
 ];
 
 const preview = [

--- a/docs/constants/navigation-deprecated.js
+++ b/docs/constants/navigation-deprecated.js
@@ -14,7 +14,15 @@ const PAGES_DIR = path.resolve(__dirname, '../pages');
 /** Manual list of directories to pull in to the getting started tutorial */
 const startingDirectories = ['introduction', 'get-started', 'tutorial', 'next-steps'];
 /** Manual list of directories to categorize as "EAS content" */
-const easDirectories = ['eas', 'build', 'app-signing', 'build-reference', 'submit', 'eas-update'];
+const easDirectories = [
+  'eas',
+  'build',
+  'app-signing',
+  'build-reference',
+  'submit',
+  'eas-update',
+  'eas-metadata',
+];
 /** Manual list of directories to categorize as "Archive" */
 const archiveDirectores = ['archive'];
 /** Private preview section which isn't linked in the documentation */
@@ -335,7 +343,7 @@ const eas = [
       makeGroup('EAS Metadata', [
         makePage('eas-metadata/introduction.md'),
         makePage('eas-metadata/getting-started.md'),
-        makePage('eas-metadata/store-json.md'),
+        // makePage('eas-metadata/store-json.md'), Disabled due to missing config overview
       ]),
     ],
     { expanded: true }

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -351,6 +351,15 @@ const archive = [
       expanded: true,
     }
   ),
+  makeSection(
+    'EAS Metadata',
+    [
+      makePage('eas-metadata/introduction.md'),
+      makePage('eas-metadata/getting-started.md'),
+      makePage('eas-metadata/store-json.md'),
+    ],
+    { expanded: true }
+  ),
 ];
 
 const featurePreview = [];

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -14,7 +14,15 @@ const PAGES_DIR = path.resolve(__dirname, '../pages');
 /** Manual list of directories to pull in to the getting started tutorial */
 const startingDirectories = ['introduction', 'get-started', 'tutorial', 'next-steps'];
 /** Manual list of directories to categorize as "EAS content" */
-const easDirectories = ['eas', 'build', 'app-signing', 'build-reference', 'submit'];
+const easDirectories = [
+  'eas',
+  'build',
+  'app-signing',
+  'build-reference',
+  'submit',
+  'eas-update',
+  'eas-metadata',
+];
 /** Manual list of directories to categorize as "Archive content" */
 const archiveDirectories = ['archive'];
 /** Private preview section which isn't linked in the documentation */
@@ -356,7 +364,7 @@ const archive = [
     [
       makePage('eas-metadata/introduction.md'),
       makePage('eas-metadata/getting-started.md'),
-      makePage('eas-metadata/store-json.md'),
+      // makePage('eas-metadata/store-json.md'), Disabled due to missing config overview
     ],
     { expanded: true }
   ),

--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -116,6 +116,8 @@ redirects[clients/upgrading]=development/upgrading/
 redirects[modules]=modules/overview/
 redirects[module-api]=modules/module-api/
 redirects[module-config]=modules/module-config/
+# EAS Metadata
+redirects[eas-metadata]=eas-metadata/introduction/
 
 redirects[introduction/walkthrough]=tutorial/planning/
 

--- a/docs/pages/eas-metadata/getting-started.md
+++ b/docs/pages/eas-metadata/getting-started.md
@@ -1,0 +1,70 @@
+---
+title: Getting started with EAS Metadata
+sidebar_title: Getting started
+---
+
+import { Terminal } from '~/ui/components/Snippet';
+
+> ⚠️ EAS Metadata is in beta and subject to breaking changes.
+
+EAS Metadata helps you prepare your app for review in the app stores and helps you prevent common pitfalls that often could lead to an app rejection.
+
+## Prerequisites
+
+EAS Metadata is available starting from EAS CLI >= 0.54.0, and _only supports the App Store_.
+
+## Create a local store configuration
+
+We first need to create our local **store.config.json** to get started. This file keeps track of all the information for the app stores. If you have an existing app in the stores, you can generate the configuration file by running:
+
+<Terminal cmd={['$ eas metadata:pull']} />
+
+If you don't have an app in the stores, you can create the **store.config.json** manually.
+
+```json
+{
+  "configVersion": 0,
+  "apple": {
+    "info": {
+      "en-US": {
+        "title": "Awesome App",
+        "subtitle": "Your self-made awesome app",
+        "description": "The most awesome app you've ever seen",
+        "keywords": ["awesome", "app"],
+        "marketingUrl": "https://example.com/en/promo",
+        "supportUrl": "https://example.com/en/support",
+        "privacyPolicyUrl": "https://example.com/en/privacy"
+      }
+    }
+  }
+}
+```
+
+> By default EAS Metadata will use the **store.config.json** file in your project. You can change the name and location of the file by [configuring the `metadataPath` on the EAS Submit](../submit/eas-json.md#metadatapath) profile.
+
+## Update the local store configuration
+
+Now it's time to edit the **store.config.json** file and customize it to your app needs. You can find all available options for the **store.config.json** in the [store configuration reference](./store-json.md).
+
+## Upload a new version of the app
+
+To create a new app version in the stores, you must upload a new binary. We can do this by running:
+
+<Terminal cmd={[
+  '# Build and deploy to the stores',
+  '$ eas build --auto-submit',
+  '# Or deploy a previous build to the stores',
+  '$ eas submit',
+]} />
+
+After the binary is submitted and processed, we can start syncing the local store configuration.
+
+## Sync the local store configuration
+
+When the **store.config.json** is up to date, we can start syncing the app stores with the local store configuration:
+
+<Terminal cmd={['$ eas metadata:push']} />
+
+## Next
+
+You can explore all available configuration options in the [store configuration reference](./store-json.md).

--- a/docs/pages/eas-metadata/getting-started.md
+++ b/docs/pages/eas-metadata/getting-started.md
@@ -13,7 +13,7 @@ EAS Metadata helps you prepare your app for review by uploading most of the requ
 
 EAS Metadata is available starting from EAS CLI >= 0.54.0, and _currently_ only supports the Apple App Store.
 
-If you are using vscode, also make sure to [install the Expo plugin](https://github.com/expo/vscode-expo) for **store.config.json** auto-completion.
+If you are using VSCode, make sure to [install the Expo plugin](https://github.com/expo/vscode-expo) for **store.config.json** auto-completion.
 
 ## Create the store config
 
@@ -46,7 +46,7 @@ If you don't have an app in the stores, EAS Metadata can't pull that information
 
 ## Update the store config
 
-Now it's time to edit the **store.config.json** file and customize it to your app needs. A complete overview of what can be defined is coming soon. In the meantime, you can use the [vscode Expo plugin](https://github.com/expo/vscode-expo) and use the auto-completion.
+Now it's time to edit the **store.config.json** file and customize it to your app needs. A complete overview of what can be defined is coming soon. In the meantime, you can use the [VSCode Expo plugin](https://github.com/expo/vscode-expo) and use the auto-completion.
 <!-- Disabled due to missing config overview
 You can find all available options for the **store.config.json** in the [store configuration reference](./store-json.md). -->
 

--- a/docs/pages/eas-metadata/getting-started.md
+++ b/docs/pages/eas-metadata/getting-started.md
@@ -13,7 +13,7 @@ EAS Metadata helps you prepare your app for review by uploading most of the requ
 
 EAS Metadata is available starting from EAS CLI >= 0.54.0, and _currently_ only supports the Apple App Store.
 
-If you are using VSCode, make sure to [install the Expo plugin](https://github.com/expo/vscode-expo) for **store.config.json** auto-completion.
+If you are using VS Code, make sure to [install the Expo plugin](https://github.com/expo/vscode-expo) for **store.config.json** auto-completion.
 
 ## Create the store config
 
@@ -46,7 +46,7 @@ If you don't have an app in the stores, EAS Metadata can't pull that information
 
 ## Update the store config
 
-Now it's time to edit the **store.config.json** file and customize it to your app needs. A complete overview of what can be defined is coming soon. In the meantime, you can use the [VSCode Expo plugin](https://github.com/expo/vscode-expo) and use the auto-completion.
+Now it's time to edit the **store.config.json** file and customize it to your app needs. A complete overview of what can be defined is coming soon. In the meantime, you can use the [VS Code Expo plugin](https://github.com/expo/vscode-expo) and use the auto-completion.
 <!-- Disabled due to missing config overview
 You can find all available options for the **store.config.json** in the [store configuration reference](./store-json.md). -->
 

--- a/docs/pages/eas-metadata/getting-started.md
+++ b/docs/pages/eas-metadata/getting-started.md
@@ -52,13 +52,13 @@ You can find all available options for the **store.config.json** in the [store c
 
 ## Upload a new app version
 
-Before we can upload the **store.config.json**, you must upload a new binary of your app. You can [read more about uploading new binaries to stores here.](../distribution/uploading-apps.md).
+Before you can upload the **store.config.json**, you must upload a new binary of your app. [Read more about uploading new binaries to stores](../distribution/uploading-apps.md).
 
 After the binary is submitted and processed, we can upload the **store.config.json** to the app stores.
 
 ## Upload the store config
 
-When you are happy with the **store.config.json** settings, we can start syncing that data to the app stores. All we need to do is one command:
+When you are happy with the **store.config.json** settings, start syncing that data to the app stores. All you need to do is run the following command:
 
 <Terminal cmd={['$ eas metadata:push']} />
 

--- a/docs/pages/eas-metadata/getting-started.md
+++ b/docs/pages/eas-metadata/getting-started.md
@@ -7,19 +7,19 @@ import { Terminal } from '~/ui/components/Snippet';
 
 > ⚠️ EAS Metadata is in beta and subject to breaking changes.
 
-EAS Metadata helps you prepare your app for review in the app stores and helps you prevent common pitfalls that often could lead to an app rejection.
+EAS Metadata helps you prepare your app for review in the app stores and helps you prevent common pitfalls that may lead to a rejected app submission.
 
 ## Prerequisites
 
-EAS Metadata is available starting from EAS CLI >= 0.54.0, and _only supports the App Store_.
+EAS Metadata is available starting from EAS CLI >= 0.54.0, and _currently_ only supports the Apple App Store.
 
 ## Create a local store configuration
 
-We first need to create our local **store.config.json** to get started. This file keeps track of all the information for the app stores. If you have an existing app in the stores, you can generate the configuration file by running:
+To get started, create a **store.config.json** in your project root directory. This file keeps track of all the information for the app stores. If you have an existing app in the stores, you can generate the configuration file by running:
 
 <Terminal cmd={['$ eas metadata:pull']} />
 
-If you don't have an app in the stores, you can create the **store.config.json** manually.
+If you don't have an app in the stores there will not be any metadata to pull, and you can initialize the **store.config.json** manually.
 
 ```json
 {
@@ -40,7 +40,7 @@ If you don't have an app in the stores, you can create the **store.config.json**
 }
 ```
 
-> By default EAS Metadata will use the **store.config.json** file in your project. You can change the name and location of the file by [configuring the `metadataPath` on the EAS Submit](../submit/eas-json.md#metadatapath) profile.
+> EAS Metadata will use the **store.config.json** file in the project root by default; you can change the name and location of the file by [configuring the `metadataPath` on the EAS Submit profile](../submit/eas-json.md#metadatapath).
 
 ## Update the local store configuration
 

--- a/docs/pages/eas-metadata/getting-started.md
+++ b/docs/pages/eas-metadata/getting-started.md
@@ -7,19 +7,21 @@ import { Terminal } from '~/ui/components/Snippet';
 
 > ⚠️ EAS Metadata is in beta and subject to breaking changes.
 
-EAS Metadata helps you prepare your app for review in the app stores and helps you prevent common pitfalls that may lead to a rejected app submission.
+EAS Metadata helps you prepare your app for review by uploading most of the required app information using a simple JSON file. It also helps you prevent common pitfalls that may lead to a rejected app submission.
 
 ## Prerequisites
 
 EAS Metadata is available starting from EAS CLI >= 0.54.0, and _currently_ only supports the Apple App Store.
 
-## Create a local store configuration
+If you are using vscode, also make sure to [install the Expo plugin](https://github.com/expo/vscode-expo) for **store.config.json** auto-completion.
 
-To get started, create a **store.config.json** in your project root directory. This file keeps track of all the information for the app stores. If you have an existing app in the stores, you can generate the configuration file by running:
+## Create the store config
+
+Let's start by creating our **store.config.json** file in the root directory of your project. This file holds all the information you want to upload to the app stores. If you have an existing app in the stores, you can generate the config file by running:
 
 <Terminal cmd={['$ eas metadata:pull']} />
 
-If you don't have an app in the stores there will not be any metadata to pull, and you can initialize the **store.config.json** manually.
+If you don't have an app in the stores, EAS Metadata can't pull that information. You can create a new **store.config.json** file manually instead.
 
 ```json
 {
@@ -40,31 +42,30 @@ If you don't have an app in the stores there will not be any metadata to pull, a
 }
 ```
 
-> EAS Metadata will use the **store.config.json** file in the project root by default; you can change the name and location of the file by [configuring the `metadataPath` on the EAS Submit profile](../submit/eas-json.md#metadatapath).
+> EAS Metadata will use the **store.config.json** file name in your project root by default; you can change the name and location of the file by [configuring the `metadataPath` on the EAS Submit profile](../submit/eas-json.md#metadatapath).
 
-## Update the local store configuration
+## Update the store config
 
-Now it's time to edit the **store.config.json** file and customize it to your app needs. You can find all available options for the **store.config.json** in the [store configuration reference](./store-json.md).
+Now it's time to edit the **store.config.json** file and customize it to your app needs. A complete overview of what can be defined is coming soon. In the meantime, you can use the [vscode Expo plugin](https://github.com/expo/vscode-expo) and use the auto-completion.
+<!-- Disabled due to missing config overview
+You can find all available options for the **store.config.json** in the [store configuration reference](./store-json.md). -->
 
-## Upload a new version of the app
+## Upload a new app version
 
-To create a new app version in the stores, you must upload a new binary. We can do this by running:
+Before we can upload the **store.config.json**, you must upload a new binary of your app. You can [read more about uploading new binaries to stores here.](../distribution/uploading-apps.md).
 
-<Terminal cmd={[
-  '# Build and deploy to the stores',
-  '$ eas build --auto-submit',
-  '# Or deploy a previous build to the stores',
-  '$ eas submit',
-]} />
+After the binary is submitted and processed, we can upload the **store.config.json** to the app stores.
 
-After the binary is submitted and processed, we can start syncing the local store configuration.
+## Upload the store config
 
-## Sync the local store configuration
-
-When the **store.config.json** is up to date, we can start syncing the app stores with the local store configuration:
+When you are happy with the **store.config.json** settings, we can start syncing that data to the app stores. All we need to do is one command:
 
 <Terminal cmd={['$ eas metadata:push']} />
 
+If EAS Metadata runs into any issues with the **store.config.json**, it will warn you when running this command. When the errors are minor, it will still try to upload the rest of the data. After correcting the **store.config.json**, you can rerun the same command to retry uploading the previously failed items.
+
+<!-- Disabled due to missing config overview
 ## Next
 
 You can explore all available configuration options in the [store configuration reference](./store-json.md).
+-->

--- a/docs/pages/eas-metadata/index.js
+++ b/docs/pages/eas-metadata/index.js
@@ -1,0 +1,3 @@
+import redirect from '~/common/redirect';
+
+export default redirect('/eas-metadata/introduction');

--- a/docs/pages/eas-metadata/introduction.md
+++ b/docs/pages/eas-metadata/introduction.md
@@ -1,0 +1,19 @@
+---
+title: EAS Metadata
+sidebar_title: Introduction
+hideTOC: true
+---
+
+import { BoxLink } from '~/ui/components/BoxLink';
+
+> ⚠️ EAS Metadata is in beta and subject to breaking changes.
+
+**EAS Metadata** is a service to help you provide all necessary information to the stores and get your app published.
+
+To get your app into the hands of your users, you have to publish the app on multiple app stores. During this process, you'll have to answer questions about complex topics that often don't apply to your app. After submitting the information, you can start the lengthy review process. If the reviewer finds any issues in the information you sent, you'll have to restart the review process, making the feedback loop worse.
+
+EAS Metadata makes this easier by allowing users to configure the app store information locally. After this store configuration is ready, you can sync the app stores using `eas metadata:push`. EAS Metadata does not only get the information into the stores; it also tries to find common pitfalls that could cause an app rejection. It does all this before sending it into the app stores, saving you valuable time to spend on your project.
+
+### Get started
+
+<BoxLink title="Getting started" href="/eas-metadata/getting-started" description="Configure EAS Metadata from scratch, or use an existing app to generate the local store configuration." />

--- a/docs/pages/eas-metadata/introduction.md
+++ b/docs/pages/eas-metadata/introduction.md
@@ -16,4 +16,4 @@ EAS Metadata makes this easier by allowing users to configure the app store info
 
 ### Get started
 
-<BoxLink title="Getting started" href="/eas-metadata/getting-started" description="Configure EAS Metadata from scratch, or use an existing app to generate the local store configuration." />
+<BoxLink title="Getting started" href="/eas-metadata/getting-started" description="Configure EAS Metadata from scratch, or use an existing app to generate the store config." />

--- a/docs/pages/eas-metadata/introduction.md
+++ b/docs/pages/eas-metadata/introduction.md
@@ -10,7 +10,7 @@ import { BoxLink } from '~/ui/components/BoxLink';
 
 **EAS Metadata** is a service to help you provide all necessary information to the stores and get your app published.
 
-To get your app into the hands of your users, you have to publish the app on multiple app stores. During this process, you'll have to answer questions about complex topics that often don't apply to your app. After submitting the information, you can start the lengthy review process. If the reviewer finds any issues in the information you sent, you'll have to restart the review process, making the feedback loop worse.
+To get your app into the hands of your users, you have to publish the app on multiple app stores. During this process, you'll have to answer questions about complex topics that often don't apply to your app. After submitting the information, you can start the lengthy review process. If the reviewer finds any issues in the information you sent, you'll have to restart the review process.
 
 EAS Metadata makes this easier by allowing users to configure the app store information locally. After this store configuration is ready, you can sync the app stores using `eas metadata:push`. EAS Metadata does not only get the information into the stores; it also tries to find common pitfalls that could cause an app rejection. It does all this before sending it into the app stores, saving you valuable time to spend on your project.
 

--- a/docs/pages/eas-metadata/store-json.md
+++ b/docs/pages/eas-metadata/store-json.md
@@ -1,0 +1,6 @@
+---
+title: EAS Metadata store.config.json schema
+sidebar_title: store configuration
+---
+
+<!-- TODO -->

--- a/docs/pages/eas-metadata/store-json.md
+++ b/docs/pages/eas-metadata/store-json.md
@@ -1,6 +1,0 @@
----
-title: EAS Metadata store.config.json schema
-sidebar_title: store configuration
----
-
-<!-- TODO -->

--- a/docs/pages/eas/index.md
+++ b/docs/pages/eas/index.md
@@ -15,3 +15,5 @@ Read the full pitch at [expo.dev/eas](https://expo.dev/eas), or follow the links
 <BoxLink title="EAS Submit" description="Upload your app to the Apple App Store or Google Play Store from the cloud with one CLI command. Learn more." href="/submit/introduction" />
 
 <BoxLink title="EAS Update" description="Address small bugs and push quick fixes directly to end-users. Learn more." href="/eas-update/introduction" />
+
+<BoxLink title="EAS Metadata (In Preview)" description="Upload all app store information required to get your app published. Learn more." href="/eas-metadata/introduction" />

--- a/docs/scripts/schemas/unversioned/eas-json-submit-ios-schema.js
+++ b/docs/scripts/schemas/unversioned/eas-json-submit-ios-schema.js
@@ -71,4 +71,11 @@ export default [
       'The Bundle identifier that will be used when accessing submit credentials managed by Expo, it does not have any effect if you are using local credentials. In most cases this value will be autodetected, but if you have multiple Xcode schemes and targets, this value might be necessary.',
     ],
   },
+  {
+    name: 'metadataPath',
+    type: 'string',
+    description: [
+      'The path to your store configuration file. [Learn more](https://docs.expo.dev/eas-metadata/introduction/).'
+    ],
+  }
 ];


### PR DESCRIPTION
# Why

This is a draft to document the usage of EAS Metadata

# How

Added docs

# Test Plan

See docs: http://localhost:3002/eas-metadata/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
