### PR TITLE
[image-picker][Android] Restore `allowsEditing` option

### DIFF
--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -355,7 +355,7 @@ dependencies {
   releaseApi 'com.squareup.leakcanary:leakcanary-android-no-op:1.4-beta1'
   api 'commons-io:commons-io:2.6'
   api 'me.leolin:ShortcutBadger:1.1.4@aar'
-  implementation "com.github.CanHub:Android-Image-Cropper:1.1.1"
+  implementation "com.github.CanHub:Android-Image-Cropper:4.3.0"
   api 'commons-codec:commons-codec:1.10'
   api 'net.openid:appauth:0.7.1'
   api 'com.airbnb.android:lottie:3.4.0'

--- a/android/versioned-abis/expoview-abi44_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi44_0_0/build.gradle
@@ -123,7 +123,7 @@ dependencies {
   releaseApi 'com.squareup.leakcanary:leakcanary-android-no-op:1.4-beta1'
   api 'commons-io:commons-io:2.6'
   api 'me.leolin:ShortcutBadger:1.1.4@aar'
-  implementation "com.github.CanHub:Android-Image-Cropper:1.1.1"
+  implementation "com.github.CanHub:Android-Image-Cropper:4.3.0"
   api 'commons-codec:commons-codec:1.10'
   api 'net.openid:appauth:0.7.1'
   api 'com.airbnb.android:lottie:3.4.0'

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/imagepicker/ImagePickerModule.kt
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/imagepicker/ImagePickerModule.kt
@@ -37,6 +37,10 @@ import abi44_0_0.expo.modules.interfaces.permissions.Permissions
 import abi44_0_0.expo.modules.interfaces.permissions.PermissionsResponse
 import abi44_0_0.expo.modules.interfaces.permissions.PermissionsResponseListener
 import abi44_0_0.expo.modules.interfaces.permissions.PermissionsStatus
+import androidx.core.os.bundleOf
+import com.canhub.cropper.CropImageActivity
+import com.canhub.cropper.CropImageOptions
+import com.canhub.cropper.options
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
@@ -261,19 +265,24 @@ class ImagePickerModule(
       return
     }
 
-    val cropImageBuilder = CropImage.activity(uri).apply {
-      pickerOptions.forceAspect?.let { (x, y) ->
-        setAspectRatio((x as Number).toInt(), (y as Number).toInt())
-        setFixAspectRatio(true)
-        setInitialCropWindowPaddingRatio(0f)
-      }
+    val intent = Intent(context, CropImageActivity::class.java).apply {
+      putExtra(CropImage.CROP_IMAGE_EXTRA_BUNDLE, bundleOf(
+        CropImage.CROP_IMAGE_EXTRA_SOURCE to uri,
+        CropImage.CROP_IMAGE_EXTRA_OPTIONS to options {
+          pickerOptions.forceAspect?.let { (x, y) ->
+            setAspectRatio((x as Number).toInt(), (y as Number).toInt())
+            setFixAspectRatio(true)
+            setInitialCropWindowPaddingRatio(0f)
+          }
 
-      setOutputUri(fileUri)
-      setOutputCompressFormat(compressFormat)
-      setOutputCompressQuality(pickerOptions.quality)
+          setOutputUri(fileUri)
+          setOutputCompressFormat(compressFormat)
+          setOutputCompressQuality(pickerOptions.quality)
+        }.cropImageOptions.also { it.validate() }
+      ))
     }
     exifDataHandler = ExifDataHandler(uri)
-    startActivityOnResult(cropImageBuilder.getIntent(context), CropImage.CROP_IMAGE_ACTIVITY_REQUEST_CODE, promise, pickerOptions)
+    startActivityOnResult(intent, CropImage.CROP_IMAGE_ACTIVITY_REQUEST_CODE, promise, pickerOptions)
   }
 
   //endregion
@@ -356,16 +365,18 @@ class ImagePickerModule(
     val contentResolver = activity.application.contentResolver
 
     if (requestCode == CropImage.CROP_IMAGE_ACTIVITY_REQUEST_CODE) {
-      val result = CropImage.getActivityResult(intent).ifNull {
+      val result = intent?.getParcelableExtra(CropImage.CROP_IMAGE_EXTRA_RESULT) as? CropImage.ActivityResult?
+      if (result == null || resultCode == Activity.RESULT_CANCELED) {
         promise.reject(ImagePickerConstants.ERR_CROPPING_FAILURE, ImagePickerConstants.CROPPING_FAILURE_MESSAGE)
         return
       }
-      val exporter = CropImageExporter(result.rotation, result.cropRect, pickerOptions.isBase64)
+
+      val exporter = CropImageExporter(result.rotation, result.cropRect!!, pickerOptions.isBase64)
       ImageResultTask(
         promise,
-        result.uri,
+        result.uriContent!!,
         contentResolver,
-        CropFileProvider(result.uri),
+        CropFileProvider(result.uriContent!!),
         pickerOptions.isAllowsEditing,
         pickerOptions.isExif,
         exporter,

--- a/android/versioned-abis/expoview-abi45_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi45_0_0/build.gradle
@@ -136,7 +136,7 @@ dependencies {
   releaseApi 'com.squareup.leakcanary:leakcanary-android-no-op:1.4-beta1'
   api 'commons-io:commons-io:2.6'
   api 'me.leolin:ShortcutBadger:1.1.4@aar'
-  implementation "com.github.CanHub:Android-Image-Cropper:1.1.1"
+  implementation "com.github.CanHub:Android-Image-Cropper:4.3.0"
   api 'commons-codec:commons-codec:1.10'
   api 'net.openid:appauth:0.7.1'
   api 'com.airbnb.android:lottie:3.4.0'

--- a/android/versioned-abis/expoview-abi45_0_0/src/main/java/abi45_0_0/expo/modules/imagepicker/ImagePickerModule.kt
+++ b/android/versioned-abis/expoview-abi45_0_0/src/main/java/abi45_0_0/expo/modules/imagepicker/ImagePickerModule.kt
@@ -37,6 +37,9 @@ import abi45_0_0.expo.modules.interfaces.permissions.Permissions
 import abi45_0_0.expo.modules.interfaces.permissions.PermissionsResponse
 import abi45_0_0.expo.modules.interfaces.permissions.PermissionsResponseListener
 import abi45_0_0.expo.modules.interfaces.permissions.PermissionsStatus
+import androidx.core.os.bundleOf
+import com.canhub.cropper.CropImageActivity
+import com.canhub.cropper.options
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
@@ -261,19 +264,24 @@ class ImagePickerModule(
       return
     }
 
-    val cropImageBuilder = CropImage.activity(uri).apply {
-      pickerOptions.forceAspect?.let { (x, y) ->
-        setAspectRatio((x as Number).toInt(), (y as Number).toInt())
-        setFixAspectRatio(true)
-        setInitialCropWindowPaddingRatio(0f)
-      }
-
-      setOutputUri(fileUri)
-      setOutputCompressFormat(compressFormat)
-      setOutputCompressQuality(pickerOptions.quality)
-    }
     exifDataHandler = ExifDataHandler(uri)
-    startActivityOnResult(cropImageBuilder.getIntent(context), CropImage.CROP_IMAGE_ACTIVITY_REQUEST_CODE, promise, pickerOptions)
+    val intent = Intent(context, CropImageActivity::class.java).apply {
+      putExtra(CropImage.CROP_IMAGE_EXTRA_BUNDLE, bundleOf(
+        CropImage.CROP_IMAGE_EXTRA_SOURCE to uri,
+        CropImage.CROP_IMAGE_EXTRA_OPTIONS to options {
+          pickerOptions.forceAspect?.let { (x, y) ->
+            setAspectRatio((x as Number).toInt(), (y as Number).toInt())
+            setFixAspectRatio(true)
+            setInitialCropWindowPaddingRatio(0f)
+          }
+
+          setOutputUri(fileUri)
+          setOutputCompressFormat(compressFormat)
+          setOutputCompressQuality(pickerOptions.quality)
+        }.cropImageOptions.also { it.validate() }
+      ))
+    }
+    startActivityOnResult(intent, CropImage.CROP_IMAGE_ACTIVITY_REQUEST_CODE, promise, pickerOptions)
   }
 
   //endregion
@@ -356,17 +364,18 @@ class ImagePickerModule(
     val contentResolver = activity.application.contentResolver
 
     if (requestCode == CropImage.CROP_IMAGE_ACTIVITY_REQUEST_CODE) {
-      val result = CropImage.getActivityResult(intent).ifNull {
+      val result = intent?.getParcelableExtra(CropImage.CROP_IMAGE_EXTRA_RESULT) as? CropImage.ActivityResult?
+      if (result == null || resultCode == Activity.RESULT_CANCELED) {
         promise.reject(ImagePickerConstants.ERR_CROPPING_FAILURE, ImagePickerConstants.CROPPING_FAILURE_MESSAGE)
         return
       }
 
-      val exporter = CropImageExporter(result.rotation, result.cropRect, pickerOptions.isBase64)
+      val exporter = CropImageExporter(result.rotation, result.cropRect!!, pickerOptions.isBase64)
       ImageResultTask(
         promise,
-        result.uri,
+        result.uriContent!!,
         contentResolver,
-        CropFileProvider(result.uri),
+        CropFileProvider(result.uriContent!!),
         pickerOptions.isAllowsEditing,
         pickerOptions.isExif,
         exporter,

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 🐛 Bug fixes
 
+- On Android restored support for `allowsEditing` option that was disabled when migrating to `registerForActivityResult` mechanism. ([#17963](https://github.com/expo/expo/pull/17963) by [@bbarthec](https://github.com/bbarthec))
+
 ### 💡 Others
 
 ## 13.2.1 — 2022-07-11
@@ -30,7 +32,7 @@ _This version does not introduce any user-facing changes._
 
 ### 💡 Others
 
-- On Android migrated to the new `registerForActivityResult` mechanism. ([#17671](https://github.com/expo/expo/pull/17671), ([#17987](https://github.com/expo/expo/pull/17987) by [@bbarthec](https://github.com/bbarthec))
+- On Android migrated to the new `registerForActivityResult` mechanism. This migration disables `allowsEditing` option. ([#17671](https://github.com/expo/expo/pull/17671), ([#17987](https://github.com/expo/expo/pull/17987) by [@bbarthec](https://github.com/bbarthec))
 - Native module on Android is now written in Kotlin using [Sweet API](https://docs.expo.dev/modules/module-api). ([#17668](https://github.com/expo/expo/pull/17668) by [@bbarthec](https://github.com/bbarthec))
 - Migrated Expo modules definitions to the new naming convention. ([#17193](https://github.com/expo/expo/pull/17193) by [@tsapeta](https://github.com/tsapeta))
 

--- a/packages/expo-image-picker/android/build.gradle
+++ b/packages/expo-image-picker/android/build.gradle
@@ -84,9 +84,11 @@ android {
 dependencies {
   implementation project(':expo-modules-core')
 
-  implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
-  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.3")
-  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.3")
-  implementation "com.github.CanHub:Android-Image-Cropper:1.1.1"
+  implementation "androidx.activity:activity-ktx:1.4.0"
+  implementation "androidx.appcompat:appcompat:1.4.2"
   implementation "androidx.exifinterface:exifinterface:1.3.3"
+  implementation "com.github.CanHub:Android-Image-Cropper:4.3.0"
+  implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
+  implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.3"
+  implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.3"
 }

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
@@ -91,7 +91,7 @@ class ImagePickerModule : Module() {
           ) { input, result -> handleResultUponActivityDestruction(result, input.options) }
           cropImageLauncher = appContext.registerForActivityResult(
             CropImageContract(this@ImagePickerModule),
-          ) { input, result -> handleResultUponActivityDestruction(result, input.options)}
+          ) { input, result -> handleResultUponActivityDestruction(result, input.options) }
         }
       }
     }
@@ -128,10 +128,10 @@ class ImagePickerModule : Module() {
     return try {
       var result = launchPicker(pickerLauncher)
       if (
-        !options.allowsMultipleSelection
-        && options.allowsEditing
-        && result.data.size == 1
-        && result.data[0].first == MediaType.IMAGE
+        !options.allowsMultipleSelection &&
+        options.allowsEditing &&
+        result.data.size == 1 &&
+        result.data[0].first == MediaType.IMAGE
       ) {
         result = launchPicker {
           cropImageLauncher.launch(CropImageContractOptions(result.data[0].second, options))

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
@@ -6,7 +6,6 @@ import android.content.Intent
 import android.net.Uri
 import expo.modules.core.errors.ModuleNotFoundException
 import android.os.OperationCanceledException
-import expo.modules.imagepicker.contracts.*
 import expo.modules.imagepicker.contracts.CameraContract
 import expo.modules.imagepicker.contracts.CameraContractOptions
 import expo.modules.imagepicker.contracts.CropImageContract
@@ -14,7 +13,6 @@ import expo.modules.imagepicker.contracts.CropImageContractOptions
 import expo.modules.imagepicker.contracts.ImageLibraryContract
 import expo.modules.imagepicker.contracts.ImageLibraryContractOptions
 import expo.modules.imagepicker.contracts.ImagePickerContractResult
-import expo.modules.imagepicker.contracts.PickingSource
 import expo.modules.interfaces.permissions.Permissions
 import expo.modules.interfaces.permissions.PermissionsStatus
 import expo.modules.kotlin.Promise
@@ -136,7 +134,7 @@ class ImagePickerModule : Module() {
         && result.data[0].first == MediaType.IMAGE
       ) {
         result = launchPicker {
-          cropImageLauncher.launch(CropImageContractOptions(result.data[0].second, options, result.pickingSource))
+          cropImageLauncher.launch(CropImageContractOptions(result.data[0].second, options))
         }
       }
       mediaHandler.readExtras(result.data, options)

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/CameraContract.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/CameraContract.kt
@@ -42,7 +42,7 @@ internal class CameraContract(
     } else {
       val uri = input.uri
       val type = uri.toMediaType(contentResolver)
-      ImagePickerContractResult.Success(listOf(type to uri), PickingSource.CAMERA)
+      ImagePickerContractResult.Success(listOf(type to uri))
     }
 }
 

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/CameraContract.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/CameraContract.kt
@@ -1,6 +1,7 @@
 package expo.modules.imagepicker.contracts
 
 import android.app.Activity
+import android.content.ContentResolver
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
@@ -21,6 +22,11 @@ import java.io.Serializable
 internal class CameraContract(
   private val appContextProvider: AppContextProvider,
 ) : AppContextActivityResultContract<CameraContractOptions, ImagePickerContractResult> {
+  val contentResolver: ContentResolver
+    get() = requireNotNull(appContextProvider.appContext.reactContext) {
+      "React Application Context is null"
+    }.contentResolver
+
   override fun createIntent(context: Context, input: CameraContractOptions): Intent =
     Intent(input.options.mediaTypes.toCameraIntentAction())
       .putExtra(MediaStore.EXTRA_OUTPUT, input.uri)
@@ -34,14 +40,16 @@ internal class CameraContract(
     if (resultCode == Activity.RESULT_CANCELED) {
       ImagePickerContractResult.Cancelled()
     } else {
-      val contentResolver = requireNotNull(appContextProvider.appContext.reactContext) { "React Application Context is null. " }.contentResolver
       val uri = input.uri
       val type = uri.toMediaType(contentResolver)
-      ImagePickerContractResult.Success(listOf(type to uri))
+      ImagePickerContractResult.Success(listOf(type to uri), PickingSource.CAMERA)
     }
 }
 
 internal data class CameraContractOptions(
+  /**
+   * Destination file in a form of content-[Uri] to save results coming from camera to.
+   */
   val uri: Uri,
   val options: ImagePickerOptions,
 ) : Serializable

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/ContractsUtils.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/ContractsUtils.kt
@@ -8,13 +8,5 @@ import expo.modules.imagepicker.MediaType
  */
 internal sealed class ImagePickerContractResult private constructor() {
   class Cancelled : ImagePickerContractResult()
-  class Success(
-    val data: List<Pair<MediaType, Uri>>,
-    val pickingSource: PickingSource,
-  ) : ImagePickerContractResult()
-}
-
-internal enum class PickingSource {
-  CAMERA,
-  IMAGE_LIBRARY,
+  class Success(val data: List<Pair<MediaType, Uri>>) : ImagePickerContractResult()
 }

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/ContractsUtils.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/ContractsUtils.kt
@@ -1,18 +1,20 @@
 package expo.modules.imagepicker.contracts
 
 import android.net.Uri
-import androidx.activity.result.contract.ActivityResultContract
 import expo.modules.imagepicker.MediaType
-
-/**
- * Alias for [androidx.activity.result.contract.ActivityResultContract] with required generic types already specified
- */
-internal typealias ImagePickerContract = ActivityResultContract<Any?, ImagePickerContractResult>
 
 /**
  * Data required to be returned upon successful contract completion
  */
 internal sealed class ImagePickerContractResult private constructor() {
   class Cancelled : ImagePickerContractResult()
-  class Success(val data: List<Pair<MediaType, Uri>>) : ImagePickerContractResult()
+  class Success(
+    val data: List<Pair<MediaType, Uri>>,
+    val pickingSource: PickingSource,
+  ) : ImagePickerContractResult()
+}
+
+internal enum class PickingSource {
+  CAMERA,
+  IMAGE_LIBRARY,
 }

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/CropImageContract.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/CropImageContract.kt
@@ -12,45 +12,43 @@ import com.canhub.cropper.CropImageActivity
 import com.canhub.cropper.CropImageOptions
 import expo.modules.imagepicker.ImagePickerOptions
 import expo.modules.imagepicker.MediaType
-import expo.modules.imagepicker.PickingSource
 import expo.modules.imagepicker.copyExifData
 import expo.modules.imagepicker.createOutputFile
 import expo.modules.imagepicker.toBitmapCompressFormat
 import expo.modules.imagepicker.toImageFileExtension
+import expo.modules.kotlin.activityresult.AppContextActivityResultContract
 import expo.modules.kotlin.providers.AppContextProvider
 import kotlinx.coroutines.runBlocking
+import java.io.Serializable
 
 internal class CropImageContract(
   private val appContextProvider: AppContextProvider,
-  private val sourceUri: Uri,
-  private val options: ImagePickerOptions,
-  private val pickingSource: PickingSource
-) : ImagePickerContract() {
-  override fun createIntent(context: Context, input: Any?) = Intent(context, CropImageActivity::class.java).apply {
-    // for [IMAGE_LIBRARY] we need to create a new file as up to this point we've been operating on the original media asset
-    // for [CAMERA] we do not have to do it as it's already been created at the beginning of the picking process
-    val needCreateNewFile = pickingSource == PickingSource.IMAGE_LIBRARY
-    val mediaType = expo.modules.imagepicker.getType(context.contentResolver, sourceUri)
-
+) : AppContextActivityResultContract<CropImageContractOptions, ImagePickerContractResult> {
+  override fun createIntent(context: Context, input: CropImageContractOptions) = Intent(context, CropImageActivity::class.java).apply {
+    val mediaType = expo.modules.imagepicker.getType(context.contentResolver, input.sourceUri)
     val compressFormat = mediaType.toBitmapCompressFormat()
 
-    val outputUri: Uri = if (needCreateNewFile) {
+    /**
+     * for `IMAGE LIBRARY` we need to create a new file as up to this point we've been operating on the original media asset
+     * for `CAMERA` we do not have to do it as it's already been created at the beginning of the picking process
+     */
+    val outputUri: Uri = if (input.pickingSource == PickingSource.IMAGE_LIBRARY) {
       createOutputFile(context.cacheDir, compressFormat.toImageFileExtension()).toUri()
     } else {
-      sourceUri
+      input.sourceUri
     }
 
     putExtra(
       CropImage.CROP_IMAGE_EXTRA_BUNDLE,
       bundleOf(
-        CropImage.CROP_IMAGE_EXTRA_SOURCE to sourceUri,
+        CropImage.CROP_IMAGE_EXTRA_SOURCE to input.sourceUri,
         CropImage.CROP_IMAGE_EXTRA_OPTIONS to CropImageOptions().apply {
           outputCompressFormat = compressFormat
-          outputCompressQuality = (this@CropImageContract.options.quality * 100).toInt()
+          outputCompressQuality = (input.options.quality * 100).toInt()
 
           this.customOutputUri = outputUri
 
-          this@CropImageContract.options.aspect?.let { (x, y) ->
+          input.options.aspect?.let { (x, y) ->
             aspectRatioX = x
             aspectRatioY = y
             fixAspectRatio = true
@@ -63,14 +61,20 @@ internal class CropImageContract(
     )
   }
 
-  override fun parseResult(resultCode: Int, intent: Intent?): ImagePickerContractResult {
+  override fun parseResult(input: CropImageContractOptions, resultCode: Int, intent: Intent?): ImagePickerContractResult {
     val result = intent?.getParcelableExtra<CropImage.ActivityResult?>(CropImage.CROP_IMAGE_EXTRA_RESULT)
     if (resultCode == Activity.RESULT_CANCELED || result == null) {
       return ImagePickerContractResult.Cancelled()
     }
     val targetUri = requireNotNull(result.uriContent)
     val contentResolver = requireNotNull(appContextProvider.appContext.reactContext) { "React Application Context is null" }.contentResolver
-    runBlocking { copyExifData(sourceUri, targetUri.toFile(), contentResolver) }
-    return ImagePickerContractResult.Success(listOf(MediaType.IMAGE to targetUri))
+    runBlocking { copyExifData(input.sourceUri, targetUri.toFile(), contentResolver) }
+    return ImagePickerContractResult.Success(listOf(MediaType.IMAGE to targetUri), input.pickingSource)
   }
 }
+
+internal data class CropImageContractOptions(
+  val sourceUri: Uri,
+  val options: ImagePickerOptions,
+  val pickingSource: PickingSource,
+) : Serializable

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/CropImageContract.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/CropImageContract.kt
@@ -27,16 +27,7 @@ internal class CropImageContract(
   override fun createIntent(context: Context, input: CropImageContractOptions) = Intent(context, CropImageActivity::class.java).apply {
     val mediaType = expo.modules.imagepicker.getType(context.contentResolver, input.sourceUri)
     val compressFormat = mediaType.toBitmapCompressFormat()
-
-    /**
-     * for `IMAGE LIBRARY` we need to create a new file as up to this point we've been operating on the original media asset
-     * for `CAMERA` we do not have to do it as it's already been created at the beginning of the picking process
-     */
-    val outputUri: Uri = if (input.pickingSource == PickingSource.IMAGE_LIBRARY) {
-      createOutputFile(context.cacheDir, compressFormat.toImageFileExtension()).toUri()
-    } else {
-      input.sourceUri
-    }
+    val outputUri = createOutputFile(context.cacheDir, compressFormat.toImageFileExtension()).toUri()
 
     putExtra(
       CropImage.CROP_IMAGE_EXTRA_BUNDLE,
@@ -69,12 +60,11 @@ internal class CropImageContract(
     val targetUri = requireNotNull(result.uriContent)
     val contentResolver = requireNotNull(appContextProvider.appContext.reactContext) { "React Application Context is null" }.contentResolver
     runBlocking { copyExifData(input.sourceUri, targetUri.toFile(), contentResolver) }
-    return ImagePickerContractResult.Success(listOf(MediaType.IMAGE to targetUri), input.pickingSource)
+    return ImagePickerContractResult.Success(listOf(MediaType.IMAGE to targetUri))
   }
 }
 
 internal data class CropImageContractOptions(
   val sourceUri: Uri,
   val options: ImagePickerOptions,
-  val pickingSource: PickingSource,
 ) : Serializable

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/CropImageContract.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/CropImageContract.kt
@@ -47,7 +47,8 @@ internal class CropImageContract(
         CropImage.CROP_IMAGE_EXTRA_OPTIONS to CropImageOptions().apply {
           outputCompressFormat = compressFormat
           outputCompressQuality = (this@CropImageContract.options.quality * 100).toInt()
-          this.outputUri = outputUri
+
+          this.customOutputUri = outputUri
 
           this@CropImageContract.options.aspect?.let { (x, y) ->
             aspectRatioX = x
@@ -67,7 +68,7 @@ internal class CropImageContract(
     if (resultCode == Activity.RESULT_CANCELED || result == null) {
       return ImagePickerContractResult.Cancelled()
     }
-    val targetUri = requireNotNull(result.uri)
+    val targetUri = requireNotNull(result.uriContent)
     val contentResolver = requireNotNull(appContextProvider.appContext.reactContext) { "React Application Context is null" }.contentResolver
     runBlocking { copyExifData(sourceUri, targetUri.toFile(), contentResolver) }
     return ImagePickerContractResult.Success(listOf(MediaType.IMAGE to targetUri))

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/ImageLibraryContract.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/ImageLibraryContract.kt
@@ -42,11 +42,11 @@ internal class ImageLibraryContract(
       ImagePickerContractResult.Cancelled()
     } else if (input.options.allowsMultipleSelection) {
       val uris = requireNotNull(intent).getAllDataUris()
-      ImagePickerContractResult.Success(uris.map { uri -> uri.toMediaType(contentResolver) to uri }, PickingSource.IMAGE_LIBRARY)
+      ImagePickerContractResult.Success(uris.map { uri -> uri.toMediaType(contentResolver) to uri })
     } else {
       val uri = requireNotNull(requireNotNull(intent).data)
       val type = uri.toMediaType(contentResolver)
-      ImagePickerContractResult.Success(listOf(type to uri), PickingSource.IMAGE_LIBRARY)
+      ImagePickerContractResult.Success(listOf(type to uri))
     }
 }
 

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/ImageLibraryContract.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/ImageLibraryContract.kt
@@ -42,11 +42,11 @@ internal class ImageLibraryContract(
       ImagePickerContractResult.Cancelled()
     } else if (input.options.allowsMultipleSelection) {
       val uris = requireNotNull(intent).getAllDataUris()
-      ImagePickerContractResult.Success(uris.map { uri -> uri.toMediaType(contentResolver) to uri })
+      ImagePickerContractResult.Success(uris.map { uri -> uri.toMediaType(contentResolver) to uri }, PickingSource.IMAGE_LIBRARY)
     } else {
       val uri = requireNotNull(requireNotNull(intent).data)
       val type = uri.toMediaType(contentResolver)
-      ImagePickerContractResult.Success(listOf(type to uri))
+      ImagePickerContractResult.Success(listOf(type to uri), PickingSource.IMAGE_LIBRARY)
     }
 }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -268,6 +268,12 @@ class AppContext(
 
 // region AppContextActivityResultCaller
 
+  /**
+   * For the time being [fallbackCallback] is not working.
+   * There are some problems with saving and restoring the state of [activityResultsManager]
+   * connected with [Activity]'s lifecycle and [AppContext] lifespan. So far, we've failed with identifying
+   * what parts of the application outlives the Activity destruction (especially [AppContext] and other [Bridge]-related parts).
+   */
   @MainThread
   override suspend fun <I : Serializable, O> registerForActivityResult(
     contract: AppContextActivityResultContract<I, O>,


### PR DESCRIPTION
# Why

Restored `allowsEditing` options on Android that was disabled in #17671

# How

I've created another `registerForActivityResult` mechanism that launches https://github.com/CanHub/Android-Image-Cropper
Additionally:
- `canhub` cropping library is upgraded to the newest version
  - it triggered updates in versioned code as well, as this library changed it's API between version `1.x.x` (old) and `4.x.x` (current)
- due to some `file://` vs `content://` problem with `Uri` that was shared between 3rd party Activities (`ImageLibrary`, `Camera`, `Cropper`) when cropping is requested a new file is created.

# Test Plan

- [x] `ncl` screen with `ImagePicking` scenarios now respects `allowsEditing` option and properly launches 3rd party cropping Activity
- [x] old versioned code works as expected after native library bump 

# TODO

- [ ] backport to sdk 46
