### PR TITLE
[docs] add expected stacktrace to error recovery page

### DIFF
--- a/docs/pages/bare/error-recovery.md
+++ b/docs/pages/bare/error-recovery.md
@@ -88,7 +88,7 @@ Last Exception Backtrace:
 
 Even though it appears the exception was thrown from expo-updates, this stacktrace generally indicates **an error that originated in JavaScript**.
 
-Unfortunately, Apple's crash reporting does not include the exception message, which details the underlying error and its location in JavaScript. To see the message and help you narrow down the issue, you may need to reproduce the crash locally with the Xcode debugger or Console app attached.
+Unfortunately, Apple's crash reporting does not include the exception message, which details the underlying error and its location in JavaScript. To see the message and help you narrow down the issue, you may need to reproduce the crash locally with the Xcode debugger or macOS Console app attached.
 
 </Tab>
 

--- a/docs/pages/bare/error-recovery.md
+++ b/docs/pages/bare/error-recovery.md
@@ -3,6 +3,8 @@ title: Error Recovery
 sidebar_title: Error Recovery
 ---
 
+import { Tab, Tabs } from '~/components/plugins/Tabs';
+
 Apps using `expo-updates` can take advantage of built-in error recovery behavior as an extra safeguard against accidentally publishing broken updates.
 
 While we cannot stress enough the importance of testing updates in a staging environment before publishing to production, humans (and even computers) occasionally make mistakes, and the error recovery behavior described here can serve as a last resort in such cases.
@@ -59,6 +61,63 @@ If an error is caught before the "content appeared" event has fired, AND this is
 - If a new update finishes downloading before the timer runs out, the app will immediately try to reload itself and launch the newly downloaded update.
 - If this newly downloaded update also throws a fatal error, OR there is no new update, OR the timer runs out, the app will immediately try to reload by rolling back to an older update, whichever one was most recently launched successfully.
 - If this also fails, or there is no older update available on the device, the app will throw the original error and crash.
+
+## Error stacktraces
+
+If your app encounters a fatal JS error, and the error recovery system cannot recover, it will re-throw the original exception in order to cause a crash. The stacktrace will look similar to this:
+
+<Tabs tabs={["iOS", "Android"]}>
+
+<Tab>
+
+```
+Last Exception Backtrace:
+0   CoreFoundation                	0xf203feba4 __exceptionPreprocess + 220 (NSException.m:200)
+1   libobjc.A.dylib               	0xf201a1be7 objc_exception_throw + 60 (objc-exception.mm:565)
+2   MyApp                         	0x10926b7ee -[EXUpdatesAppController throwException:] + 24 (EXUpdatesAppController.m:422)
+3   MyApp                         	0x109280352 -[EXUpdatesErrorRecovery _crash] + 984 (EXUpdatesErrorRecovery.m:222)
+4   MyApp                         	0x10927fa3d -[EXUpdatesErrorRecovery _runNextTask] + 148 (EXUpdatesErrorRecovery.m:0)
+5   libdispatch.dylib             	0x109bc1848 _dispatch_call_block_and_release + 32 (init.c:1517)
+6   libdispatch.dylib             	0x109bc2a2c _dispatch_client_callout + 20 (object.m:560)
+7   libdispatch.dylib             	0x109bc93a6 _dispatch_lane_serial_drain + 668 (inline_internal.h:2622)
+8   libdispatch.dylib             	0x109bca0bc _dispatch_lane_invoke + 392 (queue.c:3944)
+9   libdispatch.dylib             	0x109bd6472 _dispatch_workloop_worker_thread + 648 (queue.c:6732)
+10  libsystem_pthread.dylib       	0xf6da2845d _pthread_wqthread + 288 (pthread.c:2599)
+11  libsystem_pthread.dylib       	0xf6da2742f start_wqthread + 8
+```
+
+Even though it appears the exception was thrown from expo-updates, this stacktrace generally indicates **an error that originated in JavaScript**.
+
+Unfortunately, Apple's crash reporting does not include the exception message, which details the underlying error and its location in JavaScript. To see the message and help you narrow down the issue, you may need to reproduce the crash locally with the Xcode debugger or Console app attached.
+
+</Tab>
+
+<Tab>
+
+```
+--------- beginning of crash
+AndroidRuntime: FATAL EXCEPTION: expo-updates-error-recovery
+AndroidRuntime: Process: com.myapp.MyApp, PID: 12498
+AndroidRuntime: com.facebook.react.common.JavascriptException
+AndroidRuntime:
+AndroidRuntime: 	at com.facebook.react.modules.core.ExceptionsManagerModule.reportException(ExceptionsManagerModule.java:72)
+AndroidRuntime: 	at java.lang.reflect.Method.invoke(Native Method)
+AndroidRuntime: 	at com.facebook.react.bridge.JavaMethodWrapper.invoke(JavaMethodWrapper.java:372)
+AndroidRuntime: 	at com.facebook.react.bridge.JavaModuleWrapper.invoke(JavaModuleWrapper.java:188)
+AndroidRuntime: 	at com.facebook.react.bridge.queue.NativeRunnable.run(Native Method)
+AndroidRuntime: 	at android.os.Handler.handleCallback(Handler.java:938)
+AndroidRuntime: 	at android.os.Handler.dispatchMessage(Handler.java:99)
+AndroidRuntime: 	at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:27)
+AndroidRuntime: 	at android.os.Looper.loop(Looper.java:223)
+AndroidRuntime: 	at com.facebook.react.bridge.queue.MessageQueueThreadImpl$4.run(MessageQueueThreadImpl.java:228)
+AndroidRuntime: 	at java.lang.Thread.run(Thread.java:923)
+```
+
+On Android, the stacktrace of the original exception is preserved. Depending on your crash reporting service, you may or may not need to reproduce the crash locally in order to see more information about the underlying error.
+
+</Tab>
+
+</Tabs>
 
 ## Note about `expo-error-recovery`
 


### PR DESCRIPTION
# Why

closes ENG-6042

# How

Build a bare app with expo-updates, cause a crash from JS without possibility of recovery (i.e. no fixed updates published). Document the relevant stacktraces so they can be found when searching.

# Test Plan

`yarn run dev`, ensured page & new tabs render as expected

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
