### PR TITLE
[core][Android] Improve the creation of the `NativeModulesProxy`

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/ModuleRegistryAdapter.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/ModuleRegistryAdapter.java
@@ -113,8 +113,10 @@ public class ModuleRegistryAdapter implements ReactPackage {
     return viewManagerList;
   }
 
-  private synchronized NativeModulesProxy getOrCreateNativeModulesProxy(ReactApplicationContext reactContext,
-                                                           @Nullable ModuleRegistry moduleRegistry) {
+  private synchronized NativeModulesProxy getOrCreateNativeModulesProxy(
+    ReactApplicationContext reactContext,
+    @Nullable ModuleRegistry moduleRegistry
+  ) {
     if (mModulesProxy == null) {
       ModuleRegistry registry = moduleRegistry != null ? moduleRegistry : mModuleRegistryProvider.get(reactContext);
       if (mModulesProvider != null) {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/ModuleRegistryAdapter.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/ModuleRegistryAdapter.java
@@ -113,7 +113,7 @@ public class ModuleRegistryAdapter implements ReactPackage {
     return viewManagerList;
   }
 
-  private NativeModulesProxy getOrCreateNativeModulesProxy(ReactApplicationContext reactContext,
+  private synchronized NativeModulesProxy getOrCreateNativeModulesProxy(ReactApplicationContext reactContext,
                                                            @Nullable ModuleRegistry moduleRegistry) {
     if (mModulesProxy == null) {
       ModuleRegistry registry = moduleRegistry != null ? moduleRegistry : mModuleRegistryProvider.get(reactContext);

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/ModuleRegistryAdapter.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/ModuleRegistryAdapter.java
@@ -1,5 +1,6 @@
 package expo.modules.adapters.react;
 
+import android.util.Log;
 import androidx.annotation.Nullable;
 
 import com.facebook.react.ReactPackage;
@@ -50,7 +51,8 @@ public class ModuleRegistryAdapter implements ReactPackage {
 
   @Override
   public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
-    ModuleRegistry moduleRegistry = mModuleRegistryProvider.get(reactContext);
+    NativeModulesProxy proxy = getOrCreateNativeModulesProxy(reactContext, null);
+    ModuleRegistry moduleRegistry = proxy.getModuleRegistry();
 
     for (InternalModule internalModule : mReactAdapterPackage.createInternalModules(reactContext)) {
       moduleRegistry.registerInternalModule(internalModule);
@@ -58,7 +60,7 @@ public class ModuleRegistryAdapter implements ReactPackage {
 
     List<NativeModule> nativeModules = getNativeModulesFromModuleRegistry(reactContext, moduleRegistry);
     if (mWrapperDelegateHolders != null) {
-      KotlinInteropModuleRegistry kotlinInteropModuleRegistry = getOrCreateNativeModulesProxy(reactContext, null).getKotlinInteropModuleRegistry();
+      KotlinInteropModuleRegistry kotlinInteropModuleRegistry = proxy.getKotlinInteropModuleRegistry();
       kotlinInteropModuleRegistry.updateModuleHoldersInViewManagers(mWrapperDelegateHolders);
     }
 
@@ -121,6 +123,11 @@ public class ModuleRegistryAdapter implements ReactPackage {
         mModulesProxy = new NativeModulesProxy(reactContext, registry);
       }
     }
+
+    if (moduleRegistry != null && moduleRegistry != mModulesProxy.getModuleRegistry()) {
+      Log.e("expo-modules-core", "NativeModuleProxy was configured with a different instance of the modules registry.");
+    }
+
     return mModulesProxy;
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/NativeModulesProxy.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/NativeModulesProxy.java
@@ -247,4 +247,8 @@ public class NativeModulesProxy extends ReactContextBaseJavaModule {
     mModuleRegistry.onDestroy();
     mKotlinInteropModuleRegistry.onDestroy();
   }
+
+  ModuleRegistry getModuleRegistry() {
+    return mModuleRegistry;
+  }
 }


### PR DESCRIPTION
# Why

A follow-up to the one fix from https://github.com/expo/expo/pull/18823.
```
a launch crash because Permission module not found. this is a regression for https://github.com/expo/expo/pull/18472 in ModuleRegistryAdapter::getNativeModulesFromModuleRegistry() where custom moduleRegistry is not be used.
```

# How

- Added a warning if the `NativeModulesProxy` was created with a different modules registry.
- Always got a module registry from the `NativeModulesProxy`.
- Added a `synchronized` keyword to the `getOrCreateNativeModulesProxy` function.

# Test Plan

- expo-go ✅
- bare-expo ✅