### PR TITLE
[docs] BoxLink: support icons

### DIFF
--- a/docs/pages/eas/index.md
+++ b/docs/pages/eas/index.md
@@ -5,15 +5,16 @@ hideTOC: true
 ---
 
 import { BoxLink } from '~/ui/components/BoxLink';
+import { BuildIcon, StoreIcon, UpdateIcon } from '@expo/styleguide';
 
 Expo Application Services (EAS) are deeply integrated cloud services for Expo and React Native apps, from the team behind Expo.
 
 Read the full pitch at [expo.dev/eas](https://expo.dev/eas), or follow the links below to learn how to get started.
 
-<BoxLink title="EAS Build" description="Compile and sign Android/iOS apps with custom native code in the cloud. Learn more." href="/build/introduction" />
+<BoxLink title="EAS Build" description="Compile and sign Android/iOS apps with custom native code in the cloud. Learn more." href="/build/introduction" Icon={BuildIcon} />
 
-<BoxLink title="EAS Submit" description="Upload your app to the Apple App Store or Google Play Store from the cloud with one CLI command. Learn more." href="/submit/introduction" />
+<BoxLink title="EAS Submit" description="Upload your app to the Apple App Store or Google Play Store from the cloud with one CLI command. Learn more." href="/submit/introduction" Icon={StoreIcon} />
 
-<BoxLink title="EAS Update" description="Address small bugs and push quick fixes directly to end-users. Learn more." href="/eas-update/introduction" />
+<BoxLink title="EAS Update" description="Address small bugs and push quick fixes directly to end-users. Learn more." href="/eas-update/introduction" Icon={UpdateIcon} />
 
 <BoxLink title="EAS Metadata (In Preview)" description="Upload all app store information required to get your app published. Learn more." href="/eas-metadata/introduction" />

--- a/docs/pages/submit/introduction.md
+++ b/docs/pages/submit/introduction.md
@@ -6,14 +6,15 @@ hideTOC: true
 
 import { InlineCode } from '~/components/base/code';
 import { BoxLink } from '~/ui/components/BoxLink';
+import { AppleAppStoreIcon, GoogleAppStoreIcon } from '@expo/styleguide';
 
 **EAS Submit** is a hosted service for uploading and submitting your app binaries to the Apple App Store and Google Play Store. Since it's a hosted service, you can submit your app to both stores as long as you can run EAS CLI on your machine. This means you can easily submit your iOS and Android apps from your macOS, Windows, or Linux workstation or from CI.
 
 ### Get started
 
-<BoxLink title="Submitting to the Apple App Store" description="Learn how to submit an iOS/iPadOS app to the Apple App Store from any operating system." href="/submit/ios" />
+<BoxLink title="Submitting to the Apple App Store" description="Learn how to submit an iOS/iPadOS app to the Apple App Store from any operating system." href="/submit/ios" Icon={AppleAppStoreIcon} />
 
-<BoxLink title="Submitting to the Google Play Store" description="Learn how to submit an Android app to the Google Play Store." href="/submit/android" />
+<BoxLink title="Submitting to the Google Play Store" description="Learn how to submit an Android app to the Google Play Store." href="/submit/android" Icon={GoogleAppStoreIcon} />
 
 <BoxLink 
   title={'Learn how to use EAS Submit with "expo build"'} 

--- a/docs/ui/components/BoxLink/index.tsx
+++ b/docs/ui/components/BoxLink/index.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { borderRadius, spacing, theme, ArrowRightIcon, iconSize, shadows } from '@expo/styleguide';
-import { IconProps } from '@expo/styleguide/dist/types';
+import type { IconProps } from '@expo/styleguide/dist/types';
 import React, { ComponentType, PropsWithChildren, ReactNode } from 'react';
 
 import { A, HEADLINE, P } from '~/ui/components/Text';

--- a/docs/ui/components/BoxLink/index.tsx
+++ b/docs/ui/components/BoxLink/index.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import { borderRadius, spacing, theme, ArrowRightIcon, iconSize, shadows } from '@expo/styleguide';
-import React, { PropsWithChildren, ReactNode } from 'react';
+import { IconProps } from '@expo/styleguide/dist/types';
+import React, { ComponentType, PropsWithChildren, ReactNode } from 'react';
 
 import { A, HEADLINE, P } from '~/ui/components/Text';
 
@@ -9,16 +10,24 @@ type BoxLinkProps = PropsWithChildren<{
   description: string | ReactNode;
   href?: string;
   testID?: string;
+  Icon?: ComponentType<IconProps>;
 }>;
 
-export function BoxLink({ title, description, href, testID }: BoxLinkProps) {
+export function BoxLink({ title, description, href, testID, Icon }: BoxLinkProps) {
   return (
     <A href={href} css={tileContainerStyle} data-testid={testID}>
-      <div>
-        <HEADLINE tag="span">{title}</HEADLINE>
-        <P>{description}</P>
+      <div css={tileContentWrapperStyle}>
+        {Icon && (
+          <div css={tileIconBackgroundStyle}>
+            <Icon />
+          </div>
+        )}
+        <div>
+          <HEADLINE tag="span">{title}</HEADLINE>
+          <P>{description}</P>
+        </div>
       </div>
-      <ArrowRightIcon css={iconStyle} color={theme.icon.secondary} />
+      <ArrowRightIcon css={arrowIconStyle} color={theme.icon.secondary} />
     </A>
   );
 }
@@ -37,7 +46,24 @@ const tileContainerStyle = css({
   },
 });
 
-const iconStyle = css({
+const tileContentWrapperStyle = css({
+  display: 'flex',
+  flexDirection: 'row',
+  gap: spacing[4],
+});
+
+const tileIconBackgroundStyle = css({
+  display: 'flex',
+  backgroundColor: theme.background.tertiary,
+  borderRadius: borderRadius.medium,
+  alignSelf: 'center',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: 36,
+  height: 36,
+});
+
+const arrowIconStyle = css({
   alignSelf: 'center',
   alignContent: 'flex-end',
   minWidth: iconSize.regular,


### PR DESCRIPTION
# Why

To emphasize certain `BoxLink`s in the list, it is now possible to specify icon for them. The design was inspired by Expo dashboard boxed icons.

# How

`BoxLink` now can accept `Icon` prop, which should be on of the icons from the Expo Styleguide.

Everything is styled out of the box, user just need to pass the correct component.

I think we can leverage this feature in few more places, but for test/demo I have updated the EAS intro and EAS Submit boxes.

# Test Plan

The changes have been tested by running docs website locally.

# Preview

<img width="897" alt="Screenshot 2022-09-06 154944" src="https://user-images.githubusercontent.com/719641/188654223-0dd52877-1dd9-4fac-a743-5318212dae6f.png">
<img width="915" alt="Screenshot 2022-09-06 154927" src="https://user-images.githubusercontent.com/719641/188654229-16d0c865-055c-402a-a3d7-a69c52a455ed.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
