### PR TITLE
[menu] Fix compilation error when compileSdkVersion is set to 33

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix compilation error when the `compileSdkVersion` is set to 33.
+
 ### 💡 Others
 
 - [plugin] Migrate import from @expo/config-plugins to expo/config-plugins and @expo/config-types to expo/config. ([#18855](https://github.com/expo/expo/pull/18855) by [@brentvatne](https://github.com/brentvatne))

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix compilation error when the `compileSdkVersion` is set to 33.
+- Fix compilation error when the `compileSdkVersion` is set to 33. ([#19271](https://github.com/expo/expo/pull/19271) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/vendored/react-native-gesture-handler/android/devmenu/com/swmansion/gesturehandler/PanGestureHandler.kt
+++ b/packages/expo-dev-menu/vendored/react-native-gesture-handler/android/devmenu/com/swmansion/gesturehandler/PanGestureHandler.kt
@@ -54,7 +54,7 @@ class PanGestureHandler(context: Context?) : GestureHandler<PanGestureHandler>()
    * position of all the fingers will remain still while doing a rotation gesture.
    */
   init {
-    val vc = ViewConfiguration.get(context)
+    val vc = ViewConfiguration.get(context!!)
     val touchSlop = vc.scaledTouchSlop
     defaultMinDistSq = (touchSlop * touchSlop).toFloat()
     minDistSq = defaultMinDistSq


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/18658.
A better version of https://github.com/expo/expo/pull/18861.
Closes ENG-6440.

# How

Use the same fix as it was introduced to the gesture handler codebase: https://github.com/software-mansion/react-native-gesture-handler/blob/1e6de08f589466c86a0e790ec47b80fa18de5193/android/lib/src/main/java/com/swmansion/gesturehandler/PanGestureHandler.kt#L62

# Test Plan

- npx create-expo-app my-app
- cd my-app
- expo install expo-dev-client
- expo prebuild
- Set compileSDKVersion and targetSDKVersion to 33 in app/build.gradle
- build using Android Studio
- run expo start --dev client
- run a to open on android