### PR TITLE
[docs] update expo-updates guide to latest SDK version

### DIFF
--- a/docs/pages/bare/installing-updates.md
+++ b/docs/pages/bare/installing-updates.md
@@ -54,7 +54,7 @@ If you're migrating from an ExpoKit project to the bare workflow with `expo-upda
 <plist version="1.0">
   <dict>
     <key>EXUpdatesSDKVersion</key>
-    <string>43.0.0</string>
+    <string>45.0.0</string>
     <key>EXUpdatesURL</key>
     <string>https://exp.host/@my-expo-username/my-app</string>
   </dict>
@@ -73,7 +73,7 @@ If you're migrating from an ExpoKit project to the bare workflow with `expo-upda
    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
    <application android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:allowBackup="false" android:theme="@style/AppTheme" android:usesCleartextTraffic="true">
 +    <meta-data android:name="expo.modules.updates.EXPO_UPDATE_URL" android:value="https://exp.host/@my-expo-username/my-app"/>
-+    <meta-data android:name="expo.modules.updates.EXPO_SDK_VERSION" android:value="43.0.0"/>
++    <meta-data android:name="expo.modules.updates.EXPO_SDK_VERSION" android:value="45.0.0"/>
      <activity android:name=".MainActivity" android:label="@string/app_name" android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode" android:launchMode="singleTask" android:windowSoftInputMode="adjustResize" android:theme="@style/Theme.App.SplashScreen">
        <intent-filter>
          <action android:name="android.intent.action.MAIN"/>

--- a/docs/public/static/diffs/expo-updates-ios.diff
+++ b/docs/public/static/diffs/expo-updates-ios.diff
@@ -96,7 +96,7 @@ index 471ca3dde5..2abdd7a775 100644
 --- a/apps/bare-update/ios/bareupdate/Supporting/Expo.plist
 +++ b/apps/bare-update/ios/bareupdate/Supporting/Expo.plist
 @@ -6,5 +6,7 @@
-     <string>42.0.0</string>
+     <string>45.0.0</string>
      <key>EXUpdatesURL</key>
      <string>https://exp.host/@my-expo-username/my-app</string>
 +    <key>EXUpdatesAutoSetup</key>

--- a/docs/public/static/diffs/expo-updates-js.diff
+++ b/docs/public/static/diffs/expo-updates-js.diff
@@ -10,7 +10,7 @@ index 1c3dccb..f281582 100644
 +  "expo": {
 +    "name": "MyApp",
 +    "slug": "my-app",
-+    "sdkVersion": "38.0.0"
++    "sdkVersion": "45.0.0"
 +  }
  }
 \ No newline at end of file


### PR DESCRIPTION
# Why

The `expo-updates` guide used a mix of SDK versions (38, 42, 43) in the code snippets. This PR updates all of them to 45.

# How

Updated the docs page and linked diff files.

# Test Plan

Mk. I Eyeball.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
