### PR TITLE
[docs] fix APISection classes render, improve ToC for classes

### DIFF
--- a/docs/components/plugins/APISection.test.tsx
+++ b/docs/components/plugins/APISection.test.tsx
@@ -97,4 +97,22 @@ describe('APISection', () => {
 
     expect(container).toMatchSnapshot();
   });
+
+  test('expo-asset', () => {
+    customRender(<APISection packageName="expo-asset" forceVersion="unversioned" />);
+
+    expect(screen.getAllByRole('heading', { level: 2 })).toHaveLength(3);
+    expect(screen.getAllByRole('heading', { level: 3 })).toHaveLength(18);
+    expect(screen.getAllByRole('table')).toHaveLength(7);
+
+    expect(screen.queryByText('Classes'));
+    expect(screen.queryByText('Asset Properties'));
+    expect(screen.queryByText('Asset Methods'));
+
+    expect(screen.queryByDisplayValue('localUri'));
+    expect(screen.queryByDisplayValue('fromURI()'));
+
+    expect(screen.queryAllByText('Props')).toHaveLength(0);
+    expect(screen.queryAllByText('Enums')).toHaveLength(0);
+  });
 });

--- a/docs/components/plugins/APISection.tsx
+++ b/docs/components/plugins/APISection.tsx
@@ -131,11 +131,7 @@ const renderAPI = (
       componentsPropNames.includes(entry.name)
     );
 
-    const classes = filterDataByKind(
-      data,
-      TypeDocKind.Class,
-      entry => !isComponent(entry) && (apiName ? !entry.name.includes(apiName) : true)
-    );
+    const classes = filterDataByKind(data, TypeDocKind.Class, entry => !isComponent(entry));
 
     const componentsChildren = components
       .map((cls: ClassDefinitionData) =>

--- a/docs/components/plugins/Headings.tsx
+++ b/docs/components/plugins/Headings.tsx
@@ -31,5 +31,7 @@ export const H2 = createHeading(RawH2, 2);
 export const H3 = createHeading(RawH3, 3);
 export const H4 = createHeading(RawH4, 4);
 
+export const H2Nested = createHeading(RawH4, 2);
+
 export const H3Code = createHeading(RawH3, 3, HeadingType.InlineCode);
 export const H4Code = createHeading(RawH4, 4, HeadingType.InlineCode);

--- a/docs/components/plugins/api/APISectionClasses.tsx
+++ b/docs/components/plugins/api/APISectionClasses.tsx
@@ -3,7 +3,7 @@ import ReactMarkdown from 'react-markdown';
 
 import { InlineCode } from '~/components/base/code';
 import { B, P } from '~/components/base/paragraph';
-import { H2, H3Code, H4 } from '~/components/plugins/Headings';
+import { H2, H2Nested, H3Code, H4 } from '~/components/plugins/Headings';
 import {
   ClassDefinitionData,
   GeneratedData,
@@ -39,24 +39,21 @@ const isMethod = (child: PropData) =>
   !child.name.startsWith('_') &&
   !child?.implementationOf;
 
-const renderClass = (clx: ClassDefinitionData, hasMultipleClasses: boolean): JSX.Element => {
+const renderClass = (clx: ClassDefinitionData, exposeInSidebar: boolean): JSX.Element => {
   const { name, comment, type, extendedTypes, children, implementedTypes } = clx;
   const properties = children?.filter(isProp);
   const methods = children
     ?.filter(isMethod)
     .sort((a: PropData, b: PropData) => a.name.localeCompare(b.name));
   const returnComment = getTagData('returns', comment);
+  const Header = exposeInSidebar ? H2Nested : H4;
 
   return (
     <div key={`class-definition-${name}`} css={STYLES_APIBOX}>
       <APISectionDeprecationNote comment={comment} />
-      {hasMultipleClasses ? (
-        <H3Code tags={getTagNamesList(comment)}>
-          <InlineCode>{name}</InlineCode>
-        </H3Code>
-      ) : (
-        <H2>{name}</H2>
-      )}
+      <H3Code tags={getTagNamesList(comment)}>
+        <InlineCode>{name}</InlineCode>
+      </H3Code>
       {(extendedTypes?.length || implementedTypes?.length) && (
         <P>
           <B>Type: </B>
@@ -94,30 +91,22 @@ const renderClass = (clx: ClassDefinitionData, hasMultipleClasses: boolean): JSX
       )}
       {properties?.length ? (
         <>
-          {hasMultipleClasses ? (
-            <div css={STYLES_NESTED_SECTION_HEADER}>
-              <H4>{name} Properties</H4>
-            </div>
-          ) : (
-            <H2>{name} Properties</H2>
-          )}
+          <div css={STYLES_NESTED_SECTION_HEADER}>
+            <Header>{name} Properties</Header>
+          </div>
           <div>
             {properties.map(property =>
-              renderProp(property, property?.defaultValue, !hasMultipleClasses)
+              renderProp(property, property?.defaultValue, exposeInSidebar)
             )}
           </div>
         </>
       ) : null}
       {methods?.length && (
         <>
-          {hasMultipleClasses ? (
-            <div css={STYLES_NESTED_SECTION_HEADER}>
-              <H4>{name} Methods</H4>
-            </div>
-          ) : (
-            <H2>{name} Methods</H2>
-          )}
-          {methods.map(method => renderMethod(method, { exposeInSidebar: !hasMultipleClasses }))}
+          <div css={STYLES_NESTED_SECTION_HEADER}>
+            <Header>{name} Methods</Header>
+          </div>
+          {methods.map(method => renderMethod(method, { exposeInSidebar }))}
         </>
       )}
     </div>
@@ -126,11 +115,11 @@ const renderClass = (clx: ClassDefinitionData, hasMultipleClasses: boolean): JSX
 
 const APISectionClasses = ({ data }: APISectionClassesProps) => {
   if (data?.length) {
-    const hasMultipleClasses = data.length > 1;
+    const exposeInSidebar = data.length < 2;
     return (
       <>
-        {hasMultipleClasses ? <H2>Classes</H2> : null}
-        {data.map(cls => renderClass(cls, hasMultipleClasses))}
+        <H2>Classes</H2>
+        {data.map(cls => renderClass(cls, exposeInSidebar))}
       </>
     );
   }


### PR DESCRIPTION
# Why

Fixes ENG-6149

# How

Ensure that APIs with single class exported renders correctly. Additionally, I have updated the Classes content ToC appearance to match it to the latest changes performed for the exported Components.

# Test Plan

The changes have been tested by running docs website locally.

I have also added a test to ensure that exported class and class fields are visible on the Asset page. I have skipped adding snapshot, since we aim to remove the snapshot testing from the codebase soon.

# Preview 

<img width="1919" alt="Screenshot 2022-08-29 at 11 06 58" src="https://user-images.githubusercontent.com/719641/187166069-0da14ed3-afcd-40b8-b584-5685382f72c6.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
