### PR TITLE
[home] fix account name overflow

### DIFF
--- a/home/screens/AccountModal/LoggedInAccountView.tsx
+++ b/home/screens/AccountModal/LoggedInAccountView.tsx
@@ -72,7 +72,7 @@ export function LoggedInAccountView({ accounts }: Props) {
                   borderBottomWidth: index === accounts.length - 1 ? 1 : 0,
                   borderTopWidth: index === 0 ? 1 : 0,
                 }}>
-                <Row align={!account.owner?.fullName ? 'center' : 'start'}>
+                <Row flex="1" align={!account.owner?.fullName ? 'center' : 'start'}>
                   {account?.owner?.profilePhoto ? (
                     <Image size="xl" rounded="full" source={{ uri: account.owner.profilePhoto }} />
                   ) : (
@@ -81,23 +81,34 @@ export function LoggedInAccountView({ accounts }: Props) {
                     </View>
                   )}
                   <Spacer.Horizontal size="small" />
-                  <View>
+                  <View flex="1">
                     {account.owner ? (
                       <>
                         {account.owner.fullName ? (
                           <>
-                            <Text type="InterBold">{account.owner.fullName}</Text>
+                            <Text type="InterBold" style={{ paddingRight: 16 }} numberOfLines={1}>
+                              {account.owner.fullName}
+                            </Text>
                             <Spacer.Vertical size="tiny" />
-                            <Text color="secondary" type="InterRegular" size="small">
+                            <Text
+                              style={{ paddingRight: 16 }}
+                              color="secondary"
+                              type="InterRegular"
+                              numberOfLines={1}
+                              size="small">
                               {account.owner.username}
                             </Text>
                           </>
                         ) : (
-                          <Text type="InterBold">{account.owner.username}</Text>
+                          <Text type="InterBold" style={{ paddingRight: 16 }} numberOfLines={1}>
+                            {account.owner.username}
+                          </Text>
                         )}
                       </>
                     ) : (
-                      <Text type="InterBold">{account.name}</Text>
+                      <Text type="InterBold" style={{ paddingRight: 16 }} numberOfLines={1}>
+                        {account.name}
+                      </Text>
                     )}
                   </View>
                 </Row>

--- a/home/screens/AccountModal/LoggedInAccountView.tsx
+++ b/home/screens/AccountModal/LoggedInAccountView.tsx
@@ -86,12 +86,15 @@ export function LoggedInAccountView({ accounts }: Props) {
                       <>
                         {account.owner.fullName ? (
                           <>
-                            <Text type="InterBold" style={{ paddingRight: 16 }} numberOfLines={1}>
+                            <Text
+                              type="InterBold"
+                              style={{ paddingRight: spacing[4] }}
+                              numberOfLines={1}>
                               {account.owner.fullName}
                             </Text>
                             <Spacer.Vertical size="tiny" />
                             <Text
-                              style={{ paddingRight: 16 }}
+                              style={{ paddingRight: spacing[4] }}
                               color="secondary"
                               type="InterRegular"
                               numberOfLines={1}
@@ -100,13 +103,16 @@ export function LoggedInAccountView({ accounts }: Props) {
                             </Text>
                           </>
                         ) : (
-                          <Text type="InterBold" style={{ paddingRight: 16 }} numberOfLines={1}>
+                          <Text
+                            type="InterBold"
+                            style={{ paddingRight: spacing[4] }}
+                            numberOfLines={1}>
                             {account.owner.username}
                           </Text>
                         )}
                       </>
                     ) : (
-                      <Text type="InterBold" style={{ paddingRight: 16 }} numberOfLines={1}>
+                      <Text type="InterBold" style={{ paddingRight: spacing[4] }} numberOfLines={1}>
                         {account.name}
                       </Text>
                     )}


### PR DESCRIPTION
# Why

Account/Org names overflow their container if they're long enough. See the linear issue for an example.

# How

I fixed the overflow by adding `flex: 1` to the text's parent container and setting `numberOfLines` to 1 so long titles get truncated.

# Test Plan

![Screenshot_20220708-203805](https://user-images.githubusercontent.com/12488826/178085165-84545c6d-3d0a-42a5-b1be-d708a29dfd6c.png)