### PR TITLE
fix(cli): add mock `--non-interactive` flag to hide `eas update` errors

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Add mock `--non-interactive` flag to hide `eas update` errors.
+- Add mock `--non-interactive` flag to hide `eas update` errors. ([#18299](https://github.com/expo/expo/pull/18299) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Add mock `--non-interactive` flag to hide `eas update` errors.
+
 ### 💡 Others
 
 ## 0.2.3 — 2022-07-19

--- a/packages/@expo/cli/bin/cli.ts
+++ b/packages/@expo/cli/bin/cli.ts
@@ -41,6 +41,9 @@ const args = arg(
     // Types
     '--version': Boolean,
     '--help': Boolean,
+    // NOTE(EvanBacon): This is here to silence warnings from processes that
+    // expect the global expo-cli.
+    '--non-interactive': Boolean,
 
     // Aliases
     '-v': '--version',
@@ -55,6 +58,10 @@ if (args['--version']) {
   // Version is added in the build script.
   console.log(process.env.__EXPO_VERSION);
   process.exit(0);
+}
+
+if (args['--non-interactive']) {
+  console.warn(chalk.yellow`  {bold --non-interactive} is not supported, use {bold $CI=1} instead`);
 }
 
 // Check if we are running `npx expo <subcommand>` or `npx expo`
@@ -104,6 +111,7 @@ if (!isSubcommand) {
   const migrationMap: Record<string, string> = {
     init: 'npx create-expo-app',
     eject: 'npx expo prebuild',
+    web: 'npx expo start --web',
     'start:web': 'npx expo start --web',
     'build:ios': 'eas build -p ios',
     'build:android': 'eas build -p android',


### PR DESCRIPTION
# Why

- To accommodate the hacks inside of the eas update command, we are adding a mock `--non-interactive` flag to the versioned expo/cli.