### PR TITLE
[ci] Do not fail EAS Build job on network error

### DIFF
--- a/.github/actions/eas-build/action.yml
+++ b/.github/actions/eas-build/action.yml
@@ -54,7 +54,7 @@ runs:
       run: |
         while true
         do
-          STATUS=$(eas build:view $BUILD_ID --json 2>/dev/null | jq -r ".status")
+          STATUS=$(eas build:view $BUILD_ID --json 2>/dev/null | jq -r ".status" || true)
           if [[ "$STATUS" == "ERRORED" || "$STATUS" == "CANCELLED" ]] ; then
             echo "Build failed"
             exit 1;


### PR DESCRIPTION
# Why

https://github.com/expo/expo/actions/runs/3182333505/jobs/5188141476#step:10:51

CI jobs that run builds using EAS Build can fail if there is a network error when waiting for build to finish.

# How

Ignore errors with `|| true`

This solution has a potential risk, that if there is some bug or outage and it always returns invalid value, that job will hung for a long time until  it times out. I feel like this is not a problem until it starts happening, and if it does we can address it then.

# Test Plan



# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
