### PR TITLE
[updates] Fix android instrumented test error

### DIFF
--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/errorrecovery/ErrorRecoveryTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/errorrecovery/ErrorRecoveryTest.kt
@@ -2,8 +2,10 @@ package expo.modules.updates.errorrecovery
 
 import android.os.Message
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
+import androidx.test.platform.app.InstrumentationRegistry
 import expo.modules.updates.UpdatesConfiguration
 import expo.modules.updates.launcher.Launcher
+import expo.modules.updates.logging.UpdatesLogger
 import io.mockk.*
 import org.junit.Before
 import org.junit.Test
@@ -12,14 +14,15 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4ClassRunner::class)
 class ErrorRecoveryTest {
   private var mockDelegate: ErrorRecoveryDelegate = mockk()
-  private var errorRecovery: ErrorRecovery = ErrorRecovery()
+  private val context = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
+  private var errorRecovery: ErrorRecovery = ErrorRecovery(context)
 
   @Before
   fun setup() {
     mockDelegate = mockk(relaxed = true)
-    errorRecovery = ErrorRecovery()
+    errorRecovery = ErrorRecovery(context)
     errorRecovery.initialize(mockDelegate)
-    errorRecovery.handler = spyk(ErrorRecoveryHandler(errorRecovery.handlerThread.looper, mockDelegate))
+    errorRecovery.handler = spyk(ErrorRecoveryHandler(errorRecovery.handlerThread.looper, mockDelegate, UpdatesLogger(context)))
     // make handler run synchronously
     val messageSlot = slot<Message>()
     every { errorRecovery.handler.sendMessageAtTime(capture(messageSlot), any()) } answers {

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderTest.kt
@@ -220,7 +220,7 @@ class FileDownloaderTest {
     var error: Exception? = null
     var didSucceed = false
 
-    FileDownloader(client).downloadAsset(
+    FileDownloader(context, client).downloadAsset(
       assetEntity, File(context.cacheDir, "test"), config, context,
       object : FileDownloader.AssetDownloadCallback {
         override fun onFailure(e: Exception, assetEntity: AssetEntity) {
@@ -268,7 +268,7 @@ class FileDownloaderTest {
     var error: Exception? = null
     var didSucceed = false
 
-    FileDownloader(client).downloadAsset(
+    FileDownloader(context, client).downloadAsset(
       assetEntity, File(context.cacheDir, "test"), config, context,
       object : FileDownloader.AssetDownloadCallback {
         override fun onFailure(e: Exception, assetEntity: AssetEntity) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
@@ -29,8 +29,8 @@ import expo.modules.updates.logging.UpdatesLogger
 import expo.modules.updates.manifest.*
 import java.security.cert.CertificateException
 
-open class FileDownloader(context: Context) {
-  private val client = OkHttpClient.Builder().cache(getCache(context)).build()
+open class FileDownloader(context: Context, private val client: OkHttpClient) {
+  constructor(context: Context) : this(context, OkHttpClient.Builder().cache(getCache(context)).build())
   private val logger = UpdatesLogger(context)
 
   interface FileDownloadCallback {


### PR DESCRIPTION
# Why

android instrumented ci tests are broken, e.g. https://github.com/expo/expo/actions/runs/3084322899/jobs/4986338917
this is a regression from #18810 

# How

fix build error

# Test Plan

android instrumented ci test passed: https://github.com/expo/expo/actions/runs/3087190849/jobs/4992309986

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
