### PR TITLE
[docs] tweaks and small fixes for APISection after redesign

### DIFF
--- a/docs/components/base/list.tsx
+++ b/docs/components/base/list.tsx
@@ -67,6 +67,7 @@ export const OL: React.FC = ({ children }) => (
 );
 
 const STYLES_LIST_ITEM = css`
+  margin-left: 1rem;
   padding: 0.25rem 0;
   :before {
     font-size: 130%;

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -899,7 +899,7 @@ in here.
         data-text="true"
       >
         <li
-          class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
+          class="docs-list-item css-kaip35-STYLES_LIST_ITEM-LI"
         >
           <code
             class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -1220,7 +1220,7 @@ This should come from the user field of an
       data-text="true"
     >
       <li
-        class="docs-list-item css-1wwpkbk-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+        class="docs-list-item css-1yggycy-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
       >
         <code
           class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -1389,7 +1389,7 @@ value depending on the state of the credential.
       data-text="true"
     >
       <li
-        class="docs-list-item css-1wwpkbk-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+        class="docs-list-item css-1yggycy-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
       >
         <code
           class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -1632,7 +1632,7 @@ Calling this method will show the sign in modal before actually refreshing the u
       data-text="true"
     >
       <li
-        class="docs-list-item css-1wwpkbk-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+        class="docs-list-item css-1yggycy-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
       >
         <code
           class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -1931,7 +1931,7 @@ the user, since this remains the same for apps released by the same developer.
       data-text="true"
     >
       <li
-        class="docs-list-item css-1wwpkbk-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+        class="docs-list-item css-1yggycy-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
       >
         <code
           class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -2216,7 +2216,7 @@ from using
       data-text="true"
     >
       <li
-        class="docs-list-item css-1wwpkbk-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+        class="docs-list-item css-1yggycy-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
       >
         <code
           class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -2499,7 +2499,7 @@ sign-out operation.
       data-text="true"
     >
       <li
-        class="docs-list-item css-1wwpkbk-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+        class="docs-list-item css-1yggycy-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
       >
         <code
           class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -7207,7 +7207,7 @@ Same as
         data-text="true"
       >
         <li
-          class="docs-list-item css-xdejd6-STYLES_LIST_ITEM-LI"
+          class="docs-list-item css-kaip35-STYLES_LIST_ITEM-LI"
         >
           <code
             class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -7476,7 +7476,7 @@ This can be used to quickly create specific permission hooks in every module.
       data-text="true"
     >
       <li
-        class="docs-list-item css-1wwpkbk-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+        class="docs-list-item css-1yggycy-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
       >
         <code
           class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -7706,7 +7706,7 @@ This can be used to quickly create specific permission hooks in every module.
       data-text="true"
     >
       <li
-        class="docs-list-item css-1wwpkbk-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+        class="docs-list-item css-1yggycy-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
       >
         <code
           class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -7893,7 +7893,7 @@ This can be used to quickly create specific permission hooks in every module.
       data-text="true"
     >
       <li
-        class="docs-list-item css-1wwpkbk-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+        class="docs-list-item css-1yggycy-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
       >
         <code
           class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -8209,7 +8209,7 @@ the platform.
       data-text="true"
     >
       <li
-        class="docs-list-item css-1wwpkbk-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+        class="docs-list-item css-1yggycy-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
       >
         <code
           class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -10396,7 +10396,7 @@ exports[`APISection expo-pedometer 1`] = `
       data-text="true"
     >
       <li
-        class="docs-list-item css-1wwpkbk-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+        class="docs-list-item css-1yggycy-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
       >
         <code
           class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -10650,7 +10650,7 @@ exports[`APISection expo-pedometer 1`] = `
       data-text="true"
     >
       <li
-        class="docs-list-item css-1wwpkbk-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+        class="docs-list-item css-1yggycy-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
       >
         <code
           class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -10885,7 +10885,7 @@ a start date that is more than seven days in the past returns only the available
       data-text="true"
     >
       <li
-        class="docs-list-item css-1wwpkbk-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+        class="docs-list-item css-1yggycy-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
       >
         <code
           class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -11038,7 +11038,7 @@ available on this device.
       data-text="true"
     >
       <li
-        class="docs-list-item css-1wwpkbk-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+        class="docs-list-item css-1yggycy-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
       >
         <code
           class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -11268,7 +11268,7 @@ provided with a single argument that is
       data-text="true"
     >
       <li
-        class="docs-list-item css-1wwpkbk-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+        class="docs-list-item css-1yggycy-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
       >
         <code
           class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -9699,16 +9699,17 @@ For some types, they will represent the area used by the scanner.
         >
           <span
             class="css-zonpcr-STYLES_PERMALINK_TARGET"
-            id="interface-properties"
+            id="permissionresponse--properties"
           />
           <a
             class="css-15lh5hg-STYLES_PERMALINK_LINK"
-            href="#interface-properties"
+            href="#permissionresponse--properties"
           >
             <span
               class="css-1icvi79-STYLED_PERMALINK_CONTENT"
             >
-              Interface Properties
+              PermissionResponse
+               Properties
             </span>
             <span
               class="css-10vdcw8-STYLES_PERMALINK_ICON"
@@ -11934,16 +11935,17 @@ provided with a single argument that is
         >
           <span
             class="css-zonpcr-STYLES_PERMALINK_TARGET"
-            id="interface-properties"
+            id="permissionresponse--properties"
           />
           <a
             class="css-15lh5hg-STYLES_PERMALINK_LINK"
-            href="#interface-properties"
+            href="#permissionresponse--properties"
           >
             <span
               class="css-1icvi79-STYLED_PERMALINK_CONTENT"
             >
-              Interface Properties
+              PermissionResponse
+               Properties
             </span>
             <span
               class="css-10vdcw8-STYLES_PERMALINK_ICON"

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -4961,10 +4961,9 @@ OAuth 2.0 protocol
          
       </strong>
       <div
-        class="css-1jhkqst-platformTagStyle-platformTagFirstStyle-iosPlatformTagStyle-PlatformTags"
+        class="css-a7xwy7-platformTagStyle-platformTagFirstStyle-iosPlatformTagStyle-PlatformTags"
       >
         <svg
-          class="css-g1rf8s-platformTagIconStyle"
           color="var(--expo-theme-palette-blue-900)"
           fill="none"
           height="12"
@@ -4981,7 +4980,11 @@ OAuth 2.0 protocol
             fill="var(--expo-theme-palette-blue-900)"
           />
         </svg>
-        iOS 13.2+
+        <span
+          class="css-m237xp-platformLabelStyle"
+        >
+          iOS 13.2+
+        </span>
       </div>
       <br />
       <div

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -4961,7 +4961,7 @@ OAuth 2.0 protocol
          
       </strong>
       <div
-        class="css-a7xwy7-platformTagStyle-platformTagFirstStyle-iosPlatformTagStyle-PlatformTags"
+        class="css-1vg2gvk-platformTagStyle-platformTagFirstStyle-iosPlatformTagStyle-PlatformTags"
       >
         <svg
           color="var(--expo-theme-palette-blue-900)"
@@ -4981,7 +4981,7 @@ OAuth 2.0 protocol
           />
         </svg>
         <span
-          class="css-m237xp-platformLabelStyle"
+          class="css-41aakw-platformLabelStyle"
         >
           iOS 13.2+
         </span>

--- a/docs/components/plugins/api/APISectionClasses.tsx
+++ b/docs/components/plugins/api/APISectionClasses.tsx
@@ -83,7 +83,9 @@ const renderClass = (clx: ClassDefinitionData, hasMultipleClasses: boolean): JSX
       <CommentTextBlock comment={comment} />
       {returnComment && (
         <>
-          <H4>Returns</H4>
+          <div css={STYLES_NESTED_SECTION_HEADER}>
+            <H4>Returns</H4>
+          </div>
           <ReactMarkdown components={mdComponents}>{returnComment.text}</ReactMarkdown>
         </>
       )}

--- a/docs/components/plugins/api/APISectionInterfaces.tsx
+++ b/docs/components/plugins/api/APISectionInterfaces.tsx
@@ -30,13 +30,13 @@ export type APISectionInterfacesProps = {
 };
 
 const renderDefaultValue = (defaultValue?: CommentTagData) =>
-  defaultValue ? (
+  defaultValue && (
     <>
       <br />
       <br />
       <B>Default:</B> <InlineCode>{defaultValue.text}</InlineCode>
     </>
-  ) : null;
+  );
 
 const renderInterfaceComment = (comment?: CommentData, signatures?: MethodSignatureData[]) => {
   if (signatures && signatures.length) {
@@ -125,7 +125,7 @@ const renderInterface = ({
       {interfaceMethods.length ? (
         <>
           <div css={STYLES_NESTED_SECTION_HEADER}>
-            <H4>Interface Methods</H4>
+            <H4>{name} Methods</H4>
           </div>
           {interfaceMethods.map(method => renderMethod(method))}
         </>
@@ -133,7 +133,7 @@ const renderInterface = ({
       {interfaceFields.length ? (
         <>
           <div css={STYLES_NESTED_SECTION_HEADER}>
-            <H4>Interface Properties</H4>
+            <H4>{name} Properties</H4>
           </div>
           <Table>
             {renderTableHeadRow()}

--- a/docs/components/plugins/api/APISectionPlatformTags.tsx
+++ b/docs/components/plugins/api/APISectionPlatformTags.tsx
@@ -35,7 +35,7 @@ const getPlatformName = ({ text }: CommentTagData) => {
 };
 
 const renderPlatformIcon = (platform: CommentTagData) => {
-  const iconProps = { size: iconSize.micro, css: platformTagIconStyle };
+  const iconProps = { size: iconSize.micro };
 
   switch (getPlatformName(platform)) {
     case 'ios':
@@ -50,7 +50,6 @@ const renderPlatformIcon = (platform: CommentTagData) => {
           width={iconProps.size}
           height={iconProps.size}
           color={theme.palette.purple['900']}
-          css={iconProps.css}
         />
       );
     default:
@@ -83,7 +82,7 @@ export const PlatformTags = ({ comment, prefix, firstElement }: Props) => {
               platformName === 'expo' && expoPlatformStyle,
             ]}>
             {renderPlatformIcon(platform)}
-            {formatPlatformName(platform.text)}
+            <span css={platformLabelStyle}>{formatPlatformName(platform.text)}</span>
           </div>
         );
       })}
@@ -93,7 +92,7 @@ export const PlatformTags = ({ comment, prefix, firstElement }: Props) => {
 };
 
 const platformTagStyle = css({
-  display: 'inline-block',
+  display: 'inline-flex',
   backgroundColor: theme.background.tertiary,
   color: theme.text.default,
   fontSize: '90%',
@@ -103,6 +102,8 @@ const platformTagStyle = css({
   marginRight: spacing[2],
   borderRadius: borderRadius.small,
   border: `1px solid ${theme.border.default}`,
+  alignItems: 'center',
+  gap: spacing[1],
 
   'table &': {
     marginTop: 0,
@@ -116,10 +117,8 @@ const platformTagFirstStyle = css({
   marginTop: spacing[3],
 });
 
-const platformTagIconStyle = css({
-  marginRight: spacing[1],
-  marginBottom: spacing[0.5],
-  verticalAlign: 'middle',
+const platformLabelStyle = css({
+  verticalAlign: 'text-top',
 });
 
 const androidPlatformTagStyle = css({

--- a/docs/components/plugins/api/APISectionPlatformTags.tsx
+++ b/docs/components/plugins/api/APISectionPlatformTags.tsx
@@ -108,7 +108,7 @@ const platformTagStyle = css({
   'table &': {
     marginTop: 0,
     marginBottom: spacing[2],
-    padding: `0 ${spacing[1.5]}px`,
+    padding: `${spacing[0.5]}px ${spacing[1.5]}px`,
   },
 });
 
@@ -118,7 +118,7 @@ const platformTagFirstStyle = css({
 });
 
 const platformLabelStyle = css({
-  verticalAlign: 'text-top',
+  lineHeight: `${spacing[4]}px`,
 });
 
 const androidPlatformTagStyle = css({

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -570,8 +570,8 @@ export const STYLES_SECONDARY = css({
 });
 
 const defaultValueContainerStyle = css({
-  marginTop: spacing[2]
-})
+  marginTop: spacing[2],
+});
 
 const deprecationNoticeStyle = css({
   marginBottom: spacing[2],

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -7,7 +7,7 @@ import remarkGfm from 'remark-gfm';
 import { Code, InlineCode } from '~/components/base/code';
 import { H4 } from '~/components/base/headings';
 import Link from '~/components/base/link';
-import { LI, UL } from '~/components/base/list';
+import { LI, UL, OL } from '~/components/base/list';
 import { B, P, Quote } from '~/components/base/paragraph';
 import {
   CommentData,
@@ -53,6 +53,7 @@ export const mdComponents: MDComponents = {
     className ? <Code className={className}>{children}</Code> : <InlineCode>{children}</InlineCode>,
   h1: ({ children }) => <H4>{children}</H4>,
   ul: ({ children }) => <UL>{children}</UL>,
+  ol: ({ children }) => <OL>{children}</OL>,
   li: ({ children }) => <LI>{children}</LI>,
   a: ({ href, children }) => {
     if (

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -19,6 +19,7 @@ import {
 } from '~/components/plugins/api/APIDataTypes';
 import { PlatformTags } from '~/components/plugins/api/APISectionPlatformTags';
 import * as Constants from '~/constants/theme';
+import { Callout } from '~/ui/components/Callout';
 import { Cell, HeaderCell, Row, Table, TableHead } from '~/ui/components/Table';
 import { tableWrapperStyle } from '~/ui/components/Table/Table';
 
@@ -361,9 +362,7 @@ export const renderDefaultValue = (defaultValue?: string) =>
   defaultValue ? (
     <>
       <br />
-      <br />
-      <B>Default: </B>
-      <InlineCode>{defaultValue}</InlineCode>
+      <B>Default:</B> <InlineCode>{defaultValue}</InlineCode>
     </>
   ) : undefined;
 
@@ -401,8 +400,8 @@ export type CommentTextBlockProps = {
   comment?: CommentData;
   components?: MDComponents;
   withDash?: boolean;
-  beforeContent?: JSX.Element | null;
-  afterContent?: JSX.Element | null;
+  beforeContent?: JSX.Element;
+  afterContent?: JSX.Element;
   includePlatforms?: boolean;
   emptyCommentFallback?: string;
 };
@@ -465,14 +464,16 @@ export const CommentTextBlock = ({
 
   const deprecation = getTagData('deprecated', comment);
   const deprecationNote = deprecation ? (
-    <Quote key="deprecation-note">
-      {deprecation.text.trim().length ? (
-        <ReactMarkdown
-          components={mdInlineComponents}>{`**Deprecated.** ${deprecation.text}`}</ReactMarkdown>
-      ) : (
-        <B>Deprecated</B>
-      )}
-    </Quote>
+    <div css={deprecationNoticeStyle}>
+      <Callout type="warning" key="deprecation-note">
+        {deprecation.text.trim().length ? (
+          <ReactMarkdown
+            components={mdInlineComponents}>{`**Deprecated.** ${deprecation.text}`}</ReactMarkdown>
+        ) : (
+          <B>Deprecated</B>
+        )}
+      </Callout>
+    </div>
   ) : null;
 
   const see = getTagData('see', comment);
@@ -566,6 +567,10 @@ export const STYLES_SECONDARY = css({
   color: theme.text.secondary,
   fontSize: '90%',
   fontWeight: 600,
+});
+
+const deprecationNoticeStyle = css({
+  marginBottom: spacing[2],
 });
 
 const STYLES_EXAMPLE_IN_TABLE = css({

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -361,10 +361,9 @@ export const listParams = (parameters: MethodParamData[]) =>
 
 export const renderDefaultValue = (defaultValue?: string) =>
   defaultValue ? (
-    <>
-      <br />
+    <div css={defaultValueContainerStyle}>
       <B>Default:</B> <InlineCode>{defaultValue}</InlineCode>
-    </>
+    </div>
   ) : undefined;
 
 export const renderTypeOrSignatureType = (
@@ -569,6 +568,10 @@ export const STYLES_SECONDARY = css({
   fontSize: '90%',
   fontWeight: 600,
 });
+
+const defaultValueContainerStyle = css({
+  marginTop: spacing[2]
+})
 
 const deprecationNoticeStyle = css({
   marginBottom: spacing[2],

--- a/docs/ui/components/Callout/index.tsx
+++ b/docs/ui/components/Callout/index.tsx
@@ -4,6 +4,7 @@ import {
   iconSize,
   theme,
   typography,
+  spacing,
   ErrorIcon,
   InfoIcon,
   WarningIcon,
@@ -55,12 +56,13 @@ const containerStyle = css({
   border: `1px solid ${theme.border.default}`,
   borderRadius: borderRadius.medium,
   display: 'flex',
-  padding: '1rem',
+  padding: `${spacing[3]}px ${spacing[4]}px`,
 });
 
 const iconStyle = css({
   fontStyle: 'normal',
-  marginRight: '0.5rem',
+  marginRight: spacing[2],
+  marginTop: spacing[1],
   userSelect: 'none',
 });
 


### PR DESCRIPTION
# Why

This PR address some comments and suggestion which popped out after the initial land of APISection components redesign.

# How

The following changes have been made:
* fix unproportional spacing before the default value in the entry comment
  <img width="638" alt="Screenshot 2022-07-05 at 17 36 27" src="https://user-images.githubusercontent.com/719641/177365093-96750c76-e899-4c2f-b504-8bb958ff441b.png">

* use name of the interface instead of "Interface" in the nested headers (to match Classes and Components)
  <img width="1128" alt="Screenshot 2022-07-05 at 17 21 00" src="https://user-images.githubusercontent.com/719641/177362098-571acd45-573d-49b4-ae94-e25c9073118a.png">

* use new Callout component for the deprecation notices (their placement, as well as platform tags placement will be addressed in the separate PR)
  <img width="1118" alt="Screenshot 2022-07-05 at 17 18 38" src="https://user-images.githubusercontent.com/719641/177361636-36b59330-0c7d-4bce-b392-4f13c884c367.png">
  <img width="1118" alt="Screenshot 2022-07-05 at 17 18 34" src="https://user-images.githubusercontent.com/719641/177361643-bb110912-ec46-4925-a0db-965014748c56.png">

* add missing nested header styling for the Classes return value
  <img width="1121" alt="Screenshot 2022-07-05 at 17 31 53" src="https://user-images.githubusercontent.com/719641/177364217-f53e2b7e-9f11-4f4d-bf1e-f43be45ec343.png">

* fix OL list style in API comments
  <img width="828" alt="Screenshot 2022-07-05 at 17 29 04" src="https://user-images.githubusercontent.com/719641/177363992-889543bc-f70f-4a72-a234-89074ae24b74.png">


# Test Plan

The changes have been tested by running the docs website locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
