### PR TITLE
[modules][ios] Create a default queue for async functions

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -17,13 +17,14 @@
 
 ### 🐛 Bug fixes
 
-- Fix issue with Android builds when gradle clean and build were called concurrently.  ([#18518](https://github.com/expo/expo/pull/18518) by [EdwardDrapkin](https://github.com/EdwardDrapkin))
+- Fix issue with Android builds when gradle clean and build were called concurrently. ([#18518](https://github.com/expo/expo/pull/18518) by [EdwardDrapkin](https://github.com/EdwardDrapkin))
 - Fixed `FabricUIManager` errors when turning on new architecture mode on Android. ([#18472](https://github.com/expo/expo/pull/18472) by [@kudo](https://github.com/kudo))
 - Fixed the `2 files found with path 'lib/arm64-v8a/libfbjni.so'` error on Android. ([#18607](https://github.com/expo/expo/pull/18607) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 
 - Centralized Android emulator detection for native code and added checks to pick up additional emulator types in `EmulatorUtilities`. ([#16177](https://github.com/expo/expo/pull/16177)) by [@kbrandwijk](https://github.com/kbrandwijk), [@keith-kurak](https://github.com/keith-kurak))
+- Created a separate high priority queue for all async function calls. ([#18734](https://github.com/expo/expo/pull/18734) by [@tsapeta](https://github.com/tsapeta))
 
 ## 0.11.3 — 2022-07-18
 

--- a/packages/expo-modules-core/ios/Swift/Functions/AsyncFunctionComponent.swift
+++ b/packages/expo-modules-core/ios/Swift/Functions/AsyncFunctionComponent.swift
@@ -13,6 +13,11 @@ internal protocol AnyAsyncFunctionComponent: AnyFunction {
 }
 
 /**
+ The default queue used for module's async function calls.
+ */
+private let defaultQueue = DispatchQueue(label: "expo.modules.AsyncFunctionQueue", qos: .userInitiated)
+
+/**
  Represents a function that can only be called asynchronously, thus its JavaScript equivalent returns a Promise.
  */
 public final class AsyncFunctionComponent<Args, FirstArgType, ReturnType>: AnyAsyncFunctionComponent {
@@ -86,7 +91,7 @@ public final class AsyncFunctionComponent<Args, FirstArgType, ReturnType>: AnyAs
       arguments.append(promise)
     }
 
-    let queue = queue ?? DispatchQueue.global(qos: .default)
+    let queue = queue ?? defaultQueue
 
     queue.async { [body, name] in
       let returnedValue: ReturnType?


### PR DESCRIPTION
# Why

Instead of using a global queue with the default QoS and requesting for it each time, it makes more sense to create one separate queue for all async functions (unless they're explicitly set to run on a different one).

# How

Created `expo.modules.AsyncFunctionQueue` with user initiated QoS, which is of higher priority than the default one, but lower than the main (UI) queue.

# Test Plan

After a quick look at some expo modules examples, everything seem to work as before.