### PR TITLE
[ios][tools] Fix unversioned codegen scripts not updated

### DIFF
--- a/ios/versioned-react-native/ABI45_0_0/ReactNative/scripts/react_native_pods.rb
+++ b/ios/versioned-react-native/ABI45_0_0/ReactNative/scripts/react_native_pods.rb
@@ -454,7 +454,7 @@ def get_react_codegen_script_phases(options={})
     'input_files' => input_files,
     'show_env_vars_in_log': true,
     'output_files': ["${DERIVED_FILE_DIR}/react-codegen.log"],
-    'script': get_script_phases_with_codegen_discovery(
+    'script': get_script_phases_with_codegen_discovery_ABI45_0_0(
       react_native_path: react_native_path,
       relative_app_root: relative_app_root,
       relative_config_file_dir: relative_config_file_dir,
@@ -618,7 +618,7 @@ def use_react_native_codegen_ABI45_0_0!(spec, options={})
     :input_files => input_files, # This also needs to be relative to Xcode
     :output_files => ["${DERIVED_FILE_DIR}/codegen-#{library_name}.log"].concat(generated_files.map { |filename| "${PODS_TARGET_SRCROOT}/#{filename}"} ),
     # The final generated files will be created when this script is invoked at Xcode build time.
-    :script => get_script_phases_no_codegen_discovery(
+    :script => get_script_phases_no_codegen_discovery_ABI45_0_0(
       react_native_path: react_native_path,
       codegen_output_dir: $ABI45_0_0CODEGEN_OUTPUT_DIR,
       codegen_module_dir: $CODEGEN_MODULE_DIR,

--- a/ios/versioned-react-native/ABI45_0_0/ReactNative/scripts/react_native_pods_utils/script_phases.rb
+++ b/ios/versioned-react-native/ABI45_0_0/ReactNative/scripts/react_native_pods_utils/script_phases.rb
@@ -7,7 +7,7 @@
 
 require "erb"
 
-def get_script_phases_with_codegen_discovery(options)
+def get_script_phases_with_codegen_discovery_ABI45_0_0(options)
     export_vars = {
         'RCT_SCRIPT_RN_DIR' => "$RCT_SCRIPT_POD_INSTALLATION_ROOT/#{options[:react_native_path]}",
         'RCT_SCRIPT_APP_PATH' => "$RCT_SCRIPT_POD_INSTALLATION_ROOT/#{options[:relative_app_root]}",
@@ -16,10 +16,10 @@ def get_script_phases_with_codegen_discovery(options)
         'RCT_SCRIPT_FABRIC_ENABLED' => "#{options[:fabric_enabled]}",
         'RCT_SCRIPT_TYPE' => "withCodegenDiscovery",
     }
-    return get_script_template(options[:react_native_path], export_vars)
+    return get_script_template_ABI45_0_0(options[:react_native_path], export_vars)
 end
 
-def get_script_phases_no_codegen_discovery(options)
+def get_script_phases_no_codegen_discovery_ABI45_0_0(options)
     export_vars = {
         'RCT_SCRIPT_RN_DIR' => "${PODS_TARGET_SRCROOT}/#{options[:react_native_path]}",
         'RCT_SCRIPT_LIBRARY_NAME' => "#{options[:library_name]}",
@@ -31,11 +31,11 @@ def get_script_phases_no_codegen_discovery(options)
         'RCT_SCRIPT_CODEGEN_COMPONENT_DIR' => "#{options[:codegen_component_dir]}",
         'RCT_SCRIPT_FILE_LIST' => ("#{options[:file_list]}").dump,
     }
-    return get_script_template(options[:react_native_path], export_vars)
+    return get_script_template_ABI45_0_0(options[:react_native_path], export_vars)
 end
 
 
-def get_script_template(react_native_path, export_vars={})
+def get_script_template_ABI45_0_0(react_native_path, export_vars={})
     template =<<~EOS
         pushd "$PODS_ROOT/../" > /dev/null
         RCT_SCRIPT_POD_INSTALLATION_ROOT=$(pwd)

--- a/ios/versioned-react-native/ABI46_0_0/ReactNative/scripts/react_native_pods.rb
+++ b/ios/versioned-react-native/ABI46_0_0/ReactNative/scripts/react_native_pods.rb
@@ -489,7 +489,7 @@ def get_react_codegen_script_phases(options={})
     'input_files' => input_files,
     'show_env_vars_in_log': true,
     'output_files': ["${DERIVED_FILE_DIR}/react-codegen.log"],
-    'script': get_script_phases_with_codegen_discovery(
+    'script': get_script_phases_with_codegen_discovery_ABI46_0_0(
       react_native_path: react_native_path,
       relative_app_root: relative_app_root,
       relative_config_file_dir: relative_config_file_dir,
@@ -655,7 +655,7 @@ def use_react_native_codegen_ABI46_0_0!(spec, options={})
     :input_files => input_files + env_files, # This also needs to be relative to Xcode
     :output_files => ["${DERIVED_FILE_DIR}/codegen-#{library_name}.log"].concat(generated_files.map { |filename| "${PODS_TARGET_SRCROOT}/#{filename}"} ),
     # The final generated files will be created when this script is invoked at Xcode build time.
-    :script => get_script_phases_no_codegen_discovery(
+    :script => get_script_phases_no_codegen_discovery_ABI46_0_0(
       react_native_path: react_native_path,
       codegen_output_dir: $ABI46_0_0CODEGEN_OUTPUT_DIR,
       codegen_module_dir: $CODEGEN_MODULE_DIR,

--- a/ios/versioned-react-native/ABI46_0_0/ReactNative/scripts/react_native_pods_utils/script_phases.rb
+++ b/ios/versioned-react-native/ABI46_0_0/ReactNative/scripts/react_native_pods_utils/script_phases.rb
@@ -7,7 +7,7 @@
 
 require "erb"
 
-def get_script_phases_with_codegen_discovery(options)
+def get_script_phases_with_codegen_discovery_ABI46_0_0(options)
     export_vars = {
         'RCT_SCRIPT_RN_DIR' => "$RCT_SCRIPT_POD_INSTALLATION_ROOT/#{options[:react_native_path]}",
         'RCT_SCRIPT_APP_PATH' => "$RCT_SCRIPT_POD_INSTALLATION_ROOT/#{options[:relative_app_root]}",
@@ -16,10 +16,10 @@ def get_script_phases_with_codegen_discovery(options)
         'RCT_SCRIPT_FABRIC_ENABLED' => "#{options[:fabric_enabled]}",
         'RCT_SCRIPT_TYPE' => "withCodegenDiscovery",
     }
-    return get_script_template(options[:react_native_path], export_vars)
+    return get_script_template_ABI46_0_0(options[:react_native_path], export_vars)
 end
 
-def get_script_phases_no_codegen_discovery(options)
+def get_script_phases_no_codegen_discovery_ABI46_0_0(options)
     export_vars = {
         'RCT_SCRIPT_RN_DIR' => "${PODS_TARGET_SRCROOT}/#{options[:react_native_path]}",
         'RCT_SCRIPT_LIBRARY_NAME' => "#{options[:library_name]}",
@@ -31,11 +31,11 @@ def get_script_phases_no_codegen_discovery(options)
         'RCT_SCRIPT_CODEGEN_COMPONENT_DIR' => "#{options[:codegen_component_dir]}",
         'RCT_SCRIPT_FILE_LIST' => ("#{options[:file_list]}").dump,
     }
-    return get_script_template(options[:react_native_path], export_vars)
+    return get_script_template_ABI46_0_0(options[:react_native_path], export_vars)
 end
 
 
-def get_script_template(react_native_path, export_vars={})
+def get_script_template_ABI46_0_0(react_native_path, export_vars={})
     template =<<~EOS
         pushd "$PODS_ROOT/../" > /dev/null
         RCT_SCRIPT_POD_INSTALLATION_ROOT=$(pwd)

--- a/tools/src/Transforms.ts
+++ b/tools/src/Transforms.ts
@@ -128,6 +128,12 @@ export async function copyFileWithTransformsAsync(
   // Save transformed source file at renamed target path.
   await fs.outputFile(targetPath, content);
 
+  // Keep original file mode if needed.
+  if (options.keepFileMode) {
+    const { mode } = await fs.stat(sourcePath);
+    await fs.chmod(targetPath, mode);
+  }
+
   return {
     content,
     targetFile,

--- a/tools/src/Transforms.types.ts
+++ b/tools/src/Transforms.types.ts
@@ -78,6 +78,11 @@ export type CopyFileOptions = {
    * An object with transform rules for file paths and contents.
    */
   transforms: FileTransforms;
+
+  /**
+   * Whether to keep original file mode (the mode for `chmod`), e.g. 755.
+   */
+  keepFileMode?: boolean;
 };
 
 /**

--- a/tools/src/versioning/ios/index.ts
+++ b/tools/src/versioning/ios/index.ts
@@ -356,6 +356,11 @@ async function generateReactNativePodScriptAsync(
         path: 'react_native_pods.rb',
         ...stringTransform,
       })),
+      {
+        paths: ['react_native_pods.rb', 'script_phases.rb'],
+        find: /\b(get_script_phases_with_codegen_discovery|get_script_phases_no_codegen_discovery|get_script_template)\b/g,
+        replaceWith: `$1_${versionName}`,
+      },
     ],
   };
 

--- a/tools/src/versioning/ios/index.ts
+++ b/tools/src/versioning/ios/index.ts
@@ -11,6 +11,8 @@ import { runReactNativeCodegenAsync } from '../../Codegen';
 import { EXPO_DIR, IOS_DIR, VERSIONED_RN_IOS_DIR } from '../../Constants';
 import logger from '../../Logger';
 import { getListOfPackagesAsync, Package } from '../../Packages';
+import { copyFileWithTransformsAsync } from '../../Transforms';
+import type { FileTransforms, StringTransform } from '../../Transforms.types';
 import { renderExpoKitPodspecAsync } from '../../dynamic-macros/IosMacrosGenerator';
 import { runTransformPipelineAsync } from './transforms';
 import { injectMacros } from './transforms/injectMacros';
@@ -285,25 +287,6 @@ async function generateReactNativePodScriptAsync(
   versionedReactNativePath: string,
   versionName: string
 ): Promise<void> {
-  await fs.copy(
-    path.join(EXPO_DIR, RELATIVE_RN_PATH, 'scripts'),
-    path.join(versionedReactNativePath, 'scripts')
-  );
-
-  const targetAutolinkPath = path.join(versionedReactNativePath, 'scripts', 'react_native_pods.rb');
-  let targetSource = (await fs.readFile(targetAutolinkPath, 'utf8'))
-    .replace('def use_react_native!', `def use_react_native_${versionName}!`)
-    .replace('def use_react_native_codegen!', `def use_react_native_codegen_${versionName}!`)
-    .replace(/(\bpod\s+([^\n]+)\/third-party-podspecs\/([^\n]+))/g, '# $1')
-    .replace(/\bpod\s+'([^\']+)'/g, `pod '${versionName}$1'`)
-    .replace(/(:path => "[^"]+")/g, `$1, :project_name => '${versionName}'`)
-    // Removes duplicated constants
-    .replace("DEFAULT_OTHER_CPLUSPLUSFLAGS = '$(inherited)'", '')
-    .replace(
-      "NEW_ARCH_OTHER_CPLUSPLUSFLAGS = '$(inherited) -DRCT_NEW_ARCH_ENABLED=1 -DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1'",
-      ''
-    );
-  // Since `React-Codegen.podspec` is generated during `pod install`, versioning should be done in the pod script.
   const reactCodegenDependencies = [
     'FBReactNativeSpec',
     'React-jsiexecutor',
@@ -315,21 +298,80 @@ async function generateReactNativePodScriptAsync(
     'React-graphics',
     'React-rncore',
   ];
-  const reactCodegenDependenciesRegExp = new RegExp(
-    `["'](${reactCodegenDependencies.join('|')})["']:(\\s*\\[version\\],?)`,
-    'g'
-  );
-  targetSource = targetSource
-    .replace(
-      "$CODEGEN_OUTPUT_DIR = 'build/generated/ios'",
-      `$CODEGEN_OUTPUT_DIR = '${path.relative(IOS_DIR, versionedReactNativePath)}/codegen/ios'`
-    )
-    .replace(/\$(CODEGEN_OUTPUT_DIR)\b/g, `$${versionName}$1`)
-    .replace(/\b(React-Codegen)\b/g, `${versionName}$1`)
-    .replace(/(\$\(PODS_ROOT\)\/Headers\/Private\/)React-/g, `$1${versionName}React-`)
-    .replace(reactCodegenDependenciesRegExp, `"${versionName}$1":$2`);
 
-  await fs.writeFile(targetAutolinkPath, targetSource);
+  const reactNativePodScriptTransforms: StringTransform[] = [
+    {
+      find: /\b(def (use_react_native|use_react_native_codegen))!/g,
+      replaceWith: `$1_${versionName}!`,
+    },
+    {
+      find: /(\bpod\s+([^\n]+)\/third-party-podspecs\/([^\n]+))/g,
+      replaceWith: '# $1',
+    },
+    {
+      find: /\bpod\s+'([^\']+)'/g,
+      replaceWith: `pod '${versionName}$1'`,
+    },
+    {
+      find: /(:path => "[^"]+")/g,
+      replaceWith: `$1, :project_name => '${versionName}'`,
+    },
+
+    // Removes duplicated constants
+    {
+      find: "DEFAULT_OTHER_CPLUSPLUSFLAGS = '$(inherited)'",
+      replaceWith: '',
+    },
+    {
+      find: "NEW_ARCH_OTHER_CPLUSPLUSFLAGS = '$(inherited) -DRCT_NEW_ARCH_ENABLED=1 -DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1'",
+      replaceWith: '',
+    },
+
+    // Since `React-Codegen.podspec` is generated during `pod install`, versioning should be done in the pod script.
+    {
+      find: "$CODEGEN_OUTPUT_DIR = 'build/generated/ios'",
+      replaceWith: `$CODEGEN_OUTPUT_DIR = '${path.relative(
+        IOS_DIR,
+        versionedReactNativePath
+      )}/codegen/ios'`,
+    },
+    {
+      find: /\$(CODEGEN_OUTPUT_DIR)\b/g,
+      replaceWith: `$${versionName}$1`,
+    },
+    { find: /\b(React-Codegen)\b/g, replaceWith: `${versionName}$1` },
+    { find: /(\$\(PODS_ROOT\)\/Headers\/Private\/)React-/g, replaceWith: `$1${versionName}React-` },
+    {
+      find: new RegExp(
+        `["'](${reactCodegenDependencies.join('|')})["']:(\\s*\\[version\\],?)`,
+        'g'
+      ),
+      replaceWith: `"${versionName}$1":$2`,
+    },
+  ];
+
+  const transforms: FileTransforms = {
+    content: [
+      ...reactNativePodScriptTransforms.map((stringTransform) => ({
+        path: 'react_native_pods.rb',
+        ...stringTransform,
+      })),
+    ],
+  };
+
+  const reactNativeScriptsDir = path.join(EXPO_DIR, RELATIVE_RN_PATH, 'scripts');
+  const scriptFiles = await glob('**/*', { cwd: reactNativeScriptsDir, nodir: true, dot: true });
+  await Promise.all(
+    scriptFiles.map(async (file) => {
+      await copyFileWithTransformsAsync({
+        sourceFile: file,
+        sourceDirectory: reactNativeScriptsDir,
+        targetDirectory: path.join(versionedReactNativePath, 'scripts'),
+        transforms,
+        keepFileMode: true,
+      });
+    })
+  );
 }
 
 async function generateReactNativePodspecsAsync(


### PR DESCRIPTION
# Why

some react-native codegen scripts in script_phases.rb are not versioned, e.g. [`get_script_phases_no_codegen_discovery`](https://github.com/expo/expo/blob/85a1f11cbcd6fbac54984d3396655fd4edcd46d7/ios/versioned-react-native/ABI46_0_0/ReactNative/scripts/react_native_pods_utils/script_phases.rb#L22). this will overwrite the unversioned codegen scripts, so [the latest change for with-environment.sh execution](https://github.com/expo/react-native/blob/e25372b2f95a580f61479fa6376a8f75b5460e99/scripts/react_native_pods_utils/script_phases.rb#L48-L49) will not be applied.

# How

- [ios] versioning methods in `script_phases.rb` in sdk 45/46 code.
- [tools] refactor `generateReactNativePodScriptAsync` to use `copyFileWithTransformsAsync`
- [tools] versioning methods in `script_phases.rb`

# Test Plan

- `et remove-sdk -p ios -s 46.0.0` + `et add-sdk -p ios -s 46.0.0` and make sure no changes in scripts/ folder
- `et pods -f` and check `ios/Pods/Local Podspecs/FBReactNativeSpec.podspec.json` has `with-environment.sh`

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
