### PR TITLE
[Docs] Added padding top and bottom to center the content in the version selector.

### DIFF
--- a/docs/ui/components/Sidebar/VersionSelector.tsx
+++ b/docs/ui/components/Sidebar/VersionSelector.tsx
@@ -26,7 +26,7 @@ const STYLES_SELECT = css({
   color: theme.text.default,
   margin: 0,
   marginTop: spacing[1],
-  padding: `0 ${spacing[3]}px`,
+  padding: `${spacing[2]}px ${spacing[3]}px`,
   minHeight: 40,
   borderRadius: borderRadius.medium,
   marginBottom: spacing[4],


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The content inside the version selector was not centered properly on the Y axis.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Added padding of 2px to the top and bottom of the select component.

Old:
# Test Plan
<img width="274" alt="Screenshot 2022-10-07 at 20 48 46" src="https://user-images.githubusercontent.com/24722640/194594686-800e1897-45a5-4321-b2cd-2b83393a0a39.png">

New:
<img width="274" alt="Screenshot 2022-10-07 at 21 15 37" src="https://user-images.githubusercontent.com/24722640/194594712-da76e143-a065-4b12-a95d-b6810a3fcb55.png">



<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
