### PR TITLE
[modules][Android] Install modules host object as `global.expo.modules` instead of `global.ExpoModules`

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -48,7 +48,7 @@
 
 - Centralized Android emulator detection for native code and added checks to pick up additional emulator types in `EmulatorUtilities`. ([#16177](https://github.com/expo/expo/pull/16177)) by [@kbrandwijk](https://github.com/kbrandwijk), [@keith-kurak](https://github.com/keith-kurak))
 - Created a separate high priority queue for all async function calls. ([#18734](https://github.com/expo/expo/pull/18734) by [@tsapeta](https://github.com/tsapeta))
-- The host object for native modules is now installed as `global.expo.modules` instead of `global.ExpoModules`. ([#19273](https://github.com/expo/expo/pull/19273) by [@tsapeta](https://github.com/tsapeta))
+- The host object for native modules is now installed as `global.expo.modules` instead of `global.ExpoModules`. ([#19273](https://github.com/expo/expo/pull/19273) & [#19281](https://github.com/expo/expo/pull/19281) by [@tsapeta](https://github.com/tsapeta), [@lukmccall](https://github.com/lukmccall))
 
 ## 0.11.3 — 2022-07-18
 

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/IOTypeConversionTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/IOTypeConversionTest.kt
@@ -16,7 +16,7 @@ class IOTypeConversionTest {
       Function("file") { a: File -> a.toString() }
     }
   ) {
-    val stringValue = evaluateScript("ExpoModules.TestModule.file('/path/to/file')").getString()
+    val stringValue = evaluateScript("expo.modules.TestModule.file('/path/to/file')").getString()
     Truth.assertThat(stringValue).isEqualTo("/path/to/file")
   }
 
@@ -27,7 +27,7 @@ class IOTypeConversionTest {
       Function("path") { a: Path -> a.toString() }
     }
   ) {
-    val stringValue = evaluateScript("ExpoModules.TestModule.path('/path/to/file')").getString()
+    val stringValue = evaluateScript("expo.modules.TestModule.path('/path/to/file')").getString()
     Truth.assertThat(stringValue).isEqualTo("/path/to/file")
   }
 }

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIAsyncFunctionsTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIAsyncFunctionsTest.kt
@@ -35,11 +35,11 @@ class JSIAsyncFunctionsTest {
       AsyncFunction("boolF") { a: Boolean -> a }
     }
   ) { methodQueue ->
-    val stringValue = waitForAsyncFunction(methodQueue, "ExpoModules.TestModule.stringF('expo')").getString()
-    val intValue = waitForAsyncFunction(methodQueue, "ExpoModules.TestModule.intF(123)").getDouble().toInt()
-    val doubleValue = waitForAsyncFunction(methodQueue, "ExpoModules.TestModule.doubleF(123.3)").getDouble()
-    val floatValue = waitForAsyncFunction(methodQueue, "ExpoModules.TestModule.floatF(123.3)").getDouble().toFloat()
-    val boolValue = waitForAsyncFunction(methodQueue, "ExpoModules.TestModule.boolF(true)").getBool()
+    val stringValue = waitForAsyncFunction(methodQueue, "expo.modules.TestModule.stringF('expo')").getString()
+    val intValue = waitForAsyncFunction(methodQueue, "expo.modules.TestModule.intF(123)").getDouble().toInt()
+    val doubleValue = waitForAsyncFunction(methodQueue, "expo.modules.TestModule.doubleF(123.3)").getDouble()
+    val floatValue = waitForAsyncFunction(methodQueue, "expo.modules.TestModule.floatF(123.3)").getDouble().toFloat()
+    val boolValue = waitForAsyncFunction(methodQueue, "expo.modules.TestModule.boolF(true)").getBool()
 
     Truth.assertThat(stringValue).isEqualTo("expo")
     Truth.assertThat(intValue).isEqualTo(123)
@@ -55,7 +55,7 @@ class JSIAsyncFunctionsTest {
       AsyncFunction("listF") { a: List<String> -> a }
     }
   ) { methodQueue ->
-    val value = waitForAsyncFunction(methodQueue, "ExpoModules.TestModule.listF(['expo', 'is', 'awesome'])").getArray()
+    val value = waitForAsyncFunction(methodQueue, "expo.modules.TestModule.listF(['expo', 'is', 'awesome'])").getArray()
     Truth.assertThat(value).hasLength(3)
     val e1 = value[0].getString()
     val e2 = value[1].getString()
@@ -72,7 +72,7 @@ class JSIAsyncFunctionsTest {
       AsyncFunction("listF") { a: List<List<Int>> -> a }
     }
   ) { methodQueue ->
-    val value = waitForAsyncFunction(methodQueue, "ExpoModules.TestModule.listF([[1,2,3], [4,5,6]])").getArray()
+    val value = waitForAsyncFunction(methodQueue, "expo.modules.TestModule.listF([[1,2,3], [4,5,6]])").getArray()
     Truth.assertThat(value).hasLength(2)
     val e1 = value[0].getArray()
     val e2 = value[1].getArray()
@@ -92,7 +92,7 @@ class JSIAsyncFunctionsTest {
       AsyncFunction("mapF") { a: Map<String, String> -> a }
     }
   ) { methodQueue ->
-    val value = waitForAsyncFunction(methodQueue, "ExpoModules.TestModule.mapF({ 'k1': 'v1', 'k2': 'v2' })").getObject()
+    val value = waitForAsyncFunction(methodQueue, "expo.modules.TestModule.mapF({ 'k1': 'v1', 'k2': 'v2' })").getObject()
     val k1 = value.getProperty("k1").getString()
     val k2 = value.getProperty("k2").getString()
 
@@ -125,9 +125,9 @@ class JSIAsyncFunctionsTest {
         }
       }
     ) { methodQueue ->
-      waitForAsyncFunction(methodQueue, "ExpoModules.TestModule.f1('V2')")
-      waitForAsyncFunction(methodQueue, "ExpoModules.TestModule.f2('V2')")
-      waitForAsyncFunction(methodQueue, "ExpoModules.TestModule.f3(2)")
+      waitForAsyncFunction(methodQueue, "expo.modules.TestModule.f1('V2')")
+      waitForAsyncFunction(methodQueue, "expo.modules.TestModule.f2('V2')")
+      waitForAsyncFunction(methodQueue, "expo.modules.TestModule.f3(2)")
       Truth.assertThat(f1WasCalled).isTrue()
       Truth.assertThat(f2WasCalled).isTrue()
       Truth.assertThat(f3WasCalled).isTrue()
@@ -153,7 +153,7 @@ class JSIAsyncFunctionsTest {
         }
       }
     ) { methodQueue ->
-      val result = waitForAsyncFunction(methodQueue, "ExpoModules.TestModule.f({ 'x': 123, 's': 'expo' })").getObject()
+      val result = waitForAsyncFunction(methodQueue, "expo.modules.TestModule.f({ 'x': 123, 's': 'expo' })").getObject()
 
       val x = result.getProperty("x").getDouble().toInt()
       val s = result.getProperty("s").getString()
@@ -173,7 +173,7 @@ class JSIAsyncFunctionsTest {
     }
   ) { methodQueue ->
     val exception = Assert.assertThrows(PromiseException::class.java) {
-      waitForAsyncFunction(methodQueue, "ExpoModules.TestModule.f()")
+      waitForAsyncFunction(methodQueue, "expo.modules.TestModule.f()")
     }
 
     Truth.assertThat(exception.code).isEqualTo("Code")
@@ -190,7 +190,7 @@ class JSIAsyncFunctionsTest {
     }
   ) { methodQueue ->
     val exception = Assert.assertThrows(PromiseException::class.java) {
-      waitForAsyncFunction(methodQueue, "ExpoModules.TestModule.f()")
+      waitForAsyncFunction(methodQueue, "expo.modules.TestModule.f()")
     }
 
     Truth.assertThat(exception.code).isEqualTo("ERR_UNEXPECTED")
@@ -204,7 +204,7 @@ class JSIAsyncFunctionsTest {
       AsyncFunction("f") { _: Int -> }
     }
   ) { methodQueue ->
-    waitForAsyncFunction(methodQueue, "ExpoModules.TestModule.f(Symbol())")
+    waitForAsyncFunction(methodQueue, "expo.modules.TestModule.f(Symbol())")
   }
 
   @Test
@@ -214,7 +214,7 @@ class JSIAsyncFunctionsTest {
       AsyncFunction("intArray") { a: IntArray -> a }
     }
   ) { methodQueue ->
-    val array = waitForAsyncFunction(methodQueue, "ExpoModules.TestModule.intArray([1, 2, 3])").getArray()
+    val array = waitForAsyncFunction(methodQueue, "expo.modules.TestModule.intArray([1, 2, 3])").getArray()
     Truth.assertThat(array.size).isEqualTo(3)
 
     val e1 = array[0].getDouble().toInt()
@@ -233,7 +233,7 @@ class JSIAsyncFunctionsTest {
       AsyncFunction("stringArray") { a: Array<String> -> a }
     }
   ) { methodQueue ->
-    val array = waitForAsyncFunction(methodQueue, "ExpoModules.TestModule.stringArray(['a', 'b', 'c'])").getArray()
+    val array = waitForAsyncFunction(methodQueue, "expo.modules.TestModule.stringArray(['a', 'b', 'c'])").getArray()
     Truth.assertThat(array.size).isEqualTo(3)
 
     val e1 = array[0].getString()
@@ -252,7 +252,7 @@ class JSIAsyncFunctionsTest {
       AsyncFunction("array") { a: Array<IntArray> -> a }
     }
   ) { methodQueue ->
-    val array = waitForAsyncFunction(methodQueue, "ExpoModules.TestModule.array([[1,2], [3, 4]])").getArray()
+    val array = waitForAsyncFunction(methodQueue, "expo.modules.TestModule.array([[1,2], [3, 4]])").getArray()
     Truth.assertThat(array.size).isEqualTo(2)
 
     val a1 = array[0].getArray()

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIFunctionsTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIFunctionsTest.kt
@@ -39,11 +39,11 @@ class JSIFunctionsTest {
       Function("boolF") { a: Boolean -> a }
     }
   ) {
-    val stringValue = evaluateScript("ExpoModules.TestModule.stringF('expo')").getString()
-    val intValue = evaluateScript("ExpoModules.TestModule.intF(123)").getDouble().toInt()
-    val doubleValue = evaluateScript("ExpoModules.TestModule.doubleF(123.3)").getDouble()
-    val floatValue = evaluateScript("ExpoModules.TestModule.floatF(123.3)").getDouble().toFloat()
-    val boolValue = evaluateScript("ExpoModules.TestModule.boolF(true)").getBool()
+    val stringValue = evaluateScript("expo.modules.TestModule.stringF('expo')").getString()
+    val intValue = evaluateScript("expo.modules.TestModule.intF(123)").getDouble().toInt()
+    val doubleValue = evaluateScript("expo.modules.TestModule.doubleF(123.3)").getDouble()
+    val floatValue = evaluateScript("expo.modules.TestModule.floatF(123.3)").getDouble().toFloat()
+    val boolValue = evaluateScript("expo.modules.TestModule.boolF(true)").getBool()
 
     Truth.assertThat(stringValue).isEqualTo("expo")
     Truth.assertThat(intValue).isEqualTo(123)
@@ -59,7 +59,7 @@ class JSIFunctionsTest {
       Function("listF") { a: List<String> -> a }
     }
   ) {
-    val value = evaluateScript("ExpoModules.TestModule.listF(['expo', 'is', 'awesome'])").getArray()
+    val value = evaluateScript("expo.modules.TestModule.listF(['expo', 'is', 'awesome'])").getArray()
     Truth.assertThat(value).hasLength(3)
     val e1 = value[0].getString()
     val e2 = value[1].getString()
@@ -76,7 +76,7 @@ class JSIFunctionsTest {
       Function("listF") { a: List<List<Int>> -> a }
     }
   ) {
-    val value = evaluateScript("ExpoModules.TestModule.listF([[1,2,3], [4,5,6]])").getArray()
+    val value = evaluateScript("expo.modules.TestModule.listF([[1,2,3], [4,5,6]])").getArray()
     Truth.assertThat(value).hasLength(2)
     val e1 = value[0].getArray()
     val e2 = value[1].getArray()
@@ -104,7 +104,7 @@ class JSIFunctionsTest {
         }
       }
     ) {
-      evaluateScript("ExpoModules.TestModule.list(['V1', 'V2'])")
+      evaluateScript("expo.modules.TestModule.list(['V1', 'V2'])")
       Truth.assertThat(wasCalled).isTrue()
     }
   }
@@ -131,7 +131,7 @@ class JSIFunctionsTest {
         }
       }
     ) {
-      evaluateScript("ExpoModules.TestModule.list([{'foo':'foo'}, {'bar':'bar'}])")
+      evaluateScript("expo.modules.TestModule.list([{'foo':'foo'}, {'bar':'bar'}])")
       Truth.assertThat(wasCalled).isTrue()
     }
   }
@@ -143,7 +143,7 @@ class JSIFunctionsTest {
       Function("mapF") { a: Map<String, String> -> a }
     }
   ) {
-    val value = evaluateScript("ExpoModules.TestModule.mapF({ 'k1': 'v1', 'k2': 'v2' })").getObject()
+    val value = evaluateScript("expo.modules.TestModule.mapF({ 'k1': 'v1', 'k2': 'v2' })").getObject()
     val k1 = value.getProperty("k1").getString()
     val k2 = value.getProperty("k2").getString()
 
@@ -164,7 +164,7 @@ class JSIFunctionsTest {
         }
       }
     ) {
-      evaluateScript("ExpoModules.TestModule.f('string from js')")
+      evaluateScript("expo.modules.TestModule.f('string from js')")
       Truth.assertThat(wasCalled).isTrue()
     }
   }
@@ -181,7 +181,7 @@ class JSIFunctionsTest {
         }
       }
     ) {
-      evaluateScript("ExpoModules.TestModule.f({ 'k1': 'v1' })")
+      evaluateScript("expo.modules.TestModule.f({ 'k1': 'v1' })")
       Truth.assertThat(wasCalled).isTrue()
     }
   }
@@ -211,9 +211,9 @@ class JSIFunctionsTest {
         }
       }
     ) {
-      evaluateScript("ExpoModules.TestModule.f1('V2')")
-      evaluateScript("ExpoModules.TestModule.f2('V2')")
-      evaluateScript("ExpoModules.TestModule.f3(2)")
+      evaluateScript("expo.modules.TestModule.f1('V2')")
+      evaluateScript("expo.modules.TestModule.f2('V2')")
+      evaluateScript("expo.modules.TestModule.f3(2)")
       Truth.assertThat(f1WasCalled).isTrue()
       Truth.assertThat(f2WasCalled).isTrue()
       Truth.assertThat(f3WasCalled).isTrue()
@@ -239,7 +239,7 @@ class JSIFunctionsTest {
         }
       }
     ) {
-      val result = evaluateScript("ExpoModules.TestModule.f({ 'x': 123, 's': 'expo' })").getObject()
+      val result = evaluateScript("expo.modules.TestModule.f({ 'x': 123, 's': 'expo' })").getObject()
 
       val x = result.getProperty("x").getDouble().toInt()
       val s = result.getProperty("s").getString()
@@ -262,7 +262,7 @@ class JSIFunctionsTest {
       """
       let exception = null;
       try {
-        ExpoModules.TestModule.f()
+        expo.modules.TestModule.f()
       } catch (e) {
         if (e instanceof global.ExpoModulesCore_CodedError) {
           exception = e;
@@ -289,7 +289,7 @@ class JSIFunctionsTest {
       """
       let exception = null;
       try {
-        ExpoModules.TestModule.f()
+        expo.modules.TestModule.f()
       } catch (e) {
         if (e instanceof global.ExpoModulesCore_CodedError) {
           exception = e;
@@ -312,7 +312,7 @@ class JSIFunctionsTest {
       }
     }
   ) {
-    evaluateScript("ExpoModules.TestModule.f()")
+    evaluateScript("expo.modules.TestModule.f()")
   }
 
   @Test
@@ -334,7 +334,7 @@ class JSIFunctionsTest {
       }
     }
   ) {
-    evaluateScript("ExpoModules.TestModule.f(new Int32Array([1,2,3]), new Float32Array([1.0,2.0,3.0]), new Int8Array([1,2,3]))")
+    evaluateScript("expo.modules.TestModule.f(new Int32Array([1,2,3]), new Float32Array([1.0,2.0,3.0]), new Int8Array([1,2,3]))")
   }
 
   @Test
@@ -349,7 +349,7 @@ class JSIFunctionsTest {
     evaluateScript(
       """
       const typedArray = new Int32Array([1,2,3]);
-      ExpoModules.TestModule.f(typedArray);
+      expo.modules.TestModule.f(typedArray);
       if (typedArray[0] !== 1 || typedArray[1] !== 999 || typedArray[2] !== 3) {
         throw new Error("Array was copied")
       }
@@ -364,7 +364,7 @@ class JSIFunctionsTest {
       Function("f") { _: Int -> }
     }
   ) {
-    evaluateScript("ExpoModules.TestModule.f(Symbol())")
+    evaluateScript("expo.modules.TestModule.f(Symbol())")
   }
 
   @Test
@@ -374,7 +374,7 @@ class JSIFunctionsTest {
       Function("intArray") { a: IntArray -> a }
     }
   ) {
-    val array = evaluateScript("ExpoModules.TestModule.intArray([1, 2, 3])").getArray()
+    val array = evaluateScript("expo.modules.TestModule.intArray([1, 2, 3])").getArray()
     Truth.assertThat(array.size).isEqualTo(3)
 
     val e1 = array[0].getDouble().toInt()
@@ -393,7 +393,7 @@ class JSIFunctionsTest {
       Function("stringArray") { a: Array<String> -> a }
     }
   ) {
-    val array = evaluateScript("ExpoModules.TestModule.stringArray(['a', 'b', 'c'])").getArray()
+    val array = evaluateScript("expo.modules.TestModule.stringArray(['a', 'b', 'c'])").getArray()
     Truth.assertThat(array.size).isEqualTo(3)
 
     val e1 = array[0].getString()
@@ -412,7 +412,7 @@ class JSIFunctionsTest {
       Function("array") { a: Array<IntArray> -> a }
     }
   ) {
-    val array = evaluateScript("ExpoModules.TestModule.array([[1,2], [3, 4]])").getArray()
+    val array = evaluateScript("expo.modules.TestModule.array([[1,2], [3, 4]])").getArray()
     Truth.assertThat(array.size).isEqualTo(2)
 
     val a1 = array[0].getArray()
@@ -454,7 +454,7 @@ class JSIFunctionsTest {
         }
       }
     ) {
-      evaluateScript("ExpoModules.TestModule.jsObjectArray([{'foo':'foo'}, {'bar':'bar'}])")
+      evaluateScript("expo.modules.TestModule.jsObjectArray([{'foo':'foo'}, {'bar':'bar'}])")
       Truth.assertThat(wasCalled).isTrue()
     }
   }
@@ -474,8 +474,8 @@ class JSIFunctionsTest {
       }
     }
   ) {
-    val int = evaluateScript("ExpoModules.TestModule.eitherFirst(123)").getDouble().toInt()
-    val string = evaluateScript("ExpoModules.TestModule.eitherSecond('expo')").getString()
+    val int = evaluateScript("expo.modules.TestModule.eitherFirst(123)").getDouble().toInt()
+    val string = evaluateScript("expo.modules.TestModule.eitherSecond('expo')").getString()
 
     Truth.assertThat(int).isEqualTo(123)
     Truth.assertThat(string).isEqualTo("expo")

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIInteropModuleRegistryTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIInteropModuleRegistryTest.kt
@@ -15,7 +15,7 @@ class JSIInteropModuleRegistryTest {
       AsyncFunction("asyncFunction") {}
     }
   ) {
-    val value = evaluateScript("ExpoModules.TestModule")
+    val value = evaluateScript("expo.modules.TestModule")
     Truth.assertThat(value.isObject()).isTrue()
 
     val testModule = value.getObject()
@@ -29,11 +29,11 @@ class JSIInteropModuleRegistryTest {
     Truth.assertThat(asyncFunction.isFunction()).isTrue()
 
     Truth.assertThat(
-      evaluateScript("typeof ExpoModules.TestModule.syncFunction").getString()
+      evaluateScript("typeof expo.modules.TestModule.syncFunction").getString()
     ).isEqualTo("function")
 
     Truth.assertThat(
-      evaluateScript("typeof ExpoModules.TestModule.asyncFunction").getString()
+      evaluateScript("typeof expo.modules.TestModule.asyncFunction").getString()
     ).isEqualTo("function")
   }
 
@@ -46,8 +46,8 @@ class JSIInteropModuleRegistryTest {
     }
   ) {
 
-    val f1Value = evaluateScript("ExpoModules.TestModule.f1()")
-    val f2Value = evaluateScript("ExpoModules.TestModule.f2(\"expo\")")
+    val f1Value = evaluateScript("expo.modules.TestModule.f1()")
+    val f2Value = evaluateScript("expo.modules.TestModule.f2(\"expo\")")
 
     Truth.assertThat(f1Value.isNumber()).isTrue()
     val unboxedF1Value = f1Value.getDouble().toInt()
@@ -67,7 +67,7 @@ class JSIInteropModuleRegistryTest {
       }
     }
   ) { methodQueue ->
-    val promiseResult = waitForAsyncFunction(methodQueue, "ExpoModules.TestModule.f()")
+    val promiseResult = waitForAsyncFunction(methodQueue, "expo.modules.TestModule.f()")
     Truth.assertThat(promiseResult.isNumber()).isTrue()
     Truth.assertThat(global().getProperty("promiseResult").getDouble().toInt()).isEqualTo(20)
   }
@@ -84,9 +84,9 @@ class JSIInteropModuleRegistryTest {
     }
   ) {
 
-    val c1Value = evaluateScript("ExpoModules.TestModule.c1")
-    val c2Value = evaluateScript("ExpoModules.TestModule.c2")
-    val i1Value = evaluateScript("ExpoModules.TestModule.c3.i1")
+    val c1Value = evaluateScript("expo.modules.TestModule.c1")
+    val c2Value = evaluateScript("expo.modules.TestModule.c2")
+    val i1Value = evaluateScript("expo.modules.TestModule.c3.i1")
 
     Truth.assertThat(c1Value.isNumber()).isTrue()
     val unboxedC1Value = c1Value.getDouble().toInt()

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIPropertiesTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIPropertiesTest.kt
@@ -17,7 +17,7 @@ internal class JSIPropertiesTest {
         .set { _: String -> }
     }
   ) {
-    val keys = evaluateScript("Object.keys(ExpoModules.TestModule)").getArray()
+    val keys = evaluateScript("Object.keys(expo.modules.TestModule)").getArray()
 
     Truth.assertThat(keys).hasLength(2)
 
@@ -36,8 +36,8 @@ internal class JSIPropertiesTest {
       Property("p2").get { return@get 321 }
     }
   ) {
-    val p1 = evaluateScript("ExpoModules.TestModule.p1").getDouble().toInt()
-    val p2 = evaluateScript("ExpoModules.TestModule.p2").getDouble().toInt()
+    val p1 = evaluateScript("expo.modules.TestModule.p1").getDouble().toInt()
+    val p2 = evaluateScript("expo.modules.TestModule.p2").getDouble().toInt()
 
     Truth.assertThat(p1).isEqualTo(123)
     Truth.assertThat(p2).isEqualTo(321)
@@ -54,10 +54,10 @@ internal class JSIPropertiesTest {
         .set { newValue: Int -> innerValue = newValue }
     }
   ) {
-    evaluateScript("ExpoModules.TestModule.p = 987")
-    val p1 = evaluateScript("ExpoModules.TestModule.p").getDouble().toInt()
-    evaluateScript("ExpoModules.TestModule.p = 123")
-    val p2 = evaluateScript("ExpoModules.TestModule.p").getDouble().toInt()
+    evaluateScript("expo.modules.TestModule.p = 987")
+    val p1 = evaluateScript("expo.modules.TestModule.p").getDouble().toInt()
+    evaluateScript("expo.modules.TestModule.p = 123")
+    val p2 = evaluateScript("expo.modules.TestModule.p").getDouble().toInt()
 
     Truth.assertThat(p1).isEqualTo(987)
     Truth.assertThat(p2).isEqualTo(123)
@@ -70,8 +70,8 @@ internal class JSIPropertiesTest {
       Property("p")
     }
   ) {
-    val p = evaluateScript("ExpoModules.TestModule.p")
-    val undefined = evaluateScript("ExpoModules.TestModule.undefined")
+    val p = evaluateScript("expo.modules.TestModule.p")
+    val undefined = evaluateScript("expo.modules.TestModule.undefined")
 
     Truth.assertThat(p.isUndefined()).isTrue()
     Truth.assertThat(undefined.isUndefined()).isTrue()

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptObjectTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptObjectTest.kt
@@ -173,7 +173,7 @@ class JavaScriptObjectTest {
       val result = evaluateScript(
         """
         const x = {};
-        ExpoModules.TestModule.f(x);
+        expo.modules.TestModule.f(x);
         x
         """.trimIndent()
       ).getObject()

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptValueTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptValueTest.kt
@@ -81,7 +81,7 @@ class JavaScriptValueTest {
       val result = evaluateScript(
         """
         const x = {};
-        ExpoModules.TestModule.f(x);
+        expo.modules.TestModule.f(x);
         x
         """.trimIndent()
       ).getObject()

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/NetTypeConversionTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/NetTypeConversionTest.kt
@@ -17,7 +17,7 @@ class NetTypeConversionTest {
       Function("url") { a: URL -> a.toString() }
     }
   ) {
-    val stringValue = evaluateScript("ExpoModules.TestModule.url('https://expo.dev/')").getString()
+    val stringValue = evaluateScript("expo.modules.TestModule.url('https://expo.dev/')").getString()
     Truth.assertThat(stringValue).isEqualTo("https://expo.dev/")
   }
 
@@ -28,7 +28,7 @@ class NetTypeConversionTest {
       Function("uri") { a: Uri -> a.toString() }
     }
   ) {
-    val stringValue = evaluateScript("ExpoModules.TestModule.uri('http://api.example.org/data/2.5/forecast/daily?q=94043&mode=json&units=metric&cnt=7')").getString()
+    val stringValue = evaluateScript("expo.modules.TestModule.uri('http://api.example.org/data/2.5/forecast/daily?q=94043&mode=json&units=metric&cnt=7')").getString()
     Truth.assertThat(stringValue).isEqualTo("http://api.example.org/data/2.5/forecast/daily?q=94043&mode=json&units=metric&cnt=7")
   }
 
@@ -39,7 +39,7 @@ class NetTypeConversionTest {
       Function("uri") { a: URI -> a.toString() }
     }
   ) {
-    val stringValue = evaluateScript("ExpoModules.TestModule.uri('http://api.example.org/data/2.5/forecast/daily?q=94043&mode=json&units=metric&cnt=7')").getString()
+    val stringValue = evaluateScript("expo.modules.TestModule.uri('http://api.example.org/data/2.5/forecast/daily?q=94043&mode=json&units=metric&cnt=7')").getString()
     Truth.assertThat(stringValue).isEqualTo("http://api.example.org/data/2.5/forecast/daily?q=94043&mode=json&units=metric&cnt=7")
   }
 }

--- a/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.cpp
@@ -53,12 +53,22 @@ void JSIInteropModuleRegistry::installJSI(
   auto expoModules = std::make_shared<ExpoModulesHostObject>(this);
   auto expoModulesObject = jsi::Object::createFromHostObject(*runtime, expoModules);
 
+  // Define the `global.expo.modules` object.
+  runtimeHolder
+    ->getMainObject()
+    ->setProperty(
+      *runtime,
+      "modules",
+      expoModulesObject
+    );
+
+  // Also define `global.ExpoModules` for backwards compatibility (used before SDK47, can be removed in SDK48).
   runtime
     ->global()
     .setProperty(
       *runtime,
       "ExpoModules",
-      std::move(expoModulesObject)
+      expoModulesObject
     );
 }
 
@@ -74,11 +84,11 @@ void JSIInteropModuleRegistry::installJSIForTests() {
   auto expoModules = std::make_shared<ExpoModulesHostObject>(this);
   auto expoModulesObject = jsi::Object::createFromHostObject(jsiRuntime, expoModules);
 
-  jsiRuntime
-    .global()
-    .setProperty(
+  runtimeHolder
+    ->getMainObject()
+    ->setProperty(
       jsiRuntime,
-      "ExpoModules",
+      "modules",
       std::move(expoModulesObject)
     );
 #endif // !UNIT_TEST

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptObject.h
@@ -59,6 +59,8 @@ public:
 
   void setProperty(const std::string &name, jsi::Value value);
 
+  static jsi::Object preparePropertyDescriptor(jsi::Runtime &jsRuntime, int options);
+
 protected:
   WeakRuntimeHolder runtimeHolder;
   std::shared_ptr<jsi::Object> jsObject;
@@ -128,7 +130,5 @@ private:
       std::move(descriptor)
     });
   }
-
-  static jsi::Object preparePropertyDescriptor(jsi::Runtime &jsRuntime, int options);
 };
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.h
@@ -81,7 +81,12 @@ public:
 
   std::shared_ptr<react::CallInvoker> jsInvoker;
   std::shared_ptr<react::CallInvoker> nativeInvoker;
+
+  std::shared_ptr<jsi::Object> getMainObject();
 private:
   std::shared_ptr<jsi::Runtime> runtime;
+  std::shared_ptr<jsi::Object> mainObject;
+
+  void installMainObject();
 };
 } // namespace expo


### PR DESCRIPTION
# Why

A follow-up to https://github.com/expo/expo/pull/19273.

# How

- Added `global.expo` object to the runtime.
- Installed the Expo Modules host object as `global.expo.modules`.
- Deprecated `global.ExpoModules`, which will still exist in SDK47 for one-cycle backward compatibility. It can be removed in SDK48.
- Migrated references to `global.ExpoModules` in native unit tests

# Test Plan

- unit test ✅
- NCL ✅