### PR TITLE
[docs] Pin app.json config to right sdk versions

### DIFF
--- a/docs/pages/versions/v43.0.0/config/app.md
+++ b/docs/pages/versions/v43.0.0/config/app.md
@@ -8,7 +8,7 @@ Hi! If you found an issue within the description of the manifest properties, ple
 -->
 
 import AppConfigSchemaPropertiesTable from '~/components/plugins/AppConfigSchemaPropertiesTable';
-import schema from '~/scripts/schemas/unversioned/app-config-schema.js';
+import schema from '~/scripts/schemas/v43.0.0/app-config-schema.js';
 
 The following is a list of properties that are available for you under the `"expo"` key in **app.json** or **app.config.json**. These properties can be passed to the top level object of **app.config.js** or **app.config.ts**.
 

--- a/docs/pages/versions/v46.0.0/config/app.md
+++ b/docs/pages/versions/v46.0.0/config/app.md
@@ -8,7 +8,7 @@ Hi! If you found an issue within the description of the manifest properties, ple
 -->
 
 import AppConfigSchemaPropertiesTable from '~/components/plugins/AppConfigSchemaPropertiesTable';
-import schema from '~/scripts/schemas/unversioned/app-config-schema.js';
+import schema from '~/scripts/schemas/v46.0.0/app-config-schema.js';
 
 The following is a list of properties that are available for you under the `"expo"` key in **app.json** or **app.config.json**. These properties can be passed to the top level object of **app.config.js** or **app.config.ts**.
 


### PR DESCRIPTION
# Why

Unversioned should only be used in unversioned docs, SDKs should use the right version :)

# How

- See commits

# Test Plan

- Small docs change

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
