### PR TITLE
[android][tools] Fix standalone build for sdk 46

### DIFF
--- a/.github/workflows/client-android.yml
+++ b/.github/workflows/client-android.yml
@@ -62,6 +62,7 @@ jobs:
           yarn-tools: 'true'
           gradle: 'true'
           hermes-engine-aar: 'true'
+          ndk: 'true'
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: 🧶 Yarn install

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -193,7 +193,7 @@ dependencies {
   testImplementation 'org.mockito:mockito-core:1.10.19'
 
   /* UNCOMMENT WHEN DISTRIBUTING
-  implementation('host.exp.exponent:expoview:45.0.0@aar') {
+  implementation('host.exp.exponent:expoview:46.0.0@aar') {
     transitive = true
     exclude group: 'com.squareup.okhttp3', module: 'okhttp'
     exclude group: 'com.squareup.okhttp3', module: 'okhttp-urlconnection'

--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -8,7 +8,7 @@ apply from: new File(rootDir, "versioning_linking.gradle")
 // WHEN_VERSIONING_REMOVE_FROM_HERE
 //maven repository info
 group = 'host.exp.exponent'
-version = '45.0.0'
+version = '46.0.0'
 
 // Creating sources with comments
 task androidSourcesJar(type: Jar) {
@@ -281,7 +281,7 @@ dependencies {
   api 'org.webkit:android-jsc:r245459' // needs to be before react-native
 
   /* UNCOMMENT WHEN DISTRIBUTING
-  api 'com.facebook.react:react-native:45.0.0'
+  api 'com.facebook.react:react-native:46.0.0'
   compileOnly project(':expo')
   compileOnly project(':expo-random')
   END UNCOMMENT WHEN DISTRIBUTING */

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentPackage.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentPackage.kt
@@ -223,7 +223,11 @@ class ExponentPackage : ReactPackage {
 
     // Need to avoid initializing duplicated packages
     private val stripePackage = StripeSdkPackage()
-    private val skiaPackageClass = Class.forName("com.shopify.reactnative.skia.RNSkiaPackage")
+    private val skiaPackageClass = try {
+      Class.forName("com.shopify.reactnative.skia.RNSkiaPackage")
+    } catch (e: ClassNotFoundException) {
+      null
+    }
 
     fun kernelExponentPackage(
       context: Context,

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -31,6 +31,8 @@ useExpoModules([
 
 include ':expo'
 project(':expo').projectDir = new File('../packages/expo/android')
+
+useVendoredModulesForSettingsGradle('unversioned')
 END UNCOMMENT WHEN DISTRIBUTING */
 
 

--- a/android/vendored/unversioned/@shopify/flash-list/android/build.gradle
+++ b/android/vendored/unversioned/@shopify/flash-list/android/build.gradle
@@ -69,3 +69,32 @@ dependencies {
     androidTestImplementation("androidx.test:runner:${_androidTestRunnerVersion}")
     androidTestImplementation("androidx.test:rules:${_androidTestRunnerVersion}")
 }
+
+apply plugin: 'maven-publish'
+
+group = 'com.shopify'
+version = '1.1.0'
+
+// Creating sources with comments
+task androidSourcesJar(type: Jar) {
+  classifier = 'sources'
+  from android.sourceSets.main.java.srcDirs
+}
+
+afterEvaluate {
+  publishing {
+    publications {
+      release(MavenPublication) {
+        from components.release
+        artifactId = 'flash-list'
+        // Add additional sourcesJar to artifacts
+        artifact(androidSourcesJar)
+      }
+    }
+    repositories {
+      maven {
+        url = mavenLocal().url
+      }
+    }
+  }
+}

--- a/android/vendored/unversioned/@shopify/react-native-skia/android/build.gradle
+++ b/android/vendored/unversioned/@shopify/react-native-skia/android/build.gradle
@@ -274,3 +274,27 @@ tasks.whenTaskAdded { task ->
     task.dependsOn(":ReactAndroid:copy${currentBuildType}JniLibsProjectOnly")
   }
 }
+
+
+apply plugin: 'maven-publish'
+
+group = 'com.shopify'
+version = '0.1.136'
+
+afterEvaluate {
+  publishing {
+    publications {
+      release(MavenPublication) {
+        from components.release
+        artifactId = 'react-native-skia'
+        // Add additional sourcesJar to artifacts
+        artifact(androidSourcesJar)
+      }
+    }
+    repositories {
+      maven {
+        url = mavenLocal().url
+      }
+    }
+  }
+}

--- a/tools/package.json
+++ b/tools/package.json
@@ -23,7 +23,7 @@
     "@expo/json-file": "^8.2.34",
     "@expo/spawn-async": "^1.6.0",
     "@expo/xcodegen": "2.18.0-patch.1",
-    "@expo/xdl": "^59.2.0",
+    "@expo/xdl": "^59.2.1",
     "@octokit/rest": "^18.12.0",
     "aws-sdk": "^2.814.0",
     "body-parser": "^1.20.0",

--- a/tools/src/commands/AndroidBuildPackages.ts
+++ b/tools/src/commands/AndroidBuildPackages.ts
@@ -46,6 +46,18 @@ const EXPOVIEW_PKG = {
   sourceDir: path.join(ANDROID_DIR, 'expoview'),
   buildDirRelative: path.join('host', 'exp', 'exponent', 'expoview'),
 };
+const VENDORED_PKGS = [
+  {
+    name: 'vendored_unversioned_@shopify_flash-list',
+    sourceDir: path.join(ANDROID_DIR, 'vendored', 'unversioned', '@shopify', 'flash-list'),
+    buildDirRelative: path.join('com', 'shopify'),
+  },
+  {
+    name: 'vendored_unversioned_@shopify_react-native-skia',
+    sourceDir: path.join(ANDROID_DIR, 'vendored', 'unversioned', '@shopify', 'react-native-skia'),
+    buildDirRelative: path.join('com', 'shopify'),
+  },
+];
 
 async function _findUnimodules(pkgDir: string): Promise<Package[]> {
   const unimodules: Package[] = [];
@@ -307,7 +319,12 @@ async function action(options: ActionOptions) {
 
   // packages must stay in this order --
   // ReactAndroid MUST be first and expoview MUST be last
-  const packages: Package[] = [REACT_ANDROID_PKG, ...detachableUniversalModules, EXPOVIEW_PKG];
+  const packages: Package[] = [
+    REACT_ANDROID_PKG,
+    ...detachableUniversalModules,
+    ...VENDORED_PKGS,
+    EXPOVIEW_PKG,
+  ];
   let packagesToBuild: string[] = [];
 
   const expoviewBuildGradle = await fs.readFile(path.join(ANDROID_DIR, 'expoview', 'build.gradle'));

--- a/tools/yarn.lock
+++ b/tools/yarn.lock
@@ -1414,10 +1414,10 @@
   resolved "https://registry.yarnpkg.com/@expo/xcodegen/-/xcodegen-2.18.0-patch.1.tgz#40514e973ee6769e5abd5d1c16d40dbe85c1d9aa"
   integrity sha512-Caz2ChzVe/U3GkaK+DKlXqYorARzLZ1yM6D03LHvasnyA4T+pW6DGXHPy7cfK5AlbsV6Fi5ZtZ9gqW4jGWIFwQ==
 
-"@expo/xdl@^59.2.0":
-  version "59.2.0"
-  resolved "https://registry.yarnpkg.com/@expo/xdl/-/xdl-59.2.0.tgz#2bb1808959a68e27cfad403dbef53b7f86b26d97"
-  integrity sha512-AxWXcK5XiUXEHt7Bo+Nz8BvGhFOriKj1l1os9DOESEfJrLpP5T7i+VkbQ6ueFIZ/DpzZFueSA9J5uAsQppJ6Iw==
+"@expo/xdl@^59.2.1":
+  version "59.2.1"
+  resolved "https://registry.yarnpkg.com/@expo/xdl/-/xdl-59.2.1.tgz#af9b29a494a26817d6f096b808343ef6b16eec6a"
+  integrity sha512-EZmKZc2I3aNpWKw4T+sdmHmPMPdHLnwWJNKUcIjY6yuSVy7fChih0jAKe2Kn0PMy1iO+xRA+NHh5CgN9a7aYFw==
   dependencies:
     "@expo/bunyan" "4.0.0"
     "@expo/config" "3.3.30"


### PR DESCRIPTION
# Why

fix standalone build for sdk 46

# How

- `et android-build-packages` adds vendored modules *@shopify/react-native-skia* and *@shopify/flash-list*
  - add maven publish plugin for *@shopify/react-native-skia* and *@shopify/flash-list*. i don't want to change vendored scripts for that because sdk 46 is the last sdk to support classic build.
- *settings.gradle* and *xdl*: add new vendored modules auto linking support. the xdl change is just to [copy `versioning_linking.gradle`](https://github.com/expo/xdl/commit/afa19b59fde299f64347f9517bd83b83105bde8f)
- opt-out *@shopify/react-native-skia* if it is not a dependency.
  - dynamic import skia package by java reflection
  - xdl pr: https://github.com/expo/xdl/pull/42

# Test Plan

```sh
$ et android-build-packages -p all
$ et android-shell-app --url 'https://staging.exp.host/@kudochien/native-component-list-next' --sdkVersion 46.0.0
```

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- n/a This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
