### PR TITLE
[docs] Updates in Expo Modules guides

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -185,7 +185,7 @@ const general = [
     makePage('ui-programming/react-native-styling-buttons.md'),
     makePage('guides/userinterface.md'),
   ]),
-  makeSection('Expo Module API (Alpha)', [
+  makeSection('Expo Modules API', [
     makePage('modules/overview.md'),
     makePage('modules/module-api.md'),
     makePage('modules/android-lifecycle-listeners.md'),

--- a/docs/pages/modules/android-lifecycle-listeners.md
+++ b/docs/pages/modules/android-lifecycle-listeners.md
@@ -6,7 +6,7 @@ import { Tab, Tabs } from '~/components/plugins/Tabs';
 
 In order to respond to certain Android system events relevant to an app, such as inbound links and configuration changes, it is necessary to override the corresponding lifecycle callbacks in **MainActivity.java** and/or **MainApplication.java**.
 
-The React Native module API does not provide any mechanism to hook into these, and so setup instructions for React Native libraries often include steps to copy code into these files. To simplify and automate setup and maintenance, the Expo module API provides a mechanism that allows your library to hook into `Activity` or `Application` functions.
+The React Native module API does not provide any mechanism to hook into these, and so setup instructions for React Native libraries often include steps to copy code into these files. To simplify and automate setup and maintenance, the Expo Modules API provides a mechanism that allows your library to hook into `Activity` or `Application` functions.
 
 ## Get Started
 

--- a/docs/pages/modules/android-lifecycle-listeners.md
+++ b/docs/pages/modules/android-lifecycle-listeners.md
@@ -2,7 +2,11 @@
 title: Android Lifecycle Listeners
 ---
 
+import { Callout } from '~/ui/components/Callout';
 import { Tab, Tabs } from '~/components/plugins/Tabs';
+
+<Callout type="warning">Expo Modules APIs are in beta and subject to breaking changes.</Callout>
+<br />
 
 In order to respond to certain Android system events relevant to an app, such as inbound links and configuration changes, it is necessary to override the corresponding lifecycle callbacks in **MainActivity.java** and/or **MainApplication.java**.
 

--- a/docs/pages/modules/appdelegate-subscribers.md
+++ b/docs/pages/modules/appdelegate-subscribers.md
@@ -6,7 +6,7 @@ import { CodeBlocksTable } from '~/components/plugins/CodeBlocksTable';
 
 In order to respond to certain iOS system events relevant to an app, such as inbound links and notifications, it is necessary to handle the corresponding methods in the `AppDelegate`.
 
-The React Native module API does not provide any mechanism to hook into these methods, and so setup instructions for React Native libraries often include a step to copy code into the `AppDelegate` file. To simplify and automate setup and maintenance, the Expo module API provides a mechanism that allows your library to subscribe to calls to `AppDelegate` functions. In order for this to work, the app `AppDelegate` must inherit from `ExpoAppDelegate`, and this is a requirement for using Expo Modules.
+The React Native module API does not provide any mechanism to hook into these methods, and so setup instructions for React Native libraries often include a step to copy code into the `AppDelegate` file. To simplify and automate setup and maintenance, the Expo Modules API provides a mechanism that allows your library to subscribe to calls to `AppDelegate` functions. In order for this to work, the app `AppDelegate` must inherit from `ExpoAppDelegate`, and this is a requirement for using Expo Modules.
 
 `ExpoAppDelegate` implements most functions from [`UIApplicationDelegate`](https://developer.apple.com/documentation/uikit/uiapplicationdelegate) protocol and forwards their calls to all the subscribers.
 

--- a/docs/pages/modules/appdelegate-subscribers.md
+++ b/docs/pages/modules/appdelegate-subscribers.md
@@ -2,7 +2,11 @@
 title: iOS AppDelegate Subscribers
 ---
 
+import { Callout } from '~/ui/components/Callout';
 import { CodeBlocksTable } from '~/components/plugins/CodeBlocksTable';
+
+<Callout type="warning">Expo Modules APIs are in beta and subject to breaking changes.</Callout>
+<br />
 
 In order to respond to certain iOS system events relevant to an app, such as inbound links and notifications, it is necessary to handle the corresponding methods in the `AppDelegate`.
 

--- a/docs/pages/modules/module-api.md
+++ b/docs/pages/modules/module-api.md
@@ -2,11 +2,15 @@
 title: Native Modules
 ---
 
+import { Callout } from '~/ui/components/Callout';
 import { CodeBlocksTable } from '~/components/plugins/CodeBlocksTable';
 import { PlatformTag } from '~/ui/components/Tag';
 import { APIBox } from '~/components/plugins/APIBox';
 
-The Expo native modules API is an abstraction layer on top of React Native modules that helps you build native modules in modern languages (Swift and Kotlin) with an easy to use and convenient API that is consistent across platforms where possible.
+<Callout type="warning">Expo Modules APIs are in beta and subject to breaking changes.</Callout>
+<br />
+
+The native modules API is an abstraction layer on top of [JSI](https://reactnative.dev/architecture/glossary#javascript-interfaces-jsi) and other low-level primities that React Native is built upon. It is built with modern languages (Swift and Kotlin) and provides an easy to use and convenient API that is consistent across platforms where possible.
 
 ## Design considerations
 

--- a/docs/pages/modules/module-api.md
+++ b/docs/pages/modules/module-api.md
@@ -1,14 +1,12 @@
 ---
-title: Module API
+title: Native Modules
 ---
 
 import { CodeBlocksTable } from '~/components/plugins/CodeBlocksTable';
 import { PlatformTag } from '~/ui/components/Tag';
 import { APIBox } from '~/components/plugins/APIBox';
 
-> Note: This API is still experimental and subject to change. Some features that you need may not be implemented yet.
-
-The Expo module API provided by `expo-modules-core` is an abstraction layer on top of React Native modules that helps you build native modules in modern languages (Swift and Kotlin) with an easy to use and convenient API that is consistent across platforms where possible.
+The Expo native modules API is an abstraction layer on top of React Native modules that helps you build native modules in modern languages (Swift and Kotlin) with an easy to use and convenient API that is consistent across platforms where possible.
 
 ## Design considerations
 
@@ -16,17 +14,17 @@ The Expo module API provided by `expo-modules-core` is an abstraction layer on t
 
 After several years of maintaining over 50 native modules in the Expo SDK, we have found out that many issues that have arisen were caused by unhandled null values or using incorrect types. Modern language features can help developers avoid these bugs; for example, the lack of optional types combined with the dynamism of Objective-C made it tough to catch certain classes of bugs that would have been caught by the compiler in Swift.
 
-This is one of the reasons why the Expo module ecosystem was designed from the ground up to be used with modern native languages: Swift and Kotlin.
+This is one of the reasons why the Expo Modules ecosystem was designed from the ground up to be used with modern native languages: Swift and Kotlin.
 
 ### Passing data between runtimes
 
-Another big pain point that we have encountered is the validation of arguments passed from JavaScript to native functions. This is especially error prone, time consuming, and difficult to maintain when it comes to `NSDictionary` or `ReadableMap`, where the type of values is unknown in runtime and each property needs to be validated separately by the developer. A valuable feature of the Expo module API is that it has full knowledge of the argument types the native function expects, so it can pre-validate and convert the arguments for you! The dictionaries can be represented as native structs that we call [Records](#records). Knowing the argument types, it is also possible to [automatically convert arguments](#convertibles) to some platform-specific types (e.g. `{ x: number, y: number }` or `[number, number]` can be translated to CoreGraphics's `CGPoint` for your convenience).
+Another big pain point that we have encountered is the validation of arguments passed from JavaScript to native functions. This is especially error prone, time consuming, and difficult to maintain when it comes to `NSDictionary` or `ReadableMap`, where the type of values is unknown in runtime and each property needs to be validated separately by the developer. A valuable feature of the Expo native modules API is that it has full knowledge of the argument types the native function expects, so it can pre-validate and convert the arguments for you! The dictionaries can be represented as native structs that we call [Records](#records). Knowing the argument types, it is also possible to [automatically convert arguments](#convertibles) to some platform-specific types (e.g. `{ x: number, y: number }` or `[number, number]` can be translated to CoreGraphics's `CGPoint` for your convenience).
 
 ## Get Started
 
 ### 1. Set up the library as an Expo module
 
-To use the Expo module API, you need [set up your library as an Expo module](overview). Once that is complete, create Swift and Kotlin files from the below templates.
+To use the Expo Modules API for native modules, you need [set up your library as an Expo module](overview). Once that is complete, create Swift and Kotlin files from the below templates.
 
 <CodeBlocksTable>
 
@@ -145,6 +143,8 @@ Defines a native synchronous function that will be exported to JavaScript. Synch
 
 The function can receive up to 8 arguments. This is due to the limitations of generics in both Swift and Kotlin, because this component must be implemented separately for each arity.
 
+See the [Argument Types](#argument-types) section for more details on what types can be used in the function body.
+
 <CodeBlocksTable>
 
 ```swift
@@ -183,6 +183,8 @@ Defines a JavaScript function that always returns a `Promise` and whose native c
 
 If the type of the last argument is `Promise`, the function will wait for the promise to be resolved or rejected before the response is passed back to JavaScript. Otherwise, the function is immediately resolved with the returned value or rejected if it throws an exception.
 The function can receive up to 8 arguments (including the promise).
+
+See the [Argument Types](#argument-types) section for more details on what types can be used in the function body.
 
 It is recommended to use `AsyncFunction` over `Function` when it:
 
@@ -237,6 +239,44 @@ Events("onCameraReady", "onPictureSaved", "onBarCodeScanned")
 
 </CodeBlocksTable>
 </APIBox>
+<APIBox header="ViewManager">
+
+Enables the module to be used as a view manager. The view manager definition is built from the definition components used in the closure passed to `viewManager`. Definition components that are accepted as part of the view manager definition: [`View`](#view), [`Prop`](#prop).
+
+<CodeBlocksTable>
+
+```swift
+ViewManager {
+  View {
+    MyNativeView()
+  }
+
+  Prop("isHidden") { (view: UIView, hidden: Bool) in
+    view.isHidden = hidden
+  }
+}
+```
+
+```kotlin
+ViewManager {
+  View { context ->
+    MyNativeView(context)
+  }
+
+  Prop("isHidden") { view: View, hidden: Bool ->
+    view.isVisible = !hidden
+  }
+}
+```
+
+</CodeBlocksTable>
+
+> **Note** The API for view managers is still experimental and subject to change.
+> We are investigating how to integrate with [React Native's new architecture (Fabric)](https://reactnative.dev/architecture/fabric-renderer), which may require API changes.
+
+> **Note** Support for rendering SwiftUI views is planned. For now, you can use [`UIHostingController`](https://developer.apple.com/documentation/swiftui/uihostingcontroller) and add its content view to your UIKit view.
+
+</APIBox>
 <APIBox header="View">
 
 Defines the factory creating a native view, when the module is used as a view.
@@ -285,43 +325,7 @@ Prop("background") { view: View, @ColorInt color: Int ->
 
 </CodeBlocksTable>
 
-> Note: Props of function type (callbacks) are not supported yet.
-
-</APIBox>
-<APIBox header="ViewManager">
-
-Enables the module to be used as a view manager. The view manager definition is built from the definition components used in the closure passed to `viewManager`. Definition components that are accepted as part of the view manager definition: [`View`](#view), [`Prop`](#prop).
-
-<CodeBlocksTable>
-
-```swift
-ViewManager {
-  View {
-    UIView()
-  }
-
-  Prop("isHidden") { (view: UIView, hidden: Bool) in
-    view.isHidden = hidden
-  }
-}
-```
-
-```kotlin
-ViewManager {
-  View { context ->
-    View(context)
-  }
-
-  Prop("isHidden") { view: View, hidden: Bool ->
-    view.isVisible = !hidden
-  }
-}
-```
-
-</CodeBlocksTable>
-
-> Note: The API for view managers is still experimental and subject to change.
-> We are investigating how to integrate it with [React Native's new architecture (Fabric)](https://reactnative.dev/architecture/fabric-renderer) which may require us to make some API changes.
+> **Note** Props of function type (callbacks) are not supported yet.
 
 </APIBox>
 <APIBox header="OnCreate">
@@ -353,45 +357,59 @@ Defines module's lifecycle listener that is called when the app context owning t
 
 Defines the listener that is called when the app is about to enter the foreground mode.
 
-> Note: This function is not available on Android — you may want to use [`OnActivityEntersForeground`](#onactivityentersforeground) instead.
+> **Note** This function is not available on Android — you may want to use [`OnActivityEntersForeground`](#onactivityentersforeground) instead.
 
 </APIBox>
 <APIBox header="OnAppEntersBackground" platforms={["ios"]}>
 
 Defines the listener that is called when the app enters the background mode.
 
-> Note: This function is not available on Android — you may want to use [`OnActivityEntersBackground`](#onactivityentersbackground) instead.
+> **Note** This function is not available on Android — you may want to use [`OnActivityEntersBackground`](#onactivityentersbackground) instead.
 
 </APIBox>
 <APIBox header="OnAppBecomesActive" platforms={["ios"]}>
 
 Defines the listener that is called when the app becomes active again (after `OnAppEntersForeground`).
 
-> Note: This function is not available on Android — you may want to use [`OnActivityEntersForeground`](#onactivityentersforeground) instead.
+> **Note** This function is not available on Android — you may want to use [`OnActivityEntersForeground`](#onactivityentersforeground) instead.
 
 </APIBox>
 <APIBox header="OnActivityEntersForeground" platforms={["android"]}>
 
-> Note: This function is not available on iOS — you may want to use [`OnAppEntersForeground`](#onappentersforeground) instead.
+Defines the activity lifecycle listener that is called right after the activity is resumed.
+
+> **Note** This function is not available on iOS — you may want to use [`OnAppEntersForeground`](#onappentersforeground) instead.
 
 </APIBox>
 <APIBox header="OnActivityEntersBackground" platforms={["android"]}>
 
-> Note: This function is not available on iOS — you may want to use [`OnAppEntersBackground`](#onappentersbackground) instead.
+Defines the activity lifecycle listener that is called right after the activity is paused.
+
+> **Note** This function is not available on iOS — you may want to use [`OnAppEntersBackground`](#onappentersbackground) instead.
 
 </APIBox>
 <APIBox header="OnActivityDestroys" platforms={["android"]}>
 
-Defines the listener that is called when the activity owning the JavaScript context is about to be destroyed.
+Defines the activity lifecycle listener that is called when the activity owning the JavaScript context is about to be destroyed.
 
-> Note: This function is not available on iOS — you may want to use [`OnAppEntersBackground`](#onappentersbackground) instead.
+> **Note** This function is not available on iOS — you may want to use [`OnAppEntersBackground`](#onappentersbackground) instead.
 
 </APIBox>
 
 ## Argument Types
 
-Fundamentally, only primitive and serializable data can be passed back and forth between the runtimes. However, usually native modules need to receive custom data structures — more sophisticated than just the dictionary/map where the values are of unknown (`Any`) type and so each value has to be validated and casted on its own. The Expo module API provides protocols to make it more convenient to work with data objects, to provide automatic validation, and finally, to ensure native type-safety on each object member.
+Fundamentally, only primitive and serializable data can be passed back and forth between the runtimes. However, usually native modules need to receive custom data structures — more sophisticated than just the dictionary/map where the values are of unknown (`Any`) type and so each value has to be validated and casted on its own. The Expo Modules API provides protocols to make it more convenient to work with data objects, to provide automatic validation, and finally, to ensure native type-safety on each object member.
 
+<APIBox header="Primitives">
+
+All functions and view prop setters accept all common primitive types in Swift and Kotlin as the arguments. This includes arrays, dictionaries/maps and optionals of these primitive types.
+
+| Language | Supported primitive types |
+| -------- | ------------------------- |
+| Swift    | `Bool`, `Int`, `Int8`, `Int16`, `Int32`, `Int64`, `UInt`, `UInt8`, `UInt16`, `UInt32`, `UInt64`, `Float32`, `Double`, `String` |
+| Kotlin   | `Boolean`, `Int`, `UInt`, `Float`, `Double`, `String`, `Pair` |
+
+</APIBox>
 <APIBox header="Convertibles">
 
 _Convertibles_ are native types that can be initialized from certain specific kinds of data received from JavaScript. Such types are allowed to be used as an argument type in `Function`'s body. For example, when the `CGPoint` type is used as a function argument type, its instance can be created from an array of two numbers `(_x_, _y_)` or a JavaScript object with numeric `x` and `y` properties.
@@ -413,6 +431,7 @@ Some common iOS types from `CoreGraphics` and `UIKit` system frameworks are alre
 <APIBox header="Records">
 
 _Record_ is a convertible type and an equivalent of the dictionary (Swift) or map (Kotlin), but represented as a struct where each field can have its own type and provide a default value.
+It is a better way to represent a JavaScript object with the native type-safety.
 
 <CodeBlocksTable>
 
@@ -522,10 +541,13 @@ class MyModule : Module() {
 
 For more examples from real modules, you can refer to Expo modules that already use this API on GitHub:
 
-- `expo-cellular` ([Swift](https://github.com/expo/expo/tree/main/packages/expo-cellular/ios/CellularModule.swift), [Kotlin](https://github.com/expo/expo/tree/main/packages/expo-cellular/android/src/main/java/expo/modules/cellular/CellularModule.kt))
-- `expo-linear-gradient` ([Swift](https://github.com/expo/expo/tree/main/packages/expo-linear-gradient/ios/LinearGradientModule.swift), [Kotlin](https://github.com/expo/expo/tree/main/packages/expo-linear-gradient/android/src/main/java/expo/modules/lineargradient/LinearGradientModule.kt))
-- `expo-haptics` ([Swift](https://github.com/expo/expo/tree/main/packages/expo-haptics/ios/HapticsModule.swift))
-- `expo-clipboard` ([Swift](https://github.com/expo/expo/tree/main/packages/expo-clipboard/ios/ClipboardModule.swift), [Kotlin](https://github.com/expo/expo/tree/main/packages/expo-clipboard/android/src/main/java/expo/modules/clipboard/ClipboardModule.kt))
-- `expo-localization` ([Swift](https://github.com/expo/expo/tree/main/packages/expo-localization/ios/LocalizationModule.swift))
-- `expo-system-ui` ([Swift](https://github.com/expo/expo/tree/main/packages/expo-system-ui/ios/ExpoSystemUI/ExpoSystemUIModule.swift))
-- `expo-image-manipulator` ([Swift](https://github.com/expo/expo/tree/main/packages/expo-image-manipulator/ios/ImageManipulatorModule.swift))
+- `expo-cellular` ([Swift](https://github.com/expo/expo/tree/main/packages/expo-cellular/ios), [Kotlin](https://github.com/expo/expo/tree/main/packages/expo-cellular/android/src/main/java/expo/modules/cellular))
+- `expo-clipboard` ([Swift](https://github.com/expo/expo/tree/main/packages/expo-clipboard/ios), [Kotlin](https://github.com/expo/expo/tree/main/packages/expo-clipboard/android/src/main/java/expo/modules/clipboard))
+- `expo-crypto` ([Swift](https://github.com/expo/expo/tree/main/packages/expo-crypto/ios), [Kotlin](https://github.com/expo/expo/tree/main/packages/expo-crypto/android/src/main/java/expo/modules/crypto))
+- `expo-haptics` ([Swift](https://github.com/expo/expo/tree/main/packages/expo-haptics/ios))
+- `expo-image-manipulator` ([Swift](https://github.com/expo/expo/tree/main/packages/expo-image-manipulator/ios))
+- `expo-image-picker` ([Swift](https://github.com/expo/expo/tree/main/packages/expo-image-picker/ios), [Kotlin](https://github.com/expo/expo/tree/main/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker))
+- `expo-linear-gradient` ([Swift](https://github.com/expo/expo/tree/main/packages/expo-linear-gradient/ios), [Kotlin](https://github.com/expo/expo/tree/main/packages/expo-linear-gradient/android/src/main/java/expo/modules/lineargradient))
+- `expo-localization` ([Swift](https://github.com/expo/expo/tree/main/packages/expo-localization/ios), [Kotlin](https://github.com/expo/expo/tree/main/packages/expo-localization/android/src/main/java/expo/modules/localization))
+- `expo-system-ui` ([Swift](https://github.com/expo/expo/tree/main/packages/expo-system-ui/ios/ExpoSystemUI))
+- `expo-web-browser` ([Swift](https://github.com/expo/expo/blob/main/packages/expo-web-browser/ios), [Kotlin](https://github.com/expo/expo/blob/main/packages/expo-web-browser/android/src/main/java/expo/modules/webbrowser))

--- a/docs/pages/modules/module-config.md
+++ b/docs/pages/modules/module-config.md
@@ -2,6 +2,11 @@
 title: Module Config
 ---
 
+import { Callout } from '~/ui/components/Callout';
+
+<Callout type="warning">Expo Modules APIs are in beta and subject to breaking changes.</Callout>
+<br />
+
 Expo modules are configured in **expo-module.config.json**. This file currently is capable of configuring autolinking and module registration. The following properties are available:
 
 - `platforms` — An array of supported platforms.

--- a/docs/pages/modules/overview.md
+++ b/docs/pages/modules/overview.md
@@ -2,7 +2,11 @@
 title: Overview
 ---
 
+import { Callout } from '~/ui/components/Callout';
 import { CodeBlocksTable } from '~/components/plugins/CodeBlocksTable';
+
+<Callout type="warning">Expo Modules APIs are in beta and subject to breaking changes.</Callout>
+<br />
 
 Expo provides a set of APIs and utilities to improve the process of developing native modules for Expo and React Native and expand your app capabilities.
 

--- a/docs/pages/modules/overview.md
+++ b/docs/pages/modules/overview.md
@@ -6,18 +6,19 @@ import { CodeBlocksTable } from '~/components/plugins/CodeBlocksTable';
 
 Expo provides a set of APIs and utilities to improve the process of developing native modules for Expo and React Native and expand your app capabilities.
 
-- [Module API](./module-api.md) - Create native modules using Swift and Kotlin (_experimental_).
+- [Native Modules](./module-api.md) - Create native modules using Swift and Kotlin.
 - [Android Lifecycle Listeners](./android-lifecycle-listeners.md) - Hook into Android Activity and Application lifecycle events.
 - [iOS AppDelegate Subscribers](./appdelegate-subscribers.md) — Respond to iOS AppDelegate events.
 - [Module Config](./module-config.md) — Configure and opt in to features.
 
 ## Create a new module
 
-To create a new Expo module from scratch, run `npm create expo-module` or `yarn create expo-module`.
+To create a new Expo module from scratch, just run `yarn create expo-module` or `npm create expo-module`.
+The script will ask you a few questions and then generate the native Expo module along with the example app for iOS and Android that uses your new module.
 
-## Use the Expo Module API in an existing React Native library
+## Use the Expo Modules API in an existing React Native library
 
-You may want to use the Expo module API in existing React Native libraries, for example with [AppDelegate Subscribers](./appdelegate-subscribers.md) you can hook into `AppDelegate` methods without requiring developers to copy any code over to their own `AppDelegate`. This is particularly useful to add seamless support for Expo managed projects to a library. The following steps will set up your existing React Native library to have access to the Expo module API.
+You may want to use the Expo Modules API in existing React Native libraries, for example with [AppDelegate Subscribers](./appdelegate-subscribers.md) you can hook into `AppDelegate` methods without requiring developers to copy any code over to their own `AppDelegate`. This is particularly useful to add seamless support for Expo managed projects to a library. The following steps will set up your existing React Native library to have access to the Expo Modules API.
 
 ### 1. Initialize the module config
 
@@ -67,4 +68,4 @@ Add `expo` package as a peer dependency in your **package.json** — we recommen
 
 </CodeBlocksTable>
 
-You can now use Expo module APIs in your library. You may be interested in referring to the [Android Lifecycle Listeners](./android-lifecycle-listeners.md) and [iOS AppDelegate Subscribers](./appdelegate-subscribers.md) guides next.
+You can now use Expo Modules APIs in your library. You may be interested in referring to the [Android Lifecycle Listeners](./android-lifecycle-listeners.md) and [iOS AppDelegate Subscribers](./appdelegate-subscribers.md) guides next.


### PR DESCRIPTION
# Why

Further improvements on the Expo Modules docs page

# How

- Took Expo Modules API out of Alpha.
- Renamed `Expo Modules API` to just `Expo Modules` (sidebar on the left). This is actually not a single API, but a set of APIs + the shorter name is always better.
- Renamed `Module API` to `Native Modules`, I think this will be more clear for people.
- Added more examples of packages using the new API for native modules.
- Moved `ViewManager` component to be before `View` and `Props` (you use `ViewManager` first in your module definition, so this seems to be a more natural order).
- Clarified that view managers are still experimental and we're working on integrating it with Fabric. Also noted that we plan to support SwiftUI but until then people can embed SwiftUI views using `UIHostingController`.
- Added missing description to `OnActivityEntersForeground`, and `OnActivityEntersBackground` components.
- Added `Primitives` section to `Argument Types` to make it clear what primitive types are supported as arguments.
- Changed naming convention a little bit: `Expo module API` -> `Expo Modules API for native modules` or `Expo native modules API`. Again, this is to clarify it's about the native module. iOS AppDelegate subscribers and Android lifecycle handlers are also Expo module APIs, but they are not the same as native modules.

# Test Plan

Looks good locally