### PR TITLE
[ios] Various fixes for view recycling in Fabric

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -1286,7 +1286,7 @@ SPEC CHECKSUMS:
   ExpoLinearGradient: 91c81d92f85b422607306ad0f0aa48de755bb601
   ExpoLocalization: a9080f87ad52cab6ef367fefc6437e6ac54d1350
   ExpoMailComposer: 8fa786ef23b9f07b47b18fe00da0906a576ffaed
-  ExpoModulesCore: 9422bce288a468d32ec07fb3e12dbdac69b7e45f
+  ExpoModulesCore: c447192d27db79ef240d86696c127bd73ba03a0b
   ExpoRandom: fe4c4522cc975c76e98fc33af96daa352a17d311
   ExpoSystemUI: 30577707799df9497f510f329cc1d6798abbb7cb
   ExpoTrackingTransparency: 6792377b47c0819c7ac1bff2f68dc91304bf7116

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -3411,7 +3411,7 @@ SPEC CHECKSUMS:
   ExpoLinearGradient: 91c81d92f85b422607306ad0f0aa48de755bb601
   ExpoLocalization: a9080f87ad52cab6ef367fefc6437e6ac54d1350
   ExpoMailComposer: 8fa786ef23b9f07b47b18fe00da0906a576ffaed
-  ExpoModulesCore: 9422bce288a468d32ec07fb3e12dbdac69b7e45f
+  ExpoModulesCore: c447192d27db79ef240d86696c127bd73ba03a0b
   ExpoModulesTestCore: 8a409e6ce8a9940174344cad307d3d614363578d
   ExpoRandom: fe4c4522cc975c76e98fc33af96daa352a17d311
   ExpoSystemUI: 30577707799df9497f510f329cc1d6798abbb7cb

--- a/packages/expo-modules-core/ExpoModulesCore.podspec
+++ b/packages/expo-modules-core/ExpoModulesCore.podspec
@@ -2,6 +2,7 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 fabric_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
+fabric_compiler_flags = '-DRN_FABRIC_ENABLED'
 folly_version = '2021.06.28.00-v2'
 folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
 
@@ -26,6 +27,7 @@ Pod::Spec.new do |s|
     'CLANG_CXX_LANGUAGE_STANDARD' => 'c++17',
     'SWIFT_COMPILATION_MODE' => 'wholemodule',
     'HEADER_SEARCH_PATHS' => "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/Headers/Private/React-bridging/react/bridging\" \"$(PODS_CONFIGURATION_BUILD_DIR)/React-bridging/react_bridging.framework/Headers\"",
+    'OTHER_SWIFT_FLAGS' => "$(inherited) #{fabric_enabled ? fabric_compiler_flags : ''}"
   }
   s.user_target_xcconfig = {
     "HEADER_SEARCH_PATHS" => "\"${PODS_CONFIGURATION_BUILD_DIR}/ExpoModulesCore/Swift Compatibility Header\" \"$(PODS_ROOT)/Headers/Private/React-bridging/react/bridging\" \"$(PODS_CONFIGURATION_BUILD_DIR)/React-bridging/react_bridging.framework/Headers\"",
@@ -35,7 +37,7 @@ Pod::Spec.new do |s|
   s.dependency 'ReactCommon/turbomodule/core'
 
   if fabric_enabled
-    s.compiler_flags = folly_compiler_flags + " -DRN_FABRIC_ENABLED"
+    s.compiler_flags = folly_compiler_flags + ' ' + fabric_compiler_flags
 
     s.dependency 'React-RCTFabric'
     s.dependency 'RCT-Folly', folly_version

--- a/packages/expo-modules-core/common/cpp/fabric/ExpoViewComponentDescriptor.h
+++ b/packages/expo-modules-core/common/cpp/fabric/ExpoViewComponentDescriptor.h
@@ -12,6 +12,8 @@ namespace expo {
 
 class ExpoViewComponentDescriptor : public facebook::react::ConcreteComponentDescriptor<ExpoViewShadowNode> {
  public:
+  using Flavor = std::shared_ptr<std::string const>;
+
   ExpoViewComponentDescriptor(facebook::react::ComponentDescriptorParameters const &parameters);
 
   facebook::react::ComponentHandle getComponentHandle() const override;

--- a/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.mm
+++ b/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.mm
@@ -1,11 +1,23 @@
 // Copyright 2022-present 650 Industries. All rights reserved.
 
+#import <objc/runtime.h>
 #import <ExpoModulesCore/ExpoFabricViewObjC.h>
 
 #import <react/renderer/componentregistry/ComponentDescriptorProvider.h>
 #import <ExpoModulesCore/EXJSIConversions.h>
 #import <ExpoModulesCore/ExpoViewComponentDescriptor.h>
 #import <ExpoModulesCore/Swift.h>
+
+#ifdef RN_FABRIC_ENABLED
+#import <React/RCTSurfacePresenter.h>
+#import <React/RCTMountingManager.h>
+#import <React/RCTComponentViewRegistry.h>
+#import <butter/map.h>
+#endif
+
+#ifdef __cplusplus
+#import <string.h>
+#endif
 
 using namespace expo;
 
@@ -67,6 +79,12 @@ static NSString *normalizeEventName(NSString *eventName)
   return eventName;
 }
 
+/**
+ Cache for component flavors, where the key is a view class name and value is the flavor.
+ Flavors must be cached in order to keep using the same component handle after app reloads.
+ */
+static std::unordered_map<std::string, ExpoViewComponentDescriptor::Flavor> _componentFlavorsCache;
+
 @implementation ExpoFabricViewObjC {
   ExpoViewEventEmitter::Shared _eventEmitter;
 }
@@ -86,14 +104,37 @@ static NSString *normalizeEventName(NSString *eventName)
 
 + (facebook::react::ComponentDescriptorProvider)componentDescriptorProvider
 {
-  auto flavor = std::make_shared<std::string const>([NSStringFromClass([self class]) UTF8String]);
-  auto componentName = facebook::react::ComponentName{flavor->c_str()};
-  return facebook::react::ComponentDescriptorProvider {
-    reinterpret_cast<facebook::react::ComponentHandle>(componentName),
+  std::string className([NSStringFromClass([self class]) UTF8String]);
+
+  // We're caching the flavor pointer so that the component handle stay the same for the same class name.
+  // Otherwise, the component handle would change after reload which may cause memory leaks and unexpected view recycling behavior.
+  ExpoViewComponentDescriptor::Flavor flavor = _componentFlavorsCache[className];
+
+  if (flavor == nullptr) {
+    flavor = _componentFlavorsCache[className] = std::make_shared<std::string const>(className);
+  }
+
+  ComponentName componentName = ComponentName { flavor->c_str() };
+  ComponentHandle componentHandle = reinterpret_cast<ComponentHandle>(componentName);
+
+  return ComponentDescriptorProvider {
+    componentHandle,
     componentName,
     flavor,
     &facebook::react::concreteComponentDescriptorConstructor<expo::ExpoViewComponentDescriptor>
   };
+}
+
+- (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
+{
+  // The `contentView` should always be at the back. Shifting the index makes sure that child components are mounted on top of it.
+  [super mountChildComponentView:childComponentView index:index + 1];
+}
+
+- (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
+{
+  // All child components are mounted on top of `contentView`, so the index needs to be shifted by one.
+  [super unmountChildComponentView:childComponentView index:index + 1];
 }
 
 - (void)updateProps:(const facebook::react::Props::Shared &)props oldProps:(const facebook::react::Props::Shared &)oldProps

--- a/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.mm
+++ b/packages/expo-modules-core/ios/NativeModulesProxy/EXNativeModulesProxy.mm
@@ -385,7 +385,7 @@ RCT_EXPORT_METHOD(callMethod:(NSString *)moduleName methodNameOrKey:(id)methodNa
   componentDataByName[className] = componentData;
 
 #ifdef RN_FABRIC_ENABLED
-  Class viewClass = [ExpoFabricView makeClassForAppContext:_appContext className:className];
+  Class viewClass = [ExpoFabricView makeViewClassForAppContext:_appContext className:className];
   [[RCTComponentViewFactory currentComponentViewFactory] registerComponentViewClass:viewClass];
 #endif
 
@@ -406,13 +406,6 @@ RCT_EXPORT_METHOD(callMethod:(NSString *)moduleName methodNameOrKey:(id)methodNa
     RCTComponentData *componentData = [[RCTComponentData alloc] initWithManagerClass:moduleClass bridge:bridge eventDispatcher:bridge.eventDispatcher];
     componentDataByName[className] = componentData;
   }
-
-#ifdef RN_FABRIC_ENABLED
-  if ([className hasPrefix:@"ViewManagerAdapter_"]) {
-    Class viewClass = [ExpoFabricView makeClassForAppContext:_appContext className:className];
-    [[RCTComponentViewFactory currentComponentViewFactory] registerComponentViewClass:viewClass];
-  }
-#endif
 }
 
 - (void)assignExportedMethodsKeys:(NSMutableArray<NSMutableDictionary<const NSString *, id> *> *)exportedMethods forModuleName:(const NSString *)moduleName

--- a/packages/expo-modules-core/ios/Swift/AppContext.swift
+++ b/packages/expo-modules-core/ios/Swift/AppContext.swift
@@ -82,6 +82,12 @@ public final class AppContext: NSObject {
 
   public func findView<ViewType>(withTag viewTag: Int, ofType type: ViewType.Type) -> ViewType? {
     let view: UIView? = reactBridge?.uiManager.view(forReactTag: NSNumber(value: viewTag))
+
+    #if RN_FABRIC_ENABLED
+    if let view = view as? ExpoFabricViewObjC {
+      return view.contentView as? ViewType
+    }
+    #endif
     return view as? ViewType
   }
 


### PR DESCRIPTION
# Why

I found a few issues when testing the camera view with Fabric enabled. Mostly related to recycling, but also memory leaks.

# How

- Fixed creating subclasses of `ExpoFabricView` and cache them for recycling
- Caching component descriptor flavors to keep ComponentHandle for a specific component the same after reloading the app (prevents memory leaks in the recycling pool)
- Added `RN_FABRIC_ENABLED` flag to Swift compiler flags
- Fixed `findView` function to return the `contentView` when Fabric is enabled
- Made sure that Fabric mounts children views after/above the content view
- Removed unnecessary code for supporting Fabric in legacy view managers

# Test Plan

Tested with camera example in fabric-tester, I'll open another PR with some fixes in the camera as well