### PR TITLE
[sweet API][Kotlin] Allow the `Any` type in the `TypeConverter`

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/CppType.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/CppType.kt
@@ -2,16 +2,12 @@ package expo.modules.kotlin.jni
 
 private var nextValue = 0
 
-private fun nextValue(): Int {
-  val result = 1 shl nextValue
-  nextValue++
-  return result
-}
+private fun nextValue(): Int = (1 shl nextValue).also { nextValue++ }
 
 /**
- * Enum that represents a Cpp types. Those types can be obtain via JNI.
+ * Enum that represents Cpp types. Objects of those types can be obtained via JNI.
  */
-enum class CppType(private val value: Int) {
+enum class CppType(val value: Int) {
   DOUBLE(nextValue()),
   BOOLEAN(nextValue()),
   STRING(nextValue()),
@@ -19,6 +15,4 @@ enum class CppType(private val value: Int) {
   JS_VALUE(nextValue()),
   READABLE_ARRAY(nextValue()),
   READABLE_MAP(nextValue());
-
-  fun toValue(): Int = value
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/CppType.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/CppType.kt
@@ -1,0 +1,24 @@
+package expo.modules.kotlin.jni
+
+private var nextValue = 0
+
+private fun nextValue(): Int {
+  val result = 1 shl nextValue
+  nextValue++
+  return result
+}
+
+/**
+ * Enum that represents a Cpp types. Those types can be obtain via JNI.
+ */
+enum class CppType(private val value: Int) {
+  DOUBLE(nextValue()),
+  BOOLEAN(nextValue()),
+  STRING(nextValue()),
+  JS_OBJECT(nextValue()),
+  JS_VALUE(nextValue()),
+  READABLE_ARRAY(nextValue()),
+  READABLE_MAP(nextValue());
+
+  fun toValue(): Int = value
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/AnyType.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/AnyType.kt
@@ -11,5 +11,5 @@ class AnyType(val kType: KType) {
 
   fun convert(value: Any?): Any? = converter.convert(value)
 
-  fun getCppRequiredTypes(): Int = converter.getCppRequiredTypes().fold(0) { acc, current -> acc or current.toValue() }
+  fun getCppRequiredTypes(): Int = converter.getCppRequiredTypes().fold(0) { acc, current -> acc or current.value }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/AnyType.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/AnyType.kt
@@ -1,6 +1,5 @@
 package expo.modules.kotlin.types
 
-import com.facebook.react.bridge.Dynamic
 import kotlin.reflect.KType
 
 fun KType.toAnyType(): AnyType = AnyType(this)
@@ -10,5 +9,7 @@ class AnyType(val kType: KType) {
     TypeConverterProviderImpl.obtainTypeConverter(kType)
   }
 
-  fun convert(value: Dynamic): Any? = converter.convert(value)
+  fun convert(value: Any?): Any? = converter.convert(value)
+
+  fun getCppRequiredTypes(): Int = converter.getCppRequiredTypes().fold(0) { acc, current -> acc or current.toValue() }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ArrayTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ArrayTypeConverter.kt
@@ -3,6 +3,7 @@ package expo.modules.kotlin.types
 import com.facebook.react.bridge.Dynamic
 import expo.modules.kotlin.exception.CollectionElementCastException
 import expo.modules.kotlin.exception.exceptionDecorator
+import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.recycle
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
@@ -10,14 +11,14 @@ import kotlin.reflect.KType
 class ArrayTypeConverter(
   converterProvider: TypeConverterProvider,
   private val arrayType: KType,
-) : TypeConverter<Array<*>>(arrayType.isMarkedNullable) {
+) : DynamicAwareTypeConverters<Array<*>>(arrayType.isMarkedNullable) {
   private val arrayElementConverter = converterProvider.obtainTypeConverter(
     requireNotNull(arrayType.arguments.first().type) {
       "The array type should contain the type of the elements."
     }
   )
 
-  override fun convertNonOptional(value: Dynamic): Array<*> {
+  override fun convertFromDynamic(value: Dynamic): Array<*> {
     val jsArray = value.asArray()
     val array = createTypedArray(jsArray.size())
     for (i in 0 until jsArray.size()) {
@@ -34,6 +35,8 @@ class ArrayTypeConverter(
     return array
   }
 
+  override fun convertFromAny(value: Any): Array<*> = value as Array<*>
+
   /**
    * We can't use a Array<Any?> here. We have to create a typed array.
    * Otherwise, cast which is done before calling lambda provided by the user will always fail.
@@ -47,4 +50,6 @@ class ArrayTypeConverter(
       size
     ) as Array<Any?>
   }
+
+  override fun getCppRequiredTypes(): List<CppType> = listOf(CppType.READABLE_ARRAY)
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/BasicTypeConverters.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/BasicTypeConverters.kt
@@ -10,7 +10,7 @@ import expo.modules.kotlin.jni.JavaScriptValue
 class IntTypeConverter(isOptional: Boolean) : DynamicAwareTypeConverters<Int>(isOptional) {
   override fun convertFromDynamic(value: Dynamic): Int = value.asInt()
   override fun convertFromAny(value: Any): Int = when (value) {
-    is Double -> value.toInt()
+    is Number -> value.toInt()
     else -> value as Int
   }
 
@@ -20,7 +20,7 @@ class IntTypeConverter(isOptional: Boolean) : DynamicAwareTypeConverters<Int>(is
 class DoubleTypeConverter(isOptional: Boolean) : DynamicAwareTypeConverters<Double>(isOptional) {
   override fun convertFromDynamic(value: Dynamic): Double = value.asDouble()
   override fun convertFromAny(value: Any): Double = when (value) {
-    is Int -> value.toDouble()
+    is Number -> value.toDouble()
     else -> value as Double
   }
 
@@ -30,8 +30,7 @@ class DoubleTypeConverter(isOptional: Boolean) : DynamicAwareTypeConverters<Doub
 class FloatTypeConverter(isOptional: Boolean) : DynamicAwareTypeConverters<Float>(isOptional) {
   override fun convertFromDynamic(value: Dynamic): Float = value.asDouble().toFloat()
   override fun convertFromAny(value: Any): Float = when (value) {
-    is Int -> value.toFloat()
-    is Double -> value.toFloat()
+    is Number -> value.toFloat()
     else -> value as Float
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/BasicTypeConverters.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/BasicTypeConverters.kt
@@ -3,58 +3,107 @@ package expo.modules.kotlin.types
 import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import expo.modules.kotlin.jni.CppType
+import expo.modules.kotlin.jni.JavaScriptObject
+import expo.modules.kotlin.jni.JavaScriptValue
 
-class IntTypeConverter(isOptional: Boolean) : TypeConverter<Int>(isOptional) {
-  override fun convertNonOptional(value: Dynamic): Int = value.asInt()
+class IntTypeConverter(isOptional: Boolean) : DynamicAwareTypeConverters<Int>(isOptional) {
+  override fun convertFromDynamic(value: Dynamic): Int = value.asInt()
+  override fun convertFromAny(value: Any): Int = when (value) {
+    is Double -> value.toInt()
+    else -> value as Int
+  }
+
+  override fun getCppRequiredTypes(): List<CppType> = listOf(CppType.DOUBLE)
 }
 
-class DoubleTypeConverter(isOptional: Boolean) : TypeConverter<Double>(isOptional) {
-  override fun convertNonOptional(value: Dynamic): Double = value.asDouble()
+class DoubleTypeConverter(isOptional: Boolean) : DynamicAwareTypeConverters<Double>(isOptional) {
+  override fun convertFromDynamic(value: Dynamic): Double = value.asDouble()
+  override fun convertFromAny(value: Any): Double = when (value) {
+    is Int -> value.toDouble()
+    else -> value as Double
+  }
+
+  override fun getCppRequiredTypes(): List<CppType> = listOf(CppType.DOUBLE)
 }
 
-class FloatTypeConverter(isOptional: Boolean) : TypeConverter<Float>(isOptional) {
-  override fun convertNonOptional(value: Dynamic): Float = value.asDouble().toFloat()
+class FloatTypeConverter(isOptional: Boolean) : DynamicAwareTypeConverters<Float>(isOptional) {
+  override fun convertFromDynamic(value: Dynamic): Float = value.asDouble().toFloat()
+  override fun convertFromAny(value: Any): Float = when (value) {
+    is Int -> value.toFloat()
+    is Double -> value.toFloat()
+    else -> value as Float
+  }
+
+  override fun getCppRequiredTypes(): List<CppType> = listOf(CppType.DOUBLE)
 }
 
-class BoolTypeConverter(isOptional: Boolean) : TypeConverter<Boolean>(isOptional) {
-  override fun convertNonOptional(value: Dynamic): Boolean = value.asBoolean()
+class BoolTypeConverter(isOptional: Boolean) : DynamicAwareTypeConverters<Boolean>(isOptional) {
+  override fun convertFromDynamic(value: Dynamic): Boolean = value.asBoolean()
+  override fun convertFromAny(value: Any): Boolean = value as Boolean
+  override fun getCppRequiredTypes(): List<CppType> = listOf(CppType.BOOLEAN)
 }
 
-class StringTypeConverter(isOptional: Boolean) : TypeConverter<String>(isOptional) {
-  override fun convertNonOptional(value: Dynamic): String = value.asString()
+class StringTypeConverter(isOptional: Boolean) : DynamicAwareTypeConverters<String>(isOptional) {
+  override fun convertFromDynamic(value: Dynamic): String = value.asString()
+  override fun convertFromAny(value: Any): String = value as String
+  override fun getCppRequiredTypes(): List<CppType> = listOf(CppType.STRING)
 }
 
-class ReadableArrayTypeConverter(isOptional: Boolean) : TypeConverter<ReadableArray>(isOptional) {
-  override fun convertNonOptional(value: Dynamic): ReadableArray = value.asArray()
+class ReadableArrayTypeConverter(isOptional: Boolean) : DynamicAwareTypeConverters<ReadableArray>(isOptional) {
+  override fun convertFromDynamic(value: Dynamic): ReadableArray = value.asArray()
+  override fun convertFromAny(value: Any): ReadableArray = value as ReadableArray
+  override fun getCppRequiredTypes(): List<CppType> = listOf(CppType.READABLE_ARRAY)
 }
 
-class ReadableMapTypeConverter(isOptional: Boolean) : TypeConverter<ReadableMap>(isOptional) {
-  override fun convertNonOptional(value: Dynamic): ReadableMap = value.asMap()
+class ReadableMapTypeConverter(isOptional: Boolean) : DynamicAwareTypeConverters<ReadableMap>(isOptional) {
+  override fun convertFromDynamic(value: Dynamic): ReadableMap = value.asMap()
+  override fun convertFromAny(value: Any): ReadableMap = value as ReadableMap
+  override fun getCppRequiredTypes(): List<CppType> = listOf(CppType.READABLE_MAP)
 }
 
-class PrimitiveIntArrayTypeConverter(isOptional: Boolean) : TypeConverter<IntArray>(isOptional) {
-  override fun convertNonOptional(value: Dynamic): IntArray {
+class PrimitiveIntArrayTypeConverter(isOptional: Boolean) : DynamicAwareTypeConverters<IntArray>(isOptional) {
+  override fun convertFromDynamic(value: Dynamic): IntArray {
     val jsArray = value.asArray()
     return IntArray(jsArray.size()) { index ->
       jsArray.getInt(index)
     }
   }
+
+  override fun convertFromAny(value: Any): IntArray = value as IntArray
+  override fun getCppRequiredTypes(): List<CppType> = listOf(CppType.READABLE_ARRAY)
 }
 
-class PrimitiveDoubleArrayTypeConverter(isOptional: Boolean) : TypeConverter<DoubleArray>(isOptional) {
-  override fun convertNonOptional(value: Dynamic): DoubleArray {
+class PrimitiveDoubleArrayTypeConverter(isOptional: Boolean) : DynamicAwareTypeConverters<DoubleArray>(isOptional) {
+  override fun convertFromDynamic(value: Dynamic): DoubleArray {
     val jsArray = value.asArray()
     return DoubleArray(jsArray.size()) { index ->
       jsArray.getDouble(index)
     }
   }
+
+  override fun convertFromAny(value: Any): DoubleArray = value as DoubleArray
+  override fun getCppRequiredTypes(): List<CppType> = listOf(CppType.READABLE_ARRAY)
 }
 
-class PrimitiveFloatArrayTypeConverter(isOptional: Boolean) : TypeConverter<FloatArray>(isOptional) {
-  override fun convertNonOptional(value: Dynamic): FloatArray {
+class PrimitiveFloatArrayTypeConverter(isOptional: Boolean) : DynamicAwareTypeConverters<FloatArray>(isOptional) {
+  override fun convertFromDynamic(value: Dynamic): FloatArray {
     val jsArray = value.asArray()
     return FloatArray(jsArray.size()) { index ->
       jsArray.getDouble(index).toFloat()
     }
   }
+
+  override fun convertFromAny(value: Any): FloatArray = value as FloatArray
+  override fun getCppRequiredTypes(): List<CppType> = listOf(CppType.READABLE_ARRAY)
+}
+
+class JavaScriptValueTypeConvert(isOptional: Boolean) : TypeConverter<JavaScriptValue>(isOptional) {
+  override fun convertNonOptional(value: Any): JavaScriptValue = value as JavaScriptValue
+  override fun getCppRequiredTypes(): List<CppType> = CppType.values().toList()
+}
+
+class JavaScriptObjectTypeConverter(isOptional: Boolean) : TypeConverter<JavaScriptObject>(isOptional) {
+  override fun convertNonOptional(value: Any): JavaScriptObject = value as JavaScriptObject
+  override fun getCppRequiredTypes(): List<CppType> = listOf(CppType.JS_OBJECT)
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EnumTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EnumTypeConverter.kt
@@ -14,15 +14,15 @@ class EnumTypeConverter(
   isOptional: Boolean
 ) : DynamicAwareTypeConverters<Enum<*>>(isOptional) {
   private val enumConstants = requireNotNull(enumClass.java.enumConstants) {
-    "Passed type is not an enum type."
+    "Passed type is not an enum type"
   }.also {
     require(it.isNotEmpty()) {
-      "Passed enum type is empty."
+      "Passed enum type is empty"
     }
   }
 
   private val primaryConstructor = requireNotNull(enumClass.primaryConstructor) {
-    "Cannot convert js value to enum without the primary constructor."
+    "Cannot convert js value to enum without the primary constructor"
   }
 
   override fun getCppRequiredTypes(): List<CppType> = listOf(CppType.READABLE_MAP)
@@ -65,7 +65,7 @@ class EnumTypeConverter(
   ): Enum<*> {
     return requireNotNull(
       enumConstants.find { it.name == stringRepresentation }
-    ) { "Couldn't convert $stringRepresentation to ${enumClass.simpleName}." }
+    ) { "Couldn't convert '$stringRepresentation' to ${enumClass.simpleName}" }
   }
 
   /**
@@ -82,7 +82,7 @@ class EnumTypeConverter(
     val parameterProperty = enumClass
       .declaredMemberProperties
       .find { it.name == parameterName }
-    requireNotNull(parameterProperty) { "Cannot find a property for $parameterName parameter." }
+    requireNotNull(parameterProperty) { "Cannot find a property for $parameterName parameter" }
 
     val parameterType = parameterProperty.returnType.classifier
     val jsUnwrapValue = if (jsValue is Dynamic) {
@@ -107,6 +107,6 @@ class EnumTypeConverter(
       enumConstants.find {
         parameterProperty.get(it) == jsUnwrapValue
       }
-    ) { "Couldn't convert $jsValue to ${enumClass.simpleName} where $parameterName is the enum parameter. " }
+    ) { "Couldn't convert '$jsValue' to ${enumClass.simpleName} where $parameterName is the enum parameter" }
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EnumTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EnumTypeConverter.kt
@@ -2,6 +2,7 @@ package expo.modules.kotlin.types
 
 import com.facebook.react.bridge.Dynamic
 import expo.modules.kotlin.exception.IncompatibleArgTypeException
+import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.toKType
 import kotlin.reflect.KClass
 import kotlin.reflect.full.createType
@@ -11,22 +12,24 @@ import kotlin.reflect.full.primaryConstructor
 class EnumTypeConverter(
   private val enumClass: KClass<Enum<*>>,
   isOptional: Boolean
-) : TypeConverter<Enum<*>>(isOptional) {
-  override fun convertNonOptional(value: Dynamic): Enum<*> {
-    @Suppress("UNCHECKED_CAST")
-    val enumConstants = requireNotNull(enumClass.java.enumConstants) {
-      "Passed type is not an enum type."
-    }
-    require(enumConstants.isNotEmpty()) {
+) : DynamicAwareTypeConverters<Enum<*>>(isOptional) {
+  private val enumConstants = requireNotNull(enumClass.java.enumConstants) {
+    "Passed type is not an enum type."
+  }.also {
+    require(it.isNotEmpty()) {
       "Passed enum type is empty."
     }
+  }
 
-    val primaryConstructor = requireNotNull(enumClass.primaryConstructor) {
-      "Cannot convert js value to enum without the primary constructor."
-    }
+  private val primaryConstructor = requireNotNull(enumClass.primaryConstructor) {
+    "Cannot convert js value to enum without the primary constructor."
+  }
 
+  override fun getCppRequiredTypes(): List<CppType> = listOf(CppType.READABLE_MAP)
+
+  override fun convertFromDynamic(value: Dynamic): Enum<*> {
     if (primaryConstructor.parameters.isEmpty()) {
-      return convertEnumWithoutParameter(value, enumConstants)
+      return convertEnumWithoutParameter(value.asString(), enumConstants)
     } else if (primaryConstructor.parameters.size == 1) {
       return convertEnumWithParameter(
         value,
@@ -38,18 +41,31 @@ class EnumTypeConverter(
     throw IncompatibleArgTypeException(value.type.toKType(), enumClass.createType())
   }
 
+  override fun convertFromAny(value: Any): Enum<*> {
+    if (primaryConstructor.parameters.isEmpty()) {
+      return convertEnumWithoutParameter(value as String, enumConstants)
+    } else if (primaryConstructor.parameters.size == 1) {
+      return convertEnumWithParameter(
+        value,
+        enumConstants,
+        primaryConstructor.parameters.first().name!!
+      )
+    }
+
+    throw IncompatibleArgTypeException(value::class.createType(), enumClass.createType())
+  }
+
   /**
    * If the primary constructor doesn't take any parameters, we treat the name of each enum as a value.
    * So the jsValue has to contain string.
    */
   private fun convertEnumWithoutParameter(
-    jsValue: Dynamic,
+    stringRepresentation: String,
     enumConstants: Array<out Enum<*>>
   ): Enum<*> {
-    val unwrappedJsValue = jsValue.asString()
     return requireNotNull(
-      enumConstants.find { it.name == unwrappedJsValue }
-    ) { "Couldn't convert ${jsValue.asString()} to ${enumClass.simpleName}." }
+      enumConstants.find { it.name == stringRepresentation }
+    ) { "Couldn't convert $stringRepresentation to ${enumClass.simpleName}." }
   }
 
   /**
@@ -57,7 +73,7 @@ class EnumTypeConverter(
    * In that case, we handles two different types: Int and String.
    */
   private fun convertEnumWithParameter(
-    jsValue: Dynamic,
+    jsValue: Any,
     enumConstants: Array<out Enum<*>>,
     parameterName: String
   ): Enum<*> {
@@ -69,16 +85,28 @@ class EnumTypeConverter(
     requireNotNull(parameterProperty) { "Cannot find a property for $parameterName parameter." }
 
     val parameterType = parameterProperty.returnType.classifier
-    val jsUnwrapValue = if (parameterType == String::class) {
-      jsValue.asString()
+    val jsUnwrapValue = if (jsValue is Dynamic) {
+      if (parameterType == String::class) {
+        jsValue.asString()
+      } else {
+        jsValue.asInt()
+      }
     } else {
-      jsValue.asInt()
+      if (parameterType == String::class) {
+        jsValue as String
+      } else {
+        if (jsValue is Double) {
+          jsValue.toInt()
+        } else {
+          jsValue as Int
+        }
+      }
     }
 
     return requireNotNull(
       enumConstants.find {
         parameterProperty.get(it) == jsUnwrapValue
       }
-    ) { "Couldn't convert ${jsValue.asString()} to ${enumClass.simpleName} where $parameterName is the enum parameter. " }
+    ) { "Couldn't convert $jsValue to ${enumClass.simpleName} where $parameterName is the enum parameter. " }
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverter.kt
@@ -2,12 +2,23 @@ package expo.modules.kotlin.types
 
 import com.facebook.react.bridge.Dynamic
 import expo.modules.kotlin.exception.NullArgumentException
+import expo.modules.kotlin.jni.CppType
 
+/**
+ * Basic type converter. It has to handle two different inputs - [Dynamic] and [Any].
+ * The first one is used in the bridge implementation. The second one is used in the JSI.
+ */
 abstract class TypeConverter<Type : Any>(
+  /**
+   * Whether `null` can be assigned to the desired type.
+   */
   private val isOptional: Boolean
 ) {
-  open fun convert(value: Dynamic): Type? {
-    if (value.isNull) {
+  /**
+   * Tries to convert from [Any]? (can be also [Dynamic]) to the desired type.
+   */
+  fun convert(value: Any?): Type? {
+    if (value == null || value is Dynamic && value.isNull) {
       if (isOptional) {
         return null
       }
@@ -16,5 +27,34 @@ abstract class TypeConverter<Type : Any>(
     return convertNonOptional(value)
   }
 
-  abstract fun convertNonOptional(value: Dynamic): Type
+  /**
+   * Tries to convert from [Any] to the desired type.
+   * We know in that place that we're not dealing with `null`.
+   */
+  abstract fun convertNonOptional(value: Any): Type
+
+  /**
+   * Returns a list of C++ types that can be converted to the desired type.
+   * Sometimes we have a choice between multiple representations of the same value.
+   * For instance js object can be pass as [Map] or [expo.modules.kotlin.jni.JavaScriptObject].
+   * This value tells us which one we should choose.
+   */
+  abstract fun getCppRequiredTypes(): List<CppType>
+}
+
+/**
+ * A helper class to make a clear separation between [Any] and [Dynamic].
+ * Right it is used as a default base class for all converters, but this will change when we
+ * stop using the bridge to pass data between JS and Kotlin.
+ */
+abstract class DynamicAwareTypeConverters<T : Any>(isOptional: Boolean) : TypeConverter<T>(isOptional) {
+  override fun convertNonOptional(value: Any): T =
+    if (value is Dynamic) {
+      convertFromDynamic(value)
+    } else {
+      convertFromAny(value)
+    }
+
+  abstract fun convertFromDynamic(value: Dynamic): T
+  abstract fun convertFromAny(value: Any): T
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
@@ -6,6 +6,8 @@ import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import expo.modules.kotlin.exception.MissingTypeConverter
+import expo.modules.kotlin.jni.JavaScriptObject
+import expo.modules.kotlin.jni.JavaScriptValue
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.records.RecordTypeConverter
 import kotlin.reflect.KClass
@@ -110,6 +112,9 @@ object TypeConverterProviderImpl : TypeConverterProvider {
       IntArray::class.createType(nullable = isOptional) to PrimitiveIntArrayTypeConverter(isOptional),
       DoubleArray::class.createType(nullable = isOptional) to PrimitiveDoubleArrayTypeConverter(isOptional),
       FloatArray::class.createType(nullable = isOptional) to PrimitiveFloatArrayTypeConverter(isOptional),
+
+      JavaScriptValue::class.createType(nullable = isOptional) to JavaScriptValueTypeConvert(isOptional),
+      JavaScriptObject::class.createType(nullable = isOptional) to JavaScriptObjectTypeConverter(isOptional),
     )
   }
 }


### PR DESCRIPTION
# Why

This is the first step needed to implement all conversion logic in the Cpp that doesn't use a `folly`.

# How

- Changes signature of `convert` function - right now it receives `Any?` instead of `Dynamic`.
- Adds a `DynamicAwareTypeConverters` that handles `Dynamic` types in a separate method. This will be handy in the future when we will remove the conversion from the `Dynamic`.
- Adds `CppType` enum that represents types that can be obtained via JNI. This information will be used later to determine the correct representation of js values. 

# Test Plan

- unit test will be added later 😅
