### PR TITLE
[docs] Home: fix layout on mobile with slow connection

### DIFF
--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -12,10 +12,11 @@ import {
   GithubIcon,
   RedditIcon,
   TwitterIcon,
+  breakpoints,
 } from '@expo/styleguide';
 import { useRouter } from 'next/router';
 import React, { PropsWithChildren } from 'react';
-import { Container, Row } from 'react-grid-system';
+import { Container, Row, ScreenClassProvider } from 'react-grid-system';
 
 import DocumentationPage from '~/components/DocumentationPage';
 import { APIGridCell, CommunityGridCell, GridCell, HomeButton } from '~/ui/components/Home';
@@ -25,7 +26,9 @@ import {
   APIMapsIcon,
   APINotificationsIcon,
   CodecademyImage,
+  CodecademyImageMasks,
   DevicesImage,
+  DevicesImageMasks,
   OfficeHoursImage,
   QuickStartIcon,
   SnackImage,
@@ -52,200 +55,224 @@ const Home = () => {
   const { themeName } = useTheme();
   const { palette, button, background } = theme;
   return (
-    <DocumentationPage router={router} tocVisible={false} hideFromSearch>
-      <H1
-        css={css({ marginBottom: 8, fontFamily: typography.fontStacks.black, fontWeight: '900' })}>
-        Create amazing apps that run everywhere
-      </H1>
-      <Description>
-        Build one JavaScript/TypeScript project that runs natively on all your users' devices.
-      </Description>
-      <CellContainer>
-        <Row>
-          <GridCell xl={4} lg={12} css={quickStartCellStyle}>
-            <div
-              css={[
-                baseGradientStyle,
-                css({
-                  background: `linear-gradient(${background.secondary} 15%, #21262d00 100%)`,
-                }),
-              ]}
-            />
-            <div
-              css={{
-                position: 'relative',
-                zIndex: 1,
-              }}>
-              <H2>
-                <QuickStartIcon /> Quick Start
-              </H2>
-              <br />
-              <Terminal
-                includeMargin={false}
-                cmd={['$ npm i -g expo-cli', '$ npx create-expo-app my-app']}
-                cmdCopy="npm install --global expo-cli && npx create-expo-app my-app"
+    <ScreenClassProvider>
+      <DocumentationPage router={router} tocVisible={false} hideFromSearch>
+        <div css={imageMasksContainerStyle}>
+          <DevicesImageMasks />
+          <CodecademyImageMasks />
+        </div>
+        <H1
+          css={css({
+            marginBottom: 8,
+            fontFamily: typography.fontStacks.black,
+            fontWeight: '900',
+          })}>
+          Create amazing apps that run everywhere
+        </H1>
+        <Description>
+          Build one JavaScript/TypeScript project that runs natively on all your users' devices.
+        </Description>
+        <CellContainer>
+          <Row>
+            <GridCell xl={4} lg={12} css={quickStartCellStyle}>
+              <div
+                css={[
+                  baseGradientStyle,
+                  css({
+                    background: `linear-gradient(${background.secondary} 15%, #21262d00 100%)`,
+                  }),
+                ]}
               />
-            </div>
-          </GridCell>
-          <GridCell
-            xl={8}
-            lg={12}
-            css={[
-              tutorialCellStyle,
-              css({
-                borderColor: palette.primary[themeName === 'dark' ? '300' : '200'],
-              }),
-            ]}>
-            <div
+              <div
+                css={{
+                  position: 'relative',
+                  zIndex: 1,
+                }}>
+                <H2>
+                  <QuickStartIcon /> Quick Start
+                </H2>
+                <br />
+                <Terminal
+                  includeMargin={false}
+                  cmd={['$ npm i -g expo-cli', '$ npx create-expo-app my-app']}
+                  cmdCopy="npm install --global expo-cli && npx create-expo-app my-app"
+                />
+              </div>
+            </GridCell>
+            <GridCell
+              xl={8}
+              lg={12}
               css={[
-                baseGradientStyle,
+                tutorialCellStyle,
                 css({
-                  background: `linear-gradient(${palette.primary['100']} 15%, #201d5200 100%)`,
+                  borderColor: palette.primary[themeName === 'dark' ? '300' : '200'],
                 }),
-              ]}
-            />
-            <DevicesImage />
-            <H2 css={css({ color: palette.primary['900'], zIndex: 1, position: 'relative' })}>
-              Create a universal Android, iOS,
-              <br />
-              and web photo sharing app
-            </H2>
-            <HomeButton
+              ]}>
+              <div
+                css={[
+                  baseGradientStyle,
+                  css({
+                    background: `linear-gradient(${palette.primary['100']} 15%, #201d5200 100%)`,
+                  }),
+                ]}
+              />
+              <DevicesImage />
+              <H2 css={css({ color: palette.primary['900'], zIndex: 1, position: 'relative' })}>
+                Create a universal Android, iOS,
+                <br />
+                and web photo sharing app
+              </H2>
+              <HomeButton
+                css={css({
+                  background: button.primary.background,
+                  color: button.primary.foreground,
+                  height: 40,
+                })}
+                href="/tutorial/planning/"
+                iconRight={<ArrowRightIcon color={button.primary.foreground} />}>
+                Start Tutorial
+              </HomeButton>
+            </GridCell>
+          </Row>
+        </CellContainer>
+        <H3>Learn more</H3>
+        <Description>
+          Try out Expo in minutes and learn how to get the most out of Expo.
+        </Description>
+        <CellContainer>
+          <Row>
+            <GridCell
+              xl={6}
+              lg={6}
               css={css({
-                background: button.primary.background,
-                color: button.primary.foreground,
-                height: 40,
-              })}
-              href="/tutorial/planning/"
-              iconRight={<ArrowRightIcon color={button.primary.foreground} />}>
-              Start Tutorial
-            </HomeButton>
-          </GridCell>
-        </Row>
-      </CellContainer>
-      <H3>Learn more</H3>
-      <Description>Try out Expo in minutes and learn how to get the most out of Expo.</Description>
-      <CellContainer>
-        <Row>
-          <GridCell
-            xl={6}
-            lg={6}
-            css={css({ backgroundColor: palette.blue['000'], borderColor: palette.blue['200'] })}>
-            <SnackImage />
-            <H3 css={css({ color: palette.blue['900'], marginBottom: spacing[1.5] })}>
-              Try Expo in your browser
-            </H3>
-            <P css={css({ color: palette.blue['800'], ...typography.fontSizes[14] })}>
-              Expo’s Snack lets you try Expo
-              <br />
-              with zero local setup.
-            </P>
-            <HomeButton
-              css={css({ backgroundColor: palette.blue['500'], color: palette.blue['100'] })}
-              href="https://snack.expo.dev/"
-              target="_blank"
-              iconRight={<ArrowUpRightIcon color={palette.blue['100']} />}>
-              Create a Snack
-            </HomeButton>
-          </GridCell>
-          <GridCell
-            xl={6}
-            lg={6}
-            css={css({
-              backgroundColor: palette.orange['100'],
-              borderColor: palette.orange[themeName === 'dark' ? '300' : '200'],
-            })}>
-            <CodecademyImage />
-            <H3 css={css({ color: palette.orange['900'] })}>
-              Learn Expo on
-              <br />
-              Codecademy
-            </H3>
-            <HomeButton
-              css={css({ backgroundColor: palette.orange['800'], color: palette.orange['100'] })}
-              href="https://www.codecademy.com/learn/learn-react-native"
-              target="_blank"
-              iconRight={<ArrowUpRightIcon color={palette.orange['100']} />}>
-              Start Course
-            </HomeButton>
-          </GridCell>
-          <GridCell
-            xl={6}
-            lg={6}
-            css={css({ backgroundColor: palette.green['000'], borderColor: palette.green['200'] })}>
-            <WhyImage />
-            <H3 css={css({ color: palette.green['900'], marginBottom: spacing[1.5] })}>
-              Why choose Expo?
-            </H3>
-            <P css={{ color: palette.green['800'], ...typography.fontSizes[14] }}>
-              Learn the tradeoffs of
-              <br />
-              using Expo.
-            </P>
-            <HomeButton
-              css={css({ backgroundColor: palette.green['700'], color: palette.green['000'] })}
-              href="/introduction/faq"
-              iconRight={<ArrowRightIcon color={palette.green['000']} />}>
-              Read
-            </HomeButton>
-          </GridCell>
-          <GridCell
-            xl={6}
-            lg={6}
-            css={css({
-              backgroundColor: palette.yellow['000'],
-              borderColor: palette.yellow['300'],
-            })}>
-            <OfficeHoursImage />
-            <H3 css={css({ color: palette.yellow['900'], marginBottom: spacing[1.5] })}>
-              Join us for Office Hours
-            </H3>
-            <P css={css({ color: palette.yellow['800'], ...typography.fontSizes[14] })}>
-              Get answers to your questions and
-              <br />
-              get advice from the Expo team.
-            </P>
-            <HomeButton
-              css={css({ backgroundColor: palette.yellow['900'], color: palette.yellow['000'] })}
-              href="https://us02web.zoom.us/meeting/register/tZcvceivqj0oHdGVOjEeKY0dRxCRPb0HzaAK"
-              target="_blank"
-              iconRight={<ArrowUpRightIcon color={palette.yellow['000']} />}>
-              Register
-            </HomeButton>
-          </GridCell>
-        </Row>
-      </CellContainer>
-      <H3>Explore APIs</H3>
-      <Description>
-        Expo supplies a vast array of SDK modules. You can also create your own.
-      </Description>
-      <CellContainer>
-        <Row>
-          <APIGridCell
-            title="Maps"
-            link="/versions/latest/sdk/map-view"
-            icon={<APIMapsIcon size={70} />}
-          />
-          <APIGridCell
-            title="Camera"
-            link="/versions/latest/sdk/camera"
-            icon={<APICameraIcon size={70} />}
-          />
-          <APIGridCell
-            title="Notifications"
-            link="/versions/latest/sdk/notifications"
-            icon={<APINotificationsIcon size={70} />}
-          />
-          <APIGridCell
-            title="View all APIs"
-            link="/versions/latest/"
-            icon={<APIListIcon size={70} />}
-          />
-        </Row>
-      </CellContainer>
-      <H3>Join the community</H3>
-      <JoinTheCommunity />
-    </DocumentationPage>
+                backgroundColor: palette.blue['000'],
+                borderColor: palette.blue['200'],
+              })}>
+              <SnackImage />
+              <H3 css={css({ color: palette.blue['900'], marginBottom: spacing[1.5] })}>
+                Try Expo in your browser
+              </H3>
+              <P css={css({ color: palette.blue['800'], ...typography.fontSizes[14] })}>
+                Expo’s Snack lets you try Expo
+                <br />
+                with zero local setup.
+              </P>
+              <HomeButton
+                css={css({ backgroundColor: palette.blue['500'], color: palette.blue['100'] })}
+                href="https://snack.expo.dev/"
+                target="_blank"
+                iconRight={<ArrowUpRightIcon color={palette.blue['100']} />}>
+                Create a Snack
+              </HomeButton>
+            </GridCell>
+            <GridCell
+              xl={6}
+              lg={6}
+              css={css({
+                backgroundColor: palette.orange['100'],
+                borderColor: palette.orange[themeName === 'dark' ? '300' : '200'],
+              })}>
+              <CodecademyImage />
+              <H3 css={css({ color: palette.orange['900'] })}>
+                Learn Expo on
+                <br />
+                Codecademy
+              </H3>
+              <HomeButton
+                css={css({
+                  backgroundColor: palette.orange['800'],
+                  color: palette.orange['100'],
+                })}
+                href="https://www.codecademy.com/learn/learn-react-native"
+                target="_blank"
+                iconRight={<ArrowUpRightIcon color={palette.orange['100']} />}>
+                Start Course
+              </HomeButton>
+            </GridCell>
+            <GridCell
+              xl={6}
+              lg={6}
+              css={css({
+                backgroundColor: palette.green['000'],
+                borderColor: palette.green['200'],
+              })}>
+              <WhyImage />
+              <H3 css={css({ color: palette.green['900'], marginBottom: spacing[1.5] })}>
+                Why choose Expo?
+              </H3>
+              <P css={{ color: palette.green['800'], ...typography.fontSizes[14] }}>
+                Learn the tradeoffs of
+                <br />
+                using Expo.
+              </P>
+              <HomeButton
+                css={css({ backgroundColor: palette.green['700'], color: palette.green['000'] })}
+                href="/introduction/faq"
+                iconRight={<ArrowRightIcon color={palette.green['000']} />}>
+                Read
+              </HomeButton>
+            </GridCell>
+            <GridCell
+              xl={6}
+              lg={6}
+              css={css({
+                backgroundColor: palette.yellow['000'],
+                borderColor: palette.yellow['300'],
+              })}>
+              <OfficeHoursImage />
+              <H3 css={css({ color: palette.yellow['900'], marginBottom: spacing[1.5] })}>
+                Join us for Office Hours
+              </H3>
+              <P css={css({ color: palette.yellow['800'], ...typography.fontSizes[14] })}>
+                Get answers to your questions and
+                <br />
+                get advice from the Expo team.
+              </P>
+              <HomeButton
+                css={css({
+                  backgroundColor: palette.yellow['900'],
+                  color: palette.yellow['000'],
+                })}
+                href="https://us02web.zoom.us/meeting/register/tZcvceivqj0oHdGVOjEeKY0dRxCRPb0HzaAK"
+                target="_blank"
+                iconRight={<ArrowUpRightIcon color={palette.yellow['000']} />}>
+                Register
+              </HomeButton>
+            </GridCell>
+          </Row>
+        </CellContainer>
+        <H3>Explore APIs</H3>
+        <Description>
+          Expo supplies a vast array of SDK modules. You can also create your own.
+        </Description>
+        <CellContainer>
+          <Row>
+            <APIGridCell
+              title="Maps"
+              link="/versions/latest/sdk/map-view"
+              icon={<APIMapsIcon size={70} />}
+            />
+            <APIGridCell
+              title="Camera"
+              link="/versions/latest/sdk/camera"
+              icon={<APICameraIcon size={70} />}
+            />
+            <APIGridCell
+              title="Notifications"
+              link="/versions/latest/sdk/notifications"
+              icon={<APINotificationsIcon size={70} />}
+            />
+            <APIGridCell
+              title="View all APIs"
+              link="/versions/latest/"
+              icon={<APIListIcon size={70} />}
+            />
+          </Row>
+        </CellContainer>
+        <H3>Join the community</H3>
+        <JoinTheCommunity />
+      </DocumentationPage>
+    </ScreenClassProvider>
   );
 };
 
@@ -314,6 +341,10 @@ const quickStartCellStyle = css({
   backgroundImage: 'url("/static/images/home/QuickStartPattern.svg")',
   backgroundBlendMode: 'multiply',
   minHeight: 250,
+
+  [`@media screen and (max-width: ${(breakpoints.medium + breakpoints.large) / 2}px)`]: {
+    minHeight: 200,
+  },
 });
 
 const tutorialCellStyle = css({
@@ -321,6 +352,14 @@ const tutorialCellStyle = css({
   backgroundImage: 'url("/static/images/home/TutorialPattern.svg")',
   backgroundBlendMode: 'multiply',
   minHeight: 250,
+
+  [`@media screen and (max-width: ${(breakpoints.medium + breakpoints.large) / 2}px)`]: {
+    minHeight: 200,
+  },
+});
+
+const imageMasksContainerStyle = css({
+  height: 0,
 });
 
 export default Home;

--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -342,7 +342,7 @@ const quickStartCellStyle = css({
   backgroundBlendMode: 'multiply',
   minHeight: 250,
 
-  [`@media screen and (max-width: ${(breakpoints.medium + breakpoints.large) / 2}px)`]: {
+  [`@media screen and (max-width: ${breakpoints.medium}px)`]: {
     minHeight: 200,
   },
 });
@@ -353,7 +353,7 @@ const tutorialCellStyle = css({
   backgroundBlendMode: 'multiply',
   minHeight: 250,
 
-  [`@media screen and (max-width: ${(breakpoints.medium + breakpoints.large) / 2}px)`]: {
+  [`@media screen and (max-width: ${breakpoints.medium}px)`]: {
     minHeight: 200,
   },
 });

--- a/docs/ui/components/Home/Cells.tsx
+++ b/docs/ui/components/Home/Cells.tsx
@@ -3,6 +3,7 @@ import {
   ArrowRightIcon,
   ArrowUpRightIcon,
   borderRadius,
+  breakpoints,
   iconSize,
   palette,
   shadows,
@@ -15,6 +16,15 @@ import { Col, ColProps } from 'react-grid-system';
 
 import { P } from '~/ui/components/Text';
 
+const CustomCol = ({ children, sm, md, lg, xl, xxl }: PropsWithChildren<ColProps>) => (
+  <>
+    <Col css={cellWrapperStyle} sm={sm} md={md} lg={lg} xl={xl} xxl={xxl}>
+      {children}
+    </Col>
+    <div css={mobileCellWrapperStyle}>{children}</div>
+  </>
+);
+
 export const GridCell = ({
   children,
   sm,
@@ -24,11 +34,11 @@ export const GridCell = ({
   xxl,
   className,
 }: PropsWithChildren<ColProps>) => (
-  <Col css={cellWrapperStyle} sm={sm} md={md} lg={lg} xl={xl} xxl={xxl}>
+  <CustomCol css={cellWrapperStyle} sm={sm} md={md} lg={lg} xl={xl} xxl={xxl}>
     <div css={cellStyle} className={className}>
       {children}
     </div>
-  </Col>
+  </CustomCol>
 );
 
 type APIGridCellProps = ColProps & {
@@ -47,7 +57,7 @@ export const APIGridCell = ({
   lg = 6,
   xl = 3,
 }: APIGridCellProps) => (
-  <Col css={cellWrapperStyle} md={md} sm={sm} lg={lg} xl={xl}>
+  <CustomCol css={cellWrapperStyle} md={md} sm={sm} lg={lg} xl={xl}>
     <a href={link} css={[cellStyle, cellAPIStyle, cellHoverStyle]} className={className}>
       <div css={cellIconWrapperStyle}>{icon}</div>
       <div css={cellTitleWrapperStyle}>
@@ -55,7 +65,7 @@ export const APIGridCell = ({
         <ArrowRightIcon color={theme.icon.secondary} />
       </div>
     </a>
-  </Col>
+  </CustomCol>
 );
 
 type CommunityGridCellProps = APIGridCellProps & {
@@ -72,7 +82,7 @@ export const CommunityGridCell = ({
   className,
   md = 6,
 }: CommunityGridCellProps) => (
-  <Col css={cellWrapperStyle} md={md}>
+  <CustomCol css={cellWrapperStyle} md={md}>
     <a
       href={link}
       css={[cellStyle, cellCommunityStyle, cellCommunityHoverStyle]}
@@ -86,13 +96,25 @@ export const CommunityGridCell = ({
       </div>
       <ArrowUpRightIcon color={theme.icon.secondary} css={cellCommunityLinkIconStyle} />
     </a>
-  </Col>
+  </CustomCol>
 );
 
 const cellWrapperStyle = css`
   padding-left: 0 !important;
   padding-right: 0 !important;
+
+  @media screen and (max-width: ${(breakpoints.medium + breakpoints.large) / 2}px) {
+    display: none;
+  }
 `;
+
+const mobileCellWrapperStyle = css({
+  width: '100%',
+
+  [`@media screen and (min-width: ${(breakpoints.medium + breakpoints.large) / 2}px)`]: {
+    display: 'none',
+  },
+});
 
 const cellHoverStyle = css`
   & {

--- a/docs/ui/components/Home/Cells.tsx
+++ b/docs/ui/components/Home/Cells.tsx
@@ -103,7 +103,7 @@ const cellWrapperStyle = css`
   padding-left: 0 !important;
   padding-right: 0 !important;
 
-  @media screen and (max-width: ${(breakpoints.medium + breakpoints.large) / 2}px) {
+  @media screen and (max-width: ${breakpoints.medium}px) {
     display: none;
   }
 `;
@@ -111,7 +111,7 @@ const cellWrapperStyle = css`
 const mobileCellWrapperStyle = css({
   width: '100%',
 
-  [`@media screen and (min-width: ${(breakpoints.medium + breakpoints.large) / 2}px)`]: {
+  [`@media screen and (min-width: ${breakpoints.medium}px)`]: {
     display: 'none',
   },
 });

--- a/docs/ui/components/Home/resources/CodecademyImage.tsx
+++ b/docs/ui/components/Home/resources/CodecademyImage.tsx
@@ -18,19 +18,6 @@ export const CodecademyImage = () => (
       fill={theme.palette.orange['800']}
       stroke={theme.palette.orange['800']}
     />
-    <mask
-      id="9cc3c1cf68eeb3d655221dab7774e70e"
-      style={{ maskType: 'alpha' }}
-      maskUnits="userSpaceOnUse"
-      x="75"
-      y="1"
-      width="50"
-      height="65">
-      <path
-        d="M75.8173 26.277C75.8173 12.8234 86.7236 1.91711 100.177 1.91711V1.91711C113.631 1.91711 124.537 12.8234 124.537 26.277V65.631H75.8173V26.277Z"
-        fill="#11162D"
-      />
-    </mask>
     <g mask="url(#9cc3c1cf68eeb3d655221dab7774e70e)">
       <circle cx="87.8602" cy="65.6313" r="22.3086" fill="#E36209" />
       <circle cx="117.339" cy="57.2905" r="24.8014" fill={theme.palette.orange['200']} />
@@ -130,5 +117,23 @@ export const CodecademyImage = () => (
       fill={theme.palette.orange['200']}
       stroke={theme.palette.orange['800']}
     />
+  </svg>
+);
+
+export const CodecademyImageMasks = () => (
+  <svg width="0" height="0">
+    <mask
+      id="9cc3c1cf68eeb3d655221dab7774e70e"
+      style={{ maskType: 'alpha' }}
+      maskUnits="userSpaceOnUse"
+      x="75"
+      y="1"
+      width="50"
+      height="65">
+      <path
+        d="M75.8173 26.277C75.8173 12.8234 86.7236 1.91711 100.177 1.91711V1.91711C113.631 1.91711 124.537 12.8234 124.537 26.277V65.631H75.8173V26.277Z"
+        fill="#11162D"
+      />
+    </mask>
   </svg>
 );

--- a/docs/ui/components/Home/resources/DevicesImage.tsx
+++ b/docs/ui/components/Home/resources/DevicesImage.tsx
@@ -344,88 +344,91 @@ export const DevicesImage = () => (
       d="M134.302 13.9601C134.856 13.6266 135.491 13.4504 136.139 13.4504H180.206C180.899 13.4504 181.576 13.6521 182.156 14.0309L185.142 15.9811C187.227 17.343 186.263 20.5831 183.773 20.5831C182.389 20.5831 181.268 21.7046 181.268 23.088V24.1495C181.268 26.1191 179.671 27.7158 177.701 27.7158H138.716C136.746 27.7158 135.149 26.1191 135.149 24.1495V23.1602C135.149 21.7369 133.996 20.5831 132.572 20.5831C129.96 20.5831 129.005 17.1432 131.245 15.7973L134.302 13.9601Z"
       fill={darkTheme.background.tertiary}
     />
-    <defs>
-      <filter
-        id="3fe977fb0acabded0c62aa0c9c945938"
-        x="162.611"
-        y="17.3787"
-        width="216.241"
-        height="238.724"
-        filterUnits="userSpaceOnUse"
-        colorInterpolationFilters="sRGB">
-        <feFlood floodOpacity="0" result="BackgroundImageFix" />
-        <feColorMatrix
-          in="SourceAlpha"
-          type="matrix"
-          values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
-          result="hardAlpha"
-        />
-        <feOffset dy="5" />
-        <feGaussianBlur stdDeviation="5" />
-        <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.12 0" />
-        <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_39:1396" />
-        <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_39:1396" result="shape" />
-      </filter>
-      <linearGradient
-        id="efeb358a5390d90e5e3ede15cf021e74"
-        x1="229.398"
-        y1="45.9863"
-        x2="261.629"
-        y2="225.302"
-        gradientUnits="userSpaceOnUse">
-        <stop stopColor="#735BFF" />
-        <stop offset="1" stopColor="#AB41FF" />
-      </linearGradient>
-      <linearGradient
-        id="798da3dad1527946ee33aecf8f9ec234"
-        x1="22.0813"
-        y1="53.6141"
-        x2="94.9801"
-        y2="223.711"
-        gradientUnits="userSpaceOnUse">
-        <stop stopColor="#735BFF" />
-        <stop offset="1" stopColor="#AB41FF" />
-      </linearGradient>
-      <linearGradient
-        id="e2839d57a5b978f1058be04fb2a500dd"
-        x1="122.012"
-        y1="21.9108"
-        x2="194.91"
-        y2="192.008"
-        gradientUnits="userSpaceOnUse">
-        <stop stopColor="#735BFF" />
-        <stop offset="1" stopColor="#AB41FF" />
-      </linearGradient>
-      <clipPath id="clip0_39:1396">
-        <rect
-          x="214.901"
-          y="22.3787"
-          width="158"
-          height="188"
-          rx="4"
-          transform="rotate(13 214.901 22.3787)"
-          fill="white"
-        />
-      </clipPath>
-      <clipPath id="clip1_39:1396">
-        <rect
-          width="12.7276"
-          height="12.7276"
-          fill="white"
-          transform="translate(263.63 138.778) rotate(13)"
-        />
-      </clipPath>
-      <clipPath id="clip2_39:1396">
-        <rect
-          width="12.7276"
-          height="12.7276"
-          fill="white"
-          transform="translate(73.1624 119.133) rotate(-13)"
-        />
-      </clipPath>
-      <clipPath id="clip3_39:1396">
-        <rect width="12.7276" height="12.7276" fill="white" transform="translate(154.93 107.311)" />
-      </clipPath>
-    </defs>
+  </svg>
+);
+
+export const DevicesImageMasks = () => (
+  <svg width="0" height="0">
+    <filter
+      id="3fe977fb0acabded0c62aa0c9c945938"
+      x="162.611"
+      y="17.3787"
+      width="216.241"
+      height="238.724"
+      filterUnits="userSpaceOnUse"
+      colorInterpolationFilters="sRGB">
+      <feFlood floodOpacity="0" result="BackgroundImageFix" />
+      <feColorMatrix
+        in="SourceAlpha"
+        type="matrix"
+        values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+        result="hardAlpha"
+      />
+      <feOffset dy="5" />
+      <feGaussianBlur stdDeviation="5" />
+      <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.12 0" />
+      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_39:1396" />
+      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_39:1396" result="shape" />
+    </filter>
+    <linearGradient
+      id="efeb358a5390d90e5e3ede15cf021e74"
+      x1="229.398"
+      y1="45.9863"
+      x2="261.629"
+      y2="225.302"
+      gradientUnits="userSpaceOnUse">
+      <stop stopColor="#735BFF" />
+      <stop offset="1" stopColor="#AB41FF" />
+    </linearGradient>
+    <linearGradient
+      id="798da3dad1527946ee33aecf8f9ec234"
+      x1="22.0813"
+      y1="53.6141"
+      x2="94.9801"
+      y2="223.711"
+      gradientUnits="userSpaceOnUse">
+      <stop stopColor="#735BFF" />
+      <stop offset="1" stopColor="#AB41FF" />
+    </linearGradient>
+    <linearGradient
+      id="e2839d57a5b978f1058be04fb2a500dd"
+      x1="122.012"
+      y1="21.9108"
+      x2="194.91"
+      y2="192.008"
+      gradientUnits="userSpaceOnUse">
+      <stop stopColor="#735BFF" />
+      <stop offset="1" stopColor="#AB41FF" />
+    </linearGradient>
+    <clipPath id="clip0_39:1396">
+      <rect
+        x="214.901"
+        y="22.3787"
+        width="158"
+        height="188"
+        rx="4"
+        transform="rotate(13 214.901 22.3787)"
+        fill="white"
+      />
+    </clipPath>
+    <clipPath id="clip1_39:1396">
+      <rect
+        width="12.7276"
+        height="12.7276"
+        fill="white"
+        transform="translate(263.63 138.778) rotate(13)"
+      />
+    </clipPath>
+    <clipPath id="clip2_39:1396">
+      <rect
+        width="12.7276"
+        height="12.7276"
+        fill="white"
+        transform="translate(73.1624 119.133) rotate(-13)"
+      />
+    </clipPath>
+    <clipPath id="clip3_39:1396">
+      <rect width="12.7276" height="12.7276" fill="white" transform="translate(154.93 107.311)" />
+    </clipPath>
   </svg>
 );


### PR DESCRIPTION
# Why

Hopefully fixes https://twitter.com/tejas89_patel/status/1574819679947829248

# How

The grid component that we are using relay on the JS to inject the correct breakpoint styles, which on slow connection on mobile can lead to the broken layout when loading. 

We can alter the default initial screen size setting, but this would lead to the issues with slow connection on desktop.

An alternate solution to that is to switch to the static containers on mobile, utilizing media queries.

# Test Plan

The docs apps has been build and served locally, then I have attempted to load it in browser with Throttle settings set to "Slow 3G".

# Preview

## Locally served docs
![scr](https://user-images.githubusercontent.com/719641/192768464-70e35999-7e0d-46af-ba5c-6e9ab7bc9c62.gif)

## https://docs.expo.dev/
![scr2](https://user-images.githubusercontent.com/719641/192768928-03b6da0a-aad7-4c96-94c0-f5007d00efe5.gif)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
