### PR TITLE
[docs] APISection: improve detection of optional state for params and props

### DIFF
--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -8090,6 +8090,12 @@ This can be used to quickly create specific permission hooks in every module.
               >
                 barCodeTypes
               </strong>
+              <br />
+              <span
+                class="css-fbbx5x-STYLES_OPTIONAL"
+              >
+                (optional)
+              </span>
             </td>
             <td
               class="css-yr5jng-tableCellStyle-Cell"

--- a/docs/components/plugins/api/APIDataTypes.ts
+++ b/docs/components/plugins/api/APIDataTypes.ts
@@ -66,6 +66,7 @@ export type MethodParamData = {
   type: TypeDefinitionData;
   comment?: CommentData;
   flags?: TypePropertyDataFlags;
+  defaultValue?: string;
 };
 
 export type TypePropertyDataFlags = {

--- a/docs/components/plugins/api/APISectionInterfaces.tsx
+++ b/docs/components/plugins/api/APISectionInterfaces.tsx
@@ -7,7 +7,6 @@ import { B, P } from '~/components/base/paragraph';
 import { H2, H3Code, H4 } from '~/components/plugins/Headings';
 import {
   CommentData,
-  CommentTagData,
   InterfaceDefinitionData,
   MethodSignatureData,
   PropData,
@@ -16,10 +15,12 @@ import {
   CommentTextBlock,
   getTagData,
   mdInlineComponents,
+  parseCommentContent,
   renderFlags,
   renderParamRow,
   renderTableHeadRow,
   resolveTypeName,
+  renderDefaultValue,
   STYLES_APIBOX,
   STYLES_NESTED_SECTION_HEADER,
 } from '~/components/plugins/api/APISectionUtils';
@@ -29,19 +30,14 @@ export type APISectionInterfacesProps = {
   data: InterfaceDefinitionData[];
 };
 
-const renderDefaultValue = (defaultValue?: CommentTagData) =>
-  defaultValue && (
-    <>
-      <br />
-      <br />
-      <B>Default:</B> <InlineCode>{defaultValue.text}</InlineCode>
-    </>
-  );
-
-const renderInterfaceComment = (comment?: CommentData, signatures?: MethodSignatureData[]) => {
+const renderInterfaceComment = (
+  comment?: CommentData,
+  signatures?: MethodSignatureData[],
+  defaultValue?: string
+) => {
   if (signatures && signatures.length) {
     const { type, parameters, comment: signatureComment } = signatures[0];
-    const defaultValue = getTagData('default', signatureComment);
+    const initValue = defaultValue || getTagData('default', signatureComment)?.text;
     return (
       <>
         {parameters?.length ? parameters.map(param => renderParamRow(param)) : null}
@@ -53,19 +49,19 @@ const renderInterfaceComment = (comment?: CommentData, signatures?: MethodSignat
             <CommentTextBlock
               comment={signatureComment}
               components={mdInlineComponents}
-              afterContent={renderDefaultValue(defaultValue)}
+              afterContent={renderDefaultValue(initValue)}
             />
           </>
         )}
       </>
     );
   } else {
-    const defaultValue = getTagData('default', comment);
+    const initValue = defaultValue || getTagData('default', comment)?.text;
     return (
       <CommentTextBlock
         comment={comment}
         components={mdInlineComponents}
-        afterContent={renderDefaultValue(defaultValue)}
+        afterContent={renderDefaultValue(initValue)}
         emptyCommentFallback="-"
       />
     );
@@ -78,17 +74,19 @@ const renderInterfacePropertyRow = ({
   type,
   comment,
   signatures,
+  defaultValue,
 }: PropData): JSX.Element => {
+  const initValue = parseCommentContent(defaultValue || getTagData('default', comment)?.text);
   return (
     <Row key={name}>
       <Cell fitContent>
         <B>{name}</B>
-        {renderFlags(flags)}
+        {renderFlags(flags, initValue)}
       </Cell>
       <Cell fitContent>
         <InlineCode>{resolveTypeName(type)}</InlineCode>
       </Cell>
-      <Cell fitContent>{renderInterfaceComment(comment, signatures)}</Cell>
+      <Cell fitContent>{renderInterfaceComment(comment, signatures, initValue)}</Cell>
     </Row>
   );
 };

--- a/docs/components/plugins/api/APISectionTypes.tsx
+++ b/docs/components/plugins/api/APISectionTypes.tsx
@@ -67,7 +67,7 @@ const renderTypePropertyRow = ({
     <Row key={name}>
       <Cell fitContent>
         <B>{name}</B>
-        {renderFlags(flags)}
+        {renderFlags(flags, initValue)}
       </Cell>
       <Cell fitContent>{renderTypeOrSignatureType(type, signatures)}</Cell>
       <Cell fitContent>

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -321,13 +321,19 @@ export const resolveTypeName = ({
 
 export const parseParamName = (name: string) => (name.startsWith('__') ? name.substr(2) : name);
 
-export const renderParamRow = ({ comment, name, type, flags }: MethodParamData): JSX.Element => {
-  const defaultValue = parseCommentContent(getTagData('default', comment)?.text);
+export const renderParamRow = ({
+  comment,
+  name,
+  type,
+  flags,
+  defaultValue,
+}: MethodParamData): JSX.Element => {
+  const initValue = parseCommentContent(defaultValue || getTagData('default', comment)?.text);
   return (
     <Row key={`param-${name}`}>
       <Cell>
         <B>{parseParamName(name)}</B>
-        {renderFlags(flags)}
+        {renderFlags(flags, initValue)}
       </Cell>
       <Cell>
         <InlineCode>{resolveTypeName(type)}</InlineCode>
@@ -336,7 +342,7 @@ export const renderParamRow = ({ comment, name, type, flags }: MethodParamData):
         <CommentTextBlock
           comment={comment}
           components={mdInlineComponents}
-          afterContent={renderDefaultValue(defaultValue)}
+          afterContent={renderDefaultValue(initValue)}
           emptyCommentFallback="-"
         />
       </Cell>
@@ -365,7 +371,7 @@ export const listParams = (parameters: MethodParamData[]) =>
   parameters ? parameters?.map(param => parseParamName(param.name)).join(', ') : '';
 
 export const renderDefaultValue = (defaultValue?: string) =>
-  defaultValue ? (
+  defaultValue && defaultValue !== '...' ? (
     <div css={defaultValueContainerStyle}>
       <B>Default:</B> <InlineCode>{defaultValue}</InlineCode>
     </div>
@@ -401,8 +407,8 @@ export const renderTypeOrSignatureType = (
   return undefined;
 };
 
-export const renderFlags = (flags?: TypePropertyDataFlags) =>
-  flags?.isOptional ? (
+export const renderFlags = (flags?: TypePropertyDataFlags, defaultValue?: string) =>
+  flags?.isOptional || defaultValue ? (
     <>
       <br />
       <span css={STYLES_OPTIONAL}>(optional)</span>


### PR DESCRIPTION
# Why

During the work on tweaks for the packages docs comments, I have spotted that not all method parameters or interface props are correctly marked as optional.

# How

This small PR adds an improvement for the optional state detection, which now uses also default value. I have also made a small tweak for the default value detection (not every extracted object type have the value in the same place).

# Test Plan

The changes have been tested by running docs website locally. `yarn test` and `yarn lint` checks do not yield any errors.

# Preview

<img width="1069" alt="Screenshot 2022-07-11 at 14 46 21" src="https://user-images.githubusercontent.com/719641/178268776-c6766b20-d02d-40b1-b0fd-305f154bcc25.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
