### PR TITLE
Update React Native Directory Link

### DIFF
--- a/docs/pages/workflow/glossary-of-terms.md
+++ b/docs/pages/workflow/glossary-of-terms.md
@@ -73,7 +73,7 @@ An Expo app manifest is similar to a [web app manifest](https://developer.mozill
 
 ### Native Directory
 
-The React Native ecosystem has thousands of libraries. Without a purpose-built tool, it's hard to know what the libraries are, to search through them, to determine the quality, try them out, and filter out the libraries that won't work for your project (some don't work with Expo, some don't work with Android or iOS). [Native Directory](https://reactnative.directory/) is a website that aims to solve this problem, we recommend you use it to find packages to use in your projects.
+The React Native ecosystem has thousands of libraries. Without a purpose-built tool, it's hard to know what the libraries are, to search through them, to determine the quality, try them out, and filter out the libraries that won't work for your project (some don't work with Expo, some don't work with Android or iOS). [React Native Directory](https://reactnative.directory/) is a website that aims to solve this problem, we recommend you use it to find packages to use in your projects.
 
 ### npm
 

--- a/docs/pages/workflow/glossary-of-terms.md
+++ b/docs/pages/workflow/glossary-of-terms.md
@@ -73,7 +73,7 @@ An Expo app manifest is similar to a [web app manifest](https://developer.mozill
 
 ### Native Directory
 
-The React Native ecosystem has thousands of libraries. Without a purpose-built tool, it's hard to know what the libraries are, to search through them, to determine the quality, try them out, and filter out the libraries that won't work for your project (some don't work with Expo, some don't work with Android or iOS). [Native Directory](http://native.directory/) is a website that aims to solve this problem, we recommend you use it to find packages to use in your projects.
+The React Native ecosystem has thousands of libraries. Without a purpose-built tool, it's hard to know what the libraries are, to search through them, to determine the quality, try them out, and filter out the libraries that won't work for your project (some don't work with Expo, some don't work with Android or iOS). [Native Directory](https://reactnative.directory/) is a website that aims to solve this problem, we recommend you use it to find packages to use in your projects.
 
 ### npm
 


### PR DESCRIPTION
Update React Directory link to help users find appropriate Expo Compatible libraries.

# Why

Old link was going to a blogging website

# How

Simple readme update. I googled around to find the intended website.

# Test Plan

Navigate to website, verify legitimacy.

# Checklist

- [ x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
