### PR TITLE
[docs] Collapsible: fix double marker issue on mobile

### DIFF
--- a/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
@@ -114,7 +114,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                   class="css-1gm7vyo-detailsStyle"
                 >
                   <summary
-                    class="css-wamx7z-summaryStyle"
+                    class="css-1g95ulf-summaryStyle"
                   >
                     <div
                       class="css-17fddbt-markerWrapperStyle"
@@ -240,7 +240,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                   class="css-1gm7vyo-detailsStyle"
                 >
                   <summary
-                    class="css-wamx7z-summaryStyle"
+                    class="css-1g95ulf-summaryStyle"
                   >
                     <div
                       class="css-17fddbt-markerWrapperStyle"
@@ -283,7 +283,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                   class="css-1gm7vyo-detailsStyle"
                 >
                   <summary
-                    class="css-wamx7z-summaryStyle"
+                    class="css-1g95ulf-summaryStyle"
                   >
                     <div
                       class="css-17fddbt-markerWrapperStyle"
@@ -409,7 +409,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                   class="css-1gm7vyo-detailsStyle"
                 >
                   <summary
-                    class="css-wamx7z-summaryStyle"
+                    class="css-1g95ulf-summaryStyle"
                   >
                     <div
                       class="css-17fddbt-markerWrapperStyle"
@@ -712,7 +712,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                   class="css-1gm7vyo-detailsStyle"
                 >
                   <summary
-                    class="css-wamx7z-summaryStyle"
+                    class="css-1g95ulf-summaryStyle"
                   >
                     <div
                       class="css-17fddbt-markerWrapperStyle"

--- a/docs/ui/components/Collapsible/index.tsx
+++ b/docs/ui/components/Collapsible/index.tsx
@@ -86,6 +86,10 @@ const summaryStyle = css({
   '&:hover span': {
     color: theme.text.secondary,
   },
+
+  '::-webkit-details-marker': {
+    display: 'none',
+  },
 });
 
 const markerWrapperStyle = css({


### PR DESCRIPTION
# Why

Fixes ENG-5603

# How

Add an additional CSS rule to hide default browser marker.

# Test Plan

The change has been tested by running docs website locally, and accessing it on the iOS device.

# Preview

![IMG_0524](https://user-images.githubusercontent.com/719641/177402492-d9281285-9069-4348-8832-01f3d8606216.PNG)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
