### PR TITLE
[core][ios] Give precedence to `UIBackgroundFetchResult.newData` over `.failed` in ExpoAppDelegate

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -43,6 +43,7 @@
 - Removed the hard dependency to Hermes or JSC in _libexpo-modules-core.so_ on Android and fixed the broken support for react-native-v8. ([#18899](https://github.com/expo/expo/pull/18899) by [@kudo](https://github.com/kudo))
 - Update gradle excludes to fix detox tests. ([#19254](https://github.com/expo/expo/pull/19254) by [@esamelson](https://github.com/esamelson))
 - Fixed event listeners do not work when running with remote debugging mode on iOS. ([#19211](https://github.com/expo/expo/pull/19211) by [@kudo](https://github.com/kudo))
+- Give precedence to `UIBackgroundFetchResult.newData` over `.failed` in proxied `ExpoAppDelegate.swift` completion handlers. ([#19311](https://github.com/expo/expo/pull/19311) by [@ferologics](https://github.com/ferologics))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegate.swift
+++ b/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegate.swift
@@ -115,21 +115,28 @@ open class ExpoAppDelegate: UIResponder, UIApplicationDelegate {
     let selector = #selector(application(_:didReceiveRemoteNotification:fetchCompletionHandler:))
     let subs = subscribers.filter { $0.responds(to: selector) }
     var subscribersLeft = subs.count
-    var fetchResult: UIBackgroundFetchResult = .noData
     let dispatchQueue = DispatchQueue(label: "expo.application.remoteNotification", qos: .userInteractive)
+    var failedCount = 0
+    var newDataCount = 0
 
     let handler = { (result: UIBackgroundFetchResult) in
       dispatchQueue.sync {
         if result == .failed {
-          fetchResult = .failed
-        } else if fetchResult != .failed && result == .newData {
-          fetchResult = .newData
+          failedCount += 1
+        } else if result == .newData {
+          newDataCount += 1
         }
 
         subscribersLeft -= 1
 
         if subscribersLeft == 0 {
-          completionHandler(fetchResult)
+          if newDataCount > 0 {
+            completionHandler(.newData)
+          } else if failedCount > 0 {
+            completionHandler(.failed)
+          } else {
+            completionHandler(.noData)
+          }
         }
       }
     }
@@ -216,21 +223,28 @@ open class ExpoAppDelegate: UIResponder, UIApplicationDelegate {
     let selector = #selector(application(_:performFetchWithCompletionHandler:))
     let subs = subscribers.filter { $0.responds(to: selector) }
     var subscribersLeft = subs.count
-    var fetchResult: UIBackgroundFetchResult = .noData
     let dispatchQueue = DispatchQueue(label: "expo.application.performFetch", qos: .userInteractive)
+    var failedCount = 0
+    var newDataCount = 0
 
     let handler = { (result: UIBackgroundFetchResult) in
       dispatchQueue.sync {
         if result == .failed {
-          fetchResult = .failed
-        } else if fetchResult != .failed && result == .newData {
-          fetchResult = .newData
+          failedCount += 1
+        } else if result == .newData {
+          newDataCount += 1
         }
 
         subscribersLeft -= 1
 
         if subscribersLeft == 0 {
-          completionHandler(fetchResult)
+          if newDataCount > 0 {
+             completionHandler(.newData)
+           } else if failedCount > 0 {
+             completionHandler(.failed)
+           } else {
+             completionHandler(.noData)
+           }
         }
       }
     }


### PR DESCRIPTION
### Why
due to the else if condition a `.failed` UIBackgroundFetchResult would always be used even though other callbacks would pass `.newData`.

### How
The change assumes that even though `.failed` fetch results are passed we want to be optimistic about the `.newData` rather than the `.failed` callback.

### Test Plan
idk bruv

fixes #19310 