### PR TITLE
[ci] Fix expo-caches action for expo-yarn-workspaces generated AppEntry.js

### DIFF
--- a/.github/actions/expo-caches/action.yml
+++ b/.github/actions/expo-caches/action.yml
@@ -95,6 +95,7 @@ runs:
           ${{ steps.yarn-cache-dir-path.outputs.dir }}
           node_modules
           apps/*/node_modules
+          apps/*/__generated__/AppEntry.js
           home/node_modules
           packages/*/node_modules
           packages/@expo/*/node_modules

--- a/.github/workflows/publish-demo.yml
+++ b/.github/workflows/publish-demo.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - .github/workflows/web.yml
+      - .github/workflows/publish-demo.yml
       - yarn.lock
       - apps/**
       - packages/**


### PR DESCRIPTION
# Why

Attempting to fix this CI job: https://github.com/expo/expo/actions/runs/3055137244/jobs/4927855791. 

The AppEntry.js file is generated: https://github.com/expo/expo/tree/main/packages/expo-yarn-workspaces#define-the-entry-module-in-the-main-field-of-each-apps-packagejson

Therefore, it needs to be cached as part of this I think.

Closes ENG-6328.

# How

Cache these files.

# Test Plan

Wait for CI job.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
