### PR TITLE
[Android] Ignore `android/sdks/hermes*` directories

### DIFF
--- a/android/.gitignore
+++ b/android/.gitignore
@@ -1,4 +1,4 @@
-app/src/main/java/host/exp/exponent/generated/BasePackageList.java 
+app/src/main/java/host/exp/exponent/generated/BasePackageList.java
 
 .idea/caches/build_file_checksums.ser
 .project
@@ -11,6 +11,11 @@ tools/bin/
 app/mockFsDirectory/
 
 expoview/gradlew*
+
+# Additional SDKs
+/sdks/download
+/sdks/hermes
+/sdks/hermesc
 
 # Created by https://www.gitignore.io/api/java,android,eclipse,intellij,androidstudio
 


### PR DESCRIPTION
# Why

When building `Expo Go` for Android there's a new directory generated:
![Screenshot 2022-06-29 at 11 50 49](https://user-images.githubusercontent.com/16623003/176407577-b214dcff-61c2-4164-9308-6d902975387b.png)


# How

I've copied over `hermes`-related lines from
https://github.com/facebook/react-native/blob/4ea38e16bf533955557057656cba5346d2372acd/.gitignore#L117-L120
