### PR TITLE
[android][av][core] Fix a couple issues for expo go

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/ExperiencePackagePicker.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/ExperiencePackagePicker.kt
@@ -2,6 +2,7 @@ package versioned.host.exp.exponent
 
 import expo.modules.application.ApplicationPackage
 import expo.modules.av.AVPackage
+import expo.modules.av.video.VideoViewModule
 import expo.modules.backgroundfetch.BackgroundFetchPackage
 import expo.modules.barcodescanner.BarCodeScannerPackage
 import expo.modules.battery.BatteryPackage
@@ -138,6 +139,7 @@ object ExperiencePackagePicker : ModulesProvider {
     LinearGradientModule::class.java,
     LocalizationModule::class.java,
     RandomModule::class.java,
+    VideoViewModule::class.java,
     WebBrowserModule::class.java,
   )
 }

--- a/packages/expo-av/android/src/main/java/expo/modules/av/AVManager.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/AVManager.java
@@ -503,7 +503,7 @@ public class AVManager implements LifecycleEventListener, AudioManager.OnAudioFo
 
   @Override
   public void loadForVideo(final Integer tag, final ReadableArguments source, final ReadableArguments status, final Promise promise) {
-    ViewUtils.tryRunWithVideoView((ReactContext) getContext(), tag, new ViewUtils.VideoViewCallback() {
+    ViewUtils.tryRunWithVideoView(mModuleRegistry, tag, new ViewUtils.VideoViewCallback() {
       @Override
       public void runWithVideoView(final VideoView videoView) {
         videoView.setSource(source, status, promise);
@@ -513,7 +513,7 @@ public class AVManager implements LifecycleEventListener, AudioManager.OnAudioFo
 
   @Override
   public void unloadForVideo(final Integer tag, final Promise promise) {
-    ViewUtils.tryRunWithVideoView((ReactContext) getContext(), tag, new ViewUtils.VideoViewCallback() {
+    ViewUtils.tryRunWithVideoView(mModuleRegistry, tag, new ViewUtils.VideoViewCallback() {
       @Override
       public void runWithVideoView(final VideoView videoView) {
         videoView.setSource(null, null, promise);
@@ -523,7 +523,7 @@ public class AVManager implements LifecycleEventListener, AudioManager.OnAudioFo
 
   @Override
   public void setStatusForVideo(final Integer tag, final ReadableArguments status, final Promise promise) {
-    ViewUtils.tryRunWithVideoView((ReactContext) getContext(), tag, new ViewUtils.VideoViewCallback() {
+    ViewUtils.tryRunWithVideoView(mModuleRegistry, tag, new ViewUtils.VideoViewCallback() {
       @Override
       public void runWithVideoView(final VideoView videoView) {
         videoView.setStatus(status, promise);
@@ -533,7 +533,7 @@ public class AVManager implements LifecycleEventListener, AudioManager.OnAudioFo
 
   @Override
   public void replayVideo(final Integer tag, final ReadableArguments status, final Promise promise) {
-    ViewUtils.tryRunWithVideoView((ReactContext) getContext(), tag, new ViewUtils.VideoViewCallback() {
+    ViewUtils.tryRunWithVideoView(mModuleRegistry, tag, new ViewUtils.VideoViewCallback() {
       @Override
       public void runWithVideoView(final VideoView videoView) {
         videoView.setStatus(status, promise);
@@ -543,7 +543,7 @@ public class AVManager implements LifecycleEventListener, AudioManager.OnAudioFo
 
   @Override
   public void getStatusForVideo(final Integer tag, final Promise promise) {
-    ViewUtils.tryRunWithVideoView((ReactContext) getContext(), tag, new ViewUtils.VideoViewCallback() {
+    ViewUtils.tryRunWithVideoView(mModuleRegistry, tag, new ViewUtils.VideoViewCallback() {
       @Override
       public void runWithVideoView(final VideoView videoView) {
         promise.resolve(videoView.getStatus());

--- a/packages/expo-av/android/src/main/java/expo/modules/av/ViewUtils.kt
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/ViewUtils.kt
@@ -2,12 +2,12 @@ package expo.modules.av
 
 import androidx.annotation.AnyThread
 import androidx.annotation.UiThread
-import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.UiThreadUtil
-import com.facebook.react.uimanager.UIManagerHelper
 import expo.modules.av.video.VideoView
 import expo.modules.av.video.VideoViewWrapper
+import expo.modules.core.ModuleRegistry
 import expo.modules.core.Promise
+import expo.modules.core.interfaces.services.UIManager
 
 object ViewUtils {
   interface VideoViewCallback {
@@ -15,8 +15,8 @@ object ViewUtils {
   }
 
   @UiThread
-  private fun tryRunWithVideoViewOnUiThread(reactContext: ReactContext, viewTag: Int, callback: VideoViewCallback, promise: Promise) {
-    val videoWrapperView = UIManagerHelper.getUIManagerForReactTag(reactContext, viewTag)?.resolveView(viewTag) as VideoViewWrapper?
+  private fun tryRunWithVideoViewOnUiThread(moduleRegistry: ModuleRegistry, viewTag: Int, callback: VideoViewCallback, promise: Promise) {
+    val videoWrapperView = moduleRegistry.getModule(UIManager::class.java).resolveView(viewTag) as VideoViewWrapper?
     val videoView = videoWrapperView?.videoViewInstance
     if (videoView != null) {
       callback.runWithVideoView(videoView)
@@ -31,12 +31,12 @@ object ViewUtils {
   @JvmStatic
   @AnyThread
   @Deprecated("Use `dispatchCommands` in favor of finding view with imperative calls")
-  fun tryRunWithVideoView(reactContext: ReactContext, viewTag: Int, callback: VideoViewCallback, promise: Promise) {
+  fun tryRunWithVideoView(moduleRegistry: ModuleRegistry, viewTag: Int, callback: VideoViewCallback, promise: Promise) {
     if (UiThreadUtil.isOnUiThread()) {
-      tryRunWithVideoViewOnUiThread(reactContext, viewTag, callback, promise)
+      tryRunWithVideoViewOnUiThread(moduleRegistry, viewTag, callback, promise)
     } else {
       UiThreadUtil.runOnUiThread {
-        tryRunWithVideoViewOnUiThread(reactContext, viewTag, callback, promise)
+        tryRunWithVideoViewOnUiThread(moduleRegistry, viewTag, callback, promise)
       }
     }
   }

--- a/packages/expo-av/android/src/main/java/expo/modules/av/video/VideoManager.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/video/VideoManager.java
@@ -51,7 +51,7 @@ public class VideoManager extends ExportedModule {
 
   @ExpoMethod
   public void setFullscreen(final Integer tag, final Boolean shouldBeFullscreen, final Promise promise) {
-    ViewUtils.tryRunWithVideoView((ReactContext) getContext(), tag, new ViewUtils.VideoViewCallback() {
+    ViewUtils.tryRunWithVideoView(mModuleRegistry, tag, new ViewUtils.VideoViewCallback() {
       @Override
       public void runWithVideoView(final VideoView videoView) {
         FullscreenVideoPlayerPresentationChangeProgressListener listener = new FullscreenVideoPlayerPresentationChangeProgressListener() {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/ModuleRegistryAdapter.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/ModuleRegistryAdapter.java
@@ -1,5 +1,7 @@
 package expo.modules.adapters.react;
 
+import androidx.annotation.Nullable;
+
 import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -56,7 +58,7 @@ public class ModuleRegistryAdapter implements ReactPackage {
 
     List<NativeModule> nativeModules = getNativeModulesFromModuleRegistry(reactContext, moduleRegistry);
     if (mWrapperDelegateHolders != null) {
-      KotlinInteropModuleRegistry kotlinInteropModuleRegistry = getOrCreateNativeModulesProxy(reactContext).getKotlinInteropModuleRegistry();
+      KotlinInteropModuleRegistry kotlinInteropModuleRegistry = getOrCreateNativeModulesProxy(reactContext, null).getKotlinInteropModuleRegistry();
       kotlinInteropModuleRegistry.updateModuleHoldersInViewManagers(mWrapperDelegateHolders);
     }
 
@@ -66,7 +68,7 @@ public class ModuleRegistryAdapter implements ReactPackage {
   protected List<NativeModule> getNativeModulesFromModuleRegistry(ReactApplicationContext reactContext, ModuleRegistry moduleRegistry) {
     List<NativeModule> nativeModulesList = new ArrayList<>(2);
 
-    nativeModulesList.add(getOrCreateNativeModulesProxy(reactContext));
+    nativeModulesList.add(getOrCreateNativeModulesProxy(reactContext, moduleRegistry));
 
     // Add listener that will notify expo.modules.core.ModuleRegistry when all modules are ready
     nativeModulesList.add(new ModuleRegistryReadyNotifier(moduleRegistry));
@@ -95,7 +97,7 @@ public class ModuleRegistryAdapter implements ReactPackage {
       }
     }
 
-    NativeModulesProxy modulesProxy = Objects.requireNonNull(getOrCreateNativeModulesProxy(reactContext));
+    NativeModulesProxy modulesProxy = Objects.requireNonNull(getOrCreateNativeModulesProxy(reactContext, null));
     KotlinInteropModuleRegistry kotlinInteropModuleRegistry = modulesProxy.getKotlinInteropModuleRegistry();
     List<ViewManager<?, ?>> kViewManager = kotlinInteropModuleRegistry.exportViewManagers();
     // Saves all holders that needs to be in sync with module registry
@@ -109,13 +111,14 @@ public class ModuleRegistryAdapter implements ReactPackage {
     return viewManagerList;
   }
 
-  private NativeModulesProxy getOrCreateNativeModulesProxy(ReactApplicationContext reactContext) {
+  private NativeModulesProxy getOrCreateNativeModulesProxy(ReactApplicationContext reactContext,
+                                                           @Nullable ModuleRegistry moduleRegistry) {
     if (mModulesProxy == null) {
-      ModuleRegistry moduleRegistry = mModuleRegistryProvider.get(reactContext);
+      ModuleRegistry registry = moduleRegistry != null ? moduleRegistry : mModuleRegistryProvider.get(reactContext);
       if (mModulesProvider != null) {
-        mModulesProxy = new NativeModulesProxy(reactContext, moduleRegistry, mModulesProvider);
+        mModulesProxy = new NativeModulesProxy(reactContext, registry, mModulesProvider);
       } else {
-        mModulesProxy = new NativeModulesProxy(reactContext, moduleRegistry);
+        mModulesProxy = new NativeModulesProxy(reactContext, registry);
       }
     }
     return mModulesProxy;

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/services/UIManagerModuleWrapper.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/services/UIManagerModuleWrapper.java
@@ -5,11 +5,20 @@ import android.content.Intent;
 import android.util.Log;
 import android.view.View;
 
+import androidx.annotation.Nullable;
+
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.turbomodule.core.CallInvokerHolderImpl;
 import com.facebook.react.uimanager.IllegalViewOperationException;
 import com.facebook.react.uimanager.NativeViewHierarchyManager;
+import com.facebook.react.uimanager.UIManagerHelper;
 import com.facebook.react.uimanager.UIManagerModule;
+
+import java.lang.ref.WeakReference;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.WeakHashMap;
 
 import expo.modules.core.interfaces.ActivityEventListener;
 import expo.modules.core.interfaces.ActivityProvider;
@@ -17,12 +26,6 @@ import expo.modules.core.interfaces.InternalModule;
 import expo.modules.core.interfaces.JavaScriptContextProvider;
 import expo.modules.core.interfaces.LifecycleEventListener;
 import expo.modules.core.interfaces.services.UIManager;
-
-import java.lang.ref.WeakReference;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.WeakHashMap;
 
 public class UIManagerModuleWrapper implements
     ActivityProvider,
@@ -96,6 +99,16 @@ public class UIManagerModuleWrapper implements
         });
       }
     });
+  }
+
+  @Nullable
+  @Override
+  public View resolveView(int viewTag) {
+    final com.facebook.react.bridge.UIManager uiManager = UIManagerHelper.getUIManagerForReactTag(getContext(), viewTag);
+    if (uiManager == null) {
+      return null;
+    }
+    return uiManager.resolveView(viewTag);
   }
 
   @Override

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/core/interfaces/services/UIManager.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/core/interfaces/services/UIManager.java
@@ -2,6 +2,8 @@ package expo.modules.core.interfaces.services;
 
 import android.view.View;
 
+import androidx.annotation.Nullable;
+
 import expo.modules.core.interfaces.ActivityEventListener;
 import expo.modules.core.interfaces.LifecycleEventListener;
 
@@ -25,6 +27,10 @@ public interface UIManager {
 
   @Deprecated
   void addUIBlock(GroupUIBlock block);
+
+  @Deprecated
+  @Nullable
+  View resolveView(int viewTag);
 
   void runOnUiQueueThread(Runnable runnable);
 


### PR DESCRIPTION
# Why

fix a couple issues for expo go.

# How

- a launch crash because Permission module not found. this is a regression for #18472 in `ModuleRegistryAdapter::getNativeModulesFromModuleRegistry()` where custom moduleRegistry is not be used.
- VideoViewModule is not registered. a regression from #18798
- Video play/fullscreen does not work. because the [context](https://github.com/expo/expo/pull/18798/files#diff-92ed6ed63af93be93cb457680bd3640d56ce064cf6e6a51fa134f44148556521R506) in expo go is not ReactContext but ScopedContext. since VideoManager and AVManager is still written in legacy module, i still have to use UIManager to get the correct ReactContext.

# Test Plan

- unversioned android expo go + NCL video
- fabric-tester VideoExample

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
  - it's just fixes for unpublished commits. not changelog to confuse people.
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
