### PR TITLE
[docs] Fix numbered lists references to start from 1

### DIFF
--- a/docs/pages/archived/adhoc-builds.mdx
+++ b/docs/pages/archived/adhoc-builds.mdx
@@ -10,7 +10,7 @@ Build and install a custom version of [Expo Go](../get-started/installation.mdx#
 
 ![Adhoc Builds Overview](/static/images/adhoc-builds-overview.jpg)
 
-## 0. Prerequisites
+## Prerequisites
 
 - You’ll need a **paid** [Apple Developer Account](https://developer.apple.com/programs) to configure credentials required for the development and distribution process of an app. Learn more [here](https://developer.apple.com/programs/whats-included/).
 - Install the `expo-cli` command line app by following the instructions [here](../workflow/expo-cli.mdx).

--- a/docs/pages/build-reference/e2e-tests.mdx
+++ b/docs/pages/build-reference/e2e-tests.mdx
@@ -16,7 +16,7 @@ This guide explains how to run E2E tests with Detox in a bare workflow project. 
 
 ## Running iOS tests
 
-### 0. Initialize a new Bare Workflow project
+### 1. Initialize a new Bare Workflow project
 
 Let's start by initializing a new Expo project and running `npx expo prebuild` to generate the native projects.
 
@@ -29,7 +29,7 @@ Let's start by initializing a new Expo project and running `npx expo prebuild` t
 '$ npx expo prebuild --platform ios'
 ]} />
 
-### 1. Make home screen interactive
+### 2. Make home screen interactive
 
 The first step to writing E2E tests is to have something to test - we have an empty app, so let's make our app interactive. We can add a button and display some new text when it's pressed.
 Later, we're going to write a test that's going to tap the button and check whether the text has been displayed.
@@ -93,7 +93,7 @@ const styles = StyleSheet.create({
 
 </Collapsible>
 
-### 2. Set up Detox
+### 3. Set up Detox
 
 #### Install dependencies
 
@@ -129,7 +129,7 @@ Edit **.detoxrc.json** and replace the `ios` configuration with:
 }
 ```
 
-### 3. Write E2E tests
+### 4. Write E2E tests
 
 Next, we'll add our first E2E tests. Delete the auto-generated **e2e/firstTest.e2e.js** and create our own **e2e/homeScreen.e2e.js** with the following contents:
 
@@ -162,7 +162,7 @@ There are two tests in the suite:
 
 Both tests assume the button has the `testID` set to `click-me-button`. See [the source code](#1-make-home-screen-interactive) for details.
 
-### 4. Configure EAS Build
+### 5. Configure EAS Build
 
 Now that we have configured Detox and written our first E2E test, let's configure EAS Build and run the tests in the cloud.
 
@@ -233,7 +233,7 @@ Edit **package.json** to use [EAS Build hooks](/build-reference/npm-hooks.mdx) t
 
 > Don't forget to add executable permissions to **eas-build-pre-install.sh** and **eas-build-on-success.sh**. Run `chmod +x eas-hooks/*.sh`.
 
-### 5. Run tests on EAS Build
+### 6. Run tests on EAS Build
 
 Running the tests on EAS Build is like running a regular build:
 
@@ -243,7 +243,7 @@ If you have set up everything correctly you should see the successful test resul
 
 <img src="/static/images/eas-build/tests/03-logs.png" style={{maxWidth: "100%" }} />
 
-### 6. Upload screenshots of failed test cases
+### 7. Upload screenshots of failed test cases
 
 > This step is optional but highly recommended.
 

--- a/docs/pages/guides/using-sentry.mdx
+++ b/docs/pages/guides/using-sentry.mdx
@@ -25,9 +25,9 @@ It notifies you of exceptions or errors that your users run into while using you
 
 <PlatformsSection title="Platform compatibility" android emulator ios simulator web />
 
-## Installating and configuring Sentry
+## Installing and configuring Sentry
 
-### Step 0: Sign up for a Sentry account and create a project
+### Step 1: Sign up for a Sentry account and create a project
 
 Before getting real-time updates on errors and making your app generally incredible, you'll need to make sure you've created a Sentry project. Here's how to do that:
 
@@ -41,7 +41,7 @@ Before getting real-time updates on errors and making your app generally incredi
 
 Once you have each of these: organization name, project name, DSN, and auth token, you're all set!
 
-### Step 1: Installation
+### Step 2: Installation
 
 In your project directory, run:
 
@@ -53,7 +53,7 @@ In your project directory, run:
 cmd={['$ npx expo install expo-application expo-constants expo-device expo-updates @sentry/react-native']}
 />
 
-### Step 2: Code
+### Step 3: Code
 
 #### Initialization
 
@@ -91,7 +91,7 @@ try {
 }
 ```
 
-### Step 3: App Configuration
+### Step 4: App Configuration
 
 Configuring sentry-expo is done through the config plugin in your **app.json** or **app.config.js**.
 
@@ -117,7 +117,7 @@ to your root project file (usually **App.js**), so make sure you remove it (but 
 
 </ConfigReactNative>
 
-#### 3.1: Configure a `postPublish` hook
+#### 4.1: Configure a `postPublish` hook
 
 Add `expo.hooks` to your project's `app.json` (or `app.config.js`) file:
 
@@ -175,7 +175,7 @@ In addition to the required config fields above, you can also provide these **op
 
 </Collapsible>
 
-#### 3.2: Add the Config Plugin
+#### 4.2: Add the Config Plugin
 
 Add `expo.plugins` to your project's `app.json` (or `app.config.js`) file:
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Refs ENG-6474

# How

<!--
How did you build this feature or fix this bug and why?
-->

By re-numbering numbered lists to start from `1` and update the following individual list numbers.

Also, fixed a typo in Using Sentry guide.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally via `yarn dev ` and visit http://localhost:3002/build-reference/e2e-tests/#1-initialize-a-new-bare-workflow-project for example.

## Preview

### Before

<img width="901" alt="CleanShot 2022-10-01 at 00 55 40@2x" src="https://user-images.githubusercontent.com/10234615/193342521-d60371f0-2535-4468-9872-73f643fc239b.png">

### After

<img width="923" alt="CleanShot 2022-10-01 at 00 54 52@2x" src="https://user-images.githubusercontent.com/10234615/193342413-01c69e7e-3005-4ffb-a1f7-0c06beb13a3b.png">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
