### PR TITLE
[expo-print] Fix crash when writing PDF

### DIFF
--- a/packages/expo-print/CHANGELOG.md
+++ b/packages/expo-print/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix crash on some Android devices when WebView returns an unknown error. ([#18911](https://github.com/expo/expo/pull/18911) by [@matkastner](https://github.com/matkastner))
+
 ### 💡 Others
 
 ## 11.3.0 — 2022-07-07

--- a/packages/expo-print/android/src/main/java/expo/modules/print/PrintPDFRenderTask.kt
+++ b/packages/expo-print/android/src/main/java/expo/modules/print/PrintPDFRenderTask.kt
@@ -110,7 +110,7 @@ class PrintPDFRenderTask(private val context: Context, private val options: Map<
       callbacks.onRenderFinished(document, outputFile, numberOfPages)
     }
 
-    override fun onWriteFailed(error: CharSequence) {
+    override fun onWriteFailed(error: CharSequence?) {
       callbacks.onRenderError("E_PRINT_FAILED", "An error occurred while writing PDF data.", null)
     }
   }


### PR DESCRIPTION
# Why

When printing to file multiple times on some devices, expo-print crashes with java.lang.NullPointerException. This is because the callback method onWriteFailed does not accept null arguments.

# How

I have created an issue #18910 which describes the steps I've taken to create this bug including a snack that can reproduce it on some devices. The crash is caused by something in WebView and I traced it back to the Android docs here:

https://developer.android.com/reference/android/print/PrintDocumentAdapter.WriteResultCallback#onWriteFailed(java.lang.CharSequence)

> May be null if error is unknown.

I am not sure on the reason for the error being unknown - `expo-print` should handle this gracefully though instead of crashing out completely.

# Test Plan

I have created the following snack (really bad code I know, but demonstrates the idea - in reality I have a multiple print queues that happen to fire at the same time, it seems to happen when printToFileAsync is run twice at once.

https://snack.expo.dev/@mat.kastner/recreate-expo-print-crash

With `expo-print` version 11.3.0 if you hit the print button multiple times it can crash with a SIGABRT exception on some devices - possibly due to memory limits or cache access issues. When I make the change in this PR locally, the app no longer crashes completely and will reject the promise with the error as expected.

To test this, try running the snack on an older device (in my case a Sunmi V2 Pro).

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
