### PR TITLE
Update example code in localization docs. The usage of i18n-js is deprecated. 

### DIFF
--- a/docs/pages/versions/v46.0.0/sdk/localization.md
+++ b/docs/pages/versions/v46.0.0/sdk/localization.md
@@ -32,12 +32,12 @@ Let's make our app support English and Japanese.
 
   ```tsx
   import * as Localization from 'expo-localization';
-  import i18n from 'i18n-js';
+  import { I18n } from 'i18n-js';
   // Set the key-value pairs for the different languages you want to support.
-  i18n.translations = {
+  const i18n = I18n({
     en: { welcome: 'Hello' },
     ja: { welcome: 'こんにちは' },
-  };
+  });
   // Set the locale once at the beginning of your app.
   i18n.locale = Localization.locale;
   ```
@@ -57,13 +57,13 @@ Let's make our app support English and Japanese.
 import * as React from 'react';
 import { View, StyleSheet, Text } from 'react-native';
 import * as Localization from 'expo-localization';
-import i18n from 'i18n-js';
+import { I18n } from 'i18n-js';
 
 // Set the key-value pairs for the different languages you want to support.
-i18n.translations = {
+const i18n = new I18n({
   en: { welcome: 'Hello', name: 'Charlie' },
   ja: { welcome: 'こんにちは' },
-};
+});
 // Set the locale once at the beginning of your app.
 i18n.locale = Localization.locale;
 // When a value is missing from a language it'll fallback to another language with the key present.

--- a/docs/pages/versions/v46.0.0/sdk/localization.md
+++ b/docs/pages/versions/v46.0.0/sdk/localization.md
@@ -67,7 +67,7 @@ const i18n = new I18n({
 // Set the locale once at the beginning of your app.
 i18n.locale = Localization.locale;
 // When a value is missing from a language it'll fallback to another language with the key present.
-i18n.fallbacks = true;
+i18n.enableFallback = true;
 
 export default App => {
   return (


### PR DESCRIPTION
# Why

The document is outdated. i18n.translations is not working for the latest version of i18n-js. 

# How

Update the latest method for creating i18n instance.

# Test Plan

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
