### PR TITLE
[core] Added `REACT_NATIVE_DOWNLOADS_DIR` environment variable support

### DIFF
--- a/.github/actions/expo-caches/action.yml
+++ b/.github/actions/expo-caches/action.yml
@@ -47,6 +47,9 @@ inputs:
     description: 'Rebuild hermes-engine AAR when cache missed'
     default: 'true'
     required: false
+  react-native-gradle-downloads:
+    description: 'Restore Gradle downloads cache for React Native libraries'
+    required: false
 
 outputs:
   yarn-workspace-hit:
@@ -225,3 +228,15 @@ runs:
         # Reset reactNativeArchitectures to build all architectures
         ORG_GRADLE_PROJECT_reactNativeArchitectures:
       working-directory: android
+
+    - name: 🛠 Setup "REACT_NATIVE_DOWNLOADS_DIR" environment variable
+      if: inputs.react-native-gradle-downloads == 'true'
+      shell: bash
+      run: echo "REACT_NATIVE_DOWNLOADS_DIR=$HOME/.gradle/react-native-downloads" >> $GITHUB_ENV
+    - name: ♻️ Restore Gradle downloads cache for React Native libraries
+      if: inputs.react-native-gradle-downloads == 'true'
+      uses: actions/cache@v2
+      with:
+        path: ${{ env.REACT_NATIVE_DOWNLOADS_DIR }}
+        key: ${{ runner.os }}-gradle-downloads-${{ hashFiles('yarn.lock') }}
+        restore-keys: ${{ runner.os }}-gradle-downloads-

--- a/.github/actions/expo-caches/action.yml
+++ b/.github/actions/expo-caches/action.yml
@@ -238,5 +238,5 @@ runs:
       uses: actions/cache@v2
       with:
         path: ${{ env.REACT_NATIVE_DOWNLOADS_DIR }}
-        key: ${{ runner.os }}-gradle-downloads-${{ hashFiles('yarn.lock') }}
-        restore-keys: ${{ runner.os }}-gradle-downloads-
+        key: gradle-downloads-${{ hashFiles('yarn.lock') }}
+        restore-keys: gradle-downloads-

--- a/.github/workflows/android-instrumentation-tests.yml
+++ b/.github/workflows/android-instrumentation-tests.yml
@@ -65,6 +65,7 @@ jobs:
           avd: 'true'
           avd-api: ${{ matrix.api-level }}
           hermes-engine-aar: 'true'
+          react-native-gradle-downloads: 'true'
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: 🧶 Install node modules in root dir

--- a/.github/workflows/android-unit-tests.yml
+++ b/.github/workflows/android-unit-tests.yml
@@ -54,6 +54,7 @@ jobs:
           yarn-workspace: 'true'
           yarn-tools: 'true'
           hermes-engine-aar: 'true'
+          react-native-gradle-downloads: 'true'
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: 🧶 Install node modules in root dir

--- a/.github/workflows/client-android.yml
+++ b/.github/workflows/client-android.yml
@@ -63,6 +63,7 @@ jobs:
           gradle: 'true'
           hermes-engine-aar: 'true'
           ndk: 'true'
+          react-native-gradle-downloads: 'true'
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: 🧶 Yarn install

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -167,6 +167,7 @@ jobs:
           yarn-tools: 'true'
           avd: 'true'
           avd-api: ${{ matrix.api-level }}
+          react-native-gradle-downloads: 'true'
       - name: 🧶 Install workspace node modules
         if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile

--- a/.github/workflows/updates-e2e.yml
+++ b/.github/workflows/updates-e2e.yml
@@ -66,6 +66,7 @@ jobs:
           yarn-workspace: 'true'
           avd: 'true'
           avd-api: ${{ matrix.api-level }}
+          react-native-gradle-downloads: 'true'
       - name: 🧶 Yarn install
         if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile

--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -440,7 +440,8 @@ useVendoredModulesForExpoView('unversioned')
 // We then copy both the downloaded code and our custom makefiles and headers into third-party-ndk.
 // After that we build native code from src/main/jni with module path pointing at third-party-ndk.
 
-def downloadsDir = new File("$buildDir/downloads")
+def customDownloadsDir = System.getenv("REACT_NATIVE_DOWNLOADS_DIR")
+def downloadsDir = customDownloadsDir ? new File(customDownloadsDir) : new File("$buildDir/downloads")
 def thirdPartyNdkDir = new File("$buildDir/third-party-ndk")
 
 def reactNativeThirdParty = new File("$reactNative/ReactAndroid/src/main/jni/third-party")

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Support for CSS named colors in `UIColor` and `CGColor` convertibles on iOS. ([#18845](https://github.com/expo/expo/pull/18845) by [@tsapeta](https://github.com/tsapeta))
 - Lazy load building the module's JavaScript object from the definition on iOS (already implemented on Android). ([#18863](https://github.com/expo/expo/pull/18863) by [@tsapeta](https://github.com/tsapeta))
 - Inferring the view type in `Prop` setter closure. ([#19004](https://github.com/expo/expo/pull/19004) by [@tsapeta](https://github.com/tsapeta))
+- [core] Added `REACT_NATIVE_DOWNLOADS_DIR` environment variable to specify custom third party libraries download location. ([#19015](https://github.com/expo/expo/pull/19015) by [@kudo](https://github.com/kudo))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -49,7 +49,8 @@ def isAndroidTest = {
   return false
 }.call()
 
-def downloadsDir = new File("$buildDir/downloads")
+def customDownloadsDir = System.getenv("REACT_NATIVE_DOWNLOADS_DIR")
+def downloadsDir = customDownloadsDir ? new File(customDownloadsDir) : new File("$buildDir/downloads")
 def thirdPartyNdkDir = new File("$buildDir/third-party-ndk")
 
 def REACT_NATIVE_BUILD_FROM_SOURCE = findProject(":ReactAndroid") != null


### PR DESCRIPTION
# Why

it's not ideal for an app to download 3rd party libraries multiple times.

![Screen Shot 2022-06-26 at 2 42 49 PM](https://user-images.githubusercontent.com/46429/188780467-e7b9baed-d58e-4581-aa80-2c4f4c0c89f9.png)

# How

- [core][expoview] add `REACT_NATIVE_DOWNLOADS_DIR` environment variable to support custom download location. the way is aligned with [react-native](https://github.com/facebook/react-native/blob/37d0a25cb28879449d89056079c94177c7d2c73f/ReactAndroid/build.gradle#L34-L35) 
- [ci] add `react-native-gradle-downloads` expo cache to set the `REACT_NATIVE_DOWNLOADS_DIR` variable and restore the cache from `$HOME/.gradle/react-native-downloads`. note that i've set the cache key as yarn.lock hash value, because GH cache action will not store the updates to storage as long as cache hit. we should use a new key after dependencies changes after react-native upgrade.

# Test Plan

- `REACT_NATIVE_DOWNLOADS_DIR=$HOME/foo ./gradlew :app:assembleDebug` in apps/bare-expo/android and verify the download files should present in $HOME/foo
- ci passed and once `react-native-gradle-downloads` cache hit, the downloadBoost task should not download the boost library.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
