### PR TITLE
[updates-e2e] add test suite for missing asset recovery

### DIFF
--- a/packages/expo-updates/e2e/__tests__/Updates-e2e-assets.test.ts
+++ b/packages/expo-updates/e2e/__tests__/Updates-e2e-assets.test.ts
@@ -23,6 +23,17 @@ if (!repoRoot) {
 const projectRoot = process.env.TEST_PROJECT_ROOT ?? path.resolve(repoRoot, '..', 'updates-e2e');
 const updateDistPath = path.join(process.env.ARTIFACTS_DEST, 'dist-assets');
 
+/**
+ * The tests in this suite install an app with multiple assets, then clear all the assets from
+ * .expo-internal storage (but not SQLite). This simulates scenarios such as: a bug in our code that
+ * deletes assets unintentionally; OS deleting files from app storage if it runs out of memory; etc.
+ *
+ * Recovery code for this situation exists in the DatabaseLauncher, these are the main tests that
+ * ensure that logic doesn't regress.
+ *
+ * These tests all make use of the additional UpdatesE2ETestModule, which provides methods for
+ * clearing and reading the .expo-internal folder.
+ */
 describe('Asset deletion recovery', () => {
   afterEach(async () => {
     await Simulator.uninstallApp();
@@ -30,9 +41,18 @@ describe('Asset deletion recovery', () => {
   });
 
   it('embedded assets deleted from internal storage should be re-copied', async () => {
+    /**
+     * Simplest scenario; only one update (embedded) is loaded, then assets are cleared from
+     * internal storage. The app is then relaunched with the same embedded update.
+     * DatabaseLauncher should copy all the missing assets and run the update as normal.
+     */
     jest.setTimeout(300000 * TIMEOUT_BIAS);
     Server.start(SERVER_PORT);
 
+    /**
+     * Install the app and immediately send it a message to clear internal storage. Verify storage
+     * has been cleared properly.
+     */
     await Simulator.installApp('assets');
     // set up promise before starting the app to ensure the correct response is sent
     const promise = Server.waitForRequest(10000 * TIMEOUT_BIAS, {
@@ -48,8 +68,10 @@ describe('Asset deletion recovery', () => {
     expect(clearAssetsMessage.numFilesBefore).toBeGreaterThanOrEqual(3); // JS bundle, png, ttf
     expect(clearAssetsMessage.numFilesAfter).toBe(0);
 
+    /**
+     * Stop and then restart app. Immediately send it a message to read internal storage.
+     */
     await Simulator.stopApp();
-
     // set up promise before starting the app to ensure the correct response is sent
     const promise2 = Server.waitForRequest(10000 * TIMEOUT_BIAS, {
       command: 'readExpoInternal',
@@ -61,15 +83,33 @@ describe('Asset deletion recovery', () => {
     if (!readAssetsMessage.success) {
       throw new Error(readAssetsMessage.error);
     }
-    expect(readAssetsMessage.numFiles).toEqual(clearAssetsMessage.numFilesBefore);
 
+    /**
+     * Verify all the assets that were deleted have been re-copied back into internal storage, and
+     * that we are running the same update as before (different in the following tests).
+     */
+    expect(readAssetsMessage.numFiles).toEqual(clearAssetsMessage.numFilesBefore);
     expect(readAssetsMessage.updateId).toEqual(clearAssetsMessage.updateId);
   });
 
   it('embedded assets deleted from internal storage should be re-copied from a new embedded update', async () => {
+    /**
+     * This test ensures that when trying to launch a NEW update that includes some OLD assets we
+     * already have (according to SQLite), even if those assets are actually missing from disk
+     * (but included in the embedded update) DatabaseLauncher can recover.
+     *
+     * To create this scenario, we load a single (embedded) update, then clear assets from
+     * internal storage. Then we install a NEW build with a NEW embedded update but that includes
+     * some of the same assets. When we launch this new build, DatabaseLauncher should still copy
+     * the missing assets and run the update as normal.
+     */
     jest.setTimeout(300000 * TIMEOUT_BIAS);
     Server.start(SERVER_PORT);
 
+    /**
+     * Install the app and immediately send it a message to clear internal storage. Verify storage
+     * has been cleared properly.
+     */
     await Simulator.installApp('assets');
     // set up promise before starting the app to ensure the correct response is sent
     const promise = Server.waitForRequest(10000 * TIMEOUT_BIAS, {
@@ -85,14 +125,22 @@ describe('Asset deletion recovery', () => {
     expect(clearAssetsMessage.numFilesBefore).toBeGreaterThanOrEqual(3); // JS bundle, png, ttf
     expect(clearAssetsMessage.numFilesAfter).toBe(0);
 
+    /**
+     * Stop the app and install a newer build on top of it. The newer build has a different
+     * embedded update (different updateId) but still includes some of the same assets. Now SQLite
+     * thinks we already have these assets, but we actually just deleted them from internal
+     * storage.
+     */
     await Simulator.stopApp();
-
     await Simulator.installApp('assets2');
 
-    // set up promise before starting the app to ensure the correct response is sent
+    /**
+     * Start the new build, and immediately send it a message to read internal storage.
+     */
     const promise2 = Server.waitForRequest(10000 * TIMEOUT_BIAS, {
       command: 'readExpoInternal',
     });
+    // set up promise before starting the app to ensure the correct response is sent
     await Simulator.startApp();
     await promise2;
 
@@ -100,15 +148,32 @@ describe('Asset deletion recovery', () => {
     if (!readAssetsMessage.success) {
       throw new Error(readAssetsMessage.error);
     }
-    expect(readAssetsMessage.numFiles).toEqual(clearAssetsMessage.numFilesBefore);
 
+    /**
+     * Verify all the assets that were deleted have been re-copied back into internal storage, and
+     * that we are running a DIFFERENT update than before -- otherwise this test is no different
+     * from the previous one.
+     */
+    expect(readAssetsMessage.numFiles).toEqual(clearAssetsMessage.numFilesBefore);
     expect(readAssetsMessage.updateId).not.toEqual(clearAssetsMessage.updateId);
   });
 
   it('assets in a downloaded update deleted from internal storage should be re-copied or re-downloaded', async () => {
+    /**
+     * This test ensures we can (or at least try to) recover missing assets that originated from a
+     * downloaded update, as opposed to assets originally copied from an embedded update (which
+     * the previous 2 tests concern).
+     *
+     * To create this scenario, we launch an app, download an update with multiple assets
+     * (including at least one -- the bundle -- not part of the embedded update), make sure the
+     * update runs, then clear assets from internal storage. When we relaunch the app,
+     * DatabaseLauncher should re-download the missing assets and run the update as normal.
+     */
     jest.setTimeout(300000 * TIMEOUT_BIAS);
 
-    // prepare manifest and assets for hosting
+    /**
+     * Prepare to host update manifest and assets from the test runner
+     */
     const bundleFilename = 'bundle-assets.js';
     const newNotifyString = 'test-assets-1';
     const bundleHash = await copyBundleToStaticFolder(
@@ -151,6 +216,9 @@ describe('Asset deletion recovery', () => {
       extra: {},
     };
 
+    /**
+     * Install the app and launch it so that it downloads the new update we're hosting
+     */
     Server.start(SERVER_PORT);
     await Server.serveSignedManifest(manifest, projectRoot);
     await Simulator.installApp('assets');
@@ -163,11 +231,11 @@ describe('Asset deletion recovery', () => {
     await setTimeout(2000 * TIMEOUT_BIAS);
     expect(Server.consumeRequestedStaticFiles().length).toBe(1); // only the bundle should be new
 
-    // restart the app so it will launch the new update
+    /**
+     * Stop and restart the app so it will launch the new update. Immediately send it a message to
+     * clear internal storage while also verifying the new update is running.
+     */
     await Simulator.stopApp();
-
-    // send instructions to clear the internal assets dir
-    // while also verifying that the new update is running
     const promise = Server.waitForRequest(10000 * TIMEOUT_BIAS, {
       command: 'clearExpoInternal',
     });
@@ -175,6 +243,9 @@ describe('Asset deletion recovery', () => {
     const updatedMessage = await promise;
     expect(updatedMessage).toBe(newNotifyString);
 
+    /**
+     * Verify that the assets were cleared correctly.
+     */
     const clearAssetsMessage = await Server.waitForRequest(10000 * TIMEOUT_BIAS);
     if (!clearAssetsMessage.success) {
       throw new Error(clearAssetsMessage.error);
@@ -183,8 +254,11 @@ describe('Asset deletion recovery', () => {
     expect(clearAssetsMessage.numFilesAfter).toBe(0);
     expect(clearAssetsMessage.updateId).toEqual(manifest.id);
 
+    /**
+     * Stop and restart the app and immediately send it a message to read internal storage. Verify
+     * that the new update is running (again).
+     */
     await Simulator.stopApp();
-
     // set up promise before starting the app to ensure the correct response is sent
     const promise2 = Server.waitForRequest(10000 * TIMEOUT_BIAS, {
       command: 'readExpoInternal',
@@ -193,6 +267,11 @@ describe('Asset deletion recovery', () => {
     const updatedMessageAfterClearExpoInternal = await promise2;
     expect(updatedMessageAfterClearExpoInternal).toBe(newNotifyString);
 
+    /**
+     * Verify all the assets -- including the JS bundle from the update (which wasn't in the
+     * embedded update) -- have been restored. Additionally verify from the server side that the
+     * updated bundle was re-downloaded.
+     */
     const readAssetsMessage = await Server.waitForRequest(10000 * TIMEOUT_BIAS);
     if (!readAssetsMessage.success) {
       throw new Error(readAssetsMessage.error);

--- a/packages/expo-updates/e2e/__tests__/Updates-e2e-assets.test.ts
+++ b/packages/expo-updates/e2e/__tests__/Updates-e2e-assets.test.ts
@@ -1,0 +1,204 @@
+import path from 'path';
+import { setTimeout } from 'timers/promises';
+import uuid from 'uuid/v4';
+
+import * as Server from './utils/server';
+import * as Simulator from './utils/simulator';
+import { copyAssetToStaticFolder, copyBundleToStaticFolder } from './utils/update';
+
+const SERVER_HOST = process.env.UPDATES_HOST;
+const SERVER_PORT = parseInt(process.env.UPDATES_PORT, 10);
+
+const RUNTIME_VERSION = '1.0.0';
+
+const TIMEOUT_BIAS = process.env.CI ? 10 : 1;
+
+const repoRoot = process.env.EXPO_REPO_ROOT;
+if (!repoRoot) {
+  throw new Error(
+    'You must provide the path to the repo root in the EXPO_REPO_ROOT environment variable'
+  );
+}
+
+const projectRoot = process.env.TEST_PROJECT_ROOT ?? path.resolve(repoRoot, '..', 'updates-e2e');
+const updateDistPath = path.join(process.env.ARTIFACTS_DEST, 'dist-assets');
+
+describe('Asset deletion recovery', () => {
+  afterEach(async () => {
+    await Simulator.uninstallApp();
+    Server.stop();
+  });
+
+  it('embedded assets deleted from internal storage should be re-copied', async () => {
+    jest.setTimeout(300000 * TIMEOUT_BIAS);
+    Server.start(SERVER_PORT);
+
+    await Simulator.installApp('assets');
+    // set up promise before starting the app to ensure the correct response is sent
+    const promise = Server.waitForRequest(10000 * TIMEOUT_BIAS, {
+      command: 'clearExpoInternal',
+    });
+    await Simulator.startApp();
+    await promise;
+
+    const clearAssetsMessage = await Server.waitForRequest(10000 * TIMEOUT_BIAS);
+    if (!clearAssetsMessage.success) {
+      throw new Error(clearAssetsMessage.error);
+    }
+    expect(clearAssetsMessage.numFilesBefore).toBeGreaterThanOrEqual(3); // JS bundle, png, ttf
+    expect(clearAssetsMessage.numFilesAfter).toBe(0);
+
+    await Simulator.stopApp();
+
+    // set up promise before starting the app to ensure the correct response is sent
+    const promise2 = Server.waitForRequest(10000 * TIMEOUT_BIAS, {
+      command: 'readExpoInternal',
+    });
+    await Simulator.startApp();
+    await promise2;
+
+    const readAssetsMessage = await Server.waitForRequest(10000 * TIMEOUT_BIAS);
+    if (!readAssetsMessage.success) {
+      throw new Error(readAssetsMessage.error);
+    }
+    expect(readAssetsMessage.numFiles).toEqual(clearAssetsMessage.numFilesBefore);
+
+    expect(readAssetsMessage.updateId).toEqual(clearAssetsMessage.updateId);
+  });
+
+  it('embedded assets deleted from internal storage should be re-copied from a new embedded update', async () => {
+    jest.setTimeout(300000 * TIMEOUT_BIAS);
+    Server.start(SERVER_PORT);
+
+    await Simulator.installApp('assets');
+    // set up promise before starting the app to ensure the correct response is sent
+    const promise = Server.waitForRequest(10000 * TIMEOUT_BIAS, {
+      command: 'clearExpoInternal',
+    });
+    await Simulator.startApp();
+    await promise;
+
+    const clearAssetsMessage = await Server.waitForRequest(10000 * TIMEOUT_BIAS);
+    if (!clearAssetsMessage.success) {
+      throw new Error(clearAssetsMessage.error);
+    }
+    expect(clearAssetsMessage.numFilesBefore).toBeGreaterThanOrEqual(3); // JS bundle, png, ttf
+    expect(clearAssetsMessage.numFilesAfter).toBe(0);
+
+    await Simulator.stopApp();
+
+    await Simulator.installApp('assets2');
+
+    // set up promise before starting the app to ensure the correct response is sent
+    const promise2 = Server.waitForRequest(10000 * TIMEOUT_BIAS, {
+      command: 'readExpoInternal',
+    });
+    await Simulator.startApp();
+    await promise2;
+
+    const readAssetsMessage = await Server.waitForRequest(10000 * TIMEOUT_BIAS);
+    if (!readAssetsMessage.success) {
+      throw new Error(readAssetsMessage.error);
+    }
+    expect(readAssetsMessage.numFiles).toEqual(clearAssetsMessage.numFilesBefore);
+
+    expect(readAssetsMessage.updateId).not.toEqual(clearAssetsMessage.updateId);
+  });
+
+  it('assets in a downloaded update deleted from internal storage should be re-copied or re-downloaded', async () => {
+    jest.setTimeout(300000 * TIMEOUT_BIAS);
+
+    // prepare manifest and assets for hosting
+    const bundleFilename = 'bundle-assets.js';
+    const newNotifyString = 'test-assets-1';
+    const bundleHash = await copyBundleToStaticFolder(
+      updateDistPath,
+      bundleFilename,
+      newNotifyString
+    );
+    const { bundledAssets } = require(path.join(
+      updateDistPath,
+      Simulator.ExportedManifestFilename
+    ));
+    const assets = await Promise.all(
+      bundledAssets.map(async (filename) => {
+        const key = filename.replace('asset_', '').replace(/\.[^/.]+$/, '');
+        const hash = await copyAssetToStaticFolder(
+          path.join(updateDistPath, 'assets', key),
+          filename
+        );
+        return {
+          hash,
+          key,
+          contentType: 'image/jpg',
+          fileExtension: '.jpg',
+          url: `http://${SERVER_HOST}:${SERVER_PORT}/static/${filename}`,
+        };
+      })
+    );
+    const manifest = {
+      id: uuid(),
+      createdAt: new Date().toISOString(),
+      runtimeVersion: RUNTIME_VERSION,
+      launchAsset: {
+        hash: bundleHash,
+        key: 'test-assets-bundle',
+        contentType: 'application/javascript',
+        url: `http://${SERVER_HOST}:${SERVER_PORT}/static/${bundleFilename}`,
+      },
+      assets,
+      metadata: {},
+      extra: {},
+    };
+
+    Server.start(SERVER_PORT);
+    await Server.serveSignedManifest(manifest, projectRoot);
+    await Simulator.installApp('assets');
+    await Simulator.startApp();
+    await Server.waitForUpdateRequest(10000 * TIMEOUT_BIAS);
+    const message = await Server.waitForRequest(10000 * TIMEOUT_BIAS);
+    expect(message).toBe('test');
+
+    // give the app time to load the new update in the background
+    await setTimeout(2000 * TIMEOUT_BIAS);
+    expect(Server.consumeRequestedStaticFiles().length).toBe(1); // only the bundle should be new
+
+    // restart the app so it will launch the new update
+    await Simulator.stopApp();
+
+    // send instructions to clear the internal assets dir
+    // while also verifying that the new update is running
+    const promise = Server.waitForRequest(10000 * TIMEOUT_BIAS, {
+      command: 'clearExpoInternal',
+    });
+    await Simulator.startApp();
+    const updatedMessage = await promise;
+    expect(updatedMessage).toBe(newNotifyString);
+
+    const clearAssetsMessage = await Server.waitForRequest(10000 * TIMEOUT_BIAS);
+    if (!clearAssetsMessage.success) {
+      throw new Error(clearAssetsMessage.error);
+    }
+    expect(clearAssetsMessage.numFilesBefore).toBeGreaterThanOrEqual(4); // png, ttf, 2 JS bundles
+    expect(clearAssetsMessage.numFilesAfter).toBe(0);
+    expect(clearAssetsMessage.updateId).toEqual(manifest.id);
+
+    await Simulator.stopApp();
+
+    // set up promise before starting the app to ensure the correct response is sent
+    const promise2 = Server.waitForRequest(10000 * TIMEOUT_BIAS, {
+      command: 'readExpoInternal',
+    });
+    await Simulator.startApp();
+    const updatedMessageAfterClearExpoInternal = await promise2;
+    expect(updatedMessageAfterClearExpoInternal).toBe(newNotifyString);
+
+    const readAssetsMessage = await Server.waitForRequest(10000 * TIMEOUT_BIAS);
+    if (!readAssetsMessage.success) {
+      throw new Error(readAssetsMessage.error);
+    }
+    expect(readAssetsMessage.numFiles).toEqual(manifest.assets.length + 1); // assets + JS bundle
+    expect(readAssetsMessage.updateId).toEqual(manifest.id);
+    expect(Server.consumeRequestedStaticFiles().length).toBe(1); // should have re-downloaded only the JS bundle; the rest should have been copied from the app binary
+  });
+});

--- a/packages/expo-updates/e2e/__tests__/fixtures/App-assets.js
+++ b/packages/expo-updates/e2e/__tests__/fixtures/App-assets.js
@@ -1,22 +1,110 @@
+import { Inter_900Black } from '@expo-google-fonts/inter';
+import { NativeModulesProxy } from 'expo-modules-core';
 import { StatusBar } from 'expo-status-bar';
+import * as Updates from 'expo-updates';
 import { useEffect } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 
 const RETRY_COUNT = 5;
+const HOSTNAME = 'UPDATES_HOST';
+const PORT = 'UPDATES_PORT';
+
+require('./test.png');
+Inter_900Black;
+
+async function fetchWithRetry(url, body) {
+  for (let i = 0; i < RETRY_COUNT; i++) {
+    try {
+      const response = await fetch(url, {
+        method: body ? 'POST' : 'GET',
+        body,
+        headers: body
+          ? {
+              'Content-Type': 'application/json',
+            }
+          : undefined,
+      });
+      if (response.status === 200) {
+        return response;
+      }
+    } catch {
+      // do nothing; expected if the server isn't running yet
+    }
+    // wait 50 ms and then try again
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  console.error(`Failed to fetch URL ${url}`);
+  return null;
+}
+
+async function readExpoInternal() {
+  try {
+    const numFiles = await NativeModulesProxy.ExpoUpdatesE2ETest.readInternalAssetsFolderAsync();
+    await fetchWithRetry(
+      `http://${HOSTNAME}:${PORT}/post`,
+      JSON.stringify({
+        command: 'readExpoInternal',
+        success: true,
+        updateId: Updates.updateId,
+        numFiles,
+      })
+    );
+  } catch (e) {
+    await fetchWithRetry(
+      `http://${HOSTNAME}:${PORT}/post`,
+      JSON.stringify({
+        command: 'readExpoInternal',
+        success: false,
+        updateId: Updates.updateId,
+        error: e.message,
+      })
+    );
+  }
+}
+
+async function clearExpoInternal() {
+  try {
+    const numFilesBefore =
+      await NativeModulesProxy.ExpoUpdatesE2ETest.readInternalAssetsFolderAsync();
+    await NativeModulesProxy.ExpoUpdatesE2ETest.clearInternalAssetsFolderAsync();
+    const numFilesAfter =
+      await NativeModulesProxy.ExpoUpdatesE2ETest.readInternalAssetsFolderAsync();
+    await fetchWithRetry(
+      `http://${HOSTNAME}:${PORT}/post`,
+      JSON.stringify({
+        command: 'clearExpoInternal',
+        success: true,
+        updateId: Updates.updateId,
+        numFilesBefore,
+        numFilesAfter,
+      })
+    );
+  } catch (e) {
+    await fetchWithRetry(
+      `http://${HOSTNAME}:${PORT}/post`,
+      JSON.stringify({
+        command: 'clearExpoInternal',
+        success: false,
+        updateId: Updates.updateId,
+        error: e.message,
+      })
+    );
+  }
+}
 
 export default function App() {
   useEffect(async () => {
-    for (let i = 0; i < RETRY_COUNT; i++) {
-      try {
-        const response = await fetch('http://UPDATES_HOST:UPDATES_PORT/notify/test');
-        if (response.status === 200) {
+    const response = await fetchWithRetry(`http://${HOSTNAME}:${PORT}/notify/test`);
+    const responseObj = await response.json();
+    if (responseObj && responseObj.command) {
+      switch (responseObj.command) {
+        case 'readExpoInternal':
+          await readExpoInternal();
           break;
-        }
-      } catch {
-        // do nothing; expected if the server isn't running yet
+        case 'clearExpoInternal':
+          await clearExpoInternal();
+          break;
       }
-      // wait 50 ms and then try again
-      await new Promise((resolve) => setTimeout(resolve, 50));
     }
   }, []);
 

--- a/packages/expo-updates/e2e/__tests__/fixtures/EXUpdatesE2ETestModule.h
+++ b/packages/expo-updates/e2e/__tests__/fixtures/EXUpdatesE2ETestModule.h
@@ -1,0 +1,10 @@
+//  Copyright © 2022 650 Industries. All rights reserved.
+
+#import <ExpoModulesCore/EXExportedModule.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface EXUpdatesE2ETestModule : EXExportedModule
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/e2e/__tests__/fixtures/EXUpdatesE2ETestModule.m
+++ b/packages/expo-updates/e2e/__tests__/fixtures/EXUpdatesE2ETestModule.m
@@ -1,0 +1,66 @@
+// Copyright 2019 650 Industries. All rights reserved.
+
+#import <EXUpdates/EXUpdatesAppController.h>
+#import <EXUpdates/EXUpdatesE2ETestModule.h>
+#import <EXUpdates/EXUpdatesFileDownloader.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation EXUpdatesE2ETestModule
+
+EX_EXPORT_MODULE(ExpoUpdatesE2ETest);
+
+EX_EXPORT_METHOD_AS(readInternalAssetsFolderAsync,
+                    readInternalAssetsFolderAsync:(EXPromiseResolveBlock)resolve
+                                           reject:(EXPromiseRejectBlock)reject)
+{
+  NSURL *assetsFolder = EXUpdatesAppController.sharedInstance.updatesDirectory;
+  dispatch_async(EXUpdatesFileDownloader.assetFilesQueue, ^{
+    NSError *error;
+    NSArray<NSString *> *contents = [NSFileManager.defaultManager contentsOfDirectoryAtPath:assetsFolder.path error:&error];
+    int count = 0;
+    for (NSString *file in contents) {
+      if ([file hasPrefix:@"expo-"] && ([file hasSuffix:@".db"] || [file containsString:@".db-"])) {
+        continue;
+      }
+      count++;
+    }
+    if (error) {
+      reject(@"ERR_UPDATES_E2E_READ", error.localizedDescription, error);
+      return;
+    }
+    resolve(@(count));
+  });
+}
+
+EX_EXPORT_METHOD_AS(clearInternalAssetsFolderAsync,
+                    clearInternalAssetsFolderAsync:(EXPromiseResolveBlock)resolve
+                                            reject:(EXPromiseRejectBlock)reject)
+{
+  NSURL *assetsFolder = EXUpdatesAppController.sharedInstance.updatesDirectory;
+  dispatch_async(EXUpdatesFileDownloader.assetFilesQueue, ^{
+    NSError *error;
+    NSArray<NSString *> *contents = [NSFileManager.defaultManager contentsOfDirectoryAtPath:assetsFolder.path error:&error];
+    if (error) {
+      reject(@"ERR_UPDATES_E2E_CLEAR", error.localizedDescription, error);
+      return;
+    }
+    for (NSString *file in contents) {
+      if ([file hasPrefix:@"expo-"] && ([file hasSuffix:@".db"] || [file containsString:@".db-"])) {
+        continue;
+      }
+      NSString *filePath = [assetsFolder URLByAppendingPathComponent:file].path;
+      NSError *deleteError;
+      BOOL success = [NSFileManager.defaultManager removeItemAtPath:filePath error:&deleteError];
+      if (!success) {
+        reject(@"ERR_UPDATES_E2E_CLEAR", deleteError.localizedDescription, deleteError);
+        return;
+      }
+    }
+    resolve(nil);
+  });
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/e2e/__tests__/fixtures/UpdatesE2ETestModule.kt
+++ b/packages/expo-updates/e2e/__tests__/fixtures/UpdatesE2ETestModule.kt
@@ -1,0 +1,36 @@
+package expo.modules.updates
+
+import android.content.Context
+import expo.modules.core.ExportedModule
+import expo.modules.core.Promise
+import expo.modules.core.interfaces.ExpoMethod
+import java.util.*
+
+class UpdatesE2ETestModule(context: Context) : ExportedModule(context) {
+  override fun getName() = "ExpoUpdatesE2ETest"
+
+  @ExpoMethod
+  fun clearInternalAssetsFolderAsync(promise: Promise) {
+    try {
+      val assetsFolder = UpdatesController.instance.updatesDirectory
+      assetsFolder!!.deleteRecursively()
+      promise.resolve(null)
+    } catch (e: Throwable) {
+      promise.reject(e)
+    }
+  }
+
+  @ExpoMethod
+  fun readInternalAssetsFolderAsync(promise: Promise) {
+    try {
+      val assetsFolder = UpdatesController.instance.updatesDirectory
+      if (!assetsFolder!!.exists()) {
+        return promise.resolve(0)
+      }
+      val count = assetsFolder.walk().count() - 1 // subtract one for the folder itself, which is included in walk()
+      promise.resolve(count)
+    } catch (e: Throwable) {
+      promise.reject(e)
+    }
+  }
+}

--- a/packages/expo-updates/e2e/__tests__/setup/index.js
+++ b/packages/expo-updates/e2e/__tests__/setup/index.js
@@ -46,4 +46,8 @@ const runtimeVersion = '1.0.0';
   await setupAssetsAppAsync(projectRoot);
   await buildAndroidAsync(projectRoot, artifactsDest, 'assets');
   await buildIosAsync(projectRoot, artifactsDest, 'assets');
+
+  // build the same app a second time for tests involving overwriting installation
+  await buildAndroidAsync(projectRoot, artifactsDest, 'assets2');
+  await buildIosAsync(projectRoot, artifactsDest, 'assets2');
 })();


### PR DESCRIPTION
# Why

Resolves ENG-2473 (!)

This adds a new test suite to test the behavior of expo-updates when assets are unexpectedly missing from internal storage -- i.e. according to SQLite we should have them on disk, but we do not.

There is fallback code present in DatabaseLauncher to handle this scenario, but it's very difficult to test regularly and ensure we aren't regressing -- and this code has failed at critical times in the past. These tests are intended to catch future issues like #15112 and #14930 and prevent them from leaking out into production.

# How

- In order to set up these tests, we need a way to clear the .expo-internal storage folder where assets are stored on disk. This isn't easily possible on an Android emulator through adb, so I added an exported JS module `ExpoUpdatesE2ETest` which exposes the ability to do this to JS.
- Set up some handling in App-assets.js and the Server module so that the test runner can send commands back into the app running on the simulator, allowing it to determine when `clearInternalAssetsFolderAsync` should be called.
- Write tests for the 3 scenarios described in ENG-2473, adding comments to explain what is going on.

# Test Plan

New tests pass locally, let's see about CI...

Also locally, I reverted the 4 commits that fixed the issues we saw in production in November -- #14984, #15008, #15049, and #15123, and confirmed that with these reverts in place, the new tests **do indeed fail** where expected. So we can be confident they will actually catch regressions in the desired behavior.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
