### PR TITLE
fix(cli): disable API interaction when running in offline mode

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -26,7 +26,7 @@
 - Change `UNAUTHORIZED_ERROR` to `UNAUTHORIZED` to handle unauthorized errors. ([#18751](https://github.com/expo/expo/pull/18751) by [@EvanBacon](https://github.com/EvanBacon))
 - Catch error thrown when trying to launch redirect page without an application ID defined in `app.json`. ([#19312](https://github.com/expo/expo/pull/19312) by [@esamelson](https://github.com/esamelson))
 - Present intended variadic argument when asserting flags in `npx expo install`. ([#19396](https://github.com/expo/expo/pull/19396) by [@bycedric](https://github.com/bycedric))
-- Disable dependency validation when running in offline mode. ([#19418](https://github.com/expo/expo/pull/19418) by [@byCedric](https://github.com/byCedric))
+- Disable API interaction when running in offline mode. ([#19418](https://github.com/expo/expo/pull/19418) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Change `UNAUTHORIZED_ERROR` to `UNAUTHORIZED` to handle unauthorized errors. ([#18751](https://github.com/expo/expo/pull/18751) by [@EvanBacon](https://github.com/EvanBacon))
 - Catch error thrown when trying to launch redirect page without an application ID defined in `app.json`. ([#19312](https://github.com/expo/expo/pull/19312) by [@esamelson](https://github.com/esamelson))
 - Present intended variadic argument when asserting flags in `npx expo install`. ([#19396](https://github.com/expo/expo/pull/19396) by [@bycedric](https://github.com/bycedric))
+- Disable dependency validation when running in offline mode. ([#19418](https://github.com/expo/expo/pull/19418) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/api/user/__tests__/user-test.ts
+++ b/packages/@expo/cli/src/api/user/__tests__/user-test.ts
@@ -70,6 +70,15 @@ describe(getUserAsync, () => {
     await loginAsync({ username: 'USERNAME', password: 'PASSWORD' });
     expect(await getUserAsync()).toMatchObject({ __typename: 'User' });
   });
+
+  it('skips fetching user when running in offline mode', async () => {
+    jest.resetModules();
+    jest.mock('../../settings', () => ({ APISettings: { isOffline: true } }));
+    const { getUserAsync } = require('../user');
+
+    process.env.EXPO_TOKEN = 'accesstoken';
+    await expect(getUserAsync()).resolves.toBeUndefined();
+  });
 });
 
 describe(loginAsync, () => {

--- a/packages/@expo/cli/src/api/user/user.ts
+++ b/packages/@expo/cli/src/api/user/user.ts
@@ -8,6 +8,7 @@ import { graphqlClient } from '../graphql/client';
 import { CurrentUserQuery } from '../graphql/generated';
 import { UserQuery } from '../graphql/queries/UserQuery';
 import { fetchAsync } from '../rest/client';
+import { APISettings } from '../settings';
 import UserSettings from './UserSettings';
 
 export type Actor = NonNullable<CurrentUserQuery['meActor']>;
@@ -33,7 +34,8 @@ export function getActorDisplayName(user?: Actor): string {
 }
 
 export async function getUserAsync(): Promise<Actor | undefined> {
-  if (!currentUser && (UserSettings.getAccessToken() || UserSettings.getSession()?.sessionSecret)) {
+  const hasCredentials = UserSettings.getAccessToken() || UserSettings.getSession()?.sessionSecret;
+  if (!APISettings.isOffline && !currentUser && hasCredentials) {
     const user = await UserQuery.currentUserAsync();
     currentUser = user ?? undefined;
     if (user) {

--- a/packages/@expo/cli/src/start/doctor/dependencies/__tests__/validateDependenciesVersions-test.ts
+++ b/packages/@expo/cli/src/start/doctor/dependencies/__tests__/validateDependenciesVersions-test.ts
@@ -150,4 +150,19 @@ describe(validateDependenciesVersionsAsync, () => {
       true
     );
   });
+
+  it('skips validating dependencies when running in offline mode', async () => {
+    jest.resetModules();
+    jest.mock('../../../../api/settings', () => ({ APISettings: { isOffline: true } }));
+
+    const { validateDependenciesVersionsAsync } = require('../validateDependenciesVersions');
+    const exp = { sdkVersion: '46.0.0' };
+    const pkg = {
+      dependencies: { expo: '^46.0.0' },
+    };
+
+    await expect(
+      validateDependenciesVersionsAsync(projectRoot, exp as any, pkg)
+    ).resolves.toBeNull();
+  });
 });

--- a/packages/@expo/cli/src/start/doctor/dependencies/validateDependenciesVersions.ts
+++ b/packages/@expo/cli/src/start/doctor/dependencies/validateDependenciesVersions.ts
@@ -36,7 +36,7 @@ export async function validateDependenciesVersionsAsync(
   packagesToCheck?: string[]
 ): Promise<boolean | null> {
   if (APISettings.isOffline) {
-    debug('Skipping dependency validation in offline mode');
+    Log.warn('Skipping dependency validation in offline mode');
     return null;
   }
 

--- a/packages/@expo/cli/src/start/doctor/dependencies/validateDependenciesVersions.ts
+++ b/packages/@expo/cli/src/start/doctor/dependencies/validateDependenciesVersions.ts
@@ -5,6 +5,7 @@ import chalk from 'chalk';
 import resolveFrom from 'resolve-from';
 import semver from 'semver';
 
+import { APISettings } from '../../../api/settings';
 import * as Log from '../../../log';
 import { CommandError } from '../../../utils/errors';
 import { BundledNativeModules } from './bundledNativeModules';
@@ -20,6 +21,7 @@ interface IncorrectDependency {
 
 /**
  * Print a list of incorrect dependency versions.
+ * This only checks dependencies when not running in offline mode.
  *
  * @param projectRoot Expo project root.
  * @param exp Expo project config.
@@ -32,7 +34,12 @@ export async function validateDependenciesVersionsAsync(
   exp: Pick<ExpoConfig, 'sdkVersion'>,
   pkg: PackageJSONConfig,
   packagesToCheck?: string[]
-): Promise<boolean> {
+): Promise<boolean | null> {
+  if (APISettings.isOffline) {
+    debug('Skipping dependency validation in offline mode');
+    return null;
+  }
+
   const incorrectDeps = await getVersionedDependenciesAsync(projectRoot, exp, pkg, packagesToCheck);
   return logIncorrectDependencies(incorrectDeps);
 }

--- a/packages/@expo/cli/src/start/platforms/ExpoGoInstaller.ts
+++ b/packages/@expo/cli/src/start/platforms/ExpoGoInstaller.ts
@@ -1,8 +1,10 @@
 import semver from 'semver';
 
 import { getVersionsAsync } from '../../api/getVersions';
+import { APISettings } from '../../api/settings';
 import * as Log from '../../log';
 import { downloadExpoGoAsync } from '../../utils/downloadExpoGoAsync';
+import { CommandError } from '../../utils/errors';
 import { logNewSection } from '../../utils/ora';
 import { confirmAsync } from '../../utils/prompts';
 import type { DeviceManager } from './DeviceManager';
@@ -73,6 +75,16 @@ export class ExpoGoInstaller<IDevice> {
   /** Check if a given device has Expo Go installed, if not then download and install it. */
   async ensureAsync(deviceManager: DeviceManager<IDevice>): Promise<boolean> {
     let shouldInstall = !(await deviceManager.isAppInstalledAsync(this.appId));
+
+    if (APISettings.isOffline && !shouldInstall) {
+      Log.warn(`Skipping Expo Go version validation in offline mode`);
+      return false;
+    } else if (APISettings.isOffline && shouldInstall) {
+      throw new CommandError(
+        'NO_EXPO_GO',
+        `Expo Go is not installed on device "${deviceManager.name}", while running in offline mode. Manually install Expo Go or run without --offline flag.`
+      );
+    }
 
     if (!shouldInstall) {
       shouldInstall = await this.uninstallExpoGoIfOutdatedAsync(deviceManager);

--- a/packages/@expo/cli/src/start/platforms/__tests__/ExpoGoInstaller-test.ts
+++ b/packages/@expo/cli/src/start/platforms/__tests__/ExpoGoInstaller-test.ts
@@ -1,7 +1,6 @@
 import { asMock } from '../../../__tests__/asMock';
 import { getVersionsAsync, SDKVersion, Versions } from '../../../api/getVersions';
 import { downloadExpoGoAsync } from '../../../utils/downloadExpoGoAsync';
-import { CommandError } from '../../../utils/errors';
 import { confirmAsync } from '../../../utils/prompts';
 import { ExpoGoInstaller } from '../ExpoGoInstaller';
 


### PR DESCRIPTION
# Why

Fixes ENG-6550
Fixes #18918

# How

- Disabled dependency validation when running in offline mode
- Disabled Expo Go version validation when running in offline mode
  > **Note** it still checks if Expo Go is installed. When it's not installed, it throws instead.
- Disabled fetching user when running in offline mode
  > **Note** this would fall back to an anonymous user and (auto)disables analytics and (possible) manifest signing. 
- Updated tests to validate dependency validation is skipped in offline mode

Optionally, we could add a global catch for errors listed below, to mention the `--offline` option.
 - `error instanceof CommandError && error.code === 'API'`
 - `error.code === 'FetchError'`

# Test Plan

To test this, update your **/etc/hosts** and add `127.0.0.1 api.expo.dev`. Then run the CLI:
- `npx expo start` → this fails with a fetch error
- `npx expo start --offline` → this should succeed without issues
- `npx expo start --offline --android|ios` 
  → when Expo Go is NOT installed, it should throw
  → when Expo Go is installed, it should warn and continue to the bundle

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
