### PR TITLE
[image-picker][ios] Fix crash when picking gif

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix crash when picking a GIF image on iOS.
+- Fix crash when picking a GIF image on iOS. ([#18135](https://github.com/expo/expo/pull/18135) by [@barthap](https://github.com/barthap))
 
 ### 💡 Others
 

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix crash when picking a GIF image on iOS.
+
 ### 💡 Others
 
 - On Android migrated to the new `registerForActivityResult` mechanism. ([#17671](https://github.com/expo/expo/pull/17671), ([#17987](https://github.com/expo/expo/pull/17987) by [@bbarthec](https://github.com/bbarthec))

--- a/packages/expo-image-picker/ios/MediaHandler.swift
+++ b/packages/expo-image-picker/ios/MediaHandler.swift
@@ -170,8 +170,8 @@ private struct ImageUtils {
         throw FailedToReadImageDataException()
       }
 
-      // swiftlint:disable:next force_cast
-      guard let imageDestination = CGImageDestinationCreateWithData(data as! CFMutableData, kUTTypeGIF, 1, nil),
+      let mutableData = NSMutableData(data: data)
+      guard let imageDestination = CGImageDestinationCreateWithData(mutableData, kUTTypeGIF, 1, nil),
             let cgImage = image.cgImage
       else {
         throw FailedToCreateGifException()

--- a/packages/expo-image-picker/ios/MediaHandler.swift
+++ b/packages/expo-image-picker/ios/MediaHandler.swift
@@ -170,8 +170,8 @@ private struct ImageUtils {
         throw FailedToReadImageDataException()
       }
 
-      let mutableData = NSMutableData(data: data)
-      guard let imageDestination = CGImageDestinationCreateWithData(mutableData, kUTTypeGIF, 1, nil),
+      let destinationData = NSMutableData()
+      guard let imageDestination = CGImageDestinationCreateWithData(destinationData, kUTTypeGIF, 1, nil),
             let cgImage = image.cgImage
       else {
         throw FailedToCreateGifException()
@@ -188,7 +188,7 @@ private struct ImageUtils {
         throw FailedToExportGifException()
       }
 
-      return (data, ".gif")
+      return (destinationData as Data, ".gif")
 
     default:
       let data = image.jpegData(compressionQuality: compressionQuality)


### PR DESCRIPTION
# Why

When picking a gif image, the image picker crashed on iOS:

```
Exception	NSException *	"-[Foundation.__NSSwiftData setLength:]: unrecognized selector sent to instance 0x2823cd4d0"	0x00000002823d3660
```

at this line:
https://github.com/expo/expo/blob/6bc8d37dbac8e4e87e0513bf96714da24aeef771/packages/expo-image-picker/ios/MediaHandler.swift#L174

# How

I suspect the problem is that the `data` is a Swift `Core.Foundation` object and doesn't work with `CGImageDestinationCreateWithData` internals. Moreover, this function takes only pointer to the destination data buffer - it doesn't have to contain any image before, it can be empty.

Using `NSMutableData` helped. It was done this way in SDK 44, before migrating to Swift:
https://github.com/expo/expo/blob/80bc319bd1b2ea05fa635da3f14b8198d64228bb/packages/expo-image-picker/ios/EXImagePicker/EXImagePicker.m#L293-L294

# Test Plan

BareExpo NCL no longer crashes when picking GIF
