### PR TITLE
[docs] ensure same height of community cells

### DIFF
--- a/docs/ui/components/Home/Cells.tsx
+++ b/docs/ui/components/Home/Cells.tsx
@@ -160,7 +160,7 @@ const cellTitleWrapperStyle = css({
 
 const cellCommunityStyle = css({
   display: 'flex',
-  minHeight: 'auto',
+  minHeight: `calc(100% - (2 * ${spacing[3]}px}))`,
   padding: spacing[4],
   margin: `${spacing[3]}px ${spacing[4]}px`,
   flexDirection: 'row',


### PR DESCRIPTION
# Why

Fixes ENG-6215

# How

Ensure that cells in same row always have the same height, no matter of viewport width and space for the content avaible.

# Test Plan

The change has been tested by running docs app locally.

<img width="722" alt="Screenshot 2022-09-06 151936" src="https://user-images.githubusercontent.com/719641/188646369-305123ee-65a7-4e3c-9abf-302e92f9f5aa.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
