### PR TITLE
Fix typo in "Using Firebase" guide

### DIFF
--- a/docs/pages/guides/using-firebase.md
+++ b/docs/pages/guides/using-firebase.md
@@ -89,7 +89,8 @@ Now let's say we want another client to listen to updates to the high score of a
 ```javascript
 import { getDatabase, ref, onValue } from 'firebase/database';
 
-setupHighscoreListener(userId) {const db = getDatabase();
+setupHighscoreListener(userId) {
+const db = getDatabase();
   const reference = ref(db, 'users/' + userId);
   onValue(reference, (snapshot) => {
     const highscore = snapshot.val().highscore;

--- a/docs/pages/guides/using-firebase.md
+++ b/docs/pages/guides/using-firebase.md
@@ -90,7 +90,7 @@ Now let's say we want another client to listen to updates to the high score of a
 import { getDatabase, ref, onValue } from 'firebase/database';
 
 setupHighscoreListener(userId) {
-const db = getDatabase();
+  const db = getDatabase();
   const reference = ref(db, 'users/' + userId);
   onValue(reference, (snapshot) => {
     const highscore = snapshot.val().highscore;


### PR DESCRIPTION
# Why
`setupHighscoreListener` has what should be the first line of the function body, on the same line on the function declaration. Just a readability cleanup
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How
I read the documentation, noticed it, and decided to fix it out of my own pure good will.
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
I re-read the codument.
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- ~[ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).~
- ~[ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).~
