### PR TITLE
[docs] Tutorial: Update references of global CLI to local CLI

### DIFF
--- a/docs/pages/tutorial/image-picker.md
+++ b/docs/pages/tutorial/image-picker.md
@@ -12,19 +12,11 @@ So far we have been using code from React and React Native in our app. React giv
 
 ## Installing expo-image-picker
 
-To use expo-image-picker in our project, we first need to install it.
+To use `expo-image-picker` in our project, we first need to install it. In your project directory, run the following command:
 
-In your project directory, run the following command:
+<Terminal cmd={['$ npx expo install expo-image-picker']} />
 
-<Terminal cmd={['$ expo install expo-image-picker']} />
-
-This will tell npm (or yarn) to install a version of the `expo-image-picker` library that is compatible with your project. That's it!
-
-<Video file={"tutorial/cli-install.mp4"} />
-
-> The version numbers you see here may be different depending on when you do this tutorial.
-
-> expo-cli used yarn in this video instead of npm. The installation text will be slightly different if you do not have yarn installed. It's fine.
+This will tell npm (or yarn) to install a version of the `expo-image-picker` library that is compatible with your project.
 
 ## Picking an image
 

--- a/docs/pages/tutorial/planning.md
+++ b/docs/pages/tutorial/planning.md
@@ -29,7 +29,7 @@ Inside your preferred directory for storing your software projects, run the comm
 '$ cd ImageShare'
 ]} cmdCopy="npx create-expo-app ImageShare && cd ImageShare" />
 
-This will create a new project for the app that we will call "Image Share". Navigate to the directory and run `expo start` in it, open the project on your device, and open the code in your code editor of choice.
+This will create a new project for the app that we will call "Image Share". Navigate to the directory and run `npx expo start` in it, open the project on your device, and open the code in your code editor of choice.
 
 - If you have any trouble with this, please refer back to the ["Create a new app" page](/get-started/create-a-new-app).
 - If your app is up and running, it is time to [continue to the next step](/tutorial/text).

--- a/docs/pages/tutorial/sharing.md
+++ b/docs/pages/tutorial/sharing.md
@@ -13,7 +13,7 @@ Similar to expo-image-picker, the functionality that we need to share is availab
 
 You can install expo-sharing in the same way as you installed expo-image-picker. In your project directory run:
 
-<Terminal cmd={['$ expo install expo-sharing']} />
+<Terminal cmd={['$ npx expo install expo-sharing']} />
 
 ## Using expo-sharing to share an image
 
@@ -25,6 +25,7 @@ import React from 'react';
 import { Image, StyleSheet, Text, TouchableOpacity, View, /* @info This is required to determine which platform the code is going to run */ Platform /* @end */ } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
 /* @info As always, we must import it to use it */ import * as Sharing from 'expo-sharing'; /* @end */
+
 import * as ImageManipulator from "expo-image-manipulator";
 
 export default function App() {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Refs ENG-6084

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR global CLI references such as `expo start` & `expo install` to use local CLI with `npx`.

# Test Plan

Changes have been tested by running the docs locally.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
