### PR TITLE
[android][ios] Integrate JS inspector on Expo Go

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
@@ -614,6 +614,9 @@ abstract class ReactNativeActivity :
   val devSupportManager: RNObject?
     get() = reactInstanceManager.takeIf { it.isNotNull }?.callRecursive("getDevSupportManager")
 
+  val jsExecutorName: String?
+    get() = reactInstanceManager.takeIf { it.isNotNull }?.callRecursive("getJsExecutorName")?.get() as? String
+
   // deprecated in favor of Expo.Linking.makeUrl
   // TODO: remove this
   private val linkingUri: String?

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/internal/DevMenuModule.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/internal/DevMenuModule.kt
@@ -239,7 +239,7 @@ class DevMenuModule(reactContext: ReactApplicationContext, val experiencePropert
    * workaround to determine the state by executor name.
    */
   private val isJsExecutorInspectable: Boolean by lazy {
-    val activity = currentActivity as? ReactNativeActivity?
+    val activity = currentActivity as? ReactNativeActivity
     activity?.jsExecutorName == "JSIExecutor+HermesRuntime"
   }
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/internal/DevMenuModule.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/internal/DevMenuModule.kt
@@ -19,7 +19,10 @@ import host.exp.exponent.experience.ReactNativeActivity
 import host.exp.exponent.kernel.DevMenuManager
 import host.exp.exponent.kernel.DevMenuModuleInterface
 import host.exp.exponent.kernel.KernelConstants
+import host.exp.expoview.Exponent
 import host.exp.expoview.R
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
 import java.util.*
 import javax.inject.Inject
 
@@ -86,7 +89,10 @@ class DevMenuModule(reactContext: ReactApplicationContext, val experiencePropert
     }
     items.putBundle("dev-inspector", inspectorMap)
 
-    if (devSettings != null && devSupportManager.devSupportEnabled) {
+    if (devSettings != null && devSupportManager.devSupportEnabled && isJsExecutorInspectable) {
+      debuggerMap.putString("label", getString(R.string.devmenu_open_js_debugger))
+      debuggerMap.putBoolean("isEnabled", devSupportManager.devSupportEnabled)
+    } else if (devSettings != null && devSupportManager.devSupportEnabled) {
       debuggerMap.putString("label", getString(if (devSettings.isRemoteJSDebugEnabled) R.string.devmenu_stop_remote_debugging else R.string.devmenu_start_remote_debugging))
       debuggerMap.putBoolean("isEnabled", devSupportManager.devSupportEnabled)
     } else {
@@ -131,8 +137,12 @@ class DevMenuModule(reactContext: ReactApplicationContext, val experiencePropert
     UiThreadUtil.runOnUiThread {
       when (itemKey) {
         "dev-remote-debug" -> {
-          devSettings.isRemoteJSDebugEnabled = !devSettings.isRemoteJSDebugEnabled
-          devSupportManager.handleReloadJS()
+          if (isJsExecutorInspectable) {
+            openJsInspector()
+          } else {
+            devSettings.isRemoteJSDebugEnabled = !devSettings.isRemoteJSDebugEnabled
+            devSupportManager.handleReloadJS()
+          }
         }
         "dev-hmr" -> {
           val nextEnabled = !devSettings.isHotModuleReplacementEnabled
@@ -221,6 +231,30 @@ class DevMenuModule(reactContext: ReactApplicationContext, val experiencePropert
    */
   private fun getString(ref: Int): String {
     return reactApplicationContext.resources.getString(ref)
+  }
+
+  /**
+   * Indicates whether the underlying js executor supports inspecting.
+   * NOTE: because current react-native doesn't pass jsi runtime `isInspectable` to java,
+   * workaround to determine the state by executor name.
+   */
+  private val isJsExecutorInspectable: Boolean by lazy {
+    val activity = currentActivity as? ReactNativeActivity?
+    activity?.jsExecutorName == "JSIExecutor+HermesRuntime"
+  }
+
+  /**
+   * Open the JavaScript inspector
+   */
+  private fun openJsInspector() {
+    reactApplicationContext.runOnNativeModulesQueueThread {
+      val devSupportManager = getDevSupportManager()
+      devSupportManager?.devSettings?.packagerConnectionSettings?.inspectorServerHost?.let {
+        val url = "http://$it/inspector?applicationId=${reactApplicationContext.packageName}"
+        val request = Request.Builder().url(url).put("".toRequestBody()).build()
+        Exponent.instance.exponentNetwork.noCacheClient.newCall(request).execute()
+      }
+    }
   }
 
   //endregion internals

--- a/android/expoview/src/main/res/values/strings.xml
+++ b/android/expoview/src/main/res/values/strings.xml
@@ -37,6 +37,7 @@
   <string name="devmenu_element_inspector_unavailable">Element Inspector Unavailable</string>
   <string name="devmenu_stop_remote_debugging">Stop Remote Debugging</string>
   <string name="devmenu_start_remote_debugging">Debug Remote JS</string>
+  <string name="devmenu_open_js_debugger">Open JS Debugger</string>
   <string name="devmenu_remote_debugger_unavailable">Remote Debugger Unavailable</string>
   <string name="devmenu_disable_fast_refresh">Disable Fast Refresh</string>
   <string name="devmenu_enable_fast_refresh">Enable Fast Refresh</string>

--- a/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.mm
+++ b/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.mm
@@ -520,7 +520,6 @@
 
 - (void)setupWebSocketControls
 {
-#if DEBUG || RCT_DEV
   if ([self enablesDeveloperTools]) {
     if ([_versionManager respondsToSelector:@selector(addWebSocketNotificationHandler:queue:forMethod:)]) {
       __weak __typeof(self) weakSelf = self;
@@ -568,7 +567,6 @@
                                              forMethod:@"devMenu"];
     }
   }
-#endif
 }
 
 - (NSDictionary<NSString *, NSString *> *)devMenuItems


### PR DESCRIPTION
# Why

close ENG-4165

# How

- if the underlying js runtime is inspectable, show the dev menu as "Open JS Debugger" and open inspector provided by expo cli.
- on android, there's a workaround for checking js runtime isInspectable. because react-native doesn't expose the information from jsi runtime to java side, we could only check the underlying js executor name if it's hermes or not.

<img src="https://user-images.githubusercontent.com/46429/191202513-a30c8777-2a28-4b47-9f00-4843aad6f2ed.png" width="30%">

<img src="https://user-images.githubusercontent.com/46429/191202576-8f804598-39dd-4cf2-bbbd-266c5ce76e96.png" width="30%">

# Test Plan

- ✅ unversioned android/ios expo go + NCL (remote debugging)
- ✅ unversioned android/ios expo go + NCL jsEngine hermes (js inspector)
- ✅ unversioned android/ios expo go + NCL jsEngine hermes + tunnel (js inspector)

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
