### PR TITLE
[dev-client] update config plugin to remove exp+ scheme from autoVeri…

### DIFF
--- a/packages/expo-dev-client/CHANGELOG.md
+++ b/packages/expo-dev-client/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove default scheme from intent filters that specify `autoVerify=true`. ([#18963](https://github.com/expo/expo/pull/18963) by [@ajsmth](https://github.com/ajsmth))
+
 ### 💡 Others
 
 - Drop `@expo/config-plugins` dependency in favor of peer dependency on `expo`. ([#18595](https://github.com/expo/expo/pull/18595) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/expo-dev-client/plugin/build/withGeneratedAndroidScheme.d.ts
+++ b/packages/expo-dev-client/plugin/build/withGeneratedAndroidScheme.d.ts
@@ -1,6 +1,7 @@
 import { AndroidConfig, AndroidManifest, ConfigPlugin } from '@expo/config-plugins';
+import { ExpoConfig } from '@expo/config-types';
 export declare const withGeneratedAndroidScheme: ConfigPlugin;
-export declare function setGeneratedAndroidScheme(scheme: string, androidManifest: AndroidManifest): AndroidManifest;
+export declare function setGeneratedAndroidScheme(config: Pick<ExpoConfig, 'scheme' | 'slug'>, androidManifest: AndroidManifest): AndroidManifest;
 /**
  * Remove the custom Expo dev client scheme from intent filters, which are set to `autoVerify=true`.
  * The custom scheme `<data android:scheme="exp+<slug>"/>` seems to block verification for these intent filters.
@@ -10,4 +11,4 @@ export declare function setGeneratedAndroidScheme(scheme: string, androidManifes
  *
  * @param {AndroidManifest} androidManifest
  */
-export declare function removeExpoSchemaFromVerifiedIntentFilters(defaultScheme: string, androidManifest: AndroidManifest): AndroidConfig.Manifest.AndroidManifest;
+export declare function removeExpoSchemaFromVerifiedIntentFilters(config: Pick<ExpoConfig, 'scheme' | 'slug'>, androidManifest: AndroidManifest): AndroidConfig.Manifest.AndroidManifest;

--- a/packages/expo-dev-client/plugin/build/withGeneratedAndroidScheme.d.ts
+++ b/packages/expo-dev-client/plugin/build/withGeneratedAndroidScheme.d.ts
@@ -1,7 +1,6 @@
 import { AndroidConfig, AndroidManifest, ConfigPlugin } from '@expo/config-plugins';
-import { ExpoConfig } from '@expo/config-types';
 export declare const withGeneratedAndroidScheme: ConfigPlugin;
-export declare function setGeneratedAndroidScheme(config: Pick<ExpoConfig, 'scheme' | 'slug'>, androidManifest: AndroidManifest): AndroidManifest;
+export declare function setGeneratedAndroidScheme(scheme: string, androidManifest: AndroidManifest): AndroidManifest;
 /**
  * Remove the custom Expo dev client scheme from intent filters, which are set to `autoVerify=true`.
  * The custom scheme `<data android:scheme="exp+<slug>"/>` seems to block verification for these intent filters.
@@ -11,4 +10,4 @@ export declare function setGeneratedAndroidScheme(config: Pick<ExpoConfig, 'sche
  *
  * @param {AndroidManifest} androidManifest
  */
-export declare function removeExpoSchemaFromVerifiedIntentFilters(androidManifest: AndroidManifest): AndroidConfig.Manifest.AndroidManifest;
+export declare function removeExpoSchemaFromVerifiedIntentFilters(defaultScheme: string, androidManifest: AndroidManifest): AndroidConfig.Manifest.AndroidManifest;

--- a/packages/expo-dev-client/plugin/build/withGeneratedAndroidScheme.d.ts
+++ b/packages/expo-dev-client/plugin/build/withGeneratedAndroidScheme.d.ts
@@ -1,4 +1,14 @@
-import { AndroidManifest, ConfigPlugin } from '@expo/config-plugins';
+import { AndroidConfig, AndroidManifest, ConfigPlugin } from '@expo/config-plugins';
 import { ExpoConfig } from '@expo/config-types';
 export declare const withGeneratedAndroidScheme: ConfigPlugin;
 export declare function setGeneratedAndroidScheme(config: Pick<ExpoConfig, 'scheme' | 'slug'>, androidManifest: AndroidManifest): AndroidManifest;
+/**
+ * Remove the custom Expo dev client scheme from intent filters, which are set to `autoVerify=true`.
+ * The custom scheme `<data android:scheme="exp+<slug>"/>` seems to block verification for these intent filters.
+ * This plugin makes sure there is no scheme in the autoVerify intent filters, that starts with `exp+`.
+ 
+ * Iterate over all `autoVerify=true` intent filters, and pull out schemes starting with `exp+`.
+ *
+ * @param {AndroidManifest} androidManifest
+ */
+export declare function removeExpoSchemaFromVerifiedIntentFilters(androidManifest: AndroidManifest): AndroidConfig.Manifest.AndroidManifest;

--- a/packages/expo-dev-client/plugin/build/withGeneratedAndroidScheme.js
+++ b/packages/expo-dev-client/plugin/build/withGeneratedAndroidScheme.js
@@ -3,12 +3,13 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.setGeneratedAndroidScheme = exports.withGeneratedAndroidScheme = void 0;
+exports.removeExpoSchemaFromVerifiedIntentFilters = exports.setGeneratedAndroidScheme = exports.withGeneratedAndroidScheme = void 0;
 const config_plugins_1 = require("@expo/config-plugins");
 const getDefaultScheme_1 = __importDefault(require("./getDefaultScheme"));
 const withGeneratedAndroidScheme = (config) => {
     return (0, config_plugins_1.withAndroidManifest)(config, (config) => {
         config.modResults = setGeneratedAndroidScheme(config, config.modResults);
+        config.modResults = removeExpoSchemaFromVerifiedIntentFilters(config.modResults);
         return config;
     });
 };
@@ -22,3 +23,49 @@ function setGeneratedAndroidScheme(config, androidManifest) {
     return androidManifest;
 }
 exports.setGeneratedAndroidScheme = setGeneratedAndroidScheme;
+/**
+ * Remove the custom Expo dev client scheme from intent filters, which are set to `autoVerify=true`.
+ * The custom scheme `<data android:scheme="exp+<slug>"/>` seems to block verification for these intent filters.
+ * This plugin makes sure there is no scheme in the autoVerify intent filters, that starts with `exp+`.
+ 
+ * Iterate over all `autoVerify=true` intent filters, and pull out schemes starting with `exp+`.
+ *
+ * @param {AndroidManifest} androidManifest
+ */
+function removeExpoSchemaFromVerifiedIntentFilters(androidManifest) {
+    // see: https://github.com/expo/expo-cli/blob/f1624c75b52cc1c4f99354ec4021494e0eff74aa/packages/config-plugins/src/android/Scheme.ts#L164-L179
+    for (const application of androidManifest.manifest.application || []) {
+        for (const activity of application.activity || []) {
+            if (activityHasSingleTaskLaunchMode(activity)) {
+                for (const intentFilter of activity['intent-filter'] || []) {
+                    if (intentFilterHasAutoVerification(intentFilter) && intentFilter?.data) {
+                        intentFilter.data = intentFilterRemoveSchemeFromData(intentFilter, (scheme) => scheme?.startsWith('exp+'));
+                    }
+                }
+                break;
+            }
+        }
+    }
+    return androidManifest;
+}
+exports.removeExpoSchemaFromVerifiedIntentFilters = removeExpoSchemaFromVerifiedIntentFilters;
+/**
+ * Determine if the activity should contain the intent filters to clean.
+ *
+ * @see https://github.com/expo/expo-cli/blob/f1624c75b52cc1c4f99354ec4021494e0eff74aa/packages/config-plugins/src/android/Scheme.ts#L166
+ */
+function activityHasSingleTaskLaunchMode(activity) {
+    return activity?.$?.['android:launchMode'] === 'singleTask';
+}
+/**
+ * Determine if the intent filter has `autoVerify=true`.
+ */
+function intentFilterHasAutoVerification(intentFilter) {
+    return intentFilter?.$?.['android:autoVerify'] === 'true';
+}
+/**
+ * Remove schemes from the intent filter that matches the function.
+ */
+function intentFilterRemoveSchemeFromData(intentFilter, schemeMatcher) {
+    return intentFilter?.data?.filter((entry) => !schemeMatcher(entry?.$['android:scheme'] || ''));
+}

--- a/packages/expo-dev-client/plugin/build/withGeneratedAndroidScheme.js
+++ b/packages/expo-dev-client/plugin/build/withGeneratedAndroidScheme.js
@@ -8,15 +8,15 @@ const config_plugins_1 = require("@expo/config-plugins");
 const getDefaultScheme_1 = __importDefault(require("./getDefaultScheme"));
 const withGeneratedAndroidScheme = (config) => {
     return (0, config_plugins_1.withAndroidManifest)(config, (config) => {
-        config.modResults = setGeneratedAndroidScheme(config, config.modResults);
-        config.modResults = removeExpoSchemaFromVerifiedIntentFilters(config.modResults);
+        // Generate a cross-platform scheme used to launch the dev client.
+        const scheme = (0, getDefaultScheme_1.default)(config);
+        config.modResults = setGeneratedAndroidScheme(scheme, config.modResults);
+        config.modResults = removeExpoSchemaFromVerifiedIntentFilters(scheme, config.modResults);
         return config;
     });
 };
 exports.withGeneratedAndroidScheme = withGeneratedAndroidScheme;
-function setGeneratedAndroidScheme(config, androidManifest) {
-    // Generate a cross-platform scheme used to launch the dev client.
-    const scheme = (0, getDefaultScheme_1.default)(config);
+function setGeneratedAndroidScheme(scheme, androidManifest) {
     if (!config_plugins_1.AndroidConfig.Scheme.hasScheme(scheme, androidManifest)) {
         androidManifest = config_plugins_1.AndroidConfig.Scheme.appendScheme(scheme, androidManifest);
     }
@@ -32,14 +32,14 @@ exports.setGeneratedAndroidScheme = setGeneratedAndroidScheme;
  *
  * @param {AndroidManifest} androidManifest
  */
-function removeExpoSchemaFromVerifiedIntentFilters(androidManifest) {
+function removeExpoSchemaFromVerifiedIntentFilters(defaultScheme, androidManifest) {
     // see: https://github.com/expo/expo-cli/blob/f1624c75b52cc1c4f99354ec4021494e0eff74aa/packages/config-plugins/src/android/Scheme.ts#L164-L179
     for (const application of androidManifest.manifest.application || []) {
         for (const activity of application.activity || []) {
             if (activityHasSingleTaskLaunchMode(activity)) {
                 for (const intentFilter of activity['intent-filter'] || []) {
                     if (intentFilterHasAutoVerification(intentFilter) && intentFilter?.data) {
-                        intentFilter.data = intentFilterRemoveSchemeFromData(intentFilter, (scheme) => scheme?.startsWith('exp+'));
+                        intentFilter.data = intentFilterRemoveSchemeFromData(intentFilter, (scheme) => scheme === defaultScheme);
                     }
                 }
                 break;

--- a/packages/expo-dev-client/plugin/build/withGeneratedAndroidScheme.js
+++ b/packages/expo-dev-client/plugin/build/withGeneratedAndroidScheme.js
@@ -8,15 +8,15 @@ const config_plugins_1 = require("@expo/config-plugins");
 const getDefaultScheme_1 = __importDefault(require("./getDefaultScheme"));
 const withGeneratedAndroidScheme = (config) => {
     return (0, config_plugins_1.withAndroidManifest)(config, (config) => {
-        // Generate a cross-platform scheme used to launch the dev client.
-        const scheme = (0, getDefaultScheme_1.default)(config);
-        config.modResults = setGeneratedAndroidScheme(scheme, config.modResults);
-        config.modResults = removeExpoSchemaFromVerifiedIntentFilters(scheme, config.modResults);
+        config.modResults = setGeneratedAndroidScheme(config, config.modResults);
+        config.modResults = removeExpoSchemaFromVerifiedIntentFilters(config, config.modResults);
         return config;
     });
 };
 exports.withGeneratedAndroidScheme = withGeneratedAndroidScheme;
-function setGeneratedAndroidScheme(scheme, androidManifest) {
+function setGeneratedAndroidScheme(config, androidManifest) {
+    // Generate a cross-platform scheme used to launch the dev client.
+    const scheme = (0, getDefaultScheme_1.default)(config);
     if (!config_plugins_1.AndroidConfig.Scheme.hasScheme(scheme, androidManifest)) {
         androidManifest = config_plugins_1.AndroidConfig.Scheme.appendScheme(scheme, androidManifest);
     }
@@ -32,7 +32,9 @@ exports.setGeneratedAndroidScheme = setGeneratedAndroidScheme;
  *
  * @param {AndroidManifest} androidManifest
  */
-function removeExpoSchemaFromVerifiedIntentFilters(defaultScheme, androidManifest) {
+function removeExpoSchemaFromVerifiedIntentFilters(config, androidManifest) {
+    // Generate a cross-platform scheme used to launch the dev client.
+    const defaultScheme = (0, getDefaultScheme_1.default)(config);
     // see: https://github.com/expo/expo-cli/blob/f1624c75b52cc1c4f99354ec4021494e0eff74aa/packages/config-plugins/src/android/Scheme.ts#L164-L179
     for (const application of androidManifest.manifest.application || []) {
         for (const activity of application.activity || []) {

--- a/packages/expo-dev-client/plugin/src/__tests__/withGeneratedAndroidScheme-test.ts
+++ b/packages/expo-dev-client/plugin/src/__tests__/withGeneratedAndroidScheme-test.ts
@@ -3,6 +3,7 @@ import { AndroidConfig, AndroidManifest } from '@expo/config-plugins';
 import {
   removeExpoSchemaFromVerifiedIntentFilters,
   setGeneratedAndroidScheme,
+  withGeneratedAndroidScheme,
 } from '../withGeneratedAndroidScheme';
 
 describe(setGeneratedAndroidScheme, () => {
@@ -139,10 +140,8 @@ describe(setGeneratedAndroidScheme, () => {
       },
     };
     const config = { slug: 'cello' };
-
     androidManifest = setGeneratedAndroidScheme(config, androidManifest);
-    androidManifest = removeExpoSchemaFromVerifiedIntentFilters(androidManifest);
-
+    androidManifest = removeExpoSchemaFromVerifiedIntentFilters(config, androidManifest);
     const schemes = AndroidConfig.Scheme.getSchemesFromManifest(androidManifest);
     expect(schemes.length).toEqual(1);
   });

--- a/packages/expo-dev-client/plugin/src/__tests__/withGeneratedAndroidScheme-test.ts
+++ b/packages/expo-dev-client/plugin/src/__tests__/withGeneratedAndroidScheme-test.ts
@@ -1,6 +1,9 @@
 import { AndroidConfig, AndroidManifest } from '@expo/config-plugins';
 
-import { setGeneratedAndroidScheme } from '../withGeneratedAndroidScheme';
+import {
+  removeExpoSchemaFromVerifiedIntentFilters,
+  setGeneratedAndroidScheme,
+} from '../withGeneratedAndroidScheme';
 
 describe(setGeneratedAndroidScheme, () => {
   it(`prevents adding duplicates`, () => {
@@ -60,5 +63,87 @@ describe(setGeneratedAndroidScheme, () => {
         'exp+cello',
       ]);
     }
+  });
+
+  it(`removes exp+ scheme when intent filter autoVerify is true`, () => {
+    let androidManifest: AndroidManifest = {
+      manifest: {
+        application: [
+          {
+            activity: [
+              {
+                $: {
+                  'android:name': '.MainActivity',
+                  'android:launchMode': 'singleTask',
+                },
+                'intent-filter': [
+                  {
+                    $: {
+                      'android:autoVerify': 'true',
+                    },
+                    action: [
+                      {
+                        $: {
+                          'android:name': 'android.intent.action.VIEW',
+                        },
+                      },
+                    ],
+                    category: [
+                      {
+                        $: {
+                          'android:name': 'android.intent.category.DEFAULT',
+                        },
+                      },
+                      {
+                        $: {
+                          'android:name': 'android.intent.category.BROWSABLE',
+                        },
+                      },
+                    ],
+                    data: [],
+                  },
+                  {
+                    action: [
+                      {
+                        $: {
+                          'android:name': 'android.intent.action.VIEW',
+                        },
+                      },
+                    ],
+                    category: [
+                      {
+                        $: {
+                          'android:name': 'android.intent.category.DEFAULT',
+                        },
+                      },
+                      {
+                        $: {
+                          'android:name': 'android.intent.category.BROWSABLE',
+                        },
+                      },
+                    ],
+                    data: [],
+                  },
+                ],
+              },
+            ],
+            $: {
+              'android:name': '.MainApplication',
+            },
+          },
+        ],
+        $: {
+          'xmlns:android': 'http://schemas.android.com/apk/res/android',
+          package: 'com.placeholder.appid',
+        },
+      },
+    };
+    const config = { slug: 'cello' };
+
+    androidManifest = setGeneratedAndroidScheme(config, androidManifest);
+    androidManifest = removeExpoSchemaFromVerifiedIntentFilters(androidManifest);
+
+    const schemes = AndroidConfig.Scheme.getSchemesFromManifest(androidManifest);
+    expect(schemes.length).toEqual(1);
   });
 });

--- a/packages/expo-dev-client/plugin/src/__tests__/withGeneratedAndroidScheme-test.ts
+++ b/packages/expo-dev-client/plugin/src/__tests__/withGeneratedAndroidScheme-test.ts
@@ -3,7 +3,6 @@ import { AndroidConfig, AndroidManifest } from '@expo/config-plugins';
 import {
   removeExpoSchemaFromVerifiedIntentFilters,
   setGeneratedAndroidScheme,
-  withGeneratedAndroidScheme,
 } from '../withGeneratedAndroidScheme';
 
 describe(setGeneratedAndroidScheme, () => {

--- a/packages/expo-dev-client/plugin/src/withGeneratedAndroidScheme.ts
+++ b/packages/expo-dev-client/plugin/src/withGeneratedAndroidScheme.ts
@@ -38,7 +38,7 @@ export function setGeneratedAndroidScheme(
  * The custom scheme `<data android:scheme="exp+<slug>"/>` seems to block verification for these intent filters.
  * This plugin makes sure there is no scheme in the autoVerify intent filters, that starts with `exp+`.
  
- * Iterate over all `autoVerify=true` intent filters, and pull out schemes starting with `exp+`.
+ * Iterate over all `autoVerify=true` intent filters, and pull out schemes matching with `exp+<slug>`.
  *
  * @param {AndroidManifest} androidManifest
  */

--- a/packages/expo-dev-client/plugin/src/withGeneratedAndroidScheme.ts
+++ b/packages/expo-dev-client/plugin/src/withGeneratedAndroidScheme.ts
@@ -4,6 +4,10 @@ import {
   ConfigPlugin,
   withAndroidManifest,
 } from '@expo/config-plugins';
+import {
+  ManifestActivity,
+  ManifestIntentFilter,
+} from '@expo/config-plugins/build/android/Manifest';
 import { ExpoConfig } from '@expo/config-types';
 
 import getDefaultScheme from './getDefaultScheme';
@@ -11,6 +15,7 @@ import getDefaultScheme from './getDefaultScheme';
 export const withGeneratedAndroidScheme: ConfigPlugin = (config) => {
   return withAndroidManifest(config, (config) => {
     config.modResults = setGeneratedAndroidScheme(config, config.modResults);
+    config.modResults = removeExpoSchemaFromVerifiedIntentFilters(config.modResults);
     return config;
   });
 };
@@ -24,5 +29,58 @@ export function setGeneratedAndroidScheme(
   if (!AndroidConfig.Scheme.hasScheme(scheme, androidManifest)) {
     androidManifest = AndroidConfig.Scheme.appendScheme(scheme, androidManifest);
   }
+
   return androidManifest;
+}
+
+/**
+ * Remove the custom Expo dev client scheme from intent filters, which are set to `autoVerify=true`.
+ * The custom scheme `<data android:scheme="exp+<slug>"/>` seems to block verification for these intent filters.
+ * This plugin makes sure there is no scheme in the autoVerify intent filters, that starts with `exp+`.
+ 
+ * Iterate over all `autoVerify=true` intent filters, and pull out schemes starting with `exp+`.
+ *
+ * @param {AndroidManifest} androidManifest
+ */
+export function removeExpoSchemaFromVerifiedIntentFilters(androidManifest: AndroidManifest) {
+  // see: https://github.com/expo/expo-cli/blob/f1624c75b52cc1c4f99354ec4021494e0eff74aa/packages/config-plugins/src/android/Scheme.ts#L164-L179
+  for (const application of androidManifest.manifest.application || []) {
+    for (const activity of application.activity || []) {
+      if (activityHasSingleTaskLaunchMode(activity)) {
+        for (const intentFilter of activity['intent-filter'] || []) {
+          if (intentFilterHasAutoVerification(intentFilter) && intentFilter?.data) {
+            intentFilter.data = intentFilterRemoveSchemeFromData(intentFilter, (scheme: string) =>
+              scheme?.startsWith('exp+')
+            );
+          }
+        }
+        break;
+      }
+    }
+  }
+
+  return androidManifest;
+}
+
+/**
+ * Determine if the activity should contain the intent filters to clean.
+ *
+ * @see https://github.com/expo/expo-cli/blob/f1624c75b52cc1c4f99354ec4021494e0eff74aa/packages/config-plugins/src/android/Scheme.ts#L166
+ */
+function activityHasSingleTaskLaunchMode(activity: ManifestActivity) {
+  return activity?.$?.['android:launchMode'] === 'singleTask';
+}
+
+/**
+ * Determine if the intent filter has `autoVerify=true`.
+ */
+function intentFilterHasAutoVerification(intentFilter: ManifestIntentFilter) {
+  return intentFilter?.$?.['android:autoVerify'] === 'true';
+}
+
+/**
+ * Remove schemes from the intent filter that matches the function.
+ */
+function intentFilterRemoveSchemeFromData(intentFilter: ManifestIntentFilter, schemeMatcher: any) {
+  return intentFilter?.data?.filter((entry) => !schemeMatcher(entry?.$['android:scheme'] || ''));
 }

--- a/packages/expo-dev-client/plugin/src/withGeneratedAndroidScheme.ts
+++ b/packages/expo-dev-client/plugin/src/withGeneratedAndroidScheme.ts
@@ -8,23 +8,24 @@ import {
   ManifestActivity,
   ManifestIntentFilter,
 } from '@expo/config-plugins/build/android/Manifest';
+import { ExpoConfig } from '@expo/config-types';
 
 import getDefaultScheme from './getDefaultScheme';
 
 export const withGeneratedAndroidScheme: ConfigPlugin = (config) => {
   return withAndroidManifest(config, (config) => {
-    // Generate a cross-platform scheme used to launch the dev client.
-    const scheme = getDefaultScheme(config);
-    config.modResults = setGeneratedAndroidScheme(scheme, config.modResults);
-    config.modResults = removeExpoSchemaFromVerifiedIntentFilters(scheme, config.modResults);
+    config.modResults = setGeneratedAndroidScheme(config, config.modResults);
+    config.modResults = removeExpoSchemaFromVerifiedIntentFilters(config, config.modResults);
     return config;
   });
 };
 
 export function setGeneratedAndroidScheme(
-  scheme: string,
+  config: Pick<ExpoConfig, 'scheme' | 'slug'>,
   androidManifest: AndroidManifest
 ): AndroidManifest {
+  // Generate a cross-platform scheme used to launch the dev client.
+  const scheme = getDefaultScheme(config);
   if (!AndroidConfig.Scheme.hasScheme(scheme, androidManifest)) {
     androidManifest = AndroidConfig.Scheme.appendScheme(scheme, androidManifest);
   }
@@ -42,9 +43,11 @@ export function setGeneratedAndroidScheme(
  * @param {AndroidManifest} androidManifest
  */
 export function removeExpoSchemaFromVerifiedIntentFilters(
-  defaultScheme: string,
+  config: Pick<ExpoConfig, 'scheme' | 'slug'>,
   androidManifest: AndroidManifest
 ) {
+  // Generate a cross-platform scheme used to launch the dev client.
+  const defaultScheme = getDefaultScheme(config);
   // see: https://github.com/expo/expo-cli/blob/f1624c75b52cc1c4f99354ec4021494e0eff74aa/packages/config-plugins/src/android/Scheme.ts#L164-L179
   for (const application of androidManifest.manifest.application || []) {
     for (const activity of application.activity || []) {


### PR DESCRIPTION
…fied intent filters

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Addresses ENG-5144 

To summarize: Android auto verify links do not work with the `exp+` schema that we append in our current config plugin.

# How

This PR applies the logic @byCedric laid out in https://github.com/expo/expo/issues/19745

When an intent filter specifies `autoVerify="true"` this plugin will remove any data items that include the `exp+` scheme 

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

`autoVerify` can be set via the android property of `app.json`: 

```
"intentFilters": [
  {
    "action": "VIEW",
    "autoVerify": true,
    "data": [
      {
        "scheme": "https",
        "host": "*.myapp.io",
        "pathPrefix": "/records"
      }
    ],
    "category": [
      "BROWSABLE",
      "DEFAULT"
    ]
  }
]
```

We can test this by also manually setting these values in a project's `AndroidManifest.xml` and then running the config plugin 

I tested this manually by generating the `AndroidManifest.xml` with an autoVerify section using the config above, then symlinking this version of the plugin, running prebuild again and ensuring that the `exp+` scheme was removed from the autoVerify

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
