### PR TITLE
[dev-launcher] ui updates for landscape orientation

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🎉 New features
 
+- Better support for landscape orientation. ([#19010](https://github.com/expo/expo/pull/19010) by [@ajsmth](https://github.com/ajsmth))
+
 ### 🐛 Bug fixes
 
 - Remove the deprecated `Linking.removeEventListener` in expo-dev-launcher bundle. ([#18939](https://github.com/expo/expo/pull/18939) by [@kudo](https://github.com/kudo))

--- a/packages/expo-dev-launcher/android/src/main/AndroidManifest.xml
+++ b/packages/expo-dev-launcher/android/src/main/AndroidManifest.xml
@@ -4,7 +4,6 @@
   <application>
     <activity
       android:name="expo.modules.devlauncher.launcher.DevLauncherActivity"
-      android:screenOrientation="portrait"
       android:theme="@style/Theme.DevLauncher.LauncherActivity"
       android:launchMode="singleTask"
       android:exported="true"

--- a/packages/expo-dev-launcher/bundle/App.tsx
+++ b/packages/expo-dev-launcher/bundle/App.tsx
@@ -7,7 +7,6 @@ import {
   SettingsFilledIcon,
 } from 'expo-dev-client-components';
 import * as React from 'react';
-import { useWindowDimensions } from 'react-native';
 
 import { LoadInitialData } from './components/LoadInitialData';
 import { Splash } from './components/Splash';

--- a/packages/expo-dev-launcher/bundle/App.tsx
+++ b/packages/expo-dev-launcher/bundle/App.tsx
@@ -7,6 +7,7 @@ import {
   SettingsFilledIcon,
 } from 'expo-dev-client-components';
 import * as React from 'react';
+import { useWindowDimensions } from 'react-native';
 
 import { LoadInitialData } from './components/LoadInitialData';
 import { Splash } from './components/Splash';

--- a/packages/expo-dev-launcher/bundle/components/AppHeader.tsx
+++ b/packages/expo-dev-launcher/bundle/components/AppHeader.tsx
@@ -11,6 +11,7 @@ import {
   scale,
 } from 'expo-dev-client-components';
 import * as React from 'react';
+import { useWindowDimensions } from 'react-native';
 
 import { SafeAreaTop } from '../components/SafeAreaTop';
 import { useBuildInfo } from '../providers/BuildInfoProvider';
@@ -18,6 +19,7 @@ import { useUser } from '../providers/UserContextProvider';
 
 export function AppHeader({ navigation }) {
   const buildInfo = useBuildInfo();
+  const { width } = useWindowDimensions();
   const { appName, appIcon } = buildInfo;
 
   const { userData, selectedAccount } = useUser();
@@ -31,7 +33,11 @@ export function AppHeader({ navigation }) {
 
   return (
     <>
-      <View bg="default" pt="small" pb="small">
+      <View
+        bg="default"
+        pt="small"
+        pb="small"
+        style={{ paddingHorizontal: width > 650 ? scale[14] : 0 }}>
         <SafeAreaTop />
         <Row align="center">
           <Spacer.Horizontal size="medium" />

--- a/packages/expo-dev-launcher/bundle/components/ScreenContainer.tsx
+++ b/packages/expo-dev-launcher/bundle/components/ScreenContainer.tsx
@@ -1,0 +1,8 @@
+import { scale, View } from 'expo-dev-client-components';
+import * as React from 'react';
+import { useWindowDimensions } from 'react-native';
+
+export function ScreenContainer({ children }: { children: React.ReactNode }) {
+  const { width } = useWindowDimensions();
+  return <View style={{ flex: 1, marginHorizontal: width > 650 ? scale[14] : 0 }}>{children}</View>;
+}

--- a/packages/expo-dev-launcher/bundle/screens/BranchesScreen.tsx
+++ b/packages/expo-dev-launcher/bundle/screens/BranchesScreen.tsx
@@ -6,6 +6,7 @@ import { BasicButton } from '../components/BasicButton';
 import { EASBranchRow, EASEmptyBranchRow } from '../components/EASUpdatesRows';
 import { EmptyBranchesMessage } from '../components/EmptyBranchesMessage';
 import { FlatList } from '../components/FlatList';
+import { ScreenContainer } from '../components/ScreenContainer';
 import { getRecentRuntime } from '../functions/getRecentRuntime';
 import { useOnUpdatePress } from '../hooks/useOnUpdatePress';
 import { useUpdatesConfig } from '../providers/UpdatesConfigProvider';
@@ -127,21 +128,23 @@ export function BranchesScreen({ navigation }: BranchesScreenProps) {
   }
 
   return (
-    <View flex="1" px="medium">
-      <FlatList
-        isLoading={isLoading}
-        isRefreshing={isRefreshing}
-        onRefresh={() => refetch()}
-        ListHeaderComponent={Header}
-        extraData={{ length: branches.length, hasNextPage, loadingUpdateId }}
-        data={branches}
-        ItemSeparatorComponent={Divider}
-        renderItem={renderBranch}
-        keyExtractor={(item) => item?.id}
-        ListFooterComponent={Footer}
-        ListEmptyComponent={EmptyList}
-      />
-    </View>
+    <ScreenContainer>
+      <View flex="1" px="medium">
+        <FlatList
+          isLoading={isLoading}
+          isRefreshing={isRefreshing}
+          onRefresh={() => refetch()}
+          ListHeaderComponent={Header}
+          extraData={{ length: branches.length, hasNextPage, loadingUpdateId }}
+          data={branches}
+          ItemSeparatorComponent={Divider}
+          renderItem={renderBranch}
+          keyExtractor={(item) => item?.id}
+          ListFooterComponent={Footer}
+          ListEmptyComponent={EmptyList}
+        />
+      </View>
+    </ScreenContainer>
   );
 }
 

--- a/packages/expo-dev-launcher/bundle/screens/ExtensionsScreen.tsx
+++ b/packages/expo-dev-launcher/bundle/screens/ExtensionsScreen.tsx
@@ -20,6 +20,7 @@ import { AppHeader } from '../components/AppHeader';
 import { EASBranchRow, EASEmptyBranchRow } from '../components/EASUpdatesRows';
 import { EmptyBranchesMessage } from '../components/EmptyBranchesMessage';
 import { ListButton } from '../components/ListButton';
+import { ScreenContainer } from '../components/ScreenContainer';
 import { useThrottle } from '../hooks/useDebounce';
 import { useOnUpdatePress } from '../hooks/useOnUpdatePress';
 import { useUpdatesConfig } from '../providers/UpdatesConfigProvider';
@@ -72,7 +73,7 @@ export function ExtensionsScreen({ navigation }: ExtensionsScreenProps) {
             <RefreshControl refreshing={throttledRefreshing} onRefresh={() => refetch()} />
           ) : null
         }>
-        <View flex="1">
+        <ScreenContainer>
           {compatibleExtensions.length === 0 && (
             <>
               <Spacer.Vertical size="medium" />
@@ -208,7 +209,7 @@ export function ExtensionsScreen({ navigation }: ExtensionsScreenProps) {
               <ActivityIndicator />
             </View>
           )}
-        </View>
+        </ScreenContainer>
       </ScrollView>
     </View>
   );
@@ -298,43 +299,41 @@ function EASUpdatesPreview({
 
   // some compatible branches, possible some empty branches
   return (
-    <View>
-      <View mx="medium">
-        <View py="small" px="small">
-          <Heading size="small" color="secondary">
-            EAS Updates
-          </Heading>
-        </View>
-        {branches?.slice(0, 2).map((branch, index, arr) => {
-          const isFirst = index === 0;
-          const isLast = index === arr.length - 1 && branchCount <= 1;
-          const isLoading = branch.updates[0]?.id === loadingUpdateId;
-
-          return (
-            <View key={branch.name}>
-              <EASBranchRow
-                branch={branch}
-                isFirst={isFirst}
-                isLast={isLast}
-                navigation={navigation}
-                isLoading={isLoading}
-                onUpdatePress={onUpdatePress}
-              />
-              <Divider />
-            </View>
-          );
-        })}
-
-        {branchCount > 1 && (
-          <ListButton onPress={onSeeAllBranchesPress} isLast>
-            <Row>
-              <Text size="medium">See all branches</Text>
-              <Spacer.Horizontal />
-              <ChevronRightIcon />
-            </Row>
-          </ListButton>
-        )}
+    <View mx="medium">
+      <View py="small" px="small">
+        <Heading size="small" color="secondary">
+          EAS Updates
+        </Heading>
       </View>
+      {branches?.slice(0, 2).map((branch, index, arr) => {
+        const isFirst = index === 0;
+        const isLast = index === arr.length - 1 && branchCount <= 1;
+        const isLoading = branch.updates[0]?.id === loadingUpdateId;
+
+        return (
+          <View key={branch.name}>
+            <EASBranchRow
+              branch={branch}
+              isFirst={isFirst}
+              isLast={isLast}
+              navigation={navigation}
+              isLoading={isLoading}
+              onUpdatePress={onUpdatePress}
+            />
+            <Divider />
+          </View>
+        );
+      })}
+
+      {branchCount > 1 && (
+        <ListButton onPress={onSeeAllBranchesPress} isLast>
+          <Row>
+            <Text size="medium">See all branches</Text>
+            <Spacer.Horizontal />
+            <ChevronRightIcon />
+          </Row>
+        </ListButton>
+      )}
     </View>
   );
 }

--- a/packages/expo-dev-launcher/bundle/screens/ExtensionsStack.tsx
+++ b/packages/expo-dev-launcher/bundle/screens/ExtensionsStack.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import { createStackNavigator } from '@react-navigation/stack';
 
 import { BranchesScreen } from './BranchesScreen';

--- a/packages/expo-dev-launcher/bundle/screens/HomeScreen.tsx
+++ b/packages/expo-dev-launcher/bundle/screens/HomeScreen.tsx
@@ -17,13 +17,14 @@ import {
   BranchIcon,
 } from 'expo-dev-client-components';
 import * as React from 'react';
-import { Animated, ScrollView } from 'react-native';
+import { Animated, ScrollView, useWindowDimensions } from 'react-native';
 
 import { AppHeader } from '../components/AppHeader';
 import { DevServerExplainerModal } from '../components/DevServerExplainerModal';
 import { useLoadingContainerStyle } from '../components/EASUpdatesRows';
 import { LoadAppErrorModal } from '../components/LoadAppErrorModal';
 import { PulseIndicator } from '../components/PulseIndicator';
+import { ScreenContainer } from '../components/ScreenContainer';
 import { Toasts } from '../components/Toasts';
 import { UrlDropdown } from '../components/UrlDropdown';
 import { formatUpdateUrl } from '../functions/formatUpdateUrl';
@@ -114,7 +115,12 @@ export function HomeScreen({
   return (
     <View testID="DevLauncherMainScreen">
       <AppHeader navigation={navigation} />
-      <ScrollView contentContainerStyle={{ paddingBottom: scale['48'] }}>
+      <ScrollView
+        style={{}}
+        contentContainerStyle={{
+          paddingBottom: scale['48'],
+        }}>
+          <ScreenContainer>
         {crashReport && (
           <View px="medium" py="small" mt="small">
             <Button.ScaleOnPressContainer onPress={onCrashReportPress} bg="default" rounded="large">
@@ -197,6 +203,7 @@ export function HomeScreen({
 
           <RecentlyOpenedApps onRecentAppPress={onRecentAppPress} loadingUrl={loadingUrl} />
         </View>
+        </ScreenContainer>
       </ScrollView>
     </View>
   );

--- a/packages/expo-dev-launcher/bundle/screens/SettingsScreen.tsx
+++ b/packages/expo-dev-launcher/bundle/screens/SettingsScreen.tsx
@@ -204,7 +204,7 @@ export function SettingsScreen() {
                 </Text>
               </Row>
             </Button.ScaleOnPressContainer>
-            {(userData?.isExpoAdmin || __DEV__) && (
+            {userData?.isExpoAdmin && (
               <>
                 <Spacer.Vertical size="medium" />
                 <DebugSettings />

--- a/packages/expo-dev-launcher/bundle/screens/SettingsScreen.tsx
+++ b/packages/expo-dev-launcher/bundle/screens/SettingsScreen.tsx
@@ -16,6 +16,7 @@ import * as React from 'react';
 import { ScrollView, Switch } from 'react-native';
 import { useQueryClient } from 'react-query';
 import { SafeAreaTop } from '../components/SafeAreaTop';
+import { ScreenContainer } from '../components/ScreenContainer';
 
 import { Toasts } from '../components/Toasts';
 import { copyToClipboardAsync, updatesConfig } from '../native-modules/DevLauncherInternal';
@@ -83,135 +84,137 @@ export function SettingsScreen() {
 
   return (
     <ScrollView testID="DevLauncherSettingsScreen" showsVerticalScrollIndicator={false}>
-      <SafeAreaTop />
-      <Spacer.Vertical size="medium" />
-
-      <View px="medium">
-        <Heading size="large">Settings</Heading>
-      </View>
-
-      <View py="large" px="medium">
-        <View bg="default" rounded="large">
-          <Row px="medium" py="small" align="center">
-            <ShowMenuIcon />
-            <Spacer.Horizontal size="small" />
-            <Text size="large">Show menu at launch</Text>
-            <Spacer.Horizontal />
-            <Switch
-              accessibilityRole="switch"
-              accessibilityLabel="Toggle showing menu at launch"
-              value={showsAtLaunch}
-              onValueChange={() => setShowsAtLaunch(!showsAtLaunch)}
-            />
-          </Row>
-        </View>
-
-        <Spacer.Vertical size="large" />
-
-        <View padding="medium">
-          <Heading color="secondary">Menu gestures</Heading>
-        </View>
-
-        <View>
-          <Button.ScaleOnPressContainer
-            bg="default"
-            roundedTop="large"
-            roundedBottom="none"
-            onPress={() => setMotionGestureEnabled(!motionGestureEnabled)}
-            accessibilityState={{ checked: motionGestureEnabled }}>
-            <Row px="medium" py="small" align="center" bg="default">
-              <ShakeDeviceIcon />
-              <Spacer.Horizontal size="small" />
-              <Text size="large" color="default">
-                Shake device
-              </Text>
-              <Spacer.Horizontal />
-              {motionGestureEnabled && <CheckIcon />}
-            </Row>
-          </Button.ScaleOnPressContainer>
-
-          <Divider />
-
-          <Button.ScaleOnPressContainer
-            bg="default"
-            roundedBottom="large"
-            roundedTop="none"
-            onPress={() => setTouchGestureEnabled(!touchGestureEnabled)}
-            accessibilityState={{ checked: touchGestureEnabled }}>
-            <Row px="medium" py="small" bg="default">
-              <ThreeFingerPressIcon />
-              <Spacer.Horizontal size="small" />
-              <Text size="large" color="default">
-                Three-finger long-press
-              </Text>
-              <Spacer.Horizontal />
-              {touchGestureEnabled && <CheckIcon />}
-            </Row>
-          </Button.ScaleOnPressContainer>
-        </View>
-
-        <View padding="small">
-          <Text color="secondary" size="small" leading="large">
-            Selected gestures will toggle the developer menu while inside a preview. The menu allows
-            you to reload or return to home and exposes developer tools.
-          </Text>
-        </View>
-
+      <ScreenContainer>
+        <SafeAreaTop />
         <Spacer.Vertical size="medium" />
 
-        <View rounded="large" overflow="hidden">
-          <Row px="medium" py="small" align="center" bg="default">
-            <Text>Version</Text>
-            <Spacer.Horizontal />
-            <Text>{buildInfo?.appVersion}</Text>
-          </Row>
-
-          {Boolean(buildInfo.runtimeVersion) && (
-            <>
-              <Divider />
-              <Row px="medium" py="small" align="center" bg="default">
-                <Text>Runtime Version</Text>
-                <Spacer.Horizontal />
-                <Text>{buildInfo.runtimeVersion}</Text>
-              </Row>
-            </>
-          )}
-
-          {Boolean(buildInfo.sdkVersion) && !buildInfo.runtimeVersion && (
-            <>
-              <Divider />
-              <Row px="medium" py="small" align="center" bg="default">
-                <Text>SDK Version</Text>
-                <Spacer.Horizontal />
-                <Text>{buildInfo.sdkVersion}</Text>
-              </Row>
-            </>
-          )}
-
-          <Divider />
-
-          <Button.ScaleOnPressContainer
-            onPress={onCopyPress}
-            disabled={hasCopiedContent}
-            bg="default"
-            roundedTop="none"
-            roundedBottom="large">
-            <Row px="medium" py="small" align="center" bg="default">
-              <Text color="link" size="medium">
-                {hasCopiedContent ? 'Copied to clipboard!' : 'Tap to Copy All'}
-              </Text>
-            </Row>
-          </Button.ScaleOnPressContainer>
-          {userData?.isExpoAdmin && (
-            <>
-              <Spacer.Vertical size="medium" />
-              <DebugSettings />
-              <Spacer.Vertical size="medium" />
-              <UpdatesDebugSettings />
-            </>
-          )}
+        <View px="medium">
+          <Heading size="large">Settings</Heading>
         </View>
-      </View>
+
+        <View py="large" px="medium">
+          <View bg="default" rounded="large">
+            <Row px="medium" py="small" align="center">
+              <ShowMenuIcon />
+              <Spacer.Horizontal size="small" />
+              <Text size="large">Show menu at launch</Text>
+              <Spacer.Horizontal />
+              <Switch
+                accessibilityRole="switch"
+                accessibilityLabel="Toggle showing menu at launch"
+                value={showsAtLaunch}
+                onValueChange={() => setShowsAtLaunch(!showsAtLaunch)}
+              />
+            </Row>
+          </View>
+
+          <Spacer.Vertical size="large" />
+
+          <View padding="medium">
+            <Heading color="secondary">Menu gestures</Heading>
+          </View>
+
+          <View>
+            <Button.ScaleOnPressContainer
+              bg="default"
+              roundedTop="large"
+              roundedBottom="none"
+              onPress={() => setMotionGestureEnabled(!motionGestureEnabled)}
+              accessibilityState={{ checked: motionGestureEnabled }}>
+              <Row px="medium" py="small" align="center" bg="default">
+                <ShakeDeviceIcon />
+                <Spacer.Horizontal size="small" />
+                <Text size="large" color="default">
+                  Shake device
+                </Text>
+                <Spacer.Horizontal />
+                {motionGestureEnabled && <CheckIcon />}
+              </Row>
+            </Button.ScaleOnPressContainer>
+
+            <Divider />
+
+            <Button.ScaleOnPressContainer
+              bg="default"
+              roundedBottom="large"
+              roundedTop="none"
+              onPress={() => setTouchGestureEnabled(!touchGestureEnabled)}
+              accessibilityState={{ checked: touchGestureEnabled }}>
+              <Row px="medium" py="small" bg="default">
+                <ThreeFingerPressIcon />
+                <Spacer.Horizontal size="small" />
+                <Text size="large" color="default">
+                  Three-finger long-press
+                </Text>
+                <Spacer.Horizontal />
+                {touchGestureEnabled && <CheckIcon />}
+              </Row>
+            </Button.ScaleOnPressContainer>
+          </View>
+
+          <View padding="small">
+            <Text color="secondary" size="small" leading="large">
+              Selected gestures will toggle the developer menu while inside a preview. The menu
+              allows you to reload or return to home and exposes developer tools.
+            </Text>
+          </View>
+
+          <Spacer.Vertical size="medium" />
+
+          <View rounded="large" overflow="hidden">
+            <Row px="medium" py="small" align="center" bg="default">
+              <Text>Version</Text>
+              <Spacer.Horizontal />
+              <Text>{buildInfo?.appVersion}</Text>
+            </Row>
+
+            {Boolean(buildInfo.runtimeVersion) && (
+              <>
+                <Divider />
+                <Row px="medium" py="small" align="center" bg="default">
+                  <Text>Runtime Version</Text>
+                  <Spacer.Horizontal />
+                  <Text>{buildInfo.runtimeVersion}</Text>
+                </Row>
+              </>
+            )}
+
+            {Boolean(buildInfo.sdkVersion) && !buildInfo.runtimeVersion && (
+              <>
+                <Divider />
+                <Row px="medium" py="small" align="center" bg="default">
+                  <Text>SDK Version</Text>
+                  <Spacer.Horizontal />
+                  <Text>{buildInfo.sdkVersion}</Text>
+                </Row>
+              </>
+            )}
+
+            <Divider />
+
+            <Button.ScaleOnPressContainer
+              onPress={onCopyPress}
+              disabled={hasCopiedContent}
+              bg="default"
+              roundedTop="none"
+              roundedBottom="large">
+              <Row px="medium" py="small" align="center" bg="default">
+                <Text color="link" size="medium">
+                  {hasCopiedContent ? 'Copied to clipboard!' : 'Tap to Copy All'}
+                </Text>
+              </Row>
+            </Button.ScaleOnPressContainer>
+            {(userData?.isExpoAdmin || __DEV__) && (
+              <>
+                <Spacer.Vertical size="medium" />
+                <DebugSettings />
+                <Spacer.Vertical size="medium" />
+                <UpdatesDebugSettings />
+              </>
+            )}
+          </View>
+        </View>
+      </ScreenContainer>
     </ScrollView>
   );
 }

--- a/packages/expo-dev-launcher/bundle/screens/UpdatesScreen.tsx
+++ b/packages/expo-dev-launcher/bundle/screens/UpdatesScreen.tsx
@@ -19,6 +19,7 @@ import { ScrollView } from 'react-native-gesture-handler';
 import { BasicButton } from '../components/BasicButton';
 import { EASUpdateRow } from '../components/EASUpdatesRows';
 import { FlatList } from '../components/FlatList';
+import { ScreenContainer } from '../components/ScreenContainer';
 import { useOnUpdatePress } from '../hooks/useOnUpdatePress';
 import { useUpdatesConfig } from '../providers/UpdatesConfigProvider';
 import { useChannelsForApp } from '../queries/useChannelsForApp';
@@ -89,29 +90,31 @@ export function UpdatesScreen({ route }: UpdatesScreenProps) {
 
   function EmptyList() {
     return (
-      <View mt="large" mx="medium" bg="default" rounded="large" padding="medium">
-        <View>
-          <Heading>There are no updates available for this branch.</Heading>
-          <Spacer.Vertical size="small" />
-          <Text color="secondary" size="small">
-            Updates allow you to deliver code directly to your users.
-          </Text>
+      <ScreenContainer>
+        <View mt="large" mx="medium" bg="default" rounded="large" padding="medium">
+          <View>
+            <Heading>There are no updates available for this branch.</Heading>
+            <Spacer.Vertical size="small" />
+            <Text color="secondary" size="small">
+              Updates allow you to deliver code directly to your users.
+            </Text>
 
-          <View py="medium" align="centered">
-            <Button.ScaleOnPressContainer
-              bg="tertiary"
-              onPress={() => {
-                Linking.openURL(`https://docs.expo.dev/eas-update/how-eas-update-works/`);
-              }}>
-              <View px="2.5" py="2">
-                <Button.Text weight="medium" color="tertiary">
-                  Publish an update
-                </Button.Text>
-              </View>
-            </Button.ScaleOnPressContainer>
+            <View py="medium" align="centered">
+              <Button.ScaleOnPressContainer
+                bg="tertiary"
+                onPress={() => {
+                  Linking.openURL(`https://docs.expo.dev/eas-update/how-eas-update-works/`);
+                }}>
+                <View px="2.5" py="2">
+                  <Button.Text weight="medium" color="tertiary">
+                    Publish an update
+                  </Button.Text>
+                </View>
+              </Button.ScaleOnPressContainer>
+            </View>
           </View>
         </View>
-      </View>
+      </ScreenContainer>
     );
   }
 
@@ -137,25 +140,27 @@ export function UpdatesScreen({ route }: UpdatesScreenProps) {
   }
 
   return (
-    <View flex="1">
-      <BranchDetailsHeader
-        branchName={branchName}
-        updates={updates}
-        onOpenPress={() => onUpdatePress(updates[0])}
-      />
-      <FlatList
-        isLoading={isLoading}
-        isRefreshing={isRefreshing}
-        onRefresh={() => refetch()}
-        ListHeaderComponent={Header}
-        data={updates}
-        extraData={{ length: updates.length, loadingUpdateId }}
-        renderItem={renderUpdate}
-        keyExtractor={(item) => item.id}
-        ListFooterComponent={Footer}
-        ListEmptyComponent={EmptyList}
-      />
-    </View>
+    <ScreenContainer>
+      <View flex="1">
+        <BranchDetailsHeader
+          branchName={branchName}
+          updates={updates}
+          onOpenPress={() => onUpdatePress(updates[0])}
+        />
+        <FlatList
+          isLoading={isLoading}
+          isRefreshing={isRefreshing}
+          onRefresh={() => refetch()}
+          ListHeaderComponent={Header}
+          data={updates}
+          extraData={{ length: updates.length, loadingUpdateId }}
+          renderItem={renderUpdate}
+          keyExtractor={(item) => item.id}
+          ListFooterComponent={Footer}
+          ListEmptyComponent={EmptyList}
+        />
+      </View>
+    </ScreenContainer>
   );
 }
 


### PR DESCRIPTION
# Why

Closes ENG-5789

I did a quick audit of styles for landscape orientation. A couple of screens had some buttons cut off / hard to reach

# How

Tweaks to padding and margin when devices are past a certain width

# Test Plan

Video: 

I tested on a iPhone 13 simulator and a variety of iPad sizes


https://user-images.githubusercontent.com/40680668/188729952-957689f9-47f9-4693-b9f0-8d1da11616c3.mp4


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
