### PR TITLE
[docs][netinfo] Remove Classic build command reference

### DIFF
--- a/docs/pages/versions/unversioned/sdk/netinfo.mdx
+++ b/docs/pages/versions/unversioned/sdk/netinfo.mdx
@@ -7,7 +7,7 @@ packageName: '@react-native-community/netinfo'
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-**`@react-native-community/netinfo`** allows you to get information about connection type and connection quality.
+`@react-native-community/netinfo` allows you to get information about connection type and connection quality.
 
 <PlatformsSection android emulator ios simulator web />
 
@@ -54,7 +54,7 @@ In order to access the `ssid` property (available under `state.details.ssid`), t
 
 #### iOS only
 
-- Add the `com.apple.developer.networking.wifi-info` entitlement to your app.json file under `ios.entitlements`:
+- Add the `com.apple.developer.networking.wifi-info` entitlement to your **app.json** under `ios.entitlements`:
 
 ```json
   "ios": {
@@ -65,7 +65,6 @@ In order to access the `ssid` property (available under `state.details.ssid`), t
 ```
 
 - Check the **Access Wi-Fi Information** box in your app's App Identifier, [which can be found here](https://developer.apple.com/account/resources/identifiers/list)
+- Rebuild your app with `eas build --platform ios` or [`npx expo run:ios`](/workflow/expo-cli/#compiling)
 
-- Rebuild your app with `expo build:ios`
-
-Read the [react-native-netinfo docs](https://github.com/react-native-community/react-native-netinfo#react-native-communitynetinfo) for more information on the API and usage.
+For more information on API and usage, see [react-native-netinfo documentation](https://github.com/react-native-community/react-native-netinfo#react-native-communitynetinfo).

--- a/docs/pages/versions/unversioned/sdk/netinfo.mdx
+++ b/docs/pages/versions/unversioned/sdk/netinfo.mdx
@@ -65,6 +65,6 @@ In order to access the `ssid` property (available under `state.details.ssid`), t
 ```
 
 - Check the **Access Wi-Fi Information** box in your app's App Identifier, [which can be found here](https://developer.apple.com/account/resources/identifiers/list)
-- Rebuild your app with `eas build --platform ios` or [`npx expo run:ios`](/workflow/expo-cli/#compiling)
+- Rebuild your app with [`eas build --platform ios`](/build/setup/#4-run-a-build) or [`npx expo run:ios`](/workflow/expo-cli/#compiling)
 
 For more information on API and usage, see [react-native-netinfo documentation](https://github.com/react-native-community/react-native-netinfo#react-native-communitynetinfo).

--- a/docs/pages/versions/v43.0.0/sdk/netinfo.mdx
+++ b/docs/pages/versions/v43.0.0/sdk/netinfo.mdx
@@ -6,7 +6,7 @@ sourceCodeUrl: 'https://github.com/react-native-community/react-native-netinfo'
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-**`@react-native-community/netinfo`** allows you to get information about connection type and connection quality.
+`@react-native-community/netinfo` allows you to get information about connection type and connection quality.
 
 <PlatformsSection android emulator ios simulator web />
 
@@ -56,7 +56,7 @@ In order to access the `ssid` property (available under `state.details.ssid`), t
 
 #### iOS only
 
-- Add the `com.apple.developer.networking.wifi-info` entitlement to your app.json file under `ios.entitlements`:
+- Add the `com.apple.developer.networking.wifi-info` entitlement to your **app.json** under `ios.entitlements`:
 
 ```json
   "ios": {
@@ -67,7 +67,6 @@ In order to access the `ssid` property (available under `state.details.ssid`), t
 ```
 
 - Check the **Access Wi-Fi Information** box in your app's App Identifier, [which can be found here](https://developer.apple.com/account/resources/identifiers/list)
+- Rebuild your app with `eas build --platform ios` or [`npx expo run:ios`](/workflow/expo-cli/#compiling)
 
-- Rebuild your app with `expo build:ios`
-
-Read the [react-native-netinfo docs](https://github.com/react-native-community/react-native-netinfo#react-native-communitynetinfo) for more information on the API and usage.
+For more information on API and usage, see [react-native-netinfo documentation](https://github.com/react-native-community/react-native-netinfo#react-native-communitynetinfo).

--- a/docs/pages/versions/v43.0.0/sdk/netinfo.mdx
+++ b/docs/pages/versions/v43.0.0/sdk/netinfo.mdx
@@ -67,6 +67,6 @@ In order to access the `ssid` property (available under `state.details.ssid`), t
 ```
 
 - Check the **Access Wi-Fi Information** box in your app's App Identifier, [which can be found here](https://developer.apple.com/account/resources/identifiers/list)
-- Rebuild your app with `eas build --platform ios` or [`npx expo run:ios`](/workflow/expo-cli/#compiling)
+- Rebuild your app with [`eas build --platform ios`](/build/setup/#4-run-a-build) or [`npx expo run:ios`](/workflow/expo-cli/#compiling)
 
 For more information on API and usage, see [react-native-netinfo documentation](https://github.com/react-native-community/react-native-netinfo#react-native-communitynetinfo).

--- a/docs/pages/versions/v44.0.0/sdk/netinfo.mdx
+++ b/docs/pages/versions/v44.0.0/sdk/netinfo.mdx
@@ -6,7 +6,7 @@ sourceCodeUrl: 'https://github.com/react-native-community/react-native-netinfo'
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-**`@react-native-community/netinfo`** allows you to get information about connection type and connection quality.
+`@react-native-community/netinfo` allows you to get information about connection type and connection quality.
 
 <PlatformsSection android emulator ios simulator web />
 
@@ -56,7 +56,7 @@ In order to access the `ssid` property (available under `state.details.ssid`), t
 
 #### iOS only
 
-- Add the `com.apple.developer.networking.wifi-info` entitlement to your app.json file under `ios.entitlements`:
+- Add the `com.apple.developer.networking.wifi-info` entitlement to your **app.json** under `ios.entitlements`:
 
 ```json
   "ios": {
@@ -67,7 +67,6 @@ In order to access the `ssid` property (available under `state.details.ssid`), t
 ```
 
 - Check the **Access Wi-Fi Information** box in your app's App Identifier, [which can be found here](https://developer.apple.com/account/resources/identifiers/list)
+- Rebuild your app with `eas build --platform ios` or [`npx expo run:ios`](/workflow/expo-cli/#compiling)
 
-- Rebuild your app with `expo build:ios`
-
-Read the [react-native-netinfo docs](https://github.com/react-native-community/react-native-netinfo#react-native-communitynetinfo) for more information on the API and usage.
+For more information on API and usage, see [react-native-netinfo documentation](https://github.com/react-native-community/react-native-netinfo#react-native-communitynetinfo).

--- a/docs/pages/versions/v44.0.0/sdk/netinfo.mdx
+++ b/docs/pages/versions/v44.0.0/sdk/netinfo.mdx
@@ -67,6 +67,6 @@ In order to access the `ssid` property (available under `state.details.ssid`), t
 ```
 
 - Check the **Access Wi-Fi Information** box in your app's App Identifier, [which can be found here](https://developer.apple.com/account/resources/identifiers/list)
-- Rebuild your app with `eas build --platform ios` or [`npx expo run:ios`](/workflow/expo-cli/#compiling)
+- Rebuild your app with [`eas build --platform ios`](/build/setup/#4-run-a-build) or [`npx expo run:ios`](/workflow/expo-cli/#compiling)
 
 For more information on API and usage, see [react-native-netinfo documentation](https://github.com/react-native-community/react-native-netinfo#react-native-communitynetinfo).

--- a/docs/pages/versions/v45.0.0/sdk/netinfo.mdx
+++ b/docs/pages/versions/v45.0.0/sdk/netinfo.mdx
@@ -7,7 +7,7 @@ packageName: '@react-native-community/netinfo'
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-**`@react-native-community/netinfo`** allows you to get information about connection type and connection quality.
+`@react-native-community/netinfo` allows you to get information about connection type and connection quality.
 
 <PlatformsSection android emulator ios simulator web />
 
@@ -54,7 +54,7 @@ In order to access the `ssid` property (available under `state.details.ssid`), t
 
 #### iOS only
 
-- Add the `com.apple.developer.networking.wifi-info` entitlement to your app.json file under `ios.entitlements`:
+- Add the `com.apple.developer.networking.wifi-info` entitlement to your **app.json** under `ios.entitlements`:
 
 ```json
   "ios": {
@@ -65,7 +65,6 @@ In order to access the `ssid` property (available under `state.details.ssid`), t
 ```
 
 - Check the **Access Wi-Fi Information** box in your app's App Identifier, [which can be found here](https://developer.apple.com/account/resources/identifiers/list)
+- Rebuild your app with `eas build --platform ios` or [`npx expo run:ios`](/workflow/expo-cli/#compiling)
 
-- Rebuild your app with `expo build:ios`
-
-Read the [react-native-netinfo docs](https://github.com/react-native-community/react-native-netinfo#react-native-communitynetinfo) for more information on the API and usage.
+For more information on API and usage, see [react-native-netinfo documentation](https://github.com/react-native-community/react-native-netinfo#react-native-communitynetinfo).

--- a/docs/pages/versions/v45.0.0/sdk/netinfo.mdx
+++ b/docs/pages/versions/v45.0.0/sdk/netinfo.mdx
@@ -65,6 +65,6 @@ In order to access the `ssid` property (available under `state.details.ssid`), t
 ```
 
 - Check the **Access Wi-Fi Information** box in your app's App Identifier, [which can be found here](https://developer.apple.com/account/resources/identifiers/list)
-- Rebuild your app with `eas build --platform ios` or [`npx expo run:ios`](/workflow/expo-cli/#compiling)
+- Rebuild your app with [`eas build --platform ios`](/build/setup/#4-run-a-build) or [`npx expo run:ios`](/workflow/expo-cli/#compiling)
 
 For more information on API and usage, see [react-native-netinfo documentation](https://github.com/react-native-community/react-native-netinfo#react-native-communitynetinfo).

--- a/docs/pages/versions/v46.0.0/sdk/netinfo.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/netinfo.mdx
@@ -7,7 +7,7 @@ packageName: '@react-native-community/netinfo'
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-**`@react-native-community/netinfo`** allows you to get information about connection type and connection quality.
+`@react-native-community/netinfo` allows you to get information about connection type and connection quality.
 
 <PlatformsSection android emulator ios simulator web />
 
@@ -54,7 +54,7 @@ In order to access the `ssid` property (available under `state.details.ssid`), t
 
 #### iOS only
 
-- Add the `com.apple.developer.networking.wifi-info` entitlement to your app.json file under `ios.entitlements`:
+- Add the `com.apple.developer.networking.wifi-info` entitlement to your **app.json** under `ios.entitlements`:
 
 ```json
   "ios": {
@@ -65,7 +65,6 @@ In order to access the `ssid` property (available under `state.details.ssid`), t
 ```
 
 - Check the **Access Wi-Fi Information** box in your app's App Identifier, [which can be found here](https://developer.apple.com/account/resources/identifiers/list)
+- Rebuild your app with `eas build --platform ios` or [`npx expo run:ios`](/workflow/expo-cli/#compiling)
 
-- Rebuild your app with `expo build:ios`
-
-Read the [react-native-netinfo docs](https://github.com/react-native-community/react-native-netinfo#react-native-communitynetinfo) for more information on the API and usage.
+For more information on API and usage, see [react-native-netinfo documentation](https://github.com/react-native-community/react-native-netinfo#react-native-communitynetinfo).

--- a/docs/pages/versions/v46.0.0/sdk/netinfo.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/netinfo.mdx
@@ -65,6 +65,6 @@ In order to access the `ssid` property (available under `state.details.ssid`), t
 ```
 
 - Check the **Access Wi-Fi Information** box in your app's App Identifier, [which can be found here](https://developer.apple.com/account/resources/identifiers/list)
-- Rebuild your app with `eas build --platform ios` or [`npx expo run:ios`](/workflow/expo-cli/#compiling)
+- Rebuild your app with [`eas build --platform ios`](/build/setup/#4-run-a-build) or [`npx expo run:ios`](/workflow/expo-cli/#compiling)
 
 For more information on API and usage, see [react-native-netinfo documentation](https://github.com/react-native-community/react-native-netinfo#react-native-communitynetinfo).


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Refs ENG-5900

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR:
- removes classic build command reference for iOS and changes it to either use EAS build or the iOS compilation step.
- Updates/fixes other verbiage issues for consistency across docs.
- Backported for SDK 45, 44, 43


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
Run docs locally via yarn dev and then open http://localhost:3002/versions/v46.0.0/sdk/netinfo/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
