### PR TITLE
[docs] Classic/Standalone apps: Update the documentation

### DIFF
--- a/docs/pages/classic/building-standalone-apps.md
+++ b/docs/pages/classic/building-standalone-apps.md
@@ -120,7 +120,7 @@ Simulator builds are used to test a standalone app in an iOS simulator. To build
 
 <Terminal cmd={['$ expo build:ios -t simulator']} />
 
-Building for iOS, you can choose the option to let Expo create necessary credentials. You still have the choice to provide your own credentials. In this process, your Apple ID and password are used locally and are never saved on Expo's servers.
+When building for iOS, you can choose to let Expo create any necessary credentials that your app will need. However, you'll still have the choice to provide your own credentials if you'd like. During this process, Expo CLI will use your Apple ID and password. Your authentication information is only used locally on your computer and is never sent to Expo's servers.
 
 ```sh
 $ expo build:ios

--- a/docs/pages/classic/building-standalone-apps.md
+++ b/docs/pages/classic/building-standalone-apps.md
@@ -92,7 +92,7 @@ If you don't know what this means, let us handle it! :)
 2) I want to upload my own keystore!
 ```
 
-If you choose the first option, it is **strongly recommend** that you run the following command after the build process is complete and backup the keystore to a safe location:
+If you choose the first option, it is **strongly recommended** that you run the following command after the build process is complete. After running it, backup the keystore in a safe location:
 
 <Terminal cmd={['$ expo fetch:android:keystore']} />
 

--- a/docs/pages/classic/building-standalone-apps.md
+++ b/docs/pages/classic/building-standalone-apps.md
@@ -112,7 +112,7 @@ If you choose the first option when generating the keystore and later decide to 
 
 There are two types of build you can generate when building a standalone app for iOS: archive and simulator.
 
-Archive build is used for publishing your app to the Apple App Store or distributing it with services like TestFlight. To build an archive, run the command:
+Archive builds are used for submitting your app to the Apple App Store and distributing it with features like TestFlight. To build an iOS app archive, run:
 
 <Terminal cmd={['$ expo build:ios -t archive']} />
 

--- a/docs/pages/classic/building-standalone-apps.md
+++ b/docs/pages/classic/building-standalone-apps.md
@@ -187,7 +187,7 @@ If you use a Push Notifications Certificate and want to switch to a [Push Notifi
 
 ## 4. Wait for it to finish building
 
-Expo Build Service uses building machines to build your app. The build process starts as soon as one of the machines is free and ready to be used. To check how long the waiting time for your build is, visit [Turtle status](https://expo.dev/turtle-status) site.
+Expo's build service uses cloud services to build your app. The build process starts as soon as one of the machines is free and ready to be used. To check how long the waiting time for your build is, visit [Turtle status](https://expo.dev/turtle-status) site.
 
 Expo CLI prints a URL with a unique ID, such as `expo.dev/builds/some-unique-id`, for you to visit and check your build progress. You can also access build logs on this URL.
 

--- a/docs/pages/classic/building-standalone-apps.md
+++ b/docs/pages/classic/building-standalone-apps.md
@@ -145,7 +145,7 @@ Note: Expo does not keep your Apple ID or your Apple ID password.
   I will provide all the credentials and files needed, Expo does limited validation
 ```
 
-If you are unfamiliar with iOS credentials, it is recommended to let Expo handle the creation & management of credentials. To know more about them, refer to the [App Credentials documentation](/app-signing/app-credentials).
+If you are unfamiliar with iOS credentials, it is recommended to let Expo handle the creation & management of credentials. To learn more about them, refer to the [App Credentials documentation](/app-signing/app-credentials).
 
 If you are familiar with iOS credentials and plan to provide your own, use the [Apple Developer Portal](https://developer.apple.com/account/resources/certificates/list) to create them.
 

--- a/docs/pages/classic/building-standalone-apps.md
+++ b/docs/pages/classic/building-standalone-apps.md
@@ -189,7 +189,7 @@ If you use a Push Notifications Certificate and want to switch to a [Push Notifi
 
 Expo's build service uses cloud services to build your app. The build process starts as soon as one of the machines is free and ready to be used. To check how long the waiting time for your build is, visit [Turtle status](https://expo.dev/turtle-status) site.
 
-Expo CLI prints a URL with a unique ID, such as `expo.dev/builds/some-unique-id`, for you to visit and check your build progress. You can also access build logs on this URL.
+Expo CLI prints a URL that you can visit and check your build for its progress and logs.
 
 Alternatively, you can check the status by running:
 

--- a/docs/pages/classic/building-standalone-apps.md
+++ b/docs/pages/classic/building-standalone-apps.md
@@ -12,7 +12,7 @@ Classic Build service allows you to create standalone binaries for the Expo app 
 
 An Apple Developer account is required to build a standalone iOS app, but a Google Play Developer account is not required to build the standalone Android app. To submit to either app store, you need a developer account on that store.
 
-> We recommend you to read the best practices about [Deploying to App Stores](/distribution/app-stores) to ensure your app is in good shape to get accepted into the Apple and Google stores. Using this service, you can generate builds, but it's up to you to make your app awesome.
+> We recommend that you read the best practices about [Deploying to App Stores](/distribution/app-stores) to ensure your app gets accepted into the Apple and Google stores. Once you've created an amazing app, EAS Build can help you build it and then submit it to the app stores.
 
 ## 1. Install Expo CLI
 

--- a/docs/pages/classic/building-standalone-apps.md
+++ b/docs/pages/classic/building-standalone-apps.md
@@ -26,7 +26,7 @@ Developers using the **Windows** operating system must have WSL enabled. If you 
 
 ## 2. Configure app.json
 
-In the **app.json**, you have to add a set of configuration before running the build command. The code snippet below represents a minimal required version of the configuration:
+In **app.json**, you have to add a set of configurations before running the build command. The code snippet below represents a minimal required version of the configuration:
 
 ```json
 {

--- a/docs/pages/classic/building-standalone-apps.md
+++ b/docs/pages/classic/building-standalone-apps.md
@@ -159,7 +159,7 @@ Expo Build Service supports Enterprise distribution. When you call `expo build:i
 
 > This distribution method requires you to override your own credentials. Use this distribution if you know how to generate iOS credentials.
 
-One of the easiest ways to test your standalone app is using a [simulator build](#building-for-ios) and then using TestFlight for your physical device for testing. However, if you want to build and install an IPA directly on a physical device through Xcode, follow the steps below to generate one using Expo CLI:
+One of the easiest ways to test your standalone app is using a [simulator build](#building-for-ios) and then using TestFlight for your physical device for testing. However, if you want to build and install an app directly on a physical device through Xcode, follow the steps below to generate one using Expo CLI:
 
 - Generate preliminary certificate such as app identifier and distribution certificate by running the command:
 

--- a/docs/pages/classic/building-standalone-apps.md
+++ b/docs/pages/classic/building-standalone-apps.md
@@ -98,7 +98,7 @@ If you choose the first option, it is **strongly recommended** that you run the 
 
 Once you submit the app to the Google Play Store, all future updates to that app **must** be signed with the same keystore that the Play Store initially accepted. If you do not have a local copy of your keystore, you will be unable to publish new versions of your app to the Play Store.
 
-For any reason you delete your project or clear your credentials in the future, you will not be able to submit any updates to your app without providing the same keystore. Your only option left is to generate a new keystore and re-upload your application as a new application.
+If for any reason you delete your project or clear your credentials in the future, you will not be able to submit any updates to your app without providing the same keystore. If you're unable to retrieve the keystone, your only option left is to generate a new keystore and re-upload your application as a new application.
 
 #### Uploading your keystore after publishing the app
 

--- a/docs/pages/classic/building-standalone-apps.md
+++ b/docs/pages/classic/building-standalone-apps.md
@@ -54,7 +54,7 @@ Here are the required fields that you have to pay attention to when configuring 
 - The `slug` should be a URL safe value. The slug will be included in the URL that your app's JavaScript is published to. For example: `expo.dev/@community/native-component-list`, where `community` is the username and `native-component-list` is the slug.
 - The `ios.buildNumber` and `android.versionCode` distinguish different binaries of your app. Make sure to increment these for each build you upload to the App Store or Google Play Store.
 
-There are other options you can add to **app.json**. For example, some developers like to configure their own build number, linking scheme, etc. We recommend you to go through [Configuration with app.json/app.config.js](/workflow/configuration) for the full specification. At this step, also check [Deploying to App Stores](/distribution/app-stores) documentation. It provides details on what type of metadata is required for App stores.
+There are other options you can add to **app.json**. For example, some developers like to configure their own build number, linking scheme, etc. We recommend you to go through [Configuration with app.json/app.config.js](/workflow/configuration) for the full specification. At this step, also check [Deploying to App Stores](/distribution/app-stores) documentation. It provides details on what types of metadata are required for the app stores.
 
 ## 3. Start the build
 

--- a/docs/pages/classic/building-standalone-apps.md
+++ b/docs/pages/classic/building-standalone-apps.md
@@ -161,7 +161,7 @@ Expo Build Service supports Enterprise distribution. When you call `expo build:i
 
 One of the easiest ways to test your standalone app is using a [simulator build](#building-for-ios) and then using TestFlight for your physical device for testing. However, if you want to build and install an app directly on a physical device through Xcode, follow the steps below to generate one using Expo CLI:
 
-- Generate preliminary certificate such as app identifier and distribution certificate by running the command:
+- Generate preliminary certificates such as app identifier and distribution certificate by running the command:
 
 <Terminal cmd={['$ expo build:ios']} />
 

--- a/docs/pages/classic/building-standalone-apps.md
+++ b/docs/pages/classic/building-standalone-apps.md
@@ -88,8 +88,8 @@ For Expo to handle the process, choose the first option in the command-line when
 Would you like to upload a keystore or have us generate one for you?
 If you don't know what this means, let us handle it! :)
 
-  1) Let Expo handle the process!
-  2) I want to upload my own keystore!
+1) Let Expo handle the process!
+2) I want to upload my own keystore!
 ```
 
 If you choose the first option, it is **strongly recommend** that you run the following command after the build process is complete and backup the keystore to a safe location:

--- a/docs/pages/classic/building-standalone-apps.md
+++ b/docs/pages/classic/building-standalone-apps.md
@@ -116,7 +116,7 @@ Archive builds are used for submitting your app to the Apple App Store and distr
 
 <Terminal cmd={['$ expo build:ios -t archive']} />
 
-Simulator build is used to test the standalone app on an iOS simulator. To build it, run the command:
+Simulator builds are used to test a standalone app in an iOS simulator. To build one, run:
 
 <Terminal cmd={['$ expo build:ios -t simulator']} />
 

--- a/docs/pages/classic/building-standalone-apps.md
+++ b/docs/pages/classic/building-standalone-apps.md
@@ -70,7 +70,7 @@ To build an APK, run the command:
 
 <Terminal cmd={['$ expo build:android -t apk']} />
 
-It is recommended to build an Android App Bundle (aab) for submitting the app to the Google Play Store. To build an aab, run the command:
+We recommend building an Android App Bundle (aab) for submitting the app to the Google Play Store. To build an aab, run the command:
 
 <Terminal cmd={['$ expo build:android -t app-bundle']} />
 

--- a/docs/pages/classic/building-standalone-apps.md
+++ b/docs/pages/classic/building-standalone-apps.md
@@ -157,7 +157,7 @@ Expo Build Service supports Enterprise distribution. When you call `expo build:i
 
 #### Adhoc distribution
 
-> This distribution requires you to override and use your own credentials credential overrides. Use this distribution if you know how to generate iOS credentials.
+> This distribution method requires you to override your own credentials. Use this distribution if you know how to generate iOS credentials.
 
 One of the easiest ways to test your standalone app is using a [simulator build](#building-for-ios) and then using TestFlight for your physical device for testing. However, if you want to build and install an IPA directly on a physical device through Xcode, follow the steps below to generate one using Expo CLI:
 

--- a/docs/pages/classic/building-standalone-apps.md
+++ b/docs/pages/classic/building-standalone-apps.md
@@ -51,7 +51,7 @@ Here are the required fields that you have to pay attention to when configuring 
 
 - Add fields such as `name`, `icon`, and `version`.
 - The iOS `bundleIdentifier` and Android `package` fields use reverse DNS notation but do not have to be related to a domain. Replace `"com.yourcompany.yourappname"` with whatever makes sense for your app.
-- The `slug` uses a URL as its value. It is the combination of username and the actual slug that your app's JavaScript is published to. For example: `expo.dev/@community/native-component-list`, where `community` is the username and `native-component-list` is the slug.
+- The `slug` should be a URL safe value. The slug will be included in the URL that your app's JavaScript is published to. For example: `expo.dev/@community/native-component-list`, where `community` is the username and `native-component-list` is the slug.
 - The `ios.buildNumber` and `android.versionCode` distinguish different binaries of your app. Make sure to increment these for each build you upload to the App Store or Google Play Store.
 
 There are other options you can add to **app.json**. For example, some developers like to configure their own build number, linking scheme, etc. We recommend you to go through [Configuration with app.json/app.config.js](/workflow/configuration) for the full specification. At this step, also check [Deploying to App Stores](/distribution/app-stores) documentation. It provides details on what type of metadata is required for App stores.

--- a/docs/pages/classic/building-standalone-apps.md
+++ b/docs/pages/classic/building-standalone-apps.md
@@ -2,36 +2,35 @@
 title: Building Standalone Apps
 ---
 
-> 🆕 [Try creating your build with EAS Build](/build/setup.md), the modern build service with support for custom native code and smaller app archives.
+import { Terminal } from '~/ui/components/Snippet';
 
-> ⚠️ [The Classic Build service (`expo build:{android,ios}`) is in maintenance mode](https://blog.expo.dev/turtle-goes-out-to-sea-d334db2a6b60) and has been superseded by [EAS Build](/build/setup.md). SDK 46 will be the last SDK supported by Classic Builds and the Classic Build service will stop running for all SDK versions after January 4, 2023.
+> [Try creating your build with EAS Build](/build/setup), the modern build service with support for custom native code and smaller app archives.
 
-The purpose of this guide is to help you create standalone binaries of your Expo app for iOS and
-Android which can be submitted to the Apple App Store and Google Play Store.
+> [The Classic Build service (`expo build:{android,ios}`) is in maintenance mode](https://blog.expo.dev/turtle-goes-out-to-sea-d334db2a6b60) and has been superseded by [EAS Build](/build/setup). SDK 46 will be the last SDK supported by Classic Builds and the Classic Build service will stop running for all SDK versions after January 4, 2023.
 
-An Apple Developer account is needed to build an iOS standalone app, but a Google Play Developer
-account is not needed to build the Android standalone app. If you'd like to submit to either app
-store, you will need a developer account on that store.
+Classic Build service allows you to create standalone binaries for the Expo app using the Expo CLI. You can use that binary to submit the app to the Apple App Store and Google Play Store or test on emulators.
 
-It's a good idea to read the best practices about [Deploying to App Stores](/distribution/app-stores.md) to
-ensure your app is in good shape to get accepted into the Apple and Google marketplaces. We can
-generate builds for you, but it's up to you to make your app awesome.
+An Apple Developer account is required to build a standalone iOS app, but a Google Play Developer account is not required to build the standalone Android app. To submit to either app store, you need a developer account on that store.
+
+> We recommend you to read the best practices about [Deploying to App Stores](/distribution/app-stores) to ensure your app is in good shape to get accepted into the Apple and Google stores. Using this service, you can generate builds, but it's up to you to make your app awesome.
 
 ## 1. Install Expo CLI
 
-Expo CLI is the tool for developing and building Expo apps. Run `npm install -g expo-cli` (or `yarn global add expo-cli`) to get it.
+Expo CLI is a command-line application required to build standalone apps. It is installed as a global npm package. If you have not installed it, go through the [installation steps in the Expo CLI documentation](/workflow/expo-cli/#installation).
 
-If you haven't created an Expo account before, you'll be asked to create one when running the build command.
+You must have an Expo account created or logged. When running the build command, you can create a new one or log in to your existing account.
 
-**Windows users** must have WSL enabled. You can follow the installation guide [here](https://docs.microsoft.com/en-us/windows/wsl/install-win10). We recommend picking Ubuntu from the Windows Store. Be sure
-to launch Ubuntu at least once. After that, use an Admin powershell to run:
-`Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Windows-Subsystem-Linux`
+Developers using **Windows** operating system must have WSL enabled. If you do not have it installed, follow this [installation guide](https://docs.microsoft.com/en-us/windows/wsl/install). When it prompts for choosing a Linux distribution, we recommend picking Ubuntu from the Windows Store. Launch Ubuntu at least once and then use an admin PowerShell to run the command:
+
+<Terminal cmd={['$ Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Windows-Subsystem-Linux']} />
 
 ## 2. Configure app.json
 
-```javascript
- {
-   "expo": {
+In the **app.json/** file, you have to add a set of configuration before running the build command. The code snippet below represents a minimal required version of the configuration:
+
+```json
+{
+  "expo": {
     "name": "Your App Name",
     "icon": "./path/to/your/app-icon.png",
     "version": "1.0.0",
@@ -44,41 +43,44 @@ to launch Ubuntu at least once. After that, use an Admin powershell to run:
       "package": "com.yourcompany.yourappname",
       "versionCode": 1
     }
-   }
- }
+  }
+}
 ```
 
-- The iOS `bundleIdentifier` and Android `package` fields use reverse DNS notation, but don't have to be related to a domain. Replace `"com.yourcompany.yourappname"` with whatever makes sense for your app.
-- You're probably not surprised that `name`, `icon` and `version` are required.
-- `slug` is the url name that your app's JavaScript is published to. For example: `expo.dev/@community/native-component-list`, where `community` is my username and `native-component-list` is the slug.
+Here are the required fields that you have to pay attention to when configuring your **app.json** or **app.config.js** file:
+
+- Add fields such as `name`, `icon`, and `version`.
+- The iOS `bundleIdentifier` and Android `package` fields use reverse DNS notation but do not have to be related to a domain. Replace `"com.yourcompany.yourappname"` with whatever makes sense for your app.
+- The `slug` uses a URL as its value. It is the combination of username and the actual slug that your app's JavaScript is published to. For example: `expo.dev/@community/native-component-list`, where `community` is the username and `native-component-list` is the slug.
 - The `ios.buildNumber` and `android.versionCode` distinguish different binaries of your app. Make sure to increment these for each build you upload to the App Store or Google Play Store.
 
-There are other options you might want to add to **app.json**. We have only covered what is
-required. For example, some people like to configure their own build number, linking scheme, and
-more. We highly recommend you read through [Configuration with app.json / app.config.js](/workflow/configuration.md) for the
-full spec. This is also your last chance to double check our [recommendations](/distribution/app-stores.md)
-for App Store metadata.
+There are other options you can add to **app.json**. For example, some developers like to configure their own build number, linking scheme, etc. We recommend you to go through [Configuration with app.json/app.config.js](/workflow/configuration) for the full specification. At this step, also check [Deploying to App Stores](/distribution/app-stores) documentation. It provides details on what type of metadata is required for App stores.
 
 ## 3. Start the build
 
-Run `expo build:android` or `expo build:ios`. If you don't already have a development server running for this project, `expo` will start one for you.
+To start the build process, run `expo build:android` or `expo build:ios` depending on the platform you are building. If there is no development server running for the app you are building, `expo` will start it automatically.
 
-**Please note:** When you run `expo build`, Expo automatically publishes your app (with `expo publish`). In order to avoid accidentally publishing changes to your production app, you may want to use [release channels](/distribution/release-channels.md).
+> When you run `expo build`, Expo automatically publishes your app (with `expo publish`). To avoid accidentally publishing changes to your production app, you may want to use [release channels](/distribution/release-channels).
 
-### If you choose to build for Android
+### Building for Android
 
-When building for android you can choose to build APK (`expo build:android -t apk`) or Android App Bundle (`expo build:android -t app-bundle`).
-App bundles are recommended, but you have to make sure the [Google Play App Signing](/app-signing/app-credentials.md) is enabled for your project,
-you can read more about it [here](https://developer.android.com/guide/app-bundle).
+There are two types of build you can generate when building a standalone app for Android: an APK or an Android App Bundle (aab).
 
-The first time you build the project you will be asked whether you'd like to upload a keystore or
-have us handle it for you. If you don't know what a keystore is, you can have us generate one for you. Otherwise,
-feel free to upload your own.
+To build an APK, run the command:
 
-If you choose to let Expo generate a keystore for you, we **strongly recommend** that you later run `expo fetch:android:keystore`
-and backup your keystore to a safe location. Once you submit an app to the Google Play Store, all future updates to that app **must**
-be signed with the same keystore to be accepted by Google. If, for any reason, you delete your project or clear your credentials
-in the future, you will not be able to submit any updates to your app if you have not backed up your keystore.
+<Terminal cmd={['$ expo build:android -t apk']} />
+
+It is recommended to build an Android App Bundle (aab) for submitting the app to the Google Play Store. To build an aab, run the command:
+
+<Terminal cmd={['$ expo build:android -t app-bundle']} />
+
+When building abb, you have to make sure the [Google Play App Signing](/app-signing/app-credentials) is enabled for your project. You can read more about it in the [Android documentation](https://developer.android.com/guide/app-bundle).
+
+#### Generating keystore
+
+When building your app for the first time, you have to generate a [keystore](https://developer.android.com/training/articles/keystore). You can upload your own if you are familiar with process of generating keystore, or you can let Expo handle the process.
+
+For Expo to handle the process, choose the first option in the command-line when prompted for keystore:
 
 ```sh
 [exp] No currently active or previous builds for this project.
@@ -90,16 +92,35 @@ If you don't know what this means, let us handle it! :)
   2) I want to upload my own keystore!
 ```
 
-> **Note:** If you choose the first option and later decide to upload your own keystore, we currently offer an option to clear your current Android keystore from our build servers by running `expo build:android --clear-credentials.` **This is irreversible, so only run this command if you know what you are doing!** You can download a backup copy of the keystore by running `expo fetch:android:keystore`. **If you do not have a local copy of your keystore , you will be unable to publish new versions of your app to the Play Store**. Your only option would be to generate a new keystore and re-upload your application as a new application. You can learn more about how code signing and keystores work [in the Android documentation](https://developer.android.com/studio/publish/app-signing.html).
+If you choose the first option, it is **strongly recommend** that you run the following command after the build process is complete and backup the keystore to a safe location:
 
-### If you choose to build for iOS
+<Terminal cmd={['$ expo fetch:android:keystore']} />
 
-You can build standalone apps for iOS with two different types, an archive (`expo build:ios -t archive`) or simulator (`expo build:ios -t simulator`) build.
-With the simulator build, you can test your standalone app on a simulator.
-If you want to publish your app to the store or distribute it with tools like TestFlight, you have to use the archive.
+Once you submit the app to the Google Play Store, all future updates to that app **must** be signed with the same keystore that the Play Store initially accepted. If you do not have a local copy of your keystore, you will be unable to publish new versions of your app to the Play Store.
 
-When building for iOS, you are given a choice of letting Expo create the necessary credentials for you,
-while still having a chance to provide your own overrides. Your Apple ID and password are used locally and are never saved on Expo's servers.
+For any reason you delete your project or clear your credentials in the future, you will not be able to submit any updates to your app without providing the same keystore. Your only option left is to generate a new keystore and re-upload your application as a new application.
+
+#### Uploading your keystore after publishing the app
+
+If you choose the first option when generating the keystore and later decide to upload your own keystore, you can use the option to clear the current Android keystore from Expo's build servers by running the command:
+
+<Terminal cmd={['$ expo build:android --clear-credentials']} />
+
+**This is irreversible, so only run this command if you have generated your own keystore.** You can learn more about how code signing and keystores work in the [Android documentation](https://developer.android.com/studio/publish/app-signing.html).
+
+### Building for iOS
+
+There are two types of build you can generate when building a standalone app for iOS: archive and simulator.
+
+Archive build is used for publishing your app to the Apple App Store or distributing it with services like TestFlight. To build an archive, run the command:
+
+<Terminal cmd={['$ expo build:ios -t archive']} />
+
+Simulator build is used to test the standalone app on an iOS simulator. To build it, run the command:
+
+<Terminal cmd={['$ expo build:ios -t simulator']} />
+
+Building for iOS, you can choose the option to let Expo create necessary credentials. You still have the choice to provide your own credentials. In this process, your Apple ID and password are used locally and are never saved on Expo's servers.
 
 ```sh
 $ expo build:ios
@@ -124,65 +145,85 @@ Note: Expo does not keep your Apple ID or your Apple ID password.
   I will provide all the credentials and files needed, Expo does limited validation
 ```
 
-Unless you're very familiar with iOS credentials already, it's best to let Expo handle the creation & management of all your credentials for you. If you'd like to know more about iOS credentials, we've written a guide with everything you need to know [here](/app-signing/app-credentials.md).
+If you are unfamiliar with iOS credentials, it is recommended to let Expo handle the creation & management of credentials. To know more about them, refer to the [App Credentials documentation](/app-signing/app-credentials).
 
-If you plan on providing your own certificates, we recommend creating them in the [Apple Developer Portal](https://developer.apple.com/account/resources/certificates/list).
+If you are familiar with iOS credentials and plan to provide your own, use the [Apple Developer Portal](https://developer.apple.com/account/resources/certificates/list) to create them.
 
 #### Enterprise distribution
 
-The Expo build service supports both normal App Store distribution as well as enterprise distribution. To use the latter, you must be a member of the ["Apple Developer Enterprise Program"](https://developer.apple.com/programs/enterprise/). Only normal Apple Developer accounts can build apps that can be submitted to the Apple App Store, and only enterprise developer accounts can build apps that can be distributed using enterprise distribution methods. When you call `expo build:ios`, you just need to choose the correct team, it will be labeled `(In-House)`.
+To build and distribute your app using Apple's Enterprise distribution, it is required that you are a member of the [Apple Developer Enterprise Program](https://developer.apple.com/programs/enterprise/).
+
+Expo Build Service supports Enterprise distribution. When you call `expo build:ios`, you just need to choose the correct team that is labeled with `(In-House)`.
 
 #### Adhoc distribution
 
-> Since this requires you to provide credential overrides, this feature should only be used if you're comfortable with iOS credentials.
+> This distribution requires you to override and use your own credentials credential overrides. Use this distribution if you know how to generate iOS credentials.
 
-It's usually easiest to test your standalone app on a simulator with the `expo build:ios -t simulator` command, and then use TestFlight for your physical device testing. But if you'd like an IPA that you can install directly onto your physical device through Xcode, you can generate one with Expo CLI:
+One of the easiest ways to test your standalone app is using a [simulator build](#building-for-ios) and then using TestFlight for your physical device for testing. However, if you want to build and install an IPA directly on a physical device through Xcode, follow the steps below to generate one using Expo CLI:
 
-- Run `expo build:ios` once to generate some preliminary certificates, namely your app identifier, and distribution certificate.
-- Now, create a new provisioning profile [here](https://developer.apple.com/account/resources/profiles/list), and under `Distribution`, select `Adhoc`. Then provide your app identifier and the distribution certificate you created in the last step. **If you don't provide those exact certificates, your build will fail.**
-- Download the provisioning profile, and then pass it to the build command like this: `expo build:ios --provisioning-profile-path ~/Path/To/provisioningProfileYouCreated.mobileprovision`, and make sure the rest of the certificates you use match those you selected when creating your adhoc provisioning profile in the previous step.
+- Generate preliminary certificate such as app identifier and distribution certificate by running the command:
 
-Once Expo finishes your build, you can install it onto your device via Xcode by opening the `Devices & Simulators` window, selecting your connected device, and under `Installed Apps`, click the `+` and then select the IPA Expo generated for you.
+<Terminal cmd={['$ expo build:ios']} />
 
-> **Note:** We enable bitcode for iOS, so the **.ipa** files for iOS are much larger than the eventual App Store download available to your users. For more information, see [App Thinning](https://developer.apple.com/library/content/documentation/IDEs/Conceptual/AppDistributionGuide/AppThinning/AppThinning.html).
+- Now, create a new [provisioning profile](https://developer.apple.com/account/resources/profiles/list), and under `Distribution`, select `Adhoc`.
+- Provide the app identifier and the distribution certificate you created in the first step. **If you don't provide those exact certificates, your build will fail.**
+- Download the provisioning profile, and then pass it to the build command:
+
+<Terminal cmd={['$ expo build:ios --provisioning-profile-path ~/Path/To/provisioningProfileYouCreated.mobileprovision']} />
+
+- Make sure the other certificates you use match the ones you selected when creating your adhoc provisioning profile in the previous step.
+
+After Expo finishes your build, you can install it onto your device via Xcode.
+
+- Open the `Devices & Simulators` window in Xcode
+- Select your connected device
+- Under `Installed Apps`, click the plus (`+`) and then select the IPA generated by Expo
+
+> **Note:** We enable bitcode for iOS, so the **.ipa** files for iOS are much larger than the eventual App Store download available to your users. For more information, see [App Thinning](https://help.apple.com/xcode/mac/current/#/devbbdc5ce4f).
 
 ### Switch to Push Notification Key on iOS
 
-If you are using Push Notifications Certificate and want to switch to a Push Notifications Key you need
-to start the build with `--clear-push-cert`. We will remove the legacy certificate from our servers and generate a Push Notifications Key for you.
+If you use a Push Notifications Certificate and want to switch to a [Push Notifications Key](app-signing/app-credentials/#push-notification-keys), start the build with `--clear-push-cert` option. Expo will remove legacy certificates from its servers and generate a Push Notifications Key for you.
 
 ## 4. Wait for it to finish building
 
-When one of our building machines is free, it'll start building your app. You can check how long you'll wait on the [Turtle status](https://expo.dev/turtle-status) site. We'll print a url you can visit (such as `expo.dev/builds/some-unique-id`) to watch your build progress and access the build logs. Alternatively, you can check up on it by running `expo build:status`. When it's done, you'll see the url to your app file - an **.apk**, **.aab** (both Android), or **.ipa** (iOS) file. Copy and paste the link into your browser to download the file.
+Expo Build Service uses building machines to build your app. The build process starts as soon as one of the machines is free and ready to be used. To check how long the waiting time for your build is, visit [Turtle status](https://expo.dev/turtle-status) site.
 
-> Want to be notified programmatically as soon as your build is done? [Here's how you can set that up with webhooks](/eas/webhooks.md).
+Expo CLI prints a URL with a unique ID, such as `expo.dev/builds/some-unique-id`, for you to visit and check your build progress. You can also access build logs on this URL.
+
+Alternatively, you can check the status by running:
+
+<Terminal cmd={['$ expo build:status']} />
+
+When the build process finishes, you will get a URL to your app file - an **.apk**, **.aab** (both Android), or **.ipa** (iOS) file. Copy and paste the link into your browser to download the file.
+
+> Want to be notified programmatically as soon as your build is done? [Here's how you can set that up with webhooks](/eas/webhooks).
 
 ## 5. Test it on your device or simulator
 
 ### Android
 
-- **To run it on your Android Emulator**, first build your project with the apk flag by running `expo build:android -t apk`, and you can drag and drop the **.apk** into the emulator.
-- **To run it on your Android device**, make sure you have the Android platform tools installed along with `adb`, then just run `adb install app-filename.apk` with [USB debugging enabled on your device](https://developer.android.com/studio/run/device.html#device-developer-options) and the device plugged in.
+- **To run it on your Android Emulator**, first build your project with the apk flag by running `expo build:android -t apk`, and drag and drop the **.apk** into the emulator.
+- **To run it on your Android device**, make sure you have the Android platform tools installed along with `adb`, then just run `adb install app-filename.apk` with [USB debugging enabled on your device](https://developer.android.com/studio/run/device#device-developer-options) and the device plugged in.
 
 ### iOS
 
-- **To run it on your iOS simulator**, first build your project with the simulator flag by running `expo build:ios -t simulator`, then download the artifact with the link printed when your build completes. To install the resulting **tar.gz** file, unzip it and drag-and-drop it into your iOS simulator. If you'd like to install it from the command line, run `tar -xvzf your-app.tar.gz` to unpack the file, open a simulator, then run `xcrun simctl install booted <path to .app>`.
-
+- **To run it on your iOS simulator**, first build your project with the simulator flag by running `expo build:ios -t simulator`, then download the artifact with the link printed when your build completes. To install the resulting **tar.gz** file, unzip it and drag and drop it into your iOS simulator. If you'd like to install it from the command line, run `tar -xvzf your-app.tar.gz` to unpack the file, open a simulator, then run `xcrun simctl install booted <path to .app>`.
 - **To test a device build with Apple TestFlight**, download the **.ipa** file to your local machine. Within [App Store Connect](https://appstoreconnect.apple.com/apps), click the plus icon and create a New App. Make sure your `bundleIdentifier` matches what you've placed in **app.json**. Now, you need to use Xcode or [Transporter](https://apps.apple.com/app/transporter/id1450874784) (previously known as Application Loader) to upload the **.ipa** you got from `expo build:ios`. Once you do that, you can check the status of your build under `Activity`. Processing an app can take 10-15 minutes before it shows up under available builds.
 
 ## 6. Submit it to the appropriate store
 
-Read the guide on [Uploading Apps to the Apple App Store and Google Play](/distribution/uploading-apps.md).
+Read the documentation on [Uploading Apps to the Apple App Store and Google Play](/distribution/uploading-apps).
 
 ## 7. Update your app
 
-For the most part, when you want to update your app, just Publish again from Expo CLI. Your users will download the new JS the next time they open the app. To ensure your users have a seamless experience downloading JS updates, you may want to enable [background JS downloads](../guides/offline-support.md). However, there are a couple reasons why you might want to rebuild and resubmit the native binaries:
+To update your app, use the command `expo publish` from the Expo CLI. The physical device on which the app is installed will download the new JavaScript update the next time the app is open on that device. To ensure your app users have a seamless experience downloading JavaScript updates, you may want to enable [background JS downloads](/guides/offline-support).
+
+There are a couple of reasons why you might want to rebuild and resubmit the native binaries:
 
 - If you want to change native metadata like the app's name or icon
-- If you upgrade to a newer SDK version of your app (which requires new native code)
+- If you upgrade to a newer SDK version of the app (which requires new native code)
 
-To keep track of this, you'll need to update your app's `versionCode` and `buildNumber` in app.json (see [here](/distribution/app-stores.md#versioning-your-app) for details).
+You have to update the app's `versionCode` and `buildNumber` in **app.json**. Read the [Versioning Your app documentation](/distribution/app-stores#versioning-your-app) for more details.
 
-It is a good idea to glance through the [app.json documentation](/workflow/configuration.md) to get an idea of all the properties you can change, e.g. the icons, deep linking url scheme, handset/tablet support, and a lot more.
-
-If you run into problems during this process, we're more than happy to help out! [Join our Forums](https://forums.expo.dev/) and let us know if you have any questions.
+We also recommend you go through [**app.json** documentation](/workflow/configuration) to get an idea of all the properties you can change. Such as the icons, deep linking URL scheme, add or remove handset/tablet support, etc.

--- a/docs/pages/classic/building-standalone-apps.md
+++ b/docs/pages/classic/building-standalone-apps.md
@@ -78,7 +78,7 @@ When building an aab, make sure [Google Play App Signing](/app-signing/app-crede
 
 #### Generating keystore
 
-When building your app for the first time, you have to generate a [keystore](https://developer.android.com/training/articles/keystore). You can upload your own if you are familiar with process of generating keystore, or you can let Expo handle the process.
+When building your app for the first time, you'll have to generate a [keystore](https://developer.android.com/training/articles/keystore). You can upload your own if you are familiar with the process of generating keystores, or you can let Expo handle the process.
 
 For Expo to handle the process, choose the first option in the command-line when prompted for keystore:
 

--- a/docs/pages/classic/building-standalone-apps.md
+++ b/docs/pages/classic/building-standalone-apps.md
@@ -153,7 +153,7 @@ If you are familiar with iOS credentials and plan to provide your own, use the [
 
 To build and distribute your app using Apple's Enterprise distribution, it is required that you are a member of the [Apple Developer Enterprise Program](https://developer.apple.com/programs/enterprise/).
 
-Expo Build Service supports Enterprise distribution. When you call `expo build:ios`, you just need to choose the correct team that is labeled with `(In-House)`.
+Expo's build service supports Enterprise distribution. When you run `expo build:ios`, you'll need to choose the correct team that is labeled with `(In-House)`.
 
 #### Adhoc distribution
 

--- a/docs/pages/classic/building-standalone-apps.md
+++ b/docs/pages/classic/building-standalone-apps.md
@@ -58,7 +58,7 @@ There are other options you can add to **app.json**. For example, some developer
 
 ## 3. Start the build
 
-To start the build process, run `expo build:android` or `expo build:ios` depending on the platform you are building. If there is no development server running for the app you are building, `expo` will start it automatically.
+To start the build process, run `expo build:android` or `expo build:ios` depending on the platform you are building for. If there is no development server running for the app you are building, `expo` will start it automatically.
 
 > When you run `expo build`, Expo automatically publishes your app (with `expo publish`). To avoid accidentally publishing changes to your production app, you may want to use [release channels](/distribution/release-channels).
 

--- a/docs/pages/classic/building-standalone-apps.md
+++ b/docs/pages/classic/building-standalone-apps.md
@@ -20,7 +20,7 @@ Expo CLI is a command-line application required to build standalone apps. It is 
 
 You must have an Expo account and be logged in to create a build. When running the build command, you can create a new account or log in to an existing account.
 
-Developers using **Windows** operating system must have WSL enabled. If you do not have it installed, follow this [installation guide](https://docs.microsoft.com/en-us/windows/wsl/install). When it prompts for choosing a Linux distribution, we recommend picking Ubuntu from the Windows Store. Launch Ubuntu at least once and then use an admin PowerShell to run the command:
+Developers using the **Windows** operating system must have WSL enabled. If you do not have it installed, follow this [installation guide](https://docs.microsoft.com/en-us/windows/wsl/install). When it prompts for choosing a Linux distribution, we recommend picking Ubuntu from the Windows Store. Launch Ubuntu at least once and then use an admin PowerShell to run the command:
 
 <Terminal cmd={['$ Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Windows-Subsystem-Linux']} />
 

--- a/docs/pages/classic/building-standalone-apps.md
+++ b/docs/pages/classic/building-standalone-apps.md
@@ -74,7 +74,7 @@ We recommend building an Android App Bundle (aab) for submitting the app to the 
 
 <Terminal cmd={['$ expo build:android -t app-bundle']} />
 
-When building abb, you have to make sure the [Google Play App Signing](/app-signing/app-credentials) is enabled for your project. You can read more about it in the [Android documentation](https://developer.android.com/guide/app-bundle).
+When building an aab, make sure [Google Play App Signing](/app-signing/app-credentials) is enabled for your project. You can read more about it in the [Android documentation](https://developer.android.com/guide/app-bundle).
 
 #### Generating keystore
 

--- a/docs/pages/classic/building-standalone-apps.md
+++ b/docs/pages/classic/building-standalone-apps.md
@@ -18,7 +18,7 @@ An Apple Developer account is required to build a standalone iOS app, but a Goog
 
 Expo CLI is a command-line application required to build standalone apps. It is installed as a global npm package. If you have not installed it, go through the [installation steps in the Expo CLI documentation](/workflow/expo-cli/#installation).
 
-You must have an Expo account created or logged. When running the build command, you can create a new one or log in to your existing account.
+You must have an Expo account and be logged in to create a build. When running the build command, you can create a new account or log in to an existing account.
 
 Developers using **Windows** operating system must have WSL enabled. If you do not have it installed, follow this [installation guide](https://docs.microsoft.com/en-us/windows/wsl/install). When it prompts for choosing a Linux distribution, we recommend picking Ubuntu from the Windows Store. Launch Ubuntu at least once and then use an admin PowerShell to run the command:
 

--- a/docs/pages/classic/building-standalone-apps.md
+++ b/docs/pages/classic/building-standalone-apps.md
@@ -26,7 +26,7 @@ Developers using **Windows** operating system must have WSL enabled. If you do n
 
 ## 2. Configure app.json
 
-In the **app.json/** file, you have to add a set of configuration before running the build command. The code snippet below represents a minimal required version of the configuration:
+In the **app.json**, you have to add a set of configuration before running the build command. The code snippet below represents a minimal required version of the configuration:
 
 ```json
 {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fixes ENG-5388

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR updates to documentation to use 
- Consistent verbiage, and Terminal component for copy/paste commands. 
- It also adds a new sub-section called `Uploading your keystore after publishing the app` and replaces the he big wall of text that was used as a "Note" before.

Simplifies other sections in the doc too.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

The changes have been tested by running docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
