### PR TITLE
[docs][FirebaseAnalytics][FirebaseRecaptcha]: Add instructions about using with native Firebase SDK

### DIFF
--- a/docs/pages/versions/unversioned/sdk/firebase-analytics.md
+++ b/docs/pages/versions/unversioned/sdk/firebase-analytics.md
@@ -7,7 +7,7 @@ packageName: 'expo-firebase-analytics'
 import APISection from '~/components/plugins/APISection';
 import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-
+import { Terminal } from '~/ui/components/Snippet';
 import { InlineCode } from '~/components/base/code';
 
 > **This is the only Firebase Analytics package for React Native that has universal platform support (iOS, Android, Web, and Electron).**
@@ -25,7 +25,15 @@ When using the web platform, you'll also need to run `npx expo install firebase`
 
 ## Configuration
 
-> If you are using [`react-native-firebase`](https://rnfirebase.io/) library in your project, you should use [`@react-native-firebase/analytics`](https://rnfirebase.io/analytics/usage) package provided by the library. For more information on how to configure native Firebase library, see [using the native Firebase SDK](/guides/setup-native-firebase/).
+### With native Firebase SDK
+
+If you are using `expo-firebase-analytics` with React Native Firebase SDK (`react-native-firebase`), you'll have to install the native Firebase SDK using the `npx expo install` command:
+
+<Terminal cmd={["$ npx expo install @react-native-firebase/app"]} />
+
+This will ensure that the `react-native-firebase` dependency version is compatible with the Expo SDK version your project uses.
+
+Also, make sure that you have the `react-native-firebase` library set up correctly in your project. For more information on how to configure native Firebase SDK, see [using the native Firebase SDK](/guides/setup-native-firebase/#setup).
 
 ### Expo Go: Limitations & configuration
 

--- a/docs/pages/versions/unversioned/sdk/firebase-analytics.md
+++ b/docs/pages/versions/unversioned/sdk/firebase-analytics.md
@@ -27,13 +27,13 @@ When using the web platform, you'll also need to run `npx expo install firebase`
 
 ### With native Firebase SDK
 
-If you are using `expo-firebase-analytics` with React Native Firebase SDK (`react-native-firebase`), you'll have to install the native Firebase SDK using the `npx expo install` command:
+If you are using `expo-firebase-analytics` with React Native Firebase, you'll have to install the native Firebase SDK using the `npx expo install` command:
 
 <Terminal cmd={["$ npx expo install @react-native-firebase/app"]} />
 
-This will ensure that the `react-native-firebase` dependency version is compatible with the Expo SDK version your project uses.
+This will ensure that the `@react-native-firebase/app` dependency version is compatible with the Expo SDK version your project uses.
 
-Also, make sure that you have the `react-native-firebase` library set up correctly in your project. For more information on how to configure native Firebase SDK, see [using the native Firebase SDK](/guides/setup-native-firebase/#setup).
+Also, make sure that you have React Native Firebase set up correctly in your project. For more information on how to configure it, see [using the native Firebase SDK](/guides/setup-native-firebase/#setup).
 
 ### Expo Go: Limitations & configuration
 

--- a/docs/pages/versions/unversioned/sdk/firebase-recaptcha.md
+++ b/docs/pages/versions/unversioned/sdk/firebase-recaptcha.md
@@ -7,8 +7,9 @@ packageName: 'expo-firebase-recaptcha'
 import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
+import { Terminal } from '~/ui/components/Snippet';
 
-**`expo-firebase-recaptcha`** provides a set of building blocks for creating a reCAPTCHA verifier and using that with your Firebase Phone authentication workflow.
+`expo-firebase-recaptcha` provides a set of building blocks for creating a reCAPTCHA verifier and using that with your Firebase Phone authentication workflow.
 
 > Firebase phone authentication is not possible out of the box using the Firebase JS SDK. This because an Application Verifier object (reCAPTCHA) is needed as an additional security measure to verify that the user is real and not a bot.
 
@@ -18,13 +19,23 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 <APIInstallSection />
 
-Additionally, you'll also need to install the webview using `npx expo install react-native-webview`
+Additionally, you'll also need to install the webview using `npx expo install react-native-webview`.
 
 ## Usage
 
+### With native Firebase SDK
+
+If you are using `expo-firebase-recaptcha` with React Native Firebase SDK (`react-native-firebase`), you'll have to install the native Firebase SDK using the `npx expo install` command:
+
+<Terminal cmd={["$ npx expo install @react-native-firebase/app"]} />
+
+This will ensure that the `react-native-firebase` dependency version is compatible with the Expo SDK version your project uses.
+
+Also, make sure that you have the `react-native-firebase` library set up correctly in your project. For more information on how to configure native Firebase SDK, see [using the native Firebase SDK](/guides/setup-native-firebase/#setup).
+
 ### Basic usage
 
-To get started, [read the official Firebase phone-auth guide and **ignore all steps** that cover the reCAPTCHA configuration.](https://firebase.google.com/docs/auth/web/phone-auth)
+To get started, [read the official Firebase phone-auth guide and **ignore all steps** that cover the reCAPTCHA configuration](https://firebase.google.com/docs/auth/web/phone-auth).
 
 Instead of using the standard `firebase.auth.RecaptchaVerifier` class, we will be using our own verifier which creates a reCAPTCHA widget inside a web-browser.
 
@@ -57,7 +68,7 @@ const authResult = await firebase.auth().signInWithCredential(credential);
 
 ### Phone authentication example
 
-The examples below assumes that you are using `firebase@9.x.x`.
+The examples below assumes that you are using `firebase@9.x.x` JS SDK.
 
 <SnackInline
 label='Firebase Phone Auth'

--- a/docs/pages/versions/unversioned/sdk/firebase-recaptcha.md
+++ b/docs/pages/versions/unversioned/sdk/firebase-recaptcha.md
@@ -25,13 +25,13 @@ Additionally, you'll also need to install the webview using `npx expo install re
 
 ### With native Firebase SDK
 
-If you are using `expo-firebase-recaptcha` with React Native Firebase SDK (`react-native-firebase`), you'll have to install the native Firebase SDK using the `npx expo install` command:
+If you are using `expo-firebase-recaptcha` with React Native Firebase, you'll have to install the native SDK using the `npx expo install` command:
 
 <Terminal cmd={["$ npx expo install @react-native-firebase/app"]} />
 
-This will ensure that the `react-native-firebase` dependency version is compatible with the Expo SDK version your project uses.
+This will ensure that the `@react-native-firebase/app` dependency version is compatible with the Expo SDK version your project uses.
 
-Also, make sure that you have the `react-native-firebase` library set up correctly in your project. For more information on how to configure native Firebase SDK, see [using the native Firebase SDK](/guides/setup-native-firebase/#setup).
+Also, make sure that you have React Native Firebase set up correctly in your project. For more information on how to configure it, see [using the native Firebase SDK](/guides/setup-native-firebase/#setup).
 
 ### Basic usage
 

--- a/docs/pages/versions/v43.0.0/sdk/firebase-analytics.md
+++ b/docs/pages/versions/v43.0.0/sdk/firebase-analytics.md
@@ -6,7 +6,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-43/packages/expo-firebase-
 import APISection from '~/components/plugins/APISection';
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-
+import { Terminal } from '~/ui/components/Snippet';
 import { InlineCode } from '~/components/base/code';
 
 > **This is the only Firebase Analytics package for React Native that has universal platform support (iOS, Android, Web, and Electron).**
@@ -26,13 +26,13 @@ When using the web platform, you'll also need to run `expo install firebase`, wh
 
 ### With native Firebase SDK
 
-If you are using `expo-firebase-analytics` with React Native Firebase SDK (`react-native-firebase`), you'll have to install the native Firebase SDK using the `expo install` command:
+If you are using `expo-firebase-analytics` with React Native Firebase, you'll have to install the native Firebase SDK using the `expo install` command:
 
 <Terminal cmd={["$ expo install @react-native-firebase/app"]} />
 
-This will ensure that the `react-native-firebase` dependency version is compatible with the Expo SDK version your project uses.
+This will ensure that the `@react-native-firebase/app` dependency version is compatible with the Expo SDK version your project uses.
 
-Also, make sure that you have the `react-native-firebase` library set up correctly in your project. For more information on how to configure native Firebase SDK, see [using the native Firebase SDK](/guides/setup-native-firebase/#setup).
+Also, make sure that you have React Native Firebase set up correctly in your project. For more information on how to configure it, see [using the native Firebase SDK](/guides/setup-native-firebase/#setup).
 
 ## Expo Go: Limitations & configuration
 

--- a/docs/pages/versions/v43.0.0/sdk/firebase-analytics.md
+++ b/docs/pages/versions/v43.0.0/sdk/firebase-analytics.md
@@ -20,11 +20,19 @@ Learn more in the official [Firebase Docs](https://firebase.google.com/docs/anal
 
 <InstallSection packageName="expo-firebase-analytics" />
 
-When using the web platform, you'll also need to run `npx expo install firebase`, which installs the Firebase JS SDK.
+When using the web platform, you'll also need to run `expo install firebase`, which installs the Firebase JS SDK.
 
 ## Configuration
 
-> If you are using [`react-native-firebase`](https://rnfirebase.io/) library in your project, you should use [`@react-native-firebase/analytics`](https://rnfirebase.io/analytics/usage) package provided by the library. For more information on how to configure native Firebase library, see [using the native Firebase SDK](/guides/setup-native-firebase/).
+### With native Firebase SDK
+
+If you are using `expo-firebase-analytics` with React Native Firebase SDK (`react-native-firebase`), you'll have to install the native Firebase SDK using the `expo install` command:
+
+<Terminal cmd={["$ expo install @react-native-firebase/app"]} />
+
+This will ensure that the `react-native-firebase` dependency version is compatible with the Expo SDK version your project uses.
+
+Also, make sure that you have the `react-native-firebase` library set up correctly in your project. For more information on how to configure native Firebase SDK, see [using the native Firebase SDK](/guides/setup-native-firebase/#setup).
 
 ## Expo Go: Limitations & configuration
 

--- a/docs/pages/versions/v43.0.0/sdk/firebase-recaptcha.md
+++ b/docs/pages/versions/v43.0.0/sdk/firebase-recaptcha.md
@@ -24,13 +24,13 @@ Additionally, you'll also need to install the webview using `expo install react-
 
 ### With native Firebase SDK
 
-If you are using `expo-firebase-recaptcha` with React Native Firebase SDK (`react-native-firebase`), you'll have to install the native Firebase SDK using the `expo install` command:
+If you are using `expo-firebase-recaptcha` with React Native Firebase, you'll have to install the native Firebase SDK using the `expo install` command:
 
 <Terminal cmd={["$ expo install @react-native-firebase/app"]} />
 
-This will ensure that the `react-native-firebase` dependency version is compatible with the Expo SDK version your project uses.
+This will ensure that the `@react-native-firebase/app` dependency version is compatible with the Expo SDK version your project uses.
 
-Also, make sure that you have the `react-native-firebase` library set up correctly in your project. For more information on how to configure native Firebase SDK, see [using the native Firebase SDK](/guides/setup-native-firebase/#setup).
+Also, make sure that you have React Native Firebase set up correctly in your project. For more information on how to configure it, see [using the native Firebase SDK](/guides/setup-native-firebase/#setup).
 
 ### Basic usage
 

--- a/docs/pages/versions/v43.0.0/sdk/firebase-recaptcha.md
+++ b/docs/pages/versions/v43.0.0/sdk/firebase-recaptcha.md
@@ -6,8 +6,9 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-43/packages/expo-firebase-
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
+import { Terminal } from '~/ui/components/Snippet';
 
-**`expo-firebase-recaptcha`** provides a set of building blocks for creating a reCAPTCHA verifier and using that with your Firebase Phone authentication workflow.
+`expo-firebase-recaptcha` provides a set of building blocks for creating a reCAPTCHA verifier and using that with your Firebase Phone authentication workflow.
 
 > Firebase phone authentication is not possible out of the box using the Firebase JS SDK. This because an Application Verifier object (reCAPTCHA) is needed as an additional security measure to verify that the user is real and not a bot.
 
@@ -17,11 +18,23 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 <InstallSection packageName="expo-firebase-recaptcha" />
 
-Additionally, you'll also need to install the webview using `expo install react-native-webview`
+Additionally, you'll also need to install the webview using `expo install react-native-webview`.
 
-## Basic usage
+## Usage
 
-To get started, [read the official Firebase phone-auth guide and **ignore all steps** that cover the reCAPTCHA configuration.](https://firebase.google.com/docs/auth/web/phone-auth)
+### With native Firebase SDK
+
+If you are using `expo-firebase-recaptcha` with React Native Firebase SDK (`react-native-firebase`), you'll have to install the native Firebase SDK using the `expo install` command:
+
+<Terminal cmd={["$ expo install @react-native-firebase/app"]} />
+
+This will ensure that the `react-native-firebase` dependency version is compatible with the Expo SDK version your project uses.
+
+Also, make sure that you have the `react-native-firebase` library set up correctly in your project. For more information on how to configure native Firebase SDK, see [using the native Firebase SDK](/guides/setup-native-firebase/#setup).
+
+### Basic usage
+
+To get started, [read the official Firebase phone-auth guide and **ignore all steps** that cover the reCAPTCHA configuration](https://firebase.google.com/docs/auth/web/phone-auth).
 
 Instead of using the standard `firebase.auth.RecaptchaVerifier` class, we will be using our own verifier which creates a reCAPTCHA widget inside a web-browser.
 
@@ -52,9 +65,9 @@ const credential = firebase.auth.PhoneAuthProvider.credential(verificationId, ve
 const authResult = await firebase.auth().signInWithCredential(credential);
 ```
 
-## Example usage
+### Phone authentication example
 
-The examples below assumes that you are using `firebase@9.x.x`.
+The examples below assumes that you are using `firebase@9.x.x` JS SDK.
 
 <SnackInline
 label='Firebase Phone Auth'
@@ -91,7 +104,9 @@ const auth = getAuth();
 
 // Double-check that we can run the example
 if (!app?.options || Platform.OS === 'web') {
-  throw new Error('This example only works on Android or iOS, and requires a valid Firebase config.');
+  throw new Error(
+    'This example only works on Android or iOS, and requires a valid Firebase config.'
+  );
 }
 
 export default function App() {
@@ -156,10 +171,7 @@ export default function App() {
         disabled={!verificationId}
         onPress={async () => {
           try {
-            const credential = PhoneAuthProvider.credential(
-              verificationId,
-              verificationCode
-            );
+            const credential = PhoneAuthProvider.credential(verificationId, verificationCode);
             await signInWithCredential(auth, credential);
             showMessage({ text: 'Phone authentication successful 👍' });
           } catch (err) {
@@ -184,9 +196,7 @@ export default function App() {
             {message.text}
           </Text>
         </TouchableOpacity>
-      ) : (
-        undefined
-      )}
+      ) : undefined}
       {attemptInvisibleVerification && <FirebaseRecaptchaBanner />}
     </View>
   );
@@ -300,9 +310,7 @@ export default function PhoneAuthScreen() {
         {verifyInProgress && <ActivityIndicator style={styles.loader} />}
         {verificationId ? (
           <Text style={styles.success}>A verification code has been sent to your phone</Text>
-        ) : (
-          undefined
-        )}
+        ) : undefined}
         <Text style={styles.text}>Enter verification code</Text>
         <TextInput
           ref={verificationCodeTextInput}
@@ -318,10 +326,7 @@ export default function PhoneAuthScreen() {
             try {
               setConfirmError(undefined);
               setConfirmInProgress(true);
-              const credential = PhoneAuthProvider.credential(
-                verificationId,
-                verificationCode
-              );
+              const credential = PhoneAuthProvider.credential(verificationId, verificationCode);
               const authResult = await signInWithCredential(auth, credential);
               setConfirmInProgress(false);
               setVerificationId('');

--- a/docs/pages/versions/v44.0.0/sdk/firebase-analytics.md
+++ b/docs/pages/versions/v44.0.0/sdk/firebase-analytics.md
@@ -6,7 +6,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-44/packages/expo-firebase-
 import APISection from '~/components/plugins/APISection';
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-
+import { Terminal } from '~/ui/components/Snippet';
 import { InlineCode } from '~/components/base/code';
 
 > **This is the only Firebase Analytics package for React Native that has universal platform support (iOS, Android, Web, and Electron).**
@@ -20,11 +20,19 @@ Learn more in the official [Firebase Docs](https://firebase.google.com/docs/anal
 
 <InstallSection packageName="expo-firebase-analytics" />
 
-When using the web platform, you'll also need to run `npx expo install firebase`, which installs the Firebase JS SDK.
+When using the web platform, you'll also need to run `expo install firebase`, which installs the Firebase JS SDK.
 
 ## Configuration
 
-> If you are using [`react-native-firebase`](https://rnfirebase.io/) library in your project, you should use [`@react-native-firebase/analytics`](https://rnfirebase.io/analytics/usage) package provided by the library. For more information on how to configure native Firebase library, see [using the native Firebase SDK](/guides/setup-native-firebase/).
+### With native Firebase SDK
+
+If you are using `expo-firebase-analytics` with React Native Firebase SDK (`react-native-firebase`), you'll have to install the native Firebase SDK using the `expo install` command:
+
+<Terminal cmd={["$ expo install @react-native-firebase/app"]} />
+
+This will ensure that the `react-native-firebase` dependency version is compatible with the Expo SDK version your project uses.
+
+Also, make sure that you have the `react-native-firebase` library set up correctly in your project. For more information on how to configure native Firebase SDK, see [using the native Firebase SDK](/guides/setup-native-firebase/#setup).
 
 ## Expo Go: Limitations & configuration
 

--- a/docs/pages/versions/v44.0.0/sdk/firebase-analytics.md
+++ b/docs/pages/versions/v44.0.0/sdk/firebase-analytics.md
@@ -26,13 +26,13 @@ When using the web platform, you'll also need to run `expo install firebase`, wh
 
 ### With native Firebase SDK
 
-If you are using `expo-firebase-analytics` with React Native Firebase SDK (`react-native-firebase`), you'll have to install the native Firebase SDK using the `expo install` command:
+If you are using `expo-firebase-analytics` with React Native Firebase, you'll have to install the native Firebase SDK using the `expo install` command:
 
 <Terminal cmd={["$ expo install @react-native-firebase/app"]} />
 
-This will ensure that the `react-native-firebase` dependency version is compatible with the Expo SDK version your project uses.
+This will ensure that the `@react-native-firebase/app` dependency version is compatible with the Expo SDK version your project uses.
 
-Also, make sure that you have the `react-native-firebase` library set up correctly in your project. For more information on how to configure native Firebase SDK, see [using the native Firebase SDK](/guides/setup-native-firebase/#setup).
+Also, make sure that you have React Native Firebase set up correctly in your project. For more information on how to configure it, see [using the native Firebase SDK](/guides/setup-native-firebase/#setup).
 
 ## Expo Go: Limitations & configuration
 

--- a/docs/pages/versions/v44.0.0/sdk/firebase-recaptcha.md
+++ b/docs/pages/versions/v44.0.0/sdk/firebase-recaptcha.md
@@ -24,13 +24,13 @@ Additionally, you'll also need to install the webview using `expo install react-
 
 ### With native Firebase SDK
 
-If you are using `expo-firebase-recaptcha` with React Native Firebase SDK (`react-native-firebase`), you'll have to install the native Firebase SDK using the `expo install` command:
+If you are using `expo-firebase-recaptcha` with React Native Firebase, you'll have to install the native Firebase SDK using the `expo install` command:
 
 <Terminal cmd={["$ expo install @react-native-firebase/app"]} />
 
-This will ensure that the `react-native-firebase` dependency version is compatible with the Expo SDK version your project uses.
+This will ensure that the `@react-native-firebase/app` dependency version is compatible with the Expo SDK version your project uses.
 
-Also, make sure that you have the `react-native-firebase` library set up correctly in your project. For more information on how to configure native Firebase SDK, see [using the native Firebase SDK](/guides/setup-native-firebase/#setup).
+Also, make sure that you have React Native Firebase set up correctly in your project. For more information on how to configure it, see [using the native Firebase SDK](/guides/setup-native-firebase/#setup).
 
 ### Basic usage
 

--- a/docs/pages/versions/v44.0.0/sdk/firebase-recaptcha.md
+++ b/docs/pages/versions/v44.0.0/sdk/firebase-recaptcha.md
@@ -6,8 +6,9 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-44/packages/expo-firebase-
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
+import { Terminal } from '~/ui/components/Snippet';
 
-**`expo-firebase-recaptcha`** provides a set of building blocks for creating a reCAPTCHA verifier and using that with your Firebase Phone authentication workflow.
+`expo-firebase-recaptcha` provides a set of building blocks for creating a reCAPTCHA verifier and using that with your Firebase Phone authentication workflow.
 
 > Firebase phone authentication is not possible out of the box using the Firebase JS SDK. This because an Application Verifier object (reCAPTCHA) is needed as an additional security measure to verify that the user is real and not a bot.
 
@@ -17,11 +18,23 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 <InstallSection packageName="expo-firebase-recaptcha" />
 
-Additionally, you'll also need to install the webview using `expo install react-native-webview`
+Additionally, you'll also need to install the webview using `expo install react-native-webview`.
 
-## Basic usage
+## Usage
 
-To get started, [read the official Firebase phone-auth guide and **ignore all steps** that cover the reCAPTCHA configuration.](https://firebase.google.com/docs/auth/web/phone-auth)
+### With native Firebase SDK
+
+If you are using `expo-firebase-recaptcha` with React Native Firebase SDK (`react-native-firebase`), you'll have to install the native Firebase SDK using the `expo install` command:
+
+<Terminal cmd={["$ expo install @react-native-firebase/app"]} />
+
+This will ensure that the `react-native-firebase` dependency version is compatible with the Expo SDK version your project uses.
+
+Also, make sure that you have the `react-native-firebase` library set up correctly in your project. For more information on how to configure native Firebase SDK, see [using the native Firebase SDK](/guides/setup-native-firebase/#setup).
+
+### Basic usage
+
+To get started, [read the official Firebase phone-auth guide and **ignore all steps** that cover the reCAPTCHA configuration](https://firebase.google.com/docs/auth/web/phone-auth).
 
 Instead of using the standard `firebase.auth.RecaptchaVerifier` class, we will be using our own verifier which creates a reCAPTCHA widget inside a web-browser.
 
@@ -52,9 +65,9 @@ const credential = firebase.auth.PhoneAuthProvider.credential(verificationId, ve
 const authResult = await firebase.auth().signInWithCredential(credential);
 ```
 
-## Example usage
+### Phone authentication example
 
-The examples below assumes that you are using `firebase@9.x.x`.
+The examples below assumes that you are using `firebase@9.x.x` JS SDK.
 
 <SnackInline
 label='Firebase Phone Auth'
@@ -91,7 +104,9 @@ const auth = getAuth();
 
 // Double-check that we can run the example
 if (!app?.options || Platform.OS === 'web') {
-  throw new Error('This example only works on Android or iOS, and requires a valid Firebase config.');
+  throw new Error(
+    'This example only works on Android or iOS, and requires a valid Firebase config.'
+  );
 }
 
 export default function App() {
@@ -156,10 +171,7 @@ export default function App() {
         disabled={!verificationId}
         onPress={async () => {
           try {
-            const credential = PhoneAuthProvider.credential(
-              verificationId,
-              verificationCode
-            );
+            const credential = PhoneAuthProvider.credential(verificationId, verificationCode);
             await signInWithCredential(auth, credential);
             showMessage({ text: 'Phone authentication successful 👍' });
           } catch (err) {
@@ -184,9 +196,7 @@ export default function App() {
             {message.text}
           </Text>
         </TouchableOpacity>
-      ) : (
-        undefined
-      )}
+      ) : undefined}
       {attemptInvisibleVerification && <FirebaseRecaptchaBanner />}
     </View>
   );
@@ -300,9 +310,7 @@ export default function PhoneAuthScreen() {
         {verifyInProgress && <ActivityIndicator style={styles.loader} />}
         {verificationId ? (
           <Text style={styles.success}>A verification code has been sent to your phone</Text>
-        ) : (
-          undefined
-        )}
+        ) : undefined}
         <Text style={styles.text}>Enter verification code</Text>
         <TextInput
           ref={verificationCodeTextInput}
@@ -318,10 +326,7 @@ export default function PhoneAuthScreen() {
             try {
               setConfirmError(undefined);
               setConfirmInProgress(true);
-              const credential = PhoneAuthProvider.credential(
-                verificationId,
-                verificationCode
-              );
+              const credential = PhoneAuthProvider.credential(verificationId, verificationCode);
               const authResult = await signInWithCredential(auth, credential);
               setConfirmInProgress(false);
               setVerificationId('');

--- a/docs/pages/versions/v45.0.0/sdk/firebase-analytics.md
+++ b/docs/pages/versions/v45.0.0/sdk/firebase-analytics.md
@@ -27,13 +27,13 @@ When using the web platform, you'll also need to run `expo install firebase`, wh
 
 ### With native Firebase SDK
 
-If you are using `expo-firebase-analytics` with React Native Firebase SDK (`react-native-firebase`), you'll have to install the native Firebase SDK using the `expo install` command:
+If you are using `expo-firebase-analytics` with React Native Firebase, you'll have to install the native Firebase SDK using the `expo install` command:
 
 <Terminal cmd={["$ expo install @react-native-firebase/app"]} />
 
-This will ensure that the `react-native-firebase` dependency version is compatible with the Expo SDK version your project uses.
+This will ensure that the `@react-native-firebase/app` dependency version is compatible with the Expo SDK version your project uses.
 
-Also, make sure that you have the `react-native-firebase` library set up correctly in your project. For more information on how to configure native Firebase SDK, see [using the native Firebase SDK](/guides/setup-native-firebase/#setup).
+Also, make sure that you have React Native Firebase set up correctly in your project. For more information on how to configure it, see [using the native Firebase SDK](/guides/setup-native-firebase/#setup).
 
 ### Expo Go: Limitations & configuration
 

--- a/docs/pages/versions/v45.0.0/sdk/firebase-analytics.md
+++ b/docs/pages/versions/v45.0.0/sdk/firebase-analytics.md
@@ -7,7 +7,7 @@ packageName: 'expo-firebase-analytics'
 import APISection from '~/components/plugins/APISection';
 import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-
+import { Terminal } from '~/ui/components/Snippet';
 import { InlineCode } from '~/components/base/code';
 
 > **This is the only Firebase Analytics package for React Native that has universal platform support (iOS, Android, Web, and Electron).**
@@ -21,11 +21,19 @@ Learn more in the official [Firebase Docs](https://firebase.google.com/docs/anal
 
 <APIInstallSection />
 
-When using the web platform, you'll also need to run `npx expo install firebase`, which installs the Firebase JS SDK.
+When using the web platform, you'll also need to run `expo install firebase`, which installs the Firebase JS SDK.
 
 ## Configuration
 
-> If you are using [`react-native-firebase`](https://rnfirebase.io/) library in your project, you should use [`@react-native-firebase/analytics`](https://rnfirebase.io/analytics/usage) package provided by the library. For more information on how to configure native Firebase library, see [using the native Firebase SDK](/guides/setup-native-firebase/).
+### With native Firebase SDK
+
+If you are using `expo-firebase-analytics` with React Native Firebase SDK (`react-native-firebase`), you'll have to install the native Firebase SDK using the `expo install` command:
+
+<Terminal cmd={["$ expo install @react-native-firebase/app"]} />
+
+This will ensure that the `react-native-firebase` dependency version is compatible with the Expo SDK version your project uses.
+
+Also, make sure that you have the `react-native-firebase` library set up correctly in your project. For more information on how to configure native Firebase SDK, see [using the native Firebase SDK](/guides/setup-native-firebase/#setup).
 
 ### Expo Go: Limitations & configuration
 

--- a/docs/pages/versions/v45.0.0/sdk/firebase-recaptcha.md
+++ b/docs/pages/versions/v45.0.0/sdk/firebase-recaptcha.md
@@ -7,8 +7,9 @@ packageName: 'expo-firebase-recaptcha'
 import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
+import { Terminal } from '~/ui/components/Snippet';
 
-**`expo-firebase-recaptcha`** provides a set of building blocks for creating a reCAPTCHA verifier and using that with your Firebase Phone authentication workflow.
+`expo-firebase-recaptcha` provides a set of building blocks for creating a reCAPTCHA verifier and using that with your Firebase Phone authentication workflow.
 
 > Firebase phone authentication is not possible out of the box using the Firebase JS SDK. This because an Application Verifier object (reCAPTCHA) is needed as an additional security measure to verify that the user is real and not a bot.
 
@@ -18,13 +19,23 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 <APIInstallSection />
 
-Additionally, you'll also need to install the webview using `expo install react-native-webview`
+Additionally, you'll also need to install the webview using `expo install react-native-webview`.
 
 ## Usage
 
+### With native Firebase SDK
+
+If you are using `expo-firebase-recaptcha` with React Native Firebase SDK (`react-native-firebase`), you'll have to install the native Firebase SDK using the `expo install` command:
+
+<Terminal cmd={["$ expo install @react-native-firebase/app"]} />
+
+This will ensure that the `react-native-firebase` dependency version is compatible with the Expo SDK version your project uses.
+
+Also, make sure that you have the `react-native-firebase` library set up correctly in your project. For more information on how to configure native Firebase SDK, see [using the native Firebase SDK.](/guides/setup-native-firebase/#setup).
+
 ### Basic usage
 
-To get started, [read the official Firebase phone-auth guide and **ignore all steps** that cover the reCAPTCHA configuration.](https://firebase.google.com/docs/auth/web/phone-auth)
+To get started, [read the official Firebase phone-auth guide and **ignore all steps** that cover the reCAPTCHA configuration](https://firebase.google.com/docs/auth/web/phone-auth).
 
 Instead of using the standard `firebase.auth.RecaptchaVerifier` class, we will be using our own verifier which creates a reCAPTCHA widget inside a web-browser.
 
@@ -57,7 +68,7 @@ const authResult = await firebase.auth().signInWithCredential(credential);
 
 ### Phone authentication example
 
-The examples below assumes that you are using `firebase@9.x.x`.
+The examples below assumes that you are using `firebase@9.x.x` JS SDK.
 
 <SnackInline
 label='Firebase Phone Auth'
@@ -94,7 +105,9 @@ const auth = getAuth();
 
 // Double-check that we can run the example
 if (!app?.options || Platform.OS === 'web') {
-  throw new Error('This example only works on Android or iOS, and requires a valid Firebase config.');
+  throw new Error(
+    'This example only works on Android or iOS, and requires a valid Firebase config.'
+  );
 }
 
 export default function App() {
@@ -159,10 +172,7 @@ export default function App() {
         disabled={!verificationId}
         onPress={async () => {
           try {
-            const credential = PhoneAuthProvider.credential(
-              verificationId,
-              verificationCode
-            );
+            const credential = PhoneAuthProvider.credential(verificationId, verificationCode);
             await signInWithCredential(auth, credential);
             showMessage({ text: 'Phone authentication successful 👍' });
           } catch (err) {
@@ -187,9 +197,7 @@ export default function App() {
             {message.text}
           </Text>
         </TouchableOpacity>
-      ) : (
-        undefined
-      )}
+      ) : undefined}
       {attemptInvisibleVerification && <FirebaseRecaptchaBanner />}
     </View>
   );
@@ -303,9 +311,7 @@ export default function PhoneAuthScreen() {
         {verifyInProgress && <ActivityIndicator style={styles.loader} />}
         {verificationId ? (
           <Text style={styles.success}>A verification code has been sent to your phone</Text>
-        ) : (
-          undefined
-        )}
+        ) : undefined}
         <Text style={styles.text}>Enter verification code</Text>
         <TextInput
           ref={verificationCodeTextInput}
@@ -321,10 +327,7 @@ export default function PhoneAuthScreen() {
             try {
               setConfirmError(undefined);
               setConfirmInProgress(true);
-              const credential = PhoneAuthProvider.credential(
-                verificationId,
-                verificationCode
-              );
+              const credential = PhoneAuthProvider.credential(verificationId, verificationCode);
               const authResult = await signInWithCredential(auth, credential);
               setConfirmInProgress(false);
               setVerificationId('');

--- a/docs/pages/versions/v45.0.0/sdk/firebase-recaptcha.md
+++ b/docs/pages/versions/v45.0.0/sdk/firebase-recaptcha.md
@@ -25,13 +25,13 @@ Additionally, you'll also need to install the webview using `expo install react-
 
 ### With native Firebase SDK
 
-If you are using `expo-firebase-recaptcha` with React Native Firebase SDK (`react-native-firebase`), you'll have to install the native Firebase SDK using the `expo install` command:
+If you are using `expo-firebase-recaptcha` with React Native Firebase, you'll have to install the native Firebase SDK using the `expo install` command:
 
 <Terminal cmd={["$ expo install @react-native-firebase/app"]} />
 
-This will ensure that the `react-native-firebase` dependency version is compatible with the Expo SDK version your project uses.
+This will ensure that the `@react-native-firebase/app`dependency version is compatible with the Expo SDK version your project uses.
 
-Also, make sure that you have the `react-native-firebase` library set up correctly in your project. For more information on how to configure native Firebase SDK, see [using the native Firebase SDK.](/guides/setup-native-firebase/#setup).
+Also, make sure that you have React Native Firebase set up correctly in your project. For more information on how to configure it, see [using the native Firebase SDK](/guides/setup-native-firebase/#setup).
 
 ### Basic usage
 

--- a/docs/pages/versions/v46.0.0/sdk/firebase-analytics.md
+++ b/docs/pages/versions/v46.0.0/sdk/firebase-analytics.md
@@ -7,7 +7,7 @@ packageName: 'expo-firebase-analytics'
 import APISection from '~/components/plugins/APISection';
 import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-
+import { Terminal } from '~/ui/components/Snippet';
 import { InlineCode } from '~/components/base/code';
 
 > **This is the only Firebase Analytics package for React Native that has universal platform support (iOS, Android, Web, and Electron).**
@@ -25,7 +25,15 @@ When using the web platform, you'll also need to run `npx expo install firebase`
 
 ## Configuration
 
-> If you are using [`react-native-firebase`](https://rnfirebase.io/) library in your project, you should use [`@react-native-firebase/analytics`](https://rnfirebase.io/analytics/usage) package provided by the library. For more information on how to configure native Firebase library, see [using the native Firebase SDK](/guides/setup-native-firebase/).
+### With native Firebase SDK
+
+If you are using `expo-firebase-analytics` with React Native Firebase SDK (`react-native-firebase`), you'll have to install the native Firebase SDK using the `npx expo install` command:
+
+<Terminal cmd={["$ npx expo install @react-native-firebase/app"]} />
+
+This will ensure that the `react-native-firebase` dependency version is compatible with the Expo SDK version your project uses.
+
+Also, make sure that you have the `react-native-firebase` library set up correctly in your project. For more information on how to configure native Firebase SDK, see [using the native Firebase SDK](/guides/setup-native-firebase/#setup).
 
 ### Expo Go: Limitations & configuration
 

--- a/docs/pages/versions/v46.0.0/sdk/firebase-analytics.md
+++ b/docs/pages/versions/v46.0.0/sdk/firebase-analytics.md
@@ -27,13 +27,13 @@ When using the web platform, you'll also need to run `npx expo install firebase`
 
 ### With native Firebase SDK
 
-If you are using `expo-firebase-analytics` with React Native Firebase SDK (`react-native-firebase`), you'll have to install the native Firebase SDK using the `npx expo install` command:
+If you are using `expo-firebase-analytics` with React Native Firebase, you'll have to install the native Firebase SDK using the `npx expo install` command:
 
 <Terminal cmd={["$ npx expo install @react-native-firebase/app"]} />
 
-This will ensure that the `react-native-firebase` dependency version is compatible with the Expo SDK version your project uses.
+This will ensure that the `@react-native-firebase/app` dependency version is compatible with the Expo SDK version your project uses.
 
-Also, make sure that you have the `react-native-firebase` library set up correctly in your project. For more information on how to configure native Firebase SDK, see [using the native Firebase SDK](/guides/setup-native-firebase/#setup).
+Also, make sure that you have React Native Firebase set up correctly in your project. For more information on how to configure it, see [using the native Firebase SDK](/guides/setup-native-firebase/#setup).
 
 ### Expo Go: Limitations & configuration
 

--- a/docs/pages/versions/v46.0.0/sdk/firebase-recaptcha.md
+++ b/docs/pages/versions/v46.0.0/sdk/firebase-recaptcha.md
@@ -25,13 +25,13 @@ Additionally, you'll also need to install the webview using `npx expo install re
 
 ### With native Firebase SDK
 
-If you are using `expo-firebase-recaptcha` with React Native Firebase SDK (`react-native-firebase`), you'll have to install the native Firebase SDK using the `npx expo install` command:
+If you are using `expo-firebase-recaptcha` with React Native Firebase, you'll have to install the native SDK using the `npx expo install` command:
 
 <Terminal cmd={["$ npx expo install @react-native-firebase/app"]} />
 
-This will ensure that the `react-native-firebase` dependency version is compatible with the Expo SDK version your project uses.
+This will ensure that the `@react-native-firebase/app` dependency version is compatible with the Expo SDK version your project uses.
 
-Also, make sure that you have the `react-native-firebase` library set up correctly in your project. For more information on how to configure native Firebase SDK, see [using the native Firebase SDK.](/guides/setup-native-firebase/#setup).
+Also, make sure that you have React Native Firebase set up correctly in your project. For more information on how to configure it, see [using the native Firebase SDK](/guides/setup-native-firebase/#setup).
 
 ### Basic usage
 

--- a/docs/pages/versions/v46.0.0/sdk/firebase-recaptcha.md
+++ b/docs/pages/versions/v46.0.0/sdk/firebase-recaptcha.md
@@ -7,8 +7,9 @@ packageName: 'expo-firebase-recaptcha'
 import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
+import { Terminal } from '~/ui/components/Snippet';
 
-**`expo-firebase-recaptcha`** provides a set of building blocks for creating a reCAPTCHA verifier and using that with your Firebase Phone authentication workflow.
+`expo-firebase-recaptcha` provides a set of building blocks for creating a reCAPTCHA verifier and using that with your Firebase Phone authentication workflow.
 
 > Firebase phone authentication is not possible out of the box using the Firebase JS SDK. This because an Application Verifier object (reCAPTCHA) is needed as an additional security measure to verify that the user is real and not a bot.
 
@@ -18,13 +19,23 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 <APIInstallSection />
 
-Additionally, you'll also need to install the webview using `expo install react-native-webview`
+Additionally, you'll also need to install the webview using `npx expo install react-native-webview`.
 
 ## Usage
 
+### With native Firebase SDK
+
+If you are using `expo-firebase-recaptcha` with React Native Firebase SDK (`react-native-firebase`), you'll have to install the native Firebase SDK using the `npx expo install` command:
+
+<Terminal cmd={["$ npx expo install @react-native-firebase/app"]} />
+
+This will ensure that the `react-native-firebase` dependency version is compatible with the Expo SDK version your project uses.
+
+Also, make sure that you have the `react-native-firebase` library set up correctly in your project. For more information on how to configure native Firebase SDK, see [using the native Firebase SDK.](/guides/setup-native-firebase/#setup).
+
 ### Basic usage
 
-To get started, [read the official Firebase phone-auth guide and **ignore all steps** that cover the reCAPTCHA configuration.](https://firebase.google.com/docs/auth/web/phone-auth)
+To get started, [read the official Firebase phone-auth guide and **ignore all steps** that cover the reCAPTCHA configuration](https://firebase.google.com/docs/auth/web/phone-auth).
 
 Instead of using the standard `firebase.auth.RecaptchaVerifier` class, we will be using our own verifier which creates a reCAPTCHA widget inside a web-browser.
 
@@ -57,7 +68,7 @@ const authResult = await firebase.auth().signInWithCredential(credential);
 
 ### Phone authentication example
 
-The examples below assumes that you are using `firebase@9.x.x`.
+The examples below assumes that you are using `firebase@9.x.x` JS SDK.
 
 <SnackInline
 label='Firebase Phone Auth'
@@ -94,7 +105,9 @@ const auth = getAuth();
 
 // Double-check that we can run the example
 if (!app?.options || Platform.OS === 'web') {
-  throw new Error('This example only works on Android or iOS, and requires a valid Firebase config.');
+  throw new Error(
+    'This example only works on Android or iOS, and requires a valid Firebase config.'
+  );
 }
 
 export default function App() {
@@ -159,10 +172,7 @@ export default function App() {
         disabled={!verificationId}
         onPress={async () => {
           try {
-            const credential = PhoneAuthProvider.credential(
-              verificationId,
-              verificationCode
-            );
+            const credential = PhoneAuthProvider.credential(verificationId, verificationCode);
             await signInWithCredential(auth, credential);
             showMessage({ text: 'Phone authentication successful 👍' });
           } catch (err) {
@@ -187,9 +197,7 @@ export default function App() {
             {message.text}
           </Text>
         </TouchableOpacity>
-      ) : (
-        undefined
-      )}
+      ) : undefined}
       {attemptInvisibleVerification && <FirebaseRecaptchaBanner />}
     </View>
   );
@@ -303,9 +311,7 @@ export default function PhoneAuthScreen() {
         {verifyInProgress && <ActivityIndicator style={styles.loader} />}
         {verificationId ? (
           <Text style={styles.success}>A verification code has been sent to your phone</Text>
-        ) : (
-          undefined
-        )}
+        ) : undefined}
         <Text style={styles.text}>Enter verification code</Text>
         <TextInput
           ref={verificationCodeTextInput}
@@ -321,10 +327,7 @@ export default function PhoneAuthScreen() {
             try {
               setConfirmError(undefined);
               setConfirmInProgress(true);
-              const credential = PhoneAuthProvider.credential(
-                verificationId,
-                verificationCode
-              );
+              const credential = PhoneAuthProvider.credential(verificationId, verificationCode);
               const authResult = await signInWithCredential(auth, credential);
               setConfirmInProgress(false);
               setVerificationId('');


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Recently, #18908 introduced changes to prevent version conflict errors between Expo Firebase packages (`expo-firebase-analytics` and `expo-firebase-recaptcha`) and `react-native-firebase`. 

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR updates the documentation for `expo-firebase-analytics` and `expo-firebase-recaptcha` by:
- Adding a new section under "With native Firebase SDK" under "Usage" and "Configuration"
- These changes are backported for SDK 45, 44, and 43

It also fixes a few typos and misrepresented commands such as using `npx` with older SDK versions.

# Test Plan

To test these changes, run `expo/docs` locally & visit:
- http://localhost:3002/versions/unversioned/sdk/firebase-recaptcha/#with-native-firebase-sdk
- http://localhost:3002/versions/unversioned/sdk/firebase-analytics/#with-native-firebase-sdk

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
