### PR TITLE
[docs] Fix sharable typo on multiple places in docs

### DIFF
--- a/docs/pages/build/internal-distribution.md
+++ b/docs/pages/build/internal-distribution.md
@@ -8,7 +8,7 @@ import { theme } from '@expo/styleguide'
 
 Uploading your app to TestFlight and Google Play beta can be time consuming (e.g. waiting for the build to run through static analysis before becoming available to testers) and limiting (e.g. TestFlight can only have one active build at a time). Both Android and iOS provide alternative mechanisms to distribute apps directly to testers, so they can download and install them to physical devices directly from a web browser as soon as the builds are completed.
 
-EAS Build can help you with this by providing sharable URLs for your builds with instructions on how to get them running, so you can share a single URL with a teammate that'll include all of the information they need to test the app.
+EAS Build can help you with this by providing shareable URLs for your builds with instructions on how to get them running, so you can share a single URL with a teammate that'll include all of the information they need to test the app.
 
 > 😅 Installing an app on iOS is a bit trickier than on Android, but it's possible thanks to ad hoc and enterprise provisioning profiles. We'll talk more about this later in this doc.
 

--- a/docs/scripts/schemas/unversioned/eas-json-build-common-schema.js
+++ b/docs/scripts/schemas/unversioned/eas-json-build-common-schema.js
@@ -33,8 +33,8 @@ export default [
     name: 'distribution',
     enum: [ 'store', 'internal' ],
     description: [ 'The method of distributing your app.',
-      '- `internal` - with this option you\'ll be able to share your build URLs with anyone, and they will be able to install the builds to their devices straight from the Expo website. When using `internal`, make sure the build produces an APK or IPA file. Otherwise, the sharable URL will be useless. [Learn more about internal distribution](../../build/internal-distribution).',
-      ' - `store` - produces builds for store uploads, your build URLs won\'t be sharable.'
+      '- `internal` - with this option you\'ll be able to share your build URLs with anyone, and they will be able to install the builds to their devices straight from the Expo website. When using `internal`, make sure the build produces an APK or IPA file. Otherwise, the shareable URL will be useless. [Learn more about internal distribution](../../build/internal-distribution).',
+      ' - `store` - produces builds for store uploads, your build URLs won\'t be shareable.'
     ]
   },
   {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fixes ENG-5371

# How

<!--
How did you build this feature or fix this bug and why?
-->

There are two versions of the word "shareable" word being used (another being "sharable"), dominated by the former. This PR fixes the "sharable" references to the word "shareable".

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

The changes have been tested by running docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
