### PR TITLE
[docs] Simplify Camera example for SDK 46

### DIFF
--- a/docs/pages/versions/unversioned/sdk/camera.md
+++ b/docs/pages/versions/unversioned/sdk/camera.md
@@ -26,37 +26,50 @@ import SnackInline from '~/components/plugins/SnackInline';
 <SnackInline label='Basic Camera usage' dependencies={['expo-camera']}>
 
 ```jsx
-import React, { useState, useEffect } from 'react';
-import { StyleSheet, Text, View, TouchableOpacity } from 'react-native';
 import { Camera, CameraType } from 'expo-camera';
+import { useState } from 'react';
+import { Button, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 export default function App() {
-  const [hasPermission, setHasPermission] = useState(null);
   const [type, setType] = useState(CameraType.back);
+  const [permission, requestPermission] = Camera.useCameraPermissions();
 
-  useEffect(() => {
-    (async () => {
-      const { status } = await Camera.requestCameraPermissionsAsync();
-      setHasPermission(status === 'granted');
-    })();
-  }, []);
-
-  if (hasPermission === null) {
+  /* @hide if (!permission) ... */
+  if (!permission) {
+    // Camera permissions are still loading
     return <View />;
   }
-  if (hasPermission === false) {
-    return <Text>No access to camera</Text>;
+  /* @end */
+
+  /* @hide if (!permission.granted) ... */
+  if (!permission.granted) {
+    // Camera permissions are not granted yet
+    return (
+      <View style={styles.container}>
+        <Text style={{ textAlign: 'center' }}>
+          We need your permission to show the camera
+        </Text>
+        <Button onPress={requestPermission} title="grant permission" />
+      </View>
+    );
   }
+  /* @end */
+
+
+  function toggleCameraType() {
+    setType((current) => (
+      current === CameraType.back ? CameraType.front : CameraType.back
+    ));
+  }
+
   return (
     <View style={styles.container}>
       <Camera style={styles.camera} type={type}>
         <View style={styles.buttonContainer}>
           <TouchableOpacity
             style={styles.button}
-            onPress={() => {
-              setType(type === CameraType.back ? CameraType.front : CameraType.back);
-            }}>
-            <Text style={styles.text}> Flip </Text>
+            onPress={toggleCameraType}>
+            <Text style={styles.text}>Flip Camera</Text>
           </TouchableOpacity>
         </View>
       </Camera>
@@ -68,23 +81,25 @@ export default function App() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+    justifyContent: 'center',
   },
   camera: {
     flex: 1,
   },
   buttonContainer: {
     flex: 1,
-    backgroundColor: 'transparent',
     flexDirection: 'row',
-    margin: 20,
+    backgroundColor: 'transparent',
+    margin: 64,
   },
   button: {
-    flex: 0.1,
+    flex: 1,
     alignSelf: 'flex-end',
     alignItems: 'center',
   },
   text: {
-    fontSize: 18,
+    fontSize: 24,
+    fontWeight: 'bold',
     color: 'white',
   },
 });

--- a/docs/pages/versions/v46.0.0/sdk/camera.md
+++ b/docs/pages/versions/v46.0.0/sdk/camera.md
@@ -26,37 +26,50 @@ import SnackInline from '~/components/plugins/SnackInline';
 <SnackInline label='Basic Camera usage' dependencies={['expo-camera']}>
 
 ```jsx
-import React, { useState, useEffect } from 'react';
-import { StyleSheet, Text, View, TouchableOpacity } from 'react-native';
 import { Camera, CameraType } from 'expo-camera';
+import { useState } from 'react';
+import { Button, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 export default function App() {
-  const [hasPermission, setHasPermission] = useState(null);
   const [type, setType] = useState(CameraType.back);
+  const [permission, requestPermission] = Camera.useCameraPermissions();
 
-  useEffect(() => {
-    (async () => {
-      const { status } = await Camera.requestCameraPermissionsAsync();
-      setHasPermission(status === 'granted');
-    })();
-  }, []);
-
-  if (hasPermission === null) {
+  /* @hide if (!permission) ... */
+  if (!permission) {
+    // Camera permissions are still loading
     return <View />;
   }
-  if (hasPermission === false) {
-    return <Text>No access to camera</Text>;
+  /* @end */
+
+  /* @hide if (!permission.granted) ... */
+  if (!permission.granted) {
+    // Camera permissions are not granted yet
+    return (
+      <View style={styles.container}>
+        <Text style={{ textAlign: 'center' }}>
+          We need your permission to show the camera
+        </Text>
+        <Button onPress={requestPermission} title="grant permission" />
+      </View>
+    );
   }
+  /* @end */
+
+
+  function toggleCameraType() {
+    setType((current) => (
+      current === CameraType.back ? CameraType.front : CameraType.back
+    ));
+  }
+
   return (
     <View style={styles.container}>
       <Camera style={styles.camera} type={type}>
         <View style={styles.buttonContainer}>
           <TouchableOpacity
             style={styles.button}
-            onPress={() => {
-              setType(type === CameraType.back ? CameraType.front : CameraType.back);
-            }}>
-            <Text style={styles.text}> Flip </Text>
+            onPress={toggleCameraType}>
+            <Text style={styles.text}>Flip Camera</Text>
           </TouchableOpacity>
         </View>
       </Camera>
@@ -68,23 +81,25 @@ export default function App() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+    justifyContent: 'center',
   },
   camera: {
     flex: 1,
   },
   buttonContainer: {
     flex: 1,
-    backgroundColor: 'transparent',
     flexDirection: 'row',
-    margin: 20,
+    backgroundColor: 'transparent',
+    margin: 64,
   },
   button: {
-    flex: 0.1,
+    flex: 1,
     alignSelf: 'flex-end',
     alignItems: 'center',
   },
   text: {
-    fontSize: 18,
+    fontSize: 24,
+    fontWeight: 'bold',
     color: 'white',
   },
 });


### PR DESCRIPTION
# Why

I really hate the `useEffect` in our example codes, mostly to fetch permissions. Because we now have the `useXPermission` hooks, we can just use that instead.

We have this in a lot of examples, I think this could be a good example of how to do it now?

# How

- Removed `useEffect` and `import React from 'react';` 
  _→ Not necessary anymore, since SDK 46 also not in Snack_
- Ordered the imports alphabetically
- Added `Camera.useCameraPermission` hook
- Added permission handling UI 
  _→ This is hidden under: `if (!permission) ...` and `if (!permission.granted) ...`. We don't need to show this unless people open the Snack._
- Made "Flip" button more obvious and added margins to compensate for missing safe area

## Screenshot

<details><summary>Old example</summary>

<img width="1175" alt="Screenshot 2022-08-12 at 14 57 18" src="https://user-images.githubusercontent.com/1203991/184358584-41eb130a-95e0-43d1-8a31-2dffa270968d.png">

</details>

<img width="1184" alt="Screenshot 2022-08-12 at 14 45 23" src="https://user-images.githubusercontent.com/1203991/184356562-ac860f4c-a3a6-4334-abcf-af9856d7519b.png">


# Test Plan

Docs change only

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
