### PR TITLE
[docs-readme] Add info about using Terminal component

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -267,9 +267,9 @@ Certain directories are excluded from the sidebar in order to prevent it from ge
 
 If you just want to hide a single page from the sidebar, set `hideInSidebar: true` in the page metadata.
 
-### Use Terminal component for `expo install` commands snippets
+### Use `Terminal` component for shell commands snippets
 
-Whenever `expo install ...` commands are used or referred, use `Terminal` component to make the code snippets copy/pasteable. This component can be imported in any markdown file.
+Whenever shell commands are used or referred, use `Terminal` component to make the code snippets copy/pasteable. This component can be imported in any markdown file.
 
 ```jsx
 import { Terminal } from '~/ui/components/Snippet';

--- a/docs/README.md
+++ b/docs/README.md
@@ -286,7 +286,7 @@ import { Terminal } from '~/ui/components/Snippet';
   "# If you don’t have expo-cli yet, get it",
   "$ npm i -g expo-cli",
   "",
-]} cmdCopy="npx create-expo-app —template bare-minimum && npm i -g expo-cli" />
+]} cmdCopy="npx create-expo-app --template bare-minimum && npm i -g expo-cli" />
 ```
 
 ### Prettier

--- a/docs/README.md
+++ b/docs/README.md
@@ -281,7 +281,7 @@ import { Terminal } from '~/ui/components/Snippet';
 
 <Terminal cmd={[
   "# Create a new native project",
-  "$ npx create-expo-app —template bare-minimum",
+  "$ npx create-expo-app --template bare-minimum",
   "",
   "# If you don’t have expo-cli yet, get it",
   "$ npm i -g expo-cli",

--- a/docs/README.md
+++ b/docs/README.md
@@ -267,6 +267,28 @@ Certain directories are excluded from the sidebar in order to prevent it from ge
 
 If you just want to hide a single page from the sidebar, set `hideInSidebar: true` in the page metadata.
 
+### Use Terminal component for `expo install` commands snippets
+
+Whenever `expo install ...` commands are used or referred, use `Terminal` component to make the code snippets copy/pasteable. This component can be imported in any markdown file.
+
+```jsx
+import { Terminal } from '~/ui/components/Snippet';
+
+// for single command and one prop
+<Terminal cmd={["$ expo install package"]} />
+
+// for multiple commands
+
+<Terminal cmd={[
+  "# Create a new native project",
+  "$ npx create-expo-app —template bare-minimum",
+  "",
+  "# If you don’t have expo-cli yet, get it",
+  "$ npm i -g expo-cli",
+  "",
+]} cmdCopy="npx create-expo-app —template bare-minimum && npm i -g expo-cli" />
+```
+
 ### Prettier
 
 Please commit any sizeable diffs that are the result of `prettier` separately to make reviews as easy as possible.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This PR adds information about how to use `Terminal` component for markdown files in the `docs/` directory.

# How

<!--
How did you build this feature or fix this bug and why?
-->
The `Terminal` component is useful when referring to `expo install` command code snippets. It will be helpful for anyone contributing to Expo docs for the first time, to maintain the docs style consistency and be mindful of it.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
