### PR TITLE
[netifo][iOS][Android] Upgrade `@react-native-community/netinfo` from `8.2.0` to `9.3.0`

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/netinfo/ConnectivityReceiver.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/netinfo/ConnectivityReceiver.java
@@ -268,6 +268,37 @@ public abstract class ConnectivityReceiver {
                         } catch (Exception e) {
                             // Ignore errors
                         }
+
+                        // Get the link speed
+                        try {
+                            int linkSpeed =
+                                    wifiInfo.getLinkSpeed();
+                            details.putInt("linkSpeed", linkSpeed);
+                        } catch (Exception e) {
+                            // Ignore errors
+                        }
+
+                        // Get the current receive link speed in Mbps
+                        try {
+                            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
+                                int rxLinkSpeed =
+                                        wifiInfo.getRxLinkSpeedMbps();
+                                details.putInt("rxLinkSpeed", rxLinkSpeed);
+                            }
+                        } catch (Exception e) {
+                            // Ignore errors
+                        }
+
+                        // Get the current transmit link speed in Mbps
+                        try {
+                            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
+                                int txLinkSpeed =
+                                        wifiInfo.getTxLinkSpeedMbps();
+                                details.putInt("txLinkSpeed", txLinkSpeed);
+                            }
+                        } catch (Exception e) {
+                            // Ignore errors
+                        }
                     }
                 }
                 break;

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -93,7 +93,7 @@
     "@babel/runtime": "^7.14.0",
     "@react-native-async-storage/async-storage": "~1.17.3",
     "@react-native-community/datetimepicker": "6.1.2",
-    "@react-native-community/netinfo": "8.2.0",
+    "@react-native-community/netinfo": "9.3.0",
     "@react-native-community/slider": "4.2.1",
     "@react-native-community/viewpager": "5.0.11",
     "@react-native-masked-view/masked-view": "0.2.6",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -43,7 +43,7 @@
     "@expo/react-native-action-sheet": "^3.8.0",
     "@react-native-async-storage/async-storage": "~1.17.3",
     "@react-native-community/datetimepicker": "6.1.2",
-    "@react-native-community/netinfo": "8.2.0",
+    "@react-native-community/netinfo": "9.3.0",
     "@react-native-community/slider": "4.2.1",
     "@react-native-masked-view/masked-view": "0.2.6",
     "@react-native-picker/picker": "2.4.0",

--- a/home/package.json
+++ b/home/package.json
@@ -23,7 +23,7 @@
     "@expo/vector-icons": "^13.0.0",
     "@graphql-codegen/introspection": "^2.1.1",
     "@react-native-async-storage/async-storage": "~1.17.3",
-    "@react-native-community/netinfo": "8.2.0",
+    "@react-native-community/netinfo": "9.3.0",
     "@react-navigation/bottom-tabs": "~5.11.1",
     "@react-navigation/material-bottom-tabs": "~5.3.9",
     "@react-navigation/native": "~5.8.9",

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2417,7 +2417,7 @@ PODS:
   - React-jsinspector (0.69.1)
   - React-logger (0.69.1):
     - glog
-  - react-native-netinfo (8.2.0):
+  - react-native-netinfo (9.3.0):
     - React-Core
   - react-native-pager-view (5.4.15):
     - React-Core
@@ -4428,7 +4428,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 758e70947c232828a66b5ddc42d02b4d010fa26e
   React-jsinspector: 55605caf04e02f9b0e05842b786f1c12dde08f4b
   React-logger: ca970551cb7eea2fd814d0d5f6fc1a471eb53b76
-  react-native-netinfo: e922cb2e3eaf9ccdf16b8d4744a89657377aa4a1
+  react-native-netinfo: 129bd99f607a2dc5bb096168f3e5c150fd1f1c95
   react-native-pager-view: b1914469643f40042e65d78cbf3d3dfebd6fb0d9
   react-native-safe-area-context: f98b0b16d1546d208fc293b4661e3f81a895afd9
   react-native-segmented-control: 06607462630512ff8eef652ec560e6235a30cc3e

--- a/ios/vendored/unversioned/@react-native-community/netinfo/react-native-netinfo.podspec.json
+++ b/ios/vendored/unversioned/@react-native-community/netinfo/react-native-netinfo.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-netinfo",
-  "version": "8.2.0",
+  "version": "9.3.0",
   "summary": "React Native Network Info API for iOS & Android",
   "license": "MIT",
   "authors": "Matt Oakes <hello@mattoakes.net>",
@@ -12,7 +12,7 @@
   },
   "source": {
     "git": "https://github.com/react-native-community/react-native-netinfo.git",
-    "tag": "v8.2.0"
+    "tag": "v9.3.0"
   },
   "source_files": "ios/**/*.{h,m}",
   "dependencies": {

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -3,7 +3,7 @@
   "@react-native-async-storage/async-storage": "~1.17.3",
   "@react-native-community/datetimepicker": "6.1.2",
   "@react-native-masked-view/masked-view": "0.2.6",
-  "@react-native-community/netinfo": "8.2.0",
+  "@react-native-community/netinfo": "9.3.0",
   "@react-native-community/slider": "4.2.1",
   "@react-native-community/viewpager": "5.0.11",
   "@react-native-picker/picker": "2.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3204,10 +3204,10 @@
   dependencies:
     invariant "^2.2.4"
 
-"@react-native-community/netinfo@8.2.0":
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-8.2.0.tgz#0bcf2b618c3b0ab72bb5529df3e580af9e6ae96b"
-  integrity sha512-mPMg9Uu2XeMX3tainvCWLhD9FZtdox3fcbPXJINuyFNgEQ2AUhGcoUT1dUpcFZrY4eXYiO9cckPhPHq9lWzSAA==
+"@react-native-community/netinfo@9.3.0":
+  version "9.3.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-9.3.0.tgz#9792c23341eab5c629566baee016146f4f3f6086"
+  integrity sha512-NNdMeIXXqmPCbXrWxVqRzZ1gEZ6L1ykotWnCZLVjQBUgjyGWdL5LiDM/bcIa5DLzqZY7Km08rMgB7BoHUuEmnQ==
 
 "@react-native-community/slider@4.2.1":
   version "4.2.1"


### PR DESCRIPTION
# Why

Closes ENG-5508.

# How

Run:
```
et uvm --module "@react-native-community/netinfo" --commit "v9.3.0" --target "expo-go"
```

# Test Plan

- iOS:
  - NCL
![Screenshot 2022-06-30 at 13 51 10](https://user-images.githubusercontent.com/9578601/176671579-19558919-b33c-48e8-acb6-7568b1b052ba.png)
  - Home ✅
- Android:
  - NCL ✅  
![image](https://user-images.githubusercontent.com/9578601/176715297-36447784-4607-46ff-ba26-aba5ef720a1c.png) 
  - Home ✅
