### PR TITLE
[sweet][Kotlin] Fix instrumental tests not working on JSC

### DIFF
--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIModuleMock.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIModuleMock.kt
@@ -70,7 +70,7 @@ internal inline fun JSIInteropModuleRegistry.waitForAsyncFunction(
   }
 
   Truth
-    .assertWithMessage("Promise wasn't resolve")
+    .assertWithMessage("Promise wasn't resolved")
     .that(global().hasProperty("promiseResult")).isTrue()
   return global().getProperty("promiseResult")
 }

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIModuleMock.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIModuleMock.kt
@@ -69,7 +69,9 @@ internal inline fun JSIInteropModuleRegistry.waitForAsyncFunction(
     throw PromiseException(errorMessage)
   }
 
-  Truth.assertThat(global().hasProperty("promiseResult")).isTrue()
+  Truth
+    .assertWithMessage("Promise wasn't resolve")
+    .that(global().hasProperty("promiseResult")).isTrue()
   return global().getProperty("promiseResult")
 }
 

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.cpp
@@ -37,13 +37,6 @@ JavaScriptRuntime::JavaScriptRuntime()
     .withEnableSampleProfiling(false);
   runtime = facebook::hermes::makeHermesRuntime(config.build());
 
-  // By default "global" property isn't set in the Hermes.
-  runtime->global().setProperty(
-    *runtime,
-    jsi::PropNameID::forUtf8(*runtime, "global"),
-    runtime->global()
-  );
-
   // This version of the Hermes uses a Promise implementation that is provided by the RN.
   // The `setImmediate` function isn't defined, but is required by the Promise implementation.
   // That's why we inject it here.
@@ -67,6 +60,13 @@ JavaScriptRuntime::JavaScriptRuntime()
 #else
   runtime = facebook::jsc::makeJSCRuntime();
 #endif
+
+  // By default "global" property isn't set.
+  runtime->global().setProperty(
+    *runtime,
+    jsi::PropNameID::forUtf8(*runtime, "global"),
+    runtime->global()
+  );
 }
 
 JavaScriptRuntime::JavaScriptRuntime(


### PR DESCRIPTION
# Why

Fixes instrumental tests not working on JSC

# How

It turns out that the `global` property isn't set up in JSC too. 
Also, I've improved an error message when the promise wasn't resolved. 

# Test Plan

- run Android tests on JSC ✅