### PR TITLE
[core][ios] Ensure that AppDelegate callbacks are invoked

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -44,6 +44,7 @@
 - Update gradle excludes to fix detox tests. ([#19254](https://github.com/expo/expo/pull/19254) by [@esamelson](https://github.com/esamelson))
 - Fixed event listeners do not work when running with remote debugging mode on iOS. ([#19211](https://github.com/expo/expo/pull/19211) by [@kudo](https://github.com/kudo))
 - Give precedence to `UIBackgroundFetchResult.newData` over `.failed` in proxied `ExpoAppDelegate.swift` completion handlers. ([#19311](https://github.com/expo/expo/pull/19311) by [@ferologics](https://github.com/ferologics))
+- Ensure that AppDelegate callbacks are invoked. ([#19393](https://github.com/expo/expo/pull/19393) by [@ferologics](https://github.com/ferologics))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/AppDelegates/EXLegacyAppDelegateWrapper.m
+++ b/packages/expo-modules-core/ios/AppDelegates/EXLegacyAppDelegateWrapper.m
@@ -90,9 +90,13 @@ static dispatch_once_t onceToken;
       }
     }
   };
-  
-  for (id<UIApplicationDelegate> subcontractor in subcontractorsArray) {
-    [subcontractor application:application performFetchWithCompletionHandler:handler];
+
+  if (subcontractorsLeft == 0) {
+    completionHandler(fetchResult);
+  } else {
+    for (id<UIApplicationDelegate> subcontractor in subcontractorsArray) {
+      [subcontractor application:application performFetchWithCompletionHandler:handler];
+    }
   }
 }
 
@@ -201,9 +205,13 @@ static dispatch_once_t onceToken;
       }
     }
   };
-  
-  for (id<UIApplicationDelegate> subcontractor in subcontractorsArray) {
-    [subcontractor application:application didReceiveRemoteNotification:userInfo fetchCompletionHandler:handler];
+
+  if (subcontractorsLeft == 0) {
+    completionHandler(fetchResult);
+  } else {
+    for (id<UIApplicationDelegate> subcontractor in subcontractorsArray) {
+      [subcontractor application:application didReceiveRemoteNotification:userInfo fetchCompletionHandler:handler];
+    }
   }
 }
 

--- a/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegate.swift
+++ b/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegate.swift
@@ -92,8 +92,12 @@ open class ExpoAppDelegate: UIResponder, UIApplicationDelegate {
       }
     }
 
-    subs.forEach {
-      $0.application?(application, handleEventsForBackgroundURLSession: identifier, completionHandler: handler)
+    if subs.isEmpty {
+      completionHandler()
+    } else {
+      subs.forEach {
+        $0.application?(application, handleEventsForBackgroundURLSession: identifier, completionHandler: handler)
+      }
     }
   }
 
@@ -141,8 +145,12 @@ open class ExpoAppDelegate: UIResponder, UIApplicationDelegate {
       }
     }
 
-    subs.forEach { subscriber in
-      subscriber.application?(application, didReceiveRemoteNotification: userInfo, fetchCompletionHandler: handler)
+    if subs.isEmpty {
+      completionHandler(.noData)
+    } else {
+      subs.forEach { subscriber in
+        subscriber.application?(application, didReceiveRemoteNotification: userInfo, fetchCompletionHandler: handler)
+      }
     }
   }
 
@@ -212,8 +220,12 @@ open class ExpoAppDelegate: UIResponder, UIApplicationDelegate {
       }
     }
 
-    subs.forEach { subscriber in
-      subscriber.application?(application, performActionFor: shortcutItem, completionHandler: handler)
+    if subs.isEmpty {
+      completionHandler(result)
+    } else {
+      subs.forEach { subscriber in
+        subscriber.application?(application, performActionFor: shortcutItem, completionHandler: handler)
+      }
     }
   }
 
@@ -249,8 +261,12 @@ open class ExpoAppDelegate: UIResponder, UIApplicationDelegate {
       }
     }
 
-    subs.forEach { subscriber in
-      subscriber.application?(application, performFetchWithCompletionHandler: handler)
+    if subs.isEmpty {
+      completionHandler(.noData)
+    } else {
+      subs.forEach { subscriber in
+        subscriber.application?(application, performFetchWithCompletionHandler: handler)
+      }
     }
   }
 


### PR DESCRIPTION
**Why**
The subscriber count could be zero resulting in a noop where a callback should've been invoked.

**How**
We check the subscriber count and invoke the callback if it's zero.

**Test Plan**
I tested push notifications while patching #19311 and noticed that if I didn't use `expo-notifications` then the `EXLegacyAppDelegateWrapper` would not invoke the completionHandler of my `ExpoAppDelegateSubscriber`.