### PR TITLE
[sweet][Kotlin] Add `Property` component

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/Module.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/Module.kt
@@ -45,5 +45,5 @@ abstract class Module : AppContextProvider {
 
 @Suppress("FunctionName")
 inline fun Module.ModuleDefinition(block: ModuleDefinitionBuilder.() -> Unit): ModuleDefinitionData {
-  return ModuleDefinitionBuilder(this).also(block).build()
+  return ModuleDefinitionBuilder(this).also(block).buildModule()
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionData.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionData.kt
@@ -8,6 +8,7 @@ import expo.modules.kotlin.events.EventsDefinition
 import expo.modules.kotlin.functions.AsyncFunction
 import expo.modules.kotlin.functions.SuspendFunctionComponentBuilder
 import expo.modules.kotlin.functions.SyncFunctionComponent
+import expo.modules.kotlin.objects.ObjectDefinitionData
 import expo.modules.kotlin.views.ViewManagerDefinition
 
 /**
@@ -16,13 +17,9 @@ import expo.modules.kotlin.views.ViewManagerDefinition
  */
 class ModuleDefinitionData(
   val name: String,
-  val constantsProvider: () -> Map<String, Any?>,
-  val syncFunctions: Map<String, SyncFunctionComponent>,
-  val asyncFunctions: Map<String, AsyncFunction>,
-  val suspendFunctionBuilders: List<SuspendFunctionComponentBuilder>,
+  val objectDefinition: ObjectDefinitionData,
   val viewManagerDefinition: ViewManagerDefinition? = null,
   val eventListeners: Map<EventName, EventListener> = emptyMap(),
-  val eventsDefinition: EventsDefinition? = null
 )
 
 /**
@@ -35,14 +32,12 @@ class ProcessedModuleDefinition(
   moduleHolder: ModuleHolder
 ) {
   val name = data.name
-  val constantsProvider = data.constantsProvider
-  val syncFunctions = data.syncFunctions
-  val asyncFunctions = data.asyncFunctions + data.suspendFunctionBuilders.associate { builder ->
-    builder.name to builder.build((moduleHolder))
-  }
+  val constantsProvider = data.objectDefinition.constantsProvider
+  val syncFunctions = data.objectDefinition.syncFunctions
+  val asyncFunctions = data.objectDefinition.asyncFunctions + data.objectDefinition.buildSuspendFunctions(moduleHolder)
   val viewManagerDefinition = data.viewManagerDefinition
   val eventListeners = data.eventListeners
-  val eventsDefinition = data.eventsDefinition
+  val eventsDefinition = data.objectDefinition.eventsDefinition
 
   val functions
     get() = ConcatIterator(syncFunctions.values.iterator(), asyncFunctions.values.iterator())

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionData.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionData.kt
@@ -4,10 +4,6 @@ import expo.modules.kotlin.ConcatIterator
 import expo.modules.kotlin.ModuleHolder
 import expo.modules.kotlin.events.EventListener
 import expo.modules.kotlin.events.EventName
-import expo.modules.kotlin.events.EventsDefinition
-import expo.modules.kotlin.functions.AsyncFunction
-import expo.modules.kotlin.functions.SuspendFunctionComponentBuilder
-import expo.modules.kotlin.functions.SyncFunctionComponent
 import expo.modules.kotlin.objects.ObjectDefinitionData
 import expo.modules.kotlin.views.ViewManagerDefinition
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
@@ -1,0 +1,276 @@
+/**
+ * We used a function from the experimental STD API - typeOf (see kotlinlang.org/api/latest/jvm/stdlib/kotlin.reflect/type-of.html).
+ * We shouldn't have any problem with that function, cause it's widely used in other libraries created by JetBrains like kotlinx-serializer.
+ * This function is super handy if we want to receive a collection type.
+ * For example, it's very hard to obtain the generic parameter type from the list class.
+ * In plain Java, it's almost impossible. There is a trick to getting such information using something called TypeToken.
+ * For instance, the Gson library uses this workaround. But there still will be a problem with nullability.
+ * We didn't find a good solution to distinguish between List<Any?> and List<Any>.
+ * Mainly because from the JVM perspective it's the same type.
+ * That's why we used typeOf. It solves all problems described above.
+ */
+@file:OptIn(ExperimentalStdlibApi::class)
+@file:Suppress("FunctionName")
+
+package expo.modules.kotlin.objects
+
+import expo.modules.kotlin.Promise
+import expo.modules.kotlin.events.EventsDefinition
+import expo.modules.kotlin.functions.AsyncFunction
+import expo.modules.kotlin.functions.AsyncFunctionBuilder
+import expo.modules.kotlin.functions.AsyncFunctionComponent
+import expo.modules.kotlin.functions.AsyncFunctionWithPromiseComponent
+import expo.modules.kotlin.functions.SyncFunctionComponent
+import expo.modules.kotlin.types.toAnyType
+import kotlin.reflect.typeOf
+
+/**
+ * Base class for other definitions representing an object, such as `ModuleDefinition`.
+ */
+open class ObjectDefinitionBuilder {
+  private var constantsProvider = { emptyMap<String, Any?>() }
+  private var eventsDefinition: EventsDefinition? = null
+
+  @PublishedApi
+  internal var syncFunctions = mutableMapOf<String, SyncFunctionComponent>()
+
+  @PublishedApi
+  internal var asyncFunctions = mutableMapOf<String, AsyncFunction>()
+
+  private var functionBuilders = mutableMapOf<String, AsyncFunctionBuilder>()
+
+  @PublishedApi
+  internal var properties = mutableMapOf<String, PropertyComponentBuilder>()
+
+  fun buildObject(): ObjectDefinitionData {
+    return ObjectDefinitionData(
+      constantsProvider,
+      syncFunctions,
+      asyncFunctions,
+      functionBuilders.mapValues { (_, value) -> value.build() },
+      eventsDefinition,
+      properties.mapValues { (_, value) -> value.build() }
+    )
+  }
+
+  /**
+   * Definition function setting the module's constants to export.
+   */
+  fun Constants(constantsProvider: () -> Map<String, Any?>) {
+    this.constantsProvider = constantsProvider
+  }
+
+  /**
+   * Definition of the module's constants to export.
+   */
+  fun Constants(vararg constants: Pair<String, Any?>) {
+    constantsProvider = { constants.toMap() }
+  }
+
+  @JvmName("FunctionWithoutArgs")
+  inline fun Function(
+    name: String,
+    crossinline body: () -> Any?
+  ) {
+    SyncFunctionComponent(name, arrayOf()) { body() }.also {
+      syncFunctions[name] = it
+    }
+  }
+
+  inline fun <reified R> Function(
+    name: String,
+    crossinline body: () -> R
+  ) {
+    SyncFunctionComponent(name, arrayOf()) { body() }.also {
+      syncFunctions[name] = it
+    }
+  }
+
+  inline fun <reified R, reified P0> Function(
+    name: String,
+    crossinline body: (p0: P0) -> R
+  ) {
+    SyncFunctionComponent(name, arrayOf(typeOf<P0>().toAnyType())) { body(it[0] as P0) }.also {
+      syncFunctions[name] = it
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1> Function(
+    name: String,
+    crossinline body: (p0: P0, p1: P1) -> R
+  ) {
+    SyncFunctionComponent(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType())) { body(it[0] as P0, it[1] as P1) }.also {
+      syncFunctions[name] = it
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1, reified P2> Function(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2) -> R
+  ) {
+    SyncFunctionComponent(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2) }.also {
+      syncFunctions[name] = it
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5> Function(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) -> R
+  ) {
+    SyncFunctionComponent(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType(), typeOf<P5>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5) }.also {
+      syncFunctions[name] = it
+    }
+  }
+
+  @JvmName("AsyncFunctionWithoutArgs")
+  inline fun AsyncFunction(
+    name: String,
+    crossinline body: () -> Any?
+  ) {
+    asyncFunctions[name] = AsyncFunctionComponent(name, arrayOf()) { body() }
+  }
+
+  inline fun <reified R> AsyncFunction(
+    name: String,
+    crossinline body: () -> R
+  ) {
+    asyncFunctions[name] = AsyncFunctionComponent(name, arrayOf()) { body() }
+  }
+
+  inline fun <reified R, reified P0> AsyncFunction(
+    name: String,
+    crossinline body: (p0: P0) -> R
+  ) {
+    asyncFunctions[name] = if (P0::class == Promise::class) {
+      AsyncFunctionWithPromiseComponent(name, arrayOf()) { _, promise -> body(promise as P0) }
+    } else {
+      AsyncFunctionComponent(name, arrayOf(typeOf<P0>().toAnyType())) { body(it[0] as P0) }
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1> AsyncFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1) -> R
+  ) {
+    asyncFunctions[name] = if (P1::class == Promise::class) {
+      AsyncFunctionWithPromiseComponent(name, arrayOf(typeOf<P0>().toAnyType())) { args, promise -> body(args[0] as P0, promise as P1) }
+    } else {
+      AsyncFunctionComponent(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType())) { body(it[0] as P0, it[1] as P1) }
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1, reified P2> AsyncFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2) -> R
+  ) {
+    asyncFunctions[name] = if (P2::class == Promise::class) {
+      AsyncFunctionWithPromiseComponent(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType())) { args, promise -> body(args[0] as P0, args[1] as P1, promise as P2) }
+    } else {
+      AsyncFunctionComponent(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2) }
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3> AsyncFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3) -> R
+  ) {
+    asyncFunctions[name] = if (P3::class == Promise::class) {
+      AsyncFunctionWithPromiseComponent(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, promise as P3) }
+    } else {
+      AsyncFunctionComponent(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3) }
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4> AsyncFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4) -> R
+  ) {
+    asyncFunctions[name] = if (P4::class == Promise::class) {
+      AsyncFunctionWithPromiseComponent(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, promise as P4) }
+    } else {
+      AsyncFunctionComponent(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4) }
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5> AsyncFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) -> R
+  ) {
+    asyncFunctions[name] = if (P5::class == Promise::class) {
+      AsyncFunctionWithPromiseComponent(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, args[4] as P4, promise as P5) }
+    } else {
+      AsyncFunctionComponent(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType(), typeOf<P5>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5) }
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6> AsyncFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6) -> R
+  ) {
+    asyncFunctions[name] = if (P6::class == Promise::class) {
+      AsyncFunctionWithPromiseComponent(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType(), typeOf<P5>().toAnyType())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, args[4] as P4, args[5] as P5, promise as P6) }
+    } else {
+      AsyncFunctionComponent(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType(), typeOf<P5>().toAnyType(), typeOf<P6>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5, it[6] as P6) }
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6, reified P7> AsyncFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7) -> R
+  ) {
+    asyncFunctions[name] = if (P7::class == Promise::class) {
+      AsyncFunctionWithPromiseComponent(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType(), typeOf<P5>().toAnyType(), typeOf<P6>().toAnyType())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, args[4] as P4, args[5] as P5, args[6] as P6, promise as P7) }
+    } else {
+      AsyncFunctionComponent(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType(), typeOf<P5>().toAnyType(), typeOf<P6>().toAnyType(), typeOf<P7>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5, it[6] as P6, it[7] as P7) }
+    }
+  }
+
+  fun AsyncFunction(
+    name: String
+  ) = AsyncFunctionBuilder(name).also { functionBuilders[name] = it }
+
+  /**
+   * Defines event names that this module can send to JavaScript.
+   */
+  fun Events(vararg events: String) {
+    eventsDefinition = EventsDefinition(events)
+  }
+
+  /**
+   * Creates module's lifecycle listener that is called right after the first event listener is added.
+   */
+  inline fun OnStartObserving(crossinline body: () -> Unit) {
+    AsyncFunction("startObserving", body)
+  }
+
+  /**
+   * Creates module's lifecycle listener that is called right after all event listeners are removed.
+   */
+  inline fun OnStopObserving(crossinline body: () -> Unit) {
+    AsyncFunction("stopObserving", body)
+  }
+
+  /**
+   * Creates the property with given name. The component is basically no-op if you don't call `.get()` or `.set()` on it.
+   */
+  fun Property(name: String): PropertyComponentBuilder {
+    return PropertyComponentBuilder(name).also {
+      properties[name] = it
+    }
+  }
+
+  /**
+   * Creates the read-only property whose getter doesn't take the caller as an argument.
+   */
+  inline fun <T> Property(name: String, crossinline body: () -> T): PropertyComponentBuilder {
+    return PropertyComponentBuilder(
+      name,
+      getter = SyncFunctionComponent(
+        "get",
+        arrayOf()
+      ) { body() }
+    ).also {
+      properties[name] = it
+    }
+  }
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionData.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionData.kt
@@ -1,0 +1,21 @@
+package expo.modules.kotlin.objects
+
+import expo.modules.kotlin.ModuleHolder
+import expo.modules.kotlin.events.EventsDefinition
+import expo.modules.kotlin.functions.AsyncFunction
+import expo.modules.kotlin.functions.SuspendFunctionComponent
+import expo.modules.kotlin.functions.SuspendFunctionComponentBuilder
+import expo.modules.kotlin.functions.SyncFunctionComponent
+
+class ObjectDefinitionData(
+  val constantsProvider: () -> Map<String, Any?>,
+  val syncFunctions: Map<String, SyncFunctionComponent>,
+  val asyncFunctions: Map<String, AsyncFunction>,
+  val suspendFunctionBuilders: Map<String, SuspendFunctionComponentBuilder>,
+  val eventsDefinition: EventsDefinition?,
+  val properties: Map<String, PropertyComponent>
+) {
+  fun buildSuspendFunctions(moduleHolder: ModuleHolder): Map<String, SuspendFunctionComponent> {
+    return suspendFunctionBuilders.mapValues { (_, value) -> value.build(moduleHolder) }
+  }
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/PropertyComponent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/PropertyComponent.kt
@@ -1,0 +1,20 @@
+package expo.modules.kotlin.objects
+
+import expo.modules.kotlin.functions.SyncFunctionComponent
+
+data class PropertyComponent(
+  /**
+   * Name of the property.
+   */
+  val name: String,
+
+  /**
+   * Synchronous function that is called when the property is being accessed.
+   */
+  val getter: SyncFunctionComponent? = null,
+
+  /**
+   * Synchronous function that is called when the property is being set.
+   */
+  val setter: SyncFunctionComponent? = null
+)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/PropertyComponentBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/PropertyComponentBuilder.kt
@@ -1,0 +1,31 @@
+@file:OptIn(ExperimentalStdlibApi::class)
+
+package expo.modules.kotlin.objects
+
+import expo.modules.kotlin.functions.SyncFunctionComponent
+import expo.modules.kotlin.types.toAnyType
+import kotlin.reflect.typeOf
+
+class PropertyComponentBuilder(
+  val name: String,
+  var getter: SyncFunctionComponent? = null,
+  var setter: SyncFunctionComponent? = null
+) {
+  /**
+   * Modifier that sets property getter that has no arguments (the caller is not used).
+   */
+  inline fun <T> get(crossinline body: () -> T) = apply {
+    getter = SyncFunctionComponent("get", arrayOf()) { body() }
+  }
+
+  /**
+   * Modifier that sets property setter that receives only the new value as an argument.
+   */
+  inline fun <reified T> set(crossinline body: (newValue: T) -> Unit) = apply {
+    getter = SyncFunctionComponent("set", arrayOf(typeOf<T>().toAnyType())) { body(it[0] as T) }
+  }
+
+  fun build(): PropertyComponent {
+    return PropertyComponent(name, getter, setter)
+  }
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewGroupDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewGroupDefinitionBuilder.kt
@@ -1,4 +1,3 @@
-@file:OptIn(ExperimentalStdlibApi::class)
 @file:Suppress("FunctionName")
 
 package expo.modules.kotlin.views

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/modules/ModuleDefinitionBuilderTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/modules/ModuleDefinitionBuilderTest.kt
@@ -9,7 +9,7 @@ import org.junit.Test
 
 class ModuleDefinitionBuilderTest {
   private inline fun unboundModuleDefinition(block: ModuleDefinitionBuilder.() -> Unit): ModuleDefinitionData {
-    return ModuleDefinitionBuilder().also(block).build()
+    return ModuleDefinitionBuilder().also(block).buildModule()
   }
 
   private class TestModule : Module() {
@@ -50,9 +50,9 @@ class ModuleDefinitionBuilderTest {
     }
 
     Truth.assertThat(moduleDefinition.name).isEqualTo(moduleName)
-    Truth.assertThat(moduleDefinition.constantsProvider()).isSameInstanceAs(moduleConstants)
-    Truth.assertThat(moduleDefinition.asyncFunctions).containsKey("m1")
-    Truth.assertThat(moduleDefinition.asyncFunctions).containsKey("m2")
+    Truth.assertThat(moduleDefinition.objectDefinition.constantsProvider()).isSameInstanceAs(moduleConstants)
+    Truth.assertThat(moduleDefinition.objectDefinition.asyncFunctions).containsKey("m1")
+    Truth.assertThat(moduleDefinition.objectDefinition.asyncFunctions).containsKey("m2")
   }
 
   @Test
@@ -98,7 +98,7 @@ class ModuleDefinitionBuilderTest {
       OnStartObserving { }
     }
 
-    Truth.assertThat(moduleDefinition.asyncFunctions).containsKey("startObserving")
+    Truth.assertThat(moduleDefinition.objectDefinition.asyncFunctions).containsKey("startObserving")
   }
 
   @Test
@@ -108,7 +108,7 @@ class ModuleDefinitionBuilderTest {
       OnStopObserving { }
     }
 
-    Truth.assertThat(moduleDefinition.asyncFunctions).containsKey("stopObserving")
+    Truth.assertThat(moduleDefinition.objectDefinition.asyncFunctions).containsKey("stopObserving")
   }
 
   @Test


### PR DESCRIPTION
# Why

Adds `Property` component - this PR **only** adds a DSL syntax for `Property` component. 

# How

- Extracts from the `ModuleDefinitionBuilder` new builder - `ObjectDefinitionBuilder`. This object builder will be used later to define js classes.
- Adds `Property` component to the `ObjectDefinitionBuilder`

# Syntax

```kotlin
// read-only property
Property("prop") { "expo is awesome" }

// mutable property 
Property("prop") 
  .get { "expo is awesome" }
  .set { newValue: String -> }
```