### PR TITLE
[core] Fix proguard crash from ExpectedType

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/ExpectedType.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/ExpectedType.kt
@@ -16,16 +16,19 @@ class SingleType(
   /**
    * The representation of the type.
    */
+  @DoNotStrip
   fun getCppType() = expectedCppType.value
 
   /**
    * A convenient property to return the type of the first parameter.
    */
+  @DoNotStrip
   fun getFirstParameterType() = parameterTypes?.get(0)
 
   /**
    * A convenient property to return the type of the second parameter.
    */
+  @DoNotStrip
   fun getSecondParameterType() = parameterTypes?.get(1)
 }
 
@@ -46,15 +49,16 @@ class ExpectedType(
   val innerCombinedTypes: Int = innerPossibleTypes.fold(0) { acc, current -> acc or current.getCppType() }
 
   // Needed by JNI
+  @DoNotStrip
   fun getCombinedTypes() = innerCombinedTypes
 
   // Needed by JNI
+  @DoNotStrip
   fun getPossibleTypes() = innerPossibleTypes
 
-  /**
-   * A convenient property to return the first of possible types.
-   */
-  val firstType = innerPossibleTypes.first()
+  // Needed by JNI
+  @DoNotStrip
+  fun getFirstType() = innerPossibleTypes.first()
 
   operator fun plus(other: ExpectedType): ExpectedType {
     return ExpectedType(


### PR DESCRIPTION
# Why

updates e2e ci is still broken: https://github.com/expo/expo/actions/runs/3172569851/jobs/5167180559

# How

- follow up with #19280 to convert `firstType` as explicit `getFirstType`
- add `@DoNotStrip` annotation to getter methods

# Test Plan

updates e2e ci passed

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
