### PR TITLE
[docs] Update twitch authentication example

### DIFF
--- a/docs/pages/guides/authentication.md
+++ b/docs/pages/guides/authentication.md
@@ -1962,23 +1962,22 @@ const discovery = {
 export default function App() {
   const [request, response, promptAsync] = useAuthRequest(
     {
+      responseType: ResponseType.Token,
       clientId: 'CLIENT_ID',
       redirectUri: makeRedirectUri({
         /* @info The URI <code>[scheme]://</code> to be used in bare and standalone. If undefined, the <code>scheme</code> property of your app.json or app.config.js will be used instead. */
         scheme: 'your.app'
         /* @end */
       }),
-      scopes: ['openid', 'user_read', 'analytics:read:games'],
+      scopes: ['user:read:email', 'analytics:read:games'],
     },
     discovery
   );
 
   React.useEffect(() => {
-    if (response?.type === 'success') {
-      /* @info Exchange the code for an access token in a server. Alternatively you can use the <b>Implicit</b> auth method. */
-      const { code } = response.params;
-      /* @end */
-    }
+    if (response && response.type === 'success') {
+      const token = response.params.access_token;
+      }
   }, [response]);
 
   return (


### PR DESCRIPTION
# Why

I was issued to get auth token as written in the example, but that token was not available.
[twitch api always reponse 401 error]

# How

Update twitch example with 
https://dev.twitch.tv/docs/authentication/getting-tokens-oauth

response_type must be set to "token"

and apply v5 to Twitch API Migration Guide
check out https://dev.twitch.tv/docs/api/migration 

# Test Plan
N/A

# Checklist
N/A