### PR TITLE
[docs] Update Firebase Cloud Messaging

### DIFF
--- a/docs/pages/push-notifications/using-fcm.mdx
+++ b/docs/pages/push-notifications/using-fcm.mdx
@@ -65,15 +65,15 @@ In order for Expo to send notifications from our servers using your credentials,
 
 3. Copy the token listed next to **Server key**.
 
-  > Server Key is only available in **Cloud Messaging API (Legacy)**, which may be disabled by default. Enable it by clicking the 3-dot menu > Manage API in Google Cloud Console and follow the flow there. Once the legacy messaging API is enabled, you should see Server Key in that section.
+   > Server Key is only available in **Cloud Messaging API (Legacy)**, which may be disabled by default. Enable it by clicking the 3-dot menu > Manage API in Google Cloud Console and follow the flow there. Once the legacy messaging API is enabled, you should see Server Key in that section.
 
 4. In your [Expo account's](https://expo.dev/) dashboard, select your project, and click on **Credentials** in the navigation menu. Then, click on your **Application Identifier** that follows the pattern:`com.company.app`.
 
-  > For Legacy Application Identifiers, run `expo push:android:upload --api-key <your-token-here>`, replacing `<your-token-here>` with the string you just copied. We'll store your token securely on our servers, where it will only be accessed when you send a push notification.
+   > For Legacy Application Identifiers, run `expo push:android:upload --api-key <your-token-here>`, replacing `<your-token-here>` with the string you just copied. We'll store your token securely on our servers, where it will only be accessed when you send a push notification.
 
 5. Check that all of your **Service Credentials** are filled correctly. If the **FCM Server Key** is empty, then you can add the copied **Server key** from **Step 3**. If the FCM Server Key is populated, verify that the last characters match the **Server Key** from **Step 3**.
 
-  > **warning** Having Service Credentials in both Legacy and non-legacy Application Identifiers can prevent push notifications from working on android devices. If you have a Legacy Application Identifier, you might need to remove all of its Service Credentials.
+   > **warning** Having Service Credentials in both Legacy and non-legacy Application Identifiers can prevent push notifications from working on android devices. If you have a Legacy Application Identifier, you might need to remove all of its Service Credentials.
 
 Users who run this new version of the app will now receive notifications through FCM using your project's credentials. You can now send push notifications normally. For more information, see [Sending Notifications](/push-notifications/sending-notifications/). We'll take care of choosing the correct service to send the notification.
 

--- a/docs/pages/push-notifications/using-fcm.mdx
+++ b/docs/pages/push-notifications/using-fcm.mdx
@@ -65,11 +65,17 @@ In order for Expo to send notifications from our servers using your credentials,
 
 3. Copy the token listed next to **Server key**.
 
-> **Note:** Server Key is only available in **Cloud Messaging API (Legacy)**, which may be Disabled by default. Enable it by clicking the 3-dot menu > Manage API in Google Cloud Console and follow the flow there. Once the legacy messaging API is enabled, you should see Server Key in that section.
+  > Server Key is only available in **Cloud Messaging API (Legacy)**, which may be disabled by default. Enable it by clicking the 3-dot menu > Manage API in Google Cloud Console and follow the flow there. Once the legacy messaging API is enabled, you should see Server Key in that section.
 
-4. Run `expo push:android:upload --api-key <your-token-here>`, replacing `<your-token-here>` with the string you just copied. We'll store your token securely on our servers, where it will only be accessed when you send a push notification.
+4. In your [Expo account's](https://expo.dev/) dashboard, select your project, and click on **Credentials** in the navigation menu. Then, click on your **Application Identifier** that follows the pattern:`com.company.app`.
 
-That's it -- users who run this new version of the app will now receive notifications through FCM using your project's credentials. You just send the push notifications as you normally would (see [guide](sending-notifications.mdx)). We'll take care of choosing the correct service to send the notification.
+  > For Legacy Application Identifiers, run `expo push:android:upload --api-key <your-token-here>`, replacing `<your-token-here>` with the string you just copied. We'll store your token securely on our servers, where it will only be accessed when you send a push notification.
+
+5. Check that all of your **Service Credentials** are filled correctly. If the **FCM Server Key** is empty, then you can add the copied **Server key** from **Step 3**. If the FCM Server Key is populated, verify that the last characters match the **Server Key** from **Step 3**.
+
+  > **warning** Having Service Credentials in both Legacy and non-legacy Application Identifiers can prevent push notifications from working on android devices. If you have a Legacy Application Identifier, you might need to remove all of its Service Credentials.
+
+Users who run this new version of the app will now receive notifications through FCM using your project's credentials. You can now send push notifications normally. For more information, see [Sending Notifications](/push-notifications/sending-notifications/). We'll take care of choosing the correct service to send the notification.
 
 ## See also
 


### PR DESCRIPTION
[Version 3](https://github.com/expo/expo/pull/18806)

Had to make another PR due to git/mac issues with the file extension change from `.md` to `.mdx`

This proposes to not use `expo` command for uploading server credentials and update missing info manually on expo.dev.

# Why

Docs recommend command `expo push:android:upload --api-key <your-token-here>` which created a new Legacy Application Identifier. This lead to android notifications not working at all. Spent a lot of time trying to understand why android notifications were not working.


<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

I removed the Server Credentials from the Legacy Application Identifier which cause the android push notifications to finally work.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Upload Server Credentials the old way with `expo push:android:upload --api-key <your-token-here>`. Check if android notifications stopped working.
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
