### PR TITLE
[bare-expo] Disable missing native module errors

### DIFF
--- a/apps/bare-expo/App.tsx
+++ b/apps/bare-expo/App.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import 'expo/disable-missing-native-module-errors';
 
 import MainNavigator, { optionalRequire } from './MainNavigator';
 import { createProxy, startAsync, addListener } from './relapse/client';


### PR DESCRIPTION
# Why

@aleqsio raised this in SDK office hours

# How

Import script with side effect of disabling the errors

# Test Plan

@aleqsio would know