### PR TITLE
[docs] ConfigPluginsProperties: use APISection Platform tags

### DIFF
--- a/docs/components/plugins/ConfigSection/ConfigPluginProperties.tsx
+++ b/docs/components/plugins/ConfigSection/ConfigPluginProperties.tsx
@@ -3,17 +3,12 @@ import React, { PropsWithChildren } from 'react';
 import { InlineCode } from '~/components/base/code';
 import { B, P } from '~/components/base/paragraph';
 import { H3 } from '~/components/plugins/Headings';
+import { PlatformTags } from '~/components/plugins/api/APISectionPlatformTags';
 import { Cell, HeaderCell, Row, Table, TableHead } from '~/ui/components/Table';
 
 type Props = PropsWithChildren<{
   properties: PluginProperty[];
 }>;
-
-const platformNames: Record<Exclude<PluginProperty['platform'], undefined>, string> = {
-  android: 'Android',
-  ios: 'iOS',
-  web: 'Web',
-};
 
 export const ConfigPluginProperties = ({ children, properties }: Props) => (
   <>
@@ -35,7 +30,13 @@ export const ConfigPluginProperties = ({ children, properties }: Props) => (
             </Cell>
             <Cell>{!property.default ? '-' : <InlineCode>{property.default}</InlineCode>}</Cell>
             <Cell>
-              {!!property.platform && <B>{platformNames[property.platform]} only </B>}
+              {!!property.platform && (
+                <>
+                  <B>Only for:</B>{' '}
+                  <PlatformTags platforms={[{ text: property.platform, tag: 'platform' }]} />
+                  <br />
+                </>
+              )}
               {property.description}
             </Cell>
           </Row>

--- a/docs/components/plugins/ConfigSection/ConfigPluginProperties.tsx
+++ b/docs/components/plugins/ConfigSection/ConfigPluginProperties.tsx
@@ -1,7 +1,7 @@
 import React, { PropsWithChildren } from 'react';
 
 import { InlineCode } from '~/components/base/code';
-import { B, P } from '~/components/base/paragraph';
+import { P } from '~/components/base/paragraph';
 import { H3 } from '~/components/plugins/Headings';
 import { PlatformTags } from '~/components/plugins/api/APISectionPlatformTags';
 import { Cell, HeaderCell, Row, Table, TableHead } from '~/ui/components/Table';

--- a/docs/components/plugins/ConfigSection/ConfigPluginProperties.tsx
+++ b/docs/components/plugins/ConfigSection/ConfigPluginProperties.tsx
@@ -31,11 +31,10 @@ export const ConfigPluginProperties = ({ children, properties }: Props) => (
             <Cell>{!property.default ? '-' : <InlineCode>{property.default}</InlineCode>}</Cell>
             <Cell>
               {!!property.platform && (
-                <>
-                  <B>Only for:</B>{' '}
-                  <PlatformTags platforms={[{ text: property.platform, tag: 'platform' }]} />
-                  <br />
-                </>
+                <PlatformTags
+                  prefix="Only for:"
+                  platforms={[{ text: property.platform, tag: 'platform' }]}
+                />
               )}
               {property.description}
             </Cell>

--- a/docs/components/plugins/api/APISectionPlatformTags.tsx
+++ b/docs/components/plugins/api/APISectionPlatformTags.tsx
@@ -61,14 +61,15 @@ type Props = {
   comment?: CommentData;
   prefix?: string;
   firstElement?: boolean;
+  platforms?: CommentTagData[];
 };
 
-export const PlatformTags = ({ comment, prefix, firstElement }: Props) => {
-  const platforms = getAllTagData('platform', comment);
-  return platforms?.length ? (
+export const PlatformTags = ({ comment, prefix, firstElement, platforms }: Props) => {
+  const platformsData = platforms || getAllTagData('platform', comment);
+  return platformsData?.length ? (
     <>
       {prefix && <B>{prefix}&ensp;</B>}
-      {platforms.map(platform => {
+      {platformsData.map(platform => {
         const platformName = getPlatformName(platform);
         return (
           <div


### PR DESCRIPTION
# Why

Match the appearance of platform restriction information in `ConfigPluginsProperties` to the new design used in `APISection`.

# How

This PR replaces the text only information with a `PlatformTags` component. 

In the future, I plan to make the platform tags more universal, but for now I have decided to mimic the data structure, so the desirable effect can be archived without a bigger refactor. 

# Test Plan

The changes have been tested on the docs app running locally.

# Preview

<img width="1126" alt="Screenshot 2022-07-06 at 11 44 32" src="https://user-images.githubusercontent.com/719641/177523526-f4cb7420-0f41-42c8-8cde-c9edeedcba10.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
