### PR TITLE
[docs] EAS Build - add ubuntu 22.04 image

### DIFF
--- a/docs/pages/build-reference/infrastructure.md
+++ b/docs/pages/build-reference/infrastructure.md
@@ -56,7 +56,35 @@ When selecting an image for the build you can use the full name provided below o
   enableImmutableInstalls: false
   ```
 
-#### Image `ubuntu-20.04-jdk-11-ndk-r21e` (alias `latest`)
+#### Image `ubuntu-22.04-jdk-11-ndk-r21e` (alias `latest`)
+
+<Collapsible summary="Details">
+
+- Docker image: `ubuntu:jammy-20220531`
+- NDK 21.4.7075529
+- Node.js 16.13.2
+- Yarn 1.22.17
+- pnpm 7.0.0
+- npm 8.1.2
+- Java 11
+
+</Collapsible>
+
+#### Image `ubuntu-22.04-jdk-8-ndk-r21e`
+
+<Collapsible summary="Details">
+
+- Docker image: `ubuntu:jammy-20220531`
+- NDK 21.4.7075529
+- Node.js 16.13.2
+- Yarn 1.22.17
+- pnpm 7.0.0
+- npm 8.1.2
+- Java 8
+
+</Collapsible>
+
+#### Image `ubuntu-20.04-jdk-11-ndk-r21e` (alias `default`)
 
 <Collapsible summary="Details">
 
@@ -64,6 +92,7 @@ When selecting an image for the build you can use the full name provided below o
 - NDK 21.4.7075529
 - Node.js 16.13.2
 - Yarn 1.22.17
+- pnpm 7.0.0
 - npm 8.1.2
 - Java 11
 
@@ -77,6 +106,7 @@ When selecting an image for the build you can use the full name provided below o
 - NDK 21.4.7075529
 - Node.js 16.13.2
 - Yarn 1.22.17
+- pnpm 7.0.0
 - npm 8.1.2
 - Java 8
 
@@ -90,12 +120,13 @@ When selecting an image for the build you can use the full name provided below o
 - NDK 19.2.5345600
 - Node.js 16.13.2
 - Yarn 1.22.17
+- pnpm 7.0.0
 - npm 8.1.2
 - Java 11
 
 </Collapsible>
 
-#### Image `ubuntu-18.04-jdk-8-ndk-r19c` (alias `default`)
+#### Image `ubuntu-18.04-jdk-8-ndk-r19c`
 
 <Collapsible summary="Details">
 
@@ -103,6 +134,7 @@ When selecting an image for the build you can use the full name provided below o
 - NDK 19.2.5345600
 - Node.js 16.13.2
 - Yarn 1.22.17
+- pnpm 7.0.0
 - npm 8.1.2
 - Java 8
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

add 2 new images and missing info about pnpm versions

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
