### PR TITLE
Drop `expo build` requirement in PULL_REQUEST_TEMPLATE

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -24,5 +24,4 @@ Please check the appropriate items below if they apply to your diff. This is req
 
 - [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
 - [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
-- [ ] This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).
 - [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).


### PR DESCRIPTION
# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] ~~This diff will work correctly for `expo build` (eg: updated `@expo/xdl`).~~ 👿
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
