### PR TITLE
[docs][development/getting-started]: Add a note about rebuilding the dev client

### DIFF
--- a/docs/pages/development/getting-started.md
+++ b/docs/pages/development/getting-started.md
@@ -7,7 +7,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 import { Tab, Tabs } from '~/components/plugins/Tabs';
 import { Terminal } from '~/ui/components/Snippet';
 
-Development builds of your app are Debug builds of your project that includes the [`expo-dev-client`](https://www.npmjs.com/package/expo-dev-client) library. It allows you to develop and debug projects from Expo CLI or a compatible server.
+Development builds of your app are Debug builds of your project. To create a Development build,  [`expo-dev-client`](https://www.npmjs.com/package/expo-dev-client) library is used, which allows you to develop and debug projects from Expo CLI or a compatible server.
 
 `expo-dev-client` is designed to support any workflow, release process, or set of dependencies in the Expo/React Native ecosystem. Whatever the needs of your project, either now or in the future, you'll be able to create development builds for it and get the productivity and quality of life improvements of JavaScript-driven development.
 

--- a/docs/pages/development/getting-started.md
+++ b/docs/pages/development/getting-started.md
@@ -7,16 +7,16 @@ import SnackInline from '~/components/plugins/SnackInline';
 import { Tab, Tabs } from '~/components/plugins/Tabs';
 import { Terminal } from '~/ui/components/Snippet';
 
-Development builds of your app are Debug builds of your project that include the [`expo-dev-client`](https://www.npmjs.com/package/expo-dev-client) library, which allows you to develop and debug projects from expo-cli or a compatible server.
+Development builds of your app are Debug builds of your project that includes the [`expo-dev-client`](https://www.npmjs.com/package/expo-dev-client) library. It allows you to develop and debug projects from Expo CLI or a compatible server.
 
-`expo-dev-client` is designed to support any workflow, release process, or set of dependencies in the Expo / React Native ecosystem. Whatever the needs of your project, either now or in the future, you'll be able to create development builds for it and get the productivity and quality of life improvements of JavaScript-driven development.
+`expo-dev-client` is designed to support any workflow, release process, or set of dependencies in the Expo/React Native ecosystem. Whatever the needs of your project, either now or in the future, you'll be able to create development builds for it and get the productivity and quality of life improvements of JavaScript-driven development.
 
 ## Installing `expo-dev-client` in your project
 
-If you have used Expo before, especially with the Managed workflow, [config plugins](/guides/config-plugins.md) will let you customize your project from JavaScript without ever needing to directly modify Xcode or Android Studio projects.
+If you have used Expo before, [config plugins](/guides/config-plugins.md) allow you to customize your project from JavaScript without ever needing to directly modify your project in Xcode or Android Studio.
 
 <Terminal cmd={[
-"# Only if you don't already have a Managed Workflow project",
+"# Only if you don't already have an Expo project",
 "$ npx create-expo-app my-app",
 "",
 "$ cd my-app",
@@ -25,7 +25,7 @@ If you have used Expo before, especially with the Managed workflow, [config plug
 "$ npx expo install expo-dev-client"
 ]} cmdCopy="npx create-expo-app my-app && cd my-app && expo install expo-dev-client" />
 
-> You can also improve error messages to be helpful during the development process. To do so, add `import 'expo-dev-client';` to the top of your `App.{js|tsx}` file. [Learn more](installation.md#add-better-error-handlers).
+> You can also improve error messages to be helpful during the development process. To do so, add `import 'expo-dev-client';` to the top of your `App.{js|tsx}` file. For more information, see [add better error handlers](installation.md#add-better-error-handlers).
 
 ## Creating and installing your first development build
 
@@ -55,7 +55,9 @@ Once you have registered all of the iOS devices you would like to develop on, yo
 
 </Tabs>
 
-and [installing the resulting build on your device](/build/internal-distribution.md).
+After creating the first build, [install it on your device](/build/internal-distribution.md).
+
+> **Note**: If you are using a library that contains native APIs, for example, [`expo-secure-store`](/versions/latest/sdk/securestore/), you will have to rebuild the development client. This is because the native code of the library is not included in the development client automatically when installing the library as a dependency to your project.
 
 ## Developing your app
 
@@ -67,11 +69,9 @@ Instead, all you need to do to start developing is to run:
 
 <Terminal cmd={["$ npx expo start --dev-client"]} />
 
-and scanning the resulting QR code with your system camera or QR code reader (if you want to develop against a physical device)
+Then, scan the resulting QR code with your system camera or QR code reader (if you want to develop it against a physical device). Alternatively, you can press <kbd>a</kbd> or <kbd>i</kbd> keys (to open the app in your Android or iPhone emulator or simulator).
 
-or pressing the <kbd>A</kbd> or <kbd>I</kbd> keys (to open the app in your Android or iPhone emulator or simulator respectively).
-
-Now make some changes to your project code and see them reflected on your device!
+Now make some changes to your project code and see them reflected on your device.
 
 ### The launcher screen
 
@@ -79,7 +79,7 @@ If you launch your development build from your device's Home Screen, you will se
 
 <ImageSpotlight alt="The launcher screen of a development build" src="/static/images/dev-client/launcher-screen.png" style={{ maxWidth: 600}} />
 
-If a bundler is detected on your local network, or if you've signed in to an Expo account in both `expo-cli` and your development build, you can connect to it directly from this screen. Otherwise you can connect by scanning the QR code displayed by Expo CLI.
+If a bundler is detected on your local network, or if you've signed in to an Expo account in both `expo-cli` and your development build, you can connect to it directly from this screen. Otherwise, you can connect by scanning the QR code displayed by Expo CLI.
 
 ## Customizing your runtime
 
@@ -110,7 +110,7 @@ then register the plugin in your `app.json`. Using this module will require new 
 
 Once you've generated new builds with EAS build or the `expo run:ios`/`expo run:android` commands, you can access the new capabilities in your app's code.
 
-Add the following code to your App.tsx, run `npx expo start --dev-client`, and load your JavaScript. Now you can convert speech to text in your app!
+Add the following code to your **App.tsx**, run `npx expo start --dev-client`, and load your JavaScript. Now you can convert speech to text in your app!
 
 <!-- prettier-ignore -->
 ```js
@@ -181,4 +181,4 @@ const styles = StyleSheet.create({
 
 ## Debugging your app
 
-When you need to, you can access the menu by pressing <kbd>Cmd ⌘</kbd> + <kbd>D</kbd> or <kbd>Ctrl</kbd> + <kbd>D</kbd> in Expo CLI or by shaking your phone or tablet. Here you'll be able to access all of the functions of your development build, access any debugging functionality you need, or switch to a different version of your app.
+When you need to, you can access the menu by pressing <kbd>Cmd ⌘</kbd> + <kbd>d</kbd> or <kbd>Ctrl</kbd> + <kbd>d</kbd> in Expo CLI or by shaking your phone or tablet. Here you'll be able to access all of the functions of your development build, access any debugging functionality you need, or switch to a different version of your app.

--- a/docs/pages/development/getting-started.md
+++ b/docs/pages/development/getting-started.md
@@ -57,7 +57,7 @@ Once you have registered all of the iOS devices you would like to develop on, yo
 
 After creating the first build, [install it on your device](/build/internal-distribution.md).
 
-> **Note**: If you are using a library that contains native APIs, for example, [`expo-secure-store`](/versions/latest/sdk/securestore/), you will have to rebuild the development client. This is because the native code of the library is not included in the development client automatically when installing the library as a dependency to your project.
+> **Note**: If you add a library that contains native APIs to your project, for example, [`expo-secure-store`](/versions/latest/sdk/securestore/), you will have to rebuild the development client. This is because the native code of the library is not included in the development client automatically when installing the library as a dependency to your project.
 
 ## Developing your app
 
@@ -69,7 +69,7 @@ Instead, all you need to do to start developing is to run:
 
 <Terminal cmd={["$ npx expo start --dev-client"]} />
 
-Then, scan the resulting QR code with your system camera or QR code reader (if you want to develop it against a physical device). Alternatively, you can press <kbd>a</kbd> or <kbd>i</kbd> keys (to open the app in your Android or iPhone emulator or simulator).
+Then, scan the resulting QR code with your system camera or QR code reader (if you want to develop against a physical device). Alternatively, you can press the <kbd>a</kbd> or <kbd>i</kbd> keys (to open the app in your Android emulator or iPhone simulator).
 
 Now make some changes to your project code and see them reflected on your device.
 

--- a/docs/pages/development/getting-started.md
+++ b/docs/pages/development/getting-started.md
@@ -7,7 +7,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 import { Tab, Tabs } from '~/components/plugins/Tabs';
 import { Terminal } from '~/ui/components/Snippet';
 
-Development builds of your app are Debug builds of your project. To create a Development build,  [`expo-dev-client`](https://www.npmjs.com/package/expo-dev-client) library is used, which allows you to develop and debug projects from Expo CLI or a compatible server.
+Development builds of your app are Debug builds of your project. To create a Development build, [`expo-dev-client`](https://www.npmjs.com/package/expo-dev-client) library is used, which allows you to develop and debug projects from Expo CLI or a compatible server.
 
 `expo-dev-client` is designed to support any workflow, release process, or set of dependencies in the Expo/React Native ecosystem. Whatever the needs of your project, either now or in the future, you'll be able to create development builds for it and get the productivity and quality of life improvements of JavaScript-driven development.
 
@@ -69,7 +69,7 @@ Instead, all you need to do to start developing is to run:
 
 <Terminal cmd={["$ npx expo start --dev-client"]} />
 
-Then, scan the resulting QR code with your system camera or QR code reader (if you want to develop against a physical device). Alternatively, you can press the <kbd>a</kbd> or <kbd>i</kbd> keys (to open the app in your Android emulator or iPhone simulator).
+Then, scan the resulting QR code with your system camera or QR code reader (if you want to develop against a physical device). Alternatively, you can press the <kbd>a</kbd> or <kbd>i</kbd> keys (to open the app in your Android Emulator or iPhone simulator).
 
 Now make some changes to your project code and see them reflected on your device.
 


### PR DESCRIPTION


# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Refs ENG-5890

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR:
- adds a note about rebuilding the dev client after a library that uses native API, is added as a dependency to the project. This note is used to alert the user that they will have to rebuild the dev client.
- Update a bit of verbiage
- Also updates keyboard references to use lowercase keys. I realized the capitalization doesn't matches the Expo CLI keyboard shortcuts representation.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested by running the `docs/` locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
