### PR TITLE
chore(cli): drop preset versions in web check

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Drop hardcoded web package versions in prerequisite.
+
 ## 0.2.0 — 2022-07-07
 
 ### 🛠 Breaking changes

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Drop hardcoded web package versions in prerequisite.
+- Drop hardcoded web package versions in prerequisite. ([#18172](https://github.com/expo/expo/pull/18172) by [@EvanBacon](https://github.com/EvanBacon))
 
 ## 0.2.0 — 2022-07-07
 

--- a/packages/@expo/cli/src/start/doctor/web/WebSupportProjectPrerequisite.ts
+++ b/packages/@expo/cli/src/start/doctor/web/WebSupportProjectPrerequisite.ts
@@ -54,8 +54,8 @@ export class WebSupportProjectPrerequisite extends ProjectPrerequisite {
     const requiredPackages: ResolvedPackage[] = [
       // use react-native-web/package.json to skip node module cache issues when the user installs
       // the package and attempts to resolve the module in the same process.
-      { file: 'react-native-web/package.json', pkg: 'react-native-web', version: '~0.18.1' },
-      { file: 'react-dom/package.json', pkg: 'react-dom', version: '^18.0.0' },
+      { file: 'react-native-web/package.json', pkg: 'react-native-web' },
+      { file: 'react-dom/package.json', pkg: 'react-dom' },
     ];
 
     const bundler = getPlatformBundlers(exp).web;
@@ -66,7 +66,6 @@ export class WebSupportProjectPrerequisite extends ProjectPrerequisite {
         {
           file: '@expo/webpack-config/package.json',
           pkg: '@expo/webpack-config',
-          version: '~0.16.2',
           dev: true,
         }
       );


### PR DESCRIPTION
# Why

Add support for multiple versions in development, we added support for using the versions endpoint when the versions aren't defined for TS support.

