### PR TITLE
[docs][Expo config] Fix Constants.manifest reference and update verbiage

### DIFF
--- a/docs/pages/versions/unversioned/config/app.mdx
+++ b/docs/pages/versions/unversioned/config/app.mdx
@@ -10,7 +10,7 @@ import schema from '~/scripts/schemas/unversioned/app-config-schema.js';
 
 The following is a list of properties that are available for you under the `"expo"` key in **app.json** or **app.config.json**. These properties can be passed to the top level object of **app.config.js** or **app.config.ts**.
 
-For more general information on app configuration, such as the differences between the various app configuration files, check out our introductory [guide](/workflow/configuration/).
+For more general information on app configuration, such as the differences between the various app configuration files, see [Configuration with app.json/app.config.js](/workflow/configuration/).
 
 ## Properties
 

--- a/docs/pages/versions/v43.0.0/config/app.mdx
+++ b/docs/pages/versions/v43.0.0/config/app.mdx
@@ -10,7 +10,7 @@ import schema from '~/scripts/schemas/v43.0.0/app-config-schema.js';
 
 The following is a list of properties that are available for you under the `"expo"` key in **app.json** or **app.config.json**. These properties can be passed to the top level object of **app.config.js** or **app.config.ts**.
 
-For more general information on app configuration, such as the differences between the various app configuration files, check out our introductory [guide](/workflow/configuration/).
+For more general information on app configuration, such as the differences between the various app configuration files, see [Configuration with app.json/app.config.js](/workflow/configuration/).
 
 ## Properties
 

--- a/docs/pages/versions/v44.0.0/config/app.mdx
+++ b/docs/pages/versions/v44.0.0/config/app.mdx
@@ -10,7 +10,7 @@ import schema from '~/scripts/schemas/v44.0.0/app-config-schema.js';
 
 The following is a list of properties that are available for you under the `"expo"` key in **app.json** or **app.config.json**. These properties can be passed to the top level object of **app.config.js** or **app.config.ts**.
 
-For more general information on app configuration, such as the differences between the various app configuration files, check out our introductory [guide](/workflow/configuration/).
+For more general information on app configuration, such as the differences between the various app configuration files, see [Configuration with app.json/app.config.js](/workflow/configuration/).
 
 ## Properties
 

--- a/docs/pages/versions/v45.0.0/config/app.mdx
+++ b/docs/pages/versions/v45.0.0/config/app.mdx
@@ -10,7 +10,7 @@ import schema from '~/scripts/schemas/v45.0.0/app-config-schema.js';
 
 The following is a list of properties that are available for you under the `"expo"` key in **app.json** or **app.config.json**. These properties can be passed to the top level object of **app.config.js** or **app.config.ts**.
 
-For more general information on app configuration, such as the differences between the various app configuration files, check out our introductory [guide](/workflow/configuration/).
+For more general information on app configuration, such as the differences between the various app configuration files, see [Configuration with app.json/app.config.js](/workflow/configuration/).
 
 ## Properties
 

--- a/docs/pages/versions/v46.0.0/config/app.mdx
+++ b/docs/pages/versions/v46.0.0/config/app.mdx
@@ -10,7 +10,7 @@ import schema from '~/scripts/schemas/v46.0.0/app-config-schema.js';
 
 The following is a list of properties that are available for you under the `"expo"` key in **app.json** or **app.config.json**. These properties can be passed to the top level object of **app.config.js** or **app.config.ts**.
 
-For more general information on app configuration, such as the differences between the various app configuration files, check out our introductory [guide](/workflow/configuration/).
+For more general information on app configuration, such as the differences between the various app configuration files, see [Configuration with app.json/app.config.js](/workflow/configuration/).
 
 ## Properties
 

--- a/docs/pages/workflow/configuration.mdx
+++ b/docs/pages/workflow/configuration.mdx
@@ -3,12 +3,14 @@ title: Configuration with app.json / app.config.js
 ---
 
 import PossibleRedirectNotification from '~/components/plugins/PossibleRedirectNotification';
+import { Terminal } from '~/ui/components/Snippet';
+import { Collapsible } from '~/ui/components/Collapsible';
 
 <PossibleRedirectNotification newUrl="/versions/latest/config/app/" />
 
-The Expo config (**app.json**, **app.config.js**, **app.config.ts**) is used for configuring how a project loads in [Expo Go](https://expo.dev/expo-go), [Expo Prebuild](/workflow/prebuild) generation, and the OTA update manifest (think of this like an `index.html` for React Native apps).
+The Expo config (**app.json**, **app.config.js**, **app.config.ts**) is used for configuring how a project loads in [Expo Go](/workflow/expo-go), [Expo Prebuild](/workflow/prebuild) generation, and the OTA update manifest. You can think of this as an `index.html` but for React Native apps.
 
-The Expo config must be located at the root of your project, next to your **package.json**. Example:
+It must be located at the root of your project, next to the **package.json**. Here is a bare-minimum example:
 
 ```json
 {
@@ -19,32 +21,34 @@ The Expo config must be located at the root of your project, next to your **pack
 }
 ```
 
-Most configuration from **app.json** is accessible at runtime from your JavaScript code via [`Constants.manifest`](/versions/latest/sdk/constants/#expoconstantsmanifest). Sensitive information such as secret keys are removed. See the `"extra"` key below for information about how to pass arbitrary configuration data to your app.
+Most configuration from the Expo config is accessible at runtime from the JavaScript code using [`Constants.expoConfig`](/versions/latest/sdk/constants/#nativeconstants--properties). Sensitive information such as secret keys are removed.
 
 ## Properties
 
-**app.json** configures many things, from your app name to icon to splash screen and even deep linking scheme and API keys to use for some services. To see a full list of available properties, please refer to the [app.json / app.config.js reference](/versions/latest/config/app/).
+The Expo config configures many things such as app name, icon, splash screen, deep linking scheme, API keys to use for some services and so on. For a complete list of available properties, see [app.json/app.config.js reference](/versions/latest/config/app/).
 
 > **info** Do you use Visual Studio Code? If so, we recommend that you install the [vscode-expo](https://marketplace.visualstudio.com/items?itemName=byCedric.vscode-expo) extension to get auto-completion of properties in **app.json** files.
 
-## Extending
+## Extending configuration
 
-Library authors can extend the Expo config by using [Expo config plugins](/guides/config-plugins). Config plugins mostly used to configure the [`npx expo prebuild`](/workflow/prebuild.mdx) command.
+Library authors can extend the Expo config by using [Expo Config plugins](/guides/config-plugins).
 
-## Dynamic configuration with app.config.js
+> **info** Config plugins are mostly used to configure the [`npx expo prebuild`](/workflow/prebuild) command.
 
-For more customization you can use the JavaScript and TypeScript **app.config.js**, or **app.config.ts**. These configs have the following properties:
+## Dynamic configuration
 
-- Comments, variables, and single quotes!
+For more customization, you can use the JavaScript or [TypeScript](#using-typescript-for-configuration-appconfigts-instead-of) (**app.config.js**, or **app.config.ts**). These configs have the following properties:
+
+- Comments, variables, and single quotes.
 - Importing/requiring other JavaScript files. Using import/export syntax in external files is not supported. All imported files must be transpiled to support your current version of Node.js.
 - TypeScript support with nullish coalescing and optional chaining.
 - Updated whenever Metro bundler reloads.
 - Provide environment information to your app.
 - Does not support Promises.
 
-For example, you can export an object as default to define your config in **app.config.js**:
+For example, you can export an object to define your custom config:
 
-```js
+```js app.config.js
 const myValue = 'My App';
 
 module.exports = {
@@ -57,15 +61,23 @@ module.exports = {
 };
 ```
 
-Extras can be accessed via `expo-constants`:
+The `"extra"` key allows passing arbitrary configuration data to your app. The value of this key is accessed using [`expo-constants`](/versions/latest/sdk/constants/):
 
-```ts App.js
+```js App.js
 import Constants from 'expo-constants';
 
-Constants.manifest.extra.fact === 'kittens are cool';
+Constants.expoConfig.extra.fact === 'kittens are cool';
 ```
 
-You can access and modify incoming config values by exporting a function that returns an object. This is useful if your project also has an **app.json**. By default, Expo CLI will read the **app.json** first and send the normalized results to the **app.config.js**. This functionality is disabled when the `--config` is used to specify a custom config (also note that the [`--config` flag is deprecated](https://expo.fyi/config-flag-migration)).
+<Collapsible summary="Using SDK 45 or below?">
+
+The `extra` property is available on the `Constants.manifest` property.
+
+</Collapsible>
+
+You can access and modify incoming config values by exporting a function that returns an object. This is useful if your project also has an **app.json**. By default, Expo CLI will read the **app.json** first and send the normalized results to the **app.config.js**. This functionality is disabled when the `--config` is used to specify a custom config.
+
+> **warning** The `--config` flag is deprecated. For more information, see [Migration from `--config` in Expo CLI](https://expo.fyi/config-flag-migration).
 
 For example, your **app.json** could look like this:
 
@@ -106,11 +118,19 @@ module.exports = () => {
 };
 ```
 
-To use this configuration with Expo CLI commands, set the environment variable either for specific commands or in your shell profile. To set environment variables for specific commands, prefix the command with the variables and values, for example: `MY_ENVIRONMENT=production eas update` (this is not anything unique to Expo CLI). On Windows you can approximate this with `npx cross-env MY_ENVIRONMENT=production eas update`, or use whichever other mechanism that you are comfortable with for environment variables.
+To use this configuration with Expo CLI commands, set the environment variable either for specific commands or in your shell profile. To set environment variables for specific commands, prefix the command with the variables and values as shown in the example:
+
+<Terminal cmd={['$ MY_ENVIRONMENT=production eas update']} />
+
+This is not anything unique to Expo CLI. On Windows you can approximate the above command with:
+
+<Terminal cmd={['$ npx cross-env MY_ENVIRONMENT=production eas update']} />
+
+Or you can use any other mechanism that you are comfortable with for environment variables.
 
 ### Using TypeScript for configuration: app.config.ts instead of app.config.js
 
-You can use autocomplete and doc-blocks with a TypeScript Expo config **app.config.ts**. Create an **app.config.ts** with the following contents:
+You can use autocomplete and doc-blocks with an Expo config in TypeScript. Create an **app.config.ts** with the following contents:
 
 ```ts app.config.ts
 // `@expo/config` is installed with the `expo` package
@@ -123,7 +143,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
 });
 ```
 
-If you want to import other TypeScript files or customize the language features, then we recommend using `ts-node` as [described here](/guides/typescript#appconfigjs).
+If you want to import other TypeScript files or customize the language features, we recommend using `ts-node` as described in [Using TypeScript](/guides/typescript#appconfigjs).
 
 ### Configuration Resolution Rules
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Refs ENG-6588

# How

<!--
How did you build this feature or fix this bug and why?
-->

- By updating the reference of `Constants.manifest` to `Constants.expoConfig`. 
- Also, added a note for SDK 45 and below to use `Constants.manifest`.
- updated the overall verbiage, did some re-organization of text and added Callout components for blockquotes.
- Update link text in https://docs.expo.dev/versions/latest/config/app/ referring back to the `Configuration with app.json / app.config.js` page. Also, backported to SDK 45, 44, & 43.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally via `yarn dev` and then go open http://localhost:3002/workflow/configuration/.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
