### PR TITLE
[docs] Localization: update examples

### DIFF
--- a/docs/pages/versions/unversioned/sdk/localization.md
+++ b/docs/pages/versions/unversioned/sdk/localization.md
@@ -54,7 +54,6 @@ Let's make our app support English and Japanese.
 <SnackInline label="Localization" dependencies={['expo-localization', 'i18n-js']}>
 
 ```tsx
-import * as React from 'react';
 import { View, StyleSheet, Text } from 'react-native';
 import * as Localization from 'expo-localization';
 import { I18n } from 'i18n-js';
@@ -67,17 +66,21 @@ const translations = {
 const i18n = new I18n(translations);
 
 // Set the locale once at the beginning of your app.
-i18n.locale = 'ja';
+i18n.locale = Localization.locale;
+
 // When a value is missing from a language it'll fallback to another language with the key present.
 i18n.enableFallback = true;
+// To see the fallback mechanism uncomment line below to force app to use Japanese language.
+// i18n.locale = 'ja';
 
-export default App => {
+export default function App() {
   return (
     <View style={styles.container}>
       <Text style={styles.text}>
         {i18n.t('welcome')} {i18n.t('name')}
       </Text>
       <Text>Current locale: {i18n.locale}</Text>
+      <Text>Device locale: {Localization.locale}</Text>
     </View>
   );
 };

--- a/docs/pages/versions/unversioned/sdk/localization.md
+++ b/docs/pages/versions/unversioned/sdk/localization.md
@@ -32,19 +32,19 @@ Let's make our app support English and Japanese.
 
   ```tsx
   import * as Localization from 'expo-localization';
-  import i18n from 'i18n-js';
+  import { I18n } from 'i18n-js';
   // Set the key-value pairs for the different languages you want to support.
-  i18n.translations = {
+  const i18n = new I18n({
     en: { welcome: 'Hello' },
     ja: { welcome: 'こんにちは' },
-  };
+  });
   // Set the locale once at the beginning of your app.
   i18n.locale = Localization.locale;
   ```
 
 ### API Design Tips
 
-- You may want to refrain from localizing text for certain things, like names. In this case you can define them _once_ in your default language and reuse them with `i18n.fallbacks = true;`.
+- You may want to refrain from localizing text for certain things, like names. In this case you can define them _once_ in your default language and reuse them with `i18n.enableFallback = true;`.
 - When a user changes the device's language, your app will reset. This means you can set the language once, and don't need to update any of your React components to account for the language changes.
 - On iOS, you can add `"CFBundleAllowMixedLocalizations": true` to your `ios.infoPlist` property [in your app.json](/workflow/configuration/#ios) so that your app supports the retrieval of localized strings from frameworks.
   - This will allow you to translate app metadata, including the homescreen display name! Read [here](/distribution/app-stores#localizing-your-ios-app) for details.
@@ -57,24 +57,27 @@ Let's make our app support English and Japanese.
 import * as React from 'react';
 import { View, StyleSheet, Text } from 'react-native';
 import * as Localization from 'expo-localization';
-import i18n from 'i18n-js';
+import { I18n } from 'i18n-js';
 
 // Set the key-value pairs for the different languages you want to support.
-i18n.translations = {
+const translations = {
   en: { welcome: 'Hello', name: 'Charlie' },
   ja: { welcome: 'こんにちは' },
 };
-// Set the locale once at the beginning of your app.
-i18n.locale = Localization.locale;
-// When a value is missing from a language it'll fallback to another language with the key present.
-i18n.fallbacks = true;
+const i18n = new I18n(translations);
 
-export default App => {
+// Set the locale once at the beginning of your app.
+i18n.locale = 'ja';
+// When a value is missing from a language it'll fallback to another language with the key present.
+i18n.enableFallback = true;
+
+export default (App) => {
   return (
     <View style={styles.container}>
       <Text style={styles.text}>
         {i18n.t('welcome')} {i18n.t('name')}
       </Text>
+      <Text>Current locale: {i18n.locale}</Text>
     </View>
   );
 };
@@ -89,6 +92,7 @@ const styles = StyleSheet.create({
   },
   text: {
     fontSize: 20,
+    marginBottom: 16
   },
 });
 /* @end */

--- a/docs/pages/versions/unversioned/sdk/localization.md
+++ b/docs/pages/versions/unversioned/sdk/localization.md
@@ -71,7 +71,7 @@ i18n.locale = 'ja';
 // When a value is missing from a language it'll fallback to another language with the key present.
 i18n.enableFallback = true;
 
-export default (App) => {
+export default App => {
   return (
     <View style={styles.container}>
       <Text style={styles.text}>

--- a/docs/pages/versions/unversioned/sdk/localization.md
+++ b/docs/pages/versions/unversioned/sdk/localization.md
@@ -8,6 +8,7 @@ import APISection from '~/components/plugins/APISection';
 import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
+import { Terminal } from '~/ui/components/Snippet';
 
 **`expo-localization`** allows you to Localize your app, customizing the experience for specific regions, languages, or cultures. It also provides access to the locale data on the native device.
 Using the popular library [`i18n-js`](https://github.com/fnando/i18n-js) with `expo-localization` will enable you to create a very accessible experience for users.
@@ -20,27 +21,25 @@ Using the popular library [`i18n-js`](https://github.com/fnando/i18n-js) with `e
 
 ## Usage
 
-Let's make our app support English and Japanese.
+Let's make our app support English and Japanese. To achive this install the i18n package `i18n-js`:
 
-- Install the i18n package `i18n-js`
+<Terminal cmd={['$ expo install i18n-js']} />
 
-  ```sh
-  yarn add i18n-js
-  ```
+Then, configure the languages for your app.
 
-- Configure the languages for your app.
+```tsx
+import * as Localization from 'expo-localization';
+import { I18n } from 'i18n-js';
 
-  ```tsx
-  import * as Localization from 'expo-localization';
-  import { I18n } from 'i18n-js';
-  // Set the key-value pairs for the different languages you want to support.
-  const i18n = new I18n({
-    en: { welcome: 'Hello' },
-    ja: { welcome: 'こんにちは' },
-  });
-  // Set the locale once at the beginning of your app.
-  i18n.locale = Localization.locale;
-  ```
+// Set the key-value pairs for the different languages you want to support.
+const i18n = new I18n({
+  en: { welcome: 'Hello' },
+  ja: { welcome: 'こんにちは' },
+});
+
+// Set the locale once at the beginning of your app.
+i18n.locale = Localization.locale;
+```
 
 ### API Design Tips
 

--- a/docs/pages/versions/unversioned/sdk/localization.md
+++ b/docs/pages/versions/unversioned/sdk/localization.md
@@ -82,7 +82,7 @@ export default function App() {
       <Text>Device locale: {Localization.locale}</Text>
     </View>
   );
-};
+}
 
 /* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({

--- a/docs/pages/versions/v45.0.0/sdk/localization.md
+++ b/docs/pages/versions/v45.0.0/sdk/localization.md
@@ -32,19 +32,19 @@ Let's make our app support English and Japanese.
 
   ```tsx
   import * as Localization from 'expo-localization';
-  import i18n from 'i18n-js';
+  import { I18n } from 'i18n-js';
   // Set the key-value pairs for the different languages you want to support.
-  i18n.translations = {
+  const i18n = new I18n({
     en: { welcome: 'Hello' },
     ja: { welcome: 'こんにちは' },
-  };
+  });
   // Set the locale once at the beginning of your app.
   i18n.locale = Localization.locale;
   ```
 
 ### API Design Tips
 
-- You may want to refrain from localizing text for certain things, like names. In this case you can define them _once_ in your default language and reuse them with `i18n.fallbacks = true;`.
+- You may want to refrain from localizing text for certain things, like names. In this case you can define them _once_ in your default language and reuse them with `i18n.enableFallback = true;`.
 - When a user changes the device's language, your app will reset. This means you can set the language once, and don't need to update any of your React components to account for the language changes.
 - On iOS, you can add `"CFBundleAllowMixedLocalizations": true` to your `ios.infoPlist` property [in your app.json](/workflow/configuration/#ios) so that your app supports the retrieval of localized strings from frameworks.
   - This will allow you to translate app metadata, including the homescreen display name! Read [here](/distribution/app-stores#localizing-your-ios-app) for details.
@@ -57,24 +57,27 @@ Let's make our app support English and Japanese.
 import * as React from 'react';
 import { View, StyleSheet, Text } from 'react-native';
 import * as Localization from 'expo-localization';
-import i18n from 'i18n-js';
+import { I18n } from 'i18n-js';
 
 // Set the key-value pairs for the different languages you want to support.
-i18n.translations = {
+const translations = {
   en: { welcome: 'Hello', name: 'Charlie' },
   ja: { welcome: 'こんにちは' },
 };
-// Set the locale once at the beginning of your app.
-i18n.locale = Localization.locale;
-// When a value is missing from a language it'll fallback to another language with the key present.
-i18n.fallbacks = true;
+const i18n = new I18n(translations);
 
-export default App => {
+// Set the locale once at the beginning of your app.
+i18n.locale = 'ja';
+// When a value is missing from a language it'll fallback to another language with the key present.
+i18n.enableFallback = true;
+
+export default (App) => {
   return (
     <View style={styles.container}>
       <Text style={styles.text}>
         {i18n.t('welcome')} {i18n.t('name')}
       </Text>
+      <Text>Current locale: {i18n.locale}</Text>
     </View>
   );
 };
@@ -89,6 +92,7 @@ const styles = StyleSheet.create({
   },
   text: {
     fontSize: 20,
+    marginBottom: 16
   },
 });
 /* @end */

--- a/docs/pages/versions/v45.0.0/sdk/localization.md
+++ b/docs/pages/versions/v45.0.0/sdk/localization.md
@@ -71,7 +71,7 @@ i18n.locale = 'ja';
 // When a value is missing from a language it'll fallback to another language with the key present.
 i18n.enableFallback = true;
 
-export default (App) => {
+export default App => {
   return (
     <View style={styles.container}>
       <Text style={styles.text}>

--- a/docs/pages/versions/v45.0.0/sdk/localization.md
+++ b/docs/pages/versions/v45.0.0/sdk/localization.md
@@ -83,7 +83,7 @@ export default function App() {
       <Text>Device locale: {Localization.locale}</Text>
     </View>
   );
-};
+}
 
 /* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({

--- a/docs/pages/versions/v45.0.0/sdk/localization.md
+++ b/docs/pages/versions/v45.0.0/sdk/localization.md
@@ -8,6 +8,7 @@ import APISection from '~/components/plugins/APISection';
 import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
+import { Terminal } from '~/ui/components/Snippet';
 
 **`expo-localization`** allows you to Localize your app, customizing the experience for specific regions, languages, or cultures. It also provides access to the locale data on the native device.
 Using the popular library [`i18n-js`](https://github.com/fnando/i18n-js) with `expo-localization` will enable you to create a very accessible experience for users.
@@ -20,27 +21,25 @@ Using the popular library [`i18n-js`](https://github.com/fnando/i18n-js) with `e
 
 ## Usage
 
-Let's make our app support English and Japanese.
+Let's make our app support English and Japanese. To achive this install the i18n package `i18n-js`:
 
-- Install the i18n package `i18n-js`
+<Terminal cmd={['$ expo install i18n-js']} />
 
-  ```sh
-  yarn add i18n-js
-  ```
+Then, configure the languages for your app.
 
-- Configure the languages for your app.
+```tsx
+import * as Localization from 'expo-localization';
+import { I18n } from 'i18n-js';
 
-  ```tsx
-  import * as Localization from 'expo-localization';
-  import { I18n } from 'i18n-js';
-  // Set the key-value pairs for the different languages you want to support.
-  const i18n = new I18n({
-    en: { welcome: 'Hello' },
-    ja: { welcome: 'こんにちは' },
-  });
-  // Set the locale once at the beginning of your app.
-  i18n.locale = Localization.locale;
-  ```
+// Set the key-value pairs for the different languages you want to support.
+const i18n = new I18n({
+  en: { welcome: 'Hello' },
+  ja: { welcome: 'こんにちは' },
+});
+
+// Set the locale once at the beginning of your app.
+i18n.locale = Localization.locale;
+```
 
 ### API Design Tips
 

--- a/docs/pages/versions/v45.0.0/sdk/localization.md
+++ b/docs/pages/versions/v45.0.0/sdk/localization.md
@@ -67,17 +67,21 @@ const translations = {
 const i18n = new I18n(translations);
 
 // Set the locale once at the beginning of your app.
-i18n.locale = 'ja';
+i18n.locale = Localization.locale;
+
 // When a value is missing from a language it'll fallback to another language with the key present.
 i18n.enableFallback = true;
+// To see the fallback mechanism uncomment line below to force app to use Japanese language.
+// i18n.locale = 'ja';
 
-export default App => {
+export default function App() {
   return (
     <View style={styles.container}>
       <Text style={styles.text}>
         {i18n.t('welcome')} {i18n.t('name')}
       </Text>
       <Text>Current locale: {i18n.locale}</Text>
+      <Text>Device locale: {Localization.locale}</Text>
     </View>
   );
 };

--- a/docs/pages/versions/v46.0.0/sdk/localization.md
+++ b/docs/pages/versions/v46.0.0/sdk/localization.md
@@ -54,7 +54,6 @@ Let's make our app support English and Japanese.
 <SnackInline label="Localization" dependencies={['expo-localization', 'i18n-js']}>
 
 ```tsx
-import * as React from 'react';
 import { View, StyleSheet, Text } from 'react-native';
 import * as Localization from 'expo-localization';
 import { I18n } from 'i18n-js';
@@ -67,17 +66,21 @@ const translations = {
 const i18n = new I18n(translations);
 
 // Set the locale once at the beginning of your app.
-i18n.locale = 'ja';
+i18n.locale = Localization.locale;
+
 // When a value is missing from a language it'll fallback to another language with the key present.
 i18n.enableFallback = true;
+// To see the fallback mechanism uncomment line below to force app to use Japanese language.
+// i18n.locale = 'ja';
 
-export default App => {
+export default function App() {
   return (
     <View style={styles.container}>
       <Text style={styles.text}>
         {i18n.t('welcome')} {i18n.t('name')}
       </Text>
       <Text>Current locale: {i18n.locale}</Text>
+      <Text>Device locale: {Localization.locale}</Text>
     </View>
   );
 };

--- a/docs/pages/versions/v46.0.0/sdk/localization.md
+++ b/docs/pages/versions/v46.0.0/sdk/localization.md
@@ -32,19 +32,19 @@ Let's make our app support English and Japanese.
 
   ```tsx
   import * as Localization from 'expo-localization';
-  import i18n from 'i18n-js';
+  import { I18n } from 'i18n-js';
   // Set the key-value pairs for the different languages you want to support.
-  i18n.translations = {
+  const i18n = new I18n({
     en: { welcome: 'Hello' },
     ja: { welcome: 'こんにちは' },
-  };
+  });
   // Set the locale once at the beginning of your app.
   i18n.locale = Localization.locale;
   ```
 
 ### API Design Tips
 
-- You may want to refrain from localizing text for certain things, like names. In this case you can define them _once_ in your default language and reuse them with `i18n.fallbacks = true;`.
+- You may want to refrain from localizing text for certain things, like names. In this case you can define them _once_ in your default language and reuse them with `i18n.enableFallback = true;`.
 - When a user changes the device's language, your app will reset. This means you can set the language once, and don't need to update any of your React components to account for the language changes.
 - On iOS, you can add `"CFBundleAllowMixedLocalizations": true` to your `ios.infoPlist` property [in your app.json](/workflow/configuration/#ios) so that your app supports the retrieval of localized strings from frameworks.
   - This will allow you to translate app metadata, including the homescreen display name! Read [here](/distribution/app-stores#localizing-your-ios-app) for details.
@@ -57,24 +57,27 @@ Let's make our app support English and Japanese.
 import * as React from 'react';
 import { View, StyleSheet, Text } from 'react-native';
 import * as Localization from 'expo-localization';
-import i18n from 'i18n-js';
+import { I18n } from 'i18n-js';
 
 // Set the key-value pairs for the different languages you want to support.
-i18n.translations = {
+const translations = {
   en: { welcome: 'Hello', name: 'Charlie' },
   ja: { welcome: 'こんにちは' },
 };
-// Set the locale once at the beginning of your app.
-i18n.locale = Localization.locale;
-// When a value is missing from a language it'll fallback to another language with the key present.
-i18n.fallbacks = true;
+const i18n = new I18n(translations);
 
-export default App => {
+// Set the locale once at the beginning of your app.
+i18n.locale = 'ja';
+// When a value is missing from a language it'll fallback to another language with the key present.
+i18n.enableFallback = true;
+
+export default (App) => {
   return (
     <View style={styles.container}>
       <Text style={styles.text}>
         {i18n.t('welcome')} {i18n.t('name')}
       </Text>
+      <Text>Current locale: {i18n.locale}</Text>
     </View>
   );
 };

--- a/docs/pages/versions/v46.0.0/sdk/localization.md
+++ b/docs/pages/versions/v46.0.0/sdk/localization.md
@@ -8,6 +8,7 @@ import APISection from '~/components/plugins/APISection';
 import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
+import { Terminal } from '~/ui/components/Snippet';
 
 **`expo-localization`** allows you to Localize your app, customizing the experience for specific regions, languages, or cultures. It also provides access to the locale data on the native device.
 Using the popular library [`i18n-js`](https://github.com/fnando/i18n-js) with `expo-localization` will enable you to create a very accessible experience for users.
@@ -20,27 +21,25 @@ Using the popular library [`i18n-js`](https://github.com/fnando/i18n-js) with `e
 
 ## Usage
 
-Let's make our app support English and Japanese.
+Let's make our app support English and Japanese. To achive this install the i18n package `i18n-js`:
 
-- Install the i18n package `i18n-js`
+<Terminal cmd={['$ expo install i18n-js']} />
 
-  ```sh
-  yarn add i18n-js
-  ```
+Then, configure the languages for your app.
 
-- Configure the languages for your app.
+```tsx
+import * as Localization from 'expo-localization';
+import { I18n } from 'i18n-js';
 
-  ```tsx
-  import * as Localization from 'expo-localization';
-  import { I18n } from 'i18n-js';
-  // Set the key-value pairs for the different languages you want to support.
-  const i18n = new I18n({
-    en: { welcome: 'Hello' },
-    ja: { welcome: 'こんにちは' },
-  });
-  // Set the locale once at the beginning of your app.
-  i18n.locale = Localization.locale;
-  ```
+// Set the key-value pairs for the different languages you want to support.
+const i18n = new I18n({
+  en: { welcome: 'Hello' },
+  ja: { welcome: 'こんにちは' },
+});
+
+// Set the locale once at the beginning of your app.
+i18n.locale = Localization.locale;
+```
 
 ### API Design Tips
 

--- a/docs/pages/versions/v46.0.0/sdk/localization.md
+++ b/docs/pages/versions/v46.0.0/sdk/localization.md
@@ -82,7 +82,7 @@ export default function App() {
       <Text>Device locale: {Localization.locale}</Text>
     </View>
   );
-};
+}
 
 /* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({

--- a/docs/pages/versions/v46.0.0/sdk/localization.md
+++ b/docs/pages/versions/v46.0.0/sdk/localization.md
@@ -71,7 +71,7 @@ i18n.locale = 'ja';
 // When a value is missing from a language it'll fallback to another language with the key present.
 i18n.enableFallback = true;
 
-export default (App) => {
+export default App => {
   return (
     <View style={styles.container}>
       <Text style={styles.text}>
@@ -92,6 +92,7 @@ const styles = StyleSheet.create({
   },
   text: {
     fontSize: 20,
+    marginBottom: 16
   },
 });
 /* @end */


### PR DESCRIPTION
# Why

Fixes ENG-6091
Fixes #18695

# How

Update examples and methods mentions in text to address breaking changes in latest `i18n-js` release.

# Test Plan

https://snack.expo.dev/@simek/localization

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
