### PR TITLE
[ios][modules] Change native views API to better integrate with Fabric and its recycling mechanism

### DIFF
--- a/packages/expo-modules-core/ios/Swift/Views/ViewDefinition.swift
+++ b/packages/expo-modules-core/ios/Swift/Views/ViewDefinition.swift
@@ -1,0 +1,37 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+/**
+ A component representing the native view to export to React.
+
+ Temporarily it extends the old `ViewManagerDefinition`, but the plan is to replace it entirely.
+ The difference is that the old one allows the user to initialize the view (and pass some custom arguments).
+ To integrate well with Fabric and its recycling mechanism, we have to disallow that and so call the view initializer internally.
+ As a consequence, the user should just provide the type of the view.
+ */
+public final class ViewDefinition: ViewManagerDefinition {
+  init<ViewType>(_ viewType: ViewType.Type, elements: [AnyDefinition]) where ViewType: UIView {
+    let factory = ViewFactory({ ViewType() })
+    super.init(definitions: elements + [factory])
+  }
+}
+
+/**
+ A result builder for the view elements such as prop setters or view events.
+ */
+@resultBuilder
+public struct ViewDefinitionElementsBuilder {
+  // TODO: Restrict the element types to only these that are handled by the ViewComponent
+  public static func buildBlock(_ elements: AnyDefinition...) -> [AnyDefinition] {
+    return elements
+  }
+}
+
+/**
+ Creates a view definition describing the native view exported to React.
+ */
+public func View<ViewType: UIView>(
+  _ viewType: ViewType.Type,
+  @ViewDefinitionElementsBuilder _ elements: @escaping () -> [AnyDefinition]
+) -> ViewDefinition {
+  return ViewDefinition(viewType, elements: elements())
+}

--- a/packages/expo-modules-core/ios/Swift/Views/ViewManagerDefinition.swift
+++ b/packages/expo-modules-core/ios/Swift/Views/ViewManagerDefinition.swift
@@ -3,7 +3,7 @@ import UIKit
 /**
  The definition of the view manager. It's part of the module definition to scope only view-related definitions.
  */
-public final class ViewManagerDefinition: ObjectDefinition {
+public class ViewManagerDefinition: ObjectDefinition {
   /**
    The view factory that lets us create views.
    */


### PR DESCRIPTION
# Why

Fabric, the new architecture of React Native, introduces a new mechanism that recycles native views to be reused in the future. There is one drawback of this feature — the native view basically cannot depend on anything else than props and state. In the old architecture, we had some control on how the native view is initialized, so we could for example pass an instance of the related module, so the view can call its methods. With Fabric, we can't do that because the recycled view might be reused in different context. Reloading the app recreates the modules and so the old references are deallocated, but the pool of recycled views stays untouched, so keeping strong reference to the module instance would result in memory leaks and possibly unexpected behavior.
To better integrate with Fabric and not having to bypass the view recycling mechanism, we need to do similar thing: don't let the library author to initialize the view itself. It needs to be done internally in `expo-modules-core` and always with the initializer without arguments.

This actually can simplify the API a little bit. My proposal is to move away from
```swift
ViewManager {
  View {
    return MyView()
  }
  // ... props
}
```
to
```swift
View(MyView.self) {
  // ... props
}
```

# How

Created a new `ViewDefinition` class that extends existing `ViewManagerDefinition` and makes sure that the provided factory creates the view with a zero-argument initializer.
In the future, we'll deprecate the latter class and move its functionality to `ViewDefinition`.

# Test Plan

I locally changed the definition of `expo-linear-gradient` and it worked. I didn't commit that, because I'd like to keep backwards compatibility at least for one cycle.