### PR TITLE
[docs][ENG-4933] add information about CocoaPods cache server

### DIFF
--- a/docs/pages/build-reference/caching.mdx
+++ b/docs/pages/build-reference/caching.mdx
@@ -31,4 +31,11 @@ Currently we are caching:
 
 ## iOS dependencies
 
-There is no caching done for CocoaPods dependencies yet, only the `Podfile.lock` file is cached (in order to provide consistent results across managed app builds).
+EAS Build uses a CocoaPods cache server that can speed up downloading iOS dependencies for your build jobs and makes the service
+more resistant to the CocoaPods CDN outages.
+
+Currently we are caching all the pods available to be fetched from the CocoaPods CDN.
+
+We also cache `Podfile.lock` in order to provide consistent results across managed app builds.
+
+<br />

--- a/docs/pages/build-reference/caching.mdx
+++ b/docs/pages/build-reference/caching.mdx
@@ -31,10 +31,9 @@ Currently we are caching:
 
 ## iOS dependencies
 
-EAS Build uses a CocoaPods cache server that can speed up downloading iOS dependencies for your build jobs and makes the service
-more resistant to the CocoaPods CDN outages.
+EAS Build runs a CocoaPods cache server that can speed up downloading iOS dependencies for your build jobs. It also makes the service more resilient to CocoaPods CDN outages.
 
-Currently we are caching all the pods available to be fetched from the CocoaPods CDN.
+Currently, EAS Build is configured to cache all the pods fetched from the CocoaPods CDN.
 
 We also cache `Podfile.lock` in order to provide consistent results across managed app builds.
 

--- a/docs/pages/build-reference/caching.mdx
+++ b/docs/pages/build-reference/caching.mdx
@@ -70,9 +70,9 @@ To disable using our Maven cache server for your builds set `EAS_BUILD_DISABLE_M
 
 EAS Build runs a CocoaPods cache server that can speed up downloading iOS dependencies for your build jobs. It also makes the service more resilient to CocoaPods CDN outages.
 
-Currently, EAS Build is configured to cache almost all the pods served from official CocoaPods CDN, minus few exceptions which can't be handled by our cache server. These exceptions can be found on the [blacklist](https://github.com/expo/eas-build/blob/main/packages/cocoapods-nexus-plugin/lib/cocoapods_plugin.rb#L6) of our custom CocoaPods plugin and are fetched directly from CDN instead of being fetched through our cache server.
+Currently, EAS Build is configured to cache almost all the pods served from official CocoaPods CDN, minus few exceptions which can't be handled by our cache server. These exceptions can be found on the [blacklist](https://github.com/expo/eas-build/blob/main/packages/cocoapods-nexus-plugin/lib/cocoapods_plugin.rb#L4) of our custom CocoaPods plugin and are fetched directly from CDN instead of being fetched through our cache server.
 
-We also cache `Podfile.lock` in order to provide consistent results across managed app builds.
+We also cache `Podfile.lock` to provide consistent results across managed app builds.
 
 To disable using our CocoaPods cache server for your builds set `EAS_BUILD_DISABLE_COCOAPODS_CACHE` env variable value to `"1"` in `eas.json`.
 

--- a/docs/pages/build-reference/caching.mdx
+++ b/docs/pages/build-reference/caching.mdx
@@ -91,5 +91,3 @@ To disable using our CocoaPods cache server for your builds set `EAS_BUILD_DISAB
   // ...
 }
 ```
-
-<br />

--- a/docs/pages/build-reference/caching.mdx
+++ b/docs/pages/build-reference/caching.mdx
@@ -65,7 +65,6 @@ To disable using our Maven cache server for your builds set `EAS_BUILD_DISABLE_M
 }
 ```
 
-
 ## iOS dependencies
 
 EAS Build runs a CocoaPods cache server that can speed up downloading iOS dependencies for your build jobs. It also makes the service more resilient to CocoaPods CDN outages.

--- a/docs/pages/build-reference/caching.mdx
+++ b/docs/pages/build-reference/caching.mdx
@@ -18,6 +18,24 @@ EAS Build runs an npm cache server that can speed up downloading JavaScript depe
 
 It is not yet possible to save and restore `node_modules` between builds.
 
+To disable using our npm cache server for your builds set `EAS_BUILD_DISABLE_NPM_CACHE` env variable value to `"1"` in `eas.json`.
+
+```json
+{
+  "build": {
+    "production": {
+        "env": {
+            "EAS_BUILD_DISABLE_NPM_CACHE": "1",
+            // ...
+        }
+        // ...
+    }
+    // ...
+  }
+  // ...
+}
+```
+
 ## Android dependencies
 
 EAS Build runs a Maven cache server that can speed up downloading Android dependencies for your build jobs.
@@ -29,12 +47,49 @@ Currently we are caching:
 - `jcenter` - [https://jcenter.bintray.com/](https://jcenter.bintray.com/)
 - `plugins` - [https://plugins.gradle.org/m2/](https://plugins.gradle.org/m2/)
 
+To disable using our Maven cache server for your builds set `EAS_BUILD_DISABLE_MAVEN_CACHE` env variable value to `"1"` in `eas.json`.
+
+```json
+{
+  "build": {
+    "production": {
+        "env": {
+            "EAS_BUILD_DISABLE_MAVEN_CACHE": "1",
+            // ...
+        }
+        // ...
+    }
+    // ...
+  }
+  // ...
+}
+```
+
+
 ## iOS dependencies
 
 EAS Build runs a CocoaPods cache server that can speed up downloading iOS dependencies for your build jobs. It also makes the service more resilient to CocoaPods CDN outages.
 
-Currently, EAS Build is configured to cache all the pods fetched from the CocoaPods CDN.
+Currently, EAS Build is configured to cache almost all the pods served from official CocoaPods CDN, minus few exceptions which can't be handled by our cache server. These exceptions can be found on the [blacklist](https://github.com/expo/eas-build/blob/main/packages/cocoapods-nexus-plugin/lib/cocoapods_plugin.rb#L6) of our custom CocoaPods plugin and are fetched directly from CDN instead of being fetched through our cache server.
 
 We also cache `Podfile.lock` in order to provide consistent results across managed app builds.
+
+To disable using our CocoaPods cache server for your builds set `EAS_BUILD_DISABLE_COCOAPODS_CACHE` env variable value to `"1"` in `eas.json`.
+
+```json
+{
+  "build": {
+    "production": {
+        "env": {
+            "EAS_BUILD_DISABLE_COCOAPODS_CACHE": "1",
+            // ...
+        }
+        // ...
+    }
+    // ...
+  }
+  // ...
+}
+```
 
 <br />

--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -30,7 +30,7 @@ When selecting an image for the build you can use the full name provided below o
 - Android workers run on Kubernetes in an isolated environment
   - Every build gets its own container running on a dedicated Kubernetes node
   - Build resources: 4 CPU, 12 GB RAM
-- NPM cache deployed with Kubernetes. [Learn more](caching/#javascript-dependencies)
+- npm cache deployed with Kubernetes. [Learn more](caching/#javascript-dependencies)
 - Maven cache deployed with Kubernetes. [Learn more](caching/#android-dependencies)
 - Global Gradle configuration in `~/.gradle/gradle.properties`:
 
@@ -146,7 +146,7 @@ When selecting an image for the build you can use the full name provided below o
   - Every build gets its own fresh macOS VM
   - Hardware: Intel(R) Core(TM) i7-8700B CPU (6 cores/12 threads), 64 GB RAM
   - Build resource limits: 3 cores, 12 GB RAM
-- NPM cache. [Learn more](caching/#javascript-dependencies)
+- npm cache. [Learn more](caching/#javascript-dependencies)
 - CocoaPods cache. [Learn more](caching/#ios-dependencies)
 - `~/.npmrc`
 
@@ -163,6 +163,12 @@ When selecting an image for the build you can use the full name provided below o
   enableImmutableInstalls: false
   ```
 
+
+- Project's `Podfile` will have CocoaPods cache server URL added as a source during the build step called `Install pods` (if `Podfile` already contains explicitly specified `https://cdn.cocoapods.org/` source, it will be replaced with CocoaPods cache server URL).
+
+  ```ruby
+  source "http://10.254.24.7:8081/repository/cocoapods-proxy/"
+  ```
 #### Image `macos-monterey-12.6-xcode-14.0` (alias `latest`)
 
 <Collapsible summary="Details">

--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -146,11 +146,12 @@ When selecting an image for the build you can use the full name provided below o
   - Every build gets its own fresh macOS VM
   - Hardware: Intel(R) Core(TM) i7-8700B CPU (6 cores/12 threads), 64 GB RAM
   - Build resource limits: 3 cores, 12 GB RAM
-- npm cache. [Learn more](caching/#javascript-dependencies)
+- NPM cache. [Learn more](caching/#javascript-dependencies)
+- CocoaPods cache. [Learn more](caching/#ios-dependencies)
 - `~/.npmrc`
 
   ```ini
-  registry=http://10.254.24.8:4873
+  registry=http://10.254.24.9:4873
   ```
 
 - `~/.yarnrc.yml`
@@ -158,7 +159,7 @@ When selecting an image for the build you can use the full name provided below o
   ```yml
   unsafeHttpWhitelist:
     - '*'
-  npmRegistryServer: 'registry=http://10.254.24.8:4873'
+  npmRegistryServer: 'registry=http://10.254.24.9:4873'
   enableImmutableInstalls: false
   ```
 

--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -163,12 +163,8 @@ When selecting an image for the build you can use the full name provided below o
   enableImmutableInstalls: false
   ```
 
+- cocoapods-nexus-plugin. [Learn more](https://github.com/expo/eas-build/tree/main/packages/cocoapods-nexus-plugin)
 
-- Project's `Podfile` will have CocoaPods cache server URL added as a source during the build step called `Install pods` (if `Podfile` already contains explicitly specified `https://cdn.cocoapods.org/` source, it will be replaced with CocoaPods cache server URL).
-
-  ```ruby
-  source "http://10.254.24.7:8081/repository/cocoapods-proxy/"
-  ```
 #### Image `macos-monterey-12.6-xcode-14.0` (alias `latest`)
 
 <Collapsible summary="Details">

--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -30,8 +30,8 @@ When selecting an image for the build you can use the full name provided below o
 - Android workers run on Kubernetes in an isolated environment
   - Every build gets its own container running on a dedicated Kubernetes node
   - Build resources: 4 CPU, 12 GB RAM
-- npm cache deployed with Kubernetes. [Learn more](caching/#javascript-dependencies)
-- Maven cache deployed with Kubernetes. [Learn more](caching/#android-dependencies)
+- [npm cache deployed with Kubernetes](caching/#javascript-dependencies)
+- [Maven cache deployed with Kubernetes](caching/#android-dependencies)
 - Global Gradle configuration in `~/.gradle/gradle.properties`:
 
   ```ini
@@ -146,8 +146,8 @@ When selecting an image for the build you can use the full name provided below o
   - Every build gets its own fresh macOS VM
   - Hardware: Intel(R) Core(TM) i7-8700B CPU (6 cores/12 threads), 64 GB RAM
   - Build resource limits: 3 cores, 12 GB RAM
-- npm cache. [Learn more](caching/#javascript-dependencies)
-- CocoaPods cache. [Learn more](caching/#ios-dependencies)
+- [npm cache](caching/#javascript-dependencies)
+- [CocoaPods cache](caching/#ios-dependencies)
 - `~/.npmrc`
 
   ```ini
@@ -163,7 +163,7 @@ When selecting an image for the build you can use the full name provided below o
   enableImmutableInstalls: false
   ```
 
-- cocoapods-nexus-plugin. [Learn more](https://github.com/expo/eas-build/tree/main/packages/cocoapods-nexus-plugin)
+- [cocoapods-nexus-plugin](https://github.com/expo/eas-build/tree/main/packages/cocoapods-nexus-plugin)
 
 #### Image `macos-monterey-12.6-xcode-14.0` (alias `latest`)
 

--- a/docs/pages/build-reference/variables.mdx
+++ b/docs/pages/build-reference/variables.mdx
@@ -63,6 +63,7 @@ The following environment variables are exposed to each build job &mdash; they a
 - `EAS_BUILD_GIT_COMMIT_HASH` - the hash of the Git commit, e.g. `88f28ab5ea39108ade978de2d0d1adeedf0ece76`
 - `EAS_BUILD_NPM_CACHE_URL` - the URL of the npm cache ([learn more](/build-reference/private-npm-packages))
 - `EAS_BUILD_MAVEN_CACHE_URL` - the URL of Maven cache ([learn more](/build-reference/caching/#android-dependencies))
+- `EAS_BUILD_COCOAPODS_CACHE_URL` - the URL of CocoaPods cache ([learn more](/build-reference/caching/#ios-dependencies))
 - `EAS_BUILD_USERNAME` - the username of the user initiating the build (it's undefined for bot users)
 - `EAS_BUILD_WORKINGDIR` - the remote directory path with your project
 

--- a/docs/pages/build-reference/variables.mdx
+++ b/docs/pages/build-reference/variables.mdx
@@ -61,7 +61,7 @@ The following environment variables are exposed to each build job &mdash; they a
 - `EAS_BUILD_ID` - the build ID, e.g. `f51831f0-ea30-406a-8c5f-f8e1cc57d39c`
 - `EAS_BUILD_PROFILE` - the name of the build profile from **eas.json**, e.g. `production`
 - `EAS_BUILD_GIT_COMMIT_HASH` - the hash of the Git commit, e.g. `88f28ab5ea39108ade978de2d0d1adeedf0ece76`
-- `EAS_BUILD_NPM_CACHE_URL` - the URL of the npm cache ([learn more](/build-reference/private-npm-packages))
+- `EAS_BUILD_NPM_CACHE_URL` - the URL of npm cache ([learn more](/build-reference/private-npm-packages))
 - `EAS_BUILD_MAVEN_CACHE_URL` - the URL of Maven cache ([learn more](/build-reference/caching/#android-dependencies))
 - `EAS_BUILD_COCOAPODS_CACHE_URL` - the URL of CocoaPods cache ([learn more](/build-reference/caching/#ios-dependencies))
 - `EAS_BUILD_USERNAME` - the username of the user initiating the build (it's undefined for bot users)


### PR DESCRIPTION
# Why

Adds docs for [ENG-4933](https://linear.app/expo/issue/ENG-4933/investigate-cocoapods-cachemirror).

# How

Add information about CocoaPods cache server

# Test plan

Run the docs locallly

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
