### PR TITLE
[modules][ios] Introduce either types for function arguments

### DIFF
--- a/packages/expo-modules-core/ios/Swift/Convertibles/Either.swift
+++ b/packages/expo-modules-core/ios/Swift/Convertibles/Either.swift
@@ -1,0 +1,131 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+/*
+ A convertible type wrapper for a value that should be either of two generic types.
+ */
+open class Either<FirstType, SecondType>: ConvertibleArgument {
+  /**
+   An array of dynamic equivalents for generic either types.
+   */
+  class func dynamicTypes() -> [AnyDynamicType] {
+    return [~FirstType.self, ~SecondType.self]
+  }
+
+  /**
+   The underlying type-erased value.
+   */
+  let value: Any?
+
+  required public init(_ value: Any?) {
+    self.value = value
+  }
+
+  /**
+   Returns a bool whether the value is of the first type.
+   */
+  public func `is`(_ type: FirstType.Type) -> Bool {
+    return value is FirstType
+  }
+
+  /**
+   Returns a bool whether the value is of the second type.
+   */
+  public func `is`(_ type: SecondType.Type) -> Bool {
+    return value is SecondType
+  }
+
+  /**
+   Returns the value as of the first type or `nil` if it's not of this type.
+   */
+  public func get() -> FirstType? {
+    return value as? FirstType
+  }
+
+  /**
+   Returns the value as of the second type or `nil` if it's not of this type.
+   */
+  public func get() -> SecondType? {
+    return value as? SecondType
+  }
+
+  // MARK: - Convertible
+
+  public class func convert(from value: Any?) throws -> Self {
+    if value is FirstType || value is SecondType {
+      return Self(value)
+    }
+    throw NeitherTypeException(Self.dynamicTypes())
+  }
+}
+
+/*
+ A convertible type wrapper for a value that should be either of three generic types.
+ */
+open class EitherOfThree<FirstType, SecondType, ThirdType>: Either<FirstType, SecondType> {
+  override class func dynamicTypes() -> [AnyDynamicType] {
+    return super.dynamicTypes() + [~ThirdType.self]
+  }
+
+  /**
+   Returns a bool whether the value is of the third type.
+   */
+  public func `is`(_ type: ThirdType.Type) -> Bool {
+    return value is ThirdType
+  }
+
+  /**
+   Returns the value as of the third type or `nil` if it's not of this type.
+   */
+  public func get() -> ThirdType? {
+    return value as? ThirdType
+  }
+
+  // MARK: - Convertible
+
+  public override class func convert(from value: Any?) throws -> Self {
+    return value is ThirdType ? Self(value) : try super.convert(from: value)
+  }
+}
+
+/*
+ A convertible type wrapper for a value that should be either of four generic types.
+ */
+open class EitherOfFour<FirstType, SecondType, ThirdType, FourthType>: EitherOfThree<FirstType, SecondType, ThirdType> {
+  override class func dynamicTypes() -> [AnyDynamicType] {
+    return super.dynamicTypes() + [~FourthType.self]
+  }
+
+  /**
+   Returns a bool whether the value is of the fourth type.
+   */
+  public func `is`(_ type: FourthType.Type) -> Bool {
+    return value is FourthType
+  }
+
+  /**
+   Returns the value as of the fourth type or `nil` if it's not of this type.
+   */
+  public func get() -> FourthType? {
+    return value as? FourthType
+  }
+
+  // MARK: - Convertible
+
+  public override class func convert(from value: Any?) throws -> Self {
+    return value is FourthType ? Self(value) : try super.convert(from: value)
+  }
+}
+
+// MARK: - Exceptions
+
+/**
+ An exception thrown when the value is of neither type.
+ */
+internal class NeitherTypeException: GenericException<[AnyDynamicType]> {
+  override var reason: String {
+    var typeDescriptions = param.map({ $0.description })
+    let lastTypeDescription = typeDescriptions.removeLast()
+
+    return "Type must be either: \(typeDescriptions.joined(separator: ", ")) or \(lastTypeDescription)"
+  }
+}

--- a/packages/expo-modules-core/ios/Tests/EitherSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/EitherSpec.swift
@@ -1,0 +1,91 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+import ExpoModulesTestCore
+
+@testable import ExpoModulesCore
+
+final class EitherSpec: ExpoSpec {
+  override func spec() {
+    describe("Either") {
+      it("is the first type") {
+        let either = Either<String, Int>("string")
+        expect(either.is(String.self)) == true
+        expect(either.is(Int.self)) == false
+      }
+      it("is the second type") {
+        let either = Either<String, Int>(123)
+        expect(either.is(String.self)) == false
+        expect(either.is(Int.self)) == true
+      }
+      it("is neither") {
+        let either = Either<String, Int>(12.34)
+        expect(either.is(String.self)) == false
+        expect(either.is(Int.self)) == false
+      }
+      it("gets the first type") {
+        let either = Either<String, Int>("string")
+        let value: String? = either.get()
+        expect(value).notTo(beNil())
+      }
+      it("gets the second type") {
+        let either = Either<String, Int>(123)
+        let value: Int? = either.get()
+        expect(value).notTo(beNil())
+      }
+      it("converts as convertible") {
+        let either = try Either<String, Int>.convert(from: 123)
+        expect(either.is(String.self)) == false
+        expect(either.is(Int.self)) == true
+      }
+      it("throws when converting from neither type") {
+        expect({ try Either<String, Int>.convert(from: true) }).to(throwError(errorType: NeitherTypeException.self))
+      }
+    }
+    describe("EitherOfThree") {
+      it("is the third type") {
+        let either = EitherOfThree<String, Int, Bool>(true)
+        expect(either.is(String.self)) == false
+        expect(either.is(Int.self)) == false
+        expect(either.is(Bool.self)) == true
+      }
+      it("is neither") {
+        let either = EitherOfThree<String, Int, Bool>(12.34)
+        expect(either.is(String.self)) == false
+        expect(either.is(Int.self)) == false
+        expect(either.is(Bool.self)) == false
+      }
+      it("gets the third type") {
+        let either = EitherOfThree<String, Int, Bool>(false)
+        let value: Bool? = either.get()
+        expect(value).notTo(beNil())
+      }
+      it("throws when converting from neither type") {
+        expect({ try EitherOfThree<String, Int, Double>.convert(from: false) }).to(throwError(errorType: NeitherTypeException.self))
+      }
+    }
+    describe("EitherOfFour") {
+      it("is the fourth type") {
+        let either = EitherOfFour<String, Int, Bool, Double>(12.34)
+        expect(either.is(String.self)) == false
+        expect(either.is(Int.self)) == false
+        expect(either.is(Bool.self)) == false
+        expect(either.is(Double.self)) == true
+      }
+      it("is neither") {
+        let either = EitherOfFour<String, Int, Bool, Double>(UIColor.white)
+        expect(either.is(String.self)) == false
+        expect(either.is(Int.self)) == false
+        expect(either.is(Bool.self)) == false
+        expect(either.is(Double.self)) == false
+      }
+      it("gets the fourth type") {
+        let either = EitherOfFour<String, Int, Bool, Double>(12.34)
+        let value: Double? = either.get()
+        expect(value).notTo(beNil())
+      }
+      it("throws when converting from neither type") {
+        expect({ try EitherOfFour<String, Int, Double, Bool>.convert(from: [1, 2]) }).to(throwError(errorType: NeitherTypeException.self))
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Why

Right now it's not possible to accept multiple types for a function argument. Let's take `source` prop of the Image component as an example — we want to handle two types for this prop: `string` and `{ uri: string }`.

With "Either types" we could do:

```swift
Prop("source") { (view, source: Either<ImageSourceRecord, String>) in
  if let sourceUrl: String = source.get() {
    // ...
  }
  if let source: ImageSourceRecord = source.get() {
    // ...
  }
}
```

# How

Added three either types on iOS: `Either` that accepts two types, `EitherOfThree` and `EitherOfFour` (adding more is fairly easy, but I think it won't be necessary). In the future, when Swift starts supporting variadic generic, I believe we will be able to have just one type.

This PR only includes support for basic types — integration with records and convertibles will be added separately. 

# Test Plan

Added native unit tests