### PR TITLE
Upgrade `@rnc/datetimepicker@6.2.0` ➡️ `@rnc/datetimepicker@6.5.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Package-specific changes not released in any SDK will be added here just before 
 - Updated `@react-native-picker/picker` from `2.4.2` to `2.4.6`. ([#19390](https://github.com/expo/expo/pull/19390) by [@aleqsio](https://github.com/aleqsio))
 - Updated `react-native-screens` from `3.15.0` to `3.18.0`. ([#19383](https://github.com/expo/expo/pull/19383) by [@tsapeta](https://github.com/tsapeta))
 - Updated `@shopify/react-native-skia` from `0.1.136` to `0.1.153`. ([#19360](https://github.com/expo/expo/pull/19360) by [@kudo](https://github.com/kudo))
+- Updated `@react-native-community/datetimepicker` from `6.2.0` to `6.5.0`. ([#19419](https://github.com/expo/expo/pull/19419) by [@byCedric](https://github.com/byCedric))
 
 ### 🛠 Breaking changes
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDatePickerDialogFragment.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDatePickerDialogFragment.java
@@ -7,8 +7,6 @@
 
 package versioned.host.exp.exponent.modules.api.components.datetimepicker;
 
-import host.exp.expoview.R;
-
 import android.annotation.SuppressLint;
 import android.app.DatePickerDialog;
 import android.app.DatePickerDialog.OnDateSetListener;

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDatePickerDialogFragment.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDatePickerDialogFragment.java
@@ -7,6 +7,8 @@
 
 package versioned.host.exp.exponent.modules.api.components.datetimepicker;
 
+import host.exp.expoview.R;
+
 import android.annotation.SuppressLint;
 import android.app.DatePickerDialog;
 import android.app.DatePickerDialog.OnDateSetListener;

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDatePickerDialogModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDatePickerDialogModule.java
@@ -54,7 +54,7 @@ public class RNDatePickerDialogModule extends ReactContextBaseJavaModule {
 
     @Override
     public void onDateSet(DatePicker view, int year, int month, int day) {
-      if (!mPromiseResolved && getReactApplicationContext().hasActiveCatalystInstance()) {
+      if (!mPromiseResolved && getReactApplicationContext().hasActiveReactInstance()) {
         WritableMap result = new WritableNativeMap();
         result.putString("action", RNConstants.ACTION_DATE_SET);
         result.putInt("year", year);
@@ -67,7 +67,7 @@ public class RNDatePickerDialogModule extends ReactContextBaseJavaModule {
 
     @Override
     public void onDismiss(DialogInterface dialog) {
-      if (!mPromiseResolved && getReactApplicationContext().hasActiveCatalystInstance()) {
+      if (!mPromiseResolved && getReactApplicationContext().hasActiveReactInstance()) {
         WritableMap result = new WritableNativeMap();
         result.putString("action", RNConstants.ACTION_DISMISSED);
         mPromise.resolve(result);
@@ -77,7 +77,7 @@ public class RNDatePickerDialogModule extends ReactContextBaseJavaModule {
 
     @Override
     public void onClick(DialogInterface dialog, int which) {
-      if (!mPromiseResolved && getReactApplicationContext().hasActiveCatalystInstance()) {
+      if (!mPromiseResolved && getReactApplicationContext().hasActiveReactInstance()) {
         WritableMap result = new WritableNativeMap();
         result.putString("action", RNConstants.ACTION_NEUTRAL_BUTTON);
         mPromise.resolve(result);

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDismissableDatePickerDialog.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDismissableDatePickerDialog.java
@@ -106,5 +106,9 @@ public class RNDismissableDatePickerDialog extends DatePickerDialog {
         throw new RuntimeException(e);
       }
     }
+    if (display == RNDatePickerDisplay.SPINNER){
+      if(this.getDatePicker() != null)
+        this.getDatePicker().setCalendarViewShown(false);
+    }
   }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNTimePickerDialogFragment.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNTimePickerDialogFragment.java
@@ -8,6 +8,8 @@
 
 package versioned.host.exp.exponent.modules.api.components.datetimepicker;
 
+import host.exp.expoview.R;
+
 import android.app.Dialog;
 import android.app.TimePickerDialog;
 import android.app.TimePickerDialog.OnTimeSetListener;

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNTimePickerDialogFragment.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNTimePickerDialogFragment.java
@@ -8,8 +8,6 @@
 
 package versioned.host.exp.exponent.modules.api.components.datetimepicker;
 
-import host.exp.expoview.R;
-
 import android.app.Dialog;
 import android.app.TimePickerDialog;
 import android.app.TimePickerDialog.OnTimeSetListener;
@@ -17,10 +15,10 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.DialogInterface.OnDismissListener;
 import android.content.DialogInterface.OnClickListener;
-import android.os.Build;
 import android.os.Bundle;
 import android.text.format.DateFormat;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.DialogFragment;
 
@@ -37,6 +35,7 @@ public class RNTimePickerDialogFragment extends DialogFragment {
   @Nullable
   private static OnClickListener mOnNeutralButtonActionListener;
 
+  @NonNull
   @Override
   public Dialog onCreateDialog(Bundle savedInstanceState) {
     final Bundle args = getArguments();
@@ -118,7 +117,7 @@ public class RNTimePickerDialogFragment extends DialogFragment {
   }
 
   @Override
-  public void onDismiss(DialogInterface dialog) {
+  public void onDismiss(@NonNull DialogInterface dialog) {
     super.onDismiss(dialog);
     if (mOnDismissListener != null) {
       mOnDismissListener.onDismiss(dialog);

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNTimePickerDialogModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNTimePickerDialogModule.java
@@ -19,6 +19,7 @@ import android.content.DialogInterface.OnClickListener;
 import android.os.Bundle;
 import android.widget.TimePicker;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
@@ -39,6 +40,7 @@ public class RNTimePickerDialogModule extends ReactContextBaseJavaModule {
     super(reactContext);
   }
 
+  @NonNull
   @Override
   public String getName() {
     return FRAGMENT_TAG;
@@ -54,7 +56,7 @@ public class RNTimePickerDialogModule extends ReactContextBaseJavaModule {
 
     @Override
     public void onTimeSet(TimePicker view, int hour, int minute) {
-      if (!mPromiseResolved && getReactApplicationContext().hasActiveCatalystInstance()) {
+      if (!mPromiseResolved && getReactApplicationContext().hasActiveReactInstance()) {
         WritableMap result = new WritableNativeMap();
         result.putString("action", RNConstants.ACTION_TIME_SET);
         result.putInt("hour", hour);
@@ -66,7 +68,7 @@ public class RNTimePickerDialogModule extends ReactContextBaseJavaModule {
 
     @Override
     public void onDismiss(DialogInterface dialog) {
-      if (!mPromiseResolved && getReactApplicationContext().hasActiveCatalystInstance()) {
+      if (!mPromiseResolved && getReactApplicationContext().hasActiveReactInstance()) {
         WritableMap result = new WritableNativeMap();
         result.putString("action", RNConstants.ACTION_DISMISSED);
         mPromise.resolve(result);
@@ -76,7 +78,7 @@ public class RNTimePickerDialogModule extends ReactContextBaseJavaModule {
 
     @Override
     public void onClick(DialogInterface dialog, int which) {
-      if (!mPromiseResolved && getReactApplicationContext().hasActiveCatalystInstance()) {
+      if (!mPromiseResolved && getReactApplicationContext().hasActiveReactInstance()) {
         WritableMap result = new WritableNativeMap();
         result.putString("action", RNConstants.ACTION_NEUTRAL_BUTTON);
         mPromise.resolve(result);

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -92,7 +92,7 @@
   "dependencies": {
     "@babel/runtime": "^7.14.0",
     "@react-native-async-storage/async-storage": "~1.17.3",
-    "@react-native-community/datetimepicker": "6.2.0",
+    "@react-native-community/datetimepicker": "6.5.0",
     "@react-native-community/netinfo": "9.3.3",
     "@react-native-community/slider": "4.2.3",
     "@react-native-community/viewpager": "5.0.11",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@expo/react-native-action-sheet": "^3.8.0",
     "@react-native-async-storage/async-storage": "~1.17.3",
-    "@react-native-community/datetimepicker": "6.2.0",
+    "@react-native-community/datetimepicker": "6.5.0",
     "@react-native-community/netinfo": "9.3.3",
     "@react-native-community/slider": "4.2.3",
     "@react-native-masked-view/masked-view": "0.2.6",

--- a/ios/Exponent.xcodeproj/project.pbxproj
+++ b/ios/Exponent.xcodeproj/project.pbxproj
@@ -583,6 +583,7 @@
 		FCF6D37025B34BC200808BF5 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCF6D36F25B34BC200808BF5 /* NotificationService.swift */; };
 		FCF6D37425B34BC200808BF5 /* ExpoNotificationServiceExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = FCF6D36D25B34BC200808BF5 /* ExpoNotificationServiceExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		FE8D4A1FC2BDC25C8D4684F8 /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C849D84FFC04012BBF6DFFD /* ExpoModulesProvider.swift */; };
+		8704B111C11841D78D77E3E7 /* RNDateTimePickerShadowView.m in Sources */ = {isa = PBXBuildFile; fileRef = 76E808C4949F497592E26673 /* RNDateTimePickerShadowView.m */; settings = {COMPILER_FLAGS = "-w"; }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1251,6 +1252,8 @@
 		FCF6D36D25B34BC200808BF5 /* ExpoNotificationServiceExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = ExpoNotificationServiceExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		FCF6D36F25B34BC200808BF5 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		FCF6D37125B34BC200808BF5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		6C7BA917106C42AEA7813785 /* RNDateTimePickerShadowView.h */ = {isa = PBXFileReference; name = "RNDateTimePickerShadowView.h"; path = "RNDateTimePickerShadowView.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
+		76E808C4949F497592E26673 /* RNDateTimePickerShadowView.m */ = {isa = PBXFileReference; name = "RNDateTimePickerShadowView.m"; path = "RNDateTimePickerShadowView.m"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; explicitFileType = undefined; includeInIndex = 0; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2410,6 +2413,8 @@
 				D47336D662754EDA8EA4BC55 /* RNDateTimePicker.m */,
 				12869A47946248B094FFB1C0 /* RNDateTimePickerManager.h */,
 				D86827B3D57944D8A25F37F8 /* RNDateTimePickerManager.m */,
+				6C7BA917106C42AEA7813785 /* RNDateTimePickerShadowView.h */,
+				76E808C4949F497592E26673 /* RNDateTimePickerShadowView.m */,
 			);
 			path = DateTimePicker;
 			sourceTree = "<group>";
@@ -3310,6 +3315,7 @@
 				C3C2D83067C44A679721209C /* RNCPickerLabel.m in Sources */,
 				FBCC5A97F536402C98688A94 /* RNCPickerManager.m in Sources */,
 				142BF7101AA740B69473EA27 /* AIRMapUrlTileCachedOverlay.m in Sources */,
+				8704B111C11841D78D77E3E7 /* RNDateTimePickerShadowView.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/Exponent/Versioned/Core/Api/Components/DateTimePicker/RNDateTimePicker.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/DateTimePicker/RNDateTimePicker.m
@@ -13,6 +13,7 @@
 @interface RNDateTimePicker ()
 
 @property (nonatomic, copy) RCTBubblingEventBlock onChange;
+@property (nonatomic, copy) RCTBubblingEventBlock onPickerDismiss;
 @property (nonatomic, assign) NSInteger reactMinuteInterval;
 
 @end
@@ -22,8 +23,14 @@
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if ((self = [super initWithFrame:frame])) {
-    [self addTarget:self action:@selector(didChange)
+    #ifndef RCT_NEW_ARCH_ENABLED
+      // somehow, with Fabric, the callbacks are executed here as well as in RNDateTimePickerComponentView
+      // so do not register it with Fabric, to avoid potential problems
+      [self addTarget:self action:@selector(didChange)
                forControlEvents:UIControlEventValueChanged];
+      [self addTarget:self action:@selector(onDismiss:) forControlEvents:UIControlEventEditingDidEnd];
+    #endif
+
     _reactMinuteInterval = 1;
   }
   return self;
@@ -35,6 +42,13 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 {
   if (_onChange) {
     _onChange(@{ @"timestamp": @(self.date.timeIntervalSince1970 * 1000.0) });
+  }
+}
+
+- (void)onDismiss:(RNDateTimePicker *)sender
+{
+  if (_onPickerDismiss) {
+    _onPickerDismiss(@{});
   }
 }
 

--- a/ios/Exponent/Versioned/Core/Api/Components/DateTimePicker/RNDateTimePickerManager.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/DateTimePicker/RNDateTimePickerManager.m
@@ -6,6 +6,7 @@
  */
 
 #import "RNDateTimePickerManager.h"
+#import "RNDateTimePickerShadowView.h"
 
 #import <React/RCTBridge.h>
 #import <React/RCTEventDispatcher.h>
@@ -53,13 +54,33 @@ RCT_ENUM_CONVERTER(UIUserInterfaceStyle, (@{
 
 @end
 
-@implementation RNDateTimePickerManager
+@implementation RNDateTimePickerManager {
+  RNDateTimePicker* _picker;
+}
 
 RCT_EXPORT_MODULE()
+
+- (instancetype)init {
+  if (self = [super init]) {
+    _picker = [RNDateTimePicker new];
+  }
+  return self;
+}
+
++ (BOOL)requiresMainQueueSetup {
+  return true;
+}
 
 - (UIView *)view
 {
   return [RNDateTimePicker new];
+}
+
+- (RCTShadowView *)shadowView
+{
+  RNDateTimePickerShadowView* shadowView =  [RNDateTimePickerShadowView new];
+  shadowView.picker = _picker;
+  return shadowView;
 }
 
 + (NSString*) datepickerStyleToString: (UIDatePickerStyle) style  API_AVAILABLE(ios(13.4)){
@@ -79,28 +100,10 @@ RCT_EXPORT_MODULE()
     }
 }
 
-RCT_EXPORT_METHOD(getDefaultDisplayValue:(NSDictionary *)options resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
-{
-    dispatch_async(dispatch_get_main_queue(), ^{
-      if (@available(iOS 13.4, *)) {
-        UIDatePicker* view = [RNDateTimePicker new];
-        
-        view.preferredDatePickerStyle = UIDatePickerStyleAutomatic;
-        UIDatePickerMode renderedMode = [RCTConvert UIDatePickerMode:options[@"mode"]];
-        view.datePickerMode = renderedMode;
-        // NOTE afaict we do not need to measure the actual dimensions here, but if we do, just look at the original PR
-        
-        UIDatePickerStyle determinedDisplayValue = view.datePickerStyle;
-
-        resolve(@{
-                 @"determinedDisplayValue": [RNDateTimePickerManager datepickerStyleToString:determinedDisplayValue],
-                });
-      } else {
-        // never happens; the condition is just to avoid compiler warnings
-        reject(@"UNEXPECTED_CALL", @"unexpected getDefaultDisplayValue() call", nil);
-      }
-    });
-}
+RCT_EXPORT_SHADOW_PROPERTY(date, NSDate)
+RCT_EXPORT_SHADOW_PROPERTY(mode, UIDatePickerMode)
+RCT_EXPORT_SHADOW_PROPERTY(locale, NSLocale)
+RCT_EXPORT_SHADOW_PROPERTY(displayIOS, RNCUIDatePickerStyle)
 
 RCT_EXPORT_VIEW_PROPERTY(date, NSDate)
 RCT_EXPORT_VIEW_PROPERTY(locale, NSLocale)
@@ -109,6 +112,7 @@ RCT_EXPORT_VIEW_PROPERTY(maximumDate, NSDate)
 RCT_EXPORT_VIEW_PROPERTY(minuteInterval, NSInteger)
 RCT_EXPORT_VIEW_PROPERTY(enabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(onChange, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onPickerDismiss, RCTBubblingEventBlock)
 
 RCT_REMAP_VIEW_PROPERTY(mode, datePickerMode, UIDatePickerMode)
 RCT_REMAP_VIEW_PROPERTY(timeZoneOffsetInMinutes, timeZone, NSTimeZone)

--- a/ios/Exponent/Versioned/Core/Api/Components/DateTimePicker/RNDateTimePickerShadowView.h
+++ b/ios/Exponent/Versioned/Core/Api/Components/DateTimePicker/RNDateTimePickerShadowView.h
@@ -1,0 +1,12 @@
+#import <React/RCTShadowView.h>
+#import "RNDateTimePicker.h"
+
+@interface RNDateTimePickerShadowView : RCTShadowView
+
+@property (nullable, nonatomic, strong) RNDateTimePicker *picker;
+@property (nonatomic) UIDatePickerMode mode;
+@property (nullable, nonatomic, strong) NSDate *date;
+@property (nullable, nonatomic, strong) NSLocale *locale;
+@property (nonatomic, assign) UIDatePickerStyle displayIOS API_AVAILABLE(ios(13.4));
+
+@end

--- a/ios/Exponent/Versioned/Core/Api/Components/DateTimePicker/RNDateTimePickerShadowView.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/DateTimePicker/RNDateTimePickerShadowView.m
@@ -1,0 +1,55 @@
+#import "RNDateTimePickerShadowView.h"
+
+@implementation RNDateTimePickerShadowView
+
+- (instancetype)init
+{
+  if (self = [super init]) {
+    YGNodeSetMeasureFunc(self.yogaNode, RNDateTimePickerShadowViewMeasure);
+  }
+  return self;
+}
+
+- (void)setDate:(NSDate *)date {
+  _date = date;
+  YGNodeMarkDirty(self.yogaNode);
+}
+
+- (void)setLocale:(NSLocale *)locale {
+  _locale = locale;
+  YGNodeMarkDirty(self.yogaNode);
+}
+
+- (void)setMode:(UIDatePickerMode)mode {
+  _mode = mode;
+  YGNodeMarkDirty(self.yogaNode);
+}
+
+
+- (void)setDisplayIOS:(UIDatePickerStyle)displayIOS {
+  _displayIOS = displayIOS;
+  YGNodeMarkDirty(self.yogaNode);
+}
+
+static YGSize RNDateTimePickerShadowViewMeasure(YGNodeRef node, float width, YGMeasureMode widthMode, float height, YGMeasureMode heightMode)
+{
+  RNDateTimePickerShadowView *shadowPickerView = (__bridge RNDateTimePickerShadowView *)YGNodeGetContext(node);
+
+  __block CGSize size;
+  dispatch_sync(dispatch_get_main_queue(), ^{
+    [shadowPickerView.picker setDate:shadowPickerView.date];
+    [shadowPickerView.picker setDatePickerMode:shadowPickerView.mode];
+    [shadowPickerView.picker setLocale:shadowPickerView.locale];
+    if (@available(iOS 14.0, *)) {
+      [shadowPickerView.picker setPreferredDatePickerStyle:shadowPickerView.displayIOS];
+    }
+    size = [shadowPickerView.picker sizeThatFits:UILayoutFittingCompressedSize];
+  });
+  
+  return (YGSize){
+    RCTYogaFloatFromCoreGraphicsFloat(size.width),
+    RCTYogaFloatFromCoreGraphicsFloat(size.height)
+  };
+}
+
+@end

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -1,7 +1,7 @@
 {
   "@expo/vector-icons": "^13.0.0",
   "@react-native-async-storage/async-storage": "~1.17.3",
-  "@react-native-community/datetimepicker": "6.2.0",
+  "@react-native-community/datetimepicker": "6.5.0",
   "@react-native-masked-view/masked-view": "0.2.7",
   "@react-native-community/netinfo": "9.3.3",
   "@react-native-community/slider": "4.2.3",


### PR DESCRIPTION
# Why

Fixes ENG-6545

# How

- `et update-vendored-module --module @react-native-community/datetimepicker --target expo-go --commit bb5ed6f2039c7386ec8f7c0c4de22a73a80860ad`
  <details><summary>Upgrade log</summary>

  ```log
  📥 Cloning @react-native-community/datetimepicker#bb5ed6f2039c7386ec8f7c0c4de22a73a80860ad from https://github.com/react-native-community/react-native-datetimepicker.git
  ‼️  Using legacy vendoring for platform ios
  NOTE: In Expo, native Android styles are prefixed with ReactAndroid. Please ensure that resourceNames used for grabbing style of dialogs are being resolved properly.

  Cleaning up iOS files at Exponent/Versioned/Core/Api/Components/DateTimePicker ...

  Copying iOS files ...
  > ios/Exponent/Versioned/Core/Api/Components/DateTimePicker/RNDateTimePicker.h
  > ios/Exponent/Versioned/Core/Api/Components/DateTimePicker/RNDateTimePicker.m
  > ios/Exponent/Versioned/Core/Api/Components/DateTimePicker/RNDateTimePickerManager.h
  > ios/Exponent/Versioned/Core/Api/Components/DateTimePicker/RNDateTimePickerManager.m
  > ios/Exponent/Versioned/Core/Api/Components/DateTimePicker/RNDateTimePickerShadowView.h
  > ios/Exponent/Versioned/Core/Api/Components/DateTimePicker/RNDateTimePickerShadowView.m

  Updating pbxproj configuration ...
  Adding RNDateTimePickerShadowView.h to pbxproj configuration ...
  Adding RNDateTimePickerShadowView.m to pbxproj configuration ...
  Saving updated pbxproj structure to the file Exponent.xcodeproj/project.pbxproj ...

  Successfully updated iOS files, but please make sure Xcode project files are setup correctly in Exponent/Versioned/Core/Api/Components/DateTimePicker
  ‼️  Using legacy vendoring for platform android
  NOTE: In Expo, native Android styles are prefixed with ReactAndroid. Please ensure that resourceNames used for grabbing style of dialogs are being resolved properly.

  Cleaning up Android files at expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker ...

  Copying Android files ...
  > android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/Common.java
  > android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/MinuteIntervalSnappableTimePickerDialog.java
  > android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/ReflectionHelper.java
  > android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNConstants.java
  > android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDate.java
  > android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDatePickerDialogFragment.java
  > android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDatePickerDialogModule.java
  > android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDatePickerDisplay.java
  > android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDateTimePickerPackage.java
  > android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDismissableDatePickerDialog.java
  > android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDismissableTimePickerDialog.java
  > android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNTimePickerDialogFragment.java
  > android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNTimePickerDialogModule.java
  > android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNTimePickerDisplay.java
  ✍️  Updating bundled native modules
  ✍️  Updating workspace dependencies
  💪 Successfully updated @react-native-community/datetimepicker
  ```

  </details>

# Test Plan

- Tested in NCL on iOS 16 / iPhone 14 Pro, using unversioned

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
