### PR TITLE
[expo-modules-core] Logger changes

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ### 💡 Others
 
+### ⚠️ Notices
+
+- Logger changes. ([#18251](https://github.com/expo/expo/pull/18251) by [@douglowder](https://github.com/douglowder))
+
 ## 0.11.1 — 2022-07-11
 
 ### 🐛 Bug fixes

--- a/packages/expo-modules-core/ios/Swift/Logging/LogType.swift
+++ b/packages/expo-modules-core/ios/Swift/Logging/LogType.swift
@@ -5,7 +5,7 @@ import os.log
 /**
  An enum with available log types.
  */
-public enum LogType: Int {
+@objc public enum LogType: Int {
   case trace = 0
   case timer = 1
   case stacktrace = 2
@@ -14,6 +14,27 @@ public enum LogType: Int {
   case warn = 5
   case error = 6
   case fatal = 7
+
+  public var asString: String {
+    switch self {
+    case .trace:
+      return "trace"
+    case .timer:
+      return "timer"
+    case .stacktrace:
+      return "stacktrace"
+    case .debug:
+      return "debug"
+    case .info:
+      return "info"
+    case .warn:
+      return "warn"
+    case .error:
+      return "error"
+    case .fatal:
+      return "fatal"
+    }
+  }
 
   /**
    The string that is used to prefix the messages of this log type.

--- a/packages/expo-modules-core/ios/Swift/Logging/Logger.swift
+++ b/packages/expo-modules-core/ios/Swift/Logging/Logger.swift
@@ -15,7 +15,10 @@ public class Logger {
 
   private var handlers: [LogHandler] = []
 
-  init(category: String = "main") {
+  /**
+   Exposed for use by Swift wrappers
+   */
+  public init(category: String) {
     self.category = category
 
     if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
@@ -34,6 +37,14 @@ public class Logger {
   }
 
   // MARK: - Public logging functions
+
+  /**
+   Exposed for use by Swift wrappers
+    Application code should call one of the LogType-specific methods below
+   */
+  public func log(type: LogType = .trace, _ items: Any...) {
+    log(type: type, items)
+  }
 
   /**
    The most verbose log level that captures all the details about the behavior of the implementation.
@@ -139,7 +150,7 @@ public class Logger {
     }
     let endTime = DispatchTime.now()
     let diff = Double(endTime.uptimeNanoseconds - startTime.uptimeNanoseconds) / 1_000_000
-    log(type: .timer, "Timer '\(id)' has finished in: \(diff) seconds")
+    log(type: .timer, "Timer '\(id)' has finished in: \(diff) ms")
     timers.removeValue(forKey: id)
   }
 
@@ -177,17 +188,13 @@ public class Logger {
       }
     }
   }
-
-  private func log(type: LogType = .trace, _ items: Any...) {
-    log(type: type, items)
-  }
 }
 
-fileprivate func reformatStackSymbol(_ symbol: String) -> String {
+private func reformatStackSymbol(_ symbol: String) -> String {
   return symbol.replacingOccurrences(of: #"^\d+\s+"#, with: "", options: .regularExpression)
 }
 
-fileprivate func describe(value: Any) -> String {
+private func describe(value: Any) -> String {
   if let value = value as? String {
     return value
   }


### PR DESCRIPTION
# Why

Make changes needed to allow `Logger.swift` to be used in a wrapper class in expo-updates.

# How

- Make `init()` and other methods public
- Expose `LogType` and add `asString()` convenience method

# Test Plan

Future PRs include the new wrapper class to log errors in expo-updates, and unit tests for the same.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
