### PR TITLE
[barcode-scanner] Fix camera not being correctly released on unmount (Android)

### DIFF
--- a/packages/expo-barcode-scanner/CHANGELOG.md
+++ b/packages/expo-barcode-scanner/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix camera not being correctly released on Android on unmount (#TBD by [@stefan-schweiger](https://github.com/stefan-schweiger))
+- Fix camera not being correctly released on unmount (Android) (#18768 by [@stefan-schweiger](https://github.com/stefan-schweiger))
 
 ### 💡 Others
 

--- a/packages/expo-barcode-scanner/CHANGELOG.md
+++ b/packages/expo-barcode-scanner/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix camera not being correctly released on unmount (Android) (#18768 by [@stefan-schweiger](https://github.com/stefan-schweiger))
+- Fix camera not being correctly released on unmount (Android) ([#18768](https://github.com/expo/expo/pull/18768) by [@stefan-schweiger](https://github.com/stefan-schweiger))
 
 ### 💡 Others
 

--- a/packages/expo-barcode-scanner/CHANGELOG.md
+++ b/packages/expo-barcode-scanner/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix camera not being correctly released on Android on unmount (#TBD by [@stefan-schweiger](https://github.com/stefan-schweiger))
+
 ### 💡 Others
 
 - Drop `@expo/config-plugins` dependency in favor of peer dependency on `expo`. ([#18595](https://github.com/expo/expo/pull/18595) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/expo-barcode-scanner/android/src/main/java/expo/modules/barcodescanner/BarCodeScannerViewFinder.kt
+++ b/packages/expo-barcode-scanner/android/src/main/java/expo/modules/barcodescanner/BarCodeScannerViewFinder.kt
@@ -99,10 +99,11 @@ internal class BarCodeScannerViewFinder(
 
   @Synchronized
   private fun startCamera() {
-    if (!isStarting) {
+    if (!isStarting && !isStopping) {
       isStarting = true
       try {
-        ExpoBarCodeScanner.instance.acquireCameraInstance(cameraType)?.run {
+        camera = ExpoBarCodeScanner.instance.acquireCameraInstance(cameraType)
+        camera?.run {
           val temporaryParameters = parameters
           // set autofocus
           val focusModes = temporaryParameters.supportedFocusModes


### PR DESCRIPTION
# Why

As you can see in [this snack](https://snack.expo.dev/@stefan-5gpay/basic-barcodescanner-usage) and as I've mentioned in #18746 the camera currently does not get released correctly. This means the camera indicator always stays active and the camera continues to drain battery in the background.

# How

In the code the `camera` simply was never assigned in `BarCodeScannerViewFinder`. This means the code which stops the camera was never actually run correctly because it has a null-check.

I simply assigned `camera` and added an additional check that you can't start the camera while it is stopping. With those changes in place it works.

# Test Plan

I've created the [following patch](https://gist.github.com/stefan-schweiger/a302ec60f83779f4678dbc47085e8bb0) (which does the same thing as my PR) and created a devclient with the code from the snack. When I now scan a QR code and the camera gets unmounted it works correctly

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
