### PR TITLE
[docs] Adds doc on EAS Update rollouts

### DIFF
--- a/docs/constants/navigation-deprecated.cjs
+++ b/docs/constants/navigation-deprecated.cjs
@@ -329,6 +329,7 @@ const eas = [
         makePage('eas-update/environment-variables.md'),
         makePage('eas-update/expo-dev-client.md'),
         makePage('eas-update/known-issues.md'),
+        makePage('eas-update/rollouts.md'),
         makePage('eas-update/faq.md'),
       ]),
     ],

--- a/docs/constants/navigation.cjs
+++ b/docs/constants/navigation.cjs
@@ -308,6 +308,7 @@ const eas = [
         makePage('eas-update/environment-variables.md'),
         makePage('eas-update/expo-dev-client.md'),
         makePage('eas-update/known-issues.md'),
+        makePage('eas-update/rollouts.md'),
         makePage('eas-update/faq.md'),
       ]),
     ],

--- a/docs/pages/eas-update/rollouts.md
+++ b/docs/pages/eas-update/rollouts.md
@@ -2,6 +2,6 @@
 title: Rollouts
 ---
 
-EAS Update does not support rollouts. With that said, we built EAS Update with rollouts in mind. We plan to work on rollouts in 2023. With rollouts, you'll be able to incrementally roll out one update over another to a percentage of your end-users.
+EAS Update does not support percentage-based rollouts. With that said, we built EAS Update with percentage-based rollouts in mind. We plan to work on rollouts in 2023. With this feature, you'll be able to incrementally roll out one update over another to a percentage of your end-users.
 
-Stay tuned to our [blog](blog.expo.dev) and to our [Twitter](https://twitter.com/expo) for updates on rollouts.
+To deploy updates safely, check out our guide on [deployment patterns](/eas-update/deployment-patterns). By testing changes before updating end-users, we can significantly reduce the chance of shipping breaking changes. With that said, stay tuned to our [blog](https://blog.expo.dev) and to our [Twitter](https://twitter.com/expo) for updates on rollouts.

--- a/docs/pages/eas-update/rollouts.md
+++ b/docs/pages/eas-update/rollouts.md
@@ -1,0 +1,7 @@
+---
+title: Rollouts
+---
+
+EAS Update does not support rollouts. With that said, we built EAS Update with rollouts in mind. We plan to work on rollouts in 2023. With rollouts, you'll be able to incrementally roll out one update over another to a percentage of your end-users.
+
+Stay tuned to our [blog](blog.expo.dev) and to our [Twitter](https://twitter.com/expo) for updates on rollouts.


### PR DESCRIPTION
# Why

We don't have rollouts yet, so I wrote a doc briefly discussing that we are going to work on it in 2023.

# How

- adds /eas-update/rollouts page

# Screenshot

<img width="1875" alt="Screen Shot 2022-09-02 at 11 02 24 AM" src="https://user-images.githubusercontent.com/6455018/188178406-b863e895-b719-404e-bf8c-24af9e95b6cc.png">


# Test Plan

Read the doc and make sure it makes sense. Also make sure that it appears in the sidebar.