### PR TITLE
[modules][Android] Introduce either types for function arguments

### DIFF
--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIFunctionsTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIFunctionsTest.kt
@@ -10,6 +10,7 @@ import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.typedarray.Float32Array
 import expo.modules.kotlin.typedarray.Int32Array
 import expo.modules.kotlin.typedarray.Int8Array
+import expo.modules.kotlin.types.Either
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Test
 
@@ -455,5 +456,26 @@ class JSIFunctionsTest {
       evaluateScript("ExpoModules.TestModule.jsObjectArray([{'foo':'foo'}, {'bar':'bar'}])")
       Truth.assertThat(wasCalled).isTrue()
     }
+  }
+
+  @Test
+  fun either_should_be_convertible() = withJSIInterop(
+    inlineModule {
+      Name("TestModule")
+      Function("eitherFirst") { either: Either<Int, String> ->
+        Truth.assertThat(either.`is`(Int::class)).isTrue()
+        either.get(Int::class)
+      }
+      Function("eitherSecond") { either: Either<Int, String> ->
+        Truth.assertThat(either.`is`(String::class)).isTrue()
+        either.get(String::class)
+      }
+    }
+  ) {
+    val int = evaluateScript("ExpoModules.TestModule.eitherFirst(123)").getDouble().toInt()
+    val string = evaluateScript("ExpoModules.TestModule.eitherSecond('expo')").getString()
+
+    Truth.assertThat(int).isEqualTo(123)
+    Truth.assertThat(string).isEqualTo("expo")
   }
 }

--- a/packages/expo-modules-core/android/src/main/cpp/types/ExpectedType.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/types/ExpectedType.cpp
@@ -87,4 +87,10 @@ std::string ExpectedType::getJClassString(bool allowsPrimitives) {
   }
   return "java/lang/Object";
 }
+
+jni::local_ref<jni::JArrayClass<SingleType>::javaobject> ExpectedType::getPossibleTypes() {
+  static const auto method = getClass()->getMethod<jni::local_ref<jni::JArrayClass<SingleType>::javaobject>()>(
+    "getPossibleTypes");
+  return method(self());
+}
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/types/ExpectedType.h
+++ b/packages/expo-modules-core/android/src/main/cpp/types/ExpectedType.h
@@ -43,5 +43,7 @@ public:
    * If the allowsPrimitives is set to true type like int will be represented as a primitives.
    */
   std::string getJClassString(bool allowsPrimitives = false);
+
+  jni::local_ref<jni::JArrayClass<SingleType>::javaobject> getPossibleTypes();
 };
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.cpp
@@ -246,9 +246,9 @@ jobject PolyFrontendConverter::convert(
 }
 
 PrimitiveArrayFrontendConverter::PrimitiveArrayFrontendConverter(
-  jni::local_ref<ExpectedType::javaobject> expectedType
+  jni::local_ref<SingleType::javaobject> expectedType
 ) {
-  auto parameterExpectedType = expectedType->getFirstType()->getFirstParameterType();
+  auto parameterExpectedType = expectedType->getFirstParameterType();
   parameterType = parameterExpectedType->getCombinedTypes();
   parameterConverter = FrontendConverterProvider::instance()->obtainConverter(
     parameterExpectedType
@@ -333,10 +333,10 @@ bool PrimitiveArrayFrontendConverter::canConvert(jsi::Runtime &rt, const jsi::Va
 }
 
 ListFrontendConverter::ListFrontendConverter(
-  jni::local_ref<ExpectedType::javaobject> expectedType
+  jni::local_ref<SingleType::javaobject> expectedType
 ) : parameterConverter(
   FrontendConverterProvider::instance()->obtainConverter(
-    expectedType->getFirstType()->getFirstParameterType()
+    expectedType->getFirstParameterType()
   )
 ) {}
 
@@ -366,10 +366,10 @@ bool ListFrontendConverter::canConvert(jsi::Runtime &rt, const jsi::Value &value
 }
 
 MapFrontendConverter::MapFrontendConverter(
-  jni::local_ref<ExpectedType::javaobject> expectedType
+  jni::local_ref<SingleType::javaobject> expectedType
 ) : valueConverter(
   FrontendConverterProvider::instance()->obtainConverter(
-    expectedType->getFirstType()->getFirstParameterType()
+    expectedType->getFirstParameterType()
   )
 ) {}
 

--- a/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.h
+++ b/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.h
@@ -12,8 +12,7 @@ namespace jsi = facebook::jsi;
 
 namespace expo {
 class JSIInteropModuleRegistry;
-
-class ExpectedType;
+class SingleType;
 
 /**
  * A base interface for all frontend converter classes - converters that cast jsi values into JNI objects.
@@ -237,7 +236,7 @@ private:
 class PrimitiveArrayFrontendConverter : public FrontendConverter {
 public:
   PrimitiveArrayFrontendConverter(
-    jni::local_ref<jni::JavaClass<ExpectedType>::javaobject> expectedType
+    jni::local_ref<jni::JavaClass<SingleType>::javaobject> expectedType
   );
 
   jobject convert(
@@ -270,7 +269,7 @@ private:
 class ListFrontendConverter : public FrontendConverter {
 public:
   ListFrontendConverter(
-    jni::local_ref<jni::JavaClass<ExpectedType>::javaobject> expectedType
+    jni::local_ref<jni::JavaClass<SingleType>::javaobject> expectedType
   );
 
   jobject convert(
@@ -294,7 +293,7 @@ private:
 class MapFrontendConverter : public FrontendConverter {
 public:
   MapFrontendConverter(
-    jni::local_ref<jni::JavaClass<ExpectedType>::javaobject> expectedType
+    jni::local_ref<jni::JavaClass<SingleType>::javaobject> expectedType
   );
 
   jobject convert(

--- a/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverterProvider.h
+++ b/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverterProvider.h
@@ -32,10 +32,15 @@ public:
   /**
    * Obtains a converter for an expected type.
    */
-  std::shared_ptr<FrontendConverter> obtainConverter(jni::local_ref<ExpectedType> expectedType);
-
+  std::shared_ptr<FrontendConverter> obtainConverter(
+    jni::local_ref<jni::JavaClass<ExpectedType>::javaobject> expectedType
+  );
 private:
   FrontendConverterProvider() = default;
+
+  std::shared_ptr<FrontendConverter> obtainConverterForSingleType(
+    jni::local_ref<jni::JavaClass<SingleType>::javaobject> expectedType
+  );
 
   std::unordered_map<CppType, std::shared_ptr<FrontendConverter>> simpleConverters;
 };

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/CppType.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/CppType.kt
@@ -1,5 +1,10 @@
 package expo.modules.kotlin.jni
 
+import com.facebook.react.bridge.ReadableArray
+import com.facebook.react.bridge.ReadableMap
+import expo.modules.kotlin.typedarray.TypedArray
+import kotlin.reflect.KClass
+
 private var nextValue = 0
 
 private fun nextValue(): Int = (1 shl nextValue).also { nextValue++ }
@@ -7,19 +12,19 @@ private fun nextValue(): Int = (1 shl nextValue).also { nextValue++ }
 /**
  * Enum that represents Cpp types. Objects of those types can be obtained via JNI.
  */
-enum class CppType(val value: Int = nextValue()) {
-  NONE(0),
-  DOUBLE,
-  INT,
-  FLOAT,
-  BOOLEAN,
-  STRING,
-  JS_OBJECT,
-  JS_VALUE,
-  READABLE_ARRAY,
-  READABLE_MAP,
-  TYPED_ARRAY,
-  PRIMITIVE_ARRAY,
-  LIST,
-  MAP;
+enum class CppType(val clazz: KClass<*>, val value: Int = nextValue()) {
+  NONE(Nothing::class, 0),
+  DOUBLE(Double::class),
+  INT(Int::class),
+  FLOAT(Float::class),
+  BOOLEAN(Boolean::class),
+  STRING(String::class),
+  JS_OBJECT(JavaScriptObject::class),
+  JS_VALUE(JavaScriptValue::class),
+  READABLE_ARRAY(ReadableArray::class),
+  READABLE_MAP(ReadableMap::class),
+  TYPED_ARRAY(TypedArray::class),
+  PRIMITIVE_ARRAY(Array::class),
+  LIST(List::class),
+  MAP(Map::class);
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/ExpectedType.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/ExpectedType.kt
@@ -7,7 +7,7 @@ import expo.modules.core.interfaces.DoNotStrip
  */
 @DoNotStrip
 class SingleType(
-  expectedCppType: CppType,
+  internal val expectedCppType: CppType,
   /**
    * Types of generic parameters.
    */
@@ -16,7 +16,7 @@ class SingleType(
   /**
    * The representation of the type.
    */
-  val cppType: Int = expectedCppType.value
+  val cppType get() = expectedCppType.value
 
   /**
    * A convenient property to return the type of the first parameter.
@@ -49,6 +49,12 @@ class ExpectedType(
    * A convenient property to return the first of possible types.
    */
   val firstType = possibleTypes.first()
+
+  operator fun plus(other: ExpectedType): ExpectedType {
+    return ExpectedType(
+      *this.possibleTypes, *other.possibleTypes
+    )
+  }
 
   companion object {
     fun forPrimitiveArray(parameterType: CppType) = ExpectedType(

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/Either.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/Either.kt
@@ -1,0 +1,58 @@
+@file:Suppress("UNCHECKED_CAST")
+
+package expo.modules.kotlin.types
+
+import kotlin.reflect.KClass
+
+open class Either<FirstType : Any, SecondType : Any>(
+  @PublishedApi
+  internal val value: Any
+) {
+  @JvmName("isFirstType")
+  fun `is`(type: KClass<FirstType>): Boolean {
+    return type.isInstance(value)
+  }
+
+  @JvmName("isSecondType")
+  fun `is`(type: KClass<SecondType>): Boolean {
+    return type.isInstance(value)
+  }
+
+  @JvmName("getFirstType")
+  fun get(type: KClass<FirstType>) = value as FirstType
+
+  @JvmName("getSecondType")
+  fun get(type: KClass<SecondType>) = value as SecondType
+
+  fun first() = value as FirstType
+
+  fun second() = value as SecondType
+}
+
+open class EitherOfThree<FirstType : Any, SecondType : Any, ThirdType : Any>(
+  value: Any
+) : Either<FirstType, SecondType>(value) {
+  @JvmName("isThirdType")
+  fun `is`(type: KClass<ThirdType>): Boolean {
+    return type.isInstance(value)
+  }
+
+  @JvmName("getThirdType")
+  fun get(type: KClass<ThirdType>) = value as ThirdType
+
+  fun third() = value as ThirdType
+}
+
+class EitherOfFour<FirstType : Any, SecondType : Any, ThirdType : Any, FourthType : Any>(
+  value: Any
+) : EitherOfThree<FirstType, SecondType, ThirdType>(value) {
+  @JvmName("isFourthType")
+  fun `is`(type: KClass<FourthType>): Boolean {
+    return type.isInstance(value)
+  }
+
+  @JvmName("getFourthType")
+  fun get(type: KClass<FourthType>) = value as FourthType
+
+  fun fourth() = value as FourthType
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EitherTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EitherTypeConverter.kt
@@ -1,0 +1,155 @@
+package expo.modules.kotlin.types
+
+import expo.modules.kotlin.jni.ExpectedType
+import expo.modules.kotlin.jni.SingleType
+import kotlin.reflect.KType
+
+class EitherTypeConverter<FirstType : Any, SecondType : Any>(
+  converterProvider: TypeConverterProvider,
+  eitherType: KType,
+) : TypeConverter<Either<FirstType, SecondType>>(eitherType.isMarkedNullable) {
+  private val firstJavaType = requireNotNull(eitherType.arguments.getOrNull(0)?.type)
+  private val secondJavaType = requireNotNull(eitherType.arguments.getOrNull(1)?.type)
+  private val firstTypeConverter = converterProvider.obtainTypeConverter(
+    firstJavaType
+  )
+  private val secondTypeConverter = converterProvider.obtainTypeConverter(
+    secondJavaType
+  )
+  private val firstType = firstTypeConverter.getCppRequiredTypes()
+  private val secondType = secondTypeConverter.getCppRequiredTypes()
+
+  override fun convertNonOptional(value: Any): Either<FirstType, SecondType> {
+    val convertValueIfNeeded = Convert@{ types: Array<out SingleType>, converter: TypeConverter<*> ->
+      for (singleType in types) {
+        if (singleType.expectedCppType.clazz.isInstance(value)) {
+          return@Convert if (firstTypeConverter.isTrivial()) {
+            Either<FirstType, SecondType>(value)
+          } else {
+            Either(converter.convert(value)!!)
+          }
+        }
+      }
+      null
+    }
+
+    return convertValueIfNeeded(
+      firstType.possibleTypes,
+      firstTypeConverter
+    ) ?: convertValueIfNeeded(
+      secondType.possibleTypes,
+      secondTypeConverter
+    )
+      ?: throw TypeCastException("Cannot cast '$value' to 'Either<$firstJavaType, $secondJavaType>'")
+  }
+
+  override fun getCppRequiredTypes(): ExpectedType = firstType + secondType
+}
+
+class EitherOfThreeTypeConverter<FirstType : Any, SecondType : Any, ThirdType : Any>(
+  converterProvider: TypeConverterProvider,
+  eitherType: KType,
+) : TypeConverter<EitherOfThree<FirstType, SecondType, ThirdType>>(eitherType.isMarkedNullable) {
+  private val firstJavaType = requireNotNull(eitherType.arguments.getOrNull(0)?.type)
+  private val secondJavaType = requireNotNull(eitherType.arguments.getOrNull(1)?.type)
+  private val thirdJavaType = requireNotNull(eitherType.arguments.getOrNull(2)?.type)
+  private val firstTypeConverter = converterProvider.obtainTypeConverter(
+    firstJavaType
+  )
+  private val secondTypeConverter = converterProvider.obtainTypeConverter(
+    secondJavaType
+  )
+  private val thirdTypeConverter = converterProvider.obtainTypeConverter(
+    thirdJavaType
+  )
+  private val firstType = firstTypeConverter.getCppRequiredTypes()
+  private val secondType = secondTypeConverter.getCppRequiredTypes()
+  private val thirdType = thirdTypeConverter.getCppRequiredTypes()
+
+  override fun convertNonOptional(value: Any): EitherOfThree<FirstType, SecondType, ThirdType> {
+    val convertValueIfNeeded = Convert@{ types: Array<out SingleType>, converter: TypeConverter<*> ->
+      for (singleType in types) {
+        if (singleType.expectedCppType.clazz.isInstance(value)) {
+          return@Convert if (firstTypeConverter.isTrivial()) {
+            EitherOfThree<FirstType, SecondType, ThirdType>(value)
+          } else {
+            EitherOfThree(converter.convert(value)!!)
+          }
+        }
+      }
+      null
+    }
+
+    return convertValueIfNeeded(
+      firstType.possibleTypes,
+      firstTypeConverter
+    ) ?: convertValueIfNeeded(
+      secondType.possibleTypes,
+      secondTypeConverter
+    ) ?: convertValueIfNeeded(
+      thirdType.possibleTypes,
+      thirdTypeConverter
+    )
+      ?: throw TypeCastException("Cannot cast '$value' to 'EitherOfThree<$firstJavaType, $secondJavaType, $thirdJavaType>'")
+  }
+
+  override fun getCppRequiredTypes(): ExpectedType = firstType + secondType + thirdType
+}
+
+class EitherOfFourTypeConverter<FirstType : Any, SecondType : Any, ThirdType : Any, FourthType : Any>(
+  converterProvider: TypeConverterProvider,
+  eitherType: KType,
+) : TypeConverter<EitherOfFour<FirstType, SecondType, ThirdType, FourthType>>(eitherType.isMarkedNullable) {
+  private val firstJavaType = requireNotNull(eitherType.arguments.getOrNull(0)?.type)
+  private val secondJavaType = requireNotNull(eitherType.arguments.getOrNull(1)?.type)
+  private val thirdJavaType = requireNotNull(eitherType.arguments.getOrNull(2)?.type)
+  private val fourthJavaType = requireNotNull(eitherType.arguments.getOrNull(3)?.type)
+  private val firstTypeConverter = converterProvider.obtainTypeConverter(
+    firstJavaType
+  )
+  private val secondTypeConverter = converterProvider.obtainTypeConverter(
+    secondJavaType
+  )
+  private val thirdTypeConverter = converterProvider.obtainTypeConverter(
+    thirdJavaType
+  )
+  private val fourthTypeConverter = converterProvider.obtainTypeConverter(
+    fourthJavaType
+  )
+  private val firstType = firstTypeConverter.getCppRequiredTypes()
+  private val secondType = secondTypeConverter.getCppRequiredTypes()
+  private val thirdType = thirdTypeConverter.getCppRequiredTypes()
+  private val fourthType = fourthTypeConverter.getCppRequiredTypes()
+
+  override fun convertNonOptional(value: Any): EitherOfFour<FirstType, SecondType, ThirdType, FourthType> {
+    val convertValueIfNeeded = Convert@{ types: Array<out SingleType>, converter: TypeConverter<*> ->
+      for (singleType in types) {
+        if (singleType.expectedCppType.clazz.isInstance(value)) {
+          return@Convert if (firstTypeConverter.isTrivial()) {
+            EitherOfFour<FirstType, SecondType, ThirdType, FourthType>(value)
+          } else {
+            EitherOfFour(converter.convert(value)!!)
+          }
+        }
+      }
+      null
+    }
+
+    return convertValueIfNeeded(
+      firstType.possibleTypes,
+      firstTypeConverter
+    ) ?: convertValueIfNeeded(
+      secondType.possibleTypes,
+      secondTypeConverter
+    ) ?: convertValueIfNeeded(
+      thirdType.possibleTypes,
+      thirdTypeConverter
+    ) ?: convertValueIfNeeded(
+      fourthType.possibleTypes,
+      fourthTypeConverter
+    )
+      ?: throw TypeCastException("Cannot cast '$value' to 'EitherOfFourth<$firstJavaType, $secondJavaType, $thirdJavaType, $fourthJavaType>'")
+  }
+
+  override fun getCppRequiredTypes(): ExpectedType = firstType + secondType + thirdType
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/PairTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/PairTypeConverter.kt
@@ -58,13 +58,7 @@ class PairTypeConverter(
   }
 
   override fun getCppRequiredTypes(): ExpectedType = ExpectedType(
-    SingleType(
-      CppType.READABLE_ARRAY,
-      arrayOf(
-        converters[0].getCppRequiredTypes(),
-        converters[1].getCppRequiredTypes()
-      )
-    )
+    SingleType(CppType.READABLE_ARRAY)
   )
 
   override fun isTrivial() = false

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverter.kt
@@ -18,7 +18,7 @@ abstract class TypeConverter<Type : Any>(
   /**
    * Tries to convert from [Any]? (can be also [Dynamic]) to the desired type.
    */
-  fun convert(value: Any?): Type? {
+  open fun convert(value: Any?): Type? {
     if (value == null || value is Dynamic && value.isNull) {
       if (isOptional) {
         return null

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
@@ -91,6 +91,16 @@ object TypeConverterProviderImpl : TypeConverterProvider {
       return EnumTypeConverter(kClass as KClass<Enum<*>>, type.isMarkedNullable)
     }
 
+    if (kClass.isSubclassOf(Either::class)) {
+      if (kClass.isSubclassOf(EitherOfFour::class)) {
+        return EitherOfFourTypeConverter<Any, Any, Any, Any>(this, type)
+      }
+      if (kClass.isSubclassOf(EitherOfThree::class)) {
+        return EitherOfThreeTypeConverter<Any, Any, Any>(this, type)
+      }
+      return EitherTypeConverter<Any, Any>(this, type)
+    }
+
     val cachedConverter = cachedRecordConverters[kClass]
     if (cachedConverter != null) {
       return cachedConverter

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
@@ -91,16 +91,6 @@ object TypeConverterProviderImpl : TypeConverterProvider {
       return EnumTypeConverter(kClass as KClass<Enum<*>>, type.isMarkedNullable)
     }
 
-    if (kClass.isSubclassOf(Either::class)) {
-      if (kClass.isSubclassOf(EitherOfFour::class)) {
-        return EitherOfFourTypeConverter<Any, Any, Any, Any>(this, type)
-      }
-      if (kClass.isSubclassOf(EitherOfThree::class)) {
-        return EitherOfThreeTypeConverter<Any, Any, Any>(this, type)
-      }
-      return EitherTypeConverter<Any, Any>(this, type)
-    }
-
     val cachedConverter = cachedRecordConverters[kClass]
     if (cachedConverter != null) {
       return cachedConverter
@@ -110,6 +100,16 @@ object TypeConverterProviderImpl : TypeConverterProvider {
       val converter = RecordTypeConverter<Record>(this, type)
       cachedRecordConverters[kClass] = converter
       return converter
+    }
+
+    if (kClass.isSubclassOf(Either::class)) {
+      if (kClass.isSubclassOf(EitherOfFour::class)) {
+        return EitherOfFourTypeConverter<Any, Any, Any, Any>(this, type)
+      }
+      if (kClass.isSubclassOf(EitherOfThree::class)) {
+        return EitherOfThreeTypeConverter<Any, Any, Any>(this, type)
+      }
+      return EitherTypeConverter<Any, Any>(this, type)
     }
 
     throw MissingTypeConverter(type)

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/PairTypeConverterTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/PairTypeConverterTest.kt
@@ -5,9 +5,7 @@ package expo.modules.kotlin.types
 import com.facebook.react.bridge.DynamicFromObject
 import com.facebook.react.bridge.JavaOnlyArray
 import com.google.common.truth.Truth
-import expo.modules.kotlin.jni.CppType
 import org.junit.Test
-import kotlin.reflect.typeOf
 
 class PairTypeConverterTest {
   @Test
@@ -40,23 +38,5 @@ class PairTypeConverterTest {
     Truth.assertThat(converted).isInstanceOf(Pair::class.java)
     Truth.assertThat((converted as Pair<*, *>).first).isEqualTo(1)
     Truth.assertThat(converted.second).isEqualTo("second")
-  }
-
-  @Test
-  fun `should return correct ExpectedType`() {
-    val converter = TypeConverterProviderImpl.obtainTypeConverter(typeOf<Pair<Int, String>>())
-
-    val expectedType = converter.getCppRequiredTypes()
-
-    Truth.assertThat(expectedType.combinedTypes).isEqualTo(CppType.READABLE_ARRAY.value)
-    Truth.assertThat(expectedType.possibleTypes).hasLength(1)
-
-    val singleType = expectedType.possibleTypes.first()
-
-    val firstType = singleType.parameterTypes!![0]
-    val secondType = singleType.parameterTypes!![1]
-
-    Truth.assertThat(firstType.combinedTypes).isEqualTo(CppType.INT.value)
-    Truth.assertThat(secondType.combinedTypes).isEqualTo(CppType.STRING.value)
   }
 }


### PR DESCRIPTION
# Why

Closes ENG-6339.
A follow-up to the https://github.com/expo/expo/pull/19035.

# How

- Added an `Either` type and corresponding converter 
- Introduced some changes into the frontend converter code to support the dynamic creation of the `PolyFrontendConverter` to support passing polymorphic values (values that can be represented by multiple js types)

# Test Plan

- unit tests ✅