### PR TITLE
[dev-client] support landscape orientation

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add landscape orienation support. ([#18509](https://github.com/expo/expo/pull/18509)) by [@ajsmth](https://github.com/ajsmth)
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -565,9 +565,6 @@
     
     [self _ensureUserInterfaceStyleIsInSyncWithTraitEnv:self.window.rootViewController];
 
-    [[UIDevice currentDevice] setValue:@(orientation) forKey:@"orientation"];
-    [UIViewController attemptRotationToDeviceOrientation];
-    
     if (backgroundColor) {
       self.window.rootViewController.view.backgroundColor = backgroundColor;
       self.window.backgroundColor = backgroundColor;

--- a/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestHelper.swift
+++ b/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestHelper.swift
@@ -28,7 +28,7 @@ public class EXDevLauncherManifestHelper: NSObject {
     } else if orientation == "landscape" {
       orientationMask = .landscape
     }
-    
+
     return defaultOrientationForOrientationMask(orientationMask)
   }
 

--- a/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestHelper.swift
+++ b/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestHelper.swift
@@ -5,7 +5,9 @@ import UIKit
 @objc
 public class EXDevLauncherManifestHelper: NSObject {
   private static func defaultOrientationForOrientationMask(_ orientationMask: UIInterfaceOrientationMask) -> UIInterfaceOrientation {
-    if orientationMask.contains(.portrait) {
+    if orientationMask.contains(.all) {
+      return UIInterfaceOrientation.unknown
+    } else  if orientationMask.contains(.portrait) {
       return UIInterfaceOrientation.portrait
     } else if orientationMask.contains(.landscapeLeft) {
       return UIInterfaceOrientation.landscapeLeft
@@ -25,6 +27,8 @@ public class EXDevLauncherManifestHelper: NSObject {
       orientationMask = .portrait
     } else if orientation == "landscape" {
       orientationMask = .landscape
+    } else if orientation == "default" {
+      orientationMask = .all
     }
 
     return defaultOrientationForOrientationMask(orientationMask)

--- a/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestHelper.swift
+++ b/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestHelper.swift
@@ -27,10 +27,8 @@ public class EXDevLauncherManifestHelper: NSObject {
       orientationMask = .portrait
     } else if orientation == "landscape" {
       orientationMask = .landscape
-    } else if orientation == "default" {
-      orientationMask = .all
     }
-
+    
     return defaultOrientationForOrientationMask(orientationMask)
   }
 

--- a/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
+++ b/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
@@ -79,7 +79,7 @@ public class ExpoDevLauncherReactDelegateHandler: ExpoReactDelegateHandler, RCTB
     let rootView = RCTRootView(bridge: bridge!, moduleName: self.rootViewModuleName!, initialProperties: self.rootViewInitialProperties)
     rootView.backgroundColor = self.deferredRootView?.backgroundColor ?? UIColor.white
     let window = getWindow()
-  
+
     // NOTE: this order of assignment seems to actually have an effect on behaviour
     // direct assignment of window.rootViewController.view = rootView does not work
     let rootViewController = self.reactDelegate?.createRootViewController()

--- a/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
+++ b/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
@@ -79,8 +79,12 @@ public class ExpoDevLauncherReactDelegateHandler: ExpoReactDelegateHandler, RCTB
     let rootView = RCTRootView(bridge: bridge!, moduleName: self.rootViewModuleName!, initialProperties: self.rootViewInitialProperties)
     rootView.backgroundColor = self.deferredRootView?.backgroundColor ?? UIColor.white
     let window = getWindow()
-    window.rootViewController = self.reactDelegate?.createRootViewController()
-    window.rootViewController!.view = rootView
+  
+    // NOTE: this order of assignment seems to actually have an effect on behaviour
+    // direct assignment of window.rootViewController.view = rootView does not work
+    let rootViewController = self.reactDelegate?.createRootViewController()
+    rootViewController!.view = rootView
+    window.rootViewController = rootViewController
     window.makeKeyAndVisible()
 
     // it is purposeful that we don't clean up saved properties here, because we may initialize

--- a/packages/expo-dev-launcher/ios/Tests/EXDevLauncherManifestHelperTests.swift
+++ b/packages/expo-dev-launcher/ios/Tests/EXDevLauncherManifestHelperTests.swift
@@ -8,8 +8,8 @@ class EXDevLauncherManifestHelperTests: XCTestCase {
   func testExportManifestOrientation() {
     XCTAssertEqual(UIInterfaceOrientation.portrait, EXDevLauncherManifestHelper.exportManifestOrientation("portrait"))
     XCTAssertEqual(UIInterfaceOrientation.landscapeLeft, EXDevLauncherManifestHelper.exportManifestOrientation("landscape"))
-    XCTAssertEqual(UIInterfaceOrientation.portrait, EXDevLauncherManifestHelper.exportManifestOrientation("default"))
-    XCTAssertEqual(UIInterfaceOrientation.portrait, EXDevLauncherManifestHelper.exportManifestOrientation("unsupported-value"))
+    XCTAssertEqual(UIInterfaceOrientation.unknown, EXDevLauncherManifestHelper.exportManifestOrientation("default"))
+    XCTAssertEqual(UIInterfaceOrientation.unknown, EXDevLauncherManifestHelper.exportManifestOrientation("unsupported-value"))
   }
 
   func testExportManifestUserInterfaceStyle() {

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add landscape orienation support. ([#18509](https://github.com/expo/expo/pull/18509)) by [@ajsmth](https://github.com/ajsmth)
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuHost.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuHost.kt
@@ -51,7 +51,7 @@ class DevMenuHost(application: Application) : ReactNativeHost(application) {
     return packages
   }
 
-  override fun getUseDeveloperSupport() = false // change it and run `yarn start` in `expo-dev-menu` to launch dev menu from local packager
+  override fun getUseDeveloperSupport() = true // change it and run `yarn start` in `expo-dev-menu` to launch dev menu from local packager
 
   override fun getBundleAssetName() = "EXDevMenuApp.android.js"
 

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuHost.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuHost.kt
@@ -51,7 +51,7 @@ class DevMenuHost(application: Application) : ReactNativeHost(application) {
     return packages
   }
 
-  override fun getUseDeveloperSupport() = true // change it and run `yarn start` in `expo-dev-menu` to launch dev menu from local packager
+  override fun getUseDeveloperSupport() = false // change it and run `yarn start` in `expo-dev-menu` to launch dev menu from local packager
 
   override fun getBundleAssetName() = "EXDevMenuApp.android.js"
 

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuActivity.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuActivity.kt
@@ -80,18 +80,6 @@ class DevMenuActivity : ReactActivity() {
     }
   }
 
-  override fun onCreate(savedInstanceState: Bundle?) {
-    // Due to a bug in API 26, we can't set the orientation in translucent activity.
-    // See https://stackoverflow.com/questions/48072438/java-lang-illegalstateexception-only-fullscreen-opaque-activities-can-request-o
-    requestedOrientation = if (Build.VERSION.SDK_INT == Build.VERSION_CODES.O) {
-      ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
-    } else {
-      ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-    }
-
-    super.onCreate(savedInstanceState)
-  }
-
   override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {
     return if (keyCode == KeyEvent.KEYCODE_MENU || DevMenuManager.onKeyEvent(keyCode, event)) {
       DevMenuManager.closeMenu()

--- a/packages/expo-dev-menu/app/components/BottomSheet.tsx
+++ b/packages/expo-dev-menu/app/components/BottomSheet.tsx
@@ -568,7 +568,6 @@ export class BottomSheet extends React.Component<Props, State> {
           s.__initialized && s.setValue(sortedPropsSnapPoints[0].val - sortedPropsSnapPoints[i].val)
       );
       snapPoints = state.snapPoints;
-      console.log({ sortedPropsSnapPoints });
     } else {
       snapPoints = sortedPropsSnapPoints.map(
         (p) => new Value(sortedPropsSnapPoints[0].val - p.val)

--- a/packages/expo-dev-menu/app/components/BottomSheet.tsx
+++ b/packages/expo-dev-menu/app/components/BottomSheet.tsx
@@ -67,6 +67,8 @@ type Props = {
   innerGestureHandlerRefs: [React.RefObject<PanGestureHandler>, React.RefObject<TapGestureHandler>];
 
   animationEnabled?: boolean;
+
+  screenHeight: number;
 };
 
 type State = {
@@ -76,8 +78,6 @@ type State = {
   propsToNewIndices: { [key: string]: number };
   heightOfContent: Animated.Value<number>;
 };
-
-const { height: screenHeight } = Dimensions.get('window');
 
 const P = <T extends any>(android: T, ios: T): T => (Platform.OS === 'ios' ? ios : android);
 
@@ -532,7 +532,10 @@ export class BottomSheet extends React.Component<Props, State> {
     this.state.heightOfContent.setValue(height - this.state.initSnap);
   };
 
-  static renumber = (str: string) => (Number(str.split('%')[0]) * screenHeight) / 100;
+  static renumber = (str: string, screenHeight: number) => {
+    const result = (Number(str.split('%')[0]) * screenHeight) / 100;
+    return result;
+  };
 
   static getDerivedStateFromProps(props: Props, state: State | undefined): State {
     let snapPoints;
@@ -551,7 +554,7 @@ export class BottomSheet extends React.Component<Props, State> {
           if (typeof s === 'number') {
             return { val: s, ind: i };
           } else if (typeof s === 'string') {
-            return { val: BottomSheet.renumber(s), ind: i };
+            return { val: BottomSheet.renumber(s, props.screenHeight), ind: i };
           }
 
           throw new Error(`Invalid type for value ${s}: ${typeof s}`);
@@ -565,6 +568,7 @@ export class BottomSheet extends React.Component<Props, State> {
           s.__initialized && s.setValue(sortedPropsSnapPoints[0].val - sortedPropsSnapPoints[i].val)
       );
       snapPoints = state.snapPoints;
+      console.log({ sortedPropsSnapPoints });
     } else {
       snapPoints = sortedPropsSnapPoints.map(
         (p) => new Value(sortedPropsSnapPoints[0].val - p.val)
@@ -690,8 +694,10 @@ const styles = StyleSheet.create({
   },
   container: {
     overflow: 'hidden',
-    borderTopLeftRadius: 10,
-    borderTopRightRadius: 10,
+    borderRadius: 10,
+    maxWidth: 525,
+    width: '100%',
+    alignSelf: 'center',
   },
   fullscreenView: {
     width: '100%',

--- a/packages/expo-dev-menu/app/components/Main.tsx
+++ b/packages/expo-dev-menu/app/components/Main.tsx
@@ -351,6 +351,7 @@ export function Main({ registeredCallbacks = [] }: MainProps) {
           </Row>
         </Button.ScaleOnPressContainer>
       </View>
+      <Spacer.Vertical size="large" />
     </View>
   );
 }

--- a/packages/expo-dev-menu/app/hooks/useBottomSheet.tsx
+++ b/packages/expo-dev-menu/app/hooks/useBottomSheet.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, StyleSheet, Pressable } from 'react-native';
+import { View, StyleSheet, Pressable, useWindowDimensions } from 'react-native';
 import Animated from 'react-native-reanimated';
 
 import { BottomSheet } from '../components/BottomSheet';
@@ -55,6 +55,8 @@ export function BottomSheetProvider({ children }: BottomSheetProviderProps) {
     outputRange: [0, 0.5],
   });
 
+  const { height: screenHeight } = useWindowDimensions();
+
   return (
     <BottomSheetContext.Provider value={{ collapse }}>
       <View style={styles.container}>
@@ -69,6 +71,7 @@ export function BottomSheetProvider({ children }: BottomSheetProviderProps) {
           />
         </Pressable>
         <BottomSheet
+          screenHeight={screenHeight}
           ref={bottomSheetRef}
           callbackNode={callbackNode.current}
           snapPoints={snapPoints}>

--- a/packages/expo-dev-menu/ios/DevMenuViewController.swift
+++ b/packages/expo-dev-menu/ios/DevMenuViewController.swift
@@ -43,22 +43,10 @@ class DevMenuViewController: UIViewController {
     forceRootViewToRenderHack()
     reactRootView?.becomeFirstResponder()
   }
-
-  override var shouldAutorotate: Bool {
-    get {
-      return true
-    }
-  }
-
+  
   override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
     get {
-      return UIInterfaceOrientationMask.portrait
-    }
-  }
-
-  override var preferredInterfaceOrientationForPresentation: UIInterfaceOrientation {
-    get {
-      return UIInterfaceOrientation.portrait
+      return UIInterfaceOrientationMask.all
     }
   }
 

--- a/packages/expo-dev-menu/ios/DevMenuViewController.swift
+++ b/packages/expo-dev-menu/ios/DevMenuViewController.swift
@@ -43,7 +43,7 @@ class DevMenuViewController: UIViewController {
     forceRootViewToRenderHack()
     reactRootView?.becomeFirstResponder()
   }
-  
+
   override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
     get {
       return UIInterfaceOrientationMask.all


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Closes ENG-1804 

this took a bit longer than anticipated as I ran into some orientation related bugs: 


https://user-images.githubusercontent.com/40680668/182954479-b130f8f4-7f05-4fe5-9738-0e879a3041cc.mp4


# How

<!--
How did you build this feature or fix this bug and why?
-->

Removed the restriction for portrait orientation on the native view controllers in the dev menu, then updated the styles of the dev menu to look decent in landscape. I had to adjust some of the calculations done by the bottom sheet to get the right snap point values, but I think it works fairly well 

The big issue was related to the video posted above (on iOS only) - this was solved by "properly" setting the root view controllers' view in DevLaunchers delegate subscriber. It seems like a small change but seemed to do the trick. 🤷‍♀️ 

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

I tested both platforms with and without `expo-screen-orientation` installed - updating the `app.json` orientation value to be `default` `landscape` and `portrait` and ensured that behaviour was as expected: locked to the values when landscape / portrait, but rotates when default

Here is a quick video demonstrating: 


https://user-images.githubusercontent.com/40680668/182955072-58969cb0-3721-453f-a6bb-2b70b9a00464.mp4



# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
