### PR TITLE
[ios] Fix standalone build error on sdk 46

### DIFF
--- a/template-files/ios/ExpoKit-Podfile
+++ b/template-files/ios/ExpoKit-Podfile
@@ -1,4 +1,4 @@
-platform :ios, '12.0'
+platform :ios, '12.4'
 
 # Disable expo-updates auto create manifest in podspec script_phase
 $expo_updates_create_manifest = false
@@ -38,7 +38,13 @@ target 'ExpoKitApp' do
 
   # Install React Native and its dependencies
   require_relative '../node_modules/react-native/scripts/react_native_pods'
-  use_react_native!(production: true)
+  use_react_native!(
+    :path => '../node_modules/react-native',
+    :hermes_enabled => false,
+    :fabric_enabled => false,
+    :app_path => "#{Dir.pwd}/..",
+    :production => true,
+  )
 
   # Install vendored pods.
   require_relative '../../../ios/podfile_helpers.rb'


### PR DESCRIPTION
# Why

fix `pod install` error for standalone build on sdk 46

# How

- bump minimal ios version to 12.4
- add more settings for `use_react_native!()`

# Test Plan

`et ios-shell-app --action build --type simulator --configuration Release`
`et ios-shell-app --action configure --url 'https://staging.exp.host/@kudochien/native-component-list-next' --type simulator -s 46.0.0 --archivePath shellAppBase-simulator/Build/Products/Release-iphonesimulator/ExpoKitApp.app --output app.tar.gz`

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
