### PR TITLE
docs: add newline to KeepAwake example

### DIFF
--- a/docs/pages/versions/unversioned/sdk/keep-awake.md
+++ b/docs/pages/versions/unversioned/sdk/keep-awake.md
@@ -32,6 +32,7 @@ export default function KeepAwakeExample() {
   /* @info As long as this component is mounted, the screen will not turn off from being idle. */
   useKeepAwake();
   /* @end */
+
   return (
     <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
       <Text>This screen will never sleep!</Text>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

https://docs.expo.dev/versions/latest/sdk/keep-awake/#example-hook

<img width="396" alt="image" src="https://user-images.githubusercontent.com/1404810/192098956-1cc1bdd9-26bd-410b-8ecc-07d81947de54.png">

Should probably be a bug fix in whatever reads the `@info` stuff, but this seems quicker 😀 

# How

GH editor

# Test Plan

Not sure 😀 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
