### PR TITLE
[docs] Guides: Remove emoji and unnecessary table of contents in favor right-hand side menu

### DIFF
--- a/docs/pages/accounts/account-types.md
+++ b/docs/pages/accounts/account-types.md
@@ -66,4 +66,4 @@ Some caveats:
 - The person performing the transfer must have "Owner" role on both the source and destination accounts.
 - New publishes for renamed project must be on SDK 43 or higher.
 
-> 💡 In the case where a project on your Personal or Organization Account (`source`) is sold/given to another company/person (receiving party) and the receiving party does not want to grant you Owner access to their `destination` account, you can create a new Organization Account (`escrow`), grant the receiving party Owner access, and transfer the project to the `escrow` account. The receiving party then can transfer it to the `destination` account from the `escrow` account.
+> In the case where a project on your Personal or Organization Account (`source`) is sold/given to another company/person (receiving party) and the receiving party does not want to grant you Owner access to their `destination` account, you can create a new Organization Account (`escrow`), grant the receiving party Owner access, and transfer the project to the `escrow` account. The receiving party then can transfer it to the `destination` account from the `escrow` account.

--- a/docs/pages/bare/error-recovery.md
+++ b/docs/pages/bare/error-recovery.md
@@ -39,7 +39,7 @@ If your app throws a fatal error when executing JS which is early enough in the 
 
 If `expo-updates` catches a JS error, what will happen next depends on whether React Native has fired the native "content appeared" event (`RCTContentDidAppearNotification` on iOS, or `ReactMarkerConstants.CONTENT_APPEARED` on Android)—approximately when your app's first view has been rendered on the screen—for this particular update, either on this launch or a previous one.
 
-> 💡 **Why this distinction?** In some cases `expo-updates` may try to automatically roll back to an older (working) update, but this can be dangerous if your new update has modified persistent state in a non-backwards compatible way. We assume that if the error occurs before the first view has rendered, no such code has been able to execute, and so rolling back is safe. After this point `expo-updates` will only fix forward and will not roll back.
+> **Why this distinction?** In some cases `expo-updates` may try to automatically roll back to an older (working) update, but this can be dangerous if your new update has modified persistent state in a non-backwards compatible way. We assume that if the error occurs before the first view has rendered, no such code has been able to execute, and so rolling back is safe. After this point `expo-updates` will only fix forward and will not roll back.
 
 ### If content has appeared
 

--- a/docs/pages/bare/installing-updates.md
+++ b/docs/pages/bare/installing-updates.md
@@ -8,7 +8,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 
 expo-updates fetches and manages updates to your app stored on a remote server.
 
-> 💡 If you are creating a new project, we recommend using `npx create-react-native-app` instead of `npx react-native init` because it will handle the following configuration for you automatically.
+> If you are creating a new project, we recommend using `npx create-react-native-app` instead of `npx react-native init` because it will handle the following configuration for you automatically.
 
 ## Installation
 

--- a/docs/pages/bare/using-libraries.md
+++ b/docs/pages/bare/using-libraries.md
@@ -29,7 +29,7 @@ export default function App() {
 
 ## Using Expo SDK Libraries
 
-> 💡 If you initialized your app using `@react-native-community/cli` and you don't have the `expo` package installed in it yet, please refer to the guide for [using the Expo SDK in existing apps](../bare/existing-apps.md).
+> If you initialized your app using `@react-native-community/cli` and you don't have the `expo` package installed in it yet, please refer to the guide for [using the Expo SDK in existing apps](../bare/existing-apps.md).
 
 The Expo SDK picks up where the React Native core libraries end - it provides access to a lot of useful device and system functionality like audio, barcode scanning, camera, calendar, contacts, video, and so on. It also adds other powerful libraries like updates, maps, OAuth authentication tools, and more.
 

--- a/docs/pages/guides/authentication.md
+++ b/docs/pages/guides/authentication.md
@@ -515,7 +515,7 @@ You must use the proxy service in the Expo Go app because `exp://` cannot be add
 - Copy the "App ID" in the header into your `expoClientId: '<YOUR FBID>'`. Ex: `{ expoClientId: '474614477183384' }` (no `fb` prefix).
 - Now you're ready to use the demo component in the Expo Go app on iOS and Android.
 
-> ⚠️ If you forget to add the correct URL to the "Valid OAuth Redirect URIs", you will get an error like: `Can't Load URL: The domain of this URL isn't included in the app's domains. To be able to load this URL, add all domains and subdomains of your app to the App Domains field in your app settings.`
+> If you forget to add the correct URL to the "Valid OAuth Redirect URIs", you will get an error like: `Can't Load URL: The domain of this URL isn't included in the app's domains. To be able to load this URL, add all domains and subdomains of your app to the App Domains field in your app settings.`
 
 #### Custom Apps
 
@@ -578,7 +578,7 @@ Then add `<data android:scheme="fb<YOUR ID>"/>` to the `.MainActivity` `intent-f
 
 #### Troubleshooting native
 
-> ⚠️ The `native` redirect URI **must** be formatted like `fb<YOUR FBID>://authorize`, ex: `fb474614477183384://authorize`. Using the `Facebook` provider will do this automatically.
+> The `native` redirect URI **must** be formatted like `fb<YOUR FBID>://authorize`, ex: `fb474614477183384://authorize`. Using the `Facebook` provider will do this automatically.
 
 - If the protocol/suffix is not your FBID then you will get an error like: `No redirect URI in the params: No redirect present in URI`.
 - If the path is not `://authorize` then you will get an error like: `Can't Load URL: The domain of this URL isn't included in the app's domains. To be able to load this URL, add all domains and subdomains of your app to the App Domains field in your app settings.`

--- a/docs/pages/guides/config-plugins.md
+++ b/docs/pages/guides/config-plugins.md
@@ -18,7 +18,7 @@ You can think of plugins like a bundler for native projects, and running `expo p
 - `mods` are async functions that modify native project files, such as source code or configuration (plist, xml) files.
 - Changes performed with `mods` will require rebuilding the affected native projects.
 - `mods` are removed from the public app manifest.
-- 💡 Everything in the Expo config must be able to be converted to JSON (with the exception of the `mods` field). So no async functions outside of `mods` in your config plugins!
+- Everything in the Expo config must be able to be converted to JSON (with the exception of the `mods` field). So no async functions outside of `mods` in your config plugins!
 
 ## Using a plugin in your app
 

--- a/docs/pages/guides/configuring-statusbar.md
+++ b/docs/pages/guides/configuring-statusbar.md
@@ -12,7 +12,7 @@ This guide is intended to help you know what tools are at your disposal to confi
 
 <ImageSpotlight src="/static/images/status-bar-style-comparison.png" alt="A comparison of good and bad status bar styling" />
 
-> 👀 Notice how bad the contrast is between the status bar text and the background in the second image. This is what we want to try to avoid.
+> Notice how bad the contrast is between the status bar text and the background in the second image. This is what we want to try to avoid.
 
 ## Configuring the status bar while your app is loading (Android only)
 
@@ -94,7 +94,7 @@ export default function Playlists() {
 
 If you use `expo-status-bar` to control your status bar style, the `style="auto"` configuration will automatically pick the appropriate default style depending on the color scheme currently used by the app (this is the default behavior, if you leave out the style prop entirely then `auto` will be used). Please note that if you provide a way for users to toggle between color schemes rather than using the operating system theme, this will not have the intended behavior, and you should use `style="light"` and `style="dark"` as needed depending on the selected color scheme.
 
-> 💡Automatic theme detection is only supported in SDK 38 or higher. Prior to SDK 38, `auto` will not change depending on your color scheme, it will always assume that the theme is light.
+> Automatic theme detection is only supported in SDK 38 or higher. Prior to SDK 38, `auto` will not change depending on your color scheme, it will always assume that the theme is light.
 
 ## Factoring the status bar in with your layout
 

--- a/docs/pages/guides/customizing-webpack.md
+++ b/docs/pages/guides/customizing-webpack.md
@@ -47,7 +47,7 @@ React Native for web uses [some advanced browser features](https://github.com/ne
 
 ### ResizeObserver
 
-👉 [Browser support](https://caniuse.com/#feat=resizeobserver)
+- [Browser support](https://caniuse.com/#feat=resizeobserver)
 
 **TL;DR:** To fully support `onLayout` install `resize-observer-polyfill`.
 

--- a/docs/pages/guides/icons.md
+++ b/docs/pages/guides/icons.md
@@ -4,7 +4,7 @@ title: Icons
 
 import SnackInline from '~/components/plugins/SnackInline';
 
-As trendy as it is these days, not every app has to use emoji for all icons 😳 -- maybe you want to pull in a popular set through an icon font like FontAwesome, Glyphicons or Ionicons, or you just use some PNGs that you carefully picked out on [The Noun Project](https://thenounproject.com/). Let's look at how to do both of these approaches.
+As trendy as it is these days, not every app has to use emoji for all icons -- maybe you want to pull in a popular set through an icon font like FontAwesome, Glyphicons or Ionicons, or you just use some PNGs that you carefully picked out on [The Noun Project](https://thenounproject.com/). Let's look at how to do both of these approaches.
 
 ## @expo/vector-icons
 

--- a/docs/pages/guides/monorepos.md
+++ b/docs/pages/guides/monorepos.md
@@ -7,7 +7,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 
 Monorepos, or _"monolithic repositories"_, are single repositories containing multiple apps or packages. It can help speed up development for larger projects, makes it easier to share code, and act as a single source of truth. This guide will set up a simple monorepo with an Expo project. We currently have first-class support for yarn workspaces. If you want to use another tool, make sure you know how to configure it.
 
-> ⚠️ Monorepos are not for everyone. It requires in-depth knowledge of the used tooling, adds more complexity, and often requires specific tooling configuration. You can get far with just a single repository.
+> Monorepos are not for everyone. It requires in-depth knowledge of the used tooling, adds more complexity, and often requires specific tooling configuration. You can get far with just a single repository.
 
 <Collapsible summary="Using SDK older than 43?">
 
@@ -52,7 +52,7 @@ Yarn and other tooling have a concept called _"workspaces"_. Every package and a
 }
 ```
 
-> ⚠️ Yarn workspaces require the root **package.json** to be private. If you don't set this, `yarn install` will error with a message mentioning this.
+> Yarn workspaces require the root **package.json** to be private. If you don't set this, `yarn install` will error with a message mentioning this.
 
 ### Create our first app
 
@@ -113,7 +113,7 @@ import App from './App';
 registerRootComponent(App);
 ```
 
-> 💡 This new entrypoint already exists for bare projects. You only need to add this if you have a managed project.
+> This new entrypoint already exists for bare projects. You only need to add this if you have a managed project.
 
 ### Create a package
 

--- a/docs/pages/guides/routing-and-navigation.md
+++ b/docs/pages/guides/routing-and-navigation.md
@@ -12,7 +12,7 @@ Routing and navigation refers to the ability to organize your app into distinct 
 
 <Video file={"routing-and-navigation/preview.mp4"} loop={false} />
 
-> 🎬 This video demonstrates using React Navigation on iOS, Android, and web. Notice that it adapts to the platform conventions in each case. The code that powers this example app is available on GitHub in [react-navigation/example](https://github.com/react-navigation/react-navigation/tree/main/example).
+> This video demonstrates using React Navigation on iOS, Android, and web. Notice that it adapts to the platform conventions in each case. The code that powers this example app is available on GitHub in [react-navigation/example](https://github.com/react-navigation/react-navigation/tree/main/example).
 
 The library that we recommend that you use for routing & navigation for iOS, Android, and web is [React Navigation](https://github.com/react-navigation/react-navigation).
 

--- a/docs/pages/guides/using-custom-fonts.md
+++ b/docs/pages/guides/using-custom-fonts.md
@@ -197,7 +197,7 @@ export default props => {
 
 </SnackInline>
 
-> ⚠️ **If loading remote fonts, make sure they are being served from an origin with CORS properly configured** If you don't do this, your remote font might not load properly on the web platform.
+> **If loading remote fonts, make sure they are being served from an origin with CORS properly configured** If you don't do this, your remote font might not load properly on the web platform.
 
 ### Using `Font.loadAsync` instead of the `useFonts` hook
 

--- a/docs/pages/guides/using-electron.md
+++ b/docs/pages/guides/using-electron.md
@@ -9,15 +9,6 @@ sidebar_title: Using Electron
 
 To simplify this we created the package `@expo/electron-adapter` which wraps [`electron-webpack`][electron-webpack] and adds support for Expo web and other universal React packages.
 
-- [Setup](#-setup)
-- [Usage](#️-usage)
-  - [Starting a project](#starting-a-project)
-  - [Customizing the main process](#customizing-the-main-process)
-  - [Building your project](#building-your-project)
-- [Behavior](#-behavior)
-- [Contributing](#contributing)
-- [Learn more about Electron](#learn-more-about-electron)
-
 ## Setup
 
 - Create a new Expo project - `yarn create expo-app`

--- a/docs/pages/guides/using-electron.md
+++ b/docs/pages/guides/using-electron.md
@@ -3,22 +3,22 @@ title: Using Electron with Expo for Web
 sidebar_title: Using Electron
 ---
 
-> 🚨 Electron support is an experimental community project, so the workflow is suboptimal and subject to breaking changes. If you find bugs please report them on [expo/expo-electron-adapter](https://github.com/expo/expo-electron-adapter/issues).
+> Electron support is an experimental community project, so the workflow is suboptimal and subject to breaking changes. If you find bugs please report them on [expo/expo-electron-adapter](https://github.com/expo/expo-electron-adapter/issues).
 
 [Electron][electron] is a framework for creating desktop apps that run in a Chromium wrapper. Using Expo with Electron will enable you to use your existing components to build OSX, Windows, and Linux apps.
 
 To simplify this we created the package `@expo/electron-adapter` which wraps [`electron-webpack`][electron-webpack] and adds support for Expo web and other universal React packages.
 
-- [🏁 Setup](#-setup)
-- [⚽️ Usage](#️-usage)
+- [Setup](#-setup)
+- [Usage](#️-usage)
   - [Starting a project](#starting-a-project)
   - [Customizing the main process](#customizing-the-main-process)
   - [Building your project](#building-your-project)
-- [🧸 Behavior](#-behavior)
+- [Behavior](#-behavior)
 - [Contributing](#contributing)
 - [Learn more about Electron](#learn-more-about-electron)
 
-## 🏁 Setup
+## Setup
 
 - Create a new Expo project - `yarn create expo-app`
 - Install - `yarn add -D @expo/electron-adapter`
@@ -38,7 +38,7 @@ To simplify this we created the package `@expo/electron-adapter` which wraps [`e
     });
     ```
 
-## ⚽️ Usage
+## Usage
 
 ### Starting a project
 
@@ -62,7 +62,7 @@ To simplify this we created the package `@expo/electron-adapter` which wraps [`e
 - Use the builder with: `yarn electron-webpack && yarn electron-builder --dir -c.compression=store -c.mac.identity=null` (`-c.compression=store` speeds the builds up a lot, delete this for actual production builds)
 - Learn more about configuring your build here: [Configuring electron-builder][electron-builder-config]
 
-## 🧸 Behavior
+## Behavior
 
 - Webpack now resolves files with **.electron.js** & **.web.js** extensions in that order. If you want to use `electron` features then put them in a file like **foo.electron.js**.
 - Every universal package you have installed will be transpiled automatically, this includes packages that start with the name: `expo`, `@expo`, `@unimodules`, `@react-navigation`, `react-navigation`, `react-native`. You can add more by appending them to the array for key `expo.web.build.babel.include` in your **app.json** (this feature is experimental and subject to change).

--- a/docs/pages/guides/using-gatsby.md
+++ b/docs/pages/guides/using-gatsby.md
@@ -5,15 +5,6 @@ sidebar_title: Using Gatsby
 
 > Please open any issues related to Gatsby with Expo at [expo-cli/issues](https://github.com/expo/expo-cli/issues).
 
-- [Example](#example)
-- [Setup](#-setup)
-  - [Expo projects with Gatsby](#expo-projects-with-gatsby)
-  - [Gatsby projects with Expo](#gatsby-projects-with-expo)
-- [New Commands](#️-new-commands)
-- [File Structure](#-file-structure)
-- [Contributing](#contributing)
-- [Learn more about Gatsby](#learn-more-about-gatsby)
-
 [Gatsby](https://www.gatsbyjs.org/) is a React framework that helps you perform pre-rendering on your websites.
 Using Gatsby with Expo will enable you to [pre-render](https://www.netlify.com/blog/2016/11/22/prerendering-explained/) the web part of your Expo app. You'll also be able to use the web-enabled Expo SDK libraries (eg: Permissions, GestureHandler, Camera) with the Gatsby toolchain!
 

--- a/docs/pages/guides/using-gatsby.md
+++ b/docs/pages/guides/using-gatsby.md
@@ -6,11 +6,11 @@ sidebar_title: Using Gatsby
 > Please open any issues related to Gatsby with Expo at [expo-cli/issues](https://github.com/expo/expo-cli/issues).
 
 - [Example](#example)
-- [🏁 Setup](#-setup)
+- [Setup](#-setup)
   - [Expo projects with Gatsby](#expo-projects-with-gatsby)
   - [Gatsby projects with Expo](#gatsby-projects-with-expo)
-- [⌨️ New Commands](#️-new-commands)
-- [📁 File Structure](#-file-structure)
+- [New Commands](#️-new-commands)
+- [File Structure](#-file-structure)
 - [Contributing](#contributing)
 - [Learn more about Gatsby](#learn-more-about-gatsby)
 
@@ -23,7 +23,7 @@ This guide will show you how to use the Gatsby CLI to develop your websites with
 
 If you'd like to jump right into a working project then check out [expo/examples: with-gatsby](https://github.com/expo/examples/edit/master/with-gatsby/).
 
-## 🏁 Setup
+## Setup
 
 We put all of the features for Expo web in the plugin [`gatsby-plugin-react-native-web`](https://github.com/slorber/gatsby-plugin-react-native-web) so setup would be as easy as possible. This guide will show you how to install and use it. Under the hood it's basically doing what `expo start --web` or the Expo + Next.js workflows are doing.
 
@@ -97,7 +97,7 @@ For using the Expo SDK in a web-only Gatsby project.
   - Gestures: `yarn add react-native-gesture-handler`
   - hooks: `yarn add react-native-web-hooks`
 
-## ⌨️ New Commands
+## New Commands
 
 You'll want to use the Gatsby CLI to develop the web part of your app now. You should still use `expo-cli` to run on iOS, and Android.
 
@@ -116,7 +116,7 @@ You'll want to use the Gatsby CLI to develop the web part of your app now. You s
   - 🚫 `serve web-build`
   - ✅ `yarn gatsby serve`
 
-## 📁 File Structure
+## File Structure
 
 Here is the recommended file structure for a Expo project with Gatsby support.
 

--- a/docs/pages/guides/using-hermes.md
+++ b/docs/pages/guides/using-hermes.md
@@ -130,7 +130,7 @@ Alternatively, you can use the JavaScript inspector from the following tools:
 - [Open Google Chrome DevTools manually](https://reactnative.dev/docs/hermes#debugging-js-on-hermes-using-google-chromes-devtools)
 - [Flipper](https://fbflipper.com/)
 
-> 💡 [Development builds](/development/introduction.md) built with `expo-dev-client` simplify this process by integrating directly with the JavaScript inspector in Hermes.
+> [Development builds](/development/introduction.md) built with `expo-dev-client` simplify this process by integrating directly with the JavaScript inspector in Hermes.
 
 ## Limitations
 

--- a/docs/pages/guides/using-nextjs.md
+++ b/docs/pages/guides/using-nextjs.md
@@ -11,7 +11,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 
 Using Expo with Next.js means you can share all of your existing components and APIs across your mobile and web. Next.js has its own Webpack config so **you'll need to start your web projects with the `next-cli` and not with `expo start:web`.**
 
-> 💡 Next.js can only be used with Expo for web, this doesn't provide Server-Side Rendering (SSR) for native apps.
+> Next.js can only be used with Expo for web, this doesn't provide Server-Side Rendering (SSR) for native apps.
 
 ## TL;DR:
 
@@ -19,7 +19,7 @@ Using Expo with Next.js means you can share all of your existing components and 
 - Start: `yarn next dev`
 - Open: `http://localhost:3000/`
 
-## 🏁 Setup
+## Setup
 
 To get started, create a new project with [the template](https://github.com/expo/examples/tree/master/with-nextjs):
 
@@ -147,7 +147,7 @@ This is Vercel's preferred method for deploying Next.js projects to production.
 
 ### Polyfill setImmediate
 
-> 💡 Fixes `setImmediate is not defined` error.
+> Fixes `setImmediate is not defined` error.
 
 A lot of libraries in the React ecosystem use the `setImmediate()` API (like `react-native-reanimated`), which Next.js doesn't polyfill by default. To fix this you can polyfill it yourself.
 
@@ -268,7 +268,7 @@ export default function FontDemo() {
 
 Generate static Next.js files into your project.
 
-#### ⚙️ CLI Options
+#### CLI Options
 
 For more information run `yarn next-expo --help` (or `-h`)
 
@@ -373,8 +373,6 @@ If you would like to help make Next.js support in Expo better, please feel free 
 If you have any problems rendering a certain component with SSR then you can submit fixes to the expo/expo repo:
 
 - [Expo SDK packages][expo-packages]
-
-Thanks so much 👋
 
 <!-- Footer -->
 

--- a/docs/pages/guides/web-performance.md
+++ b/docs/pages/guides/web-performance.md
@@ -24,7 +24,7 @@ npm install -g sharp-cli
 npx expo-optimize
 ```
 
-## 📦 What Makes My App Large?
+## What Makes My App Large?
 
 To inspect bundle sizes, you can use a Webpack plugin called [_Webpack Bundle Analyzer_](https://github.com/webpack-contrib/webpack-bundle-analyzer). This plugin will help you visualize the size of your static bundles. You can use this to identify unwanted large packages that you may not have bundled intentionally.
 
@@ -67,7 +67,7 @@ EXPO_WEB_DEBUG=true expo build:web
 
 You can now search for unwanted packages by name and see which files or methods are preventing them from being tree-shaken.
 
-## ⚡️ Lighthouse
+## Lighthouse
 
 Lighthouse is a great way to see how fast, accessible, and performant your website is.
 You can test your project with the _Audit_ tab in Chrome, or with the [**Lighthouse CLI**][lighthouse].


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fixes ENG-5361

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR removes inconsistent emoji usage from Assorted Guides and a few other docs pages under the Guides section. 

It also removes unnecessary Table of Contents (TOC) for "Using Gatsby with Expo for Web" and "Using Electron with Expo for Web" guides. Both of these guides have TOC generated on the right-hand side. (This was not part of the original issue but thought it would be a good refactor.)

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

The changes have been tested by running docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
