### PR TITLE
[modules][ios] Improve views creation to better support recycling

### DIFF
--- a/packages/expo-av/ios/EXAV/Video/EXVideoManager.m
+++ b/packages/expo-av/ios/EXAV/Video/EXVideoManager.m
@@ -29,8 +29,7 @@ EX_EXPORT_MODULE(ExpoVideoManager);
 
 - (UIView *)view
 {
-  id<EXAVInterface> avModule = [_moduleRegistry getModuleImplementingProtocol:@protocol(EXAVInterface)];
-  return [[EXVideoView alloc] initWithAvModule:avModule];
+  return [[EXVideoView alloc] initWithModuleRegistry:_moduleRegistry];
 }
 
 - (NSDictionary *)constantsToExport

--- a/packages/expo-av/ios/EXAV/Video/EXVideoView.h
+++ b/packages/expo-av/ios/EXAV/Video/EXVideoView.h
@@ -1,11 +1,12 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 #import <ExpoModulesCore/EXModuleRegistry.h>
+#import <ExpoModulesCore/EXLegacyExpoViewProtocol.h>
 
 #import <EXAV/EXAVObject.h>
 #import <EXAV/EXVideoPlayerViewControllerDelegate.h>
 
-@interface EXVideoView : UIView <EXVideoPlayerViewControllerDelegate, AVPlayerViewControllerDelegate, EXAVObject>
+@interface EXVideoView : UIView <EXVideoPlayerViewControllerDelegate, AVPlayerViewControllerDelegate, EXAVObject, EXLegacyExpoViewProtocol>
 
 typedef NS_OPTIONS(NSUInteger, EXVideoFullscreenUpdate)
 {
@@ -26,7 +27,7 @@ typedef NS_OPTIONS(NSUInteger, EXVideoFullscreenUpdate)
 @property (nonatomic, copy) EXDirectEventBlock onReadyForDisplay;
 @property (nonatomic, copy) EXDirectEventBlock onFullscreenUpdate;
 
-- (instancetype)initWithAvModule:(nullable id<EXAVInterface>)avModule;
+- (instancetype)initWithModuleRegistry:(nullable EXModuleRegistry *)moduleRegistry;
 
 - (void)setStatus:(NSDictionary *)status
          resolver:(EXPromiseResolveBlock)resolve

--- a/packages/expo-av/ios/EXAV/Video/EXVideoView.m
+++ b/packages/expo-av/ios/EXAV/Video/EXVideoView.m
@@ -42,10 +42,10 @@ static NSString *const EXAVFullScreenViewControllerClassName = @"AVFullScreenVie
 
 #pragma mark - EXVideoView interface methods
 
-- (instancetype)initWithAvModule:(id<EXAVInterface>)avModule
+- (instancetype)initWithModuleRegistry:(nullable EXModuleRegistry *)moduleRegistry
 {
   if ((self = [super init])) {
-    _exAV = avModule;
+    _exAV = [moduleRegistry getModuleImplementingProtocol:@protocol(EXAVInterface)];
     [_exAV registerVideoForAudioLifecycle:self];
     
     _data = nil;

--- a/packages/expo-av/ios/EXAV/Video/VideoViewModule.swift
+++ b/packages/expo-av/ios/EXAV/Video/VideoViewModule.swift
@@ -20,12 +20,7 @@ public final class VideoViewModule: Module {
       }
     }
 
-    ViewManager {
-      View {
-        let avModule: EXAVInterface? = self.appContext?.legacyModule(implementing: EXAVInterface.self)
-        return EXVideoView(avModule: avModule)
-      }
-
+    View(EXVideoView.self) {
       Events(
         "onStatusUpdate",
         "onLoadStart",

--- a/packages/expo-blur/ios/EXBlur/BlurView.swift
+++ b/packages/expo-blur/ios/EXBlur/BlurView.swift
@@ -1,10 +1,10 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 import UIKit
-import ExpoModulesCore
+import React
 
 @objc(EXBlurView)
-public class BlurView: ExpoView {
+public class BlurView: RCTView {
   private var blurEffectView: BlurEffectView
 
   override init(frame: CGRect) {

--- a/packages/expo-modules-core/ios/EXLegacyExpoViewProtocol.h
+++ b/packages/expo-modules-core/ios/EXLegacyExpoViewProtocol.h
@@ -1,0 +1,13 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+#import <ExpoModulesCore/EXModuleRegistry.h>
+
+/**
+ The protocol required for the Objective-C views to be initialized with the legacy module registry.
+ - ToDo: Remove once all views are migrated to the new API and Swift.
+ */
+@protocol EXLegacyExpoViewProtocol
+
+- (instancetype)initWithModuleRegistry:(nullable EXModuleRegistry *)moduleRegistry;
+
+@end

--- a/packages/expo-modules-core/ios/Swift/Views/ExpoView.swift
+++ b/packages/expo-modules-core/ios/Swift/Views/ExpoView.swift
@@ -3,6 +3,27 @@
 import React
 
 /**
- The view that just extends `RCTView`. In the future we may add more features here.
+ The view that extends `RCTView` which handles some styles (e.g. borders) and accessibility.
+ Inherit from `ExpoView` to keep this behavior and let your view use the associated `AppContext`.
  */
-open class ExpoView: RCTView {}
+open class ExpoView: RCTView {
+  /**
+   A weak pointer to the associated `AppContext`.
+   */
+  public private(set) weak var appContext: AppContext?
+
+  /**
+   The required initializer that receives an instance of `AppContext`.
+   Override it if the subclassing view needs to do something during initialization.
+   */
+  required public init(appContext: AppContext? = nil) {
+    self.appContext = appContext
+    super.init(frame: .zero)
+  }
+
+  // Mark the required init as unavailable so that subclasses can avoid overriding it.
+  @available(*, unavailable)
+  required public init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}

--- a/packages/expo-modules-core/ios/Swift/Views/ViewManagerDefinition.swift
+++ b/packages/expo-modules-core/ios/Swift/Views/ViewManagerDefinition.swift
@@ -42,7 +42,7 @@ public class ViewManagerDefinition: ObjectDefinition {
   /**
    Creates a new view using the view factory. Returns `nil` if the definition doesn't use the `view` function.
    */
-  func createView() -> UIView? {
+  func createView(appContext: AppContext) -> UIView? {
     return factory?.create()
   }
 

--- a/packages/expo-modules-core/ios/Swift/Views/ViewManagerDefinitionComponents.swift
+++ b/packages/expo-modules-core/ios/Swift/Views/ViewManagerDefinitionComponents.swift
@@ -40,7 +40,7 @@ public func prop<ViewType: UIView, PropType: AnyArgument>(
 public func Prop<ViewType: UIView, PropType: AnyArgument>(
   _ name: String,
   _ setter: @escaping (ViewType, PropType) -> Void
-) -> ViewManagerDefinitionComponent {
+) -> ConcreteViewProp<ViewType, PropType> {
   return ConcreteViewProp(
     name: name,
     propType: ~PropType.self,

--- a/packages/expo-modules-core/ios/Swift/Views/ViewModuleWrapper.swift
+++ b/packages/expo-modules-core/ios/Swift/Views/ViewModuleWrapper.swift
@@ -82,8 +82,11 @@ public final class ViewModuleWrapper: RCTViewManager, DynamicModuleWrapperProtoc
    */
   @objc
   public override func view() -> UIView! {
-    guard let view = wrappedModuleHolder.definition.viewManager?.createView() else {
-      fatalError("Module `\(wrappedModuleHolder.name)` doesn't define the view manager nor view factory.")
+    guard let appContext = wrappedModuleHolder.appContext else {
+      fatalError(Exceptions.AppContextLost().reason)
+    }
+    guard let view = wrappedModuleHolder.definition.viewManager?.createView(appContext: appContext) else {
+      fatalError("Cannot create a view from module '\(self.name)'")
     }
     return view
   }


### PR DESCRIPTION
# Why

Next step in order to migrate from the `ViewManager` component to just `View` that only needs the view type and will work better with Fabric's recycling mechanism.

# How

- Added `EXLegacyExpoViewProtocol` that the legacy Objective-C view needs to conform to if it needs to be initialized with the legacy module registry.
- Initializing `ExpoView` with the `AppContext` instance that will be held by the view as a weak reference.

# Test Plan

Tested together with #18703 + ran through video, linear gradient and blur view examples.