### PR TITLE
[expo-auth-session] allow multiple response types

### DIFF
--- a/packages/expo-auth-session/src/providers/Google.ts
+++ b/packages/expo-auth-session/src/providers/Google.ts
@@ -142,8 +142,8 @@ class GoogleAuthRequest extends AuthRequest {
 
     // Apply the default scopes
     const scopes = applyRequiredScopes(config.scopes, settings.minimumScopes);
-    const responseType = config.responseType.split(' ');
-    const isImplicit = responseType.includes(ResponseType.Token) || responseType.includes(ResponseType.IdToken)
+    const responseTypes = config.responseType.split(' ');
+    const isImplicit = responseTypes.includes(ResponseType.Token) || responseTypes.includes(ResponseType.IdToken)
 
     if (isImplicit) {
       // PKCE must be disabled in implicit mode.
@@ -168,7 +168,9 @@ class GoogleAuthRequest extends AuthRequest {
    */
   async getAuthRequestConfigAsync(): Promise<AuthRequestConfig> {
     const { extraParams = {}, ...config } = await super.getAuthRequestConfigAsync();
-    if (config.responseType.split(' ').includes(ResponseType.Token) && !extraParams.nonce && !this.nonce) {
+    const responseTypes = config.responseType.split(' ');
+
+    if (responseTypes.includes(ResponseType.IdToken) && !extraParams.nonce && !this.nonce) {
       if (!this.nonce) {
         this.nonce = await generateHexStringAsync(16);
       }

--- a/packages/expo-auth-session/src/providers/Google.ts
+++ b/packages/expo-auth-session/src/providers/Google.ts
@@ -142,8 +142,9 @@ class GoogleAuthRequest extends AuthRequest {
 
     // Apply the default scopes
     const scopes = applyRequiredScopes(config.scopes, settings.minimumScopes);
-    const isImplicit =
-      config.responseType === ResponseType.Token || config.responseType === ResponseType.IdToken;
+    const responseType = config.responseType.split(' ');
+    const isImplicit = responseType.includes(ResponseType.Token) || responseType.includes(ResponseType.IdToken)
+
     if (isImplicit) {
       // PKCE must be disabled in implicit mode.
       config.usePKCE = false;
@@ -167,7 +168,7 @@ class GoogleAuthRequest extends AuthRequest {
    */
   async getAuthRequestConfigAsync(): Promise<AuthRequestConfig> {
     const { extraParams = {}, ...config } = await super.getAuthRequestConfigAsync();
-    if (config.responseType === ResponseType.IdToken && !extraParams.nonce && !this.nonce) {
+    if (config.responseType.split(' ').includes(ResponseType.Token) && !extraParams.nonce && !this.nonce) {
       if (!this.nonce) {
         this.nonce = await generateHexStringAsync(16);
       }

--- a/packages/expo-auth-session/src/providers/Google.ts
+++ b/packages/expo-auth-session/src/providers/Google.ts
@@ -142,8 +142,8 @@ class GoogleAuthRequest extends AuthRequest {
 
     // Apply the default scopes
     const scopes = applyRequiredScopes(config.scopes, settings.minimumScopes);
-    const responseTypes = config.responseType.split(' ');
-    const isImplicit = responseTypes.includes(ResponseType.Token) || responseTypes.includes(ResponseType.IdToken)
+    const responseTypes = config?.responseType?.split(' ');
+    const isImplicit = responseTypes && (responseTypes.includes(ResponseType.Token) || responseTypes.includes(ResponseType.IdToken))
 
     if (isImplicit) {
       // PKCE must be disabled in implicit mode.
@@ -168,9 +168,9 @@ class GoogleAuthRequest extends AuthRequest {
    */
   async getAuthRequestConfigAsync(): Promise<AuthRequestConfig> {
     const { extraParams = {}, ...config } = await super.getAuthRequestConfigAsync();
-    const responseTypes = config.responseType.split(' ');
+    const responseTypes = config?.responseType?.split(' ');
 
-    if (responseTypes.includes(ResponseType.IdToken) && !extraParams.nonce && !this.nonce) {
+    if (responseTypes?.includes(ResponseType.IdToken) && !extraParams.nonce && !this.nonce) {
       if (!this.nonce) {
         this.nonce = await generateHexStringAsync(16);
       }


### PR DESCRIPTION
# Why

Google allows for you to pass in `id_token token` as a response type to get back both an `id_token` and `access_token`. If you were to pass `id_token token` it would pass wrong parameters assuming it was type `code`

# How
I tested for if it includes the things and not strict equality

# Test Plan

# Checklist

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [X] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
