### PR TITLE
[tools] Ignore versioned and vendored Swift code when linting

### DIFF
--- a/tools/src/code-review/reviewers/lintSwiftFiles.ts
+++ b/tools/src/code-review/reviewers/lintSwiftFiles.ts
@@ -1,15 +1,22 @@
+import minimatch from 'minimatch';
 import path from 'path';
 
 import Git from '../../Git';
 import { lintStringAsync, LintViolation } from '../../linting/SwiftLint';
 import { ReviewComment, ReviewInput, ReviewOutput, ReviewStatus } from '../types';
 
+const IGNORED_PATHS = ['ios/{vendored,versioned}/**', '**/{Tests,UITests}/**'];
+
 /**
  * The entry point for the reviewer checking whether the PR violates SwiftLint rules.
  */
 export default async function ({ pullRequest, diff }: ReviewInput): Promise<ReviewOutput | null> {
   const swiftFiles = diff.filter((fileDiff) => {
-    return !fileDiff.deleted && path.extname(fileDiff.path) === '.swift';
+    return (
+      !fileDiff.deleted &&
+      path.extname(fileDiff.path) === '.swift' &&
+      !IGNORED_PATHS.some((pattern) => minimatch(fileDiff.to!, pattern))
+    );
   });
 
   const comments: ReviewComment[] = [];


### PR DESCRIPTION
# Why

I've got some bad feedback from the bot in #19055 😢 
There is no need for the bot to lint versioned and vendored code and test specs as well.

# How

Ignoring some paths when the bot runs SwiftLint

# Test Plan

Tested locally that `et review -p 19055` doesn't produce any review comments from the bot