### PR TITLE
[docs] APISection: move deprecations and platforms to the top of boxes

### DIFF
--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -54,7 +54,7 @@ exports[`APISection expo-apple-authentication 1`] = `
     </div>
   </h2>
   <div
-    class="css-16aqr8r-STYLES_APIBOX"
+    class="css-1nf98yv-STYLES_APIBOX"
   >
     <h3
       class="css-1fe5f89-h3-h3-STYLES_H3"
@@ -340,7 +340,7 @@ for more details.
     </div>
     <div>
       <div
-        class="css-m3vewu-STYLES_APIBOX-STYLES_APIBOX_NESTED-renderProp"
+        class="css-1ngyf63-STYLES_APIBOX-STYLES_APIBOX_NESTED-renderProp"
       >
         <h4
           class="  css-838f5l-h4-h4-STYLES_H4"
@@ -427,7 +427,7 @@ for more details.
         </p>
       </div>
       <div
-        class="css-m3vewu-STYLES_APIBOX-STYLES_APIBOX_NESTED-renderProp"
+        class="css-1ngyf63-STYLES_APIBOX-STYLES_APIBOX_NESTED-renderProp"
       >
         <h4
           class="  css-838f5l-h4-h4-STYLES_H4"
@@ -514,7 +514,7 @@ for more details.
         </p>
       </div>
       <div
-        class="css-m3vewu-STYLES_APIBOX-STYLES_APIBOX_NESTED-renderProp"
+        class="css-1ngyf63-STYLES_APIBOX-STYLES_APIBOX_NESTED-renderProp"
       >
         <h4
           class="  css-838f5l-h4-h4-STYLES_H4"
@@ -608,7 +608,7 @@ for more details.
         </p>
       </div>
       <div
-        class="css-m3vewu-STYLES_APIBOX-STYLES_APIBOX_NESTED-renderProp"
+        class="css-1ngyf63-STYLES_APIBOX-STYLES_APIBOX_NESTED-renderProp"
       >
         <h4
           class="  css-838f5l-h4-h4-STYLES_H4"
@@ -739,7 +739,7 @@ properties.
         </p>
       </div>
       <div
-        class="css-m3vewu-STYLES_APIBOX-STYLES_APIBOX_NESTED-renderProp"
+        class="css-1ngyf63-STYLES_APIBOX-STYLES_APIBOX_NESTED-renderProp"
       >
         <h4
           class="  css-838f5l-h4-h4-STYLES_H4"
@@ -960,7 +960,7 @@ in here.
     </div>
   </h2>
   <div
-    class="css-xt57ow-STYLES_APIBOX-renderMethod"
+    class="css-1k51bz3-STYLES_APIBOX-renderMethod"
   >
     <h3
       class="css-1fe5f89-h3-h3-STYLES_H3"
@@ -1262,7 +1262,7 @@ value depending on the state of the credential.
     </p>
   </div>
   <div
-    class="css-xt57ow-STYLES_APIBOX-renderMethod"
+    class="css-1k51bz3-STYLES_APIBOX-renderMethod"
   >
     <h3
       class="css-1fe5f89-h3-h3-STYLES_H3"
@@ -1444,7 +1444,7 @@ value depending on the state of the credential.
     </p>
   </div>
   <div
-    class="css-xt57ow-STYLES_APIBOX-renderMethod"
+    class="css-1k51bz3-STYLES_APIBOX-renderMethod"
   >
     <h3
       class="css-1fe5f89-h3-h3-STYLES_H3"
@@ -1717,7 +1717,7 @@ refresh operation.
     </p>
   </div>
   <div
-    class="css-xt57ow-STYLES_APIBOX-renderMethod"
+    class="css-1k51bz3-STYLES_APIBOX-renderMethod"
   >
     <h3
       class="css-1fe5f89-h3-h3-STYLES_H3"
@@ -2034,7 +2034,7 @@ sign-in operation.
     </p>
   </div>
   <div
-    class="css-xt57ow-STYLES_APIBOX-renderMethod"
+    class="css-1k51bz3-STYLES_APIBOX-renderMethod"
   >
     <h3
       class="css-1fe5f89-h3-h3-STYLES_H3"
@@ -2388,7 +2388,7 @@ sign-out operation.
     </div>
   </h2>
   <div
-    class="css-xt57ow-STYLES_APIBOX-renderMethod"
+    class="css-1k51bz3-STYLES_APIBOX-renderMethod"
   >
     <h3
       class="css-1fe5f89-h3-h3-STYLES_H3"
@@ -2653,7 +2653,7 @@ sign-out operation.
     </div>
   </h2>
   <div
-    class="css-16aqr8r-STYLES_APIBOX"
+    class="css-1nf98yv-STYLES_APIBOX"
   >
     <h3
       class="css-1fe5f89-h3-h3-STYLES_H3"
@@ -3136,7 +3136,7 @@ developers.
     </div>
   </div>
   <div
-    class="css-16aqr8r-STYLES_APIBOX"
+    class="css-1nf98yv-STYLES_APIBOX"
   >
     <h3
       class="css-1fe5f89-h3-h3-STYLES_H3"
@@ -3440,7 +3440,7 @@ may be
     </div>
   </div>
   <div
-    class="css-16aqr8r-STYLES_APIBOX"
+    class="css-1nf98yv-STYLES_APIBOX"
   >
     <h3
       class="css-1fe5f89-h3-h3-STYLES_H3"
@@ -3733,7 +3733,7 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="css-16aqr8r-STYLES_APIBOX"
+    class="css-1nf98yv-STYLES_APIBOX"
   >
     <h3
       class="css-1fe5f89-h3-h3-STYLES_H3"
@@ -4043,7 +4043,7 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="css-16aqr8r-STYLES_APIBOX"
+    class="css-1nf98yv-STYLES_APIBOX"
   >
     <h3
       class="css-1fe5f89-h3-h3-STYLES_H3"
@@ -4273,7 +4273,7 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="css-16aqr8r-STYLES_APIBOX"
+    class="css-1nf98yv-STYLES_APIBOX"
   >
     <h3
       class="css-1fe5f89-h3-h3-STYLES_H3"
@@ -4449,7 +4449,7 @@ OAuth 2.0 protocol
     </div>
   </h2>
   <div
-    class="css-tbnef7-STYLES_APIBOX-enumContentStyles-renderEnum"
+    class="css-lfq414-STYLES_APIBOX-enumContentStyles-renderEnum"
   >
     <h3
       class="css-1fe5f89-h3-h3-STYLES_H3"
@@ -4524,7 +4524,7 @@ OAuth 2.0 protocol
       .
     </p>
     <div
-      class="css-1sq1qpv-STYLES_APIBOX-enumContainerStyle-renderEnum"
+      class="css-k95b90-STYLES_APIBOX-enumContainerStyle-renderEnum"
     >
       <div
         class="css-69zzym-enumValueNameStyle"
@@ -4602,7 +4602,7 @@ OAuth 2.0 protocol
       </p>
     </div>
     <div
-      class="css-1sq1qpv-STYLES_APIBOX-enumContainerStyle-renderEnum"
+      class="css-k95b90-STYLES_APIBOX-enumContainerStyle-renderEnum"
     >
       <div
         class="css-69zzym-enumValueNameStyle"
@@ -4680,7 +4680,7 @@ OAuth 2.0 protocol
       </p>
     </div>
     <div
-      class="css-1sq1qpv-STYLES_APIBOX-enumContainerStyle-renderEnum"
+      class="css-k95b90-STYLES_APIBOX-enumContainerStyle-renderEnum"
     >
       <div
         class="css-69zzym-enumValueNameStyle"
@@ -4759,7 +4759,7 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="css-tbnef7-STYLES_APIBOX-enumContentStyles-renderEnum"
+    class="css-lfq414-STYLES_APIBOX-enumContentStyles-renderEnum"
   >
     <h3
       class="css-1fe5f89-h3-h3-STYLES_H3"
@@ -4834,7 +4834,7 @@ OAuth 2.0 protocol
       .
     </p>
     <div
-      class="css-1sq1qpv-STYLES_APIBOX-enumContainerStyle-renderEnum"
+      class="css-k95b90-STYLES_APIBOX-enumContainerStyle-renderEnum"
     >
       <div
         class="css-69zzym-enumValueNameStyle"
@@ -4912,7 +4912,7 @@ OAuth 2.0 protocol
       </p>
     </div>
     <div
-      class="css-1sq1qpv-STYLES_APIBOX-enumContainerStyle-renderEnum"
+      class="css-k95b90-STYLES_APIBOX-enumContainerStyle-renderEnum"
     >
       <div
         class="css-69zzym-enumValueNameStyle"
@@ -4990,7 +4990,7 @@ OAuth 2.0 protocol
       </p>
     </div>
     <div
-      class="css-1sq1qpv-STYLES_APIBOX-enumContainerStyle-renderEnum"
+      class="css-k95b90-STYLES_APIBOX-enumContainerStyle-renderEnum"
     >
       <strong
         class="css-m2r9l3-paragraph-STYLES_BOLD_PARAGRAPH"
@@ -4999,7 +4999,7 @@ OAuth 2.0 protocol
          
       </strong>
       <div
-        class="css-1vg2gvk-platformTagStyle-platformTagFirstStyle-iosPlatformTagStyle-PlatformTags"
+        class="css-u0js3y-platformTagStyle-platformTagFirstStyle-iosPlatformTagStyle-PlatformTags"
       >
         <svg
           color="var(--expo-theme-palette-blue-900)"
@@ -5102,7 +5102,7 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="css-tbnef7-STYLES_APIBOX-enumContentStyles-renderEnum"
+    class="css-lfq414-STYLES_APIBOX-enumContentStyles-renderEnum"
   >
     <h3
       class="css-1fe5f89-h3-h3-STYLES_H3"
@@ -5223,7 +5223,7 @@ for more details.
       </div>
     </blockquote>
     <div
-      class="css-1sq1qpv-STYLES_APIBOX-enumContainerStyle-renderEnum"
+      class="css-k95b90-STYLES_APIBOX-enumContainerStyle-renderEnum"
     >
       <div
         class="css-69zzym-enumValueNameStyle"
@@ -5295,7 +5295,7 @@ for more details.
       </code>
     </div>
     <div
-      class="css-1sq1qpv-STYLES_APIBOX-enumContainerStyle-renderEnum"
+      class="css-k95b90-STYLES_APIBOX-enumContainerStyle-renderEnum"
     >
       <div
         class="css-69zzym-enumValueNameStyle"
@@ -5367,7 +5367,7 @@ for more details.
       </code>
     </div>
     <div
-      class="css-1sq1qpv-STYLES_APIBOX-enumContainerStyle-renderEnum"
+      class="css-k95b90-STYLES_APIBOX-enumContainerStyle-renderEnum"
     >
       <div
         class="css-69zzym-enumValueNameStyle"
@@ -5439,7 +5439,7 @@ for more details.
       </code>
     </div>
     <div
-      class="css-1sq1qpv-STYLES_APIBOX-enumContainerStyle-renderEnum"
+      class="css-k95b90-STYLES_APIBOX-enumContainerStyle-renderEnum"
     >
       <div
         class="css-69zzym-enumValueNameStyle"
@@ -5512,7 +5512,7 @@ for more details.
     </div>
   </div>
   <div
-    class="css-tbnef7-STYLES_APIBOX-enumContentStyles-renderEnum"
+    class="css-lfq414-STYLES_APIBOX-enumContentStyles-renderEnum"
   >
     <h3
       class="css-1fe5f89-h3-h3-STYLES_H3"
@@ -5570,7 +5570,7 @@ for more details.
       </div>
     </h3>
     <div
-      class="css-1sq1qpv-STYLES_APIBOX-enumContainerStyle-renderEnum"
+      class="css-k95b90-STYLES_APIBOX-enumContainerStyle-renderEnum"
     >
       <div
         class="css-69zzym-enumValueNameStyle"
@@ -5648,7 +5648,7 @@ for more details.
       </p>
     </div>
     <div
-      class="css-1sq1qpv-STYLES_APIBOX-enumContainerStyle-renderEnum"
+      class="css-k95b90-STYLES_APIBOX-enumContainerStyle-renderEnum"
     >
       <div
         class="css-69zzym-enumValueNameStyle"
@@ -5720,7 +5720,7 @@ for more details.
       </code>
     </div>
     <div
-      class="css-1sq1qpv-STYLES_APIBOX-enumContainerStyle-renderEnum"
+      class="css-k95b90-STYLES_APIBOX-enumContainerStyle-renderEnum"
     >
       <div
         class="css-69zzym-enumValueNameStyle"
@@ -5792,7 +5792,7 @@ for more details.
       </code>
     </div>
     <div
-      class="css-1sq1qpv-STYLES_APIBOX-enumContainerStyle-renderEnum"
+      class="css-k95b90-STYLES_APIBOX-enumContainerStyle-renderEnum"
     >
       <div
         class="css-69zzym-enumValueNameStyle"
@@ -5865,7 +5865,7 @@ for more details.
     </div>
   </div>
   <div
-    class="css-tbnef7-STYLES_APIBOX-enumContentStyles-renderEnum"
+    class="css-lfq414-STYLES_APIBOX-enumContentStyles-renderEnum"
   >
     <h3
       class="css-1fe5f89-h3-h3-STYLES_H3"
@@ -6021,7 +6021,7 @@ for more details.
       </div>
     </blockquote>
     <div
-      class="css-1sq1qpv-STYLES_APIBOX-enumContainerStyle-renderEnum"
+      class="css-k95b90-STYLES_APIBOX-enumContainerStyle-renderEnum"
     >
       <div
         class="css-69zzym-enumValueNameStyle"
@@ -6093,7 +6093,7 @@ for more details.
       </code>
     </div>
     <div
-      class="css-1sq1qpv-STYLES_APIBOX-enumContainerStyle-renderEnum"
+      class="css-k95b90-STYLES_APIBOX-enumContainerStyle-renderEnum"
     >
       <div
         class="css-69zzym-enumValueNameStyle"
@@ -6166,7 +6166,7 @@ for more details.
     </div>
   </div>
   <div
-    class="css-tbnef7-STYLES_APIBOX-enumContentStyles-renderEnum"
+    class="css-lfq414-STYLES_APIBOX-enumContentStyles-renderEnum"
   >
     <h3
       class="css-1fe5f89-h3-h3-STYLES_H3"
@@ -6276,7 +6276,7 @@ for more details.
       </div>
     </blockquote>
     <div
-      class="css-1sq1qpv-STYLES_APIBOX-enumContainerStyle-renderEnum"
+      class="css-k95b90-STYLES_APIBOX-enumContainerStyle-renderEnum"
     >
       <div
         class="css-69zzym-enumValueNameStyle"
@@ -6354,7 +6354,7 @@ for more details.
       </p>
     </div>
     <div
-      class="css-1sq1qpv-STYLES_APIBOX-enumContainerStyle-renderEnum"
+      class="css-k95b90-STYLES_APIBOX-enumContainerStyle-renderEnum"
     >
       <div
         class="css-69zzym-enumValueNameStyle"
@@ -6432,7 +6432,7 @@ for more details.
       </p>
     </div>
     <div
-      class="css-1sq1qpv-STYLES_APIBOX-enumContainerStyle-renderEnum"
+      class="css-k95b90-STYLES_APIBOX-enumContainerStyle-renderEnum"
     >
       <div
         class="css-69zzym-enumValueNameStyle"
@@ -6567,7 +6567,7 @@ exports[`APISection expo-barcode-scanner 1`] = `
     </div>
   </h2>
   <div
-    class="css-16aqr8r-STYLES_APIBOX"
+    class="css-1nf98yv-STYLES_APIBOX"
   >
     <h3
       class="css-1fe5f89-h3-h3-STYLES_H3"
@@ -6710,7 +6710,7 @@ exports[`APISection expo-barcode-scanner 1`] = `
     </div>
     <div>
       <div
-        class="css-m3vewu-STYLES_APIBOX-STYLES_APIBOX_NESTED-renderProp"
+        class="css-1ngyf63-STYLES_APIBOX-STYLES_APIBOX_NESTED-renderProp"
       >
         <h4
           class="  css-838f5l-h4-h4-STYLES_H4"
@@ -6831,7 +6831,7 @@ minimize battery usage.
         </p>
       </div>
       <div
-        class="css-m3vewu-STYLES_APIBOX-STYLES_APIBOX_NESTED-renderProp"
+        class="css-1ngyf63-STYLES_APIBOX-STYLES_APIBOX_NESTED-renderProp"
       >
         <h4
           class="  css-838f5l-h4-h4-STYLES_H4"
@@ -6986,7 +6986,7 @@ data has been retrieved.
         </blockquote>
       </div>
       <div
-        class="css-m3vewu-STYLES_APIBOX-STYLES_APIBOX_NESTED-renderProp"
+        class="css-1ngyf63-STYLES_APIBOX-STYLES_APIBOX_NESTED-renderProp"
       >
         <h4
           class="  css-838f5l-h4-h4-STYLES_H4"
@@ -7246,7 +7246,7 @@ Same as
     </div>
   </h2>
   <div
-    class="css-xt57ow-STYLES_APIBOX-renderMethod"
+    class="css-1k51bz3-STYLES_APIBOX-renderMethod"
   >
     <h3
       class="css-1fe5f89-h3-h3-STYLES_H3"
@@ -7570,7 +7570,7 @@ This can be used to quickly create specific permission hooks in every module.
     </div>
   </h2>
   <div
-    class="css-xt57ow-STYLES_APIBOX-renderMethod"
+    class="css-1k51bz3-STYLES_APIBOX-renderMethod"
   >
     <h3
       class="css-1fe5f89-h3-h3-STYLES_H3"
@@ -7757,7 +7757,7 @@ This can be used to quickly create specific permission hooks in every module.
     </p>
   </div>
   <div
-    class="css-xt57ow-STYLES_APIBOX-renderMethod"
+    class="css-1k51bz3-STYLES_APIBOX-renderMethod"
   >
     <h3
       class="css-1fe5f89-h3-h3-STYLES_H3"
@@ -7962,7 +7962,7 @@ This can be used to quickly create specific permission hooks in every module.
     </p>
   </div>
   <div
-    class="css-xt57ow-STYLES_APIBOX-renderMethod"
+    class="css-1k51bz3-STYLES_APIBOX-renderMethod"
   >
     <h3
       class="css-1fe5f89-h3-h3-STYLES_H3"
@@ -8331,7 +8331,7 @@ code.
     </div>
   </h2>
   <div
-    class="css-16aqr8r-STYLES_APIBOX"
+    class="css-1nf98yv-STYLES_APIBOX"
   >
     <h3
       class="css-1fe5f89-h3-h3-STYLES_H3"
@@ -8492,7 +8492,7 @@ code.
     </div>
   </div>
   <div
-    class="css-16aqr8r-STYLES_APIBOX"
+    class="css-1nf98yv-STYLES_APIBOX"
   >
     <h3
       class="css-1fe5f89-h3-h3-STYLES_H3"
@@ -8634,7 +8634,7 @@ code.
     </div>
   </div>
   <div
-    class="css-16aqr8r-STYLES_APIBOX"
+    class="css-1nf98yv-STYLES_APIBOX"
   >
     <h3
       class="css-1fe5f89-h3-h3-STYLES_H3"
@@ -8759,7 +8759,7 @@ code.
     </div>
   </div>
   <div
-    class="css-16aqr8r-STYLES_APIBOX"
+    class="css-1nf98yv-STYLES_APIBOX"
   >
     <h3
       class="css-1fe5f89-h3-h3-STYLES_H3"
@@ -8929,7 +8929,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
     </div>
   </div>
   <div
-    class="css-16aqr8r-STYLES_APIBOX"
+    class="css-1nf98yv-STYLES_APIBOX"
   >
     <h3
       class="css-1fe5f89-h3-h3-STYLES_H3"
@@ -9056,7 +9056,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
     </div>
   </div>
   <div
-    class="css-16aqr8r-STYLES_APIBOX"
+    class="css-1nf98yv-STYLES_APIBOX"
   >
     <h3
       class="css-1fe5f89-h3-h3-STYLES_H3"
@@ -9360,7 +9360,7 @@ For some types, they will represent the area used by the scanner.
     </div>
   </div>
   <div
-    class="css-16aqr8r-STYLES_APIBOX"
+    class="css-1nf98yv-STYLES_APIBOX"
   >
     <h3
       class="css-1fe5f89-h3-h3-STYLES_H3"
@@ -9511,7 +9511,7 @@ For some types, they will represent the area used by the scanner.
     </div>
   </div>
   <div
-    class="css-16aqr8r-STYLES_APIBOX"
+    class="css-1nf98yv-STYLES_APIBOX"
   >
     <h3
       class="css-1fe5f89-h3-h3-STYLES_H3"
@@ -9644,7 +9644,7 @@ For some types, they will represent the area used by the scanner.
     </div>
   </h2>
   <div
-    class="css-16aqr8r-STYLES_APIBOX"
+    class="css-1nf98yv-STYLES_APIBOX"
   >
     <h3
       class="css-1fe5f89-h3-h3-STYLES_H3"
@@ -9990,7 +9990,7 @@ in order to enable/disable the permission.
     </div>
   </h2>
   <div
-    class="css-tbnef7-STYLES_APIBOX-enumContentStyles-renderEnum"
+    class="css-lfq414-STYLES_APIBOX-enumContentStyles-renderEnum"
   >
     <h3
       class="css-1fe5f89-h3-h3-STYLES_H3"
@@ -10048,7 +10048,7 @@ in order to enable/disable the permission.
       </div>
     </h3>
     <div
-      class="css-1sq1qpv-STYLES_APIBOX-enumContainerStyle-renderEnum"
+      class="css-k95b90-STYLES_APIBOX-enumContainerStyle-renderEnum"
     >
       <div
         class="css-69zzym-enumValueNameStyle"
@@ -10126,7 +10126,7 @@ in order to enable/disable the permission.
       </p>
     </div>
     <div
-      class="css-1sq1qpv-STYLES_APIBOX-enumContainerStyle-renderEnum"
+      class="css-k95b90-STYLES_APIBOX-enumContainerStyle-renderEnum"
     >
       <div
         class="css-69zzym-enumValueNameStyle"
@@ -10204,7 +10204,7 @@ in order to enable/disable the permission.
       </p>
     </div>
     <div
-      class="css-1sq1qpv-STYLES_APIBOX-enumContainerStyle-renderEnum"
+      class="css-k95b90-STYLES_APIBOX-enumContainerStyle-renderEnum"
     >
       <div
         class="css-69zzym-enumValueNameStyle"
@@ -10339,7 +10339,7 @@ exports[`APISection expo-pedometer 1`] = `
     </div>
   </h2>
   <div
-    class="css-xt57ow-STYLES_APIBOX-renderMethod"
+    class="css-1k51bz3-STYLES_APIBOX-renderMethod"
   >
     <h3
       class="css-1fe5f89-h3-h3-STYLES_H3"
@@ -10502,7 +10502,7 @@ exports[`APISection expo-pedometer 1`] = `
     </ul>
   </div>
   <div
-    class="css-xt57ow-STYLES_APIBOX-renderMethod"
+    class="css-1k51bz3-STYLES_APIBOX-renderMethod"
   >
     <h3
       class="css-1fe5f89-h3-h3-STYLES_H3"
@@ -10844,7 +10844,7 @@ a start date that is more than seven days in the past returns only the available
     </blockquote>
   </div>
   <div
-    class="css-xt57ow-STYLES_APIBOX-renderMethod"
+    class="css-1k51bz3-STYLES_APIBOX-renderMethod"
   >
     <h3
       class="css-1fe5f89-h3-h3-STYLES_H3"
@@ -11021,7 +11021,7 @@ available on this device.
     </p>
   </div>
   <div
-    class="css-xt57ow-STYLES_APIBOX-renderMethod"
+    class="css-1k51bz3-STYLES_APIBOX-renderMethod"
   >
     <h3
       class="css-1fe5f89-h3-h3-STYLES_H3"
@@ -11184,7 +11184,7 @@ available on this device.
     </ul>
   </div>
   <div
-    class="css-xt57ow-STYLES_APIBOX-renderMethod"
+    class="css-1k51bz3-STYLES_APIBOX-renderMethod"
   >
     <h3
       class="css-1fe5f89-h3-h3-STYLES_H3"
@@ -11496,7 +11496,7 @@ provided with a single argument that is
     </div>
   </h2>
   <div
-    class="css-16aqr8r-STYLES_APIBOX"
+    class="css-1nf98yv-STYLES_APIBOX"
   >
     <h3
       class="css-1fe5f89-h3-h3-STYLES_H3"
@@ -11618,7 +11618,7 @@ provided with a single argument that is
     </div>
   </div>
   <div
-    class="css-16aqr8r-STYLES_APIBOX"
+    class="css-1nf98yv-STYLES_APIBOX"
   >
     <h3
       class="css-1fe5f89-h3-h3-STYLES_H3"
@@ -11745,7 +11745,7 @@ provided with a single argument that is
     </div>
   </div>
   <div
-    class="css-16aqr8r-STYLES_APIBOX"
+    class="css-1nf98yv-STYLES_APIBOX"
   >
     <h3
       class="css-1fe5f89-h3-h3-STYLES_H3"
@@ -11827,7 +11827,7 @@ provided with a single argument that is
     </p>
   </div>
   <div
-    class="css-16aqr8r-STYLES_APIBOX"
+    class="css-1nf98yv-STYLES_APIBOX"
   >
     <h3
       class="css-1fe5f89-h3-h3-STYLES_H3"
@@ -12003,7 +12003,7 @@ provided with a single argument that is
     </div>
   </h2>
   <div
-    class="css-16aqr8r-STYLES_APIBOX"
+    class="css-1nf98yv-STYLES_APIBOX"
   >
     <h3
       class="css-1fe5f89-h3-h3-STYLES_H3"
@@ -12321,7 +12321,7 @@ provided with a single argument that is
     </div>
   </h2>
   <div
-    class="css-tbnef7-STYLES_APIBOX-enumContentStyles-renderEnum"
+    class="css-lfq414-STYLES_APIBOX-enumContentStyles-renderEnum"
   >
     <h3
       class="css-1fe5f89-h3-h3-STYLES_H3"
@@ -12379,7 +12379,7 @@ provided with a single argument that is
       </div>
     </h3>
     <div
-      class="css-1sq1qpv-STYLES_APIBOX-enumContainerStyle-renderEnum"
+      class="css-k95b90-STYLES_APIBOX-enumContainerStyle-renderEnum"
     >
       <div
         class="css-69zzym-enumValueNameStyle"
@@ -12451,7 +12451,7 @@ provided with a single argument that is
       </code>
     </div>
     <div
-      class="css-1sq1qpv-STYLES_APIBOX-enumContainerStyle-renderEnum"
+      class="css-k95b90-STYLES_APIBOX-enumContainerStyle-renderEnum"
     >
       <div
         class="css-69zzym-enumValueNameStyle"
@@ -12523,7 +12523,7 @@ provided with a single argument that is
       </code>
     </div>
     <div
-      class="css-1sq1qpv-STYLES_APIBOX-enumContainerStyle-renderEnum"
+      class="css-k95b90-STYLES_APIBOX-enumContainerStyle-renderEnum"
     >
       <div
         class="css-69zzym-enumValueNameStyle"

--- a/docs/components/plugins/api/APISectionClasses.tsx
+++ b/docs/components/plugins/api/APISectionClasses.tsx
@@ -9,6 +9,7 @@ import {
   GeneratedData,
   PropData,
 } from '~/components/plugins/api/APIDataTypes';
+import { APISectionDeprecationNote } from '~/components/plugins/api/APISectionDeprecationNote';
 import { renderMethod } from '~/components/plugins/api/APISectionMethods';
 import { renderProp } from '~/components/plugins/api/APISectionProps';
 import {
@@ -47,6 +48,7 @@ const renderClass = (clx: ClassDefinitionData, hasMultipleClasses: boolean): JSX
 
   return (
     <div key={`class-definition-${name}`} css={STYLES_APIBOX}>
+      <APISectionDeprecationNote comment={comment} />
       {hasMultipleClasses ? (
         <H3Code>
           <InlineCode>{name}</InlineCode>

--- a/docs/components/plugins/api/APISectionComponents.tsx
+++ b/docs/components/plugins/api/APISectionComponents.tsx
@@ -9,6 +9,7 @@ import {
   MethodSignatureData,
   PropsDefinitionData,
 } from '~/components/plugins/api/APIDataTypes';
+import { APISectionDeprecationNote } from '~/components/plugins/api/APISectionDeprecationNote';
 import APISectionProps from '~/components/plugins/api/APISectionProps';
 import {
   CommentTextBlock,
@@ -31,8 +32,10 @@ const renderComponent = (
 ): JSX.Element => {
   const resolvedType = extendedTypes?.length ? extendedTypes[0] : type;
   const resolvedName = getComponentName(name, children);
+  const extractedComment = getComponentComment(comment, signatures);
   return (
     <div key={`component-definition-${resolvedName}`} css={STYLES_APIBOX}>
+      <APISectionDeprecationNote comment={extractedComment} />
       <H3Code>
         <InlineCode>{resolvedName}</InlineCode>
       </H3Code>
@@ -41,7 +44,7 @@ const renderComponent = (
           <B>Type:</B> <InlineCode>{resolveTypeName(resolvedType)}</InlineCode>
         </P>
       )}
-      <CommentTextBlock comment={getComponentComment(comment, signatures)} />
+      <CommentTextBlock comment={extractedComment} />
       {componentsProps && componentsProps.length ? (
         <APISectionProps data={componentsProps} header={`${resolvedName}Props`} />
       ) : null}

--- a/docs/components/plugins/api/APISectionConstants.tsx
+++ b/docs/components/plugins/api/APISectionConstants.tsx
@@ -4,6 +4,8 @@ import { InlineCode } from '~/components/base/code';
 import { B, P } from '~/components/base/paragraph';
 import { H2, H3Code } from '~/components/plugins/Headings';
 import { ConstantDefinitionData } from '~/components/plugins/api/APIDataTypes';
+import { APISectionDeprecationNote } from '~/components/plugins/api/APISectionDeprecationNote';
+import { PlatformTags } from '~/components/plugins/api/APISectionPlatformTags';
 import {
   CommentTextBlock,
   resolveTypeName,
@@ -20,6 +22,8 @@ const renderConstant = (
   apiName?: string
 ): JSX.Element => (
   <div key={`constant-definition-${name}`} css={STYLES_APIBOX}>
+    <APISectionDeprecationNote comment={comment} />
+    <PlatformTags comment={comment} prefix="Only for:" firstElement />
     <H3Code>
       <InlineCode>
         {apiName ? `${apiName}.` : ''}
@@ -31,7 +35,7 @@ const renderConstant = (
         <B>Type:</B> <InlineCode>{resolveTypeName(type)}</InlineCode>
       </P>
     )}
-    <CommentTextBlock comment={comment} />
+    <CommentTextBlock comment={comment} includePlatforms={false} />
   </div>
 );
 

--- a/docs/components/plugins/api/APISectionDeprecationNote.tsx
+++ b/docs/components/plugins/api/APISectionDeprecationNote.tsx
@@ -1,0 +1,33 @@
+import { css } from '@emotion/react';
+import { spacing } from '@expo/styleguide';
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+
+import { B } from '~/components/base/paragraph';
+import { CommentData } from '~/components/plugins/api/APIDataTypes';
+import { getTagData, mdInlineComponents } from '~/components/plugins/api/APISectionUtils';
+import { Callout } from '~/ui/components/Callout';
+
+type Props = {
+  comment?: CommentData;
+};
+
+export const APISectionDeprecationNote = ({ comment }: Props) => {
+  const deprecation = getTagData('deprecated', comment);
+  return deprecation ? (
+    <div css={deprecationNoticeStyle}>
+      <Callout type="warning" key="deprecation-note">
+        {deprecation.text.trim().length ? (
+          <ReactMarkdown
+            components={mdInlineComponents}>{`**Deprecated.** ${deprecation.text}`}</ReactMarkdown>
+        ) : (
+          <B>Deprecated</B>
+        )}
+      </Callout>
+    </div>
+  ) : null;
+};
+
+const deprecationNoticeStyle = css({
+  marginTop: spacing[4],
+});

--- a/docs/components/plugins/api/APISectionEnums.tsx
+++ b/docs/components/plugins/api/APISectionEnums.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { InlineCode } from '~/components/base/code';
 import { H2, H3Code, H4Code } from '~/components/plugins/Headings';
 import { EnumDefinitionData, EnumValueData } from '~/components/plugins/api/APIDataTypes';
+import { APISectionDeprecationNote } from '~/components/plugins/api/APISectionDeprecationNote';
 import { PlatformTags } from '~/components/plugins/api/APISectionPlatformTags';
 import { CommentTextBlock, STYLES_APIBOX } from '~/components/plugins/api/APISectionUtils';
 
@@ -25,10 +26,12 @@ const sortByValue = (a: EnumValueData, b: EnumValueData) => {
 
 const renderEnum = ({ name, children, comment }: EnumDefinitionData): JSX.Element => (
   <div key={`enum-definition-${name}`} css={[STYLES_APIBOX, enumContentStyles]}>
+    <APISectionDeprecationNote comment={comment} />
+    <PlatformTags comment={comment} prefix="Only for:" firstElement />
     <H3Code>
       <InlineCode>{name}</InlineCode>
     </H3Code>
-    <CommentTextBlock comment={comment} />
+    <CommentTextBlock comment={comment} includePlatforms={false} />
     {children.sort(sortByValue).map((enumValue: EnumValueData) => (
       <div css={[STYLES_APIBOX, enumContainerStyle]} key={enumValue.name}>
         <PlatformTags comment={enumValue.comment} prefix="Only for:" firstElement />

--- a/docs/components/plugins/api/APISectionInterfaces.tsx
+++ b/docs/components/plugins/api/APISectionInterfaces.tsx
@@ -12,6 +12,8 @@ import {
   MethodSignatureData,
   PropData,
 } from '~/components/plugins/api/APIDataTypes';
+import { APISectionDeprecationNote } from '~/components/plugins/api/APISectionDeprecationNote';
+import { PlatformTags } from '~/components/plugins/api/APISectionPlatformTags';
 import {
   CommentTextBlock,
   getTagData,
@@ -108,6 +110,8 @@ const renderInterface = ({
 
   return (
     <div key={`interface-definition-${name}`} css={STYLES_APIBOX}>
+      <APISectionDeprecationNote comment={comment} />
+      <PlatformTags comment={comment} prefix="Only for:" firstElement />
       <H3Code>
         <InlineCode>{name}</InlineCode>
       </H3Code>
@@ -121,7 +125,7 @@ const renderInterface = ({
           ))}
         </P>
       ) : null}
-      <CommentTextBlock comment={comment} />
+      <CommentTextBlock comment={comment} includePlatforms={false} />
       {interfaceMethods.length ? (
         <>
           <div css={STYLES_NESTED_SECTION_HEADER}>

--- a/docs/components/plugins/api/APISectionMethods.tsx
+++ b/docs/components/plugins/api/APISectionMethods.tsx
@@ -11,6 +11,7 @@ import {
   MethodSignatureData,
   PropData,
 } from '~/components/plugins/api/APIDataTypes';
+import { APISectionDeprecationNote } from '~/components/plugins/api/APISectionDeprecationNote';
 import { PlatformTags } from '~/components/plugins/api/APISectionPlatformTags';
 import {
   CommentTextBlock,
@@ -43,6 +44,7 @@ export const renderMethod = (
     <div
       key={`method-signature-${name}-${parameters?.length || 0}`}
       css={[STYLES_APIBOX, !exposeInSidebar && STYLES_APIBOX_NESTED]}>
+      <APISectionDeprecationNote comment={comment} />
       <PlatformTags comment={comment} prefix="Only for:" firstElement />
       <HeaderComponent>
         <InlineCode customCss={!exposeInSidebar ? STYLES_NOT_EXPOSED_HEADER : undefined}>

--- a/docs/components/plugins/api/APISectionPlatformTags.tsx
+++ b/docs/components/plugins/api/APISectionPlatformTags.tsx
@@ -27,10 +27,10 @@ const formatPlatformName = (name: string) => {
 };
 
 const getPlatformName = ({ text }: CommentTagData) => {
-  if (text.includes('ios')) return 'ios';
-  if (text.includes('android')) return 'android';
-  if (text.includes('web')) return 'web';
-  if (text.includes('expo')) return 'expo';
+  if (text.toLowerCase().includes('ios')) return 'ios';
+  if (text.toLowerCase().includes('android')) return 'android';
+  if (text.toLowerCase().includes('web')) return 'web';
+  if (text.toLowerCase().includes('expo')) return 'expo';
   return undefined;
 };
 
@@ -115,7 +115,7 @@ const platformTagStyle = css({
 
 const platformTagFirstStyle = css({
   marginBottom: 0,
-  marginTop: spacing[3],
+  marginTop: spacing[4],
 });
 
 const platformLabelStyle = css({

--- a/docs/components/plugins/api/APISectionProps.tsx
+++ b/docs/components/plugins/api/APISectionProps.tsx
@@ -10,6 +10,8 @@ import {
   PropsDefinitionData,
   TypeDefinitionData,
 } from '~/components/plugins/api/APIDataTypes';
+import { APISectionDeprecationNote } from '~/components/plugins/api/APISectionDeprecationNote';
+import { PlatformTags } from '~/components/plugins/api/APISectionPlatformTags';
 import {
   CommentTextBlock,
   getCommentOrSignatureComment,
@@ -99,8 +101,11 @@ export const renderProp = (
   exposeInSidebar?: boolean
 ) => {
   const HeaderComponent = exposeInSidebar ? H3Code : H4Code;
+  const extractedComment = getCommentOrSignatureComment(comment, signatures);
   return (
     <div key={`prop-entry-${name}`} css={[STYLES_APIBOX, !exposeInSidebar && STYLES_APIBOX_NESTED]}>
+      <APISectionDeprecationNote comment={extractedComment} />
+      <PlatformTags comment={comment} prefix="Only for:" firstElement />
       <HeaderComponent>
         <InlineCode customCss={!exposeInSidebar ? STYLES_NOT_EXPOSED_HEADER : undefined}>
           {name}
@@ -116,7 +121,7 @@ export const renderProp = (
           </span>
         ) : null}
       </P>
-      <CommentTextBlock comment={getCommentOrSignatureComment(comment, signatures)} />
+      <CommentTextBlock comment={extractedComment} includePlatforms={false} />
     </div>
   );
 };
@@ -129,6 +134,7 @@ const APISectionProps = ({ data, defaultProps, header = 'Props' }: APISectionPro
         <H2 key="props-header">{header}</H2>
       ) : (
         <div>
+          {baseProp && <APISectionDeprecationNote comment={baseProp.comment} />}
           <div css={STYLES_NESTED_SECTION_HEADER}>
             <H4 key={`${header}-props-header`}>{header}</H4>
           </div>

--- a/docs/components/plugins/api/APISectionTypes.tsx
+++ b/docs/components/plugins/api/APISectionTypes.tsx
@@ -11,6 +11,7 @@ import {
   TypeGeneralData,
   TypeSignaturesData,
 } from '~/components/plugins/api/APIDataTypes';
+import { APISectionDeprecationNote } from '~/components/plugins/api/APISectionDeprecationNote';
 import {
   mdInlineComponents,
   resolveTypeName,
@@ -92,6 +93,7 @@ const renderType = ({
     // Object Types
     return (
       <div key={`type-definition-${name}`} css={STYLES_APIBOX}>
+        <APISectionDeprecationNote comment={comment} />
         <H3Code>
           <InlineCode>
             {name}
@@ -118,6 +120,7 @@ const renderType = ({
     if (propTypes.length) {
       return (
         <div key={`prop-type-definition-${name}`} css={STYLES_APIBOX}>
+          <APISectionDeprecationNote comment={comment} />
           <H3Code>
             <InlineCode>{name}</InlineCode>
           </H3Code>
@@ -139,6 +142,7 @@ const renderType = ({
     } else if (literalTypes.length) {
       return (
         <div key={`type-definition-${name}`} css={STYLES_APIBOX}>
+          <APISectionDeprecationNote comment={comment} />
           <H3Code>
             <InlineCode>{name}</InlineCode>
           </H3Code>
@@ -159,6 +163,7 @@ const renderType = ({
   } else if ((type.name === 'Record' && type.typeArguments) || type.type === 'reference') {
     return (
       <div key={`record-definition-${name}`} css={STYLES_APIBOX}>
+        <APISectionDeprecationNote comment={comment} />
         <H3Code>
           <InlineCode>{name}</InlineCode>
         </H3Code>
@@ -173,6 +178,7 @@ const renderType = ({
   } else if (type.type === 'intrinsic') {
     return (
       <div key={`generic-type-definition-${name}`} css={STYLES_APIBOX}>
+        <APISectionDeprecationNote comment={comment} />
         <H3Code>
           <InlineCode>{name}</InlineCode>
         </H3Code>
@@ -186,6 +192,7 @@ const renderType = ({
   } else if (type.type === 'conditional' && type.checkType) {
     return (
       <div key={`conditional-type-definition-${name}`} css={STYLES_APIBOX}>
+        <APISectionDeprecationNote comment={comment} />
         <H3Code>
           <InlineCode>
             {name}&lt;{type.checkType.name}&gt;

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -19,7 +19,6 @@ import {
 } from '~/components/plugins/api/APIDataTypes';
 import { PlatformTags } from '~/components/plugins/api/APISectionPlatformTags';
 import * as Constants from '~/constants/theme';
-import { Callout } from '~/ui/components/Callout';
 import { Cell, HeaderCell, Row, Table, TableHead } from '~/ui/components/Table';
 import { tableWrapperStyle } from '~/ui/components/Table/Table';
 
@@ -475,20 +474,6 @@ export const CommentTextBlock = ({
     </React.Fragment>
   ));
 
-  const deprecation = getTagData('deprecated', comment);
-  const deprecationNote = deprecation ? (
-    <div css={deprecationNoticeStyle}>
-      <Callout type="warning" key="deprecation-note">
-        {deprecation.text.trim().length ? (
-          <ReactMarkdown
-            components={mdInlineComponents}>{`**Deprecated.** ${deprecation.text}`}</ReactMarkdown>
-        ) : (
-          <B>Deprecated</B>
-        )}
-      </Callout>
-    </div>
-  ) : null;
-
   const see = getTagData('see', comment);
   const seeText = see ? (
     <Quote>
@@ -504,7 +489,6 @@ export const CommentTextBlock = ({
       {!withDash && includePlatforms && hasPlatforms && (
         <PlatformTags comment={comment} prefix="Only for:" />
       )}
-      {deprecationNote}
       {beforeContent}
       {withDash && (shortText || text) && ' - '}
       {withDash && includePlatforms && <PlatformTags comment={comment} />}
@@ -535,6 +519,11 @@ export const STYLES_APIBOX = css({
 
   h3: {
     marginTop: spacing[4],
+  },
+
+  th: {
+    color: theme.text.secondary,
+    padding: `${spacing[3]}px ${spacing[4]}px`,
   },
 
   [`.css-${tableWrapperStyle.name}`]: {
@@ -584,10 +573,6 @@ export const STYLES_SECONDARY = css({
 
 const defaultValueContainerStyle = css({
   marginTop: spacing[2],
-});
-
-const deprecationNoticeStyle = css({
-  marginBottom: spacing[2],
 });
 
 const STYLES_EXAMPLE_IN_TABLE = css({


### PR DESCRIPTION
# Why

This is the next part of tweaks and fixes after APISection redesign.

# How

In this PR I was focused on rearranging the order within various APISection boxes, so all of them use the same one. 

Now deprecation note and platform labels will be always displayed before the entry name. This change will be followed in the future with PR introducing tags and marked in the page ToC (right sidebar).

Additionally I have tweak nested table headers appearance, to make them a bit more subtle, than normal tables. I have also an idea how to improve this further, but  I want to address this in a separate PR in future, after getting the initial feedback.

# Test Plan

The changes have been tested by running docs website locally.

# Preview

<img width="1125" alt="Screenshot 2022-07-08 at 14 55 27" src="https://user-images.githubusercontent.com/719641/177998485-9b4cc103-8587-45ed-8000-3a9c831f69a2.png">
<img width="1125" alt="Screenshot 2022-07-08 at 14 54 43" src="https://user-images.githubusercontent.com/719641/177998497-dfcc9d0a-deb7-4160-9431-57da2042f061.png">
<img width="1125" alt="Screenshot 2022-07-08 at 14 53 03" src="https://user-images.githubusercontent.com/719641/177998499-6520fd43-9db2-40ae-996f-bd29345651f5.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
