### PR TITLE
feat(cli): added migration warning for old commands

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -15,7 +15,7 @@
 - Bail out on missing web dependencies. ([#17448](https://github.com/expo/expo/pull/17448) by [@EvanBacon](https://github.com/EvanBacon))
 - Add info about using the `--clear` flag when the `babel.config.js` file changes during `expo start`. ([#17560](https://github.com/expo/expo/pull/17560) by [@EvanBacon](https://github.com/EvanBacon))
 - Automatically enable `DEBUG` when `EXPO_DEBUG` is enabled. ([#17856](https://github.com/expo/expo/pull/17856) by [@EvanBacon](https://github.com/EvanBacon))
-- add migration warning for old commands.
+- add migration warning for old commands. ([#17882](https://github.com/expo/expo/pull/17882) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Bail out on missing web dependencies. ([#17448](https://github.com/expo/expo/pull/17448) by [@EvanBacon](https://github.com/EvanBacon))
 - Add info about using the `--clear` flag when the `babel.config.js` file changes during `expo start`. ([#17560](https://github.com/expo/expo/pull/17560) by [@EvanBacon](https://github.com/EvanBacon))
 - Automatically enable `DEBUG` when `EXPO_DEBUG` is enabled. ([#17856](https://github.com/expo/expo/pull/17856) by [@EvanBacon](https://github.com/EvanBacon))
+- add migration warning for old commands.
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/bin/cli.ts
+++ b/packages/@expo/cli/bin/cli.ts
@@ -98,6 +98,69 @@ if (!isSubcommand && args['--help']) {
   process.exit(0);
 }
 
+// NOTE(EvanBacon): Squat some directory names to help with migration,
+// users can still use folders named "send" or "eject" by using the fully qualified `npx expo start ./send`.
+if (!isSubcommand) {
+  const migrationMap: Record<string, string> = {
+    init: 'npx create-expo-app',
+    eject: 'npx expo prebuild',
+    'start:web': 'npx expo start --web',
+    'build:ios': 'eas build -p ios',
+    'build:android': 'eas build -p android',
+    'client:install:ios': 'npx expo start --ios',
+    'client:install:android': 'npx expo start --android',
+    doctor: 'expo doctor',
+    upgrade: 'expo upgrade',
+    'customize:web': 'npx expo customize',
+
+    publish: 'eas update',
+    'publish:set': 'eas update',
+    'publish:rollback': 'eas update',
+    'publish:history': 'eas update',
+    'publish:details': 'eas update',
+
+    'build:web': 'npx expo export',
+
+    'credentials:manager': `eas credentials`,
+    'fetch:ios:certs': `eas credentials`,
+    'fetch:android:keystore': `eas credentials`,
+    'fetch:android:hashes': `eas credentials`,
+    'fetch:android:upload-cert': `eas credentials`,
+    'push:android:upload': `eas credentials`,
+    'push:android:show': `eas credentials`,
+    'push:android:clear': `eas credentials`,
+    url: `eas build:list`,
+    'url:ipa': `eas build:list`,
+    'url:apk': `eas build:list`,
+    webhooks: `eas webhook`,
+    'webhooks:add': `eas webhook:create`,
+    'webhooks:remove': `eas webhook:delete`,
+    'webhooks:update': `eas webhook:update`,
+
+    'build:status': `eas build:list`,
+    'upload:android': `eas submit -p android`,
+    'upload:ios': `eas submit -p ios`,
+  };
+
+  const subcommand = args._[0];
+  if (subcommand in migrationMap) {
+    const replacement = migrationMap[subcommand];
+    console.log();
+    console.log(
+      chalk.yellow`  {gray $} {bold expo ${subcommand}} is not supported in the local CLI, please use {bold ${replacement}} instead`
+    );
+    console.log();
+    process.exit(1);
+  }
+  const deprecated = ['send', 'client:ios'];
+  if (deprecated.includes(subcommand)) {
+    console.log();
+    console.log(chalk.yellow`  {gray $} {bold expo ${subcommand}} is deprecated`);
+    console.log();
+    process.exit(1);
+  }
+}
+
 const command = isSubcommand ? args._[0] : defaultCmd;
 const commandArgs = isSubcommand ? args._.slice(1) : args._;
 

--- a/packages/@expo/cli/e2e/__tests__/index-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/index-test.ts
@@ -20,6 +20,9 @@ it('runs `npx expo -v`', async () => {
   const results = await execute('-v');
   expect(results.stdout).toEqual(require('../../package.json').version);
 });
+it('asserts with a deprecated command `npx expo send`', async () => {
+  await expect(execute('send')).rejects.toThrow(/expo send is deprecated/);
+});
 
 it('runs `npx expo --help`', async () => {
   const results = await execute('--help');


### PR DESCRIPTION
# Why

- Help users who are migrating to the new CLI by printing a clear error message regarding the deprecated commands.


# How

- Implements the guidance from https://github.com/expo/expo/pull/17487


# Test Plan

- Added e2e tests