### PR TITLE
[ci][tools] another attempt to fix android instrumented test failures

### DIFF
--- a/.github/actions/expo-caches/action.yml
+++ b/.github/actions/expo-caches/action.yml
@@ -162,7 +162,7 @@ runs:
         path: |
           ~/.android/avd/*
           ~/.android/adb*
-        key: avd-v2-${{ inputs.avd-api }}
+        key: avd-${{ inputs.avd-api }}
     - name: 📱 Create AVD and generate snapshot for caching
       if: inputs.avd == 'true' && steps.avd-cache.outputs.cache-hit != 'true'
       uses: reactivecircus/android-emulator-runner@v2

--- a/tools/src/commands/AndroidNativeUnitTests.ts
+++ b/tools/src/commands/AndroidNativeUnitTests.ts
@@ -92,6 +92,13 @@ export async function androidNativeUnitTests({
     (element) => packagesNeedToBeTestedUsingBareExpo.includes(element.packageName)
   );
 
+  if (type === 'instrumented') {
+    // Uninstall tests first to fix the `INSTALL_FAILED_UPDATE_INCOMPATIBLE` error from cached AVD in CI environment.
+    const uninstallTestCommand = 'uninstallDebugAndroidTest';
+    await runGradlew(androidPackagesTestedUsingExpoProject, uninstallTestCommand, ANDROID_DIR);
+    await runGradlew(androidPackagesTestedUsingBareProject, uninstallTestCommand, BARE_EXPO_DIR);
+  }
+
   await runGradlew(androidPackagesTestedUsingExpoProject, testCommand, ANDROID_DIR);
   await runGradlew(androidPackagesTestedUsingBareProject, testCommand, BARE_EXPO_DIR);
   console.log(chalk.green('Finished android unit tests successfully.'));


### PR DESCRIPTION
# Why

fix the `INSTALL_FAILED_UPDATE_INCOMPATIBLE` error in android instrumentation test: https://github.com/expo/expo/runs/7183161830?check_suite_focus=true

# How

- revert the cache key change: https://github.com/expo/expo/commit/0a93d66dfccb1612949fa1299c7a1adbe7491673
- it looks like it's APG change to keep the intermediate test files. this pr attempts to remove the test files first.

# Test Plan

android instrumentation ci passed: https://github.com/expo/expo/runs/7183730168?check_suite_focus=true

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
