### PR TITLE
[docs][FirebaseRecaptcha]: Remove TypeScript references from example

### DIFF
--- a/docs/pages/versions/unversioned/sdk/firebase-recaptcha.md
+++ b/docs/pages/versions/unversioned/sdk/firebase-recaptcha.md
@@ -23,7 +23,7 @@ Additionally, you'll also need to install the webview using `npx expo install re
 
 ## Usage
 
-### With native Firebase SDK
+### With React Native Firebase
 
 If you are using `expo-firebase-recaptcha` with React Native Firebase, you'll have to install the native SDK using the `npx expo install` command:
 
@@ -125,7 +125,7 @@ export default function App() {
     <View style={{ padding: 20, marginTop: 50 }}>
       <FirebaseRecaptchaVerifierModal
         ref={recaptchaVerifier}
-        firebaseConfig={app.options}
+        firebaseConfig={firebaseConfig}
         // attemptInvisibleVerification
       />
       <Text style={{ marginTop: 20 }}>Enter phone number</Text>
@@ -136,7 +136,7 @@ export default function App() {
         autoCompleteType="tel"
         keyboardType="phone-pad"
         textContentType="telephoneNumber"
-        onChangeText={phoneNumber => setPhoneNumber(phoneNumber)}
+        onChangeText={setPhoneNumber}
       />
       <Button
         title="Send Verification Code"
@@ -309,7 +309,7 @@ export default function PhoneAuthScreen() {
           style={styles.textInput}
           editable={!!verificationId}
           placeholder="123456"
-          onChangeText={verificationCode => setVerificationCode(verificationCode)}
+          onChangeText={setVerificationCode}
         />
         <Button
           title="Confirm Verification Code"

--- a/docs/pages/versions/unversioned/sdk/firebase-recaptcha.md
+++ b/docs/pages/versions/unversioned/sdk/firebase-recaptcha.md
@@ -241,7 +241,7 @@ try {
 }
 
 // Firebase references
-let app = getApp();
+const app = getApp();
 const auth = getAuth(app);
 
 export default function PhoneAuthScreen() {
@@ -274,7 +274,7 @@ export default function PhoneAuthScreen() {
           textContentType="telephoneNumber"
           placeholder="+1 999 999 9999"
           editable={!verificationId}
-          onChangeText={phoneNumber => setPhoneNumber(phoneNumber)}
+          onChangeText={setPhoneNumber}
         />
         <Button
           title={`${verificationId ? 'Resend' : 'Send'} Verification Code`}
@@ -420,7 +420,7 @@ import { FirebaseRecaptcha, FirebaseRecaptchaVerifier } from 'expo-firebase-reca
 function CustomPhoneAuthScreen () {
   const [recaptchaToken, setRecaptchaToken] = React.useState('');
 
-  async function onPressSendVerificationCode () {
+  async function onPressSendVerificationCode() {
 
     // Create an application verifier from the reCAPTCHA token
     if (!recaptchaToken) return;

--- a/docs/pages/versions/unversioned/sdk/firebase-recaptcha.md
+++ b/docs/pages/versions/unversioned/sdk/firebase-recaptcha.md
@@ -101,7 +101,7 @@ import { getAuth, PhoneAuthProvider, signInWithCredential } from 'firebase/auth'
 
 // Firebase references
 const app = getApp();
-const auth = getAuth();
+const auth = getAuth(app);
 
 // Double-check that we can run the example
 if (!app?.options || Platform.OS === 'web') {
@@ -212,7 +212,7 @@ buttonTitle='Try the Full Phone Authentication on Snack'
 label='Firebase Full Phone Auth'
 dependencies={['expo-firebase-recaptcha', 'firebase', 'react-native-webview']}>
 
-```tsx
+```jsx
 import * as React from 'react';
 import {
   Text,
@@ -225,12 +225,12 @@ import {
   Platform,
 } from 'react-native';
 import * as FirebaseRecaptcha from 'expo-firebase-recaptcha';
-import { initializeApp } from 'firebase/app';
+import { initializeApp, getApp } from 'firebase/app';
 import { getAuth, PhoneAuthProvider, signInWithCredential } from 'firebase/auth';
 
-// PROVIDE VALID FIREBASE >=9.x.x CONFIG HERE
+// Add your Firebase >=9.x.x config here
 // https://firebase.google.com/docs/web/setup
-const FIREBASE_CONFIG: any = {
+const firebaseConfig = {
   /*apiKey: "api-key",
   authDomain: "project-id.firebaseapp.com",
   databaseURL: "https://project-id.firebaseio.com",
@@ -250,7 +250,8 @@ try {
 }
 
 // Firebase references
-const auth = getAuth();
+let app = getApp();
+const auth = getAuth(app);
 
 export default function PhoneAuthScreen() {
   const recaptchaVerifier = React.useRef(null);
@@ -282,7 +283,7 @@ export default function PhoneAuthScreen() {
           textContentType="telephoneNumber"
           placeholder="+1 999 999 9999"
           editable={!verificationId}
-          onChangeText={(phoneNumber: string) => setPhoneNumber(phoneNumber)}
+          onChangeText={phoneNumber => setPhoneNumber(phoneNumber)}
         />
         <Button
           title={`${verificationId ? 'Resend' : 'Send'} Verification Code`}
@@ -295,7 +296,6 @@ export default function PhoneAuthScreen() {
               setVerificationId('');
               const verificationId = await phoneProvider.verifyPhoneNumber(
                 phoneNumber,
-                // @ts-ignore
                 recaptchaVerifier.current
               );
               setVerifyInProgress(false);
@@ -318,7 +318,7 @@ export default function PhoneAuthScreen() {
           style={styles.textInput}
           editable={!!verificationId}
           placeholder="123456"
-          onChangeText={(verificationCode: string) => setVerificationCode(verificationCode)}
+          onChangeText={verificationCode => setVerificationCode(verificationCode)}
         />
         <Button
           title="Confirm Verification Code"
@@ -346,7 +346,7 @@ export default function PhoneAuthScreen() {
       {!isConfigValid && (
         <View style={styles.overlay} pointerEvents="none">
           <Text style={styles.overlayText}>
-            To get started, set a valid FIREBASE_CONFIG in App.tsx.
+            To get started, set a valid firebaseConfig in App.js.
           </Text>
         </View>
       )}
@@ -410,7 +410,7 @@ const styles = StyleSheet.create({
 
 ## Customizing the appearance
 
-`<FirebaseRecaptchaVerifierModal>` has limited customisation options. You cannot change its appearance, but you can change the **title** and the **cancel-label**.
+`<FirebaseRecaptchaVerifierModal>` has limited customization options. You cannot change its appearance, but you can change the **title** and the **cancel-label**.
 
 ```js
 <FirebaseRecaptchaVerifierModal
@@ -438,7 +438,7 @@ class CustomPhoneAuthScreen extends React.Component {
     if (!recaptchaToken) return;
     const applicationVerifier = new FirebaseRecaptchaVerifier(recaptchaToken);
 
-    // Start phone autenthication
+    // Start phone authentication
     const phoneProvider = new PhoneAuthProvider();
     const verificationId = await phoneProvider.verifyPhoneNumber(
       '+0123456789',

--- a/docs/pages/versions/unversioned/sdk/firebase-recaptcha.md
+++ b/docs/pages/versions/unversioned/sdk/firebase-recaptcha.md
@@ -214,16 +214,7 @@ dependencies={['expo-firebase-recaptcha', 'firebase', 'react-native-webview']}>
 
 ```jsx
 import * as React from 'react';
-import {
-  Text,
-  View,
-  StyleSheet,
-  TextInput,
-  Button,
-  Alert,
-  ActivityIndicator,
-  Platform,
-} from 'react-native';
+import { Text, View, StyleSheet, TextInput, Button, Alert, ActivityIndicator } from 'react-native';
 import * as FirebaseRecaptcha from 'expo-firebase-recaptcha';
 import { initializeApp, getApp } from 'firebase/app';
 import { getAuth, PhoneAuthProvider, signInWithCredential } from 'firebase/auth';
@@ -421,20 +412,17 @@ const styles = StyleSheet.create({
 />
 ```
 
-If you want a custom look & feel, then create your own `<Modal>` or display the `<FirebaseRecaptcha>` component inline in your screen. Make sure to reserve enough space for the widget as it can not only display the compact "I'm not a robot" UI but also the **full verification UI requiring users to select images**.
+If you want a custom look and feel, then create your own `<Modal>` or display the `<FirebaseRecaptcha>` component inline in your screen. Make sure to reserve enough space for the widget as it can not only display the compact "I'm not a robot" UI but also the **full verification UI requiring users to select images**.
 
-```tsx
+```jsx
 import { FirebaseRecaptcha, FirebaseRecaptchaVerifier } from 'expo-firebase-recaptcha';
 
-class CustomPhoneAuthScreen extends React.Component {
-  state = {
-    recaptchaToken: ''
-  };
+function CustomPhoneAuthScreen () {
+  const [recaptchaToken, setRecaptchaToken] = React.useState('');
 
-  onPressSendVerificationCode = async () => {
+  async function onPressSendVerificationCode () {
 
     // Create an application verifier from the reCAPTCHA token
-    const { recaptchaToken } = this.state;
     if (!recaptchaToken) return;
     const applicationVerifier = new FirebaseRecaptchaVerifier(recaptchaToken);
 
@@ -446,18 +434,15 @@ class CustomPhoneAuthScreen extends React.Component {
     );
   };
 
-  render() {
-    return (
-      <FirebaseRecaptcha
-        style={...}
-        firebaseConfig={...}
+  return (
+    <FirebaseRecaptcha
+      style={...}
+      firebaseConfig={...}
 
-        // Store the reCAPTCHA token when it has been verified
-        onVerify={recaptchaToken => this.setState({
-          recaptchaToken
-        })} />
-    );
-  }
+      // Store the reCAPTCHA token when it has been verified
+      onVerify={token => setRecaptchaToken(token)}
+      />
+  );
 }
 ```
 
@@ -499,7 +484,7 @@ The reCAPTCHA v3 widget displayed inside a web-view.
 - **languageCode (string)** -- Language to display the reCAPTCHA challenge in. For a list of possible languages, see [reCAPTCHA Language Codes](https://developers.google.com/recaptcha/docs/language).
 - **onLoad (function)** -- A callback that is invoked when the widget has been loaded.
 - **onError (function)** -- A callback that is invoked when the widget failed to load.
-- **onVerify (function)** -- A callback that is invoked when reCAPTCHA has verified that the user is not a bot. The callback is provided with the reCAPTCHA token string. Example `onVerify={(recaptchaToken: string) => this.setState({recaptchaToken})}`.
+- **onVerify (function)** -- A callback that is invoked when reCAPTCHA has verified that the user is not a bot. The callback is provided with the reCAPTCHA token string. Example `onVerify={token => setRecaptchaToken(token)}`.
 - **onFullChallenge (function)** -- A callback that is invoked when reCAPTCHA shows the full challenge experience.
 - **invisible (boolean)** -- When `true` renders an `invisible` reCAPTCHA widget. The widget can then be triggered to verify invisibly by setting the `verify` prop to `true`.
 - **verify (boolean)** -- Use this in combination with `invisible=true` so start the verification process.

--- a/docs/pages/versions/v46.0.0/sdk/firebase-recaptcha.md
+++ b/docs/pages/versions/v46.0.0/sdk/firebase-recaptcha.md
@@ -101,7 +101,7 @@ import { getAuth, PhoneAuthProvider, signInWithCredential } from 'firebase/auth'
 
 // Firebase references
 const app = getApp();
-const auth = getAuth();
+const auth = getAuth(app);
 
 // Double-check that we can run the example
 if (!app?.options || Platform.OS === 'web') {
@@ -212,7 +212,7 @@ buttonTitle='Try the Full Phone Authentication on Snack'
 label='Firebase Full Phone Auth'
 dependencies={['expo-firebase-recaptcha', 'firebase', 'react-native-webview']}>
 
-```tsx
+```jsx
 import * as React from 'react';
 import {
   Text,
@@ -225,12 +225,12 @@ import {
   Platform,
 } from 'react-native';
 import * as FirebaseRecaptcha from 'expo-firebase-recaptcha';
-import { initializeApp } from 'firebase/app';
+import { initializeApp, getApp } from 'firebase/app';
 import { getAuth, PhoneAuthProvider, signInWithCredential } from 'firebase/auth';
 
-// PROVIDE VALID FIREBASE >=9.x.x CONFIG HERE
+// Add your Firebase >=9.x.x config here
 // https://firebase.google.com/docs/web/setup
-const FIREBASE_CONFIG: any = {
+const firebaseConfig = {
   /*apiKey: "api-key",
   authDomain: "project-id.firebaseapp.com",
   databaseURL: "https://project-id.firebaseio.com",
@@ -250,7 +250,8 @@ try {
 }
 
 // Firebase references
-const auth = getAuth();
+let app = getApp();
+const auth = getAuth(app);
 
 export default function PhoneAuthScreen() {
   const recaptchaVerifier = React.useRef(null);
@@ -282,7 +283,7 @@ export default function PhoneAuthScreen() {
           textContentType="telephoneNumber"
           placeholder="+1 999 999 9999"
           editable={!verificationId}
-          onChangeText={(phoneNumber: string) => setPhoneNumber(phoneNumber)}
+          onChangeText={phoneNumber => setPhoneNumber(phoneNumber)}
         />
         <Button
           title={`${verificationId ? 'Resend' : 'Send'} Verification Code`}
@@ -295,7 +296,6 @@ export default function PhoneAuthScreen() {
               setVerificationId('');
               const verificationId = await phoneProvider.verifyPhoneNumber(
                 phoneNumber,
-                // @ts-ignore
                 recaptchaVerifier.current
               );
               setVerifyInProgress(false);
@@ -318,7 +318,7 @@ export default function PhoneAuthScreen() {
           style={styles.textInput}
           editable={!!verificationId}
           placeholder="123456"
-          onChangeText={(verificationCode: string) => setVerificationCode(verificationCode)}
+          onChangeText={verificationCode => setVerificationCode(verificationCode)}
         />
         <Button
           title="Confirm Verification Code"
@@ -346,7 +346,7 @@ export default function PhoneAuthScreen() {
       {!isConfigValid && (
         <View style={styles.overlay} pointerEvents="none">
           <Text style={styles.overlayText}>
-            To get started, set a valid FIREBASE_CONFIG in App.tsx.
+            To get started, set a valid firebaseConfig in App.js.
           </Text>
         </View>
       )}
@@ -410,7 +410,7 @@ const styles = StyleSheet.create({
 
 ## Customizing the appearance
 
-`<FirebaseRecaptchaVerifierModal>` has limited customisation options. You cannot change its appearance, but you can change the **title** and the **cancel-label**.
+`<FirebaseRecaptchaVerifierModal>` has limited customization options. You cannot change its appearance, but you can change the **title** and the **cancel-label**.
 
 ```js
 <FirebaseRecaptchaVerifierModal
@@ -438,7 +438,7 @@ class CustomPhoneAuthScreen extends React.Component {
     if (!recaptchaToken) return;
     const applicationVerifier = new FirebaseRecaptchaVerifier(recaptchaToken);
 
-    // Start phone autenthication
+    // Start phone authentication
     const phoneProvider = new PhoneAuthProvider();
     const verificationId = await phoneProvider.verifyPhoneNumber(
       '+0123456789',

--- a/docs/pages/versions/v46.0.0/sdk/firebase-recaptcha.md
+++ b/docs/pages/versions/v46.0.0/sdk/firebase-recaptcha.md
@@ -214,16 +214,7 @@ dependencies={['expo-firebase-recaptcha', 'firebase', 'react-native-webview']}>
 
 ```jsx
 import * as React from 'react';
-import {
-  Text,
-  View,
-  StyleSheet,
-  TextInput,
-  Button,
-  Alert,
-  ActivityIndicator,
-  Platform,
-} from 'react-native';
+import { Text, View, StyleSheet, TextInput, Button, Alert, ActivityIndicator } from 'react-native';
 import * as FirebaseRecaptcha from 'expo-firebase-recaptcha';
 import { initializeApp, getApp } from 'firebase/app';
 import { getAuth, PhoneAuthProvider, signInWithCredential } from 'firebase/auth';
@@ -421,20 +412,17 @@ const styles = StyleSheet.create({
 />
 ```
 
-If you want a custom look & feel, then create your own `<Modal>` or display the `<FirebaseRecaptcha>` component inline in your screen. Make sure to reserve enough space for the widget as it can not only display the compact "I'm not a robot" UI but also the **full verification UI requiring users to select images**.
+If you want a custom look and feel, then create your own `<Modal>` or display the `<FirebaseRecaptcha>` component inline in your screen. Make sure to reserve enough space for the widget as it can not only display the compact "I'm not a robot" UI but also the **full verification UI requiring users to select images**.
 
-```tsx
+```jsx
 import { FirebaseRecaptcha, FirebaseRecaptchaVerifier } from 'expo-firebase-recaptcha';
 
-class CustomPhoneAuthScreen extends React.Component {
-  state = {
-    recaptchaToken: ''
-  };
+function CustomPhoneAuthScreen () {
+  const [recaptchaToken, setRecaptchaToken] = React.useState('');
 
-  onPressSendVerificationCode = async () => {
+  async function onPressSendVerificationCode () {
 
     // Create an application verifier from the reCAPTCHA token
-    const { recaptchaToken } = this.state;
     if (!recaptchaToken) return;
     const applicationVerifier = new FirebaseRecaptchaVerifier(recaptchaToken);
 
@@ -446,18 +434,15 @@ class CustomPhoneAuthScreen extends React.Component {
     );
   };
 
-  render() {
-    return (
-      <FirebaseRecaptcha
-        style={...}
-        firebaseConfig={...}
+  return (
+    <FirebaseRecaptcha
+      style={...}
+      firebaseConfig={...}
 
-        // Store the reCAPTCHA token when it has been verified
-        onVerify={recaptchaToken => this.setState({
-          recaptchaToken
-        })} />
-    );
-  }
+      // Store the reCAPTCHA token when it has been verified
+      onVerify={token => setRecaptchaToken(token)}
+      />
+  );
 }
 ```
 
@@ -499,7 +484,7 @@ The reCAPTCHA v3 widget displayed inside a web-view.
 - **languageCode (string)** -- Language to display the reCAPTCHA challenge in. For a list of possible languages, see [reCAPTCHA Language Codes](https://developers.google.com/recaptcha/docs/language).
 - **onLoad (function)** -- A callback that is invoked when the widget has been loaded.
 - **onError (function)** -- A callback that is invoked when the widget failed to load.
-- **onVerify (function)** -- A callback that is invoked when reCAPTCHA has verified that the user is not a bot. The callback is provided with the reCAPTCHA token string. Example `onVerify={(recaptchaToken: string) => this.setState({recaptchaToken})}`.
+- **onVerify (function)** -- A callback that is invoked when reCAPTCHA has verified that the user is not a bot. The callback is provided with the reCAPTCHA token string. Example `onVerify={token => setRecaptchaToken(token)}`.
 - **onFullChallenge (function)** -- A callback that is invoked when reCAPTCHA shows the full challenge experience.
 - **invisible (boolean)** -- When `true` renders an `invisible` reCAPTCHA widget. The widget can then be triggered to verify invisibly by setting the `verify` prop to `true`.
 - **verify (boolean)** -- Use this in combination with `invisible=true` so start the verification process.


### PR DESCRIPTION
# Why

Refs ENG-6369

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

- By updating the Phone authentication example to use JavaScript file format. Also, this makes the code easy to copy and paste. Snack also opens the file in `.js` extension.
- Fixes other typos.
- Changes implemented only for SDK 46.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running the `docs/` locally and visiting http://localhost:3002/versions/latest/sdk/firebase-recaptcha/.


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
