### PR TITLE
[docs]: Use `kbd` elements for press keyboard keys

### DIFF
--- a/docs/pages/get-started/create-a-new-app.md
+++ b/docs/pages/get-started/create-a-new-app.md
@@ -6,6 +6,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 
 Before creating a new Expo app, you have to make sure that:
+
 - Expo CLI is installed on your development machine
 - Expo Go app is installed on your iOS or Android physical device or emulator
 
@@ -14,11 +15,11 @@ If you have not installed any of these tools, go back to the [Installation](/get
 ## Initializing the project
 
 <Terminal cmd={[
-  '# Create a project named my-app',
-  '$ npx create-expo-app my-app',
-  '',
-  '# Navigate to the project directory',
-  '$ cd my-app'
+'# Create a project named my-app',
+'$ npx create-expo-app my-app',
+'',
+'# Navigate to the project directory',
+'$ cd my-app'
 ]} cmdCopy="npx create-expo-app my-app && cd my-app" />
 
 ## Starting the development server
@@ -54,9 +55,9 @@ If it still doesn't work, it may be due to the router configuration &mdash; this
 
 If you are using a simulator or emulator, you may find the following Expo CLI keyboard shortcuts to be useful to open the app on any of the following platforms:
 
-- Pressing `i` will open in an [iOS simulator](/workflow/ios-simulator).
-- Pressing `a` will open in an [Android Emulator or connected device](/workflow/android-studio-emulator).
-- Pressing `w` will open in a web browser. Expo supports all major browsers.
+- Pressing <kbd>I</kbd> will open in an [iOS simulator](/workflow/ios-simulator).
+- Pressing <kbd>A</kbd> will open in an [Android Emulator or connected device](/workflow/android-studio-emulator).
+- Pressing <kbd>W</kbd> will open in a web browser. Expo supports all major browsers.
 
 </Collapsible>
 
@@ -70,7 +71,7 @@ Expo Go is configured by default to automatically reload the app whenever a file
 
 - Make sure the you have the [development mode enabled in Expo CLI](/workflow/development-mode#development-mode).
 - Close the Expo app and reopen it.
-- Once the app is open again, shake your device to reveal the developer menu. If you are using an emulator, press `⌘+d` for iOS or `ctrl+m` for Android.
+- Once the app is open again, shake your device to reveal the developer menu. If you are using an emulator, press <kbd>⌘</kbd> + <kbd>D</kbd> for iOS or <kbd>Ctrl</kbd> + <kbd>M</kbd> for Android.
 - If you see `Enable Fast Refresh`, press it. If you see `Disable Fast Refresh`, dismiss the developer menu. Now try making another change.
 
   ![In-app developer menu](/static/images/developer-menu.png)

--- a/docs/pages/workflow/debugging.md
+++ b/docs/pages/workflow/debugging.md
@@ -64,9 +64,9 @@ Below are a few tools we recommend, and use ourselves, when it comes to debuggin
 This menu gives you access to several functions which are useful for debugging, and is built into the Expo Go app. The way you open it is a bit different depending on where you're running the Expo Go app:
 
 - iOS Device: Shake the device a little bit, or touch 3 fingers to the screen.
-- iOS Simulator: Hit `Ctrl-Cmd-Z` on a Mac in the emulator to simulate the shake gesture, or press `Cmd+D`.
+- iOS Simulator: Hit <kbd>Ctrl</kbd> + <kbd>⌘</kbd> + <kbd>Z</kbd> on a Mac in the emulator to simulate the shake gesture, or press <kbd>⌘</kbd> + <kbd>D</kbd>.
 - Android Device: Shake the device vertically a little bit, or run `adb shell input keyevent 82` in your terminal window if your device is connected via USB.
-- Android Emulator: Either hit `Cmd+M` (`Ctrl+M` on Windows), or run `adb shell input keyevent 82` in your terminal window.
+- Android Emulator: Either hit <kbd>⌘</kbd> + <kbd>M</kbd> or <kbd>Ctrl</kbd> + <kbd>M</kbd> or run `adb shell input keyevent 82` in your terminal window.
 
 The Developer Menu gives you a couple different functionalities. A few are pretty self-explanatory, like:
 
@@ -101,7 +101,7 @@ You can install it via the [release page](https://github.com/jhen0409/react-nati
 
 ### Startup
 
-After firing up React Native Debugger, you'll need to specify the port (shortcuts: `Command+T` on macOS, `Ctrl+T` on Linux/Windows) to `19000` (if you use SDK <= 39, the port should be `19001`>). After that, run your project with `expo start`, and select `Debug remote JS` from the Developer Menu. The debugger should automatically connect.
+After firing up React Native Debugger, you'll need to specify the port (shortcuts: <kbd>⌘</kbd> + <kbd>T</kbd> on macOS, <kbd>Ctrl</kbd> + <kbd>T</kbd> on Linux/Windows) to `19000` (if you use SDK <= 39, the port should be `19001`>). After that, run your project with `expo start`, and select `Debug remote JS` from the Developer Menu. The debugger should automatically connect.
 
 In the debugger console, you can see the Element tree, as well as the props, state, and children of whatever element you select. You also have the Chrome console on the right, and if you type `$r` in the console, you will see the breakdown of your selected element.
 
@@ -127,7 +127,7 @@ There are however [some limitations](https://github.com/jhen0409/react-native-de
 [Redux](https://redux.js.org/) is a popular library for managing and centralizing application state shared throughout the app. You can use Redux DevTools on React Native Debugger for debugging the application's state changes. The setup is as follows:
 
 1. Download React Native Debugger from the [releases page](https://github.com/jhen0409/react-native-debugger/releases).
-2. Open the app, press `⌘+t`/`ctrl+t` to open new window, then set the port to 19000.
+2. Open the app, press <kbd>⌘</kbd> + <kbd>T</kbd> or <kbd>Ctrl</kbd> + <kbd>T</kbd> to open a new window, then set the port to 19000.
 3. Start your app, open the in-app developer menu, and select “Debug JS Remotely.”
 4. Configure `__REDUX_DEVTOOLS_EXTENSION__` as [shown here](https://github.com/zalmoxisus/redux-devtools-extension#11-basic-store).
 
@@ -138,8 +138,8 @@ You're now good to go! If you are experiencing any issues or want to learn more 
 React DevTools is a great way to get a look at each of your components' props and state. First, you'll need to run
 
 <Terminal
-  cmdCopy="npm install -g react-devtools"
-  cmd={['# Install React DevTools with npm', '$ npm install -g react-devtools', '', '# If you are using Expo SDK <= 37: npm install -g react-devtools@^3']}
+cmdCopy="npm install -g react-devtools"
+cmd={['# Install React DevTools with npm', '$ npm install -g react-devtools', '', '# If you are using Expo SDK <= 37: npm install -g react-devtools@^3']}
 />
 
 (if you don't want to install it globally, run `npm install --dev react-devtools` to install it as a project dependency).

--- a/docs/pages/workflow/development-mode.md
+++ b/docs/pages/workflow/development-mode.md
@@ -24,11 +24,11 @@ React Native includes some very useful tools for development: remote JavaScript 
 
 The Developer Menu gives you access to a host of features that make development and debugging much easier. Invoking it depends on the device where you are running your application:
 
-- Terminal UI: Press `m` in the terminal to open the menu on connected iOS and Android
+- Terminal UI: Press <kbd>M</kbd> in the terminal to open the menu on connected iOS and Android
 - iOS Device: Shake the device a little bit.
-- iOS Simulator: Hit `Ctrl-Cmd-Z` on a Mac in the emulator to simulate the shake gesture, or press `Cmd+D`.
+- iOS Simulator: Hit <kbd>Ctrl</kbd> + <kbd>⌘</kbd> + <kbd>Z</kbd> on a Mac in the emulator to simulate the shake gesture, or press <kbd>⌘</kbd> + <kbd>D</kbd>.
 - Android Device: Shake the device vertically a little bit.
-- Android Emulator: Either hit `Cmd+M`, or run `adb shell input keyevent 82` in your terminal window.
+- Android Emulator: Either hit <kbd>⌘</kbd> + <kbd>M</kbd> or <kbd>Ctrl</kbd> + <kbd>M</kbd> or run `adb shell input keyevent 82` in your terminal window.
 
 ## Production Mode
 

--- a/docs/pages/workflow/logging.md
+++ b/docs/pages/workflow/logging.md
@@ -10,7 +10,7 @@ When you open an app that is being served from Expo CLI, the app will send logs 
 
 ### Viewing logs with Expo CLI
 
-If you use our command line tool Expo CLI, bundler logs and app logs will both automatically stream as long as your project is running. To stop your project (and end the logs stream), terminate the process with `ctrl+C`.
+If you use our command line tool Expo CLI, bundler logs and app logs will both automatically stream as long as your project is running. To stop your project (and end the logs stream), terminate the process with <kbd>Ctrl</kbd> + <kbd>C</kbd>.
 
 ## Optional: Manually access device logs
 
@@ -30,7 +30,7 @@ The following instructions apply to macOS.
 
 #### Option 1: Use GUI log
 
-- In simulator, press `⌘ + /`, _or_ go to `Debug -> Open System Log` -- both of these open a log window that displays all of the logs from your device, including the logs from your Expo app.
+- In simulator, press <kbd>⌘</kbd> + <kbd>/</kbd>, _or_ go to `Debug -> Open System Log` -- both of these open a log window that displays all of the logs from your device, including the logs from your Expo app.
 
 #### Option 2: Open it in terminal
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR:
- Replaces the inconsistent use of `Cmd+D` or `Cmd+t` (upper and lower case keys) with the new `kbd` element in multiple places across different docs

For example:
![CleanShot 2022-07-20 at 17 46 59@2x](https://user-images.githubusercontent.com/10234615/179979911-93d14222-c3a7-4c2e-a879-05c2281da858.jpg)


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

All changes have been tested by running the `docs/` locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
