### PR TITLE
Fix #19072  Altitude reference

### DIFF
--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -7,7 +7,8 @@
 ### 🎉 New features
 
 ### 🐛 Bug fixes
-
+				- Fix altitude on iPhone to use WGS184. ([#19084](https://github.com/expo/expo/pull/19084) by [@pwellner](https://github.com/pwellner))
+				
 ### 💡 Others
 
 - Drop `@expo/config-plugins` dependency in favor of peer dependency on `expo`. ([#18595](https://github.com/expo/expo/pull/18595) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### 🎉 New features
 
 ### 🐛 Bug fixes
-				- Fix altitude on iPhone to use WGS184. ([#19084](https://github.com/expo/expo/pull/19084) by [@pwellner](https://github.com/pwellner))
+- Fix altitude on iPhone to use WGS184. ([#19084](https://github.com/expo/expo/pull/19084) by [@pwellner](https://github.com/pwellner))
 				
 ### 💡 Others
 

--- a/packages/expo-location/ios/EXLocation/EXLocation.m
+++ b/packages/expo-location/ios/EXLocation/EXLocation.m
@@ -567,7 +567,7 @@ EX_EXPORT_METHOD_AS(hasStartedGeofencingAsync,
     @"coords": @{
         @"latitude": @(location.coordinate.latitude),
         @"longitude": @(location.coordinate.longitude),
-        @"altitude": @(location.altitude),
+        @"altitude": @(location.ellipsoidalAltitude),
         @"accuracy": @(location.horizontalAccuracy),
         @"altitudeAccuracy": @(location.verticalAccuracy),
         @"heading": @(location.course),


### PR DESCRIPTION
# Why
#19072

# How
Change to use correct property name on line highlighted by @byCedric 

# Test Plan
Did NOT test.  Testing is required, for example as suggested in issue #19072.  (probably best done with two real devices)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
