### PR TITLE
[docs] fix Reddit community description

### DIFF
--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -292,7 +292,7 @@ export function JoinTheCommunity() {
         <Row>
           <CommunityGridCell
             title="Reddit"
-            description="Get the latest on /r/expo."
+            description="Get the latest on r/expo."
             link="https://www.reddit.com/r/expo"
             icon={<RedditIcon color={palette.white} size={iconSize.large} />}
             iconBackground="#FC471E"


### PR DESCRIPTION
# Why

Fixes ENG-6218

# How

Correct the Reddit community box description.

# Test Plan

The change has been tested by running docs locally.

<img width="422" alt="Screenshot 2022-09-06 151254" src="https://user-images.githubusercontent.com/719641/188644332-32a60c66-b5dc-48b7-be4a-b0a8d15b63da.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
