### PR TITLE
feat(cli): add multi-platform bundle logging during export

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Automatically enable `DEBUG` when `EXPO_DEBUG` is enabled. ([#17856](https://github.com/expo/expo/pull/17856) by [@EvanBacon](https://github.com/EvanBacon))
 - add migration warning for old commands. ([#17882](https://github.com/expo/expo/pull/17882) by [@EvanBacon](https://github.com/EvanBacon))
 - Add web support for Metro bundler. ([#17927](https://github.com/expo/expo/pull/17927) by [@EvanBacon](https://github.com/EvanBacon))
+- Add multi-platform bundle logging during `expo export`.
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -17,7 +17,7 @@
 - Automatically enable `DEBUG` when `EXPO_DEBUG` is enabled. ([#17856](https://github.com/expo/expo/pull/17856) by [@EvanBacon](https://github.com/EvanBacon))
 - add migration warning for old commands. ([#17882](https://github.com/expo/expo/pull/17882) by [@EvanBacon](https://github.com/EvanBacon))
 - Add web support for Metro bundler. ([#17927](https://github.com/expo/expo/pull/17927) by [@EvanBacon](https://github.com/EvanBacon))
-- Add multi-platform bundle logging during `expo export`.
+- Add multi-platform bundle logging during `expo export`. ([#17992](https://github.com/expo/expo/pull/17992) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/src/export/exportAssets.ts
+++ b/packages/@expo/cli/src/export/exportAssets.ts
@@ -93,8 +93,6 @@ export async function exportAssetsAsync(
   if (assets[0]?.fileHashes) {
     Log.log('Saving assets');
     await saveAssetsAsync(projectRoot, { assets, outputDir });
-  } else {
-    Log.log('No assets to upload, skipped.');
   }
 
   // Add google services file if it exists

--- a/packages/@expo/cli/src/export/fork-bundleAsync.ts
+++ b/packages/@expo/cli/src/export/fork-bundleAsync.ts
@@ -1,5 +1,4 @@
-import Log from '@expo/bunyan';
-import { ExpoConfig, getConfig, getConfigFilePaths } from '@expo/config';
+import { ExpoConfig, getConfig, getConfigFilePaths, Platform } from '@expo/config';
 import {
   buildHermesBundleAsync,
   isEnableHermesManaged,
@@ -16,11 +15,12 @@ import Metro from 'metro';
 import { Terminal } from 'metro-core';
 
 import { MetroTerminalReporter } from '../start/server/metro/MetroTerminalReporter';
+import { BundleDetails } from '../start/server/metro/TerminalReporter.types';
 import { withMetroMultiPlatform } from '../start/server/metro/withMetroMultiPlatform';
 import { getPlatformBundlers } from '../start/server/platformBundlers';
 
 export type MetroDevServerOptions = LoadOptions & {
-  logger: Log;
+  logger: import('@expo/bunyan');
   quiet?: boolean;
 };
 export type BundleOptions = {
@@ -66,16 +66,33 @@ let nextBuildID = 0;
 
 // Fork of @expo/dev-server bundleAsync to add Metro logging back.
 
+async function assertEngineMismatchAsync(projectRoot: string, exp: ExpoConfig, platform: Platform) {
+  const isHermesManaged = isEnableHermesManaged(exp, platform);
+
+  const paths = getConfigFilePaths(projectRoot);
+  const configFilePath = paths.dynamicConfigPath ?? paths.staticConfigPath ?? 'app.json';
+  await maybeThrowFromInconsistentEngineAsync(
+    projectRoot,
+    configFilePath,
+    platform,
+    isHermesManaged
+  );
+}
+
 export async function bundleAsync(
   projectRoot: string,
   expoConfig: ExpoConfig,
   options: MetroDevServerOptions,
   bundles: BundleOptions[]
 ): Promise<BundleOutput[]> {
+  // Assert early so the user doesn't have to wait until bundling is complete to find out that
+  // Hermes won't be available.
+  await Promise.all(
+    bundles.map(({ platform }) => assertEngineMismatchAsync(projectRoot, expoConfig, platform))
+  );
+
   const metro = importMetroFromProject(projectRoot);
   const Server = importMetroServerFromProject(projectRoot);
-
-  let reportEvent: ((event: any) => void) | undefined;
 
   const terminal = new Terminal(process.stdout);
   const terminalReporter = new MetroTerminalReporter(projectRoot, terminal);
@@ -83,9 +100,6 @@ export async function bundleAsync(
   const reporter = {
     update(event: any) {
       terminalReporter.update(event);
-      if (reportEvent) {
-        reportEvent(event);
-      }
     },
   };
 
@@ -94,7 +108,6 @@ export async function bundleAsync(
   const { exp } = getConfig(projectRoot, { skipSDKVersionRequirement: true });
   let config = await ExpoMetroConfig.loadAsync(projectRoot, { reporter, ...options });
   config = withMetroMultiPlatform(projectRoot, config, getPlatformBundlers(exp));
-  const buildID = `bundle_${nextBuildID++}`;
 
   // @ts-expect-error
   const metroServer = await metro.runMetro(config, {
@@ -102,6 +115,7 @@ export async function bundleAsync(
   });
 
   const buildAsync = async (bundle: BundleOptions): Promise<BundleOutput> => {
+    const buildID = `bundle_${nextBuildID++}_${bundle.platform}`;
     const bundleOptions: Metro.BundleOptions = {
       ...Server.DEFAULT_BUNDLE_OPTIONS,
       bundleType: 'bundle',
@@ -114,7 +128,7 @@ export async function bundleAsync(
       createModuleIdFactory: config.serializer.createModuleIdFactory,
       onProgress: (transformedFileCount: number, totalFileCount: number) => {
         if (!options.quiet) {
-          reporter.update({
+          terminalReporter.update({
             buildID,
             type: 'bundle_transform_progressed',
             transformedFileCount,
@@ -123,26 +137,33 @@ export async function bundleAsync(
         }
       },
     };
-    reporter.update({
+    const bundleDetails = {
+      ...bundleOptions,
+      buildID,
+    };
+    terminalReporter.update({
       buildID,
       type: 'bundle_build_started',
-      bundleDetails: {
-        bundleType: bundleOptions.bundleType,
-        platform: bundle.platform,
-        entryFile: bundle.entryPoint,
-        dev: bundle.dev ?? false,
-        minify: bundle.minify ?? false,
-      },
+      bundleDetails,
     });
-    const { code, map } = await metroServer.build(bundleOptions);
-    const assets = (await metroServer.getAssets(
-      bundleOptions
-    )) as readonly BundleAssetWithFileHashes[];
-    reporter.update({
-      buildID,
-      type: 'bundle_build_done',
-    });
-    return { code, map, assets };
+    try {
+      const { code, map } = await metroServer.build(bundleOptions);
+      const assets = (await metroServer.getAssets(
+        bundleOptions
+      )) as readonly BundleAssetWithFileHashes[];
+      terminalReporter.update({
+        buildID,
+        type: 'bundle_build_done',
+      });
+      return { code, map, assets };
+    } catch (error) {
+      terminalReporter.update({
+        buildID,
+        type: 'bundle_build_failed',
+      });
+
+      throw error;
+    }
   };
 
   const maybeAddHermesBundleAsync = async (
@@ -151,24 +172,13 @@ export async function bundleAsync(
   ): Promise<BundleOutput> => {
     const { platform } = bundle;
     const isHermesManaged = isEnableHermesManaged(expoConfig, platform);
-
-    const paths = getConfigFilePaths(projectRoot);
-    const configFilePath = paths.dynamicConfigPath ?? paths.staticConfigPath ?? 'app.json';
-    await maybeThrowFromInconsistentEngineAsync(
-      projectRoot,
-      configFilePath,
-      platform,
-      isHermesManaged
-    );
-
     if (isHermesManaged) {
       const platformTag = chalk.bold(
         { ios: 'iOS', android: 'Android', web: 'Web' }[platform] || platform
       );
-      options.logger.info(
-        { tag: 'expo' },
-        `💿 ${platformTag} Building Hermes bytecode for the bundle`
-      );
+
+      terminalReporter.terminal.log(`${platformTag} Building Hermes bytecode for the bundle`);
+
       const hermesBundleOutput = await buildHermesBundleAsync(
         projectRoot,
         bundleOutput.code,
@@ -190,6 +200,10 @@ export async function bundleAsync(
       bundleOutputs.push(await maybeAddHermesBundleAsync(bundles[i], intermediateOutputs[i]));
     }
     return bundleOutputs;
+  } catch (error) {
+    // New line so errors don't show up inline with the progress bar
+    console.log('');
+    throw error;
   } finally {
     metroServer.end();
   }

--- a/packages/@expo/cli/src/export/fork-bundleAsync.ts
+++ b/packages/@expo/cli/src/export/fork-bundleAsync.ts
@@ -15,7 +15,6 @@ import Metro from 'metro';
 import { Terminal } from 'metro-core';
 
 import { MetroTerminalReporter } from '../start/server/metro/MetroTerminalReporter';
-import { BundleDetails } from '../start/server/metro/TerminalReporter.types';
 import { withMetroMultiPlatform } from '../start/server/metro/withMetroMultiPlatform';
 import { getPlatformBundlers } from '../start/server/platformBundlers';
 

--- a/packages/@expo/cli/src/start/server/metro/TerminalReporter.ts
+++ b/packages/@expo/cli/src/start/server/metro/TerminalReporter.ts
@@ -107,6 +107,12 @@ export class TerminalReporter extends XTerminalReporter implements TerminalRepor
       case 'bundle_build_done':
       case 'bundle_build_failed': {
         const startTime = this._bundleTimers.get(event.buildID);
+        // Observed a bug in Metro where the `bundle_build_done` is invoked twice during a static bundle
+        // i.e. `expo export`.
+        if (startTime == null) {
+          break;
+        }
+
         this.bundleBuildEnded(event, startTime ? Date.now() - startTime : 0);
         this._bundleTimers.delete(event.buildID);
         break;


### PR DESCRIPTION
# Why

- Resolve ENG-5329
- Add support for showing all platform bundles that are being built.
- Add support for showing the 'completed' phase when bundling is finished.
- Assert the hermes engine mismatch error before bundling to save time.
- Prevent showing errors inline with the bundling progress indicator
- Drop "uploading" log for assets since we don't upload them.

### Bundling

<img width="440" alt="Screen Shot 2022-06-27 at 6 33 43 PM" src="https://user-images.githubusercontent.com/9664363/175990752-1dfc0290-7eb9-4a5a-a951-3d7a066d152e.png">

### Completed 

<img width="369" alt="Screen Shot 2022-06-27 at 6 33 37 PM" src="https://user-images.githubusercontent.com/9664363/175990767-4c6010b6-1c9b-4dec-b83e-728de1a8da9a.png">

