### PR TITLE
Highlight React import

### DIFF
--- a/docs/pages/tutorial/image-picker.md
+++ b/docs/pages/tutorial/image-picker.md
@@ -90,8 +90,6 @@ Now we will take the data that we get from the image picker and use it to show t
 /* @info Import React to use useState */import React from 'react';/* @end */
 import { Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
-
-  
 export default function App() {
   /* @info Initialize a variable to hold our selected image data */const [selectedImage, setSelectedImage] = React.useState(null);/* @end */
 

--- a/docs/pages/tutorial/image-picker.md
+++ b/docs/pages/tutorial/image-picker.md
@@ -34,7 +34,6 @@ With the library installed in our project, we can now actually use it.
 
 <!-- prettier-ignore -->
 ```js
-import React from 'react';
 import { Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 /* @info Import the ImagePicker */import * as ImagePicker from 'expo-image-picker';/* @end */
 
@@ -87,6 +86,7 @@ Now we will take the data that we get from the image picker and use it to show t
 
 <!-- prettier-ignore -->
 ```js
+/* @info Import React to use useState */import React from 'react';/* @end */
 export default function App() {
   /* @info Initialize a variable to hold our selected image data */const [selectedImage, setSelectedImage] = React.useState(null);/* @end */
 

--- a/docs/pages/tutorial/image-picker.md
+++ b/docs/pages/tutorial/image-picker.md
@@ -34,6 +34,7 @@ With the library installed in our project, we can now actually use it.
 
 <!-- prettier-ignore -->
 ```js
+import React from 'react';
 import { Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 /* @info Import the ImagePicker */import * as ImagePicker from 'expo-image-picker';/* @end */
 
@@ -87,6 +88,10 @@ Now we will take the data that we get from the image picker and use it to show t
 <!-- prettier-ignore -->
 ```js
 /* @info Import React to use useState */import React from 'react';/* @end */
+import { Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import * as ImagePicker from 'expo-image-picker';
+
+  
 export default function App() {
   /* @info Initialize a variable to hold our selected image data */const [selectedImage, setSelectedImage] = React.useState(null);/* @end */
 

--- a/docs/pages/tutorial/image-picker.md
+++ b/docs/pages/tutorial/image-picker.md
@@ -90,6 +90,7 @@ Now we will take the data that we get from the image picker and use it to show t
 /* @info Import React to use useState */import React from 'react';/* @end */
 import { Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
+
 export default function App() {
   /* @info Initialize a variable to hold our selected image data */const [selectedImage, setSelectedImage] = React.useState(null);/* @end */
 


### PR DESCRIPTION
# Why

Right now the "React" import is present in the first snippet of the page where it's not used (yet) or highlighted.
A reader could easily miss the import. I would propose to move it to the second snippet when it's used and also to add an highlight to show it as "new" code.

# How

I updated the text on Github text editor.

# Test Plan

Rebuilding the app would show the new updated text.
