### PR TITLE
feat(docs): add 2022 Apple capabilities

### DIFF
--- a/docs/pages/build-reference/ios-capabilities.md
+++ b/docs/pages/build-reference/ios-capabilities.md
@@ -2,6 +2,8 @@
 title: iOS Capabilities
 ---
 
+import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
+
 When you make a change to your iOS entitlements, this change needs to be updated remotely on Apple's servers before making a production build. EAS Build automatically synchronizes capabilities on the Apple Developer Portal with your local entitlements configuration when you run `eas build`. Capabilities are web services provided by Apple, think of them like AWS or Firebase services.
 
 > This feature can be disabled with `EXPO_NO_CAPABILITY_SYNC=1 eas build`
@@ -24,62 +26,62 @@ If a capability is enabled for your app remotely, but not present in the native 
 
 EAS Build will only enable capabilities that it has built-in support for, any unsupported entitlements must be manually enabled via [Apple Developer Portal][apple-dev-portal].
 
-| Capability                                        | Supported |
-| ------------------------------------------------- | --------- |
-| Access WiFi Information                           | ✅        |
-| App Attest                                        | ✅        |
-| App Groups                                        | ✅        |
-| Apple Pay Payment Processing                      | ✅        |
-| Associated Domains                                | ✅        |
-| AutoFill Credential Provider                      | ✅        |
-| ClassKit                                          | ✅        |
-| Communicates with Drivers                         | ✅        |
-| Communication Notifications                       | ✅        |
-| Custom Network Protocol                           | ✅        |
-| Data Protection                                   | ✅        |
-| DriverKit Allow Third Party UserClients           | ✅        |
-| DriverKit Family Audio (development)              | ✅        |
-| DriverKit Family HID Device (development)         | ✅        |
-| DriverKit Family HID EventService (development)   | ✅        |
-| DriverKit Family Networking (development)         | ✅        |
-| DriverKit Family SCSIController (development)     | ✅        |
-| DriverKit Family Serial (development)             | ✅        |
-| DriverKit Transport HID (development)             | ✅        |
-| DriverKit USB Transport (development)             | ✅        |
-| DriverKit for Development                         | ✅        |
-| Extended Virtual Address Space                    | ✅        |
-| Family Controls                                   | ✅        |
-| FileProvider TestingMode                          | ✅        |
-| Fonts                                             | ✅        |
-| Group Activities                                  | ✅        |
-| HealthKit                                         | ✅        |
-| HomeKit                                           | ✅        |
-| Hotspot                                           | ✅        |
-| Increased Memory Limit                            | ✅        |
-| Inter-App Audio                                   | ✅        |
-| Low Latency HLS                                   | ✅        |
-| MDM Managed Associated Domains                    | ✅        |
-| Maps                                              | ✅        |
-| Media Device Discovery                            | ✅        |
-| Multipath                                         | ✅        |
-| NFC Tag Reading                                   | ✅        |
-| Network Extensions                                | ✅        |
-| On Demand Install Capable for App Clip Extensions | ✅        |
-| Personal VPN                                      | ✅        |
-| Push Notifications                                | ✅        |
-| Push to Talk                                      | ✅        |
-| Recalibrate Estimates                             | ✅        |
-| Shared with You                                   | ✅        |
-| Sign In with Apple                                | ✅        |
-| SiriKit                                           | ✅        |
-| System Extension                                  | ✅        |
-| TV Services                                       | ✅        |
-| Time Sensitive Notifications                      | ✅        |
-| Wallet                                            | ✅        |
-| WeatherKit                                        | ✅        |
-| Wireless Accessory Configuration                  | ✅        |
-| iCloud                                            | ✅        |
-| HLS Interstitial Previews                         | ❌        |
+| Capability                                        | Supported   |
+| ------------------------------------------------- | ----------- |
+| Access WiFi Information                           | <YesIcon /> |
+| App Attest                                        | <YesIcon /> |
+| App Groups                                        | <YesIcon /> |
+| Apple Pay Payment Processing                      | <YesIcon /> |
+| Associated Domains                                | <YesIcon /> |
+| AutoFill Credential Provider                      | <YesIcon /> |
+| ClassKit                                          | <YesIcon /> |
+| Communicates with Drivers                         | <YesIcon /> |
+| Communication Notifications                       | <YesIcon /> |
+| Custom Network Protocol                           | <YesIcon /> |
+| Data Protection                                   | <YesIcon /> |
+| DriverKit Allow Third Party UserClients           | <YesIcon /> |
+| DriverKit Family Audio (development)              | <YesIcon /> |
+| DriverKit Family HID Device (development)         | <YesIcon /> |
+| DriverKit Family HID EventService (development)   | <YesIcon /> |
+| DriverKit Family Networking (development)         | <YesIcon /> |
+| DriverKit Family SCSIController (development)     | <YesIcon /> |
+| DriverKit Family Serial (development)             | <YesIcon /> |
+| DriverKit Transport HID (development)             | <YesIcon /> |
+| DriverKit USB Transport (development)             | <YesIcon /> |
+| DriverKit for Development                         | <YesIcon /> |
+| Extended Virtual Address Space                    | <YesIcon /> |
+| Family Controls                                   | <YesIcon /> |
+| FileProvider TestingMode                          | <YesIcon /> |
+| Fonts                                             | <YesIcon /> |
+| Group Activities                                  | <YesIcon /> |
+| HealthKit                                         | <YesIcon /> |
+| HomeKit                                           | <YesIcon /> |
+| Hotspot                                           | <YesIcon /> |
+| Increased Memory Limit                            | <YesIcon /> |
+| Inter-App Audio                                   | <YesIcon /> |
+| Low Latency HLS                                   | <YesIcon /> |
+| MDM Managed Associated Domains                    | <YesIcon /> |
+| Maps                                              | <YesIcon /> |
+| Media Device Discovery                            | <YesIcon /> |
+| Multipath                                         | <YesIcon /> |
+| NFC Tag Reading                                   | <YesIcon /> |
+| Network Extensions                                | <YesIcon /> |
+| On Demand Install Capable for App Clip Extensions | <YesIcon /> |
+| Personal VPN                                      | <YesIcon /> |
+| Push Notifications                                | <YesIcon /> |
+| Push to Talk                                      | <YesIcon /> |
+| Recalibrate Estimates                             | <YesIcon /> |
+| Shared with You                                   | <YesIcon /> |
+| Sign In with Apple                                | <YesIcon /> |
+| SiriKit                                           | <YesIcon /> |
+| System Extension                                  | <YesIcon /> |
+| TV Services                                       | <YesIcon /> |
+| Time Sensitive Notifications                      | <YesIcon /> |
+| Wallet                                            | <YesIcon /> |
+| WeatherKit                                        | <YesIcon /> |
+| Wireless Accessory Configuration                  | <YesIcon /> |
+| iCloud                                            | <YesIcon /> |
+| HLS Interstitial Previews                         | <NoIcon />  |
 
 The unsupported capabilities either don't support iOS, or they don't have a corresponding entitlement value.
 

--- a/docs/pages/build-reference/ios-capabilities.md
+++ b/docs/pages/build-reference/ios-capabilities.md
@@ -24,43 +24,62 @@ If a capability is enabled for your app remotely, but not present in the native 
 
 EAS Build will only enable capabilities that it has built-in support for, any unsupported entitlements must be manually enabled via [Apple Developer Portal][apple-dev-portal].
 
-| Capability                       | Supported |
-|----------------------------------|-----------|
-| HomeKit                          | ✅         |
-| Hotspot                          | ✅         |
-| Multipath                        | ✅         |
-| SiriKit                          | ✅         |
-| Wireless Accessory Configuration | ✅         |
-| Extended Virtual Address Space   | ✅         |
-| Access Wi-Fi Information         | ✅         |
-| Associated Domains               | ✅         |
-| AutoFill Credential Provider     | ✅         |
-| HealthKit                        | ✅         |
-| Game Center                      | ✅         |
-| ClassKit                         | ✅         |
-| Data Protection                  | ✅         |
-| Inter-App Audio                  | ✅         |
-| Network Extensions               | ✅         |
-| NFC Tag Reading                  | ✅         |
-| Personal VPN                     | ✅         |
-| Push Notifications               | ✅         |
-| Wallet                           | ✅         |
-| Sign In with Apple               | ✅         |
-| Fonts                            | ✅         |
-| In-App Purchase                  | ✅         |
-| Communication Notifications      | ✅         |
-| Time Sensitive Notifications     | ✅         |
-| Group Activities                 | ✅         |
-| Family Controls                  | ✅         |
-| Apple Pay Payment Processing     | Partial   |
-| iCloud                           | Partial   |
-| App Groups                       | Partial   |
-| App Attest                       | ❌         |
-| FileProvider TestingMode         | ❌         |
-| HLS Interstitial Previews        | ❌         |
-| Low Latency HLS                  | ❌         |
-| MDM Managed Associated Domains   | ❌         |
-| HealthKit Estimate Recalibration | ❌         |
+| Capability                                        | Supported |
+| ------------------------------------------------- | --------- |
+| Access WiFi Information                           | ✅        |
+| App Attest                                        | ✅        |
+| App Groups                                        | ✅        |
+| Apple Pay Payment Processing                      | ✅        |
+| Associated Domains                                | ✅        |
+| AutoFill Credential Provider                      | ✅        |
+| ClassKit                                          | ✅        |
+| Communicates with Drivers                         | ✅        |
+| Communication Notifications                       | ✅        |
+| Custom Network Protocol                           | ✅        |
+| Data Protection                                   | ✅        |
+| DriverKit Allow Third Party UserClients           | ✅        |
+| DriverKit Family Audio (development)              | ✅        |
+| DriverKit Family HID Device (development)         | ✅        |
+| DriverKit Family HID EventService (development)   | ✅        |
+| DriverKit Family Networking (development)         | ✅        |
+| DriverKit Family SCSIController (development)     | ✅        |
+| DriverKit Family Serial (development)             | ✅        |
+| DriverKit Transport HID (development)             | ✅        |
+| DriverKit USB Transport (development)             | ✅        |
+| DriverKit for Development                         | ✅        |
+| Extended Virtual Address Space                    | ✅        |
+| Family Controls                                   | ✅        |
+| FileProvider TestingMode                          | ✅        |
+| Fonts                                             | ✅        |
+| Group Activities                                  | ✅        |
+| HealthKit                                         | ✅        |
+| HomeKit                                           | ✅        |
+| Hotspot                                           | ✅        |
+| Increased Memory Limit                            | ✅        |
+| Inter-App Audio                                   | ✅        |
+| Low Latency HLS                                   | ✅        |
+| MDM Managed Associated Domains                    | ✅        |
+| Maps                                              | ✅        |
+| Media Device Discovery                            | ✅        |
+| Multipath                                         | ✅        |
+| NFC Tag Reading                                   | ✅        |
+| Network Extensions                                | ✅        |
+| On Demand Install Capable for App Clip Extensions | ✅        |
+| Personal VPN                                      | ✅        |
+| Push Notifications                                | ✅        |
+| Push to Talk                                      | ✅        |
+| Recalibrate Estimates                             | ✅        |
+| Shared with You                                   | ✅        |
+| Sign In with Apple                                | ✅        |
+| SiriKit                                           | ✅        |
+| System Extension                                  | ✅        |
+| TV Services                                       | ✅        |
+| Time Sensitive Notifications                      | ✅        |
+| Wallet                                            | ✅        |
+| WeatherKit                                        | ✅        |
+| Wireless Accessory Configuration                  | ✅        |
+| iCloud                                            | ✅        |
+| HLS Interstitial Previews                         | ❌        |
 
 The unsupported capabilities either don't support iOS, or they don't have a corresponding entitlement value.
 

--- a/docs/pages/build-reference/ios-capabilities.md
+++ b/docs/pages/build-reference/ios-capabilities.md
@@ -28,7 +28,7 @@ EAS Build will only enable capabilities that it has built-in support for, any un
 
 | Support     | Capability                                        | Entitlement string                                                         |
 | ----------- | ------------------------------------------------- | -------------------------------------------------------------------------- |
-| <YesIcon /> | Access WiFi Information                           | `com.apple.developer.networking.wifi-info`                                 |
+| <YesIcon /> | Access Wi-Fi Information                          | `com.apple.developer.networking.wifi-info`                                 |
 | <YesIcon /> | App Attest                                        | `com.apple.developer.devicecheck.appattest-environment`                    |
 | <YesIcon /> | App Groups                                        | `com.apple.security.application-groups`                                    |
 | <YesIcon /> | Apple Pay Payment Processing                      | `com.apple.developer.in-app-payments`                                      |

--- a/docs/pages/build-reference/ios-capabilities.md
+++ b/docs/pages/build-reference/ios-capabilities.md
@@ -81,7 +81,7 @@ EAS Build will only enable capabilities that it has built-in support for, any un
 | <YesIcon /> | WeatherKit                                        | `com.apple.developer.weatherkit`                                           |
 | <YesIcon /> | Wireless Accessory Configuration                  | `com.apple.external-accessory.wireless-configuration`                      |
 | <YesIcon /> | iCloud                                            | `com.apple.developer.icloud-container-identifiers`                         |
-| <NoIcon />  | HLS Interstitial Previews                         | ???                                                                        |
+| <NoIcon />  | HLS Interstitial Previews                         | Unknown                                                                   |
 
 The unsupported capabilities either don't support iOS, or they don't have a corresponding entitlement value.
 

--- a/docs/pages/build-reference/ios-capabilities.md
+++ b/docs/pages/build-reference/ios-capabilities.md
@@ -26,62 +26,62 @@ If a capability is enabled for your app remotely, but not present in the native 
 
 EAS Build will only enable capabilities that it has built-in support for, any unsupported entitlements must be manually enabled via [Apple Developer Portal][apple-dev-portal].
 
-| Capability                                        | Supported   |
-| ------------------------------------------------- | ----------- |
-| Access WiFi Information                           | <YesIcon /> |
-| App Attest                                        | <YesIcon /> |
-| App Groups                                        | <YesIcon /> |
-| Apple Pay Payment Processing                      | <YesIcon /> |
-| Associated Domains                                | <YesIcon /> |
-| AutoFill Credential Provider                      | <YesIcon /> |
-| ClassKit                                          | <YesIcon /> |
-| Communicates with Drivers                         | <YesIcon /> |
-| Communication Notifications                       | <YesIcon /> |
-| Custom Network Protocol                           | <YesIcon /> |
-| Data Protection                                   | <YesIcon /> |
-| DriverKit Allow Third Party UserClients           | <YesIcon /> |
-| DriverKit Family Audio (development)              | <YesIcon /> |
-| DriverKit Family HID Device (development)         | <YesIcon /> |
-| DriverKit Family HID EventService (development)   | <YesIcon /> |
-| DriverKit Family Networking (development)         | <YesIcon /> |
-| DriverKit Family SCSIController (development)     | <YesIcon /> |
-| DriverKit Family Serial (development)             | <YesIcon /> |
-| DriverKit Transport HID (development)             | <YesIcon /> |
-| DriverKit USB Transport (development)             | <YesIcon /> |
-| DriverKit for Development                         | <YesIcon /> |
-| Extended Virtual Address Space                    | <YesIcon /> |
-| Family Controls                                   | <YesIcon /> |
-| FileProvider TestingMode                          | <YesIcon /> |
-| Fonts                                             | <YesIcon /> |
-| Group Activities                                  | <YesIcon /> |
-| HealthKit                                         | <YesIcon /> |
-| HomeKit                                           | <YesIcon /> |
-| Hotspot                                           | <YesIcon /> |
-| Increased Memory Limit                            | <YesIcon /> |
-| Inter-App Audio                                   | <YesIcon /> |
-| Low Latency HLS                                   | <YesIcon /> |
-| MDM Managed Associated Domains                    | <YesIcon /> |
-| Maps                                              | <YesIcon /> |
-| Media Device Discovery                            | <YesIcon /> |
-| Multipath                                         | <YesIcon /> |
-| NFC Tag Reading                                   | <YesIcon /> |
-| Network Extensions                                | <YesIcon /> |
-| On Demand Install Capable for App Clip Extensions | <YesIcon /> |
-| Personal VPN                                      | <YesIcon /> |
-| Push Notifications                                | <YesIcon /> |
-| Push to Talk                                      | <YesIcon /> |
-| Recalibrate Estimates                             | <YesIcon /> |
-| Shared with You                                   | <YesIcon /> |
-| Sign In with Apple                                | <YesIcon /> |
-| SiriKit                                           | <YesIcon /> |
-| System Extension                                  | <YesIcon /> |
-| TV Services                                       | <YesIcon /> |
-| Time Sensitive Notifications                      | <YesIcon /> |
-| Wallet                                            | <YesIcon /> |
-| WeatherKit                                        | <YesIcon /> |
-| Wireless Accessory Configuration                  | <YesIcon /> |
-| iCloud                                            | <YesIcon /> |
-| HLS Interstitial Previews                         | <NoIcon />  |
+| Support     | Capability                                        | Entitlement string                                                         |
+| ----------- | ------------------------------------------------- | -------------------------------------------------------------------------- |
+| <YesIcon /> | Access WiFi Information                           | `com.apple.developer.networking.wifi-info`                                 |
+| <YesIcon /> | App Attest                                        | `com.apple.developer.devicecheck.appattest-environment`                    |
+| <YesIcon /> | App Groups                                        | `com.apple.security.application-groups`                                    |
+| <YesIcon /> | Apple Pay Payment Processing                      | `com.apple.developer.in-app-payments`                                      |
+| <YesIcon /> | Associated Domains                                | `com.apple.developer.associated-domains`                                   |
+| <YesIcon /> | AutoFill Credential Provider                      | `com.apple.developer.authentication-services.autofill-credential-provider` |
+| <YesIcon /> | ClassKit                                          | `com.apple.developer.ClassKit-environment`                                 |
+| <YesIcon /> | Communicates with Drivers                         | `com.apple.developer.driverkit.communicates-with-drivers`                  |
+| <YesIcon /> | Communication Notifications                       | `com.apple.developer.usernotifications.communication`                      |
+| <YesIcon /> | Custom Network Protocol                           | `com.apple.developer.networking.custom-protocol`                           |
+| <YesIcon /> | Data Protection                                   | `com.apple.developer.default-data-protection`                              |
+| <YesIcon /> | DriverKit Allow Third Party UserClients           | `com.apple.developer.driverkit.allow-third-party-userclients`              |
+| <YesIcon /> | DriverKit Family Audio (development)              | `com.apple.developer.driverkit.family.audio`                               |
+| <YesIcon /> | DriverKit Family HID Device (development)         | `com.apple.developer.driverkit.family.hid.device`                          |
+| <YesIcon /> | DriverKit Family HID EventService (development)   | `com.apple.developer.driverkit.family.hid.eventservice`                    |
+| <YesIcon /> | DriverKit Family Networking (development)         | `com.apple.developer.driverkit.family.networking`                          |
+| <YesIcon /> | DriverKit Family SCSIController (development)     | `com.apple.developer.driverkit.family.scsicontroller`                      |
+| <YesIcon /> | DriverKit Family Serial (development)             | `com.apple.developer.driverkit.family.serial`                              |
+| <YesIcon /> | DriverKit Transport HID (development)             | `com.apple.developer.driverkit.transport.hid`                              |
+| <YesIcon /> | DriverKit USB Transport (development)             | `com.apple.developer.driverkit.transport.usb`                              |
+| <YesIcon /> | DriverKit for Development                         | `com.apple.developer.driverkit`                                            |
+| <YesIcon /> | Extended Virtual Address Space                    | `com.apple.developer.kernel.extended-virtual-addressing`                   |
+| <YesIcon /> | Family Controls                                   | `com.apple.developer.family-controls`                                      |
+| <YesIcon /> | FileProvider TestingMode                          | `com.apple.developer.fileprovider.testing-mode`                            |
+| <YesIcon /> | Fonts                                             | `com.apple.developer.user-fonts`                                           |
+| <YesIcon /> | Group Activities                                  | `com.apple.developer.group-session`                                        |
+| <YesIcon /> | HealthKit                                         | `com.apple.developer.healthkit`                                            |
+| <YesIcon /> | HomeKit                                           | `com.apple.developer.homekit`                                              |
+| <YesIcon /> | Hotspot                                           | `com.apple.developer.networking.HotspotConfiguration`                      |
+| <YesIcon /> | Increased Memory Limit                            | `com.apple.developer.kernel.increased-memory-limit`                        |
+| <YesIcon /> | Inter-App Audio                                   | `inter-app-audio`                                                          |
+| <YesIcon /> | Low Latency HLS                                   | `com.apple.developer.coremedia.hls.low-latency`                            |
+| <YesIcon /> | MDM Managed Associated Domains                    | `com.apple.developer.associated-domains.mdm-managed`                       |
+| <YesIcon /> | Maps                                              | `com.apple.developer.maps`                                                 |
+| <YesIcon /> | Media Device Discovery                            | `com.apple.developer.media-device-discovery-extension`                     |
+| <YesIcon /> | Multipath                                         | `com.apple.developer.networking.multipath`                                 |
+| <YesIcon /> | NFC Tag Reading                                   | `com.apple.developer.nfc.readersession.formats`                            |
+| <YesIcon /> | Network Extensions                                | `com.apple.developer.networking.networkextension`                          |
+| <YesIcon /> | On Demand Install Capable for App Clip Extensions | `com.apple.developer.on-demand-install-capable`                            |
+| <YesIcon /> | Personal VPN                                      | `com.apple.developer.networking.vpn.api`                                   |
+| <YesIcon /> | Push Notifications                                | `aps-environment`                                                          |
+| <YesIcon /> | Push to Talk                                      | `com.apple.developer.push-to-talk`                                         |
+| <YesIcon /> | Recalibrate Estimates                             | `com.apple.developer.healthkit.recalibrate-estimates`                      |
+| <YesIcon /> | Shared with You                                   | `com.apple.developer.shared-with-you`                                      |
+| <YesIcon /> | Sign In with Apple                                | `com.apple.developer.applesignin`                                          |
+| <YesIcon /> | SiriKit                                           | `com.apple.developer.siri`                                                 |
+| <YesIcon /> | System Extension                                  | `com.apple.developer.system-extension.install`                             |
+| <YesIcon /> | TV Services                                       | `com.apple.developer.user-management`                                      |
+| <YesIcon /> | Time Sensitive Notifications                      | `com.apple.developer.usernotifications.time-sensitive`                     |
+| <YesIcon /> | Wallet                                            | `com.apple.developer.pass-type-identifiers`                                |
+| <YesIcon /> | WeatherKit                                        | `com.apple.developer.weatherkit`                                           |
+| <YesIcon /> | Wireless Accessory Configuration                  | `com.apple.external-accessory.wireless-configuration`                      |
+| <YesIcon /> | iCloud                                            | `com.apple.developer.icloud-container-identifiers`                         |
+| <NoIcon />  | HLS Interstitial Previews                         | ???                                                                        |
 
 The unsupported capabilities either don't support iOS, or they don't have a corresponding entitlement value.
 


### PR DESCRIPTION
# Why

Reflect updates in https://github.com/expo/eas-cli/pull/1307

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Added this to `packages/eas-cli/src/credentials/ios/appstore/__tests__/bundleIdCapabilities-test.ts` in `expo/eas-cli` to auto generate the table:

```ts
it('gens docs', () => {
  const docs = CapabilityMapping.sort((a, b) => {
    return a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
  })
    .map(classifier => {
      return ['', '<YesIcon />',  classifier.name, `\`${classifier.entitlement}\``, ''].join(' | ');
    })
    .join('\n');
  console.info(docs);
});
```

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
