### PR TITLE
[expo] pin @sentry/react-native version

### DIFF
--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -106,5 +106,5 @@
   "unimodules-image-loader-interface": "~6.1.0",
   "@shopify/react-native-skia": "0.1.141",
   "@shopify/flash-list": "1.1.0",
-  "@sentry/react-native": "^4.1.3"
+  "@sentry/react-native": "4.2.2"
 }


### PR DESCRIPTION
# Why

`sentry-expo` pins `@sentry/react-native` to `4.2.2`. Upgrading the Expo SDK in a project causes `@sentry/react-native` to be upgraded to `^4.1.3`, which resolves to `4.2.4`. This causes conflicts and errors (see https://github.com/expo/sentry-expo/issues/281 and others).

# How

Pin the version in the version json.

# Test Plan

N/A

> **Note: not sure whether this needs to happen only in the sdk-46 branch, and all release branch changes will get merged back at some point, or if I also need to change this in main.**

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
