### PR TITLE
[docs] EAS Build - add new npm hooks

### DIFF
--- a/docs/pages/build-reference/how-tos.md
+++ b/docs/pages/build-reference/how-tos.md
@@ -12,12 +12,13 @@ There are three EAS Build-specific npm hooks that you can set in your package.js
 
 - `eas-build-pre-install` - executed before EAS Build runs `yarn install`.
 - `eas-build-post-install` - the behavior depends on the platform and project type:
-  - for managed Android project, it will run after `yarn install` and `expo prebuild` have completed.
-  - for bare Android project, it will run after `yarn install` has completed.
-  - for both bare and managed iOS projects, it will run after `yarn install` and `pod install` have completed.
+  - Android
+    - managed projects - runs after `yarn install` and `expo prebuild`.
+    - bare projects - runs after `yarn install`.
+  - iOS - runs after `yarn install` and `pod install`.
 - `eas-build-on-success` - this hook is triggered at the end of the build process if the build was successful.
 - `eas-build-on-error` - this hook is triggered at the end of the build process if the build failed.
-- `eas-build-on-success` - this hook is triggered at the end of the build process. You can check a status of the build using `EAS_BUILD_STATUS` environment variable, it will be set to `finished` or `errored`.
+- `eas-build-on-success` - this hook is triggered at the end of the build process. You can check the build's status with the `EAS_BUILD_STATUS` environment variable. It's either `finished` or `errored`.
 
 This is an example of how your package.json might look like:
 

--- a/docs/pages/build-reference/how-tos.md
+++ b/docs/pages/build-reference/how-tos.md
@@ -10,11 +10,14 @@ This document outlines how to configure EAS Build for some common scenarios, suc
 
 There are three EAS Build-specific npm hooks that you can set in your package.json. See the [Android build process](android-builds.md) and [iOS build process](ios-builds.md) docs to get a better understanding about the internals of the build process.
 
-- `eas-build-pre-install` - executed before EAS Build runs `yarn install`
-- `eas-build-post-install` - the behavior depends on the platform:
-  - for Android, after `yarn install` has completed
-  - for iOS, after `yarn install` and `pod install` have completed
-- `eas-build-pre-upload-artifacts` - this hook is triggered almost at the end of the build process, just before EAS Build uploads the build artifacts to AWS S3
+- `eas-build-pre-install` - executed before EAS Build runs `yarn install`.
+- `eas-build-post-install` - the behavior depends on the platform and project type:
+  - for managed Android project, it will run after `yarn install` and `expo prebuild` have completed.
+  - for bare Android project, it will run after `yarn install` has completed.
+  - for both bare and managed iOS projects, it will run after `yarn install` and `pod install` have completed.
+- `eas-build-on-success` - this hook is triggered at the end of the build process if the build was successful.
+- `eas-build-on-error` - this hook is triggered at the end of the build process if the build failed.
+- `eas-build-on-success` - this hook is triggered at the end of the build process. You can check a status of the build using `EAS_BUILD_STATUS` environment variable, it will be set to `finished` or `errored`.
 
 This is an example of how your package.json might look like:
 

--- a/docs/pages/build-reference/how-tos.md
+++ b/docs/pages/build-reference/how-tos.md
@@ -18,7 +18,7 @@ There are three EAS Build-specific npm hooks that you can set in your package.js
   - iOS - runs after `yarn install` and `pod install`.
 - `eas-build-on-success` - this hook is triggered at the end of the build process if the build was successful.
 - `eas-build-on-error` - this hook is triggered at the end of the build process if the build failed.
-- `eas-build-on-success` - this hook is triggered at the end of the build process. You can check the build's status with the `EAS_BUILD_STATUS` environment variable. It's either `finished` or `errored`.
+- `eas-build-on-complete` - this hook is triggered at the end of the build process. You can check the build's status with the `EAS_BUILD_STATUS` environment variable. It's either `finished` or `errored`.
 
 This is an example of how your package.json might look like:
 


### PR DESCRIPTION
# Why

Add new hooks that are triggered at the end of the build, and deprecate the pre-upload-artifact one

# How



# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
