### PR TITLE
Fix compile error when compileSdkVersion is set to 33

### DIFF
--- a/packages/expo-dev-menu/vendored/react-native-gesture-handler/android/devmenu/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
+++ b/packages/expo-dev-menu/vendored/react-native-gesture-handler/android/devmenu/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
@@ -147,7 +147,7 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?)
     override val name = "PanGestureHandler"
 
     override fun create(context: Context?): PanGestureHandler {
-      return PanGestureHandler(context)
+      return PanGestureHandler(context!!)
     }
 
     override fun configure(handler: PanGestureHandler, config: ReadableMap) {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This is a partial solution to #18658 and makes expo-dev-menu compile with `compileSdkVersion` set to 33. (However, there seems to be another issue when `targetSdkVersion` is also set to 33.)

See https://github.com/expo/expo/issues/18658#issuecomment-1229146946

The issue preventing compilation is the following:

```
> Task :expo-dev-menu:compileDebugKotlin FAILED
e: node_modules/expo-dev-menu/vendored/react-native-gesture-handler/android/devmenu/com/swmansion/gesturehandler/PanGestureHandler.kt: (57, 36): 
Type mismatch: inferred type is Context? but Context was expected
```

# How

<!--
How did you build this feature or fix this bug and why?
-->

I fixed the error by adding a non-null assertion (!!) on the context.

This is in-line with the upstream implementation of `react-native-gesture-handler`: [Link to relevant line in code](https://github.com/software-mansion/react-native-gesture-handler/blob/main/android/lib/src/main/java/com/swmansion/gesturehandler/PanGestureHandler.kt#L62) / https://github.com/software-mansion/react-native-gesture-handler/pull/2096

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
I compiled my app with `compileSdkVersion` set to 33 and ensured that it works in simulator and on device.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] ~Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).~
- [ ] ~Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)~
- [ ] ~This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).~
