### PR TITLE
docs(EAS Submit): correct link to EAS Build intro

### DIFF
--- a/docs/pages/submit/ios.md
+++ b/docs/pages/submit/ios.md
@@ -15,7 +15,7 @@ This guide outlines how to submit your app to the Apple App Store from your own 
 
 ## 1. Build a standalone app
 
-You'll need a native app binary signed for store submission. You can either use [EAS Build](introduction.md) or do it on your own.
+You'll need a native app binary signed for store submission. You can either use [EAS Build](/build/introduction.md) or do it on your own.
 
 ## 2. Start the submission
 


### PR DESCRIPTION
- changed the link because it led to the intro of EAS Submit instead of EAS Build as the text says