### PR TITLE
[docs] Extract some API section components

### DIFF
--- a/docs/components/plugins/APIBox.tsx
+++ b/docs/components/plugins/APIBox.tsx
@@ -13,8 +13,8 @@ type APIBoxProps = {
 export const APIBox = ({ header, platforms, children }: APIBoxProps) => {
   return (
     <div css={STYLES_APIBOX}>
+      {platforms && <PlatformTags prefix="Only for:" platforms={platforms} firstElement />}
       {header && <H3>{header}</H3>}
-      {platforms && <PlatformTags prefix="Only for:" platforms={platforms} />}
       {children}
     </div>
   );

--- a/docs/components/plugins/APIBox.tsx
+++ b/docs/components/plugins/APIBox.tsx
@@ -1,14 +1,12 @@
-import { PlatformName } from '../../types/common';
-
 import { H3 } from '~/components/plugins/Headings';
 import { PlatformTags } from '~/components/plugins/PlatformTag';
 import { STYLES_APIBOX } from '~/components/plugins/api/APISectionUtils';
+import { PlatformName } from '~/types/common';
 
-type APIBoxProps = {
+type APIBoxProps = React.PropsWithChildren<{
   header?: string;
   platforms?: PlatformName[];
-  children: JSX.Element[];
-};
+}>;
 
 export const APIBox = ({ header, platforms, children }: APIBoxProps) => {
   return (

--- a/docs/components/plugins/APIBox.tsx
+++ b/docs/components/plugins/APIBox.tsx
@@ -1,0 +1,21 @@
+import { PlatformName } from '../../types/common';
+
+import { H3 } from '~/components/plugins/Headings';
+import { PlatformTags } from '~/components/plugins/PlatformTag';
+import { STYLES_APIBOX } from '~/components/plugins/api/APISectionUtils';
+
+type APIBoxProps = {
+  header?: string;
+  platforms?: PlatformName[];
+  children: JSX.Element[];
+};
+
+export const APIBox = ({ header, platforms, children }: APIBoxProps) => {
+  return (
+    <div css={STYLES_APIBOX}>
+      {header && <H3>{header}</H3>}
+      {platforms && <PlatformTags prefix="Only for:" platforms={platforms} />}
+      {children}
+    </div>
+  );
+};

--- a/docs/components/plugins/ConfigSection/ConfigPluginProperties.tsx
+++ b/docs/components/plugins/ConfigSection/ConfigPluginProperties.tsx
@@ -3,7 +3,7 @@ import React, { PropsWithChildren } from 'react';
 import { InlineCode } from '~/components/base/code';
 import { P } from '~/components/base/paragraph';
 import { H3 } from '~/components/plugins/Headings';
-import { PlatformTags } from '~/components/plugins/api/APISectionPlatformTags';
+import { APISectionPlatformTags } from '~/components/plugins/api/APISectionPlatformTags';
 import { Cell, HeaderCell, Row, Table, TableHead } from '~/ui/components/Table';
 
 type Props = PropsWithChildren<{
@@ -31,7 +31,7 @@ export const ConfigPluginProperties = ({ children, properties }: Props) => (
             <Cell>{!property.default ? '-' : <InlineCode>{property.default}</InlineCode>}</Cell>
             <Cell>
               {!!property.platform && (
-                <PlatformTags
+                <APISectionPlatformTags
                   prefix="Only for:"
                   platforms={[{ text: property.platform, tag: 'platform' }]}
                 />

--- a/docs/components/plugins/PlatformIcon.tsx
+++ b/docs/components/plugins/PlatformIcon.tsx
@@ -1,0 +1,31 @@
+import { AndroidIcon, AppleIcon, AtSignIcon, ExpoGoLogo, iconSize, theme } from '@expo/styleguide';
+
+import { PlatformName } from '~/types/common';
+
+export type PlatformIconProps = {
+  platform?: PlatformName;
+};
+
+export const PlatformIcon = ({ platform }: PlatformIconProps) => {
+  const size = iconSize.micro;
+
+  switch (platform) {
+    case 'ios':
+      return <AppleIcon color={theme.palette.blue['900']} size={size} />;
+    case 'android':
+      return <AndroidIcon color={theme.palette.green['900']} size={size} />;
+    case 'web':
+      return <AtSignIcon color={theme.palette.orange['900']} size={size} />;
+    case 'expo':
+      return (
+        <ExpoGoLogo
+          width={iconSize.micro}
+          height={iconSize.micro}
+          color={theme.palette.purple['900']}
+          size={size}
+        />
+      );
+    default:
+      return null;
+  }
+};

--- a/docs/components/plugins/PlatformTag.tsx
+++ b/docs/components/plugins/PlatformTag.tsx
@@ -37,17 +37,19 @@ const formatPlatformName = (name: PlatformName) => {
 };
 
 export const PlatformTag = ({ platform, firstElement }: PlatformTagProps) => {
+  const platformName = getPlatformName(platform);
+
   return (
     <div
       css={[
         platformTagStyle,
         firstElement && platformTagFirstStyle,
-        platform === 'android' && androidPlatformTagStyle,
-        platform === 'ios' && iosPlatformTagStyle,
-        platform === 'web' && webPlatformTagStyle,
-        platform === 'expo' && expoPlatformStyle,
+        platformName === 'android' && androidPlatformTagStyle,
+        platformName === 'ios' && iosPlatformTagStyle,
+        platformName === 'web' && webPlatformTagStyle,
+        platformName === 'expo' && expoPlatformStyle,
       ]}>
-      <PlatformIcon platform={platform} />
+      <PlatformIcon platform={platformName} />
       <span css={platformLabelStyle}>{formatPlatformName(platform)}</span>
     </div>
   );
@@ -57,7 +59,7 @@ export const PlatformTags = ({ prefix, firstElement, platforms }: PlatformTagsPr
   return platforms?.length ? (
     <>
       {prefix && <B>{prefix}&ensp;</B>}
-      {platforms.map(getPlatformName).map(platform => {
+      {platforms.map(platform => {
         return <PlatformTag key={platform} platform={platform} firstElement={firstElement} />;
       })}
       {prefix && <br />}

--- a/docs/components/plugins/PlatformTag.tsx
+++ b/docs/components/plugins/PlatformTag.tsx
@@ -1,0 +1,120 @@
+import { css } from '@emotion/react';
+import { borderRadius, spacing, theme } from '@expo/styleguide';
+
+import { B } from '~/components/base/paragraph';
+import { PlatformIcon } from '~/components/plugins/PlatformIcon';
+import { capitalize } from '~/components/plugins/api/APISectionUtils';
+import { PlatformName } from '~/types/common';
+
+type PlatformTagProps = {
+  platform: PlatformName;
+  firstElement?: boolean;
+};
+
+type PlatformTagsProps = {
+  prefix?: string;
+  platforms?: PlatformName[];
+  firstElement?: boolean;
+};
+
+const getPlatformName = (text: string): PlatformName => {
+  if (text.toLowerCase().includes('ios')) return 'ios';
+  if (text.toLowerCase().includes('android')) return 'android';
+  if (text.toLowerCase().includes('web')) return 'web';
+  if (text.toLowerCase().includes('expo')) return 'expo';
+  return '';
+};
+
+const formatPlatformName = (name: PlatformName) => {
+  const cleanName = name.toLowerCase().replace('\n', '');
+  if (cleanName.includes('ios')) {
+    return cleanName.replace('ios', 'iOS');
+  } else if (cleanName.includes('expo')) {
+    return cleanName.replace('expo', 'Expo Go');
+  } else {
+    return capitalize(name);
+  }
+};
+
+export const PlatformTag = ({ platform, firstElement }: PlatformTagProps) => {
+  return (
+    <div
+      css={[
+        platformTagStyle,
+        firstElement && platformTagFirstStyle,
+        platform === 'android' && androidPlatformTagStyle,
+        platform === 'ios' && iosPlatformTagStyle,
+        platform === 'web' && webPlatformTagStyle,
+        platform === 'expo' && expoPlatformStyle,
+      ]}>
+      <PlatformIcon platform={platform} />
+      <span css={platformLabelStyle}>{formatPlatformName(platform)}</span>
+    </div>
+  );
+};
+
+export const PlatformTags = ({ prefix, firstElement, platforms }: PlatformTagsProps) => {
+  return platforms?.length ? (
+    <>
+      {prefix && <B>{prefix}&ensp;</B>}
+      {platforms.map(getPlatformName).map(platform => {
+        return <PlatformTag key={platform} platform={platform} firstElement={firstElement} />;
+      })}
+      {prefix && <br />}
+    </>
+  ) : null;
+};
+
+const platformTagStyle = css({
+  display: 'inline-flex',
+  backgroundColor: theme.background.tertiary,
+  color: theme.text.default,
+  fontSize: '90%',
+  fontWeight: 700,
+  padding: `${spacing[1]}px ${spacing[2]}px`,
+  marginBottom: spacing[3],
+  marginRight: spacing[2],
+  borderRadius: borderRadius.small,
+  border: `1px solid ${theme.border.default}`,
+  alignItems: 'center',
+  gap: spacing[1],
+
+  'table &': {
+    marginTop: 0,
+    marginBottom: spacing[2],
+    padding: `${spacing[0.5]}px ${spacing[1.5]}px`,
+  },
+});
+
+const platformTagFirstStyle = css({
+  marginBottom: 0,
+  marginTop: spacing[4],
+});
+
+const platformLabelStyle = css({
+  lineHeight: `${spacing[4]}px`,
+});
+
+const androidPlatformTagStyle = css({
+  backgroundColor: theme.palette.green['000'],
+  color: theme.palette.green[900],
+  borderColor: theme.palette.green[200],
+});
+
+const iosPlatformTagStyle = css({
+  backgroundColor: theme.palette.blue['000'],
+  color: theme.palette.blue[900],
+  borderColor: theme.palette.blue[200],
+});
+
+const webPlatformTagStyle = css({
+  backgroundColor: theme.palette.orange['000'],
+  color: theme.palette.orange[900],
+  borderColor: theme.palette.orange[200],
+});
+
+const expoPlatformStyle = css({
+  backgroundColor: theme.palette.purple['000'],
+  color: theme.palette.purple[900],
+  borderColor: theme.palette.purple[200],
+});

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -4981,7 +4981,7 @@ OAuth 2.0 protocol
          
       </strong>
       <div
-        class="css-1sodslb-PlatformTags"
+        class="css-1xwiwui-PlatformTag"
       >
         <svg
           color="var(--expo-theme-palette-blue-900)"
@@ -5001,7 +5001,7 @@ OAuth 2.0 protocol
           />
         </svg>
         <span
-          class="css-vefllk-PlatformTags"
+          class="css-1y4xxhe-PlatformTag"
         >
           iOS 13.2+
         </span>

--- a/docs/components/plugins/api/APISectionConstants.tsx
+++ b/docs/components/plugins/api/APISectionConstants.tsx
@@ -5,7 +5,7 @@ import { B, P } from '~/components/base/paragraph';
 import { H2, H3Code } from '~/components/plugins/Headings';
 import { ConstantDefinitionData } from '~/components/plugins/api/APIDataTypes';
 import { APISectionDeprecationNote } from '~/components/plugins/api/APISectionDeprecationNote';
-import { PlatformTags } from '~/components/plugins/api/APISectionPlatformTags';
+import { APISectionPlatformTags } from '~/components/plugins/api/APISectionPlatformTags';
 import {
   CommentTextBlock,
   resolveTypeName,
@@ -23,7 +23,7 @@ const renderConstant = (
 ): JSX.Element => (
   <div key={`constant-definition-${name}`} css={STYLES_APIBOX}>
     <APISectionDeprecationNote comment={comment} />
-    <PlatformTags comment={comment} prefix="Only for:" firstElement />
+    <APISectionPlatformTags comment={comment} prefix="Only for:" firstElement />
     <H3Code>
       <InlineCode>
         {apiName ? `${apiName}.` : ''}

--- a/docs/components/plugins/api/APISectionEnums.tsx
+++ b/docs/components/plugins/api/APISectionEnums.tsx
@@ -6,7 +6,7 @@ import { InlineCode } from '~/components/base/code';
 import { H2, H3Code, H4Code } from '~/components/plugins/Headings';
 import { EnumDefinitionData, EnumValueData } from '~/components/plugins/api/APIDataTypes';
 import { APISectionDeprecationNote } from '~/components/plugins/api/APISectionDeprecationNote';
-import { PlatformTags } from '~/components/plugins/api/APISectionPlatformTags';
+import { APISectionPlatformTags } from '~/components/plugins/api/APISectionPlatformTags';
 import { CommentTextBlock, STYLES_APIBOX } from '~/components/plugins/api/APISectionUtils';
 
 export type APISectionEnumsProps = {
@@ -27,14 +27,14 @@ const sortByValue = (a: EnumValueData, b: EnumValueData) => {
 const renderEnum = ({ name, children, comment }: EnumDefinitionData): JSX.Element => (
   <div key={`enum-definition-${name}`} css={[STYLES_APIBOX, enumContentStyles]}>
     <APISectionDeprecationNote comment={comment} />
-    <PlatformTags comment={comment} prefix="Only for:" firstElement />
+    <APISectionPlatformTags comment={comment} prefix="Only for:" firstElement />
     <H3Code>
       <InlineCode>{name}</InlineCode>
     </H3Code>
     <CommentTextBlock comment={comment} includePlatforms={false} />
     {children.sort(sortByValue).map((enumValue: EnumValueData) => (
       <div css={[STYLES_APIBOX, enumContainerStyle]} key={enumValue.name}>
-        <PlatformTags comment={enumValue.comment} prefix="Only for:" firstElement />
+        <APISectionPlatformTags comment={enumValue.comment} prefix="Only for:" firstElement />
         <div css={enumValueNameStyle}>
           <H4Code>
             <InlineCode>{enumValue.name}</InlineCode>

--- a/docs/components/plugins/api/APISectionInterfaces.tsx
+++ b/docs/components/plugins/api/APISectionInterfaces.tsx
@@ -12,7 +12,7 @@ import {
   PropData,
 } from '~/components/plugins/api/APIDataTypes';
 import { APISectionDeprecationNote } from '~/components/plugins/api/APISectionDeprecationNote';
-import { PlatformTags } from '~/components/plugins/api/APISectionPlatformTags';
+import { APISectionPlatformTags } from '~/components/plugins/api/APISectionPlatformTags';
 import {
   CommentTextBlock,
   getTagData,
@@ -109,7 +109,7 @@ const renderInterface = ({
   return (
     <div key={`interface-definition-${name}`} css={STYLES_APIBOX}>
       <APISectionDeprecationNote comment={comment} />
-      <PlatformTags comment={comment} prefix="Only for:" firstElement />
+      <APISectionPlatformTags comment={comment} prefix="Only for:" firstElement />
       <H3Code>
         <InlineCode>{name}</InlineCode>
       </H3Code>

--- a/docs/components/plugins/api/APISectionMethods.tsx
+++ b/docs/components/plugins/api/APISectionMethods.tsx
@@ -12,7 +12,7 @@ import {
   PropData,
 } from '~/components/plugins/api/APIDataTypes';
 import { APISectionDeprecationNote } from '~/components/plugins/api/APISectionDeprecationNote';
-import { PlatformTags } from '~/components/plugins/api/APISectionPlatformTags';
+import { APISectionPlatformTags } from '~/components/plugins/api/APISectionPlatformTags';
 import {
   CommentTextBlock,
   listParams,
@@ -47,7 +47,7 @@ export const renderMethod = (
       key={`method-signature-${name}-${parameters?.length || 0}`}
       css={[STYLES_APIBOX, !exposeInSidebar && STYLES_APIBOX_NESTED]}>
       <APISectionDeprecationNote comment={comment} />
-      <PlatformTags comment={comment} prefix="Only for:" firstElement />
+      <APISectionPlatformTags comment={comment} prefix="Only for:" firstElement />
       <HeaderComponent>
         <InlineCode customCss={!exposeInSidebar ? STYLES_NOT_EXPOSED_HEADER : undefined}>
           {apiName && `${apiName}.`}

--- a/docs/components/plugins/api/APISectionPlatformTags.tsx
+++ b/docs/components/plugins/api/APISectionPlatformTags.tsx
@@ -1,61 +1,8 @@
-import { css } from '@emotion/react';
-import {
-  AndroidIcon,
-  AppleIcon,
-  AtSignIcon,
-  borderRadius,
-  ExpoGoLogo,
-  iconSize,
-  spacing,
-  theme,
-} from '@expo/styleguide';
 import React from 'react';
 
-import { B } from '~/components/base/paragraph';
+import { PlatformTags } from '~/components/plugins/PlatformTag';
 import { CommentData, CommentTagData } from '~/components/plugins/api/APIDataTypes';
-import { capitalize, getAllTagData } from '~/components/plugins/api/APISectionUtils';
-
-const formatPlatformName = (name: string) => {
-  const cleanName = name.toLowerCase().replace('\n', '');
-  if (cleanName.includes('ios')) {
-    return cleanName.replace('ios', 'iOS');
-  } else if (cleanName.includes('expo')) {
-    return cleanName.replace('expo', 'Expo Go');
-  } else {
-    return capitalize(name);
-  }
-};
-
-const getPlatformName = ({ text }: CommentTagData) => {
-  if (text.toLowerCase().includes('ios')) return 'ios';
-  if (text.toLowerCase().includes('android')) return 'android';
-  if (text.toLowerCase().includes('web')) return 'web';
-  if (text.toLowerCase().includes('expo')) return 'expo';
-  return undefined;
-};
-
-const renderPlatformIcon = (platform: CommentTagData) => {
-  const iconProps = { size: iconSize.micro };
-
-  switch (getPlatformName(platform)) {
-    case 'ios':
-      return <AppleIcon color={theme.palette.blue['900']} {...iconProps} />;
-    case 'android':
-      return <AndroidIcon color={theme.palette.green['900']} {...iconProps} />;
-    case 'web':
-      return <AtSignIcon color={theme.palette.orange['900']} {...iconProps} />;
-    case 'expo':
-      return (
-        <ExpoGoLogo
-          width={iconProps.size}
-          height={iconProps.size}
-          color={theme.palette.purple['900']}
-        />
-      );
-    default:
-      return undefined;
-  }
-};
+import { getAllTagData } from '~/components/plugins/api/APISectionUtils';
 
 type Props = {
   comment?: CommentData;
@@ -64,84 +11,9 @@ type Props = {
   platforms?: CommentTagData[];
 };
 
-export const PlatformTags = ({ comment, prefix, firstElement, platforms }: Props) => {
+export const APISectionPlatformTags = ({ comment, prefix, firstElement, platforms }: Props) => {
   const platformsData = platforms || getAllTagData('platform', comment);
-  return platformsData?.length ? (
-    <>
-      {prefix && <B>{prefix}&ensp;</B>}
-      {platformsData.map(platform => {
-        const platformName = getPlatformName(platform);
-        return (
-          <div
-            key={platformName}
-            css={[
-              platformTagStyle,
-              firstElement && platformTagFirstStyle,
-              platformName === 'android' && androidPlatformTagStyle,
-              platformName === 'ios' && iosPlatformTagStyle,
-              platformName === 'web' && webPlatformTagStyle,
-              platformName === 'expo' && expoPlatformStyle,
-            ]}>
-            {renderPlatformIcon(platform)}
-            <span css={platformLabelStyle}>{formatPlatformName(platform.text)}</span>
-          </div>
-        );
-      })}
-      {prefix && <br />}
-    </>
-  ) : null;
+  const platformNames = platformsData?.map(platformData => platformData.text);
+
+  return <PlatformTags prefix={prefix} platforms={platformNames} firstElement={firstElement} />;
 };
-
-const platformTagStyle = css({
-  display: 'inline-flex',
-  backgroundColor: theme.background.tertiary,
-  color: theme.text.default,
-  fontSize: '90%',
-  fontWeight: 700,
-  padding: `${spacing[1]}px ${spacing[2]}px`,
-  marginBottom: spacing[3],
-  marginRight: spacing[2],
-  borderRadius: borderRadius.small,
-  border: `1px solid ${theme.border.default}`,
-  alignItems: 'center',
-  gap: spacing[1],
-
-  'table &': {
-    marginTop: 0,
-    marginBottom: spacing[2],
-    padding: `${spacing[0.5]}px ${spacing[1.5]}px`,
-  },
-});
-
-const platformTagFirstStyle = css({
-  marginBottom: 0,
-  marginTop: spacing[4],
-});
-
-const platformLabelStyle = css({
-  lineHeight: `${spacing[4]}px`,
-});
-
-const androidPlatformTagStyle = css({
-  backgroundColor: theme.palette.green['000'],
-  color: theme.palette.green[900],
-  borderColor: theme.palette.green[200],
-});
-
-const iosPlatformTagStyle = css({
-  backgroundColor: theme.palette.blue['000'],
-  color: theme.palette.blue[900],
-  borderColor: theme.palette.blue[200],
-});
-
-const webPlatformTagStyle = css({
-  backgroundColor: theme.palette.orange['000'],
-  color: theme.palette.orange[900],
-  borderColor: theme.palette.orange[200],
-});
-
-const expoPlatformStyle = css({
-  backgroundColor: theme.palette.purple['000'],
-  color: theme.palette.purple[900],
-  borderColor: theme.palette.purple[200],
-});

--- a/docs/components/plugins/api/APISectionProps.tsx
+++ b/docs/components/plugins/api/APISectionProps.tsx
@@ -11,7 +11,7 @@ import {
   TypeDefinitionData,
 } from '~/components/plugins/api/APIDataTypes';
 import { APISectionDeprecationNote } from '~/components/plugins/api/APISectionDeprecationNote';
-import { PlatformTags } from '~/components/plugins/api/APISectionPlatformTags';
+import { APISectionPlatformTags } from '~/components/plugins/api/APISectionPlatformTags';
 import {
   CommentTextBlock,
   getCommentOrSignatureComment,
@@ -105,7 +105,7 @@ export const renderProp = (
   return (
     <div key={`prop-entry-${name}`} css={[STYLES_APIBOX, !exposeInSidebar && STYLES_APIBOX_NESTED]}>
       <APISectionDeprecationNote comment={extractedComment} />
-      <PlatformTags comment={comment} prefix="Only for:" firstElement />
+      <APISectionPlatformTags comment={comment} prefix="Only for:" firstElement />
       <HeaderComponent>
         <InlineCode customCss={!exposeInSidebar ? STYLES_NOT_EXPOSED_HEADER : undefined}>
           {name}

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -17,7 +17,7 @@ import {
   TypeDefinitionData,
   TypePropertyDataFlags,
 } from '~/components/plugins/api/APIDataTypes';
-import { PlatformTags } from '~/components/plugins/api/APISectionPlatformTags';
+import { APISectionPlatformTags } from '~/components/plugins/api/APISectionPlatformTags';
 import * as Constants from '~/constants/theme';
 import { Cell, HeaderCell, Row, Table, TableHead } from '~/ui/components/Table';
 import { tableWrapperStyle } from '~/ui/components/Table/Table';
@@ -504,11 +504,11 @@ export const CommentTextBlock = ({
   return (
     <>
       {!withDash && includePlatforms && hasPlatforms && (
-        <PlatformTags comment={comment} prefix="Only for:" />
+        <APISectionPlatformTags comment={comment} prefix="Only for:" />
       )}
       {beforeContent}
       {withDash && (shortText || text) && ' - '}
-      {withDash && includePlatforms && <PlatformTags comment={comment} />}
+      {withDash && includePlatforms && <APISectionPlatformTags comment={comment} />}
       {shortText}
       {text}
       {afterContent}

--- a/docs/types/common.ts
+++ b/docs/types/common.ts
@@ -40,3 +40,9 @@ export type NavigationRoute = {
   weight?: number;
   children?: NavigationRoute[];
 };
+
+/**
+ * Available platforms supported by our APIs.
+ * Temporarily it also accepts other strings for compatibility reasons.
+ */
+export type PlatformName = 'ios' | 'android' | 'web' | 'expo' | string;


### PR DESCRIPTION
# Why

API section components were more designed to be used for generated TSDoc data. However, we may want to use some components on others, non-generated pages. In my case it's the [Module API](https://docs.expo.dev/modules/module-api/) page where I also need components such as platform tags and API box.

# How

- Extracted platform icons, platform tags and API box components
- Had to rename existing `PlatformTags` to `APISectionPlatformTags` since it's intended to be used with generated docs data

# Test Plan

An example of the existing page with platform-specific methods (looks the same as previously):

![Screen Shot 2022-07-21 at 15 45 28](https://user-images.githubusercontent.com/1714764/180231868-5d54c813-dc28-45bd-82de-bebcbee7dfcd.png)

Updated Modules API page using all extracted components:

![Screen Shot 2022-07-21 at 15 44 11](https://user-images.githubusercontent.com/1714764/180231889-a06be991-8ce3-4550-9c61-c81e21205cdf.png)

