### PR TITLE
[sweet][Kotlin] Add `Any` type converter

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/AnyTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/AnyTypeConverter.kt
@@ -1,0 +1,36 @@
+package expo.modules.kotlin.types
+
+import com.facebook.react.bridge.Dynamic
+import com.facebook.react.bridge.ReadableType
+import expo.modules.kotlin.jni.CppType
+
+/**
+ * Type converter that handles conversion from [Any] or [Dynamic] to [Any].
+ * In the first case, it will just pass provided value.
+ * In case when it receives [Dynamic], it will unpack the provided value.
+ * In that way, we produce the same output for JSI and bridge implementation.
+ */
+class AnyTypeConverter(isOptional: Boolean) : DynamicAwareTypeConverters<Any>(isOptional) {
+  override fun convertFromDynamic(value: Dynamic): Any {
+    return when (value.type) {
+      ReadableType.Boolean -> value.asBoolean()
+      ReadableType.Number -> value.asDouble()
+      ReadableType.String -> value.asString()
+      ReadableType.Map -> value.asMap()
+      ReadableType.Array -> value.asArray()
+      else -> error("Unknown dynamic type: ${value.type}")
+    }
+  }
+
+  override fun convertFromAny(value: Any): Any {
+    return value
+  }
+
+  override fun getCppRequiredTypes(): List<CppType> = listOf(
+    CppType.READABLE_MAP,
+    CppType.READABLE_ARRAY,
+    CppType.STRING,
+    CppType.BOOLEAN,
+    CppType.DOUBLE
+  )
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
@@ -30,6 +30,11 @@ inline fun <reified T> convert(value: Dynamic): T {
   return converter.convert(value) as T
 }
 
+inline fun <reified T> convert(value: Any?): T {
+  val converter = TypeConverterProviderImpl.obtainTypeConverter(typeOf<T>())
+  return converter.convert(value) as T
+}
+
 fun convert(value: Dynamic, type: KType): Any? {
   val converter = TypeConverterProviderImpl.obtainTypeConverter(type)
   return converter.convert(value)
@@ -115,6 +120,8 @@ object TypeConverterProviderImpl : TypeConverterProvider {
 
       JavaScriptValue::class.createType(nullable = isOptional) to JavaScriptValueTypeConvert(isOptional),
       JavaScriptObject::class.createType(nullable = isOptional) to JavaScriptObjectTypeConverter(isOptional),
+
+      Any::class.createType(nullable = isOptional) to AnyTypeConverter(isOptional),
     )
   }
 }

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/AnyTypeConverterTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/AnyTypeConverterTest.kt
@@ -1,0 +1,61 @@
+package expo.modules.kotlin.types
+
+import com.facebook.react.bridge.DynamicFromObject
+import com.facebook.react.bridge.JavaOnlyArray
+import com.google.common.truth.Truth
+import expo.modules.kotlin.exception.NullArgumentException
+import org.junit.Test
+
+internal class AnyTypeConverterTest {
+  @Test
+  fun `should unwrap dynamic type`() {
+    val dynamic = DynamicFromObject(20.0)
+
+    val converted = convert<Any>(dynamic)
+
+    Truth.assertThat(converted).isInstanceOf(java.lang.Double::class.java)
+    Truth.assertThat(converted as Double).isEqualTo(20.0)
+  }
+
+  @Test
+  fun `should support nullable values`() {
+    val convertedDynamic = convert<Any?>(DynamicFromObject(null))
+    val convertedValue = convert<Any?>(null)
+
+    Truth.assertThat(convertedDynamic).isEqualTo(null)
+    Truth.assertThat(convertedValue).isEqualTo(null)
+  }
+
+  @Test(expected = NullArgumentException::class)
+  fun `should throw when null was provided to non-nullable type (Dynamic)`() {
+    convert<Any>(DynamicFromObject(null))
+  }
+
+  @Test(expected = NullArgumentException::class)
+  fun `should throw when null was provided to non-nullable type (Any)`() {
+    convert<Any>(null)
+  }
+
+  @Test
+  fun `should work with collections`() {
+    val convertedValue = convert<List<Any>>(listOf(1.0, "string"))
+    val convertedDynamic = convert<List<Any>>(
+      JavaOnlyArray().apply {
+        pushDouble(1.0)
+        pushString("string")
+      }
+    )
+
+    Truth.assertThat(convertedValue[0]).isInstanceOf(java.lang.Double::class.java)
+    Truth.assertThat(convertedDynamic[0]).isInstanceOf(java.lang.Double::class.java)
+
+    Truth.assertThat(convertedValue[1]).isInstanceOf(String::class.java)
+    Truth.assertThat(convertedDynamic[1]).isInstanceOf(String::class.java)
+
+    Truth.assertThat(convertedValue[0] as Double).isEqualTo(1.0)
+    Truth.assertThat(convertedValue[0] as Double).isEqualTo(1.0)
+
+    Truth.assertThat(convertedValue[1] as String).isEqualTo("string")
+    Truth.assertThat(convertedValue[1] as String).isEqualTo("string")
+  }
+}


### PR DESCRIPTION
# Why

Adds a converter from `Any` to `Any`. It may look dumb, but it allows receiving a collection of mixed types.  
In case of receiving a `Dynamic` value, we will unpack it. Why? The answer is pretty simple, we want to have the same output in both JSI and bridge implementation. For instance, when you call a function with a number. This argument in bridge implementation will be wrapped using `Dynamic`, but in JSI implementation the value will be just passed a `java.lang.Double`. That's why we have to unpack the `Dynamic` value.

> Note:
In JSI implementation, `Any` type won't receive a reference type (like `JavaScriptObject`). When someone tries to pass an object to a function that expects the `Any` type, it will be converted to the `ReadableMap`.

# Test Plan

- unit tests ✅