### PR TITLE
[docs][tutorial]: Update info about Snack button

### DIFF
--- a/docs/pages/tutorial/text.md
+++ b/docs/pages/tutorial/text.md
@@ -22,9 +22,8 @@ export default function App() {
   return (
     <View style={styles.container}>
       /* @info This used to say "Open up App.js to start working on your app!" and now it is slightly more useful. */
-      <Text>To share a photo from your phone with a friend, just press the button below!</Text>
-    /* @end */
-  </View>
+      <Text>To share a photo from your phone with a friend, just press the button below!</Text>/* @end */    
+    </View>
   );
 }
 
@@ -42,7 +41,7 @@ const styles = StyleSheet.create({
 
 <br/>
 
-> **Wait, what is this "Try this example on Snack" button!?**
+> **Wait, what is this "Open in Snack" button?**
 >
 > Snack is a web-based editor that works similar to a managed Expo project. It's a great way to share code snippets with people and try things out without needing to get a project running on your own computer with `expo-cli`. Go ahead, press the button. You will see the above code running in it. Switch between iOS, Android, or web. Open it on your device in the Expo Go app by pressing the "Run" button.
 
@@ -60,8 +59,7 @@ import { StyleSheet, Text, View } from 'react-native';
 export default function App() {
   return (
     <View style={styles.container}>
-      /* @info Set the style property with color and fontSize. There are many other styles available! Look at them in the <a href="https://reactnative.dev/docs/text#style" target="_blank">React Native Text API reference</a> sometime after you're done with this tutorial. */<Text style={{color: '#888', fontSize: 18}}> /* @end */
-
+      /* @info Set the style property with color and fontSize. There are many other styles available! Look at them in the <a href="https://reactnative.dev/docs/text#style" target="_blank">React Native Text API reference</a> sometime after you're done with this tutorial. */<Text style={{ color: '#888', fontSize: 18 }}> /* @end */ 
         To share a photo from your phone with a friend, just press the button below!
       </Text>
     </View>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently, the note in the https://docs.expo.dev/tutorial/text/ says, "Try this example on Snack".

We recently changed the Snack button title as well as the look and feel. This PR reflects the changed title in the note.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes can be tested by running `docs` locally and visiting http://localhost:3002/tutorial/text/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
