### PR TITLE
[go][iOS][Android] Upgrade `react-native-view-shot` from `3.1.2` to `3.3.0`

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/viewshot/RNViewShotModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/viewshot/RNViewShotModule.java
@@ -87,12 +87,13 @@ public class RNViewShotModule extends ReactContextBaseJavaModule {
         final Integer scaleWidth = options.hasKey("width") ? (int) (dm.density * options.getDouble("width")) : null;
         final Integer scaleHeight = options.hasKey("height") ? (int) (dm.density * options.getDouble("height")) : null;
         final String resultStreamFormat = options.getString("result");
+        final String fileName = options.hasKey("fileName") ? options.getString("fileName") : null;
         final Boolean snapshotContentContainer = options.getBoolean("snapshotContentContainer");
 
         try {
             File outputFile = null;
             if (Results.TEMP_FILE.equals(resultStreamFormat)) {
-                outputFile = createTempFile(mScopedContext, extension);
+                outputFile = createTempFile(mScopedContext, extension, fileName);
             }
 
             final Activity activity = getCurrentActivity();
@@ -166,7 +167,7 @@ public class RNViewShotModule extends ReactContextBaseJavaModule {
      * whichever is available and has more free space.
      */
     @NonNull
-    private File createTempFile(@NonNull final Context context, @NonNull final String ext) throws IOException {
+    private File createTempFile(@NonNull final Context context, @NonNull final String ext, String fileName) throws IOException {
         final File externalCacheDir = context.getExternalCacheDir();
         final File internalCacheDir = context.getCacheDir();
         final File cacheDir;
@@ -185,6 +186,9 @@ public class RNViewShotModule extends ReactContextBaseJavaModule {
         }
 
         final String suffix = "." + ext;
+        if (fileName != null) {
+            return File.createTempFile(fileName, suffix, cacheDir);
+        }
         return File.createTempFile(TEMP_FILE_PREFIX, suffix, cacheDir);
     }
 }

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -118,7 +118,7 @@
     "react-native-screens": "~3.11.1",
     "react-native-shared-element": "0.8.4",
     "react-native-svg": "12.3.0",
-    "react-native-view-shot": "3.1.2",
+    "react-native-view-shot": "3.3.0",
     "react-native-webview": "11.18.1",
     "test-suite": "*"
   },

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -159,7 +159,7 @@
     "react-native-screens": "~3.11.1",
     "react-native-shared-element": "0.8.4",
     "react-native-svg": "12.3.0",
-    "react-native-view-shot": "3.1.2",
+    "react-native-view-shot": "3.3.0",
     "react-native-web": "~0.18.1",
     "react-native-webview": "11.18.1",
     "react-navigation": "^4.4.0",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -104,7 +104,7 @@
   "react-native-screens": "~3.11.1",
   "react-native-shared-element": "0.8.4",
   "react-native-svg": "12.3.0",
-  "react-native-view-shot": "3.1.2",
+  "react-native-view-shot": "3.3.0",
   "react-native-webview": "11.18.1",
   "sentry-expo": "^4.0.0",
   "unimodules-app-loader": "~3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17131,10 +17131,10 @@ react-native-svg@12.3.0:
     css-select "^4.2.1"
     css-tree "^1.0.0-alpha.39"
 
-react-native-view-shot@3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/react-native-view-shot/-/react-native-view-shot-3.1.2.tgz#8c8e84c67a4bc8b603e697dbbd59dbc9b4f84825"
-  integrity sha512-9u9fPtp6a52UMoZ/UCPrCjKZk8tnkI9To0Eh6yYnLKFEGkRZ7Chm6DqwDJbYJHeZrheCCopaD5oEOnRqhF4L2Q==
+react-native-view-shot@3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/react-native-view-shot/-/react-native-view-shot-3.3.0.tgz#7f0c6d2e09e5af770f5b74231a72625b379d60f8"
+  integrity sha512-dc3ZHCd0lvn1jtSI8bPQDta8YxzCvZ73vA8zzFH4S3TRlXLe8r5DF3wUUBlWv1p/bxbEa/A0J4kMUPeVt/v8TQ==
 
 react-native-web@~0.18.1:
   version "0.18.2"


### PR DESCRIPTION
# Why

Closes ENG-5506.

# How

Run
```
et uvm --module "react-native-view-shot" --commit "v3.3.0" --target "expo-go"
```
This module is scoped in expo go, so I had to adjust how the module is installed. 


# Test Plan

- iOS:
  - NCL ✅
![Screenshot 2022-06-30 at 14 37 58](https://user-images.githubusercontent.com/9578601/176680070-7a82b89f-a931-4300-af0b-06aee3b468c7.png)
- Android
  - NCL ✅
![image](https://user-images.githubusercontent.com/9578601/176714623-e782045a-30dd-4086-8684-b0bcf297b4b2.png)

