### PR TITLE
[docs] Use sourceCodeUrl if available for InstallSection

### DIFF
--- a/docs/components/plugins/InstallSection.tsx
+++ b/docs/components/plugins/InstallSection.tsx
@@ -44,24 +44,28 @@ const InstallSection: React.FC<Props> = ({
   hideBareInstructions = false,
   cmd = [`$ expo install ${packageName}`],
   href = getPackageLink(packageName),
-}) => (
-  <>
-    <Terminal cmd={cmd} />
-    {hideBareInstructions ? null : (
-      <p css={STYLES_P}>
-        If you're installing this in a{' '}
-        <a css={STYLES_LINK} href="/introduction/managed-vs-bare/#bare-workflow">
-          bare React Native app
-        </a>
-        , you should also follow{' '}
-        <a css={STYLES_BOLD} href={href}>
-          these additional installation instructions
-        </a>
-        .
-      </p>
-    )}
-  </>
-);
+}) => {
+  const { sourceCodeUrl } = usePageMetadata();
+
+  return (
+    <>
+      <Terminal cmd={cmd} />
+      {hideBareInstructions ? null : (
+        <p css={STYLES_P}>
+          If you're installing this in a{' '}
+          <a css={STYLES_LINK} href="/introduction/managed-vs-bare/#bare-workflow">
+            bare React Native app
+          </a>
+          , you should also follow{' '}
+          <a css={STYLES_BOLD} href={sourceCodeUrl ?? href}>
+            these additional installation instructions
+          </a>
+          .
+        </p>
+      )}
+    </>
+  );
+};
 
 export default InstallSection;
 


### PR DESCRIPTION
# Why

Currently our InstallSection component always links to the source code on the main branch, but it makes more sense to link to the README on the branch corresponding to the SDK version that the docs are being viewed for.

The reason I was looking into this was because in #18168 we are removing several packages from the expo/expo repo, but they will still exist on the related SDK branch, so this ensures that the links will continue to work on older API docs.

# How

Use `sourceCodeUrl` if it's available, otherwise fallback to generating URL from package name.

# Test Plan

I ran this locally and confirmed it worked as expected:

<img width="929" alt="image" src="https://user-images.githubusercontent.com/90494/178376715-621a9c61-caf9-4813-87b8-b30f6f8b8534.png">

I would have put this in `APIInstallSection` but that is only used in SDK 44+