### PR TITLE
Remove out-of-date versions specifiers

### DIFF
--- a/docs/pages/development/extensions.md
+++ b/docs/pages/development/extensions.md
@@ -40,7 +40,7 @@ The EAS Updates extension provides the ability to view and load published update
 It's now available for all development clients `v0.9.0` and above. In order to install it, you'll need the most recent publish of expo updates from npm:
 
 ```
-expo install expo-dev-client@0.9 expo-updates@next
+expo install expo-dev-client expo-updates
 ```
 
 #### Configure EAS Update


### PR DESCRIPTION
# Why

expo-dev-client@latest is > 0.9
expo-updates@next tag doesn't exist!

# How

Ran the command blindly and it errored out

# Test Plan

I don't know if **the guides** are meant to be 'evergreen' or what SDK version to target, so not sure

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin). 
