### PR TITLE
[docs][getting-started]: Update Getting started pages to use new local CLI

### DIFF
--- a/docs/pages/get-started/create-a-new-app.md
+++ b/docs/pages/get-started/create-a-new-app.md
@@ -7,10 +7,10 @@ import { Terminal } from '~/ui/components/Snippet';
 
 Before creating a new Expo app, you have to make sure that:
 
-- Expo CLI is installed on your development machine
+- Expo CLI is working on your development machine
 - Expo Go app is installed on your iOS or Android physical device or emulator
 
-If you have not installed any of these tools, go back to the [Installation](/get-started/installation) guide before proceeding.
+> If you need help making these tools work on your end, go back to the [Installation](/get-started/installation) guide before proceeding.
 
 ## Initializing the project
 
@@ -26,16 +26,16 @@ If you have not installed any of these tools, go back to the [Installation](/get
 
 Start the development server by running the following command:
 
-<Terminal cmd={['$ expo start']} />
+<Terminal cmd={['$ npx expo start']} />
 
-When you run `expo start` (or `npm start`), Expo CLI starts [Metro Bundler](/guides/how-expo-works/#metro-bundler). This bundler is an HTTP server that compiles the JavaScript code of your app using [Babel](https://babeljs.io/) and serves it to the Expo app. Learn more about how [Expo Development Server](/guides/how-expo-works/#expo-development-server) works.
+When you run `npx expo start` (or `yarn expo start`), Expo CLI starts [Metro Bundler](/guides/how-expo-works/#metro-bundler). This bundler is an HTTP server that compiles the JavaScript code of your app using [Babel](https://babeljs.io/) and serves it to the Expo app. Learn more about how [Expo Development Server](/guides/how-expo-works/#expo-development-server) works.
 
 ## Opening the app on your phone/tablet
 
 To open the app:
 
-- On your iPhone or iPad, open the default Apple "Camera" app and scan the QR code you see in the terminal.
 - On your Android device, press "Scan QR Code" on the "Home" tab of the Expo Go app and scan the QR code you see in the terminal.
+- On your iPhone or iPad, open the default Apple "Camera" app and scan the QR code you see in the terminal.
 
 You can open the project on multiple devices simultaneously. Go ahead and try it on an iPhone and Android phone at the same time if you have both handy.
 
@@ -45,7 +45,7 @@ First, make sure you are on the same Wi-Fi network on your computer and your dev
 
 If it still doesn't work, it may be due to the router configuration &mdash; this is common for public networks. You can work around this by choosing the "Tunnel" connection type when starting the development server, then scanning the QR code again.
 
-<Terminal cmd={['$ expo start --tunnel']} cmdCopy="expo start --tunnel" />
+<Terminal cmd={['$ npx expo start --tunnel']} />
 
 > Using the "Tunnel" connection type will make app reloads considerably slower than on "LAN" or "Local", so it's best to avoid tunnel when possible. You may want to install a simulator/emulator to speed up development if "Tunnel" is required for accessing your machine from another device on your network.
 
@@ -55,9 +55,9 @@ If it still doesn't work, it may be due to the router configuration &mdash; this
 
 If you are using a simulator or emulator, you may find the following Expo CLI keyboard shortcuts to be useful to open the app on any of the following platforms:
 
-- Pressing <kbd>I</kbd> will open in an [iOS simulator](/workflow/ios-simulator).
-- Pressing <kbd>A</kbd> will open in an [Android Emulator or connected device](/workflow/android-studio-emulator).
-- Pressing <kbd>W</kbd> will open in a web browser. Expo supports all major browsers.
+- Pressing <kbd>a</kbd> will open in an [Android Emulator or connected device](/workflow/android-studio-emulator).
+- Pressing <kbd>i</kbd> will open in an [iOS simulator](/workflow/ios-simulator).
+- Pressing <kbd>w</kbd> will open in a web browser. Expo supports all major browsers.
 
 </Collapsible>
 
@@ -71,7 +71,7 @@ Expo Go is configured by default to automatically reload the app whenever a file
 
 - Make sure the you have the [development mode enabled in Expo CLI](/workflow/development-mode#development-mode).
 - Close the Expo app and reopen it.
-- Once the app is open again, shake your device to reveal the developer menu. If you are using an emulator, press <kbd>Cmd ⌘</kbd> + <kbd>D</kbd> for iOS or <kbd>Ctrl</kbd> + <kbd>M</kbd> for Android.
+- Once the app is open again, shake your device to reveal the developer menu. If you are using an emulator, press <kbd>Ctrl</kbd> + <kbd>m</kbd> for Android or <kbd>Cmd ⌘</kbd> + <kbd>d</kbd> for iOS .
 - If you see `Enable Fast Refresh`, press it. If you see `Disable Fast Refresh`, dismiss the developer menu. Now try making another change.
 
   ![In-app developer menu](/static/images/developer-menu.png)

--- a/docs/pages/get-started/installation.md
+++ b/docs/pages/get-started/installation.md
@@ -4,16 +4,17 @@ title: Installation
 
 import { Terminal } from '~/ui/components/Snippet';
 
-To develop applications with Expo, you need two tools. A command-line application called [Expo CLI](#1-expo-cli) to serve your project, and a mobile client app called [Expo Go](#2-expo-go-app-for-ios-and) to open the project on iOS and Android platforms. Additionally, you can use any web browser to run the project on the web.
+To develop applications with Expo, you need two tools. A command-line tool called [Expo CLI](#1-expo-cli) to serve your project, and a mobile client app called [Expo Go](#2-expo-go-app-for-ios-and) to open the project on iOS and Android platforms. Additionally, you can use any web browser to run the project on the web.
 
 > You don't need macOS to build an iOS app with Expo. You only need an iOS device to run the Expo Go app. Windows, Linux, and macOS are all supported for your development machine.
 
 ## 1. Expo CLI
 
-[Expo CLI](/workflow/expo-cli) is a command-line app that is the primary interface between a developer and Expo tools. You are going to use it for different tasks in the development life cycle of your project such as serving the project in development, viewing logs, opening the app on an emulator or a physical device, etc.
+[Expo CLI](/workflow/expo-cli) is a command-line tool that is the primary interface between a developer and other Expo tools. You are going to use it for different tasks in the development life cycle of your project such as serving the project in development, viewing logs, opening the app on an emulator or a physical device, and so on.
+
 ### Requirements
 
-To install and use Expo CLI, you need to have the following tools installed on your developer machine:
+To use Expo CLI, you need to have the following tools installed on your developer machine:
 
 - [Node.js LTS release](https://nodejs.org/en/)
 - [Git](https://git-scm.com)
@@ -28,26 +29,26 @@ To install and use Expo CLI, you need to have the following tools installed on y
 - [Yarn](https://classic.yarnpkg.com/en/docs/install)
 - Windows users: [PowerShell](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-core-on-windows), Bash via WSL, or the VS Code terminal
 
-### Installing Expo CLI
+### Using Expo CLI
 
-To install Expo CLI, you need to install it as a global npm package. Open the terminal on your development machine and run the following command:
+To use Expo CLI, you can use it with `npx` &mdash; a Node.js package runner. For example, to see a list of available commands in Expo CLI, open the terminal on your development machine and run the following command:
 
 <Terminal cmd={[
-  '# Install the command line tools',
-  '$ npm install --global expo-cli'
+'# See a list of available commands in Expo CLI',
+'$ npx expo -h'
 ]} />
 
-To verify the successful installation of CLI, run the following command:
+Now, run the following command:
 
-<Terminal cmd={['$ expo whoami']} />
+<Terminal cmd={['$ npx expo whoami']} />
 
-If the installation is successful, you will see a "Not logged in" message since you are not logged in to an Expo account yet. You do not need an account to start and can proceed further with your project. However, if you want to register a new expo account, run the command:
+This command checks which Expo account is currently authenticated on your machine. You will see a **Not logged in** message since you are not logged in to an Expo account. You do not need an account to start and can proceed further with your project. However, if you want to register a new Expo account, run the following command to register a new account:
 
-<Terminal cmd={['$ expo register']} />
+<Terminal cmd={['$ npx expo register']} />
 
 If you already have an Expo account, you can log in to it by running the command:
 
-<Terminal cmd={['$ expo login']} />
+<Terminal cmd={['$ npx expo login']} />
 
 > **Need help?** Try searching the [forums](https://forums.expo.dev) &mdash; which are great resources for troubleshooting.
 
@@ -58,10 +59,10 @@ The fastest way to get up and running is to use the [Expo Go](https://expo.dev/c
 - [Android Play Store](https://play.google.com/store/apps/details?id=host.exp.exponent) - Android Lollipop (5) and greater
 - [iOS App Store](https://apps.apple.com/app/expo-go/id982107779) - iOS 11 and greater
 
-Open the Expo Go app after it has finished installing. If you have created an account with `expo-cli`, you can sign in by clicking the "Login" button in the top header on the "Home" tab. Signing in will make it easier for you to open projects in the Expo Go app while developing them &mdash; they will appear automatically under the "Projects" section on the Home tab of the app.
+Open the Expo Go app after it has finished installing. If you have created an account with Expo CLI, you can sign in by clicking the "Login" button in the top header on the "Home" tab. Signing in will make it easier for you to open projects in the Expo Go app while developing them &mdash; they will appear automatically under the "Projects" section on the Home tab of the app.
 
-> It's often useful to be able to run your app directly on your computer instead of on a separate physical device. If you would like to set this up, you can learn more about [installing the iOS Simulator (macOS only)](../workflow/ios-simulator.md) and [installing an Android Emulator](../workflow/android-studio-emulator.md).
+> It's often useful to be able to run your app directly on your computer instead of on a separate physical device. If you would like to set this up, you can learn more about [installing an Android Emulator](/workflow/android-studio-emulator) and [installing the iOS Simulator (macOS only)](/workflow/ios-simulator) .
 
 ## Up next
 
-Now that `expo-cli` and the Expo Go app are installed, [let's create a new app and write some code](../get-started/create-a-new-app.md).
+Now that Expo CLI is working and the Expo Go app is installed, [let's create a new app and write some code](../get-started/create-a-new-app.md).

--- a/docs/pages/get-started/installation.md
+++ b/docs/pages/get-started/installation.md
@@ -31,7 +31,7 @@ To use Expo CLI, you need to have the following tools installed on your develope
 
 ### Using Expo CLI
 
-To use Expo CLI, you can use it with `npx` &mdash; a Node.js package runner. For example, to see a list of available commands in Expo CLI, open the terminal on your development machine and run the following command:
+You can use Expo CLI without installation by leveraging `npx` &mdash; a Node.js package runner. For example, to see a list of available commands in Expo CLI, open the terminal on your development machine and run the following command:
 
 <Terminal cmd={[
 '# See a list of available commands in Expo CLI',


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Refs ENG-6089

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR updates https://docs.expo.dev/get-started/installation/ &  https://docs.expo.dev/get-started/create-a-new-app/ pages
- to refer and use new local Expo CLI
- remove references of global Expo CLI
- update the command the verbiage on different sections
- update keyboard shortcuts to use lowercase

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested by running `docs/` locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
