### PR TITLE
Bump @react-native-picker/picker to 2.4.6

### DIFF
--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -97,7 +97,7 @@
     "@react-native-community/slider": "4.2.3",
     "@react-native-community/viewpager": "5.0.11",
     "@react-native-masked-view/masked-view": "0.2.6",
-    "@react-native-picker/picker": "2.4.2",
+    "@react-native-picker/picker": "2.4.6",
     "@react-native-segmented-control/segmented-control": "2.4.0",
     "expo": "~46.0.0-alpha.0",
     "expo-camera": "~12.3.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -46,7 +46,7 @@
     "@react-native-community/netinfo": "9.3.0",
     "@react-native-community/slider": "4.2.3",
     "@react-native-masked-view/masked-view": "0.2.6",
-    "@react-native-picker/picker": "2.4.2",
+    "@react-native-picker/picker": "2.4.6",
     "@react-native-segmented-control/segmented-control": "2.4.0",
     "@react-navigation/bottom-tabs": "~5.11.1",
     "@react-navigation/drawer": "5.11.4",

--- a/packages/expo-test-runner/package.json
+++ b/packages/expo-test-runner/package.json
@@ -10,13 +10,13 @@
     "expo-test-runner": "bin/expo-test-runner.js"
   },
   "repository": {
-		"type": "git",
-		"url": "git+https://github.com/expo/expo-test-runner.git"
-	},
+    "type": "git",
+    "url": "git+https://github.com/expo/expo-test-runner.git"
+  },
   "bugs": {
-		"url": "https://github.com/expo/expo-test-runner/issues"
-	},
-	"homepage": "https://github.com/expo/expo-test-runner#readme",
+    "url": "https://github.com/expo/expo-test-runner/issues"
+  },
+  "homepage": "https://github.com/expo/expo-test-runner#readme",
   "scripts": {
     "build": "expo-module build",
     "clean": "expo-module clean",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -7,7 +7,7 @@
   "@react-native-community/slider": "4.2.3",
   "@react-native-community/viewpager": "5.0.11",
   "@react-native-firebase/app": "~15.4.0",
-  "@react-native-picker/picker": "2.4.2",
+  "@react-native-picker/picker": "2.4.6",
   "@react-native-segmented-control/segmented-control": "2.4.0",
   "@stripe/stripe-react-native": "0.18.1",
   "expo-analytics-amplitude": "~11.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3329,10 +3329,10 @@
   resolved "https://registry.yarnpkg.com/@react-native-masked-view/masked-view/-/masked-view-0.2.6.tgz#b26c52d5db3ad0926b13deea79c69620966a9221"
   integrity sha512-303CxmetUmgiX9NSUxatZkNh9qTYYdiM8xkGf9I3Uj20U3eGY3M78ljeNQ4UVCJA+FNGS5nC1dtS9GjIqvB4dg==
 
-"@react-native-picker/picker@2.4.2":
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/@react-native-picker/picker/-/picker-2.4.2.tgz#2925eb8e76ff6b584c80529adc251df963be9141"
-  integrity sha512-0nY8638h1J3wKz6P3IJMpOoxJDdOj7Dk/K2hP/xpqP3KnIY0lmoqYlhyNihuyVPocDGajf6SA7LFFsFepQ56ag==
+"@react-native-picker/picker@2.4.6":
+  version "2.4.6"
+  resolved "https://registry.yarnpkg.com/@react-native-picker/picker/-/picker-2.4.6.tgz#a6f804c41ca2a0bb52f1d04402e2fb76b5074e78"
+  integrity sha512-TyrQZKwi7tbGbETxpQpaf0Jld6Fw/RRWVPAShRobTUWwUglveP71mtdLwuNJV+1NXI6PqW/OvCEk9ZmFfGj0fQ==
 
 "@react-native-segmented-control/segmented-control@2.4.0":
   version "2.4.0"


### PR DESCRIPTION
 (no native changes)

# Why

Preparing for SDK47 release + https://linear.app/expo/issue/ENG-6535/react-native-pickerpicker

# How

Run `et uvm`

# Test Plan

Compared previous and current version, no relevant JS or native changes were introduced. The patch bump is due to maintainers adding windows support.

# Checklist
(removed as not applicable)