### PR TITLE
[templates] Turn off signing resource bundles in Xcode 14

### DIFF
--- a/templates/expo-template-bare-minimum/ios/Podfile
+++ b/templates/expo-template-bare-minimum/ios/Podfile
@@ -36,6 +36,17 @@ target 'HelloWorld' do
   post_install do |installer|
     react_native_post_install(installer)
     __apply_Xcode_12_5_M1_post_install_workaround(installer)
+
+    # This is necessary for Xcode 14, because it signs resource bundles by default
+    # when building for devices.
+    installer.target_installation_results.pod_target_installation_results
+      .each do |pod_name, target_installation_result|
+      target_installation_result.resource_bundle_targets.each do |resource_bundle_target|
+        resource_bundle_target.build_configurations.each do |config|
+          config.build_settings['CODE_SIGNING_ALLOWED'] = 'NO'
+        end
+      end
+    end
   end
 
   post_integrate do |installer|
@@ -43,14 +54,6 @@ target 'HelloWorld' do
       expo_patch_react_imports!(installer)
     rescue => e
       Pod::UI.warn e
-    end
-  end
-
-  # This is necessary for Xcode 14, because it signs resource bundles by default
-  # when building for devices.
-  target_installation_result.resource_bundle_targets.each do |resource_bundle_target|
-    resource_bundle_target.build_configurations.each do |config|
-      config.build_settings['CODE_SIGNING_ALLOWED'] = 'NO'
     end
   end
 end

--- a/templates/expo-template-bare-minimum/ios/Podfile
+++ b/templates/expo-template-bare-minimum/ios/Podfile
@@ -46,4 +46,11 @@ target 'HelloWorld' do
     end
   end
 
+  # This is necessary for Xcode 14, because it signs resource bundles by default
+  # when building for devices.
+  target_installation_result.resource_bundle_targets.each do |resource_bundle_target|
+    resource_bundle_target.build_configurations.each do |config|
+      config.build_settings['CODE_SIGNING_ALLOWED'] = 'NO'
+    end
+  end
 end


### PR DESCRIPTION
# Why

Same as #19095 but for the bare template project.

# How

Copy and paste @tsapeta's changes

# Test Plan

Run a build for an iOS device in Xcode 14, confirm that it works

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
