### PR TITLE
[Android][iOS] Upgrade @react-native-community/netinfo to 9.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Package-specific changes not released in any SDK will be added here just before 
 - Updated `@shopify/flash-list` from `1.1.0` to `1.3.0`. ([#19317](https://github.com/expo/expo/pull/19317) by [@kudo](https://github.com/kudo))
 - Updated `react-native-webview` from `11.23.0` to `11.23.1`. ([#19375](https://github.com/expo/expo/pull/19375) by [@aleqsio](https://github.com/aleqsio))
 - Updated `react-native-gesture-handler` from `2.5.0` to `2.7.0`. ([#19362](https://github.com/expo/expo/pull/19362) by [@tsapeta](https://github.com/tsapeta))
+- Updated `@react-native-community/netinfo` from `9.3.0` to `9.3.3`. ([#19421](https://github.com/expo/expo/pull/19421) by [@douglowder](https://github.com/douglowder))
 - Updated `@react-native-picker/picker` from `2.4.2` to `2.4.6`. ([#19390](https://github.com/expo/expo/pull/19390) by [@aleqsio](https://github.com/aleqsio))
 - Updated `react-native-screens` from `3.15.0` to `3.18.0`. ([#19383](https://github.com/expo/expo/pull/19383) by [@tsapeta](https://github.com/tsapeta))
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/netinfo/NetworkCallbackConnectivityReceiver.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/netinfo/NetworkCallbackConnectivityReceiver.java
@@ -125,6 +125,10 @@ public class NetworkCallbackConnectivityReceiver extends ConnectivityReceiver {
                             NetworkCapabilities.NET_CAPABILITY_VALIDATED)
                             && !isInternetSuspended;
 
+            if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_VPN)) {
+                isInternetReachable = isInternetReachable && capabilities.getLinkDownstreamBandwidthKbps() != 0;
+            }
+
             // Get the cellular network type
             if (network != null && connectionType == ConnectionType.CELLULAR && isInternetReachable) {
                 cellularGeneration = CellularGeneration.fromNetworkInfo(networkInfo);

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -93,7 +93,7 @@
     "@babel/runtime": "^7.14.0",
     "@react-native-async-storage/async-storage": "~1.17.3",
     "@react-native-community/datetimepicker": "6.2.0",
-    "@react-native-community/netinfo": "9.3.0",
+    "@react-native-community/netinfo": "9.3.3",
     "@react-native-community/slider": "4.2.3",
     "@react-native-community/viewpager": "5.0.11",
     "@react-native-masked-view/masked-view": "0.2.6",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -43,7 +43,7 @@
     "@expo/react-native-action-sheet": "^3.8.0",
     "@react-native-async-storage/async-storage": "~1.17.3",
     "@react-native-community/datetimepicker": "6.2.0",
-    "@react-native-community/netinfo": "9.3.0",
+    "@react-native-community/netinfo": "9.3.3",
     "@react-native-community/slider": "4.2.3",
     "@react-native-masked-view/masked-view": "0.2.6",
     "@react-native-picker/picker": "2.4.6",

--- a/home/package.json
+++ b/home/package.json
@@ -23,7 +23,7 @@
     "@expo/vector-icons": "^13.0.0",
     "@graphql-codegen/introspection": "^2.1.1",
     "@react-native-async-storage/async-storage": "~1.17.3",
-    "@react-native-community/netinfo": "9.3.0",
+    "@react-native-community/netinfo": "9.3.3",
     "@react-navigation/bottom-tabs": "~5.11.1",
     "@react-navigation/material-bottom-tabs": "~5.3.9",
     "@react-navigation/native": "~5.8.9",

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1903,7 +1903,7 @@ PODS:
   - React-jsinspector (0.70.2)
   - React-logger (0.70.2):
     - glog
-  - react-native-netinfo (9.3.0):
+  - react-native-netinfo (9.3.3):
     - React-Core
   - react-native-pager-view (5.4.24):
     - React-Core
@@ -3490,7 +3490,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 53bd208e5c27939c6e6365528393445a596a9a2b
   React-jsinspector: 26c42646ab0bb69e29e837e23754fe7121eeaf94
   React-logger: 1bfd109a0ffa4c0989bbfac0c2d8c4abe4637faa
-  react-native-netinfo: 129bd99f607a2dc5bb096168f3e5c150fd1f1c95
+  react-native-netinfo: b514dd6d9cd512b90e178c5b7158df1a1c568d47
   react-native-pager-view: 95d0418c3c74279840abec6926653d32447bafb6
   react-native-safe-area-context: 6c12e3859b6f27b25de4fee8201cfb858432d8de
   react-native-segmented-control: 06607462630512ff8eef652ec560e6235a30cc3e

--- a/ios/vendored/unversioned/@react-native-community/netinfo/ios/RNCConnectionState.m
+++ b/ios/vendored/unversioned/@react-native-community/netinfo/ios/RNCConnectionState.m
@@ -6,11 +6,11 @@
  */
 
 #import "RNCConnectionState.h"
-#if !TARGET_OS_TV
+#if !TARGET_OS_TV && !TARGET_OS_MACCATALYST
 #import <CoreTelephony/CTTelephonyNetworkInfo.h>
 #endif
 
-#if TARGET_OS_TV || TARGET_OS_OSX
+#if TARGET_OS_TV || TARGET_OS_OSX || TARGET_OS_MACCATALYST
 #include <ifaddrs.h>
 #endif
 
@@ -36,16 +36,16 @@
         _type = RNCConnectionTypeUnknown;
         _cellularGeneration = nil;
         _expensive = false;
-        
+
         if ((flags & kSCNetworkReachabilityFlagsReachable) == 0 ||
             (flags & kSCNetworkReachabilityFlagsConnectionRequired) != 0) {
             _type = RNCConnectionTypeNone;
         }
-#if !TARGET_OS_TV && !TARGET_OS_OSX
+#if !TARGET_OS_TV && !TARGET_OS_OSX && !TARGET_OS_MACCATALYST
         else if ((flags & kSCNetworkReachabilityFlagsIsWWAN) != 0) {
             _type = RNCConnectionTypeCellular;
             _expensive = true;
-            
+
             CTTelephonyNetworkInfo *netinfo = [[CTTelephonyNetworkInfo alloc] init];
             if (netinfo) {
                 if ([netinfo.currentRadioAccessTechnology isEqualToString:CTRadioAccessTechnologyGPRS] ||
@@ -73,7 +73,7 @@
 #endif
         else {
             _type = RNCConnectionTypeWifi;
-#if TARGET_OS_TV || TARGET_OS_OSX
+#if TARGET_OS_TV || TARGET_OS_OSX || TARGET_OS_MACCATALYST
             struct ifaddrs *interfaces = NULL;
             struct ifaddrs *temp_addr = NULL;
             int success = 0;

--- a/ios/vendored/unversioned/@react-native-community/netinfo/ios/RNCNetInfo.m
+++ b/ios/vendored/unversioned/@react-native-community/netinfo/ios/RNCNetInfo.m
@@ -11,7 +11,7 @@
 #include <ifaddrs.h>
 #include <arpa/inet.h>
 
-#if !TARGET_OS_TV
+#if !TARGET_OS_TV && !TARGET_OS_MACCATALYST
 #import <CoreTelephony/CTCarrier.h>
 #import <CoreTelephony/CTTelephonyNetworkInfo.h>
 #endif
@@ -130,7 +130,7 @@ RCT_EXPORT_METHOD(configure:(NSDictionary *)config)
   } else if ([requestedInterface isEqualToString: RNCConnectionTypeWifi] || [requestedInterface isEqualToString: RNCConnectionTypeEthernet]) {
     details[@"ipAddress"] = [self ipAddress] ?: NSNull.null;
     details[@"subnet"] = [self subnet] ?: NSNull.null;
-    #if !TARGET_OS_TV && !TARGET_OS_OSX   
+    #if !TARGET_OS_TV && !TARGET_OS_OSX && !TARGET_OS_MACCATALYST
       /*
         Without one of the conditions needed to use CNCopyCurrentNetworkInfo, it will leak memory.
         Clients should only set the shouldFetchWiFiSSID to true after ensuring requirements are met to get (B)SSID.
@@ -146,7 +146,7 @@ RCT_EXPORT_METHOD(configure:(NSDictionary *)config)
 
 - (NSString *)carrier
 {
-#if (TARGET_OS_TV || TARGET_OS_OSX)
+#if (TARGET_OS_TV || TARGET_OS_OSX || TARGET_OS_MACCATALYST)
   return nil;
 #else
   CTTelephonyNetworkInfo *netinfo = [[CTTelephonyNetworkInfo alloc] init];
@@ -227,7 +227,7 @@ RCT_EXPORT_METHOD(configure:(NSDictionary *)config)
   return subnet;
 }
 
-#if !TARGET_OS_TV && !TARGET_OS_OSX
+#if !TARGET_OS_TV && !TARGET_OS_OSX && !TARGET_OS_MACCATALYST
 - (NSString *)ssid
 {
   NSArray *interfaceNames = CFBridgingRelease(CNCopySupportedInterfaces());

--- a/ios/vendored/unversioned/@react-native-community/netinfo/react-native-netinfo.podspec.json
+++ b/ios/vendored/unversioned/@react-native-community/netinfo/react-native-netinfo.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-netinfo",
-  "version": "9.3.0",
+  "version": "9.3.3",
   "summary": "React Native Network Info API for iOS & Android",
   "license": "MIT",
   "authors": "Matt Oakes <hello@mattoakes.net>",
@@ -12,7 +12,7 @@
   },
   "source": {
     "git": "https://github.com/react-native-community/react-native-netinfo.git",
-    "tag": "v9.3.0"
+    "tag": "v9.3.3"
   },
   "source_files": "ios/**/*.{h,m}",
   "dependencies": {

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -3,7 +3,7 @@
   "@react-native-async-storage/async-storage": "~1.17.3",
   "@react-native-community/datetimepicker": "6.2.0",
   "@react-native-masked-view/masked-view": "0.2.7",
-  "@react-native-community/netinfo": "9.3.0",
+  "@react-native-community/netinfo": "9.3.3",
   "@react-native-community/slider": "4.2.3",
   "@react-native-community/viewpager": "5.0.11",
   "@react-native-firebase/app": "~15.4.0",


### PR DESCRIPTION
# Why

Closes ENG-6543

# How

```
et uvm -m @react-native-community/netinfo -c 'v9.3.3'
et pods -f
yarn
```

# Test Plan

- [x] test unversioned expo go ios
- [ ] test unversioned expo go android
- [ ] CI tests pass

# Checklist

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).