### PR TITLE
[docs] Home: add more animations, link icons, other small design tweaks

### DIFF
--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -1,9 +1,12 @@
 import { css } from '@emotion/react';
 import {
+  iconSize,
   spacing,
   theme,
   typography,
   useTheme,
+  ArrowUpRightIcon,
+  ArrowRightIcon,
   DiscordIcon,
   DiscourseIcon,
   GithubIcon,
@@ -28,7 +31,6 @@ import {
   SnackImage,
   WhyImage,
 } from '~/ui/components/Home/resources';
-import { Spacer } from '~/ui/components/Separator';
 import { Terminal } from '~/ui/components/Snippet';
 import { H1, H2, H3, P } from '~/ui/components/Text';
 
@@ -42,7 +44,7 @@ export const CellContainer = ({ children, style }: PropsWithChildren<{ style?: o
 );
 
 const Description = ({ children }: PropsWithChildren<object>) => (
-  <P style={{ marginTop: spacing[1], marginBottom: spacing[2], color: theme.text.secondary }}>
+  <P style={{ marginTop: spacing[1], marginBottom: spacing[3], color: theme.text.secondary }}>
     {children}
   </P>
 );
@@ -59,7 +61,6 @@ const Home = () => {
       <Description>
         Build one JavaScript/TypeScript project that runs natively on all your users' devices.
       </Description>
-      <Spacer />
       <CellContainer>
         <Row>
           <GridCell
@@ -87,7 +88,7 @@ const Home = () => {
               </H2>
               <br />
               <Terminal
-                hideOverflow
+                includeMargin={false}
                 cmd={['$ npm i -g expo-cli', '$ npx create-expo-app my-app']}
                 cmdCopy="npm install --global expo-cli && npx create-expo-app my-app"
               />
@@ -121,7 +122,8 @@ const Home = () => {
                 color: button.primary.foreground,
                 height: 40,
               }}
-              href="/tutorial/planning/">
+              href="/tutorial/planning/"
+              iconRight={<ArrowRightIcon color={button.primary.foreground} />}>
               Start Tutorial
             </HomeButton>
           </GridCell>
@@ -147,7 +149,8 @@ const Home = () => {
             <HomeButton
               style={{ backgroundColor: palette.blue['500'], color: palette.blue['100'] }}
               href="https://snack.expo.dev/"
-              target="_blank">
+              target="_blank"
+              iconRight={<ArrowUpRightIcon color={palette.blue['100']} />}>
               Create a Snack
             </HomeButton>
           </GridCell>
@@ -167,7 +170,8 @@ const Home = () => {
             <HomeButton
               style={{ backgroundColor: palette.orange['800'], color: palette.orange['100'] }}
               href="https://www.codecademy.com/learn/learn-react-native"
-              target="_blank">
+              target="_blank"
+              iconRight={<ArrowUpRightIcon color={palette.orange['100']} />}>
               Start Course
             </HomeButton>
           </GridCell>
@@ -186,7 +190,8 @@ const Home = () => {
             </P>
             <HomeButton
               style={{ backgroundColor: palette.green['700'], color: palette.green['000'] }}
-              href="/introduction/faq">
+              href="/introduction/faq"
+              iconRight={<ArrowRightIcon color={palette.green['000']} />}>
               Read
             </HomeButton>
           </GridCell>
@@ -206,7 +211,8 @@ const Home = () => {
             <HomeButton
               style={{ backgroundColor: palette.yellow['900'], color: palette.yellow['000'] }}
               href="https://us02web.zoom.us/meeting/register/tZcvceivqj0oHdGVOjEeKY0dRxCRPb0HzaAK"
-              target="_blank">
+              target="_blank"
+              iconRight={<ArrowUpRightIcon color={palette.yellow['000']} />}>
               Register
             </HomeButton>
           </GridCell>
@@ -248,13 +254,13 @@ const Home = () => {
             title="GitHub"
             description="View our SDK, submit a PR, or report an issue."
             link="https://github.com/expo/expo"
-            icon={<GithubIcon color={palette.white} />}
+            icon={<GithubIcon color={palette.white} size={iconSize.large} />}
           />
           <CommunityGridCell
             title="Discord"
             description="Join our Discord and chat with other Expo users."
             link="https://chat.expo.dev"
-            icon={<DiscordIcon color={palette.white} />}
+            icon={<DiscordIcon color={palette.white} size={iconSize.large} />}
             iconBackground="#3131E8"
           />
         </Row>
@@ -263,14 +269,14 @@ const Home = () => {
             title="Twitter"
             description="Follow Expo on Twitter for news and updates."
             link="https://twitter.com/expo"
-            icon={<TwitterIcon color={palette.white} />}
+            icon={<TwitterIcon color={palette.white} size={iconSize.large} />}
             iconBackground="#1E8EF0"
           />
           <CommunityGridCell
             title="Forums"
             description="Ask or answer a question on the forums."
             link="https://forums.expo.dev/"
-            icon={<DiscourseIcon color={palette.white} />}
+            icon={<DiscourseIcon color={palette.white} size={iconSize.large} />}
           />
         </Row>
         <Row>
@@ -278,7 +284,7 @@ const Home = () => {
             title="Reddit"
             description="Get the latest on /r/expo."
             link="https://www.reddit.com/r/expo"
-            icon={<RedditIcon color={palette.white} />}
+            icon={<RedditIcon color={palette.white} size={iconSize.large} />}
             iconBackground="#FC471E"
           />
         </Row>

--- a/docs/ui/components/Home/Cells.tsx
+++ b/docs/ui/components/Home/Cells.tsx
@@ -78,7 +78,7 @@ export const CommunityGridCell = ({
   md = 6,
 }: CommunityGridCellProps) => (
   <Col css={cellWrapperStyle} md={md}>
-    <a href={link} css={[cellStyle, cellCommunityStyle, cellHoverStyle]} style={style}>
+    <a href={link} css={[cellStyle, cellCommunityStyle, cellCommunityHoverStyle]} style={style}>
       <div css={[cellCommunityIconWrapperStyle, css({ backgroundColor: iconBackground })]}>
         {icon}
       </div>
@@ -98,10 +98,10 @@ const cellWrapperStyle = css`
 
 const cellHoverStyle = css`
   & {
-    transition: box-shadow 300ms;
+    transition: box-shadow 0.4s;
 
     svg {
-      transition: transform 300ms;
+      transition: transform 0.4s;
     }
   }
 
@@ -110,6 +110,10 @@ const cellHoverStyle = css`
 
     svg {
       transform: scale(1.1);
+    }
+
+    svg[role='img'] {
+      transform: translateX(2px);
     }
   }
 `;
@@ -196,3 +200,27 @@ const cellCommunityLinkIconStyle = css({
   alignSelf: 'center',
   minWidth: iconSize.regular,
 });
+
+const cellCommunityHoverStyle = css`
+  & {
+    transition: box-shadow 0.4s;
+
+    svg {
+      transition: transform 0.4s;
+    }
+  }
+
+  &:hover {
+    box-shadow: ${shadows.tiny};
+
+    svg {
+      transform: scale(1.1);
+    }
+
+    svg[class='css-${cellCommunityLinkIconStyle.name}'] {
+      transform: translateX(2px);
+    }
+  }
+`;
+
+console.warn(cellCommunityLinkIconStyle.name)

--- a/docs/ui/components/Home/Cells.tsx
+++ b/docs/ui/components/Home/Cells.tsx
@@ -222,5 +222,3 @@ const cellCommunityHoverStyle = css`
     }
   }
 `;
-
-console.warn(cellCommunityLinkIconStyle.name)

--- a/docs/ui/components/Home/Cells.tsx
+++ b/docs/ui/components/Home/Cells.tsx
@@ -1,5 +1,13 @@
 import { css } from '@emotion/react';
-import { borderRadius, palette, shadows, spacing, theme, typography } from '@expo/styleguide';
+import {
+  ArrowRightIcon,
+  borderRadius,
+  palette,
+  shadows,
+  spacing,
+  theme,
+  typography,
+} from '@expo/styleguide';
 import React, { PropsWithChildren } from 'react';
 import { Col, ColProps } from 'react-grid-system';
 
@@ -47,7 +55,7 @@ export const APIGridCell = ({
       <div css={cellIconWrapperStyle}>{icon}</div>
       <div css={cellTitleWrapperStyle}>
         {title}
-        <span css={cellTitleArrow}>{'->'}</span>
+        <ArrowRightIcon color={theme.icon.secondary} />
       </div>
     </a>
   </Col>
@@ -87,11 +95,19 @@ const cellWrapperStyle = css`
 
 const cellHoverStyle = css`
   & {
-    transition: box-shadow 200ms;
+    transition: box-shadow 300ms;
+
+    svg {
+      transition: transform 300ms;
+    }
   }
 
   &:hover {
     box-shadow: ${shadows.tiny};
+
+    svg {
+      transform: scale(1.1);
+    }
   }
 `;
 
@@ -132,13 +148,7 @@ const cellTitleWrapperStyle = css({
   fontFamily: typography.fontStacks.medium,
   lineHeight: '30px',
   color: theme.text.default,
-});
-
-const cellTitleArrow = css({
-  ...typography.fontSizes[18],
-  float: 'right',
-  color: theme.icon.secondary,
-  letterSpacing: 0,
+  alignItems: 'center',
 });
 
 const cellCommunityStyle = css({
@@ -151,9 +161,9 @@ const cellCommunityStyle = css({
 });
 
 const cellCommunityIconWrapperStyle = css({
-  height: 32,
-  width: 32,
-  minWidth: 32,
+  height: 48,
+  width: 48,
+  minWidth: 48,
   display: 'flex',
   justifyContent: 'center',
   alignItems: 'center',

--- a/docs/ui/components/Home/Cells.tsx
+++ b/docs/ui/components/Home/Cells.tsx
@@ -1,7 +1,9 @@
 import { css } from '@emotion/react';
 import {
   ArrowRightIcon,
+  ArrowUpRightIcon,
   borderRadius,
+  iconSize,
   palette,
   shadows,
   spacing,
@@ -80,10 +82,11 @@ export const CommunityGridCell = ({
       <div css={[cellCommunityIconWrapperStyle, css({ backgroundColor: iconBackground })]}>
         {icon}
       </div>
-      <div>
+      <div css={cellCommunityContentStyle}>
         <span css={cellCommunityTitleStyle}>{title}</span>
         <P css={cellCommunityDescriptionStyle}>{description}</P>
       </div>
+      <ArrowUpRightIcon color={theme.icon.secondary} css={cellCommunityLinkIconStyle} />
     </a>
   </Col>
 );
@@ -171,6 +174,10 @@ const cellCommunityIconWrapperStyle = css({
   marginRight: spacing[3],
 });
 
+const cellCommunityContentStyle = css({
+  flexGrow: 1,
+});
+
 const cellCommunityTitleStyle = css({
   ...typography.fontSizes[16],
   fontFamily: typography.fontStacks.medium,
@@ -182,4 +189,10 @@ const cellCommunityTitleStyle = css({
 const cellCommunityDescriptionStyle = css({
   ...typography.fontSizes[14],
   color: theme.text.secondary,
+});
+
+const cellCommunityLinkIconStyle = css({
+  marginLeft: spacing[1.5],
+  alignSelf: 'center',
+  minWidth: iconSize.regular,
 });

--- a/docs/ui/components/Home/Cells.tsx
+++ b/docs/ui/components/Home/Cells.tsx
@@ -98,10 +98,10 @@ const cellWrapperStyle = css`
 
 const cellHoverStyle = css`
   & {
-    transition: box-shadow 0.4s;
+    transition: box-shadow 200ms;
 
     svg {
-      transition: transform 0.4s;
+      transition: transform 200ms;
     }
   }
 
@@ -109,11 +109,11 @@ const cellHoverStyle = css`
     box-shadow: ${shadows.tiny};
 
     svg {
-      transform: scale(1.1);
+      transform: scale(1.05);
     }
 
     svg[role='img'] {
-      transform: translateX(2px);
+      transform: none;
     }
   }
 `;
@@ -203,10 +203,10 @@ const cellCommunityLinkIconStyle = css({
 
 const cellCommunityHoverStyle = css`
   & {
-    transition: box-shadow 0.4s;
+    transition: box-shadow 200ms;
 
     svg {
-      transition: transform 0.4s;
+      transition: transform 200ms;
     }
   }
 
@@ -214,11 +214,7 @@ const cellCommunityHoverStyle = css`
     box-shadow: ${shadows.tiny};
 
     svg {
-      transform: scale(1.1);
-    }
-
-    svg[class='css-${cellCommunityLinkIconStyle.name}'] {
-      transform: translateX(2px);
+      transform: scale(1.075);
     }
   }
 `;

--- a/docs/ui/components/Home/HomeButton.tsx
+++ b/docs/ui/components/Home/HomeButton.tsx
@@ -1,4 +1,3 @@
-import { css } from '@emotion/react';
 import { spacing, typography } from '@expo/styleguide';
 import React from 'react';
 

--- a/docs/ui/components/Home/HomeButton.tsx
+++ b/docs/ui/components/Home/HomeButton.tsx
@@ -27,13 +27,13 @@ export const HomeButton = ({ children, style, href, ...rest }: ButtonProps) => (
 const iconAnimation = css(`
   & {
     svg {
-      transition: transform 300ms;
+      transition: transform 0.4s;
     }
   }
 
   &:hover {
-    svg {
-      transform: scale(1.1);
+    svg[role=img] {
+      transform: translateX(2px);
     }
   }
 `);

--- a/docs/ui/components/Home/HomeButton.tsx
+++ b/docs/ui/components/Home/HomeButton.tsx
@@ -1,3 +1,4 @@
+import { css } from '@emotion/react';
 import { spacing, typography } from '@expo/styleguide';
 import React from 'react';
 
@@ -11,13 +12,28 @@ export const HomeButton = ({ children, style, href, ...rest }: ButtonProps) => (
     style={{
       ...typography.fontSizes[14],
       height: 36,
-      paddingLeft: spacing[3],
-      paddingRight: spacing[3],
+      paddingLeft: spacing[3.5],
+      paddingRight: spacing[3.5],
       position: 'absolute',
       bottom: 28,
       zIndex: 10,
       ...style,
-    }}>
+    }}
+    css={iconAnimation}>
     {children}
   </Button>
 );
+
+const iconAnimation = css(`
+  & {
+    svg {
+      transition: transform 300ms;
+    }
+  }
+
+  &:hover {
+    svg {
+      transform: scale(1.1);
+    }
+  }
+`);

--- a/docs/ui/components/Home/HomeButton.tsx
+++ b/docs/ui/components/Home/HomeButton.tsx
@@ -18,22 +18,7 @@ export const HomeButton = ({ children, style, href, ...rest }: ButtonProps) => (
       bottom: 28,
       zIndex: 10,
       ...style,
-    }}
-    css={iconAnimation}>
+    }}>
     {children}
   </Button>
 );
-
-const iconAnimation = css(`
-  & {
-    svg {
-      transition: transform 0.4s;
-    }
-  }
-
-  &:hover {
-    svg[role=img] {
-      transform: translateX(2px);
-    }
-  }
-`);

--- a/docs/ui/components/Snippet/Snippet.tsx
+++ b/docs/ui/components/Snippet/Snippet.tsx
@@ -4,14 +4,20 @@ import React, { PropsWithChildren } from 'react';
 
 type SnippetProps = {
   style?: SerializedStyles;
+  includeMargin?: boolean;
 };
 
-export const Snippet = ({ children, style }: PropsWithChildren<SnippetProps>) => (
-  <div css={[containerStyle, css(style)]}>{children}</div>
+export const Snippet = ({
+  children,
+  style,
+  includeMargin = true,
+}: PropsWithChildren<SnippetProps>) => (
+  <div css={[containerStyle, includeMargin && containerMarginStyle, css(style)]}>{children}</div>
 );
 
-const containerStyle = css`
-  display: flex;
-  flex-direction: column;
-  margin-bottom: ${spacing[4]}px;
-`;
+const containerStyle = css({
+  display: 'flex',
+  flexDirection: 'column',
+});
+
+const containerMarginStyle = css({ marginBottom: spacing[4] });

--- a/docs/ui/components/Snippet/blocks/Terminal.tsx
+++ b/docs/ui/components/Snippet/blocks/Terminal.tsx
@@ -13,11 +13,18 @@ type TerminalProps = {
   cmd: string[];
   cmdCopy?: string;
   hideOverflow?: boolean;
+  includeMargin?: boolean;
   title?: string;
 };
 
-export const Terminal = ({ cmd, cmdCopy, hideOverflow, title = 'Terminal' }: TerminalProps) => (
-  <Snippet style={wrapperStyle}>
+export const Terminal = ({
+  cmd,
+  cmdCopy,
+  hideOverflow,
+  includeMargin = true,
+  title = 'Terminal',
+}: TerminalProps) => (
+  <Snippet style={wrapperStyle} includeMargin={includeMargin}>
     <SnippetHeader alwaysDark title={title}>
       {renderCopyButton({ cmd, cmdCopy })}
     </SnippetHeader>


### PR DESCRIPTION
# Why

This PR focuses on the improvements for the docs home page, which I have discussed with Jon after the initial page redesign has landed.

# How

The following changes have been made:
* add small interaction animations
* add icons to the tile `Button`s
* replace text arrow with icon in `APICell`s
* resize the `CommunityCell`s icons
* remove additional margin added to the `Snippet` tile

# Test Plan

The changes have been tested by running docs website locally.

# Preview

![screencapture-localhost-3002-2022-07-15-16_09_17](https://user-images.githubusercontent.com/719641/179246964-a973009b-6170-4013-89dc-0926bcdc140a.png)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
