### PR TITLE
[templates] Fix regression from RN 0.69 upgrade

### DIFF
--- a/apps/bare-expo/android/app/build.gradle
+++ b/apps/bare-expo/android/app/build.gradle
@@ -84,6 +84,7 @@ def reactNativeRoot = new File(["node", "--print", "require.resolve('react-nativ
 project.ext.react = [
     entryFile: ["node", "-e", "require('expo/scripts/resolveAppEntry')", projectRoot, "android"].execute(null, rootDir).text.trim(),
     enableHermes: (findProperty('expo.jsEngine') ?: "jsc") == "hermes",
+    hermesCommand: new File(["node", "--print", "require.resolve('react-native/package.json')"].execute(null, rootDir).text.trim()).getParentFile().getAbsolutePath() + "/sdks/hermesc/%OS-BIN%/hermesc",
     cliPath: "${reactNativeRoot}/cli.js",
     composeSourceMapsPath: "${reactNativeRoot}/scripts/compose-source-maps.js",
 ]
@@ -175,7 +176,7 @@ android {
                         "GENERATED_SRC_DIR=$buildDir/generated/source",
                         "PROJECT_BUILD_DIR=$buildDir",
                         "REACT_ANDROID_DIR=${reactNativeRoot}/ReactAndroid",
-                        "REACT_ANDROID_BUILD_DIR=${reactNativeRoot}/build",
+                        "REACT_ANDROID_BUILD_DIR=${reactNativeRoot}/ReactAndroid/build",
                         "NODE_MODULES_DIR=$rootDir/../node_modules"
                     cFlags "-Wall", "-Werror", "-fexceptions", "-frtti", "-DWITH_INSPECTOR=1"
                     cppFlags "-std=c++17"

--- a/apps/bare-sandbox/android/app/build.gradle
+++ b/apps/bare-sandbox/android/app/build.gradle
@@ -85,6 +85,7 @@ def reactNativeRoot = new File(["node", "--print", "require.resolve('react-nativ
 project.ext.react = [
     entryFile: ["node", "-e", "require('expo/scripts/resolveAppEntry')", projectRoot, "android"].execute(null, rootDir).text.trim(),
     enableHermes: (findProperty('expo.jsEngine') ?: "jsc") == "hermes",
+    hermesCommand: new File(["node", "--print", "require.resolve('react-native/package.json')"].execute(null, rootDir).text.trim()).getParentFile().getAbsolutePath() + "/sdks/hermesc/%OS-BIN%/hermesc",
     cliPath: "${reactNativeRoot}/cli.js",
     composeSourceMapsPath: "${reactNativeRoot}/scripts/compose-source-maps.js",
 ]
@@ -159,7 +160,7 @@ android {
                         "GENERATED_SRC_DIR=$buildDir/generated/source",
                         "PROJECT_BUILD_DIR=$buildDir",
                         "REACT_ANDROID_DIR=${reactNativeRoot}/ReactAndroid",
-                        "REACT_ANDROID_BUILD_DIR=${reactNativeRoot}/build",
+                        "REACT_ANDROID_BUILD_DIR=${reactNativeRoot}/ReactAndroid/build",
                         "NODE_MODULES_DIR=$rootDir/../node_modules"
                     cFlags "-Wall", "-Werror", "-fexceptions", "-frtti", "-DWITH_INSPECTOR=1"
                     cppFlags "-std=c++17"

--- a/templates/expo-template-bare-minimum/android/app/build.gradle
+++ b/templates/expo-template-bare-minimum/android/app/build.gradle
@@ -85,6 +85,7 @@ def reactNativeRoot = new File(["node", "--print", "require.resolve('react-nativ
 project.ext.react = [
     entryFile: ["node", "-e", "require('expo/scripts/resolveAppEntry')", projectRoot, "android"].execute(null, rootDir).text.trim(),
     enableHermes: (findProperty('expo.jsEngine') ?: "jsc") == "hermes",
+    hermesCommand: new File(["node", "--print", "require.resolve('react-native/package.json')"].execute(null, rootDir).text.trim()).getParentFile().getAbsolutePath() + "/sdks/hermesc/%OS-BIN%/hermesc",
     cliPath: "${reactNativeRoot}/cli.js",
     composeSourceMapsPath: "${reactNativeRoot}/scripts/compose-source-maps.js",
 ]
@@ -159,7 +160,7 @@ android {
                         "GENERATED_SRC_DIR=$buildDir/generated/source",
                         "PROJECT_BUILD_DIR=$buildDir",
                         "REACT_ANDROID_DIR=${reactNativeRoot}/ReactAndroid",
-                        "REACT_ANDROID_BUILD_DIR=${reactNativeRoot}/build",
+                        "REACT_ANDROID_BUILD_DIR=${reactNativeRoot}/ReactAndroid/build",
                         "NODE_MODULES_DIR=$rootDir/../node_modules"
                     cFlags "-Wall", "-Werror", "-fexceptions", "-frtti", "-DWITH_INSPECTOR=1"
                     cppFlags "-std=c++17"


### PR DESCRIPTION
# Why

regression issues from my changes during react-native 0.69 upgrade

# How

- add back `hermesCommand` but resolve in react-native. this will fix the workspace support where showtime had.
- fix `REACT_ANDROID_BUILD_DIR` path. this will fix build errors in new architecture mode.

# Test Plan

- `hermesCommand`: try to build in showtime app
-  `REACT_ANDROID_BUILD_DIR`: try to app with new architecture enabled. 

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
