### PR TITLE
[dev-client] Support v8 on android

### DIFF
--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/DevLauncherClientHost.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/DevLauncherClientHost.kt
@@ -1,21 +1,18 @@
 package expo.modules.devlauncher.launcher
 
 import android.app.Application
-import com.facebook.hermes.reactexecutor.HermesExecutorFactory
 import com.facebook.react.ReactNativeHost
 import com.facebook.react.ReactPackage
 import com.facebook.react.bridge.JavaScriptExecutorFactory
-import com.facebook.react.jscexecutor.JSCExecutorFactory
-import com.facebook.react.modules.systeminfo.AndroidInfoHelpers
 import com.facebook.react.shell.MainReactPackage
-import com.facebook.soloader.SoLoader
+import devmenu.com.swmansion.gesturehandler.react.RNGestureHandlerPackage
+import devmenu.com.th3rdwave.safeareacontext.SafeAreaContextPackage
 import expo.modules.devlauncher.DevLauncherController
 import expo.modules.devlauncher.DevLauncherPackage
 import expo.modules.devlauncher.helpers.findDevMenuPackage
 import expo.modules.devlauncher.helpers.findPackagesWithDevMenuExtension
 import expo.modules.devlauncher.helpers.injectDebugServerHost
-import devmenu.com.th3rdwave.safeareacontext.SafeAreaContextPackage
-import devmenu.com.swmansion.gesturehandler.react.RNGestureHandlerPackage
+import expo.modules.devmenu.helpers.getAppJavaScriptExecutorFactory
 
 class DevLauncherClientHost(
   application: Application,
@@ -52,11 +49,7 @@ class DevLauncherClientHost(
   }
 
   override fun getJavaScriptExecutorFactory(): JavaScriptExecutorFactory? {
-    SoLoader.init(application.applicationContext, /* native exopackage */ false)
-    if (SoLoader.getLibraryPath("libjsc.so") != null) {
-      return JSCExecutorFactory(application.packageName, AndroidInfoHelpers.getFriendlyDeviceName())
-    }
-    return HermesExecutorFactory()
+    return getAppJavaScriptExecutorFactory(application)
   }
 
   override fun getJSMainModuleName() = "index"

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/helpers/DevLauncherJavaScriptExecutorExtension.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/helpers/DevLauncherJavaScriptExecutorExtension.kt
@@ -1,0 +1,70 @@
+package expo.modules.devlauncher.helpers
+
+import android.content.Context
+import com.facebook.hermes.reactexecutor.HermesExecutorFactory
+import com.facebook.react.ReactApplication
+import com.facebook.react.ReactNativeHost
+import com.facebook.react.bridge.JavaScriptExecutorFactory
+import com.facebook.react.jscexecutor.JSCExecutorFactory
+import com.facebook.react.modules.systeminfo.AndroidInfoHelpers
+import com.facebook.soloader.SoLoader
+
+
+/**
+ * Returns the [JavaScriptExecutorFactory] from application in case it override some custom [JavaScriptExecutorFactory],
+ * otherwise, returns the default [JavaScriptExecutorFactory] (either [JSCExecutorFactory] or [HermesExecutorFactory]).
+ */
+fun Any.getAppJavaScriptExecutorFactory(applicationContext: Context): JavaScriptExecutorFactory? {
+  if (isCyclingGetJavaScriptExecutorFactory()) {
+    return null
+  }
+  (applicationContext as? ReactApplication)?.reactNativeHost?.run {
+    val method = ReactNativeHost::class.java.getDeclaredMethod("getJavaScriptExecutorFactory")
+    method.isAccessible = true
+    val javaScriptExecutorFactory = method.invoke(this) as? JavaScriptExecutorFactory
+    if (javaScriptExecutorFactory != null) {
+      return javaScriptExecutorFactory
+    }
+  }
+
+  return getDefaultJavaScriptExecutorFactory(applicationContext)
+}
+
+/**
+ * Get the react-native default [JavaScriptExecutorFactory].
+ *
+ * To fix the crash from loading `ReactInstanceManagerBuilder.getDefaultJSExecutorFactory()` multiple times,
+ * we use a non-try-catch solution here.
+ * Ref: https://github.com/expo/expo/pull/16099
+ */
+private fun getDefaultJavaScriptExecutorFactory(applicationContext: Context): JavaScriptExecutorFactory {
+  SoLoader.init(applicationContext, /* native exopackage */ false)
+  if (SoLoader.getLibraryPath("libjsc.so") != null) {
+    return JSCExecutorFactory(applicationContext.packageName, AndroidInfoHelpers.getFriendlyDeviceName())
+  }
+  return HermesExecutorFactory()
+}
+
+/**
+ * Check whether it's a cycling call for [ReactNativeHost.getJavaScriptExecutorFactory].
+ * Because in [ReactNativeHost.getJavaScriptExecutorFactory] we use reflection call to get the [JavaScriptExecutorFactory]
+ * from application. In the ReactNativeHostWrapper, it will loop to this class again
+ * and we don't want to override it this time.
+ * We want to know whether there are other ReactNativeHostHandlers define the [JavaScriptExecutorFactory].
+ * E.g. The V8ExpoAdapterPackage defines its [JavaScriptExecutorFactory].
+ *
+ * Note that this method is an inline method to save the stackTrace traversal easier.
+ */
+@Suppress("NOTHING_TO_INLINE")
+private inline fun Any.isCyclingGetJavaScriptExecutorFactory(): Boolean {
+  var counter = 0
+  Thread.currentThread().stackTrace.iterator().forEach {
+    if (it.className == this::class.java.name && it.methodName == "getJavaScriptExecutorFactory") {
+      ++counter
+    }
+    if (counter >= 2) {
+      return true
+    }
+  }
+  return false
+}

--- a/packages/expo-dev-launcher/android/src/react-native-64/expo/modules/devlauncher/rncompatibility/DevLauncherReactNativeHostHandler.kt
+++ b/packages/expo-dev-launcher/android/src/react-native-64/expo/modules/devlauncher/rncompatibility/DevLauncherReactNativeHostHandler.kt
@@ -1,13 +1,10 @@
 package expo.modules.devlauncher.rncompatibility
 
 import android.content.Context
-import com.facebook.hermes.reactexecutor.HermesExecutorFactory
 import com.facebook.react.bridge.JavaScriptExecutorFactory
-import com.facebook.react.jscexecutor.JSCExecutorFactory
-import com.facebook.react.modules.systeminfo.AndroidInfoHelpers
-import com.facebook.soloader.SoLoader
 import expo.modules.core.interfaces.ReactNativeHostHandler
 import expo.modules.devlauncher.DevLauncherController
+import expo.modules.devlauncher.helpers.getAppJavaScriptExecutorFactory
 import java.lang.ref.WeakReference
 
 class DevLauncherReactNativeHostHandler(context: Context) : ReactNativeHostHandler {
@@ -23,11 +20,6 @@ class DevLauncherReactNativeHostHandler(context: Context) : ReactNativeHostHandl
   override fun getJavaScriptExecutorFactory(): JavaScriptExecutorFactory? {
     val context = contextHolder.get() ?: return null
     val applicationContext = context.applicationContext
-
-    SoLoader.init(applicationContext, /* native exopackage */ false)
-    if (SoLoader.getLibraryPath("libjsc.so") != null) {
-      return JSCExecutorFactory(applicationContext.packageName, AndroidInfoHelpers.getFriendlyDeviceName())
-    }
-    return HermesExecutorFactory()
+    return getAppJavaScriptExecutorFactory(applicationContext)
   }
 }

--- a/packages/expo-dev-launcher/android/src/react-native-65/expo/modules/devlauncher/rncompatibility/DevLauncherReactNativeHostHandler.kt
+++ b/packages/expo-dev-launcher/android/src/react-native-65/expo/modules/devlauncher/rncompatibility/DevLauncherReactNativeHostHandler.kt
@@ -1,13 +1,10 @@
 package expo.modules.devlauncher.rncompatibility
 
 import android.content.Context
-import com.facebook.hermes.reactexecutor.HermesExecutorFactory
 import com.facebook.react.bridge.JavaScriptExecutorFactory
-import com.facebook.react.jscexecutor.JSCExecutorFactory
-import com.facebook.react.modules.systeminfo.AndroidInfoHelpers
-import com.facebook.soloader.SoLoader
 import expo.modules.core.interfaces.ReactNativeHostHandler
 import expo.modules.devlauncher.DevLauncherController
+import expo.modules.devlauncher.helpers.getAppJavaScriptExecutorFactory
 import java.lang.ref.WeakReference
 
 class DevLauncherReactNativeHostHandler(context: Context) : ReactNativeHostHandler {
@@ -23,11 +20,6 @@ class DevLauncherReactNativeHostHandler(context: Context) : ReactNativeHostHandl
   override fun getJavaScriptExecutorFactory(): JavaScriptExecutorFactory? {
     val context = contextHolder.get() ?: return null
     val applicationContext = context.applicationContext
-
-    SoLoader.init(applicationContext, /* native exopackage */ false)
-    if (SoLoader.getLibraryPath("libjsc.so") != null) {
-      return JSCExecutorFactory(applicationContext.packageName, AndroidInfoHelpers.getFriendlyDeviceName())
-    }
-    return HermesExecutorFactory()
+    return getAppJavaScriptExecutorFactory(applicationContext)
   }
 }

--- a/packages/expo-dev-launcher/android/src/react-native-66/expo/modules/devlauncher/rncompatibility/DevLauncherReactNativeHostHandler.kt
+++ b/packages/expo-dev-launcher/android/src/react-native-66/expo/modules/devlauncher/rncompatibility/DevLauncherReactNativeHostHandler.kt
@@ -1,13 +1,10 @@
 package expo.modules.devlauncher.rncompatibility
 
 import android.content.Context
-import com.facebook.hermes.reactexecutor.HermesExecutorFactory
 import com.facebook.react.bridge.JavaScriptExecutorFactory
-import com.facebook.react.jscexecutor.JSCExecutorFactory
-import com.facebook.react.modules.systeminfo.AndroidInfoHelpers
-import com.facebook.soloader.SoLoader
 import expo.modules.core.interfaces.ReactNativeHostHandler
 import expo.modules.devlauncher.DevLauncherController
+import expo.modules.devlauncher.helpers.getAppJavaScriptExecutorFactory
 import java.lang.ref.WeakReference
 
 class DevLauncherReactNativeHostHandler(context: Context) : ReactNativeHostHandler {
@@ -23,11 +20,6 @@ class DevLauncherReactNativeHostHandler(context: Context) : ReactNativeHostHandl
   override fun getJavaScriptExecutorFactory(): JavaScriptExecutorFactory? {
     val context = contextHolder.get() ?: return null
     val applicationContext = context.applicationContext
-
-    SoLoader.init(applicationContext, /* native exopackage */ false)
-    if (SoLoader.getLibraryPath("libjsc.so") != null) {
-      return JSCExecutorFactory(applicationContext.packageName, AndroidInfoHelpers.getFriendlyDeviceName())
-    }
-    return HermesExecutorFactory()
+    return getAppJavaScriptExecutorFactory(applicationContext)
   }
 }

--- a/packages/expo-dev-launcher/android/src/react-native-67/expo/modules/devlauncher/rncompatibility/DevLauncherReactNativeHostHandler.kt
+++ b/packages/expo-dev-launcher/android/src/react-native-67/expo/modules/devlauncher/rncompatibility/DevLauncherReactNativeHostHandler.kt
@@ -1,14 +1,11 @@
 package expo.modules.devlauncher.rncompatibility
 
 import android.content.Context
-import com.facebook.hermes.reactexecutor.HermesExecutorFactory
 import com.facebook.react.bridge.JavaScriptExecutorFactory
 import com.facebook.react.devsupport.DevSupportManagerFactory
-import com.facebook.react.jscexecutor.JSCExecutorFactory
-import com.facebook.react.modules.systeminfo.AndroidInfoHelpers
-import com.facebook.soloader.SoLoader
 import expo.modules.core.interfaces.ReactNativeHostHandler
 import expo.modules.devlauncher.DevLauncherController
+import expo.modules.devlauncher.helpers.getAppJavaScriptExecutorFactory
 import java.lang.ref.WeakReference
 
 class DevLauncherReactNativeHostHandler(context: Context) : ReactNativeHostHandler {
@@ -24,11 +21,6 @@ class DevLauncherReactNativeHostHandler(context: Context) : ReactNativeHostHandl
   override fun getJavaScriptExecutorFactory(): JavaScriptExecutorFactory? {
     val context = contextHolder.get() ?: return null
     val applicationContext = context.applicationContext
-
-    SoLoader.init(applicationContext, /* native exopackage */ false)
-    if (SoLoader.getLibraryPath("libjsc.so") != null) {
-      return JSCExecutorFactory(applicationContext.packageName, AndroidInfoHelpers.getFriendlyDeviceName())
-    }
-    return HermesExecutorFactory()
+    return getAppJavaScriptExecutorFactory(applicationContext)
   }
 }

--- a/packages/expo-dev-launcher/android/src/react-native-69/expo/modules/devlauncher/rncompatibility/DevLauncherReactNativeHostHandler.kt
+++ b/packages/expo-dev-launcher/android/src/react-native-69/expo/modules/devlauncher/rncompatibility/DevLauncherReactNativeHostHandler.kt
@@ -21,7 +21,6 @@ class DevLauncherReactNativeHostHandler(context: Context) : ReactNativeHostHandl
   override fun getJavaScriptExecutorFactory(): JavaScriptExecutorFactory? {
     val context = contextHolder.get() ?: return null
     val applicationContext = context.applicationContext
-
     return getAppJavaScriptExecutorFactory(applicationContext)
   }
 }

--- a/packages/expo-dev-launcher/android/src/react-native-69/expo/modules/devlauncher/rncompatibility/DevLauncherReactNativeHostHandler.kt
+++ b/packages/expo-dev-launcher/android/src/react-native-69/expo/modules/devlauncher/rncompatibility/DevLauncherReactNativeHostHandler.kt
@@ -1,14 +1,11 @@
 package expo.modules.devlauncher.rncompatibility
 
 import android.content.Context
-import com.facebook.hermes.reactexecutor.HermesExecutorFactory
 import com.facebook.react.bridge.JavaScriptExecutorFactory
 import com.facebook.react.devsupport.DevSupportManagerFactory
-import com.facebook.react.jscexecutor.JSCExecutorFactory
-import com.facebook.react.modules.systeminfo.AndroidInfoHelpers
-import com.facebook.soloader.SoLoader
 import expo.modules.core.interfaces.ReactNativeHostHandler
 import expo.modules.devlauncher.DevLauncherController
+import expo.modules.devlauncher.helpers.getAppJavaScriptExecutorFactory
 import java.lang.ref.WeakReference
 
 class DevLauncherReactNativeHostHandler(context: Context) : ReactNativeHostHandler {
@@ -25,10 +22,6 @@ class DevLauncherReactNativeHostHandler(context: Context) : ReactNativeHostHandl
     val context = contextHolder.get() ?: return null
     val applicationContext = context.applicationContext
 
-    SoLoader.init(applicationContext, /* native exopackage */ false)
-    if (SoLoader.getLibraryPath("libjsc.so") != null) {
-      return JSCExecutorFactory(applicationContext.packageName, AndroidInfoHelpers.getFriendlyDeviceName())
-    }
-    return HermesExecutorFactory()
+    return getAppJavaScriptExecutorFactory(applicationContext)
   }
 }

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuHost.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuHost.kt
@@ -3,21 +3,19 @@ package expo.modules.devmenu
 import android.app.Application
 import android.content.Context
 import android.util.Log
-import com.facebook.hermes.reactexecutor.HermesExecutorFactory
 import com.facebook.react.ReactInstanceManager
 import com.facebook.react.ReactNativeHost
 import com.facebook.react.ReactPackage
 import com.facebook.react.bridge.JSIModulePackage
 import com.facebook.react.bridge.JavaScriptExecutorFactory
 import com.facebook.react.devsupport.DevServerHelper
-import com.facebook.react.jscexecutor.JSCExecutorFactory
-import com.facebook.react.modules.systeminfo.AndroidInfoHelpers
 import com.facebook.react.shell.MainReactPackage
-import com.facebook.soloader.SoLoader
+import expo.modules.devmenu.helpers.getAppJavaScriptExecutorFactory
 import expo.modules.devmenu.react.DevMenuReactInternalSettings
 import java.io.BufferedReader
 import java.io.FileNotFoundException
 import java.io.InputStreamReader
+
 /**
  * Class that represents react host used by dev menu.
  */
@@ -59,11 +57,7 @@ class DevMenuHost(application: Application) : ReactNativeHost(application) {
   fun getContext(): Context = super.getApplication()
 
   override fun getJavaScriptExecutorFactory(): JavaScriptExecutorFactory? {
-    SoLoader.init(application.applicationContext, /* native exopackage */ false)
-    if (SoLoader.getLibraryPath("libjsc.so") != null) {
-      return JSCExecutorFactory(application.packageName, AndroidInfoHelpers.getFriendlyDeviceName())
-    }
-    return HermesExecutorFactory()
+    return getAppJavaScriptExecutorFactory(application)
   }
 
   override fun createReactInstanceManager(): ReactInstanceManager {

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/helpers/DevMenuJavaScriptExecutorExtension.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/helpers/DevMenuJavaScriptExecutorExtension.kt
@@ -1,0 +1,70 @@
+package expo.modules.devmenu.helpers
+
+import android.content.Context
+import com.facebook.hermes.reactexecutor.HermesExecutorFactory
+import com.facebook.react.ReactApplication
+import com.facebook.react.ReactNativeHost
+import com.facebook.react.bridge.JavaScriptExecutorFactory
+import com.facebook.react.jscexecutor.JSCExecutorFactory
+import com.facebook.react.modules.systeminfo.AndroidInfoHelpers
+import com.facebook.soloader.SoLoader
+
+
+/**
+ * Returns the [JavaScriptExecutorFactory] from application in case it override some custom [JavaScriptExecutorFactory],
+ * otherwise, returns the default [JavaScriptExecutorFactory] (either [JSCExecutorFactory] or [HermesExecutorFactory]).
+ */
+fun ReactNativeHost.getAppJavaScriptExecutorFactory(applicationContext: Context): JavaScriptExecutorFactory? {
+  if (isCyclingGetJavaScriptExecutorFactory()) {
+    return null
+  }
+  (applicationContext as? ReactApplication)?.reactNativeHost?.run {
+    val method = ReactNativeHost::class.java.getDeclaredMethod("getJavaScriptExecutorFactory")
+    method.isAccessible = true
+    val javaScriptExecutorFactory = method.invoke(this) as? JavaScriptExecutorFactory
+    if (javaScriptExecutorFactory != null) {
+      return javaScriptExecutorFactory
+    }
+  }
+
+  return getDefaultJavaScriptExecutorFactory(applicationContext)
+}
+
+/**
+ * Get the react-native default [JavaScriptExecutorFactory].
+ *
+ * To fix the crash from loading `ReactInstanceManagerBuilder.getDefaultJSExecutorFactory()` multiple times,
+ * we use a non-try-catch solution here.
+ * Ref: https://github.com/expo/expo/pull/16099
+ */
+private fun getDefaultJavaScriptExecutorFactory(applicationContext: Context): JavaScriptExecutorFactory {
+  SoLoader.init(applicationContext, /* native exopackage */ false)
+  if (SoLoader.getLibraryPath("libjsc.so") != null) {
+    return JSCExecutorFactory(applicationContext.packageName, AndroidInfoHelpers.getFriendlyDeviceName())
+  }
+  return HermesExecutorFactory()
+}
+
+/**
+ * Check whether it's a cycling call for [ReactNativeHost.getJavaScriptExecutorFactory].
+ * Because in [ReactNativeHost.getJavaScriptExecutorFactory] we use reflection call to get the [JavaScriptExecutorFactory]
+ * from application. In the ReactNativeHostWrapper, it will loop to this class again
+ * and we don't want to override it this time.
+ * We want to know whether there are other ReactNativeHostHandlers define the [JavaScriptExecutorFactory].
+ * E.g. The V8ExpoAdapterPackage defines its [JavaScriptExecutorFactory].
+ *
+ * Note that this method is an inline method to save the stackTrace traversal easier.
+ */
+@Suppress("NOTHING_TO_INLINE")
+private inline fun Any.isCyclingGetJavaScriptExecutorFactory(): Boolean {
+  var counter = 0
+  Thread.currentThread().stackTrace.iterator().forEach {
+    if (it.className == this::class.java.name && it.methodName == "getJavaScriptExecutorFactory") {
+      ++counter
+    }
+    if (counter >= 2) {
+      return true
+    }
+  }
+  return false
+}


### PR DESCRIPTION
# Why

dev-client breaks custom `JavaScriptExecutorFactory` like v8 on android.
close ENG-5496

# How

- try to get the `JavaScriptExecutorFactory` from application first, otherwise to use the default one.
- [ ] the vendored reanimated doesn't support v8 still

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
