### PR TITLE
[image-picker] Fix missing `Promise` converter error

### DIFF
--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
@@ -68,7 +68,7 @@ class ImagePickerModule : Module() {
       launchContract({ imageLibraryLauncher.launch(contractOptions) }, options)
     }
 
-    AsyncFunction("getPendingResultAsync") Coroutine { _: Promise ->
+    AsyncFunction("getPendingResultAsync") Coroutine { ->
       val (bareResult, options) = pendingMediaPickingResult ?: return@Coroutine null
 
       pendingMediaPickingResult = null


### PR DESCRIPTION
# Why

Fixes missing `Promise` converter error in the `image-picker` module.

# How

Suspend functions can't receive promises.
