### PR TITLE
[keep-awake] Attempt to fix the crash by not referencing the function

### DIFF
--- a/packages/expo-keep-awake/CHANGELOG.md
+++ b/packages/expo-keep-awake/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Attempt to fix `EXC_BAD_ACCESS` and `NSInvalidArgumentException` crashes by not referencing to the class instance function. ([#18553](https://github.com/expo/expo/pull/18553) by [@tsapeta](https://github.com/tsapeta))
+
 ### 💡 Others
 
 ## 10.2.0 — 2022-07-07

--- a/packages/expo-keep-awake/ios/KeepAwakeModule.swift
+++ b/packages/expo-keep-awake/ios/KeepAwakeModule.swift
@@ -8,42 +8,39 @@ public final class KeepAwakeModule: Module {
   public func definition() -> ModuleDefinition {
     Name("ExpoKeepAwake")
 
-    AsyncFunction("activate", activate)
-    AsyncFunction("deactivate", deactivate)
-    AsyncFunction("isActivated", isActivated)
+    AsyncFunction("activate") { (tag: String) -> Bool in
+      if self.activeTags.isEmpty {
+        setActivated(true)
+      }
+      self.activeTags.insert(tag)
+      return true
+    }
+
+    AsyncFunction("deactivate") { (tag: String) -> Bool in
+      self.activeTags.remove(tag)
+      if self.activeTags.isEmpty {
+        setActivated(false)
+      }
+      return true
+    }
+
+    AsyncFunction("isActivated") { () -> Bool in
+      return DispatchQueue.main.sync {
+        return UIApplication.shared.isIdleTimerDisabled
+      }
+    }
 
     OnAppEntersForeground {
       if !self.activeTags.isEmpty {
         setActivated(true)
       }
     }
+
     OnAppEntersBackground {
       if !self.activeTags.isEmpty {
         setActivated(false)
       }
     }
-  }
-
-  private func activate(tag: String) -> Bool {
-    if activeTags.isEmpty {
-      setActivated(true)
-    }
-    activeTags.insert(tag)
-    return true
-  }
-
-  private func deactivate(tag: String) -> Bool {
-    activeTags.remove(tag)
-    if activeTags.isEmpty {
-      setActivated(false)
-    }
-    return true
-  }
-}
-
-private func isActivated() -> Bool {
-  return DispatchQueue.main.sync {
-    return UIApplication.shared.isIdleTimerDisabled
   }
 }
 


### PR DESCRIPTION
# Why

An attempt to fix the crash #18292 
In the keep awake module definition we're passing a reference to the function instead of specifying its own closure (that's what we do in other modules). I'm not sure how this could cause the crash (sounds like only in production builds?), but that's the only thing worth trying that comes to my mind.

# How

Moved `activate`, `deactivate` and `isActivated` from the class instance functions to AsyncFunction closures.

# Test Plan

Examples in test-suite and native-component-list apps work as expected, but we'll need to test this on production to check if it fixes #18292 
