### PR TITLE
[docs] Address docs accessibility concerns

### DIFF
--- a/docs/ui/components/Header/ThemeSelector.tsx
+++ b/docs/ui/components/Header/ThemeSelector.tsx
@@ -76,7 +76,6 @@ const selectStyle = css`
   appearance: none;
   background-color: ${theme.background.default};
   cursor: pointer;
-  outline: none;
 `;
 
 const selectIconStyle = css`

--- a/docs/ui/components/Search/styles.ts
+++ b/docs/ui/components/Search/styles.ts
@@ -91,7 +91,6 @@ export const DocSearchStyles = css`
   .DocSearch-Button:active,
   .DocSearch-Button:focus {
     color: var(--docsearch-text-color);
-    outline: none;
   }
 
   .DocSearch-Button-Container {

--- a/docs/ui/components/Sidebar/SidebarCollapsible.tsx
+++ b/docs/ui/components/Sidebar/SidebarCollapsible.tsx
@@ -3,11 +3,11 @@ import { theme, iconSize, spacing, ChevronDownIcon, borderRadius, shadows } from
 import { useRouter } from 'next/router';
 import React, { useState } from 'react';
 
+import { ButtonBase } from '../Button';
 import { CALLOUT } from '../Text';
 
 import stripVersionFromPath from '~/common/stripVersionFromPath';
 import { NavigationRoute } from '~/types/common';
-import { ButtonBase } from '../Button';
 
 if (typeof window !== 'undefined' && !window.hasOwnProperty('sidebarState')) {
   window.sidebarState = {};

--- a/docs/ui/components/Sidebar/SidebarCollapsible.tsx
+++ b/docs/ui/components/Sidebar/SidebarCollapsible.tsx
@@ -7,6 +7,7 @@ import { CALLOUT } from '../Text';
 
 import stripVersionFromPath from '~/common/stripVersionFromPath';
 import { NavigationRoute } from '~/types/common';
+import { ButtonBase } from '../Button';
 
 if (typeof window !== 'undefined' && !window.hasOwnProperty('sidebarState')) {
   window.sidebarState = {};
@@ -60,7 +61,7 @@ export function SidebarCollapsible(props: Props) {
 
   return (
     <>
-      <a css={titleStyle} onClick={toggleIsOpen}>
+      <ButtonBase css={titleStyle} aria-expanded={isOpen ? 'true' : 'false'} onClick={toggleIsOpen}>
         <div css={chevronContainerStyle}>
           <ChevronDownIcon
             size={iconSize.tiny}
@@ -68,8 +69,8 @@ export function SidebarCollapsible(props: Props) {
           />
         </div>
         <CALLOUT weight="medium">{info.name}</CALLOUT>
-      </a>
-      {isOpen && <div>{children}</div>}
+      </ButtonBase>
+      {isOpen && <div aria-hidden={!isOpen ? 'true' : 'false'}>{children}</div>}
     </>
   );
 }
@@ -83,6 +84,7 @@ const titleStyle = css({
   userSelect: 'none',
   transition: '100ms',
   padding: `${spacing[1.5]}px ${spacing[3]}px`,
+  width: '100%',
 
   ':hover': {
     cursor: 'pointer',

--- a/docs/ui/components/Sidebar/SidebarHeadEntry.tsx
+++ b/docs/ui/components/Sidebar/SidebarHeadEntry.tsx
@@ -14,14 +14,14 @@ type SidebarHeadEntryProps = {
 export const SidebarHeadEntry = ({ href, title, isActive, Icon }: SidebarHeadEntryProps) => {
   return (
     <Link href={href} passHref>
-      <div css={[entryContainerStyle, isActive && activeEntryContainerStyle]}>
+      <a css={[entryContainerStyle, isActive && activeEntryContainerStyle]}>
         <Icon
           css={entryIconStyle}
           color={isActive ? theme.link.default : theme.icon.default}
           width={iconSize.small}
         />
         <span>{title}</span>
-      </div>
+      </a>
     </Link>
   );
 };
@@ -38,6 +38,7 @@ const entryContainerStyle = css({
   alignItems: 'center',
   userSelect: 'none',
   transition: 'color 100ms',
+  textDecoration: 'none',
 
   '&:last-of-type': {
     marginBottom: 0,


### PR DESCRIPTION
# Why

Derk-Jan Karrenbeld [on Twitter](https://twitter.com/SleeplessByte/status/1569829587277725698) informed us that our new docs components are not keyboard accessible. This PR tries to address those concerns.

# How

- Makes our collapsible buttons in the side bar `<button>` elements instead of `<a>` elements.
- Adds [`aria-expanded`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-expanded) and [`aria-hidden`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden) to the collapsible content.
- Adds focus states to the search button and the theme selector.

# Screenshot

https://user-images.githubusercontent.com/6455018/190060000-0f75ccac-5868-4c76-8ae0-d1968cc74793.mov

# Test Plan

Make sure that the docs are keyboard accessible and that they behave correctly for assistive devices.