### PR TITLE
[dev-launcher] Support react-native-v8

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### 🐛 Bug fixes
 
 - Remove the deprecated `Linking.removeEventListener` in expo-dev-launcher bundle. ([#18939](https://github.com/expo/expo/pull/18939) by [@kudo](https://github.com/kudo))
+- Fixed the incompatibility with react-native-v8 on Android. ([#19117](https://github.com/expo/expo/pull/19117) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/android/src/react-native-64/expo/modules/devlauncher/rncompatibility/DevLauncherReactNativeHostHandler.kt
+++ b/packages/expo-dev-launcher/android/src/react-native-64/expo/modules/devlauncher/rncompatibility/DevLauncherReactNativeHostHandler.kt
@@ -25,6 +25,11 @@ class DevLauncherReactNativeHostHandler(context: Context) : ReactNativeHostHandl
     val applicationContext = context.applicationContext
 
     SoLoader.init(applicationContext, /* native exopackage */ false)
+    if (SoLoader.getLibraryPath("libv8android.so") != null) {
+      // Assuming V8 overrides the `getJavaScriptExecutorFactory` in the main ReactNativeHost,
+      // return null here to use the default value.
+      return null
+    }
     if (SoLoader.getLibraryPath("libjsc.so") != null) {
       return JSCExecutorFactory(applicationContext.packageName, AndroidInfoHelpers.getFriendlyDeviceName())
     }

--- a/packages/expo-dev-launcher/android/src/react-native-65/expo/modules/devlauncher/rncompatibility/DevLauncherReactNativeHostHandler.kt
+++ b/packages/expo-dev-launcher/android/src/react-native-65/expo/modules/devlauncher/rncompatibility/DevLauncherReactNativeHostHandler.kt
@@ -25,6 +25,11 @@ class DevLauncherReactNativeHostHandler(context: Context) : ReactNativeHostHandl
     val applicationContext = context.applicationContext
 
     SoLoader.init(applicationContext, /* native exopackage */ false)
+    if (SoLoader.getLibraryPath("libv8android.so") != null) {
+      // Assuming V8 overrides the `getJavaScriptExecutorFactory` in the main ReactNativeHost,
+      // return null here to use the default value.
+      return null
+    }
     if (SoLoader.getLibraryPath("libjsc.so") != null) {
       return JSCExecutorFactory(applicationContext.packageName, AndroidInfoHelpers.getFriendlyDeviceName())
     }

--- a/packages/expo-dev-launcher/android/src/react-native-66/expo/modules/devlauncher/rncompatibility/DevLauncherReactNativeHostHandler.kt
+++ b/packages/expo-dev-launcher/android/src/react-native-66/expo/modules/devlauncher/rncompatibility/DevLauncherReactNativeHostHandler.kt
@@ -25,6 +25,11 @@ class DevLauncherReactNativeHostHandler(context: Context) : ReactNativeHostHandl
     val applicationContext = context.applicationContext
 
     SoLoader.init(applicationContext, /* native exopackage */ false)
+    if (SoLoader.getLibraryPath("libv8android.so") != null) {
+      // Assuming V8 overrides the `getJavaScriptExecutorFactory` in the main ReactNativeHost,
+      // return null here to use the default value.
+      return null
+    }
     if (SoLoader.getLibraryPath("libjsc.so") != null) {
       return JSCExecutorFactory(applicationContext.packageName, AndroidInfoHelpers.getFriendlyDeviceName())
     }

--- a/packages/expo-dev-launcher/android/src/react-native-67/expo/modules/devlauncher/rncompatibility/DevLauncherReactNativeHostHandler.kt
+++ b/packages/expo-dev-launcher/android/src/react-native-67/expo/modules/devlauncher/rncompatibility/DevLauncherReactNativeHostHandler.kt
@@ -26,6 +26,11 @@ class DevLauncherReactNativeHostHandler(context: Context) : ReactNativeHostHandl
     val applicationContext = context.applicationContext
 
     SoLoader.init(applicationContext, /* native exopackage */ false)
+    if (SoLoader.getLibraryPath("libv8android.so") != null) {
+      // Assuming V8 overrides the `getJavaScriptExecutorFactory` in the main ReactNativeHost,
+      // return null here to use the default value.
+      return null
+    }
     if (SoLoader.getLibraryPath("libjsc.so") != null) {
       return JSCExecutorFactory(applicationContext.packageName, AndroidInfoHelpers.getFriendlyDeviceName())
     }

--- a/packages/expo-dev-launcher/android/src/react-native-69/expo/modules/devlauncher/rncompatibility/DevLauncherReactNativeHostHandler.kt
+++ b/packages/expo-dev-launcher/android/src/react-native-69/expo/modules/devlauncher/rncompatibility/DevLauncherReactNativeHostHandler.kt
@@ -26,6 +26,11 @@ class DevLauncherReactNativeHostHandler(context: Context) : ReactNativeHostHandl
     val applicationContext = context.applicationContext
 
     SoLoader.init(applicationContext, /* native exopackage */ false)
+    if (SoLoader.getLibraryPath("libv8android.so") != null) {
+      // Assuming V8 overrides the `getJavaScriptExecutorFactory` in the main ReactNativeHost,
+      // return null here to use the default value.
+      return null
+    }
     if (SoLoader.getLibraryPath("libjsc.so") != null) {
       return JSCExecutorFactory(applicationContext.packageName, AndroidInfoHelpers.getFriendlyDeviceName())
     }


### PR DESCRIPTION
# Why

another attempt than #18151 to support react-native-v8

# How

if there's *libv8android.so*, we just use the js executor factory from main ReactNativeHost.
for the bundled reanimated in dev-menu, i have a pr to keep jsc in debug build: https://github.com/Kudo/react-native-v8/pull/142

# Test Plan

```sh
$ yarn create expo-app -t blank@sdk-46 sdk46v8
$ cd sdk46v8
$ npx expo install react-native-v8 v8-android-jit
# add "plugins": ["react-native-v8"] to app.json

$ npx expo install expo-dev-client
$ npx expo prebuild -p android
# patch node_modules/expo-dev-launcher

$ npx expo run:android
```

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
