### PR TITLE
[sweet API][Kotlin] Add `isArray` and `getArray` functions to `JavaScriptValue`

### DIFF
--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptValue.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptValue.h
@@ -51,6 +51,8 @@ public:
 
   bool isFunction();
 
+  bool isArray();
+
   bool isObject();
 
   bool getBool();
@@ -60,6 +62,8 @@ public:
   std::string getString();
 
   jni::local_ref<jni::HybridClass<JavaScriptObject>::javaobject> getObject();
+
+  jni::local_ref<jni::JArrayClass<JavaScriptValue::javaobject>> getArray();
 
 private:
   friend HybridBase;

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptValue.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptValue.kt
@@ -19,12 +19,14 @@ class JavaScriptValue @DoNotStrip private constructor(@DoNotStrip private val mH
   external fun isString(): Boolean
   external fun isSymbol(): Boolean
   external fun isFunction(): Boolean
+  external fun isArray(): Boolean
   external fun isObject(): Boolean
 
   external fun getBool(): Boolean
   external fun getDouble(): Double
   external fun getString(): String
   external fun getObject(): JavaScriptObject
+  external fun getArray(): Array<JavaScriptValue>
 
   @Throws(Throwable::class)
   protected fun finalize() {


### PR DESCRIPTION
# Why

Adds functions to obtain arrays of `JavaScriptValue` from the `JavaScriptValue`.

# How

It was pretty straightforward. Iterate through js array and box all values in the `JavaScriptValue` object.

# Test Plan

- unit test will be added in a different PR ✅