### PR TITLE
[docs] Sharing Release: fix Video alt text, improve readability for editors

### DIFF
--- a/docs/pages/guides/sharing-preview-releases.md
+++ b/docs/pages/guides/sharing-preview-releases.md
@@ -3,7 +3,7 @@ title: Sharing pre-release versions of your app
 sidebar_title: Sharing preview releases
 ---
 
-import Video from '~/components/plugins/Video'
+import Video from '~/components/plugins/Video';
 
 The typical means of distribution for a mobile app is through the Apple App Store and/or Google Play Store, but this isn't the best way to share pre-production builds. 
 During the development process you'll want share your progress with both technical and non-technical stakeholders of the project to gather feedback and test it, 
@@ -21,7 +21,7 @@ consider [Internal Distribution](#internal-distribution) or [TestFlight for iOS]
 3. Have them [download the Expo Go app](https://expo.dev/expo-go) onto their device.
 4. They'll be able to open your application from the Profile tab of their Expo Go app.
 
-<Video alt="Finding and sharing projects in Expo Go app" file="guides/load-project.mp4" style={{height: '300px', width: 'auto'}} />
+<Video alt="Finding and sharing projects in Expo Go app" file="guides/load-project.mp4" style={{ height: '300px', width: 'auto' }} />
 
 ## Internal Distribution
 
@@ -32,10 +32,10 @@ This gives you full control of putting specific builds on devices, allowing you 
 
 To share your application to Android devices, you must build an APK (Android application package file) of your project. 
 APKs can be installed directly to an Android device over USB, by downloading the file over the web or through an email or chat app, 
-once the user accepts the security warning for installing an app that has not gone through Play Store review. AAB (Android app bundle) 
-binaries of your application must be distributed through the Play Store.
+once the user accepts the security warning for installing an app that has not gone through Play Store review. 
+AAB (Android app bundle) binaries of your application must be distributed through the Play Store.
 
-### Ad Hoc Distribution on iOS
+### iOS Ad Hoc Distribution
 
 Apple offers [Ad Hoc provisioning profiles](https://help.apple.com/xcode/mac/current/#/dev7ccaf4d3c) to distribute your app to test devices once they have been registered
 to your Apple Developer account. This method requires a paid Apple Developer account and that account will only be able to use this method to distribute
@@ -48,7 +48,7 @@ Setting up Ad Hoc certificates correctly can be intimidating if you haven't done
 If you're using [EAS Build](/build/internal-distribution.md), which is optimized for Expo and React Native projects, we'll handle the time-consuming parts
 of setting up Ad Hoc credentials for you.
 
-### Enterprise Distribution on iOS
+### iOS Enterprise Distribution
 
 If your app is only intended to be used internally and will not be distributed through the App Store, you should use Enterprise distribution. 
 Unlike Ad Hoc Distribution, there is no limit to the number of devices that can install your application, and you will not need to manage the UDIDs of each device. 

--- a/docs/pages/guides/sharing-preview-releases.md
+++ b/docs/pages/guides/sharing-preview-releases.md
@@ -5,41 +5,59 @@ sidebar_title: Sharing preview releases
 
 import Video from '~/components/plugins/Video'
 
-The typical means of distribution for a mobile app is through the Apple App Store and/or Google Play Store, but this isn't the best way to share pre-production builds. During the development process you'll want share your progress with both technical and non-technical stakeholders of the project to gather feedback and test it, and there are several approaches you can take for doing this.
+The typical means of distribution for a mobile app is through the Apple App Store and/or Google Play Store, but this isn't the best way to share pre-production builds. 
+During the development process you'll want share your progress with both technical and non-technical stakeholders of the project to gather feedback and test it, 
+and there are several approaches you can take for doing this.
 
 ## Expo Go
 
-If you are using the Expo Managed workflow, you can share your application with your team through the Expo Go app. Expo Go is the easiest option to set up, doesn't require a paid Apple Developer account, and works the same on both platforms.  Your users will launch the application through Expo Go rather than from an app icon though, so if that experience is important to you, consider [Internal Distribution](#internal-distribution) or [TestFlight for iOS](#testflight) instead.
+If you are using the Expo Managed workflow, you can share your application with your team through the Expo Go app. 
+Expo Go is the easiest option to set up, doesn't require a paid Apple Developer account, and works the same on both platforms. 
+Your users will launch the application through Expo Go rather than from an app icon though, so if that experience is important to you, 
+consider [Internal Distribution](#internal-distribution) or [TestFlight for iOS](#testflight) instead.
 
 1. Publish the latest version of your project to Expo's servers by running `expo publish`.
 2. [Invite your teammate](https://expo.dev/accounts/[account]/settings/members) to the Expo account that owns the project.
 3. Have them [download the Expo Go app](https://expo.dev/expo-go) onto their device.
 4. They'll be able to open your application from the Profile tab of their Expo Go app.
 
-
-<Video alt="Terminal running expo init, with minimal (TypeScript) selected" file="guides/load-project.mp4" style={{height: '300px', width: 'auto'}} />
+<Video alt="Finding and sharing projects in Expo Go app" file="guides/load-project.mp4" style={{height: '300px', width: 'auto'}} />
 
 ## Internal Distribution
 
-If you want to share outside of Expo Go, Android and iOS both offer ways to install a build of your application directly on devices. This gives you full control of putting specific builds on devices, allowing you to iterate quickly and have multiple builds of your application available for review at the same time.
+If you want to share outside of Expo Go, Android and iOS both offer ways to install a build of your application directly on devices. 
+This gives you full control of putting specific builds on devices, allowing you to iterate quickly and have multiple builds of your application available for review at the same time.
 
 ### Android
 
-To share your application to Android devices, you must build an APK (Android application package file) of your project. APKs can be installed directly to an Android device over USB, by downloading the file over the web or through an email or chat app, once the user accepts the security warning for installing an app that has not gone through Play Store review. AAB (Android app bundle) binaries of your application must be distributed through the Play Store.
+To share your application to Android devices, you must build an APK (Android application package file) of your project. 
+APKs can be installed directly to an Android device over USB, by downloading the file over the web or through an email or chat app, 
+once the user accepts the security warning for installing an app that has not gone through Play Store review. AAB (Android app bundle) 
+binaries of your application must be distributed through the Play Store.
 
 ### Ad Hoc Distribution on iOS
 
-Apple offers [Ad Hoc provisioning profiles](https://help.apple.com/xcode/mac/current/#/dev7ccaf4d3c) to distribute your app to test devices once they have been registered to your Apple Developer account. This method requires a paid Apple Developer account and that account will only be able to use this method to distribute to at most 100 iPhones per year.
+Apple offers [Ad Hoc provisioning profiles](https://help.apple.com/xcode/mac/current/#/dev7ccaf4d3c) to distribute your app to test devices once they have been registered
+to your Apple Developer account. This method requires a paid Apple Developer account and that account will only be able to use this method to distribute
+to at most 100 iPhones per year.
 
-You will need to know the UDID (Unique Device Identifier) of each device that will install your application, which may be challenging if you are trying to share with someone who is not a developer. Adding a new device will require a rebuild of your application. 
+You will need to know the UDID (Unique Device Identifier) of each device that will install your application, which may be challenging if you are trying to share
+with someone who is not a developer. Adding a new device will require a rebuild of your application. 
 
-Setting up Ad Hoc certificates correctly can be intimidating if you haven't done it before, and tedious even if you have. If you're using [EAS Build](/build/internal-distribution.md), which is optimized for Expo and React Native projects, we'll handle the time-consuming parts of setting up Ad Hoc credentials for you.
+Setting up Ad Hoc certificates correctly can be intimidating if you haven't done it before, and tedious even if you have. 
+If you're using [EAS Build](/build/internal-distribution.md), which is optimized for Expo and React Native projects, we'll handle the time-consuming parts
+of setting up Ad Hoc credentials for you.
 
 ### Enterprise Distribution on iOS
 
-If your app is only intended to be used internally and will not be distributed through the App Store, you should use Enterprise distribution. Unlike Ad Hoc Distribution, there is no limit to the number of devices that can install your application, and you will not need to manage the UDIDs of each device. Enterprise Distribution requires membership in the more expensive [Apple Developer Enterprise Program](https://developer.apple.com/programs/enterprise/), which requires your organization to be a legal entity and go through Apple's verification process. 
-
+If your app is only intended to be used internally and will not be distributed through the App Store, you should use Enterprise distribution. 
+Unlike Ad Hoc Distribution, there is no limit to the number of devices that can install your application, and you will not need to manage the UDIDs of each device. 
+Enterprise Distribution requires membership in the more expensive [Apple Developer Enterprise Program](https://developer.apple.com/programs/enterprise/), 
+which requires your organization to be a legal entity and go through Apple's verification process. 
 
 ## TestFlight
 
-TestFlight is another option to distribute your application to iOS devices. TestFlight also requires a paid Apple Developer account, but allows you to share your application with up to 10,000 users that can be invited with their email or a public link. This method requires you to [upload your application](/submit/ios.md) to App Store Connect and wait for the automated review before you can share a build. If you intend to ship new builds frequently, investing the time to set up Ad Hoc distribution will be worthwhile.
+TestFlight is another option to distribute your application to iOS devices. TestFlight also requires a paid Apple Developer account, 
+but allows you to share your application with up to 10,000 users that can be invited with their email or a public link. 
+This method requires you to [upload your application](/submit/ios.md) to App Store Connect and wait for the automated review before you can share a build. 
+If you intend to ship new builds frequently, investing the time to set up Ad Hoc distribution will be worthwhile.


### PR DESCRIPTION
# Why

Fixes ENG-5534

# How

This PR updates the `alt` text for the Video used on the page and I have also formatted the file for editors readability (whitespace changes should not affect the page appearance).

# Test Plan

The changes has been tested by running the docs website locally.

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
