### PR TITLE
[ios][autolinking] Use regex to match modules in expo_patch_react_imports!

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - Added support for React Native 0.69.x ([#17629](https://github.com/expo/expo/pull/17629) by [@kudo](https://github.com/kudo))
-- Use regex to match ignored modules in expo_patch_react_imports! ([#17968](https://github.com/expo/expo/pull/17968) by [@dmnkgrc](https://github.com/dmnkgrc))
+- Use regex to match ignored modules in `expo_patch_react_imports!` and fix iOS build errors when the project is inside `react-native` named folder. ([#17968](https://github.com/expo/expo/pull/17968) by [@dmnkgrc](https://github.com/dmnkgrc))
 
 ### 💡 Others
 

--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Added support for React Native 0.69.x ([#17629](https://github.com/expo/expo/pull/17629) by [@kudo](https://github.com/kudo))
+- Use regex to match ignored modules in expo_patch_react_imports! ([#17968](https://github.com/expo/expo/pull/17968) by [@dmnkgrc](https://github.com/dmnkgrc))
 
 ### 💡 Others
 

--- a/packages/expo-modules-autolinking/scripts/ios/react_import_patcher.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/react_import_patcher.rb
@@ -54,12 +54,13 @@ module Expo
         end
       end
 
-      return result.select { |dir|
+      result.reject do |dir|
         # Exclude known dirs unnecessary to patch and reduce processing time
-        !dir.include?('/react-native/') &&
-        !dir.end_with?('/react-native') &&
-        !dir.include?('/expo-')
-      }
+        # Since we are using real (absolute) pathnames we need to assert that we are inside of the node_modules
+        # directory to not collide with other directories in the user's filesystem.
+        # We reject the react-native package and packages starting with expo-
+        dir.match(%r{^.*/node_modules/(react-native(/.*)?|expo-.*)$})
+      end
     end
 
   end # class ReactImportPatcher


### PR DESCRIPTION
# Why

The previous version of the script would ignore modules if the absolute path contained ignored names even though the string had nothing to do with the ignored modules, for example:

- /Users/username/code/react-native/node_modules/react-native-permissions
- /Users/username/code/expo-learning/node_modules/react-native-paypal

This led me to temporarily having to change the structure and naming of my projects since I like to organize them by technology 😅 

# How

This PR changes the implementation to use a regex that instead will make sure that the excluded package names are located inside the `node_modules` directory. This way users of the packages can name and strucutre their projects in any way without being affected by the script.

# Test Plan

I tested this in my own project and this change allowed me to change back the name of the parent directory of my project. I added some console logs for debugging, this is an excerpt of them:

```bash
dir: /Users/dominikgarciabertapelle/code/react-native/react-native-app/node_modules/expo-application/ios match: true
dir: /Users/dominikgarciabertapelle/code/react-native/react-native-app/node_modules/expo-constants/ios match: true
dir: /Users/dominikgarciabertapelle/code/react-native/react-native-app/node_modules/expo-error-recovery/ios match: true
dir: /Users/dominikgarciabertapelle/code/react-native/react-native-app/node_modules/expo-file-system/ios match: true
dir: /Users/dominikgarciabertapelle/code/react-native/react-native-app/node_modules/expo-font/ios match: true
dir: /Users/dominikgarciabertapelle/code/react-native/react-native-app/node_modules/expo/ios match: false
dir: /Users/dominikgarciabertapelle/code/react-native/react-native-app/node_modules/expo-keep-awake/ios match: true
dir: /Users/dominikgarciabertapelle/code/react-native/react-native-app/node_modules/expo-linear-gradient/ios match: true
dir: /Users/dominikgarciabertapelle/code/react-native/react-native-app/node_modules/expo-modules-core/ios match: true
dir: /Users/dominikgarciabertapelle/code/react-native/react-native-app/node_modules/react-native/Libraries/FBLazyVector match: true
dir: /Users/dominikgarciabertapelle/code/react-native/react-native-app/node_modules/react-native/React/FBReactNativeSpec match: true
dir: /Users/dominikgarciabertapelle/code/react-native/react-native-app/node_modules/lottie-ios match: false
dir: /Users/dominikgarciabertapelle/code/react-native/react-native-app/node_modules/lottie-react-native match: false
dir: /Users/dominikgarciabertapelle/code/react-native/react-native-app/node_modules/mixpanel-react-native match: false
dir: /Users/dominikgarciabertapelle/code/react-native/react-native-app/node_modules/react-native-permissions/ios/Camera match: false
dir: /Users/dominikgarciabertapelle/code/react-native/react-native-app/node_modules/react-native-permissions/ios/Notifications match: false
dir: /Users/dominikgarciabertapelle/code/react-native/react-native-app/node_modules/react-native-permissions/ios/PhotoLibrary match: false
dir: /Users/dominikgarciabertapelle/code/react-native/react-native-app/node_modules/react-native/Libraries/RCTRequired match: true
dir: /Users/dominikgarciabertapelle/code/react-native/react-native-app/node_modules/react-native-restart match: false
dir: /Users/dominikgarciabertapelle/code/react-native/react-native-app/node_modules/react-native/Libraries/TypeSafety match: true
dir: /Users/dominikgarciabertapelle/code/react-native/react-native-app/node_modules/react-native match: true
dir: /Users/dominikgarciabertapelle/code/react-native/react-native-app/node_modules/react-native/ReactCommon/callinvoker match: true
dir: /Users/dominikgarciabertapelle/code/react-native/react-native-app/ios/build/generated/ios match: false
dir: /Users/dominikgarciabertapelle/code/react-native/react-native-app/node_modules/react-native match: true
dir: /Users/dominikgarciabertapelle/code/react-native/react-native-app/node_modules/react-native/React/CoreModules match: true
dir: /Users/dominikgarciabertapelle/code/react-native/react-native-app/node_modules/react-native/ReactCommon/cxxreact match: true
dir: /Users/dominikgarciabertapelle/code/react-native/react-native-app/node_modules/react-native/ReactCommon/hermes match: true
dir: /Users/dominikgarciabertapelle/code/react-native/react-native-app/node_modules/react-native/ReactCommon/jsi match: true
dir: /Users/dominikgarciabertapelle/code/react-native/react-native-app/node_modules/react-native/ReactCommon/jsiexecutor match: true
dir: /Users/dominikgarciabertapelle/code/react-native/react-native-app/node_modules/react-native/ReactCommon/jsinspector match: true
dir: /Users/dominikgarciabertapelle/code/react-native/react-native-app/node_modules/react-native/ReactCommon/logger match: true
dir: /Users/dominikgarciabertapelle/code/react-native/react-native-app/node_modules/react-native-adjust match: false
dir: /Users/dominikgarciabertapelle/code/react-native/react-native-app/node_modules/react-native-blob-util match: false
dir: /Users/dominikgarciabertapelle/code/react-native/react-native-app/node_modules/react-native-config match: false
dir: /Users/dominikgarciabertapelle/code/react-native/react-native-app/node_modules/react-native-document-picker match: false
dir: /Users/dominikgarciabertapelle/code/react-native/react-native-app/node_modules/react-native-flipper match: false
dir: /Users/dominikgarciabertapelle/code/react-native/react-native-app/node_modules/react-native-get-random-values match: false
```

Please let me know if there is any more information that you need from me 🙏  Thanks!

# Checklist

- [] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
