### PR TITLE
[sweet API][Kotlin] Support events for fabric

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Fix issue with Android builds when gradle clean and build were called concurrently. ([#18518](https://github.com/expo/expo/pull/18518) by [EdwardDrapkin](https://github.com/EdwardDrapkin))
 - Fixed `FabricUIManager` errors when turning on new architecture mode on Android. ([#18472](https://github.com/expo/expo/pull/18472) by [@kudo](https://github.com/kudo))
 - Fixed the `2 files found with path 'lib/arm64-v8a/libfbjni.so'` error on Android. ([#18607](https://github.com/expo/expo/pull/18607) by [@lukmccall](https://github.com/lukmccall))
+- Fixed event dispatching for Sweet API views when running in Fabric mode on Android. ([#18814](https://github.com/expo/expo/pull/18814) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/events/KModuleEventEmitterWrapper.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/events/KModuleEventEmitterWrapper.kt
@@ -1,12 +1,11 @@
 package expo.modules.kotlin.events
 
 import android.os.Bundle
+import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter
-import com.facebook.react.uimanager.UIManagerModule
-import com.facebook.react.uimanager.events.EventDispatcher
-import com.facebook.react.uimanager.events.RCTEventEmitter
+import com.facebook.react.uimanager.UIManagerHelper
 import expo.modules.kotlin.ModuleHolder
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.JSTypeConverter
@@ -62,12 +61,6 @@ open class KEventEmitterWrapper(
       .get()
       ?.getJSModule(RCTDeviceEventEmitter::class.java)
 
-  private val uiEventDispatcher: EventDispatcher?
-    get() = reactContextHolder
-      .get()
-      ?.getNativeModule(UIManagerModule::class.java)
-      ?.eventDispatcher
-
   override fun emit(eventName: String, eventBody: WritableMap?) {
     deviceEventEmitter
       ?.emit(eventName, eventBody)
@@ -84,21 +77,30 @@ open class KEventEmitterWrapper(
   }
 
   override fun emit(viewId: Int, eventName: String, eventBody: WritableMap?, coalescingKey: Short?) {
-    uiEventDispatcher
+    val context = reactContextHolder.get() ?: return
+    UIManagerHelper.getEventDispatcherForReactTag(context, viewId)
       ?.dispatchEvent(UIEvent(viewId, eventName, eventBody, coalescingKey))
   }
 
   private class UIEvent(
-    private val viewId: Int,
+    viewId: Int,
     private val eventName: String,
     private val eventBody: WritableMap?,
     private val coalescingKey: Short?
   ) : com.facebook.react.uimanager.events.Event<UIEvent>(viewId) {
-    override fun getEventName(): String = eventName
+    override fun getEventName(): String = normalizeEventName(eventName)
     override fun canCoalesce(): Boolean = coalescingKey != null
     override fun getCoalescingKey(): Short = coalescingKey ?: 0
-    override fun dispatch(rctEventEmitter: RCTEventEmitter) {
-      rctEventEmitter.receiveEvent(viewId, eventName, eventBody)
-    }
+    override fun getEventData(): WritableMap = eventBody ?: Arguments.createMap()
   }
+}
+
+/**
+ * On Android, event names should be explicitly "top" prefixed, especially in Fabric mode.
+ * This method can help to make sure event name is in correct format.
+ */
+fun normalizeEventName(eventName: String): String {
+  return if (eventName.startsWith("on")) {
+    "top" + eventName.substring(2)
+  } else eventName
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerWrapperDelegate.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerWrapperDelegate.kt
@@ -8,6 +8,7 @@ import com.facebook.react.common.MapBuilder
 import expo.modules.core.utilities.ifNull
 import expo.modules.kotlin.ModuleHolder
 import expo.modules.kotlin.callbacks.ViewCallbackDelegate
+import expo.modules.kotlin.events.normalizeEventName
 import kotlin.reflect.full.declaredMemberProperties
 import kotlin.reflect.jvm.isAccessible
 
@@ -43,7 +44,7 @@ class ViewManagerWrapperDelegate(internal var moduleHolder: ModuleHolder) {
       ?.names
       ?.forEach {
         builder.put(
-          it, MapBuilder.of<String, Any>("registrationName", it)
+          normalizeEventName(it), MapBuilder.of<String, Any>("registrationName", it)
         )
       }
     return builder.build()


### PR DESCRIPTION
# Why

fix sweet kotlin modules events for fabric mode

# How

- use `UIManagerHelper.getEventDispatcherForReactTag` to get correct `UIManager` for event dispatcher
- normalize event name to be *top* prefixed. this is what we did in https://github.com/expo/expo/pull/18541/files#diff-9b6555f483f2eedef44d1bbc6efdb8f94f9576d53cab968ec228ab5294d894f6R57-R64

# Test Plan

based on #18798 to test the video playing in fabric-tester

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
