### PR TITLE
Update using-fcm.md

### DIFF
--- a/docs/pages/push-notifications/using-fcm.md
+++ b/docs/pages/push-notifications/using-fcm.md
@@ -63,7 +63,9 @@ In order for Expo to send notifications from our servers using your credentials,
 
 2. Click on the **Cloud Messaging** tab in the Settings pane.
 
-3. Copy the token listed next to **Server key**.
+3. Copy the token listed next to **Server key**. 
+
+> ** Note:** Server Key is only available in **Cloud Messaging API (Legacy)**, which may be Disabled by default. Enable it by clicking the 3-dot menu > Manage API in Google Cloud Console and follow the flow there. Once the legacy messaging API is enabled, you should see Server Key in that section.
 
 4. Run `expo push:android:upload --api-key <your-token-here>`, replacing `<your-token-here>` with the string you just copied. We'll store your token securely on our servers, where it will only be accessed when you send a push notification.
 


### PR DESCRIPTION
# Why

The notification instructions for android instruct users to find "Server Key" in the firebase console project settings. However, Server Key may not be found on the page, because the Legacy Messaging API is disabled by default. This PR adds a note to this doc that instructs users to enable the Legacy Messaging API in order to locate the Server Key.

# How

Added a note to the android notifications docs.

# Test Plan

N/A

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
