### PR TITLE
[docs][private-npm-packages]: Revert the updated code snippets to use protocol-less URLs

### DIFF
--- a/docs/pages/build-reference/private-npm-packages.md
+++ b/docs/pages/build-reference/private-npm-packages.md
@@ -4,7 +4,7 @@ title: Using private npm packages
 
 import ImageSpotlight from '~/components/plugins/ImageSpotlight'
 
-EAS Build comes with full support for using private npm packages in your project. These can either be published to npm (if you have [the Pro/Teams plan](https://www.npmjs.com/products)) or to a private registry (e.g. using self-hosted [verdaccio](https://verdaccio.org/)).
+EAS Build comes with full support for using private npm packages in your project. These can either be published to npm (if you have [the Pro/Teams plan](https://www.npmjs.com/products)) or to a private registry (for example, using self-hosted [verdaccio](https://verdaccio.org/)).
 
 You will need to configure your project and/or provide EAS Build with your npm token before you start the build.
 
@@ -35,11 +35,11 @@ The recommended way is to add the `NPM_TOKEN` secret to your account or project'
 When EAS detects that the `NPM_TOKEN` environment variable is available during a build, it automatically creates the following `.npmrc`:
 
 ```ini
-# registry.npmjs.org/:_authToken=${NPM_TOKEN}
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}
 registry=https://registry.npmjs.org/
 ```
 
-However, this only happens when you don't already have an `.npmrc` in your project's root directory. If you do already have this file, you need to update it manually.
+However, this only happens when you don't already have a `.npmrc` in your project's root directory. If you do already have this file, you need to update it manually.
 
 You can verify it worked by viewing build logs and looking for the `Prepare project` build phase:
 
@@ -58,7 +58,7 @@ registry=__REPLACE_WITH_REGISTRY_URL__
 If your registry requires authentication, you will also need to provide the token. Assuming your registry URL is `https://registry.johndoe.com/`:
 
 ```ini
-# registry.johndoe.com/:_authToken=${NPM_TOKEN}
+//registry.johndoe.com/:_authToken=${NPM_TOKEN}
 registry=https://registry.johndoe.com/
 ```
 
@@ -67,7 +67,7 @@ registry=https://registry.johndoe.com/
 This is an advanced example, and you will probably never use it. Private npm packages are always scoped ([see npm docs](https://docs.npmjs.com/about-scopes#scopes-and-package-visibility)). Let's assume that your npm username is `johndoe` and your private self-hosted registry URL is `https://registry.johndoe.com/`. If you want to install dependencies from both sources, create the following `.npmrc` in your project's root directory:
 
 ```ini
-# registry.npmjs.org/:_authToken=${NPM_TOKEN}
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}
 @johndoe:registry=https://registry.npmjs.org/
 registry=https://registry.johndoe.com/
 ```


### PR DESCRIPTION
# Why

Refs https://github.com/expo/expo/issues/18713

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

Fix the code snippets to use `//` by using protocol-less URLs instead of `#`. For more info on protocol-less URLs, [see this](https://docs.npmjs.com/cli/v8/configuring-npm/npmrc#auth-related-configuration).

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
