### PR TITLE
[docs] SnackInline: apply new design to the component

### DIFF
--- a/docs/components/plugins/SnackInline.tsx
+++ b/docs/components/plugins/SnackInline.tsx
@@ -8,6 +8,7 @@ import {
   iconSize,
   SnackLogo,
   shadows,
+  breakpoints,
 } from '@expo/styleguide';
 import * as React from 'react';
 
@@ -157,6 +158,12 @@ const inlineSnackHeaderStyle = css({
   borderTopLeftRadius: borderRadius.small,
   borderTopRightRadius: borderRadius.small,
   justifyContent: 'space-between',
+
+  [`@media screen and (max-width: ${breakpoints.medium + 124}px)`]: {
+    flexDirection: 'column',
+    alignItems: 'flex-start',
+    gap: spacing[1],
+  },
 });
 
 const inlineSnackSoleHeaderStyle = css({
@@ -164,6 +171,7 @@ const inlineSnackSoleHeaderStyle = css({
 });
 
 const inlineSnackTitleStyle = css({
+  ...typography.fontSizes[16],
   fontFamily: typography.fontFaces.semiBold,
   color: theme.text.default,
 });

--- a/docs/components/plugins/SnackInline.tsx
+++ b/docs/components/plugins/SnackInline.tsx
@@ -1,9 +1,20 @@
-import { spacing, theme, ArrowUpRightIcon } from '@expo/styleguide';
+import { css } from '@emotion/react';
+import {
+  spacing,
+  theme,
+  ArrowUpRightIcon,
+  typography,
+  borderRadius,
+  iconSize,
+  SnackLogo,
+  shadows,
+} from '@expo/styleguide';
 import * as React from 'react';
 
 import { SNACK_URL, getSnackFiles } from '~/common/snack';
 import { PageApiVersionContext, PageApiVersionContextType } from '~/providers/page-api-version';
 import { Button } from '~/ui/components/Button';
+import { FOOTNOTE } from '~/ui/components/Text';
 
 const DEFAULT_PLATFORM = 'android';
 const LATEST_VERSION = `v${require('../../package.json').version}`;
@@ -72,46 +83,95 @@ export default class SnackInline extends React.Component<Props> {
 
   render() {
     return (
-      <div style={{ marginBottom: spacing[4] }}>
-        <div
-          ref={this.contentRef}
-          style={this.props.contentHidden ? { display: 'none' } : undefined}>
-          {this.props.children}
-        </div>
-        <form action={SNACK_URL} method="POST" target="_blank">
-          <input
-            type="hidden"
-            name="platform"
-            value={this.props.defaultPlatform || DEFAULT_PLATFORM}
-          />
-          <input type="hidden" name="name" value={this.props.label || 'Example'} />
-          <input type="hidden" name="dependencies" value={this.getDependencies()} />
-          <input type="hidden" name="sdkVersion" value={this.getSnackSdkVersion()} />
-          {this.props.platforms && (
-            <input type="hidden" name="supportedPlatforms" value={this.props.platforms.join(',')} />
-          )}
-          {this.state.ready && (
+      <div css={inlineSnackWrapperStyle}>
+        <div css={[inlineSnackHeaderStyle, this.props.contentHidden && inlineSnackSoleHeaderStyle]}>
+          <span css={inlineSnackTitleStyle}>{this.props.label || 'Snack'}</span>
+          <form action={SNACK_URL} method="POST" target="_blank">
             <input
               type="hidden"
-              name="files"
-              value={JSON.stringify(
-                getSnackFiles({
-                  templateId: this.props.templateId,
-                  code: this.getCode(),
-                  files: this.props.files,
-                  baseURL: this.getExamplesPath(),
-                })
-              )}
+              name="platform"
+              value={this.props.defaultPlatform || DEFAULT_PLATFORM}
             />
-          )}
-          <Button
-            disabled={!this.state.ready}
-            iconRight={<ArrowUpRightIcon color={theme.palette.white} />}
-            type="submit">
-            {this.props.buttonTitle || 'Try this example on Snack'}
-          </Button>
-        </form>
+            <input type="hidden" name="name" value={this.props.label || 'Example'} />
+            <input type="hidden" name="dependencies" value={this.getDependencies()} />
+            <input type="hidden" name="sdkVersion" value={this.getSnackSdkVersion()} />
+            {this.props.platforms && (
+              <input
+                type="hidden"
+                name="supportedPlatforms"
+                value={this.props.platforms.join(',')}
+              />
+            )}
+            {this.state.ready && (
+              <input
+                type="hidden"
+                name="files"
+                value={JSON.stringify(
+                  getSnackFiles({
+                    templateId: this.props.templateId,
+                    code: this.getCode(),
+                    files: this.props.files,
+                    baseURL: this.getExamplesPath(),
+                  })
+                )}
+              />
+            )}
+            <Button
+              size="mini"
+              theme="ghost"
+              disabled={!this.state.ready}
+              icon={<SnackLogo height={iconSize.regular} />}
+              iconRight={<ArrowUpRightIcon size={iconSize.small} />}
+              type="submit"
+              css={snackButtonStyle}>
+              <FOOTNOTE>{this.props.buttonTitle || 'Open in Snack'}</FOOTNOTE>
+            </Button>
+          </form>
+        </div>
+        <div ref={this.contentRef} css={this.props.contentHidden && css({ display: 'none' })}>
+          {this.props.children}
+        </div>
       </div>
     );
   }
 }
+
+const inlineSnackWrapperStyle = css({
+  display: 'flex',
+  flexDirection: 'column',
+  marginBottom: spacing[3],
+
+  pre: {
+    marginTop: 0,
+    borderTop: 0,
+    borderTopLeftRadius: 0,
+    borderTopRightRadius: 0,
+  },
+});
+
+const inlineSnackHeaderStyle = css({
+  display: 'flex',
+  border: `1px solid ${theme.border.default}`,
+  alignItems: 'center',
+  padding: `${spacing[2]}px ${spacing[4]}px`,
+  borderTopLeftRadius: borderRadius.small,
+  borderTopRightRadius: borderRadius.small,
+  justifyContent: 'space-between',
+});
+
+const inlineSnackSoleHeaderStyle = css({
+  borderRadius: borderRadius.small,
+});
+
+const inlineSnackTitleStyle = css({
+  fontFamily: typography.fontFaces.semiBold,
+  color: theme.text.default,
+});
+
+const snackButtonStyle = css({
+  border: 0,
+
+  ':hover': {
+    boxShadow: shadows.button,
+  },
+});

--- a/docs/components/plugins/SnackInline.tsx
+++ b/docs/components/plugins/SnackInline.tsx
@@ -121,7 +121,7 @@ export default class SnackInline extends React.Component<Props> {
               theme="ghost"
               disabled={!this.state.ready}
               icon={<SnackLogo height={iconSize.regular} />}
-              iconRight={<ArrowUpRightIcon size={iconSize.small} />}
+              iconRight={<ArrowUpRightIcon size={iconSize.small} color={theme.icon.secondary} />}
               type="submit"
               css={snackButtonStyle}>
               <FOOTNOTE>{this.props.buttonTitle || 'Open in Snack'}</FOOTNOTE>
@@ -153,7 +153,7 @@ const inlineSnackHeaderStyle = css({
   display: 'flex',
   border: `1px solid ${theme.border.default}`,
   alignItems: 'center',
-  padding: `${spacing[2]}px ${spacing[4]}px`,
+  padding: `${spacing[2]}px ${spacing[2.5]}px ${spacing[2]}px ${spacing[4]}px`,
   borderTopLeftRadius: borderRadius.small,
   borderTopRightRadius: borderRadius.small,
   justifyContent: 'space-between',
@@ -169,9 +169,10 @@ const inlineSnackTitleStyle = css({
 });
 
 const snackButtonStyle = css({
-  border: 0,
+  borderColor: 'transparent',
 
   ':hover': {
+    borderColor: theme.border.default,
     boxShadow: shadows.button,
   },
 });

--- a/docs/components/plugins/SnackInline.tsx
+++ b/docs/components/plugins/SnackInline.tsx
@@ -85,7 +85,7 @@ export default class SnackInline extends React.Component<Props> {
     return (
       <div css={inlineSnackWrapperStyle}>
         <div css={[inlineSnackHeaderStyle, this.props.contentHidden && inlineSnackSoleHeaderStyle]}>
-          <span css={inlineSnackTitleStyle}>{this.props.label || 'Snack'}</span>
+          <span css={inlineSnackTitleStyle}>{this.props.label || 'Example'}</span>
           <form action={SNACK_URL} method="POST" target="_blank">
             <input
               type="hidden"

--- a/docs/pages/versions/unversioned/sdk/firebase-recaptcha.md
+++ b/docs/pages/versions/unversioned/sdk/firebase-recaptcha.md
@@ -197,7 +197,7 @@ export default function App() {
 
 <SnackInline
 contentHidden
-buttonTitle='Or try the Full Phone Authentication on Snack'
+buttonTitle='Try the Full Phone Authentication on Snack'
 label='Firebase Full Phone Auth'
 dependencies={['expo-firebase-recaptcha', 'firebase', 'react-native-webview']}>
 

--- a/docs/pages/versions/v43.0.0/sdk/firebase-recaptcha.md
+++ b/docs/pages/versions/v43.0.0/sdk/firebase-recaptcha.md
@@ -197,7 +197,7 @@ export default function App() {
 
 <SnackInline
 contentHidden
-buttonTitle='Or try the Full Phone Authentication on Snack'
+buttonTitle='Try the Full Phone Authentication on Snack'
 label='Firebase Full Phone Auth'
 dependencies={['expo-firebase-recaptcha', 'firebase', 'react-native-webview']}>
 

--- a/docs/pages/versions/v44.0.0/sdk/firebase-recaptcha.md
+++ b/docs/pages/versions/v44.0.0/sdk/firebase-recaptcha.md
@@ -197,7 +197,7 @@ export default function App() {
 
 <SnackInline
 contentHidden
-buttonTitle='Or try the Full Phone Authentication on Snack'
+buttonTitle='Try the Full Phone Authentication on Snack'
 label='Firebase Full Phone Auth'
 dependencies={['expo-firebase-recaptcha', 'firebase', 'react-native-webview']}>
 

--- a/docs/pages/versions/v45.0.0/sdk/firebase-recaptcha.md
+++ b/docs/pages/versions/v45.0.0/sdk/firebase-recaptcha.md
@@ -200,7 +200,7 @@ export default function App() {
 
 <SnackInline
 contentHidden
-buttonTitle='Or try the Full Phone Authentication on Snack'
+buttonTitle='Try the Full Phone Authentication on Snack'
 label='Firebase Full Phone Auth'
 dependencies={['expo-firebase-recaptcha', 'firebase', 'react-native-webview']}>
 

--- a/docs/pages/versions/v46.0.0/sdk/firebase-recaptcha.md
+++ b/docs/pages/versions/v46.0.0/sdk/firebase-recaptcha.md
@@ -200,7 +200,7 @@ export default function App() {
 
 <SnackInline
 contentHidden
-buttonTitle='Or try the Full Phone Authentication on Snack'
+buttonTitle='Try the Full Phone Authentication on Snack'
 label='Firebase Full Phone Auth'
 dependencies={['expo-firebase-recaptcha', 'firebase', 'react-native-webview']}>
 


### PR DESCRIPTION
# Why

Refs ENG-1704

# How

This small PR changes the `SnackInline` component appearance to be inline with latest mocks.

Since we already have the `label`, which was  not shown in docs this redesign did not required and props or logic changes.

# Test Plan

The changes have been tested by running docs website locally.

# Preview
<img width="881" alt="Screenshot 2022-09-13 150626" src="https://user-images.githubusercontent.com/719641/189911087-5db34077-bb44-4c00-a035-f4dd7973b6f2.png">
<img width="878" alt="Screenshot 2022-09-13 150745" src="https://user-images.githubusercontent.com/719641/189911095-7eccc28f-cc95-464f-8ad9-c59ec77931cc.png">

### With content hidden

<img width="890" alt="Screenshot 2022-09-13 150543" src="https://user-images.githubusercontent.com/719641/189911093-c80d93e6-3628-4fbf-81d5-ebd2c2372848.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
