### PR TITLE
Update faq.md

### DIFF
--- a/docs/pages/introduction/faq.md
+++ b/docs/pages/introduction/faq.md
@@ -8,13 +8,13 @@ In addition to the questions below, see the [forums](https://forums.expo.dev/) f
 
 <Collapsible summary="What is Expo used for?">
 
-Expo is an [open-source framework](https://github.com/expo/expo/) for React Native that allows you to develop cross-platform mobile applications using both JavaScript and React. Learn more about [what Expo offers](/introduction).
+Expo is an [open-source framework](https://github.com/expo/expo/) for React Native that allows you to develop cross-platform mobile applications and web applications using both JavaScript and React. Learn more about [what Expo offers](/introduction).
 
 </Collapsible>
 
 <Collapsible summary="Do companies use Expo?">
 
-Yes, Expo is used by top companies all around the world, serving hundreds of millions of end users. See our [showcase](https://expo.dev/customers) to learn more.
+Yes, Expo is used by top companies worldwide, serving hundreds of millions of end users. See our [showcase](https://expo.dev/customers) to learn more.
 
 </Collapsible>
 
@@ -26,29 +26,29 @@ Yes, the source for Expo Go can be found in the [expo/expo GitHub repository](ht
 
 <Collapsible summary="Who created Expo?">
 
-Expo and Expo Application Services are developed by [650 industries](https://expo.dev/about). 650 industries a is a California-based company that was founded by [Charlie Cheever](https://en.wikipedia.org/wiki/Charlie_Cheever) and [James Ide](https://jameside.com/).
+Expo and Expo Application Services (EAS) are developed by [650 industries](https://expo.dev/about). 650 industries is a California-based company that was founded by [Charlie Cheever](https://en.wikipedia.org/wiki/Charlie_Cheever) and [James Ide](https://jameside.com/).
 
 </Collapsible>
 
 <Collapsible summary="Why does Expo have its own SDK?">
 
-When Expo was first created, React Native had yet to be publicly released, meaning there were no third-party packages. In order to make the developer experience of React Native reasonable, we created a number of libraries for common functionality. Many of these libraries have since been forked and modified to meet various needs, we welcome users to mix and match whichever custom native code they need to make their app great.
+When Expo was first created, React Native had yet to be publicly released. This means there were no third-party packages. To make the developer experience of React Native reasonable, we created several libraries to achieve common functionalities. Many of these libraries have since been forked and modified to meet various needs. We welcome users to mix and match whichever custom native code they need to make their app great.
 
-The Expo SDK is well tested, written in TypeScript, documented, and built for iOS, Android, and web. Every module in the Expo SDK works together to ensure versioning always matches, this creates a nice upgrading experience.
+The Expo SDK is well tested, written in TypeScript, documented, and built for Android, iOS, and the web. Every module in the Expo SDK works together to ensure versioning always matches. This creates a nice upgrading experience.
 
-The Expo SDK is also written with the [Expo native API](/modules) to make it easier to contribute, maintain, and understand.
+The Expo SDK is also written with the [Expo native API](/modules) to make contributing, maintaining, and understanding easier.
 
 </Collapsible>
 
 <Collapsible summary="Can I use Expo with this web library?">
 
-Many popular web packages like three.js or Firebase work with Expo and React Native. Check out the [Expo examples](https://github.com/expo/examples) to learn more.
+Many popular web packages such as three.js or Firebase work with Expo and React Native. Check out the [Expo examples](https://github.com/expo/examples) to learn more.
 
 </Collapsible>
 
 <Collapsible summary="Can I use Expo with my native library?">
 
-You can use native iOS and Android libraries with Expo by creating a [custom native module](/modules/) with Swift and Kotlin. Many popular libraries already have custom native modules, check out our [React Native directory](https://reactnative.directory/) to learn more.
+You can use native iOS and Android libraries with Expo by creating a [custom native module](/modules/) with Swift and Kotlin. Many popular libraries already have custom native modules. Check out our [React Native directory](https://reactnative.directory/) to learn more.
 
 </Collapsible>
 
@@ -57,10 +57,10 @@ You can use native iOS and Android libraries with Expo by creating a [custom nat
 Expo is a framework for React Native, which is a library for building iOS and Android apps. React Native is similar to `react-dom` for web development, enabling you to run React on a particular platform, but it has a few key differences:
 
 - React Native does not support HTML or CSS.
-- Instead of using the DOM, React Native uses native components. `<View />` instead of `<div />`, for example. Native components are more performant than the DOM and provide a much nicer user experience.
+- Instead of using the DOM, React Native uses native components. For example, `<View />` instead of `<div />`. Native components are more performant than the DOM and provide a much nicer user experience.
 - Unlike React.js which has access to browser APIs, React Native uses custom native APIs. For example, instead of `navigator.geolocation`, you use `expo-location` to access the user's location. Custom native APIs are similar to browser APIs except you have full control over them. This means you can access new features before they are available in the browser.
 
-In the same way React.js frameworks help users create larger websites with ease, Expo helps users create larger apps with ease. Expo provides a suite of well-tested React Native modules that run on iOS, Android, and web. Expo also provides a suite of tools for building, deploying, and updating your app.
+In the same way React.js frameworks help users create larger websites with ease, Expo helps users create larger apps with ease. Expo provides a suite of well-tested React Native modules that run on Android, iOS, and the web. Expo also provides a suite of tools for building, deploying, and updating your app.
 
 </Collapsible>
 
@@ -94,7 +94,7 @@ Yes! All Expo tools and services work great in any React Native app. For example
 
 The fastest way to share your project is to publish with [EAS Update](/eas-update/introduction) and launch in a [development build](/development/introduction). This gives your app a URL; you can share this URL with anybody who has the Expo Go app for Android or the [development build](/development/introduction.md) for iOS or Android.
 
-When you're ready, you can create a production build (**.ipa** and **.aab**) to submit to the app stores. You can build your app in a single command with [EAS Build](/build/introduction) and submit to the stores with [EAS Submit](/submit/introduction).
+When ready, you can create a production build (**.ipa** and **.aab**) to submit to the app stores. You can build your app in a single command with [EAS Build](/build/introduction) and submit it to the stores with [EAS Submit](/submit/introduction).
 
 You can also use [internal distribution](/build/internal-distribution) to share your app with ad-hoc or enterprise provisioning on iOS and an APK on Android.
 
@@ -124,7 +124,7 @@ Expo adds [features and functionality](/introduction/) to React Native projects,
 
 Expo eject was replaced by the popular [`npx expo prebuild`](/workflow/prebuild) command which continuously generates native projects for you based on the libraries in your project and the Expo config (**app.json**). Learn more in the [Expo Prebuild documentation](/workflow/prebuild).
 
-Unlike `expo eject` library authors can configure their libraries to work with Expo Prebuild by creating a [config plugin](/guides/config-plugins). This means you can use any library with Expo Prebuild. You can also use any custom native code with Expo Prebuild by creating a [development build](/development/introduction).
+Unlike the `expo eject` library, authors can configure their libraries to work with Expo Prebuild by creating a [config plugin](/guides/config-plugins). This means you can use any library with Expo Prebuild. You can also use any custom native code with Expo Prebuild by creating a [development build](/development/introduction).
 
 </Collapsible>
 
@@ -138,4 +138,4 @@ Regardless of which CLI you use, you can use any part of the [Expo SDK](/version
 
 ## Up next
 
-The time has come to write some code. Almost. First, we need to install a couple tools. [Continue to "Installation"](/get-started/installation).
+The time has come to write some code. First, we need to install a couple of tools. Continue to [Installation](/get-started/installation) to get started.

--- a/docs/pages/introduction/faq.md
+++ b/docs/pages/introduction/faq.md
@@ -8,7 +8,7 @@ In addition to the questions below, see the [forums](https://forums.expo.dev/) f
 
 <Collapsible summary="What is Expo used for?">
 
-Expo is an [open-source framework](https://github.com/expo/expo/) for React Native that allows you to develop cross-platform mobile applications and web applications using both JavaScript and React. Learn more about [what Expo offers](/introduction).
+Expo is an [open-source npm package](https://github.com/expo/expo/) and framework for React Native projects. The `expo` package enables many important features for building and scaling an app like OTA updates, instantly sharing your app, and web support. Learn more about [what Expo offers](/introduction).
 
 </Collapsible>
 

--- a/docs/pages/introduction/faq.md
+++ b/docs/pages/introduction/faq.md
@@ -6,15 +6,67 @@ import { Collapsible } from '~/ui/components/Collapsible';
 
 In addition to the questions below, see the [forums](https://forums.expo.dev/) for more common questions and answers. Some of this information is repeated from earlier sections of the introduction but we include it here for comprehensiveness.
 
+<Collapsible summary="What is Expo used for?">
+
+Expo is an [open-source framework](https://github.com/expo/expo/) for React Native that allows you to develop cross-platform mobile applications using both JavaScript and React. Learn more about [what Expo offers](/introduction).
+
+</Collapsible>
+
+<Collapsible summary="Do companies use Expo?">
+
+Yes, Expo is used by top companies all around the world, serving hundreds of millions of end users. See our [showcase](https://expo.dev/customers) to learn more.
+
+</Collapsible>
+
+<Collapsible summary="Is Expo Go open source?">
+
+Yes, the source for Expo Go can be found in the [expo/expo GitHub repository](https://github.com/expo/expo) in the `home`, `ios`, and `android` directories. The Expo Go app is also built with Expo and React Native!
+
+</Collapsible>
+
+<Collapsible summary="Who created Expo?">
+
+Expo and Expo Application Services are developed by [650 industries](https://expo.dev/about). 650 industries a is a California-based company that was founded by [Charlie Cheever](https://en.wikipedia.org/wiki/Charlie_Cheever) and [James Ide](https://jameside.com/).
+
+</Collapsible>
+
+<Collapsible summary="Why does Expo have its own SDK?">
+
+When Expo was first created, React Native had yet to be publicly released, meaning there were no third-party packages. In order to make the developer experience of React Native reasonable, we created a number of libraries for common functionality. Many of these libraries have since been forked and modified to meet various needs, we welcome users to mix and match whichever custom native code they need to make their app great.
+
+The Expo SDK is well tested, written in TypeScript, documented, and built for iOS, Android, and web. Every module in the Expo SDK works together to ensure versioning always matches, this creates a nice upgrading experience.
+
+The Expo SDK is also written with the [Expo native API](/modules) to make it easier to contribute, maintain, and understand.
+
+</Collapsible>
+
+<Collapsible summary="Can I use Expo with this web library?">
+
+Many popular web packages like three.js or Firebase work with Expo and React Native. Check out the [Expo examples](https://github.com/expo/examples) to learn more.
+
+</Collapsible>
+
+<Collapsible summary="Can I use Expo with my native library?">
+
+You can use native iOS and Android libraries with Expo by creating a [custom native module](/modules/) with Swift and Kotlin. Many popular libraries already have custom native modules, check out our [React Native directory](https://reactnative.directory/) to learn more.
+
+</Collapsible>
+
 <Collapsible summary="Is Expo similar to React for web development?">
 
-Expo and React Native are similar to React. You'll have to learn a new set of components (`View` instead of `div`, for example) and writing mobile apps is very different from websites; you think more in terms of screens and different navigators instead of separate web pages, but much more of your knowledge carries over than if you were writing a traditional Android or iOS app.
+Expo is a framework for React Native, which is a library for building iOS and Android apps. React Native is similar to `react-dom` for web development, enabling you to run React on a particular platform, but it has a few key differences:
+
+- React Native does not support HTML or CSS.
+- Instead of using the DOM, React Native uses native components. `<View />` instead of `<div />`, for example. Native components are more performant than the DOM and provide a much nicer user experience.
+- Unlike React.js which has access to browser APIs, React Native uses custom native APIs. For example, instead of `navigator.geolocation`, you use `expo-location` to access the user's location. Custom native APIs are similar to browser APIs except you have full control over them. This means you can access new features before they are available in the browser.
+
+In the same way React.js frameworks help users create larger websites with ease, Expo helps users create larger apps with ease. Expo provides a suite of well-tested React Native modules that run on iOS, Android, and web. Expo also provides a suite of tools for building, deploying, and updating your app.
 
 </Collapsible>
 
 <Collapsible summary="What is the difference between Expo and React Native?">
 
-Learn more about this on the [Already used React Native?](/workflow/already-used-react-native) page.
+The `expo` package provides a suite of features that make it easier to develop, and scale complex React Native applications. You can install `expo` in nearly any React Native app. The `expo` package is not required to use [Expo Application Services](/eas/index) or React Native, but it is highly recommended. Learn more about [what Expo offers](/introduction).
 
 </Collapsible>
 
@@ -22,33 +74,65 @@ Learn more about this on the [Already used React Native?](/workflow/already-used
 
 The Expo platform is [free and open source](https://blog.expo.dev/exponent-is-free-as-in-and-as-in-1d6d948a60dc). This includes the libraries that make up the [Expo SDK](/versions/latest/) and the [Expo CLI](/workflow/expo-cli/) used for development. The Expo Go app, the easiest way to get started, is also free from the app stores.
 
-[Expo Application Services (EAS)](https://expo.dev/eas) is an optional suite of cloud services for Expo and React Native apps, from the Expo team. EAS makes it easier to build your app, submit it to the stores, keep it updated, send push notifications, and more. You can use EAS for free if the [Free tier](https://expo.dev/pricing) quotas are sufficient for your app. More information is available on the [pricing page](https://expo.dev/pricing).
+[Expo Application Services (EAS)](https://expo.dev/eas) is an optional suite of cloud services for React Native apps, from the Expo team. EAS makes it easier to build your app, submit it to the stores, keep it updated, send push notifications, and more. You can use EAS for free if the [Free tier](https://expo.dev/pricing) quotas are sufficient for your app. More information is available on the [pricing page](https://expo.dev/pricing).
 
 </Collapsible>
 
-<Collapsible summary="How do I add custom native code to my Expo managed project?">
+<Collapsible summary="How do I add custom native code to my Expo project?">
 
-Expo Go includes the most features from the [Expo SDK](/versions/latest/). To use other native modules in a managed project, you can use [Development Builds](/development/introduction).
+To use any custom native code, you can create a [development build](/development/introduction). We do recommend using the modules in the [Expo SDK](/versions/latest/) when possible for easier upgrades and improved developer experience.
 
 </Collapsible>
 
-<Collapsible summary="Can I use parts of Expo in my app that I created with React Native CLI?">
+<Collapsible summary="Can I use Expo in my app that I created with React Native CLI?">
 
-Yes! All Expo tools and services work great in any React Native app. For example, you can use any part of the [Expo SDK](/versions/latest/), [expo-dev-client](/development/installation) and EAS Build, Submit, and Update — they work great! [Learn more about installing Expo modules in your app](/bare/installing-expo-modules) and [how to get set up with EAS Build](/build/introduction).
+Yes! All Expo tools and services work great in any React Native app. For example, you can use any part of the [Expo SDK](/versions/latest/), [expo-dev-client](/development/installation) and EAS Build, Submit, and Update — they work great! Learn more about [installing `expo` in your project](/bare/installing-expo-modules), [adopting prebuild](/guides/adopting-prebuild), and [setting up EAS Build](/build/introduction).
 
 </Collapsible>
 
 <Collapsible summary="How do I share my Expo project? Can I submit it to the app stores?">
 
-The fastest way to share your managed Expo project is to publish it and open it in a development client app. You can publish it by installing the expo-updates library in your project and running [`eas update`](/eas-update/introduction). This gives your app a URL; you can share this URL with anybody who has the Expo Go app for Android or the [Development Build](/development/introduction.md) for your app for iOS or Android, and they can open your app immediately.
+The fastest way to share your project is to publish with [EAS Update](/eas-update/introduction) and launch in a [development build](/development/introduction). This gives your app a URL; you can share this URL with anybody who has the Expo Go app for Android or the [development build](/development/introduction.md) for iOS or Android.
 
-When you're ready, you can create a standalone app (**.ipa** and **.aab**) for submission to Apple and Google's app stores. Expo will build the binary for you when you run one command; see [Building Standalone Apps](/distribution/app-stores). Apple charges $99/year to publish your app in the App Store and Google charges a $25 one-time fee for the Play Store. You can also use [internal distribution](/build/internal-distribution) to share your app with ad-hoc or enterprise provisioning on iOS and an APK on Android.
+When you're ready, you can create a production build (**.ipa** and **.aab**) to submit to the app stores. You can build your app in a single command with [EAS Build](/build/introduction) and submit to the stores with [EAS Submit](/submit/introduction).
+
+You can also use [internal distribution](/build/internal-distribution) to share your app with ad-hoc or enterprise provisioning on iOS and an APK on Android.
+
+</Collapsible>
+
+<Collapsible summary="Can I develop iOS apps on a Windows computer?">
+
+Traditionally you needed a Mac to develop iOS apps, but you can use [EAS Build](/build/introduction) to build your app in the cloud. You can also use [EAS Submit](/submit/introduction) to submit your app to the stores. Testing can be done on a physical iOS device using [Expo Go](https://expo.dev/expo-go) or a [development build](/development/introduction).
 
 </Collapsible>
 
 <Collapsible summary="What version of Android and iOS are supported by the Expo SDK?">
 
 Expo SDK supports Android 5+ and iOS 11+.
+
+</Collapsible>
+
+<Collapsible summary="What are the disadvantages of Expo?">
+
+Expo adds [features and functionality](/introduction/) to React Native projects, with very minimal overhead. You can use any custom native code with Expo by creating a [development build](/development/introduction). We offer a [local](/workflow/expo-cli#compiling) and [cloud solution](/build/index) for creating development builds.
+
+**Previously** Expo had large native binary sizes and didn't support custom native code without "ejecting". These issues went away in December 2020 when we released [EAS Build](/build/index.md) which supports any React Native app. The concept of "ejecting" was replaced by the popular [Expo Prebuild](/workflow/prebuild) feature which has been around since SDK 41 (April 2021). The `expo eject` command was fully deprecated in Expo SDK 46 (August 2022).
+
+</Collapsible>
+
+<Collapsible summary="What happens when you eject Expo?">
+
+Expo eject was replaced by the popular [`npx expo prebuild`](/workflow/prebuild) command which continuously generates native projects for you based on the libraries in your project and the Expo config (**app.json**). Learn more in the [Expo Prebuild documentation](/workflow/prebuild).
+
+Unlike `expo eject` library authors can configure their libraries to work with Expo Prebuild by creating a [config plugin](/guides/config-plugins). This means you can use any library with Expo Prebuild. You can also use any custom native code with Expo Prebuild by creating a [development build](/development/introduction).
+
+</Collapsible>
+
+<Collapsible summary="Should I use Expo CLI or React Native CLI?">
+
+Expo CLI can be used simultaneously with React Native CLI. Expo CLI provides the same core functionality as React Native CLI, and additional functionality like automatic [TypeScript setup](/guides/typescript), [web support](/workflow/web), [auto installing compatible libraries](/workflow/expo-cli#install), [improved native build commands](/workflow/expo-cli#compiling), [tunneling](/workflow/expo-cli#tunneling), [prebuild](/workflow/prebuild), [and more](/workflow/expo-cli).
+
+Regardless of which CLI you use, you can use any part of the [Expo SDK](/versions/latest/) and [Expo Application Services](/eas/index) with your project.
 
 </Collapsible>
 


### PR DESCRIPTION
# Why

- Update outdated faqs. Resolves ENG-6299
- Search "Expo" and then answered the "People also ask" questions (that's where some of the weird ones come from).
- Blocked on https://github.com/expo/expo/pull/18981 and https://github.com/expo/expo/pull/19025

As a side note, we should add structured-data support to improve the SEO of these FAQs https://developers.google.com/search/docs/advanced/structured-data/faqpage

Another aside, maybe we should drop `why-not-expo` in favor of the FAQ.