### PR TITLE
fix(cli): add no-op `--experimental-bundle` flag to `expo export`

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Fix `export` bug failing when no assets are included. ([#17414](https://github.com/expo/expo/pull/17414) by [@EvanBacon](https://github.com/EvanBacon))
 - Add correct packages (`expo-splash-screen`) and drop incorrect required packages (`react-native-unimodules`, `expo-updates`) in prebuild. ([#17447](https://github.com/expo/expo/pull/17447) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix tunnel on web breaking native. ([#17666](https://github.com/expo/expo/pull/17666) by [@EvanBacon](https://github.com/EvanBacon))
+- Add no-op `--experimental-bundle` flag to `expo export`.
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -26,7 +26,7 @@
 - Fix `export` bug failing when no assets are included. ([#17414](https://github.com/expo/expo/pull/17414) by [@EvanBacon](https://github.com/EvanBacon))
 - Add correct packages (`expo-splash-screen`) and drop incorrect required packages (`react-native-unimodules`, `expo-updates`) in prebuild. ([#17447](https://github.com/expo/expo/pull/17447) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix tunnel on web breaking native. ([#17666](https://github.com/expo/expo/pull/17666) by [@EvanBacon](https://github.com/EvanBacon))
-- Add no-op `--experimental-bundle` flag to `expo export`.
+- Add no-op `--experimental-bundle` flag to `expo export`. ([#17886](https://github.com/expo/expo/pull/17886) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/export/index.ts
+++ b/packages/@expo/cli/src/export/index.ts
@@ -17,6 +17,12 @@ export const expoExport: Command = async (argv) => {
       '--max-workers': Number,
       '--output-dir': String,
       '--platform': String,
+
+      // Hack: This is added because EAS CLI always includes the flag.
+      // If supplied, we'll do nothing with the value, but at least the process won't crash.
+      // Note that we also don't show this value in the `--help` prompt since we don't want people to use it.
+      '--experimental-bundle': Boolean,
+
       // Aliases
       '-h': '--help',
       // '-s': '--dump-sourcemap',


### PR DESCRIPTION
# Why

- eas update always includes this flag and it'll probably be difficult to determine which CLI is in use by the project, so for now we'll just consume the extra flag and do nothing with it. Ref https://github.com/expo/eas-cli/blob/968fdd221ca04e8146f1ebd83f9f3baf67362841/packages/eas-cli/src/project/publish.ts#L163

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->