### PR TITLE
Update `expo-modules-autolinking` version

### DIFF
--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -64,7 +64,7 @@
     "expo-file-system": "~14.0.0",
     "expo-font": "~10.1.0",
     "expo-keep-awake": "~10.1.0",
-    "expo-modules-autolinking": "0.7.0",
+    "expo-modules-autolinking": "0.8.1",
     "expo-modules-core": "0.9.0",
     "fbemitter": "^3.0.0",
     "getenv": "^1.0.0",


### PR DESCRIPTION
# Why

The existing version is outdated and requires a resolution for dev clients to build. `expo run:ios` on SDK 45 doesn't work with the older auto-linking version.

# How

Evan, Tomasz, Cedric and Lukasz helped me find this solution in 🇵🇱

# Test Plan

I tested this in my app with a yarn resolution.

Related: https://github.com/expo/expo/issues/17923

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
