### PR TITLE
[docs] Symlinked native modules

### DIFF
--- a/docs/pages/workflow/customizing.md
+++ b/docs/pages/workflow/customizing.md
@@ -80,8 +80,6 @@ module.exports = {
 ``` 
 - You can then run `npx expo prebuild` and your symlinked native module will be auto-linked correctly 🎉
 
-For example you might scaffold a new custom native module with  to add a native module in a `libs` folder within your project using the following command: `cd ./libs/ && npx create-react-native-library react-native-module`. You can then run `yarn link` within the `reac-native-module` directory and then symlink this to your project by running `yarn link react-native-module` in your project directory. 
-
 ## Releasing apps with custom native code to production
 
 When you're ready to ship your app, you can [build it with EAS Build](/build/introduction) exactly the same as you were building it before adding custom native code. Alternatively, you can archive and sign it locally. Unsurprisingly, we recommend EAS Build!

--- a/docs/pages/workflow/customizing.md
+++ b/docs/pages/workflow/customizing.md
@@ -49,6 +49,39 @@ If you've decided that you want to roll your app back to being fully managed (no
 
 Once you have customized the native code in your project, you can use the [`expo-dev-client`](/development/introduction) package to create a development build and retain the convenience of working with just JavaScript and/or TypeScript in Expo Go. You can create a development build for your managed or bare workflow by following [our guide](/development/getting-started).
 
+### Integrating project-specific, symlinked native modules
+
+In some cases you may want to add a custom native module specific to you project. Ideally this custom native module should live within your project, however, if you are using the managed workflow you cannot safely add the project-specific module's native code in the `ios` or `android` directories. Instead the solution is to house any project-specific native module within a local `libs` folder and then symlink this module to your project. This can be achieved as follows:
+
+- First of all create a folder to house your modules under e.g. `mkdir libs`
+- `cd ./libs` and then use [React Native Builder Bob](https://github.com/callstack/react-native-builder-bob) to scaffold a native module with the following command: `npx create-react-native-library react-native-module`
+- Follow the CLI setup for your native module and remove any unecessary parts of the native module e.g. the `example` project, `lefthook` and its `.git` folder
+- Once complete you can symlink this to your project by running `cd ./libs/react-native-module && yarn link && cd ../.. && yarn link react-native-module`
+- Within your project you should now be able to import `react-native-module`
+- However, in order for auto-linking to work correctly you need to specify the location of your native module's podspec file in a `react-native.config.js` file as follows:
+```js
+// react-native.config.js
+const path = require("path");
+
+module.exports = {
+  dependencies: {
+    "react-native-module": {
+      platforms: {
+        ios: {
+          podspecPath: path.join(
+            __dirname,
+            "./libs/react-native-module/react-native-module.podspec"
+          ),
+        },
+      },
+    },
+  },
+};
+``` 
+- You can then run `npx expo prebuild` and your symlinked native module will be auto-linked correctly 🎉
+
+For example you might scaffold a new custom native module with  to add a native module in a `libs` folder within your project using the following command: `cd ./libs/ && npx create-react-native-library react-native-module`. You can then run `yarn link` within the `reac-native-module` directory and then symlink this to your project by running `yarn link react-native-module` in your project directory. 
+
 ## Releasing apps with custom native code to production
 
 When you're ready to ship your app, you can [build it with EAS Build](/build/introduction) exactly the same as you were building it before adding custom native code. Alternatively, you can archive and sign it locally. Unsurprisingly, we recommend EAS Build!


### PR DESCRIPTION
# Why

This PR adds a section to the docs describing how you can integrate symlinked packages into your project with the managed workflow. I recently had to do this for a project that was using the managed workflow and needed to integrate a custom native module specific to their project (a Vision Camera frame processor plugin). I couldn't put the native module into the `ios` or `android` directories as this invalidates the managed workflow and so decided to symlink it as a local package in the project, but it ended up requiring some extra config to get it to find the package's podspec and auto-link correctly. Thought I'd share this into the docs as it seems like it could be a fairly consistent use case and stops people having to create a private NPM package (as I did originally) when integrating custom native code in the managed workflow.

This was a quick braindump so feel free to massively correct any of the steps or if there is a better way I've somehow missed I'd love to know 🙌


<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
