### PR TITLE
[expotools] Move publishing action to end of ppt

### DIFF
--- a/tools/src/utils/askAreYouSureAsync.ts
+++ b/tools/src/utils/askAreYouSureAsync.ts
@@ -10,18 +10,4 @@ export default async function askAreYouSureAsync(): Promise<boolean> {
     },
   ]);
   return selection;
-  // Alternate implementation below
-  /*
-  const choices = ['Yes', 'No'];
-  const { selection } = await inquirer.prompt<{ selection: string }>([
-    {
-      type: 'list',
-      name: 'selection',
-      message: 'Are you sure?',
-      choices,
-      default: 'No',
-    },
-  ]);
-  return selection === 'Yes';
-   */
 }

--- a/tools/src/utils/askAreYouSureAsync.ts
+++ b/tools/src/utils/askAreYouSureAsync.ts
@@ -1,0 +1,27 @@
+import inquirer from 'inquirer';
+
+export default async function askAreYouSureAsync(): Promise<boolean> {
+  const { selection } = await inquirer.prompt<{ selection: boolean }>([
+    {
+      type: 'confirm',
+      name: 'selection',
+      default: false,
+      message: 'Are you sure?',
+    },
+  ]);
+  return selection;
+  // Alternate implementation below
+  /*
+  const choices = ['Yes', 'No'];
+  const { selection } = await inquirer.prompt<{ selection: string }>([
+    {
+      type: 'list',
+      name: 'selection',
+      message: 'Are you sure?',
+      choices,
+      default: 'No',
+    },
+  ]);
+  return selection === 'Yes';
+   */
+}


### PR DESCRIPTION
# Why

After this change, `npm publish` commands in `publish-project-templates` will only be executed at the end of the script, and only after the user confirms their intent.

# How

Flow is modified to build up an array of commands to be executed, and then they are executed all at once at the end of the script.

Generally useful new module `askAreYouSureAsync.ts` is added to the `utils` folder.

# Test Plan

Tested locally in dry run mode.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
