### PR TITLE
[docs] improve the sidebar behaviour, especially on init render

### DIFF
--- a/docs/components/DocumentationPage.tsx
+++ b/docs/components/DocumentationPage.tsx
@@ -63,10 +63,11 @@ class DocumentationPageWithApiVersion extends React.Component<Props, State> {
   componentDidMount() {
     Router.events.on('routeChangeStart', url => {
       if (this.layoutRef.current) {
-        window.__sidebarScroll =
-          this.getActiveTopLevelSection() !== this.getActiveTopLevelSection(url)
-            ? 0
-            : this.layoutRef.current.getSidebarScrollTop();
+        if (this.getActiveTopLevelSection() !== this.getActiveTopLevelSection(url)) {
+          window.__sidebarScroll = 0;
+        } else {
+          window.__sidebarScroll = this.layoutRef.current.getSidebarScrollTop();
+        }
       }
     });
     window.addEventListener('resize', this.handleResize);
@@ -145,14 +146,14 @@ class DocumentationPageWithApiVersion extends React.Component<Props, State> {
   private getActiveTopLevelSection = (path?: string) => {
     if (this.isReferencePath(path)) {
       return 'reference';
+    } else if (this.isEasPath(path)) {
+      return 'eas';
     } else if (this.isGeneralPath()) {
       return 'general';
     } else if (this.isFeaturePreviewPath(path)) {
       return 'featurePreview';
     } else if (this.isPreviewPath()) {
       return 'preview';
-    } else if (this.isEasPath(path)) {
-      return 'eas';
     } else if (this.isArchivePath()) {
       return 'archive';
     }
@@ -161,9 +162,9 @@ class DocumentationPageWithApiVersion extends React.Component<Props, State> {
   };
 
   render() {
-    const sidebarScrollPosition = process.browser ? window.__sidebarScroll : 0;
     const routes = this.getRoutes();
     const sidebarActiveGroup = this.getActiveTopLevelSection();
+    const sidebarScrollPosition = process.browser ? window.__sidebarScroll : 0;
 
     const sidebarElement = <Sidebar routes={routes} />;
     const headerElement = (

--- a/docs/ui/components/Sidebar/SidebarCollapsible.tsx
+++ b/docs/ui/components/Sidebar/SidebarCollapsible.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { theme, iconSize, spacing, ChevronDownIcon, borderRadius, shadows } from '@expo/styleguide';
 import { useRouter } from 'next/router';
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 import { ButtonBase } from '../Button';
 import { CALLOUT } from '../Text';
@@ -20,6 +20,7 @@ type Props = React.PropsWithChildren<{
 export function SidebarCollapsible(props: Props) {
   const { info, children } = props;
   const router = useRouter();
+  const ref = useRef<HTMLButtonElement>(null);
 
   const isChildRouteActive = () => {
     let result = false;
@@ -36,10 +37,10 @@ export function SidebarCollapsible(props: Props) {
       }
     };
 
-    let posts: NavigationRoute[] = [];
-    sections?.forEach(section => {
-      posts = [...posts, ...(section?.children ?? [])];
-    });
+    const posts: NavigationRoute[] =
+      sections
+        ?.map(section => (section.type === 'page' ? [section] : section?.children ?? []))
+        .flat() ?? [];
 
     posts.forEach(isSectionActive);
     return result;
@@ -48,11 +49,22 @@ export function SidebarCollapsible(props: Props) {
   const hasCachedState =
     typeof window !== 'undefined' && window.sidebarState[info.name] !== undefined;
 
+  const containsActiveChild = isChildRouteActive();
   const initState = hasCachedState
     ? window.sidebarState[info.name]
-    : isChildRouteActive() || info.expanded;
+    : containsActiveChild || info.expanded;
 
   const [isOpen, setOpen] = useState(initState);
+
+  useEffect(() => {
+    if (containsActiveChild) {
+      const isBasePage = router.pathname.split('/').length < 3;
+      if (!hasCachedState && !isBasePage && !window.__sidebarScroll) {
+        ref?.current?.scrollIntoView({ behavior: 'smooth' });
+      }
+      window.sidebarState[info.name] = true;
+    }
+  }, []);
 
   const toggleIsOpen = () => {
     setOpen(prevState => !prevState);
@@ -61,7 +73,12 @@ export function SidebarCollapsible(props: Props) {
 
   return (
     <>
-      <ButtonBase css={titleStyle} aria-expanded={isOpen ? 'true' : 'false'} onClick={toggleIsOpen}>
+      <ButtonBase
+        ref={ref}
+        css={titleStyle}
+        aria-expanded={isOpen ? 'true' : 'false'}
+        onClick={toggleIsOpen}
+        data-collapsible-active={containsActiveChild || undefined}>
         <div css={chevronContainerStyle}>
           <ChevronDownIcon
             size={iconSize.tiny}

--- a/docs/ui/components/Sidebar/SidebarCollapsible.tsx
+++ b/docs/ui/components/Sidebar/SidebarCollapsible.tsx
@@ -60,7 +60,11 @@ export function SidebarCollapsible(props: Props) {
     if (containsActiveChild) {
       const isBasePage = router.pathname.split('/').length < 3;
       if (!hasCachedState && !isBasePage && !window.__sidebarScroll) {
-        ref?.current?.scrollIntoView({ behavior: 'smooth' });
+        if (ref?.current && ref?.current.offsetTop > 32) {
+          // note(simek): fix for URLs with '#' where we also scroll page content,
+          // probably can remove that workaround after refs refactor
+          setTimeout(() => ref?.current && ref.current.scrollIntoView({ behavior: 'smooth' }), 100);
+        }
       }
       window.sidebarState[info.name] = true;
     }


### PR DESCRIPTION
# Why

Fixes ENG-6196

Also address an issue reported by @lukmccall, where on init render on nested page the collapsible section was not properly expanded.

# How

The current implementation is based on the code already in docs, it address the issue and achieve the scrolling feature, but the code is a bit messy and I would like to refactor this completely in the future.

Currently, to avoid larger code refactor, sidebar will scroll to the active collapsible group. In most cases this yields an expected result, however, we should change it to scrolling to the certain entry in the sidebar.

Additionally I have added `data-collapsible-active` parameter to the collapsible element, which is tailored for Algolia crawler, and this information will help us improve the search hit metadata.

# Test Plan

the changes have been tested by running docs website locally.

I would appreciate, if reviewers can check out this locally too. 😉 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
