### PR TITLE
[docs] APISection: add missing deprecated notes in types and interfaces

### DIFF
--- a/docs/components/plugins/api/APISectionDeprecationNote.tsx
+++ b/docs/components/plugins/api/APISectionDeprecationNote.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { spacing } from '@expo/styleguide';
+import { theme, spacing } from '@expo/styleguide';
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
 
@@ -30,4 +30,23 @@ export const APISectionDeprecationNote = ({ comment }: Props) => {
 
 const deprecationNoticeStyle = css({
   marginTop: spacing[4],
+
+  code: {
+    backgroundColor: theme.palette.yellow['000'],
+    borderColor: theme.palette.yellow[300],
+  },
+
+  '[data-expo-theme="dark"] & code': {
+    backgroundColor: theme.palette.yellow[100],
+    borderColor: theme.palette.yellow[200],
+  },
+
+  'table &': {
+    marginTop: 0,
+    marginBottom: spacing[3],
+
+    span: {
+      fontSize: '90%',
+    },
+  },
 });

--- a/docs/components/plugins/api/APISectionInterfaces.tsx
+++ b/docs/components/plugins/api/APISectionInterfaces.tsx
@@ -48,6 +48,7 @@ const renderInterfaceComment = (
         {signatureComment && (
           <>
             <br />
+            <APISectionDeprecationNote comment={comment} />
             <CommentTextBlock
               comment={signatureComment}
               components={mdInlineComponents}
@@ -60,12 +61,15 @@ const renderInterfaceComment = (
   } else {
     const initValue = defaultValue || getTagData('default', comment)?.text;
     return (
-      <CommentTextBlock
-        comment={comment}
-        components={mdInlineComponents}
-        afterContent={renderDefaultValue(initValue)}
-        emptyCommentFallback="-"
-      />
+      <>
+        <APISectionDeprecationNote comment={comment} />
+        <CommentTextBlock
+          comment={comment}
+          components={mdInlineComponents}
+          afterContent={renderDefaultValue(initValue)}
+          emptyCommentFallback="-"
+        />
+      </>
     );
   }
 };

--- a/docs/components/plugins/api/APISectionTypes.tsx
+++ b/docs/components/plugins/api/APISectionTypes.tsx
@@ -72,6 +72,7 @@ const renderTypePropertyRow = ({
       </Cell>
       <Cell fitContent>{renderTypeOrSignatureType(type, signatures)}</Cell>
       <Cell fitContent>
+        <APISectionDeprecationNote comment={comment} />
         <CommentTextBlock
           comment={commentData}
           components={mdInlineComponents}


### PR DESCRIPTION
# Why

When working on the `Constants` docs fix I have spotted that the deprecation notes are not always rendered when the content has been specified.

# How

Add missing deprecation notes to the interfaces properties and one of the types.

Additionally I have tweak the `InlineCode` design inside notes and theirs appearance inside of the tables. 

# Test Plan

Changes have been tested by running docs website locally.

# Preview

<img width="1132" alt="Screenshot 2022-07-31 at 19 36 37" src="https://user-images.githubusercontent.com/719641/182038719-eeaad312-ec66-43b8-aac7-20212f954dd3.png">
<img width="1132" alt="Screenshot 2022-07-31 at 19 36 42" src="https://user-images.githubusercontent.com/719641/182038715-be769ff1-b938-4e7d-a91e-86202ea05dc7.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
