### PR TITLE
Revert "[expo-av][iOS] Fix `unloadAsync` race conditions (#18076)"

### DIFF
--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -11,7 +11,6 @@
 
 ### 🐛 Bug fixes
 
-- On iOS try to fix `Video` component crashes when Video unmounts before the React Native bridge is able to send out the `unloadAsync()` command. ([#18076](https://github.com/expo/expo/pull/18076) by [@hirbod](https://github.com/hirbod) and [@Pickleboyonline](https://github.com/Pickleboyonline))
 - On Android fix `Video` component crashes when activity loses focus due to accessing player from the wrong thread. ([#17280](https://github.com/expo/expo/pull/17280) by [@mnightingale](https://github.com/mnightingale))
 - Added support for React Native 0.69.x. ([#18006](https://github.com/expo/expo/pull/18006) by [@kudo](https://github.com/kudo))
 - On Android fix `Audio.setAudioModeAsync` and `Audio.setIsEnabledAsync` crashes due to accessing player from the wrong thread. ([#17840](https://github.com/expo/expo/pull/17840) by [@mnightingale](https://github.com/mnightingale))

--- a/packages/expo-av/ios/EXAV/Video/EXVideoView.m
+++ b/packages/expo-av/ios/EXAV/Video/EXVideoView.m
@@ -765,8 +765,8 @@ willEndFullScreenPresentationWithAnimationCoordinator:(id<UIViewControllerTransi
 
 - (void)dealloc
 {
-  [self setSource:nil];
   [_exAV unregisterVideoForAudioLifecycle:self];
+  [_data pauseImmediately];
   [_exAV demoteAudioSessionIfPossible];
 }
 


### PR DESCRIPTION
# Why

https://github.com/expo/expo/pull/18076#issuecomment-1174827838

This causes crashes when unmounting `<Video>` components. Looks like `EX_WEAKIFY(self)` cannot be called inside `dealloc`

# How

This reverts commit 857f814a92e6fbbf9c1540de3f45eff5df2d94ea.

# Test Plan

none