### PR TITLE
[modules] Support old-style view callbacks for views written in Objective-C

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Experimental support for typed arrays on Android. ([#18379](https://github.com/expo/expo/pull/18379) by [@lukmccall](https://github.com/lukmccall))
 - Using JSI instead of the bridge to call native methods also on legacy modules on iOS. ([#18438](https://github.com/expo/expo/pull/18438) by [@tsapeta](https://github.com/tsapeta))
 - Experimental support for Fabric on iOS (currently supported only by `expo-linear-gradient`). ([#18500](https://github.com/expo/expo/pull/18500) by [@tsapeta](https://github.com/tsapeta))
+- Added view prop callbacks support for old-style views written in Objective-C.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Experimental support for typed arrays on Android. ([#18379](https://github.com/expo/expo/pull/18379) by [@lukmccall](https://github.com/lukmccall))
 - Using JSI instead of the bridge to call native methods also on legacy modules on iOS. ([#18438](https://github.com/expo/expo/pull/18438) by [@tsapeta](https://github.com/tsapeta))
 - Experimental support for Fabric on iOS (currently supported only by `expo-linear-gradient`). ([#18500](https://github.com/expo/expo/pull/18500) by [@tsapeta](https://github.com/tsapeta))
-- Added view prop callbacks support for old-style views written in Objective-C.
+- Added view prop callbacks support for old-style views written in Objective-C. ([#18636](https://github.com/expo/expo/pull/18636) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/Swift/Events/Callback.swift
+++ b/packages/expo-modules-core/ios/Swift/Events/Callback.swift
@@ -3,7 +3,7 @@
 /**
  An alias for type-erased callback handler.
  */
-typealias AnyCallbackHandlerType = (Any) -> Void
+typealias AnyCallbackHandlerType = @convention(block) ([String: Any]) -> Void
 
 /**
  Public type-erased protocol that `Callback` object conforms to.
@@ -59,8 +59,8 @@ public class Callback<ArgType>: AnyCallback, AnyCallbackInternal {
   /**
    Allows the callback instance to be called as a function.
    */
-  public func callAsFunction(_ arg: ArgType) {
+  public func callAsFunction(_ arg: [String: Any]) {
     // TODO: Convert records to dictionaries (@tsapeta)
-    handler?(arg as Any)
+    handler?(arg)
   }
 }

--- a/packages/expo-modules-core/ios/Swift/Views/ComponentData.swift
+++ b/packages/expo-modules-core/ios/Swift/Views/ComponentData.swift
@@ -73,6 +73,21 @@ public final class ComponentData: RCTComponentData {
  */
 private func createEventSetter(eventName: String, bridge: RCTBridge?) -> RCTPropBlockAlias {
   return { [weak bridge] (target: RCTComponent, value: Any) in
+    // Callback handler that dispatches the actual event.
+    let handler: AnyCallbackHandlerType = { [weak target] (body: [String: Any]) in
+      if let target = target {
+        let componentEvent = RCTComponentEvent(name: eventName, viewTag: target.reactTag, body: body)
+        bridge?.eventDispatcher().send(componentEvent)
+      }
+    }
+
+    // This is to handle events in views written in Objective-C.
+    // Note that the property should be of type EXDirectEventBlock.
+    if let target = target as? NSObject, target.responds(to: Selector(eventName)) {
+      target.setValue(handler, forKey: eventName)
+      return
+    }
+
     // Find view's property that is named as the prop and is wrapped by `Event`.
     let child = Mirror(reflecting: target).children.first {
       $0.label == "_\(eventName)"
@@ -83,12 +98,7 @@ private func createEventSetter(eventName: String, bridge: RCTBridge?) -> RCTProp
 
     // For callbacks React Native passes a bool value whether the prop is specified or not.
     if value as? Bool == true {
-      event.settle { [weak target] (body: Any) in
-        if let target = target {
-          let componentEvent = RCTComponentEvent(name: eventName, viewTag: target.reactTag, body: ["payload": body])
-          bridge?.eventDispatcher().send(componentEvent)
-        }
-      }
+      event.settle(handler)
     } else {
       event.invalidate()
     }


### PR DESCRIPTION
# Why

Currently in the Sweet API we support view callbacks only for views written in Swift (we're looking for properties wrapped by `@Event`). To make the migration to the new API smoother, we need to handle old-style (`EXDirectEventBlock`) view callbacks that also work for views written in Objective-C.

# How

- Detect the case when the view has Objective-C property with the same name as the event and then set its value to the event handler
- As a side effect, I had to remove the additional `payload` property in the event body to make it compatible with the old-style callbacks. It wasn't used anywhere and was undocumented, so there is no reason to make it a breaking change.

# Test Plan

Tested as part of #18633 where I migrated the video view manager module to the new API while still using the old Objective-C view.
