### PR TITLE
[modules][Android]  Migrate from the `ViewManager` component to  `View`

### DIFF
--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraViewManager.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraViewManager.kt
@@ -11,11 +11,7 @@ class CameraViewModule : Module() {
   override fun definition() = ModuleDefinition {
     Name("ExponentCamera")
 
-    ViewManager {
-      View { context ->
-        ExpoCameraView(context, appContext)
-      }
-
+    View(ExpoCameraView::class) {
       Events(
         "onCameraReady",
         "onMountError",

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionBuilder.kt
@@ -60,7 +60,7 @@ class ModuleDefinitionBuilder(@PublishedApi internal val module: Module? = null)
   /**
    * Creates the view manager definition that scopes other view-related definitions.
    */
-  inline fun <T: View> View(viewType: KClass<T>, body: ViewDefinitionBuilder<T>.() -> Unit) {
+  inline fun <T : View> View(viewType: KClass<T>, body: ViewDefinitionBuilder<T>.() -> Unit) {
     require(viewManagerDefinition == null) { "The module definition may have exported only one view manager." }
 
     val viewDefinitionBuilder = ViewDefinitionBuilder(viewType)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionBuilder.kt
@@ -4,6 +4,7 @@ package expo.modules.kotlin.modules
 
 import android.app.Activity
 import android.content.Intent
+import android.view.View
 import expo.modules.kotlin.events.BasicEventListener
 import expo.modules.kotlin.events.EventListener
 import expo.modules.kotlin.events.EventListenerWithPayload
@@ -11,8 +12,10 @@ import expo.modules.kotlin.events.EventListenerWithSenderAndPayload
 import expo.modules.kotlin.events.EventName
 import expo.modules.kotlin.events.OnActivityResultPayload
 import expo.modules.kotlin.objects.ObjectDefinitionBuilder
+import expo.modules.kotlin.views.ViewDefinitionBuilder
 import expo.modules.kotlin.views.ViewManagerDefinition
 import expo.modules.kotlin.views.ViewManagerDefinitionBuilder
+import kotlin.reflect.KClass
 
 @DefinitionMarker
 class ModuleDefinitionBuilder(@PublishedApi internal val module: Module? = null) : ObjectDefinitionBuilder() {
@@ -45,12 +48,24 @@ class ModuleDefinitionBuilder(@PublishedApi internal val module: Module? = null)
   /**
    * Creates the view manager definition that scopes other view-related definitions.
    */
+  @Deprecated(message = "Use a `View` component instead.")
   inline fun ViewManager(body: ViewManagerDefinitionBuilder.() -> Unit) {
     require(viewManagerDefinition == null) { "The module definition may have exported only one view manager." }
 
     val viewManagerDefinitionBuilder = ViewManagerDefinitionBuilder()
     body.invoke(viewManagerDefinitionBuilder)
     viewManagerDefinition = viewManagerDefinitionBuilder.build()
+  }
+
+  /**
+   * Creates the view manager definition that scopes other view-related definitions.
+   */
+  inline fun <T: View> View(viewType: KClass<T>, body: ViewDefinitionBuilder<T>.() -> Unit) {
+    require(viewManagerDefinition == null) { "The module definition may have exported only one view manager." }
+
+    val viewDefinitionBuilder = ViewDefinitionBuilder(viewType)
+    body.invoke(viewDefinitionBuilder)
+    viewManagerDefinition = viewDefinitionBuilder.build()
   }
 
   /**

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerDefinition.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerDefinition.kt
@@ -8,12 +8,13 @@ import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.ReadableMap
 import expo.modules.adapters.react.NativeModulesProxy
 import expo.modules.core.ViewManager
+import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.exception.UnexpectedException
 import expo.modules.kotlin.recycle
 
 class ViewManagerDefinition(
-  private val viewFactory: (Context) -> View,
+  private val viewFactory: (Context, AppContext) -> View,
   private val viewType: Class<out View>,
   private val props: Map<String, AnyViewProp>,
   val onViewDestroys: ((View) -> Unit)? = null,
@@ -21,7 +22,7 @@ class ViewManagerDefinition(
   val viewGroupDefinition: ViewGroupDefinition? = null
 ) {
 
-  fun createView(context: Context): View = viewFactory(context)
+  fun createView(context: Context, appContext: AppContext): View = viewFactory(context, appContext)
 
   val propsNames: List<String> = props.keys.toList()
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerWrapperDelegate.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerWrapperDelegate.kt
@@ -24,7 +24,7 @@ class ViewManagerWrapperDelegate(internal var moduleHolder: ModuleHolder) {
 
   fun createView(context: Context): View {
     return definition
-      .createView(context)
+      .createView(context, moduleHolder.module.appContext)
       .also {
         configureView(it)
       }
@@ -56,8 +56,7 @@ class ViewManagerWrapperDelegate(internal var moduleHolder: ModuleHolder) {
     val kClass = view.javaClass.kotlin
     val propertiesMap = kClass
       .declaredMemberProperties
-      .map { it.name to it }
-      .toMap()
+      .associateBy { it.name }
 
     callbacks.forEach {
       val property = propertiesMap[it].ifNull {

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/views/ViewManagerDefinitionBuilderTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/views/ViewManagerDefinitionBuilderTest.kt
@@ -42,7 +42,7 @@ class ViewManagerDefinitionBuilderTest {
       }
       .build()
 
-    definition.createView(mockk())
+    definition.createView(mockk(), mockk())
     definition.setProps(
       JavaOnlyMap().apply {
         putInt("p1", 1)

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/views/ViewManagerDefinitionTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/views/ViewManagerDefinitionTest.kt
@@ -12,7 +12,7 @@ class ViewManagerDefinitionTest {
   @Test
   fun `definition should deduce type of view manager`() {
     val simpleViewManagerDefinition = ViewManagerDefinition(
-      { _,_ -> mockk<TextView>() },
+      { _, _ -> mockk<TextView>() },
       TextView::class.java,
       emptyMap()
     )

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/views/ViewManagerDefinitionTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/views/ViewManagerDefinitionTest.kt
@@ -12,13 +12,13 @@ class ViewManagerDefinitionTest {
   @Test
   fun `definition should deduce type of view manager`() {
     val simpleViewManagerDefinition = ViewManagerDefinition(
-      { mockk<TextView>() },
+      { _,_ -> mockk<TextView>() },
       TextView::class.java,
       emptyMap()
     )
 
     val groupViewManagerDefinition = ViewManagerDefinition(
-      { mockk<ListView>() },
+      { _, _ -> mockk<ListView>() },
       ListView::class.java,
       emptyMap()
     )


### PR DESCRIPTION
# Why

A follow-up to the https://github.com/expo/expo/pull/18761.

# How

- Copied `ViewManagerDefinitionBuilder` into `ViewDefinitionBuilder`.
- Deprecated `ViewManager` component.
- Introduced a `View` component`.

# Test Plan

- fabric-tester ✅
- bare-expo with NCL and test-suite for camera ✅
