### PR TITLE
[core] try to fix android instrumented test building error

### DIFF
--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -246,6 +246,7 @@ android {
       excludes.add("META-INF/MANIFEST.MF")
       excludes.add("META-INF/com.android.tools/proguard/coroutines.pro")
       excludes.add("META-INF/proguard/coroutines.pro")
+      excludes.add("**/libc++_shared.so")
     }
   }
 

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -39,12 +39,6 @@ buildscript {
   }
 }
 
-def isAndroidTest = {
-  Gradle gradle = getGradle()
-  String tskReqStr = gradle.getStartParameter().getTaskRequests().toString()
-  return tskReqStr.contains("AndroidTest")
-}.call()
-
 def isExpoModulesCoreTests = {
   Gradle gradle = getGradle()
   String tskReqStr = gradle.getStartParameter().getTaskRequests().toString()
@@ -212,7 +206,6 @@ android {
     // Gradle will add cmake target dependencies into packaging.
     // Theses files are intermediated linking files to build modules-core and should not be in final package.
     def sharedLibraries = [
-      "**/libc++_shared.so",
       "**/libfabricjni.so",
       "**/libfbjni.so",
       "**/libfolly_json.so",
@@ -237,17 +230,11 @@ android {
     // In android (instrumental) tests, we want to package all so files to enable our JSI functionality.
     // Otherwise, those files should be excluded, because will be loaded by the application.
     if (isExpoModulesCoreTests) {
-      excludes = []
-      pickFirsts = sharedLibraries
+      pickFirsts += sharedLibraries
     } else {
-      excludes = sharedLibraries
+      excludes += sharedLibraries
     }
-    if (isExpoModulesCoreTests || isAndroidTest) {
-      excludes.add("META-INF/MANIFEST.MF")
-      excludes.add("META-INF/com.android.tools/proguard/coroutines.pro")
-      excludes.add("META-INF/proguard/coroutines.pro")
-      excludes.add("**/libc++_shared.so")
-    }
+    excludes.add("**/libc++_shared.so")
   }
 
   configurations {


### PR DESCRIPTION
# Why

multiple libc++_shared.so build errors from android instrumented test: https://github.com/expo/expo/actions/runs/3202259013/jobs/5231059790

# How

- always exclude libc++_shared.so from packaging.
- this pr also removes the previous change from #19254, we don't have to exclude META-INF files. [they are excluded by default](https://android.googlesource.com/platform/tools/base/+/mirror-goog-studio-main/build-system/gradle-core/src/main/java/com/android/build/gradle/internal/packaging/PackagingOptionsUtils.kt#20). the reason we need to do it because the `excludes = []` reset all list. replace the statement by `excludes += [...]` is better than this.

# Test Plan

- android instrumented test ci passed: https://github.com/expo/expo/actions/runs/3203065701/jobs/5232723291
- all ci passed (updates e2e seems broken on main)
- check regression from #19254 by running `yarn e2e` locally in expo-dev-client

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
