### PR TITLE
[docs][Authentication]: Update Facebook's Custom App section in authentication guide

### DIFF
--- a/docs/pages/guides/authentication.md
+++ b/docs/pages/guides/authentication.md
@@ -519,13 +519,12 @@ You must use the proxy service in the Expo Go app because `exp://` cannot be add
 
 #### Custom Apps
 
-Consider using the [`react-native-fbsdk-next`](https://github.com/thebergamo/react-native-fbsdk-next) module with [Config Plugins](/guides/config-plugins/) for native auth as it supports some nonstandard OAuth features implemented by Facebook.
+For SDK 46 and above, we recommend using [`react-native-fbsdk-next`](https://github.com/thebergamo/react-native-fbsdk-next#expo-installation) module with [Development Builds](https://docs.expo.dev/development/introduction/).
 
-- The custom scheme provided by Facebook is `fb` followed by the **project ID** (ex: `fb145668956753819`):
-- Add `facebookScheme: 'fb<YOUR FBID>'` to your **app.config.js** or **app.json**. Example: `{ facebookScheme: "fb145668956753819" }` (notice the `fb` prefix).
-- You'll need to make a new native build to add this redirect URI into your app's **AndroidManifest.xml** and **Info.plist**:
-  - iOS: `eas build` or `expo build:ios`.
-  - Android: `eas build` or `expo build:android`.
+You'll have to rebuild after adding the `react-native-fbsdk-next` as a config plugin to **app.json** or **app.config.js**:
+
+- iOS: `eas build` or `npx expo run:ios`
+- Android: `eas build` or `npx expo run:android`
 - **Bare:**
   - Regenerate your native projects with `expo prebuild`, or add the redirects manually with `npx uri-scheme add fb<YOUR FBID>`
   - Rebuild the projects with `yarn ios` & `yarn android`


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Refs ENG-6354

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR updates the Custom Apps section under Authentication -> Facebook to redirect the user to use `react-native-facebook-sdk` library as a config plugin with Development builds.


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes can be tested by running `docs/` locally and then visiting: http://localhost:3002/guides/authentication/#custom-apps

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
