### PR TITLE
[docs]README: Update sidebarTitle reference

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -57,7 +57,7 @@ These metadata items include:
 - `hideFromSearch`: Whether to hide the page from Algolia search results. Defaults to `false`.
 - `hideInSidebar`: Whether to hide this page from the sidebar. Defaults to `false`.
 - `hideTOC`: Whether to hide the table of contents (appears on the right sidebar). Defaults to `false`.
-- `sidebarTitle`: The title of the page to display in the sidebar. Defaults to the page title.
+- `sidebar_title`: The title of the page to display in the sidebar. Defaults to the page title.
 
 ### Editing Code
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The `sidebarTitle` frontmatter reference doesn't seem to work accurately when changing the sidebar title of an individual docs page. After discussing with Simek and testing, the frontmatter field with `sidebar_title` seems to work.

This PR changes the reference from `sidebarTitle` to `sidebar_title` in the `docs/README.md` file.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
