### PR TITLE
[docs][bar-code-scanner]: Fix snack example

### DIFF
--- a/docs/pages/versions/unversioned/sdk/bar-code-scanner.md
+++ b/docs/pages/versions/unversioned/sdk/bar-code-scanner.md
@@ -47,7 +47,8 @@ In managed apps, scanning barcodes with the camera requires the [`Permission.CAM
 | upc_ean         | No    | Yes         |
 | qr              | Yes   | Yes         |
 
-> __Notes:__
+> **Notes:**
+>
 > - When an ITF-14 barcode is recognized, it's type can sometimes be set to `interleaved2of5`.
 > - Scanning for either `PDF417` and/or `Code39` formats can result in a noticeable increase in battery consumption on iOS. It is recommended to provide only the bar code formats you expect to scan to the `barCodeTypes` prop.
 
@@ -70,9 +71,9 @@ export default function App() {
     const getBarCodeScannerPermissions = async () => {
       const { status } = await BarCodeScanner.requestPermissionsAsync();
       setHasPermission(status === 'granted');
-    });
-    
-    getBarCodeScannerPermissions();  
+    };
+
+    getBarCodeScannerPermissions();
   }, []);
 
   const handleBarCodeScanned = ({ type, data }) => {

--- a/docs/pages/versions/v46.0.0/sdk/bar-code-scanner.md
+++ b/docs/pages/versions/v46.0.0/sdk/bar-code-scanner.md
@@ -47,7 +47,8 @@ In managed apps, scanning barcodes with the camera requires the [`Permission.CAM
 | upc_ean         | No    | Yes         |
 | qr              | Yes   | Yes         |
 
-> __Notes:__
+> **Notes:**
+>
 > - When an ITF-14 barcode is recognized, it's type can sometimes be set to `interleaved2of5`.
 > - Scanning for either `PDF417` and/or `Code39` formats can result in a noticeable increase in battery consumption on iOS. It is recommended to provide only the bar code formats you expect to scan to the `barCodeTypes` prop.
 
@@ -70,9 +71,9 @@ export default function App() {
     const getBarCodeScannerPermissions = async () => {
       const { status } = await BarCodeScanner.requestPermissionsAsync();
       setHasPermission(status === 'granted');
-    });
-    
-    getBarCodeScannerPermissions();  
+    };
+
+    getBarCodeScannerPermissions();
   }, []);
 
   const handleBarCodeScanned = ({ type, data }) => {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Refs ENG-6006

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR removes extra parentheses `)` from the Snack example under [Usage](https://docs.expo.dev/versions/latest/sdk/bar-code-scanner/#usage) section.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested by running the `/docs` locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
