### PR TITLE
[docs] APISection: fixes and tweaks

### DIFF
--- a/docs/components/base/list.tsx
+++ b/docs/components/base/list.tsx
@@ -33,10 +33,14 @@ const STYLES_UNORDERED_LIST = css`
   }
 `;
 
-const STYLES_NO_LIST_STYLE = css`
-  list-style: none;
-  margin-left: 0;
-`;
+const STYLES_NO_LIST_STYLE = css({
+  listStyle: 'none',
+  marginLeft: 0,
+
+  li: {
+    marginLeft: '0.25rem',
+  },
+});
 
 type ULProps = {
   hideBullets?: boolean;
@@ -82,17 +86,6 @@ const STYLES_LIST_ITEM = css`
   }
 `;
 
-const STYLE_RETURN_LIST = css`
-  list-style-type: '⮑';
-  padding-left: 0.5rem;
-  margin-left: 0.25rem;
-
-  ::marker {
-    color: ${theme.icon.secondary};
-    font-size: 90%;
-  }
-`;
-
 const STYLE_PROP_LIST = css`
   ::marker {
     color: ${theme.text.secondary};
@@ -101,21 +94,13 @@ const STYLE_PROP_LIST = css`
 `;
 
 type LIProps = {
-  returnType?: boolean;
   propType?: boolean;
   customCss?: SerializedStyles;
 };
 
-export const LI: React.FC<LIProps> = ({ children, returnType, propType, customCss }) => {
+export const LI: React.FC<LIProps> = ({ children, propType, customCss }) => {
   return (
-    <li
-      css={[
-        STYLES_LIST_ITEM,
-        returnType && STYLE_RETURN_LIST,
-        propType && STYLE_PROP_LIST,
-        customCss,
-      ]}
-      className="docs-list-item">
+    <li css={[STYLES_LIST_ITEM, propType && STYLE_PROP_LIST, customCss]} className="docs-list-item">
       {children}
     </li>
   );

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -821,7 +821,14 @@ properties.
             Type:
           </span>
            
-          
+          <code
+            class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
+          >
+            (
+            ) =&gt;
+             
+            void
+          </code>
         </p>
         <p
           class="css-101h856-paragraph-STYLES_PARAGRAPH"
@@ -899,7 +906,7 @@ in here.
         data-text="true"
       >
         <li
-          class="docs-list-item css-kaip35-STYLES_LIST_ITEM-LI"
+          class="docs-list-item css-k6alsv-STYLES_LIST_ITEM-LI"
         >
           <code
             class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -1216,12 +1223,30 @@ This should come from the user field of an
       </h4>
     </div>
     <ul
-      class="css-1qha16q-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1b15szc-paragraph-STYLES_UNORDERED_LIST-STYLES_NO_LIST_STYLE-UL"
       data-text="true"
     >
       <li
-        class="docs-list-item css-1yggycy-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+        class="docs-list-item css-k6alsv-STYLES_LIST_ITEM-LI"
       >
+        <svg
+          class="css-1dx3xyv-returnIconStyles"
+          color="var(--expo-theme-icon-secondary)"
+          fill="none"
+          height="16"
+          role="img"
+          size="16"
+          viewBox="0 0 20 20"
+          width="16"
+        >
+          <title>
+            Undo-icon
+          </title>
+          <path
+            d="M7.982 7.664v3.98L0 6.657l7.982-4.99v3.98h6.941a5.044 5.044 0 015.044 5.045v7.938a1.009 1.009 0 11-2.017 0v-7.938a3.026 3.026 0 00-3.027-3.027h-6.94z"
+            fill="var(--expo-theme-icon-secondary)"
+          />
+        </svg>
         <code
           class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
         >
@@ -1385,12 +1410,30 @@ value depending on the state of the credential.
       </h4>
     </div>
     <ul
-      class="css-1qha16q-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1b15szc-paragraph-STYLES_UNORDERED_LIST-STYLES_NO_LIST_STYLE-UL"
       data-text="true"
     >
       <li
-        class="docs-list-item css-1yggycy-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+        class="docs-list-item css-k6alsv-STYLES_LIST_ITEM-LI"
       >
+        <svg
+          class="css-1dx3xyv-returnIconStyles"
+          color="var(--expo-theme-icon-secondary)"
+          fill="none"
+          height="16"
+          role="img"
+          size="16"
+          viewBox="0 0 20 20"
+          width="16"
+        >
+          <title>
+            Undo-icon
+          </title>
+          <path
+            d="M7.982 7.664v3.98L0 6.657l7.982-4.99v3.98h6.941a5.044 5.044 0 015.044 5.045v7.938a1.009 1.009 0 11-2.017 0v-7.938a3.026 3.026 0 00-3.027-3.027h-6.94z"
+            fill="var(--expo-theme-icon-secondary)"
+          />
+        </svg>
         <code
           class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
         >
@@ -1628,12 +1671,30 @@ Calling this method will show the sign in modal before actually refreshing the u
       </h4>
     </div>
     <ul
-      class="css-1qha16q-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1b15szc-paragraph-STYLES_UNORDERED_LIST-STYLES_NO_LIST_STYLE-UL"
       data-text="true"
     >
       <li
-        class="docs-list-item css-1yggycy-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+        class="docs-list-item css-k6alsv-STYLES_LIST_ITEM-LI"
       >
+        <svg
+          class="css-1dx3xyv-returnIconStyles"
+          color="var(--expo-theme-icon-secondary)"
+          fill="none"
+          height="16"
+          role="img"
+          size="16"
+          viewBox="0 0 20 20"
+          width="16"
+        >
+          <title>
+            Undo-icon
+          </title>
+          <path
+            d="M7.982 7.664v3.98L0 6.657l7.982-4.99v3.98h6.941a5.044 5.044 0 015.044 5.045v7.938a1.009 1.009 0 11-2.017 0v-7.938a3.026 3.026 0 00-3.027-3.027h-6.94z"
+            fill="var(--expo-theme-icon-secondary)"
+          />
+        </svg>
         <code
           class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
         >
@@ -1927,12 +1988,30 @@ the user, since this remains the same for apps released by the same developer.
       </h4>
     </div>
     <ul
-      class="css-1qha16q-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1b15szc-paragraph-STYLES_UNORDERED_LIST-STYLES_NO_LIST_STYLE-UL"
       data-text="true"
     >
       <li
-        class="docs-list-item css-1yggycy-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+        class="docs-list-item css-k6alsv-STYLES_LIST_ITEM-LI"
       >
+        <svg
+          class="css-1dx3xyv-returnIconStyles"
+          color="var(--expo-theme-icon-secondary)"
+          fill="none"
+          height="16"
+          role="img"
+          size="16"
+          viewBox="0 0 20 20"
+          width="16"
+        >
+          <title>
+            Undo-icon
+          </title>
+          <path
+            d="M7.982 7.664v3.98L0 6.657l7.982-4.99v3.98h6.941a5.044 5.044 0 015.044 5.045v7.938a1.009 1.009 0 11-2.017 0v-7.938a3.026 3.026 0 00-3.027-3.027h-6.94z"
+            fill="var(--expo-theme-icon-secondary)"
+          />
+        </svg>
         <code
           class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
         >
@@ -2212,12 +2291,30 @@ from using
       </h4>
     </div>
     <ul
-      class="css-1qha16q-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1b15szc-paragraph-STYLES_UNORDERED_LIST-STYLES_NO_LIST_STYLE-UL"
       data-text="true"
     >
       <li
-        class="docs-list-item css-1yggycy-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+        class="docs-list-item css-k6alsv-STYLES_LIST_ITEM-LI"
       >
+        <svg
+          class="css-1dx3xyv-returnIconStyles"
+          color="var(--expo-theme-icon-secondary)"
+          fill="none"
+          height="16"
+          role="img"
+          size="16"
+          viewBox="0 0 20 20"
+          width="16"
+        >
+          <title>
+            Undo-icon
+          </title>
+          <path
+            d="M7.982 7.664v3.98L0 6.657l7.982-4.99v3.98h6.941a5.044 5.044 0 015.044 5.045v7.938a1.009 1.009 0 11-2.017 0v-7.938a3.026 3.026 0 00-3.027-3.027h-6.94z"
+            fill="var(--expo-theme-icon-secondary)"
+          />
+        </svg>
         <code
           class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
         >
@@ -2495,12 +2592,30 @@ sign-out operation.
       </h4>
     </div>
     <ul
-      class="css-1qha16q-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1b15szc-paragraph-STYLES_UNORDERED_LIST-STYLES_NO_LIST_STYLE-UL"
       data-text="true"
     >
       <li
-        class="docs-list-item css-1yggycy-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+        class="docs-list-item css-k6alsv-STYLES_LIST_ITEM-LI"
       >
+        <svg
+          class="css-1dx3xyv-returnIconStyles"
+          color="var(--expo-theme-icon-secondary)"
+          fill="none"
+          height="16"
+          role="img"
+          size="16"
+          viewBox="0 0 20 20"
+          width="16"
+        >
+          <title>
+            Undo-icon
+          </title>
+          <path
+            d="M7.982 7.664v3.98L0 6.657l7.982-4.99v3.98h6.941a5.044 5.044 0 015.044 5.045v7.938a1.009 1.009 0 11-2.017 0v-7.938a3.026 3.026 0 00-3.027-3.027h-6.94z"
+            fill="var(--expo-theme-icon-secondary)"
+          />
+        </svg>
         <code
           class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
         >
@@ -4345,7 +4460,14 @@ OAuth 2.0 protocol
             <td
               class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
             >
-              
+              <code
+                class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
+              >
+                (
+                ) =&gt;
+                 
+                void
+              </code>
             </td>
             <td
               class="css-10p2pvz-tableCellStyle-fitContentStyle-Cell"
@@ -7210,7 +7332,7 @@ Same as
         data-text="true"
       >
         <li
-          class="docs-list-item css-kaip35-STYLES_LIST_ITEM-LI"
+          class="docs-list-item css-k6alsv-STYLES_LIST_ITEM-LI"
         >
           <code
             class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
@@ -7475,12 +7597,30 @@ This can be used to quickly create specific permission hooks in every module.
       </h4>
     </div>
     <ul
-      class="css-1qha16q-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1b15szc-paragraph-STYLES_UNORDERED_LIST-STYLES_NO_LIST_STYLE-UL"
       data-text="true"
     >
       <li
-        class="docs-list-item css-1yggycy-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+        class="docs-list-item css-k6alsv-STYLES_LIST_ITEM-LI"
       >
+        <svg
+          class="css-1dx3xyv-returnIconStyles"
+          color="var(--expo-theme-icon-secondary)"
+          fill="none"
+          height="16"
+          role="img"
+          size="16"
+          viewBox="0 0 20 20"
+          width="16"
+        >
+          <title>
+            Undo-icon
+          </title>
+          <path
+            d="M7.982 7.664v3.98L0 6.657l7.982-4.99v3.98h6.941a5.044 5.044 0 015.044 5.045v7.938a1.009 1.009 0 11-2.017 0v-7.938a3.026 3.026 0 00-3.027-3.027h-6.94z"
+            fill="var(--expo-theme-icon-secondary)"
+          />
+        </svg>
         <code
           class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
         >
@@ -7705,12 +7845,30 @@ This can be used to quickly create specific permission hooks in every module.
       </h4>
     </div>
     <ul
-      class="css-1qha16q-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1b15szc-paragraph-STYLES_UNORDERED_LIST-STYLES_NO_LIST_STYLE-UL"
       data-text="true"
     >
       <li
-        class="docs-list-item css-1yggycy-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+        class="docs-list-item css-k6alsv-STYLES_LIST_ITEM-LI"
       >
+        <svg
+          class="css-1dx3xyv-returnIconStyles"
+          color="var(--expo-theme-icon-secondary)"
+          fill="none"
+          height="16"
+          role="img"
+          size="16"
+          viewBox="0 0 20 20"
+          width="16"
+        >
+          <title>
+            Undo-icon
+          </title>
+          <path
+            d="M7.982 7.664v3.98L0 6.657l7.982-4.99v3.98h6.941a5.044 5.044 0 015.044 5.045v7.938a1.009 1.009 0 11-2.017 0v-7.938a3.026 3.026 0 00-3.027-3.027h-6.94z"
+            fill="var(--expo-theme-icon-secondary)"
+          />
+        </svg>
         <code
           class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
         >
@@ -7892,12 +8050,30 @@ This can be used to quickly create specific permission hooks in every module.
       </h4>
     </div>
     <ul
-      class="css-1qha16q-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1b15szc-paragraph-STYLES_UNORDERED_LIST-STYLES_NO_LIST_STYLE-UL"
       data-text="true"
     >
       <li
-        class="docs-list-item css-1yggycy-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+        class="docs-list-item css-k6alsv-STYLES_LIST_ITEM-LI"
       >
+        <svg
+          class="css-1dx3xyv-returnIconStyles"
+          color="var(--expo-theme-icon-secondary)"
+          fill="none"
+          height="16"
+          role="img"
+          size="16"
+          viewBox="0 0 20 20"
+          width="16"
+        >
+          <title>
+            Undo-icon
+          </title>
+          <path
+            d="M7.982 7.664v3.98L0 6.657l7.982-4.99v3.98h6.941a5.044 5.044 0 015.044 5.045v7.938a1.009 1.009 0 11-2.017 0v-7.938a3.026 3.026 0 00-3.027-3.027h-6.94z"
+            fill="var(--expo-theme-icon-secondary)"
+          />
+        </svg>
         <code
           class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
         >
@@ -8208,12 +8384,30 @@ the platform.
       </h4>
     </div>
     <ul
-      class="css-1qha16q-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1b15szc-paragraph-STYLES_UNORDERED_LIST-STYLES_NO_LIST_STYLE-UL"
       data-text="true"
     >
       <li
-        class="docs-list-item css-1yggycy-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+        class="docs-list-item css-k6alsv-STYLES_LIST_ITEM-LI"
       >
+        <svg
+          class="css-1dx3xyv-returnIconStyles"
+          color="var(--expo-theme-icon-secondary)"
+          fill="none"
+          height="16"
+          role="img"
+          size="16"
+          viewBox="0 0 20 20"
+          width="16"
+        >
+          <title>
+            Undo-icon
+          </title>
+          <path
+            d="M7.982 7.664v3.98L0 6.657l7.982-4.99v3.98h6.941a5.044 5.044 0 015.044 5.045v7.938a1.009 1.009 0 11-2.017 0v-7.938a3.026 3.026 0 00-3.027-3.027h-6.94z"
+            fill="var(--expo-theme-icon-secondary)"
+          />
+        </svg>
         <code
           class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
         >
@@ -10395,12 +10589,30 @@ exports[`APISection expo-pedometer 1`] = `
       </h4>
     </div>
     <ul
-      class="css-1qha16q-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1b15szc-paragraph-STYLES_UNORDERED_LIST-STYLES_NO_LIST_STYLE-UL"
       data-text="true"
     >
       <li
-        class="docs-list-item css-1yggycy-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+        class="docs-list-item css-k6alsv-STYLES_LIST_ITEM-LI"
       >
+        <svg
+          class="css-1dx3xyv-returnIconStyles"
+          color="var(--expo-theme-icon-secondary)"
+          fill="none"
+          height="16"
+          role="img"
+          size="16"
+          viewBox="0 0 20 20"
+          width="16"
+        >
+          <title>
+            Undo-icon
+          </title>
+          <path
+            d="M7.982 7.664v3.98L0 6.657l7.982-4.99v3.98h6.941a5.044 5.044 0 015.044 5.045v7.938a1.009 1.009 0 11-2.017 0v-7.938a3.026 3.026 0 00-3.027-3.027h-6.94z"
+            fill="var(--expo-theme-icon-secondary)"
+          />
+        </svg>
         <code
           class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
         >
@@ -10649,12 +10861,30 @@ exports[`APISection expo-pedometer 1`] = `
       </h4>
     </div>
     <ul
-      class="css-1qha16q-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1b15szc-paragraph-STYLES_UNORDERED_LIST-STYLES_NO_LIST_STYLE-UL"
       data-text="true"
     >
       <li
-        class="docs-list-item css-1yggycy-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+        class="docs-list-item css-k6alsv-STYLES_LIST_ITEM-LI"
       >
+        <svg
+          class="css-1dx3xyv-returnIconStyles"
+          color="var(--expo-theme-icon-secondary)"
+          fill="none"
+          height="16"
+          role="img"
+          size="16"
+          viewBox="0 0 20 20"
+          width="16"
+        >
+          <title>
+            Undo-icon
+          </title>
+          <path
+            d="M7.982 7.664v3.98L0 6.657l7.982-4.99v3.98h6.941a5.044 5.044 0 015.044 5.045v7.938a1.009 1.009 0 11-2.017 0v-7.938a3.026 3.026 0 00-3.027-3.027h-6.94z"
+            fill="var(--expo-theme-icon-secondary)"
+          />
+        </svg>
         <code
           class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
         >
@@ -10884,12 +11114,30 @@ a start date that is more than seven days in the past returns only the available
       </h4>
     </div>
     <ul
-      class="css-1qha16q-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1b15szc-paragraph-STYLES_UNORDERED_LIST-STYLES_NO_LIST_STYLE-UL"
       data-text="true"
     >
       <li
-        class="docs-list-item css-1yggycy-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+        class="docs-list-item css-k6alsv-STYLES_LIST_ITEM-LI"
       >
+        <svg
+          class="css-1dx3xyv-returnIconStyles"
+          color="var(--expo-theme-icon-secondary)"
+          fill="none"
+          height="16"
+          role="img"
+          size="16"
+          viewBox="0 0 20 20"
+          width="16"
+        >
+          <title>
+            Undo-icon
+          </title>
+          <path
+            d="M7.982 7.664v3.98L0 6.657l7.982-4.99v3.98h6.941a5.044 5.044 0 015.044 5.045v7.938a1.009 1.009 0 11-2.017 0v-7.938a3.026 3.026 0 00-3.027-3.027h-6.94z"
+            fill="var(--expo-theme-icon-secondary)"
+          />
+        </svg>
         <code
           class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
         >
@@ -11037,12 +11285,30 @@ available on this device.
       </h4>
     </div>
     <ul
-      class="css-1qha16q-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1b15szc-paragraph-STYLES_UNORDERED_LIST-STYLES_NO_LIST_STYLE-UL"
       data-text="true"
     >
       <li
-        class="docs-list-item css-1yggycy-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+        class="docs-list-item css-k6alsv-STYLES_LIST_ITEM-LI"
       >
+        <svg
+          class="css-1dx3xyv-returnIconStyles"
+          color="var(--expo-theme-icon-secondary)"
+          fill="none"
+          height="16"
+          role="img"
+          size="16"
+          viewBox="0 0 20 20"
+          width="16"
+        >
+          <title>
+            Undo-icon
+          </title>
+          <path
+            d="M7.982 7.664v3.98L0 6.657l7.982-4.99v3.98h6.941a5.044 5.044 0 015.044 5.045v7.938a1.009 1.009 0 11-2.017 0v-7.938a3.026 3.026 0 00-3.027-3.027h-6.94z"
+            fill="var(--expo-theme-icon-secondary)"
+          />
+        </svg>
         <code
           class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
         >
@@ -11267,12 +11533,30 @@ provided with a single argument that is
       </h4>
     </div>
     <ul
-      class="css-1qha16q-paragraph-STYLES_UNORDERED_LIST-UL"
+      class="css-1b15szc-paragraph-STYLES_UNORDERED_LIST-STYLES_NO_LIST_STYLE-UL"
       data-text="true"
     >
       <li
-        class="docs-list-item css-1yggycy-STYLES_LIST_ITEM-STYLE_RETURN_LIST-LI"
+        class="docs-list-item css-k6alsv-STYLES_LIST_ITEM-LI"
       >
+        <svg
+          class="css-1dx3xyv-returnIconStyles"
+          color="var(--expo-theme-icon-secondary)"
+          fill="none"
+          height="16"
+          role="img"
+          size="16"
+          viewBox="0 0 20 20"
+          width="16"
+        >
+          <title>
+            Undo-icon
+          </title>
+          <path
+            d="M7.982 7.664v3.98L0 6.657l7.982-4.99v3.98h6.941a5.044 5.044 0 015.044 5.045v7.938a1.009 1.009 0 11-2.017 0v-7.938a3.026 3.026 0 00-3.027-3.027h-6.94z"
+            fill="var(--expo-theme-icon-secondary)"
+          />
+        </svg>
         <code
           class="inline css-18wudxk-STYLES_INLINE_CODE-InlineCode"
         >

--- a/docs/components/plugins/api/APISectionMethods.tsx
+++ b/docs/components/plugins/api/APISectionMethods.tsx
@@ -1,3 +1,5 @@
+import { css } from '@emotion/react';
+import { theme, spacing, UndoIcon, iconSize } from '@expo/styleguide';
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
 
@@ -55,8 +57,9 @@ export const renderMethod = (
           <div css={STYLES_NESTED_SECTION_HEADER}>
             <H4>Returns</H4>
           </div>
-          <UL>
-            <LI returnType>
+          <UL hideBullets>
+            <LI>
+              <UndoIcon color={theme.icon.secondary} size={iconSize.small} css={returnIconStyles} />
               <InlineCode>{resolveTypeName(type)}</InlineCode>
             </LI>
           </UL>
@@ -78,5 +81,11 @@ const APISectionMethods = ({ data, apiName, header = 'Methods' }: APISectionMeth
       )}
     </>
   ) : null;
+
+const returnIconStyles = css({
+  transform: 'rotate(180deg)',
+  marginRight: spacing[2],
+  verticalAlign: 'middle',
+});
 
 export default APISectionMethods;

--- a/docs/components/plugins/api/APISectionProps.tsx
+++ b/docs/components/plugins/api/APISectionProps.tsx
@@ -108,8 +108,7 @@ export const renderProp = (
       </HeaderComponent>
       <P>
         {flags?.isOptional && <span css={STYLES_SECONDARY}>Optional&emsp;&bull;&emsp;</span>}
-        <span css={STYLES_SECONDARY}>Type:</span>{' '}
-        {renderTypeOrSignatureType(type, signatures, true)}
+        <span css={STYLES_SECONDARY}>Type:</span> {renderTypeOrSignatureType(type, signatures)}
         {defaultValue && defaultValue !== UNKNOWN_VALUE ? (
           <span>
             <span css={STYLES_SECONDARY}>&emsp;&bull;&emsp;Default:</span>{' '}

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -72,6 +72,11 @@ export const mdComponents: MDComponents = {
   p: ({ children }) => (children ? <P>{children}</P> : null),
   strong: ({ children }) => <B>{children}</B>,
   span: ({ children }) => (children ? <span>{children}</span> : null),
+  table: ({ children }) => <Table>{children}</Table>,
+  thead: ({ children }) => <TableHead>{children}</TableHead>,
+  tr: ({ children }) => <Row>{children}</Row>,
+  th: ({ children }) => <HeaderCell>{children}</HeaderCell>,
+  td: ({ children }) => <Cell>{children}</Cell>,
 };
 
 export const mdInlineComponents: MDComponents = {
@@ -368,22 +373,30 @@ export const renderDefaultValue = (defaultValue?: string) =>
 
 export const renderTypeOrSignatureType = (
   type?: TypeDefinitionData,
-  signatures?: MethodSignatureData[],
-  includeParamType: boolean = false
+  signatures?: MethodSignatureData[]
 ) => {
-  if (type) {
-    return <InlineCode key={`signature-type-${type.name}`}>{resolveTypeName(type)}</InlineCode>;
-  } else if (signatures && signatures.length) {
-    return signatures.map(({ parameters }) =>
-      parameters && includeParamType
-        ? parameters.map(param => (
+  if (signatures && signatures.length) {
+    return (
+      <InlineCode key={`signature-type-${signatures[0].name}`}>
+        (
+        {signatures?.map(({ parameters }) =>
+          parameters?.map(param => (
             <span key={`signature-param-${param.name}`}>
               {param.name}
               {param.flags?.isOptional && '?'}: {resolveTypeName(param.type)}
             </span>
           ))
-        : listParams(parameters)
+        )}
+        ) =&gt;{' '}
+        {type ? (
+          <InlineCode key={`signature-type-${type.name}`}>{resolveTypeName(type)}</InlineCode>
+        ) : (
+          'void'
+        )}
+      </InlineCode>
     );
+  } else if (type) {
+    return <InlineCode key={`signature-type-${type.name}`}>{resolveTypeName(type)}</InlineCode>;
   }
   return undefined;
 };


### PR DESCRIPTION
# Why

This is an another round of fixes and tweaks for the APISection components after the appearance change.

# How

This PR introduces the following fixes and changes:
* fix incorrect and incomplete type resolve for the props and class fields which are a function
  <img width="619" alt="Screenshot 2022-07-06 at 10 21 50" src="https://user-images.githubusercontent.com/719641/177515949-4289b239-560a-49be-98c8-721e81ad9521.png">

* style markdown tables coming from code comments correctly:
  <img width="1126" alt="Screenshot 2022-07-06 at 11 00 50" src="https://user-images.githubusercontent.com/719641/177515718-b82a213a-1c9f-41a0-86b5-cf1bae9a10a0.png">

* replace the UTF-8 arrow character used for representing thew method return value with icon from the Styleguide
  <img width="621" alt="Screenshot 2022-07-06 at 10 37 41" src="https://user-images.githubusercontent.com/719641/177516145-8547e80a-3363-4b52-ad6f-5790c5570227.png">

# Test Plan

The changes have been tested by running docs website locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
