### PR TITLE
[cli] fix ignored existing plugins on expo install

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -28,7 +28,7 @@
 - Fix tunnel on web breaking native. ([#17666](https://github.com/expo/expo/pull/17666) by [@EvanBacon](https://github.com/EvanBacon))
 - Add no-op `--experimental-bundle` flag to `expo export`. ([#17886](https://github.com/expo/expo/pull/17886) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix auto TypeScript version check. ([#17911](https://github.com/expo/expo/pull/17911) by [@EvanBacon](https://github.com/EvanBacon))
-- Fix ignored existing plugins on expo install.
+- Fix ignored existing plugins on expo install. ([#17936](https://github.com/expo/expo/pull/17936) by [@kbrandwijk](https://github.com/kbrandwijk))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Fix tunnel on web breaking native. ([#17666](https://github.com/expo/expo/pull/17666) by [@EvanBacon](https://github.com/EvanBacon))
 - Add no-op `--experimental-bundle` flag to `expo export`. ([#17886](https://github.com/expo/expo/pull/17886) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix auto TypeScript version check. ([#17911](https://github.com/expo/expo/pull/17911) by [@EvanBacon](https://github.com/EvanBacon))
+- Fix ignored existing plugins on expo install.
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/install/installAsync.ts
+++ b/packages/@expo/cli/src/install/installAsync.ts
@@ -107,7 +107,7 @@ async function applyPluginsAsync(projectRoot: string, packages: string[]) {
   const { autoAddConfigPluginsAsync } = await import('./utils/autoAddConfigPlugins');
 
   try {
-    const { exp } = getConfig(projectRoot, { skipSDKVersionRequirement: true, skipPlugins: false });
+    const { exp } = getConfig(projectRoot, { skipSDKVersionRequirement: true });
 
     // Only auto add plugins if the plugins array is defined or if the project is using SDK +42.
     await autoAddConfigPluginsAsync(

--- a/packages/@expo/cli/src/install/installAsync.ts
+++ b/packages/@expo/cli/src/install/installAsync.ts
@@ -107,7 +107,7 @@ async function applyPluginsAsync(projectRoot: string, packages: string[]) {
   const { autoAddConfigPluginsAsync } = await import('./utils/autoAddConfigPlugins');
 
   try {
-    const { exp } = getConfig(projectRoot, { skipSDKVersionRequirement: true, skipPlugins: true });
+    const { exp } = getConfig(projectRoot, { skipSDKVersionRequirement: true, skipPlugins: false });
 
     // Only auto add plugins if the plugins array is defined or if the project is using SDK +42.
     await autoAddConfigPluginsAsync(


### PR DESCRIPTION
# Why

Existing plugins were ignored retrieving the config for expo install.

# How

No longer skip resolving plugins on install.
See https://github.com/expo/expo-cli/pull/4429 for the sister fix for the existing `expo-cli`

# Test Plan

- Initialize a blank project
- `npx expo install expo-camera`
- Add `expo-camera` plugin to `app.json`: `"plugins": ["expo-camera"]`
- Run `npx expo install sentry-expo`
- Notice that both plugins exists in the plugins array

Will look into automated testing, but suggestions are welcome.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
