### PR TITLE
[CI] Fix android ci failures

### DIFF
--- a/.github/workflows/android-instrumentation-tests.yml
+++ b/.github/workflows/android-instrumentation-tests.yml
@@ -71,7 +71,7 @@ jobs:
         if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
       - name: 📱 Run instrumented unit tests
-        timeout-minutes: 40
+        timeout-minutes: 45
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}

--- a/.github/workflows/android-instrumentation-tests.yml
+++ b/.github/workflows/android-instrumentation-tests.yml
@@ -79,6 +79,7 @@ jobs:
           arch: x86_64
           force-avd-creation: false
           script: expotools android-native-unit-tests --type instrumented
+          disk-size: 2048M
       - name: 💾 Save test results
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/client-android.yml
+++ b/.github/workflows/client-android.yml
@@ -39,7 +39,7 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     env:
-      GRADLE_OPTS: -Dorg.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=1024m
+      GRADLE_OPTS: -Dorg.gradle.jvmargs=-Xmx3072m -XX:MaxMetaspaceSize=1024m
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
# Why

fix android client and instrumented test ci failures

# How

- android client: reduce jvm usage a little bit to prevent OOM be killed by github runners.
- android instrumented test: it loooks like timeout and emulator disk size is not enough

# Test Plan

ci passed
