### PR TITLE
[docs][tutorial]: Add instructions & highlight for image-manipulator

### DIFF
--- a/docs/pages/tutorial/sharing.md
+++ b/docs/pages/tutorial/sharing.md
@@ -15,6 +15,12 @@ You can install expo-sharing in the same way as you installed expo-image-picker.
 
 <Terminal cmd={['$ npx expo install expo-sharing']} />
 
+## Installing expo-image-manipulator
+
+You'll also need expo-image-manipulator. In your project directory run:
+
+<Terminal cmd={['$ npx expo install expo-image-manipulator']} />
+
 ## Using expo-sharing to share an image
 
 <SnackInline label="Sharing" templateId="tutorial/sharing-simple" dependencies={['expo-image-picker', 'expo-sharing']}>
@@ -25,8 +31,7 @@ import React from 'react';
 import { Image, StyleSheet, Text, TouchableOpacity, View, /* @info This is required to determine which platform the code is going to run */ Platform /* @end */ } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
 /* @info As always, we must import it to use it */ import * as Sharing from 'expo-sharing'; /* @end */
-
-import * as ImageManipulator from "expo-image-manipulator";
+/* @info As always, we must import it to use it */ import * as ImageManipulator from "expo-image-manipulator"; /* @end */
 
 export default function App() {
   const [selectedImage, setSelectedImage] = React.useState(null);

--- a/docs/pages/tutorial/sharing.md
+++ b/docs/pages/tutorial/sharing.md
@@ -31,6 +31,7 @@ import React from 'react';
 import { Image, StyleSheet, Text, TouchableOpacity, View, /* @info This is required to determine which platform the code is going to run */ Platform /* @end */ } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
 /* @info As always, we must import it to use it */ import * as Sharing from 'expo-sharing'; /* @end */
+
 /* @info As always, we must import it to use it */ import * as ImageManipulator from "expo-image-manipulator"; /* @end */
 
 export default function App() {


### PR DESCRIPTION
# Why

Installing and importing `expo-image-manipulator` is missing from the [Sharing the image](https://docs.expo.dev/tutorial/sharing/) page in the Get Started Expo docs. This PR adds an instruction block to install the dependency from the command line & adds the yellow highlight the docs use to highlight diffs between each step of the guide.

# How

Was following the docs as a first time user & ran into a unhandled promise rejection. Mostly because I was following the highlights blind (it took me a sec to figure out there was an additional unhighlighted change that's necessary on this page).

# Test Plan

Installed the missing dependency & added the import statement.

At the risk of being verbose, there is no code change here. I'm just making it more obvious that you need to install a dependency & highlight the import statement diff with yellow in the browser.

# Checklist

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)