### PR TITLE
[home] fix dev menu sdk version display

### DIFF
--- a/home/menu/DevMenuTaskInfo.tsx
+++ b/home/menu/DevMenuTaskInfo.tsx
@@ -33,6 +33,14 @@ export function DevMenuTaskInfo({ task }: Props) {
           </Text>
           {sdkVersion && (
             <Text size="small" type="InterRegular" color="secondary">
+              SDK version:{' '}
+              <Text type="InterSemiBold" color="secondary" size="small">
+                {sdkVersion}
+              </Text>
+            </Text>
+          )}
+          {runtimeVersion && (
+            <Text size="small" type="InterRegular" color="secondary">
               Runtime version:{' '}
               <Text type="InterSemiBold" color="secondary" size="small">
                 {runtimeVersion}

--- a/home/screens/ProjectScreen/ProjectView.tsx
+++ b/home/screens/ProjectScreen/ProjectView.tsx
@@ -67,6 +67,15 @@ export function ProjectView({ loading, error, data, navigation }: Props) {
                 <ConstantItem title="SDK Version" value={app.sdkVersion} />
               </>
             )}
+            {app.latestReleaseForReleaseChannel?.runtimeVersion && (
+              <>
+                <Divider style={{ height: 1 }} />
+                <ConstantItem
+                  title="Runtime Version"
+                  value={app.latestReleaseForReleaseChannel?.runtimeVersion}
+                />
+              </>
+            )}
           </View>
         </View>
       </ScrollView>


### PR DESCRIPTION
# Why

There is a bug in Expo Go where we wouldn't properly show the SDK version in the dev menu. Instead, we'd show "Runtime version" even if there wasn't one.

# How

I fixed the typo that caused this bug and added an entry for runtime version.

# Test Plan

Open an app in Expo Go and launch the dev menu. You should see the SDK Version and/or Runtime Version if it exists.