### PR TITLE
[docs] adjust typography and text elements spacing

### DIFF
--- a/docs/components/__snapshots__/DocumentationSidebarRight.test.tsx.snap
+++ b/docs/components/__snapshots__/DocumentationSidebarRight.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`DocumentationSidebarRight correctly matches snapshot 1`] = `
     data-sidebar="true"
   >
     <a
-      class="css-10qhea3"
+      class="css-1fc6p3j"
       href="#base-level-heading"
       style="padding-left: 0px;"
     >
@@ -18,7 +18,7 @@ exports[`DocumentationSidebarRight correctly matches snapshot 1`] = `
       </span>
     </a>
     <a
-      class="css-1e15kg4"
+      class="css-1yg0875"
       href="#level-3-subheading"
       style="padding-left: 12px;"
     >
@@ -29,7 +29,7 @@ exports[`DocumentationSidebarRight correctly matches snapshot 1`] = `
       </span>
     </a>
     <a
-      class="css-1e15kg4"
+      class="css-1yg0875"
       href="#code-heading-depth-1"
       style="padding-left: 12px;"
     >

--- a/docs/components/base/code.tsx
+++ b/docs/components/base/code.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { theme, typography } from '@expo/styleguide';
+import { borderRadius, spacing, theme, typography } from '@expo/styleguide';
 import { Language, Prism } from 'prism-react-renderer';
 import * as React from 'react';
 import tippy, { roundArrow } from 'tippy.js';
@@ -13,10 +13,8 @@ const attributes = {
 };
 
 const STYLES_CODE_BLOCK = css`
+  ${typography.body.code};
   color: ${theme.text.default};
-  font-family: ${typography.fontFaces.mono};
-  font-size: 13px;
-  line-height: 20px;
   white-space: inherit;
   padding: 0;
   margin: 0;
@@ -44,19 +42,16 @@ const STYLES_CODE_BLOCK = css`
 `;
 
 const STYLES_INLINE_CODE = css`
+  ${typography.body.code};
   color: ${theme.text.default};
-  font-family: ${typography.fontFaces.mono};
-  font-size: 0.825em;
   white-space: pre-wrap;
   display: inline;
-  padding: 2px 4px;
-  line-height: 170%;
+  padding: ${spacing[0.5]}px ${spacing[1]}px;
   max-width: 100%;
-
   word-wrap: break-word;
   background-color: ${theme.background.secondary};
   border: 1px solid ${theme.border.default};
-  border-radius: 4px;
+  border-radius: ${borderRadius.small}px;
   vertical-align: middle;
   overflow-x: auto;
 

--- a/docs/components/base/code.tsx
+++ b/docs/components/base/code.tsx
@@ -64,6 +64,13 @@ const STYLES_INLINE_CODE = css`
   a & {
     border-color: ${theme.border.default};
   }
+
+  h2 &,
+  h3 &,
+  h4 & {
+    position: relative;
+    top: -2px;
+  }
 `;
 
 const STYLES_CODE_CONTAINER = css`

--- a/docs/components/base/headings.tsx
+++ b/docs/components/base/headings.tsx
@@ -12,7 +12,7 @@ const attributes = {
 
 const STYLES_H1 = css`
   ${h1}
-  margin-top: 0;
+  margin-top: ${spacing[2]}px;
   margin-bottom: ${spacing[6]}px;
   padding-bottom: ${spacing[4]}px;
   border-bottom: 1px solid ${theme.border.default};
@@ -26,7 +26,7 @@ export const H1 = ({ children }: HeadingProps) => (
 
 const STYLES_H2 = css`
   ${h2}
-  margin-bottom: ${spacing[4]}px;
+  margin-bottom: ${spacing[2]}px;
   margin-top: ${spacing[8]}px;
 
   code {
@@ -45,7 +45,7 @@ export const H2 = ({ children }: HeadingProps) => (
 
 const STYLES_H3 = css`
   ${h3}
-  margin-bottom: ${spacing[4]}px;
+  margin-bottom: ${spacing[1.5]}px;
   margin-top: ${spacing[6]}px;
 
   code {
@@ -64,8 +64,8 @@ export const H3 = ({ children }: HeadingProps) => (
 
 const STYLES_H4 = css`
   ${h4}
-  margin-top: ${spacing[3]}px;
-  margin-bottom: ${spacing[3]}px;
+  margin-top: ${spacing[6]}px;
+  margin-bottom: ${spacing[1]}px;
 
   code {
     ${h4}

--- a/docs/components/base/headings.tsx
+++ b/docs/components/base/headings.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { theme, typography } from '@expo/styleguide';
+import { theme, spacing, typography } from '@expo/styleguide';
 import * as React from 'react';
 
 import { h1, h2, h3, h4 } from './typography';
@@ -12,9 +12,9 @@ const attributes = {
 
 const STYLES_H1 = css`
   ${h1}
-  margin-top: 0.5rem;
-  margin-bottom: 1rem;
-  padding-bottom: 0.5rem;
+  margin-top: 0;
+  margin-bottom: ${spacing[6]}px;
+  padding-bottom: ${spacing[4]}px;
   border-bottom: 1px solid ${theme.border.default};
 `;
 
@@ -26,10 +26,8 @@ export const H1 = ({ children }: HeadingProps) => (
 
 const STYLES_H2 = css`
   ${h2}
-  margin-bottom: 1rem;
-  margin-top: 2rem;
-  padding-bottom: 0.25rem;
-  border-bottom: 1px solid ${theme.border.default};
+  margin-bottom: ${spacing[4]}px;
+  margin-top: ${spacing[8]}px;
 
   code {
     ${h2}
@@ -47,8 +45,8 @@ export const H2 = ({ children }: HeadingProps) => (
 
 const STYLES_H3 = css`
   ${h3}
-  margin-bottom: 1rem;
-  margin-top: 2rem;
+  margin-bottom: ${spacing[4]}px;
+  margin-top: ${spacing[6]}px;
 
   code {
     ${h3}
@@ -66,7 +64,8 @@ export const H3 = ({ children }: HeadingProps) => (
 
 const STYLES_H4 = css`
   ${h4}
-  margin-bottom: 0.25rem;
+  margin-top: ${spacing[3]}px;
+  margin-bottom: ${spacing[3]}px;
 
   code {
     ${h4}

--- a/docs/components/base/headings.tsx
+++ b/docs/components/base/headings.tsx
@@ -26,7 +26,7 @@ export const H1 = ({ children }: HeadingProps) => (
 
 const STYLES_H2 = css`
   ${h2}
-  margin-bottom: ${spacing[2]}px;
+  margin-bottom: ${spacing[3]}px;
   margin-top: ${spacing[8]}px;
 
   code {

--- a/docs/components/base/list.tsx
+++ b/docs/components/base/list.tsx
@@ -36,6 +36,7 @@ const STYLES_UNORDERED_LIST = css`
 const STYLES_NO_LIST_STYLE = css({
   listStyle: 'none',
   marginLeft: 0,
+  marginBottom: spacing[3],
 
   li: {
     marginLeft: '0.25rem',

--- a/docs/components/base/list.tsx
+++ b/docs/components/base/list.tsx
@@ -31,6 +31,11 @@ const STYLES_UNORDERED_LIST = css`
       margin-bottom: 0;
     }
   }
+
+  ol,
+  ul {
+    margin-left: ${spacing[1]}px;
+  }
 `;
 
 const STYLES_NO_LIST_STYLE = css({
@@ -55,14 +60,8 @@ export const UL = ({ children, hideBullets }: ULProps) => (
 
 // TODO(jim): Get anchors working properly for ordered lists.
 const STYLES_ORDERED_LIST = css`
-  ${paragraph}
+  ${STYLES_UNORDERED_LIST}
   list-style: decimal;
-  margin-left: 1rem;
-  margin-bottom: 1rem;
-
-  .anchor-icon {
-    display: none;
-  }
 `;
 
 type OLProps = React.PropsWithChildren<object>;
@@ -74,12 +73,13 @@ export const OL = ({ children }: OLProps) => (
 );
 
 const STYLES_LIST_ITEM = css`
-  margin-left: 1rem;
-  padding: 0.25rem 0;
+  margin-left: ${spacing[4]}px;
+  padding: ${spacing[1]}px 0;
+
   :before {
     font-size: 130%;
     line-height: 0;
-    margin: 0 0.5rem 0 -1rem;
+    margin: 0 ${spacing[2]}px 0 -${spacing[4]}px;
     position: relative;
     color: ${theme.text.default};
   }

--- a/docs/components/base/list.tsx
+++ b/docs/components/base/list.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { SerializedStyles } from '@emotion/serialize';
-import { theme } from '@expo/styleguide';
+import {spacing, theme } from '@expo/styleguide';
 import * as React from 'react';
 
 import { paragraph } from './typography';
@@ -12,8 +12,8 @@ const attributes = {
 const STYLES_UNORDERED_LIST = css`
   ${paragraph}
   list-style: disc;
-  margin-left: 1rem;
-  margin-bottom: 1rem;
+  margin-left: ${spacing[4]}px;
+  margin-bottom: ${spacing[6]}px;
 
   .anchor-icon {
     display: none;

--- a/docs/components/base/list.tsx
+++ b/docs/components/base/list.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { SerializedStyles } from '@emotion/serialize';
-import {spacing, theme } from '@expo/styleguide';
+import { spacing, theme } from '@expo/styleguide';
 import * as React from 'react';
 
 import { paragraph } from './typography';

--- a/docs/components/base/paragraph.tsx
+++ b/docs/components/base/paragraph.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { theme, typography, iconSize, InfoIcon, spacing } from '@expo/styleguide';
+import { theme, typography, iconSize, InfoIcon, spacing, borderRadius } from '@expo/styleguide';
 import emojiRegex from 'emoji-regex';
 import { Children, PropsWithChildren, ReactNode, BlockquoteHTMLAttributes } from 'react';
 
@@ -14,10 +14,6 @@ const attributes = {
 const STYLES_PARAGRAPH = css`
   ${paragraph}
   margin-bottom: ${spacing[4]}px;
-
-  & + ul {
-    margin-top: -${spacing[2]}px;
-  }
 `;
 
 export const P = ({ children }: PropsWithChildren<object>) => (
@@ -68,10 +64,10 @@ const STYLES_BLOCKQUOTE = css`
     grid-template-columns: auto 1fr;
     grid-gap: ${spacing[3]}px;
     padding: ${spacing[3]}px;
-    margin-bottom: ${spacing[8]}px;
+    margin-bottom: ${spacing[4]}px;
     border-left: 4px solid ${theme.border.default};
     background: ${theme.background.secondary};
-    border-radius: 4px;
+    border-radius: ${borderRadius.small};
 
     div {
       margin: 0;
@@ -83,7 +79,7 @@ const STYLES_BLOCKQUOTE = css`
   }
 
   table & {
-    margin: 0.5rem 0;
+    margin: ${spacing[2]}px 0;
 
     &:first-of-type {
       margin-top: 0;

--- a/docs/components/base/paragraph.tsx
+++ b/docs/components/base/paragraph.tsx
@@ -13,7 +13,7 @@ const attributes = {
 
 const STYLES_PARAGRAPH = css`
   ${paragraph}
-  margin-bottom: ${spacing[6]}px;
+  margin-bottom: ${spacing[4]}px;
 
   & + ul {
     margin-top: -${spacing[2]}px;

--- a/docs/components/base/paragraph.tsx
+++ b/docs/components/base/paragraph.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { theme, typography, iconSize, InfoIcon } from '@expo/styleguide';
+import { theme, typography, iconSize, InfoIcon, spacing } from '@expo/styleguide';
 import emojiRegex from 'emoji-regex';
 import { Children, PropsWithChildren, ReactNode, BlockquoteHTMLAttributes } from 'react';
 
@@ -13,7 +13,11 @@ const attributes = {
 
 const STYLES_PARAGRAPH = css`
   ${paragraph}
-  margin-bottom: 1rem;
+  margin-bottom: ${spacing[6]}px;
+
+  & + ul {
+    margin-top: -${spacing[2]}px;
+  }
 `;
 
 export const P = ({ children }: PropsWithChildren<object>) => (
@@ -23,10 +27,9 @@ export const P = ({ children }: PropsWithChildren<object>) => (
 );
 
 const STYLES_BOLD_PARAGRAPH = css`
-  ${paragraph}
+  ${STYLES_PARAGRAPH}
   font-size: inherit;
   font-family: ${typography.fontFaces.semiBold};
-  font-weight: 500;
 `;
 
 export const B = ({ children }: PropsWithChildren<object>) => (
@@ -34,9 +37,8 @@ export const B = ({ children }: PropsWithChildren<object>) => (
 );
 
 const STYLES_PARAGRAPH_DIV = css`
-  ${paragraph}
+  ${STYLES_PARAGRAPH}
   display: block;
-  margin-bottom: 1rem;
 
   &.is-wider {
     max-width: 1200px;
@@ -64,9 +66,9 @@ const STYLES_BLOCKQUOTE = css`
     ${paragraph}
     display: grid;
     grid-template-columns: auto 1fr;
-    grid-gap: 12px;
-    padding: 12px;
-    margin-bottom: 1rem;
+    grid-gap: ${spacing[3]}px;
+    padding: ${spacing[3]}px;
+    margin-bottom: ${spacing[8]}px;
     border-left: 4px solid ${theme.border.default};
     background: ${theme.background.secondary};
     border-radius: 4px;

--- a/docs/components/base/typography.tsx
+++ b/docs/components/base/typography.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import { theme, typography } from '@expo/styleguide';
 
 export const h1 = css({
-  ...typography.headers.default.huge,
+  ...typography.headers.default.h1,
   color: theme.text.default,
 });
 
@@ -22,6 +22,6 @@ export const h4 = css({
 });
 
 export const paragraph = css({
-  ...typography.fontSizes[16],
+  ...typography.body.paragraph,
   color: theme.text.default,
 });

--- a/docs/components/base/typography.tsx
+++ b/docs/components/base/typography.tsx
@@ -1,47 +1,27 @@
 import { css } from '@emotion/react';
 import { theme, typography } from '@expo/styleguide';
 
-export const h1 = css`
-  font-family: ${typography.fontFaces.semiBold};
-  color: ${theme.text.default};
-  font-size: 48px;
-  line-height: 120%;
-  letter-spacing: -0.022em;
-  font-weight: 500;
-`;
+export const h1 = css({
+  ...typography.headers.default.huge,
+  color: theme.text.default,
+});
 
-export const h2 = css`
-  font-family: ${typography.fontFaces.medium};
-  color: ${theme.text.default};
-  font-size: 30px;
-  line-height: 130%;
-  letter-spacing: -0.021em;
-  font-weight: 500;
-`;
+export const h2 = css({
+  ...typography.headers.default.h2,
+  color: theme.text.default,
+});
 
-export const h3 = css`
-  font-family: ${typography.fontFaces.medium};
-  color: ${theme.text.default};
-  font-size: 24px;
-  line-height: 130%;
-  letter-spacing: -0.019em;
-  font-weight: 500;
-`;
+export const h3 = css({
+  ...typography.headers.default.h3,
+  color: theme.text.default,
+});
 
-export const h4 = css`
-  font-family: ${typography.fontFaces.semiBold};
-  color: ${theme.text.default};
-  font-size: 18px;
-  line-height: 140%;
-  letter-spacing: -0.01em;
-  font-weight: 500;
-`;
+export const h4 = css({
+  ...typography.headers.default.h4,
+  color: theme.text.default,
+});
 
-export const paragraph = css`
-  font-family: ${typography.fontFaces.regular};
-  color: ${theme.text.default};
-  font-weight: 400;
-  font-size: 16px;
-  line-height: 160%;
-  letter-spacing: -0.011em;
-`;
+export const paragraph = css({
+  ...typography.fontSizes[16],
+  color: theme.text.default,
+});

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`APISection expo-apple-authentication 1`] = `
 <div>
   <h2
-    class="css-wpfbxc-H2"
+    class="css-1ck3d9a-H2"
     data-heading="true"
   >
     <div
@@ -75,7 +75,7 @@ exports[`APISection expo-apple-authentication 1`] = `
             class="css-6n7j50"
           >
             <code
-              class="inline css-10jm9cu-InlineCode"
+              class="inline css-ov7own-InlineCode"
             >
               AppleAuthenticationButton
             </code>
@@ -112,17 +112,17 @@ exports[`APISection expo-apple-authentication 1`] = `
       </div>
     </h3>
     <p
-      class="css-gvfsz4-P"
+      class="css-6jxvia-P"
       data-text="true"
     >
       <strong
-        class="css-cyicbq-B"
+        class="css-1qx481h-B"
       >
         Type:
       </strong>
        
       <code
-        class="inline css-10jm9cu-InlineCode"
+        class="inline css-ov7own-InlineCode"
       >
         React.FC
         &lt;
@@ -138,7 +138,7 @@ exports[`APISection expo-apple-authentication 1`] = `
       </code>
     </p>
     <p
-      class="css-gvfsz4-P"
+      class="css-6jxvia-P"
       data-text="true"
     >
       This component displays the proprietary "Sign In with Apple" / "Continue with Apple" button on
@@ -147,7 +147,7 @@ authentication process instead of a custom button. Limited customization of the 
 available via the provided properties.
     </p>
     <p
-      class="css-gvfsz4-P"
+      class="css-6jxvia-P"
       data-text="true"
     >
       You should only attempt to render this if 
@@ -156,7 +156,7 @@ available via the provided properties.
         href="/#isavailableasync"
       >
         <code
-          class="inline css-10jm9cu-InlineCode"
+          class="inline css-ov7own-InlineCode"
         >
           AppleAuthentication.isAvailableAsync()
         </code>
@@ -164,14 +164,14 @@ available via the provided properties.
       
 resolves to 
       <code
-        class="inline css-10jm9cu-InlineCode"
+        class="inline css-ov7own-InlineCode"
       >
         true
       </code>
       . This component will render nothing if it is not available, and you will get
 a warning in development mode (
       <code
-        class="inline css-10jm9cu-InlineCode"
+        class="inline css-ov7own-InlineCode"
       >
         __DEV__ === true
       </code>
@@ -180,45 +180,45 @@ a warning in development mode (
     
 
     <p
-      class="css-gvfsz4-P"
+      class="css-6jxvia-P"
       data-text="true"
     >
       The properties of this component extend from 
       <code
-        class="inline css-10jm9cu-InlineCode"
+        class="inline css-ov7own-InlineCode"
       >
         View
       </code>
       ; however, you should not attempt to set
 
       <code
-        class="inline css-10jm9cu-InlineCode"
+        class="inline css-ov7own-InlineCode"
       >
         backgroundColor
       </code>
        or 
       <code
-        class="inline css-10jm9cu-InlineCode"
+        class="inline css-ov7own-InlineCode"
       >
         borderRadius
       </code>
        with the 
       <code
-        class="inline css-10jm9cu-InlineCode"
+        class="inline css-ov7own-InlineCode"
       >
         style
       </code>
        property. This will not work and is against
 the App Store Guidelines. Instead, you should use the 
       <code
-        class="inline css-10jm9cu-InlineCode"
+        class="inline css-ov7own-InlineCode"
       >
         buttonStyle
       </code>
        property to choose one of the
 predefined color styles and the 
       <code
-        class="inline css-10jm9cu-InlineCode"
+        class="inline css-ov7own-InlineCode"
       >
         cornerRadius
       </code>
@@ -228,14 +228,14 @@ button.
     
 
     <p
-      class="css-gvfsz4-P"
+      class="css-6jxvia-P"
       data-text="true"
     >
       Make sure to attach height and width via the style props as without these styles, the button will
 not appear on the screen.
     </p>
     <blockquote
-      class="css-y2d7cg-Quote"
+      class="css-1nn217x-Quote"
       data-text="true"
     >
       <div
@@ -260,7 +260,7 @@ not appear on the screen.
       </div>
       <div>
         <strong
-          class="css-cyicbq-B"
+          class="css-1qx481h-B"
         >
           See: 
         </strong>
@@ -279,7 +279,7 @@ for more details.
       </div>
     </blockquote>
     <h2
-      class="css-wpfbxc-H2"
+      class="css-1ck3d9a-H2"
       data-heading="true"
     >
       <div
@@ -352,7 +352,7 @@ for more details.
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-tu4dab-InlineCode"
+                  class="inline css-1pk617c-InlineCode"
                 >
                   buttonStyle
                 </code>
@@ -389,7 +389,7 @@ for more details.
           </div>
         </h3>
         <p
-          class="css-gvfsz4-P"
+          class="css-6jxvia-P"
           data-text="true"
         >
           <span
@@ -399,7 +399,7 @@ for more details.
           </span>
            
           <code
-            class="inline css-10jm9cu-InlineCode"
+            class="inline css-ov7own-InlineCode"
           >
             <a
               class="css-153g748-InternalLink"
@@ -410,7 +410,7 @@ for more details.
           </code>
         </p>
         <p
-          class="css-gvfsz4-P"
+          class="css-6jxvia-P"
           data-text="true"
         >
           The Apple-defined color scheme to use to display the button.
@@ -438,7 +438,7 @@ for more details.
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-tu4dab-InlineCode"
+                  class="inline css-1pk617c-InlineCode"
                 >
                   buttonType
                 </code>
@@ -475,7 +475,7 @@ for more details.
           </div>
         </h3>
         <p
-          class="css-gvfsz4-P"
+          class="css-6jxvia-P"
           data-text="true"
         >
           <span
@@ -485,7 +485,7 @@ for more details.
           </span>
            
           <code
-            class="inline css-10jm9cu-InlineCode"
+            class="inline css-ov7own-InlineCode"
           >
             <a
               class="css-153g748-InternalLink"
@@ -496,7 +496,7 @@ for more details.
           </code>
         </p>
         <p
-          class="css-gvfsz4-P"
+          class="css-6jxvia-P"
           data-text="true"
         >
           The type of button text to display ("Sign In with Apple" vs. "Continue with Apple").
@@ -524,7 +524,7 @@ for more details.
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-tu4dab-InlineCode"
+                  class="inline css-1pk617c-InlineCode"
                 >
                   cornerRadius
                 </code>
@@ -561,7 +561,7 @@ for more details.
           </div>
         </h3>
         <p
-          class="css-gvfsz4-P"
+          class="css-6jxvia-P"
           data-text="true"
         >
           <span
@@ -576,19 +576,19 @@ for more details.
           </span>
            
           <code
-            class="inline css-10jm9cu-InlineCode"
+            class="inline css-ov7own-InlineCode"
           >
             number
           </code>
         </p>
         <p
-          class="css-gvfsz4-P"
+          class="css-6jxvia-P"
           data-text="true"
         >
           The border radius to use when rendering the button. This works similarly to
 
           <code
-            class="inline css-10jm9cu-InlineCode"
+            class="inline css-ov7own-InlineCode"
           >
             style.borderRadius
           </code>
@@ -617,7 +617,7 @@ for more details.
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-tu4dab-InlineCode"
+                  class="inline css-1pk617c-InlineCode"
                 >
                   style
                 </code>
@@ -654,7 +654,7 @@ for more details.
           </div>
         </h3>
         <p
-          class="css-gvfsz4-P"
+          class="css-6jxvia-P"
           data-text="true"
         >
           <span
@@ -669,7 +669,7 @@ for more details.
           </span>
            
           <code
-            class="inline css-10jm9cu-InlineCode"
+            class="inline css-ov7own-InlineCode"
           >
             StyleProp
             &lt;
@@ -706,18 +706,18 @@ for more details.
           </code>
         </p>
         <p
-          class="css-gvfsz4-P"
+          class="css-6jxvia-P"
           data-text="true"
         >
           The custom style to apply to the button. Should not include 
           <code
-            class="inline css-10jm9cu-InlineCode"
+            class="inline css-ov7own-InlineCode"
           >
             backgroundColor
           </code>
            or 
           <code
-            class="inline css-10jm9cu-InlineCode"
+            class="inline css-ov7own-InlineCode"
           >
             borderRadius
           </code>
@@ -747,7 +747,7 @@ properties.
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-tu4dab-InlineCode"
+                  class="inline css-1pk617c-InlineCode"
                 >
                   onPress
                 </code>
@@ -784,7 +784,7 @@ properties.
           </div>
         </h3>
         <p
-          class="css-gvfsz4-P"
+          class="css-6jxvia-P"
           data-text="true"
         >
           <span
@@ -794,7 +794,7 @@ properties.
           </span>
            
           <code
-            class="inline css-10jm9cu-InlineCode"
+            class="inline css-ov7own-InlineCode"
           >
             (
             ) =&gt;
@@ -803,7 +803,7 @@ properties.
           </code>
         </p>
         <p
-          class="css-gvfsz4-P"
+          class="css-6jxvia-P"
           data-text="true"
         >
           The method to call when the user presses the button. You should call 
@@ -812,7 +812,7 @@ properties.
             href="/#isavailableasync"
           >
             <code
-              class="inline css-10jm9cu-InlineCode"
+              class="inline css-ov7own-InlineCode"
             >
               AppleAuthentication.signInAsync
             </code>
@@ -873,14 +873,14 @@ in here.
         </div>
       </h3>
       <ul
-        class="css-viw9dk-UL"
+        class="css-ftstf7-UL"
         data-text="true"
       >
         <li
-          class="docs-list-item css-l157nt-LI"
+          class="docs-list-item css-1yzgz3v-LI"
         >
           <code
-            class="inline css-10jm9cu-InlineCode"
+            class="inline css-ov7own-InlineCode"
           >
             <a
               class="css-153g748-InternalLink"
@@ -894,7 +894,7 @@ in here.
     </div>
   </div>
   <h2
-    class="css-wpfbxc-H2"
+    class="css-1ck3d9a-H2"
     data-heading="true"
   >
     <div
@@ -966,7 +966,7 @@ in here.
             class="css-6n7j50"
           >
             <code
-              class="inline css-tu4dab-InlineCode"
+              class="inline css-1pk617c-InlineCode"
             >
               getCredentialStateAsync(user)
             </code>
@@ -1039,7 +1039,7 @@ in here.
               class="css-t44xva-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 user
               </strong>
@@ -1048,7 +1048,7 @@ in here.
               class="css-t44xva-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 string
               </code>
@@ -1064,7 +1064,7 @@ This should come from the user field of an
                   href="/#appleauthenticationcredentialstate"
                 >
                   <code
-                    class="inline css-10jm9cu-InlineCode"
+                    class="inline css-ov7own-InlineCode"
                   >
                     AppleAuthenticationCredential
                   </code>
@@ -1077,7 +1077,7 @@ This should come from the user field of an
       </table>
     </div>
     <p
-      class="css-gvfsz4-P"
+      class="css-6jxvia-P"
       data-text="true"
     >
       Queries the current state of a user credential, to determine if it is still valid or if it has been revoked.
@@ -1085,7 +1085,7 @@ This should come from the user field of an
     
 
     <blockquote
-      class="css-y2d7cg-Quote"
+      class="css-1nn217x-Quote"
       data-text="true"
     >
       <div
@@ -1112,7 +1112,7 @@ This should come from the user field of an
         
 
         <strong
-          class="css-cyicbq-B"
+          class="css-1qx481h-B"
         >
           Note:
         </strong>
@@ -1178,11 +1178,11 @@ This should come from the user field of an
       </h4>
     </div>
     <ul
-      class="css-ozzgx3-UL"
+      class="css-n6fu3c-UL"
       data-text="true"
     >
       <li
-        class="docs-list-item css-l157nt-LI"
+        class="docs-list-item css-1yzgz3v-LI"
       >
         <svg
           class="css-1xa9dbk-APISectionMethods"
@@ -1203,7 +1203,7 @@ This should come from the user field of an
           />
         </svg>
         <code
-          class="inline css-10jm9cu-InlineCode"
+          class="inline css-ov7own-InlineCode"
         >
           <a
             class="css-ccg2mn-ExternalLink"
@@ -1226,7 +1226,7 @@ This should come from the user field of an
       </li>
     </ul>
     <p
-      class="css-gvfsz4-P"
+      class="css-6jxvia-P"
       data-text="true"
     >
       A promise that fulfills with an 
@@ -1235,7 +1235,7 @@ This should come from the user field of an
         href="/#appleauthenticationcredentialstate"
       >
         <code
-          class="inline css-10jm9cu-InlineCode"
+          class="inline css-ov7own-InlineCode"
         >
           AppleAuthenticationCredentialState
         </code>
@@ -1266,7 +1266,7 @@ value depending on the state of the credential.
             class="css-6n7j50"
           >
             <code
-              class="inline css-tu4dab-InlineCode"
+              class="inline css-1pk617c-InlineCode"
             >
               isAvailableAsync()
             </code>
@@ -1303,7 +1303,7 @@ value depending on the state of the credential.
       </div>
     </h3>
     <p
-      class="css-gvfsz4-P"
+      class="css-6jxvia-P"
       data-text="true"
     >
       Determine if the current device's operating system supports Apple authentication.
@@ -1365,11 +1365,11 @@ value depending on the state of the credential.
       </h4>
     </div>
     <ul
-      class="css-ozzgx3-UL"
+      class="css-n6fu3c-UL"
       data-text="true"
     >
       <li
-        class="docs-list-item css-l157nt-LI"
+        class="docs-list-item css-1yzgz3v-LI"
       >
         <svg
           class="css-1xa9dbk-APISectionMethods"
@@ -1390,7 +1390,7 @@ value depending on the state of the credential.
           />
         </svg>
         <code
-          class="inline css-10jm9cu-InlineCode"
+          class="inline css-ov7own-InlineCode"
         >
           <a
             class="css-ccg2mn-ExternalLink"
@@ -1408,18 +1408,18 @@ value depending on the state of the credential.
       </li>
     </ul>
     <p
-      class="css-gvfsz4-P"
+      class="css-6jxvia-P"
       data-text="true"
     >
       A promise that fulfills with 
       <code
-        class="inline css-10jm9cu-InlineCode"
+        class="inline css-ov7own-InlineCode"
       >
         true
       </code>
        if the system supports Apple authentication, and 
       <code
-        class="inline css-10jm9cu-InlineCode"
+        class="inline css-ov7own-InlineCode"
       >
         false
       </code>
@@ -1448,7 +1448,7 @@ value depending on the state of the credential.
             class="css-6n7j50"
           >
             <code
-              class="inline css-tu4dab-InlineCode"
+              class="inline css-1pk617c-InlineCode"
             >
               refreshAsync(options)
             </code>
@@ -1521,7 +1521,7 @@ value depending on the state of the credential.
               class="css-t44xva-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 options
               </strong>
@@ -1530,7 +1530,7 @@ value depending on the state of the credential.
               class="css-t44xva-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 <a
                   class="css-153g748-InternalLink"
@@ -1550,7 +1550,7 @@ value depending on the state of the credential.
                   href="/#appleauthenticationrefreshoptions"
                 >
                   <code
-                    class="inline css-10jm9cu-InlineCode"
+                    class="inline css-ov7own-InlineCode"
                   >
                     AppleAuthenticationRefreshOptions
                   </code>
@@ -1563,7 +1563,7 @@ value depending on the state of the credential.
       </table>
     </div>
     <p
-      class="css-gvfsz4-P"
+      class="css-6jxvia-P"
       data-text="true"
     >
       An operation that refreshes the logged-in user’s credentials.
@@ -1626,11 +1626,11 @@ Calling this method will show the sign in modal before actually refreshing the u
       </h4>
     </div>
     <ul
-      class="css-ozzgx3-UL"
+      class="css-n6fu3c-UL"
       data-text="true"
     >
       <li
-        class="docs-list-item css-l157nt-LI"
+        class="docs-list-item css-1yzgz3v-LI"
       >
         <svg
           class="css-1xa9dbk-APISectionMethods"
@@ -1651,7 +1651,7 @@ Calling this method will show the sign in modal before actually refreshing the u
           />
         </svg>
         <code
-          class="inline css-10jm9cu-InlineCode"
+          class="inline css-ov7own-InlineCode"
         >
           <a
             class="css-ccg2mn-ExternalLink"
@@ -1674,7 +1674,7 @@ Calling this method will show the sign in modal before actually refreshing the u
       </li>
     </ul>
     <p
-      class="css-gvfsz4-P"
+      class="css-6jxvia-P"
       data-text="true"
     >
       A promise that fulfills with an 
@@ -1683,7 +1683,7 @@ Calling this method will show the sign in modal before actually refreshing the u
         href="/#appleauthenticationcredential"
       >
         <code
-          class="inline css-10jm9cu-InlineCode"
+          class="inline css-ov7own-InlineCode"
         >
           AppleAuthenticationCredential
         </code>
@@ -1691,7 +1691,7 @@ Calling this method will show the sign in modal before actually refreshing the u
       
 object after a successful authentication, and rejects with 
       <code
-        class="inline css-10jm9cu-InlineCode"
+        class="inline css-ov7own-InlineCode"
       >
         ERR_CANCELED
       </code>
@@ -1721,7 +1721,7 @@ refresh operation.
             class="css-6n7j50"
           >
             <code
-              class="inline css-tu4dab-InlineCode"
+              class="inline css-1pk617c-InlineCode"
             >
               signInAsync(options)
             </code>
@@ -1794,7 +1794,7 @@ refresh operation.
               class="css-t44xva-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 options
               </strong>
@@ -1809,7 +1809,7 @@ refresh operation.
               class="css-t44xva-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 <a
                   class="css-153g748-InternalLink"
@@ -1829,7 +1829,7 @@ refresh operation.
                   href="/#appleauthenticationsigninoptions"
                 >
                   <code
-                    class="inline css-10jm9cu-InlineCode"
+                    class="inline css-ov7own-InlineCode"
                   >
                     AppleAuthenticationSignInOptions
                   </code>
@@ -1842,14 +1842,14 @@ refresh operation.
       </table>
     </div>
     <p
-      class="css-gvfsz4-P"
+      class="css-6jxvia-P"
       data-text="true"
     >
       Sends a request to the operating system to initiate the Apple authentication flow, which will
 present a modal to the user over your app and allow them to sign in.
     </p>
     <p
-      class="css-gvfsz4-P"
+      class="css-6jxvia-P"
       data-text="true"
     >
       You can request access to the user's full name and email address in this method, which allows you
@@ -1859,7 +1859,7 @@ of these options at runtime.
     
 
     <p
-      class="css-gvfsz4-P"
+      class="css-6jxvia-P"
       data-text="true"
     >
       Additionally, you will only receive Apple Authentication Credentials the first time users sign
@@ -1878,7 +1878,7 @@ You can use
         href="/#appleauthenticationcredential"
       >
         <code
-          class="inline css-10jm9cu-InlineCode"
+          class="inline css-ov7own-InlineCode"
         >
           AppleAuthenticationCredential.user
         </code>
@@ -1943,11 +1943,11 @@ the user, since this remains the same for apps released by the same developer.
       </h4>
     </div>
     <ul
-      class="css-ozzgx3-UL"
+      class="css-n6fu3c-UL"
       data-text="true"
     >
       <li
-        class="docs-list-item css-l157nt-LI"
+        class="docs-list-item css-1yzgz3v-LI"
       >
         <svg
           class="css-1xa9dbk-APISectionMethods"
@@ -1968,7 +1968,7 @@ the user, since this remains the same for apps released by the same developer.
           />
         </svg>
         <code
-          class="inline css-10jm9cu-InlineCode"
+          class="inline css-ov7own-InlineCode"
         >
           <a
             class="css-ccg2mn-ExternalLink"
@@ -1991,7 +1991,7 @@ the user, since this remains the same for apps released by the same developer.
       </li>
     </ul>
     <p
-      class="css-gvfsz4-P"
+      class="css-6jxvia-P"
       data-text="true"
     >
       A promise that fulfills with an 
@@ -2000,7 +2000,7 @@ the user, since this remains the same for apps released by the same developer.
         href="/#appleauthenticationcredential"
       >
         <code
-          class="inline css-10jm9cu-InlineCode"
+          class="inline css-ov7own-InlineCode"
         >
           AppleAuthenticationCredential
         </code>
@@ -2008,7 +2008,7 @@ the user, since this remains the same for apps released by the same developer.
       
 object after a successful authentication, and rejects with 
       <code
-        class="inline css-10jm9cu-InlineCode"
+        class="inline css-ov7own-InlineCode"
       >
         ERR_CANCELED
       </code>
@@ -2038,7 +2038,7 @@ sign-in operation.
             class="css-6n7j50"
           >
             <code
-              class="inline css-tu4dab-InlineCode"
+              class="inline css-1pk617c-InlineCode"
             >
               signOutAsync(options)
             </code>
@@ -2111,7 +2111,7 @@ sign-in operation.
               class="css-t44xva-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 options
               </strong>
@@ -2120,7 +2120,7 @@ sign-in operation.
               class="css-t44xva-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 <a
                   class="css-153g748-InternalLink"
@@ -2140,7 +2140,7 @@ sign-in operation.
                   href="/#appleauthenticationsignoutoptions"
                 >
                   <code
-                    class="inline css-10jm9cu-InlineCode"
+                    class="inline css-ov7own-InlineCode"
                   >
                     AppleAuthenticationSignOutOptions
                   </code>
@@ -2153,14 +2153,14 @@ sign-in operation.
       </table>
     </div>
     <p
-      class="css-gvfsz4-P"
+      class="css-6jxvia-P"
       data-text="true"
     >
       An operation that ends the authenticated session.
 Calling this method will show the sign in modal before actually signing the user out.
     </p>
     <p
-      class="css-gvfsz4-P"
+      class="css-6jxvia-P"
       data-text="true"
     >
       It is not recommended to use this method to sign out the user as it works counterintuitively.
@@ -2171,7 +2171,7 @@ from using
         href="/#signinasync"
       >
         <code
-          class="inline css-10jm9cu-InlineCode"
+          class="inline css-ov7own-InlineCode"
         >
           signInAsync
         </code>
@@ -2182,7 +2182,7 @@ from using
         href="/#refreshasync"
       >
         <code
-          class="inline css-10jm9cu-InlineCode"
+          class="inline css-ov7own-InlineCode"
         >
           refreshAsync
         </code>
@@ -2246,11 +2246,11 @@ from using
       </h4>
     </div>
     <ul
-      class="css-ozzgx3-UL"
+      class="css-n6fu3c-UL"
       data-text="true"
     >
       <li
-        class="docs-list-item css-l157nt-LI"
+        class="docs-list-item css-1yzgz3v-LI"
       >
         <svg
           class="css-1xa9dbk-APISectionMethods"
@@ -2271,7 +2271,7 @@ from using
           />
         </svg>
         <code
-          class="inline css-10jm9cu-InlineCode"
+          class="inline css-ov7own-InlineCode"
         >
           <a
             class="css-ccg2mn-ExternalLink"
@@ -2294,7 +2294,7 @@ from using
       </li>
     </ul>
     <p
-      class="css-gvfsz4-P"
+      class="css-6jxvia-P"
       data-text="true"
     >
       A promise that fulfills with an 
@@ -2303,7 +2303,7 @@ from using
         href="/#appleauthenticationcredential"
       >
         <code
-          class="inline css-10jm9cu-InlineCode"
+          class="inline css-ov7own-InlineCode"
         >
           AppleAuthenticationCredential
         </code>
@@ -2311,7 +2311,7 @@ from using
       
 object after a successful authentication, and rejects with 
       <code
-        class="inline css-10jm9cu-InlineCode"
+        class="inline css-ov7own-InlineCode"
       >
         ERR_CANCELED
       </code>
@@ -2320,7 +2320,7 @@ sign-out operation.
     </p>
   </div>
   <h2
-    class="css-wpfbxc-H2"
+    class="css-1ck3d9a-H2"
     data-heading="true"
   >
     <div
@@ -2392,7 +2392,7 @@ sign-out operation.
             class="css-6n7j50"
           >
             <code
-              class="inline css-tu4dab-InlineCode"
+              class="inline css-1pk617c-InlineCode"
             >
               addRevokeListener(listener)
             </code>
@@ -2465,7 +2465,7 @@ sign-out operation.
               class="css-t44xva-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 listener
               </strong>
@@ -2474,7 +2474,7 @@ sign-out operation.
               class="css-t44xva-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 () =&gt;
                  
@@ -2547,11 +2547,11 @@ sign-out operation.
       </h4>
     </div>
     <ul
-      class="css-ozzgx3-UL"
+      class="css-n6fu3c-UL"
       data-text="true"
     >
       <li
-        class="docs-list-item css-l157nt-LI"
+        class="docs-list-item css-1yzgz3v-LI"
       >
         <svg
           class="css-1xa9dbk-APISectionMethods"
@@ -2572,7 +2572,7 @@ sign-out operation.
           />
         </svg>
         <code
-          class="inline css-10jm9cu-InlineCode"
+          class="inline css-ov7own-InlineCode"
         >
           <a
             class="css-153g748-InternalLink"
@@ -2585,7 +2585,7 @@ sign-out operation.
     </ul>
   </div>
   <h2
-    class="css-wpfbxc-H2"
+    class="css-1ck3d9a-H2"
     data-heading="true"
   >
     <div
@@ -2657,7 +2657,7 @@ sign-out operation.
             class="css-6n7j50"
           >
             <code
-              class="inline css-10jm9cu-InlineCode"
+              class="inline css-ov7own-InlineCode"
             >
               AppleAuthenticationCredential
             </code>
@@ -2694,7 +2694,7 @@ sign-out operation.
       </div>
     </h3>
     <p
-      class="css-gvfsz4-P"
+      class="css-6jxvia-P"
       data-text="true"
     >
       The object type returned from a successful call to 
@@ -2703,7 +2703,7 @@ sign-out operation.
         href="/#appleauthenticationsigninasyncoptions"
       >
         <code
-          class="inline css-10jm9cu-InlineCode"
+          class="inline css-ov7own-InlineCode"
         >
           AppleAuthentication.signInAsync()
         </code>
@@ -2715,7 +2715,7 @@ sign-out operation.
         href="/#appleauthenticationrefreshasyncoptions"
       >
         <code
-          class="inline css-10jm9cu-InlineCode"
+          class="inline css-ov7own-InlineCode"
         >
           AppleAuthentication.refreshAsync()
         </code>
@@ -2726,7 +2726,7 @@ sign-out operation.
         href="/#appleauthenticationsignoutasyncoptions"
       >
         <code
-          class="inline css-10jm9cu-InlineCode"
+          class="inline css-ov7own-InlineCode"
         >
           AppleAuthentication.signOutAsync()
         </code>
@@ -2735,7 +2735,7 @@ sign-out operation.
 which contains all of the pertinent user and credential information.
     </p>
     <blockquote
-      class="css-y2d7cg-Quote"
+      class="css-1nn217x-Quote"
       data-text="true"
     >
       <div
@@ -2760,7 +2760,7 @@ which contains all of the pertinent user and credential information.
       </div>
       <div>
         <strong
-          class="css-cyicbq-B"
+          class="css-1qx481h-B"
         >
           See: 
         </strong>
@@ -2815,7 +2815,7 @@ for more details.
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 authorizationCode
               </strong>
@@ -2824,7 +2824,7 @@ for more details.
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 <span>
                   string
@@ -2842,7 +2842,7 @@ for more details.
                 A short-lived session token used by your app for proof of authorization when interacting with
 the app's server counterpart. Unlike 
                 <code
-                  class="inline css-10jm9cu-InlineCode"
+                  class="inline css-ov7own-InlineCode"
                 >
                   user
                 </code>
@@ -2857,7 +2857,7 @@ the app's server counterpart. Unlike
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 email
               </strong>
@@ -2866,7 +2866,7 @@ the app's server counterpart. Unlike
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 <span>
                   string
@@ -2883,7 +2883,7 @@ the app's server counterpart. Unlike
               <span>
                 The user's email address. Might not be present if you didn't request the 
                 <code
-                  class="inline css-10jm9cu-InlineCode"
+                  class="inline css-ov7own-InlineCode"
                 >
                   EMAIL
                 </code>
@@ -2901,7 +2901,7 @@ an Apple domain.
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 fullName
               </strong>
@@ -2910,7 +2910,7 @@ an Apple domain.
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 <span>
                   <a
@@ -2932,19 +2932,19 @@ an Apple domain.
               <span>
                 The user's name. May be 
                 <code
-                  class="inline css-10jm9cu-InlineCode"
+                  class="inline css-ov7own-InlineCode"
                 >
                   null
                 </code>
                  or contain 
                 <code
-                  class="inline css-10jm9cu-InlineCode"
+                  class="inline css-ov7own-InlineCode"
                 >
                   null
                 </code>
                  values if you didn't request the 
                 <code
-                  class="inline css-10jm9cu-InlineCode"
+                  class="inline css-ov7own-InlineCode"
                 >
                   FULL_NAME
                 </code>
@@ -2961,7 +2961,7 @@ your app.
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 identityToken
               </strong>
@@ -2970,7 +2970,7 @@ your app.
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 <span>
                   string
@@ -2996,7 +2996,7 @@ your app.
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 realUserStatus
               </strong>
@@ -3005,7 +3005,7 @@ your app.
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 <a
                   class="css-153g748-InternalLink"
@@ -3030,7 +3030,7 @@ your app.
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 state
               </strong>
@@ -3039,7 +3039,7 @@ your app.
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 <span>
                   string
@@ -3056,7 +3056,7 @@ your app.
               <span>
                 An arbitrary string that your app provided as 
                 <code
-                  class="inline css-10jm9cu-InlineCode"
+                  class="inline css-ov7own-InlineCode"
                 >
                   state
                 </code>
@@ -3064,14 +3064,14 @@ your app.
 credential. Used to verify that the response was from the request you made. Can be used to
 avoid replay attacks. If you did not provide 
                 <code
-                  class="inline css-10jm9cu-InlineCode"
+                  class="inline css-ov7own-InlineCode"
                 >
                   state
                 </code>
                  when making the sign-in request, this field
 will be 
                 <code
-                  class="inline css-10jm9cu-InlineCode"
+                  class="inline css-ov7own-InlineCode"
                 >
                   null
                 </code>
@@ -3086,7 +3086,7 @@ will be
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 user
               </strong>
@@ -3095,7 +3095,7 @@ will be
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 string
               </code>
@@ -3137,7 +3137,7 @@ developers.
             class="css-6n7j50"
           >
             <code
-              class="inline css-10jm9cu-InlineCode"
+              class="inline css-ov7own-InlineCode"
             >
               AppleAuthenticationFullName
             </code>
@@ -3174,13 +3174,13 @@ developers.
       </div>
     </h3>
     <p
-      class="css-gvfsz4-P"
+      class="css-6jxvia-P"
       data-text="true"
     >
       An object representing the tokenized portions of the user's full name. Any of all of the fields
 may be 
       <code
-        class="inline css-10jm9cu-InlineCode"
+        class="inline css-ov7own-InlineCode"
       >
         null
       </code>
@@ -3223,7 +3223,7 @@ may be
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 familyName
               </strong>
@@ -3232,7 +3232,7 @@ may be
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 <span>
                   string
@@ -3256,7 +3256,7 @@ may be
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 givenName
               </strong>
@@ -3265,7 +3265,7 @@ may be
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 <span>
                   string
@@ -3289,7 +3289,7 @@ may be
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 middleName
               </strong>
@@ -3298,7 +3298,7 @@ may be
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 <span>
                   string
@@ -3322,7 +3322,7 @@ may be
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 namePrefix
               </strong>
@@ -3331,7 +3331,7 @@ may be
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 <span>
                   string
@@ -3355,7 +3355,7 @@ may be
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 nameSuffix
               </strong>
@@ -3364,7 +3364,7 @@ may be
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 <span>
                   string
@@ -3388,7 +3388,7 @@ may be
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 nickname
               </strong>
@@ -3397,7 +3397,7 @@ may be
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 <span>
                   string
@@ -3440,7 +3440,7 @@ may be
             class="css-6n7j50"
           >
             <code
-              class="inline css-10jm9cu-InlineCode"
+              class="inline css-ov7own-InlineCode"
             >
               AppleAuthenticationRefreshOptions
             </code>
@@ -3477,7 +3477,7 @@ may be
       </div>
     </h3>
     <p
-      class="css-gvfsz4-P"
+      class="css-6jxvia-P"
       data-text="true"
     >
       The options you can supply when making a call to 
@@ -3486,7 +3486,7 @@ may be
         href="/#appleauthenticationrefreshasyncoptions"
       >
         <code
-          class="inline css-10jm9cu-InlineCode"
+          class="inline css-ov7own-InlineCode"
         >
           AppleAuthentication.refreshAsync()
         </code>
@@ -3495,7 +3495,7 @@ may be
 You must include the ID string of the user whose credentials you'd like to refresh.
     </p>
     <blockquote
-      class="css-y2d7cg-Quote"
+      class="css-1nn217x-Quote"
       data-text="true"
     >
       <div
@@ -3520,7 +3520,7 @@ You must include the ID string of the user whose credentials you'd like to refre
       </div>
       <div>
         <strong
-          class="css-cyicbq-B"
+          class="css-1qx481h-B"
         >
           See: 
         </strong>
@@ -3575,7 +3575,7 @@ for more details.
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 requestedScopes
               </strong>
@@ -3590,7 +3590,7 @@ for more details.
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 <a
                   class="css-153g748-InternalLink"
@@ -3609,7 +3609,7 @@ for more details.
 choose to deny your app access to any scope at the time of logging in. You will still need to
 handle 
                 <code
-                  class="inline css-10jm9cu-InlineCode"
+                  class="inline css-ov7own-InlineCode"
                 >
                   null
                 </code>
@@ -3617,13 +3617,13 @@ handle
 will only be provided to you the first time each user signs into your app; in subsequent
 requests they will be 
                 <code
-                  class="inline css-10jm9cu-InlineCode"
+                  class="inline css-ov7own-InlineCode"
                 >
                   null
                 </code>
                 . Defaults to 
                 <code
-                  class="inline css-10jm9cu-InlineCode"
+                  class="inline css-ov7own-InlineCode"
                 >
                   []
                 </code>
@@ -3638,7 +3638,7 @@ requests they will be
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 state
               </strong>
@@ -3653,7 +3653,7 @@ requests they will be
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 string
               </code>
@@ -3684,7 +3684,7 @@ OAuth 2.0 protocol
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 user
               </strong>
@@ -3693,7 +3693,7 @@ OAuth 2.0 protocol
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 string
               </code>
@@ -3730,7 +3730,7 @@ OAuth 2.0 protocol
             class="css-6n7j50"
           >
             <code
-              class="inline css-10jm9cu-InlineCode"
+              class="inline css-ov7own-InlineCode"
             >
               AppleAuthenticationSignInOptions
             </code>
@@ -3767,7 +3767,7 @@ OAuth 2.0 protocol
       </div>
     </h3>
     <p
-      class="css-gvfsz4-P"
+      class="css-6jxvia-P"
       data-text="true"
     >
       The options you can supply when making a call to 
@@ -3776,7 +3776,7 @@ OAuth 2.0 protocol
         href="/#appleauthenticationsigninasyncoptions"
       >
         <code
-          class="inline css-10jm9cu-InlineCode"
+          class="inline css-ov7own-InlineCode"
         >
           AppleAuthentication.signInAsync()
         </code>
@@ -3785,7 +3785,7 @@ OAuth 2.0 protocol
 None of these options are required.
     </p>
     <blockquote
-      class="css-y2d7cg-Quote"
+      class="css-1nn217x-Quote"
       data-text="true"
     >
       <div
@@ -3810,7 +3810,7 @@ None of these options are required.
       </div>
       <div>
         <strong
-          class="css-cyicbq-B"
+          class="css-1qx481h-B"
         >
           See: 
         </strong>
@@ -3865,7 +3865,7 @@ for more details.
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 nonce
               </strong>
@@ -3880,7 +3880,7 @@ for more details.
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 string
               </code>
@@ -3909,7 +3909,7 @@ for more details.
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 requestedScopes
               </strong>
@@ -3924,7 +3924,7 @@ for more details.
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 <a
                   class="css-153g748-InternalLink"
@@ -3943,7 +3943,7 @@ for more details.
 choose to deny your app access to any scope at the time of logging in. You will still need to
 handle 
                 <code
-                  class="inline css-10jm9cu-InlineCode"
+                  class="inline css-ov7own-InlineCode"
                 >
                   null
                 </code>
@@ -3951,13 +3951,13 @@ handle
 will only be provided to you the first time each user signs into your app; in subsequent
 requests they will be 
                 <code
-                  class="inline css-10jm9cu-InlineCode"
+                  class="inline css-ov7own-InlineCode"
                 >
                   null
                 </code>
                 . Defaults to 
                 <code
-                  class="inline css-10jm9cu-InlineCode"
+                  class="inline css-ov7own-InlineCode"
                 >
                   []
                 </code>
@@ -3972,7 +3972,7 @@ requests they will be
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 state
               </strong>
@@ -3987,7 +3987,7 @@ requests they will be
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 string
               </code>
@@ -4037,7 +4037,7 @@ OAuth 2.0 protocol
             class="css-6n7j50"
           >
             <code
-              class="inline css-10jm9cu-InlineCode"
+              class="inline css-ov7own-InlineCode"
             >
               AppleAuthenticationSignOutOptions
             </code>
@@ -4074,7 +4074,7 @@ OAuth 2.0 protocol
       </div>
     </h3>
     <p
-      class="css-gvfsz4-P"
+      class="css-6jxvia-P"
       data-text="true"
     >
       The options you can supply when making a call to 
@@ -4083,7 +4083,7 @@ OAuth 2.0 protocol
         href="/#appleauthenticationsignoutasyncoptions"
       >
         <code
-          class="inline css-10jm9cu-InlineCode"
+          class="inline css-ov7own-InlineCode"
         >
           AppleAuthentication.signOutAsync()
         </code>
@@ -4092,7 +4092,7 @@ OAuth 2.0 protocol
 You must include the ID string of the user to sign out.
     </p>
     <blockquote
-      class="css-y2d7cg-Quote"
+      class="css-1nn217x-Quote"
       data-text="true"
     >
       <div
@@ -4117,7 +4117,7 @@ You must include the ID string of the user to sign out.
       </div>
       <div>
         <strong
-          class="css-cyicbq-B"
+          class="css-1qx481h-B"
         >
           See: 
         </strong>
@@ -4172,7 +4172,7 @@ for more details.
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 state
               </strong>
@@ -4187,7 +4187,7 @@ for more details.
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 string
               </code>
@@ -4218,7 +4218,7 @@ OAuth 2.0 protocol
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 user
               </strong>
@@ -4227,7 +4227,7 @@ OAuth 2.0 protocol
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 string
               </code>
@@ -4264,7 +4264,7 @@ OAuth 2.0 protocol
             class="css-6n7j50"
           >
             <code
-              class="inline css-10jm9cu-InlineCode"
+              class="inline css-ov7own-InlineCode"
             >
               Subscription
             </code>
@@ -4337,7 +4337,7 @@ OAuth 2.0 protocol
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 remove
               </strong>
@@ -4346,7 +4346,7 @@ OAuth 2.0 protocol
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 (
                 ) =&gt;
@@ -4367,7 +4367,7 @@ OAuth 2.0 protocol
     </div>
   </div>
   <h2
-    class="css-wpfbxc-H2"
+    class="css-1ck3d9a-H2"
     data-heading="true"
   >
     <div
@@ -4439,7 +4439,7 @@ OAuth 2.0 protocol
             class="css-6n7j50"
           >
             <code
-              class="inline css-10jm9cu-InlineCode"
+              class="inline css-ov7own-InlineCode"
             >
               AppleAuthenticationButtonStyle
             </code>
@@ -4476,7 +4476,7 @@ OAuth 2.0 protocol
       </div>
     </h3>
     <p
-      class="css-gvfsz4-P"
+      class="css-6jxvia-P"
       data-text="true"
     >
       An enum whose values control which pre-defined color scheme to use when rendering an 
@@ -4485,7 +4485,7 @@ OAuth 2.0 protocol
         href="/#appleauthenticationappleauthenticationbutton"
       >
         <code
-          class="inline css-10jm9cu-InlineCode"
+          class="inline css-ov7own-InlineCode"
         >
           AppleAuthenticationButton
         </code>
@@ -4518,7 +4518,7 @@ OAuth 2.0 protocol
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-10jm9cu-InlineCode"
+                  class="inline css-ov7own-InlineCode"
                 >
                   WHITE
                 </code>
@@ -4556,7 +4556,7 @@ OAuth 2.0 protocol
         </h4>
       </div>
       <code
-        class="inline css-bs4uzw-APISectionEnums"
+        class="inline css-1rann0c-APISectionEnums"
       >
         AppleAuthenticationButtonStyle
         .
@@ -4564,7 +4564,7 @@ OAuth 2.0 protocol
          ＝ 0
       </code>
       <p
-        class="css-gvfsz4-P"
+        class="css-6jxvia-P"
         data-text="true"
       >
         White button with black text.
@@ -4596,7 +4596,7 @@ OAuth 2.0 protocol
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-10jm9cu-InlineCode"
+                  class="inline css-ov7own-InlineCode"
                 >
                   WHITE_OUTLINE
                 </code>
@@ -4634,7 +4634,7 @@ OAuth 2.0 protocol
         </h4>
       </div>
       <code
-        class="inline css-bs4uzw-APISectionEnums"
+        class="inline css-1rann0c-APISectionEnums"
       >
         AppleAuthenticationButtonStyle
         .
@@ -4642,7 +4642,7 @@ OAuth 2.0 protocol
          ＝ 1
       </code>
       <p
-        class="css-gvfsz4-P"
+        class="css-6jxvia-P"
         data-text="true"
       >
         White button with a black outline and black text.
@@ -4674,7 +4674,7 @@ OAuth 2.0 protocol
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-10jm9cu-InlineCode"
+                  class="inline css-ov7own-InlineCode"
                 >
                   BLACK
                 </code>
@@ -4712,7 +4712,7 @@ OAuth 2.0 protocol
         </h4>
       </div>
       <code
-        class="inline css-bs4uzw-APISectionEnums"
+        class="inline css-1rann0c-APISectionEnums"
       >
         AppleAuthenticationButtonStyle
         .
@@ -4720,7 +4720,7 @@ OAuth 2.0 protocol
          ＝ 2
       </code>
       <p
-        class="css-gvfsz4-P"
+        class="css-6jxvia-P"
         data-text="true"
       >
         Black button with white text.
@@ -4749,7 +4749,7 @@ OAuth 2.0 protocol
             class="css-6n7j50"
           >
             <code
-              class="inline css-10jm9cu-InlineCode"
+              class="inline css-ov7own-InlineCode"
             >
               AppleAuthenticationButtonType
             </code>
@@ -4786,7 +4786,7 @@ OAuth 2.0 protocol
       </div>
     </h3>
     <p
-      class="css-gvfsz4-P"
+      class="css-6jxvia-P"
       data-text="true"
     >
       An enum whose values control which pre-defined text to use when rendering an 
@@ -4795,7 +4795,7 @@ OAuth 2.0 protocol
         href="/#appleauthenticationappleauthenticationbutton"
       >
         <code
-          class="inline css-10jm9cu-InlineCode"
+          class="inline css-ov7own-InlineCode"
         >
           AppleAuthenticationButton
         </code>
@@ -4828,7 +4828,7 @@ OAuth 2.0 protocol
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-10jm9cu-InlineCode"
+                  class="inline css-ov7own-InlineCode"
                 >
                   SIGN_IN
                 </code>
@@ -4866,7 +4866,7 @@ OAuth 2.0 protocol
         </h4>
       </div>
       <code
-        class="inline css-bs4uzw-APISectionEnums"
+        class="inline css-1rann0c-APISectionEnums"
       >
         AppleAuthenticationButtonType
         .
@@ -4874,7 +4874,7 @@ OAuth 2.0 protocol
          ＝ 0
       </code>
       <p
-        class="css-gvfsz4-P"
+        class="css-6jxvia-P"
         data-text="true"
       >
         "Sign in with Apple"
@@ -4906,7 +4906,7 @@ OAuth 2.0 protocol
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-10jm9cu-InlineCode"
+                  class="inline css-ov7own-InlineCode"
                 >
                   CONTINUE
                 </code>
@@ -4944,7 +4944,7 @@ OAuth 2.0 protocol
         </h4>
       </div>
       <code
-        class="inline css-bs4uzw-APISectionEnums"
+        class="inline css-1rann0c-APISectionEnums"
       >
         AppleAuthenticationButtonType
         .
@@ -4952,7 +4952,7 @@ OAuth 2.0 protocol
          ＝ 1
       </code>
       <p
-        class="css-gvfsz4-P"
+        class="css-6jxvia-P"
         data-text="true"
       >
         "Continue with Apple"
@@ -4962,7 +4962,7 @@ OAuth 2.0 protocol
       class="css-1xaswp1-APISectionEnums"
     >
       <strong
-        class="css-cyicbq-B"
+        class="css-1qx481h-B"
       >
         Only for:
          
@@ -5017,7 +5017,7 @@ OAuth 2.0 protocol
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-10jm9cu-InlineCode"
+                  class="inline css-ov7own-InlineCode"
                 >
                   SIGN_UP
                 </code>
@@ -5055,7 +5055,7 @@ OAuth 2.0 protocol
         </h4>
       </div>
       <code
-        class="inline css-bs4uzw-APISectionEnums"
+        class="inline css-1rann0c-APISectionEnums"
       >
         AppleAuthenticationButtonType
         .
@@ -5063,7 +5063,7 @@ OAuth 2.0 protocol
          ＝ 2
       </code>
       <p
-        class="css-gvfsz4-P"
+        class="css-6jxvia-P"
         data-text="true"
       >
         "Sign up with Apple"
@@ -5092,7 +5092,7 @@ OAuth 2.0 protocol
             class="css-6n7j50"
           >
             <code
-              class="inline css-10jm9cu-InlineCode"
+              class="inline css-ov7own-InlineCode"
             >
               AppleAuthenticationCredentialState
             </code>
@@ -5129,7 +5129,7 @@ OAuth 2.0 protocol
       </div>
     </h3>
     <p
-      class="css-gvfsz4-P"
+      class="css-6jxvia-P"
       data-text="true"
     >
       An enum whose values specify state of the credential when checked with 
@@ -5138,7 +5138,7 @@ OAuth 2.0 protocol
         href="/#appleauthenticationgetcredentialstateasyncuser"
       >
         <code
-          class="inline css-10jm9cu-InlineCode"
+          class="inline css-ov7own-InlineCode"
         >
           AppleAuthentication.getCredentialStateAsync()
         </code>
@@ -5146,7 +5146,7 @@ OAuth 2.0 protocol
       .
     </p>
     <blockquote
-      class="css-y2d7cg-Quote"
+      class="css-1nn217x-Quote"
       data-text="true"
     >
       <div
@@ -5171,7 +5171,7 @@ OAuth 2.0 protocol
       </div>
       <div>
         <strong
-          class="css-cyicbq-B"
+          class="css-1qx481h-B"
         >
           See: 
         </strong>
@@ -5215,7 +5215,7 @@ for more details.
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-10jm9cu-InlineCode"
+                  class="inline css-ov7own-InlineCode"
                 >
                   REVOKED
                 </code>
@@ -5253,7 +5253,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="inline css-bs4uzw-APISectionEnums"
+        class="inline css-1rann0c-APISectionEnums"
       >
         AppleAuthenticationCredentialState
         .
@@ -5287,7 +5287,7 @@ for more details.
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-10jm9cu-InlineCode"
+                  class="inline css-ov7own-InlineCode"
                 >
                   AUTHORIZED
                 </code>
@@ -5325,7 +5325,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="inline css-bs4uzw-APISectionEnums"
+        class="inline css-1rann0c-APISectionEnums"
       >
         AppleAuthenticationCredentialState
         .
@@ -5359,7 +5359,7 @@ for more details.
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-10jm9cu-InlineCode"
+                  class="inline css-ov7own-InlineCode"
                 >
                   NOT_FOUND
                 </code>
@@ -5397,7 +5397,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="inline css-bs4uzw-APISectionEnums"
+        class="inline css-1rann0c-APISectionEnums"
       >
         AppleAuthenticationCredentialState
         .
@@ -5431,7 +5431,7 @@ for more details.
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-10jm9cu-InlineCode"
+                  class="inline css-ov7own-InlineCode"
                 >
                   TRANSFERRED
                 </code>
@@ -5469,7 +5469,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="inline css-bs4uzw-APISectionEnums"
+        class="inline css-1rann0c-APISectionEnums"
       >
         AppleAuthenticationCredentialState
         .
@@ -5500,7 +5500,7 @@ for more details.
             class="css-6n7j50"
           >
             <code
-              class="inline css-10jm9cu-InlineCode"
+              class="inline css-ov7own-InlineCode"
             >
               AppleAuthenticationOperation
             </code>
@@ -5562,7 +5562,7 @@ for more details.
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-10jm9cu-InlineCode"
+                  class="inline css-ov7own-InlineCode"
                 >
                   IMPLICIT
                 </code>
@@ -5600,7 +5600,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="inline css-bs4uzw-APISectionEnums"
+        class="inline css-1rann0c-APISectionEnums"
       >
         AppleAuthenticationOperation
         .
@@ -5608,7 +5608,7 @@ for more details.
          ＝ 0
       </code>
       <p
-        class="css-gvfsz4-P"
+        class="css-6jxvia-P"
         data-text="true"
       >
         An operation that depends on the particular kind of credential provider.
@@ -5640,7 +5640,7 @@ for more details.
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-10jm9cu-InlineCode"
+                  class="inline css-ov7own-InlineCode"
                 >
                   LOGIN
                 </code>
@@ -5678,7 +5678,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="inline css-bs4uzw-APISectionEnums"
+        class="inline css-1rann0c-APISectionEnums"
       >
         AppleAuthenticationOperation
         .
@@ -5712,7 +5712,7 @@ for more details.
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-10jm9cu-InlineCode"
+                  class="inline css-ov7own-InlineCode"
                 >
                   REFRESH
                 </code>
@@ -5750,7 +5750,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="inline css-bs4uzw-APISectionEnums"
+        class="inline css-1rann0c-APISectionEnums"
       >
         AppleAuthenticationOperation
         .
@@ -5784,7 +5784,7 @@ for more details.
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-10jm9cu-InlineCode"
+                  class="inline css-ov7own-InlineCode"
                 >
                   LOGOUT
                 </code>
@@ -5822,7 +5822,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="inline css-bs4uzw-APISectionEnums"
+        class="inline css-1rann0c-APISectionEnums"
       >
         AppleAuthenticationOperation
         .
@@ -5853,7 +5853,7 @@ for more details.
             class="css-6n7j50"
           >
             <code
-              class="inline css-10jm9cu-InlineCode"
+              class="inline css-ov7own-InlineCode"
             >
               AppleAuthenticationScope
             </code>
@@ -5890,7 +5890,7 @@ for more details.
       </div>
     </h3>
     <p
-      class="css-gvfsz4-P"
+      class="css-6jxvia-P"
       data-text="true"
     >
       An enum whose values specify scopes you can request when calling 
@@ -5899,7 +5899,7 @@ for more details.
         href="/#appleauthenticationsigninasyncoptions"
       >
         <code
-          class="inline css-10jm9cu-InlineCode"
+          class="inline css-ov7own-InlineCode"
         >
           AppleAuthentication.signInAsync()
         </code>
@@ -5907,7 +5907,7 @@ for more details.
       .
     </p>
     <blockquote
-      class="css-y2d7cg-Quote"
+      class="css-1nn217x-Quote"
       data-text="true"
     >
       <div
@@ -5940,7 +5940,7 @@ You will still need to handle null values for any fields you request.
       </div>
     </blockquote>
     <blockquote
-      class="css-y2d7cg-Quote"
+      class="css-1nn217x-Quote"
       data-text="true"
     >
       <div
@@ -5965,7 +5965,7 @@ You will still need to handle null values for any fields you request.
       </div>
       <div>
         <strong
-          class="css-cyicbq-B"
+          class="css-1qx481h-B"
         >
           See: 
         </strong>
@@ -6009,7 +6009,7 @@ for more details.
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-10jm9cu-InlineCode"
+                  class="inline css-ov7own-InlineCode"
                 >
                   FULL_NAME
                 </code>
@@ -6047,7 +6047,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="inline css-bs4uzw-APISectionEnums"
+        class="inline css-1rann0c-APISectionEnums"
       >
         AppleAuthenticationScope
         .
@@ -6081,7 +6081,7 @@ for more details.
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-10jm9cu-InlineCode"
+                  class="inline css-ov7own-InlineCode"
                 >
                   EMAIL
                 </code>
@@ -6119,7 +6119,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="inline css-bs4uzw-APISectionEnums"
+        class="inline css-1rann0c-APISectionEnums"
       >
         AppleAuthenticationScope
         .
@@ -6150,7 +6150,7 @@ for more details.
             class="css-6n7j50"
           >
             <code
-              class="inline css-10jm9cu-InlineCode"
+              class="inline css-ov7own-InlineCode"
             >
               AppleAuthenticationUserDetectionStatus
             </code>
@@ -6187,13 +6187,13 @@ for more details.
       </div>
     </h3>
     <p
-      class="css-gvfsz4-P"
+      class="css-6jxvia-P"
       data-text="true"
     >
       An enum whose values specify the system's best guess for how likely the current user is a real person.
     </p>
     <blockquote
-      class="css-y2d7cg-Quote"
+      class="css-1nn217x-Quote"
       data-text="true"
     >
       <div
@@ -6218,7 +6218,7 @@ for more details.
       </div>
       <div>
         <strong
-          class="css-cyicbq-B"
+          class="css-1qx481h-B"
         >
           See: 
         </strong>
@@ -6262,7 +6262,7 @@ for more details.
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-10jm9cu-InlineCode"
+                  class="inline css-ov7own-InlineCode"
                 >
                   UNSUPPORTED
                 </code>
@@ -6300,7 +6300,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="inline css-bs4uzw-APISectionEnums"
+        class="inline css-1rann0c-APISectionEnums"
       >
         AppleAuthenticationUserDetectionStatus
         .
@@ -6308,7 +6308,7 @@ for more details.
          ＝ 0
       </code>
       <p
-        class="css-gvfsz4-P"
+        class="css-6jxvia-P"
         data-text="true"
       >
         The system does not support this determination and there is no data.
@@ -6340,7 +6340,7 @@ for more details.
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-10jm9cu-InlineCode"
+                  class="inline css-ov7own-InlineCode"
                 >
                   UNKNOWN
                 </code>
@@ -6378,7 +6378,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="inline css-bs4uzw-APISectionEnums"
+        class="inline css-1rann0c-APISectionEnums"
       >
         AppleAuthenticationUserDetectionStatus
         .
@@ -6386,7 +6386,7 @@ for more details.
          ＝ 1
       </code>
       <p
-        class="css-gvfsz4-P"
+        class="css-6jxvia-P"
         data-text="true"
       >
         The system has not determined whether the user might be a real person.
@@ -6418,7 +6418,7 @@ for more details.
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-10jm9cu-InlineCode"
+                  class="inline css-ov7own-InlineCode"
                 >
                   LIKELY_REAL
                 </code>
@@ -6456,7 +6456,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="inline css-bs4uzw-APISectionEnums"
+        class="inline css-1rann0c-APISectionEnums"
       >
         AppleAuthenticationUserDetectionStatus
         .
@@ -6464,7 +6464,7 @@ for more details.
          ＝ 2
       </code>
       <p
-        class="css-gvfsz4-P"
+        class="css-6jxvia-P"
         data-text="true"
       >
         The user appears to be a real person.
@@ -6477,7 +6477,7 @@ for more details.
 exports[`APISection expo-barcode-scanner 1`] = `
 <div>
   <h2
-    class="css-wpfbxc-H2"
+    class="css-1ck3d9a-H2"
     data-heading="true"
   >
     <div
@@ -6549,7 +6549,7 @@ exports[`APISection expo-barcode-scanner 1`] = `
             class="css-6n7j50"
           >
             <code
-              class="inline css-10jm9cu-InlineCode"
+              class="inline css-ov7own-InlineCode"
             >
               BarCodeScanner
             </code>
@@ -6586,17 +6586,17 @@ exports[`APISection expo-barcode-scanner 1`] = `
       </div>
     </h3>
     <p
-      class="css-gvfsz4-P"
+      class="css-6jxvia-P"
       data-text="true"
     >
       <strong
-        class="css-cyicbq-B"
+        class="css-1qx481h-B"
       >
         Type:
       </strong>
        
       <code
-        class="inline css-10jm9cu-InlineCode"
+        class="inline css-ov7own-InlineCode"
       >
         Component
         &lt;
@@ -6612,7 +6612,7 @@ exports[`APISection expo-barcode-scanner 1`] = `
       </code>
     </p>
     <h2
-      class="css-wpfbxc-H2"
+      class="css-1ck3d9a-H2"
       data-heading="true"
     >
       <div
@@ -6685,7 +6685,7 @@ exports[`APISection expo-barcode-scanner 1`] = `
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-tu4dab-InlineCode"
+                  class="inline css-1pk617c-InlineCode"
                 >
                   barCodeTypes
                 </code>
@@ -6722,7 +6722,7 @@ exports[`APISection expo-barcode-scanner 1`] = `
           </div>
         </h3>
         <p
-          class="css-gvfsz4-P"
+          class="css-6jxvia-P"
           data-text="true"
         >
           <span
@@ -6737,25 +6737,25 @@ exports[`APISection expo-barcode-scanner 1`] = `
           </span>
            
           <code
-            class="inline css-10jm9cu-InlineCode"
+            class="inline css-ov7own-InlineCode"
           >
             string[]
           </code>
         </p>
         <p
-          class="css-gvfsz4-P"
+          class="css-6jxvia-P"
           data-text="true"
         >
           An array of bar code types. Usage: 
           <code
-            class="inline css-10jm9cu-InlineCode"
+            class="inline css-ov7own-InlineCode"
           >
             BarCodeScanner.Constants.BarCodeType.&lt;codeType&gt;
           </code>
            where
 
           <code
-            class="inline css-10jm9cu-InlineCode"
+            class="inline css-ov7own-InlineCode"
           >
             codeType
           </code>
@@ -6771,12 +6771,12 @@ code types. It is recommended to provide only the bar code formats you expect to
 minimize battery usage.
         </p>
         <p
-          class="css-gvfsz4-P"
+          class="css-6jxvia-P"
           data-text="true"
         >
           For example: 
           <code
-            class="inline css-10jm9cu-InlineCode"
+            class="inline css-ov7own-InlineCode"
           >
             barCodeTypes={[BarCodeScanner.Constants.BarCodeType.qr]}
           </code>
@@ -6805,7 +6805,7 @@ minimize battery usage.
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-tu4dab-InlineCode"
+                  class="inline css-1pk617c-InlineCode"
                 >
                   onBarCodeScanned
                 </code>
@@ -6842,7 +6842,7 @@ minimize battery usage.
           </div>
         </h3>
         <p
-          class="css-gvfsz4-P"
+          class="css-6jxvia-P"
           data-text="true"
         >
           <span
@@ -6857,7 +6857,7 @@ minimize battery usage.
           </span>
            
           <code
-            class="inline css-10jm9cu-InlineCode"
+            class="inline css-ov7own-InlineCode"
           >
             <a
               class="css-153g748-InternalLink"
@@ -6868,7 +6868,7 @@ minimize battery usage.
           </code>
         </p>
         <p
-          class="css-gvfsz4-P"
+          class="css-6jxvia-P"
           data-text="true"
         >
           A callback that is invoked when a bar code has been successfully scanned. The callback is
@@ -6884,7 +6884,7 @@ provided with an
         
 
         <blockquote
-          class="css-y2d7cg-Quote"
+          class="css-1nn217x-Quote"
           data-text="true"
         >
           <div
@@ -6911,19 +6911,19 @@ provided with an
             
 
             <strong
-              class="css-cyicbq-B"
+              class="css-1qx481h-B"
             >
               Note:
             </strong>
              Passing 
             <code
-              class="inline css-10jm9cu-InlineCode"
+              class="inline css-ov7own-InlineCode"
             >
               undefined
             </code>
              to the 
             <code
-              class="inline css-10jm9cu-InlineCode"
+              class="inline css-ov7own-InlineCode"
             >
               onBarCodeScanned
             </code>
@@ -6957,7 +6957,7 @@ data has been retrieved.
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-tu4dab-InlineCode"
+                  class="inline css-1pk617c-InlineCode"
                 >
                   type
                 </code>
@@ -6994,7 +6994,7 @@ data has been retrieved.
           </div>
         </h3>
         <p
-          class="css-gvfsz4-P"
+          class="css-6jxvia-P"
           data-text="true"
         >
           <span
@@ -7009,7 +7009,7 @@ data has been retrieved.
           </span>
            
           <code
-            class="inline css-10jm9cu-InlineCode"
+            class="inline css-ov7own-InlineCode"
           >
             <span>
               'front'
@@ -7031,7 +7031,7 @@ data has been retrieved.
             </span>
              
             <code
-              class="inline css-10jm9cu-InlineCode"
+              class="inline css-ov7own-InlineCode"
             >
               Type.back
 
@@ -7039,31 +7039,31 @@ data has been retrieved.
           </span>
         </p>
         <p
-          class="css-gvfsz4-P"
+          class="css-6jxvia-P"
           data-text="true"
         >
           Camera facing. Use one of 
           <code
-            class="inline css-10jm9cu-InlineCode"
+            class="inline css-ov7own-InlineCode"
           >
             BarCodeScanner.Constants.Type
           </code>
           . Use either 
           <code
-            class="inline css-10jm9cu-InlineCode"
+            class="inline css-ov7own-InlineCode"
           >
             Type.front
           </code>
            or 
           <code
-            class="inline css-10jm9cu-InlineCode"
+            class="inline css-ov7own-InlineCode"
           >
             Type.back
           </code>
           .
 Same as 
           <code
-            class="inline css-10jm9cu-InlineCode"
+            class="inline css-ov7own-InlineCode"
           >
             Camera.Constants.Type
           </code>
@@ -7122,14 +7122,14 @@ Same as
         </div>
       </h3>
       <ul
-        class="css-viw9dk-UL"
+        class="css-ftstf7-UL"
         data-text="true"
       >
         <li
-          class="docs-list-item css-l157nt-LI"
+          class="docs-list-item css-1yzgz3v-LI"
         >
           <code
-            class="inline css-10jm9cu-InlineCode"
+            class="inline css-ov7own-InlineCode"
           >
             <a
               class="css-153g748-InternalLink"
@@ -7143,7 +7143,7 @@ Same as
     </div>
   </div>
   <h2
-    class="css-wpfbxc-H2"
+    class="css-1ck3d9a-H2"
     data-heading="true"
   >
     <div
@@ -7215,7 +7215,7 @@ Same as
             class="css-6n7j50"
           >
             <code
-              class="inline css-tu4dab-InlineCode"
+              class="inline css-1pk617c-InlineCode"
             >
               usePermissions(options)
             </code>
@@ -7288,7 +7288,7 @@ Same as
               class="css-t44xva-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 options
               </strong>
@@ -7303,7 +7303,7 @@ Same as
               class="css-t44xva-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 <a
                   class="css-153g748-InternalLink"
@@ -7328,7 +7328,7 @@ Same as
       </table>
     </div>
     <p
-      class="css-gvfsz4-P"
+      class="css-6jxvia-P"
       data-text="true"
     >
       Create a new permission hook with the permission methods built-in.
@@ -7350,7 +7350,7 @@ This can be used to quickly create specific permission hooks in every module.
         data-text="true"
       >
         <code
-          class="css-tqrxwq"
+          class="css-3rj4bb"
         >
           <span
             class="token keyword"
@@ -7474,11 +7474,11 @@ This can be used to quickly create specific permission hooks in every module.
       </h4>
     </div>
     <ul
-      class="css-ozzgx3-UL"
+      class="css-n6fu3c-UL"
       data-text="true"
     >
       <li
-        class="docs-list-item css-l157nt-LI"
+        class="docs-list-item css-1yzgz3v-LI"
       >
         <svg
           class="css-1xa9dbk-APISectionMethods"
@@ -7499,7 +7499,7 @@ This can be used to quickly create specific permission hooks in every module.
           />
         </svg>
         <code
-          class="inline css-10jm9cu-InlineCode"
+          class="inline css-ov7own-InlineCode"
         >
           [
           <span>
@@ -7550,7 +7550,7 @@ This can be used to quickly create specific permission hooks in every module.
     </ul>
   </div>
   <h2
-    class="css-wpfbxc-H2"
+    class="css-1ck3d9a-H2"
     data-heading="true"
   >
     <div
@@ -7622,7 +7622,7 @@ This can be used to quickly create specific permission hooks in every module.
             class="css-6n7j50"
           >
             <code
-              class="inline css-tu4dab-InlineCode"
+              class="inline css-1pk617c-InlineCode"
             >
               BarCodeScanner.
               getPermissionsAsync()
@@ -7660,7 +7660,7 @@ This can be used to quickly create specific permission hooks in every module.
       </div>
     </h3>
     <p
-      class="css-gvfsz4-P"
+      class="css-6jxvia-P"
       data-text="true"
     >
       Checks user's permissions for accessing the camera.
@@ -7722,11 +7722,11 @@ This can be used to quickly create specific permission hooks in every module.
       </h4>
     </div>
     <ul
-      class="css-ozzgx3-UL"
+      class="css-n6fu3c-UL"
       data-text="true"
     >
       <li
-        class="docs-list-item css-l157nt-LI"
+        class="docs-list-item css-1yzgz3v-LI"
       >
         <svg
           class="css-1xa9dbk-APISectionMethods"
@@ -7747,7 +7747,7 @@ This can be used to quickly create specific permission hooks in every module.
           />
         </svg>
         <code
-          class="inline css-10jm9cu-InlineCode"
+          class="inline css-ov7own-InlineCode"
         >
           <a
             class="css-ccg2mn-ExternalLink"
@@ -7770,7 +7770,7 @@ This can be used to quickly create specific permission hooks in every module.
       </li>
     </ul>
     <p
-      class="css-gvfsz4-P"
+      class="css-6jxvia-P"
       data-text="true"
     >
       Return a promise that fulfills to an object of type 
@@ -7779,7 +7779,7 @@ This can be used to quickly create specific permission hooks in every module.
         href="/#permissionresponse"
       >
         <code
-          class="inline css-10jm9cu-InlineCode"
+          class="inline css-ov7own-InlineCode"
         >
           PermissionResponse
         </code>
@@ -7809,7 +7809,7 @@ This can be used to quickly create specific permission hooks in every module.
             class="css-6n7j50"
           >
             <code
-              class="inline css-tu4dab-InlineCode"
+              class="inline css-1pk617c-InlineCode"
             >
               BarCodeScanner.
               requestPermissionsAsync()
@@ -7847,24 +7847,24 @@ This can be used to quickly create specific permission hooks in every module.
       </div>
     </h3>
     <p
-      class="css-gvfsz4-P"
+      class="css-6jxvia-P"
       data-text="true"
     >
       Asks the user to grant permissions for accessing the camera.
     </p>
     <p
-      class="css-gvfsz4-P"
+      class="css-6jxvia-P"
       data-text="true"
     >
       On iOS this will require apps to specify the 
       <code
-        class="inline css-10jm9cu-InlineCode"
+        class="inline css-ov7own-InlineCode"
       >
         NSCameraUsageDescription
       </code>
        entry in the 
       <code
-        class="inline css-10jm9cu-InlineCode"
+        class="inline css-ov7own-InlineCode"
       >
         Info.plist
       </code>
@@ -7927,11 +7927,11 @@ This can be used to quickly create specific permission hooks in every module.
       </h4>
     </div>
     <ul
-      class="css-ozzgx3-UL"
+      class="css-n6fu3c-UL"
       data-text="true"
     >
       <li
-        class="docs-list-item css-l157nt-LI"
+        class="docs-list-item css-1yzgz3v-LI"
       >
         <svg
           class="css-1xa9dbk-APISectionMethods"
@@ -7952,7 +7952,7 @@ This can be used to quickly create specific permission hooks in every module.
           />
         </svg>
         <code
-          class="inline css-10jm9cu-InlineCode"
+          class="inline css-ov7own-InlineCode"
         >
           <a
             class="css-ccg2mn-ExternalLink"
@@ -7975,7 +7975,7 @@ This can be used to quickly create specific permission hooks in every module.
       </li>
     </ul>
     <p
-      class="css-gvfsz4-P"
+      class="css-6jxvia-P"
       data-text="true"
     >
       Return a promise that fulfills to an object of type 
@@ -7984,7 +7984,7 @@ This can be used to quickly create specific permission hooks in every module.
         href="/#permissionresponse"
       >
         <code
-          class="inline css-10jm9cu-InlineCode"
+          class="inline css-ov7own-InlineCode"
         >
           PermissionResponse
         </code>
@@ -8014,7 +8014,7 @@ This can be used to quickly create specific permission hooks in every module.
             class="css-6n7j50"
           >
             <code
-              class="inline css-tu4dab-InlineCode"
+              class="inline css-1pk617c-InlineCode"
             >
               BarCodeScanner.
               scanFromURLAsync(url, barCodeTypes)
@@ -8088,7 +8088,7 @@ This can be used to quickly create specific permission hooks in every module.
               class="css-t44xva-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 url
               </strong>
@@ -8097,7 +8097,7 @@ This can be used to quickly create specific permission hooks in every module.
               class="css-t44xva-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 string
               </code>
@@ -8117,7 +8117,7 @@ This can be used to quickly create specific permission hooks in every module.
               class="css-t44xva-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 barCodeTypes
               </strong>
@@ -8132,7 +8132,7 @@ This can be used to quickly create specific permission hooks in every module.
               class="css-t44xva-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 string[]
               </code>
@@ -8147,7 +8147,7 @@ the platform.
               
 
               <blockquote
-                class="css-y2d7cg-Quote"
+                class="css-1nn217x-Quote"
                 data-text="true"
               >
                 <div
@@ -8174,7 +8174,7 @@ the platform.
                   
 
                   <strong
-                    class="css-cyicbq-B"
+                    class="css-1qx481h-B"
                   >
                     Note:
                   </strong>
@@ -8189,7 +8189,7 @@ the platform.
       </table>
     </div>
     <p
-      class="css-gvfsz4-P"
+      class="css-6jxvia-P"
       data-text="true"
     >
       Scan bar codes from the image given by the URL.
@@ -8251,11 +8251,11 @@ the platform.
       </h4>
     </div>
     <ul
-      class="css-ozzgx3-UL"
+      class="css-n6fu3c-UL"
       data-text="true"
     >
       <li
-        class="docs-list-item css-l157nt-LI"
+        class="docs-list-item css-1yzgz3v-LI"
       >
         <svg
           class="css-1xa9dbk-APISectionMethods"
@@ -8276,7 +8276,7 @@ the platform.
           />
         </svg>
         <code
-          class="inline css-10jm9cu-InlineCode"
+          class="inline css-ov7own-InlineCode"
         >
           <a
             class="css-ccg2mn-ExternalLink"
@@ -8300,12 +8300,12 @@ the platform.
       </li>
     </ul>
     <p
-      class="css-gvfsz4-P"
+      class="css-6jxvia-P"
       data-text="true"
     >
       A possibly empty array of objects of the 
       <code
-        class="inline css-10jm9cu-InlineCode"
+        class="inline css-ov7own-InlineCode"
       >
         BarCodeScannerResult
       </code>
@@ -8315,7 +8315,7 @@ code.
     </p>
   </div>
   <h2
-    class="css-wpfbxc-H2"
+    class="css-1ck3d9a-H2"
     data-heading="true"
   >
     <div
@@ -8387,7 +8387,7 @@ code.
             class="css-6n7j50"
           >
             <code
-              class="inline css-10jm9cu-InlineCode"
+              class="inline css-ov7own-InlineCode"
             >
               PermissionResponse
             </code>
@@ -8424,7 +8424,7 @@ code.
       </div>
     </h3>
     <p
-      class="css-gvfsz4-P"
+      class="css-6jxvia-P"
       data-text="true"
     >
       An object obtained by permissions get and request functions.
@@ -8523,7 +8523,7 @@ code.
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 canAskAgain
               </strong>
@@ -8532,7 +8532,7 @@ code.
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 boolean
               </code>
@@ -8554,7 +8554,7 @@ in order to enable/disable the permission.
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 expires
               </strong>
@@ -8563,7 +8563,7 @@ in order to enable/disable the permission.
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 <a
                   class="css-153g748-InternalLink"
@@ -8588,7 +8588,7 @@ in order to enable/disable the permission.
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 granted
               </strong>
@@ -8597,7 +8597,7 @@ in order to enable/disable the permission.
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 boolean
               </code>
@@ -8617,7 +8617,7 @@ in order to enable/disable the permission.
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 status
               </strong>
@@ -8626,7 +8626,7 @@ in order to enable/disable the permission.
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 <a
                   class="css-153g748-InternalLink"
@@ -8649,7 +8649,7 @@ in order to enable/disable the permission.
     </div>
   </div>
   <h2
-    class="css-wpfbxc-H2"
+    class="css-1ck3d9a-H2"
     data-heading="true"
   >
     <div
@@ -8721,7 +8721,7 @@ in order to enable/disable the permission.
             class="css-6n7j50"
           >
             <code
-              class="inline css-10jm9cu-InlineCode"
+              class="inline css-ov7own-InlineCode"
             >
               BarCodeBounds
             </code>
@@ -8794,7 +8794,7 @@ in order to enable/disable the permission.
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 origin
               </strong>
@@ -8803,7 +8803,7 @@ in order to enable/disable the permission.
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 <a
                   class="css-153g748-InternalLink"
@@ -8828,7 +8828,7 @@ in order to enable/disable the permission.
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 size
               </strong>
@@ -8837,7 +8837,7 @@ in order to enable/disable the permission.
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 <a
                   class="css-153g748-InternalLink"
@@ -8881,7 +8881,7 @@ in order to enable/disable the permission.
             class="css-6n7j50"
           >
             <code
-              class="inline css-10jm9cu-InlineCode"
+              class="inline css-ov7own-InlineCode"
             >
               BarCodeEvent
             </code>
@@ -8918,11 +8918,11 @@ in order to enable/disable the permission.
       </div>
     </h3>
     <p
-      class="css-gvfsz4-P"
+      class="css-6jxvia-P"
       data-text="true"
     >
       <code
-        class="inline css-10jm9cu-InlineCode"
+        class="inline css-ov7own-InlineCode"
       >
         <a
           class="css-153g748-InternalLink"
@@ -8971,7 +8971,7 @@ in order to enable/disable the permission.
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 target
               </strong>
@@ -8986,7 +8986,7 @@ in order to enable/disable the permission.
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 number
               </code>
@@ -9023,7 +9023,7 @@ in order to enable/disable the permission.
             class="css-6n7j50"
           >
             <code
-              class="inline css-10jm9cu-InlineCode"
+              class="inline css-ov7own-InlineCode"
             >
               BarCodeEventCallbackArguments
             </code>
@@ -9096,7 +9096,7 @@ in order to enable/disable the permission.
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 nativeEvent
               </strong>
@@ -9105,7 +9105,7 @@ in order to enable/disable the permission.
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 <a
                   class="css-153g748-InternalLink"
@@ -9147,7 +9147,7 @@ in order to enable/disable the permission.
             class="css-6n7j50"
           >
             <code
-              class="inline css-10jm9cu-InlineCode"
+              class="inline css-ov7own-InlineCode"
             >
               BarCodePoint
             </code>
@@ -9184,7 +9184,7 @@ in order to enable/disable the permission.
       </div>
     </h3>
     <p
-      class="css-gvfsz4-P"
+      class="css-6jxvia-P"
       data-text="true"
     >
       Those coordinates are represented in the coordinate space of the barcode source (e.g. when you
@@ -9227,7 +9227,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 x
               </strong>
@@ -9236,7 +9236,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 number
               </code>
@@ -9247,7 +9247,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               <span>
                 The 
                 <code
-                  class="inline css-10jm9cu-InlineCode"
+                  class="inline css-ov7own-InlineCode"
                 >
                   x
                 </code>
@@ -9262,7 +9262,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 y
               </strong>
@@ -9271,7 +9271,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 number
               </code>
@@ -9282,7 +9282,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               <span>
                 The 
                 <code
-                  class="inline css-10jm9cu-InlineCode"
+                  class="inline css-ov7own-InlineCode"
                 >
                   y
                 </code>
@@ -9316,7 +9316,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
             class="css-6n7j50"
           >
             <code
-              class="inline css-10jm9cu-InlineCode"
+              class="inline css-ov7own-InlineCode"
             >
               BarCodeScannedCallback
               ()
@@ -9391,7 +9391,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
                 class="css-t44xva-Cell"
               >
                 <strong
-                  class="css-cyicbq-B"
+                  class="css-1qx481h-B"
                 >
                   params
                 </strong>
@@ -9400,7 +9400,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
                 class="css-t44xva-Cell"
               >
                 <code
-                  class="inline css-10jm9cu-InlineCode"
+                  class="inline css-ov7own-InlineCode"
                 >
                   <a
                     class="css-153g748-InternalLink"
@@ -9443,7 +9443,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
             class="css-6n7j50"
           >
             <code
-              class="inline css-10jm9cu-InlineCode"
+              class="inline css-ov7own-InlineCode"
             >
               BarCodeScannerResult
             </code>
@@ -9480,7 +9480,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
       </div>
     </h3>
     <blockquote
-      class="css-y2d7cg-Quote"
+      class="css-1nn217x-Quote"
       data-text="true"
     >
       <div
@@ -9507,31 +9507,31 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
         
 
         <strong
-          class="css-cyicbq-B"
+          class="css-1qx481h-B"
         >
           Note:
         </strong>
          
         <code
-          class="inline css-10jm9cu-InlineCode"
+          class="inline css-ov7own-InlineCode"
         >
           bounds
         </code>
          and 
         <code
-          class="inline css-10jm9cu-InlineCode"
+          class="inline css-ov7own-InlineCode"
         >
           cornerPoints
         </code>
          are not always available. On iOS, for 
         <code
-          class="inline css-10jm9cu-InlineCode"
+          class="inline css-ov7own-InlineCode"
         >
           code39
         </code>
          and 
         <code
-          class="inline css-10jm9cu-InlineCode"
+          class="inline css-ov7own-InlineCode"
         >
           pdf417
         </code>
@@ -9579,7 +9579,7 @@ For some types, they will represent the area used by the scanner.
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 bounds
               </strong>
@@ -9594,7 +9594,7 @@ For some types, they will represent the area used by the scanner.
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 <a
                   class="css-153g748-InternalLink"
@@ -9626,7 +9626,7 @@ For some types, they will represent the area used by the scanner.
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 cornerPoints
               </strong>
@@ -9641,7 +9641,7 @@ For some types, they will represent the area used by the scanner.
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 <a
                   class="css-153g748-InternalLink"
@@ -9667,7 +9667,7 @@ For some types, they will represent the area used by the scanner.
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 data
               </strong>
@@ -9676,7 +9676,7 @@ For some types, they will represent the area used by the scanner.
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 string
               </code>
@@ -9696,7 +9696,7 @@ For some types, they will represent the area used by the scanner.
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 type
               </strong>
@@ -9705,7 +9705,7 @@ For some types, they will represent the area used by the scanner.
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 string
               </code>
@@ -9744,7 +9744,7 @@ For some types, they will represent the area used by the scanner.
             class="css-6n7j50"
           >
             <code
-              class="inline css-10jm9cu-InlineCode"
+              class="inline css-ov7own-InlineCode"
             >
               BarCodeSize
             </code>
@@ -9817,7 +9817,7 @@ For some types, they will represent the area used by the scanner.
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 height
               </strong>
@@ -9826,7 +9826,7 @@ For some types, they will represent the area used by the scanner.
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 number
               </code>
@@ -9846,7 +9846,7 @@ For some types, they will represent the area used by the scanner.
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 width
               </strong>
@@ -9855,7 +9855,7 @@ For some types, they will represent the area used by the scanner.
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 number
               </code>
@@ -9894,7 +9894,7 @@ For some types, they will represent the area used by the scanner.
             class="css-6n7j50"
           >
             <code
-              class="inline css-10jm9cu-InlineCode"
+              class="inline css-ov7own-InlineCode"
             >
               PermissionHookOptions
             </code>
@@ -9931,14 +9931,14 @@ For some types, they will represent the area used by the scanner.
       </div>
     </h3>
     <p
-      class="css-gvfsz4-P"
+      class="css-6jxvia-P"
       data-text="true"
     >
       Acceptable values are:
        
       <span>
         <code
-          class="inline css-10jm9cu-InlineCode"
+          class="inline css-ov7own-InlineCode"
         >
           PermissionHookBehavior
         </code>
@@ -9946,7 +9946,7 @@ For some types, they will represent the area used by the scanner.
       </span>
       <span>
         <code
-          class="inline css-10jm9cu-InlineCode"
+          class="inline css-ov7own-InlineCode"
         >
           Options
         </code>
@@ -9955,7 +9955,7 @@ For some types, they will represent the area used by the scanner.
     </p>
   </div>
   <h2
-    class="css-wpfbxc-H2"
+    class="css-1ck3d9a-H2"
     data-heading="true"
   >
     <div
@@ -10027,7 +10027,7 @@ For some types, they will represent the area used by the scanner.
             class="css-6n7j50"
           >
             <code
-              class="inline css-10jm9cu-InlineCode"
+              class="inline css-ov7own-InlineCode"
             >
               PermissionStatus
             </code>
@@ -10089,7 +10089,7 @@ For some types, they will represent the area used by the scanner.
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-10jm9cu-InlineCode"
+                  class="inline css-ov7own-InlineCode"
                 >
                   DENIED
                 </code>
@@ -10127,7 +10127,7 @@ For some types, they will represent the area used by the scanner.
         </h4>
       </div>
       <code
-        class="inline css-bs4uzw-APISectionEnums"
+        class="inline css-1rann0c-APISectionEnums"
       >
         PermissionStatus
         .
@@ -10135,7 +10135,7 @@ For some types, they will represent the area used by the scanner.
          ＝ "denied"
       </code>
       <p
-        class="css-gvfsz4-P"
+        class="css-6jxvia-P"
         data-text="true"
       >
         User has denied the permission.
@@ -10167,7 +10167,7 @@ For some types, they will represent the area used by the scanner.
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-10jm9cu-InlineCode"
+                  class="inline css-ov7own-InlineCode"
                 >
                   GRANTED
                 </code>
@@ -10205,7 +10205,7 @@ For some types, they will represent the area used by the scanner.
         </h4>
       </div>
       <code
-        class="inline css-bs4uzw-APISectionEnums"
+        class="inline css-1rann0c-APISectionEnums"
       >
         PermissionStatus
         .
@@ -10213,7 +10213,7 @@ For some types, they will represent the area used by the scanner.
          ＝ "granted"
       </code>
       <p
-        class="css-gvfsz4-P"
+        class="css-6jxvia-P"
         data-text="true"
       >
         User has granted the permission.
@@ -10245,7 +10245,7 @@ For some types, they will represent the area used by the scanner.
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-10jm9cu-InlineCode"
+                  class="inline css-ov7own-InlineCode"
                 >
                   UNDETERMINED
                 </code>
@@ -10283,7 +10283,7 @@ For some types, they will represent the area used by the scanner.
         </h4>
       </div>
       <code
-        class="inline css-bs4uzw-APISectionEnums"
+        class="inline css-1rann0c-APISectionEnums"
       >
         PermissionStatus
         .
@@ -10291,7 +10291,7 @@ For some types, they will represent the area used by the scanner.
          ＝ "undetermined"
       </code>
       <p
-        class="css-gvfsz4-P"
+        class="css-6jxvia-P"
         data-text="true"
       >
         User hasn't granted or denied the permission yet.
@@ -10304,7 +10304,7 @@ For some types, they will represent the area used by the scanner.
 exports[`APISection expo-pedometer 1`] = `
 <div>
   <h2
-    class="css-wpfbxc-H2"
+    class="css-1ck3d9a-H2"
     data-heading="true"
   >
     <div
@@ -10376,7 +10376,7 @@ exports[`APISection expo-pedometer 1`] = `
             class="css-6n7j50"
           >
             <code
-              class="inline css-tu4dab-InlineCode"
+              class="inline css-1pk617c-InlineCode"
             >
               getPermissionsAsync()
             </code>
@@ -10469,11 +10469,11 @@ exports[`APISection expo-pedometer 1`] = `
       </h4>
     </div>
     <ul
-      class="css-ozzgx3-UL"
+      class="css-n6fu3c-UL"
       data-text="true"
     >
       <li
-        class="docs-list-item css-l157nt-LI"
+        class="docs-list-item css-1yzgz3v-LI"
       >
         <svg
           class="css-1xa9dbk-APISectionMethods"
@@ -10494,7 +10494,7 @@ exports[`APISection expo-pedometer 1`] = `
           />
         </svg>
         <code
-          class="inline css-10jm9cu-InlineCode"
+          class="inline css-ov7own-InlineCode"
         >
           <a
             class="css-ccg2mn-ExternalLink"
@@ -10539,7 +10539,7 @@ exports[`APISection expo-pedometer 1`] = `
             class="css-6n7j50"
           >
             <code
-              class="inline css-tu4dab-InlineCode"
+              class="inline css-1pk617c-InlineCode"
             >
               getStepCountAsync(start, end)
             </code>
@@ -10612,7 +10612,7 @@ exports[`APISection expo-pedometer 1`] = `
               class="css-t44xva-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 start
               </strong>
@@ -10621,7 +10621,7 @@ exports[`APISection expo-pedometer 1`] = `
               class="css-t44xva-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 <a
                   class="css-ccg2mn-ExternalLink"
@@ -10647,7 +10647,7 @@ exports[`APISection expo-pedometer 1`] = `
               class="css-t44xva-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 end
               </strong>
@@ -10656,7 +10656,7 @@ exports[`APISection expo-pedometer 1`] = `
               class="css-t44xva-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 <a
                   class="css-ccg2mn-ExternalLink"
@@ -10679,7 +10679,7 @@ exports[`APISection expo-pedometer 1`] = `
       </table>
     </div>
     <p
-      class="css-gvfsz4-P"
+      class="css-6jxvia-P"
       data-text="true"
     >
       Get the step count between two dates.
@@ -10741,11 +10741,11 @@ exports[`APISection expo-pedometer 1`] = `
       </h4>
     </div>
     <ul
-      class="css-ozzgx3-UL"
+      class="css-n6fu3c-UL"
       data-text="true"
     >
       <li
-        class="docs-list-item css-l157nt-LI"
+        class="docs-list-item css-1yzgz3v-LI"
       >
         <svg
           class="css-1xa9dbk-APISectionMethods"
@@ -10766,7 +10766,7 @@ exports[`APISection expo-pedometer 1`] = `
           />
         </svg>
         <code
-          class="inline css-10jm9cu-InlineCode"
+          class="inline css-ov7own-InlineCode"
         >
           <a
             class="css-ccg2mn-ExternalLink"
@@ -10789,7 +10789,7 @@ exports[`APISection expo-pedometer 1`] = `
       </li>
     </ul>
     <p
-      class="css-gvfsz4-P"
+      class="css-6jxvia-P"
       data-text="true"
     >
       Returns a promise that fulfills with a 
@@ -10798,7 +10798,7 @@ exports[`APISection expo-pedometer 1`] = `
         href="/#pedometerresult"
       >
         <code
-          class="inline css-10jm9cu-InlineCode"
+          class="inline css-ov7own-InlineCode"
         >
           PedometerResult
         </code>
@@ -10808,7 +10808,7 @@ exports[`APISection expo-pedometer 1`] = `
     
 
     <p
-      class="css-gvfsz4-P"
+      class="css-6jxvia-P"
       data-text="true"
     >
       As 
@@ -10824,7 +10824,7 @@ exports[`APISection expo-pedometer 1`] = `
     
 
     <blockquote
-      class="css-y2d7cg-Quote"
+      class="css-1nn217x-Quote"
       data-text="true"
     >
       <div
@@ -10879,7 +10879,7 @@ a start date that is more than seven days in the past returns only the available
             class="css-6n7j50"
           >
             <code
-              class="inline css-tu4dab-InlineCode"
+              class="inline css-1pk617c-InlineCode"
             >
               isAvailableAsync()
             </code>
@@ -10916,7 +10916,7 @@ a start date that is more than seven days in the past returns only the available
       </div>
     </h3>
     <p
-      class="css-gvfsz4-P"
+      class="css-6jxvia-P"
       data-text="true"
     >
       Returns whether the pedometer is enabled on the device.
@@ -10978,11 +10978,11 @@ a start date that is more than seven days in the past returns only the available
       </h4>
     </div>
     <ul
-      class="css-ozzgx3-UL"
+      class="css-n6fu3c-UL"
       data-text="true"
     >
       <li
-        class="docs-list-item css-l157nt-LI"
+        class="docs-list-item css-1yzgz3v-LI"
       >
         <svg
           class="css-1xa9dbk-APISectionMethods"
@@ -11003,7 +11003,7 @@ a start date that is more than seven days in the past returns only the available
           />
         </svg>
         <code
-          class="inline css-10jm9cu-InlineCode"
+          class="inline css-ov7own-InlineCode"
         >
           <a
             class="css-ccg2mn-ExternalLink"
@@ -11021,12 +11021,12 @@ a start date that is more than seven days in the past returns only the available
       </li>
     </ul>
     <p
-      class="css-gvfsz4-P"
+      class="css-6jxvia-P"
       data-text="true"
     >
       Returns a promise that fulfills with a 
       <code
-        class="inline css-10jm9cu-InlineCode"
+        class="inline css-ov7own-InlineCode"
       >
         boolean
       </code>
@@ -11056,7 +11056,7 @@ available on this device.
             class="css-6n7j50"
           >
             <code
-              class="inline css-tu4dab-InlineCode"
+              class="inline css-1pk617c-InlineCode"
             >
               requestPermissionsAsync()
             </code>
@@ -11149,11 +11149,11 @@ available on this device.
       </h4>
     </div>
     <ul
-      class="css-ozzgx3-UL"
+      class="css-n6fu3c-UL"
       data-text="true"
     >
       <li
-        class="docs-list-item css-l157nt-LI"
+        class="docs-list-item css-1yzgz3v-LI"
       >
         <svg
           class="css-1xa9dbk-APISectionMethods"
@@ -11174,7 +11174,7 @@ available on this device.
           />
         </svg>
         <code
-          class="inline css-10jm9cu-InlineCode"
+          class="inline css-ov7own-InlineCode"
         >
           <a
             class="css-ccg2mn-ExternalLink"
@@ -11219,7 +11219,7 @@ available on this device.
             class="css-6n7j50"
           >
             <code
-              class="inline css-tu4dab-InlineCode"
+              class="inline css-1pk617c-InlineCode"
             >
               watchStepCount(callback)
             </code>
@@ -11292,7 +11292,7 @@ available on this device.
               class="css-t44xva-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 callback
               </strong>
@@ -11301,7 +11301,7 @@ available on this device.
               class="css-t44xva-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 <a
                   class="css-153g748-InternalLink"
@@ -11322,7 +11322,7 @@ provided with a single argument that is
                   href="/#pedometerresult"
                 >
                   <code
-                    class="inline css-10jm9cu-InlineCode"
+                    class="inline css-ov7own-InlineCode"
                   >
                     PedometerResult
                   </code>
@@ -11335,7 +11335,7 @@ provided with a single argument that is
       </table>
     </div>
     <p
-      class="css-gvfsz4-P"
+      class="css-6jxvia-P"
       data-text="true"
     >
       Subscribe to pedometer updates.
@@ -11397,11 +11397,11 @@ provided with a single argument that is
       </h4>
     </div>
     <ul
-      class="css-ozzgx3-UL"
+      class="css-n6fu3c-UL"
       data-text="true"
     >
       <li
-        class="docs-list-item css-l157nt-LI"
+        class="docs-list-item css-1yzgz3v-LI"
       >
         <svg
           class="css-1xa9dbk-APISectionMethods"
@@ -11422,7 +11422,7 @@ provided with a single argument that is
           />
         </svg>
         <code
-          class="inline css-10jm9cu-InlineCode"
+          class="inline css-ov7own-InlineCode"
         >
           <a
             class="css-153g748-InternalLink"
@@ -11434,7 +11434,7 @@ provided with a single argument that is
       </li>
     </ul>
     <p
-      class="css-gvfsz4-P"
+      class="css-6jxvia-P"
       data-text="true"
     >
       Returns a 
@@ -11443,7 +11443,7 @@ provided with a single argument that is
         href="/#subscription"
       >
         <code
-          class="inline css-10jm9cu-InlineCode"
+          class="inline css-ov7own-InlineCode"
         >
           Subscription
         </code>
@@ -11451,7 +11451,7 @@ provided with a single argument that is
        that enables you to call
 
       <code
-        class="inline css-10jm9cu-InlineCode"
+        class="inline css-ov7own-InlineCode"
       >
         remove()
       </code>
@@ -11459,7 +11459,7 @@ provided with a single argument that is
     </p>
   </div>
   <h2
-    class="css-wpfbxc-H2"
+    class="css-1ck3d9a-H2"
     data-heading="true"
   >
     <div
@@ -11531,7 +11531,7 @@ provided with a single argument that is
             class="css-6n7j50"
           >
             <code
-              class="inline css-10jm9cu-InlineCode"
+              class="inline css-ov7own-InlineCode"
             >
               PermissionResponse
             </code>
@@ -11661,7 +11661,7 @@ provided with a single argument that is
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 canAskAgain
               </strong>
@@ -11670,7 +11670,7 @@ provided with a single argument that is
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 boolean
               </code>
@@ -11688,7 +11688,7 @@ provided with a single argument that is
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 expires
               </strong>
@@ -11697,7 +11697,7 @@ provided with a single argument that is
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 <a
                   class="css-153g748-InternalLink"
@@ -11720,7 +11720,7 @@ provided with a single argument that is
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 granted
               </strong>
@@ -11729,7 +11729,7 @@ provided with a single argument that is
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 boolean
               </code>
@@ -11747,7 +11747,7 @@ provided with a single argument that is
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 status
               </strong>
@@ -11756,7 +11756,7 @@ provided with a single argument that is
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 <a
                   class="css-153g748-InternalLink"
@@ -11777,7 +11777,7 @@ provided with a single argument that is
     </div>
   </div>
   <h2
-    class="css-wpfbxc-H2"
+    class="css-1ck3d9a-H2"
     data-heading="true"
   >
     <div
@@ -11849,7 +11849,7 @@ provided with a single argument that is
             class="css-6n7j50"
           >
             <code
-              class="inline css-10jm9cu-InlineCode"
+              class="inline css-ov7own-InlineCode"
             >
               PedometerResult
             </code>
@@ -11922,7 +11922,7 @@ provided with a single argument that is
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 steps
               </strong>
@@ -11931,7 +11931,7 @@ provided with a single argument that is
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 number
               </code>
@@ -11970,7 +11970,7 @@ provided with a single argument that is
             class="css-6n7j50"
           >
             <code
-              class="inline css-10jm9cu-InlineCode"
+              class="inline css-ov7own-InlineCode"
             >
               PedometerUpdateCallback
               ()
@@ -12045,7 +12045,7 @@ provided with a single argument that is
                 class="css-t44xva-Cell"
               >
                 <strong
-                  class="css-cyicbq-B"
+                  class="css-1qx481h-B"
                 >
                   result
                 </strong>
@@ -12054,7 +12054,7 @@ provided with a single argument that is
                 class="css-t44xva-Cell"
               >
                 <code
-                  class="inline css-10jm9cu-InlineCode"
+                  class="inline css-ov7own-InlineCode"
                 >
                   <a
                     class="css-153g748-InternalLink"
@@ -12097,7 +12097,7 @@ provided with a single argument that is
             class="css-6n7j50"
           >
             <code
-              class="inline css-10jm9cu-InlineCode"
+              class="inline css-ov7own-InlineCode"
             >
               PermissionExpiration
             </code>
@@ -12134,14 +12134,14 @@ provided with a single argument that is
       </div>
     </h3>
     <p
-      class="css-gvfsz4-P"
+      class="css-6jxvia-P"
       data-text="true"
     >
       Acceptable values are:
        
       <span>
         <code
-          class="inline css-10jm9cu-InlineCode"
+          class="inline css-ov7own-InlineCode"
         >
           'never'
         </code>
@@ -12149,7 +12149,7 @@ provided with a single argument that is
       </span>
       <span>
         <code
-          class="inline css-10jm9cu-InlineCode"
+          class="inline css-ov7own-InlineCode"
         >
           number
         </code>
@@ -12179,7 +12179,7 @@ provided with a single argument that is
             class="css-6n7j50"
           >
             <code
-              class="inline css-10jm9cu-InlineCode"
+              class="inline css-ov7own-InlineCode"
             >
               Subscription
             </code>
@@ -12252,7 +12252,7 @@ provided with a single argument that is
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 remove
               </strong>
@@ -12261,7 +12261,7 @@ provided with a single argument that is
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 (
                 ) =&gt;
@@ -12282,7 +12282,7 @@ provided with a single argument that is
     </div>
   </div>
   <h2
-    class="css-wpfbxc-H2"
+    class="css-1ck3d9a-H2"
     data-heading="true"
   >
     <div
@@ -12354,7 +12354,7 @@ provided with a single argument that is
             class="css-6n7j50"
           >
             <code
-              class="inline css-10jm9cu-InlineCode"
+              class="inline css-ov7own-InlineCode"
             >
               PermissionStatus
             </code>
@@ -12416,7 +12416,7 @@ provided with a single argument that is
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-10jm9cu-InlineCode"
+                  class="inline css-ov7own-InlineCode"
                 >
                   DENIED
                 </code>
@@ -12454,7 +12454,7 @@ provided with a single argument that is
         </h4>
       </div>
       <code
-        class="inline css-bs4uzw-APISectionEnums"
+        class="inline css-1rann0c-APISectionEnums"
       >
         PermissionStatus
         .
@@ -12488,7 +12488,7 @@ provided with a single argument that is
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-10jm9cu-InlineCode"
+                  class="inline css-ov7own-InlineCode"
                 >
                   GRANTED
                 </code>
@@ -12526,7 +12526,7 @@ provided with a single argument that is
         </h4>
       </div>
       <code
-        class="inline css-bs4uzw-APISectionEnums"
+        class="inline css-1rann0c-APISectionEnums"
       >
         PermissionStatus
         .
@@ -12560,7 +12560,7 @@ provided with a single argument that is
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-10jm9cu-InlineCode"
+                  class="inline css-ov7own-InlineCode"
                 >
                   UNDETERMINED
                 </code>
@@ -12598,7 +12598,7 @@ provided with a single argument that is
         </h4>
       </div>
       <code
-        class="inline css-bs4uzw-APISectionEnums"
+        class="inline css-1rann0c-APISectionEnums"
       >
         PermissionStatus
         .
@@ -12613,7 +12613,7 @@ provided with a single argument that is
 exports[`APISection no data 1`] = `
 <div>
   <p
-    class="css-gvfsz4-P"
+    class="css-6jxvia-P"
     data-text="true"
   >
     No API data file found, sorry!

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`APISection expo-apple-authentication 1`] = `
 <div>
   <h2
-    class="css-1azb2g5-H2"
+    class="css-wpfbxc-H2"
     data-heading="true"
   >
     <div
@@ -57,7 +57,7 @@ exports[`APISection expo-apple-authentication 1`] = `
     class="css-excx5x-APISectionComponents"
   >
     <h3
-      class="css-6kh5nb-H3"
+      class="css-m417je-H3"
       data-heading="true"
     >
       <div
@@ -75,7 +75,7 @@ exports[`APISection expo-apple-authentication 1`] = `
             class="css-6n7j50"
           >
             <code
-              class="inline css-16lpqq8-InlineCode"
+              class="inline css-10jm9cu-InlineCode"
             >
               AppleAuthenticationButton
             </code>
@@ -112,17 +112,17 @@ exports[`APISection expo-apple-authentication 1`] = `
       </div>
     </h3>
     <p
-      class="css-1bjvyhe-P"
+      class="css-gvfsz4-P"
       data-text="true"
     >
       <strong
-        class="css-1k788ud-B"
+        class="css-cyicbq-B"
       >
         Type:
       </strong>
        
       <code
-        class="inline css-16lpqq8-InlineCode"
+        class="inline css-10jm9cu-InlineCode"
       >
         React.FC
         &lt;
@@ -138,7 +138,7 @@ exports[`APISection expo-apple-authentication 1`] = `
       </code>
     </p>
     <p
-      class="css-1bjvyhe-P"
+      class="css-gvfsz4-P"
       data-text="true"
     >
       This component displays the proprietary "Sign In with Apple" / "Continue with Apple" button on
@@ -147,7 +147,7 @@ authentication process instead of a custom button. Limited customization of the 
 available via the provided properties.
     </p>
     <p
-      class="css-1bjvyhe-P"
+      class="css-gvfsz4-P"
       data-text="true"
     >
       You should only attempt to render this if 
@@ -156,7 +156,7 @@ available via the provided properties.
         href="/#isavailableasync"
       >
         <code
-          class="inline css-16lpqq8-InlineCode"
+          class="inline css-10jm9cu-InlineCode"
         >
           AppleAuthentication.isAvailableAsync()
         </code>
@@ -164,14 +164,14 @@ available via the provided properties.
       
 resolves to 
       <code
-        class="inline css-16lpqq8-InlineCode"
+        class="inline css-10jm9cu-InlineCode"
       >
         true
       </code>
       . This component will render nothing if it is not available, and you will get
 a warning in development mode (
       <code
-        class="inline css-16lpqq8-InlineCode"
+        class="inline css-10jm9cu-InlineCode"
       >
         __DEV__ === true
       </code>
@@ -180,45 +180,45 @@ a warning in development mode (
     
 
     <p
-      class="css-1bjvyhe-P"
+      class="css-gvfsz4-P"
       data-text="true"
     >
       The properties of this component extend from 
       <code
-        class="inline css-16lpqq8-InlineCode"
+        class="inline css-10jm9cu-InlineCode"
       >
         View
       </code>
       ; however, you should not attempt to set
 
       <code
-        class="inline css-16lpqq8-InlineCode"
+        class="inline css-10jm9cu-InlineCode"
       >
         backgroundColor
       </code>
        or 
       <code
-        class="inline css-16lpqq8-InlineCode"
+        class="inline css-10jm9cu-InlineCode"
       >
         borderRadius
       </code>
        with the 
       <code
-        class="inline css-16lpqq8-InlineCode"
+        class="inline css-10jm9cu-InlineCode"
       >
         style
       </code>
        property. This will not work and is against
 the App Store Guidelines. Instead, you should use the 
       <code
-        class="inline css-16lpqq8-InlineCode"
+        class="inline css-10jm9cu-InlineCode"
       >
         buttonStyle
       </code>
        property to choose one of the
 predefined color styles and the 
       <code
-        class="inline css-16lpqq8-InlineCode"
+        class="inline css-10jm9cu-InlineCode"
       >
         cornerRadius
       </code>
@@ -228,14 +228,14 @@ button.
     
 
     <p
-      class="css-1bjvyhe-P"
+      class="css-gvfsz4-P"
       data-text="true"
     >
       Make sure to attach height and width via the style props as without these styles, the button will
 not appear on the screen.
     </p>
     <blockquote
-      class="css-1yla49y-Quote"
+      class="css-y2d7cg-Quote"
       data-text="true"
     >
       <div
@@ -260,7 +260,7 @@ not appear on the screen.
       </div>
       <div>
         <strong
-          class="css-1k788ud-B"
+          class="css-cyicbq-B"
         >
           See: 
         </strong>
@@ -279,7 +279,7 @@ for more details.
       </div>
     </blockquote>
     <h2
-      class="css-1azb2g5-H2"
+      class="css-wpfbxc-H2"
       data-heading="true"
     >
       <div
@@ -334,7 +334,7 @@ for more details.
         class="css-1k62do8-APISectionProps"
       >
         <h3
-          class="css-6kh5nb-H3"
+          class="css-m417je-H3"
           data-heading="true"
         >
           <div
@@ -352,7 +352,7 @@ for more details.
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-1lmmqpm-InlineCode"
+                  class="inline css-tu4dab-InlineCode"
                 >
                   buttonStyle
                 </code>
@@ -389,7 +389,7 @@ for more details.
           </div>
         </h3>
         <p
-          class="css-1bjvyhe-P"
+          class="css-gvfsz4-P"
           data-text="true"
         >
           <span
@@ -399,7 +399,7 @@ for more details.
           </span>
            
           <code
-            class="inline css-16lpqq8-InlineCode"
+            class="inline css-10jm9cu-InlineCode"
           >
             <a
               class="css-153g748-InternalLink"
@@ -410,7 +410,7 @@ for more details.
           </code>
         </p>
         <p
-          class="css-1bjvyhe-P"
+          class="css-gvfsz4-P"
           data-text="true"
         >
           The Apple-defined color scheme to use to display the button.
@@ -420,7 +420,7 @@ for more details.
         class="css-1k62do8-APISectionProps"
       >
         <h3
-          class="css-6kh5nb-H3"
+          class="css-m417je-H3"
           data-heading="true"
         >
           <div
@@ -438,7 +438,7 @@ for more details.
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-1lmmqpm-InlineCode"
+                  class="inline css-tu4dab-InlineCode"
                 >
                   buttonType
                 </code>
@@ -475,7 +475,7 @@ for more details.
           </div>
         </h3>
         <p
-          class="css-1bjvyhe-P"
+          class="css-gvfsz4-P"
           data-text="true"
         >
           <span
@@ -485,7 +485,7 @@ for more details.
           </span>
            
           <code
-            class="inline css-16lpqq8-InlineCode"
+            class="inline css-10jm9cu-InlineCode"
           >
             <a
               class="css-153g748-InternalLink"
@@ -496,7 +496,7 @@ for more details.
           </code>
         </p>
         <p
-          class="css-1bjvyhe-P"
+          class="css-gvfsz4-P"
           data-text="true"
         >
           The type of button text to display ("Sign In with Apple" vs. "Continue with Apple").
@@ -506,7 +506,7 @@ for more details.
         class="css-1k62do8-APISectionProps"
       >
         <h3
-          class="css-6kh5nb-H3"
+          class="css-m417je-H3"
           data-heading="true"
         >
           <div
@@ -524,7 +524,7 @@ for more details.
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-1lmmqpm-InlineCode"
+                  class="inline css-tu4dab-InlineCode"
                 >
                   cornerRadius
                 </code>
@@ -561,7 +561,7 @@ for more details.
           </div>
         </h3>
         <p
-          class="css-1bjvyhe-P"
+          class="css-gvfsz4-P"
           data-text="true"
         >
           <span
@@ -576,19 +576,19 @@ for more details.
           </span>
            
           <code
-            class="inline css-16lpqq8-InlineCode"
+            class="inline css-10jm9cu-InlineCode"
           >
             number
           </code>
         </p>
         <p
-          class="css-1bjvyhe-P"
+          class="css-gvfsz4-P"
           data-text="true"
         >
           The border radius to use when rendering the button. This works similarly to
 
           <code
-            class="inline css-16lpqq8-InlineCode"
+            class="inline css-10jm9cu-InlineCode"
           >
             style.borderRadius
           </code>
@@ -599,7 +599,7 @@ for more details.
         class="css-1k62do8-APISectionProps"
       >
         <h3
-          class="css-6kh5nb-H3"
+          class="css-m417je-H3"
           data-heading="true"
         >
           <div
@@ -617,7 +617,7 @@ for more details.
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-1lmmqpm-InlineCode"
+                  class="inline css-tu4dab-InlineCode"
                 >
                   style
                 </code>
@@ -654,7 +654,7 @@ for more details.
           </div>
         </h3>
         <p
-          class="css-1bjvyhe-P"
+          class="css-gvfsz4-P"
           data-text="true"
         >
           <span
@@ -669,7 +669,7 @@ for more details.
           </span>
            
           <code
-            class="inline css-16lpqq8-InlineCode"
+            class="inline css-10jm9cu-InlineCode"
           >
             StyleProp
             &lt;
@@ -706,18 +706,18 @@ for more details.
           </code>
         </p>
         <p
-          class="css-1bjvyhe-P"
+          class="css-gvfsz4-P"
           data-text="true"
         >
           The custom style to apply to the button. Should not include 
           <code
-            class="inline css-16lpqq8-InlineCode"
+            class="inline css-10jm9cu-InlineCode"
           >
             backgroundColor
           </code>
            or 
           <code
-            class="inline css-16lpqq8-InlineCode"
+            class="inline css-10jm9cu-InlineCode"
           >
             borderRadius
           </code>
@@ -729,7 +729,7 @@ properties.
         class="css-1k62do8-APISectionProps"
       >
         <h3
-          class="css-6kh5nb-H3"
+          class="css-m417je-H3"
           data-heading="true"
         >
           <div
@@ -747,7 +747,7 @@ properties.
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-1lmmqpm-InlineCode"
+                  class="inline css-tu4dab-InlineCode"
                 >
                   onPress
                 </code>
@@ -784,7 +784,7 @@ properties.
           </div>
         </h3>
         <p
-          class="css-1bjvyhe-P"
+          class="css-gvfsz4-P"
           data-text="true"
         >
           <span
@@ -794,7 +794,7 @@ properties.
           </span>
            
           <code
-            class="inline css-16lpqq8-InlineCode"
+            class="inline css-10jm9cu-InlineCode"
           >
             (
             ) =&gt;
@@ -803,7 +803,7 @@ properties.
           </code>
         </p>
         <p
-          class="css-1bjvyhe-P"
+          class="css-gvfsz4-P"
           data-text="true"
         >
           The method to call when the user presses the button. You should call 
@@ -812,7 +812,7 @@ properties.
             href="/#isavailableasync"
           >
             <code
-              class="inline css-16lpqq8-InlineCode"
+              class="inline css-10jm9cu-InlineCode"
             >
               AppleAuthentication.signInAsync
             </code>
@@ -822,7 +822,7 @@ in here.
         </p>
       </div>
       <h3
-        class="css-6kh5nb-H3"
+        class="css-m417je-H3"
         data-heading="true"
       >
         <div
@@ -873,14 +873,14 @@ in here.
         </div>
       </h3>
       <ul
-        class="css-is4ysz-UL"
+        class="css-viw9dk-UL"
         data-text="true"
       >
         <li
           class="docs-list-item css-l157nt-LI"
         >
           <code
-            class="inline css-16lpqq8-InlineCode"
+            class="inline css-10jm9cu-InlineCode"
           >
             <a
               class="css-153g748-InternalLink"
@@ -894,7 +894,7 @@ in here.
     </div>
   </div>
   <h2
-    class="css-1azb2g5-H2"
+    class="css-wpfbxc-H2"
     data-heading="true"
   >
     <div
@@ -948,7 +948,7 @@ in here.
     class="css-eu2n2e-APISectionMethods"
   >
     <h3
-      class="css-6kh5nb-H3"
+      class="css-m417je-H3"
       data-heading="true"
     >
       <div
@@ -966,7 +966,7 @@ in here.
             class="css-6n7j50"
           >
             <code
-              class="inline css-1lmmqpm-InlineCode"
+              class="inline css-tu4dab-InlineCode"
             >
               getCredentialStateAsync(user)
             </code>
@@ -1039,7 +1039,7 @@ in here.
               class="css-t44xva-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 user
               </strong>
@@ -1048,7 +1048,7 @@ in here.
               class="css-t44xva-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 string
               </code>
@@ -1064,7 +1064,7 @@ This should come from the user field of an
                   href="/#appleauthenticationcredentialstate"
                 >
                   <code
-                    class="inline css-16lpqq8-InlineCode"
+                    class="inline css-10jm9cu-InlineCode"
                   >
                     AppleAuthenticationCredential
                   </code>
@@ -1077,7 +1077,7 @@ This should come from the user field of an
       </table>
     </div>
     <p
-      class="css-1bjvyhe-P"
+      class="css-gvfsz4-P"
       data-text="true"
     >
       Queries the current state of a user credential, to determine if it is still valid or if it has been revoked.
@@ -1085,7 +1085,7 @@ This should come from the user field of an
     
 
     <blockquote
-      class="css-1yla49y-Quote"
+      class="css-y2d7cg-Quote"
       data-text="true"
     >
       <div
@@ -1112,7 +1112,7 @@ This should come from the user field of an
         
 
         <strong
-          class="css-1k788ud-B"
+          class="css-cyicbq-B"
         >
           Note:
         </strong>
@@ -1122,10 +1122,10 @@ This should come from the user field of an
       </div>
     </blockquote>
     <div
-      class="css-1remai5-APISectionMethods"
+      class="css-1dfa5yf-APISectionMethods"
     >
       <h4
-        class="  css-crowgh-H4"
+        class="  css-uucypz-H4"
         data-components-heading="true"
         data-heading="true"
       >
@@ -1178,7 +1178,7 @@ This should come from the user field of an
       </h4>
     </div>
     <ul
-      class="css-11d2x0b-UL"
+      class="css-ozzgx3-UL"
       data-text="true"
     >
       <li
@@ -1203,7 +1203,7 @@ This should come from the user field of an
           />
         </svg>
         <code
-          class="inline css-16lpqq8-InlineCode"
+          class="inline css-10jm9cu-InlineCode"
         >
           <a
             class="css-ccg2mn-ExternalLink"
@@ -1226,7 +1226,7 @@ This should come from the user field of an
       </li>
     </ul>
     <p
-      class="css-1bjvyhe-P"
+      class="css-gvfsz4-P"
       data-text="true"
     >
       A promise that fulfills with an 
@@ -1235,7 +1235,7 @@ This should come from the user field of an
         href="/#appleauthenticationcredentialstate"
       >
         <code
-          class="inline css-16lpqq8-InlineCode"
+          class="inline css-10jm9cu-InlineCode"
         >
           AppleAuthenticationCredentialState
         </code>
@@ -1248,7 +1248,7 @@ value depending on the state of the credential.
     class="css-eu2n2e-APISectionMethods"
   >
     <h3
-      class="css-6kh5nb-H3"
+      class="css-m417je-H3"
       data-heading="true"
     >
       <div
@@ -1266,7 +1266,7 @@ value depending on the state of the credential.
             class="css-6n7j50"
           >
             <code
-              class="inline css-1lmmqpm-InlineCode"
+              class="inline css-tu4dab-InlineCode"
             >
               isAvailableAsync()
             </code>
@@ -1303,16 +1303,16 @@ value depending on the state of the credential.
       </div>
     </h3>
     <p
-      class="css-1bjvyhe-P"
+      class="css-gvfsz4-P"
       data-text="true"
     >
       Determine if the current device's operating system supports Apple authentication.
     </p>
     <div
-      class="css-1remai5-APISectionMethods"
+      class="css-1dfa5yf-APISectionMethods"
     >
       <h4
-        class="  css-crowgh-H4"
+        class="  css-uucypz-H4"
         data-components-heading="true"
         data-heading="true"
       >
@@ -1365,7 +1365,7 @@ value depending on the state of the credential.
       </h4>
     </div>
     <ul
-      class="css-11d2x0b-UL"
+      class="css-ozzgx3-UL"
       data-text="true"
     >
       <li
@@ -1390,7 +1390,7 @@ value depending on the state of the credential.
           />
         </svg>
         <code
-          class="inline css-16lpqq8-InlineCode"
+          class="inline css-10jm9cu-InlineCode"
         >
           <a
             class="css-ccg2mn-ExternalLink"
@@ -1408,18 +1408,18 @@ value depending on the state of the credential.
       </li>
     </ul>
     <p
-      class="css-1bjvyhe-P"
+      class="css-gvfsz4-P"
       data-text="true"
     >
       A promise that fulfills with 
       <code
-        class="inline css-16lpqq8-InlineCode"
+        class="inline css-10jm9cu-InlineCode"
       >
         true
       </code>
        if the system supports Apple authentication, and 
       <code
-        class="inline css-16lpqq8-InlineCode"
+        class="inline css-10jm9cu-InlineCode"
       >
         false
       </code>
@@ -1430,7 +1430,7 @@ value depending on the state of the credential.
     class="css-eu2n2e-APISectionMethods"
   >
     <h3
-      class="css-6kh5nb-H3"
+      class="css-m417je-H3"
       data-heading="true"
     >
       <div
@@ -1448,7 +1448,7 @@ value depending on the state of the credential.
             class="css-6n7j50"
           >
             <code
-              class="inline css-1lmmqpm-InlineCode"
+              class="inline css-tu4dab-InlineCode"
             >
               refreshAsync(options)
             </code>
@@ -1521,7 +1521,7 @@ value depending on the state of the credential.
               class="css-t44xva-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 options
               </strong>
@@ -1530,7 +1530,7 @@ value depending on the state of the credential.
               class="css-t44xva-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 <a
                   class="css-153g748-InternalLink"
@@ -1550,7 +1550,7 @@ value depending on the state of the credential.
                   href="/#appleauthenticationrefreshoptions"
                 >
                   <code
-                    class="inline css-16lpqq8-InlineCode"
+                    class="inline css-10jm9cu-InlineCode"
                   >
                     AppleAuthenticationRefreshOptions
                   </code>
@@ -1563,17 +1563,17 @@ value depending on the state of the credential.
       </table>
     </div>
     <p
-      class="css-1bjvyhe-P"
+      class="css-gvfsz4-P"
       data-text="true"
     >
       An operation that refreshes the logged-in user’s credentials.
 Calling this method will show the sign in modal before actually refreshing the user credentials.
     </p>
     <div
-      class="css-1remai5-APISectionMethods"
+      class="css-1dfa5yf-APISectionMethods"
     >
       <h4
-        class="  css-crowgh-H4"
+        class="  css-uucypz-H4"
         data-components-heading="true"
         data-heading="true"
       >
@@ -1626,7 +1626,7 @@ Calling this method will show the sign in modal before actually refreshing the u
       </h4>
     </div>
     <ul
-      class="css-11d2x0b-UL"
+      class="css-ozzgx3-UL"
       data-text="true"
     >
       <li
@@ -1651,7 +1651,7 @@ Calling this method will show the sign in modal before actually refreshing the u
           />
         </svg>
         <code
-          class="inline css-16lpqq8-InlineCode"
+          class="inline css-10jm9cu-InlineCode"
         >
           <a
             class="css-ccg2mn-ExternalLink"
@@ -1674,7 +1674,7 @@ Calling this method will show the sign in modal before actually refreshing the u
       </li>
     </ul>
     <p
-      class="css-1bjvyhe-P"
+      class="css-gvfsz4-P"
       data-text="true"
     >
       A promise that fulfills with an 
@@ -1683,7 +1683,7 @@ Calling this method will show the sign in modal before actually refreshing the u
         href="/#appleauthenticationcredential"
       >
         <code
-          class="inline css-16lpqq8-InlineCode"
+          class="inline css-10jm9cu-InlineCode"
         >
           AppleAuthenticationCredential
         </code>
@@ -1691,7 +1691,7 @@ Calling this method will show the sign in modal before actually refreshing the u
       
 object after a successful authentication, and rejects with 
       <code
-        class="inline css-16lpqq8-InlineCode"
+        class="inline css-10jm9cu-InlineCode"
       >
         ERR_CANCELED
       </code>
@@ -1703,7 +1703,7 @@ refresh operation.
     class="css-eu2n2e-APISectionMethods"
   >
     <h3
-      class="css-6kh5nb-H3"
+      class="css-m417je-H3"
       data-heading="true"
     >
       <div
@@ -1721,7 +1721,7 @@ refresh operation.
             class="css-6n7j50"
           >
             <code
-              class="inline css-1lmmqpm-InlineCode"
+              class="inline css-tu4dab-InlineCode"
             >
               signInAsync(options)
             </code>
@@ -1794,7 +1794,7 @@ refresh operation.
               class="css-t44xva-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 options
               </strong>
@@ -1809,7 +1809,7 @@ refresh operation.
               class="css-t44xva-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 <a
                   class="css-153g748-InternalLink"
@@ -1829,7 +1829,7 @@ refresh operation.
                   href="/#appleauthenticationsigninoptions"
                 >
                   <code
-                    class="inline css-16lpqq8-InlineCode"
+                    class="inline css-10jm9cu-InlineCode"
                   >
                     AppleAuthenticationSignInOptions
                   </code>
@@ -1842,14 +1842,14 @@ refresh operation.
       </table>
     </div>
     <p
-      class="css-1bjvyhe-P"
+      class="css-gvfsz4-P"
       data-text="true"
     >
       Sends a request to the operating system to initiate the Apple authentication flow, which will
 present a modal to the user over your app and allow them to sign in.
     </p>
     <p
-      class="css-1bjvyhe-P"
+      class="css-gvfsz4-P"
       data-text="true"
     >
       You can request access to the user's full name and email address in this method, which allows you
@@ -1859,7 +1859,7 @@ of these options at runtime.
     
 
     <p
-      class="css-1bjvyhe-P"
+      class="css-gvfsz4-P"
       data-text="true"
     >
       Additionally, you will only receive Apple Authentication Credentials the first time users sign
@@ -1878,7 +1878,7 @@ You can use
         href="/#appleauthenticationcredential"
       >
         <code
-          class="inline css-16lpqq8-InlineCode"
+          class="inline css-10jm9cu-InlineCode"
         >
           AppleAuthenticationCredential.user
         </code>
@@ -1887,10 +1887,10 @@ You can use
 the user, since this remains the same for apps released by the same developer.
     </p>
     <div
-      class="css-1remai5-APISectionMethods"
+      class="css-1dfa5yf-APISectionMethods"
     >
       <h4
-        class="  css-crowgh-H4"
+        class="  css-uucypz-H4"
         data-components-heading="true"
         data-heading="true"
       >
@@ -1943,7 +1943,7 @@ the user, since this remains the same for apps released by the same developer.
       </h4>
     </div>
     <ul
-      class="css-11d2x0b-UL"
+      class="css-ozzgx3-UL"
       data-text="true"
     >
       <li
@@ -1968,7 +1968,7 @@ the user, since this remains the same for apps released by the same developer.
           />
         </svg>
         <code
-          class="inline css-16lpqq8-InlineCode"
+          class="inline css-10jm9cu-InlineCode"
         >
           <a
             class="css-ccg2mn-ExternalLink"
@@ -1991,7 +1991,7 @@ the user, since this remains the same for apps released by the same developer.
       </li>
     </ul>
     <p
-      class="css-1bjvyhe-P"
+      class="css-gvfsz4-P"
       data-text="true"
     >
       A promise that fulfills with an 
@@ -2000,7 +2000,7 @@ the user, since this remains the same for apps released by the same developer.
         href="/#appleauthenticationcredential"
       >
         <code
-          class="inline css-16lpqq8-InlineCode"
+          class="inline css-10jm9cu-InlineCode"
         >
           AppleAuthenticationCredential
         </code>
@@ -2008,7 +2008,7 @@ the user, since this remains the same for apps released by the same developer.
       
 object after a successful authentication, and rejects with 
       <code
-        class="inline css-16lpqq8-InlineCode"
+        class="inline css-10jm9cu-InlineCode"
       >
         ERR_CANCELED
       </code>
@@ -2020,7 +2020,7 @@ sign-in operation.
     class="css-eu2n2e-APISectionMethods"
   >
     <h3
-      class="css-6kh5nb-H3"
+      class="css-m417je-H3"
       data-heading="true"
     >
       <div
@@ -2038,7 +2038,7 @@ sign-in operation.
             class="css-6n7j50"
           >
             <code
-              class="inline css-1lmmqpm-InlineCode"
+              class="inline css-tu4dab-InlineCode"
             >
               signOutAsync(options)
             </code>
@@ -2111,7 +2111,7 @@ sign-in operation.
               class="css-t44xva-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 options
               </strong>
@@ -2120,7 +2120,7 @@ sign-in operation.
               class="css-t44xva-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 <a
                   class="css-153g748-InternalLink"
@@ -2140,7 +2140,7 @@ sign-in operation.
                   href="/#appleauthenticationsignoutoptions"
                 >
                   <code
-                    class="inline css-16lpqq8-InlineCode"
+                    class="inline css-10jm9cu-InlineCode"
                   >
                     AppleAuthenticationSignOutOptions
                   </code>
@@ -2153,14 +2153,14 @@ sign-in operation.
       </table>
     </div>
     <p
-      class="css-1bjvyhe-P"
+      class="css-gvfsz4-P"
       data-text="true"
     >
       An operation that ends the authenticated session.
 Calling this method will show the sign in modal before actually signing the user out.
     </p>
     <p
-      class="css-1bjvyhe-P"
+      class="css-gvfsz4-P"
       data-text="true"
     >
       It is not recommended to use this method to sign out the user as it works counterintuitively.
@@ -2171,7 +2171,7 @@ from using
         href="/#signinasync"
       >
         <code
-          class="inline css-16lpqq8-InlineCode"
+          class="inline css-10jm9cu-InlineCode"
         >
           signInAsync
         </code>
@@ -2182,7 +2182,7 @@ from using
         href="/#refreshasync"
       >
         <code
-          class="inline css-16lpqq8-InlineCode"
+          class="inline css-10jm9cu-InlineCode"
         >
           refreshAsync
         </code>
@@ -2190,10 +2190,10 @@ from using
        methods.
     </p>
     <div
-      class="css-1remai5-APISectionMethods"
+      class="css-1dfa5yf-APISectionMethods"
     >
       <h4
-        class="  css-crowgh-H4"
+        class="  css-uucypz-H4"
         data-components-heading="true"
         data-heading="true"
       >
@@ -2246,7 +2246,7 @@ from using
       </h4>
     </div>
     <ul
-      class="css-11d2x0b-UL"
+      class="css-ozzgx3-UL"
       data-text="true"
     >
       <li
@@ -2271,7 +2271,7 @@ from using
           />
         </svg>
         <code
-          class="inline css-16lpqq8-InlineCode"
+          class="inline css-10jm9cu-InlineCode"
         >
           <a
             class="css-ccg2mn-ExternalLink"
@@ -2294,7 +2294,7 @@ from using
       </li>
     </ul>
     <p
-      class="css-1bjvyhe-P"
+      class="css-gvfsz4-P"
       data-text="true"
     >
       A promise that fulfills with an 
@@ -2303,7 +2303,7 @@ from using
         href="/#appleauthenticationcredential"
       >
         <code
-          class="inline css-16lpqq8-InlineCode"
+          class="inline css-10jm9cu-InlineCode"
         >
           AppleAuthenticationCredential
         </code>
@@ -2311,7 +2311,7 @@ from using
       
 object after a successful authentication, and rejects with 
       <code
-        class="inline css-16lpqq8-InlineCode"
+        class="inline css-10jm9cu-InlineCode"
       >
         ERR_CANCELED
       </code>
@@ -2320,7 +2320,7 @@ sign-out operation.
     </p>
   </div>
   <h2
-    class="css-1azb2g5-H2"
+    class="css-wpfbxc-H2"
     data-heading="true"
   >
     <div
@@ -2374,7 +2374,7 @@ sign-out operation.
     class="css-eu2n2e-APISectionMethods"
   >
     <h3
-      class="css-6kh5nb-H3"
+      class="css-m417je-H3"
       data-heading="true"
     >
       <div
@@ -2392,7 +2392,7 @@ sign-out operation.
             class="css-6n7j50"
           >
             <code
-              class="inline css-1lmmqpm-InlineCode"
+              class="inline css-tu4dab-InlineCode"
             >
               addRevokeListener(listener)
             </code>
@@ -2465,7 +2465,7 @@ sign-out operation.
               class="css-t44xva-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 listener
               </strong>
@@ -2474,7 +2474,7 @@ sign-out operation.
               class="css-t44xva-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 () =&gt;
                  
@@ -2491,10 +2491,10 @@ sign-out operation.
       </table>
     </div>
     <div
-      class="css-1remai5-APISectionMethods"
+      class="css-1dfa5yf-APISectionMethods"
     >
       <h4
-        class="  css-crowgh-H4"
+        class="  css-uucypz-H4"
         data-components-heading="true"
         data-heading="true"
       >
@@ -2547,7 +2547,7 @@ sign-out operation.
       </h4>
     </div>
     <ul
-      class="css-11d2x0b-UL"
+      class="css-ozzgx3-UL"
       data-text="true"
     >
       <li
@@ -2572,7 +2572,7 @@ sign-out operation.
           />
         </svg>
         <code
-          class="inline css-16lpqq8-InlineCode"
+          class="inline css-10jm9cu-InlineCode"
         >
           <a
             class="css-153g748-InternalLink"
@@ -2585,7 +2585,7 @@ sign-out operation.
     </ul>
   </div>
   <h2
-    class="css-1azb2g5-H2"
+    class="css-wpfbxc-H2"
     data-heading="true"
   >
     <div
@@ -2639,7 +2639,7 @@ sign-out operation.
     class="css-16qd3rn-APISectionTypes"
   >
     <h3
-      class="css-6kh5nb-H3"
+      class="css-m417je-H3"
       data-heading="true"
     >
       <div
@@ -2657,7 +2657,7 @@ sign-out operation.
             class="css-6n7j50"
           >
             <code
-              class="inline css-16lpqq8-InlineCode"
+              class="inline css-10jm9cu-InlineCode"
             >
               AppleAuthenticationCredential
             </code>
@@ -2694,7 +2694,7 @@ sign-out operation.
       </div>
     </h3>
     <p
-      class="css-1bjvyhe-P"
+      class="css-gvfsz4-P"
       data-text="true"
     >
       The object type returned from a successful call to 
@@ -2703,7 +2703,7 @@ sign-out operation.
         href="/#appleauthenticationsigninasyncoptions"
       >
         <code
-          class="inline css-16lpqq8-InlineCode"
+          class="inline css-10jm9cu-InlineCode"
         >
           AppleAuthentication.signInAsync()
         </code>
@@ -2715,7 +2715,7 @@ sign-out operation.
         href="/#appleauthenticationrefreshasyncoptions"
       >
         <code
-          class="inline css-16lpqq8-InlineCode"
+          class="inline css-10jm9cu-InlineCode"
         >
           AppleAuthentication.refreshAsync()
         </code>
@@ -2726,7 +2726,7 @@ sign-out operation.
         href="/#appleauthenticationsignoutasyncoptions"
       >
         <code
-          class="inline css-16lpqq8-InlineCode"
+          class="inline css-10jm9cu-InlineCode"
         >
           AppleAuthentication.signOutAsync()
         </code>
@@ -2735,7 +2735,7 @@ sign-out operation.
 which contains all of the pertinent user and credential information.
     </p>
     <blockquote
-      class="css-1yla49y-Quote"
+      class="css-y2d7cg-Quote"
       data-text="true"
     >
       <div
@@ -2760,7 +2760,7 @@ which contains all of the pertinent user and credential information.
       </div>
       <div>
         <strong
-          class="css-1k788ud-B"
+          class="css-cyicbq-B"
         >
           See: 
         </strong>
@@ -2815,7 +2815,7 @@ for more details.
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 authorizationCode
               </strong>
@@ -2824,7 +2824,7 @@ for more details.
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 <span>
                   string
@@ -2842,7 +2842,7 @@ for more details.
                 A short-lived session token used by your app for proof of authorization when interacting with
 the app's server counterpart. Unlike 
                 <code
-                  class="inline css-16lpqq8-InlineCode"
+                  class="inline css-10jm9cu-InlineCode"
                 >
                   user
                 </code>
@@ -2857,7 +2857,7 @@ the app's server counterpart. Unlike
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 email
               </strong>
@@ -2866,7 +2866,7 @@ the app's server counterpart. Unlike
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 <span>
                   string
@@ -2883,7 +2883,7 @@ the app's server counterpart. Unlike
               <span>
                 The user's email address. Might not be present if you didn't request the 
                 <code
-                  class="inline css-16lpqq8-InlineCode"
+                  class="inline css-10jm9cu-InlineCode"
                 >
                   EMAIL
                 </code>
@@ -2901,7 +2901,7 @@ an Apple domain.
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 fullName
               </strong>
@@ -2910,7 +2910,7 @@ an Apple domain.
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 <span>
                   <a
@@ -2932,19 +2932,19 @@ an Apple domain.
               <span>
                 The user's name. May be 
                 <code
-                  class="inline css-16lpqq8-InlineCode"
+                  class="inline css-10jm9cu-InlineCode"
                 >
                   null
                 </code>
                  or contain 
                 <code
-                  class="inline css-16lpqq8-InlineCode"
+                  class="inline css-10jm9cu-InlineCode"
                 >
                   null
                 </code>
                  values if you didn't request the 
                 <code
-                  class="inline css-16lpqq8-InlineCode"
+                  class="inline css-10jm9cu-InlineCode"
                 >
                   FULL_NAME
                 </code>
@@ -2961,7 +2961,7 @@ your app.
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 identityToken
               </strong>
@@ -2970,7 +2970,7 @@ your app.
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 <span>
                   string
@@ -2996,7 +2996,7 @@ your app.
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 realUserStatus
               </strong>
@@ -3005,7 +3005,7 @@ your app.
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 <a
                   class="css-153g748-InternalLink"
@@ -3030,7 +3030,7 @@ your app.
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 state
               </strong>
@@ -3039,7 +3039,7 @@ your app.
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 <span>
                   string
@@ -3056,7 +3056,7 @@ your app.
               <span>
                 An arbitrary string that your app provided as 
                 <code
-                  class="inline css-16lpqq8-InlineCode"
+                  class="inline css-10jm9cu-InlineCode"
                 >
                   state
                 </code>
@@ -3064,14 +3064,14 @@ your app.
 credential. Used to verify that the response was from the request you made. Can be used to
 avoid replay attacks. If you did not provide 
                 <code
-                  class="inline css-16lpqq8-InlineCode"
+                  class="inline css-10jm9cu-InlineCode"
                 >
                   state
                 </code>
                  when making the sign-in request, this field
 will be 
                 <code
-                  class="inline css-16lpqq8-InlineCode"
+                  class="inline css-10jm9cu-InlineCode"
                 >
                   null
                 </code>
@@ -3086,7 +3086,7 @@ will be
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 user
               </strong>
@@ -3095,7 +3095,7 @@ will be
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 string
               </code>
@@ -3119,7 +3119,7 @@ developers.
     class="css-16qd3rn-APISectionTypes"
   >
     <h3
-      class="css-6kh5nb-H3"
+      class="css-m417je-H3"
       data-heading="true"
     >
       <div
@@ -3137,7 +3137,7 @@ developers.
             class="css-6n7j50"
           >
             <code
-              class="inline css-16lpqq8-InlineCode"
+              class="inline css-10jm9cu-InlineCode"
             >
               AppleAuthenticationFullName
             </code>
@@ -3174,13 +3174,13 @@ developers.
       </div>
     </h3>
     <p
-      class="css-1bjvyhe-P"
+      class="css-gvfsz4-P"
       data-text="true"
     >
       An object representing the tokenized portions of the user's full name. Any of all of the fields
 may be 
       <code
-        class="inline css-16lpqq8-InlineCode"
+        class="inline css-10jm9cu-InlineCode"
       >
         null
       </code>
@@ -3223,7 +3223,7 @@ may be
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 familyName
               </strong>
@@ -3232,7 +3232,7 @@ may be
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 <span>
                   string
@@ -3256,7 +3256,7 @@ may be
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 givenName
               </strong>
@@ -3265,7 +3265,7 @@ may be
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 <span>
                   string
@@ -3289,7 +3289,7 @@ may be
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 middleName
               </strong>
@@ -3298,7 +3298,7 @@ may be
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 <span>
                   string
@@ -3322,7 +3322,7 @@ may be
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 namePrefix
               </strong>
@@ -3331,7 +3331,7 @@ may be
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 <span>
                   string
@@ -3355,7 +3355,7 @@ may be
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 nameSuffix
               </strong>
@@ -3364,7 +3364,7 @@ may be
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 <span>
                   string
@@ -3388,7 +3388,7 @@ may be
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 nickname
               </strong>
@@ -3397,7 +3397,7 @@ may be
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 <span>
                   string
@@ -3422,7 +3422,7 @@ may be
     class="css-16qd3rn-APISectionTypes"
   >
     <h3
-      class="css-6kh5nb-H3"
+      class="css-m417je-H3"
       data-heading="true"
     >
       <div
@@ -3440,7 +3440,7 @@ may be
             class="css-6n7j50"
           >
             <code
-              class="inline css-16lpqq8-InlineCode"
+              class="inline css-10jm9cu-InlineCode"
             >
               AppleAuthenticationRefreshOptions
             </code>
@@ -3477,7 +3477,7 @@ may be
       </div>
     </h3>
     <p
-      class="css-1bjvyhe-P"
+      class="css-gvfsz4-P"
       data-text="true"
     >
       The options you can supply when making a call to 
@@ -3486,7 +3486,7 @@ may be
         href="/#appleauthenticationrefreshasyncoptions"
       >
         <code
-          class="inline css-16lpqq8-InlineCode"
+          class="inline css-10jm9cu-InlineCode"
         >
           AppleAuthentication.refreshAsync()
         </code>
@@ -3495,7 +3495,7 @@ may be
 You must include the ID string of the user whose credentials you'd like to refresh.
     </p>
     <blockquote
-      class="css-1yla49y-Quote"
+      class="css-y2d7cg-Quote"
       data-text="true"
     >
       <div
@@ -3520,7 +3520,7 @@ You must include the ID string of the user whose credentials you'd like to refre
       </div>
       <div>
         <strong
-          class="css-1k788ud-B"
+          class="css-cyicbq-B"
         >
           See: 
         </strong>
@@ -3575,7 +3575,7 @@ for more details.
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 requestedScopes
               </strong>
@@ -3590,7 +3590,7 @@ for more details.
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 <a
                   class="css-153g748-InternalLink"
@@ -3609,7 +3609,7 @@ for more details.
 choose to deny your app access to any scope at the time of logging in. You will still need to
 handle 
                 <code
-                  class="inline css-16lpqq8-InlineCode"
+                  class="inline css-10jm9cu-InlineCode"
                 >
                   null
                 </code>
@@ -3617,13 +3617,13 @@ handle
 will only be provided to you the first time each user signs into your app; in subsequent
 requests they will be 
                 <code
-                  class="inline css-16lpqq8-InlineCode"
+                  class="inline css-10jm9cu-InlineCode"
                 >
                   null
                 </code>
                 . Defaults to 
                 <code
-                  class="inline css-16lpqq8-InlineCode"
+                  class="inline css-10jm9cu-InlineCode"
                 >
                   []
                 </code>
@@ -3638,7 +3638,7 @@ requests they will be
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 state
               </strong>
@@ -3653,7 +3653,7 @@ requests they will be
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 string
               </code>
@@ -3684,7 +3684,7 @@ OAuth 2.0 protocol
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 user
               </strong>
@@ -3693,7 +3693,7 @@ OAuth 2.0 protocol
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 string
               </code>
@@ -3712,7 +3712,7 @@ OAuth 2.0 protocol
     class="css-16qd3rn-APISectionTypes"
   >
     <h3
-      class="css-6kh5nb-H3"
+      class="css-m417je-H3"
       data-heading="true"
     >
       <div
@@ -3730,7 +3730,7 @@ OAuth 2.0 protocol
             class="css-6n7j50"
           >
             <code
-              class="inline css-16lpqq8-InlineCode"
+              class="inline css-10jm9cu-InlineCode"
             >
               AppleAuthenticationSignInOptions
             </code>
@@ -3767,7 +3767,7 @@ OAuth 2.0 protocol
       </div>
     </h3>
     <p
-      class="css-1bjvyhe-P"
+      class="css-gvfsz4-P"
       data-text="true"
     >
       The options you can supply when making a call to 
@@ -3776,7 +3776,7 @@ OAuth 2.0 protocol
         href="/#appleauthenticationsigninasyncoptions"
       >
         <code
-          class="inline css-16lpqq8-InlineCode"
+          class="inline css-10jm9cu-InlineCode"
         >
           AppleAuthentication.signInAsync()
         </code>
@@ -3785,7 +3785,7 @@ OAuth 2.0 protocol
 None of these options are required.
     </p>
     <blockquote
-      class="css-1yla49y-Quote"
+      class="css-y2d7cg-Quote"
       data-text="true"
     >
       <div
@@ -3810,7 +3810,7 @@ None of these options are required.
       </div>
       <div>
         <strong
-          class="css-1k788ud-B"
+          class="css-cyicbq-B"
         >
           See: 
         </strong>
@@ -3865,7 +3865,7 @@ for more details.
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 nonce
               </strong>
@@ -3880,7 +3880,7 @@ for more details.
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 string
               </code>
@@ -3909,7 +3909,7 @@ for more details.
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 requestedScopes
               </strong>
@@ -3924,7 +3924,7 @@ for more details.
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 <a
                   class="css-153g748-InternalLink"
@@ -3943,7 +3943,7 @@ for more details.
 choose to deny your app access to any scope at the time of logging in. You will still need to
 handle 
                 <code
-                  class="inline css-16lpqq8-InlineCode"
+                  class="inline css-10jm9cu-InlineCode"
                 >
                   null
                 </code>
@@ -3951,13 +3951,13 @@ handle
 will only be provided to you the first time each user signs into your app; in subsequent
 requests they will be 
                 <code
-                  class="inline css-16lpqq8-InlineCode"
+                  class="inline css-10jm9cu-InlineCode"
                 >
                   null
                 </code>
                 . Defaults to 
                 <code
-                  class="inline css-16lpqq8-InlineCode"
+                  class="inline css-10jm9cu-InlineCode"
                 >
                   []
                 </code>
@@ -3972,7 +3972,7 @@ requests they will be
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 state
               </strong>
@@ -3987,7 +3987,7 @@ requests they will be
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 string
               </code>
@@ -4019,7 +4019,7 @@ OAuth 2.0 protocol
     class="css-16qd3rn-APISectionTypes"
   >
     <h3
-      class="css-6kh5nb-H3"
+      class="css-m417je-H3"
       data-heading="true"
     >
       <div
@@ -4037,7 +4037,7 @@ OAuth 2.0 protocol
             class="css-6n7j50"
           >
             <code
-              class="inline css-16lpqq8-InlineCode"
+              class="inline css-10jm9cu-InlineCode"
             >
               AppleAuthenticationSignOutOptions
             </code>
@@ -4074,7 +4074,7 @@ OAuth 2.0 protocol
       </div>
     </h3>
     <p
-      class="css-1bjvyhe-P"
+      class="css-gvfsz4-P"
       data-text="true"
     >
       The options you can supply when making a call to 
@@ -4083,7 +4083,7 @@ OAuth 2.0 protocol
         href="/#appleauthenticationsignoutasyncoptions"
       >
         <code
-          class="inline css-16lpqq8-InlineCode"
+          class="inline css-10jm9cu-InlineCode"
         >
           AppleAuthentication.signOutAsync()
         </code>
@@ -4092,7 +4092,7 @@ OAuth 2.0 protocol
 You must include the ID string of the user to sign out.
     </p>
     <blockquote
-      class="css-1yla49y-Quote"
+      class="css-y2d7cg-Quote"
       data-text="true"
     >
       <div
@@ -4117,7 +4117,7 @@ You must include the ID string of the user to sign out.
       </div>
       <div>
         <strong
-          class="css-1k788ud-B"
+          class="css-cyicbq-B"
         >
           See: 
         </strong>
@@ -4172,7 +4172,7 @@ for more details.
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 state
               </strong>
@@ -4187,7 +4187,7 @@ for more details.
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 string
               </code>
@@ -4218,7 +4218,7 @@ OAuth 2.0 protocol
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 user
               </strong>
@@ -4227,7 +4227,7 @@ OAuth 2.0 protocol
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 string
               </code>
@@ -4246,7 +4246,7 @@ OAuth 2.0 protocol
     class="css-16qd3rn-APISectionTypes"
   >
     <h3
-      class="css-6kh5nb-H3"
+      class="css-m417je-H3"
       data-heading="true"
     >
       <div
@@ -4264,7 +4264,7 @@ OAuth 2.0 protocol
             class="css-6n7j50"
           >
             <code
-              class="inline css-16lpqq8-InlineCode"
+              class="inline css-10jm9cu-InlineCode"
             >
               Subscription
             </code>
@@ -4337,7 +4337,7 @@ OAuth 2.0 protocol
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 remove
               </strong>
@@ -4346,7 +4346,7 @@ OAuth 2.0 protocol
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 (
                 ) =&gt;
@@ -4367,7 +4367,7 @@ OAuth 2.0 protocol
     </div>
   </div>
   <h2
-    class="css-1azb2g5-H2"
+    class="css-wpfbxc-H2"
     data-heading="true"
   >
     <div
@@ -4421,7 +4421,7 @@ OAuth 2.0 protocol
     class="css-eskewv-APISectionEnums"
   >
     <h3
-      class="css-6kh5nb-H3"
+      class="css-m417je-H3"
       data-heading="true"
     >
       <div
@@ -4439,7 +4439,7 @@ OAuth 2.0 protocol
             class="css-6n7j50"
           >
             <code
-              class="inline css-16lpqq8-InlineCode"
+              class="inline css-10jm9cu-InlineCode"
             >
               AppleAuthenticationButtonStyle
             </code>
@@ -4476,7 +4476,7 @@ OAuth 2.0 protocol
       </div>
     </h3>
     <p
-      class="css-1bjvyhe-P"
+      class="css-gvfsz4-P"
       data-text="true"
     >
       An enum whose values control which pre-defined color scheme to use when rendering an 
@@ -4485,7 +4485,7 @@ OAuth 2.0 protocol
         href="/#appleauthenticationappleauthenticationbutton"
       >
         <code
-          class="inline css-16lpqq8-InlineCode"
+          class="inline css-10jm9cu-InlineCode"
         >
           AppleAuthenticationButton
         </code>
@@ -4499,7 +4499,7 @@ OAuth 2.0 protocol
         class="css-m07iiw-APISectionEnums"
       >
         <h4
-          class="  css-crowgh-H4"
+          class="  css-uucypz-H4"
           data-components-heading="true"
           data-heading="true"
         >
@@ -4518,7 +4518,7 @@ OAuth 2.0 protocol
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-16lpqq8-InlineCode"
+                  class="inline css-10jm9cu-InlineCode"
                 >
                   WHITE
                 </code>
@@ -4556,7 +4556,7 @@ OAuth 2.0 protocol
         </h4>
       </div>
       <code
-        class="inline css-t7whmz-APISectionEnums"
+        class="inline css-bs4uzw-APISectionEnums"
       >
         AppleAuthenticationButtonStyle
         .
@@ -4564,7 +4564,7 @@ OAuth 2.0 protocol
          ＝ 0
       </code>
       <p
-        class="css-1bjvyhe-P"
+        class="css-gvfsz4-P"
         data-text="true"
       >
         White button with black text.
@@ -4577,7 +4577,7 @@ OAuth 2.0 protocol
         class="css-m07iiw-APISectionEnums"
       >
         <h4
-          class="  css-crowgh-H4"
+          class="  css-uucypz-H4"
           data-components-heading="true"
           data-heading="true"
         >
@@ -4596,7 +4596,7 @@ OAuth 2.0 protocol
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-16lpqq8-InlineCode"
+                  class="inline css-10jm9cu-InlineCode"
                 >
                   WHITE_OUTLINE
                 </code>
@@ -4634,7 +4634,7 @@ OAuth 2.0 protocol
         </h4>
       </div>
       <code
-        class="inline css-t7whmz-APISectionEnums"
+        class="inline css-bs4uzw-APISectionEnums"
       >
         AppleAuthenticationButtonStyle
         .
@@ -4642,7 +4642,7 @@ OAuth 2.0 protocol
          ＝ 1
       </code>
       <p
-        class="css-1bjvyhe-P"
+        class="css-gvfsz4-P"
         data-text="true"
       >
         White button with a black outline and black text.
@@ -4655,7 +4655,7 @@ OAuth 2.0 protocol
         class="css-m07iiw-APISectionEnums"
       >
         <h4
-          class="  css-crowgh-H4"
+          class="  css-uucypz-H4"
           data-components-heading="true"
           data-heading="true"
         >
@@ -4674,7 +4674,7 @@ OAuth 2.0 protocol
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-16lpqq8-InlineCode"
+                  class="inline css-10jm9cu-InlineCode"
                 >
                   BLACK
                 </code>
@@ -4712,7 +4712,7 @@ OAuth 2.0 protocol
         </h4>
       </div>
       <code
-        class="inline css-t7whmz-APISectionEnums"
+        class="inline css-bs4uzw-APISectionEnums"
       >
         AppleAuthenticationButtonStyle
         .
@@ -4720,7 +4720,7 @@ OAuth 2.0 protocol
          ＝ 2
       </code>
       <p
-        class="css-1bjvyhe-P"
+        class="css-gvfsz4-P"
         data-text="true"
       >
         Black button with white text.
@@ -4731,7 +4731,7 @@ OAuth 2.0 protocol
     class="css-eskewv-APISectionEnums"
   >
     <h3
-      class="css-6kh5nb-H3"
+      class="css-m417je-H3"
       data-heading="true"
     >
       <div
@@ -4749,7 +4749,7 @@ OAuth 2.0 protocol
             class="css-6n7j50"
           >
             <code
-              class="inline css-16lpqq8-InlineCode"
+              class="inline css-10jm9cu-InlineCode"
             >
               AppleAuthenticationButtonType
             </code>
@@ -4786,7 +4786,7 @@ OAuth 2.0 protocol
       </div>
     </h3>
     <p
-      class="css-1bjvyhe-P"
+      class="css-gvfsz4-P"
       data-text="true"
     >
       An enum whose values control which pre-defined text to use when rendering an 
@@ -4795,7 +4795,7 @@ OAuth 2.0 protocol
         href="/#appleauthenticationappleauthenticationbutton"
       >
         <code
-          class="inline css-16lpqq8-InlineCode"
+          class="inline css-10jm9cu-InlineCode"
         >
           AppleAuthenticationButton
         </code>
@@ -4809,7 +4809,7 @@ OAuth 2.0 protocol
         class="css-m07iiw-APISectionEnums"
       >
         <h4
-          class="  css-crowgh-H4"
+          class="  css-uucypz-H4"
           data-components-heading="true"
           data-heading="true"
         >
@@ -4828,7 +4828,7 @@ OAuth 2.0 protocol
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-16lpqq8-InlineCode"
+                  class="inline css-10jm9cu-InlineCode"
                 >
                   SIGN_IN
                 </code>
@@ -4866,7 +4866,7 @@ OAuth 2.0 protocol
         </h4>
       </div>
       <code
-        class="inline css-t7whmz-APISectionEnums"
+        class="inline css-bs4uzw-APISectionEnums"
       >
         AppleAuthenticationButtonType
         .
@@ -4874,7 +4874,7 @@ OAuth 2.0 protocol
          ＝ 0
       </code>
       <p
-        class="css-1bjvyhe-P"
+        class="css-gvfsz4-P"
         data-text="true"
       >
         "Sign in with Apple"
@@ -4887,7 +4887,7 @@ OAuth 2.0 protocol
         class="css-m07iiw-APISectionEnums"
       >
         <h4
-          class="  css-crowgh-H4"
+          class="  css-uucypz-H4"
           data-components-heading="true"
           data-heading="true"
         >
@@ -4906,7 +4906,7 @@ OAuth 2.0 protocol
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-16lpqq8-InlineCode"
+                  class="inline css-10jm9cu-InlineCode"
                 >
                   CONTINUE
                 </code>
@@ -4944,7 +4944,7 @@ OAuth 2.0 protocol
         </h4>
       </div>
       <code
-        class="inline css-t7whmz-APISectionEnums"
+        class="inline css-bs4uzw-APISectionEnums"
       >
         AppleAuthenticationButtonType
         .
@@ -4952,7 +4952,7 @@ OAuth 2.0 protocol
          ＝ 1
       </code>
       <p
-        class="css-1bjvyhe-P"
+        class="css-gvfsz4-P"
         data-text="true"
       >
         "Continue with Apple"
@@ -4962,7 +4962,7 @@ OAuth 2.0 protocol
       class="css-1xaswp1-APISectionEnums"
     >
       <strong
-        class="css-1k788ud-B"
+        class="css-cyicbq-B"
       >
         Only for:
          
@@ -4998,7 +4998,7 @@ OAuth 2.0 protocol
         class="css-m07iiw-APISectionEnums"
       >
         <h4
-          class="  css-crowgh-H4"
+          class="  css-uucypz-H4"
           data-components-heading="true"
           data-heading="true"
         >
@@ -5017,7 +5017,7 @@ OAuth 2.0 protocol
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-16lpqq8-InlineCode"
+                  class="inline css-10jm9cu-InlineCode"
                 >
                   SIGN_UP
                 </code>
@@ -5055,7 +5055,7 @@ OAuth 2.0 protocol
         </h4>
       </div>
       <code
-        class="inline css-t7whmz-APISectionEnums"
+        class="inline css-bs4uzw-APISectionEnums"
       >
         AppleAuthenticationButtonType
         .
@@ -5063,7 +5063,7 @@ OAuth 2.0 protocol
          ＝ 2
       </code>
       <p
-        class="css-1bjvyhe-P"
+        class="css-gvfsz4-P"
         data-text="true"
       >
         "Sign up with Apple"
@@ -5074,7 +5074,7 @@ OAuth 2.0 protocol
     class="css-eskewv-APISectionEnums"
   >
     <h3
-      class="css-6kh5nb-H3"
+      class="css-m417je-H3"
       data-heading="true"
     >
       <div
@@ -5092,7 +5092,7 @@ OAuth 2.0 protocol
             class="css-6n7j50"
           >
             <code
-              class="inline css-16lpqq8-InlineCode"
+              class="inline css-10jm9cu-InlineCode"
             >
               AppleAuthenticationCredentialState
             </code>
@@ -5129,7 +5129,7 @@ OAuth 2.0 protocol
       </div>
     </h3>
     <p
-      class="css-1bjvyhe-P"
+      class="css-gvfsz4-P"
       data-text="true"
     >
       An enum whose values specify state of the credential when checked with 
@@ -5138,7 +5138,7 @@ OAuth 2.0 protocol
         href="/#appleauthenticationgetcredentialstateasyncuser"
       >
         <code
-          class="inline css-16lpqq8-InlineCode"
+          class="inline css-10jm9cu-InlineCode"
         >
           AppleAuthentication.getCredentialStateAsync()
         </code>
@@ -5146,7 +5146,7 @@ OAuth 2.0 protocol
       .
     </p>
     <blockquote
-      class="css-1yla49y-Quote"
+      class="css-y2d7cg-Quote"
       data-text="true"
     >
       <div
@@ -5171,7 +5171,7 @@ OAuth 2.0 protocol
       </div>
       <div>
         <strong
-          class="css-1k788ud-B"
+          class="css-cyicbq-B"
         >
           See: 
         </strong>
@@ -5196,7 +5196,7 @@ for more details.
         class="css-m07iiw-APISectionEnums"
       >
         <h4
-          class="  css-crowgh-H4"
+          class="  css-uucypz-H4"
           data-components-heading="true"
           data-heading="true"
         >
@@ -5215,7 +5215,7 @@ for more details.
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-16lpqq8-InlineCode"
+                  class="inline css-10jm9cu-InlineCode"
                 >
                   REVOKED
                 </code>
@@ -5253,7 +5253,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="inline css-t7whmz-APISectionEnums"
+        class="inline css-bs4uzw-APISectionEnums"
       >
         AppleAuthenticationCredentialState
         .
@@ -5268,7 +5268,7 @@ for more details.
         class="css-m07iiw-APISectionEnums"
       >
         <h4
-          class="  css-crowgh-H4"
+          class="  css-uucypz-H4"
           data-components-heading="true"
           data-heading="true"
         >
@@ -5287,7 +5287,7 @@ for more details.
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-16lpqq8-InlineCode"
+                  class="inline css-10jm9cu-InlineCode"
                 >
                   AUTHORIZED
                 </code>
@@ -5325,7 +5325,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="inline css-t7whmz-APISectionEnums"
+        class="inline css-bs4uzw-APISectionEnums"
       >
         AppleAuthenticationCredentialState
         .
@@ -5340,7 +5340,7 @@ for more details.
         class="css-m07iiw-APISectionEnums"
       >
         <h4
-          class="  css-crowgh-H4"
+          class="  css-uucypz-H4"
           data-components-heading="true"
           data-heading="true"
         >
@@ -5359,7 +5359,7 @@ for more details.
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-16lpqq8-InlineCode"
+                  class="inline css-10jm9cu-InlineCode"
                 >
                   NOT_FOUND
                 </code>
@@ -5397,7 +5397,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="inline css-t7whmz-APISectionEnums"
+        class="inline css-bs4uzw-APISectionEnums"
       >
         AppleAuthenticationCredentialState
         .
@@ -5412,7 +5412,7 @@ for more details.
         class="css-m07iiw-APISectionEnums"
       >
         <h4
-          class="  css-crowgh-H4"
+          class="  css-uucypz-H4"
           data-components-heading="true"
           data-heading="true"
         >
@@ -5431,7 +5431,7 @@ for more details.
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-16lpqq8-InlineCode"
+                  class="inline css-10jm9cu-InlineCode"
                 >
                   TRANSFERRED
                 </code>
@@ -5469,7 +5469,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="inline css-t7whmz-APISectionEnums"
+        class="inline css-bs4uzw-APISectionEnums"
       >
         AppleAuthenticationCredentialState
         .
@@ -5482,7 +5482,7 @@ for more details.
     class="css-eskewv-APISectionEnums"
   >
     <h3
-      class="css-6kh5nb-H3"
+      class="css-m417je-H3"
       data-heading="true"
     >
       <div
@@ -5500,7 +5500,7 @@ for more details.
             class="css-6n7j50"
           >
             <code
-              class="inline css-16lpqq8-InlineCode"
+              class="inline css-10jm9cu-InlineCode"
             >
               AppleAuthenticationOperation
             </code>
@@ -5543,7 +5543,7 @@ for more details.
         class="css-m07iiw-APISectionEnums"
       >
         <h4
-          class="  css-crowgh-H4"
+          class="  css-uucypz-H4"
           data-components-heading="true"
           data-heading="true"
         >
@@ -5562,7 +5562,7 @@ for more details.
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-16lpqq8-InlineCode"
+                  class="inline css-10jm9cu-InlineCode"
                 >
                   IMPLICIT
                 </code>
@@ -5600,7 +5600,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="inline css-t7whmz-APISectionEnums"
+        class="inline css-bs4uzw-APISectionEnums"
       >
         AppleAuthenticationOperation
         .
@@ -5608,7 +5608,7 @@ for more details.
          ＝ 0
       </code>
       <p
-        class="css-1bjvyhe-P"
+        class="css-gvfsz4-P"
         data-text="true"
       >
         An operation that depends on the particular kind of credential provider.
@@ -5621,7 +5621,7 @@ for more details.
         class="css-m07iiw-APISectionEnums"
       >
         <h4
-          class="  css-crowgh-H4"
+          class="  css-uucypz-H4"
           data-components-heading="true"
           data-heading="true"
         >
@@ -5640,7 +5640,7 @@ for more details.
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-16lpqq8-InlineCode"
+                  class="inline css-10jm9cu-InlineCode"
                 >
                   LOGIN
                 </code>
@@ -5678,7 +5678,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="inline css-t7whmz-APISectionEnums"
+        class="inline css-bs4uzw-APISectionEnums"
       >
         AppleAuthenticationOperation
         .
@@ -5693,7 +5693,7 @@ for more details.
         class="css-m07iiw-APISectionEnums"
       >
         <h4
-          class="  css-crowgh-H4"
+          class="  css-uucypz-H4"
           data-components-heading="true"
           data-heading="true"
         >
@@ -5712,7 +5712,7 @@ for more details.
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-16lpqq8-InlineCode"
+                  class="inline css-10jm9cu-InlineCode"
                 >
                   REFRESH
                 </code>
@@ -5750,7 +5750,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="inline css-t7whmz-APISectionEnums"
+        class="inline css-bs4uzw-APISectionEnums"
       >
         AppleAuthenticationOperation
         .
@@ -5765,7 +5765,7 @@ for more details.
         class="css-m07iiw-APISectionEnums"
       >
         <h4
-          class="  css-crowgh-H4"
+          class="  css-uucypz-H4"
           data-components-heading="true"
           data-heading="true"
         >
@@ -5784,7 +5784,7 @@ for more details.
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-16lpqq8-InlineCode"
+                  class="inline css-10jm9cu-InlineCode"
                 >
                   LOGOUT
                 </code>
@@ -5822,7 +5822,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="inline css-t7whmz-APISectionEnums"
+        class="inline css-bs4uzw-APISectionEnums"
       >
         AppleAuthenticationOperation
         .
@@ -5835,7 +5835,7 @@ for more details.
     class="css-eskewv-APISectionEnums"
   >
     <h3
-      class="css-6kh5nb-H3"
+      class="css-m417je-H3"
       data-heading="true"
     >
       <div
@@ -5853,7 +5853,7 @@ for more details.
             class="css-6n7j50"
           >
             <code
-              class="inline css-16lpqq8-InlineCode"
+              class="inline css-10jm9cu-InlineCode"
             >
               AppleAuthenticationScope
             </code>
@@ -5890,7 +5890,7 @@ for more details.
       </div>
     </h3>
     <p
-      class="css-1bjvyhe-P"
+      class="css-gvfsz4-P"
       data-text="true"
     >
       An enum whose values specify scopes you can request when calling 
@@ -5899,7 +5899,7 @@ for more details.
         href="/#appleauthenticationsigninasyncoptions"
       >
         <code
-          class="inline css-16lpqq8-InlineCode"
+          class="inline css-10jm9cu-InlineCode"
         >
           AppleAuthentication.signInAsync()
         </code>
@@ -5907,7 +5907,7 @@ for more details.
       .
     </p>
     <blockquote
-      class="css-1yla49y-Quote"
+      class="css-y2d7cg-Quote"
       data-text="true"
     >
       <div
@@ -5940,7 +5940,7 @@ You will still need to handle null values for any fields you request.
       </div>
     </blockquote>
     <blockquote
-      class="css-1yla49y-Quote"
+      class="css-y2d7cg-Quote"
       data-text="true"
     >
       <div
@@ -5965,7 +5965,7 @@ You will still need to handle null values for any fields you request.
       </div>
       <div>
         <strong
-          class="css-1k788ud-B"
+          class="css-cyicbq-B"
         >
           See: 
         </strong>
@@ -5990,7 +5990,7 @@ for more details.
         class="css-m07iiw-APISectionEnums"
       >
         <h4
-          class="  css-crowgh-H4"
+          class="  css-uucypz-H4"
           data-components-heading="true"
           data-heading="true"
         >
@@ -6009,7 +6009,7 @@ for more details.
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-16lpqq8-InlineCode"
+                  class="inline css-10jm9cu-InlineCode"
                 >
                   FULL_NAME
                 </code>
@@ -6047,7 +6047,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="inline css-t7whmz-APISectionEnums"
+        class="inline css-bs4uzw-APISectionEnums"
       >
         AppleAuthenticationScope
         .
@@ -6062,7 +6062,7 @@ for more details.
         class="css-m07iiw-APISectionEnums"
       >
         <h4
-          class="  css-crowgh-H4"
+          class="  css-uucypz-H4"
           data-components-heading="true"
           data-heading="true"
         >
@@ -6081,7 +6081,7 @@ for more details.
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-16lpqq8-InlineCode"
+                  class="inline css-10jm9cu-InlineCode"
                 >
                   EMAIL
                 </code>
@@ -6119,7 +6119,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="inline css-t7whmz-APISectionEnums"
+        class="inline css-bs4uzw-APISectionEnums"
       >
         AppleAuthenticationScope
         .
@@ -6132,7 +6132,7 @@ for more details.
     class="css-eskewv-APISectionEnums"
   >
     <h3
-      class="css-6kh5nb-H3"
+      class="css-m417je-H3"
       data-heading="true"
     >
       <div
@@ -6150,7 +6150,7 @@ for more details.
             class="css-6n7j50"
           >
             <code
-              class="inline css-16lpqq8-InlineCode"
+              class="inline css-10jm9cu-InlineCode"
             >
               AppleAuthenticationUserDetectionStatus
             </code>
@@ -6187,13 +6187,13 @@ for more details.
       </div>
     </h3>
     <p
-      class="css-1bjvyhe-P"
+      class="css-gvfsz4-P"
       data-text="true"
     >
       An enum whose values specify the system's best guess for how likely the current user is a real person.
     </p>
     <blockquote
-      class="css-1yla49y-Quote"
+      class="css-y2d7cg-Quote"
       data-text="true"
     >
       <div
@@ -6218,7 +6218,7 @@ for more details.
       </div>
       <div>
         <strong
-          class="css-1k788ud-B"
+          class="css-cyicbq-B"
         >
           See: 
         </strong>
@@ -6243,7 +6243,7 @@ for more details.
         class="css-m07iiw-APISectionEnums"
       >
         <h4
-          class="  css-crowgh-H4"
+          class="  css-uucypz-H4"
           data-components-heading="true"
           data-heading="true"
         >
@@ -6262,7 +6262,7 @@ for more details.
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-16lpqq8-InlineCode"
+                  class="inline css-10jm9cu-InlineCode"
                 >
                   UNSUPPORTED
                 </code>
@@ -6300,7 +6300,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="inline css-t7whmz-APISectionEnums"
+        class="inline css-bs4uzw-APISectionEnums"
       >
         AppleAuthenticationUserDetectionStatus
         .
@@ -6308,7 +6308,7 @@ for more details.
          ＝ 0
       </code>
       <p
-        class="css-1bjvyhe-P"
+        class="css-gvfsz4-P"
         data-text="true"
       >
         The system does not support this determination and there is no data.
@@ -6321,7 +6321,7 @@ for more details.
         class="css-m07iiw-APISectionEnums"
       >
         <h4
-          class="  css-crowgh-H4"
+          class="  css-uucypz-H4"
           data-components-heading="true"
           data-heading="true"
         >
@@ -6340,7 +6340,7 @@ for more details.
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-16lpqq8-InlineCode"
+                  class="inline css-10jm9cu-InlineCode"
                 >
                   UNKNOWN
                 </code>
@@ -6378,7 +6378,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="inline css-t7whmz-APISectionEnums"
+        class="inline css-bs4uzw-APISectionEnums"
       >
         AppleAuthenticationUserDetectionStatus
         .
@@ -6386,7 +6386,7 @@ for more details.
          ＝ 1
       </code>
       <p
-        class="css-1bjvyhe-P"
+        class="css-gvfsz4-P"
         data-text="true"
       >
         The system has not determined whether the user might be a real person.
@@ -6399,7 +6399,7 @@ for more details.
         class="css-m07iiw-APISectionEnums"
       >
         <h4
-          class="  css-crowgh-H4"
+          class="  css-uucypz-H4"
           data-components-heading="true"
           data-heading="true"
         >
@@ -6418,7 +6418,7 @@ for more details.
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-16lpqq8-InlineCode"
+                  class="inline css-10jm9cu-InlineCode"
                 >
                   LIKELY_REAL
                 </code>
@@ -6456,7 +6456,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="inline css-t7whmz-APISectionEnums"
+        class="inline css-bs4uzw-APISectionEnums"
       >
         AppleAuthenticationUserDetectionStatus
         .
@@ -6464,7 +6464,7 @@ for more details.
          ＝ 2
       </code>
       <p
-        class="css-1bjvyhe-P"
+        class="css-gvfsz4-P"
         data-text="true"
       >
         The user appears to be a real person.
@@ -6477,7 +6477,7 @@ for more details.
 exports[`APISection expo-barcode-scanner 1`] = `
 <div>
   <h2
-    class="css-1azb2g5-H2"
+    class="css-wpfbxc-H2"
     data-heading="true"
   >
     <div
@@ -6531,7 +6531,7 @@ exports[`APISection expo-barcode-scanner 1`] = `
     class="css-excx5x-APISectionComponents"
   >
     <h3
-      class="css-6kh5nb-H3"
+      class="css-m417je-H3"
       data-heading="true"
     >
       <div
@@ -6549,7 +6549,7 @@ exports[`APISection expo-barcode-scanner 1`] = `
             class="css-6n7j50"
           >
             <code
-              class="inline css-16lpqq8-InlineCode"
+              class="inline css-10jm9cu-InlineCode"
             >
               BarCodeScanner
             </code>
@@ -6586,17 +6586,17 @@ exports[`APISection expo-barcode-scanner 1`] = `
       </div>
     </h3>
     <p
-      class="css-1bjvyhe-P"
+      class="css-gvfsz4-P"
       data-text="true"
     >
       <strong
-        class="css-1k788ud-B"
+        class="css-cyicbq-B"
       >
         Type:
       </strong>
        
       <code
-        class="inline css-16lpqq8-InlineCode"
+        class="inline css-10jm9cu-InlineCode"
       >
         Component
         &lt;
@@ -6612,7 +6612,7 @@ exports[`APISection expo-barcode-scanner 1`] = `
       </code>
     </p>
     <h2
-      class="css-1azb2g5-H2"
+      class="css-wpfbxc-H2"
       data-heading="true"
     >
       <div
@@ -6667,7 +6667,7 @@ exports[`APISection expo-barcode-scanner 1`] = `
         class="css-1k62do8-APISectionProps"
       >
         <h3
-          class="css-6kh5nb-H3"
+          class="css-m417je-H3"
           data-heading="true"
         >
           <div
@@ -6685,7 +6685,7 @@ exports[`APISection expo-barcode-scanner 1`] = `
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-1lmmqpm-InlineCode"
+                  class="inline css-tu4dab-InlineCode"
                 >
                   barCodeTypes
                 </code>
@@ -6722,7 +6722,7 @@ exports[`APISection expo-barcode-scanner 1`] = `
           </div>
         </h3>
         <p
-          class="css-1bjvyhe-P"
+          class="css-gvfsz4-P"
           data-text="true"
         >
           <span
@@ -6737,25 +6737,25 @@ exports[`APISection expo-barcode-scanner 1`] = `
           </span>
            
           <code
-            class="inline css-16lpqq8-InlineCode"
+            class="inline css-10jm9cu-InlineCode"
           >
             string[]
           </code>
         </p>
         <p
-          class="css-1bjvyhe-P"
+          class="css-gvfsz4-P"
           data-text="true"
         >
           An array of bar code types. Usage: 
           <code
-            class="inline css-16lpqq8-InlineCode"
+            class="inline css-10jm9cu-InlineCode"
           >
             BarCodeScanner.Constants.BarCodeType.&lt;codeType&gt;
           </code>
            where
 
           <code
-            class="inline css-16lpqq8-InlineCode"
+            class="inline css-10jm9cu-InlineCode"
           >
             codeType
           </code>
@@ -6771,12 +6771,12 @@ code types. It is recommended to provide only the bar code formats you expect to
 minimize battery usage.
         </p>
         <p
-          class="css-1bjvyhe-P"
+          class="css-gvfsz4-P"
           data-text="true"
         >
           For example: 
           <code
-            class="inline css-16lpqq8-InlineCode"
+            class="inline css-10jm9cu-InlineCode"
           >
             barCodeTypes={[BarCodeScanner.Constants.BarCodeType.qr]}
           </code>
@@ -6787,7 +6787,7 @@ minimize battery usage.
         class="css-1k62do8-APISectionProps"
       >
         <h3
-          class="css-6kh5nb-H3"
+          class="css-m417je-H3"
           data-heading="true"
         >
           <div
@@ -6805,7 +6805,7 @@ minimize battery usage.
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-1lmmqpm-InlineCode"
+                  class="inline css-tu4dab-InlineCode"
                 >
                   onBarCodeScanned
                 </code>
@@ -6842,7 +6842,7 @@ minimize battery usage.
           </div>
         </h3>
         <p
-          class="css-1bjvyhe-P"
+          class="css-gvfsz4-P"
           data-text="true"
         >
           <span
@@ -6857,7 +6857,7 @@ minimize battery usage.
           </span>
            
           <code
-            class="inline css-16lpqq8-InlineCode"
+            class="inline css-10jm9cu-InlineCode"
           >
             <a
               class="css-153g748-InternalLink"
@@ -6868,7 +6868,7 @@ minimize battery usage.
           </code>
         </p>
         <p
-          class="css-1bjvyhe-P"
+          class="css-gvfsz4-P"
           data-text="true"
         >
           A callback that is invoked when a bar code has been successfully scanned. The callback is
@@ -6884,7 +6884,7 @@ provided with an
         
 
         <blockquote
-          class="css-1yla49y-Quote"
+          class="css-y2d7cg-Quote"
           data-text="true"
         >
           <div
@@ -6911,19 +6911,19 @@ provided with an
             
 
             <strong
-              class="css-1k788ud-B"
+              class="css-cyicbq-B"
             >
               Note:
             </strong>
              Passing 
             <code
-              class="inline css-16lpqq8-InlineCode"
+              class="inline css-10jm9cu-InlineCode"
             >
               undefined
             </code>
              to the 
             <code
-              class="inline css-16lpqq8-InlineCode"
+              class="inline css-10jm9cu-InlineCode"
             >
               onBarCodeScanned
             </code>
@@ -6939,7 +6939,7 @@ data has been retrieved.
         class="css-1k62do8-APISectionProps"
       >
         <h3
-          class="css-6kh5nb-H3"
+          class="css-m417je-H3"
           data-heading="true"
         >
           <div
@@ -6957,7 +6957,7 @@ data has been retrieved.
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-1lmmqpm-InlineCode"
+                  class="inline css-tu4dab-InlineCode"
                 >
                   type
                 </code>
@@ -6994,7 +6994,7 @@ data has been retrieved.
           </div>
         </h3>
         <p
-          class="css-1bjvyhe-P"
+          class="css-gvfsz4-P"
           data-text="true"
         >
           <span
@@ -7009,7 +7009,7 @@ data has been retrieved.
           </span>
            
           <code
-            class="inline css-16lpqq8-InlineCode"
+            class="inline css-10jm9cu-InlineCode"
           >
             <span>
               'front'
@@ -7031,7 +7031,7 @@ data has been retrieved.
             </span>
              
             <code
-              class="inline css-16lpqq8-InlineCode"
+              class="inline css-10jm9cu-InlineCode"
             >
               Type.back
 
@@ -7039,31 +7039,31 @@ data has been retrieved.
           </span>
         </p>
         <p
-          class="css-1bjvyhe-P"
+          class="css-gvfsz4-P"
           data-text="true"
         >
           Camera facing. Use one of 
           <code
-            class="inline css-16lpqq8-InlineCode"
+            class="inline css-10jm9cu-InlineCode"
           >
             BarCodeScanner.Constants.Type
           </code>
           . Use either 
           <code
-            class="inline css-16lpqq8-InlineCode"
+            class="inline css-10jm9cu-InlineCode"
           >
             Type.front
           </code>
            or 
           <code
-            class="inline css-16lpqq8-InlineCode"
+            class="inline css-10jm9cu-InlineCode"
           >
             Type.back
           </code>
           .
 Same as 
           <code
-            class="inline css-16lpqq8-InlineCode"
+            class="inline css-10jm9cu-InlineCode"
           >
             Camera.Constants.Type
           </code>
@@ -7071,7 +7071,7 @@ Same as
         </p>
       </div>
       <h3
-        class="css-6kh5nb-H3"
+        class="css-m417je-H3"
         data-heading="true"
       >
         <div
@@ -7122,14 +7122,14 @@ Same as
         </div>
       </h3>
       <ul
-        class="css-is4ysz-UL"
+        class="css-viw9dk-UL"
         data-text="true"
       >
         <li
           class="docs-list-item css-l157nt-LI"
         >
           <code
-            class="inline css-16lpqq8-InlineCode"
+            class="inline css-10jm9cu-InlineCode"
           >
             <a
               class="css-153g748-InternalLink"
@@ -7143,7 +7143,7 @@ Same as
     </div>
   </div>
   <h2
-    class="css-1azb2g5-H2"
+    class="css-wpfbxc-H2"
     data-heading="true"
   >
     <div
@@ -7197,7 +7197,7 @@ Same as
     class="css-eu2n2e-APISectionMethods"
   >
     <h3
-      class="css-6kh5nb-H3"
+      class="css-m417je-H3"
       data-heading="true"
     >
       <div
@@ -7215,7 +7215,7 @@ Same as
             class="css-6n7j50"
           >
             <code
-              class="inline css-1lmmqpm-InlineCode"
+              class="inline css-tu4dab-InlineCode"
             >
               usePermissions(options)
             </code>
@@ -7288,7 +7288,7 @@ Same as
               class="css-t44xva-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 options
               </strong>
@@ -7303,7 +7303,7 @@ Same as
               class="css-t44xva-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 <a
                   class="css-153g748-InternalLink"
@@ -7328,17 +7328,17 @@ Same as
       </table>
     </div>
     <p
-      class="css-1bjvyhe-P"
+      class="css-gvfsz4-P"
       data-text="true"
     >
       Create a new permission hook with the permission methods built-in.
 This can be used to quickly create specific permission hooks in every module.
     </p>
     <div
-      class="css-152mimm-CommentTextBlock"
+      class="css-12a4dfj-CommentTextBlock"
     >
       <h4
-        class="css-crowgh-H4"
+        class="css-uucypz-H4"
         data-heading="true"
       >
         Example
@@ -7418,10 +7418,10 @@ This can be used to quickly create specific permission hooks in every module.
       </pre>
     </pre>
     <div
-      class="css-1remai5-APISectionMethods"
+      class="css-1dfa5yf-APISectionMethods"
     >
       <h4
-        class="  css-crowgh-H4"
+        class="  css-uucypz-H4"
         data-components-heading="true"
         data-heading="true"
       >
@@ -7474,7 +7474,7 @@ This can be used to quickly create specific permission hooks in every module.
       </h4>
     </div>
     <ul
-      class="css-11d2x0b-UL"
+      class="css-ozzgx3-UL"
       data-text="true"
     >
       <li
@@ -7499,7 +7499,7 @@ This can be used to quickly create specific permission hooks in every module.
           />
         </svg>
         <code
-          class="inline css-16lpqq8-InlineCode"
+          class="inline css-10jm9cu-InlineCode"
         >
           [
           <span>
@@ -7550,7 +7550,7 @@ This can be used to quickly create specific permission hooks in every module.
     </ul>
   </div>
   <h2
-    class="css-1azb2g5-H2"
+    class="css-wpfbxc-H2"
     data-heading="true"
   >
     <div
@@ -7604,7 +7604,7 @@ This can be used to quickly create specific permission hooks in every module.
     class="css-eu2n2e-APISectionMethods"
   >
     <h3
-      class="css-6kh5nb-H3"
+      class="css-m417je-H3"
       data-heading="true"
     >
       <div
@@ -7622,7 +7622,7 @@ This can be used to quickly create specific permission hooks in every module.
             class="css-6n7j50"
           >
             <code
-              class="inline css-1lmmqpm-InlineCode"
+              class="inline css-tu4dab-InlineCode"
             >
               BarCodeScanner.
               getPermissionsAsync()
@@ -7660,16 +7660,16 @@ This can be used to quickly create specific permission hooks in every module.
       </div>
     </h3>
     <p
-      class="css-1bjvyhe-P"
+      class="css-gvfsz4-P"
       data-text="true"
     >
       Checks user's permissions for accessing the camera.
     </p>
     <div
-      class="css-1remai5-APISectionMethods"
+      class="css-1dfa5yf-APISectionMethods"
     >
       <h4
-        class="  css-crowgh-H4"
+        class="  css-uucypz-H4"
         data-components-heading="true"
         data-heading="true"
       >
@@ -7722,7 +7722,7 @@ This can be used to quickly create specific permission hooks in every module.
       </h4>
     </div>
     <ul
-      class="css-11d2x0b-UL"
+      class="css-ozzgx3-UL"
       data-text="true"
     >
       <li
@@ -7747,7 +7747,7 @@ This can be used to quickly create specific permission hooks in every module.
           />
         </svg>
         <code
-          class="inline css-16lpqq8-InlineCode"
+          class="inline css-10jm9cu-InlineCode"
         >
           <a
             class="css-ccg2mn-ExternalLink"
@@ -7770,7 +7770,7 @@ This can be used to quickly create specific permission hooks in every module.
       </li>
     </ul>
     <p
-      class="css-1bjvyhe-P"
+      class="css-gvfsz4-P"
       data-text="true"
     >
       Return a promise that fulfills to an object of type 
@@ -7779,7 +7779,7 @@ This can be used to quickly create specific permission hooks in every module.
         href="/#permissionresponse"
       >
         <code
-          class="inline css-16lpqq8-InlineCode"
+          class="inline css-10jm9cu-InlineCode"
         >
           PermissionResponse
         </code>
@@ -7791,7 +7791,7 @@ This can be used to quickly create specific permission hooks in every module.
     class="css-eu2n2e-APISectionMethods"
   >
     <h3
-      class="css-6kh5nb-H3"
+      class="css-m417je-H3"
       data-heading="true"
     >
       <div
@@ -7809,7 +7809,7 @@ This can be used to quickly create specific permission hooks in every module.
             class="css-6n7j50"
           >
             <code
-              class="inline css-1lmmqpm-InlineCode"
+              class="inline css-tu4dab-InlineCode"
             >
               BarCodeScanner.
               requestPermissionsAsync()
@@ -7847,34 +7847,34 @@ This can be used to quickly create specific permission hooks in every module.
       </div>
     </h3>
     <p
-      class="css-1bjvyhe-P"
+      class="css-gvfsz4-P"
       data-text="true"
     >
       Asks the user to grant permissions for accessing the camera.
     </p>
     <p
-      class="css-1bjvyhe-P"
+      class="css-gvfsz4-P"
       data-text="true"
     >
       On iOS this will require apps to specify the 
       <code
-        class="inline css-16lpqq8-InlineCode"
+        class="inline css-10jm9cu-InlineCode"
       >
         NSCameraUsageDescription
       </code>
        entry in the 
       <code
-        class="inline css-16lpqq8-InlineCode"
+        class="inline css-10jm9cu-InlineCode"
       >
         Info.plist
       </code>
       .
     </p>
     <div
-      class="css-1remai5-APISectionMethods"
+      class="css-1dfa5yf-APISectionMethods"
     >
       <h4
-        class="  css-crowgh-H4"
+        class="  css-uucypz-H4"
         data-components-heading="true"
         data-heading="true"
       >
@@ -7927,7 +7927,7 @@ This can be used to quickly create specific permission hooks in every module.
       </h4>
     </div>
     <ul
-      class="css-11d2x0b-UL"
+      class="css-ozzgx3-UL"
       data-text="true"
     >
       <li
@@ -7952,7 +7952,7 @@ This can be used to quickly create specific permission hooks in every module.
           />
         </svg>
         <code
-          class="inline css-16lpqq8-InlineCode"
+          class="inline css-10jm9cu-InlineCode"
         >
           <a
             class="css-ccg2mn-ExternalLink"
@@ -7975,7 +7975,7 @@ This can be used to quickly create specific permission hooks in every module.
       </li>
     </ul>
     <p
-      class="css-1bjvyhe-P"
+      class="css-gvfsz4-P"
       data-text="true"
     >
       Return a promise that fulfills to an object of type 
@@ -7984,7 +7984,7 @@ This can be used to quickly create specific permission hooks in every module.
         href="/#permissionresponse"
       >
         <code
-          class="inline css-16lpqq8-InlineCode"
+          class="inline css-10jm9cu-InlineCode"
         >
           PermissionResponse
         </code>
@@ -7996,7 +7996,7 @@ This can be used to quickly create specific permission hooks in every module.
     class="css-eu2n2e-APISectionMethods"
   >
     <h3
-      class="css-6kh5nb-H3"
+      class="css-m417je-H3"
       data-heading="true"
     >
       <div
@@ -8014,7 +8014,7 @@ This can be used to quickly create specific permission hooks in every module.
             class="css-6n7j50"
           >
             <code
-              class="inline css-1lmmqpm-InlineCode"
+              class="inline css-tu4dab-InlineCode"
             >
               BarCodeScanner.
               scanFromURLAsync(url, barCodeTypes)
@@ -8088,7 +8088,7 @@ This can be used to quickly create specific permission hooks in every module.
               class="css-t44xva-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 url
               </strong>
@@ -8097,7 +8097,7 @@ This can be used to quickly create specific permission hooks in every module.
               class="css-t44xva-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 string
               </code>
@@ -8117,7 +8117,7 @@ This can be used to quickly create specific permission hooks in every module.
               class="css-t44xva-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 barCodeTypes
               </strong>
@@ -8132,7 +8132,7 @@ This can be used to quickly create specific permission hooks in every module.
               class="css-t44xva-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 string[]
               </code>
@@ -8147,7 +8147,7 @@ the platform.
               
 
               <blockquote
-                class="css-1yla49y-Quote"
+                class="css-y2d7cg-Quote"
                 data-text="true"
               >
                 <div
@@ -8174,7 +8174,7 @@ the platform.
                   
 
                   <strong
-                    class="css-1k788ud-B"
+                    class="css-cyicbq-B"
                   >
                     Note:
                   </strong>
@@ -8189,16 +8189,16 @@ the platform.
       </table>
     </div>
     <p
-      class="css-1bjvyhe-P"
+      class="css-gvfsz4-P"
       data-text="true"
     >
       Scan bar codes from the image given by the URL.
     </p>
     <div
-      class="css-1remai5-APISectionMethods"
+      class="css-1dfa5yf-APISectionMethods"
     >
       <h4
-        class="  css-crowgh-H4"
+        class="  css-uucypz-H4"
         data-components-heading="true"
         data-heading="true"
       >
@@ -8251,7 +8251,7 @@ the platform.
       </h4>
     </div>
     <ul
-      class="css-11d2x0b-UL"
+      class="css-ozzgx3-UL"
       data-text="true"
     >
       <li
@@ -8276,7 +8276,7 @@ the platform.
           />
         </svg>
         <code
-          class="inline css-16lpqq8-InlineCode"
+          class="inline css-10jm9cu-InlineCode"
         >
           <a
             class="css-ccg2mn-ExternalLink"
@@ -8300,12 +8300,12 @@ the platform.
       </li>
     </ul>
     <p
-      class="css-1bjvyhe-P"
+      class="css-gvfsz4-P"
       data-text="true"
     >
       A possibly empty array of objects of the 
       <code
-        class="inline css-16lpqq8-InlineCode"
+        class="inline css-10jm9cu-InlineCode"
       >
         BarCodeScannerResult
       </code>
@@ -8315,7 +8315,7 @@ code.
     </p>
   </div>
   <h2
-    class="css-1azb2g5-H2"
+    class="css-wpfbxc-H2"
     data-heading="true"
   >
     <div
@@ -8369,7 +8369,7 @@ code.
     class="css-dox4n0-APISectionInterfaces"
   >
     <h3
-      class="css-6kh5nb-H3"
+      class="css-m417je-H3"
       data-heading="true"
     >
       <div
@@ -8387,7 +8387,7 @@ code.
             class="css-6n7j50"
           >
             <code
-              class="inline css-16lpqq8-InlineCode"
+              class="inline css-10jm9cu-InlineCode"
             >
               PermissionResponse
             </code>
@@ -8424,16 +8424,16 @@ code.
       </div>
     </h3>
     <p
-      class="css-1bjvyhe-P"
+      class="css-gvfsz4-P"
       data-text="true"
     >
       An object obtained by permissions get and request functions.
     </p>
     <div
-      class="css-1smmlx-APISectionInterfaces"
+      class="css-sr97iy-APISectionInterfaces"
     >
       <h4
-        class="  css-crowgh-H4"
+        class="  css-uucypz-H4"
         data-components-heading="true"
         data-heading="true"
       >
@@ -8523,7 +8523,7 @@ code.
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 canAskAgain
               </strong>
@@ -8532,7 +8532,7 @@ code.
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 boolean
               </code>
@@ -8554,7 +8554,7 @@ in order to enable/disable the permission.
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 expires
               </strong>
@@ -8563,7 +8563,7 @@ in order to enable/disable the permission.
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 <a
                   class="css-153g748-InternalLink"
@@ -8588,7 +8588,7 @@ in order to enable/disable the permission.
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 granted
               </strong>
@@ -8597,7 +8597,7 @@ in order to enable/disable the permission.
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 boolean
               </code>
@@ -8617,7 +8617,7 @@ in order to enable/disable the permission.
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 status
               </strong>
@@ -8626,7 +8626,7 @@ in order to enable/disable the permission.
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 <a
                   class="css-153g748-InternalLink"
@@ -8649,7 +8649,7 @@ in order to enable/disable the permission.
     </div>
   </div>
   <h2
-    class="css-1azb2g5-H2"
+    class="css-wpfbxc-H2"
     data-heading="true"
   >
     <div
@@ -8703,7 +8703,7 @@ in order to enable/disable the permission.
     class="css-16qd3rn-APISectionTypes"
   >
     <h3
-      class="css-6kh5nb-H3"
+      class="css-m417je-H3"
       data-heading="true"
     >
       <div
@@ -8721,7 +8721,7 @@ in order to enable/disable the permission.
             class="css-6n7j50"
           >
             <code
-              class="inline css-16lpqq8-InlineCode"
+              class="inline css-10jm9cu-InlineCode"
             >
               BarCodeBounds
             </code>
@@ -8794,7 +8794,7 @@ in order to enable/disable the permission.
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 origin
               </strong>
@@ -8803,7 +8803,7 @@ in order to enable/disable the permission.
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 <a
                   class="css-153g748-InternalLink"
@@ -8828,7 +8828,7 @@ in order to enable/disable the permission.
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 size
               </strong>
@@ -8837,7 +8837,7 @@ in order to enable/disable the permission.
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 <a
                   class="css-153g748-InternalLink"
@@ -8863,7 +8863,7 @@ in order to enable/disable the permission.
     class="css-16qd3rn-APISectionTypes"
   >
     <h3
-      class="css-6kh5nb-H3"
+      class="css-m417je-H3"
       data-heading="true"
     >
       <div
@@ -8881,7 +8881,7 @@ in order to enable/disable the permission.
             class="css-6n7j50"
           >
             <code
-              class="inline css-16lpqq8-InlineCode"
+              class="inline css-10jm9cu-InlineCode"
             >
               BarCodeEvent
             </code>
@@ -8918,11 +8918,11 @@ in order to enable/disable the permission.
       </div>
     </h3>
     <p
-      class="css-1bjvyhe-P"
+      class="css-gvfsz4-P"
       data-text="true"
     >
       <code
-        class="inline css-16lpqq8-InlineCode"
+        class="inline css-10jm9cu-InlineCode"
       >
         <a
           class="css-153g748-InternalLink"
@@ -8971,7 +8971,7 @@ in order to enable/disable the permission.
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 target
               </strong>
@@ -8986,7 +8986,7 @@ in order to enable/disable the permission.
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 number
               </code>
@@ -9005,7 +9005,7 @@ in order to enable/disable the permission.
     class="css-16qd3rn-APISectionTypes"
   >
     <h3
-      class="css-6kh5nb-H3"
+      class="css-m417je-H3"
       data-heading="true"
     >
       <div
@@ -9023,7 +9023,7 @@ in order to enable/disable the permission.
             class="css-6n7j50"
           >
             <code
-              class="inline css-16lpqq8-InlineCode"
+              class="inline css-10jm9cu-InlineCode"
             >
               BarCodeEventCallbackArguments
             </code>
@@ -9096,7 +9096,7 @@ in order to enable/disable the permission.
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 nativeEvent
               </strong>
@@ -9105,7 +9105,7 @@ in order to enable/disable the permission.
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 <a
                   class="css-153g748-InternalLink"
@@ -9129,7 +9129,7 @@ in order to enable/disable the permission.
     class="css-16qd3rn-APISectionTypes"
   >
     <h3
-      class="css-6kh5nb-H3"
+      class="css-m417je-H3"
       data-heading="true"
     >
       <div
@@ -9147,7 +9147,7 @@ in order to enable/disable the permission.
             class="css-6n7j50"
           >
             <code
-              class="inline css-16lpqq8-InlineCode"
+              class="inline css-10jm9cu-InlineCode"
             >
               BarCodePoint
             </code>
@@ -9184,7 +9184,7 @@ in order to enable/disable the permission.
       </div>
     </h3>
     <p
-      class="css-1bjvyhe-P"
+      class="css-gvfsz4-P"
       data-text="true"
     >
       Those coordinates are represented in the coordinate space of the barcode source (e.g. when you
@@ -9227,7 +9227,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 x
               </strong>
@@ -9236,7 +9236,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 number
               </code>
@@ -9247,7 +9247,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               <span>
                 The 
                 <code
-                  class="inline css-16lpqq8-InlineCode"
+                  class="inline css-10jm9cu-InlineCode"
                 >
                   x
                 </code>
@@ -9262,7 +9262,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 y
               </strong>
@@ -9271,7 +9271,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 number
               </code>
@@ -9282,7 +9282,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               <span>
                 The 
                 <code
-                  class="inline css-16lpqq8-InlineCode"
+                  class="inline css-10jm9cu-InlineCode"
                 >
                   y
                 </code>
@@ -9298,7 +9298,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
     class="css-16qd3rn-APISectionTypes"
   >
     <h3
-      class="css-6kh5nb-H3"
+      class="css-m417je-H3"
       data-heading="true"
     >
       <div
@@ -9316,7 +9316,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
             class="css-6n7j50"
           >
             <code
-              class="inline css-16lpqq8-InlineCode"
+              class="inline css-10jm9cu-InlineCode"
             >
               BarCodeScannedCallback
               ()
@@ -9391,7 +9391,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
                 class="css-t44xva-Cell"
               >
                 <strong
-                  class="css-1k788ud-B"
+                  class="css-cyicbq-B"
                 >
                   params
                 </strong>
@@ -9400,7 +9400,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
                 class="css-t44xva-Cell"
               >
                 <code
-                  class="inline css-16lpqq8-InlineCode"
+                  class="inline css-10jm9cu-InlineCode"
                 >
                   <a
                     class="css-153g748-InternalLink"
@@ -9425,7 +9425,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
     class="css-16qd3rn-APISectionTypes"
   >
     <h3
-      class="css-6kh5nb-H3"
+      class="css-m417je-H3"
       data-heading="true"
     >
       <div
@@ -9443,7 +9443,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
             class="css-6n7j50"
           >
             <code
-              class="inline css-16lpqq8-InlineCode"
+              class="inline css-10jm9cu-InlineCode"
             >
               BarCodeScannerResult
             </code>
@@ -9480,7 +9480,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
       </div>
     </h3>
     <blockquote
-      class="css-1yla49y-Quote"
+      class="css-y2d7cg-Quote"
       data-text="true"
     >
       <div
@@ -9507,31 +9507,31 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
         
 
         <strong
-          class="css-1k788ud-B"
+          class="css-cyicbq-B"
         >
           Note:
         </strong>
          
         <code
-          class="inline css-16lpqq8-InlineCode"
+          class="inline css-10jm9cu-InlineCode"
         >
           bounds
         </code>
          and 
         <code
-          class="inline css-16lpqq8-InlineCode"
+          class="inline css-10jm9cu-InlineCode"
         >
           cornerPoints
         </code>
          are not always available. On iOS, for 
         <code
-          class="inline css-16lpqq8-InlineCode"
+          class="inline css-10jm9cu-InlineCode"
         >
           code39
         </code>
          and 
         <code
-          class="inline css-16lpqq8-InlineCode"
+          class="inline css-10jm9cu-InlineCode"
         >
           pdf417
         </code>
@@ -9579,7 +9579,7 @@ For some types, they will represent the area used by the scanner.
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 bounds
               </strong>
@@ -9594,7 +9594,7 @@ For some types, they will represent the area used by the scanner.
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 <a
                   class="css-153g748-InternalLink"
@@ -9626,7 +9626,7 @@ For some types, they will represent the area used by the scanner.
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 cornerPoints
               </strong>
@@ -9641,7 +9641,7 @@ For some types, they will represent the area used by the scanner.
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 <a
                   class="css-153g748-InternalLink"
@@ -9667,7 +9667,7 @@ For some types, they will represent the area used by the scanner.
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 data
               </strong>
@@ -9676,7 +9676,7 @@ For some types, they will represent the area used by the scanner.
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 string
               </code>
@@ -9696,7 +9696,7 @@ For some types, they will represent the area used by the scanner.
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 type
               </strong>
@@ -9705,7 +9705,7 @@ For some types, they will represent the area used by the scanner.
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 string
               </code>
@@ -9726,7 +9726,7 @@ For some types, they will represent the area used by the scanner.
     class="css-16qd3rn-APISectionTypes"
   >
     <h3
-      class="css-6kh5nb-H3"
+      class="css-m417je-H3"
       data-heading="true"
     >
       <div
@@ -9744,7 +9744,7 @@ For some types, they will represent the area used by the scanner.
             class="css-6n7j50"
           >
             <code
-              class="inline css-16lpqq8-InlineCode"
+              class="inline css-10jm9cu-InlineCode"
             >
               BarCodeSize
             </code>
@@ -9817,7 +9817,7 @@ For some types, they will represent the area used by the scanner.
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 height
               </strong>
@@ -9826,7 +9826,7 @@ For some types, they will represent the area used by the scanner.
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 number
               </code>
@@ -9846,7 +9846,7 @@ For some types, they will represent the area used by the scanner.
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 width
               </strong>
@@ -9855,7 +9855,7 @@ For some types, they will represent the area used by the scanner.
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 number
               </code>
@@ -9876,7 +9876,7 @@ For some types, they will represent the area used by the scanner.
     class="css-16qd3rn-APISectionTypes"
   >
     <h3
-      class="css-6kh5nb-H3"
+      class="css-m417je-H3"
       data-heading="true"
     >
       <div
@@ -9894,7 +9894,7 @@ For some types, they will represent the area used by the scanner.
             class="css-6n7j50"
           >
             <code
-              class="inline css-16lpqq8-InlineCode"
+              class="inline css-10jm9cu-InlineCode"
             >
               PermissionHookOptions
             </code>
@@ -9931,14 +9931,14 @@ For some types, they will represent the area used by the scanner.
       </div>
     </h3>
     <p
-      class="css-1bjvyhe-P"
+      class="css-gvfsz4-P"
       data-text="true"
     >
       Acceptable values are:
        
       <span>
         <code
-          class="inline css-16lpqq8-InlineCode"
+          class="inline css-10jm9cu-InlineCode"
         >
           PermissionHookBehavior
         </code>
@@ -9946,7 +9946,7 @@ For some types, they will represent the area used by the scanner.
       </span>
       <span>
         <code
-          class="inline css-16lpqq8-InlineCode"
+          class="inline css-10jm9cu-InlineCode"
         >
           Options
         </code>
@@ -9955,7 +9955,7 @@ For some types, they will represent the area used by the scanner.
     </p>
   </div>
   <h2
-    class="css-1azb2g5-H2"
+    class="css-wpfbxc-H2"
     data-heading="true"
   >
     <div
@@ -10009,7 +10009,7 @@ For some types, they will represent the area used by the scanner.
     class="css-eskewv-APISectionEnums"
   >
     <h3
-      class="css-6kh5nb-H3"
+      class="css-m417je-H3"
       data-heading="true"
     >
       <div
@@ -10027,7 +10027,7 @@ For some types, they will represent the area used by the scanner.
             class="css-6n7j50"
           >
             <code
-              class="inline css-16lpqq8-InlineCode"
+              class="inline css-10jm9cu-InlineCode"
             >
               PermissionStatus
             </code>
@@ -10070,7 +10070,7 @@ For some types, they will represent the area used by the scanner.
         class="css-m07iiw-APISectionEnums"
       >
         <h4
-          class="  css-crowgh-H4"
+          class="  css-uucypz-H4"
           data-components-heading="true"
           data-heading="true"
         >
@@ -10089,7 +10089,7 @@ For some types, they will represent the area used by the scanner.
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-16lpqq8-InlineCode"
+                  class="inline css-10jm9cu-InlineCode"
                 >
                   DENIED
                 </code>
@@ -10127,7 +10127,7 @@ For some types, they will represent the area used by the scanner.
         </h4>
       </div>
       <code
-        class="inline css-t7whmz-APISectionEnums"
+        class="inline css-bs4uzw-APISectionEnums"
       >
         PermissionStatus
         .
@@ -10135,7 +10135,7 @@ For some types, they will represent the area used by the scanner.
          ＝ "denied"
       </code>
       <p
-        class="css-1bjvyhe-P"
+        class="css-gvfsz4-P"
         data-text="true"
       >
         User has denied the permission.
@@ -10148,7 +10148,7 @@ For some types, they will represent the area used by the scanner.
         class="css-m07iiw-APISectionEnums"
       >
         <h4
-          class="  css-crowgh-H4"
+          class="  css-uucypz-H4"
           data-components-heading="true"
           data-heading="true"
         >
@@ -10167,7 +10167,7 @@ For some types, they will represent the area used by the scanner.
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-16lpqq8-InlineCode"
+                  class="inline css-10jm9cu-InlineCode"
                 >
                   GRANTED
                 </code>
@@ -10205,7 +10205,7 @@ For some types, they will represent the area used by the scanner.
         </h4>
       </div>
       <code
-        class="inline css-t7whmz-APISectionEnums"
+        class="inline css-bs4uzw-APISectionEnums"
       >
         PermissionStatus
         .
@@ -10213,7 +10213,7 @@ For some types, they will represent the area used by the scanner.
          ＝ "granted"
       </code>
       <p
-        class="css-1bjvyhe-P"
+        class="css-gvfsz4-P"
         data-text="true"
       >
         User has granted the permission.
@@ -10226,7 +10226,7 @@ For some types, they will represent the area used by the scanner.
         class="css-m07iiw-APISectionEnums"
       >
         <h4
-          class="  css-crowgh-H4"
+          class="  css-uucypz-H4"
           data-components-heading="true"
           data-heading="true"
         >
@@ -10245,7 +10245,7 @@ For some types, they will represent the area used by the scanner.
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-16lpqq8-InlineCode"
+                  class="inline css-10jm9cu-InlineCode"
                 >
                   UNDETERMINED
                 </code>
@@ -10283,7 +10283,7 @@ For some types, they will represent the area used by the scanner.
         </h4>
       </div>
       <code
-        class="inline css-t7whmz-APISectionEnums"
+        class="inline css-bs4uzw-APISectionEnums"
       >
         PermissionStatus
         .
@@ -10291,7 +10291,7 @@ For some types, they will represent the area used by the scanner.
          ＝ "undetermined"
       </code>
       <p
-        class="css-1bjvyhe-P"
+        class="css-gvfsz4-P"
         data-text="true"
       >
         User hasn't granted or denied the permission yet.
@@ -10304,7 +10304,7 @@ For some types, they will represent the area used by the scanner.
 exports[`APISection expo-pedometer 1`] = `
 <div>
   <h2
-    class="css-1azb2g5-H2"
+    class="css-wpfbxc-H2"
     data-heading="true"
   >
     <div
@@ -10358,7 +10358,7 @@ exports[`APISection expo-pedometer 1`] = `
     class="css-eu2n2e-APISectionMethods"
   >
     <h3
-      class="css-6kh5nb-H3"
+      class="css-m417je-H3"
       data-heading="true"
     >
       <div
@@ -10376,7 +10376,7 @@ exports[`APISection expo-pedometer 1`] = `
             class="css-6n7j50"
           >
             <code
-              class="inline css-1lmmqpm-InlineCode"
+              class="inline css-tu4dab-InlineCode"
             >
               getPermissionsAsync()
             </code>
@@ -10413,10 +10413,10 @@ exports[`APISection expo-pedometer 1`] = `
       </div>
     </h3>
     <div
-      class="css-1remai5-APISectionMethods"
+      class="css-1dfa5yf-APISectionMethods"
     >
       <h4
-        class="  css-crowgh-H4"
+        class="  css-uucypz-H4"
         data-components-heading="true"
         data-heading="true"
       >
@@ -10469,7 +10469,7 @@ exports[`APISection expo-pedometer 1`] = `
       </h4>
     </div>
     <ul
-      class="css-11d2x0b-UL"
+      class="css-ozzgx3-UL"
       data-text="true"
     >
       <li
@@ -10494,7 +10494,7 @@ exports[`APISection expo-pedometer 1`] = `
           />
         </svg>
         <code
-          class="inline css-16lpqq8-InlineCode"
+          class="inline css-10jm9cu-InlineCode"
         >
           <a
             class="css-ccg2mn-ExternalLink"
@@ -10521,7 +10521,7 @@ exports[`APISection expo-pedometer 1`] = `
     class="css-eu2n2e-APISectionMethods"
   >
     <h3
-      class="css-6kh5nb-H3"
+      class="css-m417je-H3"
       data-heading="true"
     >
       <div
@@ -10539,7 +10539,7 @@ exports[`APISection expo-pedometer 1`] = `
             class="css-6n7j50"
           >
             <code
-              class="inline css-1lmmqpm-InlineCode"
+              class="inline css-tu4dab-InlineCode"
             >
               getStepCountAsync(start, end)
             </code>
@@ -10612,7 +10612,7 @@ exports[`APISection expo-pedometer 1`] = `
               class="css-t44xva-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 start
               </strong>
@@ -10621,7 +10621,7 @@ exports[`APISection expo-pedometer 1`] = `
               class="css-t44xva-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 <a
                   class="css-ccg2mn-ExternalLink"
@@ -10647,7 +10647,7 @@ exports[`APISection expo-pedometer 1`] = `
               class="css-t44xva-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 end
               </strong>
@@ -10656,7 +10656,7 @@ exports[`APISection expo-pedometer 1`] = `
               class="css-t44xva-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 <a
                   class="css-ccg2mn-ExternalLink"
@@ -10679,16 +10679,16 @@ exports[`APISection expo-pedometer 1`] = `
       </table>
     </div>
     <p
-      class="css-1bjvyhe-P"
+      class="css-gvfsz4-P"
       data-text="true"
     >
       Get the step count between two dates.
     </p>
     <div
-      class="css-1remai5-APISectionMethods"
+      class="css-1dfa5yf-APISectionMethods"
     >
       <h4
-        class="  css-crowgh-H4"
+        class="  css-uucypz-H4"
         data-components-heading="true"
         data-heading="true"
       >
@@ -10741,7 +10741,7 @@ exports[`APISection expo-pedometer 1`] = `
       </h4>
     </div>
     <ul
-      class="css-11d2x0b-UL"
+      class="css-ozzgx3-UL"
       data-text="true"
     >
       <li
@@ -10766,7 +10766,7 @@ exports[`APISection expo-pedometer 1`] = `
           />
         </svg>
         <code
-          class="inline css-16lpqq8-InlineCode"
+          class="inline css-10jm9cu-InlineCode"
         >
           <a
             class="css-ccg2mn-ExternalLink"
@@ -10789,7 +10789,7 @@ exports[`APISection expo-pedometer 1`] = `
       </li>
     </ul>
     <p
-      class="css-1bjvyhe-P"
+      class="css-gvfsz4-P"
       data-text="true"
     >
       Returns a promise that fulfills with a 
@@ -10798,7 +10798,7 @@ exports[`APISection expo-pedometer 1`] = `
         href="/#pedometerresult"
       >
         <code
-          class="inline css-16lpqq8-InlineCode"
+          class="inline css-10jm9cu-InlineCode"
         >
           PedometerResult
         </code>
@@ -10808,7 +10808,7 @@ exports[`APISection expo-pedometer 1`] = `
     
 
     <p
-      class="css-1bjvyhe-P"
+      class="css-gvfsz4-P"
       data-text="true"
     >
       As 
@@ -10824,7 +10824,7 @@ exports[`APISection expo-pedometer 1`] = `
     
 
     <blockquote
-      class="css-1yla49y-Quote"
+      class="css-y2d7cg-Quote"
       data-text="true"
     >
       <div
@@ -10861,7 +10861,7 @@ a start date that is more than seven days in the past returns only the available
     class="css-eu2n2e-APISectionMethods"
   >
     <h3
-      class="css-6kh5nb-H3"
+      class="css-m417je-H3"
       data-heading="true"
     >
       <div
@@ -10879,7 +10879,7 @@ a start date that is more than seven days in the past returns only the available
             class="css-6n7j50"
           >
             <code
-              class="inline css-1lmmqpm-InlineCode"
+              class="inline css-tu4dab-InlineCode"
             >
               isAvailableAsync()
             </code>
@@ -10916,16 +10916,16 @@ a start date that is more than seven days in the past returns only the available
       </div>
     </h3>
     <p
-      class="css-1bjvyhe-P"
+      class="css-gvfsz4-P"
       data-text="true"
     >
       Returns whether the pedometer is enabled on the device.
     </p>
     <div
-      class="css-1remai5-APISectionMethods"
+      class="css-1dfa5yf-APISectionMethods"
     >
       <h4
-        class="  css-crowgh-H4"
+        class="  css-uucypz-H4"
         data-components-heading="true"
         data-heading="true"
       >
@@ -10978,7 +10978,7 @@ a start date that is more than seven days in the past returns only the available
       </h4>
     </div>
     <ul
-      class="css-11d2x0b-UL"
+      class="css-ozzgx3-UL"
       data-text="true"
     >
       <li
@@ -11003,7 +11003,7 @@ a start date that is more than seven days in the past returns only the available
           />
         </svg>
         <code
-          class="inline css-16lpqq8-InlineCode"
+          class="inline css-10jm9cu-InlineCode"
         >
           <a
             class="css-ccg2mn-ExternalLink"
@@ -11021,12 +11021,12 @@ a start date that is more than seven days in the past returns only the available
       </li>
     </ul>
     <p
-      class="css-1bjvyhe-P"
+      class="css-gvfsz4-P"
       data-text="true"
     >
       Returns a promise that fulfills with a 
       <code
-        class="inline css-16lpqq8-InlineCode"
+        class="inline css-10jm9cu-InlineCode"
       >
         boolean
       </code>
@@ -11038,7 +11038,7 @@ available on this device.
     class="css-eu2n2e-APISectionMethods"
   >
     <h3
-      class="css-6kh5nb-H3"
+      class="css-m417je-H3"
       data-heading="true"
     >
       <div
@@ -11056,7 +11056,7 @@ available on this device.
             class="css-6n7j50"
           >
             <code
-              class="inline css-1lmmqpm-InlineCode"
+              class="inline css-tu4dab-InlineCode"
             >
               requestPermissionsAsync()
             </code>
@@ -11093,10 +11093,10 @@ available on this device.
       </div>
     </h3>
     <div
-      class="css-1remai5-APISectionMethods"
+      class="css-1dfa5yf-APISectionMethods"
     >
       <h4
-        class="  css-crowgh-H4"
+        class="  css-uucypz-H4"
         data-components-heading="true"
         data-heading="true"
       >
@@ -11149,7 +11149,7 @@ available on this device.
       </h4>
     </div>
     <ul
-      class="css-11d2x0b-UL"
+      class="css-ozzgx3-UL"
       data-text="true"
     >
       <li
@@ -11174,7 +11174,7 @@ available on this device.
           />
         </svg>
         <code
-          class="inline css-16lpqq8-InlineCode"
+          class="inline css-10jm9cu-InlineCode"
         >
           <a
             class="css-ccg2mn-ExternalLink"
@@ -11201,7 +11201,7 @@ available on this device.
     class="css-eu2n2e-APISectionMethods"
   >
     <h3
-      class="css-6kh5nb-H3"
+      class="css-m417je-H3"
       data-heading="true"
     >
       <div
@@ -11219,7 +11219,7 @@ available on this device.
             class="css-6n7j50"
           >
             <code
-              class="inline css-1lmmqpm-InlineCode"
+              class="inline css-tu4dab-InlineCode"
             >
               watchStepCount(callback)
             </code>
@@ -11292,7 +11292,7 @@ available on this device.
               class="css-t44xva-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 callback
               </strong>
@@ -11301,7 +11301,7 @@ available on this device.
               class="css-t44xva-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 <a
                   class="css-153g748-InternalLink"
@@ -11322,7 +11322,7 @@ provided with a single argument that is
                   href="/#pedometerresult"
                 >
                   <code
-                    class="inline css-16lpqq8-InlineCode"
+                    class="inline css-10jm9cu-InlineCode"
                   >
                     PedometerResult
                   </code>
@@ -11335,16 +11335,16 @@ provided with a single argument that is
       </table>
     </div>
     <p
-      class="css-1bjvyhe-P"
+      class="css-gvfsz4-P"
       data-text="true"
     >
       Subscribe to pedometer updates.
     </p>
     <div
-      class="css-1remai5-APISectionMethods"
+      class="css-1dfa5yf-APISectionMethods"
     >
       <h4
-        class="  css-crowgh-H4"
+        class="  css-uucypz-H4"
         data-components-heading="true"
         data-heading="true"
       >
@@ -11397,7 +11397,7 @@ provided with a single argument that is
       </h4>
     </div>
     <ul
-      class="css-11d2x0b-UL"
+      class="css-ozzgx3-UL"
       data-text="true"
     >
       <li
@@ -11422,7 +11422,7 @@ provided with a single argument that is
           />
         </svg>
         <code
-          class="inline css-16lpqq8-InlineCode"
+          class="inline css-10jm9cu-InlineCode"
         >
           <a
             class="css-153g748-InternalLink"
@@ -11434,7 +11434,7 @@ provided with a single argument that is
       </li>
     </ul>
     <p
-      class="css-1bjvyhe-P"
+      class="css-gvfsz4-P"
       data-text="true"
     >
       Returns a 
@@ -11443,7 +11443,7 @@ provided with a single argument that is
         href="/#subscription"
       >
         <code
-          class="inline css-16lpqq8-InlineCode"
+          class="inline css-10jm9cu-InlineCode"
         >
           Subscription
         </code>
@@ -11451,7 +11451,7 @@ provided with a single argument that is
        that enables you to call
 
       <code
-        class="inline css-16lpqq8-InlineCode"
+        class="inline css-10jm9cu-InlineCode"
       >
         remove()
       </code>
@@ -11459,7 +11459,7 @@ provided with a single argument that is
     </p>
   </div>
   <h2
-    class="css-1azb2g5-H2"
+    class="css-wpfbxc-H2"
     data-heading="true"
   >
     <div
@@ -11513,7 +11513,7 @@ provided with a single argument that is
     class="css-dox4n0-APISectionInterfaces"
   >
     <h3
-      class="css-6kh5nb-H3"
+      class="css-m417je-H3"
       data-heading="true"
     >
       <div
@@ -11531,7 +11531,7 @@ provided with a single argument that is
             class="css-6n7j50"
           >
             <code
-              class="inline css-16lpqq8-InlineCode"
+              class="inline css-10jm9cu-InlineCode"
             >
               PermissionResponse
             </code>
@@ -11568,10 +11568,10 @@ provided with a single argument that is
       </div>
     </h3>
     <div
-      class="css-1smmlx-APISectionInterfaces"
+      class="css-sr97iy-APISectionInterfaces"
     >
       <h4
-        class="  css-crowgh-H4"
+        class="  css-uucypz-H4"
         data-components-heading="true"
         data-heading="true"
       >
@@ -11661,7 +11661,7 @@ provided with a single argument that is
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 canAskAgain
               </strong>
@@ -11670,7 +11670,7 @@ provided with a single argument that is
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 boolean
               </code>
@@ -11688,7 +11688,7 @@ provided with a single argument that is
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 expires
               </strong>
@@ -11697,7 +11697,7 @@ provided with a single argument that is
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 <a
                   class="css-153g748-InternalLink"
@@ -11720,7 +11720,7 @@ provided with a single argument that is
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 granted
               </strong>
@@ -11729,7 +11729,7 @@ provided with a single argument that is
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 boolean
               </code>
@@ -11747,7 +11747,7 @@ provided with a single argument that is
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 status
               </strong>
@@ -11756,7 +11756,7 @@ provided with a single argument that is
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 <a
                   class="css-153g748-InternalLink"
@@ -11777,7 +11777,7 @@ provided with a single argument that is
     </div>
   </div>
   <h2
-    class="css-1azb2g5-H2"
+    class="css-wpfbxc-H2"
     data-heading="true"
   >
     <div
@@ -11831,7 +11831,7 @@ provided with a single argument that is
     class="css-16qd3rn-APISectionTypes"
   >
     <h3
-      class="css-6kh5nb-H3"
+      class="css-m417je-H3"
       data-heading="true"
     >
       <div
@@ -11849,7 +11849,7 @@ provided with a single argument that is
             class="css-6n7j50"
           >
             <code
-              class="inline css-16lpqq8-InlineCode"
+              class="inline css-10jm9cu-InlineCode"
             >
               PedometerResult
             </code>
@@ -11922,7 +11922,7 @@ provided with a single argument that is
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 steps
               </strong>
@@ -11931,7 +11931,7 @@ provided with a single argument that is
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 number
               </code>
@@ -11952,7 +11952,7 @@ provided with a single argument that is
     class="css-16qd3rn-APISectionTypes"
   >
     <h3
-      class="css-6kh5nb-H3"
+      class="css-m417je-H3"
       data-heading="true"
     >
       <div
@@ -11970,7 +11970,7 @@ provided with a single argument that is
             class="css-6n7j50"
           >
             <code
-              class="inline css-16lpqq8-InlineCode"
+              class="inline css-10jm9cu-InlineCode"
             >
               PedometerUpdateCallback
               ()
@@ -12045,7 +12045,7 @@ provided with a single argument that is
                 class="css-t44xva-Cell"
               >
                 <strong
-                  class="css-1k788ud-B"
+                  class="css-cyicbq-B"
                 >
                   result
                 </strong>
@@ -12054,7 +12054,7 @@ provided with a single argument that is
                 class="css-t44xva-Cell"
               >
                 <code
-                  class="inline css-16lpqq8-InlineCode"
+                  class="inline css-10jm9cu-InlineCode"
                 >
                   <a
                     class="css-153g748-InternalLink"
@@ -12079,7 +12079,7 @@ provided with a single argument that is
     class="css-16qd3rn-APISectionTypes"
   >
     <h3
-      class="css-6kh5nb-H3"
+      class="css-m417je-H3"
       data-heading="true"
     >
       <div
@@ -12097,7 +12097,7 @@ provided with a single argument that is
             class="css-6n7j50"
           >
             <code
-              class="inline css-16lpqq8-InlineCode"
+              class="inline css-10jm9cu-InlineCode"
             >
               PermissionExpiration
             </code>
@@ -12134,14 +12134,14 @@ provided with a single argument that is
       </div>
     </h3>
     <p
-      class="css-1bjvyhe-P"
+      class="css-gvfsz4-P"
       data-text="true"
     >
       Acceptable values are:
        
       <span>
         <code
-          class="inline css-16lpqq8-InlineCode"
+          class="inline css-10jm9cu-InlineCode"
         >
           'never'
         </code>
@@ -12149,7 +12149,7 @@ provided with a single argument that is
       </span>
       <span>
         <code
-          class="inline css-16lpqq8-InlineCode"
+          class="inline css-10jm9cu-InlineCode"
         >
           number
         </code>
@@ -12161,7 +12161,7 @@ provided with a single argument that is
     class="css-16qd3rn-APISectionTypes"
   >
     <h3
-      class="css-6kh5nb-H3"
+      class="css-m417je-H3"
       data-heading="true"
     >
       <div
@@ -12179,7 +12179,7 @@ provided with a single argument that is
             class="css-6n7j50"
           >
             <code
-              class="inline css-16lpqq8-InlineCode"
+              class="inline css-10jm9cu-InlineCode"
             >
               Subscription
             </code>
@@ -12252,7 +12252,7 @@ provided with a single argument that is
               class="css-1uzovlc-Cell"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 remove
               </strong>
@@ -12261,7 +12261,7 @@ provided with a single argument that is
               class="css-1uzovlc-Cell"
             >
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 (
                 ) =&gt;
@@ -12282,7 +12282,7 @@ provided with a single argument that is
     </div>
   </div>
   <h2
-    class="css-1azb2g5-H2"
+    class="css-wpfbxc-H2"
     data-heading="true"
   >
     <div
@@ -12336,7 +12336,7 @@ provided with a single argument that is
     class="css-eskewv-APISectionEnums"
   >
     <h3
-      class="css-6kh5nb-H3"
+      class="css-m417je-H3"
       data-heading="true"
     >
       <div
@@ -12354,7 +12354,7 @@ provided with a single argument that is
             class="css-6n7j50"
           >
             <code
-              class="inline css-16lpqq8-InlineCode"
+              class="inline css-10jm9cu-InlineCode"
             >
               PermissionStatus
             </code>
@@ -12397,7 +12397,7 @@ provided with a single argument that is
         class="css-m07iiw-APISectionEnums"
       >
         <h4
-          class="  css-crowgh-H4"
+          class="  css-uucypz-H4"
           data-components-heading="true"
           data-heading="true"
         >
@@ -12416,7 +12416,7 @@ provided with a single argument that is
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-16lpqq8-InlineCode"
+                  class="inline css-10jm9cu-InlineCode"
                 >
                   DENIED
                 </code>
@@ -12454,7 +12454,7 @@ provided with a single argument that is
         </h4>
       </div>
       <code
-        class="inline css-t7whmz-APISectionEnums"
+        class="inline css-bs4uzw-APISectionEnums"
       >
         PermissionStatus
         .
@@ -12469,7 +12469,7 @@ provided with a single argument that is
         class="css-m07iiw-APISectionEnums"
       >
         <h4
-          class="  css-crowgh-H4"
+          class="  css-uucypz-H4"
           data-components-heading="true"
           data-heading="true"
         >
@@ -12488,7 +12488,7 @@ provided with a single argument that is
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-16lpqq8-InlineCode"
+                  class="inline css-10jm9cu-InlineCode"
                 >
                   GRANTED
                 </code>
@@ -12526,7 +12526,7 @@ provided with a single argument that is
         </h4>
       </div>
       <code
-        class="inline css-t7whmz-APISectionEnums"
+        class="inline css-bs4uzw-APISectionEnums"
       >
         PermissionStatus
         .
@@ -12541,7 +12541,7 @@ provided with a single argument that is
         class="css-m07iiw-APISectionEnums"
       >
         <h4
-          class="  css-crowgh-H4"
+          class="  css-uucypz-H4"
           data-components-heading="true"
           data-heading="true"
         >
@@ -12560,7 +12560,7 @@ provided with a single argument that is
                 class="css-6n7j50"
               >
                 <code
-                  class="inline css-16lpqq8-InlineCode"
+                  class="inline css-10jm9cu-InlineCode"
                 >
                   UNDETERMINED
                 </code>
@@ -12598,7 +12598,7 @@ provided with a single argument that is
         </h4>
       </div>
       <code
-        class="inline css-t7whmz-APISectionEnums"
+        class="inline css-bs4uzw-APISectionEnums"
       >
         PermissionStatus
         .
@@ -12613,7 +12613,7 @@ provided with a single argument that is
 exports[`APISection no data 1`] = `
 <div>
   <p
-    class="css-1bjvyhe-P"
+    class="css-gvfsz4-P"
     data-text="true"
   >
     No API data file found, sorry!

--- a/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
@@ -38,7 +38,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               style="margin-left: 0px; display: block; list-style-type: circle; overflow-x: visible;"
             >
               <div
-                class=" css-izsx1d-PDIV"
+                class=" css-ty5o0-PDIV"
                 data-text="true"
               >
                 <div
@@ -56,7 +56,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                       class="css-6n7j50"
                     >
                       <code
-                        class="inline css-16lpqq8-InlineCode"
+                        class="inline css-10jm9cu-InlineCode"
                       >
                         name
                       </code>
@@ -98,11 +98,11 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="css-t44xva-Cell"
           >
             <div
-              class=" css-izsx1d-PDIV"
+              class=" css-ty5o0-PDIV"
               data-text="true"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 (string)
               </strong>
@@ -164,7 +164,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               style="margin-left: 0px; display: block; list-style-type: circle; overflow-x: visible;"
             >
               <div
-                class=" css-izsx1d-PDIV"
+                class=" css-ty5o0-PDIV"
                 data-text="true"
               >
                 <div
@@ -182,7 +182,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                       class="css-6n7j50"
                     >
                       <code
-                        class="inline css-16lpqq8-InlineCode"
+                        class="inline css-10jm9cu-InlineCode"
                       >
                         androidNavigationBar
                       </code>
@@ -224,11 +224,11 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="css-t44xva-Cell"
           >
             <div
-              class=" css-izsx1d-PDIV"
+              class=" css-ty5o0-PDIV"
               data-text="true"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 (object)
               </strong>
@@ -333,7 +333,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               style="margin-left: 32px; display: list-item; list-style-type: default; overflow-x: visible;"
             >
               <div
-                class=" css-izsx1d-PDIV"
+                class=" css-ty5o0-PDIV"
                 data-text="true"
               >
                 <div
@@ -351,7 +351,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                       class="css-6n7j50"
                     >
                       <code
-                        class="inline css-16lpqq8-InlineCode"
+                        class="inline css-10jm9cu-InlineCode"
                       >
                         visible
                       </code>
@@ -393,11 +393,11 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="css-t44xva-Cell"
           >
             <div
-              class=" css-izsx1d-PDIV"
+              class=" css-ty5o0-PDIV"
               data-text="true"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 (enum)
               </strong>
@@ -459,7 +459,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               style="margin-left: 64px; display: list-item; list-style-type: circle; overflow-x: visible;"
             >
               <div
-                class=" css-izsx1d-PDIV"
+                class=" css-ty5o0-PDIV"
                 data-text="true"
               >
                 <div
@@ -477,7 +477,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                       class="css-6n7j50"
                     >
                       <code
-                        class="inline css-16lpqq8-InlineCode"
+                        class="inline css-10jm9cu-InlineCode"
                       >
                         always
                       </code>
@@ -519,11 +519,11 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="css-t44xva-Cell"
           >
             <div
-              class=" css-izsx1d-PDIV"
+              class=" css-ty5o0-PDIV"
               data-text="true"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 (boolean)
               </strong>
@@ -542,7 +542,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               style="margin-left: 32px; display: list-item; list-style-type: default; overflow-x: visible;"
             >
               <div
-                class=" css-izsx1d-PDIV"
+                class=" css-ty5o0-PDIV"
                 data-text="true"
               >
                 <div
@@ -560,7 +560,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                       class="css-6n7j50"
                     >
                       <code
-                        class="inline css-16lpqq8-InlineCode"
+                        class="inline css-10jm9cu-InlineCode"
                       >
                         backgroundColor
                       </code>
@@ -602,23 +602,23 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="css-t44xva-Cell"
           >
             <div
-              class=" css-izsx1d-PDIV"
+              class=" css-ty5o0-PDIV"
               data-text="true"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 (string)
               </strong>
                - Specifies the background color of the navigation bar. 
             </div>
             <div
-              class=" css-izsx1d-PDIV"
+              class=" css-ty5o0-PDIV"
               data-text="true"
             >
               6 character long hex color string, eg: 
               <code
-                class="inline css-16lpqq8-InlineCode"
+                class="inline css-10jm9cu-InlineCode"
               >
                 '#000000'
               </code>
@@ -636,7 +636,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               style="margin-left: 0px; display: block; list-style-type: circle; overflow-x: visible;"
             >
               <div
-                class=" css-izsx1d-PDIV"
+                class=" css-ty5o0-PDIV"
                 data-text="true"
               >
                 <div
@@ -654,7 +654,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                       class="css-6n7j50"
                     >
                       <code
-                        class="inline css-16lpqq8-InlineCode"
+                        class="inline css-10jm9cu-InlineCode"
                       >
                         intentFilters
                       </code>
@@ -696,11 +696,11 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="css-t44xva-Cell"
           >
             <div
-              class=" css-izsx1d-PDIV"
+              class=" css-ty5o0-PDIV"
               data-text="true"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 (array)
               </strong>
@@ -750,7 +750,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               </div>
             </div>
             <blockquote
-              class="css-1yla49y-Quote"
+              class="css-y2d7cg-Quote"
               data-text="true"
             >
               <div
@@ -775,7 +775,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               </div>
               <div>
                 <div
-                  class=" css-izsx1d-PDIV"
+                  class=" css-ty5o0-PDIV"
                   data-text="true"
                 >
                    
@@ -800,7 +800,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               style="margin-left: 32px; display: list-item; list-style-type: default; overflow-x: visible;"
             >
               <div
-                class=" css-izsx1d-PDIV"
+                class=" css-ty5o0-PDIV"
                 data-text="true"
               >
                 <div
@@ -818,7 +818,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                       class="css-6n7j50"
                     >
                       <code
-                        class="inline css-16lpqq8-InlineCode"
+                        class="inline css-10jm9cu-InlineCode"
                       >
                         autoVerify
                       </code>
@@ -860,11 +860,11 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="css-t44xva-Cell"
           >
             <div
-              class=" css-izsx1d-PDIV"
+              class=" css-ty5o0-PDIV"
               data-text="true"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 (boolean)
               </strong>
@@ -883,7 +883,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               style="margin-left: 32px; display: list-item; list-style-type: default; overflow-x: visible;"
             >
               <div
-                class=" css-izsx1d-PDIV"
+                class=" css-ty5o0-PDIV"
                 data-text="true"
               >
                 <div
@@ -901,7 +901,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                       class="css-6n7j50"
                     >
                       <code
-                        class="inline css-16lpqq8-InlineCode"
+                        class="inline css-10jm9cu-InlineCode"
                       >
                         data
                       </code>
@@ -943,11 +943,11 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="css-t44xva-Cell"
           >
             <div
-              class=" css-izsx1d-PDIV"
+              class=" css-ty5o0-PDIV"
               data-text="true"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 (array || object)
               </strong>
@@ -965,7 +965,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               style="margin-left: 64px; display: list-item; list-style-type: circle; overflow-x: visible;"
             >
               <div
-                class=" css-izsx1d-PDIV"
+                class=" css-ty5o0-PDIV"
                 data-text="true"
               >
                 <div
@@ -983,7 +983,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                       class="css-6n7j50"
                     >
                       <code
-                        class="inline css-16lpqq8-InlineCode"
+                        class="inline css-10jm9cu-InlineCode"
                       >
                         host
                       </code>
@@ -1025,11 +1025,11 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="css-t44xva-Cell"
           >
             <div
-              class=" css-izsx1d-PDIV"
+              class=" css-ty5o0-PDIV"
               data-text="true"
             >
               <strong
-                class="css-1k788ud-B"
+                class="css-cyicbq-B"
               >
                 (string)
               </strong>

--- a/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
@@ -38,7 +38,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               style="margin-left: 0px; display: block; list-style-type: circle; overflow-x: visible;"
             >
               <div
-                class=" css-ty5o0-PDIV"
+                class=" css-19f55nd-PDIV"
                 data-text="true"
               >
                 <div
@@ -56,7 +56,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                       class="css-6n7j50"
                     >
                       <code
-                        class="inline css-10jm9cu-InlineCode"
+                        class="inline css-ov7own-InlineCode"
                       >
                         name
                       </code>
@@ -98,11 +98,11 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="css-t44xva-Cell"
           >
             <div
-              class=" css-ty5o0-PDIV"
+              class=" css-19f55nd-PDIV"
               data-text="true"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 (string)
               </strong>
@@ -164,7 +164,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               style="margin-left: 0px; display: block; list-style-type: circle; overflow-x: visible;"
             >
               <div
-                class=" css-ty5o0-PDIV"
+                class=" css-19f55nd-PDIV"
                 data-text="true"
               >
                 <div
@@ -182,7 +182,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                       class="css-6n7j50"
                     >
                       <code
-                        class="inline css-10jm9cu-InlineCode"
+                        class="inline css-ov7own-InlineCode"
                       >
                         androidNavigationBar
                       </code>
@@ -224,11 +224,11 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="css-t44xva-Cell"
           >
             <div
-              class=" css-ty5o0-PDIV"
+              class=" css-19f55nd-PDIV"
               data-text="true"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 (object)
               </strong>
@@ -333,7 +333,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               style="margin-left: 32px; display: list-item; list-style-type: default; overflow-x: visible;"
             >
               <div
-                class=" css-ty5o0-PDIV"
+                class=" css-19f55nd-PDIV"
                 data-text="true"
               >
                 <div
@@ -351,7 +351,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                       class="css-6n7j50"
                     >
                       <code
-                        class="inline css-10jm9cu-InlineCode"
+                        class="inline css-ov7own-InlineCode"
                       >
                         visible
                       </code>
@@ -393,11 +393,11 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="css-t44xva-Cell"
           >
             <div
-              class=" css-ty5o0-PDIV"
+              class=" css-19f55nd-PDIV"
               data-text="true"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 (enum)
               </strong>
@@ -459,7 +459,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               style="margin-left: 64px; display: list-item; list-style-type: circle; overflow-x: visible;"
             >
               <div
-                class=" css-ty5o0-PDIV"
+                class=" css-19f55nd-PDIV"
                 data-text="true"
               >
                 <div
@@ -477,7 +477,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                       class="css-6n7j50"
                     >
                       <code
-                        class="inline css-10jm9cu-InlineCode"
+                        class="inline css-ov7own-InlineCode"
                       >
                         always
                       </code>
@@ -519,11 +519,11 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="css-t44xva-Cell"
           >
             <div
-              class=" css-ty5o0-PDIV"
+              class=" css-19f55nd-PDIV"
               data-text="true"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 (boolean)
               </strong>
@@ -542,7 +542,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               style="margin-left: 32px; display: list-item; list-style-type: default; overflow-x: visible;"
             >
               <div
-                class=" css-ty5o0-PDIV"
+                class=" css-19f55nd-PDIV"
                 data-text="true"
               >
                 <div
@@ -560,7 +560,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                       class="css-6n7j50"
                     >
                       <code
-                        class="inline css-10jm9cu-InlineCode"
+                        class="inline css-ov7own-InlineCode"
                       >
                         backgroundColor
                       </code>
@@ -602,23 +602,23 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="css-t44xva-Cell"
           >
             <div
-              class=" css-ty5o0-PDIV"
+              class=" css-19f55nd-PDIV"
               data-text="true"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 (string)
               </strong>
                - Specifies the background color of the navigation bar. 
             </div>
             <div
-              class=" css-ty5o0-PDIV"
+              class=" css-19f55nd-PDIV"
               data-text="true"
             >
               6 character long hex color string, eg: 
               <code
-                class="inline css-10jm9cu-InlineCode"
+                class="inline css-ov7own-InlineCode"
               >
                 '#000000'
               </code>
@@ -636,7 +636,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               style="margin-left: 0px; display: block; list-style-type: circle; overflow-x: visible;"
             >
               <div
-                class=" css-ty5o0-PDIV"
+                class=" css-19f55nd-PDIV"
                 data-text="true"
               >
                 <div
@@ -654,7 +654,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                       class="css-6n7j50"
                     >
                       <code
-                        class="inline css-10jm9cu-InlineCode"
+                        class="inline css-ov7own-InlineCode"
                       >
                         intentFilters
                       </code>
@@ -696,11 +696,11 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="css-t44xva-Cell"
           >
             <div
-              class=" css-ty5o0-PDIV"
+              class=" css-19f55nd-PDIV"
               data-text="true"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 (array)
               </strong>
@@ -750,7 +750,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               </div>
             </div>
             <blockquote
-              class="css-y2d7cg-Quote"
+              class="css-1nn217x-Quote"
               data-text="true"
             >
               <div
@@ -775,7 +775,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               </div>
               <div>
                 <div
-                  class=" css-ty5o0-PDIV"
+                  class=" css-19f55nd-PDIV"
                   data-text="true"
                 >
                    
@@ -800,7 +800,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               style="margin-left: 32px; display: list-item; list-style-type: default; overflow-x: visible;"
             >
               <div
-                class=" css-ty5o0-PDIV"
+                class=" css-19f55nd-PDIV"
                 data-text="true"
               >
                 <div
@@ -818,7 +818,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                       class="css-6n7j50"
                     >
                       <code
-                        class="inline css-10jm9cu-InlineCode"
+                        class="inline css-ov7own-InlineCode"
                       >
                         autoVerify
                       </code>
@@ -860,11 +860,11 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="css-t44xva-Cell"
           >
             <div
-              class=" css-ty5o0-PDIV"
+              class=" css-19f55nd-PDIV"
               data-text="true"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 (boolean)
               </strong>
@@ -883,7 +883,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               style="margin-left: 32px; display: list-item; list-style-type: default; overflow-x: visible;"
             >
               <div
-                class=" css-ty5o0-PDIV"
+                class=" css-19f55nd-PDIV"
                 data-text="true"
               >
                 <div
@@ -901,7 +901,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                       class="css-6n7j50"
                     >
                       <code
-                        class="inline css-10jm9cu-InlineCode"
+                        class="inline css-ov7own-InlineCode"
                       >
                         data
                       </code>
@@ -943,11 +943,11 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="css-t44xva-Cell"
           >
             <div
-              class=" css-ty5o0-PDIV"
+              class=" css-19f55nd-PDIV"
               data-text="true"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 (array || object)
               </strong>
@@ -965,7 +965,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               style="margin-left: 64px; display: list-item; list-style-type: circle; overflow-x: visible;"
             >
               <div
-                class=" css-ty5o0-PDIV"
+                class=" css-19f55nd-PDIV"
                 data-text="true"
               >
                 <div
@@ -983,7 +983,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                       class="css-6n7j50"
                     >
                       <code
-                        class="inline css-10jm9cu-InlineCode"
+                        class="inline css-ov7own-InlineCode"
                       >
                         host
                       </code>
@@ -1025,11 +1025,11 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="css-t44xva-Cell"
           >
             <div
-              class=" css-ty5o0-PDIV"
+              class=" css-19f55nd-PDIV"
               data-text="true"
             >
               <strong
-                class="css-cyicbq-B"
+                class="css-1qx481h-B"
               >
                 (string)
               </strong>

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -603,6 +603,7 @@ export const STYLES_NESTED_SECTION_HEADER = css({
     ...typography.fontSizes[16],
     fontFamily: typography.fontFaces.medium,
     marginBottom: 0,
+    marginTop: 0,
     color: theme.text.secondary,
   },
 });

--- a/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
+++ b/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`APISectionUtils.CommentTextBlock component basic comment 1`] = `
 <div>
   <p
-    class="css-gvfsz4-P"
+    class="css-6jxvia-P"
     data-text="true"
   >
     This is the basic comment.
@@ -23,11 +23,11 @@ exports[`APISectionUtils.CommentTextBlock component basic inline comment 1`] = `
 exports[`APISectionUtils.CommentTextBlock component comment with example 1`] = `
 <div>
   <p
-    class="css-gvfsz4-P"
+    class="css-6jxvia-P"
     data-text="true"
   >
     <strong
-      class="css-cyicbq-B"
+      class="css-1qx481h-B"
     >
       Android only.
     </strong>
@@ -38,7 +38,7 @@ exports[`APISectionUtils.CommentTextBlock component comment with example 1`] = `
       rel="noopener noreferrer"
     >
       <code
-        class="inline css-10jm9cu-InlineCode"
+        class="inline css-ov7own-InlineCode"
       >
         Install Referrer API
       </code>
@@ -62,7 +62,7 @@ from the Google Play Store. In practice, the referrer URL may not be a complete,
       data-text="true"
     >
       <code
-        class="css-tqrxwq"
+        class="css-3rj4bb"
       >
         <span
           class="token keyword"

--- a/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
+++ b/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`APISectionUtils.CommentTextBlock component basic comment 1`] = `
 <div>
   <p
-    class="css-1bjvyhe-P"
+    class="css-gvfsz4-P"
     data-text="true"
   >
     This is the basic comment.
@@ -23,11 +23,11 @@ exports[`APISectionUtils.CommentTextBlock component basic inline comment 1`] = `
 exports[`APISectionUtils.CommentTextBlock component comment with example 1`] = `
 <div>
   <p
-    class="css-1bjvyhe-P"
+    class="css-gvfsz4-P"
     data-text="true"
   >
     <strong
-      class="css-1k788ud-B"
+      class="css-cyicbq-B"
     >
       Android only.
     </strong>
@@ -38,7 +38,7 @@ exports[`APISectionUtils.CommentTextBlock component comment with example 1`] = `
       rel="noopener noreferrer"
     >
       <code
-        class="inline css-16lpqq8-InlineCode"
+        class="inline css-10jm9cu-InlineCode"
       >
         Install Referrer API
       </code>
@@ -47,10 +47,10 @@ exports[`APISectionUtils.CommentTextBlock component comment with example 1`] = `
 from the Google Play Store. In practice, the referrer URL may not be a complete, absolute URL.
   </p>
   <div
-    class="css-152mimm-CommentTextBlock"
+    class="css-12a4dfj-CommentTextBlock"
   >
     <h4
-      class="css-crowgh-H4"
+      class="css-uucypz-H4"
       data-heading="true"
     >
       Example

--- a/docs/global-styles/reset.ts
+++ b/docs/global-styles/reset.ts
@@ -85,7 +85,7 @@ export const globalReset = css`
   mark,
   audio,
   video {
-    font-weight: 400;
+    font-weight: normal;
     box-sizing: border-box;
     margin: 0;
     padding: 0;
@@ -118,15 +118,9 @@ export const globalReset = css`
   }
 
   body {
+    ${typography.body.paragraph}
     font-family: ${typography.fontFaces.regular};
     text-rendering: optimizeLegibility;
-    font-size: 16px;
-  }
-
-  @media screen and (max-width: ${Constants.breakpoints.mobile}) {
-    body {
-      font-size: 14px;
-    }
   }
 
   ::selection {

--- a/docs/global-styles/reset.ts
+++ b/docs/global-styles/reset.ts
@@ -1,8 +1,6 @@
 import { css } from '@emotion/react';
 import { theme, typography } from '@expo/styleguide';
 
-import * as Constants from '~/constants/theme';
-
 export const globalReset = css`
   html,
   body,

--- a/docs/global-styles/reset.ts
+++ b/docs/global-styles/reset.ts
@@ -119,6 +119,7 @@ export const globalReset = css`
     ${typography.body.paragraph}
     font-family: ${typography.fontFaces.regular};
     text-rendering: optimizeLegibility;
+    line-height: 1;
   }
 
   ::selection {

--- a/docs/ui/components/Search/styles.ts
+++ b/docs/ui/components/Search/styles.ts
@@ -118,16 +118,16 @@ export const DocSearchStyles = css`
 
   .DocSearch-Button-Keys {
     display: flex;
-    min-width: calc(2 * 20px + 2 * 0.4em);
+    gap: ${spacing[1.5]}px;
   }
 
   .DocSearch-Button-Key {
     display: flex;
     align-items: center;
-    height: 20px;
     ${typography.utility.pre}
     ${kbdStyle}
-    margin-left: 0.4em;
+    height: 20px;
+    min-width: 22px;
   }
 
   @media (max-width: 768px) {

--- a/docs/ui/components/Snippet/blocks/Terminal.tsx
+++ b/docs/ui/components/Snippet/blocks/Terminal.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import {darkTheme, spacing, typography} from '@expo/styleguide';
+import { darkTheme, spacing } from '@expo/styleguide';
 import React from 'react';
 
 import { Snippet } from '../Snippet';

--- a/docs/ui/components/Snippet/blocks/Terminal.tsx
+++ b/docs/ui/components/Snippet/blocks/Terminal.tsx
@@ -110,7 +110,7 @@ const unselectableStyle = css`
 
 const codeStyle = css`
   display: inline-block;
-  line-height: 135%;
+  line-height: 140%;
   background-color: transparent;
   border: none;
   color: ${darkTheme.text.default};

--- a/docs/ui/components/Snippet/blocks/Terminal.tsx
+++ b/docs/ui/components/Snippet/blocks/Terminal.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { darkTheme, spacing } from '@expo/styleguide';
+import {darkTheme, spacing, typography} from '@expo/styleguide';
 import React from 'react';
 
 import { Snippet } from '../Snippet';
@@ -110,7 +110,7 @@ const unselectableStyle = css`
 
 const codeStyle = css`
   display: inline-block;
-  line-height: 130%;
+  line-height: 135%;
   background-color: transparent;
   border: none;
   color: ${darkTheme.text.default};

--- a/docs/ui/components/Text/index.tsx
+++ b/docs/ui/components/Text/index.tsx
@@ -76,10 +76,14 @@ export const PRE = createTextComponent(TextElement.PRE, css(typography.utility.p
 export const kbdStyle = css({
   fontFamily: typography.fontFaces.medium,
   color: theme.text.secondary,
-  padding: `${spacing[0.5]}px ${spacing[1.5]}px`,
+  padding: `0 ${spacing[1]}px`,
   boxShadow: `0 0.1rem 0 1px ${theme.border.default}`,
   borderRadius: borderRadius.small,
   position: 'relative',
+  display: 'inline-flex',
+  margin: 0,
+  minWidth: 22,
+  justifyContent: 'center',
   top: -1,
 });
 


### PR DESCRIPTION
# Why

This is a part of the docs redesign:
* https://www.figma.com/file/bCkjr1y9fTDjgAm3eM1AIa/Docs-design-update-June-2021?node-id=39%3A311

# How

Apply the text styles based on the styleguide typography, adjust text element spacing based on the mocks (at least I have attempted to).

# Test Plan

The changes have been tested by running docs website locally.

### Preview

<img width="1920" alt="Screenshot 2022-08-25 at 23 21 27" src="https://user-images.githubusercontent.com/719641/186778583-af405a7b-bfcd-4e95-a962-00fe003ab3e3.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
