### PR TITLE
[docs] fixes `expo-camera` plugin configuration

### DIFF
--- a/docs/pages/guides/config-plugins.md
+++ b/docs/pages/guides/config-plugins.md
@@ -53,7 +53,7 @@ Some plugins can be customized by passing an array, where the second argument is
       {
         /* Values passed to the plugin */
         "cameraPermission": "Allow $(PRODUCT_NAME) to access your camera",
-        "microphonePermission": "Allow $(PRODUCT_NAME) to access your microphone",
+        "microphonePermission": "Allow $(PRODUCT_NAME) to access your microphone"
       }
     ]
   ]

--- a/docs/pages/guides/config-plugins.md
+++ b/docs/pages/guides/config-plugins.md
@@ -52,7 +52,8 @@ Some plugins can be customized by passing an array, where the second argument is
       "expo-camera",
       {
         /* Values passed to the plugin */
-        "locationWhenInUsePermission": "Allow $(PRODUCT_NAME) to access your location"
+        "cameraPermission": "Allow $(PRODUCT_NAME) to access your camera",
+        "microphonePermission": "Allow $(PRODUCT_NAME) to access your microphone",
       }
     ]
   ]


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The attribute configured in the example was from the `expo-location` plugin, but it was passed to the `expo-camera` configuration.

By the way, I had difficulties finding the name of the correct permissions to pass to the plugin configuration (`cameraPermission` and `microphonePermission`). Could you update the documentation to make this easier to find? Thanks

# How

<!--
How did you build this feature or fix this bug and why?
-->

I updated the text in the docs.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Not needed because no code changes.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [✅] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [✅] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [✅] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
