### PR TITLE
[sweet API][Kotlin] Deprecate `Module.coroutineScope`

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/Module.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/Module.kt
@@ -24,6 +24,8 @@ abstract class Module : AppContextProvider {
   @Suppress("PropertyName")
   @PublishedApi
   internal lateinit var coroutineScopeDelegate: Lazy<CoroutineScope>
+
+  @Deprecated(message = "Use a scope from the AppContext", replaceWith = ReplaceWith("appContext.modulesQueue"))
   val coroutineScope get() = coroutineScopeDelegate.value
 
   fun sendEvent(name: String, body: Bundle? = Bundle.EMPTY) {


### PR DESCRIPTION
# Why

Deprecates a module coroutine scope.
I don't think that API is beneficial. Developers can create their own scopes inside the module and it's a pretty rare case anyway. 