### PR TITLE
[ncl][ImagePicker] Preview multiple images

### DIFF
--- a/apps/native-component-list/src/screens/ImagePicker/ImageOrVideoPreview.tsx
+++ b/apps/native-component-list/src/screens/ImagePicker/ImageOrVideoPreview.tsx
@@ -1,8 +1,24 @@
 import { ResizeMode, Video } from 'expo-av';
 import React from 'react';
-import { View, StyleSheet, Image } from 'react-native';
+import { View, StyleSheet, Image, FlatList } from 'react-native';
 
-export default function ImageOrVideo(result: unknown) {
+export default function ImageOrVideo(result: unknown): JSX.Element | void {
+  if (isMultipleSelectionResult(result)) {
+    if (result.selected.length === 1) {
+      return ImageOrVideo(result.selected[0]);
+    }
+
+    return (
+      <View style={styles.container}>
+        <FlatList
+          horizontal
+          data={result.selected}
+          renderItem={({ item, index }) => <View key={index}>{ImageOrVideo(item) ?? null}</View>}
+        />
+      </View>
+    );
+  }
+
   if (!isAnObjectWithUriAndType(result)) {
     return;
   }
@@ -30,6 +46,15 @@ function isAnObjectWithUriAndType(obj: unknown): obj is { uri: string; type: str
     obj !== null &&
     typeof (obj as any).uri === 'string' &&
     typeof (obj as any).type === 'string'
+  );
+}
+
+function isMultipleSelectionResult(obj: unknown): obj is { cancelled: false; selected: unknown[] } {
+  return (
+    typeof obj === 'object' &&
+    obj !== null &&
+    (obj as any).cancelled === false &&
+    Array.isArray((obj as any).selected)
   );
 }
 


### PR DESCRIPTION
# Why

- On web, `expo-image-picker` supported picking multiple images, but when doing so, no preview was displayed on the ImagePicker NCL screen.
- Useful when testing iOS picker multi-select

# How

Made `ImageOrVideo` component recursive - in case of multiple images, it displays a scrollable horizontal flatlist.

This could be possibly prettified more, but I don't think it's worth it for now.

# Test Plan


https://user-images.githubusercontent.com/278340/177273376-e5d892a5-bc70-409e-9a05-113e320fb424.mov

