### PR TITLE
feat(docs): update SDK pages to reflect new CLI

### DIFF
--- a/docs/pages/build-reference/ios-capabilities.md
+++ b/docs/pages/build-reference/ios-capabilities.md
@@ -110,12 +110,12 @@ There are two ways to manually enable Apple capabilities, both systems will requ
 
 First step is to add the respective key/value pairs to your `ios/[app]/[app].entitlements` (or more specific entitlements file for multi-target apps). You can refer to [Supported Capabilities](#supported-capabilities) to determine which entitlements keys should be added.
 
-1. Log into [Apple Developer Console][apple-dev-console]. Go to "Certificates, Identifiers, & Profiles" > "Identifiers".
+1. Log into [Apple Developer Console][apple-dev-console]. Click on "Certificates, IDs & Profiles", then navigate to "Identifiers" page.
 2. Choose the bundle identifier that matches your app's bundle identifier.
 3. Scroll down and enable a capability, some capabilities may require extra setup.
 4. Scroll to the top and press "Save". You will see a dialog that says "Modify App Capabilities", press "Confirm" to continue. You will need to regenerate any provisioning profiles that use this bundle identifier before they'll be valid for building a code signed production ipa.
 
-If the last step is not done correctly then your iOS native build will fail with an error that looks something like:
+If adding capabilities process has not been done correctly then your iOS native build will fail with an error that looks something like:
 
 ```
 ❌  error: Provisioning profile "*[expo] app.bacon.hello AppStore ..." doesn't support the Associated Domains capability.

--- a/docs/pages/build-reference/ios-capabilities.md
+++ b/docs/pages/build-reference/ios-capabilities.md
@@ -117,7 +117,7 @@ First step is to add the respective key/value pairs to your `ios/[app]/[app].ent
 
 If the last step is not done correctly then your iOS native build will fail with an error that looks something like:
 
-```log
+```
 ❌  error: Provisioning profile "*[expo] app.bacon.hello AppStore ..." doesn't support the Associated Domains capability.
 
 ❌  error: Provisioning profile "*[expo] app.bacon.hello AppStore ..." doesn't include the com.apple.developer.associated-domains entitlement.

--- a/docs/pages/build-reference/ios-capabilities.md
+++ b/docs/pages/build-reference/ios-capabilities.md
@@ -4,7 +4,7 @@ title: iOS Capabilities
 
 import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 
-When you make a change to your iOS entitlements, this change needs to be updated remotely on Apple's servers before making a production build. EAS Build automatically synchronizes capabilities on the Apple Developer Portal with your local entitlements configuration when you run `eas build`. Capabilities are web services provided by Apple, think of them like AWS or Firebase services.
+When you make a change to your iOS entitlements, this change needs to be updated remotely on Apple's servers before making a production build. EAS Build automatically synchronizes capabilities on the Apple Developer Console with your local entitlements configuration when you run `eas build`. Capabilities are web services provided by Apple, think of them like AWS or Firebase services.
 
 > This feature can be disabled with `EXPO_NO_CAPABILITY_SYNC=1 eas build`
 
@@ -16,7 +16,7 @@ In managed workflow, the entitlements are read from the introspected Expo config
 
 ## Enabling
 
-If a supported entitlement is present in the entitlements file, then running `eas build` will enable it on Apple Developer Portal. If the capability is already enabled, then EAS Build will skip it.
+If a supported entitlement is present in the entitlements file, then running `eas build` will enable it on Apple Developer Console. If the capability is already enabled, then EAS Build will skip it.
 
 ## Disabling
 
@@ -24,7 +24,7 @@ If a capability is enabled for your app remotely, but not present in the native 
 
 ## Supported Capabilities
 
-EAS Build will only enable capabilities that it has built-in support for, any unsupported entitlements must be manually enabled via [Apple Developer Portal][apple-dev-portal].
+EAS Build will only enable capabilities that it has built-in support for, any unsupported entitlements must be manually enabled via [Apple Developer Console][apple-dev-console].
 
 | Support     | Capability                                        | Entitlement string                                                         |
 | ----------- | ------------------------------------------------- | -------------------------------------------------------------------------- |
@@ -81,9 +81,9 @@ EAS Build will only enable capabilities that it has built-in support for, any un
 | <YesIcon /> | WeatherKit                                        | `com.apple.developer.weatherkit`                                           |
 | <YesIcon /> | Wireless Accessory Configuration                  | `com.apple.external-accessory.wireless-configuration`                      |
 | <YesIcon /> | iCloud                                            | `com.apple.developer.icloud-container-identifiers`                         |
-| <NoIcon />  | HLS Interstitial Previews                         | Unknown                                                                   |
+| <NoIcon />  | HLS Interstitial Previews                         | Unknown                                                                    |
 
-The unsupported capabilities either don't support iOS, or they don't have a corresponding entitlement value.
+The unsupported capabilities either don't support iOS, or they don't have a corresponding entitlement value. Here are all of the [official Apple capabilities][apple-all-capabilities].
 
 Partially supported capabilities have extra configuration which EAS Build currently does not support. This includes Apple merchant IDs, App Group IDs, and iCloud container IDs. These values must all be [configured manually](https://expo.fyi/provisioning-profile-missing-capabilities) for the time being. You can also refer to this [Apple doc](https://developer.apple.com/documentation/xcode/adding-capabilities-to-your-app) for more information on manual setup.
 
@@ -93,6 +93,36 @@ You can run `EXPO_DEBUG=1 eas build` to get more detailed logs regarding the cap
 
 If you have trouble using this feature, you can disable it with the environment variable `EXPO_NO_CAPABILITY_SYNC=1`.
 
-To see all of the currently enabled capabilities, visit [Apple Developer Portal][apple-dev-portal], and find the bundle identifier matching your app, if you click on it you should see a list of all the currently enabled capabilities.
+To see all of the currently enabled capabilities, visit [Apple Developer Console][apple-dev-console], and find the bundle identifier matching your app, if you click on it you should see a list of all the currently enabled capabilities.
 
-[apple-dev-portal]: https://developer.apple.com/account/resources/identifiers/list
+## Manual setup
+
+There are two ways to manually enable Apple capabilities, both systems will require any existing Apple provisioning profiles to be regenerated.
+
+### Xcode
+
+> Preferred method for bare workflow or projects that do **not** using [Expo Prebuild](/workflow/prebuild) to continuously generate the native `ios` and `android` directories.
+
+1. Open the `ios/` directory in Xcode with `xed ios`. If you don't have an `ios/` directory, run `npx expo prebuild -p ios` to generate one.
+2. Then follow [this guide][apple-enable-capability].
+
+### Apple Developer Console
+
+First step is to add the respective key/value pairs to your `ios/[app]/[app].entitlements` (or more specific entitlements file for multi-target apps). You can refer to [Supported Capabilities](#supported-capabilities) to determine which entitlements keys should be added.
+
+1. Log into [Apple Developer Console][apple-dev-console]. Go to "Certificates, Identifiers, & Profiles" > "Identifiers".
+2. Choose the bundle identifier that matches your app's bundle identifier.
+3. Scroll down and enable a capability, some capabilities may require extra setup.
+4. Scroll to the top and press "Save". You will see a dialog that says "Modify App Capabilities", press "Confirm" to continue. You will need to regenerate any provisioning profiles that use this bundle identifier before they'll be valid for building a code signed production ipa.
+
+If the last step is not done correctly then your iOS native build will fail with an error that looks something like:
+
+```log
+❌  error: Provisioning profile "*[expo] app.bacon.hello AppStore ..." doesn't support the Associated Domains capability.
+
+❌  error: Provisioning profile "*[expo] app.bacon.hello AppStore ..." doesn't include the com.apple.developer.associated-domains entitlement.
+```
+
+[apple-enable-capability]: https://help.apple.com/xcode/mac/current/#/dev88ff319e7
+[apple-all-capabilities]: https://help.apple.com/developer-account/#/dev21218dfd6
+[apple-dev-console]: https://developer.apple.com/account/resources/identifiers/list

--- a/docs/pages/versions/unversioned/index.md
+++ b/docs/pages/versions/unversioned/index.md
@@ -8,9 +8,9 @@ import { Terminal } from '~/ui/components/Snippet';
 
 <VersionedRedirectNotification />
 
-The Expo SDK provides access to device and system functionality such as contacts, camera, gyroscope, GPS location, etc., in the form of packages. You can install any Expo SDK package using `expo-cli` with the `expo install` command. For example, three different packages are installed using the following command:
+The Expo SDK provides access to device and system functionality such as contacts, camera, gyroscope, GPS location, etc., in the form of packages. You can install any Expo SDK package using the `npx expo install` command. For example, three different packages are installed using the following command:
 
-<Terminal cmd={['$ expo install expo-camera expo-contacts expo-sensors']} />
+<Terminal cmd={['$ npx expo install expo-camera expo-contacts expo-sensors']} />
 
 After installing one or more packages, you can import them into your JavaScript code:
 
@@ -31,7 +31,7 @@ The easiest way to create a bare React Native app with support for the Expo SDK 
 '$ npx create-react-native-app my-app',
 ]} cmdCopy="npx create-react-native-app my-app" />
 
-You can install and import any Expo SDK package using the `expo install` command. If you have an existing app that you would like to add Expo SDK packages to, read about [integrating Expo SDK into existing apps](/bare/existing-apps).
+You can install and import any Expo SDK package using the `npx expo install` command. If you have an existing app that you would like to add Expo SDK packages to, read about [integrating Expo SDK into existing apps](/bare/existing-apps).
 
 ## Each Expo SDK version depends on a React Native version
 

--- a/docs/pages/versions/unversioned/sdk/apple-authentication.md
+++ b/docs/pages/versions/unversioned/sdk/apple-authentication.md
@@ -27,7 +27,7 @@ You can configure `expo-apple-authentication` using its built-in [config plugin]
 
 Apps that don't use [EAS Build](/build/introduction) must [manually configure](/build-reference/ios-capabilities#manual-setup) the **Apple Sign In** capability for their bundle identifier.
 
-If you enable through the [Apple Developer Console](/build-reference/ios-capabilities#apple-developer-console), then be sure to add the following entitlements in your `ios/[app]/[app].entitlements` file:
+If you enable the **Apple Sign In** capability through the [Apple Developer Console](/build-reference/ios-capabilities#apple-developer-console), then be sure to add the following entitlements in your `ios/[app]/[app].entitlements` file:
 
 ```xml
 <key>com.apple.developer.applesignin</key>

--- a/docs/pages/versions/unversioned/sdk/apple-authentication.md
+++ b/docs/pages/versions/unversioned/sdk/apple-authentication.md
@@ -4,6 +4,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-apple-authe
 packageName: 'expo-apple-authentication'
 ---
 
+import { ConfigReactNative, ConfigPluginExample } from '~/components/plugins/ConfigSection';
 import APISection from '~/components/plugins/APISection';
 import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
@@ -18,42 +19,42 @@ Beginning with iOS 13, any app that includes third-party authentication options 
 
 <APIInstallSection />
 
-## Configuration
+## Configuration in app.json / app.config.js
 
-### EAS Build
+You can configure `expo-apple-authentication` using its built-in [config plugin](/guides/config-plugins) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect. If your app does **not** use EAS Build, then you'll need to manually configure the package.
 
-This guide assumes [auto capability sync](../../../build-reference/ios-capabilities) is enabled (Default). Otherwise you'll need to manually enable the capabilities for your bundle identifier through the Apple Developer Console.
+<ConfigReactNative>
 
-#### Managed Workflow
+Apps that don't use [EAS Build](/build/introduction) must [manually configure](/build-reference/ios-capabilities#manual-setup) the **Apple Sign In** capability for their bundle identifier.
 
-1. Build with `eas build -p ios`. EAS Build and the config plugin will automatically configure this service with Apple.
+If you enable through the [Apple Developer Console](/build-reference/ios-capabilities#apple-developer-console), then be sure to add the following entitlements in your `ios/[app]/[app].entitlements` file:
 
-#### Bare Workflow
+```xml
+<key>com.apple.developer.applesignin</key>
+<array>
+  <string>Default</string>
+</array>
+```
 
-1. Ensure you've added enabled the Apple Sign In capability, either through the Xcode:
+Also be sure to set `CFBundleAllowMixedLocalizations` to `true` in your `ios/[app]/Info.plist` to ensure the sign in button uses the device locale.
 
-- Signing & Capabilities > + Capability > Sign in with Apple
-- Or by adding the entitlement to your `ios/[app]/[app].entitlements` file
-  ```xml
-  <key>com.apple.developer.applesignin</key>
-  <array>
-    <string>Default</string>
-  </array>
-  ```
+</ConfigReactNative>
 
-2. Add `"CFBundleAllowMixedLocalizations": true` to your `ios/[app]/Info.plist` to ensure the sign in button uses the device locale.
-3. Build with `eas build -p ios`. EAS Build will automatically configure this service with Apple.
+<ConfigPluginExample>
 
-### Classic Build
+> This plugin is included automatically when installed.
 
-1. For managed projects, set `ios.usesAppleSignIn` to `true` in `app.json`. For bare, enable the "Sign In with Apple" capability in your app. For bare projects, enable the capability in Xcode under "Signing & Capabilities" -- you'll need to be on Xcode 11 or later.
-2. Log into the Apple Developer Console, go to "Certificates, Identifiers, & Profiles" and then "Identifiers".
-3. You need to choose a primary app for the Apple Sign In configuration. This is the app whose icon will show up in the Apple Sign In system UI. If you have a set of related apps you might choose the "main" app as the primary, but most likely you'll want to just use the app you're working on now as the primary.
-4. In the list of identifiers, click on the one corresponding to your primary app. Enable the "Sign In with Apple" capability, click "Edit", and choose the "Enable as a primary App ID" option. Save the new configuration.
-5. If you chose a different app to be the primary, you'll also need to open up the configuration page for your current app, enable the "Sign In with Apple" capability, click "Edit" and choose the "Group with an existing primary App ID" option. Save this configuration as well.
-6. Next, go to the "Keys" page and register a new key. Add the "Sign In with Apple" capability, and make sure to choose the correct primary app on the configuration screen.
-7. Finally, when you want to make a standalone build to test with, run `expo build:ios --clear-provisioning-profile --revoke-credentials` so that your provisioning profile is regenerated with the new entitlement.
-8. (Optional) If you'd like to localize the button text, you can add `"CFBundleAllowMixedLocalizations": true` to your `ios.infoPlist` property [in your app.json](/workflow/configuration/#ios). Note: The localized value will only appear in your standalone app.
+Running [EAS Build](/build/introduction) locally will use [iOS capabilities signing](/build-reference/ios-capabilities) to enable the required capabilities before building.
+
+```json
+{
+  "expo": {
+    "plugins": ["expo-apple-authentication"]
+  }
+}
+```
+
+</ConfigPluginExample>
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/auth-session.md
+++ b/docs/pages/versions/unversioned/sdk/auth-session.md
@@ -7,6 +7,7 @@ packageName: 'expo-auth-session'
 import APISection from '~/components/plugins/APISection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import {APIInstallSection} from '~/components/plugins/InstallSection';
+import { ConfigReactNative, ConfigPluginExample } from '~/components/plugins/ConfigSection';
 
 import { SocialGrid, SocialGridItem, CreateAppButton } from '~/components/plugins/AuthSessionElements';
 import SnackInline from '~/components/plugins/SnackInline';
@@ -23,9 +24,9 @@ import { Terminal } from '~/ui/components/Snippet';
 
 <APIInstallSection packageName="expo-auth-session expo-random" />
 
-In **bare-workflow** you can use the [`uri-scheme` package][n-uri-scheme] to easily add, remove, list, and open your URIs.
+<ConfigReactNative>
 
-[n-uri-scheme]: https://www.npmjs.com/package/uri-scheme
+Use the [`uri-scheme` CLI][n-uri-scheme] to easily add, remove, list, and open your URIs.
 
 To make your native app handle `mycoolredirect://` simply run:
 
@@ -48,7 +49,9 @@ You can test it to ensure it works like this:
 '',
 '# Open a URI scheme',
 'npx uri-scheme open mycoolredirect://some/redirect'
-]} cmdCopy="yarn android && yarn ios && npx uri-scheme open mycoolredirect://some/redirect" />
+]} />
+
+</ConfigReactNative>
 
 ### Usage in standalone apps
 
@@ -91,7 +94,7 @@ The typical flow for browser-based authentication in mobile apps is as follows:
 
 ### It makes redirect URL allowlists easier to manage for development and working in teams
 
-Additionally, `AuthSession` **simplifies setting up authorized redirect URLs** by using an Expo service that sits between you and your authentication provider ([read Security considerations for caveats](#security-considerations)). This is particularly valuable with Expo because your app can live at various URLs. In development, you can have a tunnel URL, a lan URL, and a localhost URL. The tunnel URL on your machine for the same app will be different from a co-worker's machine. When you publish your app, that will be another URL that you need to allowlist. If you have multiple environments that you publish to, each of those will also need to be allowlisted. `AuthSession` gets around this by only having you allowlist one URL with your authentication provider: `https://auth.expo.io/@your-username/your-app-slug`. When authentication is successful, your authentication provider will redirect to that Expo Auth URL, and then the Expo Auth service will redirect back to your application. If the URL that the auth service is redirecting back to does not match the published URL for the app or the standalone app scheme (eg: `exp://expo.dev/@your-username/your-app-slug`, or `yourscheme://`), then it will show a warning page before asking the user to sign in. This means that in development you will see this warning page when you sign in, a small price to pay for the convenience.
+Additionally, `AuthSession` **simplifies setting up authorized redirect URLs** by using an Expo service that sits between you and your authentication provider ([read Security considerations for caveats](#security-considerations)). This is particularly valuable with project's using Expo CLI because your app can live at various URLs. In development, you can have a tunnel URL, a lan URL, and a localhost URL. The tunnel URL on your machine for the same app will be different from a co-worker's machine. When you publish your app with EAS Update, that will be another URL that you need to allow. If you have multiple environments that you publish to, each of those will also need to be allowlisted. `AuthSession` gets around this by only having you allowlist one URL with your authentication provider: `https://auth.expo.io/@your-username/your-app-slug`. When authentication is successful, your authentication provider will redirect to that Expo Auth URL, and then the Expo Auth service will redirect back to your application. If the URL that the auth service is redirecting back to does not match the published URL for the app or the standalone app scheme (eg: `exp://expo.dev/@your-username/your-app-slug`, or `yourscheme://`), then it will show a warning page before asking the user to sign in. This means that in development you will see this warning page when you sign in, a small price to pay for the convenience.
 
 How does this work? When you open an authentication session with `AuthSession`, it first visits `https://auth.expo.io/@your-username/your-app-slug/start` and passes in the `authUrl` and `returnUrl` (the URL to redirect back to your application) in the query parameters. The Expo Auth service saves away the `returnUrl` (and if it is not a published URL or your registered custom theme, shows a warning page) and then sends the user off to the `authUrl`. When the authentication provider redirects back to `https://auth.expo.io/@your-username/your-app-slug` on success, the Expo Auth services redirects back to the `returnUrl` that was provided on initiating the authentication flow.
 
@@ -181,11 +184,9 @@ A hook used for opinionated Facebook authentication that works across platforms.
 
 A [`DiscoveryDocument`](#discoverydocument) object containing the discovery URLs used for Facebook auth.
 
-## Usage in the bare React Native app
+## Proxy Service
 
-In managed apps, `AuthSession` uses Expo servers to create a proxy between your application and the auth provider. If you'd like, you can also create your own proxy service.
-
-### Proxy Service
+`AuthSession` uses Expo servers to create a proxy between your application and the auth provider. If you'd like, you can also create your own proxy service.
 
 This service is responsible for:
 
@@ -206,7 +207,7 @@ const redirect = (response, url) => {
     Location: url,
   });
   response.end();
-}
+};
 
 http
   .createServer((request, response) => {
@@ -247,3 +248,5 @@ There are many reasons why you might want to handle inbound links into your app,
 #### With React Navigation v5
 
 If you are using deep linking with React Navigation v5, filtering through `Linking.addEventListener` will not be sufficient, because deep linking is [handled differently](https://reactnavigation.org/docs/configuring-links/#advanced-cases). Instead, to filter these events you can add a custom `getStateFromPath` function to your linking configuration, and then filter by URL in the same way as described above.
+
+[n-uri-scheme]: https://www.npmjs.com/package/uri-scheme

--- a/docs/pages/versions/unversioned/sdk/background-fetch.md
+++ b/docs/pages/versions/unversioned/sdk/background-fetch.md
@@ -161,7 +161,7 @@ async function registerBackgroundFetchAsync() {
 
 ## Configuration
 
-In order to use `BackgroundFetch` API in standalone, detached and bare apps on iOS, your app has to include background mode in the **Info.plist** file. See [background tasks configuration guide](task-manager.md#configuration-for-standalone-apps) for more details.
+In order to use `BackgroundFetch` API in standalone, bare apps on iOS, your app has to include background mode in the **Info.plist** file. See [background tasks configuration guide](task-manager.md#configuration-for-standalone-apps) for more details.
 
 On Android, this module might listen when the device is starting up. It's necessary to continue working on tasks started with `startOnBoot`. It also keeps devices "awake" that are going idle and asleep fast, to improve reliability of the tasks. Because of this both the `RECEIVE_BOOT_COMPLETED` and `WAKE_LOCK` permissions are added automatically.
 

--- a/docs/pages/versions/unversioned/sdk/bar-code-scanner.md
+++ b/docs/pages/versions/unversioned/sdk/bar-code-scanner.md
@@ -21,7 +21,9 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 ## Configuration
 
-In managed apps, scanning barcodes with the camera requires the [`Permission.CAMERA`](permissions.md#permissionscamera) permission. See the [usage example](#usage) below.
+<!-- TODO: Replace with config format from tracking-transparency -->
+
+Scanning barcodes with the camera requires the [`Permission.CAMERA`](permissions.md#permissionscamera) permission. See the [usage example](#usage) below.
 
 ## Supported formats
 

--- a/docs/pages/versions/unversioned/sdk/build-properties.md
+++ b/docs/pages/versions/unversioned/sdk/build-properties.md
@@ -9,13 +9,11 @@ import { ConfigPluginExample } from '~/components/plugins/ConfigSection';
 import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-**`expo-build-properties`** is a [config plugin](../../../guides/config-plugins.md) for [managed apps](../../../introduction/managed-vs-bare.md) to override the default native build properties. During `expo prebuild`, the config plugin will populate build properties from given [config](#configuration-in-appjson--appconfigjs) to `android/gradle.properties` and `ios/Podfile.properties.json`.
+**`expo-build-properties`** is a [config plugin](/guides/config-plugins) configuring the native build properties of your `ios/Podfile.properties.json` and `android/gradle.properties` directories during [Expo Prebuild](/workflow/prebuild). This config plugin configures how [Expo Prebuild](/workflow/prebuild) generates the native `ios` and `android` folders and therefore cannot be used with projects that don't run `npx expo prebuild` (bare projects).
 
 <PlatformsSection ios simulator android emulator />
 
 ## Installation
-
-> **Note:** To use this config plugin, your apps must be a managed app and build by either [EAS Build](/build/introduction.md) or `expo run:[android|ios]`. This package has no effect on project's built with the classic `expo build:android` or `expo build:ios` commands, or when running in the Expo Go app.
 
 <APIInstallSection hideBareInstructions={true} />
 

--- a/docs/pages/versions/unversioned/sdk/crypto.md
+++ b/docs/pages/versions/unversioned/sdk/crypto.md
@@ -69,7 +69,7 @@ import * as Crypto from 'expo-crypto';
 
 ## Error Codes
 
-| Code                     | Description                                                                                                                                                     |
-|--------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `ERR_CRYPTO_UNAVAILABLE` | __Web Only.__ Access to the WebCrypto API is restricted to secure origins (https). <br/>You can run your web project from a secure origin with `expo start --https`. |
-| `ERR_CRYPTO_DIGEST`      | An invalid encoding type provided.                                                                                                                              |
+| Code                     | Description                                                                                                                                                              |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `ERR_CRYPTO_UNAVAILABLE` | **Web Only.** Access to the WebCrypto API is restricted to secure origins (https). <br/>You can run your web project from a secure origin with `npx expo start --https`. |
+| `ERR_CRYPTO_DIGEST`      | An invalid encoding type provided.                                                                                                                                       |

--- a/docs/pages/versions/unversioned/sdk/document-picker.md
+++ b/docs/pages/versions/unversioned/sdk/document-picker.md
@@ -4,7 +4,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-document-pi
 packageName: 'expo-document-picker'
 ---
 
-import { ConfigClassic, ConfigReactNative, ConfigPluginExample, ConfigPluginProperties } from '~/components/plugins/ConfigSection';
+import { ConfigReactNative, ConfigPluginExample, ConfigPluginProperties } from '~/components/plugins/ConfigSection';
 
 import APISection from '~/components/plugins/APISection';
 import {APIInstallSection} from '~/components/plugins/InstallSection';
@@ -76,7 +76,7 @@ Running [EAS Build](/build/introduction) locally will use [iOS capabilities sign
 </ConfigPluginExample>
 
 <ConfigPluginProperties properties={[
-{ name: 'iCloudContainerEnvironment', platform: 'ios', description: 'Sets the iOS `com.apple.developer.icloud-container-environment` entitlement used used for AdHoc iOS builds: https://github.com/expo/eas-cli/issues/693', default: 'undefined' },
+{ name: 'iCloudContainerEnvironment', platform: 'ios', description: 'Sets the iOS `com.apple.developer.icloud-container-environment` entitlement used used for AdHoc iOS builds. Possible values: `Development`, `Production`. Learn more: https://github.com/expo/eas-cli/issues/693', default: 'undefined' },
 ]} />
 
 ## API

--- a/docs/pages/versions/unversioned/sdk/document-picker.md
+++ b/docs/pages/versions/unversioned/sdk/document-picker.md
@@ -29,7 +29,7 @@ You can configure `expo-document-picker` using its built-in [config plugin](/gui
 
 Apps that don't use [EAS Build](/build/introduction) and want [iCloud storage features][icloud-entitlement] must [manually configure](/build-reference/ios-capabilities#manual-setup) the [**iCloud service with CloudKit support**](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_icloud-container-environment) for their bundle identifier.
 
-If you enable through the [Apple Developer Console](/build-reference/ios-capabilities#apple-developer-console), then be sure to add the following entitlements in your `ios/[app]/[app].entitlements` file (where `dev.expo.my-app` if your bundle identifier):
+If you enable the **iCloud** capability through the [Apple Developer Console](/build-reference/ios-capabilities#apple-developer-console), then be sure to add the following entitlements in your `ios/[app]/[app].entitlements` file (where `dev.expo.my-app` if your bundle identifier):
 
 ```xml
 <key>com.apple.developer.icloud-container-identifiers</key>

--- a/docs/pages/versions/unversioned/sdk/document-picker.md
+++ b/docs/pages/versions/unversioned/sdk/document-picker.md
@@ -4,6 +4,8 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-document-pi
 packageName: 'expo-document-picker'
 ---
 
+import { ConfigClassic, ConfigReactNative, ConfigPluginExample, ConfigPluginProperties } from '~/components/plugins/ConfigSection';
+
 import APISection from '~/components/plugins/APISection';
 import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
@@ -19,25 +21,63 @@ Provides access to the system's UI for selecting documents from the available pr
 
 <APIInstallSection />
 
-## Configuration
+## Configuration in app.json / app.config.js
 
-### Managed workflow
+You can configure `expo-document-picker` using its built-in [config plugin](/guides/config-plugins) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect. If your app does **not** use EAS Build, then you'll need to manually configure the package.
 
-For iOS, outside of the Expo Go app, the DocumentPicker module requires the [iCloud Services Entitlement](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_icloud-services) to work properly. You need to take the following steps:
+<ConfigReactNative>
 
-- Set the `usesIcloudStorage` key to `true` in your **app.json** as specified [configuration properties](/versions/latest/config/app/#usesicloudstorage).
-- You need to enable the iCloud Application Service in your App identifier. This can be done in the detail of your [App ID in the Apple Developer interface](https://developer.apple.com/account/resources/identifiers/list).
-- Enable iCloud service with CloudKit support, and create an iCloud Container. When registering the new Container, you are asked to provide a description and identifier for the container. You may enter any name under the description. Under the identifier, add `iCloud.<your_bundle_identifier>`.
+Apps that don't use [EAS Build](/build/introduction) and want [iCloud storage features][icloud-entitlement] must [manually configure](/build-reference/ios-capabilities#manual-setup) the [**iCloud service with CloudKit support**](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_icloud-container-environment) for their bundle identifier.
 
-To apply these changes, you have to revoke your existing provisioning profile and use [EAS Build](/build/introduction/) to build the app binaries.
+If you enable through the [Apple Developer Console](/build-reference/ios-capabilities#apple-developer-console), then be sure to add the following entitlements in your `ios/[app]/[app].entitlements` file (where `dev.expo.my-app` if your bundle identifier):
 
-### Bare workflow
+```xml
+<key>com.apple.developer.icloud-container-identifiers</key>
+<array>
+    <string>iCloud.dev.expo.my-app</string>
+</array>
+<key>com.apple.developer.icloud-services</key>
+<array>
+    <string>CloudDocuments</string>
+</array>
+<key>com.apple.developer.ubiquity-container-identifiers</key>
+<array>
+    <string>iCloud.dev.expo.my-app</string>
+</array>
+<key>com.apple.developer.ubiquity-kvstore-identifier</key>
+<string>$(TeamIdentifierPrefix)dev.expo.my-app</string>
+```
 
-For iOS bare projects, the `DocumentPicker` module requires the iCloud entitlement to work properly. If your app doesn't have it already, you can add it by opening the project in Xcode and following these steps:
+Apple Developer Console also requires an **iCloud Container** to be created. When registering the new container, you are asked to provide a description and identifier for the container. You may enter any name under the description. Under the identifier, add `iCloud.<your_bundle_identifier>` (same value used for `com.apple.developer.icloud-container-identifiers` and `com.apple.developer.ubiquity-container-identifiers` entitlements).
 
-- In the project, go to the `Capabilities` tab
-- Set the iCloud switch to `on`
-- Check the `iCloud Documents` checkbox
+</ConfigReactNative>
+
+<ConfigPluginExample>
+
+If you want to enable [iCloud storage features][icloud-entitlement], set the `expo.ios.usesIcloudStorage` key to `true` in your Expo config (**app.json**, **app.config.js**) as specified [configuration properties](/versions/latest/config/app/#usesicloudstorage).
+
+Running [EAS Build](/build/introduction) locally will use [iOS capabilities signing](/build-reference/ios-capabilities) to enable the required capabilities before building.
+
+```json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-document-picker",
+        {
+          "iCloudContainerEnvironment": "Production"
+        }
+      ]
+    ]
+  }
+}
+```
+
+</ConfigPluginExample>
+
+<ConfigPluginProperties properties={[
+{ name: 'iCloudContainerEnvironment', platform: 'ios', description: 'Sets the iOS `com.apple.developer.icloud-container-environment` entitlement used used for AdHoc iOS builds: https://github.com/expo/eas-cli/issues/693', default: 'undefined' },
+]} />
 
 ## API
 
@@ -46,3 +86,5 @@ import * as DocumentPicker from 'expo-document-picker';
 ```
 
 <APISection packageName="expo-document-picker" apiName="DocumentPicker" />
+
+[icloud-entitlement]: https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_icloud-services

--- a/docs/pages/versions/unversioned/sdk/firebase-analytics.md
+++ b/docs/pages/versions/unversioned/sdk/firebase-analytics.md
@@ -21,7 +21,7 @@ Learn more in the official [Firebase Docs](https://firebase.google.com/docs/anal
 
 <APIInstallSection />
 
-When using the web-platform, you'll also need to run `expo install firebase`, which install the Firebase JS SDK.
+When using the web-platform, you'll also need to run `npx expo install firebase`, which install the Firebase JS SDK.
 
 ## Configuration
 
@@ -156,6 +156,6 @@ export default () => (
 import * as Analytics from 'expo-firebase-analytics';
 ```
 
-To use web analytics, you'll also need to install the peer dependency **firebase** with `expo install firebase`.
+To use web analytics, you'll also need to install the peer dependency **firebase** with `npx expo install firebase`.
 
 <APISection packageName="expo-firebase-analytics" apiName="Analytics" />

--- a/docs/pages/versions/unversioned/sdk/firebase-recaptcha.md
+++ b/docs/pages/versions/unversioned/sdk/firebase-recaptcha.md
@@ -18,7 +18,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 <APIInstallSection />
 
-Additionally, you'll also need to install the webview using `expo install react-native-webview`
+Additionally, you'll also need to install the webview using `npx expo install react-native-webview`
 
 ## Basic usage
 
@@ -92,7 +92,9 @@ const auth = getAuth();
 
 // Double-check that we can run the example
 if (!app?.options || Platform.OS === 'web') {
-  throw new Error('This example only works on Android or iOS, and requires a valid Firebase config.');
+  throw new Error(
+    'This example only works on Android or iOS, and requires a valid Firebase config.'
+  );
 }
 
 export default function App() {
@@ -157,10 +159,7 @@ export default function App() {
         disabled={!verificationId}
         onPress={async () => {
           try {
-            const credential = PhoneAuthProvider.credential(
-              verificationId,
-              verificationCode
-            );
+            const credential = PhoneAuthProvider.credential(verificationId, verificationCode);
             await signInWithCredential(auth, credential);
             showMessage({ text: 'Phone authentication successful 👍' });
           } catch (err) {
@@ -185,9 +184,7 @@ export default function App() {
             {message.text}
           </Text>
         </TouchableOpacity>
-      ) : (
-        undefined
-      )}
+      ) : undefined}
       {attemptInvisibleVerification && <FirebaseRecaptchaBanner />}
     </View>
   );
@@ -301,9 +298,7 @@ export default function PhoneAuthScreen() {
         {verifyInProgress && <ActivityIndicator style={styles.loader} />}
         {verificationId ? (
           <Text style={styles.success}>A verification code has been sent to your phone</Text>
-        ) : (
-          undefined
-        )}
+        ) : undefined}
         <Text style={styles.text}>Enter verification code</Text>
         <TextInput
           ref={verificationCodeTextInput}
@@ -319,10 +314,7 @@ export default function PhoneAuthScreen() {
             try {
               setConfirmError(undefined);
               setConfirmInProgress(true);
-              const credential = PhoneAuthProvider.credential(
-                verificationId,
-                verificationCode
-              );
+              const credential = PhoneAuthProvider.credential(verificationId, verificationCode);
               const authResult = await signInWithCredential(auth, credential);
               setConfirmInProgress(false);
               setVerificationId('');

--- a/docs/pages/versions/unversioned/sdk/imagepicker.md
+++ b/docs/pages/versions/unversioned/sdk/imagepicker.md
@@ -24,7 +24,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 ## Configuration in app.json / app.config.js
 
-You can configure `expo-image-picker` using its built-in [config plugin](../../../guides/config-plugins.md) if you use config plugins in your project ([EAS Build](../../../build/introduction.md) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
+You can configure `expo-image-picker` using its built-in [config plugin](/guides/config-plugins) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 
 <ConfigClassic>
 

--- a/docs/pages/versions/unversioned/sdk/imagepicker.md
+++ b/docs/pages/versions/unversioned/sdk/imagepicker.md
@@ -24,7 +24,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 ## Configuration in app.json / app.config.js
 
-You can configure `expo-image-picker` using its built-in [config plugin](../../../guides/config-plugins.md) if you use config plugins in your project ([EAS Build](../../../build/introduction.md) or `expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
+You can configure `expo-image-picker` using its built-in [config plugin](../../../guides/config-plugins.md) if you use config plugins in your project ([EAS Build](../../../build/introduction.md) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 
 <ConfigClassic>
 

--- a/docs/pages/versions/unversioned/sdk/in-app-purchases.md
+++ b/docs/pages/versions/unversioned/sdk/in-app-purchases.md
@@ -10,25 +10,17 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 > ⚠️ **Development of `expo-in-app-purchases` is currently paused to focus on other projects**. Alternative libraries include [`react-native-iap`](https://github.com/dooboolab/react-native-iap) and [`react-native-purchases` from RevenueCat](https://www.revenuecat.com/blog/using-revenuecat-with-expos-managed-workflow/).
 
-**`expo-in-app-purchases`** provides an API to accept payments for in-app products. Internally this relies on the [Google Play Billing](https://developer.android.com/google/play/billing/billing_library_overview) library on Android and the [Storekit](https://developer.apple.com/documentation/storekit?language=objc) framework on iOS.
+**`expo-in-app-purchases`** provides an API to accept payments for in-app products. Internally this relies on the [Google Play Billing](https://developer.android.com/google/play/billing/billing_library_overview) library on Android and the [StoreKit](https://developer.apple.com/documentation/storekit?language=objc) framework on iOS.
 
 <PlatformsSection android ios />
 
 ## Installation
 
-<APIInstallSection hideBareInstructions cmd={['$ npm install expo-in-app-purchases']} />
+This module is **not** available in the [Expo Go app](https://expo.dev/expo-go) due to app store restrictions.
 
-This module is currently only available in the [bare](/introduction/managed-vs-bare.md#bare-workflow) workflow.
+You can create a [development build][dev-build] to work with this package.
 
-You must ensure that you have [installed and configured Expo modules](/bare/installing-expo-modules.md) before continuing.
-
-### Configure for iOS
-
-Run `npx pod-install` after installing the npm package.
-
-### Configure for Android
-
-No additional set up necessary.
+<APIInstallSection />
 
 ## Setup
 
@@ -57,3 +49,5 @@ import * as InAppPurchases from 'expo-in-app-purchases';
 ```
 
 <APISection packageName="expo-in-app-purchases" apiName="InAppPurchases" />
+
+[dev-build]: /development/getting-started.md#creating-and-installing-your-first-development-build

--- a/docs/pages/versions/unversioned/sdk/localization.md
+++ b/docs/pages/versions/unversioned/sdk/localization.md
@@ -23,7 +23,7 @@ Using the popular library [`i18n-js`](https://github.com/fnando/i18n-js) with `e
 
 Let's make our app support English and Japanese. To achive this install the i18n package `i18n-js`:
 
-<Terminal cmd={['$ expo install i18n-js']} />
+<Terminal cmd={['$ npx expo install i18n-js']} />
 
 Then, configure the languages for your app.
 
@@ -94,7 +94,7 @@ const styles = StyleSheet.create({
   },
   text: {
     fontSize: 20,
-    marginBottom: 16
+    marginBottom: 16,
   },
 });
 /* @end */

--- a/docs/pages/versions/unversioned/sdk/media-library.md
+++ b/docs/pages/versions/unversioned/sdk/media-library.md
@@ -22,7 +22,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 ## Configuration in app.json / app.config.js
 
-You can configure `expo-media-library` using its built-in [config plugin](../../../guides/config-plugins.md) if you use config plugins in your project ([EAS Build](../../../build/introduction.md) or `expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
+You can configure `expo-media-library` using its built-in [config plugin](../../../guides/config-plugins.md) if you use config plugins in your project ([EAS Build](../../../build/introduction.md) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 
 <ConfigClassic>
 

--- a/docs/pages/versions/unversioned/sdk/notifications.md
+++ b/docs/pages/versions/unversioned/sdk/notifications.md
@@ -40,7 +40,7 @@ The **`expo-notifications`** provides an API to fetch push notification tokens a
 
 ## Configuration in app.json / app.config.js
 
-You can configure `expo-notifications` using its built-in [config plugin](../../../guides/config-plugins.md) if you use config plugins in your project ([EAS Build](../../../build/introduction.md) or `expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
+You can configure `expo-notifications` using its built-in [config plugin](/guides/config-plugins) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 
 <ConfigClassic>
 
@@ -131,8 +131,7 @@ Here are a few ways people claim to have solved this problem, maybe one of these
 Go read the Apple's [Technical Note on troubleshooting push notifications](https://developer.apple.com/library/archive/technotes/tn2265/_index.html)! This the single most reliable source of information on this problem. To help you grasp what they're suggesting:
 
 - Make sure the device has a reliable connection to the Internet (try turning off Wi-Fi or switching to another network, and disabling firewall block on port 5223, as suggested in [this SO answer](https://stackoverflow.com/a/34332047/1123156)).
-- Make sure your app configuration is set properly for registering for push notifications (for bare workflow check out [this guide](https://developer.apple.com/library/ios/documentation/IDEs/Conceptual/AppDistributionGuide/AddingCapabilities/AddingCapabilities.html#//apple_ref/doc/uid/TP40012582-CH26-SW6), for managed workflow this is done automatically for you by `expo-cli`) as also suggested by [this StackOverflow answer](https://stackoverflow.com/a/10791240/1123156).
-- If you're in bare workflow you may want to try to debug this even further by logging persistent connection debug information as outlined by [this StackOverflow answer](https://stackoverflow.com/a/8036052/1123156).
+- **Bare React Native apps** must [manually enable the **Push Notifications** capability](/build-reference/ios-capabilities#manual-setup). If you have trouble setting this up, refer to [this StackOverflow answer](https://stackoverflow.com/a/10791240/1123156). You may also want to try to debug this even further by logging persistent connection debug information as outlined by [this StackOverflow answer](https://stackoverflow.com/a/8036052/1123156).
 
 </Collapsible>
 
@@ -278,13 +277,13 @@ async function registerForPushNotificationsAsync() {
 
 ## Custom notification icon and colors (Android only)
 
-In the managed workflow, set your [`notification.icon`](../config/app.md#notification) and [`notification.color`](../config/app.md#notification) keys in **app.json**, rebuild your app, and you're good to go!
+[Expo Prebuild](/workflow/prebuild) users can configure the [`notification.icon`](../config/app.md#notification) and [`notification.color`](../config/app.md#notification) keys in the project's **app.json** or by using the [`expo-notifications` config plugin directly](#optional-setup). These are build-time setting so you'll need to recompile your native Android app with `eas build -p android` or `npx expo run:android` to see the changes.
 
-For bare workflow **and EAS Build users**, the configuration is also done in **app.json**, but you'll use the [`expo-notifications` config plugin instead](#optional-setup).
+Bare react native apps can follow [this guide](https://documentation.onesignal.com/docs/customize-notification-icons) to manually configure Android notification icons in Android Studio.
 
 For your notification icon, make sure you follow [Google's design guidelines](https://material.io/design/iconography/product-icons.html#design-principles) (the icon must be all white with a transparent background) or else it may not be displayed as intended.
 
-In both the managed and bare workflow, you can also set a custom notification color _per-notification_ directly in your [`NotificationContentInput`](#notificationcontentinput) under the `color` attribute.
+You can also set a custom notification color _per-notification_ directly in your [`NotificationContentInput`](#notificationcontentinput) under the `color` attribute.
 
 ## Setting custom notification sounds
 

--- a/docs/pages/versions/unversioned/sdk/reanimated.md
+++ b/docs/pages/versions/unversioned/sdk/reanimated.md
@@ -20,7 +20,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 **In all cases,** after the installation completes, you must also add the Babel plugin to **babel.config.js**:
 
 ```jsx
-module.exports = function(api) {
+module.exports = function (api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
@@ -29,7 +29,7 @@ module.exports = function(api) {
 };
 ```
 
-After you add the Babel plugin, restart your development server and clear the bundler cache: `expo start --clear`.
+After you add the Babel plugin, restart your development server and clear the bundler cache: `npx expo start --clear`.
 
 > Note: If you load other Babel plugins, the Reanimated plugin has to be the last item in the plugins array.
 

--- a/docs/pages/versions/unversioned/sdk/screen-orientation.md
+++ b/docs/pages/versions/unversioned/sdk/screen-orientation.md
@@ -4,6 +4,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-screen-orie
 packageName: 'expo-screen-orientation'
 ---
 
+import { ConfigReactNative, ConfigPluginExample, ConfigPluginProperties } from '~/components/plugins/ConfigSection';
 import { palette } from '@expo/styleguide';
 import APISection from '~/components/plugins/APISection'
 import ImageSpotlight from '~/components/plugins/ImageSpotlight'
@@ -12,13 +13,11 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 Screen Orientation is defined as the orientation in which graphics are painted on the device. For example, the figure below has a device in a vertical and horizontal physical orientation, but a portrait screen orientation. For physical device orientation, see the orientation section of [Device Motion](devicemotion.md).
 
-<ImageSpotlight alt="Portrait orientation in different physical orientations" src="/static/images/screen-orientation-portrait.png" containerStyle={{ backgroundColor: palette.light.gray['300'] }}  />
-
-`ScreenOrientation` from **`expo`** allows changing supported screen orientations at runtime, and subscribing to orientation changes. This will take priority over the `orientation` key in **app.json**.
+<ImageSpotlight alt="Portrait orientation in different physical orientations" src="/static/images/screen-orientation-portrait.png" containerStyle={{ backgroundColor: palette.light.gray['300'] }} />
 
 On both iOS and Android platforms, changes to the screen orientation will override any system settings or user preferences. On Android, it is possible to change the screen orientation while taking the user's preferred orientation into account. On iOS, user and system settings are not accessible by the application and any changes to the screen orientation will override existing settings.
 
-> Web support has [limited support](https://caniuse.com/#feat=deviceorientation). For improved resize detection on mobile Safari, check out the docs on using [Resize Observer in Expo web](../../../guides/customizing-webpack.md#resizeobserver).
+> Web support has [limited support](https://caniuse.com/#feat=deviceorientation). For improved resize detection on mobile Safari, check out the docs on using [Resize Observer in Expo web](/guides/customizing-webpack.md#resizeobserver).
 
 <PlatformsSection android emulator ios simulator web />
 
@@ -30,25 +29,42 @@ On both iOS and Android platforms, changes to the screen orientation will overri
 
 Apple added support for _split view_ mode to iPads in iOS 9. This changed how the screen orientation is handled by the system. To put the matter shortly, for the iOS, your iPad is always in the landscape mode unless you open two applications side by side. In order to be able to lock screen orientation using this module you will need to disable support for this feature. For more information about the _split view_ mode, check out [the official Apple documentation](https://support.apple.com/en-us/HT207582).
 
-#### Managed workflow
+## Configuration in app.json / app.config.js
 
-Open your **app.json** and add the following inside of the `"expo"` field:
+You can configure `expo-screen-orientation` using its built-in [config plugin](/guides/config-plugins) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
+
+<ConfigReactNative>
+
+1. Open the `ios/` directory in Xcode with `xed ios`. If you don't have an `ios/` directory, run `npx expo prebuild -p ios` to generate one.
+2. Tick the `Requires Full Screen` checkbox in Xcode. It should be located under `Project Target > General > Deployment Info`.
+
+</ConfigReactNative>
+
+<ConfigPluginExample>
 
 ```json
 {
   "expo": {
-    ...
     "ios": {
-      ...
-      "requireFullScreen": true,
-    }
+      "requireFullScreen": true
+    },
+    "plugins": [
+      [
+        "expo-screen-orientation",
+        {
+          "initialOrientation": "DEFAULT"
+        }
+      ]
+    ]
   }
 }
 ```
 
-#### Bare workflow
+</ConfigPluginExample>
 
-Tick the `Requires Full Screen` checkbox in Xcode. It should be located under `Project Target > General > Deployment Info`.
+<ConfigPluginProperties properties={[
+{ name: 'initialOrientation', platform: 'ios', description: 'Sets the iOS initial screen orientation. Options: `DEFAULT`, `ALL`, `PORTRAIT`, `PORTRAIT_UP`, `PORTRAIT_DOWN`, `LANDSCAPE`, `LANDSCAPE_LEFT`, `LANDSCAPE_RIGHT`', default: 'undefined' },
+]} />
 
 ## API
 
@@ -64,6 +80,6 @@ import * as ScreenOrientation from 'expo-screen-orientation';
 | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
 | ERR_SCREEN_ORIENTATION_UNSUPPORTED_ORIENTATION_LOCK  | The platform does not support the [`OrientationLock`](#screenorientationorientationlock) policy. |
 | ERR_SCREEN_ORIENTATION_INVALID_ORIENTATION_LOCK      | An invalid [`OrientationLock`](#screenorientationorientationlock) was passed in.                 |
-| ERR_SCREEN_ORIENTATION_GET_ORIENTATION_LOCK          | __Android Only.__ An unknown error occurred when trying to get the orientation lock.             |
-| ERR_SCREEN_ORIENTATION_GET_PLATFORM_ORIENTATION_LOCK | __Android Only.__ An unknown error occurred when trying to get the platform orientation lock.    |
-| ERR_SCREEN_ORIENTATION_MISSING_ACTIVITY              | __Android Only.__ Could not get the current activity.                                            |
+| ERR_SCREEN_ORIENTATION_GET_ORIENTATION_LOCK          | **Android Only.** An unknown error occurred when trying to get the orientation lock.             |
+| ERR_SCREEN_ORIENTATION_GET_PLATFORM_ORIENTATION_LOCK | **Android Only.** An unknown error occurred when trying to get the platform orientation lock.    |
+| ERR_SCREEN_ORIENTATION_MISSING_ACTIVITY              | **Android Only.** Could not get the current activity.                                            |

--- a/docs/pages/versions/unversioned/sdk/sharing.md
+++ b/docs/pages/versions/unversioned/sdk/sharing.md
@@ -18,12 +18,12 @@ import Video from '~/components/plugins/Video'
 #### Sharing limitations on web
 
 - `expo-sharing` for web is built on top of the Web Share API, which still has [very limited browser support](https://caniuse.com/#feat=web-share). Be sure to check that the API can be used before calling it by using `Sharing.isAvailableAsync()`.
-- **HTTPS required on web**: The Web Share API is only available on web when the page is served over https. Run your app with `expo start --https` to enable it.
+- **HTTPS required on web**: The Web Share API is only available on web when the page is served over https. Run your app with `npx expo start --https` to enable it.
 - **No local file sharing on web**: Sharing local files by URI works on iOS and Android, but not on web. You cannot share local files on web by URI &mdash; you will need to upload them somewhere and share that URI.
 
 #### Sharing to your app from other apps
 
-Currently `expo-sharing` only supports sharing *from your app to other apps* and you cannot register to your app to have content shared to it through the native share dialog on native platforms. You can read more [in the related feature request](https://expo.canny.io/feature-requests/p/share-extension-ios-share-intent-android). If you are using the bare workflow you can build this functionality on your own, but it is not available in the managed workflow.
+Currently `expo-sharing` only supports sharing _from your app to other apps_ and you cannot register to your app to have content shared to it through the native share dialog on native platforms. You can read more [in the related feature request](https://expo.canny.io/feature-requests/p/share-extension-ios-share-intent-android). You can setup this functionality manually in Xcode and Android Studio and create an [Expo Config Plugin](/guides/config-plugins) to continue using [Expo Prebuild](/workflow/prebuild.md).
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/sqlite.md
+++ b/docs/pages/versions/unversioned/sdk/sqlite.md
@@ -20,7 +20,7 @@ An [example to do list app](https://github.com/expo/examples/tree/master/with-sq
 
 In order to open a new SQLite database using an existing `.db` file you already have, you need to do three things:
 
-- `expo install expo-file-system expo-asset`
+- `npx expo install expo-file-system expo-asset`
 - create a **metro.config.js** file in the root of your project with the following contents ([curious why? read here](../../../guides/customizing-metro.md#adding-more-file-extensions-to--assetexts)):
 
 ```ts

--- a/docs/pages/versions/unversioned/sdk/stripe.md
+++ b/docs/pages/versions/unversioned/sdk/stripe.md
@@ -82,12 +82,16 @@ urlScheme:
 
 ### Standalone apps
 
-`@stripe/stripe-react-native` is supported in Expo Go on Android and iOS out of the box, **however**, for iOS, it is only available for standalone apps built with [EAS Build](/build/introduction.md), and not for apps built on the classic build system- `expo build:ios`. Android apps built with `expo build:android` _will_ have access to the `@stripe/stripe-react-native` library.
+`@stripe/stripe-react-native` is supported in Expo Go on Android and iOS out of the box, **however**, for iOS, it is only available for standalone apps built with [EAS Build][eas-build], and not for apps built on the classic build system- `expo build:ios`. Android apps built with `expo build:android` _will_ have access to the `@stripe/stripe-react-native` library.
 
 ### Apple Pay
 
-Apple Pay **is not** supported in Expo Go. To use Apple Pay, you must use either [EAS Build](/build/introduction.md), or run `expo run:ios` in your project directory.
+Apple Pay **is not** supported in [Expo Go][expo-go]. To use Apple Pay, you must create a [development build][dev-build]. This can be done with [EAS Build][eas-build], or locally by running `npx expo run:ios`.
 
 ### Google Pay
 
-Google Pay **is not** supported in Expo Go. To use Google Pay, you must use either [EAS Build](/build/introduction.md), or run `expo run:android` in your project directory.
+Google Pay **is not** supported in [Expo Go][expo-go]. To use Google Pay, you must create a [development build][dev-build]. This can be done with [EAS Build][eas-build], or locally by running `npx expo run:android`.
+
+[eas-build]: /build/introduction
+[expo-go]: https://expo.dev/expo-go
+[dev-build]: /development/getting-started.md#creating-and-installing-your-first-development-build

--- a/docs/pages/versions/unversioned/sdk/tracking-transparency.md
+++ b/docs/pages/versions/unversioned/sdk/tracking-transparency.md
@@ -23,7 +23,7 @@ For more information on Apple's new App Tracking Transparency framework, please 
 
 ## Configuration in app.json / app.config.js
 
-You can configure `expo-tracking-transparency` using its built-in [config plugin](../../../guides/config-plugins.md) if you use config plugins in your project ([EAS Build](../../../build/introduction.md) or `expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
+You can configure `expo-tracking-transparency` using its built-in [config plugin](/guides/config-plugins) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 
 <ConfigClassic>
 

--- a/docs/pages/versions/unversioned/sdk/updates.md
+++ b/docs/pages/versions/unversioned/sdk/updates.md
@@ -22,9 +22,7 @@ Most of the methods and constants in this module can only be used or tested in r
 
 **To test manual updates in the Expo Go app**, run [`eas update`](/eas-update/introduction) and then open the published version of your app with Expo Go.
 
-**To test manual updates with managed workflow standalone apps**, you can create a [simulator build](/build-reference/simulators.md) or [APK](/build-reference/apk.md), or make a release build locally with `expo run:ios --configuration Release` and `expo run:android --variant release`.
-
-**To test manual updates in bare workflow apps**, make a release build with `expo run:ios --configuration Release` or `expo run:android --variant release` (you don't need to submit this build to the store to test).
+**To test manual updates with standalone apps**, you can create a [simulator build](/build-reference/simulators.md) or [APK](/build-reference/apk.md), or make a release build locally with `npx expo run:ios --configuration Release` and `npx expo run:android --variant release` (you don't need to submit this build to the store to test).
 
 ## API
 
@@ -36,10 +34,10 @@ import * as Updates from 'expo-updates';
 
 ## Error Codes
 
-| Code                   | Description                                                                                                                                                                                                                                                   |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ERR_UPDATES_DISABLED` | A method call was attempted when the Updates module was disabled, or the application was running in development mode                                                                                                                                          |
-| `ERR_UPDATES_RELOAD`   | An error occurred when trying to reload the application and it could not be reloaded. For bare workflow apps, double check the setup steps for this module to ensure it has been installed correctly and the proper native initialization methods are called. |
-| `ERR_UPDATES_CHECK`    | An unexpected error occurred when trying to check for new updates. Check the error message for more information.                                                                                                                                              |
-| `ERR_UPDATES_FETCH`    | An unexpected error occurred when trying to fetch a new update. Check the error message for more information.                                                                                                                                                 |
-| `ERR_UPDATES_READ_LOGS` | An unexpected error occurred when trying to read log entries. Check the error message for more information.                                                                                                                                                 |
+| Code                    | Description                                                                                                                                                                                                                                                   |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ERR_UPDATES_DISABLED`  | A method call was attempted when the Updates module was disabled, or the application was running in development mode                                                                                                                                          |
+| `ERR_UPDATES_RELOAD`    | An error occurred when trying to reload the application and it could not be reloaded. For bare workflow apps, double check the setup steps for this module to ensure it has been installed correctly and the proper native initialization methods are called. |
+| `ERR_UPDATES_CHECK`     | An unexpected error occurred when trying to check for new updates. Check the error message for more information.                                                                                                                                              |
+| `ERR_UPDATES_FETCH`     | An unexpected error occurred when trying to fetch a new update. Check the error message for more information.                                                                                                                                                 |
+| `ERR_UPDATES_READ_LOGS` | An unexpected error occurred when trying to read log entries. Check the error message for more information.                                                                                                                                                   |


### PR DESCRIPTION
# Why

- Consolidate capability guide.
- Use new local CLI in docs.
- Use React components to collapse bare setup guides (following tracking-transparency format).
