### PR TITLE
[sweet API] Throw missing exceptions

### DIFF
--- a/packages/expo-modules-core/android/src/main/cpp/Exceptions.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/Exceptions.cpp
@@ -17,7 +17,8 @@ std::string CodedException::getCode() {
 }
 
 std::optional<std::string> CodedException::getLocalizedMessage() {
-  const auto getLocalizedMessage = this->getClass()->getMethod<jni::JString()>("getLocalizedMessage");
+  const auto getLocalizedMessage = this->getClass()
+    ->getMethod<jni::JString()>("getLocalizedMessage");
   const auto message = getLocalizedMessage(this->self());
   if (message != nullptr) {
     return message->toStdString();
@@ -33,6 +34,12 @@ jni::local_ref<JavaScriptEvaluateException> JavaScriptEvaluateException::create(
   return JavaScriptEvaluateException::newInstance(
     jni::make_jstring(message),
     jni::make_jstring(jsStack)
+  );
+}
+
+jni::local_ref<UnexpectedException> UnexpectedException::create(const std::string &message) {
+  return UnexpectedException::newInstance(
+    jni::make_jstring(message)
   );
 }
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/Exceptions.h
+++ b/packages/expo-modules-core/android/src/main/cpp/Exceptions.h
@@ -41,4 +41,17 @@ public:
     const std::string &jsStack
   );
 };
+
+/**
+ * A convenient wrapper for the Kotlin UnexpectedException.
+ */
+class UnexpectedException
+  : public jni::JavaClass<UnexpectedException, CodedException> {
+public:
+  static auto constexpr kJavaDescriptor = "Lexpo/modules/kotlin/exception/UnexpectedException;";
+
+  static jni::local_ref<UnexpectedException> create(
+    const std::string &message
+  );
+};
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptValue.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptValue.cpp
@@ -6,6 +6,7 @@
 #include "JavaScriptObject.h"
 #include "JavaScriptTypedArray.h"
 #include "TypedArray.h"
+#include "Exceptions.h"
 
 namespace expo {
 void JavaScriptValue::registerNatives() {
@@ -77,8 +78,9 @@ std::string JavaScriptValue::kind() {
     return "object";
   }
 
-  // TODO(@lukmccall): maybe throw exception?
-  return "unknown";
+  jni::throwNewJavaException(
+    UnexpectedException::create("Unknown type").get()
+  );
 }
 
 bool JavaScriptValue::isNull() {
@@ -178,6 +180,7 @@ jni::local_ref<jstring> JavaScriptValue::jniKind() {
   auto result = kind();
   return jni::make_jstring(result);
 }
+
 jni::local_ref<jstring> JavaScriptValue::jniGetString() {
   auto result = getString();
   return jni::make_jstring(result);

--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
@@ -150,8 +150,11 @@ std::vector<jvalue> MethodMetadata::convertJSIArgsToJNI(
           react::ReadableNativeMap::createWithContents(std::move(dynamic)).release());
       }
     } else {
-      // TODO(@lukmccall): throw an exception
-      jarg->l = nullptr;
+      auto stringRepresentation = arg->toString(rt).utf8(rt);
+      jni::throwNewJavaException(
+        UnexpectedException::create(
+          "Cannot convert " + stringRepresentation + " to a Kotlin type.").get()
+      );
     }
   }
 

--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
@@ -153,7 +153,7 @@ std::vector<jvalue> MethodMetadata::convertJSIArgsToJNI(
       auto stringRepresentation = arg->toString(rt).utf8(rt);
       jni::throwNewJavaException(
         UnexpectedException::create(
-          "Cannot convert " + stringRepresentation + " to a Kotlin type.").get()
+          "Cannot convert '" + stringRepresentation + "' to a Kotlin type.").get()
       );
     }
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
@@ -88,8 +88,14 @@ internal class NullArgumentException :
 internal class FieldRequiredException(property: KProperty1<*, *>) :
   CodedException(message = "Value for field '$property' is required, got nil")
 
-internal class UnexpectedException(val throwable: Throwable) :
-  CodedException(message = throwable.toString(), throwable)
+@DoNotStrip
+class UnexpectedException(
+  message: String?,
+  cause: Throwable? = null
+) : CodedException(message = message, cause) {
+  constructor(throwable: Throwable) : this(throwable.toString(), throwable)
+  constructor(message: String) : this(message, null)
+}
 
 internal class ValidationException(message: String) :
   CodedException(message = message)
@@ -159,7 +165,7 @@ class JavaScriptEvaluateException(
   val jsStack: String
 ) : CodedException(
   message = """
-  Cannot evaluate JavaScript code: $message.
+  Cannot evaluate JavaScript code: $message${if (message.lastOrNull() == '.') "" else "."}
   $jsStack
   """.trimIndent()
 )

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
@@ -165,7 +165,7 @@ class JavaScriptEvaluateException(
   val jsStack: String
 ) : CodedException(
   message = """
-  Cannot evaluate JavaScript code: $message${if (message.lastOrNull() == '.') "" else "."}
+  Cannot evaluate JavaScript code: $message
   $jsStack
   """.trimIndent()
 )


### PR DESCRIPTION
# Why

I forgot to throw exceptions in two corner cases:
- when js type is not convertible to a Kotlin object - like Symbol
- when the js value has an unknown type

# How

- Exported `UnknownException` to the C++.
- Add missing exceptions.

# Test Plan

- unit tests that will be added in a separate PR