### PR TITLE
fix(cli): install dev dependencies when fixing packages

### DIFF
--- a/packages/@expo/cli/src/install/checkPackages.ts
+++ b/packages/@expo/cli/src/install/checkPackages.ts
@@ -9,7 +9,7 @@ import {
 } from '../start/doctor/dependencies/validateDependenciesVersions';
 import { isInteractive } from '../utils/interactive';
 import { confirmAsync } from '../utils/prompts';
-import { installPackagesAsync } from './installAsync';
+import { fixPackagesAsync } from './installAsync';
 import { Options } from './resolveOptions';
 
 const debug = require('debug')('expo:install:check') as typeof console.log;
@@ -62,13 +62,11 @@ export async function checkPackagesAsync(
     (isInteractive() && (await confirmAsync({ message: 'Fix dependencies?' }).catch(() => false)));
 
   if (value) {
-    // Just pass in the names, the install function will resolve the versions again.
-    const fixedDependencies = dependencies.map((dependency) => dependency.packageName);
-    debug('Installing fixed dependencies:', fixedDependencies);
+    debug('Installing fixed dependencies:', dependencies);
     // Install the corrected dependencies.
-    return installPackagesAsync(projectRoot, {
+    return fixPackagesAsync(projectRoot, {
       packageManager,
-      packages: fixedDependencies,
+      packages: dependencies,
       packageManagerArguments,
       sdkVersion: exp.sdkVersion!,
     });

--- a/packages/@expo/cli/src/install/checkPackages.ts
+++ b/packages/@expo/cli/src/install/checkPackages.ts
@@ -29,10 +29,7 @@ export async function checkPackagesAsync(
      */
     packages: string[];
     /** Package manager to use when installing the versioned packages. */
-    packageManager:
-      | PackageManager.NpmPackageManager
-      | PackageManager.YarnPackageManager
-      | PackageManager.PnpmPackageManager;
+    packageManager: PackageManager.NodePackageManager;
 
     /** How the check should resolve */
     options: Pick<Options, 'fix'>;

--- a/packages/@expo/cli/src/install/installAsync.ts
+++ b/packages/@expo/cli/src/install/installAsync.ts
@@ -22,8 +22,8 @@ export async function installAsync(
     npm: options.npm,
     yarn: options.yarn,
     pnpm: options.pnpm,
-    log: Log.log,
     silent: options.silent,
+    log: Log.log,
   });
 
   if (options.check || options.fix) {
@@ -66,10 +66,7 @@ export async function installPackagesAsync(
      */
     packages: string[];
     /** Package manager to use when installing the versioned packages. */
-    packageManager:
-      | PackageManager.NpmPackageManager
-      | PackageManager.YarnPackageManager
-      | PackageManager.PnpmPackageManager;
+    packageManager: PackageManager.NodePackageManager;
     /**
      * SDK to version `packages` for.
      * @example '44.0.0'
@@ -94,7 +91,7 @@ export async function installPackagesAsync(
     }using {bold ${packageManager.name}}`
   );
 
-  await packageManager.addWithParametersAsync(versioning.packages, packageManagerArguments);
+  await packageManager.addAsync([...packageManagerArguments, ...versioning.packages]);
 
   await applyPluginsAsync(projectRoot, versioning.packages);
 }

--- a/packages/@expo/cli/src/install/resolveOptions.ts
+++ b/packages/@expo/cli/src/install/resolveOptions.ts
@@ -1,9 +1,9 @@
-import * as PackageManager from '@expo/package-manager';
+import { NodePackageManagerForProject } from '@expo/package-manager';
 
 import { CommandError } from '../utils/errors';
 import { assertUnexpectedObjectKeys, parseVariadicArguments } from '../utils/variadic';
 
-export type Options = Pick<PackageManager.CreateForProjectOptions, 'npm' | 'pnpm' | 'yarn'> & {
+export type Options = Pick<NodePackageManagerForProject, 'npm' | 'pnpm' | 'yarn'> & {
   /** Check which packages need to be updated, does not install any provided packages. */
   check?: boolean;
   /** Should the dependencies be fixed automatically. */

--- a/packages/@expo/cli/src/start/doctor/dependencies/validateDependenciesVersions.ts
+++ b/packages/@expo/cli/src/start/doctor/dependencies/validateDependenciesVersions.ts
@@ -14,6 +14,7 @@ const debug = require('debug')('expo:doctor:dependencies:validate') as typeof co
 
 interface IncorrectDependency {
   packageName: string;
+  packageType: 'dependencies' | 'devDependencies';
   expectedVersionOrRange: string;
   actualVersion: string;
 }
@@ -98,8 +99,8 @@ export async function getVersionedDependenciesAsync(
   const resolvedDependencies = packagesToCheck?.length
     ? // Diff the provided packages to ensure we only check against installed packages.
       getFilteredObject(packagesToCheck, { ...pkg.dependencies, ...pkg.devDependencies })
-    : // If no packages are provided, check against the `package.json` `dependencies` object.
-      pkg.dependencies;
+    : // If no packages are provided, check against the `package.json` `dependencies` + `devDependencies` object.
+      { ...pkg.dependencies, ...pkg.devDependencies };
   debug(`Checking dependencies for ${exp.sdkVersion}: %O`, resolvedDependencies);
 
   // intersection of packages from package.json and bundled native modules
@@ -113,7 +114,7 @@ export async function getVersionedDependenciesAsync(
   const packageVersions = await resolvePackageVersionsAsync(projectRoot, resolvedPackagesToCheck);
   debug(`Package versions: %O`, packageVersions);
   // find incorrect dependencies by comparing the actual package versions with the bundled native module version ranges
-  const incorrectDeps = findIncorrectDependencies(packageVersions, combinedKnownPackages);
+  const incorrectDeps = findIncorrectDependencies(pkg, packageVersions, combinedKnownPackages);
   debug(`Incorrect dependencies: %O`, incorrectDeps);
 
   return incorrectDeps;
@@ -177,6 +178,7 @@ async function getPackageVersionAsync(projectRoot: string, packageName: string):
 }
 
 function findIncorrectDependencies(
+  pkg: PackageJSONConfig,
   packageVersions: Record<string, string>,
   bundledNativeModules: BundledNativeModules
 ): IncorrectDependency[] {
@@ -191,10 +193,22 @@ function findIncorrectDependencies(
     ) {
       incorrectDeps.push({
         packageName,
+        packageType: findDependencyType(pkg, packageName),
         expectedVersionOrRange,
         actualVersion,
       });
     }
   }
   return incorrectDeps;
+}
+
+function findDependencyType(
+  pkg: PackageJSONConfig,
+  packageName: string
+): IncorrectDependency['packageType'] {
+  if (pkg.devDependencies && packageName in pkg.devDependencies) {
+    return 'devDependencies';
+  }
+
+  return 'dependencies';
 }

--- a/packages/@expo/cli/src/start/doctor/ngrok/ExternalModule.ts
+++ b/packages/@expo/cli/src/start/doctor/ngrok/ExternalModule.ts
@@ -107,7 +107,7 @@ export class ExternalModule<TModule> {
       const packageManager = shouldGloballyInstall
         ? new PackageManager.NpmPackageManager({
             cwd: this.projectRoot,
-            logger: Log.log,
+            log: Log.log,
             silent: !env.EXPO_DEBUG,
           })
         : PackageManager.createForProject(this.projectRoot, {

--- a/packages/@expo/cli/src/start/doctor/ngrok/ExternalModule.ts
+++ b/packages/@expo/cli/src/start/doctor/ngrok/ExternalModule.ts
@@ -107,7 +107,7 @@ export class ExternalModule<TModule> {
       const packageManager = shouldGloballyInstall
         ? new PackageManager.NpmPackageManager({
             cwd: this.projectRoot,
-            log: Log.log,
+            logger: Log.log,
             silent: !env.EXPO_DEBUG,
           })
         : PackageManager.createForProject(this.projectRoot, {
@@ -116,9 +116,9 @@ export class ExternalModule<TModule> {
 
       try {
         if (shouldGloballyInstall) {
-          await packageManager.addGlobalAsync(packageName);
+          await packageManager.addGlobalAsync([packageName]);
         } else {
-          await packageManager.addDevAsync(packageName);
+          await packageManager.addDevAsync([packageName]);
         }
         Log.log(`Installed ${packageName}`);
       } catch (error: any) {

--- a/packages/@expo/cli/src/utils/__tests__/array-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/array-test.ts
@@ -1,4 +1,4 @@
-import { findLastIndex, intersecting, replaceValue } from '../array';
+import { findLastIndex, groupBy, intersecting, replaceValue } from '../array';
 
 describe(findLastIndex, () => {
   it('should return the last index of an item based on a given criteria', () => {
@@ -20,5 +20,16 @@ describe(replaceValue, () => {
   it(`should replace a value in an array`, () => {
     expect(replaceValue([1, 2, 3], 1, 2)).toEqual([2, 2, 3]);
     expect(replaceValue([1, 2, 3], 4, 5)).toEqual([1, 2, 3]);
+  });
+});
+
+describe(groupBy, () => {
+  it(`should group list items by returned key`, () => {
+    expect(
+      groupBy([{ name: 'John' }, { name: 'Wick' }], (character) => character.name)
+    ).toMatchObject({
+      John: [{ name: 'John' }],
+      Wick: [{ name: 'Wick' }],
+    });
   });
 });

--- a/packages/@expo/cli/src/utils/array.ts
+++ b/packages/@expo/cli/src/utils/array.ts
@@ -44,3 +44,15 @@ export function chunk<T>(array: T[], size: number): T[][] {
   }
   return chunked;
 }
+
+/** `lodash.chunk` */
+export function groupBy<T, K extends keyof any>(list: T[], getKey: (item: T) => K): Record<K, T[]> {
+  return list.reduce((previous, currentItem) => {
+    const group = getKey(currentItem);
+    if (!previous[group]) {
+      previous[group] = [];
+    }
+    previous[group].push(currentItem);
+    return previous;
+  }, {} as Record<K, T[]>);
+}

--- a/packages/@expo/cli/src/utils/array.ts
+++ b/packages/@expo/cli/src/utils/array.ts
@@ -45,7 +45,7 @@ export function chunk<T>(array: T[], size: number): T[][] {
   return chunked;
 }
 
-/** `lodash.chunk` */
+/** `lodash.groupBy` */
 export function groupBy<T, K extends keyof any>(list: T[], getKey: (item: T) => K): Record<K, T[]> {
   return list.reduce((previous, currentItem) => {
     const group = getKey(currentItem);


### PR DESCRIPTION
# Why

Fixes ENG-5953

# How

- Added `fixPackagesAsync` that only installs dependencies based on a `DependencyIssue` list
    > This is done to keep the current "free form" of `npx expo install`, where users can do `npx expo install whatever --save-dev` if they want to.
- Added `packageType` to `DependencyIssue`, to differentiate `dependencies` from `devDependencies`


# Test Plan

See tests

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
