### PR TITLE
[core] Fix expo go build error

### DIFF
--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -211,6 +211,7 @@ android {
       "**/libjsi.so",
       "**/libreactnativejni.so",
       "**/libreact_debug.so",
+      "**/libreact_nativemodule_core.so",
       "**/libreact_render_debug.so",
       "**/libreact_render_graphics.so",
       "**/libreact_render_core.so",
@@ -489,7 +490,7 @@ def packageReactNdkReleaseLibs = tasks.register("packageReactNdkReleaseLibs", Co
 afterEvaluate {
   extractAARHeaders.dependsOn(prepareThirdPartyNdkHeaders)
   extractJNIFiles.dependsOn(prepareThirdPartyNdkHeaders)
-  if (hasHermesProject && !prebuiltHermesCacheHit) {
+  if (FOR_HERMES && hasHermesProject && !prebuiltHermesCacheHit) {
     prepareHermes.dependsOn(":ReactAndroid:hermes-engine:assembleDebug")
   }
 


### PR DESCRIPTION
# Why

fix expo go build error

```
ninja: error: '/Users/kudo/expo/expo/android/ReactAndroid/hermes-engine/build/intermediates/prefab_package/debug/prefab/modules/libhermes/libs/android.x86/libhermes.so', needed by 'ReactCommon/hermes/inspector/libhermes-inspector.a', missing and no known rule to make it
```

# How

1. i am still not figuring out why `prepareHermes.dependsOn(":ReactAndroid:hermes-engine:assembleDebug")` will cleanup existing libhermes.so. considering it's only for hermes, we should set the dependency only for hermes.
2. prevent duplicated `libreact_nativemodule_core.so`

# Test Plan

android expo go build success

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
