### PR TITLE
Fix Missing "leading" slash

### DIFF
--- a/docs/pages/guides/linking.md
+++ b/docs/pages/guides/linking.md
@@ -211,7 +211,7 @@ const redirectUrl = Linking.createURL('path/into/app', {
 This will resolve into the following, depending on the environment:
 
 - _Published app in Expo Go_: `exp://u.expo.dev/[project-id]?channel-name=[channel-name]&runtime-version=[runtime-version]/--/path/into/app?hello=world`
-- _Published app in standalone_: `myapp://path/into/app?hello=world`
+- _Published app in standalone_: `myapp:///path/into/app?hello=world`
 - _Development in Expo Go_: `exp://127.0.0.1:19000/--/path/into/app?hello=world`
 
 > Notice in Expo Go that `/--/` is added to the URL when a path is specified. This indicates to Expo Go that the substring after it corresponds to the deep link path, and is not part of the path to the app itself.


### PR DESCRIPTION
This cost me quite some time to figure this out, I had problems getting my deeplinking to work as everything was fine in Expo Go testing but did not work at all in the standalone app. Via some alert debugging in production I figured out my code was failing at ```Linking.parse(url)``` after reading every piece of documentation and stuff I found online I went and read the source code and noticed differences in the commentblocks for createURL and makeURL

```
makeURL()
 * # Examples
 * - Bare: empty string
 * - Standalone, Custom: `yourscheme:///path`
 * - Web (dev): `https://localhost:19006/path`
 * - Web (prod): `https://myapp.com/path`
 * - Expo Client (dev): `exp://128.0.0.1:19000/--/path`
 * - Expo Client (prod): `exp://exp.host/@yourname/your-app/--/path`
``` 

```
createURL()
* # Examples
 * - Bare: `<scheme>://path` - uses provided scheme or scheme from Expo config `scheme`.
 * - Standalone, Custom: `yourscheme://path`
 * - Web (dev): `https://localhost:19006/path`
 * - Web (prod): `https://myapp.com/path`
 * - Expo Client (dev): `exp://128.0.0.1:19000/--/path`
 * - Expo Client (prod): `exp://exp.host/@yourname/your-app/--/path`
```

in the end this lead me to trying tripple slashes which solved my problem, I really don't know if it was my bad or if there is something wrong with the documentation / function comments but I think you should investigate it

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
