### PR TITLE
[ci] Fix building on EAS with disabled npm cache

### DIFF
--- a/apps/eas-expo-go/scripts/eas-build-pre-install.sh
+++ b/apps/eas-expo-go/scripts/eas-build-pre-install.sh
@@ -30,7 +30,7 @@ EOF
 
 git submodule update --init
 
-if [ ! -z "$EAS_BUILD_NPM_CACHE_URL" ]; then
+if [ -n "${EAS_BUILD_NPM_CACHE_URL-}" ]; then
   sed -i -e "s#https://registry.yarnpkg.com#$EAS_BUILD_NPM_CACHE_URL#g" $ROOT_DIR/yarn.lock || true
 fi
 


### PR DESCRIPTION
# Why

After migrating to different types of android workers npm cache on EAS Build is temporarily disabled. The state of the cache can be resolved based on env variable, but because we do not allow unbound variables in the script just checking that env variable is causing the error

# How

Access env variable using `${VARIABLE-}` when checking condition for enabling cache.

# Test Plan

CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
