### PR TITLE
[ci] Remove shell app workflows

### DIFF
--- a/.github/workflows/shell-app-android.yml
+++ b/.github/workflows/shell-app-android.yml
@@ -1,12 +1,13 @@
+# Github workflows need to exist on the 'main' branch
+# in order to be run on other branches using workflow_dispatch.
+# The actual workflow is loaded from the target branch
+# (the one we dispatch the workflow to run on)
+# so we need a minimal failing job on main just to be able
+# to trigger the workflow on other (usually sdk-xx) branches
 name: Android Shell App
 
 on:
   workflow_dispatch: {}
-  schedule:
-    - cron: '20 5 * * 2,4,6' # 5:20 AM UTC time on every Tuesday, Thursday and Saturday
-  push:
-    paths:
-      - .github/workflows/shell-app-android.yml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
@@ -15,82 +16,9 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        ndk-version: [21.4.7075529]
     steps:
-      - name: 👀 Checkout
-        uses: actions/checkout@v3
-        with:
-          submodules: true
-      - name: 🔨 Use JDK 11
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: '11'
-      - name: ➕ Add `EXPO_ROOT_DIR` to GITHUB_ENV
-        run: echo "EXPO_ROOT_DIR=$(pwd)" >> $GITHUB_ENV
-      - name: ➕ Add `bin` to GITHUB_PATH
-        run: echo "$(pwd)/bin" >> $GITHUB_PATH
-      - name: ♻️ Restore caches
-        uses: ./.github/actions/expo-caches
-        id: expo-caches
-        with:
-          yarn-workspace: 'true'
-          git-lfs: 'true'
-          ndk: 'true'
-          ndk-version: ${{ matrix.ndk-version }}
-          hermes-engine-aar: 'true'
-      - name: 🚚 Pull Git LFS files
-        run: git lfs pull
-      - name: 🧶 Yarn install
-        if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
-        run: yarn install --frozen-lockfile
-      - name: 🏗️ Build Android packages
-        env:
-          ANDROID_NDK_HOME: /usr/local/lib/android/sdk/ndk/${{ matrix.ndk-version }}/
-        run: expotools android-build-packages --packages all
-      - name: 🧹 Clean Android build artifacts that would needlessly bloat the shell app
-        env:
-          ANDROID_NDK_HOME: /usr/local/lib/android/sdk/ndk/${{ matrix.ndk-version }}/
-        run: ./gradlew clean
-        working-directory: android
-      - name: 🏗️ Build shell app tarball
-        run: ./buildAndroidTarballLocally.sh
-      - name: 📦️ Make an artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: android-shell-app
-          path: artifacts/android-shell-builder.tar.gz
-      - name: 📤️ Upload shell app tarball to S3
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: 'us-east-1'
-          S3_URI: s3://exp-artifacts/android-shell-builder-${{ github.sha }}.tar.gz
+      - name: Fail workflow
         run: |
-          aws s3 cp --acl public-read artifacts/android-shell-builder.tar.gz $S3_URI
-          echo "Release tarball uploaded to $S3_URI"
-          echo "You can deploy this by updating or creating a new file in https://github.com/expo/turtle/tree/master/shellTarballs/android"
-          echo "Then follow the deployment instructions: https://github.com/expo/turtle-deploy"
-      - name: 🏷️ Set the description for Slack message
-        if: ${{ github.event_name != 'push' }}
-        run: |
-          if [ ${{ github.event_name }} == 'schedule' ]; then
-            echo "SLACK_MESSAGE_DESCRIPTION=scheduled" >> $GITHUB_ENV
-          else
-            echo "SLACK_MESSAGE_DESCRIPTION=triggered by ${{ github.actor }}" >> $GITHUB_ENV
-          fi
-      - name: 🔔 Notify on Slack
-        uses: 8398a7/action-slack@v3
-        if: ${{ github.event_name != 'push' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_ANDROID }}
-          MATRIX_CONTEXT: ${{ toJson(matrix) }}
-        with:
-          channel: '#expo-android'
-          status: ${{ job.status }}
-          fields: job,message,ref,eventName,author,took
-          author_name: Android Shell App (${{ env.SLACK_MESSAGE_DESCRIPTION }})
+          echo "Shell apps were dropped on 'main'. " \
+          "Did you forget to select the SDK release branch when dispatching workflow?"
+          exit 1

--- a/.github/workflows/shell-app-ios.yml
+++ b/.github/workflows/shell-app-ios.yml
@@ -1,3 +1,9 @@
+# Github workflows need to exist on the 'main' branch
+# in order to be run on other branches using workflow_dispatch.
+# The actual workflow is loaded from the target branch
+# (the one we dispatch the workflow to run on)
+# so we need a minimal failing job on main just to be able
+# to trigger the workflow on other (usually sdk-xx) branches
 name: iOS Shell App
 
 on:
@@ -6,13 +12,6 @@ on:
       upload:
         description: 'type "upload" to confirm upload to S3'
         required: false
-  schedule:
-    - cron: '20 5 * * 2,4,6' # 5:20 AM UTC time on every Tuesday, Thursday and Saturday
-  pull_request:
-    paths:
-      - .github/workflows/shell-app-ios.yml
-      - .ruby-version
-      - exponent-view-template
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
@@ -20,73 +19,10 @@ concurrency:
 
 jobs:
   build:
-    runs-on: macos-11
+    runs-on: ubuntu-20.04
     steps:
-      - name: 👀 Checkout
-        uses: actions/checkout@v3
-        with:
-          submodules: true
-      - name: 🔨 Switch to Xcode 13.2.1
-        run: sudo xcode-select --switch /Applications/Xcode_13.2.1.app
-      - name: ➕ Add `EXPO_ROOT_DIR` to GITHUB_ENV
-        run: echo "EXPO_ROOT_DIR=$(pwd)" >> $GITHUB_ENV
-      - name: ➕ Add `bin` to GITHUB_PATH
-        run: echo "$(pwd)/bin" >> $GITHUB_PATH
-      - name: 💎 Setup Ruby and install gems
-        uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
-      - name: ♻️ Restore caches
-        uses: ./.github/actions/expo-caches
-        id: expo-caches
-        with:
-          yarn-workspace: 'true'
-          yarn-tools: 'true'
-      - name: 🧶 Yarn install
-        if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
-        run: yarn install --frozen-lockfile
-      - name: 🍏 Generate dynamic macros
-        run: expotools ios-generate-dynamic-macros
-      - name: 📦 Build iOS shell app for real devices
-        timeout-minutes: 30
+      - name: Fail workflow
         run: |
-          expotools ios-shell-app --action build --type archive --verbose true --skipRepoUpdate --shellAppSdkVersion UNVERSIONED
-      - name: 📦 Build iOS shell app for simulators
-        timeout-minutes: 30
-        run: |
-          expotools ios-shell-app --action build --type simulator --verbose true --skipRepoUpdate --shellAppSdkVersion UNVERSIONED
-      - name: ✏️ Set tarball name
-        id: tarball
-        run: echo "::set-output name=filename::ios-shell-builder-sdk-latest-${{ github.sha }}.tar.gz"
-      - name: 🤐 Package release tarball
-        run: |
-          tar \
-            -zcf ${{ steps.tarball.outputs.filename }} \
-            package.json \
-            exponent-view-template \
-            shellAppBase-builds \
-            shellAppWorkspaces \
-            ios
-      - name: 🚀 Upload shell app tarball to S3
-        if: ${{ github.event.inputs.upload == 'upload' }}
-        timeout-minutes: 40
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: 'us-east-1'
-        run: |
-          aws s3 cp --acl public-read ${{ steps.tarball.outputs.filename }} s3://exp-artifacts
-          echo "Release tarball uploaded to s3://exp-artifacts/${{ steps.tarball.outputs.filename }}"
-          echo "You can deploy this by updating or creating a new file in https://github.com/expo/turtle/tree/main/shellTarballs/ios"
-          echo "Then follow the deployment instructions: https://github.com/expo/turtle-deploy"
-      - name: 🔔 Notify on Slack
-        uses: 8398a7/action-slack@v3
-        if: failure() && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-') || github.event_name == 'schedule')
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_IOS }}
-        with:
-          channel: '#expo-ios'
-          status: ${{ job.status }}
-          fields: job,message,ref,eventName,author,took
-          author_name: Shell App (iOS)
+          echo "Shell apps were dropped on 'main'. " \
+          "Did you forget to select the SDK release branch when dispatching workflow?"
+          exit 1


### PR DESCRIPTION
# Why

Part of ENG-5734

We're dropping Shell apps so we no longer need these workflows to clog the CI workers in PRs (and on schedule)

# How

It turns out that the workflow file must exist on `main` branch to be able to run it on other (usually `sdk-*`) branches using `workflow_dispatch`.  See [this SO discussion](https://stackoverflow.com/questions/63362126/github-actions-how-to-run-a-workflow-created-on-a-non-master-branch-from-the-wo) and also the comments I added in the workflow files.
On `main` I left a minimal workflow that always fails with a meaningful error message.

# Test Plan

Ran this command using Github CLI _(equiv. of clicking workflow dispatch button in the Actions tab)_:
```sh
gh workflow run "iOS Shell App" --ref @barthap/ci/remove-shell-apps
```
Result: https://github.com/expo/expo/runs/7635696171?check_suite_focus=true
