### PR TITLE
[expo-tools] Improve generate-bare-app

### DIFF
--- a/tools/src/ExpoCLI.ts
+++ b/tools/src/ExpoCLI.ts
@@ -17,7 +17,7 @@ export async function runExpoCliAsync(
   process.on('SIGINT', () => {});
   process.on('SIGTERM', () => {});
 
-  await spawnAsync('expo', [command, ...args], {
+  await spawnAsync('npx', ['expo', command, ...args], {
     cwd: options.cwd || EXPO_DIR,
     stdio: options.stdio || 'inherit',
     env: {

--- a/tools/src/commands/GenerateBareApp.ts
+++ b/tools/src/commands/GenerateBareApp.ts
@@ -6,6 +6,7 @@ import path from 'path';
 import { EXPO_DIR, PACKAGES_DIR } from '../Constants';
 import { runExpoCliAsync } from '../ExpoCLI';
 import { GitDirectory } from '../Git';
+import { createFileTransform } from '../utils/createFileTransform';
 
 export type GenerateBareAppOptions = {
   name?: string;
@@ -92,7 +93,11 @@ async function createProjectDirectory({
   if (localTemplate) {
     const pathToBareTemplate = path.resolve(EXPO_DIR, 'templates', 'expo-template-bare-minimum');
     const pathToWorkspace = path.resolve(workspaceDir, appName);
-    return fs.copy(pathToBareTemplate, pathToWorkspace, { recursive: true });
+    return fs.copy(pathToBareTemplate, pathToWorkspace, {
+      recursive: true,
+      transformer: createFileTransform(appName),
+      resolver: createEntryResolver(appName)
+    });
   }
 
   return await runExpoCliAsync('init', [appName, '--no-install', '--template', template], {

--- a/tools/src/utils/createFileTransform.ts
+++ b/tools/src/utils/createFileTransform.ts
@@ -1,0 +1,94 @@
+// Copied from expo-cli (packages/expo-cli/src/commands/utils/createFileTransform.ts)
+import { IOSConfig } from '@expo/config-plugins';
+import Minipass from 'minipass';
+import * as path from 'path';
+import { ReadEntry } from 'tar';
+
+function escapeXMLCharacters(original: string): string {
+  const noAmps = original.replace('&', '&amp;');
+  const noLt = noAmps.replace('<', '&lt;');
+  const noGt = noLt.replace('>', '&gt;');
+  const noApos = noGt.replace('"', '\\"');
+  return noApos.replace("'", "\\'");
+}
+
+class Transformer extends Minipass {
+  data = '';
+
+  constructor(private settings: { name: string; extension: string }) {
+    super();
+  }
+
+  write(data: string) {
+    this.data += data;
+    return true;
+  }
+
+  getNormalizedName(): string {
+    if (['.xml', '.plist'].includes(this.settings.extension)) {
+      return escapeXMLCharacters(this.settings.name);
+    }
+    return this.settings.name;
+  }
+
+  end() {
+    const name = this.getNormalizedName();
+    const replaced = this.data
+      .replace(/Hello App Display Name/g, name)
+      .replace(/HelloWorld/g, IOSConfig.XcodeUtils.sanitizedName(name))
+      .replace(/helloworld/g, IOSConfig.XcodeUtils.sanitizedName(name.toLowerCase()));
+    super.write(replaced);
+    return super.end();
+  }
+}
+
+export function createEntryResolver(name: string) {
+  return (entry: ReadEntry) => {
+    if (name) {
+      // Rewrite paths for bare workflow
+      entry.path = entry.path
+        .replace(
+          /HelloWorld/g,
+          entry.path.includes('android')
+            ? IOSConfig.XcodeUtils.sanitizedName(name.toLowerCase())
+            : IOSConfig.XcodeUtils.sanitizedName(name)
+        )
+        .replace(/helloworld/g, IOSConfig.XcodeUtils.sanitizedName(name).toLowerCase());
+    }
+    if (entry.type && /^file$/i.test(entry.type) && path.basename(entry.path) === 'gitignore') {
+      // Rename `gitignore` because npm ignores files named `.gitignore` when publishing.
+      // See: https://github.com/npm/npm/issues/1862
+      entry.path = entry.path.replace(/gitignore$/, '.gitignore');
+    }
+  };
+}
+
+export function createFileTransform(name: string) {
+  return (entry: ReadEntry) => {
+    const extension = path.extname(entry.path);
+
+    // Binary files, don't process these (avoid decoding as utf8)
+    if (
+      ![
+        '.png',
+        '.jpg',
+        '.jpeg',
+        '.gif',
+        '.webp',
+        '.psd',
+        '.tiff',
+        '.svg',
+        '.jar',
+        '.keystore',
+
+        // Font files
+        '.otf',
+        '.ttf',
+      ].includes(extension) &&
+      name
+    ) {
+      return new Transformer({ name, extension });
+    }
+    return undefined;
+  };
+}


### PR DESCRIPTION
# Why

- `generate-bare-app` should now use `npx expo` instead of the globally installed `expo-cli` command
- When the `--localTemplate` option is used, the command simply copied the `bare-minimum` template files without modifying the default app name `HelloWorld` in the `ios` and `android` directories.

# How

- Modified `ExpoCLI` module to call `npx expo`
- Copied the utility module `createFileTransform.ts` from the `expo-cli` source and used that to transform the template files

# Test Plan

Manually tested generating an app.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
