### PR TITLE
[cli] remove EXPO_ENABLE_INTERSTITIAL_PAGE feature flag

### DIFF
--- a/docs/pages/workflow/expo-cli.md
+++ b/docs/pages/workflow/expo-cli.md
@@ -283,7 +283,7 @@ From here, you can choose to generate basic project files like:
 - `CI` (**boolean**) when enabled, the CLI will disable interactive functionality, skip optional prompts, and fail on non-optional prompts. Example: `CI=1 npx expo install --check` will fail if any installed packages are outdated.
 - `EXPO_NO_TELEMETRY` (**boolean**) disables anonymous usage collection.
 - `EXPO_NO_GIT_STATUS` (**boolean**) skips warning about git status during potentially dangerous actions like `npx expo prebuild --clean`.
-- `EXPO_ENABLE_INTERSTITIAL_PAGE` (**boolean**) enables the experimental "interstitial page" for selecting an app, that shows when a user has `expo-dev-client` installed, and starts the project with `expo start` instead of `expo start --dev-client`.
+- `EXPO_NO_REDIRECT_PAGE` (**boolean**) disables the redirect page for selecting an app, that shows when a user has `expo-dev-client` installed, and starts the project with `expo start` instead of `expo start --dev-client`.
 - `EXPO_PUBLIC_FOLDER` (**string**) public folder path to use with Metro for web. Default: `public`. [Learn more](/guides/customizing-metro/).
 - `EDITOR` (**string**) name of the editor to open when pressing `o` in the Terminal UI. This value is used across many command line tools.
 - `EXPO_EDITOR` (**string**) an Expo-specific version of the `EDITOR` variable which takes higher priority when defined.

--- a/docs/pages/workflow/expo-cli.md
+++ b/docs/pages/workflow/expo-cli.md
@@ -283,7 +283,7 @@ From here, you can choose to generate basic project files like:
 - `CI` (**boolean**) when enabled, the CLI will disable interactive functionality, skip optional prompts, and fail on non-optional prompts. Example: `CI=1 npx expo install --check` will fail if any installed packages are outdated.
 - `EXPO_NO_TELEMETRY` (**boolean**) disables anonymous usage collection.
 - `EXPO_NO_GIT_STATUS` (**boolean**) skips warning about git status during potentially dangerous actions like `npx expo prebuild --clean`.
-- `EXPO_NO_REDIRECT_PAGE` (**boolean**) disables the redirect page for selecting an app, that shows when a user has `expo-dev-client` installed, and starts the project with `expo start` instead of `expo start --dev-client`.
+- `EXPO_NO_REDIRECT_PAGE` (**boolean**) disables the redirect page for selecting an app, that shows when a user has `expo-dev-client` installed, and starts the project with `npx expo start` instead of `npx expo start --dev-client`.
 - `EXPO_PUBLIC_FOLDER` (**string**) public folder path to use with Metro for web. Default: `public`. [Learn more](/guides/customizing-metro/).
 - `EDITOR` (**string**) name of the editor to open when pressing `o` in the Terminal UI. This value is used across many command line tools.
 - `EXPO_EDITOR` (**string**) an Expo-specific version of the `EDITOR` variable which takes higher priority when defined.

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -29,6 +29,7 @@
 - [Interstitial page] Ensure that the development build is installed when opening the interstitial page. ([#18836](https://github.com/expo/expo/pull/18836) by [@esamelson](https://github.com/esamelson))
 - [Interstitial page] Point QR code to interstitial page when enabled. ([#18838](https://github.com/expo/expo/pull/18838) by [@esamelson](https://github.com/esamelson))
 - [Interstitial page] Minor improvements to page; try to detect if deep link succeeded. ([#18839](https://github.com/expo/expo/pull/18839) by [@esamelson](https://github.com/esamelson))
+- [Interstitial page] Flip value and change name of env flag to EXPO_NO_REDIRECT_PAGE. ([#18840](https://github.com/expo/expo/pull/18840) by [@esamelson](https://github.com/esamelson))
 
 ## 0.2.6 — 2022-07-25
 

--- a/packages/@expo/cli/src/start/server/BundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/BundlerDevServer.ts
@@ -407,7 +407,7 @@ export abstract class BundlerDevServer {
   /** Should use the interstitial page for selecting which runtime to use. */
   protected isRedirectPageEnabled(): boolean {
     return (
-      env.EXPO_ENABLE_INTERSTITIAL_PAGE &&
+      !env.EXPO_NO_REDIRECT_PAGE &&
       // if user passed --dev-client flag, skip interstitial page
       !this.isDevClient &&
       // Checks if dev client is installed.

--- a/packages/@expo/cli/src/start/server/__tests__/BundlerDevServer-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/BundlerDevServer-test.ts
@@ -35,7 +35,7 @@ const originalEnv = process.env;
 
 beforeEach(() => {
   vol.reset();
-  delete process.env.EXPO_ENABLE_INTERSTITIAL_PAGE;
+  delete process.env.EXPO_NO_REDIRECT_PAGE;
 });
 
 afterAll(() => {
@@ -172,7 +172,7 @@ describe('stopAsync', () => {
 describe('isRedirectPageEnabled', () => {
   beforeEach(() => {
     vol.reset();
-    delete process.env.EXPO_ENABLE_INTERSTITIAL_PAGE;
+    delete process.env.EXPO_NO_REDIRECT_PAGE;
   });
 
   function mockDevClientInstalled() {
@@ -187,8 +187,6 @@ describe('isRedirectPageEnabled', () => {
   it(`is redirect enabled`, async () => {
     mockDevClientInstalled();
 
-    process.env.EXPO_ENABLE_INTERSTITIAL_PAGE = '1';
-
     const server = new MockBundlerDevServer(
       '/',
       getPlatformBundlers({}),
@@ -201,7 +199,7 @@ describe('isRedirectPageEnabled', () => {
   it(`redirect can be disabled with env var`, async () => {
     mockDevClientInstalled();
 
-    process.env.EXPO_ENABLE_INTERSTITIAL_PAGE = '0';
+    process.env.EXPO_NO_REDIRECT_PAGE = '1';
 
     const server = new MockBundlerDevServer(
       '/',
@@ -215,8 +213,6 @@ describe('isRedirectPageEnabled', () => {
   it(`redirect is disabled when running in dev client mode`, async () => {
     mockDevClientInstalled();
 
-    process.env.EXPO_ENABLE_INTERSTITIAL_PAGE = '1';
-
     const server = new MockBundlerDevServer(
       '/',
       getPlatformBundlers({}),
@@ -227,8 +223,6 @@ describe('isRedirectPageEnabled', () => {
   });
 
   it(`redirect is disabled when expo-dev-client is not installed in the project`, async () => {
-    process.env.EXPO_ENABLE_INTERSTITIAL_PAGE = '1';
-
     const server = new MockBundlerDevServer(
       '/',
       getPlatformBundlers({}),

--- a/packages/@expo/cli/src/utils/env.ts
+++ b/packages/@expo/cli/src/utils/env.ts
@@ -66,9 +66,9 @@ class Env {
   get EXPO_NO_CACHE() {
     return boolish('EXPO_NO_CACHE', false);
   }
-  /** Enable the experimental interstitial app select page. */
-  get EXPO_ENABLE_INTERSTITIAL_PAGE() {
-    return boolish('EXPO_ENABLE_INTERSTITIAL_PAGE', false);
+  /** Disable the app select redirect page. */
+  get EXPO_NO_REDIRECT_PAGE() {
+    return boolish('EXPO_NO_REDIRECT_PAGE', false);
   }
   /** The React Metro port that's baked into react-native scripts and tools. */
   get RCT_METRO_PORT() {


### PR DESCRIPTION
# Why

resolves ENG-6120; ports https://github.com/expo/expo-cli/commit/fbccd3fa5d8c13cd2188c71238309e17a8359e72 to new CLI

# How

- remove env var and grep for all places it's used

# Test Plan

All unit tests still pass

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
