### PR TITLE
[expo-updates][iOS] Allow native debugging of updates

### DIFF
--- a/packages/expo-modules-core/ExpoModulesCore.podspec
+++ b/packages/expo-modules-core/ExpoModulesCore.podspec
@@ -43,7 +43,9 @@ Pod::Spec.new do |s|
     s.dependency 'RCT-Folly', folly_version
   end
 
-  if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("ios/#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')
+  ex_updates_native_debug = ENV['EX_UPDATES_NATIVE_DEBUG'] == '1'
+
+  if !ex_updates_native_debug && !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("ios/#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')
     s.source_files = 'ios/**/*.h', 'common/cpp/**/*.h'
     s.vendored_frameworks = "ios/#{s.name}.xcframework"
   else

--- a/packages/expo-modules-core/ios/EXAppDefines.h
+++ b/packages/expo-modules-core/ios/EXAppDefines.h
@@ -15,6 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (class, nonatomic, assign, readonly) BOOL APP_DEBUG NS_SWIFT_NAME(APP_DEBUG);
 @property (class, nonatomic, assign, readonly) BOOL APP_RCT_DEBUG NS_SWIFT_NAME(APP_RCT_DEBUG);
+@property (class, nonatomic, assign, readonly) BOOL APP_UPDATES_DEBUG NS_SWIFT_NAME(APP_UPDATES_DEBUG);
 @property (class, nonatomic, assign, readonly) BOOL APP_RCT_DEV NS_SWIFT_NAME(APP_RCT_DEV);
 @property (class, nonatomic, assign, readonly) BOOL APP_NEW_ARCH_ENABLED NS_SWIFT_NAME(APP_NEW_ARCH_ENABLED);
 

--- a/packages/expo-modules-core/ios/EXAppDefines.m
+++ b/packages/expo-modules-core/ios/EXAppDefines.m
@@ -20,6 +20,12 @@ static BOOL _loaded = NO;
   return [_storage[@"APP_RCT_DEBUG"] boolValue];
 }
 
++ (BOOL)APP_UPDATES_DEBUG
+{
+  [self throwIfNotLoaded];
+  return [_storage[@"APP_UPDATES_DEBUG"] boolValue];
+}
+
 + (BOOL)APP_RCT_DEV
 {
   [self throwIfNotLoaded];

--- a/packages/expo-updates/ios/EXUpdates.podspec
+++ b/packages/expo-updates/ios/EXUpdates.podspec
@@ -30,7 +30,9 @@ Pod::Spec.new do |s|
     'SWIFT_COMPILATION_MODE' => 'wholemodule'
   }
 
-  if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')
+  ex_updates_native_debug = ENV['EX_UPDATES_NATIVE_DEBUG'] == '1'
+
+  if !ex_updates_native_debug && !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')
     s.source_files = "#{s.name}/**/*.h"
     s.vendored_frameworks = "#{s.name}.xcframework"
   else
@@ -38,9 +40,10 @@ Pod::Spec.new do |s|
   end
 
   if $expo_updates_create_manifest != false
+    force_bundling_flag = ex_updates_native_debug ? "export FORCE_BUNDLING=1\n" : ""
     s.script_phase = {
       :name => 'Generate app.manifest for expo-updates',
-      :script => 'bash -l -c "$PODS_TARGET_SRCROOT/../scripts/create-manifest-ios.sh"',
+      :script => force_bundling_flag + 'bash -l -c "$PODS_TARGET_SRCROOT/../scripts/create-manifest-ios.sh"',
       :execution_position => :before_compile
     }
 

--- a/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesAppDelegateSubscriber.swift
+++ b/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesAppDelegateSubscriber.swift
@@ -5,7 +5,7 @@ import EXUpdatesInterface
 
 public class ExpoUpdatesAppDelegateSubscriber: ExpoAppDelegateSubscriber {
   public func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
-    if EXAppDefines.APP_DEBUG {
+    if (EXAppDefines.APP_DEBUG && !EXAppDefines.APP_UPDATES_DEBUG) {
       EXUpdatesControllerRegistry.sharedInstance().controller = EXUpdatesDevLauncherController.sharedInstance()
     }
     return true

--- a/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesAppDelegateSubscriber.swift
+++ b/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesAppDelegateSubscriber.swift
@@ -5,7 +5,7 @@ import EXUpdatesInterface
 
 public class ExpoUpdatesAppDelegateSubscriber: ExpoAppDelegateSubscriber {
   public func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
-    if (EXAppDefines.APP_DEBUG && !EXAppDefines.APP_UPDATES_DEBUG) {
+    if EXAppDefines.APP_DEBUG && !EXAppDefines.APP_UPDATES_DEBUG {
       EXUpdatesControllerRegistry.sharedInstance().controller = EXUpdatesDevLauncherController.sharedInstance()
     }
     return true

--- a/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesReactDelegateHandler.swift
+++ b/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesReactDelegateHandler.swift
@@ -10,7 +10,7 @@ public class ExpoUpdatesReactDelegateHandler: ExpoReactDelegateHandler, EXUpdate
   private var rootViewModuleName: String?
   private var rootViewInitialProperties: [AnyHashable: Any]?
   private lazy var shouldEnableAutoSetup: Bool = {
-    if EXAppDefines.APP_DEBUG {
+    if (EXAppDefines.APP_DEBUG && !EXAppDefines.APP_UPDATES_DEBUG) {
       return false
     }
     // if Expo.plist not found or its content is invalid, disable the auto setup

--- a/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesReactDelegateHandler.swift
+++ b/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesReactDelegateHandler.swift
@@ -10,7 +10,7 @@ public class ExpoUpdatesReactDelegateHandler: ExpoReactDelegateHandler, EXUpdate
   private var rootViewModuleName: String?
   private var rootViewInitialProperties: [AnyHashable: Any]?
   private lazy var shouldEnableAutoSetup: Bool = {
-    if (EXAppDefines.APP_DEBUG && !EXAppDefines.APP_UPDATES_DEBUG) {
+    if EXAppDefines.APP_DEBUG && !EXAppDefines.APP_UPDATES_DEBUG {
       return false
     }
     // if Expo.plist not found or its content is invalid, disable the auto setup

--- a/packages/expo/Expo.podspec
+++ b/packages/expo/Expo.podspec
@@ -19,9 +19,7 @@ Pod::Spec.new do |s|
 
   s.source_files = 'ios/**/*.{h,m,swift}'
 
-
-  ex_updates_native_debug = ENV['EX_UPDATES_NATIVE_DEBUG'] == '1'
-  if ex_updates_native_debug
+  if ENV['EX_UPDATES_NATIVE_DEBUG'] == '1'
     s.pod_target_xcconfig = {
       'OTHER_CFLAGS[config=Debug]' => "$(inherited) -DEX_UPDATES_NATIVE_DEBUG=1" 
     }

--- a/packages/expo/Expo.podspec
+++ b/packages/expo/Expo.podspec
@@ -18,4 +18,12 @@ Pod::Spec.new do |s|
   s.dependency 'ExpoModulesCore'
 
   s.source_files = 'ios/**/*.{h,m,swift}'
+
+
+  ex_updates_native_debug = ENV['EX_UPDATES_NATIVE_DEBUG'] == '1'
+  if ex_updates_native_debug
+    s.pod_target_xcconfig = {
+      'OTHER_CFLAGS[config=Debug]' => "$(inherited) -DEX_UPDATES_NATIVE_DEBUG=1" 
+    }
+  end  
 end

--- a/packages/expo/ios/EXAppDefinesLoader.m
+++ b/packages/expo/ios/EXAppDefinesLoader.m
@@ -17,6 +17,11 @@
 #else
     @"APP_DEBUG": @(NO),
 #endif
+#if EX_UPDATES_NATIVE_DEBUG
+    @"APP_UPDATES_DEBUG": @(YES),
+#else
+    @"APP_UPDATES_DEBUG": @(NO),
+#endif
     @"APP_RCT_DEBUG": @(RCT_DEBUG),
     @"APP_RCT_DEV": @(RCT_DEV),
 #if RCT_NEW_ARCH_ENABLED

--- a/packages/expo/scripts/autolinking.rb
+++ b/packages/expo/scripts/autolinking.rb
@@ -30,4 +30,25 @@ def expo_patch_react_imports!(installer, options = {})
   end
 
   Expo::ReactImportPatcher.new(installer, options).run!
+  expo_patch_for_updates_debug!(installer)
+end
+
+def expo_patch_for_updates_debug!(installer)
+  projects = installer.aggregate_targets
+    .map{ |t| t.user_project }
+    .uniq{ |p| p.path }
+    .push(installer.pods_project)
+
+  ex_updates_native_debug = ENV['EX_UPDATES_NATIVE_DEBUG'] == '1'
+
+  projects.each do |project|
+    project.build_configurations.each do |config|
+      if ex_updates_native_debug
+        config.build_settings['OTHER_CFLAGS'] = "$(inherited) -DEX_UPDATES_NATIVE_DEBUG=1"
+      else
+        config.build_settings['OTHER_CFLAGS'] = "$(inherited)"
+      end
+    end
+    project.save()
+  end
 end

--- a/packages/expo/scripts/autolinking.rb
+++ b/packages/expo/scripts/autolinking.rb
@@ -35,8 +35,8 @@ end
 
 def expo_patch_for_updates_debug!(installer)
   projects = installer.aggregate_targets
-    .map{ |t| t.user_project }
-    .uniq{ |p| p.path }
+    .map { |t| t.user_project }
+    .uniq { |p| p.path }
     .push(installer.pods_project)
 
   ex_updates_native_debug = ENV['EX_UPDATES_NATIVE_DEBUG'] == '1'


### PR DESCRIPTION
# Why

Currently, if you have a project with expo-updates installed, you need to make a release build for expo-updates to be enabled (debug builds behave like normal RN project debug builds). This makes it somewhat difficult to test and debug updates when things aren’t working as expected.

To make this easier, we want to add a build setting on both platforms to enable updates in debug builds. Ideally, each platform should have just a single setting that is very easy to switch. When this setting is turned on, in a debug build (a) everything updates-related should be fully enabled as if in a release build (see UpdatesPackage and ExpoUpdatesReactDelegateHandler), and (b) RN should generate a bundle.
# How

For iOS, add the environment variable

```sh
export EX_UPDATES_NATIVE_DEBUG=1
```

and then reinstall pods. The podspecs now detect this environment variable, and makes changes so that the debug code that would normally load from the Metro packager is bypassed, and the app is built with the EXUpdates bundle and other dependencies needed to load updates from EAS.

# Test Plan

Manually tested against EAS.

I will investigate the possibility of building the updates E2E test app this way so that the debug build flows can be tested fully in CI.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
