### PR TITLE
[docs][authentication]: Update info regarding expo-facebook

### DIFF
--- a/docs/pages/guides/authentication.md
+++ b/docs/pages/guides/authentication.md
@@ -519,7 +519,7 @@ You must use the proxy service in the Expo Go app because `exp://` cannot be add
 
 #### Custom Apps
 
-Consider using the [`react-native-fbsdk-next`](https://github.com/thebergamo/react-native-fbsdk-next) module, with EAS Build, for native auth as it supports some nonstandard OAuth features implemented by Facebook. 
+Consider using the [`react-native-fbsdk-next`](https://github.com/thebergamo/react-native-fbsdk-next) module with [Config Plugins](/guides/config-plugins/) for native auth as it supports some nonstandard OAuth features implemented by Facebook. 
 
 - The custom scheme provided by Facebook is `fb` followed by the **project ID** (ex: `fb145668956753819`):
 - Add `facebookScheme: 'fb<YOUR FBID>'` to your **app.config.js** or **app.json**. Example: `{ facebookScheme: "fb145668956753819" }` (notice the `fb` prefix).

--- a/docs/pages/guides/authentication.md
+++ b/docs/pages/guides/authentication.md
@@ -519,7 +519,7 @@ You must use the proxy service in the Expo Go app because `exp://` cannot be add
 
 #### Custom Apps
 
-Consider using the [`react-native-fbsdk-next`](https://github.com/thebergamo/react-native-fbsdk-next) module with [Config Plugins](/guides/config-plugins/) for native auth as it supports some nonstandard OAuth features implemented by Facebook. 
+Consider using the [`react-native-fbsdk-next`](https://github.com/thebergamo/react-native-fbsdk-next) module with [Config Plugins](/guides/config-plugins/) for native auth as it supports some nonstandard OAuth features implemented by Facebook.
 
 - The custom scheme provided by Facebook is `fb` followed by the **project ID** (ex: `fb145668956753819`):
 - Add `facebookScheme: 'fb<YOUR FBID>'` to your **app.config.js** or **app.json**. Example: `{ facebookScheme: "fb145668956753819" }` (notice the `fb` prefix).

--- a/docs/pages/guides/authentication.md
+++ b/docs/pages/guides/authentication.md
@@ -519,7 +519,7 @@ You must use the proxy service in the Expo Go app because `exp://` cannot be add
 
 #### Custom Apps
 
-Consider using the [`expo-facebook`](/versions/latest/sdk/facebook) module for native auth as it supports some nonstandard OAuth features implemented by Facebook.
+Consider using the [`react-native-fbsdk-next`](https://github.com/thebergamo/react-native-fbsdk-next) module, with EAS Build, for native auth as it supports some nonstandard OAuth features implemented by Facebook. 
 
 - The custom scheme provided by Facebook is `fb` followed by the **project ID** (ex: `fb145668956753819`):
 - Add `facebookScheme: 'fb<YOUR FBID>'` to your **app.config.js** or **app.json**. Example: `{ facebookScheme: "fb145668956753819" }` (notice the `fb` prefix).


### PR DESCRIPTION
# Why

`expo-facebook` was removed in SDK46

# How

Links to [react-native-fbsdk-next](https://github.com/thebergamo/react-native-fbsdk-next), like`expo-facebook` docs in SDK45 do.

# Test Plan

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
