### PR TITLE
fix(cli): speed up device opening

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Speed up native device opening for iOS and Android.
+- Speed up native device opening for iOS and Android. ([#18385](https://github.com/expo/expo/pull/18385) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Speed up native device opening for iOS and Android.
+
 ### 💡 Others
 
 ## 0.2.6 — 2022-07-25

--- a/packages/@expo/cli/src/start/platforms/ExpoGoInstaller.ts
+++ b/packages/@expo/cli/src/start/platforms/ExpoGoInstaller.ts
@@ -48,11 +48,12 @@ export class ExpoGoInstaller<IDevice> {
     const cacheId = `${this.platform}-${deviceManager.identifier}`;
 
     if (ExpoGoInstaller.cache[cacheId]) {
+      debug('skipping subsequent upgrade check');
       return false;
     }
+    ExpoGoInstaller.cache[cacheId] = true;
     if (await this.isClientOutdatedAsync(deviceManager)) {
       // Only prompt once per device, per run.
-      ExpoGoInstaller.cache[cacheId] = true;
       const confirm = await confirmAsync({
         initial: true,
         message: `Expo Go on ${deviceManager.name} is outdated, would you like to upgrade?`,

--- a/packages/@expo/cli/src/start/platforms/PlatformManager.ts
+++ b/packages/@expo/cli/src/start/platforms/PlatformManager.ts
@@ -63,7 +63,7 @@ export class PlatformManager<
     const { exp } = getConfig(this.projectRoot);
     const installedExpo = await deviceManager.ensureExpoGoAsync(exp.sdkVersion);
 
-    await deviceManager.activateWindowAsync();
+    deviceManager.activateWindowAsync();
     await deviceManager.openUrlAsync(url);
 
     await logEventAsync('Open Url on Device', {


### PR DESCRIPTION
# Why

- Pressing `i` is slow to open, this speeds the process up a bit by copying some logic over from `expo-cli`.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- `EXPO_PROFILE=1 nexpo start -i` should show improved startup time and should skip multiple version checks per device.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
