### PR TITLE
fix(cli): ensure `expo build:web` recommends running `expo export:web` 

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Ensure `expo build:web` recommends running `expo export:web` in the migration warning.
+
 ### 💡 Others
 
 ## 0.2.5 — 2022-07-19

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Ensure `expo build:web` recommends running `expo export:web` in the migration warning.
+- Ensure `expo build:web` recommends running `expo export:web` in the migration warning. ([#18312](https://github.com/expo/expo/pull/18312) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/bin/cli.ts
+++ b/packages/@expo/cli/bin/cli.ts
@@ -127,7 +127,7 @@ if (!isSubcommand) {
     'publish:history': 'eas update',
     'publish:details': 'eas update',
 
-    'build:web': 'npx expo export',
+    'build:web': 'npx expo export:web',
 
     'credentials:manager': `eas credentials`,
     'fetch:ios:certs': `eas credentials`,

--- a/packages/@expo/cli/bin/cli.ts
+++ b/packages/@expo/cli/bin/cli.ts
@@ -117,8 +117,8 @@ if (!isSubcommand) {
     'build:android': 'eas build -p android',
     'client:install:ios': 'npx expo start --ios',
     'client:install:android': 'npx expo start --android',
-    doctor: 'expo doctor',
-    upgrade: 'expo upgrade',
+    doctor: 'expo-cli doctor',
+    upgrade: 'expo-cli upgrade',
     'customize:web': 'npx expo customize',
 
     publish: 'eas update',


### PR DESCRIPTION
# Why

- Migration warning needed an update.
- `expo export` is currently Metro-only meaning it would technically work in the future with Metro web, but it's currently the wrong recommendation.

