### PR TITLE
[cli] catch error when launching redirect page without applicationId

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Drop support for experimental Webpack native symbolication. ([#18439](https://github.com/expo/expo/pull/18439) by [@EvanBacon](https://github.com/EvanBacon))
 - Implement getApplicationIdFromBundle fixing iOS app launch issue with SDK 46. ([#18537](https://github.com/expo/expo/pull/18537) by [@Anthony Mittaz](https://github.com/Anthony Mittaz))
 - Change `UNAUTHORIZED_ERROR` to `UNAUTHORIZED` to handle unauthorized errors. ([#18751](https://github.com/expo/expo/pull/18751) by [@EvanBacon](https://github.com/EvanBacon))
+- Catch error thrown when trying to launch redirect page without an application ID defined in `app.json`.
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -24,7 +24,7 @@
 - Drop support for experimental Webpack native symbolication. ([#18439](https://github.com/expo/expo/pull/18439) by [@EvanBacon](https://github.com/EvanBacon))
 - Implement getApplicationIdFromBundle fixing iOS app launch issue with SDK 46. ([#18537](https://github.com/expo/expo/pull/18537) by [@Anthony Mittaz](https://github.com/Anthony Mittaz))
 - Change `UNAUTHORIZED_ERROR` to `UNAUTHORIZED` to handle unauthorized errors. ([#18751](https://github.com/expo/expo/pull/18751) by [@EvanBacon](https://github.com/EvanBacon))
-- Catch error thrown when trying to launch redirect page without an application ID defined in `app.json`.
+- Catch error thrown when trying to launch redirect page without an application ID defined in `app.json`. ([#19312](https://github.com/expo/expo/pull/19312) by [@esamelson](https://github.com/esamelson))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/platforms/PlatformManager.ts
+++ b/packages/@expo/cli/src/start/platforms/PlatformManager.ts
@@ -72,8 +72,12 @@ export class PlatformManager<
       try {
         applicationId = await this._getAppIdResolver().getAppIdAsync();
       } catch {
-        // do nothing, expected if the applicationId is not defined anywhere (e.g. managed project
-        // without ios.bundleIdentifier)
+        Log.warn(
+          chalk`\u203A Launching in Expo Go. If you want to use a ` +
+            `development build, you need to create and install one first, or, if you already ` +
+            chalk`have a build, add {bold ios.bundleIdentifier} and {bold android.package} to ` +
+            `this project's app config.\n${learnMore('https://docs.expo.dev/development/build/')}`
+        );
       }
       if (applicationId) {
         debug(`Resolving launch URL: (appId: ${applicationId}, redirect URL: ${redirectUrl})`);

--- a/packages/@expo/cli/src/start/platforms/PlatformManager.ts
+++ b/packages/@expo/cli/src/start/platforms/PlatformManager.ts
@@ -68,7 +68,13 @@ export class PlatformManager<
     const redirectUrl = this.props.getRedirectUrl();
     if (redirectUrl) {
       // If the redirect page feature is enabled, check if the project has a resolvable native identifier.
-      const applicationId = await this._getAppIdResolver().getAppIdAsync();
+      let applicationId;
+      try {
+        applicationId = await this._getAppIdResolver().getAppIdAsync();
+      } catch {
+        // do nothing, expected if the applicationId is not defined anywhere (e.g. managed project
+        // without ios.bundleIdentifier)
+      }
       if (applicationId) {
         debug(`Resolving launch URL: (appId: ${applicationId}, redirect URL: ${redirectUrl})`);
         // NOTE(EvanBacon): This adds considerable amount of time to the command, we should consider removing or memoizing it.


### PR DESCRIPTION
# Why

Follow up from https://github.com/expo/expo/pull/19260 . Unlike `resolveAppIdFromNativeAsync`, `getAppIdAsync` can throw an error when there is no applicationId available. It would be better to just fall back to opening in Expo Go in this case.

# How

Wrap `getAppIdAsync` in a try-catch; if it throws, ignore it and open in Expo Go.

# Test Plan

```
yarn create expo-app dc-redirect
cd dc-redirect
yarn expo install expo-dev-client
yarn expo start
# press i
```
Before this PR, an error is thrown
<img width="899" alt="Screen Shot 2022-09-29 at 4 04 44 PM" src="https://user-images.githubusercontent.com/19958240/193158301-7ebc2fd8-6f23-477e-8d63-5c2fdca95a74.png">

After, we just fall back to Expo Go with a warning
<img width="1257" alt="Screen Shot 2022-09-29 at 4 33 04 PM" src="https://user-images.githubusercontent.com/19958240/193160000-acf60c7e-7467-4be7-a29b-633fb843a87e.png">



# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
