### PR TITLE
[sweet API][Kotlin] Add more information to the exceptions thrown from the prop setter

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
@@ -3,6 +3,7 @@ package expo.modules.kotlin.exception
 import com.facebook.react.bridge.ReadableType
 import expo.modules.core.interfaces.DoNotStrip
 import java.util.*
+import kotlin.reflect.KClass
 import kotlin.reflect.KProperty1
 import kotlin.reflect.KType
 
@@ -118,6 +119,15 @@ internal class FunctionCallException(
   cause: CodedException
 ) : DecoratedException(
   message = "Call to function '$moduleName.$methodName' has been rejected.",
+  cause,
+)
+
+internal class PropSetException(
+  propName: String,
+  viewType: KClass<*>,
+  cause: CodedException
+) : DecoratedException(
+  message = "Cannot set prop '$propName' on view '$viewType'",
   cause,
 )
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ConcreteViewProp.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ConcreteViewProp.kt
@@ -2,6 +2,8 @@ package expo.modules.kotlin.views
 
 import android.view.View
 import com.facebook.react.bridge.Dynamic
+import expo.modules.kotlin.exception.PropSetException
+import expo.modules.kotlin.exception.exceptionDecorator
 import expo.modules.kotlin.types.AnyType
 
 class ConcreteViewProp<ViewType : View, PropType>(
@@ -12,6 +14,10 @@ class ConcreteViewProp<ViewType : View, PropType>(
 
   @Suppress("UNCHECKED_CAST")
   override fun set(prop: Dynamic, onView: View) {
-    setter(onView as ViewType, propType.convert(prop) as PropType)
+    exceptionDecorator({
+      PropSetException(name, onView::class, it)
+    }) {
+      setter(onView as ViewType, propType.convert(prop) as PropType)
+    }
   }
 }


### PR DESCRIPTION
# Why

Decorated all exceptions that were thrown from the prop setter in the `PropSetException` to pass more information to the user. 

# How

Some time ago, I've added an ErrorManagerModule which passes information about failures in prop setters. However, we can provide more data to help users detect problems. 

# Test Plan

Before:
```
java.lang.RuntimeException: setParameters failed
```
Now:
```
expo.modules.kotlin.exception.PropSetException: Cannot set prop 'pictureSize' on view 'class expo.modules.camera.ExpoCameraView'
    → Caused by: java.lang.RuntimeException: setParameters failed
```