### PR TITLE
[docs] add styling for the `kbd` element

### DIFF
--- a/docs/common/translate-markdown.tsx
+++ b/docs/common/translate-markdown.tsx
@@ -10,6 +10,7 @@ import { UL, OL, LI } from '~/components/base/list';
 import { PDIV, B, Quote } from '~/components/base/paragraph';
 import { BareWorkflowCollapsible, ExpoKitCollapsible } from '~/ui/components/Collapsible';
 import { Cell, HeaderCell, Row, Table, TableHead } from '~/ui/components/Table';
+import { KBD } from '~/ui/components/Text';
 
 type Options = {
   customIconStyle?: React.CSSProperties;
@@ -58,6 +59,7 @@ export const thead = TableHead;
 export const tr = Row;
 export const th = HeaderCell;
 export const td = Cell;
+export const kbd = KBD;
 export const expokitDetails = ExpoKitCollapsible;
 export const bareworkflowDetails = BareWorkflowCollapsible;
 export const propertyAnchor = createPermalinkedComponent(PDIV, {

--- a/docs/ui/components/Text/index.tsx
+++ b/docs/ui/components/Text/index.tsx
@@ -1,5 +1,5 @@
 import { css, SerializedStyles } from '@emotion/react';
-import { theme, typography } from '@expo/styleguide';
+import { theme, typography, spacing, borderRadius } from '@expo/styleguide';
 import React from 'react';
 
 import { LinkBase, LinkProps } from './Link';
@@ -72,6 +72,18 @@ export const DEMI = createTextComponent(TextElement.SPAN, css(typography.utility
 export const UL = createTextComponent(TextElement.UL, css([typography.body.ul, listStyle]));
 export const OL = createTextComponent(TextElement.OL, css([typography.body.ol, listStyle]));
 export const PRE = createTextComponent(TextElement.PRE, css(typography.utility.pre));
+
+const kbdStyle = css({
+  fontFamily: typography.fontFaces.medium,
+  color: theme.text.secondary,
+  padding: `${spacing[0.5]}px ${spacing[1.5]}px`,
+  boxShadow: `0 0.1rem 0 1px ${theme.border.default}`,
+  borderRadius: borderRadius.small,
+  position: 'relative',
+  top: -1,
+});
+
+export const KBD = createTextComponent(TextElement.KBD, css([typography.utility.pre, kbdStyle]));
 
 export const A = (props: Omit<LinkProps, 'router'> & { isStyled?: boolean }) => {
   const { isStyled, ...rest } = props;

--- a/docs/ui/components/Text/types.ts
+++ b/docs/ui/components/Text/types.ts
@@ -15,6 +15,7 @@ export enum TextElement {
   UL = 'ul',
   OL = 'ol',
   PRE = 'pre',
+  KBD = 'kbd',
 }
 
 export type TextWeight = keyof typeof typography.utility.weight;


### PR DESCRIPTION
# Why

Fixes ENG-5573

Refs #18293

# How

This PR adds the styling for the `kbd` element and hooks it up into out markdown renderer.

# Test Plan

The changes have been tested by running the docs website locally, however, I did not pushed any changes to the doc files.

# Preview

<img width="591" alt="Screenshot 2022-07-19 at 18 33 15" src="https://user-images.githubusercontent.com/719641/179803621-b2d92e2f-563b-407b-9c1e-ccc715b3a506.png">

<img width="591" alt="Screenshot 2022-07-19 at 18 33 24" src="https://user-images.githubusercontent.com/719641/179803615-d76f6646-036b-476e-89bf-abbf0bb5eef2.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
