### PR TITLE
[docs] DiffBlock: fix dark mode styles issue

### DIFF
--- a/docs/global-styles/extras.ts
+++ b/docs/global-styles/extras.ts
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { darkTheme, theme, typography } from '@expo/styleguide';
+import { darkTheme, spacing, theme, typography } from '@expo/styleguide';
 
 export const globalExtras = css`
   html {
@@ -17,15 +17,15 @@ export const globalExtras = css`
     background-color: ${theme.highlight.accent};
     color: ${theme.text.default};
   }
-  
+
   ::-webkit-scrollbar {
     width: 6px;
     height: 6px;
   }
 
   ::-webkit-scrollbar-track {
-    backgroundColor: transparent,
-    cursor: pointer,
+    background-color: transparent;
+    cursor: pointer;
   }
 
   ::-webkit-scrollbar-thumb {
@@ -36,12 +36,12 @@ export const globalExtras = css`
   ::-webkit-scrollbar-thumb:hover {
     background: ${theme.background.quaternary};
   }
-  
-  html[data-expo-theme="light"] div[class*="SnippetContent"] {
+
+  html[data-expo-theme='light'] div[class*='SnippetContent'] {
     ::-webkit-scrollbar-thumb {
       background: ${darkTheme.background.quaternary};
     }
-    
+
     ::-webkit-scrollbar-thumb:hover {
       background: ${darkTheme.icon.secondary};
     }
@@ -75,10 +75,77 @@ export const globalExtras = css`
     text-decoration: line-through;
   }
 
-  // TODO: investigate why some style is forcing nested ordered lists to have
-  // 1rem bottom margin!
+  // TODO: investigate why some style is forcing nested ordered lists to have 1rem bottom margin!
+
   ul ul,
   ol ul {
     margin-bottom: 0 !important;
+  }
+
+  // Global styles for react-diff-view
+
+  .diff-unified {
+    ${typography.fontSizes[13]};
+    font-family: ${typography.fontStacks.mono};
+    border-collapse: collapse;
+    white-space: pre-wrap;
+    width: 100%;
+
+    td,
+    th {
+      border-bottom: none;
+    }
+  }
+
+  .diff-line:first-of-type {
+    height: 29px;
+
+    td {
+      padding-top: ${spacing[2]}px;
+    }
+  }
+
+  .diff-line:last-of-type {
+    height: 29px;
+  }
+
+  .diff-gutter-col {
+    width: ${spacing[10]}px;
+    background-color: ${theme.background.tertiary};
+  }
+
+  .diff-gutter {
+    ${typography.fontSizes[12]};
+    text-align: right;
+    padding: 0 ${spacing[2]}px;
+  }
+
+  .diff-gutter-normal {
+    color: ${theme.icon.secondary};
+  }
+
+  .diff-code {
+    word-break: break-word;
+    padding-left: ${spacing[4]}px;
+  }
+
+  .diff-code-insert {
+    background-color: ${theme.palette.green['000']};
+    color: ${theme.text.success};
+  }
+
+  .diff-gutter-insert {
+    background-color: ${theme.palette.green['100']};
+    color: ${theme.text.success};
+  }
+
+  .diff-code-delete {
+    background-color: ${theme.palette.red['000']};
+    color: ${theme.text.error};
+  }
+
+  .diff-gutter-delete {
+    background-color: ${theme.palette.red['100']};
+    color: ${theme.text.error};
   }
 `;

--- a/docs/pages/_app.tsx
+++ b/docs/pages/_app.tsx
@@ -10,7 +10,6 @@ import { useNProgress } from '~/common/use-nprogress';
 import DocumentationElements from '~/components/page-higher-order/DocumentationElements';
 import { AnalyticsProvider } from '~/providers/Analytics';
 
-import 'react-diff-view/style/index.css';
 import '@expo/styleguide/dist/expo-theme.css';
 import 'tippy.js/dist/tippy.css';
 

--- a/docs/ui/components/Snippet/blocks/DiffBlock.tsx
+++ b/docs/ui/components/Snippet/blocks/DiffBlock.tsx
@@ -1,5 +1,4 @@
 import { css } from '@emotion/react';
-import { spacing, theme, typography } from '@expo/styleguide';
 import React, { useEffect, useState, PropsWithChildren } from 'react';
 import { parseDiff, Diff, Hunk } from 'react-diff-view';
 

--- a/docs/ui/components/Snippet/blocks/DiffBlock.tsx
+++ b/docs/ui/components/Snippet/blocks/DiffBlock.tsx
@@ -49,7 +49,7 @@ export const DiffBlock = ({ source, raw }: Props) => {
     hunks,
     newPath,
   }: RenderLine) => (
-    <Snippet css={diffContainerStyles} key={oldRevision + '-' + newRevision}>
+    <Snippet key={oldRevision + '-' + newRevision}>
       <SnippetHeader title={newPath} />
       <SnippetContent skipPadding hideOverflow>
         <Diff viewType="unified" diffType={type} hunks={hunks}>
@@ -63,68 +63,5 @@ export const DiffBlock = ({ source, raw }: Props) => {
 };
 
 const diffContainerStyles = css`
-  table {
-    ${typography.fontSizes[14]}
-  }
 
-  td,
-  th {
-    border-bottom: none;
-  }
-
-  .diff-line:first-of-type {
-    height: 29px;
-
-    td {
-      padding-top: ${spacing[2]}px;
-    }
-  }
-
-  .diff-line:last-of-type {
-    height: 29px;
-  }
-
-  .diff-gutter-col {
-    width: ${spacing[10]}px;
-    background: ${theme.background.tertiary};
-  }
-
-  .diff-gutter-normal {
-    color: ${theme.icon.secondary};
-  }
-
-  .diff-code {
-    word-break: break-word;
-    padding-left: ${spacing[4]}px;
-  }
-
-  .diff-gutter-insert,
-  .diff-code-insert {
-    background: ${theme.palette.green['000']};
-    color: ${theme.text.success};
-  }
-
-  .diff-gutter-insert {
-    background: ${theme.background.success};
-  }
-
-  .diff-gutter-delete,
-  .diff-code-delete {
-    background: ${theme.palette.red['000']};
-    color: ${theme.text.error};
-  }
-
-  .diff-gutter-delete {
-    background: ${theme.background.error};
-  }
-
-  [data-expo-theme='dark'] & {
-    .diff-gutter-insert {
-      background: ${theme.palette.green['100']};
-    }
-
-    .diff-gutter-delete {
-      background: ${theme.palette.red['100']};
-    }
-  }
 `;

--- a/docs/ui/components/Snippet/blocks/DiffBlock.tsx
+++ b/docs/ui/components/Snippet/blocks/DiffBlock.tsx
@@ -1,4 +1,3 @@
-import { css } from '@emotion/react';
 import React, { useEffect, useState, PropsWithChildren } from 'react';
 import { parseDiff, Diff, Hunk } from 'react-diff-view';
 
@@ -60,7 +59,3 @@ export const DiffBlock = ({ source, raw }: Props) => {
 
   return <>{diff.map(renderFile)}</>;
 };
-
-const diffContainerStyles = css`
-
-`;


### PR DESCRIPTION
# Why

Fixes ENG-6613

# How

This PR fixes the `DiffBlock` line highlight issue in dark mode. The issue was not present when running app in DEV mode.

At the beginning I thought that the default styles provided by package are messing something up, then I have tried to atomize and move our custom styles around, but it did not help. At the end it looks like this is an Emotion bug, since the whole block of styles is missing only in one usecase (we have two modes, which share the same styles - inline and file loaded):

<img width="1106" alt="Screenshot 2022-10-07 at 14 37 35" src="https://user-images.githubusercontent.com/719641/194558773-fe7af1e1-d69f-4327-b8dc-c8c3eaad1fb3.png">

During the debug process I have streamlined the styles, removed the default styles provided by package (which also helped me to discover that we were using incorrect font for those blocks) and moved the `DiffBlock` related styles back to global file.

# Test Plan

`yarn export && yarn export-server`

# Preview

<img width="1128" alt="Screenshot 2022-10-07 at 14 58 55" src="https://user-images.githubusercontent.com/719641/194559463-337dbbb1-f140-4bb8-9922-60f2d72b1c72.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
