### PR TITLE
[cli] Use bundle id from app.json or native project for launching redirect page

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### 🐛 Bug fixes
 
+- Resolve bundle identifier / package from native project and then fallback to `app.json` when launching redirect page. ([#19260](https://github.com/expo/expo/pull/19260) by [@brentvatne](https://github.com/brentvatne))
 - Resolve bundle identifier from `app.json` correctly when using `npx expo start --dev-client --ios` with no local `ios` directory. ([#18747](https://github.com/expo/expo/pull/18747) by [@EvanBacon](https://github.com/EvanBacon))
 - Add web support check to metro web in `expo start`. ([#18428](https://github.com/expo/expo/pull/18428) by [@EvanBacon](https://github.com/EvanBacon))
 - Prevent development session bad gateway from ending long running `expo start` processes. ([#18451](https://github.com/expo/expo/pull/18451) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/src/start/platforms/PlatformManager.ts
+++ b/packages/@expo/cli/src/start/platforms/PlatformManager.ts
@@ -68,7 +68,7 @@ export class PlatformManager<
     const redirectUrl = this.props.getRedirectUrl();
     if (redirectUrl) {
       // If the redirect page feature is enabled, check if the project has a resolvable native identifier.
-      const applicationId = await this._getAppIdResolver().resolveAppIdFromNativeAsync();
+      const applicationId = await this._getAppIdResolver().getAppIdAsync();
       if (applicationId) {
         debug(`Resolving launch URL: (appId: ${applicationId}, redirect URL: ${redirectUrl})`);
         // NOTE(EvanBacon): This adds considerable amount of time to the command, we should consider removing or memoizing it.


### PR DESCRIPTION
# Why

I was testing the interstitial page on sdk-46 branch and noticed that even when we link to the redirect page via the QR code, when you try to launch for iOS/Android through the interactive prompt it will boot directly into Expo Go. This happens if you don't have a native project locally (often the case when using dev clients).

<img width="1013" alt="image" src="https://user-images.githubusercontent.com/90494/192392144-30b3dfee-0299-4e16-b781-3c03833df9a5.png">

# How

Use the app id resolver that looks up the native id first and then uses the app config value if not available.

# Test Plan

```
yarn create expo-app tryit
cd tryit
yarn expo install expo-dev-client
# add bundle id to app.json
nexpo start
# press i, you will see "The expo-dev-client package is installed, but a development build is not installed" warning - this is correct. If you install a dev client with the package name, it'll launch interstitial
# add package to app.json
# press a, you will see "The expo-dev-client package is installed, but a development build is not installed" warning - this is correct. If you install a dev client with the package name, it'll launch interstitial
```

<img width="1254" alt="image" src="https://user-images.githubusercontent.com/90494/192392906-44ed9b33-12a1-49a1-b9ac-8bfd31b4a849.png">

- Try `nexpo start` on projects without expo-dev-client, it has no impact