### PR TITLE
Enable Azure B2C Sign Ins

### DIFF
--- a/packages/expo-auth-session/src/AuthRequest.ts
+++ b/packages/expo-auth-session/src/AuthRequest.ts
@@ -279,7 +279,7 @@ export class AuthRequest implements Omit<AuthRequestConfig, 'state'> {
 
     const query = QueryParams.buildQueryString(params);
     // Store the URL for later
-    this.url = `${discovery.authorizationEndpoint}?${query}`;
+    this.url = `${discovery.authorizationEndpoint}${discovery.authorizationEndpoint.indexOf('?') >= 0 ? '&' : '?'}${query}`;
     return this.url;
   }
 

--- a/packages/expo-auth-session/src/Discovery.ts
+++ b/packages/expo-auth-session/src/Discovery.ts
@@ -218,7 +218,7 @@ export function issuerWithWellKnownUrl(issuer: Issuer): string {
  * @return Returns a discovery document that can be used for authentication.
  */
 export async function fetchDiscoveryAsync(issuer: Issuer): Promise<DiscoveryDocument> {
-  const json = await requestAsync<ProviderMetadata>(issuerWithWellKnownUrl(issuer), {
+  const json = await requestAsync<ProviderMetadata>(isWellKnownPath(issuer) ? issuer : issuerWithWellKnownUrl(issuer), {
     dataType: 'json',
     method: 'GET',
   });
@@ -251,4 +251,8 @@ export async function resolveDiscoveryAsync(
     return await fetchDiscoveryAsync(issuerOrDiscovery);
   }
   return issuerOrDiscovery;
+}
+
+function isWellKnownPath(issuer: Issuer): boolean {
+  return issuer.indexOf('/.well-known/openid-configuration') >= 0;
 }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Enable Azure B2C sign-ins

# How

<!--
How did you build this feature or fix this bug and why?
-->

Azure B2C well-known endpoints use query parameters in their discovery document and authorization endpoints, which makes them unsuitable for current implementation as it uses simple prefixes without checking URLs

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
