### PR TITLE
[core] Fix remote debugging crash on Android

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed crash when remote debugging is enabled on Android. ([#18165](https://github.com/expo/expo/pull/18165) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 0.11.0 — 2022-07-07

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed crash when remote debugging is enabled on Android. ([#18165](https://github.com/expo/expo/pull/18165) by [@kudo](https://github.com/kudo))
+- Fixed a crash when remote debugging is enabled on Android. ([#18165](https://github.com/expo/expo/pull/18165) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -89,13 +89,15 @@ class AppContext(
   fun installJSIInterop() {
     jsiInterop = JSIInteropModuleRegistry(this)
     val reactContext = reactContextHolder.get() ?: return
-    reactContext.javaScriptContextHolder?.get()?.let {
-      jsiInterop.installJSI(
-        it,
-        reactContext.catalystInstance.jsCallInvokerHolder as CallInvokerHolderImpl,
-        reactContext.catalystInstance.nativeCallInvokerHolder as CallInvokerHolderImpl
-      )
-    }
+    reactContext.javaScriptContextHolder?.get()
+      ?.takeIf { it != 0L }
+      ?.let {
+        jsiInterop.installJSI(
+          it,
+          reactContext.catalystInstance.jsCallInvokerHolder as CallInvokerHolderImpl,
+          reactContext.catalystInstance.nativeCallInvokerHolder as CallInvokerHolderImpl
+        )
+      }
   }
 
   /**


### PR DESCRIPTION
# Why

close ENG-5625

# How

in remote debugging mode, the javascript context ref is a non-null zero value. we should further check the value is non-zero.

# Test Plan

android unversioned expo go + NCL + remote debugging

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
