### PR TITLE
[tools][ios] Remove version prefix from the view manager name

### DIFF
--- a/ios/versioned/sdk46/ExpoModulesCore/NativeModulesProxy/ABI46_0_0EXNativeModulesProxy.mm
+++ b/ios/versioned/sdk46/ExpoModulesCore/NativeModulesProxy/ABI46_0_0EXNativeModulesProxy.mm
@@ -390,7 +390,7 @@ ABI46_0_0RCT_EXPORT_METHOD(callMethod:(NSString *)moduleName methodNameOrKey:(id
 {
   // Hacky way to get a dictionary with `ABI46_0_0RCTComponentData` from UIManager.
   NSMutableDictionary<NSString *, ABI46_0_0RCTComponentData *> *componentDataByName = [bridge.uiManager valueForKey:@"_componentDataByName"];
-  NSString *className = NSStringFromClass(moduleClass);
+  NSString *className = [moduleClass moduleName] ?: NSStringFromClass(moduleClass);
 
   if ([moduleClass isSubclassOfClass:[ABI46_0_0RCTViewManager class]] && !componentDataByName[className]) {
     ABI46_0_0RCTComponentData *componentData = [[ABI46_0_0RCTComponentData alloc] initWithManagerClass:moduleClass bridge:bridge eventDispatcher:bridge.eventDispatcher];

--- a/ios/versioned/sdk46/ExpoModulesCore/ViewManagerAdapter/ABI46_0_0EXViewManagerAdapter.m
+++ b/ios/versioned/sdk46/ExpoModulesCore/ViewManagerAdapter/ABI46_0_0EXViewManagerAdapter.m
@@ -23,7 +23,8 @@
 
 + (NSString *)moduleName
 {
-  return NSStringFromClass(self);
+  NSString *className = NSStringFromClass(self);
+  return [className hasPrefix:@"ABI46_0_0"] ? [className substringFromIndex:9] : className;
 }
 
 - (UIView *)view

--- a/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.mm
+++ b/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.mm
@@ -390,7 +390,7 @@ RCT_EXPORT_METHOD(callMethod:(NSString *)moduleName methodNameOrKey:(id)methodNa
 {
   // Hacky way to get a dictionary with `RCTComponentData` from UIManager.
   NSMutableDictionary<NSString *, RCTComponentData *> *componentDataByName = [bridge.uiManager valueForKey:@"_componentDataByName"];
-  NSString *className = NSStringFromClass(moduleClass);
+  NSString *className = [moduleClass moduleName] ?: NSStringFromClass(moduleClass);
 
   if ([moduleClass isSubclassOfClass:[RCTViewManager class]] && !componentDataByName[className]) {
     RCTComponentData *componentData = [[RCTComponentData alloc] initWithManagerClass:moduleClass bridge:bridge eventDispatcher:bridge.eventDispatcher];

--- a/tools/src/versioning/ios/transforms/expoModulesTransforms.ts
+++ b/tools/src/versioning/ios/transforms/expoModulesTransforms.ts
@@ -131,6 +131,13 @@ export function expoModulesTransforms(prefix: string): FileTransforms {
         find: new RegExp(`\b(!?${prefix})(\w+-umbrella\.h)\b`, 'g'),
         replaceWith: `${prefix}$1`,
       },
+
+      {
+        // Dynamically remove the prefix from the "moduleName" method in the view manager adapter.
+        paths: 'EXViewManagerAdapter.{m,mm}',
+        find: /return (NSStringFromClass\(self\));/g,
+        replaceWith: `NSString *className = $1;\n  return [className hasPrefix:@"${prefix}"] ? [className substringFromIndex:${prefix.length}] : className;`,
+      },
     ],
   };
 }


### PR DESCRIPTION
# Why

Changes introduced in #17411 and registering the component data for the base view manager class caused an issue that comes out only in versioned code.
The base view manager (`EXViewManagerAdapter`) contains versioning prefix (`ABI46_0_0`) in its module name and the same name is used in component data registry, but then the view config of other view managers returns unprefixed [`baseModuleName`](https://github.com/expo/expo/blob/c6678c65b68e45062d49a2deea8e822f69388278/ios/versioned-react-native/ABI46_0_0/ReactNative/React/Views/ABI46_0_0RCTComponentData.m#L477) because of this line: https://github.com/expo/expo/blob/c6678c65b68e45062d49a2deea8e822f69388278/ios/versioned-react-native/ABI46_0_0/ReactNative/React/Views/ABI46_0_0RCTComponentData.m#L491 that we add in the versioning script. Since the `proxiedProperties` prop is configured in the base class and RN couldn't find its view config, the prop was just ignored which results in no updates in our native views.

# How

- Dynamically unprefix the `moduleName` in versioned code to make sure `EXViewManagerAdapter` is always registered with this exact name
- Backported this change to SDK46
- Fixed `registerLegacyComponentData` to make sure we use the `moduleName` instead of the class name when registering the component data

I don't want to make experiments just before the release, but I think the alternative solution would be to stop adding the aforementioned `EX_REMOVE_VERSION` macro during versioning.

# Test Plan

NCL for SDK46 works as expected and prop updates are properly propagated — I tested AppleAuthentication button and Camera examples.
