### PR TITLE
[github] unify content and styling between issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,7 +12,7 @@ body:
     attributes:
       label: Summary
       description: |
-        Clearly describe what the expected behavior is and what instead is actually happening. Be concise and precise in your description. 
+        Clearly describe what the expected behavior is and what instead is actually happening. Be concise and precise in your description.
         Ex: if you report that "X library/method isn't working", then you will need to [continue debugging on your own](https://expo.fyi/manual-debugging) to more precisely define your issue before proceeding.
     validations:
       required: true
@@ -37,12 +37,17 @@ body:
     attributes:
       label: Minimal reproducible example
       description: |
-        This should include as little code as possible, and no extraneous dependencies. Do not share your entire project. 
-        Sharing a link to a [Snack](https://snack.expo.dev/) is often the best approach, but in some cases a GitHub repository is required. 
-        If a reproducible demo is not provided, your issue will be closed. You must also test your issue against the latest SDK version to ensure that it hasn't already been resolved. 
+        This should include as little code as possible, and no extraneous dependencies. Do not share your entire project.
+        Sharing a link to a [Snack](https://snack.expo.dev/) is often the best approach, but in some cases a GitHub repository is required.
+        If a reproducible demo is not provided, your issue will be closed. You must also test your issue against the latest SDK version to ensure that it hasn't already been resolved.
         [Learn more about creating a minimal reproducible example](https://stackoverflow.com/help/mcve).
     validations:
       required: true
   - type: markdown
     attributes:
-     value: Please make sure contributors can run your Snack or repository, and you explain how to reproduce the issue once the example is running.
+      value: Please make sure contributors can run your Snack or repository, and you explain how to reproduce the issue once the example is running.
+  - type: markdown
+    attributes:
+      value: |
+        **Realize that it is up to you to debug your code and be as certain as possible that the bug is with Expo, not with your own app.**
+        [Here's an excellent guide to debugging you can follow](https://gist.github.com/brentvatne/5ac00cba0c70b7a06b89a56787d6bc4a).

--- a/.github/ISSUE_TEMPLATE/bug_report_cli.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_cli.yml
@@ -7,12 +7,15 @@ body:
       value: Thanks for taking the time to file a bug report! Please fill out this form as completely as possible.
   - type: markdown
     attributes:
-      value: If you leave out sections there is a high likelihood your issue will be closed. If you have a question, not a bug report, please post it on our [forums](https://forums.expo.dev/) instead.
+      value: |
+        If you leave out sections there is a high likelihood your issue will be closed.
+        If you have a question or you think your issue might be caused by your application code, you can get help from the community on the [forums](https://forums.expo.dev/) or on [Discord](https://chat.expo.dev).
   - type: textarea
     attributes:
       label: Summary
-      description: Describe the issue in 1 or 2 sentences
-      placeholder: "Clearly describe what the expected behavior is vs. what is actually happening. This should be as short as possible, while still communicating all the necessary information. If your summary is simply, for example: 'My device cannot connect to Wi-Fi.', then you need to continue debugging yourself and provide more information."
+      description: |
+        Clearly describe what the expected behavior is vs. what is actually happening. This should be as short as possible, while still communicating all the necessary information.
+        If your summary is simply, for example: "My device cannot connect to Wi-Fi.", then you will need to [continue debugging on your own](https://expo.fyi/manual-debugging) to more precisely define your issue before proceeding.
     validations:
       required: true
   - type: dropdown
@@ -32,13 +35,16 @@ body:
   - type: textarea
     attributes:
       label: Environment
-      placeholder: Run `npx expo-env-info` and paste the output here
+      description: Run the `npx expo-env-info` command and paste its output in the field below.
     validations:
       required: true
   - type: textarea
     attributes:
-      label: Reproducible demo
-      description: 'This should include as little code as possible, do not link your entire project. If a reproducible demo is not provided, it is very likely your issue will be closed. Read [here more guidance](https://stackoverflow.com/help/mcve).'
+      label: Minimal reproducible example
+      description: |
+        This should include as little code as possible, and no extraneous dependencies. Do not share your entire project.
+        If a reproducible demo is not provided, your issue will be closed. You must also test your issue against the latest CLI version to ensure that it hasn't already been resolved.
+        [Learn more about creating a minimal reproducible example](https://stackoverflow.com/help/mcve).
     validations:
       required: true
   - type: markdown
@@ -46,4 +52,6 @@ body:
       value: Please make sure contributors can run your code and follow the steps your provided in order to reproduce the bug.
   - type: markdown
     attributes:
-      value: "**Realize that it is up to you to debug your code and be as certain as possible that the bug is with Expo, not with your own app.** [Here's an excellent guide to debugging you can follow](https://gist.github.com/brentvatne/5ac00cba0c70b7a06b89a56787d6bc4a)."
+      value: |
+        **Realize that it is up to you to debug your code and be as certain as possible that the bug is with Expo, not with your own app.**
+        [Here's an excellent guide to debugging you can follow](https://gist.github.com/brentvatne/5ac00cba0c70b7a06b89a56787d6bc4a).

--- a/.github/ISSUE_TEMPLATE/dev_client_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/dev_client_bug_report.yml
@@ -55,8 +55,8 @@ body:
     attributes:
       label: Reproducible demo
       description: |
-        This should include as little code as possible, and no extraneous dependencies. Do not share your entire project.
-        If a reproducible demo is not provided, your issue will be closed. If you link to a project that contains multiple non-Expo-core modules, it is unlikely to help us narrow down the cause of your issue more quickly. 
+        This should include as little code as possible, and no extraneous dependencies. Do not share your entire project. If a reproducible demo is not provided, your issue will be closed. 
+        If you link to a project that contains multiple non-Expo-core modules, it is unlikely to help us narrow down the cause of your issue more quickly. 
         Learn more about creating a minimal reproducible example](https://stackoverflow.com/help/mcve).
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/dev_client_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/dev_client_bug_report.yml
@@ -7,20 +7,26 @@ body:
       value: Thanks for taking the time to file a bug report! Please fill out this form as completely as possible so we have the information we need to help.
   - type: markdown
     attributes:
-      value: If you leave out sections there is a high likelihood your issue will be closed. If you have a question, not a bug report, please post it on our [forums](https://forums.expo.dev/) instead.
+      value: |
+        If you leave out sections there is a high likelihood your issue will be closed.
+        If you have a question or you think your issue might be caused by your application code, you can get help from the community on the [forums](https://forums.expo.dev/) or on [Discord](https://chat.expo.dev).
   - type: markdown
     attributes:
-      value: 'IMPORTANT: Before filling out this template further, ensure you have the latest version of the `expo-dev-client` package, `expo-cli`, and (if applicable) `eas-cli`. If not, try upgrading first and see if that fixes your issue.'
+      value: |
+        **IMPORTANT**: Before filling out this template further, ensure you have the latest version of the `expo-dev-client` package, `expo-cli`, and (if applicable) `eas-cli`. If not, try upgrading first and see if that fixes your issue.
   - type: textarea
     attributes:
       label: Summary
-      description: Describe the issue in 1 or 2 sentences
-      placeholder: Clearly describe what the expected behavior is vs. what is actually happening. This should be as short as possible, while still communicating all the necessary information. If your summary is just 'X library/method isn't working', then you need to continue debugging yourself and provide more information.
+      description: |
+        Clearly describe what the expected behavior is vs. what is actually happening. This should be as short as possible, while still communicating all the necessary information.
+        If your summary is just 'X library/method isn't working', then you need to continue debugging yourself and provide more information.
     validations:
       required: true
   - type: dropdown
     attributes:
-      label: Managed or bare workflow? If you have made manual changes inside of the `ios/` or `android/` directories in your project, the answer is bare!
+      label: Managed or bare workflow?
+      description: |
+        If you have made manual changes inside of the `ios/` or `android/` directories in your project, the answer is "bare"!
       options:
         - managed
         - bare
@@ -38,17 +44,20 @@ body:
   - type: textarea
     attributes:
       label: Package versions
-      description: 'List the package versions of `expo-dev-client`, `expo-updates`, and any other relevant libraries in your project.'
+      description: List the package versions of `expo-dev-client`, `expo-updates`, and any other relevant libraries in your project.
   - type: textarea
     attributes:
       label: Environment
-      placeholder: Run `npx expo-env-info` and paste the output here
+      description: Run the `npx expo-env-info` command and paste its output in the field below.
     validations:
       required: true
   - type: textarea
     attributes:
       label: Reproducible demo
-      description: 'This should include as little code as possible, do not simply link your entire project. If a reproducible demo is not provided, it is very likely your issue will be closed. If you link to a project that contains multiple non-Expo-core modules, it is unlikely to help us narrow down the cause of your issue more quickly. Read more guidance [here](https://stackoverflow.com/help/mcve).'
+      description: |
+        This should include as little code as possible, and no extraneous dependencies. Do not share your entire project.
+        If a reproducible demo is not provided, your issue will be closed. If you link to a project that contains multiple non-Expo-core modules, it is unlikely to help us narrow down the cause of your issue more quickly. 
+        Learn more about creating a minimal reproducible example](https://stackoverflow.com/help/mcve).
     validations:
       required: true
   - type: markdown
@@ -57,7 +66,9 @@ body:
   - type: textarea
     attributes:
       label: Stacktrace (if a crash is involved)
-      description: 'If your issue involves a crash, please provide the native stacktrace if you are able.'
+      description: If your issue involves a crash, please provide the native stacktrace if you are able to.
   - type: markdown
     attributes:
-      value: "**Realize that it is up to you to debug your code and be as certain as possible that the bug is with Expo, not with your own app.** [Here's an excellent guide to debugging you can follow](https://gist.github.com/brentvatne/5ac00cba0c70b7a06b89a56787d6bc4a)."
+      value: |
+        **Realize that it is up to you to debug your code and be as certain as possible that the bug is with Expo, not with your own app.**
+        [Here's an excellent guide to debugging you can follow](https://gist.github.com/brentvatne/5ac00cba0c70b7a06b89a56787d6bc4a).


### PR DESCRIPTION
# Why

After adjusting the base issue template, we decided to have a pass over other ones, to ensure that content is up to date and templates are styled in the same way.

# How

Adjust and unify templates copy, move most of the placeholder to the descriptions, switch to scalars.

# Test Plan

https://github.com/Simek/expo/tree/%40simek/github-unify-issue-templates/.github/ISSUE_TEMPLATE

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
