### PR TITLE
[docs] fix code annotation formatting

### DIFF
--- a/docs/components/base/code.tsx
+++ b/docs/components/base/code.tsx
@@ -133,7 +133,7 @@ export class Code extends React.Component<React.PropsWithChildren<Props>> {
           )}</span><span class="code-hidden">%%placeholder-end%%</span><span class="code-hidden">`;
         }
       )
-      .replace(/\s*<span class="token comment">&lt;!-- @end --><\/span>(\n *)?/g, '</span>');
+      .replace(/\s*<span class="token comment">&lt;!-- @end --><\/span>/g, '</span>');
   }
 
   private replaceHashCommentsWithAnnotations(value: string) {
@@ -150,7 +150,7 @@ export class Code extends React.Component<React.PropsWithChildren<Props>> {
           content
         )}</span><span class="code-hidden">%%placeholder-end%%</span><span class="code-hidden">`;
       })
-      .replace(/\s*<span class="token comment"># @end #<\/span>(\n *)?/g, '</span>');
+      .replace(/\s*<span class="token comment"># @end #<\/span>/g, '</span>');
   }
 
   private replaceSlashCommentsWithAnnotations(value: string) {
@@ -167,7 +167,7 @@ export class Code extends React.Component<React.PropsWithChildren<Props>> {
           content
         )}</span><span class="code-hidden">%%placeholder-end%%</span><span class="code-hidden">`;
       })
-      .replace(/\s*<span class="token comment">\/\* @end \*\/<\/span>(\n *)?/g, '</span>');
+      .replace(/\s*<span class="token comment">\/\* @end \*\/<\/span>/g, '</span>');
   }
 
   render() {


### PR DESCRIPTION
# Why

Code annotation parser fix for issue reported in #19237.

# How

At the beginning I thought that there is a difference when running locally vs exported but that was a bad guess.

The root of the problem was that the regex result differs when running app on Windows and Unix systems (EoL notation).

# Test Plan

I have run the website app locally on Windows and macOS, on both platforms the code block is formatted correctly and its content is exactly the same.

# Preview

<img width="594" alt="Screenshot 2022-09-25 at 17 36 43" src="https://user-images.githubusercontent.com/719641/192152015-5b53be13-e94c-4544-9280-7bc2396ce14d.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
