### PR TITLE
[docs][expo-updates]: Add code syntax highlighting

### DIFF
--- a/docs/pages/bare/installing-updates.md
+++ b/docs/pages/bare/installing-updates.md
@@ -6,7 +6,7 @@ import InstallSection from '~/components/plugins/InstallSection';
 import ConfigurationDiff from '~/components/plugins/ConfigurationDiff';
 import { Collapsible } from '~/ui/components/Collapsible';
 
-expo-updates fetches and manages updates to your app stored on a remote server.
+`expo-updates` fetches and manages updates to your app stored on a remote server.
 
 > If you are creating a new project, we recommend using `npx create-react-native-app` instead of `npx react-native init` because it will handle the following configuration for you automatically.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently, on the page https://docs.expo.dev/bare/installing-updates/, expo-updates is code syntax highlighted. 

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR adds the inline code syntax on the mention of `expo-updates` package.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

Changes have been tested by running `docs/` locally.

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
