### PR TITLE
[docs] Logging: update deprecated command, use Terminals

### DIFF
--- a/docs/pages/workflow/logging.md
+++ b/docs/pages/workflow/logging.md
@@ -8,7 +8,7 @@ Writing to the logs in an Expo app works just like in the browser: use `console.
 
 ## Recommended: View logs with Expo tools
 
-When you open an app that is being served from Expo CLI, the app will send logs over to the server and make them conveniently available to you. 
+When you open an app that is being served from Expo CLI, the app will send logs over to the server and make them conveniently available to you.
 This means that you don't need to even have your device connected to your computer to see the logs -- in fact, if someone opens the app from the other side of the world you can still see your app's logs from their device.
 
 ### Viewing logs with Expo CLI
@@ -34,7 +34,7 @@ The following instructions apply to macOS.
 
 #### Option 1: Use GUI log
 
-- In simulator, press <kbd>Cmd ⌘</kbd> + <kbd>/</kbd>, _or_ go to `Debug -> Open System Log`.<br />Both of these open a log window that displays all of the logs from your device, including the logs from your Expo app.
+- In simulator, press <kbd>Cmd ⌘</kbd> + <kbd>/</kbd>, or go to `Debug -> Open System Log`.<br />Both of these open a log window that displays all of the logs from your device, including the logs from your Expo app.
 
 #### Option 2: Open it in terminal
 

--- a/docs/pages/workflow/logging.md
+++ b/docs/pages/workflow/logging.md
@@ -2,11 +2,14 @@
 title: Viewing logs
 ---
 
+import { Terminal } from '~/ui/components/Snippet';
+
 Writing to the logs in an Expo app works just like in the browser: use `console.log`, `console.warn` and `console.error`. Note: we don't currently support `console.table` outside of remote debugging mode.
 
 ## Recommended: View logs with Expo tools
 
-When you open an app that is being served from Expo CLI, the app will send logs over to the server and make them conveniently available to you. This means that you don't need to even have your device connected to your computer to see the logs -- in fact, if someone opens the app from the other side of the world you can still see your app's logs from their device.
+When you open an app that is being served from Expo CLI, the app will send logs over to the server and make them conveniently available to you. 
+This means that you don't need to even have your device connected to your computer to see the logs -- in fact, if someone opens the app from the other side of the world you can still see your app's logs from their device.
 
 ### Viewing logs with Expo CLI
 
@@ -20,28 +23,33 @@ While it's usually not necessary, if you want to see logs for everything happeni
 
 The following instructions apply to macOS.
 
-- `brew install --HEAD libimobiledevice -g`
-- Plug your phone in
-- `idevicepair pair`
-- Press accept on your device
-- Run `idevicesyslog`
+- Install `libimobiledevice`:
+  <Terminal cmd={["$ brew install --HEAD libimobiledevice -g"]} />
+- Plug your phone in and run:
+  <Terminal cmd={["$ idevicepair pair"]} />
+- Press accept on your device, after that run:
+  <Terminal cmd={["$ idevicesyslog"]} />
 
 ### View logs for an iOS simulator
 
 #### Option 1: Use GUI log
 
-- In simulator, press <kbd>Cmd ⌘</kbd> + <kbd>/</kbd>, _or_ go to `Debug -> Open System Log` -- both of these open a log window that displays all of the logs from your device, including the logs from your Expo app.
+- In simulator, press <kbd>Cmd ⌘</kbd> + <kbd>/</kbd>, _or_ go to `Debug -> Open System Log`.<br />Both of these open a log window that displays all of the logs from your device, including the logs from your Expo app.
 
 #### Option 2: Open it in terminal
 
-- Run `instruments -s devices`
-- Find the device / OS version that the simulator you are using, eg: `iPhone 6s (9.2) [5083E2F9-29B4-421C-BDB5-893952F2B780]`
-- The part in the brackets at the end is the device code, so you can now do this: `tail -f ~/Library/Logs/CoreSimulator/DEVICE_CODE/system.log`, eg: `tail -f ~/Library/Logs/CoreSimulator/5083E2F9-29B4-421C-BDB5-893952F2B780/system.log`
+- <Terminal cmd={["xcrun xctrace list devices"]} />
+- Find the device / OS version that the simulator you are using.<br />Example: `iPhone 13 Pro Simulator (15.2) (197FE178-B32F-42D8-8CC2-93F449DC9C1A)`
+- The part in the brackets at the end is the device code, so you can now run:
+  <Terminal cmd={[
+"$ tail -f ~/Library/Logs/CoreSimulator/DEVICE_CODE/system.log",
+"# Example: tail -f ~/Library/Logs/CoreSimulator/197FE178-B32F-42D8-8CC2-93F449DC9C1A/system.log"
+]} />
 
 ### View logs from Android device or emulator
 
 The following instructions apply to any OS that supports Android development.
 
-- Ensure Android SDK is installed
-- Ensure that [USB debugging is enabled on your device](https://developer.android.com/studio/run/device.html#device-developer-options) (not necessary for emulator).
-- Run `adb logcat`
+- Ensure that [USB debugging is enabled on your device](https://developer.android.com/studio/run/device#device-developer-options) (not necessary for emulator).
+- Ensure Android SDK is installed, then run:
+  <Terminal cmd={["$ adb logcat"]} />


### PR DESCRIPTION
# Why

With Xcode 13 release the `instruments` command has been removed:
* https://developer.apple.com/forums/thread/690887?answerId=690803022#690803022

# How

This PR updates the device listing command for iOS simulators. 

Additionally, I have added Terminal components and rephrased and reformatted few steps to better fit with added components.

# Test Plan

The changes have been tested by running docs website locally.

## Preview

![screencapture-localhost-3002-workflow-logging-2022-08-20-18_28_44](https://user-images.githubusercontent.com/719641/185756988-38fe40b3-7386-4aa0-89fb-0d30d2a055c9.png)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
