### PR TITLE
[modules][camera] Add `ExpoView`

### DIFF
--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraModule.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraModule.kt
@@ -51,16 +51,16 @@ class CameraModule : Module() {
     AsyncFunction("pausePreview") { viewTag: Int ->
       val view = findView(viewTag)
 
-      if (view.isCameraOpened) {
-        view.pausePreview()
+      if (view.cameraView.isCameraOpened) {
+        view.cameraView.pausePreview()
       }
     }.runOnQueue(Queues.MAIN)
 
     AsyncFunction("resumePreview") { viewTag: Int ->
       val view = findView(viewTag)
 
-      if (view.isCameraOpened) {
-        view.resumePreview()
+      if (view.cameraView.isCameraOpened) {
+        view.cameraView.resumePreview()
       }
     }.runOnQueue(Queues.MAIN)
 
@@ -69,7 +69,7 @@ class CameraModule : Module() {
       val view = findView(viewTag)
 
       if (!EmulatorUtilities.isRunningOnEmulator()) {
-        if (!view.isCameraOpened) {
+        if (!view.cameraView.isCameraOpened) {
           throw CameraExceptions.CameraIsNotRunning()
         }
 
@@ -88,7 +88,7 @@ class CameraModule : Module() {
       val cacheDirectory = reactContext.cacheDir
       val view = findView(viewTag)
 
-      if (!view.isCameraOpened) {
+      if (!view.cameraView.isCameraOpened) {
         throw CameraExceptions.CameraIsNotRunning()
       }
 
@@ -98,29 +98,29 @@ class CameraModule : Module() {
     AsyncFunction("stopRecording") { viewTag: Int ->
       val view = findView(viewTag)
 
-      if (view.isCameraOpened) {
-        view.stopRecording()
+      if (view.cameraView.isCameraOpened) {
+        view.cameraView.stopRecording()
       }
     }.runOnQueue(Queues.MAIN)
 
     AsyncFunction("getSupportedRatios") { viewTag: Int ->
       val view = findView(viewTag)
 
-      if (!view.isCameraOpened) {
+      if (!view.cameraView.isCameraOpened) {
         throw CameraExceptions.CameraIsNotRunning()
       }
 
-      return@AsyncFunction view.supportedAspectRatios.map { it.toString() }
+      return@AsyncFunction view.cameraView.supportedAspectRatios.map { it.toString() }
     }.runOnQueue(Queues.MAIN)
 
     AsyncFunction("getAvailablePictureSizes") { ratio: String?, viewTag: Int ->
       val view = findView(viewTag)
 
-      if (!view.isCameraOpened) {
+      if (!view.cameraView.isCameraOpened) {
         throw CameraExceptions.CameraIsNotRunning()
       }
 
-      val sizes = view.getAvailablePictureSizes(AspectRatio.parse(ratio))
+      val sizes = view.cameraView.getAvailablePictureSizes(AspectRatio.parse(ratio))
       return@AsyncFunction sizes.map { it.toString() }
     }.runOnQueue(Queues.MAIN)
 

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraViewManager.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraViewManager.kt
@@ -11,11 +11,7 @@ class CameraViewModule : Module() {
   override fun definition() = ModuleDefinition {
     Name("ExponentCamera")
 
-    ViewManager {
-      View {
-        ExpoCameraView(it, appContext)
-      }
-
+    View(ExpoCameraView::class) {
       Events(
         "onCameraReady",
         "onMountError",

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraViewManager.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraViewManager.kt
@@ -1,14 +1,12 @@
 package expo.modules.camera
 
 import android.view.View
-import android.view.ViewGroup
 import com.google.android.cameraview.AspectRatio
 import com.google.android.cameraview.Size
 import expo.modules.core.interfaces.services.UIManager
 import expo.modules.interfaces.barcodescanner.BarCodeScannerSettings
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
-import java.lang.ref.WeakReference
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraViewManager.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraViewManager.kt
@@ -1,5 +1,7 @@
 package expo.modules.camera
 
+import android.view.View
+import android.view.ViewGroup
 import com.google.android.cameraview.AspectRatio
 import com.google.android.cameraview.Size
 import expo.modules.core.interfaces.services.UIManager
@@ -7,6 +9,8 @@ import expo.modules.interfaces.barcodescanner.BarCodeScannerSettings
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 import java.lang.ref.WeakReference
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
 
 class CameraViewModule : Module() {
   override fun definition() = ModuleDefinition {
@@ -14,7 +18,7 @@ class CameraViewModule : Module() {
 
     ViewManager {
       View {
-        ExpoCameraView(it, WeakReference(appContext))
+        ExpoCameraView(it, appContext)
       }
 
       Events(
@@ -29,45 +33,45 @@ class CameraViewModule : Module() {
       OnViewDestroys<ExpoCameraView> { view ->
         val uiManager = appContext.legacyModule<UIManager>()
         uiManager?.unregisterLifecycleEventListener(view)
-        view.stop()
+        view.cameraView.stop()
       }
 
       Prop("type") { view: ExpoCameraView, type: Int ->
-        view.facing = type
+        view.cameraView.facing = type
       }
 
       Prop("ratio") { view: ExpoCameraView, ratio: String? ->
         if (ratio == null) {
           return@Prop
         }
-        view.setAspectRatio(AspectRatio.parse(ratio))
+        view.cameraView.setAspectRatio(AspectRatio.parse(ratio))
       }
 
       Prop("flashMode") { view: ExpoCameraView, torchMode: Int ->
-        view.flash = torchMode
+        view.cameraView.flash = torchMode
       }
 
       Prop("autoFocus") { view: ExpoCameraView, autoFocus: Boolean ->
-        view.autoFocus = autoFocus
+        view.cameraView.autoFocus = autoFocus
       }
 
       Prop("focusDepth") { view: ExpoCameraView, depth: Float ->
-        view.focusDepth = depth
+        view.cameraView.focusDepth = depth
       }
 
       Prop("zoom") { view: ExpoCameraView, zoom: Float ->
-        view.zoom = zoom
+        view.cameraView.zoom = zoom
       }
 
       Prop("whiteBalance") { view: ExpoCameraView, whiteBalance: Int ->
-        view.whiteBalance = whiteBalance
+        view.cameraView.whiteBalance = whiteBalance
       }
 
       Prop("pictureSize") { view: ExpoCameraView, size: String? ->
         if (size == null) {
           return@Prop
         }
-        view.pictureSize = Size.parse(size)
+        view.cameraView.setPictureSize(Size.parse(size))
       }
 
       Prop("barCodeScannerSettings") { view: ExpoCameraView, settings: Map<String, Any?>? ->
@@ -75,7 +79,7 @@ class CameraViewModule : Module() {
       }
 
       Prop("useCamera2Api") { view: ExpoCameraView, useCamera2Api: Boolean ->
-        view.setUsingCamera2Api(useCamera2Api)
+        view.cameraView.setUsingCamera2Api(useCamera2Api)
       }
 
       Prop("barCodeScannerEnabled") { view: ExpoCameraView, barCodeScannerEnabled: Boolean ->

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraViewManager.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraViewManager.kt
@@ -1,12 +1,9 @@
 package expo.modules.camera
 
-import android.view.View
 import com.google.android.cameraview.AspectRatio
 import com.google.android.cameraview.Size
 import expo.modules.core.interfaces.services.UIManager
 import expo.modules.interfaces.barcodescanner.BarCodeScannerSettings
-import expo.modules.kotlin.modules.Module
-import expo.modules.kotlin.modules.ModuleDefinition
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 
@@ -69,7 +66,7 @@ class CameraViewModule : Module() {
         if (size == null) {
           return@Prop
         }
-        view.cameraView.setPictureSize(Size.parse(size))
+        view.cameraView.pictureSize = Size.parse(size)
       }
 
       Prop("barCodeScannerSettings") { view: ExpoCameraView, settings: Map<String, Any?>? ->

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
@@ -1,9 +1,9 @@
 package expo.modules.camera
 
 import android.Manifest
-import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Color
+import android.graphics.SurfaceTexture
 import android.net.Uri
 import android.os.Bundle
 import android.view.View
@@ -31,22 +31,23 @@ import expo.modules.interfaces.facedetector.FaceDetectorProviderInterface
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.Promise
 import expo.modules.kotlin.callbacks.callback
+import expo.modules.kotlin.views.ExpoView
 import java.io.File
 import java.io.IOException
-import java.lang.ref.WeakReference
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedQueue
 
 class ExpoCameraView(
   themedReactContext: Context,
-  private val appContext: WeakReference<AppContext>,
-) : CameraView(themedReactContext, true),
+  appContext: AppContext,
+) : ExpoView(themedReactContext, appContext),
   LifecycleEventListener,
   BarCodeScannerAsyncTaskDelegate,
   FaceDetectorAsyncTaskDelegate,
   PictureSavedDelegate,
   CameraViewInterface {
+  internal val cameraView = CameraView(themedReactContext, true)
 
   private val pictureTakenPromises: Queue<Promise> = ConcurrentLinkedQueue()
   private val pictureTakenOptions: MutableMap<Promise, PictureOptions> = ConcurrentHashMap()
@@ -97,16 +98,14 @@ class ExpoCameraView(
   private var mShouldScanBarCodes = false
 
   override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
-    val preview = view ?: return
-    setBackgroundColor(Color.BLACK)
     val width = right - left
     val height = bottom - top
-    preview.layout(0, 0, width, height)
-  }
 
-  @SuppressLint("MissingSuperCall")
-  override fun requestLayout() {
-    // React handles this for us, so we don't need to call super.requestLayout();
+    cameraView.layout(0, 0, width, height)
+    cameraView.setBackgroundColor(Color.BLACK)
+
+    val preview = cameraView.view ?: return
+    preview.layout(0, 0, width, height)
   }
 
   override fun onViewAdded(child: View) {
@@ -115,7 +114,7 @@ class ExpoCameraView(
     // while we need this preview to be rendered last beneath all other children
 
     // child is not preview
-    if (this.view === child || this.view == null) {
+    if (cameraView === child) {
       return
     }
 
@@ -123,19 +122,19 @@ class ExpoCameraView(
     val childrenToBeReordered = mutableListOf<View>()
     for (i in 0 until this.childCount) {
       val childView = getChildAt(i)
-      if (i == 0 && childView === this.view) {
+      if (i == 0 && childView === cameraView) {
         // preview is already first in children list - do not reorder anything
         return
       }
-      if (childView !== this.view) {
+      if (childView !== cameraView) {
         childrenToBeReordered.add(childView)
       }
     }
     for (childView in childrenToBeReordered) {
       bringChildToFront(childView)
     }
-    requestLayout()
-    invalidate()
+    cameraView.requestLayout()
+    cameraView.invalidate()
   }
 
   fun takePicture(options: PictureOptions, promise: Promise, cacheDirectory: File) {
@@ -143,7 +142,7 @@ class ExpoCameraView(
     pictureTakenOptions[promise] = options
     pictureTakenDirectories[promise] = cacheDirectory
     try {
-      super.takePicture()
+      cameraView.takePicture()
     } catch (e: Exception) {
       pictureTakenPromises.remove(promise)
       pictureTakenOptions.remove(promise)
@@ -159,9 +158,9 @@ class ExpoCameraView(
   fun record(options: RecordingOptions, promise: Promise, cacheDirectory: File) {
     try {
       val path = FileSystemUtils.generateOutputPath(cacheDirectory, "Camera", ".mp4")
-      val profile = getCamcorderProfile(cameraId, options.quality)
+      val profile = getCamcorderProfile(cameraView.cameraId, options.quality)
       options.videoBitrate?.let { profile.videoBitRate = it }
-      if (super.record(path, options.maxDuration * 1000, options.maxFileSize, !options.muteValue, profile)) {
+      if (cameraView.record(path, options.maxDuration * 1000, options.maxFileSize, !options.muteValue, profile)) {
         videoRecordedPromise = promise
       } else {
         promise.reject("E_RECORDING_FAILED", "Starting video recording failed. Another recording might be in progress.", null)
@@ -177,13 +176,13 @@ class ExpoCameraView(
    * Additionally supports [codabar, code128, maxicode, rss14, rssexpanded, upc_a, upc_ean]
    */
   private fun initBarCodeScanner() {
-    val barCodeScannerProvider = appContext.get()?.legacyModule<BarCodeScannerProviderInterface>()
+    val barCodeScannerProvider = appContext.legacyModule<BarCodeScannerProviderInterface>()
     barCodeScanner = barCodeScannerProvider?.createBarCodeDetectorWithContext(context)
   }
 
   fun setShouldScanBarCodes(shouldScanBarCodes: Boolean) {
     mShouldScanBarCodes = shouldScanBarCodes
-    scanning = mShouldScanBarCodes || shouldDetectFaces
+    cameraView.scanning = mShouldScanBarCodes || shouldDetectFaces
   }
 
   fun setBarCodeScannerSettings(settings: BarCodeScannerSettings) {
@@ -206,16 +205,20 @@ class ExpoCameraView(
     barCodeScannerTaskLock = false
   }
 
-  override fun getPreviewSizeAsArray() = intArrayOf(previewSize.width, previewSize.height)
+  override fun setPreviewTexture(surfaceTexture: SurfaceTexture?) {
+    cameraView.setPreviewTexture(surfaceTexture)
+  }
+
+  override fun getPreviewSizeAsArray() = intArrayOf(cameraView.previewSize.width, cameraView.previewSize.height)
 
   override fun onHostResume() {
     if (hasCameraPermissions()) {
-      if (isPaused && !isCameraOpened || isNew) {
+      if (isPaused && !cameraView.isCameraOpened || isNew) {
         isPaused = false
         isNew = false
         if (!EmulatorUtilities.isRunningOnEmulator()) {
-          start()
-          val faceDetectorProvider = appContext.get()?.legacyModule<FaceDetectorProviderInterface>()
+          cameraView.start()
+          val faceDetectorProvider = appContext.legacyModule<FaceDetectorProviderInterface>()
           faceDetector = faceDetectorProvider?.createFaceDetectorWithContext(context)
           pendingFaceDetectorSettings?.let {
             faceDetector?.setSettings(it)
@@ -229,26 +232,26 @@ class ExpoCameraView(
   }
 
   override fun onHostPause() {
-    if (!isPaused && isCameraOpened) {
+    if (!isPaused && cameraView.isCameraOpened) {
       faceDetector?.release()
       isPaused = true
-      stop()
+      cameraView.stop()
     }
   }
 
   override fun onHostDestroy() {
     faceDetector?.release()
-    stop()
+    cameraView.stop()
   }
 
   private fun hasCameraPermissions(): Boolean {
-    val permissionsManager = appContext.get()?.permissions ?: return false
+    val permissionsManager = appContext.permissions ?: return false
     return permissionsManager.hasGrantedPermissions(Manifest.permission.CAMERA)
   }
 
   fun setShouldDetectFaces(shouldDetectFaces: Boolean) {
     this.shouldDetectFaces = shouldDetectFaces
-    scanning = mShouldScanBarCodes || shouldDetectFaces
+    cameraView.scanning = mShouldScanBarCodes || shouldDetectFaces
   }
 
   fun setFaceDetectorSettings(settings: Map<String, Any>?) {
@@ -283,9 +286,9 @@ class ExpoCameraView(
   init {
     initBarCodeScanner()
     isChildrenDrawingOrderEnabled = true
-    val uIManager = appContext.get()?.legacyModule<UIManager>()
+    val uIManager = appContext.legacyModule<UIManager>()
     uIManager!!.registerLifecycleEventListener(this)
-    addCallback(object : Callback() {
+    cameraView.addCallback(object : CameraView.Callback() {
       override fun onCameraOpened(cameraView: CameraView) {
         onCameraReady(Unit)
       }
@@ -320,7 +323,7 @@ class ExpoCameraView(
       }
 
       override fun onFramePreview(cameraView: CameraView, data: ByteArray, width: Int, height: Int, rotation: Int) {
-        val correctRotation = getCorrectCameraRotation(rotation, facing)
+        val correctRotation = getCorrectCameraRotation(rotation, cameraView.facing)
         if (mShouldScanBarCodes && !barCodeScannerTaskLock && cameraView is BarCodeScannerAsyncTaskDelegate) {
           barCodeScannerTaskLock = true
           val delegate = cameraView as BarCodeScannerAsyncTaskDelegate
@@ -329,14 +332,16 @@ class ExpoCameraView(
         if (shouldDetectFaces && !faceDetectorTaskLock && cameraView is FaceDetectorAsyncTaskDelegate) {
           faceDetectorTaskLock = true
           val density = cameraView.resources.displayMetrics.density
-          val dimensions = ImageDimensions(width, height, correctRotation, facing)
+          val dimensions = ImageDimensions(width, height, correctRotation, cameraView.facing)
           val scaleX = cameraView.width.toDouble() / (dimensions.width * density)
           val scaleY = cameraView.height.toDouble() / (dimensions.height * density)
           val delegate = cameraView as FaceDetectorAsyncTaskDelegate
-          val task = faceDetector?.let { FaceDetectorTask(delegate, it, data, width, height, correctRotation, facing == FACING_FRONT, scaleX, scaleY) }
+          val task = faceDetector?.let { FaceDetectorTask(delegate, it, data, width, height, correctRotation, cameraView.facing == CameraView.FACING_FRONT, scaleX, scaleY) }
           task?.execute()
         }
       }
     })
+
+    addView(cameraView)
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ExpoView.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ExpoView.kt
@@ -1,0 +1,13 @@
+package expo.modules.kotlin.views
+
+import android.content.Context
+import android.widget.LinearLayout
+import expo.modules.kotlin.AppContext
+
+/**
+ * A base class that should be used by every exported views.
+ */
+abstract class ExpoView(
+  context: Context,
+  val appContext: AppContext
+) : LinearLayout(context)


### PR DESCRIPTION
# Why

Adds an `ExpoView` class. 
In order to support Fabric friendly views, we have to create our own abstraction. 

# How

Added an abstract class `ExpoView` and used it in the camera module to test if everything works correctly. 

> Note:
In the future, we may want to add more classes like `ExpoView` but with different layouts. The current implementation is using the `LinearLayout`.

# Test Plan

- NCL ✅