### PR TITLE
[ci] fix EAS Build CI workflows

### DIFF
--- a/apps/eas-expo-go/app.config.ts
+++ b/apps/eas-expo-go/app.config.ts
@@ -10,26 +10,51 @@ const mapBuildProfileToConfig: Record<string, ExpoConfig> = {
     ...base,
     slug: 'versioned-expo-go-add-sdk',
     name: 'Expo Go (versioned) + add sdk',
+    extra: {
+      eas: {
+        projectId: '8550a402-d28f-4437-af87-2fb77b576c3f',
+      },
+    },
   },
   'versioned-client': {
     ...base,
     slug: 'versioned-expo-go',
     name: 'Expo Go (versioned)',
+    extra: {
+      eas: {
+        projectId: '97ab66f4-49e2-4ec7-85cc-922c56a68bae',
+      },
+    },
   },
   'versioned-client-signed': {
     ...base,
     slug: 'versioned-expo-go',
     name: 'Expo Go (versioned)',
+    extra: {
+      eas: {
+        projectId: '97ab66f4-49e2-4ec7-85cc-922c56a68bae',
+      },
+    },
   },
   'versioned-client-signed-apk': {
     ...base,
     slug: 'versioned-expo-go',
     name: 'Expo Go (versioned)',
+    extra: {
+      eas: {
+        projectId: '97ab66f4-49e2-4ec7-85cc-922c56a68bae',
+      },
+    },
   },
   'unversioned-client': {
     ...base,
     slug: 'unversioned-expo-go',
     name: 'Expo Go (unversioned)',
+    extra: {
+      eas: {
+        projectId: '09066dbe-ef65-460e-9201-b7aa931abbf4',
+      },
+    },
   },
 };
 


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/runs/7950405511?check_suite_focus=true

Latest EAS CLI requires projectId to be specified explicitlly

# How

Add projectIds in app.json.
Those IDs are real values for projects in `expo-ci` account, but they are not used for anything during the build process, because building Expo GO does not read that app.config.ts file.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
