### PR TITLE
[docs] Update environment variables info for SDK 46 and other SDKs

### DIFF
--- a/docs/pages/eas-update/environment-variables.md
+++ b/docs/pages/eas-update/environment-variables.md
@@ -2,6 +2,8 @@
 title: Using environment variables with EAS Update
 ---
 
+import { Tab, Tabs } from '~/components/plugins/Tabs';
+
 EAS Build and EAS Update allow setting and getting environment variables at different times. There are multiple steps to ensure the proper environment variables are available when developing, building, and publishing an update.
 
 ## Setting up the app config
@@ -14,7 +16,7 @@ Next, we'll add an `API_URL` environment variable (as an example) to our project
 
 To add it to our app config, we'll add it under the `expo.extra` property.
 
-**app.config.js**
+app.config.js
 
 ```js
 export default () => ({
@@ -39,7 +41,7 @@ API_URL="http://localhost:3000" expo start
 
 The command above will set the `API_URL` to `"http://localhost:3000"`. Now, it's time to access that value inside our project.
 
-To access it, we can use the `expo-constants` library. It's located under the `Constants.expoConfig.extra.API_URL` property.
+To access it, we can use the `expo-constants` library. **For SDK 46 and above**, it's located at `Constants.expoConfig.extra.API_URL` property. For SDK 45 and below, it's located at `Constants.manifest.extra.API_URL` property.
 
 ## Setting and getting environment variables when building
 
@@ -64,7 +66,7 @@ To set the `API_URL` environment variable during a build, we can include an `"en
 
 Once we run a command like `eas build --profile production`, the `"env"` property in the "production" build profile will set the `API_URL` to `https://prod.example.com/` inside the build.
 
-To access it, we can use the `expo-constants` library. It's located under the `Constants.expoConfig.extra.API_URL` property.
+To access it, we can use the `expo-constants` library. **For SDK 46 and above**, it's located at `Constants.expoConfig.extra.API_URL` property. For SDK 45 and below, it's located at `Constants.manifest.extra.API_URL` property.
 
 ## Setting and getting environment variables when publishing an update
 
@@ -76,13 +78,17 @@ API_URL="https://prod.example.com" eas update --branch production
 
 When EAS CLI creates the update, it will set the `API_URL` to `https://prod.example.com` inside the update's bundle.
 
-To access it, we can use the `expo-constants` library. It's located under the `Constants.expoConfig.extra.API_URL` property.
+To access it, we can use the `expo-constants` library. **For SDK 46 and above**, it's located at `Constants.expoConfig.extra.API_URL` property. For SDK 45 and below, it's located at `Constants.manifest.extra.API_URL` property.
 
-> Note: We could also use the `expo-updates` library to access `API_URL`. It is under `Updates.manifest?.extra?.expoClient?.extra?.eas?.API_URL`. However, `Updates.manifest` is only present when an update is currently running. If the project is in development, `Updates.manifest` will be `undefined`. In addition, if a build is running without an update (for example, it was just downloaded or there are no updates yet), `Updates.manifest` will also be `undefined`.
+> We could also use the `expo-updates` library to access `API_URL`. It is under `Updates.manifest?.extra?.expoClient?.extra?.eas?.API_URL`. However, `Updates.manifest` is only present when an update is currently running. If the project is in development, `Updates.manifest` will be `undefined`. In addition, if a build is running without an update (for example, it was just downloaded or there are no updates yet), `Updates.manifest` will also be `undefined`.
 
 ## Creating an Env.ts file to get environment variables
 
 Many developers often create a file named **Env.ts** in their project, which they import into any file that needs to access environment variables. Combining the information above, we could write the following file to access `API_URL`:
+
+<Tabs tabs={["SDK 46+", "Before SDK 46"]}>
+
+<Tab>
 
 **Env.ts**
 
@@ -104,6 +110,34 @@ export const Env = {
 };
 ```
 
+</Tab>
+
+<Tab>
+
+**Env.ts**
+
+```ts
+import * as Constants from 'expo-constants';
+
+function getApiUrl() {
+  const API_URL = Constants.manifest.extra.API_URL;
+
+  if (!API_URL) {
+    throw new Error('API_URL is missing.');
+  }
+
+  return API_URL;
+}
+
+export const Env = {
+  API_URL: getApiUrl(),
+};
+```
+
+</Tab>
+
+</Tabs>
+
 ## Using a Babel plugin
 
-Alternatively, you can use a Babel plugin to fill in environment variables. [Learn more](/guides/environment-variables/#using-babel-to-replace-variables).
+Alternatively, you can use a Babel plugin to fill in environment variables. For more information, see [using Babel to inline environment variables during build time](guides/environment-variables/#using-babel-to-inline-environment-variables-during).

--- a/docs/pages/eas-update/environment-variables.md
+++ b/docs/pages/eas-update/environment-variables.md
@@ -2,7 +2,7 @@
 title: Using environment variables with EAS Update
 ---
 
-import { Tab, Tabs } from '~/components/plugins/Tabs';
+import { Collapsible } from '~/ui/components/Collapsible';
 
 EAS Build and EAS Update allow setting and getting environment variables at different times. There are multiple steps to ensure the proper environment variables are available when developing, building, and publishing an update.
 
@@ -41,7 +41,13 @@ API_URL="http://localhost:3000" expo start
 
 The command above will set the `API_URL` to `"http://localhost:3000"`. Now, it's time to access that value inside our project.
 
-To access it, we can use the `expo-constants` library. **For SDK 46 and above**, it's located at `Constants.expoConfig.extra.API_URL` property. For SDK 45 and below, it's located at `Constants.manifest.extra.API_URL` property.
+To access it, we can use the `expo-constants` library. It's located at `Constants.expoConfig.extra.API_URL` property.
+
+<Collapsible summary="Using SDK 45 or below?">
+
+The `API_URL` is located at `Constants.manifest2?.extra?.expoClient?.extra?.eas?.API_URL` property.
+
+</Collapsible>
 
 ## Setting and getting environment variables when building
 
@@ -66,7 +72,13 @@ To set the `API_URL` environment variable during a build, we can include an `"en
 
 Once we run a command like `eas build --profile production`, the `"env"` property in the "production" build profile will set the `API_URL` to `https://prod.example.com/` inside the build.
 
-To access it, we can use the `expo-constants` library. **For SDK 46 and above**, it's located at `Constants.expoConfig.extra.API_URL` property. For SDK 45 and below, it's located at `Constants.manifest.extra.API_URL` property.
+To access it, we can use the `expo-constants` library. It's located at `Constants.expoConfig.extra.API_URL` property.
+
+<Collapsible summary="Using SDK 45 or below?">
+
+The `API_URL` is located at `Constants.manifest?.extra?.eas?.API_URL` property.
+
+</Collapsible>
 
 ## Setting and getting environment variables when publishing an update
 
@@ -78,17 +90,19 @@ API_URL="https://prod.example.com" eas update --branch production
 
 When EAS CLI creates the update, it will set the `API_URL` to `https://prod.example.com` inside the update's bundle.
 
-To access it, we can use the `expo-constants` library. **For SDK 46 and above**, it's located at `Constants.expoConfig.extra.API_URL` property. For SDK 45 and below, it's located at `Constants.manifest.extra.API_URL` property.
+To access it, we can use the `expo-constants` library. It's located at `Constants.expoConfig.extra.API_URL` property.
 
 > We could also use the `expo-updates` library to access `API_URL`. It is under `Updates.manifest?.extra?.expoClient?.extra?.eas?.API_URL`. However, `Updates.manifest` is only present when an update is currently running. If the project is in development, `Updates.manifest` will be `undefined`. In addition, if a build is running without an update (for example, it was just downloaded or there are no updates yet), `Updates.manifest` will also be `undefined`.
+
+<Collapsible summary="Using SDK 45 or below?">
+
+The `API_URL` is located at `Constants.manifest2?.extra?.expoClient?.extra?.eas?.API_URL` property.
+
+</Collapsible>
 
 ## Creating an Env.ts file to get environment variables
 
 Many developers often create a file named **Env.ts** in their project, which they import into any file that needs to access environment variables. Combining the information above, we could write the following file to access `API_URL`:
-
-<Tabs tabs={["SDK 46+", "Before SDK 46"]}>
-
-<Tab>
 
 **Env.ts**
 
@@ -110,33 +124,17 @@ export const Env = {
 };
 ```
 
-</Tab>
+<Collapsible summary="Using SDK 45 or below?">
 
-<Tab>
-
-**Env.ts**
+Use the following snippet to access the `API_URL`:
 
 ```ts
-import * as Constants from 'expo-constants';
-
-function getApiUrl() {
-  const API_URL = Constants.manifest.extra.API_URL;
-
-  if (!API_URL) {
-    throw new Error('API_URL is missing.');
-  }
-
-  return API_URL;
-}
-
-export const Env = {
-  API_URL: getApiUrl(),
-};
+const API_URL =
+    Constants.manifest2?.extra?.expoClient?.extra?.eas?.API_URL ??
+    Constants.manifest?.extra?.eas?.API_URL;
 ```
 
-</Tab>
-
-</Tabs>
+</Collapsible>
 
 ## Using a Babel plugin
 

--- a/docs/pages/guides/environment-variables.md
+++ b/docs/pages/guides/environment-variables.md
@@ -4,7 +4,7 @@ sidebar_title: Environment variables
 ---
 
 import { Terminal } from '~/ui/components/Snippet';
-import { Tab, Tabs } from '~/components/plugins/Tabs';
+import { Collapsible } from '~/ui/components/Collapsible';
 
 Environment variables are key-value pairs configured outside your source code that allow your app to behave differently depending on the environment. For example, you can enable or disable certain features when building a testing version of your app, or you can switch to a different API endpoint when building for production.
 
@@ -38,13 +38,7 @@ API_URL="https://production.example.com" npx expo start
 
 ### Reading environment variables
 
-To read `extra` properties in your app, you can use the [`expo-constants`](/versions/latest/sdk/constants.md) library. 
-
-<Tabs tabs={["SDK 46+", "Before SDK 46"]}>
-
-<Tab>
-
-For SDK 46 and above, it is available on the `Constants.expoConfig` property.
+To read `extra` properties in your app, you can use the [`expo-constants`](/versions/latest/sdk/constants.md) library. It is available on the `Constants.expoConfig` property.
 
 ```tsx
 import { Button } from 'react-native';
@@ -61,30 +55,11 @@ function Post() {
 }
 ```
 
-</Tab>
+<Collapsible summary="Using SDK 45 or below?">
 
-<Tab>
+The `extra` property is available on the `Constants.manifest` property.
 
-For SDK 45 and below, it is available on the `Constants.manifest` property.
-
-```tsx
-import { Button } from 'react-native';
-import Constants from 'expo-constants';
-
-function Post() {
-  const apiUrl = Constants.manifest.extra.apiUrl;
-
-  async function onPress() {
-    await fetch(apiUrl, { ... })
-  }
-
-  return <Button onPress={onPress} title="Post" />;
-}
-```
-
-</Tab>
-
-</Tabs>
+</Collapsible>
 
 ## Using Babel to inline environment variables during build time
 

--- a/docs/pages/guides/environment-variables.md
+++ b/docs/pages/guides/environment-variables.md
@@ -4,6 +4,7 @@ sidebar_title: Environment variables
 ---
 
 import { Terminal } from '~/ui/components/Snippet';
+import { Tab, Tabs } from '~/components/plugins/Tabs';
 
 Environment variables are key-value pairs configured outside your source code that allow your app to behave differently depending on the environment. For example, you can enable or disable certain features when building a testing version of your app, or you can switch to a different API endpoint when building for production.
 
@@ -37,7 +38,13 @@ API_URL="https://production.example.com" npx expo start
 
 ### Reading environment variables
 
-To read `extra` properties in your app, you can use the [`expo-constants`](/versions/latest/sdk/constants.md) library. The `extra` property is available on the `Constants.expoConfig` property.
+To read `extra` properties in your app, you can use the [`expo-constants`](/versions/latest/sdk/constants.md) library. 
+
+<Tabs tabs={["SDK 46+", "Before SDK 46"]}>
+
+<Tab>
+
+For SDK 46 and above, it is available on the `Constants.expoConfig` property.
 
 ```tsx
 import { Button } from 'react-native';
@@ -53,6 +60,31 @@ function Post() {
   return <Button onPress={onPress} title="Post" />;
 }
 ```
+
+</Tab>
+
+<Tab>
+
+For SDK 45 and below, it is available on the `Constants.manifest` property.
+
+```tsx
+import { Button } from 'react-native';
+import Constants from 'expo-constants';
+
+function Post() {
+  const apiUrl = Constants.manifest.extra.apiUrl;
+
+  async function onPress() {
+    await fetch(apiUrl, { ... })
+  }
+
+  return <Button onPress={onPress} title="Post" />;
+}
+```
+
+</Tab>
+
+</Tabs>
 
 ## Using Babel to inline environment variables during build time
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Refs ENG-6458

# How

<!--
How did you build this feature or fix this bug and why?
-->

By updating `/guides/environment-variables/#reading-environment-variables` & `/eas-update/environment-variables/` ~~to refer `Constants.expoConfig.extra` for SDK 46+ and `Constants.manifest.extra` for SDK 45 and below.~~
- Add a Collapsible to refer SDK 45 and below info on both pages
- For `/eas-update/environment-variables/`, checked [this diff](https://github.com/expo/expo/pull/15957/files) to refer to previous location of `extra` property
- Update examples to provide both instances `expoConfig` and `manifest`
- Fix broken link at `/eas-update/environment-variables/`

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes can be tested locally by running `docs` using `yarn dev` and visiting 
- http://localhost:3002/eas-update/environment-variables/
- http://localhost:3002/guides/environment-variables/#reading-environment-variables

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
