### PR TITLE
[expo-updates][Android] Logging and log reading

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [Android] Logging and log reading. ([#18318](https://github.com/expo/expo/pull/18318) by [@douglowder](https://github.com/douglowder))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- [Android] Logging and log reading. ([#18318](https://github.com/expo/expo/pull/18318) by [@douglowder](https://github.com/douglowder))
+- [Android] New logger and log reader for unifying logging support in expo-updates. ([#18318](https://github.com/expo/expo/pull/18318) by [@douglowder](https://github.com/douglowder))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/logging/UpdatesLoggingTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/logging/UpdatesLoggingTest.kt
@@ -1,9 +1,5 @@
 package expo.modules.updates.logging
 
-import expo.modules.updates.logging.UpdatesErrorCode
-import expo.modules.updates.logging.UpdatesLogEntry
-import expo.modules.updates.logging.UpdatesLogReader
-import expo.modules.updates.logging.UpdatesLogger
 import expo.modules.updates.logging.UpdatesLogger.Companion.MAX_FRAMES_IN_STACKTRACE
 import junit.framework.TestCase
 import org.junit.Assert
@@ -44,9 +40,10 @@ class UpdatesLoggingTest : TestCase() {
     logger.warn("Test message", UpdatesErrorCode.JSRuntimeError)
     val now = Date()
     val nowTimestamp = now.time / 1000
+    val expectedLogEntryString = "{\"timestamp\":$nowTimestamp,\"message\":\"Test message\",\"code\":\"JSRuntimeError\",\"level\":\"warn\"}"
     val sinceThen = Date(now.time - 5000)
     val logs = UpdatesLogReader().getLogEntries(sinceThen)
-    Assert.assertTrue(logs.any { it.contains("{\"timestamp\":$nowTimestamp,\"message\":\"Test message\",\"code\":\"JSRuntimeError\",\"level\":\"warn\"}") })
+    Assert.assertTrue(logs.any { it == expectedLogEntryString })
   }
 
   @Test
@@ -56,19 +53,18 @@ class UpdatesLoggingTest : TestCase() {
     logger.info("Message 1", UpdatesErrorCode.None)
     Thread.sleep(2000)
     val secondTime = Date()
-    Thread.sleep(2000)
     logger.error("Message 2", UpdatesErrorCode.NoUpdatesAvailable)
 
     val reader = UpdatesLogReader()
 
     val firstLogs = reader.getLogEntries(firstTime)
-    Assert.assertEquals(2, firstlogs.size)
+    Assert.assertEquals(2, firstLogs.size)
     Assert.assertEquals("Message 1", UpdatesLogEntry.create(firstLogs[0]).message)
     Assert.assertEquals("Message 2", UpdatesLogEntry.create(firstLogs[1]).message)
 
     val secondLogs = reader.getLogEntries(secondTime)
-    Assert.assertEquals(1, secondlogs.size)
-    Assert.assertEquals("Message 2", UpdatesLogEntry.create(secondLogs.[0]).message)
+    Assert.assertEquals(1, secondLogs.size)
+    Assert.assertEquals("Message 2", UpdatesLogEntry.create(secondLogs[0]).message)
     Assert.assertEquals(MAX_FRAMES_IN_STACKTRACE, UpdatesLogEntry.create(secondLogs[0]).stacktrace?.size)
   }
 }

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/logging/UpdatesLoggingTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/logging/UpdatesLoggingTest.kt
@@ -46,13 +46,7 @@ class UpdatesLoggingTest : TestCase() {
     val nowTimestamp = now.time / 1000
     val sinceThen = Date(now.time - 5000)
     val logs = UpdatesLogReader().getLogEntries(sinceThen)
-    var testPassed = false
-    for (log in logs) {
-      if (log.contains("{\"timestamp\":$nowTimestamp,\"message\":\"Test message\",\"code\":\"JSRuntimeError\",\"level\":\"warn\"}")) {
-        testPassed = true
-      }
-    }
-    Assert.assertTrue(testPassed)
+    Assert.assertTrue(logs.any { it.contains("{\"timestamp\":$nowTimestamp,\"message\":\"Test message\",\"code\":\"JSRuntimeError\",\"level\":\"warn\"}") })
   }
 
   @Test

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/logging/UpdatesLoggingTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/logging/UpdatesLoggingTest.kt
@@ -72,7 +72,7 @@ class UpdatesLoggingTest : TestCase() {
     Assert.assertEquals("Message 1", UpdatesLogEntry.create(firstLogs[0]).message)
     Assert.assertEquals("Message 2", UpdatesLogEntry.create(firstLogs[1]).message)
 
-    val secondlogs = reader.getLogEntries(secondTime)
+    val secondLogs = reader.getLogEntries(secondTime)
     Assert.assertEquals(1, secondlogs.size)
     Assert.assertEquals("Message 2", UpdatesLogEntry.create(secondlogs?.get(0)).message)
     Assert.assertEquals(MAX_FRAMES_IN_STACKTRACE, UpdatesLogEntry.create(secondlogs?.get(0)).stacktrace?.size)

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/logging/UpdatesLoggingTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/logging/UpdatesLoggingTest.kt
@@ -54,7 +54,8 @@ class UpdatesLoggingTest : TestCase() {
     Thread.sleep(2000)
     val secondTime = Date()
     logger.error("Message 2", UpdatesErrorCode.NoUpdatesAvailable)
-
+    Thread.sleep(1000)
+    val thirdTime = Date()
     val reader = UpdatesLogReader()
 
     val firstLogs = reader.getLogEntries(firstTime)
@@ -66,5 +67,8 @@ class UpdatesLoggingTest : TestCase() {
     Assert.assertEquals(1, secondLogs.size)
     Assert.assertEquals("Message 2", UpdatesLogEntry.create(secondLogs[0]).message)
     Assert.assertEquals(MAX_FRAMES_IN_STACKTRACE, UpdatesLogEntry.create(secondLogs[0]).stacktrace?.size)
+
+    val thirdLogs = reader.getLogEntries(thirdTime)
+    Assert.assertEquals(0, thirdLogs.size)
   }
 }

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/logging/UpdatesLoggingTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/logging/UpdatesLoggingTest.kt
@@ -1,4 +1,4 @@
-package expo.modules.updates
+package expo.modules.updates.logging
 
 import expo.modules.updates.logging.UpdatesErrorCode
 import expo.modules.updates.logging.UpdatesLogEntry

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/logging/UpdatesLoggingTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/logging/UpdatesLoggingTest.kt
@@ -67,7 +67,7 @@ class UpdatesLoggingTest : TestCase() {
 
     val reader = UpdatesLogReader()
 
-    val firstlogs = reader.getLogEntries(firstTime)
+    val firstLogs = reader.getLogEntries(firstTime)
     Assert.assertEquals(2, firstlogs.size)
     Assert.assertEquals("Message 1", UpdatesLogEntry.create(firstLogs[0]).message)
     Assert.assertEquals("Message 2", UpdatesLogEntry.create(firstLogs[1]).message)

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/logging/UpdatesLoggingTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/logging/UpdatesLoggingTest.kt
@@ -74,7 +74,7 @@ class UpdatesLoggingTest : TestCase() {
 
     val secondLogs = reader.getLogEntries(secondTime)
     Assert.assertEquals(1, secondlogs.size)
-    Assert.assertEquals("Message 2", UpdatesLogEntry.create(secondlogs?.get(0)).message)
-    Assert.assertEquals(MAX_FRAMES_IN_STACKTRACE, UpdatesLogEntry.create(secondlogs?.get(0)).stacktrace?.size)
+    Assert.assertEquals("Message 2", UpdatesLogEntry.create(secondLogs.[0]).message)
+    Assert.assertEquals(MAX_FRAMES_IN_STACKTRACE, UpdatesLogEntry.create(secondLogs[0]).stacktrace?.size)
   }
 }

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/logging/UpdatesLoggingTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/logging/UpdatesLoggingTest.kt
@@ -69,8 +69,8 @@ class UpdatesLoggingTest : TestCase() {
 
     val firstlogs = reader.getLogEntries(firstTime)
     Assert.assertEquals(2, firstlogs.size)
-    Assert.assertEquals("Message 1", UpdatesLogEntry.create(firstlogs?.get(0)).message)
-    Assert.assertEquals("Message 2", UpdatesLogEntry.create(firstlogs?.get(1)).message)
+    Assert.assertEquals("Message 1", UpdatesLogEntry.create(firstLogs[0]).message)
+    Assert.assertEquals("Message 2", UpdatesLogEntry.create(firstLogs[1]).message)
 
     val secondlogs = reader.getLogEntries(secondTime)
     Assert.assertEquals(1, secondlogs.size)

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/logging/UpdatesLoggingTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/logging/UpdatesLoggingTest.kt
@@ -1,0 +1,80 @@
+package expo.modules.updates
+
+import expo.modules.updates.logging.UpdatesErrorCode
+import expo.modules.updates.logging.UpdatesLogEntry
+import expo.modules.updates.logging.UpdatesLogReader
+import expo.modules.updates.logging.UpdatesLogger
+import expo.modules.updates.logging.UpdatesLogger.Companion.MAX_FRAMES_IN_STACKTRACE
+import junit.framework.TestCase
+import org.junit.Assert
+import org.junit.Test
+import java.util.*
+
+class UpdatesLoggingTest : TestCase() {
+
+  @Test
+  fun testLogEntryConversion() {
+    val entry = UpdatesLogEntry(12345678, "Test message", "NoUpdatesAvailable", "warn", null, null, null)
+    val json = entry.asString()
+    val entryCopy = UpdatesLogEntry.create(json)
+    Assert.assertEquals(entry.message, entryCopy.message)
+    Assert.assertEquals(entry.timestamp, entryCopy.timestamp)
+    Assert.assertEquals(entry.code, entryCopy.code)
+    Assert.assertEquals(entry.level, entryCopy.level)
+    Assert.assertNull(entryCopy.updateId)
+    Assert.assertNull(entryCopy.assetId)
+    Assert.assertNull(entryCopy.stacktrace)
+
+    val entry2 = UpdatesLogEntry(12345678, "Test message", "UpdateFailedToLoad", "fatal", "myUpdateId", "myAssetId", listOf("stack frame 1", "stack frame 2"))
+    val json2 = entry2.asString()
+    val entryCopy2 = UpdatesLogEntry.create(json2)
+    Assert.assertEquals(entry2.message, entryCopy2.message)
+    Assert.assertEquals(entry2.timestamp, entryCopy2.timestamp)
+    Assert.assertEquals(entry2.code, entryCopy2.code)
+    Assert.assertEquals(entry2.level, entryCopy2.level)
+    Assert.assertEquals(entry2.updateId, entryCopy2.updateId)
+    Assert.assertEquals(entry2.assetId, entryCopy2.assetId)
+    Assert.assertNotNull(entryCopy2.stacktrace)
+    Assert.assertEquals(entry2.stacktrace?.size, entryCopy2.stacktrace?.size)
+  }
+
+  @Test
+  fun testOneLogAppears() {
+    val logger = UpdatesLogger()
+    logger.warn("Test message", UpdatesErrorCode.JSRuntimeError)
+    val now = Date()
+    val nowTimestamp = now.time / 1000
+    val sinceThen = Date(now.time - 5000)
+    val logs = UpdatesLogReader().getLogEntries(sinceThen)
+    var testPassed = false
+    for (log in logs) {
+      if (log.contains("{\"timestamp\":$nowTimestamp,\"message\":\"Test message\",\"code\":\"JSRuntimeError\",\"level\":\"warn\"}")) {
+        testPassed = true
+      }
+    }
+    Assert.assertTrue(testPassed)
+  }
+
+  @Test
+  fun testLogReaderTimeLimit() {
+    val logger = UpdatesLogger()
+    val firstTime = Date()
+    logger.info("Message 1", UpdatesErrorCode.None)
+    Thread.sleep(2000)
+    val secondTime = Date()
+    Thread.sleep(2000)
+    logger.error("Message 2", UpdatesErrorCode.NoUpdatesAvailable)
+
+    val reader = UpdatesLogReader()
+
+    val firstlogs = reader.getLogEntries(firstTime)
+    Assert.assertEquals(2, firstlogs.size)
+    Assert.assertEquals("Message 1", UpdatesLogEntry.create(firstlogs?.get(0)).message)
+    Assert.assertEquals("Message 2", UpdatesLogEntry.create(firstlogs?.get(1)).message)
+
+    val secondlogs = reader.getLogEntries(secondTime)
+    Assert.assertEquals(1, secondlogs.size)
+    Assert.assertEquals("Message 2", UpdatesLogEntry.create(secondlogs?.get(0)).message)
+    Assert.assertEquals(MAX_FRAMES_IN_STACKTRACE, UpdatesLogEntry.create(secondlogs?.get(0)).stacktrace?.size)
+  }
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/logging/UpdatesErrorCode.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/logging/UpdatesErrorCode.kt
@@ -1,0 +1,31 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+// Error codes for expo-updates logs
+
+package expo.modules.updates.logging
+
+enum class UpdatesErrorCode(val code: Int) {
+  None(0),
+  NoUpdatesAvailable(1),
+  UpdateAssetsNotAvailable(2),
+  UpdateServerUnreachable(3),
+  UpdateHasInvalidSignature(4),
+  UpdateFailedToLoad(5),
+  AssetsFailedToLoad(6),
+  JSRuntimeError(7);
+
+  companion object {
+    fun asString(code: UpdatesErrorCode): String {
+      return when (code) {
+        None -> "None"
+        NoUpdatesAvailable -> "NoUpdatesAvailable"
+        UpdateAssetsNotAvailable -> "UpdateAssetsNotAvailable"
+        UpdateServerUnreachable -> "UpdateServerUnreachable"
+        UpdateHasInvalidSignature -> "UpdateHasInvalidSignature"
+        UpdateFailedToLoad -> "UpdateFailedToLoad"
+        AssetsFailedToLoad -> "AssetsFailedToLoad"
+        JSRuntimeError -> "JSRuntimeError"
+      }
+    }
+  }
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/logging/UpdatesErrorCode.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/logging/UpdatesErrorCode.kt
@@ -1,31 +1,15 @@
-// Copyright 2022-present 650 Industries. All rights reserved.
-
-// Error codes for expo-updates logs
-
 package expo.modules.updates.logging
 
-enum class UpdatesErrorCode(val code: Int) {
-  None(0),
-  NoUpdatesAvailable(1),
-  UpdateAssetsNotAvailable(2),
-  UpdateServerUnreachable(3),
-  UpdateHasInvalidSignature(4),
-  UpdateFailedToLoad(5),
-  AssetsFailedToLoad(6),
-  JSRuntimeError(7);
-
-  companion object {
-    fun asString(code: UpdatesErrorCode): String {
-      return when (code) {
-        None -> "None"
-        NoUpdatesAvailable -> "NoUpdatesAvailable"
-        UpdateAssetsNotAvailable -> "UpdateAssetsNotAvailable"
-        UpdateServerUnreachable -> "UpdateServerUnreachable"
-        UpdateHasInvalidSignature -> "UpdateHasInvalidSignature"
-        UpdateFailedToLoad -> "UpdateFailedToLoad"
-        AssetsFailedToLoad -> "AssetsFailedToLoad"
-        JSRuntimeError -> "JSRuntimeError"
-      }
-    }
-  }
+/**
+ * Error codes for expo-updates logs
+ */
+enum class UpdatesErrorCode(val code: String) {
+  None("None"),
+  NoUpdatesAvailable("NoUpdatesAvailable"),
+  UpdateAssetsNotAvailable("UpdateAssetsNotAvailable"),
+  UpdateServerUnreachable("UpdateServerUnreachable"),
+  UpdateHasInvalidSignature("UpdateHasInvalidSignature"),
+  UpdateFailedToLoad("UpdateFailedToLoad"),
+  AssetsFailedToLoad("AssetsFailedToLoad"),
+  JSRuntimeError("JSRuntimeError")
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/logging/UpdatesLogEntry.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/logging/UpdatesLogEntry.kt
@@ -18,22 +18,22 @@ data class UpdatesLogEntry(
   val stacktrace: List<String>?,
 ) {
   fun asString(): String {
-    val o = JSONObject()
-    o.put("timestamp", timestamp)
-    o.put("message", message)
-    o.put("code", code)
-    o.put("level", level)
-    if (updateId != null) {
-      o.put("updateId", updateId)
-    }
-    if (assetId != null) {
-      o.put("assetId", assetId)
-    }
-    if (stacktrace != null && stacktrace.isNotEmpty()) {
-      val a = JSONArray(stacktrace)
-      o.put("stacktrace", a)
-    }
-    return o.toString()
+    return JSONObject(mapOf(
+      "timestamp" to timestamp,
+      "message" to message,
+      "code" to code,
+      "level" to level
+    )).apply {
+      if (updateId != null) {
+        put("updateId", updateId)
+      }
+      if (assetId != null) {
+        put("assetId", assetId)
+      }
+      if (stacktrace != null && stacktrace.isNotEmpty()) {
+        put("stacktrace", JSONArray(stacktrace))
+      }
+    }.toString()
   }
 
   companion object {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/logging/UpdatesLogEntry.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/logging/UpdatesLogEntry.kt
@@ -38,25 +38,18 @@ data class UpdatesLogEntry(
 
   companion object {
     fun create(json: String): UpdatesLogEntry {
-      val jsonObject = JSONTokener(json).nextValue() as JSONObject
-      val timestamp = jsonObject.getLong("timestamp")
-      val message = jsonObject.getString("message")
-      val code = jsonObject.getString("code")
-      val level = jsonObject.getString("level")
-      val updateId = jsonObject.optString("updateId", null)
-      val assetId = jsonObject.optString("assetId", null)
-      val jsonArray = jsonObject.optJSONArray("stacktrace")
-
-      var stacktrace: List<String>? = null
-
-      if (jsonArray != null) {
-        stacktrace = mutableListOf()
-        for (i in 0 until jsonArray.length()) {
-          stacktrace.add(jsonArray.getString(i))
+      val jsonObject = JSONObject(json)
+      return UpdatesLogEntry(
+        jsonObject.require("timestamp"), 
+        jsonObject.require("message"), 
+        jsonObject.require("code"), 
+        jsonObject.require("level"), 
+        jsonObject.getNullable("updateId"), 
+        jsonObject.getNullable("assetId"),
+        jsonObject.getNullable<JSONArray>("stacktrace")?.let { jsonArray ->
+          List(jsonArray.length()) { i -> jsonArray.getString(i) }
         }
-      }
-
-      return UpdatesLogEntry(timestamp, message, code, level, updateId, assetId, stacktrace)
+      )
     }
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/logging/UpdatesLogEntry.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/logging/UpdatesLogEntry.kt
@@ -1,13 +1,13 @@
-// Copyright 2022-present 650 Industries. All rights reserved.
-
-// Schema for the fields in expo-updates log message JSON strings
-
 package expo.modules.updates.logging
 
+import expo.modules.jsonutils.getNullable
+import expo.modules.jsonutils.require
 import org.json.JSONArray
 import org.json.JSONObject
-import org.json.JSONTokener
 
+/**
+ * Schema for the fields in expo-updates log message JSON strings
+ */
 data class UpdatesLogEntry(
   val timestamp: Long,
   val message: String,
@@ -18,12 +18,14 @@ data class UpdatesLogEntry(
   val stacktrace: List<String>?,
 ) {
   fun asString(): String {
-    return JSONObject(mapOf(
-      "timestamp" to timestamp,
-      "message" to message,
-      "code" to code,
-      "level" to level
-    )).apply {
+    return JSONObject(
+      mapOf(
+        "timestamp" to timestamp,
+        "message" to message,
+        "code" to code,
+        "level" to level
+      )
+    ).apply {
       if (updateId != null) {
         put("updateId", updateId)
       }
@@ -40,11 +42,11 @@ data class UpdatesLogEntry(
     fun create(json: String): UpdatesLogEntry {
       val jsonObject = JSONObject(json)
       return UpdatesLogEntry(
-        jsonObject.require("timestamp"), 
-        jsonObject.require("message"), 
-        jsonObject.require("code"), 
-        jsonObject.require("level"), 
-        jsonObject.getNullable("updateId"), 
+        jsonObject.require("timestamp"),
+        jsonObject.require("message"),
+        jsonObject.require("code"),
+        jsonObject.require("level"),
+        jsonObject.getNullable("updateId"),
         jsonObject.getNullable("assetId"),
         jsonObject.getNullable<JSONArray>("stacktrace")?.let { jsonArray ->
           List(jsonArray.length()) { i -> jsonArray.getString(i) }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/logging/UpdatesLogEntry.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/logging/UpdatesLogEntry.kt
@@ -1,0 +1,62 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+// Schema for the fields in expo-updates log message JSON strings
+
+package expo.modules.updates.logging
+
+import org.json.JSONArray
+import org.json.JSONObject
+import org.json.JSONTokener
+
+data class UpdatesLogEntry(
+  val timestamp: Long,
+  val message: String,
+  val code: String,
+  val level: String,
+  val updateId: String?,
+  val assetId: String?,
+  val stacktrace: List<String>?,
+) {
+  fun asString(): String {
+    val o = JSONObject()
+    o.put("timestamp", timestamp)
+    o.put("message", message)
+    o.put("code", code)
+    o.put("level", level)
+    if (updateId != null) {
+      o.put("updateId", updateId)
+    }
+    if (assetId != null) {
+      o.put("assetId", assetId)
+    }
+    if (stacktrace != null && stacktrace.isNotEmpty()) {
+      val a = JSONArray(stacktrace)
+      o.put("stacktrace", a)
+    }
+    return o.toString()
+  }
+
+  companion object {
+    fun create(json: String): UpdatesLogEntry {
+      val jsonObject = JSONTokener(json).nextValue() as JSONObject
+      val timestamp = jsonObject.getLong("timestamp")
+      val message = jsonObject.getString("message")
+      val code = jsonObject.getString("code")
+      val level = jsonObject.getString("level")
+      val updateId = jsonObject.optString("updateId", null)
+      val assetId = jsonObject.optString("assetId", null)
+      val jsonArray = jsonObject.optJSONArray("stacktrace")
+
+      var stacktrace: List<String>? = null
+
+      if (jsonArray != null) {
+        stacktrace = mutableListOf()
+        for (i in 0 until jsonArray.length()) {
+          stacktrace.add(jsonArray.getString(i))
+        }
+      }
+
+      return UpdatesLogEntry(timestamp, message, code, level, updateId, assetId, stacktrace)
+    }
+  }
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/logging/UpdatesLogReader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/logging/UpdatesLogReader.kt
@@ -1,0 +1,49 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+// Reads expo-updates logs
+
+package expo.modules.updates.logging
+
+import java.io.BufferedReader
+import java.io.IOException
+import java.io.InputStreamReader
+import java.util.*
+
+class UpdatesLogReader {
+
+  /**
+   Get expo-updates logs newer than the given date
+   Returns a list of strings in the JSON format of UpdatesLogEntry
+   */
+  fun getLogEntries(newerThan: Date): List<String> {
+    val result: MutableList<String> = mutableListOf()
+    val epochTimestamp = newerThan.time / 1000
+    val pid = "${android.os.Process.myPid()}"
+    try {
+      // Use logcat to read just logs with our tag, in long format (message on separate line)
+      val process = Runtime.getRuntime().exec("logcat -d -s ${UpdatesLogger.LOGGING_TAG} -vlong")
+      val bufferedReader = BufferedReader(
+        InputStreamReader(process.inputStream)
+      )
+      var line: String? = ""
+      var writeThisLine = false
+      while (bufferedReader.readLine().also { line = it } != null) {
+        if (writeThisLine) {
+          // Check that it is a valid JSON string
+          val entry = UpdatesLogEntry.create(line ?: "")
+          // Check that timestamp is equal to or later than the passed in date before writing
+          if (entry?.timestamp >= epochTimestamp) {
+            result.add(line ?: "")
+          }
+          writeThisLine = false
+        }
+        if ((line ?: "").contains(pid)) {
+          // Line has our PID, so write the next line if needed
+          writeThisLine = true
+        }
+      }
+    } catch (e: IOException) {
+    }
+    return result
+  }
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/logging/UpdatesLogReader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/logging/UpdatesLogReader.kt
@@ -2,6 +2,7 @@ package expo.modules.updates.logging
 
 import java.io.IOException
 import java.util.*
+import kotlin.jvm.Throws
 
 /**
  * Class for reading expo-updates logs
@@ -12,28 +13,25 @@ class UpdatesLogReader {
    Get expo-updates logs newer than the given date
    Returns a list of strings in the JSON format of UpdatesLogEntry
    */
+  @Throws(IOException::class)
   fun getLogEntries(newerThan: Date): List<String> {
     val epochTimestamp = newerThan.time / 1000
     val pid = "${android.os.Process.myPid()}"
-    try {
-      // Use logcat to read just logs with our tag, in long format
-      val process = Runtime.getRuntime().exec("logcat -d -s ${UpdatesLogger.EXPO_UPDATES_LOGGING_TAG} -vlong")
-      return process.inputStream.bufferedReader().useLines { lines ->
-        // Format is one header line, followed by three lines per entry
-        // First line has the tag, timestamp, pid, etc.
-        // Second line has our log message
-        // Third line is empty
-        lines
-          .drop(1)
-          .chunked(3)
-          .filter { lineTriple -> lineTriple[0].contains(pid) }
-          .map { lineTriple -> UpdatesLogEntry.create(lineTriple[1]) }
-          .filter { entry -> entry.timestamp >= epochTimestamp }
-          .map { entry -> entry.asString() }
-          .toList()
-      }
-    } catch (e: IOException) {
-      return listOf()
+    // Use logcat to read just logs with our tag, in long format
+    val process = Runtime.getRuntime().exec("logcat -d -s ${UpdatesLogger.EXPO_UPDATES_LOGGING_TAG} -vlong")
+    return process.inputStream.bufferedReader().useLines { lines ->
+      // Format is one header line, followed by three lines per entry
+      // First line has the tag, timestamp, pid, etc.
+      // Second line has our log message
+      // Third line is empty
+      lines
+        .drop(1)
+        .chunked(3)
+        .filter { lineTriple -> lineTriple[0].contains(pid) }
+        .map { lineTriple -> UpdatesLogEntry.create(lineTriple[1]) }
+        .filter { entry -> entry.timestamp >= epochTimestamp }
+        .map { entry -> entry.asString() }
+        .toList()
     }
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/logging/UpdatesLogReader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/logging/UpdatesLogReader.kt
@@ -18,7 +18,7 @@ class UpdatesLogReader {
   fun getLogEntries(newerThan: Date): List<String> {
     val result: MutableList<String> = mutableListOf()
     val epochTimestamp = newerThan.time / 1000
-    val pid = "${android.os.Process.myPid()}"
+    val pid = android.os.Process.myPid().toString()
     try {
       // Use logcat to read just logs with our tag, in long format (message on separate line)
       val process = Runtime.getRuntime().exec("logcat -d -s ${UpdatesLogger.LOGGING_TAG} -vlong")

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/logging/UpdatesLogType.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/logging/UpdatesLogType.kt
@@ -1,0 +1,47 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+// Log types (levels) for expo-updates logs
+// These correspond to ExpoModulesCore.LogType in iOS
+
+package expo.modules.updates.logging
+
+import android.util.Log
+
+enum class UpdatesLogType(val type: Int) {
+  Trace(0),
+  Timer(1),
+  Stacktrace(2),
+  Debug(3),
+  Info(4),
+  Warn(5),
+  Error(6),
+  Fatal(7);
+
+  companion object {
+    fun asString(type: UpdatesLogType): String {
+      return when (type) {
+        Trace -> "trace"
+        Timer -> "timer"
+        Stacktrace -> "stacktrace"
+        Debug -> "debug"
+        Info -> "info"
+        Warn -> "warn"
+        Error -> "error"
+        Fatal -> "fatal"
+      }
+    }
+
+    fun toOSLogType(type: UpdatesLogType): Int {
+      return when (type) {
+        Trace -> Log.DEBUG
+        Timer -> Log.DEBUG
+        Stacktrace -> Log.DEBUG
+        Debug -> Log.DEBUG
+        Info -> Log.INFO
+        Warn -> Log.WARN
+        Error -> Log.ERROR
+        Fatal -> Log.ASSERT
+      }
+    }
+  }
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/logging/UpdatesLogType.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/logging/UpdatesLogType.kt
@@ -1,36 +1,22 @@
-// Copyright 2022-present 650 Industries. All rights reserved.
-
-// Log types (levels) for expo-updates logs
-// These correspond to ExpoModulesCore.LogType in iOS
-
 package expo.modules.updates.logging
 
 import android.util.Log
 
-enum class UpdatesLogType(val type: Int) {
-  Trace(0),
-  Timer(1),
-  Stacktrace(2),
-  Debug(3),
-  Info(4),
-  Warn(5),
-  Error(6),
-  Fatal(7);
+/**
+ * Log types (levels) for expo-updates logs
+ * These correspond to ExpoModulesCore.LogType in iOS
+ */
+enum class UpdatesLogType(val type: String) {
+  Trace("trace"),
+  Timer("timer"),
+  Stacktrace("stacktrace"),
+  Debug("debug"),
+  Info("info"),
+  Warn("warn"),
+  Error("error"),
+  Fatal("fatal");
 
   companion object {
-    fun asString(type: UpdatesLogType): String {
-      return when (type) {
-        Trace -> "trace"
-        Timer -> "timer"
-        Stacktrace -> "stacktrace"
-        Debug -> "debug"
-        Info -> "info"
-        Warn -> "warn"
-        Error -> "error"
-        Fatal -> "fatal"
-      }
-    }
-
     fun toOSLogType(type: UpdatesLogType): Int {
       return when (type) {
         Trace -> Log.DEBUG

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/logging/UpdatesLogger.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/logging/UpdatesLogger.kt
@@ -1,12 +1,11 @@
-// Copyright 2022-present 650 Industries. All rights reserved.
-
-// Class that implements logging for expo-updates with its own logcat tag
-
 package expo.modules.updates.logging
 
 import android.util.Log
 import java.util.*
 
+/**
+ * Class that implements logging for expo-updates with its own logcat tag
+ */
 class UpdatesLogger {
 
   fun trace(
@@ -126,23 +125,23 @@ class UpdatesLogger {
     val logEntry = UpdatesLogEntry(
       timestamp,
       message,
-      UpdatesErrorCode.asString(code),
-      UpdatesLogType.asString(level),
+      code.code,
+      level.type,
       updateId,
       assetId,
       stacktrace
     )
     when (UpdatesLogType.toOSLogType(level)) {
-      Log.DEBUG -> Log.d(LOGGING_TAG, logEntry.asString())
-      Log.INFO -> Log.i(LOGGING_TAG, logEntry.asString())
-      Log.WARN -> Log.w(LOGGING_TAG, logEntry.asString())
-      Log.ERROR -> Log.e(LOGGING_TAG, logEntry.asString())
-      Log.ASSERT -> Log.e(LOGGING_TAG, logEntry.asString())
+      Log.DEBUG -> Log.d(EXPO_UPDATES_LOGGING_TAG, logEntry.asString())
+      Log.INFO -> Log.i(EXPO_UPDATES_LOGGING_TAG, logEntry.asString())
+      Log.WARN -> Log.w(EXPO_UPDATES_LOGGING_TAG, logEntry.asString())
+      Log.ERROR -> Log.e(EXPO_UPDATES_LOGGING_TAG, logEntry.asString())
+      Log.ASSERT -> Log.e(EXPO_UPDATES_LOGGING_TAG, logEntry.asString())
     }
   }
 
   companion object {
-    const val LOGGING_TAG = "dev.expo.updates" // All logs use this tag
+    const val EXPO_UPDATES_LOGGING_TAG = "dev.expo.updates" // All logs use this tag
     const val MAX_FRAMES_IN_STACKTRACE = 20
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/logging/UpdatesLogger.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/logging/UpdatesLogger.kt
@@ -1,0 +1,148 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+// Class that implements logging for expo-updates with its own logcat tag
+
+package expo.modules.updates.logging
+
+import android.util.Log
+import java.util.*
+
+class UpdatesLogger {
+
+  fun trace(
+    message: String,
+    code: UpdatesErrorCode
+  ) {
+    trace(message, code, null, null)
+  }
+
+  fun trace(
+    message: String,
+    code: UpdatesErrorCode,
+    updateId: String?,
+    assetId: String?
+  ) {
+    log(message, code, UpdatesLogType.Trace, updateId, assetId)
+  }
+
+  fun debug(
+    message: String,
+    code: UpdatesErrorCode
+  ) {
+    debug(message, code, null, null)
+  }
+
+  fun debug(
+    message: String,
+    code: UpdatesErrorCode,
+    updateId: String?,
+    assetId: String?
+  ) {
+    log(message, code, UpdatesLogType.Debug, updateId, assetId)
+  }
+
+  fun info(
+    message: String,
+    code: UpdatesErrorCode
+  ) {
+    info(message, code, null, null)
+  }
+
+  fun info(
+    message: String,
+    code: UpdatesErrorCode,
+    updateId: String?,
+    assetId: String?
+  ) {
+    log(message, code, UpdatesLogType.Info, updateId, assetId)
+  }
+
+  fun warn(
+    message: String,
+    code: UpdatesErrorCode
+  ) {
+    warn(message, code, null, null)
+  }
+
+  fun warn(
+    message: String,
+    code: UpdatesErrorCode,
+    updateId: String?,
+    assetId: String?
+  ) {
+    log(message, code, UpdatesLogType.Warn, updateId, assetId)
+  }
+
+  fun error(
+    message: String,
+    code: UpdatesErrorCode
+  ) {
+    error(message, code, null, null)
+  }
+
+  fun error(
+    message: String,
+    code: UpdatesErrorCode,
+    updateId: String?,
+    assetId: String?
+  ) {
+    log(message, code, UpdatesLogType.Error, updateId, assetId)
+  }
+
+  fun fatal(
+    message: String,
+    code: UpdatesErrorCode
+  ) {
+    fatal(message, code, null, null)
+  }
+
+  fun fatal(
+    message: String,
+    code: UpdatesErrorCode,
+    updateId: String?,
+    assetId: String?
+  ) {
+    log(message, code, UpdatesLogType.Fatal, updateId, assetId)
+  }
+
+  private fun log(
+    message: String,
+    code: UpdatesErrorCode,
+    level: UpdatesLogType,
+    updateId: String?,
+    assetId: String?
+  ) {
+    val timestamp = Date().time / 1000
+
+    val stacktrace = when (level) {
+      // Limit stack to 20 frames
+      UpdatesLogType.Error -> Throwable().stackTrace.take(MAX_FRAMES_IN_STACKTRACE).map { f -> f.toString() }
+      UpdatesLogType.Fatal -> Throwable().stackTrace.take(MAX_FRAMES_IN_STACKTRACE).map { f -> f.toString() }
+      else -> {
+        null
+      }
+    }
+
+    val logEntry = UpdatesLogEntry(
+      timestamp,
+      message,
+      UpdatesErrorCode.asString(code),
+      UpdatesLogType.asString(level),
+      updateId,
+      assetId,
+      stacktrace
+    )
+    when (UpdatesLogType.toOSLogType(level)) {
+      Log.DEBUG -> Log.d(LOGGING_TAG, logEntry.asString())
+      Log.INFO -> Log.i(LOGGING_TAG, logEntry.asString())
+      Log.WARN -> Log.w(LOGGING_TAG, logEntry.asString())
+      Log.ERROR -> Log.e(LOGGING_TAG, logEntry.asString())
+      Log.ASSERT -> Log.e(LOGGING_TAG, logEntry.asString())
+    }
+  }
+
+  companion object {
+    const val LOGGING_TAG = "dev.expo.updates" // All logs use this tag
+    const val MAX_FRAMES_IN_STACKTRACE = 20
+  }
+}


### PR DESCRIPTION
# Why

Provides a way to log in expo-updates, and provides code to read all logs written since a given time.

# How

- New Kotlin code implementing the logger, log reader, expo-updates specific error codes, and JSON format for log messages
- Code is designed to match the error codes and log entry shape from the iOS implementation
- Logs with severity "error" or "fatal" will include stack traces (limited to 20 frames)
- Logs are written using the usual `android.util.Log` facility, with a tag specific to expo-updates. The log reader leverages `logcat` to read only system logs with our tag, and filters out logs that do not match the current process ID

# Test Plan

New unit tests provided for logging and log reading.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
