### PR TITLE
[android] Fix bundling to wrong hermes-engine

### DIFF
--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -70,6 +70,13 @@ def reactNativeArchitectures() {
     def value = project.getProperties().get("reactNativeArchitectures")
     return value ? value.split(",") : ["armeabi-v7a", "x86", "x86_64", "arm64-v8a"]
 }
+
+def prebuiltHermesDir = findProperty("expo.prebuiltHermesDir") ?: file("${project(':ReactAndroid').projectDir}/prebuiltHermes")
+def prebuiltHermesVersion = file("${prebuiltHermesDir}/.hermesversion").exists() ? file("${prebuiltHermesDir}/.hermesversion").text : null
+def currentHermesVersion = file("${rootDir}/sdks/.hermesversion").exists() ? file("${rootDir}/sdks/.hermesversion").text : null
+def buildHermesSource = currentHermesVersion != prebuiltHermesVersion
+logger.info(":expoview - buildHermesSource[${buildHermesSource}]")
+
 // WHEN_PREPARING_REANIMATED_REMOVE_TO_HERE
 
 
@@ -283,9 +290,14 @@ dependencies {
   // WHEN_DISTRIBUTING_REMOVE_FROM_HERE
   api project(':ReactAndroid')
 
-  def hermesPath = "../../node_modules/hermes-engine/android/";
-  debugImplementation files(hermesPath + "hermes-debug.aar")
-  releaseImplementation files(hermesPath + "hermes-release.aar")
+  if (!buildHermesSource) {
+    debugImplementation(files("${prebuiltHermesDir}/hermes-engine-debug.aar"))
+    releaseImplementation(files("${prebuiltHermesDir}/hermes-engine-release.aar"))
+  } else {
+    implementation(project(':ReactAndroid:hermes-engine')) {
+      exclude(group:'com.facebook.fbjni', module: 'fbjni')
+    }
+  }
 
   // Expo modules
   api project(':expo')
@@ -666,26 +678,6 @@ def getNdkBuildFullPath() {
 
 def getCmakeToolchainFile() {
   return "-DCMAKE_TOOLCHAIN_FILE=${getNdkBuildFullPath()}/../build/cmake/android.toolchain.cmake"
-}
-
-task prepareHermes() {
-  def hermesPackagePath = findNodeModulePath(projectDir, "hermes-engine")
-  if (!hermesPackagePath) {
-    throw new GradleScriptException("Could not find the hermes-engine npm package", null)
-  }
-
-  def hermesAAR = file("$hermesPackagePath/android/hermes-debug.aar")
-  if (!hermesAAR.exists()) {
-    throw new GradleScriptException("The hermes-engine npm package is missing \"android/hermes-debug.aar\"", null)
-  }
-
-  def soFiles = zipTree(hermesAAR).matching({ it.include "**/*.so" })
-
-  copy {
-    from soFiles
-    from "$reactNative/ReactAndroid/src/main/jni/first-party/hermes/Android.mk"
-    into "$thirdPartyNdkDir/hermes"
-  }
 }
 
 // Create Android.mk library module based on jsc from npm


### PR DESCRIPTION
# Why

close ENG-5628

# How

- use the `ReactAndroid:hermes-engine` instead of the one from node_modules/hermes-engine

# Test Plan

android unversioned expo go + NCL with `"jsEngine": "hermes"`

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
