### PR TITLE
Remove unnecessary pod dependencies from expo-av

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -10,8 +10,7 @@ PODS:
     - ExpoModulesCore
   - EXAV (12.0.2):
     - ExpoModulesCore
-    - React-runtimeexecutor
-    - ReactCommon
+    - ReactCommon/turbomodule/core
   - EXBackgroundFetch (10.3.0):
     - ExpoModulesCore
   - EXBarCodeScanner (11.4.0):
@@ -696,25 +695,6 @@ PODS:
     - ReactCommon/turbomodule/core (= 0.69.5)
   - React-runtimeexecutor (0.69.5):
     - React-jsi (= 0.69.5)
-  - ReactCommon (0.69.5):
-    - React-logger (= 0.69.5)
-    - ReactCommon/react_debug_core (= 0.69.5)
-    - ReactCommon/turbomodule (= 0.69.5)
-  - ReactCommon/react_debug_core (0.69.5):
-    - React-logger (= 0.69.5)
-  - ReactCommon/turbomodule (0.69.5):
-    - DoubleConversion
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-bridging (= 0.69.5)
-    - React-callinvoker (= 0.69.5)
-    - React-Core (= 0.69.5)
-    - React-cxxreact (= 0.69.5)
-    - React-jsi (= 0.69.5)
-    - React-logger (= 0.69.5)
-    - React-perflogger (= 0.69.5)
-    - ReactCommon/turbomodule/core (= 0.69.5)
-    - ReactCommon/turbomodule/samples (= 0.69.5)
   - ReactCommon/turbomodule/core (0.69.5):
     - DoubleConversion
     - glog
@@ -726,18 +706,6 @@ PODS:
     - React-jsi (= 0.69.5)
     - React-logger (= 0.69.5)
     - React-perflogger (= 0.69.5)
-  - ReactCommon/turbomodule/samples (0.69.5):
-    - DoubleConversion
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-bridging (= 0.69.5)
-    - React-callinvoker (= 0.69.5)
-    - React-Core (= 0.69.5)
-    - React-cxxreact (= 0.69.5)
-    - React-jsi (= 0.69.5)
-    - React-logger (= 0.69.5)
-    - React-perflogger (= 0.69.5)
-    - ReactCommon/turbomodule/core (= 0.69.5)
   - RNCAsyncStorage (1.17.6):
     - React-Core
   - RNCMaskedView (0.2.6):
@@ -1273,7 +1241,7 @@ SPEC CHECKSUMS:
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   EASClient: a2581835cf9b97d0defd5d630fc6eb1bf77045e7
   EXApplication: e418d737a036e788510f2c4ad6c10a7d54d18586
-  EXAV: 8e97d63b798d96e937269b157a1a75eec0b47bbe
+  EXAV: 9c85596b3a57b5701c7f64fd22c8df370c30e4d9
   EXBackgroundFetch: 6e0952481a966c4c0580009a7e5d0f95cb531373
   EXBarCodeScanner: 557c131b375dc861595867eece49a619bfd076dd
   EXBattery: f81f2ece048150431f12792abb552dcba8794364

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1298,8 +1298,7 @@ PODS:
     - ExpoModulesCore
   - EXAV (12.0.2):
     - ExpoModulesCore
-    - React-runtimeexecutor
-    - ReactCommon
+    - ReactCommon/turbomodule/core
   - EXBackgroundFetch (10.3.0):
     - ExpoModulesCore
   - EXBarCodeScanner (11.4.0):
@@ -1983,25 +1982,6 @@ PODS:
     - ReactCommon/turbomodule/core (= 0.69.1)
   - React-runtimeexecutor (0.69.1):
     - React-jsi (= 0.69.1)
-  - ReactCommon (0.69.1):
-    - React-logger (= 0.69.1)
-    - ReactCommon/react_debug_core (= 0.69.1)
-    - ReactCommon/turbomodule (= 0.69.1)
-  - ReactCommon/react_debug_core (0.69.1):
-    - React-logger (= 0.69.1)
-  - ReactCommon/turbomodule (0.69.1):
-    - DoubleConversion
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-bridging (= 0.69.1)
-    - React-callinvoker (= 0.69.1)
-    - React-Core (= 0.69.1)
-    - React-cxxreact (= 0.69.1)
-    - React-jsi (= 0.69.1)
-    - React-logger (= 0.69.1)
-    - React-perflogger (= 0.69.1)
-    - ReactCommon/turbomodule/core (= 0.69.1)
-    - ReactCommon/turbomodule/samples (= 0.69.1)
   - ReactCommon/turbomodule/core (0.69.1):
     - DoubleConversion
     - glog
@@ -2013,18 +1993,6 @@ PODS:
     - React-jsi (= 0.69.1)
     - React-logger (= 0.69.1)
     - React-perflogger (= 0.69.1)
-  - ReactCommon/turbomodule/samples (0.69.1):
-    - DoubleConversion
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-bridging (= 0.69.1)
-    - React-callinvoker (= 0.69.1)
-    - React-Core (= 0.69.1)
-    - React-cxxreact (= 0.69.1)
-    - React-jsi (= 0.69.1)
-    - React-logger (= 0.69.1)
-    - React-perflogger (= 0.69.1)
-    - ReactCommon/turbomodule/core (= 0.69.1)
   - RNFlashList (1.1.0):
     - React-Core
   - RNGestureHandler (2.5.0):
@@ -3376,7 +3344,7 @@ SPEC CHECKSUMS:
   EASClient: a2581835cf9b97d0defd5d630fc6eb1bf77045e7
   EXAppleAuthentication: b9e9d8fa9b0cc5277b2121eb809cf0f57c2496a7
   EXApplication: e418d737a036e788510f2c4ad6c10a7d54d18586
-  EXAV: 8e97d63b798d96e937269b157a1a75eec0b47bbe
+  EXAV: 9c85596b3a57b5701c7f64fd22c8df370c30e4d9
   EXBackgroundFetch: 6e0952481a966c4c0580009a7e5d0f95cb531373
   EXBarCodeScanner: 557c131b375dc861595867eece49a619bfd076dd
   EXBattery: f81f2ece048150431f12792abb552dcba8794364

--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -17,7 +17,7 @@
 ### 💡 Others
 
 - Drop `@expo/config-plugins` dependency in favor of peer dependency on `expo`. ([#18595](https://github.com/expo/expo/pull/18595) by [@EvanBacon](https://github.com/EvanBacon))
-- Remove unnecessary CocoaPods dependency on `ReactCommon` and `React-runtimeexecutor`.
+- Remove unnecessary CocoaPods dependency on `ReactCommon` and `React-runtimeexecutor`. ([#19067](https://github.com/expo/expo/pull/19067) by [@tsapeta](https://github.com/tsapeta))
 
 ## 12.0.2 — 2022-07-18
 

--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### 💡 Others
 
 - Drop `@expo/config-plugins` dependency in favor of peer dependency on `expo`. ([#18595](https://github.com/expo/expo/pull/18595) by [@EvanBacon](https://github.com/EvanBacon))
+- Remove unnecessary CocoaPods dependency on `ReactCommon` and `React-runtimeexecutor`.
 
 ## 12.0.2 — 2022-07-18
 

--- a/packages/expo-av/ios/EXAV.podspec
+++ b/packages/expo-av/ios/EXAV.podspec
@@ -15,11 +15,7 @@ Pod::Spec.new do |s|
   s.static_framework = true
 
   s.dependency 'ExpoModulesCore'
-  s.dependency 'ReactCommon'
-  # 'React-runtimeexecutor' is added only for prebuilding purposes as this process cannot resolve transitive headers' paths at the time of writing.
-  # This dependency is transitively included via following chain: 'ReactCommon' -> 'ReactCommon/turbomodule' -> 'React-cxxreact' -> 'React-runtimeexecutor'.
-  # TODO: remove once prebuilding starts supporting resolution of transitive dependencies
-  s.dependency 'React-runtimeexecutor'
+  s.dependency 'ReactCommon/turbomodule/core'
 
   # Swift/Objective-C compatibility
   s.pod_target_xcconfig = {


### PR DESCRIPTION
# Why

`expo-av` has the entire `ReactCommon` in dependencies, which by default includes some unnecessary subspecs like `ReactCommon/turbomodule/samples`. It only needs to depend on `ReactCommon/turbomodule/core` to include `RCTTurboModuleManager.h` that has an Objective-C category on `RCTBridge` that exposes `jsCallInvoker`.

# How

- Replaced `ReactCommon` dependency with only one of its subspecs: `ReactCommon/turbomodule/core`
- Removed `React-runtimeexecutor` dependency as it was required only for prebuilds (we'll have to turn off prebuilding for `expo-av` anyway, because it contains some Swift code now).

# Test Plan

The code still compiles and `sound.setOnAudioSampleReceived` (JSI feature that needs the `jsCallInvoker`) seem to work as expected in `native-component-list` examples.