### PR TITLE
[docs] fix scrollbars appearance in components on Windows

### DIFF
--- a/docs/components/DocumentationNestedScrollLayout.tsx
+++ b/docs/components/DocumentationNestedScrollLayout.tsx
@@ -1,44 +1,11 @@
 // NOTE(jim):
 // GETTING NESTED SCROLL RIGHT IS DELICATE BUSINESS. THEREFORE THIS COMPONENT
 // IS THE ONLY PLACE WHERE SCROLL CODE SHOULD BE HANDLED. THANKS.
-import { Global, css } from '@emotion/react';
+import { css } from '@emotion/react';
 import { breakpoints, theme } from '@expo/styleguide';
 import * as React from 'react';
 
-import * as Constants from '~/constants/theme';
 import { SidebarHead } from '~/ui/components/Sidebar/SidebarHead';
-
-const STYLES_GLOBAL = css`
-  html {
-    background: ${theme.background.default};
-  }
-
-  @media screen and (max-width: ${Constants.breakpoints.mobile}) {
-    html {
-      /* width */
-      ::-webkit-scrollbar {
-        width: 6px;
-      }
-
-      /* Track */
-      ::-webkit-scrollbar-track {
-        backgroundColor: transparent,
-        cursor: pointer,
-      }
-
-      /* Handle */
-      ::-webkit-scrollbar-thumb {
-        background: ${theme.background.tertiary};
-        border-radius: 10px;
-      }
-
-      /* Handle on hover */
-      ::-webkit-scrollbar-thumb:hover {
-        background: ${theme.background.quaternary};
-      }
-    }
-  }
-`;
 
 const STYLES_CONTAINER = css`
   width: 100%;
@@ -255,7 +222,6 @@ export default class DocumentationNestedScrollLayout extends React.Component<Pro
 
     return (
       <div css={STYLES_CONTAINER}>
-        <Global styles={STYLES_GLOBAL} />
         <div css={STYLES_HEADER}>{header}</div>
         <div css={STYLES_CONTENT}>
           <div css={[STYLES_SIDEBAR, STYLES_LEFT]}>

--- a/docs/global-styles/extras.ts
+++ b/docs/global-styles/extras.ts
@@ -1,7 +1,62 @@
 import { css } from '@emotion/react';
-import { theme } from '@expo/styleguide';
+import { darkTheme, theme, typography } from '@expo/styleguide';
 
 export const globalExtras = css`
+  html {
+    background: ${theme.background.default};
+  }
+
+  body {
+    ${typography.body.paragraph}
+    font-family: ${typography.fontFaces.regular};
+    text-rendering: optimizeLegibility;
+    line-height: 1;
+  }
+
+  ::selection {
+    background-color: ${theme.highlight.accent};
+    color: ${theme.text.default};
+  }
+  
+  ::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+
+  ::-webkit-scrollbar-track {
+    backgroundColor: transparent,
+    cursor: pointer,
+  }
+
+  ::-webkit-scrollbar-thumb {
+    background: ${theme.background.tertiary};
+    border-radius: 10px;
+  }
+
+  ::-webkit-scrollbar-thumb:hover {
+    background: ${theme.background.quaternary};
+  }
+  
+  html[data-expo-theme="light"] div[class*="SnippetContent"] {
+    ::-webkit-scrollbar-thumb {
+      background: ${darkTheme.background.quaternary};
+    }
+    
+    ::-webkit-scrollbar-thumb:hover {
+      background: ${darkTheme.icon.secondary};
+    }
+  }
+
+  a {
+    -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+    color: ${theme.link.default};
+  }
+
+  img {
+    max-width: 768px;
+    width: 100%;
+  }
+
   img.wide-image {
     max-width: 900px;
   }

--- a/docs/global-styles/reset.ts
+++ b/docs/global-styles/reset.ts
@@ -1,5 +1,4 @@
 import { css } from '@emotion/react';
-import { theme, typography } from '@expo/styleguide';
 
 export const globalReset = css`
   html,
@@ -103,27 +102,5 @@ export const globalReset = css`
   nav,
   section {
     display: block;
-  }
-
-  img {
-    max-width: 768px;
-    width: 100%;
-  }
-
-  a {
-    -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
-    color: ${theme.link.default};
-  }
-
-  body {
-    ${typography.body.paragraph}
-    font-family: ${typography.fontFaces.regular};
-    text-rendering: optimizeLegibility;
-    line-height: 1;
-  }
-
-  ::selection {
-    background-color: ${theme.highlight.accent};
-    color: ${theme.text.default};
   }
 `;


### PR DESCRIPTION
# Why

Refs https://github.com/expo/expo/pull/18947#issuecomment-1247983592

This PR fixes the appearance of scrollbars inside the components on Windows (points 1. and 2. in second section of the referenced comment).

# How

Ensure that we use custom scrollbars for all components, not only for the scrollable lists.

Few overwrites have been added for the `Terminal` to force always dark appearance and ensure that scrollbars are visible in light mode.

Additionally I have moved all non reset related CSS code to `extras` file and reordered the rules a bit.

# Test Plan

The changes have been tested by running docs website locally.

## Preview

<img width="506" alt="x" src="https://user-images.githubusercontent.com/719641/190875608-4f294858-b094-479d-a4a4-2039c5f73356.png">

<img width="487" alt="Screenshot 2022-09-17 223704" src="https://user-images.githubusercontent.com/719641/190875610-fd583b59-7622-4a5e-852b-4c9d372b56f7.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
