### PR TITLE
[home] include bottom spacing when sdk warning is shown

### DIFF
--- a/home/screens/ProjectScreen/LegacyLaunchSection.tsx
+++ b/home/screens/ProjectScreen/LegacyLaunchSection.tsx
@@ -55,29 +55,31 @@ export function LegacyLaunchSection({ app }: { app: ProjectPageApp }) {
   const theme = useExpoTheme();
 
   return (
-    warning ?? (
-      <View>
-        <SectionHeader header="Classic Release Channels" style={{ paddingTop: 0 }} />
-        <View bg="default" overflow="hidden" rounded="large" border="default">
-          <TouchableOpacity
-            onPress={() => {
-              Linking.openURL(UrlUtils.normalizeUrl(app.fullName));
-            }}>
-            <Row padding="medium" justify="between" align="center" bg="default">
-              <Text size="medium" type="InterRegular">
-                default
-              </Text>
-              <OpenInternalIcon color={theme.icon.default} size={iconSize.tiny} />
-            </Row>
-          </TouchableOpacity>
+    <>
+      {warning ?? (
+        <View>
+          <SectionHeader header="Classic Release Channels" style={{ paddingTop: 0 }} />
+          <View bg="default" overflow="hidden" rounded="large" border="default">
+            <TouchableOpacity
+              onPress={() => {
+                Linking.openURL(UrlUtils.normalizeUrl(app.fullName));
+              }}>
+              <Row padding="medium" justify="between" align="center" bg="default">
+                <Text size="medium" type="InterRegular">
+                  default
+                </Text>
+                <OpenInternalIcon color={theme.icon.default} size={iconSize.tiny} />
+              </Row>
+            </TouchableOpacity>
+          </View>
+          <View padding="medium">
+            <Text size="small" color="secondary" type="InterRegular">
+              {moreLegacyBranchesText}
+            </Text>
+          </View>
         </View>
-        <View padding="medium">
-          <Text size="small" color="secondary" type="InterRegular">
-            {moreLegacyBranchesText}
-          </Text>
-        </View>
-        <Spacer.Vertical size="medium" />
-      </View>
-    )
+      )}
+      <Spacer.Vertical size="medium" />
+    </>
   );
 }


### PR DESCRIPTION
# Why

When the warning box is shown, there isn't any bottom spacing (see linear issue).

# How

Factor out the spacing intended for that section so that when the warning box is shown, the bottom space is shown as well.
