### PR TITLE
[ci] Improve EAS Build workflows for Expo Go

### DIFF
--- a/.github/actions/eas-build/action.yml
+++ b/.github/actions/eas-build/action.yml
@@ -20,6 +20,10 @@ inputs:
   noWait:
     description: 'Exit immediately after build is scheduled'
     required: false
+  message:
+    description: 'Message attached to the build'
+    required: false
+
 
 outputs:
   build_id:
@@ -33,13 +37,16 @@ runs:
       shell: bash
       id: build_start
       run: |
-        BUILD_ID=$(eas build -p $PLATFORM --profile $EAS_BUILD_PROFILE --resource-class ${{ inputs.resourceClass }} --non-interactive --json --no-wait | jq -r ".[0].id")
+        COMMIT_MESSAGE=$(git log -1 --pretty=%B)
+        MESSAGE="${MESSAGE:-$COMMIT_MESSAGE}"
+        BUILD_ID=$(eas build -p $PLATFORM --profile $EAS_BUILD_PROFILE --message "$MESSAGE" --resource-class ${{ inputs.resourceClass }} --non-interactive --json --no-wait | jq -r ".[0].id")
         echo ::set-output name=build_id::"$BUILD_ID"
       working-directory: ${{ inputs.projectRoot }}
       env:
         EXPO_TOKEN: ${{ inputs.expoToken }}
         EAS_BUILD_PROFILE: ${{ inputs.profile }}
         PLATFORM: ${{ inputs.platform }}
+        MESSAGE: ${{ inputs.message }}
         EAS_DANGEROUS_OVERRIDE_ANDROID_APPLICATION_ID: host.exp.exponent
     - name: Wait for build to finish
       shell: bash

--- a/.github/workflows/client-android-eas.yml
+++ b/.github/workflows/client-android-eas.yml
@@ -84,6 +84,26 @@ jobs:
           else
             echo ::set-output name=profile::"unversioned-client"
           fi
+      - name: Generate local credentials.json
+        working-directory: ./apps/eas-expo-go
+        run: |
+          cat >credentials.json <<EOL
+          {
+            "android": {
+              "keystore": {
+                "keystorePath": "release.keystore",
+                "keystorePassword": "$ANDROID_KEYSTORE_PASSWORD",
+                "keyAlias": "ExponentKey",
+                "keyPassword": "$ANDROID_KEY_PASSWORD"
+              }
+            }
+          }
+          EOL
+          echo $ANDROID_KEYSTORE_B64 | base64 -d > release.keystore
+        env:
+          ANDROID_KEYSTORE_B64: ${{ secrets.ANDROID_KEYSTORE_B64 }}
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
       - name: Build
         uses: ./.github/actions/eas-build
         id: build
@@ -94,6 +114,7 @@ jobs:
           expoToken: ${{ secrets.EAS_BUILD_BOT_TOKEN }}
           resourceClass: large
           noWait: ${{ github.event.schedule }}
+          message: ${{ github.event.pull_request.title }}
       - name: On workflow canceled
         if: ${{ cancelled() && steps.build.outputs.build_id }}
         run: eas build:cancel ${{ steps.build.outputs.build_id }}

--- a/.github/workflows/client-ios-eas.yml
+++ b/.github/workflows/client-ios-eas.yml
@@ -10,7 +10,7 @@ on:
         options:
           - versioned-client
           - unversioned-client
-          - versioned-client-signed
+          # - versioned-client-signed
           - versioned-client-add-sdk
   schedule:
     # 5:20 AM UTC time on every Monday, Wednesday and Friday
@@ -114,6 +114,7 @@ jobs:
           expoToken: ${{ secrets.EAS_BUILD_BOT_TOKEN }}
           resourceClass: default
           noWait: ${{ github.event.schedule }}
+          message: ${{ github.event.pull_request.title }}
       - name: On workflow canceled
         if: ${{ cancelled() && steps.build.outputs.build_id }}
         run: eas build:cancel ${{ steps.build.outputs.build_id }}

--- a/.github/workflows/client-ios-eas.yml
+++ b/.github/workflows/client-ios-eas.yml
@@ -10,7 +10,7 @@ on:
         options:
           - versioned-client
           - unversioned-client
-          # - versioned-client-signed
+          - versioned-client-signed
           - versioned-client-add-sdk
   schedule:
     # 5:20 AM UTC time on every Monday, Wednesday and Friday

--- a/apps/eas-expo-go/.gitignore
+++ b/apps/eas-expo-go/.gitignore
@@ -1,0 +1,2 @@
+credentials.json
+release.keystore

--- a/apps/eas-expo-go/eas.json
+++ b/apps/eas-expo-go/eas.json
@@ -10,8 +10,7 @@
         "image": "ubuntu-20.04-jdk-11-ndk-r21e",
         "cache": {
           "customPaths": [
-            "../../android/ReactAndroid/prebuiltHermes",
-            "/home/expo/.gradle/caches/7.3.3"
+            "../../android/ReactAndroid/prebuiltHermes"
           ]
         },
         "env": {

--- a/apps/eas-expo-go/eas.json
+++ b/apps/eas-expo-go/eas.json
@@ -5,21 +5,30 @@
   },
   "build": {
     "base": {
+      "credentialsSource": "local",
       "android": {
         "image": "ubuntu-20.04-jdk-11-ndk-r21e",
         "cache": {
           "customPaths": [
-            "../../android/ReactAndroid/prebuiltHermes"
+            "../../android/ReactAndroid/prebuiltHermes",
+            "/home/expo/.gradle/caches/7.3.3"
           ]
         },
         "env": {
           "EAS_BUILD_PLATFORM": "android",
-          "EAS_DANGEROUS_OVERRIDE_ANDROID_APPLICATION_ID": "host.exp.exponent"
+          "EAS_DANGEROUS_OVERRIDE_ANDROID_APPLICATION_ID": "host.exp.exponent",
+          "EXPO_ROOT_DIR": "/home/expo/workingdir/build"
         }
       },
       "ios": {
+        "cache": {
+          "customPaths": [
+            "../../ios/Pods"
+          ]
+        },
         "env": {
-          "EAS_BUILD_PLATFORM": "ios"
+          "EAS_BUILD_PLATFORM": "ios",
+          "EXPO_ROOT_DIR": "/Users/expo/workingdir/build"
         }
       }
     },
@@ -44,6 +53,7 @@
         "EAS_BUILD_PROFILE": "versioned-client-signed"
       },
       "android": {
+        "withoutCredentials": false,
         "gradleCommand": ":app:bundleVersionedRelease"
       },
       "ios": {

--- a/apps/eas-expo-go/eas.json
+++ b/apps/eas-expo-go/eas.json
@@ -57,6 +57,7 @@
         "gradleCommand": ":app:bundleVersionedRelease"
       },
       "ios": {
+        "credentialsSource": "remote",
         "simulator": false
       }
     },

--- a/apps/eas-expo-go/scripts/eas-build-post-install.sh
+++ b/apps/eas-expo-go/scripts/eas-build-post-install.sh
@@ -3,12 +3,7 @@
 set -xeuo pipefail
 
 ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../../.. && pwd )"
-
-mkdir -p ~/.config/direnv
-cat << EOF > ~/.config/direnv/direnv.toml
-[whitelist]
-prefix = [ "/" ]
-EOF
+export PATH="$ROOT_DIR/bin:$PATH"
 
 maybe_prebuild_hermes() {
   ANDROID_DIR="$ROOT_DIR/android"
@@ -28,7 +23,7 @@ maybe_prebuild_hermes() {
 }
 
 if [ "$EAS_BUILD_PLATFORM" = "ios" ]; then
-  direnv exec . et ios-generate-dynamic-macros
+  et ios-generate-dynamic-macros
 elif [ "$EAS_BUILD_PLATFORM" = "android" ]; then
   if [ "$EAS_BUILD_PROFILE" != "versioned-client-add-sdk" ]; then
     maybe_prebuild_hermes
@@ -36,5 +31,10 @@ elif [ "$EAS_BUILD_PLATFORM" = "android" ]; then
 fi
 
 if [ "$EAS_BUILD_PROFILE" = "versioned-client-add-sdk" ]; then
-  direnv exec . et add-sdk --platform android
+  if [ "$EAS_BUILD_PLATFORM" = "ios" ]; then
+    pushd ios
+    bundle install
+    popd
+  fi
+  et add-sdk --platform $EAS_BUILD_PLATFORM
 fi

--- a/apps/eas-expo-go/scripts/eas-build-pre-install.sh
+++ b/apps/eas-expo-go/scripts/eas-build-pre-install.sh
@@ -8,8 +8,6 @@ if [ "$EAS_BUILD_PLATFORM" = "android" ]; then
   sudo apt-get -y update
   sudo apt-get -y install ruby icu-devtools libicu66 libicu-dev maven
   sdkmanager "cmake;3.10.2.4988404"
-elif [ "$EAS_BUILD_PLATFORM" = "ios" ]; then
-  HOMEBREW_NO_AUTO_UPDATE=1 brew install direnv
 fi
 
 cat << EOF > $ROOT_DIR/.gitmodules
@@ -31,6 +29,10 @@ cat << EOF > $ROOT_DIR/.gitmodules
 EOF
 
 git submodule update --init
+
+if [ ! -z "$EAS_BUILD_NPM_CACHE_URL" ]; then
+  sed -i -e "s#https://registry.yarnpkg.com#$EAS_BUILD_NPM_CACHE_URL#g" $ROOT_DIR/yarn.lock || true
+fi
 
 pushd $ROOT_DIR/tools
 yarn


### PR DESCRIPTION
# Why

Fixes, quality of life updates, and build time improvements.

# How

- Pass PR description or commit message with `eas build --message` option.
- Pass Keystore to the build using local credentials.
- DIsable signed workflow for us (credentials are not configured).
- Fix workflow that runs versioning script.
- Cache pods and Gradle wrapper.
- Add a workaround for yarn to use cache. https://docs.expo.dev/build-reference/how-tos/#using-npm-cache-with-yarn-v1


# Test Plan

Run workflows.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
