### PR TITLE
[docs] Update deployment-patterns.md

### DIFF
--- a/docs/pages/eas-update/deployment-patterns.md
+++ b/docs/pages/eas-update/deployment-patterns.md
@@ -102,7 +102,7 @@ This flow is like an un-versioned variant of the "branch promotion flow". We do 
 
 **Testing changes:** (a) Test changes on TestFlight and the Play Store Internal Track and/or (b) Test changes with internal distribution builds.
 
-**Publishing updates:** (c) Create update branches that are environment-based, like "staging" and "production".
+**Publishing updates:** (b) Create update branches that are environment-based, like "staging" and "production".
 
 ### Diagram of flow
 
@@ -134,7 +134,7 @@ This flow is for projects that need to build and update their Android and iOS ap
 
 **Testing changes:** (a) Test changes on TestFlight and the Play Store Internal Track and/or (b) Test changes with internal distribution builds.
 
-**Publishing updates:** (c) Create update branches that are environment- and platform-based, like "ios-staging", "ios-production", "android-staging", and "android-production".
+**Publishing updates:** (b) Create update branches that are environment- and platform-based, like "ios-staging", "ios-production", "android-staging", and "android-production".
 
 ### Diagram of flow
 


### PR DESCRIPTION
Update the Publishing version in Persistent staging flow and Platform-specific flow.

# Why
In the [Persistent staging flow](https://docs.expo.dev/eas-update/deployment-patterns/#persistent-staging-flow) and the [Platform-specific flow](https://docs.expo.dev/eas-update/deployment-patterns/#platform-specific-flow) the version of publishing is tagged as c, but it seems to be the b one.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
