### PR TITLE
[emc][image-picker][Android] Migrate to custom `AppContextActivityResultContract`

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 💡 Others
 
+- On Android migrated to the new `registerForActivityResult` mechanism. ([#17671](https://github.com/expo/expo/pull/17671), ([#17987](https://github.com/expo/expo/pull/17987) by [@bbarthec](https://github.com/bbarthec))
 - Native module on Android is now written in Kotlin using [Sweet API](https://docs.expo.dev/modules/module-api). ([#17668](https://github.com/expo/expo/pull/17668) by [@bbarthec](https://github.com/bbarthec))
 - Migrated Expo modules definitions to the new naming convention. ([#17193](https://github.com/expo/expo/pull/17193) by [@tsapeta](https://github.com/tsapeta))
 

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
@@ -63,12 +63,12 @@ class ImagePickerModule : Module() {
       val uri = mediaFile.toContentUri(context)
       val contractOptions = options.toCameraContractOptions(uri)
 
-      launchContract({ cameraLauncher.launch(contractOptions, options) }, options)
+      launchContract({ cameraLauncher.launch(contractOptions) }, options)
     }
 
     AsyncFunction("launchImageLibraryAsync") Coroutine { options: ImagePickerOptions ->
       val contractOptions = options.toImageLibraryContractOptions()
-      launchContract({ imageLibraryLauncher.launch(contractOptions, options) }, options)
+      launchContract({ imageLibraryLauncher.launch(contractOptions) }, options)
     }
 
     AsyncFunction("getPendingResultAsync") Coroutine { _: Promise ->
@@ -86,12 +86,10 @@ class ImagePickerModule : Module() {
         withContext(Dispatchers.Main) {
           cameraLauncher = appContext.registerForActivityResult(
             CameraContract(this@ImagePickerModule),
-            ::handleResultUponActivityDestruction
-          )
+          ) { input, result -> handleResultUponActivityDestruction(result, input.options) }
           imageLibraryLauncher = appContext.registerForActivityResult(
             ImageLibraryContract(this@ImagePickerModule),
-            ::handleResultUponActivityDestruction
-          )
+          ) { input, result -> handleResultUponActivityDestruction(result, input.options) }
         }
       }
     }
@@ -106,8 +104,8 @@ class ImagePickerModule : Module() {
 
   private val mediaHandler = MediaHandler(this)
 
-  private lateinit var cameraLauncher: AppContextActivityResultLauncher<CameraContractOptions, ImagePickerContractResult, ImagePickerOptions>
-  private lateinit var imageLibraryLauncher: AppContextActivityResultLauncher<ImageLibraryContractOptions, ImagePickerContractResult, ImagePickerOptions>
+  private lateinit var cameraLauncher: AppContextActivityResultLauncher<CameraContractOptions, ImagePickerContractResult>
+  private lateinit var imageLibraryLauncher: AppContextActivityResultLauncher<ImageLibraryContractOptions, ImagePickerContractResult>
 
   /**
    * Stores result for an operation that has been interrupted by the activity destruction.

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerOptions.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerOptions.kt
@@ -33,23 +33,17 @@ internal class ImagePickerOptions : Record, Serializable {
   @Field
   var aspect: Pair<Int, Int>? = null
 
-  internal fun toCameraContractOptions(uri: Uri) = CameraContractOptions(
-    uri,
-    mediaTypes.toMimeType(),
-    videoMaxDuration
-  )
+  fun toCameraContractOptions(uri: Uri) = CameraContractOptions(uri, this)
 
-  fun toImageLibraryContractOptions() = ImageLibraryContractOptions(
-    mediaTypes.toMimeType(),
-  )
+  fun toImageLibraryContractOptions() = ImageLibraryContractOptions(this)
 }
 
-enum class MediaTypes(val value: String) {
+internal enum class MediaTypes(val value: String) {
   IMAGES("Images"),
   VIDEOS("Videos"),
   ALL("All");
 
-  internal fun toMimeType(): String {
+  fun toMimeType(): String {
     return when (this) {
       IMAGES -> ImageAllMimeType
       VIDEOS -> VideoAllMimeType
@@ -57,17 +51,7 @@ enum class MediaTypes(val value: String) {
     }
   }
 
-  internal fun toMultipleMimeTypes(): Array<String>? {
-    return when (this) {
-      ALL -> arrayOf(
-        ImageAllMimeType,
-        VideoAllMimeType
-      )
-      else -> null
-    }
-  }
-
-  internal fun toFileExtension(): String {
+  fun toFileExtension(): String {
     return when (this) {
       VIDEOS -> ".mp4"
       else -> ".jpeg"
@@ -77,14 +61,14 @@ enum class MediaTypes(val value: String) {
   /**
    * Return [MediaStore]'s intent capture action associated with given media types
    */
-  internal fun toCameraIntentAction(): String {
+  fun toCameraIntentAction(): String {
     return when (this) {
       VIDEOS -> MediaStore.ACTION_VIDEO_CAPTURE
       else -> MediaStore.ACTION_IMAGE_CAPTURE
     }
   }
 
-  internal companion object {
+  private companion object {
     const val ImageAllMimeType = "image/*"
     const val VideoAllMimeType = "video/*"
     const val AllMimeType = "*/*"

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/CameraContract.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/CameraContract.kt
@@ -6,8 +6,11 @@ import android.content.Intent
 import android.net.Uri
 import android.provider.MediaStore
 import androidx.activity.result.contract.ActivityResultContract
+import expo.modules.imagepicker.ImagePickerOptions
 import expo.modules.imagepicker.toMediaType
+import expo.modules.kotlin.activityresult.AppContextActivityResultContract
 import expo.modules.kotlin.providers.AppContextProvider
+import java.io.Serializable
 
 /**
  * An [ActivityResultContract] to [take a picture][MediaStore.ACTION_IMAGE_CAPTURE] or [take a video][MediaStore.ACTION_VIDEO_CAPTURE]
@@ -17,32 +20,28 @@ import expo.modules.kotlin.providers.AppContextProvider
  */
 internal class CameraContract(
   private val appContextProvider: AppContextProvider,
-) : ActivityResultContract<CameraContractOptions, ImagePickerContractResult>() {
+) : AppContextActivityResultContract<CameraContractOptions, ImagePickerContractResult> {
   override fun createIntent(context: Context, input: CameraContractOptions): Intent =
-    Intent(input.intentAction)
+    Intent(input.options.mediaTypes.toCameraIntentAction())
       .putExtra(MediaStore.EXTRA_OUTPUT, input.uri)
       .apply {
-        if (input.intentAction == MediaStore.ACTION_VIDEO_CAPTURE) {
-          putExtra(MediaStore.EXTRA_DURATION_LIMIT, input.videoMaxDuration)
+        if (input.options.mediaTypes.toCameraIntentAction() == MediaStore.ACTION_VIDEO_CAPTURE) {
+          putExtra(MediaStore.EXTRA_DURATION_LIMIT, input.options.videoMaxDuration)
         }
       }
 
-  override fun parseResult(resultCode: Int, intent: Intent?): ImagePickerContractResult =
+  override fun parseResult(input: CameraContractOptions, resultCode: Int, intent: Intent?): ImagePickerContractResult =
     if (resultCode == Activity.RESULT_CANCELED) {
       ImagePickerContractResult.Cancelled()
     } else {
       val contentResolver = requireNotNull(appContextProvider.appContext.reactContext) { "React Application Context is null. " }.contentResolver
-      val uri = intent?.data ?: throw IllegalStateException("No data available in Intent")
+      val uri = input.uri
       val type = uri.toMediaType(contentResolver)
       ImagePickerContractResult.Success(type to uri)
     }
 }
 
-data class CameraContractOptions(
+internal data class CameraContractOptions(
   val uri: Uri,
-  /**
-   * Either [MediaStore.ACTION_IMAGE_CAPTURE] or [MediaStore.ACTION_VIDEO_CAPTURE]
-   */
-  val intentAction: String,
-  val videoMaxDuration: Int,
-)
+  val options: ImagePickerOptions,
+) : Serializable

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/ImageLibraryContract.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/ImageLibraryContract.kt
@@ -4,9 +4,11 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
-import androidx.activity.result.contract.ActivityResultContract
+import expo.modules.imagepicker.ImagePickerOptions
 import expo.modules.imagepicker.toMediaType
+import expo.modules.kotlin.activityresult.AppContextActivityResultContract
 import expo.modules.kotlin.providers.AppContextProvider
+import java.io.Serializable
 
 /**
  * An [androidx.activity.result.contract.ActivityResultContract] to prompt the user to pick single or multiple image(s) or/and video(s),
@@ -16,13 +18,13 @@ import expo.modules.kotlin.providers.AppContextProvider
  */
 internal class ImageLibraryContract(
   private val appContextProvider: AppContextProvider,
-) : ActivityResultContract<ImageLibraryContractOptions, ImagePickerContractResult>() {
+) : AppContextActivityResultContract<ImageLibraryContractOptions, ImagePickerContractResult> {
   override fun createIntent(context: Context, input: ImageLibraryContractOptions) =
     Intent(Intent.ACTION_GET_CONTENT)
       .addCategory(Intent.CATEGORY_OPENABLE)
-      .setType(input.singleMimeType)
+      .setType(input.options.mediaTypes.toMimeType())
 
-  override fun parseResult(resultCode: Int, intent: Intent?) =
+  override fun parseResult(input: ImageLibraryContractOptions, resultCode: Int, intent: Intent?) =
     if (resultCode == Activity.RESULT_CANCELED) {
       ImagePickerContractResult.Cancelled()
     } else {
@@ -35,5 +37,5 @@ internal class ImageLibraryContract(
 }
 
 internal data class ImageLibraryContractOptions(
-  val singleMimeType: String,
-)
+  val options: ImagePickerOptions
+) : Serializable

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Create `AppContext.registerForActivityResult` mechanism similar to [`ComponentActivity.registerForActivityResult`](https://developer.android.com/training/basics/intents/result)). ([#17572](https://github.com/expo/expo/pull/17572) by [@bbarthec](https://github.com/bbarthec))
+- Create `AppContext.registerForActivityResult` mechanism similar to [`ComponentActivity.registerForActivityResult`](https://developer.android.com/training/basics/intents/result)). ([#17572](https://github.com/expo/expo/pull/17572), ([#17987](https://github.com/expo/expo/pull/17987) by [@bbarthec](https://github.com/bbarthec))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -5,7 +5,6 @@ package expo.modules.kotlin
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
-import androidx.activity.result.contract.ActivityResultContract
 import androidx.annotation.MainThread
 import androidx.appcompat.app.AppCompatActivity
 import com.facebook.react.bridge.ReactApplicationContext
@@ -24,6 +23,7 @@ import expo.modules.interfaces.taskManager.TaskManagerInterface
 import expo.modules.kotlin.activityresult.ActivityResultsManager
 import expo.modules.kotlin.activityresult.AppContextActivityResultFallbackCallback
 import expo.modules.kotlin.activityresult.AppContextActivityResultCaller
+import expo.modules.kotlin.activityresult.AppContextActivityResultContract
 import expo.modules.kotlin.activityresult.AppContextActivityResultLauncher
 import expo.modules.kotlin.defaultmodules.ErrorManagerModule
 import expo.modules.kotlin.events.EventEmitter
@@ -258,10 +258,10 @@ class AppContext(
 // region AppContextActivityResultCaller
 
   @MainThread
-  override suspend fun <I, O, P : Serializable> registerForActivityResult(
-    contract: ActivityResultContract<I, O>,
-    fallbackCallback: AppContextActivityResultFallbackCallback<O, P>
-  ): AppContextActivityResultLauncher<I, O, P> =
+  override suspend fun <I : Serializable, O> registerForActivityResult(
+    contract: AppContextActivityResultContract<I, O>,
+    fallbackCallback: AppContextActivityResultFallbackCallback<I, O>
+  ): AppContextActivityResultLauncher<I, O> =
     activityResultsManager.registerForActivityResult(contract, fallbackCallback)
 
 // endregion

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/activityresult/ActivityResultsManager.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/activityresult/ActivityResultsManager.kt
@@ -4,7 +4,6 @@ package expo.modules.kotlin.activityresult
 
 import android.app.Activity
 import android.content.Intent
-import androidx.activity.result.contract.ActivityResultContract
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Lifecycle
 import expo.modules.kotlin.AppContext
@@ -71,10 +70,10 @@ class ActivityResultsManager(
 
   // region AppContextActivityResultCaller
 
-  override suspend fun <I, O, P : Serializable> registerForActivityResult(
-    contract: ActivityResultContract<I, O>,
-    fallbackCallback: AppContextActivityResultFallbackCallback<O, P>
-  ): AppContextActivityResultLauncher<I, O, P> =
+  override suspend fun <I : Serializable, O> registerForActivityResult(
+    contract: AppContextActivityResultContract<I, O>,
+    fallbackCallback: AppContextActivityResultFallbackCallback<I, O>
+  ): AppContextActivityResultLauncher<I, O> =
     withActivityAvailable { activity ->
       registry.register(
         "AppContext_rq#${nextLocalRequestCode.getAndIncrement()}",

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/activityresult/AppContextActivityResultCaller.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/activityresult/AppContextActivityResultCaller.kt
@@ -1,6 +1,5 @@
 package expo.modules.kotlin.activityresult
 
-import androidx.activity.result.contract.ActivityResultContract
 import androidx.annotation.MainThread
 import java.io.Serializable
 
@@ -9,17 +8,18 @@ import java.io.Serializable
  * of ReactNative and Android's [androidx.lifecycle.Lifecycle] it needed to be adapted.
  * For more information how to use it read [androidx.activity.result.ActivityResultCaller] from `androidx.activity:activity:1.4.0`
  * or even better from `androidx.activity:activity-ktx:1.4.0`.
+ *
+ * @see [androidx.activity.result.ActivityResultCaller]
  */
 interface AppContextActivityResultCaller {
   /**
    * @see [androidx.activity.result.ActivityResultCaller.registerForActivityResult] from `androidx.activity:activity-ktx:1.4.0`.
-   * @param I - input
+   * @param I - input, it is preserved across Activity calls and is delivered to fallback callback
    * @param O - output
-   * @param P - additional parameters to be passed into the [fallbackCallback]
    */
   @MainThread
-  suspend fun <I, O, P : Serializable> registerForActivityResult(
-    contract: ActivityResultContract<I, O>,
-    fallbackCallback: AppContextActivityResultFallbackCallback<O, P>,
-  ): AppContextActivityResultLauncher<I, O, P>
+  suspend fun <I : Serializable, O> registerForActivityResult(
+    contract: AppContextActivityResultContract<I, O>,
+    fallbackCallback: AppContextActivityResultFallbackCallback<I, O>,
+  ): AppContextActivityResultLauncher<I, O>
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/activityresult/AppContextActivityResultContract.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/activityresult/AppContextActivityResultContract.kt
@@ -13,7 +13,7 @@ import java.io.Serializable
  *
  * @see androidx.activity.result.contract.ActivityResultContract
  */
-interface AppContextActivityResultContract<I: Serializable, O> {
+interface AppContextActivityResultContract<I : Serializable, O> {
   /**
    * Create an intent that can be used for [android.app.Activity.startActivityForResult].
    */

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/activityresult/AppContextActivityResultContract.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/activityresult/AppContextActivityResultContract.kt
@@ -1,0 +1,27 @@
+package expo.modules.kotlin.activityresult
+
+import android.content.Context
+import android.content.Intent
+import java.io.Serializable
+
+/**
+ * A contract specifying that an activity can be called with an input of type [I] and produce an output of type [O].
+ *
+ * Makes calling an activity for result type-safe.
+ *
+ * This interface differs from the original in terms of providing `input` parameter in the [parseResult] method.
+ *
+ * @see androidx.activity.result.contract.ActivityResultContract
+ */
+interface AppContextActivityResultContract<I: Serializable, O> {
+  /**
+   * Create an intent that can be used for [android.app.Activity.startActivityForResult].
+   */
+  fun createIntent(context: Context, input: I): Intent
+
+  /**
+   * Convert result obtained from [android.app.Activity.onActivityResult] to [O].
+   * @param input the very same input object that is used in [createIntent] method. You can use it to add additional information to constructed result.
+   */
+  fun parseResult(input: I, resultCode: Int, intent: Intent?): O
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/activityresult/AppContextActivityResultFallbackCallback.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/activityresult/AppContextActivityResultFallbackCallback.kt
@@ -6,11 +6,12 @@ import java.io.Serializable
  * Interface for fallback callback that has to be registered at the very beginning of module's lifecycle
  * in order to deliver all results in case launching [android.app.Activity] is killed.
  *
- * @param O output type, similar to the main callback
- * @param P additional parameters type. This is registered during and preserved across [android.app.Activity] destruction.
- *
  * @see [androidx.activity.result.ActivityResultCallback]
  */
-fun interface AppContextActivityResultFallbackCallback<O, P : Serializable> {
-  fun onActivityResult(result: O, params: P)
+fun interface AppContextActivityResultFallbackCallback<I : Serializable, O> {
+  /**
+   * @param input parameters used to construct Intent that launched the operation
+   * @param result output constructed by the associated [AppContextActivityResultContract]
+   */
+  fun onActivityResult(input: I, result: O)
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/activityresult/AppContextActivityResultLauncher.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/activityresult/AppContextActivityResultLauncher.kt
@@ -2,6 +2,7 @@ package expo.modules.kotlin.activityresult
 
 import androidx.activity.result.ActivityResultCallback
 import androidx.activity.result.contract.ActivityResultContract
+import java.io.Serializable
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 
@@ -9,22 +10,21 @@ import kotlin.coroutines.suspendCoroutine
  * A launcher for a previously-[AppContextActivityResultCaller.registerForActivityResult] prepared call
  * to start the process of executing an [ActivityResultContract]
  *
- * @param I type of the input required to launch
+ * @param I type of the input required to launch, it also is preserved and delivered in fallback callback
  * @param O result type
- * @param P additional parameters type that would be passed to fallback callback
  *
  * @see [androidx.activity.result.ActivityResultLauncher]
  */
-abstract class AppContextActivityResultLauncher<I, O, P> {
+abstract class AppContextActivityResultLauncher<I : Serializable, O> {
   /**
-   * @param params These params would be persisted and restored upon possible Activity destruction
-   * by the system
+   * @param input This would be persisted and restored upon possible Activity destruction by the system
+   * to keep context of launching the mechanism.
    */
-  abstract fun launch(input: I, params: P, callback: ActivityResultCallback<O>)
+  abstract fun launch(input: I, callback: ActivityResultCallback<O>)
 
-  suspend fun launch(input: I, params: P): O = suspendCoroutine { continuation ->
-    launch(input, params) { output -> continuation.resume(output) }
+  suspend fun launch(input: I): O = suspendCoroutine { continuation ->
+    launch(input) { output -> continuation.resume(output) }
   }
 
-  abstract val contract: ActivityResultContract<I, *>
+  abstract val contract: AppContextActivityResultContract<I, O>
 }


### PR DESCRIPTION
# Why

Fixes broken image picking using camera.
- first aspect: using original `ActivityResultContract` there's no way to access `input` parameter (that is used to construct launching `Intent`; in `createIntent` method) when result coming from `onActivityResult` are processed (in `parseResult` method).
- second aspect: Android for some `startActivityForResult` actions does not propagate back data  that is stored in launching Intent (e.g. start camera requires providing some pre-constructed `uri`, but this `uri` is not exposed back in the result Intent), so it's developer responsibility to persist such data between launching and reading
  - this is problematic, because we do not general mechanism for storing and restoring any state in the modules

Fortunately, there's a preservation mechanism available in our custom `registerForActivityResult` mechanism in a form of 3rd parameter `P`.

# How

- I allowed accessing `input: I` parameter in `parseResult` method, by creating our own `AppContextActivityResultContract` interface basing on the original `ActivityResultContract`.
- I also got rid of additional `parameter: P` parameter that was used to preserve additional data across Activity destruction and recreation and I replaced it with preserving `input: I` argument.
  - The idea is to have a single parameter that stores all the info needed fot the whole `registerForActivityResult` operation (consisting of some `input` and `output` info/hints and other instructions that are used to properly continue/resume pipeline after obtaining the result from 3rd party activity) .

# Test Plan

- Launching camera works
