### PR TITLE
[autolinking] Automatically use modular headers for pod dependencies

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Automatically use modular headers for pod dependencies when the package has Swift modules to link. ([#19443](https://github.com/expo/expo/pull/19443) by [@tsapeta](https://github.com/tsapeta))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-modules-autolinking/scripts/ios/autolinking_manager.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/autolinking_manager.rb
@@ -42,14 +42,13 @@ module Expo
             end
 
             podspec_dir_path = Pathname.new(pod.podspec_dir).relative_path_from(project_directory).to_path
-            podspec_file_path = File.join(podspec_dir_path, pod.pod_name + ".podspec")
-            podspec = Pod::Specification.from_file(podspec_file_path)
 
             # Ensure that the dependencies of packages with Swift code use modular headers, otherwise
             # `pod install` may fail if there is no `use_modular_headers!` declaration or
             # `:modular_headers => true` is not used for this particular dependency.
             # The latter require adding transitive dependencies to user's Podfile that we'd rather like to avoid.
             if package.has_swift_modules_to_link?
+              podspec = get_podspec_for_pod(pod)
               use_modular_headers_for_dependencies(podspec.all_dependencies)
             end
 
@@ -59,6 +58,7 @@ module Expo
             }.merge(global_flags, package.flags)
 
             if tests_only || include_tests
+              podspec = podspec || get_podspec_for_pod(pod)
               test_specs_names = podspec.test_specs.map { |test_spec|
                 test_spec.name.delete_prefix(podspec.name + "/")
               }
@@ -164,6 +164,11 @@ module Expo
         '--target',
         target_path
       ])
+    end
+
+    private def get_podspec_for_pod(pod)
+      podspec_file_path = File.join(pod.podspec_dir, pod.pod_name + ".podspec")
+      return Pod::Specification.from_file(podspec_file_path)
     end
 
     private def use_modular_headers_for_dependencies(dependencies)

--- a/packages/expo-modules-autolinking/scripts/ios/autolinking_manager.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/autolinking_manager.rb
@@ -174,6 +174,8 @@ module Expo
     private def use_modular_headers_for_dependencies(dependencies)
       dependencies.each { |dependency|
         unless @target_definition.build_pod_as_module?(dependency.name)
+          UI.info "[Expo] ".blue << "Enabling modular headers for pod #{dependency.name.green}"
+
           # This is an equivalent to setting `:modular_headers => true` for the specific dependency.
           @target_definition.set_use_modular_headers_for_pod(dependency.name, true)
         end

--- a/packages/expo-modules-autolinking/scripts/ios/package.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/package.rb
@@ -45,6 +45,10 @@ module Expo
       @debugOnly = json['debugOnly']
     end
 
+    def has_swift_modules_to_link?
+      return !@modules.empty?
+    end
+
   end # class Package
 
 end # module Expo


### PR DESCRIPTION
# Why

Pods containing Swift code and having 3rd-party dependencies not defining modules (not generating modulemaps) cannot be installed without implicitly telling CocoaPods to use modular headers. See the error from `pod install` command 👇 

![Screenshot 2022-10-06 at 22 55 11](https://user-images.githubusercontent.com/1714764/194418744-fe08e9c0-21aa-4ff4-a75a-ba4bc202b300.png)

We'd like to avoid asking users to set modular headers for these particular transitive dependencies or enabling modular headers for all pods.

# How

In Expo Autolinking, automatically set to use modular headers for the dependencies of Expo modules that contain at least one Swift module to link.

# Test Plan

`pod install` no longer fails with this error when I try to install `expo-image` package and thus doesn't require me to change my Podfile. I didn't spot any side effect for compiling.