### PR TITLE
[docs] Tutorial: Remove web references

### DIFF
--- a/docs/constants/navigation-deprecated.js
+++ b/docs/constants/navigation-deprecated.js
@@ -54,7 +54,7 @@ const starting = [
         makePage('tutorial/button.md'),
         makePage('tutorial/image-picker.md'),
         makePage('tutorial/sharing.md'),
-        makePage('tutorial/platform-differences.md'),
+        // makePage('tutorial/platform-differences.md'),
         makePage('tutorial/configuration.md'),
         makePage('tutorial/follow-up.md'),
       ]),

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -57,7 +57,7 @@ const starting = [
       makePage('tutorial/button.md'),
       makePage('tutorial/image-picker.md'),
       makePage('tutorial/sharing.md'),
-      makePage('tutorial/platform-differences.md'),
+      // makePage('tutorial/platform-differences.md'),
       makePage('tutorial/configuration.md'),
       makePage('tutorial/follow-up.md'),
     ],

--- a/docs/pages/tutorial/button.md
+++ b/docs/pages/tutorial/button.md
@@ -125,4 +125,4 @@ const styles = StyleSheet.create({
 
 > 📜 Yikes, these code snippets are getting long. For the rest of the tutorial we'll show only relevant code here, and you can click through to Snack to see the full code.
 
-- We have a button! We can now make that button do what we want it to do: open an "image picker" - a screen with a gallery of images on your device. [Continue to the next section](../tutorial/image-picker.md).
+- We have a button! We can now make that button do what we want it to do: open an "image picker" - a screen with a gallery of images on your device. [Continue to the next section](/tutorial/image-picker).

--- a/docs/pages/tutorial/configuration.md
+++ b/docs/pages/tutorial/configuration.md
@@ -11,7 +11,7 @@ Before we can consider our app truly complete we need to add a splash screen and
 
 ## Splash screen
 
-After telling our designers that we need a 1242px width by 2436px height splash screen image (more about this in [the splash screen guide](../guides/splash-screens.md)), they gave us the following file:
+After telling our designers that we need a 1242px width by 2436px height splash screen image (more about this in [the splash screen guide](/guides/splash-screens)), they gave us the following file:
 
 <ImageSpotlight src="/static/images/tutorial/splash.png" style={{ maxWidth: 150 }} containerStyle={{ marginBottom: 0 }} />
 
@@ -75,6 +75,6 @@ Save this image to the **assets** directory inside of your project and call it *
 
 ## We have completed our app!
 
-Well done, you have now gone through the motions of building a simple but meaningful app that runs on iOS, Android, and web from the same codebase! We hope that this tutorial has answered some of your questions and posed many more.
+Well done, you have now gone through the motions of building a simple but meaningful app that runs on iOS, and Android from the same codebase! We hope that this tutorial has answered some of your questions and posed many more.
 
-The next section of the tutorial will guide you towards resources to learn more about concepts we've covered here and others we have only mentioned in passing, like standalone apps. [Continue to find out how you can learn more](../tutorial/follow-up.md).
+The next section of the tutorial will guide you towards resources to learn more about concepts we've covered here and others we have only mentioned in passing, like standalone apps. [Continue to find out how you can learn more](/tutorial/follow-up).

--- a/docs/pages/tutorial/follow-up.md
+++ b/docs/pages/tutorial/follow-up.md
@@ -18,7 +18,7 @@ We used React components and APIs here with little explanation. Having a solid u
 
 ## async/await, import, and other JavaScript features
 
-Read about [Modern JavaScript on React Native Express](http://www.reactnativeexpress.com/modern_javascript).
+Read about [Modern JavaScript on React Native Express](https://www.reactnative.express/javascript/features).
 
 ### How to verify your learning
 
@@ -42,7 +42,7 @@ This is the way you position and size the components on your screen. Learn more 
 
 ## Configuring your app with app.json
 
-We covered the basic minimal configuration, but you learn more about customizing your [app icon](../guides/app-icons.md) and [splash screen](../guides/splash-screens.md) in their respective guides. Learn more about other properties you can configure in [app.json property reference](../workflow/configuration.md)
+We covered the basic minimal configuration, but you learn more about customizing your [app icon](/guides/app-icons) and [splash screen](/guides/splash-screens) in their respective guides. Learn more about other properties you can configure in [app.json property reference](/workflow/configuration).
 
 ### How to verify your Learning
 
@@ -54,7 +54,7 @@ We covered the basic minimal configuration, but you learn more about customizing
 
 ## Standalone apps & deployment
 
-How can you take what you have built and turn it into an app that you ship to the App Store and Play Store. Learn more about [distributing your app to stores](../distribution/introduction.md) and [deploying websites](../distribution/publishing-websites.md).
+How can you take what you have built and turn it into an app that you ship to the App Store and Play Store. Learn more about [distributing your app to stores](/distribution/introduction) and [deploying websites](/distribution/publishing-websites).
 
 ## Navigation
 
@@ -62,8 +62,8 @@ Most apps have multiple screens, we just have one here! Learn more about how to 
 
 ## Debugging
 
-Sometimes things go wrong, and when they do you need to use debugging tools to figure out where your code is having trouble. [Read more about debugging](../workflow/debugging.md).
+Sometimes things go wrong, and when they do you need to use debugging tools to figure out where your code is having trouble. [Read more about debugging](/workflow/debugging).
 
 ## Using the documentation
 
-[Read more about how you can navigate this documentation and use it effectively](../next-steps/using-the-documentation.md).
+[Read more about how you can navigate this documentation and use it effectively](/next-steps/using-the-documentation).

--- a/docs/pages/tutorial/image-picker.md
+++ b/docs/pages/tutorial/image-picker.md
@@ -6,7 +6,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 import Video from '~/components/plugins/Video';
 import { Terminal } from '~/ui/components/Snippet';
 
-So far we have been using code from React and React Native in our app. React gives us a nice way to build components and React Native gives us pre-built components that work on iOS, Android, and web &mdash; like `View`, `Text`, `TouchableOpacity`. React Native does _not_ provide us with an image picker. For this, we can use an Expo library called [expo-image-picker](../versions/latest/sdk/imagepicker.md):
+So far we have been using code from React and React Native in our app. React gives us a nice way to build components and React Native gives us pre-built components that work on iOS, and Android &mdash; like `View`, `Text`, `TouchableOpacity`. React Native does _not_ provide us with an image picker. For this, we can use an Expo library called [expo-image-picker](/versions/latest/sdk/imagepicker):
 
 > **`expo-image-picker`** provides access to the system's UI for selecting images and videos from the phone's library or taking a photo with the camera.
 
@@ -153,4 +153,4 @@ Your app should now look and behave like this:
 
 > 👀 You might expect that because we gave our image an equal width and height it would be a square, but in the above video it's rectangular. This is because of `resizeMode`, an image style property that lets us control how the image is resized to fit the given dimensions. Try switching it from `contain` to `stretch` or `cover` to see other behaviors.
 
-🥳 We have made great progress! Up next, [let's make it possible to share the image](../tutorial/sharing.md).
+🥳 We have made great progress! Up next, [let's make it possible to share the image](/tutorial/sharing).

--- a/docs/pages/tutorial/image-picker.md
+++ b/docs/pages/tutorial/image-picker.md
@@ -6,7 +6,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 import Video from '~/components/plugins/Video';
 import { Terminal } from '~/ui/components/Snippet';
 
-So far we have been using code from React and React Native in our app. React gives us a nice way to build components and React Native gives us pre-built components that work on iOS, and Android &mdash; like `View`, `Text`, `TouchableOpacity`. React Native does _not_ provide us with an image picker. For this, we can use an Expo library called [expo-image-picker](/versions/latest/sdk/imagepicker):
+So far we have been using code from React and React Native in our app. React gives us a nice way to build components and React Native gives us pre-built components that work on iOS, Android, and web &mdash; like `View`, `Text`, `TouchableOpacity`. React Native does _not_ provide us with an image picker. For this, we can use an Expo library called [expo-image-picker](/versions/latest/sdk/imagepicker):
 
 > **`expo-image-picker`** provides access to the system's UI for selecting images and videos from the phone's library or taking a photo with the camera.
 

--- a/docs/pages/tutorial/image.md
+++ b/docs/pages/tutorial/image.md
@@ -142,4 +142,4 @@ const styles = StyleSheet.create({
 
 You might notice that we also added some new styles here to make things look a bit prettier. We used `marginBottom` on the logo to space things out between the logo and the instructions, and we added `marginHorizontal` to give our instructions some spacing around the edges of the screen.
 
-Time to make things interactive. [Let's move on to creating a button](../tutorial/button.md).
+Time to make things interactive. [Let's move on to creating a button](/tutorial/button).

--- a/docs/pages/tutorial/planning.md
+++ b/docs/pages/tutorial/planning.md
@@ -2,16 +2,28 @@
 title: First steps
 ---
 
-In this tutorial we are going to build an app for iOS, Android, and web that allows you to share photos with your friends! Of course there are already plenty of apps that let you share photos from your phone, you just can't do it with _your own app_. Let's remedy that.
+import { Terminal } from '~/ui/components/Snippet';
+
+In this tutorial we are going to build an app for iOS, and Android that allows you to share photos with your friends! Of course there are already plenty of apps that let you share photos from your phone, you just can't do it with _your own app_. Let's remedy that.
 
 ## Before we get started
 
 - ✅ This tutorial assumes that you have installed Expo CLI and the Expo Go app, and that you have initialized and run a simple app successfully. If this is you, please continue reading this page!
-- 🛑 If you don't have a "Hello, world!" app running on your machine yet, please refer back to the ["Installation"](../get-started/installation.md) and ["Create a new app"](../get-started/create-a-new-app.md) guides.
+- 🛑 If you don't have a "Hello, world!" app running on your machine yet, please refer back to the ["Installation"](/get-started/installation) and ["Create a new app"](/get-started/create-a-new-app) guides.
 
 ## Initialize a new app
 
-Inside your preferred directory for storing your software projects, run `npx create-expo-app ImageShare` to create a new project for our app that we will call "Image Share". Navigate to the directory and run `expo start` in it, open the project on your device, and open the code in your code editor of choice.
+Inside your preferred directory for storing your software projects, run the command: 
 
-- ⬅️ If you have any trouble with this, please refer back to the ["Create a new app" page](../get-started/create-a-new-app.md).
-- ➡️ If your app is up and running, it is time to [continue to the next step](../tutorial/text.md).
+<Terminal cmd={[
+  '# Create a project named ImageShare',
+  '$ npx create-expo-app ImageShare',
+  '',
+  '# Navigate to the project directory',
+  '$ cd ImageShare'
+]} cmdCopy="npx create-expo-app ImageShare && cd ImageShare" />
+
+This will create a new project for the app that we will call "Image Share". Navigate to the directory and run `expo start` in it, open the project on your device, and open the code in your code editor of choice.
+
+- ⬅️ If you have any trouble with this, please refer back to the ["Create a new app" page](/get-started/create-a-new-app).
+- ➡️ If your app is up and running, it is time to [continue to the next step](/tutorial/text).

--- a/docs/pages/tutorial/sharing.md
+++ b/docs/pages/tutorial/sharing.md
@@ -35,8 +35,13 @@ export default function App() {
     setSelectedImage({ localUri: pickerResult.uri });
   };
 
-  /* @info Share the selected image on the user's device */
+  /* @info Share the selected image if sharing is available on the user's device */
   let openShareDialogAsync = async () => {    
+    if (Platform.OS === 'web') {
+      alert(`Uh oh, sharing isn't available on your platform`);
+      return;
+    }
+
     await Sharing.shareAsync(selectedImage.localUri);
   }; /* @end */
 
@@ -67,7 +72,32 @@ export default function App() {
 
 <Video file={"tutorial/sharing-native.mp4"} />
 
-🥰 Everything is working great! The operating system share dialog opens up and is ready to share our selected image so it's time to shift our focus towards the purely aesthetic. In the next step of this tutorial we will [customize our app icon and splash screen](/tutorial/configuration).
+🥰 Everything is working great! The operating system share dialog opens up and is ready to share our selected image. 
+
+## Platform differences on web
+
+<Video file={"tutorial/sharing-web-unavailable.mp4"} />
+
+On running the app in a web browser, when we hit "Share this photo" we see that our `alert` warns us that sharing is not available. This is happening because the desktop Chrome browser does not currently provide a way for users to share content.
+
+In the perfect world we want to write code to perform our task just once and have it run the same on every platform. Even on the web, where this is an explicit design goal, it's often necessary to consider differences between web browsers.
+
+Expo tools try to handle smoothing over these differences between iOS, Android, web (and different web browsers) for you, but it isn't always possible. There are two important differences between how the iOS and Android share APIs work and how the Web Share API works.
+
+- It isn't always available on web.
+- We can't share local file URIs on web.
+
+> It's actually technically possible in the latest versions of Chrome for Android to share files, but it's very new and not yet supported by `expo-sharing`, so we will ignore that here for now.
+
+<Collapsible summary="Want to learn more about why we can't use expo-sharing in Chrome?">
+
+Sharing didn't work here because the desktop Chrome browser doesn't yet implement the [Web Share API](https://web.dev/web-share/). _"But wait,"_ you say, _"aren't we using expo-sharing, not the Web Share API?"_ You can think of the Expo SDK libraries as translators for different platforms. They speak the language of Expo and turn it into the language of iOS, Android, and web. It isn't always possible to translate from Expo's language to the platform that you're working with. In other words, if the platform doesn't implement a feature, Expo can't tell it to invoke that feature. In some cases Expo can attempt to [polyfill](<https://en.wikipedia.org/wiki/Polyfill_(programming)>) the feature for you, but this isn't always possible. Invoking your operating system's built-in share dialog to share content with other applications needs to be implemented by the platform itself &mdash; Chrome in this case.
+
+</Collapsible>
+
+## Up next
+
+It's time to shift our focus towards the purely aesthetic. In the next step of this tutorial we will [customize our app icon and splash screen](/tutorial/configuration).
 
 <!-- TODO(brentvatne): when we have a better workflow for https in expo-cli and a way to open Snack web on mobile we should revisit this -->
 

--- a/docs/pages/tutorial/sharing.md
+++ b/docs/pages/tutorial/sharing.md
@@ -7,7 +7,7 @@ import Video from '~/components/plugins/Video';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 
-Similar to expo-image-picker, the functionality that we need to share is available in an Expo library &mdash; this one is called [expo-sharing](../versions/latest/sdk/sharing.md).
+Similar to expo-image-picker, the functionality that we need to share is available in an Expo library &mdash; this one is called [expo-sharing](/versions/latest/sdk/sharing).
 
 ## Installing expo-sharing
 
@@ -35,13 +35,8 @@ export default function App() {
     setSelectedImage({ localUri: pickerResult.uri });
   };
 
-  /* @info Share the selected image if sharing is available on the user's device */
-  let openShareDialogAsync = async () => {
-    if (Platform.OS === 'web') {
-      alert(`Uh oh, sharing isn't available on your platform`);
-      return;
-    }
-
+  /* @info Share the selected image on the user's device */
+  let openShareDialogAsync = async () => {    
     await Sharing.shareAsync(selectedImage.localUri);
   }; /* @end */
 
@@ -72,25 +67,7 @@ export default function App() {
 
 <Video file={"tutorial/sharing-native.mp4"} />
 
-🥰 Everything is working great! The operating system share dialog opens up and is ready to share our selected image.
-
-## Running the app on the web
-
-<!-- ### Using Google Chrome for desktop -->
-
-<Video file={"tutorial/sharing-web-unavailable.mp4"} />
-
-😱 Uh oh. When we hit "Share this photo" we see that our `alert` warns us that sharing is not available. This is happening because the desktop Chrome browser does not currently provide a way for users to share content.
-
-<Collapsible summary="Want to learn more about why we can't use expo-sharing in Chrome?">
-
-Sharing didn't work here because the desktop Chrome browser doesn't yet implement the [Web Share API](https://web.dev/web-share/). _"But wait,"_ you say, _"aren't we using expo-sharing, not the Web Share API?"_ You can think of the Expo SDK libraries as translators for different platforms. They speak the language of Expo and turn it into the language of iOS, Android, and web. It isn't always possible to translate from Expo's language to the platform that you're working with. In other words, if the platform doesn't implement a feature, Expo can't tell it to invoke that feature. In some cases Expo can attempt to [polyfill](<https://en.wikipedia.org/wiki/Polyfill_(programming)>) the feature for you, but this isn't always possible. Invoking your operating system's built-in share dialog to share content with other applications needs to be implemented by the platform itself &mdash; Chrome in this case.
-
-</Collapsible>
-
-## Working with what we have available
-
-In the next section we are going to look at how we can handle this and another important platform difference. [Continue to "Handling platform differences"](../tutorial/platform-differences.md).
+🥰 Everything is working great! The operating system share dialog opens up and is ready to share our selected image  so it's time to shift our focus towards the purely aesthetic. In the next step of this tutorial we will [customize our app icon and splash screen](/tutorial/configuration).
 
 <!-- TODO(brentvatne): when we have a better workflow for https in expo-cli and a way to open Snack web on mobile we should revisit this -->
 

--- a/docs/pages/tutorial/sharing.md
+++ b/docs/pages/tutorial/sharing.md
@@ -67,7 +67,7 @@ export default function App() {
 
 <Video file={"tutorial/sharing-native.mp4"} />
 
-🥰 Everything is working great! The operating system share dialog opens up and is ready to share our selected image  so it's time to shift our focus towards the purely aesthetic. In the next step of this tutorial we will [customize our app icon and splash screen](/tutorial/configuration).
+🥰 Everything is working great! The operating system share dialog opens up and is ready to share our selected image so it's time to shift our focus towards the purely aesthetic. In the next step of this tutorial we will [customize our app icon and splash screen](/tutorial/configuration).
 
 <!-- TODO(brentvatne): when we have a better workflow for https in expo-cli and a way to open Snack web on mobile we should revisit this -->
 

--- a/docs/pages/tutorial/sharing.md
+++ b/docs/pages/tutorial/sharing.md
@@ -74,7 +74,7 @@ export default function App() {
 
 🥰 Everything is working great! The operating system share dialog opens up and is ready to share our selected image. 
 
-## Platform differences on web
+## Platform differences with web
 
 <Video file={"tutorial/sharing-web-unavailable.mp4"} />
 

--- a/docs/pages/tutorial/text.md
+++ b/docs/pages/tutorial/text.md
@@ -44,7 +44,7 @@ const styles = StyleSheet.create({
 
 > 😳 **Wait, what is this "Try this example on Snack" button!?**
 >
-> Snack is a web-based editor that works similar to a managed Expo project. It's a great way to share code snippets with people and try things out without needing to get a project running on your own computer with `expo-cli`. Go ahead, press the button. You will see the above code running in it. Switch between iOS, or Android. Open it on your device in the Expo Go app by pressing the "Run" button.
+> Snack is a web-based editor that works similar to a managed Expo project. It's a great way to share code snippets with people and try things out without needing to get a project running on your own computer with `expo-cli`. Go ahead, press the button. You will see the above code running in it. Switch between iOS, Android, or web. Open it on your device in the Expo Go app by pressing the "Run" button.
 
 ## Adding style
 

--- a/docs/pages/tutorial/text.md
+++ b/docs/pages/tutorial/text.md
@@ -44,7 +44,7 @@ const styles = StyleSheet.create({
 
 > 😳 **Wait, what is this "Try this example on Snack" button!?**
 >
-> Snack is a web-based editor that works similar to a managed Expo project. It's a great way to share code snippets with people and try things out without needing to get a project running on your own computer with `expo-cli`. Go ahead, press the button. You will see the above code running in it. Switch between iOS, Android, or web. Open it on your device in the Expo Go app by pressing the "Run" button.
+> Snack is a web-based editor that works similar to a managed Expo project. It's a great way to share code snippets with people and try things out without needing to get a project running on your own computer with `expo-cli`. Go ahead, press the button. You will see the above code running in it. Switch between iOS, or Android. Open it on your device in the Expo Go app by pressing the "Run" button.
 
 ## Adding style
 
@@ -86,4 +86,4 @@ const styles = StyleSheet.create({
 
 Good, that looks better! If you want to learn more about the other styles available on the Text component, [you can read more here](https://reactnative.dev/docs/text#style).
 
-Next we're going to look at adding the logo, [let's continue on to looking at the Image component for that](../tutorial/image.md).
+Next we're going to look at adding the logo, [let's continue on to looking at the Image component for that](/tutorial/image).


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fixes ENG-5249 & #17824 

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR removes references of the "web" part used in the Tutorial. It hides the "Handling Platform differences" page and updates the inline Snack example on "Sharing" page.

Additionally, all internal links are converted to use the full path and verified any external links to make sure they are working.

_Note:_ This is a workaround for the web part for now.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
The changes have been tested by running docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
