### PR TITLE
reuse community doc component

### DIFF
--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -247,6 +247,17 @@ const Home = () => {
         </Row>
       </CellContainer>
       <H3>Join the community</H3>
+      <JoinTheCommunity />
+    </DocumentationPage>
+  );
+};
+
+
+export function JoinTheCommunity() {
+  const { palette } = theme;
+
+  return (
+    <>
       <Description>See the source code, connect with others, and get connected.</Description>
       <CellContainer>
         <Row>
@@ -289,9 +300,9 @@ const Home = () => {
           />
         </Row>
       </CellContainer>
-    </DocumentationPage>
-  );
-};
+    </>
+  )
+}
 
 const baseGradientStyle = css({
   top: 0,

--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -252,7 +252,6 @@ const Home = () => {
   );
 };
 
-
 export function JoinTheCommunity() {
   const { palette } = theme;
 
@@ -301,7 +300,7 @@ export function JoinTheCommunity() {
         </Row>
       </CellContainer>
     </>
-  )
+  );
 }
 
 const baseGradientStyle = css({

--- a/docs/pages/next-steps/community.md
+++ b/docs/pages/next-steps/community.md
@@ -1,10 +1,8 @@
 ---
 title: Join the community
+hideTOC: true
 ---
 
-Want to chat about Expo? The best way to get in touch with our team and other people developing with Expo is to join our [forums](https://forums.expo.dev/). We always like to hear about projects and components that people are building on Expo and there's usually someone available to answer questions.
+import { JoinTheCommunity } from '../index.tsx';
 
-- [Join the Expo forums](https://forums.expo.dev/)
-- [Chat with other developers on Discord](https://discord.gg/4gtbPAdpaE)
-- [Follow us on Twitter @expo](https://twitter.com/expo)
-- [Become a contributor on GitHub](https://github.com/expo)
+<JoinTheCommunity />


### PR DESCRIPTION
# Why

https://exponent-internal.slack.com/archives/C1QMWQ1P0/p1662240316279509



### Before

<img width="1397" alt="Screen Shot 2022-09-03 at 4 23 31 PM" src="https://user-images.githubusercontent.com/9664363/188288850-ae1320b7-8d32-40c4-932f-010d85bf2b0a.png">

### After

<img width="1397" alt="Screen Shot 2022-09-03 at 4 58 15 PM" src="https://user-images.githubusercontent.com/9664363/188288851-f4582d46-1097-4714-95bd-c9bb6f2f9934.png">



<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
