### PR TITLE
[writing-styleguide]: Add a soft rule about referencing multiple platforms

### DIFF
--- a/guides/Expo Documentation Writing Style Guide.md
+++ b/guides/Expo Documentation Writing Style Guide.md
@@ -100,6 +100,10 @@ Always use a capital "B" for bytes. Write "bit" or a lowercase "b" for bits. For
 
 For an in-detail reference on Bytes and Bits, read the [Writing API documentation](#writing-api-documentation).
 
+### Referencing Android, iOS and Web
+
+In most cases, to refer to multiple platforms (Android, iOS and Web) in one sentence or order sections on a particular page, follow the pattern: **"Android, iOS, and Web"**.
+
 ## Punctuation
 
 ### Use double quotes in prose


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Refs ENG-6291

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
