### PR TITLE
[docs] Use the install and permission format for brightness

### DIFF
--- a/docs/pages/versions/unversioned/sdk/brightness.md
+++ b/docs/pages/versions/unversioned/sdk/brightness.md
@@ -5,7 +5,9 @@ packageName: 'expo-brightness'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import {APIInstallSection} from '~/components/plugins/InstallSection';
+import { APIInstallSection } from '~/components/plugins/InstallSection';
+import { AndroidPermissions } from '~/components/plugins/permissions';
+import { ConfigClassic, ConfigReactNative, ConfigPluginExample, ConfigPluginProperties } from '~/components/plugins/ConfigSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
 
@@ -18,6 +20,50 @@ On Android, there is a global system-wide brightness setting, and each app has i
 ## Installation
 
 <APIInstallSection />
+
+## Configuration in app.json / app.config.js
+
+You can configure `expo-brightness` using its built-in [config plugin](../../../guides/config-plugins.md) if you use config plugins in your project ([EAS Build](../../../build/introduction.md) or `expo run:[android|ios]`).
+
+<ConfigClassic>
+
+Add the [`WRITE_SETTINGS`](#permissions) permissions to the [`permissions`](../config/app.md#permissions) list in the app manifest.
+
+</ConfigClassic>
+
+<ConfigReactNative>
+
+Learn how to configure the native projects in the [installation instructions in the `expo-brightness` repository](https://github.com/expo/expo/tree/main/packages/expo-brightness#installation-in-bare-react-native-projects).
+
+</ConfigReactNative>
+
+<ConfigPluginExample>
+
+```json
+{
+  "expo": {
+    "plugins": [
+      "expo-brightness"
+    ]
+  }
+}
+```
+
+</ConfigPluginExample>
+
+<ConfigPluginProperties properties={[]} />
+
+## Permissions
+
+### Android
+
+- On Android, the module requires permission to change the system-wide brightness. You can omit this permission if you are not using the `setSystemBrightness*` methods.
+
+<AndroidPermissions permissions={['WRITE_SETTINGS']} />
+
+### iOS
+
+_No usage description required._
 
 ## Usage
 

--- a/docs/pages/versions/v43.0.0/sdk/brightness.md
+++ b/docs/pages/versions/v43.0.0/sdk/brightness.md
@@ -5,6 +5,8 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-43/packages/expo-brightnes
 
 import APISection from '~/components/plugins/APISection';
 import InstallSection from '~/components/plugins/InstallSection';
+import { AndroidPermissions } from '~/components/plugins/permissions';
+import { ConfigClassic, ConfigReactNative, ConfigPluginExample, ConfigPluginProperties } from '~/components/plugins/ConfigSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
 
@@ -17,6 +19,94 @@ On Android, there is a global system-wide brightness setting, and each app has i
 ## Installation
 
 <InstallSection packageName="expo-brightness" />
+
+## Configuration in app.json / app.config.js
+
+You can configure `expo-brightness` using its built-in [config plugin](../../../guides/config-plugins.md) if you use config plugins in your project ([EAS Build](../../../build/introduction.md) or `expo run:[android|ios]`).
+
+<ConfigClassic>
+
+Add the [`WRITE_SETTINGS`](#permissions) permissions to the [`permissions`](../config/app.md#permissions) list in the app manifest.
+
+</ConfigClassic>
+
+<ConfigReactNative>
+
+Learn how to configure the native projects in the [installation instructions in the `expo-brightness` repository](https://github.com/expo/expo/tree/main/packages/expo-brightness#installation-in-bare-react-native-projects).
+
+</ConfigReactNative>
+
+<ConfigPluginExample>
+
+```json
+{
+  "expo": {
+    "plugins": [
+      "expo-brightness"
+    ]
+  }
+}
+```
+
+</ConfigPluginExample>
+
+<ConfigPluginProperties properties={[]} />
+
+## Permissions
+
+### Android
+
+- On Android, the module requires permission to change the system-wide brightness. You can omit this permission if you are not using the `setSystemBrightness*` methods.
+
+<AndroidPermissions permissions={['WRITE_SETTINGS']} />
+
+### iOS
+
+_No usage description required._
+
+## Configuration in app.json / app.config.js
+
+You can configure `expo-brightness` using its built-in [config plugin](../../../guides/config-plugins.md) if you use config plugins in your project ([EAS Build](../../../build/introduction.md) or `expo run:[android|ios]`).
+
+<ConfigClassic>
+
+Add the [`WRITE_SETTINGS`](#permissions) permissions to the [`permissions`](../config/app.md#permissions) list in the app manifest.
+
+</ConfigClassic>
+
+<ConfigReactNative>
+
+Learn how to configure the native projects in the [installation instructions in the `expo-brightness` repository](https://github.com/expo/expo/tree/main/packages/expo-brightness#installation-in-bare-react-native-projects).
+
+</ConfigReactNative>
+
+<ConfigPluginExample>
+
+```json
+{
+  "expo": {
+    "plugins": [
+      "expo-brightness"
+    ]
+  }
+}
+```
+
+</ConfigPluginExample>
+
+<ConfigPluginProperties properties={[]} />
+
+## Permissions
+
+### Android
+
+- On Android, the module requires permission to change the system-wide brightness. You can omit this permission if you are not using the `setSystemBrightness*` methods.
+
+<AndroidPermissions permissions={['WRITE_SETTINGS']} />
+
+### iOS
+
+_No usage description required._
 
 ## Usage
 

--- a/docs/pages/versions/v44.0.0/sdk/brightness.md
+++ b/docs/pages/versions/v44.0.0/sdk/brightness.md
@@ -5,6 +5,8 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-44/packages/expo-brightnes
 
 import APISection from '~/components/plugins/APISection';
 import InstallSection from '~/components/plugins/InstallSection';
+import { AndroidPermissions } from '~/components/plugins/permissions';
+import { ConfigClassic, ConfigReactNative, ConfigPluginExample, ConfigPluginProperties } from '~/components/plugins/ConfigSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
 
@@ -17,6 +19,50 @@ On Android, there is a global system-wide brightness setting, and each app has i
 ## Installation
 
 <InstallSection packageName="expo-brightness" />
+
+## Configuration in app.json / app.config.js
+
+You can configure `expo-brightness` using its built-in [config plugin](../../../guides/config-plugins.md) if you use config plugins in your project ([EAS Build](../../../build/introduction.md) or `expo run:[android|ios]`).
+
+<ConfigClassic>
+
+Add the [`WRITE_SETTINGS`](#permissions) permissions to the [`permissions`](../config/app.md#permissions) list in the app manifest.
+
+</ConfigClassic>
+
+<ConfigReactNative>
+
+Learn how to configure the native projects in the [installation instructions in the `expo-brightness` repository](https://github.com/expo/expo/tree/main/packages/expo-brightness#installation-in-bare-react-native-projects).
+
+</ConfigReactNative>
+
+<ConfigPluginExample>
+
+```json
+{
+  "expo": {
+    "plugins": [
+      "expo-brightness"
+    ]
+  }
+}
+```
+
+</ConfigPluginExample>
+
+<ConfigPluginProperties properties={[]} />
+
+## Permissions
+
+### Android
+
+- On Android, the module requires permission to change the system-wide brightness. You can omit this permission if you are not using the `setSystemBrightness*` methods.
+
+<AndroidPermissions permissions={['WRITE_SETTINGS']} />
+
+### iOS
+
+_No usage description required._
 
 ## Usage
 

--- a/docs/pages/versions/v45.0.0/sdk/brightness.md
+++ b/docs/pages/versions/v45.0.0/sdk/brightness.md
@@ -5,7 +5,9 @@ packageName: 'expo-brightness'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import {APIInstallSection} from '~/components/plugins/InstallSection';
+import { APIInstallSection } from '~/components/plugins/InstallSection';
+import { AndroidPermissions } from '~/components/plugins/permissions';
+import { ConfigClassic, ConfigReactNative, ConfigPluginExample, ConfigPluginProperties } from '~/components/plugins/ConfigSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
 
@@ -18,6 +20,50 @@ On Android, there is a global system-wide brightness setting, and each app has i
 ## Installation
 
 <APIInstallSection />
+
+## Configuration in app.json / app.config.js
+
+You can configure `expo-brightness` using its built-in [config plugin](../../../guides/config-plugins.md) if you use config plugins in your project ([EAS Build](../../../build/introduction.md) or `expo run:[android|ios]`).
+
+<ConfigClassic>
+
+Add the [`WRITE_SETTINGS`](#permissions) permissions to the [`permissions`](../config/app.md#permissions) list in the app manifest.
+
+</ConfigClassic>
+
+<ConfigReactNative>
+
+Learn how to configure the native projects in the [installation instructions in the `expo-brightness` repository](https://github.com/expo/expo/tree/main/packages/expo-brightness#installation-in-bare-react-native-projects).
+
+</ConfigReactNative>
+
+<ConfigPluginExample>
+
+```json
+{
+  "expo": {
+    "plugins": [
+      "expo-brightness"
+    ]
+  }
+}
+```
+
+</ConfigPluginExample>
+
+<ConfigPluginProperties properties={[]} />
+
+## Permissions
+
+### Android
+
+- On Android, the module requires permission to change the system-wide brightness. You can omit this permission if you are not using the `setSystemBrightness*` methods.
+
+<AndroidPermissions permissions={['WRITE_SETTINGS']} />
+
+### iOS
+
+_No usage description required._
 
 ## Usage
 

--- a/docs/pages/versions/v46.0.0/sdk/brightness.md
+++ b/docs/pages/versions/v46.0.0/sdk/brightness.md
@@ -5,7 +5,9 @@ packageName: 'expo-brightness'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import {APIInstallSection} from '~/components/plugins/InstallSection';
+import { APIInstallSection } from '~/components/plugins/InstallSection';
+import { AndroidPermissions } from '~/components/plugins/permissions';
+import { ConfigClassic, ConfigReactNative, ConfigPluginExample, ConfigPluginProperties } from '~/components/plugins/ConfigSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
 
@@ -18,6 +20,50 @@ On Android, there is a global system-wide brightness setting, and each app has i
 ## Installation
 
 <APIInstallSection />
+
+## Configuration in app.json / app.config.js
+
+You can configure `expo-brightness` using its built-in [config plugin](../../../guides/config-plugins.md) if you use config plugins in your project ([EAS Build](../../../build/introduction.md) or `expo run:[android|ios]`).
+
+<ConfigClassic>
+
+Add the [`WRITE_SETTINGS`](#permissions) permissions to the [`permissions`](../config/app.md#permissions) list in the app manifest.
+
+</ConfigClassic>
+
+<ConfigReactNative>
+
+Learn how to configure the native projects in the [installation instructions in the `expo-brightness` repository](https://github.com/expo/expo/tree/main/packages/expo-brightness#installation-in-bare-react-native-projects).
+
+</ConfigReactNative>
+
+<ConfigPluginExample>
+
+```json
+{
+  "expo": {
+    "plugins": [
+      "expo-brightness"
+    ]
+  }
+}
+```
+
+</ConfigPluginExample>
+
+<ConfigPluginProperties properties={[]} />
+
+## Permissions
+
+### Android
+
+- On Android, the module requires permission to change the system-wide brightness. You can omit this permission if you are not using the `setSystemBrightness*` methods.
+
+<AndroidPermissions permissions={['WRITE_SETTINGS']} />
+
+### iOS
+
+_No usage description required._
 
 ## Usage
 


### PR DESCRIPTION
# Why

Follows the "installation and permissions" format.

> **Note** this is a stacked PR on #19172

# How

- Added Install guide
- Added permissions (mostly for Android)

# Test Plan

Docs change only.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
