### PR TITLE
[expo-in-app-purchases][android] Fix null error in `purchaseItemAsync` when details argument is not passed

### DIFF
--- a/packages/expo-in-app-purchases/CHANGELOG.md
+++ b/packages/expo-in-app-purchases/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix null error in purchaseItemAsync when details argument is not passed [#18272](https://github.com/expo/expo/pull/18272)
+
 ### 💡 Others
 
 ## 13.1.0 — 2022-07-07

--- a/packages/expo-in-app-purchases/android/src/main/java/expo/modules/inapppurchases/BillingManager.java
+++ b/packages/expo-in-app-purchases/android/src/main/java/expo/modules/inapppurchases/BillingManager.java
@@ -36,6 +36,7 @@ import java.util.Set;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import expo.modules.core.Promise;
+import expo.modules.core.arguments.MapArguments;
 import expo.modules.core.arguments.ReadableArguments;
 import expo.modules.core.interfaces.services.EventEmitter;
 
@@ -137,11 +138,10 @@ public class BillingManager implements PurchasesUpdatedListener {
    * Start a purchase or subscription replace flow
    */
   public void purchaseItemAsync(final String skuId, @Nullable final ReadableArguments details, final Promise promise) {
-    String oldPurchaseToken = details.getString("oldPurchaseToken");
-    ReadableArguments accountIdentifiers = details.getArguments("accountIdentifiers");
-    String obfuscatedAccountId = accountIdentifiers.getString("obfuscatedAccountId");
-    String obfuscatedProfileId = accountIdentifiers.getString("obfuscatedProfileId");
-    Boolean isVrPurchaseFlow = details.getBoolean("isVrPurchaseFlow");
+    ReadableArguments d = details != null ? details : new MapArguments();
+    String oldPurchaseToken = d.getString("oldPurchaseToken");
+    ReadableArguments accountIdentifiers = d.getArguments("accountIdentifiers");
+    Boolean isVrPurchaseFlow = d.getBoolean("isVrPurchaseFlow");
 
     Runnable purchaseFlowRequest = new Runnable() {
       @Override
@@ -164,9 +164,13 @@ public class BillingManager implements PurchasesUpdatedListener {
          * For Android billing to work without a 'Something went wrong on our end. Please try again.'
          * error, we must provide BOTH obfuscatedAccountId and obfuscatedProfileId.
          */
-        if (obfuscatedAccountId != null && obfuscatedProfileId != null) {
-          purchaseParams.setObfuscatedAccountId(obfuscatedAccountId);
-          purchaseParams.setObfuscatedProfileId(obfuscatedProfileId);
+        if (accountIdentifiers != null) {
+          String obfuscatedAccountId = accountIdentifiers.getString("obfuscatedAccountId");
+          String obfuscatedProfileId = accountIdentifiers.getString("obfuscatedProfileId");
+          if (obfuscatedAccountId != null && obfuscatedProfileId != null) {
+            purchaseParams.setObfuscatedAccountId(obfuscatedAccountId);
+            purchaseParams.setObfuscatedProfileId(obfuscatedProfileId);
+          }
         }
 
         // false will be the default, unless true is passed


### PR DESCRIPTION
# Why

https://github.com/expo/expo/issues/17654

The `details` argument of [purchaseItemAsync](https://docs.expo.dev/versions/latest/sdk/in-app-purchases/#inapppurchasespurchaseitemasyncitemid-details) is not required, but if omitting it, the following error occurs.

"[Error: Encountered an exception while calling native method: Exception occurred while executing exported method purchaseItemAsync on module ExpoInAppPurchases: Attempt to invoke interface method 'java.lang.String expo.modules.core.arguments.ReadableArguments.getString(java.lang.String)' on a null object reference]"

This occurs at the following location.
https://github.com/expo/expo/blob/519ac3d86864da9dd920a9ff8d0c880f6ec81a58/packages/expo-in-app-purchases/android/src/main/java/expo/modules/inapppurchases/BillingManager.java#L139-L140

I have made `purchaseItemAsync` work without the `details` argument in this Pull Request.

Related: https://github.com/expo/expo/pull/16670

# How

I have added null checks in `purchaseItemAsync`.


# Test Plan

I created a sample app repo outside of this repo to test.
https://github.com/gaishimo/expo-iap-test

In that app, I call `purchaseItemAsync` to test the billing.
https://github.com/gaishimo/expo-iap-test/blob/68c043181a2a9ced7fe8615c6dbcdcc5502d1357/App.tsx#L74-L97


### Screenshots (Before)
| without "details" | with "details" |
|:-----------:|:------------:|
|<img width="200" src="https://user-images.githubusercontent.com/4277693/179379237-63bf8a85-2f74-44e8-a0f2-57b522b4843b.png" />|<img width="200" src="https://user-images.githubusercontent.com/4277693/179379247-ceaee212-e9ca-4626-9392-1b14d8d77062.png" />|


### Screenshots (After)

| without "details" | with "details" |
|:-----------:|:------------:|
|<img width="200" src="https://user-images.githubusercontent.com/4277693/179377764-a75328b5-568b-4f17-88e0-b1c70e0f5548.png" />|<img width="200" src="https://user-images.githubusercontent.com/4277693/179377741-b46a3c84-81d1-4485-8823-93c1cd59be22.png" />|


