### PR TITLE
[dev-launcher][Android] Redesign the splash screen

### DIFF
--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/splashscreen/DevLauncherSplashScreen.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/splashscreen/DevLauncherSplashScreen.kt
@@ -2,27 +2,35 @@ package expo.modules.devlauncher.splashscreen
 
 import android.annotation.SuppressLint
 import android.content.Context
-import android.view.Gravity
+import android.graphics.Color
+import android.util.TypedValue
+import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.RelativeLayout
-import android.widget.TextView
 import expo.modules.devlauncher.R
 
 @SuppressLint("ViewConstructor")
 class DevLauncherSplashScreen(
   context: Context,
-  textColor: Int
 ) : RelativeLayout(context) {
   init {
-    val textView = TextView(context)
-    textView.text = context.getString(R.string.splash_screen_text)
-    textView.gravity = Gravity.CENTER
-    textView.textSize = 24F
-    textView.layoutParams = LayoutParams(
-      LinearLayout.LayoutParams.MATCH_PARENT,
-      LinearLayout.LayoutParams.MATCH_PARENT
+    setBackgroundColor(Color.WHITE)
+
+    val imageWidthDPI = 85f
+    val imageWidthPixels = TypedValue.applyDimension(
+      TypedValue.COMPLEX_UNIT_DIP,
+      imageWidthDPI,
+      context.resources.displayMetrics
     )
-    textView.setTextColor(textColor)
-    addView(textView)
+
+    val imageView = ImageView(context)
+    imageView.setImageResource(R.drawable._expodevclientcomponents_assets_logoicon)
+    imageView.layoutParams = LayoutParams(
+      imageWidthPixels.toInt(),
+      LinearLayout.LayoutParams.WRAP_CONTENT,
+    ).apply {
+      addRule(CENTER_IN_PARENT, TRUE)
+    }
+    addView(imageView)
   }
 }

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/splashscreen/DevLauncherSplashScreenProvider.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/splashscreen/DevLauncherSplashScreenProvider.kt
@@ -1,49 +1,18 @@
 package expo.modules.devlauncher.splashscreen
 
 import android.app.Activity
-import android.content.Context
-import android.graphics.Color
 import android.view.ViewGroup
-import androidx.core.graphics.ColorUtils
 
 class DevLauncherSplashScreenProvider {
   fun attachSplashScreenViewAsync(activity: Activity): DevLauncherSplashScreen? {
     val contentView = activity.findViewById<ViewGroup>(android.R.id.content)
       ?: return null
-    val backgroundColor = getBackgroundColor(activity)
+
     val splashScreenView = DevLauncherSplashScreen(
       activity,
-      getTextColorForBackgroundColor(backgroundColor)
     )
-    splashScreenView.setBackgroundColor(backgroundColor)
+
     contentView.addView(splashScreenView)
-
     return splashScreenView
-  }
-
-  private fun getBackgroundColor(context: Context): Int {
-    val expoSplashScreenColor = context
-      .resources
-      .getIdentifier(
-        "splashscreen_background",
-        "drawable",
-        context.packageName
-      )
-
-    return if (expoSplashScreenColor == 0) {
-      // splashscreen_background doesn't exist
-      Color.parseColor("#000020")
-    } else {
-      expoSplashScreenColor
-    }
-  }
-
-  private fun getTextColorForBackgroundColor(backgroundColor: Int): Int {
-    val luminance = ColorUtils.calculateLuminance(backgroundColor)
-    return if (luminance > 0.5) {
-      Color.BLACK
-    } else {
-      Color.WHITE
-    }
   }
 }


### PR DESCRIPTION
# Why

Redesigns the splash screen on Android. Right now, we 3 different splash screens:
- app one 
- native one 
- from the launcher app.

The native one and the one from the js app were looking differently. So I made them look the same. 

> Note:
We don't have to do the same on iOS, because we don't have a native splash screen there.

# How

Made the native screen similar to the one from the js. 

# Test Plan

- bare-expo ✅