### PR TITLE
Update `react-native-maps` to 1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Package-specific changes not released in any SDK will be added here just before 
 - Updated `react-native-screens` from `3.15.0` to `3.18.0`. ([#19383](https://github.com/expo/expo/pull/19383) by [@tsapeta](https://github.com/tsapeta))
 - Updated `@shopify/react-native-skia` from `0.1.136` to `0.1.153`. ([#19360](https://github.com/expo/expo/pull/19360) by [@kudo](https://github.com/kudo))
 - Updated `@react-native-community/datetimepicker` from `6.2.0` to `6.5.0`. ([#19419](https://github.com/expo/expo/pull/19419) by [@byCedric](https://github.com/byCedric))
-- Updated `react-native-maps` from `0.31.1` to `1.3.2`.
+- Updated `react-native-maps` from `0.31.1` to `1.3.2`. ([#19414](https://github.com/expo/expo/pull/19414) by [@aleqsio](https://github.com/aleqsio))
 
 ### 🛠 Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Package-specific changes not released in any SDK will be added here just before 
 - Updated `react-native-screens` from `3.15.0` to `3.18.0`. ([#19383](https://github.com/expo/expo/pull/19383) by [@tsapeta](https://github.com/tsapeta))
 - Updated `@shopify/react-native-skia` from `0.1.136` to `0.1.153`. ([#19360](https://github.com/expo/expo/pull/19360) by [@kudo](https://github.com/kudo))
 - Updated `@react-native-community/datetimepicker` from `6.2.0` to `6.5.0`. ([#19419](https://github.com/expo/expo/pull/19419) by [@byCedric](https://github.com/byCedric))
+- Updated `react-native-maps` from `0.31.1` to `1.3.2`.
 
 ### 🛠 Breaking changes
 

--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -357,9 +357,9 @@ dependencies {
 
   api 'com.squareup.picasso:picasso:2.5.2'
   api 'com.google.android.gms:play-services-analytics:17.0.0'
-  api 'com.google.android.gms:play-services-maps:18.0.0'
+  api 'com.google.android.gms:play-services-maps:18.0.1'
   api 'com.google.android.gms:play-services-auth:17.0.0'
-  api 'com.google.android.gms:play-services-location:17.0.0'
+  api 'com.google.android.gms:play-services-location:20.0.0'
   api 'com.google.android.gms:play-services-fitness:17.0.0'
   api 'com.google.android.gms:play-services-wallet:17.0.0' //may need 10.+
   debugApi 'com.squareup.leakcanary:leakcanary-android-no-op:1.4-beta1'

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapCircleManager.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapCircleManager.java
@@ -2,7 +2,6 @@ package versioned.host.exp.exponent.modules.api.components.maps;
 
 import android.content.Context;
 import android.graphics.Color;
-import android.os.Build;
 import android.util.DisplayMetrics;
 import android.view.WindowManager;
 
@@ -18,14 +17,10 @@ public class AirMapCircleManager extends ViewGroupManager<AirMapCircle> {
 
   public AirMapCircleManager(ReactApplicationContext reactContext) {
     super();
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-      metrics = new DisplayMetrics();
-      ((WindowManager) reactContext.getSystemService(Context.WINDOW_SERVICE))
-          .getDefaultDisplay()
-          .getRealMetrics(metrics);
-    } else {
-      metrics = reactContext.getResources().getDisplayMetrics();
-    }
+    metrics = new DisplayMetrics();
+    ((WindowManager) reactContext.getSystemService(Context.WINDOW_SERVICE))
+        .getDefaultDisplay()
+        .getRealMetrics(metrics);
   }
 
   @Override

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapGradientPolyline.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapGradientPolyline.java
@@ -38,9 +38,7 @@ public class AirMapGradientPolyline extends AirMapFeature {
 
   private GoogleMap map;
 
-  private TileOverlayOptions tileOverlayOptions;
   private TileOverlay tileOverlay;
-  private AirMapGradientPolylineProvider tileProvider;
   protected final Context context;
 
   public AirMapGradientPolyline(Context context) {
@@ -88,8 +86,8 @@ public class AirMapGradientPolyline extends AirMapFeature {
   private TileOverlayOptions createTileOverlayOptions() {
     TileOverlayOptions options = new TileOverlayOptions();
     options.zIndex(zIndex);
-    this.tileProvider = new AirMapGradientPolylineProvider(context, points, colors, width);
-    options.tileProvider(this.tileProvider);
+    AirMapGradientPolylineProvider tileProvider = new AirMapGradientPolylineProvider(context, points, colors, width);
+    options.tileProvider(tileProvider);
     return options;
   }
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapGradientPolylineManager.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapGradientPolylineManager.java
@@ -1,7 +1,6 @@
 package versioned.host.exp.exponent.modules.api.components.maps;
 
 import android.content.Context;
-import android.os.Build;
 import android.util.DisplayMetrics;
 import android.view.WindowManager;
 
@@ -21,14 +20,10 @@ public class AirMapGradientPolylineManager extends ViewGroupManager<AirMapGradie
 
   public AirMapGradientPolylineManager(ReactApplicationContext reactContext) {
     super();
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-      metrics = new DisplayMetrics();
-      ((WindowManager) reactContext.getSystemService(Context.WINDOW_SERVICE))
-          .getDefaultDisplay()
-          .getRealMetrics(metrics);
-    } else {
-      metrics = reactContext.getResources().getDisplayMetrics();
-    }
+    metrics = new DisplayMetrics();
+    ((WindowManager) reactContext.getSystemService(Context.WINDOW_SERVICE))
+        .getDefaultDisplay()
+        .getRealMetrics(metrics);
   }
 
   @Override

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapHeatmap.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapHeatmap.java
@@ -49,7 +49,7 @@ public class AirMapHeatmap extends AirMapFeature {
     }
     
     public void setOpacity(double opacity) {
-        this.opacity = new Double(opacity);
+        this.opacity = opacity;
         if (heatmapTileProvider != null) {
             heatmapTileProvider.setOpacity(opacity);
         }
@@ -59,7 +59,7 @@ public class AirMapHeatmap extends AirMapFeature {
     }
 
     public void setRadius(int radius) {
-        this.radius = new Integer(radius);
+        this.radius = radius;
         if (heatmapTileProvider != null) {
             heatmapTileProvider.setRadius(radius);
         }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapLocalTileManager.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapLocalTileManager.java
@@ -1,7 +1,6 @@
 package versioned.host.exp.exponent.modules.api.components.maps;
 
 import android.content.Context;
-import android.os.Build;
 import android.util.DisplayMetrics;
 import android.view.WindowManager;
 
@@ -14,18 +13,13 @@ import com.facebook.react.uimanager.annotations.ReactProp;
  * Created by zavadpe on 30/11/2017.
  */
 public class AirMapLocalTileManager extends ViewGroupManager<AirMapLocalTile> {
-    private DisplayMetrics metrics;
 
     public AirMapLocalTileManager(ReactApplicationContext reactContext) {
         super();
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-            metrics = new DisplayMetrics();
-            ((WindowManager) reactContext.getSystemService(Context.WINDOW_SERVICE))
-                    .getDefaultDisplay()
-                    .getRealMetrics(metrics);
-        } else {
-            metrics = reactContext.getResources().getDisplayMetrics();
-        }
+        DisplayMetrics metrics = new DisplayMetrics();
+        ((WindowManager) reactContext.getSystemService(Context.WINDOW_SERVICE))
+                .getDefaultDisplay()
+                .getRealMetrics(metrics);
     }
 
     @Override
@@ -53,4 +47,8 @@ public class AirMapLocalTileManager extends ViewGroupManager<AirMapLocalTile> {
         view.setZIndex(zIndex);
     }
 
+    @ReactProp(name = "useAssets", defaultBoolean = false)
+    public void setUseAssets(AirMapLocalTile view, boolean useAssets) {
+        view.setUseAssets(useAssets);
+    }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapManager.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapManager.java
@@ -2,6 +2,7 @@ package versioned.host.exp.exponent.modules.api.components.maps;
 
 import android.view.View;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.facebook.react.bridge.Arguments;
@@ -16,32 +17,17 @@ import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
-import com.google.android.gms.location.LocationRequest;
+import com.google.android.gms.location.Priority;
 import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.GoogleMapOptions;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.LatLngBounds;
-import com.google.android.gms.maps.model.MapStyleOptions;
 
-import java.util.HashMap;
 import java.util.Map;
 
 public class AirMapManager extends ViewGroupManager<AirMapView> {
 
   private static final String REACT_CLASS = "AIRMap";
-  private static final int ANIMATE_TO_REGION = 1;
-  private static final int ANIMATE_TO_COORDINATE = 2;
-  private static final int ANIMATE_TO_VIEWING_ANGLE = 3;
-  private static final int ANIMATE_TO_BEARING = 4;
-  private static final int FIT_TO_ELEMENTS = 5;
-  private static final int FIT_TO_SUPPLIED_MARKERS = 6;
-  private static final int FIT_TO_COORDINATES = 7;
-  private static final int SET_MAP_BOUNDARIES = 8;
-  private static final int ANIMATE_TO_NAVIGATION = 9; 
-  private static final int SET_INDOOR_ACTIVE_LEVEL_INDEX = 10;
-  private static final int SET_CAMERA = 11;
-  private static final int ANIMATE_CAMERA = 12;
-
 
   private final Map<String, Integer> MAP_TYPES = MapBuilder.of(
       "standard", GoogleMap.MAP_TYPE_NORMAL,
@@ -52,10 +38,10 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
   );
 
   private final Map<String, Integer> MY_LOCATION_PRIORITY = MapBuilder.of(
-          "balanced", LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY,
-          "high", LocationRequest.PRIORITY_HIGH_ACCURACY,
-          "low", LocationRequest.PRIORITY_LOW_POWER,
-          "passive", LocationRequest.PRIORITY_NO_POWER
+          "balanced", Priority.PRIORITY_BALANCED_POWER_ACCURACY,
+          "high", Priority.PRIORITY_HIGH_ACCURACY,
+          "low", Priority.PRIORITY_LOW_POWER,
+          "passive", Priority.PRIORITY_PASSIVE
   );
 
   private final ReactApplicationContext appContext;
@@ -123,7 +109,7 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
 
   @ReactProp(name = "customMapStyleString")
   public void setMapStyle(AirMapView view, @Nullable String customMapStyleString) {
-    view.map.setMapStyle(new MapStyleOptions(customMapStyleString));
+    view.setMapStyle(customMapStyleString);
   }
 
   @ReactProp(name = "mapPadding")
@@ -291,41 +277,37 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
   }
 
   @Override
-  public void receiveCommand(AirMapView view, int commandId, @Nullable ReadableArray args) {
-    Integer duration;
-    Double lat;
-    Double lng;
-    Double lngDelta;
-    Double latDelta;
-    float bearing;
-    float angle;
+  public void receiveCommand(@NonNull AirMapView view, String commandId, @Nullable ReadableArray args) {
+    int duration;
+    double lat;
+    double lng;
+    double lngDelta;
+    double latDelta;
     ReadableMap region;
     ReadableMap camera;
 
     switch (commandId) {
-      case SET_CAMERA:
+      case "setCamera":
+        if(args == null) {
+          break;
+        }
         camera = args.getMap(0);
         view.animateToCamera(camera, 0);
         break;
 
-      case ANIMATE_CAMERA:
+      case "animateCamera":
+        if(args == null) {
+          break;
+        }
         camera = args.getMap(0);
         duration = args.getInt(1);
         view.animateToCamera(camera, duration);
         break;
 
-      case ANIMATE_TO_NAVIGATION:
-        region = args.getMap(0);
-        lng = region.getDouble("longitude");
-        lat = region.getDouble("latitude");
-        LatLng location = new LatLng(lat, lng);
-        bearing = (float)args.getDouble(1);
-        angle = (float)args.getDouble(2);
-        duration = args.getInt(3);
-        view.animateToNavigation(location, bearing, angle, duration);
-        break;
-
-      case ANIMATE_TO_REGION:
+      case "animateToRegion":
+        if(args == null) {
+          break;
+        }
         region = args.getMap(0);
         duration = args.getInt(1);
         lng = region.getDouble("longitude");
@@ -339,43 +321,38 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
         view.animateToRegion(bounds, duration);
         break;
 
-      case ANIMATE_TO_COORDINATE:
-        region = args.getMap(0);
-        duration = args.getInt(1);
-        lng = region.getDouble("longitude");
-        lat = region.getDouble("latitude");
-        view.animateToCoordinate(new LatLng(lat, lng), duration);
-        break;
-
-      case ANIMATE_TO_VIEWING_ANGLE:
-        angle = (float)args.getDouble(0);
-        duration = args.getInt(1);
-        view.animateToViewingAngle(angle, duration);
-        break;
-
-      case ANIMATE_TO_BEARING:
-        bearing = (float)args.getDouble(0);
-        duration = args.getInt(1);
-        view.animateToBearing(bearing, duration);
-        break;
-
-      case FIT_TO_ELEMENTS:
+      case "fitToElements":
+        if(args == null) {
+          break;
+        }
         view.fitToElements(args.getMap(0), args.getBoolean(1));
         break;
 
-      case FIT_TO_SUPPLIED_MARKERS:
+      case "fitToSuppliedMarkers":
+        if(args == null) {
+          break;
+        }
         view.fitToSuppliedMarkers(args.getArray(0), args.getMap(1), args.getBoolean(2));
         break;
 
-      case FIT_TO_COORDINATES:
+      case "fitToCoordinates":
+        if(args == null) {
+          break;
+        }
         view.fitToCoordinates(args.getArray(0), args.getMap(1), args.getBoolean(2));
         break;
 
-      case SET_MAP_BOUNDARIES:
+      case "setMapBoundaries":
+        if(args == null) {
+          break;
+        }
         view.setMapBoundaries(args.getMap(0), args.getMap(1));
         break;
 
-      case SET_INDOOR_ACTIVE_LEVEL_INDEX:
+      case "setIndoorActiveLevelIndex":
+        if(args == null) {
+          break;
+        }
         view.setIndoorActiveLevelIndex(args.getInt(0));
         break;
     }
@@ -411,46 +388,6 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
         "onMapLoaded", MapBuilder.of("registrationName", "onMapLoaded")
     ));
 
-    return map;
-  }
-  
-  @Nullable
-  @Override
-  public Map<String, Integer> getCommandsMap() {
-    Map<String, Integer> map = this.CreateMap(
-        "setCamera", SET_CAMERA,
-        "animateCamera", ANIMATE_CAMERA,
-        "animateToRegion", ANIMATE_TO_REGION,
-        "animateToCoordinate", ANIMATE_TO_COORDINATE,
-        "animateToViewingAngle", ANIMATE_TO_VIEWING_ANGLE,
-        "animateToBearing", ANIMATE_TO_BEARING,
-        "fitToElements", FIT_TO_ELEMENTS,
-        "fitToSuppliedMarkers", FIT_TO_SUPPLIED_MARKERS,
-        "fitToCoordinates", FIT_TO_COORDINATES,
-        "animateToNavigation", ANIMATE_TO_NAVIGATION
-    );
-
-    map.putAll(MapBuilder.of(
-      "setMapBoundaries", SET_MAP_BOUNDARIES,
-      "setIndoorActiveLevelIndex", SET_INDOOR_ACTIVE_LEVEL_INDEX
-    ));
-
-    return map;
-  }
-
-  public static <K, V> Map<K, V> CreateMap(
-  K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5, K k6, V v6, K k7, V v7, K k8, V v8, K k9, V v9, K k10, V v10) {
-    Map map = new HashMap<K, V>();
-    map.put(k1, v1);
-    map.put(k2, v2);
-    map.put(k3, v3);
-    map.put(k4, v4);
-    map.put(k5, v5);
-    map.put(k6, v6);
-    map.put(k7, v7);
-    map.put(k8, v8);
-    map.put(k9, v9);
-    map.put(k10, v10);
     return map;
   }
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapMarker.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapMarker.java
@@ -76,7 +76,6 @@ public class AirMapMarker extends AirMapFeature {
 
   private boolean tracksViewChanges = true;
   private boolean tracksViewChangesActive = false;
-  private boolean hasViewChanges = true;
 
   private boolean hasCustomMarkerView = false;
   private final AirMapMarkerManager markerManager;
@@ -96,7 +95,7 @@ public class AirMapMarker extends AirMapFeature {
             imageReference = dataSource.getResult();
             if (imageReference != null) {
               CloseableImage image = imageReference.get();
-              if (image != null && image instanceof CloseableStaticBitmap) {
+              if (image instanceof CloseableStaticBitmap) {
                 CloseableStaticBitmap closeableStaticBitmap = (CloseableStaticBitmap) image;
                 Bitmap bitmap = closeableStaticBitmap.getUnderlyingBitmap();
                 if (bitmap != null) {
@@ -289,13 +288,7 @@ public class AirMapMarker extends AirMapFeature {
   public void updateMarkerIcon() {
     if (marker == null) return;
 
-    if (!hasCustomMarkerView) {
-      // No more updates for this, as it's a simple icon
-      hasViewChanges = false;
-    }
-    if (marker != null) {
-      marker.setIcon(getIcon());
-    }
+    marker.setIcon(getIcon());
   }
 
   public LatLng interpolate(float fraction, LatLng a, LatLng b) {
@@ -322,7 +315,6 @@ public class AirMapMarker extends AirMapFeature {
   }
 
   public void setImage(String uri) {
-    hasViewChanges = true;
 
     boolean shouldLoadImage = true;
 
@@ -368,18 +360,16 @@ public class AirMapMarker extends AirMapFeature {
       logoHolder.setController(controller);
     } else {
       iconBitmapDescriptor = getBitmapDescriptorByName(uri);
-      if (iconBitmapDescriptor != null) {
-          int drawableId = getDrawableResourceByName(uri);
-          iconBitmap = BitmapFactory.decodeResource(getResources(), drawableId);
-          if (iconBitmap == null) { // VectorDrawable or similar
-              Drawable drawable = getResources().getDrawable(drawableId);
-              iconBitmap = Bitmap.createBitmap(drawable.getIntrinsicWidth(), drawable.getIntrinsicHeight(), Bitmap.Config.ARGB_8888);
-              drawable.setBounds(0, 0, drawable.getIntrinsicWidth(), drawable.getIntrinsicHeight());
-              Canvas canvas = new Canvas(iconBitmap);
-              drawable.draw(canvas);
-          }
+      int drawableId = getDrawableResourceByName(uri);
+      iconBitmap = BitmapFactory.decodeResource(getResources(), drawableId);
+      if (iconBitmap == null) { // VectorDrawable or similar
+          Drawable drawable = getResources().getDrawable(drawableId);
+          iconBitmap = Bitmap.createBitmap(drawable.getIntrinsicWidth(), drawable.getIntrinsicHeight(), Bitmap.Config.ARGB_8888);
+          drawable.setBounds(0, 0, drawable.getIntrinsicWidth(), drawable.getIntrinsicHeight());
+          Canvas canvas = new Canvas(iconBitmap);
+          drawable.draw(canvas);
       }
-      if (this.markerManager != null && uri != null) {
+      if (this.markerManager != null) {
         this.markerManager.getSharedIcon(uri).updateIcon(iconBitmapDescriptor, iconBitmap);
       }
       update(true);
@@ -389,7 +379,6 @@ public class AirMapMarker extends AirMapFeature {
   public void setIconBitmapDescriptor(BitmapDescriptor bitmapDescriptor, Bitmap bitmap) {
     this.iconBitmapDescriptor = bitmapDescriptor;
     this.iconBitmap = bitmap;
-    this.hasViewChanges = true;
     this.update(true);
   }
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapMarkerManager.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapMarkerManager.java
@@ -4,6 +4,7 @@ import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.view.View;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.facebook.react.bridge.ReadableArray;
@@ -24,15 +25,10 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class AirMapMarkerManager extends ViewGroupManager<AirMapMarker> {
 
-  private static final int SHOW_INFO_WINDOW = 1;
-  private static final int HIDE_INFO_WINDOW = 2;
-  private static final int ANIMATE_MARKER_TO_COORDINATE = 3;
-  private static final int REDRAW = 4;
-
   public static class AirMapMarkerSharedIcon {
     private BitmapDescriptor iconBitmapDescriptor;
     private Bitmap bitmap;
-    private Map<AirMapMarker, Boolean> markers;
+    private final Map<AirMapMarker, Boolean> markers;
     private boolean loadImageStarted;
 
     public AirMapMarkerSharedIcon(){
@@ -113,7 +109,7 @@ public class AirMapMarkerManager extends ViewGroupManager<AirMapMarker> {
     }
   }
 
-  private Map<String, AirMapMarkerSharedIcon> sharedIcons = new ConcurrentHashMap<>();
+  private final Map<String, AirMapMarkerSharedIcon> sharedIcons = new ConcurrentHashMap<>();
 
   /**
    * get the shared icon object, if not existed, create a new one and store it.
@@ -289,33 +285,25 @@ public class AirMapMarkerManager extends ViewGroupManager<AirMapMarker> {
   }
 
   @Override
-  @Nullable
-  public Map<String, Integer> getCommandsMap() {
-    return MapBuilder.of(
-        "showCallout", SHOW_INFO_WINDOW,
-        "hideCallout", HIDE_INFO_WINDOW,
-        "animateMarkerToCoordinate", ANIMATE_MARKER_TO_COORDINATE,
-        "redraw", REDRAW
-    );
-  }
-
-  @Override
-  public void receiveCommand(AirMapMarker view, int commandId, @Nullable ReadableArray args) {
-    Integer duration;
-    Double lat;
-    Double lng;
+  public void receiveCommand(@NonNull AirMapMarker view, String commandId, @Nullable ReadableArray args) {
+    int duration;
+    double lat;
+    double lng;
     ReadableMap region;
 
     switch (commandId) {
-      case SHOW_INFO_WINDOW:
+      case "showCallout":
         ((Marker) view.getFeature()).showInfoWindow();
         break;
 
-      case HIDE_INFO_WINDOW:
+      case "hideCallout":
         ((Marker) view.getFeature()).hideInfoWindow();
         break;
 
-      case ANIMATE_MARKER_TO_COORDINATE:
+      case "animateMarkerToCoordinate":
+        if(args == null) {
+          break;
+        }
         region = args.getMap(0);
         duration = args.getInt(1);
 
@@ -324,7 +312,7 @@ public class AirMapMarkerManager extends ViewGroupManager<AirMapMarker> {
         view.animateToCoodinate(new LatLng(lat, lng), duration);
         break;
 
-      case REDRAW:
+      case "redraw":
         view.updateMarkerIcon();
         break;
     }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapOverlay.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapOverlay.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.graphics.Bitmap;
 
 import com.facebook.react.bridge.ReadableArray;
-import com.facebook.react.bridge.ReadableMap;
 import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.model.BitmapDescriptor;
 import com.google.android.gms.maps.model.BitmapDescriptorFactory;
@@ -13,8 +12,6 @@ import com.google.android.gms.maps.model.GroundOverlayOptions;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.LatLngBounds;
 
-import java.util.ArrayList;
-
 public class AirMapOverlay extends AirMapFeature implements ImageReadable {
 
   private GroundOverlayOptions groundOverlayOptions;
@@ -22,7 +19,6 @@ public class AirMapOverlay extends AirMapFeature implements ImageReadable {
   private LatLngBounds bounds;
   private float bearing;
   private BitmapDescriptor iconBitmapDescriptor;
-  private Bitmap iconBitmap;
   private boolean tappable;
   private float zIndex;
   private float transparency;
@@ -133,7 +129,6 @@ public class AirMapOverlay extends AirMapFeature implements ImageReadable {
 
   @Override
   public void setIconBitmap(Bitmap bitmap) {
-    this.iconBitmap = bitmap;
   }
 
   @Override

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapOverlayManager.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapOverlayManager.java
@@ -1,7 +1,6 @@
 package versioned.host.exp.exponent.modules.api.components.maps;
 
 import android.content.Context;
-import android.os.Build;
 import android.util.DisplayMetrics;
 import android.view.WindowManager;
 
@@ -17,18 +16,13 @@ import com.facebook.react.uimanager.annotations.ReactProp;
 import java.util.Map;
 
 public class AirMapOverlayManager extends ViewGroupManager<AirMapOverlay> {
-  private final DisplayMetrics metrics;
 
   public AirMapOverlayManager(ReactApplicationContext reactContext) {
     super();
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-      metrics = new DisplayMetrics();
-      ((WindowManager) reactContext.getSystemService(Context.WINDOW_SERVICE))
-          .getDefaultDisplay()
-          .getRealMetrics(metrics);
-    } else {
-      metrics = reactContext.getResources().getDisplayMetrics();
-    }
+    DisplayMetrics metrics = new DisplayMetrics();
+    ((WindowManager) reactContext.getSystemService(Context.WINDOW_SERVICE))
+        .getDefaultDisplay()
+        .getRealMetrics(metrics);
   }
 
   @Override

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapPolygonManager.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapPolygonManager.java
@@ -2,7 +2,6 @@ package versioned.host.exp.exponent.modules.api.components.maps;
 
 import android.content.Context;
 import android.graphics.Color;
-import android.os.Build;
 import android.util.DisplayMetrics;
 import android.view.WindowManager;
 
@@ -22,14 +21,10 @@ public class AirMapPolygonManager extends ViewGroupManager<AirMapPolygon> {
 
   public AirMapPolygonManager(ReactApplicationContext reactContext) {
     super();
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-      metrics = new DisplayMetrics();
-      ((WindowManager) reactContext.getSystemService(Context.WINDOW_SERVICE))
-          .getDefaultDisplay()
-          .getRealMetrics(metrics);
-    } else {
-      metrics = reactContext.getResources().getDisplayMetrics();
-    }
+    metrics = new DisplayMetrics();
+    ((WindowManager) reactContext.getSystemService(Context.WINDOW_SERVICE))
+        .getDefaultDisplay()
+        .getRealMetrics(metrics);
   }
 
   @Override

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapPolyline.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapPolyline.java
@@ -109,7 +109,7 @@ public class AirMapPolyline extends AirMapFeature {
       if(isGap) {
         this.pattern.add(new Gap(patternValue));
       }else {
-        PatternItem patternItem = null;
+        PatternItem patternItem;
         boolean isLineCapRound = this.lineCap instanceof RoundCap;
         if(isLineCapRound) {
           patternItem = new Dot();

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapPolylineManager.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapPolylineManager.java
@@ -2,7 +2,6 @@ package versioned.host.exp.exponent.modules.api.components.maps;
 
 import android.content.Context;
 import android.graphics.Color;
-import android.os.Build;
 import android.util.DisplayMetrics;
 import android.view.WindowManager;
 
@@ -26,14 +25,10 @@ public class AirMapPolylineManager extends ViewGroupManager<AirMapPolyline> {
 
   public AirMapPolylineManager(ReactApplicationContext reactContext) {
     super();
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-      metrics = new DisplayMetrics();
-      ((WindowManager) reactContext.getSystemService(Context.WINDOW_SERVICE))
-          .getDefaultDisplay()
-          .getRealMetrics(metrics);
-    } else {
-      metrics = reactContext.getResources().getDisplayMetrics();
-    }
+    metrics = new DisplayMetrics();
+    ((WindowManager) reactContext.getSystemService(Context.WINDOW_SERVICE))
+        .getDefaultDisplay()
+        .getRealMetrics(metrics);
   }
 
   @Override

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapTileProvider.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapTileProvider.java
@@ -14,12 +14,8 @@ import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.Rect;
 
-import androidx.annotation.NonNull;
 import androidx.work.OneTimeWorkRequest;
 import androidx.work.WorkManager;
-import androidx.work.WorkRequest;
-import androidx.work.Worker;
-import androidx.work.WorkerParameters;
 import androidx.work.Data;
 import androidx.work.Constraints;
 import androidx.work.NetworkType;
@@ -27,10 +23,7 @@ import androidx.work.ExistingWorkPolicy;
 import androidx.work.Operation;
 import androidx.work.WorkInfo;
 
-import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.model.Tile;
-import com.google.android.gms.maps.model.TileOverlay;
-import com.google.android.gms.maps.model.TileOverlayOptions;
 import com.google.android.gms.maps.model.TileProvider;
 import com.google.android.gms.maps.model.UrlTileProvider;
 
@@ -61,7 +54,7 @@ public class AirMapTileProvider implements TileProvider {
     @Override
     public URL getTileUrl(int x, int y, int zoom) {
 
-      if (AirMapTileProvider.this.flipY == true) {
+      if (AirMapTileProvider.this.flipY) {
         y = (1 << zoom) - y - 1;
       }
 
@@ -69,14 +62,14 @@ public class AirMapTileProvider implements TileProvider {
           .replace("{x}", Integer.toString(x))
           .replace("{y}", Integer.toString(y))
           .replace("{z}", Integer.toString(zoom));
-      URL url = null;
+      URL url;
 
       if(AirMapTileProvider.this.maximumZ > 0 && zoom > AirMapTileProvider.this.maximumZ) {
-        return url;
+        return null;
       }
 
       if(AirMapTileProvider.this.minimumZ > 0 && zoom < AirMapTileProvider.this.minimumZ) {
-        return url;
+        return null;
       }
 
       try {
@@ -152,7 +145,7 @@ public class AirMapTileProvider implements TileProvider {
     if (image == null && this.tileCachePath != null && this.offlineMode) {
       Log.d("urlTile", "findLowerZoomTileForScaling");
       int zoomLevelToStart = (zoom > this.maximumNativeZ) ? this.maximumNativeZ - 1 : zoom - 1; 
-      int minimumZoomToSearch = this.minimumZ >= zoom - 3 ? this.minimumZ : zoom - 3;
+      int minimumZoomToSearch = Math.max(this.minimumZ, zoom - 3);
       for (int tryZoom = zoomLevelToStart; tryZoom >= minimumZoomToSearch; tryZoom--) {
   			image = scaleLowerZoomTile(x, y, zoom, tryZoom);
 	  		if (image != null) {
@@ -166,16 +159,15 @@ public class AirMapTileProvider implements TileProvider {
 
 	byte[] getTileImage(int x, int y, int zoom) {
 		byte[] image = null;
-		boolean fallbackOnSyncFetch = false;
-		
+
 		if (this.tileCachePath != null) {
 			image = readTileImage(x, y, zoom);
 			if (image != null) {
-				Log.d("urlTile: tile cache HIT for ", Integer.toString(zoom) + 
-					"/" + Integer.toString(x) + "/" + Integer.toString(y));
+				Log.d("urlTile", "tile cache HIT for " + zoom +
+					"/" + x + "/" + y);
 			} else {
-				Log.d("urlTile: tile cache MISS for ", Integer.toString(zoom) + 
-        	"/" + Integer.toString(x) + "/" + Integer.toString(y));
+				Log.d("urlTile", "tile cache MISS for " + zoom +
+        	"/" + x + "/" + y);
 			}
 			if (image != null && !this.offlineMode) {
 				checkForRefresh(x, y, zoom);
@@ -198,39 +190,35 @@ public class AirMapTileProvider implements TileProvider {
 						.build()
 					)
 				.build();
-			if (tileRefreshWorkRequest != null) {
-				WorkManager workManager = WorkManager.getInstance(this.context.getApplicationContext());
-				Operation fetchOperation = workManager
-					.enqueueUniqueWork(fileName, ExistingWorkPolicy.KEEP, tileRefreshWorkRequest);
-				Future<Operation.State.SUCCESS> operationFuture = fetchOperation.getResult();
-				try {
-					operationFuture.get(1L, TimeUnit.SECONDS);
-					Thread.sleep(500);
-					Future<List<WorkInfo>> fetchFuture = workManager.getWorkInfosByTag(fileName);
-					List<WorkInfo> workInfo = fetchFuture.get(1L, TimeUnit.SECONDS);
-					Log.d("urlTile: ", workInfo.get(0).toString());
-					if (this.tileCachePath != null) {
-						image = readTileImage(x, y, zoom);
-						if (image != null) {
-							Log.d("urlTile: tile cache fetch HIT for ", Integer.toString(zoom) + 
-								"/" + Integer.toString(x) + "/" + Integer.toString(y));
-						} else {
-								Log.d("urlTile: tile cache fetch MISS for ", Integer.toString(zoom) + 
-									"/" + Integer.toString(x) + "/" + Integer.toString(y));
-						}
+			WorkManager workManager = WorkManager.getInstance(this.context.getApplicationContext());
+			Operation fetchOperation = workManager
+				.enqueueUniqueWork(fileName, ExistingWorkPolicy.KEEP, tileRefreshWorkRequest);
+			Future<Operation.State.SUCCESS> operationFuture = fetchOperation.getResult();
+			try {
+				operationFuture.get(1L, TimeUnit.SECONDS);
+				Thread.sleep(500);
+				Future<List<WorkInfo>> fetchFuture = workManager.getWorkInfosByTag(fileName);
+				List<WorkInfo> workInfo = fetchFuture.get(1L, TimeUnit.SECONDS);
+				Log.d("urlTile: ", workInfo.get(0).toString());
+				if (this.tileCachePath != null) {
+					image = readTileImage(x, y, zoom);
+					if (image != null) {
+						Log.d("urlTile","tile cache fetch HIT for " + zoom +
+							"/" + x + "/" + y);
+					} else {
+							Log.d("urlTile","tile cache fetch MISS for " + zoom +
+								"/" + x + "/" + y);
 					}
-				} catch (Exception e) {
-      			e.printStackTrace();
 				}
-			} else {
-				fallbackOnSyncFetch = true;
+			} catch (Exception e) {
+			  e.printStackTrace();
 			}
-		} else if (fallbackOnSyncFetch || (image == null && !this.offlineMode)) {
+		} else if (image == null && !this.offlineMode) {
 			Log.d("urlTile", "Normal fetch");
 			image = fetchTile(x, y, zoom);
 			if (image == null) {
-				Log.d("urlTile: tile fetch TIMEOUT / FAIL for ", Integer.toString(zoom) + 
-					"/" + Integer.toString(x) + "/" + Integer.toString(y));
+				Log.d("urlTile", "tile fetch TIMEOUT / FAIL for " + zoom +
+					"/" + x + "/" + y);
 			}
 		}
 
@@ -304,7 +292,7 @@ public class AirMapTileProvider implements TileProvider {
     int yParent = y >> overZoomLevel;
     int zoomParent = zoom - overZoomLevel;
     
-    int xOffset = x % zoomFactor;;
+    int xOffset = x % zoomFactor;
     int yOffset = y % zoomFactor;
 
     byte[] data;
@@ -351,11 +339,9 @@ public class AirMapTileProvider implements TileProvider {
 						.build()
 					)
 				.build();
-			if (tileRefreshWorkRequest != null) {
-				WorkManager.getInstance(this.context.getApplicationContext())
-				.enqueueUniqueWork(fileName, ExistingWorkPolicy.KEEP, tileRefreshWorkRequest);
-			} 
-		} 
+			WorkManager.getInstance(this.context.getApplicationContext())
+			.enqueueUniqueWork(fileName, ExistingWorkPolicy.KEEP, tileRefreshWorkRequest);
+		}
 	}
 
 	byte[] fetchTile(int x, int y, int zoom) {
@@ -377,10 +363,7 @@ public class AirMapTileProvider implements TileProvider {
 			buffer.flush();
 
 			return buffer.toByteArray();
-		} catch (IOException e) {
-			e.printStackTrace();
-			return null;
-		} catch (OutOfMemoryError e) {
+		} catch (IOException | OutOfMemoryError e) {
 			e.printStackTrace();
 			return null;
 		} finally {
@@ -416,10 +399,7 @@ public class AirMapTileProvider implements TileProvider {
 			}
 
 			return buffer.toByteArray();
-		} catch (IOException e) {
-			e.printStackTrace();
-			return null;
-		} catch (OutOfMemoryError e) {
+		} catch (IOException | OutOfMemoryError e) {
 			e.printStackTrace();
 			return null;
 		} finally {
@@ -442,10 +422,7 @@ public class AirMapTileProvider implements TileProvider {
 			out.write(image);
 
 			return true;
-		} catch (IOException e) {
-			e.printStackTrace();
-			return false;
-		} catch (OutOfMemoryError e) {
+		} catch (IOException | OutOfMemoryError e) {
 			e.printStackTrace();
 			return false;
 		} finally {
@@ -457,9 +434,8 @@ public class AirMapTileProvider implements TileProvider {
 		if (this.tileCachePath == null) {
 			return null;
 		}
-		String s = this.tileCachePath + '/' + Integer.toString(zoom) + 
-			"/" + Integer.toString(x) + "/" + Integer.toString(y);
-		return s;
+		return this.tileCachePath + '/' + zoom +
+			"/" + x + "/" + y;
 	}
 	
 	protected URL getTileUrl(int x, int y, int zoom) {
@@ -510,6 +486,5 @@ public class AirMapTileProvider implements TileProvider {
 	}
 
 	public void setCustomMode() {
-		this.customMode = customMode;
 	}
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapTileWorker.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapTileWorker.java
@@ -10,7 +10,6 @@ import androidx.work.WorkerParameters;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -30,8 +29,8 @@ public class AirMapTileWorker extends Worker {
 
 	@Override
 	public Result doWork() {
-		byte[] image = null;
-		URL url = null;
+		byte[] image;
+		URL url;
     String fileName = getInputData().getString("filename");
 
     try {
@@ -84,10 +83,7 @@ public class AirMapTileWorker extends Worker {
         buffer.flush();
 
         return buffer.toByteArray();
-      } catch (IOException e) {
-        e.printStackTrace();
-        return null;
-      } catch (OutOfMemoryError e) {
+      } catch (IOException | OutOfMemoryError e) {
         e.printStackTrace();
         return null;
       } finally {
@@ -109,10 +105,7 @@ public class AirMapTileWorker extends Worker {
         out.write(image);
 
         return true;
-      } catch (IOException e) {
-        e.printStackTrace();
-        return false;
-      } catch (OutOfMemoryError e) {
+      } catch (IOException | OutOfMemoryError e) {
         e.printStackTrace();
         return false;
       } finally {

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapUrlTile.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapUrlTile.java
@@ -87,7 +87,7 @@ public class AirMapUrlTile extends AirMapFeature {
   public void setFlipY(boolean flipY) {
     this.flipY = flipY;
     if (tileProvider != null) {
-      tileProvider.setFlipY((boolean)flipY);
+      tileProvider.setFlipY(flipY);
     }
     if (tileOverlay != null) {
       tileOverlay.clearTileCache();
@@ -97,7 +97,7 @@ public class AirMapUrlTile extends AirMapFeature {
   public void setDoubleTileSize(boolean doubleTileSize) {
     this.doubleTileSize = doubleTileSize;
     if (tileProvider != null) {
-      tileProvider.setDoubleTileSize((boolean)doubleTileSize);
+      tileProvider.setDoubleTileSize(doubleTileSize);
     }
     setCustomTileProviderMode();
     if (tileOverlay != null) {
@@ -149,7 +149,7 @@ public class AirMapUrlTile extends AirMapFeature {
   public void setOfflineMode(boolean offlineMode) {
     this.offlineMode = offlineMode;
     if (tileProvider != null) {
-      tileProvider.setOfflineMode((boolean)offlineMode);
+      tileProvider.setOfflineMode(offlineMode);
     }
     if (tileOverlay != null) {
       tileOverlay.clearTileCache();

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapUrlTileManager.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapUrlTileManager.java
@@ -1,7 +1,6 @@
 package versioned.host.exp.exponent.modules.api.components.maps;
 
 import android.content.Context;
-import android.os.Build;
 import android.util.DisplayMetrics;
 import android.view.WindowManager;
 
@@ -11,18 +10,13 @@ import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.annotations.ReactProp;
 
 public class AirMapUrlTileManager extends ViewGroupManager<AirMapUrlTile> {
-  private DisplayMetrics metrics;
 
   public AirMapUrlTileManager(ReactApplicationContext reactContext) {
     super();
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-      metrics = new DisplayMetrics();
-      ((WindowManager) reactContext.getSystemService(Context.WINDOW_SERVICE))
-          .getDefaultDisplay()
-          .getRealMetrics(metrics);
-    } else {
-      metrics = reactContext.getResources().getDisplayMetrics();
-    }
+    DisplayMetrics metrics = new DisplayMetrics();
+    ((WindowManager) reactContext.getSystemService(Context.WINDOW_SERVICE))
+        .getDefaultDisplay()
+        .getRealMetrics(metrics);
   }
 
   @Override

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapView.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapView.java
@@ -5,10 +5,9 @@ import android.content.res.ColorStateList;
 import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.graphics.Point;
-import android.graphics.PorterDuff;
-import android.graphics.Rect;
-import android.os.Build;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.core.content.PermissionChecker;
 import androidx.core.view.GestureDetectorCompat;
 import androidx.core.view.MotionEventCompat;
@@ -32,7 +31,6 @@ import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.UIManagerModule;
-import com.facebook.react.uimanager.ViewProps;
 import com.facebook.react.uimanager.events.EventDispatcher;
 import com.google.android.gms.maps.CameraUpdate;
 import com.google.android.gms.maps.CameraUpdateFactory;
@@ -46,13 +44,13 @@ import com.google.android.gms.maps.model.CameraPosition;
 import com.google.android.gms.maps.model.GroundOverlay;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.LatLngBounds;
+import com.google.android.gms.maps.model.MapStyleOptions;
 import com.google.android.gms.maps.model.Marker;
 import com.google.android.gms.maps.model.MarkerOptions;
 import com.google.android.gms.maps.model.PointOfInterest;
 import com.google.android.gms.maps.model.Polygon;
 import com.google.android.gms.maps.model.Polyline;
 import com.google.android.gms.maps.model.TileOverlay;
-import com.google.android.gms.maps.model.VisibleRegion;
 import com.google.android.gms.maps.model.IndoorBuilding;
 import com.google.android.gms.maps.model.IndoorLevel;
 import com.google.maps.android.data.kml.KmlContainer;
@@ -76,7 +74,6 @@ import static androidx.core.content.PermissionChecker.checkSelfPermission;
 public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     GoogleMap.OnMarkerDragListener, OnMapReadyCallback, GoogleMap.OnPoiClickListener, GoogleMap.OnIndoorStateChangeListener {
   public GoogleMap map;
-  private KmlLayer kmlLayer;
   private ProgressBar mapLoadingProgressBar;
   private RelativeLayout mapLoadingLayout;
   private ImageView cacheImageView;
@@ -92,6 +89,10 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
   private boolean moveOnMarkerPress = true;
   private boolean cacheEnabled = false;
   private ReadableMap initialRegion;
+  private ReadableMap initialCamera;
+  private ReadableMap region;
+  private ReadableMap camera;
+  private String customMapStyleString;
   private boolean initialRegionSet = false;
   private boolean initialCameraSet = false;
   private LatLngBounds cameraLastIdleBounds;
@@ -114,9 +115,9 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
   private boolean destroyed = false;
   private final ThemedReactContext context;
   private final EventDispatcher eventDispatcher;
-  private FusedLocationSource fusedLocationSource;
+  private final FusedLocationSource fusedLocationSource;
 
-  private ViewAttacherGroup attacherGroup;
+  private final ViewAttacherGroup attacherGroup;
   private LatLng tapLocation;
 
   private static boolean contextHasBug(Context context) {
@@ -143,9 +144,8 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
         superContext = reactContext.getCurrentActivity();
       } else if (!contextHasBug(reactContext.getApplicationContext())) {
         superContext = reactContext.getApplicationContext();
-      } else {
-        // ¯\_(ツ)_/¯
       }
+
     }
     return superContext;
   }
@@ -210,7 +210,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
   }
 
   @Override
-  public void onMapReady(final GoogleMap map) {
+  public void onMapReady(@NonNull final GoogleMap map) {
     if (destroyed) {
       return;
     }
@@ -219,10 +219,8 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     this.map.setOnMarkerDragListener(this);
     this.map.setOnPoiClickListener(this);
     this.map.setOnIndoorStateChangeListener(this);
-    if(initialRegion != null) {
-      setRegion(initialRegion);
-      initialRegionSet = true;
-    }
+
+    applyBridgedProps();
 
     manager.pushEvent(context, this, "onMapReady", new WritableNativeMap());
 
@@ -241,9 +239,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
         coordinate.putDouble("accuracy", location.getAccuracy());
         coordinate.putDouble("speed", location.getSpeed());
         coordinate.putDouble("heading", location.getBearing());
-        if(android.os.Build.VERSION.SDK_INT >= 18){
         coordinate.putBoolean("isFromMockProvider", location.isFromMockProvider());
-        }
 
         event.putMap("coordinate", coordinate);
 
@@ -291,7 +287,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     map.setOnPolylineClickListener(new GoogleMap.OnPolylineClickListener() {
       @Override
       public void onPolylineClick(Polyline polyline) {
-        WritableMap event = makeClickEventData(polyline.getPoints().get(0));
+        WritableMap event = makeClickEventData(tapLocation);
         event.putString("action", "polyline-press");
         manager.pushEvent(context, polylineMap.get(polyline), "onPress", event);
       }
@@ -465,30 +461,50 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
   public void setInitialRegion(ReadableMap initialRegion) {
     this.initialRegion = initialRegion;
     // Theoretically onMapReady might be called before setInitialRegion
-    // In that case, trigger setRegion manually
+    // In that case, trigger moveToRegion manually
     if (!initialRegionSet && map != null) {
-      setRegion(initialRegion);
+      moveToRegion(initialRegion);
       initialRegionSet = true;
     }
   }
 
   public void setInitialCamera(ReadableMap initialCamera) {
-    if (!initialCameraSet && initialCamera != null) {
-      setCamera(initialCamera);
+    this.initialCamera = initialCamera;
+    // Theoretically onMapReady might be called before setInitialCamera
+    // In that case, trigger moveToCamera manually
+    if (!initialCameraSet && map != null) {
+      moveToCamera(initialCamera);
       initialCameraSet = true;
     }
   }
 
-  public void setRegion(ReadableMap region) {
+  private void applyBridgedProps() {
+    if(initialRegion != null) {
+      moveToRegion(initialRegion);
+      initialRegionSet = true;
+    } else if(initialCamera != null) {
+      moveToCamera(initialCamera);
+      initialCameraSet = true;
+    } else if(region != null) {
+      moveToRegion(region);
+    } else {
+      moveToCamera(camera);
+    }
+    if(customMapStyleString != null) {
+      map.setMapStyle(new MapStyleOptions(customMapStyleString));
+    }
+  }
+
+  private void moveToRegion(ReadableMap region) {
     if (region == null) return;
 
-    Double lng = region.getDouble("longitude");
-    Double lat = region.getDouble("latitude");
-    Double lngDelta = region.getDouble("longitudeDelta");
-    Double latDelta = region.getDouble("latitudeDelta");
+    double lng = region.getDouble("longitude");
+    double lat = region.getDouble("latitude");
+    double lngDelta = region.getDouble("longitudeDelta");
+    double latDelta = region.getDouble("latitudeDelta");
     LatLngBounds bounds = new LatLngBounds(
-        new LatLng(lat - latDelta / 2, lng - lngDelta / 2), // southwest
-        new LatLng(lat + latDelta / 2, lng + lngDelta / 2)  // northeast
+            new LatLng(lat - latDelta / 2, lng - lngDelta / 2), // southwest
+            new LatLng(lat + latDelta / 2, lng + lngDelta / 2)  // northeast
     );
     if (super.getHeight() <= 0 || super.getWidth() <= 0) {
       // in this case, our map has not been laid out yet, so we save the bounds in a local
@@ -503,15 +519,29 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     }
   }
 
+  public void setRegion(ReadableMap region) {
+    this.region = region;
+    if(region != null && map != null) {
+      moveToRegion(region);
+    }
+  }
+
   public void setCamera(ReadableMap camera) {
+    this.camera = camera;
+    if(camera != null && map != null) {
+      moveToCamera(camera);
+    }
+  }
+
+  public void moveToCamera(ReadableMap camera) {
     if (camera == null) return;
 
     CameraPosition.Builder builder = new CameraPosition.Builder();
 
     ReadableMap center = camera.getMap("center");
     if (center != null) {
-      Double lng = center.getDouble("longitude");
-      Double lat = center.getDouble("latitude");
+      double lng = center.getDouble("longitude");
+      double lat = center.getDouble("latitude");
       builder.target(new LatLng(lat, lng));
     }
 
@@ -529,6 +559,13 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     } else {
       map.moveCamera(update);
       cameraToSet = null;
+    }
+  }
+
+  public void setMapStyle(@Nullable String customMapStyleString) {
+    this.customMapStyleString = customMapStyleString;
+    if(map != null && customMapStyleString != null) {
+      map.setMapStyle(new MapStyleOptions(customMapStyleString));
     }
   }
 
@@ -600,24 +637,13 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
         color = Color.parseColor("#606060");
       }
 
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-        ColorStateList progressTintList = ColorStateList.valueOf(loadingIndicatorColor);
-        ColorStateList secondaryProgressTintList = ColorStateList.valueOf(loadingIndicatorColor);
-        ColorStateList indeterminateTintList = ColorStateList.valueOf(loadingIndicatorColor);
+      ColorStateList progressTintList = ColorStateList.valueOf(loadingIndicatorColor);
+      ColorStateList secondaryProgressTintList = ColorStateList.valueOf(loadingIndicatorColor);
+      ColorStateList indeterminateTintList = ColorStateList.valueOf(loadingIndicatorColor);
 
-        this.mapLoadingProgressBar.setProgressTintList(progressTintList);
-        this.mapLoadingProgressBar.setSecondaryProgressTintList(secondaryProgressTintList);
-        this.mapLoadingProgressBar.setIndeterminateTintList(indeterminateTintList);
-      } else {
-        PorterDuff.Mode mode = PorterDuff.Mode.SRC_IN;
-        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.GINGERBREAD_MR1) {
-          mode = PorterDuff.Mode.MULTIPLY;
-        }
-        if (this.mapLoadingProgressBar.getIndeterminateDrawable() != null)
-          this.mapLoadingProgressBar.getIndeterminateDrawable().setColorFilter(color, mode);
-        if (this.mapLoadingProgressBar.getProgressDrawable() != null)
-          this.mapLoadingProgressBar.getProgressDrawable().setColorFilter(color, mode);
-      }
+      this.mapLoadingProgressBar.setProgressTintList(progressTintList);
+      this.mapLoadingProgressBar.setSecondaryProgressTintList(secondaryProgressTintList);
+      this.mapLoadingProgressBar.setIndeterminateTintList(indeterminateTintList);
     }
   }
 
@@ -799,41 +825,13 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     }
   }
 
-  public void animateToNavigation(LatLng location, float bearing, float angle, int duration) {
-    if (map == null) return;
-    CameraPosition cameraPosition = new CameraPosition.Builder(map.getCameraPosition())
-        .bearing(bearing)
-        .tilt(angle)
-        .target(location)
-        .build();
-    map.animateCamera(CameraUpdateFactory.newCameraPosition(cameraPosition), duration, null);
-  }
-
   public void animateToRegion(LatLngBounds bounds, int duration) {
     if (map == null) return;
-    map.animateCamera(CameraUpdateFactory.newLatLngBounds(bounds, 0), duration, null);
-  }
-
-  public void animateToViewingAngle(float angle, int duration) {
-    if (map == null) return;
-
-    CameraPosition cameraPosition = new CameraPosition.Builder(map.getCameraPosition())
-      .tilt(angle)
-      .build();
-    map.animateCamera(CameraUpdateFactory.newCameraPosition(cameraPosition), duration, null);
-  }
-
-  public void animateToBearing(float bearing, int duration) {
-    if (map == null) return;
-    CameraPosition cameraPosition = new CameraPosition.Builder(map.getCameraPosition())
-        .bearing(bearing)
-        .build();
-    map.animateCamera(CameraUpdateFactory.newCameraPosition(cameraPosition), duration, null);
-  }
-
-  public void animateToCoordinate(LatLng coordinate, int duration) {
-    if (map == null) return;
-    map.animateCamera(CameraUpdateFactory.newLatLng(coordinate), duration, null);
+    if(duration <= 0) {
+      map.moveCamera(CameraUpdateFactory.newLatLngBounds(bounds, 0));
+    } else {
+      map.animateCamera(CameraUpdateFactory.newLatLngBounds(bounds, 0), duration, null);
+    }
   }
 
   public void fitToElements(ReadableMap edgePadding, boolean animated) {
@@ -931,8 +929,8 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
 
     for (int i = 0; i < coordinatesArray.size(); i++) {
       ReadableMap latLng = coordinatesArray.getMap(i);
-      Double lat = latLng.getDouble("latitude");
-      Double lng = latLng.getDouble("longitude");
+      double lat = latLng.getDouble("latitude");
+      double lng = latLng.getDouble("longitude");
       builder.include(new LatLng(lat, lng));
     }
 
@@ -986,12 +984,12 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
 
     LatLngBounds.Builder builder = new LatLngBounds.Builder();
 
-    Double latNE = northEast.getDouble("latitude");
-    Double lngNE = northEast.getDouble("longitude");
+    double latNE = northEast.getDouble("latitude");
+    double lngNE = northEast.getDouble("longitude");
     builder.include(new LatLng(latNE, lngNE));
 
-    Double latSW = southWest.getDouble("latitude");
-    Double lngSW = southWest.getDouble("longitude");
+    double latSW = southWest.getDouble("latitude");
+    double lngSW = southWest.getDouble("longitude");
     builder.include(new LatLng(latSW, lngSW));
 
     LatLngBounds bounds = builder.build();
@@ -1188,7 +1186,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
         return;
       }
 
-      kmlLayer = new KmlLayer(map, kmlStream, context);
+      KmlLayer kmlLayer = new KmlLayer(map, kmlStream, context);
       kmlLayer.addLayerToMap();
 
       WritableMap pointers = new WritableNativeMap();
@@ -1211,7 +1209,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
         container = container.getContainers().iterator().next();
       }
 
-      Integer index = 0;
+      int index = 0;
       for (KmlPlacemark placemark : container.getPlacemarks()) {
         MarkerOptions options = new MarkerOptions();
 
@@ -1265,13 +1263,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
 
       manager.pushEvent(context, this, "onKmlReady", pointers);
 
-    } catch (XmlPullParserException e) {
-      e.printStackTrace();
-    } catch (IOException e) {
-      e.printStackTrace();
-    } catch (InterruptedException e) {
-      e.printStackTrace();
-    } catch (ExecutionException e) {
+    } catch (XmlPullParserException | IOException | InterruptedException | ExecutionException e) {
       e.printStackTrace();
     }
   }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapWMSTile.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapWMSTile.java
@@ -2,10 +2,6 @@ package versioned.host.exp.exponent.modules.api.components.maps;
 
 import android.content.Context;
 
-import android.util.Log;
-
-import com.google.android.gms.maps.GoogleMap;
-import com.google.android.gms.maps.model.TileOverlay;
 import com.google.android.gms.maps.model.TileOverlayOptions;
 import com.google.android.gms.maps.model.UrlTileProvider;
 
@@ -20,7 +16,7 @@ public class AirMapWMSTile extends AirMapUrlTile {
 
     class AIRMapWMSTileProvider extends UrlTileProvider {
     private String urlTemplate;
-    private int tileSize;
+    private final int tileSize;
 
     public AIRMapWMSTileProvider(int width, int height, String urlTemplate) {
       super(width, height);
@@ -80,8 +76,6 @@ public class AirMapWMSTile extends AirMapUrlTile {
     }
   }
 
-  private AIRMapGSUrlTileProvider tileProvider;
-
   public AirMapWMSTile(Context context) {
     super(context);
   }
@@ -91,10 +85,10 @@ public class AirMapWMSTile extends AirMapUrlTile {
     TileOverlayOptions options = new TileOverlayOptions();
     options.zIndex(zIndex);
     options.transparency(1 - this.opacity);
-    this.tileProvider = new AIRMapGSUrlTileProvider((int)this.tileSize, this.urlTemplate, 
-      (int)this.maximumZ, (int)this.maximumNativeZ, (int)this.minimumZ, this.tileCachePath, 
-      (int)this.tileCacheMaxAge, this.offlineMode, this.context, this.customTileProviderNeeded);
-    options.tileProvider(this.tileProvider);
+    AIRMapGSUrlTileProvider tileProvider = new AIRMapGSUrlTileProvider((int) this.tileSize, this.urlTemplate,
+            (int) this.maximumZ, (int) this.maximumNativeZ, (int) this.minimumZ, this.tileCachePath,
+            (int) this.tileCacheMaxAge, this.offlineMode, this.context, this.customTileProviderNeeded);
+    options.tileProvider(tileProvider);
     return options;
   }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapWMSTileManager.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapWMSTileManager.java
@@ -1,7 +1,6 @@
 package versioned.host.exp.exponent.modules.api.components.maps;
 
 import android.content.Context;
-import android.os.Build;
 import android.util.DisplayMetrics;
 import android.view.WindowManager;
 
@@ -11,18 +10,13 @@ import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.annotations.ReactProp;
 
 public class AirMapWMSTileManager extends ViewGroupManager<AirMapWMSTile> {
-  private DisplayMetrics metrics;
 
   public AirMapWMSTileManager(ReactApplicationContext reactContext) {
     super();
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-      metrics = new DisplayMetrics();
-      ((WindowManager) reactContext.getSystemService(Context.WINDOW_SERVICE))
-          .getDefaultDisplay()
-          .getRealMetrics(metrics);
-    } else {
-      metrics = reactContext.getResources().getDisplayMetrics();
-    }
+    DisplayMetrics metrics = new DisplayMetrics();
+    ((WindowManager) reactContext.getSystemService(Context.WINDOW_SERVICE))
+        .getDefaultDisplay()
+        .getRealMetrics(metrics);
   }
 
   @Override

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/FileUtil.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/FileUtil.java
@@ -18,10 +18,6 @@ import java.nio.channels.ReadableByteChannel;
 
 public class FileUtil extends AsyncTask<String, Void, InputStream> {
 
-  private final String NAME = "FileUtil";
-  private final String TEMP_FILE_SUFFIX = "temp";
-
-  private Exception exception;
   private Context context;
 
   public FileUtil(Context context) {
@@ -39,7 +35,6 @@ public class FileUtil extends AsyncTask<String, Void, InputStream> {
       }
       return context.getContentResolver().openInputStream(fileContentUri);
     } catch (Exception e) {
-      this.exception = e;
       FLog.e(
           ReactConstants.TAG,
           "Could not retrieve file for contentUri " + urls[0],
@@ -51,6 +46,8 @@ public class FileUtil extends AsyncTask<String, Void, InputStream> {
   private InputStream getDownloadFileInputStream(Context context, Uri uri)
       throws IOException {
     final File outputDir = context.getApplicationContext().getCacheDir();
+    String NAME = "FileUtil";
+    String TEMP_FILE_SUFFIX = "temp";
     final File file = File.createTempFile(NAME, TEMP_FILE_SUFFIX, outputDir);
     file.deleteOnExit();
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/FusedLocationSource.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/FusedLocationSource.java
@@ -1,5 +1,6 @@
 package versioned.host.exp.exponent.modules.api.components.maps;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.location.Location;
 import android.os.Looper;
@@ -9,6 +10,7 @@ import com.google.android.gms.location.LocationCallback;
 import com.google.android.gms.location.LocationRequest;
 import com.google.android.gms.location.LocationResult;
 import com.google.android.gms.location.LocationServices;
+import com.google.android.gms.location.Priority;
 import com.google.android.gms.maps.LocationSource;
 import com.google.android.gms.tasks.OnSuccessListener;
 
@@ -24,7 +26,7 @@ public class FusedLocationSource implements LocationSource {
         fusedLocationClientProviderClient =
                 LocationServices.getFusedLocationProviderClient(context);
         locationRequest = LocationRequest.create();
-        locationRequest.setPriority(LocationRequest.PRIORITY_HIGH_ACCURACY);
+        locationRequest.setPriority(Priority.PRIORITY_HIGH_ACCURACY);
         locationRequest.setInterval(5000);
     }
 
@@ -40,6 +42,7 @@ public class FusedLocationSource implements LocationSource {
         locationRequest.setFastestInterval(fastestInterval);
     }
 
+    @SuppressLint("MissingPermission")
     @Override
     public void activate(final OnLocationChangedListener onLocationChangedListener) {
         try {

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/ImageReader.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/ImageReader.java
@@ -49,7 +49,7 @@ public class ImageReader {
             imageReference = dataSource.getResult();
             if (imageReference != null) {
               CloseableImage image = imageReference.get();
-              if (image != null && image instanceof CloseableStaticBitmap) {
+              if (image instanceof CloseableStaticBitmap) {
                 CloseableStaticBitmap closeableStaticBitmap = (CloseableStaticBitmap) image;
                 Bitmap bitmap = closeableStaticBitmap.getUnderlyingBitmap();
                 if (bitmap != null) {
@@ -104,11 +104,9 @@ public class ImageReader {
       logoHolder.setController(controller);
     } else {
       BitmapDescriptor iconBitmapDescriptor = getBitmapDescriptorByName(uri);
-      if (iconBitmapDescriptor != null) {
-        imp.setIconBitmapDescriptor(iconBitmapDescriptor);
-        imp.setIconBitmap(BitmapFactory.decodeResource(this.resources, getDrawableResourceByName
-            (uri)));
-      }
+      imp.setIconBitmapDescriptor(iconBitmapDescriptor);
+      imp.setIconBitmap(BitmapFactory.decodeResource(this.resources, getDrawableResourceByName
+          (uri)));
       imp.update();
     }
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/ViewAttacherGroup.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/ViewAttacherGroup.java
@@ -1,11 +1,8 @@
 package versioned.host.exp.exponent.modules.api.components.maps;
 
 import android.content.Context;
-import android.graphics.Canvas;
 import android.graphics.Rect;
-import android.os.Build;
 
-import com.facebook.react.uimanager.ViewProps;
 import com.facebook.react.views.view.ReactViewGroup;
 
 public class ViewAttacherGroup extends ReactViewGroup {
@@ -17,9 +14,7 @@ public class ViewAttacherGroup extends ReactViewGroup {
     this.setVisibility(VISIBLE);
     this.setAlpha(0.0f);
     this.setRemoveClippedSubviews(false);
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
-      this.setClipBounds(new Rect(0, 0, 0, 0));
-    }
+    this.setClipBounds(new Rect(0, 0, 0, 0));
     this.setOverflow("hidden"); // Change to ViewProps.HIDDEN until RN 0.57 is base
   }
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/ViewChangesTracker.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/ViewChangesTracker.java
@@ -8,10 +8,10 @@ import java.util.LinkedList;
 public class ViewChangesTracker {
 
   private static ViewChangesTracker instance;
-  private Handler handler;
-  private LinkedList<AirMapMarker> markers = new LinkedList<>();
+  private final Handler handler;
+  private final LinkedList<AirMapMarker> markers = new LinkedList<>();
   private boolean hasScheduledFrame = false;
-  private Runnable updateRunnable;
+  private final Runnable updateRunnable;
   private final long fps = 40;
 
   private ViewChangesTracker() {
@@ -56,7 +56,7 @@ public class ViewChangesTracker {
     return markers.contains(marker);
   }
 
-  private LinkedList<AirMapMarker> markersToRemove = new LinkedList<>();
+  private final LinkedList<AirMapMarker> markersToRemove = new LinkedList<>();
 
   public void update() {
     for (AirMapMarker marker : markers) {

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -146,7 +146,7 @@
     "react-native": "0.70.2",
     "react-native-gesture-handler": "~2.7.0",
     "react-native-iphone-x-helper": "^1.3.0",
-    "react-native-maps": "0.31.1",
+    "react-native-maps": "1.3.2",
     "react-native-pager-view": "5.4.24",
     "react-native-paper": "^4.0.1",
     "react-native-reanimated": "~2.10.0",

--- a/home/package.json
+++ b/home/package.json
@@ -58,7 +58,7 @@
     "react-native-gesture-handler": "~2.7.0",
     "react-native-infinite-scroll-view": "^0.4.5",
     "react-native-keyboard-aware-scroll-view": "^0.9.5",
-    "react-native-maps": "0.31.1",
+    "react-native-maps": "1.3.2",
     "react-native-paper": "^4.0.1",
     "react-native-reanimated": "~2.10.0",
     "react-native-safe-area-context": "4.4.1",

--- a/home/screens/GeofencingScreen.tsx
+++ b/home/screens/GeofencingScreen.tsx
@@ -13,7 +13,7 @@ import {
   Text,
   View,
 } from 'react-native';
-import MapView, { Circle, MapEvent } from 'react-native-maps';
+import MapView, { Circle, MapPressEvent } from 'react-native-maps';
 
 import NavigationEvents from '../components/NavigationEvents';
 import Button from '../components/PrimaryButton';
@@ -150,7 +150,7 @@ export default class GeofencingScreen extends React.Component<Props, State> {
     }
   };
 
-  onMapPress = ({ nativeEvent: { coordinate } }: MapEvent) => {
+  onMapPress = ({ nativeEvent: { coordinate } }: MapPressEvent) => {
     this.setState(
       (state) => ({
         geofencingRegions: [

--- a/ios/Exponent/Versioned/Core/Api/Components/GoogleMaps/AIRGoogleMap.h
+++ b/ios/Exponent/Versioned/Core/Api/Components/GoogleMaps/AIRGoogleMap.h
@@ -22,7 +22,7 @@
 @property (nonatomic, assign) MKCoordinateRegion initialRegion;
 @property (nonatomic, assign) MKCoordinateRegion region;
 @property (nonatomic, assign) GMSCameraPosition *cameraProp;   // Because the base class already has a "camera" prop.
-@property (nonatomic, assign) GMSCameraPosition *initialCamera;
+@property (nonatomic, strong) GMSCameraPosition *initialCamera;
 @property (nonatomic, assign) NSString *customMapStyleString;
 @property (nonatomic, assign) UIEdgeInsets mapPadding;
 @property (nonatomic, assign) NSString *paddingAdjustmentBehaviorString;

--- a/ios/Exponent/Versioned/Core/Api/Components/GoogleMaps/AIRGoogleMap.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/GoogleMaps/AIRGoogleMap.m
@@ -62,9 +62,11 @@ id regionAsJSON(MKCoordinateRegion region) {
   NSMutableArray<UIView *> *_reactSubviews;
   MKCoordinateRegion _initialRegion;
   MKCoordinateRegion _region;
-  BOOL _initialCameraSetOnLoad;
+  BOOL _initialRegionSet;
+  BOOL _initialCameraSet;
+  BOOL _didLayoutSubviews;
+  BOOL _didPrepareMap;
   BOOL _didCallOnMapReady;
-  BOOL _didMoveToWindow;
   BOOL _zoomTapEnabled;
 }
 
@@ -83,9 +85,11 @@ id regionAsJSON(MKCoordinateRegion region) {
     _cameraProp = nil;
     _initialRegion = MKCoordinateRegionMake(CLLocationCoordinate2DMake(0.0, 0.0), MKCoordinateSpanMake(0.0, 0.0));
     _region = MKCoordinateRegionMake(CLLocationCoordinate2DMake(0.0, 0.0), MKCoordinateSpanMake(0.0, 0.0));
-    _initialCameraSetOnLoad = false;
+    _initialRegionSet = false;
+    _initialCameraSet = false;
+    _didLayoutSubviews = false;
+    _didPrepareMap = false;
     _didCallOnMapReady = false;
-    _didMoveToWindow = false;
     _zoomTapEnabled = YES;
 
     // Listen to the myLocation property of GMSMapView.
@@ -245,42 +249,47 @@ id regionAsJSON(MKCoordinateRegion region) {
     ];
 }
 
-- (void)didMoveToWindow {
-  if (_didMoveToWindow) return;
-  _didMoveToWindow = true;
+- (void)layoutSubviews {
+  [super layoutSubviews];
+  if(_didLayoutSubviews) return;
+  _didLayoutSubviews = true;
 
   if (_initialCamera != nil) {
     self.camera = _initialCamera;
+    _initialCameraSet = true;
   }
   else if (_initialRegion.span.latitudeDelta != 0.0 &&
       _initialRegion.span.longitudeDelta != 0.0) {
     self.camera = [AIRGoogleMap makeGMSCameraPositionFromMap:self andMKCoordinateRegion:_initialRegion];
+    _initialRegionSet = true;
   } else if (_region.span.latitudeDelta != 0.0 &&
       _region.span.longitudeDelta != 0.0) {
     self.camera = [AIRGoogleMap makeGMSCameraPositionFromMap:self andMKCoordinateRegion:_region];
   }
-
-  [super didMoveToWindow];
 }
 
 - (void)setInitialRegion:(MKCoordinateRegion)initialRegion {
-  if (_initialCameraSetOnLoad) return;
   _initialRegion = initialRegion;
-  _initialCameraSetOnLoad = _didMoveToWindow;
-  self.camera = [AIRGoogleMap makeGMSCameraPositionFromMap:self andMKCoordinateRegion:initialRegion];
+  if(!_initialRegionSet && _didLayoutSubviews){
+    self.camera = [AIRGoogleMap makeGMSCameraPositionFromMap:self andMKCoordinateRegion:initialRegion];
+    _initialRegionSet = true;
+  }
 }
 
 - (void)setInitialCamera:(GMSCameraPosition*)initialCamera {
-    if (_initialCameraSetOnLoad) return;
     _initialCamera = initialCamera;
-    _initialCameraSetOnLoad = _didMoveToWindow;
-    self.camera = initialCamera;
+    if(!_initialCameraSet && _didLayoutSubviews){
+      self.camera = initialCamera;
+      _initialCameraSet = true;
+    }
 }
 
 - (void)setRegion:(MKCoordinateRegion)region {
   // TODO: The JS component is repeatedly setting region unnecessarily. We might want to deal with that in here.
   _region = region;
-  self.camera = [AIRGoogleMap makeGMSCameraPositionFromMap:self  andMKCoordinateRegion:region];
+  if(_didLayoutSubviews) {
+    self.camera = [AIRGoogleMap makeGMSCameraPositionFromMap:self  andMKCoordinateRegion:region];
+  }
 }
 
 - (void)setCameraProp:(GMSCameraPosition*)camera {
@@ -288,14 +297,23 @@ id regionAsJSON(MKCoordinateRegion region) {
     self.camera = camera;
 }
 
+- (void)setOnMapReady:(RCTBubblingEventBlock)onMapReady {
+    _onMapReady = onMapReady;
+    if(!_didCallOnMapReady && _didPrepareMap) {
+      self.onMapReady(@{});
+      _didCallOnMapReady = true;
+    }
+}
 
 - (void)didPrepareMap {
   UIView* mapView = [self valueForKey:@"mapView"]; //GMSVectorMapView
   [self overrideGestureRecognizersForView:mapView];
 
-  if (_didCallOnMapReady) return;
-  _didCallOnMapReady = true;
-  if (self.onMapReady) self.onMapReady(@{});
+  if (!_didCallOnMapReady && self.onMapReady) {
+    self.onMapReady(@{});
+    _didCallOnMapReady = true;
+  }
+  _didPrepareMap = true;
 }
 
 - (void)mapViewDidFinishTileRendering {

--- a/ios/Exponent/Versioned/Core/Api/Components/GoogleMaps/AIRGoogleMapCircle.h
+++ b/ios/Exponent/Versioned/Core/Api/Components/GoogleMaps/AIRGoogleMapCircle.h
@@ -14,9 +14,9 @@
 @property (nonatomic, strong) GMSCircle *circle;
 @property (nonatomic, assign) double radius;
 @property (nonatomic, assign) CLLocationCoordinate2D centerCoordinate;
-@property (nonatomic, assign) UIColor *strokeColor;
+@property (nonatomic, strong) UIColor *strokeColor;
 @property (nonatomic, assign) double strokeWidth;
-@property (nonatomic, assign) UIColor *fillColor;
+@property (nonatomic, strong) UIColor *fillColor;
 @property (nonatomic, assign) int zIndex;
 
 @end

--- a/ios/Exponent/Versioned/Core/Api/Components/GoogleMaps/AIRGoogleMapCircle.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/GoogleMaps/AIRGoogleMapCircle.m
@@ -11,13 +11,32 @@
 #import <React/RCTUtils.h>
 
 @implementation AIRGoogleMapCircle
+{
+  BOOL _didMoveToWindow;
+}
 
 - (instancetype)init
 {
   if (self = [super init]) {
+    _didMoveToWindow = false;
     _circle = [[GMSCircle alloc] init];
   }
   return self;
+}
+
+- (void)didMoveToWindow {
+  [super didMoveToWindow];
+  if(_didMoveToWindow) return;
+  _didMoveToWindow = true;
+  if(_fillColor) {
+    _circle.fillColor = _fillColor;
+  }
+  if(_strokeColor) {
+    _circle.strokeColor = _strokeColor;
+  }
+  if(_strokeWidth) {
+    _circle.strokeWidth = _strokeWidth;
+  }
 }
 
 - (void)setRadius:(double)radius
@@ -35,19 +54,25 @@
 -(void)setStrokeColor:(UIColor *)strokeColor
 {
   _strokeColor = strokeColor;
-  _circle.strokeColor = strokeColor;
+  if(_didMoveToWindow) {
+    _circle.strokeColor = strokeColor;
+  }
 }
 
 -(void)setStrokeWidth:(double)strokeWidth
 {
   _strokeWidth = strokeWidth;
-  _circle.strokeWidth = strokeWidth;
+  if(_didMoveToWindow) {
+    _circle.strokeWidth = strokeWidth;
+  }
 }
 
 -(void)setFillColor:(UIColor *)fillColor
 {
   _fillColor = fillColor;
-  _circle.fillColor = fillColor;
+  if(_didMoveToWindow) {
+    _circle.fillColor = fillColor;
+  }
 }
 
 -(void)setZIndex:(int)zIndex

--- a/ios/Exponent/Versioned/Core/Api/Components/GoogleMaps/AIRGoogleMapMarker.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/GoogleMaps/AIRGoogleMapMarker.m
@@ -326,6 +326,12 @@ CGRect unionRect(CGRect a, CGRect b) {
     _reloadImageCancellationBlock = nil;
   }
 
+  if (!_realMarker.icon) {
+    // prevent glitch with marker (cf. https://github.com/react-native-maps/react-native-maps/issues/3657)
+    UIImage *emptyImage = [[UIImage alloc] init];
+    _realMarker.icon = emptyImage;
+  }
+
   _reloadImageCancellationBlock =
   [[_bridge moduleForName:@"ImageLoader"] loadImageWithURLRequest:[RCTConvert NSURLRequest:_iconSrc]
                                           size:self.bounds.size

--- a/ios/Exponent/Versioned/Core/Api/Components/GoogleMaps/AIRGoogleMapPolygon.h
+++ b/ios/Exponent/Versioned/Core/Api/Components/GoogleMaps/AIRGoogleMapPolygon.h
@@ -20,9 +20,9 @@
 @property (nonatomic, strong) NSArray<NSArray<AIRMapCoordinate *> *> *holes;
 @property (nonatomic, copy) RCTBubblingEventBlock onPress;
 
-@property (nonatomic, assign) UIColor *fillColor;
+@property (nonatomic, strong) UIColor *fillColor;
 @property (nonatomic, assign) double strokeWidth;
-@property (nonatomic, assign) UIColor *strokeColor;
+@property (nonatomic, strong) UIColor *strokeColor;
 @property (nonatomic, assign) BOOL geodesic;
 @property (nonatomic, assign) int zIndex;
 @property (nonatomic, assign) BOOL tappable;

--- a/ios/Exponent/Versioned/Core/Api/Components/GoogleMaps/AIRGoogleMapPolygon.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/GoogleMaps/AIRGoogleMapPolygon.m
@@ -11,14 +11,33 @@
 #import <GoogleMaps/GoogleMaps.h>
 
 @implementation AIRGoogleMapPolygon
+{
+  BOOL _didMoveToWindow;
+}
 
 - (instancetype)init
 {
   if (self = [super init]) {
+    _didMoveToWindow = false;
     _polygon = [[AIRGMSPolygon alloc] init];
   }
 
   return self;
+}
+
+- (void)didMoveToWindow {
+  [super didMoveToWindow];
+  if(_didMoveToWindow) return;
+  _didMoveToWindow = true;
+  if(_fillColor) {
+    _polygon.fillColor = _fillColor;
+  }
+  if(_strokeColor) {
+    _polygon.strokeColor = _strokeColor;
+  }
+  if(_strokeWidth) {
+    _polygon.strokeWidth = _strokeWidth;
+  }
 }
 
 - (void)setCoordinates:(NSArray<AIRMapCoordinate *> *)coordinates
@@ -58,19 +77,25 @@
 -(void)setFillColor:(UIColor *)fillColor
 {
   _fillColor = fillColor;
-  _polygon.fillColor = fillColor;
+  if(_didMoveToWindow) {
+    _polygon.fillColor = fillColor;
+  }
 }
 
 -(void)setStrokeWidth:(double)strokeWidth
 {
   _strokeWidth = strokeWidth;
-  _polygon.strokeWidth = strokeWidth;
+  if(_didMoveToWindow) {
+    _polygon.strokeWidth = strokeWidth;
+  }
 }
 
 -(void)setStrokeColor:(UIColor *) strokeColor
 {
   _strokeColor = strokeColor;
-  _polygon.strokeColor = strokeColor;
+  if(_didMoveToWindow) {
+    _polygon.strokeColor = strokeColor;
+  }
 }
 
 -(void)setGeodesic:(BOOL)geodesic

--- a/ios/Exponent/Versioned/Core/Api/Components/Maps/AIRMap.h
+++ b/ios/Exponent/Versioned/Core/Api/Components/Maps/AIRMap.h
@@ -40,7 +40,6 @@ extern const NSInteger AIRMapMaxZoomLevel;
 @property (nonatomic, assign) CGFloat minDelta;
 @property (nonatomic, assign) CGFloat maxDelta;
 @property (nonatomic, assign) UIEdgeInsets legalLabelInsets;
-@property (nonatomic, strong) NSTimer *regionChangeObserveTimer;
 @property (nonatomic, assign) MKCoordinateRegion initialRegion;
 @property (nonatomic, assign) MKMapCamera *initialCamera;
 @property (nonatomic, assign) CGFloat minZoomLevel;

--- a/ios/Exponent/Versioned/Core/Api/Components/Maps/AIRMap.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/Maps/AIRMap.m
@@ -48,7 +48,6 @@ const NSInteger AIRMapMaxZoomLevel = 20;
 @implementation AIRMap
 {
     UIView *_legalLabel;
-    CLLocationManager *_locationManager;
     BOOL _initialRegionSet;
     BOOL _initialCameraSet;
 
@@ -90,11 +89,6 @@ const NSInteger AIRMapMaxZoomLevel = 20;
         self.compassOffset = CGPointMake(0, 0);
     }
     return self;
-}
-
-- (void)dealloc
-{
-    [_regionChangeObserveTimer invalidate];
 }
 
 -(void)addSubview:(UIView *)view {
@@ -350,12 +344,6 @@ const NSInteger AIRMapMaxZoomLevel = 20;
 - (void)setShowsUserLocation:(BOOL)showsUserLocation
 {
     if (self.showsUserLocation != showsUserLocation) {
-        if (showsUserLocation && !_locationManager) {
-            _locationManager = [CLLocationManager new];
-            if ([_locationManager respondsToSelector:@selector(requestWhenInUseAuthorization)]) {
-                [_locationManager requestWhenInUseAuthorization];
-            }
-        }
         super.showsUserLocation = showsUserLocation;
     }
 }

--- a/ios/Exponent/Versioned/Core/Api/Components/Maps/AIRMapManager.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/Maps/AIRMapManager.m
@@ -28,8 +28,6 @@
 #import "AIRMapSnapshot.h"
 #import "RCTConvert+AirMap.h"
 #import "AIRMapOverlay.h"
-#import "AIRWeakTimerReference.h"
-#import "AIRWeakMapReference.h"
 #import <MapKit/MapKit.h>
 
 static NSString *const RCTMapViewKey = @"MapView";
@@ -278,31 +276,6 @@ RCT_EXPORT_METHOD(animateCamera:(nonnull NSNumber *)reactTag
     }];
 }
 
-
-RCT_EXPORT_METHOD(animateToNavigation:(nonnull NSNumber *)reactTag
-        withRegion:(MKCoordinateRegion)region
-        withBearing:(CGFloat)bearing
-        withAngle:(double)angle
-        withDuration:(CGFloat)duration)
-{
-    [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
-        id view = viewRegistry[reactTag];
-        if (![view isKindOfClass:[AIRMap class]]) {
-            RCTLogError(@"Invalid view returned from registry, expecting AIRMap, got: %@", view);
-        } else {
-            AIRMap *mapView = (AIRMap *)view;
-            MKMapCamera *mapCamera = [[mapView camera] copy];
-             [mapCamera setPitch:angle];
-             [mapCamera setHeading:bearing];
-
-            [AIRMap animateWithDuration:duration/1000 animations:^{
-                [(AIRMap *)view setRegion:region animated:YES];
-                [mapView setCamera:mapCamera animated:YES];
-            }];
-        }
-    }];
-}
-
 RCT_EXPORT_METHOD(animateToRegion:(nonnull NSNumber *)reactTag
         withRegion:(MKCoordinateRegion)region
         withDuration:(CGFloat)duration)
@@ -317,68 +290,6 @@ RCT_EXPORT_METHOD(animateToRegion:(nonnull NSNumber *)reactTag
             }];
         }
     }];
-}
-
-RCT_EXPORT_METHOD(animateToCoordinate:(nonnull NSNumber *)reactTag
-        withRegion:(CLLocationCoordinate2D)latlng
-        withDuration:(CGFloat)duration)
-{
-    [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
-        id view = viewRegistry[reactTag];
-        if (![view isKindOfClass:[AIRMap class]]) {
-            RCTLogError(@"Invalid view returned from registry, expecting AIRMap, got: %@", view);
-        } else {
-            AIRMap *mapView = (AIRMap *)view;
-            MKCoordinateRegion region;
-            region.span = mapView.region.span;
-            region.center = latlng;
-            [AIRMap animateWithDuration:duration/1000 animations:^{
-                [mapView setRegion:region animated:YES];
-            }];
-        }
-    }];
-}
-
-RCT_EXPORT_METHOD(animateToViewingAngle:(nonnull NSNumber *)reactTag
-                  withAngle:(double)angle
-                  withDuration:(CGFloat)duration)
-{
-  [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
-      id view = viewRegistry[reactTag];
-      if (![view isKindOfClass:[AIRMap class]]) {
-          RCTLogError(@"Invalid view returned from registry, expecting AIRMap, got: %@", view);
-      } else {
-          AIRMap *mapView = (AIRMap *)view;
-
-          MKMapCamera *mapCamera = [[mapView camera] copy];
-          [mapCamera setPitch:angle];
-
-          [AIRMap animateWithDuration:duration/1000 animations:^{
-              [mapView setCamera:mapCamera animated:YES];
-          }];
-      }
-  }];
-}
-
-RCT_EXPORT_METHOD(animateToBearing:(nonnull NSNumber *)reactTag
-                  withBearing:(CGFloat)bearing
-                  withDuration:(CGFloat)duration)
-{
-  [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
-      id view = viewRegistry[reactTag];
-      if (![view isKindOfClass:[AIRMap class]]) {
-          RCTLogError(@"Invalid view returned from registry, expecting AIRMap, got: %@", view);
-      } else {
-          AIRMap *mapView = (AIRMap *)view;
-
-          MKMapCamera *mapCamera = [[mapView camera] copy];
-          [mapCamera setHeading:bearing];
-
-          [AIRMap animateWithDuration:duration/1000 animations:^{
-              [mapView setCamera:mapCamera animated:YES];
-          }];
-      }
-  }];
 }
 
 RCT_EXPORT_METHOD(fitToElements:(nonnull NSNumber *)reactTag
@@ -677,24 +588,6 @@ RCT_EXPORT_METHOD(getAddressFromCoordinates:(nonnull NSNumber *)reactTag
                       else if ([result isEqualToString:@"base64"]) {
                           callback(@[[NSNull null], [data base64EncodedStringWithOptions:NSDataBase64EncodingEndLineWithCarriageReturn]]);
                       }
-                      else if ([result isEqualToString:@"legacy"]) {
-
-                          // In the initial (iOS only) implementation of takeSnapshot,
-                          // both the uri and the base64 encoded string were returned.
-                          // Returning both is rarely useful and in fact causes a
-                          // performance penalty when only the file URI is desired.
-                          // In that case the base64 encoded string was always marshalled
-                          // over the JS-bridge (which is quite slow).
-                          // A new more flexible API was created to cover this.
-                          // This code should be removed in a future release when the
-                          // old API is fully deprecated.
-                          [data writeToFile:filePath atomically:YES];
-                          NSDictionary *snapshotData = @{
-                                                         @"uri": filePath,
-                                                         @"data": [data base64EncodedStringWithOptions:NSDataBase64EncodingEndLineWithCarriageReturn]
-                                                         };
-                          callback(@[[NSNull null], snapshotData]);
-                      }
                   }
                   UIGraphicsEndImageContext();
               }];
@@ -778,12 +671,11 @@ RCT_EXPORT_METHOD(getAddressFromCoordinates:(nonnull NSNumber *)reactTag
     }
 
     if (nearestDistance <= maxMeters) {
-        AIRMapCoordinate *firstCoord = nearestPolyline.coordinates.firstObject;
         id event = @{
                    @"action": @"polyline-press",
                    @"coordinate": @{
-                       @"latitude": @(firstCoord.coordinate.latitude),
-                       @"longitude": @(firstCoord.coordinate.longitude)
+                       @"latitude": @(tapCoordinate.latitude),
+                       @"longitude": @(tapCoordinate.longitude)
                    }
                    };
         nearestPolyline.onPress(event);
@@ -1048,30 +940,14 @@ static int kDragCenterContext;
     
 }
 
-- (void)mapView:(AIRMap *)mapView regionWillChangeAnimated:(__unused BOOL)animated
+- (void)mapViewDidChangeVisibleRegion:(AIRMap *)mapView
 {
-    // Don't send region did change events until map has
-    // started rendering, as these won't represent the final location
-    if(mapView.hasStartedRendering){
-        [self _regionChanged:mapView];
-    }
-
-    AIRWeakTimerReference *weakTarget = [[AIRWeakTimerReference alloc] initWithTarget:self andSelector:@selector(_onTick:)];
-    
-    mapView.regionChangeObserveTimer = [NSTimer timerWithTimeInterval:AIRMapRegionChangeObserveInterval
-                                                               target:weakTarget
-                                                             selector:@selector(timerDidFire:)
-                                                             userInfo:@{ RCTMapViewKey: [[AIRWeakMapReference alloc] initWithMapView: mapView] }
-                                                              repeats:YES];
-
-    [[NSRunLoop mainRunLoop] addTimer:mapView.regionChangeObserveTimer forMode:NSRunLoopCommonModes];
+    [self _regionChanged:mapView];
 }
 
 - (void)mapView:(AIRMap *)mapView regionDidChangeAnimated:(__unused BOOL)animated
 {
     CGFloat zoomLevel = [self zoomLevel:mapView];
-    [mapView.regionChangeObserveTimer invalidate];
-    mapView.regionChangeObserveTimer = nil;
 
     // Don't send region did change events until map has
     // started rendering, as these won't represent the final location
@@ -1103,7 +979,6 @@ static int kDragCenterContext;
       mapView.hasStartedRendering = YES;
     }
     [mapView beginLoading];
-    [self _emitRegionChangeEvent:mapView continuous:NO];
 }
 
 - (void)mapViewDidFinishRenderingMap:(AIRMap *)mapView fullyRendered:(BOOL)fullyRendered
@@ -1112,12 +987,6 @@ static int kDragCenterContext;
 }
 
 #pragma mark Private
-
-- (void)_onTick:(NSTimer *)timer
-{
-    AIRWeakMapReference *weakRef = timer.userInfo[RCTMapViewKey];
-    [self _regionChanged:weakRef.mapView];
-}
 
 - (void)_regionChanged:(AIRMap *)mapView
 {

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -15,8 +15,8 @@ abstract_target 'Expo Go' do
   # Expo Client dependencies
   pod 'Amplitude'
   pod 'CocoaLumberjack', '~> 3.5.3'
-  pod 'GoogleMaps', '~> 3.6'
-  pod 'Google-Maps-iOS-Utils', '~> 2.1.0'
+  pod 'GoogleMaps', '~> 7.1'
+  pod 'Google-Maps-iOS-Utils', '~> 4.1.0'
   pod 'JKBigInteger', :podspec => 'vendored/common/JKBigInteger.podspec.json'
   pod 'MBProgressHUD', '~> 1.2.0'
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1528,21 +1528,24 @@ PODS:
     - PromisesObjC (~> 2.1)
   - fmt (6.2.1)
   - glog (0.3.5)
-  - Google-Maps-iOS-Utils (2.1.0):
-    - Google-Maps-iOS-Utils/Clustering (= 2.1.0)
-    - Google-Maps-iOS-Utils/Geometry (= 2.1.0)
-    - Google-Maps-iOS-Utils/Heatmap (= 2.1.0)
-    - Google-Maps-iOS-Utils/QuadTree (= 2.1.0)
+  - Google-Maps-iOS-Utils (4.1.0):
+    - Google-Maps-iOS-Utils/Clustering (= 4.1.0)
+    - Google-Maps-iOS-Utils/Geometry (= 4.1.0)
+    - Google-Maps-iOS-Utils/GeometryUtils (= 4.1.0)
+    - Google-Maps-iOS-Utils/Heatmap (= 4.1.0)
+    - Google-Maps-iOS-Utils/QuadTree (= 4.1.0)
     - GoogleMaps
-  - Google-Maps-iOS-Utils/Clustering (2.1.0):
+  - Google-Maps-iOS-Utils/Clustering (4.1.0):
     - Google-Maps-iOS-Utils/QuadTree
     - GoogleMaps
-  - Google-Maps-iOS-Utils/Geometry (2.1.0):
+  - Google-Maps-iOS-Utils/Geometry (4.1.0):
     - GoogleMaps
-  - Google-Maps-iOS-Utils/Heatmap (2.1.0):
+  - Google-Maps-iOS-Utils/GeometryUtils (4.1.0):
+    - GoogleMaps
+  - Google-Maps-iOS-Utils/Heatmap (4.1.0):
     - Google-Maps-iOS-Utils/QuadTree
     - GoogleMaps
-  - Google-Maps-iOS-Utils/QuadTree (2.1.0):
+  - Google-Maps-iOS-Utils/QuadTree (4.1.0):
     - GoogleMaps
   - Google-Mobile-Ads-SDK (9.5.0):
     - GoogleAppMeasurement (< 10.0, >= 7.0)
@@ -1571,10 +1574,10 @@ PODS:
     - GoogleUtilities/Environment (~> 7.7)
     - nanopb (< 2.30910.0, >= 2.30908.0)
     - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleMaps (3.10.0):
-    - GoogleMaps/Maps (= 3.10.0)
-  - GoogleMaps/Base (3.10.0)
-  - GoogleMaps/Maps (3.10.0):
+  - GoogleMaps (7.1.0):
+    - GoogleMaps/Maps (= 7.1.0)
+  - GoogleMaps/Base (7.1.0)
+  - GoogleMaps/Maps (7.1.0):
     - GoogleMaps/Base
   - GoogleMLKit/FaceDetection (2.6.0):
     - GoogleMLKit/MLKitCore
@@ -2378,8 +2381,8 @@ DEPENDENCIES:
   - FBReactNativeSpec (from `../react-native-lab/react-native/React/FBReactNativeSpec`)
   - FirebaseCore
   - glog (from `../react-native-lab/react-native/third-party-podspecs/glog.podspec`)
-  - Google-Maps-iOS-Utils (~> 2.1.0)
-  - GoogleMaps (~> 3.6)
+  - Google-Maps-iOS-Utils (~> 4.1.0)
+  - GoogleMaps (~> 7.1)
   - GoogleUtilities
   - hermes-engine (from `../react-native-lab/react-native/sdks/hermes/hermes-engine.podspec`)
   - JKBigInteger (from `vendored/common/JKBigInteger.podspec.json`)
@@ -3445,11 +3448,11 @@ SPEC CHECKSUMS:
   FirebaseInstallations: 0a115432c4e223c5ab20b0dbbe4cbefa793a0e8e
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
-  Google-Maps-iOS-Utils: c32891ff472eaaa1fca032beedafa1a013af7875
+  Google-Maps-iOS-Utils: 3343332b18dfd5be8f1f44edd7d481ace3da4d9a
   Google-Mobile-Ads-SDK: caf686ba55108412e02a3eedb136e12e488dbfaa
   GoogleAppMeasurement: 6ee231473fbd75c11221dfce489894334024eead
   GoogleDataTransport: 1c8145da7117bd68bbbed00cf304edb6a24de00f
-  GoogleMaps: 8c080862ff2748ece9929471b30feb56a6c5079d
+  GoogleMaps: bc56ffb0324e345a2d91bac1a64a920f9c8f1b20
   GoogleMLKit: 755661c46990a85e42278015f26400286d98ad95
   GoogleSignIn: 7137d297ddc022a7e0aa4619c86d72c909fa7213
   GoogleToolboxForMac: 8bef7c7c5cf7291c687cf5354f39f9db6399ad34
@@ -3522,6 +3525,6 @@ SPEC CHECKSUMS:
   Yoga: 043f8eb97345d0171f27fead4d1849cacf0472a5
   ZXingObjC: fdbb269f25dd2032da343e06f10224d62f537bdb
 
-PODFILE CHECKSUM: 28c4f8c13981ced803a02a1c9a3fad0365f4da31
+PODFILE CHECKSUM: f1f976b5439fb54b3351769b94dcdee5d58fc1eb
 
 COCOAPODS: 1.11.2

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -92,7 +92,7 @@
   "react-native-branch": "^5.4.0",
   "react-native-gesture-handler": "~2.7.0",
   "react-native-get-random-values": "~1.8.0",
-  "react-native-maps": "0.31.1",
+  "react-native-maps": "1.3.2",
   "react-native-pager-view": "5.4.24",
   "react-native-reanimated": "~2.10.0",
   "react-native-screens": "~3.18.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3344,7 +3344,7 @@
   resolved "https://registry.yarnpkg.com/@react-native/assets/-/assets-1.0.0.tgz#c6f9bf63d274bafc8e970628de24986b30a55c8e"
   integrity sha512-KrwSpS1tKI70wuKl68DwJZYEvXktDHdZMG0k2AXD/rJVSlB23/X2CB2cutVR0HwNMJIal9HOUOBB2rVfa6UGtQ==
 
-"@react-native/normalize-color@*", "@react-native/normalize-color@2.0.0", "@react-native/normalize-color@^2.0.0":
+"@react-native/normalize-color@2.0.0", "@react-native/normalize-color@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@react-native/normalize-color/-/normalize-color-2.0.0.tgz#da955909432474a9a0fe1cbffc66576a0447f567"
   integrity sha512-Wip/xsc5lw8vsBlmY2MO/gFLp3MvuZ2baBZjDeTjjndMgM0h5sxz7AZR62RDPGgstp8Np7JzjvVqVT7tpFZqsw==
@@ -4010,10 +4010,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/geojson@^7946.0.7":
-  version "7946.0.8"
-  resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.8.tgz#30744afdb385e2945e22f3b033f897f76b1f12ca"
-  integrity sha512-1rkryxURpr6aWP7R786/UQOkJ3PcpQiWkAXBmdWc7ryFWqN6a4xfK7BtjXvFBKO9LjQ+MWQSWxYeZX1OApnArA==
+"@types/geojson@^7946.0.8":
+  version "7946.0.10"
+  resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.10.tgz#6dfbf5ea17142f7f9a043809f1cd4c448cb68249"
+  integrity sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA==
 
 "@types/getenv@^1.0.0":
   version "1.0.0"
@@ -8205,15 +8205,6 @@ dependency-graph@^0.11.0:
   resolved "https://registry.yarnpkg.com/dependency-graph/-/dependency-graph-0.11.0.tgz#ac0ce7ed68a54da22165a85e97a01d53f5eb2e27"
   integrity sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==
 
-deprecated-react-native-prop-types@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/deprecated-react-native-prop-types/-/deprecated-react-native-prop-types-2.3.0.tgz#c10c6ee75ff2b6de94bb127f142b814e6e08d9ab"
-  integrity sha512-pWD0voFtNYxrVqvBMYf5gq3NA2GCpfodS1yNynTPc93AYA/KEMGeWDqqeUB6R2Z9ZofVhks2aeJXiuQqKNpesA==
-  dependencies:
-    "@react-native/normalize-color" "*"
-    invariant "*"
-    prop-types "*"
-
 deprecation@^2.0.0, deprecation@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-2.3.1.tgz#6368cbdb40abf3373b525ac87e4a260c3a700919"
@@ -11456,7 +11447,7 @@ into-stream@^3.1.0:
     from2 "^2.1.1"
     p-is-promise "^1.1.0"
 
-invariant@*, invariant@2.2.4, invariant@^2.2.2, invariant@^2.2.4:
+invariant@2.2.4, invariant@^2.2.2, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -16700,7 +16691,7 @@ prompts@^2.0.1, prompts@^2.2.1, prompts@^2.3.2, prompts@^2.4.0, prompts@^2.4.1, 
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@*, prop-types@15.8.1, prop-types@^15.5.8, prop-types@^15.6.2, prop-types@^15.7.0, prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@15.8.1, prop-types@^15.5.8, prop-types@^15.6.2, prop-types@^15.7.0, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -17218,13 +17209,12 @@ react-native-keyboard-aware-scroll-view@^0.9.5:
     prop-types "^15.6.2"
     react-native-iphone-x-helper "^1.0.3"
 
-react-native-maps@0.31.1:
-  version "0.31.1"
-  resolved "https://registry.yarnpkg.com/react-native-maps/-/react-native-maps-0.31.1.tgz#574be035a52287e3ab1c1da35e2ce3e2116f0fd6"
-  integrity sha512-vipeOPykqLRMCLcLUCZEB+cTdNSlq88NLb0jChY4UGTY5fgOS7GYWkfswy6bW1ayTRLxJS3zpMGFDUY59/ZrXA==
+react-native-maps@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/react-native-maps/-/react-native-maps-1.3.2.tgz#8e30bfd9d934de02827253e5cde6c08a04f6356c"
+  integrity sha512-NB7HGRZOgxxXCWzrhIVucx/bsrEWANvk3DLci1ov4P9MQnEVQYQCCkTxsnaEvO191GeBOCRDyYn6jckqbfMtmg==
   dependencies:
-    "@types/geojson" "^7946.0.7"
-    deprecated-react-native-prop-types "^2.3.0"
+    "@types/geojson" "^7946.0.8"
 
 react-native-pager-view@5.4.24:
   version "5.4.24"


### PR DESCRIPTION
# Why
Update for sdk 47
Closes ENG-6534.

# How

There were a lot of native changes and a major version bump.
The following manual change needed to be made to `ios/Podfile`:
```diff
- pod 'GoogleMaps', '~> 3.6'
+ pod 'GoogleMaps', '~> 7.1'
- pod 'Google-Maps-iOS-Utils', '~> 2.1.0'
+ pod 'Google-Maps-iOS-Utils', '~> 4.1.0'
  ```
In addition, Expo home uses `react-native-maps` so fixing a breaking change in typescript types was also required.


# Test Plan

Tested manually in Expo Go Android and iOS as well in Bare Expo.

<!-- disable:changelog-checks -->