### PR TITLE
[docs] CodeBlocksTable: unify appearance with other code blocks

### DIFF
--- a/docs/components/plugins/CodeBlocksTable.tsx
+++ b/docs/components/plugins/CodeBlocksTable.tsx
@@ -1,6 +1,10 @@
 import { css } from '@emotion/react';
-import { theme, typography } from '@expo/styleguide';
+import { breakpoints, spacing } from '@expo/styleguide';
 import { PropsWithChildren } from 'react';
+
+import { Snippet } from '~/ui/components/Snippet/Snippet';
+import { SnippetContent } from '~/ui/components/Snippet/SnippetContent';
+import { SnippetHeader } from '~/ui/components/Snippet/SnippetHeader';
 
 const MDX_CLASS_NAME_TO_TAB_NAME: Record<string, string> = {
   'language-swift': 'Swift',
@@ -12,78 +16,12 @@ const MDX_CLASS_NAME_TO_TAB_NAME: Record<string, string> = {
   'language-groovy': 'Gradle',
 };
 
-const CodeSamplesCSS = css`
-  display: flex;
-  flex-direction: row;
-  max-width: 100%;
-  margin: 20px 0;
-
-  .code-block-column {
-    display: flex;
-    flex-direction: column;
-    flex: 1;
-    margin-right: -1px;
-    min-width: 0;
-
-    pre {
-      border-top-left-radius: 0;
-      border-top-right-radius: 0;
-    }
-    &:not(:first-of-type) pre {
-      border-bottom-left-radius: 0;
-    }
-    &:not(:last-child) pre {
-      border-bottom-right-radius: 0;
-    }
-    &:first-of-type .code-block-header {
-      border-top-left-radius: 4px;
-    }
-    &:last-child .code-block-header {
-      border-top-right-radius: 4px;
-    }
-  }
-  .code-block-header {
-    padding: 6px 16px;
-    background-color: ${theme.background.secondary};
-    border: 1px solid ${theme.border.default};
-    border-bottom-width: 0px;
-
-    span {
-      ${typography.fontSizes[15]}
-      color: ${theme.text.default};
-      font-family: ${typography.fontFaces.mono};
-    }
-  }
-  .code-block-content {
-    flex: 1;
-    overflow-x: auto;
-
-    pre {
-      height: 100%;
-      margin: 0;
-
-      ::-webkit-scrollbar {
-        height: 6px;
-      }
-      ::-webkit-scrollbar-track {
-        background: ${theme.background.secondary};
-      }
-      ::-webkit-scrollbar-thumb {
-        background: ${theme.background.tertiary};
-        border-radius: 10px;
-      }
-      ::-webkit-scrollbar-thumb:hover {
-        background: ${theme.background.quaternary};
-      }
-    }
-  }
-`;
-
 type Props = PropsWithChildren<{
   tabs?: string[];
+  connected?: boolean;
 }>;
 
-export function CodeBlocksTable({ children, tabs, ...rest }: Props) {
+export function CodeBlocksTable({ children, tabs, connected = true, ...rest }: Props) {
   const childrenArray = Array.isArray(children) ? children : [children];
   const codeBlocks = childrenArray.filter(
     ({ props }) =>
@@ -97,15 +35,63 @@ export function CodeBlocksTable({ children, tabs, ...rest }: Props) {
     });
 
   return (
-    <div css={CodeSamplesCSS} {...rest}>
+    <div css={[codeBlocksWrapperStyle, connected && codeBlockConnectedWrapperStyle]} {...rest}>
       {codeBlocks.map((codeBlock, index) => (
-        <div key={index} className="code-block-column">
-          <div className="code-block-header">
-            <span>{tabNames[index]}</span>
-          </div>
-          <div className="code-block-content">{codeBlock}</div>
-        </div>
+        <Snippet key={index}>
+          <SnippetHeader title={tabNames[index]} />
+          <SnippetContent skipPadding>{codeBlock}</SnippetContent>
+        </Snippet>
       ))}
     </div>
   );
 }
+
+const codeBlocksWrapperStyle = css({
+  display: 'grid',
+  gridTemplateColumns: 'minmax(0, 1fr) minmax(0, 1fr)',
+  gap: spacing[4],
+  gridAutoRows: '1fr',
+
+  pre: {
+    border: 0,
+    margin: 0,
+    gridTemplateRows: 'minmax(100px, 1fr)',
+  },
+
+  [`@media screen and (max-width: ${breakpoints.large}px)`]: {
+    gridTemplateColumns: 'minmax(0, 1fr)',
+    gridAutoRows: 'auto',
+
+    '> div': {
+      marginBottom: 0,
+
+      '&:last-of-type': {
+        marginBottom: spacing[4],
+      },
+    },
+  },
+});
+
+const codeBlockConnectedWrapperStyle = css({
+  [`@media screen and (min-width: ${breakpoints.large}px)`]: {
+    gridGap: 0,
+
+    '> div:nth-of-type(odd)': {
+      '> div': {
+        borderRight: 0,
+        borderTopRightRadius: 0,
+        borderBottomRightRadius: 0,
+      },
+    },
+
+    '& > div:nth-of-type(even)': {
+      '> div': {
+        borderTopLeftRadius: 0,
+        borderBottomLeftRadius: 0,
+      },
+    },
+    '> div > div:nth-of-type(even)': {
+      height: '100%',
+    },
+  },
+});

--- a/docs/components/plugins/CodeBlocksTable.tsx
+++ b/docs/components/plugins/CodeBlocksTable.tsx
@@ -37,9 +37,11 @@ export function CodeBlocksTable({ children, tabs, connected = true, ...rest }: P
   return (
     <div css={[codeBlocksWrapperStyle, connected && codeBlockConnectedWrapperStyle]} {...rest}>
       {codeBlocks.map((codeBlock, index) => (
-        <Snippet key={index}>
+        <Snippet key={index} css={snippetWrapperStyle}>
           <SnippetHeader title={tabNames[index]} />
-          <SnippetContent skipPadding>{codeBlock}</SnippetContent>
+          <SnippetContent skipPadding css={snippetContentStyle}>
+            {codeBlock}
+          </SnippetContent>
         </Snippet>
       ))}
     </div>
@@ -56,19 +58,12 @@ const codeBlocksWrapperStyle = css({
     border: 0,
     margin: 0,
     gridTemplateRows: 'minmax(100px, 1fr)',
+    height: '100%',
   },
 
   [`@media screen and (max-width: ${breakpoints.large}px)`]: {
     gridTemplateColumns: 'minmax(0, 1fr)',
     gridAutoRows: 'auto',
-
-    '> div': {
-      marginBottom: 0,
-
-      '&:last-of-type': {
-        marginBottom: spacing[4],
-      },
-    },
   },
 });
 
@@ -84,14 +79,25 @@ const codeBlockConnectedWrapperStyle = css({
       },
     },
 
-    '& > div:nth-of-type(even)': {
+    '> div:nth-of-type(even)': {
       '> div': {
         borderTopLeftRadius: 0,
         borderBottomLeftRadius: 0,
       },
     },
-    '> div > div:nth-of-type(even)': {
-      height: '100%',
+  },
+});
+
+const snippetWrapperStyle = css({
+  [`@media screen and (max-width: ${breakpoints.large}px)`]: {
+    marginBottom: 0,
+
+    '&:last-of-type': {
+      marginBottom: spacing[4],
     },
   },
+});
+
+const snippetContentStyle = css({
+  height: '100%',
 });

--- a/docs/pages/eas/metadata/config.mdx
+++ b/docs/pages/eas/metadata/config.mdx
@@ -21,9 +21,7 @@ You can find all configuration options in the [store config schema](./schema.mdx
 
 > If you have the [VS Code Expo plugin](https://github.com/expo/vscode-expo#readme) installed, you get auto-complete, suggestions, and warnings for **store.config.json** files.
 
-<CodeBlocksTable tabs={['store.config.json']}>
-
-```json
+```json store.config.json
 {
   "configVersion": 0,
   "apple": {
@@ -41,9 +39,6 @@ You can find all configuration options in the [store config schema](./schema.mdx
   }
 }
 ```
-
-</CodeBlocksTable>
-
 
 ## Dynamic store config
 

--- a/docs/pages/eas/metadata/getting-started.mdx
+++ b/docs/pages/eas/metadata/getting-started.mdx
@@ -5,7 +5,6 @@ sidebar_title: Getting started
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Terminal } from '~/ui/components/Snippet';
-import { CodeBlocksTable } from '~/components/plugins/CodeBlocksTable';
 
 > **warning** EAS Metadata is in beta and subject to breaking changes.
 
@@ -27,9 +26,7 @@ If you already have an app in the stores, you can pull the information into a st
 
 If you don't have an app in the stores yet, EAS Metadata can't generate the store config for you. Instead, create a new store config file.
 
-<CodeBlocksTable tabs={['store.config.json']}>
-
-```json
+```json store.config.json
 {
   "configVersion": 0,
   "apple": {
@@ -47,8 +44,6 @@ If you don't have an app in the stores yet, EAS Metadata can't generate the stor
   }
 }
 ```
-
-</CodeBlocksTable>
 
 > By default, EAS Metadata uses the **store.config.json** file at the root of your project. You can change the name and location of this file by setting the **eas.json** [`metadataPath`](../../submit/eas-json.mdx#metadatapath) property.
 

--- a/docs/pages/eas/metadata/schema.mdx
+++ b/docs/pages/eas/metadata/schema.mdx
@@ -63,9 +63,8 @@ Parental controls on the App Store use this calculated age rating.
 EAS Metadata uses the least restrictive answer for each of these questions by default.
 
 <Collapsible summary="Complete advisory with the least restrictive answers">
-  <CodeBlocksTable tabs={['store.config.json']} style={{ marginTop: 0 }}>
 
-```json
+```json store.config.json
 {
   "configVersion": 0,
   "apple": {
@@ -91,7 +90,6 @@ EAS Metadata uses the least restrictive answer for each of these questions by de
 }
 ```
 
-  </CodeBlocksTable>
 </Collapsible>
 
 <MetadataTable>
@@ -151,9 +149,8 @@ EAS Metadata uses the least restrictive answer for each of these questions by de
 The App Store helps users discover new apps by [categorizing apps into categories](https://developer.apple.com/app-store/categories/), using primary, secondary, and possible subcategories.
 
 <Collapsible summary="Primary and secondary category">
-  <CodeBlocksTable tabs={['store.config.json']} style={{ marginTop: 0 }}>
 
-```json
+```json store.config.json
 {
   "configVersion": 0,
   "apple": {
@@ -162,13 +159,11 @@ The App Store helps users discover new apps by [categorizing apps into categorie
 }
 ```
 
-  </CodeBlocksTable>
 </Collapsible>
 
 <Collapsible summary="Primary, subcategories, and secondary category">
-  <CodeBlocksTable tabs={['store.config.json']} style={{ marginTop: 0 }}>
 
-```json
+```json store.config.json
 {
   "configVersion": 0,
   "apple": {
@@ -180,7 +175,6 @@ The App Store helps users discover new apps by [categorizing apps into categorie
 }
 ```
 
-  </CodeBlocksTable>
 </Collapsible>
 
 <MetadataTable key='apple.categories' headers={['Name', 'Description']}>
@@ -228,9 +222,8 @@ The App Store is a global service used by many people in different languages.
 You can localize your App Store presence in [multiple languages](#apple-info-languages).
 
 <Collapsible summary="Minimal localized info in English (U.S.)">
-  <CodeBlocksTable tabs={['store.config.json']} style={{ marginTop: 0 }}>
 
-```json
+```json store.config.json
 {
   "configVersion": 0,
   "apple": {
@@ -244,13 +237,11 @@ You can localize your App Store presence in [multiple languages](#apple-info-lan
 }
 ```
 
-  </CodeBlocksTable>
 </Collapsible>
 
 <Collapsible summary="Complete localized info written in English (U.S.)">
-  <CodeBlocksTable tabs={['store.config.json']} style={{ marginTop: 0 }}>
 
-```json
+```json store.config.json
 {
   "configVersion": 0,
   "apple": {
@@ -272,7 +263,6 @@ You can localize your App Store presence in [multiple languages](#apple-info-lan
 }
 ```
 
-  </CodeBlocksTable>
 </Collapsible>
 
 <MetadataTable>
@@ -362,9 +352,8 @@ There are multiple strategies to put the app in the hands of your users.
 You can release the app automatically after store approval or gradually release an update to your users.
 
 <Collapsible summary="Automatic release after 25th of December, 2022 (UTC)">
-  <CodeBlocksTable tabs={['store.config.json']} style={{ marginTop: 0 }}>
 
-```json
+```json store.config.json
 {
   "configVersion": 0,
   "apple": {
@@ -375,7 +364,6 @@ You can release the app automatically after store approval or gradually release 
 }
 ```
 
-  </CodeBlocksTable>
 </Collapsible>
 
 <MetadataTable>
@@ -412,9 +400,8 @@ Before publishing the app on the App Store, store approval is required.
 The App Store review team must have all the information to test your app, or you risk an app rejection.
 
 <Collapsible summary="Minimal review information">
-  <CodeBlocksTable tabs={['store.config.json']} style={{ marginTop: 0 }}>
 
-```json
+```json store.config.json
 {
   "configVersion": 0,
   "apple": {
@@ -428,13 +415,11 @@ The App Store review team must have all the information to test your app, or you
 }
 ```
 
-  </CodeBlocksTable>
 </Collapsible>
 
 <Collapsible summary="Complete review information">
-  <CodeBlocksTable tabs={['store.config.json']} style={{ marginTop: 0 }}>
 
-```json
+```json store.config.json
 {
   "configVersion": 0,
   "apple": {
@@ -452,7 +437,6 @@ The App Store review team must have all the information to test your app, or you
 }
 ```
 
-  </CodeBlocksTable>
 </Collapsible>
 
 <MetadataTable>

--- a/docs/pages/modules/appdelegate-subscribers.mdx
+++ b/docs/pages/modules/appdelegate-subscribers.mdx
@@ -44,9 +44,7 @@ In this scenario, `ExpoAppDelegate` passes a new completion block to each subscr
 
 ## Example
 
-<CodeBlocksTable tabs={['AppLifecycleDelegate.swift']}>
-
-```swift
+```swift AppLifecycleDelegate.swift
 import ExpoModulesCore
 
 public class AppLifecycleDelegate: ExpoAppDelegateSubscriber {
@@ -72,16 +70,10 @@ public class AppLifecycleDelegate: ExpoAppDelegateSubscriber {
 }
 ```
 
-</CodeBlocksTable>
-
-<CodeBlocksTable tabs={['expo-module.config.json']}>
-
-```json
+```json expo-module.config.json
 {
   "ios": {
     "appDelegateSubscribers": ["AppLifecycleDelegate"]
   }
 }
 ```
-
-</CodeBlocksTable>

--- a/docs/pages/modules/get-started.mdx
+++ b/docs/pages/modules/get-started.mdx
@@ -47,9 +47,7 @@ dependencies {
 
 Add `expo` package as a peer dependency in your **package.json** — we recommend using `*` as a version range so as not to cause any duplicated packages in user's **node_modules** folder. Your library also needs to depend on `expo-modules-core` but only as a dev dependency — it's already provided in the projects depending on your library by the `expo` package with the version of core that is compatible with the specific SDK used in the project.<br/>
 
-<CodeBlocksTable tabs={["package.json"]}>
-
-```json
+```json package.json
 {
   // ...
   "devDependencies": {
@@ -60,8 +58,6 @@ Add `expo` package as a peer dependency in your **package.json** — we recommen
   }
 }
 ```
-
-</CodeBlocksTable>
 
 ## Create a native module
 
@@ -96,9 +92,7 @@ class MyModule : Module() {
 
 Then, add your classes to Android and/or iOS `modules` in the [module config](./module-config.mdx). Expo Autolinking will automatically link these classes as native modules in the user's project.
 
-<CodeBlocksTable tabs={["expo-module.config.json"]}>
-
-```json
+```json expo-module.config.json
 {
   "ios": {
     "modules": ["MyModule"]
@@ -109,21 +103,15 @@ Then, add your classes to Android and/or iOS `modules` in the [module config](./
 }
 ```
 
-</CodeBlocksTable>
-
 If you already have an example app in your workspace, ensure that the module is linked correctly.
 - **On Android** the native module class will be linked automatically before building, as part of the Gradle build task.
 - **On iOS** you need to run `pod install` to link the new class.
 These module classes can now be accessed from the JavaScript code using the `requireNativeModule` function from the `expo-modules-core` package. We recommend creating a separate file that exports the native module for simplicity.
 
-<CodeBlocksTable tabs={["MyModule.ts"]}>
-
-```typescript
+```ts MyModule.ts
 import { requireNativeModule } from 'expo-modules-core';
 
 export default requireNativeModule('MyModule');
 ```
-
-</CodeBlocksTable>
 
 Now that the class is set up and linked, you can start to implement its functionality. See the [native module API](./module-api.mdx) reference page and links to [examples](./module-api.mdx#examples) from simple to moderately complex real-world modules for your reference to better understand how to use the API.

--- a/docs/pages/modules/module-api.mdx
+++ b/docs/pages/modules/module-api.mdx
@@ -96,7 +96,7 @@ import { requireNativeModule } from 'expo-modules-core';
 const MyModule = requireNativeModule('MyModule');
 
 function getMessage() {
-return MyModule.syncFunction('bar');
+  return MyModule.syncFunction('bar');
 }
 ```
 
@@ -148,7 +148,7 @@ import { requireNativeModule } from 'expo-modules-core';
 const MyModule = requireNativeModule('MyModule');
 
 async function getMessageAsync() {
-return await MyModule.asyncFunction('bar');
+  return await MyModule.asyncFunction('bar');
 }
 ```
 

--- a/docs/pages/modules/module-api.mdx
+++ b/docs/pages/modules/module-api.mdx
@@ -19,13 +19,10 @@ The module definition consists of the DSL components that describe the module's 
 
 Sets the name of the module that JavaScript code will use to refer to the module. Takes a string as an argument. Can be inferred from module's class name, but it's recommended to set it explicitly for clarity.
 
-<CodeBlocksTable tabs={["Swift / Kotlin"]}>
-
-```swift
+```swift Swift / Kotlin
 Name("MyModuleName")
 ```
 
-</CodeBlocksTable>
 </APIBox>
 <APIBox header="Constants">
 
@@ -90,18 +87,19 @@ Function("syncFunction") { message: String ->
 }
 ```
 
-```javascript
+</CodeBlocksTable>
+
+```js JavaScript
 import { requireNativeModule } from 'expo-modules-core';
 
 // Assume that we have named the module "MyModule"
 const MyModule = requireNativeModule('MyModule');
 
 function getMessage() {
-  return MyModule.syncFunction('bar');
+return MyModule.syncFunction('bar');
 }
 ```
 
-</CodeBlocksTable>
 </APIBox>
 <APIBox header="AsyncFunction">
 
@@ -141,18 +139,19 @@ AsyncFunction("asyncFunction") { message: String, promise: Promise ->
 }
 ```
 
-```javascript
+</CodeBlocksTable>
+
+```js JavaScript
 import { requireNativeModule } from 'expo-modules-core';
 
 // Assume that we have named the module "MyModule"
 const MyModule = requireNativeModule('MyModule');
 
 async function getMessageAsync() {
-  return await MyModule.asyncFunction('bar');
+return await MyModule.asyncFunction('bar');
 }
 ```
 
-</CodeBlocksTable>
 </APIBox>
 <APIBox header="Events">
 

--- a/docs/ui/components/Snippet/SnippetContent.tsx
+++ b/docs/ui/components/Snippet/SnippetContent.tsx
@@ -6,10 +6,12 @@ type SnippetContentProps = PropsWithChildren<{
   alwaysDark?: boolean;
   hideOverflow?: boolean;
   skipPadding?: boolean;
+  className?: string;
 }>;
 
 export const SnippetContent = ({
   children,
+  className,
   alwaysDark = false,
   hideOverflow = false,
   skipPadding = false,
@@ -20,7 +22,8 @@ export const SnippetContent = ({
       alwaysDark && contentDarkStyle,
       hideOverflow && contentHideOverflow,
       skipPadding && skipPaddingStyle,
-    ]}>
+    ]}
+    className={className}>
     {children}
   </div>
 );


### PR DESCRIPTION
# Why

For a while `CodeBlocksTable` was used as a workaround for adding titles to the code block, besides its intended use case, which was to display code block side by side.

# How

With new features shipped, we now can replace the single code block usages of this component with markdown notation.

Additionally, I have updated the behaviour and appearance of `CodeBlocksTable` on mobile, previously code blocks were always displayed in columns, no mater of the viewport size. 

Also a new prop `connected` has been added, which is set to `true` by default (would prefer if this could be `false`, but this ensures the backward compatibility without adding `connected` prop to all existing usages). 

# Test Plan

The changes have been tested by running docs website locally.

# Preview

<img width="1211" alt="Screenshot 2022-09-30 at 15 12 38" src="https://user-images.githubusercontent.com/719641/193279205-f556dffb-2c8f-4b4d-8798-c20f6954789b.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
