### PR TITLE
[module-template] Add support for web

### DIFF
--- a/packages/expo-module-template/example/babel.config.js
+++ b/packages/expo-module-template/example/babel.config.js
@@ -1,0 +1,19 @@
+const path = require('path');
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: [
+      [
+        'module-resolver',
+        {
+          extensions: ['.tsx', '.ts', '.js', '.json'],
+          alias: {
+            // For development, we want to alias the library to the source
+            '<%- project.slug %>': path.join(__dirname, '..', 'src', '<%- project.name %>.ts'),
+          },
+        },
+      ],
+    ],
+  };
+};

--- a/packages/expo-module-template/example/webpack.config.js
+++ b/packages/expo-module-template/example/webpack.config.js
@@ -1,0 +1,20 @@
+const createConfigAsync = require('@expo/webpack-config');
+const path = require('path');
+
+module.exports = async (env, argv) => {
+  const config = await createConfigAsync(
+    {
+      ...env,
+      babel: {
+        dangerouslyAddModulePathsToTranspile: ['<%- project.slug %>'],
+      },
+    },
+    argv
+  );
+  config.resolve.modules = [
+    path.resolve(__dirname, './node_modules'),
+    path.resolve(__dirname, '../node_modules'),
+  ];
+
+  return config;
+};

--- a/packages/expo-module-template/src/{%- project.name %}.ts
+++ b/packages/expo-module-template/src/{%- project.name %}.ts
@@ -1,10 +1,10 @@
-import { requireNativeModule, NativeModulesProxy, EventEmitter, Subscription } from 'expo-modules-core';
+import { NativeModulesProxy, EventEmitter, Subscription } from 'expo-modules-core';
 
-import <%- project.name %>View, { <%- project.name %>ViewProps } from './<%- project.name %>View'
-
-// It loads the native module object from the JSI or falls back to
-// the bridge module (from NativeModulesProxy) if the remote debugger is on.
-const <%- project.name %> = requireNativeModule('<%- project.name %>');
+// Import the native module. On web, it will be resolved to <%- project.name %>.web.ts
+// and on native platforms to <%- project.name %>.ts
+import <%- project.name %> from './<%- project.name %>Module';
+import <%- project.name %>View from './<%- project.name %>View';
+import { ChangeEventPayload, <%- project.name %>ViewProps } from './<%- project.name %>.types';
 
 // Get the native constant value.
 export const PI = <%- project.name %>.PI;
@@ -21,15 +21,8 @@ export async function setValueAsync(value: string) {
 // This will be fixed in the stable release and built into the module object.
 const emitter = new EventEmitter(NativeModulesProxy.<%- project.name %>);
 
-export type ChangeEventPayload = {
-  value: string;
-};
-
 export function addChangeListener(listener: (event: ChangeEventPayload) => void): Subscription {
   return emitter.addListener<ChangeEventPayload>('onChange', listener);
 }
 
-export {
-  <%- project.name %>View,
-  <%- project.name %>ViewProps
-};
+export { <%- project.name %>View, <%- project.name %>ViewProps, ChangeEventPayload };

--- a/packages/expo-module-template/src/{%- project.name %}.ts
+++ b/packages/expo-module-template/src/{%- project.name %}.ts
@@ -19,7 +19,8 @@ export async function setValueAsync(value: string) {
 
 // For now the events are not going through the JSI, so we have to use its bridge equivalent.
 // This will be fixed in the stable release and built into the module object.
-const emitter = new EventEmitter(NativeModulesProxy.<%- project.name %>);
+// Note: On web, NativeModulesProxy.<%- project.name %> is undefined, so we fall back to the directly imported implementation
+const emitter = new EventEmitter(NativeModulesProxy.<%- project.name %> ?? <%- project.name %>);
 
 export function addChangeListener(listener: (event: ChangeEventPayload) => void): Subscription {
   return emitter.addListener<ChangeEventPayload>('onChange', listener);

--- a/packages/expo-module-template/src/{%- project.name %}.types.ts
+++ b/packages/expo-module-template/src/{%- project.name %}.types.ts
@@ -1,0 +1,7 @@
+export type ChangeEventPayload = {
+  value: string;
+};
+
+export type <%- project.name %>ViewProps = {
+  name: string;
+};

--- a/packages/expo-module-template/src/{%- project.name %}Module.ts
+++ b/packages/expo-module-template/src/{%- project.name %}Module.ts
@@ -1,0 +1,5 @@
+import { requireNativeModule } from 'expo-modules-core';
+
+// It loads the native module object from the JSI or falls back to
+// the bridge module (from NativeModulesProxy) if the remote debugger is on.
+export default requireNativeModule('<%- project.name %>');

--- a/packages/expo-module-template/src/{%- project.name %}Module.web.ts
+++ b/packages/expo-module-template/src/{%- project.name %}Module.web.ts
@@ -10,6 +10,4 @@ export default {
   hello() {
     return 'Hello world! 👋';
   },
-  startObserving() {},
-  stopObserving() {},
 };

--- a/packages/expo-module-template/src/{%- project.name %}Module.web.ts
+++ b/packages/expo-module-template/src/{%- project.name %}Module.web.ts
@@ -1,0 +1,15 @@
+import { EventEmitter } from 'expo-modules-core';
+
+const emitter = new EventEmitter({} as any);
+
+export default {
+  PI: Math.PI,
+  async setValueAsync(value: string): Promise<void> {
+    emitter.emit('onChange', { value });
+  },
+  hello() {
+    return 'Hello world! 👋';
+  },
+  startObserving() {},
+  stopObserving() {},
+};

--- a/packages/expo-module-template/src/{%- project.name %}View.tsx
+++ b/packages/expo-module-template/src/{%- project.name %}View.tsx
@@ -1,9 +1,7 @@
 import { requireNativeViewManager } from 'expo-modules-core';
 import * as React from 'react';
 
-export type <%- project.name %>ViewProps = {
-  name: string;
-};
+import { <%- project.name %>ViewProps } from './<%- project.name %>.types';
 
 const NativeView: React.ComponentType<<%- project.name %>ViewProps> =
   requireNativeViewManager('<%- project.name %>');

--- a/packages/expo-module-template/src/{%- project.name %}View.web.tsx
+++ b/packages/expo-module-template/src/{%- project.name %}View.web.tsx
@@ -3,10 +3,11 @@ import * as React from 'react';
 import { <%- project.name %>ViewProps } from './<%- project.name %>.types';
 
 function <%- project.name %>WebView(props: <%- project.name %>ViewProps) {
-  React.useEffect(() => {
-    console.log(props.name);
-  }, [props.name]);
-  return <div />;
+  return (
+    <div>
+      <span>{props.name}</span>
+    </div>
+  );
 }
 
 export default <%- project.name %>WebView;

--- a/packages/expo-module-template/src/{%- project.name %}View.web.tsx
+++ b/packages/expo-module-template/src/{%- project.name %}View.web.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+
+import { <%- project.name %>ViewProps } from './<%- project.name %>.types';
+
+function <%- project.name %>WebView(props: <%- project.name %>ViewProps) {
+  React.useEffect(() => {
+    console.log(props.name);
+  }, [props.name]);
+  return <div />;
+}
+
+export default <%- project.name %>WebView;


### PR DESCRIPTION
# Why

`yarn create expo-module` created a module that was failing on web

# How

- Updated `babel.config.js` and `webpack.config.js` in the example to resolve module import from the `<module_dir>/src`
- Split module files into `FileName.ts` and `FileName.web.ts` to separate the web implementation
- Added basic web module and view

# Test Plan

Locally ran `create-expo-app`, then `cd example`, `yarn web`, and `yarn ios` to test both web and native.

<!-- disable:changelog-checks -->