### PR TITLE
[jest-preset]: Update `transform` key

### DIFF
--- a/packages/jest-expo/CHANGELOG.md
+++ b/packages/jest-expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Update `transform` in `jest-preset` to support transforming other file extensions such as .jsx, .tsx, etc. ([#18476](https://github.com/expo/expo/pull/18476) by [@@amandeepmittal](https://github.com/@amandeepmittal))
+
 ### 💡 Others
 
 ## 46.0.1 — 2022-07-11

--- a/packages/jest-expo/jest-preset.js
+++ b/packages/jest-expo/jest-preset.js
@@ -7,7 +7,9 @@ const jestPreset = cloneDeep(require('react-native/jest-preset'));
 
 // transform
 if (!jestPreset.transform) {
-  jestPreset.transform = {};
+  jestPreset.transform = {
+    '\\.[jt]sx?$': 'babel-jest',
+  };
 }
 
 const defaultAssetNamePattern = '^.+\\.(bmp|gif|jpg|jpeg|mp4|png|psd|svg|webp)$';


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Ths PR updates `transform` key in `jest-preset` package to support files and their syntax (which is ideally not supported by Node out of the box) such as JSX abd TypeScript.  

Currently, the `transform` is [set to an empty object](https://github.com/expo/expo/blob/master/packages/jest-expo/jest-preset.js?rgh-link-date=2022-07-29T14%3A27%3A08Z#L10) in the package. 

Also Refs to:
- #18329
- ENG-5876

# How

<!--
How did you build this feature or fix this bug and why?
-->

Jest [documentation recommends](https://jestjs.io/docs/configuration#transform-objectstring-pathtotransformer--pathtotransformer-object) using RegExp `"\\.[jt]sx?$": "babel-jest",` to allow transforming any .js, .jsx, .ts or .tsx file. Populating the `transform` key by default will resolve the issue.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Testing locally in an Expo project, when, the `transform` key is not populated by the aforementioned RegExp, importing  a file with an extension, for example, `.jsx` will give a syntax error running tests with Jest. 

An example screenshot of the error. where the `TextComponent` is defined inside a file using `.jsx` extension:

![111](https://user-images.githubusercontent.com/10234615/182624678-da191a57-7b1c-41f7-a781-c37d87bb97aa.jpeg)

 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
