### PR TITLE
[core] Decouple jsc or hermes runtime lib on Android

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Fixed `FabricUIManager` errors when turning on new architecture mode on Android. ([#18472](https://github.com/expo/expo/pull/18472) by [@kudo](https://github.com/kudo))
 - Fixed the `2 files found with path 'lib/arm64-v8a/libfbjni.so'` error on Android. ([#18607](https://github.com/expo/expo/pull/18607) by [@lukmccall](https://github.com/lukmccall))
 - Fixed event dispatching for Sweet API views when running in Fabric mode on Android. ([#18814](https://github.com/expo/expo/pull/18814) by [@kudo](https://github.com/kudo))
+- Removed the hard dependency to Hermes or JSC in *libexpo-modules-core.so* on Android and fixed the broken support for react-native-v8. ([#18899](https://github.com/expo/expo/pull/18899) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/CMakeLists.txt
+++ b/packages/expo-modules-core/android/CMakeLists.txt
@@ -22,6 +22,14 @@ file(GLOB common_sources "${COMMON_DIR}/*.cpp")
 
 # shared
 
+macro(createVarAsBoolToInt name value)
+  if(${value})
+    set(${name} "1")
+  else()
+    set(${name} "0")
+  endif()
+endmacro()
+
 add_library(CommonSettings INTERFACE)
 
 add_library(
@@ -41,13 +49,17 @@ else()
   set(NEW_ARCHITECTURE_COMPILE_OPTIONS "")
 endif()
 
+createVarAsBoolToInt("USE_HERMES_INT" ${USE_HERMES})
+createVarAsBoolToInt("UNIT_TEST_INT" ${UNIT_TEST})
+
 target_compile_options(CommonSettings INTERFACE
   -O2
   -frtti
   -fexceptions
   -Wall
   -fstack-protector-all
-  -DFOR_HERMES=${FOR_HERMES}
+  -DUSE_HERMES=${USE_HERMES_INT}
+  -DUNIT_TEST=${UNIT_TEST_INT}
   ${NEW_ARCHITECTURE_COMPILE_OPTIONS}
 )
 
@@ -60,7 +72,33 @@ if (NOT LIBRN_DIR)
 endif ()
 
 file(GLOB libfbjni_include_DIRS "${BUILD_DIR}/fbjni-*-headers.jar/")
-file(GLOB HERMES_SO_DIR "${BUILD_DIR}/third-party-ndk/hermes/jni/${ANDROID_ABI}")
+
+# tests
+
+if(${UNIT_TEST})
+  if(${USE_HERMES})
+    file(GLOB HERMES_SO_DIR "${BUILD_DIR}/third-party-ndk/hermes/jni/${ANDROID_ABI}")
+    find_library(
+        JSEXECUTOR_LIB
+        hermes
+        PATHS ${HERMES_SO_DIR}
+        NO_CMAKE_FIND_ROOT_PATH
+    )
+    set(JSEXECUTOR_INCLUDE "${HERMES_HEADER_DIR}")
+  else()
+    find_library(
+        JSEXECUTOR_LIB
+        jscexecutor
+        PATHS ${LIBRN_DIR}
+        NO_CMAKE_FIND_ROOT_PATH
+    )
+    set(JSEXECUTOR_INCLUDE "")
+  endif()
+else()
+  set(JSEXECUTOR_LIB "")
+  set(JSEXECUTOR_INCLUDE "")
+endif()
+
 
 # includes
 
@@ -76,12 +114,12 @@ target_include_directories(
         "${REACT_NATIVE_DIR}/ReactCommon/react/nativemodule/core"
         "${REACT_NATIVE_DIR}/ReactCommon/callinvoker"
         "${REACT_NATIVE_DIR}/ReactCommon/jsi"
-        "${HERMES_HEADER_DIR}"
         "${BUILD_DIR}/third-party-ndk/boost/boost_${BOOST_VERSION}"
         "${BUILD_DIR}/third-party-ndk/double-conversion"
         "${BUILD_DIR}/third-party-ndk/folly"
         "${libfbjni_include_DIRS}"
         "${COMMON_DIR}"
+        "${JSEXECUTOR_INCLUDE}"
         "${SRC_DIR}/fabric"
 )
 
@@ -133,20 +171,6 @@ find_library(
         NO_CMAKE_FIND_ROOT_PATH
 )
 
-find_library(
-        HERMES_LIB
-        hermes
-        PATHS ${HERMES_SO_DIR}
-        NO_CMAKE_FIND_ROOT_PATH
-)
-
-find_library(
-        JSEXECUTOR_LIB
-        jscexecutor
-        PATHS ${LIBRN_DIR}
-        NO_CMAKE_FIND_ROOT_PATH
-)
-
 #reactnativejni
 
 # linking
@@ -160,32 +184,16 @@ target_compile_options(
         -DFOLLY_MOBILE=1
 )
 
-if (${FOR_HERMES})
-    target_link_libraries(
-            ${PACKAGE_NAME}
-            CommonSettings
-            ${LOG_LIB}
-            ${FBJNI_LIB}
-            ${JSI_LIB}
-            ${HERMES_LIB}
-            ${REACT_NATIVE_JNI_LIB}
-            ${FOLLY_LIB}
-            ${REACT_NATIVE_MODULES_CORE}
-            android
-            ${NEW_ARCHITECTURE_DEPENDENCIES}
-    )
-else ()
-    target_link_libraries(
-            ${PACKAGE_NAME}
-            CommonSettings
-            ${LOG_LIB}
-            ${FBJNI_LIB}
-            ${JSI_LIB}
-            ${JSEXECUTOR_LIB}
-            ${REACT_NATIVE_JNI_LIB}
-            ${FOLLY_LIB}
-            ${REACT_NATIVE_MODULES_CORE}
-            android
-            ${NEW_ARCHITECTURE_DEPENDENCIES}
-    )
-endif ()
+target_link_libraries(
+        ${PACKAGE_NAME}
+        CommonSettings
+        ${LOG_LIB}
+        ${FBJNI_LIB}
+        ${JSI_LIB}
+        ${JSEXECUTOR_LIB}
+        ${REACT_NATIVE_JNI_LIB}
+        ${FOLLY_LIB}
+        ${REACT_NATIVE_MODULES_CORE}
+        android
+        ${NEW_ARCHITECTURE_DEPENDENCIES}
+)

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -39,7 +39,7 @@ buildscript {
   }
 }
 
-def isAndroidTest() {
+def isAndroidTest = {
   Gradle gradle = getGradle()
   String tskReqStr = gradle.getStartParameter().getTaskRequests().toString()
   if (tskReqStr =~ /:expo-modules-core:connected\w*AndroidTest/) {
@@ -47,7 +47,7 @@ def isAndroidTest() {
     return androidTests.exists() && androidTests.isDirectory()
   }
   return false
-}
+}.call()
 
 def downloadsDir = new File("$buildDir/downloads")
 def thirdPartyNdkDir = new File("$buildDir/third-party-ndk")
@@ -82,21 +82,24 @@ def currentHermesVersion = file("${REACT_NATIVE_DIR}/sdks/.hermesversion").exist
 def hasHermesProject = findProject(":ReactAndroid:hermes-engine") != null
 def prebuiltHermesCacheHit = hasHermesProject && currentHermesVersion == prebuiltHermesVersion
 
-def FOR_HERMES = false
+def USE_HERMES = false
 def HERMES_HEADER_DIR = null
 def HERMES_AAR = null
 if (findProject(":app")) {
   def appProjectExt = project(":app").ext
   if (appProjectExt.has("react")) {
-    FOR_HERMES = project(":app").ext.react.enableHermes
+    USE_HERMES = project(":app").ext.react.enableHermes
   } else {
-    FOR_HERMES = (findProperty('expo.jsEngine') ?: "jsc") == "hermes"
+    USE_HERMES = (findProperty('expo.jsEngine') ?: "jsc") == "hermes"
   }
 } else {
-  FOR_HERMES = (findProperty('expo.jsEngine') ?: "jsc") == "hermes"
+  USE_HERMES = (findProperty('expo.jsEngine') ?: "jsc") == "hermes"
 }
 
-if (FOR_HERMES) {
+// Currently the needs for hermes/jsc are only for androidTest, so we turn on this flag only when `isAndroidTest` is true
+USE_HERMES = USE_HERMES && isAndroidTest
+
+if (USE_HERMES) {
   if (prebuiltHermesCacheHit) {
     HERMES_HEADER_DIR = file("${thirdPartyNdkDir}/hermes/prefab/modules/libhermes/include")
     HERMES_AAR = file("${prebuiltHermesDir}/hermes-engine-debug.aar")
@@ -176,12 +179,13 @@ android {
           "-DREACT_NATIVE_SO_DIR=${REACT_NATIVE_SO_DIR}",
           "-DREACT_NATIVE_TARGET_VERSION=${REACT_NATIVE_TARGET_VERSION}",
           "-DBOOST_VERSION=${BOOST_VERSION}",
-          "-DFOR_HERMES=${FOR_HERMES}",
+          "-DUSE_HERMES=${USE_HERMES}",
           "-DHERMES_HEADER_DIR=${HERMES_HEADER_DIR}",
           "-DIS_NEW_ARCHITECTURE_ENABLED=${isNewArchitectureEnabled}",
           "-DPROJECT_BUILD_DIR=$buildDir",
           "-DREACT_ANDROID_DIR=${REACT_NATIVE_DIR}/ReactAndroid",
-          "-DREACT_ANDROID_BUILD_DIR=${REACT_NATIVE_DIR}/ReactAndroid/build"
+          "-DREACT_ANDROID_BUILD_DIR=${REACT_NATIVE_DIR}/ReactAndroid/build",
+          "-DUNIT_TEST=${isAndroidTest}"
       }
     }
   }
@@ -224,7 +228,7 @@ android {
 
     // In android (instrumental) tests, we want to package all so files to enable our JSI functionality.
     // Otherwise, those files should be excluded, because will be loaded by the application.
-    if (isAndroidTest()) {
+    if (isAndroidTest) {
       excludes = [
         "META-INF/MANIFEST.MF",
         "META-INF/com.android.tools/proguard/coroutines.pro",
@@ -298,7 +302,7 @@ dependencies {
   androidTestImplementation "com.google.truth:truth:1.1.2"
   androidTestImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.0"
 
-  if (FOR_HERMES) {
+  if (USE_HERMES) {
     def hermesProject = findProject(":ReactAndroid:hermes-engine")
     androidTestImplementation (hermesProject ?: files(HERMES_AAR))
   } else {
@@ -459,7 +463,7 @@ task prepareFolly(dependsOn: [downloadFolly], type: Copy) {
 // END FOLLy
 
 task prepareHermes(dependsOn: createNativeDepsDirectories) {
-  if (!FOR_HERMES) {
+  if (!USE_HERMES) {
     return
   }
 
@@ -474,7 +478,7 @@ task prepareHermes(dependsOn: createNativeDepsDirectories) {
   }
 }
 
-task prepareThirdPartyNdkHeaders(dependsOn: [prepareBoost, prepareDoubleConversion, prepareFolly, prepareHermes]) {}
+task prepareThirdPartyNdkHeaders(dependsOn: [prepareBoost, prepareDoubleConversion, prepareFolly]) {}
 
 def packageReactNdkDebugLibs = tasks.register("packageReactNdkDebugLibs", Copy) {
   dependsOn(":ReactAndroid:packageReactNdkDebugLibsForBuck")
@@ -490,8 +494,11 @@ def packageReactNdkReleaseLibs = tasks.register("packageReactNdkReleaseLibs", Co
 afterEvaluate {
   extractAARHeaders.dependsOn(prepareThirdPartyNdkHeaders)
   extractJNIFiles.dependsOn(prepareThirdPartyNdkHeaders)
-  if (FOR_HERMES && hasHermesProject && !prebuiltHermesCacheHit) {
-    prepareHermes.dependsOn(":ReactAndroid:hermes-engine:assembleDebug")
+  if (USE_HERMES) {
+    prepareThirdPartyNdkHeaders.dependsOn(prepareHermes)
+    if (hasHermesProject && !prebuiltHermesCacheHit) {
+      prepareHermes.dependsOn(":ReactAndroid:hermes-engine:assembleDebug")
+    }
   }
 
   if (isNewArchitectureEnabled) {

--- a/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.cpp
@@ -63,6 +63,9 @@ void JSIInteropModuleRegistry::installJSI(
 }
 
 void JSIInteropModuleRegistry::installJSIForTests() {
+#if !UNIT_TEST
+  throw std::logic_error("The function is only avaiable when UNIT_TEST is defined.");
+#else
   runtimeHolder = std::make_shared<JavaScriptRuntime>();
   jsi::Runtime &jsiRuntime = runtimeHolder->get();
 
@@ -78,6 +81,7 @@ void JSIInteropModuleRegistry::installJSIForTests() {
       "ExpoModules",
       std::move(expoModulesObject)
     );
+#endif // !UNIT_TEST
 }
 
 jni::local_ref<JavaScriptModuleObject::javaobject>

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.cpp
@@ -5,7 +5,9 @@
 #include "JavaScriptObject.h"
 #include "Exceptions.h"
 
-#if FOR_HERMES
+#if UNIT_TEST
+
+#if USE_HERMES
 
 #include <hermes/hermes.h>
 
@@ -16,6 +18,8 @@
 #include <jsi/JSCRuntime.h>
 
 #endif
+
+#endif // UNIT_TEST
 
 namespace jsi = facebook::jsi;
 
@@ -32,7 +36,10 @@ void SyncCallInvoker::invokeSync(std::function<void()> &&func) {
 JavaScriptRuntime::JavaScriptRuntime()
   : jsInvoker(std::make_shared<SyncCallInvoker>()),
     nativeInvoker(std::make_shared<SyncCallInvoker>()) {
-#if FOR_HERMES
+#if !UNIT_TEST
+  throw std::logic_error("The JavaScriptRuntime constructor is only avaiable when UNIT_TEST is defined.");
+#else
+#if USE_HERMES
   auto config = ::hermes::vm::RuntimeConfig::Builder()
     .withEnableSampleProfiling(false);
   runtime = facebook::hermes::makeHermesRuntime(config.build());
@@ -82,6 +89,7 @@ JavaScriptRuntime::JavaScriptRuntime()
     ),
     "<<evaluated>>"
   );
+#endif // !UNIT_TEST
 }
 
 JavaScriptRuntime::JavaScriptRuntime(


### PR DESCRIPTION
# Why

the expo-modules-core links hermes or jsc to create a js runtime, however the call flow is only for android instrumented test. the test code increases build time as well as introducing the lib dependency to hermes/jsc and then breaks v8 support.
fix https://github.com/Kudo/react-native-v8/issues/134

# How

- Use `UNIT_TEST` preprocessor for the test code.
- change `FOR_HERMES -> USE_HERMES`

# Test Plan

- bare-expo
- `./gradlew :expo-modules-core:connectedAndroidTest` in `android`. this is running instrumented test on jsc
- `./gradlew :expo-modules-core:connectedAndroidTest` in `apps/bare-expo/android`. this is running instrumented test on hermes
- unzip the apk and use `objdump -x /path/to/libexpo-modules-core.so` to make sure there's no hermes or jsc dependency.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
