### PR TITLE
[docs][ui-component-libraries]: Fixes typo, and links

### DIFF
--- a/docs/pages/guides/userinterface.md
+++ b/docs/pages/guides/userinterface.md
@@ -12,6 +12,6 @@ Below (in no particular order) are some of the most popular UI Libraries. Test t
 - [NativeBase](https://nativebase.io/), and their [docs](https://docs.nativebase.io/)
 - [React Native UI Kitten](https://github.com/akveo/react-native-ui-kitten), and their [docs](https://akveo.github.io/react-native-ui-kitten/docs/getting-started/what-is-ui-kitten#what-is-ui-kitten)
 - [React Native iOS Kit](https://github.com/callstack/react-native-ios-kit), and their [docs](https://callstack.github.io/react-native-ios-kit/docs/installation)
-- [Fluent UI](https://developer.microsoft.com/en-us/fluentui#/), and their [docs](https://developer.microsoft.com/en-us/fluentui#/get-started)
+- [Fluent UI](https://github.com/microsoft/fluentui-react-native), and their [docs](https://developer.microsoft.com/en-us/fluentui#/get-started)
 
 > **Note:** As with any library, it's always best to find one with a large and active community. This way, help is easy to come by. Check out any project's GitHub page to see what the activity is like.

--- a/docs/pages/guides/userinterface.md
+++ b/docs/pages/guides/userinterface.md
@@ -2,16 +2,15 @@
 title: User Interface Component Libraries
 ---
 
-The User Interface (UI) is a huge part of any app. If the icon is your front door, the UI is the interior design. You can definitely take the route of completely designing your own UI from scratch, but if you want to get it up and running fast while still having a polished finish, there are plenty of libraries already in place to help get your app where you want it.
+The User Interface (UI) is a huge part of any app. If the icon is your front door, the UI is the interior design. You can definitely take the route of completely designing your own UI from scratch, however, if you want to get it up and running fast while still having a polished finish, there are plenty of libraries already in place to help get your app where you want it.
 
 Below (in no particular order) are some of the most popular UI Libraries. Test them all out and see what you like!
 
 - [React Native Paper](https://github.com/callstack/react-native-paper), and their [docs](https://callstack.github.io/react-native-paper/index.html)
 - [React Native UI Lib](https://github.com/wix/react-native-ui-lib), and their [docs](https://wix.github.io/react-native-ui-lib/)
 - [React Native Elements](https://reactnativeelements.com/), and their [docs](https://reactnativeelements.com/docs)
-- [Native Base](https://nativebase.io/), and their [docs](https://docs.nativebase.io/)
-- [React Native Material UI](https://github.com/xotahal/react-native-material-ui), and their [docs](https://github.com/xotahal/react-native-material-ui/blob/master/docs/GettingStarted.md)
-- [React Native UI Kitten](https://akveo.github.io/react-native-ui-kitten/#/home), and their [docs](https://akveo.github.io/react-native-ui-kitten/#/docs/quick-start/getting-started)
-- [React Native iOS Kit](https://github.com/callstack/react-native-ios-kit), and their [docs](https://callstack.github.io/react-native-ios-kit/docs/installation.html)
+- [NativeBase](https://nativebase.io/), and their [docs](https://docs.nativebase.io/)
+- [React Native UI Kitten](https://github.com/akveo/react-native-ui-kitten), and their [docs](https://akveo.github.io/react-native-ui-kitten/docs/getting-started/what-is-ui-kitten#what-is-ui-kitten)
+- [React Native iOS Kit](https://github.com/callstack/react-native-ios-kit), and their [docs](https://callstack.github.io/react-native-ios-kit/docs/installation)
 
 > **Note:** As with any library, it's always best to find one with a large and active community. This way, help is easy to come by. Check out any project's GitHub page to see what the activity is like.

--- a/docs/pages/guides/userinterface.md
+++ b/docs/pages/guides/userinterface.md
@@ -12,5 +12,6 @@ Below (in no particular order) are some of the most popular UI Libraries. Test t
 - [NativeBase](https://nativebase.io/), and their [docs](https://docs.nativebase.io/)
 - [React Native UI Kitten](https://github.com/akveo/react-native-ui-kitten), and their [docs](https://akveo.github.io/react-native-ui-kitten/docs/getting-started/what-is-ui-kitten#what-is-ui-kitten)
 - [React Native iOS Kit](https://github.com/callstack/react-native-ios-kit), and their [docs](https://callstack.github.io/react-native-ios-kit/docs/installation)
+- [Fluent UI](https://developer.microsoft.com/en-us/fluentui#/), and their [docs](https://developer.microsoft.com/en-us/fluentui#/get-started)
 
 > **Note:** As with any library, it's always best to find one with a large and active community. This way, help is easy to come by. Check out any project's GitHub page to see what the activity is like.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Some of the links were not pointing to towards the correct documentation. Also, there was a branding typo `Native Base` which is now converted to `NativeBase`. This PR, also removes [React Native Material UI](https://github.com/xotahal/react-native-material-ui) library reference since it has been maintained in last few years.


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

Changes have been tested by running the docs locally.

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
