### PR TITLE
[image-picker][Android] Update & cleanup gradle dependencies

### DIFF
--- a/packages/expo-image-picker/android/build.gradle
+++ b/packages/expo-image-picker/android/build.gradle
@@ -85,11 +85,8 @@ dependencies {
   implementation project(':expo-modules-core')
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
-  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3")
-  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.1")
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.3")
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.3")
   implementation "com.github.CanHub:Android-Image-Cropper:1.1.1"
   implementation "androidx.exifinterface:exifinterface:1.3.3"
-  api "androidx.legacy:legacy-support-v4:1.0.0"
-  api 'commons-codec:commons-codec:1.10'
-  api 'commons-io:commons-io:2.6'
 }


### PR DESCRIPTION
# Why

Extracted part of
- #16251

# How

Upgrades:
- `org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3 ➡️ 1.6.3`
- `org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.1 ➡️ 1.6.3`

Removals (these are no longer needed):
- `androidx.legacy:legacy-support`
- `commons-codec:commons-codec`
- `commons-io:commons-io`
