### PR TITLE
[image-picker][Android] Add support for selecting multiple media files

### DIFF
--- a/apps/native-component-list/src/screens/ImagePicker/ImagePickerScreen.tsx
+++ b/apps/native-component-list/src/screens/ImagePicker/ImagePickerScreen.tsx
@@ -122,7 +122,6 @@ const LAUNCH_PICKER_PARAMETERS: FunctionParameter[] = [
         name: 'allowsMultipleSelection',
         type: 'boolean',
         initial: false,
-        platforms: ['web', 'ios'],
       },
       {
         name: 'selectionLimit',

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### 🎉 New features
 
+- On Android added support for selecting multiple images/videos. ([#18161](https://github.com/expo/expo/pull/18161) by [@bbarthec](https://github.com/bbarthec))
 - On iOS 14+ added support for selecting multiple images/videos. ([#18102](https://github.com/expo/expo/pull/18102) by [@barthap](https://github.com/barthap))
 
 ### 🐛 Bug fixes

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalContracts::class)
-
 package expo.modules.imagepicker
 
 import android.Manifest
@@ -24,7 +22,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
-import kotlin.contracts.ExperimentalContracts
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
@@ -145,7 +142,7 @@ class ImagePickerModule : Module() {
    */
   private suspend fun launchPicker(
     pickerLauncher: suspend () -> ImagePickerContractResult,
-  ): Pair<MediaType, Uri> = withContext(Dispatchers.Main) {
+  ): List<Pair<MediaType, Uri>> = withContext(Dispatchers.Main) {
     when (val pickingResult = pickerLauncher()) {
       is ImagePickerContractResult.Success -> pickingResult.data
       is ImagePickerContractResult.Cancelled -> throw OperationCanceledException()
@@ -200,6 +197,6 @@ internal enum class PickingSource {
  * Simple data structure to hold the data that has to be preserved after the Activity is destroyed.
  */
 internal data class PendingMediaPickingResult(
-  val data: Pair<MediaType, Uri>,
+  val data: List<Pair<MediaType, Uri>>,
   val options: ImagePickerOptions
 )

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerOptions.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerOptions.kt
@@ -15,6 +15,9 @@ internal class ImagePickerOptions : Record, Serializable {
   var allowsEditing: Boolean = false
 
   @Field
+  var allowsMultipleSelection: Boolean = false
+
+  @Field
   @FloatRange(from = 0.0, to = 1.0)
   var quality: Double = 0.2
 

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerResponse.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerResponse.kt
@@ -9,32 +9,39 @@ internal class ImagePickerCancelledResponse : Record {
   val cancelled: Boolean = true
 }
 
-internal sealed class ImagePickerMediaResponse(
-  @Field val type: MediaType,
-  @Field val uri: String,
-  @Field val width: Int,
-  @Field val height: Int,
-) : Record {
+internal sealed class ImagePickerResponse : Record {
   @Field
   val cancelled: Boolean = false
 
-  class Image(
-    uri: String,
-    width: Int,
-    height: Int,
+  sealed class Single(
+    @Field val type: MediaType,
+    @Field val uri: String,
+    @Field val width: Int,
+    @Field val height: Int,
+  ) : ImagePickerResponse() {
+    class Image(
+      uri: String,
+      width: Int,
+      height: Int,
 
-    @Field val base64: String?,
-    @Field val exif: Bundle?
-  ) : ImagePickerMediaResponse(MediaType.IMAGE, uri, width, height)
+      @Field val base64: String?,
+      @Field val exif: Bundle?
+    ) : Single(MediaType.IMAGE, uri, width, height)
 
-  class Video(
-    uri: String,
-    width: Int,
-    height: Int,
+    class Video(
+      uri: String,
+      width: Int,
+      height: Int,
 
-    @Field val duration: Int,
-    @Field val rotation: Int
-  ) : ImagePickerMediaResponse(MediaType.VIDEO, uri, width, height)
+      @Field val duration: Int,
+      @Field val rotation: Int
+    ) : Single(MediaType.VIDEO, uri, width, height)
+  }
+
+  class Multiple(
+    @Field
+    val selected: List<Single>
+  ) : ImagePickerResponse()
 }
 
 enum class MediaType(val value: String) {

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerUtils.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerUtils.kt
@@ -1,5 +1,6 @@
 package expo.modules.imagepicker
 
+import android.content.ClipData
 import android.content.ContentResolver
 import android.content.Context
 import android.graphics.Bitmap
@@ -99,6 +100,21 @@ internal fun String.toBitmapCompressFormat(): Bitmap.CompressFormat = when {
 internal fun MediaMetadataRetriever.extractInt(key: Int): Int {
   return this.extractMetadata(key)?.toInt() ?: throw FailedToExtractVideoMetadataException()
 }
+
+/**
+ * [Iterable] implementation for [ClipData] items
+ */
+val ClipData.items: Iterable<ClipData.Item>
+  get() = object : Iterable<ClipData.Item> {
+    override fun iterator() = object : Iterator<ClipData.Item> {
+      var index = 0
+      val count = itemCount
+
+      override fun hasNext(): Boolean = index < count
+
+      override fun next(): ClipData.Item = getItemAt(index++)
+    }
+  }
 
 /**
  * Copy the media file from `sourceUri` to `destinationUri`.

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerUtils.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerUtils.kt
@@ -3,6 +3,7 @@ package expo.modules.imagepicker
 import android.content.ClipData
 import android.content.ContentResolver
 import android.content.Context
+import android.content.Intent
 import android.graphics.Bitmap
 import android.media.MediaMetadataRetriever
 import android.net.Uri
@@ -115,6 +116,27 @@ val ClipData.items: Iterable<ClipData.Item>
       override fun next(): ClipData.Item = getItemAt(index++)
     }
   }
+
+/**
+ * Gets all data that is associated with this [Intent].
+ * Original data order is preserved.
+ *
+ * Adapted from [androidx.activity.result.contract.ActivityResultContracts.GetMultipleContents.getClipDataUris]
+ */
+internal fun Intent.getAllDataUris(): List<Uri> {
+  // Use a LinkedHashSet to maintain any ordering that may be present in the ClipData
+  val resultSet = LinkedHashSet<Uri>()
+
+  data
+    ?.let { resultSet.add(it) }
+
+  clipData
+    ?.items
+    ?.map { it.uri }
+    ?.let { resultSet.addAll(it) }
+
+  return resultSet.toList()
+}
 
 /**
  * Copy the media file from `sourceUri` to `destinationUri`.

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/CameraContract.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/CameraContract.kt
@@ -37,7 +37,7 @@ internal class CameraContract(
       val contentResolver = requireNotNull(appContextProvider.appContext.reactContext) { "React Application Context is null. " }.contentResolver
       val uri = input.uri
       val type = uri.toMediaType(contentResolver)
-      ImagePickerContractResult.Success(type to uri)
+      ImagePickerContractResult.Success(listOf(type to uri))
     }
 }
 

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/ContractsUtils.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/ContractsUtils.kt
@@ -14,5 +14,5 @@ internal typealias ImagePickerContract = ActivityResultContract<Any?, ImagePicke
  */
 internal sealed class ImagePickerContractResult private constructor() {
   class Cancelled : ImagePickerContractResult()
-  class Success(val data: Pair<MediaType, Uri>) : ImagePickerContractResult()
+  class Success(val data: List<Pair<MediaType, Uri>>) : ImagePickerContractResult()
 }

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/CropImageContract.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/CropImageContract.kt
@@ -70,6 +70,6 @@ internal class CropImageContract(
     val targetUri = requireNotNull(result.uri)
     val contentResolver = requireNotNull(appContextProvider.appContext.reactContext) { "React Application Context is null" }.contentResolver
     runBlocking { copyExifData(sourceUri, targetUri.toFile(), contentResolver) }
-    return ImagePickerContractResult.Success(MediaType.IMAGE to targetUri)
+    return ImagePickerContractResult.Success(listOf(MediaType.IMAGE to targetUri))
   }
 }

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/ImageLibraryContract.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/ImageLibraryContract.kt
@@ -14,7 +14,8 @@ import java.io.Serializable
  * An [androidx.activity.result.contract.ActivityResultContract] to prompt the user to pick single or multiple image(s) or/and video(s),
  * receiving a `content://` [Uri] for each piece of content.
  *
- * @see [androidx.activity.result.contract.ActivityResultContracts.GetContent]
+ * @see [androidx.activity.result.contract.ActivityResultContracts.GetContent],
+ * @see [androidx.activity.result.contract.ActivityResultContracts.GetMultipleContents]
  */
 internal class ImageLibraryContract(
   private val appContextProvider: AppContextProvider,
@@ -23,17 +24,48 @@ internal class ImageLibraryContract(
     Intent(Intent.ACTION_GET_CONTENT)
       .addCategory(Intent.CATEGORY_OPENABLE)
       .setType(input.options.mediaTypes.toMimeType())
+      .apply {
+        if (input.options.allowsMultipleSelection) {
+          this.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
+        }
+      }
 
   override fun parseResult(input: ImageLibraryContractOptions, resultCode: Int, intent: Intent?) =
     if (resultCode == Activity.RESULT_CANCELED) {
       ImagePickerContractResult.Cancelled()
+    } else if (input.options.allowsMultipleSelection) {
+      val uris = requireNotNull(intent).getClipDataUris()
+      val contentResolver = requireNotNull(appContextProvider.appContext.reactContext) { "React Application Context is null. "}.contentResolver
+      ImagePickerContractResult.Success(uris.map { uri -> uri.toMediaType(contentResolver) to uri })
     } else {
       val uri = requireNotNull(requireNotNull(intent).data)
       val contentResolver = requireNotNull(appContextProvider.appContext.reactContext) { "React Application Context is null. " }.contentResolver
       val type = uri.toMediaType(contentResolver)
-
-      ImagePickerContractResult.Success(type to uri)
+      ImagePickerContractResult.Success(listOf(type to uri))
     }
+}
+
+/**
+ * Copied from [androidx.activity.result.contract.ActivityResultContracts.GetMultipleContents.getClipDataUris]
+ */
+internal fun Intent.getClipDataUris(): List<Uri> {
+  // Use a LinkedHashSet to maintain any ordering that may be present in the ClipData
+  val resultSet = LinkedHashSet<Uri>()
+  data?.let { data ->
+    resultSet.add(data)
+  }
+  val clipData = clipData
+  if (clipData == null && resultSet.isEmpty()) {
+    return emptyList()
+  } else if (clipData != null) {
+    for (i in 0 until clipData.itemCount) {
+      val uri = clipData.getItemAt(i).uri
+      if (uri != null) {
+        resultSet.add(uri)
+      }
+    }
+  }
+  return ArrayList(resultSet)
 }
 
 internal data class ImageLibraryContractOptions(


### PR DESCRIPTION
# Why

Part of ENG-2795,
Part of ENG-5617
Part of module audit
Similar to #18102

# How

Used [Intent.EXTRA_ALLOW_MULTIPLE](https://developer.android.com/reference/android/content/Intent#EXTRA_ALLOW_MULTIPLE) flag when launching `ImageLibrary`-based picker.

# Warnings

- When `mediaTypes = 'all'` and `allowsMultipleSelection = true` then all files available on the device are presented - that needs to be investigated further.

# Test Plan

- [x] `ncl`

https://user-images.githubusercontent.com/16623003/177982283-7b5be6b2-fbd4-4689-a554-171fc60baf31.mp4


