### PR TITLE
[docs] Update cellular to unify install and permissions

### DIFF
--- a/docs/components/plugins/ConfigSection/ConfigPluginProperties.tsx
+++ b/docs/components/plugins/ConfigSection/ConfigPluginProperties.tsx
@@ -7,41 +7,45 @@ import { APISectionPlatformTags } from '~/components/plugins/api/APISectionPlatf
 import { Cell, HeaderCell, Row, Table, TableHead } from '~/ui/components/Table';
 
 type Props = PropsWithChildren<{
-  properties: PluginProperty[];
+  properties?: PluginProperty[];
 }>;
 
 export const ConfigPluginProperties = ({ children, properties }: Props) => (
   <>
     <H3>Configurable properties</H3>
     {!!children && <P>{children}</P>}
-    <Table>
-      <TableHead>
-        <Row>
-          <HeaderCell>Name</HeaderCell>
-          <HeaderCell>Default</HeaderCell>
-          <HeaderCell>Description</HeaderCell>
-        </Row>
-      </TableHead>
-      <tbody>
-        {properties.map(property => (
-          <Row key={property.name}>
-            <Cell fitContent>
-              <InlineCode>{property.name}</InlineCode>
-            </Cell>
-            <Cell>{!property.default ? '-' : <InlineCode>{property.default}</InlineCode>}</Cell>
-            <Cell>
-              {!!property.platform && (
-                <APISectionPlatformTags
-                  prefix="Only for:"
-                  platforms={[{ text: property.platform, tag: 'platform' }]}
-                />
-              )}
-              {property.description}
-            </Cell>
+
+    {properties && properties.length === 0 && <P>No configurable properties.</P>}
+    {properties && properties.length > 0 && (
+      <Table>
+        <TableHead>
+          <Row>
+            <HeaderCell>Name</HeaderCell>
+            <HeaderCell>Default</HeaderCell>
+            <HeaderCell>Description</HeaderCell>
           </Row>
-        ))}
-      </tbody>
-    </Table>
+        </TableHead>
+        <tbody>
+          {properties.map(property => (
+            <Row key={property.name}>
+              <Cell fitContent>
+                <InlineCode>{property.name}</InlineCode>
+              </Cell>
+              <Cell>{!property.default ? '-' : <InlineCode>{property.default}</InlineCode>}</Cell>
+              <Cell>
+                {!!property.platform && (
+                  <APISectionPlatformTags
+                    prefix="Only for:"
+                    platforms={[{ text: property.platform, tag: 'platform' }]}
+                  />
+                )}
+                {property.description}
+              </Cell>
+            </Row>
+          ))}
+        </tbody>
+      </Table>
+    )}
   </>
 );
 

--- a/docs/pages/versions/unversioned/sdk/cellular.md
+++ b/docs/pages/versions/unversioned/sdk/cellular.md
@@ -5,7 +5,9 @@ packageName: 'expo-cellular'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import {APIInstallSection} from '~/components/plugins/InstallSection';
+import { APIInstallSection } from '~/components/plugins/InstallSection';
+import { AndroidPermissions } from '~/components/plugins/permissions';
+import { ConfigClassic, ConfigReactNative, ConfigPluginExample, ConfigPluginProperties } from '~/components/plugins/ConfigSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-cellular`** provides information about the user’s cellular service provider, such as its unique identifier, cellular connection type, and whether it allows VoIP calls on its network.
@@ -15,6 +17,48 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 ## Installation
 
 <APIInstallSection />
+
+## Configuration in app.json / app.config.js
+
+You can configure `expo-cellular` using its built-in [config plugin](../../../guides/config-plugins.md) if you use config plugins in your project ([EAS Build](../../../build/introduction.md) or `expo run:[android|ios]`).
+
+<ConfigClassic>
+
+Add the [`READ_PHONE_STATE`](#permissions) permissions to the [`permissions`](../config/app.md#permissions) list in the app manifest.
+
+</ConfigClassic>
+
+<ConfigReactNative>
+
+Learn how to configure the native projects in the [installation instructions in the `expo-cellular` repository](https://github.com/expo/expo/tree/main/packages/expo-cellular#installation-in-bare-react-native-projects).
+
+</ConfigReactNative>
+
+<ConfigPluginExample>
+
+```json
+{
+  "expo": {
+    "plugins": [
+      "expo-cellular"
+    ]
+  }
+}
+```
+
+</ConfigPluginExample>
+
+<ConfigPluginProperties properties={[]} />
+
+## Permissions
+
+### Android
+
+<AndroidPermissions permissions={['READ_PHONE_STATE']} />
+
+### iOS
+
+_No usage description required._
 
 ## API
 

--- a/docs/pages/versions/v43.0.0/sdk/cellular.md
+++ b/docs/pages/versions/v43.0.0/sdk/cellular.md
@@ -4,7 +4,9 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-43/packages/expo-cellular'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import { APIInstallSection } from '~/components/plugins/InstallSection';
+import { AndroidPermissions } from '~/components/plugins/permissions';
+import { ConfigClassic, ConfigReactNative, ConfigPluginExample, ConfigPluginProperties } from '~/components/plugins/ConfigSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-cellular`** provides information about the user’s cellular service provider, such as its unique identifier, cellular connection type, and whether it allows VoIP calls on its network.
@@ -13,7 +15,49 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 ## Installation
 
-<InstallSection packageName="expo-cellular" />
+<APIInstallSection />
+
+## Configuration in app.json / app.config.js
+
+You can configure `expo-cellular` using its built-in [config plugin](../../../guides/config-plugins.md) if you use config plugins in your project ([EAS Build](../../../build/introduction.md) or `expo run:[android|ios]`).
+
+<ConfigClassic>
+
+Add the [`READ_PHONE_STATE`](#permissions) permissions to the [`permissions`](../config/app.md#permissions) list in the app manifest.
+
+</ConfigClassic>
+
+<ConfigReactNative>
+
+Learn how to configure the native projects in the [installation instructions in the `expo-cellular` repository](https://github.com/expo/expo/tree/main/packages/expo-cellular#installation-in-bare-react-native-projects).
+
+</ConfigReactNative>
+
+<ConfigPluginExample>
+
+```json
+{
+  "expo": {
+    "plugins": [
+      "expo-cellular"
+    ]
+  }
+}
+```
+
+</ConfigPluginExample>
+
+<ConfigPluginProperties properties={[]} />
+
+## Permissions
+
+### Android
+
+<AndroidPermissions permissions={['READ_PHONE_STATE']} />
+
+### iOS
+
+_No usage description required._
 
 ## API
 

--- a/docs/pages/versions/v43.0.0/sdk/cellular.md
+++ b/docs/pages/versions/v43.0.0/sdk/cellular.md
@@ -1,6 +1,7 @@
 ---
 title: Cellular
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-43/packages/expo-cellular'
+packageName: expo-cellular
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/v44.0.0/sdk/cellular.md
+++ b/docs/pages/versions/v44.0.0/sdk/cellular.md
@@ -4,7 +4,9 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-44/packages/expo-cellular'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import InstallSection from '~/components/plugins/InstallSection';
+import { APIInstallSection } from '~/components/plugins/InstallSection';
+import { AndroidPermissions } from '~/components/plugins/permissions';
+import { ConfigClassic, ConfigReactNative, ConfigPluginExample, ConfigPluginProperties } from '~/components/plugins/ConfigSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-cellular`** provides information about the user’s cellular service provider, such as its unique identifier, cellular connection type, and whether it allows VoIP calls on its network.
@@ -13,7 +15,49 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 ## Installation
 
-<InstallSection packageName="expo-cellular" />
+<APIInstallSection />
+
+## Configuration in app.json / app.config.js
+
+You can configure `expo-cellular` using its built-in [config plugin](../../../guides/config-plugins.md) if you use config plugins in your project ([EAS Build](../../../build/introduction.md) or `expo run:[android|ios]`).
+
+<ConfigClassic>
+
+Add the [`READ_PHONE_STATE`](#permissions) permissions to the [`permissions`](../config/app.md#permissions) list in the app manifest.
+
+</ConfigClassic>
+
+<ConfigReactNative>
+
+Learn how to configure the native projects in the [installation instructions in the `expo-cellular` repository](https://github.com/expo/expo/tree/main/packages/expo-cellular#installation-in-bare-react-native-projects).
+
+</ConfigReactNative>
+
+<ConfigPluginExample>
+
+```json
+{
+  "expo": {
+    "plugins": [
+      "expo-cellular"
+    ]
+  }
+}
+```
+
+</ConfigPluginExample>
+
+<ConfigPluginProperties properties={[]} />
+
+## Permissions
+
+### Android
+
+<AndroidPermissions permissions={['READ_PHONE_STATE']} />
+
+### iOS
+
+_No usage description required._
 
 ## API
 

--- a/docs/pages/versions/v44.0.0/sdk/cellular.md
+++ b/docs/pages/versions/v44.0.0/sdk/cellular.md
@@ -1,6 +1,7 @@
 ---
 title: Cellular
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-44/packages/expo-cellular'
+packageName: expo-cellular
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/v45.0.0/sdk/cellular.md
+++ b/docs/pages/versions/v45.0.0/sdk/cellular.md
@@ -5,7 +5,9 @@ packageName: 'expo-cellular'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import {APIInstallSection} from '~/components/plugins/InstallSection';
+import { APIInstallSection } from '~/components/plugins/InstallSection';
+import { AndroidPermissions } from '~/components/plugins/permissions';
+import { ConfigClassic, ConfigReactNative, ConfigPluginExample, ConfigPluginProperties } from '~/components/plugins/ConfigSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-cellular`** provides information about the user’s cellular service provider, such as its unique identifier, cellular connection type, and whether it allows VoIP calls on its network.
@@ -15,6 +17,48 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 ## Installation
 
 <APIInstallSection />
+
+## Configuration in app.json / app.config.js
+
+You can configure `expo-cellular` using its built-in [config plugin](../../../guides/config-plugins.md) if you use config plugins in your project ([EAS Build](../../../build/introduction.md) or `expo run:[android|ios]`).
+
+<ConfigClassic>
+
+Add the [`READ_PHONE_STATE`](#permissions) permissions to the [`permissions`](../config/app.md#permissions) list in the app manifest.
+
+</ConfigClassic>
+
+<ConfigReactNative>
+
+Learn how to configure the native projects in the [installation instructions in the `expo-cellular` repository](https://github.com/expo/expo/tree/main/packages/expo-cellular#installation-in-bare-react-native-projects).
+
+</ConfigReactNative>
+
+<ConfigPluginExample>
+
+```json
+{
+  "expo": {
+    "plugins": [
+      "expo-cellular"
+    ]
+  }
+}
+```
+
+</ConfigPluginExample>
+
+<ConfigPluginProperties properties={[]} />
+
+## Permissions
+
+### Android
+
+<AndroidPermissions permissions={['READ_PHONE_STATE']} />
+
+### iOS
+
+_No usage description required._
 
 ## API
 

--- a/docs/pages/versions/v46.0.0/sdk/cellular.md
+++ b/docs/pages/versions/v46.0.0/sdk/cellular.md
@@ -6,6 +6,8 @@ packageName: 'expo-cellular'
 
 import APISection from '~/components/plugins/APISection';
 import {APIInstallSection} from '~/components/plugins/InstallSection';
+import { AndroidPermissions } from '~/components/plugins/permissions';
+import { ConfigClassic, ConfigReactNative, ConfigPluginExample, ConfigPluginProperties } from '~/components/plugins/ConfigSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-cellular`** provides information about the user’s cellular service provider, such as its unique identifier, cellular connection type, and whether it allows VoIP calls on its network.
@@ -15,6 +17,48 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 ## Installation
 
 <APIInstallSection />
+
+## Configuration in app.json / app.config.js
+
+You can configure `expo-cellular` using its built-in [config plugin](../../../guides/config-plugins.md) if you use config plugins in your project ([EAS Build](../../../build/introduction.md) or `expo run:[android|ios]`).
+
+<ConfigClassic>
+
+Add the [`READ_PHONE_STATE`](#permissions) permissions to the [`permissions`](../config/app.md#permissions) list in the app manifest.
+
+</ConfigClassic>
+
+<ConfigReactNative>
+
+Learn how to configure the native projects in the [installation instructions in the `expo-cellular` repository](https://github.com/expo/expo/tree/main/packages/expo-cellular#installation-in-bare-react-native-projects).
+
+</ConfigReactNative>
+
+<ConfigPluginExample>
+
+```json
+{
+  "expo": {
+    "plugins": [
+      "expo-cellular"
+    ]
+  }
+}
+```
+
+</ConfigPluginExample>
+
+<ConfigPluginProperties properties={[]} />
+
+## Permissions
+
+### Android
+
+<AndroidPermissions permissions={['READ_PHONE_STATE']} />
+
+### iOS
+
+_No usage description required._
 
 ## API
 


### PR DESCRIPTION
# Why

Follows the "installation and permissions" format.

# How

- Added Install guide
- Added permissions (mostly for Android)

# Test Plan

Docs change only.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
