### PR TITLE
[docs] Draft a non-recursive JSON schema renderer

### DIFF
--- a/docs/components/plugins/JsonSchema/Definition.tsx
+++ b/docs/components/plugins/JsonSchema/Definition.tsx
@@ -1,0 +1,36 @@
+import assert from 'assert';
+import * as React from 'react';
+
+import { DefinitionDescription } from './DefinitionDescription';
+import DefinitionProperties from './DefinitionProperties';
+import { resolveRef } from './utils/reference';
+import { Schema, SchemaProperty } from './utils/types';
+
+interface DefinitionProps {
+  /** The full JSON Schema to render the data from */
+  schema: Schema;
+  /** The path to the JSON Schema object to render, defaults to root */
+  path: string;
+}
+
+export interface DefinitionRenderProps {
+  /** The full JSON Schema to render the data from */
+  schema: Schema;
+  /** The resolved JSON Schema definition to render */
+  definition: SchemaProperty;
+}
+
+export function Definition({ schema, path }: DefinitionProps) {
+  const definition = resolveRef(schema, path);
+  assert(definition, `Definition was not found in schema, used path: ${path}`);
+
+  return (
+    <>
+      <DefinitionDescription schema={schema} definition={definition} />
+      <br />
+      {definition.properties ? (
+        <DefinitionProperties schema={schema} definition={definition} />
+      ) : null}
+    </>
+  );
+}

--- a/docs/components/plugins/JsonSchema/DefinitionDescription.tsx
+++ b/docs/components/plugins/JsonSchema/DefinitionDescription.tsx
@@ -1,0 +1,17 @@
+import MDX from '@mdx-js/runtime';
+
+import * as mdxComponents from '~/common/translate-markdown';
+import { P } from '~/ui/components/Text';
+import { DefinitionRenderProps } from './Definition';
+
+export function DefinitionDescription({ definition }: DefinitionRenderProps) {
+  if (definition.markdownDescription) {
+    return (
+      <MDX components={mdxComponents}>
+        {definition.markdownDescription}
+      </MDX>
+    );
+  }
+
+  return <P>{definition.description}</P>;
+}

--- a/docs/components/plugins/JsonSchema/DefinitionProperties.tsx
+++ b/docs/components/plugins/JsonSchema/DefinitionProperties.tsx
@@ -1,0 +1,47 @@
+import assert from 'assert';
+
+import { DefinitionRenderProps } from './Definition';
+import { DefinitionDescription } from './DefinitionDescription';
+import { DefinitionType } from './DefinitionType';
+
+import { Cell, HeaderCell, Row, Table, TableHead } from '~/ui/components/Table';
+import { BOLD, CALLOUT } from '~/ui/components/Text';
+
+export default function DefinitionProperties({ schema, definition }: DefinitionRenderProps) {
+  assert(definition.properties, 'Definition is a non-object type without properties');
+
+  return (
+    <Table>
+      <TableHead>
+        <Row>
+          <HeaderCell>Property</HeaderCell>
+          <HeaderCell>Type</HeaderCell>
+          <HeaderCell>Description</HeaderCell>
+        </Row>
+      </TableHead>
+      <tbody>
+        {Object.entries(definition.properties).map(([name, property]) => {
+          const isRequired = definition.required && definition.required.includes(name);
+          return (
+            <Row key={name}>
+              <Cell fitContent>
+                <BOLD>{name}</BOLD>
+                {isRequired && (
+                  <CALLOUT theme="secondary" css={{ fontSize: '90%' }}>
+                    required
+                  </CALLOUT>
+                )}
+              </Cell>
+              <Cell fitContent>
+                <DefinitionType schema={schema} definition={property as any} />
+              </Cell>
+              <Cell>
+                <DefinitionDescription schema={schema} definition={property as any} />
+              </Cell>
+            </Row>
+          );
+        })}
+      </tbody>
+    </Table>
+  );
+}

--- a/docs/components/plugins/JsonSchema/DefinitionType.tsx
+++ b/docs/components/plugins/JsonSchema/DefinitionType.tsx
@@ -1,0 +1,79 @@
+import { DefinitionRenderProps } from './Definition';
+import { resolveRef } from './utils/reference';
+import { Schema, SchemaProperty } from './utils/types';
+
+import { CODE } from '~/ui/components/Text';
+
+export function DefinitionType(props: DefinitionRenderProps) {
+  const type = getPropertyType(props.schema, props.definition);
+  return !type ? null : <CODE css={{ whiteSpace: 'nowrap' }}>{type}</CODE>;
+}
+
+/**
+ * Get the type of a single JSON Schema property to render.
+ * For primitive types, the text is returned.
+ * For complex types, such as array, the `items` types are resolved.
+ */
+export function getPropertyType(
+  schema: Schema,
+  property: SchemaProperty | null,
+  expandEnum = true
+): null | string {
+  const definition = property && property.$ref ? resolveRef(schema, property.$ref) : property;
+
+  if (!definition) {
+    return null;
+  }
+
+  if (definition.const) {
+    return definition.const;
+  }
+
+  if (definition.enum) {
+    return !expandEnum ? 'enum' : 'enum: ' + definition.enum.join(', ');
+  }
+
+  if (definition.oneOf || definition.anyOf) {
+    const list = definition.oneOf || definition.anyOf;
+    return (list as any[])
+      .map((subDef: any) => getPropertyType(schema, subDef, false))
+      .filter((value, index, list) => value && list.indexOf(value) === index)
+      .join('|');
+  }
+
+  if (
+    definition.type === 'string' &&
+    definition.format &&
+    ['date', 'date-time'].includes(definition.format)
+  ) {
+    return 'Date';
+  }
+
+  if (definition.type === 'array') {
+    if (!definition.items) return 'array';
+
+    if ('oneOf' in definition.items || 'anyOf' in definition.items) {
+      const types = getPropertyType(schema, definition.items, false);
+      return `(${types})[]`;
+    }
+
+    if (!Array.isArray(definition.items)) {
+      return getPropertyType(schema, definition.items) + '[]';
+    }
+
+    // Does not work nicely for categories
+    // if (Array.isArray(definition.items)) {
+    //   const types = definition.items.map(subDef => getPropertyType(schema, subDef, false));
+    //   return `[${uniq(types).join('|')}]`;
+    // }
+
+    return 'array'; // TODO(cedric): check inside types
+  }
+
+  if (definition.type) {
+    return definition.type;
+  }
+
+  // Fallback
+  return '?';
+}

--- a/docs/components/plugins/JsonSchema/__tests__/DefinitionType.test.ts
+++ b/docs/components/plugins/JsonSchema/__tests__/DefinitionType.test.ts
@@ -1,0 +1,103 @@
+import { getPropertyType } from '../DefinitionType';
+import { Schema } from '../utils/types';
+
+const schema: Schema = {
+  definitions: {
+    test: { type: 'string' },
+  },
+  properties: {
+    testRef: { $ref: '#/definitions/test' },
+    testBoolean: { type: 'boolean' },
+    testNumber: { type: 'number' },
+    testString: { type: 'string' },
+    testConst: { const: 'arbitrary' },
+    testEnum: { enum: ['one', 'two'] },
+    testStringDate: { type: 'string', format: 'date' },
+    testStringDateTime: { type: 'string', format: 'date-time' },
+    testOneOf: {
+      oneOf: [{ type: 'string' }, { type: 'boolean' }],
+    },
+    testAnyOf: {
+      anyOf: [{ type: 'number' }, { type: 'boolean' }],
+    },
+    testArray: { type: 'array' },
+    testArrayObject: {
+      type: 'array',
+      items: { type: 'string' },
+    },
+    testArrayObjectOneOf: {
+      type: 'array',
+      items: {
+        oneOf: [{ type: 'string' }, { type: 'number' }],
+      },
+    },
+    testArrayObjectAnyOf: {
+      type: 'array',
+      items: {
+        anyOf: [{ type: 'boolean' }, { type: 'string' }],
+      },
+    },
+  },
+};
+
+describe(getPropertyType, () => {
+  it('returns referenced definition type', () => {
+    expect(getPropertyType(schema, schema.properties!.testRef)).toBe(schema.definitions!.test.type);
+  });
+
+  it('returns null without definition', () => {
+    expect(getPropertyType(schema, null)).toBeNull();
+  });
+
+  it('returns primitive types', () => {
+    expect(getPropertyType(schema, schema.properties!.testBoolean)).toBe('boolean');
+    expect(getPropertyType(schema, schema.properties!.testNumber)).toBe('number');
+    expect(getPropertyType(schema, schema.properties!.testString)).toBe('string');
+  });
+
+  it('returns const value as type', () => {
+    expect(getPropertyType(schema, schema.properties!.testConst)).toBe(
+      schema.properties!.testConst.const
+    );
+  });
+
+  it('returns enum value as type', () => {
+    expect(getPropertyType(schema, schema.properties!.testEnum, false)).toBe('enum');
+    expect(getPropertyType(schema, schema.properties!.testEnum, true)).toBe(
+      `enum: ${schema.properties!.testEnum.enum!.join(', ')}`
+    );
+  });
+
+  it('returns oneOf types', () => {
+    expect(getPropertyType(schema, schema.properties!.testOneOf)).toBe('string|boolean');
+  });
+
+  it('returns anyOf types', () => {
+    expect(getPropertyType(schema, schema.properties!.testAnyOf)).toBe('number|boolean');
+  });
+
+  it('returns array without items type', () => {
+    expect(getPropertyType(schema, schema.properties!.testArray)).toBe('array');
+  });
+
+  it('returns array with items object', () => {
+    expect(getPropertyType(schema, schema.properties!.testArrayObject)).toBe('string[]');
+  });
+
+  it('returns array with items object and oneOf types', () => {
+    expect(getPropertyType(schema, schema.properties!.testArrayObjectOneOf)).toBe(
+      '(string|number)[]'
+    );
+  });
+
+  it('returns array with items object and anyOf types', () => {
+    expect(getPropertyType(schema, schema.properties!.testArrayObjectAnyOf)).toBe(
+      '(boolean|string)[]'
+    );
+  });
+
+  it('returns date-formatted string as date type', () => {
+    expect(getPropertyType(schema, schema.properties!.testStringDate)).toBe('Date');
+    expect(getPropertyType(schema, schema.properties!.testStringDateTime)).toBe('Date');
+  });
+});

--- a/docs/components/plugins/JsonSchema/index.ts
+++ b/docs/components/plugins/JsonSchema/index.ts
@@ -1,0 +1,4 @@
+export * from './Definition';
+export * from './DefinitionDescription';
+export * from './DefinitionProperties';
+export * from './DefinitionType';

--- a/docs/components/plugins/JsonSchema/utils/__tests__/reference.test.ts
+++ b/docs/components/plugins/JsonSchema/utils/__tests__/reference.test.ts
@@ -1,0 +1,42 @@
+import { resolveRef } from '../reference';
+import { Schema } from '../types';
+
+const schema: Schema = {
+  type: 'object',
+  properties: {
+    testDict: {
+      '$ref': '#/definitions/dict',
+    },
+  },
+  definitions: {
+    dict: {
+      type: 'object',
+      properties: {
+        propA: { type: 'string' },
+        propB: { type: 'number' },
+      },
+    },
+    deep: {
+      dict: {
+        type: 'object',
+        properties: {
+          test: { type: 'boolean' },
+        },
+      },
+    },
+  },
+};
+
+describe(resolveRef, () => {
+  it(`validates path starting with '#/'`, () => {
+    expect(() => resolveRef(schema, 'invalid/path')).toThrow('valid JSON Schema path starts with');
+  });
+
+  it(`resolves #/definitions/dictionary`, () => {
+    expect(resolveRef(schema, '#/definitions/dict')).toBe(schema.definitions!.dict);
+  });
+
+  it(`resolves #/definitions/deep/dict`, () => {
+    expect(resolveRef(schema, '#/definitions/deep/dict')).toBe(schema.definitions!.deep.dict);
+  });
+});

--- a/docs/components/plugins/JsonSchema/utils/reference.ts
+++ b/docs/components/plugins/JsonSchema/utils/reference.ts
@@ -1,0 +1,24 @@
+import assert from 'assert';
+
+import { Schema, SchemaProperty } from './types';
+
+/**
+ * Find the referenced JSON Schema property within the schema.
+ * This uses paths like `#/definitions/SomeObject` to resolve it.
+ */
+export function resolveRef(schema: Schema, path: string): null | SchemaProperty {
+  assert(path.startsWith('#/'), `A valid JSON Schema path starts with '#/'`);
+
+  const pathSegments = path.replace(/^#\//, '').split('/');
+  let pathReference = schema;
+
+  for (const segment of pathSegments) {
+    if (!pathReference[segment]) {
+      return null;
+    }
+
+    pathReference = pathReference[segment];
+  }
+
+  return pathReference;
+}

--- a/docs/components/plugins/JsonSchema/utils/types.ts
+++ b/docs/components/plugins/JsonSchema/utils/types.ts
@@ -1,0 +1,23 @@
+export interface Schema extends SchemaProperty {
+  definitions?: Record<string, any>;
+  [key: string]: any;
+}
+
+export interface SchemaProperty {
+  $ref?: string;
+
+  type?: string;
+  enum?: string[];
+  const?: string;
+
+  required?: string[];
+  description?: string;
+  markdownDescription?: string;
+
+  items?: any;
+  oneOf?: any;
+  anyOf?: any;
+  format?: string;
+
+  properties?: Record<string, SchemaProperty>;
+}

--- a/docs/constants/navigation-deprecated.js
+++ b/docs/constants/navigation-deprecated.js
@@ -329,6 +329,17 @@ const eas = [
     ],
     { expanded: true }
   ),
+  makeSection(
+    'EAS Metadata',
+    [
+      makeGroup('EAS Metadata', [
+        makePage('eas-metadata/introduction.md'),
+        makePage('eas-metadata/getting-started.md'),
+        makePage('eas-metadata/store-json.md'),
+      ]),
+    ],
+    { expanded: true }
+  ),
 ];
 
 const preview = [

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -351,6 +351,15 @@ const archive = [
       expanded: true,
     }
   ),
+  makeSection(
+    'EAS Metadata',
+    [
+      makePage('eas-metadata/introduction.md'),
+      makePage('eas-metadata/getting-started.md'),
+      makePage('eas-metadata/store-json.md'),
+    ],
+    { expanded: true }
+  ),
 ];
 
 const featurePreview = [];

--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -116,6 +116,8 @@ redirects[clients/upgrading]=development/upgrading/
 redirects[modules]=modules/overview/
 redirects[module-api]=modules/module-api/
 redirects[module-config]=modules/module-config/
+# EAS Metadata
+redirects[eas-metadata]=eas-metadata/introduction/
 
 redirects[introduction/walkthrough]=tutorial/planning/
 

--- a/docs/pages/eas-metadata/getting-started.md
+++ b/docs/pages/eas-metadata/getting-started.md
@@ -1,0 +1,70 @@
+---
+title: Getting started with EAS Metadata
+sidebar_title: Getting started
+---
+
+import { Terminal } from '~/ui/components/Snippet';
+
+> ⚠️ EAS Metadata is in beta and subject to breaking changes.
+
+EAS Metadata helps you prepare your app for review in the app stores and helps you prevent common pitfalls that often could lead to an app rejection.
+
+## Prerequisites
+
+EAS Metadata is available starting from EAS CLI >= 0.54.0, and _only supports the App Store_.
+
+## Create a local store configuration
+
+We first need to create our local **store.config.json** to get started. This file keeps track of all the information for the app stores. If you have an existing app in the stores, you can generate the configuration file by running:
+
+<Terminal cmd={['$ eas metadata:pull']} />
+
+If you don't have an app in the stores, you can create the **store.config.json** manually.
+
+```json
+{
+  "configVersion": 0,
+  "apple": {
+    "info": {
+      "en-US": {
+        "title": "Awesome App",
+        "subtitle": "Your self-made awesome app",
+        "description": "The most awesome app you've ever seen",
+        "keywords": ["awesome", "app"],
+        "marketingUrl": "https://example.com/en/promo",
+        "supportUrl": "https://example.com/en/support",
+        "privacyPolicyUrl": "https://example.com/en/privacy"
+      }
+    }
+  }
+}
+```
+
+> By default EAS Metadata will use the **store.config.json** file in your project. You can change the name and location of the file by [configuring the `metadataPath` on the EAS Submit](../submit/eas-json.md#metadatapath) profile.
+
+## Update the local store configuration
+
+Now it's time to edit the **store.config.json** file and customize it to your app needs. You can find all available options for the **store.config.json** in the [store configuration reference](./store-json.md).
+
+## Upload a new version of the app
+
+To create a new app version in the stores, you must upload a new binary. We can do this by running:
+
+<Terminal cmd={[
+  '# Build and deploy to the stores',
+  '$ eas build --auto-submit',
+  '# Or deploy a previous build to the stores',
+  '$ eas submit',
+]} />
+
+After the binary is submitted and processed, we can start syncing the local store configuration.
+
+## Sync the local store configuration
+
+When the **store.config.json** is up to date, we can start syncing the app stores with the local store configuration:
+
+<Terminal cmd={['$ eas metadata:push']} />
+
+## Next
+
+You can explore all available configuration options in the [store configuration reference](./store-json.md).

--- a/docs/pages/eas-metadata/getting-started.md
+++ b/docs/pages/eas-metadata/getting-started.md
@@ -7,19 +7,19 @@ import { Terminal } from '~/ui/components/Snippet';
 
 > ⚠️ EAS Metadata is in beta and subject to breaking changes.
 
-EAS Metadata helps you prepare your app for review in the app stores and helps you prevent common pitfalls that often could lead to an app rejection.
+EAS Metadata helps you prepare your app for review in the app stores and helps you prevent common pitfalls that may lead to a rejected app submission.
 
 ## Prerequisites
 
-EAS Metadata is available starting from EAS CLI >= 0.54.0, and _only supports the App Store_.
+EAS Metadata is available starting from EAS CLI >= 0.54.0, and _currently_ only supports the Apple App Store.
 
 ## Create a local store configuration
 
-We first need to create our local **store.config.json** to get started. This file keeps track of all the information for the app stores. If you have an existing app in the stores, you can generate the configuration file by running:
+To get started, create a **store.config.json** in your project root directory. This file keeps track of all the information for the app stores. If you have an existing app in the stores, you can generate the configuration file by running:
 
 <Terminal cmd={['$ eas metadata:pull']} />
 
-If you don't have an app in the stores, you can create the **store.config.json** manually.
+If you don't have an app in the stores there will not be any metadata to pull, and you can initialize the **store.config.json** manually.
 
 ```json
 {
@@ -40,7 +40,7 @@ If you don't have an app in the stores, you can create the **store.config.json**
 }
 ```
 
-> By default EAS Metadata will use the **store.config.json** file in your project. You can change the name and location of the file by [configuring the `metadataPath` on the EAS Submit](../submit/eas-json.md#metadatapath) profile.
+> EAS Metadata will use the **store.config.json** file in the project root by default; you can change the name and location of the file by [configuring the `metadataPath` on the EAS Submit profile](../submit/eas-json.md#metadatapath).
 
 ## Update the local store configuration
 

--- a/docs/pages/eas-metadata/index.js
+++ b/docs/pages/eas-metadata/index.js
@@ -1,0 +1,3 @@
+import redirect from '~/common/redirect';
+
+export default redirect('/eas-metadata/introduction');

--- a/docs/pages/eas-metadata/introduction.md
+++ b/docs/pages/eas-metadata/introduction.md
@@ -1,0 +1,19 @@
+---
+title: EAS Metadata
+sidebar_title: Introduction
+hideTOC: true
+---
+
+import { BoxLink } from '~/ui/components/BoxLink';
+
+> ⚠️ EAS Metadata is in beta and subject to breaking changes.
+
+**EAS Metadata** is a service to help you provide all necessary information to the stores and get your app published.
+
+To get your app into the hands of your users, you have to publish the app on multiple app stores. During this process, you'll have to answer questions about complex topics that often don't apply to your app. After submitting the information, you can start the lengthy review process. If the reviewer finds any issues in the information you sent, you'll have to restart the review process, making the feedback loop worse.
+
+EAS Metadata makes this easier by allowing users to configure the app store information locally. After this store configuration is ready, you can sync the app stores using `eas metadata:push`. EAS Metadata does not only get the information into the stores; it also tries to find common pitfalls that could cause an app rejection. It does all this before sending it into the app stores, saving you valuable time to spend on your project.
+
+### Get started
+
+<BoxLink title="Getting started" href="/eas-metadata/getting-started" description="Configure EAS Metadata from scratch, or use an existing app to generate the local store configuration." />

--- a/docs/pages/eas-metadata/introduction.md
+++ b/docs/pages/eas-metadata/introduction.md
@@ -10,7 +10,7 @@ import { BoxLink } from '~/ui/components/BoxLink';
 
 **EAS Metadata** is a service to help you provide all necessary information to the stores and get your app published.
 
-To get your app into the hands of your users, you have to publish the app on multiple app stores. During this process, you'll have to answer questions about complex topics that often don't apply to your app. After submitting the information, you can start the lengthy review process. If the reviewer finds any issues in the information you sent, you'll have to restart the review process, making the feedback loop worse.
+To get your app into the hands of your users, you have to publish the app on multiple app stores. During this process, you'll have to answer questions about complex topics that often don't apply to your app. After submitting the information, you can start the lengthy review process. If the reviewer finds any issues in the information you sent, you'll have to restart the review process.
 
 EAS Metadata makes this easier by allowing users to configure the app store information locally. After this store configuration is ready, you can sync the app stores using `eas metadata:push`. EAS Metadata does not only get the information into the stores; it also tries to find common pitfalls that could cause an app rejection. It does all this before sending it into the app stores, saving you valuable time to spend on your project.
 

--- a/docs/pages/eas-metadata/store-json.md
+++ b/docs/pages/eas-metadata/store-json.md
@@ -1,0 +1,6 @@
+---
+title: EAS Metadata store.config.json schema
+sidebar_title: store configuration
+---
+
+<!-- TODO -->

--- a/docs/pages/eas-metadata/store-json.md
+++ b/docs/pages/eas-metadata/store-json.md
@@ -3,4 +3,26 @@ title: EAS Metadata store.config.json schema
 sidebar_title: store configuration
 ---
 
-<!-- TODO -->
+import schema from '~/scripts/schemas/unversioned/eas-metadata.json';
+import { Definition } from '~/components/plugins/JsonSchema';
+
+
+## Apple store config
+
+<Definition schema={schema} path="#/definitions/AppleConfig" />
+
+### Categories
+
+<Definition schema={schema} path="#/definitions/apple/AppleCategory" />
+
+### Localized info settings
+
+<Definition schema={schema} path="#/definitions/apple/AppleInfo" />
+
+### Review settings
+
+<Definition schema={schema} path="#/definitions/apple/AppleReview" />
+
+### Release settings
+
+<Definition schema={schema} path="#/definitions/apple/AppleRelease" />

--- a/docs/pages/eas/index.md
+++ b/docs/pages/eas/index.md
@@ -15,3 +15,5 @@ Read the full pitch at [expo.dev/eas](https://expo.dev/eas), or follow the links
 <BoxLink title="EAS Submit" description="Upload your app to the Apple App Store or Google Play Store from the cloud with one CLI command. Learn more." href="/submit/introduction" />
 
 <BoxLink title="EAS Update" description="Address small bugs and push quick fixes directly to end-users. Learn more." href="/eas-update/introduction" />
+
+<BoxLink title="EAS Metadata (In Preview)" description="Upload all app store information required to get your app published. Learn more." href="/eas-metadata/introduction" />

--- a/docs/scripts/schemas/unversioned/eas-json-submit-ios-schema.js
+++ b/docs/scripts/schemas/unversioned/eas-json-submit-ios-schema.js
@@ -71,4 +71,11 @@ export default [
       'The Bundle identifier that will be used when accessing submit credentials managed by Expo, it does not have any effect if you are using local credentials. In most cases this value will be autodetected, but if you have multiple Xcode schemes and targets, this value might be necessary.',
     ],
   },
+  {
+    name: 'metadataPath',
+    type: 'string',
+    description: [
+      'The path to your store configuration file. [Learn more](https://docs.expo.dev/eas-metadata/introduction/).'
+    ],
+  }
 ];

--- a/docs/scripts/schemas/unversioned/eas-metadata.json
+++ b/docs/scripts/schemas/unversioned/eas-metadata.json
@@ -1,0 +1,760 @@
+{
+  "$schema": "http://json-schema.org/draft-06/schema",
+  "type": "object",
+  "definitions": {
+    "apple": {
+      "AppleKidsAge": {
+        "enum": ["FIVE_AND_UNDER", "SIX_TO_EIGHT", "NINE_TO_ELEVEN"]
+      },
+      "AppleRating": {
+        "enum": ["NONE", "INFREQUENT_OR_MILD", "FREQUENT_OR_INTENSE"]
+      },
+      "AppleCategory": {
+        "type": "array",
+        "description": "App Store categories for the app, can add up to two categories. The first item in this list is the primary category, the second is the secondary and optional category. `STICKERS` and `GAMES` categories can add up to two additional subcategories, written as nested array.",
+        "markdownDescription": "App Store categories for the app, can add up to two categories. The first item in this list is the primary category, the second is the secondary and optional category. `STICKERS` and `GAMES` categories can add up to two additional subcategories, written as nested array. E.g.\n\n- `[\"SPORTS\"]`\n- `[\"SPORTS\", \"LIFESTYLE\"]`\n- `[[\"GAMES\", \"GAMES_CARD\"], \"ENTERTAINMENT\"]`\n- `[\"GAMES\", \"WEATHER\"]`",
+        "minItems": 1,
+        "maxItems": 2,
+        "uniqueItems": true,
+        "defaultSnippets": [
+          {
+            "label": "Basic categories",
+            "description": "Add two simple categories",
+            "body": ["$1", "$2"]
+          },
+          {
+            "label": "Category with subcategories",
+            "description": "Add a category containing subcategories",
+            "body": [["${1|GAMES,STICKERS|}", "$3", "$4"]]
+          }
+        ],
+        "items": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/apple/AppleCategory/categories/root"
+            },
+            {
+              "$ref": "#/definitions/apple/AppleCategory/categories/parent"
+            },
+            {
+              "type": "array",
+              "description": "The GAMES category can have additional subcategories",
+              "minItems": 1,
+              "maxItems": 3,
+              "uniqueItems": true,
+              "items": [
+                {
+                  "const": "GAMES"
+                },
+                {
+                  "$ref": "#/definitions/apple/AppleCategory/categories/games"
+                },
+                {
+                  "$ref": "#/definitions/apple/AppleCategory/categories/games"
+                }
+              ]
+            },
+            {
+              "type": "array",
+              "description": "The STICKERS category can have additional subcategories",
+              "minItems": 1,
+              "maxItems": 3,
+              "uniqueItems": true,
+              "items": [
+                {
+                  "const": "STICKERS"
+                },
+                {
+                  "$ref": "#/definitions/apple/AppleCategory/categories/stickers"
+                },
+                {
+                  "$ref": "#/definitions/apple/AppleCategory/categories/stickers"
+                }
+              ]
+            }
+          ]
+        },
+        "categories": {
+          "root": {
+            "enum": [
+              "BUSINESS",
+              "SOCIAL_NETWORKING",
+              "MEDICAL",
+              "FOOD_AND_DRINK",
+              "EDUCATION",
+              "BOOKS",
+              "SPORTS",
+              "FINANCE",
+              "REFERENCE",
+              "GRAPHICS_AND_DESIGN",
+              "DEVELOPER_TOOLS",
+              "HEALTH_AND_FITNESS",
+              "MUSIC",
+              "WEATHER",
+              "TRAVEL",
+              "ENTERTAINMENT",
+              "LIFESTYLE",
+              "MAGAZINES_AND_NEWSPAPERS",
+              "UTILITIES",
+              "SHOPPING",
+              "PRODUCTIVITY",
+              "NEWS",
+              "PHOTO_AND_VIDEO",
+              "NAVIGATION"
+            ]
+          },
+          "parent": {
+            "enum": ["GAMES", "STICKERS"]
+          },
+          "games": {
+            "enum": [
+              "GAMES_SPORTS",
+              "GAMES_WORD",
+              "GAMES_MUSIC",
+              "GAMES_ADVENTURE",
+              "GAMES_ACTION",
+              "GAMES_ROLE_PLAYING",
+              "GAMES_CASUAL",
+              "GAMES_BOARD",
+              "GAMES_TRIVIA",
+              "GAMES_CARD",
+              "GAMES_PUZZLE",
+              "GAMES_CASINO",
+              "GAMES_STRATEGY",
+              "GAMES_SIMULATION",
+              "GAMES_RACING",
+              "GAMES_FAMILY"
+            ]
+          },
+          "stickers": {
+            "enum": [
+              "STICKERS_PLACES_AND_OBJECTS",
+              "STICKERS_EMOJI_AND_EXPRESSIONS",
+              "STICKERS_CELEBRATIONS",
+              "STICKERS_CELEBRITIES",
+              "STICKERS_MOVIES_AND_TV",
+              "STICKERS_SPORTS_AND_ACTIVITIES",
+              "STICKERS_EATING_AND_DRINKING",
+              "STICKERS_CHARACTERS",
+              "STICKERS_ANIMALS",
+              "STICKERS_FASHION",
+              "STICKERS_ART",
+              "STICKERS_GAMING",
+              "STICKERS_KIDS_AND_FAMILY",
+              "STICKERS_PEOPLE",
+              "STICKERS_MUSIC"
+            ]
+          }
+        }
+      },
+      "AppleInfo": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["title", "privacyPolicyUrl"],
+        "defaultSnippets": [
+          {
+            "label": "Basic",
+            "description": "Create the minimum required locale properties",
+            "body": {
+              "title": "${1:App title}",
+              "privacyPolicyUrl": "https://${3:www.}"
+            }
+          },
+          {
+            "label": "Full",
+            "description": "Create all available locale properties",
+            "body": {
+              "title": "${1:App title}",
+              "subtitle": "${2:Subtitle for your app}",
+              "description": "${3:A longer description of what your app does}",
+              "keywords": ["${4:keyword}"],
+              "releaseNotes": "${5:Bug fixes and improved stability}",
+              "promoText": "${6:Short tagline for your app}",
+              "marketingUrl": "https://${7:www.}",
+              "supportUrl": "https://${8:www.}",
+              "privacyPolicyUrl": "https://${9:www.}",
+              "privacyChoicesUrl": "https://${10:www.}"
+            }
+          }
+        ],
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "Name of the app in the store. This should be similar to the installed app name.",
+            "minLength": 2,
+            "maxLength": 30,
+            "meta": {
+              "storeInfo": "The name will be reviewed before it is made available on the App Store."
+            }
+          },
+          "subtitle": {
+            "type": "string",
+            "description": "Subtext for the app. Example: 'A Fun Game For Friends'",
+            "maxLength": 30,
+            "meta": {
+              "storeInfo": "The subtitle will be reviewed before it is made available on the App Store."
+            }
+          },
+          "description": {
+            "type": "string",
+            "description": "Main description of what the app does",
+            "minLength": 10,
+            "maxLength": 4000,
+            "meta": {
+              "versioned": true,
+              "liveEdits": true
+            }
+          },
+          "keywords": {
+            "type": "array",
+            "description": "List of keywords to help users find the app in the App Store",
+            "uniqueItems": true,
+            "items": {
+              "maxLength": 100,
+              "type": "string"
+            },
+            "meta": {
+              "versioned": true
+            }
+          },
+          "releaseNotes": {
+            "type": "string",
+            "description": "Changes since the last public version",
+            "maxLength": 4000,
+            "meta": {
+              "versioned": true,
+              "liveEdits": true
+            }
+          },
+          "promoText": {
+            "type": "string",
+            "description": "Short tagline for the app",
+            "maxLength": 170,
+            "meta": {
+              "versioned": true,
+              "liveEdits": true,
+              "aso": false
+            }
+          },
+          "marketingUrl": {
+            "type": "string",
+            "description": "URL to the app marketing page",
+            "maxLength": 255,
+            "meta": {
+              "versioned": true,
+              "liveEdits": true
+            }
+          },
+          "supportUrl": {
+            "type": "string",
+            "description": "URL to the app support page",
+            "maxLength": 255,
+            "meta": {
+              "versioned": true,
+              "liveEdits": true
+            }
+          },
+          "privacyPolicyText": {
+            "type": "string",
+            "description": "Privacy policy for Apple TV"
+          },
+          "privacyPolicyUrl": {
+            "type": "string",
+            "description": "A URL that links to your privacy policy. A privacy policy is required for all apps.",
+            "maxLength": 255,
+            "meta": {
+              "versioned": true,
+              "liveEdits": true
+            }
+          },
+          "privacyChoicesUrl": {
+            "type": "string",
+            "description": "A URL where users can modify and delete the data collected from the app, or decide how their data is used and shared.",
+            "maxLength": 255,
+            "meta": {
+              "versioned": true,
+              "liveEdits": true,
+              "optional": true
+            }
+          }
+        }
+      },
+      "AppleAdvisory": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "alcoholTobaccoOrDrugUseOrReferences",
+          "contests",
+          "gamblingSimulated",
+          "horrorOrFearThemes",
+          "matureOrSuggestiveThemes",
+          "medicalOrTreatmentInformation",
+          "profanityOrCrudeHumor",
+          "sexualContentGraphicAndNudity",
+          "sexualContentOrNudity",
+          "violenceCartoonOrFantasy",
+          "violenceRealistic",
+          "violenceRealisticProlongedGraphicOrSadistic",
+          "gambling",
+          "unrestrictedWebAccess",
+          "kidsAgeBand",
+          "seventeenPlus"
+        ],
+        "defaultSnippets": [
+          {
+            "label": "Basic",
+            "description": "Create an advisory that disables all age-rated properties, for when your app does nothing",
+            "body": {
+              "alcoholTobaccoOrDrugUseOrReferences": "NONE",
+              "contests": "NONE",
+              "gamblingSimulated": "NONE",
+              "horrorOrFearThemes": "NONE",
+              "matureOrSuggestiveThemes": "NONE",
+              "medicalOrTreatmentInformation": "NONE",
+              "profanityOrCrudeHumor": "NONE",
+              "sexualContentGraphicAndNudity": "NONE",
+              "sexualContentOrNudity": "NONE",
+              "violenceCartoonOrFantasy": "NONE",
+              "violenceRealistic": "NONE",
+              "violenceRealisticProlongedGraphicOrSadistic": "NONE",
+              "gambling": false,
+              "unrestrictedWebAccess": false,
+              "kidsAgeBand": null,
+              "seventeenPlus": false
+            }
+          },
+          {
+            "label": "Full",
+            "description": "Create an advisory that enables some of the age-rated properties",
+            "body": {
+              "alcoholTobaccoOrDrugUseOrReferences": "${1|NONE,INFREQUENT_OR_MILD,FREQUENT_OR_INTENSE|}",
+              "contests": "${2|NONE,INFREQUENT_OR_MILD,FREQUENT_OR_INTENSE|}",
+              "gamblingSimulated": "${3|NONE,INFREQUENT_OR_MILD,FREQUENT_OR_INTENSE|}",
+              "horrorOrFearThemes": "${4|NONE,INFREQUENT_OR_MILD,FREQUENT_OR_INTENSE|}",
+              "matureOrSuggestiveThemes": "${5|NONE,INFREQUENT_OR_MILD,FREQUENT_OR_INTENSE|}",
+              "medicalOrTreatmentInformation": "${6|NONE,INFREQUENT_OR_MILD,FREQUENT_OR_INTENSE|}",
+              "profanityOrCrudeHumor": "${7|NONE,INFREQUENT_OR_MILD,FREQUENT_OR_INTENSE|}",
+              "sexualContentGraphicAndNudity": "${8|NONE,INFREQUENT_OR_MILD,FREQUENT_OR_INTENSE|}",
+              "sexualContentOrNudity": "${9|NONE,INFREQUENT_OR_MILD,FREQUENT_OR_INTENSE|}",
+              "violenceCartoonOrFantasy": "${10|NONE,INFREQUENT_OR_MILD,FREQUENT_OR_INTENSE|}",
+              "violenceRealistic": "${11|NONE,INFREQUENT_OR_MILD,FREQUENT_OR_INTENSE|}",
+              "violenceRealisticProlongedGraphicOrSadistic": "${12|NONE,INFREQUENT_OR_MILD,FREQUENT_OR_INTENSE|}",
+              "unrestrictedWebAccess": false,
+              "gambling": false,
+              "kidsAgeBand": null,
+              "seventeenPlus": false
+            }
+          }
+        ],
+        "properties": {
+          "alcoholTobaccoOrDrugUseOrReferences": {
+            "$ref": "#/definitions/apple/AppleRating",
+            "description": "Does the app contain alcohol, tobacco, or drug use or references?"
+          },
+          "contests": {
+            "$ref": "#/definitions/apple/AppleRating",
+            "description": "Does the app contain contests?"
+          },
+          "gamblingSimulated": {
+            "$ref": "#/definitions/apple/AppleRating",
+            "description": "Does the app contain simulated gambling?"
+          },
+          "medicalOrTreatmentInformation": {
+            "$ref": "#/definitions/apple/AppleRating",
+            "description": "Does the app contain medical or treatment information?"
+          },
+          "profanityOrCrudeHumor": {
+            "$ref": "#/definitions/apple/AppleRating",
+            "description": "Does the app contain profanity or crude humor?"
+          },
+          "sexualContentGraphicAndNudity": {
+            "$ref": "#/definitions/apple/AppleRating",
+            "description": "Does the app contain graphic sexual content and nudity?"
+          },
+          "sexualContentOrNudity": {
+            "$ref": "#/definitions/apple/AppleRating",
+            "description": "Does the app contain sexual content or nudity?"
+          },
+          "horrorOrFearThemes": {
+            "$ref": "#/definitions/apple/AppleRating",
+            "description": "Does the app contain horror or fear themes?"
+          },
+          "matureOrSuggestiveThemes": {
+            "$ref": "#/definitions/apple/AppleRating",
+            "description": "Does the app contain mature or suggestive themes?"
+          },
+          "violenceCartoonOrFantasy": {
+            "$ref": "#/definitions/apple/AppleRating",
+            "description": "Does the app contain cartoon or fantasy violence?"
+          },
+          "violenceRealisticProlongedGraphicOrSadistic": {
+            "$ref": "#/definitions/apple/AppleRating",
+            "description": "Does the app contain prolonged graphic or sadistic realistic violence?"
+          },
+          "violenceRealistic": {
+            "$ref": "#/definitions/apple/AppleRating",
+            "description": "Does the app contain realistic violence?"
+          },
+          "unrestrictedWebAccess": {
+            "type": "boolean",
+            "description": "Does your app contain unrestricted web access, such as with an embedded browser?"
+          },
+          "gambling": {
+            "type": "boolean",
+            "description": "Does your app contain gambling?"
+          },
+          "kidsAgeBand": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/definitions/apple/AppleKidsAge"
+              }
+            ],
+            "description": "When parents visit the Kids category on the App Store, they expect the apps they find will protect their children’s data, provide only age-appropriate content, and require a parental gate in order to link out of the app, request permissions, or present purchasing opportunities. It’s critical that no personally identifiable information or device information be transmitted to third parties, and that advertisements are human-reviewed for age appropriateness in order to be displayed.\n@see https://developer.apple.com/news/?id=091202019a",
+            "markdownDescription": "When parents visit the Kids category on the App Store, they expect the apps they find will protect their children’s data, provide only age-appropriate content, and require a parental gate in order to link out of the app, request permissions, or present purchasing opportunities. It’s critical that no personally identifiable information or device information be transmitted to third parties, and that advertisements are human-reviewed for age appropriateness in order to be displayed.\n\n[Learn more](https://developer.apple.com/news/?id=091202019a)"
+          },
+          "seventeenPlus": {
+            "type": "boolean",
+            "description": "If your app rates 12+ or lower, and you believe its content may not be suitable for children under 17, you can manually set the age rating to 17+.\n@see https://help.apple.com/app-store-connect/#/dev599d50efb",
+            "markdownDescription": "If your app rates 12+ or lower, and you believe its content may not be suitable for children under 17, you can manually set the age rating to 17+.\n\n[Learn more](https://help.apple.com/app-store-connect/#/dev599d50efb)"
+          }
+        }
+      },
+      "AppleRelease": {
+        "type": "object",
+        "description": "Configure how the app is released in the app store.",
+        "additionalProperties": false,
+        "properties": {
+          "automaticRelease": {
+            "description": "If and how the app should automatically be released when approved by App Store review.",
+            "markdownDescription": "If and how the app should automatically be released when approved by App Store review.\n- `false` - Manually release the app after store approval. (default behavior)\n- `true` - Automatically release after store approval.\n- `Date` - Automatically schedule release on this date, after store approval.\n\nApple does not guarantee that your app is available at the chosen scheduled release date.",
+            "oneOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "boolean"
+              }
+            ],
+            "defaultSnippets": [
+              {
+                "label": "Manual release",
+                "description": "Manually release the app after store approval",
+                "body": false
+              },
+              {
+                "label": "Automatic release",
+                "description": "Automatically release the app after store approval",
+                "body": true
+              },
+              {
+                "label": "Scheduled release",
+                "description": "Automatically release the app on this date, and store approval",
+                "body": "$CURRENT_YEAR-${1:$CURRENT_MONTH}-${2:$CURRENT_DATE}T${3:$CURRENT_HOUR}:00:00+00:00"
+              }
+            ]
+          },
+          "phasedRelease": {
+            "type": "boolean",
+            "description": "Phased release for automatic updates lets you gradually release this update over a 7-day period to users who have turned on automatic updates. Keep in mind that this version will still be available to all users as a manual update from the App Store. You can pause the phased release for up to 30 days or release this update to all users at any time.\n@see https://help.apple.com/app-store-connect/#/dev3d65fcee1",
+            "markdownDescription": "Phased release for automatic updates lets you gradually release this update over a 7-day period to users who have turned on automatic updates.\n\nKeep in mind that this version will still be available to all users as a manual update from the App Store.\n\nYou can pause the phased release for up to 30 days or release this update to all users at any time.\n\n[Learn More](https://help.apple.com/app-store-connect/#/dev3d65fcee1)"
+          }
+        }
+      },
+      "AppleReview": {
+        "type": "object",
+        "description": "Info provided to the App Store review team to help them understand how to use your app.",
+        "required": ["firstName", "lastName", "email", "phone"],
+        "defaultSnippets": [
+          {
+            "label": "Basic",
+            "description": "Only define the contact details in case communcation is needed with the App Store review team.",
+            "body": {
+              "firstName": "$1",
+              "lastName": "$2",
+              "email": "$3",
+              "phone": "+$4"
+            }
+          },
+          {
+            "label": "Full",
+            "description": "Define the demo account credentials, additional info, and contact details for the App Store review team.",
+            "body": {
+              "firstName": "$1",
+              "lastName": "$2",
+              "email": "$3",
+              "phone": "+$4",
+              "demoUsername": "$5",
+              "demoPassword": "$6",
+              "demoRequired": true,
+              "notes": "$7"
+            }
+          }
+        ],
+        "properties": {
+          "firstName": {
+            "type": "string",
+            "description": "First name of contact in case communication is needed with the App Store review team.",
+            "minLength": 1
+          },
+          "lastName": {
+            "type": "string",
+            "description": "Last name of contact in case communication is needed with the App Store review team.",
+            "minLength": 1
+          },
+          "email": {
+            "type": "string",
+            "description": "Email address of contact in case communication is needed with the App Store review team.",
+            "format": "email"
+          },
+          "phone": {
+            "type": "string",
+            "description": "Phone number of contact in case communication is needed with the App Store review team. Preface the phone number with ‘+’ followed by the country code (for example, +44 844 209 0611)"
+          },
+          "demoUsername": {
+            "type": "string",
+            "description": "The user name to sign in to your app to review its features."
+          },
+          "demoPassword": {
+            "type": "string",
+            "description": "The password to sign in to your app to review its features."
+          },
+          "demoRequired": {
+            "type": "boolean",
+            "description": "A Boolean value that indicates if sign-in information is required to review all the features of your app. If users sign in using social media, provide information for an account for review. Credentials must be valid and active for duration of review.",
+            "markdownDescription": "A Boolean value that indicates if sign-in information is required to review all the features of your app. If users sign in using social media, provide information for an account for review.\n\n**Credentials must be valid and active for duration of review.**"
+          },
+          "notes": {
+            "type": "string",
+            "description": "Additional information about your app that can help during the review process. Do not include demo account details.",
+            "markdownDescription": "Additional information about your app that can help during the review process.\n\n**Do not include demo account details.**",
+            "minLength": 2,
+            "maxLength": 4000
+          }
+        }
+      }
+    },
+    "AppleConfig": {
+      "type": "object",
+      "description": "Configuration that is specific to the Apple App Store.",
+      "additionalProperties": false,
+      "properties": {
+        "version": {
+          "type": "string",
+          "description": "The version string to edit, or create, if it doesn't exist. All the metadata will be stored on this app version.",
+          "minLength": 1,
+          "defaultSnippets": [
+            {
+              "body": "${1:1}.${2:0}"
+            }
+          ]
+        },
+        "copyright": {
+          "type": "string",
+          "description": "The updated company copyright. Example: 2021 Evan Bacon",
+          "defaultSnippets": [
+            {
+              "body": "$CURRENT_YEAR ${1:name}"
+            }
+          ],
+          "meta": {
+            "versioned": true,
+            "liveEdits": true,
+            "storeInfo": "The name of the person or entity that owns the exclusive rights to your app, preceded by the year the rights were obtained (for example, \"2008 Acme Inc.\"). Do not provide a URL."
+          }
+        },
+        "advisory": {
+          "$ref": "#/definitions/apple/AppleAdvisory"
+        },
+        "categories": {
+          "$ref": "#/definitions/apple/AppleCategory"
+        },
+        "info": {
+          "description": "Localized core app info",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "ar-SA": {
+              "$ref": "#/definitions/apple/AppleInfo",
+              "description": "Arabic"
+            },
+            "ca": {
+              "$ref": "#/definitions/apple/AppleInfo",
+              "description": "Catalan"
+            },
+            "zh-Hans": {
+              "$ref": "#/definitions/apple/AppleInfo",
+              "description": "Chinese (Simplified)"
+            },
+            "zh-Hant": {
+              "$ref": "#/definitions/apple/AppleInfo",
+              "description": "Chinese (Traditional)"
+            },
+            "hr": {
+              "$ref": "#/definitions/apple/AppleInfo",
+              "description": "Croatian"
+            },
+            "cs": {
+              "$ref": "#/definitions/apple/AppleInfo",
+              "description": "Czech"
+            },
+            "da": {
+              "$ref": "#/definitions/apple/AppleInfo",
+              "description": "Danish"
+            },
+            "nl-NL": {
+              "$ref": "#/definitions/apple/AppleInfo",
+              "description": "Dutch"
+            },
+            "en-AU": {
+              "$ref": "#/definitions/apple/AppleInfo",
+              "description": "English (Australia)"
+            },
+            "en-CA": {
+              "$ref": "#/definitions/apple/AppleInfo",
+              "description": "English (Canada)"
+            },
+            "en-GB": {
+              "$ref": "#/definitions/apple/AppleInfo",
+              "description": "English (U.K.)"
+            },
+            "en-US": {
+              "$ref": "#/definitions/apple/AppleInfo",
+              "description": "English (U.S.)"
+            },
+            "fi": {
+              "$ref": "#/definitions/apple/AppleInfo",
+              "description": "Finnish"
+            },
+            "fr-FR": {
+              "$ref": "#/definitions/apple/AppleInfo",
+              "description": "French"
+            },
+            "fr-CA": {
+              "$ref": "#/definitions/apple/AppleInfo",
+              "description": "French (Canada)"
+            },
+            "de-DE": {
+              "$ref": "#/definitions/apple/AppleInfo",
+              "description": "German"
+            },
+            "el": {
+              "$ref": "#/definitions/apple/AppleInfo",
+              "description": "Greek"
+            },
+            "he": {
+              "$ref": "#/definitions/apple/AppleInfo",
+              "description": "Hebrew"
+            },
+            "hi": {
+              "$ref": "#/definitions/apple/AppleInfo",
+              "description": "Hindi"
+            },
+            "hu": {
+              "$ref": "#/definitions/apple/AppleInfo",
+              "description": "Hungarian"
+            },
+            "id": {
+              "$ref": "#/definitions/apple/AppleInfo",
+              "description": "Indonesian"
+            },
+            "it": {
+              "$ref": "#/definitions/apple/AppleInfo",
+              "description": "Italian"
+            },
+            "ja": {
+              "$ref": "#/definitions/apple/AppleInfo",
+              "description": "Japanese"
+            },
+            "ko": {
+              "$ref": "#/definitions/apple/AppleInfo",
+              "description": "Korean"
+            },
+            "ms": {
+              "$ref": "#/definitions/apple/AppleInfo",
+              "description": "Malay"
+            },
+            "no": {
+              "$ref": "#/definitions/apple/AppleInfo",
+              "description": "Norwegian"
+            },
+            "pl": {
+              "$ref": "#/definitions/apple/AppleInfo",
+              "description": "Polish"
+            },
+            "pt-BR": {
+              "$ref": "#/definitions/apple/AppleInfo",
+              "description": "Portuguese (Brazil)"
+            },
+            "pt-PT": {
+              "$ref": "#/definitions/apple/AppleInfo",
+              "description": "Portuguese (Portugal)"
+            },
+            "ro": {
+              "$ref": "#/definitions/apple/AppleInfo",
+              "description": "Romanian"
+            },
+            "ru": {
+              "$ref": "#/definitions/apple/AppleInfo",
+              "description": "Russian"
+            },
+            "sk": {
+              "$ref": "#/definitions/apple/AppleInfo",
+              "description": "Slovak"
+            },
+            "es-MX": {
+              "$ref": "#/definitions/apple/AppleInfo",
+              "description": "Spanish (Mexico)"
+            },
+            "es-ES": {
+              "$ref": "#/definitions/apple/AppleInfo",
+              "description": "Spanish (Spain)"
+            },
+            "sv": {
+              "$ref": "#/definitions/apple/AppleInfo",
+              "description": "Swedish"
+            },
+            "th": {
+              "$ref": "#/definitions/apple/AppleInfo",
+              "description": "Thai"
+            },
+            "tr": {
+              "$ref": "#/definitions/apple/AppleInfo",
+              "description": "Turkish"
+            },
+            "uk": {
+              "$ref": "#/definitions/apple/AppleInfo",
+              "description": "Ukrainian"
+            },
+            "vi": {
+              "$ref": "#/definitions/apple/AppleInfo",
+              "description": "Vietnamese"
+            }
+          }
+        },
+        "release": {
+          "$ref": "#/definitions/apple/AppleRelease",
+          "description": "Release strategy"
+        },
+        "review": {
+          "$ref": "#/definitions/apple/AppleReview",
+          "description": "Info for the App Store reviewer"
+        }
+      }
+    }
+  },
+  "properties": {
+    "configVersion": {
+      "const": 0,
+      "description": "The EAS metadata store configuration version"
+    },
+    "apple": {
+      "$ref": "#/definitions/AppleConfig"
+    }
+  },
+  "additionalProperties": false,
+  "required": ["configVersion", "apple"]
+}


### PR DESCRIPTION
# Why

We need a way to render the EAS Metadata JSON Schema in our docs. This schema should be the single source of truth for the documentation, just like the app manifest docs.

Unfortunately, due to the complexity of the EAS Metadata schema, we can't reuse the `AppConfigSchemePropertiesTable` to render the JSON Schema.
- [Because we need to list all available localizations for a single object](https://github.com/expo/eas-cli/blob/main/packages/eas-cli/schema/metadata-0.json#L605-L767), it creates a recursive hell, where the referred object is rendered for every localization.

# How

- Copied `eas-metadata.json` as reference schema.
- Added `JsonSchema` components, based on existing `AppConfigSchemePropertiesTable`.

# Test Plan

> This is still in draft. we might take another direction.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
