### PR TITLE
[home] optional chain manifest.extra accesses to prevent dev menu crashes

### DIFF
--- a/home/menu/DevMenuTaskInfo.tsx
+++ b/home/menu/DevMenuTaskInfo.tsx
@@ -12,9 +12,9 @@ type Props = {
 export function DevMenuTaskInfo({ task }: Props) {
   const taskUrl = task.manifestUrl ? FriendlyUrls.toFriendlyString(task.manifestUrl) : '';
   const manifest = task.manifestString && JSON.parse(task.manifestString);
-  const iconUrl = manifest && (manifest.iconUrl ?? manifest.extra.expoClient.iconUrl);
-  const taskName = manifest && (manifest.name ?? manifest.extra.expoClient.name);
-  const sdkVersion = manifest && (manifest.sdkVersion ?? manifest.extra.expoClient.sdkVersion);
+  const iconUrl = manifest && (manifest.iconUrl ?? manifest.extra?.expoClient?.iconUrl);
+  const taskName = manifest && (manifest.name ?? manifest.extra?.expoClient?.name);
+  const sdkVersion = manifest && (manifest.sdkVersion ?? manifest.extra?.expoClient?.sdkVersion);
   const runtimeVersion = manifest && manifest.runtimeVersion;
 
   const devServerName =


### PR DESCRIPTION
# Why

`manifest.extra.expoClient` doesn't always exist, as demonstrated when opening up apps/jest-expo-mock-generator (see linear issue).

# How

I added optional chaining to the failing property accesses. 

# Test Plan

Opening jest-expo Mock Generator should work now:

![Screen Shot 2022-07-11 at 21 52 10](https://user-images.githubusercontent.com/12488826/178391358-09a84963-4fcc-4e42-9373-887cdc9db5b2.png)

