### PR TITLE
[docs] BoxLink: better support for external links

### DIFF
--- a/docs/ui/components/BoxLink/index.tsx
+++ b/docs/ui/components/BoxLink/index.tsx
@@ -1,5 +1,13 @@
 import { css } from '@emotion/react';
-import { borderRadius, spacing, theme, ArrowRightIcon, iconSize, shadows } from '@expo/styleguide';
+import {
+  borderRadius,
+  spacing,
+  theme,
+  ArrowRightIcon,
+  iconSize,
+  shadows,
+  ArrowUpRightIcon,
+} from '@expo/styleguide';
 import type { IconProps } from '@expo/styleguide/dist/types';
 import React, { ComponentType, PropsWithChildren, ReactNode } from 'react';
 
@@ -14,8 +22,10 @@ type BoxLinkProps = PropsWithChildren<{
 }>;
 
 export function BoxLink({ title, description, href, testID, Icon }: BoxLinkProps) {
+  const isExternal = Boolean(href && href.startsWith('http'));
+  const ArrowIcon = isExternal ? ArrowUpRightIcon : ArrowRightIcon;
   return (
-    <A href={href} css={tileContainerStyle} data-testid={testID}>
+    <A href={href} css={tileContainerStyle} data-testid={testID} openInNewTab={isExternal}>
       <div css={tileContentWrapperStyle}>
         {Icon && (
           <div css={tileIconBackgroundStyle}>
@@ -27,7 +37,7 @@ export function BoxLink({ title, description, href, testID, Icon }: BoxLinkProps
           <P>{description}</P>
         </div>
       </div>
-      <ArrowRightIcon css={arrowIconStyle} color={theme.icon.secondary} />
+      <ArrowIcon css={arrowIconStyle} color={theme.icon.secondary} />
     </A>
   );
 }


### PR DESCRIPTION
# Why

Lately, I have spotted that people are also using `BoxLink` also for the external links, which I don't have in mind creating this component.

# How

Let's embrace this usage by changing arrow icon based on URL and opening link in new tab when the link lead to an external site.

# Test Plan

The changes have been tested locally in docs app.

# Preview

<img width="892" alt="Screenshot 2022-09-14 131726" src="https://user-images.githubusercontent.com/719641/190141284-7ff7ac9f-6574-425f-b2a1-992fd13ea5e8.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
