### PR TITLE
[docs] remove walkthrough page and references

### DIFF
--- a/docs/common/error-utilities.ts
+++ b/docs/common/error-utilities.ts
@@ -168,7 +168,8 @@ const RENAMED_PAGES: Record<string, string> = {
   '/introduction/installation/': '/get-started/installation/',
   '/versions/latest/overview/': '/versions/latest/',
   '/versions/latest/introduction/installation/': '/get-started/installation/',
-  '/workflow/exploring-managed-workflow/': '/introduction/walkthrough/',
+  '/workflow/exploring-managed-workflow/': '/tutorial/planning/',
+  '/introduction/walkthrough/': '/tutorial/planning/',
 
   // Move overview to index
   '/versions/v37.0.0/sdk/overview/': '/versions/v37.0.0/',

--- a/docs/constants/navigation-deprecated.js
+++ b/docs/constants/navigation-deprecated.js
@@ -60,7 +60,7 @@ const starting = [
       ]),
       makeGroup('Conceptual Overview', [
         makePage('introduction/managed-vs-bare.md'),
-        makePage('introduction/walkthrough.md'),
+        // makePage('introduction/walkthrough.md'),
         makePage('introduction/why-not-expo.md'),
         makePage('introduction/faq.md'),
       ]),

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -67,7 +67,7 @@ const starting = [
     'Conceptual Overview',
     [
       makePage('introduction/managed-vs-bare.md'),
-      makePage('introduction/walkthrough.md'),
+      // makePage('introduction/walkthrough.md'),
       makePage('introduction/why-not-expo.md'),
       makePage('introduction/faq.md'),
     ],

--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -117,6 +117,8 @@ redirects[modules]=modules/overview/
 redirects[module-api]=modules/module-api/
 redirects[module-config]=modules/module-config/
 
+redirects[introduction/walkthrough]=tutorial/planning/
+
 echo "::group::[5/6] Add custom redirects"
 for i in "${!redirects[@]}" # iterate over keys
 do

--- a/docs/pages/bare/exploring-bare-workflow.md
+++ b/docs/pages/bare/exploring-bare-workflow.md
@@ -69,4 +69,4 @@ With [Expo Application Services (EAS)](/eas/index.md), you can build and submit 
 
 You are now, at a very high level, familiar with the steps you would go through to get started on building an app with the bare workflow. Continue on to [Up and Running](hello-world.md) to get started coding!
 
-Are you feeling intimidated? It might be better for you to start out with the managed workflow if you're new to this. Check out the [managed workflow walkthrough](../introduction/walkthrough.md) for more information.
+Are you feeling intimidated? It might be better for you to start out with the managed workflow if you're new to this. Check out the [First steps](../tutorial/planning/) for more information.


### PR DESCRIPTION
# Why

The walkthrough page is outdated. We are removing it until it is replaced.

# How

Removed page from navigation, added redirects in both places, updated incoming links to it.

# Test Plan

Tested locally for navigation and redirects.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
