### PR TITLE
feat(docs): Update SQLite loading example 

### DIFF
--- a/docs/pages/versions/v43.0.0/sdk/sqlite.md
+++ b/docs/pages/versions/v43.0.0/sdk/sqlite.md
@@ -41,10 +41,20 @@ async function openDatabase(pathToDatabaseFile: string): Promise<SQLite.WebSQLDa
   if (!(await FileSystem.getInfoAsync(FileSystem.documentDirectory + 'SQLite')).exists) {
     await FileSystem.makeDirectoryAsync(FileSystem.documentDirectory + 'SQLite');
   }
-  await FileSystem.downloadAsync(
-    Asset.fromModule(require(pathToDatabaseFile)).uri,
-    FileSystem.documentDirectory + 'SQLite/myDatabaseName.db'
-  );
+  
+  const file = require(pathToDatabaseFile);
+  const dbURI = Asset.fromModule(file).uri;
+  
+  // Support Debug mode request(http://) and device request(file://) when load an asset
+  if (dbURI.includes("http")) {
+    await FileSystem.downloadAsync(dbURI, FileSystem.documentDirectory + 'SQLite/myDatabaseName.db');
+  } else {
+    await FileSystem.copyAsync({
+      from: dbURI,
+      to: FileSystem.documentDirectory + 'SQLite/myDatabaseName.db',
+    });
+  }
+    
   return SQLite.openDatabase('myDatabaseName.db');
 }
 ```


### PR DESCRIPTION
## Why?
When loading an asset from the package using the Simulator or Debug mode, it uses an `http://` request. When installed in the device via Testflight or Production mode, it uses the `file://` protocol that isn't supported to the [download async](https://docs.expo.dev/versions/latest/sdk/filesystem/#supported-uri-schemes-1) method, given an error.  

To make the code more realistic when going to production, I added a few lines to help others that could struggle with this problem. 