### PR TITLE
[expo] Add @sentry/react-native to bundledNativeModules

### DIFF
--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -106,5 +106,5 @@
   "unimodules-image-loader-interface": "~6.1.0",
   "@shopify/react-native-skia": "0.1.136",
   "@shopify/flash-list": "1.1.0",
-  "@sentry/react-native": "~4.1.3"
+  "@sentry/react-native": "^4.1.3"
 }

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -105,5 +105,6 @@
   "unimodules-app-loader": "~3.1.0",
   "unimodules-image-loader-interface": "~6.1.0",
   "@shopify/react-native-skia": "0.1.136",
-  "@shopify/flash-list": "1.1.0"
+  "@shopify/flash-list": "1.1.0",
+  "@sentry/react-native": "~4.1.3"
 }

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -101,7 +101,7 @@
   "react-native-svg": "12.3.0",
   "react-native-view-shot": "3.3.0",
   "react-native-webview": "11.22.4",
-  "sentry-expo": "^4.0.0",
+  "sentry-expo": "~5.0.0",
   "unimodules-app-loader": "~3.1.0",
   "unimodules-image-loader-interface": "~6.1.0",
   "@shopify/react-native-skia": "0.1.136",


### PR DESCRIPTION
# Why

`sentry-expo` requires a specific version of `@sentry/react-native`, but we didn't have that version listed. I added the version required for SDK 45 here: https://github.com/expo/expo/pull/18249, but for SDK 46 we'll release a version of `sentry-expo` that uses v4.

# How

Added entry to JSON.

# Test Plan

`expo install @sentry/react-native` should install version ~4.1.3.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
