### PR TITLE
[docs][tutorial]: Fix code examples in Image Picker

### DIFF
--- a/docs/pages/tutorial/image-picker.md
+++ b/docs/pages/tutorial/image-picker.md
@@ -32,15 +32,8 @@ import { Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 
 export default function App() {
-  /* @info Request permissions to access the "camera roll", then launch the picker and log the result. */
-  let openImagePickerAsync = async () => {
-    let permissionResult = await ImagePicker.requestMediaLibraryPermissionsAsync();
-
-    if (permissionResult.granted === false) {
-      alert("Permission to access camera roll is required!");
-      return;
-    }
-
+  /* @info Launch the picker and log the result. */
+  let openImagePickerAsync = async () => {    
     let pickerResult = await ImagePicker.launchImageLibraryAsync();
     console.log(pickerResult);
   }
@@ -80,6 +73,7 @@ Now we will take the data that we get from the image picker and use it to show t
 <!-- prettier-ignore -->
 ```js
 /* @info Import React to use useState */import React from 'react';/* @end */
+
 import { Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
 
@@ -88,13 +82,6 @@ export default function App() {
 
 
   let openImagePickerAsync = async () => {
-    let permissionResult = await ImagePicker.requestMediaLibraryPermissionsAsync();
-
-    if (permissionResult.granted === false) {
-      alert('Permission to access camera roll is required!');
-      return;
-    }
-
     let pickerResult = await ImagePicker.launchImageLibraryAsync();
 
     /* @info Stop running the function here if the user cancelled the dialog */

--- a/docs/public/static/examples/unversioned/tutorial/image-picker-log.js
+++ b/docs/public/static/examples/unversioned/tutorial/image-picker-log.js
@@ -4,13 +4,6 @@ import * as ImagePicker from 'expo-image-picker';
 
 export default function App() {
   let openImagePickerAsync = async () => {
-    let permissionResult = await ImagePicker.requestCameraRollPermissionsAsync();
-
-    if (permissionResult.granted === false) {
-      alert('Permission to access camera roll is required!');
-      return;
-    }
-
     let pickerResult = await ImagePicker.launchImageLibraryAsync();
     console.log(pickerResult);
   };

--- a/docs/public/static/examples/unversioned/tutorial/image-picker-show.js
+++ b/docs/public/static/examples/unversioned/tutorial/image-picker-show.js
@@ -6,13 +6,6 @@ export default function App() {
   let [selectedImage, setSelectedImage] = React.useState(null);
 
   let openImagePickerAsync = async () => {
-    let permissionResult = await ImagePicker.requestCameraRollPermissionsAsync();
-
-    if (permissionResult.granted === false) {
-      alert('Permission to access camera roll is required!');
-      return;
-    }
-
     let pickerResult = await ImagePicker.launchImageLibraryAsync();
     if (pickerResult.cancelled === true) {
       return;

--- a/docs/public/static/examples/v43.0.0/tutorial/image-picker-log.js
+++ b/docs/public/static/examples/v43.0.0/tutorial/image-picker-log.js
@@ -4,13 +4,6 @@ import * as ImagePicker from 'expo-image-picker';
 
 export default function App() {
   let openImagePickerAsync = async () => {
-    let permissionResult = await ImagePicker.requestCameraRollPermissionsAsync();
-
-    if (permissionResult.granted === false) {
-      alert('Permission to access camera roll is required!');
-      return;
-    }
-
     let pickerResult = await ImagePicker.launchImageLibraryAsync();
     console.log(pickerResult);
   };

--- a/docs/public/static/examples/v43.0.0/tutorial/image-picker-show.js
+++ b/docs/public/static/examples/v43.0.0/tutorial/image-picker-show.js
@@ -6,13 +6,6 @@ export default function App() {
   let [selectedImage, setSelectedImage] = React.useState(null);
 
   let openImagePickerAsync = async () => {
-    let permissionResult = await ImagePicker.requestCameraRollPermissionsAsync();
-
-    if (permissionResult.granted === false) {
-      alert('Permission to access camera roll is required!');
-      return;
-    }
-
     let pickerResult = await ImagePicker.launchImageLibraryAsync();
     if (pickerResult.cancelled === true) {
       return;

--- a/docs/public/static/examples/v44.0.0/tutorial/image-picker-log.js
+++ b/docs/public/static/examples/v44.0.0/tutorial/image-picker-log.js
@@ -4,13 +4,6 @@ import * as ImagePicker from 'expo-image-picker';
 
 export default function App() {
   let openImagePickerAsync = async () => {
-    let permissionResult = await ImagePicker.requestCameraRollPermissionsAsync();
-
-    if (permissionResult.granted === false) {
-      alert('Permission to access camera roll is required!');
-      return;
-    }
-
     let pickerResult = await ImagePicker.launchImageLibraryAsync();
     console.log(pickerResult);
   };

--- a/docs/public/static/examples/v44.0.0/tutorial/image-picker-show.js
+++ b/docs/public/static/examples/v44.0.0/tutorial/image-picker-show.js
@@ -6,13 +6,6 @@ export default function App() {
   let [selectedImage, setSelectedImage] = React.useState(null);
 
   let openImagePickerAsync = async () => {
-    let permissionResult = await ImagePicker.requestCameraRollPermissionsAsync();
-
-    if (permissionResult.granted === false) {
-      alert('Permission to access camera roll is required!');
-      return;
-    }
-
     let pickerResult = await ImagePicker.launchImageLibraryAsync();
     if (pickerResult.cancelled === true) {
       return;

--- a/docs/public/static/examples/v45.0.0/tutorial/image-picker-log.js
+++ b/docs/public/static/examples/v45.0.0/tutorial/image-picker-log.js
@@ -4,13 +4,6 @@ import * as ImagePicker from 'expo-image-picker';
 
 export default function App() {
   let openImagePickerAsync = async () => {
-    let permissionResult = await ImagePicker.requestCameraRollPermissionsAsync();
-
-    if (permissionResult.granted === false) {
-      alert('Permission to access camera roll is required!');
-      return;
-    }
-
     let pickerResult = await ImagePicker.launchImageLibraryAsync();
     console.log(pickerResult);
   };

--- a/docs/public/static/examples/v45.0.0/tutorial/image-picker-show.js
+++ b/docs/public/static/examples/v45.0.0/tutorial/image-picker-show.js
@@ -6,13 +6,6 @@ export default function App() {
   let [selectedImage, setSelectedImage] = React.useState(null);
 
   let openImagePickerAsync = async () => {
-    let permissionResult = await ImagePicker.requestCameraRollPermissionsAsync();
-
-    if (permissionResult.granted === false) {
-      alert('Permission to access camera roll is required!');
-      return;
-    }
-
     let pickerResult = await ImagePicker.launchImageLibraryAsync();
     if (pickerResult.cancelled === true) {
       return;

--- a/docs/public/static/examples/v46.0.0/tutorial/image-picker-log.js
+++ b/docs/public/static/examples/v46.0.0/tutorial/image-picker-log.js
@@ -4,13 +4,6 @@ import * as ImagePicker from 'expo-image-picker';
 
 export default function App() {
   let openImagePickerAsync = async () => {
-    let permissionResult = await ImagePicker.requestCameraRollPermissionsAsync();
-
-    if (permissionResult.granted === false) {
-      alert('Permission to access camera roll is required!');
-      return;
-    }
-
     let pickerResult = await ImagePicker.launchImageLibraryAsync();
     console.log(pickerResult);
   };

--- a/docs/public/static/examples/v46.0.0/tutorial/image-picker-show.js
+++ b/docs/public/static/examples/v46.0.0/tutorial/image-picker-show.js
@@ -6,13 +6,6 @@ export default function App() {
   let [selectedImage, setSelectedImage] = React.useState(null);
 
   let openImagePickerAsync = async () => {
-    let permissionResult = await ImagePicker.requestCameraRollPermissionsAsync();
-
-    if (permissionResult.granted === false) {
-      alert('Permission to access camera roll is required!');
-      return;
-    }
-
     let pickerResult = await ImagePicker.launchImageLibraryAsync();
     if (pickerResult.cancelled === true) {
       return;


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Refs ENG-6197 ENG-6198

# How

<!--
How did you build this feature or fix this bug and why?
-->

By removing permissions snippets from code snippets in the Image Picker module and also updating the snack code in `public/examples/[version]/tutorial/` files.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested by running `docs` locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
