### PR TITLE
[sweet][ios] Improve rejecting in do-catch

### DIFF
--- a/packages/expo-modules-core/ios/Swift/Promise.swift
+++ b/packages/expo-modules-core/ios/Swift/Promise.swift
@@ -22,7 +22,11 @@ public struct Promise: AnyArgument {
   }
 
   public func reject(_ error: Error) {
-    rejecter(UnexpectedException(error))
+    if let exception = error as? Exception {
+      rejecter(exception)
+    } else {
+      rejecter(UnexpectedException(error))
+    }
   }
 
   public func reject(_ error: Exception) {


### PR DESCRIPTION
# Why

Instead of doing
```swift
do {
  try func_thatThrows_ExpoException()
  try func_thatThrows_anyError()
} catch let exception as Exception {
 promise.reject(exception)
} catch {
  promise.reject(error)
}
```
we could do just single `catch`:
```swift
do {
  try func_thatThrows_ExpoException()
  try func_thatThrows_anyError()
} catch {
  promise.reject(error)
}
```

# How

Introduced exception type checking in `promise.reject(_ error: Error)`.

# Test Plan

CI, local dev

<!-- disable:changelog-checks -->