### PR TITLE
[sweet API][Kotlin] Add option to generate a `coalescingKey` in callback

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Added view prop callbacks support for old-style views written in Objective-C. ([#18636](https://github.com/expo/expo/pull/18636) by [@tsapeta](https://github.com/tsapeta))
 - Add Logger support for writing logs to a file; add Logger and associated classes to Android. ([#18513](https://github.com/expo/expo/pull/18513) by [@douglowder](https://github.com/douglowder))
 - Experimental support for Fabric on Android. ([#18541](https://github.com/expo/expo/pull/18541) by [@kudo](https://github.com/kudo))
-- Add option to generate a `coalescingKey` in callback on Android.
+- Add option to generate a `coalescingKey` in callback on Android. ([#18774](https://github.com/expo/expo/pull/18774) by [@lukmccall](https://github.com/lukmccall))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -14,10 +14,11 @@
 - Added view prop callbacks support for old-style views written in Objective-C. ([#18636](https://github.com/expo/expo/pull/18636) by [@tsapeta](https://github.com/tsapeta))
 - Add Logger support for writing logs to a file; add Logger and associated classes to Android. ([#18513](https://github.com/expo/expo/pull/18513) by [@douglowder](https://github.com/douglowder))
 - Experimental support for Fabric on Android. ([#18541](https://github.com/expo/expo/pull/18541) by [@kudo](https://github.com/kudo))
+- Add option to generate a `coalescingKey` in callback on Android.
 
 ### 🐛 Bug fixes
 
-- Fix issue with Android builds when gradle clean and build were called concurrently.  ([#18518](https://github.com/expo/expo/pull/18518) by [EdwardDrapkin](https://github.com/EdwardDrapkin))
+- Fix issue with Android builds when gradle clean and build were called concurrently. ([#18518](https://github.com/expo/expo/pull/18518) by [EdwardDrapkin](https://github.com/EdwardDrapkin))
 - Fixed `FabricUIManager` errors when turning on new architecture mode on Android. ([#18472](https://github.com/expo/expo/pull/18472) by [@kudo](https://github.com/kudo))
 - Fixed the `2 files found with path 'lib/arm64-v8a/libfbjni.so'` error on Android. ([#18607](https://github.com/expo/expo/pull/18607) by [@lukmccall](https://github.com/lukmccall))
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/callbacks/ViewCallback.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/callbacks/ViewCallback.kt
@@ -31,7 +31,7 @@ class ViewCallback<T>(
         viewId = view.id,
         eventName = name,
         eventBody = convertEventBody(arg),
-        coalescingKey= coalescingKey?.invoke(arg)
+        coalescingKey = coalescingKey?.invoke(arg)
       )
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/callbacks/ViewCallback.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/callbacks/ViewCallback.kt
@@ -12,7 +12,8 @@ import kotlin.reflect.KType
 class ViewCallback<T>(
   private val name: String,
   private val type: KType,
-  private val view: View
+  private val view: View,
+  private val coalescingKey: CoalescingKey<T>?
 ) : Callback<T> {
   internal lateinit var module: Module
 
@@ -24,7 +25,14 @@ class ViewCallback<T>(
       ?: return
     val appContext = nativeModulesProxy.kotlinInteropModuleRegistry.appContext
 
-    appContext.callbackInvoker?.emit(view.id, name, convertEventBody(arg))
+    appContext
+      .callbackInvoker
+      ?.emit(
+        viewId = view.id,
+        eventName = name,
+        eventBody = convertEventBody(arg),
+        coalescingKey= coalescingKey?.invoke(arg)
+      )
   }
 
   private fun convertEventBody(arg: T): WritableMap? {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/callbacks/ViewCallbackDelegate.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/callbacks/ViewCallbackDelegate.kt
@@ -8,7 +8,13 @@ import kotlin.reflect.KProperty
 import kotlin.reflect.KType
 import kotlin.reflect.typeOf
 
-class ViewCallbackDelegate<T>(private val type: KType, view: View) {
+typealias CoalescingKey<T> = (event: T) -> Short
+
+class ViewCallbackDelegate<T>(
+  private val type: KType,
+  view: View,
+  private val coalescingKey: CoalescingKey<T>?
+) {
   private val viewHolder = WeakReference(view)
   internal var isValidated = false
 
@@ -17,11 +23,17 @@ class ViewCallbackDelegate<T>(private val type: KType, view: View) {
       throw IllegalStateException("You have to export this property as a callback in the `ViewManager`.")
     }
 
-    val view = viewHolder.get() ?: throw IllegalStateException("Can't send an event from the view that is deallocated.")
-    return ViewCallback(property.name, type, view)
+    val view = viewHolder.get()
+      ?: throw IllegalStateException("Can't send an event from the view that is deallocated.")
+    return ViewCallback(property.name, type, view, coalescingKey)
   }
 }
 
-inline fun <reified T> View.callback(): ViewCallbackDelegate<T> {
-  return ViewCallbackDelegate(typeOf<T>(), this)
+/**
+ * Creates a reference to the js callback.
+ * @param coalescingKey a key generator used to determine which other events of this type this event can be coalesced with.
+ * For example, touch move events should only be coalesced within a single gesture so a coalescing key there would be the unique gesture id.
+ */
+inline fun <reified T> View.callback(noinline coalescingKey: CoalescingKey<T>? = null): ViewCallbackDelegate<T> {
+  return ViewCallbackDelegate(typeOf<T>(), this, coalescingKey)
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/events/EventEmitter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/events/EventEmitter.kt
@@ -1,7 +1,6 @@
 package expo.modules.kotlin.events
 
 import com.facebook.react.bridge.WritableMap
-import expo.modules.kotlin.callbacks.CoalescingKey
 import expo.modules.kotlin.records.Record
 
 // We want to decorate a legacy event emitter interface to support advanced conversion between types in events.

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/events/EventEmitter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/events/EventEmitter.kt
@@ -1,6 +1,7 @@
 package expo.modules.kotlin.events
 
 import com.facebook.react.bridge.WritableMap
+import expo.modules.kotlin.callbacks.CoalescingKey
 import expo.modules.kotlin.records.Record
 
 // We want to decorate a legacy event emitter interface to support advanced conversion between types in events.
@@ -9,5 +10,5 @@ interface EventEmitter : expo.modules.core.interfaces.services.EventEmitter {
   fun emit(eventName: String, eventBody: WritableMap?)
   fun emit(eventName: String, eventBody: Record?)
   fun emit(eventName: String, eventBody: Map<*, *>?)
-  fun emit(viewId: Int, eventName: String, eventBody: WritableMap?)
+  fun emit(viewId: Int, eventName: String, eventBody: WritableMap?, coalescingKey: Short? = null)
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/events/KModuleEventEmitterWrapper.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/events/KModuleEventEmitterWrapper.kt
@@ -72,6 +72,7 @@ open class KEventEmitterWrapper(
     deviceEventEmitter
       ?.emit(eventName, eventBody)
   }
+
   override fun emit(eventName: String, eventBody: Record?) {
     deviceEventEmitter
       ?.emit(eventName, JSTypeConverter.convertToJSValue(eventBody))
@@ -82,19 +83,20 @@ open class KEventEmitterWrapper(
       ?.emit(eventName, JSTypeConverter.convertToJSValue(eventBody))
   }
 
-  override fun emit(viewId: Int, eventName: String, eventBody: WritableMap?) {
+  override fun emit(viewId: Int, eventName: String, eventBody: WritableMap?, coalescingKey: Short?) {
     uiEventDispatcher
-      ?.dispatchEvent(UIEvent(viewId, eventName, eventBody))
+      ?.dispatchEvent(UIEvent(viewId, eventName, eventBody, coalescingKey))
   }
 
   private class UIEvent(
     private val viewId: Int,
     private val eventName: String,
-    private val eventBody: WritableMap?
+    private val eventBody: WritableMap?,
+    private val coalescingKey: Short?
   ) : com.facebook.react.uimanager.events.Event<UIEvent>(viewId) {
     override fun getEventName(): String = eventName
-    override fun canCoalesce(): Boolean = false
-    override fun getCoalescingKey(): Short = 0
+    override fun canCoalesce(): Boolean = coalescingKey != null
+    override fun getCoalescingKey(): Short = coalescingKey ?: 0
     override fun dispatch(rctEventEmitter: RCTEventEmitter) {
       rctEventEmitter.receiveEvent(viewId, eventName, eventBody)
     }


### PR DESCRIPTION
# Why

Adds support for `coalescingKey` in callbacks.  

# How

Callback from now can receive a function that generates a `coalescingKey` from event data. That value is used later when we're emitting an event via a react-native event emitter to determine if the event can be collapsed to save computing power.  

# Test Plan

- used in the camera module 
