### PR TITLE
[docs][firebase-analytics]: Add a note about native Firebase SDK

### DIFF
--- a/docs/pages/versions/unversioned/sdk/firebase-analytics.md
+++ b/docs/pages/versions/unversioned/sdk/firebase-analytics.md
@@ -12,7 +12,7 @@ import { InlineCode } from '~/components/base/code';
 
 > **This is the only Firebase Analytics package for React Native that has universal platform support (iOS, Android, Web, and Electron).**
 
-**`expo-firebase-analytics`** enables the use of native Google Analytics for Firebase. Google Analytics for Firebase is a free app measurement solution that provides insight on app usage and user engagement.
+`expo-firebase-analytics` enables the use of native Google Analytics for Firebase. Google Analytics for Firebase is a free app measurement solution that provides insight on app usage and user engagement.
 Learn more in the official [Firebase Docs](https://firebase.google.com/docs/analytics/).
 
 <PlatformsSection android emulator ios simulator web />
@@ -21,12 +21,11 @@ Learn more in the official [Firebase Docs](https://firebase.google.com/docs/anal
 
 <APIInstallSection />
 
-When using the web-platform, you'll also need to run `npx expo install firebase`, which install the Firebase JS SDK.
+When using the web platform, you'll also need to run `npx expo install firebase`, which installs the Firebase JS SDK.
 
 ## Configuration
 
-To use this package, the native Firebase configurations need to be added to your app.
-[Please follow this guide on how to set up native Firebase.](/guides/setup-native-firebase)
+> If you are using [`react-native-firebase`](https://rnfirebase.io/) library in your project, you should use [`@react-native-firebase/analytics`](https://rnfirebase.io/analytics/usage) package provided by the library. For more information on how to configure native Firebase library, see [using the native Firebase SDK](/guides/setup-native-firebase/).
 
 ### Expo Go: Limitations & configuration
 

--- a/docs/pages/versions/v43.0.0/sdk/firebase-analytics.md
+++ b/docs/pages/versions/v43.0.0/sdk/firebase-analytics.md
@@ -11,7 +11,7 @@ import { InlineCode } from '~/components/base/code';
 
 > **This is the only Firebase Analytics package for React Native that has universal platform support (iOS, Android, Web, and Electron).**
 
-**`expo-firebase-analytics`** enables the use of native Google Analytics for Firebase. Google Analytics for Firebase is a free app measurement solution that provides insight on app usage and user engagement.
+`expo-firebase-analytics` enables the use of native Google Analytics for Firebase. Google Analytics for Firebase is a free app measurement solution that provides insight on app usage and user engagement.
 Learn more in the official [Firebase Docs](https://firebase.google.com/docs/analytics/).
 
 <PlatformsSection android emulator ios simulator web />
@@ -20,12 +20,11 @@ Learn more in the official [Firebase Docs](https://firebase.google.com/docs/anal
 
 <InstallSection packageName="expo-firebase-analytics" />
 
-When using the web-platform, you'll also need to run `expo install firebase`, which install the Firebase JS SDK.
+When using the web platform, you'll also need to run `npx expo install firebase`, which installs the Firebase JS SDK.
 
 ## Configuration
 
-To use this package, the native Firebase configurations need to be added to your app.
-[Please follow this guide on how to set up native Firebase.](/guides/setup-native-firebase)
+> If you are using [`react-native-firebase`](https://rnfirebase.io/) library in your project, you should use [`@react-native-firebase/analytics`](https://rnfirebase.io/analytics/usage) package provided by the library. For more information on how to configure native Firebase library, see [using the native Firebase SDK](/guides/setup-native-firebase/).
 
 ## Expo Go: Limitations & configuration
 

--- a/docs/pages/versions/v44.0.0/sdk/firebase-analytics.md
+++ b/docs/pages/versions/v44.0.0/sdk/firebase-analytics.md
@@ -11,7 +11,7 @@ import { InlineCode } from '~/components/base/code';
 
 > **This is the only Firebase Analytics package for React Native that has universal platform support (iOS, Android, Web, and Electron).**
 
-**`expo-firebase-analytics`** enables the use of native Google Analytics for Firebase. Google Analytics for Firebase is a free app measurement solution that provides insight on app usage and user engagement.
+`expo-firebase-analytics` enables the use of native Google Analytics for Firebase. Google Analytics for Firebase is a free app measurement solution that provides insight on app usage and user engagement.
 Learn more in the official [Firebase Docs](https://firebase.google.com/docs/analytics/).
 
 <PlatformsSection android emulator ios simulator web />
@@ -20,12 +20,11 @@ Learn more in the official [Firebase Docs](https://firebase.google.com/docs/anal
 
 <InstallSection packageName="expo-firebase-analytics" />
 
-When using the web-platform, you'll also need to run `expo install firebase`, which install the Firebase JS SDK.
+When using the web platform, you'll also need to run `npx expo install firebase`, which installs the Firebase JS SDK.
 
 ## Configuration
 
-To use this package, the native Firebase configurations need to be added to your app.
-[Please follow this guide on how to set up native Firebase.](/guides/setup-native-firebase)
+> If you are using [`react-native-firebase`](https://rnfirebase.io/) library in your project, you should use [`@react-native-firebase/analytics`](https://rnfirebase.io/analytics/usage) package provided by the library. For more information on how to configure native Firebase library, see [using the native Firebase SDK](/guides/setup-native-firebase/).
 
 ## Expo Go: Limitations & configuration
 

--- a/docs/pages/versions/v45.0.0/sdk/firebase-analytics.md
+++ b/docs/pages/versions/v45.0.0/sdk/firebase-analytics.md
@@ -12,7 +12,7 @@ import { InlineCode } from '~/components/base/code';
 
 > **This is the only Firebase Analytics package for React Native that has universal platform support (iOS, Android, Web, and Electron).**
 
-**`expo-firebase-analytics`** enables the use of native Google Analytics for Firebase. Google Analytics for Firebase is a free app measurement solution that provides insight on app usage and user engagement.
+`expo-firebase-analytics` enables the use of native Google Analytics for Firebase. Google Analytics for Firebase is a free app measurement solution that provides insight on app usage and user engagement.
 Learn more in the official [Firebase Docs](https://firebase.google.com/docs/analytics/).
 
 <PlatformsSection android emulator ios simulator web />
@@ -21,12 +21,11 @@ Learn more in the official [Firebase Docs](https://firebase.google.com/docs/anal
 
 <APIInstallSection />
 
-When using the web-platform, you'll also need to run `expo install firebase`, which install the Firebase JS SDK.
+When using the web platform, you'll also need to run `npx expo install firebase`, which installs the Firebase JS SDK.
 
 ## Configuration
 
-To use this package, the native Firebase configurations need to be added to your app.
-[Please follow this guide on how to set up native Firebase.](/guides/setup-native-firebase)
+> If you are using [`react-native-firebase`](https://rnfirebase.io/) library in your project, you should use [`@react-native-firebase/analytics`](https://rnfirebase.io/analytics/usage) package provided by the library. For more information on how to configure native Firebase library, see [using the native Firebase SDK](/guides/setup-native-firebase/).
 
 ### Expo Go: Limitations & configuration
 

--- a/docs/pages/versions/v46.0.0/sdk/firebase-analytics.md
+++ b/docs/pages/versions/v46.0.0/sdk/firebase-analytics.md
@@ -12,7 +12,7 @@ import { InlineCode } from '~/components/base/code';
 
 > **This is the only Firebase Analytics package for React Native that has universal platform support (iOS, Android, Web, and Electron).**
 
-**`expo-firebase-analytics`** enables the use of native Google Analytics for Firebase. Google Analytics for Firebase is a free app measurement solution that provides insight on app usage and user engagement.
+`expo-firebase-analytics` enables the use of native Google Analytics for Firebase. Google Analytics for Firebase is a free app measurement solution that provides insight on app usage and user engagement.
 Learn more in the official [Firebase Docs](https://firebase.google.com/docs/analytics/).
 
 <PlatformsSection android emulator ios simulator web />
@@ -21,12 +21,11 @@ Learn more in the official [Firebase Docs](https://firebase.google.com/docs/anal
 
 <APIInstallSection />
 
-When using the web-platform, you'll also need to run `expo install firebase`, which install the Firebase JS SDK.
+When using the web platform, you'll also need to run `npx expo install firebase`, which installs the Firebase JS SDK.
 
 ## Configuration
 
-To use this package, the native Firebase configurations need to be added to your app.
-[Please follow this guide on how to set up native Firebase.](/guides/setup-native-firebase)
+> If you are using [`react-native-firebase`](https://rnfirebase.io/) library in your project, you should use [`@react-native-firebase/analytics`](https://rnfirebase.io/analytics/usage) package provided by the library. For more information on how to configure native Firebase library, see [using the native Firebase SDK](/guides/setup-native-firebase/).
 
 ### Expo Go: Limitations & configuration
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Refs ENG-6292

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR adds a note to all currently active SDK docs for guiding the user to use `@react-native-firebase/analytics` if they use `react-native-firebase` library in their project since `expo-firebase-analytics` version is not compatible.

Currently, the `expo-firebase-analytics` core package is not compatible with `react-native-firebase` version. 

Keith [created a PR](https://github.com/expo/expo/pull/18908) for updating the incompatible versions but there is not timeline (yet) on when it will be released (before or at the point of releasing SDK 47).

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested by running `docs/` locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
