### PR TITLE
[notifications] Limit the trampolines fix on android 12+

### DIFF
--- a/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/notifications/service/NotificationsService.kt
+++ b/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/notifications/service/NotificationsService.kt
@@ -461,7 +461,7 @@ open class NotificationsService : BroadcastReceiver() {
       // [notification trampolines](https://developer.android.com/about/versions/12/behavior-changes-12#identify-notification-trampolines)
       // are not allowed. If the notification wants to open foreground app,
       // we should use the dedicated Activity pendingIntent.
-      if (action.opensAppToForeground()) {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && action.opensAppToForeground()) {
         val notificationResponse = getNotificationResponseFromBroadcastIntent(intent)
         return ExpoHandlingDelegate.createPendingIntentForOpeningApp(context, intent, notificationResponse)
       }

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/notifications/service/NotificationsService.kt
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/notifications/service/NotificationsService.kt
@@ -461,7 +461,7 @@ open class NotificationsService : BroadcastReceiver() {
       // [notification trampolines](https://developer.android.com/about/versions/12/behavior-changes-12#identify-notification-trampolines)
       // are not allowed. If the notification wants to open foreground app,
       // we should use the dedicated Activity pendingIntent.
-      if (action.opensAppToForeground()) {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && action.opensAppToForeground()) {
         val notificationResponse = getNotificationResponseFromBroadcastIntent(intent)
         return ExpoHandlingDelegate.createPendingIntentForOpeningApp(context, intent, notificationResponse)
       }

--- a/android/versioned-abis/expoview-abi45_0_0/src/main/java/abi45_0_0/expo/modules/notifications/service/NotificationsService.kt
+++ b/android/versioned-abis/expoview-abi45_0_0/src/main/java/abi45_0_0/expo/modules/notifications/service/NotificationsService.kt
@@ -461,7 +461,7 @@ open class NotificationsService : BroadcastReceiver() {
       // [notification trampolines](https://developer.android.com/about/versions/12/behavior-changes-12#identify-notification-trampolines)
       // are not allowed. If the notification wants to open foreground app,
       // we should use the dedicated Activity pendingIntent.
-      if (action.opensAppToForeground()) {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && action.opensAppToForeground()) {
         val notificationResponse = getNotificationResponseFromBroadcastIntent(intent)
         return ExpoHandlingDelegate.createPendingIntentForOpeningApp(context, intent, notificationResponse)
       }

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationsService.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationsService.kt
@@ -454,7 +454,7 @@ open class NotificationsService : BroadcastReceiver() {
       // [notification trampolines](https://developer.android.com/about/versions/12/behavior-changes-12#identify-notification-trampolines)
       // are not allowed. If the notification wants to open foreground app,
       // we should use the dedicated Activity pendingIntent.
-      if (action.opensAppToForeground()) {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && action.opensAppToForeground()) {
         val notificationResponse = getNotificationResponseFromBroadcastIntent(intent)
         return ExpoHandlingDelegate.createPendingIntentForOpeningApp(context, intent, notificationResponse)
       }


### PR DESCRIPTION
# Why

because the notification trampolines fix changes the call flows much, limit the new call flow only for android 12+ for sdk-45 stability. 

related notification trampolines fixes: #17686 #17751 #17838 #17871

# How

add android version check to the new call flow

# Test Plan

- bare-expo + NCL notification (android 12)
- bare-expo + NCL notification (android 8)

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
