### PR TITLE
fix(cli): fix installing latest client

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix bug preventing the installation of beta clients.
+
 ### 💡 Others
 
 ## 0.2.2 — 2022-07-18

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix bug preventing the installation of beta clients.
+- Fix bug preventing the installation of beta clients. ([#18298](https://github.com/expo/expo/pull/18298) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/api/__tests__/getVersions-test.ts
+++ b/packages/@expo/cli/src/api/__tests__/getVersions-test.ts
@@ -1,5 +1,4 @@
 import nock from 'nock';
-import { parse } from 'semver';
 
 import { getExpoApiBaseUrl } from '../endpoint';
 import { getVersionsAsync } from '../getVersions';

--- a/packages/@expo/cli/src/api/__tests__/getVersions-test.ts
+++ b/packages/@expo/cli/src/api/__tests__/getVersions-test.ts
@@ -2,7 +2,7 @@ import nock from 'nock';
 import { parse } from 'semver';
 
 import { getExpoApiBaseUrl } from '../endpoint';
-import { getReleasedVersionsAsync, getVersionsAsync } from '../getVersions';
+import { getVersionsAsync } from '../getVersions';
 
 beforeAll(() => {
   process.env.EXPO_NO_CACHE = 'true';
@@ -22,22 +22,6 @@ describe(getVersionsAsync, () => {
       .get('/v2/versions/latest')
       .reply(500, 'something went wrong');
     await expect(getVersionsAsync()).rejects.toThrowError(/Expo server/);
-    expect(scope.isDone()).toBe(true);
-  });
-});
-
-describe(getReleasedVersionsAsync, () => {
-  it('gets released versions', async () => {
-    const scope = nock(getExpoApiBaseUrl())
-      .get('/v2/versions/latest')
-      .reply(200, require('./fixtures/versions-latest.json'));
-    const versions = await getReleasedVersionsAsync();
-    // A list of SDK versions like `43.0.0`
-    expect(
-      Object.keys(versions).every((value) => {
-        return parse(value) && value.endsWith('.0.0');
-      })
-    );
     expect(scope.isDone()).toBe(true);
   });
 });

--- a/packages/@expo/cli/src/api/getVersions.ts
+++ b/packages/@expo/cli/src/api/getVersions.ts
@@ -59,17 +59,3 @@ export async function getVersionsAsync({
   const json = await results.json();
   return json.data;
 }
-
-/** Get the currently released version while also accounting for if the user is running in `EXPO_BETA` mode. */
-export async function getReleasedVersionsAsync({
-  skipCache,
-}: { skipCache?: boolean } = {}): Promise<SDKVersions> {
-  // NOTE(brentvatne): it is possible for an unreleased version to be published to
-  // the versions endpoint, but in some cases we only want to list out released
-  // versions
-  const { sdkVersions } = await getVersionsAsync({ skipCache });
-  return pickBy(
-    sdkVersions,
-    (data, _sdkVersionString) => !!data.releaseNoteUrl || (env.EXPO_BETA && data.beta)
-  );
-}

--- a/packages/@expo/cli/src/api/getVersions.ts
+++ b/packages/@expo/cli/src/api/getVersions.ts
@@ -1,6 +1,4 @@
-import { env } from '../utils/env';
 import { CommandError } from '../utils/errors';
-import { pickBy } from '../utils/obj';
 import { createCachedFetch } from './rest/client';
 
 /** Represents version info for a particular SDK. */

--- a/packages/@expo/cli/src/api/rest/wrapFetchWithBaseUrl.ts
+++ b/packages/@expo/cli/src/api/rest/wrapFetchWithBaseUrl.ts
@@ -2,6 +2,8 @@ import { URL } from 'url';
 
 import { FetchLike } from './client.types';
 
+const debug = require('debug')('expo:api:fetch:base') as typeof console.log;
+
 /**
  * Wrap a fetch function with support for a predefined base URL.
  * This implementation works like the browser fetch, applying the input to a prefix base URL.
@@ -15,6 +17,7 @@ export function wrapFetchWithBaseUrl(fetch: FetchLike, baseUrl: string): FetchLi
     if (init?.searchParams) {
       parsed.search = init.searchParams.toString();
     }
+    debug('fetch:', parsed.toString().trim());
     return fetch(parsed.toString(), init);
   };
 }

--- a/packages/@expo/cli/src/start/doctor/dependencies/__tests__/getVersionedPackages-test.ts
+++ b/packages/@expo/cli/src/start/doctor/dependencies/__tests__/getVersionedPackages-test.ts
@@ -18,7 +18,21 @@ jest.mock('../bundledNativeModules', () => ({
 describe(getVersionedPackagesAsync, () => {
   it('should return versioned packages', async () => {
     asMock(getVersionedNativeModulesAsync).mockResolvedValueOnce({});
-
+    asMock(getVersionsAsync).mockResolvedValueOnce({
+      sdkVersions: {
+        '1.0.0': {
+          relatedPackages: {
+            '@expo/vector-icons': '3.0.0',
+            'react-native': 'default',
+            react: 'default',
+            'react-dom': 'default',
+            'expo-sms': 'default',
+          },
+          facebookReactVersion: 'facebook-react',
+          facebookReactNativeVersion: 'facebook-rn',
+        },
+      },
+    } as any);
     const { packages, messages } = await getVersionedPackagesAsync('/', {
       sdkVersion: '1.0.0',
       packages: ['@expo/vector-icons', 'react@next', 'expo-camera', 'uuid@^3.4.0'],

--- a/packages/@expo/cli/src/start/doctor/dependencies/__tests__/getVersionedPackages-test.ts
+++ b/packages/@expo/cli/src/start/doctor/dependencies/__tests__/getVersionedPackages-test.ts
@@ -1,5 +1,5 @@
 import { asMock } from '../../../../__tests__/asMock';
-import { getReleasedVersionsAsync } from '../../../../api/getVersions';
+import { getVersionsAsync } from '../../../../api/getVersions';
 import { getVersionedNativeModulesAsync } from '../bundledNativeModules';
 import {
   getOperationLog,
@@ -9,7 +9,6 @@ import {
 
 jest.mock('../../../../api/getVersions', () => ({
   getVersionsAsync: jest.fn(),
-  getReleasedVersionsAsync: jest.fn(),
 }));
 
 jest.mock('../bundledNativeModules', () => ({
@@ -19,19 +18,6 @@ jest.mock('../bundledNativeModules', () => ({
 describe(getVersionedPackagesAsync, () => {
   it('should return versioned packages', async () => {
     asMock(getVersionedNativeModulesAsync).mockResolvedValueOnce({});
-    asMock(getReleasedVersionsAsync).mockResolvedValueOnce({
-      '1.0.0': {
-        relatedPackages: {
-          '@expo/vector-icons': '3.0.0',
-          'react-native': 'default',
-          react: 'default',
-          'react-dom': 'default',
-          'expo-sms': 'default',
-        },
-        facebookReactVersion: 'facebook-react',
-        facebookReactNativeVersion: 'facebook-rn',
-      },
-    });
 
     const { packages, messages } = await getVersionedPackagesAsync('/', {
       sdkVersion: '1.0.0',
@@ -74,7 +60,7 @@ describe(getOperationLog, () => {
 
 describe(getRemoteVersionsForSdkAsync, () => {
   it('returns an empty object when the SDK version is not supported', async () => {
-    asMock(getReleasedVersionsAsync).mockResolvedValueOnce({});
+    asMock(getVersionsAsync).mockResolvedValueOnce({ sdkVersions: {} } as any);
 
     expect(await getRemoteVersionsForSdkAsync({ sdkVersion: '1.0.0', skipCache: true })).toEqual(
       {}
@@ -82,18 +68,20 @@ describe(getRemoteVersionsForSdkAsync, () => {
   });
 
   it('returns versions for SDK with Facebook overrides', async () => {
-    asMock(getReleasedVersionsAsync).mockResolvedValueOnce({
-      '1.0.0': {
-        relatedPackages: {
-          'react-native': 'default',
-          react: 'default',
-          'react-dom': 'default',
-          'expo-sms': 'default',
+    asMock(getVersionsAsync).mockResolvedValueOnce({
+      sdkVersions: {
+        '1.0.0': {
+          relatedPackages: {
+            'react-native': 'default',
+            react: 'default',
+            'react-dom': 'default',
+            'expo-sms': 'default',
+          },
+          facebookReactVersion: 'facebook-react',
+          facebookReactNativeVersion: 'facebook-rn',
         },
-        facebookReactVersion: 'facebook-react',
-        facebookReactNativeVersion: 'facebook-rn',
       },
-    });
+    } as any);
 
     expect(await getRemoteVersionsForSdkAsync({ sdkVersion: '1.0.0', skipCache: true })).toEqual({
       'expo-sms': 'default',

--- a/packages/@expo/cli/src/start/doctor/dependencies/getVersionedPackages.ts
+++ b/packages/@expo/cli/src/start/doctor/dependencies/getVersionedPackages.ts
@@ -1,6 +1,6 @@
 import npmPackageArg from 'npm-package-arg';
 
-import { getReleasedVersionsAsync, SDKVersion } from '../../../api/getVersions';
+import { getVersionsAsync, SDKVersion } from '../../../api/getVersions';
 import { getVersionedNativeModulesAsync } from './bundledNativeModules';
 
 const debug = require('debug')(
@@ -55,7 +55,7 @@ export async function getRemoteVersionsForSdkAsync({
   sdkVersion,
   skipCache,
 }: { sdkVersion?: string; skipCache?: boolean } = {}): Promise<DependencyList> {
-  const sdkVersions = await getReleasedVersionsAsync({ skipCache });
+  const { sdkVersions } = await getVersionsAsync({ skipCache });
 
   // We only want versioned dependencies so skip if they cannot be found.
   if (!sdkVersion || !(sdkVersion in sdkVersions)) {

--- a/packages/@expo/cli/src/start/platforms/ExpoGoInstaller.ts
+++ b/packages/@expo/cli/src/start/platforms/ExpoGoInstaller.ts
@@ -30,7 +30,7 @@ export class ExpoGoInstaller<IDevice> {
     }
     const version = await this._getExpectedClientVersionAsync();
     debug(`Expected Expo Go version: ${version}, installed version: ${installedVersion}`);
-    return version ? semver.lt(installedVersion, version) : true;
+    return version ? !semver.eq(installedVersion, version) : true;
   }
 
   /** Returns the expected version of Expo Go given the project SDK Version. Exposed for testing. */

--- a/packages/@expo/cli/src/utils/downloadExpoGoAsync.ts
+++ b/packages/@expo/cli/src/utils/downloadExpoGoAsync.ts
@@ -1,7 +1,7 @@
 import { getExpoHomeDirectory } from '@expo/config/build/getUserState';
 import path from 'path';
 
-import { getReleasedVersionsAsync, SDKVersion } from '../api/getVersions';
+import { getVersionsAsync, SDKVersion } from '../api/getVersions';
 import { downloadAppAsync } from './downloadAppAsync';
 import { CommandError } from './errors';
 import { profile } from './profile';
@@ -58,8 +58,14 @@ export async function downloadExpoGoAsync(
         `Unable to determine which Expo Go version to install (platform: ${platform})`
       );
     }
-    const versions = await getReleasedVersionsAsync();
+    const { sdkVersions: versions } = await getVersionsAsync();
+
     const version = versions[sdkVersion];
+    if (!version) {
+      throw new CommandError(
+        `Unable to find a version of Expo Go for SDK ${sdkVersion} (platform: ${platform})`
+      );
+    }
     debug(`Installing Expo Go version for SDK ${sdkVersion} at URL: ${version[versionsKey]}`);
     url = version[versionsKey] as string;
   }


### PR DESCRIPTION
# Why

- Install client app when the versions don't match exactly. This allows for downgrading the client. Fixes behavior [copied from expo-cli](https://github.com/expo/expo-cli/blob/954c8528e55ee83f49500b846025fc89f4ea8633/packages/xdl/src/Simulator.ts#L436).
- Ignores beta versions and installs whatever client version matches the installed `expo` version.

# Test Plan

In a new project `yarn expo start -i` should prompt to install the latest SDK 46 client. Running `yarn expo start -i` in an older project will install the older version of Expo Go.
