### PR TITLE
[ios] Add support for view callbacks in Fabric

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Add better JSI error handling on Android. ([#18259](https://github.com/expo/expo/pull/18259) by [@lukmccall](https://github.com/lukmccall))
 - Experimental support for typed arrays on Android. ([#18379](https://github.com/expo/expo/pull/18379) by [@lukmccall](https://github.com/lukmccall))
 - Using JSI instead of the bridge to call native methods also on legacy modules on iOS. ([#18438](https://github.com/expo/expo/pull/18438) by [@tsapeta](https://github.com/tsapeta))
-- Experimental support for Fabric on iOS (currently supported only by `expo-linear-gradient`). ([#18500](https://github.com/expo/expo/pull/18500) by [@tsapeta](https://github.com/tsapeta))
+- Experimental support for Fabric on iOS. ([#18500](https://github.com/expo/expo/pull/18500), [#18678](https://github.com/expo/expo/pull/18678) by [@tsapeta](https://github.com/tsapeta))
 - Added view prop callbacks support for old-style views written in Objective-C. ([#18636](https://github.com/expo/expo/pull/18636) by [@tsapeta](https://github.com/tsapeta))
 - Add Logger support for writing logs to a file; add Logger and associated classes to Android. ([#18513](https://github.com/expo/expo/pull/18513) by [@douglowder](https://github.com/douglowder))
 - Experimental support for Fabric on Android. ([#18541](https://github.com/expo/expo/pull/18541) by [@kudo](https://github.com/kudo))

--- a/packages/expo-modules-core/common/cpp/fabric/ExpoViewEventEmitter.cpp
+++ b/packages/expo-modules-core/common/cpp/fabric/ExpoViewEventEmitter.cpp
@@ -1,0 +1,13 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+#include "ExpoViewEventEmitter.h"
+
+using namespace facebook;
+
+namespace expo {
+
+void ExpoViewEventEmitter::dispatch(std::string eventName, react::ValueFactory payloadFactory) const {
+  dispatchEvent(eventName, payloadFactory);
+}
+
+} // namespace expo

--- a/packages/expo-modules-core/common/cpp/fabric/ExpoViewEventEmitter.h
+++ b/packages/expo-modules-core/common/cpp/fabric/ExpoViewEventEmitter.h
@@ -5,12 +5,22 @@
 #ifdef __cplusplus
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
+#include <jsi/jsi.h>
+
+namespace react = facebook::react;
 
 namespace expo {
 
 class ExpoViewEventEmitter : public facebook::react::ViewEventEmitter {
 public:
   using ViewEventEmitter::ViewEventEmitter;
+  using Shared = std::shared_ptr<const ExpoViewEventEmitter>;
+
+  /**
+   Dispatches an event to send from the native view to JavaScript.
+   This is basically exposing `dispatchEvent` from `facebook::react::EventEmitter` for public use.
+   */
+  void dispatch(std::string eventName, react::ValueFactory payloadFactory) const;
 };
 
 } // namespace expo

--- a/packages/expo-modules-core/ios/ExpoModulesCore.h
+++ b/packages/expo-modules-core/ios/ExpoModulesCore.h
@@ -1,5 +1,9 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
+// Uncomment this to temporarily disable Fabric.
+// Also make sure to change `RCT_NEW_ARCH_ENABLED` C++ flag in Pods project's build settings.
+//#undef RN_FABRIC_ENABLED
+
 // Some headers needs to be imported from Objective-C code too.
 // Otherwise they won't be visible in `ExpoModulesCore-Swift.h`.
 #import <React/RCTView.h>

--- a/packages/expo-modules-core/ios/Fabric/ExpoFabricView.swift
+++ b/packages/expo-modules-core/ios/Fabric/ExpoFabricView.swift
@@ -91,6 +91,8 @@ public class ExpoFabricView: ExpoFabricViewObjC {
     }
   }
 
+  // MARK: - Privates
+
   /**
    Creates the content view using the associated view module.
    */
@@ -100,6 +102,25 @@ public class ExpoFabricView: ExpoFabricViewObjC {
     }
     // Setting the content view automatically adds the view as a subview.
     contentView = view
+    installEventDispatchers()
+  }
+
+  /**
+   Installs convenient event dispatchers for declared events, so the view can just invoke the block to dispatch the proper event.
+   */
+  private func installEventDispatchers() {
+    guard let view = contentView, let moduleHolder = moduleHolder else {
+      return
+    }
+    moduleHolder.viewManager?.eventNames.forEach { eventName in
+      installEventDispatcher(forEvent: eventName, onView: view) { [weak self] (body: [String: Any]) in
+        if let self = self {
+          self.dispatchEvent(eventName, payload: body)
+        } else {
+          log.error("Cannot dispatch an event while the managing ExpoFabricView is deallocated")
+        }
+      }
+    }
   }
 
   // MARK: - Statics

--- a/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.h
+++ b/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.h
@@ -31,6 +31,8 @@
 
 @property (nonatomic, strong, nullable) UIView *contentView;
 
+- (void)dispatchEvent:(nonnull NSString *)eventName payload:(nullable id)payload;
+
 - (void)updateProp:(nonnull NSString *)propName withValue:(nonnull id)value;
 
 - (void)prepareForRecycle;

--- a/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.mm
+++ b/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.mm
@@ -54,7 +54,22 @@ id convertFollyDynamicToId(const folly::dynamic &dyn)
 
 } // namespace
 
-@implementation ExpoFabricViewObjC
+/**
+ React Native doesn't use the "on" prefix internally. Instead, it uses "top" but it's on the roadmap to get rid of it too.
+ We're still using "on" in a few places, so let's make sure we normalize that.
+ */
+static NSString *normalizeEventName(NSString *eventName)
+{
+  if ([eventName hasPrefix:@"on"]) {
+    NSString *firstLetter = [[eventName substringWithRange:NSMakeRange(2, 1)] lowercaseString];
+    return [firstLetter stringByAppendingString:[eventName substringFromIndex:3]];
+  }
+  return eventName;
+}
+
+@implementation ExpoFabricViewObjC {
+  ExpoViewEventEmitter::Shared _eventEmitter;
+}
 
 - (instancetype)initWithFrame:(CGRect)frame
 {
@@ -94,6 +109,21 @@ id convertFollyDynamicToId(const folly::dynamic &dyn)
   }
 
   [super updateProps:props oldProps:oldProps];
+}
+
+- (void)updateEventEmitter:(const react::EventEmitter::Shared &)eventEmitter
+{
+  [super updateEventEmitter:eventEmitter];
+  _eventEmitter = std::static_pointer_cast<const ExpoViewEventEmitter>(eventEmitter);
+}
+
+#pragma mark - Events
+
+- (void)dispatchEvent:(nonnull NSString *)eventName payload:(nullable id)payload
+{
+  _eventEmitter->dispatch([normalizeEventName(eventName) UTF8String], [payload](jsi::Runtime &runtime) {
+    return jsi::Value(runtime, expo::convertObjCObjectToJSIValue(runtime, payload));
+  });
 }
 
 #pragma mark - Methods to override in Swift

--- a/packages/expo-modules-core/ios/Swift/Events/EventDispatcher.swift
+++ b/packages/expo-modules-core/ios/Swift/Events/EventDispatcher.swift
@@ -1,0 +1,28 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+/**
+ Type of the dispatcher handler.
+ - Note: It must be marked as `@convention(block)` as long as we support Objective-C views and thus need to use `setValue(_: forKey)`.
+ */
+internal typealias EventDispatcherHandler = @convention(block) ([String: Any]) -> Void
+
+/**
+ Installs convenient event dispatchers for the given event and view.
+ The provided handler can be specific to Paper or Fabric.
+ */
+internal func installEventDispatcher<ViewType>(forEvent eventName: String, onView view: ViewType, handler: @escaping EventDispatcherHandler) {
+  // Find view's property that is named as the prop and is wrapped by `Event`.
+  let child = Mirror(reflecting: view).children.first {
+    $0.label == "_\(eventName)"
+  }
+
+  if let event = child?.value as? AnyEventInternal {
+    event.settle(handler)
+  } else if let view = view as? UIView, view.responds(to: Selector(eventName)) {
+    // This is to handle events in legacy views written in Objective-C.
+    // Note that the property should be of type EXDirectEventBlock.
+    view.setValue(handler, forKey: eventName)
+  } else {
+    log.warn("Couldn't find the property for event '\(eventName)' in '\(type(of: view))' class")
+  }
+}

--- a/packages/expo-modules-core/ios/Swift/Views/ComponentData.swift
+++ b/packages/expo-modules-core/ios/Swift/Views/ComponentData.swift
@@ -69,38 +69,15 @@ public final class ComponentData: RCTComponentData {
 }
 
 /**
- Creates a setter for the event prop.
+ Creates a setter for the event prop. Used only by Paper.
  */
 private func createEventSetter(eventName: String, bridge: RCTBridge?) -> RCTPropBlockAlias {
   return { [weak bridge] (target: RCTComponent, value: Any) in
-    // Callback handler that dispatches the actual event.
-    let handler: AnyCallbackHandlerType = { [weak target] (body: [String: Any]) in
+    installEventDispatcher(forEvent: eventName, onView: target) { [weak target] (body: [String: Any]) in
       if let target = target {
         let componentEvent = RCTComponentEvent(name: eventName, viewTag: target.reactTag, body: body)
         bridge?.eventDispatcher().send(componentEvent)
       }
-    }
-
-    // This is to handle events in views written in Objective-C.
-    // Note that the property should be of type EXDirectEventBlock.
-    if let target = target as? NSObject, target.responds(to: Selector(eventName)) {
-      target.setValue(handler, forKey: eventName)
-      return
-    }
-
-    // Find view's property that is named as the prop and is wrapped by `Event`.
-    let child = Mirror(reflecting: target).children.first {
-      $0.label == "_\(eventName)"
-    }
-    guard let event = child?.value as? AnyEventInternal else {
-      return
-    }
-
-    // For callbacks React Native passes a bool value whether the prop is specified or not.
-    if value as? Bool == true {
-      event.settle(handler)
-    } else {
-      event.invalidate()
     }
   }
 }


### PR DESCRIPTION
# Why

Added support for view callbacks when Fabric is enabled.

# How

- Extended `ExpoViewEventEmitter` to expose protected `dispatchEvent` function for public use.
- Added a way for views to dispatch events.
- Both flows are supported: `EXDirectEventBlock` in Objective-C and `@Event` properties in Swift.
- Updated `fabric-tester` app by adding a video player that updates Play/Resume button based on the playback status received from the callback

# Test Plan

Tested in `fabric-tester`
