### PR TITLE
[docs] update callouts on the pages

### DIFF
--- a/docs/pages/build-reference/variables.md
+++ b/docs/pages/build-reference/variables.md
@@ -78,7 +78,10 @@ You can create up to 100 account-wide secrets for each Expo account and 100 app-
 
 You can manage secrets through the Expo website and EAS CLI.
 
-> ⚠️ Always remember that **anything that is included in your client side code should be considered public and readable to any individual that can run the application**. EAS Secrets are intended to be used to provide values to an EAS Build job so that they may be used during the build process. Examples of correct usage include setting the `NPM_TOKEN` for installing private packages from npm, or a Sentry API key to create a release and upload your sourcemaps to their service. EAS Secrets do not provide any additional security for values that you end up embedding in your application itself, such as an AWS access key or other private keys.
+> **warning** Always remember that **anything that is included in your client side code should be considered public and readable to any individual that can run the application**. 
+> EAS Secrets are intended to be used to provide values to an EAS Build job so that they may be used during the build process. 
+> Examples of correct usage include setting the `NPM_TOKEN` for installing private packages from npm, or a Sentry API key to create a release and upload your sourcemaps to their service. 
+> EAS Secrets do not provide any additional security for values that you end up embedding in your application itself, such as an AWS access key or other private keys.
 
 ### Secrets on the Expo website
 

--- a/docs/pages/build/building-on-ci.md
+++ b/docs/pages/build/building-on-ci.md
@@ -42,7 +42,7 @@ To install EAS CLI in your project, run:
 npm install --save-dev eas-cli
 ```
 
-> 💡 Make sure to update this dependency frequently to stay up to date with the EAS API interface. */}
+> **info** Make sure to update this dependency frequently to stay up to date with the EAS API interface. */}
 
 ### Provide a personal access token to authenticate with your Expo account on CI
 

--- a/docs/pages/development/getting-started.md
+++ b/docs/pages/development/getting-started.md
@@ -106,7 +106,8 @@ then register the plugin in your `app.json`. Using this module will require new 
 }
 ```
 
-> ⚠️ Because adding this module changes your native runtime, you'll need to generate a new development build before using it. If you forget to do so, you'll get an `Invariant Violation: Native module cannot be null.` error when you attempt to load your app.
+> **warning** Because adding this module changes your native runtime, you'll need to generate a new development build before using it. 
+> If you forget to do so, you'll get an `Invariant Violation: Native module cannot be null.` error when you attempt to load your app.
 
 Once you've generated new builds with EAS build or the `expo run:ios`/`expo run:android` commands, you can access the new capabilities in your app's code.
 

--- a/docs/pages/eas-update/code-signing.md
+++ b/docs/pages/eas-update/code-signing.md
@@ -6,7 +6,7 @@ import Head from '~/components/Head'
 
 <Head title="EAS Update Code Signing" />
 
-> ⚠️ Expo Updates code signing is in early beta, meaning that it is not yet ready for use in production apps. We may still make breaking changes to the developer-facing portion and the end-user portion as well.
+> **warning** Expo Updates code signing is in early beta, meaning that it is not yet ready for use in production apps. We may still make breaking changes to the developer-facing portion and the end-user portion as well.
 
 > EAS Update Code Signing is only available to accounts subscribed to the EAS Enterprise plan. [Sign up](https://expo.dev/pricing).
 

--- a/docs/pages/eas-update/expo-dev-client.md
+++ b/docs/pages/eas-update/expo-dev-client.md
@@ -2,7 +2,7 @@
 title: Using expo-dev-client with EAS Update
 ---
 
-> ⚠️ This guide is likely to change as we continue to work on EAS Update.
+> **warning** This guide is likely to change as we continue to work on EAS Update.
 
 The [`expo-dev-client`](/development/introduction) library allows us to launch different versions of our project. One of the most popular use-cases is to preview a published update inside a development build, using the `expo-dev-client` library.
 

--- a/docs/pages/eas/metadata/config.md
+++ b/docs/pages/eas/metadata/config.md
@@ -3,11 +3,9 @@ title: Configuring EAS Metadata
 sidebar_title: store.config.json
 ---
 
-import { Callout } from '~/ui/components/Callout';
 import { CodeBlocksTable } from '~/components/plugins/CodeBlocksTable';
 
-<Callout type="warning">EAS Metadata is in beta and subject to breaking changes.</Callout>
-<br />
+> **warning** EAS Metadata is in beta and subject to breaking changes.
 
 EAS Metadata is configured by a **store.config.json** file at the _root of your project_.
 

--- a/docs/pages/eas/metadata/faq.md
+++ b/docs/pages/eas/metadata/faq.md
@@ -3,9 +3,7 @@ title: EAS Metadata - FAQ
 sidebar_title: FAQ
 ---
 
-import { Callout } from '~/ui/components/Callout';
-
-<Callout type="warning">EAS Metadata is in beta and subject to breaking changes.</Callout>
+> **warning** EAS Metadata is in beta and subject to breaking changes.
 
 ## Pitch
 

--- a/docs/pages/eas/metadata/getting-started.md
+++ b/docs/pages/eas/metadata/getting-started.md
@@ -4,12 +4,10 @@ sidebar_title: Getting started
 ---
 
 import { BoxLink } from '~/ui/components/BoxLink';
-import { Callout } from '~/ui/components/Callout';
 import { Terminal } from '~/ui/components/Snippet';
 import { CodeBlocksTable } from '~/components/plugins/CodeBlocksTable';
 
-<Callout type="warning">EAS Metadata is in beta and subject to breaking changes.</Callout>
-<br />
+> **warning** EAS Metadata is in beta and subject to breaking changes.
 
 EAS Metadata enables you to automate and maintain your app store presence from the command line. It uses a [**store.config.json**](./config.md#static-store-config) file containing all required app information instead of going through multiple different forms. It also tries to find common pitfalls that could cause app rejections with built-in validation.
 

--- a/docs/pages/eas/metadata/index.md
+++ b/docs/pages/eas/metadata/index.md
@@ -5,11 +5,9 @@ hideTOC: true
 ---
 
 import { BoxLink } from '~/ui/components/BoxLink';
-import { Callout } from '~/ui/components/Callout';
 import { Terminal } from '~/ui/components/Snippet';
 
-<Callout type="warning">  EAS Metadata is in beta and subject to breaking changes.</Callout>
-<br />
+> **warning** EAS Metadata is in beta and subject to breaking changes.
 
 **EAS Metadata** enables you to automate and maintain your app store presence from the command line.
 

--- a/docs/pages/eas/metadata/schema.md
+++ b/docs/pages/eas/metadata/schema.md
@@ -4,7 +4,6 @@ sidebar_title: Metadata schema
 sidebar_depth: 4
 ---
 
-import { Callout } from '~/ui/components/Callout';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { markdownComponents as MD } from '~/ui/components/Markdown';
 import { CodeBlocksTable } from '~/components/plugins/CodeBlocksTable';
@@ -16,8 +15,7 @@ import {
   MetadataDescriptionCell,
 } from '~/components/plugins/EasMetadataTable';
 
-<Callout type="warning">EAS Metadata is in beta and subject to breaking changes.</Callout>
-<br />
+> **warning** EAS Metadata is in beta and subject to breaking changes.
 
 The store config in EAS Metadata contains information that otherwise would be provided manually through the app store dashboards.
 This document outlines the structure of the object in your store config.

--- a/docs/pages/guides/authentication.md
+++ b/docs/pages/guides/authentication.md
@@ -508,7 +508,7 @@ You must use the proxy service in the Expo Go app because `exp://` cannot be add
 - Copy the "App ID" in the header into your `expoClientId: '<YOUR FBID>'`. Ex: `{ expoClientId: '474614477183384' }` (no `fb` prefix).
 - Now you're ready to use the demo component in the Expo Go app on iOS and Android.
 
-> ⚠️ If you forget to add the correct URL to the "Valid OAuth Redirect URIs", you will get an error like: `Can't Load URL: The domain of this URL isn't included in the app's domains. To be able to load this URL, add all domains and subdomains of your app to the App Domains field in your app settings.`
+> **warning** If you forget to add the correct URL to the "Valid OAuth Redirect URIs", you will get an error like: `Can't Load URL: The domain of this URL isn't included in the app's domains. To be able to load this URL, add all domains and subdomains of your app to the App Domains field in your app settings.`
 
 #### Custom Apps
 
@@ -570,7 +570,7 @@ Then add `<data android:scheme="fb<YOUR ID>"/>` to the `.MainActivity` `intent-f
 
 #### Troubleshooting native
 
-> ⚠️ The `native` redirect URI **must** be formatted like `fb<YOUR FBID>://authorize`, ex: `fb474614477183384://authorize`. Using the `Facebook` provider will do this automatically.
+> **warning** The `native` redirect URI **must** be formatted like `fb<YOUR FBID>://authorize`, ex: `fb474614477183384://authorize`. Using the `Facebook` provider will do this automatically.
 
 - If the protocol/suffix is not your FBID then you will get an error like: `No redirect URI in the params: No redirect present in URI`.
 - If the path is not `://authorize` then you will get an error like: `Can't Load URL: The domain of this URL isn't included in the app's domains. To be able to load this URL, add all domains and subdomains of your app to the App Domains field in your app settings.`

--- a/docs/pages/guides/configuring-statusbar.md
+++ b/docs/pages/guides/configuring-statusbar.md
@@ -92,7 +92,7 @@ export default function Playlists() {
 
 If you use `expo-status-bar` to control your status bar style, the `style="auto"` configuration will automatically pick the appropriate default style depending on the color scheme currently used by the app (this is the default behavior, if you leave out the style prop entirely then `auto` will be used). Please note that if you provide a way for users to toggle between color schemes rather than using the operating system theme, this will not have the intended behavior, and you should use `style="light"` and `style="dark"` as needed depending on the selected color scheme.
 
-> 💡Automatic theme detection is only supported in SDK 38 or higher. Prior to SDK 38, `auto` will not change depending on your color scheme, it will always assume that the theme is light.
+> **info** Automatic theme detection is only supported in SDK 38 or higher. Prior to SDK 38, `auto` will not change depending on your color scheme, it will always assume that the theme is light.
 
 ## Factoring the status bar in with your layout
 

--- a/docs/pages/guides/monorepos.md
+++ b/docs/pages/guides/monorepos.md
@@ -7,7 +7,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 
 Monorepos, or _"monolithic repositories"_, are single repositories containing multiple apps or packages. It can help speed up development for larger projects, makes it easier to share code, and act as a single source of truth. This guide will set up a simple monorepo with an Expo project. We currently have first-class support for yarn workspaces. If you want to use another tool, make sure you know how to configure it.
 
-> ⚠️ Monorepos are not for everyone. It requires in-depth knowledge of the used tooling, adds more complexity, and often requires specific tooling configuration. You can get far with just a single repository.
+> **warning** Monorepos are not for everyone. It requires in-depth knowledge of the used tooling, adds more complexity, and often requires specific tooling configuration. You can get far with just a single repository.
 
 <Collapsible summary="Using SDK older than 43?">
 
@@ -49,7 +49,7 @@ Yarn and other tooling have a concept called _"workspaces"_. Every package and a
 }
 ```
 
-> ⚠️ Yarn workspaces require the root **package.json** to be private. If you don't set this, `yarn install` will error with a message mentioning this.
+> **warning** Yarn workspaces require the root **package.json** to be private. If you don't set this, `yarn install` will error with a message mentioning this.
 
 ### Create our first app
 
@@ -201,7 +201,7 @@ import App from './App';
 registerRootComponent(App);
 ```
 
-> 💡 This new entrypoint already exists for bare projects. You only need to add this if you have a managed project.
+> **info** This new entrypoint already exists for bare projects. You only need to add this if you have a managed project.
 
 ### Create a package
 

--- a/docs/pages/guides/using-custom-fonts.md
+++ b/docs/pages/guides/using-custom-fonts.md
@@ -256,7 +256,7 @@ const styles = StyleSheet.create({
 
 </SnackInline>
 
-> ⚠️ **If loading remote fonts, make sure they are being served from an origin with CORS properly configured**. If you don't do this, your remote font might not load properly on the web platform.
+> **warning**  **If loading remote fonts, make sure they are being served from an origin with CORS properly configured**. If you don't do this, your remote font might not load properly on the web platform.
 
 ### Using `Font.loadAsync` instead of the `useFonts` hook
 

--- a/docs/pages/modules/android-lifecycle-listeners.md
+++ b/docs/pages/modules/android-lifecycle-listeners.md
@@ -2,11 +2,9 @@
 title: Android Lifecycle Listeners
 ---
 
-import { Callout } from '~/ui/components/Callout';
 import { Tab, Tabs } from '~/components/plugins/Tabs';
 
-<Callout type="warning">Expo Modules APIs are in beta and subject to breaking changes.</Callout>
-<br />
+> **warning** Expo Modules APIs are in beta and subject to breaking changes.
 
 In order to respond to certain Android system events relevant to an app, such as inbound links and configuration changes, it is necessary to override the corresponding lifecycle callbacks in **MainActivity.java** and/or **MainApplication.java**.
 

--- a/docs/pages/modules/appdelegate-subscribers.md
+++ b/docs/pages/modules/appdelegate-subscribers.md
@@ -2,11 +2,9 @@
 title: iOS AppDelegate Subscribers
 ---
 
-import { Callout } from '~/ui/components/Callout';
 import { CodeBlocksTable } from '~/components/plugins/CodeBlocksTable';
 
-<Callout type="warning">Expo Modules APIs are in beta and subject to breaking changes.</Callout>
-<br />
+> **warning** Expo Modules APIs are in beta and subject to breaking changes.
 
 In order to respond to certain iOS system events relevant to an app, such as inbound links and notifications, it is necessary to handle the corresponding methods in the `AppDelegate`.
 

--- a/docs/pages/modules/module-api.md
+++ b/docs/pages/modules/module-api.md
@@ -2,13 +2,11 @@
 title: Native Modules
 ---
 
-import { Callout } from '~/ui/components/Callout';
 import { CodeBlocksTable } from '~/components/plugins/CodeBlocksTable';
 import { PlatformTag } from '~/ui/components/Tag';
 import { APIBox } from '~/components/plugins/APIBox';
 
-<Callout type="warning">Expo Modules APIs are in beta and subject to breaking changes.</Callout>
-<br />
+> **warning** Expo Modules APIs are in beta and subject to breaking changes.
 
 The native modules API is an abstraction layer on top of [JSI](https://reactnative.dev/architecture/glossary#javascript-interfaces-jsi) and other low-level primities that React Native is built upon. It is built with modern languages (Swift and Kotlin) and provides an easy to use and convenient API that is consistent across platforms where possible.
 

--- a/docs/pages/modules/module-config.md
+++ b/docs/pages/modules/module-config.md
@@ -2,10 +2,7 @@
 title: Module Config
 ---
 
-import { Callout } from '~/ui/components/Callout';
-
-<Callout type="warning">Expo Modules APIs are in beta and subject to breaking changes.</Callout>
-<br />
+> **warning** Expo Modules APIs are in beta and subject to breaking changes.
 
 Expo modules are configured in **expo-module.config.json**. This file currently is capable of configuring autolinking and module registration. The following properties are available:
 

--- a/docs/pages/modules/overview.md
+++ b/docs/pages/modules/overview.md
@@ -2,11 +2,9 @@
 title: Overview
 ---
 
-import { Callout } from '~/ui/components/Callout';
 import { CodeBlocksTable } from '~/components/plugins/CodeBlocksTable';
 
-<Callout type="warning">Expo Modules APIs are in beta and subject to breaking changes.</Callout>
-<br />
+> **warning** Expo Modules APIs are in beta and subject to breaking changes.
 
 Expo provides a set of APIs and utilities to improve the process of developing native modules for Expo and React Native and expand your app capabilities.
 

--- a/docs/pages/versions/unversioned/sdk/camera.md
+++ b/docs/pages/versions/unversioned/sdk/camera.md
@@ -13,7 +13,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 <PlatformsSection android ios web />
 
-> 💡 Android devices can use one of two available Camera APIs: you can opt-in to using [`Camera2`](https://developer.android.com/reference/android/hardware/camera2/package-summary) with the `useCamera2Api` prop.
+> **info** Android devices can use one of two available Camera APIs: you can opt-in to using [`Camera2`](https://developer.android.com/reference/android/hardware/camera2/package-summary) with the `useCamera2Api` prop.
 
 ## Installation
 
@@ -21,7 +21,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 ## Usage
 
-> ⚠️ Only one Camera preview can be active at any given time. If you have multiple screens in your app, you should unmount `Camera` components whenever a screen is unfocused.
+> **warning** Only one Camera preview can be active at any given time. If you have multiple screens in your app, you should unmount `Camera` components whenever a screen is unfocused.
 
 <SnackInline label='Basic Camera usage' dependencies={['expo-camera']}>
 

--- a/docs/pages/versions/unversioned/sdk/clipboard.md
+++ b/docs/pages/versions/unversioned/sdk/clipboard.md
@@ -73,7 +73,7 @@ const styles = StyleSheet.create({
 import * as Clipboard from 'expo-clipboard';
 ```
 
-> ⚠️ On Web, this module uses the [`AsyncClipboard` API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API),
+> **warning** On Web, this module uses the [`AsyncClipboard` API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API),
 > which might behave differently between browsers or not be fully supported.
 > Especially on WebKit, there's an issue which makes this API unusable in asynchronous code.
 > [Click here for more details](https://bugs.webkit.org/show_bug.cgi?id=222262).

--- a/docs/pages/versions/unversioned/sdk/in-app-purchases.md
+++ b/docs/pages/versions/unversioned/sdk/in-app-purchases.md
@@ -8,7 +8,7 @@ import {APIInstallSection} from '~/components/plugins/InstallSection';
 import APISection from '~/components/plugins/APISection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-> ⚠️ **Development of `expo-in-app-purchases` is currently paused to focus on other projects**. Alternative libraries include [`react-native-iap`](https://github.com/dooboolab/react-native-iap) and [`react-native-purchases` from RevenueCat](https://www.revenuecat.com/blog/using-revenuecat-with-expos-managed-workflow/).
+> **warning** **Development of `expo-in-app-purchases` is currently paused to focus on other projects**. Alternative libraries include [`react-native-iap`](https://github.com/dooboolab/react-native-iap) and [`react-native-purchases` from RevenueCat](https://www.revenuecat.com/blog/using-revenuecat-with-expos-managed-workflow/).
 
 **`expo-in-app-purchases`** provides an API to accept payments for in-app products. Internally this relies on the [Google Play Billing](https://developer.android.com/google/play/billing/billing_library_overview) library on Android and the [StoreKit](https://developer.apple.com/documentation/storekit?language=objc) framework on iOS.
 

--- a/docs/pages/versions/unversioned/sdk/masked-view.md
+++ b/docs/pages/versions/unversioned/sdk/masked-view.md
@@ -9,9 +9,9 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`@react-native-masked-view/masked-view`** provides a masked view which only displays the pixels that overlap with the view rendered in its mask element.
 
-> ⚠️ You can only have one of either `@react-native-community/masked-view` (deprecated) or `@react-native-masked-view/masked-view` installed in your project at any given time. React Navigation v6 and above requires `@react-native-masked-view/masked-view`, so you should use that package instead if you are using the latest version of React Navigation.
+> **warning** You can only have one of either `@react-native-community/masked-view` (deprecated) or `@react-native-masked-view/masked-view` installed in your project at any given time. React Navigation v6 and above requires `@react-native-masked-view/masked-view`, so you should use that package instead if you are using the latest version of React Navigation.
 
-> ⚠️ Android support for this library is experimental and you may encounter inconsistencies in behavior across platforms. Please report issues you encounter to [react-native-masked-view/masked-view/issues](https://github.com/react-native-masked-view/masked-view).
+> **warning** Android support for this library is experimental and you may encounter inconsistencies in behavior across platforms. Please report issues you encounter to [react-native-masked-view/masked-view/issues](https://github.com/react-native-masked-view/masked-view).
 
 <PlatformsSection android emulator ios simulator />
 

--- a/docs/pages/versions/unversioned/sdk/media-library.md
+++ b/docs/pages/versions/unversioned/sdk/media-library.md
@@ -12,7 +12,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-media-library`** provides access to the user's media library, allowing them to access their existing images and videos from your app, as well as save new ones. You can also subscribe to any updates made to the user's media library.
 
-> ⚠️ If your Android app created an album using SDK &lt;= 40 and you want to add more assets to this album, you may need to migrate it to the new scoped directory. Otherwise, your app won't have access to the old album directory and expo-media-library won't be able to add new assets to it. However, all other functions will work without problems. You only need to migrate the old album if you want to add something to it. For more information, check out [Android R changes](https://expo.fyi/android-r) and [`MediaLibrary.migrateAlbumIfNeededAsync`](#medialibrarymigratealbumifneededasyncalbum).
+> **warning** If your Android app created an album using SDK &lt;= 40 and you want to add more assets to this album, you may need to migrate it to the new scoped directory. Otherwise, your app won't have access to the old album directory and expo-media-library won't be able to add new assets to it. However, all other functions will work without problems. You only need to migrate the old album if you want to add something to it. For more information, check out [Android R changes](https://expo.fyi/android-r) and [`MediaLibrary.migrateAlbumIfNeededAsync`](#medialibrarymigratealbumifneededasyncalbum).
 
 <PlatformsSection android emulator ios simulator />
 

--- a/docs/pages/versions/unversioned/sdk/picker.md
+++ b/docs/pages/versions/unversioned/sdk/picker.md
@@ -12,7 +12,7 @@ import Video from '~/components/plugins/Video'
 
 A component that provides access to the system UI for picking between several options.
 
-> 💡 This library was formerly known as `@react-native-community/picker`. If you have that library in your SDK 40+ project, you can uninstall it and install this one instead.
+> **info** This library was formerly known as `@react-native-community/picker`. If you have that library in your SDK 40+ project, you can uninstall it and install this one instead.
 
 <PlatformsSection android emulator ios simulator web />
 

--- a/docs/pages/versions/v45.0.0/sdk/camera.md
+++ b/docs/pages/versions/v45.0.0/sdk/camera.md
@@ -13,7 +13,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 <PlatformsSection android ios web />
 
-> 💡 Android devices can use one of two available Camera APIs: you can opt-in to using [`Camera2`](https://developer.android.com/reference/android/hardware/camera2/package-summary) with the `useCamera2Api` prop.
+> **info** Android devices can use one of two available Camera APIs: you can opt-in to using [`Camera2`](https://developer.android.com/reference/android/hardware/camera2/package-summary) with the `useCamera2Api` prop.
 
 ## Installation
 
@@ -21,7 +21,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 ## Usage
 
-> ⚠️ Only one Camera preview can be active at any given time. If you have multiple screens in your app, you should unmount `Camera` components whenever a screen is unfocused.
+> **warning** Only one Camera preview can be active at any given time. If you have multiple screens in your app, you should unmount `Camera` components whenever a screen is unfocused.
 
 <SnackInline label='Basic Camera usage' dependencies={['expo-camera']}>
 

--- a/docs/pages/versions/v45.0.0/sdk/clipboard.md
+++ b/docs/pages/versions/v45.0.0/sdk/clipboard.md
@@ -73,7 +73,7 @@ const styles = StyleSheet.create({
 import * as Clipboard from 'expo-clipboard';
 ```
 
-> ⚠️ On Web, this module uses the [`AsyncClipboard` API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API),
+> **warning** On Web, this module uses the [`AsyncClipboard` API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API),
 > which might behave differently between browsers or not be fully supported.
 > Especially on WebKit, there's an issue which makes this API unusable in asynchronous code.
 > [Click here for more details](https://bugs.webkit.org/show_bug.cgi?id=222262).

--- a/docs/pages/versions/v45.0.0/sdk/facebook.md
+++ b/docs/pages/versions/v45.0.0/sdk/facebook.md
@@ -25,7 +25,7 @@ For bare apps, here are links to the [iOS Installation Walkthrough](https://deve
 
 ## Registering your app with Facebook
 
-> 💡 When following these steps you will find on the Facebook Developer site that there are many fields and steps that you don't actually care about. Just look for the information that we ask you for and you will be OK!
+> **info** When following these steps you will find on the Facebook Developer site that there are many fields and steps that you don't actually care about. Just look for the information that we ask you for and you will be OK!
 
 Follow [Facebook's developer documentation](https://developers.facebook.com/docs/apps/register) to register an application with Facebook's API and get an application ID. Take note of this application ID because it will be used as the `appId` option in your [`Facebook.logInWithReadPermissionsAsync`](#expofacebookloginwithreadpermissionsasync 'Facebook.logInWithReadPermissionsAsync') call.
 

--- a/docs/pages/versions/v45.0.0/sdk/in-app-purchases.md
+++ b/docs/pages/versions/v45.0.0/sdk/in-app-purchases.md
@@ -8,7 +8,7 @@ import {APIInstallSection} from '~/components/plugins/InstallSection';
 import APISection from '~/components/plugins/APISection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-> ⚠️ **Development of `expo-in-app-purchases` is currently paused to focus on other projects**. Alternative libraries include [`react-native-iap`](https://github.com/dooboolab/react-native-iap) and [`react-native-purchases` from RevenueCat](https://www.revenuecat.com/blog/using-revenuecat-with-expos-managed-workflow/).
+> **warning** **Development of `expo-in-app-purchases` is currently paused to focus on other projects**. Alternative libraries include [`react-native-iap`](https://github.com/dooboolab/react-native-iap) and [`react-native-purchases` from RevenueCat](https://www.revenuecat.com/blog/using-revenuecat-with-expos-managed-workflow/).
 
 **`expo-in-app-purchases`** provides an API to accept payments for in-app products. Internally this relies on the [Google Play Billing](https://developer.android.com/google/play/billing/billing_library_overview) library on Android and the [Storekit](https://developer.apple.com/documentation/storekit?language=objc) framework on iOS.
 

--- a/docs/pages/versions/v45.0.0/sdk/masked-view.md
+++ b/docs/pages/versions/v45.0.0/sdk/masked-view.md
@@ -9,9 +9,9 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`@react-native-masked-view/masked-view`** provides a masked view which only displays the pixels that overlap with the view rendered in its mask element.
 
-> ⚠️ You can only have one of either `@react-native-community/masked-view` (deprecated) or `@react-native-masked-view/masked-view` installed in your project at any given time. React Navigation v6 and above requires `@react-native-masked-view/masked-view`, so you should use that package instead if you are using the latest version of React Navigation.
+> **warning** You can only have one of either `@react-native-community/masked-view` (deprecated) or `@react-native-masked-view/masked-view` installed in your project at any given time. React Navigation v6 and above requires `@react-native-masked-view/masked-view`, so you should use that package instead if you are using the latest version of React Navigation.
 
-> ⚠️ Android support for this library is experimental and you may encounter inconsistencies in behavior across platforms. Please report issues you encounter to [react-native-masked-view/masked-view/issues](https://github.com/react-native-masked-view/masked-view).
+> **warning** Android support for this library is experimental and you may encounter inconsistencies in behavior across platforms. Please report issues you encounter to [react-native-masked-view/masked-view/issues](https://github.com/react-native-masked-view/masked-view).
 
 <PlatformsSection android emulator ios simulator />
 

--- a/docs/pages/versions/v45.0.0/sdk/media-library.md
+++ b/docs/pages/versions/v45.0.0/sdk/media-library.md
@@ -12,7 +12,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-media-library`** provides access to the user's media library, allowing them to access their existing images and videos from your app, as well as save new ones. You can also subscribe to any updates made to the user's media library.
 
-> ⚠️ If your Android app created an album using SDK &lt;= 40 and you want to add more assets to this album, you may need to migrate it to the new scoped directory. Otherwise, your app won't have access to the old album directory and expo-media-library won't be able to add new assets to it. However, all other functions will work without problems. You only need to migrate the old album if you want to add something to it. For more information, check out [Android R changes](https://expo.fyi/android-r) and [`MediaLibrary.migrateAlbumIfNeededAsync`](#medialibrarymigratealbumifneededasyncalbum).
+> **warning** If your Android app created an album using SDK &lt;= 40 and you want to add more assets to this album, you may need to migrate it to the new scoped directory. Otherwise, your app won't have access to the old album directory and expo-media-library won't be able to add new assets to it. However, all other functions will work without problems. You only need to migrate the old album if you want to add something to it. For more information, check out [Android R changes](https://expo.fyi/android-r) and [`MediaLibrary.migrateAlbumIfNeededAsync`](#medialibrarymigratealbumifneededasyncalbum).
 
 <PlatformsSection android emulator ios simulator />
 

--- a/docs/pages/versions/v45.0.0/sdk/picker.md
+++ b/docs/pages/versions/v45.0.0/sdk/picker.md
@@ -12,7 +12,7 @@ import Video from '~/components/plugins/Video'
 
 A component that provides access to the system UI for picking between several options.
 
-> 💡 This library was formerly known as `@react-native-community/picker`. If you have that library in your SDK 40+ project, you can uninstall it and install this one instead.
+> **info** This library was formerly known as `@react-native-community/picker`. If you have that library in your SDK 40+ project, you can uninstall it and install this one instead.
 
 <PlatformsSection android emulator ios simulator web />
 

--- a/docs/pages/versions/v46.0.0/sdk/camera.md
+++ b/docs/pages/versions/v46.0.0/sdk/camera.md
@@ -13,7 +13,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 <PlatformsSection android ios web />
 
-> 💡 Android devices can use one of two available Camera APIs: you can opt-in to using [`Camera2`](https://developer.android.com/reference/android/hardware/camera2/package-summary) with the `useCamera2Api` prop.
+> **info** Android devices can use one of two available Camera APIs: you can opt-in to using [`Camera2`](https://developer.android.com/reference/android/hardware/camera2/package-summary) with the `useCamera2Api` prop.
 
 ## Installation
 
@@ -21,7 +21,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 ## Usage
 
-> ⚠️ Only one Camera preview can be active at any given time. If you have multiple screens in your app, you should unmount `Camera` components whenever a screen is unfocused.
+> **warning** Only one Camera preview can be active at any given time. If you have multiple screens in your app, you should unmount `Camera` components whenever a screen is unfocused.
 
 <SnackInline label='Basic Camera usage' dependencies={['expo-camera']}>
 

--- a/docs/pages/versions/v46.0.0/sdk/clipboard.md
+++ b/docs/pages/versions/v46.0.0/sdk/clipboard.md
@@ -73,7 +73,7 @@ const styles = StyleSheet.create({
 import * as Clipboard from 'expo-clipboard';
 ```
 
-> ⚠️ On Web, this module uses the [`AsyncClipboard` API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API),
+> **warning** On Web, this module uses the [`AsyncClipboard` API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API),
 > which might behave differently between browsers or not be fully supported.
 > Especially on WebKit, there's an issue which makes this API unusable in asynchronous code.
 > [Click here for more details](https://bugs.webkit.org/show_bug.cgi?id=222262).

--- a/docs/pages/versions/v46.0.0/sdk/in-app-purchases.md
+++ b/docs/pages/versions/v46.0.0/sdk/in-app-purchases.md
@@ -8,7 +8,7 @@ import {APIInstallSection} from '~/components/plugins/InstallSection';
 import APISection from '~/components/plugins/APISection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-> ⚠️ **Development of `expo-in-app-purchases` is currently paused to focus on other projects**. Alternative libraries include [`react-native-iap`](https://github.com/dooboolab/react-native-iap) and [`react-native-purchases` from RevenueCat](https://www.revenuecat.com/blog/using-revenuecat-with-expos-managed-workflow/).
+> **warning** **Development of `expo-in-app-purchases` is currently paused to focus on other projects**. Alternative libraries include [`react-native-iap`](https://github.com/dooboolab/react-native-iap) and [`react-native-purchases` from RevenueCat](https://www.revenuecat.com/blog/using-revenuecat-with-expos-managed-workflow/).
 
 **`expo-in-app-purchases`** provides an API to accept payments for in-app products. Internally this relies on the [Google Play Billing](https://developer.android.com/google/play/billing/billing_library_overview) library on Android and the [Storekit](https://developer.apple.com/documentation/storekit?language=objc) framework on iOS.
 

--- a/docs/pages/versions/v46.0.0/sdk/masked-view.md
+++ b/docs/pages/versions/v46.0.0/sdk/masked-view.md
@@ -9,9 +9,9 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`@react-native-masked-view/masked-view`** provides a masked view which only displays the pixels that overlap with the view rendered in its mask element.
 
-> ⚠️ You can only have one of either `@react-native-community/masked-view` (deprecated) or `@react-native-masked-view/masked-view` installed in your project at any given time. React Navigation v6 and above requires `@react-native-masked-view/masked-view`, so you should use that package instead if you are using the latest version of React Navigation.
+> **warning** You can only have one of either `@react-native-community/masked-view` (deprecated) or `@react-native-masked-view/masked-view` installed in your project at any given time. React Navigation v6 and above requires `@react-native-masked-view/masked-view`, so you should use that package instead if you are using the latest version of React Navigation.
 
-> ⚠️ Android support for this library is experimental and you may encounter inconsistencies in behavior across platforms. Please report issues you encounter to [react-native-masked-view/masked-view/issues](https://github.com/react-native-masked-view/masked-view).
+> **warning** Android support for this library is experimental and you may encounter inconsistencies in behavior across platforms. Please report issues you encounter to [react-native-masked-view/masked-view/issues](https://github.com/react-native-masked-view/masked-view).
 
 <PlatformsSection android emulator ios simulator />
 

--- a/docs/pages/versions/v46.0.0/sdk/media-library.md
+++ b/docs/pages/versions/v46.0.0/sdk/media-library.md
@@ -12,7 +12,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-media-library`** provides access to the user's media library, allowing them to access their existing images and videos from your app, as well as save new ones. You can also subscribe to any updates made to the user's media library.
 
-> ⚠️ If your Android app created an album using SDK &lt;= 40 and you want to add more assets to this album, you may need to migrate it to the new scoped directory. Otherwise, your app won't have access to the old album directory and expo-media-library won't be able to add new assets to it. However, all other functions will work without problems. You only need to migrate the old album if you want to add something to it. For more information, check out [Android R changes](https://expo.fyi/android-r) and [`MediaLibrary.migrateAlbumIfNeededAsync`](#medialibrarymigratealbumifneededasyncalbum).
+> **warning** If your Android app created an album using SDK &lt;= 40 and you want to add more assets to this album, you may need to migrate it to the new scoped directory. Otherwise, your app won't have access to the old album directory and expo-media-library won't be able to add new assets to it. However, all other functions will work without problems. You only need to migrate the old album if you want to add something to it. For more information, check out [Android R changes](https://expo.fyi/android-r) and [`MediaLibrary.migrateAlbumIfNeededAsync`](#medialibrarymigratealbumifneededasyncalbum).
 
 <PlatformsSection android emulator ios simulator />
 

--- a/docs/pages/versions/v46.0.0/sdk/picker.md
+++ b/docs/pages/versions/v46.0.0/sdk/picker.md
@@ -12,7 +12,7 @@ import Video from '~/components/plugins/Video'
 
 A component that provides access to the system UI for picking between several options.
 
-> 💡 This library was formerly known as `@react-native-community/picker`. If you have that library in your SDK 40+ project, you can uninstall it and install this one instead.
+> **info** This library was formerly known as `@react-native-community/picker`. If you have that library in your SDK 40+ project, you can uninstall it and install this one instead.
 
 <PlatformsSection android emulator ios simulator web />
 

--- a/docs/pages/workflow/configuration.md
+++ b/docs/pages/workflow/configuration.md
@@ -25,7 +25,7 @@ Most configuration from **app.json** is accessible at runtime from your JavaScri
 
 **app.json** configures many things, from your app name to icon to splash screen and even deep linking scheme and API keys to use for some services. To see a full list of available properties, please refer to the [app.json / app.config.js reference](/versions/latest/config/app/).
 
-> 💡 Do you use Visual Studio Code? If so, we recommend that you install the [vscode-expo](https://marketplace.visualstudio.com/items?itemName=byCedric.vscode-expo) extension to get auto-completion of properties in **app.json** files.
+> **info** Do you use Visual Studio Code? If so, we recommend that you install the [vscode-expo](https://marketplace.visualstudio.com/items?itemName=byCedric.vscode-expo) extension to get auto-completion of properties in **app.json** files.
 
 ## Extending
 


### PR DESCRIPTION
# Why

Follow up for #19238

# How

This PR replaces the imported callouts and callouts starting with certain emojis with newly added type syntax.

# Test Plan

The changes have been tested by running docs website locally..

# Preview

<img width="925" alt="Screenshot 2022-09-27 141144" src="https://user-images.githubusercontent.com/719641/192523189-d50953e4-8793-4fea-b00a-faeea996dd08.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
