### PR TITLE
[home] don't use cached responses on home screen, fix broken useCallbacks

### DIFF
--- a/dev-home-config.json
+++ b/dev-home-config.json
@@ -1,3 +1,3 @@
 {
-  "url": "exp://exp.host/@expo-home-dev/expo-home-dev-94badacfdfb49ea18d53aa6e3d9bcb5a1f1271bb"
+  "url": "exp://exp.host/@expo-home-dev/expo-home-dev-f59fd65601328e5ec0479a9e4ccbef640b6c9d87"
 }

--- a/dev-home-config.json
+++ b/dev-home-config.json
@@ -1,3 +1,3 @@
 {
-  "url": "exp://exp.host/@expo-home-dev/expo-home-dev-90c37f2bfb5f4363a9814e8b24b75d0a9adb0c9a"
+  "url": "exp://exp.host/@expo-home-dev/expo-home-dev-94badacfdfb49ea18d53aa6e3d9bcb5a1f1271bb"
 }

--- a/home/screens/BranchListScreen/BranchListView.tsx
+++ b/home/screens/BranchListScreen/BranchListView.tsx
@@ -85,18 +85,21 @@ function BranchList({ data, appId, loadMoreAsync }: Props) {
     }
   };
 
-  const renderItem = ({ item: branch, index }: { item: BranchManifest; index: number }) => {
-    return (
-      <BranchListItem
-        key={branch.id}
-        appId={appId}
-        name={branch.name}
-        latestUpdate={branch.latestUpdate}
-        first={index === 0}
-        last={index === data.length - 1}
-      />
-    );
-  };
+  const renderItem = React.useCallback(
+    ({ item: branch, index }: { item: BranchManifest; index: number }) => {
+      return (
+        <BranchListItem
+          key={branch.id}
+          appId={appId}
+          name={branch.name}
+          latestUpdate={branch.latestUpdate}
+          first={index === 0}
+          last={index === data.length - 1}
+        />
+      );
+    },
+    [appId, data]
+  );
 
   return (
     <View

--- a/home/screens/BranchListScreen/BranchListView.tsx
+++ b/home/screens/BranchListScreen/BranchListView.tsx
@@ -60,7 +60,7 @@ function BranchList({ data, appId, loadMoreAsync }: Props) {
   const isLoading = React.useRef<null | boolean>(false);
   const theme = useExpoTheme();
 
-  const extractKey = React.useCallback((item: BranchManifest) => item.id, []);
+  const extractKey = (item: BranchManifest) => item.id;
 
   const handleLoadMoreAsync = async () => {
     if (isLoading.current) return;
@@ -85,21 +85,18 @@ function BranchList({ data, appId, loadMoreAsync }: Props) {
     }
   };
 
-  const renderItem = React.useCallback(
-    ({ item: branch, index }: { item: BranchManifest; index: number }) => {
-      return (
-        <BranchListItem
-          key={branch.id}
-          appId={appId}
-          name={branch.name}
-          latestUpdate={branch.latestUpdate}
-          first={index === 0}
-          last={index === data.length - 1}
-        />
-      );
-    },
-    []
-  );
+  const renderItem = ({ item: branch, index }: { item: BranchManifest; index: number }) => {
+    return (
+      <BranchListItem
+        key={branch.id}
+        appId={appId}
+        name={branch.name}
+        latestUpdate={branch.latestUpdate}
+        first={index === 0}
+        last={index === data.length - 1}
+      />
+    );
+  };
 
   return (
     <View

--- a/home/screens/HomeScreen/HomeScreenView.tsx
+++ b/home/screens/HomeScreen/HomeScreenView.tsx
@@ -254,6 +254,7 @@ export class HomeScreenView extends React.Component<Props, State> {
               variables: {
                 accountName,
               },
+              fetchPolicy: 'network-only',
             })
           : new Promise<undefined>((resolve) => {
               resolve(undefined);

--- a/home/screens/ProjectsListScreen/ProjectList.tsx
+++ b/home/screens/ProjectsListScreen/ProjectList.tsx
@@ -127,20 +127,23 @@ function ProjectListView({ data, loadMoreAsync }: Props) {
   const totalAppCount = data.appCount ?? 0;
   const canLoadMore = currentAppCount < totalAppCount;
 
-  const renderItem: ListRenderItem<CommonAppDataFragment> = ({ item: app, index }) => {
-    return (
-      <ProjectsListItem
-        key={app.id}
-        id={app.id}
-        name={app.name}
-        imageURL={app.iconUrl || undefined}
-        subtitle={app.packageName || app.fullName}
-        sdkVersion={app.sdkVersion}
-        first={index === 0}
-        last={index === (data.apps ?? []).length - 1}
-      />
-    );
-  };
+  const renderItem: ListRenderItem<CommonAppDataFragment> = React.useCallback(
+    ({ item: app, index }) => {
+      return (
+        <ProjectsListItem
+          key={app.id}
+          id={app.id}
+          name={app.name}
+          imageURL={app.iconUrl || undefined}
+          subtitle={app.packageName || app.fullName}
+          sdkVersion={app.sdkVersion}
+          first={index === 0}
+          last={index === (data.apps ?? []).length - 1}
+        />
+      );
+    },
+    [data.apps]
+  );
 
   return (
     <View

--- a/home/screens/ProjectsListScreen/ProjectList.tsx
+++ b/home/screens/ProjectsListScreen/ProjectList.tsx
@@ -108,7 +108,7 @@ export function ProjectList(props: Props) {
 function ProjectListView({ data, loadMoreAsync }: Props) {
   const isLoading = React.useRef<null | boolean>(false);
   const theme = useExpoTheme();
-  const extractKey = React.useCallback((item: CommonAppDataFragment) => item.id, []);
+  const extractKey = (item: CommonAppDataFragment) => item.id;
 
   const handleLoadMoreAsync = async () => {
     if (isLoading.current) return;

--- a/home/screens/SnacksListScreen/SnackList.tsx
+++ b/home/screens/SnacksListScreen/SnackList.tsx
@@ -46,12 +46,12 @@ export function SnackListView(props: Props) {
   return <SnackList {...props} />;
 }
 
+const extractKey = (item: CommonSnackDataFragment) => item.id;
+
 function SnackList({ data, loadMoreAsync }: Props) {
   const [isLoadingMore, setLoadingMore] = React.useState(false);
   const isLoading = React.useRef<null | boolean>(false);
   const theme = useExpoTheme();
-
-  const extractKey = (item: CommonSnackDataFragment) => item.id;
 
   const handleLoadMoreAsync = async () => {
     if (isLoading.current) return;
@@ -80,21 +80,22 @@ function SnackList({ data, loadMoreAsync }: Props) {
     }
   };
 
-  const renderItem = ({ item: snack, index }: { item: CommonSnackDataFragment; index: number }) => {
-    console.log({ snack });
-
-    return (
-      <SnacksListItem
-        key={snack.id}
-        url={snack.fullName}
-        name={snack.name}
-        description={snack.description}
-        isDraft={snack.isDraft}
-        first={index === 0}
-        last={index === data.length - 1}
-      />
-    );
-  };
+  const renderItem = React.useCallback(
+    ({ item: snack, index }: { item: CommonSnackDataFragment; index: number }) => {
+      return (
+        <SnacksListItem
+          key={snack.id}
+          url={snack.fullName}
+          name={snack.name}
+          description={snack.description}
+          isDraft={snack.isDraft}
+          first={index === 0}
+          last={index === data.length - 1}
+        />
+      );
+    },
+    [data]
+  );
 
   return (
     <View

--- a/home/screens/SnacksListScreen/SnackList.tsx
+++ b/home/screens/SnacksListScreen/SnackList.tsx
@@ -51,7 +51,7 @@ function SnackList({ data, loadMoreAsync }: Props) {
   const isLoading = React.useRef<null | boolean>(false);
   const theme = useExpoTheme();
 
-  const extractKey = React.useCallback((item: CommonSnackDataFragment) => item.slug, []);
+  const extractKey = (item: CommonSnackDataFragment) => item.id;
 
   const handleLoadMoreAsync = async () => {
     if (isLoading.current) return;
@@ -80,22 +80,21 @@ function SnackList({ data, loadMoreAsync }: Props) {
     }
   };
 
-  const renderItem = React.useCallback(
-    ({ item: snack, index }: { item: CommonSnackDataFragment; index: number }) => {
-      return (
-        <SnacksListItem
-          key={index.toString()}
-          url={snack.fullName}
-          name={snack.name}
-          description={snack.description}
-          isDraft={snack.isDraft}
-          first={index === 0}
-          last={index === data.length - 1}
-        />
-      );
-    },
-    []
-  );
+  const renderItem = ({ item: snack, index }: { item: CommonSnackDataFragment; index: number }) => {
+    console.log({ snack });
+
+    return (
+      <SnacksListItem
+        key={snack.id}
+        url={snack.fullName}
+        name={snack.name}
+        description={snack.description}
+        isDraft={snack.isDraft}
+        first={index === 0}
+        last={index === data.length - 1}
+      />
+    );
+  };
 
   return (
     <View


### PR DESCRIPTION
# Why

See linear issue.

# How

This bug occurred because we were getting cached responses, so I only changed the query to use the network.

I also observed a bug on list pages where when you load new responses by scrolling, the style for the ending item of the list didn't update. The bug occurred because we had some `useCallback`s with missing dependencies, which I fixed.

# Test Plan

Follow the reproduction steps detailed in the linear issue.
