### PR TITLE
[dev-launcher][ios] update getAuthSchemeAsync to handle apps with 1 u…

### DIFF
--- a/packages/expo-dev-launcher/ios/EXDevLauncherAuth.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherAuth.m
@@ -100,7 +100,7 @@ RCT_EXPORT_METHOD(getAuthSchemeAsync:(RCTPromiseResolveBlock)resolve
   NSArray<NSDictionary*> *urlTypes = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleURLTypes"];
   
   if (urlTypes != nil) {
-    for (int i = 0; i <= urlTypes.count; i++) {
+    for (int i = 0; i < urlTypes.count; i++) {
       NSDictionary *urlType = urlTypes[i];
       NSArray<NSString*> *schemes = urlType[@"CFBundleURLSchemes"];
       

--- a/packages/expo-dev-launcher/ios/EXDevLauncherAuth.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherAuth.m
@@ -100,7 +100,7 @@ RCT_EXPORT_METHOD(getAuthSchemeAsync:(RCTPromiseResolveBlock)resolve
   NSArray<NSDictionary*> *urlTypes = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleURLTypes"];
   
   if (urlTypes != nil) {
-    for (int i = 1; i <= urlTypes.count; i++) {
+    for (int i = 0; i <= urlTypes.count; i++) {
       NSDictionary *urlType = urlTypes[i];
       NSArray<NSString*> *schemes = urlType[@"CFBundleURLSchemes"];
       


### PR DESCRIPTION

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

I stumbled into this today while debugging something else - this app happened to have 1 url scheme and it was giving me a crash whenever i tried to log in: 

<img width="320" alt="Screen Shot 2022-07-28 at 2 04 19 PM" src="https://user-images.githubusercontent.com/40680668/181637446-fe69ed89-f46d-4bce-b1d6-5fb5af4d8c6d.png">


# How

<!--
How did you build this feature or fix this bug and why?
-->

For some reason the for loop starts at index 1, so I changed it to start at 0. If there is a good reason for starting at index 1 then we should update the for loop to check the length of the array 

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->



# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
