### PR TITLE
[contributing] Update Java version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ Manual smoke tests are included in `apps/native-component-list`, this is a good 
    - Ensures your computer is set up for React Native (will install the Android NDK if it's not present)
    - Downloads the Node packages (`yarn install`)
 
-   Make sure that you're using Java 8 (e.g. OpenJDK 1.8.0_292). `ANDROID_SDK_ROOT`, `ANDROID_NDK_HOME` environmental variables should be set or configured via `local.properties` file in `android` folder of the native project you're working with.
+   Make sure that you're using Java 11 (e.g. Azul Zulu JDK 11.0.15+10). `ANDROID_SDK_ROOT` environmental variable should be set or configured via `local.properties` file in `android` folder of the native project you're working with.
 
 6. Navigate to the bare sandbox project `cd apps/bare-expo`
 7. Run the project on any platform (maybe start with web; it's the fastest! 😁)


### PR DESCRIPTION
# Why

https://github.com/expo/expo/pull/18177#issuecomment-1181641955

We use Java 11 and the guide is misleading

# How

- Changed to Java 11, suggested the Azul Zulu JDK as it is recommended for RN by many people. ([article](https://shift.infinite.red/dont-use-the-wrong-jdk-for-react-native-if-you-re-using-an-m1-mac-252533dd47a2)) However, I don't have strong opinion here and I'm open to suggestions.
- Also removed the `ANDROID_NDK_HOME` as it is now deprecated.

# Test Plan

None