### PR TITLE
[core][dev-client] Support react-native nightly builds

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed build errors when testing on React Native nightly builds. ([#19369](https://github.com/expo/expo/pull/19369) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 2.0.0 — 2022-10-27

--- a/packages/expo-dev-launcher/android/build.gradle
+++ b/packages/expo-dev-launcher/android/build.gradle
@@ -192,7 +192,12 @@ def getNodeModulesPackageVersion(packageName, overridePropName) {
 }
 
 def getRNVersion() {
-  return getNodeModulesPackageVersion("react-native", "reactNativeVersion")
+  def versionNumber = getNodeModulesPackageVersion("react-native", "reactNativeVersion")
+  if (versionNumber == versionToNumber(0, 0, 0)) {
+    // react-native nightly build published as `0.0.0-20221002-2027-2319f75c8` form, but its semantic is latest
+    return versionToNumber(9999, 9999, 9999)
+  }
+  return versionNumber
 }
 
 def getExpoPackageVersion() {

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed build errors when testing on React Native nightly builds. ([#19369](https://github.com/expo/expo/pull/19369) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 2.0.0 — 2022-10-27

--- a/packages/expo-dev-menu/android/build.gradle
+++ b/packages/expo-dev-menu/android/build.gradle
@@ -14,6 +14,10 @@ def reactNativeFilePath = ["node", "--print", "require.resolve('react-native/pac
 def inputFile = new File(reactNativeFilePath)
 def json = new JsonSlurper().parseText(inputFile.text)
 def reactNativeVersion = json.version as String
+if (reactNativeVersion.startsWith('0.0.0-')) {
+  // react-native nightly build published as `0.0.0-20221002-2027-2319f75c8` form, but its semantic is latest
+  reactNativeVersion = '9999.9999.9999'
+}
 def (major, minor, patch) = reactNativeVersion.tokenize('.')
 
 def engine = "jsc"

--- a/packages/expo-dev-menu/expo-dev-menu.podspec
+++ b/packages/expo-dev-menu/expo-dev-menu.podspec
@@ -10,6 +10,8 @@ rescue
   reactVersion = '0.66.0'
 end
 
+# react-native nightly build published as `0.0.0-20221002-2027-2319f75c8` form, but its semantic is latest
+reactVersion = '9999.9999.9999' if reactVersion.start_with?('0.0.0-')
 splitedReactVersion = reactVersion.split('.')
 rnVersion = splitedReactVersion[1]
 rnPatchVersion = splitedReactVersion[2]

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed build errors when testing on React Native nightly builds. ([#19369](https://github.com/expo/expo/pull/19369) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 0.13.3 — 2022-10-30

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -67,7 +67,12 @@ file("$REACT_NATIVE_DIR/ReactAndroid/gradle.properties").withInputStream { react
 def FOLLY_VERSION = reactProperties.getProperty("FOLLY_VERSION")
 def BOOST_VERSION = reactProperties.getProperty("BOOST_VERSION")
 def DOUBLE_CONVERSION_VERSION = reactProperties.getProperty("DOUBLE_CONVERSION_VERSION")
-def REACT_NATIVE_TARGET_VERSION = reactProperties.getProperty("VERSION_NAME").split("\\.")[1].toInteger()
+def REACT_NATIVE_VERSION = reactProperties.getProperty("VERSION_NAME")
+if (REACT_NATIVE_VERSION.startsWith("0.0.0-")) {
+  // react-native nightly build published as `0.0.0-20221002-2027-2319f75c8` form, but its semantic is latest
+  REACT_NATIVE_VERSION = "9999.9999.9999"
+}
+def REACT_NATIVE_TARGET_VERSION = REACT_NATIVE_VERSION.split("\\.")[1].toInteger()
 
 def reactNativeThirdParty = new File("$REACT_NATIVE_DIR/ReactAndroid/src/main/jni/third-party")
 

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed build errors when testing on React Native nightly builds. ([#19369](https://github.com/expo/expo/pull/19369) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 47.0.0-beta.7 — 2022-10-30

--- a/packages/expo/android/build.gradle
+++ b/packages/expo/android/build.gradle
@@ -23,11 +23,12 @@ def getRNVersion() {
   def coreVersion = version.split("-")[0]
   def (major, minor, patch) = coreVersion.tokenize('.').collect { it.toInteger() }
 
-  return versionToNumber(
-      major,
-      minor,
-      patch
-  )
+  def versionNumber = versionToNumber(major, minor, patch)
+  if (versionNumber == versionToNumber(0, 0, 0)) {
+    // react-native nightly build published as `0.0.0-20221002-2027-2319f75c8` form, but its semantic is latest
+    return versionToNumber(9999, 9999, 9999)
+  }
+  return versionNumber
 }
 
 ensureDependeciesWereEvaluated(project)


### PR DESCRIPTION
# Why

follow up with https://github.com/facebook/react-native/pull/34838#issuecomment-1264675931 to support nightly build

# How

override react-native version as `9999.9999.9999` when it's `0.0.0-` prefixed

# Test Plan

1. adding a react-native nightly version and remove all 3rd party libraries from bare-expo
2. do some manual changes
  - _packages/expo/android/src/main/java/expo/modules/ReactNativeHostWrapperBase.kt_ to remove deprecated `getUIImplementationProvider`
3. test ios / android build

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
