### PR TITLE
Fix error "provider.credential is not a function"

### DIFF
--- a/docs/pages/guides/authentication.md
+++ b/docs/pages/guides/authentication.md
@@ -1186,7 +1186,6 @@ export default function App() {
 
       /* @info Create a Google credential with the <code>id_token</code> */
       const auth = getAuth();
-      
       const credential = GoogleAuthProvider.credential(id_token);
       /* @end */
       signInWithCredential(auth, credential);

--- a/docs/pages/guides/authentication.md
+++ b/docs/pages/guides/authentication.md
@@ -1186,8 +1186,8 @@ export default function App() {
 
       /* @info Create a Google credential with the <code>id_token</code> */
       const auth = getAuth();
-      const provider = new GoogleAuthProvider();
-      const credential = provider.credential(id_token);
+      
+      const credential = GoogleAuthProvider.credential(id_token);
       /* @end */
       signInWithCredential(auth, credential);
     }


### PR DESCRIPTION
# Why

When using GoogleAuthProvider like the code example

```
const provider = new GoogleAuthProvider();
const credential = provider.credential(id_token);
```
We get the following error "provider.credential is not a function"

![Screenshot 2022-08-05 at 5 14 45 PM](https://user-images.githubusercontent.com/43630417/183197186-fcaa1459-e698-441f-82d5-710b71749260.png)


# Test Plan
By creating creating a new credential using `GoogleAuthProvider.credential(id_token);` we fix the error.

Example
```
const credential = GoogleAuthProvider.credential(id_token);
signInWithCredential(auth, credential);
```

