### PR TITLE
[ENG-5837][docs] EAS Build: mention how to opt out of using versioned Expo CLI for prebuild

### DIFF
--- a/docs/pages/build-reference/android-builds.md
+++ b/docs/pages/build-reference/android-builds.md
@@ -33,7 +33,7 @@ Next, this is what happens when EAS Build picks up your request:
 1. Run the `eas-build-pre-install` script from package.json if defined.
 1. Run `npm install` in the project root (or `yarn install` if `yarn.lock` exists).
 1. Run `expo doctor` to diagnose potential issues with your project configuration.
-1. Additional step for **managed** projects: Run `expo prebuild` to convert the project to a bare one. This step will use the versioned Expo CLI for projects that use Expo SDK 46+. You can choose to still use the (deprecated) global Expo CLI installation by setting `EXPO_USE_LOCAL_CLI=0` in the build profile.
+1. Additional step for **managed** projects: Run `expo prebuild` to convert the project to a bare one. This step will use the versioned Expo CLI for projects that use Expo SDK 46+. You can still choose to use the (deprecated) global Expo CLI installation by setting `EXPO_USE_LOCAL_CLI=0` in the build profile.
 1. Restore a previously saved cache identified by the `cache.key` value in the build profile. ([Learn more](../build/eas-json/).)
 1. Run the `eas-build-post-install` script from package.json if defined.
 1. Restore the keystore (if it was included in the build request).

--- a/docs/pages/build-reference/android-builds.md
+++ b/docs/pages/build-reference/android-builds.md
@@ -33,7 +33,7 @@ Next, this is what happens when EAS Build picks up your request:
 1. Run the `eas-build-pre-install` script from package.json if defined.
 1. Run `npm install` in the project root (or `yarn install` if `yarn.lock` exists).
 1. Run `expo doctor` to diagnose potential issues with your project configuration.
-1. Additional step for **managed** projects: Run `expo prebuild` to convert the project to a bare one.
+1. Additional step for **managed** projects: Run `expo prebuild` to convert the project to a bare one. This step will use the versioned Expo CLI for projects that use Expo SDK 46+. You can choose to still use the (deprecated) global Expo CLI installation by setting `EXPO_USE_GLOBAL_CLI=1` in the build profile.
 1. Restore a previously saved cache identified by the `cache.key` value in the build profile. ([Learn more](../build/eas-json/).)
 1. Run the `eas-build-post-install` script from package.json if defined.
 1. Restore the keystore (if it was included in the build request).

--- a/docs/pages/build-reference/android-builds.md
+++ b/docs/pages/build-reference/android-builds.md
@@ -33,7 +33,7 @@ Next, this is what happens when EAS Build picks up your request:
 1. Run the `eas-build-pre-install` script from package.json if defined.
 1. Run `npm install` in the project root (or `yarn install` if `yarn.lock` exists).
 1. Run `expo doctor` to diagnose potential issues with your project configuration.
-1. Additional step for **managed** projects: Run `expo prebuild` to convert the project to a bare one. This step will use the versioned Expo CLI for projects that use Expo SDK 46+. You can choose to still use the (deprecated) global Expo CLI installation by setting `EXPO_USE_GLOBAL_CLI=1` in the build profile.
+1. Additional step for **managed** projects: Run `expo prebuild` to convert the project to a bare one. This step will use the versioned Expo CLI for projects that use Expo SDK 46+. You can choose to still use the (deprecated) global Expo CLI installation by setting `EXPO_USE_LOCAL_CLI=0` in the build profile.
 1. Restore a previously saved cache identified by the `cache.key` value in the build profile. ([Learn more](../build/eas-json/).)
 1. Run the `eas-build-post-install` script from package.json if defined.
 1. Restore the keystore (if it was included in the build request).

--- a/docs/pages/build-reference/ios-builds.md
+++ b/docs/pages/build-reference/ios-builds.md
@@ -41,7 +41,7 @@ In this next phase, this is what happens when EAS Build picks up your request:
    - Write the Provisioning Profile to the `~/Library/MobileDevice/Provisioning Profiles` directory.
    - Verify that the Distribution Certificate and Provisioning Profile match (every Provisioning Profile is assigned to a particular Distribution Certificate and cannot be used for building the iOS with any other certificate).
 
-1. Additional step for **managed** projects: Run `expo prebuild` to convert the project to a bare one. This step will use the versioned Expo CLI for projects that use Expo SDK 46+. You can choose to still use the (deprecated) global Expo CLI installation by setting `EXPO_USE_LOCAL_CLI=0` in the build profile.
+1. Additional step for **managed** projects: Run `expo prebuild` to convert the project to a bare one. This step will use the versioned Expo CLI for projects that use Expo SDK 46+. You can still choose to use the (deprecated) global Expo CLI installation by setting `EXPO_USE_LOCAL_CLI=0` in the build profile.
 1. Restore a previously saved cache identified by the `cache.key` value in the build profile. ([Learn more](../build/eas-json/).)
 1. Run `pod install` in the **ios** directory inside your project.
 1. Run the `eas-build-post-install` script from package.json if defined.

--- a/docs/pages/build-reference/ios-builds.md
+++ b/docs/pages/build-reference/ios-builds.md
@@ -41,7 +41,7 @@ In this next phase, this is what happens when EAS Build picks up your request:
    - Write the Provisioning Profile to the `~/Library/MobileDevice/Provisioning Profiles` directory.
    - Verify that the Distribution Certificate and Provisioning Profile match (every Provisioning Profile is assigned to a particular Distribution Certificate and cannot be used for building the iOS with any other certificate).
 
-1. Additional step for **managed** projects: Run `expo prebuild` to convert the project to a bare one. This step will use the versioned Expo CLI for projects that use Expo SDK 46+. You can choose to still use the (deprecated) global Expo CLI installation by setting `EXPO_USE_GLOBAL_CLI=1` in the build profile.
+1. Additional step for **managed** projects: Run `expo prebuild` to convert the project to a bare one. This step will use the versioned Expo CLI for projects that use Expo SDK 46+. You can choose to still use the (deprecated) global Expo CLI installation by setting `EXPO_USE_LOCAL_CLI=0` in the build profile.
 1. Restore a previously saved cache identified by the `cache.key` value in the build profile. ([Learn more](../build/eas-json/).)
 1. Run `pod install` in the **ios** directory inside your project.
 1. Run the `eas-build-post-install` script from package.json if defined.

--- a/docs/pages/build-reference/ios-builds.md
+++ b/docs/pages/build-reference/ios-builds.md
@@ -41,7 +41,7 @@ In this next phase, this is what happens when EAS Build picks up your request:
    - Write the Provisioning Profile to the `~/Library/MobileDevice/Provisioning Profiles` directory.
    - Verify that the Distribution Certificate and Provisioning Profile match (every Provisioning Profile is assigned to a particular Distribution Certificate and cannot be used for building the iOS with any other certificate).
 
-1. **Managed** projects require an additional step: Run `expo prebuild` to convert the project to a bare one.
+1. Additional step for **managed** projects: Run `expo prebuild` to convert the project to a bare one. This step will use the versioned Expo CLI for projects that use Expo SDK 46+. You can choose to still use the (deprecated) global Expo CLI installation by setting `EXPO_USE_GLOBAL_CLI=1` in the build profile.
 1. Restore a previously saved cache identified by the `cache.key` value in the build profile. ([Learn more](../build/eas-json/).)
 1. Run `pod install` in the **ios** directory inside your project.
 1. Run the `eas-build-post-install` script from package.json if defined.

--- a/docs/scripts/schemas/unversioned/eas-json-build-common-schema.js
+++ b/docs/scripts/schemas/unversioned/eas-json-build-common-schema.js
@@ -11,7 +11,7 @@ export default [
     enum: ['local', 'remote'],
     description: [
       'The source of credentials used to sign build artifacts.',
-      ' - `local` - if you want to provide your own `credentials.json` file. ([learn more on this here](/app-signing/local-credentials)).',
+      ' - `local` - if you want to provide your own `credentials.json` file. ([Learn more on this here](/app-signing/local-credentials).)',
       ' - `remote` - if you want to use the credentials managed by EAS (this is the default option).'
     ],
   },
@@ -71,7 +71,7 @@ export default [
     name: 'expoCli',
     type: 'string',
     description: [
-      'Version of [expo-cli](https://www.npmjs.com/package/expo-cli) used to [prebuild](../../workflow/expo-cli/#expo-prebuild) your app. It does not have any effect on bare projects.',
+      '**Deprecated**: Version of [expo-cli](https://www.npmjs.com/package/expo-cli) used to [prebuild](../../workflow/expo-cli/#expo-prebuild) your app. It\'s only use when prebuilding apps that use Expo SDK <=45. For newer SDKs, EAS Build will use the versioned Expo CLI. It comes with the `expo` package installed in your project ([learn more](/workflow/expo-cli)). You can opt out of using the versioned Expo CLI by setting the `EXPO_USE_GLOBAL_CLI=1` env variable in the build profile. Also, it does not have any effect on bare projects.',
     ],
   },
   {

--- a/docs/scripts/schemas/unversioned/eas-json-build-common-schema.js
+++ b/docs/scripts/schemas/unversioned/eas-json-build-common-schema.js
@@ -71,7 +71,7 @@ export default [
     name: 'expoCli',
     type: 'string',
     description: [
-      '**Deprecated**: Version of [expo-cli](https://www.npmjs.com/package/expo-cli) used to [prebuild](../../workflow/expo-cli/#expo-prebuild) your app. It\'s only use when prebuilding apps that use Expo SDK <=45. For newer SDKs, EAS Build will use the versioned Expo CLI. It comes with the `expo` package installed in your project ([learn more](/workflow/expo-cli)). You can opt out of using the versioned Expo CLI by setting the `EXPO_USE_GLOBAL_CLI=1` env variable in the build profile. Also, it does not have any effect on bare projects.',
+      '**Deprecated**: Version of [expo-cli](https://www.npmjs.com/package/expo-cli) used to [prebuild](../../workflow/expo-cli/#expo-prebuild) your app. It\'s only use when prebuilding apps that use Expo SDK <=45. For newer SDKs, EAS Build will use the versioned Expo CLI. It comes with the `expo` package installed in your project ([learn more](/workflow/expo-cli)). You can opt out of using the versioned Expo CLI by setting the `EXPO_USE_LOCAL_CLI=0` env variable in the build profile. Also, it does not have any effect on bare projects.',
     ],
   },
   {

--- a/docs/scripts/schemas/unversioned/eas-json-build-common-schema.js
+++ b/docs/scripts/schemas/unversioned/eas-json-build-common-schema.js
@@ -71,7 +71,7 @@ export default [
     name: 'expoCli',
     type: 'string',
     description: [
-      '**Deprecated**: Version of [expo-cli](https://www.npmjs.com/package/expo-cli) used to [prebuild](../../workflow/expo-cli/#expo-prebuild) your app. It\'s only use when prebuilding apps that use Expo SDK <=45. For newer SDKs, EAS Build will use the versioned Expo CLI. It comes with the `expo` package installed in your project ([learn more](/workflow/expo-cli)). You can opt out of using the versioned Expo CLI by setting the `EXPO_USE_LOCAL_CLI=0` env variable in the build profile. Also, it does not have any effect on bare projects.',
+      '**Deprecated**: Version of [expo-cli](https://www.npmjs.com/package/expo-cli) used to [prebuild](../../workflow/expo-cli/#expo-prebuild) your app. It only affects managed projects on Expo SDK 45 and lower. For newer SDKs, EAS Build will use the versioned Expo CLI. It comes with the `expo` package installed in your project ([learn more](/workflow/expo-cli)). You can opt out of using the versioned Expo CLI by setting the `EXPO_USE_LOCAL_CLI=0` env variable in the build profile.',
     ],
   },
   {


### PR DESCRIPTION
For Expo SDK 46+, EAS Build will use the versioned Expo CLI for prebuilding the project. This PR adds documentation on how to opt out of using it.