### PR TITLE
[docs][push-notifications] Update docs with push/send rate limits

### DIFF
--- a/docs/pages/push-notifications/faq.mdx
+++ b/docs/pages/push-notifications/faq.mdx
@@ -13,9 +13,7 @@ There is no cost associated with sending notifications through Expo's classic pu
 
 ### How many notifications can I send through Expo?
 
-We don't impose any limit on the number of push notifications you can send. For best results, we do recommend you add throttling (handled automatically in the [`expo-server-sdk-node`](https://github.com/expo/expo-server-sdk-node)) and retry logic to your server.
-
-Total notifications is much less important than your maximum notification throughput—how many notifications you send per second at peak. If this number is more than a couple hundred, reach out to us because we'd love to hear about what you're working on!
+There is a limit of 600 notifications per second per project that can be sent. If you exceed this rate, subsequent requests will fail until the rate falls below 600 per second again. For best results, we do recommend you add throttling (handled automatically in the [`expo-server-sdk-node`](https://github.com/expo/expo-server-sdk-node)) and retry logic to your server.
 
 ### How do I set up push notifications?
 

--- a/docs/pages/push-notifications/sending-notifications.mdx
+++ b/docs/pages/push-notifications/sending-notifications.mdx
@@ -225,6 +225,8 @@ Inside both push tickets and push receipts, look for a `details` object with an 
 
 If there's an error with the entire request for either push tickets or push receipts, the `errors` object may be one of the following values, and you should handle these errors like so:
 
+- `TOO_MANY_REQUESTS`: you are exceeding the request limit of 600 notifications per second per project. We recommend implementing rate-limiting in your server to prevent sending more than 600 notifications per second (note that if you use [expo-server-sdk-node](https://github.com/expo/expo-server-sdk-node), this is already implemented along with exponential backoffs for retries).
+
 - `PUSH_TOO_MANY_EXPERIENCE_IDS`: you are trying to send push notifications to different Expo experiences, for example `@username/projectAAA` and `@username/projectBBB`. Check the `details` field for a mapping of experience names to their associated push tokens from the request, and remove any from another experience.
 
 - `PUSH_TOO_MANY_NOTIFICATIONS`: you are trying to send more than 100 push notifications in one request. Make sure you are only sending 100 (or less) notifications in each request.


### PR DESCRIPTION
# Why
We're adding a limit of 600 notifications per second in https://github.com/expo/universe/pull/10594. This diff updates the docs to explain the rate limit and how to handle failures/retries.

# How
Update docs in markdown.

# Test Plan
N/A

# Checklist


- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [X] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
