### PR TITLE
[prebuild-config] bump image-utils version

### DIFF
--- a/packages/@expo/prebuild-config/package.json
+++ b/packages/@expo/prebuild-config/package.json
@@ -38,7 +38,7 @@
     "@expo/config": "7.0.0",
     "@expo/config-plugins": "~5.0.0",
     "@expo/config-types": "^46.0.0",
-    "@expo/image-utils": "0.3.20",
+    "@expo/image-utils": "0.3.21",
     "@expo/json-file": "8.2.36",
     "debug": "^4.3.1",
     "fs-extra": "^9.0.0",


### PR DESCRIPTION
# Why

image-utils@0.3.21 bumped the required sharp-cli version.

# How

No idea why this was pinned to 0.3.20.
Updating this will probably cause an avalanche of version bumps.

# Test Plan

?

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
