### PR TITLE
[docs] Update eas-build infrastructure reference.

### DIFF
--- a/docs/pages/build-reference/infrastructure.md
+++ b/docs/pages/build-reference/infrastructure.md
@@ -9,7 +9,7 @@ This document describes the current build infrastructure as of June 27, 2022. It
 
 ## Worker IP addresses
 
-An up-to-date list of worker IP addresses is published [here](https://expo.dev/eas-build-worker-ips.txt).
+Here is the [up-to-date list of worker IP addresses](https://expo.dev/eas-build-worker-ips.txt).
 
 ## Configuring build environment
 

--- a/docs/pages/build-reference/infrastructure.md
+++ b/docs/pages/build-reference/infrastructure.md
@@ -5,7 +5,11 @@ sidebar_title: Server infrastructure
 
 import { Collapsible } from '~/ui/components/Collapsible';
 
-This document describes the current build infrastructure as of May 13, 2022. It is likely to change over time, and this document will be updated.
+This document describes the current build infrastructure as of June 27, 2022. It is likely to change over time, and this document will be updated.
+
+## Worker IP addresses
+
+An up-to-date list of worker IP addresses is published [here](https://expo.dev/eas-build-worker-ips.txt).
 
 ## Configuring build environment
 


### PR DESCRIPTION
# Why

Document IPs for EAS Build workers.

# How

Added new section to EAS Build infrastructure page for worker IPs.

# Test Plan

Check docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
