### PR TITLE
[dev-menu] Integrate hermes inspector like expo go

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - Fix compilation error when the `compileSdkVersion` is set to 33. ([#19271](https://github.com/expo/expo/pull/19271) by [@lukmccall](https://github.com/lukmccall))
+- Fixed the *Local dev tools* menu doesn't work for Hermes. ([#19301](https://github.com/expo/expo/pull/19301) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuAppInfo.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuAppInfo.kt
@@ -37,10 +37,11 @@ object DevMenuAppInfo {
       hostUrl = DevMenuManager.currentManifestURL
     }
 
-    val engine = if (instanceManager.jsExecutorName.contains("Hermes")) {
-      "Hermes"
-    } else {
-      "JSC"
+    val jsExecutorName = instanceManager.jsExecutorName
+    val engine = when {
+      jsExecutorName.contains("Hermes") -> "Hermes"
+      jsExecutorName.contains("V8") -> "V8"
+      else -> "JSC"
     }
 
     return Bundle().apply {

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuDevSettings.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuDevSettings.kt
@@ -27,7 +27,7 @@ object DevMenuDevSettings {
           "isJSInspectorAvailable",
           run {
             val jsExecutorName = reactInstanceManager.jsExecutorName
-            jsExecutorName.contains("Hermes")
+            jsExecutorName.contains("Hermes") || jsExecutorName.contains("V8")
           }
         )
       }

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuDevSettings.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuDevSettings.kt
@@ -26,13 +26,8 @@ object DevMenuDevSettings {
         putBoolean(
           "isJSInspectorAvailable",
           run {
-            val packageName = reactInstanceManager.currentReactContext?.packageName
-              ?: return@run false
-            val metroHost = "http://${devSettings.packagerConnectionSettings.debugServerHost}"
-            runBlocking {
-              DevMenuManager.metroClient
-                .queryJSInspectorAvailability(metroHost, packageName)
-            }
+            val jsExecutorName = reactInstanceManager.jsExecutorName
+            jsExecutorName.contains("Hermes")
           }
         )
       }

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/api/DevMenuMetroClient.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/api/DevMenuMetroClient.kt
@@ -4,26 +4,10 @@ import android.net.Uri
 import expo.modules.devmenu.helpers.await
 import okhttp3.OkHttpClient
 import okhttp3.Request
-import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
 
 class DevMenuMetroClient {
   private val httpClient = OkHttpClient()
-
-  suspend fun queryJSInspectorAvailability(metroHost: String, applicationId: String): Boolean {
-    val url = Uri.parse("$metroHost/inspector")
-      .buildUpon()
-      .appendQueryParameter("applicationId", applicationId)
-      .build()
-    val request = Request.Builder()
-      .get()
-      .url(url.toString())
-      .build()
-    return try {
-      request.await(httpClient).isSuccessful
-    } catch (e: Exception) {
-      false
-    }
-  }
 
   suspend fun openJSInspector(metroHost: String, applicationId: String) {
     val url = Uri.parse("$metroHost/inspector")
@@ -31,7 +15,7 @@ class DevMenuMetroClient {
       .appendQueryParameter("applicationId", applicationId)
       .build()
     val request = Request.Builder()
-      .put(RequestBody.create(null, ""))
+      .put("".toRequestBody(null))
       .url(url.toString())
       .build()
     request.await(httpClient)

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/devtools/DevMenuDevToolsDelegate.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/devtools/DevMenuDevToolsDelegate.kt
@@ -67,7 +67,7 @@ class DevMenuDevToolsDelegate(
     }
   }
 
-  fun openJsInspector() = runWithDevSupportEnabled {
+  fun openJSInspector() = runWithDevSupportEnabled {
     val devSettings = (devSettings as? DevInternalSettings) ?: return
     val reactContext = reactContext ?: return
     val metroHost = "http://${devSettings.packagerConnectionSettings.debugServerHost}"

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/extensions/DevMenuExtension.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/extensions/DevMenuExtension.kt
@@ -81,8 +81,8 @@ class DevMenuExtension(reactContext: ReactApplicationContext) :
     }
 
     if (devSettings is DevInternalSettings) {
-      action("js-inspector", devDelegate::openJsInspector) {
-        label = { "Open JavaScript Inspector" }
+      action("js-inspector", devDelegate::openJSInspector) {
+        label = { "Open JavaScript debugger" }
         glyphName = { "language-javascript" }
         importance = DevMenuItemImportance.LOW.value
       }

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/websockets/DevMenuCommandHandlersProvider.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/websockets/DevMenuCommandHandlersProvider.kt
@@ -53,7 +53,7 @@ class DevMenuCommandHandlersProvider(
             val activity = instanceManager.currentReactContext?.currentActivity ?: return
             devDelegate.togglePerformanceMonitor(activity)
           }
-          "openJsInspector" -> devDelegate.openJsInspector()
+          "openJSInspector" -> devDelegate.openJSInspector()
           else -> Log.w("DevMenu", "Unknown command: $command")
         }
       }

--- a/packages/expo-dev-menu/app/components/Main.tsx
+++ b/packages/expo-dev-menu/app/components/Main.tsx
@@ -233,29 +233,27 @@ export function Main({ registeredCallbacks = [] }: MainProps) {
           />
         </View>
         <Divider />
-        {Platform.OS === 'android' && (
-          <>
-            <View bg="default">
-              <SettingsRowButton
-                disabled={!devSettings.isJSInspectorAvailable}
-                label="Open JavaScript Inspector"
-                icon={<SettingsFilledIcon />}
-                onPress={actions.openJSInspector}
-              />
-            </View>
-            <Divider />
-          </>
+        {devSettings.isJSInspectorAvailable ? (
+          <View bg="default">
+            <SettingsRowButton
+              disabled={!devSettings.isJSInspectorAvailable}
+              label="Open JS debugger"
+              icon={<DebugIcon />}
+              onPress={actions.openJSInspector}
+            />
+          </View>
+        ) : (
+          <View bg="default">
+            <SettingsRowSwitch
+              disabled={!devSettings.isRemoteDebuggingAvailable}
+              testID="remote-js-debugger"
+              label="Remote JS debugger"
+              icon={<DebugIcon />}
+              isEnabled={devSettings.isDebuggingRemotely}
+              setIsEnabled={actions.toggleDebugRemoteJS}
+            />
+          </View>
         )}
-        <View bg="default">
-          <SettingsRowSwitch
-            disabled={!devSettings.isRemoteDebuggingAvailable}
-            testID="local-dev-tools"
-            label="Local dev tools"
-            icon={<DebugIcon />}
-            isEnabled={devSettings.isDebuggingRemotely}
-            setIsEnabled={actions.toggleDebugRemoteJS}
-          />
-        </View>
         <Divider />
         <View bg="default" roundedBottom="large">
           <SettingsRowSwitch

--- a/packages/expo-dev-menu/app/components/__tests__/Main.test.tsx
+++ b/packages/expo-dev-menu/app/components/__tests__/Main.test.tsx
@@ -78,7 +78,7 @@ describe('<Main />', () => {
     expect(toggleElementInspectorAsync).toHaveBeenCalledTimes(1);
 
     expect(toggleDebugRemoteJSAsync).toHaveBeenCalledTimes(0);
-    await act(async () => fireEvent.press(getByTestId('local-dev-tools')));
+    await act(async () => fireEvent.press(getByTestId('remote-js-debugger')));
     expect(toggleDebugRemoteJSAsync).toHaveBeenCalledTimes(1);
 
     expect(toggleFastRefreshAsync).toHaveBeenCalledTimes(0);

--- a/packages/expo-dev-menu/app/native-modules/DevMenu.ts
+++ b/packages/expo-dev-menu/app/native-modules/DevMenu.ts
@@ -74,9 +74,6 @@ export async function toggleFastRefreshAsync() {
 }
 
 export async function openJSInspector() {
-  if (Platform.OS !== 'android') {
-    return;
-  }
   return await dispatchCallableAsync('js-inspector');
 }
 

--- a/packages/expo-dev-menu/app/native-modules/DevMenu.ts
+++ b/packages/expo-dev-menu/app/native-modules/DevMenu.ts
@@ -1,6 +1,6 @@
-import { DeviceEventEmitter, NativeModules, EventSubscription, Platform } from 'react-native';
+import { DeviceEventEmitter, NativeModules, EventSubscription } from 'react-native';
 
-export type JSEngine = 'Hermes' | 'JSC';
+export type JSEngine = 'Hermes' | 'JSC' | 'V8';
 
 export type AppInfo = {
   appIcon?: string;

--- a/packages/expo-dev-menu/ios/DevMenuDevOptionsDelegate.swift
+++ b/packages/expo-dev-menu/ios/DevMenuDevOptionsDelegate.swift
@@ -31,6 +31,22 @@ class DevMenuDevOptionsDelegate {
     devSettings?.toggleElementInspector()
   }
 
+  internal func openJSInspector() {
+    guard let bundleURL = bridge?.bundleURL else {
+      return
+    }
+    let port = bundleURL.port ?? Int(RCT_METRO_PORT)
+    let host = bundleURL.host ?? "localhost"
+    let openURL = "http://\(host):\(port)/inspector?applicationId=\(Bundle.main.bundleIdentifier ?? "")"
+    guard let url = URL(string: openURL) else {
+      NSLog("[DevMenu] Invalid openJSInspector URL: $@", openURL)
+      return
+    }
+    let request = NSMutableURLRequest(url: url)
+    request.httpMethod = "PUT"
+    URLSession.shared.dataTask(with: request as URLRequest).resume()
+  }
+
   internal func toggleRemoteDebugging() {
     guard let devSettings = devSettings else {
       return

--- a/packages/expo-dev-menu/ios/EXDevMenuAppInfo.m
+++ b/packages/expo-dev-menu/ios/EXDevMenuAppInfo.m
@@ -26,9 +26,14 @@
     appVersion = [manager.currentManifest version];
   }
   
-  NSString *engine = @"JSC";
-  if ([[[[manager currentBridge] batchedBridge] bridgeDescription] containsString:@"Hermes"]) {
+  NSString *engine;
+  NSString *bridgeDescription = [[[manager currentBridge] batchedBridge] bridgeDescription];
+  if ([bridgeDescription containsString:@"Hermes"]) {
     engine = @"Hermes";
+  } else if ([bridgeDescription containsString:@"V8"]) {
+    engine = @"V8";
+  } else {
+    engine = @"JSC";
   }
   
   NSString *hostUrl = [manager.currentManifestURL absoluteString] ?: @"";

--- a/packages/expo-dev-menu/ios/EXDevMenuDevSettings.swift
+++ b/packages/expo-dev-menu/ios/EXDevMenuDevSettings.swift
@@ -17,6 +17,7 @@ class EXDevMenuDevSettings: NSObject {
     devSettings["isElementInspectorAvailable"] = false;
     devSettings["isHotLoadingAvailable"] = false;
     devSettings["isPerfMonitorAvailable"] = false;
+    devSettings["isJSInspectorAvailable"] = false
     
     let manager = DevMenuManager.shared
     
@@ -34,6 +35,7 @@ class EXDevMenuDevSettings: NSObject {
       devSettings["isRemoteDebuggingAvailable"] = bridgeSettings.isRemoteDebuggingAvailable
       devSettings["isHotLoadingAvailable"] = bridgeSettings.isHotLoadingAvailable
       devSettings["isPerfMonitorAvailable"] = isPerfMonitorAvailable
+      devSettings["isJSInspectorAvailable"] = bridge.batched.isInspectable
        
       let isElementInspectorAvailable = manager.currentManifest?.isDevelopmentMode()
       devSettings["isElementInspectorAvailable"] = isElementInspectorAvailable

--- a/packages/expo-dev-menu/ios/Modules/DevMenuExtensions.swift
+++ b/packages/expo-dev-menu/ios/Modules/DevMenuExtensions.swift
@@ -33,7 +33,7 @@ open class DevMenuExtensions: NSObject, DevMenuExtensionProtocol {
     inspector.isEnabled = { devSettings.isElementInspectorShown }
 
     #if DEBUG
-    let jsInspector = DevMenuExtensions.jsInspctorAction(devDelegate.openJSInspector)
+    let jsInspector = DevMenuExtensions.jsInspectorAction(devDelegate.openJSInspector)
     jsInspector.isAvailable = { bridge.batched.isInspectable }
     jsInspector.isEnabled = { true }
 
@@ -91,12 +91,12 @@ open class DevMenuExtensions: NSObject, DevMenuExtensionProtocol {
     return inspector
   }
 
-  private static func jsInspctorAction(_ action: @escaping () -> Void) -> DevMenuAction {
-    let jsInspctror = DevMenuAction(withId: "js-inspector", action: action)
-    jsInspctror.label = { "Open JS debugger" }
-    jsInspctror.glyphName = { "language-javascript" }
-    jsInspctror.importance = DevMenuScreenItem.ImportanceLow
-    return jsInspctror
+  private static func jsInspectorAction(_ action: @escaping () -> Void) -> DevMenuAction {
+    let jsInspectror = DevMenuAction(withId: "js-inspector", action: action)
+    jsInspectror.label = { "Open JS debugger" }
+    jsInspectror.glyphName = { "language-javascript" }
+    jsInspectror.importance = DevMenuScreenItem.ImportanceLow
+    return jsInspectror
   }
 
   private static func remoteDebugAction(_ action: @escaping () -> Void) -> DevMenuAction {

--- a/packages/expo-dev-menu/ios/Modules/DevMenuExtensions.swift
+++ b/packages/expo-dev-menu/ios/Modules/DevMenuExtensions.swift
@@ -33,6 +33,10 @@ open class DevMenuExtensions: NSObject, DevMenuExtensionProtocol {
     inspector.isEnabled = { devSettings.isElementInspectorShown }
 
     #if DEBUG
+    let jsInspector = DevMenuExtensions.jsInspctorAction(devDelegate.openJSInspector)
+    jsInspector.isAvailable = { bridge.batched.isInspectable }
+    jsInspector.isEnabled = { true }
+
     let remoteDebug = DevMenuExtensions.remoteDebugAction(devDelegate.toggleRemoteDebugging)
     remoteDebug.isAvailable = { devSettings.isRemoteDebuggingAvailable }
     remoteDebug.isEnabled = { devSettings.isDebuggingRemotely }
@@ -48,6 +52,7 @@ open class DevMenuExtensions: NSObject, DevMenuExtensionProtocol {
     container.addItem(reload)
     container.addItem(perfMonitor)
     container.addItem(inspector)
+    container.addItem(jsInspector)
     container.addItem(remoteDebug)
     container.addItem(fastRefresh)
 
@@ -84,6 +89,14 @@ open class DevMenuExtensions: NSObject, DevMenuExtensionProtocol {
     inspector.importance = DevMenuScreenItem.ImportanceHigh
     inspector.registerKeyCommand(input: "i", modifiers: .command)
     return inspector
+  }
+
+  private static func jsInspctorAction(_ action: @escaping () -> Void) -> DevMenuAction {
+    let jsInspctror = DevMenuAction(withId: "js-inspector", action: action)
+    jsInspctror.label = { "Open JS debugger" }
+    jsInspctror.glyphName = { "language-javascript" }
+    jsInspctror.importance = DevMenuScreenItem.ImportanceLow
+    return jsInspctror
   }
 
   private static func remoteDebugAction(_ action: @escaping () -> Void) -> DevMenuAction {


### PR DESCRIPTION
# Why

align the hermes inspector implementation as expo go #19175.
close ENG-6295 

# How

- from the dev-menu, if the js engine is inspectable (hermes /v8), show *Open JS debugger*. otherwise, show the *Remote JS debugger*
- change the menu label from *Local dev tools* to *Remote JS debugger* that would make more clear what it is.
- [android] change the isJSInsectorAvailable detection from sending http request to dev-server to check engine type. that aligns with expo go implementation and shows the dev menu faster (without waiting for dev-server http response).
- [ios] integrate dev-server's endpoint to open the js inspector. note that i still use the classic dev-menu-item extensions to register the command. that would align with android implementations.
- align `JsInspector -> JSInspector`
- also, support js inspector for v8

# Test Plan

- ✅ ios bare-expo hermes + Open JS debugger
- ✅ ios bare-expo jsc + Remote JS debugger
- ✅ android bare-expo hermes (have to downgrade react-native because the vendored reanimated lead to a crash) + Open JS debugger
- ✅ android bare-expo jsc + Remote JS debugger

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
