### PR TITLE
[docs] PlatformsSection: use doc icons to improve spacing in table

### DIFF
--- a/docs/components/plugins/PlatformsSection.tsx
+++ b/docs/components/plugins/PlatformsSection.tsx
@@ -1,9 +1,10 @@
 import { css } from '@emotion/react';
-import { StatusFailedIcon, StatusSuccessIcon, StatusWaitingIcon, theme } from '@expo/styleguide';
+import { StatusWaitingIcon, theme } from '@expo/styleguide';
 import * as React from 'react';
 
 import { H4 } from '~/components/base/headings';
 import { ElementType } from '~/types/common';
+import { NoIcon, YesIcon } from '~/ui/components/DocIcons';
 import { Cell, HeaderCell, Row, Table, TableHead, TableLayout } from '~/ui/components/Table';
 
 const STYLES_TITLE = css`
@@ -33,7 +34,7 @@ type IsSupported = boolean | undefined | { pending: string };
 function getInfo(isSupported: IsSupported, { title }: Platform) {
   if (isSupported === true) {
     return {
-      children: <StatusSuccessIcon color={theme.status.success} />,
+      children: <YesIcon />,
       title: `${title} is supported`,
     };
   } else if (typeof isSupported === 'object') {
@@ -48,7 +49,7 @@ function getInfo(isSupported: IsSupported, { title }: Platform) {
   }
 
   return {
-    children: <StatusFailedIcon color={theme.status.error} />,
+    children: <NoIcon />,
     title: `${title} is not supported`,
   };
 }


### PR DESCRIPTION
# Why

Currently, using icons directly from Styleguide leads to an additional spacing at the bottom of the cells.

# How

This PR switches PlatformsSection icons for the supported and not supported status by Yes/No icons which includes the in table placement correction in their styles.

# Test Plan

the changes have been tested by running docs website locally.

# Preview

<img width="1189" alt="Screenshot 2022-08-29 at 16 10 13" src="https://user-images.githubusercontent.com/719641/187221105-59c263a3-c075-4fca-b173-e64bd1f9725b.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
