### PR TITLE
[home] remove unused retainApolloStore option from signout action

### DIFF
--- a/dev-home-config.json
+++ b/dev-home-config.json
@@ -1,3 +1,3 @@
 {
-  "url": "exp://exp.host/@expo-home-dev/expo-home-dev-51cd3111ab64d39d27cb6399e8e4eece6ec451b9"
+  "url": "exp://exp.host/@expo-home-dev/expo-home-dev-9fa8ed7fbb5f9904f7af54c7d06f86ce1698ef16"
 }

--- a/home/redux/SessionActions.ts
+++ b/home/redux/SessionActions.ts
@@ -15,7 +15,7 @@ export default {
     };
   },
 
-  signOut({ retainApolloStore = false }: { retainApolloStore?: boolean } = {}): AppThunk {
+  signOut(): AppThunk {
     return async (dispatch: AppDispatch) => {
       const session = await LocalStorage.getSessionAsync();
       if (session) {
@@ -30,9 +30,7 @@ export default {
 
       await LocalStorage.clearHistoryAsync();
 
-      if (!retainApolloStore) {
-        ApolloClient.resetStore();
-      }
+      ApolloClient.resetStore();
 
       return dispatch({
         type: 'signOut',


### PR DESCRIPTION
We always want to wipe apollo state after logging out and this option has gone unused for a while, so I figured we should remove it.

I also published dev home so it reflects the state of `main` more accurately.