### PR TITLE
[docs] BoxLink: fix mobile appearance

### DIFF
--- a/docs/ui/components/BoxLink/index.tsx
+++ b/docs/ui/components/BoxLink/index.tsx
@@ -6,7 +6,8 @@ import {
   ArrowRightIcon,
   iconSize,
   shadows,
-  ArrowUpRightIcon, breakpoints,
+  ArrowUpRightIcon,
+  breakpoints,
 } from '@expo/styleguide';
 import type { IconProps } from '@expo/styleguide/dist/types';
 import React, { ComponentType, PropsWithChildren, ReactNode } from 'react';

--- a/docs/ui/components/BoxLink/index.tsx
+++ b/docs/ui/components/BoxLink/index.tsx
@@ -6,7 +6,7 @@ import {
   ArrowRightIcon,
   iconSize,
   shadows,
-  ArrowUpRightIcon,
+  ArrowUpRightIcon, breakpoints,
 } from '@expo/styleguide';
 import type { IconProps } from '@expo/styleguide/dist/types';
 import React, { ComponentType, PropsWithChildren, ReactNode } from 'react';
@@ -69,8 +69,12 @@ const tileIconBackgroundStyle = css({
   alignSelf: 'center',
   alignItems: 'center',
   justifyContent: 'center',
-  width: 36,
+  minWidth: 36,
   height: 36,
+
+  [`@media screen and (max-width: ${(breakpoints.medium + breakpoints.large) / 2}px)`]: {
+    alignSelf: 'flex-start',
+  },
 });
 
 const arrowIconStyle = css({


### PR DESCRIPTION
# Why

Fixes ENG-6461

# How

Correct BoxLink icon styles on mobile.

# Test Plan

The changes have been tested by running docs website locally in browser and on the hardware device.

<img width="380" align="left" src="https://user-images.githubusercontent.com/719641/192251512-590a87a8-e804-479a-bbf4-9257a1e589c6.PNG">
<img width="380" alt="Screenshot 2022-09-26 at 12 06 38" src="https://user-images.githubusercontent.com/719641/192251727-1e1c588d-6fb6-4783-af2f-f7ddab52db48.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
