### PR TITLE
[core] Fix new architecture mode errors on android

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### 🐛 Bug fixes
 
 - Fix issue with Android builds when gradle clean and build were called concurrently.  ([#18518](https://github.com/expo/expo/pull/18518) by [EdwardDrapkin](https://github.com/EdwardDrapkin))
+- Fixed `FabricUIManager` errors when turning on new architecture mode on Android. ([#18472](https://github.com/expo/expo/pull/18472) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/CMakeLists.txt
+++ b/packages/expo-modules-core/android/CMakeLists.txt
@@ -50,7 +50,7 @@ target_include_directories(
         "${REACT_NATIVE_DIR}/ReactCommon/react/nativemodule/core"
         "${REACT_NATIVE_DIR}/ReactCommon/callinvoker"
         "${REACT_NATIVE_DIR}/ReactCommon/jsi"
-        "${HERMES_DIR}/android/include"
+        "${HERMES_HEADER_DIR}"
         "${BUILD_DIR}/third-party-ndk/boost/boost_${BOOST_VERSION}"
         "${BUILD_DIR}/third-party-ndk/double-conversion"
         "${BUILD_DIR}/third-party-ndk/folly"

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -71,8 +71,15 @@ def reactNativeArchitectures() {
   return value ? value.split(",") : ["armeabi-v7a", "x86", "x86_64", "arm64-v8a"]
 }
 
+// HERMES
+def prebuiltHermesDir = findProperty("expo.prebuiltHermesDir") ?: file("${REACT_NATIVE_DIR}/ReactAndroid/prebuiltHermes")
+def prebuiltHermesVersion = file("${prebuiltHermesDir}/.hermesversion").exists() ? file("${prebuiltHermesDir}/.hermesversion").text : null
+def currentHermesVersion = file("${REACT_NATIVE_DIR}/sdks/.hermesversion").exists() ? file("${REACT_NATIVE_DIR}/sdks/.hermesversion").text : null
+def hasHermesProject = findProject(":ReactAndroid:hermes-engine") != null
+def prebuiltHermesCacheHit = hasHermesProject && currentHermesVersion == prebuiltHermesVersion
+
 def FOR_HERMES = false
-def HERMES_ENGINE_DIR = null
+def HERMES_HEADER_DIR = null
 def HERMES_AAR = null
 if (findProject(":app")) {
   def appProjectExt = project(":app").ext
@@ -86,23 +93,30 @@ if (findProject(":app")) {
 }
 
 if (FOR_HERMES) {
-  // The `hermes-engine` package doesn't contain the correct version of the Hermes.
-  // The AAR we need to import is located in the React Native package.
-  // However, the version from RN doesn't include header files.
-  // To get those, we must fall back to the `hermes-engine` package.
-  HERMES_ENGINE_DIR = new File(["node", "--print", "require.resolve('hermes-engine/package.json')"].execute(null, rootDir).text.trim()).parent
-  if (REACT_NATIVE_BUILD_FROM_SOURCE) {
-    // TODO(@lukmccall): Use Hermes from the `ReactAndroid:hermes-engine`
-    HERMES_AAR = file("$HERMES_ENGINE_DIR/android/hermes-debug.aar")
+  if (prebuiltHermesCacheHit) {
+    HERMES_HEADER_DIR = file("${thirdPartyNdkDir}/hermes/prefab/modules/libhermes/include")
+    HERMES_AAR = file("${prebuiltHermesDir}/hermes-engine-debug.aar")
+  } else if (hasHermesProject) {
+    HERMES_HEADER_DIR = file("${thirdPartyNdkDir}/hermes/prefab/modules/libhermes/include")
+    HERMES_AAR = file("${REACT_NATIVE_DIR}/ReactAndroid/hermes-engine/build/outputs/aar/hermes-engine-debug.aar")
   } else {
+    // The `hermes-engine` package doesn't contain the correct version of the Hermes.
+    // The AAR we need to import is located in the React Native package.
+    // However, the version from RN doesn't include header files.
+    // To get those, we must fall back to the `hermes-engine` package.
+    def hermesEngineDir = new File(["node", "--print", "require.resolve('hermes-engine/package.json')"].execute(null, rootDir).text.trim()).parent
+
     def prebuiltAAR = fileTree(REACT_NATIVE_DIR).matching { include "**/hermes-engine/**/hermes-engine-*-debug.aar" }
     if (prebuiltAAR.any()) {
       HERMES_AAR = prebuiltAAR.singleFile
     } else {
-      HERMES_AAR = file("$HERMES_ENGINE_DIR/android/hermes-debug.aar")
+      HERMES_AAR = file("${hermesEngineDir}/android/hermes-debug.aar")
     }
+    HERMES_HEADER_DIR = file("${hermesEngineDir}/android/include")
   }
 }
+// END HERMES
+
 
 // Creating sources with comments
 task androidSourcesJar(type: Jar) {
@@ -156,7 +170,7 @@ android {
           "-DREACT_NATIVE_TARGET_VERSION=${REACT_NATIVE_TARGET_VERSION}",
           "-DBOOST_VERSION=${BOOST_VERSION}",
           "-DFOR_HERMES=${FOR_HERMES}",
-          "-DHERMES_DIR=${HERMES_ENGINE_DIR}"
+          "-DHERMES_HEADER_DIR=${HERMES_HEADER_DIR}"
       }
     }
   }
@@ -264,7 +278,8 @@ dependencies {
   androidTestImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.0"
 
   if (FOR_HERMES) {
-    androidTestImplementation files(HERMES_AAR)
+    def hermesProject = findProject(":ReactAndroid:hermes-engine")
+    androidTestImplementation (hermesProject ?: files(HERMES_AAR))
   } else {
     androidTestImplementation "org.webkit:android-jsc:+"
   }
@@ -427,12 +442,14 @@ task prepareHermes(dependsOn: createNativeDepsDirectories) {
     return
   }
 
-  def soFiles = zipTree(HERMES_AAR).matching({ it.include "**/*.so" })
+  doLast {
+    def files = zipTree(HERMES_AAR).matching({ it.include "**/*.so", "prefab/modules/libhermes/include/**/*" })
 
-  copy {
-    from soFiles
-    from "$REACT_NATIVE_DIR/ReactAndroid/src/main/jni/first-party/hermes/Android.mk"
-    into "$thirdPartyNdkDir/hermes"
+    copy {
+      from files
+      from "$REACT_NATIVE_DIR/ReactAndroid/src/main/jni/first-party/hermes/Android.mk"
+      into "$thirdPartyNdkDir/hermes"
+    }
   }
 }
 
@@ -441,6 +458,9 @@ task prepareThirdPartyNdkHeaders(dependsOn: [prepareBoost, prepareDoubleConversi
 afterEvaluate {
   extractAARHeaders.dependsOn(prepareThirdPartyNdkHeaders)
   extractJNIFiles.dependsOn(prepareThirdPartyNdkHeaders)
+  if (hasHermesProject && !prebuiltHermesCacheHit) {
+    prepareHermes.dependsOn(":ReactAndroid:hermes-engine:assembleDebug")
+  }
 }
 
 tasks.whenTaskAdded { task ->

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `FabricUIManager` errors when turning on new architecture mode on Android. ([#18472](https://github.com/expo/expo/pull/18472) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 46.0.1 — 2022-07-25

--- a/packages/expo/android/src/main/java/expo/modules/ReactNativeHostWrapperBase.kt
+++ b/packages/expo/android/src/main/java/expo/modules/ReactNativeHostWrapperBase.kt
@@ -93,8 +93,7 @@ open class ReactNativeHostWrapperBase(
       reactNativeHostHandlers.forEach { handler ->
         handler.onRegisterJSIModules(reactApplicationContext, jsContext, useDeveloperSupport)
       }
-      userJSIModulePackage?.getJSIModules(reactApplicationContext, jsContext)
-      return emptyList()
+      return userJSIModulePackage?.getJSIModules(reactApplicationContext, jsContext)?.toList() ?: emptyList()
     }
   }
 

--- a/packages/expo/android/src/main/java/expo/modules/ReactNativeHostWrapperBase.kt
+++ b/packages/expo/android/src/main/java/expo/modules/ReactNativeHostWrapperBase.kt
@@ -35,6 +35,8 @@ open class ReactNativeHostWrapperBase(
       handler.onDidCreateReactInstanceManager(result, developerSupport)
     }
 
+    injectHostReactInstanceManager(result)
+
     return result
   }
 
@@ -106,6 +108,16 @@ open class ReactNativeHostWrapperBase(
       methodMap[name] = method
     }
     return method!!.invoke(host) as T
+  }
+
+  /**
+   * Inject the @{ReactInstanceManager} from the wrapper to the wrapped host.
+   * In case the wrapped host to call `getReactInstanceManager` inside its methods.
+   */
+  fun injectHostReactInstanceManager(reactInstanceManager: ReactInstanceManager) {
+    val mReactInstanceManagerField = ReactNativeHost::class.java.getDeclaredField("mReactInstanceManager")
+    mReactInstanceManagerField.isAccessible = true
+    mReactInstanceManagerField.set(host, reactInstanceManager)
   }
 
   //endregion


### PR DESCRIPTION
# Why

on sdk 46, the new architecture mode has a couple errors.

# How

- FabricUIManager is not correctly initialized
  - we return the JSI modules from `ReactNativeHostWrapper`. that is for the `FabricJSIModuleProvider` in `MainApplicationReactNativeHost`.
  - in fabric mode, there's an early call path for `ModuleRegistryAdapter.createViewManagers()`. in the case, the `NativeModulesProxy` is still null.
- crash because [`getDefaultJSExecutorFactory`](https://github.com/facebook/react-native/blob/8524177910a980d6b0a2494d8d9845d833adfdde/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManagerBuilder.java#L387-L389) calls twice. the static initialization is not catchable.
  - the `MainApplicationReactNativeHost` calls `getReactInstanceManager()` inside its closure, the instance is not the one we created in the ReactNativeHostWrapper. this pr uses reflection to replace the internal `mReactInstanceManager` value for the wrapper ReactNativeHost.
- crash when expo-modules-core setup `ExpoModules` property through jsi to hermes
  - when building expo-modules-core, the hermes is still the old one from `hermes-engine`. in my case i will have crash like `Object::setProperty(Runtime& runtime, const char* name, T&& value)` calls to `symbolToString` (it should be `createStringFromAscii`) because it's inline template in *jsi-inl.h*. this pr tries to use the building from source hermes for expo-modules-core.

# Test Plan

```
$ yarn create expo-app -t blank@sdk-46 sdk46`
$ npx expo prebuild -p android
$ cd android && ./gradlew -PnewArchEnabled=true :app:installDebug
```

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
