### PR TITLE
[docs] APISection: small tweaks for the display, fix spacing

### DIFF
--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -4496,7 +4496,7 @@ OAuth 2.0 protocol
       class="css-1xaswp1-APISectionEnums"
     >
       <div
-        class="css-m07iiw-APISectionEnums"
+        class="css-6gai93-APISectionEnums"
       >
         <h4
           class="  css-uucypz-H4"
@@ -4574,7 +4574,7 @@ OAuth 2.0 protocol
       class="css-1xaswp1-APISectionEnums"
     >
       <div
-        class="css-m07iiw-APISectionEnums"
+        class="css-6gai93-APISectionEnums"
       >
         <h4
           class="  css-uucypz-H4"
@@ -4652,7 +4652,7 @@ OAuth 2.0 protocol
       class="css-1xaswp1-APISectionEnums"
     >
       <div
-        class="css-m07iiw-APISectionEnums"
+        class="css-6gai93-APISectionEnums"
       >
         <h4
           class="  css-uucypz-H4"
@@ -4806,7 +4806,7 @@ OAuth 2.0 protocol
       class="css-1xaswp1-APISectionEnums"
     >
       <div
-        class="css-m07iiw-APISectionEnums"
+        class="css-6gai93-APISectionEnums"
       >
         <h4
           class="  css-uucypz-H4"
@@ -4884,7 +4884,7 @@ OAuth 2.0 protocol
       class="css-1xaswp1-APISectionEnums"
     >
       <div
-        class="css-m07iiw-APISectionEnums"
+        class="css-6gai93-APISectionEnums"
       >
         <h4
           class="  css-uucypz-H4"
@@ -4995,7 +4995,7 @@ OAuth 2.0 protocol
       </div>
       <br />
       <div
-        class="css-m07iiw-APISectionEnums"
+        class="css-6gai93-APISectionEnums"
       >
         <h4
           class="  css-uucypz-H4"
@@ -5193,7 +5193,7 @@ for more details.
       class="css-1xaswp1-APISectionEnums"
     >
       <div
-        class="css-m07iiw-APISectionEnums"
+        class="css-6gai93-APISectionEnums"
       >
         <h4
           class="  css-uucypz-H4"
@@ -5265,7 +5265,7 @@ for more details.
       class="css-1xaswp1-APISectionEnums"
     >
       <div
-        class="css-m07iiw-APISectionEnums"
+        class="css-6gai93-APISectionEnums"
       >
         <h4
           class="  css-uucypz-H4"
@@ -5337,7 +5337,7 @@ for more details.
       class="css-1xaswp1-APISectionEnums"
     >
       <div
-        class="css-m07iiw-APISectionEnums"
+        class="css-6gai93-APISectionEnums"
       >
         <h4
           class="  css-uucypz-H4"
@@ -5409,7 +5409,7 @@ for more details.
       class="css-1xaswp1-APISectionEnums"
     >
       <div
-        class="css-m07iiw-APISectionEnums"
+        class="css-6gai93-APISectionEnums"
       >
         <h4
           class="  css-uucypz-H4"
@@ -5540,7 +5540,7 @@ for more details.
       class="css-1xaswp1-APISectionEnums"
     >
       <div
-        class="css-m07iiw-APISectionEnums"
+        class="css-6gai93-APISectionEnums"
       >
         <h4
           class="  css-uucypz-H4"
@@ -5618,7 +5618,7 @@ for more details.
       class="css-1xaswp1-APISectionEnums"
     >
       <div
-        class="css-m07iiw-APISectionEnums"
+        class="css-6gai93-APISectionEnums"
       >
         <h4
           class="  css-uucypz-H4"
@@ -5690,7 +5690,7 @@ for more details.
       class="css-1xaswp1-APISectionEnums"
     >
       <div
-        class="css-m07iiw-APISectionEnums"
+        class="css-6gai93-APISectionEnums"
       >
         <h4
           class="  css-uucypz-H4"
@@ -5762,7 +5762,7 @@ for more details.
       class="css-1xaswp1-APISectionEnums"
     >
       <div
-        class="css-m07iiw-APISectionEnums"
+        class="css-6gai93-APISectionEnums"
       >
         <h4
           class="  css-uucypz-H4"
@@ -5987,7 +5987,7 @@ for more details.
       class="css-1xaswp1-APISectionEnums"
     >
       <div
-        class="css-m07iiw-APISectionEnums"
+        class="css-6gai93-APISectionEnums"
       >
         <h4
           class="  css-uucypz-H4"
@@ -6059,7 +6059,7 @@ for more details.
       class="css-1xaswp1-APISectionEnums"
     >
       <div
-        class="css-m07iiw-APISectionEnums"
+        class="css-6gai93-APISectionEnums"
       >
         <h4
           class="  css-uucypz-H4"
@@ -6240,7 +6240,7 @@ for more details.
       class="css-1xaswp1-APISectionEnums"
     >
       <div
-        class="css-m07iiw-APISectionEnums"
+        class="css-6gai93-APISectionEnums"
       >
         <h4
           class="  css-uucypz-H4"
@@ -6318,7 +6318,7 @@ for more details.
       class="css-1xaswp1-APISectionEnums"
     >
       <div
-        class="css-m07iiw-APISectionEnums"
+        class="css-6gai93-APISectionEnums"
       >
         <h4
           class="  css-uucypz-H4"
@@ -6396,7 +6396,7 @@ for more details.
       class="css-1xaswp1-APISectionEnums"
     >
       <div
-        class="css-m07iiw-APISectionEnums"
+        class="css-6gai93-APISectionEnums"
       >
         <h4
           class="  css-uucypz-H4"
@@ -10067,7 +10067,7 @@ For some types, they will represent the area used by the scanner.
       class="css-1xaswp1-APISectionEnums"
     >
       <div
-        class="css-m07iiw-APISectionEnums"
+        class="css-6gai93-APISectionEnums"
       >
         <h4
           class="  css-uucypz-H4"
@@ -10145,7 +10145,7 @@ For some types, they will represent the area used by the scanner.
       class="css-1xaswp1-APISectionEnums"
     >
       <div
-        class="css-m07iiw-APISectionEnums"
+        class="css-6gai93-APISectionEnums"
       >
         <h4
           class="  css-uucypz-H4"
@@ -10223,7 +10223,7 @@ For some types, they will represent the area used by the scanner.
       class="css-1xaswp1-APISectionEnums"
     >
       <div
-        class="css-m07iiw-APISectionEnums"
+        class="css-6gai93-APISectionEnums"
       >
         <h4
           class="  css-uucypz-H4"
@@ -12394,7 +12394,7 @@ provided with a single argument that is
       class="css-1xaswp1-APISectionEnums"
     >
       <div
-        class="css-m07iiw-APISectionEnums"
+        class="css-6gai93-APISectionEnums"
       >
         <h4
           class="  css-uucypz-H4"
@@ -12466,7 +12466,7 @@ provided with a single argument that is
       class="css-1xaswp1-APISectionEnums"
     >
       <div
-        class="css-m07iiw-APISectionEnums"
+        class="css-6gai93-APISectionEnums"
       >
         <h4
           class="  css-uucypz-H4"
@@ -12538,7 +12538,7 @@ provided with a single argument that is
       class="css-1xaswp1-APISectionEnums"
     >
       <div
-        class="css-m07iiw-APISectionEnums"
+        class="css-6gai93-APISectionEnums"
       >
         <h4
           class="  css-uucypz-H4"

--- a/docs/components/plugins/api/APISectionEnums.tsx
+++ b/docs/components/plugins/api/APISectionEnums.tsx
@@ -69,6 +69,10 @@ const enumContainerStyle = css({
 
 const enumValueNameStyle = css({
   marginTop: spacing[3],
+
+  h4: {
+    marginTop: 0,
+  },
 });
 
 const enumValueStyles = css({

--- a/docs/components/plugins/api/APISectionMethods.tsx
+++ b/docs/components/plugins/api/APISectionMethods.tsx
@@ -6,6 +6,7 @@ import ReactMarkdown from 'react-markdown';
 import { InlineCode } from '~/components/base/code';
 import { LI, UL } from '~/components/base/list';
 import { H2, H3Code, H4, H4Code } from '~/components/plugins/Headings';
+import { APIDataType } from '~/components/plugins/api/APIDataType';
 import {
   MethodDefinitionData,
   MethodSignatureData,
@@ -72,7 +73,7 @@ export const renderMethod = (
                   size={iconSize.small}
                   css={returnIconStyles}
                 />
-                <InlineCode>{resolveTypeName(type)}</InlineCode>
+                <APIDataType typeDefinition={type} />
               </LI>
             </UL>
             {comment?.returns && (

--- a/docs/components/plugins/api/APISectionTypes.tsx
+++ b/docs/components/plugins/api/APISectionTypes.tsx
@@ -73,6 +73,7 @@ const renderTypePropertyRow = ({
 }: PropData): JSX.Element => {
   const initValue = parseCommentContent(defaultValue || getTagData('default', comment)?.text);
   const commentData = getCommentOrSignatureComment(comment, signatures);
+  const hasDeprecationNote = Boolean(getTagData('deprecated', comment));
   return (
     <Row key={name}>
       <Cell fitContent>
@@ -87,7 +88,7 @@ const renderTypePropertyRow = ({
           comment={commentData}
           components={mdInlineComponents}
           afterContent={renderDefaultValue(initValue)}
-          emptyCommentFallback="-"
+          emptyCommentFallback={hasDeprecationNote ? undefined : '-'}
         />
       </Cell>
     </Row>

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -589,6 +589,10 @@ export const STYLES_APIBOX = css({
 
 export const STYLES_APIBOX_NESTED = css({
   boxShadow: 'none',
+
+  h4: {
+    marginTop: 0,
+  },
 });
 
 export const STYLES_NESTED_SECTION_HEADER = css({


### PR DESCRIPTION
# Why

During work on the doc comment typos and validating the changes I have spotted few minor display regressions after the typography PR has landed and an issue with rendering return method type.

# How

This PR fixes the spacing issues introduced with the typography changes, fixes the incorrect rendering of block types in method returns and removed an additional empty comment marking, when the entry has the deprecation note.

# Test Plan

The changes have been tested by running docs website locally.

## Preview

<img width="1115" alt="Screenshot 2022-08-31 at 12 57 53" src="https://user-images.githubusercontent.com/719641/187663473-a42830ba-ff78-463a-ae68-d612928ddddc.png">
<img width="1115" alt="Screenshot 2022-08-31 at 12 57 12" src="https://user-images.githubusercontent.com/719641/187663481-461b708c-aa2c-4fb8-801a-7d1bacfce279.png">
<img width="1071" alt="Screenshot 2022-08-31 at 12 56 48" src="https://user-images.githubusercontent.com/719641/187663484-6db9b6d2-5bdd-4370-8b3b-89f4209a2684.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
