### PR TITLE
refactor(cli): implement new package manager

### DIFF
--- a/packages/@expo/cli/src/install/checkPackages.ts
+++ b/packages/@expo/cli/src/install/checkPackages.ts
@@ -29,10 +29,7 @@ export async function checkPackagesAsync(
      */
     packages: string[];
     /** Package manager to use when installing the versioned packages. */
-    packageManager:
-      | PackageManager.NpmPackageManager
-      | PackageManager.YarnPackageManager
-      | PackageManager.PnpmPackageManager;
+    packageManager: PackageManager.NodePackageManager;
 
     /** How the check should resolve */
     options: Pick<Options, 'fix'>;

--- a/packages/@expo/cli/src/install/installAsync.ts
+++ b/packages/@expo/cli/src/install/installAsync.ts
@@ -22,8 +22,8 @@ export async function installAsync(
     npm: options.npm,
     yarn: options.yarn,
     pnpm: options.pnpm,
-    log: Log.log,
     silent: options.silent,
+    log: Log.log,
   });
 
   if (options.check || options.fix) {
@@ -66,10 +66,7 @@ export async function installPackagesAsync(
      */
     packages: string[];
     /** Package manager to use when installing the versioned packages. */
-    packageManager:
-      | PackageManager.NpmPackageManager
-      | PackageManager.YarnPackageManager
-      | PackageManager.PnpmPackageManager;
+    packageManager: PackageManager.NodePackageManager;
     /**
      * SDK to version `packages` for.
      * @example '44.0.0'
@@ -94,7 +91,7 @@ export async function installPackagesAsync(
     }using {bold ${packageManager.name}}`
   );
 
-  await packageManager.addWithParametersAsync(versioning.packages, packageManagerArguments);
+  await packageManager.addAsync([...packageManagerArguments, ...versioning.packages]);
 
   await applyPluginsAsync(projectRoot, versioning.packages);
 }

--- a/packages/@expo/cli/src/install/resolveOptions.ts
+++ b/packages/@expo/cli/src/install/resolveOptions.ts
@@ -1,9 +1,9 @@
-import * as PackageManager from '@expo/package-manager';
+import { NodePackageManagerForProject } from '@expo/package-manager';
 
 import { CommandError } from '../utils/errors';
 import { assertUnexpectedObjectKeys, parseVariadicArguments } from '../utils/variadic';
 
-export type Options = Pick<PackageManager.CreateForProjectOptions, 'npm' | 'pnpm' | 'yarn'> & {
+export type Options = Pick<NodePackageManagerForProject, 'npm' | 'pnpm' | 'yarn'> & {
   /** Check which packages need to be updated, does not install any provided packages. */
   check?: boolean;
   /** Should the dependencies be fixed automatically. */

--- a/packages/@expo/cli/src/start/doctor/ngrok/ExternalModule.ts
+++ b/packages/@expo/cli/src/start/doctor/ngrok/ExternalModule.ts
@@ -107,7 +107,7 @@ export class ExternalModule<TModule> {
       const packageManager = shouldGloballyInstall
         ? new PackageManager.NpmPackageManager({
             cwd: this.projectRoot,
-            logger: Log.log,
+            log: Log.log,
             silent: !env.EXPO_DEBUG,
           })
         : PackageManager.createForProject(this.projectRoot, {

--- a/packages/@expo/cli/src/start/doctor/ngrok/ExternalModule.ts
+++ b/packages/@expo/cli/src/start/doctor/ngrok/ExternalModule.ts
@@ -107,7 +107,7 @@ export class ExternalModule<TModule> {
       const packageManager = shouldGloballyInstall
         ? new PackageManager.NpmPackageManager({
             cwd: this.projectRoot,
-            log: Log.log,
+            logger: Log.log,
             silent: !env.EXPO_DEBUG,
           })
         : PackageManager.createForProject(this.projectRoot, {
@@ -116,9 +116,9 @@ export class ExternalModule<TModule> {
 
       try {
         if (shouldGloballyInstall) {
-          await packageManager.addGlobalAsync(packageName);
+          await packageManager.addGlobalAsync([packageName]);
         } else {
-          await packageManager.addDevAsync(packageName);
+          await packageManager.addDevAsync([packageName]);
         }
         Log.log(`Installed ${packageName}`);
       } catch (error: any) {


### PR DESCRIPTION
# Why

This implements the proposed package manager from #18576 in `@expo/cli`.

# How

This only changes the implementation, no tests.


Edit: it might be just my Windows that's being weird here.

---
~~This PR is a bit hard to test, it seems that the local `@expo/package-manager` isn't linked or used fro the local workspace. Probably related to a known unhandled edgecase in `expo-yarn-workspaces`, where it can overwrite package versions if there are more than 1 installed.~~

~~One thing that worked on my machine was adding `"resolution": { "@expo/package-manager": "file:./packages/@expo/package-manager" }`. Or this in the `@expo/cli` package:~~

![image](https://user-images.githubusercontent.com/1203991/193348619-57242ab4-1b67-4bcf-8327-059e5c4d34f6.png)
---



# Test Plan

In this PR there are no changes in the tests. It should kinda be a drop-in replacement, without too much trouble (except for a few semantics). In the stacked PR #19344, I updated _some_ tests.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
