### PR TITLE
[tools] Ignore packages in __tests__ and __mocks__ directories

### DIFF
--- a/tools/src/Packages.ts
+++ b/tools/src/Packages.ts
@@ -360,7 +360,7 @@ export async function getListOfPackagesAsync(): Promise<Package[]> {
   if (!cachedPackages) {
     const paths = await glob('**/package.json', {
       cwd: PACKAGES_DIR,
-      ignore: ['**/example/**', '**/node_modules/**'],
+      ignore: ['**/example/**', '**/node_modules/**', '**/__tests__/**', '**/__mocks__/**'],
     });
     cachedPackages = paths
       .map((packageJsonPath) => {


### PR DESCRIPTION
# Why

Closes ENG-5652

# How

Added `__tests__` and `__mocks__` directories to the list of ignored directories when looking up for the packages in the repo.

# Test Plan

`et publish -l` no longer lists the `js-config-test` package and `et publish js-config-test` fails because it cannot find the package. Some other expotools commands may change its behavior too, but we never want to do anything with those packages as they are not full-fledged so I think it fixes not only the publish script.
