### PR TITLE
[sweet][swift] Fix optional function arguments

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 - Fix modules have not been deallocated during the application reload on iOS. ([#17285](https://github.com/expo/expo/pull/17285) by [@lukmccall](https://github.com/lukmccall))
 - Fix view props weren't recognized in the bare workflow on iOS. ([#17411](https://github.com/expo/expo/pull/17411) by [@lukmccall](https://github.com/lukmccall))
+- Fix support for optional function arguments on iOS. ([#17950](https://github.com/expo/expo/pull/17950) by [@barthap](https://github.com/barthap))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/Swift/Arguments/AnyArgument.swift
+++ b/packages/expo-modules-core/ios/Swift/Arguments/AnyArgument.swift
@@ -5,6 +5,9 @@
  */
 public protocol AnyArgument {}
 
+// Extend the optional type - this is required to support optional arguments.
+extension Optional: AnyArgument where Wrapped: AnyArgument {}
+
 // Extend the primitive types — these may come from React Native bridge.
 extension Bool: AnyArgument {}
 

--- a/packages/expo-modules-core/ios/Swift/DynamicTypes/DynamicOptionalType.swift
+++ b/packages/expo-modules-core/ios/Swift/DynamicTypes/DynamicOptionalType.swift
@@ -22,7 +22,7 @@ internal struct DynamicOptionalType: AnyDynamicType {
   }
 
   func cast<ValueType>(_ value: ValueType) throws -> Any {
-    if Optional.isNil(value) {
+    if Optional.isNil(value) || value is NSNull {
       return Optional<Any>.none as Any
     }
     return try wrappedType.cast(value)

--- a/packages/expo-modules-core/ios/Tests/DynamicTypeSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/DynamicTypeSpec.swift
@@ -247,6 +247,12 @@ final class DynamicTypeSpec: ExpoSpec {
           // Simply checking `result == nil` does NOT work here, see `Optional.isNil` extension implementation.
           expect(Optional.isNil(result)) == true
         }
+        it("succeeds with NSNull") {
+          let value = NSNull()
+          let result = try (~Double?.self).cast(value as Any)
+          expect(result).to(beAKindOf(Double?.self))
+          expect(Optional.isNil(result)) == true
+        }
         it("throws CastingException") {
           expect { try (~Double?.self).cast("a string") as? Double }.to(
             throwError(errorType: Conversions.CastingException<Double>.self)

--- a/packages/expo-modules-core/ios/Tests/FunctionSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/FunctionSpec.swift
@@ -4,190 +4,222 @@ import ExpoModulesTestCore
 
 class FunctionSpec: ExpoSpec {
   override func spec() {
-    let appContext = AppContext()
+    let appContext = AppContext.create()
     let functionName = "test function name"
 
-    func testFunctionReturning<T: Equatable>(value returnValue: T) {
-      waitUntil { done in
-        mockModuleHolder(appContext) {
-          AsyncFunction(functionName) {
-            return returnValue
-          }
-        }
-        .call(function: functionName, args: []) { result in
-          let value = try! result.get()
-
-          expect(value).notTo(beNil())
-          expect(value).to(beAKindOf(T.self))
-          expect(value as? T).to(equal(returnValue))
-          done()
-        }
-      }
-    }
-
-    it("is called") {
-      waitUntil { done in
-        mockModuleHolder(appContext) {
-          AsyncFunction(functionName) {
-            done()
-          }
-        }
-        .call(function: functionName, args: [])
-      }
-    }
-
-    it("returns bool values") {
-      testFunctionReturning(value: true)
-      testFunctionReturning(value: false)
-      testFunctionReturning(value: [true, false])
-    }
-
-    it("returns int values") {
-      testFunctionReturning(value: 1_234)
-      testFunctionReturning(value: [2, 1, 3, 7])
-    }
-
-    it("returns double values") {
-      testFunctionReturning(value: 3.14)
-      testFunctionReturning(value: [0, 1.1, 2.2])
-    }
-
-    it("returns string values") {
-      testFunctionReturning(value: "a string")
-      testFunctionReturning(value: ["expo", "modules", "core"])
-    }
-
-    it("is called with nil value") {
-      let str: String? = nil
-
-      mockModuleHolder(appContext) {
-        AsyncFunction(functionName) { (a: String?) in
-          expect(a == nil) == true
-        }
-      }
-      .callSync(function: functionName, args: [str as Any])
-    }
-
-    it("is called with an array of arrays") {
-      let array: [[String]] = [["expo"]]
-
-      mockModuleHolder(appContext) {
-        AsyncFunction(functionName) { (a: [[String]]) in
-          expect(a.first!.first) == array.first!.first
-        }
-      }
-      .callSync(function: functionName, args: [array])
-    }
-
-    describe("converting dicts to records") {
-      struct TestRecord: Record {
-        @Field var property: String = "expo"
-        @Field var optionalProperty: Int?
-        @Field("propertyWithCustomKey") var customKeyProperty: String = "expo"
-      }
-      let dict = [
-        "property": "Hello",
-        "propertyWithCustomKey": "Expo!"
-      ]
-
-      it("converts to simple record when passed as an argument") {
+    context("native") {
+      func testFunctionReturning<T: Equatable>(value returnValue: T) {
         waitUntil { done in
           mockModuleHolder(appContext) {
-            AsyncFunction(functionName) { (a: TestRecord) in
-              return a.property
+            AsyncFunction(functionName) {
+              return returnValue
             }
           }
-          .call(function: functionName, args: [dict]) { result in
+          .call(function: functionName, args: []) { result in
             let value = try! result.get()
 
             expect(value).notTo(beNil())
-            expect(value).to(beAKindOf(String.self))
-            expect(value).to(be(dict["property"]))
+            expect(value).to(beAKindOf(T.self))
+            expect(value as? T).to(equal(returnValue))
             done()
           }
         }
       }
 
-      it("converts to record with custom key") {
+      it("is called") {
         waitUntil { done in
           mockModuleHolder(appContext) {
-            AsyncFunction(functionName) { (a: TestRecord) in
-              return a.customKeyProperty
+            AsyncFunction(functionName) {
+              done()
             }
           }
-          .call(function: functionName, args: [dict]) { result in
-            let value = try! result.get()
-            expect(value).notTo(beNil())
-            expect(value).to(beAKindOf(String.self))
-            expect(value).to(be(dict["propertyWithCustomKey"]))
+          .call(function: functionName, args: [])
+        }
+      }
+
+      it("returns bool values") {
+        testFunctionReturning(value: true)
+        testFunctionReturning(value: false)
+        testFunctionReturning(value: [true, false])
+      }
+
+      it("returns int values") {
+        testFunctionReturning(value: 1_234)
+        testFunctionReturning(value: [2, 1, 3, 7])
+      }
+
+      it("returns double values") {
+        testFunctionReturning(value: 3.14)
+        testFunctionReturning(value: [0, 1.1, 2.2])
+      }
+
+      it("returns string values") {
+        testFunctionReturning(value: "a string")
+        testFunctionReturning(value: ["expo", "modules", "core"])
+      }
+
+      it("is called with nil value") {
+        let str: String? = nil
+
+        mockModuleHolder(appContext) {
+          AsyncFunction(functionName) { (a: String?) in
+            expect(a == nil) == true
+          }
+        }
+        .callSync(function: functionName, args: [str as Any])
+      }
+
+      it("is called with an array of arrays") {
+        let array: [[String]] = [["expo"]]
+
+        mockModuleHolder(appContext) {
+          AsyncFunction(functionName) { (a: [[String]]) in
+            expect(a.first!.first) == array.first!.first
+          }
+        }
+        .callSync(function: functionName, args: [array])
+      }
+
+      describe("converting dicts to records") {
+        struct TestRecord: Record {
+          @Field var property: String = "expo"
+          @Field var optionalProperty: Int?
+          @Field("propertyWithCustomKey") var customKeyProperty: String = "expo"
+        }
+        let dict = [
+          "property": "Hello",
+          "propertyWithCustomKey": "Expo!"
+        ]
+
+        it("converts to simple record when passed as an argument") {
+          waitUntil { done in
+            mockModuleHolder(appContext) {
+              AsyncFunction(functionName) { (a: TestRecord) in
+                return a.property
+              }
+            }
+            .call(function: functionName, args: [dict]) { result in
+              let value = try! result.get()
+
+              expect(value).notTo(beNil())
+              expect(value).to(beAKindOf(String.self))
+              expect(value).to(be(dict["property"]))
+              done()
+            }
+          }
+        }
+
+        it("converts to record with custom key") {
+          waitUntil { done in
+            mockModuleHolder(appContext) {
+              AsyncFunction(functionName) { (a: TestRecord) in
+                return a.customKeyProperty
+              }
+            }
+            .call(function: functionName, args: [dict]) { result in
+              let value = try! result.get()
+              expect(value).notTo(beNil())
+              expect(value).to(beAKindOf(String.self))
+              expect(value).to(be(dict["propertyWithCustomKey"]))
+              done()
+            }
+          }
+        }
+
+        it("returns the record back") {
+          waitUntil { done in
+            mockModuleHolder(appContext) {
+              AsyncFunction(functionName) { (a: TestRecord) in
+                return a.toDictionary()
+              }
+            }
+            .call(function: functionName, args: [dict]) { result in
+              let value = try! result.get()
+
+              expect(value).notTo(beNil())
+              expect(value).to(beAKindOf(Record.Dict.self))
+
+              let valueAsDict = value as! Record.Dict
+
+              expect(valueAsDict["property"] as? String).to(equal(dict["property"]))
+              expect(valueAsDict["propertyWithCustomKey"] as? String).to(equal(dict["propertyWithCustomKey"]))
+              done()
+            }
+          }
+        }
+      }
+
+      it("throws when called with more arguments than expected") {
+        waitUntil { done in
+          mockModuleHolder(appContext) {
+            AsyncFunction(functionName) { (_: Int) in
+              return "something"
+            }
+          }
+          // Function expects one argument, let's give it more.
+          .call(function: functionName, args: [1, 2]) { result in
+            switch result {
+            case .failure(let error):
+              expect(error).notTo(beNil())
+              expect(error).to(beAKindOf(InvalidArgsNumberException.self))
+            case .success(_):
+              fail()
+            }
             done()
           }
         }
       }
 
-      it("returns the record back") {
+      it("throws when called with arguments of incompatible types") {
         waitUntil { done in
           mockModuleHolder(appContext) {
-            AsyncFunction(functionName) { (a: TestRecord) in
-              return a.toDictionary()
+            AsyncFunction(functionName) { (_: String) in
+              return "something"
             }
           }
-          .call(function: functionName, args: [dict]) { result in
-            let value = try! result.get()
-
-            expect(value).notTo(beNil())
-            expect(value).to(beAKindOf(Record.Dict.self))
-
-            let valueAsDict = value as! Record.Dict
-
-            expect(valueAsDict["property"] as? String).to(equal(dict["property"]))
-            expect(valueAsDict["propertyWithCustomKey"] as? String).to(equal(dict["propertyWithCustomKey"]))
+          // Function expects a string, let's give it a number.
+          .call(function: functionName, args: [1]) { result in
+            switch result {
+            case .failure(let error):
+              expect(error).notTo(beNil())
+              expect(error).to(beAKindOf(ArgumentCastException.self))
+              expect(error.isCausedBy(Conversions.CastingException<String>.self)) == true
+            case .success(_):
+              fail()
+            }
             done()
           }
         }
       }
     }
+    
+    context("JavaScript") {
+      let runtime = appContext.runtime
+      
+      beforeSuite {
+        appContext.moduleRegistry.register(holder: mockModuleHolder(appContext) {
+          Name("TestModule")
 
-    it("throws when called with more arguments than expected") {
-      waitUntil { done in
-        mockModuleHolder(appContext) {
-          AsyncFunction(functionName) { (_: Int) in
-            return "something"
+          Function("returnPiSync") { Double.pi }
+          
+          Function("returnNullSync") { () -> Double? in
+            return nil
           }
-        }
-        // Function expects one argument, let's give it more.
-        .call(function: functionName, args: [1, 2]) { result in
-          switch result {
-          case .failure(let error):
-            expect(error).notTo(beNil())
-            expect(error).to(beAKindOf(InvalidArgsNumberException.self))
-          case .success(_):
-            fail()
+          
+          Function("isArgNilSync") { (arg: Double?) -> Bool in
+            return arg == nil
           }
-          done()
-        }
+        })
       }
-    }
-
-    it("throws when called with arguments of incompatible types") {
-      waitUntil { done in
-        mockModuleHolder(appContext) {
-          AsyncFunction(functionName) { (_: String) in
-            return "something"
-          }
-        }
-        // Function expects a string, let's give it a number.
-        .call(function: functionName, args: [1]) { result in
-          switch result {
-          case .failure(let error):
-            expect(error).notTo(beNil())
-            expect(error).to(beAKindOf(ArgumentCastException.self))
-            expect(error.isCausedBy(Conversions.CastingException<String>.self)) == true
-          case .success(_):
-            fail()
-          }
-          done()
-        }
+      
+      it("returns values") {
+        expect(try runtime?.eval("ExpoModules.TestModule.returnPiSync()").asDouble()) == Double.pi
+        expect(try runtime?.eval("ExpoModules.TestModule.returnNullSync()").isNull()) == true
+      }
+      
+      it("accepts optional argument") {
+        expect(try runtime?.eval("ExpoModules.TestModule.isArgNilSync(3.14)").asBool()) == false
+        expect(try runtime?.eval("ExpoModules.TestModule.isArgNilSync(null)").asBool()) == true
       }
     }
   }

--- a/packages/expo-modules-core/ios/Tests/FunctionSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/FunctionSpec.swift
@@ -200,26 +200,26 @@ class FunctionSpec: ExpoSpec {
         appContext.moduleRegistry.register(holder: mockModuleHolder(appContext) {
           Name("TestModule")
 
-          Function("returnPiSync") { Double.pi }
+          Function("returnPi") { Double.pi }
           
-          Function("returnNullSync") { () -> Double? in
+          Function("returnNull") { () -> Double? in
             return nil
           }
           
-          Function("isArgNilSync") { (arg: Double?) -> Bool in
+          Function("isArgNull") { (arg: Double?) -> Bool in
             return arg == nil
           }
         })
       }
       
       it("returns values") {
-        expect(try runtime?.eval("ExpoModules.TestModule.returnPiSync()").asDouble()) == Double.pi
-        expect(try runtime?.eval("ExpoModules.TestModule.returnNullSync()").isNull()) == true
+        expect(try runtime?.eval("ExpoModules.TestModule.returnPi()").asDouble()) == Double.pi
+        expect(try runtime?.eval("ExpoModules.TestModule.returnNull()").isNull()) == true
       }
       
-      it("accepts optional argument") {
-        expect(try runtime?.eval("ExpoModules.TestModule.isArgNilSync(3.14)").asBool()) == false
-        expect(try runtime?.eval("ExpoModules.TestModule.isArgNilSync(null)").asBool()) == true
+      it("accepts optional arguments") {
+        expect(try runtime?.eval("ExpoModules.TestModule.isArgNull(3.14)").asBool()) == false
+        expect(try runtime?.eval("ExpoModules.TestModule.isArgNull(null)").asBool()) == true
       }
     }
   }


### PR DESCRIPTION
# Why

Optional function arguments were broken on iOS Sweet API. They were recognized as required and providing `null` resulted in `ArgumentCastException`.

# How

- Added support for `NSNull` in `DynamicOptionalType` - needed when called from legacy bridge.
- Made `Optional` conform to `AnyArgument` protocol.

Swift has some confusing behaviour, when generic argument is marked as `<T: SomeProtocol>`. In this case, `Optional<T>` must also conform to that protocol, or otherwise `T?` will be silently resolved as `T`. See the Swift playground example below:

```swift
import Foundation

public protocol AnyArgument {}

extension String: AnyArgument {}

// if you comment this out, the Function arg A0 will be resolved
// as `String` instead of `Optional<String>`
extension Optional: AnyArgument where Wrapped: AnyArgument {}

func Function<R, A0: AnyArgument>(
  _ name: String,
  _ closure: @escaping (A0) throws -> R
) {
  // print the resolved type. Expected: Optional<String>
  print(A0.self)
}

Function("fn") { (arg: String?) in 
 // no-op
}
```

# Test Plan

- I'd write a unit test case for this, but don't know where exactly 🙄 
