### PR TITLE
[core] Fix module registry initialized twice

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `ModuleRegistry` be initialized twice when startup on Android. ([#19384](https://github.com/expo/expo/pull/19384) by [@kudo](https://github.com/kudo) and [@lukmccall](https://github.com/lukmccall))
+
 ### 💡 Others
 
 ## 0.11.6 — 2022-10-02

--- a/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.cpp
@@ -59,7 +59,7 @@ void JSIInteropModuleRegistry::installJSI(
 
 void JSIInteropModuleRegistry::installJSIForTests() {
 #if !UNIT_TEST
-  throw std::logic_error("The function is only avaiable when UNIT_TEST is defined.");
+  throw std::logic_error("The function is only available when UNIT_TEST is defined.");
 #else
   runtimeHolder = std::make_shared<JavaScriptRuntime>();
   jsi::Runtime &jsiRuntime = *runtimeHolder->get();

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/ModuleRegistryAdapter.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/ModuleRegistryAdapter.java
@@ -1,5 +1,6 @@
 package expo.modules.adapters.react;
 
+import android.util.Log;
 import androidx.annotation.Nullable;
 
 import com.facebook.react.ReactPackage;
@@ -48,7 +49,8 @@ public class ModuleRegistryAdapter implements ReactPackage {
 
   @Override
   public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
-    ModuleRegistry moduleRegistry = mModuleRegistryProvider.get(reactContext);
+    NativeModulesProxy proxy = getOrCreateNativeModulesProxy(reactContext, null);
+    ModuleRegistry moduleRegistry = proxy.getModuleRegistry();
 
     for (InternalModule internalModule : mReactAdapterPackage.createInternalModules(reactContext)) {
       moduleRegistry.registerInternalModule(internalModule);
@@ -56,7 +58,7 @@ public class ModuleRegistryAdapter implements ReactPackage {
 
     List<NativeModule> nativeModules = getNativeModulesFromModuleRegistry(reactContext, moduleRegistry);
     if (mWrapperDelegateHolders != null) {
-      KotlinInteropModuleRegistry kotlinInteropModuleRegistry = getOrCreateNativeModulesProxy(reactContext, null).getKotlinInteropModuleRegistry();
+      KotlinInteropModuleRegistry kotlinInteropModuleRegistry = proxy.getKotlinInteropModuleRegistry();
       kotlinInteropModuleRegistry.updateModuleHoldersInViewManagers(mWrapperDelegateHolders);
     }
 
@@ -105,8 +107,10 @@ public class ModuleRegistryAdapter implements ReactPackage {
     return viewManagerList;
   }
 
-  private NativeModulesProxy getOrCreateNativeModulesProxy(ReactApplicationContext reactContext,
-                                                           @Nullable ModuleRegistry moduleRegistry) {
+  private synchronized NativeModulesProxy getOrCreateNativeModulesProxy(
+    ReactApplicationContext reactContext,
+    @Nullable ModuleRegistry moduleRegistry
+  ) {
     if (mModulesProxy == null) {
       ModuleRegistry registry = moduleRegistry != null ? moduleRegistry : mModuleRegistryProvider.get(reactContext);
       if (mModulesProvider != null) {
@@ -115,6 +119,11 @@ public class ModuleRegistryAdapter implements ReactPackage {
         mModulesProxy = new NativeModulesProxy(reactContext, registry);
       }
     }
+
+    if (moduleRegistry != null && moduleRegistry != mModulesProxy.getModuleRegistry()) {
+      Log.e("expo-modules-core", "NativeModuleProxy was configured with a different instance of the modules registry.");
+    }
+
     return mModulesProxy;
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/ModuleRegistryAdapter.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/ModuleRegistryAdapter.java
@@ -111,6 +111,9 @@ public class ModuleRegistryAdapter implements ReactPackage {
     ReactApplicationContext reactContext,
     @Nullable ModuleRegistry moduleRegistry
   ) {
+    if (mModulesProxy != null && mModulesProxy.getKotlinInteropModuleRegistry().getWasDestroyed()) {
+      mModulesProxy = null;
+    }
     if (mModulesProxy == null) {
       ModuleRegistry registry = moduleRegistry != null ? moduleRegistry : mModuleRegistryProvider.get(reactContext);
       if (mModulesProvider != null) {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/ModuleRegistryAdapter.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/ModuleRegistryAdapter.java
@@ -1,5 +1,7 @@
 package expo.modules.adapters.react;
 
+import androidx.annotation.Nullable;
+
 import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -54,7 +56,7 @@ public class ModuleRegistryAdapter implements ReactPackage {
 
     List<NativeModule> nativeModules = getNativeModulesFromModuleRegistry(reactContext, moduleRegistry);
     if (mWrapperDelegateHolders != null) {
-      KotlinInteropModuleRegistry kotlinInteropModuleRegistry = getOrCreateNativeModulesProxy(reactContext).getKotlinInteropModuleRegistry();
+      KotlinInteropModuleRegistry kotlinInteropModuleRegistry = getOrCreateNativeModulesProxy(reactContext, null).getKotlinInteropModuleRegistry();
       kotlinInteropModuleRegistry.updateModuleHoldersInViewManagers(mWrapperDelegateHolders);
     }
 
@@ -64,7 +66,7 @@ public class ModuleRegistryAdapter implements ReactPackage {
   protected List<NativeModule> getNativeModulesFromModuleRegistry(ReactApplicationContext reactContext, ModuleRegistry moduleRegistry) {
     List<NativeModule> nativeModulesList = new ArrayList<>(2);
 
-    nativeModulesList.add(getOrCreateNativeModulesProxy(reactContext));
+    nativeModulesList.add(getOrCreateNativeModulesProxy(reactContext, moduleRegistry));
 
     // Add listener that will notify expo.modules.core.ModuleRegistry when all modules are ready
     nativeModulesList.add(new ModuleRegistryReadyNotifier(moduleRegistry));
@@ -93,7 +95,7 @@ public class ModuleRegistryAdapter implements ReactPackage {
       }
     }
 
-    NativeModulesProxy modulesProxy = Objects.requireNonNull(getOrCreateNativeModulesProxy(reactContext));
+    NativeModulesProxy modulesProxy = Objects.requireNonNull(getOrCreateNativeModulesProxy(reactContext, null));
     KotlinInteropModuleRegistry kotlinInteropModuleRegistry = modulesProxy.getKotlinInteropModuleRegistry();
     List<ViewManager<?, ?>> kViewManager = kotlinInteropModuleRegistry.exportViewManagers();
     // Saves all holders that needs to be in sync with module registry
@@ -103,13 +105,14 @@ public class ModuleRegistryAdapter implements ReactPackage {
     return viewManagerList;
   }
 
-  private NativeModulesProxy getOrCreateNativeModulesProxy(ReactApplicationContext reactContext) {
+  private NativeModulesProxy getOrCreateNativeModulesProxy(ReactApplicationContext reactContext,
+                                                           @Nullable ModuleRegistry moduleRegistry) {
     if (mModulesProxy == null) {
-      ModuleRegistry moduleRegistry = mModuleRegistryProvider.get(reactContext);
+      ModuleRegistry registry = moduleRegistry != null ? moduleRegistry : mModuleRegistryProvider.get(reactContext);
       if (mModulesProvider != null) {
-        mModulesProxy = new NativeModulesProxy(reactContext, moduleRegistry, mModulesProvider);
+        mModulesProxy = new NativeModulesProxy(reactContext, registry, mModulesProvider);
       } else {
-        mModulesProxy = new NativeModulesProxy(reactContext, moduleRegistry);
+        mModulesProxy = new NativeModulesProxy(reactContext, registry);
       }
     }
     return mModulesProxy;

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/NativeModulesProxy.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/NativeModulesProxy.java
@@ -1,5 +1,6 @@
 package expo.modules.adapters.react;
 
+import android.util.Log;
 import android.util.SparseArray;
 
 import com.facebook.react.bridge.Dynamic;
@@ -127,6 +128,9 @@ public class NativeModulesProxy extends ReactContextBaseJavaModule {
     constants.put(MODULES_CONSTANTS_KEY, modulesConstants);
     constants.put(EXPORTED_METHODS_KEY, exportedMethodsMap);
     constants.put(VIEW_MANAGERS_METADATA_KEY, viewManagersMetadata);
+
+    Log.i("ExpoModulesCore", "✅ Constants was exported");
+
     return constants;
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/NativeModulesProxy.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/NativeModulesProxy.java
@@ -247,4 +247,8 @@ public class NativeModulesProxy extends ReactContextBaseJavaModule {
     mModuleRegistry.onDestroy();
     mKotlinInteropModuleRegistry.onDestroy();
   }
+
+  ModuleRegistry getModuleRegistry() {
+    return mModuleRegistry;
+  }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -5,12 +5,14 @@ package expo.modules.kotlin
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
+import android.util.Log
 import androidx.annotation.MainThread
 import androidx.appcompat.app.AppCompatActivity
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.turbomodule.core.CallInvokerHolderImpl
 import expo.modules.core.errors.ContextDestroyedException
 import expo.modules.core.interfaces.ActivityProvider
+import expo.modules.core.interfaces.JavaScriptContextProvider
 import expo.modules.interfaces.barcodescanner.BarCodeScannerInterface
 import expo.modules.interfaces.camera.CameraViewInterface
 import expo.modules.interfaces.constants.ConstantsInterface
@@ -86,18 +88,25 @@ class AppContext(
    * Initializes a JSI part of the module registry.
    * It will be a NOOP if the remote debugging was activated.
    */
-  fun installJSIInterop() {
-    jsiInterop = JSIInteropModuleRegistry(this)
-    val reactContext = reactContextHolder.get() ?: return
-    reactContext.javaScriptContextHolder?.get()
-      ?.takeIf { it != 0L }
-      ?.let {
-        jsiInterop.installJSI(
-          it,
-          reactContext.catalystInstance.jsCallInvokerHolder as CallInvokerHolderImpl,
-          reactContext.catalystInstance.nativeCallInvokerHolder as CallInvokerHolderImpl
-        )
-      }
+  fun installJSIInterop() = synchronized<Unit>(this) {
+    try {
+      jsiInterop = JSIInteropModuleRegistry(this)
+      val reactContext = reactContextHolder.get() ?: return
+      val jsContextHolder = legacyModule<JavaScriptContextProvider>()?.javaScriptContextRef
+      val catalystInstance = reactContext.catalystInstance ?: return
+      jsContextHolder
+        ?.takeIf { it != 0L }
+        ?.let {
+          jsiInterop.installJSI(
+            it,
+            catalystInstance.jsCallInvokerHolder as CallInvokerHolderImpl,
+            catalystInstance.nativeCallInvokerHolder as CallInvokerHolderImpl
+          )
+          Log.i("ExpoModulesCore", "✅ JSI interop was installed")
+        }
+    } catch (e: Throwable) {
+      Log.e("ExpoModulesCore", "Cannot install JSI interop: $e", e)
+    }
   }
 
   /**

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KotlinInteropModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KotlinInteropModuleRegistry.kt
@@ -25,6 +25,9 @@ class KotlinInteropModuleRegistry(
   private val registry: ModuleRegistry
     get() = appContext.registry
 
+  var wasDestroyed = false
+    private set
+
   fun hasModule(name: String): Boolean = registry.hasModule(name)
 
   fun callMethod(moduleName: String, method: String, arguments: ReadableArray, promise: Promise) {
@@ -108,6 +111,7 @@ class KotlinInteropModuleRegistry(
 
   fun onDestroy() {
     appContext.onDestroy()
+    wasDestroyed = true
   }
 
   fun installJSIInterop() {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleRegistry.kt
@@ -74,5 +74,6 @@ class ModuleRegistry(
     forEach {
       it.cleanUp()
     }
+    registry.clear()
   }
 }


### PR DESCRIPTION
# Why

regression from https://github.com/expo/expo/commit/f9fed44e91dd8caf47d29408a830684d08d04b97 and fixed in main. this pr is cherry-picking the relevant commits to sdk-46.

# How

- partially cherry-pick 512e1329940ce158edcdb91bc91a3d4990578eab
- cherry-pick fd55187745b6f953ab41bff4219853571b73accc
- cherry-pick 72841a140323949bdc1863a8173f627a399b1599

# Test Plan

- [bare-expo] add breakpoint at `NotificationsHandler.onCreate` and check how many times it is called when starting up.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
