### PR TITLE
[expo-dev-launcher] switch to metro logging for uncaught exceptions

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### 💡 Others
 
 - Refactored inline Android emulator checks to use enhanced checking in `EmulatorUtilities.isRunningOnEmulator()`. ([#16177](https://github.com/expo/expo/pull/16177)) by [@kbrandwijk](https://github.com/kbrandwijk), [@keith-kurak](https://github.com/keith-kurak))
-- Switched uncaught exception logging to use metro websocket instead of expo-cli logUrl.
+- Switched uncaught exception logging to use metro websocket instead of expo-cli logUrl. ([#18787](https://github.com/expo/expo/pull/18787) by [@esamelson](https://github.com/esamelson))
 
 ## 1.2.1 — 2022-08-16
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 💡 Others
 
 - Refactored inline Android emulator checks to use enhanced checking in `EmulatorUtilities.isRunningOnEmulator()`. ([#16177](https://github.com/expo/expo/pull/16177)) by [@kbrandwijk](https://github.com/kbrandwijk), [@keith-kurak](https://github.com/keith-kurak))
+- Switched uncaught exception logging to use metro websocket instead of expo-cli logUrl.
 
 ## 1.2.1 — 2022-08-16
 

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/errors/DevLauncherUncaughtExceptionHandler.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/errors/DevLauncherUncaughtExceptionHandler.kt
@@ -109,28 +109,24 @@ class DevLauncherUncaughtExceptionHandler(
     }
 
     try {
-      val url = getLogsUrl()
+      val url = getWebSocketUrl()
       val remoteLogManager = DevLauncherRemoteLogManager(DevLauncherKoinContext.app.koin.get(), url)
         .apply {
           deferError("Your app just crashed. See the error below.")
           deferError(exception)
         }
-      remoteLogManager.sendSync()
+      remoteLogManager.sendViaWebSocket()
     } catch (e: Throwable) {
       Log.e("DevLauncher", "Couldn't send an exception to bundler. $e", e)
     }
   }
 
-  private fun getLogsUrl(): Uri {
-    val logsUrlFromManifest = controller.manifest?.getLogUrl()
-    if (logsUrlFromManifest.isNullOrEmpty()) {
-      return Uri.parse(logsUrlFromManifest)
-    }
-
+  private fun getWebSocketUrl(): Uri {
     return Uri
       .parse(controller.appHost.reactInstanceManager.devSupportManager.sourceUrl)
       .buildUpon()
-      .path("logs")
+      .scheme("http")
+      .path("hot")
       .clearQuery()
       .build()
   }

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/errors/DevLauncherUncaughtExceptionHandler.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/errors/DevLauncherUncaughtExceptionHandler.kt
@@ -125,7 +125,6 @@ class DevLauncherUncaughtExceptionHandler(
     return Uri
       .parse(controller.appHost.reactInstanceManager.devSupportManager.sourceUrl)
       .buildUpon()
-      .scheme("http")
       .path("hot")
       .clearQuery()
       .build()

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/errors/DevLauncherUncaughtExceptionHandler.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/errors/DevLauncherUncaughtExceptionHandler.kt
@@ -122,6 +122,8 @@ class DevLauncherUncaughtExceptionHandler(
   }
 
   private fun getWebSocketUrl(): Uri {
+    // URL structure replicates
+    // https://github.com/facebook/react-native/blob/0.69-stable/Libraries/Utilities/HMRClient.js#L164
     return Uri
       .parse(controller.appHost.reactInstanceManager.devSupportManager.sourceUrl)
       .buildUpon()

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/logs/DevLauncherRemoteLog.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/logs/DevLauncherRemoteLog.kt
@@ -1,39 +1,25 @@
 package expo.modules.devlauncher.logs
 
-import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import com.google.gson.annotations.Expose
 
-internal interface DevLauncherRemoteLogBody {
-  val message: String
-  val stack: String?
-
-  override fun toString(): String
-}
-
-internal class DevLauncherSimpleRemoteLogBody(override val message: String) : DevLauncherRemoteLogBody {
-  override val stack: String? = null
-
-  override fun toString(): String = message
-}
-
-internal class DevLauncherExceptionRemoteLogBody(exception: Throwable) : DevLauncherRemoteLogBody {
-  override val message: String = exception.toString()
-  override val stack: String = exception.stackTraceToRemoteLogString()
-
-  override fun toString(): String = Gson().toJson(this)
-}
-
 @Suppress("UNUSED")
 internal data class DevLauncherRemoteLog(
-  val logBody: DevLauncherRemoteLogBody,
-  @Expose val level: String = "error"
+  val logBody: String,
+  @Expose val level: String = "error",
+  @Expose val mode: String = "BRIDGE"
 ) {
-  @Expose
-  val includesStack = logBody.stack !== null
+  constructor(
+    throwable: Throwable,
+    level: String = "error",
+    mode: String = "BRIDGE"
+  ) : this(throwable.toRemoteLogString(), level, mode)
 
   @Expose
-  private val body = logBody.toString()
+  private val data = arrayOf(logBody)
+
+  @Expose
+  private val type = "log"
 
   fun toJson(): String {
     return GsonBuilder()
@@ -43,14 +29,15 @@ internal data class DevLauncherRemoteLog(
   }
 }
 
-internal fun Throwable.stackTraceToRemoteLogString(): String {
-  val baseTrace = stackTrace.joinToString(separator = "\n") {
+internal fun Throwable.toRemoteLogString(): String {
+  val separator = "\n  "
+  val baseTrace = stackTrace.joinToString(separator) {
     it.toString()
   }
 
   cause?.let {
-    return baseTrace + "\nCaused By ${it.stackTraceToRemoteLogString()}"
+    return baseTrace + "\nCaused by ${it.toRemoteLogString()}"
   }
 
-  return baseTrace
+  return "$this$separator$baseTrace"
 }

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/logs/DevLauncherRemoteLog.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/logs/DevLauncherRemoteLog.kt
@@ -5,22 +5,16 @@ import com.google.gson.annotations.Expose
 
 @Suppress("UNUSED")
 internal data class DevLauncherRemoteLog(
-  val logBody: String,
+  val messages: List<String>,
   @Expose val level: String = "error",
   @Expose val mode: String = "BRIDGE"
 ) {
-  constructor(
-    throwable: Throwable,
-    level: String = "error",
-    mode: String = "BRIDGE"
-  ) : this(throwable.toRemoteLogString(), level, mode)
-
   /**
-   * `data` is an array whose members are simply concatenated before printing, so we use a trivial
-   * array of just a single string (which may span multiple lines).
+   * `data` is an array whose members are simply concatenated with a space before printing to the
+   * console, so we join messages with a newline and send an array consisting of just a single item.
    */
   @Expose
-  private val data = arrayOf(logBody)
+  private val data = arrayOf(messages.joinToString("\n"))
 
   @Expose
   private val type = "log"
@@ -31,18 +25,4 @@ internal data class DevLauncherRemoteLog(
       .create()
       .toJson(this)
   }
-}
-
-internal fun Throwable.toRemoteLogString(): String {
-  val separator = "\n  "
-  val baseTrace = stackTrace.joinToString(separator) {
-    it.toString()
-  }
-  val remoteLogString = "$this$separator$baseTrace"
-
-  cause?.let {
-    return "$remoteLogString\nCaused by ${it.toRemoteLogString()}"
-  }
-
-  return remoteLogString
 }

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/logs/DevLauncherRemoteLog.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/logs/DevLauncherRemoteLog.kt
@@ -15,6 +15,10 @@ internal data class DevLauncherRemoteLog(
     mode: String = "BRIDGE"
   ) : this(throwable.toRemoteLogString(), level, mode)
 
+  /**
+   * `data` is an array whose members are simply concatenated before printing, so we use a trivial
+   * array of just a single string (which may span multiple lines).
+   */
   @Expose
   private val data = arrayOf(logBody)
 
@@ -34,10 +38,11 @@ internal fun Throwable.toRemoteLogString(): String {
   val baseTrace = stackTrace.joinToString(separator) {
     it.toString()
   }
+  val remoteLogString = "$this$separator$baseTrace"
 
   cause?.let {
-    return baseTrace + "\nCaused by ${it.toRemoteLogString()}"
+    return "$remoteLogString\nCaused by ${it.toRemoteLogString()}"
   }
 
-  return "$this$separator$baseTrace"
+  return remoteLogString
 }

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/logs/DevLauncherRemoteLog.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/logs/DevLauncherRemoteLog.kt
@@ -3,6 +3,10 @@ package expo.modules.devlauncher.logs
 import com.google.gson.GsonBuilder
 import com.google.gson.annotations.Expose
 
+/**
+ * object format comes from
+ * https://github.com/facebook/react-native/blob/0.69-stable/Libraries/Utilities/HMRClient.js#L119-L134
+ */
 @Suppress("UNUSED")
 internal data class DevLauncherRemoteLog(
   val messages: List<String>,

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/logs/DevLauncherRemoteLogManager.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/logs/DevLauncherRemoteLogManager.kt
@@ -1,35 +1,84 @@
 package expo.modules.devlauncher.logs
 
 import android.net.Uri
+import android.util.Log
+import expo.modules.devlauncher.koin.DevLauncherKoinContext
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
 import okhttp3.WebSocket
 import okhttp3.WebSocketListener
 
-class DevLauncherRemoteLogManager(private val httpClient: OkHttpClient, private val url: Uri) : WebSocketListener() {
+class DevLauncherRemoteLogManager private constructor(private val httpClient: OkHttpClient, private val url: Uri) : WebSocketListener() {
   private val batch: MutableList<DevLauncherRemoteLog> = mutableListOf()
+  private var ws: WebSocket? = null
+  private var isOpen = false
 
-  fun deferError(throwable: Throwable) {
+  @Synchronized
+  fun sendError(throwable: Throwable) {
     batch.add(DevLauncherRemoteLog(throwable))
-  }
-
-  fun deferError(message: String) {
-    batch.add(DevLauncherRemoteLog(message))
-  }
-
-  fun sendViaWebSocket() {
-    val request = Request.Builder().url(url.toString()).build()
-    httpClient.newWebSocket(request, this)
-
-    httpClient.dispatcher().executorService().shutdown()
-  }
-
-  override fun onOpen(webSocket: WebSocket, response: Response) {
-    batch.forEach {
-      webSocket.send(it.toJson())
+    if (isOpen) {
+      sendMessages(ws)
+    } else {
+      openWebSocket()
     }
-    webSocket.close(1000, null)
-    batch.clear()
+  }
+
+  @Synchronized
+  fun sendError(message: String) {
+    batch.add(DevLauncherRemoteLog(message))
+    if (isOpen) {
+      sendMessages(ws)
+    } else {
+      openWebSocket()
+    }
+  }
+
+  @Synchronized
+  fun openWebSocket() {
+    val request = Request.Builder().url(url.toString()).build()
+    ws = httpClient.newWebSocket(request, this)
+  }
+
+  @Synchronized
+  fun closeWebSocket() {
+    isOpen = false
+    ws?.close(1000, null)
+  }
+
+  @Synchronized
+  fun sendMessages(webSocket: WebSocket?) {
+    webSocket?.let { socket ->
+      batch.forEach { log ->
+        socket.send(log.toJson())
+      }
+      batch.clear()
+    }
+  }
+
+  @Synchronized
+  override fun onOpen(webSocket: WebSocket, response: Response) {
+    sendMessages(webSocket)
+    isOpen = true
+  }
+
+  companion object {
+    private val map: MutableMap<String, DevLauncherRemoteLogManager> = mutableMapOf()
+
+    fun forUrl(url: Uri): DevLauncherRemoteLogManager {
+      val key = url.toString()
+      if (!map.containsKey(key)) {
+        map[key] = DevLauncherRemoteLogManager(DevLauncherKoinContext.app.koin.get(), url)
+      }
+      return map[key]!!
+    }
+
+    fun closeAll() {
+      map.forEach {
+        it.value.closeWebSocket()
+      }
+      val httpClient = DevLauncherKoinContext.app.koin.get<OkHttpClient>()
+      httpClient.dispatcher().executorService().shutdown()
+    }
   }
 }

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/logs/DevLauncherRemoteLogManager.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/logs/DevLauncherRemoteLogManager.kt
@@ -1,84 +1,45 @@
 package expo.modules.devlauncher.logs
 
 import android.net.Uri
-import android.util.Log
-import expo.modules.devlauncher.koin.DevLauncherKoinContext
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
 import okhttp3.WebSocket
 import okhttp3.WebSocketListener
 
-class DevLauncherRemoteLogManager private constructor(private val httpClient: OkHttpClient, private val url: Uri) : WebSocketListener() {
-  private val batch: MutableList<DevLauncherRemoteLog> = mutableListOf()
-  private var ws: WebSocket? = null
-  private var isOpen = false
+class DevLauncherRemoteLogManager(private val httpClient: OkHttpClient, private val url: Uri) : WebSocketListener() {
+  private val batch: MutableList<String> = mutableListOf()
 
-  @Synchronized
-  fun sendError(throwable: Throwable) {
-    batch.add(DevLauncherRemoteLog(throwable))
-    if (isOpen) {
-      sendMessages(ws)
-    } else {
-      openWebSocket()
-    }
+  fun deferError(throwable: Throwable) {
+    batch.add(throwable.toRemoteLogString())
   }
 
-  @Synchronized
-  fun sendError(message: String) {
-    batch.add(DevLauncherRemoteLog(message))
-    if (isOpen) {
-      sendMessages(ws)
-    } else {
-      openWebSocket()
-    }
+  fun deferError(message: String) {
+    batch.add(message)
   }
 
-  @Synchronized
-  fun openWebSocket() {
+  fun sendViaWebSocket() {
     val request = Request.Builder().url(url.toString()).build()
-    ws = httpClient.newWebSocket(request, this)
+    httpClient.newWebSocket(request, this)
   }
 
-  @Synchronized
-  fun closeWebSocket() {
-    isOpen = false
-    ws?.close(1000, null)
-  }
-
-  @Synchronized
-  fun sendMessages(webSocket: WebSocket?) {
-    webSocket?.let { socket ->
-      batch.forEach { log ->
-        socket.send(log.toJson())
-      }
-      batch.clear()
-    }
-  }
-
-  @Synchronized
   override fun onOpen(webSocket: WebSocket, response: Response) {
-    sendMessages(webSocket)
-    isOpen = true
+    webSocket.send(DevLauncherRemoteLog(batch).toJson())
+    webSocket.close(1000, null)
+    batch.clear()
+  }
+}
+
+internal fun Throwable.toRemoteLogString(): String {
+  val separator = "\n  "
+  val baseTrace = stackTrace.joinToString(separator) {
+    it.toString()
+  }
+  val remoteLogString = "$this$separator$baseTrace"
+
+  cause?.let {
+    return "$remoteLogString\nCaused by ${it.toRemoteLogString()}"
   }
 
-  companion object {
-    private val map: MutableMap<String, DevLauncherRemoteLogManager> = mutableMapOf()
-
-    fun forUrl(url: Uri): DevLauncherRemoteLogManager {
-      val key = url.toString()
-      if (!map.containsKey(key)) {
-        map[key] = DevLauncherRemoteLogManager(DevLauncherKoinContext.app.koin.get(), url)
-      }
-      return map[key]!!
-    }
-
-    fun closeAll() {
-      map.forEach {
-        it.value.closeWebSocket()
-      }
-      val httpClient = DevLauncherKoinContext.app.koin.get<OkHttpClient>()
-      httpClient.dispatcher().executorService().shutdown()
-    }
-  }
+  return remoteLogString
 }

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/logs/DevLauncherRemoteLogManager.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/logs/DevLauncherRemoteLogManager.kt
@@ -1,49 +1,35 @@
 package expo.modules.devlauncher.logs
 
 import android.net.Uri
-import android.os.Build
-import expo.modules.devlauncher.helpers.await
-import expo.modules.devlauncher.helpers.post
-import kotlinx.coroutines.runBlocking
-import okhttp3.MediaType
 import okhttp3.OkHttpClient
-import okhttp3.RequestBody
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
 
-class DevLauncherRemoteLogManager(private val httpClient: OkHttpClient, private val url: Uri) {
+class DevLauncherRemoteLogManager(private val httpClient: OkHttpClient, private val url: Uri) : WebSocketListener() {
   private val batch: MutableList<DevLauncherRemoteLog> = mutableListOf()
 
   fun deferError(throwable: Throwable) {
-    addToBatch(
-      DevLauncherRemoteLog(
-        DevLauncherExceptionRemoteLogBody(throwable)
-      )
-    )
+    batch.add(DevLauncherRemoteLog(throwable))
   }
 
   fun deferError(message: String) {
-    addToBatch(
-      DevLauncherRemoteLog(
-        DevLauncherSimpleRemoteLogBody(message)
-      )
-    )
+    batch.add(DevLauncherRemoteLog(message))
   }
 
-  private fun addToBatch(log: DevLauncherRemoteLog) {
-    batch.add(log)
+  fun sendViaWebSocket() {
+    val request = Request.Builder().url(url.toString()).build()
+    httpClient.newWebSocket(request, this)
+
+    httpClient.dispatcher().executorService().shutdown()
   }
 
-  fun sendSync() = runBlocking {
-    val content = batch.joinToString(separator = ",") { it.toJson() }
-    val requestBody = RequestBody.create(MediaType.get("application/json"), "[$content]")
-
-    val postRequest = post(
-      url,
-      requestBody,
-      "Device-Id" to Build.ID,
-      "Device-Name" to Build.DISPLAY
-    )
-    postRequest.await(httpClient)
-
+  override fun onOpen(webSocket: WebSocket, response: Response) {
+    batch.forEach {
+      webSocket.send(it.toJson())
+    }
+    webSocket.close(1000, null)
     batch.clear()
   }
 }

--- a/packages/expo-dev-launcher/ios/Errors/EXDevLauncherUncaughtExceptionHandler.swift
+++ b/packages/expo-dev-launcher/ios/Errors/EXDevLauncherUncaughtExceptionHandler.swift
@@ -40,7 +40,7 @@ public class EXDevLauncherUncaughtExceptionHandler: NSObject {
   static func tryToSendExceptionToBundler(_ exception: NSException) {
     let controller = EXDevLauncherController.sharedInstance()
     if (controller.isAppRunning()) {
-      guard let url = getLogsUrl(controller) else {
+      guard let url = getWebSocketUrl(controller) else {
         return
       }
       
@@ -50,18 +50,19 @@ public class EXDevLauncherUncaughtExceptionHandler: NSObject {
       logsManager.sendSync()
     }
   }
-  
-  static func getLogsUrl(_ controller: EXDevLauncherController) -> URL? {
-    let logsUrlFromManifest = controller.appManifest()?.logUrl()
-    if (logsUrlFromManifest != nil) {
-      return URL.init(string: logsUrlFromManifest!)
-    }
-    
+
+  static func getWebSocketUrl(_ controller: EXDevLauncherController) -> URL? {
     guard let appUrl = controller.appBridge?.bundleURL else {
       return nil
     }
-    
-    return URL.init(string: "logs", relativeTo: appUrl)
+    guard let socketUrl = URL.init(string: "hot", relativeTo: appUrl) else {
+      return nil
+    }
+    guard var components = URLComponents(url: socketUrl, resolvingAgainstBaseURL: true) else {
+      return nil
+    }
+    components.scheme = "ws"
+    return components.url
   }
   
   static func tryToSaveException(_ exception: NSException) {

--- a/packages/expo-dev-launcher/ios/Errors/EXDevLauncherUncaughtExceptionHandler.swift
+++ b/packages/expo-dev-launcher/ios/Errors/EXDevLauncherUncaughtExceptionHandler.swift
@@ -52,6 +52,9 @@ public class EXDevLauncherUncaughtExceptionHandler: NSObject {
   }
 
   static func getWebSocketUrl(_ controller: EXDevLauncherController) -> URL? {
+    // URL structure replicates
+    // https://github.com/facebook/react-native/blob/0.69-stable/Libraries/Utilities/HMRClient.js#L164
+    // but URLSessionWebSocketTask will crash if the scheme is not `ws` or `wss`
     guard let appUrl = controller.appBridge?.bundleURL else {
       return nil
     }

--- a/packages/expo-dev-launcher/ios/Logs/EXDevLauncherRemoteLogsManager.swift
+++ b/packages/expo-dev-launcher/ios/Logs/EXDevLauncherRemoteLogsManager.swift
@@ -1,52 +1,52 @@
 import Foundation
 
 class EXDevLauncherRemoteLogsManager {
-  private var batch: [[String: Any]] = []
+  private var batch: [String] = []
   private let url: URL
-  
+
   init(withUrl url: URL) {
     self.url = url
   }
-  
+
   func deferError(exception: NSException) {
-    batch.append([
-      "level": "error",
-      "body": [
-        "message": exception.description,
-        "stack": exception.callStackSymbols.joined(separator: "\n")
-      ],
-      "includesStack": true
-    ])
+    batch.append("\(exception.name.rawValue): \(exception.reason ?? exception.description)")
+    batch.append("  \(exception.callStackSymbols.joined(separator: "\n  "))")
   }
-  
+
   func deferError(message: String) {
-    batch.append([
-      "level": "error",
-      "body": message,
-      "includesStack": false
-    ])
+    batch.append(message)
   }
-  
+
   func sendSync() {
-    guard let data = try? JSONSerialization.data(withJSONObject: batch, options: []) else {
+    let messageJson = [
+      "type": "log",
+      "level": "error",
+      "mode": "BRIDGE",
+      "data": [batch.joined(separator: "\n")]
+    ] as [String : Any]
+    guard let data = try? JSONSerialization.data(withJSONObject: messageJson, options: []) else {
       batch.removeAll()
       return
     }
-    
+
     batch.removeAll()
-    
-    var request = URLRequest.init(url: self.url)
-    request.httpMethod = "POST"
-    request.httpBody = data
-    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-    request.setValue(UIDevice.current.identifierForVendor?.uuidString ?? UIDevice.current.name , forHTTPHeaderField: "Device-Id")
-    request.setValue(UIDevice.current.name, forHTTPHeaderField: "Device-Name")
-    
-    let group = DispatchGroup()
-    group.enter()
-    URLSession.shared.dataTask(with: request) { data, response, error in
-      group.leave()
-    }.resume()
-    group.wait(timeout: DispatchTime.now() + .seconds(2))
+
+    if #available(iOS 13.0, *) {
+      let group = DispatchGroup()
+      group.enter()
+
+      let task = URLSession.shared.webSocketTask(with: self.url)
+      task.resume()
+
+      guard let dataString = String(data: data, encoding: .utf8) else {
+        group.leave()
+        return
+      }
+      let message = URLSessionWebSocketTask.Message.string(dataString)
+      task.send(message) { error in
+        group.leave()
+      }
+      _ = group.wait(timeout: DispatchTime.now() + .seconds(2))
+    }
   }
 }

--- a/packages/expo-dev-launcher/ios/Logs/EXDevLauncherRemoteLogsManager.swift
+++ b/packages/expo-dev-launcher/ios/Logs/EXDevLauncherRemoteLogsManager.swift
@@ -28,7 +28,7 @@ class EXDevLauncherRemoteLogsManager {
       // the console, so we join messages with a newline and send an array consisting of just a
       // single item.
       "data": [batch.joined(separator: "\n")]
-    ] as [String : Any]
+    ] as [String: Any]
     guard let data = try? JSONSerialization.data(withJSONObject: messageJson, options: []) else {
       batch.removeAll()
       return
@@ -48,7 +48,7 @@ class EXDevLauncherRemoteLogsManager {
         return
       }
       let message = URLSessionWebSocketTask.Message.string(dataString)
-      task.send(message) { error in
+      task.send(message) { _ in
         group.leave()
       }
       _ = group.wait(timeout: DispatchTime.now() + .seconds(2))

--- a/packages/expo-dev-launcher/ios/Logs/EXDevLauncherRemoteLogsManager.swift
+++ b/packages/expo-dev-launcher/ios/Logs/EXDevLauncherRemoteLogsManager.swift
@@ -18,10 +18,15 @@ class EXDevLauncherRemoteLogsManager {
   }
 
   func sendSync() {
+    // message format comes from
+    // https://github.com/facebook/react-native/blob/0.69-stable/Libraries/Utilities/HMRClient.js#L119-L134
     let messageJson = [
       "type": "log",
       "level": "error",
       "mode": "BRIDGE",
+      // `data` is an array whose members are simply concatenated with a space before printing to
+      // the console, so we join messages with a newline and send an array consisting of just a
+      // single item.
       "data": [batch.joined(separator: "\n")]
     ] as [String : Any]
     guard let data = try? JSONSerialization.data(withJSONObject: messageJson, options: []) else {


### PR DESCRIPTION
# Why

resolves ENG-6066

# How

- Send logs to HMRClient websocket (replicating https://github.com/facebook/react-native/blob/0.69-stable/Libraries/Utilities/HMRClient.js) rather than expo-cli logUrl.
- Change object format to match what the websocket expects. I switched to sending just a single concatenated message per `sendSync` to make it simpler and also more predictable when multiple exceptions are involved.
- On Android there doesn't seem to be a very good built in way to make the websocket call synchronous. That said, I had no issues when testing (the 2 second timeout before calling the default exception handler seems to be plenty).
- The iOS implementation works on iOS 13+ only. I think this is ok since we are dropping support for iOS 12 with SDK 47 anyway. (And this won't cause issues for iOS 12 users, just the logging won't work.)

# Test Plan

I wasn't sure exactly how this was tested initially, but I tested by calling a method exported to JS that would call `dispatch_async`/`AsyncTask.execute` and throw multiple exceptions on a background thread. Confirmed that before this change, crash logs showed up in `expo start` and after this change, the following shows up in `npx expo start`:
<img width="776" alt="Screen Shot 2022-08-18 at 6 10 16 PM" src="https://user-images.githubusercontent.com/19958240/186249641-fb1b846c-c3a9-4755-a906-43dc7f4cbf3d.png">
<img width="709" alt="Screen Shot 2022-08-23 at 12 04 27 PM" src="https://user-images.githubusercontent.com/19958240/186249648-65545552-b0db-4f48-825f-49cae4e22bcb.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
