### PR TITLE
[expo] bump bundled version of `react-native-svg`

### DIFF
--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -117,7 +117,7 @@
     "react-native-safe-area-context": "4.3.1",
     "react-native-screens": "~3.15.0",
     "react-native-shared-element": "0.8.4",
-    "react-native-svg": "12.3.0",
+    "react-native-svg": "12.4.4",
     "react-native-view-shot": "3.3.0",
     "react-native-webview": "11.22.4",
     "test-suite": "*"

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -155,7 +155,7 @@
     "react-native-safe-area-view": "^0.14.8",
     "react-native-screens": "~3.15.0",
     "react-native-shared-element": "0.8.4",
-    "react-native-svg": "12.3.0",
+    "react-native-svg": "12.4.4",
     "react-native-view-shot": "3.3.0",
     "react-native-web": "~0.18.7",
     "react-native-webview": "11.22.4",

--- a/ios/Exponent/Versioned/Core/Api/Components/Svg/Utils/RNSVGPathMeasure.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/Svg/Utils/RNSVGPathMeasure.m
@@ -20,7 +20,7 @@ static CGFloat idealFlatness = (CGFloat).01;
 /**
  * returns the distance between two points
  */
-CGFloat distance(CGPoint p1, CGPoint p2)
+static CGFloat distance(CGPoint p1, CGPoint p2)
 {
     CGFloat dx = p2.x - p1.x;
     CGFloat dy = p2.y - p1.y;
@@ -58,7 +58,7 @@ CGFloat distance(CGPoint p1, CGPoint p2)
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  */
-void subdivideBezierAtT(const CGPoint bez[4], CGPoint bez1[4], CGPoint bez2[4], CGFloat t)
+static void subdivideBezierAtT(const CGPoint bez[4], CGPoint bez1[4], CGPoint bez2[4], CGFloat t)
 {
     CGPoint q;
     CGFloat mt = 1 - t;

--- a/packages/expo-stories/package.json
+++ b/packages/expo-stories/package.json
@@ -33,7 +33,7 @@
     "react-native-gesture-handler": "~2.5.0",
     "react-native-safe-area-context": "4.3.1",
     "react-native-screens": "~3.15.0",
-    "react-native-svg": "12.3.0",
+    "react-native-svg": "12.4.4",
     "sane": "^5.0.1"
   }
 }

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -98,7 +98,7 @@
   "react-native-safe-area-context": "4.3.1",
   "react-native-screens": "~3.15.0",
   "react-native-shared-element": "0.8.4",
-  "react-native-svg": "12.3.0",
+  "react-native-svg": "12.4.4",
   "react-native-view-shot": "3.3.0",
   "react-native-webview": "11.23.0",
   "sentry-expo": "~5.0.0",


### PR DESCRIPTION
# Why

Fixes #19013

# How

Bump bundled `react-native-svg` to the latest release from `12` major via `et uvm`.

# Test Plan

NCL app was starting correctly after performing a bump.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
