### PR TITLE
[menu][iOS] Fix `PanGestureHandler` does not get active when it has a `simultaneousHandlers`

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixes `PanGestureHandler` does not get active when it has a `simultaneousHandler` on iOS.
+- Fixes `PanGestureHandler` does not get active when it has a `simultaneousHandler` on iOS. ([#18657](https://github.com/expo/expo/pull/18657) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixes `PanGestureHandler` does not get active when it has a `simultaneousHandler` on iOS.
+
 ### 💡 Others
 
 ## 1.2.0 — 2022-08-11

--- a/packages/expo-dev-menu/vendored/react-native-gesture-handler/ios/DevMenuRNGestureHandler.m
+++ b/packages/expo-dev-menu/vendored/react-native-gesture-handler/ios/DevMenuRNGestureHandler.m
@@ -7,14 +7,14 @@
 
 #import <React/UIView+React.h>
 
-@interface UIGestureRecognizer (GestureHandler)
-@property (nonatomic, readonly) DevMenuRNGestureHandler *gestureHandler;
+@interface UIGestureRecognizer (DevMenuGestureHandler)
+@property (nonatomic, readonly) DevMenuRNGestureHandler *devMenuGestureHandler;
 @end
 
 
-@implementation UIGestureRecognizer (GestureHandler)
+@implementation UIGestureRecognizer (DevMenuGestureHandler)
 
-- (DevMenuRNGestureHandler *)gestureHandler
+- (DevMenuRNGestureHandler *)devMenuGestureHandler
 {
     id delegate = self.delegate;
     if ([delegate isKindOfClass:[DevMenuRNGestureHandler class]]) {
@@ -327,7 +327,7 @@ static NSHashTable<DevMenuRNGestureHandler *> *allGestureHandlers;
 
 + (DevMenuRNGestureHandler *)findGestureHandlerByRecognizer:(UIGestureRecognizer *)recognizer
 {
-    DevMenuRNGestureHandler *handler = recognizer.gestureHandler;
+    DevMenuRNGestureHandler *handler = recognizer.devMenuGestureHandler;
     if (handler != nil) {
         return handler;
     }
@@ -341,7 +341,7 @@ static NSHashTable<DevMenuRNGestureHandler *> *allGestureHandlers;
 
     for (UIGestureRecognizer *recognizer in reactView.gestureRecognizers) {
         if ([recognizer isKindOfClass:[DevMenuRNDummyGestureRecognizer class]]) {
-            return recognizer.gestureHandler;
+            return recognizer.devMenuGestureHandler;
         }
     }
 


### PR DESCRIPTION
# Why

Fixes https://github.com/software-mansion/react-native-gesture-handler/issues/2169
Closes ENG-6065.
Note: 
This PR aims to fix that issue in dev-client. I'm working on a similar fix to the expo go too.

# How

I have to rename the function inside of the extension to the `UIGestureRecognizer`. It seems that if a gesture handler is installed, it calls the incorrect version of this function 🤷 
So in the end, iOS calls the version from the dev-menu package, where `gestureHandler` always returns nil - views in the user app won't be of type `DevMenuRNGestureHandler`.

# Test Plan

- https://snack.expo.dev/@gorhom/7a1a40 ✅