### PR TITLE
[media-library] Prevent `_exportAsset` from crashing

### DIFF
--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Use `PHAssetCollectionSubtypeAny` subtype to avoid Recently Deleted album to show up ([#17561](https://github.com/expo/expo/pull/17561) by [@chuganzy](https://github.com/chuganzy))
+- Fix `MediaLibrary._exportAsset` crashing if `filename` is nil. ([#17999](https://github.com/expo/expo/pull/17999) by [@ken0nek](https://github.com/ken0nek))
 
 ### 💡 Others
 

--- a/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m
+++ b/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m
@@ -817,10 +817,10 @@ EX_EXPORT_METHOD_AS(getAssetsAsync,
 {
   if (asset) {
     NSString *fileName = [asset valueForKey:@"filename"];
-    
+
     return @{
              @"id": asset.localIdentifier,
-             @"filename": fileName,
+             @"filename": EXNullIfNil(fileName),
              @"uri": [EXMediaLibrary _assetUriForLocalId:asset.localIdentifier],
              @"mediaType": [EXMediaLibrary _stringifyMediaType:asset.mediaType],
              @"mediaSubtypes": [EXMediaLibrary _stringifyMediaSubtypes:asset.mediaSubtypes],


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Prevent `_exportAsset` from crashing

[EXMediaLibrary.m - Line 822](https://github.com/expo/expo/blob/main/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m#L822)

## Log from Firebase Crashlytics

```
Fatal Exception: NSInvalidArgumentException
*** -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]: attempt to insert nil object from objects[1]

...

EXMediaLibrary.m - Line 822
+[EXMediaLibrary _exportAsset:] + 822

EXMediaLibrary.m - Line 596
-[EXMediaLibrary photoLibraryDidChange:] + 596
```

ref: https://github.com/expo/expo/pull/5937

# How

<!--
How did you build this feature or fix this bug and why?
-->

Add `EXNullIfNill`

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
