### PR TITLE
[docs][sqlite] Update importing existing database section

### DIFF
--- a/docs/pages/versions/unversioned/sdk/sqlite.mdx
+++ b/docs/pages/versions/unversioned/sdk/sqlite.mdx
@@ -7,8 +7,9 @@ packageName: 'expo-sqlite'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import { Terminal } from '~/ui/components/Snippet';
 
-**`expo-sqlite`** gives your app access to a database that can be queried through a [WebSQL](https://www.w3.org/TR/webdatabase/)-like API. The database is persisted across restarts of your app.
+`expo-sqlite` gives your app access to a database that can be queried through a [WebSQL](https://www.w3.org/TR/webdatabase/)-like API. The database is persisted across restarts of your app.
 
 An [example to do list app](https://github.com/expo/examples/tree/master/with-sqlite) is available that uses this module for storage.
 
@@ -18,35 +19,38 @@ An [example to do list app](https://github.com/expo/examples/tree/master/with-sq
 
 ### Importing an existing database
 
-In order to open a new SQLite database using an existing `.db` file you already have, you need to do three things:
+To open a new SQLite database using an existing `.db` file you already have, you'll need to do three things:
 
-- `npx expo install expo-file-system expo-asset`
-- create a **metro.config.js** file in the root of your project with the following contents ([curious why? read here](/guides/customizing-metro.mdx#adding-more-file-extensions-to--assetexts)):
+- Install `expo-file-system` and `expo-asset` packages:
 
-```ts
-const { getDefaultConfig } = require('expo/metro-config');
+  <Terminal cmd={['$ npx expo install expo-file-system expo-asset']} />
 
-const defaultConfig = getDefaultConfig(__dirname);
+- Create a **metro.config.js** file at the root of your project with the following contents ([curious why? read here](/guides/customizing-metro.mdx#adding-more-file-extensions-to--assetexts)):
 
-defaultConfig.resolver.assetExts.push('db');
+  ```ts
+  const { getDefaultConfig } = require('expo/metro-config');
 
-module.exports = defaultConfig;
-```
+  const defaultConfig = getDefaultConfig(__dirname);
+
+  defaultConfig.resolver.assetExts.push('db');
+
+  module.exports = defaultConfig;
+  ```
 
 - Use the following function (or similar) to open your database:
 
-```ts
-async function openDatabase(pathToDatabaseFile: string): Promise<SQLite.WebSQLDatabase> {
-  if (!(await FileSystem.getInfoAsync(FileSystem.documentDirectory + 'SQLite')).exists) {
-    await FileSystem.makeDirectoryAsync(FileSystem.documentDirectory + 'SQLite');
+  ```ts
+  async function openDatabase(pathToDatabaseFile: string): Promise<SQLite.WebSQLDatabase> {
+    if (!(await FileSystem.getInfoAsync(FileSystem.documentDirectory + 'SQLite')).exists) {
+      await FileSystem.makeDirectoryAsync(FileSystem.documentDirectory + 'SQLite');
+    }
+    await FileSystem.downloadAsync(
+      Asset.fromModule(require(pathToDatabaseFile)).uri,
+      FileSystem.documentDirectory + 'SQLite/myDatabaseName.db'
+    );
+    return SQLite.openDatabase('myDatabaseName.db');
   }
-  await FileSystem.downloadAsync(
-    Asset.fromModule(require(pathToDatabaseFile)).uri,
-    FileSystem.documentDirectory + 'SQLite/myDatabaseName.db'
-  );
-  return SQLite.openDatabase('myDatabaseName.db');
-}
-```
+  ```
 
 ### Executing statements outside of a transaction
 

--- a/docs/pages/versions/unversioned/sdk/sqlite.mdx
+++ b/docs/pages/versions/unversioned/sdk/sqlite.mdx
@@ -21,7 +21,7 @@ An [example to do list app](https://github.com/expo/examples/tree/master/with-sq
 
 To open a new SQLite database using an existing `.db` file you already have, you'll need to do three things:
 
-- Install `expo-file-system` and `expo-asset` packages:
+- Install `expo-file-system` and `expo-asset` modules:
 
   <Terminal cmd={['$ npx expo install expo-file-system expo-asset']} />
 
@@ -54,7 +54,7 @@ To open a new SQLite database using an existing `.db` file you already have, you
 
 ### Executing statements outside of a transaction
 
-> **info** You should use this kind of execution only when it is necessary. For instance, when code is a no-op within transactions. For example, `PRAGMA foreign_keys = ON;`.
+> **info** You should use this kind of execution only when it is necessary. For instance, when code is a no-op within transactions. Example: `PRAGMA foreign_keys = ON;`.
 
 ```js
 const db = SQLite.openDatabase('dbName', version);

--- a/docs/pages/versions/unversioned/sdk/sqlite.mdx
+++ b/docs/pages/versions/unversioned/sdk/sqlite.mdx
@@ -54,7 +54,7 @@ To open a new SQLite database using an existing `.db` file you already have, you
 
 ### Executing statements outside of a transaction
 
-> Please note that you should use this kind of execution only when it is necessary. For instance, when code is a no-op within transactions (like eg. `PRAGMA foreign_keys = ON;`).
+> **info** You should use this kind of execution only when it is necessary. For instance, when code is a no-op within transactions. For example, `PRAGMA foreign_keys = ON;`.
 
 ```js
 const db = SQLite.openDatabase('dbName', version);

--- a/docs/pages/versions/v43.0.0/sdk/sqlite.mdx
+++ b/docs/pages/versions/v43.0.0/sdk/sqlite.mdx
@@ -20,7 +20,7 @@ An [example to do list app](https://github.com/expo/examples/tree/master/with-sq
 
 To open a new SQLite database using an existing `.db` file you already have, you need to do three things:
 
-- Install `expo-file-system` and `expo-asset` packages:
+- Install `expo-file-system` and `expo-asset` modules:
 
   <Terminal cmd={['$ expo install expo-file-system expo-asset']} />
 
@@ -55,7 +55,7 @@ To open a new SQLite database using an existing `.db` file you already have, you
 
 ### Executing statements outside of a transaction
 
-> **info** You should use this kind of execution only when it is necessary. For instance, when code is a no-op within transactions. For example, `PRAGMA foreign_keys = ON;`.
+> **info** You should use this kind of execution only when it is necessary. For instance, when code is a no-op within transactions. Example: `PRAGMA foreign_keys = ON;`.
 
 ```js
 const db = SQLite.openDatabase('dbName', version);

--- a/docs/pages/versions/v43.0.0/sdk/sqlite.mdx
+++ b/docs/pages/versions/v43.0.0/sdk/sqlite.mdx
@@ -6,8 +6,9 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-43/packages/expo-sqlite'
 import APISection from '~/components/plugins/APISection';
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import { Terminal } from '~/ui/components/Snippet';
 
-**`expo-sqlite`** gives your app access to a database that can be queried through a [WebSQL](https://www.w3.org/TR/webdatabase/)-like API. The database is persisted across restarts of your app.
+`expo-sqlite` gives your app access to a database that can be queried through a [WebSQL](https://www.w3.org/TR/webdatabase/)-like API. The database is persisted across restarts of your app.
 
 An [example to do list app](https://github.com/expo/examples/tree/master/with-sqlite) is available that uses this module for storage.
 
@@ -17,41 +18,44 @@ An [example to do list app](https://github.com/expo/examples/tree/master/with-sq
 
 ### Importing an existing database
 
-In order to open a new SQLite database using an existing `.db` file you already have, you need to do three things:
+To open a new SQLite database using an existing `.db` file you already have, you need to do three things:
 
-- `expo install expo-file-system expo-asset`
-- create a **metro.config.js** file in the root of your project with the following contents ([curious why? read here](/guides/customizing-metro.mdx#adding-more-file-extensions-to--assetexts)):
+- Install `expo-file-system` and `expo-asset` packages:
 
-```ts
-const { getDefaultConfig } = require('expo/metro-config');
+  <Terminal cmd={['$ expo install expo-file-system expo-asset']} />
 
-const defaultConfig = getDefaultConfig(__dirname);
+- Create a **metro.config.js** file in the root of your project with the following contents ([curious why? read here](/guides/customizing-metro.mdx#adding-more-file-extensions-to--assetexts)):
 
-module.exports = {
-  resolver: {
-    assetExts: [...defaultConfig.resolver.assetExts, 'db'],
-  },
-};
-```
+  ```ts
+  const { getDefaultConfig } = require('expo/metro-config');
+
+  const defaultConfig = getDefaultConfig(__dirname);
+
+  module.exports = {
+    resolver: {
+      assetExts: [...defaultConfig.resolver.assetExts, 'db'],
+    },
+  };
+  ```
 
 - Use the following function (or similar) to open your database:
 
-```ts
-async function openDatabase(pathToDatabaseFile: string): Promise<SQLite.WebSQLDatabase> {
-  if (!(await FileSystem.getInfoAsync(FileSystem.documentDirectory + 'SQLite')).exists) {
-    await FileSystem.makeDirectoryAsync(FileSystem.documentDirectory + 'SQLite');
+  ```ts
+  async function openDatabase(pathToDatabaseFile: string): Promise<SQLite.WebSQLDatabase> {
+    if (!(await FileSystem.getInfoAsync(FileSystem.documentDirectory + 'SQLite')).exists) {
+      await FileSystem.makeDirectoryAsync(FileSystem.documentDirectory + 'SQLite');
+    }
+    await FileSystem.downloadAsync(
+      Asset.fromModule(require(pathToDatabaseFile)).uri,
+      FileSystem.documentDirectory + 'SQLite/myDatabaseName.db'
+    );
+    return SQLite.openDatabase('myDatabaseName.db');
   }
-  await FileSystem.downloadAsync(
-    Asset.fromModule(require(pathToDatabaseFile)).uri,
-    FileSystem.documentDirectory + 'SQLite/myDatabaseName.db'
-  );
-  return SQLite.openDatabase('myDatabaseName.db');
-}
-```
+  ```
 
 ### Executing statements outside of a transaction
 
-> Please note that you should use this kind of execution only when it is necessary. For instance, when code is a no-op within transactions (like eg. `PRAGMA foreign_keys = ON;`).
+> **info** You should use this kind of execution only when it is necessary. For instance, when code is a no-op within transactions. For example, `PRAGMA foreign_keys = ON;`.
 
 ```js
 const db = SQLite.openDatabase('dbName', version);

--- a/docs/pages/versions/v43.0.0/sdk/sqlite.mdx
+++ b/docs/pages/versions/v43.0.0/sdk/sqlite.mdx
@@ -24,7 +24,7 @@ To open a new SQLite database using an existing `.db` file you already have, you
 
   <Terminal cmd={['$ expo install expo-file-system expo-asset']} />
 
-- Create a **metro.config.js** file in the root of your project with the following contents ([curious why? read here](/guides/customizing-metro.mdx#adding-more-file-extensions-to--assetexts)):
+- Create a **metro.config.js** file in the root of your project with the following snippet to [add support for `.db` file extension](/guides/customizing-metro/#adding-more-file-extensions-to--assetexts):
 
   ```ts
   const { getDefaultConfig } = require('expo/metro-config');

--- a/docs/pages/versions/v44.0.0/sdk/sqlite.mdx
+++ b/docs/pages/versions/v44.0.0/sdk/sqlite.mdx
@@ -20,7 +20,7 @@ An [example to do list app](https://github.com/expo/examples/tree/master/with-sq
 
 To open a new SQLite database using an existing `.db` file you already have, you need to do three things:
 
-- Install `expo-file-system` and `expo-asset` packages:
+- Install `expo-file-system` and `expo-asset` modules:
 
   <Terminal cmd={['$ expo install expo-file-system expo-asset']} />
 
@@ -55,7 +55,7 @@ To open a new SQLite database using an existing `.db` file you already have, you
 
 ### Executing statements outside of a transaction
 
-> **info** You should use this kind of execution only when it is necessary. For instance, when code is a no-op within transactions. For example, `PRAGMA foreign_keys = ON;`.
+> **info** You should use this kind of execution only when it is necessary. For instance, when code is a no-op within transactions. Example: `PRAGMA foreign_keys = ON;`.
 
 ```js
 const db = SQLite.openDatabase('dbName', version);

--- a/docs/pages/versions/v44.0.0/sdk/sqlite.mdx
+++ b/docs/pages/versions/v44.0.0/sdk/sqlite.mdx
@@ -6,8 +6,9 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-44/packages/expo-sqlite'
 import APISection from '~/components/plugins/APISection';
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import { Terminal } from '~/ui/components/Snippet';
 
-**`expo-sqlite`** gives your app access to a database that can be queried through a [WebSQL](https://www.w3.org/TR/webdatabase/)-like API. The database is persisted across restarts of your app.
+`expo-sqlite` gives your app access to a database that can be queried through a [WebSQL](https://www.w3.org/TR/webdatabase/)-like API. The database is persisted across restarts of your app.
 
 An [example to do list app](https://github.com/expo/examples/tree/master/with-sqlite) is available that uses this module for storage.
 
@@ -17,41 +18,44 @@ An [example to do list app](https://github.com/expo/examples/tree/master/with-sq
 
 ### Importing an existing database
 
-In order to open a new SQLite database using an existing `.db` file you already have, you need to do three things:
+To open a new SQLite database using an existing `.db` file you already have, you need to do three things:
 
-- `expo install expo-file-system expo-asset`
-- create a **metro.config.js** file in the root of your project with the following contents ([curious why? read here](/guides/customizing-metro.mdx#adding-more-file-extensions-to--assetexts)):
+- Install `expo-file-system` and `expo-asset` packages:
 
-```ts
-const { getDefaultConfig } = require('expo/metro-config');
+  <Terminal cmd={['$ expo install expo-file-system expo-asset']} />
 
-const defaultConfig = getDefaultConfig(__dirname);
+- Create a **metro.config.js** file in the root of your project with the following contents ([curious why? read here](/guides/customizing-metro.mdx#adding-more-file-extensions-to--assetexts)):
 
-module.exports = {
-  resolver: {
-    assetExts: [...defaultConfig.resolver.assetExts, 'db'],
-  },
-};
-```
+  ```ts
+  const { getDefaultConfig } = require('expo/metro-config');
+
+  const defaultConfig = getDefaultConfig(__dirname);
+
+  module.exports = {
+    resolver: {
+      assetExts: [...defaultConfig.resolver.assetExts, 'db'],
+    },
+  };
+  ```
 
 - Use the following function (or similar) to open your database:
 
-```ts
-async function openDatabase(pathToDatabaseFile: string): Promise<SQLite.WebSQLDatabase> {
-  if (!(await FileSystem.getInfoAsync(FileSystem.documentDirectory + 'SQLite')).exists) {
-    await FileSystem.makeDirectoryAsync(FileSystem.documentDirectory + 'SQLite');
+  ```ts
+  async function openDatabase(pathToDatabaseFile: string): Promise<SQLite.WebSQLDatabase> {
+    if (!(await FileSystem.getInfoAsync(FileSystem.documentDirectory + 'SQLite')).exists) {
+      await FileSystem.makeDirectoryAsync(FileSystem.documentDirectory + 'SQLite');
+    }
+    await FileSystem.downloadAsync(
+      Asset.fromModule(require(pathToDatabaseFile)).uri,
+      FileSystem.documentDirectory + 'SQLite/myDatabaseName.db'
+    );
+    return SQLite.openDatabase('myDatabaseName.db');
   }
-  await FileSystem.downloadAsync(
-    Asset.fromModule(require(pathToDatabaseFile)).uri,
-    FileSystem.documentDirectory + 'SQLite/myDatabaseName.db'
-  );
-  return SQLite.openDatabase('myDatabaseName.db');
-}
-```
+  ```
 
 ### Executing statements outside of a transaction
 
-> Please note that you should use this kind of execution only when it is necessary. For instance, when code is a no-op within transactions (like eg. `PRAGMA foreign_keys = ON;`).
+> **info** You should use this kind of execution only when it is necessary. For instance, when code is a no-op within transactions. For example, `PRAGMA foreign_keys = ON;`.
 
 ```js
 const db = SQLite.openDatabase('dbName', version);

--- a/docs/pages/versions/v45.0.0/sdk/sqlite.mdx
+++ b/docs/pages/versions/v45.0.0/sdk/sqlite.mdx
@@ -7,8 +7,9 @@ packageName: 'expo-sqlite'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import { Terminal } from '~/ui/components/Snippet';
 
-**`expo-sqlite`** gives your app access to a database that can be queried through a [WebSQL](https://www.w3.org/TR/webdatabase/)-like API. The database is persisted across restarts of your app.
+`expo-sqlite` gives your app access to a database that can be queried through a [WebSQL](https://www.w3.org/TR/webdatabase/)-like API. The database is persisted across restarts of your app.
 
 An [example to do list app](https://github.com/expo/examples/tree/master/with-sqlite) is available that uses this module for storage.
 
@@ -18,39 +19,42 @@ An [example to do list app](https://github.com/expo/examples/tree/master/with-sq
 
 ### Importing an existing database
 
-In order to open a new SQLite database using an existing `.db` file you already have, you need to do three things:
+To open a new SQLite database using an existing `.db` file you already have, you need to do three things:
 
-- `expo install expo-file-system expo-asset`
-- create a **metro.config.js** file in the root of your project with the following contents ([curious why? read here](/guides/customizing-metro.mdx#adding-more-file-extensions-to--assetexts)):
+- Install `expo-file-system` and `expo-asset` packages:
 
-```ts
-const { getDefaultConfig } = require('expo/metro-config');
+  <Terminal cmd={['$ expo install expo-file-system expo-asset']} />
 
-const defaultConfig = getDefaultConfig(__dirname);
+- Create a **metro.config.js** file in the root of your project with the following contents ([curious why? read here](/guides/customizing-metro.mdx#adding-more-file-extensions-to--assetexts)):
 
-defaultConfig.resolver.assetExts.push('db');
+  ```ts
+  const { getDefaultConfig } = require('expo/metro-config');
 
-module.exports = defaultConfig;
-```
+  const defaultConfig = getDefaultConfig(__dirname);
+
+  defaultConfig.resolver.assetExts.push('db');
+
+  module.exports = defaultConfig;
+  ```
 
 - Use the following function (or similar) to open your database:
 
-```ts
-async function openDatabase(pathToDatabaseFile: string): Promise<SQLite.WebSQLDatabase> {
-  if (!(await FileSystem.getInfoAsync(FileSystem.documentDirectory + 'SQLite')).exists) {
-    await FileSystem.makeDirectoryAsync(FileSystem.documentDirectory + 'SQLite');
+  ```ts
+  async function openDatabase(pathToDatabaseFile: string): Promise<SQLite.WebSQLDatabase> {
+    if (!(await FileSystem.getInfoAsync(FileSystem.documentDirectory + 'SQLite')).exists) {
+      await FileSystem.makeDirectoryAsync(FileSystem.documentDirectory + 'SQLite');
+    }
+    await FileSystem.downloadAsync(
+      Asset.fromModule(require(pathToDatabaseFile)).uri,
+      FileSystem.documentDirectory + 'SQLite/myDatabaseName.db'
+    );
+    return SQLite.openDatabase('myDatabaseName.db');
   }
-  await FileSystem.downloadAsync(
-    Asset.fromModule(require(pathToDatabaseFile)).uri,
-    FileSystem.documentDirectory + 'SQLite/myDatabaseName.db'
-  );
-  return SQLite.openDatabase('myDatabaseName.db');
-}
-```
+  ```
 
 ### Executing statements outside of a transaction
 
-> Please note that you should use this kind of execution only when it is necessary. For instance, when code is a no-op within transactions (like eg. `PRAGMA foreign_keys = ON;`).
+> **info** You should use this kind of execution only when it is necessary. For instance, when code is a no-op within transactions. For example, `PRAGMA foreign_keys = ON;`.
 
 ```js
 const db = SQLite.openDatabase('dbName', version);

--- a/docs/pages/versions/v45.0.0/sdk/sqlite.mdx
+++ b/docs/pages/versions/v45.0.0/sdk/sqlite.mdx
@@ -21,7 +21,7 @@ An [example to do list app](https://github.com/expo/examples/tree/master/with-sq
 
 To open a new SQLite database using an existing `.db` file you already have, you need to do three things:
 
-- Install `expo-file-system` and `expo-asset` packages:
+- Install `expo-file-system` and `expo-asset` modules:
 
   <Terminal cmd={['$ expo install expo-file-system expo-asset']} />
 
@@ -54,7 +54,7 @@ To open a new SQLite database using an existing `.db` file you already have, you
 
 ### Executing statements outside of a transaction
 
-> **info** You should use this kind of execution only when it is necessary. For instance, when code is a no-op within transactions. For example, `PRAGMA foreign_keys = ON;`.
+> **info** You should use this kind of execution only when it is necessary. For instance, when code is a no-op within transactions. Example: `PRAGMA foreign_keys = ON;`.
 
 ```js
 const db = SQLite.openDatabase('dbName', version);

--- a/docs/pages/versions/v46.0.0/sdk/sqlite.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/sqlite.mdx
@@ -7,8 +7,9 @@ packageName: 'expo-sqlite'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import { Terminal } from '~/ui/components/Snippet';
 
-**`expo-sqlite`** gives your app access to a database that can be queried through a [WebSQL](https://www.w3.org/TR/webdatabase/)-like API. The database is persisted across restarts of your app.
+`expo-sqlite` gives your app access to a database that can be queried through a [WebSQL](https://www.w3.org/TR/webdatabase/)-like API. The database is persisted across restarts of your app.
 
 An [example to do list app](https://github.com/expo/examples/tree/master/with-sqlite) is available that uses this module for storage.
 
@@ -18,35 +19,38 @@ An [example to do list app](https://github.com/expo/examples/tree/master/with-sq
 
 ### Importing an existing database
 
-In order to open a new SQLite database using an existing `.db` file you already have, you need to do three things:
+To open a new SQLite database using an existing `.db` file you already have, you'll need to do three things:
 
-- `expo install expo-file-system expo-asset`
-- create a **metro.config.js** file in the root of your project with the following contents ([curious why? read here](/guides/customizing-metro.mdx#adding-more-file-extensions-to--assetexts)):
+- Install `expo-file-system` and `expo-asset` packages:
 
-```ts
-const { getDefaultConfig } = require('expo/metro-config');
+  <Terminal cmd={['$ npx expo install expo-file-system expo-asset']} />
 
-const defaultConfig = getDefaultConfig(__dirname);
+- Create a **metro.config.js** file at the root of your project with the following contents ([curious why? read here](/guides/customizing-metro.mdx#adding-more-file-extensions-to--assetexts)):
 
-defaultConfig.resolver.assetExts.push('db');
+  ```ts
+  const { getDefaultConfig } = require('expo/metro-config');
 
-module.exports = defaultConfig;
-```
+  const defaultConfig = getDefaultConfig(__dirname);
+
+  defaultConfig.resolver.assetExts.push('db');
+
+  module.exports = defaultConfig;
+  ```
 
 - Use the following function (or similar) to open your database:
 
-```ts
-async function openDatabase(pathToDatabaseFile: string): Promise<SQLite.WebSQLDatabase> {
-  if (!(await FileSystem.getInfoAsync(FileSystem.documentDirectory + 'SQLite')).exists) {
-    await FileSystem.makeDirectoryAsync(FileSystem.documentDirectory + 'SQLite');
+  ```ts
+  async function openDatabase(pathToDatabaseFile: string): Promise<SQLite.WebSQLDatabase> {
+    if (!(await FileSystem.getInfoAsync(FileSystem.documentDirectory + 'SQLite')).exists) {
+      await FileSystem.makeDirectoryAsync(FileSystem.documentDirectory + 'SQLite');
+    }
+    await FileSystem.downloadAsync(
+      Asset.fromModule(require(pathToDatabaseFile)).uri,
+      FileSystem.documentDirectory + 'SQLite/myDatabaseName.db'
+    );
+    return SQLite.openDatabase('myDatabaseName.db');
   }
-  await FileSystem.downloadAsync(
-    Asset.fromModule(require(pathToDatabaseFile)).uri,
-    FileSystem.documentDirectory + 'SQLite/myDatabaseName.db'
-  );
-  return SQLite.openDatabase('myDatabaseName.db');
-}
-```
+  ```
 
 ### Executing statements outside of a transaction
 

--- a/docs/pages/versions/v46.0.0/sdk/sqlite.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/sqlite.mdx
@@ -21,7 +21,7 @@ An [example to do list app](https://github.com/expo/examples/tree/master/with-sq
 
 To open a new SQLite database using an existing `.db` file you already have, you'll need to do three things:
 
-- Install `expo-file-system` and `expo-asset` packages:
+- Install `expo-file-system` and `expo-asset` modules:
 
   <Terminal cmd={['$ npx expo install expo-file-system expo-asset']} />
 
@@ -54,7 +54,7 @@ To open a new SQLite database using an existing `.db` file you already have, you
 
 ### Executing statements outside of a transaction
 
-> **info** You should use this kind of execution only when it is necessary. For instance, when code is a no-op within transactions. For example, `PRAGMA foreign_keys = ON;`.
+> **info** You should use this kind of execution only when it is necessary. For instance, when code is a no-op within transactions. Example: `PRAGMA foreign_keys = ON;`.
 
 ```js
 const db = SQLite.openDatabase('dbName', version);

--- a/docs/pages/versions/v46.0.0/sdk/sqlite.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/sqlite.mdx
@@ -54,7 +54,7 @@ To open a new SQLite database using an existing `.db` file you already have, you
 
 ### Executing statements outside of a transaction
 
-> Please note that you should use this kind of execution only when it is necessary. For instance, when code is a no-op within transactions (like eg. `PRAGMA foreign_keys = ON;`).
+> **info** You should use this kind of execution only when it is necessary. For instance, when code is a no-op within transactions. For example, `PRAGMA foreign_keys = ON;`.
 
 ```js
 const db = SQLite.openDatabase('dbName', version);


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Refs ENG-6502

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR:
- Fixes `npx expo install` for SDK 46 version docs.
- Adds Terminal component to highlight commands
- Update note to use Callout component
- Updates/fixes other verbiage issues for consistency across docs
- Backports relevant changes for SDKs older than 46 for consistency

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
Run docs locally via yarn dev and then open
- http://localhost:3002/versions/unversioned/sdk/sqlite/
- http://localhost:3002/versions/v44.0.0/sdk/sqlite/ for backported changes

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
