### PR TITLE
chore(updates): use local CLI for E2E tests

### DIFF
--- a/.github/workflows/updates-e2e.yml
+++ b/.github/workflows/updates-e2e.yml
@@ -69,6 +69,9 @@ jobs:
       - name: 🧶 Yarn install
         if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
+      - name: 🛠 Build local Expo CLI
+        working-directory: packages/@expo/cli
+        run: yarn prepare
       - name: Build expo-updates CLI
         working-directory: packages/expo-updates
         run: yarn build:cli

--- a/packages/expo-updates/e2e/__tests__/setup/project.js
+++ b/packages/expo-updates/e2e/__tests__/setup/project.js
@@ -59,6 +59,8 @@ async function prepareLocalUpdatesModule(repoRoot) {
 }
 
 async function initAsync(workingDir, repoRoot, runtimeVersion) {
+  const localCliBin = path.join(repoRoot, 'packages/@expo/cli/build/bin/cli');
+
   // initialize project
   await spawnAsync('expo-cli', ['init', 'updates-e2e', '--yes'], {
     cwd: workingDir,
@@ -165,8 +167,9 @@ async function initAsync(workingDir, repoRoot, runtimeVersion) {
     stdio: 'inherit',
   });
   const templateVersion = require(path.join(localTemplatePath, 'package.json')).version;
+
   await spawnAsync(
-    'expo-cli',
+    localCliBin,
     ['prebuild', '--template', `expo-template-bare-minimum-${templateVersion}.tgz`],
     {
       cwd: projectRoot,


### PR DESCRIPTION
# Why

- Using the old CLI doesn't account for new versioned changes like the ones proposed here https://github.com/expo/expo/pull/18381
- Unblocks this PR https://github.com/expo/expo/pull/18381

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

- Build the local CLI then use it to run prebuild in the E2E tests.
- Did not use local CLI for other cases since they're all deprecated.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- Updates E2E tests should continue to pass.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
