### PR TITLE
[docs] add subgroups to React Native section

### DIFF
--- a/docs/constants/navigation-deprecated.js
+++ b/docs/constants/navigation-deprecated.js
@@ -399,16 +399,7 @@ const reference = VERSIONS.reduce(
       makeSection('Expo SDK', [makeGroup('Expo SDK', pagesFromDir(`versions/${version}/sdk`))], {
         expanded: true,
       }),
-      makeSection(
-        'React Native',
-        [
-          makeGroup(
-            'React Native',
-            sortLegacyReactNative(pagesFromDir(`versions/${version}/react-native`))
-          ),
-        ],
-        { expanded: true }
-      ),
+      makeSection('React Native', sortLegacyReactNative(version), { expanded: true }),
     ],
   }),
   {}
@@ -511,30 +502,10 @@ function sortAlphabetical(pages) {
 /**
  * Sort the list of React Native pages by legacy custom sorting.
  */
-function sortLegacyReactNative(pages) {
-  const order = [
-    'Learn the Basics',
-    'Props',
-    'State',
-    'Style',
-    'Height and Width',
-    'Layout with Flexbox',
-    'Handling Text Input',
-    'Handling Touches',
-    'Using a ScrollView',
-    'Using List Views',
-    'Networking',
-    'Platform Specific Code',
-    'Navigating Between Screens',
-    'Images',
-    'Animations',
-    'Accessibility',
-    'Timers',
-    'Performance',
-    'Gesture Responder System',
-    'JavaScript Environment',
-    'Direct Manipulation',
-    'Color Reference',
+function sortLegacyReactNative(version) {
+  const pages = pagesFromDir(`versions/${version}/react-native`);
+
+  const components = [
     'ActivityIndicator',
     'Button',
     'DatePickerIOS',
@@ -574,6 +545,9 @@ function sortLegacyReactNative(pages) {
     'ViewPagerAndroid',
     'VirtualizedList',
     'WebView',
+  ];
+
+  const apis = [
     'AccessibilityInfo',
     'ActionSheetIOS',
     'Alert',
@@ -587,34 +561,46 @@ function sortLegacyReactNative(pages) {
     'DatePickerAndroid',
     'Dimensions',
     'Easing',
-    'Image Style Props',
     'ImageStore',
     'InteractionManager',
     'Keyboard',
-    'Layout Props',
     'LayoutAnimation',
     'ListViewDataSource',
     'NetInfo',
     'PanResponder',
     'PixelRatio',
     'Settings',
-    'Shadow Props',
     'Share',
     'StatusBarIOS',
     'StyleSheet',
     'Systrace',
-    'Text Style Props',
     'TimePickerAndroid',
     'ToastAndroid',
     'Transforms',
     'Vibration',
     'VibrationIOS',
+  ];
+
+  const props = [
+    'Image Style Props',
+    'Layout Props',
+    'Shadow Props',
+    'Text Style Props',
     'View Style Props',
   ];
 
-  return pages.sort((a, b) => {
-    const aIndex = order.indexOf(a.name);
-    const bIndex = order.indexOf(b.name);
-    return aIndex < 0 || bIndex < 0 ? bIndex - aIndex : aIndex - bIndex;
-  });
+  return [
+    makeGroup(
+      'Components',
+      pages.filter(page => components.includes(page.name))
+    ),
+    makeGroup(
+      'APIs',
+      pages.filter(page => apis.includes(page.name))
+    ),
+    makeGroup(
+      'Props',
+      pages.filter(page => props.includes(page.name))
+    ),
+  ];
 }

--- a/docs/constants/navigation-deprecated.js
+++ b/docs/constants/navigation-deprecated.js
@@ -512,6 +512,7 @@ function sortLegacyReactNative(version) {
     'DrawerLayoutAndroid',
     'FlatList',
     'Image',
+    'ImageBackground',
     'InputAccessoryView',
     'KeyboardAvoidingView',
     'ListView',
@@ -520,6 +521,7 @@ function sortLegacyReactNative(version) {
     'NavigatorIOS',
     'Picker',
     'PickerIOS',
+    'Pressable',
     'ProgressBarAndroid',
     'ProgressViewIOS',
     'RefreshControl',
@@ -553,6 +555,9 @@ function sortLegacyReactNative(version) {
     'Alert',
     'AlertIOS',
     'Animated',
+    'Animated.Value',
+    'Animated.ValueXY',
+    'Appearance',
     'AppState',
     'AsyncStorage',
     'BackAndroid',
@@ -560,6 +565,7 @@ function sortLegacyReactNative(version) {
     'Clipboard',
     'DatePickerAndroid',
     'Dimensions',
+    'DynamicColorIOS',
     'Easing',
     'ImageStore',
     'InteractionManager',
@@ -569,6 +575,8 @@ function sortLegacyReactNative(version) {
     'NetInfo',
     'PanResponder',
     'PixelRatio',
+    'Platform',
+    'PlatformColor',
     'Settings',
     'Share',
     'StatusBarIOS',
@@ -581,6 +589,8 @@ function sortLegacyReactNative(version) {
     'VibrationIOS',
   ];
 
+  const hooks = ['useColorScheme', 'useWindowDimensions'];
+
   const props = [
     'Image Style Props',
     'Layout Props',
@@ -589,18 +599,34 @@ function sortLegacyReactNative(version) {
     'View Style Props',
   ];
 
+  const types = [
+    'LayoutEvent Object Type',
+    'PressEvent Object Type',
+    'React Node Object Type',
+    'Rect Object Type',
+    'ViewToken Object Type',
+  ];
+
   return [
     makeGroup(
       'Components',
       pages.filter(page => components.includes(page.name))
     ),
     makeGroup(
+      'Props',
+      pages.filter(page => props.includes(page.name))
+    ),
+    makeGroup(
       'APIs',
       pages.filter(page => apis.includes(page.name))
     ),
     makeGroup(
-      'Props',
-      pages.filter(page => props.includes(page.name))
+      'Hooks',
+      pages.filter(page => hooks.includes(page.name))
+    ),
+    makeGroup(
+      'Types',
+      pages.filter(page => types.includes(page.name))
     ),
   ];
 }

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -21,7 +21,7 @@ const easDirectories = [
   'eas-update',
   'eas-metadata',
 ];
-/** Manual list of directories to categorize as "Archive content" */
+/** Manual list of directories to categorize as "Archive" */
 const archiveDirectories = ['archive'];
 /** Private preview section which isn't linked in the documentation */
 const previewDirectories = ['preview'];
@@ -372,10 +372,7 @@ const reference = VERSIONS.reduce(
     [version]: [
       makeSection('Configuration Files', pagesFromDir(`versions/${version}/config`)),
       makeSection('Expo SDK', pagesFromDir(`versions/${version}/sdk`)),
-      makeSection(
-        'React Native',
-        sortLegacyReactNative(pagesFromDir(`versions/${version}/react-native`))
-      ),
+      makeSection('React Native', sortLegacyReactNative(version), { expanded: true }),
     ],
   }),
   {}
@@ -481,30 +478,10 @@ function sortAlphabetical(pages) {
 /**
  * Sort the list of React Native pages by legacy custom sorting.
  */
-function sortLegacyReactNative(pages) {
-  const order = [
-    'Learn the Basics',
-    'Props',
-    'State',
-    'Style',
-    'Height and Width',
-    'Layout with Flexbox',
-    'Handling Text Input',
-    'Handling Touches',
-    'Using a ScrollView',
-    'Using List Views',
-    'Networking',
-    'Platform Specific Code',
-    'Navigating Between Screens',
-    'Images',
-    'Animations',
-    'Accessibility',
-    'Timers',
-    'Performance',
-    'Gesture Responder System',
-    'JavaScript Environment',
-    'Direct Manipulation',
-    'Color Reference',
+function sortLegacyReactNative(version) {
+  const pages = pagesFromDir(`versions/${version}/react-native`);
+
+  const components = [
     'ActivityIndicator',
     'Button',
     'DatePickerIOS',
@@ -544,6 +521,9 @@ function sortLegacyReactNative(pages) {
     'ViewPagerAndroid',
     'VirtualizedList',
     'WebView',
+  ];
+
+  const apis = [
     'AccessibilityInfo',
     'ActionSheetIOS',
     'Alert',
@@ -557,34 +537,46 @@ function sortLegacyReactNative(pages) {
     'DatePickerAndroid',
     'Dimensions',
     'Easing',
-    'Image Style Props',
     'ImageStore',
     'InteractionManager',
     'Keyboard',
-    'Layout Props',
     'LayoutAnimation',
     'ListViewDataSource',
     'NetInfo',
     'PanResponder',
     'PixelRatio',
     'Settings',
-    'Shadow Props',
     'Share',
     'StatusBarIOS',
     'StyleSheet',
     'Systrace',
-    'Text Style Props',
     'TimePickerAndroid',
     'ToastAndroid',
     'Transforms',
     'Vibration',
     'VibrationIOS',
+  ];
+
+  const props = [
+    'Image Style Props',
+    'Layout Props',
+    'Shadow Props',
+    'Text Style Props',
     'View Style Props',
   ];
 
-  return pages.sort((a, b) => {
-    const aIndex = order.indexOf(a.name);
-    const bIndex = order.indexOf(b.name);
-    return aIndex < 0 || bIndex < 0 ? bIndex - aIndex : aIndex - bIndex;
-  });
+  return [
+    makeGroup(
+      'Components',
+      pages.filter(page => components.includes(page.name))
+    ),
+    makeGroup(
+      'APIs',
+      pages.filter(page => apis.includes(page.name))
+    ),
+    makeGroup(
+      'Props',
+      pages.filter(page => props.includes(page.name))
+    ),
+  ];
 }

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -488,6 +488,7 @@ function sortLegacyReactNative(version) {
     'DrawerLayoutAndroid',
     'FlatList',
     'Image',
+    'ImageBackground',
     'InputAccessoryView',
     'KeyboardAvoidingView',
     'ListView',
@@ -496,6 +497,7 @@ function sortLegacyReactNative(version) {
     'NavigatorIOS',
     'Picker',
     'PickerIOS',
+    'Pressable',
     'ProgressBarAndroid',
     'ProgressViewIOS',
     'RefreshControl',
@@ -529,6 +531,9 @@ function sortLegacyReactNative(version) {
     'Alert',
     'AlertIOS',
     'Animated',
+    'Animated.Value',
+    'Animated.ValueXY',
+    'Appearance',
     'AppState',
     'AsyncStorage',
     'BackAndroid',
@@ -536,6 +541,7 @@ function sortLegacyReactNative(version) {
     'Clipboard',
     'DatePickerAndroid',
     'Dimensions',
+    'DynamicColorIOS',
     'Easing',
     'ImageStore',
     'InteractionManager',
@@ -545,6 +551,8 @@ function sortLegacyReactNative(version) {
     'NetInfo',
     'PanResponder',
     'PixelRatio',
+    'Platform',
+    'PlatformColor',
     'Settings',
     'Share',
     'StatusBarIOS',
@@ -557,6 +565,8 @@ function sortLegacyReactNative(version) {
     'VibrationIOS',
   ];
 
+  const hooks = ['useColorScheme', 'useWindowDimensions'];
+
   const props = [
     'Image Style Props',
     'Layout Props',
@@ -565,18 +575,34 @@ function sortLegacyReactNative(version) {
     'View Style Props',
   ];
 
+  const types = [
+    'LayoutEvent Object Type',
+    'PressEvent Object Type',
+    'React Node Object Type',
+    'Rect Object Type',
+    'ViewToken Object Type',
+  ];
+
   return [
     makeGroup(
       'Components',
       pages.filter(page => components.includes(page.name))
     ),
     makeGroup(
+      'Props',
+      pages.filter(page => props.includes(page.name))
+    ),
+    makeGroup(
       'APIs',
       pages.filter(page => apis.includes(page.name))
     ),
     makeGroup(
-      'Props',
-      pages.filter(page => props.includes(page.name))
+      'Hooks',
+      pages.filter(page => hooks.includes(page.name))
+    ),
+    makeGroup(
+      'Types',
+      pages.filter(page => types.includes(page.name))
     ),
   ];
 }


### PR DESCRIPTION
# Why

Let's mimic the React Native pages categorization in the sidebar.

# How

This PR add the "Components", "APIs" and "Props" groups for the "React Native" section in API Reference.

I have also removed several guides titles which seems to be no longer synced from React Native docs.

# Test Plan

The changes has been tested by running docs website locally.

### Preview

<img width="250" alt="Screenshot 2022-08-25 195855" src="https://user-images.githubusercontent.com/719641/186743453-042e1311-fea6-4437-8abd-6c0c1fd542f8.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
