### PR TITLE
[dev-launcher][ios] configure dev launcher for development by using EX_DEV…

### DIFF
--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -89,8 +89,10 @@
   
   [modules addObject:[RCTDevMenu new]];
   [modules addObject:[RCTAsyncLocalStorage new]];
-  [modules addObject:[EXDevLauncherLoadingView new]];
+#ifndef EX_DEV_LAUNCHER_URL
   [modules addObject:[EXDevLauncherRCTDevSettings new]];
+#endif
+  [modules addObject:[EXDevLauncherLoadingView new]];
   [modules addObject:[EXDevLauncherInternal new]];
   [modules addObject:[EXDevLauncherAuth new]];
   

--- a/packages/expo-dev-launcher/ios/ReactNative/EXDevLauncherRCTBridge.m
+++ b/packages/expo-dev-launcher/ios/ReactNative/EXDevLauncherRCTBridge.m
@@ -29,8 +29,9 @@
  */
 - (RCTDevSettings *)devSettings
 {
-  //  uncomment below to enable fast refresh for development builds of DevLauncher
-  //  return super.devSettings;
+#ifdef EX_DEV_LAUNCHER_URL
+ return super.devSettings;
+#endif
  return nil;
 }
 

--- a/packages/expo-dev-launcher/ios/ReactNative/EXDevLauncherRCTDevSettings.m
+++ b/packages/expo-dev-launcher/ios/ReactNative/EXDevLauncherRCTDevSettings.m
@@ -6,6 +6,9 @@
 
 + (NSString *)moduleName
 {
+#ifdef EX_DEV_LAUNCHER_URL
+  return @"EXDevLauncherDevSettings";
+#endif
   return @"DevSettings";
 }
 

--- a/packages/expo-dev-launcher/ios/ReactNative/EXDevLauncherRCTDevSettings.m
+++ b/packages/expo-dev-launcher/ios/ReactNative/EXDevLauncherRCTDevSettings.m
@@ -6,9 +6,6 @@
 
 + (NSString *)moduleName
 {
-#ifdef EX_DEV_LAUNCHER_URL
-  return @"EXDevLauncherDevSettings";
-#endif
   return @"DevSettings";
 }
 


### PR DESCRIPTION
…_LAUNCHER env variable

# Why

This PR reduces the number of steps you have to take to set up a local bundler for dev launcher development

Doug already set up the `EX_DEV_LAUNCHER_URL` environment variable to configure the bundler, but fast refresh and dev settings were broken, so this PR uses this same flag to configure those things



# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

`export EX_DEV_LAUNCHER_URL=http://localhost:8090 && pod install` in a project -> uses local packager + fast refresh works
`pod install` in a project -> renders bundled dev launcher

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
