### PR TITLE
Better practice for use of initializeApp()

### DIFF
--- a/docs/pages/guides/using-firebase.md
+++ b/docs/pages/guides/using-firebase.md
@@ -46,7 +46,7 @@ const firebaseConfig = {
   measurementId: 'G-measurement-id',
 };
 
-initializeApp(firebaseConfig);
+let myApp = initializeApp(firebaseConfig);
 ```
 
 ### Temporarily Bypass Default Security Rules
@@ -162,9 +162,9 @@ import {
 } from 'firebase/auth';
 import * as Facebook from 'expo-facebook';
 
-initializeApp(config);
+let myApp = initializeApp(config);
 
-const auth = getAuth();
+const auth = getAuth(myApp);
 
 // Listen for authentication state to change.
 onAuthStateChanged(auth, user => {
@@ -228,9 +228,9 @@ import { getFirestore, setDoc, doc } from 'firebase/firestore';
 
 const firebaseConfig = { ... }  // apiKey, authDomain, etc. (see above)
 
-initializeApp(firebaseConfig);
+let myApp = initializeApp(firebaseConfig);
 
-const firestore = getFirestore();
+const firestore = getFirestore(myApp);
 
 await setDoc(doc(firestore, "characters", "mario"), {
   employment: "plumber",


### PR DESCRIPTION
following better practices for Firebase: use output of `initializeApp()` when fetching other services (e.g. `getAuth(myApp)` and `getFirestore(myApp)`)

# Why

Be specific (don't rely on "defaults") when fetching Firebase services.

# How

Better practices.

# Test Plan

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
