### PR TITLE
[docs] Removing broken hyperlink

### DIFF
--- a/docs/pages/guides/splash-screens.md
+++ b/docs/pages/guides/splash-screens.md
@@ -20,7 +20,7 @@ Create an app icon and splash image with the [Figma template](https://www.figma.
 
 ### Make a splash image
 
-The iOS Human Interface Guidelines list the static launch image sizes. I'll go with `1242` pixels wide and `2436` pixels tall -- this is the width of the iPhone 8 Plus (the widest iPhone) and the height of the iPhone X (the tallest iPhone). Expo will resize the image for you depending on the size of the device, and we can specify the strategy used to resize the image with `splash.resizeMode`.
+The [iOS Human Interface Guidelines](https://developer.apple.com/design/human-interface-guidelines/foundations/layout#specifications) list the devices screen sizes. I'll go with `1242` pixels wide (width of the widest iPhone at the moment of writing) and `2436` pixels tall (height of the tallest iPhone at the moment of writing). Expo will resize the image for you depending on the size of the device, and we can specify the strategy used to resize the image with `splash.resizeMode`.
 
 Android screen sizes vary greatly with the massive variety of devices on the market. One strategy to deal with this is to look at the most common resolutions and design around that - [you can see a list of devices and their resolutions here](https://material.io/resources/devices/). Given that we can resize and crop our splash image automatically, it looks like we can stick with our dimensions, as long as we don't depend on the splash image fitting the screen exactly. This is convenient because we can use one splash image for both iOS and Android - less for you to read in this guide and less work for you to do.
 

--- a/docs/pages/guides/splash-screens.md
+++ b/docs/pages/guides/splash-screens.md
@@ -20,7 +20,7 @@ Create an app icon and splash image with the [Figma template](https://www.figma.
 
 ### Make a splash image
 
-The [iOS Human Interface Guidelines](https://developer.apple.com/ios/human-interface-guidelines/icons-and-images/launch-screen/) list the static launch image sizes. I'll go with `1242` pixels wide and `2436` pixels tall -- this is the width of the iPhone 8 Plus (the widest iPhone) and the height of the iPhone X (the tallest iPhone). Expo will resize the image for you depending on the size of the device, and we can specify the strategy used to resize the image with `splash.resizeMode`.
+The iOS Human Interface Guidelines list the static launch image sizes. I'll go with `1242` pixels wide and `2436` pixels tall -- this is the width of the iPhone 8 Plus (the widest iPhone) and the height of the iPhone X (the tallest iPhone). Expo will resize the image for you depending on the size of the device, and we can specify the strategy used to resize the image with `splash.resizeMode`.
 
 Android screen sizes vary greatly with the massive variety of devices on the market. One strategy to deal with this is to look at the most common resolutions and design around that - [you can see a list of devices and their resolutions here](https://material.io/resources/devices/). Given that we can resize and crop our splash image automatically, it looks like we can stick with our dimensions, as long as we don't depend on the splash image fitting the screen exactly. This is convenient because we can use one splash image for both iOS and Android - less for you to read in this guide and less work for you to do.
 


### PR DESCRIPTION
# Why

As mentioned in #17929, the current link is broken.

# How

Removing the broken link to make the documentation clearer.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
