### PR TITLE
Update documentation to add a condition for staging when switching based on channel

### DIFF
--- a/docs/pages/build-reference/variables.md
+++ b/docs/pages/build-reference/variables.md
@@ -181,7 +181,7 @@ The following are two possible alternative approaches, each with different trade
     if (Updates.channel === 'production') {
       Config.apiUrl = 'https://api.production.com';
       Config.enableHiddenFeatures = false;
-    } else {
+    } else if (Updates.channel === 'staging') {
       Config.apiUrl = 'https://api.staging.com';
       Config.enableHiddenFeatures = true;
     }


### PR DESCRIPTION
This updates the documentation to add a condition for staging when switching based on channel. Otherwise the staging config will be returned in dev mode

# Why
This is to make to documentation for switching variables based on channel clearer.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
