### PR TITLE
[ENG-3865][docs] update docs on EAS Build artifacts

### DIFF
--- a/docs/pages/build-reference/android-builds.md
+++ b/docs/pages/build-reference/android-builds.md
@@ -51,7 +51,7 @@ Next, this is what happens when EAS Build picks up your request:
 1. If the build was successful: run the `eas-build-on-success` script from **package.json** if defined.
 1. If the build failed: run the `eas-build-on-error` script from **package.json** if defined.
 1. Run the `eas-build-on-complete` script from **package.json** if defined. The `EAS_BUILD_STATUS` env variable is set to either `finished` or `errored`.
-1. Upload the build artifacts archive to a private AWS S3 bucket if `buildArtifactsPaths` is specified in the build profile.
+1. Upload the build artifacts archive to a private AWS S3 bucket if `buildArtifactPaths` is specified in the build profile.
 
 ## Project Auto-Configuration
 

--- a/docs/pages/build-reference/android-builds.md
+++ b/docs/pages/build-reference/android-builds.md
@@ -44,13 +44,14 @@ Next, this is what happens when EAS Build picks up your request:
 
 1. **Deprecated:** Run the `eas-build-pre-upload-artifacts` script from **package.json** if defined.
 1. Store a cache of files and directories defined in the build profile. Subsequent builds will restore this cache. ([Learn more](../build/eas-json/).)
-1. Upload the build artifact to AWS S3.
+1. Upload the application archive to AWS S3.
 
-   - The artifact path can be configured in **eas.json** at `builds.android.PROFILE_NAME.artifactPath`. It defaults to `android/app/build/outputs/**/*.{apk,aab}`. We're using the [fast-glob](https://github.com/mrmlnc/fast-glob#pattern-syntax) package for pattern matching.
+   - The artifact path can be configured in **eas.json** at `builds.android.PROFILE_NAME.applicationArchivePath`. It defaults to `android/app/build/outputs/**/*.{apk,aab}`. We're using the [fast-glob](https://github.com/mrmlnc/fast-glob#pattern-syntax) package for pattern matching.
 
 1. If the build was successful: run the `eas-build-on-success` script from **package.json** if defined.
 1. If the build failed: run the `eas-build-on-error` script from **package.json** if defined.
 1. Run the `eas-build-on-complete` script from **package.json** if defined. The `EAS_BUILD_STATUS` env variable is set to either `finished` or `errored`.
+1. Upload the build artifacts archive to a private AWS S3 bucket if `buildArtifactsPaths` is specified in the build profile.
 
 ## Project Auto-Configuration
 

--- a/docs/pages/build-reference/ios-builds.md
+++ b/docs/pages/build-reference/ios-builds.md
@@ -57,7 +57,7 @@ In this next phase, this is what happens when EAS Build picks up your request:
 1. If the build was successful: run the `eas-build-on-success` script from **package.json** if defined.
 1. If the build failed: run the `eas-build-on-error` script from **package.json** if defined.
 1. Run the `eas-build-on-complete` script from **package.json** if defined. The `EAS_BUILD_STATUS` env variable is set to either `finished` or `errored`.
-1. Upload the build artifacts archive to a private AWS S3 bucket if `buildArtifactsPaths` is specified in the build profile.
+1. Upload the build artifacts archive to a private AWS S3 bucket if `buildArtifactPaths` is specified in the build profile.
 
 ## Building iOS Projects With Fastlane
 

--- a/docs/pages/build-reference/ios-builds.md
+++ b/docs/pages/build-reference/ios-builds.md
@@ -50,13 +50,14 @@ In this next phase, this is what happens when EAS Build picks up your request:
 1. Run `fastlane gym` in the **ios** directory.
 1. **Deprecated:** Run the `eas-build-pre-upload-artifacts` script from **package.json** if defined.
 1. Store a cache of files and directories defined in the build profile. `Podfile.lock` is cached by default. Subsequent builds will restore this cache. ([Learn more](../build/eas-json/).)
-1. Upload the build artifact to a private AWS S3 bucket.
+1. Upload the application archive to a private AWS S3 bucket.
 
-   - The artifact path can be configured in **eas.json** at `builds.ios.PROFILE_NAME.artifactPath`. It defaults to **ios/build/App.ipa**. You can specify a glob-like pattern for `artifactPath`. We're using the [fast-glob](https://github.com/mrmlnc/fast-glob#pattern-syntax) package under the hood.
+   - The artifact path can be configured in **eas.json** at `builds.ios.PROFILE_NAME.applicationArchivePath`. It defaults to **ios/build/App.ipa**. You can specify a glob-like pattern for `applicationArchivePath`. We're using the [fast-glob](https://github.com/mrmlnc/fast-glob#pattern-syntax) package under the hood.
 
 1. If the build was successful: run the `eas-build-on-success` script from **package.json** if defined.
 1. If the build failed: run the `eas-build-on-error` script from **package.json** if defined.
 1. Run the `eas-build-on-complete` script from **package.json** if defined. The `EAS_BUILD_STATUS` env variable is set to either `finished` or `errored`.
+1. Upload the build artifacts archive to a private AWS S3 bucket if `buildArtifactsPaths` is specified in the build profile.
 
 ## Building iOS Projects With Fastlane
 

--- a/docs/scripts/schemas/unversioned/eas-json-build-android-schema.js
+++ b/docs/scripts/schemas/unversioned/eas-json-build-android-schema.js
@@ -50,10 +50,10 @@ export default [
     ],
   },
   {
-    name: 'artifactPath',
+    name: 'applicationArchivePath',
     type: 'string',
     description: [
-      'Path (or pattern) where EAS Build is going to look for the build artifacts. EAS Build uses the `fast-glob` npm package for pattern matching ([see their README to learn more about the syntax you can use](https://github.com/mrmlnc/fast-glob#pattern-syntax)). The default value is `android/app/build/outputs/**/*.{apk,aab}`.'
+      'Path (or pattern) where EAS Build is going to look for the application archive. EAS Build uses the `fast-glob` npm package for pattern matching ([see their README to learn more about the syntax you can use](https://github.com/mrmlnc/fast-glob#pattern-syntax)). The default value is `android/app/build/outputs/**/*.{apk,aab}`.'
     ],
   },
 ]

--- a/docs/scripts/schemas/unversioned/eas-json-build-common-schema.js
+++ b/docs/scripts/schemas/unversioned/eas-json-build-common-schema.js
@@ -59,11 +59,11 @@ export default [
     ],
   },
   {
-    name: 'buildArtifactsPaths',
+    name: 'buildartifactPaths',
     type: 'string[]',
     description: [
-      'List of paths (or patterns) where EAS Build is going to look for the build artifacts. Use `applicationArchivePath` for specifying the path for uploading the application archive. Build artifacts are uploaded even if the build fails. EAS Build uses the `fast-glob` npm package for pattern matching ([see their README to learn more about the syntax you can use](https://github.com/mrmlnc/fast-glob#pattern-syntax)).'
-    ]
+      'List of paths (or patterns) where EAS Build is going to look for the build artifacts. Use `applicationArchivePath` for specifying the path for uploading the application archive. Build artifacts are uploaded even if the build fails. EAS Build uses the `fast-glob` npm package for pattern matching ([see their README to learn more about the syntax you can use](https://github.com/mrmlnc/fast-glob#pattern-syntax)).',
+    ],
   },
   {
     name: 'node',

--- a/docs/scripts/schemas/unversioned/eas-json-build-common-schema.js
+++ b/docs/scripts/schemas/unversioned/eas-json-build-common-schema.js
@@ -10,7 +10,7 @@ export default [
     name: 'credentialsSource',
     enum: ['local', 'remote'],
     description: [
-      'The source of credentials used to sign build artifacts.',
+      'The source of credentials used to sign the application archive.',
       ' - `local` - if you want to provide your own `credentials.json` file. ([Learn more on this here](/app-signing/local-credentials).)',
       ' - `remote` - if you want to use the credentials managed by EAS (this is the default option).',
     ],
@@ -57,6 +57,13 @@ export default [
       'Note: `--platform` and `--non-interactive` will be added automatically by the build engine, so you do not need to specify them manually.',
       '[Learn more about prebuild options](../../workflow/expo-cli/#expo-prebuild).',
     ],
+  },
+  {
+    name: 'buildArtifactsPaths',
+    type: 'string[]',
+    description: [
+      'List of paths (or patterns) where EAS Build is going to look for the build artifacts. Use `applicationArchivePath` for specifying the path for uploading the application archive. Build artifacts are uploaded even if the build fails. EAS Build uses the `fast-glob` npm package for pattern matching ([see their README to learn more about the syntax you can use](https://github.com/mrmlnc/fast-glob#pattern-syntax)).'
+    ]
   },
   {
     name: 'node',

--- a/docs/scripts/schemas/unversioned/eas-json-build-common-schema.js
+++ b/docs/scripts/schemas/unversioned/eas-json-build-common-schema.js
@@ -59,7 +59,7 @@ export default [
     ],
   },
   {
-    name: 'buildartifactPaths',
+    name: 'buildArtifactPaths',
     type: 'string[]',
     description: [
       'List of paths (or patterns) where EAS Build is going to look for the build artifacts. Use `applicationArchivePath` for specifying the path for uploading the application archive. Build artifacts are uploaded even if the build fails. EAS Build uses the `fast-glob` npm package for pattern matching ([see their README to learn more about the syntax you can use](https://github.com/mrmlnc/fast-glob#pattern-syntax)).',

--- a/docs/scripts/schemas/unversioned/eas-json-build-ios-schema.js
+++ b/docs/scripts/schemas/unversioned/eas-json-build-ios-schema.js
@@ -71,10 +71,10 @@ export default [
     ],
   },
   {
-    name: 'artifactPath',
+    name: 'applicationArchivePath',
     type: 'string',
     description: [
-      'Path (or pattern) where EAS Build is going to look for the build artifacts. EAS Build uses the `fast-glob` npm package for pattern matching, ([see their README to learn more about the syntax you can use](https://github.com/mrmlnc/fast-glob#pattern-syntax)). You should modify that path only if you are using a custom `Gymfile`. The default is `ios/build/Build/Products/*-iphonesimulator/*.app` when building for simulator and `ios/build/*.ipa` in other cases.'
+      'Path (or pattern) where EAS Build is going to look for the application archive. EAS Build uses the `fast-glob` npm package for pattern matching ([see their README to learn more about the syntax you can use](https://github.com/mrmlnc/fast-glob#pattern-syntax)). You should modify that path only if you are using a custom `Gymfile`. The default is `ios/build/Build/Products/*-iphonesimulator/*.app` when building for simulator and `ios/build/*.ipa` in other cases.'
     ],
   },
 ]


### PR DESCRIPTION
A follow-up to changes in https://github.com/expo/eas-cli/pull/1321:
- rename `artifactPath` to `applicationArchivePath` 
- add `buildArtifactsPaths` that can be used to upload any arbitrary build artifacts
