### PR TITLE
[tools] Update the module template on publish

### DIFF
--- a/tools/src/publish-packages/tasks/publishPackagesPipeline.ts
+++ b/tools/src/publish-packages/tasks/publishPackagesPipeline.ts
@@ -19,6 +19,7 @@ import { selectPackagesToPublish } from './selectPackagesToPublish';
 import { updateAndroidProjects } from './updateAndroidProjects';
 import { updateBundledNativeModulesFile } from './updateBundledNativeModulesFile';
 import { updateIosProjects } from './updateIosProjects';
+import { updateModuleTemplate } from './updateModuleTemplate';
 import { updatePackageVersions } from './updatePackageVersions';
 import { updateWorkspaceProjects } from './updateWorkspaceProjects';
 
@@ -38,6 +39,7 @@ export const publishPackagesPipeline = new Task<TaskArgs>(
       selectPackagesToPublish,
       updatePackageVersions,
       updateBundledNativeModulesFile,
+      updateModuleTemplate,
       updateWorkspaceProjects,
       updateAndroidProjects,
       updateIosProjects,

--- a/tools/src/publish-packages/tasks/updateModuleTemplate.ts
+++ b/tools/src/publish-packages/tasks/updateModuleTemplate.ts
@@ -1,0 +1,79 @@
+import JsonFile from '@expo/json-file';
+import chalk from 'chalk';
+import path from 'path';
+
+import logger from '../../Logger';
+import { getPackageByName, Package } from '../../Packages';
+import { Task } from '../../TasksRunner';
+import { Parcel, TaskArgs } from '../types';
+import { selectPackagesToPublish } from './selectPackagesToPublish';
+
+const { cyan, green } = chalk;
+const MODULE_TEMPLATE_PKG_NAME = 'expo-module-template';
+const TEMPLATE_PACKAGE_JSON_FILENAME = '$package.json';
+const PACKAGES_TO_UPDATE = ['expo-modules-core', 'expo-module-scripts'];
+
+/**
+ * Updates the module template if necessary.
+ */
+export const updateModuleTemplate = new Task<TaskArgs>(
+  {
+    name: 'updateModuleTemplate',
+    dependsOn: [selectPackagesToPublish],
+    filesToStage: [`packages/${MODULE_TEMPLATE_PKG_NAME}/${TEMPLATE_PACKAGE_JSON_FILENAME}`],
+  },
+  async (parcels: Parcel[]) => {
+    logger.info('\n🆙 Updating the module template...');
+
+    const dependencies = parcels.filter((parcel) =>
+      PACKAGES_TO_UPDATE.includes(parcel.pkg.packageName)
+    );
+
+    if (dependencies.length === 0) {
+      logger.debug('Yay, there is no need to update the module template 🥳');
+      return;
+    }
+
+    const moduleTemplatePkg = getPackageByName(MODULE_TEMPLATE_PKG_NAME);
+
+    if (!moduleTemplatePkg) {
+      logger.error(
+        `❗️ Unable to find the module template package: ${green(MODULE_TEMPLATE_PKG_NAME)}`
+      );
+      return;
+    }
+
+    await updateTemplatePackageJsonAsync(moduleTemplatePkg, dependencies);
+  }
+);
+
+async function updateTemplatePackageJsonAsync(
+  templatePkg: Package,
+  dependencies: Parcel[]
+): Promise<void> {
+  const packageJsonPath = path.join(templatePkg.path, TEMPLATE_PACKAGE_JSON_FILENAME);
+  const packageJson = await JsonFile.readAsync(packageJsonPath);
+
+  for (const { pkg, state } of dependencies) {
+    const newVersion = state.releaseVersion;
+    const oldVersion = packageJson.devDependencies?.[pkg.packageName];
+
+    if (!newVersion || !oldVersion || oldVersion === newVersion) {
+      continue;
+    }
+
+    const newVersionRange = '^' + newVersion;
+
+    logger.log(
+      `   Updating dev dependency on ${green(pkg.packageName)}:`,
+      `${cyan.bold(oldVersion)} -> ${cyan.bold(newVersionRange)}`
+    );
+
+    if (packageJson.devDependencies) {
+      packageJson.devDependencies[pkg.packageName] = newVersionRange;
+    }
+  }
+
+  // Save the template for package.json
+  await JsonFile.writeAsync(packageJsonPath, packageJson);
+}


### PR DESCRIPTION
# Why

The `expo-module-template` package contains a templated version for `package.json` (named `$package.json`) which needs to be updated when `expo-modules-core` or `expo-module-scripts` are going to be published.
Closes ENG-5484

# How

Added another task to the publish script that updates the `$package.json` file. The implementation is kinda simple and naive — we can make it more generic in the future, but for now it seems to be enough.

# Test Plan

`et publish expo-modules-core --dry` has updated `expo-modules-core` to `^0.12.0` in `$package.json` 
