### PR TITLE
[docs] Update twitch authentication example

### DIFF
--- a/docs/pages/guides/authentication.md
+++ b/docs/pages/guides/authentication.md
@@ -1968,7 +1968,7 @@ export default function App() {
         scheme: 'your.app'
         /* @end */
       }),
-      scopes: ['openid', 'user_read', 'analytics:read:games'],
+      scopes: ['user:read:email', 'analytics:read:games'],
     },
     discovery
   );
@@ -2031,7 +2031,7 @@ export default function App() {
         scheme: 'your.app'
         /* @end */
       }),
-      scopes: ['openid', 'user_read', 'analytics:read:games'],
+      scopes: ['user:read:email', 'analytics:read:games'],
     },
     discovery
   );


### PR DESCRIPTION
# Why

https://dev.twitch.tv/docs/api/migration#authentication-scopes
"user_read" scope(v5) now decommissioned 

# How

Just replace example code with lasted Twitch API Scope
https://dev.twitch.tv/docs/api/migration#authentication-scopes

# Test Plan

N/A

# Checklist

N/A
