### PR TITLE
[expo-updates] Make extra header processing code consistent between manifests and assets

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - [Android] New logger and log reader for unifying logging support in expo-updates. ([#18318](https://github.com/expo/expo/pull/18318) by [@douglowder](https://github.com/douglowder))
 - Add JS methods to read and clear client logs. ([#18390](https://github.com/expo/expo/pull/18390) by [@douglowder](https://github.com/douglowder))
+- Make extra header processing code consistent between manifests and assets. ([#18564](https://github.com/expo/expo/pull/18564) by [@wschurman](https://github.com/wschurman))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderTest.kt
@@ -124,6 +124,34 @@ class FileDownloaderTest {
   }
 
   @Test
+  @Throws(JSONException::class)
+  fun testAssetExtraHeaders_ObjectTypes() {
+    val configMap = mapOf<String, Any>(
+      "updateUrl" to Uri.parse("https://u.expo.dev/00000000-0000-0000-0000-000000000000"),
+      "runtimeVersion" to "1.0",
+    )
+
+    val config = UpdatesConfiguration(null, configMap)
+
+    val extraHeaders = JSONObject().apply {
+      put("expo-string", "test")
+      put("expo-number", 47.5)
+      put("expo-boolean", true)
+    }
+
+    val assetEntity = AssetEntity("test", "jpg").apply {
+      url = Uri.parse("https://example.com")
+      extraRequestHeaders = extraHeaders
+    }
+
+    // assetRequestHeaders should not be able to override preset headers
+    val actual = FileDownloader.createRequestForAsset(assetEntity, config, context)
+    Assert.assertEquals("test", actual.header("expo-string"))
+    Assert.assertEquals("47.5", actual.header("expo-number"))
+    Assert.assertEquals("true", actual.header("expo-boolean"))
+  }
+
+  @Test
   fun testGetExtraHeaders() {
     mockkObject(ManifestMetadata)
     every { ManifestMetadata.getServerDefinedHeaders(any(), any()) } returns null

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderTest.kt
@@ -69,12 +69,15 @@ class FileDownloaderTest {
       put("expo-string", "test")
       put("expo-number", 47.5)
       put("expo-boolean", true)
+      put("expo-null", JSONObject.NULL)
     }
 
+    // manifest extraHeaders should have their values coerced to strings
     val actual = FileDownloader.createRequestForManifest(config, extraHeaders, context)
     Assert.assertEquals("test", actual.header("expo-string"))
     Assert.assertEquals("47.5", actual.header("expo-number"))
     Assert.assertEquals("true", actual.header("expo-boolean"))
+    Assert.assertEquals("null", actual.header(("expo-null")))
   }
 
   @Test
@@ -137,6 +140,7 @@ class FileDownloaderTest {
       put("expo-string", "test")
       put("expo-number", 47.5)
       put("expo-boolean", true)
+      put("expo-null", JSONObject.NULL)
     }
 
     val assetEntity = AssetEntity("test", "jpg").apply {
@@ -144,11 +148,12 @@ class FileDownloaderTest {
       extraRequestHeaders = extraHeaders
     }
 
-    // assetRequestHeaders should not be able to override preset headers
+    // assetRequestHeaders should have their values coerced to strings
     val actual = FileDownloader.createRequestForAsset(assetEntity, config, context)
     Assert.assertEquals("test", actual.header("expo-string"))
     Assert.assertEquals("47.5", actual.header("expo-number"))
     Assert.assertEquals("true", actual.header("expo-boolean"))
+    Assert.assertEquals("null", actual.header("expo-null"))
   }
 
   @Test

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
@@ -624,6 +624,8 @@ certificateChainFromManifestResponse:(nullable NSString *)certificateChainFromMa
       } else {
         [request setValue:((NSNumber *)value).stringValue forHTTPHeaderField:key];
       }
+    } else if ([value isKindOfClass:[NSNull class]]) {
+      [request setValue:@"null" forHTTPHeaderField:key];
     } else {
       [request setValue:[(NSObject *)value description] forHTTPHeaderField:key];
     }

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
@@ -609,12 +609,31 @@ certificateChainFromManifestResponse:(nullable NSString *)certificateChainFromMa
   return nil;
 }
 
++ (void)_setHTTPHeaderFields:(nullable NSDictionary *)headers onRequest:(NSMutableURLRequest *)request {
+  if (!headers) {
+    return;
+  }
+  
+  for (NSString *key in headers) {
+    id value = headers[key];
+    if ([value isKindOfClass:[NSString class]]) {
+      [request setValue:value forHTTPHeaderField:key];
+    } else if ([value isKindOfClass:[NSNumber class]]) {
+      if (CFGetTypeID((__bridge CFTypeRef)(value)) == CFBooleanGetTypeID()) {
+        [request setValue:((NSNumber *)value).boolValue ? @"true" : @"false" forHTTPHeaderField:key];
+      } else {
+        [request setValue:((NSNumber *)value).stringValue forHTTPHeaderField:key];
+      }
+    } else {
+      [request setValue:[(NSObject *)value description] forHTTPHeaderField:key];
+    }
+  }
+}
+
 - (void)_setHTTPHeaderFields:(NSMutableURLRequest *)request
                 extraHeaders:(NSDictionary *)extraHeaders
 {
-  for (NSString *key in extraHeaders) {
-    [request setValue:extraHeaders[key] forHTTPHeaderField:key];
-  }
+  [EXUpdatesFileDownloader _setHTTPHeaderFields:extraHeaders onRequest:request];
 
   [request setValue:@"ios" forHTTPHeaderField:@"Expo-Platform"];
   [request setValue:@"1" forHTTPHeaderField:@"Expo-API-Version"];
@@ -629,22 +648,7 @@ certificateChainFromManifestResponse:(nullable NSString *)certificateChainFromMa
 - (void)_setManifestHTTPHeaderFields:(NSMutableURLRequest *)request withExtraHeaders:(nullable NSDictionary *)extraHeaders
 {
   // apply extra headers before anything else, so they don't override preset headers
-  if (extraHeaders) {
-    for (NSString *key in extraHeaders) {
-      id value = extraHeaders[key];
-      if ([value isKindOfClass:[NSString class]]) {
-        [request setValue:value forHTTPHeaderField:key];
-      } else if ([value isKindOfClass:[NSNumber class]]) {
-        if (CFGetTypeID((__bridge CFTypeRef)(value)) == CFBooleanGetTypeID()) {
-          [request setValue:((NSNumber *)value).boolValue ? @"true" : @"false" forHTTPHeaderField:key];
-        } else {
-          [request setValue:((NSNumber *)value).stringValue forHTTPHeaderField:key];
-        }
-      } else {
-        [request setValue:[(NSObject *)value description] forHTTPHeaderField:key];
-      }
-    }
-  }
+  [EXUpdatesFileDownloader _setHTTPHeaderFields:extraHeaders onRequest:request];
 
   [request setValue:@"multipart/mixed,application/expo+json,application/json" forHTTPHeaderField:@"Accept"];
   [request setValue:@"ios" forHTTPHeaderField:@"Expo-Platform"];

--- a/packages/expo-updates/ios/Tests/EXUpdatesFileDownloaderTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesFileDownloaderTests.m
@@ -148,4 +148,24 @@
   XCTAssertEqualObjects(@"custom", [actual valueForHTTPHeaderField:@"expo-updates-environment"]);
 }
 
+- (void)testAssetExtraHeaders_ObjectTypes
+{
+  EXUpdatesConfig *config = [EXUpdatesConfig configWithDictionary:@{
+    EXUpdatesConfigUpdateUrlKey: @"https://u.expo.dev/00000000-0000-0000-0000-000000000000",
+    EXUpdatesConfigRuntimeVersionKey: @"1.0"
+  }];
+  EXUpdatesFileDownloader *downloader = [[EXUpdatesFileDownloader alloc] initWithUpdatesConfig:config];
+
+  NSDictionary *extraHeaders = @{
+    @"expo-string": @"test",
+    @"expo-number": @(47.5),
+    @"expo-boolean": @YES
+  };
+
+  NSURLRequest *actual = [downloader createGenericRequestWithURL:[NSURL URLWithString:@"https://u.expo.dev/00000000-0000-0000-0000-000000000000"] extraHeaders:extraHeaders];
+  XCTAssertEqualObjects(@"test", [actual valueForHTTPHeaderField:@"expo-string"]);
+  XCTAssertEqualObjects(@"47.5", [actual valueForHTTPHeaderField:@"expo-number"]);
+  XCTAssertEqualObjects(@"true", [actual valueForHTTPHeaderField:@"expo-boolean"]);
+}
+
 @end

--- a/packages/expo-updates/ios/Tests/EXUpdatesFileDownloaderTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesFileDownloaderTests.m
@@ -45,17 +45,19 @@
     EXUpdatesConfigRuntimeVersionKey: @"1.0"
   }];
   EXUpdatesFileDownloader *downloader = [[EXUpdatesFileDownloader alloc] initWithUpdatesConfig:config];
-
+  
   NSDictionary *extraHeaders = @{
     @"expo-string": @"test",
     @"expo-number": @(47.5),
-    @"expo-boolean": @YES
+    @"expo-boolean": @YES,
+    @"expo-null": NSNull.null
   };
 
   NSURLRequest *actual = [downloader createManifestRequestWithURL:[NSURL URLWithString:@"https://u.expo.dev/00000000-0000-0000-0000-000000000000"] extraHeaders:extraHeaders];
   XCTAssertEqualObjects(@"test", [actual valueForHTTPHeaderField:@"expo-string"]);
   XCTAssertEqualObjects(@"47.5", [actual valueForHTTPHeaderField:@"expo-number"]);
   XCTAssertEqualObjects(@"true", [actual valueForHTTPHeaderField:@"expo-boolean"]);
+  XCTAssertEqualObjects(@"null", [actual valueForHTTPHeaderField:@"expo-null"]);
 }
 
 - (void)testExtraHeaders_OverrideOrder
@@ -159,13 +161,15 @@
   NSDictionary *extraHeaders = @{
     @"expo-string": @"test",
     @"expo-number": @(47.5),
-    @"expo-boolean": @YES
+    @"expo-boolean": @YES,
+    @"expo-null": NSNull.null
   };
 
   NSURLRequest *actual = [downloader createGenericRequestWithURL:[NSURL URLWithString:@"https://u.expo.dev/00000000-0000-0000-0000-000000000000"] extraHeaders:extraHeaders];
   XCTAssertEqualObjects(@"test", [actual valueForHTTPHeaderField:@"expo-string"]);
   XCTAssertEqualObjects(@"47.5", [actual valueForHTTPHeaderField:@"expo-number"]);
   XCTAssertEqualObjects(@"true", [actual valueForHTTPHeaderField:@"expo-boolean"]);
+  XCTAssertEqualObjects(@"null", [actual valueForHTTPHeaderField:@"expo-null"]);
 }
 
 @end


### PR DESCRIPTION
# Why

The code for manifest extra headers has always had methods for coercing into strings. The asset extra header code diverged from this (from the time it was added).

# How

Make extra header processing code the same for all requests.

# Test Plan

Run tests.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
