### PR TITLE
[expo-updates][Android] Get downloaded update IDs

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -17,6 +17,8 @@
 
 ### 💡 Others
 
+- [Android] Get downloaded update IDs. ([#17933](https://github.com/expo/expo/pull/17933) by [@douglowder](https://github.com/douglowder))
+
 ## 1.0.0 — 2022-06-09
 
 ### 🐛 Bug fixes

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/helpers/DevLauncherUpdatesHelper.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/helpers/DevLauncherUpdatesHelper.kt
@@ -24,7 +24,6 @@ suspend fun UpdatesInterface.loadUpdate(
           // if the update is null, we previously aborted the fetch, so we've already resumed
           update?.let { cont.resume(update) }
         }
-        override fun onQuerySuccess(updateIds: MutableList<UUID>?) {}
         override fun onFailure(e: Exception?) {
           cont.resumeWithException(e ?: Exception("There was an unexpected error loading the update."))
         }

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/helpers/DevLauncherUpdatesHelper.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/helpers/DevLauncherUpdatesHelper.kt
@@ -5,6 +5,8 @@ import android.net.Uri
 import expo.modules.updatesinterface.UpdatesInterface
 import org.json.JSONObject
 import java.lang.Exception
+import java.util.*
+import kotlin.collections.HashMap
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
@@ -22,6 +24,7 @@ suspend fun UpdatesInterface.loadUpdate(
           // if the update is null, we previously aborted the fetch, so we've already resumed
           update?.let { cont.resume(update) }
         }
+        override fun onQuerySuccess(updateIds: MutableList<UUID>?) {}
         override fun onFailure(e: Exception?) {
           cont.resumeWithException(e ?: Exception("There was an unexpected error loading the update."))
         }

--- a/packages/expo-updates-interface/CHANGELOG.md
+++ b/packages/expo-updates-interface/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- [Android] Get downloaded update IDs. ([#17933](https://github.com/expo/expo/pull/17933) by [@douglowder](https://github.com/douglowder))
+
 ## 0.6.0 — 2022-04-18
 
 ### 🎉 New features

--- a/packages/expo-updates-interface/android/src/main/java/expo/modules/updatesinterface/UpdatesInterface.java
+++ b/packages/expo-updates-interface/android/src/main/java/expo/modules/updatesinterface/UpdatesInterface.java
@@ -17,7 +17,6 @@ public interface UpdatesInterface {
   interface UpdateCallback {
     void onFailure(Exception e);
     void onSuccess(Update update);
-    void onQuerySuccess(List<UUID> updateIds);
     void onProgress(int successfulAssetCount, int failedAssetCount, int totalAssetCount);
 
     /**
@@ -28,6 +27,11 @@ public interface UpdatesInterface {
     boolean onManifestLoaded(JSONObject manifest);
   }
 
+  interface QueryCallback {
+    void onFailure(Exception e);
+    void onSuccess(List<UUID> updateIds);
+  }
+  
   interface Update {
     JSONObject getManifest();
     String getLaunchAssetPath();
@@ -37,5 +41,5 @@ public interface UpdatesInterface {
 
   void fetchUpdateWithConfiguration(HashMap<String, Object> configuration, Context context, UpdateCallback callback);
 
-  void storedUpdateIdsWithConfiguration(HashMap<String, Object> configuration, Context context, UpdateCallback callback);
+  void storedUpdateIdsWithConfiguration(HashMap<String, Object> configuration, Context context, QueryCallback callback);
 }

--- a/packages/expo-updates-interface/android/src/main/java/expo/modules/updatesinterface/UpdatesInterface.java
+++ b/packages/expo-updates-interface/android/src/main/java/expo/modules/updatesinterface/UpdatesInterface.java
@@ -5,6 +5,8 @@ import android.content.Context;
 import org.json.JSONObject;
 
 import java.util.HashMap;
+import java.util.List;
+import java.util.UUID;
 
 /**
  * Interface for modules that depend on expo-updates for loading production updates but do not want
@@ -15,6 +17,7 @@ public interface UpdatesInterface {
   interface UpdateCallback {
     void onFailure(Exception e);
     void onSuccess(Update update);
+    void onQuerySuccess(List<UUID> updateIds);
     void onProgress(int successfulAssetCount, int failedAssetCount, int totalAssetCount);
 
     /**
@@ -33,4 +36,6 @@ public interface UpdatesInterface {
   void reset();
 
   void fetchUpdateWithConfiguration(HashMap<String, Object> configuration, Context context, UpdateCallback callback);
+
+  void storedUpdateIdsWithConfiguration(HashMap<String, Object> configuration, Context context, UpdateCallback callback);
 }

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 - (cli) Fix help command parsing. ([#17293](https://github.com/expo/expo/pull/17293) by [@wschurman](https://github.com/wschurman))
 - [iOS] Get downloaded update IDs. ([#17817](https://github.com/expo/expo/pull/17817) by [@douglowder](https://github.com/douglowder))
+- [Android] Get downloaded update IDs. ([#17933](https://github.com/expo/expo/pull/17933) by [@douglowder](https://github.com/douglowder))
 
 ## 0.13.0 — 2022-04-21
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/launcher/DatabaseLauncherTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/launcher/DatabaseLauncherTest.kt
@@ -8,6 +8,7 @@ import expo.modules.updates.UpdatesConfiguration
 import expo.modules.updates.db.UpdatesDatabase
 import expo.modules.updates.db.entity.AssetEntity
 import expo.modules.updates.db.entity.UpdateEntity
+import expo.modules.updates.db.enums.UpdateStatus
 import expo.modules.updates.launcher.Launcher.LauncherCallback
 import expo.modules.updates.loader.FileDownloader
 import expo.modules.updates.selectionpolicy.SelectionPolicy
@@ -37,6 +38,69 @@ class DatabaseLauncherTest {
   @After
   fun closeDb() {
     db.close()
+  }
+
+  @Test
+  fun testGetUpdateIds_EmptyDB() {
+    val launcher = DatabaseLauncher(
+      UpdatesConfiguration(null, null),
+      File("test"),
+      FileDownloader(context),
+      SelectionPolicy(
+        mockk(),
+        mockk(),
+        mockk()
+      )
+    )
+    val readyUpdateIds = launcher.getReadyUpdateIds(db)
+    Assert.assertEquals(0, readyUpdateIds.size)
+  }
+
+  @Test
+  fun testGetUpdateIds_DBWithOneUpdate() {
+    val testUpdate = UpdateEntity(UUID.randomUUID(), Date(), "1.0", "scopeKey")
+    testUpdate.lastAccessed = Date(Date().time - 24 * 60 * 60 * 1000) // yesterday
+    testUpdate.status = UpdateStatus.READY
+    db.updateDao().insertUpdate(testUpdate)
+
+    val launcher = DatabaseLauncher(
+      UpdatesConfiguration(null, null),
+      File("test"),
+      FileDownloader(context),
+      SelectionPolicy(
+        mockk(),
+        mockk(),
+        mockk()
+      )
+    )
+    val readyUpdateIds = launcher.getReadyUpdateIds(db)
+    Assert.assertEquals(1, readyUpdateIds.size)
+  }
+
+  @Test
+  fun testGetUpdateIds_DBWithOneReadyUpdate() {
+    val testUpdate1 = UpdateEntity(UUID.randomUUID(), Date(), "1.0", "scopeKey")
+    testUpdate1.lastAccessed = Date(Date().time - 24 * 60 * 60 * 1000) // yesterday
+    testUpdate1.status = UpdateStatus.READY
+    db.updateDao().insertUpdate(testUpdate1)
+
+    val testUpdate2 = UpdateEntity(UUID.randomUUID(), Date(), "1.0", "scopeKey")
+    testUpdate2.lastAccessed = Date(Date().time - 24 * 60 * 60 * 1000) // yesterday
+    testUpdate2.status = UpdateStatus.PENDING
+    db.updateDao().insertUpdate(testUpdate2)
+
+    val launcher = DatabaseLauncher(
+      UpdatesConfiguration(null, null),
+      File("test"),
+      FileDownloader(context),
+      SelectionPolicy(
+        mockk(),
+        mockk(),
+        mockk()
+      )
+    )
+    val readyUpdateIds = launcher.getReadyUpdateIds(db)
+    Assert.assertEquals(1, readyUpdateIds.size)
   }
 
   @Test

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/launcher/DatabaseLauncherTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/launcher/DatabaseLauncherTest.kt
@@ -1,6 +1,7 @@
 package expo.modules.updates.launcher
 
 import android.content.Context
+import android.text.format.DateUtils
 import androidx.room.Room
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
 import androidx.test.platform.app.InstrumentationRegistry
@@ -59,7 +60,7 @@ class DatabaseLauncherTest {
   @Test
   fun testGetUpdateIds_DBWithOneUpdate() {
     val testUpdate = UpdateEntity(UUID.randomUUID(), Date(), "1.0", "scopeKey")
-    testUpdate.lastAccessed = Date(Date().time - 24 * 60 * 60 * 1000) // yesterday
+    testUpdate.lastAccessed = Date(Date().time - DateUtils.DAY_IN_MILLIS) // yesterday
     testUpdate.status = UpdateStatus.READY
     db.updateDao().insertUpdate(testUpdate)
 
@@ -80,12 +81,12 @@ class DatabaseLauncherTest {
   @Test
   fun testGetUpdateIds_DBWithOneReadyUpdate() {
     val testUpdate1 = UpdateEntity(UUID.randomUUID(), Date(), "1.0", "scopeKey")
-    testUpdate1.lastAccessed = Date(Date().time - 24 * 60 * 60 * 1000) // yesterday
+    testUpdate1.lastAccessed = Date(Date().time - DateUtils.DAY_IN_MILLIS) // yesterday
     testUpdate1.status = UpdateStatus.READY
     db.updateDao().insertUpdate(testUpdate1)
 
     val testUpdate2 = UpdateEntity(UUID.randomUUID(), Date(), "1.0", "scopeKey")
-    testUpdate2.lastAccessed = Date(Date().time - 24 * 60 * 60 * 1000) // yesterday
+    testUpdate2.lastAccessed = Date(Date().time - DateUtils.DAY_IN_MILLIS) // yesterday
     testUpdate2.status = UpdateStatus.PENDING
     db.updateDao().insertUpdate(testUpdate2)
 
@@ -106,7 +107,7 @@ class DatabaseLauncherTest {
   @Test
   fun testLaunch_MarkUpdateAccessed() {
     val testUpdate = UpdateEntity(UUID.randomUUID(), Date(), "1.0", "scopeKey")
-    testUpdate.lastAccessed = Date(Date().time - 24 * 60 * 60 * 1000) // yesterday
+    testUpdate.lastAccessed = Date(Date().time - DateUtils.DAY_IN_MILLIS) // yesterday
     db.updateDao().insertUpdate(testUpdate)
 
     val testAsset = AssetEntity("bundle-1234", "js")

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
@@ -12,6 +12,7 @@ import expo.modules.updates.selectionpolicy.LauncherSelectionPolicySingleUpdate
 import expo.modules.updates.selectionpolicy.ReaperSelectionPolicyDevelopmentClient
 import expo.modules.updates.selectionpolicy.SelectionPolicy
 import expo.modules.updatesinterface.UpdatesInterface
+import expo.modules.updatesinterface.UpdatesInterface.QueryCallback
 import expo.modules.updatesinterface.UpdatesInterface.UpdateCallback
 import org.json.JSONObject
 import java.util.*
@@ -30,7 +31,7 @@ class UpdatesDevLauncherController : UpdatesInterface {
   override fun fetchUpdateWithConfiguration(
     configuration: HashMap<String, Any>,
     context: Context,
-    callback: UpdatesInterface.UpdateCallback
+    callback: UpdateCallback
   ) {
     val controller = UpdatesController.instance
     val updatesConfiguration = UpdatesConfiguration(context, configuration)
@@ -92,7 +93,7 @@ class UpdatesDevLauncherController : UpdatesInterface {
     update: UpdateEntity,
     configuration: UpdatesConfiguration,
     context: Context,
-    callback: UpdatesInterface.UpdateCallback
+    callback: UpdateCallback
   ) {
     val controller = UpdatesController.instance
 
@@ -141,7 +142,7 @@ class UpdatesDevLauncherController : UpdatesInterface {
     )
   }
 
-  override fun storedUpdateIdsWithConfiguration(configuration: HashMap<String, Any>, context: Context, callback: UpdateCallback) {
+  override fun storedUpdateIdsWithConfiguration(configuration: HashMap<String, Any>, context: Context, callback: QueryCallback) {
     val controller = UpdatesController.instance
     val updatesConfiguration = UpdatesConfiguration(context, configuration)
     if (updatesConfiguration.updateUrl == null || updatesConfiguration.scopeKey == null) {
@@ -162,7 +163,7 @@ class UpdatesDevLauncherController : UpdatesInterface {
     )
     val readyUpdateIds = launcher.getReadyUpdateIds(databaseHolder.database)
     controller.databaseHolder.releaseDatabase()
-    callback.onQuerySuccess(readyUpdateIds)
+    callback.onSuccess(readyUpdateIds)
   }
 
   companion object {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
@@ -141,27 +141,28 @@ class UpdatesDevLauncherController : UpdatesInterface {
     )
   }
 
-  override fun storedUpdateIdsWithConfiguration(configuration: HashMap<String, Any>?, context: Context?, callback: UpdateCallback?) {
+  override fun storedUpdateIdsWithConfiguration(configuration: HashMap<String, Any>, context: Context, callback: UpdateCallback) {
     val controller = UpdatesController.instance
     val updatesConfiguration = UpdatesConfiguration(context, configuration)
     if (updatesConfiguration.updateUrl == null || updatesConfiguration.scopeKey == null) {
-      callback?.onFailure(Exception("Failed to load update: UpdatesConfiguration object must include a valid update URL"))
+      callback.onFailure(Exception("Failed to load update: UpdatesConfiguration object must include a valid update URL"))
       return
     }
-    if (controller.updatesDirectory == null) {
-      callback?.onFailure(controller.updatesDirectoryException)
+    val updatesDirectory = controller.updatesDirectory
+    if (updatesDirectory == null) {
+      callback.onFailure(controller.updatesDirectoryException)
       return
     }
     val databaseHolder = controller.databaseHolder
     val launcher = DatabaseLauncher(
       updatesConfiguration,
-      controller.updatesDirectory!!,
+      updatesDirectory,
       controller.fileDownloader,
       controller.selectionPolicy
     )
     val readyUpdateIds = launcher.getReadyUpdateIds(databaseHolder.database)
     controller.databaseHolder.releaseDatabase()
-    callback?.onQuerySuccess(readyUpdateIds)
+    callback.onQuerySuccess(readyUpdateIds)
   }
 
   companion object {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/UpdateDao.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/UpdateDao.kt
@@ -56,6 +56,9 @@ abstract class UpdateDao {
   @Query("SELECT * FROM updates WHERE status = :status;")
   abstract fun loadAllUpdatesWithStatus(status: UpdateStatus): List<UpdateEntity>
 
+  @Query("SELECT id FROM updates WHERE status = :status;")
+  abstract fun loadAllUpdateIdsWithStatus(status: UpdateStatus): List<UUID>
+
   fun loadUpdateWithId(id: UUID): UpdateEntity? {
     val updateEntities = _loadUpdatesWithId(id)
     return if (updateEntities.isNotEmpty()) updateEntities[0] else null

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.kt
@@ -124,6 +124,10 @@ class DatabaseLauncher(
     return selectionPolicy.selectUpdateToLaunch(filteredLaunchableUpdates, manifestFilters)
   }
 
+  fun getReadyUpdateIds(database: UpdatesDatabase): List<UUID> {
+    return database.updateDao().loadAllUpdateIdsWithStatus(UpdateStatus.READY)
+  }
+
   internal fun ensureAssetExists(asset: AssetEntity, database: UpdatesDatabase, context: Context): File? {
     val assetFile = File(updatesDirectory, asset.relativePath)
     var assetFileExists = assetFile.exists()


### PR DESCRIPTION
# Why

In order for the dev client to be able to indicate in the UI whether a particular update is available to load offline, we need to add a method to the expo-updates-interface to let it see which updates are stored locally (in sqlite) and ready to load.

It should be sufficient for this method to return a list of UUIDs for updates that have the READY status in sqlite.

# How

New method

```java
  void storedUpdateIdsWithConfiguration(HashMap<String, Object> configuration, Context context, UpdateCallback callback);
```

is added to the interface for Android.

The implementation in `UpdatesDevLauncherController` calls into a new method in `DatabaseLauncher`, which uses a new query in `UpdateDao` to retrieve READY update UUIDs.

# Test Plan

New unit tests are added to the existing `DatabaseLauncherTest` (Android test class) to verify the changes.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
