### PR TITLE
[github] EAS Build action: ensure that commit message do not exceed limit

### DIFF
--- a/.github/actions/eas-build/action.yml
+++ b/.github/actions/eas-build/action.yml
@@ -37,7 +37,7 @@ runs:
       shell: bash
       id: build_start
       run: |
-        COMMIT_MESSAGE=$(git log -1 --pretty=%B)
+        COMMIT_MESSAGE=$(git log -1 --pretty=%B | head -c1000)
         MESSAGE="${MESSAGE:-$COMMIT_MESSAGE}"
         BUILD_ID=$(eas build -p $PLATFORM --profile $EAS_BUILD_PROFILE --message "$MESSAGE" --resource-class ${{ inputs.resourceClass }} --non-interactive --json --no-wait | jq -r ".[0].id")
         echo ::set-output name=build_id::"$BUILD_ID"


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/actions/runs/3143314552/jobs/5107908059

# How

Take only first 1000 characters from `git log` entry.

# Test Plan

Tested commands locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
