### PR TITLE
chore(docs): Updated docs to reflect the new local Expo CLI

### DIFF
--- a/docs/pages/distribution/publishing-websites.md
+++ b/docs/pages/distribution/publishing-websites.md
@@ -5,12 +5,12 @@ title: Publishing Websites
 ## Creating a Build
 
 - Optimize the assets for speed - `npx expo-optimize` (formerly `expo optimize`)
-- Bundle the project for production - `expo build:web`
+- Bundle the project for production - `npx expo export:web` (`expo build:web` in the legacy Expo CLI).
   - Creates a production ready static bundle in the `web-build/` directory. Don't edit this folder directly.
   - Uses Webpack to [optimize the project.][webpack-optimize]
   - If you make any changes to your project, you'll need to re-build for production.
-  - For more help use `expo build:web --help`
-  - To speed up builds you can skip the PWA asset generation with `expo build:web --no-pwa`
+  - For more help use `npx expo export:web --help`
+  <!-- - To speed up builds you can skip the PWA asset generation with `expo build:web --no-pwa` -->
 - You can now deploy or host this anywhere you like.
 
 **Tips**
@@ -58,7 +58,7 @@ Vercel has a single-command zero-config deployment flow. You can use `vercel` to
 
 1. [Install the Vercel CLI](https://vercel.com/download).
 
-2. Build your Expo web app with `expo build:web`.
+2. Build your Expo web app with `npx expo export:web` (SDK 45 and lower should use `expo build:web` via the legacy global Expo CLI).
 
 3. To deploy:
 
@@ -118,13 +118,15 @@ yarn add -D gh-pages
 
 Add the following to your **package.json**:
 
+> In projects running SDK 45 or lower, use `expo build:web` instead of `expo export:web`.
+
 ```js
 /* package.json */
 {
     "homepage": "http://evanbacon.github.io/expo-gh-pages",
     "scripts": {
         "deploy": "gh-pages -d web-build",
-        "predeploy": "expo build:web"
+        "predeploy": "expo export:web"
     }
 }
 ```
@@ -178,10 +180,11 @@ Here are the formal instructions for deploying to GitHub Pages:
    "scripts": {
      /* ... */
      "deploy": "gh-pages -d web-build",
-     "predeploy": "expo build:web"
+     "predeploy": "expo export:web"
    }
    ```
 
+   > In projects running SDK 45 or lower, use `expo build:web` instead of `expo export:web`.
    > `predeploy` is automatically run before `deploy`.
 
 5. **Generate a _production build_ of your app, and deploy it to GitHub Pages.** (2 minutes)
@@ -215,10 +218,12 @@ In the existing `scripts` property, add a `predeploy` property and a `deploy` pr
 ```js
 "scripts": {
   /* ... */
-  "predeploy": "expo build:web",
+  "predeploy": "expo export:web",
   "deploy-hosting": "npm run predeploy && firebase deploy --only hosting",
 }
 ```
+
+> In projects running SDK 45 or lower, use `expo build:web` instead of `expo export:web`.
 
 Run the `npm run deploy-hosting` command to deploy.
 

--- a/docs/pages/guides/authentication.md
+++ b/docs/pages/guides/authentication.md
@@ -176,7 +176,7 @@ export default function App() {
 - Setup redirect URIs: Your Project > Permitted Redirect URIs: (be sure to save after making changes).
   - _Expo Go_: `exp://localhost:19000/--/`
   - _Web dev_: `https://localhost:19006`
-    - Run `expo start:web --https` to run with **https**, auth won't work otherwise.
+    - Run `expo start --web --https` to run with **https**, auth won't work otherwise.
     - Adding a slash to the end of the URL doesn't matter.
   - _Standalone and Bare_: `your-scheme://`
     - Scheme should be specified in app.json `expo.scheme: 'your-scheme'`, then added to the app code with `makeRedirectUri({ native: 'your-scheme://' })`)
@@ -1081,7 +1081,7 @@ Expo web client ID for use in the browser.
 - Give it a name (e.g. "Web App").
 - **URIs** (Authorized JavaScript origins): https://localhost:19006 & https://yourwebsite.com
 - **Authorized redirect URIs**: https://localhost:19006 & https://yourwebsite.com
-- To test this be sure to start your app with `expo start:web --https`.
+- To test this be sure to start your app with `expo start --web --https`.
 
 <Tabs tabs={["Standard", "Firebase"]}>
 <Tab>
@@ -1683,7 +1683,7 @@ export default function App() {
   - _Expo Go_: `exp://localhost:19000/--/`
   - _Web dev_: `https://localhost:19006`
     - Important: Ensure there's no slash at the end of the URL unless manually changed in the app code with `makeRedirectUri({ path: '/' })`.
-    - Run `expo start:web --https` to run with **https**, auth won't work otherwise.
+    - Run `expo start --web --https` to run with **https**, auth won't work otherwise.
   - _Custom app_: `your-scheme://`
     - Scheme should be specified in app.json `expo.scheme: 'your-scheme'`, then added to the app code with `makeRedirectUri({ native: 'your-scheme://' })`)
   - _Proxy_: `https://auth.expo.io/@username/slug`
@@ -1757,7 +1757,6 @@ export default function App() {
 </Tab>
 
 <Tab>
-
 
 <!-- prettier-ignore -->
 ```tsx

--- a/docs/pages/guides/customizing-webpack.md
+++ b/docs/pages/guides/customizing-webpack.md
@@ -2,16 +2,16 @@
 title: Customizing Webpack
 ---
 
-When you run `expo start:web` or `expo build:web` the CLI will check to see if your project has a **webpack.config.js** in the root directory. If the project doesn't then Expo will use the default `@expo/webpack-config` (preferred).
+When you run `expo start --web` or `expo export:web` the CLI will check to see if your project has a **webpack.config.js** in the root directory. If the project doesn't then Expo will use the default `@expo/webpack-config` (preferred).
 
 > This is akin to `react-scripts` & `create-react-app`.
 
-If you need to edit the config the best way to do this is by running `expo customize:web` and selecting the **webpack.config.js** option.
-This will install `@expo/webpack-config` as a devDependency and create a template **webpack.config.js** into your project.
+If you need to edit the config the best way to do this is by running `npx expo customize webpack.config.js`.
+This will install `@expo/webpack-config` as a dev dependency and create a template `./webpack.config.js` in your project.
 You can now make changes to a config object based on the default config and return it for Expo CLI to use.
 Deleting the config will cause Expo to fall back to the default again.
 
-If you create a new Webpack config or make any changes to it you'll need to restart your Webpack dev server with `expo start:web`.
+If you create a new Webpack config or make any changes to it you'll need to restart your Webpack dev server with `npx expo start`.
 
 ## Example
 
@@ -77,13 +77,12 @@ The reason it automatically includes the polyfill is because `react-native-web` 
 
 ## Editing static files
 
-You can also use `expo customize:web` to generate the static project files: **index.html**, **serve.json**, **favicon.ico**, etc...
+You can also use `npx expo customize` to generate the static project files: **index.html**, **serve.json**, etc...
 These can be used to customize your project in a more familiar way.
 
-All of the files you select from the terminal prompt will be copied to a `web/` folder in your project's root directory. Think of this folder like `public/` in Create React App. We use "web" instead of "public" because Expo projects target more then just web. For mobile platforms, we similarly put platform-specific project files in `/ios` and `/android` folders.
+All of the files you select from the terminal prompt will be copied to a `web/` folder in your project's root directory. Think of this folder like `public/` in Create React App. We use "web" instead of "public" because Expo Webpack is web-only, the static folder does not work for iOS or Android apps. For mobile platforms, we similarly put platform-specific project files in `/ios` and `/android` folders.
 
-Deleting any of these files will cause Expo CLI to fall back to their respective default copies.
-If at some point you want to reset these files to their initial values simply run `expo customize:web --force` or `-f` for short.
+Deleting any of these files will cause Expo Webpack to fallback to their respective default copies.
 
 ### Why
 

--- a/docs/pages/guides/customizing-webpack.md
+++ b/docs/pages/guides/customizing-webpack.md
@@ -77,7 +77,7 @@ The reason it automatically includes the polyfill is because `react-native-web` 
 
 ## Editing static files
 
-You can also use `npx expo customize` to generate the static project files: **index.html**, **serve.json**, etc...
+You can also use `npx expo customize` to generate the static project files: **index.html**, **serve.json**, etc.
 These can be used to customize your project in a more familiar way.
 
 All of the files you select from the terminal prompt will be copied to a `web/` folder in your project's root directory. Think of this folder like `public/` in Create React App. We use "web" instead of "public" because Expo Webpack is web-only, the static folder does not work for iOS or Android apps. For mobile platforms, we similarly put platform-specific project files in `/ios` and `/android` folders.

--- a/docs/pages/guides/progressive-web-apps.md
+++ b/docs/pages/guides/progressive-web-apps.md
@@ -6,17 +6,15 @@ import { InlineCode } from '~/components/base/code';
 
 A progressive web app (or PWA for short) is a website that can be installed on the user's device and used offline. If you build your native app with Expo, then Expo CLI can generate a lot of the PWA automatically based on how the native app works. Ex: icons, splash screens, orientation, etc. Just [add service workers](https://expo.fyi/enabling-web-service-workers) to get a complete PWA.
 
-You can test your PWA in an Emulator and Simulator by running `expo start:web --https --ios --android` then installing the PWA via the mobile browser.
-
 ## Usage
 
-Expo web projects generate PWA assets and manifests by default, you only need to [add offline web support](https://expo.fyi/enabling-web-service-workers) to get a full PWA. You can disable asset and manifest generation by passing the `--no-pwa` to `expo build:web`, this won't effect favicon generation.
+Expo web projects generate PWA assets and manifests by default, you only need to [add offline web support](https://expo.fyi/enabling-web-service-workers) to get a full PWA.
 
-When you run `expo build:web` the Webpack config reads your **app.config.js** (or **app.json**) and generates a PWA from it.
+When you run `npx expo export:web` (`expo build:web` for SDK 45 and lower) the Webpack config reads your **app.config.js** (or **app.json**) and generates a PWA from it.
 
 The following properties can be used to customize your PWA:
 
-| **app.config.js**                                             | **manifest.json**               | **index.html**                                            |
+| **app.config.js**                                           | **manifest.json**             | **index.html**                                          |
 | ----------------------------------------------------------- | ----------------------------- | ------------------------------------------------------- |
 | `web.backgroundColor`                                       | `background_color`            |                                                         |
 | <InlineCode>web.description \| description</InlineCode>     | `description`                 | `<meta name="description" />`                           |
@@ -115,7 +113,7 @@ export default {
 
 Under the hood `@expo/webpack-config` uses a CLI called `expo-pwa`. If you want more control on how PWAs are generated, you can use the `expo-pwa` CLI directly.
 
-Firstly, you'll need to eject the **web/index.html** with `expo customize:web`. Now you can generate custom files and link them in the **web/index.html**. `@expo/webpack-config` will check to see if assets are linked first before attempting to generate new ones.
+Firstly, you'll need to eject the **web/index.html** with `npx expo customize`. Now you can generate custom files and link them in the **web/index.html**. `@expo/webpack-config` will check to see if assets are linked first before attempting to generate new ones.
 
 #### manifest.json
 
@@ -126,6 +124,6 @@ Firstly, you'll need to eject the **web/index.html** with `expo customize:web`. 
 <link rel="manifest" href="/manifest.json" />
 ```
 
-Now `expo build:web` will copy the **web/manifest.json** file into the build folder and skip converting the **app.config.js** or **app.json** into a **manifest.json**.
+Now `npx expo export:web` will copy the **web/manifest.json** file into the build folder and skip converting the **app.config.js** or **app.json** into a **manifest.json**.
 
 Note that if the `icons` property is not defined then the build step will still attempt to generate and append Chrome icons to your **manifest.json**.

--- a/docs/pages/guides/running-in-the-browser.md
+++ b/docs/pages/guides/running-in-the-browser.md
@@ -2,9 +2,29 @@
 title: Running in the Browser
 ---
 
-You can use Expo to create web apps that run in the browser using the same code-base as your existing native app.
+import { Terminal } from '~/ui/components/Snippet';
+
+You can use Expo to create web apps that run in the browser using the same code-base as your existing native app. These apps are rendered using the highly optimized `react-dom` reconciler via `react-native-web`, meaning there's no compromise on performance.
+
+The underlying technology 'React Native for web' (RNW) was developed by Twitter and is used today on the [twitter.com](https://twitter.com/expo) website. RNW is also used by [Flipkart](https://twitter.com/naqvitalha/status/969577892991549440), [Uber](https://www.youtube.com/watch?v=RV9rxrNIxnY), [Major League Soccer](https://matchcenter.mlssoccer.com/), [BeatGig](https://beatgig.com/) and many others.
 
 ## Adding web support to Expo projects
+
+Install the required packages in your project:
+
+<Terminal cmd={["$ npx expo install react-native-web react-dom @expo/webpack-config"]} />
+
+Then start the app with:
+
+<Terminal cmd={["$ npx expo start --web"]} />
+
+And that's it! Packages in the Expo SDK are optimized for web and SSR environments, your web-support millage may vary when using community packages.
+
+<details>
+<summary>
+<h4>Legacy Guide</h4>
+</summary>
+<p>
 
 All projects after _SDK 32_ come with web support by default. To add web support to an existing Expo app you can do the following:
 
@@ -13,14 +33,16 @@ All projects after _SDK 32_ come with web support by default. To add web support
   - Ensure your project has at least `expo@^33.0.0` installed.
 - Start your project with `expo start` then press `w` to start Webpack and open the project in the browser.
 
+</p>
+</details>
+
 **Tips**
 
-- Startup faster in web-only mode by running `expo web`
-- Test protected APIs like Camera and Sharing by using the `--https` or `--no-https` flags.
+- Test protected APIs like the camera and user location by adding the `--https` flag to `npx expo start`. This will host your app from a secure origin like `https://localhost:19006`.
 
 ## Frameworks
 
-The Expo Unimodules and dev-tools are highly composable and can be used in _any_ **react.js** project. Here are a few popular integrations:
+The Expo modules and dev-tools are highly composable and can be used in _any_ React project. Here are a few popular integrations:
 
 - [**Next.js:**](https://dev.to/evanbacon/next-js-expo-and-react-native-for-web-3kd9) Server Side Render your website and get incredible SEO.
 - [**Gatsby:**](https://dev.to/evanbacon/gatsby-react-native-for-web-expo-2kgc) Prerender your static-site.
@@ -28,7 +50,7 @@ The Expo Unimodules and dev-tools are highly composable and can be used in _any_
 
 ## Tree-Shaking
 
-The package `babel-preset-expo` extends `@babel/preset-env` on web and is used to configure your project for Unimodules. The core feature is that it won't compile your modules to **core.js** when targeting web, this means that you get optimal tree-shaking and dead-code-elimination.
+The package `babel-preset-expo` extends `@babel/preset-env` on web and is used to configure your project for universal modules. The core feature is that it won't compile your modules to **core.js** when targeting web, this means that you get optimal tree-shaking and dead-code-elimination.
 This step is optional with the React Native CLI but you'll get a much smaller bundle size and faster website if you do choose to use it. This is because `module:metro-react-native-babel-preset` is made for usage with the Metro bundler and not Webpack.
 
 > `babel-preset-expo` is required for usage with Create React App, optional but recommended for all React Native projects using Unimodules.
@@ -44,43 +66,35 @@ This step is optional with the React Native CLI but you'll get a much smaller bu
 
 ## App Entry
 
-The initial file of your web app. Be sure to use `registerRootComponent` from `expo` to ensure web is initialized correctly.
+The initial file of your web app. Be sure to use `registerRootComponent` from `expo` to ensure web the root DOM element is added to the HTML.
 
-### Managed
+If your root project file is `node_modules/expo/AppEntry` or you have a root `App.js`, then the entry component will setup automatically.
 
-- Remove the `main` field of your **package.json**:
-  ```diff
-  {
-  -   "main": "index.js",
-  }
-  ```
-- Create an **App.js** in the root of your project:
+### Manual App Entry
 
-```tsx
-import React from 'react';
-import { View } from 'react-native';
-
-export default () => <View />;
-```
-
-- And that's it, `expo-cli` will handle the rest!
-
-### Bare Workflow
-
-- Remove the `main` field of your **package.json** or set it to `./index`:
-- Install Expo: `yarn add expo`
-- Change the root **index.js** to look like this:
+In your project's main entry file (presumably `index.js`), add:
 
 ```tsx
 import { registerRootComponent } from 'expo';
 
+// Assuming `App.js` is the root component.
 import App from './App';
 
+// Tells Expo to install the root React component in your `index.html` document body.
+// This runs `AppRegistry.registerComponent()` -> `ReactDOM.render()`
+// behind a web-only flag.
 registerRootComponent(App);
 ```
 
-- That's all! You don't need to invoke `ReactDOM.render` or `AppRegistry.registerComponent` because `registerRootComponent` will do this for you for each platform automatically.
+### Alternative Rendering Patterns
+
+> **Example:** The website [beatgig.com][beatgig] uses Expo web + Next.js to achieve SSR in the browser.
+
+By default Expo is rendering your web app as a "single page application" or SPA, this rendering pattern is the closest to how native rendering works. If you'd like to render your Expo web using "server-side rendering" (SSR) or "static site generation" (SSG) then you should try using the Expo SDK with another tool like Gatsby, Next.js, Remix, etc. the caveat being that these tools are less universal and require a bit more effort to share code across platforms.
+
+The ability to use Expo web with these other React frameworks is what makes it the most powerful way to build a universal app. The possibilities are endless and you won't hit a theoretic performance wall in the future.
 
 [rnw]: https://github.com/necolas/react-native-web/
 [forums]: https://forums.expo.dev/
 [canny]: https://expo.canny.io/feature-requests
+[beatgig]: https://beatgig.com/

--- a/docs/pages/guides/running-in-the-browser.md
+++ b/docs/pages/guides/running-in-the-browser.md
@@ -90,7 +90,7 @@ registerRootComponent(App);
 
 > **Example:** The website [beatgig.com][beatgig] uses Expo web + Next.js to achieve SSR in the browser.
 
-By default Expo is rendering your web app as a "single page application" or SPA, this rendering pattern is the closest to how native rendering works. If you'd like to render your Expo web using "server-side rendering" (SSR) or "static site generation" (SSG) then you should try using the Expo SDK with another tool like Gatsby, Next.js, Remix, etc. the caveat being that these tools are less universal and require a bit more effort to share code across platforms.
+By default, Expo is rendering your web app as a "single page application" or SPA. This rendering pattern is the closest to how native rendering works. If you'd like to render your Expo web using "server-side rendering" (SSR) or "static site generation" (SSG) then you should try using the Expo SDK with another tool like Gatsby, Next.js, Remix, etc. The caveat is that these tools are less universal and require a bit more effort to share code across platforms.
 
 The ability to use Expo web with these other React frameworks is what makes it the most powerful way to build a universal app. The possibilities are endless and you won't hit a theoretic performance wall in the future.
 

--- a/docs/pages/guides/using-nextjs.md
+++ b/docs/pages/guides/using-nextjs.md
@@ -9,7 +9,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 
 [Next.js][nextjs] is a React framework that provides simple page-based routing as well as server-side rendering. To use Next.js with Expo for web we recommend that you use a library called [`@expo/next-adapter`][next-adapter] to handle the configuration and integration of the tools.
 
-Using Expo with Next.js means you can share all of your existing components and APIs across your mobile and web. Next.js has its own Webpack config so **you'll need to start your web projects with the `next-cli` and not with `expo start:web`.**
+Using Expo with Next.js means you can share all of your existing components and APIs across your mobile and web. Next.js has its own Webpack config so **you'll need to start your web projects with the `next-cli` and not with `expo start`.**
 
 > Next.js can only be used with Expo for web, this doesn't provide Server-Side Rendering (SSR) for native apps.
 
@@ -149,7 +149,7 @@ This is Vercel's preferred method for deploying Next.js projects to production.
 A lot of libraries in the React ecosystem use the `setImmediate()` API (like `react-native-reanimated`), which Next.js doesn't polyfill by default. To fix this you can polyfill it yourself.
 
 - Install: `yarn add setimmediate`
-- Import in **pages/_app.js**, at the top of the file:
+- Import in **pages/\_app.js**, at the top of the file:
   ```js
   import 'setimmediate';
   ```

--- a/docs/pages/guides/using-preact.md
+++ b/docs/pages/guides/using-preact.md
@@ -8,7 +8,7 @@ sidebar_title: Using Preact
 [Preact](https://preactjs.com/) is a 3kb alternative to React. Using Preact in a blank `react-native-web` project can lower your GZipped bundle by nearly 24kb.
 
 - Install Preact (requires Preact 10+): `yarn add preact-responder-event-plugin preact`
-- Run `expo customize:web` and select **webpack.config.js**
+- Run `npx expo customize webpack.config.js` to generate a `./webpack.config.js` file in your project.
 - Modify the webpack config to use Preact instead of React:
 
   ```js
@@ -41,4 +41,4 @@ sidebar_title: Using Preact
   };
   ```
 
-- That's it! Running `expo build:web` will now produce a significantly smaller bundle.
+- That's it! Running `npx expo export:web` will now produce a significantly smaller bundle.

--- a/docs/pages/guides/web-performance.md
+++ b/docs/pages/guides/web-performance.md
@@ -37,8 +37,7 @@ To inspect bundle sizes, you can use a Webpack plugin called [_Webpack Bundle An
 
 1. Install the bundle analyzer:
    <Terminal cmd={['$ yarn add -D webpack-bundle-analyzer']} />
-2. Reveal the Webpack Config:
-   - Run `expo customize:web` and select **webpack.config.js**.
+2. Reveal the Webpack config by running `npx expo customize webpack.config.js`.
 3. Customize the config to generate a web report:
 
 ```js
@@ -66,7 +65,7 @@ module.exports = async (env, argv) => {
 
 If you want to track down why a package was included, you can build your project in [debug mode](https://github.com/expo/expo-cli/blob/af9e390b74dcb7a0132e73b34ea0cdb9437a771c/packages/xdl/src/Web.ts#L69-L92).
 
-<Terminal cmd={['$ EXPO_WEB_DEBUG=true expo build:web']} />
+<Terminal cmd={['$ EXPO_WEB_DEBUG=true npx expo export:web']} />
 
 > This will make your bundle much larger, and you shouldn't publish your project in this state.
 
@@ -77,7 +76,7 @@ You can now search for unwanted packages by name and see which files or methods 
 Lighthouse is a great way to see how fast, accessible, and performant your website is.
 You can test your project with the _Audit_ tab in Chrome, or with the [**Lighthouse CLI**][lighthouse].
 
-After creating a production build with `expo build:web` and serving it somewhere, run Lighthouse with the URL your site is hosted at.
+After creating a production build with `npx expo export:web` and serving it somewhere, run Lighthouse with the URL your site is hosted at.
 
 ```sh
 lighthouse <url> --view

--- a/docs/pages/versions/unversioned/sdk/webbrowser.md
+++ b/docs/pages/versions/unversioned/sdk/webbrowser.md
@@ -89,5 +89,4 @@ You're method can still run in an async function but there cannot be any long ru
 
 **Web only:** The current environment doesn't support crypto. Ensure you are running from a secure origin (https).
 
-When using Expo CLI you can run `expo start:web --https` or `expo start --web --https` to open your web page in a secure development environment.
-
+> **Tip:** You can run `npx expo start --web --https` to open your web page in a secure development environment.

--- a/docs/pages/versions/v46.0.0/sdk/webbrowser.md
+++ b/docs/pages/versions/v46.0.0/sdk/webbrowser.md
@@ -89,5 +89,4 @@ You're method can still run in an async function but there cannot be any long ru
 
 **Web only:** The current environment doesn't support crypto. Ensure you are running from a secure origin (https).
 
-When using Expo CLI you can run `expo start:web --https` or `expo start --web --https` to open your web page in a secure development environment.
-
+> **Tip:** You can run `npx expo start --web --https` to open your web page in a secure development environment.


### PR DESCRIPTION
# Why

- `expo customize:web` -> `npx expo customize`
- `expo start:web` -> `npx expo start`
- `expo build:web` -> `expo export:web`
- Update the unversioned web guide since it's three years old.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
