### PR TITLE
[github] README: update link to Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <a aria-label="Join our forums" href="https://forums.expo.dev" target="_blank">
     <img alt="Forums" src="https://img.shields.io/badge/Ask%20Questions%20-blue.svg?style=flat-square&logo=discourse&logoWidth=15&labelColor=000000&color=4630EB" />
   </a>
-  <a aria-label="Join our Discord" href="https://discord.gg/4gtbPAdpaE" target="_blank">
+  <a aria-label="Join our Discord" href="https://chat.expo.dev" target="_blank">
     <img alt="Discord" src="https://img.shields.io/discord/695411232856997968.svg?style=flat-square&labelColor=000000&color=4630EB&logo=discord&logoColor=FFFFFF&label=" />
   </a>
   <a aria-label="Expo is free to use" href="https://github.com/expo/expo/blob/main/LICENSE" target="_blank">


### PR DESCRIPTION
# Why

Fixes #18207

# How

Change the old invite link with dedicated subdomain - https://chat.expo.dev.

# Test Plan

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
