### PR TITLE
[scripts] Update setup-react-android to fallback sdkmanager

### DIFF
--- a/scripts/setup-react-android.sh
+++ b/scripts/setup-react-android.sh
@@ -2,6 +2,11 @@
 
 sdk_manager="sdkmanager"
 
+# Fallback to ANDROID_SDK_ROOT if sdkmanager is not found
+if ! [ -x "$(command -v ${sdk_manager})" ]; then
+  sdk_manager="$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager"
+fi
+
 # Ensure the `sdkmanager` is installed for React Android
 if ! [ -x "$(command -v ${sdk_manager})" ]; then
   echo "Error: You need to install Android SDK tools before proceeding. You can install these through Android Studio. Make sure that you also install the CLI tools and that sdkmanager can be found in your PATH."


### PR DESCRIPTION
# Why
 
While following the [Contributing guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#set-up-android) I got stuck in the Android setup as my machine does not recognize `sdkmanager` as a command even though I have Android SDK tools installed. This PR updates `setup-react-android` to fallback `sdkmanager` location using `$ANDROID_SDK_ROOT`, that way users won't have to manually export an alias for `sdkmanager`.

# How

By using the `ANDROID_SDK_ROOT` we can get the `sdkmanager` binary through `$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager`, the idea is that this would be only a fallback, and users that have already set up an alias for `sdkmanager` wouldn't be affected in any way.

# Test Plan

Run `npm run setup:native`

![image](https://user-images.githubusercontent.com/11707729/193354712-a136bc16-dba3-405e-a5c8-e959fab4d086.png)


 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
