### PR TITLE
[modules][ios] Group together some common exceptions

### DIFF
--- a/packages/expo-modules-core/ios/NativeModulesProxy/NativeModulesProxyModule.swift
+++ b/packages/expo-modules-core/ios/NativeModulesProxy/NativeModulesProxyModule.swift
@@ -16,7 +16,7 @@ public class NativeModulesProxyModule: Module {
 
     AsyncFunction("callMethod") { (moduleName: String, methodName: String, arguments: [Any], promise: Promise) in
       guard let appContext = self.appContext else {
-        return promise.reject(AppContextLostException())
+        return promise.reject(Exceptions.AppContextLost())
       }
 
       // Call a method on the new module if exists

--- a/packages/expo-modules-core/ios/Swift/AppContext.swift
+++ b/packages/expo-modules-core/ios/Swift/AppContext.swift
@@ -342,14 +342,10 @@ public final class AppContext: NSObject {
 
 // MARK: - Public exceptions
 
-public final class AppContextLostException: Exception {
-  override public var reason: String {
-    "The app context has been lost"
-  }
-}
+// Deprecated since v1.0.0
+@available(*, deprecated, renamed: "Exceptions.AppContextLost")
+public typealias AppContextLostException = Exceptions.AppContextLost
 
-public final class RuntimeLostException: Exception {
-  override public var reason: String {
-    "The JavaScript runtime has been lost"
-  }
-}
+// Deprecated since v1.0.0
+@available(*, deprecated, renamed: "Exceptions.RuntimeLost")
+public typealias RuntimeLostException = Exceptions.RuntimeLost

--- a/packages/expo-modules-core/ios/Swift/Exceptions/CommonExceptions.swift
+++ b/packages/expo-modules-core/ios/Swift/Exceptions/CommonExceptions.swift
@@ -1,0 +1,62 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+/**
+ A group of the most common exceptions that might be necessary for modules.
+ */
+public struct Exceptions {
+  /**
+   The Expo app context is no longer available.
+   */
+  public final class AppContextLost: Exception {
+    override public var reason: String {
+      "The app context has been lost"
+    }
+  }
+
+  /**
+   The JavaScript runtime is no longer available.
+   */
+  public final class RuntimeLost: Exception {
+    override public var reason: String {
+      "The JavaScript runtime has been lost"
+    }
+  }
+
+  /**
+   An exception to throw when the operation is not supported on the simulator.
+   */
+  public final class SimulatorNotSupported: Exception {
+    override public var reason: String {
+      "This operation is not supported on the simulator"
+    }
+  }
+
+  /**
+   An exception to throw when the view with the given tag and class cannot be found.
+   */
+  public final class ViewNotFound<ViewType: UIView>: GenericException<(tag: Int, type: ViewType.Type)> {
+    override public var reason: String {
+      "Unable to find the '\(param.type)' view with tag '\(param.tag)'"
+    }
+  }
+
+  /**
+   An exception to throw when there is no module implementing the `EXFileSystemInterface` interface.
+   */
+  public final class FileSystemModuleNotFound: Exception {
+    override public var reason: String {
+      "FileSystem module not found, make sure 'expo-file-system' is linked correctly"
+    }
+  }
+
+  /**
+   An exception to throw when there is no module implementing the `EXPermissionsInterface` interface.
+   - Note: This should never happen since the module is a part of `expo-modules-core`, but for compatibility reasons
+   `appContext.permissions` is still an optional value.
+   */
+  public final class PermissionsModuleNotFound: Exception {
+    override public var reason: String {
+      "Permissions module not found"
+    }
+  }
+}


### PR DESCRIPTION
# Why

There are some exceptions that are useful in many modules, such as when the app context or runtime are lost or when the file system module is not linked.

# How

- Added `Exceptions` struct to `expo-modules-core` that groups together all common exceptions.
- Deprecated `AppContextLostException` in favor of `Exceptions.AppContextLost`
- Deprecated `RuntimeLostException` in favor of `Exceptions.RuntimeLost`

# Test Plan

I used some of those exceptions in #18703 
