### PR TITLE
[contributing] Fix Konsole executable name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ Manual smoke tests are included in `apps/native-component-list`, this is a good 
 
 ### Set up documentation
 
-If you plan to contribute to the documentation, run  `npm run setup:docs`. 
+If you plan to contribute to the documentation, run `npm run setup:docs`.
 
 ### Set up Android
 
@@ -62,7 +62,7 @@ If you will be working with the iOS project, ensure **ruby 2.7** is installed on
    - Web: `yarn web`
    - iOS: `yarn ios`
    - Android: `yarn android`
-   - If you are working on Linux, make sure to set the `TERMINAL` environment variable to your preferred terminal application. (e.g. `export TERMINAL="Konsole"`)
+   - If you are working on Linux, make sure to set the `TERMINAL` environment variable to your preferred terminal application. (e.g. `export TERMINAL="konsole"`)
 
 3. You are now running the `test-suite` app via the `bare-expo` project. The next section explains how you can begin to make changes to SDK packages.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
The executable filename for the terminal emulator Konsole is `konsole` not `Konsole`. I was following the guide and I copied the command directly because I use Konsole. It didn't work because `Konsole` doesn't exist.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
