### PR TITLE
[docs] BackgroundFetch: fix API section in unversioned file

### DIFF
--- a/docs/pages/versions/unversioned/sdk/background-fetch.md
+++ b/docs/pages/versions/unversioned/sdk/background-fetch.md
@@ -5,6 +5,7 @@ packageName: 'expo-background-fetch'
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
+import APISection from '~/components/plugins/APISection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
 import ImageSpotlight from '~/components/plugins/ImageSpotlight'


### PR DESCRIPTION
# Why

Currently, the API section seems to not be working in unversioned file for `BackgroundFetch` package.

<img width="1418" alt="Screenshot 2022-07-03 101003" src="https://user-images.githubusercontent.com/719641/177031102-6a1552c0-853e-4c2b-9b2a-5ae9d2ee56a8.png">

# How

Add missing component import.

# Test Plan

The change has been tested by running docs website locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
