### PR TITLE
[ios] Backport versioned JS namespace to SDK 44 and 45

### DIFF
--- a/ios/versioned-react-native/ABI44_0_0/ReactNative/Libraries/Image/ABI44_0_0RCTImageEditingManager.mm
+++ b/ios/versioned-react-native/ABI44_0_0/ReactNative/Libraries/Image/ABI44_0_0RCTImageEditingManager.mm
@@ -39,7 +39,7 @@ ABI44_0_0RCT_EXPORT_MODULE()
  *        All units are in px (not points).
  */
 ABI44_0_0RCT_EXPORT_METHOD(cropImage:(NSURLRequest *)imageRequest
-                  cropData:(JS::NativeImageEditor::Options &)cropData
+                  cropData:(ABI44_0_0JS::NativeImageEditor::Options &)cropData
                   successCallback:(ABI44_0_0RCTResponseSenderBlock)successCallback
                   errorCallback:(ABI44_0_0RCTResponseSenderBlock)errorCallback)
 {
@@ -55,7 +55,7 @@ ABI44_0_0RCT_EXPORT_METHOD(cropImage:(NSURLRequest *)imageRequest
   };
   
   // We must keep a copy of cropData so that we can access data from it at a later time
-  JS::NativeImageEditor::Options cropDataCopy = cropData;
+  ABI44_0_0JS::NativeImageEditor::Options cropDataCopy = cropData;
 
   [[_bridge moduleForName:@"ImageLoader" lazilyLoadIfNecessary:YES]
    loadImageWithURLRequest:imageRequest callback:^(NSError *error, UIImage *image) {

--- a/ios/versioned-react-native/ABI44_0_0/ReactNative/Libraries/NativeAnimation/ABI44_0_0RCTNativeAnimatedModule.mm
+++ b/ios/versioned-react-native/ABI44_0_0/ReactNative/Libraries/NativeAnimation/ABI44_0_0RCTNativeAnimatedModule.mm
@@ -213,7 +213,7 @@ ABI44_0_0RCT_EXPORT_METHOD(stopListeningToAnimatedNodeValue:(double)tag)
 
 ABI44_0_0RCT_EXPORT_METHOD(addAnimatedEventToView:(double)viewTag
                   eventName:(nonnull NSString *)eventName
-                  eventMapping:(JS::NativeAnimatedModule::EventMapping &)eventMapping)
+                  eventMapping:(ABI44_0_0JS::NativeAnimatedModule::EventMapping &)eventMapping)
 {
   NSMutableDictionary *eventMappingDict = [NSMutableDictionary new];
   eventMappingDict[@"nativeEventPath"] = ABI44_0_0RCTConvertVecToArray(eventMapping.nativeEventPath());

--- a/ios/versioned-react-native/ABI44_0_0/ReactNative/Libraries/NativeAnimation/ABI44_0_0RCTNativeAnimatedTurboModule.mm
+++ b/ios/versioned-react-native/ABI44_0_0/ReactNative/Libraries/NativeAnimation/ABI44_0_0RCTNativeAnimatedTurboModule.mm
@@ -228,7 +228,7 @@ ABI44_0_0RCT_EXPORT_METHOD(stopListeningToAnimatedNodeValue:(double)tag)
 
 ABI44_0_0RCT_EXPORT_METHOD(addAnimatedEventToView:(double)viewTag
                   eventName:(nonnull NSString *)eventName
-                  eventMapping:(JS::NativeAnimatedModule::EventMapping &)eventMapping)
+                  eventMapping:(ABI44_0_0JS::NativeAnimatedModule::EventMapping &)eventMapping)
 {
   NSMutableDictionary *eventMappingDict = [NSMutableDictionary new];
   eventMappingDict[@"nativeEventPath"] = ABI44_0_0RCTConvertVecToArray(eventMapping.nativeEventPath());

--- a/ios/versioned-react-native/ABI44_0_0/ReactNative/Libraries/Network/ABI44_0_0RCTNetworking.mm
+++ b/ios/versioned-react-native/ABI44_0_0/ReactNative/Libraries/Network/ABI44_0_0RCTNetworking.mm
@@ -668,7 +668,7 @@ ABI44_0_0RCT_EXPORT_MODULE()
 
 #pragma mark - JS API
 
-ABI44_0_0RCT_EXPORT_METHOD(sendRequest:(JS::NativeNetworkingIOS::SpecSendRequestQuery &)query
+ABI44_0_0RCT_EXPORT_METHOD(sendRequest:(ABI44_0_0JS::NativeNetworkingIOS::SpecSendRequestQuery &)query
                   callback:(ABI44_0_0RCTResponseSenderBlock)responseSender)
 {
   NSDictionary *queryDict = @{

--- a/ios/versioned-react-native/ABI44_0_0/ReactNative/Libraries/PushNotificationIOS/ABI44_0_0RCTPushNotificationManager.mm
+++ b/ios/versioned-react-native/ABI44_0_0/ReactNative/Libraries/PushNotificationIOS/ABI44_0_0RCTPushNotificationManager.mm
@@ -284,7 +284,7 @@ ABI44_0_0RCT_EXPORT_METHOD(getApplicationIconBadgeNumber:(ABI44_0_0RCTResponseSe
   callback(@[@(ABI44_0_0RCTSharedApplication().applicationIconBadgeNumber)]);
 }
 
-ABI44_0_0RCT_EXPORT_METHOD(requestPermissions:(JS::NativePushNotificationManagerIOS::SpecRequestPermissionsPermission &)permissions
+ABI44_0_0RCT_EXPORT_METHOD(requestPermissions:(ABI44_0_0JS::NativePushNotificationManagerIOS::SpecRequestPermissionsPermission &)permissions
                  resolve:(ABI44_0_0RCTPromiseResolveBlock)resolve
                  reject:(ABI44_0_0RCTPromiseRejectBlock)reject)
 {
@@ -349,7 +349,7 @@ static inline NSDictionary *ABI44_0_0RCTSettingsDictForUNNotificationSettings(BO
   return @{@"alert": @(alert), @"badge": @(badge), @"sound": @(sound)};
 }
 
-ABI44_0_0RCT_EXPORT_METHOD(presentLocalNotification:(JS::NativePushNotificationManagerIOS::Notification &)notification)
+ABI44_0_0RCT_EXPORT_METHOD(presentLocalNotification:(ABI44_0_0JS::NativePushNotificationManagerIOS::Notification &)notification)
 {
   NSMutableDictionary *notificationDict = [NSMutableDictionary new];
   notificationDict[@"alertTitle"] = notification.alertTitle();
@@ -370,7 +370,7 @@ ABI44_0_0RCT_EXPORT_METHOD(presentLocalNotification:(JS::NativePushNotificationM
   [ABI44_0_0RCTSharedApplication() presentLocalNotificationNow:[ABI44_0_0RCTConvert UILocalNotification:notificationDict]];
 }
 
-ABI44_0_0RCT_EXPORT_METHOD(scheduleLocalNotification:(JS::NativePushNotificationManagerIOS::Notification &)notification)
+ABI44_0_0RCT_EXPORT_METHOD(scheduleLocalNotification:(ABI44_0_0JS::NativePushNotificationManagerIOS::Notification &)notification)
 {
   NSMutableDictionary *notificationDict = [NSMutableDictionary new];
   notificationDict[@"alertTitle"] = notification.alertTitle();
@@ -488,7 +488,7 @@ ABI44_0_0RCT_EXPORT_METHOD(getApplicationIconBadgeNumber:(ABI44_0_0RCTResponseSe
   ABI44_0_0RCTLogError(@"Not implemented: %@", NSStringFromSelector(_cmd));
 }
 
-ABI44_0_0RCT_EXPORT_METHOD(requestPermissions:(JS::NativePushNotificationManagerIOS::SpecRequestPermissionsPermission &)permissions
+ABI44_0_0RCT_EXPORT_METHOD(requestPermissions:(ABI44_0_0JS::NativePushNotificationManagerIOS::SpecRequestPermissionsPermission &)permissions
                  resolve:(ABI44_0_0RCTPromiseResolveBlock)resolve
                  reject:(ABI44_0_0RCTPromiseRejectBlock)reject)
 {
@@ -505,12 +505,12 @@ ABI44_0_0RCT_EXPORT_METHOD(checkPermissions:(ABI44_0_0RCTResponseSenderBlock)cal
   ABI44_0_0RCTLogError(@"Not implemented: %@", NSStringFromSelector(_cmd));
 }
 
-ABI44_0_0RCT_EXPORT_METHOD(presentLocalNotification:(JS::NativePushNotificationManagerIOS::Notification &)notification)
+ABI44_0_0RCT_EXPORT_METHOD(presentLocalNotification:(ABI44_0_0JS::NativePushNotificationManagerIOS::Notification &)notification)
 {
   ABI44_0_0RCTLogError(@"Not implemented: %@", NSStringFromSelector(_cmd));
 }
 
-ABI44_0_0RCT_EXPORT_METHOD(scheduleLocalNotification:(JS::NativePushNotificationManagerIOS::Notification &)notification)
+ABI44_0_0RCT_EXPORT_METHOD(scheduleLocalNotification:(ABI44_0_0JS::NativePushNotificationManagerIOS::Notification &)notification)
 {
   ABI44_0_0RCTLogError(@"Not implemented: %@", NSStringFromSelector(_cmd));
 }

--- a/ios/versioned-react-native/ABI44_0_0/ReactNative/Libraries/Settings/ABI44_0_0RCTSettingsManager.mm
+++ b/ios/versioned-react-native/ABI44_0_0/ReactNative/Libraries/Settings/ABI44_0_0RCTSettingsManager.mm
@@ -52,14 +52,14 @@ ABI44_0_0RCT_EXPORT_MODULE()
   return self;
 }
 
-- (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<JS::NativeSettingsManager::Constants>)constantsToExport
+- (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<ABI44_0_0JS::NativeSettingsManager::Constants>)constantsToExport
 {
-  return (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<JS::NativeSettingsManager::Constants>)[self getConstants];
+  return (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<ABI44_0_0JS::NativeSettingsManager::Constants>)[self getConstants];
 }
 
-- (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<JS::NativeSettingsManager::Constants>)getConstants
+- (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<ABI44_0_0JS::NativeSettingsManager::Constants>)getConstants
 {
-  return ABI44_0_0facebook::ABI44_0_0React::typedConstants<JS::NativeSettingsManager::Constants>({
+  return ABI44_0_0facebook::ABI44_0_0React::typedConstants<ABI44_0_0JS::NativeSettingsManager::Constants>({
     .settings = ABI44_0_0RCTJSONClean([_defaults dictionaryRepresentation])
   });
 }

--- a/ios/versioned-react-native/ABI44_0_0/ReactNative/Libraries/TypeSafety/ABI44_0_0RCTTypedModuleConstants.h
+++ b/ios/versioned-react-native/ABI44_0_0/ReactNative/Libraries/TypeSafety/ABI44_0_0RCTTypedModuleConstants.h
@@ -17,9 +17,9 @@
  *
  * The ABI44_0_0NativeModuleSpec will define a constantsToExport method which you can implement as follows:
  *
- * - (nonnull ModuleConstants<JS::Constants>)constantsToExport
+ * - (nonnull ModuleConstants<ABI44_0_0JS::Constants>)constantsToExport
  * {
- *   return typedConstants<JS::Constants>({ ... });
+ *   return typedConstants<ABI44_0_0JS::Constants>({ ... });
  * }
  */
 

--- a/ios/versioned-react-native/ABI44_0_0/ReactNative/React/Base/ABI44_0_0RCTModuleMethod.mm
+++ b/ios/versioned-react-native/ABI44_0_0/ReactNative/React/Base/ABI44_0_0RCTModuleMethod.mm
@@ -371,7 +371,7 @@ ABI44_0_0RCT_EXTERN_C_END
         NSDictionary *errorJSON = ABI44_0_0RCTJSErrorFromCodeMessageAndNSError(code, message, error);
         [bridge enqueueCallback:json args:@[ errorJSON ]];
       });
-    } else if ([typeName hasPrefix:@"JS::"]) {
+    } else if ([typeName hasPrefix:@"ABI44_0_0JS::"]) {
       NSString *selectorNameForCxxType =
           [[typeName stringByReplacingOccurrencesOfString:@"::" withString:@"_"] stringByAppendingString:@":"];
       selector = NSSelectorFromString(selectorNameForCxxType);

--- a/ios/versioned-react-native/ABI44_0_0/ReactNative/React/CoreModules/ABI44_0_0RCTAccessibilityManager.mm
+++ b/ios/versioned-react-native/ABI44_0_0/ReactNative/React/CoreModules/ABI44_0_0RCTAccessibilityManager.mm
@@ -242,7 +242,7 @@ ABI44_0_0RCT_EXPORT_MODULE()
 }
 
 ABI44_0_0RCT_EXPORT_METHOD(setAccessibilityContentSizeMultipliers
-                  : (JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers &)
+                  : (ABI44_0_0JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers &)
                       JSMultipliers)
 {
   NSMutableDictionary<NSString *, NSNumber *> *multipliers = [NSMutableDictionary new];

--- a/ios/versioned-react-native/ABI44_0_0/ReactNative/React/CoreModules/ABI44_0_0RCTActionSheetManager.mm
+++ b/ios/versioned-react-native/ABI44_0_0/ReactNative/React/CoreModules/ABI44_0_0RCTActionSheetManager.mm
@@ -56,7 +56,7 @@ ABI44_0_0RCT_EXPORT_MODULE()
 }
 
 ABI44_0_0RCT_EXPORT_METHOD(showActionSheetWithOptions
-                  : (JS::NativeActionSheetManager::SpecShowActionSheetWithOptionsOptions &)options callback
+                  : (ABI44_0_0JS::NativeActionSheetManager::SpecShowActionSheetWithOptionsOptions &)options callback
                   : (ABI44_0_0RCTResponseSenderBlock)callback)
 {
   if (ABI44_0_0RCTRunningInAppExtension()) {
@@ -170,7 +170,7 @@ ABI44_0_0RCT_EXPORT_METHOD(showActionSheetWithOptions
 }
 
 ABI44_0_0RCT_EXPORT_METHOD(showShareActionSheetWithOptions
-                  : (JS::NativeActionSheetManager::SpecShowShareActionSheetWithOptionsOptions &)options failureCallback
+                  : (ABI44_0_0JS::NativeActionSheetManager::SpecShowShareActionSheetWithOptionsOptions &)options failureCallback
                   : (ABI44_0_0RCTResponseSenderBlock)failureCallback successCallback
                   : (ABI44_0_0RCTResponseSenderBlock)successCallback)
 {

--- a/ios/versioned-react-native/ABI44_0_0/ReactNative/React/CoreModules/ABI44_0_0RCTAlertManager.mm
+++ b/ios/versioned-react-native/ABI44_0_0/ReactNative/React/CoreModules/ABI44_0_0RCTAlertManager.mm
@@ -68,7 +68,7 @@ ABI44_0_0RCT_EXPORT_MODULE()
  * The key from the `buttons` dictionary is passed back in the callback on click.
  * Buttons are displayed in the order they are specified.
  */
-ABI44_0_0RCT_EXPORT_METHOD(alertWithArgs : (JS::NativeAlertManager::Args &)args callback : (ABI44_0_0RCTResponseSenderBlock)callback)
+ABI44_0_0RCT_EXPORT_METHOD(alertWithArgs : (ABI44_0_0JS::NativeAlertManager::Args &)args callback : (ABI44_0_0RCTResponseSenderBlock)callback)
 {
   NSString *title = [ABI44_0_0RCTConvert NSString:args.title()];
   NSString *message = [ABI44_0_0RCTConvert NSString:args.message()];

--- a/ios/versioned-react-native/ABI44_0_0/ReactNative/React/CoreModules/ABI44_0_0RCTAppState.mm
+++ b/ios/versioned-react-native/ABI44_0_0/ReactNative/React/CoreModules/ABI44_0_0RCTAppState.mm
@@ -49,16 +49,16 @@ ABI44_0_0RCT_EXPORT_MODULE()
   return dispatch_get_main_queue();
 }
 
-- (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<JS::NativeAppState::Constants>)constantsToExport
+- (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<ABI44_0_0JS::NativeAppState::Constants>)constantsToExport
 {
-  return (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<JS::NativeAppState::Constants>)[self getConstants];
+  return (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<ABI44_0_0JS::NativeAppState::Constants>)[self getConstants];
 }
 
-- (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<JS::NativeAppState::Constants>)getConstants
+- (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<ABI44_0_0JS::NativeAppState::Constants>)getConstants
 {
-  __block ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<JS::NativeAppState::Constants> constants;
+  __block ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<ABI44_0_0JS::NativeAppState::Constants> constants;
   ABI44_0_0RCTUnsafeExecuteOnMainQueueSync(^{
-    constants = ABI44_0_0facebook::ABI44_0_0React::typedConstants<JS::NativeAppState::Constants>({
+    constants = ABI44_0_0facebook::ABI44_0_0React::typedConstants<ABI44_0_0JS::NativeAppState::Constants>({
         .initialAppState = ABI44_0_0RCTCurrentAppState(),
     });
   });

--- a/ios/versioned-react-native/ABI44_0_0/ReactNative/React/CoreModules/ABI44_0_0RCTExceptionsManager.mm
+++ b/ios/versioned-react-native/ABI44_0_0/ReactNative/React/CoreModules/ABI44_0_0RCTExceptionsManager.mm
@@ -132,7 +132,7 @@ ABI44_0_0RCT_EXPORT_METHOD(reportUnhandledException : (NSString *)message stack 
 
 ABI44_0_0RCT_EXPORT_METHOD(dismissRedbox) {}
 
-ABI44_0_0RCT_EXPORT_METHOD(reportException : (JS::NativeExceptionsManager::ExceptionData &)data)
+ABI44_0_0RCT_EXPORT_METHOD(reportException : (ABI44_0_0JS::NativeExceptionsManager::ExceptionData &)data)
 {
   NSString *message = data.message();
   double exceptionId = data.id_();

--- a/ios/versioned-react-native/ABI44_0_0/ReactNative/React/CoreModules/ABI44_0_0RCTPlatform.mm
+++ b/ios/versioned-react-native/ABI44_0_0/ReactNative/React/CoreModules/ABI44_0_0RCTPlatform.mm
@@ -51,24 +51,24 @@ ABI44_0_0RCT_EXPORT_MODULE(PlatformConstants)
 }
 
 // TODO: Use the generated struct return type.
-- (ModuleConstants<JS::NativePlatformConstantsIOS::Constants>)constantsToExport
+- (ModuleConstants<ABI44_0_0JS::NativePlatformConstantsIOS::Constants>)constantsToExport
 {
-  return (ModuleConstants<JS::NativePlatformConstantsIOS::Constants>)[self getConstants];
+  return (ModuleConstants<ABI44_0_0JS::NativePlatformConstantsIOS::Constants>)[self getConstants];
 }
 
-- (ModuleConstants<JS::NativePlatformConstantsIOS::Constants>)getConstants
+- (ModuleConstants<ABI44_0_0JS::NativePlatformConstantsIOS::Constants>)getConstants
 {
-  __block ModuleConstants<JS::NativePlatformConstantsIOS::Constants> constants;
+  __block ModuleConstants<ABI44_0_0JS::NativePlatformConstantsIOS::Constants> constants;
   ABI44_0_0RCTUnsafeExecuteOnMainQueueSync(^{
     UIDevice *device = [UIDevice currentDevice];
     auto versions = ABI44_0_0RCTGetreactNativeVersion();
-    constants = typedConstants<JS::NativePlatformConstantsIOS::Constants>({
+    constants = typedConstants<ABI44_0_0JS::NativePlatformConstantsIOS::Constants>({
         .forceTouchAvailable = ABI44_0_0RCTForceTouchAvailable() ? true : false,
         .osVersion = [device systemVersion],
         .systemName = [device systemName],
         .interfaceIdiom = interfaceIdiom([device userInterfaceIdiom]),
         .isTesting = ABI44_0_0RCTRunningInTestEnvironment() ? true : false,
-        .reactNativeVersion = JS::NativePlatformConstantsIOS::ConstantsreactNativeVersion::Builder(
+        .reactNativeVersion = ABI44_0_0JS::NativePlatformConstantsIOS::ConstantsreactNativeVersion::Builder(
             {.minor = [versions[@"minor"] doubleValue],
              .major = [versions[@"major"] doubleValue],
              .patch = [versions[@"patch"] doubleValue],

--- a/ios/versioned-react-native/ABI44_0_0/ReactNative/React/CoreModules/ABI44_0_0RCTStatusBarManager.mm
+++ b/ios/versioned-react-native/ABI44_0_0/ReactNative/React/CoreModules/ABI44_0_0RCTStatusBarManager.mm
@@ -175,11 +175,11 @@ ABI44_0_0RCT_EXPORT_METHOD(setNetworkActivityIndicatorVisible : (BOOL)visible)
   ABI44_0_0RCTSharedApplication().networkActivityIndicatorVisible = visible;
 }
 
-- (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<JS::NativeStatusBarManagerIOS::Constants>)getConstants
+- (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<ABI44_0_0JS::NativeStatusBarManagerIOS::Constants>)getConstants
 {
-  __block ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<JS::NativeStatusBarManagerIOS::Constants> constants;
+  __block ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<ABI44_0_0JS::NativeStatusBarManagerIOS::Constants> constants;
   ABI44_0_0RCTUnsafeExecuteOnMainQueueSync(^{
-    constants = ABI44_0_0facebook::ABI44_0_0React::typedConstants<JS::NativeStatusBarManagerIOS::Constants>({
+    constants = ABI44_0_0facebook::ABI44_0_0React::typedConstants<ABI44_0_0JS::NativeStatusBarManagerIOS::Constants>({
         .HEIGHT = ABI44_0_0RCTSharedApplication().statusBarFrame.size.height,
         .DEFAULT_BACKGROUND_COLOR = folly::none,
     });
@@ -188,9 +188,9 @@ ABI44_0_0RCT_EXPORT_METHOD(setNetworkActivityIndicatorVisible : (BOOL)visible)
   return constants;
 }
 
-- (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<JS::NativeStatusBarManagerIOS::Constants>)constantsToExport
+- (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<ABI44_0_0JS::NativeStatusBarManagerIOS::Constants>)constantsToExport
 {
-  return (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<JS::NativeStatusBarManagerIOS::Constants>)[self getConstants];
+  return (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<ABI44_0_0JS::NativeStatusBarManagerIOS::Constants>)[self getConstants];
 }
 
 - (std::shared_ptr<ABI44_0_0facebook::ABI44_0_0React::TurboModule>)getTurboModule:

--- a/ios/versioned-react-native/ABI44_0_0/ReactNative/React/CoreModules/ABI44_0_0RCTWebSocketModule.mm
+++ b/ios/versioned-react-native/ABI44_0_0/ReactNative/React/CoreModules/ABI44_0_0RCTWebSocketModule.mm
@@ -65,7 +65,7 @@ ABI44_0_0RCT_EXPORT_MODULE()
 ABI44_0_0RCT_EXPORT_METHOD(connect
                   : (NSURL *)URL protocols
                   : (NSArray *)protocols options
-                  : (JS::NativeWebSocketModule::SpecConnectOptions &)options socketID
+                  : (ABI44_0_0JS::NativeWebSocketModule::SpecConnectOptions &)options socketID
                   : (double)socketID)
 {
   NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:URL];

--- a/ios/versioned-react-native/ABI44_0_0/ReactNative/React/FBReactNativeSpec/FBReactNativeSpec/ABI44_0_0FBReactNativeSpec-generated.mm
+++ b/ios/versioned-react-native/ABI44_0_0/ReactNative/React/FBReactNativeSpec/FBReactNativeSpec/ABI44_0_0FBReactNativeSpec-generated.mm
@@ -51,9 +51,9 @@ namespace ABI44_0_0facebook {
   } // namespace ABI44_0_0React
 } // namespace ABI44_0_0facebook
 @implementation ABI44_0_0RCTCxxConvert (NativeAccessibilityManager_SpecSetAccessibilityContentSizeMultipliersJSMultipliers)
-+ (ABI44_0_0RCTManagedPointer *)JS_NativeAccessibilityManager_SpecSetAccessibilityContentSizeMultipliersJSMultipliers:(id)json
++ (ABI44_0_0RCTManagedPointer *)ABI44_0_0JS_NativeAccessibilityManager_SpecSetAccessibilityContentSizeMultipliersJSMultipliers:(id)json
 {
-  return ABI44_0_0facebook::ABI44_0_0React::managedPointer<JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers>(json);
+  return ABI44_0_0facebook::ABI44_0_0React::managedPointer<ABI44_0_0JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers>(json);
 }
 @end
 namespace ABI44_0_0facebook {
@@ -117,7 +117,7 @@ namespace ABI44_0_0facebook {
         
         
         methodMap_["setAccessibilityContentSizeMultipliers"] = MethodMetadata {1, __hostFunction_NativeAccessibilityManagerSpecJSI_setAccessibilityContentSizeMultipliers};
-        setMethodArgConversionSelector(@"setAccessibilityContentSizeMultipliers", 0, @"JS_NativeAccessibilityManager_SpecSetAccessibilityContentSizeMultipliersJSMultipliers:");
+        setMethodArgConversionSelector(@"setAccessibilityContentSizeMultipliers", 0, @"ABI44_0_0JS_NativeAccessibilityManager_SpecSetAccessibilityContentSizeMultipliersJSMultipliers:");
         
         methodMap_["setAccessibilityFocus"] = MethodMetadata {1, __hostFunction_NativeAccessibilityManagerSpecJSI_setAccessibilityFocus};
         
@@ -128,15 +128,15 @@ namespace ABI44_0_0facebook {
   } // namespace ABI44_0_0React
 } // namespace ABI44_0_0facebook
 @implementation ABI44_0_0RCTCxxConvert (NativeActionSheetManager_SpecShowActionSheetWithOptionsOptions)
-+ (ABI44_0_0RCTManagedPointer *)JS_NativeActionSheetManager_SpecShowActionSheetWithOptionsOptions:(id)json
++ (ABI44_0_0RCTManagedPointer *)ABI44_0_0JS_NativeActionSheetManager_SpecShowActionSheetWithOptionsOptions:(id)json
 {
-  return ABI44_0_0facebook::ABI44_0_0React::managedPointer<JS::NativeActionSheetManager::SpecShowActionSheetWithOptionsOptions>(json);
+  return ABI44_0_0facebook::ABI44_0_0React::managedPointer<ABI44_0_0JS::NativeActionSheetManager::SpecShowActionSheetWithOptionsOptions>(json);
 }
 @end
 @implementation ABI44_0_0RCTCxxConvert (NativeActionSheetManager_SpecShowShareActionSheetWithOptionsOptions)
-+ (ABI44_0_0RCTManagedPointer *)JS_NativeActionSheetManager_SpecShowShareActionSheetWithOptionsOptions:(id)json
++ (ABI44_0_0RCTManagedPointer *)ABI44_0_0JS_NativeActionSheetManager_SpecShowShareActionSheetWithOptionsOptions:(id)json
 {
-  return ABI44_0_0facebook::ABI44_0_0React::managedPointer<JS::NativeActionSheetManager::SpecShowShareActionSheetWithOptionsOptions>(json);
+  return ABI44_0_0facebook::ABI44_0_0React::managedPointer<ABI44_0_0JS::NativeActionSheetManager::SpecShowShareActionSheetWithOptionsOptions>(json);
 }
 @end
 namespace ABI44_0_0facebook {
@@ -154,17 +154,17 @@ namespace ABI44_0_0facebook {
       : ObjCTurboModule(params) {
         
         methodMap_["showActionSheetWithOptions"] = MethodMetadata {2, __hostFunction_NativeActionSheetManagerSpecJSI_showActionSheetWithOptions};
-        setMethodArgConversionSelector(@"showActionSheetWithOptions", 0, @"JS_NativeActionSheetManager_SpecShowActionSheetWithOptionsOptions:");
+        setMethodArgConversionSelector(@"showActionSheetWithOptions", 0, @"ABI44_0_0JS_NativeActionSheetManager_SpecShowActionSheetWithOptionsOptions:");
         
         methodMap_["showShareActionSheetWithOptions"] = MethodMetadata {3, __hostFunction_NativeActionSheetManagerSpecJSI_showShareActionSheetWithOptions};
-        setMethodArgConversionSelector(@"showShareActionSheetWithOptions", 0, @"JS_NativeActionSheetManager_SpecShowShareActionSheetWithOptionsOptions:");
+        setMethodArgConversionSelector(@"showShareActionSheetWithOptions", 0, @"ABI44_0_0JS_NativeActionSheetManager_SpecShowShareActionSheetWithOptionsOptions:");
     }
   } // namespace ABI44_0_0React
 } // namespace ABI44_0_0facebook
 @implementation ABI44_0_0RCTCxxConvert (NativeAlertManager_Args)
-+ (ABI44_0_0RCTManagedPointer *)JS_NativeAlertManager_Args:(id)json
++ (ABI44_0_0RCTManagedPointer *)ABI44_0_0JS_NativeAlertManager_Args:(id)json
 {
-  return ABI44_0_0facebook::ABI44_0_0React::managedPointer<JS::NativeAlertManager::Args>(json);
+  return ABI44_0_0facebook::ABI44_0_0React::managedPointer<ABI44_0_0JS::NativeAlertManager::Args>(json);
 }
 @end
 namespace ABI44_0_0facebook {
@@ -178,14 +178,14 @@ namespace ABI44_0_0facebook {
       : ObjCTurboModule(params) {
         
         methodMap_["alertWithArgs"] = MethodMetadata {2, __hostFunction_NativeAlertManagerSpecJSI_alertWithArgs};
-        setMethodArgConversionSelector(@"alertWithArgs", 0, @"JS_NativeAlertManager_Args:");
+        setMethodArgConversionSelector(@"alertWithArgs", 0, @"ABI44_0_0JS_NativeAlertManager_Args:");
     }
   } // namespace ABI44_0_0React
 } // namespace ABI44_0_0facebook
 @implementation ABI44_0_0RCTCxxConvert (NativeAnimatedModule_EventMapping)
-+ (ABI44_0_0RCTManagedPointer *)JS_NativeAnimatedModule_EventMapping:(id)json
++ (ABI44_0_0RCTManagedPointer *)ABI44_0_0JS_NativeAnimatedModule_EventMapping:(id)json
 {
-  return ABI44_0_0facebook::ABI44_0_0React::managedPointer<JS::NativeAnimatedModule::EventMapping>(json);
+  return ABI44_0_0facebook::ABI44_0_0React::managedPointer<ABI44_0_0JS::NativeAnimatedModule::EventMapping>(json);
 }
 @end
 namespace ABI44_0_0facebook {
@@ -337,7 +337,7 @@ namespace ABI44_0_0facebook {
         
         
         methodMap_["addAnimatedEventToView"] = MethodMetadata {3, __hostFunction_NativeAnimatedModuleSpecJSI_addAnimatedEventToView};
-        setMethodArgConversionSelector(@"addAnimatedEventToView", 2, @"JS_NativeAnimatedModule_EventMapping:");
+        setMethodArgConversionSelector(@"addAnimatedEventToView", 2, @"ABI44_0_0JS_NativeAnimatedModule_EventMapping:");
         
         methodMap_["removeAnimatedEventFromView"] = MethodMetadata {3, __hostFunction_NativeAnimatedModuleSpecJSI_removeAnimatedEventFromView};
         
@@ -351,9 +351,9 @@ namespace ABI44_0_0facebook {
   } // namespace ABI44_0_0React
 } // namespace ABI44_0_0facebook
 @implementation ABI44_0_0RCTCxxConvert (NativeAnimatedTurboModule_EventMapping)
-+ (ABI44_0_0RCTManagedPointer *)JS_NativeAnimatedTurboModule_EventMapping:(id)json
++ (ABI44_0_0RCTManagedPointer *)ABI44_0_0JS_NativeAnimatedTurboModule_EventMapping:(id)json
 {
-  return ABI44_0_0facebook::ABI44_0_0React::managedPointer<JS::NativeAnimatedTurboModule::EventMapping>(json);
+  return ABI44_0_0facebook::ABI44_0_0React::managedPointer<ABI44_0_0JS::NativeAnimatedTurboModule::EventMapping>(json);
 }
 @end
 namespace ABI44_0_0facebook {
@@ -505,7 +505,7 @@ namespace ABI44_0_0facebook {
         
         
         methodMap_["addAnimatedEventToView"] = MethodMetadata {3, __hostFunction_NativeAnimatedTurboModuleSpecJSI_addAnimatedEventToView};
-        setMethodArgConversionSelector(@"addAnimatedEventToView", 2, @"JS_NativeAnimatedTurboModule_EventMapping:");
+        setMethodArgConversionSelector(@"addAnimatedEventToView", 2, @"ABI44_0_0JS_NativeAnimatedTurboModule_EventMapping:");
         
         methodMap_["removeAnimatedEventFromView"] = MethodMetadata {3, __hostFunction_NativeAnimatedTurboModuleSpecJSI_removeAnimatedEventFromView};
         
@@ -1023,15 +1023,15 @@ namespace ABI44_0_0facebook {
   } // namespace ABI44_0_0React
 } // namespace ABI44_0_0facebook
 @implementation ABI44_0_0RCTCxxConvert (NativeExceptionsManager_StackFrame)
-+ (ABI44_0_0RCTManagedPointer *)JS_NativeExceptionsManager_StackFrame:(id)json
++ (ABI44_0_0RCTManagedPointer *)ABI44_0_0JS_NativeExceptionsManager_StackFrame:(id)json
 {
-  return ABI44_0_0facebook::ABI44_0_0React::managedPointer<JS::NativeExceptionsManager::StackFrame>(json);
+  return ABI44_0_0facebook::ABI44_0_0React::managedPointer<ABI44_0_0JS::NativeExceptionsManager::StackFrame>(json);
 }
 @end
 @implementation ABI44_0_0RCTCxxConvert (NativeExceptionsManager_ExceptionData)
-+ (ABI44_0_0RCTManagedPointer *)JS_NativeExceptionsManager_ExceptionData:(id)json
++ (ABI44_0_0RCTManagedPointer *)ABI44_0_0JS_NativeExceptionsManager_ExceptionData:(id)json
 {
-  return ABI44_0_0facebook::ABI44_0_0React::managedPointer<JS::NativeExceptionsManager::ExceptionData>(json);
+  return ABI44_0_0facebook::ABI44_0_0React::managedPointer<ABI44_0_0JS::NativeExceptionsManager::ExceptionData>(json);
 }
 @end
 namespace ABI44_0_0facebook {
@@ -1067,7 +1067,7 @@ namespace ABI44_0_0facebook {
         
         
         methodMap_["reportException"] = MethodMetadata {1, __hostFunction_NativeExceptionsManagerSpecJSI_reportException};
-        setMethodArgConversionSelector(@"reportException", 0, @"JS_NativeExceptionsManager_ExceptionData:");
+        setMethodArgConversionSelector(@"reportException", 0, @"ABI44_0_0JS_NativeExceptionsManager_ExceptionData:");
         
         methodMap_["updateExceptionMessage"] = MethodMetadata {3, __hostFunction_NativeExceptionsManagerSpecJSI_updateExceptionMessage};
         
@@ -1101,9 +1101,9 @@ namespace ABI44_0_0facebook {
   } // namespace ABI44_0_0React
 } // namespace ABI44_0_0facebook
 @implementation ABI44_0_0RCTCxxConvert (NativeFrameRateLogger_SpecSetGlobalOptionsOptions)
-+ (ABI44_0_0RCTManagedPointer *)JS_NativeFrameRateLogger_SpecSetGlobalOptionsOptions:(id)json
++ (ABI44_0_0RCTManagedPointer *)ABI44_0_0JS_NativeFrameRateLogger_SpecSetGlobalOptionsOptions:(id)json
 {
-  return ABI44_0_0facebook::ABI44_0_0React::managedPointer<JS::NativeFrameRateLogger::SpecSetGlobalOptionsOptions>(json);
+  return ABI44_0_0facebook::ABI44_0_0React::managedPointer<ABI44_0_0JS::NativeFrameRateLogger::SpecSetGlobalOptionsOptions>(json);
 }
 @end
 namespace ABI44_0_0facebook {
@@ -1129,7 +1129,7 @@ namespace ABI44_0_0facebook {
       : ObjCTurboModule(params) {
         
         methodMap_["setGlobalOptions"] = MethodMetadata {1, __hostFunction_NativeFrameRateLoggerSpecJSI_setGlobalOptions};
-        setMethodArgConversionSelector(@"setGlobalOptions", 0, @"JS_NativeFrameRateLogger_SpecSetGlobalOptionsOptions:");
+        setMethodArgConversionSelector(@"setGlobalOptions", 0, @"ABI44_0_0JS_NativeFrameRateLogger_SpecSetGlobalOptionsOptions:");
         
         methodMap_["setContext"] = MethodMetadata {1, __hostFunction_NativeFrameRateLoggerSpecJSI_setContext};
         
@@ -1203,27 +1203,27 @@ namespace ABI44_0_0facebook {
   } // namespace ABI44_0_0React
 } // namespace ABI44_0_0facebook
 @implementation ABI44_0_0RCTCxxConvert (NativeImageEditor_OptionsOffset)
-+ (ABI44_0_0RCTManagedPointer *)JS_NativeImageEditor_OptionsOffset:(id)json
++ (ABI44_0_0RCTManagedPointer *)ABI44_0_0JS_NativeImageEditor_OptionsOffset:(id)json
 {
-  return ABI44_0_0facebook::ABI44_0_0React::managedPointer<JS::NativeImageEditor::OptionsOffset>(json);
+  return ABI44_0_0facebook::ABI44_0_0React::managedPointer<ABI44_0_0JS::NativeImageEditor::OptionsOffset>(json);
 }
 @end
 @implementation ABI44_0_0RCTCxxConvert (NativeImageEditor_OptionsSize)
-+ (ABI44_0_0RCTManagedPointer *)JS_NativeImageEditor_OptionsSize:(id)json
++ (ABI44_0_0RCTManagedPointer *)ABI44_0_0JS_NativeImageEditor_OptionsSize:(id)json
 {
-  return ABI44_0_0facebook::ABI44_0_0React::managedPointer<JS::NativeImageEditor::OptionsSize>(json);
+  return ABI44_0_0facebook::ABI44_0_0React::managedPointer<ABI44_0_0JS::NativeImageEditor::OptionsSize>(json);
 }
 @end
 @implementation ABI44_0_0RCTCxxConvert (NativeImageEditor_OptionsDisplaySize)
-+ (ABI44_0_0RCTManagedPointer *)JS_NativeImageEditor_OptionsDisplaySize:(id)json
++ (ABI44_0_0RCTManagedPointer *)ABI44_0_0JS_NativeImageEditor_OptionsDisplaySize:(id)json
 {
-  return ABI44_0_0facebook::ABI44_0_0React::managedPointer<JS::NativeImageEditor::OptionsDisplaySize>(json);
+  return ABI44_0_0facebook::ABI44_0_0React::managedPointer<ABI44_0_0JS::NativeImageEditor::OptionsDisplaySize>(json);
 }
 @end
 @implementation ABI44_0_0RCTCxxConvert (NativeImageEditor_Options)
-+ (ABI44_0_0RCTManagedPointer *)JS_NativeImageEditor_Options:(id)json
++ (ABI44_0_0RCTManagedPointer *)ABI44_0_0JS_NativeImageEditor_Options:(id)json
 {
-  return ABI44_0_0facebook::ABI44_0_0React::managedPointer<JS::NativeImageEditor::Options>(json);
+  return ABI44_0_0facebook::ABI44_0_0React::managedPointer<ABI44_0_0JS::NativeImageEditor::Options>(json);
 }
 @end
 namespace ABI44_0_0facebook {
@@ -1237,7 +1237,7 @@ namespace ABI44_0_0facebook {
       : ObjCTurboModule(params) {
         
         methodMap_["cropImage"] = MethodMetadata {4, __hostFunction_NativeImageEditorSpecJSI_cropImage};
-        setMethodArgConversionSelector(@"cropImage", 1, @"JS_NativeImageEditor_Options:");
+        setMethodArgConversionSelector(@"cropImage", 1, @"ABI44_0_0JS_NativeImageEditor_Options:");
     }
   } // namespace ABI44_0_0React
 } // namespace ABI44_0_0facebook
@@ -1279,15 +1279,15 @@ namespace ABI44_0_0facebook {
   } // namespace ABI44_0_0React
 } // namespace ABI44_0_0facebook
 @implementation ABI44_0_0RCTCxxConvert (NativeImagePickerIOS_SpecOpenCameraDialogConfig)
-+ (ABI44_0_0RCTManagedPointer *)JS_NativeImagePickerIOS_SpecOpenCameraDialogConfig:(id)json
++ (ABI44_0_0RCTManagedPointer *)ABI44_0_0JS_NativeImagePickerIOS_SpecOpenCameraDialogConfig:(id)json
 {
-  return ABI44_0_0facebook::ABI44_0_0React::managedPointer<JS::NativeImagePickerIOS::SpecOpenCameraDialogConfig>(json);
+  return ABI44_0_0facebook::ABI44_0_0React::managedPointer<ABI44_0_0JS::NativeImagePickerIOS::SpecOpenCameraDialogConfig>(json);
 }
 @end
 @implementation ABI44_0_0RCTCxxConvert (NativeImagePickerIOS_SpecOpenSelectDialogConfig)
-+ (ABI44_0_0RCTManagedPointer *)JS_NativeImagePickerIOS_SpecOpenSelectDialogConfig:(id)json
++ (ABI44_0_0RCTManagedPointer *)ABI44_0_0JS_NativeImagePickerIOS_SpecOpenSelectDialogConfig:(id)json
 {
-  return ABI44_0_0facebook::ABI44_0_0React::managedPointer<JS::NativeImagePickerIOS::SpecOpenSelectDialogConfig>(json);
+  return ABI44_0_0facebook::ABI44_0_0React::managedPointer<ABI44_0_0JS::NativeImagePickerIOS::SpecOpenSelectDialogConfig>(json);
 }
 @end
 namespace ABI44_0_0facebook {
@@ -1327,10 +1327,10 @@ namespace ABI44_0_0facebook {
         
         
         methodMap_["openCameraDialog"] = MethodMetadata {3, __hostFunction_NativeImagePickerIOSSpecJSI_openCameraDialog};
-        setMethodArgConversionSelector(@"openCameraDialog", 0, @"JS_NativeImagePickerIOS_SpecOpenCameraDialogConfig:");
+        setMethodArgConversionSelector(@"openCameraDialog", 0, @"ABI44_0_0JS_NativeImagePickerIOS_SpecOpenCameraDialogConfig:");
         
         methodMap_["openSelectDialog"] = MethodMetadata {3, __hostFunction_NativeImagePickerIOSSpecJSI_openSelectDialog};
-        setMethodArgConversionSelector(@"openSelectDialog", 0, @"JS_NativeImagePickerIOS_SpecOpenSelectDialogConfig:");
+        setMethodArgConversionSelector(@"openSelectDialog", 0, @"ABI44_0_0JS_NativeImagePickerIOS_SpecOpenSelectDialogConfig:");
         
         methodMap_["clearAllPendingVideos"] = MethodMetadata {0, __hostFunction_NativeImagePickerIOSSpecJSI_clearAllPendingVideos};
         
@@ -1560,9 +1560,9 @@ namespace ABI44_0_0facebook {
   } // namespace ABI44_0_0React
 } // namespace ABI44_0_0facebook
 @implementation ABI44_0_0RCTCxxConvert (NativeNetworkingIOS_SpecSendRequestQuery)
-+ (ABI44_0_0RCTManagedPointer *)JS_NativeNetworkingIOS_SpecSendRequestQuery:(id)json
++ (ABI44_0_0RCTManagedPointer *)ABI44_0_0JS_NativeNetworkingIOS_SpecSendRequestQuery:(id)json
 {
-  return ABI44_0_0facebook::ABI44_0_0React::managedPointer<JS::NativeNetworkingIOS::SpecSendRequestQuery>(json);
+  return ABI44_0_0facebook::ABI44_0_0React::managedPointer<ABI44_0_0JS::NativeNetworkingIOS::SpecSendRequestQuery>(json);
 }
 @end
 namespace ABI44_0_0facebook {
@@ -1592,7 +1592,7 @@ namespace ABI44_0_0facebook {
       : ObjCTurboModule(params) {
         
         methodMap_["sendRequest"] = MethodMetadata {2, __hostFunction_NativeNetworkingIOSSpecJSI_sendRequest};
-        setMethodArgConversionSelector(@"sendRequest", 0, @"JS_NativeNetworkingIOS_SpecSendRequestQuery:");
+        setMethodArgConversionSelector(@"sendRequest", 0, @"ABI44_0_0JS_NativeNetworkingIOS_SpecSendRequestQuery:");
         
         methodMap_["abortRequest"] = MethodMetadata {1, __hostFunction_NativeNetworkingIOSSpecJSI_abortRequest};
         
@@ -1625,15 +1625,15 @@ namespace ABI44_0_0facebook {
   } // namespace ABI44_0_0React
 } // namespace ABI44_0_0facebook
 @implementation ABI44_0_0RCTCxxConvert (NativePushNotificationManagerIOS_SpecRequestPermissionsPermission)
-+ (ABI44_0_0RCTManagedPointer *)JS_NativePushNotificationManagerIOS_SpecRequestPermissionsPermission:(id)json
++ (ABI44_0_0RCTManagedPointer *)ABI44_0_0JS_NativePushNotificationManagerIOS_SpecRequestPermissionsPermission:(id)json
 {
-  return ABI44_0_0facebook::ABI44_0_0React::managedPointer<JS::NativePushNotificationManagerIOS::SpecRequestPermissionsPermission>(json);
+  return ABI44_0_0facebook::ABI44_0_0React::managedPointer<ABI44_0_0JS::NativePushNotificationManagerIOS::SpecRequestPermissionsPermission>(json);
 }
 @end
 @implementation ABI44_0_0RCTCxxConvert (NativePushNotificationManagerIOS_Notification)
-+ (ABI44_0_0RCTManagedPointer *)JS_NativePushNotificationManagerIOS_Notification:(id)json
++ (ABI44_0_0RCTManagedPointer *)ABI44_0_0JS_NativePushNotificationManagerIOS_Notification:(id)json
 {
-  return ABI44_0_0facebook::ABI44_0_0React::managedPointer<JS::NativePushNotificationManagerIOS::Notification>(json);
+  return ABI44_0_0facebook::ABI44_0_0React::managedPointer<ABI44_0_0JS::NativePushNotificationManagerIOS::Notification>(json);
 }
 @end
 namespace ABI44_0_0facebook {
@@ -1720,7 +1720,7 @@ namespace ABI44_0_0facebook {
         
         
         methodMap_["requestPermissions"] = MethodMetadata {1, __hostFunction_NativePushNotificationManagerIOSSpecJSI_requestPermissions};
-        setMethodArgConversionSelector(@"requestPermissions", 0, @"JS_NativePushNotificationManagerIOS_SpecRequestPermissionsPermission:");
+        setMethodArgConversionSelector(@"requestPermissions", 0, @"ABI44_0_0JS_NativePushNotificationManagerIOS_SpecRequestPermissionsPermission:");
         
         methodMap_["abandonPermissions"] = MethodMetadata {0, __hostFunction_NativePushNotificationManagerIOSSpecJSI_abandonPermissions};
         
@@ -1729,10 +1729,10 @@ namespace ABI44_0_0facebook {
         
         
         methodMap_["presentLocalNotification"] = MethodMetadata {1, __hostFunction_NativePushNotificationManagerIOSSpecJSI_presentLocalNotification};
-        setMethodArgConversionSelector(@"presentLocalNotification", 0, @"JS_NativePushNotificationManagerIOS_Notification:");
+        setMethodArgConversionSelector(@"presentLocalNotification", 0, @"ABI44_0_0JS_NativePushNotificationManagerIOS_Notification:");
         
         methodMap_["scheduleLocalNotification"] = MethodMetadata {1, __hostFunction_NativePushNotificationManagerIOSSpecJSI_scheduleLocalNotification};
-        setMethodArgConversionSelector(@"scheduleLocalNotification", 0, @"JS_NativePushNotificationManagerIOS_Notification:");
+        setMethodArgConversionSelector(@"scheduleLocalNotification", 0, @"ABI44_0_0JS_NativePushNotificationManagerIOS_Notification:");
         
         methodMap_["cancelAllLocalNotifications"] = MethodMetadata {0, __hostFunction_NativePushNotificationManagerIOSSpecJSI_cancelAllLocalNotifications};
         
@@ -1840,9 +1840,9 @@ namespace ABI44_0_0facebook {
   } // namespace ABI44_0_0React
 } // namespace ABI44_0_0facebook
 @implementation ABI44_0_0RCTCxxConvert (NativeShareModule_SpecShareContent)
-+ (ABI44_0_0RCTManagedPointer *)JS_NativeShareModule_SpecShareContent:(id)json
++ (ABI44_0_0RCTManagedPointer *)ABI44_0_0JS_NativeShareModule_SpecShareContent:(id)json
 {
-  return ABI44_0_0facebook::ABI44_0_0React::managedPointer<JS::NativeShareModule::SpecShareContent>(json);
+  return ABI44_0_0facebook::ABI44_0_0React::managedPointer<ABI44_0_0JS::NativeShareModule::SpecShareContent>(json);
 }
 @end
 namespace ABI44_0_0facebook {
@@ -1856,7 +1856,7 @@ namespace ABI44_0_0facebook {
       : ObjCTurboModule(params) {
         
         methodMap_["share"] = MethodMetadata {2, __hostFunction_NativeShareModuleSpecJSI_share};
-        setMethodArgConversionSelector(@"share", 0, @"JS_NativeShareModule_SpecShareContent:");
+        setMethodArgConversionSelector(@"share", 0, @"ABI44_0_0JS_NativeShareModule_SpecShareContent:");
     }
   } // namespace ABI44_0_0React
 } // namespace ABI44_0_0facebook
@@ -2011,9 +2011,9 @@ namespace ABI44_0_0facebook {
   } // namespace ABI44_0_0React
 } // namespace ABI44_0_0facebook
 @implementation ABI44_0_0RCTCxxConvert (NativeWebSocketModule_SpecConnectOptions)
-+ (ABI44_0_0RCTManagedPointer *)JS_NativeWebSocketModule_SpecConnectOptions:(id)json
++ (ABI44_0_0RCTManagedPointer *)ABI44_0_0JS_NativeWebSocketModule_SpecConnectOptions:(id)json
 {
-  return ABI44_0_0facebook::ABI44_0_0React::managedPointer<JS::NativeWebSocketModule::SpecConnectOptions>(json);
+  return ABI44_0_0facebook::ABI44_0_0React::managedPointer<ABI44_0_0JS::NativeWebSocketModule::SpecConnectOptions>(json);
 }
 @end
 namespace ABI44_0_0facebook {
@@ -2051,7 +2051,7 @@ namespace ABI44_0_0facebook {
       : ObjCTurboModule(params) {
         
         methodMap_["connect"] = MethodMetadata {4, __hostFunction_NativeWebSocketModuleSpecJSI_connect};
-        setMethodArgConversionSelector(@"connect", 2, @"JS_NativeWebSocketModule_SpecConnectOptions:");
+        setMethodArgConversionSelector(@"connect", 2, @"ABI44_0_0JS_NativeWebSocketModule_SpecConnectOptions:");
         
         methodMap_["send"] = MethodMetadata {2, __hostFunction_NativeWebSocketModuleSpecJSI_send};
         

--- a/ios/versioned-react-native/ABI44_0_0/ReactNative/React/FBReactNativeSpec/FBReactNativeSpec/ABI44_0_0FBReactNativeSpec.h
+++ b/ios/versioned-react-native/ABI44_0_0/ReactNative/React/FBReactNativeSpec/FBReactNativeSpec/ABI44_0_0FBReactNativeSpec.h
@@ -45,7 +45,7 @@ namespace ABI44_0_0facebook {
     };
   } // namespace ABI44_0_0React
 } // namespace ABI44_0_0facebook
-namespace JS {
+namespace ABI44_0_0JS {
   namespace NativeAccessibilityManager {
     struct SpecSetAccessibilityContentSizeMultipliersJSMultipliers {
       folly::Optional<double> extraSmall() const;
@@ -69,7 +69,7 @@ namespace JS {
 }
 
 @interface ABI44_0_0RCTCxxConvert (NativeAccessibilityManager_SpecSetAccessibilityContentSizeMultipliersJSMultipliers)
-+ (ABI44_0_0RCTManagedPointer *)JS_NativeAccessibilityManager_SpecSetAccessibilityContentSizeMultipliersJSMultipliers:(id)json;
++ (ABI44_0_0RCTManagedPointer *)ABI44_0_0JS_NativeAccessibilityManager_SpecSetAccessibilityContentSizeMultipliersJSMultipliers:(id)json;
 @end
 @protocol ABI44_0_0NativeAccessibilityManagerSpec <ABI44_0_0RCTBridgeModule, ABI44_0_0RCTTurboModule>
 
@@ -85,7 +85,7 @@ namespace JS {
                                   onError:(ABI44_0_0RCTResponseSenderBlock)onError;
 - (void)getCurrentVoiceOverState:(ABI44_0_0RCTResponseSenderBlock)onSuccess
                          onError:(ABI44_0_0RCTResponseSenderBlock)onError;
-- (void)setAccessibilityContentSizeMultipliers:(JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers &)JSMultipliers;
+- (void)setAccessibilityContentSizeMultipliers:(ABI44_0_0JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers &)JSMultipliers;
 - (void)setAccessibilityFocus:(double)ABI44_0_0ReactTag;
 - (void)announceForAccessibility:(NSString *)announcement;
 
@@ -101,7 +101,7 @@ namespace ABI44_0_0facebook {
     };
   } // namespace ABI44_0_0React
 } // namespace ABI44_0_0facebook
-namespace JS {
+namespace ABI44_0_0JS {
   namespace NativeActionSheetManager {
     struct SpecShowActionSheetWithOptionsOptions {
       NSString *title() const;
@@ -122,9 +122,9 @@ namespace JS {
 }
 
 @interface ABI44_0_0RCTCxxConvert (NativeActionSheetManager_SpecShowActionSheetWithOptionsOptions)
-+ (ABI44_0_0RCTManagedPointer *)JS_NativeActionSheetManager_SpecShowActionSheetWithOptionsOptions:(id)json;
++ (ABI44_0_0RCTManagedPointer *)ABI44_0_0JS_NativeActionSheetManager_SpecShowActionSheetWithOptionsOptions:(id)json;
 @end
-namespace JS {
+namespace ABI44_0_0JS {
   namespace NativeActionSheetManager {
     struct SpecShowShareActionSheetWithOptionsOptions {
       NSString *message() const;
@@ -143,13 +143,13 @@ namespace JS {
 }
 
 @interface ABI44_0_0RCTCxxConvert (NativeActionSheetManager_SpecShowShareActionSheetWithOptionsOptions)
-+ (ABI44_0_0RCTManagedPointer *)JS_NativeActionSheetManager_SpecShowShareActionSheetWithOptionsOptions:(id)json;
++ (ABI44_0_0RCTManagedPointer *)ABI44_0_0JS_NativeActionSheetManager_SpecShowShareActionSheetWithOptionsOptions:(id)json;
 @end
 @protocol ABI44_0_0NativeActionSheetManagerSpec <ABI44_0_0RCTBridgeModule, ABI44_0_0RCTTurboModule>
 
-- (void)showActionSheetWithOptions:(JS::NativeActionSheetManager::SpecShowActionSheetWithOptionsOptions &)options
+- (void)showActionSheetWithOptions:(ABI44_0_0JS::NativeActionSheetManager::SpecShowActionSheetWithOptionsOptions &)options
                           callback:(ABI44_0_0RCTResponseSenderBlock)callback;
-- (void)showShareActionSheetWithOptions:(JS::NativeActionSheetManager::SpecShowShareActionSheetWithOptionsOptions &)options
+- (void)showShareActionSheetWithOptions:(ABI44_0_0JS::NativeActionSheetManager::SpecShowShareActionSheetWithOptionsOptions &)options
                         failureCallback:(ABI44_0_0RCTResponseSenderBlock)failureCallback
                         successCallback:(ABI44_0_0RCTResponseSenderBlock)successCallback;
 
@@ -165,7 +165,7 @@ namespace ABI44_0_0facebook {
     };
   } // namespace ABI44_0_0React
 } // namespace ABI44_0_0facebook
-namespace JS {
+namespace ABI44_0_0JS {
   namespace NativeAlertManager {
     struct Args {
       NSString *title() const;
@@ -185,11 +185,11 @@ namespace JS {
 }
 
 @interface ABI44_0_0RCTCxxConvert (NativeAlertManager_Args)
-+ (ABI44_0_0RCTManagedPointer *)JS_NativeAlertManager_Args:(id)json;
++ (ABI44_0_0RCTManagedPointer *)ABI44_0_0JS_NativeAlertManager_Args:(id)json;
 @end
 @protocol ABI44_0_0NativeAlertManagerSpec <ABI44_0_0RCTBridgeModule, ABI44_0_0RCTTurboModule>
 
-- (void)alertWithArgs:(JS::NativeAlertManager::Args &)args
+- (void)alertWithArgs:(ABI44_0_0JS::NativeAlertManager::Args &)args
              callback:(ABI44_0_0RCTResponseSenderBlock)callback;
 
 @end
@@ -204,7 +204,7 @@ namespace ABI44_0_0facebook {
     };
   } // namespace ABI44_0_0React
 } // namespace ABI44_0_0facebook
-namespace JS {
+namespace ABI44_0_0JS {
   namespace NativeAnimatedModule {
     struct EventMapping {
       ABI44_0_0facebook::ABI44_0_0React::LazyVector<NSString *> nativeEventPath() const;
@@ -218,7 +218,7 @@ namespace JS {
 }
 
 @interface ABI44_0_0RCTCxxConvert (NativeAnimatedModule_EventMapping)
-+ (ABI44_0_0RCTManagedPointer *)JS_NativeAnimatedModule_EventMapping:(id)json;
++ (ABI44_0_0RCTManagedPointer *)ABI44_0_0JS_NativeAnimatedModule_EventMapping:(id)json;
 @end
 @protocol ABI44_0_0NativeAnimatedModuleSpec <ABI44_0_0RCTBridgeModule, ABI44_0_0RCTTurboModule>
 
@@ -253,7 +253,7 @@ saveValueCallback:(ABI44_0_0RCTResponseSenderBlock)saveValueCallback;
 - (void)dropAnimatedNode:(double)tag;
 - (void)addAnimatedEventToView:(double)viewTag
                      eventName:(NSString *)eventName
-                  eventMapping:(JS::NativeAnimatedModule::EventMapping &)eventMapping;
+                  eventMapping:(ABI44_0_0JS::NativeAnimatedModule::EventMapping &)eventMapping;
 - (void)removeAnimatedEventFromView:(double)viewTag
                           eventName:(NSString *)eventName
                     animatedNodeTag:(double)animatedNodeTag;
@@ -272,7 +272,7 @@ namespace ABI44_0_0facebook {
     };
   } // namespace ABI44_0_0React
 } // namespace ABI44_0_0facebook
-namespace JS {
+namespace ABI44_0_0JS {
   namespace NativeAnimatedTurboModule {
     struct EventMapping {
       ABI44_0_0facebook::ABI44_0_0React::LazyVector<NSString *> nativeEventPath() const;
@@ -286,7 +286,7 @@ namespace JS {
 }
 
 @interface ABI44_0_0RCTCxxConvert (NativeAnimatedTurboModule_EventMapping)
-+ (ABI44_0_0RCTManagedPointer *)JS_NativeAnimatedTurboModule_EventMapping:(id)json;
++ (ABI44_0_0RCTManagedPointer *)ABI44_0_0JS_NativeAnimatedTurboModule_EventMapping:(id)json;
 @end
 @protocol ABI44_0_0NativeAnimatedTurboModuleSpec <ABI44_0_0RCTBridgeModule, ABI44_0_0RCTTurboModule>
 
@@ -321,7 +321,7 @@ saveValueCallback:(ABI44_0_0RCTResponseSenderBlock)saveValueCallback;
 - (void)dropAnimatedNode:(double)tag;
 - (void)addAnimatedEventToView:(double)viewTag
                      eventName:(NSString *)eventName
-                  eventMapping:(JS::NativeAnimatedTurboModule::EventMapping &)eventMapping;
+                  eventMapping:(ABI44_0_0JS::NativeAnimatedTurboModule::EventMapping &)eventMapping;
 - (void)removeAnimatedEventFromView:(double)viewTag
                           eventName:(NSString *)eventName
                     animatedNodeTag:(double)animatedNodeTag;
@@ -358,7 +358,7 @@ namespace ABI44_0_0facebook {
     };
   } // namespace ABI44_0_0React
 } // namespace ABI44_0_0facebook
-namespace JS {
+namespace ABI44_0_0JS {
   namespace NativeAppState {
     struct Constants {
 
@@ -391,8 +391,8 @@ namespace JS {
                      error:(ABI44_0_0RCTResponseSenderBlock)error;
 - (void)addListener:(NSString *)eventName;
 - (void)removeListeners:(double)count;
-- (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<JS::NativeAppState::Constants::Builder>)constantsToExport;
-- (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<JS::NativeAppState::Constants::Builder>)getConstants;
+- (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<ABI44_0_0JS::NativeAppState::Constants::Builder>)constantsToExport;
+- (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<ABI44_0_0JS::NativeAppState::Constants::Builder>)getConstants;
 
 @end
 namespace ABI44_0_0facebook {
@@ -477,7 +477,7 @@ namespace ABI44_0_0facebook {
     };
   } // namespace ABI44_0_0React
 } // namespace ABI44_0_0facebook
-namespace JS {
+namespace ABI44_0_0JS {
   namespace NativeBlobModule {
     struct Constants {
 
@@ -515,8 +515,8 @@ namespace JS {
 - (void)createFromParts:(NSArray *)parts
                  withId:(NSString *)withId;
 - (void)release:(NSString *)blobId;
-- (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<JS::NativeBlobModule::Constants::Builder>)constantsToExport;
-- (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<JS::NativeBlobModule::Constants::Builder>)getConstants;
+- (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<ABI44_0_0JS::NativeBlobModule::Constants::Builder>)constantsToExport;
+- (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<ABI44_0_0JS::NativeBlobModule::Constants::Builder>)getConstants;
 
 @end
 namespace ABI44_0_0facebook {
@@ -673,7 +673,7 @@ namespace ABI44_0_0facebook {
     };
   } // namespace ABI44_0_0React
 } // namespace ABI44_0_0facebook
-namespace JS {
+namespace ABI44_0_0JS {
   namespace NativeDeviceInfo {
     struct DisplayMetrics {
 
@@ -703,7 +703,7 @@ namespace JS {
     };
   }
 }
-namespace JS {
+namespace ABI44_0_0JS {
   namespace NativeDeviceInfo {
     struct DisplayMetricsAndroid {
 
@@ -734,16 +734,16 @@ namespace JS {
     };
   }
 }
-namespace JS {
+namespace ABI44_0_0JS {
   namespace NativeDeviceInfo {
     struct DimensionsPayload {
 
       struct Builder {
         struct Input {
-          folly::Optional<JS::NativeDeviceInfo::DisplayMetrics::Builder> window;
-          folly::Optional<JS::NativeDeviceInfo::DisplayMetrics::Builder> screen;
-          folly::Optional<JS::NativeDeviceInfo::DisplayMetricsAndroid::Builder> windowPhysicalPixels;
-          folly::Optional<JS::NativeDeviceInfo::DisplayMetricsAndroid::Builder> screenPhysicalPixels;
+          folly::Optional<ABI44_0_0JS::NativeDeviceInfo::DisplayMetrics::Builder> window;
+          folly::Optional<ABI44_0_0JS::NativeDeviceInfo::DisplayMetrics::Builder> screen;
+          folly::Optional<ABI44_0_0JS::NativeDeviceInfo::DisplayMetricsAndroid::Builder> windowPhysicalPixels;
+          folly::Optional<ABI44_0_0JS::NativeDeviceInfo::DisplayMetricsAndroid::Builder> screenPhysicalPixels;
         };
 
         /** Initialize with a set of values */
@@ -764,13 +764,13 @@ namespace JS {
     };
   }
 }
-namespace JS {
+namespace ABI44_0_0JS {
   namespace NativeDeviceInfo {
     struct Constants {
 
       struct Builder {
         struct Input {
-          ABI44_0_0RCTRequired<JS::NativeDeviceInfo::DimensionsPayload::Builder> Dimensions;
+          ABI44_0_0RCTRequired<ABI44_0_0JS::NativeDeviceInfo::DimensionsPayload::Builder> Dimensions;
           folly::Optional<bool> isIPhoneX_deprecated;
         };
 
@@ -794,8 +794,8 @@ namespace JS {
 }
 @protocol ABI44_0_0NativeDeviceInfoSpec <ABI44_0_0RCTBridgeModule, ABI44_0_0RCTTurboModule>
 
-- (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<JS::NativeDeviceInfo::Constants::Builder>)constantsToExport;
-- (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<JS::NativeDeviceInfo::Constants::Builder>)getConstants;
+- (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<ABI44_0_0JS::NativeDeviceInfo::Constants::Builder>)constantsToExport;
+- (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<ABI44_0_0JS::NativeDeviceInfo::Constants::Builder>)getConstants;
 
 @end
 namespace ABI44_0_0facebook {
@@ -809,7 +809,7 @@ namespace ABI44_0_0facebook {
     };
   } // namespace ABI44_0_0React
 } // namespace ABI44_0_0facebook
-namespace JS {
+namespace ABI44_0_0JS {
   namespace NativeExceptionsManager {
     struct StackFrame {
       folly::Optional<double> column() const;
@@ -826,16 +826,16 @@ namespace JS {
 }
 
 @interface ABI44_0_0RCTCxxConvert (NativeExceptionsManager_StackFrame)
-+ (ABI44_0_0RCTManagedPointer *)JS_NativeExceptionsManager_StackFrame:(id)json;
++ (ABI44_0_0RCTManagedPointer *)ABI44_0_0JS_NativeExceptionsManager_StackFrame:(id)json;
 @end
-namespace JS {
+namespace ABI44_0_0JS {
   namespace NativeExceptionsManager {
     struct ExceptionData {
       NSString *message() const;
       NSString *originalMessage() const;
       NSString *name() const;
       NSString *componentStack() const;
-      ABI44_0_0facebook::ABI44_0_0React::LazyVector<JS::NativeExceptionsManager::StackFrame> stack() const;
+      ABI44_0_0facebook::ABI44_0_0React::LazyVector<ABI44_0_0JS::NativeExceptionsManager::StackFrame> stack() const;
       double id_() const;
       bool isFatal() const;
       id<NSObject> _Nullable extraData() const;
@@ -848,7 +848,7 @@ namespace JS {
 }
 
 @interface ABI44_0_0RCTCxxConvert (NativeExceptionsManager_ExceptionData)
-+ (ABI44_0_0RCTManagedPointer *)JS_NativeExceptionsManager_ExceptionData:(id)json;
++ (ABI44_0_0RCTManagedPointer *)ABI44_0_0JS_NativeExceptionsManager_ExceptionData:(id)json;
 @end
 @protocol ABI44_0_0NativeExceptionsManagerSpec <ABI44_0_0RCTBridgeModule, ABI44_0_0RCTTurboModule>
 
@@ -858,7 +858,7 @@ namespace JS {
 - (void)reportSoftException:(NSString *)message
                       stack:(NSArray *)stack
                 exceptionId:(double)exceptionId;
-- (void)reportException:(JS::NativeExceptionsManager::ExceptionData &)data;
+- (void)reportException:(ABI44_0_0JS::NativeExceptionsManager::ExceptionData &)data;
 - (void)updateExceptionMessage:(NSString *)message
                          stack:(NSArray *)stack
                    exceptionId:(double)exceptionId;
@@ -899,7 +899,7 @@ namespace ABI44_0_0facebook {
     };
   } // namespace ABI44_0_0React
 } // namespace ABI44_0_0facebook
-namespace JS {
+namespace ABI44_0_0JS {
   namespace NativeFrameRateLogger {
     struct SpecSetGlobalOptionsOptions {
       folly::Optional<bool> debug() const;
@@ -913,11 +913,11 @@ namespace JS {
 }
 
 @interface ABI44_0_0RCTCxxConvert (NativeFrameRateLogger_SpecSetGlobalOptionsOptions)
-+ (ABI44_0_0RCTManagedPointer *)JS_NativeFrameRateLogger_SpecSetGlobalOptionsOptions:(id)json;
++ (ABI44_0_0RCTManagedPointer *)ABI44_0_0JS_NativeFrameRateLogger_SpecSetGlobalOptionsOptions:(id)json;
 @end
 @protocol ABI44_0_0NativeFrameRateLoggerSpec <ABI44_0_0RCTBridgeModule, ABI44_0_0RCTTurboModule>
 
-- (void)setGlobalOptions:(JS::NativeFrameRateLogger::SpecSetGlobalOptionsOptions &)options;
+- (void)setGlobalOptions:(ABI44_0_0JS::NativeFrameRateLogger::SpecSetGlobalOptionsOptions &)options;
 - (void)setContext:(NSString *)context;
 - (void)beginScroll;
 - (void)endScroll;
@@ -954,7 +954,7 @@ namespace ABI44_0_0facebook {
     };
   } // namespace ABI44_0_0React
 } // namespace ABI44_0_0facebook
-namespace JS {
+namespace ABI44_0_0JS {
   namespace NativeI18nManager {
     struct Constants {
 
@@ -987,8 +987,8 @@ namespace JS {
 - (void)allowRTL:(BOOL)allowRTL;
 - (void)forceRTL:(BOOL)forceRTL;
 - (void)swapLeftAndRightInRTL:(BOOL)flipStyles;
-- (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<JS::NativeI18nManager::Constants::Builder>)constantsToExport;
-- (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<JS::NativeI18nManager::Constants::Builder>)getConstants;
+- (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<ABI44_0_0JS::NativeI18nManager::Constants::Builder>)constantsToExport;
+- (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<ABI44_0_0JS::NativeI18nManager::Constants::Builder>)getConstants;
 
 @end
 namespace ABI44_0_0facebook {
@@ -1002,7 +1002,7 @@ namespace ABI44_0_0facebook {
     };
   } // namespace ABI44_0_0React
 } // namespace ABI44_0_0facebook
-namespace JS {
+namespace ABI44_0_0JS {
   namespace NativeImageEditor {
     struct OptionsOffset {
       double x() const;
@@ -1016,9 +1016,9 @@ namespace JS {
 }
 
 @interface ABI44_0_0RCTCxxConvert (NativeImageEditor_OptionsOffset)
-+ (ABI44_0_0RCTManagedPointer *)JS_NativeImageEditor_OptionsOffset:(id)json;
++ (ABI44_0_0RCTManagedPointer *)ABI44_0_0JS_NativeImageEditor_OptionsOffset:(id)json;
 @end
-namespace JS {
+namespace ABI44_0_0JS {
   namespace NativeImageEditor {
     struct OptionsSize {
       double width() const;
@@ -1032,9 +1032,9 @@ namespace JS {
 }
 
 @interface ABI44_0_0RCTCxxConvert (NativeImageEditor_OptionsSize)
-+ (ABI44_0_0RCTManagedPointer *)JS_NativeImageEditor_OptionsSize:(id)json;
++ (ABI44_0_0RCTManagedPointer *)ABI44_0_0JS_NativeImageEditor_OptionsSize:(id)json;
 @end
-namespace JS {
+namespace ABI44_0_0JS {
   namespace NativeImageEditor {
     struct OptionsDisplaySize {
       double width() const;
@@ -1048,14 +1048,14 @@ namespace JS {
 }
 
 @interface ABI44_0_0RCTCxxConvert (NativeImageEditor_OptionsDisplaySize)
-+ (ABI44_0_0RCTManagedPointer *)JS_NativeImageEditor_OptionsDisplaySize:(id)json;
++ (ABI44_0_0RCTManagedPointer *)ABI44_0_0JS_NativeImageEditor_OptionsDisplaySize:(id)json;
 @end
-namespace JS {
+namespace ABI44_0_0JS {
   namespace NativeImageEditor {
     struct Options {
-      JS::NativeImageEditor::OptionsOffset offset() const;
-      JS::NativeImageEditor::OptionsSize size() const;
-      folly::Optional<JS::NativeImageEditor::OptionsDisplaySize> displaySize() const;
+      ABI44_0_0JS::NativeImageEditor::OptionsOffset offset() const;
+      ABI44_0_0JS::NativeImageEditor::OptionsSize size() const;
+      folly::Optional<ABI44_0_0JS::NativeImageEditor::OptionsDisplaySize> displaySize() const;
       NSString *resizeMode() const;
       folly::Optional<bool> allowExternalStorage() const;
 
@@ -1067,12 +1067,12 @@ namespace JS {
 }
 
 @interface ABI44_0_0RCTCxxConvert (NativeImageEditor_Options)
-+ (ABI44_0_0RCTManagedPointer *)JS_NativeImageEditor_Options:(id)json;
++ (ABI44_0_0RCTManagedPointer *)ABI44_0_0JS_NativeImageEditor_Options:(id)json;
 @end
 @protocol ABI44_0_0NativeImageEditorSpec <ABI44_0_0RCTBridgeModule, ABI44_0_0RCTTurboModule>
 
 - (void)cropImage:(NSString *)uri
-         cropData:(JS::NativeImageEditor::Options &)cropData
+         cropData:(ABI44_0_0JS::NativeImageEditor::Options &)cropData
   successCallback:(ABI44_0_0RCTResponseSenderBlock)successCallback
     errorCallback:(ABI44_0_0RCTResponseSenderBlock)errorCallback;
 
@@ -1117,7 +1117,7 @@ namespace ABI44_0_0facebook {
     };
   } // namespace ABI44_0_0React
 } // namespace ABI44_0_0facebook
-namespace JS {
+namespace ABI44_0_0JS {
   namespace NativeImagePickerIOS {
     struct SpecOpenCameraDialogConfig {
       bool unmirrorFrontFacingCamera() const;
@@ -1131,9 +1131,9 @@ namespace JS {
 }
 
 @interface ABI44_0_0RCTCxxConvert (NativeImagePickerIOS_SpecOpenCameraDialogConfig)
-+ (ABI44_0_0RCTManagedPointer *)JS_NativeImagePickerIOS_SpecOpenCameraDialogConfig:(id)json;
++ (ABI44_0_0RCTManagedPointer *)ABI44_0_0JS_NativeImagePickerIOS_SpecOpenCameraDialogConfig:(id)json;
 @end
-namespace JS {
+namespace ABI44_0_0JS {
   namespace NativeImagePickerIOS {
     struct SpecOpenSelectDialogConfig {
       bool showImages() const;
@@ -1147,16 +1147,16 @@ namespace JS {
 }
 
 @interface ABI44_0_0RCTCxxConvert (NativeImagePickerIOS_SpecOpenSelectDialogConfig)
-+ (ABI44_0_0RCTManagedPointer *)JS_NativeImagePickerIOS_SpecOpenSelectDialogConfig:(id)json;
++ (ABI44_0_0RCTManagedPointer *)ABI44_0_0JS_NativeImagePickerIOS_SpecOpenSelectDialogConfig:(id)json;
 @end
 @protocol ABI44_0_0NativeImagePickerIOSSpec <ABI44_0_0RCTBridgeModule, ABI44_0_0RCTTurboModule>
 
 - (void)canRecordVideos:(ABI44_0_0RCTResponseSenderBlock)callback;
 - (void)canUseCamera:(ABI44_0_0RCTResponseSenderBlock)callback;
-- (void)openCameraDialog:(JS::NativeImagePickerIOS::SpecOpenCameraDialogConfig &)config
+- (void)openCameraDialog:(ABI44_0_0JS::NativeImagePickerIOS::SpecOpenCameraDialogConfig &)config
          successCallback:(ABI44_0_0RCTResponseSenderBlock)successCallback
           cancelCallback:(ABI44_0_0RCTResponseSenderBlock)cancelCallback;
-- (void)openSelectDialog:(JS::NativeImagePickerIOS::SpecOpenSelectDialogConfig &)config
+- (void)openSelectDialog:(ABI44_0_0JS::NativeImagePickerIOS::SpecOpenSelectDialogConfig &)config
          successCallback:(ABI44_0_0RCTResponseSenderBlock)successCallback
           cancelCallback:(ABI44_0_0RCTResponseSenderBlock)cancelCallback;
 - (void)clearAllPendingVideos;
@@ -1236,7 +1236,7 @@ namespace ABI44_0_0facebook {
     };
   } // namespace ABI44_0_0React
 } // namespace ABI44_0_0facebook
-namespace JS {
+namespace ABI44_0_0JS {
   namespace NativeJSDevSupport {
     struct Constants {
 
@@ -1269,8 +1269,8 @@ namespace JS {
 - (void)onSuccess:(NSString *)data;
 - (void)onFailure:(double)errorCode
             error:(NSString *)error;
-- (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<JS::NativeJSDevSupport::Constants::Builder>)constantsToExport;
-- (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<JS::NativeJSDevSupport::Constants::Builder>)getConstants;
+- (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<ABI44_0_0JS::NativeJSDevSupport::Constants::Builder>)constantsToExport;
+- (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<ABI44_0_0JS::NativeJSDevSupport::Constants::Builder>)getConstants;
 
 @end
 namespace ABI44_0_0facebook {
@@ -1366,7 +1366,7 @@ namespace ABI44_0_0facebook {
     };
   } // namespace ABI44_0_0React
 } // namespace ABI44_0_0facebook
-namespace JS {
+namespace ABI44_0_0JS {
   namespace NativeNetworkingIOS {
     struct SpecSendRequestQuery {
       NSString *method() const;
@@ -1386,11 +1386,11 @@ namespace JS {
 }
 
 @interface ABI44_0_0RCTCxxConvert (NativeNetworkingIOS_SpecSendRequestQuery)
-+ (ABI44_0_0RCTManagedPointer *)JS_NativeNetworkingIOS_SpecSendRequestQuery:(id)json;
++ (ABI44_0_0RCTManagedPointer *)ABI44_0_0JS_NativeNetworkingIOS_SpecSendRequestQuery:(id)json;
 @end
 @protocol ABI44_0_0NativeNetworkingIOSSpec <ABI44_0_0RCTBridgeModule, ABI44_0_0RCTTurboModule>
 
-- (void)sendRequest:(JS::NativeNetworkingIOS::SpecSendRequestQuery &)query
+- (void)sendRequest:(ABI44_0_0JS::NativeNetworkingIOS::SpecSendRequestQuery &)query
            callback:(ABI44_0_0RCTResponseSenderBlock)callback;
 - (void)abortRequest:(double)requestId;
 - (void)clearCookies:(ABI44_0_0RCTResponseSenderBlock)callback;
@@ -1409,7 +1409,7 @@ namespace ABI44_0_0facebook {
     };
   } // namespace ABI44_0_0React
 } // namespace ABI44_0_0facebook
-namespace JS {
+namespace ABI44_0_0JS {
   namespace NativePlatformConstantsIOS {
     struct ConstantsreactNativeVersion {
 
@@ -1439,14 +1439,14 @@ namespace JS {
     };
   }
 }
-namespace JS {
+namespace ABI44_0_0JS {
   namespace NativePlatformConstantsIOS {
     struct Constants {
 
       struct Builder {
         struct Input {
           ABI44_0_0RCTRequired<bool> isTesting;
-          ABI44_0_0RCTRequired<JS::NativePlatformConstantsIOS::ConstantsreactNativeVersion::Builder> reactNativeVersion;
+          ABI44_0_0RCTRequired<ABI44_0_0JS::NativePlatformConstantsIOS::ConstantsreactNativeVersion::Builder> reactNativeVersion;
           ABI44_0_0RCTRequired<bool> forceTouchAvailable;
           ABI44_0_0RCTRequired<NSString *> osVersion;
           ABI44_0_0RCTRequired<NSString *> systemName;
@@ -1473,8 +1473,8 @@ namespace JS {
 }
 @protocol ABI44_0_0NativePlatformConstantsIOSSpec <ABI44_0_0RCTBridgeModule, ABI44_0_0RCTTurboModule>
 
-- (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<JS::NativePlatformConstantsIOS::Constants::Builder>)constantsToExport;
-- (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<JS::NativePlatformConstantsIOS::Constants::Builder>)getConstants;
+- (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<ABI44_0_0JS::NativePlatformConstantsIOS::Constants::Builder>)constantsToExport;
+- (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<ABI44_0_0JS::NativePlatformConstantsIOS::Constants::Builder>)getConstants;
 
 @end
 namespace ABI44_0_0facebook {
@@ -1488,7 +1488,7 @@ namespace ABI44_0_0facebook {
     };
   } // namespace ABI44_0_0React
 } // namespace ABI44_0_0facebook
-namespace JS {
+namespace ABI44_0_0JS {
   namespace NativePushNotificationManagerIOS {
     struct SpecRequestPermissionsPermission {
       bool alert() const;
@@ -1503,9 +1503,9 @@ namespace JS {
 }
 
 @interface ABI44_0_0RCTCxxConvert (NativePushNotificationManagerIOS_SpecRequestPermissionsPermission)
-+ (ABI44_0_0RCTManagedPointer *)JS_NativePushNotificationManagerIOS_SpecRequestPermissionsPermission:(id)json;
++ (ABI44_0_0RCTManagedPointer *)ABI44_0_0JS_NativePushNotificationManagerIOS_SpecRequestPermissionsPermission:(id)json;
 @end
-namespace JS {
+namespace ABI44_0_0JS {
   namespace NativePushNotificationManagerIOS {
     struct Notification {
       NSString *alertTitle() const;
@@ -1526,7 +1526,7 @@ namespace JS {
 }
 
 @interface ABI44_0_0RCTCxxConvert (NativePushNotificationManagerIOS_Notification)
-+ (ABI44_0_0RCTManagedPointer *)JS_NativePushNotificationManagerIOS_Notification:(id)json;
++ (ABI44_0_0RCTManagedPointer *)ABI44_0_0JS_NativePushNotificationManagerIOS_Notification:(id)json;
 @end
 @protocol ABI44_0_0NativePushNotificationManagerIOSSpec <ABI44_0_0RCTBridgeModule, ABI44_0_0RCTTurboModule>
 
@@ -1534,13 +1534,13 @@ namespace JS {
                        fetchResult:(NSString *)fetchResult;
 - (void)setApplicationIconBadgeNumber:(double)num;
 - (void)getApplicationIconBadgeNumber:(ABI44_0_0RCTResponseSenderBlock)callback;
-- (void)requestPermissions:(JS::NativePushNotificationManagerIOS::SpecRequestPermissionsPermission &)permission
+- (void)requestPermissions:(ABI44_0_0JS::NativePushNotificationManagerIOS::SpecRequestPermissionsPermission &)permission
                    resolve:(ABI44_0_0RCTPromiseResolveBlock)resolve
                     reject:(ABI44_0_0RCTPromiseRejectBlock)reject;
 - (void)abandonPermissions;
 - (void)checkPermissions:(ABI44_0_0RCTResponseSenderBlock)callback;
-- (void)presentLocalNotification:(JS::NativePushNotificationManagerIOS::Notification &)notification;
-- (void)scheduleLocalNotification:(JS::NativePushNotificationManagerIOS::Notification &)notification;
+- (void)presentLocalNotification:(ABI44_0_0JS::NativePushNotificationManagerIOS::Notification &)notification;
+- (void)scheduleLocalNotification:(ABI44_0_0JS::NativePushNotificationManagerIOS::Notification &)notification;
 - (void)cancelAllLocalNotifications;
 - (void)cancelLocalNotifications:(NSDictionary *)userInfo;
 - (void)getInitialNotification:(ABI44_0_0RCTPromiseResolveBlock)resolve
@@ -1605,7 +1605,7 @@ namespace ABI44_0_0facebook {
     };
   } // namespace ABI44_0_0React
 } // namespace ABI44_0_0facebook
-namespace JS {
+namespace ABI44_0_0JS {
   namespace NativeSettingsManager {
     struct Constants {
 
@@ -1636,8 +1636,8 @@ namespace JS {
 
 - (void)setValues:(NSDictionary *)values;
 - (void)deleteValues:(NSArray *)values;
-- (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<JS::NativeSettingsManager::Constants::Builder>)constantsToExport;
-- (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<JS::NativeSettingsManager::Constants::Builder>)getConstants;
+- (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<ABI44_0_0JS::NativeSettingsManager::Constants::Builder>)constantsToExport;
+- (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<ABI44_0_0JS::NativeSettingsManager::Constants::Builder>)getConstants;
 
 @end
 namespace ABI44_0_0facebook {
@@ -1651,7 +1651,7 @@ namespace ABI44_0_0facebook {
     };
   } // namespace ABI44_0_0React
 } // namespace ABI44_0_0facebook
-namespace JS {
+namespace ABI44_0_0JS {
   namespace NativeShareModule {
     struct SpecShareContent {
       NSString *title() const;
@@ -1665,11 +1665,11 @@ namespace JS {
 }
 
 @interface ABI44_0_0RCTCxxConvert (NativeShareModule_SpecShareContent)
-+ (ABI44_0_0RCTManagedPointer *)JS_NativeShareModule_SpecShareContent:(id)json;
++ (ABI44_0_0RCTManagedPointer *)ABI44_0_0JS_NativeShareModule_SpecShareContent:(id)json;
 @end
 @protocol ABI44_0_0NativeShareModuleSpec <ABI44_0_0RCTBridgeModule, ABI44_0_0RCTTurboModule>
 
-- (void)share:(JS::NativeShareModule::SpecShareContent &)content
+- (void)share:(ABI44_0_0JS::NativeShareModule::SpecShareContent &)content
   dialogTitle:(NSString *)dialogTitle
       resolve:(ABI44_0_0RCTPromiseResolveBlock)resolve
        reject:(ABI44_0_0RCTPromiseRejectBlock)reject;
@@ -1703,7 +1703,7 @@ namespace ABI44_0_0facebook {
     };
   } // namespace ABI44_0_0React
 } // namespace ABI44_0_0facebook
-namespace JS {
+namespace ABI44_0_0JS {
   namespace NativeSourceCode {
     struct Constants {
 
@@ -1732,8 +1732,8 @@ namespace JS {
 }
 @protocol ABI44_0_0NativeSourceCodeSpec <ABI44_0_0RCTBridgeModule, ABI44_0_0RCTTurboModule>
 
-- (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<JS::NativeSourceCode::Constants::Builder>)constantsToExport;
-- (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<JS::NativeSourceCode::Constants::Builder>)getConstants;
+- (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<ABI44_0_0JS::NativeSourceCode::Constants::Builder>)constantsToExport;
+- (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<ABI44_0_0JS::NativeSourceCode::Constants::Builder>)getConstants;
 
 @end
 namespace ABI44_0_0facebook {
@@ -1747,7 +1747,7 @@ namespace ABI44_0_0facebook {
     };
   } // namespace ABI44_0_0React
 } // namespace ABI44_0_0facebook
-namespace JS {
+namespace ABI44_0_0JS {
   namespace NativeStatusBarManagerIOS {
     struct Constants {
 
@@ -1785,8 +1785,8 @@ namespace JS {
         animated:(BOOL)animated;
 - (void)setHidden:(BOOL)hidden
     withAnimation:(NSString *)withAnimation;
-- (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<JS::NativeStatusBarManagerIOS::Constants::Builder>)constantsToExport;
-- (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<JS::NativeStatusBarManagerIOS::Constants::Builder>)getConstants;
+- (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<ABI44_0_0JS::NativeStatusBarManagerIOS::Constants::Builder>)constantsToExport;
+- (ABI44_0_0facebook::ABI44_0_0React::ModuleConstants<ABI44_0_0JS::NativeStatusBarManagerIOS::Constants::Builder>)getConstants;
 
 @end
 namespace ABI44_0_0facebook {
@@ -1842,7 +1842,7 @@ namespace ABI44_0_0facebook {
     };
   } // namespace ABI44_0_0React
 } // namespace ABI44_0_0facebook
-namespace JS {
+namespace ABI44_0_0JS {
   namespace NativeWebSocketModule {
     struct SpecConnectOptions {
       id<NSObject> _Nullable headers() const;
@@ -1855,13 +1855,13 @@ namespace JS {
 }
 
 @interface ABI44_0_0RCTCxxConvert (NativeWebSocketModule_SpecConnectOptions)
-+ (ABI44_0_0RCTManagedPointer *)JS_NativeWebSocketModule_SpecConnectOptions:(id)json;
++ (ABI44_0_0RCTManagedPointer *)ABI44_0_0JS_NativeWebSocketModule_SpecConnectOptions:(id)json;
 @end
 @protocol ABI44_0_0NativeWebSocketModuleSpec <ABI44_0_0RCTBridgeModule, ABI44_0_0RCTTurboModule>
 
 - (void)connect:(NSString *)url
       protocols:(NSArray * _Nullable)protocols
-        options:(JS::NativeWebSocketModule::SpecConnectOptions &)options
+        options:(ABI44_0_0JS::NativeWebSocketModule::SpecConnectOptions &)options
        socketID:(double)socketID;
 - (void)send:(NSString *)message
  forSocketID:(double)forSocketID;
@@ -1887,220 +1887,220 @@ namespace ABI44_0_0facebook {
   } // namespace ABI44_0_0React
 } // namespace ABI44_0_0facebook
 
-inline folly::Optional<double> JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers::extraSmall() const
+inline folly::Optional<double> ABI44_0_0JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers::extraSmall() const
 {
   id const p = _v[@"extraSmall"];
   return ABI44_0_0RCTBridgingToOptionalDouble(p);
 }
-inline folly::Optional<double> JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers::small() const
+inline folly::Optional<double> ABI44_0_0JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers::small() const
 {
   id const p = _v[@"small"];
   return ABI44_0_0RCTBridgingToOptionalDouble(p);
 }
-inline folly::Optional<double> JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers::medium() const
+inline folly::Optional<double> ABI44_0_0JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers::medium() const
 {
   id const p = _v[@"medium"];
   return ABI44_0_0RCTBridgingToOptionalDouble(p);
 }
-inline folly::Optional<double> JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers::large() const
+inline folly::Optional<double> ABI44_0_0JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers::large() const
 {
   id const p = _v[@"large"];
   return ABI44_0_0RCTBridgingToOptionalDouble(p);
 }
-inline folly::Optional<double> JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers::extraLarge() const
+inline folly::Optional<double> ABI44_0_0JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers::extraLarge() const
 {
   id const p = _v[@"extraLarge"];
   return ABI44_0_0RCTBridgingToOptionalDouble(p);
 }
-inline folly::Optional<double> JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers::extraExtraLarge() const
+inline folly::Optional<double> ABI44_0_0JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers::extraExtraLarge() const
 {
   id const p = _v[@"extraExtraLarge"];
   return ABI44_0_0RCTBridgingToOptionalDouble(p);
 }
-inline folly::Optional<double> JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers::extraExtraExtraLarge() const
+inline folly::Optional<double> ABI44_0_0JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers::extraExtraExtraLarge() const
 {
   id const p = _v[@"extraExtraExtraLarge"];
   return ABI44_0_0RCTBridgingToOptionalDouble(p);
 }
-inline folly::Optional<double> JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers::accessibilityMedium() const
+inline folly::Optional<double> ABI44_0_0JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers::accessibilityMedium() const
 {
   id const p = _v[@"accessibilityMedium"];
   return ABI44_0_0RCTBridgingToOptionalDouble(p);
 }
-inline folly::Optional<double> JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers::accessibilityLarge() const
+inline folly::Optional<double> ABI44_0_0JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers::accessibilityLarge() const
 {
   id const p = _v[@"accessibilityLarge"];
   return ABI44_0_0RCTBridgingToOptionalDouble(p);
 }
-inline folly::Optional<double> JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers::accessibilityExtraLarge() const
+inline folly::Optional<double> ABI44_0_0JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers::accessibilityExtraLarge() const
 {
   id const p = _v[@"accessibilityExtraLarge"];
   return ABI44_0_0RCTBridgingToOptionalDouble(p);
 }
-inline folly::Optional<double> JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers::accessibilityExtraExtraLarge() const
+inline folly::Optional<double> ABI44_0_0JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers::accessibilityExtraExtraLarge() const
 {
   id const p = _v[@"accessibilityExtraExtraLarge"];
   return ABI44_0_0RCTBridgingToOptionalDouble(p);
 }
-inline folly::Optional<double> JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers::accessibilityExtraExtraExtraLarge() const
+inline folly::Optional<double> ABI44_0_0JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers::accessibilityExtraExtraExtraLarge() const
 {
   id const p = _v[@"accessibilityExtraExtraExtraLarge"];
   return ABI44_0_0RCTBridgingToOptionalDouble(p);
 }
-inline NSString *JS::NativeActionSheetManager::SpecShowActionSheetWithOptionsOptions::title() const
+inline NSString *ABI44_0_0JS::NativeActionSheetManager::SpecShowActionSheetWithOptionsOptions::title() const
 {
   id const p = _v[@"title"];
   return ABI44_0_0RCTBridgingToOptionalString(p);
 }
-inline NSString *JS::NativeActionSheetManager::SpecShowActionSheetWithOptionsOptions::message() const
+inline NSString *ABI44_0_0JS::NativeActionSheetManager::SpecShowActionSheetWithOptionsOptions::message() const
 {
   id const p = _v[@"message"];
   return ABI44_0_0RCTBridgingToOptionalString(p);
 }
-inline folly::Optional<ABI44_0_0facebook::ABI44_0_0React::LazyVector<NSString *>> JS::NativeActionSheetManager::SpecShowActionSheetWithOptionsOptions::options() const
+inline folly::Optional<ABI44_0_0facebook::ABI44_0_0React::LazyVector<NSString *>> ABI44_0_0JS::NativeActionSheetManager::SpecShowActionSheetWithOptionsOptions::options() const
 {
   id const p = _v[@"options"];
   return ABI44_0_0RCTBridgingToOptionalVec(p, ^NSString *(id itemValue_0) { return ABI44_0_0RCTBridgingToString(itemValue_0); });
 }
-inline folly::Optional<ABI44_0_0facebook::ABI44_0_0React::LazyVector<double>> JS::NativeActionSheetManager::SpecShowActionSheetWithOptionsOptions::destructiveButtonIndices() const
+inline folly::Optional<ABI44_0_0facebook::ABI44_0_0React::LazyVector<double>> ABI44_0_0JS::NativeActionSheetManager::SpecShowActionSheetWithOptionsOptions::destructiveButtonIndices() const
 {
   id const p = _v[@"destructiveButtonIndices"];
   return ABI44_0_0RCTBridgingToOptionalVec(p, ^double(id itemValue_0) { return ABI44_0_0RCTBridgingToDouble(itemValue_0); });
 }
-inline folly::Optional<double> JS::NativeActionSheetManager::SpecShowActionSheetWithOptionsOptions::cancelButtonIndex() const
+inline folly::Optional<double> ABI44_0_0JS::NativeActionSheetManager::SpecShowActionSheetWithOptionsOptions::cancelButtonIndex() const
 {
   id const p = _v[@"cancelButtonIndex"];
   return ABI44_0_0RCTBridgingToOptionalDouble(p);
 }
-inline folly::Optional<double> JS::NativeActionSheetManager::SpecShowActionSheetWithOptionsOptions::anchor() const
+inline folly::Optional<double> ABI44_0_0JS::NativeActionSheetManager::SpecShowActionSheetWithOptionsOptions::anchor() const
 {
   id const p = _v[@"anchor"];
   return ABI44_0_0RCTBridgingToOptionalDouble(p);
 }
-inline folly::Optional<double> JS::NativeActionSheetManager::SpecShowActionSheetWithOptionsOptions::tintColor() const
+inline folly::Optional<double> ABI44_0_0JS::NativeActionSheetManager::SpecShowActionSheetWithOptionsOptions::tintColor() const
 {
   id const p = _v[@"tintColor"];
   return ABI44_0_0RCTBridgingToOptionalDouble(p);
 }
-inline NSString *JS::NativeActionSheetManager::SpecShowActionSheetWithOptionsOptions::userInterfaceStyle() const
+inline NSString *ABI44_0_0JS::NativeActionSheetManager::SpecShowActionSheetWithOptionsOptions::userInterfaceStyle() const
 {
   id const p = _v[@"userInterfaceStyle"];
   return ABI44_0_0RCTBridgingToOptionalString(p);
 }
-inline folly::Optional<ABI44_0_0facebook::ABI44_0_0React::LazyVector<double>> JS::NativeActionSheetManager::SpecShowActionSheetWithOptionsOptions::disabledButtonIndices() const
+inline folly::Optional<ABI44_0_0facebook::ABI44_0_0React::LazyVector<double>> ABI44_0_0JS::NativeActionSheetManager::SpecShowActionSheetWithOptionsOptions::disabledButtonIndices() const
 {
   id const p = _v[@"disabledButtonIndices"];
   return ABI44_0_0RCTBridgingToOptionalVec(p, ^double(id itemValue_0) { return ABI44_0_0RCTBridgingToDouble(itemValue_0); });
 }
-inline NSString *JS::NativeActionSheetManager::SpecShowShareActionSheetWithOptionsOptions::message() const
+inline NSString *ABI44_0_0JS::NativeActionSheetManager::SpecShowShareActionSheetWithOptionsOptions::message() const
 {
   id const p = _v[@"message"];
   return ABI44_0_0RCTBridgingToOptionalString(p);
 }
-inline NSString *JS::NativeActionSheetManager::SpecShowShareActionSheetWithOptionsOptions::url() const
+inline NSString *ABI44_0_0JS::NativeActionSheetManager::SpecShowShareActionSheetWithOptionsOptions::url() const
 {
   id const p = _v[@"url"];
   return ABI44_0_0RCTBridgingToOptionalString(p);
 }
-inline NSString *JS::NativeActionSheetManager::SpecShowShareActionSheetWithOptionsOptions::subject() const
+inline NSString *ABI44_0_0JS::NativeActionSheetManager::SpecShowShareActionSheetWithOptionsOptions::subject() const
 {
   id const p = _v[@"subject"];
   return ABI44_0_0RCTBridgingToOptionalString(p);
 }
-inline folly::Optional<double> JS::NativeActionSheetManager::SpecShowShareActionSheetWithOptionsOptions::anchor() const
+inline folly::Optional<double> ABI44_0_0JS::NativeActionSheetManager::SpecShowShareActionSheetWithOptionsOptions::anchor() const
 {
   id const p = _v[@"anchor"];
   return ABI44_0_0RCTBridgingToOptionalDouble(p);
 }
-inline folly::Optional<double> JS::NativeActionSheetManager::SpecShowShareActionSheetWithOptionsOptions::tintColor() const
+inline folly::Optional<double> ABI44_0_0JS::NativeActionSheetManager::SpecShowShareActionSheetWithOptionsOptions::tintColor() const
 {
   id const p = _v[@"tintColor"];
   return ABI44_0_0RCTBridgingToOptionalDouble(p);
 }
-inline folly::Optional<ABI44_0_0facebook::ABI44_0_0React::LazyVector<NSString *>> JS::NativeActionSheetManager::SpecShowShareActionSheetWithOptionsOptions::excludedActivityTypes() const
+inline folly::Optional<ABI44_0_0facebook::ABI44_0_0React::LazyVector<NSString *>> ABI44_0_0JS::NativeActionSheetManager::SpecShowShareActionSheetWithOptionsOptions::excludedActivityTypes() const
 {
   id const p = _v[@"excludedActivityTypes"];
   return ABI44_0_0RCTBridgingToOptionalVec(p, ^NSString *(id itemValue_0) { return ABI44_0_0RCTBridgingToString(itemValue_0); });
 }
-inline NSString *JS::NativeActionSheetManager::SpecShowShareActionSheetWithOptionsOptions::userInterfaceStyle() const
+inline NSString *ABI44_0_0JS::NativeActionSheetManager::SpecShowShareActionSheetWithOptionsOptions::userInterfaceStyle() const
 {
   id const p = _v[@"userInterfaceStyle"];
   return ABI44_0_0RCTBridgingToOptionalString(p);
 }
-inline NSString *JS::NativeAlertManager::Args::title() const
+inline NSString *ABI44_0_0JS::NativeAlertManager::Args::title() const
 {
   id const p = _v[@"title"];
   return ABI44_0_0RCTBridgingToOptionalString(p);
 }
-inline NSString *JS::NativeAlertManager::Args::message() const
+inline NSString *ABI44_0_0JS::NativeAlertManager::Args::message() const
 {
   id const p = _v[@"message"];
   return ABI44_0_0RCTBridgingToOptionalString(p);
 }
-inline folly::Optional<ABI44_0_0facebook::ABI44_0_0React::LazyVector<id<NSObject> >> JS::NativeAlertManager::Args::buttons() const
+inline folly::Optional<ABI44_0_0facebook::ABI44_0_0React::LazyVector<id<NSObject> >> ABI44_0_0JS::NativeAlertManager::Args::buttons() const
 {
   id const p = _v[@"buttons"];
   return ABI44_0_0RCTBridgingToOptionalVec(p, ^id<NSObject> (id itemValue_0) { return itemValue_0; });
 }
-inline NSString *JS::NativeAlertManager::Args::type() const
+inline NSString *ABI44_0_0JS::NativeAlertManager::Args::type() const
 {
   id const p = _v[@"type"];
   return ABI44_0_0RCTBridgingToOptionalString(p);
 }
-inline NSString *JS::NativeAlertManager::Args::defaultValue() const
+inline NSString *ABI44_0_0JS::NativeAlertManager::Args::defaultValue() const
 {
   id const p = _v[@"defaultValue"];
   return ABI44_0_0RCTBridgingToOptionalString(p);
 }
-inline NSString *JS::NativeAlertManager::Args::cancelButtonKey() const
+inline NSString *ABI44_0_0JS::NativeAlertManager::Args::cancelButtonKey() const
 {
   id const p = _v[@"cancelButtonKey"];
   return ABI44_0_0RCTBridgingToOptionalString(p);
 }
-inline NSString *JS::NativeAlertManager::Args::destructiveButtonKey() const
+inline NSString *ABI44_0_0JS::NativeAlertManager::Args::destructiveButtonKey() const
 {
   id const p = _v[@"destructiveButtonKey"];
   return ABI44_0_0RCTBridgingToOptionalString(p);
 }
-inline NSString *JS::NativeAlertManager::Args::keyboardType() const
+inline NSString *ABI44_0_0JS::NativeAlertManager::Args::keyboardType() const
 {
   id const p = _v[@"keyboardType"];
   return ABI44_0_0RCTBridgingToOptionalString(p);
 }
-inline ABI44_0_0facebook::ABI44_0_0React::LazyVector<NSString *> JS::NativeAnimatedModule::EventMapping::nativeEventPath() const
+inline ABI44_0_0facebook::ABI44_0_0React::LazyVector<NSString *> ABI44_0_0JS::NativeAnimatedModule::EventMapping::nativeEventPath() const
 {
   id const p = _v[@"nativeEventPath"];
   return ABI44_0_0RCTBridgingToVec(p, ^NSString *(id itemValue_0) { return ABI44_0_0RCTBridgingToString(itemValue_0); });
 }
-inline folly::Optional<double> JS::NativeAnimatedModule::EventMapping::animatedValueTag() const
+inline folly::Optional<double> ABI44_0_0JS::NativeAnimatedModule::EventMapping::animatedValueTag() const
 {
   id const p = _v[@"animatedValueTag"];
   return ABI44_0_0RCTBridgingToOptionalDouble(p);
 }
-inline ABI44_0_0facebook::ABI44_0_0React::LazyVector<NSString *> JS::NativeAnimatedTurboModule::EventMapping::nativeEventPath() const
+inline ABI44_0_0facebook::ABI44_0_0React::LazyVector<NSString *> ABI44_0_0JS::NativeAnimatedTurboModule::EventMapping::nativeEventPath() const
 {
   id const p = _v[@"nativeEventPath"];
   return ABI44_0_0RCTBridgingToVec(p, ^NSString *(id itemValue_0) { return ABI44_0_0RCTBridgingToString(itemValue_0); });
 }
-inline folly::Optional<double> JS::NativeAnimatedTurboModule::EventMapping::animatedValueTag() const
+inline folly::Optional<double> ABI44_0_0JS::NativeAnimatedTurboModule::EventMapping::animatedValueTag() const
 {
   id const p = _v[@"animatedValueTag"];
   return ABI44_0_0RCTBridgingToOptionalDouble(p);
 }
 
-inline JS::NativeAppState::Constants::Builder::Builder(const Input i) : _factory(^{
+inline ABI44_0_0JS::NativeAppState::Constants::Builder::Builder(const Input i) : _factory(^{
   NSMutableDictionary *d = [NSMutableDictionary new];
   auto initialAppState = i.initialAppState.get();
   d[@"initialAppState"] = initialAppState;
   return d;
 }) {}
-inline JS::NativeAppState::Constants::Builder::Builder(Constants i) : _factory(^{
+inline ABI44_0_0JS::NativeAppState::Constants::Builder::Builder(Constants i) : _factory(^{
   return i.unsafeRawValue();
 }) {}
 
 
 
-inline JS::NativeBlobModule::Constants::Builder::Builder(const Input i) : _factory(^{
+inline ABI44_0_0JS::NativeBlobModule::Constants::Builder::Builder(const Input i) : _factory(^{
   NSMutableDictionary *d = [NSMutableDictionary new];
   auto BLOB_URI_SCHEME = i.BLOB_URI_SCHEME.get();
   d[@"BLOB_URI_SCHEME"] = BLOB_URI_SCHEME;
@@ -2108,7 +2108,7 @@ inline JS::NativeBlobModule::Constants::Builder::Builder(const Input i) : _facto
   d[@"BLOB_URI_HOST"] = BLOB_URI_HOST;
   return d;
 }) {}
-inline JS::NativeBlobModule::Constants::Builder::Builder(Constants i) : _factory(^{
+inline ABI44_0_0JS::NativeBlobModule::Constants::Builder::Builder(Constants i) : _factory(^{
   return i.unsafeRawValue();
 }) {}
 
@@ -2118,7 +2118,7 @@ inline JS::NativeBlobModule::Constants::Builder::Builder(Constants i) : _factory
 
 
 
-inline JS::NativeDeviceInfo::DisplayMetrics::Builder::Builder(const Input i) : _factory(^{
+inline ABI44_0_0JS::NativeDeviceInfo::DisplayMetrics::Builder::Builder(const Input i) : _factory(^{
   NSMutableDictionary *d = [NSMutableDictionary new];
   auto width = i.width.get();
   d[@"width"] = @(width);
@@ -2130,10 +2130,10 @@ inline JS::NativeDeviceInfo::DisplayMetrics::Builder::Builder(const Input i) : _
   d[@"fontScale"] = @(fontScale);
   return d;
 }) {}
-inline JS::NativeDeviceInfo::DisplayMetrics::Builder::Builder(DisplayMetrics i) : _factory(^{
+inline ABI44_0_0JS::NativeDeviceInfo::DisplayMetrics::Builder::Builder(DisplayMetrics i) : _factory(^{
   return i.unsafeRawValue();
 }) {}
-inline JS::NativeDeviceInfo::DisplayMetricsAndroid::Builder::Builder(const Input i) : _factory(^{
+inline ABI44_0_0JS::NativeDeviceInfo::DisplayMetricsAndroid::Builder::Builder(const Input i) : _factory(^{
   NSMutableDictionary *d = [NSMutableDictionary new];
   auto width = i.width.get();
   d[@"width"] = @(width);
@@ -2147,10 +2147,10 @@ inline JS::NativeDeviceInfo::DisplayMetricsAndroid::Builder::Builder(const Input
   d[@"densityDpi"] = @(densityDpi);
   return d;
 }) {}
-inline JS::NativeDeviceInfo::DisplayMetricsAndroid::Builder::Builder(DisplayMetricsAndroid i) : _factory(^{
+inline ABI44_0_0JS::NativeDeviceInfo::DisplayMetricsAndroid::Builder::Builder(DisplayMetricsAndroid i) : _factory(^{
   return i.unsafeRawValue();
 }) {}
-inline JS::NativeDeviceInfo::DimensionsPayload::Builder::Builder(const Input i) : _factory(^{
+inline ABI44_0_0JS::NativeDeviceInfo::DimensionsPayload::Builder::Builder(const Input i) : _factory(^{
   NSMutableDictionary *d = [NSMutableDictionary new];
   auto window = i.window;
   d[@"window"] = window.hasValue() ? window.value().buildUnsafeRawValue() : nil;
@@ -2162,10 +2162,10 @@ inline JS::NativeDeviceInfo::DimensionsPayload::Builder::Builder(const Input i) 
   d[@"screenPhysicalPixels"] = screenPhysicalPixels.hasValue() ? screenPhysicalPixels.value().buildUnsafeRawValue() : nil;
   return d;
 }) {}
-inline JS::NativeDeviceInfo::DimensionsPayload::Builder::Builder(DimensionsPayload i) : _factory(^{
+inline ABI44_0_0JS::NativeDeviceInfo::DimensionsPayload::Builder::Builder(DimensionsPayload i) : _factory(^{
   return i.unsafeRawValue();
 }) {}
-inline JS::NativeDeviceInfo::Constants::Builder::Builder(const Input i) : _factory(^{
+inline ABI44_0_0JS::NativeDeviceInfo::Constants::Builder::Builder(const Input i) : _factory(^{
   NSMutableDictionary *d = [NSMutableDictionary new];
   auto Dimensions = i.Dimensions.get();
   d[@"Dimensions"] = Dimensions.buildUnsafeRawValue();
@@ -2173,87 +2173,87 @@ inline JS::NativeDeviceInfo::Constants::Builder::Builder(const Input i) : _facto
   d[@"isIPhoneX_deprecated"] = isIPhoneX_deprecated.hasValue() ? @((BOOL)isIPhoneX_deprecated.value()) : nil;
   return d;
 }) {}
-inline JS::NativeDeviceInfo::Constants::Builder::Builder(Constants i) : _factory(^{
+inline ABI44_0_0JS::NativeDeviceInfo::Constants::Builder::Builder(Constants i) : _factory(^{
   return i.unsafeRawValue();
 }) {}
-inline folly::Optional<double> JS::NativeExceptionsManager::StackFrame::column() const
+inline folly::Optional<double> ABI44_0_0JS::NativeExceptionsManager::StackFrame::column() const
 {
   id const p = _v[@"column"];
   return ABI44_0_0RCTBridgingToOptionalDouble(p);
 }
-inline NSString *JS::NativeExceptionsManager::StackFrame::file() const
+inline NSString *ABI44_0_0JS::NativeExceptionsManager::StackFrame::file() const
 {
   id const p = _v[@"file"];
   return ABI44_0_0RCTBridgingToOptionalString(p);
 }
-inline folly::Optional<double> JS::NativeExceptionsManager::StackFrame::lineNumber() const
+inline folly::Optional<double> ABI44_0_0JS::NativeExceptionsManager::StackFrame::lineNumber() const
 {
   id const p = _v[@"lineNumber"];
   return ABI44_0_0RCTBridgingToOptionalDouble(p);
 }
-inline NSString *JS::NativeExceptionsManager::StackFrame::methodName() const
+inline NSString *ABI44_0_0JS::NativeExceptionsManager::StackFrame::methodName() const
 {
   id const p = _v[@"methodName"];
   return ABI44_0_0RCTBridgingToString(p);
 }
-inline folly::Optional<bool> JS::NativeExceptionsManager::StackFrame::collapse() const
+inline folly::Optional<bool> ABI44_0_0JS::NativeExceptionsManager::StackFrame::collapse() const
 {
   id const p = _v[@"collapse"];
   return ABI44_0_0RCTBridgingToOptionalBool(p);
 }
-inline NSString *JS::NativeExceptionsManager::ExceptionData::message() const
+inline NSString *ABI44_0_0JS::NativeExceptionsManager::ExceptionData::message() const
 {
   id const p = _v[@"message"];
   return ABI44_0_0RCTBridgingToString(p);
 }
-inline NSString *JS::NativeExceptionsManager::ExceptionData::originalMessage() const
+inline NSString *ABI44_0_0JS::NativeExceptionsManager::ExceptionData::originalMessage() const
 {
   id const p = _v[@"originalMessage"];
   return ABI44_0_0RCTBridgingToOptionalString(p);
 }
-inline NSString *JS::NativeExceptionsManager::ExceptionData::name() const
+inline NSString *ABI44_0_0JS::NativeExceptionsManager::ExceptionData::name() const
 {
   id const p = _v[@"name"];
   return ABI44_0_0RCTBridgingToOptionalString(p);
 }
-inline NSString *JS::NativeExceptionsManager::ExceptionData::componentStack() const
+inline NSString *ABI44_0_0JS::NativeExceptionsManager::ExceptionData::componentStack() const
 {
   id const p = _v[@"componentStack"];
   return ABI44_0_0RCTBridgingToOptionalString(p);
 }
-inline ABI44_0_0facebook::ABI44_0_0React::LazyVector<JS::NativeExceptionsManager::StackFrame> JS::NativeExceptionsManager::ExceptionData::stack() const
+inline ABI44_0_0facebook::ABI44_0_0React::LazyVector<ABI44_0_0JS::NativeExceptionsManager::StackFrame> ABI44_0_0JS::NativeExceptionsManager::ExceptionData::stack() const
 {
   id const p = _v[@"stack"];
-  return ABI44_0_0RCTBridgingToVec(p, ^JS::NativeExceptionsManager::StackFrame(id itemValue_0) { return JS::NativeExceptionsManager::StackFrame(itemValue_0); });
+  return ABI44_0_0RCTBridgingToVec(p, ^ABI44_0_0JS::NativeExceptionsManager::StackFrame(id itemValue_0) { return ABI44_0_0JS::NativeExceptionsManager::StackFrame(itemValue_0); });
 }
-inline double JS::NativeExceptionsManager::ExceptionData::id_() const
+inline double ABI44_0_0JS::NativeExceptionsManager::ExceptionData::id_() const
 {
   id const p = _v[@"id_"];
   return ABI44_0_0RCTBridgingToDouble(p);
 }
-inline bool JS::NativeExceptionsManager::ExceptionData::isFatal() const
+inline bool ABI44_0_0JS::NativeExceptionsManager::ExceptionData::isFatal() const
 {
   id const p = _v[@"isFatal"];
   return ABI44_0_0RCTBridgingToBool(p);
 }
-inline id<NSObject> _Nullable JS::NativeExceptionsManager::ExceptionData::extraData() const
+inline id<NSObject> _Nullable ABI44_0_0JS::NativeExceptionsManager::ExceptionData::extraData() const
 {
   id const p = _v[@"extraData"];
   return p;
 }
 
-inline folly::Optional<bool> JS::NativeFrameRateLogger::SpecSetGlobalOptionsOptions::debug() const
+inline folly::Optional<bool> ABI44_0_0JS::NativeFrameRateLogger::SpecSetGlobalOptionsOptions::debug() const
 {
   id const p = _v[@"debug"];
   return ABI44_0_0RCTBridgingToOptionalBool(p);
 }
-inline folly::Optional<bool> JS::NativeFrameRateLogger::SpecSetGlobalOptionsOptions::reportStackTraces() const
+inline folly::Optional<bool> ABI44_0_0JS::NativeFrameRateLogger::SpecSetGlobalOptionsOptions::reportStackTraces() const
 {
   id const p = _v[@"reportStackTraces"];
   return ABI44_0_0RCTBridgingToOptionalBool(p);
 }
 
-inline JS::NativeI18nManager::Constants::Builder::Builder(const Input i) : _factory(^{
+inline ABI44_0_0JS::NativeI18nManager::Constants::Builder::Builder(const Input i) : _factory(^{
   NSMutableDictionary *d = [NSMutableDictionary new];
   auto isRTL = i.isRTL.get();
   d[@"isRTL"] = @(isRTL);
@@ -2261,81 +2261,81 @@ inline JS::NativeI18nManager::Constants::Builder::Builder(const Input i) : _fact
   d[@"doLeftAndRightSwapInRTL"] = @(doLeftAndRightSwapInRTL);
   return d;
 }) {}
-inline JS::NativeI18nManager::Constants::Builder::Builder(Constants i) : _factory(^{
+inline ABI44_0_0JS::NativeI18nManager::Constants::Builder::Builder(Constants i) : _factory(^{
   return i.unsafeRawValue();
 }) {}
-inline double JS::NativeImageEditor::OptionsOffset::x() const
+inline double ABI44_0_0JS::NativeImageEditor::OptionsOffset::x() const
 {
   id const p = _v[@"x"];
   return ABI44_0_0RCTBridgingToDouble(p);
 }
-inline double JS::NativeImageEditor::OptionsOffset::y() const
+inline double ABI44_0_0JS::NativeImageEditor::OptionsOffset::y() const
 {
   id const p = _v[@"y"];
   return ABI44_0_0RCTBridgingToDouble(p);
 }
-inline double JS::NativeImageEditor::OptionsSize::width() const
+inline double ABI44_0_0JS::NativeImageEditor::OptionsSize::width() const
 {
   id const p = _v[@"width"];
   return ABI44_0_0RCTBridgingToDouble(p);
 }
-inline double JS::NativeImageEditor::OptionsSize::height() const
+inline double ABI44_0_0JS::NativeImageEditor::OptionsSize::height() const
 {
   id const p = _v[@"height"];
   return ABI44_0_0RCTBridgingToDouble(p);
 }
-inline double JS::NativeImageEditor::OptionsDisplaySize::width() const
+inline double ABI44_0_0JS::NativeImageEditor::OptionsDisplaySize::width() const
 {
   id const p = _v[@"width"];
   return ABI44_0_0RCTBridgingToDouble(p);
 }
-inline double JS::NativeImageEditor::OptionsDisplaySize::height() const
+inline double ABI44_0_0JS::NativeImageEditor::OptionsDisplaySize::height() const
 {
   id const p = _v[@"height"];
   return ABI44_0_0RCTBridgingToDouble(p);
 }
-inline JS::NativeImageEditor::OptionsOffset JS::NativeImageEditor::Options::offset() const
+inline ABI44_0_0JS::NativeImageEditor::OptionsOffset ABI44_0_0JS::NativeImageEditor::Options::offset() const
 {
   id const p = _v[@"offset"];
-  return JS::NativeImageEditor::OptionsOffset(p);
+  return ABI44_0_0JS::NativeImageEditor::OptionsOffset(p);
 }
-inline JS::NativeImageEditor::OptionsSize JS::NativeImageEditor::Options::size() const
+inline ABI44_0_0JS::NativeImageEditor::OptionsSize ABI44_0_0JS::NativeImageEditor::Options::size() const
 {
   id const p = _v[@"size"];
-  return JS::NativeImageEditor::OptionsSize(p);
+  return ABI44_0_0JS::NativeImageEditor::OptionsSize(p);
 }
-inline folly::Optional<JS::NativeImageEditor::OptionsDisplaySize> JS::NativeImageEditor::Options::displaySize() const
+inline folly::Optional<ABI44_0_0JS::NativeImageEditor::OptionsDisplaySize> ABI44_0_0JS::NativeImageEditor::Options::displaySize() const
 {
   id const p = _v[@"displaySize"];
-  return (p == nil ? folly::none : folly::make_optional(JS::NativeImageEditor::OptionsDisplaySize(p)));
+  return (p == nil ? folly::none : folly::make_optional(ABI44_0_0JS::NativeImageEditor::OptionsDisplaySize(p)));
 }
-inline NSString *JS::NativeImageEditor::Options::resizeMode() const
+inline NSString *ABI44_0_0JS::NativeImageEditor::Options::resizeMode() const
 {
   id const p = _v[@"resizeMode"];
   return ABI44_0_0RCTBridgingToOptionalString(p);
 }
-inline folly::Optional<bool> JS::NativeImageEditor::Options::allowExternalStorage() const
+inline folly::Optional<bool> ABI44_0_0JS::NativeImageEditor::Options::allowExternalStorage() const
 {
   id const p = _v[@"allowExternalStorage"];
   return ABI44_0_0RCTBridgingToOptionalBool(p);
 }
 
-inline bool JS::NativeImagePickerIOS::SpecOpenCameraDialogConfig::unmirrorFrontFacingCamera() const
+inline bool ABI44_0_0JS::NativeImagePickerIOS::SpecOpenCameraDialogConfig::unmirrorFrontFacingCamera() const
 {
   id const p = _v[@"unmirrorFrontFacingCamera"];
   return ABI44_0_0RCTBridgingToBool(p);
 }
-inline bool JS::NativeImagePickerIOS::SpecOpenCameraDialogConfig::videoMode() const
+inline bool ABI44_0_0JS::NativeImagePickerIOS::SpecOpenCameraDialogConfig::videoMode() const
 {
   id const p = _v[@"videoMode"];
   return ABI44_0_0RCTBridgingToBool(p);
 }
-inline bool JS::NativeImagePickerIOS::SpecOpenSelectDialogConfig::showImages() const
+inline bool ABI44_0_0JS::NativeImagePickerIOS::SpecOpenSelectDialogConfig::showImages() const
 {
   id const p = _v[@"showImages"];
   return ABI44_0_0RCTBridgingToBool(p);
 }
-inline bool JS::NativeImagePickerIOS::SpecOpenSelectDialogConfig::showVideos() const
+inline bool ABI44_0_0JS::NativeImagePickerIOS::SpecOpenSelectDialogConfig::showVideos() const
 {
   id const p = _v[@"showVideos"];
   return ABI44_0_0RCTBridgingToBool(p);
@@ -2343,7 +2343,7 @@ inline bool JS::NativeImagePickerIOS::SpecOpenSelectDialogConfig::showVideos() c
 
 
 
-inline JS::NativeJSDevSupport::Constants::Builder::Builder(const Input i) : _factory(^{
+inline ABI44_0_0JS::NativeJSDevSupport::Constants::Builder::Builder(const Input i) : _factory(^{
   NSMutableDictionary *d = [NSMutableDictionary new];
   auto ERROR_CODE_EXCEPTION = i.ERROR_CODE_EXCEPTION.get();
   d[@"ERROR_CODE_EXCEPTION"] = @(ERROR_CODE_EXCEPTION);
@@ -2351,54 +2351,54 @@ inline JS::NativeJSDevSupport::Constants::Builder::Builder(const Input i) : _fac
   d[@"ERROR_CODE_VIEW_NOT_FOUND"] = @(ERROR_CODE_VIEW_NOT_FOUND);
   return d;
 }) {}
-inline JS::NativeJSDevSupport::Constants::Builder::Builder(Constants i) : _factory(^{
+inline ABI44_0_0JS::NativeJSDevSupport::Constants::Builder::Builder(Constants i) : _factory(^{
   return i.unsafeRawValue();
 }) {}
 
 
 
 
-inline NSString *JS::NativeNetworkingIOS::SpecSendRequestQuery::method() const
+inline NSString *ABI44_0_0JS::NativeNetworkingIOS::SpecSendRequestQuery::method() const
 {
   id const p = _v[@"method"];
   return ABI44_0_0RCTBridgingToString(p);
 }
-inline NSString *JS::NativeNetworkingIOS::SpecSendRequestQuery::url() const
+inline NSString *ABI44_0_0JS::NativeNetworkingIOS::SpecSendRequestQuery::url() const
 {
   id const p = _v[@"url"];
   return ABI44_0_0RCTBridgingToString(p);
 }
-inline id<NSObject>  JS::NativeNetworkingIOS::SpecSendRequestQuery::data() const
+inline id<NSObject>  ABI44_0_0JS::NativeNetworkingIOS::SpecSendRequestQuery::data() const
 {
   id const p = _v[@"data"];
   return p;
 }
-inline id<NSObject>  JS::NativeNetworkingIOS::SpecSendRequestQuery::headers() const
+inline id<NSObject>  ABI44_0_0JS::NativeNetworkingIOS::SpecSendRequestQuery::headers() const
 {
   id const p = _v[@"headers"];
   return p;
 }
-inline NSString *JS::NativeNetworkingIOS::SpecSendRequestQuery::responseType() const
+inline NSString *ABI44_0_0JS::NativeNetworkingIOS::SpecSendRequestQuery::responseType() const
 {
   id const p = _v[@"responseType"];
   return ABI44_0_0RCTBridgingToString(p);
 }
-inline bool JS::NativeNetworkingIOS::SpecSendRequestQuery::incrementalUpdates() const
+inline bool ABI44_0_0JS::NativeNetworkingIOS::SpecSendRequestQuery::incrementalUpdates() const
 {
   id const p = _v[@"incrementalUpdates"];
   return ABI44_0_0RCTBridgingToBool(p);
 }
-inline double JS::NativeNetworkingIOS::SpecSendRequestQuery::timeout() const
+inline double ABI44_0_0JS::NativeNetworkingIOS::SpecSendRequestQuery::timeout() const
 {
   id const p = _v[@"timeout"];
   return ABI44_0_0RCTBridgingToDouble(p);
 }
-inline bool JS::NativeNetworkingIOS::SpecSendRequestQuery::withCredentials() const
+inline bool ABI44_0_0JS::NativeNetworkingIOS::SpecSendRequestQuery::withCredentials() const
 {
   id const p = _v[@"withCredentials"];
   return ABI44_0_0RCTBridgingToBool(p);
 }
-inline JS::NativePlatformConstantsIOS::ConstantsreactNativeVersion::Builder::Builder(const Input i) : _factory(^{
+inline ABI44_0_0JS::NativePlatformConstantsIOS::ConstantsreactNativeVersion::Builder::Builder(const Input i) : _factory(^{
   NSMutableDictionary *d = [NSMutableDictionary new];
   auto major = i.major.get();
   d[@"major"] = @(major);
@@ -2410,10 +2410,10 @@ inline JS::NativePlatformConstantsIOS::ConstantsreactNativeVersion::Builder::Bui
   d[@"prerelease"] = prerelease.hasValue() ? @((double)prerelease.value()) : nil;
   return d;
 }) {}
-inline JS::NativePlatformConstantsIOS::ConstantsreactNativeVersion::Builder::Builder(ConstantsreactNativeVersion i) : _factory(^{
+inline ABI44_0_0JS::NativePlatformConstantsIOS::ConstantsreactNativeVersion::Builder::Builder(ConstantsreactNativeVersion i) : _factory(^{
   return i.unsafeRawValue();
 }) {}
-inline JS::NativePlatformConstantsIOS::Constants::Builder::Builder(const Input i) : _factory(^{
+inline ABI44_0_0JS::NativePlatformConstantsIOS::Constants::Builder::Builder(const Input i) : _factory(^{
   NSMutableDictionary *d = [NSMutableDictionary new];
   auto isTesting = i.isTesting.get();
   d[@"isTesting"] = @(isTesting);
@@ -2429,101 +2429,101 @@ inline JS::NativePlatformConstantsIOS::Constants::Builder::Builder(const Input i
   d[@"interfaceIdiom"] = interfaceIdiom;
   return d;
 }) {}
-inline JS::NativePlatformConstantsIOS::Constants::Builder::Builder(Constants i) : _factory(^{
+inline ABI44_0_0JS::NativePlatformConstantsIOS::Constants::Builder::Builder(Constants i) : _factory(^{
   return i.unsafeRawValue();
 }) {}
-inline bool JS::NativePushNotificationManagerIOS::SpecRequestPermissionsPermission::alert() const
+inline bool ABI44_0_0JS::NativePushNotificationManagerIOS::SpecRequestPermissionsPermission::alert() const
 {
   id const p = _v[@"alert"];
   return ABI44_0_0RCTBridgingToBool(p);
 }
-inline bool JS::NativePushNotificationManagerIOS::SpecRequestPermissionsPermission::badge() const
+inline bool ABI44_0_0JS::NativePushNotificationManagerIOS::SpecRequestPermissionsPermission::badge() const
 {
   id const p = _v[@"badge"];
   return ABI44_0_0RCTBridgingToBool(p);
 }
-inline bool JS::NativePushNotificationManagerIOS::SpecRequestPermissionsPermission::sound() const
+inline bool ABI44_0_0JS::NativePushNotificationManagerIOS::SpecRequestPermissionsPermission::sound() const
 {
   id const p = _v[@"sound"];
   return ABI44_0_0RCTBridgingToBool(p);
 }
-inline NSString *JS::NativePushNotificationManagerIOS::Notification::alertTitle() const
+inline NSString *ABI44_0_0JS::NativePushNotificationManagerIOS::Notification::alertTitle() const
 {
   id const p = _v[@"alertTitle"];
   return ABI44_0_0RCTBridgingToOptionalString(p);
 }
-inline folly::Optional<double> JS::NativePushNotificationManagerIOS::Notification::fireDate() const
+inline folly::Optional<double> ABI44_0_0JS::NativePushNotificationManagerIOS::Notification::fireDate() const
 {
   id const p = _v[@"fireDate"];
   return ABI44_0_0RCTBridgingToOptionalDouble(p);
 }
-inline NSString *JS::NativePushNotificationManagerIOS::Notification::alertBody() const
+inline NSString *ABI44_0_0JS::NativePushNotificationManagerIOS::Notification::alertBody() const
 {
   id const p = _v[@"alertBody"];
   return ABI44_0_0RCTBridgingToOptionalString(p);
 }
-inline NSString *JS::NativePushNotificationManagerIOS::Notification::alertAction() const
+inline NSString *ABI44_0_0JS::NativePushNotificationManagerIOS::Notification::alertAction() const
 {
   id const p = _v[@"alertAction"];
   return ABI44_0_0RCTBridgingToOptionalString(p);
 }
-inline id<NSObject> _Nullable JS::NativePushNotificationManagerIOS::Notification::userInfo() const
+inline id<NSObject> _Nullable ABI44_0_0JS::NativePushNotificationManagerIOS::Notification::userInfo() const
 {
   id const p = _v[@"userInfo"];
   return p;
 }
-inline NSString *JS::NativePushNotificationManagerIOS::Notification::category() const
+inline NSString *ABI44_0_0JS::NativePushNotificationManagerIOS::Notification::category() const
 {
   id const p = _v[@"category"];
   return ABI44_0_0RCTBridgingToOptionalString(p);
 }
-inline NSString *JS::NativePushNotificationManagerIOS::Notification::repeatInterval() const
+inline NSString *ABI44_0_0JS::NativePushNotificationManagerIOS::Notification::repeatInterval() const
 {
   id const p = _v[@"repeatInterval"];
   return ABI44_0_0RCTBridgingToOptionalString(p);
 }
-inline folly::Optional<double> JS::NativePushNotificationManagerIOS::Notification::applicationIconBadgeNumber() const
+inline folly::Optional<double> ABI44_0_0JS::NativePushNotificationManagerIOS::Notification::applicationIconBadgeNumber() const
 {
   id const p = _v[@"applicationIconBadgeNumber"];
   return ABI44_0_0RCTBridgingToOptionalDouble(p);
 }
-inline folly::Optional<bool> JS::NativePushNotificationManagerIOS::Notification::isSilent() const
+inline folly::Optional<bool> ABI44_0_0JS::NativePushNotificationManagerIOS::Notification::isSilent() const
 {
   id const p = _v[@"isSilent"];
   return ABI44_0_0RCTBridgingToOptionalBool(p);
 }
 
 
-inline JS::NativeSettingsManager::Constants::Builder::Builder(const Input i) : _factory(^{
+inline ABI44_0_0JS::NativeSettingsManager::Constants::Builder::Builder(const Input i) : _factory(^{
   NSMutableDictionary *d = [NSMutableDictionary new];
   auto settings = i.settings.get();
   d[@"settings"] = settings;
   return d;
 }) {}
-inline JS::NativeSettingsManager::Constants::Builder::Builder(Constants i) : _factory(^{
+inline ABI44_0_0JS::NativeSettingsManager::Constants::Builder::Builder(Constants i) : _factory(^{
   return i.unsafeRawValue();
 }) {}
-inline NSString *JS::NativeShareModule::SpecShareContent::title() const
+inline NSString *ABI44_0_0JS::NativeShareModule::SpecShareContent::title() const
 {
   id const p = _v[@"title"];
   return ABI44_0_0RCTBridgingToOptionalString(p);
 }
-inline NSString *JS::NativeShareModule::SpecShareContent::message() const
+inline NSString *ABI44_0_0JS::NativeShareModule::SpecShareContent::message() const
 {
   id const p = _v[@"message"];
   return ABI44_0_0RCTBridgingToOptionalString(p);
 }
 
-inline JS::NativeSourceCode::Constants::Builder::Builder(const Input i) : _factory(^{
+inline ABI44_0_0JS::NativeSourceCode::Constants::Builder::Builder(const Input i) : _factory(^{
   NSMutableDictionary *d = [NSMutableDictionary new];
   auto scriptURL = i.scriptURL.get();
   d[@"scriptURL"] = scriptURL;
   return d;
 }) {}
-inline JS::NativeSourceCode::Constants::Builder::Builder(Constants i) : _factory(^{
+inline ABI44_0_0JS::NativeSourceCode::Constants::Builder::Builder(Constants i) : _factory(^{
   return i.unsafeRawValue();
 }) {}
-inline JS::NativeStatusBarManagerIOS::Constants::Builder::Builder(const Input i) : _factory(^{
+inline ABI44_0_0JS::NativeStatusBarManagerIOS::Constants::Builder::Builder(const Input i) : _factory(^{
   NSMutableDictionary *d = [NSMutableDictionary new];
   auto HEIGHT = i.HEIGHT.get();
   d[@"HEIGHT"] = @(HEIGHT);
@@ -2531,12 +2531,12 @@ inline JS::NativeStatusBarManagerIOS::Constants::Builder::Builder(const Input i)
   d[@"DEFAULT_BACKGROUND_COLOR"] = DEFAULT_BACKGROUND_COLOR.hasValue() ? @((double)DEFAULT_BACKGROUND_COLOR.value()) : nil;
   return d;
 }) {}
-inline JS::NativeStatusBarManagerIOS::Constants::Builder::Builder(Constants i) : _factory(^{
+inline ABI44_0_0JS::NativeStatusBarManagerIOS::Constants::Builder::Builder(Constants i) : _factory(^{
   return i.unsafeRawValue();
 }) {}
 
 
-inline id<NSObject> _Nullable JS::NativeWebSocketModule::SpecConnectOptions::headers() const
+inline id<NSObject> _Nullable ABI44_0_0JS::NativeWebSocketModule::SpecConnectOptions::headers() const
 {
   id const p = _v[@"headers"];
   return p;

--- a/ios/versioned-react-native/ABI45_0_0/Expo/ExpoKit/Core/Api/SafeAreaContext/ABI45_0_0SafeAreaContextSpec.h
+++ b/ios/versioned-react-native/ABI45_0_0/Expo/ExpoKit/Core/Api/SafeAreaContext/ABI45_0_0SafeAreaContextSpec.h
@@ -25,7 +25,7 @@
 #import <folly/Optional.h>
 #import <vector>
 
-namespace JS {
+namespace ABI45_0_0JS {
   namespace NativeSafeAreaContext {
     struct ConstantsInitialWindowMetricsInsets {
 
@@ -55,7 +55,7 @@ namespace JS {
     };
   }
 }
-namespace JS {
+namespace ABI45_0_0JS {
   namespace NativeSafeAreaContext {
     struct ConstantsInitialWindowMetricsFrame {
 
@@ -85,14 +85,14 @@ namespace JS {
     };
   }
 }
-namespace JS {
+namespace ABI45_0_0JS {
   namespace NativeSafeAreaContext {
     struct ConstantsInitialWindowMetrics {
 
       struct Builder {
         struct Input {
-          ABI45_0_0RCTRequired<JS::NativeSafeAreaContext::ConstantsInitialWindowMetricsInsets::Builder> insets;
-          ABI45_0_0RCTRequired<JS::NativeSafeAreaContext::ConstantsInitialWindowMetricsFrame::Builder> frame;
+          ABI45_0_0RCTRequired<ABI45_0_0JS::NativeSafeAreaContext::ConstantsInitialWindowMetricsInsets::Builder> insets;
+          ABI45_0_0RCTRequired<ABI45_0_0JS::NativeSafeAreaContext::ConstantsInitialWindowMetricsFrame::Builder> frame;
         };
 
         /** Initialize with a set of values */
@@ -113,13 +113,13 @@ namespace JS {
     };
   }
 }
-namespace JS {
+namespace ABI45_0_0JS {
   namespace NativeSafeAreaContext {
     struct Constants {
 
       struct Builder {
         struct Input {
-          folly::Optional<JS::NativeSafeAreaContext::ConstantsInitialWindowMetrics::Builder> initialWindowMetrics;
+          folly::Optional<ABI45_0_0JS::NativeSafeAreaContext::ConstantsInitialWindowMetrics::Builder> initialWindowMetrics;
         };
 
         /** Initialize with a set of values */
@@ -142,8 +142,8 @@ namespace JS {
 }
 @protocol ABI45_0_0NativeSafeAreaContextSpec <ABI45_0_0RCTBridgeModule, ABI45_0_0RCTTurboModule>
 
-- (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<JS::NativeSafeAreaContext::Constants::Builder>)constantsToExport;
-- (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<JS::NativeSafeAreaContext::Constants::Builder>)getConstants;
+- (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<ABI45_0_0JS::NativeSafeAreaContext::Constants::Builder>)constantsToExport;
+- (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<ABI45_0_0JS::NativeSafeAreaContext::Constants::Builder>)getConstants;
 
 @end
 namespace ABI45_0_0facebook {
@@ -157,7 +157,7 @@ namespace ABI45_0_0facebook {
     };
   } // namespace ABI45_0_0React
 } // namespace ABI45_0_0facebook
-inline JS::NativeSafeAreaContext::ConstantsInitialWindowMetricsInsets::Builder::Builder(const Input i) : _factory(^{
+inline ABI45_0_0JS::NativeSafeAreaContext::ConstantsInitialWindowMetricsInsets::Builder::Builder(const Input i) : _factory(^{
   NSMutableDictionary *d = [NSMutableDictionary new];
   auto top = i.top.get();
   d[@"top"] = @(top);
@@ -169,10 +169,10 @@ inline JS::NativeSafeAreaContext::ConstantsInitialWindowMetricsInsets::Builder::
   d[@"left"] = @(left);
   return d;
 }) {}
-inline JS::NativeSafeAreaContext::ConstantsInitialWindowMetricsInsets::Builder::Builder(ConstantsInitialWindowMetricsInsets i) : _factory(^{
+inline ABI45_0_0JS::NativeSafeAreaContext::ConstantsInitialWindowMetricsInsets::Builder::Builder(ConstantsInitialWindowMetricsInsets i) : _factory(^{
   return i.unsafeRawValue();
 }) {}
-inline JS::NativeSafeAreaContext::ConstantsInitialWindowMetricsFrame::Builder::Builder(const Input i) : _factory(^{
+inline ABI45_0_0JS::NativeSafeAreaContext::ConstantsInitialWindowMetricsFrame::Builder::Builder(const Input i) : _factory(^{
   NSMutableDictionary *d = [NSMutableDictionary new];
   auto x = i.x.get();
   d[@"x"] = @(x);
@@ -184,10 +184,10 @@ inline JS::NativeSafeAreaContext::ConstantsInitialWindowMetricsFrame::Builder::B
   d[@"height"] = @(height);
   return d;
 }) {}
-inline JS::NativeSafeAreaContext::ConstantsInitialWindowMetricsFrame::Builder::Builder(ConstantsInitialWindowMetricsFrame i) : _factory(^{
+inline ABI45_0_0JS::NativeSafeAreaContext::ConstantsInitialWindowMetricsFrame::Builder::Builder(ConstantsInitialWindowMetricsFrame i) : _factory(^{
   return i.unsafeRawValue();
 }) {}
-inline JS::NativeSafeAreaContext::ConstantsInitialWindowMetrics::Builder::Builder(const Input i) : _factory(^{
+inline ABI45_0_0JS::NativeSafeAreaContext::ConstantsInitialWindowMetrics::Builder::Builder(const Input i) : _factory(^{
   NSMutableDictionary *d = [NSMutableDictionary new];
   auto insets = i.insets.get();
   d[@"insets"] = insets.buildUnsafeRawValue();
@@ -195,15 +195,15 @@ inline JS::NativeSafeAreaContext::ConstantsInitialWindowMetrics::Builder::Builde
   d[@"frame"] = frame.buildUnsafeRawValue();
   return d;
 }) {}
-inline JS::NativeSafeAreaContext::ConstantsInitialWindowMetrics::Builder::Builder(ConstantsInitialWindowMetrics i) : _factory(^{
+inline ABI45_0_0JS::NativeSafeAreaContext::ConstantsInitialWindowMetrics::Builder::Builder(ConstantsInitialWindowMetrics i) : _factory(^{
   return i.unsafeRawValue();
 }) {}
-inline JS::NativeSafeAreaContext::Constants::Builder::Builder(const Input i) : _factory(^{
+inline ABI45_0_0JS::NativeSafeAreaContext::Constants::Builder::Builder(const Input i) : _factory(^{
   NSMutableDictionary *d = [NSMutableDictionary new];
   auto initialWindowMetrics = i.initialWindowMetrics;
   d[@"initialWindowMetrics"] = initialWindowMetrics.hasValue() ? initialWindowMetrics.value().buildUnsafeRawValue() : nil;
   return d;
 }) {}
-inline JS::NativeSafeAreaContext::Constants::Builder::Builder(Constants i) : _factory(^{
+inline ABI45_0_0JS::NativeSafeAreaContext::Constants::Builder::Builder(Constants i) : _factory(^{
   return i.unsafeRawValue();
 }) {}

--- a/ios/versioned-react-native/ABI45_0_0/ReactNative/Libraries/Image/ABI45_0_0RCTImageEditingManager.mm
+++ b/ios/versioned-react-native/ABI45_0_0/ReactNative/Libraries/Image/ABI45_0_0RCTImageEditingManager.mm
@@ -39,7 +39,7 @@ ABI45_0_0RCT_EXPORT_MODULE()
  *        All units are in px (not points).
  */
 ABI45_0_0RCT_EXPORT_METHOD(cropImage:(NSURLRequest *)imageRequest
-                  cropData:(JS::NativeImageEditor::Options &)cropData
+                  cropData:(ABI45_0_0JS::NativeImageEditor::Options &)cropData
                   successCallback:(ABI45_0_0RCTResponseSenderBlock)successCallback
                   errorCallback:(ABI45_0_0RCTResponseSenderBlock)errorCallback)
 {
@@ -55,7 +55,7 @@ ABI45_0_0RCT_EXPORT_METHOD(cropImage:(NSURLRequest *)imageRequest
   };
 
   // We must keep a copy of cropData so that we can access data from it at a later time
-  JS::NativeImageEditor::Options cropDataCopy = cropData;
+  ABI45_0_0JS::NativeImageEditor::Options cropDataCopy = cropData;
 
   [[_moduleRegistry moduleForName:"ImageLoader"]
    loadImageWithURLRequest:imageRequest callback:^(NSError *error, UIImage *image) {

--- a/ios/versioned-react-native/ABI45_0_0/ReactNative/Libraries/NativeAnimation/ABI45_0_0RCTNativeAnimatedModule.mm
+++ b/ios/versioned-react-native/ABI45_0_0/ReactNative/Libraries/NativeAnimation/ABI45_0_0RCTNativeAnimatedModule.mm
@@ -221,7 +221,7 @@ ABI45_0_0RCT_EXPORT_METHOD(stopListeningToAnimatedNodeValue:(double)tag)
 
 ABI45_0_0RCT_EXPORT_METHOD(addAnimatedEventToView:(double)viewTag
                   eventName:(nonnull NSString *)eventName
-                  eventMapping:(JS::NativeAnimatedModule::EventMapping &)eventMapping)
+                  eventMapping:(ABI45_0_0JS::NativeAnimatedModule::EventMapping &)eventMapping)
 {
   NSMutableDictionary *eventMappingDict = [NSMutableDictionary new];
   eventMappingDict[@"nativeEventPath"] = ABI45_0_0RCTConvertVecToArray(eventMapping.nativeEventPath());

--- a/ios/versioned-react-native/ABI45_0_0/ReactNative/Libraries/NativeAnimation/ABI45_0_0RCTNativeAnimatedTurboModule.mm
+++ b/ios/versioned-react-native/ABI45_0_0/ReactNative/Libraries/NativeAnimation/ABI45_0_0RCTNativeAnimatedTurboModule.mm
@@ -232,7 +232,7 @@ ABI45_0_0RCT_EXPORT_METHOD(stopListeningToAnimatedNodeValue:(double)tag)
 
 ABI45_0_0RCT_EXPORT_METHOD(addAnimatedEventToView:(double)viewTag
                   eventName:(nonnull NSString *)eventName
-                  eventMapping:(JS::NativeAnimatedModule::EventMapping &)eventMapping)
+                  eventMapping:(ABI45_0_0JS::NativeAnimatedModule::EventMapping &)eventMapping)
 {
   NSMutableDictionary *eventMappingDict = [NSMutableDictionary new];
   eventMappingDict[@"nativeEventPath"] = ABI45_0_0RCTConvertVecToArray(eventMapping.nativeEventPath());

--- a/ios/versioned-react-native/ABI45_0_0/ReactNative/Libraries/Network/ABI45_0_0RCTNetworking.mm
+++ b/ios/versioned-react-native/ABI45_0_0/ReactNative/Libraries/Network/ABI45_0_0RCTNetworking.mm
@@ -678,7 +678,7 @@ ABI45_0_0RCT_EXPORT_MODULE()
 
 #pragma mark - JS API
 
-ABI45_0_0RCT_EXPORT_METHOD(sendRequest:(JS::NativeNetworkingIOS::SpecSendRequestQuery &)query
+ABI45_0_0RCT_EXPORT_METHOD(sendRequest:(ABI45_0_0JS::NativeNetworkingIOS::SpecSendRequestQuery &)query
                   callback:(ABI45_0_0RCTResponseSenderBlock)responseSender)
 {
   NSDictionary *queryDict = @{

--- a/ios/versioned-react-native/ABI45_0_0/ReactNative/Libraries/PushNotificationIOS/ABI45_0_0RCTPushNotificationManager.mm
+++ b/ios/versioned-react-native/ABI45_0_0/ReactNative/Libraries/PushNotificationIOS/ABI45_0_0RCTPushNotificationManager.mm
@@ -283,7 +283,7 @@ ABI45_0_0RCT_EXPORT_METHOD(getApplicationIconBadgeNumber:(ABI45_0_0RCTResponseSe
   callback(@[@(ABI45_0_0RCTSharedApplication().applicationIconBadgeNumber)]);
 }
 
-ABI45_0_0RCT_EXPORT_METHOD(requestPermissions:(JS::NativePushNotificationManagerIOS::SpecRequestPermissionsPermission &)permissions
+ABI45_0_0RCT_EXPORT_METHOD(requestPermissions:(ABI45_0_0JS::NativePushNotificationManagerIOS::SpecRequestPermissionsPermission &)permissions
                  resolve:(ABI45_0_0RCTPromiseResolveBlock)resolve
                  reject:(ABI45_0_0RCTPromiseRejectBlock)reject)
 {
@@ -348,7 +348,7 @@ static inline NSDictionary *ABI45_0_0RCTSettingsDictForUNNotificationSettings(BO
   return @{@"alert": @(alert), @"badge": @(badge), @"sound": @(sound)};
 }
 
-ABI45_0_0RCT_EXPORT_METHOD(presentLocalNotification:(JS::NativePushNotificationManagerIOS::Notification &)notification)
+ABI45_0_0RCT_EXPORT_METHOD(presentLocalNotification:(ABI45_0_0JS::NativePushNotificationManagerIOS::Notification &)notification)
 {
   NSMutableDictionary *notificationDict = [NSMutableDictionary new];
   notificationDict[@"alertTitle"] = notification.alertTitle();
@@ -369,7 +369,7 @@ ABI45_0_0RCT_EXPORT_METHOD(presentLocalNotification:(JS::NativePushNotificationM
   [ABI45_0_0RCTSharedApplication() presentLocalNotificationNow:[ABI45_0_0RCTConvert UILocalNotification:notificationDict]];
 }
 
-ABI45_0_0RCT_EXPORT_METHOD(scheduleLocalNotification:(JS::NativePushNotificationManagerIOS::Notification &)notification)
+ABI45_0_0RCT_EXPORT_METHOD(scheduleLocalNotification:(ABI45_0_0JS::NativePushNotificationManagerIOS::Notification &)notification)
 {
   NSMutableDictionary *notificationDict = [NSMutableDictionary new];
   notificationDict[@"alertTitle"] = notification.alertTitle();
@@ -495,7 +495,7 @@ ABI45_0_0RCT_EXPORT_METHOD(getApplicationIconBadgeNumber:(ABI45_0_0RCTResponseSe
   ABI45_0_0RCTLogError(@"Not implemented: %@", NSStringFromSelector(_cmd));
 }
 
-ABI45_0_0RCT_EXPORT_METHOD(requestPermissions:(JS::NativePushNotificationManagerIOS::SpecRequestPermissionsPermission &)permissions
+ABI45_0_0RCT_EXPORT_METHOD(requestPermissions:(ABI45_0_0JS::NativePushNotificationManagerIOS::SpecRequestPermissionsPermission &)permissions
                  resolve:(ABI45_0_0RCTPromiseResolveBlock)resolve
                  reject:(ABI45_0_0RCTPromiseRejectBlock)reject)
 {
@@ -512,12 +512,12 @@ ABI45_0_0RCT_EXPORT_METHOD(checkPermissions:(ABI45_0_0RCTResponseSenderBlock)cal
   ABI45_0_0RCTLogError(@"Not implemented: %@", NSStringFromSelector(_cmd));
 }
 
-ABI45_0_0RCT_EXPORT_METHOD(presentLocalNotification:(JS::NativePushNotificationManagerIOS::Notification &)notification)
+ABI45_0_0RCT_EXPORT_METHOD(presentLocalNotification:(ABI45_0_0JS::NativePushNotificationManagerIOS::Notification &)notification)
 {
   ABI45_0_0RCTLogError(@"Not implemented: %@", NSStringFromSelector(_cmd));
 }
 
-ABI45_0_0RCT_EXPORT_METHOD(scheduleLocalNotification:(JS::NativePushNotificationManagerIOS::Notification &)notification)
+ABI45_0_0RCT_EXPORT_METHOD(scheduleLocalNotification:(ABI45_0_0JS::NativePushNotificationManagerIOS::Notification &)notification)
 {
   ABI45_0_0RCTLogError(@"Not implemented: %@", NSStringFromSelector(_cmd));
 }

--- a/ios/versioned-react-native/ABI45_0_0/ReactNative/Libraries/Settings/ABI45_0_0RCTSettingsManager.mm
+++ b/ios/versioned-react-native/ABI45_0_0/ReactNative/Libraries/Settings/ABI45_0_0RCTSettingsManager.mm
@@ -52,14 +52,14 @@ ABI45_0_0RCT_EXPORT_MODULE()
   return self;
 }
 
-- (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<JS::NativeSettingsManager::Constants>)constantsToExport
+- (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<ABI45_0_0JS::NativeSettingsManager::Constants>)constantsToExport
 {
-  return (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<JS::NativeSettingsManager::Constants>)[self getConstants];
+  return (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<ABI45_0_0JS::NativeSettingsManager::Constants>)[self getConstants];
 }
 
-- (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<JS::NativeSettingsManager::Constants>)getConstants
+- (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<ABI45_0_0JS::NativeSettingsManager::Constants>)getConstants
 {
-  return ABI45_0_0facebook::ABI45_0_0React::typedConstants<JS::NativeSettingsManager::Constants>({
+  return ABI45_0_0facebook::ABI45_0_0React::typedConstants<ABI45_0_0JS::NativeSettingsManager::Constants>({
     .settings = ABI45_0_0RCTJSONClean([_defaults dictionaryRepresentation])
   });
 }

--- a/ios/versioned-react-native/ABI45_0_0/ReactNative/Libraries/TypeSafety/ABI45_0_0RCTTypedModuleConstants.h
+++ b/ios/versioned-react-native/ABI45_0_0/ReactNative/Libraries/TypeSafety/ABI45_0_0RCTTypedModuleConstants.h
@@ -17,9 +17,9 @@
  *
  * The ABI45_0_0NativeModuleSpec will define a constantsToExport method which you can implement as follows:
  *
- * - (nonnull ModuleConstants<JS::Constants>)constantsToExport
+ * - (nonnull ModuleConstants<ABI45_0_0JS::Constants>)constantsToExport
  * {
- *   return typedConstants<JS::Constants>({ ... });
+ *   return typedConstants<ABI45_0_0JS::Constants>({ ... });
  * }
  */
 

--- a/ios/versioned-react-native/ABI45_0_0/ReactNative/React/Base/ABI45_0_0RCTModuleMethod.mm
+++ b/ios/versioned-react-native/ABI45_0_0/ReactNative/React/Base/ABI45_0_0RCTModuleMethod.mm
@@ -371,7 +371,7 @@ ABI45_0_0RCT_EXTERN_C_END
         NSDictionary *errorJSON = ABI45_0_0RCTJSErrorFromCodeMessageAndNSError(code, message, error);
         [bridge enqueueCallback:json args:@[ errorJSON ]];
       });
-    } else if ([typeName hasPrefix:@"JS::"]) {
+    } else if ([typeName hasPrefix:@"ABI45_0_0JS::"]) {
       NSString *selectorNameForCxxType =
           [[typeName stringByReplacingOccurrencesOfString:@"::" withString:@"_"] stringByAppendingString:@":"];
       selector = NSSelectorFromString(selectorNameForCxxType);

--- a/ios/versioned-react-native/ABI45_0_0/ReactNative/React/CoreModules/ABI45_0_0RCTAccessibilityManager.mm
+++ b/ios/versioned-react-native/ABI45_0_0/ReactNative/React/CoreModules/ABI45_0_0RCTAccessibilityManager.mm
@@ -255,7 +255,7 @@ ABI45_0_0RCT_EXPORT_MODULE()
 }
 
 ABI45_0_0RCT_EXPORT_METHOD(setAccessibilityContentSizeMultipliers
-                  : (JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers &)
+                  : (ABI45_0_0JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers &)
                       JSMultipliers)
 {
   NSMutableDictionary<NSString *, NSNumber *> *multipliers = [NSMutableDictionary new];
@@ -303,7 +303,7 @@ ABI45_0_0RCT_EXPORT_METHOD(announceForAccessibility : (NSString *)announcement)
 
 ABI45_0_0RCT_EXPORT_METHOD(announceForAccessibilityWithOptions
                   : (NSString *)announcement options
-                  : (JS::NativeAccessibilityManager::SpecAnnounceForAccessibilityWithOptionsOptions &)options)
+                  : (ABI45_0_0JS::NativeAccessibilityManager::SpecAnnounceForAccessibilityWithOptionsOptions &)options)
 {
   if (@available(iOS 11.0, *)) {
     NSMutableDictionary<NSString *, NSNumber *> *attrsDictionary = [NSMutableDictionary new];

--- a/ios/versioned-react-native/ABI45_0_0/ReactNative/React/CoreModules/ABI45_0_0RCTActionSheetManager.mm
+++ b/ios/versioned-react-native/ABI45_0_0/ReactNative/React/CoreModules/ABI45_0_0RCTActionSheetManager.mm
@@ -56,7 +56,7 @@ ABI45_0_0RCT_EXPORT_MODULE()
 }
 
 ABI45_0_0RCT_EXPORT_METHOD(showActionSheetWithOptions
-                  : (JS::NativeActionSheetManager::SpecShowActionSheetWithOptionsOptions &)options callback
+                  : (ABI45_0_0JS::NativeActionSheetManager::SpecShowActionSheetWithOptionsOptions &)options callback
                   : (ABI45_0_0RCTResponseSenderBlock)callback)
 {
   if (ABI45_0_0RCTRunningInAppExtension()) {
@@ -183,7 +183,7 @@ ABI45_0_0RCT_EXPORT_METHOD(showActionSheetWithOptions
 }
 
 ABI45_0_0RCT_EXPORT_METHOD(showShareActionSheetWithOptions
-                  : (JS::NativeActionSheetManager::SpecShowShareActionSheetWithOptionsOptions &)options failureCallback
+                  : (ABI45_0_0JS::NativeActionSheetManager::SpecShowShareActionSheetWithOptionsOptions &)options failureCallback
                   : (ABI45_0_0RCTResponseSenderBlock)failureCallback successCallback
                   : (ABI45_0_0RCTResponseSenderBlock)successCallback)
 {

--- a/ios/versioned-react-native/ABI45_0_0/ReactNative/React/CoreModules/ABI45_0_0RCTAlertManager.mm
+++ b/ios/versioned-react-native/ABI45_0_0/ReactNative/React/CoreModules/ABI45_0_0RCTAlertManager.mm
@@ -68,7 +68,7 @@ ABI45_0_0RCT_EXPORT_MODULE()
  * The key from the `buttons` dictionary is passed back in the callback on click.
  * Buttons are displayed in the order they are specified.
  */
-ABI45_0_0RCT_EXPORT_METHOD(alertWithArgs : (JS::NativeAlertManager::Args &)args callback : (ABI45_0_0RCTResponseSenderBlock)callback)
+ABI45_0_0RCT_EXPORT_METHOD(alertWithArgs : (ABI45_0_0JS::NativeAlertManager::Args &)args callback : (ABI45_0_0RCTResponseSenderBlock)callback)
 {
   NSString *title = [ABI45_0_0RCTConvert NSString:args.title()];
   NSString *message = [ABI45_0_0RCTConvert NSString:args.message()];

--- a/ios/versioned-react-native/ABI45_0_0/ReactNative/React/CoreModules/ABI45_0_0RCTAppState.mm
+++ b/ios/versioned-react-native/ABI45_0_0/ReactNative/React/CoreModules/ABI45_0_0RCTAppState.mm
@@ -49,16 +49,16 @@ ABI45_0_0RCT_EXPORT_MODULE()
   return dispatch_get_main_queue();
 }
 
-- (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<JS::NativeAppState::Constants>)constantsToExport
+- (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<ABI45_0_0JS::NativeAppState::Constants>)constantsToExport
 {
-  return (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<JS::NativeAppState::Constants>)[self getConstants];
+  return (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<ABI45_0_0JS::NativeAppState::Constants>)[self getConstants];
 }
 
-- (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<JS::NativeAppState::Constants>)getConstants
+- (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<ABI45_0_0JS::NativeAppState::Constants>)getConstants
 {
-  __block ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<JS::NativeAppState::Constants> constants;
+  __block ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<ABI45_0_0JS::NativeAppState::Constants> constants;
   ABI45_0_0RCTUnsafeExecuteOnMainQueueSync(^{
-    constants = ABI45_0_0facebook::ABI45_0_0React::typedConstants<JS::NativeAppState::Constants>({
+    constants = ABI45_0_0facebook::ABI45_0_0React::typedConstants<ABI45_0_0JS::NativeAppState::Constants>({
         .initialAppState = ABI45_0_0RCTCurrentAppState(),
     });
   });

--- a/ios/versioned-react-native/ABI45_0_0/ReactNative/React/CoreModules/ABI45_0_0RCTExceptionsManager.mm
+++ b/ios/versioned-react-native/ABI45_0_0/ReactNative/React/CoreModules/ABI45_0_0RCTExceptionsManager.mm
@@ -106,7 +106,7 @@ ABI45_0_0RCT_EXPORT_METHOD(reportUnhandledException : (NSString *)message stack 
 
 ABI45_0_0RCT_EXPORT_METHOD(dismissRedbox) {}
 
-ABI45_0_0RCT_EXPORT_METHOD(reportException : (JS::NativeExceptionsManager::ExceptionData &)data)
+ABI45_0_0RCT_EXPORT_METHOD(reportException : (ABI45_0_0JS::NativeExceptionsManager::ExceptionData &)data)
 {
   NSString *message = data.message();
   double exceptionId = data.id_();

--- a/ios/versioned-react-native/ABI45_0_0/ReactNative/React/CoreModules/ABI45_0_0RCTPlatform.mm
+++ b/ios/versioned-react-native/ABI45_0_0/ReactNative/React/CoreModules/ABI45_0_0RCTPlatform.mm
@@ -51,24 +51,24 @@ ABI45_0_0RCT_EXPORT_MODULE(PlatformConstants)
 }
 
 // TODO: Use the generated struct return type.
-- (ModuleConstants<JS::NativePlatformConstantsIOS::Constants>)constantsToExport
+- (ModuleConstants<ABI45_0_0JS::NativePlatformConstantsIOS::Constants>)constantsToExport
 {
-  return (ModuleConstants<JS::NativePlatformConstantsIOS::Constants>)[self getConstants];
+  return (ModuleConstants<ABI45_0_0JS::NativePlatformConstantsIOS::Constants>)[self getConstants];
 }
 
-- (ModuleConstants<JS::NativePlatformConstantsIOS::Constants>)getConstants
+- (ModuleConstants<ABI45_0_0JS::NativePlatformConstantsIOS::Constants>)getConstants
 {
-  __block ModuleConstants<JS::NativePlatformConstantsIOS::Constants> constants;
+  __block ModuleConstants<ABI45_0_0JS::NativePlatformConstantsIOS::Constants> constants;
   ABI45_0_0RCTUnsafeExecuteOnMainQueueSync(^{
     UIDevice *device = [UIDevice currentDevice];
     auto versions = ABI45_0_0RCTGetreactNativeVersion();
-    constants = typedConstants<JS::NativePlatformConstantsIOS::Constants>({
+    constants = typedConstants<ABI45_0_0JS::NativePlatformConstantsIOS::Constants>({
         .forceTouchAvailable = ABI45_0_0RCTForceTouchAvailable() ? true : false,
         .osVersion = [device systemVersion],
         .systemName = [device systemName],
         .interfaceIdiom = interfaceIdiom([device userInterfaceIdiom]),
         .isTesting = ABI45_0_0RCTRunningInTestEnvironment() ? true : false,
-        .reactNativeVersion = JS::NativePlatformConstantsIOS::ConstantsreactNativeVersion::Builder(
+        .reactNativeVersion = ABI45_0_0JS::NativePlatformConstantsIOS::ConstantsreactNativeVersion::Builder(
             {.minor = [versions[@"minor"] doubleValue],
              .major = [versions[@"major"] doubleValue],
              .patch = [versions[@"patch"] doubleValue],

--- a/ios/versioned-react-native/ABI45_0_0/ReactNative/React/CoreModules/ABI45_0_0RCTStatusBarManager.mm
+++ b/ios/versioned-react-native/ABI45_0_0/ReactNative/React/CoreModules/ABI45_0_0RCTStatusBarManager.mm
@@ -175,11 +175,11 @@ ABI45_0_0RCT_EXPORT_METHOD(setNetworkActivityIndicatorVisible : (BOOL)visible)
   ABI45_0_0RCTSharedApplication().networkActivityIndicatorVisible = visible;
 }
 
-- (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<JS::NativeStatusBarManagerIOS::Constants>)getConstants
+- (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<ABI45_0_0JS::NativeStatusBarManagerIOS::Constants>)getConstants
 {
-  __block ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<JS::NativeStatusBarManagerIOS::Constants> constants;
+  __block ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<ABI45_0_0JS::NativeStatusBarManagerIOS::Constants> constants;
   ABI45_0_0RCTUnsafeExecuteOnMainQueueSync(^{
-    constants = ABI45_0_0facebook::ABI45_0_0React::typedConstants<JS::NativeStatusBarManagerIOS::Constants>({
+    constants = ABI45_0_0facebook::ABI45_0_0React::typedConstants<ABI45_0_0JS::NativeStatusBarManagerIOS::Constants>({
         .HEIGHT = ABI45_0_0RCTSharedApplication().statusBarFrame.size.height,
         .DEFAULT_BACKGROUND_COLOR = folly::none,
     });
@@ -188,9 +188,9 @@ ABI45_0_0RCT_EXPORT_METHOD(setNetworkActivityIndicatorVisible : (BOOL)visible)
   return constants;
 }
 
-- (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<JS::NativeStatusBarManagerIOS::Constants>)constantsToExport
+- (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<ABI45_0_0JS::NativeStatusBarManagerIOS::Constants>)constantsToExport
 {
-  return (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<JS::NativeStatusBarManagerIOS::Constants>)[self getConstants];
+  return (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<ABI45_0_0JS::NativeStatusBarManagerIOS::Constants>)[self getConstants];
 }
 
 - (std::shared_ptr<ABI45_0_0facebook::ABI45_0_0React::TurboModule>)getTurboModule:

--- a/ios/versioned-react-native/ABI45_0_0/ReactNative/React/CoreModules/ABI45_0_0RCTWebSocketModule.mm
+++ b/ios/versioned-react-native/ABI45_0_0/ReactNative/React/CoreModules/ABI45_0_0RCTWebSocketModule.mm
@@ -65,7 +65,7 @@ ABI45_0_0RCT_EXPORT_MODULE()
 ABI45_0_0RCT_EXPORT_METHOD(connect
                   : (NSURL *)URL protocols
                   : (NSArray *)protocols options
-                  : (JS::NativeWebSocketModule::SpecConnectOptions &)options socketID
+                  : (ABI45_0_0JS::NativeWebSocketModule::SpecConnectOptions &)options socketID
                   : (double)socketID)
 {
   NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:URL];

--- a/ios/versioned-react-native/ABI45_0_0/ReactNative/codegen/ios/ABI45_0_0FBReactNativeSpec/ABI45_0_0FBReactNativeSpec-generated.mm
+++ b/ios/versioned-react-native/ABI45_0_0/ReactNative/codegen/ios/ABI45_0_0FBReactNativeSpec/ABI45_0_0FBReactNativeSpec-generated.mm
@@ -65,15 +65,15 @@ namespace ABI45_0_0facebook {
   } // namespace ABI45_0_0React
 } // namespace ABI45_0_0facebook
 @implementation ABI45_0_0RCTCxxConvert (NativeAccessibilityManager_SpecSetAccessibilityContentSizeMultipliersJSMultipliers)
-+ (ABI45_0_0RCTManagedPointer *)JS_NativeAccessibilityManager_SpecSetAccessibilityContentSizeMultipliersJSMultipliers:(id)json
++ (ABI45_0_0RCTManagedPointer *)ABI45_0_0JS_NativeAccessibilityManager_SpecSetAccessibilityContentSizeMultipliersJSMultipliers:(id)json
 {
-  return ABI45_0_0facebook::ABI45_0_0React::managedPointer<JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers>(json);
+  return ABI45_0_0facebook::ABI45_0_0React::managedPointer<ABI45_0_0JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers>(json);
 }
 @end
 @implementation ABI45_0_0RCTCxxConvert (NativeAccessibilityManager_SpecAnnounceForAccessibilityWithOptionsOptions)
-+ (ABI45_0_0RCTManagedPointer *)JS_NativeAccessibilityManager_SpecAnnounceForAccessibilityWithOptionsOptions:(id)json
++ (ABI45_0_0RCTManagedPointer *)ABI45_0_0JS_NativeAccessibilityManager_SpecAnnounceForAccessibilityWithOptionsOptions:(id)json
 {
-  return ABI45_0_0facebook::ABI45_0_0React::managedPointer<JS::NativeAccessibilityManager::SpecAnnounceForAccessibilityWithOptionsOptions>(json);
+  return ABI45_0_0facebook::ABI45_0_0React::managedPointer<ABI45_0_0JS::NativeAccessibilityManager::SpecAnnounceForAccessibilityWithOptionsOptions>(json);
 }
 @end
 namespace ABI45_0_0facebook {
@@ -141,7 +141,7 @@ namespace ABI45_0_0facebook {
         
         
         methodMap_["setAccessibilityContentSizeMultipliers"] = MethodMetadata {1, __hostFunction_NativeAccessibilityManagerSpecJSI_setAccessibilityContentSizeMultipliers};
-        setMethodArgConversionSelector(@"setAccessibilityContentSizeMultipliers", 0, @"JS_NativeAccessibilityManager_SpecSetAccessibilityContentSizeMultipliersJSMultipliers:");
+        setMethodArgConversionSelector(@"setAccessibilityContentSizeMultipliers", 0, @"ABI45_0_0JS_NativeAccessibilityManager_SpecSetAccessibilityContentSizeMultipliersJSMultipliers:");
         
         methodMap_["setAccessibilityFocus"] = MethodMetadata {1, __hostFunction_NativeAccessibilityManagerSpecJSI_setAccessibilityFocus};
         
@@ -150,20 +150,20 @@ namespace ABI45_0_0facebook {
         
         
         methodMap_["announceForAccessibilityWithOptions"] = MethodMetadata {2, __hostFunction_NativeAccessibilityManagerSpecJSI_announceForAccessibilityWithOptions};
-        setMethodArgConversionSelector(@"announceForAccessibilityWithOptions", 1, @"JS_NativeAccessibilityManager_SpecAnnounceForAccessibilityWithOptionsOptions:");
+        setMethodArgConversionSelector(@"announceForAccessibilityWithOptions", 1, @"ABI45_0_0JS_NativeAccessibilityManager_SpecAnnounceForAccessibilityWithOptionsOptions:");
     }
   } // namespace ABI45_0_0React
 } // namespace ABI45_0_0facebook
 @implementation ABI45_0_0RCTCxxConvert (NativeActionSheetManager_SpecShowActionSheetWithOptionsOptions)
-+ (ABI45_0_0RCTManagedPointer *)JS_NativeActionSheetManager_SpecShowActionSheetWithOptionsOptions:(id)json
++ (ABI45_0_0RCTManagedPointer *)ABI45_0_0JS_NativeActionSheetManager_SpecShowActionSheetWithOptionsOptions:(id)json
 {
-  return ABI45_0_0facebook::ABI45_0_0React::managedPointer<JS::NativeActionSheetManager::SpecShowActionSheetWithOptionsOptions>(json);
+  return ABI45_0_0facebook::ABI45_0_0React::managedPointer<ABI45_0_0JS::NativeActionSheetManager::SpecShowActionSheetWithOptionsOptions>(json);
 }
 @end
 @implementation ABI45_0_0RCTCxxConvert (NativeActionSheetManager_SpecShowShareActionSheetWithOptionsOptions)
-+ (ABI45_0_0RCTManagedPointer *)JS_NativeActionSheetManager_SpecShowShareActionSheetWithOptionsOptions:(id)json
++ (ABI45_0_0RCTManagedPointer *)ABI45_0_0JS_NativeActionSheetManager_SpecShowShareActionSheetWithOptionsOptions:(id)json
 {
-  return ABI45_0_0facebook::ABI45_0_0React::managedPointer<JS::NativeActionSheetManager::SpecShowShareActionSheetWithOptionsOptions>(json);
+  return ABI45_0_0facebook::ABI45_0_0React::managedPointer<ABI45_0_0JS::NativeActionSheetManager::SpecShowShareActionSheetWithOptionsOptions>(json);
 }
 @end
 namespace ABI45_0_0facebook {
@@ -181,17 +181,17 @@ namespace ABI45_0_0facebook {
       : ObjCTurboModule(params) {
         
         methodMap_["showActionSheetWithOptions"] = MethodMetadata {2, __hostFunction_NativeActionSheetManagerSpecJSI_showActionSheetWithOptions};
-        setMethodArgConversionSelector(@"showActionSheetWithOptions", 0, @"JS_NativeActionSheetManager_SpecShowActionSheetWithOptionsOptions:");
+        setMethodArgConversionSelector(@"showActionSheetWithOptions", 0, @"ABI45_0_0JS_NativeActionSheetManager_SpecShowActionSheetWithOptionsOptions:");
         
         methodMap_["showShareActionSheetWithOptions"] = MethodMetadata {3, __hostFunction_NativeActionSheetManagerSpecJSI_showShareActionSheetWithOptions};
-        setMethodArgConversionSelector(@"showShareActionSheetWithOptions", 0, @"JS_NativeActionSheetManager_SpecShowShareActionSheetWithOptionsOptions:");
+        setMethodArgConversionSelector(@"showShareActionSheetWithOptions", 0, @"ABI45_0_0JS_NativeActionSheetManager_SpecShowShareActionSheetWithOptionsOptions:");
     }
   } // namespace ABI45_0_0React
 } // namespace ABI45_0_0facebook
 @implementation ABI45_0_0RCTCxxConvert (NativeAlertManager_Args)
-+ (ABI45_0_0RCTManagedPointer *)JS_NativeAlertManager_Args:(id)json
++ (ABI45_0_0RCTManagedPointer *)ABI45_0_0JS_NativeAlertManager_Args:(id)json
 {
-  return ABI45_0_0facebook::ABI45_0_0React::managedPointer<JS::NativeAlertManager::Args>(json);
+  return ABI45_0_0facebook::ABI45_0_0React::managedPointer<ABI45_0_0JS::NativeAlertManager::Args>(json);
 }
 @end
 namespace ABI45_0_0facebook {
@@ -205,14 +205,14 @@ namespace ABI45_0_0facebook {
       : ObjCTurboModule(params) {
         
         methodMap_["alertWithArgs"] = MethodMetadata {2, __hostFunction_NativeAlertManagerSpecJSI_alertWithArgs};
-        setMethodArgConversionSelector(@"alertWithArgs", 0, @"JS_NativeAlertManager_Args:");
+        setMethodArgConversionSelector(@"alertWithArgs", 0, @"ABI45_0_0JS_NativeAlertManager_Args:");
     }
   } // namespace ABI45_0_0React
 } // namespace ABI45_0_0facebook
 @implementation ABI45_0_0RCTCxxConvert (NativeAnimatedModule_EventMapping)
-+ (ABI45_0_0RCTManagedPointer *)JS_NativeAnimatedModule_EventMapping:(id)json
++ (ABI45_0_0RCTManagedPointer *)ABI45_0_0JS_NativeAnimatedModule_EventMapping:(id)json
 {
-  return ABI45_0_0facebook::ABI45_0_0React::managedPointer<JS::NativeAnimatedModule::EventMapping>(json);
+  return ABI45_0_0facebook::ABI45_0_0React::managedPointer<ABI45_0_0JS::NativeAnimatedModule::EventMapping>(json);
 }
 @end
 namespace ABI45_0_0facebook {
@@ -364,7 +364,7 @@ namespace ABI45_0_0facebook {
         
         
         methodMap_["addAnimatedEventToView"] = MethodMetadata {3, __hostFunction_NativeAnimatedModuleSpecJSI_addAnimatedEventToView};
-        setMethodArgConversionSelector(@"addAnimatedEventToView", 2, @"JS_NativeAnimatedModule_EventMapping:");
+        setMethodArgConversionSelector(@"addAnimatedEventToView", 2, @"ABI45_0_0JS_NativeAnimatedModule_EventMapping:");
         
         methodMap_["removeAnimatedEventFromView"] = MethodMetadata {3, __hostFunction_NativeAnimatedModuleSpecJSI_removeAnimatedEventFromView};
         
@@ -378,9 +378,9 @@ namespace ABI45_0_0facebook {
   } // namespace ABI45_0_0React
 } // namespace ABI45_0_0facebook
 @implementation ABI45_0_0RCTCxxConvert (NativeAnimatedTurboModule_EventMapping)
-+ (ABI45_0_0RCTManagedPointer *)JS_NativeAnimatedTurboModule_EventMapping:(id)json
++ (ABI45_0_0RCTManagedPointer *)ABI45_0_0JS_NativeAnimatedTurboModule_EventMapping:(id)json
 {
-  return ABI45_0_0facebook::ABI45_0_0React::managedPointer<JS::NativeAnimatedTurboModule::EventMapping>(json);
+  return ABI45_0_0facebook::ABI45_0_0React::managedPointer<ABI45_0_0JS::NativeAnimatedTurboModule::EventMapping>(json);
 }
 @end
 namespace ABI45_0_0facebook {
@@ -532,7 +532,7 @@ namespace ABI45_0_0facebook {
         
         
         methodMap_["addAnimatedEventToView"] = MethodMetadata {3, __hostFunction_NativeAnimatedTurboModuleSpecJSI_addAnimatedEventToView};
-        setMethodArgConversionSelector(@"addAnimatedEventToView", 2, @"JS_NativeAnimatedTurboModule_EventMapping:");
+        setMethodArgConversionSelector(@"addAnimatedEventToView", 2, @"ABI45_0_0JS_NativeAnimatedTurboModule_EventMapping:");
         
         methodMap_["removeAnimatedEventFromView"] = MethodMetadata {3, __hostFunction_NativeAnimatedTurboModuleSpecJSI_removeAnimatedEventFromView};
         
@@ -1050,15 +1050,15 @@ namespace ABI45_0_0facebook {
   } // namespace ABI45_0_0React
 } // namespace ABI45_0_0facebook
 @implementation ABI45_0_0RCTCxxConvert (NativeExceptionsManager_StackFrame)
-+ (ABI45_0_0RCTManagedPointer *)JS_NativeExceptionsManager_StackFrame:(id)json
++ (ABI45_0_0RCTManagedPointer *)ABI45_0_0JS_NativeExceptionsManager_StackFrame:(id)json
 {
-  return ABI45_0_0facebook::ABI45_0_0React::managedPointer<JS::NativeExceptionsManager::StackFrame>(json);
+  return ABI45_0_0facebook::ABI45_0_0React::managedPointer<ABI45_0_0JS::NativeExceptionsManager::StackFrame>(json);
 }
 @end
 @implementation ABI45_0_0RCTCxxConvert (NativeExceptionsManager_ExceptionData)
-+ (ABI45_0_0RCTManagedPointer *)JS_NativeExceptionsManager_ExceptionData:(id)json
++ (ABI45_0_0RCTManagedPointer *)ABI45_0_0JS_NativeExceptionsManager_ExceptionData:(id)json
 {
-  return ABI45_0_0facebook::ABI45_0_0React::managedPointer<JS::NativeExceptionsManager::ExceptionData>(json);
+  return ABI45_0_0facebook::ABI45_0_0React::managedPointer<ABI45_0_0JS::NativeExceptionsManager::ExceptionData>(json);
 }
 @end
 namespace ABI45_0_0facebook {
@@ -1094,7 +1094,7 @@ namespace ABI45_0_0facebook {
         
         
         methodMap_["reportException"] = MethodMetadata {1, __hostFunction_NativeExceptionsManagerSpecJSI_reportException};
-        setMethodArgConversionSelector(@"reportException", 0, @"JS_NativeExceptionsManager_ExceptionData:");
+        setMethodArgConversionSelector(@"reportException", 0, @"ABI45_0_0JS_NativeExceptionsManager_ExceptionData:");
         
         methodMap_["updateExceptionMessage"] = MethodMetadata {3, __hostFunction_NativeExceptionsManagerSpecJSI_updateExceptionMessage};
         
@@ -1128,9 +1128,9 @@ namespace ABI45_0_0facebook {
   } // namespace ABI45_0_0React
 } // namespace ABI45_0_0facebook
 @implementation ABI45_0_0RCTCxxConvert (NativeFrameRateLogger_SpecSetGlobalOptionsOptions)
-+ (ABI45_0_0RCTManagedPointer *)JS_NativeFrameRateLogger_SpecSetGlobalOptionsOptions:(id)json
++ (ABI45_0_0RCTManagedPointer *)ABI45_0_0JS_NativeFrameRateLogger_SpecSetGlobalOptionsOptions:(id)json
 {
-  return ABI45_0_0facebook::ABI45_0_0React::managedPointer<JS::NativeFrameRateLogger::SpecSetGlobalOptionsOptions>(json);
+  return ABI45_0_0facebook::ABI45_0_0React::managedPointer<ABI45_0_0JS::NativeFrameRateLogger::SpecSetGlobalOptionsOptions>(json);
 }
 @end
 namespace ABI45_0_0facebook {
@@ -1156,7 +1156,7 @@ namespace ABI45_0_0facebook {
       : ObjCTurboModule(params) {
         
         methodMap_["setGlobalOptions"] = MethodMetadata {1, __hostFunction_NativeFrameRateLoggerSpecJSI_setGlobalOptions};
-        setMethodArgConversionSelector(@"setGlobalOptions", 0, @"JS_NativeFrameRateLogger_SpecSetGlobalOptionsOptions:");
+        setMethodArgConversionSelector(@"setGlobalOptions", 0, @"ABI45_0_0JS_NativeFrameRateLogger_SpecSetGlobalOptionsOptions:");
         
         methodMap_["setContext"] = MethodMetadata {1, __hostFunction_NativeFrameRateLoggerSpecJSI_setContext};
         
@@ -1230,27 +1230,27 @@ namespace ABI45_0_0facebook {
   } // namespace ABI45_0_0React
 } // namespace ABI45_0_0facebook
 @implementation ABI45_0_0RCTCxxConvert (NativeImageEditor_OptionsOffset)
-+ (ABI45_0_0RCTManagedPointer *)JS_NativeImageEditor_OptionsOffset:(id)json
++ (ABI45_0_0RCTManagedPointer *)ABI45_0_0JS_NativeImageEditor_OptionsOffset:(id)json
 {
-  return ABI45_0_0facebook::ABI45_0_0React::managedPointer<JS::NativeImageEditor::OptionsOffset>(json);
+  return ABI45_0_0facebook::ABI45_0_0React::managedPointer<ABI45_0_0JS::NativeImageEditor::OptionsOffset>(json);
 }
 @end
 @implementation ABI45_0_0RCTCxxConvert (NativeImageEditor_OptionsSize)
-+ (ABI45_0_0RCTManagedPointer *)JS_NativeImageEditor_OptionsSize:(id)json
++ (ABI45_0_0RCTManagedPointer *)ABI45_0_0JS_NativeImageEditor_OptionsSize:(id)json
 {
-  return ABI45_0_0facebook::ABI45_0_0React::managedPointer<JS::NativeImageEditor::OptionsSize>(json);
+  return ABI45_0_0facebook::ABI45_0_0React::managedPointer<ABI45_0_0JS::NativeImageEditor::OptionsSize>(json);
 }
 @end
 @implementation ABI45_0_0RCTCxxConvert (NativeImageEditor_OptionsDisplaySize)
-+ (ABI45_0_0RCTManagedPointer *)JS_NativeImageEditor_OptionsDisplaySize:(id)json
++ (ABI45_0_0RCTManagedPointer *)ABI45_0_0JS_NativeImageEditor_OptionsDisplaySize:(id)json
 {
-  return ABI45_0_0facebook::ABI45_0_0React::managedPointer<JS::NativeImageEditor::OptionsDisplaySize>(json);
+  return ABI45_0_0facebook::ABI45_0_0React::managedPointer<ABI45_0_0JS::NativeImageEditor::OptionsDisplaySize>(json);
 }
 @end
 @implementation ABI45_0_0RCTCxxConvert (NativeImageEditor_Options)
-+ (ABI45_0_0RCTManagedPointer *)JS_NativeImageEditor_Options:(id)json
++ (ABI45_0_0RCTManagedPointer *)ABI45_0_0JS_NativeImageEditor_Options:(id)json
 {
-  return ABI45_0_0facebook::ABI45_0_0React::managedPointer<JS::NativeImageEditor::Options>(json);
+  return ABI45_0_0facebook::ABI45_0_0React::managedPointer<ABI45_0_0JS::NativeImageEditor::Options>(json);
 }
 @end
 namespace ABI45_0_0facebook {
@@ -1264,7 +1264,7 @@ namespace ABI45_0_0facebook {
       : ObjCTurboModule(params) {
         
         methodMap_["cropImage"] = MethodMetadata {4, __hostFunction_NativeImageEditorSpecJSI_cropImage};
-        setMethodArgConversionSelector(@"cropImage", 1, @"JS_NativeImageEditor_Options:");
+        setMethodArgConversionSelector(@"cropImage", 1, @"ABI45_0_0JS_NativeImageEditor_Options:");
     }
   } // namespace ABI45_0_0React
 } // namespace ABI45_0_0facebook
@@ -1313,15 +1313,15 @@ namespace ABI45_0_0facebook {
   } // namespace ABI45_0_0React
 } // namespace ABI45_0_0facebook
 @implementation ABI45_0_0RCTCxxConvert (NativeImagePickerIOS_SpecOpenCameraDialogConfig)
-+ (ABI45_0_0RCTManagedPointer *)JS_NativeImagePickerIOS_SpecOpenCameraDialogConfig:(id)json
++ (ABI45_0_0RCTManagedPointer *)ABI45_0_0JS_NativeImagePickerIOS_SpecOpenCameraDialogConfig:(id)json
 {
-  return ABI45_0_0facebook::ABI45_0_0React::managedPointer<JS::NativeImagePickerIOS::SpecOpenCameraDialogConfig>(json);
+  return ABI45_0_0facebook::ABI45_0_0React::managedPointer<ABI45_0_0JS::NativeImagePickerIOS::SpecOpenCameraDialogConfig>(json);
 }
 @end
 @implementation ABI45_0_0RCTCxxConvert (NativeImagePickerIOS_SpecOpenSelectDialogConfig)
-+ (ABI45_0_0RCTManagedPointer *)JS_NativeImagePickerIOS_SpecOpenSelectDialogConfig:(id)json
++ (ABI45_0_0RCTManagedPointer *)ABI45_0_0JS_NativeImagePickerIOS_SpecOpenSelectDialogConfig:(id)json
 {
-  return ABI45_0_0facebook::ABI45_0_0React::managedPointer<JS::NativeImagePickerIOS::SpecOpenSelectDialogConfig>(json);
+  return ABI45_0_0facebook::ABI45_0_0React::managedPointer<ABI45_0_0JS::NativeImagePickerIOS::SpecOpenSelectDialogConfig>(json);
 }
 @end
 namespace ABI45_0_0facebook {
@@ -1361,10 +1361,10 @@ namespace ABI45_0_0facebook {
         
         
         methodMap_["openCameraDialog"] = MethodMetadata {3, __hostFunction_NativeImagePickerIOSSpecJSI_openCameraDialog};
-        setMethodArgConversionSelector(@"openCameraDialog", 0, @"JS_NativeImagePickerIOS_SpecOpenCameraDialogConfig:");
+        setMethodArgConversionSelector(@"openCameraDialog", 0, @"ABI45_0_0JS_NativeImagePickerIOS_SpecOpenCameraDialogConfig:");
         
         methodMap_["openSelectDialog"] = MethodMetadata {3, __hostFunction_NativeImagePickerIOSSpecJSI_openSelectDialog};
-        setMethodArgConversionSelector(@"openSelectDialog", 0, @"JS_NativeImagePickerIOS_SpecOpenSelectDialogConfig:");
+        setMethodArgConversionSelector(@"openSelectDialog", 0, @"ABI45_0_0JS_NativeImagePickerIOS_SpecOpenSelectDialogConfig:");
         
         methodMap_["clearAllPendingVideos"] = MethodMetadata {0, __hostFunction_NativeImagePickerIOSSpecJSI_clearAllPendingVideos};
         
@@ -1594,9 +1594,9 @@ namespace ABI45_0_0facebook {
   } // namespace ABI45_0_0React
 } // namespace ABI45_0_0facebook
 @implementation ABI45_0_0RCTCxxConvert (NativeNetworkingIOS_SpecSendRequestQuery)
-+ (ABI45_0_0RCTManagedPointer *)JS_NativeNetworkingIOS_SpecSendRequestQuery:(id)json
++ (ABI45_0_0RCTManagedPointer *)ABI45_0_0JS_NativeNetworkingIOS_SpecSendRequestQuery:(id)json
 {
-  return ABI45_0_0facebook::ABI45_0_0React::managedPointer<JS::NativeNetworkingIOS::SpecSendRequestQuery>(json);
+  return ABI45_0_0facebook::ABI45_0_0React::managedPointer<ABI45_0_0JS::NativeNetworkingIOS::SpecSendRequestQuery>(json);
 }
 @end
 namespace ABI45_0_0facebook {
@@ -1626,7 +1626,7 @@ namespace ABI45_0_0facebook {
       : ObjCTurboModule(params) {
         
         methodMap_["sendRequest"] = MethodMetadata {2, __hostFunction_NativeNetworkingIOSSpecJSI_sendRequest};
-        setMethodArgConversionSelector(@"sendRequest", 0, @"JS_NativeNetworkingIOS_SpecSendRequestQuery:");
+        setMethodArgConversionSelector(@"sendRequest", 0, @"ABI45_0_0JS_NativeNetworkingIOS_SpecSendRequestQuery:");
         
         methodMap_["abortRequest"] = MethodMetadata {1, __hostFunction_NativeNetworkingIOSSpecJSI_abortRequest};
         
@@ -1659,15 +1659,15 @@ namespace ABI45_0_0facebook {
   } // namespace ABI45_0_0React
 } // namespace ABI45_0_0facebook
 @implementation ABI45_0_0RCTCxxConvert (NativePushNotificationManagerIOS_SpecRequestPermissionsPermission)
-+ (ABI45_0_0RCTManagedPointer *)JS_NativePushNotificationManagerIOS_SpecRequestPermissionsPermission:(id)json
++ (ABI45_0_0RCTManagedPointer *)ABI45_0_0JS_NativePushNotificationManagerIOS_SpecRequestPermissionsPermission:(id)json
 {
-  return ABI45_0_0facebook::ABI45_0_0React::managedPointer<JS::NativePushNotificationManagerIOS::SpecRequestPermissionsPermission>(json);
+  return ABI45_0_0facebook::ABI45_0_0React::managedPointer<ABI45_0_0JS::NativePushNotificationManagerIOS::SpecRequestPermissionsPermission>(json);
 }
 @end
 @implementation ABI45_0_0RCTCxxConvert (NativePushNotificationManagerIOS_Notification)
-+ (ABI45_0_0RCTManagedPointer *)JS_NativePushNotificationManagerIOS_Notification:(id)json
++ (ABI45_0_0RCTManagedPointer *)ABI45_0_0JS_NativePushNotificationManagerIOS_Notification:(id)json
 {
-  return ABI45_0_0facebook::ABI45_0_0React::managedPointer<JS::NativePushNotificationManagerIOS::Notification>(json);
+  return ABI45_0_0facebook::ABI45_0_0React::managedPointer<ABI45_0_0JS::NativePushNotificationManagerIOS::Notification>(json);
 }
 @end
 namespace ABI45_0_0facebook {
@@ -1758,7 +1758,7 @@ namespace ABI45_0_0facebook {
         
         
         methodMap_["requestPermissions"] = MethodMetadata {1, __hostFunction_NativePushNotificationManagerIOSSpecJSI_requestPermissions};
-        setMethodArgConversionSelector(@"requestPermissions", 0, @"JS_NativePushNotificationManagerIOS_SpecRequestPermissionsPermission:");
+        setMethodArgConversionSelector(@"requestPermissions", 0, @"ABI45_0_0JS_NativePushNotificationManagerIOS_SpecRequestPermissionsPermission:");
         
         methodMap_["abandonPermissions"] = MethodMetadata {0, __hostFunction_NativePushNotificationManagerIOSSpecJSI_abandonPermissions};
         
@@ -1767,10 +1767,10 @@ namespace ABI45_0_0facebook {
         
         
         methodMap_["presentLocalNotification"] = MethodMetadata {1, __hostFunction_NativePushNotificationManagerIOSSpecJSI_presentLocalNotification};
-        setMethodArgConversionSelector(@"presentLocalNotification", 0, @"JS_NativePushNotificationManagerIOS_Notification:");
+        setMethodArgConversionSelector(@"presentLocalNotification", 0, @"ABI45_0_0JS_NativePushNotificationManagerIOS_Notification:");
         
         methodMap_["scheduleLocalNotification"] = MethodMetadata {1, __hostFunction_NativePushNotificationManagerIOSSpecJSI_scheduleLocalNotification};
-        setMethodArgConversionSelector(@"scheduleLocalNotification", 0, @"JS_NativePushNotificationManagerIOS_Notification:");
+        setMethodArgConversionSelector(@"scheduleLocalNotification", 0, @"ABI45_0_0JS_NativePushNotificationManagerIOS_Notification:");
         
         methodMap_["cancelAllLocalNotifications"] = MethodMetadata {0, __hostFunction_NativePushNotificationManagerIOSSpecJSI_cancelAllLocalNotifications};
         
@@ -1881,9 +1881,9 @@ namespace ABI45_0_0facebook {
   } // namespace ABI45_0_0React
 } // namespace ABI45_0_0facebook
 @implementation ABI45_0_0RCTCxxConvert (NativeShareModule_SpecShareContent)
-+ (ABI45_0_0RCTManagedPointer *)JS_NativeShareModule_SpecShareContent:(id)json
++ (ABI45_0_0RCTManagedPointer *)ABI45_0_0JS_NativeShareModule_SpecShareContent:(id)json
 {
-  return ABI45_0_0facebook::ABI45_0_0React::managedPointer<JS::NativeShareModule::SpecShareContent>(json);
+  return ABI45_0_0facebook::ABI45_0_0React::managedPointer<ABI45_0_0JS::NativeShareModule::SpecShareContent>(json);
 }
 @end
 namespace ABI45_0_0facebook {
@@ -1897,7 +1897,7 @@ namespace ABI45_0_0facebook {
       : ObjCTurboModule(params) {
         
         methodMap_["share"] = MethodMetadata {2, __hostFunction_NativeShareModuleSpecJSI_share};
-        setMethodArgConversionSelector(@"share", 0, @"JS_NativeShareModule_SpecShareContent:");
+        setMethodArgConversionSelector(@"share", 0, @"ABI45_0_0JS_NativeShareModule_SpecShareContent:");
     }
   } // namespace ABI45_0_0React
 } // namespace ABI45_0_0facebook
@@ -2052,9 +2052,9 @@ namespace ABI45_0_0facebook {
   } // namespace ABI45_0_0React
 } // namespace ABI45_0_0facebook
 @implementation ABI45_0_0RCTCxxConvert (NativeWebSocketModule_SpecConnectOptions)
-+ (ABI45_0_0RCTManagedPointer *)JS_NativeWebSocketModule_SpecConnectOptions:(id)json
++ (ABI45_0_0RCTManagedPointer *)ABI45_0_0JS_NativeWebSocketModule_SpecConnectOptions:(id)json
 {
-  return ABI45_0_0facebook::ABI45_0_0React::managedPointer<JS::NativeWebSocketModule::SpecConnectOptions>(json);
+  return ABI45_0_0facebook::ABI45_0_0React::managedPointer<ABI45_0_0JS::NativeWebSocketModule::SpecConnectOptions>(json);
 }
 @end
 namespace ABI45_0_0facebook {
@@ -2092,7 +2092,7 @@ namespace ABI45_0_0facebook {
       : ObjCTurboModule(params) {
         
         methodMap_["connect"] = MethodMetadata {4, __hostFunction_NativeWebSocketModuleSpecJSI_connect};
-        setMethodArgConversionSelector(@"connect", 2, @"JS_NativeWebSocketModule_SpecConnectOptions:");
+        setMethodArgConversionSelector(@"connect", 2, @"ABI45_0_0JS_NativeWebSocketModule_SpecConnectOptions:");
         
         methodMap_["send"] = MethodMetadata {2, __hostFunction_NativeWebSocketModuleSpecJSI_send};
         

--- a/ios/versioned-react-native/ABI45_0_0/ReactNative/codegen/ios/ABI45_0_0FBReactNativeSpec/ABI45_0_0FBReactNativeSpec.h
+++ b/ios/versioned-react-native/ABI45_0_0/ReactNative/codegen/ios/ABI45_0_0FBReactNativeSpec/ABI45_0_0FBReactNativeSpec.h
@@ -48,7 +48,7 @@ namespace ABI45_0_0facebook {
     };
   } // namespace ABI45_0_0React
 } // namespace ABI45_0_0facebook
-namespace JS {
+namespace ABI45_0_0JS {
   namespace NativeAccessibilityManager {
     struct SpecSetAccessibilityContentSizeMultipliersJSMultipliers {
       folly::Optional<double> extraSmall() const;
@@ -72,9 +72,9 @@ namespace JS {
 }
 
 @interface ABI45_0_0RCTCxxConvert (NativeAccessibilityManager_SpecSetAccessibilityContentSizeMultipliersJSMultipliers)
-+ (ABI45_0_0RCTManagedPointer *)JS_NativeAccessibilityManager_SpecSetAccessibilityContentSizeMultipliersJSMultipliers:(id)json;
++ (ABI45_0_0RCTManagedPointer *)ABI45_0_0JS_NativeAccessibilityManager_SpecSetAccessibilityContentSizeMultipliersJSMultipliers:(id)json;
 @end
-namespace JS {
+namespace ABI45_0_0JS {
   namespace NativeAccessibilityManager {
     struct SpecAnnounceForAccessibilityWithOptionsOptions {
       folly::Optional<bool> queue() const;
@@ -87,7 +87,7 @@ namespace JS {
 }
 
 @interface ABI45_0_0RCTCxxConvert (NativeAccessibilityManager_SpecAnnounceForAccessibilityWithOptionsOptions)
-+ (ABI45_0_0RCTManagedPointer *)JS_NativeAccessibilityManager_SpecAnnounceForAccessibilityWithOptionsOptions:(id)json;
++ (ABI45_0_0RCTManagedPointer *)ABI45_0_0JS_NativeAccessibilityManager_SpecAnnounceForAccessibilityWithOptionsOptions:(id)json;
 @end
 @protocol ABI45_0_0NativeAccessibilityManagerSpec <ABI45_0_0RCTBridgeModule, ABI45_0_0RCTTurboModule>
 
@@ -103,11 +103,11 @@ namespace JS {
                                   onError:(ABI45_0_0RCTResponseSenderBlock)onError;
 - (void)getCurrentVoiceOverState:(ABI45_0_0RCTResponseSenderBlock)onSuccess
                          onError:(ABI45_0_0RCTResponseSenderBlock)onError;
-- (void)setAccessibilityContentSizeMultipliers:(JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers &)JSMultipliers;
+- (void)setAccessibilityContentSizeMultipliers:(ABI45_0_0JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers &)JSMultipliers;
 - (void)setAccessibilityFocus:(double)ABI45_0_0ReactTag;
 - (void)announceForAccessibility:(NSString *)announcement;
 - (void)announceForAccessibilityWithOptions:(NSString *)announcement
-                                    options:(JS::NativeAccessibilityManager::SpecAnnounceForAccessibilityWithOptionsOptions &)options;
+                                    options:(ABI45_0_0JS::NativeAccessibilityManager::SpecAnnounceForAccessibilityWithOptionsOptions &)options;
 
 @end
 namespace ABI45_0_0facebook {
@@ -121,7 +121,7 @@ namespace ABI45_0_0facebook {
     };
   } // namespace ABI45_0_0React
 } // namespace ABI45_0_0facebook
-namespace JS {
+namespace ABI45_0_0JS {
   namespace NativeActionSheetManager {
     struct SpecShowActionSheetWithOptionsOptions {
       NSString *title() const;
@@ -143,9 +143,9 @@ namespace JS {
 }
 
 @interface ABI45_0_0RCTCxxConvert (NativeActionSheetManager_SpecShowActionSheetWithOptionsOptions)
-+ (ABI45_0_0RCTManagedPointer *)JS_NativeActionSheetManager_SpecShowActionSheetWithOptionsOptions:(id)json;
++ (ABI45_0_0RCTManagedPointer *)ABI45_0_0JS_NativeActionSheetManager_SpecShowActionSheetWithOptionsOptions:(id)json;
 @end
-namespace JS {
+namespace ABI45_0_0JS {
   namespace NativeActionSheetManager {
     struct SpecShowShareActionSheetWithOptionsOptions {
       NSString *message() const;
@@ -165,13 +165,13 @@ namespace JS {
 }
 
 @interface ABI45_0_0RCTCxxConvert (NativeActionSheetManager_SpecShowShareActionSheetWithOptionsOptions)
-+ (ABI45_0_0RCTManagedPointer *)JS_NativeActionSheetManager_SpecShowShareActionSheetWithOptionsOptions:(id)json;
++ (ABI45_0_0RCTManagedPointer *)ABI45_0_0JS_NativeActionSheetManager_SpecShowShareActionSheetWithOptionsOptions:(id)json;
 @end
 @protocol ABI45_0_0NativeActionSheetManagerSpec <ABI45_0_0RCTBridgeModule, ABI45_0_0RCTTurboModule>
 
-- (void)showActionSheetWithOptions:(JS::NativeActionSheetManager::SpecShowActionSheetWithOptionsOptions &)options
+- (void)showActionSheetWithOptions:(ABI45_0_0JS::NativeActionSheetManager::SpecShowActionSheetWithOptionsOptions &)options
                           callback:(ABI45_0_0RCTResponseSenderBlock)callback;
-- (void)showShareActionSheetWithOptions:(JS::NativeActionSheetManager::SpecShowShareActionSheetWithOptionsOptions &)options
+- (void)showShareActionSheetWithOptions:(ABI45_0_0JS::NativeActionSheetManager::SpecShowShareActionSheetWithOptionsOptions &)options
                         failureCallback:(ABI45_0_0RCTResponseSenderBlock)failureCallback
                         successCallback:(ABI45_0_0RCTResponseSenderBlock)successCallback;
 
@@ -187,7 +187,7 @@ namespace ABI45_0_0facebook {
     };
   } // namespace ABI45_0_0React
 } // namespace ABI45_0_0facebook
-namespace JS {
+namespace ABI45_0_0JS {
   namespace NativeAlertManager {
     struct Args {
       NSString *title() const;
@@ -207,11 +207,11 @@ namespace JS {
 }
 
 @interface ABI45_0_0RCTCxxConvert (NativeAlertManager_Args)
-+ (ABI45_0_0RCTManagedPointer *)JS_NativeAlertManager_Args:(id)json;
++ (ABI45_0_0RCTManagedPointer *)ABI45_0_0JS_NativeAlertManager_Args:(id)json;
 @end
 @protocol ABI45_0_0NativeAlertManagerSpec <ABI45_0_0RCTBridgeModule, ABI45_0_0RCTTurboModule>
 
-- (void)alertWithArgs:(JS::NativeAlertManager::Args &)args
+- (void)alertWithArgs:(ABI45_0_0JS::NativeAlertManager::Args &)args
              callback:(ABI45_0_0RCTResponseSenderBlock)callback;
 
 @end
@@ -226,7 +226,7 @@ namespace ABI45_0_0facebook {
     };
   } // namespace ABI45_0_0React
 } // namespace ABI45_0_0facebook
-namespace JS {
+namespace ABI45_0_0JS {
   namespace NativeAnimatedModule {
     struct EventMapping {
       ABI45_0_0facebook::ABI45_0_0React::LazyVector<NSString *> nativeEventPath() const;
@@ -240,7 +240,7 @@ namespace JS {
 }
 
 @interface ABI45_0_0RCTCxxConvert (NativeAnimatedModule_EventMapping)
-+ (ABI45_0_0RCTManagedPointer *)JS_NativeAnimatedModule_EventMapping:(id)json;
++ (ABI45_0_0RCTManagedPointer *)ABI45_0_0JS_NativeAnimatedModule_EventMapping:(id)json;
 @end
 @protocol ABI45_0_0NativeAnimatedModuleSpec <ABI45_0_0RCTBridgeModule, ABI45_0_0RCTTurboModule>
 
@@ -275,7 +275,7 @@ saveValueCallback:(ABI45_0_0RCTResponseSenderBlock)saveValueCallback;
 - (void)dropAnimatedNode:(double)tag;
 - (void)addAnimatedEventToView:(double)viewTag
                      eventName:(NSString *)eventName
-                  eventMapping:(JS::NativeAnimatedModule::EventMapping &)eventMapping;
+                  eventMapping:(ABI45_0_0JS::NativeAnimatedModule::EventMapping &)eventMapping;
 - (void)removeAnimatedEventFromView:(double)viewTag
                           eventName:(NSString *)eventName
                     animatedNodeTag:(double)animatedNodeTag;
@@ -294,7 +294,7 @@ namespace ABI45_0_0facebook {
     };
   } // namespace ABI45_0_0React
 } // namespace ABI45_0_0facebook
-namespace JS {
+namespace ABI45_0_0JS {
   namespace NativeAnimatedTurboModule {
     struct EventMapping {
       ABI45_0_0facebook::ABI45_0_0React::LazyVector<NSString *> nativeEventPath() const;
@@ -308,7 +308,7 @@ namespace JS {
 }
 
 @interface ABI45_0_0RCTCxxConvert (NativeAnimatedTurboModule_EventMapping)
-+ (ABI45_0_0RCTManagedPointer *)JS_NativeAnimatedTurboModule_EventMapping:(id)json;
++ (ABI45_0_0RCTManagedPointer *)ABI45_0_0JS_NativeAnimatedTurboModule_EventMapping:(id)json;
 @end
 @protocol ABI45_0_0NativeAnimatedTurboModuleSpec <ABI45_0_0RCTBridgeModule, ABI45_0_0RCTTurboModule>
 
@@ -343,7 +343,7 @@ saveValueCallback:(ABI45_0_0RCTResponseSenderBlock)saveValueCallback;
 - (void)dropAnimatedNode:(double)tag;
 - (void)addAnimatedEventToView:(double)viewTag
                      eventName:(NSString *)eventName
-                  eventMapping:(JS::NativeAnimatedTurboModule::EventMapping &)eventMapping;
+                  eventMapping:(ABI45_0_0JS::NativeAnimatedTurboModule::EventMapping &)eventMapping;
 - (void)removeAnimatedEventFromView:(double)viewTag
                           eventName:(NSString *)eventName
                     animatedNodeTag:(double)animatedNodeTag;
@@ -380,7 +380,7 @@ namespace ABI45_0_0facebook {
     };
   } // namespace ABI45_0_0React
 } // namespace ABI45_0_0facebook
-namespace JS {
+namespace ABI45_0_0JS {
   namespace NativeAppState {
     struct Constants {
 
@@ -413,8 +413,8 @@ namespace JS {
                      error:(ABI45_0_0RCTResponseSenderBlock)error;
 - (void)addListener:(NSString *)eventName;
 - (void)removeListeners:(double)count;
-- (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<JS::NativeAppState::Constants::Builder>)constantsToExport;
-- (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<JS::NativeAppState::Constants::Builder>)getConstants;
+- (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<ABI45_0_0JS::NativeAppState::Constants::Builder>)constantsToExport;
+- (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<ABI45_0_0JS::NativeAppState::Constants::Builder>)getConstants;
 
 @end
 namespace ABI45_0_0facebook {
@@ -499,7 +499,7 @@ namespace ABI45_0_0facebook {
     };
   } // namespace ABI45_0_0React
 } // namespace ABI45_0_0facebook
-namespace JS {
+namespace ABI45_0_0JS {
   namespace NativeBlobModule {
     struct Constants {
 
@@ -537,8 +537,8 @@ namespace JS {
 - (void)createFromParts:(NSArray *)parts
                  withId:(NSString *)withId;
 - (void)release:(NSString *)blobId;
-- (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<JS::NativeBlobModule::Constants::Builder>)constantsToExport;
-- (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<JS::NativeBlobModule::Constants::Builder>)getConstants;
+- (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<ABI45_0_0JS::NativeBlobModule::Constants::Builder>)constantsToExport;
+- (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<ABI45_0_0JS::NativeBlobModule::Constants::Builder>)getConstants;
 
 @end
 namespace ABI45_0_0facebook {
@@ -695,7 +695,7 @@ namespace ABI45_0_0facebook {
     };
   } // namespace ABI45_0_0React
 } // namespace ABI45_0_0facebook
-namespace JS {
+namespace ABI45_0_0JS {
   namespace NativeDeviceInfo {
     struct DisplayMetrics {
 
@@ -725,7 +725,7 @@ namespace JS {
     };
   }
 }
-namespace JS {
+namespace ABI45_0_0JS {
   namespace NativeDeviceInfo {
     struct DisplayMetricsAndroid {
 
@@ -756,16 +756,16 @@ namespace JS {
     };
   }
 }
-namespace JS {
+namespace ABI45_0_0JS {
   namespace NativeDeviceInfo {
     struct DimensionsPayload {
 
       struct Builder {
         struct Input {
-          folly::Optional<JS::NativeDeviceInfo::DisplayMetrics::Builder> window;
-          folly::Optional<JS::NativeDeviceInfo::DisplayMetrics::Builder> screen;
-          folly::Optional<JS::NativeDeviceInfo::DisplayMetricsAndroid::Builder> windowPhysicalPixels;
-          folly::Optional<JS::NativeDeviceInfo::DisplayMetricsAndroid::Builder> screenPhysicalPixels;
+          folly::Optional<ABI45_0_0JS::NativeDeviceInfo::DisplayMetrics::Builder> window;
+          folly::Optional<ABI45_0_0JS::NativeDeviceInfo::DisplayMetrics::Builder> screen;
+          folly::Optional<ABI45_0_0JS::NativeDeviceInfo::DisplayMetricsAndroid::Builder> windowPhysicalPixels;
+          folly::Optional<ABI45_0_0JS::NativeDeviceInfo::DisplayMetricsAndroid::Builder> screenPhysicalPixels;
         };
 
         /** Initialize with a set of values */
@@ -786,13 +786,13 @@ namespace JS {
     };
   }
 }
-namespace JS {
+namespace ABI45_0_0JS {
   namespace NativeDeviceInfo {
     struct Constants {
 
       struct Builder {
         struct Input {
-          ABI45_0_0RCTRequired<JS::NativeDeviceInfo::DimensionsPayload::Builder> Dimensions;
+          ABI45_0_0RCTRequired<ABI45_0_0JS::NativeDeviceInfo::DimensionsPayload::Builder> Dimensions;
           folly::Optional<bool> isIPhoneX_deprecated;
         };
 
@@ -816,8 +816,8 @@ namespace JS {
 }
 @protocol ABI45_0_0NativeDeviceInfoSpec <ABI45_0_0RCTBridgeModule, ABI45_0_0RCTTurboModule>
 
-- (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<JS::NativeDeviceInfo::Constants::Builder>)constantsToExport;
-- (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<JS::NativeDeviceInfo::Constants::Builder>)getConstants;
+- (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<ABI45_0_0JS::NativeDeviceInfo::Constants::Builder>)constantsToExport;
+- (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<ABI45_0_0JS::NativeDeviceInfo::Constants::Builder>)getConstants;
 
 @end
 namespace ABI45_0_0facebook {
@@ -831,7 +831,7 @@ namespace ABI45_0_0facebook {
     };
   } // namespace ABI45_0_0React
 } // namespace ABI45_0_0facebook
-namespace JS {
+namespace ABI45_0_0JS {
   namespace NativeExceptionsManager {
     struct StackFrame {
       folly::Optional<double> column() const;
@@ -848,16 +848,16 @@ namespace JS {
 }
 
 @interface ABI45_0_0RCTCxxConvert (NativeExceptionsManager_StackFrame)
-+ (ABI45_0_0RCTManagedPointer *)JS_NativeExceptionsManager_StackFrame:(id)json;
++ (ABI45_0_0RCTManagedPointer *)ABI45_0_0JS_NativeExceptionsManager_StackFrame:(id)json;
 @end
-namespace JS {
+namespace ABI45_0_0JS {
   namespace NativeExceptionsManager {
     struct ExceptionData {
       NSString *message() const;
       NSString *originalMessage() const;
       NSString *name() const;
       NSString *componentStack() const;
-      ABI45_0_0facebook::ABI45_0_0React::LazyVector<JS::NativeExceptionsManager::StackFrame> stack() const;
+      ABI45_0_0facebook::ABI45_0_0React::LazyVector<ABI45_0_0JS::NativeExceptionsManager::StackFrame> stack() const;
       double id_() const;
       bool isFatal() const;
       id<NSObject> _Nullable extraData() const;
@@ -870,7 +870,7 @@ namespace JS {
 }
 
 @interface ABI45_0_0RCTCxxConvert (NativeExceptionsManager_ExceptionData)
-+ (ABI45_0_0RCTManagedPointer *)JS_NativeExceptionsManager_ExceptionData:(id)json;
++ (ABI45_0_0RCTManagedPointer *)ABI45_0_0JS_NativeExceptionsManager_ExceptionData:(id)json;
 @end
 @protocol ABI45_0_0NativeExceptionsManagerSpec <ABI45_0_0RCTBridgeModule, ABI45_0_0RCTTurboModule>
 
@@ -880,7 +880,7 @@ namespace JS {
 - (void)reportSoftException:(NSString *)message
                       stack:(NSArray *)stack
                 exceptionId:(double)exceptionId;
-- (void)reportException:(JS::NativeExceptionsManager::ExceptionData &)data;
+- (void)reportException:(ABI45_0_0JS::NativeExceptionsManager::ExceptionData &)data;
 - (void)updateExceptionMessage:(NSString *)message
                          stack:(NSArray *)stack
                    exceptionId:(double)exceptionId;
@@ -921,7 +921,7 @@ namespace ABI45_0_0facebook {
     };
   } // namespace ABI45_0_0React
 } // namespace ABI45_0_0facebook
-namespace JS {
+namespace ABI45_0_0JS {
   namespace NativeFrameRateLogger {
     struct SpecSetGlobalOptionsOptions {
       folly::Optional<bool> debug() const;
@@ -935,11 +935,11 @@ namespace JS {
 }
 
 @interface ABI45_0_0RCTCxxConvert (NativeFrameRateLogger_SpecSetGlobalOptionsOptions)
-+ (ABI45_0_0RCTManagedPointer *)JS_NativeFrameRateLogger_SpecSetGlobalOptionsOptions:(id)json;
++ (ABI45_0_0RCTManagedPointer *)ABI45_0_0JS_NativeFrameRateLogger_SpecSetGlobalOptionsOptions:(id)json;
 @end
 @protocol ABI45_0_0NativeFrameRateLoggerSpec <ABI45_0_0RCTBridgeModule, ABI45_0_0RCTTurboModule>
 
-- (void)setGlobalOptions:(JS::NativeFrameRateLogger::SpecSetGlobalOptionsOptions &)options;
+- (void)setGlobalOptions:(ABI45_0_0JS::NativeFrameRateLogger::SpecSetGlobalOptionsOptions &)options;
 - (void)setContext:(NSString *)context;
 - (void)beginScroll;
 - (void)endScroll;
@@ -976,7 +976,7 @@ namespace ABI45_0_0facebook {
     };
   } // namespace ABI45_0_0React
 } // namespace ABI45_0_0facebook
-namespace JS {
+namespace ABI45_0_0JS {
   namespace NativeI18nManager {
     struct Constants {
 
@@ -1010,8 +1010,8 @@ namespace JS {
 - (void)allowRTL:(BOOL)allowRTL;
 - (void)forceRTL:(BOOL)forceRTL;
 - (void)swapLeftAndRightInRTL:(BOOL)flipStyles;
-- (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<JS::NativeI18nManager::Constants::Builder>)constantsToExport;
-- (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<JS::NativeI18nManager::Constants::Builder>)getConstants;
+- (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<ABI45_0_0JS::NativeI18nManager::Constants::Builder>)constantsToExport;
+- (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<ABI45_0_0JS::NativeI18nManager::Constants::Builder>)getConstants;
 
 @end
 namespace ABI45_0_0facebook {
@@ -1025,7 +1025,7 @@ namespace ABI45_0_0facebook {
     };
   } // namespace ABI45_0_0React
 } // namespace ABI45_0_0facebook
-namespace JS {
+namespace ABI45_0_0JS {
   namespace NativeImageEditor {
     struct OptionsOffset {
       double x() const;
@@ -1039,9 +1039,9 @@ namespace JS {
 }
 
 @interface ABI45_0_0RCTCxxConvert (NativeImageEditor_OptionsOffset)
-+ (ABI45_0_0RCTManagedPointer *)JS_NativeImageEditor_OptionsOffset:(id)json;
++ (ABI45_0_0RCTManagedPointer *)ABI45_0_0JS_NativeImageEditor_OptionsOffset:(id)json;
 @end
-namespace JS {
+namespace ABI45_0_0JS {
   namespace NativeImageEditor {
     struct OptionsSize {
       double width() const;
@@ -1055,9 +1055,9 @@ namespace JS {
 }
 
 @interface ABI45_0_0RCTCxxConvert (NativeImageEditor_OptionsSize)
-+ (ABI45_0_0RCTManagedPointer *)JS_NativeImageEditor_OptionsSize:(id)json;
++ (ABI45_0_0RCTManagedPointer *)ABI45_0_0JS_NativeImageEditor_OptionsSize:(id)json;
 @end
-namespace JS {
+namespace ABI45_0_0JS {
   namespace NativeImageEditor {
     struct OptionsDisplaySize {
       double width() const;
@@ -1071,14 +1071,14 @@ namespace JS {
 }
 
 @interface ABI45_0_0RCTCxxConvert (NativeImageEditor_OptionsDisplaySize)
-+ (ABI45_0_0RCTManagedPointer *)JS_NativeImageEditor_OptionsDisplaySize:(id)json;
++ (ABI45_0_0RCTManagedPointer *)ABI45_0_0JS_NativeImageEditor_OptionsDisplaySize:(id)json;
 @end
-namespace JS {
+namespace ABI45_0_0JS {
   namespace NativeImageEditor {
     struct Options {
-      JS::NativeImageEditor::OptionsOffset offset() const;
-      JS::NativeImageEditor::OptionsSize size() const;
-      folly::Optional<JS::NativeImageEditor::OptionsDisplaySize> displaySize() const;
+      ABI45_0_0JS::NativeImageEditor::OptionsOffset offset() const;
+      ABI45_0_0JS::NativeImageEditor::OptionsSize size() const;
+      folly::Optional<ABI45_0_0JS::NativeImageEditor::OptionsDisplaySize> displaySize() const;
       NSString *resizeMode() const;
       folly::Optional<bool> allowExternalStorage() const;
 
@@ -1090,12 +1090,12 @@ namespace JS {
 }
 
 @interface ABI45_0_0RCTCxxConvert (NativeImageEditor_Options)
-+ (ABI45_0_0RCTManagedPointer *)JS_NativeImageEditor_Options:(id)json;
++ (ABI45_0_0RCTManagedPointer *)ABI45_0_0JS_NativeImageEditor_Options:(id)json;
 @end
 @protocol ABI45_0_0NativeImageEditorSpec <ABI45_0_0RCTBridgeModule, ABI45_0_0RCTTurboModule>
 
 - (void)cropImage:(NSString *)uri
-         cropData:(JS::NativeImageEditor::Options &)cropData
+         cropData:(ABI45_0_0JS::NativeImageEditor::Options &)cropData
   successCallback:(ABI45_0_0RCTResponseSenderBlock)successCallback
     errorCallback:(ABI45_0_0RCTResponseSenderBlock)errorCallback;
 
@@ -1145,7 +1145,7 @@ namespace ABI45_0_0facebook {
     };
   } // namespace ABI45_0_0React
 } // namespace ABI45_0_0facebook
-namespace JS {
+namespace ABI45_0_0JS {
   namespace NativeImagePickerIOS {
     struct SpecOpenCameraDialogConfig {
       bool unmirrorFrontFacingCamera() const;
@@ -1159,9 +1159,9 @@ namespace JS {
 }
 
 @interface ABI45_0_0RCTCxxConvert (NativeImagePickerIOS_SpecOpenCameraDialogConfig)
-+ (ABI45_0_0RCTManagedPointer *)JS_NativeImagePickerIOS_SpecOpenCameraDialogConfig:(id)json;
++ (ABI45_0_0RCTManagedPointer *)ABI45_0_0JS_NativeImagePickerIOS_SpecOpenCameraDialogConfig:(id)json;
 @end
-namespace JS {
+namespace ABI45_0_0JS {
   namespace NativeImagePickerIOS {
     struct SpecOpenSelectDialogConfig {
       bool showImages() const;
@@ -1175,16 +1175,16 @@ namespace JS {
 }
 
 @interface ABI45_0_0RCTCxxConvert (NativeImagePickerIOS_SpecOpenSelectDialogConfig)
-+ (ABI45_0_0RCTManagedPointer *)JS_NativeImagePickerIOS_SpecOpenSelectDialogConfig:(id)json;
++ (ABI45_0_0RCTManagedPointer *)ABI45_0_0JS_NativeImagePickerIOS_SpecOpenSelectDialogConfig:(id)json;
 @end
 @protocol ABI45_0_0NativeImagePickerIOSSpec <ABI45_0_0RCTBridgeModule, ABI45_0_0RCTTurboModule>
 
 - (void)canRecordVideos:(ABI45_0_0RCTResponseSenderBlock)callback;
 - (void)canUseCamera:(ABI45_0_0RCTResponseSenderBlock)callback;
-- (void)openCameraDialog:(JS::NativeImagePickerIOS::SpecOpenCameraDialogConfig &)config
+- (void)openCameraDialog:(ABI45_0_0JS::NativeImagePickerIOS::SpecOpenCameraDialogConfig &)config
          successCallback:(ABI45_0_0RCTResponseSenderBlock)successCallback
           cancelCallback:(ABI45_0_0RCTResponseSenderBlock)cancelCallback;
-- (void)openSelectDialog:(JS::NativeImagePickerIOS::SpecOpenSelectDialogConfig &)config
+- (void)openSelectDialog:(ABI45_0_0JS::NativeImagePickerIOS::SpecOpenSelectDialogConfig &)config
          successCallback:(ABI45_0_0RCTResponseSenderBlock)successCallback
           cancelCallback:(ABI45_0_0RCTResponseSenderBlock)cancelCallback;
 - (void)clearAllPendingVideos;
@@ -1264,7 +1264,7 @@ namespace ABI45_0_0facebook {
     };
   } // namespace ABI45_0_0React
 } // namespace ABI45_0_0facebook
-namespace JS {
+namespace ABI45_0_0JS {
   namespace NativeJSDevSupport {
     struct Constants {
 
@@ -1297,8 +1297,8 @@ namespace JS {
 - (void)onSuccess:(NSString *)data;
 - (void)onFailure:(double)errorCode
             error:(NSString *)error;
-- (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<JS::NativeJSDevSupport::Constants::Builder>)constantsToExport;
-- (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<JS::NativeJSDevSupport::Constants::Builder>)getConstants;
+- (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<ABI45_0_0JS::NativeJSDevSupport::Constants::Builder>)constantsToExport;
+- (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<ABI45_0_0JS::NativeJSDevSupport::Constants::Builder>)getConstants;
 
 @end
 namespace ABI45_0_0facebook {
@@ -1394,7 +1394,7 @@ namespace ABI45_0_0facebook {
     };
   } // namespace ABI45_0_0React
 } // namespace ABI45_0_0facebook
-namespace JS {
+namespace ABI45_0_0JS {
   namespace NativeNetworkingIOS {
     struct SpecSendRequestQuery {
       NSString *method() const;
@@ -1414,11 +1414,11 @@ namespace JS {
 }
 
 @interface ABI45_0_0RCTCxxConvert (NativeNetworkingIOS_SpecSendRequestQuery)
-+ (ABI45_0_0RCTManagedPointer *)JS_NativeNetworkingIOS_SpecSendRequestQuery:(id)json;
++ (ABI45_0_0RCTManagedPointer *)ABI45_0_0JS_NativeNetworkingIOS_SpecSendRequestQuery:(id)json;
 @end
 @protocol ABI45_0_0NativeNetworkingIOSSpec <ABI45_0_0RCTBridgeModule, ABI45_0_0RCTTurboModule>
 
-- (void)sendRequest:(JS::NativeNetworkingIOS::SpecSendRequestQuery &)query
+- (void)sendRequest:(ABI45_0_0JS::NativeNetworkingIOS::SpecSendRequestQuery &)query
            callback:(ABI45_0_0RCTResponseSenderBlock)callback;
 - (void)abortRequest:(double)requestId;
 - (void)clearCookies:(ABI45_0_0RCTResponseSenderBlock)callback;
@@ -1437,7 +1437,7 @@ namespace ABI45_0_0facebook {
     };
   } // namespace ABI45_0_0React
 } // namespace ABI45_0_0facebook
-namespace JS {
+namespace ABI45_0_0JS {
   namespace NativePlatformConstantsIOS {
     struct ConstantsreactNativeVersion {
 
@@ -1467,14 +1467,14 @@ namespace JS {
     };
   }
 }
-namespace JS {
+namespace ABI45_0_0JS {
   namespace NativePlatformConstantsIOS {
     struct Constants {
 
       struct Builder {
         struct Input {
           ABI45_0_0RCTRequired<bool> isTesting;
-          ABI45_0_0RCTRequired<JS::NativePlatformConstantsIOS::ConstantsreactNativeVersion::Builder> reactNativeVersion;
+          ABI45_0_0RCTRequired<ABI45_0_0JS::NativePlatformConstantsIOS::ConstantsreactNativeVersion::Builder> reactNativeVersion;
           ABI45_0_0RCTRequired<bool> forceTouchAvailable;
           ABI45_0_0RCTRequired<NSString *> osVersion;
           ABI45_0_0RCTRequired<NSString *> systemName;
@@ -1501,8 +1501,8 @@ namespace JS {
 }
 @protocol ABI45_0_0NativePlatformConstantsIOSSpec <ABI45_0_0RCTBridgeModule, ABI45_0_0RCTTurboModule>
 
-- (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<JS::NativePlatformConstantsIOS::Constants::Builder>)constantsToExport;
-- (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<JS::NativePlatformConstantsIOS::Constants::Builder>)getConstants;
+- (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<ABI45_0_0JS::NativePlatformConstantsIOS::Constants::Builder>)constantsToExport;
+- (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<ABI45_0_0JS::NativePlatformConstantsIOS::Constants::Builder>)getConstants;
 
 @end
 namespace ABI45_0_0facebook {
@@ -1516,7 +1516,7 @@ namespace ABI45_0_0facebook {
     };
   } // namespace ABI45_0_0React
 } // namespace ABI45_0_0facebook
-namespace JS {
+namespace ABI45_0_0JS {
   namespace NativePushNotificationManagerIOS {
     struct SpecRequestPermissionsPermission {
       bool alert() const;
@@ -1531,9 +1531,9 @@ namespace JS {
 }
 
 @interface ABI45_0_0RCTCxxConvert (NativePushNotificationManagerIOS_SpecRequestPermissionsPermission)
-+ (ABI45_0_0RCTManagedPointer *)JS_NativePushNotificationManagerIOS_SpecRequestPermissionsPermission:(id)json;
++ (ABI45_0_0RCTManagedPointer *)ABI45_0_0JS_NativePushNotificationManagerIOS_SpecRequestPermissionsPermission:(id)json;
 @end
-namespace JS {
+namespace ABI45_0_0JS {
   namespace NativePushNotificationManagerIOS {
     struct Notification {
       NSString *alertTitle() const;
@@ -1554,7 +1554,7 @@ namespace JS {
 }
 
 @interface ABI45_0_0RCTCxxConvert (NativePushNotificationManagerIOS_Notification)
-+ (ABI45_0_0RCTManagedPointer *)JS_NativePushNotificationManagerIOS_Notification:(id)json;
++ (ABI45_0_0RCTManagedPointer *)ABI45_0_0JS_NativePushNotificationManagerIOS_Notification:(id)json;
 @end
 @protocol ABI45_0_0NativePushNotificationManagerIOSSpec <ABI45_0_0RCTBridgeModule, ABI45_0_0RCTTurboModule>
 
@@ -1562,13 +1562,13 @@ namespace JS {
                        fetchResult:(NSString *)fetchResult;
 - (void)setApplicationIconBadgeNumber:(double)num;
 - (void)getApplicationIconBadgeNumber:(ABI45_0_0RCTResponseSenderBlock)callback;
-- (void)requestPermissions:(JS::NativePushNotificationManagerIOS::SpecRequestPermissionsPermission &)permission
+- (void)requestPermissions:(ABI45_0_0JS::NativePushNotificationManagerIOS::SpecRequestPermissionsPermission &)permission
                    resolve:(ABI45_0_0RCTPromiseResolveBlock)resolve
                     reject:(ABI45_0_0RCTPromiseRejectBlock)reject;
 - (void)abandonPermissions;
 - (void)checkPermissions:(ABI45_0_0RCTResponseSenderBlock)callback;
-- (void)presentLocalNotification:(JS::NativePushNotificationManagerIOS::Notification &)notification;
-- (void)scheduleLocalNotification:(JS::NativePushNotificationManagerIOS::Notification &)notification;
+- (void)presentLocalNotification:(ABI45_0_0JS::NativePushNotificationManagerIOS::Notification &)notification;
+- (void)scheduleLocalNotification:(ABI45_0_0JS::NativePushNotificationManagerIOS::Notification &)notification;
 - (void)cancelAllLocalNotifications;
 - (void)cancelLocalNotifications:(NSDictionary *)userInfo;
 - (void)getInitialNotification:(ABI45_0_0RCTPromiseResolveBlock)resolve
@@ -1634,7 +1634,7 @@ namespace ABI45_0_0facebook {
     };
   } // namespace ABI45_0_0React
 } // namespace ABI45_0_0facebook
-namespace JS {
+namespace ABI45_0_0JS {
   namespace NativeSettingsManager {
     struct Constants {
 
@@ -1665,8 +1665,8 @@ namespace JS {
 
 - (void)setValues:(NSDictionary *)values;
 - (void)deleteValues:(NSArray *)values;
-- (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<JS::NativeSettingsManager::Constants::Builder>)constantsToExport;
-- (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<JS::NativeSettingsManager::Constants::Builder>)getConstants;
+- (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<ABI45_0_0JS::NativeSettingsManager::Constants::Builder>)constantsToExport;
+- (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<ABI45_0_0JS::NativeSettingsManager::Constants::Builder>)getConstants;
 
 @end
 namespace ABI45_0_0facebook {
@@ -1680,7 +1680,7 @@ namespace ABI45_0_0facebook {
     };
   } // namespace ABI45_0_0React
 } // namespace ABI45_0_0facebook
-namespace JS {
+namespace ABI45_0_0JS {
   namespace NativeShareModule {
     struct SpecShareContent {
       NSString *title() const;
@@ -1694,11 +1694,11 @@ namespace JS {
 }
 
 @interface ABI45_0_0RCTCxxConvert (NativeShareModule_SpecShareContent)
-+ (ABI45_0_0RCTManagedPointer *)JS_NativeShareModule_SpecShareContent:(id)json;
++ (ABI45_0_0RCTManagedPointer *)ABI45_0_0JS_NativeShareModule_SpecShareContent:(id)json;
 @end
 @protocol ABI45_0_0NativeShareModuleSpec <ABI45_0_0RCTBridgeModule, ABI45_0_0RCTTurboModule>
 
-- (void)share:(JS::NativeShareModule::SpecShareContent &)content
+- (void)share:(ABI45_0_0JS::NativeShareModule::SpecShareContent &)content
   dialogTitle:(NSString *)dialogTitle
       resolve:(ABI45_0_0RCTPromiseResolveBlock)resolve
        reject:(ABI45_0_0RCTPromiseRejectBlock)reject;
@@ -1732,7 +1732,7 @@ namespace ABI45_0_0facebook {
     };
   } // namespace ABI45_0_0React
 } // namespace ABI45_0_0facebook
-namespace JS {
+namespace ABI45_0_0JS {
   namespace NativeSourceCode {
     struct Constants {
 
@@ -1761,8 +1761,8 @@ namespace JS {
 }
 @protocol ABI45_0_0NativeSourceCodeSpec <ABI45_0_0RCTBridgeModule, ABI45_0_0RCTTurboModule>
 
-- (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<JS::NativeSourceCode::Constants::Builder>)constantsToExport;
-- (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<JS::NativeSourceCode::Constants::Builder>)getConstants;
+- (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<ABI45_0_0JS::NativeSourceCode::Constants::Builder>)constantsToExport;
+- (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<ABI45_0_0JS::NativeSourceCode::Constants::Builder>)getConstants;
 
 @end
 namespace ABI45_0_0facebook {
@@ -1776,7 +1776,7 @@ namespace ABI45_0_0facebook {
     };
   } // namespace ABI45_0_0React
 } // namespace ABI45_0_0facebook
-namespace JS {
+namespace ABI45_0_0JS {
   namespace NativeStatusBarManagerIOS {
     struct Constants {
 
@@ -1814,8 +1814,8 @@ namespace JS {
         animated:(BOOL)animated;
 - (void)setHidden:(BOOL)hidden
     withAnimation:(NSString *)withAnimation;
-- (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<JS::NativeStatusBarManagerIOS::Constants::Builder>)constantsToExport;
-- (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<JS::NativeStatusBarManagerIOS::Constants::Builder>)getConstants;
+- (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<ABI45_0_0JS::NativeStatusBarManagerIOS::Constants::Builder>)constantsToExport;
+- (ABI45_0_0facebook::ABI45_0_0React::ModuleConstants<ABI45_0_0JS::NativeStatusBarManagerIOS::Constants::Builder>)getConstants;
 
 @end
 namespace ABI45_0_0facebook {
@@ -1871,7 +1871,7 @@ namespace ABI45_0_0facebook {
     };
   } // namespace ABI45_0_0React
 } // namespace ABI45_0_0facebook
-namespace JS {
+namespace ABI45_0_0JS {
   namespace NativeWebSocketModule {
     struct SpecConnectOptions {
       id<NSObject> _Nullable headers() const;
@@ -1884,13 +1884,13 @@ namespace JS {
 }
 
 @interface ABI45_0_0RCTCxxConvert (NativeWebSocketModule_SpecConnectOptions)
-+ (ABI45_0_0RCTManagedPointer *)JS_NativeWebSocketModule_SpecConnectOptions:(id)json;
++ (ABI45_0_0RCTManagedPointer *)ABI45_0_0JS_NativeWebSocketModule_SpecConnectOptions:(id)json;
 @end
 @protocol ABI45_0_0NativeWebSocketModuleSpec <ABI45_0_0RCTBridgeModule, ABI45_0_0RCTTurboModule>
 
 - (void)connect:(NSString *)url
       protocols:(NSArray * _Nullable)protocols
-        options:(JS::NativeWebSocketModule::SpecConnectOptions &)options
+        options:(ABI45_0_0JS::NativeWebSocketModule::SpecConnectOptions &)options
        socketID:(double)socketID;
 - (void)send:(NSString *)message
  forSocketID:(double)forSocketID;
@@ -1916,235 +1916,235 @@ namespace ABI45_0_0facebook {
   } // namespace ABI45_0_0React
 } // namespace ABI45_0_0facebook
 
-inline folly::Optional<double> JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers::extraSmall() const
+inline folly::Optional<double> ABI45_0_0JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers::extraSmall() const
 {
   id const p = _v[@"extraSmall"];
   return ABI45_0_0RCTBridgingToOptionalDouble(p);
 }
-inline folly::Optional<double> JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers::small() const
+inline folly::Optional<double> ABI45_0_0JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers::small() const
 {
   id const p = _v[@"small"];
   return ABI45_0_0RCTBridgingToOptionalDouble(p);
 }
-inline folly::Optional<double> JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers::medium() const
+inline folly::Optional<double> ABI45_0_0JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers::medium() const
 {
   id const p = _v[@"medium"];
   return ABI45_0_0RCTBridgingToOptionalDouble(p);
 }
-inline folly::Optional<double> JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers::large() const
+inline folly::Optional<double> ABI45_0_0JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers::large() const
 {
   id const p = _v[@"large"];
   return ABI45_0_0RCTBridgingToOptionalDouble(p);
 }
-inline folly::Optional<double> JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers::extraLarge() const
+inline folly::Optional<double> ABI45_0_0JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers::extraLarge() const
 {
   id const p = _v[@"extraLarge"];
   return ABI45_0_0RCTBridgingToOptionalDouble(p);
 }
-inline folly::Optional<double> JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers::extraExtraLarge() const
+inline folly::Optional<double> ABI45_0_0JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers::extraExtraLarge() const
 {
   id const p = _v[@"extraExtraLarge"];
   return ABI45_0_0RCTBridgingToOptionalDouble(p);
 }
-inline folly::Optional<double> JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers::extraExtraExtraLarge() const
+inline folly::Optional<double> ABI45_0_0JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers::extraExtraExtraLarge() const
 {
   id const p = _v[@"extraExtraExtraLarge"];
   return ABI45_0_0RCTBridgingToOptionalDouble(p);
 }
-inline folly::Optional<double> JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers::accessibilityMedium() const
+inline folly::Optional<double> ABI45_0_0JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers::accessibilityMedium() const
 {
   id const p = _v[@"accessibilityMedium"];
   return ABI45_0_0RCTBridgingToOptionalDouble(p);
 }
-inline folly::Optional<double> JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers::accessibilityLarge() const
+inline folly::Optional<double> ABI45_0_0JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers::accessibilityLarge() const
 {
   id const p = _v[@"accessibilityLarge"];
   return ABI45_0_0RCTBridgingToOptionalDouble(p);
 }
-inline folly::Optional<double> JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers::accessibilityExtraLarge() const
+inline folly::Optional<double> ABI45_0_0JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers::accessibilityExtraLarge() const
 {
   id const p = _v[@"accessibilityExtraLarge"];
   return ABI45_0_0RCTBridgingToOptionalDouble(p);
 }
-inline folly::Optional<double> JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers::accessibilityExtraExtraLarge() const
+inline folly::Optional<double> ABI45_0_0JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers::accessibilityExtraExtraLarge() const
 {
   id const p = _v[@"accessibilityExtraExtraLarge"];
   return ABI45_0_0RCTBridgingToOptionalDouble(p);
 }
-inline folly::Optional<double> JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers::accessibilityExtraExtraExtraLarge() const
+inline folly::Optional<double> ABI45_0_0JS::NativeAccessibilityManager::SpecSetAccessibilityContentSizeMultipliersJSMultipliers::accessibilityExtraExtraExtraLarge() const
 {
   id const p = _v[@"accessibilityExtraExtraExtraLarge"];
   return ABI45_0_0RCTBridgingToOptionalDouble(p);
 }
-inline folly::Optional<bool> JS::NativeAccessibilityManager::SpecAnnounceForAccessibilityWithOptionsOptions::queue() const
+inline folly::Optional<bool> ABI45_0_0JS::NativeAccessibilityManager::SpecAnnounceForAccessibilityWithOptionsOptions::queue() const
 {
   id const p = _v[@"queue"];
   return ABI45_0_0RCTBridgingToOptionalBool(p);
 }
-inline NSString *JS::NativeActionSheetManager::SpecShowActionSheetWithOptionsOptions::title() const
+inline NSString *ABI45_0_0JS::NativeActionSheetManager::SpecShowActionSheetWithOptionsOptions::title() const
 {
   id const p = _v[@"title"];
   return ABI45_0_0RCTBridgingToOptionalString(p);
 }
-inline NSString *JS::NativeActionSheetManager::SpecShowActionSheetWithOptionsOptions::message() const
+inline NSString *ABI45_0_0JS::NativeActionSheetManager::SpecShowActionSheetWithOptionsOptions::message() const
 {
   id const p = _v[@"message"];
   return ABI45_0_0RCTBridgingToOptionalString(p);
 }
-inline folly::Optional<ABI45_0_0facebook::ABI45_0_0React::LazyVector<NSString *>> JS::NativeActionSheetManager::SpecShowActionSheetWithOptionsOptions::options() const
+inline folly::Optional<ABI45_0_0facebook::ABI45_0_0React::LazyVector<NSString *>> ABI45_0_0JS::NativeActionSheetManager::SpecShowActionSheetWithOptionsOptions::options() const
 {
   id const p = _v[@"options"];
   return ABI45_0_0RCTBridgingToOptionalVec(p, ^NSString *(id itemValue_0) { return ABI45_0_0RCTBridgingToString(itemValue_0); });
 }
-inline folly::Optional<ABI45_0_0facebook::ABI45_0_0React::LazyVector<double>> JS::NativeActionSheetManager::SpecShowActionSheetWithOptionsOptions::destructiveButtonIndices() const
+inline folly::Optional<ABI45_0_0facebook::ABI45_0_0React::LazyVector<double>> ABI45_0_0JS::NativeActionSheetManager::SpecShowActionSheetWithOptionsOptions::destructiveButtonIndices() const
 {
   id const p = _v[@"destructiveButtonIndices"];
   return ABI45_0_0RCTBridgingToOptionalVec(p, ^double(id itemValue_0) { return ABI45_0_0RCTBridgingToDouble(itemValue_0); });
 }
-inline folly::Optional<double> JS::NativeActionSheetManager::SpecShowActionSheetWithOptionsOptions::cancelButtonIndex() const
+inline folly::Optional<double> ABI45_0_0JS::NativeActionSheetManager::SpecShowActionSheetWithOptionsOptions::cancelButtonIndex() const
 {
   id const p = _v[@"cancelButtonIndex"];
   return ABI45_0_0RCTBridgingToOptionalDouble(p);
 }
-inline folly::Optional<double> JS::NativeActionSheetManager::SpecShowActionSheetWithOptionsOptions::anchor() const
+inline folly::Optional<double> ABI45_0_0JS::NativeActionSheetManager::SpecShowActionSheetWithOptionsOptions::anchor() const
 {
   id const p = _v[@"anchor"];
   return ABI45_0_0RCTBridgingToOptionalDouble(p);
 }
-inline folly::Optional<double> JS::NativeActionSheetManager::SpecShowActionSheetWithOptionsOptions::tintColor() const
+inline folly::Optional<double> ABI45_0_0JS::NativeActionSheetManager::SpecShowActionSheetWithOptionsOptions::tintColor() const
 {
   id const p = _v[@"tintColor"];
   return ABI45_0_0RCTBridgingToOptionalDouble(p);
 }
-inline folly::Optional<double> JS::NativeActionSheetManager::SpecShowActionSheetWithOptionsOptions::cancelButtonTintColor() const
+inline folly::Optional<double> ABI45_0_0JS::NativeActionSheetManager::SpecShowActionSheetWithOptionsOptions::cancelButtonTintColor() const
 {
   id const p = _v[@"cancelButtonTintColor"];
   return ABI45_0_0RCTBridgingToOptionalDouble(p);
 }
-inline NSString *JS::NativeActionSheetManager::SpecShowActionSheetWithOptionsOptions::userInterfaceStyle() const
+inline NSString *ABI45_0_0JS::NativeActionSheetManager::SpecShowActionSheetWithOptionsOptions::userInterfaceStyle() const
 {
   id const p = _v[@"userInterfaceStyle"];
   return ABI45_0_0RCTBridgingToOptionalString(p);
 }
-inline folly::Optional<ABI45_0_0facebook::ABI45_0_0React::LazyVector<double>> JS::NativeActionSheetManager::SpecShowActionSheetWithOptionsOptions::disabledButtonIndices() const
+inline folly::Optional<ABI45_0_0facebook::ABI45_0_0React::LazyVector<double>> ABI45_0_0JS::NativeActionSheetManager::SpecShowActionSheetWithOptionsOptions::disabledButtonIndices() const
 {
   id const p = _v[@"disabledButtonIndices"];
   return ABI45_0_0RCTBridgingToOptionalVec(p, ^double(id itemValue_0) { return ABI45_0_0RCTBridgingToDouble(itemValue_0); });
 }
-inline NSString *JS::NativeActionSheetManager::SpecShowShareActionSheetWithOptionsOptions::message() const
+inline NSString *ABI45_0_0JS::NativeActionSheetManager::SpecShowShareActionSheetWithOptionsOptions::message() const
 {
   id const p = _v[@"message"];
   return ABI45_0_0RCTBridgingToOptionalString(p);
 }
-inline NSString *JS::NativeActionSheetManager::SpecShowShareActionSheetWithOptionsOptions::url() const
+inline NSString *ABI45_0_0JS::NativeActionSheetManager::SpecShowShareActionSheetWithOptionsOptions::url() const
 {
   id const p = _v[@"url"];
   return ABI45_0_0RCTBridgingToOptionalString(p);
 }
-inline NSString *JS::NativeActionSheetManager::SpecShowShareActionSheetWithOptionsOptions::subject() const
+inline NSString *ABI45_0_0JS::NativeActionSheetManager::SpecShowShareActionSheetWithOptionsOptions::subject() const
 {
   id const p = _v[@"subject"];
   return ABI45_0_0RCTBridgingToOptionalString(p);
 }
-inline folly::Optional<double> JS::NativeActionSheetManager::SpecShowShareActionSheetWithOptionsOptions::anchor() const
+inline folly::Optional<double> ABI45_0_0JS::NativeActionSheetManager::SpecShowShareActionSheetWithOptionsOptions::anchor() const
 {
   id const p = _v[@"anchor"];
   return ABI45_0_0RCTBridgingToOptionalDouble(p);
 }
-inline folly::Optional<double> JS::NativeActionSheetManager::SpecShowShareActionSheetWithOptionsOptions::tintColor() const
+inline folly::Optional<double> ABI45_0_0JS::NativeActionSheetManager::SpecShowShareActionSheetWithOptionsOptions::tintColor() const
 {
   id const p = _v[@"tintColor"];
   return ABI45_0_0RCTBridgingToOptionalDouble(p);
 }
-inline folly::Optional<double> JS::NativeActionSheetManager::SpecShowShareActionSheetWithOptionsOptions::cancelButtonTintColor() const
+inline folly::Optional<double> ABI45_0_0JS::NativeActionSheetManager::SpecShowShareActionSheetWithOptionsOptions::cancelButtonTintColor() const
 {
   id const p = _v[@"cancelButtonTintColor"];
   return ABI45_0_0RCTBridgingToOptionalDouble(p);
 }
-inline folly::Optional<ABI45_0_0facebook::ABI45_0_0React::LazyVector<NSString *>> JS::NativeActionSheetManager::SpecShowShareActionSheetWithOptionsOptions::excludedActivityTypes() const
+inline folly::Optional<ABI45_0_0facebook::ABI45_0_0React::LazyVector<NSString *>> ABI45_0_0JS::NativeActionSheetManager::SpecShowShareActionSheetWithOptionsOptions::excludedActivityTypes() const
 {
   id const p = _v[@"excludedActivityTypes"];
   return ABI45_0_0RCTBridgingToOptionalVec(p, ^NSString *(id itemValue_0) { return ABI45_0_0RCTBridgingToString(itemValue_0); });
 }
-inline NSString *JS::NativeActionSheetManager::SpecShowShareActionSheetWithOptionsOptions::userInterfaceStyle() const
+inline NSString *ABI45_0_0JS::NativeActionSheetManager::SpecShowShareActionSheetWithOptionsOptions::userInterfaceStyle() const
 {
   id const p = _v[@"userInterfaceStyle"];
   return ABI45_0_0RCTBridgingToOptionalString(p);
 }
-inline NSString *JS::NativeAlertManager::Args::title() const
+inline NSString *ABI45_0_0JS::NativeAlertManager::Args::title() const
 {
   id const p = _v[@"title"];
   return ABI45_0_0RCTBridgingToOptionalString(p);
 }
-inline NSString *JS::NativeAlertManager::Args::message() const
+inline NSString *ABI45_0_0JS::NativeAlertManager::Args::message() const
 {
   id const p = _v[@"message"];
   return ABI45_0_0RCTBridgingToOptionalString(p);
 }
-inline folly::Optional<ABI45_0_0facebook::ABI45_0_0React::LazyVector<id<NSObject> >> JS::NativeAlertManager::Args::buttons() const
+inline folly::Optional<ABI45_0_0facebook::ABI45_0_0React::LazyVector<id<NSObject> >> ABI45_0_0JS::NativeAlertManager::Args::buttons() const
 {
   id const p = _v[@"buttons"];
   return ABI45_0_0RCTBridgingToOptionalVec(p, ^id<NSObject> (id itemValue_0) { return itemValue_0; });
 }
-inline NSString *JS::NativeAlertManager::Args::type() const
+inline NSString *ABI45_0_0JS::NativeAlertManager::Args::type() const
 {
   id const p = _v[@"type"];
   return ABI45_0_0RCTBridgingToOptionalString(p);
 }
-inline NSString *JS::NativeAlertManager::Args::defaultValue() const
+inline NSString *ABI45_0_0JS::NativeAlertManager::Args::defaultValue() const
 {
   id const p = _v[@"defaultValue"];
   return ABI45_0_0RCTBridgingToOptionalString(p);
 }
-inline NSString *JS::NativeAlertManager::Args::cancelButtonKey() const
+inline NSString *ABI45_0_0JS::NativeAlertManager::Args::cancelButtonKey() const
 {
   id const p = _v[@"cancelButtonKey"];
   return ABI45_0_0RCTBridgingToOptionalString(p);
 }
-inline NSString *JS::NativeAlertManager::Args::destructiveButtonKey() const
+inline NSString *ABI45_0_0JS::NativeAlertManager::Args::destructiveButtonKey() const
 {
   id const p = _v[@"destructiveButtonKey"];
   return ABI45_0_0RCTBridgingToOptionalString(p);
 }
-inline NSString *JS::NativeAlertManager::Args::keyboardType() const
+inline NSString *ABI45_0_0JS::NativeAlertManager::Args::keyboardType() const
 {
   id const p = _v[@"keyboardType"];
   return ABI45_0_0RCTBridgingToOptionalString(p);
 }
-inline ABI45_0_0facebook::ABI45_0_0React::LazyVector<NSString *> JS::NativeAnimatedModule::EventMapping::nativeEventPath() const
+inline ABI45_0_0facebook::ABI45_0_0React::LazyVector<NSString *> ABI45_0_0JS::NativeAnimatedModule::EventMapping::nativeEventPath() const
 {
   id const p = _v[@"nativeEventPath"];
   return ABI45_0_0RCTBridgingToVec(p, ^NSString *(id itemValue_0) { return ABI45_0_0RCTBridgingToString(itemValue_0); });
 }
-inline folly::Optional<double> JS::NativeAnimatedModule::EventMapping::animatedValueTag() const
+inline folly::Optional<double> ABI45_0_0JS::NativeAnimatedModule::EventMapping::animatedValueTag() const
 {
   id const p = _v[@"animatedValueTag"];
   return ABI45_0_0RCTBridgingToOptionalDouble(p);
 }
-inline ABI45_0_0facebook::ABI45_0_0React::LazyVector<NSString *> JS::NativeAnimatedTurboModule::EventMapping::nativeEventPath() const
+inline ABI45_0_0facebook::ABI45_0_0React::LazyVector<NSString *> ABI45_0_0JS::NativeAnimatedTurboModule::EventMapping::nativeEventPath() const
 {
   id const p = _v[@"nativeEventPath"];
   return ABI45_0_0RCTBridgingToVec(p, ^NSString *(id itemValue_0) { return ABI45_0_0RCTBridgingToString(itemValue_0); });
 }
-inline folly::Optional<double> JS::NativeAnimatedTurboModule::EventMapping::animatedValueTag() const
+inline folly::Optional<double> ABI45_0_0JS::NativeAnimatedTurboModule::EventMapping::animatedValueTag() const
 {
   id const p = _v[@"animatedValueTag"];
   return ABI45_0_0RCTBridgingToOptionalDouble(p);
 }
 
-inline JS::NativeAppState::Constants::Builder::Builder(const Input i) : _factory(^{
+inline ABI45_0_0JS::NativeAppState::Constants::Builder::Builder(const Input i) : _factory(^{
   NSMutableDictionary *d = [NSMutableDictionary new];
   auto initialAppState = i.initialAppState.get();
   d[@"initialAppState"] = initialAppState;
   return d;
 }) {}
-inline JS::NativeAppState::Constants::Builder::Builder(Constants i) : _factory(^{
+inline ABI45_0_0JS::NativeAppState::Constants::Builder::Builder(Constants i) : _factory(^{
   return i.unsafeRawValue();
 }) {}
 
 
 
-inline JS::NativeBlobModule::Constants::Builder::Builder(const Input i) : _factory(^{
+inline ABI45_0_0JS::NativeBlobModule::Constants::Builder::Builder(const Input i) : _factory(^{
   NSMutableDictionary *d = [NSMutableDictionary new];
   auto BLOB_URI_SCHEME = i.BLOB_URI_SCHEME.get();
   d[@"BLOB_URI_SCHEME"] = BLOB_URI_SCHEME;
@@ -2152,7 +2152,7 @@ inline JS::NativeBlobModule::Constants::Builder::Builder(const Input i) : _facto
   d[@"BLOB_URI_HOST"] = BLOB_URI_HOST;
   return d;
 }) {}
-inline JS::NativeBlobModule::Constants::Builder::Builder(Constants i) : _factory(^{
+inline ABI45_0_0JS::NativeBlobModule::Constants::Builder::Builder(Constants i) : _factory(^{
   return i.unsafeRawValue();
 }) {}
 
@@ -2162,7 +2162,7 @@ inline JS::NativeBlobModule::Constants::Builder::Builder(Constants i) : _factory
 
 
 
-inline JS::NativeDeviceInfo::DisplayMetrics::Builder::Builder(const Input i) : _factory(^{
+inline ABI45_0_0JS::NativeDeviceInfo::DisplayMetrics::Builder::Builder(const Input i) : _factory(^{
   NSMutableDictionary *d = [NSMutableDictionary new];
   auto width = i.width.get();
   d[@"width"] = @(width);
@@ -2174,10 +2174,10 @@ inline JS::NativeDeviceInfo::DisplayMetrics::Builder::Builder(const Input i) : _
   d[@"fontScale"] = @(fontScale);
   return d;
 }) {}
-inline JS::NativeDeviceInfo::DisplayMetrics::Builder::Builder(DisplayMetrics i) : _factory(^{
+inline ABI45_0_0JS::NativeDeviceInfo::DisplayMetrics::Builder::Builder(DisplayMetrics i) : _factory(^{
   return i.unsafeRawValue();
 }) {}
-inline JS::NativeDeviceInfo::DisplayMetricsAndroid::Builder::Builder(const Input i) : _factory(^{
+inline ABI45_0_0JS::NativeDeviceInfo::DisplayMetricsAndroid::Builder::Builder(const Input i) : _factory(^{
   NSMutableDictionary *d = [NSMutableDictionary new];
   auto width = i.width.get();
   d[@"width"] = @(width);
@@ -2191,10 +2191,10 @@ inline JS::NativeDeviceInfo::DisplayMetricsAndroid::Builder::Builder(const Input
   d[@"densityDpi"] = @(densityDpi);
   return d;
 }) {}
-inline JS::NativeDeviceInfo::DisplayMetricsAndroid::Builder::Builder(DisplayMetricsAndroid i) : _factory(^{
+inline ABI45_0_0JS::NativeDeviceInfo::DisplayMetricsAndroid::Builder::Builder(DisplayMetricsAndroid i) : _factory(^{
   return i.unsafeRawValue();
 }) {}
-inline JS::NativeDeviceInfo::DimensionsPayload::Builder::Builder(const Input i) : _factory(^{
+inline ABI45_0_0JS::NativeDeviceInfo::DimensionsPayload::Builder::Builder(const Input i) : _factory(^{
   NSMutableDictionary *d = [NSMutableDictionary new];
   auto window = i.window;
   d[@"window"] = window.hasValue() ? window.value().buildUnsafeRawValue() : nil;
@@ -2206,10 +2206,10 @@ inline JS::NativeDeviceInfo::DimensionsPayload::Builder::Builder(const Input i) 
   d[@"screenPhysicalPixels"] = screenPhysicalPixels.hasValue() ? screenPhysicalPixels.value().buildUnsafeRawValue() : nil;
   return d;
 }) {}
-inline JS::NativeDeviceInfo::DimensionsPayload::Builder::Builder(DimensionsPayload i) : _factory(^{
+inline ABI45_0_0JS::NativeDeviceInfo::DimensionsPayload::Builder::Builder(DimensionsPayload i) : _factory(^{
   return i.unsafeRawValue();
 }) {}
-inline JS::NativeDeviceInfo::Constants::Builder::Builder(const Input i) : _factory(^{
+inline ABI45_0_0JS::NativeDeviceInfo::Constants::Builder::Builder(const Input i) : _factory(^{
   NSMutableDictionary *d = [NSMutableDictionary new];
   auto Dimensions = i.Dimensions.get();
   d[@"Dimensions"] = Dimensions.buildUnsafeRawValue();
@@ -2217,87 +2217,87 @@ inline JS::NativeDeviceInfo::Constants::Builder::Builder(const Input i) : _facto
   d[@"isIPhoneX_deprecated"] = isIPhoneX_deprecated.hasValue() ? @((BOOL)isIPhoneX_deprecated.value()) : nil;
   return d;
 }) {}
-inline JS::NativeDeviceInfo::Constants::Builder::Builder(Constants i) : _factory(^{
+inline ABI45_0_0JS::NativeDeviceInfo::Constants::Builder::Builder(Constants i) : _factory(^{
   return i.unsafeRawValue();
 }) {}
-inline folly::Optional<double> JS::NativeExceptionsManager::StackFrame::column() const
+inline folly::Optional<double> ABI45_0_0JS::NativeExceptionsManager::StackFrame::column() const
 {
   id const p = _v[@"column"];
   return ABI45_0_0RCTBridgingToOptionalDouble(p);
 }
-inline NSString *JS::NativeExceptionsManager::StackFrame::file() const
+inline NSString *ABI45_0_0JS::NativeExceptionsManager::StackFrame::file() const
 {
   id const p = _v[@"file"];
   return ABI45_0_0RCTBridgingToOptionalString(p);
 }
-inline folly::Optional<double> JS::NativeExceptionsManager::StackFrame::lineNumber() const
+inline folly::Optional<double> ABI45_0_0JS::NativeExceptionsManager::StackFrame::lineNumber() const
 {
   id const p = _v[@"lineNumber"];
   return ABI45_0_0RCTBridgingToOptionalDouble(p);
 }
-inline NSString *JS::NativeExceptionsManager::StackFrame::methodName() const
+inline NSString *ABI45_0_0JS::NativeExceptionsManager::StackFrame::methodName() const
 {
   id const p = _v[@"methodName"];
   return ABI45_0_0RCTBridgingToString(p);
 }
-inline folly::Optional<bool> JS::NativeExceptionsManager::StackFrame::collapse() const
+inline folly::Optional<bool> ABI45_0_0JS::NativeExceptionsManager::StackFrame::collapse() const
 {
   id const p = _v[@"collapse"];
   return ABI45_0_0RCTBridgingToOptionalBool(p);
 }
-inline NSString *JS::NativeExceptionsManager::ExceptionData::message() const
+inline NSString *ABI45_0_0JS::NativeExceptionsManager::ExceptionData::message() const
 {
   id const p = _v[@"message"];
   return ABI45_0_0RCTBridgingToString(p);
 }
-inline NSString *JS::NativeExceptionsManager::ExceptionData::originalMessage() const
+inline NSString *ABI45_0_0JS::NativeExceptionsManager::ExceptionData::originalMessage() const
 {
   id const p = _v[@"originalMessage"];
   return ABI45_0_0RCTBridgingToOptionalString(p);
 }
-inline NSString *JS::NativeExceptionsManager::ExceptionData::name() const
+inline NSString *ABI45_0_0JS::NativeExceptionsManager::ExceptionData::name() const
 {
   id const p = _v[@"name"];
   return ABI45_0_0RCTBridgingToOptionalString(p);
 }
-inline NSString *JS::NativeExceptionsManager::ExceptionData::componentStack() const
+inline NSString *ABI45_0_0JS::NativeExceptionsManager::ExceptionData::componentStack() const
 {
   id const p = _v[@"componentStack"];
   return ABI45_0_0RCTBridgingToOptionalString(p);
 }
-inline ABI45_0_0facebook::ABI45_0_0React::LazyVector<JS::NativeExceptionsManager::StackFrame> JS::NativeExceptionsManager::ExceptionData::stack() const
+inline ABI45_0_0facebook::ABI45_0_0React::LazyVector<ABI45_0_0JS::NativeExceptionsManager::StackFrame> ABI45_0_0JS::NativeExceptionsManager::ExceptionData::stack() const
 {
   id const p = _v[@"stack"];
-  return ABI45_0_0RCTBridgingToVec(p, ^JS::NativeExceptionsManager::StackFrame(id itemValue_0) { return JS::NativeExceptionsManager::StackFrame(itemValue_0); });
+  return ABI45_0_0RCTBridgingToVec(p, ^ABI45_0_0JS::NativeExceptionsManager::StackFrame(id itemValue_0) { return ABI45_0_0JS::NativeExceptionsManager::StackFrame(itemValue_0); });
 }
-inline double JS::NativeExceptionsManager::ExceptionData::id_() const
+inline double ABI45_0_0JS::NativeExceptionsManager::ExceptionData::id_() const
 {
   id const p = _v[@"id"];
   return ABI45_0_0RCTBridgingToDouble(p);
 }
-inline bool JS::NativeExceptionsManager::ExceptionData::isFatal() const
+inline bool ABI45_0_0JS::NativeExceptionsManager::ExceptionData::isFatal() const
 {
   id const p = _v[@"isFatal"];
   return ABI45_0_0RCTBridgingToBool(p);
 }
-inline id<NSObject> _Nullable JS::NativeExceptionsManager::ExceptionData::extraData() const
+inline id<NSObject> _Nullable ABI45_0_0JS::NativeExceptionsManager::ExceptionData::extraData() const
 {
   id const p = _v[@"extraData"];
   return p;
 }
 
-inline folly::Optional<bool> JS::NativeFrameRateLogger::SpecSetGlobalOptionsOptions::debug() const
+inline folly::Optional<bool> ABI45_0_0JS::NativeFrameRateLogger::SpecSetGlobalOptionsOptions::debug() const
 {
   id const p = _v[@"debug"];
   return ABI45_0_0RCTBridgingToOptionalBool(p);
 }
-inline folly::Optional<bool> JS::NativeFrameRateLogger::SpecSetGlobalOptionsOptions::reportStackTraces() const
+inline folly::Optional<bool> ABI45_0_0JS::NativeFrameRateLogger::SpecSetGlobalOptionsOptions::reportStackTraces() const
 {
   id const p = _v[@"reportStackTraces"];
   return ABI45_0_0RCTBridgingToOptionalBool(p);
 }
 
-inline JS::NativeI18nManager::Constants::Builder::Builder(const Input i) : _factory(^{
+inline ABI45_0_0JS::NativeI18nManager::Constants::Builder::Builder(const Input i) : _factory(^{
   NSMutableDictionary *d = [NSMutableDictionary new];
   auto isRTL = i.isRTL.get();
   d[@"isRTL"] = @(isRTL);
@@ -2307,81 +2307,81 @@ inline JS::NativeI18nManager::Constants::Builder::Builder(const Input i) : _fact
   d[@"localeIdentifier"] = localeIdentifier;
   return d;
 }) {}
-inline JS::NativeI18nManager::Constants::Builder::Builder(Constants i) : _factory(^{
+inline ABI45_0_0JS::NativeI18nManager::Constants::Builder::Builder(Constants i) : _factory(^{
   return i.unsafeRawValue();
 }) {}
-inline double JS::NativeImageEditor::OptionsOffset::x() const
+inline double ABI45_0_0JS::NativeImageEditor::OptionsOffset::x() const
 {
   id const p = _v[@"x"];
   return ABI45_0_0RCTBridgingToDouble(p);
 }
-inline double JS::NativeImageEditor::OptionsOffset::y() const
+inline double ABI45_0_0JS::NativeImageEditor::OptionsOffset::y() const
 {
   id const p = _v[@"y"];
   return ABI45_0_0RCTBridgingToDouble(p);
 }
-inline double JS::NativeImageEditor::OptionsSize::width() const
+inline double ABI45_0_0JS::NativeImageEditor::OptionsSize::width() const
 {
   id const p = _v[@"width"];
   return ABI45_0_0RCTBridgingToDouble(p);
 }
-inline double JS::NativeImageEditor::OptionsSize::height() const
+inline double ABI45_0_0JS::NativeImageEditor::OptionsSize::height() const
 {
   id const p = _v[@"height"];
   return ABI45_0_0RCTBridgingToDouble(p);
 }
-inline double JS::NativeImageEditor::OptionsDisplaySize::width() const
+inline double ABI45_0_0JS::NativeImageEditor::OptionsDisplaySize::width() const
 {
   id const p = _v[@"width"];
   return ABI45_0_0RCTBridgingToDouble(p);
 }
-inline double JS::NativeImageEditor::OptionsDisplaySize::height() const
+inline double ABI45_0_0JS::NativeImageEditor::OptionsDisplaySize::height() const
 {
   id const p = _v[@"height"];
   return ABI45_0_0RCTBridgingToDouble(p);
 }
-inline JS::NativeImageEditor::OptionsOffset JS::NativeImageEditor::Options::offset() const
+inline ABI45_0_0JS::NativeImageEditor::OptionsOffset ABI45_0_0JS::NativeImageEditor::Options::offset() const
 {
   id const p = _v[@"offset"];
-  return JS::NativeImageEditor::OptionsOffset(p);
+  return ABI45_0_0JS::NativeImageEditor::OptionsOffset(p);
 }
-inline JS::NativeImageEditor::OptionsSize JS::NativeImageEditor::Options::size() const
+inline ABI45_0_0JS::NativeImageEditor::OptionsSize ABI45_0_0JS::NativeImageEditor::Options::size() const
 {
   id const p = _v[@"size"];
-  return JS::NativeImageEditor::OptionsSize(p);
+  return ABI45_0_0JS::NativeImageEditor::OptionsSize(p);
 }
-inline folly::Optional<JS::NativeImageEditor::OptionsDisplaySize> JS::NativeImageEditor::Options::displaySize() const
+inline folly::Optional<ABI45_0_0JS::NativeImageEditor::OptionsDisplaySize> ABI45_0_0JS::NativeImageEditor::Options::displaySize() const
 {
   id const p = _v[@"displaySize"];
-  return (p == nil ? folly::none : folly::make_optional(JS::NativeImageEditor::OptionsDisplaySize(p)));
+  return (p == nil ? folly::none : folly::make_optional(ABI45_0_0JS::NativeImageEditor::OptionsDisplaySize(p)));
 }
-inline NSString *JS::NativeImageEditor::Options::resizeMode() const
+inline NSString *ABI45_0_0JS::NativeImageEditor::Options::resizeMode() const
 {
   id const p = _v[@"resizeMode"];
   return ABI45_0_0RCTBridgingToOptionalString(p);
 }
-inline folly::Optional<bool> JS::NativeImageEditor::Options::allowExternalStorage() const
+inline folly::Optional<bool> ABI45_0_0JS::NativeImageEditor::Options::allowExternalStorage() const
 {
   id const p = _v[@"allowExternalStorage"];
   return ABI45_0_0RCTBridgingToOptionalBool(p);
 }
 
-inline bool JS::NativeImagePickerIOS::SpecOpenCameraDialogConfig::unmirrorFrontFacingCamera() const
+inline bool ABI45_0_0JS::NativeImagePickerIOS::SpecOpenCameraDialogConfig::unmirrorFrontFacingCamera() const
 {
   id const p = _v[@"unmirrorFrontFacingCamera"];
   return ABI45_0_0RCTBridgingToBool(p);
 }
-inline bool JS::NativeImagePickerIOS::SpecOpenCameraDialogConfig::videoMode() const
+inline bool ABI45_0_0JS::NativeImagePickerIOS::SpecOpenCameraDialogConfig::videoMode() const
 {
   id const p = _v[@"videoMode"];
   return ABI45_0_0RCTBridgingToBool(p);
 }
-inline bool JS::NativeImagePickerIOS::SpecOpenSelectDialogConfig::showImages() const
+inline bool ABI45_0_0JS::NativeImagePickerIOS::SpecOpenSelectDialogConfig::showImages() const
 {
   id const p = _v[@"showImages"];
   return ABI45_0_0RCTBridgingToBool(p);
 }
-inline bool JS::NativeImagePickerIOS::SpecOpenSelectDialogConfig::showVideos() const
+inline bool ABI45_0_0JS::NativeImagePickerIOS::SpecOpenSelectDialogConfig::showVideos() const
 {
   id const p = _v[@"showVideos"];
   return ABI45_0_0RCTBridgingToBool(p);
@@ -2389,7 +2389,7 @@ inline bool JS::NativeImagePickerIOS::SpecOpenSelectDialogConfig::showVideos() c
 
 
 
-inline JS::NativeJSDevSupport::Constants::Builder::Builder(const Input i) : _factory(^{
+inline ABI45_0_0JS::NativeJSDevSupport::Constants::Builder::Builder(const Input i) : _factory(^{
   NSMutableDictionary *d = [NSMutableDictionary new];
   auto ERROR_CODE_EXCEPTION = i.ERROR_CODE_EXCEPTION.get();
   d[@"ERROR_CODE_EXCEPTION"] = @(ERROR_CODE_EXCEPTION);
@@ -2397,54 +2397,54 @@ inline JS::NativeJSDevSupport::Constants::Builder::Builder(const Input i) : _fac
   d[@"ERROR_CODE_VIEW_NOT_FOUND"] = @(ERROR_CODE_VIEW_NOT_FOUND);
   return d;
 }) {}
-inline JS::NativeJSDevSupport::Constants::Builder::Builder(Constants i) : _factory(^{
+inline ABI45_0_0JS::NativeJSDevSupport::Constants::Builder::Builder(Constants i) : _factory(^{
   return i.unsafeRawValue();
 }) {}
 
 
 
 
-inline NSString *JS::NativeNetworkingIOS::SpecSendRequestQuery::method() const
+inline NSString *ABI45_0_0JS::NativeNetworkingIOS::SpecSendRequestQuery::method() const
 {
   id const p = _v[@"method"];
   return ABI45_0_0RCTBridgingToString(p);
 }
-inline NSString *JS::NativeNetworkingIOS::SpecSendRequestQuery::url() const
+inline NSString *ABI45_0_0JS::NativeNetworkingIOS::SpecSendRequestQuery::url() const
 {
   id const p = _v[@"url"];
   return ABI45_0_0RCTBridgingToString(p);
 }
-inline id<NSObject>  JS::NativeNetworkingIOS::SpecSendRequestQuery::data() const
+inline id<NSObject>  ABI45_0_0JS::NativeNetworkingIOS::SpecSendRequestQuery::data() const
 {
   id const p = _v[@"data"];
   return p;
 }
-inline id<NSObject>  JS::NativeNetworkingIOS::SpecSendRequestQuery::headers() const
+inline id<NSObject>  ABI45_0_0JS::NativeNetworkingIOS::SpecSendRequestQuery::headers() const
 {
   id const p = _v[@"headers"];
   return p;
 }
-inline NSString *JS::NativeNetworkingIOS::SpecSendRequestQuery::responseType() const
+inline NSString *ABI45_0_0JS::NativeNetworkingIOS::SpecSendRequestQuery::responseType() const
 {
   id const p = _v[@"responseType"];
   return ABI45_0_0RCTBridgingToString(p);
 }
-inline bool JS::NativeNetworkingIOS::SpecSendRequestQuery::incrementalUpdates() const
+inline bool ABI45_0_0JS::NativeNetworkingIOS::SpecSendRequestQuery::incrementalUpdates() const
 {
   id const p = _v[@"incrementalUpdates"];
   return ABI45_0_0RCTBridgingToBool(p);
 }
-inline double JS::NativeNetworkingIOS::SpecSendRequestQuery::timeout() const
+inline double ABI45_0_0JS::NativeNetworkingIOS::SpecSendRequestQuery::timeout() const
 {
   id const p = _v[@"timeout"];
   return ABI45_0_0RCTBridgingToDouble(p);
 }
-inline bool JS::NativeNetworkingIOS::SpecSendRequestQuery::withCredentials() const
+inline bool ABI45_0_0JS::NativeNetworkingIOS::SpecSendRequestQuery::withCredentials() const
 {
   id const p = _v[@"withCredentials"];
   return ABI45_0_0RCTBridgingToBool(p);
 }
-inline JS::NativePlatformConstantsIOS::ConstantsreactNativeVersion::Builder::Builder(const Input i) : _factory(^{
+inline ABI45_0_0JS::NativePlatformConstantsIOS::ConstantsreactNativeVersion::Builder::Builder(const Input i) : _factory(^{
   NSMutableDictionary *d = [NSMutableDictionary new];
   auto major = i.major.get();
   d[@"major"] = @(major);
@@ -2456,10 +2456,10 @@ inline JS::NativePlatformConstantsIOS::ConstantsreactNativeVersion::Builder::Bui
   d[@"prerelease"] = prerelease.hasValue() ? @((double)prerelease.value()) : nil;
   return d;
 }) {}
-inline JS::NativePlatformConstantsIOS::ConstantsreactNativeVersion::Builder::Builder(ConstantsreactNativeVersion i) : _factory(^{
+inline ABI45_0_0JS::NativePlatformConstantsIOS::ConstantsreactNativeVersion::Builder::Builder(ConstantsreactNativeVersion i) : _factory(^{
   return i.unsafeRawValue();
 }) {}
-inline JS::NativePlatformConstantsIOS::Constants::Builder::Builder(const Input i) : _factory(^{
+inline ABI45_0_0JS::NativePlatformConstantsIOS::Constants::Builder::Builder(const Input i) : _factory(^{
   NSMutableDictionary *d = [NSMutableDictionary new];
   auto isTesting = i.isTesting.get();
   d[@"isTesting"] = @(isTesting);
@@ -2475,101 +2475,101 @@ inline JS::NativePlatformConstantsIOS::Constants::Builder::Builder(const Input i
   d[@"interfaceIdiom"] = interfaceIdiom;
   return d;
 }) {}
-inline JS::NativePlatformConstantsIOS::Constants::Builder::Builder(Constants i) : _factory(^{
+inline ABI45_0_0JS::NativePlatformConstantsIOS::Constants::Builder::Builder(Constants i) : _factory(^{
   return i.unsafeRawValue();
 }) {}
-inline bool JS::NativePushNotificationManagerIOS::SpecRequestPermissionsPermission::alert() const
+inline bool ABI45_0_0JS::NativePushNotificationManagerIOS::SpecRequestPermissionsPermission::alert() const
 {
   id const p = _v[@"alert"];
   return ABI45_0_0RCTBridgingToBool(p);
 }
-inline bool JS::NativePushNotificationManagerIOS::SpecRequestPermissionsPermission::badge() const
+inline bool ABI45_0_0JS::NativePushNotificationManagerIOS::SpecRequestPermissionsPermission::badge() const
 {
   id const p = _v[@"badge"];
   return ABI45_0_0RCTBridgingToBool(p);
 }
-inline bool JS::NativePushNotificationManagerIOS::SpecRequestPermissionsPermission::sound() const
+inline bool ABI45_0_0JS::NativePushNotificationManagerIOS::SpecRequestPermissionsPermission::sound() const
 {
   id const p = _v[@"sound"];
   return ABI45_0_0RCTBridgingToBool(p);
 }
-inline NSString *JS::NativePushNotificationManagerIOS::Notification::alertTitle() const
+inline NSString *ABI45_0_0JS::NativePushNotificationManagerIOS::Notification::alertTitle() const
 {
   id const p = _v[@"alertTitle"];
   return ABI45_0_0RCTBridgingToOptionalString(p);
 }
-inline folly::Optional<double> JS::NativePushNotificationManagerIOS::Notification::fireDate() const
+inline folly::Optional<double> ABI45_0_0JS::NativePushNotificationManagerIOS::Notification::fireDate() const
 {
   id const p = _v[@"fireDate"];
   return ABI45_0_0RCTBridgingToOptionalDouble(p);
 }
-inline NSString *JS::NativePushNotificationManagerIOS::Notification::alertBody() const
+inline NSString *ABI45_0_0JS::NativePushNotificationManagerIOS::Notification::alertBody() const
 {
   id const p = _v[@"alertBody"];
   return ABI45_0_0RCTBridgingToOptionalString(p);
 }
-inline NSString *JS::NativePushNotificationManagerIOS::Notification::alertAction() const
+inline NSString *ABI45_0_0JS::NativePushNotificationManagerIOS::Notification::alertAction() const
 {
   id const p = _v[@"alertAction"];
   return ABI45_0_0RCTBridgingToOptionalString(p);
 }
-inline id<NSObject> _Nullable JS::NativePushNotificationManagerIOS::Notification::userInfo() const
+inline id<NSObject> _Nullable ABI45_0_0JS::NativePushNotificationManagerIOS::Notification::userInfo() const
 {
   id const p = _v[@"userInfo"];
   return p;
 }
-inline NSString *JS::NativePushNotificationManagerIOS::Notification::category() const
+inline NSString *ABI45_0_0JS::NativePushNotificationManagerIOS::Notification::category() const
 {
   id const p = _v[@"category"];
   return ABI45_0_0RCTBridgingToOptionalString(p);
 }
-inline NSString *JS::NativePushNotificationManagerIOS::Notification::repeatInterval() const
+inline NSString *ABI45_0_0JS::NativePushNotificationManagerIOS::Notification::repeatInterval() const
 {
   id const p = _v[@"repeatInterval"];
   return ABI45_0_0RCTBridgingToOptionalString(p);
 }
-inline folly::Optional<double> JS::NativePushNotificationManagerIOS::Notification::applicationIconBadgeNumber() const
+inline folly::Optional<double> ABI45_0_0JS::NativePushNotificationManagerIOS::Notification::applicationIconBadgeNumber() const
 {
   id const p = _v[@"applicationIconBadgeNumber"];
   return ABI45_0_0RCTBridgingToOptionalDouble(p);
 }
-inline folly::Optional<bool> JS::NativePushNotificationManagerIOS::Notification::isSilent() const
+inline folly::Optional<bool> ABI45_0_0JS::NativePushNotificationManagerIOS::Notification::isSilent() const
 {
   id const p = _v[@"isSilent"];
   return ABI45_0_0RCTBridgingToOptionalBool(p);
 }
 
 
-inline JS::NativeSettingsManager::Constants::Builder::Builder(const Input i) : _factory(^{
+inline ABI45_0_0JS::NativeSettingsManager::Constants::Builder::Builder(const Input i) : _factory(^{
   NSMutableDictionary *d = [NSMutableDictionary new];
   auto settings = i.settings.get();
   d[@"settings"] = settings;
   return d;
 }) {}
-inline JS::NativeSettingsManager::Constants::Builder::Builder(Constants i) : _factory(^{
+inline ABI45_0_0JS::NativeSettingsManager::Constants::Builder::Builder(Constants i) : _factory(^{
   return i.unsafeRawValue();
 }) {}
-inline NSString *JS::NativeShareModule::SpecShareContent::title() const
+inline NSString *ABI45_0_0JS::NativeShareModule::SpecShareContent::title() const
 {
   id const p = _v[@"title"];
   return ABI45_0_0RCTBridgingToOptionalString(p);
 }
-inline NSString *JS::NativeShareModule::SpecShareContent::message() const
+inline NSString *ABI45_0_0JS::NativeShareModule::SpecShareContent::message() const
 {
   id const p = _v[@"message"];
   return ABI45_0_0RCTBridgingToOptionalString(p);
 }
 
-inline JS::NativeSourceCode::Constants::Builder::Builder(const Input i) : _factory(^{
+inline ABI45_0_0JS::NativeSourceCode::Constants::Builder::Builder(const Input i) : _factory(^{
   NSMutableDictionary *d = [NSMutableDictionary new];
   auto scriptURL = i.scriptURL.get();
   d[@"scriptURL"] = scriptURL;
   return d;
 }) {}
-inline JS::NativeSourceCode::Constants::Builder::Builder(Constants i) : _factory(^{
+inline ABI45_0_0JS::NativeSourceCode::Constants::Builder::Builder(Constants i) : _factory(^{
   return i.unsafeRawValue();
 }) {}
-inline JS::NativeStatusBarManagerIOS::Constants::Builder::Builder(const Input i) : _factory(^{
+inline ABI45_0_0JS::NativeStatusBarManagerIOS::Constants::Builder::Builder(const Input i) : _factory(^{
   NSMutableDictionary *d = [NSMutableDictionary new];
   auto HEIGHT = i.HEIGHT.get();
   d[@"HEIGHT"] = @(HEIGHT);
@@ -2577,12 +2577,12 @@ inline JS::NativeStatusBarManagerIOS::Constants::Builder::Builder(const Input i)
   d[@"DEFAULT_BACKGROUND_COLOR"] = DEFAULT_BACKGROUND_COLOR.hasValue() ? @((double)DEFAULT_BACKGROUND_COLOR.value()) : nil;
   return d;
 }) {}
-inline JS::NativeStatusBarManagerIOS::Constants::Builder::Builder(Constants i) : _factory(^{
+inline ABI45_0_0JS::NativeStatusBarManagerIOS::Constants::Builder::Builder(Constants i) : _factory(^{
   return i.unsafeRawValue();
 }) {}
 
 
-inline id<NSObject> _Nullable JS::NativeWebSocketModule::SpecConnectOptions::headers() const
+inline id<NSObject> _Nullable ABI45_0_0JS::NativeWebSocketModule::SpecConnectOptions::headers() const
 {
   id const p = _v[@"headers"];
   return p;


### PR DESCRIPTION
# Why

Follow up on #18246 

# How

Manually versioned `JS` namespace in SDK 44 and 45, according to what the script did for SDK 46 in #18232 

# Test Plan

Expo Go builds as expected and NCL for SDK 45 seems to work as expected
