### PR TITLE
[expo-updates] Clarify spec for assetRequestHeaders

### DIFF
--- a/docs/pages/technical-specs/expo-updates-0.md
+++ b/docs/pages/technical-specs/expo-updates-0.md
@@ -167,13 +167,11 @@ type ManifestExtensions = {
 
 type ExpoAssetHeaderDictionary = {
   [assetKey: string]: {
-    'header-name': 'header-value',
-    ...
+    [headerName: string]: string,
   };
-  ...
 }
 ```
-  * `assetRequestHeaders`: MAY contain an dictionary of header (key, value) pairs to include with asset requests.
+  * `assetRequestHeaders`: MAY contain an dictionary of header (key, value) pairs to include with asset requests. Key and value MUST both be strings.
 
 ## Asset Request
 A conformant client library MUST make a GET request to the asset URLs specified by the manifest. The client library SHOULD include a header accepting the asset's content type as specified in the manifest. Additionally, the client library SHOULD specify the compression encoding the client library is capable of handling.


### PR DESCRIPTION
# Why

A recent crash was caused by a server change not abiding by this updated spec. This PR updates the spec to be more constrained in what is supported.

# How

Update spec.

# Test Plan

N/A