### PR TITLE
Add Fig as an autocomplete method

### DIFF
--- a/docs/pages/workflow/expo-cli.md
+++ b/docs/pages/workflow/expo-cli.md
@@ -44,6 +44,16 @@ You will find a list of all commands derived from the latest version of Expo CLI
 
 > Based on `expo-cli` v5.2.0
 
+## Autocomplete
+
+You can get IDE-style autocompletions for Expo with <a href="https://fig.io/" target="_blank"><img src="https://fig.io/badges/Logo.svg" width="15" height="15"/></a> [Fig](https://fig.io/). It works in bash, zsh, and fish.
+
+To install, run:
+
+```shell
+brew install fig
+```
+
 ---
 
 ### Core


### PR DESCRIPTION
# Why

[Fig](https://fig.io) provides autocomplete for 300+ CLI tools including Expo. It looks like this:

We think this will help users become more efficient with Expo CLI, so we would love to have Fig listed as an autocomplete method in your docs. Thanks so much and please let me know if you have any questions!

# How

Modified the docs. 

# Test Plan

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
