### PR TITLE
feat: add support for $EXPO_EDITOR

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Add `EXPO_EDITOR` environment variable for overriding the `EDITOR` variable. This is used in the `expo start` Terminal UI when pressing `o`.
+- Add `EXPO_EDITOR` environment variable for overriding the `EDITOR` variable. This is used in the `expo start` Terminal UI when pressing `o`. ([#18285](https://github.com/expo/expo/pull/18285) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add `EXPO_EDITOR` environment variable for overriding the `EDITOR` variable. This is used in the `expo start` Terminal UI when pressing `o`.
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/@expo/cli/src/utils/__tests__/editor-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/editor-test.ts
@@ -6,7 +6,24 @@ import { guessEditor, openInEditorAsync } from '../editor';
 
 jest.mock('../../log');
 
+const original_EXPO_EDITOR = process.env.EXPO_EDITOR;
+
+afterAll(() => {
+  process.env.EXPO_EDITOR = original_EXPO_EDITOR;
+});
+
 describe(guessEditor, () => {
+  beforeEach(() => {
+    delete process.env.EXPO_EDITOR;
+  });
+
+  it(`uses EXPO_EDITOR as the highest priority setting if defined`, () => {
+    process.env.EXPO_EDITOR = 'bacon';
+    guessEditor();
+
+    expect(editors.getEditor).toBeCalledWith('bacon');
+  });
+
   it(`defaults to vscode if the default editor cannot be guessed`, () => {
     asMock(editors.defaultEditor).mockImplementationOnce(() => {
       throw new Error('Could not guess default editor');

--- a/packages/@expo/cli/src/utils/editor.ts
+++ b/packages/@expo/cli/src/utils/editor.ts
@@ -2,14 +2,22 @@ import spawnAsync from '@expo/spawn-async';
 import editors from 'env-editor';
 
 import * as Log from '../log';
+import { env } from './env';
 
 const debug = require('debug')('expo:utils:editor') as typeof console.log;
 
 /** Guess what the default editor is and default to VSCode. */
 export function guessEditor(): editors.Editor {
   try {
+    const editor = env.EXPO_EDITOR;
+    if (editor) {
+      debug('Using $EXPO_EDITOR:', editor);
+      return editors.getEditor(editor);
+    }
+    debug('Falling back on $EDITOR:', editor);
     return editors.defaultEditor();
   } catch {
+    debug('Falling back on vscode');
     return editors.getEditor('vscode');
   }
 }

--- a/packages/@expo/cli/src/utils/env.ts
+++ b/packages/@expo/cli/src/utils/env.ts
@@ -83,6 +83,11 @@ class Env {
   get EXPO_PUBLIC_FOLDER(): string {
     return string('EXPO_PUBLIC_FOLDER', 'public');
   }
+
+  /** Higher priority `$EDIOTR` variable for indicating which editor to use when pressing `o` in the Terminal UI. */
+  get EXPO_EDITOR(): string {
+    return string('EXPO_EDITOR', '');
+  }
 }
 
 export const env = new Env();


### PR DESCRIPTION
# Why

Feature request from @brentvatne. 

# How

- Add `EXPO_EDITOR` environment variable for overriding the `EDITOR` variable. This is used in the `expo start` Terminal UI when pressing `o`.

# Test Plan

- Added unit tests