### PR TITLE
[firebase] Bump firebase native versions for our firebase packages

### DIFF
--- a/apps/bare-expo/ios/Podfile
+++ b/apps/bare-expo/ios/Podfile
@@ -17,6 +17,13 @@ podfile_properties = JSON.parse(File.read('./Podfile.properties.json')) rescue {
 abstract_target 'BareExpoMain' do
   pod 'expo-dev-menu', path: '../../../packages/expo-dev-menu', :testspecs => ['Tests', 'UITests']
 
+  # Required by latest firebase versions
+  # See https://github.com/invertase/react-native-firebase/issues/6332#issuecomment-1189734581
+  pod 'Firebase', :modular_headers => true
+  pod 'FirebaseCoreInternal', :modular_headers => true
+  pod 'GoogleUtilities', :modular_headers => true
+  $RNFirebaseAsStaticFramework = true
+
   use_expo_modules!(
     tests: [
       'expo-dev-menu-interface',
@@ -36,10 +43,6 @@ abstract_target 'BareExpoMain' do
     # An absolute path to your application root.
     :app_path => "#{Dir.pwd}/.."
   )
-
-  # required for Firebase modules
-  # see https://github.com/invertase/react-native-firebase/issues/6332
-  use_modular_headers!
 
   # Fix Google Sign-in and Flipper
   post_install do |installer|

--- a/apps/bare-expo/ios/Podfile
+++ b/apps/bare-expo/ios/Podfile
@@ -37,6 +37,10 @@ abstract_target 'BareExpoMain' do
     :app_path => "#{Dir.pwd}/.."
   )
 
+  # required for Firebase modules
+  # see https://github.com/invertase/react-native-firebase/issues/6332
+  use_modular_headers!
+
   # Fix Google Sign-in and Flipper
   post_install do |installer|
     # `installer.pods_project` might be nil for `incremental_installation: true` and no new project generated

--- a/apps/bare-expo/ios/Podfile
+++ b/apps/bare-expo/ios/Podfile
@@ -19,10 +19,8 @@ abstract_target 'BareExpoMain' do
 
   # Required by latest firebase versions
   # See https://github.com/invertase/react-native-firebase/issues/6332#issuecomment-1189734581
-  pod 'Firebase', :modular_headers => true
-  pod 'FirebaseCoreInternal', :modular_headers => true
+  pod 'FirebaseCore', :modular_headers => true
   pod 'GoogleUtilities', :modular_headers => true
-  $RNFirebaseAsStaticFramework = true
 
   use_expo_modules!(
     tests: [

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -240,6 +240,8 @@ PODS:
     - React-Core (= 0.69.5)
     - React-jsi (= 0.69.5)
     - ReactCommon/turbomodule/core (= 0.69.5)
+  - Firebase (9.5.0):
+    - Firebase/Core (= 9.5.0)
   - Firebase/Core (9.5.0):
     - Firebase/CoreOnly
     - FirebaseAnalytics (~> 9.5.0)
@@ -323,12 +325,24 @@ PODS:
     - GoogleToolboxForMac/Defines (= 2.3.2)
     - "GoogleToolboxForMac/NSString+URLArguments (= 2.3.2)"
   - "GoogleToolboxForMac/NSString+URLArguments (2.3.2)"
+  - GoogleUtilities (7.7.0):
+    - GoogleUtilities/AppDelegateSwizzler (= 7.7.0)
+    - GoogleUtilities/Environment (= 7.7.0)
+    - GoogleUtilities/ISASwizzler (= 7.7.0)
+    - GoogleUtilities/Logger (= 7.7.0)
+    - GoogleUtilities/MethodSwizzler (= 7.7.0)
+    - GoogleUtilities/Network (= 7.7.0)
+    - "GoogleUtilities/NSData+zlib (= 7.7.0)"
+    - GoogleUtilities/Reachability (= 7.7.0)
+    - GoogleUtilities/SwizzlerTestHelpers (= 7.7.0)
+    - GoogleUtilities/UserDefaults (= 7.7.0)
   - GoogleUtilities/AppDelegateSwizzler (7.7.0):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
   - GoogleUtilities/Environment (7.7.0):
     - PromisesObjC (< 3.0, >= 1.2)
+  - GoogleUtilities/ISASwizzler (7.7.0)
   - GoogleUtilities/Logger (7.7.0):
     - GoogleUtilities/Environment
   - GoogleUtilities/MethodSwizzler (7.7.0):
@@ -340,6 +354,8 @@ PODS:
   - "GoogleUtilities/NSData+zlib (7.7.0)"
   - GoogleUtilities/Reachability (7.7.0):
     - GoogleUtilities/Logger
+  - GoogleUtilities/SwizzlerTestHelpers (7.7.0):
+    - GoogleUtilities/MethodSwizzler
   - GoogleUtilities/UserDefaults (7.7.0):
     - GoogleUtilities/Logger
   - GoogleUtilitiesComponents (1.1.0):
@@ -864,7 +880,10 @@ DEPENDENCIES:
   - EXVideoThumbnails (from `../../../packages/expo-video-thumbnails/ios`)
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
   - FBReactNativeSpec (from `../node_modules/react-native/React/FBReactNativeSpec`)
+  - Firebase
+  - FirebaseCoreInternal
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
+  - GoogleUtilities
   - hermes-engine (from `../node_modules/react-native/sdks/hermes/hermes-engine.podspec`)
   - libevent (~> 2.1.12)
   - Nimble (from `./../../../ios/Nimble.podspec`)
@@ -1409,6 +1428,6 @@ SPEC CHECKSUMS:
   Yoga: c2b1f2494060865ac1f27e49639e72371b1205fa
   ZXingObjC: fdbb269f25dd2032da343e06f10224d62f537bdb
 
-PODFILE CHECKSUM: 0358a5fe9d2485c66be187803b11513ce6319d05
+PODFILE CHECKSUM: 88110908da5b2f787de03596e3492c51cf175302
 
 COCOAPODS: 1.11.2

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -240,8 +240,6 @@ PODS:
     - React-Core (= 0.69.5)
     - React-jsi (= 0.69.5)
     - ReactCommon/turbomodule/core (= 0.69.5)
-  - Firebase (9.5.0):
-    - Firebase/Core (= 9.5.0)
   - Firebase/Core (9.5.0):
     - Firebase/CoreOnly
     - FirebaseAnalytics (~> 9.5.0)
@@ -392,11 +390,11 @@ PODS:
     - MLImage (= 1.0.0-beta2)
     - MLKitCommon (~> 5.0)
     - Protobuf (~> 3.12)
-  - nanopb (2.30908.0):
-    - nanopb/decode (= 2.30908.0)
-    - nanopb/encode (= 2.30908.0)
-  - nanopb/decode (2.30908.0)
-  - nanopb/encode (2.30908.0)
+  - nanopb (2.30909.0):
+    - nanopb/decode (= 2.30909.0)
+    - nanopb/encode (= 2.30909.0)
+  - nanopb/decode (2.30909.0)
+  - nanopb/encode (2.30909.0)
   - Nimble (9.2.1)
   - PromisesObjC (2.1.1)
   - Protobuf (3.20.1)
@@ -880,8 +878,7 @@ DEPENDENCIES:
   - EXVideoThumbnails (from `../../../packages/expo-video-thumbnails/ios`)
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
   - FBReactNativeSpec (from `../node_modules/react-native/React/FBReactNativeSpec`)
-  - Firebase
-  - FirebaseCoreInternal
+  - FirebaseCore
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - GoogleUtilities
   - hermes-engine (from `../node_modules/react-native/sdks/hermes/hermes-engine.podspec`)
@@ -1372,7 +1369,7 @@ SPEC CHECKSUMS:
   MLKitCommon: 3bc17c6f7d25ce3660f030350b46ae7ec9ebca6e
   MLKitFaceDetection: 617cb847441868a8bfd4b48d751c9b33c1104948
   MLKitVision: e87dc3f2e456a6ab32361ebd985e078dd2746143
-  nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
+  nanopb: b552cce312b6c8484180ef47159bc0f65a1f0431
   Nimble: d954d0accfd082f2225e62d71008440493e318f4
   PromisesObjC: ab77feca74fa2823e7af4249b8326368e61014cb
   Protobuf: b60ec2f51ad74765f44d0c09d2e0579d7de21745
@@ -1428,6 +1425,6 @@ SPEC CHECKSUMS:
   Yoga: c2b1f2494060865ac1f27e49639e72371b1205fa
   ZXingObjC: fdbb269f25dd2032da343e06f10224d62f537bdb
 
-PODFILE CHECKSUM: 88110908da5b2f787de03596e3492c51cf175302
+PODFILE CHECKSUM: 8a469077ac39b3a18e077c4f4da370423300396b
 
 COCOAPODS: 1.11.2

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -50,10 +50,10 @@ PODS:
   - EXFirebaseAnalytics (7.1.1):
     - EXFirebaseCore
     - ExpoModulesCore
-    - Firebase/Core (= 8.14.0)
+    - Firebase/Core (= 9.5.0)
   - EXFirebaseCore (5.1.1):
     - ExpoModulesCore
-    - Firebase/Core (= 8.14.0)
+    - Firebase/Core (= 9.5.0)
   - EXFont (10.2.0):
     - ExpoModulesCore
   - EXGL (11.4.0):
@@ -240,65 +240,68 @@ PODS:
     - React-Core (= 0.69.5)
     - React-jsi (= 0.69.5)
     - ReactCommon/turbomodule/core (= 0.69.5)
-  - Firebase/Core (8.14.0):
+  - Firebase/Core (9.5.0):
     - Firebase/CoreOnly
-    - FirebaseAnalytics (~> 8.14.0)
-  - Firebase/CoreOnly (8.14.0):
-    - FirebaseCore (= 8.14.0)
-  - FirebaseAnalytics (8.14.0):
-    - FirebaseAnalytics/AdIdSupport (= 8.14.0)
-    - FirebaseCore (~> 8.0)
-    - FirebaseInstallations (~> 8.0)
+    - FirebaseAnalytics (~> 9.5.0)
+  - Firebase/CoreOnly (9.5.0):
+    - FirebaseCore (= 9.5.0)
+  - FirebaseAnalytics (9.5.0):
+    - FirebaseAnalytics/AdIdSupport (= 9.5.0)
+    - FirebaseCore (~> 9.0)
+    - FirebaseInstallations (~> 9.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
     - GoogleUtilities/MethodSwizzler (~> 7.7)
     - GoogleUtilities/Network (~> 7.7)
     - "GoogleUtilities/NSData+zlib (~> 7.7)"
-    - nanopb (~> 2.30908.0)
-  - FirebaseAnalytics/AdIdSupport (8.14.0):
-    - FirebaseCore (~> 8.0)
-    - FirebaseInstallations (~> 8.0)
-    - GoogleAppMeasurement (= 8.14.0)
+    - nanopb (< 2.30910.0, >= 2.30908.0)
+  - FirebaseAnalytics/AdIdSupport (9.5.0):
+    - FirebaseCore (~> 9.0)
+    - FirebaseInstallations (~> 9.0)
+    - GoogleAppMeasurement (= 9.5.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
     - GoogleUtilities/MethodSwizzler (~> 7.7)
     - GoogleUtilities/Network (~> 7.7)
     - "GoogleUtilities/NSData+zlib (~> 7.7)"
-    - nanopb (~> 2.30908.0)
-  - FirebaseCore (8.14.0):
-    - FirebaseCoreDiagnostics (~> 8.0)
+    - nanopb (< 2.30910.0, >= 2.30908.0)
+  - FirebaseCore (9.5.0):
+    - FirebaseCoreDiagnostics (~> 9.0)
+    - FirebaseCoreInternal (~> 9.0)
     - GoogleUtilities/Environment (~> 7.7)
     - GoogleUtilities/Logger (~> 7.7)
-  - FirebaseCoreDiagnostics (8.15.0):
-    - GoogleDataTransport (~> 9.1)
+  - FirebaseCoreDiagnostics (9.5.0):
+    - GoogleDataTransport (< 10.0.0, >= 9.1.4)
     - GoogleUtilities/Environment (~> 7.7)
     - GoogleUtilities/Logger (~> 7.7)
-    - nanopb (~> 2.30908.0)
-  - FirebaseInstallations (8.15.0):
-    - FirebaseCore (~> 8.0)
+    - nanopb (< 2.30910.0, >= 2.30908.0)
+  - FirebaseCoreInternal (9.5.0):
+    - "GoogleUtilities/NSData+zlib (~> 7.7)"
+  - FirebaseInstallations (9.5.0):
+    - FirebaseCore (~> 9.0)
     - GoogleUtilities/Environment (~> 7.7)
     - GoogleUtilities/UserDefaults (~> 7.7)
-    - PromisesObjC (< 3.0, >= 1.2)
+    - PromisesObjC (~> 2.1)
   - fmt (6.2.1)
   - glog (0.3.5)
-  - GoogleAppMeasurement (8.14.0):
-    - GoogleAppMeasurement/AdIdSupport (= 8.14.0)
+  - GoogleAppMeasurement (9.5.0):
+    - GoogleAppMeasurement/AdIdSupport (= 9.5.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
     - GoogleUtilities/MethodSwizzler (~> 7.7)
     - GoogleUtilities/Network (~> 7.7)
     - "GoogleUtilities/NSData+zlib (~> 7.7)"
-    - nanopb (~> 2.30908.0)
-  - GoogleAppMeasurement/AdIdSupport (8.14.0):
-    - GoogleAppMeasurement/WithoutAdIdSupport (= 8.14.0)
+    - nanopb (< 2.30910.0, >= 2.30908.0)
+  - GoogleAppMeasurement/AdIdSupport (9.5.0):
+    - GoogleAppMeasurement/WithoutAdIdSupport (= 9.5.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
     - GoogleUtilities/MethodSwizzler (~> 7.7)
     - GoogleUtilities/Network (~> 7.7)
     - "GoogleUtilities/NSData+zlib (~> 7.7)"
-    - nanopb (~> 2.30908.0)
-  - GoogleAppMeasurement/WithoutAdIdSupport (8.14.0):
+    - nanopb (< 2.30910.0, >= 2.30908.0)
+  - GoogleAppMeasurement/WithoutAdIdSupport (9.5.0):
     - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
     - GoogleUtilities/MethodSwizzler (~> 7.7)
     - GoogleUtilities/Network (~> 7.7)
     - "GoogleUtilities/NSData+zlib (~> 7.7)"
-    - nanopb (~> 2.30908.0)
+    - nanopb (< 2.30910.0, >= 2.30908.0)
   - GoogleDataTransport (9.1.4):
     - GoogleUtilities/Environment (~> 7.7)
     - nanopb (< 2.30910.0, >= 2.30908.0)
@@ -379,7 +382,7 @@ PODS:
   - nanopb/decode (2.30908.0)
   - nanopb/encode (2.30908.0)
   - Nimble (9.2.1)
-  - PromisesObjC (2.1.0)
+  - PromisesObjC (2.1.1)
   - Protobuf (3.20.1)
   - Quick (5.0.1)
   - RCT-Folly (2021.06.28.00-v2):
@@ -919,6 +922,7 @@ SPEC REPOS:
     - FirebaseAnalytics
     - FirebaseCore
     - FirebaseCoreDiagnostics
+    - FirebaseCoreInternal
     - FirebaseInstallations
     - fmt
     - GoogleAppMeasurement
@@ -1274,8 +1278,8 @@ SPEC CHECKSUMS:
   EXErrorRecovery: 74d71ee59f6814315457b09d68e86aa95cc7d05d
   EXFaceDetector: 6e4d4a8ce54ebe3c939b287bd111a6c151dfbc43
   EXFileSystem: 5733242b9545bfebb5584769083de35d21578853
-  EXFirebaseAnalytics: 15c5f2d5bae6668ecb1104f98b2b74a2d9fd3740
-  EXFirebaseCore: 9ee5a9691a8480f0fbaeb7f3cd135f256d436fdf
+  EXFirebaseAnalytics: 8713dd05a7d30100571517270b844c40ccc1b467
+  EXFirebaseCore: 7ca84e92f9c27949114c240918e164d2558c6a8b
   EXFont: a5d80bd9b3452b2d5abbce2487da89b0150e6487
   EXGL: 764f418a6ea75d59903f870842af2cf28947b86d
   EXGL_CPP: 675bb4ef2987925ab05981b41110e8db9c8fcf58
@@ -1327,14 +1331,15 @@ SPEC CHECKSUMS:
   EXVideoThumbnails: 486533e1a66c9859f9b9e3b2e1f9f0b275515b48
   FBLazyVector: 0045cf98ca4a48af3bf7108d85b1c243740fa289
   FBReactNativeSpec: 3bb5eb657e2de9e0f17dd2ded43576906de5611a
-  Firebase: 7e8fe528c161b9271d365217a74c16aaf834578e
-  FirebaseAnalytics: 2fc3876e2eb347673ad2f35e249ae7b15d6c88f5
-  FirebaseCore: b84a44ee7ba999e0f9f76d198a9c7f60a797b848
-  FirebaseCoreDiagnostics: 92e07a649aeb66352b319d43bdd2ee3942af84cb
-  FirebaseInstallations: 40bd9054049b2eae9a2c38ef1c3dd213df3605cd
+  Firebase: 800f16f07af493d98d017446a315c27af0552f41
+  FirebaseAnalytics: 1b60984a408320dda637306f3f733699ef8473d7
+  FirebaseCore: 25c0400b670fd1e2f2104349cd3b5dcce8d9418f
+  FirebaseCoreDiagnostics: 17cbf4e72b1dbd64bfdc33d4b1f07bce4f16f1d8
+  FirebaseCoreInternal: 50a8e39cae8abf72d5145d07ea34c3244f70862b
+  FirebaseInstallations: 41f811b530c41dd90973d0174381cdb3fcb5e839
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 3d02b25ca00c2d456734d0bcff864cbc62f6ae1a
-  GoogleAppMeasurement: 71156240babd3cc6ced03e0d54816f01a880c730
+  GoogleAppMeasurement: 6ee231473fbd75c11221dfce489894334024eead
   GoogleDataTransport: 5fffe35792f8b96ec8d6775f5eccd83c998d5a3b
   GoogleMLKit: 755661c46990a85e42278015f26400286d98ad95
   GoogleToolboxForMac: 8bef7c7c5cf7291c687cf5354f39f9db6399ad34
@@ -1350,7 +1355,7 @@ SPEC CHECKSUMS:
   MLKitVision: e87dc3f2e456a6ab32361ebd985e078dd2746143
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
   Nimble: d954d0accfd082f2225e62d71008440493e318f4
-  PromisesObjC: 99b6f43f9e1044bd87a95a60beff28c2c44ddb72
+  PromisesObjC: ab77feca74fa2823e7af4249b8326368e61014cb
   Protobuf: b60ec2f51ad74765f44d0c09d2e0579d7de21745
   Quick: 749aa754fd1e7d984f2000fe051e18a3a9809179
   RCT-Folly: b9d9fe1fc70114b751c076104e52f3b1b5e5a95a
@@ -1404,6 +1409,6 @@ SPEC CHECKSUMS:
   Yoga: c2b1f2494060865ac1f27e49639e72371b1205fa
   ZXingObjC: fdbb269f25dd2032da343e06f10224d62f537bdb
 
-PODFILE CHECKSUM: f12343e83990a41a0ec9d3997ccf1664f2d84abb
+PODFILE CHECKSUM: 0358a5fe9d2485c66be187803b11513ce6319d05
 
 COCOAPODS: 1.11.2

--- a/packages/expo-firebase-analytics/CHANGELOG.md
+++ b/packages/expo-firebase-analytics/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### 💡 Others
 
+- On Android bumped `com.google.firebase:firebase-core:20.1.2 ➡️ 21.1.0`, `com.google.firebase:firebase-common:20.1.0 ➡️ 20.1.1`, and `com.google.firebase:firebase-analytics:20.1.2 ➡️ 21.1.0` ([#18908](https://github.com/expo/expo/pull/18908) by [@keith-kurak](https://github.com/keith-kurak))
+- On iOS bumped `Firebase/Core@8.14.0 ➡️ 9.5.0`. ([#18908](https://github.com/expo/expo/pull/18908) by [@keith-kurak](https://github.com/keith-kurak))
+
 ## 7.1.1 — 2022-07-16
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-firebase-analytics/android/build.gradle
+++ b/packages/expo-firebase-analytics/android/build.gradle
@@ -91,9 +91,11 @@ dependencies {
   // project :expo > host.exp.exponent:expo-firebase-analytics:X.X.X
   // project :expo > host.exp.exponent:expo-firebase-core:X.X.X
   // api platform("com.google.firebase:firebase-bom:24.1.0")
-  api 'com.google.firebase:firebase-core:20.1.2'
-  api 'com.google.firebase:firebase-common:20.1.0'
-  api 'com.google.firebase:firebase-analytics:20.1.2'
+  // See https://firebase.google.com/support/release-notes/android 
+  // for individual package versions for latest BOM version specified in react-native-firebase
+  api 'com.google.firebase:firebase-core:21.1.0'
+  api 'com.google.firebase:firebase-common:20.1.1'
+  api 'com.google.firebase:firebase-analytics:21.1.0'
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
 }

--- a/packages/expo-firebase-analytics/android/build.gradle
+++ b/packages/expo-firebase-analytics/android/build.gradle
@@ -91,7 +91,7 @@ dependencies {
   // project :expo > host.exp.exponent:expo-firebase-analytics:X.X.X
   // project :expo > host.exp.exponent:expo-firebase-core:X.X.X
   // api platform("com.google.firebase:firebase-bom:24.1.0")
-  // See https://firebase.google.com/support/release-notes/android 
+  // See https://firebase.google.com/support/release-notes/android
   // for individual package versions for latest BOM version specified in react-native-firebase
   api 'com.google.firebase:firebase-core:21.1.0'
   api 'com.google.firebase:firebase-common:20.1.1'

--- a/packages/expo-firebase-analytics/ios/EXFirebaseAnalytics.podspec
+++ b/packages/expo-firebase-analytics/ios/EXFirebaseAnalytics.podspec
@@ -2,7 +2,7 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, '..', 'package.json')))
 
-firebase_sdk_version = '8.14.0'
+firebase_sdk_version = '9.5.0'
 if defined? $FirebaseSDKVersion
   firebase_sdk_version = $FirebaseSDKVersion
 end

--- a/packages/expo-firebase-core/CHANGELOG.md
+++ b/packages/expo-firebase-core/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### 💡 Others
 
+- On Android bumped `com.google.firebase:firebase-core:20.1.2 ➡️ 21.1.0` and `com.google.firebase:firebase-common:20.1.0 ➡️ 20.1.1`. ([#18908](https://github.com/expo/expo/pull/18908) by [@keith-kurak](https://github.com/keith-kurak))
+- On iOS bumped `Firebase/Core@8.14.0 ➡️ 9.5.0`. ([#18908](https://github.com/expo/expo/pull/18908) by [@keith-kurak](https://github.com/keith-kurak))
+
 ## 5.1.1 — 2022-07-16
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-firebase-core/android/build.gradle
+++ b/packages/expo-firebase-core/android/build.gradle
@@ -90,8 +90,10 @@ dependencies {
   // project :expo > host.exp.exponent:expo-firebase-analytics:X.X.X
   // project :expo > host.exp.exponent:expo-firebase-core:X.X.X
   // api platform("com.google.firebase:firebase-bom:24.1.0")
-  api 'com.google.firebase:firebase-core:20.1.2'
-  api 'com.google.firebase:firebase-common:20.1.0'
+  // See https://firebase.google.com/support/release-notes/android 
+  // for individual package versions for latest BOM version specified in react-native-firebase
+  api 'com.google.firebase:firebase-core:21.1.0'
+  api 'com.google.firebase:firebase-common:20.1.1'
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
 }

--- a/packages/expo-firebase-core/android/build.gradle
+++ b/packages/expo-firebase-core/android/build.gradle
@@ -90,7 +90,7 @@ dependencies {
   // project :expo > host.exp.exponent:expo-firebase-analytics:X.X.X
   // project :expo > host.exp.exponent:expo-firebase-core:X.X.X
   // api platform("com.google.firebase:firebase-bom:24.1.0")
-  // See https://firebase.google.com/support/release-notes/android 
+  // See https://firebase.google.com/support/release-notes/android
   // for individual package versions for latest BOM version specified in react-native-firebase
   api 'com.google.firebase:firebase-core:21.1.0'
   api 'com.google.firebase:firebase-common:20.1.1'

--- a/packages/expo-firebase-core/ios/EXFirebaseCore.podspec
+++ b/packages/expo-firebase-core/ios/EXFirebaseCore.podspec
@@ -2,7 +2,7 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, '..', 'package.json')))
 
-firebase_sdk_version = '8.14.0'
+firebase_sdk_version = '9.5.0'
 if defined? $FirebaseSDKVersion
   firebase_sdk_version = $FirebaseSDKVersion
 end

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -107,6 +107,5 @@
   "unimodules-image-loader-interface": "~6.1.0",
   "@shopify/react-native-skia": "0.1.137",
   "@shopify/flash-list": "1.1.0",
-  "@sentry/react-native": "^4.1.3",
-  
+  "@sentry/react-native": "^4.1.3"
 }

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -6,6 +6,7 @@
   "@react-native-community/netinfo": "9.3.0",
   "@react-native-community/slider": "4.2.3",
   "@react-native-community/viewpager": "5.0.11",
+  "@react-native-firebase/app": "~15.4.0",
   "@react-native-picker/picker": "2.4.2",
   "@react-native-segmented-control/segmented-control": "2.4.0",
   "@stripe/stripe-react-native": "0.13.1",
@@ -106,5 +107,6 @@
   "unimodules-image-loader-interface": "~6.1.0",
   "@shopify/react-native-skia": "0.1.137",
   "@shopify/flash-list": "1.1.0",
-  "@sentry/react-native": "^4.1.3"
+  "@sentry/react-native": "^4.1.3",
+  
 }


### PR DESCRIPTION
# Why

Fulfills [ENG-5762](https://linear.app/expo/issue/ENG-5762/bump-firebase-native-version-from-8-9-for-our-firebase-packages), preventing version conflict errors between Expo Firebase packages and `@react-native-firebase` packages on `pod install`, etc.

# How

Updated native Firebase module versions to match those in latest `@react-native-firebase/app` (15.4.0). For Android, compared BOM version from RN Firebase with individual versions specified in [Google's upgrade tool](https://firebase.google.com/support/release-notes/android).

Also added `@react-native-firebase/app` to **bundledNativeVersions.json**, as, while there are scenarios where it would be fine to use a later version, using a later version with the Expo Firebase packages is likely to cause an error, as RN Firebase frequently upgrades the native versions on minor revisions. Seems similar to how we now treat `@sentry/react-native`.

# Possible documentation updates

In order to successfully test, I had to employ workarounds documented in open issues on the react-native-firebase and firebase-js-sdk repos. Happy to include documentation tweaks with this PR, but wanted some feedback on their appropriateness first:

## "The following Swift pods cannot yet be integrated as static libraries" error on pod install (https://github.com/invertase/react-native-firebase/issues/6332)
[This workaround using the expo-build-properties plugin ](https://github.com/invertase/react-native-firebase/issues/6332#issuecomment-1172950523) worked for me, also seemed to be the most congruent with the maintainer's feedback on the thread. This workaround is needed even if you only include the Expo Firebase modules, so my thought was that we should include it in our Firebase guides, [even as we try to delegate more native config to RN Firebase's docs](https://github.com/expo/expo/pull/18881). One big drawback of this workaround is that Flipper is not yet compatible with it, but that tradeoff seems preferable to the options that involve either downgrading to 14.x or certain Firebase features not working.

## Error: While trying to resolve module idb (https://github.com/firebase/firebase-js-sdk/issues/6253)
This error seems to occur with any use of the Firebase JS SDK, and is worked around with a [Metro config tweak](https://github.com/firebase/firebase-js-sdk/issues/6253#issuecomment-1123923581). Could be resolved with an update to the idb package.

(also reported here: https://github.com/expo/expo/issues/17469)

# Test Plan

Imported `@react-native-firebase/app`, `expo-firebase-analytics`, and `expo-firebase-recaptcha` into fresh SDK 46 app, ran prebuild and built locally. Init'ed recaptcha components sent test analytics events.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
