### PR TITLE
[expo] Add `@sentry/react-native` to bundledNativeModules for SDK 45.

### DIFF
--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -109,5 +109,6 @@
   "react-native-webview": "11.18.1",
   "sentry-expo": "^4.2.0",
   "unimodules-app-loader": "~3.1.0",
-  "unimodules-image-loader-interface": "~6.1.0"
+  "unimodules-image-loader-interface": "~6.1.0",
+  "@sentry/react-native": "^3.1.1"
 }


### PR DESCRIPTION
# Why

`sentry-expo` requires a specific version of `@sentry/react-native`, but we didn't have that version listed. It used to be the latest version, so it didn't matter, but with `@sentry/react-native@4` being released, this started to cause issues for our users.

# How

Added entry to match https://github.com/expo/sentry-expo/blob/30b841ef7f2112ec436c08abad6779e7afa745ce/package.json#L45

# Test Plan

`expo install @sentry/react-native` should install version ^3.1.1.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
