### PR TITLE
Fix link to "adopting prebuild"

### DIFF
--- a/docs/pages/workflow/prebuild.md
+++ b/docs/pages/workflow/prebuild.md
@@ -111,7 +111,7 @@ Everything offered by Expo including [EAS][eas], Expo CLI, and the libraries in 
 
 A single native project on its own is complicated to maintain, scale, and grow. In a cross-platform app, you have multiple native projects that you must maintain and keep up to date for the latest operating system releases and to avoid falling too far behind in any third party dependencies. We created the _optional_ Expo Prebuild system to streamline this process. Below are a few issues we've identified with native development in the context of React Native and some corresponding reasons we believe Expo Prebuild solves these issues.
 
-> Prebuild can be used in any React Native project. Read more in [adopting prebuild](/workflow/adopting-prebuild).
+> Prebuild can be used in any React Native project. Read more in [adopting prebuild](/guides/adopting-prebuild).
 
 ### Sensible upgrades
 


### PR DESCRIPTION
# Why

Incorrect link.

# How

Corrected link :)

# Test Plan

I clicked link.

# Checklist


- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
