### PR TITLE
[docs] add ability to specify title of code block in MD files

### DIFF
--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -7394,7 +7394,7 @@ This can be used to quickly create specific permission hooks in every module.
     </div>
     <pre>
       <pre
-        class="css-1k9ceoi"
+        class="css-apshsk"
         data-text="true"
       >
         <code

--- a/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
+++ b/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
@@ -58,7 +58,7 @@ from the Google Play Store. In practice, the referrer URL may not be a complete,
   </div>
   <pre>
     <pre
-      class="css-1k9ceoi"
+      class="css-apshsk"
       data-text="true"
     >
       <code

--- a/docs/mdx-plugins/remark-code-title.js
+++ b/docs/mdx-plugins/remark-code-title.js
@@ -1,0 +1,18 @@
+import { visit } from 'unist-util-visit';
+
+/**
+ * This simple plugin appends the code block meta to the node value.
+ */
+export default function remarkLinkRewrite() {
+  return (tree, file) => {
+    if (!file.cwd || !file.history || !file.history.length) {
+      return;
+    }
+
+    visit(tree, 'code', node => {
+      if (node.meta) {
+        node.value = '@@@' + node.meta + '@@@' + node.value;
+      }
+    });
+  };
+}

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -9,6 +9,7 @@ import remarkMdxDisableExplicitJsx from 'remark-mdx-disable-explicit-jsx';
 import remarkMDXFrontmatter from 'remark-mdx-frontmatter';
 import semver from 'semver';
 
+import remarkCodeTitle from './mdx-plugins/remark-code-title.js';
 import remarkCreateStaticProps from './mdx-plugins/remark-create-static-props.js';
 import remarkExportHeadings from './mdx-plugins/remark-export-headings.js';
 import remarkLinkRewrite from './mdx-plugins/remark-link-rewrite.js';
@@ -53,6 +54,7 @@ export default {
               [remarkMdxDisableExplicitJsx, { whiteList: ['kbd'] }],
               remarkFrontmatter,
               [remarkMDXFrontmatter, { name: 'meta' }],
+              remarkCodeTitle,
               remarkExportHeadings,
               remarkLinkRewrite,
               [remarkCreateStaticProps, `{ meta: meta || {}, headings: headings || [] }`],

--- a/docs/pages/build-reference/npm-hooks.md
+++ b/docs/pages/build-reference/npm-hooks.md
@@ -2,8 +2,6 @@
 title: Build lifecycle hooks
 ---
 
-import { Collapsible } from '~/ui/components/Collapsible';
-
 There are five EAS Build lifecycle npm hooks that you can set in your **package.json**. See the [Android build process](android-builds.md) and [iOS build process](ios-builds.md) docs to get a better understanding about the internals of the build process.
 
 - `eas-build-pre-install` - executed before EAS Build runs `npm install`.
@@ -16,7 +14,7 @@ There are five EAS Build lifecycle npm hooks that you can set in your **package.
 
 This is an example of how your **package.json** might look like:
 
-```json
+```json package.json
 {
   "name": "my-app",
   "scripts": {
@@ -38,9 +36,11 @@ This is an example of how your **package.json** might look like:
 
 If you would like to run a script (or some part of a script) only for iOS builds or only for Android builds, you can fork the behavior depending on the platform within the script; iOS builds run on macOS (Darwin) and Android builds run on Ubuntu (Linux). See examples for common ways to do this through a shell script or a Node script below.
 
-<Collapsible summary="Example package.json and shell script">
+## Examples
 
-```json
+### `package.json` and shell script
+
+```json package.json
 {
   "name": "my-app",
   "scripts": {
@@ -54,23 +54,21 @@ If you would like to run a script (or some part of a script) only for iOS builds
 }
 ```
 
-```bash
+```bash pre-install
 #!/bin/bash
 # This is a file called "pre-install" in the root of the project
 
 unamestr=$(uname)
 if [[ "$unamestr" == 'Linux' ]]; then
-	echo "Linux detected, run commands for Android builds here"
+  echo "Linux detected, run commands for Android builds here"
 elif [[ "$unamestr" == 'Darwin' ]]; then
-	echo "macOS detected, run commands for iOS builds here"
+  echo "macOS detected, run commands for iOS builds here"
 fi
 ```
 
-</Collapsible>
+### `package.json` and Node script
 
-<Collapsible summary="Example package.json and Node script">
-
-```json
+```json package.json
 {
   "name": "my-app",
   "scripts": {
@@ -84,7 +82,7 @@ fi
 }
 ```
 
-```javascript
+```js pre-install.js
 // This is a file called "pre-install.js" in the root of the project
 if (process.platform === 'linux') {
   console.log('Linux detected, run commands for Android builds here');
@@ -92,5 +90,3 @@ if (process.platform === 'linux') {
   console.log('macOS detected, run commands for iOS builds here');
 }
 ```
-
-</Collapsible>

--- a/docs/pages/build/automating-submissions.md
+++ b/docs/pages/build/automating-submissions.md
@@ -16,8 +16,7 @@ By default, `--auto-submit` will try to use a submission profile with the same n
 
 When running `eas build --profile <profile-name> --auto-submit`, the project's **app.config.js** will be evaluated using any environment variables associated with the build profile `<profile-name>`. For example, suppose we ran `eas build -p ios --profile production --auto-submit` with the following configuration:
 
-```json
-// eas.json
+```json eas.json
 {
   "build": {
     "production": {
@@ -34,8 +33,7 @@ When running `eas build --profile <profile-name> --auto-submit`, the project's *
 }
 ```
 
-```js
-// app.config.js
+```js app.config.js
 export default () => {
   return {
     name: process.env.APP_ENV === 'production' ? 'My App' : 'My App (DEV)',

--- a/docs/pages/build/internal-distribution.md
+++ b/docs/pages/build/internal-distribution.md
@@ -20,7 +20,7 @@ The following three steps will guide you through adding internal distribution to
 
 Open up **eas.json** and add a new build profile for iOS and/or Android.
 
-```json
+```json eas.json
 {
   "build": {
     "preview": {

--- a/docs/pages/development/development-workflows.md
+++ b/docs/pages/development/development-workflows.md
@@ -83,7 +83,7 @@ Developers on your team with expertise working with Xcode and Android Studio can
 
 If you need to look at release builds of your project, it is convenient to not overwrite the development build of your app every time you do so. You can accomplish this by using [**app.config.js**](../workflow/configuration.md) to set the bundle identifier or package name based on an environment variable. When changing the ID of your project, be aware that some modules will expect you to perform installation steps for each bundle identifier or package name you use. [Learn more about how to use this pattern on EAS Build with build variants](/build-reference/variants.md).
 
-```js
+```js app.config.js
 // Example app.config.js where the bundle identifier and package name are
 // swapped out depending on an environment variable
 module.exports = () => {

--- a/docs/pages/distribution/app-stores.md
+++ b/docs/pages/distribution/app-stores.md
@@ -54,9 +54,9 @@ Apple will ask you a series of questions when you submit the app. Depending on w
 
 ## Localizing your iOS app
 
-If you plan on shipping your app to different countries, or regions, or want it to support various languages, you can provide [localized](/versions/latest/sdk/localization) strings for things like the display name and system dialogs. All of this is easily set up [in your app.json](/workflow/configuration). First, set `ios.infoPlist.CFBundleAllowMixedLocalizations: true`, then provide a list of file paths to `locales`.
+If you plan on shipping your app to different countries, or regions, or want it to support various languages, you can provide [localized](/versions/latest/sdk/localization) strings for things like the display name and system dialogs. All of this is easily set up [in your `app.json`](/workflow/configuration) file. First, set `ios.infoPlist.CFBundleAllowMixedLocalizations: true`, then provide a list of file paths to `locales`.
 
-```json
+```json app.json
 {
   "expo": {
     "ios": {
@@ -73,8 +73,7 @@ If you plan on shipping your app to different countries, or regions, or want it 
 
 The keys provided to `locales` should be the [language identifier](https://developer.apple.com/documentation/xcode/choosing-localization-regions-and-scripts), made up of a [2-letter language code](https://www.loc.gov/standards/iso639-2/php/code_list.php) of your desired language, with an optional region code (e.g. `en-US` or `en-GB`), and the value should point to a JSON file that looks something like this:
 
-```json
-// japanese.json
+```json japanese.json
 {
   "CFBundleDisplayName": "こんにちは",
   "NSContactsUsageDescription": "日本語のこれらの言葉"

--- a/docs/pages/guides/customizing-metro.md
+++ b/docs/pages/guides/customizing-metro.md
@@ -39,8 +39,7 @@ Metro resolves files as either source code or assets. Source code is JavaScript,
 
 The most common customization is to include extra asset extensions to Metro. In the **metro.config.js** file, add the file extension (without a leading `.`) to `resolver.assetExts`:
 
-```js
-// metro.config.js
+```js metro.config.js
 const { getDefaultConfig } = require('expo/metro-config');
 
 const config = getDefaultConfig(__dirname);

--- a/docs/pages/guides/environment-variables.md
+++ b/docs/pages/guides/environment-variables.md
@@ -17,9 +17,7 @@ In the app config, there is an `extra` property. This property is available when
 
 The following is an example of a [dynamic app config](/versions/latest/config/app/#app-config) that reads from [`process.env`](https://nodejs.org/dist/latest/docs/api/process.html#process_process_env) to set an environment variable on the `extra` field.
 
-```js
-// app.config.js
-
+```js app.config.js
 module.exports = {
   name: 'MyApp',
   version: '1.0.0',

--- a/docs/pages/guides/progressive-web-apps.md
+++ b/docs/pages/guides/progressive-web-apps.md
@@ -72,8 +72,7 @@ In order to add offline support, you'll need to add service workers to your proj
 
 Related applications can be inferred automatically from the following native **app.config.js** properties:
 
-```js
-// app.config.js
+```js app.config.js
 export default {
   ios: {
     bundleIdentifier: 'com.myapp',
@@ -89,7 +88,7 @@ export default {
 
 **Optionally** you could override these values by manually defining the related applications:
 
-```js
+```js app.config.js
 export default {
   web: {
     relatedApplications: [
@@ -120,7 +119,7 @@ Firstly, you'll need to generate the **web/index.html** with `npx expo customize
 - `touch web/manifest.json` or `expo-pwa manifest`
 - Add the following line to the `<head/>` element of your **web/index.html**:
 
-```html
+```html web/index.html
 <link rel="manifest" href="/manifest.json" />
 ```
 

--- a/docs/pages/workflow/configuration.md
+++ b/docs/pages/workflow/configuration.md
@@ -59,8 +59,7 @@ module.exports = {
 
 Extras can be accessed via `expo-constants`:
 
-```ts
-// App.js
+```ts App.js
 import Constants from 'expo-constants';
 
 Constants.manifest.extra.fact === 'kittens are cool';
@@ -70,7 +69,7 @@ You can access and modify incoming config values by exporting a function that re
 
 For example, your **app.json** could look like this:
 
-```json
+```json app.json
 {
   "expo": {
     "name": "My App"
@@ -80,7 +79,7 @@ For example, your **app.json** could look like this:
 
 And in your **app.config.js**, you are provided with that configuration in the arguments to the exported function:
 
-```js
+```js app.config.js
 module.exports = ({ config }) => {
   console.log(config.name); // prints 'My App'
   return {
@@ -93,7 +92,7 @@ module.exports = ({ config }) => {
 
 It's common to have some different configuration in development, staging, and production environments, or to swap out configuration entirely in order to white label an app. To accomplish this, you can use **app.config.js** along with environment variables.
 
-```js
+```js app.config.js
 module.exports = () => {
   if (process.env.MY_ENVIRONMENT === 'production') {
     return {
@@ -113,9 +112,7 @@ To use this configuration with Expo CLI commands, set the environment variable e
 
 You can use autocomplete and doc-blocks with a TypeScript Expo config **app.config.ts**. Create an **app.config.ts** with the following contents:
 
-```ts
-// app.config.ts
-
+```ts app.config.ts
 // `@expo/config` is installed with the `expo` package
 // ensuring the versioning is correct.
 import { ExpoConfig, ConfigContext } from '@expo/config';


### PR DESCRIPTION
# Why

Feature request for a while, which simplifies the process on naming code blocks.

# How

This PR adds the simple remark plugin which appends the code block meta to the value. Then, in code block component we detect this insertion, and based on that the default code block or Snippet is rendered.

Additionally, I have added the "Copy" button which includes the value before the highlight and without the comments.

I have replaced few entires in the MD as an example, but for sure there are more place where we can utilize this feature.

As a follow up for this PR, I would like to refactor the `code` component, move it to the new `ui` directory and add tests for component render and all regex operations performed within it.

# Test Plan

The changes have been tested by running docs website locally.

Additionally, I have verified that all types of annotations related to the website displays are correctly removed, when user copy the code block content.

# Preview

<img width="1162" alt="Screenshot 2022-09-26 at 11 40 22" src="https://user-images.githubusercontent.com/719641/192244852-e66fe391-0eed-4e21-9792-dc41463454c0.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
