### PR TITLE
[sweet][ios] Fix class components outside e-m-c

### DIFF
--- a/packages/expo-modules-core/ios/Swift/Classes/ClassComponentElementsBuilder.swift
+++ b/packages/expo-modules-core/ios/Swift/Classes/ClassComponentElementsBuilder.swift
@@ -12,7 +12,7 @@ public struct ClassComponentElementsBuilder<OwnerType> {
   /**
    Default implementation without any constraints that just returns type-erased element.
    */
-  static func buildExpression<ElementType: ClassComponentElement>(
+  public static func buildExpression<ElementType: ClassComponentElement>(
     _ element: ElementType
   ) -> AnyClassComponentElement {
     return element
@@ -23,7 +23,7 @@ public struct ClassComponentElementsBuilder<OwnerType> {
    we need to instruct the function to pass `this` to the closure
    as the first argument and deduct it from `argumentsCount`.
    */
-  static func buildExpression<ElementType: ClassComponentElement>(
+  public static func buildExpression<ElementType: ClassComponentElement>(
     _ element: ElementType
   ) -> AnyClassComponentElement where ElementType.OwnerType == OwnerType {
     if var function = element as? AnyFunction {


### PR DESCRIPTION
# Why

When writing a class in a module not being inside e-m-c, class function calls didn't receive the `self` object in the first argument. When debugging, `SyncFunctionComponent.takesOwner` was always `false`.
Moreover, type inference wasn't working:

<img width="1021" alt="Screenshot 2022-07-12 at 09 02 49" src="https://user-images.githubusercontent.com/278340/178428940-47a65edf-ff10-4ec7-88e5-7f317468db17.png">

# How

It turns out that all `@resultBuilder` functions in `ClassComponentElementsBuilder` need to be `public`.

# Test Plan

Copied the "Counter" example from tests to another package, compiled and ran the code successfully.

# Checklist

<!-- disable:changelog-checks -->