### PR TITLE
fix(cli): prevent development session bad gateway error

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- Prevent development session bad gateway from ending long running `expo start` processes.
+- Prevent development session bad gateway from ending long running `expo start` processes. ([#18451](https://github.com/expo/expo/pull/18451) by [@EvanBacon](https://github.com/EvanBacon))
 - Speed up native device opening for iOS and Android. ([#18385](https://github.com/expo/expo/pull/18385) by [@EvanBacon](https://github.com/EvanBacon))
 - Drop support for experimental Webpack native symbolication. ([#18439](https://github.com/expo/expo/pull/18439) by [@EvanBacon](https://github.com/EvanBacon))
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- Prevent development session bad gateway from ending long running `expo start` processes.
 - Speed up native device opening for iOS and Android. ([#18385](https://github.com/expo/expo/pull/18385) by [@EvanBacon](https://github.com/EvanBacon))
 - Drop support for experimental Webpack native symbolication. ([#18439](https://github.com/expo/expo/pull/18439) by [@EvanBacon](https://github.com/EvanBacon))
 

--- a/packages/@expo/cli/src/start/server/DevelopmentSession.ts
+++ b/packages/@expo/cli/src/start/server/DevelopmentSession.ts
@@ -6,6 +6,7 @@ import {
   updateDevelopmentSessionAsync,
 } from '../../api/updateDevelopmentSession';
 import { getUserAsync } from '../../api/user/user';
+import { Log } from '../../log';
 import * as ProjectDevices from '../project/devices';
 
 const debug = require('debug')('expo:start:server:developmentSession') as typeof console.log;
@@ -62,12 +63,16 @@ export class DevelopmentSession {
 
     if (this.url) {
       debug(`Development session ping (runtime: ${runtime}, url: ${this.url})`);
-      await updateDevelopmentSessionAsync({
-        url: this.url,
-        runtime,
-        exp,
-        deviceIds,
-      });
+      try {
+        await updateDevelopmentSessionAsync({
+          url: this.url,
+          runtime,
+          exp,
+          deviceIds,
+        });
+      } catch (error) {
+        Log.warn(`Non-fatal error updating development session API: ${error}`);
+      }
     }
 
     this.stopNotifying();


### PR DESCRIPTION
# Why

When `expo start` is running for around an hour, the `development-sessions/notify-alive` API endpoint throws and ends the process. This PR wraps the error and surfaces it as a warning: 

```
RuntimeError: abort(CommandError: Unexpected response when updating the development session on Expo servers: Bad Gateway.). Build with -s ASSERTIONS=1 for more info.
```

CC server team (@FiberJW) to see if there was a change on the backend that causes this.

# Test Plan

I'll attempt to repro by keeping the server open for an hour. 

Update: dev session just continues to timeout after a while:

```
Non-fatal error updating development session API: FetchError: request to https://api.expo.dev/v2/development-sessions/notify-alive failed, reason: connect ETIMEDOUT 104.18.7.41:443
Non-fatal error updating development session API: FetchError: request to https://api.expo.dev/v2/development-sessions/notify-alive failed, reason: connect ETIMEDOUT 104.18.7.41:443
Non-fatal error updating development session API: FetchError: request to https://api.expo.dev/v2/development-sessions/notify-alive failed, reason: getaddrinfo ENOTFOUND api.expo.dev
Non-fatal error updating development session API: FetchError: request to https://api.expo.dev/v2/development-sessions/notify-alive failed, reason: getaddrinfo ENOTFOUND api.expo.dev
Non-fatal error updating development session API: FetchError: request to https://api.expo.dev/v2/development-sessions/notify-alive failed, reason: getaddrinfo ENOTFOUND api.expo.dev
Non-fatal error updating development session API: FetchError: request to https://api.expo.dev/v2/development-sessions/notify-alive failed, reason: getaddrinfo ENOTFOUND api.expo.dev
Non-fatal error updating development session API: FetchError: request to https://api.expo.dev/v2/development-sessions/notify-alive failed, reason: getaddrinfo ENOTFOUND api.expo.dev
Non-fatal error updating development session API: FetchError: request to https://api.expo.dev/v2/development-sessions/notify-alive failed, reason: getaddrinfo ENOTFOUND api.expo.dev
```

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
