### PR TITLE
[docs] Add documentation for Either types

### DIFF
--- a/docs/pages/modules/module-api.mdx
+++ b/docs/pages/modules/module-api.mdx
@@ -444,6 +444,47 @@ class FileReadOptions : Record {
 
 </CodeBlocksTable>
 </APIBox>
+<APIBox header="Eithers">
+
+There are some use cases where you want to pass various types for a single function argument. This is where Either types might come in handy.
+They act as a container for a value of one of a couple of types.
+
+<CodeBlocksTable>
+
+```swift
+Function("foo") { (bar: Either<String, Int>) in
+  if let bar: String = bar.get() {
+    // `bar` is a String
+  }
+  if let bar: Int = bar.get() {
+    // `bar` is an Int
+  }
+}
+```
+
+```kotlin
+Function("foo") { bar: Either<String, Int> ->
+  bar.get(String::class).let {
+    // `it` is a String
+  }
+  bar.get(Int::class).let {
+    // `it` is an Int
+  }
+}
+```
+
+</CodeBlocksTable>
+
+The implementation for three Either types is currently provided out of the box, allowing you to use up to four different subtypes.
+
+- `Either<FirstType, SecondType>` — A container for one of two types.
+- `EitherOfThree<FirstType, SecondType, ThirdType>` — A container for one of three types.
+- `EitherOfFour<FirstType, SecondType, ThirdType, FourthType>` — A container for one of four types.
+
+> **info**
+> Either types are available as of SDK 47.
+
+</APIBox>
 
 ## Examples
 


### PR DESCRIPTION
# Why

Follow up #19035 and #19138 

# How

Added documentation for `Either` types

# Test Plan

![Screenshot 2022-09-30 at 12 25 45](https://user-images.githubusercontent.com/1714764/193252089-68ca5371-ab64-459a-911a-f14a915f14c4.png)

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
