### PR TITLE
uploadAsync() example: Update filesystem.md

### DIFF
--- a/docs/pages/versions/unversioned/sdk/filesystem.md
+++ b/docs/pages/versions/unversioned/sdk/filesystem.md
@@ -432,30 +432,24 @@ Upload the contents of the file pointed by `fileUri` to the remote url.
 ```javascript
 import * as FileSystem from 'expo-file-system'
 
-FileSystem.uploadAsync(
+try {
+  const response = await FileSystem.uploadAsync(
     `http://192.168.0.1:1234/binary-upload`,
     fileUri,
     {
-        fieldName: "file",
-        httpMethod: "PATCH",
-        uploadType: FileSystem.FileSystemUploadType.BINARY_CONTENT,
+      fieldName: "file",
+      httpMethod: "PATCH",
+      uploadType: FileSystem.FileSystemUploadType.BINARY_CONTENT,
     }
-)
-.then(object => console.log(JSON.stringify(object,null,4)))
-.catch(error => console.log(error))
+  )
+  console.log(JSON.stringify(response, null, 4))
+} catch(error) {
+  console.log(error)
+}
 ```
 **server**
-```javascript
-const express = require('express');
-const app = express();
-const fs = require('fs');
 
-// This method will save the binary content of the request as a file.
-app.patch('/binary-upload', (req, res) => {
-    req.pipe(fs.createWriteStream('./uploads/location' + Date.now() + '.m4a'));
-    res.end('OK');
-});
-```
+please refer to [how to handle such requests](https://docs.expo.dev/versions/latest/sdk/filesystem/#how-to-handle-such-requests) with a simple Node.js server
 
 #### Arguments
 

--- a/docs/pages/versions/unversioned/sdk/filesystem.md
+++ b/docs/pages/versions/unversioned/sdk/filesystem.md
@@ -426,6 +426,37 @@ Returns a Promise that resolves to an object with the following fields:
 
 Upload the contents of the file pointed by `fileUri` to the remote url.
 
+#### Example
+
+**client**
+```javascript
+import * as FileSystem from 'expo-file-system'
+
+FileSystem.uploadAsync(
+    `http://192.168.0.1:1234/binary-upload`,
+    fileUri,
+    {
+        fieldName: "file",
+        httpMethod: "PATCH",
+        uploadType: FileSystem.FileSystemUploadType.BINARY_CONTENT,
+    }
+)
+.then(object => console.log(JSON.stringify(object,null,4)))
+.catch(error => console.log(error))
+```
+**server**
+```javascript
+const express = require('express');
+const app = express();
+const fs = require('fs');
+
+// This method will save the binary content of the request as a file.
+app.patch('/binary-upload', (req, res) => {
+    req.pipe(fs.createWriteStream('./uploads/location' + Date.now() + '.m4a'));
+    res.end('OK');
+});
+```
+
 #### Arguments
 
 - **url (_string_)** -- The remote URL, where the file will be sent.

--- a/docs/pages/versions/unversioned/sdk/filesystem.md
+++ b/docs/pages/versions/unversioned/sdk/filesystem.md
@@ -449,7 +449,7 @@ try {
 ```
 **server**
 
-please refer to [how to handle such requests](https://docs.expo.dev/versions/latest/sdk/filesystem/#how-to-handle-such-requests) with a simple Node.js server
+Please refer to the "[how to handle such requests](#how-to-handle-such-requests)" section - there is code for a simple Node.js server.
 
 #### Arguments
 


### PR DESCRIPTION
uploadAsync() example

# Why

Useful example for those unfamiliar with traditional HTTP Patch request method

# How

Added working example

# Test Plan

Example working in personal project

# Checklist

- [x ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
