### PR TITLE
fix(cli): hide server rate limiting warning during `npx expo start`

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### 💡 Others
 
+- Hide server rate limiting warning during `npx expo start`.
 - Update the README file. ([#18663](https://github.com/expo/expo/pull/18663) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix `prebuild` e2e tests. ([#18612](https://github.com/expo/expo/pull/18612) by [@EvanBacon](https://github.com/EvanBacon))
 - Add warning about malformed project when running prebuild in non-interactive mode. ([#18436](https://github.com/expo/expo/pull/18436) by [@wkozyra95](https://github.com/wkozyra95))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 ### 💡 Others
 
-- Hide server rate limiting warning during `npx expo start`.
+- Hide server rate limiting warning during `npx expo start`. ([#19038](https://github.com/expo/expo/pull/19038) by [@EvanBacon](https://github.com/EvanBacon))
 - Update the README file. ([#18663](https://github.com/expo/expo/pull/18663) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix `prebuild` e2e tests. ([#18612](https://github.com/expo/expo/pull/18612) by [@EvanBacon](https://github.com/EvanBacon))
 - Add warning about malformed project when running prebuild in non-interactive mode. ([#18436](https://github.com/expo/expo/pull/18436) by [@wkozyra95](https://github.com/wkozyra95))

--- a/packages/@expo/cli/src/start/server/BundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/BundlerDevServer.ts
@@ -1,7 +1,6 @@
 import { MessageSocket } from '@expo/dev-server';
 import assert from 'assert';
 import openBrowserAsync from 'better-opn';
-import chalk from 'chalk';
 import resolveFrom from 'resolve-from';
 
 import { APISettings } from '../../api/settings';

--- a/packages/@expo/cli/src/start/server/BundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/BundlerDevServer.ts
@@ -244,13 +244,15 @@ export abstract class BundlerDevServer {
       this.isTargetingNative()
         ? this.getNativeRuntimeUrl()
         : this.getDevServerUrl({ hostType: 'localhost' }),
-      (error) => {
-        Log.error(
-          chalk.red(
-            '\nAn unexpected error occurred while updating the Dev Client API. This project will not appear in the "Development servers" section of the Expo Go app until this process has been restarted.'
-          )
-        );
-        Log.exception(error);
+      () => {
+        // TODO: This appears to be happening consistently after an hour.
+        // We should investigate why this is happening and fix it on our servers.
+        // Log.error(
+        //   chalk.red(
+        //     '\nAn unexpected error occurred while updating the Dev Session API. This project will not appear in the "Development servers" section of the Expo Go app until this process has been restarted.'
+        //   )
+        // );
+        // Log.exception(error);
         this.devSession?.closeAsync().catch((error) => {
           debug('[dev-session] error closing: ' + error.message);
         });


### PR DESCRIPTION
# Why

After an hour of `npx expo start` running, the dev session endpoint starts throwing errors due to rate limiting. This was secretly happening on the legacy CLI too, but that CLI was just hiding the error. Now, we'll do the same here.
