### PR TITLE
[cli] Add assert with possibly intended variadic argument

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Implement getApplicationIdFromBundle fixing iOS app launch issue with SDK 46. ([#18537](https://github.com/expo/expo/pull/18537) by [@Anthony Mittaz](https://github.com/Anthony Mittaz))
 - Change `UNAUTHORIZED_ERROR` to `UNAUTHORIZED` to handle unauthorized errors. ([#18751](https://github.com/expo/expo/pull/18751) by [@EvanBacon](https://github.com/EvanBacon))
 - Catch error thrown when trying to launch redirect page without an application ID defined in `app.json`. ([#19312](https://github.com/expo/expo/pull/19312) by [@esamelson](https://github.com/esamelson))
+- Present intended variadic argument when asserting flags in `npx expo install`. ([#19396](https://github.com/expo/expo/pull/) by [@bycedric](https://github.com/bycedric))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -25,7 +25,7 @@
 - Implement getApplicationIdFromBundle fixing iOS app launch issue with SDK 46. ([#18537](https://github.com/expo/expo/pull/18537) by [@Anthony Mittaz](https://github.com/Anthony Mittaz))
 - Change `UNAUTHORIZED_ERROR` to `UNAUTHORIZED` to handle unauthorized errors. ([#18751](https://github.com/expo/expo/pull/18751) by [@EvanBacon](https://github.com/EvanBacon))
 - Catch error thrown when trying to launch redirect page without an application ID defined in `app.json`. ([#19312](https://github.com/expo/expo/pull/19312) by [@esamelson](https://github.com/esamelson))
-- Present intended variadic argument when asserting flags in `npx expo install`. ([#19396](https://github.com/expo/expo/pull/) by [@bycedric](https://github.com/bycedric))
+- Present intended variadic argument when asserting flags in `npx expo install`. ([#19396](https://github.com/expo/expo/pull/19396) by [@bycedric](https://github.com/bycedric))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/install/resolveOptions.ts
+++ b/packages/@expo/cli/src/install/resolveOptions.ts
@@ -1,7 +1,7 @@
 import * as PackageManager from '@expo/package-manager';
 
 import { CommandError } from '../utils/errors';
-import { assertUnexpectedObjectKeys, parseVariadicArguments } from '../utils/variadic';
+import { assertUnexpectedVariadicFlags, parseVariadicArguments } from '../utils/variadic';
 
 export type Options = Pick<PackageManager.CreateForProjectOptions, 'npm' | 'pnpm' | 'yarn'> & {
   /** Check which packages need to be updated, does not install any provided packages. */
@@ -29,7 +29,11 @@ export async function resolveArgsAsync(
 ): Promise<{ variadic: string[]; options: Options; extras: string[] }> {
   const { variadic, extras, flags } = parseVariadicArguments(argv);
 
-  assertUnexpectedObjectKeys(['--check', '--fix', '--npm', '--pnpm', '--yarn'], flags);
+  assertUnexpectedVariadicFlags(
+    ['--check', '--fix', '--npm', '--pnpm', '--yarn'],
+    { variadic, extras, flags },
+    'npx expo install'
+  );
 
   return {
     // Variadic arguments like `npx expo install react react-dom` -> ['react', 'react-dom']

--- a/packages/@expo/cli/src/utils/__tests__/variadic-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/variadic-test.ts
@@ -1,4 +1,4 @@
-import { parseVariadicArguments } from '../variadic';
+import { parseVariadicArguments, assertUnexpectedVariadicFlags } from '../variadic';
 
 describe(parseVariadicArguments, () => {
   it(`parses complex`, () => {
@@ -23,5 +23,51 @@ describe(parseVariadicArguments, () => {
     expect(() => parseVariadicArguments(['avo', '--', '--npm', '--'])).toThrow(
       /Unexpected multiple --/
     );
+  });
+});
+
+describe(assertUnexpectedVariadicFlags, () => {
+  it(`splits unknown flags into extras`, () => {
+    expect(
+      assertUnexpectedVariadicFlags(['--yarn'], {
+        variadic: ['chalk'],
+        flags: { '-D': true },
+        extras: [],
+      })
+    ).toThrowError('Did you mean: chalk -- -D');
+  });
+
+  it(`splits unknown flags and combines existing extras`, () => {
+    expect(
+      assertUnexpectedVariadicFlags(['--npm'], {
+        variadic: ['chalk'],
+        flags: { '-D': true },
+        extras: ['--ignore-scripts'],
+      })
+    ).toThrowError('Did you mean: chalk -- --ignore-scripts -D');
+  });
+
+  it(`accepts empty variadic`, () => {
+    expect(
+      assertUnexpectedVariadicFlags(['--pnpm'], {
+        variadic: [],
+        flags: { '--ignore-scripts': true, '-D': true },
+        extras: [],
+      })
+    ).toThrowError('Did you mean: -- --ignore-scripts -D');
+  });
+
+  it('prepends command prefix', () => {
+    expect(
+      assertUnexpectedVariadicFlags(
+        ['--yarn'],
+        {
+          variadic: ['chalk'],
+          flags: { '-D': true },
+          extras: [],
+        },
+        'npx expo install'
+      )
+    ).toThrowError('Did you mean: npx expo install chalk -- -D');
   });
 });

--- a/packages/@expo/cli/src/utils/__tests__/variadic-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/variadic-test.ts
@@ -28,7 +28,7 @@ describe(parseVariadicArguments, () => {
 
 describe(assertUnexpectedVariadicFlags, () => {
   it(`splits unknown flags into extras`, () => {
-    expect(
+    expect(() =>
       assertUnexpectedVariadicFlags(['--yarn'], {
         variadic: ['chalk'],
         flags: { '-D': true },
@@ -38,7 +38,7 @@ describe(assertUnexpectedVariadicFlags, () => {
   });
 
   it(`splits unknown flags and combines existing extras`, () => {
-    expect(
+    expect(() =>
       assertUnexpectedVariadicFlags(['--npm'], {
         variadic: ['chalk'],
         flags: { '-D': true },
@@ -48,7 +48,7 @@ describe(assertUnexpectedVariadicFlags, () => {
   });
 
   it(`accepts empty variadic`, () => {
-    expect(
+    expect(() =>
       assertUnexpectedVariadicFlags(['--pnpm'], {
         variadic: [],
         flags: { '--ignore-scripts': true, '-D': true },
@@ -58,7 +58,7 @@ describe(assertUnexpectedVariadicFlags, () => {
   });
 
   it('prepends command prefix', () => {
-    expect(
+    expect(() =>
       assertUnexpectedVariadicFlags(
         ['--yarn'],
         {

--- a/packages/@expo/cli/src/utils/variadic.ts
+++ b/packages/@expo/cli/src/utils/variadic.ts
@@ -72,7 +72,7 @@ export function assertUnexpectedVariadicFlags(
 
     throw new CommandError(
       'BAD_ARGS',
-      `Unexpected: ${unexpectedFlags.join(', ')}\nDid you mean: ${cmd}`
+      `Unexpected: ${unexpectedFlags.join(', ')}\nDid you mean: ${cmd.trim()}`
     );
   }
 }

--- a/packages/@expo/cli/src/utils/variadic.ts
+++ b/packages/@expo/cli/src/utils/variadic.ts
@@ -49,3 +49,30 @@ export function assertUnexpectedObjectKeys(keys: string[], obj: Record<string, a
     throw new CommandError('BAD_ARGS', `Unexpected: ${unexpectedKeys.join(', ')}`);
   }
 }
+
+export function assertUnexpectedVariadicFlags(
+  expectedFlags: string[],
+  { extras, flags, variadic }: ReturnType<typeof parseVariadicArguments>,
+  prefixCommand = ''
+) {
+  const unexpectedFlags = Object.keys(flags).filter((key) => !expectedFlags.includes(key));
+
+  if (unexpectedFlags.length > 0) {
+    const intendedFlags = Object.entries(flags)
+      .filter(([key]) => expectedFlags.includes(key))
+      .map(([key]) => key);
+
+    const cmd = [
+      prefixCommand,
+      ...variadic,
+      ...intendedFlags,
+      '--',
+      ...extras.concat(unexpectedFlags),
+    ].join(' ');
+
+    throw new CommandError(
+      'BAD_ARGS',
+      `Unexpected: ${unexpectedFlags.join(', ')}\nDid you mean: ${cmd}`
+    );
+  }
+}


### PR DESCRIPTION
# Why

Fixes ENG-6110

# How

- Added `assertUnexpectedVariadicFlags` that splits unexpected flags into extras, using the full output of `parseVariadicArguments`, and optionally a command prefix
- Implemented the new assert in `npx expo install`'s `resolveOptions`

# Test Plan

- See tests

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
