### PR TITLE
[android][clipboard] Use Sweet API coroutines

### DIFF
--- a/packages/expo-clipboard/CHANGELOG.md
+++ b/packages/expo-clipboard/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 💡 Others
 
 - Migrated Expo modules definitions to the new naming convention. ([#17193](https://github.com/expo/expo/pull/17193) by [@tsapeta](https://github.com/tsapeta))
+- Migrated Android module to use Sweet API coroutines.
 
 ## 3.0.1 — 2022-04-20
 

--- a/packages/expo-clipboard/CHANGELOG.md
+++ b/packages/expo-clipboard/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### 💡 Others
 
 - Migrated Expo modules definitions to the new naming convention. ([#17193](https://github.com/expo/expo/pull/17193) by [@tsapeta](https://github.com/tsapeta))
-- Migrated Android module to use Sweet API coroutines.
+- Migrated Android module to use Sweet API coroutines. ([#18036](https://github.com/expo/expo/pull/18036) by [@barthap](https://github.com/barthap))
 
 ## 3.0.1 — 2022-04-20
 

--- a/packages/expo-clipboard/android/src/main/java/expo/modules/clipboard/ClipboardModule.kt
+++ b/packages/expo-clipboard/android/src/main/java/expo/modules/clipboard/ClipboardModule.kt
@@ -78,8 +78,8 @@ class ClipboardModule : Module() {
       try {
         val imageResult = imageFromContentUri(context, imageUri, options)
         return@SuspendBody imageResult.toBundle()
-      } catch(err: Throwable) {
-        throw when(err) {
+      } catch (err: Throwable) {
+        throw when (err) {
           is CodedException -> err
           is SecurityException -> NoPermissionException(err)
           else -> PasteFailureException(err, kind = "image")

--- a/packages/expo-clipboard/android/src/main/java/expo/modules/clipboard/ClipboardModule.kt
+++ b/packages/expo-clipboard/android/src/main/java/expo/modules/clipboard/ClipboardModule.kt
@@ -13,6 +13,7 @@ import android.util.Log
 import androidx.core.os.bundleOf
 import expo.modules.core.utilities.ifNull
 import expo.modules.kotlin.exception.CodedException
+import expo.modules.kotlin.functions.Coroutine
 
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
@@ -66,19 +67,20 @@ class ClipboardModule : Module() {
     // endregion
 
     // region Images
-    AsyncFunction("getImageAsync").SuspendBody { options: GetImageOptions ->
+    AsyncFunction("getImageAsync") Coroutine { options: GetImageOptions ->
       val imageUri = clipboardManager
         .takeIf { clipboardHasItemWithType("image/*") }
         ?.firstItem
         ?.uri
         .ifNull {
-          return@SuspendBody null
+          return@Coroutine null
         }
 
       try {
         val imageResult = imageFromContentUri(context, imageUri, options)
-        return@SuspendBody imageResult.toBundle()
+        return@Coroutine imageResult.toBundle()
       } catch (err: Throwable) {
+        err.printStackTrace()
         throw when (err) {
           is CodedException -> err
           is SecurityException -> NoPermissionException(err)
@@ -87,11 +89,12 @@ class ClipboardModule : Module() {
       }
     }
 
-    AsyncFunction("setImageAsync").SuspendBody { imageData: String ->
+    AsyncFunction("setImageAsync") Coroutine { imageData: String ->
       try {
         val clip = clipDataFromBase64Image(context, imageData, clipboardCacheDir)
         clipboardManager.setPrimaryClip(clip)
       } catch (err: Throwable) {
+        err.printStackTrace()
         throw when (err) {
           is CodedException -> err
           else -> CopyFailureException(err, kind = "image")


### PR DESCRIPTION
# Why

Sweet API now supports coroutines, but expo-clipboard was still using its own implementation.

# How

Used `AsyncFunction().SuspendBody { }` and removed clipboard `moduleCoroutineScope`. Modified error handling to be try-catch.

# Test Plan

- NCL
- Test suite
- Tried to unit test, but we don't support unit testing coroutine functions yet.
