### PR TITLE
[image-picker][ios] Default to the new picker

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🎉 New features
 
+- The new `PHPickerViewController` is now default picker interface on iOS 14+. ([#18871](https://github.com/expo/expo/pull/18871) by [@barthap](https://github.com/barthap))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-image-picker/ios/ImagePickerModule.swift
+++ b/packages/expo-image-picker/ios/ImagePickerModule.swift
@@ -91,7 +91,7 @@ public class ImagePickerModule: Module, OnMediaPickingResultHandler {
                                         options: options,
                                         imagePickerHandler: imagePickerDelegate)
 
-    if #available(iOS 14, *), options.allowsMultipleSelection && sourceType != .camera {
+    if #available(iOS 14, *), !options.allowsEditing && sourceType != .camera {
       self.launchMultiSelectPicker(pickingContext: pickingContext)
     } else {
       self.launchLegacyImagePicker(sourceType: sourceType, pickingContext: pickingContext)
@@ -139,7 +139,8 @@ public class ImagePickerModule: Module, OnMediaPickingResultHandler {
     var configuration = PHPickerConfiguration(photoLibrary: PHPhotoLibrary.shared())
     let options = pickingContext.options
 
-    configuration.selectionLimit = options.selectionLimit
+    // selection limit = 1 --> single selection, reflects the old picker behavior
+    configuration.selectionLimit = options.allowsMultipleSelection ? options.selectionLimit : 1
     configuration.filter = options.mediaTypes.toPickerFilter()
     if #available(iOS 15, *) {
       configuration.selection = options.orderedSelection ? .ordered : .default

--- a/packages/expo-image-picker/ios/ImagePickerModule.swift
+++ b/packages/expo-image-picker/ios/ImagePickerModule.swift
@@ -140,7 +140,7 @@ public class ImagePickerModule: Module, OnMediaPickingResultHandler {
     let options = pickingContext.options
 
     // selection limit = 1 --> single selection, reflects the old picker behavior
-    configuration.selectionLimit = options.allowsMultipleSelection ? options.selectionLimit : 1
+    configuration.selectionLimit = options.allowsMultipleSelection ? options.selectionLimit : SINGLE_SELECTION
     configuration.filter = options.mediaTypes.toPickerFilter()
     if #available(iOS 15, *) {
       configuration.selection = options.orderedSelection ? .ordered : .default

--- a/packages/expo-image-picker/ios/ImagePickerOptions.swift
+++ b/packages/expo-image-picker/ios/ImagePickerOptions.swift
@@ -6,6 +6,7 @@ import PhotosUI
 
 internal let DEFAULT_QUALITY = 0.2
 internal let UNLIMITED_SELECTION = 0
+internal let SINGLE_SELECTION = 1
 
 internal struct ImagePickerOptions: Record {
   @Field


### PR DESCRIPTION
# Why

Resolves ENG-5809

As there were no reported issues with the new iOS picker, we can set it as default.

# How

Modified picker selection condition: Now:
- when iOS 14+ and cropping is disabled, use the new picker
- When multiple selection is disabled, set selection limit to 1 (single select) - does the same as [I described here](https://twitter.com/barthap10/status/1549642426243072001?s=20&t=PaYEyPVE-eO7OoBSieQ4uA)

# Test Plan

NCL