### PR TITLE
[core][ios] Patch legacy modules unavailable in `onCreate`

### DIFF
--- a/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.mm
+++ b/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.mm
@@ -202,8 +202,8 @@ RCT_EXPORT_MODULE(NativeUnimoduleProxy)
 - (void)setBridge:(RCTBridge *)bridge
 {
   ExpoBridgeModule* expoBridgeModule = [bridge moduleForClass:ExpoBridgeModule.class];
-  [expoBridgeModule legacyProxyDidSetBridgeWithLegacyModuleProxy:self
-                                            legacyModuleRegistry:_exModuleRegistry];
+  [expoBridgeModule legacyProxyDidSetBridgeWithLegacyModulesProxy:self
+                                             legacyModuleRegistry:_exModuleRegistry];
   _appContext = [expoBridgeModule appContext];
 
   if (!_bridge) {

--- a/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.mm
+++ b/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.mm
@@ -201,9 +201,10 @@ RCT_EXPORT_MODULE(NativeUnimoduleProxy)
 
 - (void)setBridge:(RCTBridge *)bridge
 {
-  _appContext = [(ExpoBridgeModule *)[bridge moduleForClass:ExpoBridgeModule.class] appContext];
-  [_appContext setLegacyModuleRegistry:_exModuleRegistry];
-  [_appContext setLegacyModulesProxy:self];
+  ExpoBridgeModule* expoBridgeModule = [bridge moduleForClass:ExpoBridgeModule.class];
+  [expoBridgeModule legacyProxyDidSetBridgeWithLegacyModuleProxy:self
+                                            legacyModuleRegistry:_exModuleRegistry];
+  _appContext = [expoBridgeModule appContext];
 
   if (!_bridge) {
     // The `setBridge` can be called during module setup or after. Registering more modules

--- a/packages/expo-modules-core/ios/Swift/AppContext.swift
+++ b/packages/expo-modules-core/ios/Swift/AppContext.swift
@@ -28,11 +28,9 @@ public final class AppContext: NSObject {
   /**
    The legacy module registry with modules written in the old-fashioned way.
    */
-  @objc
-  public weak var legacyModuleRegistry: EXModuleRegistry?
+  internal weak var legacyModuleRegistry: EXModuleRegistry?
 
-  @objc
-  public weak var legacyModulesProxy: LegacyNativeModulesProxy?
+  internal weak var legacyModulesProxy: LegacyNativeModulesProxy?
 
   /**
    React bridge of the context's app. Can be `nil` when the bridge

--- a/packages/expo-modules-core/ios/Swift/ExpoBridgeModule.swift
+++ b/packages/expo-modules-core/ios/Swift/ExpoBridgeModule.swift
@@ -54,10 +54,10 @@ public final class ExpoBridgeModule: NSObject, RCTBridgeModule {
    This should be called inside EXNativeModulesProxy.setBridge()
    */
   @objc
-  public func legacyProxyDidSetBridge(legacyModuleProxy: LegacyNativeModulesProxy,
+  public func legacyProxyDidSetBridge(legacyModulesProxy: LegacyNativeModulesProxy,
                                       legacyModuleRegistry: EXModuleRegistry) {
     appContext.legacyModuleRegistry = legacyModuleRegistry
-    appContext.legacyModulesProxy = legacyModuleProxy
+    appContext.legacyModulesProxy = legacyModulesProxy
     
     // we need to register all the modules after the legacy module registry is set
     // otherwise legacy modules (e.g. permissions) won't be available in OnCreate { }

--- a/packages/expo-modules-core/ios/Swift/ExpoBridgeModule.swift
+++ b/packages/expo-modules-core/ios/Swift/ExpoBridgeModule.swift
@@ -20,8 +20,7 @@ public final class ExpoBridgeModule: NSObject, RCTBridgeModule {
    architecture of Expo modules and the app itself.
    */
   override init() {
-    appContext = AppContext().useModulesProvider("ExpoModulesProvider")
-    appContext.moduleRegistry.register(moduleType: NativeModulesProxyModule.self)
+    appContext = AppContext()
     super.init()
 
     // Listen to React Native notifications posted just before the JS is executed.
@@ -49,6 +48,21 @@ public final class ExpoBridgeModule: NSObject, RCTBridgeModule {
     didSet {
       appContext.reactBridge = bridge
     }
+  }
+  
+  /**
+   This should be called inside EXNativeModulesProxy.setBridge()
+   */
+  @objc
+  public func legacyProxyDidSetBridge(legacyModuleProxy: LegacyNativeModulesProxy,
+                                      legacyModuleRegistry: EXModuleRegistry) {
+    appContext.legacyModuleRegistry = legacyModuleRegistry
+    appContext.legacyModulesProxy = legacyModuleProxy
+    
+    // we need to register all the modules after the legacy module registry is set
+    // otherwise legacy modules (e.g. permissions) won't be available in OnCreate { }
+    appContext.useModulesProvider("ExpoModulesProvider")
+    appContext.moduleRegistry.register(moduleType: NativeModulesProxyModule.self)
   }
 
   // MARK: - Notifications


### PR DESCRIPTION
# Why

Using legacy modules (e.g. permissions) in expo-module `OnCreate { ... }` is broken on iOS.

Looking at:
https://github.com/expo/expo/blob/017a717d6e53504db019327a27ceb1047f8f8805/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.mm#L202-L206

In `EXNativeModulesProxy setBridge` we're calling `[bridge moduleForClass:ExpoBridgeModule.class]`
to get access to `appContext`. This implies calling `ExpoBridgeModule.init()` because `ExpoBridgeModule` is first accessed (and thus initialized) at this time.
https://github.com/expo/expo/blob/017a717d6e53504db019327a27ceb1047f8f8805/packages/expo-modules-core/ios/Swift/ExpoBridgeModule.swift#L22-L24
The `AppContext` is created here and the modules are registered. And now, for each module, `ModuleHolder` calls `OnCreate` on it - everything is happening inside `ExpoBridgeModule.init()`.
Then call stack comes back to `EXNativeModulesProxy setBridge` where it all started. One line below we have `[_appContext setLegacyModuleRegistry...`, but it's already too late.

# How

Deferred registering sweet modules after `appContext.legacyModuleRegistry` is set.

# Test Plan

NCL - ImagePicker now registers permission requesters successfully in `OnCreate`

<!-- disable:changelog-checks -->
