### PR TITLE
[github] final fix for the template syntax errors

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -30,7 +30,7 @@ body:
   - type: textarea
     attributes:
       label: Environment
-      placeholder: Run `npx expo-env-info` and paste the output here
+      description: Run `npx expo-env-info` command and paste its output in the field below.
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,8 +11,7 @@ body:
   - type: textarea
     attributes:
       label: Summary
-      description: Describe the issue
-      placeholder: >
+      description: |
         Clearly describe what the expected behavior is and what instead is actually happening. Be concise and precise in your description. 
         Ex: if you report that "X library/method isn't working", then you will need to [continue debugging on your own](https://expo.fyi/manual-debugging) to more precisely define your issue before proceeding.
     validations:
@@ -37,7 +36,7 @@ body:
   - type: textarea
     attributes:
       label: Minimal reproducible example
-      description: >
+      description: |
         This should include as little code as possible, and no extraneous dependencies. Do not share your entire project. 
         Sharing a link to a [Snack](https://snack.expo.dev/) is often the best approach, but in some cases a GitHub repository is required. 
         If a reproducible demo is not provided, your issue will be closed. You must also test your issue against the latest SDK version to ensure that it hasn't already been resolved. 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -30,7 +30,7 @@ body:
   - type: textarea
     attributes:
       label: Environment
-      description: Run `npx expo-env-info` command and paste its output in the field below.
+      description: Run the `npx expo-env-info` command and paste its output in the field below.
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,7 +12,9 @@ body:
     attributes:
       label: Summary
       description: Describe the issue
-      placeholder: "Clearly describe what the expected behavior is and what instead is actually happening. Be concise and precise in your description. Ex: if you report that “X library/method isn't working”, then you will need to [continue debugging on your own](https://expo.fyi/manual-debugging) to more precisely define your issue before proceeding."
+      placeholder: >
+        Clearly describe what the expected behavior is and what instead is actually happening. Be concise and precise in your description. 
+        Ex: if you report that "X library/method isn't working", then you will need to [continue debugging on your own](https://expo.fyi/manual-debugging) to more precisely define your issue before proceeding.
     validations:
       required: true
   - type: dropdown
@@ -35,7 +37,11 @@ body:
   - type: textarea
     attributes:
       label: Minimal reproducible example
-      description: "This should include as little code as possible, and no extraneous dependencies. Do not share your entire project. Sharing a link to a [Snack](https://snack.expo.dev/) is often the best approach, but in some cases a GitHub repository is required. If a reproducible demo is not provided, your issue will be closed. You must also test your issue against the latest SDK version to ensure that it hasn't already been resolved. [Learn more about creating a minimal reproducible example](https://stackoverflow.com/help/mcve)."
+      description: >
+        This should include as little code as possible, and no extraneous dependencies. Do not share your entire project. 
+        Sharing a link to a [Snack](https://snack.expo.dev/) is often the best approach, but in some cases a GitHub repository is required. 
+        If a reproducible demo is not provided, your issue will be closed. You must also test your issue against the latest SDK version to ensure that it hasn't already been resolved. 
+        [Learn more about creating a minimal reproducible example](https://stackoverflow.com/help/mcve).
     validations:
       required: true
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,7 +12,7 @@ body:
     attributes:
       label: Summary
       description: Describe the issue
-      placeholder: 'Clearly describe what the expected behavior is and what instead is actually happening. Be concise and precise in your description. Ex: if you report that "X library/method is not working", then you will need to [continue debugging on your own](https://expo.fyi/manual-debugging) to more precisely define your issue before proceeding.'
+      placeholder: "Clearly describe what the expected behavior is and what instead is actually happening. Be concise and precise in your description. Ex: if you report that “X library/method isn't working”, then you will need to [continue debugging on your own](https://expo.fyi/manual-debugging) to more precisely define your issue before proceeding."
     validations:
       required: true
   - type: dropdown
@@ -35,9 +35,9 @@ body:
   - type: textarea
     attributes:
       label: Minimal reproducible example
-      description: 'This should include as little code as possible, and no extraneous dependencies. Do not share your entire project. Sharing a link to a [Snack](https://snack.expo.dev/) is often the best approach, but in some cases a GitHub repository is required. If a reproducible demo is not provided, your issue will be closed. You must also test your issue against the latest SDK version to ensure that it hasn't already been resolved. [Learn more about creating a minimal reproducible example](https://stackoverflow.com/help/mcve).'
+      description: "This should include as little code as possible, and no extraneous dependencies. Do not share your entire project. Sharing a link to a [Snack](https://snack.expo.dev/) is often the best approach, but in some cases a GitHub repository is required. If a reproducible demo is not provided, your issue will be closed. You must also test your issue against the latest SDK version to ensure that it hasn't already been resolved. [Learn more about creating a minimal reproducible example](https://stackoverflow.com/help/mcve)."
     validations:
       required: true
   - type: markdown
     attributes:
-`     value: Please make sure contributors can run your Snack or repository, and you explain how to reproduce the issue once the example is running.
+     value: Please make sure contributors can run your Snack or repository, and you explain how to reproduce the issue once the example is running.


### PR DESCRIPTION
# Why

Using single quotes for wrapping english sentences is not a good idea.

# How

Fix wrapping quotes, replace in description quotes with typography correct ones, so the YAML parser do not try to interpret them.

This should be the final fix, I have proofread all descriptions this time.

# Test Plan

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
