### PR TITLE
[docs] document cli option to skip push notifications credentials setup for EAS Build

### DIFF
--- a/docs/pages/build-reference/eas-json.md
+++ b/docs/pages/build-reference/eas-json.md
@@ -139,10 +139,9 @@ This document is a reference that outlines the schema for the `"build"` key in *
 {
   "cli": {
     "version": /* @info Required EAS CLI version range. */"SEMVER_RANGE"/* @end */,
-    "requireCommit": /* @info If true, ensures that all changes are committed before a build. Defaults to false. */boolean/* @end */
-
-    "appVersionSource": /* @info If set to remote, values stored on EAS servers will take precedense over local values. Defaults to local. */string/* @end */
-
+    "requireCommit": /* @info If true, ensures that all changes are committed before a build. Defaults to false. */boolean/* @end */,
+    "appVersionSource": /* @info If set to remote, values stored on EAS servers will take precedense over local values. Defaults to local. */string/* @end */,
+    "promptToConfigurePushNotfications": /* @info If set to false, skips Push Notifications credentials setup for EAS Build. Defaults to true. */boolean/* @end */,
   },
   "build": {
     /* @info any arbitrary name - used as an identifier */"BUILD_PROFILE_NAME_1"/* @end */: {


### PR DESCRIPTION
Documents new cli option added in https://github.com/expo/eas-cli/pull/1315