### PR TITLE
[docs] clean up dev client compatibility page

### DIFF
--- a/docs/pages/development/compatibility.md
+++ b/docs/pages/development/compatibility.md
@@ -8,32 +8,28 @@ You do not need to use any of these packages in your project in order to use `ex
 
 ## Expo SDKs
 
-This table lists the highest minor version of `expo-dev-client` that is supported by each Expo SDK version.
+In a project with the `expo` package installed, running `npx expo install expo-dev-client` will always install the latest compatible version. For convenience, this table lists the highest minor version of `expo-dev-client` that is supported by various Expo SDK versions.
 
-| Expo SDK | expo-dev-client   |
-| -------- | ----------------- |
-| SDK 45   | `0.9.X` - `1.0.X` |
-| SDK 44   | `0.8.X`           |
-| SDK 43   | `0.8.X`           |
-| SDK 42   | `0.7.X`           |
+| Expo SDK | expo-dev-client |
+| -------- | --------------- |
+| SDK 46   | `1.2.X`         |
+| SDK 45   | `1.0.X`         |
+| SDK 44   | `0.8.X`         |
+| SDK 43   | `0.8.X`         |
+| SDK 42   | `0.7.X`         |
 
 ## react-native
 
 | expo-dev-client | react-native        |
 | --------------- | ------------------- |
+| `1.2.X`         | `0.69.X`            |
+| `1.1.X`         | `0.69.X`            |
+| `1.0.X`         | `0.64.X` - `0.68.X` |
 | `0.9.X`         | `0.64.X` - `0.68.X` |
 | `0.8.X`         | `0.64.X`            |
 | `0.7.X`         | `0.62.X` - `0.64.X` |
 | `0.6.X`         | `0.62.X` - `0.63.X` |
 
-## expo-splash-screen
-
-| expo-dev-client | expo-splash-screen           |
-| --------------- | ---------------------------- |
-| `0.4.X`         | `0.10.3`, `0.11.2` and above |
-
 ## react-native-reanimated
 
-| expo-dev-client | react-native-reanimated |
-| --------------- | ----------------------- |
-| `0.4.X`         | `2.2.0` and above       |
+All recent versions of `expo-dev-client` are compatible with `react-native-reanimated@2.2.0` and above.


### PR DESCRIPTION
# Why

fixes ENG-6064

# How

- Added compatibility information with Expo & RN for the last few dev client versions
- Added a note about `npx expo install` which kind of supersedes the first table (I think it was added before dev-client was in `bundledNativeModules`)
- Removed splash screen compatibility table as it's no longer relevant

# Test Plan

`yarn dev`, page renders as expected

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
