### PR TITLE
[sweet API][Kotlin] Add method to drain event loop

### DIFF
--- a/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.cpp
@@ -26,6 +26,7 @@ void JSIInteropModuleRegistry::registerNatives() {
                    makeNativeMethod("evaluateScript", JSIInteropModuleRegistry::evaluateScript),
                    makeNativeMethod("global", JSIInteropModuleRegistry::global),
                    makeNativeMethod("createObject", JSIInteropModuleRegistry::createObject),
+                   makeNativeMethod("drainJSEventLoop", JSIInteropModuleRegistry::drainJSEventLoop),
                  });
 }
 
@@ -113,5 +114,9 @@ jni::local_ref<JavaScriptObject::javaobject> JSIInteropModuleRegistry::global() 
 
 jni::local_ref<JavaScriptObject::javaobject> JSIInteropModuleRegistry::createObject() {
   return runtimeHolder->createObject();
+}
+
+void JSIInteropModuleRegistry::drainJSEventLoop() {
+  runtimeHolder->drainJSEventLoop();
 }
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.h
@@ -74,6 +74,11 @@ public:
    */
   jni::local_ref<JavaScriptObject::javaobject> createObject();
 
+  /**
+   * Exposes a `JavaScriptRuntime::drainJSEventLoop` function to Kotlin
+   */
+  void drainJSEventLoop();
+
   std::shared_ptr<react::CallInvoker> jsInvoker;
   std::shared_ptr<react::CallInvoker> nativeInvoker;
   std::shared_ptr<JavaScriptRuntime> runtimeHolder;

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.cpp
@@ -17,9 +17,10 @@
 
 #endif
 
+namespace jsi = facebook::jsi;
+
 namespace expo {
 
-namespace jsi = facebook::jsi;
 
 JavaScriptRuntime::JavaScriptRuntime() {
 #if FOR_HERMES
@@ -80,5 +81,9 @@ jni::local_ref<JavaScriptObject::javaobject> JavaScriptRuntime::global() {
 jni::local_ref<JavaScriptObject::javaobject> JavaScriptRuntime::createObject() {
   auto newObject = std::make_shared<jsi::Object>(*runtime);
   return JavaScriptObject::newObjectCxxArgs(weak_from_this(), newObject);
+}
+
+void JavaScriptRuntime::drainJSEventLoop() {
+  while (!runtime->drainMicrotasks()) {}
 }
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.h
@@ -59,6 +59,11 @@ public:
    */
   jni::local_ref<jni::HybridClass<JavaScriptObject>::javaobject> createObject();
 
+  /**
+   * Drains the JavaScript VM internal Microtask (a.k.a. event loop) queue.
+   */
+  void drainJSEventLoop();
+
   std::shared_ptr<react::CallInvoker> jsInvoker;
   std::shared_ptr<react::CallInvoker> nativeInvoker;
 private:

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIInteropModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIInteropModuleRegistry.kt
@@ -50,6 +50,11 @@ class JSIInteropModuleRegistry(appContext: AppContext) {
   external fun createObject(): JavaScriptObject
 
   /**
+   * Drains the JavaScript VM internal Microtask (a.k.a. event loop) queue.
+   */
+  external fun drainJSEventLoop()
+
+  /**
    * Returns a `JavaScriptModuleObject` that is a bridge between [expo.modules.kotlin.modules.Module]
    * and HostObject exported via JSI.
    *


### PR DESCRIPTION
# Why

Adds a method to drain even loop from Kotlin. 

# How

Exposes a `drainMicrotasks` function from `JSI`.
This function is very handy when you're trying to test async flows. 
