### PR TITLE
[docs] prevent Archive pages from being indexed

### DIFF
--- a/docs/components/DocumentationPage.tsx
+++ b/docs/components/DocumentationPage.tsx
@@ -245,9 +245,10 @@ class DocumentationPageWithApiVersion extends React.Component<Props, State> {
             content="https://docs.expo.dev/static/images/twitter.png"
           />
 
-          {(this.props.version === 'unversioned' || this.isPreviewPath()) && (
-            <meta name="robots" content="noindex" />
-          )}
+          {(this.props.version === 'unversioned' ||
+            this.isPreviewPath() ||
+            this.isArchivePath()) && <meta name="robots" content="noindex" />}
+
           {this.props.version !== 'unversioned' && (
             <link rel="canonical" href={this.getCanonicalUrl()} />
           )}


### PR DESCRIPTION
# Why

Fixes ENG-5997

# How

This PR adds `noindex` property to the Archive pages.

# Test Plan

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
