### PR TITLE
[docs] Explain how to use development builds for E2E tests

### DIFF
--- a/docs/pages/build-reference/e2e-tests.md
+++ b/docs/pages/build-reference/e2e-tests.md
@@ -417,29 +417,45 @@ const { exec } = require('child_process');
 const argparse = require('detox/src/utils/argparse');
 const appConfig = require('../app.json');
 
-//////////// General util methods //////////////
+/**
+ * General util methods
+ */
 
-// Async wait for n milliseconds
+/**
+ * Async wait for n milliseconds
+ */
 const sleepAsync = t => new Promise(res => setTimeout(res, t));
 
-// Get Detox configuration being used
+/**
+ * Get Detox configuration being used
+ */
 const getConfigurationName = () => argparse.getArgValue('configuration');
 
-// Get EAS app ID
+/**
+ * Get EAS app ID
+ */
 const getAppId = () => appConfig?.expo?.extra?.eas?.projectId || '';
 
-///////////// Methods to construct test URLs ///////////////
-
-// For local dev testing, returns the packager URL with the disable onboarding query param
+/**
+ * Methods to construct test URLs
+ */
+ 
+/**
+ * For local dev testing, returns the packager URL with the disable onboarding query param
+ */
 const getDevLauncherPackagerUrl = platform => {
   return `http://localhost:8081/index.bundle?platform=${platform}&dev=true&minify=false&disableOnboarding=1`;
 };
 
-// Returns the URL for the most recent update for the 'test_debug' EAS update channel
+/**
+ * Returns the URL for the most recent update for the 'test_debug' EAS update channel
+ */
 const getLatestUpdateUrl = () =>
   `https://u.expo.dev/${getAppId()}?channel-name=test_debug&disableOnboarding=1`;
 
-// Wraps a React Native bundle URL in the deep link form required by expo-dev-launcher for this app
+/**
+ * Wraps a React Native bundle URL in the deep link form required by expo-dev-launcher for this app
+ */
 const getDeepLinkUrl = url =>
   `eastestsexample://expo-development-client/?url=${encodeURIComponent(url)}`;
 

--- a/docs/pages/build-reference/e2e-tests.md
+++ b/docs/pages/build-reference/e2e-tests.md
@@ -245,7 +245,7 @@ If you have set up everything correctly you should see the successful test resul
 
 ### 6. Upload screenshots of failed test cases
 
-> This step is optional but highly recommended. 
+> This step is optional but highly recommended.
 
 When an E2E test case fails, it can be helpful to see the screenshot of the application state. EAS Build makes it easy to upload any arbitrary build artifacts using the [`buildArtifactPaths`](/build-reference/eas-json.md#buildartifactpaths) field in **eas.json**.
 
@@ -366,9 +366,9 @@ The above guide explains how to run E2E tests against a release build of your pr
 
 We can use [development builds](/development/introduction/) to load from a local development server or from [published updates](/eas-update/introduction/) instead, and save time and CI resources. This can be done by having your E2E test runner invoke the app with a URL that points to a specific update bundle URL, as described in the [development builds deep linking URLs guide](/development/development-workflows/#deep-linking-urls).
 
-Development builds typically display an onboarding welcome screen when an app is launched for the first time — this is intended to provide context about the expo-dev-client UI for developers, but it can interfere with your E2E tests (which expect to interact with your app and not an onboarding screen).  In order to skip the onboarding screen in a test environment, the query parameter `disableOnboarding=1` can be appended to the project URL (an EAS Update URL or a local development server URL).
+Development builds typically display an onboarding welcome screen when an app is launched for the first time — this is intended to provide context about the expo-dev-client UI for developers, but it can interfere with your E2E tests (which expect to interact with your app and not an onboarding screen). In order to skip the onboarding screen in a test environment, the query parameter `disableOnboarding=1` can be appended to the project URL (an EAS Update URL or a local development server URL).
 
-An example of such a Detox test is shown below.  Full example code is available on the [eas-tests-example repository](https://github.com/expo/eas-tests-example).
+An example of such a Detox test is shown below. Full example code is available on the [eas-tests-example repository](https://github.com/expo/eas-tests-example).
 
 <Collapsible summary="homeScreen.e2e.js">
 
@@ -413,7 +413,7 @@ describe('Home screen', () => {
 <Collapsible summary="utils.js">
 
 ```js
-const {exec} = require('child_process');
+const { exec } = require('child_process');
 const argparse = require('detox/src/utils/argparse');
 const appConfig = require('../app.json');
 
@@ -426,20 +426,22 @@ const sleepAsync = t => new Promise(res => setTimeout(res, t));
 const getConfigurationName = () => argparse.getArgValue('configuration');
 
 // Get EAS app ID
-const getAppId = () => appConfig?.expo?.extra?.eas?.projectId || "";
+const getAppId = () => appConfig?.expo?.extra?.eas?.projectId || '';
 
 ///////////// Methods to construct test URLs ///////////////
 
 // For local dev testing, returns the packager URL with the disable onboarding query param
-const getDevLauncherPackagerUrl = (platform) => {
+const getDevLauncherPackagerUrl = platform => {
   return `http://localhost:8081/index.bundle?platform=${platform}&dev=true&minify=false&disableOnboarding=1`;
 };
 
 // Returns the URL for the most recent update for the 'test_debug' EAS update channel
-const getLatestUpdateUrl = () => `https://u.expo.dev/${getAppId()}?channel-name=test_debug&disableOnboarding=1`;
+const getLatestUpdateUrl = () =>
+  `https://u.expo.dev/${getAppId()}?channel-name=test_debug&disableOnboarding=1`;
 
 // Wraps a React Native bundle URL in the deep link form required by expo-dev-launcher for this app
-const getDeepLinkUrl = (url) =>   `eastestsexample://expo-development-client/?url=${encodeURIComponent(url)}`;
+const getDeepLinkUrl = url =>
+  `eastestsexample://expo-development-client/?url=${encodeURIComponent(url)}`;
 
 module.exports = {
   sleepAsync,

--- a/docs/pages/build-reference/e2e-tests.md
+++ b/docs/pages/build-reference/e2e-tests.md
@@ -370,7 +370,7 @@ Development builds typically display an onboarding welcome screen when an app is
 
 An example of such a Detox test is shown below.  Full example code is available on the [eas-tests-example repository](https://github.com/expo/eas-tests-example).
 
-_homeScreen.e2e.js_:
+<Collapsible summary="homeScreen.e2e.js">
 
 ```js
 const {
@@ -408,7 +408,10 @@ describe('Home screen', () => {
 });
 ```
 
-_utils.js_:
+</Collapsible>
+
+<Collapsible summary="utils.js">
+
 ```js
 const {exec} = require('child_process');
 const argparse = require('detox/src/utils/argparse');
@@ -448,3 +451,5 @@ module.exports = {
   invokeDevLauncherUrl,
 };
 ```
+
+</Collapsible>

--- a/docs/pages/build-reference/e2e-tests.md
+++ b/docs/pages/build-reference/e2e-tests.md
@@ -357,3 +357,15 @@ Run a build with `eas build -p ios --profile test` and wait for the build to fin
 ## Repository
 
 The full example from this guide is available at https://github.com/expo/eas-tests-example.
+
+## Alternative Approaches
+
+### Using development builds to speed up test run time
+
+The above guide explains how to run E2E tests against a release build of your project, which requires executing a full native build before each test run. Re-building the native app each time you run E2E tests may not be desirable if only the project JavaScript or assets have changed, but this is necessary for release builds because the app JavaScript bundle is embedded into the binary.
+
+We can use [development builds](/development/introduction/) to load from a local development server or from [published updates](/eas-update/introduction/) instead, and save time and CI resources. This can be done by having your E2E test runner invoke the app with a URL that points to a specific update bundle URL, as described in the [development builds deep linking URLs guide](/development/development-workflows/#deep-linking-urls).
+
+Development builds typically display an onboarding welcome screen when an app is launched for the first time — this is intended to provide context about the expo-dev-client UI for developers, but it can interfere with your E2E tests (which expect to interact with your app and not an onboarding screen).  In order to skip the onboarding screen in a test environment, the query parameter `disableOnboarding=1` can be appended to the project URL (an EAS Update URL or a local development server URL).
+
+An example of a Detox test using this technique is available on the [eas-tests-example repository](https://github.com/expo/eas-tests-example).

--- a/docs/pages/build-reference/e2e-tests.md
+++ b/docs/pages/build-reference/e2e-tests.md
@@ -362,11 +362,11 @@ The full example from this guide is available at https://github.com/expo/eas-tes
 
 ### Using development builds to speed up test run time
 
-The above guide explains how to run E2E tests against a release build of your project, which requires executing a full native build before each test run. Re-building the native app each time you run E2E tests may not be desirable if only the project JavaScript or assets have changed, but this is necessary for release builds because the app JavaScript bundle is embedded into the binary.
+The above guide explains how to run E2E tests against a release build of your project, which requires executing a full native build before each test run. Re-building the native app each time you run E2E tests may not be desirable if only the project JavaScript or assets have changed. However, this is necessary for release builds because the app JavaScript bundle is embedded into the binary.
 
-We can use [development builds](/development/introduction/) to load from a local development server or from [published updates](/eas-update/introduction/) instead, and save time and CI resources. This can be done by having your E2E test runner invoke the app with a URL that points to a specific update bundle URL, as described in the [development builds deep linking URLs guide](/development/development-workflows/#deep-linking-urls).
+Instead, we can use [development builds](/development/introduction/) to load from a local development server or from [published updates](/eas-update/introduction/) to save time and CI resources. This can be done by having your E2E test runner invoke the app with a URL that points to a specific update bundle URL, as described in the [development builds deep linking URLs guide](/development/development-workflows/#deep-linking-urls).
 
-Development builds typically display an onboarding welcome screen when an app is launched for the first time — this is intended to provide context about the expo-dev-client UI for developers, but it can interfere with your E2E tests (which expect to interact with your app and not an onboarding screen). In order to skip the onboarding screen in a test environment, the query parameter `disableOnboarding=1` can be appended to the project URL (an EAS Update URL or a local development server URL).
+Development builds typically display an onboarding welcome screen when an app is launched for the first time, which intends to provide context about the `expo-dev-client` UI for developers. However, it can interfere with your E2E tests (which expect to interact with your app and not an onboarding screen). To skip the onboarding screen in a test environment, the query parameter `disableOnboarding=1` can be appended to the project URL (an EAS Update URL or a local development server URL).
 
 An example of such a Detox test is shown below. Full example code is available on the [eas-tests-example repository](https://github.com/expo/eas-tests-example).
 


### PR DESCRIPTION
# Why

Normally, when the dev launcher loads a bundle for the first time, the dev menu and an onboarding view are shown. With the changes in #19024 , the automatic popup of onboarding and dev menu can be disabled with an additional query parameter in the bundle URL.

This doc change explains how to use this feature to enable E2E testing of debug builds in EAS, including example source code.

Changes to the example app are currently in this branch:

https://github.com/expo/eas-tests-example/tree/doug/debug-testing

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
