### PR TITLE
[ENG-4109][android][expo-modules-core] better android emulator detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Package-specific changes not released in any SDK will be added here just before 
 
 ### 🐛 Bug fixes
 
+### 💡 Others
+
+- Refactored inline Android emulator checks to use enhanced checking in `EmulatorUtilities.isRunningOnEmulator()`. ([#16177](https://github.com/expo/expo/pull/16177)) by [@kbrandwijk](https://github.com/kbrandwijk), [@keith-kurak](https://github.com/keith-kurak))
+
 ## 46.0.0 — 2022-07-19
 
 ### 📚 3rd party library updates

--- a/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.kt
@@ -419,7 +419,7 @@ class ExpoUpdatesAppLoader @JvmOverloads constructor(
   private val clientEnvironment: String
     get() = if (Constants.isStandaloneApp()) {
       "STANDALONE"
-    } else if (isRunningOnEmulator) {
+    } else if (EmulatorUtilities.isRunningOnEmulator()) {
       "EXPO_SIMULATOR"
     } else {
       "EXPO_DEVICE"

--- a/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.kt
@@ -3,10 +3,10 @@ package host.exp.exponent
 
 import android.content.Context
 import android.net.Uri
-import android.os.Build
 import android.util.Log
 import expo.modules.jsonutils.getNullable
 import expo.modules.manifests.core.LegacyManifest
+import expo.modules.core.utilities.EmulatorUtilities
 import expo.modules.updates.UpdatesConfiguration
 import expo.modules.updates.UpdatesUtils
 import expo.modules.updates.db.DatabaseHolder
@@ -413,10 +413,13 @@ class ExpoUpdatesAppLoader @JvmOverloads constructor(
       return headers
     }
 
+  private val isRunningOnEmulator: Boolean
+    get() = EmulatorUtilities.isRunningOnEmulator()
+
   private val clientEnvironment: String
     get() = if (Constants.isStandaloneApp()) {
       "STANDALONE"
-    } else if (Build.FINGERPRINT.contains("vbox") || Build.FINGERPRINT.contains("generic")) {
+    } else if (isRunningOnEmulator) {
       "EXPO_SIMULATOR"
     } else {
       "EXPO_DEVICE"

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Refactored inline Android emulator checks to use enhanced checking in `EmulatorUtilities.isRunningOnEmulator()`. ([#16177](https://github.com/expo/expo/pull/16177)) by [@kbrandwijk](https://github.com/kbrandwijk), [@keith-kurak](https://github.com/keith-kurak))
+
 ## 12.3.0 — 2022-07-07
 
 ### 🐛 Bug fixes

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraModule.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraModule.kt
@@ -2,7 +2,6 @@ package expo.modules.camera
 
 import android.Manifest
 import android.content.Context
-import android.os.Build
 
 import com.google.android.cameraview.AspectRatio
 
@@ -13,6 +12,7 @@ import expo.modules.core.interfaces.ExpoMethod
 import expo.modules.core.ModuleRegistryDelegate
 import expo.modules.core.Promise
 import expo.modules.core.interfaces.services.UIManager
+import expo.modules.core.utilities.EmulatorUtilities
 import expo.modules.interfaces.permissions.Permissions
 
 import java.lang.Exception
@@ -86,7 +86,7 @@ class CameraModule(
       viewTag,
       object : UIManager.UIBlock<ExpoCameraView> {
         override fun resolve(view: ExpoCameraView) {
-          if (!Build.FINGERPRINT.contains("generic")) {
+          if (!EmulatorUtilities.isRunningOnEmulator()) {
             if (view.isCameraOpened) {
               view.takePicture(options, promise, cacheDirectory)
             } else {

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
@@ -6,7 +6,6 @@ import android.graphics.Color
 import android.Manifest
 import android.media.CamcorderProfile
 import android.net.Uri
-import android.os.Build
 import android.os.Bundle
 import android.view.View
 
@@ -30,6 +29,7 @@ import expo.modules.camera.utils.FileSystemUtils
 import expo.modules.camera.utils.ImageDimensions
 import expo.modules.core.ModuleRegistryDelegate
 import expo.modules.core.Promise
+import expo.modules.core.utilities.EmulatorUtilities
 import expo.modules.core.interfaces.LifecycleEventListener
 import expo.modules.core.interfaces.services.UIManager
 import expo.modules.core.interfaces.services.EventEmitter
@@ -208,7 +208,7 @@ class ExpoCameraView(
       if (isPaused && !isCameraOpened || isNew) {
         isPaused = false
         isNew = false
-        if (!Build.FINGERPRINT.contains("generic")) {
+        if (!EmulatorUtilities.isRunningOnEmulator()) {
           start()
           val faceDetectorProvider: FaceDetectorProviderInterface? by moduleRegistry()
           faceDetector = faceDetectorProvider?.createFaceDetectorWithContext(context)

--- a/packages/expo-constants/CHANGELOG.md
+++ b/packages/expo-constants/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Refactored inline Android emulator checks to use enhanced checking in `EmulatorUtilities.isRunningOnEmulator()`. ([#16177](https://github.com/expo/expo/pull/16177)) by [@kbrandwijk](https://github.com/kbrandwijk), [@keith-kurak](https://github.com/keith-kurak))
+
 ## 13.2.3 — 2022-07-25
 
 ### 🐛 Bug fixes

--- a/packages/expo-constants/android/src/main/java/expo/modules/constants/ConstantsService.kt
+++ b/packages/expo-constants/android/src/main/java/expo/modules/constants/ConstantsService.kt
@@ -77,7 +77,7 @@ open class ConstantsService(private val context: Context) : InternalModule, Cons
 
   override fun getDeviceYearClass() = YearClass.get(context)
 
-  override fun getIsDevice() = !isRunningOnEmulator
+  override fun getIsDevice() = !EmulatorUtilities.isRunningOnEmulator()
 
   override fun getStatusBarHeight() = statusBarHeightInternal
 

--- a/packages/expo-constants/android/src/main/java/expo/modules/constants/ConstantsService.kt
+++ b/packages/expo-constants/android/src/main/java/expo/modules/constants/ConstantsService.kt
@@ -5,6 +5,7 @@ import org.apache.commons.io.IOUtils
 import com.facebook.device.yearclass.YearClass
 
 import expo.modules.core.interfaces.InternalModule
+import expo.modules.core.utilities.EmulatorUtilities
 import expo.modules.interfaces.constants.ConstantsInterface
 
 import android.os.Build
@@ -76,7 +77,7 @@ open class ConstantsService(private val context: Context) : InternalModule, Cons
 
   override fun getDeviceYearClass() = YearClass.get(context)
 
-  override fun getIsDevice() = !isRunningOnGenymotion && !isRunningOnStockEmulator
+  override fun getIsDevice() = !isRunningOnEmulator
 
   override fun getStatusBarHeight() = statusBarHeightInternal
 
@@ -121,11 +122,8 @@ open class ConstantsService(private val context: Context) : InternalModule, Cons
       return dp.toInt()
     }
 
-    private val isRunningOnGenymotion: Boolean
-      get() = Build.FINGERPRINT.contains("vbox")
-
-    private val isRunningOnStockEmulator: Boolean
-      get() = Build.FINGERPRINT.contains("generic")
+    private val isRunningOnEmulator: Boolean
+      get() = EmulatorUtilities.isRunningOnEmulator()
 
     private fun getLongVersionCode(info: PackageInfo) =
       if (Build.VERSION.SDK_INT >= 28) info.longVersionCode

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Refactored inline Android emulator checks to use enhanced checking in `EmulatorUtilities.isRunningOnEmulator()`. ([#16177](https://github.com/expo/expo/pull/16177)) by [@kbrandwijk](https://github.com/kbrandwijk), [@keith-kurak](https://github.com/keith-kurak))
+
 ## 1.1.1 — 2022-07-20
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherInternalModule.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherInternalModule.kt
@@ -10,6 +10,7 @@ import android.net.Uri
 import android.os.Build
 import com.facebook.react.bridge.*
 import com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter
+import expo.modules.core.utilities.EmulatorUtilities
 import expo.modules.devlauncher.DevLauncherController
 import expo.modules.devlauncher.DevLauncherController.Companion.wasInitialized
 import expo.modules.devlauncher.helpers.DevLauncherInstallationIDHelper
@@ -52,11 +53,10 @@ class DevLauncherInternalModule(reactContext: ReactApplicationContext?) :
   override fun hasConstants(): Boolean = true
 
   override fun getConstants(): Map<String, Any> {
-    val isRunningOnGenymotion = Build.FINGERPRINT.contains("vbox")
-    val isRunningOnStockEmulator = Build.FINGERPRINT.contains("generic")
+    val isRunningOnEmulator = EmulatorUtilities.isRunningOnEmulator()
     return mapOf(
       "installationID" to installationIDHelper.getOrCreateInstallationID(reactApplicationContext),
-      "isDevice" to (!isRunningOnGenymotion && !isRunningOnStockEmulator),
+      "isDevice" to !isRunningOnEmulator,
       "updatesConfig" to getUpdatesConfig(),
     )
   }

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/DevLauncherActivity.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/DevLauncherActivity.kt
@@ -12,10 +12,13 @@ import com.facebook.react.ReactActivityDelegate
 import com.facebook.react.ReactInstanceManager
 import com.facebook.react.ReactRootView
 import com.facebook.react.bridge.ReactContext
+
+import expo.modules.core.utilities.EmulatorUtilities
 import expo.modules.devlauncher.koin.DevLauncherKoinComponent
 import expo.modules.devlauncher.splashscreen.DevLauncherSplashScreen
 import expo.modules.devlauncher.splashscreen.DevLauncherSplashScreenProvider
 import expo.modules.devmenu.DevMenuManager
+
 import org.koin.core.component.inject
 
 const val SEARCH_FOR_ROOT_VIEW_INTERVAL = 20L
@@ -84,7 +87,7 @@ class DevLauncherActivity : ReactActivity(), ReactInstanceManager.ReactInstanceE
   }
 
   private val isSimulator
-    get() = Build.FINGERPRINT.contains("vbox") || Build.FINGERPRINT.contains("generic")
+    get() = EmulatorUtilities.isRunningOnEmulator()
 
   private fun searchForRootView() {
     if (rootView != null) {

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Refactored inline Android emulator checks to use enhanced checking in `EmulatorUtilities.isRunningOnEmulator()`. ([#16177](https://github.com/expo/expo/pull/16177)) by [@kbrandwijk](https://github.com/kbrandwijk), [@keith-kurak](https://github.com/keith-kurak))
+
 ## 1.1.1 — 2022-07-20
 
 ### 🐛 Bug fixes

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/modules/DevMenuInternalModule.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/modules/DevMenuInternalModule.kt
@@ -6,6 +6,8 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.ReadableMap
+
+import expo.modules.core.utilities.EmulatorUtilities
 import expo.modules.devmenu.modules.internals.DevMenuInternalFontManagerModule
 import expo.modules.devmenu.modules.internals.DevMenuInternalMenuControllerModule
 
@@ -64,7 +66,7 @@ class DevMenuInternalModule(
   override fun getName() = "ExpoDevMenuInternal"
 
   private val doesDeviceSupportKeyCommands
-    get() = Build.FINGERPRINT.contains("vbox") || Build.FINGERPRINT.contains("generic")
+    get() = EmulatorUtilities.isRunningOnEmulator()
 
   override fun getConstants(): Map<String, Any> {
     return mapOf(

--- a/packages/expo-device/CHANGELOG.md
+++ b/packages/expo-device/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Refactored inline emulator checks to use enhanced checking in `EmulatorUtilities.isRunningOnEmulator() `. ([#16177](https://github.com/expo/expo/pull/16177)) by [@kbrandwijk](https://github.com/kbrandwijk), [@keith-kurak](https://github.com/keith-kurak))
+
 ## 4.3.0 — 2022-07-07
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-device/android/src/main/java/expo/modules/device/DeviceModule.kt
+++ b/packages/expo-device/android/src/main/java/expo/modules/device/DeviceModule.kt
@@ -3,6 +3,7 @@ package expo.modules.device
 import expo.modules.core.ExportedModule
 import expo.modules.core.Promise
 import expo.modules.core.interfaces.ExpoMethod
+import expo.modules.core.utilities.EmulatorUtilities
 
 import com.facebook.device.yearclass.YearClass
 
@@ -37,7 +38,7 @@ class DeviceModule(private val mContext: Context) : ExportedModule(mContext) {
   }
 
   override fun getConstants(): Map<String, Any> = mapOf(
-    "isDevice" to (!isRunningOnGenymotion && !isRunningOnStockEmulator),
+    "isDevice" to !isRunningOnEmulator,
     "brand" to Build.BRAND,
     "manufacturer" to Build.MANUFACTURER,
     "modelName" to Build.MODEL,
@@ -96,7 +97,7 @@ class DeviceModule(private val mContext: Context) : ExportedModule(mContext) {
   @ExpoMethod
   fun isRootedExperimentalAsync(promise: Promise) {
     var isRooted = false
-    val isDevice = !isRunningOnGenymotion && !isRunningOnStockEmulator
+    val isDevice = !isRunningOnEmulator
 
     try {
       val buildTags = Build.TAGS
@@ -151,10 +152,8 @@ class DeviceModule(private val mContext: Context) : ExportedModule(mContext) {
   companion object {
     private val TAG = DeviceModule::class.java.simpleName
 
-    private val isRunningOnGenymotion: Boolean
-      get() = Build.FINGERPRINT.contains("vbox")
-    private val isRunningOnStockEmulator: Boolean
-      get() = Build.FINGERPRINT.contains("generic")
+    private val isRunningOnEmulator: Boolean
+      get() = EmulatorUtilities.isRunningOnEmulator()
 
     private fun getDeviceType(context: Context): DeviceType {
       // Detect TVs via UI mode (Android TVs) or system features (Fire TV).

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- Centralized Android emulator detection for native code and added checks to pick up additional emulator types in `EmulatorUtilities`. ([#16177](https://github.com/expo/expo/pull/16177)) by [@kbrandwijk](https://github.com/kbrandwijk), [@keith-kurak](https://github.com/keith-kurak))
+
 ## 0.11.3 — 2022-07-18
 
 ### 💡 Others

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/core/utilities/EmulatorUtilities.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/core/utilities/EmulatorUtilities.kt
@@ -1,0 +1,32 @@
+package expo.modules.core.utilities
+
+import android.os.Build
+import java.util.*
+
+object EmulatorUtilities {
+  fun isRunningOnEmulator(): Boolean {
+    return Build.FINGERPRINT.startsWith("generic") ||
+      Build.FINGERPRINT.startsWith("unknown") ||
+      Build.MODEL.contains("google_sdk") ||
+      Build.MODEL.lowercase(Locale.ROOT).contains("droid4x") ||
+      Build.MODEL.contains("Emulator") ||
+      Build.MODEL.contains("Android SDK built for x86") ||
+      Build.MANUFACTURER.contains("Genymotion") ||
+      Build.HARDWARE.contains("goldfish") ||
+      Build.HARDWARE.contains("ranchu") ||
+      Build.HARDWARE.contains("vbox86") ||
+      Build.PRODUCT.contains("sdk") ||
+      Build.PRODUCT.contains("google_sdk") ||
+      Build.PRODUCT.contains("sdk_google") ||
+      Build.PRODUCT.contains("sdk_x86") ||
+      Build.PRODUCT.contains("vbox86p") ||
+      Build.PRODUCT.contains("emulator") ||
+      Build.PRODUCT.contains("simulator") ||
+      Build.BOARD.lowercase(Locale.ROOT).contains("nox") ||
+      Build.BOOTLOADER.lowercase(Locale.ROOT).contains("nox") ||
+      Build.HARDWARE.lowercase(Locale.ROOT).contains("nox") ||
+      Build.PRODUCT.lowercase(Locale.ROOT).contains("nox") ||
+      Build.SERIAL.lowercase(Locale.ROOT).contains("nox") ||
+      (Build.BRAND.startsWith("generic") && Build.DEVICE.startsWith("generic"))
+  }
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/core/utilities/EmulatorUtilities.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/core/utilities/EmulatorUtilities.kt
@@ -4,6 +4,7 @@ import android.os.Build
 import java.util.*
 
 object EmulatorUtilities {
+  // Adapted from https://github.com/react-native-device-info/react-native-device-info/blob/ea9f868a80acaec68583094c891098a03ecb411a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java#L225
   fun isRunningOnEmulator(): Boolean {
     return Build.FINGERPRINT.startsWith("generic") ||
       Build.FINGERPRINT.startsWith("unknown") ||


### PR DESCRIPTION
# Why

Existing Android Emulator detection is very basic, and leads to false positives/negatives in detection. This PR aims to improve that detection across the board. This PR fulfills the original scope of [16177](https://github.com/expo/expo/pull/16177) and also fulfills [ENG-4109](https://linear.app/expo/issue/ENG-4109/refactor-android-emulator-detection-across-packages) by refactoring the emulator check into a single class.

# How

The new logic is adapted from react-native-device-info (https://github.com/react-native-device-info/react-native-device-info/blob/master/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java#L225). Changes are committed per package, so this can also be cherry picked if needed.

# Test Plan
Verify the following on emulator (and the inverse on a device). Used debugger to verify flags being set when I couldn't find where the flags affected functionality (happy for test suggestions there).

Via functionality in Test Suite:
- [x] [expo-camera] - `CameraView` does not show, `takePictureAsync()` saves sample photo to disk (latter appears to be broken due to preexisting bug, opening issue to address separately)
- [x] [expo-constants] - 'Constants.isDevice` returns false
- [x] [expo-device] - `isDevice` returns false

Via debugger on dev client:
- [x] [expo-dev-launcher] - `isSimulator` is true / `isDevice` is false
- [x] [expo-dev-menu] - `doesDeviceSupportKeyCommands` is true

Via debugger on Expo Go:
- [x] **ExpoUpdatesAppLoader** - request headers indicate simulator

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
