### PR TITLE
[Go][Android][iOS] Upgrade `@react-native-picker/picker@2.4.0` ➡️ `2.4.2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Package-specific changes not released in any SDK will be added here just before 
 
 ### 📚 3rd party library updates
 
+- Updated `@react-native-picker/picker` from `2.4.0` to `2.4.2`. ([#18098](https://github.com/expo/expo/pull/18098) by [@bbarthec](https://github.com/bbarthec))
 - Updated `lottie-react-native` from `5.0.1` to `5.1.3`. ([#18051](https://github.com/expo/expo/pull/18051) by [@lukmccall](https://github.com/lukmccall))
 - Updated `react-native-view-shot` from `3.1.2` to `3.3.0`. ([#18050](https://github.com/expo/expo/pull/18050) by [@lukmccall](https://github.com/lukmccall))
 - Updated `react-native-maps` from `0.30.2` to `0.31.1`. ([#18052](https://github.com/expo/expo/pull/18052) by [@lukmccall](https://github.com/lukmccall))

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/picker/ReactPicker.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/picker/ReactPicker.java
@@ -7,6 +7,8 @@
 
 package versioned.host.exp.exponent.modules.api.components.picker;
 
+import host.exp.expoview.R;
+
 import android.content.Context;
 import android.content.ContextWrapper;
 import android.content.res.ColorStateList;
@@ -29,7 +31,6 @@ import com.facebook.react.modules.i18nmanager.I18nUtil;
 import com.facebook.react.uimanager.UIManagerModule;
 
 import javax.annotation.Nullable;
-import host.exp.expoview.R;
 
 public class ReactPicker extends AppCompatSpinner {
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/picker/ReactPickerManager.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/picker/ReactPickerManager.java
@@ -7,6 +7,8 @@
 
 package versioned.host.exp.exponent.modules.api.components.picker;
 
+import host.exp.expoview.R;
+
 import android.content.Context;
 import android.graphics.Color;
 import android.graphics.Typeface;
@@ -32,7 +34,6 @@ import com.facebook.react.uimanager.events.EventDispatcher;
 import java.util.Map;
 
 import javax.annotation.Nullable;
-import host.exp.expoview.R;
 
 /**
  * {@link ViewManager} for the {@link ReactPicker} view. This is abstract because the

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -97,7 +97,7 @@
     "@react-native-community/slider": "4.2.1",
     "@react-native-community/viewpager": "5.0.11",
     "@react-native-masked-view/masked-view": "0.2.6",
-    "@react-native-picker/picker": "2.4.0",
+    "@react-native-picker/picker": "2.4.2",
     "@react-native-segmented-control/segmented-control": "2.4.0",
     "expo": "~45.0.0-beta.1",
     "expo-camera": "~12.2.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -46,7 +46,7 @@
     "@react-native-community/netinfo": "9.3.0",
     "@react-native-community/slider": "4.2.1",
     "@react-native-masked-view/masked-view": "0.2.6",
-    "@react-native-picker/picker": "2.4.0",
+    "@react-native-picker/picker": "2.4.2",
     "@react-native-segmented-control/segmented-control": "2.4.0",
     "@react-navigation/bottom-tabs": "~5.11.1",
     "@react-navigation/drawer": "5.11.4",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -6,7 +6,7 @@
   "@react-native-community/netinfo": "9.3.0",
   "@react-native-community/slider": "4.2.1",
   "@react-native-community/viewpager": "5.0.11",
-  "@react-native-picker/picker": "2.4.0",
+  "@react-native-picker/picker": "2.4.2",
   "@react-native-segmented-control/segmented-control": "2.4.0",
   "@stripe/stripe-react-native": "0.6.0",
   "expo-ads-admob": "~13.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3224,10 +3224,10 @@
   resolved "https://registry.yarnpkg.com/@react-native-masked-view/masked-view/-/masked-view-0.2.6.tgz#b26c52d5db3ad0926b13deea79c69620966a9221"
   integrity sha512-303CxmetUmgiX9NSUxatZkNh9qTYYdiM8xkGf9I3Uj20U3eGY3M78ljeNQ4UVCJA+FNGS5nC1dtS9GjIqvB4dg==
 
-"@react-native-picker/picker@2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@react-native-picker/picker/-/picker-2.4.0.tgz#7ca2e01a3bdf854ee01ca752762ffa73c0e83313"
-  integrity sha512-duGZc3a8Qa21YPrA4U3oR9NAUzBA66FTjubGK2CodA6rNjiwN+xC32hOZ5unkf4qD3DqLWeoPjg3fYf54bVMjA==
+"@react-native-picker/picker@2.4.2":
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/@react-native-picker/picker/-/picker-2.4.2.tgz#2925eb8e76ff6b584c80529adc251df963be9141"
+  integrity sha512-0nY8638h1J3wKz6P3IJMpOoxJDdOj7Dk/K2hP/xpqP3KnIY0lmoqYlhyNihuyVPocDGajf6SA7LFFsFepQ56ag==
 
 "@react-native-segmented-control/segmented-control@2.4.0":
   version "2.4.0"


### PR DESCRIPTION
# Why

Resolves [ENG-5513](https://linear.app/expo/issue/ENG-5513/react-native-pickerpicker-240-%E2%9E%A1%EF%B8%8F-242)

# How


1. `et uvm -m @react-native-picker/picker --commit v2.4.2`
2. adjusted legacy vendoring script to add missing import

# Test Plan

`Expo Go` compiles and runs `ncl`
