### PR TITLE
[sweet API][Kotlin] Implement sweet typed arrays 

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Add better JSI error handling on Android. ([#18259](https://github.com/expo/expo/pull/18259) by [@lukmccall](https://github.com/lukmccall))
+- Experimental support for typed arrays on iOS. ([#18379](https://github.com/expo/expo/pull/18379) by [@lukmccall](https://github.com/lukmccall))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptTypedArrayTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptTypedArrayTest.kt
@@ -1,0 +1,379 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package expo.modules.kotlin.jni
+
+import com.google.common.truth.Truth
+import expo.modules.kotlin.typedarray.Float32Array
+import expo.modules.kotlin.typedarray.Float64Array
+import expo.modules.kotlin.typedarray.Int16Array
+import expo.modules.kotlin.typedarray.Int32Array
+import expo.modules.kotlin.typedarray.Int8Array
+import expo.modules.kotlin.typedarray.Uint16Array
+import expo.modules.kotlin.typedarray.Uint32Array
+import expo.modules.kotlin.typedarray.Uint8Array
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Test
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+internal class JavaScriptTypedArrayTest {
+
+  @Test
+  fun kind_should_return_correct_type() = withJSIInterop {
+    val uint16Result = evaluateScript("new Uint16Array(4)")
+    val float32Result = evaluateScript("new Float32Array([1.2, 3.4])")
+
+    Truth.assertThat(uint16Result.isTypedArray()).isTrue()
+    Truth.assertThat(float32Result.isTypedArray()).isTrue()
+
+    val uintTypedArray = uint16Result.getTypedArray()
+    Truth.assertThat(uintTypedArray.kind).isEqualTo(TypedArrayKind.Uint16Array)
+
+    val float32TypedArray = float32Result.getTypedArray()
+    Truth.assertThat(float32TypedArray.kind).isEqualTo(TypedArrayKind.Float32Array)
+  }
+
+  @Test
+  fun should_be_able_access_elements_via_object_api() = withJSIInterop {
+    val typedArray = evaluateScript("new Float32Array([1.2, 3.4])").getTypedArray()
+
+    val first = typedArray.getProperty("0").getDouble()
+    val second = typedArray.getProperty("1").getDouble()
+
+    Truth.assertThat(first).isWithin(1.0e-6).of(1.2)
+    Truth.assertThat(second).isWithin(1.0e-6).of(3.4)
+  }
+
+  @Test
+  fun should_be_convertible_to_direct_buffer_float32() = withJSIInterop {
+    val typedArray = evaluateScript("new Float32Array([1.2, 3.4])").getTypedArray()
+
+    val buffer = typedArray.toDirectBuffer()
+
+    Truth.assertThat(buffer.isDirect).isTrue()
+    Truth.assertThat(buffer.isReadOnly).isFalse()
+
+    val first = buffer.getFloat(0)
+    val second = buffer.getFloat(4)
+
+    Truth.assertThat(first).isEqualTo(1.2f)
+    Truth.assertThat(second).isEqualTo(3.4f)
+  }
+
+  @Test
+  fun should_be_convertible_to_direct_buffer_int32() = withJSIInterop {
+    val typedArray = evaluateScript("new Int32Array([21, 31])").getTypedArray()
+
+    val buffer = typedArray.toDirectBuffer()
+
+    Truth.assertThat(buffer.isDirect).isTrue()
+    Truth.assertThat(buffer.isReadOnly).isFalse()
+
+    val first = buffer.getInt(0)
+    val second = buffer.getInt(4)
+
+    Truth.assertThat(first).isEqualTo(21)
+    Truth.assertThat(second).isEqualTo(31)
+  }
+
+  @Test
+  fun should_be_convertible_to_direct_buffer_int8() = withJSIInterop {
+    val typedArray = evaluateScript("new Int8Array([21, 31])").getTypedArray()
+
+    val buffer = typedArray.toDirectBuffer()
+
+    Truth.assertThat(buffer.isDirect).isTrue()
+    Truth.assertThat(buffer.isReadOnly).isFalse()
+
+    val first = buffer.get(0)
+    val second = buffer.get(1)
+
+    Truth.assertThat(first).isEqualTo(21)
+    Truth.assertThat(second).isEqualTo(31)
+  }
+
+  @Test
+  fun raw_read() = withJSIInterop {
+    val typedArray = evaluateScript("new Int32Array([21, 31])").getTypedArray()
+
+    val firstBytes = ByteArray(4)
+    val secondBytes = ByteArray(4)
+    typedArray.read(firstBytes, 0, 4)
+    typedArray.read(secondBytes, 4, 4)
+
+    val first = wrapBytes(firstBytes).int
+    val second = wrapBytes(secondBytes).int
+
+    Truth.assertThat(first).isEqualTo(21)
+    Truth.assertThat(second).isEqualTo(31)
+  }
+
+  @Test
+  fun raw_write() = withJSIInterop {
+    val typedArray = evaluateScript("new Int32Array([21, 31])").getTypedArray()
+
+    val bytes = ByteArray(4)
+    wrapBytes(bytes).putInt(21345)
+
+    typedArray.write(bytes, 4, 4)
+
+    val first = typedArray.getProperty("0").getDouble().toInt()
+    val second = typedArray.getProperty("1").getDouble().toInt()
+
+    Truth.assertThat(first).isEqualTo(21)
+    Truth.assertThat(second).isEqualTo(21345)
+  }
+
+  @Test
+  fun int8_read() = withJSIInterop {
+    val rawTypedArray = evaluateScript("new Int8Array([-128, 127])").getTypedArray()
+    val typedArray = Int8Array(rawTypedArray)
+
+    val first = typedArray[0]
+    val second = typedArray[1]
+
+    Truth.assertThat(first).isEqualTo(-128)
+    Truth.assertThat(second).isEqualTo(127)
+  }
+
+  @Test
+  fun int8_write() = withJSIInterop {
+    val rawTypedArray = evaluateScript("new Int8Array(2)").getTypedArray()
+    val typedArray = Int8Array(rawTypedArray)
+
+    typedArray[0] = -128
+    typedArray[1] = 127
+
+    val first = typedArray[0]
+    val second = typedArray[1]
+
+    Truth.assertThat(first).isEqualTo(-128)
+    Truth.assertThat(second).isEqualTo(127)
+  }
+
+  @Test
+  fun int16_read() = withJSIInterop {
+    val rawTypedArray = evaluateScript("new Int16Array([-32768, 32767])").getTypedArray()
+    val typedArray = Int16Array(rawTypedArray)
+
+    val first = typedArray[0]
+    val second = typedArray[1]
+
+    Truth.assertThat(first).isEqualTo(-32768)
+    Truth.assertThat(second).isEqualTo(32767)
+  }
+
+  @Test
+  fun int16_write() = withJSIInterop {
+    val rawTypedArray = evaluateScript("new Int16Array([0, 0])").getTypedArray()
+    val typedArray = Int16Array(rawTypedArray)
+
+    typedArray[0] = -32768
+    typedArray[1] = 32767
+
+    val first = typedArray[0]
+    val second = typedArray[1]
+
+    Truth.assertThat(first).isEqualTo(-32768)
+    Truth.assertThat(second).isEqualTo(32767)
+  }
+
+  @Test
+  fun int32_read() = withJSIInterop {
+    val rawTypedArray = evaluateScript("new Int32Array([-2147483648, 2147483647])").getTypedArray()
+    val typedArray = Int32Array(rawTypedArray)
+
+    val first = typedArray[0]
+    val second = typedArray[1]
+
+    Truth.assertThat(first).isEqualTo(-2147483648)
+    Truth.assertThat(second).isEqualTo(2147483647)
+  }
+
+  @Test
+  fun int32_write() = withJSIInterop {
+    val rawTypedArray = evaluateScript("new Int32Array(2)").getTypedArray()
+    val typedArray = Int32Array(rawTypedArray)
+
+    typedArray[0] = -2147483648
+    typedArray[1] = 2147483647
+
+    val first = typedArray[0]
+    val second = typedArray[1]
+
+    Truth.assertThat(first).isEqualTo(-2147483648)
+    Truth.assertThat(second).isEqualTo(2147483647)
+  }
+
+  @Test
+  fun uint8_read() = withJSIInterop {
+    val rawTypedArray = evaluateScript("new Uint8Array([1, 255])").getTypedArray()
+    val typedArray = Uint8Array(rawTypedArray)
+
+    val first = typedArray[0]
+    val second = typedArray[1]
+
+    Truth.assertThat(first).isEqualTo(1.toUByte())
+    Truth.assertThat(second).isEqualTo(255.toUByte())
+  }
+
+  @Test
+  fun uint8_write() = withJSIInterop {
+    val rawTypedArray = evaluateScript("new Uint8Array(2)").getTypedArray()
+    val typedArray = Uint8Array(rawTypedArray)
+
+    typedArray[0] = 10u
+    typedArray[1] = 255u
+
+    val first = typedArray[0]
+    val second = typedArray[1]
+
+    Truth.assertThat(first).isEqualTo(10.toUByte())
+    Truth.assertThat(second).isEqualTo(255.toUByte())
+  }
+
+  @Test
+  fun uint8clamped_read() = withJSIInterop {
+    val rawTypedArray = evaluateScript("new Uint8ClampedArray([1, 255])").getTypedArray()
+    val typedArray = Uint8Array(rawTypedArray)
+
+    val first = typedArray[0]
+    val second = typedArray[1]
+
+    Truth.assertThat(first).isEqualTo(1.toUByte())
+    Truth.assertThat(second).isEqualTo(255.toUByte())
+  }
+
+  @Test
+  fun uint8clamped_write() = withJSIInterop {
+    val rawTypedArray = evaluateScript("new Uint8ClampedArray(2)").getTypedArray()
+    val typedArray = Uint8Array(rawTypedArray)
+
+    typedArray[0] = 10u
+    typedArray[1] = 255u
+
+    val first = typedArray[0]
+    val second = typedArray[1]
+
+    Truth.assertThat(first).isEqualTo(10.toUByte())
+    Truth.assertThat(second).isEqualTo(255.toUByte())
+  }
+
+  @Test
+  fun uint16_read() = withJSIInterop {
+    val rawTypedArray = evaluateScript("new Uint16Array([123, 65535])").getTypedArray()
+    val typedArray = Uint16Array(rawTypedArray)
+
+    val first = typedArray[0]
+    val second = typedArray[1]
+
+    Truth.assertThat(first).isEqualTo(123.toUShort())
+    Truth.assertThat(second).isEqualTo(65535.toUShort())
+  }
+
+  @Test
+  fun uint16_write() = withJSIInterop {
+    val rawTypedArray = evaluateScript("new Uint16Array(2)").getTypedArray()
+    val typedArray = Uint16Array(rawTypedArray)
+
+    typedArray[0] = 123.toUShort()
+    typedArray[1] = 65535.toUShort()
+
+    val first = typedArray[0]
+    val second = typedArray[1]
+
+    Truth.assertThat(first).isEqualTo(123.toUShort())
+    Truth.assertThat(second).isEqualTo(65535.toUShort())
+  }
+
+  @Test
+  fun uint32_read() = withJSIInterop {
+    val rawTypedArray = evaluateScript("new Uint32Array([123, 4294967295])").getTypedArray()
+    val typedArray = Uint32Array(rawTypedArray)
+
+    val first = typedArray[0]
+    val second = typedArray[1]
+
+    Truth.assertThat(first).isEqualTo(123.toUInt())
+    Truth.assertThat(second).isEqualTo(4294967295.toUInt())
+  }
+
+  @Test
+  fun uint32_write() = withJSIInterop {
+    val rawTypedArray = evaluateScript("new Uint32Array(2)").getTypedArray()
+    val typedArray = Uint32Array(rawTypedArray)
+
+    typedArray[0] = 123.toUInt()
+    typedArray[1] = 4294967295.toUInt()
+
+    val first = typedArray[0]
+    val second = typedArray[1]
+
+    Truth.assertThat(first).isEqualTo(123.toUInt())
+    Truth.assertThat(second).isEqualTo(4294967295.toUInt())
+  }
+
+  @Test
+  fun float32_read() = withJSIInterop {
+    val rawTypedArray = evaluateScript("new Float32Array([-1.12432, 987765.312])").getTypedArray()
+    val typedArray = Float32Array(rawTypedArray)
+
+    val first = typedArray[0]
+    val second = typedArray[1]
+
+    Truth.assertThat(first).isEqualTo(-1.12432f)
+    Truth.assertThat(second).isEqualTo(987765.312f)
+  }
+
+  @Test
+  fun float32_write() = withJSIInterop {
+    val rawTypedArray = evaluateScript("new Float32Array(2)").getTypedArray()
+    val typedArray = Float32Array(rawTypedArray)
+
+    typedArray[0] = -1.12432f
+    typedArray[1] = 987765.312f
+
+    val first = typedArray[0]
+    val second = typedArray[1]
+
+    Truth.assertThat(first).isEqualTo(-1.12432f)
+    Truth.assertThat(second).isEqualTo(987765.312f)
+  }
+
+  @Test
+  fun float64_read() = withJSIInterop {
+    val rawTypedArray = evaluateScript("new Float64Array([-1.12432, 987765.312])").getTypedArray()
+    val typedArray = Float64Array(rawTypedArray)
+
+    val first = typedArray[0]
+    val second = typedArray[1]
+
+    Truth.assertThat(first).isEqualTo(-1.12432)
+    Truth.assertThat(second).isEqualTo(987765.312)
+  }
+
+  @Test
+  fun float64_write() = withJSIInterop {
+    val rawTypedArray = evaluateScript("new Float64Array(2)").getTypedArray()
+    val typedArray = Float64Array(rawTypedArray)
+
+    typedArray[0] = -1.12432
+    typedArray[1] = 987765.312
+
+    val first = typedArray[0]
+    val second = typedArray[1]
+
+    Truth.assertThat(first).isEqualTo(-1.12432)
+    Truth.assertThat(second).isEqualTo(987765.312)
+  }
+
+  @Test
+  fun length_should_return_correct_value() = withJSIInterop {
+    val rawTypedArray = evaluateScript("new Float64Array(16)").getTypedArray()
+    val typedArray = Float64Array(rawTypedArray)
+
+    Truth.assertThat(typedArray.length).isEqualTo(16)
+  }
+
+  private fun wrapBytes(array: ByteArray): ByteBuffer = ByteBuffer.wrap(array).order(ByteOrder.nativeOrder())
+}

--- a/packages/expo-modules-core/android/src/main/cpp/JNIInjector.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JNIInjector.cpp
@@ -4,6 +4,7 @@
 #include "JavaScriptModuleObject.h"
 #include "JavaScriptValue.h"
 #include "JavaScriptObject.h"
+#include "JavaScriptTypedArray.h"
 #include "CachedReferencesRegistry.h"
 
 #include <jni.h>
@@ -19,5 +20,6 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *) {
     expo::JavaScriptModuleObject::registerNatives();
     expo::JavaScriptValue::registerNatives();
     expo::JavaScriptObject::registerNatives();
+    expo::JavaScriptTypedArray::registerNatives();
   });
 }

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptObject.h
@@ -59,10 +59,12 @@ public:
 
   void setProperty(const std::string &name, jsi::Value value);
 
-private:
-  friend HybridBase;
+protected:
   WeakRuntimeHolder runtimeHolder;
   std::shared_ptr<jsi::Object> jsObject;
+
+private:
+  friend HybridBase;
 
   bool jniHasProperty(jni::alias_ref<jstring> name);
 

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptTypedArray.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptTypedArray.cpp
@@ -1,0 +1,82 @@
+#include "JavaScriptTypedArray.h"
+
+namespace expo {
+
+JavaScriptTypedArray::JavaScriptTypedArray(
+  std::weak_ptr<JavaScriptRuntime> runtime,
+  std::shared_ptr<jsi::Object> jsObject
+) : jni::HybridClass<JavaScriptTypedArray, JavaScriptObject>(std::move(runtime),
+                                                             std::move(jsObject)) {
+  jsi::Runtime &jsRuntime = *runtimeHolder.lock()->get();
+  typedArrayWrapper = std::make_shared<expo::TypedArray>(jsRuntime, *get());
+  rawPointer = static_cast<char *>(typedArrayWrapper->getRawPointer(jsRuntime));
+}
+
+void JavaScriptTypedArray::registerNatives() {
+  registerHybrid({
+                   makeNativeMethod("getRawKind", JavaScriptTypedArray::getRawKind),
+                   makeNativeMethod("toDirectBuffer", JavaScriptTypedArray::toDirectBuffer),
+                   makeNativeMethod("read", JavaScriptTypedArray::readBuffer),
+                   makeNativeMethod("write", JavaScriptTypedArray::writeBuffer),
+
+                   makeNativeMethod("readByte", JavaScriptTypedArray::read<int8_t>),
+                   makeNativeMethod("read2Byte", JavaScriptTypedArray::read<int16_t>),
+                   makeNativeMethod("read4Byte", JavaScriptTypedArray::read<int32_t>),
+                   makeNativeMethod("read8Byte", JavaScriptTypedArray::read<int64_t>),
+                   makeNativeMethod("readFloat", JavaScriptTypedArray::read<float>),
+                   makeNativeMethod("readDouble", JavaScriptTypedArray::read<double>),
+
+                   makeNativeMethod("writeByte", JavaScriptTypedArray::write<int8_t>),
+                   makeNativeMethod("write2Byte", JavaScriptTypedArray::write<int16_t>),
+                   makeNativeMethod("write4Byte", JavaScriptTypedArray::write<int32_t>),
+                   makeNativeMethod("write8Byte", JavaScriptTypedArray::write<int64_t>),
+                   makeNativeMethod("writeFloat", JavaScriptTypedArray::write<float>),
+                   makeNativeMethod("writeDouble", JavaScriptTypedArray::write<double>),
+                 });
+}
+
+int JavaScriptTypedArray::getRawKind() {
+  auto runtime = runtimeHolder.lock();
+  assert(runtime != nullptr);
+  return (int) typedArrayWrapper->getKind(*runtime->get());
+}
+
+jni::local_ref<jni::JByteBuffer> JavaScriptTypedArray::toDirectBuffer() {
+  auto runtime = runtimeHolder.lock();
+  assert(runtime != nullptr);
+  jsi::Runtime &jsRuntime = *runtime->get();
+
+  auto byteLength = typedArrayWrapper->byteLength(jsRuntime);
+  auto byteOffset = typedArrayWrapper->byteOffset(jsRuntime);
+
+  auto byteBuffer = jni::JByteBuffer::wrapBytes(
+    static_cast<uint8_t *>(typedArrayWrapper->getRawPointer(jsRuntime)),
+    byteLength - byteOffset
+  );
+
+  byteBuffer->order(jni::JByteOrder::nativeOrder());
+
+  return byteBuffer;
+}
+
+void JavaScriptTypedArray::readBuffer(
+  jni::alias_ref<jni::JArrayByte> buffer,
+  int position,
+  int size
+) {
+  buffer->setRegion(
+    0,
+    size,
+    reinterpret_cast<const signed char *>(rawPointer + position)
+  );
+}
+
+void JavaScriptTypedArray::writeBuffer(
+  jni::alias_ref<jni::JArrayByte> buffer,
+  int position,
+  int size
+) {
+  auto region = buffer->getRegion(0, size);
+  memcpy(rawPointer + position, region.get(), size);
+}
+}

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptTypedArray.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptTypedArray.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include "TypedArray.h"
+#include "JavaScriptObject.h"
+#include "JavaScriptRuntime.h"
+
+#include <fbjni/fbjni.h>
+#include <fbjni/ByteBuffer.h>
+#include <jsi/jsi.h>
+
+#include <memory>
+
+namespace expo {
+
+namespace jni = facebook::jni;
+namespace jsi = facebook::jsi;
+
+class JavaScriptTypedArray : public jni::HybridClass<JavaScriptTypedArray, JavaScriptObject> {
+public:
+  static auto constexpr
+    kJavaDescriptor = "Lexpo/modules/kotlin/jni/JavaScriptTypedArray;";
+  static auto constexpr TAG = "JavaScriptTypedArray";
+
+  static void registerNatives();
+
+  JavaScriptTypedArray(
+    std::weak_ptr<JavaScriptRuntime> runtime,
+    std::shared_ptr<jsi::Object> jsObject
+  );
+
+  /**
+   * Gets a raw kind of the underlying typed array.
+   */
+  int getRawKind();
+
+  /**
+   * Converts typed array into a direct byte buffer.
+   */
+  jni::local_ref<jni::JByteBuffer> toDirectBuffer();
+
+private:
+  std::shared_ptr<expo::TypedArray> typedArrayWrapper;
+
+  /**
+   * Cached pointer to the beginning of the byte buffer.
+   */
+  char *rawPointer;
+
+  void readBuffer(jni::alias_ref<jni::JArrayByte> buffer, int position, int size);
+
+  void writeBuffer(jni::alias_ref<jni::JArrayByte> buffer, int position, int size);
+
+  template<class T>
+  T read(int position) {
+    return *reinterpret_cast<T *>(rawPointer + position);
+  }
+
+  template<class T>
+  void write(int position, T value) {
+    *reinterpret_cast<T *>(rawPointer + position) = value;
+  }
+};
+} // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptTypedArray.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptTypedArray.h
@@ -2,7 +2,7 @@
 
 #include "TypedArray.h"
 #include "JavaScriptObject.h"
-#include "JavaScriptRuntime.h"
+#include "WeakRuntimeHolder.h"
 
 #include <fbjni/fbjni.h>
 #include <fbjni/ByteBuffer.h>
@@ -11,6 +11,8 @@
 #include <memory>
 
 namespace expo {
+
+class JavaScriptRuntime;
 
 namespace jni = facebook::jni;
 namespace jsi = facebook::jsi;
@@ -25,6 +27,11 @@ public:
 
   JavaScriptTypedArray(
     std::weak_ptr<JavaScriptRuntime> runtime,
+    std::shared_ptr<jsi::Object> jsObject
+  );
+
+  JavaScriptTypedArray(
+    WeakRuntimeHolder runtime,
     std::shared_ptr<jsi::Object> jsObject
   );
 

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptValue.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptValue.cpp
@@ -129,10 +129,7 @@ bool JavaScriptValue::isObject() {
 
 bool JavaScriptValue::isTypedArray() {
   if (jsValue->isObject()) {
-    auto runtime = runtimeHolder.lock();
-    assert(runtime != nullptr);
-
-    jsi::Runtime &jsRuntime = *runtime->get();
+    jsi::Runtime &jsRuntime = runtimeHolder.getJSRuntime();
     return expo::isTypedArray(jsRuntime, jsValue->getObject(jsRuntime));
   }
   return false;
@@ -187,9 +184,8 @@ jni::local_ref<jstring> JavaScriptValue::jniGetString() {
 }
 
 jni::local_ref<JavaScriptTypedArray::javaobject> JavaScriptValue::getTypedArray() {
-  auto runtime = runtimeHolder.lock();
-  assert(runtime != nullptr);
-  auto jsObject = std::make_shared<jsi::Object>(jsValue->getObject(*runtime->get()));
+  auto &jsRuntime = runtimeHolder.getJSRuntime();
+  auto jsObject = std::make_shared<jsi::Object>(jsValue->getObject(jsRuntime));
   return JavaScriptTypedArray::newObjectCxxArgs(runtimeHolder, jsObject);
 }
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptValue.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptValue.cpp
@@ -4,6 +4,8 @@
 
 #include "JavaScriptRuntime.h"
 #include "JavaScriptObject.h"
+#include "JavaScriptTypedArray.h"
+#include "TypedArray.h"
 
 namespace expo {
 void JavaScriptValue::registerNatives() {
@@ -17,12 +19,14 @@ void JavaScriptValue::registerNatives() {
                    makeNativeMethod("isSymbol", JavaScriptValue::isSymbol),
                    makeNativeMethod("isFunction", JavaScriptValue::isFunction),
                    makeNativeMethod("isArray", JavaScriptValue::isArray),
+                   makeNativeMethod("isTypedArray", JavaScriptValue::isTypedArray),
                    makeNativeMethod("isObject", JavaScriptValue::isObject),
                    makeNativeMethod("getBool", JavaScriptValue::getBool),
                    makeNativeMethod("getDouble", JavaScriptValue::getDouble),
                    makeNativeMethod("getString", JavaScriptValue::jniGetString),
                    makeNativeMethod("getObject", JavaScriptValue::getObject),
                    makeNativeMethod("getArray", JavaScriptValue::getArray),
+                   makeNativeMethod("getTypedArray", JavaScriptValue::getTypedArray),
                  });
 }
 
@@ -123,6 +127,17 @@ bool JavaScriptValue::isObject() {
   return jsValue->isObject();
 }
 
+bool JavaScriptValue::isTypedArray() {
+  if (jsValue->isObject()) {
+    auto runtime = runtimeHolder.lock();
+    assert(runtime != nullptr);
+
+    jsi::Runtime &jsRuntime = *runtime->get();
+    return expo::isTypedArray(jsRuntime, jsValue->getObject(jsRuntime));
+  }
+  return false;
+}
+
 bool JavaScriptValue::getBool() {
   return jsValue->getBool();
 }
@@ -166,9 +181,15 @@ jni::local_ref<jstring> JavaScriptValue::jniKind() {
   auto result = kind();
   return jni::make_jstring(result);
 }
-
 jni::local_ref<jstring> JavaScriptValue::jniGetString() {
   auto result = getString();
   return jni::make_jstring(result);
+}
+
+jni::local_ref<JavaScriptTypedArray::javaobject> JavaScriptValue::getTypedArray() {
+  auto runtime = runtimeHolder.lock();
+  assert(runtime != nullptr);
+  auto jsObject = std::make_shared<jsi::Object>(jsValue->getObject(*runtime->get()));
+  return JavaScriptTypedArray::newObjectCxxArgs(runtimeHolder, jsObject);
 }
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptValue.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptValue.h
@@ -4,6 +4,7 @@
 
 #include "JSIObjectWrapper.h"
 #include "WeakRuntimeHolder.h"
+#include "JavaScriptTypedArray.h"
 
 #include <fbjni/fbjni.h>
 #include <jsi/jsi.h>
@@ -17,6 +18,8 @@ namespace expo {
 class JavaScriptRuntime;
 
 class JavaScriptObject;
+
+class JavaScriptTypedArray;
 
 /**
  * Represents any JavaScript value. Its purpose is to expose the `jsi::Value` API back to Kotlin.
@@ -61,6 +64,8 @@ public:
 
   bool isObject();
 
+  bool isTypedArray();
+
   bool getBool();
 
   double getDouble();
@@ -71,6 +76,7 @@ public:
 
   jni::local_ref<jni::JArrayClass<JavaScriptValue::javaobject>> getArray();
 
+  jni::local_ref<JavaScriptTypedArray::javaobject> getTypedArray();
 private:
   friend HybridBase;
 

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptValue.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptValue.h
@@ -77,6 +77,7 @@ public:
   jni::local_ref<jni::JArrayClass<JavaScriptValue::javaobject>> getArray();
 
   jni::local_ref<JavaScriptTypedArray::javaobject> getTypedArray();
+
 private:
   friend HybridBase;
 

--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
@@ -2,6 +2,7 @@
 #include "JSIInteropModuleRegistry.h"
 #include "JavaScriptValue.h"
 #include "JavaScriptObject.h"
+#include "JavaScriptTypedArray.h"
 #include "CachedReferencesRegistry.h"
 #include "Exceptions.h"
 
@@ -109,6 +110,13 @@ std::vector<jvalue> MethodMetadata::convertJSIArgsToJNI(
     } else if (desiredType & CppType::JS_OBJECT) {
       jarg->l = makeGlobalIfNecessary(
         JavaScriptObject::newObjectCxxArgs(
+          moduleRegistry->runtimeHolder->weak_from_this(),
+          std::make_shared<jsi::Object>(arg->getObject(rt))
+        ).release()
+      );
+    } else if (desiredType & CppType::TYPED_ARRAY) {
+      jarg->l = makeGlobalIfNecessary(
+        JavaScriptTypedArray::newObjectCxxArgs(
           moduleRegistry->runtimeHolder->weak_from_this(),
           std::make_shared<jsi::Object>(arg->getObject(rt))
         ).release()

--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.h
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.h
@@ -28,7 +28,8 @@ enum CppType {
   JS_OBJECT = 1 << 3,
   JS_VALUE = 1 << 4,
   READABLE_ARRAY = 1 << 5,
-  READABLE_MAP = 1 << 6
+  READABLE_MAP = 1 << 6,
+  TYPED_ARRAY = 1 << 7
 };
 
 /**

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/CppType.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/CppType.kt
@@ -15,5 +15,6 @@ enum class CppType(val value: Int) {
   JS_OBJECT(nextValue()),
   JS_VALUE(nextValue()),
   READABLE_ARRAY(nextValue()),
-  READABLE_MAP(nextValue());
+  READABLE_MAP(nextValue()),
+  TYPED_ARRAY(nextValue());
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptObject.kt
@@ -9,7 +9,7 @@ import expo.modules.core.interfaces.DoNotStrip
  */
 @Suppress("KotlinJniMissingFunction")
 @DoNotStrip
-class JavaScriptObject @DoNotStrip private constructor(@DoNotStrip private val mHybridData: HybridData) {
+open class JavaScriptObject @DoNotStrip internal constructor(@DoNotStrip private val mHybridData: HybridData) {
   /**
    * The property descriptor options for the property being defined or modified.
    */

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptTypedArray.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptTypedArray.kt
@@ -1,0 +1,69 @@
+package expo.modules.kotlin.jni
+
+import com.facebook.jni.HybridData
+import expo.modules.core.interfaces.DoNotStrip
+import expo.modules.kotlin.typedarray.AnyTypedArray
+import java.nio.ByteBuffer
+
+private var nextValue = 1
+
+private fun nextValue(): Int = nextValue++
+
+enum class TypedArrayKind(val value: Int = nextValue()) {
+  Int8Array,
+  Int16Array,
+  Int32Array,
+  Uint8Array,
+  Uint8ClampedArray,
+  Uint16Array,
+  Uint32Array,
+  Float32Array,
+  Float64Array,
+  BigInt64Array,
+  BigUint64Array,
+}
+
+@Suppress("KotlinJniMissingFunction")
+@DoNotStrip
+class JavaScriptTypedArray @DoNotStrip constructor(hybridData: HybridData)
+  : JavaScriptObject(hybridData), AnyTypedArray {
+
+  override val kind: TypedArrayKind by lazy {
+    val rawKind = getRawKind()
+    TypedArrayKind.values().first { it.value == rawKind }
+  }
+
+  override val length: Int by lazy {
+    getProperty("length").getDouble().toInt()
+  }
+
+  override val byteLength: Int by lazy {
+    getProperty("byteLength").getDouble().toInt()
+  }
+
+  override val byteOffset: Int by lazy {
+    getProperty("byteOffset").getDouble().toInt()
+  }
+
+  private external fun getRawKind(): Int
+
+  external override fun toDirectBuffer(): ByteBuffer
+
+  external override fun read(buffer: ByteArray, position: Int, size: Int)
+  external override fun write(buffer: ByteArray, position: Int, size: Int)
+
+  external override fun readByte(position: Int): Byte
+  external override fun read2Byte(position: Int): Short
+  external override fun read4Byte(position: Int): Int
+  external override fun read8Byte(position: Int): Long
+  external override fun readFloat(position: Int): Float
+
+  external override fun readDouble(position: Int): Double
+  external override fun writeByte(position: Int, value: Byte)
+  external override fun write2Byte(position: Int, value: Short)
+  external override fun write4Byte(position: Int, value: Int)
+  external override fun write8Byte(position: Int, value: Long)
+  external override fun writeFloat(position: Int, value: Float)
+
+  external override fun writeDouble(position: Int, value: Double)
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptTypedArray.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptTypedArray.kt
@@ -25,8 +25,8 @@ enum class TypedArrayKind(val value: Int = nextValue()) {
 
 @Suppress("KotlinJniMissingFunction")
 @DoNotStrip
-class JavaScriptTypedArray @DoNotStrip constructor(hybridData: HybridData)
-  : JavaScriptObject(hybridData), AnyTypedArray {
+class JavaScriptTypedArray @DoNotStrip constructor(hybridData: HybridData) :
+  JavaScriptObject(hybridData), AnyTypedArray {
 
   override val kind: TypedArrayKind by lazy {
     val rawKind = getRawKind()

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptValue.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptValue.kt
@@ -20,6 +20,7 @@ class JavaScriptValue @DoNotStrip private constructor(@DoNotStrip private val mH
   external fun isSymbol(): Boolean
   external fun isFunction(): Boolean
   external fun isArray(): Boolean
+  external fun isTypedArray(): Boolean
   external fun isObject(): Boolean
 
   external fun getBool(): Boolean
@@ -27,6 +28,7 @@ class JavaScriptValue @DoNotStrip private constructor(@DoNotStrip private val mH
   external fun getString(): String
   external fun getObject(): JavaScriptObject
   external fun getArray(): Array<JavaScriptValue>
+  external fun getTypedArray(): JavaScriptTypedArray
 
   @Throws(Throwable::class)
   protected fun finalize() {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/typedarray/AnyTypedArray.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/typedarray/AnyTypedArray.kt
@@ -1,0 +1,51 @@
+package expo.modules.kotlin.typedarray
+
+import expo.modules.kotlin.jni.TypedArrayKind
+import java.nio.ByteBuffer
+
+interface AnyTypedArray {
+  /**
+   * Returns the kind of the typed array, such as `Int8Array` or `Float32Array`.
+   */
+  val kind: TypedArrayKind
+
+  /**
+   * Returns the number of elements held in the typed array.
+   * Fixed at construction time and thus read only.
+   */
+  val length: Int
+
+  /**
+   * The length in bytes from the start of the underlying ArrayBuffer.
+   * Fixed at construction time and thus read-only.
+   */
+  val byteLength: Int
+
+  /**
+   * The offset in bytes from the start of the underlying ArrayBuffer.
+   * Fixed at construction time and thus read-only.
+   */
+  val byteOffset: Int
+
+  /**
+   * Converts typed array into a direct byte buffer.
+   */
+  fun toDirectBuffer(): ByteBuffer
+
+  fun read(buffer: ByteArray, position: Int, size: Int)
+  fun write(buffer: ByteArray, position: Int, size: Int)
+
+  fun readByte(position: Int): Byte
+  fun read2Byte(position: Int): Short
+  fun read4Byte(position: Int): Int
+  fun read8Byte(position: Int): Long
+  fun readFloat(position: Int): Float
+  fun readDouble(position: Int): Double
+
+  fun writeByte(position: Int, value: Byte)
+  fun write2Byte(position: Int, value: Short)
+  fun write4Byte(position: Int, value: Int)
+  fun write8Byte(position: Int, value: Long)
+  fun writeFloat(position: Int, value: Float)
+  fun writeDouble(position: Int, value: Double)
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/typedarray/ConcreteTypedArrays.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/typedarray/ConcreteTypedArrays.kt
@@ -1,0 +1,154 @@
+package expo.modules.kotlin.typedarray
+
+import expo.modules.kotlin.jni.JavaScriptTypedArray
+
+@Suppress("NOTHING_TO_INLINE")
+private inline fun AnyTypedArray.checkIfInRange(index: Int) {
+  if (index < 0 || index >= length) {
+    throw IndexOutOfBoundsException()
+  }
+}
+
+class Int8Array(private val rawArray: JavaScriptTypedArray)
+  : AnyTypedArray by rawArray, GenericTypedArray<Byte> {
+  override operator fun get(index: Int): Byte {
+    checkIfInRange(index)
+    return readByte(index)
+  }
+
+  override operator fun set(index: Int, value: Byte) {
+    checkIfInRange(index)
+    writeByte(index, value)
+  }
+}
+
+class Int16Array(private val rawArray: JavaScriptTypedArray)
+  : AnyTypedArray by rawArray, GenericTypedArray<Short> {
+  override operator fun get(index: Int): Short {
+    checkIfInRange(index)
+    return read2Byte(index * 2)
+  }
+
+  override operator fun set(index: Int, value: Short) {
+    checkIfInRange(index)
+    write2Byte(index * 2, value)
+  }
+}
+
+class Int32Array(private val rawArray: JavaScriptTypedArray)
+  : AnyTypedArray by rawArray, GenericTypedArray<Int> {
+  override operator fun get(index: Int): Int {
+    checkIfInRange(index)
+    return read4Byte(index * 4)
+  }
+
+  override operator fun set(index: Int, value: Int) {
+    checkIfInRange(index)
+    write4Byte(index * 4, value)
+  }
+}
+
+class Uint8Array(private val rawArray: JavaScriptTypedArray)
+  : AnyTypedArray by rawArray, GenericTypedArray<UByte> {
+  override operator fun get(index: Int): UByte {
+    checkIfInRange(index)
+    return readByte(index).toUByte()
+  }
+
+  override operator fun set(index: Int, value: UByte) {
+    checkIfInRange(index)
+    writeByte(index, value.toByte())
+  }
+}
+
+class Uint8ClampedArray(private val rawArray: JavaScriptTypedArray)
+  : AnyTypedArray by rawArray, GenericTypedArray<UByte> {
+  override operator fun get(index: Int): UByte {
+    checkIfInRange(index)
+    return readByte(index).toUByte()
+  }
+
+  override operator fun set(index: Int, value: UByte) {
+    checkIfInRange(index)
+    writeByte(index, value.toByte())
+  }
+}
+
+class Uint16Array(private val rawArray: JavaScriptTypedArray)
+  : AnyTypedArray by rawArray, GenericTypedArray<UShort> {
+  override operator fun get(index: Int): UShort {
+    checkIfInRange(index)
+    return read2Byte(index * 2).toUShort()
+  }
+
+  override operator fun set(index: Int, value: UShort) {
+    checkIfInRange(index)
+    write2Byte(index * 2, value.toShort())
+  }
+}
+
+class Uint32Array(private val rawArray: JavaScriptTypedArray)
+  : AnyTypedArray by rawArray, GenericTypedArray<UInt> {
+  override operator fun get(index: Int): UInt {
+    checkIfInRange(index)
+    return read4Byte(index * 4).toUInt()
+  }
+
+  override operator fun set(index: Int, value: UInt) {
+    checkIfInRange(index)
+    write4Byte(index * 4, value.toInt())
+  }
+}
+
+class Float32Array(private val rawArray: JavaScriptTypedArray)
+  : AnyTypedArray by rawArray, GenericTypedArray<Float> {
+  override operator fun get(index: Int): Float {
+    checkIfInRange(index)
+    return readFloat(index * 4)
+  }
+
+  override operator fun set(index: Int, value: Float) {
+    checkIfInRange(index)
+    writeFloat(index * 4, value)
+  }
+}
+
+class Float64Array(private val rawArray: JavaScriptTypedArray)
+  : AnyTypedArray by rawArray, GenericTypedArray<Double> {
+
+  override operator fun get(index: Int): Double {
+    checkIfInRange(index)
+    return readDouble(index * 8)
+  }
+
+  override operator fun set(index: Int, value: Double) {
+    checkIfInRange(index)
+    writeDouble(index * 8, value)
+  }
+}
+
+class BigInt64Array(private val rawArray: JavaScriptTypedArray)
+  : AnyTypedArray by rawArray, GenericTypedArray<Long> {
+  override operator fun get(index: Int): Long {
+    checkIfInRange(index)
+    return read8Byte(index * 8)
+  }
+
+  override operator fun set(index: Int, value: Long) {
+    checkIfInRange(index)
+    write8Byte(index * 8, value)
+  }
+}
+
+class BigUint64Array(private val rawArray: JavaScriptTypedArray)
+  : AnyTypedArray by rawArray, GenericTypedArray<ULong> {
+  override operator fun get(index: Int): ULong {
+    checkIfInRange(index)
+    return read8Byte(index * 8).toULong()
+  }
+
+  override operator fun set(index: Int, value: ULong) {
+    checkIfInRange(index)
+    write8Byte(index * 8, value.toLong())
+  }
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/typedarray/ConcreteTypedArrays.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/typedarray/ConcreteTypedArrays.kt
@@ -13,12 +13,12 @@ class Int8Array(private val rawArray: JavaScriptTypedArray) :
   AnyTypedArray by rawArray, GenericTypedArray<Byte> {
   override operator fun get(index: Int): Byte {
     checkIfInRange(index)
-    return readByte(index)
+    return readByte(index * Byte.SIZE_BYTES)
   }
 
   override operator fun set(index: Int, value: Byte) {
     checkIfInRange(index)
-    writeByte(index, value)
+    writeByte(index * Byte.SIZE_BYTES, value)
   }
 }
 
@@ -26,12 +26,12 @@ class Int16Array(private val rawArray: JavaScriptTypedArray) :
   AnyTypedArray by rawArray, GenericTypedArray<Short> {
   override operator fun get(index: Int): Short {
     checkIfInRange(index)
-    return read2Byte(index * 2)
+    return read2Byte(index * Short.SIZE_BYTES)
   }
 
   override operator fun set(index: Int, value: Short) {
     checkIfInRange(index)
-    write2Byte(index * 2, value)
+    write2Byte(index * Short.SIZE_BYTES, value)
   }
 }
 
@@ -39,12 +39,12 @@ class Int32Array(private val rawArray: JavaScriptTypedArray) :
   AnyTypedArray by rawArray, GenericTypedArray<Int> {
   override operator fun get(index: Int): Int {
     checkIfInRange(index)
-    return read4Byte(index * 4)
+    return read4Byte(index * Int.SIZE_BYTES)
   }
 
   override operator fun set(index: Int, value: Int) {
     checkIfInRange(index)
-    write4Byte(index * 4, value)
+    write4Byte(index * Int.SIZE_BYTES, value)
   }
 }
 
@@ -52,12 +52,12 @@ class Uint8Array(private val rawArray: JavaScriptTypedArray) :
   AnyTypedArray by rawArray, GenericTypedArray<UByte> {
   override operator fun get(index: Int): UByte {
     checkIfInRange(index)
-    return readByte(index).toUByte()
+    return readByte(index * UByte.SIZE_BYTES).toUByte()
   }
 
   override operator fun set(index: Int, value: UByte) {
     checkIfInRange(index)
-    writeByte(index, value.toByte())
+    writeByte(index * UByte.SIZE_BYTES, value.toByte())
   }
 }
 
@@ -65,12 +65,12 @@ class Uint8ClampedArray(private val rawArray: JavaScriptTypedArray) :
   AnyTypedArray by rawArray, GenericTypedArray<UByte> {
   override operator fun get(index: Int): UByte {
     checkIfInRange(index)
-    return readByte(index).toUByte()
+    return readByte(index * UByte.SIZE_BYTES).toUByte()
   }
 
   override operator fun set(index: Int, value: UByte) {
     checkIfInRange(index)
-    writeByte(index, value.toByte())
+    writeByte(index * UByte.SIZE_BYTES, value.toByte())
   }
 }
 
@@ -78,12 +78,12 @@ class Uint16Array(private val rawArray: JavaScriptTypedArray) :
   AnyTypedArray by rawArray, GenericTypedArray<UShort> {
   override operator fun get(index: Int): UShort {
     checkIfInRange(index)
-    return read2Byte(index * 2).toUShort()
+    return read2Byte(index * UShort.SIZE_BYTES).toUShort()
   }
 
   override operator fun set(index: Int, value: UShort) {
     checkIfInRange(index)
-    write2Byte(index * 2, value.toShort())
+    write2Byte(index * UShort.SIZE_BYTES, value.toShort())
   }
 }
 
@@ -91,12 +91,12 @@ class Uint32Array(private val rawArray: JavaScriptTypedArray) :
   AnyTypedArray by rawArray, GenericTypedArray<UInt> {
   override operator fun get(index: Int): UInt {
     checkIfInRange(index)
-    return read4Byte(index * 4).toUInt()
+    return read4Byte(index * UInt.SIZE_BYTES).toUInt()
   }
 
   override operator fun set(index: Int, value: UInt) {
     checkIfInRange(index)
-    write4Byte(index * 4, value.toInt())
+    write4Byte(index * UInt.SIZE_BYTES, value.toInt())
   }
 }
 
@@ -104,12 +104,12 @@ class Float32Array(private val rawArray: JavaScriptTypedArray) :
   AnyTypedArray by rawArray, GenericTypedArray<Float> {
   override operator fun get(index: Int): Float {
     checkIfInRange(index)
-    return readFloat(index * 4)
+    return readFloat(index * Float.SIZE_BYTES)
   }
 
   override operator fun set(index: Int, value: Float) {
     checkIfInRange(index)
-    writeFloat(index * 4, value)
+    writeFloat(index * Float.SIZE_BYTES, value)
   }
 }
 
@@ -118,12 +118,12 @@ class Float64Array(private val rawArray: JavaScriptTypedArray) :
 
   override operator fun get(index: Int): Double {
     checkIfInRange(index)
-    return readDouble(index * 8)
+    return readDouble(index * Double.SIZE_BYTES)
   }
 
   override operator fun set(index: Int, value: Double) {
     checkIfInRange(index)
-    writeDouble(index * 8, value)
+    writeDouble(index * Double.SIZE_BYTES, value)
   }
 }
 
@@ -131,12 +131,12 @@ class BigInt64Array(private val rawArray: JavaScriptTypedArray) :
   AnyTypedArray by rawArray, GenericTypedArray<Long> {
   override operator fun get(index: Int): Long {
     checkIfInRange(index)
-    return read8Byte(index * 8)
+    return read8Byte(index * Long.SIZE_BYTES)
   }
 
   override operator fun set(index: Int, value: Long) {
     checkIfInRange(index)
-    write8Byte(index * 8, value)
+    write8Byte(index * Long.SIZE_BYTES, value)
   }
 }
 
@@ -144,11 +144,11 @@ class BigUint64Array(private val rawArray: JavaScriptTypedArray) :
   AnyTypedArray by rawArray, GenericTypedArray<ULong> {
   override operator fun get(index: Int): ULong {
     checkIfInRange(index)
-    return read8Byte(index * 8).toULong()
+    return read8Byte(index * ULong.SIZE_BYTES).toULong()
   }
 
   override operator fun set(index: Int, value: ULong) {
     checkIfInRange(index)
-    write8Byte(index * 8, value.toLong())
+    write8Byte(index * ULong.SIZE_BYTES, value.toLong())
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/typedarray/ConcreteTypedArrays.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/typedarray/ConcreteTypedArrays.kt
@@ -9,8 +9,8 @@ private inline fun AnyTypedArray.checkIfInRange(index: Int) {
   }
 }
 
-class Int8Array(private val rawArray: JavaScriptTypedArray)
-  : AnyTypedArray by rawArray, GenericTypedArray<Byte> {
+class Int8Array(private val rawArray: JavaScriptTypedArray) :
+  AnyTypedArray by rawArray, GenericTypedArray<Byte> {
   override operator fun get(index: Int): Byte {
     checkIfInRange(index)
     return readByte(index)
@@ -22,8 +22,8 @@ class Int8Array(private val rawArray: JavaScriptTypedArray)
   }
 }
 
-class Int16Array(private val rawArray: JavaScriptTypedArray)
-  : AnyTypedArray by rawArray, GenericTypedArray<Short> {
+class Int16Array(private val rawArray: JavaScriptTypedArray) :
+  AnyTypedArray by rawArray, GenericTypedArray<Short> {
   override operator fun get(index: Int): Short {
     checkIfInRange(index)
     return read2Byte(index * 2)
@@ -35,8 +35,8 @@ class Int16Array(private val rawArray: JavaScriptTypedArray)
   }
 }
 
-class Int32Array(private val rawArray: JavaScriptTypedArray)
-  : AnyTypedArray by rawArray, GenericTypedArray<Int> {
+class Int32Array(private val rawArray: JavaScriptTypedArray) :
+  AnyTypedArray by rawArray, GenericTypedArray<Int> {
   override operator fun get(index: Int): Int {
     checkIfInRange(index)
     return read4Byte(index * 4)
@@ -48,8 +48,8 @@ class Int32Array(private val rawArray: JavaScriptTypedArray)
   }
 }
 
-class Uint8Array(private val rawArray: JavaScriptTypedArray)
-  : AnyTypedArray by rawArray, GenericTypedArray<UByte> {
+class Uint8Array(private val rawArray: JavaScriptTypedArray) :
+  AnyTypedArray by rawArray, GenericTypedArray<UByte> {
   override operator fun get(index: Int): UByte {
     checkIfInRange(index)
     return readByte(index).toUByte()
@@ -61,8 +61,8 @@ class Uint8Array(private val rawArray: JavaScriptTypedArray)
   }
 }
 
-class Uint8ClampedArray(private val rawArray: JavaScriptTypedArray)
-  : AnyTypedArray by rawArray, GenericTypedArray<UByte> {
+class Uint8ClampedArray(private val rawArray: JavaScriptTypedArray) :
+  AnyTypedArray by rawArray, GenericTypedArray<UByte> {
   override operator fun get(index: Int): UByte {
     checkIfInRange(index)
     return readByte(index).toUByte()
@@ -74,8 +74,8 @@ class Uint8ClampedArray(private val rawArray: JavaScriptTypedArray)
   }
 }
 
-class Uint16Array(private val rawArray: JavaScriptTypedArray)
-  : AnyTypedArray by rawArray, GenericTypedArray<UShort> {
+class Uint16Array(private val rawArray: JavaScriptTypedArray) :
+  AnyTypedArray by rawArray, GenericTypedArray<UShort> {
   override operator fun get(index: Int): UShort {
     checkIfInRange(index)
     return read2Byte(index * 2).toUShort()
@@ -87,8 +87,8 @@ class Uint16Array(private val rawArray: JavaScriptTypedArray)
   }
 }
 
-class Uint32Array(private val rawArray: JavaScriptTypedArray)
-  : AnyTypedArray by rawArray, GenericTypedArray<UInt> {
+class Uint32Array(private val rawArray: JavaScriptTypedArray) :
+  AnyTypedArray by rawArray, GenericTypedArray<UInt> {
   override operator fun get(index: Int): UInt {
     checkIfInRange(index)
     return read4Byte(index * 4).toUInt()
@@ -100,8 +100,8 @@ class Uint32Array(private val rawArray: JavaScriptTypedArray)
   }
 }
 
-class Float32Array(private val rawArray: JavaScriptTypedArray)
-  : AnyTypedArray by rawArray, GenericTypedArray<Float> {
+class Float32Array(private val rawArray: JavaScriptTypedArray) :
+  AnyTypedArray by rawArray, GenericTypedArray<Float> {
   override operator fun get(index: Int): Float {
     checkIfInRange(index)
     return readFloat(index * 4)
@@ -113,8 +113,8 @@ class Float32Array(private val rawArray: JavaScriptTypedArray)
   }
 }
 
-class Float64Array(private val rawArray: JavaScriptTypedArray)
-  : AnyTypedArray by rawArray, GenericTypedArray<Double> {
+class Float64Array(private val rawArray: JavaScriptTypedArray) :
+  AnyTypedArray by rawArray, GenericTypedArray<Double> {
 
   override operator fun get(index: Int): Double {
     checkIfInRange(index)
@@ -127,8 +127,8 @@ class Float64Array(private val rawArray: JavaScriptTypedArray)
   }
 }
 
-class BigInt64Array(private val rawArray: JavaScriptTypedArray)
-  : AnyTypedArray by rawArray, GenericTypedArray<Long> {
+class BigInt64Array(private val rawArray: JavaScriptTypedArray) :
+  AnyTypedArray by rawArray, GenericTypedArray<Long> {
   override operator fun get(index: Int): Long {
     checkIfInRange(index)
     return read8Byte(index * 8)
@@ -140,8 +140,8 @@ class BigInt64Array(private val rawArray: JavaScriptTypedArray)
   }
 }
 
-class BigUint64Array(private val rawArray: JavaScriptTypedArray)
-  : AnyTypedArray by rawArray, GenericTypedArray<ULong> {
+class BigUint64Array(private val rawArray: JavaScriptTypedArray) :
+  AnyTypedArray by rawArray, GenericTypedArray<ULong> {
   override operator fun get(index: Int): ULong {
     checkIfInRange(index)
     return read8Byte(index * 8).toULong()

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/typedarray/GenericTypedArray.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/typedarray/GenericTypedArray.kt
@@ -1,0 +1,8 @@
+package expo.modules.kotlin.typedarray
+
+interface GenericTypedArray<T> : AnyTypedArray, Iterable<T> {
+  operator fun get(index: Int): T
+  operator fun set(index: Int, value: T)
+
+  override fun iterator(): Iterator<T> = TypedArrayIterator(this)
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/typedarray/TypedArrayIterator.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/typedarray/TypedArrayIterator.kt
@@ -1,0 +1,9 @@
+package expo.modules.kotlin.typedarray
+
+class TypedArrayIterator<T>(private val typedArray: GenericTypedArray<T>) : Iterator<T> {
+  private var current = 0
+
+  override fun hasNext(): Boolean = current < typedArray.length
+
+  override fun next(): T = typedArray[current++]
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/BasicTypeConverters.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/BasicTypeConverters.kt
@@ -3,9 +3,22 @@ package expo.modules.kotlin.types
 import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import expo.modules.kotlin.typedarray.BigInt64Array
+import expo.modules.kotlin.typedarray.BigUint64Array
 import expo.modules.kotlin.jni.CppType
+import expo.modules.kotlin.typedarray.Float32Array
+import expo.modules.kotlin.typedarray.Float64Array
+import expo.modules.kotlin.typedarray.Int16Array
+import expo.modules.kotlin.typedarray.Int32Array
+import expo.modules.kotlin.typedarray.Int8Array
 import expo.modules.kotlin.jni.JavaScriptObject
+import expo.modules.kotlin.jni.JavaScriptTypedArray
 import expo.modules.kotlin.jni.JavaScriptValue
+import expo.modules.kotlin.typedarray.AnyTypedArray
+import expo.modules.kotlin.typedarray.Uint16Array
+import expo.modules.kotlin.typedarray.Uint32Array
+import expo.modules.kotlin.typedarray.Uint8Array
+import expo.modules.kotlin.typedarray.Uint8ClampedArray
 
 class IntTypeConverter(isOptional: Boolean) : DynamicAwareTypeConverters<Int>(isOptional) {
   override fun convertFromDynamic(value: Dynamic): Int = value.asInt()
@@ -105,4 +118,60 @@ class JavaScriptValueTypeConvert(isOptional: Boolean) : TypeConverter<JavaScript
 class JavaScriptObjectTypeConverter(isOptional: Boolean) : TypeConverter<JavaScriptObject>(isOptional) {
   override fun convertNonOptional(value: Any): JavaScriptObject = value as JavaScriptObject
   override fun getCppRequiredTypes(): List<CppType> = listOf(CppType.JS_OBJECT)
+}
+
+abstract class BaseTypeArrayConverter<T : AnyTypedArray>(isOptional: Boolean) : TypeConverter<T>(isOptional) {
+  abstract fun wrapJavaScriptTypedArray(value: JavaScriptTypedArray): T
+
+  override fun convertNonOptional(value: Any): T = wrapJavaScriptTypedArray(value as JavaScriptTypedArray)
+
+  override fun getCppRequiredTypes(): List<CppType> = listOf(CppType.TYPED_ARRAY)
+}
+
+class Int8ArrayTypeConverter(isOptional: Boolean) : BaseTypeArrayConverter<Int8Array>(isOptional) {
+  override fun wrapJavaScriptTypedArray(value: JavaScriptTypedArray) = Int8Array(value)
+}
+
+class Int16ArrayTypeConverter(isOptional: Boolean) : BaseTypeArrayConverter<Int16Array>(isOptional) {
+  override fun wrapJavaScriptTypedArray(value: JavaScriptTypedArray) = Int16Array(value)
+}
+
+class Int32ArrayTypeConverter(isOptional: Boolean) : BaseTypeArrayConverter<Int32Array>(isOptional) {
+  override fun wrapJavaScriptTypedArray(value: JavaScriptTypedArray) = Int32Array(value)
+}
+
+class Uint8ArrayTypeConverter(isOptional: Boolean) : BaseTypeArrayConverter<Uint8Array>(isOptional) {
+  override fun wrapJavaScriptTypedArray(value: JavaScriptTypedArray) = Uint8Array(value)
+}
+
+class Uint8ClampedArrayTypeConverter(isOptional: Boolean) : BaseTypeArrayConverter<Uint8ClampedArray>(isOptional) {
+  override fun wrapJavaScriptTypedArray(value: JavaScriptTypedArray) = Uint8ClampedArray(value)
+}
+
+class Uint16ArrayTypeConverter(isOptional: Boolean) : BaseTypeArrayConverter<Uint16Array>(isOptional) {
+  override fun wrapJavaScriptTypedArray(value: JavaScriptTypedArray) = Uint16Array(value)
+}
+
+class Uint32ArrayTypeConverter(isOptional: Boolean) : BaseTypeArrayConverter<Uint32Array>(isOptional) {
+  override fun wrapJavaScriptTypedArray(value: JavaScriptTypedArray) = Uint32Array(value)
+}
+
+class Float32ArrayTypeConverter(isOptional: Boolean) : BaseTypeArrayConverter<Float32Array>(isOptional) {
+  override fun wrapJavaScriptTypedArray(value: JavaScriptTypedArray) = Float32Array(value)
+}
+
+class Float64ArrayTypeConverter(isOptional: Boolean) : BaseTypeArrayConverter<Float64Array>(isOptional) {
+  override fun wrapJavaScriptTypedArray(value: JavaScriptTypedArray) = Float64Array(value)
+}
+
+class BigInt64ArrayTypeConverter(isOptional: Boolean) : BaseTypeArrayConverter<BigInt64Array>(isOptional) {
+  override fun wrapJavaScriptTypedArray(value: JavaScriptTypedArray) = BigInt64Array(value)
+}
+
+class BigUint64ArrayTypeConverter(isOptional: Boolean) : BaseTypeArrayConverter<BigUint64Array>(isOptional) {
+  override fun wrapJavaScriptTypedArray(value: JavaScriptTypedArray) = BigUint64Array(value)
+}
+
+class TypedArrayTypeConverter(isOptional: Boolean) : BaseTypeArrayConverter<AnyTypedArray>(isOptional) {
+  override fun wrapJavaScriptTypedArray(value: JavaScriptTypedArray): AnyTypedArray = value
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
@@ -6,8 +6,20 @@ import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import expo.modules.kotlin.exception.MissingTypeConverter
+import expo.modules.kotlin.typedarray.BigInt64Array
+import expo.modules.kotlin.typedarray.BigUint64Array
+import expo.modules.kotlin.typedarray.Float32Array
+import expo.modules.kotlin.typedarray.Float64Array
+import expo.modules.kotlin.typedarray.Int16Array
+import expo.modules.kotlin.typedarray.Int32Array
+import expo.modules.kotlin.typedarray.Int8Array
 import expo.modules.kotlin.jni.JavaScriptObject
 import expo.modules.kotlin.jni.JavaScriptValue
+import expo.modules.kotlin.typedarray.AnyTypedArray
+import expo.modules.kotlin.typedarray.Uint16Array
+import expo.modules.kotlin.typedarray.Uint32Array
+import expo.modules.kotlin.typedarray.Uint8Array
+import expo.modules.kotlin.typedarray.Uint8ClampedArray
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.records.RecordTypeConverter
 import kotlin.reflect.KClass
@@ -120,6 +132,19 @@ object TypeConverterProviderImpl : TypeConverterProvider {
 
       JavaScriptValue::class.createType(nullable = isOptional) to JavaScriptValueTypeConvert(isOptional),
       JavaScriptObject::class.createType(nullable = isOptional) to JavaScriptObjectTypeConverter(isOptional),
+
+      Int8Array::class.createType(nullable = isOptional) to Int8ArrayTypeConverter(isOptional),
+      Int16Array::class.createType(nullable = isOptional) to Int16ArrayTypeConverter(isOptional),
+      Int32Array::class.createType(nullable = isOptional) to Int32ArrayTypeConverter(isOptional),
+      Uint8Array::class.createType(nullable = isOptional) to Uint8ArrayTypeConverter(isOptional),
+      Uint8ClampedArray::class.createType(nullable = isOptional) to Uint8ClampedArrayTypeConverter(isOptional),
+      Uint16Array::class.createType(nullable = isOptional) to Uint16ArrayTypeConverter(isOptional),
+      Uint32Array::class.createType(nullable = isOptional) to Uint32ArrayTypeConverter(isOptional),
+      Float32Array::class.createType(nullable = isOptional) to Float32ArrayTypeConverter(isOptional),
+      Float64Array::class.createType(nullable = isOptional) to Float64ArrayTypeConverter(isOptional),
+      BigInt64Array::class.createType(nullable = isOptional) to BigInt64ArrayTypeConverter(isOptional),
+      BigUint64Array::class.createType(nullable = isOptional) to BigUint64ArrayTypeConverter(isOptional),
+      AnyTypedArray::class.createType(nullable = isOptional) to TypedArrayTypeConverter(isOptional),
 
       Any::class.createType(nullable = isOptional) to AnyTypeConverter(isOptional),
     )

--- a/packages/expo-modules-core/common/cpp/TypedArray.cpp
+++ b/packages/expo-modules-core/common/cpp/TypedArray.cpp
@@ -38,6 +38,10 @@ size_t TypedArray::byteOffset(jsi::Runtime &runtime) const {
   return getProperty(runtime, "byteOffset").asNumber();
 }
 
+size_t TypedArray::byteLength(jsi::Runtime &runtime) const {
+  return getProperty(runtime, "byteLength").asNumber();
+}
+
 jsi::ArrayBuffer TypedArray::getBuffer(jsi::Runtime &runtime) const {
   auto buffer = getProperty(runtime, "buffer");
   if (buffer.isObject() && buffer.asObject(runtime).isArrayBuffer(runtime)) {

--- a/packages/expo-modules-core/common/cpp/TypedArray.h
+++ b/packages/expo-modules-core/common/cpp/TypedArray.h
@@ -2,6 +2,8 @@
 
 #ifdef __cplusplus
 
+#pragma once
+
 #include <jsi/jsi.h>
 
 namespace jsi = facebook::jsi;
@@ -33,6 +35,8 @@ class TypedArray : public jsi::Object {
   TypedArrayKind getKind(jsi::Runtime &runtime) const;
 
   size_t byteOffset(jsi::Runtime &runtime) const;
+
+  size_t byteLength(jsi::Runtime &runtime) const;
 
   jsi::ArrayBuffer getBuffer(jsi::Runtime &runtime) const;
 


### PR DESCRIPTION
# Why

A follow-up to the https://github.com/expo/expo/pull/17667.

# How

- Reused some C++ utils to deal with typed arrays
- Made classes for typed arrays on both sides: native and JS
- Added new converters to obtain typed arrays as function arguments 
- Added tests

# Test Plan

- unit tests ✅
