### PR TITLE
[autolinking] Fix node resolution error when executed from scripts

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed node executable resolution errors on iOS when `pod install` is executed from package.json `scripts`. ([#18580](https://github.com/expo/expo/pull/18580) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 0.10.1 — 2022-07-25

--- a/packages/expo-modules-autolinking/scripts/ios/xcode_env_generator.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/xcode_env_generator.rb
@@ -10,7 +10,7 @@ def maybe_generate_xcode_env_file!()
   end
 
   # Adding the meta character `;` at the end of command for Ruby `Kernel.exec` to execute the command in shell.
-  stdout, stderr, status = Open3.capture3('command -v node;')
+  stdout, stderr, status = Open3.capture3('node --print "process.argv[0]";')
   node_path = stdout.strip
   if !stderr.empty? || status.exitstatus != 0 || node_path.empty?
     Pod::UI.warn "Unable to generate `.xcode.env.local` for Node.js binary path: #{stderr}"


### PR DESCRIPTION
# Why

fix https://github.com/expo/expo/pull/18330#issuecomment-1208645614

# How

when executed from package.json `scripts`, the *node* from `command -v node` is actually a wrapper to temp file, e.g.
*/var/folders/yw/6bx918xn4671rggfcdxz7fph0000gn/T/yarn--1660058355887-0.20052152174853344/node*
```
#!/bin/sh

exec "/Users/kudo/.volta/tools/image/node/16.16.0/bin/node" "$@"
```
the temp wrapper file may be purged soon after prebuild completed.

the pr changes the `command -v node` to `node --print "process.argv[0]"` when generating the *.xcode.env.local* content. it should be the final node path. even though it's slightly different for my setup, e.g. volta: `/Users/kudo/.volta/bin/volta` -> `/Users/kudo/.volta/tools/image/node/16.16.0/bin/node` where it was originally pointed to volta wrapper path and now to final node executable. that should be fine for pointing to final node executable path though.

# Test Plan

```
yarn create expo-app -t blank@sdk-46 sdk46
# add `"prebuild": "npx expo prebuild -p ios --clean"` to package.json *scripts* field
yarn prebuild
# verify the content of .xcode.env.local
```

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
