### PR TITLE
[modules][Android] Fix modules aren't created after reload

### DIFF
--- a/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.cpp
@@ -64,7 +64,7 @@ void JSIInteropModuleRegistry::installJSI(
 
 void JSIInteropModuleRegistry::installJSIForTests() {
 #if !UNIT_TEST
-  throw std::logic_error("The function is only avaiable when UNIT_TEST is defined.");
+  throw std::logic_error("The function is only available when UNIT_TEST is defined.");
 #else
   runtimeHolder = std::make_shared<JavaScriptRuntime>();
   jsi::Runtime &jsiRuntime = runtimeHolder->get();

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/ModuleRegistryAdapter.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/ModuleRegistryAdapter.java
@@ -117,6 +117,9 @@ public class ModuleRegistryAdapter implements ReactPackage {
     ReactApplicationContext reactContext,
     @Nullable ModuleRegistry moduleRegistry
   ) {
+    if (mModulesProxy != null && mModulesProxy.getKotlinInteropModuleRegistry().getWasDestroyed()) {
+      mModulesProxy = null;
+    }
     if (mModulesProxy == null) {
       ModuleRegistry registry = moduleRegistry != null ? moduleRegistry : mModuleRegistryProvider.get(reactContext);
       if (mModulesProvider != null) {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/NativeModulesProxy.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/NativeModulesProxy.java
@@ -1,5 +1,6 @@
 package expo.modules.adapters.react;
 
+import android.util.Log;
 import android.util.SparseArray;
 
 import com.facebook.react.bridge.Dynamic;
@@ -127,6 +128,9 @@ public class NativeModulesProxy extends ReactContextBaseJavaModule {
     constants.put(MODULES_CONSTANTS_KEY, modulesConstants);
     constants.put(EXPORTED_METHODS_KEY, exportedMethodsMap);
     constants.put(VIEW_MANAGERS_METADATA_KEY, viewManagersMetadata);
+
+    Log.i("ExpoModulesCore", "✅ Constants was exported");
+
     return constants;
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -3,6 +3,7 @@ package expo.modules.kotlin
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
+import android.util.Log
 import android.view.View
 import androidx.annotation.MainThread
 import androidx.annotation.UiThread
@@ -12,6 +13,7 @@ import com.facebook.react.turbomodule.core.CallInvokerHolderImpl
 import com.facebook.react.uimanager.UIManagerHelper
 import expo.modules.core.errors.ContextDestroyedException
 import expo.modules.core.interfaces.ActivityProvider
+import expo.modules.core.interfaces.JavaScriptContextProvider
 import expo.modules.interfaces.barcodescanner.BarCodeScannerInterface
 import expo.modules.interfaces.camera.CameraViewInterface
 import expo.modules.interfaces.constants.ConstantsInterface
@@ -98,7 +100,8 @@ class AppContext(
   fun installJSIInterop() {
     jsiInterop = JSIInteropModuleRegistry(this)
     val reactContext = reactContextHolder.get() ?: return
-    reactContext.javaScriptContextHolder?.get()
+    val jsContextHolder = legacyModule<JavaScriptContextProvider>()?.javaScriptContextRef
+    jsContextHolder
       ?.takeIf { it != 0L }
       ?.let {
         jsiInterop.installJSI(
@@ -106,6 +109,7 @@ class AppContext(
           reactContext.catalystInstance.jsCallInvokerHolder as CallInvokerHolderImpl,
           reactContext.catalystInstance.nativeCallInvokerHolder as CallInvokerHolderImpl
         )
+        Log.i("ExpoModulesCore", "✅ JSI interop was installed")
       }
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -114,7 +114,7 @@ class AppContext(
           Log.i("ExpoModulesCore", "✅ JSI interop was installed")
         }
     } catch (e: Throwable) {
-      Log.e("ExpoModulesCore", "Cannot install JSI interop: $e", e)rrrr
+      Log.e("ExpoModulesCore", "Cannot install JSI interop: $e", e)
     }
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KotlinInteropModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KotlinInteropModuleRegistry.kt
@@ -25,6 +25,9 @@ class KotlinInteropModuleRegistry(
   private val registry: ModuleRegistry
     get() = appContext.registry
 
+  var wasDestroyed = false
+    private set
+
   fun hasModule(name: String): Boolean = registry.hasModule(name)
 
   fun callMethod(moduleName: String, method: String, arguments: ReadableArray, promise: Promise) {
@@ -108,6 +111,7 @@ class KotlinInteropModuleRegistry(
 
   fun onDestroy() {
     appContext.onDestroy()
+    wasDestroyed = true
   }
 
   fun installJSIInterop() {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleRegistry.kt
@@ -74,5 +74,6 @@ class ModuleRegistry(
     forEach {
       it.cleanUp()
     }
+    registry.clear()
   }
 }


### PR DESCRIPTION
# Why

A follow-up to https://github.com/expo/expo/pull/18844 and https://github.com/expo/expo/pull/18823.
It turns out that the recently added fix breaks the reload behavior. Right now, when you hard reload your app, modules won't be installed, because the `mModulesProxy` isn't recreated. 

# How

Made sure that the module proxy is recreated after reload.
Added some debug logs. 

> Note:
There are still some problems when someone reloads the app multiple times.  

# Test Plan

- unit tests ✅
- bare-expo ✅
- expo-go ✅
