### PR TITLE
[expo-av][iOS] fix race conditions

### DIFF
--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### 🐛 Bug fixes
 
+- On iOS try to fix `Video` component crashes when Video unmounts before the React Native bridge is able to send out the `unloadAsync()` command. ([#18076](https://github.com/expo/expo/pull/18076) by [@hirbod](https://github.com/hirbod) and [@Pickleboyonline](https://github.com/Pickleboyonline))
 - On Android fix `Video` component crashes when activity loses focus due to accessing player from the wrong thread. ([#17280](https://github.com/expo/expo/pull/17280) by [@mnightingale](https://github.com/mnightingale))
 - Added support for React Native 0.69.x. ([#18006](https://github.com/expo/expo/pull/18006) by [@kudo](https://github.com/kudo))
 - On Android fix `Audio.setAudioModeAsync` and `Audio.setIsEnabledAsync` crashes due to accessing player from the wrong thread. ([#17840](https://github.com/expo/expo/pull/17840) by [@mnightingale](https://github.com/mnightingale))

--- a/packages/expo-av/ios/EXAV/Video/EXVideoView.m
+++ b/packages/expo-av/ios/EXAV/Video/EXVideoView.m
@@ -765,8 +765,8 @@ willEndFullScreenPresentationWithAnimationCoordinator:(id<UIViewControllerTransi
 
 - (void)dealloc
 {
+  [self setSource:nil];
   [_exAV unregisterVideoForAudioLifecycle:self];
-  [_data pauseImmediately];
   [_exAV demoteAudioSessionIfPossible];
 }
 


### PR DESCRIPTION
# Why

Essentially, the thought process is that the Video unmounts before the React Native bridge is able to send out the unloadAsync() command in some circumstances, which leads to:

```log
NSInternalInconsistencyException: An instance 0x28225af10 of class AVPlayerLayer was deallocated while key value observers were still registered with it. Current observation info: <NSKeyValueObservationInfo 0x2832b0d00> (
<NSKeyValueObservance 0x282264540: Observer: 0x10783e7a0, Key path: readyForDisplay, Options: <New: YES, Old: NO, Prior: NO> Context: 0x0, Property: 0x283a19560>
)
```

Thanks once again to @Pickleboyonline 

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Instead of calling `pauseImmediately` in the dealloc method, we're calling the Obj-C equivalent for `unloadAsync()` and call `setSource:nil`

Although we are not quite sure if this will make the crash reports disappear, it is worth a try, as the de-allocation should be cleaner this way

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Tested on couple of real devices and inside the simulator, no regressions.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
