### PR TITLE
[docs] Update testing-with-jest

### DIFF
--- a/docs/pages/guides/testing-with-jest.mdx
+++ b/docs/pages/guides/testing-with-jest.mdx
@@ -26,17 +26,6 @@ Then, we need to add/update **package.json** to include:
 }
 ```
 
-Now let's add `react-test-renderer` to our project. Pick a version that is compatible with the React version used by your project. For example, if you use React 17.x then you should install `react-test-renderer@17`:
-
-<Terminal
-  cmd={[
-    '# Using yarn',
-    '$ yarn add react-test-renderer@17 --dev',
-    '# Using npm',
-    '$ npm i react-test-renderer@17 --save-dev',
-  ]}
-/>
-
 That's it! Now we can start writing Jest tests!
 
 > **Note**: [react-native-testing-library](https://github.com/callstack/react-native-testing-library) is a library built on top of react-test-renderer that could be helpful in your workflow, but we won't cover it in this guide.


### PR DESCRIPTION
`react-test-renderer` is now a dependency of `jest-expo` and doesn't need a separate install.

# Why

Trying to install react-test-renderer crashes. When I ran tests, I realised it wasn't necessary anymore.

# How

Just a documentation fix.

# Test Plan

Run the tutorial without this step.

# Checklist



- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
