### PR TITLE
[home] make outdated classic update warning more informative

### DIFF
--- a/dev-home-config.json
+++ b/dev-home-config.json
@@ -1,3 +1,3 @@
 {
-  "url": "exp://exp.host/@expo-home-dev/expo-home-dev-f59fd65601328e5ec0479a9e4ccbef640b6c9d87"
+  "url": "exp://exp.host/@expo-home-dev/expo-home-dev-c377bb1ea7409c8e73221b3c7c34235c6b9e3a82"
 }

--- a/home/screens/ProjectScreen/LegacyLaunchSection.tsx
+++ b/home/screens/ProjectScreen/LegacyLaunchSection.tsx
@@ -1,5 +1,5 @@
 import { iconSize, OpenInternalIcon } from '@expo/styleguide-native';
-import { View, Text, Spacer, Row, useExpoTheme } from 'expo-dev-client-components';
+import { View, Text, Row, useExpoTheme } from 'expo-dev-client-components';
 import * as WebBrowser from 'expo-web-browser';
 import * as React from 'react';
 import { Linking, Platform } from 'react-native';
@@ -35,8 +35,7 @@ export function LegacyLaunchSection({ app }: { app: ProjectPageApp }) {
   if (doesLatestLegacyPublishHaveRuntimeVersion) {
     warning = (
       <WarningBox
-        title="Incompatible update"
-        message="The latest update uses a runtime version that is not compatible with Expo Go. To continue, create a custom dev client."
+        message="The latest classic update on the 'default' release channel uses a runtime version that is not compatible with Expo Go. To continue, create a development build."
         showLearnMore
         onLearnMorePress={() => {
           WebBrowser.openBrowserAsync('https://docs.expo.dev/clients/getting-started/');
@@ -46,8 +45,7 @@ export function LegacyLaunchSection({ app }: { app: ProjectPageApp }) {
   } else if (isLatestLegacyPublishDeprecated) {
     warning = (
       <WarningBox
-        title="Unsupported SDK version"
-        message={`This project's SDK version (${legacyUpdatesSDKMajorVersion}) is no longer supported.`}
+        message={`The latest classic update on the 'default' release channel uses SDK (${legacyUpdatesSDKMajorVersion}), which is no longer supported.`}
       />
     );
   }
@@ -55,31 +53,28 @@ export function LegacyLaunchSection({ app }: { app: ProjectPageApp }) {
   const theme = useExpoTheme();
 
   return (
-    <>
+    <View>
+      <SectionHeader header="Classic Release Channels" style={{ paddingTop: 0 }} />
       {warning ?? (
-        <View>
-          <SectionHeader header="Classic Release Channels" style={{ paddingTop: 0 }} />
-          <View bg="default" overflow="hidden" rounded="large" border="default">
-            <TouchableOpacity
-              onPress={() => {
-                Linking.openURL(UrlUtils.normalizeUrl(app.fullName));
-              }}>
-              <Row padding="medium" justify="between" align="center" bg="default">
-                <Text size="medium" type="InterRegular">
-                  default
-                </Text>
-                <OpenInternalIcon color={theme.icon.default} size={iconSize.tiny} />
-              </Row>
-            </TouchableOpacity>
-          </View>
-          <View padding="medium">
-            <Text size="small" color="secondary" type="InterRegular">
-              {moreLegacyBranchesText}
-            </Text>
-          </View>
+        <View bg="default" overflow="hidden" rounded="large" border="default">
+          <TouchableOpacity
+            onPress={() => {
+              Linking.openURL(UrlUtils.normalizeUrl(app.fullName));
+            }}>
+            <Row padding="medium" justify="between" align="center" bg="default">
+              <Text size="medium" type="InterRegular">
+                default
+              </Text>
+              <OpenInternalIcon color={theme.icon.default} size={iconSize.tiny} />
+            </Row>
+          </TouchableOpacity>
         </View>
       )}
-      <Spacer.Vertical size="medium" />
-    </>
+      <View padding="medium">
+        <Text size="small" color="secondary" type="InterRegular">
+          {moreLegacyBranchesText}
+        </Text>
+      </View>
+    </View>
   );
 }

--- a/home/screens/ProjectScreen/LegacyLaunchSection.tsx
+++ b/home/screens/ProjectScreen/LegacyLaunchSection.tsx
@@ -54,7 +54,7 @@ export function LegacyLaunchSection({ app }: { app: ProjectPageApp }) {
 
   return (
     <View>
-      <SectionHeader header="Classic Release Channels" style={{ paddingTop: 0 }} />
+      <SectionHeader header="Classic release channels" style={{ paddingTop: 0 }} />
       {warning ?? (
         <View bg="default" overflow="hidden" rounded="large" border="default">
           <TouchableOpacity

--- a/home/screens/ProjectScreen/ProjectView.tsx
+++ b/home/screens/ProjectScreen/ProjectView.tsx
@@ -55,10 +55,24 @@ export function ProjectView({ loading, error, data, navigation }: Props) {
       <ScrollView style={{ flex: 1 }}>
         <ProjectHeader app={app} />
         <View padding="medium">
-          {appHasLegacyUpdate(app) && <LegacyLaunchSection app={app} />}
-          {appHasEASUpdates(app) && <EASUpdateLaunchSection app={app} />}
-          {!appHasLegacyUpdate(app) && !appHasEASUpdates(app) && <EmptySection />}
-          <Spacer.Vertical size="xl" />
+          {appHasEASUpdates(app) && (
+            <>
+              <EASUpdateLaunchSection app={app} />
+              <Spacer.Vertical size="xl" />
+            </>
+          )}
+          {appHasLegacyUpdate(app) && (
+            <>
+              <LegacyLaunchSection app={app} />
+              <Spacer.Vertical size="xl" />
+            </>
+          )}
+          {!appHasLegacyUpdate(app) && !appHasEASUpdates(app) && (
+            <>
+              <EmptySection />
+              <Spacer.Vertical size="xl" />
+            </>
+          )}
           <View bg="default" border="default" overflow="hidden" rounded="large">
             <ConstantItem title="Owner" value={app.username} />
             {app.sdkVersion !== '0.0.0' && (

--- a/home/screens/ProjectScreen/WarningBox.tsx
+++ b/home/screens/ProjectScreen/WarningBox.tsx
@@ -1,18 +1,13 @@
 import { spacing } from '@expo/styleguide-native';
-import { useExpoTheme, Text, Spacer, Row, View } from 'expo-dev-client-components';
+import { useExpoTheme, Text, Spacer, View } from 'expo-dev-client-components';
 import * as React from 'react';
-import { Platform } from 'react-native';
 import { TouchableOpacity } from 'react-native-gesture-handler';
 
-import { Ionicons } from '../../components/Icons';
-
 export function WarningBox({
-  title,
   message,
   showLearnMore,
   onLearnMorePress,
 }: {
-  title: string;
   message: string;
   showLearnMore?: boolean;
   onLearnMorePress?: () => void;
@@ -37,23 +32,8 @@ export function WarningBox({
     </>
   ) : null;
   return (
-    <View bg="warning" border="warning" rounded="medium" padding="medium">
-      <Row align="center">
-        <Ionicons
-          name={Platform.select({ ios: 'ios-warning', default: 'md-warning' })}
-          size={18}
-          lightColor={theme.text.warning}
-          darkColor={theme.text.warning}
-          style={{
-            marginRight: 4,
-          }}
-        />
-        <Text color="warning" type="InterSemiBold">
-          {title}
-        </Text>
-      </Row>
-      <Spacer.Vertical size="small" />
-      <Text color="warning" type="InterRegular">
+    <View bg="warning" border="warning" rounded="large" padding="medium">
+      <Text color="warning" type="InterRegular" size="medium">
         {message}
       </Text>
       {learnMoreButton}


### PR DESCRIPTION
# Why

When looking at a project page screen that has outdated classic updates, it shows a warning at the top of the page saying that the project is out of date, which isn't necessarily true if you've started using EAS Update instead of classic.

# How

- I relocated the classic updates section to under the EAS Branches section (if it exists)
- I factored out the header for 'Classic Release Channels' always be present even if the warning is being shown
- I removed the title section of the `WarningBox` component to reduce redundancy and visual importance
- I updated the warning messages to be clearer about the error relating to the classic update on the `default` channel, not your EAS Updates or updates on any other classic release channel. 

# Test Plan

'Classic Release Channels' under 'Branches':

![Screen Shot 2022-08-23 at 16 31 05](https://user-images.githubusercontent.com/12488826/186261933-f10c8824-e028-438e-8b1b-524ff633b19a.png)

Outdated SDK Version with EAS Branches:

![Screen Shot 2022-08-23 at 16 35 14](https://user-images.githubusercontent.com/12488826/186261934-5a4894b7-b6f2-4128-a6dd-9de42bf14ab8.png)

Incompatible runtime version:

![Screen Shot 2022-08-23 at 16 34 52](https://user-images.githubusercontent.com/12488826/186261935-c9bee02f-8250-4745-8050-71a9ccf57cb6.png)


Outdated SDK Version without EAS Branches:

![Screen Shot 2022-08-23 at 16 45 55](https://user-images.githubusercontent.com/12488826/186262172-eff397c5-92a3-4034-b43f-2a2645d2b647.png)

