### PR TITLE
[modules][Android] Remove temporary array when passing args to java

### DIFF
--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.h
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.h
@@ -118,16 +118,15 @@ private:
   jsi::Function createPromiseBody(
     jsi::Runtime &runtime,
     JSIInteropModuleRegistry *moduleRegistry,
-    std::vector<jobject> &&args
+    jobjectArray globalArgs
   );
 
-  std::vector<jobject> convertJSIArgsToJNI(
+  jobjectArray convertJSIArgsToJNI(
     JSIInteropModuleRegistry *moduleRegistry,
     JNIEnv *env,
     jsi::Runtime &rt,
     const jsi::Value *args,
-    size_t count,
-    bool returnGlobalReferences
+    size_t count
   );
 };
 } // namespace expo


### PR DESCRIPTION
# Why

Removes temporary array which was used to pass arguments from C++ to java.
By doing that I could reduce the number of global references that have to be created before calling the async function.

# Test Plan

- unit tests ✅
- bare-expo and NCL ✅