### PR TITLE
[with-node] Add quotes for arguments

### DIFF
--- a/packages/expo-constants/CHANGELOG.md
+++ b/packages/expo-constants/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed *with-node.sh* doesn't keep quotes when passing arguments to Node.js and caused build errors when there are spaces in target name. ([#18741](https://github.com/expo/expo/pull/18741) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 - Refactored inline Android emulator checks to use enhanced checking in `EmulatorUtilities.isRunningOnEmulator()`. ([#16177](https://github.com/expo/expo/pull/16177)) by [@kbrandwijk](https://github.com/kbrandwijk), [@keith-kurak](https://github.com/keith-kurak))

--- a/packages/expo-constants/scripts/with-node.sh
+++ b/packages/expo-constants/scripts/with-node.sh
@@ -40,5 +40,6 @@ fi
 
 # Execute argument, if present
 if [[ "$#" -gt 0 ]]; then
-  "$NODE_BINARY" $@
+  args=( "$@" )
+  "$NODE_BINARY" "${args[@]}"
 fi

--- a/packages/expo-constants/scripts/with-node.sh
+++ b/packages/expo-constants/scripts/with-node.sh
@@ -40,6 +40,5 @@ fi
 
 # Execute argument, if present
 if [[ "$#" -gt 0 ]]; then
-  args=( "$@" )
-  "$NODE_BINARY" "${args[@]}"
+  "$NODE_BINARY" "$@"
 fi

--- a/packages/expo-module-scripts/CHANGELOG.md
+++ b/packages/expo-module-scripts/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed *with-node.sh* doesn't keep quotes when passing arguments to Node.js and caused build errors when there are spaces in target name. ([#18741](https://github.com/expo/expo/pull/18741) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 2.1.0 — 2022-08-04

--- a/packages/expo-module-scripts/templates/scripts/with-node.sh
+++ b/packages/expo-module-scripts/templates/scripts/with-node.sh
@@ -40,5 +40,6 @@ fi
 
 # Execute argument, if present
 if [[ "$#" -gt 0 ]]; then
-  "$NODE_BINARY" $@
+  args=( "$@" )
+  "$NODE_BINARY" "${args[@]}"
 fi

--- a/packages/expo-module-scripts/templates/scripts/with-node.sh
+++ b/packages/expo-module-scripts/templates/scripts/with-node.sh
@@ -40,6 +40,5 @@ fi
 
 # Execute argument, if present
 if [[ "$#" -gt 0 ]]; then
-  args=( "$@" )
-  "$NODE_BINARY" "${args[@]}"
+  "$NODE_BINARY" "$@"
 fi

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### 🐛 Bug fixes
 
 - Fix small race condition in recovery code on Android where in very rare scenarios, a bundle could be downloaded twice. ([#18377](https://github.com/expo/expo/pull/18377) by [@esamelson](https://github.com/esamelson))
+- Fixed *with-node.sh* doesn't keep quotes when passing arguments to Node.js and caused build errors when there are spaces in target name. ([#18741](https://github.com/expo/expo/pull/18741) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-updates/scripts/with-node.sh
+++ b/packages/expo-updates/scripts/with-node.sh
@@ -40,5 +40,6 @@ fi
 
 # Execute argument, if present
 if [[ "$#" -gt 0 ]]; then
-  "$NODE_BINARY" $@
+  args=( "$@" )
+  "$NODE_BINARY" "${args[@]}"
 fi

--- a/packages/expo-updates/scripts/with-node.sh
+++ b/packages/expo-updates/scripts/with-node.sh
@@ -40,6 +40,5 @@ fi
 
 # Execute argument, if present
 if [[ "$#" -gt 0 ]]; then
-  args=( "$@" )
-  "$NODE_BINARY" "${args[@]}"
+  "$NODE_BINARY" "$@"
 fi


### PR DESCRIPTION
# Why

fix #18490

# How

keep quotes for the arguments.
~reference the solution from https://unix.stackexchange.com/a/472593~
reference the solution from https://stackoverflow.com/a/1669548

# Test Plan

```
$ yarn create expo-app -t blank@sdk-46 sdk46
$ npx expo prebuild
$ open ios/sdk46.xcworkspace
# change the scheme name to "sdk46 (test)"
# "Archive" the project
```

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
