### PR TITLE
[image-picker][ios] Support video export preset

### DIFF
--- a/packages/expo-image-picker/ios/ImagePickerExceptions.swift
+++ b/packages/expo-image-picker/ios/ImagePickerExceptions.swift
@@ -98,6 +98,18 @@ internal class FailedToReadVideoException: Exception {
   }
 }
 
+internal class FailedToTranscodeVideoException: Exception {
+  override var reason: String {
+    "Failed to transcode picked video"
+  }
+}
+
+internal class UnsupportedVideoExportPresetException: GenericException<String> {
+  override var reason: String {
+    "Video cannot be transcoded with export preset: \(param)"
+  }
+}
+
 internal class FailedToPickVideoException: Exception {
   override var reason: String {
     "Video could not be picked"

--- a/packages/expo-image-picker/ios/MediaHandler.swift
+++ b/packages/expo-image-picker/ios/MediaHandler.swift
@@ -189,21 +189,40 @@ internal struct MediaHandler {
               let videoUrl = url as? URL else {
           return completion(assetId, .failure(FailedToReadVideoException().causedBy(error)))
         }
+        
+        // In case of passthrough, we want original file extension, mp4 otherwise
+        // TODO: (barthap) Support other file extensions?
+        let transcodeFileType = AVFileType.mp4
+        let transcodeFileExtension = ".mp4"
+        let originalExtension = ".\(videoUrl.pathExtension)"
 
-        let targetUrl = try generateUrl(withFileExtension: ".mov")
-        try VideoUtils.tryCopyingVideo(at: videoUrl, to: targetUrl)
+        // We need to copy the result into a place that we control, because the picker
+        // can remove the original file during conversion.
+        // Also, the transcoding may need a separate url - one of these will be used as a final result
+        let assetUrl = try generateUrl(withFileExtension: originalExtension)
+        let transcodedUrl = try generateUrl(withFileExtension: transcodeFileExtension)
+        try VideoUtils.tryCopyingVideo(at: videoUrl, to: assetUrl)
+        
+        VideoUtils.transcodeVideoAsync(sourceAssetUrl: assetUrl,
+                                       destinationUrl: transcodedUrl,
+                                       outputFileType: transcodeFileType,
+                                       exportPreset: options.videoExportPreset) { result in
+          if case .failure(let exception) = result {
+            return completion(assetId, .failure(exception))
+          }
+          let targetUrl = try! result.get()
 
-        guard let size = VideoUtils.readSizeFrom(url: targetUrl) else {
-          return completion(assetId, .failure(FailedToReadVideoSizeException()))
+          guard let size = VideoUtils.readSizeFrom(url: targetUrl) else {
+            return completion(assetId, .failure(FailedToReadVideoSizeException()))
+          }
+          let duration = VideoUtils.readDurationFrom(url: targetUrl)
+
+          let result = VideoInfo(uri: targetUrl.absoluteString,
+                                 width: size.width,
+                                 height: size.height,
+                                 duration: duration)
+          completion(assetId, .success(result))
         }
-
-        let duration = VideoUtils.readDurationFrom(url: targetUrl)
-
-        let result = VideoInfo(uri: targetUrl.absoluteString,
-                               width: size.width,
-                               height: size.height,
-                               duration: duration)
-        completion(assetId, .success(result))
       } catch let exception as Exception {
         return completion(assetId, .failure(exception))
       } catch {
@@ -508,5 +527,46 @@ private struct VideoUtils {
   static func readVideoUrlFrom(mediaInfo: MediaInfo) -> URL? {
     return mediaInfo[.mediaURL] as? URL
         ?? mediaInfo[.referenceURL] as? URL
+  }
+  
+  /**
+   Asynchronously transcodes asset provided as `sourceAssetUrl` according to `exportPreset`.
+   Result URL is returned to the `completion` closure.
+   Transcoded video is saved at `destinationUrl`, unless `exportPreset` is set to `passthrough`.
+   In this case, `sourceAssetUrl` is returned.
+   */
+  static func transcodeVideoAsync(sourceAssetUrl: URL,
+                                  destinationUrl: URL,
+                                  outputFileType: AVFileType,
+                                  exportPreset: VideoExportPreset,
+                                  completion: @escaping (Result<URL, Exception>) -> Void) {
+    if case .passthrough = exportPreset {
+      return completion(.success((sourceAssetUrl)))
+    }
+    
+    let asset = AVURLAsset(url: sourceAssetUrl)
+    let preset = exportPreset.toAVAssetExportPreset()
+    AVAssetExportSession.determineCompatibility(ofExportPreset: preset,
+                                                with: asset,
+                                                outputFileType: outputFileType) { canBeTranscoded in
+      guard canBeTranscoded else {
+        return completion(.failure(UnsupportedVideoExportPresetException(preset.description)))
+      }
+      guard let exportSession = AVAssetExportSession(asset: asset,
+                                                     presetName: preset) else {
+        return completion(.failure(FailedToTranscodeVideoException()))
+      }
+      exportSession.outputFileType = outputFileType
+      exportSession.outputURL = destinationUrl
+      exportSession.exportAsynchronously {
+        switch exportSession.status {
+        case .failed:
+          let error = exportSession.error
+          completion(.failure(FailedToTranscodeVideoException().causedBy(error)))
+        default:
+          completion(.success((destinationUrl)))
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
# Why

Part of ENG-5617

**Background**:
The new `PHPickerViewController` doesn't have a direct possibility to control output video format so the `ImagePickerOptions.videoExportPreset` is ignored.

The old `UIImagePickerController` has [`videoExportPreset` field which is deprecated.](https://developer.apple.com/documentation/uikit/uiimagepickercontroller/2890964-videoexportpreset). The deprecation message directly says to use `PHPickerViewController` and `AVAssetExportSession`.

# How

Manually wrote the whole video transcoding flow as suggested on Apple website.
Reference:
- [Apple suggestion on handling this](https://developer.apple.com/forums/thread/651491)
- [Documentation and guide](https://developer.apple.com/documentation/avfoundation/media_reading_and_writing/exporting_video_to_alternative_formats)

# Test Plan

NCL

# TODO

We need to update the deprecation message in docs (not yet sure how): [see the `videoExportPreset` row](https://docs.expo.dev/versions/latest/sdk/imagepicker/#imagepickeroptions).
Also, not sure what to write in changelog then.
