### PR TITLE
[modules][Android] Expose `NativeModulesProxy` config as a JSI module

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/ModuleRegistryAdapter.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/ModuleRegistryAdapter.java
@@ -117,7 +117,7 @@ public class ModuleRegistryAdapter implements ReactPackage {
     ReactApplicationContext reactContext,
     @Nullable ModuleRegistry moduleRegistry
   ) {
-    if (mModulesProxy != null && mModulesProxy.getKotlinInteropModuleRegistry().getWasDestroyed()) {
+    if (mModulesProxy != null && mModulesProxy.getKotlinInteropModuleRegistry().shouldBeRecreated(reactContext)) {
       mModulesProxy = null;
     }
     if (mModulesProxy == null) {
@@ -127,6 +127,8 @@ public class ModuleRegistryAdapter implements ReactPackage {
       } else {
         mModulesProxy = new NativeModulesProxy(reactContext, registry);
       }
+
+      mModulesProxy.getKotlinInteropModuleRegistry().setLegacyModulesProxy(mModulesProxy);
     }
 
     if (moduleRegistry != null && moduleRegistry != mModulesProxy.getModuleRegistry()) {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/NativeModulesProxy.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/NativeModulesProxy.java
@@ -53,6 +53,7 @@ public class NativeModulesProxy extends ReactContextBaseJavaModule {
   private Map<String, Map<String, Integer>> mExportedMethodsKeys;
   private Map<String, SparseArray<String>> mExportedMethodsReverseKeys;
   private KotlinInteropModuleRegistry mKotlinInteropModuleRegistry;
+  private Map<String, Object> cachedConstants;
 
   public NativeModulesProxy(ReactApplicationContext context, ModuleRegistry moduleRegistry) {
     super(context);
@@ -92,6 +93,10 @@ public class NativeModulesProxy extends ReactContextBaseJavaModule {
   @Nullable
   @Override
   public Map<String, Object> getConstants() {
+    if (cachedConstants != null) {
+      return cachedConstants;
+    }
+
     mModuleRegistry.ensureIsInitialized();
     getKotlinInteropModuleRegistry().installJSIInterop();
 
@@ -130,6 +135,8 @@ public class NativeModulesProxy extends ReactContextBaseJavaModule {
     constants.put(VIEW_MANAGERS_METADATA_KEY, viewManagersMetadata);
 
     Log.i("ExpoModulesCore", "✅ Constants was exported");
+
+    cachedConstants = constants;
 
     return constants;
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/defaultmodules/NativeModulesProxyModule.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/defaultmodules/NativeModulesProxyModule.kt
@@ -1,0 +1,16 @@
+package expo.modules.kotlin.defaultmodules
+
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+
+internal const val NativeModulesProxyModuleName = "NativeModulesProxy"
+
+class NativeModulesProxyModule : Module() {
+  override fun definition() = ModuleDefinition {
+    Name(NativeModulesProxyModuleName)
+
+    Constants {
+      appContext.legacyModulesProxyHolder?.get()?.constants ?: emptyMap()
+    }
+  }
+}


### PR DESCRIPTION
# Why

A follow-up to the https://github.com/expo/expo/pull/17741.
Part of ENG-5091.

# How

- Created a `NativeModulesProxyModule` that exports the same constants as a `ModulesProxyHolder`.
- Fixed issue with `getOrCreateNativeModulesProxy`.

> Note:
In the future, `ModulesProxyHolder` won't be exporting any constants. The whole config will be managed by the `ModulesProxyHolder`. 

# Test Plan

- bare-expo ✅