### PR TITLE
[home] use RN FlatList instead of RNGH to make fetch-on-scroll work on iOS 

### DIFF
--- a/home/components/FlatList.tsx
+++ b/home/components/FlatList.tsx
@@ -1,4 +1,0 @@
-import { FlatList as RNFlatList, Platform } from 'react-native';
-import { FlatList as RNGHFlatList } from 'react-native-gesture-handler';
-
-export const FlatList = Platform.OS === 'android' ? RNFlatList : RNGHFlatList;

--- a/home/screens/AccountModal/LoggedInAccountView.tsx
+++ b/home/screens/AccountModal/LoggedInAccountView.tsx
@@ -3,9 +3,9 @@ import { useNavigation } from '@react-navigation/native';
 import { SectionHeader } from 'components/SectionHeader';
 import { Text, View, Image, useExpoTheme, Row, Spacer, Divider } from 'expo-dev-client-components';
 import React from 'react';
+import { FlatList } from 'react-native';
 import { TouchableOpacity } from 'react-native-gesture-handler';
 
-import { FlatList } from '../../components/FlatList';
 import { Home_CurrentUserQuery } from '../../graphql/types';
 import { useDispatch } from '../../redux/Hooks';
 import SessionActions from '../../redux/SessionActions';

--- a/home/screens/BranchDetailsScreen/BranchDetailsView.tsx
+++ b/home/screens/BranchDetailsScreen/BranchDetailsView.tsx
@@ -4,9 +4,8 @@ import { StackScreenProps } from '@react-navigation/stack';
 import dedent from 'dedent';
 import { Divider, Text, useExpoTheme, View } from 'expo-dev-client-components';
 import * as React from 'react';
-import { ActivityIndicator, RefreshControl } from 'react-native';
+import { ActivityIndicator, RefreshControl, FlatList } from 'react-native';
 
-import { FlatList } from '../../components/FlatList';
 import { SectionHeader } from '../../components/SectionHeader';
 import { UpdateListItem } from '../../components/UpdateListItem';
 import { BranchDetailsQuery } from '../../graphql/types';

--- a/home/screens/BranchListScreen/BranchListView.tsx
+++ b/home/screens/BranchListScreen/BranchListView.tsx
@@ -1,11 +1,10 @@
 import { spacing } from '@expo/styleguide-native';
 import { Divider, useExpoTheme, View } from 'expo-dev-client-components';
 import * as React from 'react';
-import { ActivityIndicator, View as RNView } from 'react-native';
+import { FlatList, ActivityIndicator, View as RNView } from 'react-native';
 import InfiniteScrollView from 'react-native-infinite-scroll-view';
 
 import { BranchListItem } from '../../components/BranchListItem';
-import { FlatList } from '../../components/FlatList';
 import { BranchesForProjectQuery } from '../../graphql/types';
 
 type BranchManifest = {

--- a/home/screens/ProjectsListScreen/ProjectList.tsx
+++ b/home/screens/ProjectsListScreen/ProjectList.tsx
@@ -2,10 +2,9 @@ import { spacing } from '@expo/styleguide-native';
 import dedent from 'dedent';
 import { Divider, useExpoTheme, View } from 'expo-dev-client-components';
 import * as React from 'react';
-import { ActivityIndicator, ListRenderItem, View as RNView } from 'react-native';
+import { FlatList, ActivityIndicator, ListRenderItem, View as RNView } from 'react-native';
 import InfiniteScrollView from 'react-native-infinite-scroll-view';
 
-import { FlatList } from '../../components/FlatList';
 import PrimaryButton from '../../components/PrimaryButton';
 import { ProjectsListItem } from '../../components/ProjectsListItem';
 import { StyledText } from '../../components/Text';

--- a/home/screens/SnacksListScreen/SnackList.tsx
+++ b/home/screens/SnacksListScreen/SnackList.tsx
@@ -1,10 +1,9 @@
 import { spacing } from '@expo/styleguide-native';
 import { Divider, useExpoTheme, View } from 'expo-dev-client-components';
 import * as React from 'react';
-import { ActivityIndicator, View as RNView } from 'react-native';
+import { FlatList, ActivityIndicator, View as RNView } from 'react-native';
 import InfiniteScrollView from 'react-native-infinite-scroll-view';
 
-import { FlatList } from '../../components/FlatList';
 import { SnacksListItem } from '../../components/SnacksListItem';
 import { CommonSnackDataFragment } from '../../graphql/types';
 


### PR DESCRIPTION
# Why

We're using RNGH FlatList on iOS, which for some reason stopped firing its infinite scroll callbacks which we use for our list pages.

# How

I removed our custom export which chose RNGH's FlatList for iOS and replaced it with a normal import from react-native itself.

# Test Plan

Visit a project list on iOS Expo Go and make sure you can view the whole list:

https://user-images.githubusercontent.com/12488826/178389547-3f96e3b9-4633-42f4-ad3f-60e8c4a58d0a.mp4

Notice the Snacks list, in particular, grow when we get close to the bottom (the scrollbar to the right jumps ups).

