### PR TITLE
Fix broken getting started share docs

### DIFF
--- a/docs/pages/tutorial/sharing.md
+++ b/docs/pages/tutorial/sharing.md
@@ -25,6 +25,7 @@ import React from 'react';
 import { Image, StyleSheet, Text, TouchableOpacity, View, /* @info This is required to determine which platform the code is going to run */ Platform /* @end */ } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
 /* @info As always, we must import it to use it */ import * as Sharing from 'expo-sharing'; /* @end */
+import * as ImageManipulator from "expo-image-manipulator";
 
 export default function App() {
   const [selectedImage, setSelectedImage] = React.useState(null);
@@ -42,7 +43,8 @@ export default function App() {
       return;
     }
 
-    await Sharing.shareAsync(selectedImage.localUri);
+    const imageTmp = await ImageManipulator.manipulateAsync(selectedImage.localUri);
+    await Sharing.shareAsync(imageTmp.uri);
   }; /* @end */
 
   if (selectedImage !== null) {


### PR DESCRIPTION
You need to create a temporary image or you'll be greeted with a "Error: Not allowed to read file under given URL.". Testing my doc change locally on Android it's working great.

Please patch soon. A bit jarring to be greeted with errors when trying out an official tutorial.

# Why

Tutorial is broken here https://docs.expo.dev/tutorial/sharing/

# How

See specifics here https://stackoverflow.com/questions/61240694/how-to-share-a-local-photo-using-react-expo-sharing-shareasync/63442412#63442412

# Test Plan

I have only tested the fix on Android.

# Checklist

Sorry I don't have time to tackle the below checklist. But this tutorial being broken seems pretty critical. Please feel free to hijack my code here to modify anything needed.

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
