### PR TITLE
[sweet API][Kotlin] Set up a test environment for async flow

### DIFF
--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -249,6 +249,8 @@ dependencies {
   androidTestImplementation 'androidx.test:rules:1.4.0'
   androidTestImplementation "io.mockk:mockk-android:1.12.3"
   androidTestImplementation "com.google.truth:truth:1.1.2"
+  androidTestImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.0"
+
   if (FOR_HERMES) {
     androidTestImplementation files(new File(HERMES_DIR, "android/hermes-debug.aar"))
   } else {

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.cpp
@@ -20,11 +20,49 @@
 namespace expo {
 
 namespace jsi = facebook::jsi;
+void SyncCallInvoker::invokeAsync(std::function<void()> &&func) {
+  func();
+}
 
-JavaScriptRuntime::JavaScriptRuntime() {
+void SyncCallInvoker::invokeSync(std::function<void()> &&func) {
+  func();
+}
+
+JavaScriptRuntime::JavaScriptRuntime()
+  : jsInvoker(std::make_shared<SyncCallInvoker>()),
+    nativeInvoker(std::make_shared<SyncCallInvoker>()) {
 #if FOR_HERMES
-  auto config = ::hermes::vm::RuntimeConfig::Builder().withEnableSampleProfiling(false);
+  auto config = ::hermes::vm::RuntimeConfig::Builder()
+    .withEnableSampleProfiling(false);
   runtime = facebook::hermes::makeHermesRuntime(config.build());
+
+  // By default "global" property isn't set in the Hermes.
+  runtime->global().setProperty(
+    *runtime,
+    jsi::PropNameID::forUtf8(*runtime, "global"),
+    runtime->global()
+  );
+
+  // This version of the Hermes uses a Promise implementation that is provided by the RN.
+  // The `setImmediate` function isn't defined, but is required by the Promise implementation.
+  // That's why we inject it here.
+  auto setImmediatePropName = jsi::PropNameID::forUtf8(*runtime, "setImmediate");
+  runtime->global().setProperty(
+    *runtime,
+    setImmediatePropName,
+    jsi::Function::createFromHostFunction(
+      *runtime,
+      setImmediatePropName,
+      1,
+      [](jsi::Runtime &rt,
+         const jsi::Value &thisVal,
+         const jsi::Value *args,
+         size_t count) {
+        args[0].asObject(rt).asFunction(rt).call(rt);
+        return jsi::Value::undefined();
+      }
+    )
+  );
 #else
   runtime = facebook::jsc::makeJSCRuntime();
 #endif

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.h
@@ -6,14 +6,27 @@
 #include <fbjni/fbjni.h>
 #include <ReactCommon/CallInvoker.h>
 
-
 namespace jsi = facebook::jsi;
 namespace jni = facebook::jni;
 namespace react = facebook::react;
 
 namespace expo {
 class JavaScriptValue;
+
 class JavaScriptObject;
+
+/**
+ * Dummy CallInvoker that invokes everything immediately.
+ * Used in the test environment to check the async flow.
+ */
+class SyncCallInvoker : public react::CallInvoker {
+public:
+  void invokeAsync(std::function<void()> &&func) override;
+
+  void invokeSync(std::function<void()> &&func) override;
+
+  ~SyncCallInvoker() override = default;
+};
 
 /**
  * A wrapper for the jsi::Runtime.
@@ -27,7 +40,7 @@ class JavaScriptRuntime : public std::enable_shared_from_this<JavaScriptRuntime>
 public:
   /**
    * Initializes a runtime that is independent from React Native and its runtime initialization.
-   * This flow is mostly intended for tests. The JS call invoker is unavailable thus calling async functions is not supported.
+   * This flow is mostly intended for tests. The JS call invoker is set to `SyncCallInvoker`.
    */
   JavaScriptRuntime();
 
@@ -47,7 +60,9 @@ public:
    * @throws if the input format is unknown, or evaluation causes an error,
    * a jni::JniException<JavaScriptEvaluateException> will be thrown.
    */
-  jni::local_ref<jni::HybridClass<JavaScriptValue>::javaobject> evaluateScript(const std::string &script);
+  jni::local_ref<jni::HybridClass<JavaScriptValue>::javaobject> evaluateScript(
+    const std::string &script
+  );
 
   /**
    * Returns the runtime global object for use in Kotlin.


### PR DESCRIPTION
# Why

Sets up a test environment to work with async functions. 

# How

- Implemented a basic `CallInvoker` that automatically calls the received function. 
- Mocked `setImmediate ` function that is needed by Hermes `Promise` implementation.
- Exports a `global` object to the js.
