### PR TITLE
[docs] Increase max-old-space-size to 6.5GB

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "rimraf .next/preval && next dev -p 3002",
-    "build": "cross-env NODE_OPTIONS=--max-old-space-size=6144 next build",
+    "build": "cross-env NODE_OPTIONS=--max-old-space-size=6656 next build",
     "export": "yarn run build && next export && yarn run export-issue-404",
     "export-issue-404": "echo \"🛠  Patching https://github.com/vercel/next.js/issues/16528\"; cp out/404/index.html out/404.html",
     "export-server": "http-server out -p 8000",


### PR DESCRIPTION
# Why

We have too many pages in our docs. This makes our CI builder run out of memory and fail to build the docs. The CI builder has 7GB of memory and we are currently using more than 6GB. This PR raises it to 6.5GB to attempt to quickly fix the issue.

This is a very short-term quick fix. In the future, we should upgrade to MDXv2 which uses significantly less memory, among other solutions.

# How

Adds 512 to the existing `--max-old-space-size` option.

# Test Plan

Make sure that the docs build without running out of memory