### PR TITLE
[docs] small tweaks on the Configuring Statusbar page

### DIFF
--- a/docs/pages/guides/configuring-statusbar.mdx
+++ b/docs/pages/guides/configuring-statusbar.mdx
@@ -5,24 +5,26 @@ title: Configuring the Status Bar
 import { InlineCode } from '~/components/base/code';
 import ImageSpotlight from '~/components/plugins/ImageSpotlight'
 import { Collapsible } from '~/ui/components/Collapsible';
+import { APIBox } from '~/components/plugins/APIBox';
 
-The status bar configuration often feels like a small detail to a developer, but it can make a big difference on the overall feel and perceived level of polish of your app by users. When you have a white status bar on a white background, you just know something isn't going quite right.
+The status bar configuration often feels like a small detail to a developer, but it can make a big difference on the overall feel and perceived level of polish of your app by users.
+When you have a white status bar on a white background, you just know something isn't going quite right.
 
 This guide is intended to help you know what tools are at your disposal to configure the status bar for your iOS and Android apps.
 
 <ImageSpotlight src="/static/images/status-bar-style-comparison.png" alt="A comparison of good and bad status bar styling" />
 
-> 👀 Notice how bad the contrast is between the status bar text and the background in the second image. This is what we want to try to avoid.
+> Notice how bad the contrast is between the status bar text and the background in the second image. This is what we want to try to avoid.
 
-## Configuring the status bar while your app is loading (Android only)
+## Configuring the status bar while app is loading (Android only)
 
-> This type of configuration is currently only available on Android. On iOS, it is not possible in the Expo Go app to customize the status bar before the app has loaded, while the splash screen is presented.
+> **info** This type of configuration is currently only available on Android. On iOS, it is not possible in the Expo Go app to customize the status bar before the app has loaded, while the splash screen is presented.
 
-The configuration for configuring the status bar while the splash screen is visible on Android is available through the `androidStatusBar` object in **app.json**. The options available are similar to those provided by [expo-status-bar](../versions/latest/sdk/status-bar.mdx).
+The configuration for configuring the status bar while the splash screen is visible on Android is available through the `androidStatusBar` object in **app.json**. The options available are similar to those provided by [`expo-status-bar`](../versions/latest/sdk/status-bar.mdx).
 
 <Collapsible summary="See the full list of options available to configure the status bar statically on Android">
 
-### `androidStatusBar.barStyle`
+<APIBox header="androidStatusBar.barStyle" platforms={["android"]}>
 
 This option can be used to specify whether the status bar content (icons and text in the status bar) is light, or dark. Usually a status bar with a light background has dark content, and a status bar with a dark background has light content.
 
@@ -34,13 +36,17 @@ The valid values are:
 > Note: If you choose `light-content` and have either a very light image set as the `SplashScreen` or `backgroundColor` set to a light color, the status bar icons may blend in and not be visible.
 > Same goes for `dark-content` when you have a very dark image set as the `SplashScreen` or `backgroundColor` set to a dark color.
 
-### `androidStatusBar.backgroundColor`
+</APIBox>
+
+<APIBox header="androidStatusBar.backgroundColor" platforms={["android"]}>
 
 This option can be used to set a background color for the status bar.
 The valid value is a 6-character long hexadecimal solid color string with the format `#RRGGBB` (e.g. `#C2185B`) or 8-character long hexadecimal color string with transparency with the format `#RRGGBBAA` (e.g. `#23C1B255`).
 Defaults to `#00000000` (fully transparent color) for `dark-content` bar style and `#00000088` (semi-transparent black) for `light-content` bar style.
 
-### `androidStatusBar.translucent`
+</APIBox>
+
+<APIBox header="androidStatusBar.translucent" platforms={["android"]}>
 
 Value type - `boolean`.
 Specifies whether the status bar should be translucent.
@@ -51,7 +57,9 @@ Defaults to `true`.
 > Note: A translucent status bar makes sense when the `backgroundColor` is using a transparent color (`#RRGGBBAA`).
 > When you use a translucent status bar and a solid `backgroundColor` (`#RRGGBB`) then the upper part of your app will be partially covered by the non-transparent status bar and thus some of your app's content might not be visible to the user.
 
-### `androidStatusBar.hidden`
+</APIBox>
+
+<APIBox header="androidStatusBar.hidden" platforms={["android"]}>
 
 Value type - `boolean`.
 Tells the system whether the status bar should be visible or not.
@@ -59,11 +67,14 @@ When the status bar is not visible it can be presented via the `swipe down` gest
 When set to `true`, the status bar will not respect `backgroundColor` or `barStyle` settings.
 Defaults to `false`.
 
+</APIBox>
+
 </Collapsible>
 
-## Updating the status bar while your app is running
+## Updating the status bar while app is running
 
-The `StatusBar` component provided by [`expo-status-bar`](../versions/latest/sdk/status-bar.mdx) allows you to control the appearance of the status bar while your app is running. `expo-status-bar` also provides imperative methods such as `setStatusBarStyle(style)` to control the style through function calls rather than the `StatusBar` component, if you find that to be helpful for your use case.
+The `StatusBar` component provided by [`expo-status-bar`](../versions/latest/sdk/status-bar.mdx) allows you to control the appearance of the status bar while your app is running.
+`expo-status-bar` also provides imperative methods such as `setStatusBarStyle(style)` to control the style through function calls rather than the `StatusBar` component, if you find that to be helpful for your use case.
 
 To fix the contrast issue from the screenshot at the top of this guide, we could use the following code:
 
@@ -84,35 +95,39 @@ export default function Playlists() {
 
 <Collapsible summary={<span>How is <InlineCode>expo-status-bar</InlineCode> different from the StatusBar component included in React Native?</span>}>
 
-`expo-status-bar` builds on top of the `StatusBar` component that React Native provides in order to give you better defaults when you're building an app with Expo tools. For example, the `translucent` property of `expo-status-bar` defaults to `true` or, if you have changed that property in `androidStatusBar`, it will use that value instead. The default in React Native for `translucent` is always `false`, which can be confusing when in projects created using Expo tools, because the default is `true` for consistency with iOS.
+`expo-status-bar` builds on top of the `StatusBar` component that React Native provides in order to give you better defaults when you're building an app with Expo tools.
+  For example, the `translucent` property of `expo-status-bar` defaults to `true` or, if you have changed that property in `androidStatusBar`, it will use that value instead.
+  The default in React Native for `translucent` is always `false`, which can be confusing when in projects created using Expo tools, because the default is `true` for consistency with iOS.
 
 </Collapsible>
 
 ## Themes and status bar styles
 
-If you use `expo-status-bar` to control your status bar style, the `style="auto"` configuration will automatically pick the appropriate default style depending on the color scheme currently used by the app (this is the default behavior, if you leave out the style prop entirely then `auto` will be used). Please note that if you provide a way for users to toggle between color schemes rather than using the operating system theme, this will not have the intended behavior, and you should use `style="light"` and `style="dark"` as needed depending on the selected color scheme.
-
-> **info** Automatic theme detection is only supported in SDK 38 or higher. Prior to SDK 38, `auto` will not change depending on your color scheme, it will always assume that the theme is light.
+If you use `expo-status-bar` to control your status bar style, the `style="auto"` configuration will automatically pick the appropriate default style depending on the color scheme currently used by the app
+(this is the default behavior, if you leave out the style prop entirely then `auto` will be used). Please note that if you provide a way for users to toggle between color schemes rather than using the operating system theme,
+this will not have the intended behavior, and you should use `style="light"` and `style="dark"` as needed depending on the selected color scheme.
 
 ## Factoring the status bar in with your layout
 
 When you have a translucent status bar, it's important to remember that content can be rendered underneath it (if it couldn't, what would be the point of it being translucent? there would be nothing for you to see through it!).
 
-Libraries like [React Navigation](/guides/routing-and-navigation.mdx) will handle this for you when the UI that they provide overlap with the status bar. You are likely to encounter cases where you will need to manually adjust your layout to prevent some content (such as text) from being rendered underneath it. To do this, we recommend using [react-native-safe-area-context](../versions/latest/sdk/safe-area-context.mdx) to find the safe area insets and add padding or margins to your layout accordingly.
+Libraries like [React Navigation](/guides/routing-and-navigation.mdx) will handle this for you when the UI that they provide overlap with the status bar.
+You are likely to encounter cases where you will need to manually adjust your layout to prevent some content (such as text) from being rendered underneath it.
+To do this, we recommend using [`react-native-safe-area-context`](../versions/latest/sdk/safe-area-context.mdx) to find the safe area insets and add padding or margins to your layout accordingly.
 
 ## Working with misbehaving 3rd-party Libraries
 
-Projects initialized with Expo tools make the status bar `translucent` by default on Android. This is consistent with iOS and more in line with material design. Unfortunately, some libraries don't support `translucent` status bars. This is generally bad practice and those libraries should be fixed, but if you must use one of them, there are some options available for you to accommodate their limitations:
+Projects initialized with Expo tools make the status bar `translucent` by default on Android. This is consistent with iOS and more in line with material design.
+Unfortunately, some libraries don't support `translucent` status bars. This is generally bad practice and those libraries should be fixed,
+but if you must use one of them, there are some options available for you to accommodate their limitations:
 
-### Set the `backgroundColor` of the status bar to an opaque color and disable `translucent` option
+### Workaround #1
 
 Setting solely `backgroundColor` to an opaque color will disable the `transparency` of the status bar, but preserve `translucency`.
 You need to explicitly set `translucent` to `false` if you want your app's status bar to take up space on the device's screen.
-This is a good option if your status bar color never needs to change.
+This is a good option if your status bar color never needs to change, for example:
 
-Example:
-
-```json
+```json app.json
 {
   "expo": {
     "androidStatusBar": {
@@ -123,6 +138,7 @@ Example:
 }
 ```
 
-### Place an empty `View` on top of your screen
+### Workaround #2
 
-You can place an empty `View` on top of your screen with a background color to act as a status bar, or set a top padding. You can get the height of the status bar (and notch, if there is one) by using the top inset value provided by [react-native-safe-area-context](../versions/latest/sdk/safe-area-context.mdx).
+You can place an empty `View` on top of your screen with a background color to act as a status bar, or set a top padding.
+You can get the height of the status bar (and notch, if there is one) by using the top inset value provided by [`react-native-safe-area-context`](../versions/latest/sdk/safe-area-context.mdx).

--- a/docs/pages/guides/configuring-statusbar.mdx
+++ b/docs/pages/guides/configuring-statusbar.mdx
@@ -121,7 +121,7 @@ Projects initialized with Expo tools make the status bar `translucent` by defaul
 Unfortunately, some libraries don't support `translucent` status bars. This is generally bad practice and those libraries should be fixed,
 but if you must use one of them, there are some options available for you to accommodate their limitations:
 
-### Workaround #1
+### Opaque colored background
 
 Setting solely `backgroundColor` to an opaque color will disable the `transparency` of the status bar, but preserve `translucency`.
 You need to explicitly set `translucent` to `false` if you want your app's status bar to take up space on the device's screen.
@@ -138,7 +138,7 @@ This is a good option if your status bar color never needs to change, for exampl
 }
 ```
 
-### Workaround #2
+### Empty `View`
 
 You can place an empty `View` on top of your screen with a background color to act as a status bar, or set a top padding.
 You can get the height of the status bar (and notch, if there is one) by using the top inset value provided by [`react-native-safe-area-context`](../versions/latest/sdk/safe-area-context.mdx).


### PR DESCRIPTION
# Why

I have spotted when working on the Prettier PR, that we can use `APIBox`es for the property described on that page, rest changes came as addition.

# How

Use `APIBox` components for the properties list, this allow us to mark them as Android only in the same way we mark that fact in other parts of docs.

Additionally I have:
* removed the note related to times prior SDK 38, this information is no longer relevant, 
* tweak other callouts
* ensure that packages names are always in inline code blocks
* simplify/shorten few headers
* reformat files for the editor (get rid of long one liners)

# Test Plan

The changes have been tested by running docs website locally.

# Preview

<img width="893" alt="Screenshot 2022-09-30 124435" src="https://user-images.githubusercontent.com/719641/193254355-b862c927-52c5-4e82-8680-c57d1d3b8ee4.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
