### PR TITLE
[bare-expo] fix Podfile

### DIFF
--- a/apps/bare-expo/ios/Podfile
+++ b/apps/bare-expo/ios/Podfile
@@ -34,18 +34,6 @@ abstract_target 'BareExpoMain' do
 
   config = use_native_modules!
 
-  use_react_native!(
-    :path => config[:reactNativePath],
-    :hermes_enabled => podfile_properties['expo.jsEngine'] == 'hermes',
-    :fabric_enabled => flags[:fabric_enabled],
-    # An absolute path to your application root.
-    :app_path => "#{Pod::Config.instance.installation_root}/.."
-    #
-    # Uncomment to opt-in to using Flipper
-    # Note that if you have use_frameworks! enabled, Flipper will not work
-    # :flipper_configuration => !ENV['CI'] ? FlipperConfiguration.enabled : FlipperConfiguration.disabled,
-  )
-
   # Fix Google Sign-in and Flipper
   post_install do |installer|
     # `installer.pods_project` might be nil for `incremental_installation: true` and no new project generated
@@ -85,7 +73,7 @@ abstract_target 'BareExpoMain' do
   target 'BareExpo' do
     use_react_native!(
       :path => config[:reactNativePath],
-      :hermes_enabled => flags[:hermes_enabled] || podfile_properties['expo.jsEngine'] == 'hermes',
+      :hermes_enabled => podfile_properties['expo.jsEngine'] == 'hermes',
       :fabric_enabled => flags[:fabric_enabled],
       # An absolute path to your application root.
       :app_path => "#{Pod::Config.instance.installation_root}/..",
@@ -99,7 +87,7 @@ abstract_target 'BareExpoMain' do
   target 'BareExpoDetox' do
     use_react_native!(
       :path => config[:reactNativePath],
-      :hermes_enabled => flags[:hermes_enabled] || podfile_properties['expo.jsEngine'] == 'hermes',
+      :hermes_enabled => podfile_properties['expo.jsEngine'] == 'hermes',
       :fabric_enabled => flags[:fabric_enabled],
       # An absolute path to your application root.
       :app_path => "#{Pod::Config.instance.installation_root}/..",


### PR DESCRIPTION
# Why

my mistake from #19261 that leaving `use_react_native!` in the shared section. the reason to have dedicated `use_react_native!` is that we have different flipper configurations between BareExpo and BareExpoDetox targets. 

# How

- remove unused `use_react_native!` section
- update hermes_enable to use the one from _Podfile.properties.json_, so we will have jsc by default.

# Test Plan

ci passed

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
