### PR TITLE
Add yarn files to template `.gitignore`

### DIFF
--- a/templates/expo-template-bare-minimum/gitignore
+++ b/templates/expo-template-bare-minimum/gitignore
@@ -36,6 +36,13 @@ local.properties
 node_modules/
 npm-debug.log
 yarn-error.log
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions
 
 # BUCK
 buck-out/

--- a/templates/expo-template-blank-typescript/gitignore
+++ b/templates/expo-template-blank-typescript/gitignore
@@ -10,5 +10,14 @@ npm-debug.*
 *.orig.*
 web-build/
 
+# Yarn
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions
+
 # macOS
 .DS_Store

--- a/templates/expo-template-blank/gitignore
+++ b/templates/expo-template-blank/gitignore
@@ -10,5 +10,14 @@ npm-debug.*
 *.orig.*
 web-build/
 
+# Yarn
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions
+
 # macOS
 .DS_Store

--- a/templates/expo-template-tabs/gitignore
+++ b/templates/expo-template-tabs/gitignore
@@ -10,5 +10,14 @@ npm-debug.*
 *.orig.*
 web-build/
 
+# Yarn
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions
+
 # macOS
 .DS_Store


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Feature suggested in #18000
-  #18000 
- TLDR: It's annoying for yarn users to have to add `.yarn` folder. It also causes issues as explained in the discussion.

# How

<!--
How did you build this feature or fix this bug and why?
-->

I just added the files from the yarn docs to the `.gitignore`

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

I didn't think this would need tests.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).

None of the above are applicable
