### PR TITLE
[modules][ios] Automatically convert records to dicts when returned by the function

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Add Logger support for writing logs to a file; add Logger and associated classes to Android. ([#18513](https://github.com/expo/expo/pull/18513) by [@douglowder](https://github.com/douglowder))
 - Experimental support for Fabric on Android. ([#18541](https://github.com/expo/expo/pull/18541) by [@kudo](https://github.com/kudo))
 - Add option to generate a `coalescingKey` in callback on Android. ([#18774](https://github.com/expo/expo/pull/18774) by [@lukmccall](https://github.com/lukmccall))
+- Automatically convert records to dicts when returned by the function. ([#18824](https://github.com/expo/expo/pull/18824) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/Swift/Conversions.swift
+++ b/packages/expo-modules-core/ios/Swift/Conversions.swift
@@ -148,6 +148,16 @@ internal final class Conversions {
     return String(number) + (number == 1 ? singular : (plural ?? singular + "s"))
   }
 
+  /**
+   Converts the function result to the type compatible with JavaScript.
+   */
+  static func convertFunctionResult<ValueType>(_ value: ValueType?) -> Any {
+    if let value = value as? Record {
+      return value.toDictionary()
+    }
+    return value
+  }
+
   // MARK: - Exceptions
 
   /**

--- a/packages/expo-modules-core/ios/Swift/Functions/AsyncFunctionComponent.swift
+++ b/packages/expo-modules-core/ios/Swift/Functions/AsyncFunctionComponent.swift
@@ -66,7 +66,7 @@ public final class AsyncFunctionComponent<Args, FirstArgType, ReturnType>: AnyAs
 
   func call(by owner: AnyObject?, withArguments args: [Any], callback: @escaping (FunctionCallResult) -> ()) {
     let promise = Promise { value in
-      callback(.success(value as Any))
+      callback(.success(Conversions.convertFunctionResult(value)))
     } rejecter: { exception in
       callback(.failure(exception))
     }

--- a/packages/expo-modules-core/ios/Swift/Functions/SyncFunctionComponent.swift
+++ b/packages/expo-modules-core/ios/Swift/Functions/SyncFunctionComponent.swift
@@ -52,7 +52,7 @@ public final class SyncFunctionComponent<Args, FirstArgType, ReturnType>: AnySyn
   func call(by owner: AnyObject?, withArguments args: [Any], callback: @escaping (FunctionCallResult) -> ()) {
     do {
       let result = try call(by: owner, withArguments: args)
-      callback(.success(result))
+      callback(.success(Conversions.convertFunctionResult(result)))
     } catch let error as Exception {
       callback(.failure(error))
     } catch {
@@ -70,7 +70,8 @@ public final class SyncFunctionComponent<Args, FirstArgType, ReturnType>: AnySyn
         forFunction: self
       )
       let argumentsTuple = try Conversions.toTuple(arguments) as! Args
-      return try body(argumentsTuple)
+      let result = try body(argumentsTuple)
+      return Conversions.convertFunctionResult(result)
     } catch let error as Exception {
       throw FunctionCallException(name).causedBy(error)
     } catch {
@@ -85,7 +86,8 @@ public final class SyncFunctionComponent<Args, FirstArgType, ReturnType>: AnySyn
       guard let self = self else {
         throw NativeFunctionUnavailableException(name)
       }
-      return try self.call(by: this, withArguments: args)
+      let result = try self.call(by: this, withArguments: args)
+      return Conversions.convertFunctionResult(result)
     }
   }
 }

--- a/packages/expo-modules-core/ios/Tests/FunctionSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/FunctionSpec.swift
@@ -80,7 +80,7 @@ class FunctionSpec: ExpoSpec {
         .callSync(function: functionName, args: [array])
       }
 
-      describe("converting dicts to records") {
+      describe("converting records") {
         struct TestRecord: Record {
           @Field var property: String = "expo"
           @Field var optionalProperty: Int?
@@ -126,11 +126,20 @@ class FunctionSpec: ExpoSpec {
           }
         }
 
-        it("returns the record back") {
+        it("returns the record back (sync)") {
+          let result = try Function(functionName) { (record: TestRecord) in record }
+            .call(by: nil, withArguments: [dict]) as? TestRecord.Dict
+
+          expect(result).notTo(beNil())
+          expect(result?["property"] as? String).to(equal(dict["property"]))
+          expect(result?["propertyWithCustomKey"] as? String).to(equal(dict["propertyWithCustomKey"]))
+        }
+
+        it("returns the record back (async)") {
           waitUntil { done in
             mockModuleHolder(appContext) {
               AsyncFunction(functionName) { (a: TestRecord) in
-                return a.toDictionary()
+                return a
               }
             }
             .call(function: functionName, args: [dict]) { result in


### PR DESCRIPTION
# Why

Currently it is possible to return a record on Android and it will be automatically unpacked and returned to JS as a dictionary.
On iOS, however, it's not possible, or rather, it returns `null` to JS.

# How

- Added a function for converting function results
- Added conversion to AsyncFunction and Function
- Added a new test

# Test Plan

Native unit test is passing
