### PR TITLE
[docs] fix spacing inside LI elements, fix FCM guide appearance

### DIFF
--- a/docs/components/base/list.tsx
+++ b/docs/components/base/list.tsx
@@ -74,7 +74,6 @@ export const OL = ({ children }: OLProps) => (
 
 const STYLES_LIST_ITEM = css`
   margin-left: ${spacing[4]}px;
-  padding: ${spacing[1]}px 0;
 
   :before {
     font-size: 130%;
@@ -82,10 +81,6 @@ const STYLES_LIST_ITEM = css`
     margin: 0 ${spacing[2]}px 0 -${spacing[4]}px;
     position: relative;
     color: ${theme.text.default};
-  }
-
-  > div {
-    display: inline;
   }
 `;
 

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -880,7 +880,7 @@ in here.
         data-text="true"
       >
         <li
-          class="docs-list-item css-1yzgz3v-LI"
+          class="docs-list-item css-1vg85kg-LI"
         >
           <code
             class="inline css-ov7own-InlineCode"
@@ -1193,7 +1193,7 @@ This should come from the user field of an
       data-text="true"
     >
       <li
-        class="docs-list-item css-1yzgz3v-LI"
+        class="docs-list-item css-1vg85kg-LI"
       >
         <svg
           class="css-1a9xr20"
@@ -1380,7 +1380,7 @@ value depending on the state of the credential.
       data-text="true"
     >
       <li
-        class="docs-list-item css-1yzgz3v-LI"
+        class="docs-list-item css-1vg85kg-LI"
       >
         <svg
           class="css-1a9xr20"
@@ -1641,7 +1641,7 @@ Calling this method will show the sign in modal before actually refreshing the u
       data-text="true"
     >
       <li
-        class="docs-list-item css-1yzgz3v-LI"
+        class="docs-list-item css-1vg85kg-LI"
       >
         <svg
           class="css-1a9xr20"
@@ -1958,7 +1958,7 @@ the user, since this remains the same for apps released by the same developer.
       data-text="true"
     >
       <li
-        class="docs-list-item css-1yzgz3v-LI"
+        class="docs-list-item css-1vg85kg-LI"
       >
         <svg
           class="css-1a9xr20"
@@ -2261,7 +2261,7 @@ from using
       data-text="true"
     >
       <li
-        class="docs-list-item css-1yzgz3v-LI"
+        class="docs-list-item css-1vg85kg-LI"
       >
         <svg
           class="css-1a9xr20"
@@ -2562,7 +2562,7 @@ sign-out operation.
       data-text="true"
     >
       <li
-        class="docs-list-item css-1yzgz3v-LI"
+        class="docs-list-item css-1vg85kg-LI"
       >
         <svg
           class="css-1a9xr20"
@@ -7174,7 +7174,7 @@ Same as
         data-text="true"
       >
         <li
-          class="docs-list-item css-1yzgz3v-LI"
+          class="docs-list-item css-1vg85kg-LI"
         >
           <code
             class="inline css-ov7own-InlineCode"
@@ -7526,7 +7526,7 @@ This can be used to quickly create specific permission hooks in every module.
       data-text="true"
     >
       <li
-        class="docs-list-item css-1yzgz3v-LI"
+        class="docs-list-item css-1vg85kg-LI"
       >
         <svg
           class="css-1a9xr20"
@@ -7774,7 +7774,7 @@ This can be used to quickly create specific permission hooks in every module.
       data-text="true"
     >
       <li
-        class="docs-list-item css-1yzgz3v-LI"
+        class="docs-list-item css-1vg85kg-LI"
       >
         <svg
           class="css-1a9xr20"
@@ -7979,7 +7979,7 @@ This can be used to quickly create specific permission hooks in every module.
       data-text="true"
     >
       <li
-        class="docs-list-item css-1yzgz3v-LI"
+        class="docs-list-item css-1vg85kg-LI"
       >
         <svg
           class="css-1a9xr20"
@@ -8308,7 +8308,7 @@ the platform.
       data-text="true"
     >
       <li
-        class="docs-list-item css-1yzgz3v-LI"
+        class="docs-list-item css-1vg85kg-LI"
       >
         <svg
           class="css-1a9xr20"
@@ -10534,7 +10534,7 @@ exports[`APISection expo-pedometer 1`] = `
       data-text="true"
     >
       <li
-        class="docs-list-item css-1yzgz3v-LI"
+        class="docs-list-item css-1vg85kg-LI"
       >
         <svg
           class="css-1a9xr20"
@@ -10806,7 +10806,7 @@ exports[`APISection expo-pedometer 1`] = `
       data-text="true"
     >
       <li
-        class="docs-list-item css-1yzgz3v-LI"
+        class="docs-list-item css-1vg85kg-LI"
       >
         <svg
           class="css-1a9xr20"
@@ -11051,7 +11051,7 @@ a start date that is more than seven days in the past returns only the available
       data-text="true"
     >
       <li
-        class="docs-list-item css-1yzgz3v-LI"
+        class="docs-list-item css-1vg85kg-LI"
       >
         <svg
           class="css-1a9xr20"
@@ -11222,7 +11222,7 @@ available on this device.
       data-text="true"
     >
       <li
-        class="docs-list-item css-1yzgz3v-LI"
+        class="docs-list-item css-1vg85kg-LI"
       >
         <svg
           class="css-1a9xr20"
@@ -11470,7 +11470,7 @@ provided with a single argument that is
       data-text="true"
     >
       <li
-        class="docs-list-item css-1yzgz3v-LI"
+        class="docs-list-item css-1vg85kg-LI"
       >
         <svg
           class="css-1a9xr20"

--- a/docs/pages/push-notifications/using-fcm.mdx
+++ b/docs/pages/push-notifications/using-fcm.mdx
@@ -5,7 +5,7 @@ sidebar_title: Using FCM
 
 **Firebase Cloud Messaging is required for all Android apps using Expo SDK**, unless you're still running your app in the Expo Go app. To set up your Expo Android app to get push notifications using your own FCM credentials, follow this guide closely.
 
-Note that FCM is not currently available for `expo-notifications` on iOS.
+> **info** Note that FCM is not currently available for `expo-notifications` on iOS.
 
 ## Client Setup
 
@@ -14,37 +14,37 @@ Note that FCM is not currently available for `expo-notifications` on iOS.
 2. In your new project console, click **Add Firebase to your Android app** and follow the setup steps. **Make sure that the Android package name you enter is the same as the value of `android.package` in your app.json.**
 
 3. Download the `google-services.json` file and place it in your app's root directory.
-   > **Note:** The `google-services.json` file contains unique and non-secret identifiers of your Firebase project. For more information, see [Understand Firebase Projects](https://firebase.google.com/docs/projects/learn-more#config-files-objects).
-4. In your app.json, add an `android.googleServicesFile` field with the relative path to the `google-services.json` file you just downloaded. If you placed it in the root directory, this will probably look like
+    > **Note:** The `google-services.json` file contains unique and non-secret identifiers of your Firebase project. For more information, see [Understand Firebase Projects](https://firebase.google.com/docs/projects/learn-more#config-files-objects).
 
-```javascript
-{
-  ...
-  "android": {
-    "googleServicesFile": "./google-services.json",
-    ...
-  }
-}
-```
+4. In your app.json, add an `android.googleServicesFile` field with the relative path to the `google-services.json` file you just downloaded. If you placed it in the root directory, this will probably look like
+    ```javascript
+    {
+      ...
+      "android": {
+        "googleServicesFile": "./google-services.json",
+        ...
+      }
+    }
+    ```
 
 5. Confirm that your API key in `google-services.json` has the correct "API restrictions" in the [Google Cloud Platform API Credentials console](https://console.cloud.google.com/apis/credentials). For push notifications to work correctly, Firebase requires the API key to either be unrestricted (the key can call any API), or have access to both `Firebase Cloud Messaging API` and `Firebase Installations API`. The API key can be found under the `client.api_key.current_key` field in `google-services.json`.
 
-```javascript
-{
-  ...
-  "client": [
+    ```javascript
     {
-      "api_key": [
+      ...
+      "client": [
         {
-          "current_key" "<your Google Cloud Platform API key>",
+          "api_key": [
+            {
+              "current_key" "<your Google Cloud Platform API key>",
+            }
+          ],
         }
-      ],
+      ]
     }
-  ]
-}
-```
+    ```
 
-> **Note:** Firebase will create an API key in the Google Cloud Platform console with a name like `Android key (auto created by Firebase)`. **This is not always the same key as the one found in `google-services.json`. Always confirm your key and associated restrictions in the Google Cloud Platform console.**
+    > **Note:** Firebase will create an API key in the Google Cloud Platform console with a name like `Android key (auto created by Firebase)`. **This is not always the same key as the one found in `google-services.json`. Always confirm your key and associated restrictions in the Google Cloud Platform console.**
 
 6. Finally, make a new build of your app by running `eas build --platform android` (or `expo build:android` if you're using the classic build system).
 
@@ -65,7 +65,9 @@ In order for Expo to send notifications from our servers using your credentials,
 
 3. Copy the token listed next to **Server key**.
 
-   > Server Key is only available in **Cloud Messaging API (Legacy)**, which may be disabled by default. Enable it by clicking the 3-dot menu > Manage API in Google Cloud Console and follow the flow there. Once the legacy messaging API is enabled, you should see Server Key in that section.
+   > Server Key is only available in **Cloud Messaging API (Legacy)**, which may be disabled by default.
+   >
+   > Enable it by clicking the 3-dot menu > **Manage API in Google Cloud Console** and follow the flow there. Once the legacy messaging API is enabled, you should see Server Key in that section.
 
 4. In your [Expo account's](https://expo.dev/) dashboard, select your project, and click on **Credentials** in the navigation menu. Then, click on your **Application Identifier** that follows the pattern:`com.company.app`.
 


### PR DESCRIPTION
# Why

Fixes ENG-6527

# How

Remove the force inlined display inside the list elements, adjust spacing accordingly (spacing between elements will be a bit different than earlier, but the updated spacing better matches the mock anyway).

Additionally, I have updated the FCM page content to fix broken steps enumeration (better alternative fix will be pushed in the future, in form of the Step component).

# Test Plan

The changes have been tested by running docs website locally.

# Preview

<img width="1151" alt="Screenshot 2022-10-03 at 16 50 53" src="https://user-images.githubusercontent.com/719641/193609531-746068b3-e1c9-4c9c-a139-653f81ea54ec.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
