### PR TITLE
fix(cli): fix `npx expo start --dev-client --ios`

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug fixes
 
+- Resolve bundle identifier from `app.json` correctly when using `npx expo start --dev-client --ios` with no local `ios` directory.
 - Add web support check to metro web in `expo start`. ([#18428](https://github.com/expo/expo/pull/18428) by [@EvanBacon](https://github.com/EvanBacon))
 - Prevent development session bad gateway from ending long running `expo start` processes. ([#18451](https://github.com/expo/expo/pull/18451) by [@EvanBacon](https://github.com/EvanBacon))
 - Speed up native device opening for iOS and Android. ([#18385](https://github.com/expo/expo/pull/18385) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 🐛 Bug fixes
 
-- Resolve bundle identifier from `app.json` correctly when using `npx expo start --dev-client --ios` with no local `ios` directory.
+- Resolve bundle identifier from `app.json` correctly when using `npx expo start --dev-client --ios` with no local `ios` directory. ([#18747](https://github.com/expo/expo/pull/18747) by [@EvanBacon](https://github.com/EvanBacon))
 - Add web support check to metro web in `expo start`. ([#18428](https://github.com/expo/expo/pull/18428) by [@EvanBacon](https://github.com/EvanBacon))
 - Prevent development session bad gateway from ending long running `expo start` processes. ([#18451](https://github.com/expo/expo/pull/18451) by [@EvanBacon](https://github.com/EvanBacon))
 - Speed up native device opening for iOS and Android. ([#18385](https://github.com/expo/expo/pull/18385) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/src/start/platforms/android/AndroidAppIdResolver.ts
+++ b/packages/@expo/cli/src/start/platforms/android/AndroidAppIdResolver.ts
@@ -2,6 +2,10 @@ import { AndroidConfig } from '@expo/config-plugins';
 
 import { AppIdResolver } from '../AppIdResolver';
 
+const debug = require('debug')(
+  'expo:start:platforms:android:AndroidAppIdResolver'
+) as typeof console.log;
+
 /** Resolves the Android package name from the Expo config or native files. */
 export class AndroidAppIdResolver extends AppIdResolver {
   constructor(projectRoot: string) {
@@ -12,7 +16,8 @@ export class AndroidAppIdResolver extends AppIdResolver {
     try {
       await AndroidConfig.Paths.getProjectPathOrThrowAsync(this.projectRoot);
       return true;
-    } catch {
+    } catch (error: any) {
+      debug('Expected error checking for native project:', error);
       return false;
     }
   }
@@ -33,7 +38,9 @@ export class AndroidAppIdResolver extends AppIdResolver {
       if (androidManifest.manifest?.$?.package) {
         return androidManifest.manifest.$.package;
       }
-    } catch {}
+    } catch (error: any) {
+      debug('Expected error resolving the package name from the AndroidManifest.xml:', error);
+    }
 
     return null;
   }

--- a/packages/@expo/cli/src/start/platforms/ios/AppleAppIdResolver.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/AppleAppIdResolver.ts
@@ -4,6 +4,8 @@ import fs from 'fs';
 
 import { AppIdResolver } from '../AppIdResolver';
 
+const debug = require('debug')('expo:start:platforms:ios:AppleAppIdResolver') as typeof console.log;
+
 /** Resolves the iOS bundle identifier from the Expo config or native files. */
 export class AppleAppIdResolver extends AppIdResolver {
   constructor(projectRoot: string) {
@@ -12,9 +14,11 @@ export class AppleAppIdResolver extends AppIdResolver {
 
   async hasNativeProjectAsync(): Promise<boolean> {
     try {
+      // Never returns nullish values.
       return !!IOSConfig.Paths.getAppDelegateFilePath(this.projectRoot);
-    } catch {
-      return true;
+    } catch (error: any) {
+      debug('Expected error checking for native project:', error);
+      return false;
     }
   }
 
@@ -25,7 +29,9 @@ export class AppleAppIdResolver extends AppIdResolver {
       if (bundleId) {
         return bundleId;
       }
-    } catch {}
+    } catch (error: any) {
+      debug('Expected error resolving the bundle identifier from the pbxproj:', error);
+    }
 
     // Check Info.plist
     try {
@@ -34,7 +40,9 @@ export class AppleAppIdResolver extends AppIdResolver {
       if (data.CFBundleIdentifier && !data.CFBundleIdentifier.startsWith('$(')) {
         return data.CFBundleIdentifier;
       }
-    } catch {}
+    } catch (error) {
+      debug('Expected error resolving the bundle identifier from the project Info.plist:', error);
+    }
 
     return null;
   }

--- a/packages/@expo/cli/src/start/platforms/ios/__tests__/AppleAppIdResolver-test.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/__tests__/AppleAppIdResolver-test.ts
@@ -28,6 +28,21 @@ jest.mock('@expo/config', () => ({
 
 // Most cases are tested in the superclass.
 
+describe('hasNativeProjectAsync', () => {
+  it(`returns true when the AppDelegate file exists`, async () => {
+    const resolver = new AppleAppIdResolver('/');
+    asMock(IOSConfig.Paths.getAppDelegateFilePath).mockReturnValueOnce('/foo/bar/AppDelegate.m');
+    expect(await resolver.hasNativeProjectAsync()).toBe(true);
+  });
+  it(`returns false when the AppDelegate getter throws`, async () => {
+    const resolver = new AppleAppIdResolver('/');
+    asMock(IOSConfig.Paths.getAppDelegateFilePath).mockImplementationOnce(() => {
+      throw new Error('file missing');
+    });
+    expect(await resolver.hasNativeProjectAsync()).toBe(false);
+  });
+});
+
 describe('getAppIdAsync', () => {
   it('resolves the app id from native files', async () => {
     const resolver = new AppleAppIdResolver('/');


### PR DESCRIPTION

# Why

- resolve ENG-6095
- Resolve bundle identifier from `app.json` correctly when using `npx expo start --dev-client --ios` with no local `ios` directory

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
