### PR TITLE
[modules][ios] Defer the creation of module's JS object until its first usage

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Automatically convert records to dicts when returned by the function. ([#18824](https://github.com/expo/expo/pull/18824) by [@tsapeta](https://github.com/tsapeta))
 - Closures passed to definition components are now implicitly capturing `self` on iOS. ([#18831](https://github.com/expo/expo/pull/18831) by [@tsapeta](https://github.com/tsapeta))
 - Support for CSS named colors in `UIColor` and `CGColor` convertibles on iOS. ([#18845](https://github.com/expo/expo/pull/18845) by [@tsapeta](https://github.com/tsapeta))
+- Lazy load building the module's JavaScript object from the definition on iOS (already implemented on Android). ([#18863](https://github.com/expo/expo/pull/18863) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/common/cpp/JSIUtils.cpp
+++ b/packages/expo-modules-core/common/cpp/JSIUtils.cpp
@@ -1,0 +1,20 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+#include "JSIUtils.h"
+
+namespace expo {
+
+std::vector<jsi::PropNameID> jsiArrayToPropNameIdsVector(jsi::Runtime &runtime, const jsi::Array &array) {
+  size_t size = array.size(runtime);
+  std::vector<jsi::PropNameID> vector;
+
+  vector.reserve(size);
+
+  for (size_t i = 0; i < size; i++) {
+    jsi::String name = array.getValueAtIndex(runtime, i).getString(runtime);
+    vector.push_back(jsi::PropNameID::forString(runtime, name));
+  }
+  return vector;
+}
+
+} // namespace expo

--- a/packages/expo-modules-core/common/cpp/JSIUtils.h
+++ b/packages/expo-modules-core/common/cpp/JSIUtils.h
@@ -1,0 +1,19 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+#pragma once
+#ifdef __cplusplus
+
+#include <jsi/jsi.h>
+
+namespace jsi = facebook::jsi;
+
+namespace expo {
+
+/**
+ Converts `jsi::Array` to a vector with prop name ids (`std::vector<jsi::PropNameID>`).
+ */
+std::vector<jsi::PropNameID> jsiArrayToPropNameIdsVector(jsi::Runtime &runtime, const jsi::Array &array);
+
+} // namespace expo
+
+#endif // __cplusplus

--- a/packages/expo-modules-core/common/cpp/LazyObject.cpp
+++ b/packages/expo-modules-core/common/cpp/LazyObject.cpp
@@ -1,0 +1,45 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+#include "JSIUtils.h"
+#include "LazyObject.h"
+
+namespace expo {
+
+LazyObject::LazyObject(const LazyObjectInitializer initializer) : initializer(initializer) {}
+
+LazyObject::~LazyObject() {
+  backedObject = nullptr;
+}
+
+jsi::Value LazyObject::get(jsi::Runtime &runtime, const jsi::PropNameID &name) {
+  if (!backedObject) {
+    if (name.utf8(runtime) == "$$typeof") {
+      // React Native asks for this property for some reason, we can just ignore it.
+      return jsi::Value::undefined();
+    }
+    backedObject = initializer(runtime);
+  }
+  return backedObject ? backedObject->getProperty(runtime, name) : jsi::Value::undefined();
+}
+
+void LazyObject::set(jsi::Runtime &runtime, const jsi::PropNameID &name, const jsi::Value &value) {
+  if (!backedObject) {
+    backedObject = initializer(runtime);
+  }
+  if (backedObject) {
+    backedObject->setProperty(runtime, name, value);
+  }
+}
+
+std::vector<jsi::PropNameID> LazyObject::getPropertyNames(jsi::Runtime &runtime) {
+  if (!backedObject) {
+    backedObject = initializer(runtime);
+  }
+  if (backedObject) {
+    jsi::Array propertyNames = backedObject->getPropertyNames(runtime);
+    return jsiArrayToPropNameIdsVector(runtime, propertyNames);
+  }
+  return {};
+}
+
+} // namespace expo

--- a/packages/expo-modules-core/common/cpp/LazyObject.h
+++ b/packages/expo-modules-core/common/cpp/LazyObject.h
@@ -1,0 +1,43 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+#pragma once
+
+#ifdef __cplusplus
+
+#include <jsi/jsi.h>
+
+namespace jsi = facebook::jsi;
+
+namespace expo {
+
+/**
+ A function that is responsible for initializing the backed object.
+ */
+typedef std::function<std::shared_ptr<jsi::Object>(jsi::Runtime &)> LazyObjectInitializer;
+
+/**
+ A host object that defers the creating of the raw object until any property is accessed for the first time.
+ */
+class JSI_EXPORT LazyObject : public jsi::HostObject {
+public:
+  using Shared = std::shared_ptr<LazyObject>;
+
+  LazyObject(const LazyObjectInitializer initializer);
+
+  virtual ~LazyObject();
+
+  jsi::Value get(jsi::Runtime &, const jsi::PropNameID &name) override;
+
+  void set(jsi::Runtime &, const jsi::PropNameID &name, const jsi::Value &value) override;
+
+  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime &rt) override;
+
+private:
+  const LazyObjectInitializer initializer;
+  std::shared_ptr<jsi::Object> backedObject;
+
+}; // class LazyObject
+
+} // namespace expo
+
+#endif // __cplusplus

--- a/packages/expo-modules-core/ios/JSI/EXJSIInstaller.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJSIInstaller.mm
@@ -3,6 +3,7 @@
 #import <ExpoModulesCore/EXJSIInstaller.h>
 #import <ExpoModulesCore/EXJavaScriptRuntime.h>
 #import <ExpoModulesCore/ExpoModulesHostObject.h>
+#import <ExpoModulesCore/LazyObject.h>
 #import <ExpoModulesCore/Swift.h>
 
 namespace jsi = facebook::jsi;

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptObject.h
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptObject.h
@@ -42,6 +42,11 @@ NS_SWIFT_NAME(JavaScriptObject)
  Returns the pointer to the underlying object.
  */
 - (nonnull jsi::Object *)get;
+
+/**
+ Returns the shared pointer to the underlying object.
+ */
+- (std::shared_ptr<jsi::Object>)getShared;
 #endif // __cplusplus
 
 #pragma mark - Accessing object properties

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptObject.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptObject.mm
@@ -37,6 +37,11 @@
   return _jsObjectPtr.get();
 }
 
+- (std::shared_ptr<jsi::Object>)getShared
+{
+  return _jsObjectPtr;
+}
+
 #pragma mark - Accessing object properties
 
 - (BOOL)hasProperty:(nonnull NSString *)name

--- a/packages/expo-modules-core/ios/JSI/ExpoModulesHostObject.h
+++ b/packages/expo-modules-core/ios/JSI/ExpoModulesHostObject.h
@@ -3,6 +3,7 @@
 #ifdef __cplusplus
 
 #import <vector>
+#import <unordered_map>
 #import <jsi/jsi.h>
 
 namespace jsi = facebook::jsi;
@@ -10,6 +11,8 @@ namespace jsi = facebook::jsi;
 @class EXAppContext;
 
 namespace expo {
+
+using SharedJSIObject = std::shared_ptr<jsi::Object>;
 
 class JSI_EXPORT ExpoModulesHostObject : public jsi::HostObject {
 public:
@@ -25,6 +28,7 @@ public:
 
 private:
   EXAppContext *appContext;
+  std::unordered_map<std::string, SharedJSIObject> modulesCache;
 
 }; // class ExpoModulesHostObject
 

--- a/packages/expo-modules-core/ios/JSI/ExpoModulesHostObject.h
+++ b/packages/expo-modules-core/ios/JSI/ExpoModulesHostObject.h
@@ -13,6 +13,7 @@ namespace jsi = facebook::jsi;
 namespace expo {
 
 using SharedJSIObject = std::shared_ptr<jsi::Object>;
+using UniqueJSIObject = std::unique_ptr<jsi::Object>;
 
 class JSI_EXPORT ExpoModulesHostObject : public jsi::HostObject {
 public:
@@ -28,7 +29,7 @@ public:
 
 private:
   EXAppContext *appContext;
-  std::unordered_map<std::string, SharedJSIObject> modulesCache;
+  std::unordered_map<std::string, UniqueJSIObject> modulesCache;
 
 }; // class ExpoModulesHostObject
 

--- a/packages/expo-modules-core/ios/JSI/ExpoModulesHostObject.mm
+++ b/packages/expo-modules-core/ios/JSI/ExpoModulesHostObject.mm
@@ -2,6 +2,7 @@
 
 #import <ExpoModulesCore/ExpoModulesHostObject.h>
 #import <ExpoModulesCore/EXJavaScriptObject.h>
+#import <ExpoModulesCore/LazyObject.h>
 #import <ExpoModulesCore/Swift.h>
 
 namespace expo {
@@ -9,14 +10,33 @@ namespace expo {
 ExpoModulesHostObject::ExpoModulesHostObject(EXAppContext *appContext) : appContext(appContext) {}
 
 ExpoModulesHostObject::~ExpoModulesHostObject() {
+  modulesCache.clear();
   [appContext setRuntime:nil];
 }
 
 jsi::Value ExpoModulesHostObject::get(jsi::Runtime &runtime, const jsi::PropNameID &name) {
-  NSString *moduleName = [NSString stringWithUTF8String:name.utf8(runtime).c_str()];
-  EXJavaScriptObject *nativeObject = [appContext getNativeModuleObject:moduleName];
+  std::string moduleName = name.utf8(runtime);
+  NSString *nsModuleName = [NSString stringWithUTF8String:moduleName.c_str()];
 
-  return nativeObject ? jsi::Value(runtime, *[nativeObject get]) : jsi::Value::undefined();
+  if (![appContext hasModule:nsModuleName]) {
+    // The module object can already be cached but no longer registered — we remove it from the cache in that case.
+    modulesCache.erase(moduleName);
+    return jsi::Value::undefined();
+  }
+  if (SharedJSIObject cachedObject = modulesCache[moduleName]) {
+    return jsi::Value(runtime, *cachedObject);
+  }
+
+  // Create a lazy object for the specific module. It defers initialization of the final module object.
+  LazyObject::Shared moduleLazyObject = std::make_shared<LazyObject>(^SharedJSIObject(jsi::Runtime &runtime) {
+    return [[appContext getNativeModuleObject:nsModuleName] getShared];
+  });
+  SharedJSIObject moduleObject = std::make_shared<jsi::Object>(jsi::Object::createFromHostObject(runtime, moduleLazyObject));
+
+  // Save the module's lazy host object for later use.
+  modulesCache[moduleName] = moduleObject;
+
+  return jsi::Value(runtime, *moduleObject);
 }
 
 void ExpoModulesHostObject::set(jsi::Runtime &runtime, const jsi::PropNameID &name, const jsi::Value &value) {

--- a/packages/expo-modules-core/ios/Swift/ModuleHolder.swift
+++ b/packages/expo-modules-core/ios/Swift/ModuleHolder.swift
@@ -101,6 +101,7 @@ public final class ModuleHolder {
     guard let runtime = appContext?.runtime else {
       return nil
     }
+    log.info("Creating JS object for module '\(name)'")
     return definition.build(inRuntime: runtime)
   }
 


### PR DESCRIPTION
# Why

On Android each module is represented as a JS host object and so the modules and even their properties are all loaded lazily.
On iOS, there is only one layer of laziness. Only `global.ExpoModules` is the host object, which basically means that all modules are still loaded on startup — when `requireNativeModule` is called, but this usually happens in the top-level scope.

# How

Added the second layer of laziness by wrapping module's JS object with the new `LazyObject` host object that defers the initialization (building the JS object from the module's definition) until its first usage.

As a result, executing `global.ExpoModules.ExpoCrypto` does **not** build the JS object from the definition yet, but `global.ExpoModules.ExpoCrypto.digestString` does.

I made the `LazyObject` class more generic (not module-specific) as I think there will more cases to use it (e.g. module namespaces).

# Test Plan

Tested with NCL examples and native unit tests.
