### PR TITLE
[client] Fixed `the function must be called on main queue` error when the app is reloaded from the error screen

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `the function must be called on main queue` error when the app is reload from the error screen on iOS.
+
 ### 💡 Others
 
 - Refactored inline Android emulator checks to use enhanced checking in `EmulatorUtilities.isRunningOnEmulator()`. ([#16177](https://github.com/expo/expo/pull/16177)) by [@kbrandwijk](https://github.com/kbrandwijk), [@keith-kurak](https://github.com/keith-kurak))

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed `the function must be called on main queue` error when the app is reload from the error screen on iOS.
+- Fixed `the function must be called on main queue` error when the app is reload from the error screen on iOS. ([#18563](https://github.com/expo/expo/pull/18563) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -263,6 +263,8 @@
 
 - (void)navigateToLauncher
 {
+  NSAssert([NSThread isMainThread], @"This function must be called on main thread");
+
   [_appBridge invalidate];
   [self invalidateDevMenuApp];
   

--- a/packages/expo-dev-launcher/ios/Errors/EXDevLauncherErrorViewController.swift
+++ b/packages/expo-dev-launcher/ios/Errors/EXDevLauncherErrorViewController.swift
@@ -60,6 +60,8 @@ public class EXDevLauncherErrorViewController: UIViewController, UITableViewData
   }
 
   private func navigateToLauncher() {
-    manager?.controller?.navigateToLauncher()
+    RCTExecuteOnMainQueue { [self]
+      self.manager?.controller?.navigateToLauncher()
+    }
   }
 }


### PR DESCRIPTION
# Why

Closes ENG-5225.
Fixed `the function must be called on main queue` error when the app is reloaded from the error screen

# How

Makes sure that `navigateToLauncher:` is always called on the main thread. 

# Test Plan

- bare-expo