### PR TITLE
[docs] Tutorial: fix ToC

### DIFF
--- a/docs/pages/tutorial/follow-up.md
+++ b/docs/pages/tutorial/follow-up.md
@@ -50,20 +50,20 @@ We covered the basic minimal configuration, but you learn more about customizing
 
 <br />
 
-# Topics that you will soon care about
+## Topics that you will soon care about
 
-## Standalone apps & deployment
+### Standalone apps & deployment
 
 How can you take what you have built and turn it into an app that you ship to the App Store and Play Store. Learn more about [distributing your app to stores](/distribution/introduction) and [deploying websites](/distribution/publishing-websites).
 
-## Navigation
+### Navigation
 
 Most apps have multiple screens, we just have one here! Learn more about how to add navigation to your app by following the [Fundamentals guide](https://reactnavigation.org/docs/getting-started) in the React Navigation documentation.
 
-## Debugging
+### Debugging
 
 Sometimes things go wrong, and when they do you need to use debugging tools to figure out where your code is having trouble. [Read more about debugging](/workflow/debugging).
 
-## Using the documentation
+### Using the documentation
 
 [Read more about how you can navigate this documentation and use it effectively](/next-steps/using-the-documentation).


### PR DESCRIPTION
# Why

Using H1 in page content is not correct and leads to ToC display issues.

# How

Fix the headers levels on the Tutorial - Learn More page.

# Test Plan

The changes have been tested by running docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
