### PR TITLE
[home] use `isDevice` from expo-device package

### DIFF
--- a/home/FeatureFlags.ts
+++ b/home/FeatureFlags.ts
@@ -1,11 +1,11 @@
-import Constants from 'expo-constants';
+import { isDevice } from 'expo-device';
 
 import Environment from './utils/Environment';
 
 export default {
   // Disable all project tools in the App Store client.
   ENABLE_PROJECT_TOOLS: !Environment.IsIOSRestrictedBuild,
-  ENABLE_QR_CODE_BUTTON: Constants.isDevice && !Environment.IsIOSRestrictedBuild,
+  ENABLE_QR_CODE_BUTTON: isDevice && !Environment.IsIOSRestrictedBuild,
   // Disable the clipboard button in the App Store client.
   ENABLE_CLIPBOARD_BUTTON: !Environment.IsIOSRestrictedBuild,
 };

--- a/home/menu/DevMenuOnboarding.tsx
+++ b/home/menu/DevMenuOnboarding.tsx
@@ -1,6 +1,6 @@
 import { borderRadius } from '@expo/styleguide-native';
-import Constants from 'expo-constants';
 import { View, Text, Button, useExpoTheme, Spacer } from 'expo-dev-client-components';
+import { isDevice } from 'expo-device';
 import React from 'react';
 import { Platform, StyleSheet, TouchableOpacity as TouchableOpacityRN } from 'react-native';
 import { TouchableOpacity as TouchableOpacityGH } from 'react-native-gesture-handler';
@@ -19,7 +19,7 @@ const KEYBOARD_CODES: { [key: string]: string } = {
 
 const ONBOARDING_MESSAGE = (() => {
   let fragment;
-  if (Constants.isDevice) {
+  if (isDevice) {
     if (Platform.OS === 'ios') {
       fragment =
         'you can shake your device or long press anywhere on the screen with three fingers';

--- a/home/screens/HomeScreen/HomeScreenView.tsx
+++ b/home/screens/HomeScreen/HomeScreenView.tsx
@@ -1,7 +1,7 @@
 import { spacing } from '@expo/styleguide-native';
 import { StackScreenProps } from '@react-navigation/stack';
-import Constants from 'expo-constants';
 import { View, Divider, Spacer } from 'expo-dev-client-components';
+import { isDevice } from 'expo-device';
 import * as React from 'react';
 import {
   Alert,
@@ -295,7 +295,7 @@ export class HomeScreenView extends React.Component<Props, State> {
 
     const baseMessage = `Make sure you are signed in to the same Expo account on your computer and this app. Also verify that your computer is connected to the internet, and ideally to the same Wi-Fi network as your mobile device. Lastly, ensure that you are using the latest version of Expo CLI. Pull to refresh to update.`;
     const message = Platform.select({
-      ios: Constants.isDevice
+      ios: isDevice
         ? baseMessage
         : `${baseMessage} If this still doesn't work, press the + icon on the header to type the project URL manually.`,
       android: baseMessage,


### PR DESCRIPTION
# Why

`Constants.isDevice` is deprecated.

# How

Use `isDevice` from the `expo-device` package:
* https://docs.expo.dev/versions/latest/sdk/device/#deviceisdevice

# Test Plan

Home app runs correctly, there were no test or lint errors.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
