### PR TITLE
caching: remove jcenter

### DIFF
--- a/docs/pages/build-reference/caching.md
+++ b/docs/pages/build-reference/caching.md
@@ -25,7 +25,6 @@ EAS Build runs a Maven cache server that can speed up downloading Android depend
 Currently we are caching:
 - `maven-central` - [https://repo1.maven.org/maven2/](https://repo1.maven.org/maven2/)
 - `google` - [https://maven.google.com/](https://maven.google.com/)
-- `jcenter` - [https://jcenter.bintray.com/](https://jcenter.bintray.com/)
 - `plugins` - [https://plugins.gradle.org/m2/](https://plugins.gradle.org/m2/)
 
 


### PR DESCRIPTION
# Why

jcenter is offline.

Sources:
- [“JFrog, the maintainers of JCenter, announced that they are sunsetting JCenter.”](https://stackoverflow.com/a/70689801/2257664)
- https://blog.gradle.org/jcenter-shutdown

# How
.

# Test Plan

.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
