### PR TITLE
[docs] ensure that `unversioned` docs do not appear in PROD

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -55,8 +55,6 @@ jobs:
       - name: 🏗️ Build Docs website for deploy
         run: yarn export
         timeout-minutes: 20
-        env:
-          USE_ESBUILD: 1
       # TODO(cedric): If we have time, we should make sure all links are valid and connected to a proper header
       # - name: lint links
       #   run: yarn lint-links --quiet

--- a/docs/constants/versions.js
+++ b/docs/constants/versions.js
@@ -29,16 +29,6 @@ export const BETA_VERSION = betaVersion ? `v${betaVersion}` : false;
  */
 export const VERSIONS = versionDirectories
   .filter(dir => {
-    // show all versions in dev mode
-    if (process.env.NODE_ENV !== 'production') {
-      return true;
-    }
-
-    // hide unversioned in production
-    if (dir === 'unversioned') {
-      return false;
-    }
-
     // show all other versions in production except
     // those greater than the package.json version number
     const dirVersion = semver.clean(dir);

--- a/docs/package.json
+++ b/docs/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "yarn generate-static-resoures && next dev -p 3002",
     "build": "next build",
-    "export": "yarn run build && next export && yarn run export-issue-404",
+    "export": "yarn generate-static-resoures production && yarn run build && next export && yarn run export-issue-404",
     "export-issue-404": "echo \"🛠  Patching https://github.com/vercel/next.js/issues/16528\"; cp out/404/index.html out/404.html",
     "export-server": "http-server out -p 8000",
     "import-react-native-docs": "node ./scripts/import-react-native-docs.js",

--- a/docs/scripts/generate-static-resources.js
+++ b/docs/scripts/generate-static-resources.js
@@ -8,10 +8,16 @@ import * as versions from '../constants/versions.js';
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 const basePath = path.join(dirname, '../', 'public', 'static', 'constants');
 
+const env = process.argv.slice(2)[0] || 'development';
+
 const writeResource = (filename, data) =>
   fs.writeFileSync(path.join(basePath, filename), JSON.stringify(data), { flag: 'wx' });
 
 fs.mkdirSync(basePath);
 
-writeResource('versions.json', versions);
+writeResource('versions.json', {
+  ...versions,
+  VERSIONS:
+    env === 'production' ? versions.VERSIONS.filter(v => v !== 'unversioned') : versions.VERSIONS,
+});
 writeResource('navigation.json', navigation);


### PR DESCRIPTION
# Why

Fixes ENG-6421

# How

After the MDX refactor we have ditech the Babel `@preval` in favor of static resource generation, unfortunately it looks like we cannot relay on the `process` env data anymore, so I have altered the generation script, so we can pass the env param now.

`error-utilities` were responsible for partially fixing this issue on PROD, since it was rewriting `unversioned` paths to `latest`, the problem was that API version selector still included the invalid label.

Additionally, I have removed the no longer necessary `USE_ESBUILD` flag from the docs workflow.

# Test Plan

The changes have been tested locally. I have run app in development mode and exported an prod variant too to ensure that problematic version i filtered out.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
