### PR TITLE
[docs]: Improve kbd elements using Cmd symbol with Cmd prefix

### DIFF
--- a/docs/pages/development/getting-started.md
+++ b/docs/pages/development/getting-started.md
@@ -181,4 +181,4 @@ const styles = StyleSheet.create({
 
 ## Debugging your app
 
-When you need to, you can access the menu by pressing <kbd>⌘</kbd> + <kbd>D</kbd> or <kbd>Ctrl</kbd> + <kbd>D</kbd> in Expo CLI or by shaking your phone or tablet. Here you'll be able to access all of the functions of your development build, access any debugging functionality you need, or switch to a different version of your app.
+When you need to, you can access the menu by pressing <kbd>Cmd ⌘</kbd> + <kbd>D</kbd> or <kbd>Ctrl</kbd> + <kbd>D</kbd> in Expo CLI or by shaking your phone or tablet. Here you'll be able to access all of the functions of your development build, access any debugging functionality you need, or switch to a different version of your app.

--- a/docs/pages/get-started/create-a-new-app.md
+++ b/docs/pages/get-started/create-a-new-app.md
@@ -71,7 +71,7 @@ Expo Go is configured by default to automatically reload the app whenever a file
 
 - Make sure the you have the [development mode enabled in Expo CLI](/workflow/development-mode#development-mode).
 - Close the Expo app and reopen it.
-- Once the app is open again, shake your device to reveal the developer menu. If you are using an emulator, press <kbd>⌘</kbd> + <kbd>D</kbd> for iOS or <kbd>Ctrl</kbd> + <kbd>M</kbd> for Android.
+- Once the app is open again, shake your device to reveal the developer menu. If you are using an emulator, press <kbd>Cmd ⌘</kbd> + <kbd>D</kbd> for iOS or <kbd>Ctrl</kbd> + <kbd>M</kbd> for Android.
 - If you see `Enable Fast Refresh`, press it. If you see `Disable Fast Refresh`, dismiss the developer menu. Now try making another change.
 
   ![In-app developer menu](/static/images/developer-menu.png)

--- a/docs/pages/guides/using-clojurescript.md
+++ b/docs/pages/guides/using-clojurescript.md
@@ -130,7 +130,7 @@ React Native uses JavaScriptCore, so modules using built-in node like stream, fs
 
 ### Do I need to restart the REPL after adding new JavaScript modules or assets?
 
-No, you do need to reload JavaScript. To do that, select **Reload** from the Developer Menu. You can also press `⌘ + R` in the iOS Simulator, or press `R` twice on Android emulators.
+No, you do need to reload JavaScript. To do that, select **Reload** from the Developer Menu. You can also press <kbd>Cmd ⌘</kbd> + <kbd>R</kbd> in the iOS Simulator, or press <kbd>R</kbd> twice on Android emulators.
 
 ### Will it support Boot?
 

--- a/docs/pages/workflow/debugging.md
+++ b/docs/pages/workflow/debugging.md
@@ -64,9 +64,9 @@ Below are a few tools we recommend, and use ourselves, when it comes to debuggin
 This menu gives you access to several functions which are useful for debugging, and is built into the Expo Go app. The way you open it is a bit different depending on where you're running the Expo Go app:
 
 - iOS Device: Shake the device a little bit, or touch 3 fingers to the screen.
-- iOS Simulator: Hit <kbd>Ctrl</kbd> + <kbd>⌘</kbd> + <kbd>Z</kbd> on a Mac in the emulator to simulate the shake gesture, or press <kbd>⌘</kbd> + <kbd>D</kbd>.
+- iOS Simulator: Hit <kbd>Ctrl</kbd> + <kbd>Cmd ⌘</kbd> + <kbd>Z</kbd> on a Mac in the emulator to simulate the shake gesture, or press <kbd>Cmd ⌘</kbd> + <kbd>D</kbd>.
 - Android Device: Shake the device vertically a little bit, or run `adb shell input keyevent 82` in your terminal window if your device is connected via USB.
-- Android Emulator: Either hit <kbd>⌘</kbd> + <kbd>M</kbd> or <kbd>Ctrl</kbd> + <kbd>M</kbd> or run `adb shell input keyevent 82` in your terminal window.
+- Android Emulator: Either hit <kbd>Cmd ⌘</kbd> + <kbd>M</kbd> or <kbd>Ctrl</kbd> + <kbd>M</kbd> or run `adb shell input keyevent 82` in your terminal window.
 
 The Developer Menu gives you a couple different functionalities. A few are pretty self-explanatory, like:
 
@@ -101,7 +101,7 @@ You can install it via the [release page](https://github.com/jhen0409/react-nati
 
 ### Startup
 
-After firing up React Native Debugger, you'll need to specify the port (shortcuts: <kbd>⌘</kbd> + <kbd>T</kbd> on macOS, <kbd>Ctrl</kbd> + <kbd>T</kbd> on Linux/Windows) to `19000` (if you use SDK <= 39, the port should be `19001`>). After that, run your project with `expo start`, and select `Debug remote JS` from the Developer Menu. The debugger should automatically connect.
+After firing up React Native Debugger, you'll need to specify the port (shortcuts: <kbd>Cmd ⌘</kbd> + <kbd>T</kbd> on macOS, <kbd>Ctrl</kbd> + <kbd>T</kbd> on Linux/Windows) to `19000` (if you use SDK <= 39, the port should be `19001`>). After that, run your project with `expo start`, and select `Debug remote JS` from the Developer Menu. The debugger should automatically connect.
 
 In the debugger console, you can see the Element tree, as well as the props, state, and children of whatever element you select. You also have the Chrome console on the right, and if you type `$r` in the console, you will see the breakdown of your selected element.
 
@@ -127,7 +127,7 @@ There are however [some limitations](https://github.com/jhen0409/react-native-de
 [Redux](https://redux.js.org/) is a popular library for managing and centralizing application state shared throughout the app. You can use Redux DevTools on React Native Debugger for debugging the application's state changes. The setup is as follows:
 
 1. Download React Native Debugger from the [releases page](https://github.com/jhen0409/react-native-debugger/releases).
-2. Open the app, press <kbd>⌘</kbd> + <kbd>T</kbd> or <kbd>Ctrl</kbd> + <kbd>T</kbd> to open a new window, then set the port to 19000.
+2. Open the app, press <kbd>Cmd ⌘</kbd> + <kbd>T</kbd> or <kbd>Ctrl</kbd> + <kbd>T</kbd> to open a new window, then set the port to 19000.
 3. Start your app, open the in-app developer menu, and select “Debug JS Remotely.”
 4. Configure `__REDUX_DEVTOOLS_EXTENSION__` as [shown here](https://github.com/zalmoxisus/redux-devtools-extension#11-basic-store).
 

--- a/docs/pages/workflow/development-mode.md
+++ b/docs/pages/workflow/development-mode.md
@@ -26,9 +26,9 @@ The Developer Menu gives you access to a host of features that make development 
 
 - Terminal UI: Press <kbd>M</kbd> in the terminal to open the menu on connected iOS and Android
 - iOS Device: Shake the device a little bit.
-- iOS Simulator: Hit <kbd>Ctrl</kbd> + <kbd>⌘</kbd> + <kbd>Z</kbd> on a Mac in the emulator to simulate the shake gesture, or press <kbd>⌘</kbd> + <kbd>D</kbd>.
+- iOS Simulator: Hit <kbd>Ctrl</kbd> + <kbd>Cmd ⌘</kbd> + <kbd>Z</kbd> on a Mac in the emulator to simulate the shake gesture, or press <kbd>Cmd ⌘</kbd> + <kbd>D</kbd>.
 - Android Device: Shake the device vertically a little bit.
-- Android Emulator: Either hit <kbd>⌘</kbd> + <kbd>M</kbd> or <kbd>Ctrl</kbd> + <kbd>M</kbd> or run `adb shell input keyevent 82` in your terminal window.
+- Android Emulator: Either hit <kbd>Cmd ⌘</kbd> + <kbd>M</kbd> or <kbd>Ctrl</kbd> + <kbd>M</kbd> or run `adb shell input keyevent 82` in your terminal window.
 
 ## Production Mode
 

--- a/docs/pages/workflow/ios-simulator.md
+++ b/docs/pages/workflow/ios-simulator.md
@@ -15,13 +15,13 @@ This step is very easy but it takes a while. Open up the Mac App Store, search f
 
 ## Step 2: Install Xcode Command Line Tools
 
-Open Xcode, then choose "Preferences..." from the Xcode menu (or press ⌘+,). Go to the Locations panel and install the tools by selecting the most recent version in the Command Line Tools dropdown.
+Open Xcode, then choose "Preferences..." from the Xcode menu (or press <kbd>Cmd ⌘</kbd> + <kbd>,</kbd>). Go to the Locations panel and install the tools by selecting the most recent version in the Command Line Tools dropdown.
 
 <ImageSpotlight alt="Xcode preferences" src="/static/images/xcode-command-line.png" containerStyle={{ paddingBottom: 0 }} />
 
 ## Step 3: Try it out
 
-Run your app with `expo-cli` and press `i` from the command line. You may get a warning about needing to accept the Xcode license. Run the command that it suggests. Open your app again, success! Or no? If no, please seek help on StackOverflow, Google, or the [Expo CLI section of the forums](https://forums.expo.dev/c/expo-cli). The troubleshooting tips below may be helpful too.
+Run your app with `expo-cli` and press <kbd>I</kbd> from the command line. You may get a warning about needing to accept the Xcode license. Run the command that it suggests. Open your app again, success! Or no? If no, please seek help on StackOverflow, Google, or the [Expo CLI section of the forums](https://forums.expo.dev/c/expo-cli). The troubleshooting tips below may be helpful too.
 
 <Video file="open-in-ios-simulator.mp4" />
 

--- a/docs/pages/workflow/logging.md
+++ b/docs/pages/workflow/logging.md
@@ -30,7 +30,7 @@ The following instructions apply to macOS.
 
 #### Option 1: Use GUI log
 
-- In simulator, press <kbd>⌘</kbd> + <kbd>/</kbd>, _or_ go to `Debug -> Open System Log` -- both of these open a log window that displays all of the logs from your device, including the logs from your Expo app.
+- In simulator, press <kbd>Cmd ⌘</kbd> + <kbd>/</kbd>, _or_ go to `Debug -> Open System Log` -- both of these open a log window that displays all of the logs from your device, including the logs from your Expo app.
 
 #### Option 2: Open it in terminal
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Using `⌘` just for macOS commands doesn't seem to follow a specific convention.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Replaced usage of `⌘` with `Cmd ⌘` as an alternative. 

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

All changes have been tested locally running the `/docs` repo.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
