### PR TITLE
[github] fix base issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,7 +12,7 @@ body:
     attributes:
       label: Summary
       description: Describe the issue
-      placeholder: Clearly describe what the expected behavior is and what instead is actually happening. Be concise and precise in your description. Ex: if you report that "X library/method isn't working", then you will need to [continue debugging on your own](https://expo.fyi/manual-debugging) to more precisely define your issue before proceeding.
+      placeholder: 'Clearly describe what the expected behavior is and what instead is actually happening. Be concise and precise in your description. Ex: if you report that "X library/method isn't working", then you will need to [continue debugging on your own](https://expo.fyi/manual-debugging) to more precisely define your issue before proceeding.'
     validations:
       required: true
   - type: dropdown


### PR DESCRIPTION
# Why

Currently base issue template has the syntax error:
<img width="953" alt="Screenshot 2022-08-11 133234" src="https://user-images.githubusercontent.com/719641/184124393-f7f15ed5-ed75-4ad4-b683-091986fe3076.png">

And this leads to template not being visible in the wizard:
<img width="967" alt="Screenshot 2022-08-11 133216" src="https://user-images.githubusercontent.com/719641/184124455-d006744a-aabd-4e3f-94b8-d3a76cd91789.png">

# How

Fix te syntax issue by wrapping placeholder in single quotes.

# Test Plan

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
