### PR TITLE
[docs] Update Contacts calendar formats

### DIFF
--- a/docs/pages/versions/unversioned/sdk/contacts.md
+++ b/docs/pages/versions/unversioned/sdk/contacts.md
@@ -877,12 +877,24 @@ const calendarFormat = Contacts.CalendarFormats.Coptic;
 
 This format denotes the common calendar format used to specify how a date is calculated in `nonGregorianBirthday` fields.
 
-| Constant  | value         | iOS | Android |
-| --------- | ------------- | --- | ------- |
-| Gregorian | `'gregorian'` | ✅  | ✅      |
-| Chinese   | `'chinese'`   | ✅  | ❌      |
-| Hebrew    | `'hebrew'`    | ✅  | ❌      |
-| Islamic   | `'islamic'`   | ✅  | ❌      |
+| Constant            | value                   | iOS | Android |
+| ------------------- | ----------------------- | --- | ------- |
+| Gregorian           | `'gregorian'`           | ✅  | ✅      |
+| Buddhist            | `'buddhist'`            | ✅  | ❌      |
+| Chinese             | `'chinese'`             | ✅  | ❌      |
+| Coptic              | `'coptic'`              | ✅  | ❌      |
+| EthiopicAmeteMihret | `'ethiopicAmeteMihret'` | ✅  | ❌      |
+| EthiopicAmeteAlem   | `'ethiopicAmeteAlem'`   | ✅  | ❌      |
+| Hebrew              | `'hebrew'`              | ✅  | ❌      |
+| ISO8601             | `'iso8601'`             | ✅  | ❌      |
+| Indian              | `'indian'`              | ✅  | ❌      |
+| Islamic             | `'islamic'`             | ✅  | ❌      |
+| IslamicCivil        | `'islamicCivil'`        | ✅  | ❌      |
+| Japanese            | `'japanese'`            | ✅  | ❌      |
+| Persian             | `'persian'`             | ✅  | ❌      |
+| RepublicOfChina     | `'republicOfChina'`     | ✅  | ❌      |
+| IslamicTabular      | `'islamicTabular'`      | ✅  | ❌      |
+| IslamicUmmAlQura    | `'islamicUmmAlQura'`    | ✅  | ❌      |
 
 ### Contact Fields
 

--- a/docs/pages/versions/unversioned/sdk/contacts.md
+++ b/docs/pages/versions/unversioned/sdk/contacts.md
@@ -556,8 +556,8 @@ A set of fields that define information about a single entity.
 | image                   | `Image`                   | Thumbnail image (ios: 320x320)                                                                                   | ✅   | ✅      |
 | rawImage                | `Image`                   | Raw image without cropping, usually large.                                                                       | ✅   | ✅      |
 | contactType             | `ContactType`             | Denoting a person or company.                                                                                    | ✅   | ✅      |
-| birthday                | `Date`                    | Birthday information in JS format.                                                                               | ✅   | ✅      |
-| dates                   | `Date[]`                  | A list of other relevant user dates in JS format.                                                                | ✅   | ✅      |
+| birthday                | `Date`                    | Birthday information in Gregorian format.                                                                        | ✅   | ✅      |
+| dates                   | `Date[]`                  | A list of other relevant user dates in Gregorian format.                                                         | ✅   | ✅      |
 | relationships           | `Relationship[]`          | Names of other relevant user connections                                                                         | ✅   | ✅      |
 | emails                  | `Email[]`                 | Email addresses                                                                                                  | ✅   | ✅      |
 | phoneNumbers            | `PhoneNumber[]`           | Phone numbers                                                                                                    | ✅   | ✅      |

--- a/docs/pages/versions/unversioned/sdk/contacts.md
+++ b/docs/pages/versions/unversioned/sdk/contacts.md
@@ -557,7 +557,7 @@ A set of fields that define information about a single entity.
 | rawImage                | `Image`                   | Raw image without cropping, usually large.                                                                       | ✅   | ✅      |
 | contactType             | `ContactType`             | Denoting a person or company.                                                                                    | ✅   | ✅      |
 | birthday                | `Date`                    | Birthday information in Gregorian format.                                                                        | ✅   | ✅      |
-| dates                   | `Date[]`                  | A list of other relevant user dates in Gregorian format.                                                         | ✅   | ✅      |
+| dates                   | `Date[]`                  | A labeled list of other relevant user dates in Gregorian format.                                                 | ✅   | ✅      |
 | relationships           | `Relationship[]`          | Names of other relevant user connections                                                                         | ✅   | ✅      |
 | emails                  | `Email[]`                 | Email addresses                                                                                                  | ✅   | ✅      |
 | phoneNumbers            | `PhoneNumber[]`           | Phone numbers                                                                                                    | ✅   | ✅      |

--- a/docs/pages/versions/unversioned/sdk/contacts.md
+++ b/docs/pages/versions/unversioned/sdk/contacts.md
@@ -534,40 +534,40 @@ const allContainers = await Contacts.getContainersAsync({
 
 A set of fields that define information about a single entity.
 
-| Name                    | Type                      | Description                                                    | iOS  | Android |
-| ----------------------- | ------------------------- | -------------------------------------------------------------- | ---- | ------- |
-| id                      | `string`                  | Immutable identifier used for querying and indexing.           | ✅   | ✅      |
-| name                    | `string`                  | Full name with proper format.                                  | ✅   | ✅      |
-| firstName               | `string`                  | Given name.                                                    | ✅   | ✅      |
-| middleName              | `string`                  | Middle name.                                                   | ✅   | ✅      |
-| lastName                | `string`                  | Family name.                                                   | ✅   | ✅      |
-| maidenName              | `string`                  | Maiden name.                                                   | ✅   | ✅      |
-| namePrefix              | `string`                  | Dr. Mr. Mrs. Ect...                                            | ✅   | ✅      |
-| nameSuffix              | `string`                  | Jr. Sr. Ect...                                                 | ✅   | ✅      |
-| nickname                | `string`                  | An alias to the proper name.                                   | ✅   | ✅      |
-| phoneticFirstName       | `string`                  | Pronunciation of the first name.                               | ✅   | ✅      |
-| phoneticMiddleName      | `string`                  | Pronunciation of the middle name.                              | ✅   | ✅      |
-| phoneticLastName        | `string`                  | Pronunciation of the last name.                                | ✅   | ✅      |
-| company                 | `string`                  | Organization the entity belongs to.                            | ✅   | ✅      |
-| jobTitle                | `string`                  | Job description.                                               | ✅   | ✅      |
-| department              | `string`                  | Job department.                                                | ✅   | ✅      |
-| note                    | `string`                  | Additional information.                                        | ✅\* | ✅      |
-| imageAvailable          | `boolean`                 | Used for efficient retrieval of images.                        | ✅   | ✅      |
-| image                   | `Image`                   | Thumbnail image (ios: 320x320)                                 | ✅   | ✅      |
-| rawImage                | `Image`                   | Raw image without cropping, usually large.                     | ✅   | ✅      |
-| contactType             | `ContactType`             | Denoting a person or company.                                  | ✅   | ✅      |
-| birthday                | `Date`                    | Birthday information in JS format.                             | ✅   | ✅      |
-| dates                   | `Date[]`                  | A list of other relevant user dates.                           | ✅   | ✅      |
-| relationships           | `Relationship[]`          | Names of other relevant user connections                       | ✅   | ✅      |
-| emails                  | `Email[]`                 | Email addresses                                                | ✅   | ✅      |
-| phoneNumbers            | `PhoneNumber[]`           | Phone numbers                                                  | ✅   | ✅      |
-| addresses               | `Address[]`               | Locations                                                      | ✅   | ✅      |
-| instantMessageAddresses | `InstantMessageAddress[]` | IM connections                                                 | ✅   | ✅      |
-| urlAddresses            | `UrlAddress[]`            | Web Urls                                                       | ✅   | ✅      |
-| nonGregorianBirthday    | `Date`                    | Birthday that doesn't conform to the Gregorian calendar format | ✅   | ❌      |
-| socialProfiles          | `SocialProfile[]`         | Social networks                                                | ✅   | ❌      |
-| thumbnail               | `Image`                   | Deprecated: Use `image`                                        | ❌   | ❌      |
-| previousLastName        | `string`                  | Deprecated: Use `maidenName`                                   | ❌   | ❌      |
+| Name                    | Type                      | Description                                                                                                      | iOS  | Android |
+| ----------------------- | ------------------------- | ---------------------------------------------------------------------------------------------------------------- | ---- | ------- |
+| id                      | `string`                  | Immutable identifier used for querying and indexing.                                                             | ✅   | ✅      |
+| name                    | `string`                  | Full name with proper format.                                                                                    | ✅   | ✅      |
+| firstName               | `string`                  | Given name.                                                                                                      | ✅   | ✅      |
+| middleName              | `string`                  | Middle name.                                                                                                     | ✅   | ✅      |
+| lastName                | `string`                  | Family name.                                                                                                     | ✅   | ✅      |
+| maidenName              | `string`                  | Maiden name.                                                                                                     | ✅   | ✅      |
+| namePrefix              | `string`                  | Dr. Mr. Mrs. Ect...                                                                                              | ✅   | ✅      |
+| nameSuffix              | `string`                  | Jr. Sr. Ect...                                                                                                   | ✅   | ✅      |
+| nickname                | `string`                  | An alias to the proper name.                                                                                     | ✅   | ✅      |
+| phoneticFirstName       | `string`                  | Pronunciation of the first name.                                                                                 | ✅   | ✅      |
+| phoneticMiddleName      | `string`                  | Pronunciation of the middle name.                                                                                | ✅   | ✅      |
+| phoneticLastName        | `string`                  | Pronunciation of the last name.                                                                                  | ✅   | ✅      |
+| company                 | `string`                  | Organization the entity belongs to.                                                                              | ✅   | ✅      |
+| jobTitle                | `string`                  | Job description.                                                                                                 | ✅   | ✅      |
+| department              | `string`                  | Job department.                                                                                                  | ✅   | ✅      |
+| note                    | `string`                  | Additional information.                                                                                          | ✅\* | ✅      |
+| imageAvailable          | `boolean`                 | Used for efficient retrieval of images.                                                                          | ✅   | ✅      |
+| image                   | `Image`                   | Thumbnail image (ios: 320x320)                                                                                   | ✅   | ✅      |
+| rawImage                | `Image`                   | Raw image without cropping, usually large.                                                                       | ✅   | ✅      |
+| contactType             | `ContactType`             | Denoting a person or company.                                                                                    | ✅   | ✅      |
+| birthday                | `Date`                    | Birthday information in JS format.                                                                               | ✅   | ✅      |
+| dates                   | `Date[]`                  | A list of other relevant user dates in JS format.                                                                | ✅   | ✅      |
+| relationships           | `Relationship[]`          | Names of other relevant user connections                                                                         | ✅   | ✅      |
+| emails                  | `Email[]`                 | Email addresses                                                                                                  | ✅   | ✅      |
+| phoneNumbers            | `PhoneNumber[]`           | Phone numbers                                                                                                    | ✅   | ✅      |
+| addresses               | `Address[]`               | Locations                                                                                                        | ✅   | ✅      |
+| instantMessageAddresses | `InstantMessageAddress[]` | IM connections                                                                                                   | ✅   | ✅      |
+| urlAddresses            | `UrlAddress[]`            | Web Urls                                                                                                         | ✅   | ✅      |
+| nonGregorianBirthday    | `Date`                    | Birthday that doesn't conform to the Gregorian calendar format, interpreted based on the CalendarFormat setting. | ✅   | ❌      |
+| socialProfiles          | `SocialProfile[]`         | Social networks                                                                                                  | ✅   | ❌      |
+| thumbnail               | `Image`                   | Deprecated: Use `image`                                                                                          | ❌   | ❌      |
+| previousLastName        | `string`                  | Deprecated: Use `maidenName`                                                                                     | ❌   | ❌      |
 
 > \*On iOS 13 and up, the `note` field [requires your app to request additional entitlements](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_contacts_notes). The Expo Go app does not contain those entitlements, so in order to test this feature you will need to [request the entitlement from Apple here](https://developer.apple.com/contact/request/contact-note-field), set the [`ios.accessesContactNotes`](../config/app.md#accessescontactnotes) field in app.json to `true`, and [build your app as a standalone app](../../../distribution/building-standalone-apps.md).
 

--- a/docs/pages/versions/v42.0.0/sdk/contacts.md
+++ b/docs/pages/versions/v42.0.0/sdk/contacts.md
@@ -876,12 +876,24 @@ const calendarFormat = Contacts.CalendarFormats.Coptic;
 
 This format denotes the common calendar format used to specify how a date is calculated in `nonGregorianBirthday` fields.
 
-| Constant  | value         | iOS | Android |
-| --------- | ------------- | --- | ------- |
-| Gregorian | `'gregorian'` | ✅  | ✅      |
-| Chinese   | `'chinese'`   | ✅  | ❌      |
-| Hebrew    | `'hebrew'`    | ✅  | ❌      |
-| Islamic   | `'islamic'`   | ✅  | ❌      |
+| Constant            | value                   | iOS | Android |
+| ------------------- | ----------------------- | --- | ------- |
+| Gregorian           | `'gregorian'`           | ✅  | ✅      |
+| Buddhist            | `'buddhist'`            | ✅  | ❌      |
+| Chinese             | `'chinese'`             | ✅  | ❌      |
+| Coptic              | `'coptic'`              | ✅  | ❌      |
+| EthiopicAmeteMihret | `'ethiopicAmeteMihret'` | ✅  | ❌      |
+| EthiopicAmeteAlem   | `'ethiopicAmeteAlem'`   | ✅  | ❌      |
+| Hebrew              | `'hebrew'`              | ✅  | ❌      |
+| ISO8601             | `'iso8601'`             | ✅  | ❌      |
+| Indian              | `'indian'`              | ✅  | ❌      |
+| Islamic             | `'islamic'`             | ✅  | ❌      |
+| IslamicCivil        | `'islamicCivil'`        | ✅  | ❌      |
+| Japanese            | `'japanese'`            | ✅  | ❌      |
+| Persian             | `'persian'`             | ✅  | ❌      |
+| RepublicOfChina     | `'republicOfChina'`     | ✅  | ❌      |
+| IslamicTabular      | `'islamicTabular'`      | ✅  | ❌      |
+| IslamicUmmAlQura    | `'islamicUmmAlQura'`    | ✅  | ❌      |
 
 ### Contact Fields
 

--- a/docs/pages/versions/v42.0.0/sdk/contacts.md
+++ b/docs/pages/versions/v42.0.0/sdk/contacts.md
@@ -555,8 +555,8 @@ A set of fields that define information about a single entity.
 | image                   | `Image`                   | Thumbnail image (ios: 320x320)                                                                                   | ✅   | ✅      |
 | rawImage                | `Image`                   | Raw image without cropping, usually large.                                                                       | ✅   | ✅      |
 | contactType             | `ContactType`             | Denoting a person or company.                                                                                    | ✅   | ✅      |
-| birthday                | `Date`                    | Birthday information in JS format.                                                                               | ✅   | ✅      |
-| dates                   | `Date[]`                  | A list of other relevant user dates in JS format.                                                                | ✅   | ✅      |
+| birthday                | `Date`                    | Birthday information in Gregorian format.                                                                        | ✅   | ✅      |
+| dates                   | `Date[]`                  | A list of other relevant user dates in Gregorian format.                                                         | ✅   | ✅      |
 | relationships           | `Relationship[]`          | Names of other relevant user connections                                                                         | ✅   | ✅      |
 | emails                  | `Email[]`                 | Email addresses                                                                                                  | ✅   | ✅      |
 | phoneNumbers            | `PhoneNumber[]`           | Phone numbers                                                                                                    | ✅   | ✅      |

--- a/docs/pages/versions/v42.0.0/sdk/contacts.md
+++ b/docs/pages/versions/v42.0.0/sdk/contacts.md
@@ -556,7 +556,7 @@ A set of fields that define information about a single entity.
 | rawImage                | `Image`                   | Raw image without cropping, usually large.                                                                       | ✅   | ✅      |
 | contactType             | `ContactType`             | Denoting a person or company.                                                                                    | ✅   | ✅      |
 | birthday                | `Date`                    | Birthday information in Gregorian format.                                                                        | ✅   | ✅      |
-| dates                   | `Date[]`                  | A list of other relevant user dates in Gregorian format.                                                         | ✅   | ✅      |
+| dates                   | `Date[]`                  | A labeled list of other relevant user dates in Gregorian format.                                                 | ✅   | ✅      |
 | relationships           | `Relationship[]`          | Names of other relevant user connections                                                                         | ✅   | ✅      |
 | emails                  | `Email[]`                 | Email addresses                                                                                                  | ✅   | ✅      |
 | phoneNumbers            | `PhoneNumber[]`           | Phone numbers                                                                                                    | ✅   | ✅      |

--- a/docs/pages/versions/v42.0.0/sdk/contacts.md
+++ b/docs/pages/versions/v42.0.0/sdk/contacts.md
@@ -533,40 +533,40 @@ const allContainers = await Contacts.getContainersAsync({
 
 A set of fields that define information about a single entity.
 
-| Name                    | Type                      | Description                                                    | iOS  | Android |
-| ----------------------- | ------------------------- | -------------------------------------------------------------- | ---- | ------- |
-| id                      | `string`                  | Immutable identifier used for querying and indexing.           | ✅   | ✅      |
-| name                    | `string`                  | Full name with proper format.                                  | ✅   | ✅      |
-| firstName               | `string`                  | Given name.                                                    | ✅   | ✅      |
-| middleName              | `string`                  | Middle name.                                                   | ✅   | ✅      |
-| lastName                | `string`                  | Family name.                                                   | ✅   | ✅      |
-| maidenName              | `string`                  | Maiden name.                                                   | ✅   | ✅      |
-| namePrefix              | `string`                  | Dr. Mr. Mrs. Ect...                                            | ✅   | ✅      |
-| nameSuffix              | `string`                  | Jr. Sr. Ect...                                                 | ✅   | ✅      |
-| nickname                | `string`                  | An alias to the proper name.                                   | ✅   | ✅      |
-| phoneticFirstName       | `string`                  | Pronunciation of the first name.                               | ✅   | ✅      |
-| phoneticMiddleName      | `string`                  | Pronunciation of the middle name.                              | ✅   | ✅      |
-| phoneticLastName        | `string`                  | Pronunciation of the last name.                                | ✅   | ✅      |
-| company                 | `string`                  | Organization the entity belongs to.                            | ✅   | ✅      |
-| jobTitle                | `string`                  | Job description.                                               | ✅   | ✅      |
-| department              | `string`                  | Job department.                                                | ✅   | ✅      |
-| note                    | `string`                  | Additional information.                                        | ✅\* | ✅      |
-| imageAvailable          | `boolean`                 | Used for efficient retrieval of images.                        | ✅   | ✅      |
-| image                   | `Image`                   | Thumbnail image (ios: 320x320)                                 | ✅   | ✅      |
-| rawImage                | `Image`                   | Raw image without cropping, usually large.                     | ✅   | ✅      |
-| contactType             | `ContactType`             | Denoting a person or company.                                  | ✅   | ✅      |
-| birthday                | `Date`                    | Birthday information in JS format.                             | ✅   | ✅      |
-| dates                   | `Date[]`                  | A list of other relevant user dates.                           | ✅   | ✅      |
-| relationships           | `Relationship[]`          | Names of other relevant user connections                       | ✅   | ✅      |
-| emails                  | `Email[]`                 | Email addresses                                                | ✅   | ✅      |
-| phoneNumbers            | `PhoneNumber[]`           | Phone numbers                                                  | ✅   | ✅      |
-| addresses               | `Address[]`               | Locations                                                      | ✅   | ✅      |
-| instantMessageAddresses | `InstantMessageAddress[]` | IM connections                                                 | ✅   | ✅      |
-| urlAddresses            | `UrlAddress[]`            | Web Urls                                                       | ✅   | ✅      |
-| nonGregorianBirthday    | `Date`                    | Birthday that doesn't conform to the Gregorian calendar format | ✅   | ❌      |
-| socialProfiles          | `SocialProfile[]`         | Social networks                                                | ✅   | ❌      |
-| thumbnail               | `Image`                   | Deprecated: Use `image`                                        | ❌   | ❌      |
-| previousLastName        | `string`                  | Deprecated: Use `maidenName`                                   | ❌   | ❌      |
+| Name                    | Type                      | Description                                                                                                      | iOS  | Android |
+| ----------------------- | ------------------------- | ---------------------------------------------------------------------------------------------------------------- | ---- | ------- |
+| id                      | `string`                  | Immutable identifier used for querying and indexing.                                                             | ✅   | ✅      |
+| name                    | `string`                  | Full name with proper format.                                                                                    | ✅   | ✅      |
+| firstName               | `string`                  | Given name.                                                                                                      | ✅   | ✅      |
+| middleName              | `string`                  | Middle name.                                                                                                     | ✅   | ✅      |
+| lastName                | `string`                  | Family name.                                                                                                     | ✅   | ✅      |
+| maidenName              | `string`                  | Maiden name.                                                                                                     | ✅   | ✅      |
+| namePrefix              | `string`                  | Dr. Mr. Mrs. Ect...                                                                                              | ✅   | ✅      |
+| nameSuffix              | `string`                  | Jr. Sr. Ect...                                                                                                   | ✅   | ✅      |
+| nickname                | `string`                  | An alias to the proper name.                                                                                     | ✅   | ✅      |
+| phoneticFirstName       | `string`                  | Pronunciation of the first name.                                                                                 | ✅   | ✅      |
+| phoneticMiddleName      | `string`                  | Pronunciation of the middle name.                                                                                | ✅   | ✅      |
+| phoneticLastName        | `string`                  | Pronunciation of the last name.                                                                                  | ✅   | ✅      |
+| company                 | `string`                  | Organization the entity belongs to.                                                                              | ✅   | ✅      |
+| jobTitle                | `string`                  | Job description.                                                                                                 | ✅   | ✅      |
+| department              | `string`                  | Job department.                                                                                                  | ✅   | ✅      |
+| note                    | `string`                  | Additional information.                                                                                          | ✅\* | ✅      |
+| imageAvailable          | `boolean`                 | Used for efficient retrieval of images.                                                                          | ✅   | ✅      |
+| image                   | `Image`                   | Thumbnail image (ios: 320x320)                                                                                   | ✅   | ✅      |
+| rawImage                | `Image`                   | Raw image without cropping, usually large.                                                                       | ✅   | ✅      |
+| contactType             | `ContactType`             | Denoting a person or company.                                                                                    | ✅   | ✅      |
+| birthday                | `Date`                    | Birthday information in JS format.                                                                               | ✅   | ✅      |
+| dates                   | `Date[]`                  | A list of other relevant user dates in JS format.                                                                | ✅   | ✅      |
+| relationships           | `Relationship[]`          | Names of other relevant user connections                                                                         | ✅   | ✅      |
+| emails                  | `Email[]`                 | Email addresses                                                                                                  | ✅   | ✅      |
+| phoneNumbers            | `PhoneNumber[]`           | Phone numbers                                                                                                    | ✅   | ✅      |
+| addresses               | `Address[]`               | Locations                                                                                                        | ✅   | ✅      |
+| instantMessageAddresses | `InstantMessageAddress[]` | IM connections                                                                                                   | ✅   | ✅      |
+| urlAddresses            | `UrlAddress[]`            | Web Urls                                                                                                         | ✅   | ✅      |
+| nonGregorianBirthday    | `Date`                    | Birthday that doesn't conform to the Gregorian calendar format, interpreted based on the CalendarFormat setting. | ✅   | ❌      |
+| socialProfiles          | `SocialProfile[]`         | Social networks                                                                                                  | ✅   | ❌      |
+| thumbnail               | `Image`                   | Deprecated: Use `image`                                                                                          | ❌   | ❌      |
+| previousLastName        | `string`                  | Deprecated: Use `maidenName`                                                                                     | ❌   | ❌      |
 
 > \*On iOS 13 and up, the `note` field [requires your app to request additional entitlements](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_contacts_notes). The Expo Go app does not contain those entitlements, so in order to test this feature you will need to [request the entitlement from Apple here](https://developer.apple.com/contact/request/contact-note-field), set the [`ios.accessesContactNotes`](../config/app.md#accessescontactnotes) field in app.json to `true`, and [build your app as a standalone app](../../../distribution/building-standalone-apps.md).
 

--- a/docs/pages/versions/v43.0.0/sdk/contacts.md
+++ b/docs/pages/versions/v43.0.0/sdk/contacts.md
@@ -876,12 +876,24 @@ const calendarFormat = Contacts.CalendarFormats.Coptic;
 
 This format denotes the common calendar format used to specify how a date is calculated in `nonGregorianBirthday` fields.
 
-| Constant  | value         | iOS | Android |
-| --------- | ------------- | --- | ------- |
-| Gregorian | `'gregorian'` | ✅  | ✅      |
-| Chinese   | `'chinese'`   | ✅  | ❌      |
-| Hebrew    | `'hebrew'`    | ✅  | ❌      |
-| Islamic   | `'islamic'`   | ✅  | ❌      |
+| Constant            | value                   | iOS | Android |
+| ------------------- | ----------------------- | --- | ------- |
+| Gregorian           | `'gregorian'`           | ✅  | ✅      |
+| Buddhist            | `'buddhist'`            | ✅  | ❌      |
+| Chinese             | `'chinese'`             | ✅  | ❌      |
+| Coptic              | `'coptic'`              | ✅  | ❌      |
+| EthiopicAmeteMihret | `'ethiopicAmeteMihret'` | ✅  | ❌      |
+| EthiopicAmeteAlem   | `'ethiopicAmeteAlem'`   | ✅  | ❌      |
+| Hebrew              | `'hebrew'`              | ✅  | ❌      |
+| ISO8601             | `'iso8601'`             | ✅  | ❌      |
+| Indian              | `'indian'`              | ✅  | ❌      |
+| Islamic             | `'islamic'`             | ✅  | ❌      |
+| IslamicCivil        | `'islamicCivil'`        | ✅  | ❌      |
+| Japanese            | `'japanese'`            | ✅  | ❌      |
+| Persian             | `'persian'`             | ✅  | ❌      |
+| RepublicOfChina     | `'republicOfChina'`     | ✅  | ❌      |
+| IslamicTabular      | `'islamicTabular'`      | ✅  | ❌      |
+| IslamicUmmAlQura    | `'islamicUmmAlQura'`    | ✅  | ❌      |
 
 ### Contact Fields
 

--- a/docs/pages/versions/v43.0.0/sdk/contacts.md
+++ b/docs/pages/versions/v43.0.0/sdk/contacts.md
@@ -555,8 +555,8 @@ A set of fields that define information about a single entity.
 | image                   | `Image`                   | Thumbnail image (ios: 320x320)                                                                                   | ✅   | ✅      |
 | rawImage                | `Image`                   | Raw image without cropping, usually large.                                                                       | ✅   | ✅      |
 | contactType             | `ContactType`             | Denoting a person or company.                                                                                    | ✅   | ✅      |
-| birthday                | `Date`                    | Birthday information in JS format.                                                                               | ✅   | ✅      |
-| dates                   | `Date[]`                  | A list of other relevant user dates in JS format.                                                                | ✅   | ✅      |
+| birthday                | `Date`                    | Birthday information in Gregorian format.                                                                        | ✅   | ✅      |
+| dates                   | `Date[]`                  | A list of other relevant user dates in Gregorian format.                                                         | ✅   | ✅      |
 | relationships           | `Relationship[]`          | Names of other relevant user connections                                                                         | ✅   | ✅      |
 | emails                  | `Email[]`                 | Email addresses                                                                                                  | ✅   | ✅      |
 | phoneNumbers            | `PhoneNumber[]`           | Phone numbers                                                                                                    | ✅   | ✅      |

--- a/docs/pages/versions/v43.0.0/sdk/contacts.md
+++ b/docs/pages/versions/v43.0.0/sdk/contacts.md
@@ -556,7 +556,7 @@ A set of fields that define information about a single entity.
 | rawImage                | `Image`                   | Raw image without cropping, usually large.                                                                       | ✅   | ✅      |
 | contactType             | `ContactType`             | Denoting a person or company.                                                                                    | ✅   | ✅      |
 | birthday                | `Date`                    | Birthday information in Gregorian format.                                                                        | ✅   | ✅      |
-| dates                   | `Date[]`                  | A list of other relevant user dates in Gregorian format.                                                         | ✅   | ✅      |
+| dates                   | `Date[]`                  | A labeled list of other relevant user dates in Gregorian format.                                                 | ✅   | ✅      |
 | relationships           | `Relationship[]`          | Names of other relevant user connections                                                                         | ✅   | ✅      |
 | emails                  | `Email[]`                 | Email addresses                                                                                                  | ✅   | ✅      |
 | phoneNumbers            | `PhoneNumber[]`           | Phone numbers                                                                                                    | ✅   | ✅      |

--- a/docs/pages/versions/v43.0.0/sdk/contacts.md
+++ b/docs/pages/versions/v43.0.0/sdk/contacts.md
@@ -533,40 +533,40 @@ const allContainers = await Contacts.getContainersAsync({
 
 A set of fields that define information about a single entity.
 
-| Name                    | Type                      | Description                                                    | iOS  | Android |
-| ----------------------- | ------------------------- | -------------------------------------------------------------- | ---- | ------- |
-| id                      | `string`                  | Immutable identifier used for querying and indexing.           | ✅   | ✅      |
-| name                    | `string`                  | Full name with proper format.                                  | ✅   | ✅      |
-| firstName               | `string`                  | Given name.                                                    | ✅   | ✅      |
-| middleName              | `string`                  | Middle name.                                                   | ✅   | ✅      |
-| lastName                | `string`                  | Family name.                                                   | ✅   | ✅      |
-| maidenName              | `string`                  | Maiden name.                                                   | ✅   | ✅      |
-| namePrefix              | `string`                  | Dr. Mr. Mrs. Ect...                                            | ✅   | ✅      |
-| nameSuffix              | `string`                  | Jr. Sr. Ect...                                                 | ✅   | ✅      |
-| nickname                | `string`                  | An alias to the proper name.                                   | ✅   | ✅      |
-| phoneticFirstName       | `string`                  | Pronunciation of the first name.                               | ✅   | ✅      |
-| phoneticMiddleName      | `string`                  | Pronunciation of the middle name.                              | ✅   | ✅      |
-| phoneticLastName        | `string`                  | Pronunciation of the last name.                                | ✅   | ✅      |
-| company                 | `string`                  | Organization the entity belongs to.                            | ✅   | ✅      |
-| jobTitle                | `string`                  | Job description.                                               | ✅   | ✅      |
-| department              | `string`                  | Job department.                                                | ✅   | ✅      |
-| note                    | `string`                  | Additional information.                                        | ✅\* | ✅      |
-| imageAvailable          | `boolean`                 | Used for efficient retrieval of images.                        | ✅   | ✅      |
-| image                   | `Image`                   | Thumbnail image (ios: 320x320)                                 | ✅   | ✅      |
-| rawImage                | `Image`                   | Raw image without cropping, usually large.                     | ✅   | ✅      |
-| contactType             | `ContactType`             | Denoting a person or company.                                  | ✅   | ✅      |
-| birthday                | `Date`                    | Birthday information in JS format.                             | ✅   | ✅      |
-| dates                   | `Date[]`                  | A list of other relevant user dates.                           | ✅   | ✅      |
-| relationships           | `Relationship[]`          | Names of other relevant user connections                       | ✅   | ✅      |
-| emails                  | `Email[]`                 | Email addresses                                                | ✅   | ✅      |
-| phoneNumbers            | `PhoneNumber[]`           | Phone numbers                                                  | ✅   | ✅      |
-| addresses               | `Address[]`               | Locations                                                      | ✅   | ✅      |
-| instantMessageAddresses | `InstantMessageAddress[]` | IM connections                                                 | ✅   | ✅      |
-| urlAddresses            | `UrlAddress[]`            | Web Urls                                                       | ✅   | ✅      |
-| nonGregorianBirthday    | `Date`                    | Birthday that doesn't conform to the Gregorian calendar format | ✅   | ❌      |
-| socialProfiles          | `SocialProfile[]`         | Social networks                                                | ✅   | ❌      |
-| thumbnail               | `Image`                   | Deprecated: Use `image`                                        | ❌   | ❌      |
-| previousLastName        | `string`                  | Deprecated: Use `maidenName`                                   | ❌   | ❌      |
+| Name                    | Type                      | Description                                                                                                      | iOS  | Android |
+| ----------------------- | ------------------------- | ---------------------------------------------------------------------------------------------------------------- | ---- | ------- |
+| id                      | `string`                  | Immutable identifier used for querying and indexing.                                                             | ✅   | ✅      |
+| name                    | `string`                  | Full name with proper format.                                                                                    | ✅   | ✅      |
+| firstName               | `string`                  | Given name.                                                                                                      | ✅   | ✅      |
+| middleName              | `string`                  | Middle name.                                                                                                     | ✅   | ✅      |
+| lastName                | `string`                  | Family name.                                                                                                     | ✅   | ✅      |
+| maidenName              | `string`                  | Maiden name.                                                                                                     | ✅   | ✅      |
+| namePrefix              | `string`                  | Dr. Mr. Mrs. Ect...                                                                                              | ✅   | ✅      |
+| nameSuffix              | `string`                  | Jr. Sr. Ect...                                                                                                   | ✅   | ✅      |
+| nickname                | `string`                  | An alias to the proper name.                                                                                     | ✅   | ✅      |
+| phoneticFirstName       | `string`                  | Pronunciation of the first name.                                                                                 | ✅   | ✅      |
+| phoneticMiddleName      | `string`                  | Pronunciation of the middle name.                                                                                | ✅   | ✅      |
+| phoneticLastName        | `string`                  | Pronunciation of the last name.                                                                                  | ✅   | ✅      |
+| company                 | `string`                  | Organization the entity belongs to.                                                                              | ✅   | ✅      |
+| jobTitle                | `string`                  | Job description.                                                                                                 | ✅   | ✅      |
+| department              | `string`                  | Job department.                                                                                                  | ✅   | ✅      |
+| note                    | `string`                  | Additional information.                                                                                          | ✅\* | ✅      |
+| imageAvailable          | `boolean`                 | Used for efficient retrieval of images.                                                                          | ✅   | ✅      |
+| image                   | `Image`                   | Thumbnail image (ios: 320x320)                                                                                   | ✅   | ✅      |
+| rawImage                | `Image`                   | Raw image without cropping, usually large.                                                                       | ✅   | ✅      |
+| contactType             | `ContactType`             | Denoting a person or company.                                                                                    | ✅   | ✅      |
+| birthday                | `Date`                    | Birthday information in JS format.                                                                               | ✅   | ✅      |
+| dates                   | `Date[]`                  | A list of other relevant user dates in JS format.                                                                | ✅   | ✅      |
+| relationships           | `Relationship[]`          | Names of other relevant user connections                                                                         | ✅   | ✅      |
+| emails                  | `Email[]`                 | Email addresses                                                                                                  | ✅   | ✅      |
+| phoneNumbers            | `PhoneNumber[]`           | Phone numbers                                                                                                    | ✅   | ✅      |
+| addresses               | `Address[]`               | Locations                                                                                                        | ✅   | ✅      |
+| instantMessageAddresses | `InstantMessageAddress[]` | IM connections                                                                                                   | ✅   | ✅      |
+| urlAddresses            | `UrlAddress[]`            | Web Urls                                                                                                         | ✅   | ✅      |
+| nonGregorianBirthday    | `Date`                    | Birthday that doesn't conform to the Gregorian calendar format, interpreted based on the CalendarFormat setting. | ✅   | ❌      |
+| socialProfiles          | `SocialProfile[]`         | Social networks                                                                                                  | ✅   | ❌      |
+| thumbnail               | `Image`                   | Deprecated: Use `image`                                                                                          | ❌   | ❌      |
+| previousLastName        | `string`                  | Deprecated: Use `maidenName`                                                                                     | ❌   | ❌      |
 
 > \*On iOS 13 and up, the `note` field [requires your app to request additional entitlements](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_contacts_notes). The Expo Go app does not contain those entitlements, so in order to test this feature you will need to [request the entitlement from Apple here](https://developer.apple.com/contact/request/contact-note-field), set the [`ios.accessesContactNotes`](../config/app.md#accessescontactnotes) field in app.json to `true`, and [build your app as a standalone app](../../../distribution/building-standalone-apps.md).
 

--- a/docs/pages/versions/v44.0.0/sdk/contacts.md
+++ b/docs/pages/versions/v44.0.0/sdk/contacts.md
@@ -876,12 +876,24 @@ const calendarFormat = Contacts.CalendarFormats.Coptic;
 
 This format denotes the common calendar format used to specify how a date is calculated in `nonGregorianBirthday` fields.
 
-| Constant  | value         | iOS | Android |
-| --------- | ------------- | --- | ------- |
-| Gregorian | `'gregorian'` | ✅  | ✅      |
-| Chinese   | `'chinese'`   | ✅  | ❌      |
-| Hebrew    | `'hebrew'`    | ✅  | ❌      |
-| Islamic   | `'islamic'`   | ✅  | ❌      |
+| Constant            | value                   | iOS | Android |
+| ------------------- | ----------------------- | --- | ------- |
+| Gregorian           | `'gregorian'`           | ✅  | ✅      |
+| Buddhist            | `'buddhist'`            | ✅  | ❌      |
+| Chinese             | `'chinese'`             | ✅  | ❌      |
+| Coptic              | `'coptic'`              | ✅  | ❌      |
+| EthiopicAmeteMihret | `'ethiopicAmeteMihret'` | ✅  | ❌      |
+| EthiopicAmeteAlem   | `'ethiopicAmeteAlem'`   | ✅  | ❌      |
+| Hebrew              | `'hebrew'`              | ✅  | ❌      |
+| ISO8601             | `'iso8601'`             | ✅  | ❌      |
+| Indian              | `'indian'`              | ✅  | ❌      |
+| Islamic             | `'islamic'`             | ✅  | ❌      |
+| IslamicCivil        | `'islamicCivil'`        | ✅  | ❌      |
+| Japanese            | `'japanese'`            | ✅  | ❌      |
+| Persian             | `'persian'`             | ✅  | ❌      |
+| RepublicOfChina     | `'republicOfChina'`     | ✅  | ❌      |
+| IslamicTabular      | `'islamicTabular'`      | ✅  | ❌      |
+| IslamicUmmAlQura    | `'islamicUmmAlQura'`    | ✅  | ❌      |
 
 ### Contact Fields
 

--- a/docs/pages/versions/v44.0.0/sdk/contacts.md
+++ b/docs/pages/versions/v44.0.0/sdk/contacts.md
@@ -555,8 +555,8 @@ A set of fields that define information about a single entity.
 | image                   | `Image`                   | Thumbnail image (ios: 320x320)                                                                                   | ✅   | ✅      |
 | rawImage                | `Image`                   | Raw image without cropping, usually large.                                                                       | ✅   | ✅      |
 | contactType             | `ContactType`             | Denoting a person or company.                                                                                    | ✅   | ✅      |
-| birthday                | `Date`                    | Birthday information in JS format.                                                                               | ✅   | ✅      |
-| dates                   | `Date[]`                  | A list of other relevant user dates in JS format.                                                                | ✅   | ✅      |
+| birthday                | `Date`                    | Birthday information in Gregorian format.                                                                        | ✅   | ✅      |
+| dates                   | `Date[]`                  | A list of other relevant user dates in Gregorian format.                                                         | ✅   | ✅      |
 | relationships           | `Relationship[]`          | Names of other relevant user connections                                                                         | ✅   | ✅      |
 | emails                  | `Email[]`                 | Email addresses                                                                                                  | ✅   | ✅      |
 | phoneNumbers            | `PhoneNumber[]`           | Phone numbers                                                                                                    | ✅   | ✅      |

--- a/docs/pages/versions/v44.0.0/sdk/contacts.md
+++ b/docs/pages/versions/v44.0.0/sdk/contacts.md
@@ -556,7 +556,7 @@ A set of fields that define information about a single entity.
 | rawImage                | `Image`                   | Raw image without cropping, usually large.                                                                       | ✅   | ✅      |
 | contactType             | `ContactType`             | Denoting a person or company.                                                                                    | ✅   | ✅      |
 | birthday                | `Date`                    | Birthday information in Gregorian format.                                                                        | ✅   | ✅      |
-| dates                   | `Date[]`                  | A list of other relevant user dates in Gregorian format.                                                         | ✅   | ✅      |
+| dates                   | `Date[]`                  | A labeled list of other relevant user dates in Gregorian format.                                                 | ✅   | ✅      |
 | relationships           | `Relationship[]`          | Names of other relevant user connections                                                                         | ✅   | ✅      |
 | emails                  | `Email[]`                 | Email addresses                                                                                                  | ✅   | ✅      |
 | phoneNumbers            | `PhoneNumber[]`           | Phone numbers                                                                                                    | ✅   | ✅      |

--- a/docs/pages/versions/v44.0.0/sdk/contacts.md
+++ b/docs/pages/versions/v44.0.0/sdk/contacts.md
@@ -533,40 +533,40 @@ const allContainers = await Contacts.getContainersAsync({
 
 A set of fields that define information about a single entity.
 
-| Name                    | Type                      | Description                                                    | iOS  | Android |
-| ----------------------- | ------------------------- | -------------------------------------------------------------- | ---- | ------- |
-| id                      | `string`                  | Immutable identifier used for querying and indexing.           | ✅   | ✅      |
-| name                    | `string`                  | Full name with proper format.                                  | ✅   | ✅      |
-| firstName               | `string`                  | Given name.                                                    | ✅   | ✅      |
-| middleName              | `string`                  | Middle name.                                                   | ✅   | ✅      |
-| lastName                | `string`                  | Family name.                                                   | ✅   | ✅      |
-| maidenName              | `string`                  | Maiden name.                                                   | ✅   | ✅      |
-| namePrefix              | `string`                  | Dr. Mr. Mrs. Ect...                                            | ✅   | ✅      |
-| nameSuffix              | `string`                  | Jr. Sr. Ect...                                                 | ✅   | ✅      |
-| nickname                | `string`                  | An alias to the proper name.                                   | ✅   | ✅      |
-| phoneticFirstName       | `string`                  | Pronunciation of the first name.                               | ✅   | ✅      |
-| phoneticMiddleName      | `string`                  | Pronunciation of the middle name.                              | ✅   | ✅      |
-| phoneticLastName        | `string`                  | Pronunciation of the last name.                                | ✅   | ✅      |
-| company                 | `string`                  | Organization the entity belongs to.                            | ✅   | ✅      |
-| jobTitle                | `string`                  | Job description.                                               | ✅   | ✅      |
-| department              | `string`                  | Job department.                                                | ✅   | ✅      |
-| note                    | `string`                  | Additional information.                                        | ✅\* | ✅      |
-| imageAvailable          | `boolean`                 | Used for efficient retrieval of images.                        | ✅   | ✅      |
-| image                   | `Image`                   | Thumbnail image (ios: 320x320)                                 | ✅   | ✅      |
-| rawImage                | `Image`                   | Raw image without cropping, usually large.                     | ✅   | ✅      |
-| contactType             | `ContactType`             | Denoting a person or company.                                  | ✅   | ✅      |
-| birthday                | `Date`                    | Birthday information in JS format.                             | ✅   | ✅      |
-| dates                   | `Date[]`                  | A list of other relevant user dates.                           | ✅   | ✅      |
-| relationships           | `Relationship[]`          | Names of other relevant user connections                       | ✅   | ✅      |
-| emails                  | `Email[]`                 | Email addresses                                                | ✅   | ✅      |
-| phoneNumbers            | `PhoneNumber[]`           | Phone numbers                                                  | ✅   | ✅      |
-| addresses               | `Address[]`               | Locations                                                      | ✅   | ✅      |
-| instantMessageAddresses | `InstantMessageAddress[]` | IM connections                                                 | ✅   | ✅      |
-| urlAddresses            | `UrlAddress[]`            | Web Urls                                                       | ✅   | ✅      |
-| nonGregorianBirthday    | `Date`                    | Birthday that doesn't conform to the Gregorian calendar format | ✅   | ❌      |
-| socialProfiles          | `SocialProfile[]`         | Social networks                                                | ✅   | ❌      |
-| thumbnail               | `Image`                   | Deprecated: Use `image`                                        | ❌   | ❌      |
-| previousLastName        | `string`                  | Deprecated: Use `maidenName`                                   | ❌   | ❌      |
+| Name                    | Type                      | Description                                                                                                      | iOS  | Android |
+| ----------------------- | ------------------------- | ---------------------------------------------------------------------------------------------------------------- | ---- | ------- |
+| id                      | `string`                  | Immutable identifier used for querying and indexing.                                                             | ✅   | ✅      |
+| name                    | `string`                  | Full name with proper format.                                                                                    | ✅   | ✅      |
+| firstName               | `string`                  | Given name.                                                                                                      | ✅   | ✅      |
+| middleName              | `string`                  | Middle name.                                                                                                     | ✅   | ✅      |
+| lastName                | `string`                  | Family name.                                                                                                     | ✅   | ✅      |
+| maidenName              | `string`                  | Maiden name.                                                                                                     | ✅   | ✅      |
+| namePrefix              | `string`                  | Dr. Mr. Mrs. Ect...                                                                                              | ✅   | ✅      |
+| nameSuffix              | `string`                  | Jr. Sr. Ect...                                                                                                   | ✅   | ✅      |
+| nickname                | `string`                  | An alias to the proper name.                                                                                     | ✅   | ✅      |
+| phoneticFirstName       | `string`                  | Pronunciation of the first name.                                                                                 | ✅   | ✅      |
+| phoneticMiddleName      | `string`                  | Pronunciation of the middle name.                                                                                | ✅   | ✅      |
+| phoneticLastName        | `string`                  | Pronunciation of the last name.                                                                                  | ✅   | ✅      |
+| company                 | `string`                  | Organization the entity belongs to.                                                                              | ✅   | ✅      |
+| jobTitle                | `string`                  | Job description.                                                                                                 | ✅   | ✅      |
+| department              | `string`                  | Job department.                                                                                                  | ✅   | ✅      |
+| note                    | `string`                  | Additional information.                                                                                          | ✅\* | ✅      |
+| imageAvailable          | `boolean`                 | Used for efficient retrieval of images.                                                                          | ✅   | ✅      |
+| image                   | `Image`                   | Thumbnail image (ios: 320x320)                                                                                   | ✅   | ✅      |
+| rawImage                | `Image`                   | Raw image without cropping, usually large.                                                                       | ✅   | ✅      |
+| contactType             | `ContactType`             | Denoting a person or company.                                                                                    | ✅   | ✅      |
+| birthday                | `Date`                    | Birthday information in JS format.                                                                               | ✅   | ✅      |
+| dates                   | `Date[]`                  | A list of other relevant user dates in JS format.                                                                | ✅   | ✅      |
+| relationships           | `Relationship[]`          | Names of other relevant user connections                                                                         | ✅   | ✅      |
+| emails                  | `Email[]`                 | Email addresses                                                                                                  | ✅   | ✅      |
+| phoneNumbers            | `PhoneNumber[]`           | Phone numbers                                                                                                    | ✅   | ✅      |
+| addresses               | `Address[]`               | Locations                                                                                                        | ✅   | ✅      |
+| instantMessageAddresses | `InstantMessageAddress[]` | IM connections                                                                                                   | ✅   | ✅      |
+| urlAddresses            | `UrlAddress[]`            | Web Urls                                                                                                         | ✅   | ✅      |
+| nonGregorianBirthday    | `Date`                    | Birthday that doesn't conform to the Gregorian calendar format, interpreted based on the CalendarFormat setting. | ✅   | ❌      |
+| socialProfiles          | `SocialProfile[]`         | Social networks                                                                                                  | ✅   | ❌      |
+| thumbnail               | `Image`                   | Deprecated: Use `image`                                                                                          | ❌   | ❌      |
+| previousLastName        | `string`                  | Deprecated: Use `maidenName`                                                                                     | ❌   | ❌      |
 
 > \*On iOS 13 and up, the `note` field [requires your app to request additional entitlements](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_contacts_notes). The Expo Go app does not contain those entitlements, so in order to test this feature you will need to [request the entitlement from Apple here](https://developer.apple.com/contact/request/contact-note-field), set the [`ios.accessesContactNotes`](../config/app.md#accessescontactnotes) field in app.json to `true`, and [build your app as a standalone app](../../../distribution/building-standalone-apps.md).
 

--- a/docs/pages/versions/v45.0.0/sdk/contacts.md
+++ b/docs/pages/versions/v45.0.0/sdk/contacts.md
@@ -877,12 +877,24 @@ const calendarFormat = Contacts.CalendarFormats.Coptic;
 
 This format denotes the common calendar format used to specify how a date is calculated in `nonGregorianBirthday` fields.
 
-| Constant  | value         | iOS | Android |
-| --------- | ------------- | --- | ------- |
-| Gregorian | `'gregorian'` | ✅  | ✅      |
-| Chinese   | `'chinese'`   | ✅  | ❌      |
-| Hebrew    | `'hebrew'`    | ✅  | ❌      |
-| Islamic   | `'islamic'`   | ✅  | ❌      |
+| Constant            | value                   | iOS | Android |
+| ------------------- | ----------------------- | --- | ------- |
+| Gregorian           | `'gregorian'`           | ✅  | ✅      |
+| Buddhist            | `'buddhist'`            | ✅  | ❌      |
+| Chinese             | `'chinese'`             | ✅  | ❌      |
+| Coptic              | `'coptic'`              | ✅  | ❌      |
+| EthiopicAmeteMihret | `'ethiopicAmeteMihret'` | ✅  | ❌      |
+| EthiopicAmeteAlem   | `'ethiopicAmeteAlem'`   | ✅  | ❌      |
+| Hebrew              | `'hebrew'`              | ✅  | ❌      |
+| ISO8601             | `'iso8601'`             | ✅  | ❌      |
+| Indian              | `'indian'`              | ✅  | ❌      |
+| Islamic             | `'islamic'`             | ✅  | ❌      |
+| IslamicCivil        | `'islamicCivil'`        | ✅  | ❌      |
+| Japanese            | `'japanese'`            | ✅  | ❌      |
+| Persian             | `'persian'`             | ✅  | ❌      |
+| RepublicOfChina     | `'republicOfChina'`     | ✅  | ❌      |
+| IslamicTabular      | `'islamicTabular'`      | ✅  | ❌      |
+| IslamicUmmAlQura    | `'islamicUmmAlQura'`    | ✅  | ❌      |
 
 ### Contact Fields
 

--- a/docs/pages/versions/v45.0.0/sdk/contacts.md
+++ b/docs/pages/versions/v45.0.0/sdk/contacts.md
@@ -556,8 +556,8 @@ A set of fields that define information about a single entity.
 | image                   | `Image`                   | Thumbnail image (ios: 320x320)                                                                                   | ✅   | ✅      |
 | rawImage                | `Image`                   | Raw image without cropping, usually large.                                                                       | ✅   | ✅      |
 | contactType             | `ContactType`             | Denoting a person or company.                                                                                    | ✅   | ✅      |
-| birthday                | `Date`                    | Birthday information in JS format.                                                                               | ✅   | ✅      |
-| dates                   | `Date[]`                  | A list of other relevant user dates in JS format.                                                                | ✅   | ✅      |
+| birthday                | `Date`                    | Birthday information in Gregorian format.                                                                        | ✅   | ✅      |
+| dates                   | `Date[]`                  | A list of other relevant user dates in Gregorian format.                                                         | ✅   | ✅      |
 | relationships           | `Relationship[]`          | Names of other relevant user connections                                                                         | ✅   | ✅      |
 | emails                  | `Email[]`                 | Email addresses                                                                                                  | ✅   | ✅      |
 | phoneNumbers            | `PhoneNumber[]`           | Phone numbers                                                                                                    | ✅   | ✅      |

--- a/docs/pages/versions/v45.0.0/sdk/contacts.md
+++ b/docs/pages/versions/v45.0.0/sdk/contacts.md
@@ -557,7 +557,7 @@ A set of fields that define information about a single entity.
 | rawImage                | `Image`                   | Raw image without cropping, usually large.                                                                       | ✅   | ✅      |
 | contactType             | `ContactType`             | Denoting a person or company.                                                                                    | ✅   | ✅      |
 | birthday                | `Date`                    | Birthday information in Gregorian format.                                                                        | ✅   | ✅      |
-| dates                   | `Date[]`                  | A list of other relevant user dates in Gregorian format.                                                         | ✅   | ✅      |
+| dates                   | `Date[]`                  | A labeled list of other relevant user dates in Gregorian format.                                                 | ✅   | ✅      |
 | relationships           | `Relationship[]`          | Names of other relevant user connections                                                                         | ✅   | ✅      |
 | emails                  | `Email[]`                 | Email addresses                                                                                                  | ✅   | ✅      |
 | phoneNumbers            | `PhoneNumber[]`           | Phone numbers                                                                                                    | ✅   | ✅      |

--- a/docs/pages/versions/v45.0.0/sdk/contacts.md
+++ b/docs/pages/versions/v45.0.0/sdk/contacts.md
@@ -534,40 +534,40 @@ const allContainers = await Contacts.getContainersAsync({
 
 A set of fields that define information about a single entity.
 
-| Name                    | Type                      | Description                                                    | iOS  | Android |
-| ----------------------- | ------------------------- | -------------------------------------------------------------- | ---- | ------- |
-| id                      | `string`                  | Immutable identifier used for querying and indexing.           | ✅   | ✅      |
-| name                    | `string`                  | Full name with proper format.                                  | ✅   | ✅      |
-| firstName               | `string`                  | Given name.                                                    | ✅   | ✅      |
-| middleName              | `string`                  | Middle name.                                                   | ✅   | ✅      |
-| lastName                | `string`                  | Family name.                                                   | ✅   | ✅      |
-| maidenName              | `string`                  | Maiden name.                                                   | ✅   | ✅      |
-| namePrefix              | `string`                  | Dr. Mr. Mrs. Ect...                                            | ✅   | ✅      |
-| nameSuffix              | `string`                  | Jr. Sr. Ect...                                                 | ✅   | ✅      |
-| nickname                | `string`                  | An alias to the proper name.                                   | ✅   | ✅      |
-| phoneticFirstName       | `string`                  | Pronunciation of the first name.                               | ✅   | ✅      |
-| phoneticMiddleName      | `string`                  | Pronunciation of the middle name.                              | ✅   | ✅      |
-| phoneticLastName        | `string`                  | Pronunciation of the last name.                                | ✅   | ✅      |
-| company                 | `string`                  | Organization the entity belongs to.                            | ✅   | ✅      |
-| jobTitle                | `string`                  | Job description.                                               | ✅   | ✅      |
-| department              | `string`                  | Job department.                                                | ✅   | ✅      |
-| note                    | `string`                  | Additional information.                                        | ✅\* | ✅      |
-| imageAvailable          | `boolean`                 | Used for efficient retrieval of images.                        | ✅   | ✅      |
-| image                   | `Image`                   | Thumbnail image (ios: 320x320)                                 | ✅   | ✅      |
-| rawImage                | `Image`                   | Raw image without cropping, usually large.                     | ✅   | ✅      |
-| contactType             | `ContactType`             | Denoting a person or company.                                  | ✅   | ✅      |
-| birthday                | `Date`                    | Birthday information in JS format.                             | ✅   | ✅      |
-| dates                   | `Date[]`                  | A list of other relevant user dates.                           | ✅   | ✅      |
-| relationships           | `Relationship[]`          | Names of other relevant user connections                       | ✅   | ✅      |
-| emails                  | `Email[]`                 | Email addresses                                                | ✅   | ✅      |
-| phoneNumbers            | `PhoneNumber[]`           | Phone numbers                                                  | ✅   | ✅      |
-| addresses               | `Address[]`               | Locations                                                      | ✅   | ✅      |
-| instantMessageAddresses | `InstantMessageAddress[]` | IM connections                                                 | ✅   | ✅      |
-| urlAddresses            | `UrlAddress[]`            | Web Urls                                                       | ✅   | ✅      |
-| nonGregorianBirthday    | `Date`                    | Birthday that doesn't conform to the Gregorian calendar format | ✅   | ❌      |
-| socialProfiles          | `SocialProfile[]`         | Social networks                                                | ✅   | ❌      |
-| thumbnail               | `Image`                   | Deprecated: Use `image`                                        | ❌   | ❌      |
-| previousLastName        | `string`                  | Deprecated: Use `maidenName`                                   | ❌   | ❌      |
+| Name                    | Type                      | Description                                                                                                      | iOS  | Android |
+| ----------------------- | ------------------------- | ---------------------------------------------------------------------------------------------------------------- | ---- | ------- |
+| id                      | `string`                  | Immutable identifier used for querying and indexing.                                                             | ✅   | ✅      |
+| name                    | `string`                  | Full name with proper format.                                                                                    | ✅   | ✅      |
+| firstName               | `string`                  | Given name.                                                                                                      | ✅   | ✅      |
+| middleName              | `string`                  | Middle name.                                                                                                     | ✅   | ✅      |
+| lastName                | `string`                  | Family name.                                                                                                     | ✅   | ✅      |
+| maidenName              | `string`                  | Maiden name.                                                                                                     | ✅   | ✅      |
+| namePrefix              | `string`                  | Dr. Mr. Mrs. Ect...                                                                                              | ✅   | ✅      |
+| nameSuffix              | `string`                  | Jr. Sr. Ect...                                                                                                   | ✅   | ✅      |
+| nickname                | `string`                  | An alias to the proper name.                                                                                     | ✅   | ✅      |
+| phoneticFirstName       | `string`                  | Pronunciation of the first name.                                                                                 | ✅   | ✅      |
+| phoneticMiddleName      | `string`                  | Pronunciation of the middle name.                                                                                | ✅   | ✅      |
+| phoneticLastName        | `string`                  | Pronunciation of the last name.                                                                                  | ✅   | ✅      |
+| company                 | `string`                  | Organization the entity belongs to.                                                                              | ✅   | ✅      |
+| jobTitle                | `string`                  | Job description.                                                                                                 | ✅   | ✅      |
+| department              | `string`                  | Job department.                                                                                                  | ✅   | ✅      |
+| note                    | `string`                  | Additional information.                                                                                          | ✅\* | ✅      |
+| imageAvailable          | `boolean`                 | Used for efficient retrieval of images.                                                                          | ✅   | ✅      |
+| image                   | `Image`                   | Thumbnail image (ios: 320x320)                                                                                   | ✅   | ✅      |
+| rawImage                | `Image`                   | Raw image without cropping, usually large.                                                                       | ✅   | ✅      |
+| contactType             | `ContactType`             | Denoting a person or company.                                                                                    | ✅   | ✅      |
+| birthday                | `Date`                    | Birthday information in JS format.                                                                               | ✅   | ✅      |
+| dates                   | `Date[]`                  | A list of other relevant user dates in JS format.                                                                | ✅   | ✅      |
+| relationships           | `Relationship[]`          | Names of other relevant user connections                                                                         | ✅   | ✅      |
+| emails                  | `Email[]`                 | Email addresses                                                                                                  | ✅   | ✅      |
+| phoneNumbers            | `PhoneNumber[]`           | Phone numbers                                                                                                    | ✅   | ✅      |
+| addresses               | `Address[]`               | Locations                                                                                                        | ✅   | ✅      |
+| instantMessageAddresses | `InstantMessageAddress[]` | IM connections                                                                                                   | ✅   | ✅      |
+| urlAddresses            | `UrlAddress[]`            | Web Urls                                                                                                         | ✅   | ✅      |
+| nonGregorianBirthday    | `Date`                    | Birthday that doesn't conform to the Gregorian calendar format, interpreted based on the CalendarFormat setting. | ✅   | ❌      |
+| socialProfiles          | `SocialProfile[]`         | Social networks                                                                                                  | ✅   | ❌      |
+| thumbnail               | `Image`                   | Deprecated: Use `image`                                                                                          | ❌   | ❌      |
+| previousLastName        | `string`                  | Deprecated: Use `maidenName`                                                                                     | ❌   | ❌      |
 
 > \*On iOS 13 and up, the `note` field [requires your app to request additional entitlements](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_contacts_notes). The Expo Go app does not contain those entitlements, so in order to test this feature you will need to [request the entitlement from Apple here](https://developer.apple.com/contact/request/contact-note-field), set the [`ios.accessesContactNotes`](../config/app.md#accessescontactnotes) field in app.json to `true`, and [build your app as a standalone app](../../../distribution/building-standalone-apps.md).
 


### PR DESCRIPTION
# Why

Fixes #10426

# How

- I checked the iOS and Android source code for the up to date list of calendar formats and updated the table in the docs to match.
- I updated the versions for SDK 42, 43, 44, 45 and unversioned.

# Test Plan

- I checked the docs by running `yarn dev` and looking at the results.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
