### PR TITLE
[docs] Clarify using organization slug in sentry docs

### DIFF
--- a/docs/pages/guides/using-sentry.md
+++ b/docs/pages/guides/using-sentry.md
@@ -88,8 +88,8 @@ Add `expo.hooks` to your project's `app.json` (or `app.config.js`) file:
         {
           "file": "sentry-expo/upload-sourcemaps",
           "config": {
-            "organization": "your sentry organization's short name here",
-            "project": "your sentry project's name here",
+            "organization": "your sentry organization slug here",
+            "project": "your sentry project name here",
             "authToken": "your auth token here"
           }
         }


### PR DESCRIPTION
# Why

The `sentry-expo` readme got updated to clarity using the organization slug. This docs page mirrors that readme (https://github.com/expo/sentry-expo/blob/main/README.md#step-2-code).

# How

Updated to match project readme

# Test Plan

Mk. 1 Eyeball

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
