### PR TITLE
[home] don't poll for projects if not logged in

### DIFF
--- a/home/screens/HomeScreen/HomeScreenView.tsx
+++ b/home/screens/HomeScreen/HomeScreenView.tsx
@@ -81,7 +81,7 @@ export class HomeScreenView extends React.Component<Props, State> {
 
     // @evanbacon: Without this setTimeout, the state doesn't update correctly and the "Recently in Development" items don't load for 10 seconds.
     setTimeout(() => {
-      this._startPollingForProjects();
+      if (this.props.isAuthenticated) this._startPollingForProjects();
     }, 1);
 
     // NOTE(brentvatne): if we add QR code button to the menu again, we'll need to
@@ -189,6 +189,10 @@ export class HomeScreenView extends React.Component<Props, State> {
       this._fetchProjectsAsync();
     }
 
+    if (!prevProps.isAuthenticated && this.props.isAuthenticated) {
+      this._startPollingForProjects();
+    }
+
     if (prevProps.isAuthenticated && !this.props.isAuthenticated) {
       // Remove all projects except Snack, because they are tied to device id
       // Fix this lint warning when converting to hooks
@@ -196,6 +200,8 @@ export class HomeScreenView extends React.Component<Props, State> {
       this.setState(({ projects }) => ({
         projects: projects.filter((p) => p.source === 'snack'),
       }));
+
+      this._stopPollingForProjects();
     }
   }
 


### PR DESCRIPTION
# Why

We poll for projects even when a user isn't logged in, which is invalid and unnecessary.

# How

Check for authentication before polling, and start/stop polling based on auth status changes.

# Test Plan

Running Expo Go locally won't show the errors shown in the linear issue. 