### PR TITLE
[docs] Update FAQ description explaining what Expo is used for

### DIFF
--- a/docs/pages/introduction/faq.mdx
+++ b/docs/pages/introduction/faq.mdx
@@ -26,7 +26,7 @@ Yes, the source for Expo Go can be found in the [expo/expo GitHub repository](ht
 
 <Collapsible summary="Who created Expo?">
 
-Expo and Expo Application Services (EAS) are developed by [650 industries](https://expo.dev/about). 650 industries is a California-based company that was founded by [Charlie Cheever](https://en.wikipedia.org/wiki/Charlie_Cheever) and [James Ide](https://jameside.com/).
+Expo and Expo Application Services (EAS) are developed by [650 Industries](https://expo.dev/about). 650 Industries is a California-based company that was founded by [Charlie Cheever](https://en.wikipedia.org/wiki/Charlie_Cheever) and [James Ide](https://jameside.com/).
 
 </Collapsible>
 
@@ -70,6 +70,12 @@ The `expo` package provides a suite of features that make it easier to develop, 
 
 </Collapsible>
 
+<Collapsible summary="Do I need to switch from React Native to use Expo?">
+
+No, the `expo` npm package and CLI work with any React Native app. [Expo Application Services](/eas/index) also works with all React Native apps with first-class support for builds, updates, app store submissions, and more.
+
+</Collapsible>
+
 <Collapsible summary="How much does Expo cost?">
 
 The Expo platform is [free and open source](https://blog.expo.dev/exponent-is-free-as-in-and-as-in-1d6d948a60dc). This includes the libraries that make up the [Expo SDK](/versions/latest/) and the [Expo CLI](/workflow/expo-cli/) used for development. The Expo Go app, the easiest way to get started, is also free from the app stores.
@@ -108,7 +114,7 @@ Traditionally you needed a Mac to develop iOS apps, but you can use [EAS Build](
 
 <Collapsible summary="What version of Android and iOS are supported by the Expo SDK?">
 
-Expo SDK supports Android 5+ and iOS 11+.
+Expo SDK supports Android 5+ and iOS 13+.
 
 </Collapsible>
 

--- a/docs/pages/introduction/faq.mdx
+++ b/docs/pages/introduction/faq.mdx
@@ -8,7 +8,7 @@ In addition to the questions below, see the [forums](https://forums.expo.dev/) f
 
 <Collapsible summary="What is Expo used for?">
 
-Expo is an [open-source npm package](https://github.com/expo/expo/) and framework for React Native projects. The `expo` package enables many important features for building and scaling an app like OTA updates, instantly sharing your app, and web support. Learn more about [what Expo offers](/introduction).
+Expo is an [open-source framework](https://github.com/expo/expo/) for apps that run natively on Android, iOS, and the web. Expo brings together the best of mobile and the web and enables many important features for building and scaling an app like live updates, instantly sharing your app, and web support. The `expo` npm package is compatible with all React Native projects. Learn more about [what Expo offers](/introduction).
 
 </Collapsible>
 

--- a/docs/pages/introduction/faq.mdx
+++ b/docs/pages/introduction/faq.mdx
@@ -8,7 +8,7 @@ In addition to the questions below, see the [forums](https://forums.expo.dev/) f
 
 <Collapsible summary="What is Expo used for?">
 
-Expo is an [open-source framework](https://github.com/expo/expo/) for apps that run natively on Android, iOS, and the web. Expo brings together the best of mobile and the web and enables many important features for building and scaling an app like live updates, instantly sharing your app, and web support. The `expo` npm package is compatible with all React Native projects. Learn more about [what Expo offers](/introduction).
+Expo is an [open-source framework](https://github.com/expo/expo/) for apps that run natively on Android, iOS, and the web. Expo brings together the best of mobile and the web and enables many important features for building and scaling an app like live updates, instantly sharing your app, and web support. The `expo` npm package brings these features to any React Native project. Learn more about [what Expo offers](/introduction).
 
 </Collapsible>
 


### PR DESCRIPTION
# Why

Provides a stronger and broader description of Expo, especially for rendering this content in search results for people asking this question or learning about Expo.

# Test Plan

`yarn dev` => http://localhost:3002/introduction/faq/