### PR TITLE
[docs] ConfigurationDiff: fix title overflow, small UI tweaks

### DIFF
--- a/docs/components/plugins/ConfigurationDiff.tsx
+++ b/docs/components/plugins/ConfigurationDiff.tsx
@@ -55,7 +55,7 @@ const diffContainerStyles = css`
   border: 1px solid ${theme.border.default};
   background-color: ${theme.background.screen};
   border-radius: ${borderRadius.small}px;
-  margin-bottom: ${spacing[2.5]}px;
+  margin-bottom: ${spacing[4]}px;
 
   table {
     ${typography.fontSizes[14]}
@@ -88,8 +88,9 @@ const titleContainerStyles = css`
   padding: ${spacing[3.5]}px;
   background-color: ${theme.background.default};
   border-bottom: 1px solid ${theme.border.default};
-  font-size: 0.9rem;
+  border-radius: ${borderRadius.small}px ${borderRadius.small}px 0 0;
   color: ${theme.text.default};
+  word-break: break-word;
 `;
 
 export default ConfigurationDiff;


### PR DESCRIPTION
# Why

Currently, the title of `ConfigurationDiff` can overflow on mobile, and title container background overflows the border:

<img width="380" alt="Screenshot 2022-06-28 at 10 32 51" src="https://user-images.githubusercontent.com/719641/176133040-bcbd5f3e-3f0d-4998-8fa5-20a5dffb384b.png">

# How

Fix the issues mentioned above by updating the ConfigurationDiff component styles.

# Test Plan

The changes have been tested on docs website run locally.

# Preview

<img width="380" alt="Screenshot 2022-06-28 at 10 35 11" src="https://user-images.githubusercontent.com/719641/176133540-b02ad757-3983-4ee3-a2f0-5b25b935b85e.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
