### PR TITLE
[image] Add a future new base implementation on iOS

### DIFF
--- a/packages/expo-image/ios/ImageCacheType.swift
+++ b/packages/expo-image/ios/ImageCacheType.swift
@@ -1,0 +1,24 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+import SDWebImage
+import ExpoModulesCore
+
+enum ImageCacheType: Int, EnumArgument {
+  case unknown = 0
+  case none = 1
+  case disk = 2
+  case memory = 3
+
+  static func fromSdCacheType(_ sdImageCacheType: SDImageCacheType) -> ImageCacheType {
+    switch sdImageCacheType {
+    case .none:
+      return .none
+    case .disk:
+      return .disk
+    case .memory:
+      return .memory
+    default:
+      return .unknown
+    }
+  }
+}

--- a/packages/expo-image/ios/ImageModule.swift
+++ b/packages/expo-image/ios/ImageModule.swift
@@ -1,0 +1,41 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+import ExpoModulesCore
+import SDWebImage
+
+public final class ImageModule: Module {
+  lazy var prefetcher = SDWebImagePrefetcher.shared
+
+  public func definition() -> ModuleDefinition {
+    Name("ExpoImage")
+
+    View(ImageView.self) {
+      Events(
+        "onLoadStart",
+        "onProgress",
+        "onError",
+        "onLoad"
+      )
+
+      Prop("source") { (view, source: ImageSource) in
+        view.source = source
+      }
+
+      Prop("resizeMode") { (view, resizeMode: ImageResizeMode) in
+        view.resizeMode = resizeMode
+      }
+
+      Prop("transition") { (view, transition: ImageTransition?) in
+        view.transition = transition
+      }
+    }
+
+    Function("clearMemoryCache") {
+      SDImageCache.shared.clearMemory()
+    }
+
+    Function("clearDiskCache") {
+      SDImageCache.shared.clearDisk()
+    }
+  }
+}

--- a/packages/expo-image/ios/ImageResizeMode.swift
+++ b/packages/expo-image/ios/ImageResizeMode.swift
@@ -1,0 +1,24 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+import ExpoModulesCore
+
+enum ImageResizeMode: String, EnumArgument {
+  case cover
+  case contain
+  case stretch
+  case `repeat`
+  case center
+
+  func toContentMode() -> UIView.ContentMode {
+    switch self {
+    case .cover:
+      return .scaleAspectFill
+    case .contain:
+      return .scaleAspectFit
+    case .stretch, .repeat:
+      return .scaleToFill
+    case .center:
+      return .center
+    }
+  }
+}

--- a/packages/expo-image/ios/ImageSource.swift
+++ b/packages/expo-image/ios/ImageSource.swift
@@ -1,0 +1,20 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+import ExpoModulesCore
+
+struct ImageSource: Record {
+  @Field
+  var width: Double?
+
+  @Field
+  var height: Double?
+
+  @Field
+  var uri: URL?
+
+  @Field
+  var scale: Double = 1.0
+
+  @Field
+  var headers: [String: String]?
+}

--- a/packages/expo-image/ios/ImageTransition.swift
+++ b/packages/expo-image/ios/ImageTransition.swift
@@ -1,0 +1,73 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+import ExpoModulesCore
+
+enum ImageTransitionTiming: Int, EnumArgument {
+  case none = 0
+  case easeInOut = 1
+  case easeIn = 2
+  case easeOut = 3
+  case linear = 4
+
+  func toAnimationOption() -> UIView.AnimationOptions {
+    switch self {
+    case .none:
+      return []
+    case .easeInOut:
+      return .curveEaseInOut
+    case .easeIn:
+      return .curveEaseIn
+    case .easeOut:
+      return .curveEaseOut
+    case .linear:
+      return .curveLinear
+    }
+  }
+}
+
+enum ImageTransitionEffect: UInt, EnumArgument {
+  case none = 0
+  case crossDissolve = 1
+  case flipFromLeft = 2
+  case flipFromRight = 3
+  case flipFromTop = 4
+  case flipFromBottom = 5
+  case curlUp = 6
+  case curlDown = 7
+
+  func toAnimationOption() -> UIView.AnimationOptions {
+    switch self {
+    case .none:
+      return []
+    case .crossDissolve:
+      return .transitionCrossDissolve
+    case .flipFromLeft:
+      return .transitionFlipFromLeft
+    case .flipFromRight:
+      return .transitionFlipFromRight
+    case .flipFromTop:
+      return .transitionFlipFromTop
+    case .flipFromBottom:
+      return .transitionFlipFromBottom
+    case .curlUp:
+      return .transitionCurlUp
+    case .curlDown:
+      return .transitionCurlDown
+    }
+  }
+}
+
+struct ImageTransition: Record {
+  @Field
+  var duration: Double = 0.1
+
+  @Field
+  var timing: ImageTransitionTiming = .easeInOut
+
+  @Field
+  var effect: ImageTransitionEffect = .crossDissolve
+
+  func toAnimationOptions() -> UIView.AnimationOptions {
+    return [timing.toAnimationOption(), effect.toAnimationOption()]
+  }
+}

--- a/packages/expo-image/ios/ImageUtils.swift
+++ b/packages/expo-image/ios/ImageUtils.swift
@@ -1,0 +1,47 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+import SDWebImage
+import ExpoModulesCore
+
+func cacheTypeToString(_ cacheType: SDImageCacheType) -> String {
+  switch cacheType {
+  case .none:
+    return "none"
+  case .disk:
+    return "disk"
+  case .memory, .all:
+    // `all` doesn't make much sense, so we treat it as `memory`.
+    return "memory"
+  }
+}
+
+func imageFormatToMediaType(_ format: SDImageFormat) -> String? {
+  switch format {
+  case .undefined:
+    return nil
+  case .JPEG:
+    return "image/jpeg"
+  case .PNG:
+    return "image/png"
+  case .GIF:
+    return "image/gif"
+  case .TIFF:
+    return "image/tiff"
+  case .webP:
+    return "image/webp"
+  case .HEIC:
+    return "image/heic"
+  case .HEIF:
+    return "image/heif"
+  case .PDF:
+    return "application/pdf"
+  case .SVG:
+    return "image/svg+xml"
+  default:
+    // On one hand we could remove this clause and always ensure that we have handled
+    // all supported formats (by erroring compilation otherwise).
+    // On the other hand, we do support overriding SDWebImage version,
+    // so we shouldn't fail to compile on SDWebImage versions with.
+    return nil
+  }
+}

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -1,0 +1,147 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+import SDWebImage
+import ExpoModulesCore
+
+private typealias SDWebImageContext = [SDWebImageContextOption: Any]
+
+public final class ImageView: ExpoView {
+  let sdImageView = SDAnimatedImageView(frame: .zero)
+  let imageManager = SDWebImageManager()
+
+  var source: ImageSource? {
+    didSet {
+      loadFromSource(source)
+    }
+  }
+
+  var resizeMode: ImageResizeMode = .cover {
+    didSet {
+      sdImageView.contentMode = resizeMode.toContentMode()
+      loadFromSource(source)
+    }
+  }
+
+  var transition: ImageTransition?
+
+  // MARK: - Events
+
+  @Event
+  var onLoadStart: Callback<Any>
+
+  @Event
+  var onProgress: Callback<Any>
+
+  @Event
+  var onError: Callback<Any>
+
+  @Event
+  var onLoad: Callback<Any>
+
+  // MARK: - ExpoView
+
+  public required init(appContext: AppContext? = nil) {
+    super.init(appContext: appContext)
+
+    clipsToBounds = true
+    sdImageView.contentMode = .scaleAspectFill
+    sdImageView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+    sdImageView.layer.masksToBounds = true
+
+    addSubview(sdImageView)
+  }
+
+  // MARK: - Implementation
+
+  func loadFromSource(_ source: ImageSource?) {
+    guard let source = source else {
+      renderImage(nil)
+      return
+    }
+    var context = SDWebImageContext()
+
+    // Cancel currently running load requests.
+    // Each ImageView instance has its own image manager,
+    // so it doesn't affect other views.
+    if imageManager.isRunning {
+      imageManager.cancelAll()
+    }
+
+    // Modify URL request to add headers.
+    if let headers = source.headers {
+      context[SDWebImageContextOption.downloadRequestModifier] = SDWebImageDownloaderRequestModifier(headers: headers)
+    }
+
+    onLoadStart([:])
+
+    imageManager.loadImage(with: source.uri,
+                           context: context,
+                           progress: imageLoadProgress(_:_:_:),
+                           completed: imageLoadCompleted(_:_:_:_:_:_:))
+  }
+
+  // MARK: - Loading
+
+  private func imageLoadProgress(_ receivedSize: Int, _ expectedSize: Int, _ imageUrl: URL?) {
+    onProgress([
+      "loaded": receivedSize,
+      "total": expectedSize
+    ])
+  }
+
+  private func imageLoadCompleted(
+    _ image: UIImage?,
+    _ data: Data?,
+    _ error: Error?,
+    _ cacheType: SDImageCacheType,
+    _ finished: Bool,
+    _ imageUrl: URL?
+  ) {
+    if let error = error {
+      onError(["error": error.localizedDescription])
+      return
+    }
+    guard finished else {
+      log.debug("Loading the image has been canceled")
+      return
+    }
+    if let image = image {
+      onLoad([
+        "cacheType": cacheTypeToString(cacheType),
+        "source": [
+          "url": imageUrl?.absoluteString,
+          "width": image.size.width,
+          "height": image.size.height,
+          "mediaType": imageFormatToMediaType(image.sd_imageFormat)
+        ]
+      ])
+    }
+    renderImage(processImage(image))
+  }
+
+  // MARK: - Processing
+
+  private func processImage(_ image: UIImage?) -> UIImage? {
+    guard let image = image else {
+      return nil
+    }
+    if resizeMode == .repeat {
+      return image.resizableImage(withCapInsets: .zero, resizingMode: .tile)
+    } else {
+      return image.resizableImage(withCapInsets: .zero, resizingMode: .stretch)
+    }
+  }
+
+  // MARK: - Rendering
+
+  private func renderImage(_ image: UIImage?) {
+    if let transition = transition, transition.duration > 0 {
+      let options = transition.toAnimationOptions()
+      UIView.transition(with: sdImageView, duration: transition.duration, options: options) { [weak sdImageView] in
+        sdImageView?.image = image
+      }
+    } else {
+      sdImageView.image = image
+    }
+  }
+}


### PR DESCRIPTION
# Why

The renewed `expo-image` package needs to be rewritten to the new Expo Modules API. This only adds some basic implementation in the new API, but the package is still using the old one (`EXImage.podspec` doesn't even include Swift files).
Expect more PRs to come out soon.

# How

Rewrote some basic functionality to Swift and the new Expo Modules API

# Test Plan

I have a bunch of more changes ready locally, including new examples in NCL app. Here is the sneak peek:

https://user-images.githubusercontent.com/1714764/193449419-cd79e39f-2730-4676-9c5a-823cdaf07258.mp4
