### PR TITLE
[go][iOS] Fix `PanGestureHandler` does not get active when it has a `simultaneousHandlers`

### DIFF
--- a/ios/vendored/sdk44/react-native-gesture-handler/ios/ABI44_0_0RNGestureHandler.m
+++ b/ios/vendored/sdk44/react-native-gesture-handler/ios/ABI44_0_0RNGestureHandler.m
@@ -7,14 +7,14 @@
 
 #import <ABI44_0_0React/ABI44_0_0UIView+React.h>
 
-@interface UIGestureRecognizer (GestureHandler)
-@property (nonatomic, readonly) ABI44_0_0RNGestureHandler *gestureHandler;
+@interface UIGestureRecognizer (ABI44_0_0GestureHandler)
+@property (nonatomic, readonly) ABI44_0_0RNGestureHandler *ABI44_0_0gestureHandler;
 @end
 
 
-@implementation UIGestureRecognizer (GestureHandler)
+@implementation UIGestureRecognizer (ABI44_0_0GestureHandler)
 
-- (ABI44_0_0RNGestureHandler *)gestureHandler
+- (ABI44_0_0RNGestureHandler *)ABI44_0_0gestureHandler
 {
     id delegate = self.delegate;
     if ([delegate isKindOfClass:[ABI44_0_0RNGestureHandler class]]) {
@@ -327,7 +327,7 @@ static NSHashTable<ABI44_0_0RNGestureHandler *> *allGestureHandlers;
 
 + (ABI44_0_0RNGestureHandler *)findGestureHandlerByRecognizer:(UIGestureRecognizer *)recognizer
 {
-    ABI44_0_0RNGestureHandler *handler = recognizer.gestureHandler;
+    ABI44_0_0RNGestureHandler *handler = recognizer.ABI44_0_0gestureHandler;
     if (handler != nil) {
         return handler;
     }
@@ -341,7 +341,7 @@ static NSHashTable<ABI44_0_0RNGestureHandler *> *allGestureHandlers;
 
     for (UIGestureRecognizer *recognizer in reactView.gestureRecognizers) {
         if ([recognizer isKindOfClass:[ABI44_0_0RNDummyGestureRecognizer class]]) {
-            return recognizer.gestureHandler;
+            return recognizer.ABI44_0_0gestureHandler;
         }
     }
 

--- a/ios/vendored/sdk45/react-native-gesture-handler/ios/ABI45_0_0RNGestureHandler.m
+++ b/ios/vendored/sdk45/react-native-gesture-handler/ios/ABI45_0_0RNGestureHandler.m
@@ -7,14 +7,14 @@
 
 #import <ABI45_0_0React/ABI45_0_0UIView+React.h>
 
-@interface UIGestureRecognizer (GestureHandler)
-@property (nonatomic, readonly) ABI45_0_0RNGestureHandler *gestureHandler;
+@interface UIGestureRecognizer (ABI45_0_0GestureHandler)
+@property (nonatomic, readonly) ABI45_0_0RNGestureHandler *ABI45_0_0gestureHandler;
 @end
 
 
-@implementation UIGestureRecognizer (GestureHandler)
+@implementation UIGestureRecognizer (ABI45_0_0GestureHandler)
 
-- (ABI45_0_0RNGestureHandler *)gestureHandler
+- (ABI45_0_0RNGestureHandler *)ABI45_0_0gestureHandler
 {
     id delegate = self.delegate;
     if ([delegate isKindOfClass:[ABI45_0_0RNGestureHandler class]]) {
@@ -327,7 +327,7 @@ static NSHashTable<ABI45_0_0RNGestureHandler *> *allGestureHandlers;
 
 + (ABI45_0_0RNGestureHandler *)findGestureHandlerByRecognizer:(UIGestureRecognizer *)recognizer
 {
-    ABI45_0_0RNGestureHandler *handler = recognizer.gestureHandler;
+    ABI45_0_0RNGestureHandler *handler = recognizer.ABI45_0_0gestureHandler;
     if (handler != nil) {
         return handler;
     }
@@ -341,7 +341,7 @@ static NSHashTable<ABI45_0_0RNGestureHandler *> *allGestureHandlers;
 
     for (UIGestureRecognizer *recognizer in reactView.gestureRecognizers) {
         if ([recognizer isKindOfClass:[ABI45_0_0RNDummyGestureRecognizer class]]) {
-            return recognizer.gestureHandler;
+            return recognizer.ABI45_0_0gestureHandler;
         }
     }
 

--- a/ios/vendored/sdk46/react-native-gesture-handler/ios/ABI46_0_0RNGestureHandler.m
+++ b/ios/vendored/sdk46/react-native-gesture-handler/ios/ABI46_0_0RNGestureHandler.m
@@ -7,14 +7,14 @@
 
 #import <ABI46_0_0React/ABI46_0_0UIView+React.h>
 
-@interface UIGestureRecognizer (GestureHandler)
-@property (nonatomic, readonly) ABI46_0_0RNGestureHandler *gestureHandler;
+@interface UIGestureRecognizer (ABI46_0_0GestureHandler)
+@property (nonatomic, readonly) ABI46_0_0RNGestureHandler *ABI46_0_0gestureHandler;
 @end
 
 
-@implementation UIGestureRecognizer (GestureHandler)
+@implementation UIGestureRecognizer (ABI46_0_0GestureHandler)
 
-- (ABI46_0_0RNGestureHandler *)gestureHandler
+- (ABI46_0_0RNGestureHandler *)ABI46_0_0gestureHandler
 {
     id delegate = self.delegate;
     if ([delegate isKindOfClass:[ABI46_0_0RNGestureHandler class]]) {
@@ -343,7 +343,7 @@ static NSHashTable<ABI46_0_0RNGestureHandler *> *allGestureHandlers;
 
 + (ABI46_0_0RNGestureHandler *)findGestureHandlerByRecognizer:(UIGestureRecognizer *)recognizer
 {
-    ABI46_0_0RNGestureHandler *handler = recognizer.gestureHandler;
+    ABI46_0_0RNGestureHandler *handler = recognizer.ABI46_0_0gestureHandler;
     if (handler != nil) {
         return handler;
     }
@@ -357,7 +357,7 @@ static NSHashTable<ABI46_0_0RNGestureHandler *> *allGestureHandlers;
 
     for (UIGestureRecognizer *recognizer in reactView.gestureRecognizers) {
         if ([recognizer isKindOfClass:[ABI46_0_0RNDummyGestureRecognizer class]]) {
-            return recognizer.gestureHandler;
+            return recognizer.ABI46_0_0gestureHandler;
         }
     }
 

--- a/tools/src/versioning/ios/transforms/vendoredModulesTransforms.ts
+++ b/tools/src/versioning/ios/transforms/vendoredModulesTransforms.ts
@@ -136,12 +136,12 @@ export default function vendoredModulesTransformsFactory(prefix: string): Config
         {
           paths: 'RNGestureHandler.m',
           find: /UIGestureRecognizer \(GestureHandler\)/g,
-          replaceWith: `UIGestureRecognizer (${prefix}GestureHandler)`
+          replaceWith: `UIGestureRecognizer (${prefix}GestureHandler)`,
         },
         {
           paths: 'RNGestureHandler.m',
           find: /gestureHandler/g,
-          replaceWith: `${prefix}gestureHandler`
+          replaceWith: `${prefix}gestureHandler`,
         },
       ],
     },

--- a/tools/src/versioning/ios/transforms/vendoredModulesTransforms.ts
+++ b/tools/src/versioning/ios/transforms/vendoredModulesTransforms.ts
@@ -133,6 +133,16 @@ export default function vendoredModulesTransformsFactory(prefix: string): Config
           find: /\bRN(\w+?)\b/g,
           replaceWith: `${prefix}RN$1`,
         },
+        {
+          paths: 'RNGestureHandler.m',
+          find: /UIGestureRecognizer \(GestureHandler\)/g,
+          replaceWith: `UIGestureRecognizer (${prefix}GestureHandler)`
+        },
+        {
+          paths: 'RNGestureHandler.m',
+          find: /gestureHandler/g,
+          replaceWith: `${prefix}gestureHandler`
+        },
       ],
     },
     'react-native-pager-view': {


### PR DESCRIPTION
# Why

Fixes: https://github.com/software-mansion/react-native-gesture-handler/issues/2169
Similar to the https://github.com/expo/expo/pull/18657, but for the Expo Go.

# How

Updated versioning script and run:
`et add-sdk-version --platform ios --sdkVersion 46.0.0 -v react-native-gesture-handler`

For other SDKs, I apply this change manually. 

# Test Plan

- [snack.expo.dev/@gorhom/7a1a40](https://snack.expo.dev/@gorhom/7a1a40) ✅