### PR TITLE
[expo-updates] fix proguard in Android builds

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Validate asset hash against expected hash before writing file to disk. ([#17745](https://github.com/expo/expo/pull/17745) by [@wschurman](https://github.com/wschurman))
 - Fixed missing `app.manifest` on react-native 0.69 or Android Gradle Plugin 7.1+. ([#18034](https://github.com/expo/expo/pull/18034) by [@kudo](https://github.com/kudo))
 - Suppress EXUpdatesService load in Expo Go to prevent crash. ([#18056](https://github.com/expo/expo/pull/18056) by [@douglowder](https://github.com/douglowder))
+- Fix proguard support in Android builds. ([#18035](https://github.com/expo/expo/pull/18035) by [@esamelson](https://github.com/esamelson))
 
 ### 💡 Others
 

--- a/packages/expo-updates/android/proguard-rules.pro
+++ b/packages/expo-updates/android/proguard-rules.pro
@@ -1,3 +1,7 @@
 -keepclassmembers class com.facebook.react.ReactInstanceManager {
   private final com.facebook.react.bridge.JSBundleLoader mBundleLoader;
 }
+
+-keepclassmembers class com.facebook.react.devsupport.DisabledDevSupportManager {
+  private final com.facebook.react.bridge.DefaultNativeModuleCallExceptionHandler mDefaultNativeModuleCallExceptionHandler;
+}

--- a/packages/expo-updates/e2e/__tests__/setup/project.js
+++ b/packages/expo-updates/e2e/__tests__/setup/project.js
@@ -115,6 +115,13 @@ async function setupAsync(workingDir, repoRoot, runtimeVersion) {
     }
   );
 
+  // enable proguard on Android
+  await fs.appendFile(
+    path.join(projectRoot, 'android', 'gradle.properties'),
+    '\nandroid.enableProguardInReleaseBuilds=true',
+    'utf-8'
+  );
+
   // copy App.js from test fixtures
   const appJsSourcePath = path.resolve(__dirname, '..', 'fixtures', 'App.js');
   const appJsDestinationPath = path.resolve(projectRoot, 'App.js');


### PR DESCRIPTION
# Why

Proguard support is broken in expo-updates, see https://github.com/expo/expo/issues/18002

# How

- add proguard rule to keep class member `DisabledDevSupportManager.mDefaultNativeModuleCallExceptionHandler`, which is used by reflection added in https://github.com/expo/expo/commit/219b799486fe10325a6513dc595fafca099391dd
- `grep -rn "getDeclaredField" packages/expo-updates/android` to ensure no other proguard rules need to be added

# Test Plan

Enable proguard in e2e tests, verify that it breaks the tests without this change (first commit) and the new proguard rule fixes the tests (second commit)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
