### PR TITLE
[docs][expo-localization]: Fix typo

### DIFF
--- a/docs/pages/versions/unversioned/sdk/localization.mdx
+++ b/docs/pages/versions/unversioned/sdk/localization.mdx
@@ -21,7 +21,7 @@ Using the popular library [`i18n-js`](https://github.com/fnando/i18n-js) with `e
 
 ## Usage
 
-Let's make our app support English and Japanese. To achive this install the i18n package `i18n-js`:
+Let's make our app support English and Japanese. To achieve this install the i18n package `i18n-js`:
 
 <Terminal cmd={['$ npx expo install i18n-js']} />
 

--- a/docs/pages/versions/v45.0.0/sdk/localization.mdx
+++ b/docs/pages/versions/v45.0.0/sdk/localization.mdx
@@ -21,7 +21,7 @@ Using the popular library [`i18n-js`](https://github.com/fnando/i18n-js) with `e
 
 ## Usage
 
-Let's make our app support English and Japanese. To achive this install the i18n package `i18n-js`:
+Let's make our app support English and Japanese. To achieve this install the i18n package `i18n-js`:
 
 <Terminal cmd={['$ expo install i18n-js']} />
 

--- a/docs/pages/versions/v46.0.0/sdk/localization.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/localization.mdx
@@ -21,7 +21,7 @@ Using the popular library [`i18n-js`](https://github.com/fnando/i18n-js) with `e
 
 ## Usage
 
-Let's make our app support English and Japanese. To achive this install the i18n package `i18n-js`:
+Let's make our app support English and Japanese. To achieve this install the i18n package `i18n-js`:
 
 <Terminal cmd={['$ expo install i18n-js']} />
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
Motivation to contribute to open source and hacktoberfest 2022
# How

<!--
How did you build this feature or fix this bug and why?
-->
It is a typo fixed on localization page
# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
No tests were made as it is a typo fixed
# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
