### PR TITLE
Fixed deprecation of linking event listener and logical error

### DIFF
--- a/docs/pages/versions/unversioned/sdk/notifications.md
+++ b/docs/pages/versions/unversioned/sdk/notifications.md
@@ -671,7 +671,7 @@ export default function App() {
         async getInitialURL() {
           // First, you may want to do the default deep link handling
           // Check if app was opened from a deep link
-          const url = await Linking.getInitialURL();
+          let url = await Linking.getInitialURL();
 
           if (url != null) {
             return url;
@@ -679,7 +679,7 @@ export default function App() {
 
           // Handle URL from expo push notifications
           const response = await Notifications.getLastNotificationResponseAsync();
-          const url = response?.notification.request.content.data.url;
+          url = response?.notification.request.content.data.url;
 
           return url;
         }
@@ -687,7 +687,7 @@ export default function App() {
           const onReceiveURL = ({ url }: { url: string }) => listener(url);
 
           // Listen to incoming links from deep linking
-          Linking.addEventListener('url', onReceiveURL);
+          const linkingEventListener = Linking.addEventListener('url', onReceiveURL);
 
           // Listen to expo push notifications
           const subscription = Notifications.addNotificationResponseReceivedListener(response => {
@@ -702,7 +702,7 @@ export default function App() {
 
           return () => {
             // Clean up the event listeners
-            Linking.removeEventListener('url', onReceiveURL);
+            linkingEventListener.remove();
             subscription.remove();
           };
         },


### PR DESCRIPTION
# Why

Linking removeEventListener is deprecated -> [Link](https://reactnative.dev/docs/linking#removeeventlistener)
Notification doc example code syntax error fixed -> [Link](https://reactnative.dev/docs/linking#removeeventlistener)
```js
...
async getInitialURL() {
  // First, you may want to do the default deep link handling
  // Check if app was opened from a deep link
  const url = await Linking.getInitialURL();

  if (url != null) {
    return url;
  }

  // Handle URL from expo push notifications
  const response = await Notifications.getLastNotificationResponseAsync();
  const url = response?.notification.request.content.data.url;

  return url;
}
...
```
`url` variable was defined two times with `const`

# How

I'm taking syntax error about the "url", like this:
```
Identifier 'url' has already been declared.
```

# Test Plan

Tested on my personal project.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
