### PR TITLE
[android][intent-chooser] add options to trigger the intent chooser

### DIFF
--- a/apps/native-component-list/src/screens/IntentLauncherScreen.tsx
+++ b/apps/native-component-list/src/screens/IntentLauncherScreen.tsx
@@ -66,6 +66,19 @@ export default class IntentLauncherScreen extends React.Component {
             data: 'package:package.name.that.doesnt.exist',
           }
         )}
+
+        {this.renderSettingsLink(
+          'Wireless Settings with Chooser',
+          ActivityAction.WIRELESS_SETTINGS,
+          {
+            chooser: {
+              title: 'Open Wireless Settings',
+              extra: {
+                'android.intent.extra.AUTO_LAUNCH_SINGLE_CHOICE': false,
+              },
+            },
+          }
+        )}
       </ScrollView>
     );
   }

--- a/packages/expo-intent-launcher/CHANGELOG.md
+++ b/packages/expo-intent-launcher/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add a `chooser` dictionary option to wrap the Intent inside an `ACTION_CHOOSER` intent. This forces Android to display the app choice dialog even when the user already has a default app selected to handle an Intent. The `chooser` option supports `title`, `flags` and `extra` config.
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-intent-launcher/android/src/main/java/expo/modules/intentlauncher/IntentLauncherModule.kt
+++ b/packages/expo-intent-launcher/android/src/main/java/expo/modules/intentlauncher/IntentLauncherModule.kt
@@ -31,6 +31,8 @@ private const val ATTR_DATA = "data"
 private const val ATTR_FLAGS = "flags"
 private const val ATTR_PACKAGE_NAME = "packageName"
 private const val ATTR_CLASS_NAME = "className"
+private const val ATTR_CHOOSER = "chooser"
+private const val ATTR_CHOOSER_TITLE = "title"
 
 class IntentLauncherModule(
   context: Context,
@@ -61,7 +63,7 @@ class IntentLauncherModule(
       return
     }
 
-    val intent = Intent(activityAction)
+    var intent = Intent(activityAction)
 
     if (params.containsKey(ATTR_CLASS_NAME)) {
       intent.component =
@@ -83,6 +85,18 @@ class IntentLauncherModule(
     params.getArguments(ATTR_EXTRA)?.let { intent.putExtras(it.toBundle()) }
     params.getInt(ATTR_FLAGS)?.let { intent.addFlags(it) }
     params.getString(ATTR_CATEGORY)?.let { intent.addCategory(it) }
+
+    if (params.containsKey(ATTR_CHOOSER)) {
+      var chooserParams = params.getArguments(ATTR_CHOOSER)
+
+      if (chooserParams.containsKey(ATTR_CHOOSER_TITLE))
+        intent = Intent.createChooser(intent, chooserParams.getString(ATTR_CHOOSER_TITLE));
+      else
+        intent = Intent.createChooser(intent, "");
+
+      chooserParams.getArguments(ATTR_EXTRA)?.let { intent.putExtras(it.toBundle()) }
+      chooserParams.getInt(ATTR_FLAGS)?.let { intent.addFlags(it) }
+    }
 
     uiManager.registerActivityEventListener(this)
     pendingPromise = promise


### PR DESCRIPTION
Should I include updates to the docs in this PR or as a separate PR? Not sure with the checklist asking for it here and the contributing guidelines mentioning to create a separate PR.

# Why

For some generic intents like ACTION_SEND it can be desired to always ask the user which app should handle the intent and not present the option to "always open with".

# How

By adding a `chooser` option to the intent launcher params. If present, the original intent gets wrapped using [`Intent.createChooser`](https://developer.android.com/reference/android/content/Intent#createChooser(android.content.Intent,%20java.lang.CharSequence)) to force the app choice dialog.

# Test Plan

Added a "Wireless Settings with Chooser" button on the IntentLauncher API demo of bare-expo.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
