### PR TITLE
[go][iOS][Android] Upgrade `react-native-reanimated` from `2.8.0` to `2.9.1`

### DIFF
--- a/android/expoview/src/main/Common/cpp/Tools/RuntimeDecorator.cpp
+++ b/android/expoview/src/main/Common/cpp/Tools/RuntimeDecorator.cpp
@@ -71,21 +71,27 @@ void RuntimeDecorator::decorateRuntime(
           1,
           setGlobalConsole));
 
+  auto chronoNow = [](jsi::Runtime &rt,
+                      const jsi::Value &thisValue,
+                      const jsi::Value *args,
+                      size_t count) -> jsi::Value {
+    double now = std::chrono::system_clock::now().time_since_epoch() /
+        std::chrono::milliseconds(1);
+    return jsi::Value(now);
+  };
+
   rt.global().setProperty(
       rt,
       "_chronoNow",
       jsi::Function::createFromHostFunction(
-          rt,
-          jsi::PropNameID::forAscii(rt, "_chronoNow"),
-          0,
-          [](jsi::Runtime &rt,
-             const jsi::Value &thisValue,
-             const jsi::Value *args,
-             size_t count) -> jsi::Value {
-            double now = std::chrono::system_clock::now().time_since_epoch() /
-                std::chrono::milliseconds(1);
-            return jsi::Value(now);
-          }));
+          rt, jsi::PropNameID::forAscii(rt, "_chronoNow"), 0, chronoNow));
+  jsi::Object performance(rt);
+  performance.setProperty(
+      rt,
+      "now",
+      jsi::Function::createFromHostFunction(
+          rt, jsi::PropNameID::forAscii(rt, "now"), 0, chronoNow));
+  rt.global().setProperty(rt, "performance", performance);
 }
 
 void RuntimeDecorator::decorateUIRuntime(

--- a/android/expoview/src/main/cpp/headers/NativeProxy.h
+++ b/android/expoview/src/main/cpp/headers/NativeProxy.h
@@ -131,7 +131,7 @@ class NativeProxy : public jni::HybridClass<NativeProxy> {
       jni::alias_ref<LayoutAnimations::javaobject> layoutAnimations);
   static void registerNatives();
 
- ~NativeProxy();
+  ~NativeProxy();
 
  private:
   friend HybridBase;

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/reanimated/sensor/ReanimatedSensorType.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/reanimated/sensor/ReanimatedSensorType.java
@@ -1,11 +1,13 @@
 package versioned.host.exp.exponent.modules.api.reanimated.sensor;
 
+import android.hardware.Sensor;
+
 public enum ReanimatedSensorType {
-  ACCELEROMETER(1),
-  GYROSCOPE(2),
-  GRAVITY(3),
-  MAGNETIC_FIELD(4),
-  ROTATION_VECTOR(5);
+  ACCELEROMETER(Sensor.TYPE_ACCELEROMETER),
+  GYROSCOPE(Sensor.TYPE_GYROSCOPE),
+  GRAVITY(Sensor.TYPE_GRAVITY),
+  MAGNETIC_FIELD(Sensor.TYPE_MAGNETIC_FIELD),
+  ROTATION_VECTOR(Sensor.TYPE_ROTATION_VECTOR);
 
   private final int type;
 

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -113,7 +113,7 @@
     "react-dom": "18.0.0",
     "react-native": "0.69.1",
     "react-native-gesture-handler": "~2.5.0",
-    "react-native-reanimated": "~3.0.0-rc.0",
+    "react-native-reanimated": "~2.9.1",
     "react-native-safe-area-context": "4.2.4",
     "react-native-screens": "~3.11.1",
     "react-native-shared-element": "0.8.4",

--- a/apps/bare-sandbox/package.json
+++ b/apps/bare-sandbox/package.json
@@ -19,7 +19,7 @@
     "react-dom": "18.0.0",
     "react-native": "0.69.1",
     "react-native-gesture-handler": "~2.5.0",
-    "react-native-reanimated": "~3.0.0-rc.0",
+    "react-native-reanimated": "~2.9.1",
     "react-native-screens": "~3.11.1",
     "react-native-web": "~0.18.1"
   },

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -153,7 +153,7 @@
     "react-native-maps": "0.31.1",
     "react-native-pager-view": "5.4.15",
     "react-native-paper": "^4.0.1",
-    "react-native-reanimated": "~3.0.0-rc.0",
+    "react-native-reanimated": "~2.9.1",
     "react-native-redash": "^14.1.1",
     "react-native-safe-area-context": "4.2.4",
     "react-native-safe-area-view": "^0.14.8",

--- a/home/package.json
+++ b/home/package.json
@@ -61,7 +61,7 @@
     "react-native-keyboard-aware-scroll-view": "^0.9.5",
     "react-native-maps": "0.31.1",
     "react-native-paper": "^4.0.1",
-    "react-native-reanimated": "~3.0.0-rc.0",
+    "react-native-reanimated": "~2.9.1",
     "react-native-safe-area-context": "4.2.4",
     "react-native-screens": "~3.11.1",
     "react-redux": "^7.2.0",

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2530,7 +2530,7 @@ PODS:
     - ReactCommon/turbomodule/core (= 0.69.1)
   - RNGestureHandler (2.2.0):
     - React-Core
-  - RNReanimated (2.8.0):
+  - RNReanimated (2.9.1):
     - DoubleConversion
     - FBLazyVector
     - FBReactNativeSpec
@@ -4446,7 +4446,7 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: 27f468c5576eaf05ffb7a907528e44c75a3fcbae
   ReactCommon: e30ec17dfb1d4c4f3419eac254350d6abca6d5a2
   RNGestureHandler: bf572f552ea324acd5b5464b8d30755b2d8c1de6
-  RNReanimated: 64573e25e078ae6bec03b891586d50b9ec284393
+  RNReanimated: 5c8c17e26787fd8984cd5accdc70fef2ca70aafd
   RNScreens: 4d83613b50b74ed277026375dc0810893b0c347f
   Stripe: ee32e594fa4dee4bdf2a8a3039f7fb07a21075dc
   stripe-react-native: bd992665f71c5233d62719c4031351f3f3b769fe
@@ -4458,6 +4458,6 @@ SPEC CHECKSUMS:
   Yoga: 7ab6e3ee4ce47d7b789d1cb520163833e515f452
   ZXingObjC: fdbb269f25dd2032da343e06f10224d62f537bdb
 
-PODFILE CHECKSUM: 991c5530f98fa584f131b3ef606330f8fc2aa690
+PODFILE CHECKSUM: 36be981ada3f4ab6169e5050570592ffeb4bf944
 
 COCOAPODS: 1.11.2

--- a/ios/vendored/unversioned/react-native-reanimated/Common/cpp/Tools/RuntimeDecorator.cpp
+++ b/ios/vendored/unversioned/react-native-reanimated/Common/cpp/Tools/RuntimeDecorator.cpp
@@ -71,21 +71,27 @@ void RuntimeDecorator::decorateRuntime(
           1,
           setGlobalConsole));
 
+  auto chronoNow = [](jsi::Runtime &rt,
+                      const jsi::Value &thisValue,
+                      const jsi::Value *args,
+                      size_t count) -> jsi::Value {
+    double now = std::chrono::system_clock::now().time_since_epoch() /
+        std::chrono::milliseconds(1);
+    return jsi::Value(now);
+  };
+
   rt.global().setProperty(
       rt,
       "_chronoNow",
       jsi::Function::createFromHostFunction(
-          rt,
-          jsi::PropNameID::forAscii(rt, "_chronoNow"),
-          0,
-          [](jsi::Runtime &rt,
-             const jsi::Value &thisValue,
-             const jsi::Value *args,
-             size_t count) -> jsi::Value {
-            double now = std::chrono::system_clock::now().time_since_epoch() /
-                std::chrono::milliseconds(1);
-            return jsi::Value(now);
-          }));
+          rt, jsi::PropNameID::forAscii(rt, "_chronoNow"), 0, chronoNow));
+  jsi::Object performance(rt);
+  performance.setProperty(
+      rt,
+      "now",
+      jsi::Function::createFromHostFunction(
+          rt, jsi::PropNameID::forAscii(rt, "now"), 0, chronoNow));
+  rt.global().setProperty(rt, "performance", performance);
 }
 
 void RuntimeDecorator::decorateUIRuntime(

--- a/ios/vendored/unversioned/react-native-reanimated/RNReanimated.podspec.json
+++ b/ios/vendored/unversioned/react-native-reanimated/RNReanimated.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "RNReanimated",
-  "version": "2.8.0",
+  "version": "2.9.1",
   "summary": "More powerful alternative to Animated library for React Native.",
   "description": "RNReanimated",
   "homepage": "https://github.com/software-mansion/react-native-reanimated",
@@ -14,7 +14,7 @@
   },
   "source": {
     "git": "https://github.com/software-mansion/react-native-reanimated.git",
-    "tag": "2.8.0"
+    "tag": "2.9.1"
   },
   "source_files": [
     "ios/**/*.{mm,h,m}",

--- a/ios/vendored/unversioned/react-native-reanimated/ios/native/REAInitializer.mm
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/native/REAInitializer.mm
@@ -54,6 +54,7 @@ JSIExecutor::RuntimeInstaller REAJSIExecutorRuntimeInstaller(
     uintptr_t* workletRuntimeData = reinterpret_cast<uintptr_t*>(
         workletRuntimeValue.getObject(runtime).getArrayBuffer(runtime).data(runtime));
     workletRuntimeData[0] = reinterpret_cast<uintptr_t>(reanimatedModule->runtime.get());
+
     runtime.global().setProperty(
         runtime,
         "_WORKLET_RUNTIME",

--- a/ios/vendored/unversioned/react-native-reanimated/ios/sensor/ReanimatedSensor.m
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/sensor/ReanimatedSensor.m
@@ -141,9 +141,9 @@
                                                         attitude.quaternion.y,
                                                         attitude.quaternion.z,
                                                         attitude.quaternion.w,
-                                                        attitude.pitch,
-                                                        attitude.roll,
                                                         attitude.yaw,
+                                                        attitude.pitch,
+                                                        attitude.roll
                                                     };
                                                     self->_setter(data);
                                                     self->_lastTimestamp = currentTime;

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -99,7 +99,7 @@
   "react-native-get-random-values": "~1.8.0",
   "react-native-maps": "0.31.1",
   "react-native-pager-view": "5.4.15",
-  "react-native-reanimated": "~2.8.0",
+  "react-native-reanimated": "~2.9.1",
   "react-native-safe-area-context": "4.2.4",
   "react-native-screens": "~3.11.1",
   "react-native-shared-element": "0.8.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17053,11 +17053,12 @@ react-native-paper@^4.0.1:
     color "^3.1.2"
     react-native-iphone-x-helper "^1.3.1"
 
-react-native-reanimated@~3.0.0-rc.0:
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-3.0.0-rc.0.tgz#05edcb2d9ca99c50d6e0ce378b74a5a0661bba93"
-  integrity sha512-YlkqVPKVs97ZMRwzdrxuhCXvU6RjxXmxE9rOiyAij/uJVMb+5Zx5CQH5ngfKjT/iEqC8HE/n6jd3pi3UlKsPeQ==
+react-native-reanimated@~2.9.1:
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-2.9.1.tgz#d9a932e312c13c05b4f919e43ebbf76d996e0bc1"
+  integrity sha512-309SIhDBwY4F1n6e5Mr5D1uPZm2ESIcmZsGXHUu8hpKX4oIOlZj2MilTk+kHhi05LjChoJkcpfkstotCJmPRPg==
   dependencies:
+    "@babel/plugin-proposal-export-namespace-from" "^7.17.12"
     "@babel/plugin-transform-object-assign" "^7.16.7"
     "@babel/preset-typescript" "^7.16.7"
     "@types/invariant" "^2.2.35"


### PR DESCRIPTION
# Why

Closes ENG-5515

# How

Run:
```
 et uvm --module "react-native-reanimated" --commit "2.9.1" --target "expo-go"
```

# Test Plan

- NCL ✅
> Note: some functionalities couldn't be tested, because they require a newer version of the gesture handler.