### PR TITLE
[expo] Rename EXPO_USE_BETA_CLI to EXPO_USE_LOCAL_CLI and default to true

### DIFF
--- a/packages/expo/bin/cli.js
+++ b/packages/expo/bin/cli.js
@@ -6,7 +6,7 @@ const { boolish } = require('getenv');
 run();
 
 function run() {
-  // Use new beta CLI by default.
+  // Use new local CLI by default.
   if (boolish('EXPO_USE_LOCAL_CLI', true)) {
     return spawn(require.resolve('@expo/cli'), process.argv.slice(2), { stdio: 'inherit' }).on(
       'exit',

--- a/packages/expo/bin/cli.js
+++ b/packages/expo/bin/cli.js
@@ -6,8 +6,8 @@ const { boolish } = require('getenv');
 run();
 
 function run() {
-  // Use new beta CLI.
-  if (boolish('EXPO_USE_BETA_CLI', false)) {
+  // Use new beta CLI by default.
+  if (boolish('EXPO_USE_LOCAL_CLI', true)) {
     return spawn(require.resolve('@expo/cli'), process.argv.slice(2), { stdio: 'inherit' }).on(
       'exit',
       (code) => {


### PR DESCRIPTION
# Why

This should be enabled by default on SDK 46+, and it shouldn't be named "beta" for those who want to opt out.