### PR TITLE
[core][Android] Fix android tests on Hermes

### DIFF
--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -92,6 +92,7 @@ if (FOR_HERMES) {
   // To get those, we must fall back to the `hermes-engine` package.
   HERMES_ENGINE_DIR = new File(["node", "--print", "require.resolve('hermes-engine/package.json')"].execute(null, rootDir).text.trim()).parent
   if (REACT_NATIVE_BUILD_FROM_SOURCE) {
+    // TODO(@lukmccall): Use Hermes from the `ReactAndroid:hermes-engine`
     HERMES_AAR = file("$HERMES_ENGINE_DIR/android/hermes-debug.aar")
   } else {
     def prebuiltAAR = fileTree(REACT_NATIVE_DIR).matching { include "**/hermes-engine/**/hermes-engine-*-debug.aar" }

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -72,7 +72,8 @@ def reactNativeArchitectures() {
 }
 
 def FOR_HERMES = false
-def HERMES_DIR = new File(["node", "--print", "require.resolve('hermes-engine/package.json')"].execute(null, rootDir).text.trim()).parent
+def HERMES_ENGINE_DIR = null
+def HERMES_AAR = null
 if (findProject(":app")) {
   def appProjectExt = project(":app").ext
   if (appProjectExt.has("react")) {
@@ -82,6 +83,24 @@ if (findProject(":app")) {
   }
 } else {
   FOR_HERMES = (findProperty('expo.jsEngine') ?: "jsc") == "hermes"
+}
+
+if (FOR_HERMES) {
+  // The `hermes-engine` package doesn't contain the correct version of the Hermes.
+  // The AAR we need to import is located in the React Native package.
+  // However, the version from RN doesn't include header files.
+  // To get those, we must fall back to the `hermes-engine` package.
+  HERMES_ENGINE_DIR = new File(["node", "--print", "require.resolve('hermes-engine/package.json')"].execute(null, rootDir).text.trim()).parent
+  if (REACT_NATIVE_BUILD_FROM_SOURCE) {
+    HERMES_AAR = file("$HERMES_ENGINE_DIR/android/hermes-debug.aar")
+  } else {
+    def prebuiltAAR = fileTree(REACT_NATIVE_DIR).matching { include "**/hermes-engine/**/hermes-engine-*-debug.aar" }
+    if (prebuiltAAR.any()) {
+      HERMES_AAR = prebuiltAAR.singleFile
+    } else {
+      HERMES_AAR = file("$HERMES_ENGINE_DIR/android/hermes-debug.aar")
+    }
+  }
 }
 
 // Creating sources with comments
@@ -136,7 +155,7 @@ android {
           "-DREACT_NATIVE_TARGET_VERSION=${REACT_NATIVE_TARGET_VERSION}",
           "-DBOOST_VERSION=${BOOST_VERSION}",
           "-DFOR_HERMES=${FOR_HERMES}",
-          "-DHERMES_DIR=${HERMES_DIR}"
+          "-DHERMES_DIR=${HERMES_ENGINE_DIR}"
       }
     }
   }
@@ -244,7 +263,7 @@ dependencies {
   androidTestImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.0"
 
   if (FOR_HERMES) {
-    androidTestImplementation files(new File(HERMES_DIR, "android/hermes-debug.aar"))
+    androidTestImplementation files(HERMES_AAR)
   } else {
     androidTestImplementation "org.webkit:android-jsc:+"
   }
@@ -407,12 +426,7 @@ task prepareHermes() {
     return
   }
 
-  def hermesAAR = file("$HERMES_DIR/android/hermes-debug.aar")
-  if (!hermesAAR.exists()) {
-    throw new GradleScriptException("The hermes-engine npm package is missing \"android/hermes-debug.aar\"", null)
-  }
-
-  def soFiles = zipTree(hermesAAR).matching({ it.include "**/*.so" })
+  def soFiles = zipTree(HERMES_AAR).matching({ it.include "**/*.so" })
 
   copy {
     from soFiles


### PR DESCRIPTION
# Why

Fixes:
```
2022-06-29 16:42:23.594 16410-16410/? A/DEBUG: Cause: null pointer dereference
2022-06-29 16:42:23.594 16410-16410/? A/DEBUG:     x0  00000000000e9510  x1  0000007854ed0ce8  x2  00ffffffffffffff  x3  000000000293067e
2022-06-29 16:42:23.594 16410-16410/? A/DEBUG:     x4  0000000000000000  x5  0000007854ed0d60  x6  0000000000000000  x7  000000783b4293f4
2022-06-29 16:42:23.594 16410-16410/? A/DEBUG:     x8  7b2548531c03bf1d  x9  7b2548531c03bf1d  x10 0000000000000000  x11 7b2548531c03bf1d
2022-06-29 16:42:23.594 16410-16410/? A/DEBUG:     x12 000000000293067e  x13 00000364b2a2ce67  x14 00043d5421ab39a5  x15 0000000034155555
2022-06-29 16:42:23.594 16410-16410/? A/DEBUG:     x16 00000078499a8b48  x17 000000797657646c  x18 0000007840758000  x19 b40000783adab800
2022-06-29 16:42:23.594 16410-16410/? A/DEBUG:     x20 0000007854ed0f60  x21 0000000000000000  x22 0000007854ed0fa0  x23 b4000078ba8256c0
2022-06-29 16:42:23.594 16410-16410/? A/DEBUG:     x24 b4000078ba8256d0  x25 0000000000000001  x26 0000007854ed8000  x27 00000078d3617000
2022-06-29 16:42:23.594 16410-16410/? A/DEBUG:     x28 0000000000000000  x29 0000007854ed0f30
2022-06-29 16:42:23.594 16410-16410/? A/DEBUG:     lr  00000078497141d8  sp  0000007854ed0d90  pc  00000078497141dc  pst 0000000060001000
2022-06-29 16:42:23.594 16410-16410/? A/DEBUG: backtrace:
2022-06-29 16:42:23.594 16410-16410/? A/DEBUG:       #00 pc 00000000000291dc  /data/app/~~da9OPGbojr0zfLcsKHsdEg==/expo.modules.test-5d9CHLA06HOroDg-jCTR5w==/lib/arm64/libhermes.so (BuildId: 4fbed506ba7b5e91b09f3a3ace7967fb54b2332c)
2022-06-29 16:42:23.594 16410-16410/? A/DEBUG:       #01 pc 0000000000083e78  /data/app/~~da9OPGbojr0zfLcsKHsdEg==/expo.modules.test-5d9CHLA06HOroDg-jCTR5w==/lib/arm64/libexpo-modules-core.so (expo::JavaScriptRuntime::JavaScriptRuntime()+672) (BuildId: b6fae6fab54155ca35d5beea1df9d39fab7dd6a4)
2022-06-29 16:42:23.594 16410-16410/? A/DEBUG:       #02 pc 0000000000076468  /data/app/~~da9OPGbojr0zfLcsKHsdEg==/expo.modules.test-5d9CHLA06HOroDg-jCTR5w==/lib/arm64/libexpo-modules-core.so (std::__ndk1::shared_ptr<expo::JavaScriptRuntime> std::__ndk1::shared_ptr<expo::JavaScriptRuntime>::make_shared<>()+92) (BuildId: b6fae6fab54155ca35d5beea1df9d39fab7dd6a4)
```
This error occurs when you're trying to run Android tests on Hermes.

# How

The Hermes library included in the test environment wasn't correct. From RN 0.69, the so file is located inside the `react-native` package. Unforunelty, the provided Hermes library doesn't contain header files. That's why we're still using the `hermes-engine` package to obtain those files.

# Test Plan

- run Android tests ✅