### PR TITLE
[sweet][Kotlin] Use `unordered_map` instead of `map`

### DIFF
--- a/packages/expo-modules-core/android/src/main/cpp/CachedReferencesRegistry.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/CachedReferencesRegistry.cpp
@@ -33,7 +33,7 @@ void CachedReferencesRegistry::loadJClass(
   // This is appropriate for classes that are never unloaded which is any class in an Android app.
   auto clazz = (jclass) env->NewGlobalRef(env->FindClass(name.c_str()));
 
-  std::unordered_map<std::pair<std::string, std::string>, jmethodID> methods;
+  MethodHashMap methods;
   methods.reserve(methodsNames.size());
 
   for (auto &method: methodsNames) {
@@ -60,6 +60,6 @@ jmethodID CachedReferencesRegistry::CachedJClass::getMethod(const std::string &n
 
 CachedReferencesRegistry::CachedJClass::CachedJClass(
   jclass clazz,
-  std::unordered_map<std::pair<std::string, std::string>, jmethodID> methods
+  MethodHashMap methods
 ) : clazz(clazz), methods(std::move(methods)) {}
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/CachedReferencesRegistry.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/CachedReferencesRegistry.cpp
@@ -32,7 +32,10 @@ void CachedReferencesRegistry::loadJClass(
   // Note this clazz variable points to a leaked global reference.
   // This is appropriate for classes that are never unloaded which is any class in an Android app.
   auto clazz = (jclass) env->NewGlobalRef(env->FindClass(name.c_str()));
-  std::map<std::pair<std::string, std::string>, jmethodID> methods;
+
+  std::unordered_map<std::pair<std::string, std::string>, jmethodID> methods;
+  methods.reserve(methodsNames.size());
+
   for (auto &method: methodsNames) {
     methods.insert(
       {method, env->GetMethodID(clazz, method.first.c_str(), method.second.c_str())}
@@ -55,7 +58,8 @@ jmethodID CachedReferencesRegistry::CachedJClass::getMethod(const std::string &n
   return methods.at({name, signature});
 }
 
-CachedReferencesRegistry::CachedJClass::CachedJClass(jclass clazz,
-                                                     std::map<std::pair<std::string, std::string>, jmethodID> methods
+CachedReferencesRegistry::CachedJClass::CachedJClass(
+  jclass clazz,
+  std::unordered_map<std::pair<std::string, std::string>, jmethodID> methods
 ) : clazz(clazz), methods(std::move(methods)) {}
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/CachedReferencesRegistry.h
+++ b/packages/expo-modules-core/android/src/main/cpp/CachedReferencesRegistry.h
@@ -4,6 +4,7 @@
 
 #include <jsi/jsi.h>
 #include <fbjni/fbjni.h>
+#include "boost/functional/hash.hpp"
 
 #include <memory>
 #include <unordered_map>
@@ -12,6 +13,12 @@ namespace jni = facebook::jni;
 namespace jsi = facebook::jsi;
 
 namespace expo {
+using MethodHashMap = std::unordered_map<
+  std::pair<std::string, std::string>,
+  jmethodID,
+  boost::hash<std::pair<std::string, std::string>>
+>;
+
 /**
  * Singleton registry used to store references to often used Java classes.
  *
@@ -24,7 +31,7 @@ public:
    */
   class CachedJClass {
   public:
-    CachedJClass(jclass clazz, std::unordered_map<std::pair<std::string, std::string>, jmethodID> methods);
+    CachedJClass(jclass clazz, MethodHashMap methods);
 
     /**
      * A bare reference to the class object.
@@ -37,7 +44,7 @@ public:
     jmethodID getMethod(const std::string &name, const std::string &signature);
 
   private:
-    std::unordered_map<std::pair<std::string, std::string>, jmethodID> methods;
+    MethodHashMap methods;
   };
 
   CachedReferencesRegistry(CachedReferencesRegistry const &) = delete;

--- a/packages/expo-modules-core/android/src/main/cpp/CachedReferencesRegistry.h
+++ b/packages/expo-modules-core/android/src/main/cpp/CachedReferencesRegistry.h
@@ -6,7 +6,7 @@
 #include <fbjni/fbjni.h>
 
 #include <memory>
-#include <map>
+#include <unordered_map>
 
 namespace jni = facebook::jni;
 namespace jsi = facebook::jsi;
@@ -24,7 +24,7 @@ public:
    */
   class CachedJClass {
   public:
-    CachedJClass(jclass clazz, std::map<std::pair<std::string, std::string>, jmethodID> methods);
+    CachedJClass(jclass clazz, std::unordered_map<std::pair<std::string, std::string>, jmethodID> methods);
 
     /**
      * A bare reference to the class object.
@@ -37,7 +37,7 @@ public:
     jmethodID getMethod(const std::string &name, const std::string &signature);
 
   private:
-    std::map<std::pair<std::string, std::string>, jmethodID> methods;
+    std::unordered_map<std::pair<std::string, std::string>, jmethodID> methods;
   };
 
   CachedReferencesRegistry(CachedReferencesRegistry const &) = delete;
@@ -62,7 +62,7 @@ public:
 private:
   CachedReferencesRegistry() = default;
 
-  std::map<std::string, CachedJClass> jClassRegistry;
+  std::unordered_map<std::string, CachedJClass> jClassRegistry;
 
   void loadJClass(
     JNIEnv *env,

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.h
@@ -7,7 +7,7 @@
 #include <react/jni/ReadableNativeArray.h>
 #include <jni/JCallback.h>
 
-#include <map>
+#include <unordered_map>
 
 #include "MethodMetadata.h"
 #include "JNIFunctionBody.h"
@@ -111,12 +111,12 @@ private:
   /**
    * Metadata map that stores information about all available methods on this module.
    */
-  std::map<std::string, MethodMetadata> methodsMetadata;
+  std::unordered_map<std::string, MethodMetadata> methodsMetadata;
 
   /**
    * A constants map.
    */
-  std::map<std::string, folly::dynamic> constants;
+  std::unordered_map<std::string, folly::dynamic> constants;
 
   explicit JavaScriptModuleObject(jni::alias_ref<jhybridobject> jThis)
     : javaPart_(jni::make_global(jThis)) {}


### PR DESCRIPTION
# Why

Starts using `unordered_map` instead of `map` to cached data. 
It isn't a huge change, but in my opinion, the `unordered_map` (hash map) fits better when we just want to cache data 🤷 

# Test Plan

- unit tests ✅