### PR TITLE
[client][iOS] Prebuild `react-native-gesture-handler`

### DIFF
--- a/packages/expo-dev-menu/expo-dev-menu.podspec
+++ b/packages/expo-dev-menu/expo-dev-menu.podspec
@@ -57,10 +57,16 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = { "DEFINES_MODULE" => "YES" }
 
   s.subspec 'GestureHandler' do |handler|
-    handler.source_files = 'vendored/react-native-gesture-handler/**/*.{h,m}'
-    handler.private_header_files = 'vendored/react-native-gesture-handler/**/*.h'
+    if File.exist?("vendored/react-native-gesture-handler/DevMenuRNGestureHandler.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')
+      handler.source_files = "vendored/react-native-gesture-handler/**/*.{h}"
+      handler.vendored_frameworks = "vendored/react-native-gesture-handler/DevMenuRNGestureHandler.xcframework"
+      handler.private_header_files = 'vendored/react-native-gesture-handler/**/*.h'
+    else
+      handler.source_files = 'vendored/react-native-gesture-handler/**/*.{h,m}'
+      handler.private_header_files = 'vendored/react-native-gesture-handler/**/*.h'
 
-    handler.compiler_flags = '-w -Xanalyzer -analyzer-disable-all-checks'
+      handler.compiler_flags = '-w -Xanalyzer -analyzer-disable-all-checks'
+    end
   end
 
   s.subspec 'Reanimated' do |reanimated|

--- a/packages/expo-dev-menu/vendored/react-native-gesture-handler/RNGestureHandler.podspec.json
+++ b/packages/expo-dev-menu/vendored/react-native-gesture-handler/RNGestureHandler.podspec.json
@@ -1,0 +1,21 @@
+{
+  "name": "DevMenuRNGestureHandler",
+  "version": "2.1.2",
+  "summary": "Experimental implementation of a new declarative API for gesture handling in react-native",
+  "homepage": "https://github.com/software-mansion/react-native-gesture-handler",
+  "license": "MIT",
+  "authors": {
+    "Krzysztof Magiera": "krzys.magiera@gmail.com"
+  },
+  "platforms": {
+    "ios": "12.0"
+  },
+  "source": {
+    "git": "https://github.com/software-mansion/react-native-gesture-handler",
+    "tag": "2.1.2"
+  },
+  "source_files": "ios/**/*.{h,m}",
+  "dependencies": {
+    "React-Core": []
+  }
+}

--- a/packages/expo-dev-menu/vendored/react-native-gesture-handler/ios/DevMenuRNGestureHandlerPointerTracker.h
+++ b/packages/expo-dev-menu/vendored/react-native-gesture-handler/ios/DevMenuRNGestureHandlerPointerTracker.h
@@ -1,4 +1,5 @@
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 #import "DevMenuRNTouchEventType.h"
 

--- a/tools/src/commands/Vendor.ts
+++ b/tools/src/commands/Vendor.ts
@@ -317,10 +317,21 @@ function getGestureHandlerPipe() {
       new CopyFiles({
         filePattern: 'ios/**/*.@(h|m)',
         to: destination,
+      }),
+      new GenerateJsonFromPodspec({
+        from: 'RNGestureHandler.podspec',
+        saveTo: `${destination}/RNGestureHandler.podspec.json`,
+        transform: async (podspec) => ({...podspec, name: 'DevMenuRNGestureHandler', platforms: {'ios': await getRequierdIosVersion()}})
       })
   );
 
-  return { transformations };
+  return {
+    transformations,
+    prebuild: {
+      podspecPath: `${destination}/RNGestureHandler.podspec.json`,
+      output: destination,
+    },
+  };
 }
 
 function getSafeAreaConfig() {


### PR DESCRIPTION
# Why

Prebuilding the `react-native-gesture-handler`
Part of ENG-5410.

# How

Similar to https://github.com/expo/expo/pull/18679.

# Test Plan

- run `et vendor -c "[dev-menu] gesture-handler" --only-prebuild` ✅
- build bare-expo ✅
