### PR TITLE
Fix `'undefined'` as strings

### DIFF
--- a/packages/expo-auth-session/src/providers/Google.ts
+++ b/packages/expo-auth-session/src/providers/Google.ts
@@ -263,7 +263,7 @@ export function useAuthRequest(
 
   const responseType = useMemo(() => {
     // Allow overrides.
-    if (typeof config.responseType !== 'undefined') {
+    if (typeof config.responseType !== undefined) {
       return config.responseType;
     }
     // You can only use `response_token=code` on installed apps (iOS, Android without proxy).
@@ -278,7 +278,7 @@ export function useAuthRequest(
   }, [config.responseType, config.clientSecret, useProxy]);
 
   const redirectUri = useMemo((): string => {
-    if (typeof config.redirectUri !== 'undefined') {
+    if (typeof config.redirectUri !== undefined) {
       return config.redirectUri;
     }
 
@@ -326,7 +326,7 @@ export function useAuthRequest(
 
   const shouldAutoExchangeCode = useMemo(() => {
     // allow overrides
-    if (typeof config.shouldAutoExchangeCode !== 'undefined') {
+    if (typeof config.shouldAutoExchangeCode !== undefined) {
       return config.shouldAutoExchangeCode;
     }
 


### PR DESCRIPTION
`Google.useAuthRequest` is checking for `undefined` as a literal string.

# Why

Fixing a code typo.

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
