### PR TITLE
[ios] Backport recent changes in SplashScreen to SDK 44 and 45

### DIFF
--- a/ios/versioned/sdk44/EXSplashScreen/EXSplashScreen/ABI44_0_0EXSplashScreenModule.m
+++ b/ios/versioned/sdk44/EXSplashScreen/EXSplashScreen/ABI44_0_0EXSplashScreenModule.m
@@ -39,6 +39,7 @@ ABI44_0_0EX_EXPORT_METHOD_AS(hideAsync,
     ABI44_0_0EX_ENSURE_STRONGIFY(self);
     UIViewController *currentViewController = [self reactViewController];
     [[self splashScreenService] hideSplashScreenFor:currentViewController
+                                            options:ABI44_0_0EXSplashScreenDefault
                                     successCallback:^(BOOL hasEffect){ resolve(@(hasEffect)); }
                                     failureCallback:^(NSString *message){ reject(@"ERR_SPLASH_SCREEN_CANNOT_HIDE", message, nil); }];
   });
@@ -53,6 +54,7 @@ ABI44_0_0EX_EXPORT_METHOD_AS(preventAutoHideAsync,
     ABI44_0_0EX_ENSURE_STRONGIFY(self);
     UIViewController *currentViewController = [self reactViewController];
     [[self splashScreenService] preventSplashScreenAutoHideFor:currentViewController
+                                                       options:ABI44_0_0EXSplashScreenDefault
                                                successCallback:^(BOOL hasEffect){ resolve(@(hasEffect)); }
                                                failureCallback:^(NSString *message){ reject(@"ERR_SPLASH_SCREEN_CANNOT_PREVENT_AUTOHIDE", message, nil); }];
   });

--- a/ios/versioned/sdk44/EXSplashScreen/EXSplashScreen/ABI44_0_0EXSplashScreenService.h
+++ b/ios/versioned/sdk44/EXSplashScreen/EXSplashScreen/ABI44_0_0EXSplashScreenService.h
@@ -8,6 +8,14 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef NS_OPTIONS(NSUInteger, ABI44_0_0EXSplashScreenOptions) {
+   ABI44_0_0EXSplashScreenDefault = 0,
+
+   // Show splash screen even it was already shown before.
+   // e.g. show splash screen again when reloading apps,
+   ABI44_0_0EXSplashScreenForceShow = 1 << 0,
+ };
+
 /**
 * Entry point for handling SplashScreen associated mechanism.
 * This class has state based on the following relation { ViewController -> ApplicationSplashScreenState }.
@@ -18,13 +26,15 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Overloaded method. See main method below.
  */
-- (void)showSplashScreenFor:(UIViewController *)viewController;
+- (void)showSplashScreenFor:(UIViewController *)viewController
+                    options:(ABI44_0_0EXSplashScreenOptions)options;
 
 /**
  * Entry point for SplashScreen unimodule.
  * Registers SplashScreen for given viewController and presents it in that viewController.
  */
 - (void)showSplashScreenFor:(UIViewController *)viewController
+                    options:(ABI44_0_0EXSplashScreenOptions)options
    splashScreenViewProvider:(id<ABI44_0_0EXSplashScreenViewProvider>)splashScreenViewProvider
             successCallback:(void (^)(void))successCallback
             failureCallback:(void (^)(NSString *message))failureCallback;
@@ -34,6 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Registers SplashScreen for given viewController and ABI44_0_0EXSplashController and presents it in that viewController.
  */
 -(void)showSplashScreenFor:(UIViewController *)viewController
+                   options:(ABI44_0_0EXSplashScreenOptions)options
     splashScreenController:(ABI44_0_0EXSplashScreenViewController *)splashScreenController
            successCallback:(void (^)(void))successCallback
            failureCallback:(void (^)(NSString *message))failureCallback;
@@ -42,6 +53,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Hides SplashScreen for given viewController.
  */
 - (void)hideSplashScreenFor:(UIViewController *)viewController
+                    options:(ABI44_0_0EXSplashScreenOptions)options
             successCallback:(void (^)(BOOL hasEffect))successCallback
             failureCallback:(void (^)(NSString *message))failureCallback;
 
@@ -49,6 +61,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Prevents SplashScreen from default autohiding.
  */
 - (void)preventSplashScreenAutoHideFor:(UIViewController *)viewController
+                               options:(ABI44_0_0EXSplashScreenOptions)options
                        successCallback:(void (^)(BOOL hasEffect))successCallback
                        failureCallback:(void (^)(NSString *message))failureCallback;
 

--- a/ios/versioned/sdk44/EXSplashScreen/EXSplashScreen/ABI44_0_0EXSplashScreenService.m
+++ b/ios/versioned/sdk44/EXSplashScreen/EXSplashScreen/ABI44_0_0EXSplashScreenService.m
@@ -36,9 +36,11 @@ ABI44_0_0EX_REGISTER_SINGLETON_MODULE(SplashScreen);
 }
 
 - (void)showSplashScreenFor:(UIViewController *)viewController
+                    options:(ABI44_0_0EXSplashScreenOptions)options
 {
   id<ABI44_0_0EXSplashScreenViewProvider> splashScreenViewProvider = [ABI44_0_0EXSplashScreenViewNativeProvider new];
   return [self showSplashScreenFor:viewController
+                           options:options
           splashScreenViewProvider:splashScreenViewProvider
                    successCallback:^{}
                    failureCallback:^(NSString *message){ ABI44_0_0EXLogWarn(@"%@", message); }];
@@ -46,6 +48,7 @@ ABI44_0_0EX_REGISTER_SINGLETON_MODULE(SplashScreen);
 
 
 - (void)showSplashScreenFor:(UIViewController *)viewController
+                    options:(ABI44_0_0EXSplashScreenOptions)options
    splashScreenViewProvider:(id<ABI44_0_0EXSplashScreenViewProvider>)splashScreenViewProvider
             successCallback:(void (^)(void))successCallback
             failureCallback:(void (^)(NSString * _Nonnull))failureCallback
@@ -61,12 +64,14 @@ ABI44_0_0EX_REGISTER_SINGLETON_MODULE(SplashScreen);
                                                                                                splashScreenView:splashScreenView];
   
   [self showSplashScreenFor:viewController
+                    options:options
      splashScreenController:splashScreenController
             successCallback:successCallback
             failureCallback:failureCallback];
 }
 
 - (void)showSplashScreenFor:(UIViewController *)viewController
+                    options:(ABI44_0_0EXSplashScreenOptions)options
      splashScreenController:(ABI44_0_0EXSplashScreenViewController *)splashScreenController
             successCallback:(void (^)(void))successCallback
             failureCallback:(void (^)(NSString * _Nonnull))failureCallback
@@ -81,6 +86,7 @@ ABI44_0_0EX_REGISTER_SINGLETON_MODULE(SplashScreen);
 }
 
 - (void)preventSplashScreenAutoHideFor:(UIViewController *)viewController
+                               options:(ABI44_0_0EXSplashScreenOptions)options
                        successCallback:(void (^)(BOOL hasEffect))successCallback
                        failureCallback:(void (^)(NSString * _Nonnull))failureCallback
 {
@@ -93,6 +99,7 @@ ABI44_0_0EX_REGISTER_SINGLETON_MODULE(SplashScreen);
 }
 
 - (void)hideSplashScreenFor:(UIViewController *)viewController
+                    options:(ABI44_0_0EXSplashScreenOptions)options
             successCallback:(void (^)(BOOL hasEffect))successCallback
             failureCallback:(void (^)(NSString * _Nonnull))failureCallback
 {
@@ -113,6 +120,7 @@ ABI44_0_0EX_REGISTER_SINGLETON_MODULE(SplashScreen);
   BOOL needsHide = [[self.splashScreenControllers objectForKey:viewController] needsHideOnAppContentDidAppear];
   if (needsHide) {
     [self hideSplashScreenFor:viewController
+                      options:ABI44_0_0EXSplashScreenDefault
               successCallback:^(BOOL hasEffect){}
               failureCallback:^(NSString *message){}];
   }
@@ -126,6 +134,7 @@ ABI44_0_0EX_REGISTER_SINGLETON_MODULE(SplashScreen);
   BOOL needsShow = [[self.splashScreenControllers objectForKey:viewController] needsShowOnAppContentWillReload];
   if (needsShow) {
     [self showSplashScreenFor:viewController
+                      options:ABI44_0_0EXSplashScreenForceShow
        splashScreenController:[self.splashScreenControllers objectForKey:viewController]
               successCallback:^{}
               failureCallback:^(NSString *message){}];
@@ -138,7 +147,7 @@ ABI44_0_0EX_REGISTER_SINGLETON_MODULE(SplashScreen);
 {
   UIViewController *rootViewController = [[application keyWindow] rootViewController];
   if (rootViewController) {
-    [self showSplashScreenFor:rootViewController];
+    [self showSplashScreenFor:rootViewController options:ABI44_0_0EXSplashScreenDefault];
   }
 
   [self addRootViewControllerListener];
@@ -180,7 +189,7 @@ ABI44_0_0EX_REGISTER_SINGLETON_MODULE(SplashScreen);
     UIViewController *newRootViewController = change[@"new"];
     if (newRootViewController != nil) {
       [self removeRootViewControllerListener];
-      [self showSplashScreenFor:newRootViewController];
+      [self showSplashScreenFor:newRootViewController options:ABI44_0_0EXSplashScreenDefault];
       [self addRootViewControllerListener];
     }
   }
@@ -190,9 +199,9 @@ ABI44_0_0EX_REGISTER_SINGLETON_MODULE(SplashScreen);
       UIViewController *viewController = (UIViewController *)newView.nextResponder;
       // To show splash screen as soon as possible, we do not wait for hiding callback and call showSplashScreen immediately.
       // GCD main queue should keep the calls in sequence.
-      [self hideSplashScreenFor:viewController successCallback:^(BOOL hasEffect){} failureCallback:^(NSString *message){}];
+      [self hideSplashScreenFor:viewController options:ABI44_0_0EXSplashScreenDefault successCallback:^(BOOL hasEffect){} failureCallback:^(NSString *message){}];
       [self.splashScreenControllers removeObjectForKey:viewController];
-      [self showSplashScreenFor:viewController];
+      [self showSplashScreenFor:viewController options:ABI44_0_0EXSplashScreenDefault];
     }
   }
 }

--- a/ios/versioned/sdk45/EXSplashScreen/EXSplashScreen/ABI45_0_0EXSplashScreenModule.m
+++ b/ios/versioned/sdk45/EXSplashScreen/EXSplashScreen/ABI45_0_0EXSplashScreenModule.m
@@ -39,6 +39,7 @@ ABI45_0_0EX_EXPORT_METHOD_AS(hideAsync,
     ABI45_0_0EX_ENSURE_STRONGIFY(self);
     UIViewController *currentViewController = [self reactViewController];
     [[self splashScreenService] hideSplashScreenFor:currentViewController
+                                            options:ABI45_0_0EXSplashScreenDefault
                                     successCallback:^(BOOL hasEffect){ resolve(@(hasEffect)); }
                                     failureCallback:^(NSString *message){ reject(@"ERR_SPLASH_SCREEN_CANNOT_HIDE", message, nil); }];
   });
@@ -53,6 +54,7 @@ ABI45_0_0EX_EXPORT_METHOD_AS(preventAutoHideAsync,
     ABI45_0_0EX_ENSURE_STRONGIFY(self);
     UIViewController *currentViewController = [self reactViewController];
     [[self splashScreenService] preventSplashScreenAutoHideFor:currentViewController
+                                                       options:ABI45_0_0EXSplashScreenDefault
                                                successCallback:^(BOOL hasEffect){ resolve(@(hasEffect)); }
                                                failureCallback:^(NSString *message){ reject(@"ERR_SPLASH_SCREEN_CANNOT_PREVENT_AUTOHIDE", message, nil); }];
   });

--- a/ios/versioned/sdk45/EXSplashScreen/EXSplashScreen/ABI45_0_0EXSplashScreenService.h
+++ b/ios/versioned/sdk45/EXSplashScreen/EXSplashScreen/ABI45_0_0EXSplashScreenService.h
@@ -8,6 +8,14 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef NS_OPTIONS(NSUInteger, ABI45_0_0EXSplashScreenOptions) {
+   ABI45_0_0EXSplashScreenDefault = 0,
+
+   // Show splash screen even it was already shown before.
+   // e.g. show splash screen again when reloading apps,
+   ABI45_0_0EXSplashScreenForceShow = 1 << 0,
+ };
+
 /**
 * Entry point for handling SplashScreen associated mechanism.
 * This class has state based on the following relation { ViewController -> ApplicationSplashScreenState }.
@@ -18,13 +26,15 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Overloaded method. See main method below.
  */
-- (void)showSplashScreenFor:(UIViewController *)viewController;
+- (void)showSplashScreenFor:(UIViewController *)viewController
+                    options:(ABI45_0_0EXSplashScreenOptions)options;
 
 /**
  * Entry point for SplashScreen unimodule.
  * Registers SplashScreen for given viewController and presents it in that viewController.
  */
 - (void)showSplashScreenFor:(UIViewController *)viewController
+                    options:(ABI45_0_0EXSplashScreenOptions)options
    splashScreenViewProvider:(id<ABI45_0_0EXSplashScreenViewProvider>)splashScreenViewProvider
             successCallback:(void (^)(void))successCallback
             failureCallback:(void (^)(NSString *message))failureCallback;
@@ -34,6 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Registers SplashScreen for given viewController and ABI45_0_0EXSplashController and presents it in that viewController.
  */
 -(void)showSplashScreenFor:(UIViewController *)viewController
+                   options:(ABI45_0_0EXSplashScreenOptions)options
     splashScreenController:(ABI45_0_0EXSplashScreenViewController *)splashScreenController
            successCallback:(void (^)(void))successCallback
            failureCallback:(void (^)(NSString *message))failureCallback;
@@ -42,6 +53,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Hides SplashScreen for given viewController.
  */
 - (void)hideSplashScreenFor:(UIViewController *)viewController
+                    options:(ABI45_0_0EXSplashScreenOptions)options
             successCallback:(void (^)(BOOL hasEffect))successCallback
             failureCallback:(void (^)(NSString *message))failureCallback;
 
@@ -49,6 +61,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Prevents SplashScreen from default autohiding.
  */
 - (void)preventSplashScreenAutoHideFor:(UIViewController *)viewController
+                               options:(ABI45_0_0EXSplashScreenOptions)options
                        successCallback:(void (^)(BOOL hasEffect))successCallback
                        failureCallback:(void (^)(NSString *message))failureCallback;
 

--- a/ios/versioned/sdk45/EXSplashScreen/EXSplashScreen/ABI45_0_0EXSplashScreenService.m
+++ b/ios/versioned/sdk45/EXSplashScreen/EXSplashScreen/ABI45_0_0EXSplashScreenService.m
@@ -36,9 +36,11 @@ ABI45_0_0EX_REGISTER_SINGLETON_MODULE(SplashScreen);
 }
 
 - (void)showSplashScreenFor:(UIViewController *)viewController
+                    options:(ABI45_0_0EXSplashScreenOptions)options
 {
   id<ABI45_0_0EXSplashScreenViewProvider> splashScreenViewProvider = [ABI45_0_0EXSplashScreenViewNativeProvider new];
   return [self showSplashScreenFor:viewController
+                           options:options
           splashScreenViewProvider:splashScreenViewProvider
                    successCallback:^{}
                    failureCallback:^(NSString *message){ ABI45_0_0EXLogWarn(@"%@", message); }];
@@ -46,6 +48,7 @@ ABI45_0_0EX_REGISTER_SINGLETON_MODULE(SplashScreen);
 
 
 - (void)showSplashScreenFor:(UIViewController *)viewController
+                    options:(ABI45_0_0EXSplashScreenOptions)options
    splashScreenViewProvider:(id<ABI45_0_0EXSplashScreenViewProvider>)splashScreenViewProvider
             successCallback:(void (^)(void))successCallback
             failureCallback:(void (^)(NSString * _Nonnull))failureCallback
@@ -61,12 +64,14 @@ ABI45_0_0EX_REGISTER_SINGLETON_MODULE(SplashScreen);
                                                                                                splashScreenView:splashScreenView];
   
   [self showSplashScreenFor:viewController
+                    options:options
      splashScreenController:splashScreenController
             successCallback:successCallback
             failureCallback:failureCallback];
 }
 
 - (void)showSplashScreenFor:(UIViewController *)viewController
+                    options:(ABI45_0_0EXSplashScreenOptions)options
      splashScreenController:(ABI45_0_0EXSplashScreenViewController *)splashScreenController
             successCallback:(void (^)(void))successCallback
             failureCallback:(void (^)(NSString * _Nonnull))failureCallback
@@ -81,6 +86,7 @@ ABI45_0_0EX_REGISTER_SINGLETON_MODULE(SplashScreen);
 }
 
 - (void)preventSplashScreenAutoHideFor:(UIViewController *)viewController
+                               options:(ABI45_0_0EXSplashScreenOptions)options
                        successCallback:(void (^)(BOOL hasEffect))successCallback
                        failureCallback:(void (^)(NSString * _Nonnull))failureCallback
 {
@@ -93,6 +99,7 @@ ABI45_0_0EX_REGISTER_SINGLETON_MODULE(SplashScreen);
 }
 
 - (void)hideSplashScreenFor:(UIViewController *)viewController
+                    options:(ABI45_0_0EXSplashScreenOptions)options
             successCallback:(void (^)(BOOL hasEffect))successCallback
             failureCallback:(void (^)(NSString * _Nonnull))failureCallback
 {
@@ -113,6 +120,7 @@ ABI45_0_0EX_REGISTER_SINGLETON_MODULE(SplashScreen);
   BOOL needsHide = [[self.splashScreenControllers objectForKey:viewController] needsHideOnAppContentDidAppear];
   if (needsHide) {
     [self hideSplashScreenFor:viewController
+                      options:ABI45_0_0EXSplashScreenDefault
               successCallback:^(BOOL hasEffect){}
               failureCallback:^(NSString *message){}];
   }
@@ -126,6 +134,7 @@ ABI45_0_0EX_REGISTER_SINGLETON_MODULE(SplashScreen);
   BOOL needsShow = [[self.splashScreenControllers objectForKey:viewController] needsShowOnAppContentWillReload];
   if (needsShow) {
     [self showSplashScreenFor:viewController
+                      options:ABI45_0_0EXSplashScreenForceShow
        splashScreenController:[self.splashScreenControllers objectForKey:viewController]
               successCallback:^{}
               failureCallback:^(NSString *message){}];
@@ -138,7 +147,7 @@ ABI45_0_0EX_REGISTER_SINGLETON_MODULE(SplashScreen);
 {
   UIViewController *rootViewController = [[application keyWindow] rootViewController];
   if (rootViewController) {
-    [self showSplashScreenFor:rootViewController];
+    [self showSplashScreenFor:rootViewController options:ABI45_0_0EXSplashScreenDefault];
   }
 
   [self addRootViewControllerListener];
@@ -180,7 +189,7 @@ ABI45_0_0EX_REGISTER_SINGLETON_MODULE(SplashScreen);
     UIViewController *newRootViewController = change[@"new"];
     if (newRootViewController != nil) {
       [self removeRootViewControllerListener];
-      [self showSplashScreenFor:newRootViewController];
+      [self showSplashScreenFor:newRootViewController options:ABI45_0_0EXSplashScreenDefault];
       [self addRootViewControllerListener];
     }
   }
@@ -190,9 +199,9 @@ ABI45_0_0EX_REGISTER_SINGLETON_MODULE(SplashScreen);
       UIViewController *viewController = (UIViewController *)newView.nextResponder;
       // To show splash screen as soon as possible, we do not wait for hiding callback and call showSplashScreen immediately.
       // GCD main queue should keep the calls in sequence.
-      [self hideSplashScreenFor:viewController successCallback:^(BOOL hasEffect){} failureCallback:^(NSString *message){}];
+      [self hideSplashScreenFor:viewController options:ABI45_0_0EXSplashScreenDefault successCallback:^(BOOL hasEffect){} failureCallback:^(NSString *message){}];
       [self.splashScreenControllers removeObjectForKey:viewController];
-      [self showSplashScreenFor:viewController];
+      [self showSplashScreenFor:viewController options:ABI45_0_0EXSplashScreenDefault];
     }
   }
 }


### PR DESCRIPTION
# Why

We need to backport changes from #18229 to SDK 44 and 45. Right now opening a project for these SDKs fails due to unrecognized selector being sent to the singleton module.

# How

Added the options param to SDK 44 and 45

# Test Plan

Opening NCL for SDK 45 works as expected
