### PR TITLE
[ios] add exportedInterfaces to EXUpdatesBinding

### DIFF
--- a/ios/Exponent/Versioned/Core/UniversalModules/EXUpdatesBinding.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXUpdatesBinding.m
@@ -91,6 +91,10 @@ NS_ASSUME_NONNULL_BEGIN
   // no-op in managed
 }
 
++ (const NSArray<Protocol *> *)exportedInterfaces {
+  return @[@protocol(EXUpdatesModuleInterface)];
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/versioned-react-native/ABI44_0_0/Expo/ExpoKit/Core/UniversalModules/ABI44_0_0EXUpdatesBinding.m
+++ b/ios/versioned-react-native/ABI44_0_0/Expo/ExpoKit/Core/UniversalModules/ABI44_0_0EXUpdatesBinding.m
@@ -86,6 +86,10 @@ NS_ASSUME_NONNULL_BEGIN
   // no-op in managed
 }
 
++ (const NSArray<Protocol *> *)exportedInterfaces {
+  return @[@protocol(ABI44_0_0EXUpdatesModuleInterface)];
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/versioned-react-native/ABI45_0_0/Expo/ExpoKit/Core/UniversalModules/ABI45_0_0EXUpdatesBinding.m
+++ b/ios/versioned-react-native/ABI45_0_0/Expo/ExpoKit/Core/UniversalModules/ABI45_0_0EXUpdatesBinding.m
@@ -91,6 +91,10 @@ NS_ASSUME_NONNULL_BEGIN
   // no-op in managed
 }
 
++ (const NSArray<Protocol *> *)exportedInterfaces {
+  return @[@protocol(ABI45_0_0EXUpdatesModuleInterface)];
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/versioned-react-native/ABI46_0_0/Expo/ExpoKit/Core/UniversalModules/ABI46_0_0EXUpdatesBinding.m
+++ b/ios/versioned-react-native/ABI46_0_0/Expo/ExpoKit/Core/UniversalModules/ABI46_0_0EXUpdatesBinding.m
@@ -91,6 +91,10 @@ NS_ASSUME_NONNULL_BEGIN
   // no-op in managed
 }
 
++ (const NSArray<Protocol *> *)exportedInterfaces {
+  return @[@protocol(ABI46_0_0EXUpdatesModuleInterface)];
+}
+
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
# Why

ref #18691

Digging into this, I found that [this line](https://github.com/expo/expo/blob/4a28459174be2ec33f94b07af6499fe25aaa02b0/packages/expo-updates/ios/EXUpdates/EXUpdatesModule.m#L29) is nil in Expo Go and therefore the localAssets object doesn't get properly exported.

# How

Confirmed via debugger that while [`registerInternalModule`](https://github.com/expo/expo/blob/4a28459174be2ec33f94b07af6499fe25aaa02b0/packages/expo-modules-core/ios/ModuleRegistry/EXModuleRegistry.m#L109) is called for EXUpdatesBinding, `exportedInterfaces` returns an empty array. This wasn't the case in the past and I'm not sure what change might have caused it recently, but explicitly implementing this method and returning an array containing the correct interface fixes the issue. (It looks like we do this in some of the other scoped modules, too.)

# Test Plan

Used the repro case from #18691; with this change applied, the assets load as expected. Confirmed via debugger that `exportedInterfaces` is no longer an empty array and the correct module is returned in `EXUpdatesModule`.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
