### PR TITLE
[core] Fix `2 files found with path 'lib/arm64-v8a/libfbjni.so'`

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 - Fix issue with Android builds when gradle clean and build were called concurrently.  ([#18518](https://github.com/expo/expo/pull/18518) by [EdwardDrapkin](https://github.com/EdwardDrapkin))
 - Fixed `FabricUIManager` errors when turning on new architecture mode on Android. ([#18472](https://github.com/expo/expo/pull/18472) by [@kudo](https://github.com/kudo))
-- Fixed the `2 files found with path 'lib/arm64-v8a/libfbjni.so'` error on Android.
+- Fixed the `2 files found with path 'lib/arm64-v8a/libfbjni.so'` error on Android. ([#18607](https://github.com/expo/expo/pull/18607) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - Fix issue with Android builds when gradle clean and build were called concurrently.  ([#18518](https://github.com/expo/expo/pull/18518) by [EdwardDrapkin](https://github.com/EdwardDrapkin))
 - Fixed `FabricUIManager` errors when turning on new architecture mode on Android. ([#18472](https://github.com/expo/expo/pull/18472) by [@kudo](https://github.com/kudo))
+- Fixed the `2 files found with path 'lib/arm64-v8a/libfbjni.so'` error on Android.
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -42,11 +42,10 @@ buildscript {
 def isAndroidTest() {
   Gradle gradle = getGradle()
   String tskReqStr = gradle.getStartParameter().getTaskRequests().toString()
-  if (tskReqStr.contains(":expo-modules-core:connectedDebugAndroidTest") || tskReqStr.contains(":expo-modules-core:connectedReleaseAndroidTest")) {
+  if (tskReqStr =~ /:expo-modules-core:connected\w+AndroidTest/) {
     def androidTests = project.file("src/androidTest")
     return androidTests.exists() && androidTests.isDirectory()
   }
-
   return false
 }
 

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -42,7 +42,12 @@ buildscript {
 def isAndroidTest() {
   Gradle gradle = getGradle()
   String tskReqStr = gradle.getStartParameter().getTaskRequests().toString()
-  return tskReqStr.contains("AndroidTest")
+  if (tskReqStr.contains(":expo-modules-core:connectedDebugAndroidTest") || tskReqStr.contains(":expo-modules-core:connectedReleaseAndroidTest")) {
+    def androidTests = project.file("src/androidTest")
+    return androidTests.exists() && androidTests.isDirectory()
+  }
+
+  return false
 }
 
 def downloadsDir = new File("$buildDir/downloads")


### PR DESCRIPTION
# Why

Fixes: https://exponent-internal.slack.com/archives/C1QNF5L3C/p1660134048900199


# How

The `expo-modules-core` will only include shared libraries if needed. So if someone runs an android test for other packages, those files won't be included.

# Test Plan

https://github.com/expo/expo-test-example