### PR TITLE
[expo-dev-launcher] add URL to deep link error screen on iOS

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Refactored inline Android emulator checks to use enhanced checking in `EmulatorUtilities.isRunningOnEmulator()`. ([#16177](https://github.com/expo/expo/pull/16177)) by [@kbrandwijk](https://github.com/kbrandwijk), [@keith-kurak](https://github.com/keith-kurak))
 - Made deep link error screen on iOS show a friendlier message. ([#18467](https://github.com/expo/expo/pull/18467) by [@esamelson](https://github.com/esamelson))
+- Added URL to deep link error screen message on iOS.
 
 ## 1.1.1 — 2022-07-20
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - Refactored inline Android emulator checks to use enhanced checking in `EmulatorUtilities.isRunningOnEmulator()`. ([#16177](https://github.com/expo/expo/pull/16177)) by [@kbrandwijk](https://github.com/kbrandwijk), [@keith-kurak](https://github.com/keith-kurak))
 - Made deep link error screen on iOS show a friendlier message. ([#18467](https://github.com/expo/expo/pull/18467) by [@esamelson](https://github.com/esamelson))
-- Added URL to deep link error screen message on iOS.
+- Added URL to deep link error screen message on iOS. ([#18511](https://github.com/expo/expo/pull/18511) by [@esamelson](https://github.com/esamelson))
 
 ## 1.1.1 — 2022-07-20
 

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -325,8 +325,11 @@
       if (!self) {
         return;
       }
-      
-      EXDevLauncherAppError *appError = [[EXDevLauncherAppError alloc] initWithMessage:error.localizedDescription stack:nil];
+
+      EXDevLauncherUrl *devLauncherUrl = [[EXDevLauncherUrl alloc] init:url];
+      NSURL *appUrl = devLauncherUrl.url;
+      NSString *errorMessage = [NSString stringWithFormat:@"Failed to load app from %@ with error: %@", appUrl.absoluteString, error.localizedDescription];
+      EXDevLauncherAppError *appError = [[EXDevLauncherAppError alloc] initWithMessage:errorMessage stack:nil];
       [self.errorManager showError:appError];
     });
   }];


### PR DESCRIPTION
# Why

Follow up to #18467 as it was pointed out to me the error message could still be easily improved by including the failing URL.

# How

Customize the error message and include the URL-decoded app URL from the deep link.

# Test Plan

Using the deep links from #18467,

![Simulator Screen Shot - iPhone 13 - 2022-08-04 at 16 37 12](https://user-images.githubusercontent.com/19958240/182973162-4662cf64-7291-4cdb-af3c-87b2be484475.png)
![Simulator Screen Shot - iPhone 13 - 2022-08-04 at 16 37 27](https://user-images.githubusercontent.com/19958240/182973166-23d6bcf5-7ea9-4e62-aca8-cefe4ac62bee.png)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
