### PR TITLE
[tools] Fix versioning on iOS

### DIFF
--- a/packages/expo-modules-core/ios/JSI/EXJSIInstaller.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJSIInstaller.mm
@@ -1,6 +1,7 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
 #import <ExpoModulesCore/EXJSIInstaller.h>
+#import <ExpoModulesCore/EXJavaScriptRuntime.h>
 #import <ExpoModulesCore/ExpoModulesHostObject.h>
 #import <ExpoModulesCore/Swift.h>
 
@@ -14,6 +15,7 @@ static NSString *expoModulesHostObjectPropertyName = @"ExpoModules";
 @interface RCTBridge (ExpoBridgeWithRuntime)
 
 - (void *)runtime;
+- (std::shared_ptr<facebook::react::CallInvoker>)jsCallInvoker;
 
 @end
 

--- a/tools/src/versioning/ios/index.ts
+++ b/tools/src/versioning/ios/index.ts
@@ -183,34 +183,23 @@ async function generateVersionedReactNativeAsync(versionName: string): Promise<v
   // Clone react native latest version
   console.log(`Copying files from ${chalk.magenta(RELATIVE_RN_PATH)} ...`);
 
-  await fs.copy(
-    path.join(EXPO_DIR, RELATIVE_RN_PATH, 'React'),
-    path.join(versionedReactNativePath, 'React')
-  );
-  await fs.copy(
-    path.join(EXPO_DIR, RELATIVE_RN_PATH, 'Libraries'),
-    path.join(versionedReactNativePath, 'Libraries')
-  );
-  await fs.copy(
-    path.join(EXPO_DIR, RELATIVE_RN_PATH, 'React.podspec'),
-    path.join(versionedReactNativePath, 'React.podspec')
-  );
-  await fs.copy(
-    path.join(EXPO_DIR, RELATIVE_RN_PATH, 'React-Core.podspec'),
-    path.join(versionedReactNativePath, 'React-Core.podspec')
-  );
-  await fs.copy(
-    path.join(EXPO_DIR, RELATIVE_RN_PATH, 'ReactCommon', 'ReactCommon.podspec'),
-    path.join(versionedReactNativePath, 'ReactCommon', 'ReactCommon.podspec')
-  );
-  await fs.copy(
-    path.join(EXPO_DIR, RELATIVE_RN_PATH, 'ReactCommon', 'React-Fabric.podspec'),
-    path.join(versionedReactNativePath, 'ReactCommon', 'React-Fabric.podspec')
-  );
-  await fs.copy(
-    path.join(EXPO_DIR, RELATIVE_RN_PATH, 'package.json'),
-    path.join(versionedReactNativePath, 'package.json')
-  );
+  const filesToCopy = [
+    'React',
+    'Libraries',
+    'React.podspec',
+    'React-Core.podspec',
+    'ReactCommon/ReactCommon.podspec',
+    'ReactCommon/React-Fabric.podspec',
+    'ReactCommon/React-bridging.podspec',
+    'package.json',
+  ];
+
+  for (const fileToCopy of filesToCopy) {
+    await fs.copy(
+      path.join(EXPO_DIR, RELATIVE_RN_PATH, fileToCopy),
+      path.join(versionedReactNativePath, fileToCopy)
+    );
+  }
 
   console.log(`Removing unnecessary ${chalk.magenta('*.js')} files ...`);
 

--- a/tools/src/versioning/ios/transforms/expoModulesTransforms.ts
+++ b/tools/src/versioning/ios/transforms/expoModulesTransforms.ts
@@ -1,6 +1,6 @@
 import { FileTransforms } from '../../../Transforms.types';
 
-const objcFilesPattern = '*.{h,m,mm}';
+const objcFilesPattern = '*.{h,m,mm,cpp}';
 const swiftFilesPattern = '*.swift';
 
 export function expoModulesTransforms(prefix: string): FileTransforms {
@@ -30,7 +30,7 @@ export function expoModulesTransforms(prefix: string): FileTransforms {
       },
       {
         // Prefix symbols and imports.
-        find: /\b(EX|UM|RCT)/g,
+        find: /\b(EX|UM|RCT|ExpoBridgeModule)/g,
         replaceWith: `${prefix}$1`,
       },
 
@@ -43,8 +43,8 @@ export function expoModulesTransforms(prefix: string): FileTransforms {
       },
       {
         paths: swiftFilesPattern,
-        find: /@objc\((Expo|EX|EAS)\)/g,
-        replaceWith: `@objc(${prefix}$1)`,
+        find: /@objc\((Expo|EX|EAS)/g,
+        replaceWith: `@objc(${prefix}$1`,
       },
       {
         paths: swiftFilesPattern,
@@ -97,8 +97,8 @@ export function expoModulesTransforms(prefix: string): FileTransforms {
       {
         // Prefixes imports from other React Native libs
         paths: objcFilesPattern,
-        find: new RegExp(`#import <(ReactCommon|jsi)/(${prefix})?`, 'g'),
-        replaceWith: `#import <${prefix}$1/${prefix}`,
+        find: new RegExp(`#(import|include) <(ReactCommon|jsi)/(${prefix})?`, 'g'),
+        replaceWith: `#$1 <${prefix}$2/${prefix}`,
       },
       {
         // Prefixes versionable namespaces

--- a/tools/src/versioning/ios/transforms/podspecTransforms.ts
+++ b/tools/src/versioning/ios/transforms/podspecTransforms.ts
@@ -55,8 +55,15 @@ export function podspecTransforms(versionName: string): TransformPipeline {
       {
         // Fixes HEADER_SEARCH_PATHS
         paths: ['React-Core.podspec', 'ReactCommon.podspec'],
-        replace: /(Headers\/Private\/)(React-Core)/g,
-        with: `$1${versionName}$2`,
+        replace: /(Headers\/Private\/|_BUILD_DIR\)\/)(React-)(Core|bridging)/g,
+        with: `$1${versionName}$2$3`,
+      },
+
+      // React-bridging
+      {
+        paths: 'React-bridging.podspec',
+        replace: /\bheader_mappings_dir\s*=\s*"."/,
+        with: 'header_mappings_dir    = "react/bridging"',
       },
 
       // React-cxxreact

--- a/tools/src/versioning/ios/transforms/postTransforms.ts
+++ b/tools/src/versioning/ios/transforms/postTransforms.ts
@@ -71,6 +71,12 @@ export function postTransforms(versionName: string): TransformPipeline {
         replace: /@interface (\w+) \((CertificateAdditions|Private)\)/g,
         with: `@interface $1 (${versionName}$2)`,
       },
+      {
+        // Fix prefixing imports from React-bridging
+        paths: 'ReactCommon',
+        replace: new RegExp(`(React)\\/${versionName}(bridging)\\/`, 'g'),
+        with: `$1/$2/${versionName}`,
+      },
 
       // Universal modules
       {
@@ -96,7 +102,11 @@ export function postTransforms(versionName: string): TransformPipeline {
         with: `${versionName}NSDictionary+$1.h`,
       },
       {
-        paths: [`${versionName}EXNotifications`, `${versionName}EXAppState`],
+        paths: [
+          `${versionName}EXNotifications`,
+          `${versionName}EXAppState`,
+          `${versionName}EXVersionManager`,
+        ],
         replace: new RegExp(`EXModuleRegistryHolder${versionName}React`, 'g'),
         with: 'EXModuleRegistryHolderReact',
       },

--- a/tools/src/versioning/ios/transforms/vendoredModulesTransforms.ts
+++ b/tools/src/versioning/ios/transforms/vendoredModulesTransforms.ts
@@ -139,7 +139,7 @@ export default function vendoredModulesTransformsFactory(prefix: string): Config
         {
           // `RNG*` symbols are already prefixed at this point,
           // but there are some new symbols in RNGH that don't have "G".
-          paths: '*.{h,m}',
+          paths: '*.{h,m,mm}',
           find: /\bRN(\w+?)\b/g,
           replaceWith: `${prefix}RN$1`,
         },

--- a/tools/src/versioning/ios/versionVendoredModules.ts
+++ b/tools/src/versioning/ios/versionVendoredModules.ts
@@ -111,7 +111,7 @@ function baseTransformsFactory(prefix: string): Required<FileTransforms> {
         replaceWith: `$1${prefix}$2`,
       },
       {
-        find: /\b(RCT|RNC|RNG|RNR|REA|RNS)(\w+)\b/g,
+        find: /\b(RCT|RNC|RNG|RNR|REA|RNS|YG)(\w+)\b/g,
         replaceWith: `${prefix}$1$2`,
       },
       {
@@ -123,9 +123,9 @@ function baseTransformsFactory(prefix: string): Required<FileTransforms> {
         replaceWith: `${prefix}React::`,
       },
       {
-        find: /using namespace (facebook|react)/g,
+        find: /namespace (facebook|react)/g,
         replaceWith: (_, p1) => {
-          return `using namespace ${prefix}${p1 === 'react' ? 'React' : p1}`;
+          return `namespace ${prefix}${p1 === 'react' ? 'React' : p1}`;
         },
       },
       {


### PR DESCRIPTION
# Why

Versioning CI job was failing for a long time: https://github.com/expo/expo/runs/7268398459

# How

Added appropriate rules to fix below issues:
- The new pod `React-bridging` was not being versioned at all
- `.cpp` files in `expo-modules-core` were not transformed
- `ExpoBridgeModule` was not transformed in Objective-C
- Some `#include`s were not versioned
- `YGValue` in `react-native-safe-area-context` was missing the prefix

# Test Plan

`et add-sdk -s 46.0.0 -p ios` succeeds and then Expo Go builds as expected