### PR TITLE
[docs][adopting-prebuild]: Fix keyboard shortcut reference

### DIFF
--- a/docs/pages/guides/adopting-prebuild.md
+++ b/docs/pages/guides/adopting-prebuild.md
@@ -115,7 +115,7 @@ If your project has any native modifications (changes to the `ios` or `android` 
 
 - Check to see if your changes overlap with the built-in [Expo config fields](/versions/latest/config/app/). For example, if you have an app icon, be sure to define it as `expo.icon` in the `app.json` then re-run `npx expo prebuild`.
 - Look up if any of the packages you're using require an [Expo Config Plugin][config-plugins]. If a package in your project required additional changes inside of the `ios/` or `android/` folders, then you will probably need a Config Plugin. Some plugins can be automatically added by running `npx expo install` with all of the packages in your `package.json` `dependencies`. If a package requires a plugin but doesn't supply one, then you can try checking the community plugins at [`expo/config-plugins`](https://github.com/expo/config-plugins) to see if one already exists.
-- You can use the [VS Code Expo extension][vs-code-expo] to introspect your changes and debug if prebuild is generating the native code you expect. Just press `cmd+shift+P`, type "Expo: Preview Modifier", and select the native file you wish to introspect.
+- You can use the [VS Code Expo extension][vs-code-expo] to introspect your changes and debug if prebuild is generating the native code you expect. Just press <kbd>Cmd ⌘</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd>, type "Expo: Preview Modifier", and select the native file you wish to introspect.
 - Additionally, you can develop local config plugins to fit your needs. [Learn more](/guides/config-plugins#developing-a-plugin).
 
 ## Adding More Features


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The keyboard shortcut reference in [Migrating Native Customizations](https://docs.expo.dev/guides/adopting-prebuild/#migrating-native-customizations) doesn't match the [Docs Writing style guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md#referencing-keyboard-shortcuts).

# How

<!--
How did you build this feature or fix this bug and why?
-->

By using `kbd` components that are pre-styled to represent the keyboard shortcut references as mentioned in the Writing Style Guide.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested by running `docs` locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
