### PR TITLE
[expo-updates] fix rare race condition on Android exposed by e2e tests

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix small race condition in recovery code on Android where in very rare scenarios, a bundle could be downloaded twice.
+- Fix small race condition in recovery code on Android where in very rare scenarios, a bundle could be downloaded twice. ([#18377](https://github.com/expo/expo/pull/18377) by [@esamelson](https://github.com/esamelson))
 
 ### 💡 Others
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix small race condition in recovery code on Android where in very rare scenarios, a bundle could be downloaded twice.
+
 ### 💡 Others
 
 - [iOS] New logger and log reader for unifying logging support in expo-updates. ([#18284](https://github.com/expo/expo/pull/18284) by [@douglowder](https://github.com/douglowder))

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.kt
@@ -85,6 +85,10 @@ class DatabaseLauncher(
 
     localAssetFiles = mutableMapOf<AssetEntity, String>().apply {
       for (asset in assetEntities) {
+        if (asset.id == launchAsset.id) {
+          // we took care of this one above
+          continue
+        }
         val filename = asset.relativePath
         if (filename != null) {
           val assetFile = ensureAssetExists(asset, database, context)


### PR DESCRIPTION
# Why

The e2e tests [failed on main](https://github.com/expo/expo/runs/7505934482?check_suite_focus=true) earlier after landing my PRs.

After doing some work to diagnose locally, I determined that the cause is an actual (but very rare, and harmless) race condition in the Android DatabaseLauncher logic -- in the rare scenarios that we need to recover from a missing asset, and the bundle itself is missing, it's possible it can sometimes be downloaded twice.

While this is relatively harmless as far as bugs go, I'd like to fix it primarily to keep the e2e tests as reliable as possible.

# How

Skip calling `ensureAssetExists` in the for loop, as we already took care of it in the lines above.

# Test Plan

It's hard to be 100% certain that the test failure won't recur, as it was very rare; I only got it 4 times in maybe 50 runs of the test locally. However, based on logging I am quite sure that it was caused by the bundle being downloaded twice -- originating from lines 79 and 90 in DatabaseLauncher.kt -- and so I'm confident in this fix.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
