### PR TITLE
fix(cli): handle UNAUTHORIZED errors

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -17,7 +17,7 @@
 - Speed up native device opening for iOS and Android. ([#18385](https://github.com/expo/expo/pull/18385) by [@EvanBacon](https://github.com/EvanBacon))
 - Drop support for experimental Webpack native symbolication. ([#18439](https://github.com/expo/expo/pull/18439) by [@EvanBacon](https://github.com/EvanBacon))
 - Implement getApplicationIdFromBundle fixing iOS app launch issue with SDK 46. ([#18537](https://github.com/expo/expo/pull/18537) by [@Anthony Mittaz](https://github.com/Anthony Mittaz))
-- Change `UNAUTHORIZED_ERROR` to `UNAUTHORIZED` to handle unauthorized errors.
+- Change `UNAUTHORIZED_ERROR` to `UNAUTHORIZED` to handle unauthorized errors. ([#18751](https://github.com/expo/expo/pull/18751) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Speed up native device opening for iOS and Android. ([#18385](https://github.com/expo/expo/pull/18385) by [@EvanBacon](https://github.com/EvanBacon))
 - Drop support for experimental Webpack native symbolication. ([#18439](https://github.com/expo/expo/pull/18439) by [@EvanBacon](https://github.com/EvanBacon))
 - Implement getApplicationIdFromBundle fixing iOS app launch issue with SDK 46. ([#18537](https://github.com/expo/expo/pull/18537) by [@Anthony Mittaz](https://github.com/Anthony Mittaz))
+- Change `UNAUTHORIZED_ERROR` to `UNAUTHORIZED` to handle unauthorized errors.
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/api/rest/client.ts
+++ b/packages/@expo/cli/src/api/rest/client.ts
@@ -14,6 +14,7 @@ import { wrapFetchWithOffline } from './wrapFetchWithOffline';
 
 export class ApiV2Error extends Error {
   readonly name = 'ApiV2Error';
+  readonly code: string;
   readonly expoApiV2ErrorCode: string;
   readonly expoApiV2ErrorDetails?: JSONValue;
   readonly expoApiV2ErrorServerStack?: string;
@@ -27,6 +28,7 @@ export class ApiV2Error extends Error {
     metadata?: object;
   }) {
     super(response.message);
+    this.code = response.code;
     this.expoApiV2ErrorCode = response.code;
     this.expoApiV2ErrorDetails = response.details;
     this.expoApiV2ErrorServerStack = response.stack;

--- a/packages/@expo/cli/src/start/server/middleware/ClassicManifestMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/ClassicManifestMiddleware.ts
@@ -28,6 +28,10 @@ type SignManifestProps = {
 
 interface ClassicManifestRequestInfo extends ManifestRequestInfo {}
 
+const debug = require('debug')(
+  'expo:start:server:middleware:ClassicManifestMiddleware'
+) as typeof console.log;
+
 export class ClassicManifestMiddleware extends ManifestMiddleware<ClassicManifestRequestInfo> {
   public getParsedHeaders(req: ServerRequest): ClassicManifestRequestInfo {
     const platform = parsePlatformHeader(req) || 'ios';
@@ -111,7 +115,8 @@ export class ClassicManifestMiddleware extends ManifestMiddleware<ClassicManifes
     try {
       return await this._getManifestStringAsync(props);
     } catch (error: any) {
-      if (error.code === 'UNAUTHORIZED_ERROR' && props.manifest.owner) {
+      debug(`Error getting manifest:`, error);
+      if (error.code === 'UNAUTHORIZED' && props.manifest.owner) {
         // Don't have permissions for siging, warn and enable offline mode.
         this.addSigningDisabledWarning(
           `This project belongs to ${chalk.bold(

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/ClassicManifestMiddleware-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/ClassicManifestMiddleware-test.ts
@@ -1,9 +1,9 @@
 import { asMock } from '../../../../__tests__/asMock';
+import { ApiV2Error } from '../../../../api/rest/client';
 import { APISettings } from '../../../../api/settings';
 import { signClassicExpoGoManifestAsync } from '../../../../api/signManifest';
 import { getUserAsync } from '../../../../api/user/user';
 import * as Log from '../../../../log';
-import { CommandError } from '../../../../utils/errors';
 import { ClassicManifestMiddleware } from '../ClassicManifestMiddleware';
 import { ServerRequest } from '../server.types';
 
@@ -97,7 +97,7 @@ describe('_fetchComputedManifestStringAsync', () => {
     middleware._getManifestStringAsync = jest
       .fn()
       .mockImplementationOnce(() => {
-        throw new CommandError('UNAUTHORIZED');
+        throw new ApiV2Error({ message: '...', code: 'UNAUTHORIZED' });
       })
       .mockImplementationOnce(async () => 'signed-manifest-lol');
 
@@ -125,7 +125,7 @@ describe('_fetchComputedManifestStringAsync', () => {
     middleware._getManifestStringAsync = jest
       .fn()
       .mockImplementationOnce(() => {
-        throw new CommandError('ENOTFOUND');
+        throw new ApiV2Error({ message: '...', code: 'ENOTFOUND' });
       })
       .mockImplementationOnce(async () => 'signed-manifest-lol');
 
@@ -172,7 +172,7 @@ describe('_fetchComputedManifestStringAsync', () => {
     const middleware = new ClassicManifestMiddleware('/', {} as any);
 
     middleware._getManifestStringAsync = jest.fn(() => {
-      throw new CommandError('ENOTFOUND');
+      throw new ApiV2Error({ message: '...', code: 'ENOTFOUND' });
     });
 
     const invokeMethod = async (owner = 'bacon') => {
@@ -197,7 +197,7 @@ describe('_fetchComputedManifestStringAsync', () => {
     expect(Log.warn).toBeCalledTimes(1);
 
     middleware._getManifestStringAsync = jest.fn(() => {
-      throw new CommandError('UNAUTHORIZED');
+      throw new ApiV2Error({ message: '...', code: 'UNAUTHORIZED' });
     });
 
     // Call again but with a different error.

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/ClassicManifestMiddleware-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/ClassicManifestMiddleware-test.ts
@@ -97,7 +97,7 @@ describe('_fetchComputedManifestStringAsync', () => {
     middleware._getManifestStringAsync = jest
       .fn()
       .mockImplementationOnce(() => {
-        throw new CommandError('UNAUTHORIZED_ERROR');
+        throw new CommandError('UNAUTHORIZED');
       })
       .mockImplementationOnce(async () => 'signed-manifest-lol');
 
@@ -197,7 +197,7 @@ describe('_fetchComputedManifestStringAsync', () => {
     expect(Log.warn).toBeCalledTimes(1);
 
     middleware._getManifestStringAsync = jest.fn(() => {
-      throw new CommandError('UNAUTHORIZED_ERROR');
+      throw new CommandError('UNAUTHORIZED');
     });
 
     // Call again but with a different error.


### PR DESCRIPTION
# Why

The API error didn't match anymore causing unauthorized accounts to fail when loading signed manifests. This was reported by the React Navigation team in Discord.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# Test Plan

- `expo.owner: 'foobarthing'` in `app.json`
- `expo start --ios` should warn and continue loading the project in Expo Go as expected:
```
This project belongs to @react-navigation and you have not been granted the appropriate permissions.
Please request access from an admin of @react-navigation or change the "owner" field to an account you belong to.
Learn more: https://docs.expo.dev/versions/latest/config/app/#owner
Falling back to offline mode.
```

## Continuous

- We had tests in place but they didn't work, now they do.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
