### PR TITLE
[docs] Search: transform URLs when running in dev mode

### DIFF
--- a/docs/ui/components/Search/Search.tsx
+++ b/docs/ui/components/Search/Search.tsx
@@ -6,6 +6,8 @@ import { LATEST_VERSION } from '~/constants/versions.cjs';
 import { usePageApiVersion } from '~/providers/page-api-version';
 import { DocSearchStyles } from '~/ui/components/Search/styles';
 
+const env = process.env.NODE_ENV;
+
 export const Search = () => {
   const { version } = usePageApiVersion();
   return (
@@ -20,10 +22,16 @@ export const Search = () => {
         }}
         transformItems={items =>
           items.map(item => {
-            if (item.url.includes(LATEST_VERSION)) {
-              return { ...item, url: item.url.replace(LATEST_VERSION, 'latest') };
-            }
-            return item;
+            const envUrl =
+              env === 'development'
+                ? item.url.replace('https://docs.expo.dev/', 'http://localhost:3002/')
+                : item.url;
+            return {
+              ...item,
+              url: envUrl.includes(LATEST_VERSION)
+                ? envUrl.replace(LATEST_VERSION, 'latest')
+                : envUrl,
+            };
           })
         }
       />


### PR DESCRIPTION
# Why

Fixes ENG-6307

Currently, when searching in dev mode, after clicking on the serach result user is redirector to the PROD, let's fix that.

# How

If running in development mode replace the docs domain in URL with `localhost`.

> Note: This won't affect already stored/saved searches!

# Test Plan

The change has been tested by running docs website locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
