### PR TITLE
[home] don't reset store when logging in and never fetch projects if not logged in

### DIFF
--- a/home/screens/AccountModal/LoggedOutAccountView.tsx
+++ b/home/screens/AccountModal/LoggedOutAccountView.tsx
@@ -7,7 +7,6 @@ import { TouchableOpacity } from 'react-native-gesture-handler';
 import url from 'url';
 
 import Analytics from '../../api/Analytics';
-import ApolloClient from '../../api/ApolloClient';
 import Config from '../../api/Config';
 import { useDispatch, useSelector } from '../../redux/Hooks';
 import SessionActions from '../../redux/SessionActions';
@@ -40,7 +39,6 @@ export function LoggedOutAccountView({ refetch }: Props) {
       // after logging in, wait for redux action to dispatch, refetch with new sessionSecret, then dismiss modal
       if (isFinishedAuthenticating && sessionSecretExists) {
         try {
-          await ApolloClient.resetStore();
           await refetch();
         } finally {
           // in the case that it rejects, we still want to dismiss the modal

--- a/home/screens/HomeScreen/HomeScreenView.tsx
+++ b/home/screens/HomeScreen/HomeScreenView.tsx
@@ -222,8 +222,6 @@ export class HomeScreenView extends React.Component<Props, State> {
   };
 
   private _startPollingForProjects = async () => {
-    if (!this.props.isAuthenticated) return;
-
     await this._fetchProjectsAsync();
     this._projectPolling = setInterval(this._fetchProjectsAsync, PROJECT_UPDATE_INTERVAL);
   };

--- a/home/screens/HomeScreen/HomeScreenView.tsx
+++ b/home/screens/HomeScreen/HomeScreenView.tsx
@@ -222,6 +222,8 @@ export class HomeScreenView extends React.Component<Props, State> {
   };
 
   private _startPollingForProjects = async () => {
+    if (!this.props.isAuthenticated) return;
+
     await this._fetchProjectsAsync();
     this._projectPolling = setInterval(this._fetchProjectsAsync, PROJECT_UPDATE_INTERVAL);
   };
@@ -234,6 +236,8 @@ export class HomeScreenView extends React.Component<Props, State> {
   };
 
   private _fetchProjectsAsync = async () => {
+    if (!this.props.isAuthenticated) return;
+
     const { accountName } = this.props;
 
     try {


### PR DESCRIPTION
# Why

On Android, we get development errors about resetting the Apollo store when logging in. This is because the app wrongly resets the store on log-in, which is unnecessary because the store should be already cleared if the user previously logged out successfully.

# How

- I removed the `client.resetStore()` call from the log in function
- I added a guard to `_fetchProjectsAsync` to prevent calling our API when not logged in.

# Test Plan

Logging in on Android shouldn't result in the error described in the linear task.