### PR TITLE
[docs] Use npx install for InstallSection except on SDK 43, 44, and 45 versioned docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -278,7 +278,7 @@ Whenever shell commands are used or referred, use `Terminal` component to make t
 import { Terminal } from '~/ui/components/Snippet';
 
 // for single command and one prop
-<Terminal cmd={["$ expo install package"]} />
+<Terminal cmd={["$ npx expo install package"]} />
 
 // for multiple commands
 

--- a/docs/components/plugins/InstallSection.tsx
+++ b/docs/components/plugins/InstallSection.tsx
@@ -3,6 +3,7 @@ import { theme, typography } from '@expo/styleguide';
 import * as React from 'react';
 
 import { usePageMetadata } from '~/providers/page-metadata';
+import { PageApiVersionContext, PageApiVersionContextType } from '~/providers/page-api-version';
 import { Terminal } from '~/ui/components/Snippet';
 
 const STYLES_P = css`
@@ -39,13 +40,26 @@ type InstallSectionProps = React.PropsWithChildren<{
 const getPackageLink = (packageNames: string) =>
   `https://github.com/expo/expo/tree/main/packages/${packageNames.split(' ')[0]}`;
 
+function getInstallCmd(packageName: string) {
+  return `$ npx expo install ${packageName}`;
+}
+
 const InstallSection = ({
   packageName,
   hideBareInstructions = false,
-  cmd = [`$ expo install ${packageName}`],
+  cmd = [getInstallCmd(packageName)],
   href = getPackageLink(packageName),
 }: InstallSectionProps) => {
   const { sourceCodeUrl } = usePageMetadata();
+  const { version } = React.useContext(PageApiVersionContext);
+
+  // Recommend just `expo install` for SDK 43, 44, and 45.
+  // TODO: remove this when we drop SDK 45 from docs
+  if (version.startsWith('v43') || version.startsWith('v44') || version.startsWith('v45')) {
+    if (cmd[0] === getInstallCmd(packageName)) {
+      cmd[0] = cmd[0].replace('npx expo', 'expo');
+    }
+  }
 
   return (
     <>

--- a/docs/components/plugins/InstallSection.tsx
+++ b/docs/components/plugins/InstallSection.tsx
@@ -2,8 +2,8 @@ import { css } from '@emotion/react';
 import { theme, typography } from '@expo/styleguide';
 import * as React from 'react';
 
+import { PageApiVersionContext } from '~/providers/page-api-version';
 import { usePageMetadata } from '~/providers/page-metadata';
-import { PageApiVersionContext, PageApiVersionContextType } from '~/providers/page-api-version';
 import { Terminal } from '~/ui/components/Snippet';
 
 const STYLES_P = css`


### PR DESCRIPTION
# Why

We shouldn't be recommending running `expo install` without `npx` on SDK 46+

# How

Use page context to grab the version and special case for old versions.

# Test Plan

## SDK 44

<img width="1382" alt="image" src="https://user-images.githubusercontent.com/90494/189568221-41eab9fd-a813-4f54-a730-c1f2ceec47f1.png">

## SDK 46

<img width="1382" alt="image" src="https://user-images.githubusercontent.com/90494/189568249-b4582e40-77bc-4528-9bc0-e3891241ca49.png">