### PR TITLE
[docs] ensure that we always have active sidebar link in viewport

### DIFF
--- a/docs/ui/components/Sidebar/SidebarCollapsible.tsx
+++ b/docs/ui/components/Sidebar/SidebarCollapsible.tsx
@@ -58,14 +58,6 @@ export function SidebarCollapsible(props: Props) {
 
   useEffect(() => {
     if (containsActiveChild) {
-      const isBasePage = router.pathname.split('/').length < 3;
-      if (!hasCachedState && !isBasePage && !window.__sidebarScroll) {
-        if (ref?.current && ref?.current.offsetTop > 32) {
-          // note(simek): fix for URLs with '#' where we also scroll page content,
-          // probably can remove that workaround after refs refactor
-          setTimeout(() => ref?.current && ref.current.scrollIntoView({ behavior: 'smooth' }), 100);
-        }
-      }
       window.sidebarState[info.name] = true;
     }
   }, []);
@@ -75,6 +67,10 @@ export function SidebarCollapsible(props: Props) {
     window.sidebarState[info.name] = !isOpen;
   };
 
+  const customDataAttributes = containsActiveChild && {
+    'data-collapsible-active': true,
+  };
+
   return (
     <>
       <ButtonBase
@@ -82,7 +78,7 @@ export function SidebarCollapsible(props: Props) {
         css={titleStyle}
         aria-expanded={isOpen ? 'true' : 'false'}
         onClick={toggleIsOpen}
-        data-collapsible-active={containsActiveChild || undefined}>
+        {...customDataAttributes}>
         <div css={chevronContainerStyle}>
           <ChevronDownIcon
             size={iconSize.tiny}

--- a/docs/ui/components/Sidebar/SidebarLink.tsx
+++ b/docs/ui/components/Sidebar/SidebarLink.tsx
@@ -3,6 +3,7 @@ import { theme, typography, spacing } from '@expo/styleguide';
 import NextLink from 'next/link';
 import { useRouter } from 'next/router';
 import * as React from 'react';
+import { useEffect, useRef } from 'react';
 
 import stripVersionFromPath from '~/common/stripVersionFromPath';
 import { NavigationRoute } from '~/types/common';
@@ -11,12 +12,21 @@ type SidebarLinkProps = React.PropsWithChildren<{
   info: NavigationRoute;
 }>;
 
+const HEAD_NAV_HEIGHT = 160;
+
+const isLinkInViewport = (element: HTMLAnchorElement) => {
+  const rect = element.getBoundingClientRect();
+  return (
+    rect.top - HEAD_NAV_HEIGHT >= 0 &&
+    rect.left >= 0 &&
+    rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
+    rect.right <= (window.innerWidth || document.documentElement.clientWidth)
+  );
+};
+
 export const SidebarLink = ({ info, children }: SidebarLinkProps) => {
   const { asPath, pathname } = useRouter();
-
-  if (info.hidden) {
-    return null;
-  }
+  const ref = useRef<HTMLAnchorElement>(null);
 
   const checkSelection = () => {
     // Special case for root url
@@ -32,16 +42,27 @@ export const SidebarLink = ({ info, children }: SidebarLinkProps) => {
 
   const isSelected = checkSelection();
 
-  const customDataAttributes = isSelected
-    ? {
-        'data-sidebar-anchor-selected': true,
-      }
-    : {};
+  useEffect(() => {
+    if (isSelected && ref?.current && !isLinkInViewport(ref?.current)) {
+      setTimeout(() => ref?.current && ref.current.scrollIntoView({ behavior: 'smooth' }), 50);
+    }
+  }, []);
+
+  if (info.hidden) {
+    return null;
+  }
+
+  const customDataAttributes = isSelected && {
+    'data-sidebar-anchor-selected': true,
+  };
 
   return (
     <div css={STYLES_CONTAINER}>
       <NextLink href={info.href as string} as={info.as || info.href} passHref>
-        <a {...customDataAttributes} css={[STYLES_LINK, isSelected && STYLES_LINK_ACTIVE]}>
+        <a
+          {...customDataAttributes}
+          ref={ref}
+          css={[STYLES_LINK, isSelected && STYLES_LINK_ACTIVE]}>
           {isSelected && <div css={STYLES_ACTIVE_BULLET} />}
           {children}
         </a>
@@ -59,6 +80,7 @@ const STYLES_LINK = css`
   transition: 50ms ease color;
   align-items: flex-start;
   padding-left: ${spacing[4] + spacing[0.5]}px;
+  scroll-margin: 60px;
 
   &:hover {
     color: ${theme.link.default};


### PR DESCRIPTION
# Why

Fixes ENG-6397

# How

This PR moves scroll logic to the `SidebarLink` component and adds a check if link is in a view port which improves the UX of the sidebar even more without performing a large refactor.

It was possible to go with this approach thanks to `scroll-margin` CSS property - https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin - which allow us to add offset for the `scrollIntoView` final location.

# Test Plan

The changes have been tested by running docs website locally.

## Preview

![scr](https://user-images.githubusercontent.com/719641/191278410-7510dbce-6754-4633-b370-452bd47c5600.gif)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
