### PR TITLE
[docs] add info about new image with XCode 14 installed

### DIFF
--- a/docs/pages/build-reference/infrastructure.md
+++ b/docs/pages/build-reference/infrastructure.md
@@ -162,6 +162,22 @@ When selecting an image for the build you can use the full name provided below o
   enableImmutableInstalls: false
   ```
 
+#### Image `macos-monterey-12.6-xcode-14.0`
+
+<Collapsible summary="Details">
+
+- macOS Monterey 12.6
+- Xcode 14.0 (14A309)
+- Node.js 16.13.2
+- Yarn 1.22.17
+- pnpm 7.11.0
+- npm 8.1.2
+- fastlane 2.210.0
+- CocoaPods 1.11.3
+- Ruby 2.7
+
+</Collapsible>
+
 #### Image `macos-monterey-12.4-xcode-13.4` (alias `latest`)
 
 <Collapsible summary="Details">

--- a/docs/pages/build-reference/infrastructure.md
+++ b/docs/pages/build-reference/infrastructure.md
@@ -162,7 +162,7 @@ When selecting an image for the build you can use the full name provided below o
   enableImmutableInstalls: false
   ```
 
-#### Image `macos-monterey-12.6-xcode-14.0`
+#### Image `macos-monterey-12.6-xcode-14.0` (alias `latest`)
 
 <Collapsible summary="Details">
 
@@ -178,7 +178,7 @@ When selecting an image for the build you can use the full name provided below o
 
 </Collapsible>
 
-#### Image `macos-monterey-12.4-xcode-13.4` (alias `latest`)
+#### Image `macos-monterey-12.4-xcode-13.4` (alias `default`)
 
 <Collapsible summary="Details">
 
@@ -194,7 +194,7 @@ When selecting an image for the build you can use the full name provided below o
 
 </Collapsible>
 
-#### Image `macos-monterey-12.3-xcode-13.3` (alias `default`)
+#### Image `macos-monterey-12.3-xcode-13.3`
 
 <Collapsible summary="Details">
 


### PR DESCRIPTION
# Why

Companion to https://github.com/expo/eas-cli/pull/1365

# How

Add info about the new image with XCode 14 installed, update the latest and default images

I will merge it once https://github.com/expo/eas-cli/pull/1365 is merged

# Test Plan

Test locally

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
