### PR TITLE
[expo-updates][iOS] Fix crash in Expo Go

### DIFF
--- a/ios/Exponent/Kernel/Views/EXAppViewController.m
+++ b/ios/Exponent/Kernel/Views/EXAppViewController.m
@@ -65,7 +65,7 @@ NS_ASSUME_NONNULL_BEGIN
   <EXReactAppManagerUIDelegate, EXAppLoaderDelegate, EXErrorViewDelegate, EXAppLoadingCancelViewDelegate>
 
 @property (nonatomic, assign) BOOL isLoading;
-@property (nonatomic, assign) BOOL isBridgeAlreadyLoading;
+@property (atomic, assign) BOOL isBridgeAlreadyLoading;
 @property (nonatomic, weak) EXKernelAppRecord *appRecord;
 @property (nonatomic, strong) EXErrorView *errorView;
 @property (nonatomic, strong) NSTimer *tmrAutoReloadDebounce;

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -82,6 +82,13 @@ abstract_target 'Expo Go' do
         end
       end
 
+      if pod_name.end_with?('EXUpdates')
+        target_installation_result.native_target.build_configurations.each do |config|
+          config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)']
+          config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] << 'SUPPRESS_EXPO_UPDATES_SERVICE=1'
+        end
+      end
+
       # Build React Native with RCT_DEV enabled and RCT_ENABLE_INSPECTOR and
       # RCT_ENABLE_PACKAGER_CONNECTION disabled
       next unless pod_name.start_with?('React')

--- a/ios/versioned/sdk43/EXUpdates/EXUpdates/ABI43_0_0EXUpdatesService.m
+++ b/ios/versioned/sdk43/EXUpdates/EXUpdates/ABI43_0_0EXUpdatesService.m
@@ -13,11 +13,17 @@ ABI43_0_0EX_REGISTER_MODULE();
 
 + (const NSArray<Protocol *> *)exportedInterfaces
 {
+#if SUPPRESS_EXPO_UPDATES_SERVICE // used in Expo Go
+  return @[];
+#endif
   return @[@protocol(ABI43_0_0EXUpdatesModuleInterface)];
 }
 
 - (ABI43_0_0EXUpdatesConfig *)config
 {
+#if SUPPRESS_EXPO_UPDATES_SERVICE // used in Expo Go
+  return nil;
+#endif
   return ABI43_0_0EXUpdatesAppController.sharedInstance.config;
 }
 

--- a/ios/versioned/sdk44/EXUpdates/EXUpdates/ABI44_0_0EXUpdatesService.m
+++ b/ios/versioned/sdk44/EXUpdates/EXUpdates/ABI44_0_0EXUpdatesService.m
@@ -13,11 +13,17 @@ ABI44_0_0EX_REGISTER_MODULE();
 
 + (const NSArray<Protocol *> *)exportedInterfaces
 {
+#if SUPPRESS_EXPO_UPDATES_SERVICE // used in Expo Go
+  return @[];
+#endif
   return @[@protocol(ABI44_0_0EXUpdatesModuleInterface)];
 }
 
 - (ABI44_0_0EXUpdatesConfig *)config
 {
+#if SUPPRESS_EXPO_UPDATES_SERVICE // used in Expo Go
+  return nil;
+#endif
   return ABI44_0_0EXUpdatesAppController.sharedInstance.config;
 }
 

--- a/ios/versioned/sdk45/EXUpdates/EXUpdates/ABI45_0_0EXUpdatesService.m
+++ b/ios/versioned/sdk45/EXUpdates/EXUpdates/ABI45_0_0EXUpdatesService.m
@@ -13,11 +13,17 @@ ABI45_0_0EX_REGISTER_MODULE();
 
 + (const NSArray<Protocol *> *)exportedInterfaces
 {
+#if SUPPRESS_EXPO_UPDATES_SERVICE // used in Expo Go
+  return @[];
+#endif
   return @[@protocol(ABI45_0_0EXUpdatesModuleInterface)];
 }
 
 - (ABI45_0_0EXUpdatesConfig *)config
 {
+#if SUPPRESS_EXPO_UPDATES_SERVICE // used in Expo Go
+  return nil;
+#endif
   return ABI45_0_0EXUpdatesAppController.sharedInstance.config;
 }
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Android: Fix asset hash storage. ([#17732](https://github.com/expo/expo/pull/17732) by [@wschurman](https://github.com/wschurman))
 - Validate asset hash against expected hash before writing file to disk. ([#17745](https://github.com/expo/expo/pull/17745) by [@wschurman](https://github.com/wschurman))
 - Fixed missing `app.manifest` on react-native 0.69 or Android Gradle Plugin 7.1+. ([#18034](https://github.com/expo/expo/pull/18034) by [@kudo](https://github.com/kudo))
+- Suppress EXUpdatesService load in Expo Go to prevent crash. ([#18056](https://github.com/expo/expo/pull/18056) by [@douglowder](https://github.com/douglowder))
 
 ### 💡 Others
 

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesService.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesService.m
@@ -13,11 +13,17 @@ EX_REGISTER_MODULE();
 
 + (const NSArray<Protocol *> *)exportedInterfaces
 {
+#if SUPPRESS_EXPO_UPDATES_SERVICE // used in Expo Go
+  return @[];
+#endif
   return @[@protocol(EXUpdatesModuleInterface)];
 }
 
 - (EXUpdatesConfig *)config
 {
+#if SUPPRESS_EXPO_UPDATES_SERVICE // used in Expo Go
+  return nil;
+#endif
   return EXUpdatesAppController.sharedInstance.config;
 }
 


### PR DESCRIPTION
# Why

Expo Go does not use the Expo.plist-dependent `EXUpdatesService` module, but relies on `EXUpdatesBinding`, which is loaded dynamically during the React Native module loading process.

Under some circumstances (e.g. repeated reloads of the app bundle when in debug mode), it is possible to create a situation where `EXUpdatesBinding` is initialized too late, and the reading of module constants during load invokes `EXUpdatesService.sharedInstance`, triggering a crash due to Expo.plist not being present.

# How

Add a new preprocessor definition (SUPPRESS_EXPO_UPDATES_SERVICE) to the Exponent Podfile `post_install()` step, and modify `EXUpdatesService` so that it does not export the updates interface when present in the Expo Go app. Behavior in other apps is unaffected.

# Test Plan

Manually tested to ensure that the crash is no longer reproducible, and that the Podfile `post_install` adds the new preprocessor definition only to vendored and unvendored EXUpdate modules.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
