### PR TITLE
[expo-dev-menu] Make internal runtime undebuggable

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -1274,7 +1274,7 @@ SPEC CHECKSUMS:
   Expo: f35ce9004f13fe930476bd8e667eeb170166ca4e
   expo-dev-client: 4aea43e3e4495cd676c7954c33bd3bd604cfab3a
   expo-dev-launcher: 54354885ddd62fd30d2a47b642368ed6609e5dfe
-  expo-dev-menu: 849a756eb23c06c153d689757bf55094888ff0fe
+  expo-dev-menu: 4b6c7bcd6cb6c8ece9c3003bd8484b0a98c35d08
   expo-dev-menu-interface: 3629393147ac495c03ef22bdcef66e6fa42b78c3
   ExpoCellular: 5cd085987f010055ab92c81d60e948ce0c4b5a89
   ExpoClipboard: 596aa4a0f894fbdddc985dc3d2e0e7efeb8ca973

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/DevLauncherClientHost.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/DevLauncherClientHost.kt
@@ -1,21 +1,18 @@
 package expo.modules.devlauncher.launcher
 
 import android.app.Application
-import com.facebook.hermes.reactexecutor.HermesExecutorFactory
 import com.facebook.react.ReactNativeHost
 import com.facebook.react.ReactPackage
 import com.facebook.react.bridge.JavaScriptExecutorFactory
-import com.facebook.react.jscexecutor.JSCExecutorFactory
-import com.facebook.react.modules.systeminfo.AndroidInfoHelpers
 import com.facebook.react.shell.MainReactPackage
-import com.facebook.soloader.SoLoader
+import devmenu.com.swmansion.gesturehandler.react.RNGestureHandlerPackage
+import devmenu.com.th3rdwave.safeareacontext.SafeAreaContextPackage
 import expo.modules.devlauncher.DevLauncherController
 import expo.modules.devlauncher.DevLauncherPackage
 import expo.modules.devlauncher.helpers.findDevMenuPackage
 import expo.modules.devlauncher.helpers.findPackagesWithDevMenuExtension
 import expo.modules.devlauncher.helpers.injectDebugServerHost
-import devmenu.com.th3rdwave.safeareacontext.SafeAreaContextPackage
-import devmenu.com.swmansion.gesturehandler.react.RNGestureHandlerPackage
+import expo.modules.devmenu.react.createNonDebuggableJavaScriptExecutorFactory
 
 class DevLauncherClientHost(
   application: Application,
@@ -52,11 +49,7 @@ class DevLauncherClientHost(
   }
 
   override fun getJavaScriptExecutorFactory(): JavaScriptExecutorFactory? {
-    SoLoader.init(application.applicationContext, /* native exopackage */ false)
-    if (SoLoader.getLibraryPath("libjsc.so") != null) {
-      return JSCExecutorFactory(application.packageName, AndroidInfoHelpers.getFriendlyDeviceName())
-    }
-    return HermesExecutorFactory()
+    return createNonDebuggableJavaScriptExecutorFactory(application)
   }
 
   override fun getJSMainModuleName() = "index"

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuHost.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuHost.kt
@@ -3,20 +3,17 @@ package expo.modules.devmenu
 import android.app.Application
 import android.content.Context
 import android.util.Log
-import com.facebook.hermes.reactexecutor.HermesExecutorFactory
 import com.facebook.react.ReactInstanceManager
 import com.facebook.react.ReactNativeHost
 import com.facebook.react.ReactPackage
 import com.facebook.react.bridge.JavaScriptExecutorFactory
 import com.facebook.react.devsupport.DevServerHelper
-import com.facebook.react.jscexecutor.JSCExecutorFactory
-import com.facebook.react.modules.systeminfo.AndroidInfoHelpers
 import com.facebook.react.shell.MainReactPackage
-import com.facebook.soloader.SoLoader
 import devmenu.com.swmansion.gesturehandler.react.RNGestureHandlerPackage
 import devmenu.com.swmansion.reanimated.ReanimatedPackage
 import devmenu.com.th3rdwave.safeareacontext.SafeAreaContextPackage
 import expo.modules.devmenu.react.DevMenuReactInternalSettings
+import expo.modules.devmenu.react.createNonDebuggableJavaScriptExecutorFactory
 import java.io.BufferedReader
 import java.io.FileNotFoundException
 import java.io.InputStreamReader
@@ -39,11 +36,8 @@ class DevMenuHost(application: Application) : ReactNativeHost(application) {
 
     try {
       val devLauncherPackage = Class.forName("expo.modules.devlauncher.DevLauncherPackage")
-
-      if (devLauncherPackage != null) {
-        val pkg = devLauncherPackage.getConstructor().newInstance() as ReactPackage
-        packages.add(pkg)
-      }
+      val pkg = devLauncherPackage.getConstructor().newInstance() as ReactPackage
+      packages.add(pkg)
     } catch (e: ClassNotFoundException) {
       // dev launcher is not installed in this project
     }
@@ -60,11 +54,7 @@ class DevMenuHost(application: Application) : ReactNativeHost(application) {
   fun getContext(): Context = super.getApplication()
 
   override fun getJavaScriptExecutorFactory(): JavaScriptExecutorFactory? {
-    SoLoader.init(application.applicationContext, /* native exopackage */ false)
-    if (SoLoader.getLibraryPath("libjsc.so") != null) {
-      return JSCExecutorFactory(application.packageName, AndroidInfoHelpers.getFriendlyDeviceName())
-    }
-    return HermesExecutorFactory()
+    return createNonDebuggableJavaScriptExecutorFactory(application)
   }
 
   override fun createReactInstanceManager(): ReactInstanceManager {

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/react/DevMenuHostHelper.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/react/DevMenuHostHelper.kt
@@ -1,0 +1,23 @@
+package expo.modules.devmenu.react
+
+import android.app.Application
+import com.facebook.hermes.reactexecutor.HermesExecutorFactory
+import com.facebook.react.bridge.JavaScriptExecutorFactory
+import com.facebook.react.jscexecutor.JSCExecutorFactory
+import com.facebook.react.modules.systeminfo.AndroidInfoHelpers
+import com.facebook.soloader.SoLoader
+
+fun createNonDebuggableJavaScriptExecutorFactory(application: Application): JavaScriptExecutorFactory {
+  SoLoader.init(application.applicationContext, /* native exopackage */ false)
+  if (SoLoader.getLibraryPath("libjsc.so") != null) {
+    return JSCExecutorFactory(application.packageName, AndroidInfoHelpers.getFriendlyDeviceName())
+  }
+  return HermesExecutorFactory().also {
+    try {
+      HermesExecutorFactory::class.java
+        .getMethod("setEnableDebugger", Boolean::class.java)
+        .invoke(it, false)
+    } catch (_: Throwable) {
+    }
+  }
+}

--- a/packages/expo-dev-menu/expo-dev-menu.podspec
+++ b/packages/expo-dev-menu/expo-dev-menu.podspec
@@ -10,14 +10,16 @@ rescue
   reactVersion = '0.66.0'
 end
 
-rnVersion = reactVersion.split('.')[1]
+splitedReactVersion = reactVersion.split('.')
+rnVersion = splitedReactVersion[1]
+rnPatchVersion = splitedReactVersion[2]
 
 folly_prefix = ""
 if rnVersion.to_i >= 64
   folly_prefix = "RCT-"
 end
 
-folly_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DRNVERSION=' + rnVersion
+folly_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DRNVERSION=' + rnVersion + ' -DRNPATCHVERSION=' + rnPatchVersion
 folly_compiler_flags = folly_flags + ' ' + '-Wno-comma -Wno-shorten-64-to-32'
 folly_version = '2021.04.26.00'
 boost_compiler_flags = '-Wno-documentation'

--- a/packages/expo-dev-menu/ios/DevMenuBaseAppInstance+Reanimated.mm
+++ b/packages/expo-dev-menu/ios/DevMenuBaseAppInstance+Reanimated.mm
@@ -37,10 +37,16 @@ typedef facebook::react::JSCExecutorFactory ExecutorFactory;
 
 #if RNVERSION >= 64
   // installs globals such as console, nativePerformanceNow, etc.
-  return std::make_unique<ExecutorFactory>(RCTJSIExecutorRuntimeInstaller(installer));
+  auto executorFactory = std::make_unique<ExecutorFactory>(RCTJSIExecutorRuntimeInstaller(installer));
 #else
-  return std::make_unique<ExecutorFactory>(installer);
+  auto executorFactory = std::make_unique<ExecutorFactory>(installer);
 #endif
+
+#if RNVERSION >= 70 && RNPATCHVERSION >= 1
+  executorFactory->setEnableDebugger(false);
+#endif
+  
+  return executorFactory;
 }
 
 @end


### PR DESCRIPTION
# Why

Takes advantage of https://github.com/facebook/react-native/pull/34489.
It'll improve our integration with Hermes inspector - users don't have to reload their app anymore to see correct sources. 

# How

Set `enable debugger` on internal runtimes. 

# Test Plan

I couldn't test it properly because our basic template crashes with RN `0.70`.