### PR TITLE
[docs][ios-developer-mode]: Add info about Developer mode not available in some cases

### DIFF
--- a/docs/pages/guides/ios-developer-mode.md
+++ b/docs/pages/guides/ios-developer-mode.md
@@ -8,7 +8,7 @@ On devices running iOS 16 and above, you will need to enable a special OS-level 
 
 This does not apply to builds signed using enterprise provisioning, nor to any builds installed on an iOS simulator.
 
-To enable Developer Mode on your iOS 16+ device, follow the instructions below (once per device). On some devices, the option to enable it might now show until the build is installed.
+To enable Developer Mode on your iOS 16+ device, follow the instructions below (once per device). On some devices, the option to enable it might not show until the build is installed.
 
 - In the Settings app, navigate to "Privacy & Security" > "Developer Mode".
 

--- a/docs/pages/guides/ios-developer-mode.md
+++ b/docs/pages/guides/ios-developer-mode.md
@@ -8,7 +8,7 @@ On devices running iOS 16 and above, you will need to enable a special OS-level 
 
 This does not apply to builds signed using enterprise provisioning, nor to any builds installed on an iOS simulator.
 
-To enable Developer Mode on your iOS 16+ device, follow these instructions after installing your app (once per device):
+To enable Developer Mode on your iOS 16+ device, follow the instructions below (once per device). On some devices, the option to enable it might now show until the build is installed.
 
 - In the Settings app, navigate to "Privacy & Security" > "Developer Mode".
 

--- a/docs/pages/guides/ios-developer-mode.md
+++ b/docs/pages/guides/ios-developer-mode.md
@@ -8,7 +8,7 @@ On devices running iOS 16 and above, you will need to enable a special OS-level 
 
 This does not apply to builds signed using enterprise provisioning, nor to any builds installed on an iOS simulator.
 
-To enable Developer Mode on your iOS 16+ device, follow these instructions (once per device):
+To enable Developer Mode on your iOS 16+ device, follow these instructions after installing your app (once per device):
 
 - In the Settings app, navigate to "Privacy & Security" > "Developer Mode".
 


### PR DESCRIPTION
The developer option does not show up until after you have installed an app that requires it. It was confusing to me to read these instructions and try and find the setting before installing my app on my device.

Thanks for the great product!

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
