### PR TITLE
[modules][Android] Hide `Either` type behind opt-in flag

### DIFF
--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIFunctionsTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIFunctionsTest.kt
@@ -3,6 +3,7 @@
 package expo.modules.kotlin.jni
 
 import com.google.common.truth.Truth
+import expo.modules.kotlin.apifetures.EitherType
 import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.exception.JavaScriptEvaluateException
 import expo.modules.kotlin.records.Field
@@ -458,6 +459,7 @@ class JSIFunctionsTest {
     }
   }
 
+  @OptIn(EitherType::class)
   @Test
   fun either_should_be_convertible() = withJSIInterop(
     inlineModule {

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIFunctionsTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIFunctionsTest.kt
@@ -3,7 +3,7 @@
 package expo.modules.kotlin.jni
 
 import com.google.common.truth.Truth
-import expo.modules.kotlin.apifetures.EitherType
+import expo.modules.kotlin.apifeatures.EitherType
 import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.exception.JavaScriptEvaluateException
 import expo.modules.kotlin.records.Field

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/apifeatures/Features.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/apifeatures/Features.kt
@@ -1,4 +1,4 @@
-package expo.modules.kotlin.apifetures
+package expo.modules.kotlin.apifeatures
 
 @RequiresOptIn(message = "This API is experimental. It may be changed in the future without notice.", level = RequiresOptIn.Level.WARNING)
 @Retention(AnnotationRetention.BINARY)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/apifetures/Fetures.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/apifetures/Fetures.kt
@@ -1,0 +1,6 @@
+package expo.modules.kotlin.apifetures
+
+@RequiresOptIn(message = "This API is experimental. It may be changed in the future without notice.", level = RequiresOptIn.Level.WARNING)
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+annotation class EitherType

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/Either.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/Either.kt
@@ -2,7 +2,7 @@
 
 package expo.modules.kotlin.types
 
-import expo.modules.kotlin.apifetures.EitherType
+import expo.modules.kotlin.apifeatures.EitherType
 import kotlin.reflect.KClass
 
 @EitherType

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/Either.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/Either.kt
@@ -2,8 +2,10 @@
 
 package expo.modules.kotlin.types
 
+import expo.modules.kotlin.apifetures.EitherType
 import kotlin.reflect.KClass
 
+@EitherType
 open class Either<FirstType : Any, SecondType : Any>(
   @PublishedApi
   internal val value: Any
@@ -29,6 +31,7 @@ open class Either<FirstType : Any, SecondType : Any>(
   fun second() = value as SecondType
 }
 
+@EitherType
 open class EitherOfThree<FirstType : Any, SecondType : Any, ThirdType : Any>(
   value: Any
 ) : Either<FirstType, SecondType>(value) {
@@ -43,6 +46,7 @@ open class EitherOfThree<FirstType : Any, SecondType : Any, ThirdType : Any>(
   fun third() = value as ThirdType
 }
 
+@EitherType
 class EitherOfFour<FirstType : Any, SecondType : Any, ThirdType : Any, FourthType : Any>(
   value: Any
 ) : EitherOfThree<FirstType, SecondType, ThirdType>(value) {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EitherTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EitherTypeConverter.kt
@@ -1,6 +1,6 @@
 package expo.modules.kotlin.types
 
-import expo.modules.kotlin.apifetures.EitherType
+import expo.modules.kotlin.apifeatures.EitherType
 import expo.modules.kotlin.jni.ExpectedType
 import expo.modules.kotlin.jni.SingleType
 import kotlin.reflect.KType

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EitherTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EitherTypeConverter.kt
@@ -1,9 +1,11 @@
 package expo.modules.kotlin.types
 
+import expo.modules.kotlin.apifetures.EitherType
 import expo.modules.kotlin.jni.ExpectedType
 import expo.modules.kotlin.jni.SingleType
 import kotlin.reflect.KType
 
+@EitherType
 class EitherTypeConverter<FirstType : Any, SecondType : Any>(
   converterProvider: TypeConverterProvider,
   eitherType: KType,
@@ -46,6 +48,7 @@ class EitherTypeConverter<FirstType : Any, SecondType : Any>(
   override fun getCppRequiredTypes(): ExpectedType = firstType + secondType
 }
 
+@EitherType
 class EitherOfThreeTypeConverter<FirstType : Any, SecondType : Any, ThirdType : Any>(
   converterProvider: TypeConverterProvider,
   eitherType: KType,
@@ -96,6 +99,7 @@ class EitherOfThreeTypeConverter<FirstType : Any, SecondType : Any, ThirdType : 
   override fun getCppRequiredTypes(): ExpectedType = firstType + secondType + thirdType
 }
 
+@EitherType
 class EitherOfFourTypeConverter<FirstType : Any, SecondType : Any, ThirdType : Any, FourthType : Any>(
   converterProvider: TypeConverterProvider,
   eitherType: KType,

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
@@ -6,6 +6,7 @@ import android.graphics.Color
 import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import expo.modules.kotlin.apifetures.EitherType
 import expo.modules.kotlin.exception.MissingTypeConverter
 import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
@@ -102,6 +103,11 @@ object TypeConverterProviderImpl : TypeConverterProvider {
       return converter
     }
 
+    return handelEither(type, kClass) ?: throw MissingTypeConverter(type)
+  }
+
+  @OptIn(EitherType::class)
+  private fun handelEither(type: KType, kClass: KClass<*>): TypeConverter<*>? {
     if (kClass.isSubclassOf(Either::class)) {
       if (kClass.isSubclassOf(EitherOfFour::class)) {
         return EitherOfFourTypeConverter<Any, Any, Any, Any>(this, type)
@@ -112,7 +118,7 @@ object TypeConverterProviderImpl : TypeConverterProvider {
       return EitherTypeConverter<Any, Any>(this, type)
     }
 
-    throw MissingTypeConverter(type)
+    return null
   }
 
   private fun createCashedConverters(isOptional: Boolean): Map<KType, TypeConverter<*>> {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
@@ -6,7 +6,7 @@ import android.graphics.Color
 import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
-import expo.modules.kotlin.apifetures.EitherType
+import expo.modules.kotlin.apifeatures.EitherType
 import expo.modules.kotlin.exception.MissingTypeConverter
 import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType


### PR DESCRIPTION
# Why

Hides the `Either` type behind the opt-in flag. 
To indicate that some parts of Sweet API are experimental and may change, I would like to use the opt-in mechanism introduced by Kotlin. In that way, we inform users that some functions may be dangerous to use.

# How

You can read more about experimental flags here: https://kotlinlang.org/docs/opt-in-requirements.html.

# Test Plan

- not required ✅