### PR TITLE
[modules][Android] Prevent proguard from striping `PromiseImpl.<init>` and `ExpectedType` methods

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/ExpectedType.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/ExpectedType.kt
@@ -16,17 +16,17 @@ class SingleType(
   /**
    * The representation of the type.
    */
-  val cppType get() = expectedCppType.value
+  fun getCppType() = expectedCppType.value
 
   /**
    * A convenient property to return the type of the first parameter.
    */
-  val firstParameterType get() = parameterTypes?.get(0)
+  fun getFirstParameterType() = parameterTypes?.get(0)
 
   /**
    * A convenient property to return the type of the second parameter.
    */
-  val secondParameterType get() = parameterTypes?.get(1)
+  fun getSecondParameterType() = parameterTypes?.get(1)
 }
 
 /**
@@ -36,23 +36,29 @@ class SingleType(
  */
 @DoNotStrip
 class ExpectedType(
-  vararg val possibleTypes: SingleType
+  private vararg val innerPossibleTypes: SingleType
 ) {
   constructor(vararg expectedTypes: CppType) : this(*expectedTypes.map { SingleType(it) }.toTypedArray())
 
   /**
    * A convenient property to return combined int value of expected types.
    */
-  val combinedTypes: Int = possibleTypes.fold(0) { acc, current -> acc or current.cppType }
+  val innerCombinedTypes: Int = innerPossibleTypes.fold(0) { acc, current -> acc or current.getCppType() }
+
+  // Needed by JNI
+  fun getCombinedTypes() = innerCombinedTypes
+
+  // Needed by JNI
+  fun getPossibleTypes() = innerPossibleTypes
 
   /**
    * A convenient property to return the first of possible types.
    */
-  val firstType = possibleTypes.first()
+  val firstType = innerPossibleTypes.first()
 
   operator fun plus(other: ExpectedType): ExpectedType {
     return ExpectedType(
-      *this.possibleTypes, *other.possibleTypes
+      *this.innerPossibleTypes, *other.innerPossibleTypes
     )
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/PromiseImpl.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/PromiseImpl.kt
@@ -24,9 +24,9 @@ private const val STACK_FRAME_KEY_LINE_NUMBER = "lineNumber"
 private const val STACK_FRAME_KEY_METHOD_NAME = "methodName"
 
 @DoNotStrip
-class PromiseImpl(
-  internal val resolveBlock: JavaCallback,
-  internal val rejectBlock: JavaCallback
+class PromiseImpl @DoNotStrip internal constructor(
+  @DoNotStrip internal val resolveBlock: JavaCallback,
+  @DoNotStrip internal val rejectBlock: JavaCallback
 ) : Promise {
   private var wasResolve = false
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EitherTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EitherTypeConverter.kt
@@ -36,10 +36,10 @@ class EitherTypeConverter<FirstType : Any, SecondType : Any>(
     }
 
     return convertValueIfNeeded(
-      firstType.possibleTypes,
+      firstType.getPossibleTypes(),
       firstTypeConverter
     ) ?: convertValueIfNeeded(
-      secondType.possibleTypes,
+      secondType.getPossibleTypes(),
       secondTypeConverter
     )
       ?: throw TypeCastException("Cannot cast '$value' to 'Either<$firstJavaType, $secondJavaType>'")
@@ -84,13 +84,13 @@ class EitherOfThreeTypeConverter<FirstType : Any, SecondType : Any, ThirdType : 
     }
 
     return convertValueIfNeeded(
-      firstType.possibleTypes,
+      firstType.getPossibleTypes(),
       firstTypeConverter
     ) ?: convertValueIfNeeded(
-      secondType.possibleTypes,
+      secondType.getPossibleTypes(),
       secondTypeConverter
     ) ?: convertValueIfNeeded(
-      thirdType.possibleTypes,
+      thirdType.getPossibleTypes(),
       thirdTypeConverter
     )
       ?: throw TypeCastException("Cannot cast '$value' to 'EitherOfThree<$firstJavaType, $secondJavaType, $thirdJavaType>'")
@@ -140,16 +140,16 @@ class EitherOfFourTypeConverter<FirstType : Any, SecondType : Any, ThirdType : A
     }
 
     return convertValueIfNeeded(
-      firstType.possibleTypes,
+      firstType.getPossibleTypes(),
       firstTypeConverter
     ) ?: convertValueIfNeeded(
-      secondType.possibleTypes,
+      secondType.getPossibleTypes(),
       secondTypeConverter
     ) ?: convertValueIfNeeded(
-      thirdType.possibleTypes,
+      thirdType.getPossibleTypes(),
       thirdTypeConverter
     ) ?: convertValueIfNeeded(
-      fourthType.possibleTypes,
+      fourthType.getPossibleTypes(),
       fourthTypeConverter
     )
       ?: throw TypeCastException("Cannot cast '$value' to 'EitherOfFourth<$firstJavaType, $secondJavaType, $thirdJavaType, $fourthJavaType>'")


### PR DESCRIPTION
# Why

Fixes JNI crashes in the release builds.

# How

- Fixed `PromiseImpl.<init>` being removed by proguard by adding and `@DoNotStrip` annotation.
- Fixed `ExpectedType` properties being removed by using normal functions instead. 

# Test Plan

- bare-expo ✅