### PR TITLE
GitLab CI: fix the path to the cache

### DIFF
--- a/docs/pages/build/building-on-ci.md
+++ b/docs/pages/build/building-on-ci.md
@@ -110,13 +110,17 @@ image: node:alpine
 cache:
   key: ${CI_COMMIT_REF_SLUG}
   paths:
-    - ~/.npm
+    - .npm
+    # or with yarn:
+    #- .yarn
 
 stages:
   - build
 
 before_script:
-  - npm ci
+  - npm ci --cache .npm
+  # or with yarn:
+  #- yarn install --cache-folder .yarn
 
 eas-build:
   stage: build


### PR DESCRIPTION
# Why

Fixes #17883

# How

I took the example from the documentation of GitLab CI: https://docs.gitlab.com/ee/ci/caching/index.html#cache-nodejs-dependencies

# Test Plan

I tested it with GitLab CI.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
