### PR TITLE
[dev-launcher][ios] fix deferred deep links

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### 🐛 Bug fixes
 
 - Fixed `the function must be called on main queue` error when the app is reload from the error screen on iOS. ([#18563](https://github.com/expo/expo/pull/18563) by [@lukmccall](https://github.com/lukmccall))
+- Fix deferred deep link handling on iOS. ([#18614](https://github.com/expo/expo/pull/18614)) by [@ajsmth](https://github.com/ajsmth)
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
+++ b/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
@@ -45,7 +45,7 @@ public class ExpoDevLauncherReactDelegateHandler: ExpoReactDelegateHandler, RCTB
     self.reactDelegate = reactDelegate
     self.bridgeDelegate = EXRCTBridgeDelegateInterceptor(bridgeDelegate: bridgeDelegate, interceptor: self)
     self.launchOptions = launchOptions
-
+    
     EXDevLauncherController.sharedInstance().autoSetupPrepare(self, launchOptions: launchOptions)
     if (EXUpdatesControllerRegistry.sharedInstance().controller != nil) {
       EXDevLauncherController.sharedInstance().updatesInterface = EXUpdatesControllerRegistry.sharedInstance().controller
@@ -73,7 +73,20 @@ public class ExpoDevLauncherReactDelegateHandler: ExpoReactDelegateHandler, RCTB
   // MARK: EXDevelopmentClientControllerDelegate implementations
 
   public func devLauncherController(_ developmentClientController: EXDevLauncherController, didStartWithSuccess success: Bool) {
-    let bridge = RCTBridge(delegate: self.bridgeDelegate, launchOptions: self.launchOptions)
+    
+    var launchOptions: [AnyHashable: Any] = [:]
+    
+    if let initialLaunchOptions = self.launchOptions {
+      for (key, value) in initialLaunchOptions {
+        launchOptions[key] = value
+      }
+    }
+    
+    for (key, value) in developmentClientController.getLaunchOptions() {
+      launchOptions[key] = value
+    }
+    
+    let bridge = RCTBridge(delegate: self.bridgeDelegate, launchOptions: launchOptions)
     developmentClientController.appBridge = bridge
 
     let rootView = RCTRootView(bridge: bridge!, moduleName: self.rootViewModuleName!, initialProperties: self.rootViewInitialProperties)

--- a/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
+++ b/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
@@ -45,7 +45,7 @@ public class ExpoDevLauncherReactDelegateHandler: ExpoReactDelegateHandler, RCTB
     self.reactDelegate = reactDelegate
     self.bridgeDelegate = EXRCTBridgeDelegateInterceptor(bridgeDelegate: bridgeDelegate, interceptor: self)
     self.launchOptions = launchOptions
-    
+
     EXDevLauncherController.sharedInstance().autoSetupPrepare(self, launchOptions: launchOptions)
     if (EXUpdatesControllerRegistry.sharedInstance().controller != nil) {
       EXDevLauncherController.sharedInstance().updatesInterface = EXUpdatesControllerRegistry.sharedInstance().controller
@@ -73,19 +73,18 @@ public class ExpoDevLauncherReactDelegateHandler: ExpoReactDelegateHandler, RCTB
   // MARK: EXDevelopmentClientControllerDelegate implementations
 
   public func devLauncherController(_ developmentClientController: EXDevLauncherController, didStartWithSuccess success: Bool) {
-    
     var launchOptions: [AnyHashable: Any] = [:]
-    
+
     if let initialLaunchOptions = self.launchOptions {
       for (key, value) in initialLaunchOptions {
         launchOptions[key] = value
       }
     }
-    
+
     for (key, value) in developmentClientController.getLaunchOptions() {
       launchOptions[key] = value
     }
-    
+
     let bridge = RCTBridge(delegate: self.bridgeDelegate, launchOptions: launchOptions)
     developmentClientController.appBridge = bridge
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Closes ENG-5284

The issue outlines some strange / annoying popup behaviour with the deep link modal in the dev launcher. 

After taking a closer look, it was actually a symptom of these deep links never being passed through properly, so these deferred deep links were not actually working: 


https://user-images.githubusercontent.com/40680668/184225209-afa942e7-e6b5-43e8-9207-fd10575f70ae.mp4



# How

<!--
How did you build this feature or fix this bug and why?
-->

In the `didStartWithSuccess` method of the delegate handler, we now loop over the initial launch options and any additional launch options captured by the `EXDevLauncherController` - this assumes that more recent deep links captured by the deep link registry will potentially override the initial url that the app might be launched with - I figured this was the most sensible approach

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Deep links are now properly captured, passed to the app instance, and are consumed:


https://user-images.githubusercontent.com/40680668/184225555-7d1f5c33-fca8-4859-815e-fb18f6b5c5ef.mp4



# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
