### PR TITLE
Update expo.dev url in build.md 

### DIFF
--- a/docs/pages/development/build.md
+++ b/docs/pages/development/build.md
@@ -44,7 +44,7 @@ To create and share a development build with your team, you can run the followin
 
 <Terminal cmd={["$ eas build --profile development --platform android"]} cmdCopy="eas build --profile development --platform android" />
 
-To share the build with your team, direct them to the build page on https://expo.dev. There, they'll be able to download the app directly on their device.
+To share the build with your team, direct them to the build page on [https://expo.dev](https://expo.dev). There, they'll be able to download the app directly on their device.
 
 </Tab>
 <Tab>
@@ -57,7 +57,7 @@ You can register an iOS device and install a provisioning profile with the follo
 Once you've registered all iOS devices you'll want to run your development build on, you can run the following to create a build ready for internal distribution:
 <Terminal cmd={["$ eas build --profile development --platform ios"]} />
 
-To share the build with your team, direct them to the build page on https://expo.dev . There, they'll be able to download the app directly on their device.
+To share the build with your team, direct them to the build page on [https://expo.dev](https://expo.dev). There, they'll be able to download the app directly on their device.
 
 Note: If you register any new iOS devices, you'll need create a new development build. Learn more about [internal distribution](/build/internal-distribution).
 

--- a/docs/pages/development/build.md
+++ b/docs/pages/development/build.md
@@ -57,7 +57,7 @@ You can register an iOS device and install a provisioning profile with the follo
 Once you've registered all iOS devices you'll want to run your development build on, you can run the following to create a build ready for internal distribution:
 <Terminal cmd={["$ eas build --profile development --platform ios"]} />
 
-To share the build with your team, direct them to the build page on https://expo.dev. There, they'll be able to download the app directly on their device.
+To share the build with your team, direct them to the build page on https://expo.dev . There, they'll be able to download the app directly on their device.
 
 Note: If you register any new iOS devices, you'll need create a new development build. Learn more about [internal distribution](/build/internal-distribution).
 

--- a/docs/pages/development/build.md
+++ b/docs/pages/development/build.md
@@ -44,7 +44,7 @@ To create and share a development build with your team, you can run the followin
 
 <Terminal cmd={["$ eas build --profile development --platform android"]} cmdCopy="eas build --profile development --platform android" />
 
-To share the build with your team, direct them to the build page on [https://expo.dev](https://expo.dev). There, they'll be able to download the app directly on their device.
+To share the build with your team, direct them to the build page in [Expo Dashboard](https://expo.dev/accounts/[account]/projects/[project]/builds). There, they'll be able to download the app directly on their device.
 
 </Tab>
 <Tab>

--- a/docs/pages/development/build.md
+++ b/docs/pages/development/build.md
@@ -57,7 +57,7 @@ You can register an iOS device and install a provisioning profile with the follo
 Once you've registered all iOS devices you'll want to run your development build on, you can run the following to create a build ready for internal distribution:
 <Terminal cmd={["$ eas build --profile development --platform ios"]} />
 
-To share the build with your team, direct them to the build page on [https://expo.dev](https://expo.dev). There, they'll be able to download the app directly on their device.
+To share the build with your team, direct them to the build page in [Expo Dashboard](https://expo.dev/accounts/[account]/projects/[project]/builds). There, they'll be able to download the app directly on their device.
 
 Note: If you register any new iOS devices, you'll need create a new development build. Learn more about [internal distribution](/build/internal-distribution).
 


### PR DESCRIPTION
The link is not redirecting to https://expo.dev/ because of the period

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
When we click on expo.dev it's not redirecting to the website.

# How

<!--
How did you build this feature or fix this bug and why?
-->
Added space after the period in expo.dev .

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
Checked by clicking on it

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
