### PR TITLE
changed minInterval value for testing in android

### DIFF
--- a/docs/pages/versions/unversioned/sdk/background-fetch.md
+++ b/docs/pages/versions/unversioned/sdk/background-fetch.md
@@ -154,7 +154,7 @@ For Android, you can set the `minimumInterval` option of your task to a small nu
 ```tsx
 async function registerBackgroundFetchAsync() {
   return BackgroundFetch.registerTaskAsync(BACKGROUND_FETCH_TASK, {
-    minimumInterval: 1, // task will fire 1 minute after app is backgrounded
+    minimumInterval: 1 * 60, // task will fire 1 minute after app is backgrounded
   });
 }
 ```


### PR DESCRIPTION
In this page we want a user to test the background tasks in android by changing the minInterval to 1 min but, earlier it was written as  'minInterval : 1', which is wrong because the minInterval takes the value in seconds so, I updated that value to 'minInterval : 1 * 60'.

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
