### PR TITLE
fix(cli): update @types/react and @types/react-native check to be compatible with new exports field

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Add correct packages (`expo-splash-screen`) and drop incorrect required packages (`react-native-unimodules`, `expo-updates`) in prebuild. ([#17447](https://github.com/expo/expo/pull/17447) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix tunnel on web breaking native. ([#17666](https://github.com/expo/expo/pull/17666) by [@EvanBacon](https://github.com/EvanBacon))
 - Add no-op `--experimental-bundle` flag to `expo export`. ([#17886](https://github.com/expo/expo/pull/17886) by [@EvanBacon](https://github.com/EvanBacon))
+- Fix required package checks for @types/react to work with new exports field ([#17880](https://github.com/expo/expo/pull/17880) by [@jaysoo](https://github.com/jaysoo))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/doctor/typescript/TypeScriptProjectPrerequisite.ts
+++ b/packages/@expo/cli/src/start/doctor/typescript/TypeScriptProjectPrerequisite.ts
@@ -74,8 +74,8 @@ export class TypeScriptProjectPrerequisite extends ProjectPrerequisite {
           // use typescript/package.json to skip node module cache issues when the user installs
           // the package and attempts to resolve the module in the same process.
           { file: 'typescript/package.json', pkg: 'typescript' },
-          { file: '@types/react/index.d.ts', pkg: '@types/react' },
-          { file: '@types/react-native/index.d.ts', pkg: '@types/react-native' },
+          { file: '@types/react/package.json', pkg: '@types/react' },
+          { file: '@types/react-native/package.json', pkg: '@types/react-native' },
         ],
       });
     } catch (error) {


### PR DESCRIPTION
# Why

The current check for `@types/react/index.d.ts` will not work in latest version of `@types/react` since it now contains an `exports` field in `package.json`. Only paths in `exports` are valid for package resolution.

You'll see this message if you try to update `@types/react`.

```
It looks like you're trying to use TypeScript but don't have the required dependencies installed. Would you like to install @types/react?
```

# How

Instead of using `@types/react/index.d.ts`, use `@types/react/package.json` (which is exported). Also change `@types/react-native/index.d.ts` to `@types/react-native/package.json`. The `package.json` path should exist for all packages (at least if they want to be compatible with common tooling.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Try updating `@types/react` to latest (with `exports` field in `package.json`) and make sure the warning does not show up.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
