### PR TITLE
[android] Upgrade jsc-android to 250230.2.1

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -109,12 +109,6 @@ android {
   }
 }
 
-configurations.all {
-  resolutionStrategy {
-    force 'org.webkit:android-jsc:r245459'
-  }
-}
-
 dependencies {
   implementation fileTree(dir: 'libs', include: ['*.jar'])
 
@@ -216,7 +210,7 @@ dependencies {
   // WHEN_DISTRIBUTING_REMOVE_TO_HERE
 
   /* UNCOMMENT WHEN DISTRIBUTING
-  api 'org.webkit:android-jsc:r245459' // needs to be before react-native
+  api 'org.webkit:android-jsc:r250230' // needs to be before react-native
   api 'com.facebook.react:react-native:+'
   END UNCOMMENT WHEN DISTRIBUTING */
 

--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -256,12 +256,6 @@ class GenerateDynamicMacrosPlugin implements Plugin<Project> {
 
 apply plugin: GenerateDynamicMacrosPlugin
 
-configurations.all {
-  resolutionStrategy {
-    force 'org.webkit:android-jsc:r245459'
-  }
-}
-
 // WHEN_VERSIONING_REMOVE_TO_HERE
 
 dependencies {
@@ -286,7 +280,7 @@ dependencies {
 
   // WHEN_VERSIONING_REMOVE_FROM_HERE
 
-  api 'org.webkit:android-jsc:r245459' // needs to be before react-native
+  api 'org.webkit:android-jsc:r250230' // needs to be before react-native
 
   /* UNCOMMENT WHEN DISTRIBUTING
   api 'com.facebook.react:react-native:45.0.0'

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "eslint": "^8.20.0",
     "expo-yarn-workspaces": "*",
-    "jsc-android": "^245459.0.0",
+    "jsc-android": "^250230.2.1",
     "prettier": "^2.7.1",
     "yarn-deduplicate": "^3.1.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13205,11 +13205,6 @@ jsbn@~0.1.0:
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
   integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
 
-jsc-android@^245459.0.0:
-  version "245459.0.0"
-  resolved "https://registry.yarnpkg.com/jsc-android/-/jsc-android-245459.0.0.tgz#e584258dd0b04c9159a27fb104cd5d491fd202c9"
-  integrity sha512-wkjURqwaB1daNkDi2OYYbsLnIdC/lUM2nPXQKRs5pqEU9chDg435bjvo+LSaHotDENygHQDHe+ntUkkw2gwMtg==
-
 jsc-android@^250230.2.1:
   version "250230.2.1"
   resolved "https://registry.yarnpkg.com/jsc-android/-/jsc-android-250230.2.1.tgz#3790313a970586a03ab0ad47defbc84df54f1b83"


### PR DESCRIPTION
# Why

react-native starts `jsc-android@250230.2.1` from 0.66.0. as we drop sdk 44 (react-native 0.64) in sdk 47, it's a good time to upgrade jsc for expo go.

# How

- update jsc-android package and the gradle dependencies
- remove the old gradle resolutions for react-native <= 0.58

# Test Plan

- android unversioned expo go + NCL

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
