### PR TITLE
[docs] add missing hide placeholders

### DIFF
--- a/docs/pages/guides/icons.md
+++ b/docs/pages/guides/icons.md
@@ -29,7 +29,7 @@ export default function App() {
   );
 }
 
-/* @hide */
+/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,

--- a/docs/pages/versions/unversioned/sdk/background-fetch.md
+++ b/docs/pages/versions/unversioned/sdk/background-fetch.md
@@ -114,14 +114,13 @@ export default function BackgroundFetchScreen() {
   );
 }
 
-/* @hide */
+/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   screen: {
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
   },
-
   textContainer: {
     margin: 10,
   },
@@ -129,7 +128,6 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
   },
 });
-
 /* @end */
 ```
 

--- a/docs/pages/versions/unversioned/sdk/background-fetch.md
+++ b/docs/pages/versions/unversioned/sdk/background-fetch.md
@@ -47,7 +47,8 @@ TaskManager.defineTask(BACKGROUND_FETCH_TASK, async () => {
   return BackgroundFetch.BackgroundFetchResult.NewData;
 });
 
-// 2. Register the task at some point in your app by providing the same name, and some configuration options for how the background fetch should behave
+// 2. Register the task at some point in your app by providing the same name,
+// and some configuration options for how the background fetch should behave
 // Note: This does NOT need to be in the global scope and CAN be used in your React components!
 async function registerBackgroundFetchAsync() {
   return BackgroundFetch.registerTaskAsync(BACKGROUND_FETCH_TASK, {

--- a/docs/pages/versions/v43.0.0/sdk/background-fetch.md
+++ b/docs/pages/versions/v43.0.0/sdk/background-fetch.md
@@ -112,14 +112,13 @@ export default function BackgroundFetchScreen() {
   );
 }
 
-/* @hide */
+/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   screen: {
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
   },
-
   textContainer: {
     margin: 10,
   },
@@ -127,7 +126,6 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
   },
 });
-
 /* @end */
 ```
 

--- a/docs/pages/versions/v43.0.0/sdk/background-fetch.md
+++ b/docs/pages/versions/v43.0.0/sdk/background-fetch.md
@@ -45,7 +45,8 @@ TaskManager.defineTask(BACKGROUND_FETCH_TASK, async () => {
   return BackgroundFetch.BackgroundFetchResult.NewData;
 });
 
-// 2. Register the task at some point in your app by providing the same name, and some configuration options for how the background fetch should behave
+// 2. Register the task at some point in your app by providing the same name,
+// and some configuration options for how the background fetch should behave
 // Note: This does NOT need to be in the global scope and CAN be used in your React components!
 async function registerBackgroundFetchAsync() {
   return BackgroundFetch.registerTaskAsync(BACKGROUND_FETCH_TASK, {

--- a/docs/pages/versions/v44.0.0/sdk/background-fetch.md
+++ b/docs/pages/versions/v44.0.0/sdk/background-fetch.md
@@ -114,14 +114,13 @@ export default function BackgroundFetchScreen() {
   );
 }
 
-/* @hide */
+/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   screen: {
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
   },
-
   textContainer: {
     margin: 10,
   },
@@ -129,7 +128,6 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
   },
 });
-
 /* @end */
 ```
 

--- a/docs/pages/versions/v44.0.0/sdk/background-fetch.md
+++ b/docs/pages/versions/v44.0.0/sdk/background-fetch.md
@@ -47,7 +47,8 @@ TaskManager.defineTask(BACKGROUND_FETCH_TASK, async () => {
   return BackgroundFetch.BackgroundFetchResult.NewData;
 });
 
-// 2. Register the task at some point in your app by providing the same name, and some configuration options for how the background fetch should behave
+// 2. Register the task at some point in your app by providing the same name,
+// and some configuration options for how the background fetch should behave
 // Note: This does NOT need to be in the global scope and CAN be used in your React components!
 async function registerBackgroundFetchAsync() {
   return BackgroundFetch.registerTaskAsync(BACKGROUND_FETCH_TASK, {

--- a/docs/pages/versions/v45.0.0/sdk/background-fetch.md
+++ b/docs/pages/versions/v45.0.0/sdk/background-fetch.md
@@ -113,14 +113,13 @@ export default function BackgroundFetchScreen() {
   );
 }
 
-/* @hide */
+/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   screen: {
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
   },
-
   textContainer: {
     margin: 10,
   },
@@ -128,7 +127,6 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
   },
 });
-
 /* @end */
 ```
 

--- a/docs/pages/versions/v45.0.0/sdk/background-fetch.md
+++ b/docs/pages/versions/v45.0.0/sdk/background-fetch.md
@@ -46,7 +46,8 @@ TaskManager.defineTask(BACKGROUND_FETCH_TASK, async () => {
   return BackgroundFetch.BackgroundFetchResult.NewData;
 });
 
-// 2. Register the task at some point in your app by providing the same name, and some configuration options for how the background fetch should behave
+// 2. Register the task at some point in your app by providing the same name,
+// and some configuration options for how the background fetch should behave
 // Note: This does NOT need to be in the global scope and CAN be used in your React components!
 async function registerBackgroundFetchAsync() {
   return BackgroundFetch.registerTaskAsync(BACKGROUND_FETCH_TASK, {

--- a/docs/pages/versions/v46.0.0/sdk/background-fetch.md
+++ b/docs/pages/versions/v46.0.0/sdk/background-fetch.md
@@ -114,14 +114,13 @@ export default function BackgroundFetchScreen() {
   );
 }
 
-/* @hide */
+/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   screen: {
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
   },
-
   textContainer: {
     margin: 10,
   },
@@ -129,7 +128,6 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
   },
 });
-
 /* @end */
 ```
 

--- a/docs/pages/versions/v46.0.0/sdk/background-fetch.md
+++ b/docs/pages/versions/v46.0.0/sdk/background-fetch.md
@@ -47,7 +47,8 @@ TaskManager.defineTask(BACKGROUND_FETCH_TASK, async () => {
   return BackgroundFetch.BackgroundFetchResult.NewData;
 });
 
-// 2. Register the task at some point in your app by providing the same name, and some configuration options for how the background fetch should behave
+// 2. Register the task at some point in your app by providing the same name,
+// and some configuration options for how the background fetch should behave
 // Note: This does NOT need to be in the global scope and CAN be used in your React components!
 async function registerBackgroundFetchAsync() {
   return BackgroundFetch.registerTaskAsync(BACKGROUND_FETCH_TASK, {


### PR DESCRIPTION
# Why

While working on review changes in MDX PR I have spotted that some code block includes an additional new line at the end. It looks like when `@hide` is used without the placeholder Prism add a new line anyway.

I plan to attempt to fix this behavior in MDX PR, but I feel like adding some placeholders instead (where possible) is a better solution.

# How

This PR adds the missing `@hide` placeholders, and fixes the whitespaces in few code blocks.

# Test Plan

The change have been tested by running docs website locally.

## Preview

<img width="647" alt="Screenshot 2022-09-17 235015" src="https://user-images.githubusercontent.com/719641/190877515-b2090c5d-37ce-48a5-ad90-8f2d1f9c325f.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
