### PR TITLE
Update push notification example code for android 13

### DIFF
--- a/docs/pages/push-notifications/overview.mdx
+++ b/docs/pages/push-notifications/overview.mdx
@@ -103,6 +103,14 @@ async function sendPushNotification(expoPushToken) {
 async function registerForPushNotificationsAsync() {
   let token;
   if (Device.isDevice) {
+    if (Platform.OS === 'android') {
+      Notifications.setNotificationChannelAsync('default', {
+        name: 'default',
+        importance: Notifications.AndroidImportance.MAX,
+        vibrationPattern: [0, 250, 250, 250],
+        lightColor: '#FF231F7C',
+      });
+    }
     const { status: existingStatus } = await Notifications.getPermissionsAsync();
     let finalStatus = existingStatus;
     if (existingStatus !== 'granted') {
@@ -119,14 +127,6 @@ async function registerForPushNotificationsAsync() {
     alert('Must use physical device for Push Notifications');
   }
 
-  if (Platform.OS === 'android') {
-    Notifications.setNotificationChannelAsync('default', {
-      name: 'default',
-      importance: Notifications.AndroidImportance.MAX,
-      vibrationPattern: [0, 250, 250, 250],
-      lightColor: '#FF231F7C',
-    });
-  }
 
   return token;
 }


### PR DESCRIPTION
I had to move setting the channel to the beginning to prompt permission dialog for android 13. Otherwise fails with denied status and no prompt to allow/deny.

# Why

The example no longer works if you are running a device with android 13.

# How

Moved the default channel code up above the get/request permissions block.

# Test Plan

This change fixed my app implementation. Kept thinking I didn't have google services setup correctly but it was.