### PR TITLE
[expotools] "Others" category in add-changelog

### DIFF
--- a/tools/src/commands/AddChangelog.ts
+++ b/tools/src/commands/AddChangelog.ts
@@ -79,7 +79,7 @@ async function checkOrAskForOptions(options: ActionOptions): Promise<ActionOptio
       type: 'list',
       name: 'type',
       message: 'What is the type?',
-      choices: ['bug-fix', 'new-feature', 'breaking-change', 'library-upgrade', 'notice'],
+      choices: ['bug-fix', 'new-feature', 'breaking-change', 'library-upgrade', 'notice', 'other'],
     });
   }
 
@@ -100,6 +100,8 @@ function toChangeType(type: string): Changelogs.ChangeType | null {
       return Changelogs.ChangeType.LIBRARY_UPGRADES;
     case 'notice':
       return Changelogs.ChangeType.NOTICES;
+    case 'other':
+      return Changelogs.ChangeType.OTHERS;
   }
   return null;
 }
@@ -200,7 +202,7 @@ export default (program: Command) => {
     )
     .option(
       '-t, --type <string>',
-      'Type of change that determines the section into which the entry should be added. Possible options: bug-fix | new-feature | breaking-change | library-upgrade | notice.'
+      'Type of change that determines the section into which the entry should be added. Possible options: bug-fix | new-feature | breaking-change | library-upgrade | notice | other.'
     )
     .option(
       '-v, --version [string]',


### PR DESCRIPTION
# Why

The `add-changelog` command does not support the "Others" changelog category.

# How

Added the missing category in the implementation and help menu.

# Test Plan

Existing tests should pass.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
