### PR TITLE
[docs] Add `disableHierarchicalLookup` and context for each required config setting

### DIFF
--- a/docs/pages/guides/monorepos.md
+++ b/docs/pages/guides/monorepos.md
@@ -105,7 +105,7 @@ module.exports = config;
 
 Metro has three separate stages in its bundling process, [documented here](https://facebook.github.io/metro/docs/concepts). During the first phase, **Resolution**, Metro resolves your app's required files and dependencies. Metro does that with the `watchFolders` option, which is set to the project directory by default. This default setting works great for apps that don't use a monorepo structure.
 
-When using monorepos, your app dependencies are split up into different directories. Each of these directories must be within the scope of the [watchFolders](https://facebook.github.io/metro/docs/configuration/#watchfolders). If a file is outside of that scope, Metro won't be able to find it. Setting this path to the root of your monorepo
+When using monorepos, your app dependencies splits up into different directories. Each of these directories must be within the scope of the [watchFolders](https://facebook.github.io/metro/docs/configuration/#watchfolders). If a file is outside of that scope, Metro won't be able to find it. Setting this path to the root of your monorepo
 
 As your monorepo increases in size, watching all files within the monorepo becomes slower. If you want to speed that up, you can (dynamically) watch the relevant paths to minimize the watch scope. For example:
 
@@ -143,14 +143,14 @@ config.resolver.disableHierarchicalLookup = true;
 
 </Collapsible>
 
-<Collapsible summary="2. Why do we need tell Metro how to resolve packages?">
+<Collapsible summary="2. Why do we need to tell Metro how to resolve packages?">
 
 This option is important to resolve libraries in the correct **node_modules** directories. Monorepo tooling, like Yarn, usually creates two different **node_modules** directories which are used for a single workspace.
 
 1. **apps/mobile/node_modules** - The "project" folder
 2. **node_modules** - The "root" folder
 
-Yarn uses the root folder to install packages that are used in multiple workspaces. If a workspace uses a different package version, it installs that different version in the project folder.
+Yarn uses the root folder to install packages used in multiple workspaces. If a workspace uses a different package version, it installs that different version in the project folder.
 
 We have to tell Metro to look in these two folders. The order is important here because the project folder **node_modules** can contain specific versions we use for our app. When the package does not exist in the project folder, it should try the shared root folder.
 
@@ -158,7 +158,7 @@ We have to tell Metro to look in these two folders. The order is important here 
 
 <Collapsible summary="3. Why do we need to disable the hierarchical lookup?">
 
-This option is important for certain edge cases, such as a monorepo that includes multiple versions of the `react` package. Let's say you have the following monorepo:
+This option is important for certain edge cases, such as a monorepo that includes multiple versions of the `react` package. For example, let's say you have the following monorepo:
 
 1. **apps/marketing** - A simple Next.js website to attract new users. (uses `react@17.x.x`)
 2. **apps/mobile** - Your awesome Expo app. (uses `react@18.x.x`)
@@ -176,7 +176,7 @@ Expo modules and React Native libraries usually don't add `react` as a peer depe
 With hierarchical lookup enabled, whenever `expo` imports `react`, Metro will resolve to `react@17.x.x` and not `react@18.x.x`. This causes "multiple React versions" errors in your app.
 
 By disabling hierarchical lookup, we can force Metro to resolve only folders from the `nodeModulesPaths = [...]` order we defined in #2.
-This option is documented in [the Metro Resolution Algorithm documentation](https://facebook.github.io/metro/docs/resolution/#algorithm), under step 5.
+This option is documented in the [Metro Resolution Algorithm documentation](https://facebook.github.io/metro/docs/resolution/#algorithm), under step 5.
 
 When we disable this hierarchical lookup, it should not matter where the React Native library is installed.
 Whenever a library imports `react`, or any other library, Metro always resolves the library from the `nodeModulesPaths` we defined.

--- a/docs/pages/guides/monorepos.md
+++ b/docs/pages/guides/monorepos.md
@@ -262,17 +262,17 @@ As mentioned earlier, using monorepos is not for everyone. You take on increased
 
 ### Can I use another monorepo tool instead of yarn workspaces?
 
-There are a lot of monorepo tools available and each of these tools have their own benefits. It's hard for us to keep up with the latest tools and methods, and because of that, we won't officially support new monorepo tools. That being said, if the tool follows these 3 rules, it should work fine.
+There are a lot of monorepo tools available, and each of these tools has its benefits. It's hard for us to keep up with the latest tools and methods, and because of that, we won't officially support new monorepo tools. That being said, if the tool follows these three rules, it should work fine.
 
 <Collapsible summary="1. All dependencies must be installed in a node_modules directory">
 
-React Native dependencies contain a lot of other files besides JavaScript, like gradle files such as `react-native/react.gradle`. These native files are referenced from different sources other than Node, and because of that, makes it fundamentally incompatible with concepts like plug'n'play modules. All dependencies should be written to a **node_modules** directory to make sure these references work.
+React Native dependencies contain many other files besides JavaScript, like Gradle files such as `react-native/react.gradle`. These native files are referenced from different sources other than Node, and because of that, it makes it fundamentally incompatible with concepts like Plug'n'Play modules.
 
 </Collapsible>
 
 <Collapsible summary="2. Dependencies used in mulitple workspaces can be installed in the root node_modules directory">
 
-Whenever multiple workspaces use the same version of a single dependency, they can be installed in a root **node_modules** directory. Monorepo tools usually do this to save some duplicate tasks, like installing the exact same dependency twice in multiple places. This rule isn't necessary, but does set us up for rule #3.
+Whenever multiple workspaces use the same version of a single dependency, they can be installed in a root **node_modules** directory. Monorepo tools usually do this to save some duplicate tasks, like installing the exact same dependency twice in multiple places. This rule isn't necessary but does set us up for rule #3.
 
 </Collapsible>
 
@@ -283,13 +283,15 @@ In the [Modify the Metro config](#modify-the-metro-config) step, we instructed M
 - #2 - Resolve dependencies in the order of the local **/apps/<name\>/node_modules** and root **/node_modules** directories.
 - #3 - Disable resolving dependencies using the hierarchical lookup strategy.
 
-If a workspace uses a different version of a library, e.g. `react`, that different version should be installed in the workspace **node_modules** directory. When Metro resolves `react` from the workspace, it should find that different version in `**/apps/<name\>/node_modules** and not look inside the root **/node_modules** directory.
+If a workspace uses a different library version than the one installed in the root **/node_modules**, that different library version must be installed in the workspace **/apps/<name\>/node_modules** directory.
 
-When importing a dependency from the root **/node_modules** folder, that also imports `react`, it should still resolve to the different version installed in **/apps/<name\>/node_modules**. That's what the disable hierarchical lookup does for Metro. Without this, some libraries might be importing the wrong `react` version and cause "multiple react versions found" errors.
+When Metro resolves a library, e.g. `react`, from the workspace, it should find that different version in `**/apps/<name\>/node_modules** and not look inside the root **/node_modules** directory.
+
+When importing a dependency from the root **/node_modules** folder, that also imports `react`, it should still resolve to the different version installed in **/apps/<name\>/node_modules**. That's what the disabled hierarchical lookup option does for Metro. Without this, some libraries might import the wrong `react` version and cause "multiple react versions found" errors.
 
 </Collapsible>
 
-The default setting of tools like [pnpm](https://pnpm.io/) does not follow these rules. You can change that by adding the **.npmrc** file with `node-linker=hoisted` ([see docs](https://pnpm.io/npmrc#node-linker)). This will change the behavior to match these rules.
+The default setting of tools like [pnpm](https://pnpm.io/) does not follow these rules. You can change that by adding the **.npmrc** file with `node-linker=hoisted` ([see docs](https://pnpm.io/npmrc#node-linker)). That config option will change the behavior to match these rules.
 
 ### Script '...' does not exist
 

--- a/docs/pages/guides/monorepos.md
+++ b/docs/pages/guides/monorepos.md
@@ -140,9 +140,9 @@ We have to tell Metro to look in these two folders. The order is important here 
 
 This option is important for certain edge cases, such as a monorepo that includes multiple versions of the `react` package. Let's say you have the following monorepo:
 
-1. **apps/marketing** - A simple NextJS website to attract new users. (uses `react@17.x.x`)
+1. **apps/marketing** - A simple Next.js website to attract new users. (uses `react@17.x.x`)
 2. **apps/mobile** - Your awesome Expo app. (uses `react@18.x.x`)
-3. **apps/web** - Your awesome NextJS website. (uses `react@17.x.x`)
+3. **apps/web** - Your awesome Next.js website. (uses `react@17.x.x`)
 
 With monorepo tooling like Yarn, React is installed in two different **node_modules** folders.
 1. **node_modules** - The root folder, contains `react@17.x.x`.

--- a/docs/pages/guides/monorepos.md
+++ b/docs/pages/guides/monorepos.md
@@ -153,7 +153,7 @@ Expo modules and React Native libraries usually don't add `react` as a peer depe
 1. **node_modules** - The root folder, contains `expo@...` and `react@17.x.x`.
 2. **apps/mobile/node_modules** - The Expo app's folder, contains `react@18.x.x`. 
 
-With hierarchical lookup enabled, whenever `expo` imports `react`, Metro will resolve to`react@17.x.x` and not `react@18.x.x`. This causes "multiple React versions" errors in your app.
+With hierarchical lookup enabled, whenever `expo` imports `react`, Metro will resolve to `react@17.x.x` and not `react@18.x.x`. This causes "multiple React versions" errors in your app.
 
 By disabling hierarchical lookup, we can force Metro to resolve only folders from the `nodeModulesPaths = [...]` order we defined in #2.
 This option is documented in [the Metro Resolution Algorithm documentation](https://facebook.github.io/metro/docs/resolution/#algorithm), under step 5.

--- a/docs/pages/guides/monorepos.md
+++ b/docs/pages/guides/monorepos.md
@@ -270,9 +270,9 @@ React Native dependencies contain many other files besides JavaScript, like Grad
 
 </Collapsible>
 
-<Collapsible summary="2. Dependencies used in mulitple workspaces can be installed in the root node_modules directory">
+<Collapsible summary="2. Dependencies used in multiple workspaces can be installed in the root node_modules directory">
 
-Whenever multiple workspaces use the same version of a single dependency, they can be installed in a root **node_modules** directory. Monorepo tools usually do this to save some duplicate tasks, like installing the exact same dependency twice in multiple places. This rule isn't necessary but does set us up for rule #3.
+Whenever multiple workspaces use the same version of a single dependency, they can be installed in a root **node_modules** directory. Monorepo tools usually do this to remove duplicate tasks, like installing the exact same dependency twice in different places. This rule isn't necessary but does set us up for rule #3.
 
 </Collapsible>
 

--- a/docs/pages/guides/monorepos.md
+++ b/docs/pages/guides/monorepos.md
@@ -103,7 +103,7 @@ module.exports = config;
 
 This option enables the app to refresh or reload when you edit imported files outside the app folder. It's important for libraries within your monorepo that are imported into your app. Without this setting, you must manually reload your app and possibly clear the Metro cache to see the changed library files.
 
-As your monorepo increases in size, watching all files within the monorepo becomes slower. If you want to speed that up, you can (dynamically) watch the relevant paths to minimize the watchers. E.g.
+As your monorepo increases in size, watching all files within the monorepo becomes slower. If you want to speed that up, you can (dynamically) watch the relevant paths to minimize the watchers. For example:
 
 ```js
 const path = require('path');
@@ -148,14 +148,14 @@ With monorepo tooling like Yarn, React is installed in two different **node_modu
 1. **node_modules** - The root folder, contains `react@17.x.x`.
 2. **apps/mobile/node_modules** - The Expo app's folder, contains `react@18.x.x`. 
 
-React Native libraries, including Expo modules, usually don't add `react@18.x.x` as peer dependency. As a result, monorepo tooling, like Yarn, will install these dependencies to the root **node_modules** directory, for example:
+Expo modules and React Native libraries usually don't add `react` as a peer dependency. As a result, monorepo tooling, like Yarn, will install these dependencies to the root **node_modules** directory, for example:
 
 1. **node_modules** - The root folder, contains `expo@...` and `react@17.x.x`.
 2. **apps/mobile/node_modules** - The Expo app's folder, contains `react@18.x.x`. 
 
-With hierarchical lookup enabled, whenever `expo` imports `react` it will resolve `react@17.x.x` and not `react@18.x.x`. This causes "multiple React versions" errors in your app.
+With hierarchical lookup enabled, whenever `expo` imports `react`, Metro will resolve to`react@17.x.x` and not `react@18.x.x`. This causes "multiple React versions" errors in your app.
 
-By disabling hierarchical lookup, we can force Metro to only resolve folders from the `nodeModulesPaths = [...]` order we defined in #2.
+By disabling hierarchical lookup, we can force Metro to resolve only folders from the `nodeModulesPaths = [...]` order we defined in #2.
 This option is documented in [the Metro Resolution Algorithm documentation](https://facebook.github.io/metro/docs/resolution/#algorithm), under step 5.
 
 When we disable this hierarchical lookup, it should not matter where the React Native library is installed.
@@ -260,9 +260,9 @@ export default function App() {
 
 As mentioned earlier, using monorepos is not for everyone. You take on increased complexity and need to solve issues you most likely will run into. Here are a couple of common issues you might encounter.
 
-### Can I use another monorepo tool instead of yarn workspaces?
+### Can I use another monorepo tool instead of Yarn workspaces?
 
-There are a lot of monorepo tools available, and each of these tools has its benefits. It's hard for us to keep up with the latest tools and methods, and because of that, we won't officially support new monorepo tools. That being said, if the tool follows these three rules, it should work fine.
+There are a lot of monorepo tools available, and each of these tools has its benefits. It's hard for us to keep up with the latest tools and methods, and because of that, we can't officially support new monorepo tools. That being said, if the tool follows these three rules, it should work fine.
 
 <Collapsible summary="1. All dependencies must be installed in a node_modules directory">
 
@@ -285,13 +285,13 @@ In the [Modify the Metro config](#modify-the-metro-config) step, we instructed M
 
 If a workspace uses a different library version than the one installed in the root **/node_modules**, that different library version must be installed in the workspace **/apps/<name\>/node_modules** directory.
 
-When Metro resolves a library, e.g. `react`, from the workspace, it should find that different version in `**/apps/<name\>/node_modules** and not look inside the root **/node_modules** directory.
+When Metro resolves a library, e.g. `react`, from the workspace, it should find that different version in **/apps/<name\>/node_modules** and not look inside the root **/node_modules** directory.
 
-When importing a dependency from the root **/node_modules** folder, that also imports `react`, it should still resolve to the different version installed in **/apps/<name\>/node_modules**. That's what the disabled hierarchical lookup option does for Metro. Without this, some libraries might import the wrong `react` version and cause "multiple react versions found" errors.
+When importing a dependency from the root **/node_modules** folder that also imports `react`, `react` should still resolve to the different version installed in **/apps/<name\>/node_modules**. That's what the disabled hierarchical lookup option does for Metro. Without this, some libraries might import the wrong `react` version and cause "multiple React versions found" errors.
 
 </Collapsible>
 
-The default setting of tools like [pnpm](https://pnpm.io/) does not follow these rules. You can change that by adding the **.npmrc** file with `node-linker=hoisted` ([see docs](https://pnpm.io/npmrc#node-linker)). That config option will change the behavior to match these rules.
+The default settings of tools like [pnpm](https://pnpm.io/) do not follow these rules. You can change that by adding an **.npmrc** file with `node-linker=hoisted` ([see docs](https://pnpm.io/npmrc#node-linker)). That config option will change the behavior to match these rules.
 
 ### Script '...' does not exist
 

--- a/docs/pages/guides/monorepos.md
+++ b/docs/pages/guides/monorepos.md
@@ -103,7 +103,7 @@ module.exports = config;
 
 This option enables the app to refresh or reload when you edit imported files outside the app folder. It's important for libraries within your monorepo that are imported into your app. Without this setting, you must manually reload your app and possibly clear the Metro cache to see the changed library files.
 
-If your monorepo becomes really big, watching all files within the monorepo might be slow. If you want to speed that up, you can (dynamically) watch the relevant paths to minimize the watchers. E.g.
+As your monorepo increases in size, watching all files within the monorepo becomes slower. If you want to speed that up, you can (dynamically) watch the relevant paths to minimize the watchers. E.g.
 
 ```js
 const path = require('path');
@@ -125,7 +125,7 @@ config.watchFolders = [__dirname, ...appPackagesPaths];
 
 <Collapsible summary="2. Why do we need tell Metro how to resolve packages?">
 
-This option is important to resolve libraries in the right **node_modules** folders. Monorepo tooling, like Yarn, usually creates two different **node_modules** folders which are used for a single workspace.
+This option is important to resolve libraries in the correct **node_modules** directories. Monorepo tooling, like Yarn, usually creates two different **node_modules** directories which are used for a single workspace.
 
 1. **apps/mobile/node_modules** - The "project" folder
 2. **node_modules** - The "root" folder
@@ -138,7 +138,7 @@ We have to tell Metro to look in these two folders. The order is important here 
 
 <Collapsible summary="3. Why do we need to disable the hierarchical lookup?">
 
-This option is important for certain edge cases of your monorepo, like multiple React versions. Let's say you have the following monorepo:
+This option is important for certain edge cases, such as a monorepo that includes multiple versions of the `react` package. Let's say you have the following monorepo:
 
 1. **apps/marketing** - A simple NextJS website to attract new users. (uses `react@17.x.x`)
 2. **apps/mobile** - Your awesome Expo app. (uses `react@18.x.x`)
@@ -148,15 +148,14 @@ With monorepo tooling like Yarn, React is installed in two different **node_modu
 1. **node_modules** - The root folder, contains `react@17.x.x`.
 2. **apps/mobile/node_modules** - The Expo app's folder, contains `react@18.x.x`. 
 
-Because React Native libraries, including Expo, usually don't add `react@18.x.x` as peer dependency, monorepo tooling like Yarn installs `expo` or a React Native library in the wrong folder.
-It's unaware of the dependency of `react@18.x.x` and installs the package in the root **node_modules** folder.
+React Native libraries, including Expo modules, usually don't add `react@18.x.x` as peer dependency. As a result, monorepo tooling, like Yarn, will install these dependencies to the root **node_modules** directory, for example:
 
 1. **node_modules** - The root folder, contains `expo@...` and `react@17.x.x`.
 2. **apps/mobile/node_modules** - The Expo app's folder, contains `react@18.x.x`. 
 
-Unfortunately, whenever `expo` imports `react`, it would resolve `react@17.x.x` and not `react@18.x.x`. This causes "multiple React versions" errors in your app.
+With hierarchical lookup enabled, whenever `expo` imports `react` it will resolve `react@17.x.x` and not `react@18.x.x`. This causes "multiple React versions" errors in your app.
 
-With the `disableHierarchicalLookup = true`, we can force Metro to only resolve folders from the `nodeModulesPaths = [...]` order we defined in #2.
+By disabling hierarchical lookup, we can force Metro to only resolve folders from the `nodeModulesPaths = [...]` order we defined in #2.
 This option is documented in [the Metro Resolution Algorithm documentation](https://facebook.github.io/metro/docs/resolution/#algorithm), under step 5.
 
 When we disable this hierarchical lookup, it should not matter where the React Native library is installed.

--- a/docs/pages/guides/monorepos.md
+++ b/docs/pages/guides/monorepos.md
@@ -129,6 +129,7 @@ config.watchFolders = [__dirname, ...Object.values(monorepoPackages)];
 // Add the monorepo workspaces as `extraNodeModules` to Metro.
 // If your monorepo tooling creates workspace symlinks in the `node_modules` folder,
 // you can either add symlink support to Metro or set the `extraNodeModules` to avoid the symlinks.
+// See: https://facebook.github.io/metro/docs/configuration/#extranodemodules
 config.resolver.extraNodeModules = monorepoPackages;
 
 // 2. Let Metro know where to resolve packages and in what order

--- a/docs/pages/guides/monorepos.md
+++ b/docs/pages/guides/monorepos.md
@@ -157,7 +157,7 @@ It's unaware of the dependency of `react@18.x.x` and installs the package in the
 Unfortunately, whenever `expo` imports `react`, it would resolve `react@17.x.x` and not `react@18.x.x`. This causes "multiple React versions" errors in your app.
 
 With the `disableHierarchicalLookup = true`, we can force Metro to only resolve folders from the `nodeModulesPaths = [...]` order we defined in #2.
-This option is documented in [the Metro Resolution Algorithm documentation](https://github.com/facebook/metro/blob/b0c5aacecd102e52b61233211223345351f94fa0/docs/Resolution.md#resolution-algorithm), under step 5.
+This option is documented in [the Metro Resolution Algorithm documentation](https://facebook.github.io/metro/docs/resolution/#algorithm), under step 5.
 
 When we disable this hierarchical lookup, it should not matter where the React Native library is installed.
 Whenever a library imports `react`, or any other library, Metro always resolves the library from the `nodeModulesPaths` we defined.


### PR DESCRIPTION
# Why

Fixes ENG-5937

[Some people are running into issues when multiple React versions are installed.](https://github.com/expo/expo/issues/18693#issuecomment-1219899654) This `disableHierarchicalLookup` should cover most of these edge cases in Metro.

# How

1. Added `disableHierarchicalLookup`
2. Added context for each individual config properties.

# Test Plan

Docs change only, you can test [this change in the repro here](https://github.com/princejoogie/expo-issue-reproduction/pull/1).

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
