### PR TITLE
[docs] use Terminal component on few more pages, other small tweaks

### DIFF
--- a/docs/pages/accounts/account-types.md
+++ b/docs/pages/accounts/account-types.md
@@ -6,7 +6,7 @@ title: Account Types
 
 Every user of Expo has their own Personal Account. With this account, we can safely identify you as the developer or owner of an app. You can use Personal Accounts for all features Expo has to offer. In cases where you take an action that doesn't specify which account it should belong to, it will default to your Personal Account
 
-This account is just for you, **never share access to this account for any reason.**
+> This account is just for you, **never share access to this account for any reason.**
 
 ## Organizations
 
@@ -55,14 +55,16 @@ We have taken a lot of care to make sure that all of the functionality that you 
 
 Accounts may be renamed a limited number of times. Simply visit [the account settings page](https://expo.dev/accounts/[account]/settings) and follow the prompts under **Rename Account**.
 
-Some caveats:
+#### Some caveats
+
 - New publishes for projects belonging to renamed accounts must be on SDK 43 or higher.
 
 ### Transferring Projects Between Accounts
 
 Projects may be renamed a limited number of times. Simply visit [the project settings page](https://expo.dev/accounts/[account]/projects/[project]/settings) and follow the prompts under **Transfer project**.
 
-Some caveats:
+#### Some caveats
+
 - The person performing the transfer must have "Owner" role on both the source and destination accounts.
 - New publishes for renamed project must be on SDK 43 or higher.
 

--- a/docs/pages/accounts/programmatic-access.md
+++ b/docs/pages/accounts/programmatic-access.md
@@ -2,22 +2,19 @@
 title: Programmatic Access
 ---
 
-
-## Programmatic Access
-
 When setting up CI or writing a script to help manage your projects, we recommend avoiding using your username and password to authenticate. With these credentials, anyone would be able to log in and use your account.
 
 Instead of providing credentials, you can generate tokens that will allow you to manage each integration point separately. Anyone who has access to these tokens will be able to perform actions against your account. Please treat them with the same care as a user password. In case something is leaked, you can revoke these tokens to block access.
 
-### Personal Account: Personal Access Tokens
+## Personal Account: Personal Access Tokens
 
 You can create Personal Access Tokens from the [Access Tokens page](https://expo.dev/settings/access-tokens) on your dashboard. Anyone with this token can perform actions on your behalf. That applies to all content on your Personal Account, as well as any Personal Accounts or Organizations that you have been granted access to.
 
-### Organizations: Bot Users & Access Tokens
+## Organizations: Bot Users & Access Tokens
 
 Organizations can create Bot Users to take actions on resources owned by the Organization.  Bot Users can be assigned [a role](/working-together) to limit the actions they are authorized to perform.  Bot users cannot sign in to any Expo products, cannot own any projects themselves, and can only authenticate via an access token.
 
-### Using Access Tokens
+## Using Access Tokens
 
 You can use any tokens you have created to perform actions with the Expo CLI (other than signing in and out). To use tokens, you need to define an environment variable, like `EXPO_TOKEN="token"`, before running commands.
 
@@ -29,6 +26,6 @@ Common situations where access tokens are useful:
 - Renew a token to keep it as secure as possible; no need to reset your password and sign out of all sessions
 - Give someone (or a script) one-time access to your project with limited permissions
 
-### Revoking Access Tokens
+## Revoking Access Tokens
 
 In case a token was accidentally leaked, you can revoke it without changing your username and password. When you revoke the access token, you block all access to your account using this token. To do this, go to the [Access Token page](https://expo.dev/settings/access-tokens) on your dashboard and delete the token you want to revoke.

--- a/docs/pages/build-reference/how-tos.md
+++ b/docs/pages/build-reference/how-tos.md
@@ -68,9 +68,9 @@ See [Using private npm packages](/build-reference/private-npm-packages) to learn
 
 By default the EAS npm cache won't work with yarn v1, because `yarn.lock` files contain URLs to registries for every package and yarn does not provide any way to override it. The issue is fixed in yarn v2, but the yarn team does not plan to backport it to yarn v1. If you want to take advantage of the npm cache, you can use the `eas-build-pre-install` script to override the registry in your `yarn.lock`.
 
-e.g.
+#### Example
 
-```
+```json
 {
  "scripts": {
     "eas-build-pre-install": "bash -c \"[ ! -z \\\"$EAS_BUILD_NPM_CACHE_URL\\\" ] && sed -i -e \\\"s#https://registry.yarnpkg.com#$EAS_BUILD_NPM_CACHE_URL#g\\\" yarn.lock\" || true"

--- a/docs/pages/development/extensions.md
+++ b/docs/pages/development/extensions.md
@@ -2,48 +2,53 @@
 title: Extensions
 ---
 
-import ImageSpotlight from '~/components/plugins/ImageSpotlight'
+import ImageSpotlight from '~/components/plugins/ImageSpotlight';
+import { Terminal } from '~/ui/components/Snippet';
 
 Extensions allow you to extend your development client with additional capabilities.
 
-
-### Extending the dev menu
+## Extending the dev menu
 
 The dev menu can be extended to include extra buttons by using the `registerDevMenuItems` API:
 
 ```tsx
-import { registerDevMenuItems } from 'expo-dev-menu'
+import { registerDevMenuItems } from 'expo-dev-menu';
 
 const devMenuItems = [
   {
     name: 'My Custom Button',
     callback: () => console.log("Hello world!")
   }
-]
+];
 
-registerDevMenuItems(devMenuItems)
+registerDevMenuItems(devMenuItems);
 ```
 
 This will create a new section in the dev menu that includes the buttons you have registered: 
 
-<ImageSpotlight alt="An example of a custom menu button in expo-dev-menu" src="/static/images/dev-client/custom-menu-button.png" containerStyle={{ paddingBottom: 0 }} />
+<ImageSpotlight
+  alt="An example of a custom menu button in expo-dev-menu"
+  src="/static/images/dev-client/custom-menu-button.png"
+  style={{ maxWidth: 600 }}
+/>
 
-*Note: Subsequent calls of `registerDevMenuItems` will override all previous entries.*
+> Note: Subsequent calls of `registerDevMenuItems` will override all previous entries.
 
+## EAS Updates
 
-### EAS Updates
-
-<ImageSpotlight alt="An example list of EAS Updates that can be loaded in the expo-dev-client" src="/static/images/dev-client/eas-updates-screen.png" containerStyle={{ paddingBottom: 0 }} />
+<ImageSpotlight 
+  alt="An example list of EAS Updates that can be loaded in the expo-dev-client"
+  src="/static/images/dev-client/eas-updates-screen.png"
+  style={{ maxWidth: 600 }}
+/>
 
 The EAS Updates extension provides the ability to view and load published updates in your development client.
 
 It's now available for all development clients `v0.9.0` and above. In order to install it, you'll need the most recent publish of expo updates from npm:
 
-```
-expo install expo-dev-client expo-updates
-```
+<Terminal cmd={['$ expo install expo-dev-client expo-updates']} />
 
-#### Configure EAS Update
+### Configure EAS Update
 
 If you have not yet configured EAS Updates in your project, you can find [additional instructions on how to do so here.](/eas-update/getting-started/)
 

--- a/docs/pages/development/troubleshooting.md
+++ b/docs/pages/development/troubleshooting.md
@@ -6,11 +6,11 @@ Issues are often solved by upgrading to the latest version of `expo-dev-client`,
 
 If you're not able to resolve your issue, please [let us know!](https://github.com/expo/expo/issues/new?template=dev_client_bug_report.yml)
 
-### The keyboard shortcuts for the Dev Menu don't work reliably in my iOS simulator
+### The keyboard shortcuts for the Dev Menu don't work reliably in iOS simulator
 
 Make sure you have "Send keyboard input to device" enabled for the simulator. This option can be found under I/O > Input in the menu.
 
-### I am getting a build error from Swift on the line `import expo-dev-launcher`
+### I am getting a build error from Swift on `import expo-dev-launcher` line
 
 If you are building for iOS and getting an error that looks something like this:
 

--- a/docs/pages/distribution/hosting-your-app.md
+++ b/docs/pages/distribution/hosting-your-app.md
@@ -3,6 +3,7 @@ title: Hosting Updates on Your Servers
 ---
 
 import { ConfigClassic } from '~/components/plugins/ConfigSection';
+import { Terminal } from '~/ui/components/Snippet';
 
 Normally, when updates are enabled, your app will fetch updates comprising JavaScript bundles and assets from Expo’s CDN. However, there will be situations when you will want to host your JS bundles and assets on your own servers. For example, updates are slow or unusable in countries that have blocked Expo’s CDN providers on AWS and Google Cloud. In these cases, you can host your updates on your own servers to better suit your use cases.
 
@@ -27,16 +28,16 @@ First, you’ll need to export all the static files of your update so they can b
 
 Once you've exported your update's static files, you can host the contents on your own server. For example, in your `dist` output directory, an easy way to host your own files is to push the contents to GitHub. You can enable [GitHub Pages](https://pages.github.com/) to make your app available at a base URL like https://username.github.io/project-name. To host your files on GitHub, you'd do something like this:
 
-```
-# run this from your project directory
-expo export --public-url https://expo.github.io/self-hosting-example
-
-# commit output directory contents to your repo
-cd dist
-git init && git remote add origin git@github.com:expo/self-hosting-example.git
-git add * && git commit -m "Update my app with this JS bundle"
-git push origin master
-```
+<Terminal cmd={[
+'# run this from your project directory',
+'$ expo export --public-url https://expo.github.io/self-hosting-example',
+'',
+'# commit output directory contents to your repo',
+'$ cd dist',
+'$ git init && git remote add origin git@github.com:expo/self-hosting-example.git',
+'$ git add * && git commit -m "Update my app with this JS bundle"',
+'$ git push origin master',
+]} />
 
 To setup a QR code to view your hosted update, or if you want to host your files locally, follow the instructions below in the 'Loading QR Code/URL in Development' section.
 
@@ -68,13 +69,13 @@ Here's an example of **firebase.json** configuration, with a [deploy target](htt
 }
 ```
 
-```
-# export your app locally
-expo export --public-url https://my-app-native.firebaseapp.com/
-
-# deploy the app to firebase
-firebase deploy --only hosting:native -m "Deploy my app"`
-```
+<Terminal cmd={[
+'# export your app locally',
+'$ expo export --public-url https://my-app-native.firebaseapp.com/',
+'',
+'# deploy the app to firebase',
+'$ firebase deploy --only hosting:native -m "Deploy my app"',
+]} />
 
 ## Building the standalone app
 
@@ -110,17 +111,17 @@ QR code: Generate the URI from a website like https://www.qr-code-generator.com/
 
 Run `expo export` in dev mode and then start a simple HTTP server in your output directory:
 
-```
-# Find your local IP address with `ipconfig getifaddr en0`
-# export static app files
-expo export --public-url http://`ipconfig getifaddr en0`:8000 --dev
-
-# cd into your output directory
-cd dist
-
-# run a simple http server from output directory
-python -m SimpleHTTPServer 8000
-```
+<Terminal cmd={[
+'# Find your local IP address with `ipconfig getifaddr en0`',
+'# export static app files',
+'$ expo export --public-url http://`ipconfig getifaddr en0`:8000 --dev',
+'',
+'# cd into your output directory',
+'$ cd dist',
+'',
+'# run a simple http server from output directory',
+'$ python -m SimpleHTTPServer 8000',
+]} />
 
 URI: `exp://192.xxx.xxx.xxx:8000/android-index.json` (find your local IP with a command like `ipconfig getifaddr en0`)
 

--- a/docs/pages/guides/config-plugins.md
+++ b/docs/pages/guides/config-plugins.md
@@ -2,6 +2,8 @@
 title: Config Plugins
 ---
 
+import { Terminal } from '~/ui/components/Snippet';
+
 > This guide applies to SDK 41+ projects. The Expo Go app doesn't support custom native modules.
 
 When adding a native module to your project, most of the setup can be done automatically by installing the module in your project, but some modules require a more complex setup. For instance, say you installed `expo-camera` in your bare project, you now need to configure the native app to enable camera permissions — this is where config plugins come in. Config plugins are a system for extending the Expo config and customizing the prebuild phase of managed builds.
@@ -10,7 +12,7 @@ Internally Expo CLI uses config plugins to generate and configure all the native
 
 You can think of plugins like a bundler for native projects, and running `expo prebuild` as a way to bundle the projects by evaluating all the project plugins. Doing so will generate `ios` and `android` directories. These directories can be modified manually after being generated, but then they can no longer be safely regenerated without potentially overwriting manual modifications.
 
-**Quick facts**
+#### Quick facts
 
 - Plugins are functions that can change values on your Expo config.
 - Plugins are mostly meant to be used with [`expo prebuild`][cli-prebuild] or `eas build` commands.
@@ -28,9 +30,7 @@ For instance, `expo-camera` has a plugin that adds camera permissions to the **I
 
 Install it in your project:
 
-```sh
-expo install expo-camera
-```
+<Terminal cmd={['$ expo install expo-camera']} />
 
 In your app's Expo config (**app.json**, or **app.config.js**), add `expo-camera` to the list of plugins:
 

--- a/docs/pages/guides/using-styled-components.md
+++ b/docs/pages/guides/using-styled-components.md
@@ -2,15 +2,15 @@
 title: Using Styled Components
 ---
 
+import { Terminal } from '~/ui/components/Snippet';
+
 Styled Components is a CSS-in-JS solution that enables you to create React components with a given style very easily. Using `styled-components` with Expo, you can create universal styles that'll work the same across web, mobile, and desktop!
 
 ## Getting Started
 
-Install the package:
+Install the Styled Components package:
 
-```sh
-yarn add styled-components
-```
+<Terminal cmd={['$ yarn add styled-components']} />
 
 Use `styled-components/native` instead of `styled-components`:
 
@@ -42,22 +42,18 @@ Usage with Next.js is a little different because we need to apply the React Nati
 
 - Add `@expo/next-adapter` to your project:
 
-```sh
-npx @expo/next-adapter
-```
+<Terminal cmd={['$ npx @expo/next-adapter']} />
 
 - Install the styled-components Babel plugin:
 
-```sh
-yarn add -D babel-plugin-styled-components
-```
+<Terminal cmd={['$ yarn add -D babel-plugin-styled-components']} />
 
 - Use the Babel plugin in your **babel.config.js** file:
 
 ```diff
 module.exports = {
     presets: ['@expo/next-adapter/babel'],
-+    plugins: [['styled-components', { 'ssr': true }]]
++   plugins: [['styled-components', { ssr: true }]]
 };
 ```
 

--- a/docs/pages/guides/web-performance.md
+++ b/docs/pages/guides/web-performance.md
@@ -2,27 +2,32 @@
 title: Web Performance
 ---
 
+import { Terminal } from '~/ui/components/Snippet';
+
 Expo uses **react-native-web** which is the highly optimized framework used to power major websites and PWAs like [Twitter](https://mobile.twitter.com), [Major League Soccer](https://matchcenter.mlssoccer.com), [Flipkart](https://twitter.com/naqvitalha/status/969577892991549440), [Uber](https://www.youtube.com/watch?v=RV9rxrNIxnY), [The Times](https://github.com/newsuk/times-components), [DataCamp](https://www.datacamp.com/community/tech/porting-practice-to-web-part1).
 
-### Presets
+## Presets
 
 There are a number of performance tools at your disposal that will not only optimize your web app, but also improve the performance of your native app! Here are the officially recommended and most optimal set of tools to use when creating universal projects:
 
-- **Babel:** [`babel-preset-expo`](https://www.npmjs.com/package/babel-preset-expo) extends the default react-native preset and adds support for all other Expo platforms. In the browser this has massive performance benefits by enabling tree-shaking of the unused `react-native-web` modules.
-- **Webpack Config:** [`@expo/webpack-config`](https://www.npmjs.com/package/@expo/webpack-config) A default Webpack config that's optimized for running `react-native-web` apps and creating [progressive web apps](https://developers.google.com/web/progressive-web-apps/).
-- **Jest:** [`jest-expo`](https://www.npmjs.com/package/jest-expo) A universal solution for testing your code against all of the platforms it runs on. Learn more about [Universal Testing.](https://blog.expo.dev/testing-universal-react-native-apps-with-jest-and-expo-113b4bf9cc44)
+- #### Babel
+  [`babel-preset-expo`](https://www.npmjs.com/package/babel-preset-expo) extends the default react-native preset and adds support for all other Expo platforms. In the browser this has massive performance benefits by enabling tree-shaking of the unused `react-native-web` modules.
+- #### Jest
+  [`jest-expo`](https://www.npmjs.com/package/jest-expo) A universal solution for testing your code against all of the platforms it runs on. Learn more about [Universal Testing](https://blog.expo.dev/testing-universal-react-native-apps-with-jest-and-expo-113b4bf9cc44).
+- #### Webpack Config
+  [`@expo/webpack-config`](https://www.npmjs.com/package/@expo/webpack-config) A default Webpack config that's optimized for running `react-native-web` apps and creating [progressive web apps](https://developers.google.com/web/progressive-web-apps/).
 
 ## Optimize Your Assets
 
 The easiest and most **highly** recommended way to improve you project is to optimize your assets. You can reduce the size of your assets with the [Expo Optimize CLI](https://www.npmjs.com/package/expo-optimize).
 
-```sh
-# Make sure you can successfully install the native image editing library Sharp
-npm install -g sharp-cli
-
-# Then in your project run:
-npx expo-optimize
-```
+<Terminal cmd={[
+'# Make sure you can successfully install the native image editing library Sharp',
+'$ npm install -g sharp-cli',
+'',
+'# Then in your project run:',
+'$ npx expo-optimize',
+]} />
 
 ## 📦 What Makes My App Large?
 
@@ -30,8 +35,10 @@ To inspect bundle sizes, you can use a Webpack plugin called [_Webpack Bundle An
 
 ### Using Bundle Analyzer
 
-1. Install the bundle analyzer: `yarn add -D webpack-bundle-analyzer`
-2. Reveal the Webpack Config: `expo customize:web` and select **webpack.config.js**.
+1. Install the bundle analyzer:
+   <Terminal cmd={['$ yarn add -D webpack-bundle-analyzer']} />
+2. Reveal the Webpack Config: 
+   * Run `expo customize:web` and select **webpack.config.js**.
 3. Customize the config to generate a web report:
 
 ```js
@@ -59,9 +66,7 @@ module.exports = async (env, argv) => {
 
 If you want to track down why a package was included, you can build your project in [debug mode](https://github.com/expo/expo-cli/blob/af9e390b74dcb7a0132e73b34ea0cdb9437a771c/packages/xdl/src/Web.ts#L69-L92).
 
-```sh
-EXPO_WEB_DEBUG=true expo build:web
-```
+<Terminal cmd={['$ EXPO_WEB_DEBUG=true expo build:web']} />
 
 > This will make your bundle much larger, and you shouldn't publish your project in this state.
 

--- a/docs/pages/workflow/publishing.md
+++ b/docs/pages/workflow/publishing.md
@@ -2,6 +2,8 @@
 title: Publishing updates
 ---
 
+import ImageSpotlight from '~/components/plugins/ImageSpotlight';
+
 While you’re developing your project, you’re writing code on your
 computer, and when you use Expo CLI, a server and the Metro bundler run on your machine and bundle up all your source code and make
 it available from a URL. Your URL for a project you’re working on
@@ -51,7 +53,11 @@ Your users will get the most recent compatible release that was pushed to a [rel
 
 The following flowchart shows how we determine which release to return to a user:
 
-![Serving Flowchart](/static/images/release-channels-flowchart.png)
+<ImageSpotlight
+  alt="Serving Flowchart"
+  src="/static/images/release-channels-flowchart.png"
+  style={{ maxWidth: 600 }}
+/>
 
 ## Deploying to the App Store and Play Store
 


### PR DESCRIPTION
# Why

Still not all pages use the latest `Terminal` component, let's cut few off from the list.

# How

This PR replaces the SH/Bash code block with the `Terminal` component.

Additionally I have updated the headers on the few pages to improve ToC rendering.

On two pages I have also set the smaller than default `maxWidth` for the spotlight images for the red-ability improvement.

# Test Plan

The changes have been tested by running Expo docs website locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
