### PR TITLE
[cli] point QR code to interstitial page when enabled

### DIFF
--- a/docs/pages/workflow/expo-cli.md
+++ b/docs/pages/workflow/expo-cli.md
@@ -283,7 +283,7 @@ From here, you can choose to generate basic project files like:
 - `CI` (**boolean**) when enabled, the CLI will disable interactive functionality, skip optional prompts, and fail on non-optional prompts. Example: `CI=1 npx expo install --check` will fail if any installed packages are outdated.
 - `EXPO_NO_TELEMETRY` (**boolean**) disables anonymous usage collection.
 - `EXPO_NO_GIT_STATUS` (**boolean**) skips warning about git status during potentially dangerous actions like `npx expo prebuild --clean`.
-- `EXPO_ENABLE_INTERSTITIAL_PAGE` (**boolean**) enables the experimental "interstitial page" for selecting an app, that shows when a user has `expo-dev-client` installed, and starts the project with `expo start` instead of `expo start --dev-client`.
+- `EXPO_NO_REDIRECT_PAGE` (**boolean**) disables the redirect page for selecting an app, that shows when a user has `expo-dev-client` installed, and starts the project with `npx expo start` instead of `npx expo start --dev-client`.
 - `EXPO_PUBLIC_FOLDER` (**string**) public folder path to use with Metro for web. Default: `public`. [Learn more](/guides/customizing-metro/).
 - `EDITOR` (**string**) name of the editor to open when pressing `o` in the Terminal UI. This value is used across many command line tools.
 - `EXPO_EDITOR` (**string**) an Expo-specific version of the `EDITOR` variable which takes higher priority when defined.

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -28,6 +28,8 @@
 - [Interstitial page] Capture missing analytics event when user opens development build. ([#18792](https://github.com/expo/expo/pull/18792) by [@esamelson](https://github.com/esamelson))
 - [Interstitial page] Ensure that the development build is installed when opening the interstitial page. ([#18836](https://github.com/expo/expo/pull/18836) by [@esamelson](https://github.com/esamelson))
 - [Interstitial page] Point QR code to interstitial page when enabled. ([#18838](https://github.com/expo/expo/pull/18838) by [@esamelson](https://github.com/esamelson))
+- [Interstitial page] Minor improvements to page; try to detect if deep link succeeded. ([#18839](https://github.com/expo/expo/pull/18839) by [@esamelson](https://github.com/esamelson))
+- [Interstitial page] Flip value and change name of env flag to EXPO_NO_REDIRECT_PAGE. ([#18840](https://github.com/expo/expo/pull/18840) by [@esamelson](https://github.com/esamelson))
 
 ## 0.2.6 — 2022-07-25
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Add warning about malformed project when running prebuild in non-interactive mode. ([#18436](https://github.com/expo/expo/pull/18436) by [@wkozyra95](https://github.com/wkozyra95))
 - [Interstitial page] Capture missing analytics event when user opens development build. ([#18792](https://github.com/expo/expo/pull/18792) by [@esamelson](https://github.com/esamelson))
 - [Interstitial page] Ensure that the development build is installed when opening the interstitial page. ([#18836](https://github.com/expo/expo/pull/18836) by [@esamelson](https://github.com/esamelson))
+- [Interstitial page] Point QR code to interstitial page when enabled. ([#18838](https://github.com/expo/expo/pull/18838) by [@esamelson](https://github.com/esamelson))
 
 ## 0.2.6 — 2022-07-25
 

--- a/packages/@expo/cli/src/start/interface/interactiveActions.ts
+++ b/packages/@expo/cli/src/start/interface/interactiveActions.ts
@@ -20,10 +20,13 @@ export class DevServerManagerActions {
     // If native dev server is running, print its URL.
     if (this.devServerManager.getNativeDevServerPort()) {
       try {
-        const url = this.devServerManager.getDefaultDevServer().getNativeRuntimeUrl()!;
+        const qrCodeUrl = this.devServerManager.getDefaultDevServer().getQRCodeUrl()!;
+        // even if the QR code points to the interstitial page, we want to display the native
+        // runtime URL
+        const nativeRuntimeUrl = this.devServerManager.getDefaultDevServer().getNativeRuntimeUrl()!;
 
-        printQRCode(url);
-        Log.log(printItem(chalk`Metro waiting on {underline ${url}}`));
+        printQRCode(qrCodeUrl);
+        Log.log(printItem(chalk`Metro waiting on {underline ${nativeRuntimeUrl}}`));
         // TODO: if development build, change this message!
         Log.log(printItem('Scan the QR code above with Expo Go (Android) or the Camera app (iOS)'));
       } catch (error) {

--- a/packages/@expo/cli/src/start/interface/interactiveActions.ts
+++ b/packages/@expo/cli/src/start/interface/interactiveActions.ts
@@ -19,13 +19,20 @@ export class DevServerManagerActions {
   ) {
     // If native dev server is running, print its URL.
     if (this.devServerManager.getNativeDevServerPort()) {
+      const devServer = this.devServerManager.getDefaultDevServer();
       try {
-        const qrCodeUrl = this.devServerManager.getDefaultDevServer().getQRCodeUrl()!;
-        // even if the QR code points to the interstitial page, we want to display the native
-        // runtime URL
-        const nativeRuntimeUrl = this.devServerManager.getDefaultDevServer().getNativeRuntimeUrl()!;
+        const nativeRuntimeUrl = devServer.getNativeRuntimeUrl()!;
+        const interstitialPageUrl = devServer.getInterstitialPageUrl();
 
-        printQRCode(qrCodeUrl);
+        printQRCode(interstitialPageUrl ?? nativeRuntimeUrl);
+
+        if (interstitialPageUrl) {
+          Log.log(
+            printItem(
+              chalk`Choose an app to open your project at {underline ${interstitialPageUrl}}`
+            )
+          );
+        }
         Log.log(printItem(chalk`Metro waiting on {underline ${nativeRuntimeUrl}}`));
         // TODO: if development build, change this message!
         Log.log(printItem('Scan the QR code above with Expo Go (Android) or the Camera app (iOS)'));
@@ -34,7 +41,7 @@ export class DevServerManagerActions {
         if (error.code !== 'NO_DEV_CLIENT_SCHEME') {
           throw error;
         } else {
-          const serverUrl = this.devServerManager.getDefaultDevServer().getDevServerUrl();
+          const serverUrl = devServer.getDevServerUrl();
           Log.log(printItem(chalk`Metro waiting on {underline ${serverUrl}}`));
           Log.log(printItem(`Linking is disabled because the client scheme cannot be resolved.`));
         }

--- a/packages/@expo/cli/src/start/interface/interactiveActions.ts
+++ b/packages/@expo/cli/src/start/interface/interactiveActions.ts
@@ -22,7 +22,7 @@ export class DevServerManagerActions {
       const devServer = this.devServerManager.getDefaultDevServer();
       try {
         const nativeRuntimeUrl = devServer.getNativeRuntimeUrl()!;
-        const interstitialPageUrl = devServer.getInterstitialPageUrl();
+        const interstitialPageUrl = devServer.getRedirectUrl();
 
         printQRCode(interstitialPageUrl ?? nativeRuntimeUrl);
 

--- a/packages/@expo/cli/src/start/platforms/PlatformManager.ts
+++ b/packages/@expo/cli/src/start/platforms/PlatformManager.ts
@@ -37,7 +37,10 @@ export class PlatformManager<
       getDevServerUrl: () => string | null;
       /** Expo Go URL. */
       getExpoGoUrl: () => string;
-      /** Get redirect URL for native disambiguation. */
+      /**
+       * Get redirect URL for native disambiguation.
+       * @returns a URL like `http://localhost:19000/_expo/loading`
+       */
       getRedirectUrl: () => string | null;
       /** Dev Client */
       getCustomRuntimeUrl: (props?: { scheme?: string }) => string | null;
@@ -58,7 +61,7 @@ export class PlatformManager<
    * The CLI will check if the project has a custom dev client and if the redirect page feature is enabled.
    * If both are true, the CLI will return the redirect page URL.
    */
-  private async getExpoGoOrCustomRuntimeUrlAsync(
+  protected async getExpoGoOrCustomRuntimeUrlAsync(
     deviceManager: DeviceManager<IDevice>
   ): Promise<string> {
     // Determine if the redirect page feature is enabled first since it's the cheapest to check.

--- a/packages/@expo/cli/src/start/platforms/PlatformManager.ts
+++ b/packages/@expo/cli/src/start/platforms/PlatformManager.ts
@@ -1,6 +1,8 @@
 import { getConfig } from '@expo/config';
 import assert from 'assert';
+import chalk from 'chalk';
 
+import { Log } from '../../log';
 import { logEventAsync } from '../../utils/analytics/rudderstackClient';
 import { CommandError, UnimplementedError } from '../../utils/errors';
 import { learnMore } from '../../utils/link';
@@ -33,8 +35,10 @@ export class PlatformManager<
       platform: 'ios' | 'android';
       /** Get the base URL for the dev server hosting this platform manager. */
       getDevServerUrl: () => string | null;
-      /** Expo Go URL */
-      getExpoGoUrl: (isDevelopmentBuildInstalled: boolean) => string | null;
+      /** Expo Go URL. */
+      getExpoGoUrl: () => string;
+      /** Get redirect URL for native disambiguation. */
+      getRedirectUrl: () => string | null;
       /** Dev Client */
       getCustomRuntimeUrl: (props?: { scheme?: string }) => string | null;
       /** Resolve a device, this function should automatically handle opening the device and asserting any system validations. */
@@ -49,17 +53,47 @@ export class PlatformManager<
     throw new UnimplementedError();
   }
 
+  /**
+   * Get the URL for users intending to launch the project in Expo Go.
+   * The CLI will check if the project has a custom dev client and if the redirect page feature is enabled.
+   * If both are true, the CLI will return the redirect page URL.
+   */
+  private async getExpoGoOrCustomRuntimeUrlAsync(
+    deviceManager: DeviceManager<IDevice>
+  ): Promise<string> {
+    // Determine if the redirect page feature is enabled first since it's the cheapest to check.
+    const redirectUrl = this.props.getRedirectUrl();
+    if (redirectUrl) {
+      // If the redirect page feature is enabled, check if the project has a resolvable native identifier.
+      const applicationId = await this._getAppIdResolver().resolveAppIdFromNativeAsync();
+      if (applicationId) {
+        debug(`Resolving launch URL: (appId: ${applicationId}, redirect URL: ${redirectUrl})`);
+        // NOTE(EvanBacon): This adds considerable amount of time to the command, we should consider removing or memoizing it.
+        // Finally determine if the target device has a custom dev client installed.
+        if (await deviceManager.isAppInstalledAsync(applicationId)) {
+          return redirectUrl;
+        } else {
+          // Log a warning if no development build is available on the device, but the
+          // interstitial page would otherwise be opened.
+          Log.warn(
+            chalk`\u203A The {bold expo-dev-client} package is installed, but a development build is not ` +
+              chalk`installed on {bold ${deviceManager.name}}.\nLaunching in Expo Go. If you want to use a ` +
+              `development build, you need to create and install one first.\n${learnMore(
+                'https://docs.expo.dev/development/build/'
+              )}`
+          );
+        }
+      }
+    }
+
+    return this.props.getExpoGoUrl();
+  }
+
   protected async openProjectInExpoGoAsync(
     resolveSettings: Partial<IResolveDeviceProps> = {}
   ): Promise<{ url: string }> {
     const deviceManager = await this.props.resolveDeviceAsync(resolveSettings);
-    const applicationId = await this._getAppIdResolver().resolveAppIdFromNativeAsync();
-    const isDevelopmentBuildInstalled = applicationId
-      ? await deviceManager.isAppInstalledAsync(applicationId)
-      : true;
-    const url = this.props.getExpoGoUrl(isDevelopmentBuildInstalled);
-    // This should never happen, but just in case...
-    assert(url, 'Could not get dev server URL');
+    const url = await this.getExpoGoOrCustomRuntimeUrlAsync(deviceManager);
 
     deviceManager.logOpeningUrl(url);
 

--- a/packages/@expo/cli/src/start/platforms/__tests__/PlatformManager-test.ts
+++ b/packages/@expo/cli/src/start/platforms/__tests__/PlatformManager-test.ts
@@ -16,9 +16,23 @@ jest.mock('@expo/config', () => ({
   })),
 }));
 
+const originalEnv = process.env;
+
+afterAll(() => {
+  process.env = originalEnv;
+});
+
 describe('openAsync', () => {
+  beforeEach(() => {
+    delete process.env.EXPO_ENABLE_INTERSTITIAL_PAGE;
+  });
+
   // Mock haven
-  function createManager({ customUrl = 'custom://path', isAppInstalled = true } = {}) {
+  function createManager({
+    customUrl = 'custom://path',
+    isAppInstalled = true,
+  }: { customUrl?: string | null; isAppInstalled?: boolean } = {}) {
+    const getRedirectUrl = jest.fn((): null | string => null);
     const getExpoGoUrl = jest.fn(() => 'exp://localhost:19000/');
     const getDevServerUrl = jest.fn(() => 'http://localhost:19000/');
     const getCustomRuntimeUrl = jest.fn(() => customUrl);
@@ -38,6 +52,7 @@ describe('openAsync', () => {
       getCustomRuntimeUrl,
       getDevServerUrl,
       getExpoGoUrl,
+      getRedirectUrl,
     });
 
     // @ts-expect-error
@@ -52,6 +67,7 @@ describe('openAsync', () => {
       getCustomRuntimeUrl,
       getDevServerUrl,
       getExpoGoUrl,
+      getRedirectUrl,
     };
   }
 
@@ -73,6 +89,9 @@ describe('openAsync', () => {
     expect(resolveDeviceAsync).toHaveBeenCalledTimes(1);
     expect(getExpoGoUrl).toHaveBeenCalledTimes(1);
 
+    // Ensure we don't make the expensive call to check if the app is installed.
+    expect(device.isAppInstalledAsync).toHaveBeenCalledTimes(0);
+
     expect(device.activateWindowAsync).toHaveBeenCalledTimes(1);
     expect(device.ensureExpoGoAsync).toHaveBeenCalledTimes(1);
     expect(device.ensureExpoGoAsync).toHaveBeenNthCalledWith(1, '45.0.0');
@@ -81,6 +100,72 @@ describe('openAsync', () => {
     // Logging
     expect(device.logOpeningUrl).toHaveBeenNthCalledWith(1, url);
     expect(Log.warn).toHaveBeenCalledTimes(0);
+    expect(Log.error).toHaveBeenCalledTimes(0);
+  });
+
+  it(`opens a project using the redirect page`, async () => {
+    process.env.EXPO_ENABLE_INTERSTITIAL_PAGE = '1';
+
+    const { manager, getRedirectUrl, getExpoGoUrl, device, resolveDeviceAsync } = createManager({
+      isAppInstalled: true,
+    });
+
+    const url = 'http://localhost:19000/_expo/loading';
+    getRedirectUrl.mockImplementationOnce(() => url);
+
+    expect(await manager.openAsync({ runtime: 'expo' })).toStrictEqual({
+      url,
+    });
+
+    expect(resolveDeviceAsync).toHaveBeenCalledTimes(1);
+    expect(getExpoGoUrl).toHaveBeenCalledTimes(0);
+
+    // Ensure we check if the app is installed (once!).
+    expect(device.isAppInstalledAsync).toHaveBeenCalledTimes(1);
+    expect(device.isAppInstalledAsync).toHaveBeenNthCalledWith(1, 'dev.bacon.app');
+
+    expect(device.activateWindowAsync).toHaveBeenCalledTimes(1);
+    expect(device.ensureExpoGoAsync).toHaveBeenCalledTimes(1);
+    expect(device.ensureExpoGoAsync).toHaveBeenNthCalledWith(1, '45.0.0');
+    expect(device.openUrlAsync).toHaveBeenNthCalledWith(1, url);
+
+    // Logging
+    expect(device.logOpeningUrl).toHaveBeenNthCalledWith(1, url);
+    expect(Log.warn).toHaveBeenCalledTimes(0);
+    expect(Log.error).toHaveBeenCalledTimes(0);
+  });
+
+  it(`opens a project using Expo Go because no dev client could handle the redirect page`, async () => {
+    process.env.EXPO_ENABLE_INTERSTITIAL_PAGE = '1';
+
+    const { manager, getRedirectUrl, getExpoGoUrl, device, resolveDeviceAsync } = createManager({
+      isAppInstalled: false,
+    });
+
+    const url = 'exp://localhost:19000/';
+    getRedirectUrl.mockImplementationOnce(() => 'http://localhost:19000/_expo/loading');
+
+    expect(await manager.openAsync({ runtime: 'expo' })).toStrictEqual({
+      url,
+    });
+
+    expect(resolveDeviceAsync).toHaveBeenCalledTimes(1);
+    expect(getRedirectUrl).toHaveBeenCalledTimes(1);
+    expect(getExpoGoUrl).toHaveBeenCalledTimes(1);
+
+    // Ensure we check if the app is installed (once!).
+    expect(device.isAppInstalledAsync).toHaveBeenCalledTimes(1);
+    expect(device.isAppInstalledAsync).toHaveBeenNthCalledWith(1, 'dev.bacon.app');
+
+    expect(device.activateWindowAsync).toHaveBeenCalledTimes(1);
+    expect(device.ensureExpoGoAsync).toHaveBeenCalledTimes(1);
+    expect(device.ensureExpoGoAsync).toHaveBeenNthCalledWith(1, '45.0.0');
+    expect(device.openUrlAsync).toHaveBeenNthCalledWith(1, url);
+
+    // Logging
+    expect(device.logOpeningUrl).toHaveBeenNthCalledWith(1, url);
+    expect(Log.warn).toHaveBeenCalledTimes(1);
+    expect(Log.warn).toHaveBeenNthCalledWith(1, expect.stringMatching(/iPhone 13/gm));
     expect(Log.error).toHaveBeenCalledTimes(0);
   });
 

--- a/packages/@expo/cli/src/start/platforms/android/AndroidPlatformManager.ts
+++ b/packages/@expo/cli/src/start/platforms/android/AndroidPlatformManager.ts
@@ -16,8 +16,10 @@ export class AndroidPlatformManager extends PlatformManager<Device, AndroidOpenI
     options: {
       /** Get the base URL for the dev server hosting this platform manager. */
       getDevServerUrl: () => string | null;
-      /** Expo Go URL. */
-      getExpoGoUrl: (isDevelopmentBuildInstalled: boolean) => string | null;
+      /** Expo Go URL */
+      getExpoGoUrl: () => string;
+      /** Get redirect URL for native disambiguation. */
+      getRedirectUrl: () => string | null;
       /** Dev Client URL. */
       getCustomRuntimeUrl: (props?: { scheme?: string }) => string | null;
     }

--- a/packages/@expo/cli/src/start/platforms/ios/ApplePlatformManager.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/ApplePlatformManager.ts
@@ -12,8 +12,10 @@ export class ApplePlatformManager extends PlatformManager<Device> {
     options: {
       /** Get the base URL for the dev server hosting this platform manager. */
       getDevServerUrl: () => string | null;
-      /** Expo Go URL */
-      getExpoGoUrl: (isDevelopmentBuildInstalled: boolean) => string | null;
+      /** Expo Go URL. */
+      getExpoGoUrl: () => string;
+      /** Get redirect URL for native disambiguation. */
+      getRedirectUrl: () => string | null;
       /** Dev Client */
       getCustomRuntimeUrl: (props?: { scheme?: string }) => string | null;
     }

--- a/packages/@expo/cli/src/start/server/BundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/BundlerDevServer.ts
@@ -418,14 +418,7 @@ export abstract class BundlerDevServer {
     isDevelopmentBuildInstalled: boolean = true
   ): string | null {
     if (this.shouldUseInterstitialPage(isDevelopmentBuildInstalled)) {
-      if (platform) {
-        const loadingUrl =
-          platform === 'emulator'
-            ? this.urlCreator?.constructLoadingUrl({}, 'android')
-            : this.urlCreator?.constructLoadingUrl({}, 'ios');
-        return loadingUrl ?? null;
-      }
-      return this.urlCreator?.constructLoadingUrl({}, null) ?? null;
+      return this.getInterstitialPageUrl(platform, isDevelopmentBuildInstalled);
     }
 
     // Log a warning if no development build is available on the device, but the
@@ -444,6 +437,23 @@ export abstract class BundlerDevServer {
     }
 
     return this.urlCreator?.constructUrl({ scheme: 'exp' }) ?? null;
+  }
+
+  public getInterstitialPageUrl(
+    platform: keyof typeof PLATFORM_MANAGERS | null = null,
+    isDevelopmentBuildInstalled: boolean = true
+  ): string | null {
+    if (!this.shouldUseInterstitialPage(isDevelopmentBuildInstalled)) {
+      return null;
+    }
+    if (platform) {
+      const loadingUrl =
+        platform === 'emulator'
+          ? this.urlCreator?.constructLoadingUrl({}, 'android')
+          : this.urlCreator?.constructLoadingUrl({}, 'ios');
+      return loadingUrl ?? null;
+    }
+    return this.urlCreator?.constructLoadingUrl({}, null) ?? null;
   }
 
   protected async getPlatformManagerAsync(platform: keyof typeof PLATFORM_MANAGERS) {

--- a/packages/@expo/cli/src/start/server/BundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/BundlerDevServer.ts
@@ -405,7 +405,7 @@ export abstract class BundlerDevServer {
   }
 
   /** Should use the interstitial page for selecting which runtime to use. */
-  private isRedirectPageEnabled(): boolean {
+  protected isRedirectPageEnabled(): boolean {
     return (
       env.EXPO_ENABLE_INTERSTITIAL_PAGE &&
       // if user passed --dev-client flag, skip interstitial page

--- a/packages/@expo/cli/src/start/server/BundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/BundlerDevServer.ts
@@ -349,6 +349,13 @@ export abstract class BundlerDevServer {
       : this.getUrlCreator().constructUrl({ ...opts, scheme: 'exp' });
   }
 
+  public getQRCodeUrl(opts: Partial<CreateURLOptions> = {}) {
+    const { scheme, ...restOpts } = opts;
+    return this.shouldUseInterstitialPage()
+      ? this.getUrlCreator().constructLoadingUrl(restOpts, null)
+      : this.getNativeRuntimeUrl(opts);
+  }
+
   /** Get the URL for the running instance of the dev server. */
   public getDevServerUrl(options: { hostType?: 'localhost' } = {}): string | null {
     const instance = this.getInstance();
@@ -405,6 +412,8 @@ export abstract class BundlerDevServer {
     return (
       env.EXPO_ENABLE_INTERSTITIAL_PAGE &&
       isDevelopmentBuildInstalled &&
+      // if user passed --dev-client flag, skip interstitial page
+      !this.isDevClient &&
       // Checks if dev client is installed.
       !!resolveFrom.silent(this.projectRoot, 'expo-dev-launcher')
     );
@@ -419,7 +428,7 @@ export abstract class BundlerDevServer {
       const loadingUrl =
         platform === 'emulator'
           ? this.urlCreator?.constructLoadingUrl({}, 'android')
-          : this.urlCreator?.constructLoadingUrl({ hostType: 'localhost' }, 'ios');
+          : this.urlCreator?.constructLoadingUrl({}, 'ios');
       return loadingUrl ?? null;
     }
 

--- a/packages/@expo/cli/src/start/server/BundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/BundlerDevServer.ts
@@ -407,7 +407,7 @@ export abstract class BundlerDevServer {
   /** Should use the interstitial page for selecting which runtime to use. */
   protected isRedirectPageEnabled(): boolean {
     return (
-      env.EXPO_ENABLE_INTERSTITIAL_PAGE &&
+      !env.EXPO_NO_REDIRECT_PAGE &&
       // if user passed --dev-client flag, skip interstitial page
       !this.isDevClient &&
       // Checks if dev client is installed.

--- a/packages/@expo/cli/src/start/server/BundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/BundlerDevServer.ts
@@ -349,13 +349,6 @@ export abstract class BundlerDevServer {
       : this.getUrlCreator().constructUrl({ ...opts, scheme: 'exp' });
   }
 
-  public getQRCodeUrl(opts: Partial<CreateURLOptions> = {}) {
-    const { scheme, ...restOpts } = opts;
-    return this.shouldUseInterstitialPage()
-      ? this.getUrlCreator().constructLoadingUrl(restOpts, null)
-      : this.getNativeRuntimeUrl(opts);
-  }
-
   /** Get the URL for the running instance of the dev server. */
   public getDevServerUrl(options: { hostType?: 'localhost' } = {}): string | null {
     const instance = this.getInstance();
@@ -421,15 +414,18 @@ export abstract class BundlerDevServer {
 
   /** Get the URL for opening in Expo Go. */
   protected getExpoGoUrl(
-    platform: keyof typeof PLATFORM_MANAGERS,
+    platform: keyof typeof PLATFORM_MANAGERS | null = null,
     isDevelopmentBuildInstalled: boolean = true
   ): string | null {
     if (this.shouldUseInterstitialPage(isDevelopmentBuildInstalled)) {
-      const loadingUrl =
-        platform === 'emulator'
-          ? this.urlCreator?.constructLoadingUrl({}, 'android')
-          : this.urlCreator?.constructLoadingUrl({}, 'ios');
-      return loadingUrl ?? null;
+      if (platform) {
+        const loadingUrl =
+          platform === 'emulator'
+            ? this.urlCreator?.constructLoadingUrl({}, 'android')
+            : this.urlCreator?.constructLoadingUrl({}, 'ios');
+        return loadingUrl ?? null;
+      }
+      return this.urlCreator?.constructLoadingUrl({}, null) ?? null;
     }
 
     // Log a warning if no development build is available on the device, but the

--- a/packages/@expo/cli/src/start/server/UrlCreator.ts
+++ b/packages/@expo/cli/src/start/server/UrlCreator.ts
@@ -30,9 +30,11 @@ export class UrlCreator {
   /**
    * @returns URL like `http://localhost:19000/_expo/loading?platform=ios`
    */
-  public constructLoadingUrl(options: CreateURLOptions, platform: string): string {
+  public constructLoadingUrl(options: CreateURLOptions, platform: string | null): string {
     const url = new URL('_expo/loading', this.constructUrl({ scheme: 'http', ...options }));
-    url.search = new URLSearchParams({ platform }).toString();
+    if (platform) {
+      url.search = new URLSearchParams({ platform }).toString();
+    }
     const loadingUrl = url.toString();
     debug(`Loading URL: ${loadingUrl}`);
     return loadingUrl;

--- a/packages/@expo/cli/src/start/server/UrlCreator.ts
+++ b/packages/@expo/cli/src/start/server/UrlCreator.ts
@@ -28,7 +28,14 @@ export class UrlCreator {
   ) {}
 
   /**
+   * Return a URL for the "loading" interstitial page that is used to disambiguate which
+   * native runtime to open the dev server with.
+   *
+   * @param options options for creating the URL
+   * @param platform when opening the URL from the CLI to a connected device we can specify the platform as a query parameter, otherwise it will be inferred from the unsafe user agent sniffing.
+   *
    * @returns URL like `http://localhost:19000/_expo/loading?platform=ios`
+   * @returns URL like `http://localhost:19000/_expo/loading` when no platform is provided.
    */
   public constructLoadingUrl(options: CreateURLOptions, platform: string | null): string {
     const url = new URL('_expo/loading', this.constructUrl({ scheme: 'http', ...options }));

--- a/packages/@expo/cli/src/start/server/__tests__/BundlerDevServer-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/BundlerDevServer-test.ts
@@ -97,7 +97,10 @@ class MockBundlerDevServer extends BundlerDevServer {
     return ['./fake.config.js'];
   }
 
-  public getExpoGoUrl(platform: 'simulator' | 'emulator', isDevelopmentBuildInstalled: boolean) {
+  public getExpoGoUrl(
+    platform: 'simulator' | 'emulator' | null,
+    isDevelopmentBuildInstalled: boolean
+  ) {
     return super.getExpoGoUrl(platform, isDevelopmentBuildInstalled);
   }
 }
@@ -192,7 +195,8 @@ describe('getExpoGoUrl', () => {
     expect(server.getExpoGoUrl('simulator', true)).toBe(
       'http://100.100.1.100:3000/_expo/loading?platform=ios'
     );
-    expect(urlCreator.constructLoadingUrl).toBeCalledTimes(2);
+    expect(server.getExpoGoUrl(null, true)).toBe('http://100.100.1.100:3000/_expo/loading');
+    expect(urlCreator.constructLoadingUrl).toBeCalledTimes(3);
 
     // should skip interstitial page if no development build is installed on the device
     expect(server.getExpoGoUrl('emulator', false)).toBe('exp://100.100.1.100:3000');
@@ -211,56 +215,6 @@ describe('getExpoGoUrl', () => {
 });
 
 describe('getNativeRuntimeUrl', () => {
-  it(`gets the native runtime URL`, async () => {
-    const server = new MockBundlerDevServer('/', getPlatformBundlers({}));
-    await server.startAsync({
-      location: {},
-    });
-    expect(server.getNativeRuntimeUrl()).toBe('exp://100.100.1.100:3000');
-    expect(server.getNativeRuntimeUrl({ hostname: 'localhost' })).toBe('exp://127.0.0.1:3000');
-    expect(server.getNativeRuntimeUrl({ scheme: 'foobar' })).toBe('exp://100.100.1.100:3000');
-  });
-  it(`gets the native runtime URL for dev client`, async () => {
-    const server = new MockBundlerDevServer('/', getPlatformBundlers({}), true);
-    await server.startAsync({
-      location: {
-        scheme: 'my-app',
-      },
-    });
-    expect(server.getNativeRuntimeUrl()).toBe(
-      'my-app://expo-development-client/?url=http%3A%2F%2F100.100.1.100%3A3000'
-    );
-    expect(server.getNativeRuntimeUrl({ hostname: 'localhost' })).toBe(
-      'my-app://expo-development-client/?url=http%3A%2F%2F127.0.0.1%3A3000'
-    );
-    expect(server.getNativeRuntimeUrl({ scheme: 'foobar' })).toBe(
-      'foobar://expo-development-client/?url=http%3A%2F%2F100.100.1.100%3A3000'
-    );
-  });
-});
-
-describe('getQRCodeUrl', () => {
-  it(`gets the interstitial page URL`, async () => {
-    process.env.EXPO_ENABLE_INTERSTITIAL_PAGE = '1';
-    vol.fromJSON(
-      {
-        'node_modules/expo-dev-launcher/package.json': '',
-      },
-      '/'
-    );
-
-    const server = new MockBundlerDevServer('/', getPlatformBundlers({}));
-    await server.startAsync({
-      location: {},
-    });
-    expect(server.getQRCodeUrl()).toBe('http://100.100.1.100:3000/_expo/loading');
-    expect(server.getQRCodeUrl({ hostname: 'localhost' })).toBe(
-      'http://127.0.0.1:3000/_expo/loading'
-    );
-    expect(server.getQRCodeUrl({ scheme: 'foobar' })).toBe(
-      'http://100.100.1.100:3000/_expo/loading'
-    );
-  });
   it(`gets the native runtime URL`, async () => {
     const server = new MockBundlerDevServer('/', getPlatformBundlers({}));
     await server.startAsync({

--- a/packages/@expo/cli/src/start/server/__tests__/BundlerDevServer-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/BundlerDevServer-test.ts
@@ -1,7 +1,6 @@
 import openBrowserAsync from 'better-opn';
 import { vol } from 'memfs';
 
-import * as Log from '../../../log';
 import { BundlerDevServer, BundlerStartOptions, DevServerInstance } from '../BundlerDevServer';
 import { UrlCreator } from '../UrlCreator';
 import { getPlatformBundlers } from '../platformBundlers';

--- a/packages/@expo/cli/src/start/server/__tests__/BundlerDevServer-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/BundlerDevServer-test.ts
@@ -35,7 +35,7 @@ const originalEnv = process.env;
 
 beforeEach(() => {
   vol.reset();
-  delete process.env.EXPO_ENABLE_INTERSTITIAL_PAGE;
+  delete process.env.EXPO_NO_REDIRECT_PAGE;
 });
 
 afterAll(() => {
@@ -172,7 +172,7 @@ describe('stopAsync', () => {
 describe('isRedirectPageEnabled', () => {
   beforeEach(() => {
     vol.reset();
-    delete process.env.EXPO_ENABLE_INTERSTITIAL_PAGE;
+    delete process.env.EXPO_NO_REDIRECT_PAGE;
   });
 
   function mockDevClientInstalled() {
@@ -187,8 +187,6 @@ describe('isRedirectPageEnabled', () => {
   it(`is redirect enabled`, async () => {
     mockDevClientInstalled();
 
-    process.env.EXPO_ENABLE_INTERSTITIAL_PAGE = '1';
-
     const server = new MockBundlerDevServer(
       '/',
       getPlatformBundlers({}),
@@ -201,7 +199,7 @@ describe('isRedirectPageEnabled', () => {
   it(`redirect can be disabled with env var`, async () => {
     mockDevClientInstalled();
 
-    process.env.EXPO_ENABLE_INTERSTITIAL_PAGE = '0';
+    process.env.EXPO_NO_REDIRECT_PAGE = '1';
 
     const server = new MockBundlerDevServer(
       '/',
@@ -215,8 +213,6 @@ describe('isRedirectPageEnabled', () => {
   it(`redirect is disabled when running in dev client mode`, async () => {
     mockDevClientInstalled();
 
-    process.env.EXPO_ENABLE_INTERSTITIAL_PAGE = '1';
-
     const server = new MockBundlerDevServer(
       '/',
       getPlatformBundlers({}),
@@ -227,8 +223,6 @@ describe('isRedirectPageEnabled', () => {
   });
 
   it(`redirect is disabled when expo-dev-client is not installed in the project`, async () => {
-    process.env.EXPO_ENABLE_INTERSTITIAL_PAGE = '1';
-
     const server = new MockBundlerDevServer(
       '/',
       getPlatformBundlers({}),

--- a/packages/@expo/cli/src/start/server/__tests__/UrlCreator-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/UrlCreator-test.ts
@@ -33,6 +33,11 @@ describe('constructLoadingUrl', () => {
       createDefaultCreator().constructLoadingUrl({ scheme: 'my-scheme' }, 'android')
     ).toMatchInlineSnapshot(`"my-scheme://100.100.1.100:8081/_expo/loading?platform=android"`);
   });
+  it(`allows null platform`, () => {
+    expect(createDefaultCreator().constructLoadingUrl({}, null)).toMatchInlineSnapshot(
+      `"http://100.100.1.100:8081/_expo/loading"`
+    );
+  });
 });
 
 describe('constructDevClientUrl', () => {

--- a/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
@@ -70,7 +70,12 @@ export class MetroBundlerDevServer extends BundlerDevServer {
     // https://github.com/expo/expo/issues/13114
     prependMiddleware(middleware, manifestMiddleware);
 
-    middleware.use(new InterstitialPageMiddleware(this.projectRoot).getHandler());
+    middleware.use(
+      new InterstitialPageMiddleware(this.projectRoot, {
+        // TODO: Prevent this from becoming stale.
+        scheme: options.location.scheme ?? null,
+      }).getHandler()
+    );
 
     const deepLinkMiddleware = new RuntimeRedirectMiddleware(this.projectRoot, {
       onDeepLink: getDeepLinkHandler(this.projectRoot),

--- a/packages/@expo/cli/src/start/server/middleware/InterstitialPageMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/InterstitialPageMiddleware.ts
@@ -9,6 +9,7 @@ import {
   assertMissingRuntimePlatform,
   assertRuntimePlatform,
   parsePlatformHeader,
+  resolvePlatformFromUserAgentHeader,
   RuntimePlatform,
 } from './resolvePlatform';
 import { ServerRequest, ServerResponse } from './server.types';
@@ -75,7 +76,7 @@ export class InterstitialPageMiddleware extends ExpoMiddleware {
     res = disableResponseCache(res);
     res.setHeader('Content-Type', 'text/html');
 
-    const platform = parsePlatformHeader(req);
+    const platform = parsePlatformHeader(req) ?? resolvePlatformFromUserAgentHeader(req);
     assertMissingRuntimePlatform(platform);
     assertRuntimePlatform(platform);
 

--- a/packages/@expo/cli/src/start/server/middleware/InterstitialPageMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/InterstitialPageMiddleware.ts
@@ -1,4 +1,4 @@
-import { ExpoConfig, getConfig, getNameFromConfig } from '@expo/config';
+import { getConfig, getNameFromConfig } from '@expo/config';
 import { getRuntimeVersionNullable } from '@expo/config-plugins/build/utils/Updates';
 import { readFile } from 'fs/promises';
 import path from 'path';
@@ -14,32 +14,32 @@ import {
 } from './resolvePlatform';
 import { ServerRequest, ServerResponse } from './server.types';
 
+type ProjectVersion = {
+  type: 'sdk' | 'runtime';
+  version: string | null;
+};
+
 const debug = require('debug')(
   'expo:start:server:middleware:interstitialPage'
 ) as typeof console.log;
 
 export const LoadingEndpoint = '/_expo/loading';
 
-function getRuntimeVersion(exp: ExpoConfig, platform: 'android' | 'ios' | null): string {
-  if (!platform) {
-    return 'Undetected';
-  }
-
-  return getRuntimeVersionNullable(exp, platform) ?? 'Undetected';
-}
-
 export class InterstitialPageMiddleware extends ExpoMiddleware {
-  constructor(projectRoot: string) {
+  constructor(
+    projectRoot: string,
+    protected options: { scheme: string | null } = { scheme: null }
+  ) {
     super(projectRoot, [LoadingEndpoint]);
   }
 
   /** Get the template HTML page and inject values. */
   async _getPageAsync({
     appName,
-    runtimeVersion,
+    projectVersion,
   }: {
     appName: string;
-    runtimeVersion: string | null;
+    projectVersion: ProjectVersion;
   }): Promise<string> {
     const templatePath =
       // Production: This will resolve when installed in the project.
@@ -49,8 +49,13 @@ export class InterstitialPageMiddleware extends ExpoMiddleware {
     let content = (await readFile(templatePath)).toString('utf-8');
 
     content = content.replace(/{{\s*AppName\s*}}/, appName);
-    content = content.replace(/{{\s*RuntimeVersion\s*}}/, runtimeVersion ?? '');
     content = content.replace(/{{\s*Path\s*}}/, this.projectRoot);
+    content = content.replace(/{{\s*Scheme\s*}}/, this.options.scheme ?? 'Unknown');
+    content = content.replace(
+      /{{\s*ProjectVersionType\s*}}/,
+      `${projectVersion.type === 'sdk' ? 'SDK' : 'Runtime'} version`
+    );
+    content = content.replace(/{{\s*ProjectVersion\s*}}/, projectVersion.version ?? 'Undetected');
 
     return content;
   }
@@ -58,17 +63,21 @@ export class InterstitialPageMiddleware extends ExpoMiddleware {
   /** Get settings for the page from the project config. */
   _getProjectOptions(platform: RuntimePlatform): {
     appName: string;
-    runtimeVersion: string | null;
+    projectVersion: ProjectVersion;
   } {
     assertRuntimePlatform(platform);
 
     const { exp } = getConfig(this.projectRoot);
     const { appName } = getNameFromConfig(exp);
-    const runtimeVersion = getRuntimeVersion(exp, platform);
+    const runtimeVersion = getRuntimeVersionNullable(exp, platform);
+    const sdkVersion = exp.sdkVersion ?? null;
 
     return {
       appName: appName ?? 'App',
-      runtimeVersion,
+      projectVersion:
+        sdkVersion && !runtimeVersion
+          ? { type: 'sdk', version: sdkVersion }
+          : { type: 'runtime', version: runtimeVersion },
     };
   }
 
@@ -80,11 +89,11 @@ export class InterstitialPageMiddleware extends ExpoMiddleware {
     assertMissingRuntimePlatform(platform);
     assertRuntimePlatform(platform);
 
-    const { appName, runtimeVersion } = this._getProjectOptions(platform);
+    const { appName, projectVersion } = this._getProjectOptions(platform);
     debug(
-      `Create loading page. (platform: ${platform}, appName: ${appName}, runtimeVersion: ${runtimeVersion})`
+      `Create loading page. (platform: ${platform}, appName: ${appName}, projectVersion: ${projectVersion.version}, type: ${projectVersion.type})`
     );
-    const content = await this._getPageAsync({ appName, runtimeVersion });
+    const content = await this._getPageAsync({ appName, projectVersion });
     res.end(content);
   }
 }

--- a/packages/@expo/cli/src/start/server/middleware/RuntimeRedirectMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/RuntimeRedirectMiddleware.ts
@@ -6,6 +6,7 @@ import {
   assertMissingRuntimePlatform,
   assertRuntimePlatform,
   parsePlatformHeader,
+  resolvePlatformFromUserAgentHeader,
   RuntimePlatform,
 } from './resolvePlatform';
 import { ServerRequest, ServerResponse } from './server.types';
@@ -36,7 +37,7 @@ export class RuntimeRedirectMiddleware extends ExpoMiddleware {
   async handleRequestAsync(req: ServerRequest, res: ServerResponse): Promise<void> {
     const { query } = parse(req.url!, true);
     const isDevClient = query['choice'] === 'expo-dev-client';
-    const platform = parsePlatformHeader(req);
+    const platform = parsePlatformHeader(req) ?? resolvePlatformFromUserAgentHeader(req);
     assertMissingRuntimePlatform(platform);
     assertRuntimePlatform(platform);
     const runtime = isDevClient ? 'custom' : 'expo';

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/InterstitialPageMiddleware-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/InterstitialPageMiddleware-test.ts
@@ -97,7 +97,7 @@ describe('_getPageAsync', () => {
 });
 
 describe('handleRequestAsync', () => {
-  it('returns the interstitial page', async () => {
+  it('returns the interstitial page with platform header', async () => {
     const middleware = new InterstitialPageMiddleware('/');
 
     middleware._getProjectOptions = jest.fn(() => ({
@@ -115,6 +115,44 @@ describe('handleRequestAsync', () => {
 
     await middleware.handleRequestAsync(
       asReq({ url: 'http://localhost:3000', headers: { 'expo-platform': 'ios' } }),
+      response
+    );
+    expect(response.statusCode).toBe(200);
+    expect(response.end).toBeCalledWith('mock-value');
+    expect(response.setHeader).toHaveBeenNthCalledWith(
+      1,
+      'Cache-Control',
+      'private, no-cache, no-store, must-revalidate'
+    );
+    expect(response.setHeader).toHaveBeenNthCalledWith(2, 'Expires', '-1');
+    expect(response.setHeader).toHaveBeenNthCalledWith(3, 'Pragma', 'no-cache');
+    expect(response.setHeader).toHaveBeenNthCalledWith(4, 'Content-Type', 'text/html');
+  });
+
+  it('returns the interstitial page with user-agent header', async () => {
+    const middleware = new InterstitialPageMiddleware('/');
+
+    middleware._getProjectOptions = jest.fn(() => ({
+      runtimeVersion: '123',
+      appName: 'App',
+    }));
+
+    middleware._getPageAsync = jest.fn(async () => 'mock-value');
+
+    const response = {
+      setHeader: jest.fn(),
+      end: jest.fn(),
+      statusCode: 200,
+    } as unknown as ServerResponse;
+
+    await middleware.handleRequestAsync(
+      asReq({
+        url: 'http://localhost:3000',
+        headers: {
+          'user-agent':
+            'Mozilla/5.0 (Linux; Android 11; Pixel 2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Mobile Safari/537.36',
+        },
+      }),
       response
     );
     expect(response.statusCode).toBe(200);

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/RuntimeRedirectMiddleware-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/RuntimeRedirectMiddleware-test.ts
@@ -62,6 +62,28 @@ describe('handleRequestAsync', () => {
     expect(onDeepLink).toBeCalledWith({ runtime: 'expo', platform: 'android' });
   });
 
+  it('redirects to Expo Go with user agent header', async () => {
+    const { middleware, getLocation, onDeepLink } = createMiddleware();
+
+    const response = createMockResponse();
+    await middleware.handleRequestAsync(
+      asReq({
+        url: 'http://localhost:19000/_expo/link',
+        headers: {
+          'user-agent':
+            'Mozilla/5.0 (Linux; Android 11; Pixel 2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Mobile Safari/537.36',
+        },
+      }),
+      response
+    );
+    expect(response.statusCode).toBe(307);
+    expect(response.end).toBeCalledWith();
+    expect(response.setHeader).toBeCalledTimes(4);
+    expect(response.setHeader).toHaveBeenNthCalledWith(1, 'Location', 'mock-location-expo');
+    expect(getLocation).toBeCalledWith({ runtime: 'expo' });
+    expect(onDeepLink).toBeCalledWith({ runtime: 'expo', platform: 'android' });
+  });
+
   it('redirects to a custom runtime', async () => {
     const { middleware, getLocation, onDeepLink } = createMiddleware();
 

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/resolvePlatform-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/resolvePlatform-test.ts
@@ -74,6 +74,11 @@ describe(parsePlatformHeader, () => {
   });
 });
 
+/**
+ * To update the user-agent values in these tests, turn on EXPO_DEBUG and make a
+ * request to load an interstitial page without the `platform` query param or
+ * 'expo-platform' header
+ */
 describe(resolvePlatformFromUserAgentHeader, () => {
   it(`resolves ios from user-agent string`, () => {
     expect(
@@ -82,6 +87,7 @@ describe(resolvePlatformFromUserAgentHeader, () => {
           url: 'http://localhost:3000',
           headers: {
             'user-agent':
+              // user-agent value from iPhone 15.2 simulator
               'Mozilla/5.0 (iPhone; CPU iPhone OS 15_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.2 Mobile/15E148 Safari/604.1',
           },
         })
@@ -95,18 +101,23 @@ describe(resolvePlatformFromUserAgentHeader, () => {
           url: 'http://localhost:3000',
           headers: {
             'user-agent':
+              // user-agent value from a Google Pixel 2
               'Mozilla/5.0 (Linux; Android 11; Pixel 2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Mobile Safari/537.36',
           },
         })
       )
     );
   });
-  it(`returns null`, () => {
+  it(`returns null from a non-matching user-agent string`, () => {
     expect(
       resolvePlatformFromUserAgentHeader(
         asRequest({
           url: 'http://localhost:3000',
-          headers: {},
+          headers: {
+            'user-agent':
+              // user-agent value from Firefox on macOS
+              'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:104.0) Gecko/20100101 Firefox/104.0',
+          },
         })
       )
     );

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/resolvePlatform-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/resolvePlatform-test.ts
@@ -1,5 +1,6 @@
 import {
   parsePlatformHeader,
+  resolvePlatformFromUserAgentHeader,
   assertMissingRuntimePlatform,
   assertRuntimePlatform,
 } from '../resolvePlatform';
@@ -70,6 +71,45 @@ describe(parsePlatformHeader, () => {
         })
       )
     ).toBe('android');
+  });
+});
+
+describe(resolvePlatformFromUserAgentHeader, () => {
+  it(`resolves ios from user-agent string`, () => {
+    expect(
+      resolvePlatformFromUserAgentHeader(
+        asRequest({
+          url: 'http://localhost:3000',
+          headers: {
+            'user-agent':
+              'Mozilla/5.0 (iPhone; CPU iPhone OS 15_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.2 Mobile/15E148 Safari/604.1',
+          },
+        })
+      )
+    );
+  });
+  it(`resolves android from user-agent string`, () => {
+    expect(
+      resolvePlatformFromUserAgentHeader(
+        asRequest({
+          url: 'http://localhost:3000',
+          headers: {
+            'user-agent':
+              'Mozilla/5.0 (Linux; Android 11; Pixel 2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Mobile Safari/537.36',
+          },
+        })
+      )
+    );
+  });
+  it(`returns null`, () => {
+    expect(
+      resolvePlatformFromUserAgentHeader(
+        asRequest({
+          url: 'http://localhost:3000',
+          headers: {},
+        })
+      )
+    );
   });
 });
 

--- a/packages/@expo/cli/src/start/server/middleware/resolvePlatform.ts
+++ b/packages/@expo/cli/src/start/server/middleware/resolvePlatform.ts
@@ -3,6 +3,10 @@ import { parse } from 'url';
 import { CommandError } from '../../../utils/errors';
 import { ServerRequest } from './server.types';
 
+const debug = require('debug')(
+  'expo:start:server:middleware:resolvePlatform'
+) as typeof console.log;
+
 /** Supported platforms */
 export type RuntimePlatform = 'ios' | 'android';
 
@@ -23,14 +27,16 @@ export function parsePlatformHeader(req: ServerRequest): string | null {
 
 /** Guess the platform from the user-agent header. */
 export function resolvePlatformFromUserAgentHeader(req: ServerRequest): string | null {
+  let platform = null;
   const userAgent = req.headers['user-agent'];
   if (userAgent?.match(/Android/i)) {
-    return 'android';
+    platform = 'android';
   }
   if (userAgent?.match(/iPhone|iPad/i)) {
-    return 'ios';
+    platform = 'ios';
   }
-  return null;
+  debug(`Resolved platform ${platform} from user-agent header: ${userAgent}`);
+  return platform;
 }
 
 /** Assert if the runtime platform is not included. */

--- a/packages/@expo/cli/src/start/server/middleware/resolvePlatform.ts
+++ b/packages/@expo/cli/src/start/server/middleware/resolvePlatform.ts
@@ -10,7 +10,7 @@ export type RuntimePlatform = 'ios' | 'android';
  * Extract the runtime platform from the server request.
  * 1. Query param `platform`: `?platform=ios`
  * 2. Header `expo-platform`: `'expo-platform': ios`
- * 2. Legacy header `exponent-platform`: `'exponent-platform': ios`
+ * 3. Legacy header `exponent-platform`: `'exponent-platform': ios`
  *
  * Returns first item in the case of an array.
  */
@@ -19,6 +19,18 @@ export function parsePlatformHeader(req: ServerRequest): string | null {
   const platform =
     url.query?.platform || req.headers['expo-platform'] || req.headers['exponent-platform'];
   return (Array.isArray(platform) ? platform[0] : platform) ?? null;
+}
+
+/** Guess the platform from the user-agent header. */
+export function resolvePlatformFromUserAgentHeader(req: ServerRequest): string | null {
+  const userAgent = req.headers['user-agent'];
+  if (userAgent?.match(/Android/i)) {
+    return 'android';
+  }
+  if (userAgent?.match(/iPhone|iPad/i)) {
+    return 'ios';
+  }
+  return null;
 }
 
 /** Assert if the runtime platform is not included. */

--- a/packages/@expo/cli/src/utils/env.ts
+++ b/packages/@expo/cli/src/utils/env.ts
@@ -66,9 +66,9 @@ class Env {
   get EXPO_NO_CACHE() {
     return boolish('EXPO_NO_CACHE', false);
   }
-  /** Enable the experimental interstitial app select page. */
-  get EXPO_ENABLE_INTERSTITIAL_PAGE() {
-    return boolish('EXPO_ENABLE_INTERSTITIAL_PAGE', false);
+  /** Disable the app select redirect page. */
+  get EXPO_NO_REDIRECT_PAGE() {
+    return boolish('EXPO_NO_REDIRECT_PAGE', false);
   }
   /** The React Metro port that's baked into react-native scripts and tools. */
   get RCT_METRO_PORT() {

--- a/packages/@expo/cli/static/loading-page/index.html
+++ b/packages/@expo/cli/static/loading-page/index.html
@@ -185,10 +185,27 @@
       color: var(--secondary-text-color);
     }
 
+    #alert {
+      background-color: #fff;
+      color: var(--secondary-text-color);
+
+      padding-top: 20px;
+      padding-bottom: 20px;
+      padding-left: 10px;
+      padding-right: 10px;
+
+      text-align: center;
+      font-size: 16px;
+      letter-spacing: -0.0001em;
+      line-height: 150%;
+
+      display: none;
+    }
   </style>
   <title>Expo Start | Loading Page</title>
 </head>
 <body>
+  <div id="alert"></div>
   <div class="logo-box">
     <div class="logo-background-box">
 
@@ -216,8 +233,8 @@
       <div class="info-box-details">
         <p class="info-box-app-name">{{ AppName }}</p>
         <div class="info-box-details-record">
-          <p>Runtime version</p>
-          <p>{{ RuntimeVersion }}</p>
+          <p>{{ ProjectVersionType }}</p>
+          <p>{{ ProjectVersion }}</p>
         </div>
         <!-- <div class="info-box-details-record">
           <p>Branch</p>
@@ -239,11 +256,29 @@
     <p class="bottom-bar-header">
       How would you like to open this project?
     </p>
-    <a id="expo-dev-client-link" href="/_expo/link?choice=expo-dev-client" class="bottom-bar-button bottom-bar-button-dark">Development App</a>
+    <a id="expo-dev-client-link" href="/_expo/link?choice=expo-dev-client" class="bottom-bar-button bottom-bar-button-dark">Development Build</a>
     <a id="expo-go-link" href="/_expo/link?choice=expo-go" class="bottom-bar-button bottom-bar-button-grey">Expo Go</a>
   </div>
   
   <script>
+  const alertElement = document.getElementById("alert");
+
+  const showAlert = (isExpoGo) => {
+    if (isExpoGo) {
+      alertElement.innerHTML = 'Unable to open in Expo Go. Please install <b>Expo Go</b> to continue.' +
+      '<br><a href="https://expo.dev/client">Learn more.</a>';
+    } else {
+      alertElement.innerHTML = 'Unable to open in Development Build with the <b>{{ Scheme }}</b> scheme. Please build and install a compatible <b>Development Build</b> to continue.' +
+      '<br><a href="https://docs.expo.dev/development/build/">Learn more.</a>';
+    }
+
+    alertElement.style.display = "block";
+  }
+
+  const hideAlert = () => {
+    alertElement.style.display = "none";
+  }
+
   function findGetParameter(parameterName) {
     let result = null;
 
@@ -257,11 +292,69 @@
     return result;
   }
 
+  function tryToDetectDeepLinkFailure(isExpoGo) {
+    const waitForRedirect = 800;
+    let didHide = false;
+    let didLoseFocuse = false;
+
+    const onVisibilitychange = (e) => { 
+      if (e.target.visibilityState === 'hidden') {
+        didHide = true;
+        hideAlert();
+      }
+    };
+
+    const clearOnFocus = () => {
+      hideAlert();
+      window.removeEventListener('focus', clearOnFocus);
+    };
+
+    const showErrorOnFocus = () => {
+      window.removeEventListener('focus', showErrorOnFocus);
+
+      setTimeout(() => {
+        window.addEventListener('focus', clearOnFocus);
+
+        if (!didHide) {
+          showAlert(isExpoGo);
+        }
+      }, waitForRedirect);
+    }
+
+    const onBlur = () => {
+      didLoseFocuse = true;
+      window.removeEventListener('blur', onBlur);
+      window.addEventListener('focus', showErrorOnFocus);
+    };
+
+    window.addEventListener('blur', onBlur);
+    document.addEventListener("visibilitychange", onVisibilitychange);
+    setTimeout(() => {
+      // A modal was shown. So we need to wait for a user input.
+      if (didLoseFocuse) {
+        return;
+      }
+
+      window.addEventListener('focus', clearOnFocus);
+      document.removeEventListener("visibilitychange", onVisibilitychange);
+
+      // deeplink seems to be working
+      if (didHide) {
+        return;
+      }
+
+      showAlert(isExpoGo);
+    }, waitForRedirect);
+  }
+
+  const devClientLink = document.getElementById("expo-dev-client-link");
+  const goLink = document.getElementById("expo-go-link");
+
+  devClientLink.onclick = () => tryToDetectDeepLinkFailure(false);
+  goLink.onclick = () => tryToDetectDeepLinkFailure(true);
+
   const platform = findGetParameter("platform");
   if (platform) {
-    const devClientLink = document.getElementById("expo-dev-client-link");
-    const goLink = document.getElementById("expo-go-link");
-
     devClientLink.href += "&platform=" + encodeURIComponent(platform);
     goLink.href += "&platform=" + encodeURIComponent(platform);
   }


### PR DESCRIPTION
# Why

third step of ENG-6120 -- ports most of https://github.com/expo/expo-cli/commit/e901f5e0b0d08903a9f112945d2c5c3ad29211d9 to new CLI

# How

- Add user-agent parsing to deduce the platform in cases where it isn't provided (i.e. when the user has opened the interstitial page via QR code)
- Allow platform to be optional in `getLoadingUrl`
- Show a QR code for the interstitial page when it's enabled (but still print the native runtime URL)
- Don't restrict iOS interstitial page URL to localhost

# Test Plan

Added unit tests for all new functionality. Also tested manually to ensure parity with the old CLI:
- `EXPO_ENABLE_INTERSTITIAL_PAGE=1 npx expo start` + scan QR code -> see interstitial page
- both buttons on interstitial page work
- `EXPO_ENABLE_INTERSTITIAL_PAGE=1 npx expo start --dev-client` + scan QR code -> opens in dev client
- remove expo-dev-client from project, `EXPO_ENABLE_INTERSTITIAL_PAGE=1 npx expo start` + scan QR code -> opens in Expo Go

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
