### PR TITLE
[github] fix another template syntax error, validate templates with schema

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: "\U0001F41B SDK Bug Report"
 description: 'Report a reproducible bug in the Expo SDK'
-labels: 'needs review'
+labels: ['needs review']
 body:
   - type: markdown
     attributes:
@@ -12,7 +12,7 @@ body:
     attributes:
       label: Summary
       description: Describe the issue
-      placeholder: 'Clearly describe what the expected behavior is and what instead is actually happening. Be concise and precise in your description. Ex: if you report that "X library/method isn't working", then you will need to [continue debugging on your own](https://expo.fyi/manual-debugging) to more precisely define your issue before proceeding.'
+      placeholder: 'Clearly describe what the expected behavior is and what instead is actually happening. Be concise and precise in your description. Ex: if you report that "X library/method is not working", then you will need to [continue debugging on your own](https://expo.fyi/manual-debugging) to more precisely define your issue before proceeding.'
     validations:
       required: true
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,7 +1,7 @@
 name: "\U0001F4C3 Documentation Bug"
 description: 'You want to report something that is wrong or missing from the documentation.'
 title: '[docs] '
-labels: 'docs'
+labels: ['docs']
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
# Why

Refs #18603

The PR above solve one issue, but introduced another one, which has been reported in wrong line and column.

This became obvious after opening file in IDE.

# How

Fix another syntax error in template and update the `labels` filed according to the GitHub schema (http://json.schemastore.org/github-issue-forms.json).

# Test Plan

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
