### PR TITLE
[go][iOS][Android] Upgrade `react-native-reanimated@2.8.0 ➡️ 2.9.0`

### DIFF
--- a/android/expoview/src/main/Common/cpp/Tools/RuntimeDecorator.cpp
+++ b/android/expoview/src/main/Common/cpp/Tools/RuntimeDecorator.cpp
@@ -71,21 +71,27 @@ void RuntimeDecorator::decorateRuntime(
           1,
           setGlobalConsole));
 
+  auto chronoNow = [](jsi::Runtime &rt,
+                      const jsi::Value &thisValue,
+                      const jsi::Value *args,
+                      size_t count) -> jsi::Value {
+    double now = std::chrono::system_clock::now().time_since_epoch() /
+        std::chrono::milliseconds(1);
+    return jsi::Value(now);
+  };
+
   rt.global().setProperty(
       rt,
       "_chronoNow",
       jsi::Function::createFromHostFunction(
-          rt,
-          jsi::PropNameID::forAscii(rt, "_chronoNow"),
-          0,
-          [](jsi::Runtime &rt,
-             const jsi::Value &thisValue,
-             const jsi::Value *args,
-             size_t count) -> jsi::Value {
-            double now = std::chrono::system_clock::now().time_since_epoch() /
-                std::chrono::milliseconds(1);
-            return jsi::Value(now);
-          }));
+          rt, jsi::PropNameID::forAscii(rt, "_chronoNow"), 0, chronoNow));
+  jsi::Object performance(rt);
+  performance.setProperty(
+      rt,
+      "now",
+      jsi::Function::createFromHostFunction(
+          rt, jsi::PropNameID::forAscii(rt, "now"), 0, chronoNow));
+  rt.global().setProperty(rt, "performance", performance);
 }
 
 void RuntimeDecorator::decorateUIRuntime(

--- a/android/expoview/src/main/cpp/headers/NativeProxy.h
+++ b/android/expoview/src/main/cpp/headers/NativeProxy.h
@@ -131,7 +131,7 @@ class NativeProxy : public jni::HybridClass<NativeProxy> {
       jni::alias_ref<LayoutAnimations::javaobject> layoutAnimations);
   static void registerNatives();
 
- ~NativeProxy();
+  ~NativeProxy();
 
  private:
   friend HybridBase;

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/reanimated/sensor/ReanimatedSensorType.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/reanimated/sensor/ReanimatedSensorType.java
@@ -1,11 +1,13 @@
 package versioned.host.exp.exponent.modules.api.reanimated.sensor;
 
+import android.hardware.Sensor;
+
 public enum ReanimatedSensorType {
-  ACCELEROMETER(1),
-  GYROSCOPE(2),
-  GRAVITY(3),
-  MAGNETIC_FIELD(4),
-  ROTATION_VECTOR(5);
+  ACCELEROMETER(Sensor.TYPE_ACCELEROMETER),
+  GYROSCOPE(Sensor.TYPE_GYROSCOPE),
+  GRAVITY(Sensor.TYPE_GRAVITY),
+  MAGNETIC_FIELD(Sensor.TYPE_MAGNETIC_FIELD),
+  ROTATION_VECTOR(Sensor.TYPE_ROTATION_VECTOR);
 
   private final int type;
 

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -113,7 +113,7 @@
     "react-dom": "18.0.0",
     "react-native": "0.69.1",
     "react-native-gesture-handler": "~2.5.0",
-    "react-native-reanimated": "~3.0.0-rc.0",
+    "react-native-reanimated": "~2.9.0",
     "react-native-safe-area-context": "4.2.4",
     "react-native-screens": "~3.11.1",
     "react-native-shared-element": "0.8.4",

--- a/apps/bare-sandbox/package.json
+++ b/apps/bare-sandbox/package.json
@@ -19,7 +19,7 @@
     "react-dom": "18.0.0",
     "react-native": "0.69.1",
     "react-native-gesture-handler": "~2.5.0",
-    "react-native-reanimated": "~3.0.0-rc.0",
+    "react-native-reanimated": "~2.9.0",
     "react-native-screens": "~3.11.1",
     "react-native-web": "~0.18.1"
   },

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -152,7 +152,7 @@
     "react-native-maps": "0.30.2",
     "react-native-pager-view": "5.4.15",
     "react-native-paper": "^4.0.1",
-    "react-native-reanimated": "~3.0.0-rc.0",
+    "react-native-reanimated": "~2.9.0",
     "react-native-redash": "^14.1.1",
     "react-native-safe-area-context": "4.2.4",
     "react-native-safe-area-view": "^0.14.8",

--- a/home/package.json
+++ b/home/package.json
@@ -61,7 +61,7 @@
     "react-native-keyboard-aware-scroll-view": "^0.9.5",
     "react-native-maps": "0.30.2",
     "react-native-paper": "^4.0.1",
-    "react-native-reanimated": "~3.0.0-rc.0",
+    "react-native-reanimated": "~2.9.0",
     "react-native-safe-area-context": "4.2.4",
     "react-native-screens": "~3.11.1",
     "react-redux": "^7.2.0",

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2530,7 +2530,7 @@ PODS:
     - ReactCommon/turbomodule/core (= 0.69.1)
   - RNGestureHandler (2.2.0):
     - React-Core
-  - RNReanimated (2.8.0):
+  - RNReanimated (2.9.0):
     - DoubleConversion
     - FBLazyVector
     - FBReactNativeSpec
@@ -4446,7 +4446,7 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: 27f468c5576eaf05ffb7a907528e44c75a3fcbae
   ReactCommon: e30ec17dfb1d4c4f3419eac254350d6abca6d5a2
   RNGestureHandler: bf572f552ea324acd5b5464b8d30755b2d8c1de6
-  RNReanimated: 64573e25e078ae6bec03b891586d50b9ec284393
+  RNReanimated: f8544cbf23b39b63bb2adb378d66dd11735662bd
   RNScreens: 4d83613b50b74ed277026375dc0810893b0c347f
   Stripe: ee32e594fa4dee4bdf2a8a3039f7fb07a21075dc
   stripe-react-native: bd992665f71c5233d62719c4031351f3f3b769fe

--- a/ios/vendored/unversioned/react-native-reanimated/Common/cpp/Tools/RuntimeDecorator.cpp
+++ b/ios/vendored/unversioned/react-native-reanimated/Common/cpp/Tools/RuntimeDecorator.cpp
@@ -71,21 +71,27 @@ void RuntimeDecorator::decorateRuntime(
           1,
           setGlobalConsole));
 
+  auto chronoNow = [](jsi::Runtime &rt,
+                      const jsi::Value &thisValue,
+                      const jsi::Value *args,
+                      size_t count) -> jsi::Value {
+    double now = std::chrono::system_clock::now().time_since_epoch() /
+        std::chrono::milliseconds(1);
+    return jsi::Value(now);
+  };
+
   rt.global().setProperty(
       rt,
       "_chronoNow",
       jsi::Function::createFromHostFunction(
-          rt,
-          jsi::PropNameID::forAscii(rt, "_chronoNow"),
-          0,
-          [](jsi::Runtime &rt,
-             const jsi::Value &thisValue,
-             const jsi::Value *args,
-             size_t count) -> jsi::Value {
-            double now = std::chrono::system_clock::now().time_since_epoch() /
-                std::chrono::milliseconds(1);
-            return jsi::Value(now);
-          }));
+          rt, jsi::PropNameID::forAscii(rt, "_chronoNow"), 0, chronoNow));
+  jsi::Object performance(rt);
+  performance.setProperty(
+      rt,
+      "now",
+      jsi::Function::createFromHostFunction(
+          rt, jsi::PropNameID::forAscii(rt, "now"), 0, chronoNow));
+  rt.global().setProperty(rt, "performance", performance);
 }
 
 void RuntimeDecorator::decorateUIRuntime(

--- a/ios/vendored/unversioned/react-native-reanimated/RNReanimated.podspec.json
+++ b/ios/vendored/unversioned/react-native-reanimated/RNReanimated.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "RNReanimated",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "summary": "More powerful alternative to Animated library for React Native.",
   "description": "RNReanimated",
   "homepage": "https://github.com/software-mansion/react-native-reanimated",
@@ -14,7 +14,7 @@
   },
   "source": {
     "git": "https://github.com/software-mansion/react-native-reanimated.git",
-    "tag": "2.8.0"
+    "tag": "2.9.0"
   },
   "source_files": [
     "ios/**/*.{mm,h,m}",

--- a/ios/vendored/unversioned/react-native-reanimated/ios/native/REAInitializer.mm
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/native/REAInitializer.mm
@@ -54,6 +54,7 @@ JSIExecutor::RuntimeInstaller REAJSIExecutorRuntimeInstaller(
     uintptr_t* workletRuntimeData = reinterpret_cast<uintptr_t*>(
         workletRuntimeValue.getObject(runtime).getArrayBuffer(runtime).data(runtime));
     workletRuntimeData[0] = reinterpret_cast<uintptr_t>(reanimatedModule->runtime.get());
+
     runtime.global().setProperty(
         runtime,
         "_WORKLET_RUNTIME",

--- a/ios/vendored/unversioned/react-native-reanimated/ios/sensor/ReanimatedSensor.m
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/sensor/ReanimatedSensor.m
@@ -141,9 +141,9 @@
                                                         attitude.quaternion.y,
                                                         attitude.quaternion.z,
                                                         attitude.quaternion.w,
-                                                        attitude.pitch,
-                                                        attitude.roll,
                                                         attitude.yaw,
+                                                        attitude.pitch,
+                                                        attitude.roll
                                                     };
                                                     self->_setter(data);
                                                     self->_lastTimestamp = currentTime;

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -99,7 +99,7 @@
   "react-native-get-random-values": "~1.8.0",
   "react-native-maps": "0.30.2",
   "react-native-pager-view": "5.4.15",
-  "react-native-reanimated": "~2.8.0",
+  "react-native-reanimated": "~2.9.0",
   "react-native-safe-area-context": "4.2.4",
   "react-native-screens": "~3.11.1",
   "react-native-shared-element": "0.8.4",


### PR DESCRIPTION
# Why

Resolves [ENG-5515](https://linear.app/expo/issue/ENG-5515/react-native-reanimated-280-%E2%9E%A1%EF%B8%8F-290)

# How

1. `et uvm --module "react-native-reanimated" --commit "2.9.0" --target "expo-go"`

# Test Plan (In progress)

- [ ] On Android:
    - [ ] Expo Go (unversioned) compiles and runs
    - [ ] example screens from ncl works
- [ ] On iOS:
    - [ ] Expo Go (unversioned) compiles and runs
    - [ ] example screens from ncl works
    
# TODOs after merge:

- [ ] update example screens to catch up with the official `example` app functionalities (https://github.com/software-mansion/react-native-reanimated/tree/main/Example)   