### PR TITLE
[home] don't factor in user data loading state when deciding to show log in button

### DIFF
--- a/home/screens/HomeScreen/HomeScreenHeader.tsx
+++ b/home/screens/HomeScreen/HomeScreenHeader.tsx
@@ -10,13 +10,11 @@ import { HomeScreenDataQuery } from '../../graphql/types';
 import { useTheme } from '../../utils/useTheme';
 
 type Props = {
-  loading?: boolean;
   currentUser?: Exclude<HomeScreenDataQuery['account']['byName'], null>;
 };
 
-export function HomeScreenHeader({ currentUser, loading }: Props) {
+export function HomeScreenHeader({ currentUser }: Props) {
   const { theme, themeType } = useTheme();
-
   const navigation = useNavigation();
 
   async function onAccountButtonPress() {
@@ -26,41 +24,37 @@ export function HomeScreenHeader({ currentUser, loading }: Props) {
 
   let rightContent: React.ReactNode | null = null;
 
-  // when loading, show nothing to rather than a loading indicator to prevent flicker
-  if (!loading) {
-    // when user is logged in, show account button
-    if (currentUser) {
-      rightContent = (
-        <Button.Container onPress={onAccountButtonPress}>
-          {/* Show profile picture for personal accounts / accounts with members */}
-          {currentUser?.owner?.profilePhoto ? (
-            <Image size="xl" rounded="full" source={{ uri: currentUser.owner.profilePhoto }} />
-          ) : (
-            <View rounded="full" height="xl" width="xl" bg="secondary" align="centered">
-              <UsersIcon color={theme.icon.default} size={iconSize.small} />
-            </View>
-          )}
-        </Button.Container>
-      );
-    } else {
-      // when user is logged out, show log in button
-      rightContent = (
-        <TouchableOpacity
-          onPress={onAccountButtonPress}
-          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-          style={{
-            borderRadius: borderRadius.small,
-            padding: spacing[2],
-            backgroundColor: theme.button.ghost.background,
-            borderWidth: 1,
-            borderColor: theme.button.ghost.border,
-          }}>
-          <Button.Text type="InterSemiBold" color="ghost" size="small">
-            Log In
-          </Button.Text>
-        </TouchableOpacity>
-      );
-    }
+  if (currentUser) {
+    rightContent = (
+      <Button.Container onPress={onAccountButtonPress}>
+        {/* Show profile picture for personal accounts / accounts with members */}
+        {currentUser?.owner?.profilePhoto ? (
+          <Image size="xl" rounded="full" source={{ uri: currentUser.owner.profilePhoto }} />
+        ) : (
+          <View rounded="full" height="xl" width="xl" bg="secondary" align="centered">
+            <UsersIcon color={theme.icon.default} size={iconSize.small} />
+          </View>
+        )}
+      </Button.Container>
+    );
+  } else {
+    // when user is logged out, show log in button
+    rightContent = (
+      <TouchableOpacity
+        onPress={onAccountButtonPress}
+        hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+        style={{
+          borderRadius: borderRadius.small,
+          padding: spacing[2],
+          backgroundColor: theme.button.ghost.background,
+          borderWidth: 1,
+          borderColor: theme.button.ghost.border,
+        }}>
+        <Button.Text type="InterSemiBold" color="ghost" size="small">
+          Log In
+        </Button.Text>
+      </TouchableOpacity>
+    );
   }
 
   return (

--- a/home/screens/HomeScreen/HomeScreenView.tsx
+++ b/home/screens/HomeScreen/HomeScreenView.tsx
@@ -58,7 +58,6 @@ type State = {
   isNetworkAvailable: boolean;
   isRefreshing: boolean;
   data?: Exclude<HomeScreenDataQuery['account']['byName'], null>;
-  loading: boolean;
 };
 
 type NavigationProps = StackScreenProps<HomeStackRoutes, 'Home'>;
@@ -72,7 +71,6 @@ export class HomeScreenView extends React.Component<Props, State> {
     isNetworkAvailable: Connectivity.isAvailable(),
     isRefreshing: false,
     data: this.props.initialData?.account.byName,
-    loading: !this.props.initialData?.account.byName, // if there is initial data, we're not loading
   };
 
   componentDidMount() {
@@ -225,7 +223,6 @@ export class HomeScreenView extends React.Component<Props, State> {
 
   private _startPollingForProjects = async () => {
     await this._fetchProjectsAsync();
-    this.setState({ loading: false });
     this._projectPolling = setInterval(this._fetchProjectsAsync, PROJECT_UPDATE_INTERVAL);
   };
 

--- a/home/screens/HomeScreen/HomeScreenView.tsx
+++ b/home/screens/HomeScreen/HomeScreenView.tsx
@@ -106,7 +106,7 @@ export class HomeScreenView extends React.Component<Props, State> {
 
     return (
       <View style={styles.container}>
-        <HomeScreenHeader currentUser={data} loading={this.state.loading} />
+        <HomeScreenHeader currentUser={data} />
         <ScrollView
           refreshControl={
             <RefreshControl refreshing={isRefreshing} onRefresh={this._handleRefreshAsync} />


### PR DESCRIPTION
# Why

In a previous PR, I changed the home screen so that we don't poll for projects until a user logs in. This created a bug where the log in button wouldn't show because we were waiting on a `loading` boolean to be updated that only gets set when we poll for projects.

# How

Because we attempt to load user data during the splash screen, we don't need to track a loading state to prevent log in button flashes as I previously intended. `currentUser` data should already be present when the home screen is shown, and if it's not there, we show the log in button. 

# Test Plan

Opening Expo Go on Android (or iOS for that manner) when not logged in should show the log in button in the top right.

![Screenshot_20220707-124507](https://user-images.githubusercontent.com/12488826/177827201-17edd8e4-173f-4d83-9b8a-0db09ad54f7d.png)

