### PR TITLE
[docs] Update Classic Updates to EAS Update migration doc

### DIFF
--- a/docs/pages/bare/updating-your-app.mdx
+++ b/docs/pages/bare/updating-your-app.mdx
@@ -2,13 +2,13 @@
 title: Updating your app
 ---
 
-EAS update works with projects created with `react-native init` and with Expo projects that are ejected. These projects have **android** and **ios** directories so that we can modify native files directly.
+EAS update works with bare React Native projects created with `react-native init`. These projects have **android** and **ios** directories that you can modify native files directly.
 
-The steps for configuring a bare React Native project are identical to the steps for configuring an Expo project. However, you may need to edit some of the code `eas update:configure` and `eas build:configure` generates depending on how you build and run your project.
+The steps for configuring a bare React Native project are identical to the steps for configuring an Expo project. However, you may need to edit some of the code `eas update:configure` generates depending on how you build and run your project.
 
 ## App config
 
-The `eas update:configure` will add two values to our project's app config (**app.json**/**app.config.js**).
+The `eas update:configure` will add two values to your project's app config.
 
 ```json
 {
@@ -23,9 +23,9 @@ The `eas update:configure` will add two values to our project's app config (**ap
 }
 ```
 
-The `runtimeVerson` property guarantees compatibility between a build's native code and an update. For bare React Native projects, it's necessary to set this value manually whenever you make a change to any native code in your project. Read [our doc on runtime versions](/eas-update/runtime-versions/#custom--runtimeversion) and learn how to [avoid publishing bad updates](/eas-update/runtime-versions/#avoiding-crashes-with-incompatible-updates).
+The `runtimeVerson` property guarantees compatibility between a build's native code and an update. It's necessary to set this value manually whenever you make a change to any native code in your project. Read [our doc on runtime versions](/eas-update/runtime-versions/#custom--runtimeversion) and learn how to [avoid publishing bad updates](/eas-update/runtime-versions/#avoiding-crashes-with-incompatible-updates).
 
-The `updates.url` property will eventually tell your app to query against for updates. This `url` is our "https://u.expo.dev" domain, followed by your project's ID on EAS' servers. If you go to the URL directly, you'll see an error about missing a header. You can see a manifest by adding three query parameters to the URL: `runtime-version`, `channel-name`, and `platform`. If we published an update with a runtime version of `1.0.0`, a channel of `production`, and a platform of `android`, the full URL you could visit would be similar to this:
+The `updates.url` property is the "https://u.expo.dev" domain followed by your project's ID on EAS' servers. If you go to the URL directly, you'll see an error about missing a header. You can see a manifest by adding three query parameters to the URL: `runtime-version`, `channel-name`, and `platform`. If we published an update with a runtime version of `1.0.0`, a channel of `production`, and a platform of `android`, the full URL you could visit would be similar to this:
 
 ```
 https://u.expo.dev/your-project-id?runtime-version=1.0.0&channel-name=production&platform=android
@@ -33,9 +33,9 @@ https://u.expo.dev/your-project-id?runtime-version=1.0.0&channel-name=production
 
 ## EAS config and native files
 
-To generate an EAS config (**eas.json**), run `eas build:configure`. This command will create the **eas.json** file and it will also modify the **AndroidManifest.xml** file inside the **android** directory and the **Expo.plist** file inside the **ios** directory.
+To generate the **eas.json** file, run `eas build:configure`. This command will create the **eas.json** file and it will also modify the **AndroidManifest.xml** file inside the **android** directory and the **Expo.plist** file inside the **ios** directory.
 
-Inside **eas.json**, we'll want to add `channel` properties to each build profile we'd like to send updates to. Assuming we're using the default **eas.json** configuration, we recommend adding `channel` properties to the `preview` and `production` build profiles.
+Inside **eas.json**, you'll want to add `channel` properties to each build profile you'd like to send updates to. Assuming you're using the default **eas.json** configuration, we recommend adding `channel` properties to the `preview` and `production` build profiles.
 
 ```json
 {
@@ -61,7 +61,7 @@ Inside **eas.json**, we'll want to add `channel` properties to each build profil
 }
 ```
 
-Inside **AndroidManifest.xml**, we'll see the following additions:
+Inside **AndroidManifest.xml**, you'll see the following additions:
 
 ```xml
 <meta-data android:name="expo.modules.updates.EXPO_UPDATE_URL" android:value="https://u.expo.dev/your-project-id"/>
@@ -70,7 +70,7 @@ Inside **AndroidManifest.xml**, we'll see the following additions:
 
 The `EXPO_UPDATE_URL` value should contain your project's ID.
 
-Inside **Expo.plist**, we'll see the following additions:
+Inside **Expo.plist**, you'll see the following additions:
 
 ```xml
 <key>EXUpdatesRuntimeVersion</key>
@@ -81,11 +81,11 @@ Inside **Expo.plist**, we'll see the following additions:
 
 The `EXUpdatesURL` value should contain your project's ID.
 
-Once we've built our project into a build, the `expo-updates` library will make requests for manifests with the native configuration defined above, along with the channel specified in **eas.json**.
+Once you've built your project into a build, the `expo-updates` library will make requests for manifests with the native configuration defined above, along with the channel specified in **eas.json**.
 
 ## Configuring the channel manually
 
-If we create a build with EAS Build, the channel name from **eas.json** will automatically be added to our build's **AndroidManifest.xml** and **Expo.plist** at build time. If you're using EAS Build, the following steps are not necessary.
+If you create a build with EAS Build, the channel name from **eas.json** will automatically be added to our build's **AndroidManifest.xml** and **Expo.plist** at build time. If you're using EAS Build, the following steps are not necessary.
 
 If your project is not using EAS Build or you are creating release builds with either `expo run:ios --configuration Release` or `expo run:android --variant release`, you'll need to set the channel configuration manually inside both **AndroidManifest.xml** and **Expo.plist**.
 
@@ -107,8 +107,8 @@ In **Expo.plist**, you'll need to add the following, replacing `your-channel-nam
 
 ## What's next
 
-Once our project is set up with EAS Update, eventually we'll make native changes to your project. Whenever that happens, we'll need to update the `runtimeVersion` in our project's app config. Then, we'll need to run `eas build:configure`, which will update **AndroidManifest.xml** and **Expo.plist** with the new runtime version. Once that's done, we'll need to make new builds, after which, we'll be able to send updates with `eas update`.
+Once your project is set up with EAS Update, eventually you'll make native changes to your project. Whenever that happens, you'll need to update the `runtimeVersion` in your project's app config. Once that's done, you'll need to make new builds, after which, you'll be able to send updates with `eas update`.
 
 ## Set your own updates service
 
-EAS Update is a great updates service for most projects, however, some projects have unique requirements that make a self-hosted updates service a better solution. Since the expo-updates library is open source and follows the Expo Updates protocol, you can set up a custom server to serve updates to your end-users. [Learn more](/distribution/custom-updates-server).
+Some projects have unique requirements that require a self-hosted updates service. Since the expo-updates library is open source and follows the [Expo Updates protocol](/technical-specs/expo-updates-0.mdx), you can set up a custom server to serve updates to your users. [Learn more](/distribution/custom-updates-server.mdx).

--- a/docs/pages/eas-update/migrate-to-eas-update.mdx
+++ b/docs/pages/eas-update/migrate-to-eas-update.mdx
@@ -16,11 +16,11 @@ EAS Update requires the following versions or greater:
 - Expo SDK >= 45.0.0
 - expo-updates >= 0.13.0
 
-## Install Expo CLI and EAS CLI
+## Install EAS CLI
 
-1. Install EAS and Expo CLIs with:
+1. Install EAS CLI:
 
-   <Terminal cmd={['$ npm install --global eas-cli expo-cli']} />
+   <Terminal cmd={['$ npm install --global eas-cli']} />
 
 2. Then, log in with your expo account:
 
@@ -30,23 +30,15 @@ EAS Update requires the following versions or greater:
 
 You'll need to make the following changes to your project:
 
-1. Install the latest `expo-updates` library with:
-
-   <Terminal cmd={['$ yarn add expo-updates']} />
-
-2. Initialize your project with EAS Update:
+1. Initialize your project with EAS Update:
 
    <Terminal cmd={['$ eas update:configure']} />
 
-   After this command, you should have two a new fields in your app config (**app.json**/**app.config.js**) at `expo.updates.url` and `expo.runtimeVersion`.
+   After this command, you should have two a new fields in your app config at `expo.updates.url` and `expo.runtimeVersion`.
 
-3. To ensure that updates are compatible with the underlying native code inside a build, EAS Update uses a new field named `runtimeVersion` that replaces the `sdkVersion` field in your project's app config (**app.json**/**app.config.js**). Remove the `expo.sdkVersion` property from your app config.
+2. To ensure that updates are compatible with the underlying native code inside a build, EAS Update uses a new field named `runtimeVersion` that replaces the `sdkVersion` field in your project's app config. Remove the `expo.sdkVersion` property from your app config.
 
-4. Next, set your project up with EAS Build by running:
-
-   <Terminal cmd={['$ eas build:configure']} />
-
-5. To allow updates to apply to builds built with EAS, update your EAS build profiles in **eas.json** to include `channel` properties. These channels should replace any `releaseChannel` properties. We find it convenient to name the `channel` after the profile's name. For instance, the `preview` profile has a `channel` named `"preview"` and the `production` profile has a `channel` named `"production"`.
+3. To allow updates to apply to builds built with EAS, update your EAS build profiles in **eas.json** to include `channel` properties. These channels should replace any `releaseChannel` properties. We find it convenient to name the `channel` after the profile's name. For instance, the `preview` profile has a `channel` named `"preview"` and the `production` profile has a `channel` named `"production"`.
 
    ```json
    {
@@ -66,25 +58,15 @@ You'll need to make the following changes to your project:
    }
    ```
 
-6. Optional: If your project is a bare React Native project, [read the doc](/bare/updating-your-app) on extra configuration you may need.
+4. Optional: If your project is a bare React Native project, [read the doc](/bare/updating-your-app) on extra configuration you may need.
 
 ## Create new builds
 
-The changes above affect the native code layer inside builds, which means we'll need to make new builds. Once your builds are complete, we'll be ready to develop an update and publish it.
-
-## Developing locally
-
-EAS Update uses a [modern manifest format](/technical-specs/expo-updates-0). When you have a EAS Update url in your app config at `updates.url`, Expo CLI will automatically serve the correct manifest format for your project. This will ensure that the code you develop locally will work as an update when published later. You can start a locally development session just like before, with:
-
-<Terminal cmd={[
-'$ yarn start',
-'# or',
-'$ npx expo start',
-]} />
+The changes above affect the native code layer inside builds, which means you'll need to make new builds. Once your builds are complete, you'll be ready to develop an update and publish it.
 
 ## Publishing an update
 
-To publish an update, run:
+After making a change to your poject locally, you're ready to publish an update, run:
 
 ```bash
 eas update --branch [branch-name] --message [message]
@@ -93,22 +75,14 @@ eas update --branch [branch-name] --message [message]
 eas update --branch production --message "Fixes typo"
 ```
 
-EAS Update adds a new type of object called a "branch". A branch is a list of updates, and it is linked to a channel. In the diagram below, builds with a channel of "production" are linked to a branch named "production". By default, channels and branches of the same name are linked until changed.
+EAS Update adds a new idea called a "branch". A branch is a list of updates, and it is mapped to a channel. In the diagram below, builds with a channel of "production" are linked to a branch named "production". By default, channels and branches of the same name are linked until changed. By default, this behaves like the Classic Updates service.
 
 <ImageSpotlight alt={`Channel "production" linked to branch "production"`} src="/static/images/eas-update/channel-branch.png" />
 
 ## Additional possible migration steps
 
-- If you have any scripts that run `expo publish`, you can replace those with `eas update`. You can view all the options for publishing with `eas update --help`
+- Replace instances of `expo publish` with `eas update`. You can view all the options for publishing with `eas update --help`.
 - If you have any code that references `Updates.releaseChannel` from the `expo-updates` library, replace them with `Updates.channel`.
-- Remove any code that references `Constants.manifest`. That will now always return `null`. If you're using SDK 46 or above, you can access most properties you'll need with `Constants.expoConfig`.
+- Remove any code that references `Constants.manifest`. That will now always return `null`. If you're using SDK 46 or above, you can access most properties you'll need with `Constants.expoConfig` from the `expo-constants` library.
 
-## Known issues
-
-EAS Update is currently in "preview", meaning that we may make major changes to developer-facing workflows. There are also a variety of [known issues](/eas-update/known-issues), which you should consider before using EAS Update with your project.
-
-## Next steps
-
-EAS Update is built to be faster and more powerful than ever before. We can't wait to hear what you think. Try setting up EAS Update to publish on pushing to GitHub with a [GitHub Action](/eas-update/github-actions). Also check out the new sets of [deployment patterns](/eas-update/deployment-patterns) enabled by EAS Update.
-
-If you run into issues or have feedback, join us on [Discord](https://chat.expo.dev/) in the #eas channel.
+If you run into issues or have feedback, join us on [Discord](https://chat.expo.dev/) in the #update channel.


### PR DESCRIPTION
# Why

Update the Classic Updates to EAS migration doc to reflect the current state of things.

This PR:
- Removes the instruction to install expo-updates, since that happens automatically now.
- Removes instructions about EAS Build.
- Removes mentions of EAS Update being in preview.
- Fixes some copy/verbiage issues

# Test Plan

Make sure that the migration doc still makes sense and is an accurate instruction set to upgrade an app from Classic Updates to EAS Update.