### PR TITLE
[docs][firebase] Add required config plugin step

### DIFF
--- a/docs/pages/versions/unversioned/sdk/firebase-analytics.md
+++ b/docs/pages/versions/unversioned/sdk/firebase-analytics.md
@@ -12,7 +12,7 @@ import { InlineCode } from '~/components/base/code';
 
 > **This is the only Firebase Analytics package for React Native that has universal platform support (iOS, Android, Web, and Electron).**
 
-`expo-firebase-analytics` enables the use of native Google Analytics for Firebase. Google Analytics for Firebase is a free app measurement solution that provides insight on app usage and user engagement.
+`expo-firebase-analytics` provides a unified native and web API for Google Analytics for Firebase, including partial Expo Go compatibility. Google Analytics for Firebase is a free app measurement solution that provides insight on app usage and user engagement.
 Learn more in the official [Firebase Docs](https://firebase.google.com/docs/analytics/).
 
 <PlatformsSection android emulator ios simulator web />
@@ -24,6 +24,31 @@ Learn more in the official [Firebase Docs](https://firebase.google.com/docs/anal
 When using the web platform, you'll also need to run `npx expo install firebase`, which installs the Firebase JS SDK.
 
 ## Configuration
+
+### Additional configuration for iOS
+
+`expo-firebase-analytics` uses native Firebase libraries on iOS that require additional configuration using the `expo-build-properties` config plugin. Install the plugin and apply the following configuration to your Expo config file.
+
+<Terminal cmd={["$ npx expo install expo-build-properties"]} />
+
+#### Example app.json with config plugin
+
+```json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-build-properties",
+        {
+          "ios": {
+            "useFrameworks": "static"
+          }
+        }
+      ]
+    ]
+  }
+}
+```
 
 ### With native Firebase SDK
 

--- a/docs/pages/versions/unversioned/sdk/firebase-analytics.md
+++ b/docs/pages/versions/unversioned/sdk/firebase-analytics.md
@@ -27,7 +27,7 @@ When using the web platform, you'll also need to run `npx expo install firebase`
 
 ### Additional configuration for iOS
 
-`expo-firebase-analytics` uses native Firebase libraries on iOS that require additional configuration using the `expo-build-properties` config plugin. Install the plugin and apply the following configuration to your Expo config file.
+`expo-firebase-analytics` uses native Firebase libraries on iOS that require additional configuration using the `expo-build-properties` config plugin. Install the plugin and apply the following configuration to your [Expo config](/workflow/configuration/) file.
 
 <Terminal cmd={["$ npx expo install expo-build-properties"]} />
 

--- a/docs/pages/versions/unversioned/sdk/firebase-recaptcha.md
+++ b/docs/pages/versions/unversioned/sdk/firebase-recaptcha.md
@@ -25,7 +25,7 @@ Additionally, you'll also need to install the webview using `npx expo install re
 
 ### Additional configuration for iOS
 
-`expo-firebase-recaptcha` uses native Firebase libraries on iOS that require additional configuration using the `expo-build-properties` config plugin. Install the plugin and apply the following configuration to your Expo config file.
+`expo-firebase-recaptcha` uses native Firebase libraries on iOS that require additional configuration using the `expo-build-properties` config plugin. Install the plugin and apply the following configuration to your [Expo config](/workflow/configuration/) file.
 
 <Terminal cmd={["$ npx expo install expo-build-properties"]} />
 

--- a/docs/pages/versions/unversioned/sdk/firebase-recaptcha.md
+++ b/docs/pages/versions/unversioned/sdk/firebase-recaptcha.md
@@ -23,6 +23,31 @@ Additionally, you'll also need to install the webview using `npx expo install re
 
 ## Usage
 
+### Additional configuration for iOS
+
+`expo-firebase-recaptcha` uses native Firebase libraries on iOS that require additional configuration using the `expo-build-properties` config plugin. Install the plugin and apply the following configuration to your Expo config file.
+
+<Terminal cmd={["$ npx expo install expo-build-properties"]} />
+
+#### Example app.json with config plugin
+
+```json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-build-properties",
+        {
+          "ios": {
+            "useFrameworks": "static"
+          }
+        }
+      ]
+    ]
+  }
+}
+```
+
 ### With React Native Firebase
 
 If you are using `expo-firebase-recaptcha` with React Native Firebase, you'll have to install the native SDK using the `npx expo install` command:

--- a/docs/pages/versions/v46.0.0/sdk/firebase-analytics.md
+++ b/docs/pages/versions/v46.0.0/sdk/firebase-analytics.md
@@ -12,7 +12,7 @@ import { InlineCode } from '~/components/base/code';
 
 > **This is the only Firebase Analytics package for React Native that has universal platform support (iOS, Android, Web, and Electron).**
 
-`expo-firebase-analytics` enables the use of native Google Analytics for Firebase. Google Analytics for Firebase is a free app measurement solution that provides insight on app usage and user engagement.
+`expo-firebase-analytics` provides a unified native and web API for Google Analytics for Firebase, including partial Expo Go compatibility. Google Analytics for Firebase is a free app measurement solution that provides insight on app usage and user engagement.
 Learn more in the official [Firebase Docs](https://firebase.google.com/docs/analytics/).
 
 <PlatformsSection android emulator ios simulator web />
@@ -24,6 +24,31 @@ Learn more in the official [Firebase Docs](https://firebase.google.com/docs/anal
 When using the web platform, you'll also need to run `npx expo install firebase`, which installs the Firebase JS SDK.
 
 ## Configuration
+
+### Additional configuration for iOS
+
+`expo-firebase-analytics` uses native Firebase libraries on iOS that require additional configuration using the `expo-build-properties` config plugin. Install the plugin and apply the following configuration to your Expo config file.
+
+<Terminal cmd={["$ npx expo install expo-build-properties"]} />
+
+#### Example app.json with config plugin
+
+```json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-build-properties",
+        {
+          "ios": {
+            "useFrameworks": "static"
+          }
+        }
+      ]
+    ]
+  }
+}
+```
 
 ### With native Firebase SDK
 

--- a/docs/pages/versions/v46.0.0/sdk/firebase-analytics.md
+++ b/docs/pages/versions/v46.0.0/sdk/firebase-analytics.md
@@ -27,7 +27,7 @@ When using the web platform, you'll also need to run `npx expo install firebase`
 
 ### Additional configuration for iOS
 
-`expo-firebase-analytics` uses native Firebase libraries on iOS that require additional configuration using the `expo-build-properties` config plugin. Install the plugin and apply the following configuration to your Expo config file.
+`expo-firebase-analytics` uses native Firebase libraries on iOS that require additional configuration using the `expo-build-properties` config plugin. Install the plugin and apply the following configuration to your [Expo config](/workflow/configuration/) file.
 
 <Terminal cmd={["$ npx expo install expo-build-properties"]} />
 

--- a/docs/pages/versions/v46.0.0/sdk/firebase-recaptcha.md
+++ b/docs/pages/versions/v46.0.0/sdk/firebase-recaptcha.md
@@ -25,7 +25,7 @@ Additionally, you'll also need to install the webview using `npx expo install re
 
 ### Additional configuration for iOS
 
-`expo-firebase-recaptcha` uses native Firebase libraries on iOS that require additional configuration using the `expo-build-properties` config plugin. Install the plugin and apply the following configuration to your Expo config file.
+`expo-firebase-recaptcha` uses native Firebase libraries on iOS that require additional configuration using the `expo-build-properties` config plugin. Install the plugin and apply the following configuration to your [Expo config](/workflow/configuration/) file.
 
 <Terminal cmd={["$ npx expo install expo-build-properties"]} />
 

--- a/docs/pages/versions/v46.0.0/sdk/firebase-recaptcha.md
+++ b/docs/pages/versions/v46.0.0/sdk/firebase-recaptcha.md
@@ -23,6 +23,31 @@ Additionally, you'll also need to install the webview using `npx expo install re
 
 ## Usage
 
+### Additional configuration for iOS
+
+`expo-firebase-recaptcha` uses native Firebase libraries on iOS that require additional configuration using the `expo-build-properties` config plugin. Install the plugin and apply the following configuration to your Expo config file.
+
+<Terminal cmd={["$ npx expo install expo-build-properties"]} />
+
+#### Example app.json with config plugin
+
+```json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-build-properties",
+        {
+          "ios": {
+            "useFrameworks": "static"
+          }
+        }
+      ]
+    ]
+  }
+}
+```
+
 ### With native Firebase SDK
 
 If you are using `expo-firebase-recaptcha` with React Native Firebase, you'll have to install the native SDK using the `npx expo install` command:


### PR DESCRIPTION
# Why

The latest versions of expo-firebase-* packages will cause builds to fail unless the `expo-build-properties` config plugin is used as specified, so this adds it to the docs and heads off "why isn't this working?" questions.

# How

Updated for unversioned and current SDK. Also tweaked the description on expo-firebase-analytics to de-emphasize its necessity.

# Additional thoughts
- On the SDK 46 doc only, technically speaking, since we updated this package mid-cycle, this only applies to `expo-firebase-analytics` >= 7.2.0. Not sure if we wanted to get that specific in this doc.