### PR TITLE
fix(cli): fix rudderstack anonymous ID generation in dev-client start command

### DIFF
--- a/packages/@expo/cli/src/start/startAsync.ts
+++ b/packages/@expo/cli/src/start/startAsync.ts
@@ -3,7 +3,7 @@ import chalk from 'chalk';
 
 import * as Log from '../log';
 import getDevClientProperties from '../utils/analytics/getDevClientProperties';
-import { logEvent } from '../utils/analytics/rudderstackClient';
+import { logEventAsync } from '../utils/analytics/rudderstackClient';
 import { installExitHooks } from '../utils/exit';
 import { isInteractive } from '../utils/interactive';
 import { profile } from '../utils/profile';
@@ -103,7 +103,7 @@ export async function startAsync(
   // Some tracking thing
 
   if (options.devClient) {
-    track(projectRoot, exp);
+    await trackAsync(projectRoot, exp);
   }
 
   await profile(devServerManager.startAsync.bind(devServerManager))(startOptions);
@@ -133,13 +133,13 @@ export async function startAsync(
   );
 }
 
-function track(projectRoot: string, exp: ExpoConfig) {
-  logEvent('dev client start command', {
+async function trackAsync(projectRoot: string, exp: ExpoConfig): Promise<void> {
+  await logEventAsync('dev client start command', {
     status: 'started',
     ...getDevClientProperties(projectRoot, exp),
   });
-  installExitHooks(() => {
-    logEvent('dev client start command', {
+  installExitHooks(async () => {
+    await logEventAsync('dev client start command', {
       status: 'finished',
       ...getDevClientProperties(projectRoot, exp),
     });

--- a/packages/@expo/cli/src/utils/analytics/__tests__/rudderstackClient-test.ts
+++ b/packages/@expo/cli/src/utils/analytics/__tests__/rudderstackClient-test.ts
@@ -3,7 +3,7 @@ import os from 'os';
 import {
   getContext,
   getRudderAnalyticsClient,
-  logEvent,
+  logEventAsync,
   setUserDataAsync,
 } from '../rudderstackClient';
 
@@ -11,20 +11,20 @@ jest.mock('ci-info', () => ({ isCI: true, isPR: true, name: 'GitHub Actions' }))
 
 jest.mock('@expo/rudder-sdk-node');
 
-describe(logEvent, () => {
+describe(logEventAsync, () => {
   // order of these tests matters since the module retains state
 
-  it('does not log when the user has not been identified', () => {
-    logEvent('Start Project');
+  it('does not log when the user has not been identified', async () => {
+    await logEventAsync('Start Project');
     expect(getRudderAnalyticsClient().track).not.toHaveBeenCalled();
   });
 
   it('logs when the user has been identified', async () => {
     await setUserDataAsync('fake', {});
-    logEvent('Start Project');
+    await logEventAsync('Start Project');
     expect(getRudderAnalyticsClient().track).toHaveBeenCalledWith({
       anonymousId: expect.any(String),
-      context: expect.any(Object),
+      context: getContext(),
       event: 'Start Project',
       properties: { source: 'expo', source_version: undefined },
       userId: 'fake',

--- a/packages/@expo/cli/src/utils/analytics/__tests__/rudderstackClient-test.ts
+++ b/packages/@expo/cli/src/utils/analytics/__tests__/rudderstackClient-test.ts
@@ -4,6 +4,7 @@ import {
   getContext,
   getRudderAnalyticsClient,
   logEventAsync,
+  resetInternalStateForTesting,
   setUserDataAsync,
 } from '../rudderstackClient';
 
@@ -12,11 +13,8 @@ jest.mock('ci-info', () => ({ isCI: true, isPR: true, name: 'GitHub Actions' }))
 jest.mock('@expo/rudder-sdk-node');
 
 describe(logEventAsync, () => {
-  // order of these tests matters since the module retains state
-
-  it('does not log when the user has not been identified', async () => {
-    await logEventAsync('Start Project');
-    expect(getRudderAnalyticsClient().track).not.toHaveBeenCalled();
+  beforeEach(() => {
+    resetInternalStateForTesting();
   });
 
   it('logs when the user has been identified', async () => {
@@ -29,6 +27,11 @@ describe(logEventAsync, () => {
       properties: { source: 'expo', source_version: undefined },
       userId: 'fake',
     });
+  });
+
+  it('does not log when the user has not been identified', async () => {
+    await logEventAsync('Start Project');
+    expect(getRudderAnalyticsClient().track).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/@expo/cli/src/utils/analytics/rudderstackClient.ts
+++ b/packages/@expo/cli/src/utils/analytics/rudderstackClient.ts
@@ -67,29 +67,9 @@ type Event =
   | 'dev client start command'
   | 'dev client run command';
 
-export function logEvent(event: Event, properties: Record<string, any> = {}): void {
-  if (env.EXPO_NO_TELEMETRY) {
-    return;
-  }
-
-  identifyIfNotYetIdentified();
-
-  if (!identifyData) {
-    return;
-  }
-  const { userId, deviceId } = identifyData;
-  const commonEventProperties = { source_version: process.env.__EXPO_VERSION, source: 'expo' };
-
-  const identity = { userId, anonymousId: deviceId };
-  getRudderAnalyticsClient().track({
-    event,
-    properties: { ...properties, ...commonEventProperties },
-    ...identity,
-    context: getContext(),
-  });
-}
-
-/** Log event while ensuring the user is identified. */
+/**
+ * Log an event, ensuring the user is identified before logging the event.
+ **/
 export async function logEventAsync(
   event: Event,
   properties: Record<string, any> = {}

--- a/packages/@expo/cli/src/utils/analytics/rudderstackClient.ts
+++ b/packages/@expo/cli/src/utils/analytics/rudderstackClient.ts
@@ -20,6 +20,12 @@ let identifyData: {
   traits: Record<string, any>;
 } | null = null;
 
+export function resetInternalStateForTesting() {
+  identified = false;
+  identifyData = null;
+  client = null;
+}
+
 export function getRudderAnalyticsClient(): RudderAnalytics {
   if (client) {
     return client;


### PR DESCRIPTION
# Why

We're seeing a spike in anonymous IDs for our metrics. This is probably due to `logEvent` being called (it's only called in one place) without having required auth first.

# How

The short-term fix proposed in this PR is to not log in cases where the user wasn't required to have auth'ed.

# Test Plan

1. `yarn build` in this package
2. `rm -rf ~/.expo` to clear any unique identifier previously generated.
3. In some expo app, run `nexpo start --dev-client`, see via temporary console.log that this would historically have used a random UUID for each time this is run. Now, see that it doesn't log.

Also run new test.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
