### PR TITLE
[docs] Contacts: remove very old breaking changes section

### DIFF
--- a/docs/pages/versions/unversioned/sdk/contacts.md
+++ b/docs/pages/versions/unversioned/sdk/contacts.md
@@ -918,14 +918,3 @@ This table illustrates what fields will be added on demand to every contact.
 | RAW_IMAGE              | `'rawImage'`                | ✅             | ❌             |
 | THUMBNAIL              | `'thumbnail'`               | **Deprecated** | **Deprecated** |
 | PREVIOUS_LAST_NAME     | `'previousLastName'`        | **Deprecated** | **Deprecated** |
-
-## Breaking Changes
-
-### SDK 29
-
-- The `thumbnail` field has been deprecated, use `image` on both platforms instead.
-- On iOS `image` is now `rawImage`. There is no Android version of `rawImage`.
-- Images now return a localUri instead of Base64 string.
-- Base64 string is now returned in an encodable format.
-- Empty contact fields will no longer be returned as empty strings on iOS.
-- Passing no fields will now return all contact information.

--- a/docs/pages/versions/v42.0.0/sdk/contacts.md
+++ b/docs/pages/versions/v42.0.0/sdk/contacts.md
@@ -921,14 +921,3 @@ This table illustrates what fields will be added on demand to every contact.
 | RAW_IMAGE              | `'rawImage'`                | ✅             | ❌             |
 | THUMBNAIL              | `'thumbnail'`               | **Deprecated** | **Deprecated** |
 | PREVIOUS_LAST_NAME     | `'previousLastName'`        | **Deprecated** | **Deprecated** |
-
-## Breaking Changes
-
-### SDK 29
-
-- The `thumbnail` field has been deprecated, use `image` on both platforms instead.
-- On iOS `image` is now `rawImage`. There is no Android version of `rawImage`.
-- Images now return a localUri instead of Base64 string.
-- Base64 string is now returned in an encodable format.
-- Empty contact fields will no longer be returned as empty strings on iOS.
-- Passing no fields will now return all contact information.

--- a/docs/pages/versions/v43.0.0/sdk/contacts.md
+++ b/docs/pages/versions/v43.0.0/sdk/contacts.md
@@ -921,14 +921,3 @@ This table illustrates what fields will be added on demand to every contact.
 | RAW_IMAGE              | `'rawImage'`                | ✅             | ❌             |
 | THUMBNAIL              | `'thumbnail'`               | **Deprecated** | **Deprecated** |
 | PREVIOUS_LAST_NAME     | `'previousLastName'`        | **Deprecated** | **Deprecated** |
-
-## Breaking Changes
-
-### SDK 29
-
-- The `thumbnail` field has been deprecated, use `image` on both platforms instead.
-- On iOS `image` is now `rawImage`. There is no Android version of `rawImage`.
-- Images now return a localUri instead of Base64 string.
-- Base64 string is now returned in an encodable format.
-- Empty contact fields will no longer be returned as empty strings on iOS.
-- Passing no fields will now return all contact information.

--- a/docs/pages/versions/v44.0.0/sdk/contacts.md
+++ b/docs/pages/versions/v44.0.0/sdk/contacts.md
@@ -921,14 +921,3 @@ This table illustrates what fields will be added on demand to every contact.
 | RAW_IMAGE              | `'rawImage'`                | ✅             | ❌             |
 | THUMBNAIL              | `'thumbnail'`               | **Deprecated** | **Deprecated** |
 | PREVIOUS_LAST_NAME     | `'previousLastName'`        | **Deprecated** | **Deprecated** |
-
-## Breaking Changes
-
-### SDK 29
-
-- The `thumbnail` field has been deprecated, use `image` on both platforms instead.
-- On iOS `image` is now `rawImage`. There is no Android version of `rawImage`.
-- Images now return a localUri instead of Base64 string.
-- Base64 string is now returned in an encodable format.
-- Empty contact fields will no longer be returned as empty strings on iOS.
-- Passing no fields will now return all contact information.

--- a/docs/pages/versions/v45.0.0/sdk/contacts.md
+++ b/docs/pages/versions/v45.0.0/sdk/contacts.md
@@ -918,14 +918,3 @@ This table illustrates what fields will be added on demand to every contact.
 | RAW_IMAGE              | `'rawImage'`                | ✅             | ❌             |
 | THUMBNAIL              | `'thumbnail'`               | **Deprecated** | **Deprecated** |
 | PREVIOUS_LAST_NAME     | `'previousLastName'`        | **Deprecated** | **Deprecated** |
-
-## Breaking Changes
-
-### SDK 29
-
-- The `thumbnail` field has been deprecated, use `image` on both platforms instead.
-- On iOS `image` is now `rawImage`. There is no Android version of `rawImage`.
-- Images now return a localUri instead of Base64 string.
-- Base64 string is now returned in an encodable format.
-- Empty contact fields will no longer be returned as empty strings on iOS.
-- Passing no fields will now return all contact information.


### PR DESCRIPTION
# Why

Fixes ENG-5533

# How

This PR removes very old breaking changes section from Contacts docs.

# Test Plan

The changes have been tested by running website locally.

# Preview

<img width="1920" alt="Screenshot 2022-07-01 at 09 49 07" src="https://user-images.githubusercontent.com/719641/176849811-db74ce7c-4833-4137-aa8c-75928634ddf2.png">

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
