### PR TITLE
[docs] add experimental DocIcons components

### DIFF
--- a/docs/pages/app-signing/app-credentials.md
+++ b/docs/pages/app-signing/app-credentials.md
@@ -3,6 +3,7 @@ title: App credentials explained
 ---
 
 import { ConfigClassic } from '~/components/plugins/ConfigSection';
+import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 
 Expo automates the process of signing your app for iOS and Android, but in both cases you can choose to provide your own overrides. [EAS Build](/build/introduction.md) can generate signed or unsigned applications, but in order to distribute your application through the stores, it **must** be a signed application.
 
@@ -43,11 +44,11 @@ Provisioning profiles expire after 12 months, but this won't affect apps in prod
 
 ### Summary
 
-| Credential               | Limit Per Account | App-specific? | Can be revoked with no production side effects? | Used at... |
-| ------------------------ | ----------------- | ------------- | ----------------------------------------------- | ---------- |
-| Distribution Certificate | 2                 | ❌            | ✅                                              | Build time |
-| Push Notification Key    | 2                 | ❌            | ❌                                              | Run time   |
-| Provisioning Profile     | Unlimited         | ✅            | ✅                                              | Build time |
+| Credential               | Limit Per Account | App-specific? | Can be revoked with no production side effects? | Used at…   |
+|--------------------------|-------------------|---------------|-------------------------------------------------|------------|
+| Distribution Certificate | 2                 | <NoIcon />    | <YesIcon />                                     | Build time |
+| Push Notification Key    | 2                 | <NoIcon />    | <NoIcon />                                      | Run time   |
+| Provisioning Profile     | Unlimited         | <YesIcon />   | <YesIcon />                                     | Build time |
 
 ### Clearing Credentials
 

--- a/docs/pages/bare/installing-expo-modules.md
+++ b/docs/pages/bare/installing-expo-modules.md
@@ -4,6 +4,7 @@ title: Installing Expo modules
 
 import InstallSection from '~/components/plugins/InstallSection';
 import ConfigurationDiff from '~/components/plugins/ConfigurationDiff';
+import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 
 > Are you migrating from `react-native-unimodules`? If yes, please refer to [the Expo modules migration guide](https://expo.fyi/expo-modules-migration).
 
@@ -21,8 +22,13 @@ Aside from initializing a new project with `expo-cli`, the easiest way to get up
 
 <InstallSection packageName="expo" cmd={["# Install and configure the expo package automatically", "npx install-expo-modules@latest"]} hideBareInstructions />
 
-- ✅ **When the command succeeds**, you will be able to add any Expo module in your app! Proceed to [Usage](#usage) for more information.
-- ❌ **If the command fails**, please follow the manual installation instructions. Updating code programmatically can be tricky, and if your project deviates significantly from a default React Native project, then you need to perform manual installation and adapt the instructions here to your codebase.
+- <YesIcon small />{' '}
+
+  **When the command succeeds**, you will be able to add any Expo module in your app! Proceed to [Usage](#usage) for more information.
+
+- <NoIcon small />{' '}
+
+  **If the command fails**, please follow the manual installation instructions. Updating code programmatically can be tricky, and if your project deviates significantly from a default React Native project, then you need to perform manual installation and adapt the instructions here to your codebase.
 
 ## Manual installation
 

--- a/docs/pages/introduction/managed-vs-bare.md
+++ b/docs/pages/introduction/managed-vs-bare.md
@@ -3,6 +3,8 @@ title: Workflows
 sidebar_title: Workflows
 ---
 
+import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
+
 The two approaches to building applications with Expo tools are called the "managed" and "bare" workflows.
 
 - With the _managed workflow_ you only write JavaScript / TypeScript and Expo tools and services take care of everything else for you.
@@ -30,16 +32,16 @@ In the bare workflow the developer has complete control, along with the complexi
 
 ## Workflow comparison
 
-| Feature                                                      | Managed workflow | Bare workflow                                                      |
-| ------------------------------------------------------------ | ---------------- | ------------------------------------------------------------------ |
-| Develop apps with **only** JavaScript/TypeScript             | ✅               |                                                                    |
-| Use Expo build service to create your iOS and Android builds | ✅               | ✅ ([with EAS Build](/build/introduction.md))                      |
-| Use Expo's push notification service                         | ✅               | ✅                                                                 |
-| Use Expo's updates features                                  | ✅               | ✅                                                                 |
-| Develop with the Expo Go app                                 | ✅               | ✅ (if you follow [these guidelines](../bare/using-expo-client.md)) |
-| Access to Expo SDK                                           | ✅               | ✅                                                                 |
-| Add custom native code and manage native dependencies        | ✅               | ✅                                                                 |
-| Develop in Xcode and Android Studio                          |                  | ✅                                                                 |
+| Feature                                                      | Managed workflow | Bare workflow                                                                |
+| ------------------------------------------------------------ |------------------|------------------------------------------------------------------------------|
+| Develop apps with **only** JavaScript/TypeScript             | <YesIcon />      | <NoIcon />                                                                   |
+| Use Expo build service to create your iOS and Android builds | <YesIcon />      | <YesIcon /> ([with EAS Build](/build/introduction.md))                       |
+| Use Expo's push notification service                         | <YesIcon />      | <YesIcon />                                                                  |
+| Use Expo's updates features                                  | <YesIcon />      | <YesIcon />                                                                  |
+| Develop with the Expo Go app                                 | <YesIcon />      | <YesIcon /> (if you follow [these guidelines](../bare/using-expo-client.md)) |
+| Access to Expo SDK                                           | <YesIcon />      | <YesIcon />                                                                  |
+| Add custom native code and manage native dependencies        | <YesIcon />      | <YesIcon />                                                                  |
+| Develop in Xcode and Android Studio                          | <NoIcon />       | <YesIcon />                                                                  |
 
 ## Which workflow is right for me?
 

--- a/docs/pages/tutorial/planning.md
+++ b/docs/pages/tutorial/planning.md
@@ -2,14 +2,19 @@
 title: First steps
 ---
 
+import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 import { Terminal } from '~/ui/components/Snippet';
 
 In this tutorial we are going to build an app for iOS, and Android that allows you to share photos with your friends! Of course there are already plenty of apps that let you share photos from your phone, you just can't do it with _your own app_. Let's remedy that.
 
 ## Before we get started
 
-- ✅ This tutorial assumes that you have installed Expo CLI and the Expo Go app, and that you have initialized and run a simple app successfully. If this is you, please continue reading this page!
-- 🛑 If you don't have a "Hello, world!" app running on your machine yet, please refer back to the ["Installation"](/get-started/installation) and ["Create a new app"](/get-started/create-a-new-app) guides.
+- <YesIcon />{' '}
+
+  **This tutorial assumes that you have installed Expo CLI and the Expo Go app**, and that you have initialized and run a simple app successfully. If this is you, please continue reading this page!
+- <NoIcon />{' '}
+
+  **If you don't have a "Hello, world!" app running on your machine yet**, please refer back to the ["Installation"](/get-started/installation) and ["Create a new app"](/get-started/create-a-new-app) guides.
 
 ## Initialize a new app
 

--- a/docs/ui/components/DocIcons/IconBase.tsx
+++ b/docs/ui/components/DocIcons/IconBase.tsx
@@ -1,0 +1,28 @@
+import { css } from '@emotion/react';
+import { iconSize, spacing, theme } from '@expo/styleguide';
+import * as React from 'react';
+
+export type DocIconProps = {
+  Icon?: React.ElementType;
+  color?: string;
+  small?: boolean;
+};
+
+export const IconBase = ({ color, small, Icon }: DocIconProps) => {
+  if (!Icon) return null;
+
+  return (
+    <Icon
+      css={iconStyles}
+      color={color ?? theme.icon.default}
+      size={small ? iconSize.small : iconSize.regular}
+    />
+  );
+};
+
+const iconStyles = css({
+  'table &': {
+    float: 'left',
+    marginRight: spacing[1.5],
+  },
+});

--- a/docs/ui/components/DocIcons/IconBase.tsx
+++ b/docs/ui/components/DocIcons/IconBase.tsx
@@ -21,7 +21,11 @@ export const IconBase = ({ color, small, Icon }: DocIconProps) => {
 };
 
 const iconStyles = css({
-  'table &': {
+  'table &, li &': {
     verticalAlign: 'middle',
+  },
+
+  'li &': {
+    marginTop: -spacing[0.5],
   },
 });

--- a/docs/ui/components/DocIcons/IconBase.tsx
+++ b/docs/ui/components/DocIcons/IconBase.tsx
@@ -22,7 +22,6 @@ export const IconBase = ({ color, small, Icon }: DocIconProps) => {
 
 const iconStyles = css({
   'table &': {
-    float: 'left',
-    marginRight: spacing[1.5],
+    verticalAlign: 'middle',
   },
 });

--- a/docs/ui/components/DocIcons/NoIcon.tsx
+++ b/docs/ui/components/DocIcons/NoIcon.tsx
@@ -1,0 +1,8 @@
+import { StatusFailedIcon, theme } from '@expo/styleguide';
+import * as React from 'react';
+
+import { IconBase, DocIconProps } from './IconBase';
+
+export const NoIcon = ({ small }: DocIconProps) => (
+  <IconBase Icon={StatusFailedIcon} color={theme.status.error} small={small} />
+);

--- a/docs/ui/components/DocIcons/YesIcon.tsx
+++ b/docs/ui/components/DocIcons/YesIcon.tsx
@@ -1,0 +1,8 @@
+import { StatusSuccessIcon, theme } from '@expo/styleguide';
+import * as React from 'react';
+
+import { IconBase, DocIconProps } from './IconBase';
+
+export const YesIcon = ({ small }: DocIconProps) => (
+  <IconBase Icon={StatusSuccessIcon} color={theme.status.success} small={small} />
+);

--- a/docs/ui/components/DocIcons/index.ts
+++ b/docs/ui/components/DocIcons/index.ts
@@ -1,0 +1,2 @@
+export * from './YesIcon';
+export * from './NoIcon';


### PR DESCRIPTION
# Why

Refs ENG-5361

# How

This PR introduces experimental `DocIcons` components, which are easy-to-use Styleguide icons, tailored to replace certain emojis on the docs pages.

The first batch contains "Yes" and "No" icons, used already in the API docs package compatibility tables. I have migrated the usage only few pages as an example, but there are a lot of other occurrences to address (quick serach shows 750 entries of just tick/check emoji).

> **Warning** 
>
> Those icons have the experimental state and should be used with caution, until we ship the renderer refactor and migration to updated MDX packages. Currently, in some cases (inside certain components) using those icons cause Markdown renderer to break, so every migration should be verified on the docs.
>
> <img width="855" alt="Screenshot 2022-07-09 123313" src="https://user-images.githubusercontent.com/719641/178103238-624cc0d3-2b97-44e6-acbe-d80e99b3afdf.png">

There is a workaround, which forces renderer to parse the icon and text after it separately, it is not pretty, but it works. See modified Markdown files for an examples.

# Test Plan

The new components have been tested by running website locally and altering several appearances of emojis on few different pages.

# Preview

<img width="848" alt="Screenshot 2022-07-09 131708" src="https://user-images.githubusercontent.com/719641/178103357-88d6e00c-8bcf-4e7f-8f01-0d29efc9f056.png">

<img width="854" alt="Screenshot 2022-07-09 125525" src="https://user-images.githubusercontent.com/719641/178103342-45467f81-60c6-4289-8b18-ce737093b6bb.png">

<img width="851" alt="Screenshot 2022-07-09 134457" src="https://user-images.githubusercontent.com/719641/178104250-45c48bf0-752c-4756-bf42-6df1aff879ed.png">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
