### PR TITLE
feat(docs): move security doc from distribution to app signing

### DIFF
--- a/docs/common/error-utilities.ts
+++ b/docs/common/error-utilities.ts
@@ -238,6 +238,7 @@ const RENAMED_PAGES: Record<string, string> = {
   '/classic/turtle-cli/': '/archive/classic-updates/turtle-cli/',
 
   // Consolidate distribution
+  '/distribution/security/': '/app-signing/security/',
   '/distribution/uploading-apps/': '/submit/introduction/',
   '/versions/latest/distribution/uploading-apps/': '/submit/introduction/',
 };

--- a/docs/constants/navigation-deprecated.cjs
+++ b/docs/constants/navigation-deprecated.cjs
@@ -101,7 +101,6 @@ const general = [
       makePage('distribution/runtime-versions.md'),
       makePage('distribution/custom-updates-server.md'),
       makePage('distribution/app-transfers.md'),
-      makePage('distribution/security.md'),
       makePage('distribution/publishing-websites.md'),
     ]),
   ]),
@@ -270,6 +269,7 @@ const eas = [
         makePage('app-signing/local-credentials.md'),
         makePage('app-signing/existing-credentials.md'),
         makePage('app-signing/syncing-credentials.md'),
+        makePage('app-signing/security.md'),
       ]),
       makeGroup('Reference', [
         makePage('build-reference/eas-json.md'),

--- a/docs/constants/navigation.cjs
+++ b/docs/constants/navigation.cjs
@@ -107,7 +107,6 @@ const general = [
     makePage('distribution/runtime-versions.md'),
     makePage('distribution/custom-updates-server.md'),
     makePage('distribution/app-transfers.md'),
-    makePage('distribution/security.md'),
     makePage('distribution/publishing-websites.md'),
   ]),
   makeSection('Development Builds', [
@@ -251,6 +250,7 @@ const eas = [
         makePage('app-signing/local-credentials.md'),
         makePage('app-signing/existing-credentials.md'),
         makePage('app-signing/syncing-credentials.md'),
+        makePage('app-signing/security.md'),
       ]),
       makeGroup('Reference', [
         makePage('build-reference/eas-json.md'),

--- a/docs/pages/app-signing/app-credentials.md
+++ b/docs/pages/app-signing/app-credentials.md
@@ -7,7 +7,7 @@ import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 
 Expo automates the process of signing your app for iOS and Android, but in both cases you can choose to provide your own overrides. [EAS Build](/build/introduction.md) can generate signed or unsigned applications, but in order to distribute your application through the stores, it **must** be a signed application.
 
-On this page, we'll talk about the credentials that each platform requires. If you're curious about how we store your credentials on our end, take a look at our [security documentation](/distribution/security.md).
+On this page, we'll talk about the credentials that each platform requires. If you're curious about how we store your credentials on our end, take a look at our [security documentation](/app-signing/security).
 
 <ConfigClassic>
 
@@ -45,7 +45,7 @@ Provisioning profiles expire after 12 months, but this won't affect apps in prod
 ### Summary
 
 | Credential               | Limit Per Account | App-specific? | Can be revoked with no production side effects? | Used at…   |
-|--------------------------|-------------------|---------------|-------------------------------------------------|------------|
+| ------------------------ | ----------------- | ------------- | ----------------------------------------------- | ---------- |
 | Distribution Certificate | 2                 | <NoIcon />    | <YesIcon />                                     | Build time |
 | Push Notification Key    | 2                 | <NoIcon />    | <NoIcon />                                      | Run time   |
 | Provisioning Profile     | Unlimited         | <YesIcon />   | <YesIcon />                                     | Build time |

--- a/docs/pages/app-signing/managed-credentials.md
+++ b/docs/pages/app-signing/managed-credentials.md
@@ -22,7 +22,7 @@ When you run `eas build`, you will be prompted to generate credentials if you ha
 
 Generating your iOS credentials (distribution certificate, provisioning profile, and push key) requires you to sign in with an [Apple Developer Program](https://developer.apple.com/programs) membership.
 
-> If you have any security concerns about EAS managing your credentials or about logging in to your Apple Developer account through EAS CLI, please refer to the ["Security"](/distribution/security.md) guide. If that does not satisfy your concerns, you can reach out to [secure@expo.dev](mailto:secure@expo.dev) for more information, or use [local credentials](/app-signing/local-credentials.md) instead.
+> If you have any security concerns about EAS managing your credentials or about logging in to your Apple Developer account through EAS CLI, please refer to the ["Security"](/app-signing/security) guide. If that does not satisfy your concerns, you can reach out to [secure@expo.dev](mailto:secure@expo.dev) for more information, or use [local credentials](/app-signing/local-credentials.md) instead.
 
 ### Push notification credentials
 

--- a/docs/pages/app-signing/security.md
+++ b/docs/pages/app-signing/security.md
@@ -4,7 +4,7 @@ title: Security
 
 Before you enter outside credentials or provide other sensitive data to third-party software you should ask yourself whether you trust the software to use it responsibly and protect it. Due to the nature of what goes into building an app binary for distribution on app stores, the Expo standalone app build service requires various pieces of information with varying degrees of sensitivity. This document explains what those are, how we store them, and what could go wrong if they were to be compromised.
 
-Most data stored by Expo — credentials or otherwise — is encrypted at rest by our cloud provider, Google Cloud. Credentials are additionally encrypted using [KMS](https://cloud.google.com/kms/). Credentials are only unencrypted for as long as we need them in memory in the standalone app builders or push notification services. Credentials are always encrypted in our databases, message queues, and other less transient parts of the system.
+Most data stored by Expo servers — credentials or otherwise — is encrypted at rest by our cloud provider, Google Cloud. Credentials are additionally encrypted using [KMS](https://cloud.google.com/kms/). Credentials are only unencrypted for as long as we need them in memory in the standalone app builders or push notification services. Credentials are always encrypted in our databases, message queues, and other less transient parts of the system.
 
 All of the data related to the information explained below can be downloaded and removed from Expo servers (if it is stored there at all in the first place), and some of it may be available through other locations such as the Apple Developer Portal.
 
@@ -40,7 +40,7 @@ None, they are available through the Apple Developer console.
 
 ## Apple Developer account credentials
 
-When creating a standalone app build, or uploading to the App Store you will be prompted for your Apple Developer account credentials. We do not store these on our servers &mdash; Expo CLI only uses them locally. Your computer alone provisions distribution certificates and auth keys that are sent to Expo; your developer credentials are not sent to Expo. An additional layer of security is enforced by Apple, as they require two-factor authentication for all Apple Developer accounts.
+When creating a standalone app build, or uploading to the App Store you will be prompted for your Apple Developer account credentials. We do not store these on our servers &mdash; EAS CLI only uses them locally. Your computer alone provisions distribution certificates and auth keys that are sent to Expo servers; your developer credentials are not sent to Expo servers. An additional layer of security is enforced by Apple, as they require two-factor authentication for all Apple Developer accounts.
 
 When creating ad-hoc builds, we temporarily store an Apple Developer session token used to create an ad-hoc provisioning profile with your development device’s UDID. Once we are done using this session token we destroy it.
 
@@ -109,4 +109,4 @@ You won't be able to send notifications to users until they open your app again.
 
 ## Need more control?
 
-If the above information doesn't satisfy your security requirements, you may wish to run your standalone app builds [on your own infrastructure](../build-reference/local-builds/). Note that you will still need to provide your push notification credentials in order to use the push notification service. If that is also not possible, we recommend handling push notifications on your own.
+If the above information doesn't satisfy your security requirements, you may wish to run your standalone app builds [on your own infrastructure](/build-reference/local-builds/). Note that you will still need to provide your push notification credentials in order to use the push notification service. If that is also not possible, we recommend handling push notifications on your own.

--- a/docs/pages/archived/adhoc-builds.md
+++ b/docs/pages/archived/adhoc-builds.md
@@ -48,7 +48,7 @@ Run `expo client:ios`
 
 You are given a choice of letting `expo-cli` create the necessary credentials for you, while still having a chance to provide your own overrides. Your Apple ID and password are used locally and never saved on Expo's servers.
 
-Letting Expo handle credentials for you will greatly simplify the build process. Learn more [here](../distribution/security.md) on what these credentials are and how we store them.
+Letting Expo handle credentials for you will greatly simplify the build process. Learn more [here](/app-signing/security) on what these credentials are and how we store them.
 
 ```sh
 $ expo client:ios


### PR DESCRIPTION
- reduce the number of random docs in the distribution section.
- update security docs to say "EAS CLI" since the new Expo CLI does no Apple credential handling.