### PR TITLE
[cli] Implement getApplicationIdFromBundle fixing iOS app launch issue with SDK 46

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Prevent development session bad gateway from ending long running `expo start` processes. ([#18451](https://github.com/expo/expo/pull/18451) by [@EvanBacon](https://github.com/EvanBacon))
 - Speed up native device opening for iOS and Android. ([#18385](https://github.com/expo/expo/pull/18385) by [@EvanBacon](https://github.com/EvanBacon))
 - Drop support for experimental Webpack native symbolication. ([#18439](https://github.com/expo/expo/pull/18439) by [@EvanBacon](https://github.com/EvanBacon))
+- Implement getApplicationIdFromBundle fixing iOS app launch issue with SDK 46. ([#18537](https://github.com/expo/expo/pull/18537) by [@Anthony Mittaz](https://github.com/Anthony Mittaz))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/platforms/ios/AppleDeviceManager.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/AppleDeviceManager.ts
@@ -1,12 +1,13 @@
 import * as osascript from '@expo/osascript';
 import assert from 'assert';
 import chalk from 'chalk';
+import fs from 'fs';
 import path from 'path';
 
 import { delayAsync, waitForActionAsync } from '../../../utils/delay';
 import { CommandError } from '../../../utils/errors';
-import { validateUrl } from '../../../utils/url';
 import { parsePlistAsync } from '../../../utils/plist';
+import { validateUrl } from '../../../utils/url';
 import { DeviceManager } from '../DeviceManager';
 import { ExpoGoInstaller } from '../ExpoGoInstaller';
 import { BaseResolveDeviceProps } from '../PlatformManager';
@@ -19,6 +20,8 @@ import {
 } from './getBestSimulator';
 import { promptAppleDeviceAsync } from './promptAppleDevice';
 import * as SimControl from './simctl';
+
+const debug = require('debug')('expo:start:platforms:ios:AppleDeviceManager') as typeof console.log;
 
 const EXPO_GO_BUNDLE_IDENTIFIER = 'host.exp.Exponent';
 
@@ -143,9 +146,15 @@ export class AppleDeviceManager extends DeviceManager<SimControl.Device> {
   }
 
   private async getApplicationIdFromBundle(filePath: string): Promise<string> {
+    debug('getApplicationIdFromBundle:', filePath);
     const builtInfoPlistPath = path.join(filePath, 'Info.plist');
-    const { CFBundleIdentifier } = await parsePlistAsync(builtInfoPlistPath);
-    return CFBundleIdentifier;
+    if (fs.existsSync(builtInfoPlistPath)) {
+      const { CFBundleIdentifier } = await parsePlistAsync(builtInfoPlistPath);
+      debug('getApplicationIdFromBundle: using built Info.plist', CFBundleIdentifier);
+      return CFBundleIdentifier;
+    }
+    debug('getApplicationIdFromBundle: no Info.plist found');
+    return EXPO_GO_BUNDLE_IDENTIFIER;
   }
 
   private async waitForAppInstalledAsync(applicationId: string): Promise<boolean> {

--- a/packages/@expo/cli/src/start/platforms/ios/AppleDeviceManager.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/AppleDeviceManager.ts
@@ -1,10 +1,12 @@
 import * as osascript from '@expo/osascript';
 import assert from 'assert';
 import chalk from 'chalk';
+import path from 'path';
 
 import { delayAsync, waitForActionAsync } from '../../../utils/delay';
 import { CommandError } from '../../../utils/errors';
 import { validateUrl } from '../../../utils/url';
+import { parsePlistAsync } from '../../../utils/plist';
 import { DeviceManager } from '../DeviceManager';
 import { ExpoGoInstaller } from '../ExpoGoInstaller';
 import { BaseResolveDeviceProps } from '../PlatformManager';
@@ -141,8 +143,9 @@ export class AppleDeviceManager extends DeviceManager<SimControl.Device> {
   }
 
   private async getApplicationIdFromBundle(filePath: string): Promise<string> {
-    // TODO: Implement...
-    return EXPO_GO_BUNDLE_IDENTIFIER;
+    const builtInfoPlistPath = path.join(filePath, 'Info.plist');
+    const { CFBundleIdentifier } = await parsePlistAsync(builtInfoPlistPath);
+    return CFBundleIdentifier;
   }
 
   private async waitForAppInstalledAsync(applicationId: string): Promise<boolean> {


### PR DESCRIPTION
# Why

When running `expo run:ios` the app does get installed but not launched inside my current iOS simulator.

Fix:  https://github.com/expo/expo/issues/1853

# How

The method wasn't really implemented.

# Test Plan

Followed reproduction from here: https://github.com/expo/expo/issues/18536

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
