### PR TITLE
[docs] Lottie: Fix typo when using APIInstallSection component

### DIFF
--- a/docs/pages/versions/unversioned/sdk/lottie.md
+++ b/docs/pages/versions/unversioned/sdk/lottie.md
@@ -14,7 +14,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 ## Installation
 
-<InstallSection packageName="lottie-react-native" href="https://github.com/lottie-react-native/lottie-react-native" />
+<APIInstallSection packageName="lottie-react-native" href="https://github.com/lottie-react-native/lottie-react-native" />
 
 ## Usage
 

--- a/docs/pages/versions/v45.0.0/sdk/lottie.md
+++ b/docs/pages/versions/v45.0.0/sdk/lottie.md
@@ -14,7 +14,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 ## Installation
 
-<InstallSection packageName="lottie-react-native" href="https://github.com/lottie-react-native/lottie-react-native" />
+<APIInstallSection packageName="lottie-react-native" href="https://github.com/lottie-react-native/lottie-react-native" />
 
 ## Usage
 

--- a/docs/pages/versions/v46.0.0/sdk/lottie.md
+++ b/docs/pages/versions/v46.0.0/sdk/lottie.md
@@ -14,7 +14,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 ## Installation
 
-<InstallSection packageName="lottie-react-native" href="https://github.com/lottie-react-native/lottie-react-native" />
+<APIInstallSection packageName="lottie-react-native" href="https://github.com/lottie-react-native/lottie-react-native" />
 
 ## Usage
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently, the latest SDK release docs for Lottie are not showing Installation instructions missing. See the screenshot:

![CleanShot 2022-07-19 at 22 13 00@2x](https://user-images.githubusercontent.com/10234615/179804550-00efa23b-30a6-4be2-a15c-e63a415fd565.jpg)

Thanks to @hirbod for his [tweet](https://twitter.com/nightstomp/status/1549393666250362883) and for letting us know.

# How
<!--
How did you build this feature or fix this bug and why?
-->

This PR adds a fix to add back the installation instructions to the `unversioned`, SDK 45 & 46 versions by using the `APIInstallSection` component (which was imported before but was never used).


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

Changes have been tested by runnings `docs/` locally.

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
