### PR TITLE
[notifications] Fix older notifications be overwritten issue

### DIFF
--- a/android/versioned-abis/expoview-abi43_0_0/src/main/AndroidManifest.xml
+++ b/android/versioned-abis/expoview-abi43_0_0/src/main/AndroidManifest.xml
@@ -323,6 +323,7 @@
           android:excludeFromRecents="true"
           android:noHistory="true"
           android:launchMode="standard"
+          android:taskAffinity=""
           />
 
         <provider

--- a/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/notifications/service/NotificationForwarderActivity.kt
+++ b/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/notifications/service/NotificationForwarderActivity.kt
@@ -16,15 +16,9 @@ class NotificationForwarderActivity : Activity() {
     super.onCreate(savedInstanceState)
     val broadcastIntent =
       NotificationsService.createNotificationResponseBroadcastIntent(applicationContext, intent.extras)
+    val notificationResponse = NotificationsService.getNotificationResponseFromBroadcastIntent(broadcastIntent)
+    ExpoHandlingDelegate.openAppToForeground(this, notificationResponse)
     sendBroadcast(broadcastIntent)
-
-    val foregroundLaunchActivityIntent = ExpoHandlingDelegate.getForegroundLaunchActivityIntent(this)
-    if (foregroundLaunchActivityIntent != null) {
-      val notificationResponse = NotificationsService.getNotificationResponseFromBroadcastIntent(broadcastIntent)
-      NotificationsService.setNotificationResponseToIntent(foregroundLaunchActivityIntent, notificationResponse)
-      startActivity(foregroundLaunchActivityIntent)
-    }
-
     finish()
   }
 

--- a/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/notifications/service/NotificationForwarderActivity.kt
+++ b/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/notifications/service/NotificationForwarderActivity.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import expo.modules.notifications.BuildConfig
+import abi43_0_0.expo.modules.notifications.service.delegates.ExpoHandlingDelegate
 
 /**
  * An internal Activity that passes given Intent extras from
@@ -16,6 +17,14 @@ class NotificationForwarderActivity : Activity() {
     val broadcastIntent =
       NotificationsService.createNotificationResponseBroadcastIntent(applicationContext, intent.extras)
     sendBroadcast(broadcastIntent)
+
+    val foregroundLaunchActivityIntent = ExpoHandlingDelegate.getForegroundLaunchActivityIntent(this)
+    if (foregroundLaunchActivityIntent != null) {
+      val notificationResponse = NotificationsService.getNotificationResponseFromBroadcastIntent(broadcastIntent)
+      NotificationsService.setNotificationResponseToIntent(foregroundLaunchActivityIntent, notificationResponse)
+      startActivity(foregroundLaunchActivityIntent)
+    }
+
     finish()
   }
 

--- a/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/notifications/service/delegates/ExpoHandlingDelegate.kt
+++ b/android/versioned-abis/expoview-abi43_0_0/src/main/java/abi43_0_0/expo/modules/notifications/service/delegates/ExpoHandlingDelegate.kt
@@ -76,13 +76,14 @@ class ExpoHandlingDelegate(protected val context: Context) : HandlingDelegate {
       return PendingIntent.getActivity(context, requestCode, backgroundActivityIntent, intentFlags)
     }
 
-    fun getForegroundLaunchActivityIntent(context: Context): Intent? {
-      val intent = getNotificationActionLauncher(context)
-        ?: ExpoHandlingDelegate.getMainActivityLauncher(context) ?: run {
-        Log.w("expo-notifications", "No launch intent found for application. Interacting with the notification won't open the app. The implementation uses `getLaunchIntentForPackage` to find appropriate activity.")
-        return null
+    fun openAppToForeground(context: Context, notificationResponse: NotificationResponse) {
+      (getNotificationActionLauncher(context) ?: getMainActivityLauncher(context))?.let { intent ->
+        NotificationsService.setNotificationResponseToIntent(intent, notificationResponse)
+        context.startActivity(intent)
+        return
       }
-      return intent
+
+      Log.w("expo-notifications", "No launch intent found for application. Interacting with the notification won't open the app. The implementation uses `getLaunchIntentForPackage` to find appropriate activity.")
     }
 
     private fun getNotificationActionLauncher(context: Context): Intent? {
@@ -126,16 +127,6 @@ class ExpoHandlingDelegate(protected val context: Context) : HandlingDelegate {
         it.onNotificationResponseReceived(notificationResponse)
       }
     }
-  }
-
-  protected fun openAppToForeground(context: Context, notificationResponse: NotificationResponse) {
-    (getNotificationActionLauncher(context) ?: getMainActivityLauncher(context))?.let { intent ->
-      NotificationsService.setNotificationResponseToIntent(intent, notificationResponse)
-      context.startActivity(intent)
-      return
-    }
-
-    Log.w("expo-notifications", "No launch intent found for application. Interacting with the notification won't open the app. The implementation uses `getLaunchIntentForPackage` to find appropriate activity.")
   }
 
   override fun handleNotificationsDropped() {

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/AndroidManifest.xml
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/AndroidManifest.xml
@@ -324,6 +324,7 @@
           android:excludeFromRecents="true"
           android:noHistory="true"
           android:launchMode="standard"
+          android:taskAffinity=""
           />
 
         <provider

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/notifications/service/NotificationForwarderActivity.kt
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/notifications/service/NotificationForwarderActivity.kt
@@ -16,15 +16,9 @@ class NotificationForwarderActivity : Activity() {
     super.onCreate(savedInstanceState)
     val broadcastIntent =
       NotificationsService.createNotificationResponseBroadcastIntent(applicationContext, intent.extras)
+    val notificationResponse = NotificationsService.getNotificationResponseFromBroadcastIntent(broadcastIntent)
+    ExpoHandlingDelegate.openAppToForeground(this, notificationResponse)
     sendBroadcast(broadcastIntent)
-
-    val foregroundLaunchActivityIntent = ExpoHandlingDelegate.getForegroundLaunchActivityIntent(this)
-    if (foregroundLaunchActivityIntent != null) {
-      val notificationResponse = NotificationsService.getNotificationResponseFromBroadcastIntent(broadcastIntent)
-      NotificationsService.setNotificationResponseToIntent(foregroundLaunchActivityIntent, notificationResponse)
-      startActivity(foregroundLaunchActivityIntent)
-    }
-
     finish()
   }
 

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/notifications/service/NotificationForwarderActivity.kt
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/notifications/service/NotificationForwarderActivity.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import expo.modules.notifications.BuildConfig
+import abi44_0_0.expo.modules.notifications.service.delegates.ExpoHandlingDelegate
 
 /**
  * An internal Activity that passes given Intent extras from
@@ -16,6 +17,14 @@ class NotificationForwarderActivity : Activity() {
     val broadcastIntent =
       NotificationsService.createNotificationResponseBroadcastIntent(applicationContext, intent.extras)
     sendBroadcast(broadcastIntent)
+
+    val foregroundLaunchActivityIntent = ExpoHandlingDelegate.getForegroundLaunchActivityIntent(this)
+    if (foregroundLaunchActivityIntent != null) {
+      val notificationResponse = NotificationsService.getNotificationResponseFromBroadcastIntent(broadcastIntent)
+      NotificationsService.setNotificationResponseToIntent(foregroundLaunchActivityIntent, notificationResponse)
+      startActivity(foregroundLaunchActivityIntent)
+    }
+
     finish()
   }
 

--- a/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/notifications/service/delegates/ExpoHandlingDelegate.kt
+++ b/android/versioned-abis/expoview-abi44_0_0/src/main/java/abi44_0_0/expo/modules/notifications/service/delegates/ExpoHandlingDelegate.kt
@@ -76,13 +76,14 @@ class ExpoHandlingDelegate(protected val context: Context) : HandlingDelegate {
       return PendingIntent.getActivity(context, requestCode, backgroundActivityIntent, intentFlags)
     }
 
-    fun getForegroundLaunchActivityIntent(context: Context): Intent? {
-      val intent = getNotificationActionLauncher(context)
-        ?: ExpoHandlingDelegate.getMainActivityLauncher(context) ?: run {
-        Log.w("expo-notifications", "No launch intent found for application. Interacting with the notification won't open the app. The implementation uses `getLaunchIntentForPackage` to find appropriate activity.")
-        return null
+    fun openAppToForeground(context: Context, notificationResponse: NotificationResponse) {
+      (getNotificationActionLauncher(context) ?: getMainActivityLauncher(context))?.let { intent ->
+        NotificationsService.setNotificationResponseToIntent(intent, notificationResponse)
+        context.startActivity(intent)
+        return
       }
-      return intent
+
+      Log.w("expo-notifications", "No launch intent found for application. Interacting with the notification won't open the app. The implementation uses `getLaunchIntentForPackage` to find appropriate activity.")
     }
 
     private fun getNotificationActionLauncher(context: Context): Intent? {

--- a/android/versioned-abis/expoview-abi45_0_0/src/main/AndroidManifest.xml
+++ b/android/versioned-abis/expoview-abi45_0_0/src/main/AndroidManifest.xml
@@ -323,6 +323,7 @@
           android:excludeFromRecents="true"
           android:noHistory="true"
           android:launchMode="standard"
+          android:taskAffinity=""
           />
 
         <provider

--- a/android/versioned-abis/expoview-abi45_0_0/src/main/java/abi45_0_0/expo/modules/notifications/service/NotificationForwarderActivity.kt
+++ b/android/versioned-abis/expoview-abi45_0_0/src/main/java/abi45_0_0/expo/modules/notifications/service/NotificationForwarderActivity.kt
@@ -16,15 +16,9 @@ class NotificationForwarderActivity : Activity() {
     super.onCreate(savedInstanceState)
     val broadcastIntent =
       NotificationsService.createNotificationResponseBroadcastIntent(applicationContext, intent.extras)
+    val notificationResponse = NotificationsService.getNotificationResponseFromBroadcastIntent(broadcastIntent)
+    ExpoHandlingDelegate.openAppToForeground(this, notificationResponse)
     sendBroadcast(broadcastIntent)
-
-    val foregroundLaunchActivityIntent = ExpoHandlingDelegate.getForegroundLaunchActivityIntent(this)
-    if (foregroundLaunchActivityIntent != null) {
-      val notificationResponse = NotificationsService.getNotificationResponseFromBroadcastIntent(broadcastIntent)
-      NotificationsService.setNotificationResponseToIntent(foregroundLaunchActivityIntent, notificationResponse)
-      startActivity(foregroundLaunchActivityIntent)
-    }
-
     finish()
   }
 

--- a/android/versioned-abis/expoview-abi45_0_0/src/main/java/abi45_0_0/expo/modules/notifications/service/NotificationForwarderActivity.kt
+++ b/android/versioned-abis/expoview-abi45_0_0/src/main/java/abi45_0_0/expo/modules/notifications/service/NotificationForwarderActivity.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import expo.modules.notifications.BuildConfig
+import abi45_0_0.expo.modules.notifications.service.delegates.ExpoHandlingDelegate
 
 /**
  * An internal Activity that passes given Intent extras from
@@ -16,6 +17,14 @@ class NotificationForwarderActivity : Activity() {
     val broadcastIntent =
       NotificationsService.createNotificationResponseBroadcastIntent(applicationContext, intent.extras)
     sendBroadcast(broadcastIntent)
+
+    val foregroundLaunchActivityIntent = ExpoHandlingDelegate.getForegroundLaunchActivityIntent(this)
+    if (foregroundLaunchActivityIntent != null) {
+      val notificationResponse = NotificationsService.getNotificationResponseFromBroadcastIntent(broadcastIntent)
+      NotificationsService.setNotificationResponseToIntent(foregroundLaunchActivityIntent, notificationResponse)
+      startActivity(foregroundLaunchActivityIntent)
+    }
+
     finish()
   }
 

--- a/android/versioned-abis/expoview-abi45_0_0/src/main/java/abi45_0_0/expo/modules/notifications/service/delegates/ExpoHandlingDelegate.kt
+++ b/android/versioned-abis/expoview-abi45_0_0/src/main/java/abi45_0_0/expo/modules/notifications/service/delegates/ExpoHandlingDelegate.kt
@@ -76,13 +76,14 @@ class ExpoHandlingDelegate(protected val context: Context) : HandlingDelegate {
       return PendingIntent.getActivity(context, requestCode, backgroundActivityIntent, intentFlags)
     }
 
-    fun getForegroundLaunchActivityIntent(context: Context): Intent? {
-      val intent = getNotificationActionLauncher(context)
-        ?: ExpoHandlingDelegate.getMainActivityLauncher(context) ?: run {
-        Log.w("expo-notifications", "No launch intent found for application. Interacting with the notification won't open the app. The implementation uses `getLaunchIntentForPackage` to find appropriate activity.")
-        return null
+    fun openAppToForeground(context: Context, notificationResponse: NotificationResponse) {
+      (getNotificationActionLauncher(context) ?: getMainActivityLauncher(context))?.let { intent ->
+        NotificationsService.setNotificationResponseToIntent(intent, notificationResponse)
+        context.startActivity(intent)
+        return
       }
-      return intent
+
+      Log.w("expo-notifications", "No launch intent found for application. Interacting with the notification won't open the app. The implementation uses `getLaunchIntentForPackage` to find appropriate activity.")
     }
 
     private fun getNotificationActionLauncher(context: Context): Intent? {

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fixed Android data-only FCM notifications (i.e. notifications without a title and message) appearing in the notification drawer ([#17707](https://github.com/expo/expo/pull/17707) by [@sausti](https://github.com/sausti))
 - Add support for unregistering from push notifications on Android and iOS ([#17812](https://github.com/expo/expo/pull/17812) by [@sausti](https://github.com/sausti))
 - Fix another Android 12+ trampoline issue from push notifications. ([#17871](https://github.com/expo/expo/pull/17871) by [@kudo](https://github.com/kudo))
+- Fixed `useLastNotificationResponse` returns latest received notification but not the clicked notification on Android. ([#17974](https://github.com/expo/expo/pull/17974) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-notifications/android/src/main/AndroidManifest.xml
+++ b/packages/expo-notifications/android/src/main/AndroidManifest.xml
@@ -34,6 +34,7 @@
       android:excludeFromRecents="true"
       android:noHistory="true"
       android:launchMode="standard"
+      android:taskAffinity=""
       />
   </application>
 </manifest>

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationForwarderActivity.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationForwarderActivity.kt
@@ -16,14 +16,8 @@ class NotificationForwarderActivity : Activity() {
     super.onCreate(savedInstanceState)
     val broadcastIntent =
       NotificationsService.createNotificationResponseBroadcastIntent(applicationContext, intent.extras)
-
-    val foregroundLaunchActivityIntent = ExpoHandlingDelegate.getForegroundLaunchActivityIntent(this)
-    if (foregroundLaunchActivityIntent != null) {
-      val notificationResponse = NotificationsService.getNotificationResponseFromBroadcastIntent(broadcastIntent)
-      NotificationsService.setNotificationResponseToIntent(foregroundLaunchActivityIntent, notificationResponse)
-      startActivity(foregroundLaunchActivityIntent)
-    }
-
+    val notificationResponse = NotificationsService.getNotificationResponseFromBroadcastIntent(broadcastIntent)
+    ExpoHandlingDelegate.openAppToForeground(this, notificationResponse)
     sendBroadcast(broadcastIntent)
     finish()
   }

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationForwarderActivity.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationForwarderActivity.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import expo.modules.notifications.BuildConfig
+import expo.modules.notifications.service.delegates.ExpoHandlingDelegate
 
 /**
  * An internal Activity that passes given Intent extras from
@@ -15,6 +16,14 @@ class NotificationForwarderActivity : Activity() {
     super.onCreate(savedInstanceState)
     val broadcastIntent =
       NotificationsService.createNotificationResponseBroadcastIntent(applicationContext, intent.extras)
+
+    val foregroundLaunchActivityIntent = ExpoHandlingDelegate.getForegroundLaunchActivityIntent(this)
+    if (foregroundLaunchActivityIntent != null) {
+      val notificationResponse = NotificationsService.getNotificationResponseFromBroadcastIntent(broadcastIntent)
+      NotificationsService.setNotificationResponseToIntent(foregroundLaunchActivityIntent, notificationResponse)
+      startActivity(foregroundLaunchActivityIntent)
+    }
+
     sendBroadcast(broadcastIntent)
     finish()
   }

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoHandlingDelegate.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoHandlingDelegate.kt
@@ -76,13 +76,14 @@ class ExpoHandlingDelegate(protected val context: Context) : HandlingDelegate {
       return PendingIntent.getActivity(context, requestCode, backgroundActivityIntent, intentFlags)
     }
 
-    fun getForegroundLaunchActivityIntent(context: Context): Intent? {
-      val intent = getNotificationActionLauncher(context)
-        ?: ExpoHandlingDelegate.getMainActivityLauncher(context) ?: run {
-        Log.w("expo-notifications", "No launch intent found for application. Interacting with the notification won't open the app. The implementation uses `getLaunchIntentForPackage` to find appropriate activity.")
-        return null
+    fun openAppToForeground(context: Context, notificationResponse: NotificationResponse) {
+      (getNotificationActionLauncher(context) ?: getMainActivityLauncher(context))?.let { intent ->
+        NotificationsService.setNotificationResponseToIntent(intent, notificationResponse)
+        context.startActivity(intent)
+        return
       }
-      return intent
+
+      Log.w("expo-notifications", "No launch intent found for application. Interacting with the notification won't open the app. The implementation uses `getLaunchIntentForPackage` to find appropriate activity.")
     }
 
     private fun getNotificationActionLauncher(context: Context): Intent? {
@@ -135,16 +136,6 @@ class ExpoHandlingDelegate(protected val context: Context) : HandlingDelegate {
         it.onNotificationResponseReceived(notificationResponse)
       }
     }
-  }
-
-  protected fun openAppToForeground(context: Context, notificationResponse: NotificationResponse) {
-    (getNotificationActionLauncher(context) ?: getMainActivityLauncher(context))?.let { intent ->
-      NotificationsService.setNotificationResponseToIntent(intent, notificationResponse)
-      context.startActivity(intent)
-      return
-    }
-
-    Log.w("expo-notifications", "No launch intent found for application. Interacting with the notification won't open the app. The implementation uses `getLaunchIntentForPackage` to find appropriate activity.")
   }
 
   override fun handleNotificationsDropped() {


### PR DESCRIPTION
# Why

when there are multiple notifications, the latest one will overwrite previous' intent extra data. `useLastNotificationResponse` returns the latest received notification but not the clicked notification.

fixed https://github.com/expo/expo/issues/17966 https://github.com/expo/expo/issues/17531#issuecomment-1160495971

# How

- the previous PendingIntent be overwritten because `PendingIntent.FLAG_UPDATE_CURRENT`. we also used `PendingIntent.FLAG_UPDATE_CURRENT` for previous implementation, the main difference is that for `PendingIntent.getActivities`, it is slightly different to check whether two PendingIntent are equal. i noticed that OneSignal reverted their implementation of PendingIntent.getActivities aka the Reverse Activity Trampoline because the problem for Xiaomi devices. in this pr, i changed the implementation to

```
notification pendingIntent -> hidden background Activity (NotificationForwarderActivity) -> foreground Activity -> broadcast receiveResponse -> finishe NotificationForwarderActivity
``` 

- remove `foregroundActivityIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_MULTIPLE_TASK` that cause #17960

- backport changes to versioned code

# Test Plan

follow #17966 to test multiple notifications and the `Notifications.addNotificationResponseReceivedListener` returned content

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
