### PR TITLE
[core] Fix androidTest build error

### DIFF
--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -42,7 +42,7 @@ buildscript {
 def isAndroidTest() {
   Gradle gradle = getGradle()
   String tskReqStr = gradle.getStartParameter().getTaskRequests().toString()
-  if (tskReqStr =~ /:expo-modules-core:connected\w+AndroidTest/) {
+  if (tskReqStr =~ /:expo-modules-core:connected\w*AndroidTest/) {
     def androidTests = project.file("src/androidTest")
     return androidTests.exists() && androidTests.isDirectory()
   }


### PR DESCRIPTION
# Why

fix https://github.com/expo/expo/runs/8010466191?check_suite_focus=true

# How

the command we executed for test is `:expo-modules-core:connectedAndroidTest`. this pr fixes the regular expression.

# Test Plan

android instrumented ci passed: https://github.com/expo/expo/runs/8020966246?check_suite_focus=true

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
