### PR TITLE
[core] Fix dangling pointer in fbjni from MethodMetadata::createPromiseBody

### DIFF
--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
@@ -261,7 +261,7 @@ jsi::Function MethodMetadata::toAsyncFunction(
       // Creates a JSI promise
       jsi::Value promise = Promise.callAsConstructor(
         rt,
-        createPromiseBody(rt, moduleRegistry, tempArray)
+        createPromiseBody(rt, moduleRegistry, std::move(tempArray))
       );
       return promise;
     }
@@ -271,13 +271,13 @@ jsi::Function MethodMetadata::toAsyncFunction(
 jsi::Function MethodMetadata::createPromiseBody(
   jsi::Runtime &runtime,
   JSIInteropModuleRegistry *moduleRegistry,
-  jni::local_ref<jni::JArrayClass<jobject>::javaobject> &args
+  jni::local_ref<jni::JArrayClass<jobject>::javaobject> &&args
 ) {
   return jsi::Function::createFromHostFunction(
     runtime,
     jsi::PropNameID::forAscii(runtime, "promiseFn"),
     2,
-    [this, &args, moduleRegistry](
+    [this, args = std::move(args), moduleRegistry](
       jsi::Runtime &rt,
       const jsi::Value &thisVal,
       const jsi::Value *promiseConstructorArgs,

--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
@@ -261,7 +261,7 @@ jsi::Function MethodMetadata::toAsyncFunction(
       // Creates a JSI promise
       jsi::Value promise = Promise.callAsConstructor(
         rt,
-        createPromiseBody(rt, moduleRegistry, std::move(tempArray))
+        createPromiseBody(rt, moduleRegistry, tempArray)
       );
       return promise;
     }
@@ -271,13 +271,13 @@ jsi::Function MethodMetadata::toAsyncFunction(
 jsi::Function MethodMetadata::createPromiseBody(
   jsi::Runtime &runtime,
   JSIInteropModuleRegistry *moduleRegistry,
-  jni::local_ref<jni::JArrayClass<jobject>::javaobject> &&args
+  jni::local_ref<jni::JArrayClass<jobject>::javaobject> &args
 ) {
   return jsi::Function::createFromHostFunction(
     runtime,
     jsi::PropNameID::forAscii(runtime, "promiseFn"),
     2,
-    [this, args = std::move(args), moduleRegistry](
+    [this, &args, moduleRegistry](
       jsi::Runtime &rt,
       const jsi::Value &thisVal,
       const jsi::Value *promiseConstructorArgs,

--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.h
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.h
@@ -117,7 +117,7 @@ private:
   jsi::Function createPromiseBody(
     jsi::Runtime &runtime,
     JSIInteropModuleRegistry *moduleRegistry,
-    jni::local_ref<jni::JArrayClass<jobject>::javaobject> &&args
+    jni::local_ref<jni::JArrayClass<jobject>::javaobject> &args
   );
 
   std::vector<jvalue> convertJSIArgsToJNI(

--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.h
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.h
@@ -117,7 +117,7 @@ private:
   jsi::Function createPromiseBody(
     jsi::Runtime &runtime,
     JSIInteropModuleRegistry *moduleRegistry,
-    jni::local_ref<jni::JArrayClass<jobject>::javaobject> &args
+    jni::local_ref<jni::JArrayClass<jobject>::javaobject> &&args
   );
 
   std::vector<jvalue> convertJSIArgsToJNI(


### PR DESCRIPTION
# Why

close ENG-5686

# How

my investigation is that `fbjni::local_ref` should not pass across functions, especially for lambdas.
my current solution is easiest one that assume the `MethodMetadata::createPromiseBody()` is a synchronous call. another solution might be using `fbjni::make_global` to pass `fbjni::global_ref` or using `releaseAlias` to pass `fbjni::alias_ref`. i am not familiar with fbjni and afraid of leakage from these alternative solutions. please review whether this solution makes sense.

# Test Plan

bare-expo + Test suite AuthSession test

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
