### PR TITLE
Update firebase docs

### DIFF
--- a/docs/pages/guides/setup-native-firebase.md
+++ b/docs/pages/guides/setup-native-firebase.md
@@ -13,7 +13,7 @@ This will guide you through a series of steps to create your own Firebase projec
 
 ## Setup
 
-Follow the official [React Native Firebase documentation](https://rnfirebase.io/#expo) to get started with native Firebase packages in custom development builds.
+Follow the official [React Native Firebase documentation](https://rnfirebase.io/#expo) to get started with native Firebase packages in [development builds](/development/introduction).
 
 ## Manual setup
 
@@ -75,4 +75,4 @@ After following the iOS and Android setup, you can optionally configure your pro
 - Install the `react-native-firebase` packages (e.g. `yarn add @react-native-firebase/app @react-native-firebase/auth` etc..)
 - Rebuild with `npx expo run:ios` or `npx expo run:android`
 
-Continue further on the [react-native-firebase](https://rnfirebase.io/) website.
+Continue further on the [react-native-firebase](https://rnfirebase.io/#installation) website.

--- a/docs/pages/guides/setup-native-firebase.md
+++ b/docs/pages/guides/setup-native-firebase.md
@@ -3,7 +3,7 @@ title: Using the native Firebase SDK
 sidebar_title: Using Native Firebase
 ---
 
-It's possible to use Firebase through the web SDK, built only in JavaScript, or the native SDK, which is built in native code for iOS and Android. The web SDK only provides access to some Firebase features and the most notable limitation is the lack of support for browser features used in Firebase Analytics or the redirect URI scheme used for phone authentication. If this is important for you, it may make sense to install the native SDK in your app.
+React Native supports both the Firebase JavaScript SDK, and the native iOS and Android SDKs. The JavaScript SDK only provides access to some Firebase features and the most notable limitation is the lack of support for browser features used in Firebase Analytics or the redirect URI scheme used for phone authentication. If this is important for you, it may make sense to install the native SDK in your app.
 
 ## Create Firebase project
 
@@ -11,98 +11,21 @@ If you have not done so already, create a Firebase project for your app by click
 
 This will guide you through a series of steps to create your own Firebase project.
 
-## Managed Workflow Setup
+## Using Prebuild
 
-Some (but not all) native Firebase features can be used with the Managed Workflow. The most notable native feature is Firebase Analytics,
-which is otherwise unavailable in react-native using the Firebase JavaScript SDK.
+If your project uses [Expo Prebuild](/workflow/prebuild.md) to generate the native `ios` and `android` directories continuously, then you can follow the official [React Native Firebase documentation](https://rnfirebase.io/#expo).
 
-### Adding the Native Firebase Plugin
+> The term **Using Prebuild** was formally referred to as the **Managed workflow**. [Learn more](/archived/managed-workflow).
 
-- To being using Native Firebase with Expo, you will start using the plugin `@react-native-firebase/app`. You can reference the [React Native Firebase docs](https://rnfirebase.io/#expo) for more details as needed.
-- **Note: By doing this you will convert your project into a semi-managed project and will need to rebuild it if any native code changes. For more information on adding custom native code, see [here](https://docs.expo.dev/workflow/customizing/).**
+## Manual setup
 
-```json
-{
-  "expo": {
-    "plugins": [
-      "@react-native-firebase/app"
-    ]
-  }
-}
-```
+> Follow this guide if your project is **not** using [Expo Prebuild](/workflow/prebuild) to generate the native `ios` and `android` directories continuously.
 
-- Once the plugin is in use you will need to:
-  - To **prebuild** your project, you will run `expo prebuild`. This will need to be done after every native code change.
-  - To **run** your project on a **local simulator** you will run `expo run [ios:android]`
-  - To **run** your project on a **external device** you will need to build a [development client](https://docs.expo.dev/development/getting-started/) and install it on your external device. This development client will act as a custom version of Expo Go built with your native code. To start the developemnt client you will run `expo start --dev-client`
-  - To **build** your project you will use `eas build`
-
-### Android
-
-- Open **Project overview** in the firebase console and click on the Android icon or + button to **Add Firebase to your Android app**.
-- **Make sure that the Android package name is the same as the value of `android.package` in your app.json.**
-- Register the app & download the config file by clicking **"Download google-services.json"** and drag the file into your Expo project folder.
-- Add the relative path to the Android **google-services.json** file to **app.json**.
-
-```json
-{
-  "expo": {
-    "android": {
-      "package": "com.mypackage.coolapp",
-      "googleServicesFile": "./google-services.json"
-    }
-  }
-}
-```
-
-### iOS
-
-- Open **Project overview** in the Firebase console and click on the iOS icon or + button to **Add Firebase to your iOS app**.
-- **Make sure that the iOS bundle ID is the same as the value of `ios.bundleIdentifier` in your app.json.**
-- Register the app & download the config file by clicking **"Download GoogleService-Info.plist"** and drag the file into your Expo project folder.
-- Add the relative path to the iOS **GoogleService-Info.plist** file to **app.json**.
-
-```json
-{
-  "expo": {
-    "ios": {
-      "bundleIdentifier": "com.mypackage.coolapp",
-      "googleServicesFile": "./GoogleService-Info.plist"
-    }
-  }
-}
-```
-
-### Web
-
-- Open **Project overview** in the Firebase console and click on the Web icon or + button to **Add Firebase to your Web app**.
-- Register the app & copy the config into your **app.json** under the key `web.config.firebase`.
-
-```json
-{
-  "expo": {
-    "web": {
-      "config": {
-        "firebase": {
-          "appId": "xxxxxxxxxxxxx:web:xxxxxxxxxxxxxxxx",
-          "apiKey": "AIzaXXXXXXXX-xxxxxxxxxxxxxxxxxxx",
-          "projectId": "my-awesome-project-id",
-          ...
-          "measurementId": "G-XXXXXXXXXXXX"
-        }
-      }
-    }
-  }
-}
-```
-
-## Bare Workflow Setup
-
-In the bare workflow, the firebase configuration needs to be added according to the native Firebase SDK installation guides
+Without [Expo Prebuild](/workflow/prebuild.md), the firebase configuration needs to be added according to the native Firebase SDK installation guides
 for [iOS](https://firebase.google.com/docs/ios/setup) and [Android](https://firebase.google.com/docs/android/setup).
-Below you will find a tailored instruction for use with react-native and the Expo Bare Workflow.
+Below you will find a tailored instruction for use with React Native.
 
-You are free to use any native Firebase packages such as [react-native-firebase](https://rnfirebase.io/) in the bare workflow.
+You are free to use any native Firebase packages such as [`react-native-firebase`](https://rnfirebase.io/) in the bare workflow.
 
 ### Android
 
@@ -121,7 +44,7 @@ You are free to use any native Firebase packages such as [react-native-firebase]
   ```groovy
   apply plugin: 'com.google.gms.google-services'
   ```
-- Finally rebuild your native Android app: `expo run:android`
+- Finally rebuild your native Android app: `npx expo run:android`
 
 ### iOS
 
@@ -141,20 +64,19 @@ You are free to use any native Firebase packages such as [react-native-firebase]
     ```objc
     @import Firebase;
     ```
-    
-  Note that following the upgrade to Expo SDK 45, your AppDelegate file will have the `.mm` extension as opposed to the `.m` extension.
+    Note that following the upgrade to Expo SDK 45, your AppDelegate file will have the `.mm` extension as opposed to the `.m` extension.
 - At the top of the `didFinishLaunchingWithOptions` method:
   ```objc
   - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
       [FIRApp configure];
   ```
-- Rebuild your iOS project to see the changes: `expo run:ios`
+- Rebuild your iOS project to see the changes: `npx expo run:ios`
 
 ### Usage with react-native-firebase
 
 After following the iOS and Android setup, you can optionally configure your project to work with `react-native-firebase` version 6 as well.
 
-- Install the `react-native-firebase` packages (e.g. `yarn add @react-native-firebase/app @react-native-firebase/auth etc..`)
-- Install the pods on iOS
+- Install the `react-native-firebase` packages (e.g. `yarn add @react-native-firebase/app @react-native-firebase/auth` etc..)
+- Rebuild with `npx expo run:ios` or `npx expo run:android`
 
 Continue further on the [react-native-firebase](https://rnfirebase.io/) website.

--- a/docs/pages/guides/setup-native-firebase.md
+++ b/docs/pages/guides/setup-native-firebase.md
@@ -11,27 +11,23 @@ If you have not done so already, create a Firebase project for your app by click
 
 This will guide you through a series of steps to create your own Firebase project.
 
-## Using Prebuild
+## Setup
 
-If your project uses [Expo Prebuild](/workflow/prebuild.md) to generate the native `ios` and `android` directories continuously, then you can follow the official [React Native Firebase documentation](https://rnfirebase.io/#expo).
-
-> The term **Using Prebuild** was formally referred to as the **Managed workflow**. [Learn more](/archived/managed-workflow).
+Follow the official [React Native Firebase documentation](https://rnfirebase.io/#expo) to get started with native Firebase packages in custom development builds.
 
 ## Manual setup
 
-> Follow this guide if your project is **not** using [Expo Prebuild](/workflow/prebuild) to generate the native `ios` and `android` directories continuously.
-
-Without [Expo Prebuild](/workflow/prebuild.md), the firebase configuration needs to be added according to the native Firebase SDK installation guides
+The firebase configuration needs to be added according to the native Firebase SDK installation guides
 for [iOS](https://firebase.google.com/docs/ios/setup) and [Android](https://firebase.google.com/docs/android/setup).
 Below you will find a tailored instruction for use with React Native.
 
-You are free to use any native Firebase packages such as [`react-native-firebase`](https://rnfirebase.io/) in the bare workflow.
+You are free to use any native Firebase packages such as [`react-native-firebase`](https://rnfirebase.io/) in bare React Native apps.
 
 ### Android
 
 - Open **Project overview** in the Firebase console and click on the Android icon or + button to **Add Firebase to your Android app**.
 - **Make sure that the Android package name is the same as the value of `applicationId` in your `android/app/build.gradle`.**
-- Register the app & download the config file by clicking **"Download google-services.json"** to this location `/android/app/google-services.json`.
+- Register the app & download the config file by clicking **Download google-services.json** to this location `/android/app/google-services.json`.
 - Import the `google-services` plugin inside of your `android/build.gradle` file:
   ```groovy
   buildscript {
@@ -50,8 +46,8 @@ You are free to use any native Firebase packages such as [`react-native-firebase
 
 - Open **Project overview** in the Firebase console and click on the iOS icon or + button to **Add Firebase to your iOS app**.
 - **Make sure that the iOS bundle ID is the same as the value of `Bundle Identifier` of your iOS project.**
-- Register the app & download the config file by clicking **"Download GoogleService-Info.plist"**.
-- Open your Expo iOS project in Xcode `ios/{projectName}.xcworkspace` and then drag the services file into your project. If you don't see the `.xcworkspace` workspace file, run `npx pod-install` to create it.
+- Register the app & download the config file by clicking **Download GoogleService-Info.plist**.
+- Open your iOS project in Xcode `ios/{projectName}.xcworkspace` and then drag the services file into your project. If you don't see the `.xcworkspace` workspace file, run `npx pod-install` to create it.
 
   - Be sure to enable **'Copy items if needed'**.
 

--- a/docs/pages/guides/using-firebase.md
+++ b/docs/pages/guides/using-firebase.md
@@ -12,7 +12,7 @@ import { Terminal } from '~/ui/components/Snippet';
 
 If you'd like to use Firebase in the Expo Go app, we recommend using the [Firebase JS SDK](https://github.com/firebase/firebase-js-sdk). It supports Authentication, Firestore & Realtime databases, Storage, and Functions on React Native. Other modules like Analytics are [not supported through the Firebase JS SDK](https://firebase.google.com/support/guides/environments_js-sdk), but you can use [`expo-firebase-analytics`](/versions/latest/sdk/firebase-analytics) for that.
 
-If you'd like access to the full suite of native firebase tools, we recommend using the [React Native Firebase](https://github.com/invertase/react-native-firebase) libraries which have first-class support for [Expo Prebuild](/workflow/prebuild). React Native Firebase is not supported in the Expo Go app so you'll need to create [a development build](/development/introduction).
+If you'd like access to the full suite of native firebase tools, we recommend using the [React Native Firebase](https://rnfirebase.io/#expo) with a [development build](/development/introduction). React Native Firebase is not supported in the [Expo Go](https://expo.dev/expo-go) app.
 
 > **Note:** This guide mostly covers Firebase Realtime Database (and some Firestore as well). For more background on why some Firebase services are not supported, please refer to the ["What goes into the Expo SDK?" FYI page](https://expo.fyi/whats-in-the-sdk).
 

--- a/docs/pages/guides/using-firebase.md
+++ b/docs/pages/guides/using-firebase.md
@@ -8,11 +8,11 @@ import { Terminal } from '~/ui/components/Snippet';
 
 > This guide uses `firebase@9.1.0`. As of SDK 43, the Expo SDK no longer enforces or recommends any specific version of Firebase to use in your app. If you are using an older version of the `firebase` library in your project you may have to adapt the code examples below to match the version that you are using, with the help of the [Firebase JS SDK documentation](https://github.com/firebase/firebase-js-sdk).
 
-## Usage with Expo
+## Usage with Expo Go
 
-If you'd like to use Firebase in the Expo Go app with the managed workflow, we'd recommend using the [Firebase JS SDK](https://github.com/firebase/firebase-js-sdk). It supports Authentication, Firestore & Realtime databases, Storage, and Functions on React Native. Other modules like Analytics are [not supported through the Firebase JS SDK](https://firebase.google.com/support/guides/environments_js-sdk), but you can use [expo-firebase-analytics](/versions/latest/sdk/firebase-analytics) for that.
+If you'd like to use Firebase in the Expo Go app, we recommend using the [Firebase JS SDK](https://github.com/firebase/firebase-js-sdk). It supports Authentication, Firestore & Realtime databases, Storage, and Functions on React Native. Other modules like Analytics are [not supported through the Firebase JS SDK](https://firebase.google.com/support/guides/environments_js-sdk), but you can use [`expo-firebase-analytics`](/versions/latest/sdk/firebase-analytics) for that.
 
-If you'd like access to the full suite of native firebase tools, we recommend using the [react-native-firebase](https://github.com/invertase/react-native-firebase) library and creating [a development build](/development/introduction) of your app using a built-in [config plugin](/guides/config-plugins).
+If you'd like access to the full suite of native firebase tools, we recommend using the [React Native Firebase](https://github.com/invertase/react-native-firebase) libraries which have first-class support for [Expo Prebuild](/workflow/prebuild). React Native Firebase is not supported in the Expo Go app so you'll need to create [a development build](/development/introduction).
 
 > **Note:** This guide mostly covers Firebase Realtime Database (and some Firestore as well). For more background on why some Firebase services are not supported, please refer to the ["What goes into the Expo SDK?" FYI page](https://expo.fyi/whats-in-the-sdk).
 
@@ -20,7 +20,7 @@ If you'd like access to the full suite of native firebase tools, we recommend us
 
 First we need to setup a Firebase Account and create a new project. We will be using the JavaScript SDK provided by Firebase, so pull it into your Expo project.
 
-<Terminal cmd={['$ expo install firebase']} />
+<Terminal cmd={['$ npx expo install firebase']} />
 
 [Firebase Console](http://console.firebase.google.com/) provides you with an API key, and other identifiers for your project needed for initialization. [firebase-web-start](https://firebase.google.com/docs/database/web/start) has a detailed description of what each field means and where to find them in your console.
 
@@ -111,7 +111,9 @@ We can choose different login methods that make sense to our application. The lo
 
 ### Facebook Login
 
-A common login system many developers opt for is a simple Facebook login that users are already familiar with. Expo provides a great Facebook login component already, so we just need to plug that in.
+<!-- TODO: Mention third-party facebook packages -->
+
+A common login system many developers opt for is a simple Facebook login that users are already familiar with.
 
 See the Facebook section of our docs for information on how to set this up. This works just as well with Google and [several others](<https://firebase.google.com/docs/reference/android/com/google/firebase/auth/AuthCredential#getProvider()>).
 
@@ -119,7 +121,7 @@ See the Facebook section of our docs for information on how to set this up. This
 
 Once you have added Facebook login to your Expo app, we need to adjust the Firebase console to check for it. Go to [Firebase Console](http://console.firebase.google.com/) >> _Authentication_ >> _Sign-In method_ tab to enable Facebook as a sign-in provider.
 
-You can add whichever provider makes sense for you, or even add multiple providers. We will stick with Facebook for now since we already have a simple drop-in Expo component already built.
+You can add whichever provider makes sense for you, or even add multiple providers.
 
 ### Phone Authentication
 
@@ -243,11 +245,11 @@ This sample was borrowed and edited from [this forum post](https://forums.expo.d
 
 In order to record analytics events, the Expo Firebase Core and Analytics packages needs to be installed.
 
-<Terminal cmd={['$ expo install expo-firebase-analytics']} />
+<Terminal cmd={['$ npx expo install expo-firebase-analytics']} />
 
-This package uses the native Firebase SDK in standalone apps and bare apps and a JavaScript based implementation on Expo Go.
+This package uses a JavaScript-based implementation in Expo Go, and the native Firebase SDK everywhere else.
 
-To configure native Firebase, please follow the configuration instructions for the [expo-firebase-analytics](/versions/latest/sdk/firebase-analytics) package.
+To configure native Firebase, please follow the configuration instructions for the [`expo-firebase-analytics`](/versions/latest/sdk/firebase-analytics) package.
 
 ```javascript
 import * as Analytics from 'expo-firebase-analytics';


### PR DESCRIPTION
# Why

- We should delegate out most of the native firebase docs to RNFirebase