### PR TITLE
chore(cli): Add warning when prebuilding with CI=1

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### 💡 Others
 
-- Add warning about malformed project when running prebuild in non-interactive mode.
+- Add warning about malformed project when running prebuild in non-interactive mode. ([#18436](https://github.com/expo/expo/pull/18436) by [@wkozyra95](https://github.com/wkozyra95))
 
 ## 0.2.6 — 2022-07-25
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### 💡 Others
 
+- Add warning about malformed project when running prebuild in non-interactive mode.
+
 ## 0.2.6 — 2022-07-25
 
 ### 🎉 New features

--- a/packages/@expo/cli/src/prebuild/clearNativeFolder.ts
+++ b/packages/@expo/cli/src/prebuild/clearNativeFolder.ts
@@ -137,6 +137,9 @@ export async function promptToClearMalformedNativeProjectsAsync(
       initial: true,
     }))
   ) {
+    if (!isInteractive()) {
+      Log.warn(`${message}, project files will be cleared and reinitialized.`);
+    }
     await clearNativeFolder(projectRoot, platforms);
   } else {
     // Warn the user that the process may fail.


### PR DESCRIPTION
# Why

backport https://github.com/expo/expo-cli/pull/4456

Currently, if someone has a managed project with an ios directory, or is writing eas secrets to ios directory e.g.

```
echo "$IOS_GOOGLE_SERVICES_BASE64" | base64 -d > ios/GoogleService-Info.plist
```
then only warning they are getting that ios directory is deleted is log

```
- Clearing ios
✔ Cleared ios code
```
# How


# Test Plan

Run prebuld using versioned cli with `CI=1` env.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
