### PR TITLE
[docs][FirebaseAnalytics][FirebaseRecaptcha]: Revert changes and the contents of note back for other SDKs

### DIFF
--- a/docs/pages/versions/v43.0.0/sdk/firebase-analytics.md
+++ b/docs/pages/versions/v43.0.0/sdk/firebase-analytics.md
@@ -6,7 +6,6 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-43/packages/expo-firebase-
 import APISection from '~/components/plugins/APISection';
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { Terminal } from '~/ui/components/Snippet';
 import { InlineCode } from '~/components/base/code';
 
 > **This is the only Firebase Analytics package for React Native that has universal platform support (iOS, Android, Web, and Electron).**
@@ -26,13 +25,7 @@ When using the web platform, you'll also need to run `expo install firebase`, wh
 
 ### With native Firebase SDK
 
-If you are using `expo-firebase-analytics` with React Native Firebase, you'll have to install the native Firebase SDK using the `expo install` command:
-
-<Terminal cmd={["$ expo install @react-native-firebase/app"]} />
-
-This will ensure that the `@react-native-firebase/app` dependency version is compatible with the Expo SDK version your project uses.
-
-Also, make sure that you have React Native Firebase set up correctly in your project. For more information on how to configure it, see [using the native Firebase SDK](/guides/setup-native-firebase/#setup).
+If you are using [React Native Firebase](https://rnfirebase.io/) in your project, you should use [`@react-native-firebase/analytics`](https://rnfirebase.io/analytics/usage) package provided by the library. For more information on how to configure the native Firebase, see [using the native Firebase SDK](/guides/setup-native-firebase/).
 
 ## Expo Go: Limitations & configuration
 

--- a/docs/pages/versions/v43.0.0/sdk/firebase-recaptcha.md
+++ b/docs/pages/versions/v43.0.0/sdk/firebase-recaptcha.md
@@ -24,13 +24,7 @@ Additionally, you'll also need to install the webview using `expo install react-
 
 ### With native Firebase SDK
 
-If you are using `expo-firebase-recaptcha` with React Native Firebase, you'll have to install the native Firebase SDK using the `expo install` command:
-
-<Terminal cmd={["$ expo install @react-native-firebase/app"]} />
-
-This will ensure that the `@react-native-firebase/app` dependency version is compatible with the Expo SDK version your project uses.
-
-Also, make sure that you have React Native Firebase set up correctly in your project. For more information on how to configure it, see [using the native Firebase SDK](/guides/setup-native-firebase/#setup).
+If you are using [React Native Firebase](https://rnfirebase.io/) in your project, you should use [`@react-native-firebase/auth`](https://rnfirebase.io/auth/phone-auth) package provided by the library. For more information on how to configure the native Firebase, see [using the native Firebase SDK](/guides/setup-native-firebase/).
 
 ### Basic usage
 

--- a/docs/pages/versions/v44.0.0/sdk/firebase-analytics.md
+++ b/docs/pages/versions/v44.0.0/sdk/firebase-analytics.md
@@ -6,7 +6,6 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-44/packages/expo-firebase-
 import APISection from '~/components/plugins/APISection';
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { Terminal } from '~/ui/components/Snippet';
 import { InlineCode } from '~/components/base/code';
 
 > **This is the only Firebase Analytics package for React Native that has universal platform support (iOS, Android, Web, and Electron).**
@@ -26,13 +25,7 @@ When using the web platform, you'll also need to run `expo install firebase`, wh
 
 ### With native Firebase SDK
 
-If you are using `expo-firebase-analytics` with React Native Firebase, you'll have to install the native Firebase SDK using the `expo install` command:
-
-<Terminal cmd={["$ expo install @react-native-firebase/app"]} />
-
-This will ensure that the `@react-native-firebase/app` dependency version is compatible with the Expo SDK version your project uses.
-
-Also, make sure that you have React Native Firebase set up correctly in your project. For more information on how to configure it, see [using the native Firebase SDK](/guides/setup-native-firebase/#setup).
+If you are using [React Native Firebase](https://rnfirebase.io/) in your project, you should use [`@react-native-firebase/analytics`](https://rnfirebase.io/analytics/usage) package provided by the library. For more information on how to configure the native Firebase, see [using the native Firebase SDK](/guides/setup-native-firebase/).
 
 ## Expo Go: Limitations & configuration
 

--- a/docs/pages/versions/v44.0.0/sdk/firebase-recaptcha.md
+++ b/docs/pages/versions/v44.0.0/sdk/firebase-recaptcha.md
@@ -24,13 +24,7 @@ Additionally, you'll also need to install the webview using `expo install react-
 
 ### With native Firebase SDK
 
-If you are using `expo-firebase-recaptcha` with React Native Firebase, you'll have to install the native Firebase SDK using the `expo install` command:
-
-<Terminal cmd={["$ expo install @react-native-firebase/app"]} />
-
-This will ensure that the `@react-native-firebase/app` dependency version is compatible with the Expo SDK version your project uses.
-
-Also, make sure that you have React Native Firebase set up correctly in your project. For more information on how to configure it, see [using the native Firebase SDK](/guides/setup-native-firebase/#setup).
+If you are using [React Native Firebase](https://rnfirebase.io/) in your project, you should use [`@react-native-firebase/auth`](https://rnfirebase.io/auth/phone-auth) package provided by the library. For more information on how to configure the native Firebase, see [using the native Firebase SDK](/guides/setup-native-firebase/).
 
 ### Basic usage
 

--- a/docs/pages/versions/v45.0.0/sdk/firebase-analytics.md
+++ b/docs/pages/versions/v45.0.0/sdk/firebase-analytics.md
@@ -7,7 +7,6 @@ packageName: 'expo-firebase-analytics'
 import APISection from '~/components/plugins/APISection';
 import {APIInstallSection} from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { Terminal } from '~/ui/components/Snippet';
 import { InlineCode } from '~/components/base/code';
 
 > **This is the only Firebase Analytics package for React Native that has universal platform support (iOS, Android, Web, and Electron).**
@@ -27,13 +26,7 @@ When using the web platform, you'll also need to run `expo install firebase`, wh
 
 ### With native Firebase SDK
 
-If you are using `expo-firebase-analytics` with React Native Firebase, you'll have to install the native Firebase SDK using the `expo install` command:
-
-<Terminal cmd={["$ expo install @react-native-firebase/app"]} />
-
-This will ensure that the `@react-native-firebase/app` dependency version is compatible with the Expo SDK version your project uses.
-
-Also, make sure that you have React Native Firebase set up correctly in your project. For more information on how to configure it, see [using the native Firebase SDK](/guides/setup-native-firebase/#setup).
+If you are using [React Native Firebase](https://rnfirebase.io/) in your project, you should use [`@react-native-firebase/analytics`](https://rnfirebase.io/analytics/usage) package provided by the library. For more information on how to configure the native Firebase, see [using the native Firebase SDK](/guides/setup-native-firebase/).
 
 ### Expo Go: Limitations & configuration
 

--- a/docs/pages/versions/v45.0.0/sdk/firebase-recaptcha.md
+++ b/docs/pages/versions/v45.0.0/sdk/firebase-recaptcha.md
@@ -25,13 +25,7 @@ Additionally, you'll also need to install the webview using `expo install react-
 
 ### With native Firebase SDK
 
-If you are using `expo-firebase-recaptcha` with React Native Firebase, you'll have to install the native Firebase SDK using the `expo install` command:
-
-<Terminal cmd={["$ expo install @react-native-firebase/app"]} />
-
-This will ensure that the `@react-native-firebase/app`dependency version is compatible with the Expo SDK version your project uses.
-
-Also, make sure that you have React Native Firebase set up correctly in your project. For more information on how to configure it, see [using the native Firebase SDK](/guides/setup-native-firebase/#setup).
+If you are using [React Native Firebase](https://rnfirebase.io/) in your project, you should use [`@react-native-firebase/auth`](https://rnfirebase.io/auth/phone-auth) package provided by the library. For more information on how to configure the native Firebase, see [using the native Firebase SDK](/guides/setup-native-firebase/).
 
 ### Basic usage
 


### PR DESCRIPTION
# Why

As discussed on Slack, version compatibility is only applicable to SDK 46.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR reverts the changes of #19130 to recommend using React Native Firebase packages for SDK 45, 44, and 43 for both `expo-firebase-analytics` and `expo-firebase-recaptcha`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested by running `docs` locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
