### PR TITLE
[cli] capture analytics event when user opens development build from interstitial page

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Update the README file. ([#18663](https://github.com/expo/expo/pull/18663) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix `prebuild` e2e tests. ([#18612](https://github.com/expo/expo/pull/18612) by [@EvanBacon](https://github.com/EvanBacon))
 - Add warning about malformed project when running prebuild in non-interactive mode. ([#18436](https://github.com/expo/expo/pull/18436) by [@wkozyra95](https://github.com/wkozyra95))
+- [Interstitial page] Capture missing analytics event when user opens development build. ([#18792](https://github.com/expo/expo/pull/18792) by [@esamelson](https://github.com/esamelson))
 
 ## 0.2.6 — 2022-07-25
 

--- a/packages/@expo/cli/src/start/server/middleware/RuntimeRedirectMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/RuntimeRedirectMiddleware.ts
@@ -17,14 +17,16 @@ const debug = require('debug')(
 /** Runtime to target: expo = Expo Go, custom = Dev Client. */
 type RuntimeTarget = 'expo' | 'custom';
 
+export type DeepLinkHandler = (props: {
+  runtime: RuntimeTarget;
+  platform: RuntimePlatform;
+}) => void | Promise<void>;
+
 export class RuntimeRedirectMiddleware extends ExpoMiddleware {
   constructor(
     protected projectRoot: string,
     protected options: {
-      onDeepLink: (props: {
-        runtime: RuntimeTarget;
-        platform: RuntimePlatform;
-      }) => void | Promise<void>;
+      onDeepLink: DeepLinkHandler;
       getLocation: (props: { runtime: RuntimeTarget }) => string | null | undefined;
     }
   ) {


### PR DESCRIPTION
# Why

first step of ENG-6120

restore missing functionality from https://github.com/expo/expo-cli/commit/ef40347a18a4e0ccdb35d4486a9615c0f5dcb9ec to new CLI

# How

Add log for `started` event; ignored the `ready` event for now since we don't send it anywhere in the new CLI currently

# Test Plan

Added tests, also tested manually by adding logging to `logEventAsync` and comparing the output to the old CLI
- event logged when I press "Development Build" on the interstitial page
- event not logged when I press "Expo Go"

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
