### PR TITLE
[expo-modules-core] Logger changes

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### 💡 Others
 
+- Logger changes. ([#18271](https://github.com/expo/expo/pull/18271) by [@douglowder](https://github.com/douglowder))
+
+### ⚠️ Notices
+
 ## 0.11.2 — 2022-07-16
 
 ### 🐛 Bug fixes

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Logger changes. ([#18271](https://github.com/expo/expo/pull/18271) by [@douglowder](https://github.com/douglowder))
+- Changed access levels in the Logger and fixed the timer to log milliseconds instead of seconds. ([#18271](https://github.com/expo/expo/pull/18271) by [@douglowder](https://github.com/douglowder))
 
 ### ⚠️ Notices
 

--- a/packages/expo-modules-core/ios/Swift/Logging/LogType.swift
+++ b/packages/expo-modules-core/ios/Swift/Logging/LogType.swift
@@ -45,7 +45,7 @@ public enum LogType: Int {
    Maps the log types to the log types used by the `os.log` logger.
    */
   @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
-  func toOSLogType() -> OSLogType {
+  public func toOSLogType() -> OSLogType {
     switch self {
     case .trace, .timer, .stacktrace, .debug:
       return .debug

--- a/packages/expo-modules-core/ios/Swift/Logging/Logger.swift
+++ b/packages/expo-modules-core/ios/Swift/Logging/Logger.swift
@@ -139,7 +139,7 @@ public class Logger {
     }
     let endTime = DispatchTime.now()
     let diff = Double(endTime.uptimeNanoseconds - startTime.uptimeNanoseconds) / 1_000_000
-    log(type: .timer, "Timer '\(id)' has finished in: \(diff) seconds")
+    log(type: .timer, "Timer '\(id)' has finished in: \(diff) ms")
     timers.removeValue(forKey: id)
   }
 
@@ -183,11 +183,11 @@ public class Logger {
   }
 }
 
-fileprivate func reformatStackSymbol(_ symbol: String) -> String {
+private func reformatStackSymbol(_ symbol: String) -> String {
   return symbol.replacingOccurrences(of: #"^\d+\s+"#, with: "", options: .regularExpression)
 }
 
-fileprivate func describe(value: Any) -> String {
+private func describe(value: Any) -> String {
   if let value = value as? String {
     return value
   }


### PR DESCRIPTION
# Why

Small changes to `Logger` and `LogType` to support a new error logging feature to be added to expo-updates.

# How

- `LogType`: make `toOSLogType()` public
- `Logger`: correct the timer units
- `Logger`: SwiftLint fixes

# Test Plan

Existing tests should still pass with these changes.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
