### PR TITLE
[docs] Updating Images of Enabling Emulator for Expo-Location 

### DIFF
--- a/docs/pages/versions/unversioned/sdk/location.md
+++ b/docs/pages/versions/unversioned/sdk/location.md
@@ -135,13 +135,13 @@ const styles = StyleSheet.create({
 
 With Simulator open, go to Debug > Location and choose any option besides "None" (obviously).
 
-![iOS Simulator location](/static/images/ios-simulator-location.png)
+![iOS Simulator location](https://docs.expo.dev/static/images/ios-simulator-location.png)
 
 ### Android Emulator
 
 Open Android Studio, and launch your AVD in the emulator. Then, on the options bar for your device, click the icon for "More" and navigate to the "Location" tab.
 
-![Android Simulator location](/static/images/android-emulator-location.png)
+![Android Simulator location](https://docs.expo.dev/static/images/android-emulator-location.png)
 
 If you don't receive the locations in the emulator, you may have to turn off "Improve Location Accuracy" in Settings - Location in the emulator. This will turn off Wi-Fi location and only use GPS. Then you can manipulate the location with GPS data through the emulator.
 


### PR DESCRIPTION
Updating the images from the Expo Official website
* Before ![before](https://i.ibb.co/ZGFJhz1/Pje-Nl08-Lc-W.png)
* After ![before](https://i.ibb.co/P9qVpxF/chrome-4g-U1f-HKll7.png)

# Why

Image examples weren't showing

# Checklist

- [ YES] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ YES] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ YES] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
