### PR TITLE
[docs]: Fix section title and link in the Deprecated section

### DIFF
--- a/docs/pages/bare/using-expo-client.md
+++ b/docs/pages/bare/using-expo-client.md
@@ -130,8 +130,8 @@ export default function App() {
 
 This method is the least reliable because there are several reasons that a `require` statement might throw an error. For example, there could be an internal error, the module could be missing, the native module could be linked incorrectly, and so on. You should avoid using this method.
 
-## **Deprecated**: use the `.expo.[js/json/ts/tsx]` extension to provide Expo Go specific fallbacks
+## Deprecated
 
-The `.expo` extension is removed in SDK 41. Instead, consider using [conditional inline requires](#use-conditional-inline-requires-to-provide-fallbacks), and read [expo.fyi/expo-extension-migration](https://expo.fyi/expo-extension-migration) for specific guidance on migration.
+The `.expo.[js/json/ts/tsx]` extensions to provide Expo Go specific fallbacks are removed in favor of optional imports syntax. For more information, see [Migration off the expo file extension](https://github.com/expo/fyi/blob/main/expo-extension-migration.md#after).
 
 [expo-go]: https://expo.dev/expo-go

--- a/docs/pages/bare/using-expo-client.md
+++ b/docs/pages/bare/using-expo-client.md
@@ -130,7 +130,7 @@ export default function App() {
 
 This method is the least reliable because there are several reasons that a `require` statement might throw an error. For example, there could be an internal error, the module could be missing, the native module could be linked incorrectly, and so on. You should avoid using this method.
 
-## Deprecated
+## Deprecated `.expo` extensions
 
 The `.expo.[js/json/ts/tsx]` extensions to provide Expo Go specific fallbacks are removed in favor of optional imports syntax. For more information, see [Migration off the expo file extension](https://github.com/expo/fyi/blob/main/expo-extension-migration.md#after).
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Refs to feedback here: https://github.com/expo/expo/pull/18947#issuecomment-1247983592

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR fixes the large section and title and removes the broken link and updates the verbiage in the Deprecated section.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes can be tested by running docs locally and visiting: http://localhost:3002/bare/using-expo-client/#deprecated--expo--extensions

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
