### PR TITLE
[docs] add missing key to the ToC labels

### DIFF
--- a/docs/components/DocumentationSidebarRightLink.tsx
+++ b/docs/components/DocumentationSidebarRightLink.tsx
@@ -158,7 +158,7 @@ const DocumentationSidebarRightLink = React.forwardRef<HTMLAnchorElement, Sideba
           {tags && tags.length ? (
             <div css={STYLES_TAG_CONTAINER}>
               {tags.map(tag => (
-                <Tag name={tag} type="toc" />
+                <Tag name={tag} type="toc" key={`${displayTitle}-${tag}`} />
               ))}
             </div>
           ) : undefined}


### PR DESCRIPTION
# Why

<img width="675" alt="Screenshot 2022-09-14 130923" src="https://user-images.githubusercontent.com/719641/190138933-54ce3ccf-4d8a-4eb5-83b4-c50a1636b652.png">

# How

Add missing `key` prop to the ToC sidebar entry labels.

# Test Plan

The change has been tested by running docs website locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
