### PR TITLE
[modules][Kotlin] Improve logging

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/ModuleRegistryAdapter.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/ModuleRegistryAdapter.java
@@ -1,8 +1,5 @@
 package expo.modules.adapters.react;
 
-import android.util.Log;
-import androidx.annotation.Nullable;
-
 import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -12,12 +9,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import androidx.annotation.Nullable;
 import expo.modules.BuildConfig;
 import expo.modules.adapters.react.views.SimpleViewManagerAdapter;
 import expo.modules.adapters.react.views.ViewGroupManagerAdapter;
 import expo.modules.core.ModuleRegistry;
 import expo.modules.core.interfaces.InternalModule;
 import expo.modules.core.interfaces.Package;
+import expo.modules.kotlin.CoreLoggerKt;
 import expo.modules.kotlin.KotlinInteropModuleRegistry;
 import expo.modules.kotlin.ModulesProvider;
 import expo.modules.kotlin.views.ViewWrapperDelegateHolder;
@@ -130,7 +129,7 @@ public class ModuleRegistryAdapter implements ReactPackage {
     }
 
     if (moduleRegistry != null && moduleRegistry != mModulesProxy.getModuleRegistry()) {
-      Log.e("expo-modules-core", "NativeModuleProxy was configured with a different instance of the modules registry.");
+      CoreLoggerKt.getLogger().error("❌ NativeModuleProxy was configured with a different instance of the modules registry.", null);
     }
 
     return mModulesProxy;

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/NativeModulesProxy.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/NativeModulesProxy.java
@@ -15,6 +15,7 @@ import expo.modules.core.ExportedModule;
 import expo.modules.core.ModuleRegistry;
 import expo.modules.core.ViewManager;
 import expo.modules.core.interfaces.ExpoMethod;
+import expo.modules.kotlin.CoreLoggerKt;
 import expo.modules.kotlin.ExpoModulesHelper;
 import expo.modules.kotlin.KotlinInteropModuleRegistry;
 import expo.modules.kotlin.KPromiseWrapper;
@@ -129,7 +130,7 @@ public class NativeModulesProxy extends ReactContextBaseJavaModule {
     constants.put(EXPORTED_METHODS_KEY, exportedMethodsMap);
     constants.put(VIEW_MANAGERS_METADATA_KEY, viewManagersMetadata);
 
-    Log.i("ExpoModulesCore", "✅ Constants was exported");
+    CoreLoggerKt.getLogger().info("✅ Constants was exported");
 
     return constants;
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/core/logging/LogHandler.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/core/logging/LogHandler.kt
@@ -10,5 +10,5 @@ abstract class LogHandler(
   val category: String
 ) {
 
-  internal abstract fun log(type: LogType, message: String)
+  internal abstract fun log(type: LogType, message: String, cause: Throwable? = null)
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/core/logging/Logger.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/core/logging/Logger.kt
@@ -29,7 +29,12 @@ class Logger(
       this.add(OSLogHandler(category))
     }
     if (options.contains(LoggerOptions.logToFile)) {
-      this.add(PersistentFileLogHandler(category, context!!))
+      this.add(
+        PersistentFileLogHandler(
+          category,
+          requireNotNull(context) { "You have to provide the `Context` to create a file logger" }
+        )
+      )
     }
   }.toList()
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/core/logging/Logger.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/core/logging/Logger.kt
@@ -17,7 +17,7 @@ class Logger(
   /**
    * Android context is required if logging to a file
    */
-  context: Context,
+  context: Context? = null,
   /**
    * One of the predefined LoggerOptions values
    */
@@ -29,7 +29,7 @@ class Logger(
       this.add(OSLogHandler(category))
     }
     if (options.contains(LoggerOptions.logToFile)) {
-      this.add(PersistentFileLogHandler(category, context))
+      this.add(PersistentFileLogHandler(category, context!!))
     }
   }.toList()
 
@@ -68,29 +68,29 @@ class Logger(
    * Used to log an unwanted state that has not much impact on the process so it can be continued,
    * but could potentially become an error.
    * */
-  fun warn(message: String) {
-    log(LogType.Warn, message)
+  fun warn(message: String, cause: Throwable? = null) {
+    log(LogType.Warn, message, cause)
   }
 
   /**
    * Logs unwanted state that has an impact on the currently running process, but the entire app
    * can continue to run.
    */
-  fun error(message: String) {
-    log(LogType.Error, message)
+  fun error(message: String, cause: Throwable? = null) {
+    log(LogType.Error, message, cause)
   }
 
   /**
    * Logs critical error due to which the entire app cannot continue to run.
    */
-  fun fatal(message: String) {
-    log(LogType.Fatal, message)
+  fun fatal(message: String, cause: Throwable? = null) {
+    log(LogType.Fatal, message, cause)
   }
 
-  private fun log(type: LogType, message: String) {
+  private fun log(type: LogType, message: String, cause: Throwable? = null) {
     if (LogType.toOSLogType(type) >= minOSLevel) {
       handlers.forEach { handler ->
-        handler.log(type, message)
+        handler.log(type, message, cause)
       }
     }
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/core/logging/OSLogHandler.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/core/logging/OSLogHandler.kt
@@ -11,6 +11,13 @@ internal class OSLogHandler(
   category
 ) {
   override fun log(type: LogType, message: String, cause: Throwable?) {
+    if (!isAndroid) {
+      println("[${type.type}] $category\t$message")
+      cause?.let {
+        println("${it.localizedMessage}\n${cause.stackTraceToString()}")
+      }
+      return
+    }
     when (LogType.toOSLogType(type)) {
       Log.DEBUG -> Log.d(category, message, cause)
       Log.INFO -> Log.i(category, message, cause)
@@ -20,3 +27,5 @@ internal class OSLogHandler(
     }
   }
 }
+
+private val isAndroid = "The Android Project" == System.getProperty("java.specification.vendor")

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/core/logging/OSLogHandler.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/core/logging/OSLogHandler.kt
@@ -10,13 +10,13 @@ internal class OSLogHandler(
 ) : LogHandler(
   category
 ) {
-  override fun log(type: LogType, message: String) {
+  override fun log(type: LogType, message: String, cause: Throwable?) {
     when (LogType.toOSLogType(type)) {
-      Log.DEBUG -> Log.d(category, message)
-      Log.INFO -> Log.i(category, message)
-      Log.WARN -> Log.w(category, message)
-      Log.ERROR -> Log.e(category, message)
-      Log.ASSERT -> Log.e(category, message)
+      Log.DEBUG -> Log.d(category, message, cause)
+      Log.INFO -> Log.i(category, message, cause)
+      Log.WARN -> Log.w(category, message, cause)
+      Log.ERROR -> Log.e(category, message, cause)
+      Log.ASSERT -> Log.e(category, message, cause)
     }
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/core/logging/PersistentFileLogHandler.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/core/logging/PersistentFileLogHandler.kt
@@ -15,7 +15,10 @@ internal class PersistentFileLogHandler(
 
   private val persistentFileLog = PersistentFileLog(category, context)
 
-  override fun log(type: LogType, message: String) {
+  override fun log(type: LogType, message: String, cause: Throwable?) {
     persistentFileLog.appendEntry(message)
+    cause?.let {
+      persistentFileLog.appendEntry("${cause.localizedMessage}\n${cause.stackTraceToString()}")
+    }
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -3,7 +3,6 @@ package expo.modules.kotlin
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
-import android.util.Log
 import android.view.View
 import androidx.annotation.MainThread
 import androidx.annotation.UiThread
@@ -89,6 +88,8 @@ class AppContext(
       // properties are initialized first. Not having that would trigger NPE.
       registry.register(ErrorManagerModule())
       registry.register(modulesProvider)
+
+      logger.info("✅ AppContext was initialized")
     }
   }
 
@@ -110,10 +111,10 @@ class AppContext(
             catalystInstance.jsCallInvokerHolder as CallInvokerHolderImpl,
             catalystInstance.nativeCallInvokerHolder as CallInvokerHolderImpl
           )
-          Log.i("ExpoModulesCore", "✅ JSI interop was installed")
+          logger.info("✅ JSI interop was installed")
         }
     } catch (e: Throwable) {
-      Log.e("ExpoModulesCore", "Cannot install JSI interop: $e", e)
+      logger.error("❌ Cannot install JSI interop: $e", e)
     }
   }
 
@@ -225,6 +226,7 @@ class AppContext(
     registry.cleanUp()
     modulesQueue.cancel(ContextDestroyedException())
     mainQueue.cancel(ContextDestroyedException())
+    logger.info("✅ AppContext was destroyed")
   }
 
   internal fun onHostResume() {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/CoreLogger.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/CoreLogger.kt
@@ -1,0 +1,6 @@
+package expo.modules.kotlin
+
+import expo.modules.core.logging.Logger
+import expo.modules.core.logging.LoggerOptions
+
+internal val logger = Logger("ExpoModulesCore", null, options = LoggerOptions.logToOS)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KotlinInteropModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KotlinInteropModuleRegistry.kt
@@ -80,12 +80,11 @@ class KotlinInteropModuleRegistry(
   fun viewManagersMetadata(): Map<String, Map<String, Any>> {
     return registry
       .filter { it.definition.viewManagerDefinition != null }
-      .map { holder ->
+      .associate { holder ->
         holder.name to mapOf(
           "propsNames" to (holder.definition.viewManagerDefinition?.propsNames ?: emptyList())
         )
       }
-      .toMap()
   }
 
   fun extractViewManagersDelegateHolders(viewManagers: List<ViewManager<*, *>>): List<ViewWrapperDelegateHolder> =
@@ -112,6 +111,7 @@ class KotlinInteropModuleRegistry(
   fun onDestroy() {
     appContext.onDestroy()
     wasDestroyed = true
+    logger.info("✅ KotlinInteropModuleRegistry was destroyed")
   }
 
   fun installJSIInterop() {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleRegistry.kt
@@ -76,5 +76,6 @@ class ModuleRegistry(
       it.cleanUp()
     }
     registry.clear()
+    logger.info("✅ ModuleRegistry was destroyed")
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerDefinition.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerDefinition.kt
@@ -1,7 +1,6 @@
 package expo.modules.kotlin.views
 
 import android.content.Context
-import android.util.Log
 import android.view.View
 import android.view.ViewGroup
 import com.facebook.react.bridge.ReactContext
@@ -11,6 +10,7 @@ import expo.modules.core.ViewManager
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.exception.UnexpectedException
+import expo.modules.kotlin.logger
 import expo.modules.kotlin.recycle
 
 class ViewManagerDefinition(
@@ -43,7 +43,7 @@ class ViewManagerDefinition(
         try {
           propDelegate.set(this, onView)
         } catch (exception: Throwable) {
-          Log.e("ExpoModulesCore", "Cannot set the '$key' prop on the '${viewType.simpleName}'.", exception)
+          logger.error("❌ Cannot set the '$key' prop on the '${viewType.simpleName}'", exception)
 
           handleException(
             onView,

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerWrapperDelegate.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerWrapperDelegate.kt
@@ -9,6 +9,7 @@ import expo.modules.core.utilities.ifNull
 import expo.modules.kotlin.ModuleHolder
 import expo.modules.kotlin.callbacks.ViewCallbackDelegate
 import expo.modules.kotlin.events.normalizeEventName
+import expo.modules.kotlin.logger
 import kotlin.reflect.full.declaredMemberProperties
 import kotlin.reflect.jvm.isAccessible
 
@@ -60,18 +61,18 @@ class ViewManagerWrapperDelegate(internal var moduleHolder: ModuleHolder) {
 
     callbacks.forEach {
       val property = propertiesMap[it].ifNull {
-        Log.w("ExpoModuleCore", "Property `$it` does not exist in ${kClass.simpleName}.")
+        logger.warn("⚠️ Property `$it` does not exist in ${kClass.simpleName}")
         return@forEach
       }
       property.isAccessible = true
 
       val delegate = property.getDelegate(view).ifNull {
-        Log.w("ExpoModulesCore", "Property delegate for `$it` in ${kClass.simpleName} does not exist.")
+        logger.warn("⚠️ Property delegate for `$it` in ${kClass.simpleName} does not exist")
         return@forEach
       }
 
       val viewDelegate = (delegate as? ViewCallbackDelegate<*>).ifNull {
-        Log.w("ExpoModulesCore", "Property delegate for `$it` cannot be cased to `ViewCallbackDelegate`.")
+        logger.warn("⚠️ Property delegate for `$it` cannot be cased to `ViewCallbackDelegate`")
         return@forEach
       }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerWrapperDelegate.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerWrapperDelegate.kt
@@ -1,7 +1,6 @@
 package expo.modules.kotlin.views
 
 import android.content.Context
-import android.util.Log
 import android.view.View
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.common.MapBuilder


### PR DESCRIPTION
# Why

Improves logging in the expo modules core.

# How

On iOS, we logged more information about the correct initialization of the core components than on Android. This PR aims to change that by logging when the core Kotlin classes were initialized or destroyed correctly. 

# Test Plan

- bare-expo ✅