### PR TITLE
Update document-picker.md

### DIFF
--- a/docs/pages/versions/unversioned/sdk/document-picker.md
+++ b/docs/pages/versions/unversioned/sdk/document-picker.md
@@ -28,6 +28,19 @@ For iOS, outside of the Expo Go app, the DocumentPicker module requires the [iCl
 - Set the `usesIcloudStorage` key to `true` in your **app.json** as specified [configuration properties](/versions/latest/config/app/#usesicloudstorage).
 - You need to enable the iCloud Application Service in your App identifier. This can be done in the detail of your [App ID in the Apple Developer interface](https://developer.apple.com/account/ios/identifier/bundle).
 - Enable iCloud service with CloudKit support, and create an iCloud Container. When registering the new Container, you are asked to provide a description and identifier for the container. You may enter any name under the description. Under the identifier, add `iCloud.<your_bundle_identifier>`.
+- Define a plugin in your `app.json` file to define a `iCloudContainerEnvironment` entitlement for your app:
+
+```
+    "plugins": [
+        [
+            "expo-document-picker",
+                {
+                    "iCloudContainerEnvironment": "Production"
+                }
+        ]
+    ],
+
+```
 
 To apply these changes, you have to revoke your existing provisioning profile and use [EAS Build](/build/introduction/) to build the app binaries.
 

--- a/docs/pages/versions/unversioned/sdk/document-picker.md
+++ b/docs/pages/versions/unversioned/sdk/document-picker.md
@@ -28,19 +28,22 @@ For iOS, outside of the Expo Go app, the DocumentPicker module requires the [iCl
 - Set the `usesIcloudStorage` key to `true` in your **app.json** as specified [configuration properties](/versions/latest/config/app/#usesicloudstorage).
 - You need to enable the iCloud Application Service in your App identifier. This can be done in the detail of your [App ID in the Apple Developer interface](https://developer.apple.com/account/ios/identifier/bundle).
 - Enable iCloud service with CloudKit support, and create an iCloud Container. When registering the new Container, you are asked to provide a description and identifier for the container. You may enter any name under the description. Under the identifier, add `iCloud.<your_bundle_identifier>`.
-- Define a plugin in your `app.json` file to define a `iCloudContainerEnvironment` entitlement for your app:
+- Add `expo-document-picker` [config plugin](/guides/config-plugins/) in **app.json** or **app.config.js** and pass `iCloudContainerEnvironment` entitlement as an option to the plugin:
 
 ```
-    "plugins": [
-        [
-            "expo-document-picker",
-                {
-                    "iCloudContainerEnvironment": "Production"
-                }
-        ]
-    ],
-
+{
+  "plugins": [
+    [
+      "expo-document-picker",
+      {
+        "iCloudContainerEnvironment": "Development | Production"
+      }
+    ]
+  ]
+}
 ```
+
+In the above snippet, `iCloudContainerEnvironment` takes either `Development` or `Production` as the value depending on which environment you create the iCloud container.
 
 To apply these changes, you have to revoke your existing provisioning profile and use [EAS Build](/build/introduction/) to build the app binaries.
 


### PR DESCRIPTION
# Why

A configuration step is missing to get the DocumentPicker working in managed workflows.

See also https://forums.expo.dev/t/build-issue-after-enabling-the-icloud-application-service/65490/7

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
