### PR TITLE
[docs] switch to new Algolia infra

### DIFF
--- a/docs/components/plugins/AlgoliaSearch.tsx
+++ b/docs/components/plugins/AlgoliaSearch.tsx
@@ -142,7 +142,8 @@ class AlgoliaSearchWithApiVersion extends React.Component<Props> {
     const currentVersion = this.props.version === 'latest' ? LATEST_VERSION : this.props.version;
 
     this.docsearch = docsearch({
-      apiKey: '2955d7b41a0accbe5b6aa2db32f3b8ac',
+      appId: 'QEX7PB7D46',
+      apiKey: '89231e630c63f383765538848f9a0e9e',
       indexName: 'expo',
       inputSelector: this.props.hiddenOnMobile
         ? '#algolia-search-box'


### PR DESCRIPTION
# Why

After the latest SDK release the search result do not return API Reference matches. This is a result of using legacy Algolia infra.

# How

Let's switch to the new Algolia infra to fix the issue.

# Test Plan

I have tested the search results by running website locally and everything seems to be fine. 

## Preview

<img width="523" alt="Screenshot 2022-08-04 at 14 29 13" src="https://user-images.githubusercontent.com/719641/182847195-a5142969-b844-4087-b0fa-0f5cba23a43c.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
