### PR TITLE
add sdk 46 blog post to docs/pages/workflow

### DIFF
--- a/docs/pages/workflow/upgrading-expo-sdk-walkthrough.md
+++ b/docs/pages/workflow/upgrading-expo-sdk-walkthrough.md
@@ -8,6 +8,10 @@ Expo maintains ~6 months of backward compatibility. Once an SDK version has been
 
 > **Note**: If you are running ExpoKit inside a native project, upgrading will require extra steps. ExpoKit is deprecated and is no longer supported after SDK 38. We recommend [migrating existing ExpoKit projects to the bare workflow](/bare/migrating-from-expokit).
 
+## SDK 46
+
+[Blog Post](https://blog.expo.dev/expo-sdk-46-c2a1655f63f7)
+
 ## SDK 45
 
 [Blog Post](https://blog.expo.dev/expo-sdk-45-f4e332954a68)


### PR DESCRIPTION
# Why

With the new addition to Expo SDK 46, I noticed the docs hadn't yet included the newest blog post, so I thought this would be a great opportunity to pitch in!

# How

I included the following link (https://blog.expo.dev/expo-sdk-46-c2a1655f63f7) to help future Expo users navigate to the correct migration guide when landing on the [Upgrading Expo SDK](https://docs.expo.dev/workflow/upgrading-expo-sdk-walkthrough/) page.

# Test Plan

I followed the contribution guidelines (https://github.com/expo/expo/blob/main/CONTRIBUTING.md) . I followed steps 1-5 in the "Download and Set up" section. running `npm run setup:docs` in step 5 versus the first command. then I jump to the Updating Documentation section (https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-updating-documentation) and made my updates accordingly. I cd'ed into the `docs` directory and ran `yarn dev`, and saw my changes reflected and working on the local host.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [X] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).

Lastly I just wanted to give `Kim#0404` on Discord a big THANK YOU for getting me unstuck. They deserve the recognition!