### PR TITLE
[sweet API][Kotlin] Simplify usage of `JavaScriptRuntime`

### DIFF
--- a/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.cpp
@@ -59,7 +59,7 @@ void JSIInteropModuleRegistry::installJSI(
 
 void JSIInteropModuleRegistry::installJSIForTests() {
   runtimeHolder = std::make_shared<JavaScriptRuntime>();
-  jsi::Runtime &jsiRuntime = *runtimeHolder->get();
+  jsi::Runtime &jsiRuntime = runtimeHolder->get();
 
   auto expoModules = std::make_shared<ExpoModulesHostObject>(this);
   auto expoModulesObject = jsi::Object::createFromHostObject(jsiRuntime, expoModules);

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptObject.h
@@ -5,6 +5,7 @@
 #include "JSIObjectWrapper.h"
 #include "JSITypeConverter.h"
 #include "JavaScriptRuntime.h"
+#include "WeakRuntimeHolder.h"
 
 #include <fbjni/fbjni.h>
 #include <jsi/jsi.h>
@@ -16,8 +17,6 @@ namespace jsi = facebook::jsi;
 
 namespace expo {
 class JavaScriptValue;
-
-class JavaScriptRuntime;
 
 /**
  * Represents any JavaScript object. Its purpose is to exposes `jsi::Object` API back to Kotlin.
@@ -32,6 +31,11 @@ public:
 
   JavaScriptObject(
     std::weak_ptr<JavaScriptRuntime> runtime,
+    std::shared_ptr<jsi::Object> jsObject
+  );
+
+  JavaScriptObject(
+    WeakRuntimeHolder runtime,
     std::shared_ptr<jsi::Object> jsObject
   );
 
@@ -57,7 +61,7 @@ public:
 
 private:
   friend HybridBase;
-  std::weak_ptr<JavaScriptRuntime> runtimeHolder;
+  WeakRuntimeHolder runtimeHolder;
   std::shared_ptr<jsi::Object> jsObject;
 
   bool jniHasProperty(jni::alias_ref<jstring> name);
@@ -88,14 +92,13 @@ private:
     typename = std::enable_if_t<is_jsi_type_converter_defined<T>>
   >
   void setProperty(jni::alias_ref<jstring> name, T value) {
-    auto runtime = runtimeHolder.lock();
-    assert(runtime != nullptr);
-    auto cName = name->toStdString();
+    jsi::Runtime &jsRuntime = runtimeHolder.getJSRuntime();
 
+    auto cName = name->toStdString();
     jsObject->setProperty(
-      *runtime->get(),
+      jsRuntime,
       cName.c_str(),
-      jsi_type_converter<T>::convert(*runtime->get(), value)
+      jsi_type_converter<T>::convert(jsRuntime, value)
     );
   }
 
@@ -104,9 +107,7 @@ private:
     typename = std::enable_if_t<is_jsi_type_converter_defined<T>>
   >
   void defineProperty(jni::alias_ref<jstring> name, T value, int options) {
-    auto runtime = runtimeHolder.lock();
-    assert(runtime != nullptr);
-    jsi::Runtime &jsRuntime = *runtime->get();
+    jsi::Runtime &jsRuntime = runtimeHolder.getJSRuntime();
 
     auto cName = name->toStdString();
     jsi::Object global = jsRuntime.global();

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.cpp
@@ -80,8 +80,8 @@ JavaScriptRuntime::JavaScriptRuntime(
   this->runtime = std::shared_ptr<jsi::Runtime>(std::shared_ptr<jsi::Runtime>(), runtime);
 }
 
-jsi::Runtime *JavaScriptRuntime::get() {
-  return runtime.get();
+jsi::Runtime &JavaScriptRuntime::get() const {
+  return *runtime;
 }
 
 jni::local_ref<JavaScriptValue::javaobject>

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.h
@@ -53,7 +53,7 @@ public:
   /**
    * Returns the underlying runtime object.
    */
-  jsi::Runtime *get();
+  jsi::Runtime &get() const;
 
   /**
    * Evaluates given JavaScript source code.

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptValue.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptValue.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "JSIObjectWrapper.h"
+#include "WeakRuntimeHolder.h"
 
 #include <fbjni/fbjni.h>
 #include <jsi/jsi.h>
@@ -30,6 +31,11 @@ public:
 
   JavaScriptValue(
     std::weak_ptr<JavaScriptRuntime> runtime,
+    std::shared_ptr<jsi::Value> jsValue
+  );
+
+  JavaScriptValue(
+    WeakRuntimeHolder runtime,
     std::shared_ptr<jsi::Value> jsValue
   );
 
@@ -68,7 +74,7 @@ public:
 private:
   friend HybridBase;
 
-  std::weak_ptr<JavaScriptRuntime> runtimeHolder;
+  WeakRuntimeHolder runtimeHolder;
   std::shared_ptr<jsi::Value> jsValue;
 
   jni::local_ref<jstring> jniKind();

--- a/packages/expo-modules-core/android/src/main/cpp/WeakRuntimeHolder.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/WeakRuntimeHolder.cpp
@@ -1,0 +1,17 @@
+#include "WeakRuntimeHolder.h"
+#include "JavaScriptRuntime.h"
+
+namespace expo {
+WeakRuntimeHolder::WeakRuntimeHolder(std::weak_ptr<JavaScriptRuntime> runtime)
+  : std::weak_ptr<JavaScriptRuntime>(std::move(runtime)) {}
+
+jsi::Runtime &WeakRuntimeHolder::getJSRuntime() {
+  auto runtime = lock();
+  assert((runtime != nullptr) && "JS Runtime was used after deallocation");
+  return runtime->get();
+}
+
+void WeakRuntimeHolder::ensureRuntimeIsValid() {
+  assert((!expired()) && "JS Runtime was used after deallocation");
+}
+} // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/WeakRuntimeHolder.h
+++ b/packages/expo-modules-core/android/src/main/cpp/WeakRuntimeHolder.h
@@ -1,0 +1,36 @@
+// Copyright © 2021-present 650 Industries, Inc. (aka Expo)
+
+#pragma once
+
+#include <jsi/jsi.h>
+
+#include <memory>
+
+namespace expo {
+
+namespace jsi = facebook::jsi;
+
+class JavaScriptRuntime;
+
+/**
+ * A convenient class to access underlying jni::Runtime and hold a weak reference to expo::JavaScriptRuntime.
+ * It's working like std::weak_ptr but can have more helper methods.
+ */
+class WeakRuntimeHolder : public std::weak_ptr<JavaScriptRuntime> {
+public:
+  WeakRuntimeHolder() = default;
+
+  WeakRuntimeHolder(WeakRuntimeHolder const &) = default;
+
+  WeakRuntimeHolder(WeakRuntimeHolder &&) = default;
+
+  WeakRuntimeHolder(std::weak_ptr<JavaScriptRuntime> runtime);
+
+  /**
+   * @return an reference to the jsi::Runtime.
+   */
+  jsi::Runtime &getJSRuntime();
+
+  void ensureRuntimeIsValid();
+};
+} // namespace expo


### PR DESCRIPTION
# Why

In many places, we have a similar code that accesses the `jsi::Runtime` from `weak_ptr`. It makes the code hard to read. So I decided to decorate the `std::weak_ptr<JavaScriptRuntime>` with additional access functions. 
 
# How

Added a `WeakRuntimeHolder` with two additional methods to access `jsi::Runtime`

# Test Plan

- unit tests ✅