### PR TITLE
[docs] replace invalid headings, remove unnecessary <br/>s

### DIFF
--- a/docs/pages/bare/installing-expo-modules.md
+++ b/docs/pages/bare/installing-expo-modules.md
@@ -34,8 +34,6 @@ The following instructions apply to installing the latest version of Expo module
 
 <InstallSection packageName="expo" cmd={["npm install expo"]} hideBareInstructions />
 
-<br />
-
 Once installation is complete, apply the changes from the following diffs to configure Expo modules in your project. This is expected to take about five minutes, and you may need to adapt it slightly depending on how customized your project is.
 
 ### Configuration for iOS

--- a/docs/pages/bare/installing-updates.md
+++ b/docs/pages/bare/installing-updates.md
@@ -16,8 +16,6 @@ Like most Expo modules, **this package requires that you have already [installed
 
 <InstallSection packageName="expo-updates" cmd={["expo install expo-updates", "npx pod-install"]} hideBareInstructions />
 
-<br />
-
 Once installation is complete, apply the changes from the following diffs to configure expo-updates in your project. This is expected to take about five minutes, and you may need to adapt it slightly depending on how customized your project is.
 
 ## Configuration in JavaScript and JSON

--- a/docs/pages/build-reference/caching.md
+++ b/docs/pages/build-reference/caching.md
@@ -32,5 +32,3 @@ Currently we are caching:
 ## iOS dependencies
 
 There is no caching done for CocoaPods dependencies yet, only the `Podfile.lock` file is cached (in order to provide consistent results across managed app builds).
-
-<br />

--- a/docs/pages/build-reference/limitations.md
+++ b/docs/pages/build-reference/limitations.md
@@ -48,6 +48,3 @@ The goal for managed projects with EAS Build is to remove the limitations common
 ## Get notified about changes
 
 To be notified as progress is made on these items, you can subscribe to the EAS newsletter on [expo.dev/eas](https://expo.dev/eas).
-
-<br />
-

--- a/docs/pages/guides/linking.md
+++ b/docs/pages/guides/linking.md
@@ -169,13 +169,9 @@ To make your native app handle `myapp://` simply run:
 
 <Terminal cmd={['$ npx uri-scheme add myapp']} />
 
-<br />
-
 You should now be able to see a list of all your project's schemes by running:
 
 <Terminal cmd={['$ npx uri-scheme list']} />
-
-<br />
 
 You can test it to ensure it works like this:
 

--- a/docs/pages/guides/using-sentry.md
+++ b/docs/pages/guides/using-sentry.md
@@ -115,10 +115,7 @@ Sentry.init({
 
 to your root project file (usually **App.js**), so make sure you remove it (but keep the `sentry-expo` import and original `Sentry.init` call!)
 
-
 </ConfigReactNative>
-
-<br />
 
 #### 3.1: Configure a `postPublish` hook
 
@@ -177,8 +174,6 @@ In addition to the required config fields above, you can also provide these **op
 > - url → `SENTRY_URL`
 
 </Collapsible>
-
-<br />
 
 #### 3.2: Add the Config Plugin
 

--- a/docs/pages/versions/unversioned/sdk/auth-session.md
+++ b/docs/pages/versions/unversioned/sdk/auth-session.md
@@ -32,13 +32,9 @@ To make your native app handle `mycoolredirect://` simply run:
 
 <Terminal cmd={['$ npx uri-scheme add mycoolredirect']} />
 
-<br />
-
 You should now be able to see a list of all your project's schemes by running:
 
 <Terminal cmd={['$ npx uri-scheme list']} />
-
-<br />
 
 You can test it to ensure it works like this:
 

--- a/docs/pages/versions/unversioned/sdk/captureRef.md
+++ b/docs/pages/versions/unversioned/sdk/captureRef.md
@@ -48,7 +48,7 @@ Snapshots the given view.
 
 An image of the format specified in the options parameter.
 
-##### Note on pixel values
+## Note on pixel values
 
 Remember to take the device `PixelRatio` into account. When you work with pixel values in a UI, most of the time those units are "logical pixels" or "device-independent pixels". With images like PNG files, you often work with "physical pixels". You can get the `PixelRatio` of the device using the React Native API: `PixelRatio.get()`
 

--- a/docs/pages/versions/v43.0.0/sdk/auth-session.md
+++ b/docs/pages/versions/v43.0.0/sdk/auth-session.md
@@ -29,13 +29,9 @@ To make your native app handle `mycoolredirect://` simply run:
 
 <Terminal cmd={['$ npx uri-scheme add mycoolredirect']} copyCmd="npx uri-scheme add mycoolredirect" />
 
-<br />
-
 You should now be able to see a list of all your project's schemes by running:
 
 <Terminal cmd={['$ npx uri-scheme list']} copyCmd="npx uri-scheme list" />
-
-<br />
 
 You can test it to ensure it works like this:
 

--- a/docs/pages/versions/v43.0.0/sdk/captureRef.md
+++ b/docs/pages/versions/v43.0.0/sdk/captureRef.md
@@ -47,7 +47,7 @@ Snapshots the given view.
 
 An image of the format specified in the options parameter.
 
-##### Note on pixel values
+## Note on pixel values
 
 Remember to take the device `PixelRatio` into account. When you work with pixel values in a UI, most of the time those units are "logical pixels" or "device-independent pixels". With images like PNG files, you often work with "physical pixels". You can get the `PixelRatio` of the device using the React Native API: `PixelRatio.get()`
 

--- a/docs/pages/versions/v43.0.0/sdk/facebook-ads.md
+++ b/docs/pages/versions/v43.0.0/sdk/facebook-ads.md
@@ -334,7 +334,7 @@ Asks for permissions to use data for tracking the user or the device.
 
 > iOS: it requires the `NSUserTrackingUsageDescription` message added to the **Info.plist**.
 
-##### Returns
+**Returns**
 
 A promise that resolves to an object of type [PermissionResponse](permissions.md#permissionresponse).
 
@@ -344,7 +344,7 @@ Checks application's permissions for using data for tracking the user or the dev
 
 > iOS: it requires the `NSUserTrackingUsageDescription` message added to the **Info.plist**.
 
-##### Returns
+**Returns**
 
 A promise that resolves to an object of type [PermissionResponse](permissions.md#permissionresponse).
 

--- a/docs/pages/versions/v44.0.0/sdk/auth-session.md
+++ b/docs/pages/versions/v44.0.0/sdk/auth-session.md
@@ -29,13 +29,9 @@ To make your native app handle `mycoolredirect://` simply run:
 
 <Terminal cmd={['$ npx uri-scheme add mycoolredirect']} />
 
-<br />
-
 You should now be able to see a list of all your project's schemes by running:
 
 <Terminal cmd={['$ npx uri-scheme list']} cmdCopy="npx uri-scheme list" />
-
-<br />
 
 You can test it to ensure it works like this:
 

--- a/docs/pages/versions/v44.0.0/sdk/captureRef.md
+++ b/docs/pages/versions/v44.0.0/sdk/captureRef.md
@@ -47,7 +47,7 @@ Snapshots the given view.
 
 An image of the format specified in the options parameter.
 
-##### Note on pixel values
+## Note on pixel values
 
 Remember to take the device `PixelRatio` into account. When you work with pixel values in a UI, most of the time those units are "logical pixels" or "device-independent pixels". With images like PNG files, you often work with "physical pixels". You can get the `PixelRatio` of the device using the React Native API: `PixelRatio.get()`
 

--- a/docs/pages/versions/v44.0.0/sdk/facebook-ads.md
+++ b/docs/pages/versions/v44.0.0/sdk/facebook-ads.md
@@ -334,7 +334,7 @@ Asks for permissions to use data for tracking the user or the device.
 
 > iOS: it requires the `NSUserTrackingUsageDescription` message added to the **Info.plist**.
 
-##### Returns
+**Returns**
 
 A promise that resolves to an object of type [PermissionResponse](permissions.md#permissionresponse).
 
@@ -344,7 +344,7 @@ Checks application's permissions for using data for tracking the user or the dev
 
 > iOS: it requires the `NSUserTrackingUsageDescription` message added to the **Info.plist**.
 
-##### Returns
+**Returns**
 
 A promise that resolves to an object of type [PermissionResponse](permissions.md#permissionresponse).
 

--- a/docs/pages/versions/v45.0.0/sdk/auth-session.md
+++ b/docs/pages/versions/v45.0.0/sdk/auth-session.md
@@ -31,13 +31,9 @@ To make your native app handle `mycoolredirect://` simply run:
 
 <Terminal cmd={['$ npx uri-scheme add mycoolredirect']} />
 
-<br />
-
 You should now be able to see a list of all your project's schemes by running:
 
 <Terminal cmd={['$ npx uri-scheme list']} />
-
-<br />
 
 You can test it to ensure it works like this:
 

--- a/docs/pages/versions/v45.0.0/sdk/captureRef.md
+++ b/docs/pages/versions/v45.0.0/sdk/captureRef.md
@@ -48,7 +48,7 @@ Snapshots the given view.
 
 An image of the format specified in the options parameter.
 
-##### Note on pixel values
+## Note on pixel values
 
 Remember to take the device `PixelRatio` into account. When you work with pixel values in a UI, most of the time those units are "logical pixels" or "device-independent pixels". With images like PNG files, you often work with "physical pixels". You can get the `PixelRatio` of the device using the React Native API: `PixelRatio.get()`
 

--- a/docs/pages/versions/v45.0.0/sdk/facebook-ads.md
+++ b/docs/pages/versions/v45.0.0/sdk/facebook-ads.md
@@ -337,7 +337,7 @@ Asks for permissions to use data for tracking the user or the device.
 
 > iOS: it requires the `NSUserTrackingUsageDescription` message added to the **Info.plist**.
 
-##### Returns
+**Returns**
 
 A promise that resolves to an object of type [PermissionResponse](permissions.md#permissionresponse).
 
@@ -347,7 +347,7 @@ Checks application's permissions for using data for tracking the user or the dev
 
 > iOS: it requires the `NSUserTrackingUsageDescription` message added to the **Info.plist**.
 
-##### Returns
+**Returns**
 
 A promise that resolves to an object of type [PermissionResponse](permissions.md#permissionresponse).
 

--- a/docs/pages/versions/v46.0.0/sdk/auth-session.md
+++ b/docs/pages/versions/v46.0.0/sdk/auth-session.md
@@ -31,13 +31,9 @@ To make your native app handle `mycoolredirect://` simply run:
 
 <Terminal cmd={['$ npx uri-scheme add mycoolredirect']} />
 
-<br />
-
 You should now be able to see a list of all your project's schemes by running:
 
 <Terminal cmd={['$ npx uri-scheme list']} />
-
-<br />
 
 You can test it to ensure it works like this:
 

--- a/docs/pages/versions/v46.0.0/sdk/captureRef.md
+++ b/docs/pages/versions/v46.0.0/sdk/captureRef.md
@@ -48,7 +48,7 @@ Snapshots the given view.
 
 An image of the format specified in the options parameter.
 
-##### Note on pixel values
+## Note on pixel values
 
 Remember to take the device `PixelRatio` into account. When you work with pixel values in a UI, most of the time those units are "logical pixels" or "device-independent pixels". With images like PNG files, you often work with "physical pixels". You can get the `PixelRatio` of the device using the React Native API: `PixelRatio.get()`
 

--- a/docs/pages/workflow/expo-cli.md
+++ b/docs/pages/workflow/expo-cli.md
@@ -188,7 +188,7 @@ You can debug using `lldb` and all of the native Apple debugging tools by openin
 
 Building from Xcode is useful because you can set native breakpoints and profile any part of the application. Be sure to track changes in source control (git) in case you need to regenerate the native app with `npx expo prebuild -p ios --clean`.
 
-##### iOS development signing
+**iOS development signing**
 
 If you want to see how your app will run on your device, all you have to do is connect it, run `npx expo run:ios —-device`, select your connected device.
 

--- a/docs/pages/workflow/using-libraries.md
+++ b/docs/pages/workflow/using-libraries.md
@@ -54,8 +54,6 @@ After the platform compatibility table, there will be an Installation section, w
 
 <InstallSection packageName="expo-device" hideBareInstructions />
 
-<br />
-
 The `npx expo install` command will pick a version of the library that is compatible with your project and then use your JavaScript package manager (such as npm) to install it.
 
 Next, under the API section the reference page will tell you how to import the library in your code:


### PR DESCRIPTION
# Why

I have spotted the H5 issue while testing MDX v2 site. Those tags renders incorrect on PROD and in MDX v2 version since we don't have defined styles for them in markdown parser.

<img width="257" alt="Screenshot 2022-09-09 135109" src="https://user-images.githubusercontent.com/719641/189343683-b2469f91-3d6b-45d4-a407-2786b1ef4f24.png">

# How

This PR replaces the problematic headers with higher level ones, or just with bold text, if they are nested too deep.

Additionally I have removed several `<br/>`, since they were used when custom component did not have the correct spacing, which has been fixed in typography update PR.

# Test Plan

The changes has been tested by running website locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
