### PR TITLE
[modules] Fix `global.expo` object installation on iOS

### DIFF
--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.mm
@@ -43,10 +43,7 @@ static NSString *mainObjectPropertyName = @"expo";
     _runtime = jsc::makeJSCRuntime();
 #endif
     _jsCallInvoker = nil;
-
-    // Add the main object to the runtime (`global.expo`).
-    _mainObject = [self createObject];
-    [[self global] defineProperty:mainObjectPropertyName value:_mainObject options:EXJavaScriptObjectPropertyDescriptorEnumerable];
+    [self initializeMainObject];
   }
   return self;
 }
@@ -60,6 +57,7 @@ static NSString *mainObjectPropertyName = @"expo";
     // See explanation for constructor (8): https://en.cppreference.com/w/cpp/memory/shared_ptr/shared_ptr
     _runtime = std::shared_ptr<jsi::Runtime>(std::shared_ptr<jsi::Runtime>(), runtime);
     _jsCallInvoker = callInvoker;
+    [self initializeMainObject];
   }
   return self;
 }
@@ -187,6 +185,15 @@ static NSString *mainObjectPropertyName = @"expo";
 }
 
 #pragma mark - Private
+
+- (void)initializeMainObject
+{
+  if (!_mainObject) {
+    // Add the main object to the runtime (`global.expo`).
+    _mainObject = [self createObject];
+    [[self global] defineProperty:mainObjectPropertyName value:_mainObject options:EXJavaScriptObjectPropertyDescriptorEnumerable];
+  }
+}
 
 - (nonnull EXJavaScriptObject *)createHostFunction:(nonnull NSString *)name
                                          argsCount:(NSInteger)argsCount


### PR DESCRIPTION
# Why

When working on #19273, I didn't notice that `EXJavaScriptRuntime`'s `initWithRuntime:callInvoker:` is not a convenience initializer (it calls `[super init]`, not `[self init]`). As a result, runtimes created with this initializer didn't have `global.expo` object 😅
The issue didn't come out in native unit tests because they use the no-arguments `init` which installed the object correctly.

# How

Ensured that `global.expo` object is created and installed in both initializers.

# Test Plan

`console.log(global.expo)` is now defined and has `modules` host object defined

<!-- disable:changelog-checks -->