### PR TITLE
[ENG-5117][docs] move EAS Build npm hooks to separate page

### DIFF
--- a/docs/constants/navigation-deprecated.js
+++ b/docs/constants/navigation-deprecated.js
@@ -282,6 +282,7 @@ const eas = [
       makeGroup('Reference', [
         makePage('build-reference/eas-json.md'),
         makePage('build-reference/migrating.md'),
+        makePage('build-reference/npm-hooks.md'),
         makePage('build-reference/how-tos.md'),
         makePage('build-reference/private-npm-packages.md'),
         makePage('build-reference/variables.md'),

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -264,6 +264,7 @@ const eas = [
       makeGroup('Reference', [
         makePage('build-reference/eas-json.md'),
         makePage('build-reference/migrating.md'),
+        makePage('build-reference/npm-hooks.md'),
         makePage('build-reference/how-tos.md'),
         makePage('build-reference/private-npm-packages.md'),
         makePage('build-reference/variables.md'),

--- a/docs/pages/build-reference/android-builds.md
+++ b/docs/pages/build-reference/android-builds.md
@@ -42,11 +42,15 @@ Next, this is what happens when EAS Build picks up your request:
 
    - `COMMAND` is the command defined in your **eas.json** at `builds.android.PROFILE_NAME.gradleCommand`. It defaults to `:app:bundleRelease` which produces the AAB (Android App Bundle).
 
-1. Run the `eas-build-pre-upload-artifacts` script from package.json if defined.
+1. **Deprecated:** Run the `eas-build-pre-upload-artifacts` script from package.json if defined.
 1. Store a cache of files and directories defined in the build profile. Subsequent builds will restore this cache. ([Learn more](../build/eas-json/).)
 1. Upload the build artifact to AWS S3.
 
    - The artifact path can be configured in **eas.json** at `builds.android.PROFILE_NAME.artifactPath`. It defaults to `android/app/build/outputs/**/*.{apk,aab}`. We're using the [fast-glob](https://github.com/mrmlnc/fast-glob#pattern-syntax) package for pattern matching.
+
+1. If the build was successful: run the `eas-build-on-success` script from package.json if defined.
+1. If the build failed: run the `eas-build-on-error` script from package.json if defined.
+1. Run the `eas-build-on-complete` script from package.json if defined. The `EAS_BUILD_STATUS` env variable is set to either `finished` or `errored`.
 
 ## Project Auto-Configuration
 

--- a/docs/pages/build-reference/android-builds.md
+++ b/docs/pages/build-reference/android-builds.md
@@ -30,27 +30,27 @@ Next, this is what happens when EAS Build picks up your request:
 
 1. Download the project tarball from a private AWS S3 bucket and unpack it.
 1. Create `.npmrc` if `NPM_TOKEN` is set. ([Learn more](/build-reference/private-npm-packages).)
-1. Run the `eas-build-pre-install` script from package.json if defined.
+1. Run the `eas-build-pre-install` script from **package.json** if defined.
 1. Run `npm install` in the project root (or `yarn install` if `yarn.lock` exists).
 1. Run `expo doctor` to diagnose potential issues with your project configuration.
 1. Additional step for **managed** projects: Run `expo prebuild` to convert the project to a bare one. This step will use the versioned Expo CLI for projects that use Expo SDK 46+. You can still choose to use the (deprecated) global Expo CLI installation by setting `EXPO_USE_LOCAL_CLI=0` in the build profile.
 1. Restore a previously saved cache identified by the `cache.key` value in the build profile. ([Learn more](../build/eas-json/).)
-1. Run the `eas-build-post-install` script from package.json if defined.
+1. Run the `eas-build-post-install` script from **package.json** if defined.
 1. Restore the keystore (if it was included in the build request).
 1. Inject the signing configuration into **build.gradle**. [Learn more](#configuring-gradle).
 1. Run `./gradlew COMMAND` in the **android** directory inside your project.
 
    - `COMMAND` is the command defined in your **eas.json** at `builds.android.PROFILE_NAME.gradleCommand`. It defaults to `:app:bundleRelease` which produces the AAB (Android App Bundle).
 
-1. **Deprecated:** Run the `eas-build-pre-upload-artifacts` script from package.json if defined.
+1. **Deprecated:** Run the `eas-build-pre-upload-artifacts` script from **package.json** if defined.
 1. Store a cache of files and directories defined in the build profile. Subsequent builds will restore this cache. ([Learn more](../build/eas-json/).)
 1. Upload the build artifact to AWS S3.
 
    - The artifact path can be configured in **eas.json** at `builds.android.PROFILE_NAME.artifactPath`. It defaults to `android/app/build/outputs/**/*.{apk,aab}`. We're using the [fast-glob](https://github.com/mrmlnc/fast-glob#pattern-syntax) package for pattern matching.
 
-1. If the build was successful: run the `eas-build-on-success` script from package.json if defined.
-1. If the build failed: run the `eas-build-on-error` script from package.json if defined.
-1. Run the `eas-build-on-complete` script from package.json if defined. The `EAS_BUILD_STATUS` env variable is set to either `finished` or `errored`.
+1. If the build was successful: run the `eas-build-on-success` script from **package.json** if defined.
+1. If the build failed: run the `eas-build-on-error` script from **package.json** if defined.
+1. Run the `eas-build-on-complete` script from **package.json** if defined. The `EAS_BUILD_STATUS` env variable is set to either `finished` or `errored`.
 
 ## Project Auto-Configuration
 

--- a/docs/pages/build-reference/how-tos.md
+++ b/docs/pages/build-reference/how-tos.md
@@ -6,49 +6,6 @@ import ImageSpotlight from '~/components/plugins/ImageSpotlight'
 
 This document outlines how to configure EAS Build for some common scenarios, such as monorepos and repositories with private dependencies. The examples described here do not provide step-by-step instructions to set up EAS Build from scratch. Instead, they explain the changes from the standard process that are necessary to accommodate the given scenario.
 
-## EAS Build-specific npm hooks
-
-There are three EAS Build-specific npm hooks that you can set in your package.json. See the [Android build process](android-builds.md) and [iOS build process](ios-builds.md) docs to get a better understanding about the internals of the build process.
-
-- `eas-build-pre-install` - executed before EAS Build runs `yarn install`.
-- `eas-build-post-install` - the behavior depends on the platform and project type:
-  - Android
-    - managed projects - runs after `yarn install` and `expo prebuild`.
-    - bare projects - runs after `yarn install`.
-  - iOS - runs after `yarn install` and `pod install`.
-- `eas-build-on-success` - this hook is triggered at the end of the build process if the build was successful.
-- `eas-build-on-error` - this hook is triggered at the end of the build process if the build failed.
-- `eas-build-on-complete` - this hook is triggered at the end of the build process. You can check the build's status with the `EAS_BUILD_STATUS` environment variable. It's either `finished` or `errored`.
-
-This is an example of how your package.json might look like:
-
-```json
-{
-  "main": "index.js",
-  "scripts": {
-    "eas-build-pre-install": "echo 123",
-    "eas-build-post-install": "echo 456",
-    "eas-build-pre-upload-artifacts": "echo 789",
-    "android": "expo run:android",
-    "ios": "expo run:ios",
-    "web": "expo start --web",
-    "start": "react-native start",
-    "test": "jest"
-  },
-  "dependencies": {
-    "expo": "~40.0.0"
-    // ...
-  },
-  "devDependencies": {
-    // ...
-  },
-  "jest": {
-    "preset": "react-native"
-  },
-  "private": true
-}
-```
-
 ## How to set up EAS Build with a monorepo
 
 - Run all EAS CLI commands from the root of the app directory. For example: if your project exists inside of your git repository at `apps/my-app`, then run `eas build` from there.
@@ -76,7 +33,7 @@ By default the EAS npm cache won't work with yarn v1, because `yarn.lock` files 
 
 ```json
 {
- "scripts": {
+  "scripts": {
     "eas-build-pre-install": "bash -c \"[ ! -z \\\"$EAS_BUILD_NPM_CACHE_URL\\\" ] && sed -i -e \\\"s#https://registry.yarnpkg.com#$EAS_BUILD_NPM_CACHE_URL#g\\\" yarn.lock\" || true"
   }
 }

--- a/docs/pages/build-reference/infrastructure.md
+++ b/docs/pages/build-reference/infrastructure.md
@@ -13,7 +13,7 @@ Here is the [up-to-date list of worker IP addresses](https://expo.dev/eas-build-
 
 ## Configuring build environment
 
-Images for each platform have one specific version of Node, yarn, CocoaPods, Xcode, Ruby, Fastlane, and so on. You can override some of the versions in [eas.json](../build/eas-json). If there's no dedicated configuration option you're looking for, you can use [npm hooks](how-tos/#eas-build-specific-npm-hooks) to install or update any system dependencies with `apt-get` or `brew`. Please take into account that those customizations are applied during the build and will increase your build times.
+Images for each platform have one specific version of Node, yarn, CocoaPods, Xcode, Ruby, Fastlane, and so on. You can override some of the versions in [eas.json](../build/eas-json). If there's no dedicated configuration option you're looking for, you can use [npm hooks](npm-hooks) to install or update any system dependencies with `apt-get` or `brew`. Please take into account that those customizations are applied during the build and will increase your build times.
 
 When selecting an image for the build you can use the full name provided below or one of the aliases: `default`, `latest`.
 
@@ -51,8 +51,8 @@ When selecting an image for the build you can use the full name provided below o
 
   ```yml
   unsafeHttpWhitelist:
-    - "*"
-  npmRegistryServer: "http://npm-cache-service.worker-infra-production.svc.cluster.local:4873"
+    - '*'
+  npmRegistryServer: 'http://npm-cache-service.worker-infra-production.svc.cluster.local:4873'
   enableImmutableInstalls: false
   ```
 
@@ -157,8 +157,8 @@ When selecting an image for the build you can use the full name provided below o
 
   ```yml
   unsafeHttpWhitelist:
-    - "*"
-  npmRegistryServer: "registry=http://10.254.24.8:4873"
+    - '*'
+  npmRegistryServer: 'registry=http://10.254.24.8:4873'
   enableImmutableInstalls: false
   ```
 

--- a/docs/pages/build-reference/infrastructure.md
+++ b/docs/pages/build-reference/infrastructure.md
@@ -13,7 +13,7 @@ Here is the [up-to-date list of worker IP addresses](https://expo.dev/eas-build-
 
 ## Configuring build environment
 
-Images for each platform have one specific version of Node, yarn, CocoaPods, Xcode, Ruby, Fastlane, and so on. You can override some of the versions in [eas.json](../build/eas-json). If there's no dedicated configuration option you're looking for, you can use [npm hooks](npm-hooks) to install or update any system dependencies with `apt-get` or `brew`. Please take into account that those customizations are applied during the build and will increase your build times.
+Images for each platform have one specific version of Node.js, yarn, CocoaPods, Xcode, Ruby, Fastlane, and so on. You can override some of the versions in [eas.json](../build/eas-json). If there is no dedicated configuration option you're looking for, you can use [npm hooks](npm-hooks) to install or update any system dependencies with `apt-get` or `brew`. Please take into account that those customizations are applied during the build and will increase your build times.
 
 When selecting an image for the build you can use the full name provided below or one of the aliases: `default`, `latest`.
 

--- a/docs/pages/build-reference/ios-builds.md
+++ b/docs/pages/build-reference/ios-builds.md
@@ -31,7 +31,7 @@ In this next phase, this is what happens when EAS Build picks up your request:
 
 1. Download the project tarball from a private AWS S3 bucket and unpack it.
 1. Create `.npmrc` if `NPM_TOKEN` is set. ([Learn more](/build-reference/private-npm-packages).)
-1. Run the `eas-build-pre-install` script from package.json if defined.
+1. Run the `eas-build-pre-install` script from **package.json** if defined.
 1. Run `npm install` in the project root (or `yarn install` if `yarn.lock` exists).
 1. Run `expo doctor` to diagnose potential issues with your project configuration.
 1. Restore the credentials
@@ -44,19 +44,19 @@ In this next phase, this is what happens when EAS Build picks up your request:
 1. Additional step for **managed** projects: Run `expo prebuild` to convert the project to a bare one. This step will use the versioned Expo CLI for projects that use Expo SDK 46+. You can still choose to use the (deprecated) global Expo CLI installation by setting `EXPO_USE_LOCAL_CLI=0` in the build profile.
 1. Restore a previously saved cache identified by the `cache.key` value in the build profile. ([Learn more](../build/eas-json/).)
 1. Run `pod install` in the **ios** directory inside your project.
-1. Run the `eas-build-post-install` script from package.json if defined.
+1. Run the `eas-build-post-install` script from **package.json** if defined.
 1. Update the Xcode project with the ID of the Provisioning Profile.
 1. Create **Gymfile** in the **ios** directory if it does **not** already exist (check out the [Default Gymfile](#default-gymfile) section).
 1. Run `fastlane gym` in the **ios** directory.
-1. **Deprecated:** Run the `eas-build-pre-upload-artifacts` script from package.json if defined.
+1. **Deprecated:** Run the `eas-build-pre-upload-artifacts` script from **package.json** if defined.
 1. Store a cache of files and directories defined in the build profile. `Podfile.lock` is cached by default. Subsequent builds will restore this cache. ([Learn more](../build/eas-json/).)
 1. Upload the build artifact to a private AWS S3 bucket.
 
    - The artifact path can be configured in **eas.json** at `builds.ios.PROFILE_NAME.artifactPath`. It defaults to **ios/build/App.ipa**. You can specify a glob-like pattern for `artifactPath`. We're using the [fast-glob](https://github.com/mrmlnc/fast-glob#pattern-syntax) package under the hood.
 
-1. If the build was successful: run the `eas-build-on-success` script from package.json if defined.
-1. If the build failed: run the `eas-build-on-error` script from package.json if defined.
-1. Run the `eas-build-on-complete` script from package.json if defined. The `EAS_BUILD_STATUS` env variable is set to either `finished` or `errored`.
+1. If the build was successful: run the `eas-build-on-success` script from **package.json** if defined.
+1. If the build failed: run the `eas-build-on-error` script from **package.json** if defined.
+1. Run the `eas-build-on-complete` script from **package.json** if defined. The `EAS_BUILD_STATUS` env variable is set to either `finished` or `errored`.
 
 ## Building iOS Projects With Fastlane
 

--- a/docs/pages/build-reference/ios-builds.md
+++ b/docs/pages/build-reference/ios-builds.md
@@ -48,11 +48,15 @@ In this next phase, this is what happens when EAS Build picks up your request:
 1. Update the Xcode project with the ID of the Provisioning Profile.
 1. Create **Gymfile** in the **ios** directory if it does **not** already exist (check out the [Default Gymfile](#default-gymfile) section).
 1. Run `fastlane gym` in the **ios** directory.
-1. Run the `eas-build-pre-upload-artifacts` script from package.json if defined.
+1. **Deprecated:** Run the `eas-build-pre-upload-artifacts` script from package.json if defined.
 1. Store a cache of files and directories defined in the build profile. `Podfile.lock` is cached by default. Subsequent builds will restore this cache. ([Learn more](../build/eas-json/).)
 1. Upload the build artifact to a private AWS S3 bucket.
 
    - The artifact path can be configured in **eas.json** at `builds.ios.PROFILE_NAME.artifactPath`. It defaults to **ios/build/App.ipa**. You can specify a glob-like pattern for `artifactPath`. We're using the [fast-glob](https://github.com/mrmlnc/fast-glob#pattern-syntax) package under the hood.
+
+1. If the build was successful: run the `eas-build-on-success` script from package.json if defined.
+1. If the build failed: run the `eas-build-on-error` script from package.json if defined.
+1. Run the `eas-build-on-complete` script from package.json if defined. The `EAS_BUILD_STATUS` env variable is set to either `finished` or `errored`.
 
 ## Building iOS Projects With Fastlane
 

--- a/docs/pages/build-reference/npm-hooks.md
+++ b/docs/pages/build-reference/npm-hooks.md
@@ -2,7 +2,7 @@
 title: EAS Build hooks
 ---
 
-There are five EAS Build-specific npm hooks that you can set in your package.json. See the [Android build process](android-builds.md) and [iOS build process](ios-builds.md) docs to get a better understanding about the internals of the build process.
+There are five EAS Build-specific npm hooks that you can set in your **package.json**. See the [Android build process](android-builds.md) and [iOS build process](ios-builds.md) docs to get a better understanding about the internals of the build process.
 
 - `eas-build-pre-install` - executed before EAS Build runs `yarn install`.
 - `eas-build-post-install` - the behavior depends on the platform and project type:
@@ -14,7 +14,7 @@ There are five EAS Build-specific npm hooks that you can set in your package.jso
 - `eas-build-on-error` - this hook is triggered at the end of the build process if the build failed.
 - `eas-build-on-complete` - this hook is triggered at the end of the build process. You can check the build's status with the `EAS_BUILD_STATUS` environment variable. It's either `finished` or `errored`.
 
-This is an example of how your package.json might look like:
+This is an example of how your **package.json** might look like:
 
 ```json
 {

--- a/docs/pages/build-reference/npm-hooks.md
+++ b/docs/pages/build-reference/npm-hooks.md
@@ -1,0 +1,45 @@
+---
+title: EAS Build hooks
+---
+
+There are five EAS Build-specific npm hooks that you can set in your package.json. See the [Android build process](android-builds.md) and [iOS build process](ios-builds.md) docs to get a better understanding about the internals of the build process.
+
+- `eas-build-pre-install` - executed before EAS Build runs `yarn install`.
+- `eas-build-post-install` - the behavior depends on the platform and project type:
+  - Android
+    - managed projects - runs after `yarn install` and `expo prebuild`.
+    - bare projects - runs after `yarn install`.
+  - iOS - runs after `yarn install` and `pod install`.
+- `eas-build-on-success` - this hook is triggered at the end of the build process if the build was successful.
+- `eas-build-on-error` - this hook is triggered at the end of the build process if the build failed.
+- `eas-build-on-complete` - this hook is triggered at the end of the build process. You can check the build's status with the `EAS_BUILD_STATUS` environment variable. It's either `finished` or `errored`.
+
+This is an example of how your package.json might look like:
+
+```json
+{
+  "main": "index.js",
+  "scripts": {
+    "eas-build-pre-install": "echo 123",
+    "eas-build-post-install": "echo 456",
+    "eas-build-on-success": "echo 789",
+    "eas-build-on-error": "echo 012",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
+    "web": "expo start --web",
+    "start": "react-native start",
+    "test": "jest"
+  },
+  "dependencies": {
+    "expo": "~40.0.0"
+    // ...
+  },
+  "devDependencies": {
+    // ...
+  },
+  "jest": {
+    "preset": "react-native"
+  },
+  "private": true
+}
+```


### PR DESCRIPTION
https://linear.app/expo/issue/ENG-5117/move-eas-build-specific-npm-hooks-to-its-own-page

Moves the EAS Build npm hooks section to separate page.