### PR TITLE
[bare-expo] Fix starting start-metro script on Linux

### DIFF
--- a/apps/bare-expo/scripts/start-metro.sh
+++ b/apps/bare-expo/scripts/start-metro.sh
@@ -15,6 +15,7 @@ else
 
   commandFile=$(dirname "$0")/start.command
   cat > ${commandFile} << EOF
+#!/bin/sh
 cd "\$(dirname "\$0")/.."
 # Run 'react-native start --help' to get more parameters
 yarn start --port ${port}


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
Without a shebang using `start-metro.sh` (at least on Linux and with Konsole) will produce this error.
```sh

Warning: Could not start program '/home/igoro00/Code/expo/apps/bare-expo/scripts/start.command' with arguments ''.



Warning: execve: Exec format error


```

# How

<!--
How did you build this feature or fix this bug and why?
-->
To fix that I simply added a shebang to the generated script. I chose `#!/bin/sh` to be compatible with all POSIX systems. 

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
It shouldn't break anything on any POSIX-compliant systems, even if it worked for you before (macOS?). But just to be sure you can test it.
 - Delete `apps/bare-expo/scripts/start.command` if it already exists. 
 - Then run `yarn android` or `yarn ios`
 - If metro has launched in the another terminal window, it works

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
