### PR TITLE
[expo-image-picker] Fix incorrect translation on UIImage

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix images taken with `launchCameraAsync` being translated incorrectly on some camera orientations. ([#19185](https://github.com/expo/expo/pull/19185) by [@jacobjaffe](https://github.com/JacobJaffe) and [@reececox](https://github.com/reececox))
+
 ### 💡 Others
 
 - Drop `@expo/config-plugins` dependency in favor of peer dependency on `expo`. ([#18595](https://github.com/expo/expo/pull/18595) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/expo-image-picker/ios/UIImage+fixOrientation.swift
+++ b/packages/expo-image-picker/ios/UIImage+fixOrientation.swift
@@ -15,7 +15,7 @@ extension UIImage {
     case .down,
          .downMirrored:
       transform = transform
-        .translatedBy(x: self.size.width, y: self.size.width)
+        .translatedBy(x: self.size.width, y: self.size.height)
         .rotated(by: .pi)
     case .left,
          .leftMirrored:


### PR DESCRIPTION
Fixes #17875

This was found here: https://github.com/expo/expo/issues/17875#issuecomment-1221547735

I tested this locally with the patch & a new dev-client, and this immediately fixes the issue. It also seems pretty apparently the bug, reading the code.

# Why

`ImagePicker.launchCameraAsync()` incorrectly translates the result at a certain orientation.

# How

Both translations were being applied via `width`. This is incorrect.

# Test Plan

I created a local dev client with this patch. My test case is simple:
1. use `ImagePicker.launchCameraAsync()` 
2. rotate the phone to the *left* and use the front camera. 
3. use the resulting `uri` in an `Image` src.

Without this patch, the resulting image has a black offset (see https://github.com/expo/expo/issues/17875 for a clear example).

I've also tested all other orientations to ensure that this doesn't break other orientations.

# Checklist


- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
