### PR TITLE
[modules][ios] Restrict view definition elements

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Closures passed to definition components are now implicitly capturing `self` on iOS. ([#18831](https://github.com/expo/expo/pull/18831) by [@tsapeta](https://github.com/tsapeta))
 - Support for CSS named colors in `UIColor` and `CGColor` convertibles on iOS. ([#18845](https://github.com/expo/expo/pull/18845) by [@tsapeta](https://github.com/tsapeta))
 - Lazy load building the module's JavaScript object from the definition on iOS (already implemented on Android). ([#18863](https://github.com/expo/expo/pull/18863) by [@tsapeta](https://github.com/tsapeta))
+- Inferring the view type in `Prop` setter closure. ([#19004](https://github.com/expo/expo/pull/19004) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/Swift/Modules/ModuleDefinition.swift
+++ b/packages/expo-modules-core/ios/Swift/Modules/ModuleDefinition.swift
@@ -83,6 +83,6 @@ internal struct ConstantsDefinition: AnyDefinition {
 /**
  A definition for module's events that can be sent to JavaScript.
  */
-internal struct EventsDefinition: AnyDefinition {
+public struct EventsDefinition: AnyDefinition {
   let names: [String]
 }

--- a/packages/expo-modules-core/ios/Swift/Objects/ObjectDefinitionComponents.swift
+++ b/packages/expo-modules-core/ios/Swift/Objects/ObjectDefinitionComponents.swift
@@ -22,7 +22,7 @@ public func Constants(@_implicitSelfCapture _ body: @autoclosure @escaping () ->
 /**
  Defines event names that the object can send to JavaScript.
  */
-public func Events(_ names: String...) -> AnyDefinition {
+public func Events(_ names: String...) -> EventsDefinition {
   return EventsDefinition(names: names)
 }
 

--- a/packages/expo-modules-core/ios/Swift/Views/ViewDefinition.swift
+++ b/packages/expo-modules-core/ios/Swift/Views/ViewDefinition.swift
@@ -22,25 +22,42 @@ public final class ViewDefinition<ViewType: UIView>: ViewManagerDefinition {
     }
     return ViewType(frame: .zero)
   }
-}
 
-/**
- A result builder for the view elements such as prop setters or view events.
- */
-@resultBuilder
-public struct ViewDefinitionElementsBuilder {
-  // TODO: Restrict the element types to only these that are handled by the ViewComponent
-  public static func buildBlock(_ elements: AnyDefinition...) -> [AnyDefinition] {
-    return elements
+  /**
+   A result builder for the view elements such as prop setters or view events.
+   */
+  @resultBuilder
+  public struct ElementsBuilder {
+    public static func buildBlock(_ elements: AnyViewDefinitionElement...) -> [AnyDefinition] {
+      return elements
+    }
+
+    /**
+     Accepts `Events` component as a definition element of `View`.
+     */
+    public static func buildExpression(_ element: EventsDefinition) -> AnyViewDefinitionElement {
+      return element
+    }
+
+    /**
+     Accepts `Prop` component as a definition element and lets to skip defining the view type — it's inferred from the `View` component.
+     */
+    public static func buildExpression<PropType: AnyArgument>(_ element: ConcreteViewProp<ViewType, PropType>) -> AnyViewDefinitionElement {
+      return element
+    }
   }
 }
+
+public protocol AnyViewDefinitionElement: AnyDefinition {}
+extension ConcreteViewProp: AnyViewDefinitionElement {}
+extension EventsDefinition: AnyViewDefinitionElement {}
 
 /**
  Creates a view definition describing the native view exported to React.
  */
 public func View<ViewType: UIView>(
   _ viewType: ViewType.Type,
-  @ViewDefinitionElementsBuilder _ elements: @escaping () -> [AnyDefinition]
+  @ViewDefinition<ViewType>.ElementsBuilder _ elements: @escaping () -> [AnyDefinition]
 ) -> ViewDefinition<ViewType> {
   return ViewDefinition(viewType, elements: elements())
 }

--- a/packages/expo-modules-core/ios/Tests/ViewDefinitionSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/ViewDefinitionSpec.swift
@@ -1,0 +1,54 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+import ExpoModulesTestCore
+
+@testable import ExpoModulesCore
+
+final class ViewDefinitionSpec: ExpoSpec {
+  override func spec() {
+    describe("View") {
+      it("creates a view") {
+        let definition = View(UIImageView.self) {}
+        let view = definition.createView(appContext: AppContext())
+        expect(view).to(beAKindOf(UIImageView.self))
+      }
+    }
+
+    describe("Prop") {
+      it("sets the prop") {
+        let textView = UITextView()
+        let content = "hello"
+        let definition = View(UITextView.self) {
+          Prop("content") { (view: UITextView, value: String) in
+            view.text = value
+          }
+        }
+        try definition.propsDict()["content"]?.set(value: content, onView: textView)
+        expect(textView.text) == content
+      }
+
+      it("infers view type") {
+        let textView = UITextView()
+        let content = "hello"
+        let definition = View(UITextView.self) {
+          // The type of `view` is inferred and equals to the type passed to `View` component.
+          Prop("content") { (view, _: String) in
+            expect(view).to(beAKindOf(UITextView.self))
+          }
+        }
+        try definition.propsDict()["content"]?.set(value: content, onView: textView)
+      }
+    }
+
+    describe("Events") {
+      it("defines events") {
+        let imageLoadedEvent = "imageLoaded"
+        let imageFailedEvent = "imageFailed"
+        let definition = View(UIImageView.self) {
+          Events(imageLoadedEvent, imageFailedEvent)
+        }
+        expect(definition.eventNames).to(contain(imageLoadedEvent, imageFailedEvent))
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Why

Only `Events` and `Prop` components are handled by `ViewDefinition`, so it sounds like a good idea to prevent adding other components in the compile time.

# How

- Only `Events` and `Prop` components can be used in the `View` body.
- The view type in `Prop` is now inferred from the type passed to `View` component.
- Added simple test spec for `ViewDefinition`

# Test Plan

The code compiles, I also checked how that would work in `expo-camera` and ran unit tests.