### PR TITLE
[docs] Add store icon to eas metadata

### DIFF
--- a/docs/pages/eas/index.md
+++ b/docs/pages/eas/index.md
@@ -17,4 +17,4 @@ Read the full pitch at [expo.dev/eas](https://expo.dev/eas), or follow the links
 
 <BoxLink title="EAS Update" description="Address small bugs and push quick fixes directly to end-users. Learn more." href="/eas-update/introduction" Icon={UpdateIcon} />
 
-<BoxLink title="EAS Metadata (In Preview)" description="Upload all app store information required to get your app published. Learn more." href="/eas/metadata/" />
+<BoxLink title="EAS Metadata (In Preview)" description="Upload all app store information required to get your app published. Learn more." href="/eas/metadata/" Icon={StoreIcon} />


### PR DESCRIPTION
# Why

Now all EAS parts have an icon.

# How

- Added `StoreIcon` to EAS Metadata

Ideally, we would have a unique icon for EAS Metadata. We do have one for `vscode-icons` (we added an icon to `store.config.json` files, [here](https://github.com/vscode-icons/vscode-icons/pull/3059)) but that doesn't exist in the `@expo/styleguide`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
