### PR TITLE
[docs] Added app-name for creation cmd

### DIFF
--- a/docs/pages/guides/typescript.md
+++ b/docs/pages/guides/typescript.md
@@ -66,7 +66,7 @@ Certain language features may require additional configuration, for example if y
 
 ## Starting from scratch: using a TypeScript template
 
-<Terminal cmd={['$ npx create-expo-app -t expo-template-blank-typescript']} cmdCopy="npx create-expo-app -t expo-template-blank-typescript" />
+<Terminal cmd={['$ npx create-expo-app app-name -t expo-template-blank-typescript']} cmdCopy="npx create-expo-app app-name -t expo-template-blank-typescript" />
 
 The easiest way to get started is to initialize your new project using a TypeScript template, then run `yarn tsc` or `npx tsc` to "typecheck" the project.
 


### PR DESCRIPTION
Added `app-name` for app creation command under the section `Starting from scratch: using a TypeScript template` to avoid `E404` error

# Why

Ensuring that developers that are new to expo managed react native don't run into the error as I did

# How

Found this when I was trying to create expo app with typescript template from [here](https://docs.expo.dev/guides/typescript/#starting-from-scratch-using-a-typescript-template)
