### PR TITLE
[docs] fix wrong key for accessing extra env vars through expoConfig

### DIFF
--- a/docs/pages/eas-update/environment-variables.md
+++ b/docs/pages/eas-update/environment-variables.md
@@ -76,7 +76,7 @@ API_URL="https://prod.example.com" eas update --branch production
 
 When EAS CLI creates the update, it will set the `API_URL` to `https://prod.example.com` inside the update's bundle.
 
-To access it, we can use the `expo-constants` library. It's located under the `Constants.expoConfig.API_URL` property.
+To access it, we can use the `expo-constants` library. It's located under the `Constants.expoConfig.extra.API_URL` property.
 
 > Note: We could also use the `expo-updates` library to access `API_URL`. It is under `Updates.manifest?.extra?.expoClient?.extra?.eas?.API_URL`. However, `Updates.manifest` is only present when an update is currently running. If the project is in development, `Updates.manifest` will be `undefined`. In addition, if a build is running without an update (for example, it was just downloaded or there are no updates yet), `Updates.manifest` will also be `undefined`.
 


### PR DESCRIPTION
# Why

Wrong key.

# How

Right key.

# Test Plan

Mk 1 Eyeball.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
