### PR TITLE
[ci] Fix incorrect expo-git-decrypt key name

### DIFF
--- a/.github/actions/expo-git-decrypt/action.yml
+++ b/.github/actions/expo-git-decrypt/action.yml
@@ -21,7 +21,7 @@ runs:
       run: brew install git-crypt
     - name: 🔓 Decrypt secrets if possible
       env:
-        GIT_CRYPT_KEY_BASE64: ${{ inputs.GIT_CRYPT_KEY_BASE64 }}
+        GIT_CRYPT_KEY_BASE64: ${{ inputs.key }}
       shell: bash
       run: |
         if [[ ${GIT_CRYPT_KEY_BASE64:-unset} = unset ]]; then


### PR DESCRIPTION
# Why

close ENG-6054

# How

fix the incorrect key name for expo-git-decrypt

# Test Plan

Check client ci actions whether the `Decrypt secrets if possible` phase success
