### PR TITLE
[android][intent-launcher] add support for packageName without className option

### DIFF
--- a/packages/expo-intent-launcher/CHANGELOG.md
+++ b/packages/expo-intent-launcher/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- The `packageName` option can now be used without specifying the `className` option. When the `className` option isn't provided, `packageName` will use [`Intent.setPackage`](https://developer.android.com/reference/android/content/Intent#setPackage(java.lang.String)) to limit the components an Intent can resolve to.
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-intent-launcher/android/src/main/java/expo/modules/intentlauncher/IntentLauncherModule.kt
+++ b/packages/expo-intent-launcher/android/src/main/java/expo/modules/intentlauncher/IntentLauncherModule.kt
@@ -67,6 +67,8 @@ class IntentLauncherModule(
       intent.component =
         if (params.containsKey(ATTR_PACKAGE_NAME)) ComponentName(params.getString(ATTR_PACKAGE_NAME), params.getString(ATTR_CLASS_NAME))
         else ComponentName(context, params.getString(ATTR_CLASS_NAME))
+    } else if (params.containsKey(ATTR_PACKAGE_NAME)) {
+      intent.setPackage(params.getString(ATTR_PACKAGE_NAME))
     }
 
     // `setData` and `setType` are exclusive, so we need to use `setDateAndType` in that case.


### PR DESCRIPTION
# Why

For some generic intents like `ACTION_SEND` it can be handy to be able to specify which package you'd like to handle the intent without having to specify the `className` option as well. Especially when the intent is supposed to be handled by a different package than your own.

# How

Added an else-case that uses [`Intent.setPackage`](https://developer.android.com/reference/android/content/Intent#setPackage(java.lang.String)) when `packageName` option is present but `className` isn't.

# Test Plan

I had some trouble creating a reproducible test case in the `bare-expo` app when run with the simulator that gets created through `yarn android` as the only app it has to handle for example the SEND intent is its SMS app. I am unsure how best to provide a test plan for this as there isn't anything to go from for the existing `packageName` + `className` option combo. Any tips would be appreciated.

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
