### PR TITLE
[docs] Development Builds: use `kbd` element to represent keyboard shortcuts

### DIFF
--- a/docs/pages/development/getting-started.md
+++ b/docs/pages/development/getting-started.md
@@ -69,7 +69,7 @@ Instead, all you need to do to start developing is to run:
 
 and scanning the resulting QR code with your system camera or QR code reader (if you want to develop against a physical device)
 
-or pressing the "a" or "i" keys (to open the app in your Android or iPhone emulator or simulator respectively).
+or pressing the <kbd>a</kbd> or <kbd>i</kbd> keys (to open the app in your Android or iPhone emulator or simulator respectively).
 
 Now make some changes to your project code and see them reflected on your device!
 
@@ -181,4 +181,4 @@ const styles = StyleSheet.create({
 
 ## Debugging your app
 
-When you need to, you can access the menu by pressing Cmd-d in Expo CLI or by shaking your phone or tablet. Here you'll be able to access all of the functions of your development build, access any debugging functionality you need, or switch to a different version of your app.
+When you need to, you can access the menu by pressing <kbd>⌘</kbd>+<kbd>d</kbd>/<kbd>ctrl</kbd>+<kbd>d</kbd> in Expo CLI or by shaking your phone or tablet. Here you'll be able to access all of the functions of your development build, access any debugging functionality you need, or switch to a different version of your app.

--- a/docs/pages/development/getting-started.md
+++ b/docs/pages/development/getting-started.md
@@ -181,4 +181,4 @@ const styles = StyleSheet.create({
 
 ## Debugging your app
 
-When you need to, you can access the menu by pressing <kbd>⌘</kbd>+<kbd>d</kbd>/<kbd>ctrl</kbd>+<kbd>d</kbd> in Expo CLI or by shaking your phone or tablet. Here you'll be able to access all of the functions of your development build, access any debugging functionality you need, or switch to a different version of your app.
+When you need to, you can access the menu by pressing <kbd>⌘</kbd> + <kbd>D</kbd> or <kbd>Ctrl</kbd> + <kbd>D</kbd> in Expo CLI or by shaking your phone or tablet. Here you'll be able to access all of the functions of your development build, access any debugging functionality you need, or switch to a different version of your app.

--- a/docs/pages/development/getting-started.md
+++ b/docs/pages/development/getting-started.md
@@ -69,7 +69,7 @@ Instead, all you need to do to start developing is to run:
 
 and scanning the resulting QR code with your system camera or QR code reader (if you want to develop against a physical device)
 
-or pressing the <kbd>a</kbd> or <kbd>i</kbd> keys (to open the app in your Android or iPhone emulator or simulator respectively).
+or pressing the <kbd>A</kbd> or <kbd>I</kbd> keys (to open the app in your Android or iPhone emulator or simulator respectively).
 
 Now make some changes to your project code and see them reflected on your device!
 


### PR DESCRIPTION


# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Refs ENG-5555

# How

<!--
How did you build this feature or fix this bug and why?
-->

As per our new [style guide](https://www.notion.so/expo/Getting-Started-Tutorial-outline-76189e5977d34d9b976aa6f00757a023), we should use `<kbd>` elements in markdown files to represent keyboard shortcuts.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes tested by running docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
