### PR TITLE
[docs] Account Types: remove that org account cannot be renamed

### DIFF
--- a/docs/pages/accounts/account-types.md
+++ b/docs/pages/accounts/account-types.md
@@ -21,21 +21,20 @@ Common situations where Organizations are useful:
 
 |                                                                     | Personal Accounts | Organization |
 | ------------------------------------------------------------------- | ----------------- | ------------ |
-| **Create Projects**                                                 | ✅                 | ✅            |
-| **Build projects to submit to App Store and Play Store**            | ✅                 | ✅            |
-| **Release bug fixes with updates**                                  | ✅                 | ✅            |
-| **Transfer control of individual projects to another user**         | ✅                 | ✅
-| **Transfer control of all projects to another user**                |                   | ✅            |
-| **Programmatic access with limited privileges**                     |                   | ✅            |
-| **Designate multiple users who have complete control of a project** |                   | ✅            |
+| **Create Projects**                                                 | ✅                | ✅           |
+| **Build projects to submit to App Store and Play Store**            | ✅                | ✅           |
+| **Release bug fixes with updates**                                  | ✅                | ✅           |
+| **Transfer control of individual projects to another user**         | ✅                | ✅           |
+| **Transfer control of all projects to another user**                |                   | ✅           |
+| **Programmatic access with limited privileges**                     |                   | ✅           |
+| **Designate multiple users who have complete control of a project** |                   | ✅           |
 
 ### Creating New Organizations
 
 To create a new Organization, visit [expo.dev/create-organization](https://expo.dev/create-organization) and sign in to your Personal Account.
 You can also create a new Organization by selecting "New Organization" from the account selection dropdown at the top of your dashboard.
 
-You'll need to choose a name for your Organization. Once you have created the organization, you will not be able to rename it.
-To associate projects with an Organization, you will need to add the [Owner key](/versions/latest/config/app/#owner) to your project's app.json
+You'll need to choose a name for your Organization. To associate projects with an Organization, you will need to add the [Owner key](/versions/latest/config/app/#owner) to your project's app.json
 
 ### Converting Personal Accounts into Organizations
 

--- a/docs/pages/accounts/account-types.md
+++ b/docs/pages/accounts/account-types.md
@@ -32,9 +32,9 @@ Common situations where Organizations are useful:
 ### Creating New Organizations
 
 To create a new Organization, visit [expo.dev/create-organization](https://expo.dev/create-organization) and sign in to your Personal Account.
-You can also create a new Organization by selecting "New Organization" from the account selection dropdown at the top of your dashboard.
+You can also create a new Organization by selecting "New Organization" from the account selection dropdown at the top of your dashboard. You'll need to choose a name for your Organization. 
 
-You'll need to choose a name for your Organization. To associate projects with an Organization, you will need to add the [Owner key](/versions/latest/config/app/#owner) to your project's app.json
+To associate projects with an Organization, you will need to add the [Owner key](/versions/latest/config/app/#owner) to your project's app.json
 
 ### Converting Personal Accounts into Organizations
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Refs ENG-5757

# How

<!--
How did you build this feature or fix this bug and why?
-->
This PR:
- Removes the part where it said one could not rename an organization account.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

Changes have been tested running the docs locally.

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
