### PR TITLE
[docs] Fix broken links to expo/fyi

### DIFF
--- a/docs/pages/app-signing/app-credentials.mdx
+++ b/docs/pages/app-signing/app-credentials.mdx
@@ -67,7 +67,7 @@ See [here](https://developer.android.com/studio/publish/app-signing) to find mor
 
 ### App signing by Google Play
 
-When you [upload your first release to Google Play](https://github.com/expo/fyi/blob/master/first-android-submission.md) you will see a notice about "App signing by Google Play" and "Google is protecting your app signing key". This is the default behavior and requires no action on your behalf except to press "Continue".
+When you [upload your first release to Google Play](https://expo.fyi/first-android-submission) you will see a notice about "App signing by Google Play" and "Google is protecting your app signing key". This is the default behavior and requires no action on your behalf except to press "Continue".
 
 > If you lose your upload keystore (or it's compromised), you must ask the Google Support Team to reset your upload key.
 

--- a/docs/pages/app-signing/app-credentials.mdx
+++ b/docs/pages/app-signing/app-credentials.mdx
@@ -67,7 +67,7 @@ See [here](https://developer.android.com/studio/publish/app-signing) to find mor
 
 ### App signing by Google Play
 
-When you [upload your first release to Google Play](https://github.com/expo/fyi/blob/master/first-android-submission.mdx) you will see a notice about "App signing by Google Play" and "Google is protecting your app signing key". This is the default behavior and requires no action on your behalf except to press "Continue".
+When you [upload your first release to Google Play](https://github.com/expo/fyi/blob/master/first-android-submission.md) you will see a notice about "App signing by Google Play" and "Google is protecting your app signing key". This is the default behavior and requires no action on your behalf except to press "Continue".
 
 > If you lose your upload keystore (or it's compromised), you must ask the Google Support Team to reset your upload key.
 

--- a/docs/pages/versions/unversioned/sdk/notifications.mdx
+++ b/docs/pages/versions/unversioned/sdk/notifications.mdx
@@ -19,7 +19,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 
 The **`expo-notifications`** provides an API to fetch push notification tokens and to present, schedule, receive and respond to notifications.
 
-> Migrating from Expo's `LegacyNotifications` module? [Here's a guide to help make the transition as easy as possible](https://github.com/expo/fyi/blob/master/LegacyNotifications-to-ExpoNotifications.md).
+> Migrating from Expo's `LegacyNotifications` module? [Here's a guide to help make the transition as easy as possible](https://expo.fyi/legacy-notifications-to-expo-notifications).
 
 <PlatformsSection title="Push notifications Platform Compatibility" android ios />
 

--- a/docs/pages/versions/unversioned/sdk/notifications.mdx
+++ b/docs/pages/versions/unversioned/sdk/notifications.mdx
@@ -19,7 +19,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 
 The **`expo-notifications`** provides an API to fetch push notification tokens and to present, schedule, receive and respond to notifications.
 
-> Migrating from Expo's `LegacyNotifications` module? [Here's a guide to help make the transition as easy as possible](https://github.com/expo/fyi/blob/master/LegacyNotifications-to-ExpoNotifications.mdx).
+> Migrating from Expo's `LegacyNotifications` module? [Here's a guide to help make the transition as easy as possible](https://github.com/expo/fyi/blob/master/LegacyNotifications-to-ExpoNotifications.md).
 
 <PlatformsSection title="Push notifications Platform Compatibility" android ios />
 
@@ -33,17 +33,17 @@ The **`expo-notifications`** provides an API to fetch push notification tokens a
 
 ## Features
 
-- 📣 schedule a one-off notification for a specific date, or some time from now,
-- 🔁 schedule a notification repeating in some time interval (or a calendar date match on iOS),
-- 💯 get and set application badge icon number,
-- 📲 fetch a native device push token so you can send push notifications with FCM and APNS,
-- 😎 fetch an Expo push token so you can send push notifications with Expo,
-- 📬 listen to incoming notifications in the foreground and background,
-- 👆 listen to interactions with notifications,
-- 🎛 handle notifications when the app is in foreground,
-- 🔕 imperatively dismiss notifications from Notification Center/tray,
-- 🗂 create, update, delete Android notification channels,
-- 🎨 set custom icon and color for notifications on Android.
+- Schedule a one-off notification for a specific date, or some time from now,
+- Schedule a notification repeating in some time interval (or a calendar date match on iOS),
+- Get and set application badge icon number,
+- Fetch a native device push token so you can send push notifications with FCM and APNS,
+- Fetch an Expo push token so you can send push notifications with Expo,
+- Listen to incoming notifications in the foreground and background,
+- Listen to interactions with notifications,
+- Handle notifications when the app is in foreground,
+- Imperatively dismiss notifications from Notification Center/tray,
+- Create, update, delete Android notification channels,
+- Set custom icon and color for notifications on Android.
 
 ## Installation
 

--- a/docs/pages/versions/v43.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v43.0.0/sdk/notifications.mdx
@@ -18,21 +18,21 @@ import { Collapsible } from '~/ui/components/Collapsible';
 
 The **`expo-notifications`** provides an API to fetch push notification tokens and to present, schedule, receive and respond to notifications.
 
-> Migrating from Expo's `LegacyNotifications` module? [Here's a guide to help make the transition as easy as possible](https://github.com/expo/fyi/blob/master/LegacyNotifications-to-ExpoNotifications.mdx).
+> Migrating from Expo's `LegacyNotifications` module? [Here's a guide to help make the transition as easy as possible](https://github.com/expo/fyi/blob/master/LegacyNotifications-to-ExpoNotifications.md).
 
 ### Features
 
-- 📣 schedule a one-off notification for a specific date, or some time from now,
-- 🔁 schedule a notification repeating in some time interval (or a calendar date match on iOS),
-- 💯 get and set application badge icon number,
-- 📲 fetch a native device push token so you can send push notifications with FCM and APNS,
-- 😎 fetch an Expo push token so you can send push notifications with Expo,
-- 📬 listen to incoming notifications in the foreground and background,
-- 👆 listen to interactions with notifications,
-- 🎛 handle notifications when the app is in foreground,
-- 🔕 imperatively dismiss notifications from Notification Center/tray,
-- 🗂 create, update, delete Android notification channels,
-- 🎨 set custom icon and color for notifications on Android.
+- Schedule a one-off notification for a specific date, or some time from now,
+- Schedule a notification repeating in some time interval (or a calendar date match on iOS),
+- Get and set application badge icon number,
+- Fetch a native device push token so you can send push notifications with FCM and APNS,
+- Fetch an Expo push token so you can send push notifications with Expo,
+- Listen to incoming notifications in the foreground and background,
+- Listen to interactions with notifications,
+- Handle notifications when the app is in foreground,
+- Imperatively dismiss notifications from Notification Center/tray,
+- Create, update, delete Android notification channels,
+- Set custom icon and color for notifications on Android.
 
 <PlatformsSection title="Push notifications Platform Compatibility" android ios />
 

--- a/docs/pages/versions/v43.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v43.0.0/sdk/notifications.mdx
@@ -18,7 +18,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 
 The **`expo-notifications`** provides an API to fetch push notification tokens and to present, schedule, receive and respond to notifications.
 
-> Migrating from Expo's `LegacyNotifications` module? [Here's a guide to help make the transition as easy as possible](https://github.com/expo/fyi/blob/master/LegacyNotifications-to-ExpoNotifications.md).
+> Migrating from Expo's `LegacyNotifications` module? [Here's a guide to help make the transition as easy as possible](https://expo.fyi/legacy-notifications-to-expo-notifications).
 
 ### Features
 

--- a/docs/pages/versions/v44.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v44.0.0/sdk/notifications.mdx
@@ -18,21 +18,21 @@ import { Collapsible } from '~/ui/components/Collapsible';
 
 The **`expo-notifications`** provides an API to fetch push notification tokens and to present, schedule, receive and respond to notifications.
 
-> Migrating from Expo's `LegacyNotifications` module? [Here's a guide to help make the transition as easy as possible](https://github.com/expo/fyi/blob/master/LegacyNotifications-to-ExpoNotifications.mdx).
+> Migrating from Expo's `LegacyNotifications` module? [Here's a guide to help make the transition as easy as possible](https://github.com/expo/fyi/blob/master/LegacyNotifications-to-ExpoNotifications.md).
 
 ### Features
 
-- 📣 schedule a one-off notification for a specific date, or some time from now,
-- 🔁 schedule a notification repeating in some time interval (or a calendar date match on iOS),
-- 💯 get and set application badge icon number,
-- 📲 fetch a native device push token so you can send push notifications with FCM and APNS,
-- 😎 fetch an Expo push token so you can send push notifications with Expo,
-- 📬 listen to incoming notifications in the foreground and background,
-- 👆 listen to interactions with notifications,
-- 🎛 handle notifications when the app is in foreground,
-- 🔕 imperatively dismiss notifications from Notification Center/tray,
-- 🗂 create, update, delete Android notification channels,
-- 🎨 set custom icon and color for notifications on Android.
+- Schedule a one-off notification for a specific date, or some time from now,
+- Schedule a notification repeating in some time interval (or a calendar date match on iOS),
+- Get and set application badge icon number,
+- Fetch a native device push token so you can send push notifications with FCM and APNS,
+- Fetch an Expo push token so you can send push notifications with Expo,
+- Listen to incoming notifications in the foreground and background,
+- Listen to interactions with notifications,
+- Handle notifications when the app is in foreground,
+- Imperatively dismiss notifications from Notification Center/tray,
+- Create, update, delete Android notification channels,
+- Set custom icon and color for notifications on Android.
 
 <PlatformsSection title="Push notifications Platform Compatibility" android ios />
 

--- a/docs/pages/versions/v44.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v44.0.0/sdk/notifications.mdx
@@ -18,7 +18,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 
 The **`expo-notifications`** provides an API to fetch push notification tokens and to present, schedule, receive and respond to notifications.
 
-> Migrating from Expo's `LegacyNotifications` module? [Here's a guide to help make the transition as easy as possible](https://github.com/expo/fyi/blob/master/LegacyNotifications-to-ExpoNotifications.md).
+> Migrating from Expo's `LegacyNotifications` module? [Here's a guide to help make the transition as easy as possible](https://expo.fyi/legacy-notifications-to-expo-notifications).
 
 ### Features
 

--- a/docs/pages/versions/v45.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v45.0.0/sdk/notifications.mdx
@@ -19,7 +19,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 
 The **`expo-notifications`** provides an API to fetch push notification tokens and to present, schedule, receive and respond to notifications.
 
-> Migrating from Expo's `LegacyNotifications` module? [Here's a guide to help make the transition as easy as possible](https://github.com/expo/fyi/blob/master/LegacyNotifications-to-ExpoNotifications.md).
+> Migrating from Expo's `LegacyNotifications` module? [Here's a guide to help make the transition as easy as possible](https://expo.fyi/legacy-notifications-to-expo-notifications).
 
 <PlatformsSection title="Push notifications Platform Compatibility" android ios />
 

--- a/docs/pages/versions/v45.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v45.0.0/sdk/notifications.mdx
@@ -19,7 +19,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 
 The **`expo-notifications`** provides an API to fetch push notification tokens and to present, schedule, receive and respond to notifications.
 
-> Migrating from Expo's `LegacyNotifications` module? [Here's a guide to help make the transition as easy as possible](https://github.com/expo/fyi/blob/master/LegacyNotifications-to-ExpoNotifications.mdx).
+> Migrating from Expo's `LegacyNotifications` module? [Here's a guide to help make the transition as easy as possible](https://github.com/expo/fyi/blob/master/LegacyNotifications-to-ExpoNotifications.md).
 
 <PlatformsSection title="Push notifications Platform Compatibility" android ios />
 
@@ -33,17 +33,17 @@ The **`expo-notifications`** provides an API to fetch push notification tokens a
 
 ## Features
 
-- 📣 schedule a one-off notification for a specific date, or some time from now,
-- 🔁 schedule a notification repeating in some time interval (or a calendar date match on iOS),
-- 💯 get and set application badge icon number,
-- 📲 fetch a native device push token so you can send push notifications with FCM and APNS,
-- 😎 fetch an Expo push token so you can send push notifications with Expo,
-- 📬 listen to incoming notifications in the foreground and background,
-- 👆 listen to interactions with notifications,
-- 🎛 handle notifications when the app is in foreground,
-- 🔕 imperatively dismiss notifications from Notification Center/tray,
-- 🗂 create, update, delete Android notification channels,
-- 🎨 set custom icon and color for notifications on Android.
+- Schedule a one-off notification for a specific date, or some time from now,
+- Schedule a notification repeating in some time interval (or a calendar date match on iOS),
+- Get and set application badge icon number,
+- Fetch a native device push token so you can send push notifications with FCM and APNS,
+- Fetch an Expo push token so you can send push notifications with Expo,
+- Listen to incoming notifications in the foreground and background,
+- Listen to interactions with notifications,
+- Handle notifications when the app is in foreground,
+- Imperatively dismiss notifications from Notification Center/tray,
+- Create, update, delete Android notification channels,
+- Set custom icon and color for notifications on Android.
 
 ## Installation
 

--- a/docs/pages/versions/v46.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/notifications.mdx
@@ -19,7 +19,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 
 The **`expo-notifications`** provides an API to fetch push notification tokens and to present, schedule, receive and respond to notifications.
 
-> Migrating from Expo's `LegacyNotifications` module? [Here's a guide to help make the transition as easy as possible](https://github.com/expo/fyi/blob/master/LegacyNotifications-to-ExpoNotifications.md).
+> Migrating from Expo's `LegacyNotifications` module? [Here's a guide to help make the transition as easy as possible](https://expo.fyi/legacy-notifications-to-expo-notifications).
 
 <PlatformsSection title="Push notifications Platform Compatibility" android ios />
 

--- a/docs/pages/versions/v46.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/notifications.mdx
@@ -19,7 +19,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 
 The **`expo-notifications`** provides an API to fetch push notification tokens and to present, schedule, receive and respond to notifications.
 
-> Migrating from Expo's `LegacyNotifications` module? [Here's a guide to help make the transition as easy as possible](https://github.com/expo/fyi/blob/master/LegacyNotifications-to-ExpoNotifications.mdx).
+> Migrating from Expo's `LegacyNotifications` module? [Here's a guide to help make the transition as easy as possible](https://github.com/expo/fyi/blob/master/LegacyNotifications-to-ExpoNotifications.md).
 
 <PlatformsSection title="Push notifications Platform Compatibility" android ios />
 
@@ -33,17 +33,17 @@ The **`expo-notifications`** provides an API to fetch push notification tokens a
 
 ## Features
 
-- 📣 schedule a one-off notification for a specific date, or some time from now,
-- 🔁 schedule a notification repeating in some time interval (or a calendar date match on iOS),
-- 💯 get and set application badge icon number,
-- 📲 fetch a native device push token so you can send push notifications with FCM and APNS,
-- 😎 fetch an Expo push token so you can send push notifications with Expo,
-- 📬 listen to incoming notifications in the foreground and background,
-- 👆 listen to interactions with notifications,
-- 🎛 handle notifications when the app is in foreground,
-- 🔕 imperatively dismiss notifications from Notification Center/tray,
-- 🗂 create, update, delete Android notification channels,
-- 🎨 set custom icon and color for notifications on Android.
+- Schedule a one-off notification for a specific date, or some time from now,
+- Schedule a notification repeating in some time interval (or a calendar date match on iOS),
+- Get and set application badge icon number,
+- Fetch a native device push token so you can send push notifications with FCM and APNS,
+- Fetch an Expo push token so you can send push notifications with Expo,
+- Listen to incoming notifications in the foreground and background,
+- Listen to interactions with notifications,
+- Handle notifications when the app is in foreground,
+- Imperatively dismiss notifications from Notification Center/tray,
+- Create, update, delete Android notification channels,
+- Set custom icon and color for notifications on Android.
 
 ## Installation
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Refs https://forums.expo.dev/t/link-on-docs-page-returns-404/66847

# How

<!--
How did you build this feature or fix this bug and why?
-->

There are some broken links to `expo/fyi` repo in `Notifications` and App Credentials pages. This PR fixes those links and removes emojis from the `Notifications` page.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
Run docs locally via `yarn dev` and visit http://localhost:3002/versions/latest/sdk/notifications/ & http://localhost:3002/app-signing/app-credentials/.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
