### PR TITLE
[expo-dev-menu][iOS] Fix use_frameworks!

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] fix use_frameworks! compilation. ([#18073](https://github.com/expo/expo/pull/18073) by [@douglowder](https://github.com/douglowder))
+
 ### 💡 Others
 
 ## 1.0.0 — 2022-06-09

--- a/packages/expo-dev-menu/ios/DevMenuRCTBridge.m
+++ b/packages/expo-dev-menu/ios/DevMenuRCTBridge.m
@@ -1,7 +1,11 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 #import <EXDevMenu/DevMenuRCTBridge.h>
+#if __has_include(<EXDevMenu/EXDevMenu-Swift.h>)
+#import <EXDevMenu/EXDevMenu-Swift.h>
+#else
 #import <EXDevMenu-Swift.h>
+#endif
 #import <RCTCxxBridge+Private.h>
 
 #import <React/RCTPerformanceLogger.h>

--- a/packages/expo-dev-menu/ios/EXDevMenuAppInfo.m
+++ b/packages/expo-dev-menu/ios/EXDevMenuAppInfo.m
@@ -1,6 +1,10 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 #import "EXDevMenuAppInfo.h"
+#if __has_include(<EXDevMenu/EXDevMenu-Swift.h>)
+#import <EXDevMenu/EXDevMenu-Swift.h>
+#else
 #import <EXDevMenu-Swift.h>
+#endif
 #import <EXManifests/EXManifestsManifestFactory.h>
 
 @implementation EXDevMenuAppInfo


### PR DESCRIPTION
# Why

If a project uses dynamic frameworks on iOS, projects that include expo-dev-menu will not compile. This PR fixes that issue.

# How

Use the correct header construction that checks for the two different ways to import `EXDevMenu-Swift.h`. This construction is used in other places in Expo packages to solve the same problem.

# Test plan

Tested with a customer project that reproduces the issue.

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
