### PR TITLE
[sweet API][Kotlin] Renam `AnyTypedArray` -> `TypedArray`

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptTypedArray.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptTypedArray.kt
@@ -2,7 +2,7 @@ package expo.modules.kotlin.jni
 
 import com.facebook.jni.HybridData
 import expo.modules.core.interfaces.DoNotStrip
-import expo.modules.kotlin.typedarray.AnyTypedArray
+import expo.modules.kotlin.typedarray.TypedArray
 import java.nio.ByteBuffer
 
 private var nextValue = 1
@@ -26,7 +26,7 @@ enum class TypedArrayKind(val value: Int = nextValue()) {
 @Suppress("KotlinJniMissingFunction")
 @DoNotStrip
 class JavaScriptTypedArray @DoNotStrip constructor(hybridData: HybridData) :
-  JavaScriptObject(hybridData), AnyTypedArray {
+  JavaScriptObject(hybridData), TypedArray {
 
   override val kind: TypedArrayKind by lazy {
     val rawKind = getRawKind()

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/typedarray/ConcreteTypedArrays.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/typedarray/ConcreteTypedArrays.kt
@@ -3,14 +3,14 @@ package expo.modules.kotlin.typedarray
 import expo.modules.kotlin.jni.JavaScriptTypedArray
 
 @Suppress("NOTHING_TO_INLINE")
-private inline fun AnyTypedArray.checkIfInRange(index: Int) {
+private inline fun TypedArray.checkIfInRange(index: Int) {
   if (index < 0 || index >= length) {
     throw IndexOutOfBoundsException()
   }
 }
 
 class Int8Array(private val rawArray: JavaScriptTypedArray) :
-  AnyTypedArray by rawArray, GenericTypedArray<Byte> {
+  TypedArray by rawArray, GenericTypedArray<Byte> {
   override operator fun get(index: Int): Byte {
     checkIfInRange(index)
     return readByte(index * Byte.SIZE_BYTES)
@@ -23,7 +23,7 @@ class Int8Array(private val rawArray: JavaScriptTypedArray) :
 }
 
 class Int16Array(private val rawArray: JavaScriptTypedArray) :
-  AnyTypedArray by rawArray, GenericTypedArray<Short> {
+  TypedArray by rawArray, GenericTypedArray<Short> {
   override operator fun get(index: Int): Short {
     checkIfInRange(index)
     return read2Byte(index * Short.SIZE_BYTES)
@@ -36,7 +36,7 @@ class Int16Array(private val rawArray: JavaScriptTypedArray) :
 }
 
 class Int32Array(private val rawArray: JavaScriptTypedArray) :
-  AnyTypedArray by rawArray, GenericTypedArray<Int> {
+  TypedArray by rawArray, GenericTypedArray<Int> {
   override operator fun get(index: Int): Int {
     checkIfInRange(index)
     return read4Byte(index * Int.SIZE_BYTES)
@@ -49,7 +49,7 @@ class Int32Array(private val rawArray: JavaScriptTypedArray) :
 }
 
 class Uint8Array(private val rawArray: JavaScriptTypedArray) :
-  AnyTypedArray by rawArray, GenericTypedArray<UByte> {
+  TypedArray by rawArray, GenericTypedArray<UByte> {
   override operator fun get(index: Int): UByte {
     checkIfInRange(index)
     return readByte(index * UByte.SIZE_BYTES).toUByte()
@@ -62,7 +62,7 @@ class Uint8Array(private val rawArray: JavaScriptTypedArray) :
 }
 
 class Uint8ClampedArray(private val rawArray: JavaScriptTypedArray) :
-  AnyTypedArray by rawArray, GenericTypedArray<UByte> {
+  TypedArray by rawArray, GenericTypedArray<UByte> {
   override operator fun get(index: Int): UByte {
     checkIfInRange(index)
     return readByte(index * UByte.SIZE_BYTES).toUByte()
@@ -75,7 +75,7 @@ class Uint8ClampedArray(private val rawArray: JavaScriptTypedArray) :
 }
 
 class Uint16Array(private val rawArray: JavaScriptTypedArray) :
-  AnyTypedArray by rawArray, GenericTypedArray<UShort> {
+  TypedArray by rawArray, GenericTypedArray<UShort> {
   override operator fun get(index: Int): UShort {
     checkIfInRange(index)
     return read2Byte(index * UShort.SIZE_BYTES).toUShort()
@@ -88,7 +88,7 @@ class Uint16Array(private val rawArray: JavaScriptTypedArray) :
 }
 
 class Uint32Array(private val rawArray: JavaScriptTypedArray) :
-  AnyTypedArray by rawArray, GenericTypedArray<UInt> {
+  TypedArray by rawArray, GenericTypedArray<UInt> {
   override operator fun get(index: Int): UInt {
     checkIfInRange(index)
     return read4Byte(index * UInt.SIZE_BYTES).toUInt()
@@ -101,7 +101,7 @@ class Uint32Array(private val rawArray: JavaScriptTypedArray) :
 }
 
 class Float32Array(private val rawArray: JavaScriptTypedArray) :
-  AnyTypedArray by rawArray, GenericTypedArray<Float> {
+  TypedArray by rawArray, GenericTypedArray<Float> {
   override operator fun get(index: Int): Float {
     checkIfInRange(index)
     return readFloat(index * Float.SIZE_BYTES)
@@ -114,7 +114,7 @@ class Float32Array(private val rawArray: JavaScriptTypedArray) :
 }
 
 class Float64Array(private val rawArray: JavaScriptTypedArray) :
-  AnyTypedArray by rawArray, GenericTypedArray<Double> {
+  TypedArray by rawArray, GenericTypedArray<Double> {
 
   override operator fun get(index: Int): Double {
     checkIfInRange(index)
@@ -128,7 +128,7 @@ class Float64Array(private val rawArray: JavaScriptTypedArray) :
 }
 
 class BigInt64Array(private val rawArray: JavaScriptTypedArray) :
-  AnyTypedArray by rawArray, GenericTypedArray<Long> {
+  TypedArray by rawArray, GenericTypedArray<Long> {
   override operator fun get(index: Int): Long {
     checkIfInRange(index)
     return read8Byte(index * Long.SIZE_BYTES)
@@ -141,7 +141,7 @@ class BigInt64Array(private val rawArray: JavaScriptTypedArray) :
 }
 
 class BigUint64Array(private val rawArray: JavaScriptTypedArray) :
-  AnyTypedArray by rawArray, GenericTypedArray<ULong> {
+  TypedArray by rawArray, GenericTypedArray<ULong> {
   override operator fun get(index: Int): ULong {
     checkIfInRange(index)
     return read8Byte(index * ULong.SIZE_BYTES).toULong()

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/typedarray/GenericTypedArray.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/typedarray/GenericTypedArray.kt
@@ -1,6 +1,6 @@
 package expo.modules.kotlin.typedarray
 
-interface GenericTypedArray<T> : AnyTypedArray, Iterable<T> {
+interface GenericTypedArray<T> : TypedArray, Iterable<T> {
   operator fun get(index: Int): T
   operator fun set(index: Int, value: T)
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/typedarray/TypedArray.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/typedarray/TypedArray.kt
@@ -3,7 +3,10 @@ package expo.modules.kotlin.typedarray
 import expo.modules.kotlin.jni.TypedArrayKind
 import java.nio.ByteBuffer
 
-interface AnyTypedArray {
+/**
+ * The base interface for any type of the typed array.
+ */
+interface TypedArray {
   /**
    * Returns the kind of the typed array, such as `Int8Array` or `Float32Array`.
    */

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/BasicTypeConverters.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/BasicTypeConverters.kt
@@ -14,7 +14,7 @@ import expo.modules.kotlin.typedarray.Int8Array
 import expo.modules.kotlin.jni.JavaScriptObject
 import expo.modules.kotlin.jni.JavaScriptTypedArray
 import expo.modules.kotlin.jni.JavaScriptValue
-import expo.modules.kotlin.typedarray.AnyTypedArray
+import expo.modules.kotlin.typedarray.TypedArray
 import expo.modules.kotlin.typedarray.Uint16Array
 import expo.modules.kotlin.typedarray.Uint32Array
 import expo.modules.kotlin.typedarray.Uint8Array
@@ -120,7 +120,7 @@ class JavaScriptObjectTypeConverter(isOptional: Boolean) : TypeConverter<JavaScr
   override fun getCppRequiredTypes(): List<CppType> = listOf(CppType.JS_OBJECT)
 }
 
-abstract class BaseTypeArrayConverter<T : AnyTypedArray>(isOptional: Boolean) : TypeConverter<T>(isOptional) {
+abstract class BaseTypeArrayConverter<T : TypedArray>(isOptional: Boolean) : TypeConverter<T>(isOptional) {
   abstract fun wrapJavaScriptTypedArray(value: JavaScriptTypedArray): T
 
   override fun convertNonOptional(value: Any): T = wrapJavaScriptTypedArray(value as JavaScriptTypedArray)
@@ -172,6 +172,6 @@ class BigUint64ArrayTypeConverter(isOptional: Boolean) : BaseTypeArrayConverter<
   override fun wrapJavaScriptTypedArray(value: JavaScriptTypedArray) = BigUint64Array(value)
 }
 
-class TypedArrayTypeConverter(isOptional: Boolean) : BaseTypeArrayConverter<AnyTypedArray>(isOptional) {
-  override fun wrapJavaScriptTypedArray(value: JavaScriptTypedArray): AnyTypedArray = value
+class TypedArrayTypeConverter(isOptional: Boolean) : BaseTypeArrayConverter<TypedArray>(isOptional) {
+  override fun wrapJavaScriptTypedArray(value: JavaScriptTypedArray): TypedArray = value
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
@@ -15,7 +15,7 @@ import expo.modules.kotlin.typedarray.Int32Array
 import expo.modules.kotlin.typedarray.Int8Array
 import expo.modules.kotlin.jni.JavaScriptObject
 import expo.modules.kotlin.jni.JavaScriptValue
-import expo.modules.kotlin.typedarray.AnyTypedArray
+import expo.modules.kotlin.typedarray.TypedArray
 import expo.modules.kotlin.typedarray.Uint16Array
 import expo.modules.kotlin.typedarray.Uint32Array
 import expo.modules.kotlin.typedarray.Uint8Array
@@ -144,7 +144,7 @@ object TypeConverterProviderImpl : TypeConverterProvider {
       Float64Array::class.createType(nullable = isOptional) to Float64ArrayTypeConverter(isOptional),
       BigInt64Array::class.createType(nullable = isOptional) to BigInt64ArrayTypeConverter(isOptional),
       BigUint64Array::class.createType(nullable = isOptional) to BigUint64ArrayTypeConverter(isOptional),
-      AnyTypedArray::class.createType(nullable = isOptional) to TypedArrayTypeConverter(isOptional),
+      TypedArray::class.createType(nullable = isOptional) to TypedArrayTypeConverter(isOptional),
 
       Any::class.createType(nullable = isOptional) to AnyTypeConverter(isOptional),
     )


### PR DESCRIPTION
# Why

Replaces `AnyTypedArray` with `TypedArray`.

# How

Align with naming on the iOS.