### PR TITLE
[ios] fix expo go crash when receiving notifications with content.data.body

### DIFF
--- a/ios/Exponent/Kernel/Services/EXUserNotificationManager.m
+++ b/ios/Exponent/Kernel/Services/EXUserNotificationManager.m
@@ -68,12 +68,6 @@ static NSString * const scopedIdentifierSeparator = @":";
     }
   }
 
-  NSDictionary *userInfo = notification.request.content.userInfo;
-  if (userInfo && userInfo[@"body"] && userInfo[@"body"][@"_displayInForeground"]) {
-    // If user specifically set `_displayInForeground` in the notification, it always override `notification.iosDisplayInForeground` in `app.json`.
-    shouldDisplayInForeground = [userInfo[@"body"][@"_displayInForeground"] boolValue];
-  }
-
   // Notifications were only shown while the app wasn't active or if the user specifies to do so.
   if ([UIApplication sharedApplication].applicationState != UIApplicationStateActive || shouldDisplayInForeground) {
     // TODO(iOS 14): use UNNotificationPresentationOptionList and UNNotificationPresentationOptionBanner


### PR DESCRIPTION
# Why

fix #17977

# How

i guess the fix might be

```diff
-  if (userInfo && userInfo[@"body"] && userInfo[@"body"][@"_displayInForeground"]) {
+  if (userInfo && userInfo[@"body"] && userInfo[@"_displayInForeground"]) {
```
however, the `_displayInForeground` looks like a legacy code we removed: https://github.com/expo/universe/pull/3630. i am going to clean all the code directly.

# Test Plan

versioned expo go + https://snack.expo.dev/@simenb/push-notifications and uncomment the body payload

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- n/a This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
