### PR TITLE
feat(cli): add EXPO_NO_DEFAULT_PORT to skip proxy port

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Add `EXPO_NO_DEFAULT_PORT` to skip proxy port.
+- Add `EXPO_NO_DEFAULT_PORT` to skip proxy port. ([#18464](https://github.com/expo/expo/pull/18464) by [@EvanBacon](https://github.com/EvanBacon))
 - Disable interactive prompts in non TTY processes. ([#18300](https://github.com/expo/expo/pull/18300) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🐛 Bug fixes

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🎉 New features
 
+- Add `EXPO_NO_DEFAULT_PORT` to skip proxy port.
 - Disable interactive prompts in non TTY processes. ([#18300](https://github.com/expo/expo/pull/18300) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🐛 Bug fixes

--- a/packages/@expo/cli/src/start/server/UrlCreator.ts
+++ b/packages/@expo/cli/src/start/server/UrlCreator.ts
@@ -2,6 +2,7 @@ import assert from 'assert';
 import { URL } from 'url';
 
 import * as Log from '../../log';
+import { env } from '../../utils/env';
 import { getIpAddress } from '../../utils/ip';
 
 const debug = require('debug')('expo:start:server:urlCreator') as typeof console.log;
@@ -148,10 +149,16 @@ function joinUrlComponents({ protocol, hostname, port }: Partial<UrlComponents>)
   // This is because Android React Native WebSocket implementation is not spec compliant and fails without a port:
   // `E unknown:ReactNative: java.lang.IllegalArgumentException: Invalid URL port: "-1"`
   // Invoked first in `metro-runtime/src/modules/HMRClient.js`
-  const validPort = port || '80';
+  const validPort = env.EXPO_NO_DEFAULT_PORT ? port : port || '80';
   const validProtocol = protocol ? `${protocol}://` : '';
 
-  return `${validProtocol}${hostname}:${validPort}`;
+  let url = `${validProtocol}${hostname}`;
+
+  if (validPort) {
+    url += `:${validPort}`;
+  }
+
+  return url;
 }
 
 /** @deprecated */

--- a/packages/@expo/cli/src/start/server/__tests__/UrlCreator-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/UrlCreator-test.ts
@@ -5,6 +5,7 @@ import { UrlCreator } from '../UrlCreator';
 jest.mock('../../../log');
 
 beforeEach(() => {
+  delete process.env.EXPO_NO_DEFAULT_PORT;
   delete process.env.EXPO_PACKAGER_PROXY_URL;
   delete process.env.REACT_NATIVE_PACKAGER_HOSTNAME;
 });
@@ -67,6 +68,16 @@ describe('constructDevClientUrl', () => {
 });
 
 describe('constructUrl', () => {
+  it(`skips default port with environment variable`, () => {
+    process.env.EXPO_NO_DEFAULT_PORT = 'true';
+    process.env.EXPO_PACKAGER_PROXY_URL = 'http://expo.dev';
+    expect(createDefaultCreator().constructUrl({})).toMatchInlineSnapshot(`"http://expo.dev"`);
+  });
+  it(`adds a default port by default when using a non-standard URL`, () => {
+    process.env.EXPO_PACKAGER_PROXY_URL = 'http://expo.dev';
+    expect(createDefaultCreator().constructUrl({})).toMatchInlineSnapshot(`"http://expo.dev:80"`);
+  });
+
   it(`creates default`, () => {
     expect(createDefaultCreator().constructUrl({})).toMatchInlineSnapshot(
       `"http://100.100.1.100:8081"`

--- a/packages/@expo/cli/src/utils/env.ts
+++ b/packages/@expo/cli/src/utils/env.ts
@@ -88,6 +88,26 @@ class Env {
   get EXPO_EDITOR(): string {
     return string('EXPO_EDITOR', '');
   }
+
+  /**
+   * Overwrite the dev server URL, disregarding the `--port`, `--host`, `--tunnel`, `--lan`, `--localhost` arguments.
+   * This is useful for browser editors that require custom proxy URLs.
+   *
+   * The URL will not be used verbatim unless `EXPO_NO_DEFAULT_PORT=true` is also set,
+   * otherwise a `:80` port will be added for Android support.
+   */
+  get EXPO_PACKAGER_PROXY_URL(): string {
+    return string('EXPO_PACKAGER_PROXY_URL', '');
+  }
+
+  /**
+   * Disable the enforced `:80` port when using custom dev server URLs.
+   * This can break the incomplete Android WebSocket implementation but allows
+   * `EXPO_PACKAGER_PROXY_URL` to work as expected.
+   * */
+  get EXPO_NO_DEFAULT_PORT(): boolean {
+    return boolish('EXPO_NO_DEFAULT_PORT', false);
+  }
 }
 
 export const env = new Env();


### PR DESCRIPTION
# Why

Possibly required for supporting tools like gitpod and codesandbox on iOS. It's unclear how we'll make Android work, may just need to upstream a fix for the WebSocket bug.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->


# Test Plan

Added tests for the expected behavior.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
