### PR TITLE
[updates] Fix app.manifest missing from AGP 7.1 on Android

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fixed `source-login-scripts.sh` ~/zlogin typo. ([#17622](https://github.com/expo/expo/pull/17622) by [@vrgimael](https://github.com/vrgimael))
 - Android: Fix asset hash storage. ([#17732](https://github.com/expo/expo/pull/17732) by [@wschurman](https://github.com/wschurman))
 - Validate asset hash against expected hash before writing file to disk. ([#17745](https://github.com/expo/expo/pull/17745) by [@wschurman](https://github.com/wschurman))
+- Fixed missing `app.manifest` on react-native 0.69 or Android Gradle Plugin 7.1+. ([#18034](https://github.com/expo/expo/pull/18034) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-updates/scripts/create-manifest-android.gradle
+++ b/packages/expo-updates/scripts/create-manifest-android.gradle
@@ -73,13 +73,18 @@ def setupClosure = {
         from(assetsDir)
       }
 
-      // Workaround for Android Gradle Plugin 3.2+ new asset directory
+      // Workaround for Android Gradle Plugin 3.2+ asset directory
       into ("merged_assets/${variant.name}/merge${targetName}Assets/out") {
         from(assetsDir)
       }
 
-      // Workaround for Android Gradle Plugin 3.4+ new asset directory
+      // Workaround for Android Gradle Plugin 3.4+ asset directory
       into ("merged_assets/${variant.name}/out") {
+        from(assetsDir)
+      }
+
+      // Workaround for Android Gradle Plugin 7.1+ asset directory
+      into ("assets/${variant.name}/merge${targetName}Assets") {
         from(assetsDir)
       }
 


### PR DESCRIPTION
# Why

updates e2e test failed from app crash where app.manifest is missing. AGP is bumped to 7.1 on react-native 0.69 and the intermediate asset output is changed. the app.manifest doesn't copy to correct place.

# How

add the intermediate asset output for AGP 7.1

# Test Plan

updates e2e ci passed

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
