### PR TITLE
[packages] Update tsconfig from template

### DIFF
--- a/packages/expo-ads-admob/tsconfig.json
+++ b/packages/expo-ads-admob/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-ads-facebook/tsconfig.json
+++ b/packages/expo-ads-facebook/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-analytics-amplitude/tsconfig.json
+++ b/packages/expo-analytics-amplitude/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-analytics-segment/tsconfig.json
+++ b/packages/expo-analytics-segment/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-app-loading/tsconfig.json
+++ b/packages/expo-app-loading/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-apple-authentication/tsconfig.json
+++ b/packages/expo-apple-authentication/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-application/tsconfig.json
+++ b/packages/expo-application/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-asset/tsconfig.json
+++ b/packages/expo-asset/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-auth-session/tsconfig.json
+++ b/packages/expo-auth-session/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-background-fetch/tsconfig.json
+++ b/packages/expo-background-fetch/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-barcode-scanner/tsconfig.json
+++ b/packages/expo-barcode-scanner/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-battery/tsconfig.json
+++ b/packages/expo-battery/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-blur/tsconfig.json
+++ b/packages/expo-blur/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-branch/tsconfig.json
+++ b/packages/expo-branch/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-brightness/tsconfig.json
+++ b/packages/expo-brightness/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-calendar/tsconfig.json
+++ b/packages/expo-calendar/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-camera/tsconfig.json
+++ b/packages/expo-camera/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-cellular/tsconfig.json
+++ b/packages/expo-cellular/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-checkbox/tsconfig.json
+++ b/packages/expo-checkbox/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-clipboard/tsconfig.json
+++ b/packages/expo-clipboard/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-constants/tsconfig.json
+++ b/packages/expo-constants/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-contacts/tsconfig.json
+++ b/packages/expo-contacts/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-crypto/tsconfig.json
+++ b/packages/expo-crypto/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-dev-client-components/tsconfig.json
+++ b/packages/expo-dev-client-components/tsconfig.json
@@ -2,15 +2,8 @@
 {
   "extends": "expo-module-scripts/tsconfig.base",
   "compilerOptions": {
-    "outDir": "./build",
-    "resolveJsonModule": true,
-    "baseUrl": ".",
-    "noEmit": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitAny": true
+    "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-dev-client-components/tsconfig.json
+++ b/packages/expo-dev-client-components/tsconfig.json
@@ -2,7 +2,14 @@
 {
   "extends": "expo-module-scripts/tsconfig.base",
   "compilerOptions": {
-    "outDir": "./build"
+    "outDir": "./build",
+    "resolveJsonModule": true,
+    "baseUrl": ".",
+    "noEmit": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitAny": true
   },
   "include": ["./src"],
   "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]

--- a/packages/expo-dev-client/tsconfig.json
+++ b/packages/expo-dev-client/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-dev-launcher/tsconfig.json
+++ b/packages/expo-dev-launcher/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-dev-menu/tsconfig.json
+++ b/packages/expo-dev-menu/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-device/tsconfig.json
+++ b/packages/expo-device/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-document-picker/tsconfig.json
+++ b/packages/expo-document-picker/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-eas-client/tsconfig.json
+++ b/packages/expo-eas-client/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-error-recovery/tsconfig.json
+++ b/packages/expo-error-recovery/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-face-detector/tsconfig.json
+++ b/packages/expo-face-detector/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-facebook/tsconfig.json
+++ b/packages/expo-facebook/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-file-system/tsconfig.json
+++ b/packages/expo-file-system/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-firebase-analytics/tsconfig.json
+++ b/packages/expo-firebase-analytics/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-firebase-core/tsconfig.json
+++ b/packages/expo-firebase-core/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-firebase-recaptcha/tsconfig.json
+++ b/packages/expo-firebase-recaptcha/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-font/tsconfig.json
+++ b/packages/expo-font/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-haptics/tsconfig.json
+++ b/packages/expo-haptics/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-image-manipulator/tsconfig.json
+++ b/packages/expo-image-manipulator/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-image-picker/tsconfig.json
+++ b/packages/expo-image-picker/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-image/tsconfig.json
+++ b/packages/expo-image/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-in-app-purchases/tsconfig.json
+++ b/packages/expo-in-app-purchases/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-intent-launcher/tsconfig.json
+++ b/packages/expo-intent-launcher/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-keep-awake/tsconfig.json
+++ b/packages/expo-keep-awake/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-linear-gradient/tsconfig.json
+++ b/packages/expo-linear-gradient/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-local-authentication/tsconfig.json
+++ b/packages/expo-local-authentication/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-localization/tsconfig.json
+++ b/packages/expo-localization/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-location/tsconfig.json
+++ b/packages/expo-location/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-mail-composer/tsconfig.json
+++ b/packages/expo-mail-composer/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-media-library/tsconfig.json
+++ b/packages/expo-media-library/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-module-template/tsconfig.json
+++ b/packages/expo-module-template/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-modules-core/tsconfig.json
+++ b/packages/expo-modules-core/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-navigation-bar/tsconfig.json
+++ b/packages/expo-navigation-bar/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-network/tsconfig.json
+++ b/packages/expo-network/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-notifications/tsconfig.json
+++ b/packages/expo-notifications/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-print/tsconfig.json
+++ b/packages/expo-print/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-random/tsconfig.json
+++ b/packages/expo-random/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-screen-capture/tsconfig.json
+++ b/packages/expo-screen-capture/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-screen-orientation/tsconfig.json
+++ b/packages/expo-screen-orientation/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-secure-store/tsconfig.json
+++ b/packages/expo-secure-store/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-sensors/tsconfig.json
+++ b/packages/expo-sensors/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-sharing/tsconfig.json
+++ b/packages/expo-sharing/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-speech/tsconfig.json
+++ b/packages/expo-speech/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-splash-screen/tsconfig.json
+++ b/packages/expo-splash-screen/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-sqlite/tsconfig.json
+++ b/packages/expo-sqlite/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-standard-web-crypto/tsconfig.json
+++ b/packages/expo-standard-web-crypto/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-status-bar/tsconfig.json
+++ b/packages/expo-status-bar/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-store-review/tsconfig.json
+++ b/packages/expo-store-review/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-system-ui/tsconfig.json
+++ b/packages/expo-system-ui/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-task-manager/tsconfig.json
+++ b/packages/expo-task-manager/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-tracking-transparency/tsconfig.json
+++ b/packages/expo-tracking-transparency/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-updates/tsconfig.json
+++ b/packages/expo-updates/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-video-thumbnails/tsconfig.json
+++ b/packages/expo-video-thumbnails/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo-web-browser/tsconfig.json
+++ b/packages/expo-web-browser/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/expo/tsconfig.json
+++ b/packages/expo/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }

--- a/packages/html-elements/tsconfig.json
+++ b/packages/html-elements/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__stories__/*"]
 }


### PR DESCRIPTION
# Why

In https://github.com/expo/expo/commit/55046b833504078674c1a5f3f617965046f95277 I updated the `tsconfig.json` template to ignore `__stories__` as it was already done in `expo-av` (see #13988) - that is the only package that has stories now.

Now when working with packages, running `yarn` inside package directory runs `expo-module configure` which updates overwrites package tsconfig with the template and makes git dirty.

# How

Updated all `packages/*/tsconfig.json` to match the template from `expo-module-scripts/templates/tsconfig.json`.

```sh
cd <expo_repo_root_dir>

# run `yarn expo-module configure` for all packages
for d in ./packages/*/ ; do (cd "$d" && yarn expo-module configure); done

# remove untracked files - some packages do not have eslintrc/npmignore etc. but above command created them
git clean -f
git add packages/*/tsconfig.json
git commit
```

# Test Plan

See git diff

<!-- disable:changelog-checks -->
