### PR TITLE
[splash-screen] Fixed `'SplashScreen.show' has already been called for given view controller.`

### DIFF
--- a/packages/expo-splash-screen/CHANGELOG.md
+++ b/packages/expo-splash-screen/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `'SplashScreen.show' has already been called for given view controller.` warning being displayed when using `expo-dev-client` on iOS.
+
 ### 💡 Others
 
 ## 0.16.1 — 2022-07-16

--- a/packages/expo-splash-screen/CHANGELOG.md
+++ b/packages/expo-splash-screen/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed `'SplashScreen.show' has already been called for given view controller.` warning being displayed when using `expo-dev-client` on iOS.
+- Fixed `'SplashScreen.show' has already been called for given view controller.` warning being displayed when using `expo-dev-client` on iOS. ([#18682](https://github.com/expo/expo/pull/18682) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenService.m
+++ b/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenService.m
@@ -188,7 +188,10 @@ EX_REGISTER_SINGLETON_MODULE(SplashScreen);
 {
   if (object == UIApplication.sharedApplication.keyWindow && [keyPath isEqualToString:kRootViewController]) {
     UIViewController *newRootViewController = change[@"new"];
-    if (newRootViewController != nil) {
+    // For unknown reasons, this function may be sometimes called twice with the same changes.
+    // What leads to warnings like this one: `'SplashScreen.show' has already been called for given view controller`.
+    // To prevent this weird behaviour, we check if the value was really changed.
+    if (newRootViewController != nil && newRootViewController != self.observingRootViewController) {
       [self removeRootViewControllerListener];
       [self showSplashScreenFor:newRootViewController options:EXSplashScreenDefault];
       [self addRootViewControllerListener];


### PR DESCRIPTION
# Why

Closes ENG-6063.

# How

For unknown reasons, `observeValueForKeyPath:ofObject:change:context:` may be sometimes called twice with the same change. I don't know why, but for sure we only add one listener 🤷 

# Test Plan

- bare-expo ✅
- expo go ✅