### PR TITLE
[docs] Update documentation page for expo-updates

### DIFF
--- a/docs/pages/versions/unversioned/sdk/updates.mdx
+++ b/docs/pages/versions/unversioned/sdk/updates.mdx
@@ -24,6 +24,32 @@ Most of the methods and constants in this module can only be used or tested in r
 
 **To test manual updates with standalone apps**, you can create a [simulator build](/build-reference/simulators.mdx) or [APK](/build-reference/apk.mdx), or make a release build locally with `npx expo run:ios --configuration Release` and `npx expo run:android --variant release` (you don't need to submit this build to the store to test).
 
+### Using expo-updates with private update server
+Example implementation (of server) and example app using private server can be found in repo [custom-expo-updates-server](https://github.com/expo/custom-expo-updates-server)
+
+There is requirement for every private server to implement this [protocol](https://docs.expo.dev/technical-specs/expo-updates-0/)
+
+### Configuration options
+
+Some build-time configuration options are available to configure the behavior of `expo-updates`. On iOS, these properties are set as keys in `Expo.plist` and on Android as `meta-data` tags in `AndroidManifest.xml` adjacent to the tags added during installation. On Android, you may also define these properties at runtime by passing a `Map` as the second parameter of `UpdatesController.initialize()`, and when provided the values will override any values specified in `AndroidManifest.xml`. On iOS, you may set these properties at runtime by calling `[UpdatesController.sharedInstance setConfiguration:]` at any point _before_ calling `start` or `startAndShowLaunchScreen` and the values in this dictionary will override any values specified in `Expo.plist`.
+
+| iOS plist/dictionary key | Android Map key | Android meta-data name         | Default | Required? |
+|--------------------------|---------------- | ------------------------------ | ------- | --------- |
+| `EXUpdatesEnabled`       | `enabled`       | `expo.modules.updates.ENABLED` | `true`  | ❌        |
+| `EXUpdatesURL`           | `updateUrl`     | `expo.modules.updates.EXPO_UPDATE_URL` | (none)  | ✅        |
+| `EXUpdatesRequestHeaders`| `requestHeaders`| `expo.modules.updates.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY` | (none)  | ❌        |
+| `EXUpdatesSDKVersion`    | `sdkVersion`    | `expo.modules.updates.EXPO_SDK_VERSION` | (none)  | (exactly one of `sdkVersion` or `runtimeVersion` is required, Required for apps hosted on Expo's server) |
+| `EXUpdatesRuntimeVersion` | `runtimeVersion` | `expo.modules.updates.EXPO_RUNTIME_VERSION` | (none)  | (exactly one of `sdkVersion` or `runtimeVersion` is required) |
+| `EXUpdatesReleaseChannel` | `releaseChannel` | `expo.modules.updates.EXPO_RELEASE_CHANNEL` | `default` | ❌        |
+| `EXUpdatesCheckOnLaunch` | `checkOnLaunch` | `expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH` | `ALWAYS` (`ALWAYS`, `NEVER`, `WIFI_ONLY`, `ERROR_RECOVERY_ONLY`)| ❌        |
+| `EXUpdatesLaunchWaitMs`  | `launchWaitMs`  | `expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS` | `0`     | ❌        |
+| `EXUpdatesCodeSigningCertificate` | `codeSigningCertificate` | `expo.modules.updates.CODE_SIGNING_CERTIFICATE`    | (none)  | ❌        |
+| `EXUpdatesCodeSigningMetadata`    | `codeSigningMetadata`    | `expo.modules.updates.CODE_SIGNING_METADATA`       | (none)  | ❌        |
+| `EXUpdatesCodeSigningIncludeManifestResponseCertificateChain` | `codeSigningIncludeManifestResponseCertificateChain` | `expo.modules.updates.CODE_SIGNING_INCLUDE_MANIFEST_RESPONSE_CERTIFICATE_CHAIN` | false | ❌        |
+| `EXUpdatesConfigCodeSigningAllowUnsignedManifests` | `codeSigningAllowUnsignedManifests` | `expo.modules.updates.CODE_SIGNING_ALLOW_UNSIGNED_MANIFESTS` | false | ❌        |
+
+For detailed explanation check expo-updates [README.md](https://github.com/expo/expo/blob/main/packages/expo-updates/README.md)
+
 ## API
 
 ```js

--- a/docs/pages/versions/unversioned/sdk/updates.mdx
+++ b/docs/pages/versions/unversioned/sdk/updates.mdx
@@ -25,16 +25,16 @@ Most of the methods and constants in this module can only be used or tested in r
 
 **To test manual updates with standalone apps**, you can create a [simulator build](/build-reference/simulators.mdx) or [APK](/build-reference/apk.mdx), or make a release build locally with `npx expo run:ios --configuration Release` and `npx expo run:android --variant release` (you don't need to submit this build to the store to test).
 
-### Using expo-updates with a private server
+### Using expo-updates with a custom server
 
-There is a requirement for every private server to implement [Expo Updates protocol](https://docs.expo.dev/technical-specs/expo-updates-0/).
+Every custom updates server must implement the [Expo Updates protocol](https://docs.expo.dev/technical-specs/expo-updates-0/).
 
-You can find an example implementation of a private server and an app using that server in the [custom-expo-updates-server](https://github.com/expo/custom-expo-updates-server) repository.
+You can find an example implementation of a custom server and an app using that server in the [custom-expo-updates-server](https://github.com/expo/custom-expo-updates-server) repository.
 
 
 ### Configuration options
 
-Some build-time configuration options are available to configure the behavior of `expo-updates`. 
+There are build-time configuration options that control the behavior of `expo-updates`. 
 
 On Android, these options are set as `meta-data` tags adjacent to the tags added during installation in the **AndroidManifest.xml** file. You can also define these options at runtime by passing a `Map` as the second parameter of `UpdatesController.initialize()`, and the provided values will override any value specified in **AndroidManifest.xml**.
 
@@ -55,7 +55,7 @@ On iOS, these properties are set as keys in **Expo.plist** file. You can also se
 | `EXUpdatesCodeSigningIncludeManifestResponseCertificateChain` | `codeSigningIncludeManifestResponseCertificateChain` | `expo.modules.updates.CODE_SIGNING_INCLUDE_MANIFEST_RESPONSE_CERTIFICATE_CHAIN` | false | <NoIcon />        |
 | `EXUpdatesConfigCodeSigningAllowUnsignedManifests` | `codeSigningAllowUnsignedManifests` | `expo.modules.updates.CODE_SIGNING_ALLOW_UNSIGNED_MANIFESTS` | false | <NoIcon />        |
 
-For detailed explanation, see [`expo-updates`](https://github.com/expo/expo/blob/main/packages/expo-updates/README.md) repository.
+For a detailed explanation, see the [`expo-updates`](https://github.com/expo/expo/blob/main/packages/expo-updates/README.md) repository.
 
 ## API
 

--- a/docs/pages/versions/unversioned/sdk/updates.mdx
+++ b/docs/pages/versions/unversioned/sdk/updates.mdx
@@ -24,10 +24,12 @@ Most of the methods and constants in this module can only be used or tested in r
 
 **To test manual updates with standalone apps**, you can create a [simulator build](/build-reference/simulators.mdx) or [APK](/build-reference/apk.mdx), or make a release build locally with `npx expo run:ios --configuration Release` and `npx expo run:android --variant release` (you don't need to submit this build to the store to test).
 
-### Using expo-updates with private update server
-Example implementation (of server) and example app using private server can be found in repo [custom-expo-updates-server](https://github.com/expo/custom-expo-updates-server)
+### Using expo-updates with a private server
 
-There is requirement for every private server to implement this [protocol](https://docs.expo.dev/technical-specs/expo-updates-0/)
+There is a requirement for every private server to implement [Expo Updates protocol](https://docs.expo.dev/technical-specs/expo-updates-0/).
+
+You can find an example implementation of a private server and an app using that server in the [custom-expo-updates-server](https://github.com/expo/custom-expo-updates-server) repository.
+
 
 ### Configuration options
 

--- a/docs/pages/versions/unversioned/sdk/updates.mdx
+++ b/docs/pages/versions/unversioned/sdk/updates.mdx
@@ -7,6 +7,7 @@ packageName: 'expo-updates'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 
 The expo-updates library allows you to programmatically control and respond to new updates made available to your app.
 
@@ -41,18 +42,18 @@ On iOS, these properties are set as keys in **Expo.plist** file. You can also se
 
 | iOS plist/dictionary key | Android Map key | Android meta-data name         | Default | Required? |
 |--------------------------|---------------- | ------------------------------ | ------- | --------- |
-| `EXUpdatesEnabled`       | `enabled`       | `expo.modules.updates.ENABLED` | `true`  | ❌        |
-| `EXUpdatesURL`           | `updateUrl`     | `expo.modules.updates.EXPO_UPDATE_URL` | (none)  | ✅        |
-| `EXUpdatesRequestHeaders`| `requestHeaders`| `expo.modules.updates.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY` | (none)  | ❌        |
+| `EXUpdatesEnabled`       | `enabled`       | `expo.modules.updates.ENABLED` | `true`  | <NoIcon />        |
+| `EXUpdatesURL`           | `updateUrl`     | `expo.modules.updates.EXPO_UPDATE_URL` | (none)  | <YesIcon />        |
+| `EXUpdatesRequestHeaders`| `requestHeaders`| `expo.modules.updates.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY` | (none)  | <NoIcon />        |
 | `EXUpdatesSDKVersion`    | `sdkVersion`    | `expo.modules.updates.EXPO_SDK_VERSION` | (none)  | (exactly one of `sdkVersion` or `runtimeVersion` is required, Required for apps hosted on Expo's server) |
 | `EXUpdatesRuntimeVersion` | `runtimeVersion` | `expo.modules.updates.EXPO_RUNTIME_VERSION` | (none)  | (exactly one of `sdkVersion` or `runtimeVersion` is required) |
-| `EXUpdatesReleaseChannel` | `releaseChannel` | `expo.modules.updates.EXPO_RELEASE_CHANNEL` | `default` | ❌        |
-| `EXUpdatesCheckOnLaunch` | `checkOnLaunch` | `expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH` | `ALWAYS` (`ALWAYS`, `NEVER`, `WIFI_ONLY`, `ERROR_RECOVERY_ONLY`)| ❌        |
-| `EXUpdatesLaunchWaitMs`  | `launchWaitMs`  | `expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS` | `0`     | ❌        |
-| `EXUpdatesCodeSigningCertificate` | `codeSigningCertificate` | `expo.modules.updates.CODE_SIGNING_CERTIFICATE`    | (none)  | ❌        |
-| `EXUpdatesCodeSigningMetadata`    | `codeSigningMetadata`    | `expo.modules.updates.CODE_SIGNING_METADATA`       | (none)  | ❌        |
-| `EXUpdatesCodeSigningIncludeManifestResponseCertificateChain` | `codeSigningIncludeManifestResponseCertificateChain` | `expo.modules.updates.CODE_SIGNING_INCLUDE_MANIFEST_RESPONSE_CERTIFICATE_CHAIN` | false | ❌        |
-| `EXUpdatesConfigCodeSigningAllowUnsignedManifests` | `codeSigningAllowUnsignedManifests` | `expo.modules.updates.CODE_SIGNING_ALLOW_UNSIGNED_MANIFESTS` | false | ❌        |
+| `EXUpdatesReleaseChannel` | `releaseChannel` | `expo.modules.updates.EXPO_RELEASE_CHANNEL` | `default` | <NoIcon />        |
+| `EXUpdatesCheckOnLaunch` | `checkOnLaunch` | `expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH` | `ALWAYS` (`ALWAYS`, `NEVER`, `WIFI_ONLY`, `ERROR_RECOVERY_ONLY`)| <NoIcon />        |
+| `EXUpdatesLaunchWaitMs`  | `launchWaitMs`  | `expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS` | `0`     | <NoIcon />        |
+| `EXUpdatesCodeSigningCertificate` | `codeSigningCertificate` | `expo.modules.updates.CODE_SIGNING_CERTIFICATE`    | (none)  | <NoIcon />        |
+| `EXUpdatesCodeSigningMetadata`    | `codeSigningMetadata`    | `expo.modules.updates.CODE_SIGNING_METADATA`       | (none)  | <NoIcon />        |
+| `EXUpdatesCodeSigningIncludeManifestResponseCertificateChain` | `codeSigningIncludeManifestResponseCertificateChain` | `expo.modules.updates.CODE_SIGNING_INCLUDE_MANIFEST_RESPONSE_CERTIFICATE_CHAIN` | false | <NoIcon />        |
+| `EXUpdatesConfigCodeSigningAllowUnsignedManifests` | `codeSigningAllowUnsignedManifests` | `expo.modules.updates.CODE_SIGNING_ALLOW_UNSIGNED_MANIFESTS` | false | <NoIcon />        |
 
 For detailed explanation, see [`expo-updates`](https://github.com/expo/expo/blob/main/packages/expo-updates/README.md) repository.
 

--- a/docs/pages/versions/unversioned/sdk/updates.mdx
+++ b/docs/pages/versions/unversioned/sdk/updates.mdx
@@ -33,7 +33,11 @@ You can find an example implementation of a private server and an app using that
 
 ### Configuration options
 
-Some build-time configuration options are available to configure the behavior of `expo-updates`. On iOS, these properties are set as keys in `Expo.plist` and on Android as `meta-data` tags in `AndroidManifest.xml` adjacent to the tags added during installation. On Android, you may also define these properties at runtime by passing a `Map` as the second parameter of `UpdatesController.initialize()`, and when provided the values will override any values specified in `AndroidManifest.xml`. On iOS, you may set these properties at runtime by calling `[UpdatesController.sharedInstance setConfiguration:]` at any point _before_ calling `start` or `startAndShowLaunchScreen` and the values in this dictionary will override any values specified in `Expo.plist`.
+Some build-time configuration options are available to configure the behavior of `expo-updates`. 
+
+On Android, these options are set as `meta-data` tags adjacent to the tags added during installation in the **AndroidManifest.xml** file. You can also define these options at runtime by passing a `Map` as the second parameter of `UpdatesController.initialize()`, and the provided values will override any value specified in **AndroidManifest.xml**.
+
+On iOS, these properties are set as keys in **Expo.plist** file. You can also set them at runtime by calling `[UpdatesController.sharedInstance setConfiguration:]` at any point before calling `start` or `startAndShowLaunchScreen`, and the values in this dictionary will override any values specified in **Expo.plist**.
 
 | iOS plist/dictionary key | Android Map key | Android meta-data name         | Default | Required? |
 |--------------------------|---------------- | ------------------------------ | ------- | --------- |

--- a/docs/pages/versions/unversioned/sdk/updates.mdx
+++ b/docs/pages/versions/unversioned/sdk/updates.mdx
@@ -54,7 +54,7 @@ On iOS, these properties are set as keys in **Expo.plist** file. You can also se
 | `EXUpdatesCodeSigningIncludeManifestResponseCertificateChain` | `codeSigningIncludeManifestResponseCertificateChain` | `expo.modules.updates.CODE_SIGNING_INCLUDE_MANIFEST_RESPONSE_CERTIFICATE_CHAIN` | false | ❌        |
 | `EXUpdatesConfigCodeSigningAllowUnsignedManifests` | `codeSigningAllowUnsignedManifests` | `expo.modules.updates.CODE_SIGNING_ALLOW_UNSIGNED_MANIFESTS` | false | ❌        |
 
-For detailed explanation check expo-updates [README.md](https://github.com/expo/expo/blob/main/packages/expo-updates/README.md)
+For detailed explanation, see [`expo-updates`](https://github.com/expo/expo/blob/main/packages/expo-updates/README.md) repository.
 
 ## API
 


### PR DESCRIPTION
Adding references to more detailed information and adding missing configuration reference

# Why

I was playing with expo-updates as an alternative to codepush because I wanted to have a custom update server (because of compliance issues) and my experience could be better if documentation was clearly stated it is possible and linking example implementation.

Also documentation was missing configuration options. It is weird experience to be looking at documentation and not having the information there - I had to visit multiple pages & repos to have complete information...

# How

Mostly copy-paste from readme of expo-updates

# Test Plan
Ideally some native english speaker will read the update and correct possible mistakes

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
