### PR TITLE
[splash-screen] fix splash screen doesn't show when reloading apps

### DIFF
--- a/ios/Exponent/Kernel/Views/EXAppViewController.m
+++ b/ios/Exponent/Kernel/Views/EXAppViewController.m
@@ -384,6 +384,7 @@ NS_ASSUME_NONNULL_BEGIN
     dispatch_once(&once, ^{
       UIViewController *rootViewController = [UIApplication sharedApplication].keyWindow.rootViewController;
       [splashScreenService hideSplashScreenFor:rootViewController
+                                       options:EXSplashScreenDefault
                                successCallback:^(BOOL hasEffect){}
                                failureCallback:^(NSString * _Nonnull message) {
         EXLogWarn(@"Hiding splash screen from root view controller did not succeed: %@", message);
@@ -395,6 +396,7 @@ NS_ASSUME_NONNULL_BEGIN
   dispatch_async(dispatch_get_main_queue(), ^{
     EX_ENSURE_STRONGIFY(self);
     [splashScreenService showSplashScreenFor:self
+                                     options:EXSplashScreenDefault
                     splashScreenViewProvider:provider
                              successCallback:hideRootViewControllerSplashScreen
                              failureCallback:^(NSString *message){ EXLogWarn(@"%@", message); }];
@@ -415,6 +417,7 @@ NS_ASSUME_NONNULL_BEGIN
     self.managedSplashScreenController = [[EXManagedAppSplashScreenViewController alloc] initWithRootView:rootView
                                                                                                  splashScreenView:splashScreenView];
     [splashScreenService showSplashScreenFor:self
+                                     options:EXSplashScreenDefault
                       splashScreenController:self.managedSplashScreenController
                              successCallback:^{}
                              failureCallback:^(NSString *message){ EXLogWarn(@"%@", message); }];

--- a/packages/expo-splash-screen/CHANGELOG.md
+++ b/packages/expo-splash-screen/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed splash screen not showing when reloading apps on iOS. ([#18229](https://github.com/expo/expo/pull/18229) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 0.16.0 — 2022-07-07

--- a/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenModule.m
+++ b/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenModule.m
@@ -39,6 +39,7 @@ EX_EXPORT_METHOD_AS(hideAsync,
     EX_ENSURE_STRONGIFY(self);
     UIViewController *currentViewController = [self reactViewController];
     [[self splashScreenService] hideSplashScreenFor:currentViewController
+                                            options:EXSplashScreenDefault
                                     successCallback:^(BOOL hasEffect){ resolve(@(hasEffect)); }
                                     failureCallback:^(NSString *message){ reject(@"ERR_SPLASH_SCREEN_CANNOT_HIDE", message, nil); }];
   });
@@ -53,6 +54,7 @@ EX_EXPORT_METHOD_AS(preventAutoHideAsync,
     EX_ENSURE_STRONGIFY(self);
     UIViewController *currentViewController = [self reactViewController];
     [[self splashScreenService] preventSplashScreenAutoHideFor:currentViewController
+                                                       options:EXSplashScreenDefault
                                                successCallback:^(BOOL hasEffect){ resolve(@(hasEffect)); }
                                                failureCallback:^(NSString *message){ reject(@"ERR_SPLASH_SCREEN_CANNOT_PREVENT_AUTOHIDE", message, nil); }];
   });

--- a/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenService.h
+++ b/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenService.h
@@ -8,6 +8,14 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef NS_OPTIONS(NSUInteger, EXSplashScreenOptions) {
+  EXSplashScreenDefault = 0,
+
+  // Show splash screen even it was already shown before.
+  // e.g. show splash screen again when reloading apps,
+  EXSplashScreenForceShow = 1 << 0,
+};
+
 /**
 * Entry point for handling SplashScreen associated mechanism.
 * This class has state based on the following relation { ViewController -> ApplicationSplashScreenState }.
@@ -18,13 +26,15 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Overloaded method. See main method below.
  */
-- (void)showSplashScreenFor:(UIViewController *)viewController;
+- (void)showSplashScreenFor:(UIViewController *)viewController
+                    options:(EXSplashScreenOptions)options;
 
 /**
  * Entry point for SplashScreen unimodule.
  * Registers SplashScreen for given viewController and presents it in that viewController.
  */
 - (void)showSplashScreenFor:(UIViewController *)viewController
+                    options:(EXSplashScreenOptions)options
    splashScreenViewProvider:(id<EXSplashScreenViewProvider>)splashScreenViewProvider
             successCallback:(void (^)(void))successCallback
             failureCallback:(void (^)(NSString *message))failureCallback;
@@ -34,6 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Registers SplashScreen for given viewController and EXSplashController and presents it in that viewController.
  */
 -(void)showSplashScreenFor:(UIViewController *)viewController
+                   options:(EXSplashScreenOptions)options
     splashScreenController:(EXSplashScreenViewController *)splashScreenController
            successCallback:(void (^)(void))successCallback
            failureCallback:(void (^)(NSString *message))failureCallback;
@@ -42,6 +53,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Hides SplashScreen for given viewController.
  */
 - (void)hideSplashScreenFor:(UIViewController *)viewController
+                    options:(EXSplashScreenOptions)options
             successCallback:(void (^)(BOOL hasEffect))successCallback
             failureCallback:(void (^)(NSString *message))failureCallback;
 
@@ -49,6 +61,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Prevents SplashScreen from default autohiding.
  */
 - (void)preventSplashScreenAutoHideFor:(UIViewController *)viewController
+                               options:(EXSplashScreenOptions)options
                        successCallback:(void (^)(BOOL hasEffect))successCallback
                        failureCallback:(void (^)(NSString *message))failureCallback;
 

--- a/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenService.m
+++ b/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenService.m
@@ -36,9 +36,11 @@ EX_REGISTER_SINGLETON_MODULE(SplashScreen);
 }
 
 - (void)showSplashScreenFor:(UIViewController *)viewController
+                    options:(EXSplashScreenOptions)options
 {
   id<EXSplashScreenViewProvider> splashScreenViewProvider = [EXSplashScreenViewNativeProvider new];
   return [self showSplashScreenFor:viewController
+                           options:options
           splashScreenViewProvider:splashScreenViewProvider
                    successCallback:^{}
                    failureCallback:^(NSString *message){ EXLogWarn(@"%@", message); }];
@@ -46,11 +48,12 @@ EX_REGISTER_SINGLETON_MODULE(SplashScreen);
 
 
 - (void)showSplashScreenFor:(UIViewController *)viewController
+                    options:(EXSplashScreenOptions)options
    splashScreenViewProvider:(id<EXSplashScreenViewProvider>)splashScreenViewProvider
             successCallback:(void (^)(void))successCallback
             failureCallback:(void (^)(NSString * _Nonnull))failureCallback
 {
-  if ([self.splashScreenControllers objectForKey:viewController]) {
+  if ((options & EXSplashScreenForceShow) == 0 && [self.splashScreenControllers objectForKey:viewController]) {
     return failureCallback(@"'SplashScreen.show' has already been called for given view controller.");
   }
   
@@ -61,17 +64,19 @@ EX_REGISTER_SINGLETON_MODULE(SplashScreen);
                                                                                                splashScreenView:splashScreenView];
   
   [self showSplashScreenFor:viewController
+                    options:options
      splashScreenController:splashScreenController
             successCallback:successCallback
             failureCallback:failureCallback];
 }
 
 - (void)showSplashScreenFor:(UIViewController *)viewController
+                    options:(EXSplashScreenOptions)options
      splashScreenController:(EXSplashScreenViewController *)splashScreenController
             successCallback:(void (^)(void))successCallback
             failureCallback:(void (^)(NSString * _Nonnull))failureCallback
 {
-  if ([self.splashScreenControllers objectForKey:viewController]) {
+  if ((options & EXSplashScreenForceShow) == 0 && [self.splashScreenControllers objectForKey:viewController]) {
     return failureCallback(@"'SplashScreen.show' has already been called for given view controller.");
   }
   
@@ -81,6 +86,7 @@ EX_REGISTER_SINGLETON_MODULE(SplashScreen);
 }
 
 - (void)preventSplashScreenAutoHideFor:(UIViewController *)viewController
+                               options:(EXSplashScreenOptions)options
                        successCallback:(void (^)(BOOL hasEffect))successCallback
                        failureCallback:(void (^)(NSString * _Nonnull))failureCallback
 {
@@ -93,6 +99,7 @@ EX_REGISTER_SINGLETON_MODULE(SplashScreen);
 }
 
 - (void)hideSplashScreenFor:(UIViewController *)viewController
+                    options:(EXSplashScreenOptions)options
             successCallback:(void (^)(BOOL hasEffect))successCallback
             failureCallback:(void (^)(NSString * _Nonnull))failureCallback
 {
@@ -113,6 +120,7 @@ EX_REGISTER_SINGLETON_MODULE(SplashScreen);
   BOOL needsHide = [[self.splashScreenControllers objectForKey:viewController] needsHideOnAppContentDidAppear];
   if (needsHide) {
     [self hideSplashScreenFor:viewController
+                      options:EXSplashScreenDefault
               successCallback:^(BOOL hasEffect){}
               failureCallback:^(NSString *message){}];
   }
@@ -125,7 +133,9 @@ EX_REGISTER_SINGLETON_MODULE(SplashScreen);
   }
   BOOL needsShow = [[self.splashScreenControllers objectForKey:viewController] needsShowOnAppContentWillReload];
   if (needsShow) {
+    // For reloading apps, specify `EXSplashScreenForceShow` to show splash screen again
     [self showSplashScreenFor:viewController
+                      options:EXSplashScreenForceShow
        splashScreenController:[self.splashScreenControllers objectForKey:viewController]
               successCallback:^{}
               failureCallback:^(NSString *message){}];
@@ -138,7 +148,7 @@ EX_REGISTER_SINGLETON_MODULE(SplashScreen);
 {
   UIViewController *rootViewController = [[application keyWindow] rootViewController];
   if (rootViewController) {
-    [self showSplashScreenFor:rootViewController];
+    [self showSplashScreenFor:rootViewController options:EXSplashScreenDefault];
   }
 
   [self addRootViewControllerListener];
@@ -180,7 +190,7 @@ EX_REGISTER_SINGLETON_MODULE(SplashScreen);
     UIViewController *newRootViewController = change[@"new"];
     if (newRootViewController != nil) {
       [self removeRootViewControllerListener];
-      [self showSplashScreenFor:newRootViewController];
+      [self showSplashScreenFor:newRootViewController options:EXSplashScreenDefault];
       [self addRootViewControllerListener];
     }
   }
@@ -190,9 +200,9 @@ EX_REGISTER_SINGLETON_MODULE(SplashScreen);
       UIViewController *viewController = (UIViewController *)newView.nextResponder;
       // To show splash screen as soon as possible, we do not wait for hiding callback and call showSplashScreen immediately.
       // GCD main queue should keep the calls in sequence.
-      [self hideSplashScreenFor:viewController successCallback:^(BOOL hasEffect){} failureCallback:^(NSString *message){}];
+      [self hideSplashScreenFor:viewController options:EXSplashScreenDefault successCallback:^(BOOL hasEffect){} failureCallback:^(NSString *message){}];
       [self.splashScreenControllers removeObjectForKey:viewController];
-      [self showSplashScreenFor:viewController];
+      [self showSplashScreenFor:viewController options:EXSplashScreenDefault];
     }
   }
 }


### PR DESCRIPTION
# Why

follow up with https://github.com/expo/expo/pull/17592#issuecomment-1141256478 and fix the issue where splash screen doesn't show when reloading apps.
fix #12000

# How

same approach as #17592 but introducing a generic `EXSplashScreenOptions` for the force show feature.

# Test Plan

test with the awesome repro example from #17592: https://github.com/ilyausorov/expo-splash-screen-updates-fix-demo

1. copy the patches to `node_modules/expo-splash-screen`
2. `EXPO_USE_SOURCE=1 pod install`
3. npx expo run:ios

also tested the splash screen functionalities from bare-expo and expo go

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
