### PR TITLE
Fix default start and end points in LinearGradient on Android

### DIFF
--- a/packages/expo-linear-gradient/CHANGELOG.md
+++ b/packages/expo-linear-gradient/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix default start and end points on Android.
+
 ### 💡 Others
 
 ## 12.0.0-beta.1 — 2022-10-06

--- a/packages/expo-linear-gradient/CHANGELOG.md
+++ b/packages/expo-linear-gradient/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix default start and end points on Android.
+- Fix default start and end points on Android. ([#19460](https://github.com/expo/expo/pull/19460) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-linear-gradient/android/src/main/java/expo/modules/lineargradient/LinearGradientView.java
+++ b/packages/expo-linear-gradient/android/src/main/java/expo/modules/lineargradient/LinearGradientView.java
@@ -16,8 +16,8 @@ public class LinearGradientView extends View {
   private RectF mTempRectForBorderRadius;
 
   private float[] mLocations;
-  private float[] mStartPos = {0, 0};
-  private float[] mEndPos = {0, 1};
+  private float[] mStartPos = {0.5F, 0};
+  private float[] mEndPos = {0.5F, 1};
   private int[] mColors;
   private int[] mSize = {0, 0};
   private float[] mBorderRadii = {0, 0, 0, 0, 0, 0, 0, 0};


### PR DESCRIPTION
# Why

In LinearGradient, `start` prop should default to `{ x: 0.5, y: 0 }` and `end` should default to `{ x: 0.5, y: 1 }`.
That's how it [behaves on iOS](https://github.com/expo/expo/blob/9d37297aa41a9aa04861241fcdb8d222c77be118/packages/expo-linear-gradient/ios/LinearGradientLayer.swift#L6-L7) and how the [documentation says](https://docs.expo.dev/versions/v46.0.0/sdk/linear-gradient/#start).

We actually provide default values here 👇  https://github.com/expo/expo/blob/9d37297aa41a9aa04861241fcdb8d222c77be118/packages/expo-linear-gradient/android/src/main/java/expo/modules/lineargradient/LinearGradientModule.kt#L26-L32
However, this works only when `x` or `y` is not provided and these setters are called.
If `start` and `end` props are not passed at all, these setters are not getting called and so the gradient starts from `{ x: 0, y: 0 }` and ends in `{ x: 0, y: 1 }`, which results in a diagonal gradient (unexpected).

# How

Changed the initial values used by `LinearGradientView` to the correct default values.

# Test Plan

Tested in fabric-tester example where we don't provide the start point. 
