### PR TITLE
[tools] Various fixes in iOS versioning script

### DIFF
--- a/tools/src/versioning/ios/index.ts
+++ b/tools/src/versioning/ios/index.ts
@@ -1144,14 +1144,16 @@ function _getReactNativeTransformRules(versionPrefix, reactPodName) {
       pattern: `s/\\+${versionPrefix}React/\\+React/g`,
     },
     {
-      // Prefixes all direct references to objects under `facebook` namespace.
+      // Prefixes all direct references to objects under `facebook` and `JS` namespaces.
       // It must be applied before versioning `namespace facebook` so
       // `using namespace facebook::` don't get versioned twice.
-      pattern: `s/facebook::/${versionPrefix}facebook::/g`,
+      flags: '-Ei',
+      pattern: `s/(facebook|JS)::/${versionPrefix}\\1::/g`,
     },
     {
       // Prefixes facebook namespace.
-      pattern: `s/namespace facebook/namespace ${versionPrefix}facebook/g`,
+      flags: '-Ei',
+      pattern: `s/namespace (facebook|JS)/namespace ${versionPrefix}\\1/g`,
     },
     {
       // For UMReactNativeAdapter

--- a/tools/src/versioning/ios/index.ts
+++ b/tools/src/versioning/ios/index.ts
@@ -92,7 +92,7 @@ async function namespaceReactNativeFilesAsync(filenames, versionPrefix, versione
     // filter transformRules to patterns which apply to this dirname
     const filteredTransformRules =
       transformRulesCache[dirname] || _getTransformRulesForDirname(transformRules, dirname);
-    transformRulesCache[dirname] = transformRules;
+    transformRulesCache[dirname] = filteredTransformRules;
 
     // Perform sed find & replace.
     for (const rule of filteredTransformRules) {
@@ -1079,21 +1079,8 @@ function _getReactNativeTransformRules(versionPrefix, reactPodName) {
       pattern: `s/\\([^+]\\)AIR/\\1${versionPrefix}AIR/g`,
     },
     {
-      pattern: `s/\\([^A-Za-z0-9_]\\)EX/\\1${versionPrefix}EX/g`,
-    },
-    {
-      pattern: `s/\\([^A-Za-z0-9_]\\)UM/\\1${versionPrefix}UM/g`,
-    },
-    {
-      pattern: `s/\\([^A-Za-z0-9_+]\\)ART/\\1${versionPrefix}ART/g`,
-    },
-    {
-      paths: 'Components',
-      pattern: `s/\\([^A-Za-z0-9_+]\\)SM/\\1${versionPrefix}SM/g`,
-    },
-    {
-      paths: 'Core/Api',
-      pattern: `s/\\([^A-Za-z0-9_+]\\)RN/\\1${versionPrefix}RN/g`,
+      flags: '-Ei',
+      pattern: `s/(^|[^A-Za-z0-9_+])(RN|REA|EX|UM|ART|SM)/\\1${versionPrefix}\\2/g`,
     },
     {
       paths: 'Core/Api',
@@ -1114,10 +1101,6 @@ function _getReactNativeTransformRules(versionPrefix, reactPodName) {
     {
       // React will be prefixed in a moment
       pattern: `s/#import <${versionPrefix}RCTAnimation/#import <React/g`,
-    },
-    {
-      paths: 'Core/Api/Reanimated',
-      pattern: `s/\\([^A-Za-z0-9_+]\\)REA/\\1${versionPrefix}REA/g`,
     },
     {
       pattern: `s/^REA/${versionPrefix}REA/g`,

--- a/tools/src/versioning/ios/transforms/expoModulesTransforms.ts
+++ b/tools/src/versioning/ios/transforms/expoModulesTransforms.ts
@@ -51,6 +51,12 @@ export function expoModulesTransforms(prefix: string): FileTransforms {
         find: /r(eactTag)/gi,
         replaceWith: (_, p1) => `${prefix.toLowerCase()}R${p1}`,
       },
+      {
+        // Prefixes name of the Expo modules provider.
+        paths: swiftFilesPattern,
+        find: /"(ExpoModulesProvider)"/g,
+        replaceWith: `"${prefix}$1"`,
+      },
 
       // Only Objective-C
 
@@ -81,18 +87,6 @@ export function expoModulesTransforms(prefix: string): FileTransforms {
         paths: objcFilesPattern,
         find: /@import (Expo|EX|EAS)(\w+)/g,
         replaceWith: `@import ${prefix}$1$2`,
-      },
-      {
-        // Prefixes Objective-C name of the Swift modules provider.
-        paths: ['EXNativeModulesProxy.mm'],
-        find: 'NSClassFromString(@"ExpoModulesProvider")',
-        replaceWith: `NSClassFromString(@"${prefix}ExpoModulesProvider")`,
-      },
-      {
-        // Prefixes Objective-C name of the Swift modules provider.
-        paths: ['EXNativeModulesProxy.mm'],
-        find: '[NSString stringWithFormat:@"%@.ExpoModulesProvider"',
-        replaceWith: `[NSString stringWithFormat:@"%@.${prefix}ExpoModulesProvider"`,
       },
       {
         // Prefixes imports from other React Native libs

--- a/tools/src/versioning/ios/transforms/postTransforms.ts
+++ b/tools/src/versioning/ios/transforms/postTransforms.ts
@@ -80,7 +80,7 @@ export function postTransforms(versionName: string): TransformPipeline {
       {
         // Codegen adds methods to `RCTCxxConvert` that start with `JS_`, which refer to `JS::`
         // C++ namespace that we prefix, so these methods must be prefixed as well.
-        paths: 'FBReactNativeSpec-generated.mm',
+        paths: ['FBReactNativeSpec.h', 'FBReactNativeSpec-generated.mm'],
         replace: /(RCTManagedPointer \*\))(JS_)/g,
         with: `$1${versionName}$2`,
       },

--- a/tools/src/versioning/ios/transforms/postTransforms.ts
+++ b/tools/src/versioning/ios/transforms/postTransforms.ts
@@ -77,6 +77,13 @@ export function postTransforms(versionName: string): TransformPipeline {
         replace: new RegExp(`(React)\\/${versionName}(bridging)\\/`, 'g'),
         with: `$1/$2/${versionName}`,
       },
+      {
+        // Codegen adds methods to `RCTCxxConvert` that start with `JS_`, which refer to `JS::`
+        // C++ namespace that we prefix, so these methods must be prefixed as well.
+        paths: 'FBReactNativeSpec-generated.mm',
+        replace: /(RCTManagedPointer \*\))(JS_)/g,
+        with: `$1${versionName}$2`,
+      },
 
       // Universal modules
       {

--- a/tools/src/versioning/ios/transforms/vendoredModulesTransforms.ts
+++ b/tools/src/versioning/ios/transforms/vendoredModulesTransforms.ts
@@ -9,11 +9,6 @@ export default function vendoredModulesTransformsFactory(prefix: string): Config
     '@stripe/stripe-react-native': {
       content: [
         {
-          paths: '*.m',
-          find: /RCT_EXTERN_MODULE\((ApplePayButtonManager|CardFieldManager|AuBECSDebitFormManager|StripeSdk|StripeContainerManager|CardFormManager)/,
-          replaceWith: `RCT_EXTERN_REMAP_MODULE($1, ${prefix}$1`,
-        },
-        {
           paths: '',
           find: /\.reactFocus\(/,
           replaceWith: `.${prefix.toLowerCase()}ReactFocus(`,
@@ -22,11 +17,6 @@ export default function vendoredModulesTransformsFactory(prefix: string): Config
     },
     'lottie-react-native': {
       content: [
-        {
-          paths: 'LRNAnimationViewManagerObjC.m',
-          find: /RCT_EXTERN_MODULE\(/,
-          replaceWith: `RCT_EXTERN_REMAP_MODULE(LottieAnimationView, ${prefix}`,
-        },
         {
           paths: 'ContainerView.swift',
           find: /\breactSetFrame/g,

--- a/tools/src/versioning/ios/versionVendoredModules.ts
+++ b/tools/src/versioning/ios/versionVendoredModules.ts
@@ -141,6 +141,14 @@ function baseTransformsFactory(prefix: string): Required<FileTransforms> {
         replaceWith: (_, p1) => `${prefix.toLowerCase()}R${p1}`,
       },
       {
+        // Modules written in Swift are registered using `RCT_EXTERN_MODULE` macro in Objective-C.
+        // These modules are usually unprefixed at this point as they don't include any common prefixes (e.g. RCT, RNC).
+        // We have to remap them to prefixed names. It's necessary for at least Stripe, Lottie and FlashList.
+        paths: '*.m',
+        find: new RegExp(`RCT_EXTERN_MODULE\\((?!${prefix})(\\w+)`, 'g'),
+        replaceWith: `RCT_EXTERN_REMAP_MODULE($1, ${prefix}$1`,
+      },
+      {
         find: /<jsi\/(.*)\.h>/,
         replaceWith: `<${prefix}jsi/${prefix}$1.h>`,
       },


### PR DESCRIPTION
# Why

It turned out that #18205 was not enough 😞 
Fixes ENG-5704

# How

- I've found a bug causing nondeterministic behavior — *sed* transform rules are filtered and cached by directories, but by mistake (I hope so) we cached the unfiltered array, so it's been nondeterministic depending on the order of `readdir` (https://github.com/expo/expo/commit/04aacf509e2b6092c4a72a42d5fa1b947bd5144a)
- Codegen wraps generated symbols into the `JS` C++ namespace. In React Native 0.69, there is some more magic that dynamically calls proper functions from the generated code. Unfortunately, so far we were not prefixing this namespace and it resulted in the issue reported by @FiberJW in ENG-5704. It's not visible in the provided stacktrace, but under the hood the function from SDK44 was called instead of the unversioned one. (https://github.com/expo/expo/commit/3c522f11295aef8e5d2226ef2af6b01557db1f5e)
- The string that refers to the ExpoModulesProvider class needs to be prefixed. The function that is loading this class has been moved to Swift so the rule had to be adjusted. (https://github.com/expo/expo/commit/300141382bc7d24d2509b73dad6c8f7d18d10665)
- FlashList uses mixed ObjC/Swift native module which needs to be properly versioned. We were handling this in Lottie and Stripe, but separately. Now there will be a more generic rule that should cover all vendored libs. (https://github.com/expo/expo/commit/3741697fb4701d18ecaca305ce9921f7295bbce1)

# Test Plan

Tested as part of #18232 
