### PR TITLE
[dev-launcher] add organizations to account selector

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - Include extra information in the recently opened list ([#17633](https://github.com/expo/expo/pull/17633) by [@ajsmth](https://github.com/ajsmth))
 - Add debug settings for EAS Updates (admin only) ([#17842](https://github.com/expo/expo/pull/17842) by [@ajsmth](https://github.com/ajsmth))
-- Add organizations to account selector
+- Add organizations to account selector ([#18152](https://github.com/expo/expo/pull/18152) by [@ajsmth](https://github.com/ajsmth))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Include extra information in the recently opened list ([#17633](https://github.com/expo/expo/pull/17633) by [@ajsmth](https://github.com/ajsmth))
 - Add debug settings for EAS Updates (admin only) ([#17842](https://github.com/expo/expo/pull/17842) by [@ajsmth](https://github.com/ajsmth))
+- Add organizations to account selector
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-dev-launcher/babel.config.js
+++ b/packages/expo-dev-launcher/babel.config.js
@@ -43,6 +43,10 @@ module.exports = function (api) {
 
   return {
     presets: ['babel-preset-expo'],
-    plugins: [['babel-plugin-module-resolver', moduleResolverConfig]],
+    plugins: [
+      ['babel-plugin-module-resolver', moduleResolverConfig],
+      // required for react-native-reanimated "export * as default" pattern
+      '@babel/plugin-proposal-export-namespace-from',
+    ],
   };
 };

--- a/packages/expo-dev-launcher/bundle/components/AppHeader.tsx
+++ b/packages/expo-dev-launcher/bundle/components/AppHeader.tsx
@@ -8,6 +8,7 @@ import {
   Spacer,
   View,
   UserIcon,
+  scale,
 } from 'expo-dev-client-components';
 import * as React from 'react';
 
@@ -26,7 +27,7 @@ export function AppHeader({ navigation }) {
   };
 
   const isAuthenticated = userData != null;
-  const selectedUserImage = selectedAccount?.owner?.profilePhoto;
+  const selectedUserImage = selectedAccount?.owner?.profilePhoto ?? null;
 
   return (
     <>
@@ -53,7 +54,7 @@ export function AppHeader({ navigation }) {
             </Row>
           </View>
 
-          <View>
+          <View align="centered" style={{ justifyContent: 'flex-end' }}>
             <Button.ScaleOnPressContainer
               onPress={onUserProfilePress}
               minScale={0.85}
@@ -63,8 +64,10 @@ export function AppHeader({ navigation }) {
               <View>
                 {isAuthenticated ? (
                   <View rounded="full" padding="small">
-                    <View bg="secondary" rounded="full">
-                      <Image size="xl" rounded="full" source={{ uri: selectedUserImage }} />
+                    <View height="xl" width="xl" bg="secondary" rounded="full">
+                      {selectedUserImage && (
+                        <Image size="xl" rounded="full" source={{ uri: selectedUserImage }} />
+                      )}
                     </View>
                   </View>
                 ) : (
@@ -76,6 +79,20 @@ export function AppHeader({ navigation }) {
                 )}
               </View>
             </Button.ScaleOnPressContainer>
+            {!selectedUserImage && (
+              <Row
+                style={{
+                  height: scale[2],
+                  flexWrap: 'wrap',
+                  maxWidth: scale[16],
+                  paddingRight: scale[2],
+                  transform: [{ translateY: -scale[2] }],
+                }}>
+                <Text numberOfLines={1} size="small" align="center" weight="medium">
+                  {selectedAccount?.name}
+                </Text>
+              </Row>
+            )}
           </View>
         </Row>
       </View>

--- a/packages/expo-dev-launcher/bundle/components/AppHeader.tsx
+++ b/packages/expo-dev-launcher/bundle/components/AppHeader.tsx
@@ -63,7 +63,9 @@ export function AppHeader({ navigation }) {
               <View>
                 {isAuthenticated ? (
                   <View rounded="full" padding="small">
-                    <Image size="xl" rounded="full" source={{ uri: selectedUserImage }} />
+                    <View bg="secondary" rounded="full">
+                      <Image size="xl" rounded="full" source={{ uri: selectedUserImage }} />
+                    </View>
                   </View>
                 ) : (
                   <View mx="small">

--- a/packages/expo-dev-launcher/bundle/functions/getUserProfileAsync.ts
+++ b/packages/expo-dev-launcher/bundle/functions/getUserProfileAsync.ts
@@ -15,7 +15,7 @@ export type UserData = {
 export type UserAccount = {
   id: string;
   name: string;
-  owner: {
+  owner?: {
     username: string;
     fullName?: string;
     profilePhoto?: string;

--- a/packages/expo-dev-launcher/bundle/screens/UserProfileScreen.tsx
+++ b/packages/expo-dev-launcher/bundle/screens/UserProfileScreen.tsx
@@ -183,38 +183,57 @@ function UserAccountSelector({
   onSelectAccount,
   onLogoutPress,
 }: UserAccountSelectorProps) {
+  const accounts: UserAccount[] = [];
+  const orgs: UserAccount[] = [];
+
+  for (const account of userData.accounts) {
+    if (account != null) {
+      if (account.owner != null) {
+        accounts.push(account);
+      } else {
+        orgs.push(account);
+      }
+    }
+  }
+
+  const accountsSortedByType: UserAccount[] = [...accounts, ...orgs];
+
   return (
     <View>
       <View>
-        {userData.accounts
-          .filter((account) => account && account.owner)
-          .map((account, index, arr) => {
-            const isLast = index === arr.length - 1;
-            const isFirst = index === 0;
-            const isSelected = account.id === selectedAccount?.id;
+        {accountsSortedByType.map((account, index, arr) => {
+          const isLast = index === arr.length - 1;
+          const isFirst = index === 0;
+          const isSelected = account.id === selectedAccount?.id;
 
-            return (
-              <Button.ScaleOnPressContainer
-                key={account.id}
-                onPress={() => onSelectAccount(account)}
-                bg="default"
-                roundedBottom={isLast ? 'large' : 'none'}
-                roundedTop={isFirst ? 'large' : 'none'}>
-                <Row align="center" py="small" px="medium" bg="default">
-                  <Image size="large" rounded="full" source={{ uri: account.owner.profilePhoto }} />
-                  <Spacer.Horizontal size="small" />
+          return (
+            <Button.ScaleOnPressContainer
+              key={account.id}
+              onPress={() => onSelectAccount(account)}
+              bg="default"
+              roundedBottom={isLast ? 'large' : 'none'}
+              roundedTop={isFirst ? 'large' : 'none'}>
+              <Row align="center" py="small" px="medium" bg="default">
+                <View rounded="full" bg="secondary">
+                  <Image
+                    size="large"
+                    rounded="full"
+                    source={{ uri: account.owner?.profilePhoto }}
+                  />
+                </View>
+                <Spacer.Horizontal size="small" />
 
-                  <View>
-                    <Heading>{account.owner.username}</Heading>
-                  </View>
+                <View>
+                  <Heading>{account.owner?.username ?? account.name}</Heading>
+                </View>
 
-                  <Spacer.Vertical />
-                  {isSelected && <CheckIcon testID={`active-account-checkmark-${account.id}`} />}
-                </Row>
-                {!isLast && <Divider />}
-              </Button.ScaleOnPressContainer>
-            );
-          })}
+                <Spacer.Vertical />
+                {isSelected && <CheckIcon testID={`active-account-checkmark-${account.id}`} />}
+              </Row>
+              {!isLast && <Divider />}
+            </Button.ScaleOnPressContainer>
+          );
+        })}
       </View>
 
       <Spacer.Vertical size="medium" />

--- a/packages/expo-dev-launcher/package.json
+++ b/packages/expo-dev-launcher/package.json
@@ -35,6 +35,7 @@
     "semver": "^7.3.5"
   },
   "devDependencies": {
+    "@babel/plugin-proposal-export-namespace-from": "^7.18.6",
     "@react-navigation/bottom-tabs": "^6.0.9",
     "@react-navigation/core": "5.15.1",
     "@react-navigation/native": "5.9.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -415,6 +415,14 @@
     "@babel/helper-plugin-utils" "^7.17.12"
     "@babel/plugin-syntax-export-namespace-from" "^7.8.3"
 
+"@babel/plugin-proposal-export-namespace-from@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.18.6.tgz#1016f0aa5ab383bbf8b3a85a2dcaedf6c8ee7491"
+  integrity sha512-zr/QcUlUo7GPo6+X1wC98NJADqmy5QTFWWhqeQWiki4XHafJtLl/YMGkmRB2szDD2IYJCCdBTd4ElwhId9T7Xw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.18.6"
+    "@babel/plugin-syntax-export-namespace-from" "^7.8.3"
+
 "@babel/plugin-proposal-json-strings@^7.17.12":
   version "7.17.12"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.17.12.tgz#f4642951792437233216d8c1af370bb0fbff4664"


### PR DESCRIPTION
# Why

Closes ENG-5279 

A user recently reported not seeing their org on this selector 

The selector doesn't do much at the moment other than sync with the CLI to determine a local packager IP but it makes sense to put these in there to have some kind of parity with the site 

# How

Updated the rendering logic to display organizations in this selector 
Updated the app header to account for an empty image and include a small label for the organization name
 

Sidenote: I had to add a babel plugin to get the bundler to work w/ the latest updates to reanimated

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Screenshots: 
<img width="412" alt="Screen Shot 2022-07-07 at 12 54 32 PM" src="https://user-images.githubusercontent.com/40680668/177863800-7fc06b2f-78f2-433e-b984-5e94e8498afb.png">
<img width="400" alt="Screen Shot 2022-07-07 at 1 14 20 PM" src="https://user-images.githubusercontent.com/40680668/177863805-563fe280-b0b6-40af-aee9-71b09fac87bf.png">



# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
