### PR TITLE
Add a missing gradle task dependency declaration

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix issue with Android builds when gradle clean and build were called concurrently.  ([#18518](https://github.com/expo/expo/pull/18518) by [EdwardDrapkin](https://github.com/EdwardDrapkin))
+
 ### 💡 Others
 
 - Centralized Android emulator detection for native code and added checks to pick up additional emulator types in `EmulatorUtilities`. ([#16177](https://github.com/expo/expo/pull/16177)) by [@kbrandwijk](https://github.com/kbrandwijk), [@keith-kurak](https://github.com/keith-kurak))

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -422,7 +422,7 @@ task prepareFolly(dependsOn: [downloadFolly], type: Copy) {
 }
 // END FOLLy
 
-task prepareHermes() {
+task prepareHermes(dependsOn: createNativeDepsDirectories) {
   if (!FOR_HERMES) {
     return
   }
@@ -444,7 +444,7 @@ afterEvaluate {
 }
 
 tasks.whenTaskAdded { task ->
-  if (!task.name.contains("Clean") && (task.name.contains('externalNativeBuild') || task.name.startsWith('configureCMake'))) {
+  if (!task.name.contains("Clean") && (task.name.contains('externalNativeBuild') || task.name.startsWith('configureCMake') || task.name.startsWith('buildCMake'))) {
     def buildType = task.name.endsWith('Debug') ? 'Debug' : 'Release'
     task.dependsOn(extractAARHeaders)
     task.dependsOn(extractJNIFiles)


### PR DESCRIPTION
The prepareHermes() task was missing a declaration for file dependencies, so builds that were run alongside a clean command failed, for example in AppCenter which runs `clean app:assembleRelease app:bundleRelease` as one command.

Fixes https://github.com/expo/expo/issues/18473 and https://github.com/expo/expo/issues/18412
