### PR TITLE
[docs][eas-json]: Update minimal production profile example

### DIFF
--- a/docs/pages/build/eas-json.md
+++ b/docs/pages/build/eas-json.md
@@ -92,14 +92,17 @@ Similar to [development builds](#development-builds), you can configure your pre
 
 These builds are submitted to an app store, for release to the general public or as part of a store-facilitated testing process such as TestFlight.
 
-Production builds must be installed through their respective app stores; they cannot be installed directly to your iOS device/simulator or Android device/emulator. The only exception to this if you explicitly set `"buildType": "apk"` for Android on your build profile; however, it is recommended to use AAB when submitting to stores, and this is the default configuration.
+Production builds must be installed through their respective app stores; they cannot be installed directly to your iOS device/simulator or Android device/emulator. The only exception to this is if you explicitly set `"buildType": "apk"` for Android on your build profile; however, it is recommended to use AAB when submitting to stores, and this is the default configuration.
 
 A minimal `production` profile looks like this:
 
 ```json
 {
   "build": {
-    "production": {}
+    "production": {
+      "distribution": "store"
+      // ...
+    }
     // ...
   }
   // ...


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Refs https://github.com/expo/expo/issues/18752

# How

<!--
How did you build this feature or fix this bug and why?
-->

By updating the minimal `production` profile to mention `"distribution": "store"`:

```json
{
  "build": {
    "production": {
      "distribution": "store"
      // ...
    }
    // ...
  }
  // ...
}
```

In the original issue, it is mentioned that that EAS Build fails for iOS when "distribution" option is not specified and set to "store".

Also fixes a minor grammar issue.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested by running `docs/` locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
