### PR TITLE
[docs] ToC tags hotfixes

### DIFF
--- a/docs/components/DocumentationSidebarRightLink.tsx
+++ b/docs/components/DocumentationSidebarRightLink.tsx
@@ -95,7 +95,7 @@ const isOverflowing = (el: HTMLElement) => {
   }
 
   const childrenWidth = Array.from(el.children).reduce((sum, child) => sum + child.scrollWidth, 0);
-  return childrenWidth >= el.scrollWidth;
+  return childrenWidth >= el.scrollWidth - parseInt(el.style.paddingLeft, 10);
 };
 
 type TooltipProps = React.PropsWithChildren<{

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -4968,7 +4968,7 @@ OAuth 2.0 protocol
          
       </strong>
       <div
-        class="css-140enuz-PlatformTag"
+        class="css-1kq9nqw-PlatformTag"
       >
         <svg
           color="var(--expo-theme-palette-blue-900)"

--- a/docs/ui/components/Tag/styles.ts
+++ b/docs/ui/components/Tag/styles.ts
@@ -20,6 +20,10 @@ export const tagStyle = css({
     marginBottom: spacing[2],
     padding: `${spacing[0.5]}px ${spacing[1.5]}px`,
   },
+
+  'nav &': {
+    whiteSpace: 'pre',
+  },
 });
 
 export const tagFirstStyle = css({


### PR DESCRIPTION
# Why

After the deploy of ToC tag I have spotted two small issues.

# How

This PR fixes the following problems with new tags:
* platform tags with space in them in rare cases can render in two lines breaking to appearance, I have added an CSS rule to prevent that bechaviour
* tooltips do not correctly appear for all of the shortened entries with platform tag, there was a padding-width gap where text has been truncated, but there was no tooltip

# Test Plan

The changes has been tested by running docs website locally.

# Preview

<img width="240" alt="x" src="https://user-images.githubusercontent.com/719641/182421707-a3567128-b60a-46ca-a3e7-6f501605534c.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
