### PR TITLE
[tools] Use uppercase for git HEAD

### DIFF
--- a/tools/src/Git.ts
+++ b/tools/src/Git.ts
@@ -221,7 +221,7 @@ export class GitDirectory {
    */
   async logAsync(options: GitLogOptions = {}): Promise<GitLog[]> {
     const fromCommit = options.fromCommit ?? '';
-    const toCommit = options.toCommit ?? 'head';
+    const toCommit = options.toCommit ?? 'HEAD';
     const commitSeparator = options.symmetricDifference ? '...' : '..';
     const paths = options.paths ?? ['.'];
     const cherryPickOptions = options.cherryPick

--- a/tools/src/publish-packages/tasks/findUnpublished.ts
+++ b/tools/src/publish-packages/tasks/findUnpublished.ts
@@ -61,7 +61,7 @@ async function getPackageGitLogsAsync(
 
   const commits = await gitDir.logAsync({
     fromCommit,
-    toCommit: 'head',
+    toCommit: 'HEAD',
   });
 
   const gitFiles = await gitDir.logFilesAsync({


### PR DESCRIPTION
# Why

Publishing from linux does not work.

# How

HEAD is a file, so on macOS that value is not case sensitive, but on linux it has to be uppercase

# Test Plan


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
