### PR TITLE
[docs][permissions]: Update keyboard shortcut references

### DIFF
--- a/docs/pages/guides/permissions.md
+++ b/docs/pages/guides/permissions.md
@@ -112,6 +112,6 @@ On the web, permissions like the `Camera` and `Location` can only be requested f
 
 Often you want to be able to test what happens when a user rejects permissions, to ensure your app reacts gracefully. An operating-system level restriction on both iOS and Android prohibits an app from asking for the same permission more than once (you can imagine how this could be annoying for the user to be repeatedly prompted for permissions after rejecting them). To test different flows involving permissions in development, you may need to uninstall and reinstall the native app.
 
-When testing in [Expo Go][expo-go], you can delete the app and reinstall it by running `npx expo start` and pressing `i` or `a` in the [Expo CLI](/workflow/expo-cli) Terminal UI.
+When testing in [Expo Go][expo-go], you can delete the app and reinstall it by running `npx expo start` and pressing <kbd>i</kbd> or <kbd>a</kbd> in the [Expo CLI](/workflow/expo-cli) Terminal UI.
 
 [expo-go]: https://expo.dev/expo-go


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The keyboard shortcut references used in https://docs.expo.dev/guides/permissions/ do not match the [Writing Style Guideline](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md#referencing-keyboard-shortcuts)

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR corrects using  keyboard shortcut references by using `kbd` component.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested by running the `docs/` locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
