### PR TITLE
[expo-camera][android] - fix takePictureAsync when running on emulator

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Drop `@expo/config-plugins` dependency in favor of peer dependency on `expo`. ([#18595](https://github.com/expo/expo/pull/18595) by [@EvanBacon](https://github.com/EvanBacon))
 - Refactored inline Android emulator checks to use enhanced checking in `EmulatorUtilities.isRunningOnEmulator()`. ([#16177](https://github.com/expo/expo/pull/16177)) by [@kbrandwijk](https://github.com/kbrandwijk), [@keith-kurak](https://github.com/keith-kurak))
+- Refactored inline Android emulator checks to use enhanced checking in `EmulatorUtilities.isRunningOnEmulator()`. ([#18704](https://github.com/expo/expo/pull/18704)) by [@keith-kurak](https://github.com/keith-kurak))
 
 ## 12.3.0 — 2022-07-07
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -9,12 +9,12 @@
 - On iOS and Android, added new `additionalExif` parameter to `takePictureAsync()` method so that users can add extra information to the photos, such as GPS coordinates. ([#18469](https://github.com/expo/expo/pull/18469) by [@alexyangjie](https://github.com/alexyangjie))
 
 ### 🐛 Bug fixes
+- Fix error when calling `takePictureAsync()` on Android emulator. ([#18704](https://github.com/expo/expo/pull/18704)) by [@keith-kurak](https://github.com/keith-kurak))
 
 ### 💡 Others
 
 - Drop `@expo/config-plugins` dependency in favor of peer dependency on `expo`. ([#18595](https://github.com/expo/expo/pull/18595) by [@EvanBacon](https://github.com/EvanBacon))
 - Refactored inline Android emulator checks to use enhanced checking in `EmulatorUtilities.isRunningOnEmulator()`. ([#16177](https://github.com/expo/expo/pull/16177)) by [@kbrandwijk](https://github.com/kbrandwijk), [@keith-kurak](https://github.com/keith-kurak))
-- Refactored inline Android emulator checks to use enhanced checking in `EmulatorUtilities.isRunningOnEmulator()`. ([#18704](https://github.com/expo/expo/pull/18704)) by [@keith-kurak](https://github.com/keith-kurak))
 
 ## 12.3.0 — 2022-07-07
 

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraViewHelper.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraViewHelper.kt
@@ -20,6 +20,7 @@ import expo.modules.interfaces.facedetector.FaceDetectorInterface
 import expo.modules.camera.events.FaceDetectionErrorEvent
 import expo.modules.camera.events.PictureSavedEvent
 import expo.modules.camera.events.BarCodeScannedEvent
+import java.io.ByteArrayOutputStream
 import java.io.IOException
 import java.text.SimpleDateFormat
 import java.util.*
@@ -152,9 +153,9 @@ object CameraViewHelper {
     baseExif.saveAttributes()
   }
 
-  fun generateSimulatorPhoto(width: Int, height: Int): Bitmap {
-    val fakePhoto = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
-    val canvas = Canvas(fakePhoto)
+  fun generateSimulatorPhoto(width: Int, height: Int): ByteArray {
+    val fakePhotoBitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+    val canvas = Canvas(fakePhotoBitmap)
     val background = Paint().apply {
       color = Color.BLACK
     }
@@ -166,6 +167,10 @@ object CameraViewHelper {
     val calendar = Calendar.getInstance()
     val simpleDateFormat = SimpleDateFormat("dd.MM.yy HH:mm:ss", Locale.US)
     canvas.drawText(simpleDateFormat.format(calendar.time), width * 0.1f, height * 0.9f, textPaint)
-    return fakePhoto
+
+    val stream = ByteArrayOutputStream()
+    fakePhotoBitmap.compress(Bitmap.CompressFormat.PNG, 90, stream)
+    val fakePhotoByteArray = stream.toByteArray()
+    return fakePhotoByteArray
   }
 }


### PR DESCRIPTION
# Why

Resolve [ENG-5895](https://linear.app/expo/issue/ENG-5895/takepictureasync-fails-silently-while-trying-to-produce-a-sample-image), so `Camera.takePictureAsync()` takes a simulated photo instead of failing silently when running on an Android emulator.

# How

The only time `ResolveTakenPictureAsyncTask` took a `Bitmap` instead of a `ByteArray` was when processing the simulated photo, so changed `generateSimulatorPhoto()` to always return a `ByteArray` to make it use the same code paths as a real camera image. In turn, this meant that there was no scenario under which `imageData` would be null when executing `ResolveTakenPictureAsyncTask`, so made the value required and removed the null handling. 

# Test Plan

Tested bare-expo app/ Camera component test against emulator and Android device with `skipProcessing` on and off.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
