### PR TITLE
[docs] fix eas update getting started doc

### DIFF
--- a/docs/pages/eas-update/getting-started.md
+++ b/docs/pages/eas-update/getting-started.md
@@ -26,7 +26,7 @@ Install EAS and Expo CLIs by running:
 1. Create an account at [https://expo.dev/signup](https://expo.dev/signup)
 2. Then, log in with EAS CLI:
 
-<Terminal cmd={['$ eas login']} />
+   <Terminal cmd={['$ eas login']} />
 
 3. After logging in, you can verify the logged-in account with `eas whoami`.
 
@@ -40,15 +40,15 @@ Create a project by running:
 
 1. Install the latest `expo-updates` library with:
 
-<Terminal cmd={['$ expo install expo-updates']} />
+   <Terminal cmd={['$ expo install expo-updates']} />
 
 2. Initialize your project with EAS Update:
 
-<Terminal cmd={['$ eas update:configure']} />
+   <Terminal cmd={['$ eas update:configure']} />
 
 3. To set up the configuration file for builds, run:
 
-<Terminal cmd={['$ eas build:configure']} />
+   <Terminal cmd={['$ eas build:configure']} />
 
 This command will create a file named **eas.json**.
 


### PR DESCRIPTION
# Why

In the EAS Update getting started doc, the terminal components were not indented which make all the numbered list items incorrect.

# Screenshot

<img width="881" alt="Screen Shot 2022-08-19 at 3 12 49 AM" src="https://user-images.githubusercontent.com/6455018/185564389-34e541af-4773-4eaa-b678-c16e990726f5.png">

# Test Plan

Make sure that the numbered items are labeled correctly like in the screenshot above.