### PR TITLE
[dev-launcher][home][test-suite] remove deprecated removeEventListener

### DIFF
--- a/apps/test-suite/screens/SelectScreen.js
+++ b/apps/test-suite/screens/SelectScreen.js
@@ -66,7 +66,10 @@ export default class SelectScreen extends React.PureComponent {
   }
 
   componentWillUnmount() {
-    Linking.removeEventListener('url', this._handleOpenURL);
+    if (this._openUrlSubscription != null) {
+      this._openUrlSubscription.remove();
+      this._openUrlSubscription = null;
+    }
   }
 
   checkLinking = (incomingTests) => {
@@ -108,7 +111,7 @@ export default class SelectScreen extends React.PureComponent {
   };
 
   componentDidMount() {
-    Linking.addEventListener('url', this._handleOpenURL);
+    this._openUrlSubscription = Linking.addEventListener('url', this._handleOpenURL);
 
     Linking.getInitialURL()
       .then((url) => {

--- a/apps/test-suite/tests/Linking.js
+++ b/apps/test-suite/tests/Linking.js
@@ -63,7 +63,7 @@ export function test(t) {
           await waitFor(8000);
           t.expect(handlerCalled).toBe(true);
           t.expect(subscription).toBeTruthy();
-          Linking.removeEventListener('url', handler);
+          subscription.remove();
         });
 
         // We can't run this test on iOS since iOS asks "whether to open this link in Expo"
@@ -74,11 +74,11 @@ export function test(t) {
             t.expect(url).toEqual(Linking.makeUrl('++message=Redirected automatically by timer'));
             handlerCalled = true;
           };
-          Linking.addEventListener('url', handler);
+          const subscription = Linking.addEventListener('url', handler);
           await Linking.openURL(`${redirectingBackendUrl}${Linking.makeUrl('++')}`);
           await waitFor(8000);
           t.expect(handlerCalled).toBe(true);
-          Linking.removeEventListener('url', handler);
+          subscription.remove();
         });
       }
 
@@ -89,11 +89,11 @@ export function test(t) {
           handlerCalled = true;
           if (Platform.OS === 'ios') WebBrowser.dismissBrowser();
         };
-        Linking.addEventListener('url', handler);
+        const subscription = Linking.addEventListener('url', handler);
         await WebBrowser.openBrowserAsync(`${redirectingBackendUrl}${Linking.makeUrl('++')}`);
         await waitFor(1000);
         t.expect(handlerCalled).toBe(true);
-        Linking.removeEventListener('url', handler);
+        subscription.remove();
       });
 
       t.it('listener gets called with a proper URL when opened with Linking.openURL', async () => {
@@ -101,11 +101,11 @@ export function test(t) {
         const handler = ({ url }) => {
           handlerCalled = true;
         };
-        Linking.addEventListener('url', handler);
+        const subscription = Linking.addEventListener('url', handler);
         await Linking.openURL(Linking.makeUrl('++'));
         await waitFor(500);
         t.expect(handlerCalled).toBe(true);
-        Linking.removeEventListener('url', handler);
+        subscription.remove();
       });
 
       t.it('listener parses out deep link information correctly', async () => {
@@ -118,11 +118,11 @@ export function test(t) {
           t.expect(queryParams.query).toEqual('param');
           handlerCalled = true;
         };
-        Linking.addEventListener('url', handler);
+        const subscription = Linking.addEventListener('url', handler);
         await Linking.openURL(Linking.makeUrl('++test/path?query=param'));
         await waitFor(500);
         t.expect(handlerCalled).toBe(true);
-        Linking.removeEventListener('url', handler);
+        subscription.remove();
       });
     });
   });

--- a/apps/test-suite/tests/Notifications.js
+++ b/apps/test-suite/tests/Notifications.js
@@ -1525,6 +1525,7 @@ export async function test(t) {
             let notificationSent = false;
             Alert.alert(`Please move the app to the background and wait for 5 seconds`);
             let userInteractionTimeout = null;
+            let subscription = null;
             async function handleStateChange(state) {
               const identifier = 'test-interactive-notification';
               if (state === 'background' && !notificationSent) {
@@ -1549,7 +1550,10 @@ export async function test(t) {
                 t.expect(handleSuccessSpy).not.toHaveBeenCalled();
                 t.expect(handleErrorSpy).not.toHaveBeenCalledWith(identifier);
                 t.expect(notificationReceivedSpy).not.toHaveBeenCalled();
-                AppState.removeEventListener('change', handleStateChange);
+                if (subscription != null) {
+                  subscription.remove();
+                  subscription = null;
+                }
                 resolve();
               }
             }
@@ -1557,14 +1561,17 @@ export async function test(t) {
               console.warn(
                 "Scheduled notification test was skipped and marked as successful. It required user interaction which hasn't occured in time."
               );
-              AppState.removeEventListener('change', handleStateChange);
+              if (subscription != null) {
+                subscription.remove();
+                subscription = null;
+              }
               Alert.alert(
                 'Scheduled notification test was skipped',
                 `The test required user interaction which hasn't occurred in time (${secondsToTimeout} seconds). It has been marked as passing. Better luck next time!`
               );
               resolve();
             }, secondsToTimeout * 1000);
-            AppState.addEventListener('change', handleStateChange);
+            subscription = AppState.addEventListener('change', handleStateChange);
           }),
         30000
       );

--- a/home/navigation/Navigation.tsx
+++ b/home/navigation/Navigation.tsx
@@ -218,11 +218,11 @@ export default (props: { theme: ColorTheme }) => {
       });
     }
 
-    Linking.addEventListener('url', handleDeepLinks);
+    const deepLinkSubscription = Linking.addEventListener('url', handleDeepLinks);
 
     return () => {
       isNavigationReadyRef.current = false;
-      Linking.removeEventListener('url', handleDeepLinks);
+      deepLinkSubscription.remove();
     };
   }, []);
 

--- a/home/screens/GeofencingScreen.tsx
+++ b/home/screens/GeofencingScreen.tsx
@@ -4,7 +4,15 @@ import * as Notifications from 'expo-notifications';
 import * as Permissions from 'expo-permissions';
 import * as TaskManager from 'expo-task-manager';
 import * as React from 'react';
-import { AppState, AppStateStatus, Platform, StyleSheet, Text, View } from 'react-native';
+import {
+  AppState,
+  AppStateStatus,
+  NativeEventSubscription,
+  Platform,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
 import MapView, { Circle, MapEvent } from 'react-native-maps';
 
 import NavigationEvents from '../components/NavigationEvents';
@@ -38,6 +46,8 @@ type Props = unknown;
 export default class GeofencingScreen extends React.Component<Props, State> {
   mapViewRef = React.createRef<MapView>();
 
+  appStateSubscription?: NativeEventSubscription;
+
   readonly state: State = {
     isGeofencing: false,
     newRegionRadius: REGION_RADIUSES[1],
@@ -50,7 +60,7 @@ export default class GeofencingScreen extends React.Component<Props, State> {
     const { status } = await Permissions.askAsync(Permissions.LOCATION);
 
     if (status !== 'granted') {
-      AppState.addEventListener('change', this.handleAppStateChange);
+      this.appStateSubscription = AppState.addEventListener('change', this.handleAppStateChange);
       this.setState({
         error:
           'Location permissions are required in order to use this feature. You can manually enable them at any time in the "Location Services" section of the Settings app.',
@@ -88,7 +98,10 @@ export default class GeofencingScreen extends React.Component<Props, State> {
     }
 
     if (this.state.initialRegion) {
-      AppState.removeEventListener('change', this.handleAppStateChange);
+      if (this.appStateSubscription != null) {
+        this.appStateSubscription.remove();
+        this.appStateSubscription = undefined;
+      }
       return;
     }
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove the deprecated `Linking.removeEventListener` in expo-dev-launcher bundle. ([#18939](https://github.com/expo/expo/pull/18939) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 - Refactored inline Android emulator checks to use enhanced checking in `EmulatorUtilities.isRunningOnEmulator()`. ([#16177](https://github.com/expo/expo/pull/16177)) by [@kbrandwijk](https://github.com/kbrandwijk), [@keith-kurak](https://github.com/keith-kurak))


### PR DESCRIPTION
# Why

the deprecated `AppState.removeEventListener` / `Linking.removeEventListener` is removed from react-native 0.70. we should migrate our apps toward this.

# How

search all `AppState.removeEventListener` / `Linking.removeEventListener` and rewrite as subscription.remove()
this is still one from @react-navigation/native, we should upgrade for [this fix](https://github.com/react-navigation/react-navigation/commit/bd5cd55e130cba2c6c35bbf360e3727a9fcf00e4).

# Test Plan

- bare-expo no deprecated warning from our code base

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
