### PR TITLE
[expo-updates][Android] Allow native debugging of updates

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Drop `@expo/config-plugins` dependency in favor of peer dependency on `expo`. ([#18595](https://github.com/expo/expo/pull/18595) by [@EvanBacon](https://github.com/EvanBacon))
 - Log various errors with the new Updates logger; add E2E tests for the logger. ([#18810](https://github.com/expo/expo/pull/18810) by [@douglowder](https://github.com/douglowder))
 - [iOS] Flag to enable native debugging of updates. ([#19292](https://github.com/expo/expo/pull/19292) by [@douglowder](https://github.com/douglowder))
+- [Android] Flag to enable native debugging of updates. ([#19441](https://github.com/expo/expo/pull/19441) by [@douglowder](https://github.com/douglowder))
 
 ### ⚠️ Notices
 

--- a/packages/expo-updates/android/build.gradle
+++ b/packages/expo-updates/android/build.gradle
@@ -9,6 +9,15 @@ version = '0.14.3'
 def ex_updates_native_debug_env = System.getenv("EX_UPDATES_NATIVE_DEBUG") ?: "0"
 def ex_updates_native_debug = ex_updates_native_debug_env == "1" ? "true" : "false"
 
+// For native updates debugging, override these properties
+if (findProject(":app")) {
+  def appProjectExt = project(":app").ext
+  if (appProjectExt.has("react") && ex_updates_native_debug) {
+    appProjectExt.react.bundleInDebug = true
+    appProjectExt.react.devDisabledInDebug = true
+  }
+}
+
 apply from: "../scripts/create-manifest-android.gradle"
 
 buildscript {

--- a/packages/expo-updates/android/build.gradle
+++ b/packages/expo-updates/android/build.gradle
@@ -6,6 +6,9 @@ apply plugin: 'maven-publish'
 group = 'host.exp.exponent'
 version = '0.14.3'
 
+def ex_updates_native_debug_env = System.getenv("EX_UPDATES_NATIVE_DEBUG") ?: "0"
+def ex_updates_native_debug = ex_updates_native_debug_env == "1" ? "true" : "false"
+
 apply from: "../scripts/create-manifest-android.gradle"
 
 buildscript {
@@ -80,6 +83,7 @@ android {
     versionName '0.14.3'
     consumerProguardFiles("proguard-rules.pro")
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    buildConfigField("boolean", "EX_UPDATES_NATIVE_DEBUG", ex_updates_native_debug)
     // uncomment below to export the database schema when making changes
     /* javaCompileOptions {
       annotationProcessorOptions {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.kt
@@ -25,19 +25,21 @@ class UpdatesPackage : Package {
   }
 
   override fun createReactNativeHostHandlers(context: Context): List<ReactNativeHostHandler> {
+    val useNativeDebug = BuildConfig.EX_UPDATES_NATIVE_DEBUG;
+    Log.w("expo-updates-package", "EX_UPDATES_NATIVE_DEBUG = $useNativeDebug")
     val handler: ReactNativeHostHandler = object : ReactNativeHostHandler {
       private var mShouldAutoSetup: Boolean? = null
 
       override fun getJSBundleFile(useDeveloperSupport: Boolean): String? {
-        return if (shouldAutoSetup(context) && !useDeveloperSupport) UpdatesController.instance.launchAssetFile else null
+        return if (shouldAutoSetup(context) && (useNativeDebug || !useDeveloperSupport)) UpdatesController.instance.launchAssetFile else null
       }
 
       override fun getBundleAssetName(useDeveloperSupport: Boolean): String? {
-        return if (shouldAutoSetup(context) && !useDeveloperSupport) UpdatesController.instance.bundleAssetName else null
+        return if (shouldAutoSetup(context) && (useNativeDebug || !useDeveloperSupport)) UpdatesController.instance.bundleAssetName else null
       }
 
       override fun onWillCreateReactInstanceManager(useDeveloperSupport: Boolean) {
-        if (shouldAutoSetup(context) && !useDeveloperSupport) {
+        if (shouldAutoSetup(context) && (useNativeDebug || !useDeveloperSupport)) {
           UpdatesController.initialize(context)
         }
       }
@@ -45,7 +47,7 @@ class UpdatesPackage : Package {
       override fun onDidCreateReactInstanceManager(reactInstanceManager: ReactInstanceManager, useDeveloperSupport: Boolean) {
         // WHEN_VERSIONING_REMOVE_FROM_HERE
         // This code path breaks versioning and is not necessary for Expo Go.
-        if (shouldAutoSetup(context) && !useDeveloperSupport) {
+        if (shouldAutoSetup(context) && (useNativeDebug || !useDeveloperSupport)) {
           UpdatesController.instance.onDidCreateReactInstanceManager(reactInstanceManager)
         }
         // WHEN_VERSIONING_REMOVE_TO_HERE

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.kt
@@ -25,7 +25,7 @@ class UpdatesPackage : Package {
   }
 
   override fun createReactNativeHostHandlers(context: Context): List<ReactNativeHostHandler> {
-    val useNativeDebug = BuildConfig.EX_UPDATES_NATIVE_DEBUG;
+    val useNativeDebug = BuildConfig.EX_UPDATES_NATIVE_DEBUG
     Log.w("expo-updates-package", "EX_UPDATES_NATIVE_DEBUG = $useNativeDebug")
     val handler: ReactNativeHostHandler = object : ReactNativeHostHandler {
       private var mShouldAutoSetup: Boolean? = null

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.kt
@@ -26,7 +26,6 @@ class UpdatesPackage : Package {
 
   override fun createReactNativeHostHandlers(context: Context): List<ReactNativeHostHandler> {
     val useNativeDebug = BuildConfig.EX_UPDATES_NATIVE_DEBUG
-    Log.w("expo-updates-package", "EX_UPDATES_NATIVE_DEBUG = $useNativeDebug")
     val handler: ReactNativeHostHandler = object : ReactNativeHostHandler {
       private var mShouldAutoSetup: Boolean? = null
 


### PR DESCRIPTION
# Why

Currently, if you have a project with expo-updates installed, you need to make a release build for expo-updates to be enabled (debug builds behave like normal RN project debug builds). This makes it somewhat difficult to test and debug updates when things aren’t working as expected.

To make this easier, we want to add a build setting on both platforms to enable updates in debug builds. Ideally, each platform should have just a single setting that is very easy to switch. When this setting is turned on, in a debug build (a) everything updates-related should be fully enabled as if in a release build (see UpdatesPackage and ExpoUpdatesReactDelegateHandler), and (b) RN should generate a bundle.
# How

For Android, execute the following steps to create a local debug build like this:

- Set the local environment variable:
```sh 
export EX_UPDATES_NATIVE_DEBUG=1
```
- Modify your app's `AndroidManifest.xml` to select a channel for which this app will receive updates. (In an EAS build, this value is set automatically to the channel for the EAS profile being built.)
```patch
diff --git a/android/app/src/main/AndroidManifest.xml b/android/app/src/main/AndroidManifest.xml
index 143fa2d..36d5af2 100644
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
     <meta-data android:name="expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH" android:value="ALWAYS"/>
     <meta-data android:name="expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS" android:value="0"/>
     <meta-data android:name="expo.modules.updates.EXPO_RUNTIME_VERSION" android:value="1.0.0"/>
+    <meta-data android:name="expo.modules.updates.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY" android:value="{&quot;expo-channel-name&quot;:&quot;previewdebug&quot;}" />
     <activity android:name=".MainActivity" android:label="@string/app_name" android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode" android:launchMode="singleTask" android:windowSoftInputMode="adjustResize" android:theme="@style/Theme.App.SplashScreen" android:exported="true">
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>
```

Then create a debug build of your app:
```sh
cd android
./gradlew :app:installDebug
```
---
You can also create this type of build using EAS, by setting the correct values in the build configuration.  Example:
```json
{
  "cli": {
    "version": ">= 2.1.0"
  },
  "build": {
    "previewdebug": {
      "env": {
        "EX_UPDATES_NATIVE_DEBUG": "1"
      },
      "distribution": "internal",
      "android": {
        "buildType": "apk",
        "gradleCommand": ":app:assembleDebug"
      },
      "channel": "previewdebug"
    },
    "production": {}
  },
  "submit": {
    "production": {}
  }
}
```

# Test Plan

Manually tested against EAS.

I will investigate the possibility of building the updates E2E test app this way so that the debug build flows can be tested fully in CI.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
