### PR TITLE
[menu] Fix the duplicated `DevMenuRNGestureHandlerStateManager.h` output file error

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix the duplicated `DevMenuRNGestureHandlerStateManager.h` output file compilation error on iOS.
+- Fix the duplicated `DevMenuRNGestureHandlerStateManager.h` output file compilation error on iOS. ([#18562](https://github.com/expo/expo/pull/18562) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix the duplicated `DevMenuRNGestureHandlerStateManager.h` output file compilation error on iOS.
+
 ### 💡 Others
 
 - Refactored inline Android emulator checks to use enhanced checking in `EmulatorUtilities.isRunningOnEmulator()`. ([#16177](https://github.com/expo/expo/pull/16177)) by [@kbrandwijk](https://github.com/kbrandwijk), [@keith-kurak](https://github.com/keith-kurak))

--- a/packages/expo-dev-menu/vendored/react-native-reanimated/ios/DevMenuRNGestureHandlerStateManager.h
+++ b/packages/expo-dev-menu/vendored/react-native-reanimated/ios/DevMenuRNGestureHandlerStateManager.h
@@ -1,7 +1,0 @@
-// This interface is located in the gesture handler package.
-// We have to remove it from reanimated to avoid duplicate files error.
-//@protocol DevMenuRNGestureHandlerStateManager
-//
-//- (void)setGestureState:(int)state forHandler:(int)handlerTag;
-//
-//@end

--- a/packages/expo-dev-menu/vendored/react-native-reanimated/ios/DevMenuRNGestureHandlerStateManager.h
+++ b/packages/expo-dev-menu/vendored/react-native-reanimated/ios/DevMenuRNGestureHandlerStateManager.h
@@ -1,5 +1,7 @@
-@protocol DevMenuRNGestureHandlerStateManager
-
-- (void)setGestureState:(int)state forHandler:(int)handlerTag;
-
-@end
+// This interface is located in the gesture handler package.
+// We have to remove it from reanimated to avoid duplicate files error.
+//@protocol DevMenuRNGestureHandlerStateManager
+//
+//- (void)setGestureState:(int)state forHandler:(int)handlerTag;
+//
+//@end

--- a/tools/src/commands/Vendor.ts
+++ b/tools/src/commands/Vendor.ts
@@ -28,7 +28,7 @@ const CONFIGURATIONS = {
 
 function getReanimatedPipe() {
   console.warn(
-    'You have to adjust the installation steps of the react-native-reanimated to work well with the react-native-gesture-handler. For more information go to the https://github.com/expo/expo/pull/17878'
+    'You have to adjust the installation steps of the react-native-reanimated to work well with the react-native-gesture-handler. For more information go to the https://github.com/expo/expo/pull/17878 and https://github.com/expo/expo/pull/18562'
   );
   const destination = 'packages/expo-dev-menu/vendored/react-native-reanimated';
 


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/18397.

# How

Removed duplicated header file.

# Test Plan

- compile bare-expo and https://github.com/mlecoq/expoBuildIssue/tree/sdk46