### PR TITLE
[docs] Re-organize overview, getting started and native module API

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -187,6 +187,7 @@ const general = [
   ]),
   makeSection('Expo Modules API', [
     makePage('modules/overview.mdx'),
+    makePage('modules/get-started.mdx'),
     makePage('modules/module-api.mdx'),
     makePage('modules/android-lifecycle-listeners.mdx'),
     makePage('modules/appdelegate-subscribers.mdx'),

--- a/docs/pages/modules/get-started.mdx
+++ b/docs/pages/modules/get-started.mdx
@@ -16,7 +16,7 @@ To create a new Expo module from scratch, run the `create-expo-module` script as
 You may want to use the Expo Modules API in existing React Native libraries, for example with [AppDelegate Subscribers](./appdelegate-subscribers.mdx) you can hook into `AppDelegate` methods without requiring developers to copy any code over to their own `AppDelegate`. This is particularly useful to add seamless support for Expo managed projects to a library. The following steps will set up your existing React Native library to have access to the Expo Modules API.
 
 Create the [**expo-module.config.json**](./module-config.mdx) file at the root of your project and start from the empty object `{}` inside it. We will fill it in later to enable specific features.
-The presence of the module config is enough for [Expo Autolinking](https://docs.expo.dev/workflow/glossary-of-terms/#expo-autolinking) to recognize it as an Expo module and automatically link your native code.
+The presence of the module config is enough for [Expo Autolinking](/workflow/glossary-of-terms/#expo-autolinking) to recognize it as an Expo module and automatically link your native code.
 
 ### Add the `expo-modules-core` native dependency
 
@@ -93,7 +93,7 @@ class MyModule : Module() {
 
 </CodeBlocksTable>
 
-Then, add your classes to iOS and/or Android `modules` in the [module config](./module-config.mdx). Expo Autolinking will automatically link these classes as native modules in the user's project.
+Then, add your classes to Android and/or iOS `modules` in the [module config](./module-config.mdx). Expo Autolinking will automatically link these classes as native modules in the user's project.
 
 <CodeBlocksTable tabs={["expo-module.config.json"]}>
 
@@ -111,8 +111,8 @@ Then, add your classes to iOS and/or Android `modules` in the [module config](./
 </CodeBlocksTable>
 
 If you already have an example app in your workspace, ensure that the module is linked correctly.
-- **On iOS** you need to run `pod install` to link the new class.
 - **On Android** the native module class will be linked automatically before building, as part of the Gradle build task.
+- **On iOS** you need to run `pod install` to link the new class.
 These module classes can now be accessed from the JavaScript code using the `requireNativeModule` function from the `expo-modules-core` package. We recommend creating a separate file that exports the native module for simplicity.
 
 <CodeBlocksTable tabs={["MyModule.ts"]}>

--- a/docs/pages/modules/get-started.mdx
+++ b/docs/pages/modules/get-started.mdx
@@ -7,7 +7,7 @@ import { Terminal } from '~/ui/components/Snippet';
 
 ## Create a new module
 
-To create a new Expo module from scratch, just run the `create-expo-module` script as below. The script will ask you a few questions and then generate the native Expo module along with the example app for iOS and Android that uses your new module.
+To create a new Expo module from scratch, run the `create-expo-module` script as shown below. The script will ask you a few questions and then generate the native Expo module along with the example app for iOS and Android that uses your new module.
 
 <Terminal cmd={[`$ npx create-expo-module`]} />
 
@@ -15,8 +15,8 @@ To create a new Expo module from scratch, just run the `create-expo-module` scri
 
 You may want to use the Expo Modules API in existing React Native libraries, for example with [AppDelegate Subscribers](./appdelegate-subscribers.mdx) you can hook into `AppDelegate` methods without requiring developers to copy any code over to their own `AppDelegate`. This is particularly useful to add seamless support for Expo managed projects to a library. The following steps will set up your existing React Native library to have access to the Expo Modules API.
 
-Create the [module config](./module-config.mdx) **expo-module.config.json** file just near your **package.json** and start from the empty object `{}` in there. We will fill it in later to enable specific features.
-The presence of the module config is enough for Expo Autolinking to recognize it as an Expo module and automatically link your native code.
+Create the [**expo-module.config.json**](./module-config.mdx) file at the root of your project and start from the empty object `{}` inside it. We will fill it in later to enable specific features.
+The presence of the module config is enough for [Expo Autolinking](https://docs.expo.dev/workflow/glossary-of-terms/#expo-autolinking) to recognize it as an Expo module and automatically link your native code.
 
 ### Add the `expo-modules-core` native dependency
 
@@ -64,7 +64,7 @@ Add `expo` package as a peer dependency in your **package.json** — we recommen
 
 ## Create a native module
 
-To use the Expo Modules API for native modules, you need to [set up your library as an Expo module](#set-up-a-library-as-an-expo-module). Once that is complete, create Swift and Kotlin files from the below templates.
+To use the Expo Modules API for native modules, you need to [set up your library as an Expo module](#set-up-a-library-as-an-expo-module). Once complete, create Swift and Kotlin files from the templates below.
 
 <CodeBlocksTable tabs={["MyModule.swift", "MyModule.kt"]}>
 
@@ -93,7 +93,7 @@ class MyModule : Module() {
 
 </CodeBlocksTable>
 
-Then add your classes to iOS and/or Android `modules` in the [module config](./module-config.mdx). Expo Autolinking will automatically link these classes as native modules in user's project.
+Then, add your classes to iOS and/or Android `modules` in the [module config](./module-config.mdx). Expo Autolinking will automatically link these classes as native modules in the user's project.
 
 <CodeBlocksTable tabs={["expo-module.config.json"]}>
 
@@ -111,12 +111,9 @@ Then add your classes to iOS and/or Android `modules` in the [module config](./m
 </CodeBlocksTable>
 
 If you already have an example app in your workspace, ensure that the module is linked correctly.
-
-**On iOS** you need to run `pod install` to link the new class.
-
-**On Android** the native module class will be linked automatically before building, as part of the Gradle build task.
-
-These module classes can now be accessed from the JavaScript code using the `requireNativeModule` function from the `expo-modules-core` package. For simplicity we recommend to create a separate file that exports the native module.
+- **On iOS** you need to run `pod install` to link the new class.
+- **On Android** the native module class will be linked automatically before building, as part of the Gradle build task.
+These module classes can now be accessed from the JavaScript code using the `requireNativeModule` function from the `expo-modules-core` package. We recommend creating a separate file that exports the native module for simplicity.
 
 <CodeBlocksTable tabs={["MyModule.ts"]}>
 
@@ -128,4 +125,4 @@ export default requireNativeModule('MyModule');
 
 </CodeBlocksTable>
 
-Now that the class is set up and linked, you can start to implement its functionality. See the [native module API](./module-api.mdx) reference page, along with links to [examples](./module-api.mdx#examples) of simple to moderately complex real-world modules that you can reference to better understand how to use the API.
+Now that the class is set up and linked, you can start to implement its functionality. See the [native module API](./module-api.mdx) reference page and links to [examples](./module-api.mdx#examples) from simple to moderately complex real-world modules for your reference to better understand how to use the API.

--- a/docs/pages/modules/get-started.mdx
+++ b/docs/pages/modules/get-started.mdx
@@ -13,7 +13,8 @@ To create a new Expo module from scratch, run the `create-expo-module` script as
 
 ## Set up a library as an Expo module
 
-You may want to use the Expo Modules API in existing React Native libraries, for example with [AppDelegate Subscribers](./appdelegate-subscribers.mdx) you can hook into `AppDelegate` methods without requiring developers to copy any code over to their own `AppDelegate`. This is particularly useful to add seamless support for Expo managed projects to a library. The following steps will set up your existing React Native library to have access to the Expo Modules API.
+You can use the Expo Modules API in existing React Native libraries.
+The following steps will set up your existing React Native library to access Expo Modules APIs.
 
 Create the [**expo-module.config.json**](./module-config.mdx) file at the root of your project and start from the empty object `{}` inside it. We will fill it in later to enable specific features.
 The presence of the module config is enough for [Expo Autolinking](/workflow/glossary-of-terms/#expo-autolinking) to recognize it as an Expo module and automatically link your native code.

--- a/docs/pages/modules/get-started.mdx
+++ b/docs/pages/modules/get-started.mdx
@@ -1,0 +1,131 @@
+---
+title: Get Started
+---
+
+import { CodeBlocksTable } from '~/components/plugins/CodeBlocksTable';
+import { Terminal } from '~/ui/components/Snippet';
+
+## Create a new module
+
+To create a new Expo module from scratch, just run the `create-expo-module` script as below. The script will ask you a few questions and then generate the native Expo module along with the example app for iOS and Android that uses your new module.
+
+<Terminal cmd={[`$ npx create-expo-module`]} />
+
+## Set up a library as an Expo module
+
+You may want to use the Expo Modules API in existing React Native libraries, for example with [AppDelegate Subscribers](./appdelegate-subscribers.mdx) you can hook into `AppDelegate` methods without requiring developers to copy any code over to their own `AppDelegate`. This is particularly useful to add seamless support for Expo managed projects to a library. The following steps will set up your existing React Native library to have access to the Expo Modules API.
+
+Create the [module config](./module-config.mdx) **expo-module.config.json** file just near your **package.json** and start from the empty object `{}` in there. We will fill it in later to enable specific features.
+The presence of the module config is enough for Expo Autolinking to recognize it as an Expo module and automatically link your native code.
+
+### Add the `expo-modules-core` native dependency
+
+Add `expo-modules-core` as a dependency in your podspec and **build.gradle** files.<br/>
+
+<CodeBlocksTable tabs={["*.podspec", "build.gradle"]}>
+
+```ruby
+# ...
+Pod::Spec.new do |s|
+  # ...
+  s.dependency 'ExpoModulesCore'
+end
+```
+
+```groovy
+// ...
+dependencies {
+  // ...
+  implementation project(':expo-modules-core')
+}
+```
+
+</CodeBlocksTable>
+
+### Add Expo packages to dependencies
+
+Add `expo` package as a peer dependency in your **package.json** — we recommend using `*` as a version range so as not to cause any duplicated packages in user's **node_modules** folder. Your library also needs to depend on `expo-modules-core` but only as a dev dependency — it's already provided in the projects depending on your library by the `expo` package with the version of core that is compatible with the specific SDK used in the project.<br/>
+
+<CodeBlocksTable tabs={["package.json"]}>
+
+```json
+{
+  // ...
+  "devDependencies": {
+    "expo-modules-core": "^X.Y.Z"
+  },
+  "peerDependencies": {
+    "expo": "*"
+  }
+}
+```
+
+</CodeBlocksTable>
+
+## Create a native module
+
+To use the Expo Modules API for native modules, you need to [set up your library as an Expo module](#set-up-a-library-as-an-expo-module). Once that is complete, create Swift and Kotlin files from the below templates.
+
+<CodeBlocksTable tabs={["MyModule.swift", "MyModule.kt"]}>
+
+```swift
+import ExpoModulesCore
+
+public class MyModule: Module {
+  public func definition() -> ModuleDefinition {
+    // Definition components go here
+  }
+}
+```
+
+```kotlin
+package my.module.package
+
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+
+class MyModule : Module() {
+  override fun definition() = ModuleDefinition {
+    // Definition components go here
+  }
+}
+```
+
+</CodeBlocksTable>
+
+Then add your classes to iOS and/or Android `modules` in the [module config](./module-config.mdx). Expo Autolinking will automatically link these classes as native modules in user's project.
+
+<CodeBlocksTable tabs={["expo-module.config.json"]}>
+
+```json
+{
+  "ios": {
+    "modules": ["MyModule"]
+  },
+  "android": {
+    "modules": ["my.module.package.MyModule"]
+  }
+}
+```
+
+</CodeBlocksTable>
+
+If you already have an example app in your workspace, ensure that the module is linked correctly.
+
+**On iOS** you need to run `pod install` to link the new class.
+
+**On Android** the native module class will be linked automatically before building, as part of the Gradle build task.
+
+These module classes can now be accessed from the JavaScript code using the `requireNativeModule` function from the `expo-modules-core` package. For simplicity we recommend to create a separate file that exports the native module.
+
+<CodeBlocksTable tabs={["MyModule.ts"]}>
+
+```typescript
+import { requireNativeModule } from 'expo-modules-core';
+
+export default requireNativeModule('MyModule');
+```
+
+</CodeBlocksTable>
+
+Now that the class is set up and linked, you can start to implement its functionality. See the [native module API](./module-api.mdx) reference page, along with links to [examples](./module-api.mdx#examples) of simple to moderately complex real-world modules that you can reference to better understand how to use the API.

--- a/docs/pages/modules/module-api.mdx
+++ b/docs/pages/modules/module-api.mdx
@@ -10,81 +10,10 @@ import { APIBox } from '~/components/plugins/APIBox';
 
 The native modules API is an abstraction layer on top of [JSI](https://reactnative.dev/architecture/glossary#javascript-interfaces-jsi) and other low-level primities that React Native is built upon. It is built with modern languages (Swift and Kotlin) and provides an easy to use and convenient API that is consistent across platforms where possible.
 
-## Design considerations
-
-### Why Swift and Kotlin?
-
-After several years of maintaining over 50 native modules in the Expo SDK, we have found out that many issues that have arisen were caused by unhandled null values or using incorrect types. Modern language features can help developers avoid these bugs; for example, the lack of optional types combined with the dynamism of Objective-C made it tough to catch certain classes of bugs that would have been caught by the compiler in Swift.
-
-This is one of the reasons why the Expo Modules ecosystem was designed from the ground up to be used with modern native languages: Swift and Kotlin.
-
-### Passing data between runtimes
-
-Another big pain point that we have encountered is the validation of arguments passed from JavaScript to native functions. This is especially error prone, time consuming, and difficult to maintain when it comes to `NSDictionary` or `ReadableMap`, where the type of values is unknown in runtime and each property needs to be validated separately by the developer. A valuable feature of the Expo native modules API is that it has full knowledge of the argument types the native function expects, so it can pre-validate and convert the arguments for you! The dictionaries can be represented as native structs that we call [Records](#records). Knowing the argument types, it is also possible to [automatically convert arguments](#convertibles) to some platform-specific types (e.g. `{ x: number, y: number }` or `[number, number]` can be translated to CoreGraphics's `CGPoint` for your convenience).
-
-## Get Started
-
-### 1. Set up the library as an Expo module
-
-To use the Expo Modules API for native modules, you need [set up your library as an Expo module](overview). Once that is complete, create Swift and Kotlin files from the below templates.
-
-<CodeBlocksTable>
-
-```swift
-import ExpoModulesCore
-
-public class MyModule: Module {
-  public func definition() -> ModuleDefinition {
-    // Definition components go here
-  }
-}
-```
-
-```kotlin
-package my.module.package
-
-import expo.modules.kotlin.modules.Module
-import expo.modules.kotlin.modules.ModuleDefinition
-
-class MyModule : Module() {
-  override fun definition() = ModuleDefinition {
-    // Definition components go here
-  }
-}
-```
-
-</CodeBlocksTable>
-
-### 2. Set up module config
-
-Add your classes to iOS and/or Android `modules` in the [module config](module-config).
-
-<CodeBlocksTable tabs={["expo-module.config.json"]}>
-
-```json
-{
-  "ios": {
-    "modules": ["MyModule"]
-  },
-  "android": {
-    "modules": ["my.module.package.MyModule"]
-  }
-}
-```
-
-</CodeBlocksTable>
-
-### 3. Ensure the module is linked
-
-**On iOS** you also need to run `pod install` to link the new class.
-
-**On Android** it will be linked automatically before building.
-
-Now that the class is set up and linked, you can start to add functionality. The rest of this guide is a reference for the module API, along with links to [examples](#examples) of simple to moderately complex real-world modules that you can reference to better understand how to use the API.
-
 ## Definition Components
 
-As you might have noticed in the snippets above, each module class must implement the `definition` function. The definition consists of components that describe the module's functionality and behavior.
+As you might have noticed in the snippets on the [Get Started](./get-started.mdx) page, each module class must implement the `definition` function.
+The module definition consists of the DSL components that describe the module's functionality and behavior.
 
 <APIBox header="Name">
 

--- a/docs/pages/modules/overview.mdx
+++ b/docs/pages/modules/overview.mdx
@@ -16,35 +16,35 @@ Expo provides a set of APIs and utilities to improve the process of developing n
 ## Design considerations
 
 Our team needs to maintain a large set of libraries, and maintaining native modules over time and in a constantly changing environment is quite expensive.
-We found out that the existing React Native API for native modules is not scaling very well and is giving us some additional overhead on many levels, from onboarding new contributors (lack of a good documentation) to writing a lot of boilerplate code.
-To make the maintainance easier and let the community iterate faster, we decided to create a module system that reduces the costs and technical debt to a minimum.
+We found out that the existing React Native API for native modules is not scaling very well and is giving us some additional overhead on many levels, from onboarding new contributors (lack of good documentation) to writing a lot of boilerplate code.
+To make the maintenance easier and let the community iterate faster, we decided to create a module system that reduces the costs and technical debt to a minimum.
 
 ### Why Swift and Kotlin?
 
-After several years of maintaining over 50 native modules in the Expo SDK, we have found out that many issues that have arisen were caused by unhandled null values or using incorrect types.
+After several years of maintaining over 50 native modules in the Expo SDK, we have discovered that many issues were caused by unhandled null values or incorrect types.
 Modern language features can help developers avoid these bugs; for example, the lack of optional types combined with the dynamism of Objective-C made it tough to catch certain classes of bugs that would have been caught by the compiler in Swift.
 
 Another difficulty of writing React Native modules is context switching between the vastly different languages and paradigms for writing native modules on each platform.
-Due to the differences between these platforms, it cannot be completely avoided, but we feel the need to have just one common API and documentation to simplify the development as much as possible and make it easier for a single developer to maintain a library on multiple platforms.
+Due to the differences between these platforms, it cannot be avoided completely. We feel the need to have just one common API and documentation to simplify the development as much as possible and make it easier for a single developer to maintain a library on multiple platforms.
 
 This is one of the reasons why the Expo Modules ecosystem was designed from the ground up to be used with modern native languages: Swift and Kotlin.
 
 ### Passing data between runtimes
 
-Another big pain point that we have encountered is the validation of arguments passed from JavaScript to native functions.
-This is especially error prone, time consuming, and difficult to maintain when it comes to `NSDictionary` or `ReadableMap`, where the type of values is unknown in runtime and each property needs to be validated separately by the developer.
-A valuable feature of the Expo native modules API is that it has full knowledge of the argument types the native function expects, so it can pre-validate and convert the arguments for you! The dictionaries can be represented as native structs that we call [Records](./module-api.md#records).
-Knowing the argument types, it is also possible to [automatically convert arguments](./module-api.md#convertibles) to some platform-specific types (e.g. `{ x: number, y: number }` or `[number, number]` can be translated to CoreGraphics's `CGPoint` for your convenience).
+Another big pain point we have encountered is the validation of arguments passed from JavaScript to native functions.
+This is especially error prone, time consuming, and difficult to maintain when it comes to `NSDictionary` or `ReadableMap`, where the type of values is unknown in runtime, and each property needs to be validated separately by the developer.
+A valuable feature of the Expo native modules API is its full knowledge of the argument types the native function expects. It can pre-validate and convert the arguments for you! The dictionaries can be represented as native structs that we call [Records](./module-api.md#records).
+Knowing the argument types, it is also possible to [automatically convert arguments](./module-api.md#convertibles) to some platform-specific types (for example, `{ x: number, y: number }` or `[number, number]` can be translated to CoreGraphics's `CGPoint` for your convenience).
 
 ### React Native New Architecture
 
 React Native version 0.68 introduced the [New Architecture](https://reactnative.dev/docs/the-new-architecture/landing-page), which offers developers new capabilities for building mobile apps.
 It consists of the new native modules system called [Turbo Modules](https://reactnative.dev/docs/the-new-architecture/pillars-turbomodules) and the new rendering system called [Fabric](https://reactnative.dev/architecture/fabric-renderer).
 Native libraries need to be adapted to take advantage of these new systems. For Fabric, it needs even more work as it doesn't provide any compatibility layer, which means that view managers written in the old way don't work with Fabric and the other way around — Fabric native components don't work with the old renderer.
-It basically implies that existing libraries have to provide the support for both architectures for a while, increasing the technical debt.
+It basically implies that existing libraries have to provide support for both architectures for a while, increasing the technical debt.
 
-The new architecture is mostly written in C++ so you may end up needing to write some C++ code to your library as well.
-As we all, React Native developers, use high-level JavaScript on the daily basis, we are rather reluctant to write C++, which is on the opposite side of the spectrum.
+The new architecture is mostly written in C++, so you may end up writing some C++ code for your library as well.
+As we all, React Native developers, use high-level JavaScript on a daily basis, we are rather reluctant to write C++, which is on the opposite side of the spectrum.
 Moreover, including C++ code in the library has a negative impact on build times, especially on Android, and can be more difficult to debug.
 
 We took these into account when designing the Expo Modules API with the goal in mind to make it renderer-agnostic, so that the module doesn't need to know whether the app is run on the new architecture or not, significantly reducing the cost for library developers.

--- a/docs/pages/modules/overview.mdx
+++ b/docs/pages/modules/overview.mdx
@@ -13,61 +13,38 @@ Expo provides a set of APIs and utilities to improve the process of developing n
 - [iOS AppDelegate Subscribers](./appdelegate-subscribers.mdx) — Respond to iOS AppDelegate events.
 - [Module Config](./module-config.mdx) — Configure and opt in to features.
 
-## Create a new module
+## Design considerations
 
-To create a new Expo module from scratch, just run `yarn create expo-module` or `npm create expo-module`.
-The script will ask you a few questions and then generate the native Expo module along with the example app for iOS and Android that uses your new module.
+Our team needs to maintain a large set of libraries, and maintaining native modules over time and in a constantly changing environment is quite expensive.
+We found out that the existing React Native API for native modules is not scaling very well and is giving us some additional overhead on many levels, from onboarding new contributors (lack of a good documentation) to writing a lot of boilerplate code.
+To make the maintainance easier and let the community iterate faster, we decided to create a module system that reduces the costs and technical debt to a minimum.
 
-## Use the Expo Modules API in an existing React Native library
+### Why Swift and Kotlin?
 
-You may want to use the Expo Modules API in existing React Native libraries, for example with [AppDelegate Subscribers](./appdelegate-subscribers.mdx) you can hook into `AppDelegate` methods without requiring developers to copy any code over to their own `AppDelegate`. This is particularly useful to add seamless support for Expo managed projects to a library. The following steps will set up your existing React Native library to have access to the Expo Modules API.
+After several years of maintaining over 50 native modules in the Expo SDK, we have found out that many issues that have arisen were caused by unhandled null values or using incorrect types.
+Modern language features can help developers avoid these bugs; for example, the lack of optional types combined with the dynamism of Objective-C made it tough to catch certain classes of bugs that would have been caught by the compiler in Swift.
 
-### 1. Initialize the module config
+Another difficulty of writing React Native modules is context switching between the vastly different languages and paradigms for writing native modules on each platform.
+Due to the differences between these platforms, it cannot be completely avoided, but we feel the need to have just one common API and documentation to simplify the development as much as possible and make it easier for a single developer to maintain a library on multiple platforms.
 
-Create the [module config](module-config) **expo-module.config.json** file just near your **package.json** and start from the empty object `{}` in there. We will fill it in later to enable specific features. <br/>
+This is one of the reasons why the Expo Modules ecosystem was designed from the ground up to be used with modern native languages: Swift and Kotlin.
 
-### 2. Add the `expo-modules-core` native dependency
+### Passing data between runtimes
 
-Add `expo-modules-core` as a dependency in your podspec and **build.gradle** files.<br/>
+Another big pain point that we have encountered is the validation of arguments passed from JavaScript to native functions.
+This is especially error prone, time consuming, and difficult to maintain when it comes to `NSDictionary` or `ReadableMap`, where the type of values is unknown in runtime and each property needs to be validated separately by the developer.
+A valuable feature of the Expo native modules API is that it has full knowledge of the argument types the native function expects, so it can pre-validate and convert the arguments for you! The dictionaries can be represented as native structs that we call [Records](./module-api.md#records).
+Knowing the argument types, it is also possible to [automatically convert arguments](./module-api.md#convertibles) to some platform-specific types (e.g. `{ x: number, y: number }` or `[number, number]` can be translated to CoreGraphics's `CGPoint` for your convenience).
 
-<CodeBlocksTable tabs={["*.podspec", "build.gradle"]}>
+### React Native New Architecture
 
-```ruby
-# ...
-Pod::Spec.new do |s|
-  # ...
-  s.dependency 'ExpoModulesCore'
-end
-```
+React Native version 0.68 introduced the [New Architecture](https://reactnative.dev/docs/the-new-architecture/landing-page), which offers developers new capabilities for building mobile apps.
+It consists of the new native modules system called [Turbo Modules](https://reactnative.dev/docs/the-new-architecture/pillars-turbomodules) and the new rendering system called [Fabric](https://reactnative.dev/architecture/fabric-renderer).
+Native libraries need to be adapted to take advantage of these new systems. For Fabric, it needs even more work as it doesn't provide any compatibility layer, which means that view managers written in the old way don't work with Fabric and the other way around — Fabric native components don't work with the old renderer.
+It basically implies that existing libraries have to provide the support for both architectures for a while, increasing the technical debt.
 
-```groovy
-// ...
-dependencies {
-  // ...
-  implementation project(':expo-modules-core')
-}
-```
+The new architecture is mostly written in C++ so you may end up needing to write some C++ code to your library as well.
+As we all, React Native developers, use high-level JavaScript on the daily basis, we are rather reluctant to write C++, which is on the opposite side of the spectrum.
+Moreover, including C++ code in the library has a negative impact on build times, especially on Android, and can be more difficult to debug.
 
-</CodeBlocksTable>
-
-### 3. Add Expo packages to dependencies
-
-Add `expo` package as a peer dependency in your **package.json** — we recommend using `*` as a version range so as not to cause any duplicated packages in user's **node_modules** folder. Your library also needs to depend on `expo-modules-core` but only as a dev dependency — it's already provided in the projects depending on your library by the `expo` package with the version of core that is compatible with the specific SDK used in the project.<br/>
-
-<CodeBlocksTable tabs={["package.json"]}>
-
-```json
-{
-  // ...
-  "devDependencies": {
-    "expo-modules-core": "^X.Y.Z"
-  },
-  "peerDependencies": {
-    "expo": "*"
-  }
-}
-```
-
-</CodeBlocksTable>
-
-You can now use Expo Modules APIs in your library. You may be interested in referring to the [Android Lifecycle Listeners](./android-lifecycle-listeners.mdx) and [iOS AppDelegate Subscribers](./appdelegate-subscribers.mdx) guides next.
+We took these into account when designing the Expo Modules API with the goal in mind to make it renderer-agnostic, so that the module doesn't need to know whether the app is run on the new architecture or not, significantly reducing the cost for library developers.


### PR DESCRIPTION
# Why

Closes ENG-6349

# How

- Separated *Get Started* from *Overview* and *Module API*
- Moved design considerations to *Overview*
- Added a section about the new architecture
