### PR TITLE
[modules][ios] Implicitly capture `self` in all DSL components

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Experimental support for Fabric on Android. ([#18541](https://github.com/expo/expo/pull/18541) by [@kudo](https://github.com/kudo))
 - Add option to generate a `coalescingKey` in callback on Android. ([#18774](https://github.com/expo/expo/pull/18774) by [@lukmccall](https://github.com/lukmccall))
 - Automatically convert records to dicts when returned by the function. ([#18824](https://github.com/expo/expo/pull/18824) by [@tsapeta](https://github.com/tsapeta))
+- Closures passed to definition components are now implicitly capturing `self` on iOS.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Experimental support for Fabric on Android. ([#18541](https://github.com/expo/expo/pull/18541) by [@kudo](https://github.com/kudo))
 - Add option to generate a `coalescingKey` in callback on Android. ([#18774](https://github.com/expo/expo/pull/18774) by [@lukmccall](https://github.com/lukmccall))
 - Automatically convert records to dicts when returned by the function. ([#18824](https://github.com/expo/expo/pull/18824) by [@tsapeta](https://github.com/tsapeta))
-- Closures passed to definition components are now implicitly capturing `self` on iOS.
+- Closures passed to definition components are now implicitly capturing `self` on iOS. ([#18831](https://github.com/expo/expo/pull/18831) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/Swift/Classes/ClassComponentFactories.swift
+++ b/packages/expo-modules-core/ios/Swift/Classes/ClassComponentFactories.swift
@@ -4,7 +4,7 @@
  Class constructor without arguments.
  */
 public func Constructor<R>(
-  _ body: @escaping () throws -> R
+  @_implicitSelfCapture _ body: @escaping () throws -> R
 ) -> SyncFunctionComponent<(), Void, R> {
   return Function("constructor", body)
 }
@@ -13,7 +13,7 @@ public func Constructor<R>(
  Class constructor with one argument.
  */
 public func Constructor<R, A0: AnyArgument>(
-  _ body: @escaping (A0) throws -> R
+  @_implicitSelfCapture _ body: @escaping (A0) throws -> R
 ) -> SyncFunctionComponent<(A0), A0, R> {
   return Function("constructor", body)
 }
@@ -22,7 +22,7 @@ public func Constructor<R, A0: AnyArgument>(
  Class constructor with two arguments.
  */
 public func Constructor<R, A0: AnyArgument, A1: AnyArgument>(
-  _ body: @escaping (A0, A1) throws -> R
+  @_implicitSelfCapture _ body: @escaping (A0, A1) throws -> R
 ) -> SyncFunctionComponent<(A0, A1), A0, R> {
   return Function("constructor", body)
 }
@@ -31,7 +31,7 @@ public func Constructor<R, A0: AnyArgument, A1: AnyArgument>(
  Class constructor with three arguments.
  */
 public func Constructor<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument>(
-  _ body: @escaping (A0, A1, A2) throws -> R
+  @_implicitSelfCapture _ body: @escaping (A0, A1, A2) throws -> R
 ) -> SyncFunctionComponent<(A0, A1, A2), A0, R> {
   return Function("constructor", body)
 }
@@ -40,7 +40,7 @@ public func Constructor<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument>(
  Class constructor with four arguments.
  */
 public func Constructor<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument>(
-  _ body: @escaping (A0, A1, A2, A3) throws -> R
+  @_implicitSelfCapture _ body: @escaping (A0, A1, A2, A3) throws -> R
 ) -> SyncFunctionComponent<(A0, A1, A2, A3), A0, R> {
   return Function("constructor", body)
 }
@@ -49,7 +49,7 @@ public func Constructor<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3
  Class constructor with five arguments.
  */
 public func Constructor<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument, A4: AnyArgument>(
-  _ body: @escaping (A0, A1, A2, A3, A4) throws -> R
+  @_implicitSelfCapture _ body: @escaping (A0, A1, A2, A3, A4) throws -> R
 ) -> SyncFunctionComponent<(A0, A1, A2, A3, A4), A0, R> {
   return Function("constructor", body)
 }
@@ -58,7 +58,7 @@ public func Constructor<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3
  Class constructor with six arguments.
  */
 public func Constructor<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument, A4: AnyArgument, A5: AnyArgument>(
-  _ body: @escaping (A0, A1, A2, A3, A4, A5) throws -> R
+  @_implicitSelfCapture _ body: @escaping (A0, A1, A2, A3, A4, A5) throws -> R
 ) -> SyncFunctionComponent<(A0, A1, A2, A3, A4, A5), A0, R> {
   return Function("constructor", body)
 }
@@ -68,7 +68,7 @@ public func Constructor<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3
  */
 public func Class(
   _ name: String,
-  @ClassComponentElementsBuilder<JavaScriptObject> _ elements: () -> [AnyClassComponentElement]
+  @ClassComponentElementsBuilder<JavaScriptObject> @_implicitSelfCapture _ elements: () -> [AnyClassComponentElement]
 ) -> ClassComponent {
   return ClassComponent(name: name, associatedType: JavaScriptObject.self, elements: elements())
 }
@@ -79,7 +79,7 @@ public func Class(
 public func Class<SharedObjectType: SharedObject>(
   _ name: String = String(describing: SharedObjectType.self),
   _ sharedObjectType: SharedObjectType.Type,
-  @ClassComponentElementsBuilder<SharedObjectType> _ elements: () -> [AnyClassComponentElement]
+  @ClassComponentElementsBuilder<SharedObjectType> @_implicitSelfCapture _ elements: () -> [AnyClassComponentElement]
 ) -> ClassComponent {
   return ClassComponent(name: name, associatedType: SharedObjectType.self, elements: elements())
 }
@@ -90,7 +90,7 @@ public func Class<SharedObjectType: SharedObject>(
  */
 public func Class<SharedObjectType: SharedObject>(
   _ sharedObjectType: SharedObjectType.Type,
-  @ClassComponentElementsBuilder<SharedObjectType> _ elements: () -> [AnyClassComponentElement]
+  @ClassComponentElementsBuilder<SharedObjectType> @_implicitSelfCapture _ elements: () -> [AnyClassComponentElement]
 ) -> ClassComponent {
   return ClassComponent(name: String(describing: SharedObjectType.self), associatedType: SharedObjectType.self, elements: elements())
 }

--- a/packages/expo-modules-core/ios/Swift/Functions/AsyncFunctionComponent.swift
+++ b/packages/expo-modules-core/ios/Swift/Functions/AsyncFunctionComponent.swift
@@ -154,7 +154,7 @@ internal final class NativeFunctionUnavailableException: GenericException<String
  */
 public func AsyncFunction<R>(
   _ name: String,
-  _ closure: @escaping () throws -> R
+  @_implicitSelfCapture _ closure: @escaping () throws -> R
 ) -> AsyncFunctionComponent<(), Void, R> {
   return AsyncFunctionComponent(
     name,
@@ -169,7 +169,7 @@ public func AsyncFunction<R>(
  */
 public func AsyncFunction<R, A0: AnyArgument>(
   _ name: String,
-  _ closure: @escaping (A0) throws -> R
+  @_implicitSelfCapture _ closure: @escaping (A0) throws -> R
 ) -> AsyncFunctionComponent<(A0), A0, R> {
   return AsyncFunctionComponent(
     name,
@@ -184,7 +184,7 @@ public func AsyncFunction<R, A0: AnyArgument>(
  */
 public func AsyncFunction<R, A0: AnyArgument, A1: AnyArgument>(
   _ name: String,
-  _ closure: @escaping (A0, A1) throws -> R
+  @_implicitSelfCapture _ closure: @escaping (A0, A1) throws -> R
 ) -> AsyncFunctionComponent<(A0, A1), A0, R> {
   return AsyncFunctionComponent(
     name,
@@ -199,7 +199,7 @@ public func AsyncFunction<R, A0: AnyArgument, A1: AnyArgument>(
  */
 public func AsyncFunction<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument>(
   _ name: String,
-  _ closure: @escaping (A0, A1, A2) throws -> R
+  @_implicitSelfCapture _ closure: @escaping (A0, A1, A2) throws -> R
 ) -> AsyncFunctionComponent<(A0, A1, A2), A0, R> {
   return AsyncFunctionComponent(
     name,
@@ -218,7 +218,7 @@ public func AsyncFunction<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument>(
  */
 public func AsyncFunction<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument>(
   _ name: String,
-  _ closure: @escaping (A0, A1, A2, A3) throws -> R
+  @_implicitSelfCapture _ closure: @escaping (A0, A1, A2, A3) throws -> R
 ) -> AsyncFunctionComponent<(A0, A1, A2, A3), A0, R> {
   return AsyncFunctionComponent(
     name,
@@ -238,7 +238,7 @@ public func AsyncFunction<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, 
  */
 public func AsyncFunction<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument, A4: AnyArgument>(
   _ name: String,
-  _ closure: @escaping (A0, A1, A2, A3, A4) throws -> R
+  @_implicitSelfCapture _ closure: @escaping (A0, A1, A2, A3, A4) throws -> R
 ) -> AsyncFunctionComponent<(A0, A1, A2, A3, A4), A0, R> {
   return AsyncFunctionComponent(
     name,
@@ -259,7 +259,7 @@ public func AsyncFunction<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, 
  */
 public func AsyncFunction<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument, A4: AnyArgument, A5: AnyArgument>(
   _ name: String,
-  _ closure: @escaping (A0, A1, A2, A3, A4, A5) throws -> R
+  @_implicitSelfCapture _ closure: @escaping (A0, A1, A2, A3, A4, A5) throws -> R
 ) -> AsyncFunctionComponent<(A0, A1, A2, A3, A4, A5), A0, R> {
   return AsyncFunctionComponent(
     name,
@@ -281,7 +281,7 @@ public func AsyncFunction<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, 
  */
 public func AsyncFunction<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument, A4: AnyArgument, A5: AnyArgument, A6: AnyArgument>(
   _ name: String,
-  _ closure: @escaping (A0, A1, A2, A3, A4, A5, A6) throws -> R
+  @_implicitSelfCapture _ closure: @escaping (A0, A1, A2, A3, A4, A5, A6) throws -> R
 ) -> AsyncFunctionComponent<(A0, A1, A2, A3, A4, A5, A6), A0, R> {
   return AsyncFunctionComponent(
     name,
@@ -304,7 +304,7 @@ public func AsyncFunction<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, 
  */
 public func AsyncFunction<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument, A4: AnyArgument, A5: AnyArgument, A6: AnyArgument, A7: AnyArgument>(
   _ name: String,
-  _ closure: @escaping (A0, A1, A2, A3, A4, A5, A6, A7) throws -> R
+  @_implicitSelfCapture _ closure: @escaping (A0, A1, A2, A3, A4, A5, A6, A7) throws -> R
 ) -> AsyncFunctionComponent<(A0, A1, A2, A3, A4, A5, A6, A7), A0, R> {
   return AsyncFunctionComponent(
     name,

--- a/packages/expo-modules-core/ios/Swift/Functions/SyncFunctionComponent.swift
+++ b/packages/expo-modules-core/ios/Swift/Functions/SyncFunctionComponent.swift
@@ -97,7 +97,7 @@ public final class SyncFunctionComponent<Args, FirstArgType, ReturnType>: AnySyn
  */
 public func Function<R>(
   _ name: String,
-  _ closure: @escaping () throws -> R
+  @_implicitSelfCapture _ closure: @escaping () throws -> R
 ) -> SyncFunctionComponent<(), Void, R> {
   return SyncFunctionComponent(
     name,
@@ -112,7 +112,7 @@ public func Function<R>(
  */
 public func Function<R, A0: AnyArgument>(
   _ name: String,
-  _ closure: @escaping (A0) throws -> R
+  @_implicitSelfCapture _ closure: @escaping (A0) throws -> R
 ) -> SyncFunctionComponent<(A0), A0, R> {
   return SyncFunctionComponent(
     name,
@@ -127,7 +127,7 @@ public func Function<R, A0: AnyArgument>(
  */
 public func Function<R, A0: AnyArgument, A1: AnyArgument>(
   _ name: String,
-  _ closure: @escaping (A0, A1) throws -> R
+  @_implicitSelfCapture _ closure: @escaping (A0, A1) throws -> R
 ) -> SyncFunctionComponent<(A0, A1), A0, R> {
   return SyncFunctionComponent(
     name,
@@ -142,7 +142,7 @@ public func Function<R, A0: AnyArgument, A1: AnyArgument>(
  */
 public func Function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument>(
   _ name: String,
-  _ closure: @escaping (A0, A1, A2) throws -> R
+  @_implicitSelfCapture _ closure: @escaping (A0, A1, A2) throws -> R
 ) -> SyncFunctionComponent<(A0, A1, A2), A0, R> {
   return SyncFunctionComponent(
     name,
@@ -161,7 +161,7 @@ public func Function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument>(
  */
 public func Function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument>(
   _ name: String,
-  _ closure: @escaping (A0, A1, A2, A3) throws -> R
+  @_implicitSelfCapture _ closure: @escaping (A0, A1, A2, A3) throws -> R
 ) -> SyncFunctionComponent<(A0, A1, A2, A3), A0, R> {
   return SyncFunctionComponent(
     name,
@@ -181,7 +181,7 @@ public func Function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: A
  */
 public func Function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument, A4: AnyArgument>(
   _ name: String,
-  _ closure: @escaping (A0, A1, A2, A3, A4) throws -> R
+  @_implicitSelfCapture _ closure: @escaping (A0, A1, A2, A3, A4) throws -> R
 ) -> SyncFunctionComponent<(A0, A1, A2, A3, A4), A0, R> {
   return SyncFunctionComponent(
     name,
@@ -202,7 +202,7 @@ public func Function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: A
  */
 public func Function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument, A4: AnyArgument, A5: AnyArgument>(
   _ name: String,
-  _ closure: @escaping (A0, A1, A2, A3, A4, A5) throws -> R
+  @_implicitSelfCapture _ closure: @escaping (A0, A1, A2, A3, A4, A5) throws -> R
 ) -> SyncFunctionComponent<(A0, A1, A2, A3, A4, A5), A0, R> {
   return SyncFunctionComponent(
     name,
@@ -224,7 +224,7 @@ public func Function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: A
  */
 public func Function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument, A4: AnyArgument, A5: AnyArgument, A6: AnyArgument>(
   _ name: String,
-  _ closure: @escaping (A0, A1, A2, A3, A4, A5, A6) throws -> R
+  @_implicitSelfCapture _ closure: @escaping (A0, A1, A2, A3, A4, A5, A6) throws -> R
 ) -> SyncFunctionComponent<(A0, A1, A2, A3, A4, A5, A6), A0, R> {
   return SyncFunctionComponent(
     name,
@@ -247,7 +247,7 @@ public func Function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: A
  */
 public func Function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument, A4: AnyArgument, A5: AnyArgument, A6: AnyArgument, A7: AnyArgument>(
   _ name: String,
-  _ closure: @escaping (A0, A1, A2, A3, A4, A5, A6, A7) throws -> R
+  @_implicitSelfCapture _ closure: @escaping (A0, A1, A2, A3, A4, A5, A6, A7) throws -> R
 ) -> SyncFunctionComponent<(A0, A1, A2, A3, A4, A5, A6, A7), A0, R> {
   return SyncFunctionComponent(
     name,

--- a/packages/expo-modules-core/ios/Swift/Modules/ModuleDefinitionComponents.swift
+++ b/packages/expo-modules-core/ios/Swift/Modules/ModuleDefinitionComponents.swift
@@ -92,42 +92,42 @@ public func Name(_ name: String) -> AnyDefinition {
 /**
  Creates module's lifecycle listener that is called right after module initialization.
  */
-public func OnCreate(_ closure: @escaping () -> Void) -> AnyDefinition {
+public func OnCreate(@_implicitSelfCapture _ closure: @escaping () -> Void) -> AnyDefinition {
   return EventListener(.moduleCreate, closure)
 }
 
 /**
  Creates module's lifecycle listener that is called when the module is about to be deallocated.
  */
-public func OnDestroy(_ closure: @escaping () -> Void) -> AnyDefinition {
+public func OnDestroy(@_implicitSelfCapture _ closure: @escaping () -> Void) -> AnyDefinition {
   return EventListener(.moduleDestroy, closure)
 }
 
 /**
  Creates module's lifecycle listener that is called when the app context owning the module is about to be deallocated.
  */
-public func OnAppContextDestroys(_ closure: @escaping () -> Void) -> AnyDefinition {
+public func OnAppContextDestroys(@_implicitSelfCapture _ closure: @escaping () -> Void) -> AnyDefinition {
   return EventListener(.appContextDestroys, closure)
 }
 
 /**
  Creates a listener that is called when the app is about to enter the foreground mode.
  */
-public func OnAppEntersForeground(_ closure: @escaping () -> Void) -> AnyDefinition {
+public func OnAppEntersForeground(@_implicitSelfCapture _ closure: @escaping () -> Void) -> AnyDefinition {
   return EventListener(.appEntersForeground, closure)
 }
 
 /**
  Creates a listener that is called when the app becomes active again.
  */
-public func OnAppBecomesActive(_ closure: @escaping () -> Void) -> AnyDefinition {
+public func OnAppBecomesActive(@_implicitSelfCapture _ closure: @escaping () -> Void) -> AnyDefinition {
   return EventListener(.appBecomesActive, closure)
 }
 
 /**
  Creates a listener that is called when the app enters the background mode.
  */
-public func OnAppEntersBackground(_ closure: @escaping () -> Void) -> AnyDefinition {
+public func OnAppEntersBackground(@_implicitSelfCapture _ closure: @escaping () -> Void) -> AnyDefinition {
   return EventListener(.appEntersBackground, closure)
 }
 

--- a/packages/expo-modules-core/ios/Swift/Objects/ObjectDefinitionComponents.swift
+++ b/packages/expo-modules-core/ios/Swift/Objects/ObjectDefinitionComponents.swift
@@ -14,7 +14,7 @@ public func constants(_ body: @escaping () -> [String: Any?]) -> AnyDefinition {
 /**
  Definition function setting the module's constants to export.
  */
-public func Constants(_ body: @escaping () -> [String: Any?]) -> AnyDefinition {
+public func Constants(@_implicitSelfCapture _ body: @escaping () -> [String: Any?]) -> AnyDefinition {
   return ConstantsDefinition(body: body)
 }
 
@@ -29,7 +29,7 @@ public func constants(_ body: @autoclosure @escaping () -> [String: Any?]) -> An
 /**
  Definition function setting the module's constants to export.
  */
-public func Constants(_ body: @autoclosure @escaping () -> [String: Any?]) -> AnyDefinition {
+public func Constants(@_implicitSelfCapture _ body: @autoclosure @escaping () -> [String: Any?]) -> AnyDefinition {
   return ConstantsDefinition(body: body)
 }
 
@@ -246,7 +246,7 @@ public func onStartObserving(_ body: @escaping () -> Void) -> AsyncFunctionCompo
 /**
  Function that is invoked when the first event listener is added.
  */
-public func OnStartObserving(_ body: @escaping () -> Void) -> AsyncFunctionComponent<(), Void, Void> {
+public func OnStartObserving(@_implicitSelfCapture _ body: @escaping () -> Void) -> AsyncFunctionComponent<(), Void, Void> {
   return AsyncFunctionComponent("startObserving", firstArgType: Void.self, dynamicArgumentTypes: [], body)
 }
 
@@ -261,6 +261,6 @@ public func onStopObserving(_ body: @escaping () -> Void) -> AsyncFunctionCompon
 /**
  Function that is invoked when all event listeners are removed.
  */
-public func OnStopObserving(_ body: @escaping () -> Void) -> AsyncFunctionComponent<(), Void, Void> {
+public func OnStopObserving(@_implicitSelfCapture _ body: @escaping () -> Void) -> AsyncFunctionComponent<(), Void, Void> {
   return AsyncFunctionComponent("stopObserving", firstArgType: Void.self, dynamicArgumentTypes: [], body)
 }

--- a/packages/expo-modules-core/ios/Swift/Objects/PropertyComponent.swift
+++ b/packages/expo-modules-core/ios/Swift/Objects/PropertyComponent.swift
@@ -135,13 +135,16 @@ public func Property(_ name: String) -> PropertyComponent {
 /**
  Creates the read-only property whose getter doesn't take the caller as an argument.
  */
-public func Property<Value: AnyArgument>(_ name: String, get: @escaping () -> Value) -> PropertyComponent {
+public func Property<Value: AnyArgument>(_ name: String, @_implicitSelfCapture get: @escaping () -> Value) -> PropertyComponent {
   return PropertyComponent(name: name).get(get)
 }
 
 /**
  Creates the read-only property whose getter takes the caller as an argument.
  */
-public func Property<Value: AnyArgument, Caller>(_ name: String, get: @escaping (Caller) -> Value) -> PropertyComponent {
+public func Property<Value: AnyArgument, Caller>(
+  _ name: String,
+  @_implicitSelfCapture get: @escaping (Caller) -> Value
+) -> PropertyComponent {
   return PropertyComponent(name: name).get(get)
 }

--- a/packages/expo-modules-core/ios/Swift/Views/ViewManagerDefinitionComponents.swift
+++ b/packages/expo-modules-core/ios/Swift/Views/ViewManagerDefinitionComponents.swift
@@ -39,7 +39,7 @@ public func prop<ViewType: UIView, PropType: AnyArgument>(
  */
 public func Prop<ViewType: UIView, PropType: AnyArgument>(
   _ name: String,
-  _ setter: @escaping (ViewType, PropType) -> Void
+  @_implicitSelfCapture _ setter: @escaping (ViewType, PropType) -> Void
 ) -> ConcreteViewProp<ViewType, PropType> {
   return ConcreteViewProp(
     name: name,


### PR DESCRIPTION
# Why

It's a bit annoying when we have to explicitly use `self` to capture it in closures passed to definition components, so it would be a nice addition if the user can omit it.
Swift has [`@_implicitSelfCapture`](https://github.com/apple/swift/blob/main/docs/ReferenceGuides/UnderscoredAttributes.md#_implicitselfcapture) attribute that we could use for this.
The requirement for explicit `self` was made to help prevent users from inadvertently creating retain cycles, but it's not the case in our code because `self` is already an owner of these definition components.
There is some risk in using it, since it's an internal underscored and undocumented attribute, but many underscored attributes later become an official attribute. For example `@_functionBuilder` became public as `@resultBuilder` and the old one still works fine.
The attribute is also listed [here](https://github.com/apple/swift/blob/329d5846bccf8b7d94a9eca2568ced3d354ce7cc/include/swift/Basic/Features.def#L78) as a language feature (not experimental).

I'm wondering what are your thoughts on that?

# How

Added `@_implicitSelfCapture` to all definition components that take a closure as an argument.

# Test Plan

It compiles and seem to work fine — I was able to remove all `self`s from the CameraViewModule.