### PR TITLE
[android] Fix dbflow crash in release build

### DIFF
--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -203,8 +203,7 @@ android {
 
   buildTypes {
     release {
-      minifyEnabled false
-      proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+      consumerProguardFiles('proguard-rules.pro')
     }
   }
 


### PR DESCRIPTION
# Why

close ENG-5783

# How

dbflow should add a proguard rule to be away from proguard minification, we added this in [expoview](https://github.com/expo/expo/blob/dbb4ad66062cab7a12c5025a7383378862b2ba72/android/expoview/proguard-rules.pro#L147). for expoview as a library project to add proguard rules, the correct way is the `consumerProguardFiles`. the old way may be deprecated in new AGP.
 
# Test Plan

android expo go versioned release build + NCL

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
