### PR TITLE
[docs] Fixed typo in usage example for customisable reCaptcha

### DIFF
--- a/docs/pages/versions/unversioned/sdk/firebase-recaptcha.md
+++ b/docs/pages/versions/unversioned/sdk/firebase-recaptcha.md
@@ -419,7 +419,7 @@ const styles = StyleSheet.create({
 If you want a custom look & feel, then create your own `<Modal>` or display the `<FirebaseRecaptcha>` component inline in your screen. Make sure to reserve enough space for the widget as it can not only display the compact "I'm not a robot" UI but also the **full verification UI requiring users to select images**.
 
 ```tsx
-import { FirebaseRecaptchaVerifier } from 'expo-firebase-recaptcha';
+import { FirebaseRecaptcha, FirebaseRecaptchaVerifier } from 'expo-firebase-recaptcha';
 
 class CustomPhoneAuthScreen extends React.Component {
   state = {
@@ -443,7 +443,7 @@ class CustomPhoneAuthScreen extends React.Component {
 
   render() {
     return (
-      <FirebaseRecaptchaVerifier
+      <FirebaseRecaptcha
         style={...}
         firebaseConfig={...}
 

--- a/docs/pages/versions/v45.0.0/sdk/firebase-recaptcha.md
+++ b/docs/pages/versions/v45.0.0/sdk/firebase-recaptcha.md
@@ -419,7 +419,7 @@ const styles = StyleSheet.create({
 If you want a custom look & feel, then create your own `<Modal>` or display the `<FirebaseRecaptcha>` component inline in your screen. Make sure to reserve enough space for the widget as it can not only display the compact "I'm not a robot" UI but also the **full verification UI requiring users to select images**.
 
 ```tsx
-import { FirebaseRecaptchaVerifier } from 'expo-firebase-recaptcha';
+import { FirebaseRecaptcha, FirebaseRecaptchaVerifier } from 'expo-firebase-recaptcha';
 
 class CustomPhoneAuthScreen extends React.Component {
   state = {
@@ -443,7 +443,7 @@ class CustomPhoneAuthScreen extends React.Component {
 
   render() {
     return (
-      <FirebaseRecaptchaVerifier
+      <FirebaseRecaptcha
         style={...}
         firebaseConfig={...}
 

--- a/docs/pages/versions/v46.0.0/sdk/firebase-recaptcha.md
+++ b/docs/pages/versions/v46.0.0/sdk/firebase-recaptcha.md
@@ -419,7 +419,7 @@ const styles = StyleSheet.create({
 If you want a custom look & feel, then create your own `<Modal>` or display the `<FirebaseRecaptcha>` component inline in your screen. Make sure to reserve enough space for the widget as it can not only display the compact "I'm not a robot" UI but also the **full verification UI requiring users to select images**.
 
 ```tsx
-import { FirebaseRecaptchaVerifier } from 'expo-firebase-recaptcha';
+import { FirebaseRecaptcha, FirebaseRecaptchaVerifier } from 'expo-firebase-recaptcha';
 
 class CustomPhoneAuthScreen extends React.Component {
   state = {
@@ -443,7 +443,7 @@ class CustomPhoneAuthScreen extends React.Component {
 
   render() {
     return (
-      <FirebaseRecaptchaVerifier
+      <FirebaseRecaptcha
         style={...}
         firebaseConfig={...}
 


### PR DESCRIPTION
# Why
This small typo may block progress of people who will try  

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

[Link](https://docs.expo.dev/versions/v45.0.0/sdk/firebase-recaptcha/) to the current version of edited page