### PR TITLE
[modules][Android] Improve registration of activity contracts

### DIFF
--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
@@ -80,20 +80,18 @@ class ImagePickerModule : Module() {
 
     // endregion
 
-    OnCreate {
-      coroutineScope.launch {
-        withContext(Dispatchers.Main) {
-          cameraLauncher = appContext.registerForActivityResult(
-            CameraContract(this@ImagePickerModule),
-          ) { input, result -> handleResultUponActivityDestruction(result, input.options) }
-          imageLibraryLauncher = appContext.registerForActivityResult(
-            ImageLibraryContract(this@ImagePickerModule),
-          ) { input, result -> handleResultUponActivityDestruction(result, input.options) }
-          cropImageLauncher = appContext.registerForActivityResult(
-            CropImageContract(this@ImagePickerModule),
-          ) { input, result -> handleResultUponActivityDestruction(result, input.options) }
-        }
-      }
+    RegisterActivityContracts {
+      cameraLauncher = registerForActivityResult(
+        CameraContract(this@ImagePickerModule),
+      ) { input, result -> handleResultUponActivityDestruction(result, input.options) }
+
+      imageLibraryLauncher = registerForActivityResult(
+        ImageLibraryContract(this@ImagePickerModule),
+      ) { input, result -> handleResultUponActivityDestruction(result, input.options) }
+
+      cropImageLauncher = registerForActivityResult(
+        CropImageContract(this@ImagePickerModule),
+      ) { input, result -> handleResultUponActivityDestruction(result, input.options) }
     }
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -50,8 +50,7 @@ class AppContext(
   val legacyModuleRegistry: expo.modules.core.ModuleRegistry,
   private val reactContextHolder: WeakReference<ReactApplicationContext>
 ) : CurrentActivityProvider, AppContextActivityResultCaller {
-  val registry = ModuleRegistry(WeakReference(this)).apply {
-  }
+  val registry = ModuleRegistry(WeakReference(this))
   private val reactLifecycleDelegate = ReactLifecycleDelegate(this)
 
   // We postpone creating the `JSIInteropModuleRegistry` to not load so files in unit tests.
@@ -292,6 +291,7 @@ class AppContext(
    * what parts of the application outlives the Activity destruction (especially [AppContext] and other [Bridge]-related parts).
    */
   @MainThread
+  @Deprecated(message = "`registerForActivityResult` was deprecated. Please use `RegisterActivityContracts` component instead.")
   override suspend fun <I : Serializable, O> registerForActivityResult(
     contract: AppContextActivityResultContract<I, O>,
     fallbackCallback: AppContextActivityResultFallbackCallback<I, O>

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
@@ -11,6 +11,7 @@ import expo.modules.kotlin.exception.MethodNotFoundException
 import expo.modules.kotlin.exception.exceptionDecorator
 import expo.modules.kotlin.jni.JavaScriptModuleObject
 import expo.modules.kotlin.modules.Module
+import kotlinx.coroutines.launch
 
 class ModuleHolder(val module: Module) {
   val definition = module.definition()
@@ -79,6 +80,14 @@ class ModuleHolder(val module: Module) {
   fun <Sender, Payload> post(eventName: EventName, sender: Sender, payload: Payload) {
     val listener = definition.eventListeners[eventName] ?: return
     (listener as? EventListenerWithSenderAndPayload<Sender, Payload>)?.call(sender, payload)
+  }
+
+  fun registerContracts() {
+    definition.registerContracts?.let {
+      module.appContext.mainQueue.launch {
+        it.invoke(module.appContext)
+      }
+    }
   }
 
   fun cleanUp() {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleRegistry.kt
@@ -25,6 +25,7 @@ class ModuleRegistry(
       )
     }
     holder.post(EventName.MODULE_CREATE)
+    holder.registerContracts()
     registry[holder.name] = holder
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionBuilder.kt
@@ -5,6 +5,7 @@ package expo.modules.kotlin.modules
 import android.app.Activity
 import android.content.Intent
 import android.view.View
+import expo.modules.kotlin.activityresult.AppContextActivityResultCaller
 import expo.modules.kotlin.events.BasicEventListener
 import expo.modules.kotlin.events.EventListener
 import expo.modules.kotlin.events.EventListenerWithPayload
@@ -27,6 +28,9 @@ class ModuleDefinitionBuilder(@PublishedApi internal val module: Module? = null)
   @PublishedApi
   internal val eventListeners = mutableMapOf<EventName, EventListener>()
 
+  @PublishedApi
+  internal var registerContracts: (suspend AppContextActivityResultCaller.() -> Unit)? = null
+
   fun buildModule(): ModuleDefinitionData {
     val moduleName = name ?: module?.javaClass?.simpleName
 
@@ -34,7 +38,8 @@ class ModuleDefinitionBuilder(@PublishedApi internal val module: Module? = null)
       requireNotNull(moduleName),
       buildObject(),
       viewManagerDefinition,
-      eventListeners
+      eventListeners,
+      registerContracts
     )
   }
 
@@ -73,6 +78,13 @@ class ModuleDefinitionBuilder(@PublishedApi internal val module: Module? = null)
    */
   inline fun OnCreate(crossinline body: () -> Unit) {
     eventListeners[EventName.MODULE_CREATE] = BasicEventListener(EventName.MODULE_CREATE) { body() }
+  }
+
+  /**
+   * Allows registration of activity contracts. It's run after `OnCreate` block.
+   */
+  fun RegisterActivityContracts(body: suspend AppContextActivityResultCaller.() -> Unit) {
+    registerContracts = body
   }
 
   /**

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionData.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionData.kt
@@ -1,6 +1,7 @@
 package expo.modules.kotlin.modules
 
 import expo.modules.kotlin.ConcatIterator
+import expo.modules.kotlin.activityresult.AppContextActivityResultCaller
 import expo.modules.kotlin.events.EventListener
 import expo.modules.kotlin.events.EventName
 import expo.modules.kotlin.objects.ObjectDefinitionData
@@ -11,6 +12,7 @@ class ModuleDefinitionData(
   val objectDefinition: ObjectDefinitionData,
   val viewManagerDefinition: ViewManagerDefinition? = null,
   val eventListeners: Map<EventName, EventListener> = emptyMap(),
+  val registerContracts: (suspend AppContextActivityResultCaller.() -> Unit)? = null
 ) {
 
   val constantsProvider = objectDefinition.constantsProvider


### PR DESCRIPTION
# Why

Improves registration of activity contracts by adding a `RegisterActivityContracts` component. That component ensures that provided block is dispatched on the correct thread. 

# How

- Added `RegisterActivityContracts` component.
- Registered contracts on the main thread.
- Deprecated previous registration method.

# Test Plan

- bare-expo and NCL ✅