### PR TITLE
Update react native webview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Package-specific changes not released in any SDK will be added here just before 
 ## Unpublished
 
 ### 📚 3rd party library updates
+
 - Updated `@stripe/stripe-react-native` from `0.13.1` to `0.18.1` on iOS. ([#19055](https://github.com/expo/expo/pull/19055) by [@tsapeta](https://github.com/tsapeta))
 - Updated `@shopify/flash-list` from `1.1.0` to `1.3.0`. ([#19317](https://github.com/expo/expo/pull/19317) by [@kudo](https://github.com/kudo))
 - Updated `react-native-webview` from `11.23.0` to `11.23.1`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Package-specific changes not released in any SDK will be added here just before 
 
 - Updated `@stripe/stripe-react-native` from `0.13.1` to `0.18.1` on iOS. ([#19055](https://github.com/expo/expo/pull/19055) by [@tsapeta](https://github.com/tsapeta))
 - Updated `@shopify/flash-list` from `1.1.0` to `1.3.0`. ([#19317](https://github.com/expo/expo/pull/19317) by [@kudo](https://github.com/kudo))
-- Updated `react-native-webview` from `11.23.0` to `11.23.1`.
+- Updated `react-native-webview` from `11.23.0` to `11.23.1`. ([#19375](https://github.com/expo/expo/pull/19375) by [@aleqsio](https://github.com/aleqsio))
 
 ### 🛠 Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ Package-specific changes not released in any SDK will be added here just before 
 ## Unpublished
 
 ### 📚 3rd party library updates
-
 - Updated `@stripe/stripe-react-native` from `0.13.1` to `0.18.1` on iOS. ([#19055](https://github.com/expo/expo/pull/19055) by [@tsapeta](https://github.com/tsapeta))
 - Updated `@shopify/flash-list` from `1.1.0` to `1.3.0`. ([#19317](https://github.com/expo/expo/pull/19317) by [@kudo](https://github.com/kudo))
+- Updated `react-native-webview` from `11.23.0` to `11.23.1`.
 
 ### 🛠 Breaking changes
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/webview/RNCWebViewManager.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/webview/RNCWebViewManager.java
@@ -316,13 +316,10 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
     if (enabled) {
       Context ctx = view.getContext();
       if (ctx != null) {
-        view.getSettings().setAppCachePath(ctx.getCacheDir().getAbsolutePath());
         view.getSettings().setCacheMode(WebSettings.LOAD_DEFAULT);
-        view.getSettings().setAppCacheEnabled(true);
       }
     } else {
       view.getSettings().setCacheMode(WebSettings.LOAD_NO_CACHE);
-      view.getSettings().setAppCacheEnabled(false);
     }
   }
 
@@ -521,7 +518,6 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
     // Disable caching
     view.getSettings().setCacheMode(WebSettings.LOAD_NO_CACHE);
-    view.getSettings().setAppCacheEnabled(false);
     view.clearHistory();
     view.clearCache(true);
 

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -119,7 +119,7 @@
     "react-native-shared-element": "0.8.4",
     "react-native-svg": "12.3.0",
     "react-native-view-shot": "3.3.0",
-    "react-native-webview": "11.22.4",
+    "react-native-webview": "11.23.1",
     "test-suite": "*"
   },
   "devDependencies": {

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -157,7 +157,7 @@
     "react-native-svg": "12.3.0",
     "react-native-view-shot": "3.3.0",
     "react-native-web": "~0.18.9",
-    "react-native-webview": "11.22.4",
+    "react-native-webview": "11.23.1",
     "react-navigation": "^4.4.0",
     "react-navigation-shared-element": "^3.1.2",
     "react-navigation-stack": "^2.8.2",

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1944,7 +1944,7 @@ PODS:
     - React
     - React-callinvoker
     - React-Core
-  - react-native-webview (11.22.4):
+  - react-native-webview (11.23.1):
     - React-Core
   - React-perflogger (0.70.1)
   - React-RCTActionSheet (0.70.1):
@@ -3495,7 +3495,7 @@ SPEC CHECKSUMS:
   react-native-safe-area-context: 6c12e3859b6f27b25de4fee8201cfb858432d8de
   react-native-segmented-control: 06607462630512ff8eef652ec560e6235a30cc3e
   react-native-skia: faacd6a970a757d67c4f4a44a31d347651abbb8e
-  react-native-webview: a1ed211d50a5047a4fe54e07140991e277cd66e6
+  react-native-webview: d33e2db8925d090871ffeb232dfa50cb3a727581
   React-perflogger: 48c6b363e867d64b682e84f80ca45636bd65e19c
   React-RCTActionSheet: 33c74fe5c754835e3715c300618da9aa2f7203fa
   React-RCTAnimation: 2dbf0120d4d1ab7716079b4180f2ca89c465e46b

--- a/ios/vendored/unversioned/react-native-webview/apple/RNCWebView.m
+++ b/ios/vendored/unversioned/react-native-webview/apple/RNCWebView.m
@@ -1143,9 +1143,13 @@ RCTAutoInsetsProtocol>
   
   if (_onShouldStartLoadWithRequest) {
     NSMutableDictionary<NSString *, id> *event = [self baseEvent];
+    if (request.mainDocumentURL) {
+      [event addEntriesFromDictionary: @{
+        @"mainDocumentURL": (request.mainDocumentURL).absoluteString,
+      }];
+    }
     [event addEntriesFromDictionary: @{
       @"url": (request.URL).absoluteString,
-      @"mainDocumentURL": (request.mainDocumentURL).absoluteString,
       @"navigationType": navigationTypes[@(navigationType)],
       @"isTopFrame": @(isTopFrame)
     }];

--- a/ios/vendored/unversioned/react-native-webview/react-native-webview.podspec.json
+++ b/ios/vendored/unversioned/react-native-webview/react-native-webview.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-webview",
-  "version": "11.22.4",
+  "version": "11.23.1",
   "summary": "React Native WebView component for iOS, Android, macOS, and Windows",
   "license": "MIT",
   "authors": "Jamon Holmgren <jamon@infinite.red>",
@@ -11,7 +11,7 @@
   },
   "source": {
     "git": "https://github.com/react-native-webview/react-native-webview.git",
-    "tag": "v11.22.4"
+    "tag": "v11.23.1"
   },
   "source_files": "apple/**/*.{h,m}",
   "dependencies": {

--- a/packages/expo-test-runner/package.json
+++ b/packages/expo-test-runner/package.json
@@ -10,13 +10,13 @@
     "expo-test-runner": "bin/expo-test-runner.js"
   },
   "repository": {
-		"type": "git",
-		"url": "git+https://github.com/expo/expo-test-runner.git"
-	},
+    "type": "git",
+    "url": "git+https://github.com/expo/expo-test-runner.git"
+  },
   "bugs": {
-		"url": "https://github.com/expo/expo-test-runner/issues"
-	},
-	"homepage": "https://github.com/expo/expo-test-runner#readme",
+    "url": "https://github.com/expo/expo-test-runner/issues"
+  },
+  "homepage": "https://github.com/expo/expo-test-runner#readme",
   "scripts": {
     "build": "expo-module build",
     "clean": "expo-module clean",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -100,7 +100,7 @@
   "react-native-shared-element": "0.8.4",
   "react-native-svg": "12.3.0",
   "react-native-view-shot": "3.3.0",
-  "react-native-webview": "11.23.0",
+  "react-native-webview": "11.23.1",
   "sentry-expo": "~5.0.0",
   "unimodules-app-loader": "~3.1.0",
   "unimodules-image-loader-interface": "~6.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17430,10 +17430,10 @@ react-native-web@~0.18.9:
     postcss-value-parser "^4.2.0"
     styleq "^0.1.2"
 
-react-native-webview@11.22.4:
-  version "11.22.4"
-  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-11.22.4.tgz#0381b09ed33ad3c1f9d5c40a6c619dc9306757d8"
-  integrity sha512-nhDibIY2wzjA1Ydn0Kiydx5e20XJ3QWTi2wgIq4iq76pI186fqtcgcsaT69XUGLM0C2iQSn33d/joDgW20pFWg==
+react-native-webview@11.23.1:
+  version "11.23.1"
+  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-11.23.1.tgz#6a4bf2620e491dd4fecf4e6dc079005117fae12c"
+  integrity sha512-bmqsdg4RYOUYD37R9XTrQALm7eD62KbLNPRfgvpLGd1SjaurvAjjsLrLN4mt6yOtKOMKeZvlcAl3x6De6cCQsA==
   dependencies:
     escape-string-regexp "2.0.0"
     invariant "2.2.4"


### PR DESCRIPTION
# Why

To update Expo Go bundled vendored module `react-native-webview` to latest versions for SDK47

# How

Running et update tool.

# Test Plan

Tested manually using native component list both on Expo Go iOS and Expo Go Android

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).

<!-- disable:changelog-checks -->