### PR TITLE
[docs]: Use npx expo install commands in SDK 46 API reference index

### DIFF
--- a/docs/pages/versions/unversioned/index.md
+++ b/docs/pages/versions/unversioned/index.md
@@ -10,7 +10,7 @@ import { InlineCode } from '~/components/base/code';
 
 <VersionedRedirectNotification />
 
-The Expo SDK provides access to device and system functionality such as contacts, camera, gyroscope, GPS location, etc., in the form of packages. You can install any Expo SDK package using the `npx expo install` command. For example, three different packages are installed using the following command:
+The Expo SDK provides access to device and system functionality such as contacts, camera, gyroscope, GPS location, and so on, in the form of packages. You can install any Expo SDK package using the `npx expo install` command. For example, three different packages are installed using the following command:
 
 <Terminal cmd={['$ npx expo install expo-camera expo-contacts expo-sensors']} />
 

--- a/docs/pages/versions/v46.0.0/index.md
+++ b/docs/pages/versions/v46.0.0/index.md
@@ -10,9 +10,9 @@ import { InlineCode } from '~/components/base/code';
 
 <VersionedRedirectNotification />
 
-The Expo SDK provides access to device and system functionality such as contacts, camera, gyroscope, GPS location, etc., in the form of packages. You can install any Expo SDK package using `expo-cli` with the `expo install` command. For example, three different packages are installed using the following command:
+The Expo SDK provides access to device and system functionality such as contacts, camera, gyroscope, GPS location, and so on, in the form of packages. You can install any Expo SDK package using the `npx expo install` command. For example, three different packages are installed using the following command:
 
-<Terminal cmd={['$ expo install expo-camera expo-contacts expo-sensors']} />
+<Terminal cmd={['$ npx expo install expo-camera expo-contacts expo-sensors']} />
 
 After installing one or more packages, you can import them into your JavaScript code:
 


### PR DESCRIPTION

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Refs ENG-6424

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Update the verbiage in the `unversioned` docs for API reference index page
- Update the command to use `npx expo` in SDK 46 for API reference index page
- Match the introduction on both of the above pages to be same

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and then go to https://localhost:3002/versions/latest/ 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
