### PR TITLE
[tools] fix android versioning

### DIFF
--- a/tools/src/versioning/android/copyExpoview.ts
+++ b/tools/src/versioning/android/copyExpoview.ts
@@ -33,24 +33,20 @@ export async function copyExpoviewAsync(sdkVersion: string, androidDir: string):
   }
 
   const settingsGradlePath = path.join(androidDir, 'settings.gradle');
-  const settingsGradle = await fs.readFile(settingsGradlePath, 'utf-8');
+  let settingsGradle = await fs.readFile(settingsGradlePath, 'utf-8');
   if (!settingsGradle.match(abiVersion)) {
-    await fs.writeFile(
-      settingsGradlePath,
-      settingsGradle.replace(
-        /ADD_NEW_SUPPORTED_ABIS_HERE/,
-        `ADD_NEW_SUPPORTED_ABIS_HERE\n    "${abiVersion}",`
-      )
+    settingsGradle = settingsGradle.replace(
+      /ADD_NEW_SUPPORTED_ABIS_HERE/,
+      `ADD_NEW_SUPPORTED_ABIS_HERE\n    "${abiVersion}",`
     );
   }
   const vendoredLinking = `useVendoredModulesForSettingsGradle('sdk${sdkVersion.split('.')[0]}')`;
   if (!settingsGradle.match(vendoredLinking)) {
-    await fs.writeFile(
-      settingsGradlePath,
-      settingsGradle.replace(
-        /(^useVendoredModulesForSettingsGradle\('unversioned'\))/gm,
-        `$1\n${vendoredLinking}`
-      )
+    settingsGradle = settingsGradle.replace(
+      /(^useVendoredModulesForSettingsGradle\('unversioned'\))/gm,
+      `$1\n${vendoredLinking}`
     );
   }
+
+  await fs.writeFile(settingsGradlePath, settingsGradle);
 }

--- a/tools/src/versioning/android/versionCxx/patches/expo-modules-core.patch
+++ b/tools/src/versioning/android/versionCxx/patches/expo-modules-core.patch
@@ -119,23 +119,23 @@ diff --git a/packages/expo-modules-core/android/src/main/cpp/JNIFunctionBody.cpp
 index ae14c3396a..c2fe1fce5f 100644
 --- a/packages/expo-modules-core/android/src/main/cpp/JNIFunctionBody.cpp
 +++ b/packages/expo-modules-core/android/src/main/cpp/JNIFunctionBody.cpp
-@@ -13,7 +13,7 @@ JNIFunctionBody::invoke(jni::local_ref<jni::JArrayClass<jobject>> &&args) {
+@@ -14,7 +14,7 @@
    // Because of that, it can't be cached - we will try to invoke the nonexistent method
    // if we receive an object of a different class than the one used to obtain the method id.
    // The only cacheable method id can be obtain from the base class.
 -  static const auto method = jni::findClassLocal("expo/modules/kotlin/jni/JNIFunctionBody")
 +  static const auto method = jni::findClassLocal("{VERSIONED_ABI_NAME}/expo/modules/kotlin/jni/JNIFunctionBody")
-     ->getMethod<
-       react::ReadableNativeArray::javaobject(jni::local_ref<jni::JArrayClass<jobject>>)
-     >(
-@@ -32,7 +32,7 @@ void JNIAsyncFunctionBody::invoke(
+     ->getMethod<jni::local_ref<react::ReadableNativeArray::javaobject>(jobjectArray)>(
+       "invoke",
+       "([Ljava/lang/Object;)Lcom/facebook/react/bridge/ReadableNativeArray;"
+@@ -32,7 +32,7 @@
    // Because of that, it can't be cached - we will try to invoke the nonexistent method
    // if we receive an object of a different class than the one used to obtain the method id.
    // The only cacheable method id can be obtain from the base class.
 -  static const auto method = jni::findClassLocal("expo/modules/kotlin/jni/JNIAsyncFunctionBody")
 +  static const auto method = jni::findClassLocal("{VERSIONED_ABI_NAME}/expo/modules/kotlin/jni/JNIAsyncFunctionBody")
      ->getMethod<
-       void(jni::local_ref<jni::JArrayClass<jobject>>, jobject)
+       void(jobjectArray , jobject)
      >(
 diff --git a/packages/expo-modules-core/android/src/main/cpp/JNIFunctionBody.h b/packages/expo-modules-core/android/src/main/cpp/JNIFunctionBody.h
 index 4d86132af1..b96eeb3303 100644

--- a/tools/src/versioning/android/versionVendoredModules.ts
+++ b/tools/src/versioning/android/versionVendoredModules.ts
@@ -191,8 +191,8 @@ async function baseTransformsFactoryAsync(prefix: string): Promise<Required<File
     path: [
       {
         // For package renaming, src/main/java/* -> src/main/java/abiN/*
-        find: /\/java\//,
-        replaceWith: `/java/${prefix}/`,
+        find: /\/(java|kotlin)\//,
+        replaceWith: `/$1/${prefix}/`,
       },
     ],
     content: [
@@ -218,7 +218,7 @@ async function baseTransformsFactoryAsync(prefix: string): Promise<Required<File
       },
       {
         paths: 'build.gradle',
-        find: `implementation 'com.facebook.react:react-native:+'`,
+        find: /\b(compileOnly|implementation)\s+['"]com.facebook.react:react-native:.+['"]/gm,
         replaceWith:
           `implementation 'host.exp:reactandroid-${prefix}:1.0.0'` +
           '\n' +


### PR DESCRIPTION
# Why

fix for sdk46 android versioning

# How

- fix that settings.gradle content be overwrote from my change of vendoring skia
- update expo-modules-core patch
- fix vendor modules versioning for @shopify/flash-list

# Test Plan

1. `et add-sdk -p android -s 46.0.0`
2. versioned android expo go + sdk46 ncl launch test

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
