### PR TITLE
[modules][Android] Simplify unpacking of method results

### DIFF
--- a/packages/expo-modules-core/android/src/main/cpp/JNIFunctionBody.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JNIFunctionBody.cpp
@@ -7,7 +7,7 @@ namespace jni = facebook::jni;
 namespace react = facebook::react;
 
 namespace expo {
-jni::local_ref<react::ReadableNativeArray::javaobject>
+jni::local_ref<jni::JObject>
 JNIFunctionBody::invoke(jobjectArray args) {
   // Do NOT use getClass here!
   // Method obtained from `getClass` will point to the overridden version of the method.
@@ -15,9 +15,9 @@ JNIFunctionBody::invoke(jobjectArray args) {
   // if we receive an object of a different class than the one used to obtain the method id.
   // The only cacheable method id can be obtain from the base class.
   static const auto method = jni::findClassLocal("expo/modules/kotlin/jni/JNIFunctionBody")
-    ->getMethod<jni::local_ref<react::ReadableNativeArray::javaobject>(jobjectArray)>(
+    ->getMethod<jni::local_ref<jni::JObject>(jobjectArray)>(
       "invoke",
-      "([Ljava/lang/Object;)Lcom/facebook/react/bridge/ReadableNativeArray;"
+      "([Ljava/lang/Object;)Ljava/lang/Object;"
     );
 
   return method(this->self(), args);
@@ -37,7 +37,7 @@ void JNIAsyncFunctionBody::invoke(
       void(jobjectArray , jobject)
     >(
       "invoke",
-      "([Ljava/lang/Object;Ljava/lang/Object;)V"
+      "([Ljava/lang/Object;Lexpo/modules/kotlin/jni/PromiseImpl;)V"
     );
 
   method(this->self(), args, promise);

--- a/packages/expo-modules-core/android/src/main/cpp/JNIFunctionBody.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JNIFunctionBody.h
@@ -23,7 +23,7 @@ public:
    * @param args
    * @return result of the Kotlin function
    */
-  jni::local_ref<react::ReadableNativeArray::javaobject> invoke(
+  jni::local_ref<jni::JObject> invoke(
     jobjectArray args
   );
 };

--- a/packages/expo-modules-core/android/src/main/cpp/JNIInjector.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JNIInjector.cpp
@@ -6,6 +6,7 @@
 #include "JavaScriptObject.h"
 #include "JavaScriptTypedArray.h"
 #include "JavaReferencesCache.h"
+#include "JavaCallback.h"
 #include "types/FrontendConverterProvider.h"
 
 #if RN_FABRIC_ENABLED
@@ -27,6 +28,7 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *) {
     expo::JavaScriptValue::registerNatives();
     expo::JavaScriptObject::registerNatives();
     expo::JavaScriptTypedArray::registerNatives();
+    expo::JavaCallback::registerNatives();
 #if RN_FABRIC_ENABLED
     expo::FabricComponentsRegistry::registerNatives();
 #endif

--- a/packages/expo-modules-core/android/src/main/cpp/JavaCallback.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaCallback.cpp
@@ -1,0 +1,56 @@
+// Copyright © 2021-present 650 Industries, Inc. (aka Expo)
+
+#include "JavaCallback.h"
+
+namespace expo {
+
+JavaCallback::JavaCallback(Callback callback)
+  : callback(std::move(callback)) {}
+
+
+void JavaCallback::registerNatives() {
+  registerHybrid({
+                   makeNativeMethod("invoke", JavaCallback::invoke),
+                   makeNativeMethod("invoke", JavaCallback::invokeBool),
+                   makeNativeMethod("invoke", JavaCallback::invokeInt),
+                   makeNativeMethod("invoke", JavaCallback::invokeDouble),
+                   makeNativeMethod("invoke", JavaCallback::invokeFloat),
+                   makeNativeMethod("invoke", JavaCallback::invokeString),
+                   makeNativeMethod("invoke", JavaCallback::invokeArray),
+                   makeNativeMethod("invoke", JavaCallback::invokeMap),
+                 });
+}
+
+
+void JavaCallback::invoke() {
+  callback(nullptr);
+}
+
+void JavaCallback::invokeBool(bool result) {
+  callback(result);
+}
+
+void JavaCallback::invokeInt(int result) {
+  callback(result);
+}
+
+void JavaCallback::invokeDouble(double result) {
+  callback(result);
+}
+
+void JavaCallback::invokeFloat(float result) {
+  callback(result);
+}
+
+void JavaCallback::invokeString(jni::alias_ref<jstring> result) {
+  callback(result->toStdString());
+}
+
+void JavaCallback::invokeArray(jni::alias_ref<react::WritableNativeArray::javaobject> result) {
+  callback(result->cthis()->consume());
+}
+
+void JavaCallback::invokeMap(jni::alias_ref<react::WritableNativeMap::javaobject> result) {
+  callback(result->cthis()->consume());
+}
+} // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JavaCallback.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaCallback.h
@@ -1,0 +1,48 @@
+// Copyright © 2021-present 650 Industries, Inc. (aka Expo)
+
+#pragma once
+
+#include <fbjni/fbjni.h>
+#include <folly/dynamic.h>
+
+#include <react/jni/WritableNativeArray.h>
+#include <react/jni/WritableNativeMap.h>
+
+namespace jni = facebook::jni;
+namespace react = facebook::react;
+
+namespace expo {
+class JavaCallback : public jni::HybridClass<JavaCallback> {
+public:
+  static auto constexpr
+    kJavaDescriptor = "Lexpo/modules/kotlin/jni/JavaCallback;";
+  static auto constexpr TAG = "JavaCallback";
+
+  static void registerNatives();
+
+private:
+  friend HybridBase;
+
+  using Callback = std::function<void(folly::dynamic)>;
+
+  JavaCallback(Callback callback);
+
+  void invoke();
+
+  void invokeBool(bool result);
+
+  void invokeInt(int result);
+
+  void invokeDouble(double result);
+
+  void invokeFloat(float result);
+
+  void invokeString(jni::alias_ref<jstring> result);
+
+  void invokeArray(jni::alias_ref<react::WritableNativeArray::javaobject> result);
+
+  void invokeMap(jni::alias_ref<react::WritableNativeMap::javaobject> result);
+
+  Callback callback;
+};
+} // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JavaReferencesCache.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaReferencesCache.cpp
@@ -29,6 +29,10 @@ void JavaReferencesCache::loadJClasses(JNIEnv *env) {
     {"<init>", "(Lcom/facebook/react/bridge/Callback;Lcom/facebook/react/bridge/Callback;)V"}
   });
 
+  loadJClass(env, "expo/modules/kotlin/jni/PromiseImpl", {
+    {"<init>", "(Lexpo/modules/kotlin/jni/JavaCallback;Lexpo/modules/kotlin/jni/JavaCallback;)V"}
+  });
+
   loadJClass(env, "java/lang/Object", {});
   loadJClass(env, "java/lang/String", {});
   loadJClass(env, "expo/modules/kotlin/jni/JavaScriptObject", {});
@@ -36,6 +40,8 @@ void JavaReferencesCache::loadJClasses(JNIEnv *env) {
   loadJClass(env, "expo/modules/kotlin/jni/JavaScriptTypedArray", {});
   loadJClass(env, "com/facebook/react/bridge/ReadableNativeArray", {});
   loadJClass(env, "com/facebook/react/bridge/ReadableNativeMap", {});
+  loadJClass(env, "com/facebook/react/bridge/WritableNativeArray", {});
+  loadJClass(env, "com/facebook/react/bridge/WritableNativeMap", {});
 }
 
 void JavaReferencesCache::loadJClass(

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/Promise.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/Promise.kt
@@ -1,6 +1,10 @@
 package expo.modules.kotlin
 
+import com.facebook.react.bridge.WritableMap
 import expo.modules.kotlin.exception.CodedException
+import expo.modules.kotlin.jni.PromiseImpl
+
+private const val unknownCode = "UnknownCode"
 
 interface Promise {
   fun resolve(value: Any?)
@@ -9,5 +13,60 @@ interface Promise {
 
   fun reject(exception: CodedException) {
     reject(exception.code, exception.localizedMessage, exception.cause)
+  }
+}
+
+fun Promise.toBridgePromise(): com.facebook.react.bridge.Promise {
+  val expoPromise = this
+  val resolveMethod = if (expoPromise is PromiseImpl) {
+    expoPromise.resolveBlock::invoke
+  } else {
+    expoPromise::resolve
+  }
+
+  return object : com.facebook.react.bridge.Promise {
+    override fun resolve(value: Any?) {
+      resolveMethod(value)
+    }
+
+    override fun reject(code: String?, message: String?) {
+      expoPromise.reject(code ?: unknownCode, message, null)
+    }
+
+    override fun reject(code: String?, throwable: Throwable?) {
+      expoPromise.reject(code ?: unknownCode, null, throwable)
+    }
+
+    override fun reject(code: String?, message: String?, throwable: Throwable?) {
+      expoPromise.reject(code ?: unknownCode, message, throwable)
+    }
+
+    override fun reject(throwable: Throwable?) {
+      expoPromise.reject(unknownCode, null, throwable)
+    }
+
+    override fun reject(throwable: Throwable?, userInfo: WritableMap?) {
+      expoPromise.reject(unknownCode, null, throwable)
+    }
+
+    override fun reject(code: String?, userInfo: WritableMap) {
+      expoPromise.reject(code ?: unknownCode, null, null)
+    }
+
+    override fun reject(code: String?, throwable: Throwable?, userInfo: WritableMap?) {
+      expoPromise.reject(code ?: unknownCode, null, throwable)
+    }
+
+    override fun reject(code: String?, message: String?, userInfo: WritableMap) {
+      expoPromise.reject(code ?: unknownCode, message, null)
+    }
+
+    override fun reject(code: String?, message: String?, throwable: Throwable?, userInfo: WritableMap?) {
+      expoPromise.reject(code ?: unknownCode, message, throwable)
+    }
+
+    override fun reject(message: String?) {
+      expoPromise.reject(unknownCode, message, null)
+    }
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/defaultmodules/NativeModulesProxyModule.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/defaultmodules/NativeModulesProxyModule.kt
@@ -1,11 +1,11 @@
 package expo.modules.kotlin.defaultmodules
 
 import com.facebook.react.bridge.ReadableArray
-import expo.modules.kotlin.KPromiseWrapper
 import expo.modules.kotlin.Promise
 import expo.modules.kotlin.exception.UnexpectedException
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
+import expo.modules.kotlin.toBridgePromise
 
 internal const val NativeModulesProxyModuleName = "NativeModulesProxy"
 
@@ -18,8 +18,7 @@ class NativeModulesProxyModule : Module() {
     }
 
     AsyncFunction("callMethod") { moduleName: String, methodName: String, arguments: ReadableArray, promise: Promise ->
-      val kPromise = promise as KPromiseWrapper
-      val bridgePromise = kPromise.bridgePromise
+      val bridgePromise = promise.toBridgePromise()
       val legacyModulesProxyHolder = appContext.legacyModulesProxyHolder?.get()
         ?: throw UnexpectedException("The legacy modules proxy holder has been lost")
       legacyModulesProxyHolder.callMethod(moduleName, methodName, arguments, bridgePromise)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunction.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunction.kt
@@ -2,7 +2,6 @@ package expo.modules.kotlin.functions
 
 import com.facebook.react.bridge.ReadableArray
 import expo.modules.kotlin.AppContext
-import expo.modules.kotlin.KPromiseWrapper
 import expo.modules.kotlin.ModuleHolder
 import expo.modules.kotlin.Promise
 import expo.modules.kotlin.exception.CodedException
@@ -57,8 +56,6 @@ abstract class AsyncFunction(
       argsCount,
       desiredArgsTypes.map { it.getCppRequiredTypes() }.toTypedArray()
     ) { args, bridgePromise ->
-      val kotlinPromise = KPromiseWrapper(bridgePromise as com.facebook.react.bridge.Promise)
-
       val queue = when (queue) {
         Queues.MAIN -> appContext.mainQueue
         Queues.DEFAULT -> appContext.modulesQueue
@@ -69,12 +66,12 @@ abstract class AsyncFunction(
           exceptionDecorator({
             FunctionCallException(name, jsObject.name, it)
           }) {
-            callUserImplementation(args, kotlinPromise)
+            callUserImplementation(args, bridgePromise)
           }
         } catch (e: CodedException) {
-          kotlinPromise.reject(e)
+          bridgePromise.reject(e)
         } catch (e: Throwable) {
-          kotlinPromise.reject(UnexpectedException(e))
+          bridgePromise.reject(UnexpectedException(e))
         }
       }
     }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/SuspendFunctionComponent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/SuspendFunctionComponent.kt
@@ -2,7 +2,6 @@ package expo.modules.kotlin.functions
 
 import com.facebook.react.bridge.ReadableArray
 import expo.modules.kotlin.AppContext
-import expo.modules.kotlin.KPromiseWrapper
 import expo.modules.kotlin.ModuleHolder
 import expo.modules.kotlin.Promise
 import expo.modules.kotlin.exception.CodedException
@@ -52,8 +51,6 @@ class SuspendFunctionComponent(
       argsCount,
       desiredArgsTypes.map { it.getCppRequiredTypes() }.toTypedArray()
     ) { args, bridgePromise ->
-      val kotlinPromise = KPromiseWrapper(bridgePromise as com.facebook.react.bridge.Promise)
-
       val queue = when (queue) {
         Queues.MAIN -> appContext.mainQueue
         Queues.DEFAULT -> appContext.modulesQueue
@@ -66,13 +63,13 @@ class SuspendFunctionComponent(
           }) {
             val result = body.invoke(this, convertArgs(args))
             if (isActive) {
-              kotlinPromise.resolve(result)
+              bridgePromise.resolve(result)
             }
           }
         } catch (e: CodedException) {
-          kotlinPromise.reject(e)
+          bridgePromise.reject(e)
         } catch (e: Throwable) {
-          kotlinPromise.reject(UnexpectedException(e))
+          bridgePromise.reject(UnexpectedException(e))
         }
       }
     }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/SyncFunctionComponent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/SyncFunctionComponent.kt
@@ -1,6 +1,5 @@
 package expo.modules.kotlin.functions
 
-import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReadableArray
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.CodedException
@@ -34,8 +33,7 @@ class SyncFunctionComponent(
         FunctionCallException(name, jsObject.name, it)
       }) {
         val result = call(args)
-        val convertedResult = JSTypeConverter.convertToJSValue(result)
-        return@exceptionDecorator Arguments.fromJavaArgs(arrayOf(convertedResult))
+        return@exceptionDecorator JSTypeConverter.convertToJSValue(result)
       }
     }
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JNIFunctionBody.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JNIFunctionBody.kt
@@ -1,6 +1,5 @@
 package expo.modules.kotlin.jni
 
-import com.facebook.react.bridge.ReadableNativeArray
 import expo.modules.core.interfaces.DoNotStrip
 
 /**
@@ -12,13 +11,9 @@ import expo.modules.core.interfaces.DoNotStrip
 fun interface JNIFunctionBody {
   /**
    * Invokes the Kotlin part of the JNI function.
-   *
-   * We used a [com.facebook.react.bridge.ReadableNativeArray] to communicate with CPP, because
-   * right now it's the only object which is recognizable by those two worlds.
-   * In the future, we may want to swap it for something else.
    */
   @DoNotStrip
-  fun invoke(args: Array<Any?>): ReadableNativeArray?
+  fun invoke(args: Array<Any?>): Any?
 }
 
 /**
@@ -30,10 +25,7 @@ fun interface JNIFunctionBody {
 fun interface JNIAsyncFunctionBody {
   /**
    * Invokes the Kotlin part of the JNI function.
-   *
-   * Note: that the `bridgePromise` has type of [Any], but it should be an instance of [com.facebook.react.bridge.Promise].
-   * This is dictated by the fact that [com.facebook.react.bridge.Promise] isn't a hybrid object of jni::HybridClass.
    */
   @DoNotStrip
-  fun invoke(args: Array<Any?>, bridgePromise: Any)
+  fun invoke(args: Array<Any?>, bridgePromise: PromiseImpl)
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaCallback.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaCallback.kt
@@ -1,0 +1,43 @@
+package expo.modules.kotlin.jni
+
+import com.facebook.jni.HybridData
+import com.facebook.react.bridge.WritableNativeArray
+import com.facebook.react.bridge.WritableNativeMap
+import expo.modules.core.interfaces.DoNotStrip
+import expo.modules.kotlin.exception.UnexpectedException
+
+@Suppress("KotlinJniMissingFunction")
+@DoNotStrip
+class JavaCallback @DoNotStrip internal constructor(@DoNotStrip private val mHybridData: HybridData) {
+
+  operator fun invoke(result: Any?) {
+    if (result == null) {
+      invoke()
+      return
+    }
+    when (result) {
+      is Int -> invoke(result)
+      is Boolean -> invoke(result)
+      is Double -> invoke(result)
+      is Float -> invoke(result)
+      is String -> invoke(result)
+      is WritableNativeArray -> invoke(result)
+      is WritableNativeMap -> invoke(result)
+      else -> throw UnexpectedException("Unknown type: ${result.javaClass}")
+    }
+  }
+
+  private external fun invoke()
+  private external fun invoke(result: Int)
+  private external fun invoke(result: Boolean)
+  private external fun invoke(result: Double)
+  private external fun invoke(result: Float)
+  private external fun invoke(result: String)
+  private external fun invoke(result: WritableNativeArray)
+  private external fun invoke(result: WritableNativeMap)
+
+  @Throws(Throwable::class)
+  protected fun finalize() {
+    mHybridData.resetNative()
+  }
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/PromiseImpl.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/PromiseImpl.kt
@@ -1,0 +1,98 @@
+package expo.modules.kotlin.jni
+
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.bridge.WritableNativeArray
+import com.facebook.react.bridge.WritableNativeMap
+import expo.modules.core.interfaces.DoNotStrip
+import expo.modules.kotlin.Promise
+import expo.modules.kotlin.types.JSTypeConverter
+
+private const val ERROR_STACK_FRAME_LIMIT = 50
+
+private const val ERROR_DEFAULT_MESSAGE = "Error not specified."
+
+// Keys for reject WritableMap
+private const val ERROR_MAP_KEY_CODE = "code"
+private const val ERROR_MAP_KEY_MESSAGE = "message"
+private const val ERROR_MAP_KEY_USER_INFO = "userInfo"
+private const val ERROR_MAP_KEY_NATIVE_STACK = "nativeStackAndroid"
+
+// Keys for ERROR_MAP_KEY_NATIVE_STACK's StackFrame maps
+private const val STACK_FRAME_KEY_CLASS = "class"
+private const val STACK_FRAME_KEY_FILE = "file"
+private const val STACK_FRAME_KEY_LINE_NUMBER = "lineNumber"
+private const val STACK_FRAME_KEY_METHOD_NAME = "methodName"
+
+@DoNotStrip
+class PromiseImpl(
+  internal val resolveBlock: JavaCallback,
+  internal val rejectBlock: JavaCallback
+) : Promise {
+  private var wasResolve = false
+
+  override fun resolve(value: Any?) = checkIfWasResolved {
+    resolveBlock(
+      JSTypeConverter.convertToJSValue(value)
+    )
+  }
+
+  // Copy of the reject method from [com.facebook.react.bridge.PromiseImpl]
+  override fun reject(code: String, message: String?, cause: Throwable?) = checkIfWasResolved {
+    val errorInfo = WritableNativeMap()
+
+    errorInfo.putString(ERROR_MAP_KEY_CODE, code)
+
+    // Use the custom message if provided otherwise use the throwable message.
+    if (message != null) {
+      errorInfo.putString(ERROR_MAP_KEY_MESSAGE, message)
+    } else if (cause != null) {
+      errorInfo.putString(ERROR_MAP_KEY_MESSAGE, cause.message)
+    } else {
+      // The JavaScript side expects a map with at least an error message.
+      // /Libraries/BatchedBridge/NativeModules.js -> createErrorFromErrorData
+      // TYPE: (errorData: { message: string })
+      errorInfo.putString(ERROR_MAP_KEY_MESSAGE, ERROR_DEFAULT_MESSAGE)
+    }
+
+    // For consistency with iOS ensure userInfo key exists, even if we null it.
+    // iOS: /React/Base/RCTUtils.m -> RCTJSErrorFromCodeMessageAndNSError
+    errorInfo.putNull(ERROR_MAP_KEY_USER_INFO)
+
+    // Attach a nativeStackAndroid array if a throwable was passed
+    // this matches iOS behavior - iOS adds a `nativeStackIOS` property
+    // iOS: /React/Base/RCTUtils.m -> RCTJSErrorFromCodeMessageAndNSError
+    if (cause != null) {
+      val stackTrace: Array<StackTraceElement> = cause.stackTrace
+      val nativeStackAndroid = WritableNativeArray()
+
+      // Build an an Array of StackFrames to match JavaScript:
+      // iOS: /Libraries/Core/Devtools/parseErrorStack.js -> StackFrame
+      var i = 0
+      while (i < stackTrace.size && i < ERROR_STACK_FRAME_LIMIT) {
+        val frame = stackTrace[i]
+        val frameMap: WritableMap = WritableNativeMap()
+        // NOTE: no column number exists StackTraceElement
+        frameMap.putString(STACK_FRAME_KEY_CLASS, frame.className)
+        frameMap.putString(STACK_FRAME_KEY_FILE, frame.fileName)
+        frameMap.putInt(STACK_FRAME_KEY_LINE_NUMBER, frame.lineNumber)
+        frameMap.putString(STACK_FRAME_KEY_METHOD_NAME, frame.methodName)
+        nativeStackAndroid.pushMap(frameMap)
+        i++
+      }
+      errorInfo.putArray(ERROR_MAP_KEY_NATIVE_STACK, nativeStackAndroid)
+    } else {
+      errorInfo.putArray(ERROR_MAP_KEY_NATIVE_STACK, WritableNativeArray())
+    }
+
+    rejectBlock.invoke(errorInfo)
+  }
+
+  private inline fun checkIfWasResolved(body: () -> Unit) {
+    if (wasResolve) {
+      return
+    }
+
+    body()
+    wasResolve = true
+  }
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/PropertyComponent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/PropertyComponent.kt
@@ -1,6 +1,5 @@
 package expo.modules.kotlin.objects
 
-import com.facebook.react.bridge.Arguments
 import expo.modules.kotlin.functions.SyncFunctionComponent
 import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
@@ -29,8 +28,7 @@ class PropertyComponent(
   fun attachToJSObject(jsObject: JavaScriptModuleObject) {
     val jniGetter = if (getter != null) {
       JNIFunctionBody {
-        val result = getter.call(emptyArray())
-        return@JNIFunctionBody Arguments.fromJavaArgs(arrayOf(result))
+        return@JNIFunctionBody getter.call(emptyArray())
       }
     } else {
       null


### PR DESCRIPTION
# Why

Simplifies unpacking of method results.
Before, we used a similar approach to the RN when receiving results from Kotlin functions in Cpp. The result was obtained as a WritableArray, and then it was unpaced. That solution isn't ideal in the long term because we always return a single value.

# How

That change for the sync function was pretty straightforward. Right now, the Kotlin function body returns an arbitrary object which is later unpaced and converted to the jsi value. 
Unfortunately, to simplify the flow of async functions, I've to introduce my implementation of the callback and the promise. 

# Test Plan

- tests ✅
- bare-expo and NCL ✅

I've also run simply benchmarks:
Before:
![image](https://user-images.githubusercontent.com/9578601/191914435-8c7b4322-42dc-497f-9370-12e7294c7593.png)
After:
![image](https://user-images.githubusercontent.com/9578601/191914480-96533261-d2f4-4f93-a071-fd3dc558b069.png)
