### PR TITLE
[android][ios] Upgrade @shopify/react-native-skia to v0.1.136

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Package-specific changes not released in any SDK will be added here just before 
 - Updated `react-native-pager-view` from `5.4.15` to `5.4.24`. ([#18084](https://github.com/expo/expo/pull/18084) by [@kudo](https://github.com/kudo))
 - Updated `@stripe/stripe-react-native` from `0.6.0` to `0.13.1`. ([#18072](https://github.com/expo/expo/pull/18072) by [@kudo](https://github.com/kudo))
 - Updated `react-native-safe-area-context` from `4.2.4` to `4.3.1`. ([#18048](https://github.com/expo/expo/pull/18048) by [@kudo](https://github.com/kudo))
-- Added `@shopify/react-native-skia@0.1.134`. ([#18120](https://github.com/expo/expo/pull/18120) by [@kudo](https://github.com/kudo))
+- Added `@shopify/react-native-skia@0.1.136`. ([#18120](https://github.com/expo/expo/pull/18120) and [#18187](https://github.com/expo/expo/pull/18187) by [@kudo](https://github.com/kudo))
 - Added `@shopify/flash-list@1.1.0`. ([#18137](https://github.com/expo/expo/pull/18137) by [@kudo](https://github.com/kudo))
 
 ### 🛠 Breaking changes

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -54,7 +54,7 @@
     "@react-navigation/native": "~5.8.9",
     "@react-navigation/stack": "~5.12.6",
     "@shopify/flash-list": "1.1.0",
-    "@shopify/react-native-skia": "0.1.134",
+    "@shopify/react-native-skia": "0.1.136",
     "@use-expo/permissions": "^2.0.0",
     "date-format": "^2.0.0",
     "deep-object-diff": "^1.1.0",

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1833,32 +1833,32 @@ PODS:
     - ReactCommon/turbomodule/core
   - react-native-segmented-control (2.4.0):
     - React-Core
-  - react-native-skia (0.1.134):
+  - react-native-skia (0.1.136):
     - React
     - React-callinvoker
     - React-Core
-    - react-native-skia/Api (= 0.1.134)
-    - react-native-skia/Jsi (= 0.1.134)
-    - react-native-skia/RNSkia (= 0.1.134)
-    - react-native-skia/SkiaHeaders (= 0.1.134)
-    - react-native-skia/Utils (= 0.1.134)
-  - react-native-skia/Api (0.1.134):
+    - react-native-skia/Api (= 0.1.136)
+    - react-native-skia/Jsi (= 0.1.136)
+    - react-native-skia/RNSkia (= 0.1.136)
+    - react-native-skia/SkiaHeaders (= 0.1.136)
+    - react-native-skia/Utils (= 0.1.136)
+  - react-native-skia/Api (0.1.136):
     - React
     - React-callinvoker
     - React-Core
-  - react-native-skia/Jsi (0.1.134):
+  - react-native-skia/Jsi (0.1.136):
     - React
     - React-callinvoker
     - React-Core
-  - react-native-skia/RNSkia (0.1.134):
+  - react-native-skia/RNSkia (0.1.136):
     - React
     - React-callinvoker
     - React-Core
-  - react-native-skia/SkiaHeaders (0.1.134):
+  - react-native-skia/SkiaHeaders (0.1.136):
     - React
     - React-callinvoker
     - React-Core
-  - react-native-skia/Utils (0.1.134):
+  - react-native-skia/Utils (0.1.136):
     - React
     - React-callinvoker
     - React-Core
@@ -3442,7 +3442,7 @@ SPEC CHECKSUMS:
   react-native-pager-view: 95d0418c3c74279840abec6926653d32447bafb6
   react-native-safe-area-context: 6c12e3859b6f27b25de4fee8201cfb858432d8de
   react-native-segmented-control: 06607462630512ff8eef652ec560e6235a30cc3e
-  react-native-skia: 886dce8cc9dc9bb47d3e716e528bb81e45b4bff3
+  react-native-skia: faacd6a970a757d67c4f4a44a31d347651abbb8e
   react-native-webview: a1ed211d50a5047a4fe54e07140991e277cd66e6
   React-perflogger: c9161ff0f1c769993cd11d2751e4331ff4ceb7cd
   React-RCTActionSheet: 2d885b0bea76a5254ef852939273edd8de116180

--- a/ios/vendored/unversioned/@shopify/react-native-skia/react-native-skia.podspec.json
+++ b/ios/vendored/unversioned/@shopify/react-native-skia/react-native-skia.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-skia",
-  "version": "0.1.134",
+  "version": "0.1.136",
   "summary": "High-performance React Native Graphics using Skia",
   "description": "@shopify/react-native-skia",
   "homepage": "https://github.com/shopify/react-native-skia",
@@ -13,7 +13,7 @@
   },
   "source": {
     "git": "https://github.com/shopify/react-native-skia/react-native-skia.git",
-    "tag": "0.1.134"
+    "tag": "0.1.136"
   },
   "requires_arc": true,
   "pod_target_xcconfig": {

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -109,6 +109,6 @@
   "sentry-expo": "^4.0.0",
   "unimodules-app-loader": "~3.1.0",
   "unimodules-image-loader-interface": "~6.1.0",
-  "@shopify/react-native-skia": "0.1.134",
+  "@shopify/react-native-skia": "0.1.136",
   "@shopify/flash-list": "1.1.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3430,12 +3430,12 @@
     recyclerlistview "4.0.1"
     tslib "2.4.0"
 
-"@shopify/react-native-skia@0.1.134":
-  version "0.1.134"
-  resolved "https://registry.yarnpkg.com/@shopify/react-native-skia/-/react-native-skia-0.1.134.tgz#9ecfbe8298b206bb02e94e07aa4301fe55583cc1"
-  integrity sha512-VXyAKOkIwgo5d7zuwh0upAAs7klm7A4YTThx8bwzh+FOHar9mPzdT8vitBQzzrqkOqCcc80jfH8xZ5ePrVgTIQ==
+"@shopify/react-native-skia@0.1.136":
+  version "0.1.136"
+  resolved "https://registry.yarnpkg.com/@shopify/react-native-skia/-/react-native-skia-0.1.136.tgz#cb399cd1216dfc14ad3cca226e6d0450b1e7ab7c"
+  integrity sha512-gNsBw9/ISNL7tAHdfhjeW3Y9/FPN93mPx4XSJS7xwbEgYaJdBP+1T1MyCCZZZTTcqJ6bCVp9FFUR6yo0u93Pgg==
   dependencies:
-    canvaskit-wasm "^0.34.0"
+    canvaskit-wasm "^0.35.0"
     react-reconciler "^0.26.2"
 
 "@sideway/address@^4.1.3":
@@ -4868,6 +4868,11 @@
     "@webassemblyjs/ast" "1.9.0"
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
+
+"@webgpu/types@^0.1.20":
+  version "0.1.21"
+  resolved "https://registry.yarnpkg.com/@webgpu/types/-/types-0.1.21.tgz#b181202daec30d66ccd67264de23814cfd176d3a"
+  integrity sha512-pUrWq3V5PiSGFLeLxoGqReTZmiiXwY3jRkIG5sLLKjyqNxrwm/04b4nw7LSmGWJcKk59XOM/YRTUwOzo4MMlow==
 
 "@wojtekmaj/enzyme-adapter-react-17@^0.6.3":
   version "0.6.7"
@@ -6483,10 +6488,12 @@ caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001358:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001358.tgz#473d35dabf5e448b463095cab7924e96ccfb8c00"
   integrity sha512-hvp8PSRymk85R20bsDra7ZTCpSVGN/PAz9pSAjPSjKC+rNmnUk5vCRgJwiTT/O4feQ/yu/drvZYpKxxhbFuChw==
 
-canvaskit-wasm@^0.34.0:
-  version "0.34.1"
-  resolved "https://registry.yarnpkg.com/canvaskit-wasm/-/canvaskit-wasm-0.34.1.tgz#dc8a4c0378e92d9541be8b9dd1c4abe69354cf4d"
-  integrity sha512-8qdrp0RO8wRUGTpn2JyfbBxsc5auSSTcHu4p2aazbmL7n15PzSpuZR5TKIg8xuVqqezclzLY2x/HEDSAuxmIxQ==
+canvaskit-wasm@^0.35.0:
+  version "0.35.0"
+  resolved "https://registry.yarnpkg.com/canvaskit-wasm/-/canvaskit-wasm-0.35.0.tgz#90afc625958367f4a27907fb8c03240045933a46"
+  integrity sha512-y/eTJ4xoIBkKzD37aQAvBL451LIp9YiB8Vs1e8J3Qwe7WcTHsAD00E5WocPzZo+0+XaSCkJ6cS/BxBDXTSnW1g==
+  dependencies:
+    "@webgpu/types" "^0.1.20"
 
 capital-case@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
# Why

last minute to vendor the latest version of @shopify/react-native-skia for sdk 46

# How

- `et uvm -m @shopify/react-native-skia -c 0.1.136`
- update yarn.lock

# Test Plan

- android unversioned expo go + NCL skia
- ios unversioned expo go + NCL skia

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
