### PR TITLE
feat(docs): add structured data

### DIFF
--- a/docs/pages/introduction/faq.md
+++ b/docs/pages/introduction/faq.md
@@ -3,8 +3,11 @@ title: Common questions
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';
+import { FAQSection } from '~/ui/components/FAQSection';
 
 In addition to the questions below, see the [forums](https://forums.expo.dev/) for more common questions and answers. Some of this information is repeated from earlier sections of the introduction but we include it here for comprehensiveness.
+
+<FAQSection name="Expo frequently asked questions">
 
 <Collapsible summary="What is Expo used for?">
 
@@ -135,6 +138,8 @@ Expo CLI can be used simultaneously with React Native CLI. Expo CLI provides the
 Regardless of which CLI you use, you can use any part of the [Expo SDK](/versions/latest/) and [Expo Application Services](/eas/index) with your project.
 
 </Collapsible>
+
+</FAQSection>
 
 ## Up next
 

--- a/docs/ui/components/FAQSection/index.tsx
+++ b/docs/ui/components/FAQSection/index.tsx
@@ -44,7 +44,10 @@ export function FAQSection({ name, children }: PropsWithChildren<{ name: string 
   return (
     <>
       <Head>
-        <script type="application/ld+json">{JSON.stringify(ldJson)}</script>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(ldJson) }}
+        />
       </Head>
       {children}
     </>

--- a/docs/ui/components/FAQSection/index.tsx
+++ b/docs/ui/components/FAQSection/index.tsx
@@ -1,0 +1,52 @@
+import Head from 'next/head';
+import React, { Children, PropsWithChildren, useMemo } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+/** When wrapped around `Collapsible` components, this element generates the static ld+json required for Google search indexing. */
+export function FAQSection({ name, children }: PropsWithChildren<{ name: string }>) {
+  const mainEntity = useMemo(() => {
+    const faqs: { question: string; answer: string }[] = [];
+
+    Children.forEach(children, child => {
+      if (
+        child &&
+        typeof child === 'object' &&
+        'props' in child &&
+        child?.props?.mdxType === 'Collapsible'
+      ) {
+        const content = child.props.children;
+        faqs.push({
+          question: child.props.summary,
+          answer: renderToStaticMarkup(content).replace(
+            /\/\.\.\/\.\.\/\.\.\/\.\.\/\.\.\/\.\.\/\.\.\//g,
+            'https://docs.expo.dev/'
+          ),
+        });
+      }
+    });
+    return faqs.map(faq => ({
+      '@type': 'Question',
+      name: faq.question,
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: faq.answer,
+      },
+    }));
+  }, [children]);
+
+  const ldJson = {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    '@name': name,
+    mainEntity,
+  };
+
+  return (
+    <>
+      <Head>
+        <script type="application/ld+json">{JSON.stringify(ldJson)}</script>
+      </Head>
+      {children}
+    </>
+  );
+}


### PR DESCRIPTION
# Why

Optimize the search engine results so the top actionable items come from a more up-to-date source.

- Tested the results [here](https://search.google.com/test/rich-results/result/r%2Ffaq?id=uF9gdUhtE1DOXbOIjnNHUw)
- Ensured that the ld+json was available statically by running `yarn export` and checking the raw source.

<img width="358" alt="Screen Shot 2022-09-14 at 7 57 20 PM" src="https://user-images.githubusercontent.com/9664363/190288540-c8ade079-f5f3-41a5-8b79-b399e5e51307.png">


- The FAQ abides by [Google's rules](https://developers.google.com/search/docs/advanced/structured-data/faqpage)
