### PR TITLE
[cli] try to detect if deep link was successful

### DIFF
--- a/docs/pages/workflow/expo-cli.md
+++ b/docs/pages/workflow/expo-cli.md
@@ -283,7 +283,7 @@ From here, you can choose to generate basic project files like:
 - `CI` (**boolean**) when enabled, the CLI will disable interactive functionality, skip optional prompts, and fail on non-optional prompts. Example: `CI=1 npx expo install --check` will fail if any installed packages are outdated.
 - `EXPO_NO_TELEMETRY` (**boolean**) disables anonymous usage collection.
 - `EXPO_NO_GIT_STATUS` (**boolean**) skips warning about git status during potentially dangerous actions like `npx expo prebuild --clean`.
-- `EXPO_ENABLE_INTERSTITIAL_PAGE` (**boolean**) enables the experimental "interstitial page" for selecting an app, that shows when a user has `expo-dev-client` installed, and starts the project with `expo start` instead of `expo start --dev-client`.
+- `EXPO_NO_REDIRECT_PAGE` (**boolean**) disables the redirect page for selecting an app, that shows when a user has `expo-dev-client` installed, and starts the project with `npx expo start` instead of `npx expo start --dev-client`.
 - `EXPO_PUBLIC_FOLDER` (**string**) public folder path to use with Metro for web. Default: `public`. [Learn more](/guides/customizing-metro/).
 - `EDITOR` (**string**) name of the editor to open when pressing `o` in the Terminal UI. This value is used across many command line tools.
 - `EXPO_EDITOR` (**string**) an Expo-specific version of the `EDITOR` variable which takes higher priority when defined.

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -28,6 +28,7 @@
 - [Interstitial page] Capture missing analytics event when user opens development build. ([#18792](https://github.com/expo/expo/pull/18792) by [@esamelson](https://github.com/esamelson))
 - [Interstitial page] Ensure that the development build is installed when opening the interstitial page. ([#18836](https://github.com/expo/expo/pull/18836) by [@esamelson](https://github.com/esamelson))
 - [Interstitial page] Point QR code to interstitial page when enabled. ([#18838](https://github.com/expo/expo/pull/18838) by [@esamelson](https://github.com/esamelson))
+- [Interstitial page] Minor improvements to page; try to detect if deep link succeeded. ([#18839](https://github.com/expo/expo/pull/18839) by [@esamelson](https://github.com/esamelson))
 
 ## 0.2.6 — 2022-07-25
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -29,6 +29,7 @@
 - [Interstitial page] Ensure that the development build is installed when opening the interstitial page. ([#18836](https://github.com/expo/expo/pull/18836) by [@esamelson](https://github.com/esamelson))
 - [Interstitial page] Point QR code to interstitial page when enabled. ([#18838](https://github.com/expo/expo/pull/18838) by [@esamelson](https://github.com/esamelson))
 - [Interstitial page] Minor improvements to page; try to detect if deep link succeeded. ([#18839](https://github.com/expo/expo/pull/18839) by [@esamelson](https://github.com/esamelson))
+- [Interstitial page] Flip value and change name of env flag to EXPO_NO_REDIRECT_PAGE. ([#18840](https://github.com/expo/expo/pull/18840) by [@esamelson](https://github.com/esamelson))
 
 ## 0.2.6 — 2022-07-25
 

--- a/packages/@expo/cli/src/start/server/BundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/BundlerDevServer.ts
@@ -407,7 +407,7 @@ export abstract class BundlerDevServer {
   /** Should use the interstitial page for selecting which runtime to use. */
   protected isRedirectPageEnabled(): boolean {
     return (
-      env.EXPO_ENABLE_INTERSTITIAL_PAGE &&
+      !env.EXPO_NO_REDIRECT_PAGE &&
       // if user passed --dev-client flag, skip interstitial page
       !this.isDevClient &&
       // Checks if dev client is installed.

--- a/packages/@expo/cli/src/start/server/__tests__/BundlerDevServer-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/BundlerDevServer-test.ts
@@ -35,7 +35,7 @@ const originalEnv = process.env;
 
 beforeEach(() => {
   vol.reset();
-  delete process.env.EXPO_ENABLE_INTERSTITIAL_PAGE;
+  delete process.env.EXPO_NO_REDIRECT_PAGE;
 });
 
 afterAll(() => {
@@ -172,7 +172,7 @@ describe('stopAsync', () => {
 describe('isRedirectPageEnabled', () => {
   beforeEach(() => {
     vol.reset();
-    delete process.env.EXPO_ENABLE_INTERSTITIAL_PAGE;
+    delete process.env.EXPO_NO_REDIRECT_PAGE;
   });
 
   function mockDevClientInstalled() {
@@ -187,8 +187,6 @@ describe('isRedirectPageEnabled', () => {
   it(`is redirect enabled`, async () => {
     mockDevClientInstalled();
 
-    process.env.EXPO_ENABLE_INTERSTITIAL_PAGE = '1';
-
     const server = new MockBundlerDevServer(
       '/',
       getPlatformBundlers({}),
@@ -201,7 +199,7 @@ describe('isRedirectPageEnabled', () => {
   it(`redirect can be disabled with env var`, async () => {
     mockDevClientInstalled();
 
-    process.env.EXPO_ENABLE_INTERSTITIAL_PAGE = '0';
+    process.env.EXPO_NO_REDIRECT_PAGE = '1';
 
     const server = new MockBundlerDevServer(
       '/',
@@ -215,8 +213,6 @@ describe('isRedirectPageEnabled', () => {
   it(`redirect is disabled when running in dev client mode`, async () => {
     mockDevClientInstalled();
 
-    process.env.EXPO_ENABLE_INTERSTITIAL_PAGE = '1';
-
     const server = new MockBundlerDevServer(
       '/',
       getPlatformBundlers({}),
@@ -227,8 +223,6 @@ describe('isRedirectPageEnabled', () => {
   });
 
   it(`redirect is disabled when expo-dev-client is not installed in the project`, async () => {
-    process.env.EXPO_ENABLE_INTERSTITIAL_PAGE = '1';
-
     const server = new MockBundlerDevServer(
       '/',
       getPlatformBundlers({}),

--- a/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
@@ -71,7 +71,9 @@ export class MetroBundlerDevServer extends BundlerDevServer {
     prependMiddleware(middleware, manifestMiddleware);
 
     middleware.use(
-      new InterstitialPageMiddleware(this.projectRoot, options.location.scheme).getHandler()
+      new InterstitialPageMiddleware(this.projectRoot, {
+        scheme: options.location.scheme ?? null,
+      }).getHandler()
     );
 
     const deepLinkMiddleware = new RuntimeRedirectMiddleware(this.projectRoot, {

--- a/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
@@ -70,7 +70,9 @@ export class MetroBundlerDevServer extends BundlerDevServer {
     // https://github.com/expo/expo/issues/13114
     prependMiddleware(middleware, manifestMiddleware);
 
-    middleware.use(new InterstitialPageMiddleware(this.projectRoot).getHandler());
+    middleware.use(
+      new InterstitialPageMiddleware(this.projectRoot, options.location.scheme).getHandler()
+    );
 
     const deepLinkMiddleware = new RuntimeRedirectMiddleware(this.projectRoot, {
       onDeepLink: getDeepLinkHandler(this.projectRoot),

--- a/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
@@ -72,6 +72,7 @@ export class MetroBundlerDevServer extends BundlerDevServer {
 
     middleware.use(
       new InterstitialPageMiddleware(this.projectRoot, {
+        // TODO: Prevent this from becoming stale.
         scheme: options.location.scheme ?? null,
       }).getHandler()
     );

--- a/packages/@expo/cli/src/start/server/middleware/InterstitialPageMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/InterstitialPageMiddleware.ts
@@ -1,5 +1,5 @@
-import { ExpoConfig, getConfig, getNameFromConfig } from '@expo/config';
-import { getRuntimeVersionNullable } from '@expo/config-plugins/build/utils/Updates';
+import { getConfig, getNameFromConfig } from '@expo/config';
+import { getRuntimeVersionNullable, getSDKVersion } from '@expo/config-plugins/build/utils/Updates';
 import { readFile } from 'fs/promises';
 import path from 'path';
 import resolveFrom from 'resolve-from';
@@ -20,26 +20,23 @@ const debug = require('debug')(
 
 export const LoadingEndpoint = '/_expo/loading';
 
-function getRuntimeVersion(exp: ExpoConfig, platform: 'android' | 'ios' | null): string {
-  if (!platform) {
-    return 'Undetected';
-  }
-
-  return getRuntimeVersionNullable(exp, platform) ?? 'Undetected';
-}
-
 export class InterstitialPageMiddleware extends ExpoMiddleware {
-  constructor(projectRoot: string) {
+  private scheme: string | null;
+
+  constructor(projectRoot: string, scheme?: string | null) {
     super(projectRoot, [LoadingEndpoint]);
+    this.scheme = scheme ?? null;
   }
 
   /** Get the template HTML page and inject values. */
   async _getPageAsync({
     appName,
     runtimeVersion,
+    sdkVersion,
   }: {
     appName: string;
     runtimeVersion: string | null;
+    sdkVersion: string | null;
   }): Promise<string> {
     const templatePath =
       // Production: This will resolve when installed in the project.
@@ -49,8 +46,16 @@ export class InterstitialPageMiddleware extends ExpoMiddleware {
     let content = (await readFile(templatePath)).toString('utf-8');
 
     content = content.replace(/{{\s*AppName\s*}}/, appName);
-    content = content.replace(/{{\s*RuntimeVersion\s*}}/, runtimeVersion ?? '');
     content = content.replace(/{{\s*Path\s*}}/, this.projectRoot);
+    content = content.replace(/{{\s*Scheme\s*}}/, this.scheme ?? 'Unknown');
+
+    if (!runtimeVersion && sdkVersion) {
+      content = content.replace(/{{\s*ProjectVersionType\s*}}/, 'SDK version');
+      content = content.replace(/{{\s*ProjectVersion\s*}}/, sdkVersion);
+    } else {
+      content = content.replace(/{{\s*ProjectVersionType\s*}}/, 'Runtime version');
+      content = content.replace(/{{\s*ProjectVersion\s*}}/, runtimeVersion ?? 'Undetected');
+    }
 
     return content;
   }
@@ -59,16 +64,19 @@ export class InterstitialPageMiddleware extends ExpoMiddleware {
   _getProjectOptions(platform: RuntimePlatform): {
     appName: string;
     runtimeVersion: string | null;
+    sdkVersion: string | null;
   } {
     assertRuntimePlatform(platform);
 
     const { exp } = getConfig(this.projectRoot);
     const { appName } = getNameFromConfig(exp);
-    const runtimeVersion = getRuntimeVersion(exp, platform);
+    const runtimeVersion = getRuntimeVersionNullable(exp, platform);
+    const sdkVersion = getSDKVersion(exp);
 
     return {
       appName: appName ?? 'App',
       runtimeVersion,
+      sdkVersion,
     };
   }
 
@@ -80,11 +88,11 @@ export class InterstitialPageMiddleware extends ExpoMiddleware {
     assertMissingRuntimePlatform(platform);
     assertRuntimePlatform(platform);
 
-    const { appName, runtimeVersion } = this._getProjectOptions(platform);
+    const { appName, runtimeVersion, sdkVersion } = this._getProjectOptions(platform);
     debug(
       `Create loading page. (platform: ${platform}, appName: ${appName}, runtimeVersion: ${runtimeVersion})`
     );
-    const content = await this._getPageAsync({ appName, runtimeVersion });
+    const content = await this._getPageAsync({ appName, runtimeVersion, sdkVersion });
     res.end(content);
   }
 }

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/InterstitialPageMiddleware-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/InterstitialPageMiddleware-test.ts
@@ -1,5 +1,5 @@
 import { getConfig, getNameFromConfig } from '@expo/config';
-import { getRuntimeVersionNullable, getSDKVersion } from '@expo/config-plugins/build/utils/Updates';
+import { getRuntimeVersionNullable } from '@expo/config-plugins/build/utils/Updates';
 import { vol } from 'memfs';
 
 import { asMock } from '../../../../__tests__/asMock';
@@ -20,7 +20,6 @@ jest.mock('@expo/config', () => ({
 }));
 jest.mock('@expo/config-plugins/build/utils/Updates', () => ({
   getRuntimeVersionNullable: jest.fn(),
-  getSDKVersion: jest.fn(() => '45.0.0'),
 }));
 
 const asReq = (req: Partial<ServerRequest>) => req as ServerRequest;
@@ -65,21 +64,41 @@ describe('_getProjectOptions', () => {
     const middleware = new InterstitialPageMiddleware('/');
 
     expect(middleware._getProjectOptions('ios')).toEqual({
-      runtimeVersion: '123',
       appName: 'my-app',
-      sdkVersion: '45.0.0',
+      projectVersion: {
+        type: 'runtime',
+        version: '123',
+      },
     });
     expect(getConfig).toBeCalled();
     expect(getRuntimeVersionNullable).toBeCalledWith(
       { name: 'my-app', sdkVersion: '45.0.0', slug: 'my-app' },
       'ios'
     );
-    expect(getSDKVersion).toBeCalledWith({ name: 'my-app', sdkVersion: '45.0.0', slug: 'my-app' });
+  });
+  it('returns the project settings from the config with SDK version', async () => {
+    asMock(getNameFromConfig).mockReturnValueOnce({ appName: 'my-app' });
+    asMock(getRuntimeVersionNullable).mockReturnValueOnce(null);
+
+    const middleware = new InterstitialPageMiddleware('/');
+
+    expect(middleware._getProjectOptions('ios')).toEqual({
+      appName: 'my-app',
+      projectVersion: {
+        type: 'sdk',
+        version: '45.0.0',
+      },
+    });
+    expect(getConfig).toBeCalled();
+    expect(getRuntimeVersionNullable).toBeCalledWith(
+      { name: 'my-app', sdkVersion: '45.0.0', slug: 'my-app' },
+      'ios'
+    );
   });
 });
 
 describe('_getPageAsync', () => {
-  it('returns the static HTML with templates filled in for runtime version', async () => {
+  it('returns the static HTML with templates filled in', async () => {
     const projectRoot = '/';
     vol.fromJSON(
       {
@@ -93,48 +112,32 @@ describe('_getPageAsync', () => {
     await expect(
       middleware._getPageAsync({
         appName: 'App',
-        runtimeVersion: '123',
-        sdkVersion: '45.0.0',
+        projectVersion: {
+          type: 'runtime',
+          version: '123',
+        },
       })
     ).resolves.toEqual('AppName: "App", Runtime version "123", Path: /, Scheme: "Unknown"');
-  });
-
-  it('returns the static HTML with templates filled in for SDK version', async () => {
-    const projectRoot = '/';
-    vol.fromJSON(
-      {
-        'node_modules/expo/static/loading-page/index.html':
-          'AppName: "{{ AppName }}", {{ ProjectVersionType }} "{{ ProjectVersion }}", Path: {{ Path }}, Scheme: "{{ Scheme }}"',
-      },
-      projectRoot
-    );
-
-    const middleware = new InterstitialPageMiddleware(projectRoot);
     await expect(
       middleware._getPageAsync({
         appName: 'App',
-        runtimeVersion: null,
-        sdkVersion: '45.0.0',
+        projectVersion: {
+          type: 'sdk',
+          version: '45.0.0',
+        },
       })
     ).resolves.toEqual('AppName: "App", SDK version "45.0.0", Path: /, Scheme: "Unknown"');
-  });
 
-  it('returns the static HTML with templates filled in for scheme', async () => {
-    const projectRoot = '/';
-    vol.fromJSON(
-      {
-        'node_modules/expo/static/loading-page/index.html':
-          'AppName: "{{ AppName }}", {{ ProjectVersionType }} "{{ ProjectVersion }}", Path: {{ Path }}, Scheme: "{{ Scheme }}"',
-      },
-      projectRoot
-    );
-
-    const middleware = new InterstitialPageMiddleware(projectRoot, 'testscheme');
+    const middlewareWithScheme = new InterstitialPageMiddleware(projectRoot, {
+      scheme: 'testscheme',
+    });
     await expect(
-      middleware._getPageAsync({
+      middlewareWithScheme._getPageAsync({
         appName: 'App',
-        runtimeVersion: '123',
-        sdkVersion: '45.0.0',
+        projectVersion: {
+          type: 'runtime',
+          version: '123',
+        },
       })
     ).resolves.toEqual('AppName: "App", Runtime version "123", Path: /, Scheme: "testscheme"');
   });
@@ -145,9 +148,11 @@ describe('handleRequestAsync', () => {
     const middleware = new InterstitialPageMiddleware('/');
 
     middleware._getProjectOptions = jest.fn(() => ({
-      runtimeVersion: '123',
       appName: 'App',
-      sdkVersion: '45.0.0',
+      projectVersion: {
+        type: 'runtime',
+        version: '123',
+      },
     }));
 
     middleware._getPageAsync = jest.fn(async () => 'mock-value');
@@ -178,9 +183,11 @@ describe('handleRequestAsync', () => {
     const middleware = new InterstitialPageMiddleware('/');
 
     middleware._getProjectOptions = jest.fn(() => ({
-      runtimeVersion: '123',
       appName: 'App',
-      sdkVersion: '45.0.0',
+      projectVersion: {
+        type: 'runtime',
+        version: '123',
+      },
     }));
 
     middleware._getPageAsync = jest.fn(async () => 'mock-value');

--- a/packages/@expo/cli/src/utils/env.ts
+++ b/packages/@expo/cli/src/utils/env.ts
@@ -66,9 +66,9 @@ class Env {
   get EXPO_NO_CACHE() {
     return boolish('EXPO_NO_CACHE', false);
   }
-  /** Enable the experimental interstitial app select page. */
-  get EXPO_ENABLE_INTERSTITIAL_PAGE() {
-    return boolish('EXPO_ENABLE_INTERSTITIAL_PAGE', false);
+  /** Disable the app select redirect page. */
+  get EXPO_NO_REDIRECT_PAGE() {
+    return boolish('EXPO_NO_REDIRECT_PAGE', false);
   }
   /** The React Metro port that's baked into react-native scripts and tools. */
   get RCT_METRO_PORT() {

--- a/packages/@expo/cli/static/loading-page/index.html
+++ b/packages/@expo/cli/static/loading-page/index.html
@@ -185,10 +185,27 @@
       color: var(--secondary-text-color);
     }
 
+    #alert {
+      background-color: #fff;
+      color: var(--secondary-text-color);
+
+      padding-top: 20px;
+      padding-bottom: 20px;
+      padding-left: 10px;
+      padding-right: 10px;
+
+      text-align: center;
+      font-size: 16px;
+      letter-spacing: -0.0001em;
+      line-height: 150%;
+
+      display: none;
+    }
   </style>
   <title>Expo Start | Loading Page</title>
 </head>
 <body>
+  <div id="alert"></div>
   <div class="logo-box">
     <div class="logo-background-box">
 
@@ -216,8 +233,8 @@
       <div class="info-box-details">
         <p class="info-box-app-name">{{ AppName }}</p>
         <div class="info-box-details-record">
-          <p>Runtime version</p>
-          <p>{{ RuntimeVersion }}</p>
+          <p>{{ ProjectVersionType }}</p>
+          <p>{{ ProjectVersion }}</p>
         </div>
         <!-- <div class="info-box-details-record">
           <p>Branch</p>
@@ -239,11 +256,29 @@
     <p class="bottom-bar-header">
       How would you like to open this project?
     </p>
-    <a id="expo-dev-client-link" href="/_expo/link?choice=expo-dev-client" class="bottom-bar-button bottom-bar-button-dark">Development App</a>
+    <a id="expo-dev-client-link" href="/_expo/link?choice=expo-dev-client" class="bottom-bar-button bottom-bar-button-dark">Development Build</a>
     <a id="expo-go-link" href="/_expo/link?choice=expo-go" class="bottom-bar-button bottom-bar-button-grey">Expo Go</a>
   </div>
   
   <script>
+  const alertElement = document.getElementById("alert");
+
+  const showAlert = (isExpoGo) => {
+    if (isExpoGo) {
+      alertElement.innerHTML = 'Unable to open in Expo Go. Please install <b>Expo Go</b> to continue.' +
+      '<br><a href="https://expo.dev/client">Learn more.</a>';
+    } else {
+      alertElement.innerHTML = 'Unable to open in Development Build with the <b>{{ Scheme }}</b> scheme. Please build and install a compatible <b>Development Build</b> to continue.' +
+      '<br><a href="https://docs.expo.dev/development/build/">Learn more.</a>';
+    }
+
+    alertElement.style.display = "block";
+  }
+
+  const hideAlert = () => {
+    alertElement.style.display = "none";
+  }
+
   function findGetParameter(parameterName) {
     let result = null;
 
@@ -257,11 +292,69 @@
     return result;
   }
 
+  function tryToDetectDeepLinkFailure(isExpoGo) {
+    const waitForRedirect = 800;
+    let didHide = false;
+    let didLoseFocuse = false;
+
+    const onVisibilitychange = (e) => { 
+      if (e.target.visibilityState === 'hidden') {
+        didHide = true;
+        hideAlert();
+      }
+    };
+
+    const clearOnFocus = () => {
+      hideAlert();
+      window.removeEventListener('focus', clearOnFocus);
+    };
+
+    const showErrorOnFocus = () => {
+      window.removeEventListener('focus', showErrorOnFocus);
+
+      setTimeout(() => {
+        window.addEventListener('focus', clearOnFocus);
+
+        if (!didHide) {
+          showAlert(isExpoGo);
+        }
+      }, waitForRedirect);
+    }
+
+    const onBlur = () => {
+      didLoseFocuse = true;
+      window.removeEventListener('blur', onBlur);
+      window.addEventListener('focus', showErrorOnFocus);
+    };
+
+    window.addEventListener('blur', onBlur);
+    document.addEventListener("visibilitychange", onVisibilitychange);
+    setTimeout(() => {
+      // A modal was shown. So we need to wait for a user input.
+      if (didLoseFocuse) {
+        return;
+      }
+
+      window.addEventListener('focus', clearOnFocus);
+      document.removeEventListener("visibilitychange", onVisibilitychange);
+
+      // deeplink seems to be working
+      if (didHide) {
+        return;
+      }
+
+      showAlert(isExpoGo);
+    }, waitForRedirect);
+  }
+
+  const devClientLink = document.getElementById("expo-dev-client-link");
+  const goLink = document.getElementById("expo-go-link");
+
+  devClientLink.onclick = () => tryToDetectDeepLinkFailure(false);
+  goLink.onclick = () => tryToDetectDeepLinkFailure(true);
+
   const platform = findGetParameter("platform");
   if (platform) {
-    const devClientLink = document.getElementById("expo-dev-client-link");
-    const goLink = document.getElementById("expo-go-link");
-
     devClientLink.href += "&platform=" + encodeURIComponent(platform);
     goLink.href += "&platform=" + encodeURIComponent(platform);
   }


### PR DESCRIPTION
# Why

fourth step of ENG-6120; ports https://github.com/expo/expo-cli/commit/9777ad69353723215730f608c1c5ab909c786ebb and the relevant portions of https://github.com/expo/expo-cli/commit/b5c59a7910af01b9b239c385de739aabd87e0748 to the new CLI

# How

- Copied HTML changes to this repo and resolved conflicts
- Pull scheme and SDK version into InterstitialPageHandler, and replace the relevant strings in HTML

# Test Plan

Added unit tests for all new functionality and updated existing tests. Tested manually to ensure the page looks as expected (parity with old CLI).

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
