### PR TITLE
[sweet API][Kotlin] Add an option to specify the method queue

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -1,5 +1,3 @@
-@file:OptIn(DelicateCoroutinesApi::class)
-
 package expo.modules.kotlin
 
 import android.app.Activity
@@ -21,9 +19,9 @@ import expo.modules.interfaces.permissions.Permissions
 import expo.modules.interfaces.sensors.SensorServiceInterface
 import expo.modules.interfaces.taskManager.TaskManagerInterface
 import expo.modules.kotlin.activityresult.ActivityResultsManager
-import expo.modules.kotlin.activityresult.AppContextActivityResultFallbackCallback
 import expo.modules.kotlin.activityresult.AppContextActivityResultCaller
 import expo.modules.kotlin.activityresult.AppContextActivityResultContract
+import expo.modules.kotlin.activityresult.AppContextActivityResultFallbackCallback
 import expo.modules.kotlin.activityresult.AppContextActivityResultLauncher
 import expo.modules.kotlin.defaultmodules.ErrorManagerModule
 import expo.modules.kotlin.events.EventEmitter
@@ -37,6 +35,7 @@ import expo.modules.kotlin.providers.CurrentActivityProvider
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.newSingleThreadContext
@@ -58,11 +57,18 @@ class AppContext(
   /**
    * A queue used to dispatch all async methods that are called via JSI.
    */
-  internal val modulesQueue = CoroutineScope(
+  @OptIn(DelicateCoroutinesApi::class)
+  val modulesQueue = CoroutineScope(
     // TODO(@lukmccall): maybe it will be better to use a thread pool
-    newSingleThreadContext("ExpoModulesCoreQueue") +
+    newSingleThreadContext("expo.modules.AsyncFunctionQueue") +
       SupervisorJob() +
-      CoroutineName("ExpoModulesCoreCoroutineQueue")
+      CoroutineName("expo.modules.AsyncFunctionQueue")
+  )
+
+  val mainQueue = CoroutineScope(
+    Dispatchers.Main +
+      SupervisorJob() +
+      CoroutineName("expo.modules.MainQueue")
   )
 
   private val activityResultsManager = ActivityResultsManager(this)
@@ -202,14 +208,15 @@ class AppContext(
   internal val errorManager: ErrorManagerModule?
     get() = registry.getModule()
 
-  fun onDestroy() {
+  internal fun onDestroy() {
     reactContextHolder.get()?.removeLifecycleEventListener(reactLifecycleDelegate)
     registry.post(EventName.MODULE_DESTROY)
     registry.cleanUp()
     modulesQueue.cancel(ContextDestroyedException())
+    mainQueue.cancel(ContextDestroyedException())
   }
 
-  fun onHostResume() {
+  internal fun onHostResume() {
     activityResultsManager.onHostResume(
       requireNotNull(currentActivity) {
         "Current Activity is not available at this moment. This is an invalid state and this should never happen"
@@ -218,11 +225,11 @@ class AppContext(
     registry.post(EventName.ACTIVITY_ENTERS_FOREGROUND)
   }
 
-  fun onHostPause() {
+  internal fun onHostPause() {
     registry.post(EventName.ACTIVITY_ENTERS_BACKGROUND)
   }
 
-  fun onHostDestroy() {
+  internal fun onHostDestroy() {
     activityResultsManager.onHostDestroy(
       requireNotNull(currentActivity) {
         "Current Activity is not available at this moment. This is an invalid state and this should never happen"
@@ -231,7 +238,7 @@ class AppContext(
     registry.post(EventName.ACTIVITY_DESTROYS)
   }
 
-  fun onActivityResult(activity: Activity, requestCode: Int, resultCode: Int, data: Intent?) {
+  internal fun onActivityResult(activity: Activity, requestCode: Int, resultCode: Int, data: Intent?) {
     activityResultsManager.onActivityResult(activity, requestCode, resultCode, data)
     registry.post(
       EventName.ON_ACTIVITY_RESULT,
@@ -244,7 +251,7 @@ class AppContext(
     )
   }
 
-  fun onNewIntent(intent: Intent?) {
+  internal fun onNewIntent(intent: Intent?) {
     registry.post(
       EventName.ON_NEW_INTENT,
       intent

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
@@ -11,10 +11,9 @@ import expo.modules.kotlin.exception.MethodNotFoundException
 import expo.modules.kotlin.exception.exceptionDecorator
 import expo.modules.kotlin.jni.JavaScriptModuleObject
 import expo.modules.kotlin.modules.Module
-import expo.modules.kotlin.modules.ProcessedModuleDefinition
 
 class ModuleHolder(val module: Module) {
-  val definition = ProcessedModuleDefinition(module.definition(), this)
+  val definition = module.definition()
 
   val name get() = definition.name
 
@@ -51,7 +50,7 @@ class ModuleHolder(val module: Module) {
     val method = definition.asyncFunctions[methodName]
       ?: throw MethodNotFoundException()
 
-    method.call(args, promise)
+    method.call(this, args, promise)
   }
 
   /**

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AnyFunction.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AnyFunction.kt
@@ -81,7 +81,7 @@ abstract class AnyFunction(
   /**
    * Attaches current function to the provided js object.
    */
-  abstract fun attachToJSObject(appContext: AppContext, jsObject: JavaScriptModuleObject)
+  internal abstract fun attachToJSObject(appContext: AppContext, jsObject: JavaScriptModuleObject)
 
   fun getCppRequiredTypes(): List<ExpectedType> {
     return desiredArgsTypes.map { it.getCppRequiredTypes() }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunction.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunction.kt
@@ -28,11 +28,7 @@ abstract class AsyncFunction(
     }
 
     if (queue == null) {
-      exceptionDecorator({
-        FunctionCallException(name, holder.name, it)
-      }) {
-        callUserImplementation(args, promise)
-      }
+      callUserImplementation(args, promise)
     } else {
       queue.launch {
         try {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunction.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunction.kt
@@ -3,6 +3,7 @@ package expo.modules.kotlin.functions
 import com.facebook.react.bridge.ReadableArray
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.KPromiseWrapper
+import expo.modules.kotlin.ModuleHolder
 import expo.modules.kotlin.Promise
 import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.exception.FunctionCallException
@@ -13,16 +14,46 @@ import expo.modules.kotlin.types.AnyType
 import kotlinx.coroutines.launch
 
 /**
- * Base class of all function components that require a promise to be called.
+ * Base class of async function components that require a promise to be called.
  */
 abstract class AsyncFunction(
   name: String,
   desiredArgsTypes: Array<AnyType>
-) : AnyFunction(name, desiredArgsTypes) {
-  @Throws(CodedException::class)
-  abstract fun call(args: ReadableArray, promise: Promise)
+) : BaseAsyncFunctionComponent(name, desiredArgsTypes) {
 
-  abstract fun call(args: Array<Any?>, promise: Promise)
+  override fun call(holder: ModuleHolder, args: ReadableArray, promise: Promise) {
+    val queue = when (queue) {
+      Queues.MAIN -> holder.module.appContext.mainQueue
+      Queues.DEFAULT -> null
+    }
+
+    if (queue == null) {
+      exceptionDecorator({
+        FunctionCallException(name, holder.name, it)
+      }) {
+        callUserImplementation(args, promise)
+      }
+    } else {
+      queue.launch {
+        try {
+          exceptionDecorator({
+            FunctionCallException(name, holder.name, it)
+          }) {
+            callUserImplementation(args, promise)
+          }
+        } catch (e: CodedException) {
+          promise.reject(e)
+        } catch (e: Throwable) {
+          promise.reject(UnexpectedException(e))
+        }
+      }
+    }
+  }
+
+  @Throws(CodedException::class)
+  internal abstract fun callUserImplementation(args: ReadableArray, promise: Promise)
+
+  internal abstract fun callUserImplementation(args: Array<Any?>, promise: Promise)
 
   override fun attachToJSObject(appContext: AppContext, jsObject: JavaScriptModuleObject) {
     jsObject.registerAsyncFunction(
@@ -31,12 +62,18 @@ abstract class AsyncFunction(
       desiredArgsTypes.map { it.getCppRequiredTypes() }.toTypedArray()
     ) { args, bridgePromise ->
       val kotlinPromise = KPromiseWrapper(bridgePromise as com.facebook.react.bridge.Promise)
-      appContext.modulesQueue.launch {
+
+      val queue = when (queue) {
+        Queues.MAIN -> appContext.mainQueue
+        Queues.DEFAULT -> appContext.modulesQueue
+      }
+
+      queue.launch {
         try {
           exceptionDecorator({
-            FunctionCallException(jsObject.name, name, it)
+            FunctionCallException(name, jsObject.name, it)
           }) {
-            call(args, kotlinPromise)
+            callUserImplementation(args, kotlinPromise)
           }
         } catch (e: CodedException) {
           kotlinPromise.reject(e)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunctionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunctionBuilder.kt
@@ -8,47 +8,63 @@ import kotlin.reflect.typeOf
 
 class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
   @PublishedApi
-  internal var functionBuilder: SuspendFunctionComponentBuilder? = null
+  internal var suspendFunctionComponent: SuspendFunctionComponent? = null
 
-  inline fun <reified R> SuspendBody(crossinline block: suspend () -> R) {
-    functionBuilder = SuspendFunctionComponentBuilder(name, arrayOf()) { block() }
+  inline fun <reified R> SuspendBody(crossinline block: suspend () -> R): SuspendFunctionComponent {
+    return SuspendFunctionComponent(name, arrayOf()) { block() }.also {
+      suspendFunctionComponent = it
+    }
   }
 
-  inline fun <reified R, reified P0> SuspendBody(crossinline block: suspend (p0: P0) -> R) {
-    functionBuilder = SuspendFunctionComponentBuilder(name, arrayOf(typeOf<P0>().toAnyType())) { block(it[0] as P0) }
+  inline fun <reified R, reified P0> SuspendBody(crossinline block: suspend (p0: P0) -> R): SuspendFunctionComponent {
+    return SuspendFunctionComponent(name, arrayOf(typeOf<P0>().toAnyType())) { block(it[0] as P0) }.also {
+      suspendFunctionComponent = it
+    }
   }
 
-  inline fun <reified R, reified P0, reified P1> SuspendBody(crossinline block: suspend (p0: P0, p1: P1) -> R) {
-    functionBuilder = SuspendFunctionComponentBuilder(name, arrayOf(typeOf<P0>().toAnyType())) { block(it[0] as P0, it[0] as P1) }
+  inline fun <reified R, reified P0, reified P1> SuspendBody(crossinline block: suspend (p0: P0, p1: P1) -> R): SuspendFunctionComponent {
+    return SuspendFunctionComponent(name, arrayOf(typeOf<P0>().toAnyType())) { block(it[0] as P0, it[0] as P1) }.also {
+      suspendFunctionComponent = it
+    }
   }
 
-  inline fun <reified R, reified P0, reified P1, reified P2> SuspendBody(crossinline block: suspend (p0: P0, p1: P1, p2: P2) -> R) {
-    functionBuilder = SuspendFunctionComponentBuilder(name, arrayOf(typeOf<P0>().toAnyType())) { block(it[0] as P0, it[1] as P1, it[2] as P2) }
+  inline fun <reified R, reified P0, reified P1, reified P2> SuspendBody(crossinline block: suspend (p0: P0, p1: P1, p2: P2) -> R): SuspendFunctionComponent {
+    return SuspendFunctionComponent(name, arrayOf(typeOf<P0>().toAnyType())) { block(it[0] as P0, it[1] as P1, it[2] as P2) }.also {
+      suspendFunctionComponent = it
+    }
   }
 
-  inline fun <reified R, reified P0, reified P1, reified P2, reified P3> SuspendBody(crossinline block: suspend (p0: P0, p1: P1, p2: P2, p3: P3) -> R) {
-    functionBuilder = SuspendFunctionComponentBuilder(name, arrayOf(typeOf<P0>().toAnyType())) { block(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3) }
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3> SuspendBody(crossinline block: suspend (p0: P0, p1: P1, p2: P2, p3: P3) -> R): SuspendFunctionComponent {
+    return SuspendFunctionComponent(name, arrayOf(typeOf<P0>().toAnyType())) { block(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3) }.also {
+      suspendFunctionComponent = it
+    }
   }
 
-  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4> SuspendBody(crossinline block: suspend (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4) -> R) {
-    functionBuilder = SuspendFunctionComponentBuilder(name, arrayOf(typeOf<P0>().toAnyType())) { block(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4) }
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4> SuspendBody(crossinline block: suspend (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4) -> R): SuspendFunctionComponent {
+    return SuspendFunctionComponent(name, arrayOf(typeOf<P0>().toAnyType())) { block(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4) }.also {
+      suspendFunctionComponent = it
+    }
   }
 
-  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5> SuspendBody(crossinline block: suspend (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) -> R) {
-    functionBuilder = SuspendFunctionComponentBuilder(name, arrayOf(typeOf<P0>().toAnyType())) { block(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5) }
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5> SuspendBody(crossinline block: suspend (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) -> R): SuspendFunctionComponent {
+    return SuspendFunctionComponent(name, arrayOf(typeOf<P0>().toAnyType())) { block(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5) }.also {
+      suspendFunctionComponent = it
+    }
   }
 
-  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6> SuspendBody(crossinline block: suspend (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6) -> R) {
-    functionBuilder = SuspendFunctionComponentBuilder(name, arrayOf(typeOf<P0>().toAnyType())) { block(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5, it[6] as P6) }
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6> SuspendBody(crossinline block: suspend (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6) -> R): SuspendFunctionComponent {
+    return SuspendFunctionComponent(name, arrayOf(typeOf<P0>().toAnyType())) { block(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5, it[6] as P6) }.also {
+      suspendFunctionComponent = it
+    }
   }
 
-  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6, reified P7> SuspendBody(crossinline block: suspend (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7) -> R) {
-    functionBuilder = SuspendFunctionComponentBuilder(name, arrayOf(typeOf<P0>().toAnyType())) { block(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5, it[6] as P6, it[7] as P7) }
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6, reified P7> SuspendBody(crossinline block: suspend (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7) -> R): SuspendFunctionComponent {
+    return SuspendFunctionComponent(name, arrayOf(typeOf<P0>().toAnyType())) { block(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5, it[6] as P6, it[7] as P7) }.also {
+      suspendFunctionComponent = it
+    }
   }
 
-  internal fun build(): SuspendFunctionComponentBuilder {
-    return requireNotNull(functionBuilder)
-  }
+  internal fun build() = requireNotNull(suspendFunctionComponent)
 }
 
 inline infix fun <reified R> AsyncFunctionBuilder.Coroutine(crossinline block: suspend () -> R) = SuspendBody(block)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunctionComponent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunctionComponent.kt
@@ -11,11 +11,11 @@ class AsyncFunctionComponent(
   private val body: (args: Array<out Any?>) -> Any?
 ) : AsyncFunction(name, desiredArgsTypes) {
   @Throws(CodedException::class)
-  override fun call(args: ReadableArray, promise: Promise) {
+  override fun callUserImplementation(args: ReadableArray, promise: Promise) {
     promise.resolve(body(convertArgs(args)))
   }
 
-  override fun call(args: Array<Any?>, promise: Promise) {
+  override fun callUserImplementation(args: Array<Any?>, promise: Promise) {
     promise.resolve(body(convertArgs(args)))
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunctionWithPromiseComponent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunctionWithPromiseComponent.kt
@@ -11,11 +11,11 @@ class AsyncFunctionWithPromiseComponent(
   private val body: (args: Array<out Any?>, promise: Promise) -> Unit
 ) : AsyncFunction(name, desiredArgsTypes) {
   @Throws(CodedException::class)
-  override fun call(args: ReadableArray, promise: Promise) {
+  override fun callUserImplementation(args: ReadableArray, promise: Promise) {
     body(convertArgs(args), promise)
   }
 
-  override fun call(args: Array<Any?>, promise: Promise) {
+  override fun callUserImplementation(args: Array<Any?>, promise: Promise) {
     body(convertArgs(args), promise)
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/BaseAsyncFunctionComponent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/BaseAsyncFunctionComponent.kt
@@ -1,0 +1,25 @@
+package expo.modules.kotlin.functions
+
+import com.facebook.react.bridge.ReadableArray
+import expo.modules.kotlin.ModuleHolder
+import expo.modules.kotlin.Promise
+import expo.modules.kotlin.types.AnyType
+
+enum class Queues {
+  MAIN,
+  DEFAULT,
+}
+
+abstract class BaseAsyncFunctionComponent(
+  name: String,
+  desiredArgsTypes: Array<AnyType>
+) : AnyFunction(name, desiredArgsTypes) {
+
+  protected var queue = Queues.DEFAULT
+
+  abstract fun call(holder: ModuleHolder, args: ReadableArray, promise: Promise)
+
+  fun runOnQueue(queue: Queues) = apply {
+    this.queue = queue
+  }
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/SuspendFunctionComponent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/SuspendFunctionComponent.kt
@@ -1,62 +1,79 @@
 package expo.modules.kotlin.functions
 
 import com.facebook.react.bridge.ReadableArray
+import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.KPromiseWrapper
 import expo.modules.kotlin.ModuleHolder
 import expo.modules.kotlin.Promise
 import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.exception.FunctionCallException
 import expo.modules.kotlin.exception.UnexpectedException
 import expo.modules.kotlin.exception.exceptionDecorator
+import expo.modules.kotlin.jni.JavaScriptModuleObject
 import expo.modules.kotlin.types.AnyType
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import java.lang.ref.WeakReference
-
-/**
- * We can't construct a `SuspendFunctionComponent` in the build phase, because it has to have access to module coroutine scope.
- * So we create another builder to store needed information and build it later - during the holder initialization.
- */
-class SuspendFunctionComponentBuilder(
-  internal val name: String,
-  private val desiredArgsTypes: Array<AnyType>,
-  private val body: suspend CoroutineScope.(args: Array<out Any?>) -> Any?,
-) {
-  fun build(moduleHolder: ModuleHolder) =
-    SuspendFunctionComponent(name, desiredArgsTypes, WeakReference(moduleHolder), body)
-}
 
 class SuspendFunctionComponent(
   name: String,
   desiredArgsTypes: Array<AnyType>,
-  private val moduleHolderRef: WeakReference<ModuleHolder>,
   private val body: suspend CoroutineScope.(args: Array<out Any?>) -> Any?
-) : AsyncFunction(name, desiredArgsTypes) {
-  @Throws(CodedException::class)
-  override fun call(args: ReadableArray, promise: Promise) {
-    callWithConvertedArguments(convertArgs(args), promise)
-  }
+) : BaseAsyncFunctionComponent(name, desiredArgsTypes) {
 
-  override fun call(args: Array<Any?>, promise: Promise) {
-    callWithConvertedArguments(convertArgs(args), promise)
-  }
+  override fun call(holder: ModuleHolder, args: ReadableArray, promise: Promise) {
+    val appContext = holder.module.appContext
+    val queue = when (queue) {
+      Queues.MAIN -> appContext.mainQueue
+      Queues.DEFAULT -> appContext.modulesQueue
+    }
 
-  private fun callWithConvertedArguments(convertedArgs: Array<out Any?>, promise: Promise) {
-    val holder = moduleHolderRef.get() ?: return
-    val scope = holder.module.coroutineScopeDelegate.value
-
-    scope.launch {
+    queue.launch {
       try {
-        val result = exceptionDecorator({ cause -> FunctionCallException(name, holder.name, cause) }) {
-          body.invoke(scope, convertedArgs)
-        }
-        if (isActive) {
-          promise.resolve(result)
+        exceptionDecorator({
+          FunctionCallException(name, holder.name, it)
+        }) {
+          val result = body.invoke(this, convertArgs(args))
+          if (isActive) {
+            promise.resolve(result)
+          }
         }
       } catch (e: CodedException) {
         promise.reject(e)
       } catch (e: Throwable) {
         promise.reject(UnexpectedException(e))
+      }
+    }
+  }
+
+  override fun attachToJSObject(appContext: AppContext, jsObject: JavaScriptModuleObject) {
+    jsObject.registerAsyncFunction(
+      name,
+      argsCount,
+      desiredArgsTypes.map { it.getCppRequiredTypes() }.toTypedArray()
+    ) { args, bridgePromise ->
+      val kotlinPromise = KPromiseWrapper(bridgePromise as com.facebook.react.bridge.Promise)
+
+      val queue = when (queue) {
+        Queues.MAIN -> appContext.mainQueue
+        Queues.DEFAULT -> appContext.modulesQueue
+      }
+
+      queue.launch {
+        try {
+          exceptionDecorator({
+            FunctionCallException(name, jsObject.name, it)
+          }) {
+            val result = body.invoke(this, convertArgs(args))
+            if (isActive) {
+              kotlinPromise.resolve(result)
+            }
+          }
+        } catch (e: CodedException) {
+          kotlinPromise.reject(e)
+        } catch (e: Throwable) {
+          kotlinPromise.reject(UnexpectedException(e))
+        }
       }
     }
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/SyncFunctionComponent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/SyncFunctionComponent.kt
@@ -31,7 +31,7 @@ class SyncFunctionComponent(
       getCppRequiredTypes().toTypedArray()
     ) { args ->
       return@registerSyncFunction exceptionDecorator({
-        FunctionCallException(jsObject.name, name, it)
+        FunctionCallException(name, jsObject.name, it)
       }) {
         val result = call(args)
         val convertedResult = JSTypeConverter.convertToJSValue(result)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionData.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionData.kt
@@ -1,40 +1,23 @@
 package expo.modules.kotlin.modules
 
 import expo.modules.kotlin.ConcatIterator
-import expo.modules.kotlin.ModuleHolder
 import expo.modules.kotlin.events.EventListener
 import expo.modules.kotlin.events.EventName
 import expo.modules.kotlin.objects.ObjectDefinitionData
 import expo.modules.kotlin.views.ViewManagerDefinition
 
-/**
- * Intermediate data used to create a proper [ProcessedModuleDefinition].
- * It contains all, unprocessed data from [ModuleDefinitionBuilder].
- */
 class ModuleDefinitionData(
   val name: String,
   val objectDefinition: ObjectDefinitionData,
   val viewManagerDefinition: ViewManagerDefinition? = null,
   val eventListeners: Map<EventName, EventListener> = emptyMap(),
-)
-
-/**
- * A final version of the ModuleDefinition.
- * Most values are just copied from [ModuleDefinitionData].
- * However some fields like `asyncFunctions` need to be processed or bound with the [ModuleHolder].
- */
-class ProcessedModuleDefinition(
-  data: ModuleDefinitionData,
-  moduleHolder: ModuleHolder
 ) {
-  val name = data.name
-  val constantsProvider = data.objectDefinition.constantsProvider
-  val syncFunctions = data.objectDefinition.syncFunctions
-  val asyncFunctions = data.objectDefinition.asyncFunctions + data.objectDefinition.buildSuspendFunctions(moduleHolder)
-  val viewManagerDefinition = data.viewManagerDefinition
-  val eventListeners = data.eventListeners
-  val eventsDefinition = data.objectDefinition.eventsDefinition
-  val properties = data.objectDefinition.properties
+
+  val constantsProvider = objectDefinition.constantsProvider
+  val syncFunctions = objectDefinition.syncFunctions
+  val asyncFunctions = objectDefinition.asyncFunctions
+  val eventsDefinition = objectDefinition.eventsDefinition
+  val properties = objectDefinition.properties
 
   val functions
     get() = ConcatIterator(syncFunctions.values.iterator(), asyncFunctions.values.iterator())

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
@@ -46,8 +46,7 @@ open class ObjectDefinitionBuilder {
     return ObjectDefinitionData(
       constantsProvider,
       syncFunctions,
-      asyncFunctions,
-      functionBuilders.mapValues { (_, value) -> value.build() },
+      asyncFunctions + functionBuilders.mapValues { (_, value) -> value.build() },
       eventsDefinition,
       properties.mapValues { (_, value) -> value.build() }
     )
@@ -71,8 +70,8 @@ open class ObjectDefinitionBuilder {
   inline fun Function(
     name: String,
     crossinline body: () -> Any?
-  ) {
-    SyncFunctionComponent(name, arrayOf()) { body() }.also {
+  ): SyncFunctionComponent {
+    return SyncFunctionComponent(name, arrayOf()) { body() }.also {
       syncFunctions[name] = it
     }
   }
@@ -80,8 +79,8 @@ open class ObjectDefinitionBuilder {
   inline fun <reified R> Function(
     name: String,
     crossinline body: () -> R
-  ) {
-    SyncFunctionComponent(name, arrayOf()) { body() }.also {
+  ): SyncFunctionComponent {
+    return SyncFunctionComponent(name, arrayOf()) { body() }.also {
       syncFunctions[name] = it
     }
   }
@@ -89,8 +88,8 @@ open class ObjectDefinitionBuilder {
   inline fun <reified R, reified P0> Function(
     name: String,
     crossinline body: (p0: P0) -> R
-  ) {
-    SyncFunctionComponent(name, arrayOf(typeOf<P0>().toAnyType())) { body(it[0] as P0) }.also {
+  ): SyncFunctionComponent {
+    return SyncFunctionComponent(name, arrayOf(typeOf<P0>().toAnyType())) { body(it[0] as P0) }.also {
       syncFunctions[name] = it
     }
   }
@@ -98,8 +97,8 @@ open class ObjectDefinitionBuilder {
   inline fun <reified R, reified P0, reified P1> Function(
     name: String,
     crossinline body: (p0: P0, p1: P1) -> R
-  ) {
-    SyncFunctionComponent(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType())) { body(it[0] as P0, it[1] as P1) }.also {
+  ): SyncFunctionComponent {
+    return SyncFunctionComponent(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType())) { body(it[0] as P0, it[1] as P1) }.also {
       syncFunctions[name] = it
     }
   }
@@ -107,8 +106,8 @@ open class ObjectDefinitionBuilder {
   inline fun <reified R, reified P0, reified P1, reified P2> Function(
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2) -> R
-  ) {
-    SyncFunctionComponent(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2) }.also {
+  ): SyncFunctionComponent {
+    return SyncFunctionComponent(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2) }.also {
       syncFunctions[name] = it
     }
   }
@@ -116,8 +115,8 @@ open class ObjectDefinitionBuilder {
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5> Function(
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) -> R
-  ) {
-    SyncFunctionComponent(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType(), typeOf<P5>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5) }.also {
+  ): SyncFunctionComponent {
+    return SyncFunctionComponent(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType(), typeOf<P5>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5) }.also {
       syncFunctions[name] = it
     }
   }
@@ -126,102 +125,122 @@ open class ObjectDefinitionBuilder {
   inline fun AsyncFunction(
     name: String,
     crossinline body: () -> Any?
-  ) {
-    asyncFunctions[name] = AsyncFunctionComponent(name, arrayOf()) { body() }
+  ): AsyncFunction {
+    return AsyncFunctionComponent(name, arrayOf()) { body() }.also {
+      asyncFunctions[name] = it
+    }
   }
 
   inline fun <reified R> AsyncFunction(
     name: String,
     crossinline body: () -> R
-  ) {
-    asyncFunctions[name] = AsyncFunctionComponent(name, arrayOf()) { body() }
+  ): AsyncFunction {
+    return AsyncFunctionComponent(name, arrayOf()) { body() }.also {
+      asyncFunctions[name] = it
+    }
   }
 
   inline fun <reified R, reified P0> AsyncFunction(
     name: String,
     crossinline body: (p0: P0) -> R
-  ) {
-    asyncFunctions[name] = if (P0::class == Promise::class) {
+  ): AsyncFunction {
+    return if (P0::class == Promise::class) {
       AsyncFunctionWithPromiseComponent(name, arrayOf()) { _, promise -> body(promise as P0) }
     } else {
       AsyncFunctionComponent(name, arrayOf(typeOf<P0>().toAnyType())) { body(it[0] as P0) }
+    }.also {
+      asyncFunctions[name] = it
     }
   }
 
   inline fun <reified R, reified P0, reified P1> AsyncFunction(
     name: String,
     crossinline body: (p0: P0, p1: P1) -> R
-  ) {
-    asyncFunctions[name] = if (P1::class == Promise::class) {
+  ): AsyncFunction {
+    return if (P1::class == Promise::class) {
       AsyncFunctionWithPromiseComponent(name, arrayOf(typeOf<P0>().toAnyType())) { args, promise -> body(args[0] as P0, promise as P1) }
     } else {
       AsyncFunctionComponent(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType())) { body(it[0] as P0, it[1] as P1) }
+    }.also {
+      asyncFunctions[name] = it
     }
   }
 
   inline fun <reified R, reified P0, reified P1, reified P2> AsyncFunction(
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2) -> R
-  ) {
-    asyncFunctions[name] = if (P2::class == Promise::class) {
+  ): AsyncFunction {
+    return if (P2::class == Promise::class) {
       AsyncFunctionWithPromiseComponent(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType())) { args, promise -> body(args[0] as P0, args[1] as P1, promise as P2) }
     } else {
       AsyncFunctionComponent(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2) }
+    }.also {
+      asyncFunctions[name] = it
     }
   }
 
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3> AsyncFunction(
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3) -> R
-  ) {
-    asyncFunctions[name] = if (P3::class == Promise::class) {
+  ): AsyncFunction {
+    return if (P3::class == Promise::class) {
       AsyncFunctionWithPromiseComponent(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, promise as P3) }
     } else {
       AsyncFunctionComponent(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3) }
+    }.also {
+      asyncFunctions[name] = it
     }
   }
 
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4> AsyncFunction(
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4) -> R
-  ) {
-    asyncFunctions[name] = if (P4::class == Promise::class) {
+  ): AsyncFunction {
+    return if (P4::class == Promise::class) {
       AsyncFunctionWithPromiseComponent(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, promise as P4) }
     } else {
       AsyncFunctionComponent(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4) }
+    }.also {
+      asyncFunctions[name] = it
     }
   }
 
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5> AsyncFunction(
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) -> R
-  ) {
-    asyncFunctions[name] = if (P5::class == Promise::class) {
+  ): AsyncFunction {
+    return if (P5::class == Promise::class) {
       AsyncFunctionWithPromiseComponent(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, args[4] as P4, promise as P5) }
     } else {
       AsyncFunctionComponent(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType(), typeOf<P5>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5) }
+    }.also {
+      asyncFunctions[name] = it
     }
   }
 
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6> AsyncFunction(
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6) -> R
-  ) {
-    asyncFunctions[name] = if (P6::class == Promise::class) {
+  ): AsyncFunction {
+    return if (P6::class == Promise::class) {
       AsyncFunctionWithPromiseComponent(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType(), typeOf<P5>().toAnyType())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, args[4] as P4, args[5] as P5, promise as P6) }
     } else {
       AsyncFunctionComponent(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType(), typeOf<P5>().toAnyType(), typeOf<P6>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5, it[6] as P6) }
+    }.also {
+      asyncFunctions[name] = it
     }
   }
 
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6, reified P7> AsyncFunction(
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7) -> R
-  ) {
-    asyncFunctions[name] = if (P7::class == Promise::class) {
+  ): AsyncFunction {
+    return if (P7::class == Promise::class) {
       AsyncFunctionWithPromiseComponent(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType(), typeOf<P5>().toAnyType(), typeOf<P6>().toAnyType())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, args[4] as P4, args[5] as P5, args[6] as P6, promise as P7) }
     } else {
       AsyncFunctionComponent(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType(), typeOf<P5>().toAnyType(), typeOf<P6>().toAnyType(), typeOf<P7>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5, it[6] as P6, it[7] as P7) }
+    }.also {
+      asyncFunctions[name] = it
     }
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionData.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionData.kt
@@ -1,21 +1,13 @@
 package expo.modules.kotlin.objects
 
-import expo.modules.kotlin.ModuleHolder
 import expo.modules.kotlin.events.EventsDefinition
-import expo.modules.kotlin.functions.AsyncFunction
-import expo.modules.kotlin.functions.SuspendFunctionComponent
-import expo.modules.kotlin.functions.SuspendFunctionComponentBuilder
+import expo.modules.kotlin.functions.BaseAsyncFunctionComponent
 import expo.modules.kotlin.functions.SyncFunctionComponent
 
 class ObjectDefinitionData(
   val constantsProvider: () -> Map<String, Any?>,
   val syncFunctions: Map<String, SyncFunctionComponent>,
-  val asyncFunctions: Map<String, AsyncFunction>,
-  val suspendFunctionBuilders: Map<String, SuspendFunctionComponentBuilder>,
+  val asyncFunctions: Map<String, BaseAsyncFunctionComponent>,
   val eventsDefinition: EventsDefinition?,
   val properties: Map<String, PropertyComponent>
-) {
-  fun buildSuspendFunctions(moduleHolder: ModuleHolder): Map<String, SuspendFunctionComponent> {
-    return suspendFunctionBuilders.mapValues { (_, value) -> value.build(moduleHolder) }
-  }
-}
+)

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/functions/AnyFunctionTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/functions/AnyFunctionTest.kt
@@ -12,6 +12,7 @@ import expo.modules.kotlin.Promise
 import expo.modules.kotlin.exception.ArgumentCastException
 import expo.modules.kotlin.exception.InvalidArgsNumberException
 import expo.modules.kotlin.types.toAnyType
+import io.mockk.mockk
 import org.junit.Test
 import kotlin.reflect.KType
 import kotlin.reflect.typeOf
@@ -20,12 +21,12 @@ class AnyFunctionTest {
   class MockedAnyFunction(
     desiredArgsTypes: Array<KType>
   ) : AsyncFunction("my-method", desiredArgsTypes.map { it.toAnyType() }.toTypedArray()) {
-    override fun call(args: ReadableArray, promise: Promise) {
+    override fun callUserImplementation(args: ReadableArray, promise: Promise) {
       convertArgs(args)
       throw NullPointerException()
     }
 
-    override fun call(args: Array<Any?>, promise: Promise) {
+    override fun callUserImplementation(args: Array<Any?>, promise: Promise) {
       error("Not implemented.")
     }
   }
@@ -37,6 +38,7 @@ class AnyFunctionTest {
 
     assertThrows<InvalidArgsNumberException>("Received 2 arguments, but 1 was expected.") {
       method.call(
+        mockk(),
         JavaOnlyArray().apply {
           pushInt(1)
           pushInt(2)
@@ -55,6 +57,7 @@ class AnyFunctionTest {
 
     assertThrows<InvalidArgsNumberException>("Received 1 arguments, but 2 was expected.") {
       method.call(
+        mockk(),
         JavaOnlyArray().apply {
           pushInt(1)
         },
@@ -77,6 +80,7 @@ class AnyFunctionTest {
       """.trimIndent()
     ) {
       method.call(
+        mockk(),
         JavaOnlyArray().apply {
           pushString("STRING")
         },
@@ -94,6 +98,7 @@ class AnyFunctionTest {
 
     assertThrows<NullPointerException> {
       method.call(
+        mockk(),
         JavaOnlyArray(),
         promise
       )


### PR DESCRIPTION
# Why

Adds an ability to choose on which queue async method should be dispatched. 

# How

- Removed a `SuspendFunctionComponentBuilder`, because we won't be using a module scope anymore. So, we don't need to bind `SuspendFunctionComponent` with the module. 
- Added an `BaseAsyncFunctionComponent`. It is an entry point where users can choose a queue. 
- Ensured that all DSL method returns function components. 

# Test Plan

- unit tests ✅
- NCL ✅
