### PR TITLE
[apps][ncl] Fix owner field

### DIFF
--- a/apps/native-component-list/app.json
+++ b/apps/native-component-list/app.json
@@ -3,7 +3,7 @@
     "name": "Expo APIs",
     "description": "This demonstrates a bunch of the native components that you can use in React Native core and Expo.",
     "slug": "native-component-list",
-    "owner": "community",
+    "owner": "expo",
     "sdkVersion": "UNVERSIONED",
     "version": "UNVERSIONED",
     "githubUrl": "https://github.com/expo/native-component-list",


### PR DESCRIPTION
# Why

The CI job to publish this to EAS is failing due to the mismatch between the owner of the projectId and the owner field. This fixes the owner field.

# How

Update owner field to correct value.

# Test Plan

Wait for CI.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
