### PR TITLE
[NCL] Fix AuthSession

### DIFF
--- a/apps/native-component-list/src/screens/AuthSession/AuthSessionScreen.tsx
+++ b/apps/native-component-list/src/screens/AuthSession/AuthSessionScreen.tsx
@@ -24,6 +24,9 @@ const languages = [
   { key: 'nl', value: 'Dutch' },
   { key: 'fi', value: 'Finnish' },
 ];
+
+const PROJECT_NAME_FOR_PROXY = '@community/native-component-list';
+
 export default function AuthSessionScreen() {
   const [useProxy, setProxy] = React.useState<boolean>(false);
   const [usePKCE, setPKCE] = React.useState<boolean>(true);
@@ -64,7 +67,7 @@ export default function AuthSessionScreen() {
             value={language}
             setValue={setLanguage}
           />
-          <H4>ID: @community/native-component-list</H4>
+          <H4>ID: {PROJECT_NAME_FOR_PROXY}</H4>
         </View>
         <H2>Services</H2>
         <AuthSessionProviders
@@ -96,7 +99,7 @@ function AuthSessionProviders(props: {
     path: 'redirect',
     preferLocalhost: Platform.select({ android: false, default: true }),
     useProxy,
-    projectNameForProxy: '@community/native-component-list',
+    projectNameForProxy: PROJECT_NAME_FOR_PROXY,
   });
 
   const options = {
@@ -146,7 +149,7 @@ function Google({ prompt, language, usePKCE }: any) {
     },
     {
       path: 'redirect',
-      projectNameForProxy: '@community/native-component-list',
+      projectNameForProxy: PROJECT_NAME_FOR_PROXY,
       preferLocalhost: true,
     }
   );
@@ -162,7 +165,11 @@ function Google({ prompt, language, usePKCE }: any) {
       request={request}
       title="google"
       result={result}
-      promptAsync={() => promptAsync()}
+      promptAsync={() =>
+        promptAsync({
+          projectNameForProxy: PROJECT_NAME_FOR_PROXY,
+        })
+      }
     />
   );
 }
@@ -178,7 +185,7 @@ function GoogleFirebase({ prompt, language, usePKCE }: any) {
     },
     {
       path: 'redirect',
-      projectNameForProxy: '@community/native-component-list',
+      projectNameForProxy: PROJECT_NAME_FOR_PROXY,
       preferLocalhost: true,
     }
   );
@@ -194,7 +201,11 @@ function GoogleFirebase({ prompt, language, usePKCE }: any) {
       request={request}
       title="google_firebase"
       result={result}
-      promptAsync={() => promptAsync()}
+      promptAsync={() =>
+        promptAsync({
+          projectNameForProxy: PROJECT_NAME_FOR_PROXY,
+        })
+      }
     />
   );
 }
@@ -261,7 +272,11 @@ function Okta({ redirectUri, usePKCE, useProxy }: any) {
       title="okta"
       request={request}
       result={result}
-      promptAsync={promptAsync}
+      promptAsync={() =>
+        promptAsync({
+          projectNameForProxy: PROJECT_NAME_FOR_PROXY,
+        })
+      }
       useProxy={useProxy}
     />
   );
@@ -314,7 +329,11 @@ function Reddit({ redirectUri, prompt, usePKCE, useProxy }: any) {
       title="reddit"
       request={request}
       result={result}
-      promptAsync={promptAsync}
+      promptAsync={() =>
+        promptAsync({
+          projectNameForProxy: PROJECT_NAME_FOR_PROXY,
+        })
+      }
       useProxy={useProxy}
     />
   );
@@ -367,7 +386,13 @@ function Imgur({ redirectUri, prompt, usePKCE, useProxy }: any) {
       title="imgur"
       request={request}
       result={result}
-      promptAsync={() => promptAsync({ useProxy, windowFeatures: { width: 500, height: 750 } })}
+      promptAsync={() =>
+        promptAsync({
+          useProxy,
+          windowFeatures: { width: 500, height: 750 },
+          projectNameForProxy: PROJECT_NAME_FOR_PROXY,
+        })
+      }
       useProxy={useProxy}
     />
   );
@@ -417,7 +442,13 @@ function Github({ redirectUri, prompt, usePKCE, useProxy }: any) {
       title="github"
       request={request}
       result={result}
-      promptAsync={() => promptAsync({ useProxy, windowFeatures: { width: 500, height: 750 } })}
+      promptAsync={() =>
+        promptAsync({
+          useProxy,
+          windowFeatures: { width: 500, height: 750 },
+          projectNameForProxy: PROJECT_NAME_FOR_PROXY,
+        })
+      }
       useProxy={useProxy}
     />
   );
@@ -450,7 +481,11 @@ function Uber({ redirectUri, prompt, usePKCE, useProxy }: any) {
       title="uber"
       request={request}
       result={result}
-      promptAsync={promptAsync}
+      promptAsync={() =>
+        promptAsync({
+          projectNameForProxy: PROJECT_NAME_FOR_PROXY,
+        })
+      }
       useProxy={useProxy}
     />
   );
@@ -502,7 +537,11 @@ function FitBit({ redirectUri, prompt, usePKCE, useProxy }: any) {
       title="fitbit"
       request={request}
       result={result}
-      promptAsync={promptAsync}
+      promptAsync={() =>
+        promptAsync({
+          projectNameForProxy: PROJECT_NAME_FOR_PROXY,
+        })
+      }
       useProxy={useProxy}
     />
   );
@@ -519,7 +558,7 @@ function Facebook({ usePKCE, useProxy, language }: any) {
     {
       path: 'redirect',
       preferLocalhost: true,
-      projectNameForProxy: '@community/native-component-list',
+      projectNameForProxy: PROJECT_NAME_FOR_PROXY,
       useProxy,
     }
   );
@@ -530,7 +569,11 @@ function Facebook({ usePKCE, useProxy, language }: any) {
       title="facebook"
       request={request}
       result={result}
-      promptAsync={() => promptAsync()}
+      promptAsync={() =>
+        promptAsync({
+          projectNameForProxy: PROJECT_NAME_FOR_PROXY,
+        })
+      }
     />
   );
 }
@@ -563,7 +606,11 @@ function Slack({ redirectUri, prompt, usePKCE, useProxy }: any) {
       title="slack"
       request={request}
       result={result}
-      promptAsync={promptAsync}
+      promptAsync={() =>
+        promptAsync({
+          projectNameForProxy: PROJECT_NAME_FOR_PROXY,
+        })
+      }
       useProxy={useProxy}
     />
   );
@@ -594,7 +641,11 @@ function Spotify({ redirectUri, prompt, usePKCE, useProxy }: any) {
       title="spotify"
       request={request}
       result={result}
-      promptAsync={promptAsync}
+      promptAsync={() =>
+        promptAsync({
+          projectNameForProxy: PROJECT_NAME_FOR_PROXY,
+        })
+      }
       useProxy={useProxy}
     />
   );
@@ -640,7 +691,11 @@ function Strava({ redirectUri, prompt, usePKCE, useProxy }: any) {
       title="strava"
       request={request}
       result={result}
-      promptAsync={promptAsync}
+      promptAsync={() =>
+        promptAsync({
+          projectNameForProxy: PROJECT_NAME_FOR_PROXY,
+        })
+      }
       useProxy={useProxy}
     />
   );
@@ -665,7 +720,11 @@ function Identity({ redirectUri, prompt, useProxy }: any) {
       title="identity4"
       request={request}
       result={result}
-      promptAsync={promptAsync}
+      promptAsync={() =>
+        promptAsync({
+          projectNameForProxy: PROJECT_NAME_FOR_PROXY,
+        })
+      }
       useProxy={useProxy}
     />
   );
@@ -695,7 +754,11 @@ function Coinbase({ redirectUri, prompt, usePKCE, useProxy }: any) {
       title="coinbase"
       request={request}
       result={result}
-      promptAsync={promptAsync}
+      promptAsync={() =>
+        promptAsync({
+          projectNameForProxy: PROJECT_NAME_FOR_PROXY,
+        })
+      }
       useProxy={useProxy}
     />
   );
@@ -724,7 +787,11 @@ function Dropbox({ redirectUri, prompt, usePKCE, useProxy }: any) {
       title="dropbox"
       request={request}
       result={result}
-      promptAsync={promptAsync}
+      promptAsync={() =>
+        promptAsync({
+          projectNameForProxy: PROJECT_NAME_FOR_PROXY,
+        })
+      }
       useProxy={useProxy}
     />
   );
@@ -752,7 +819,11 @@ function Twitch({ redirectUri, prompt, usePKCE, useProxy }: any) {
       title="twitch"
       request={request}
       result={result}
-      promptAsync={promptAsync}
+      promptAsync={() =>
+        promptAsync({
+          projectNameForProxy: PROJECT_NAME_FOR_PROXY,
+        })
+      }
       useProxy={useProxy}
     />
   );


### PR DESCRIPTION
# Why

sdk 46 unversioned qa found that AuthSession doesn't work

# How

follow up with [01095ed7962617c0cd2ed531e2514f7108319f3d](https://github.com/expo/expo/commit/01095ed7962617c0cd2ed531e2514f7108319f3d) that furthers add `projectNameForProxy` to the promptAsync options

# Test Plan

unversioned android expo go + NCL auth session

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
