### PR TITLE
[docs] Change broken link

### DIFF
--- a/docs/pages/versions/unversioned/sdk/webview.mdx
+++ b/docs/pages/versions/unversioned/sdk/webview.mdx
@@ -18,7 +18,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 ## Usage
 
-You should refer to the [react-native-webview docs](https://github.com/react-native-community/react-native-webview/blob/master/docs/Guide.mdx#react-native-webview-guide) for more information on the API and its usage. But the following example (courtesy of that repo) is a quick way to get up and running!
+You should refer to the [react-native-webview docs](https://github.com/react-native-webview/react-native-webview/blob/HEAD/docs/Guide.md#react-native-webview-guide) for more information on the API and its usage. But the following example (courtesy of that repo) is a quick way to get up and running!
 
 <SnackInline label="Basic Webview usage" dependencies={["react-native-webview", "expo-constants"]}>
 

--- a/docs/pages/versions/unversioned/sdk/webview.mdx
+++ b/docs/pages/versions/unversioned/sdk/webview.mdx
@@ -18,7 +18,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 ## Usage
 
-You should refer to the [react-native-webview docs](https://github.com/react-native-webview/react-native-webview/blob/HEAD/docs/Guide.md#react-native-webview-guide) for more information on the API and its usage. But the following example (courtesy of that repo) is a quick way to get up and running!
+You should refer to the [react-native-webview docs](https://github.com/react-native-webview/react-native-webview/blob/master/docs/Guide.md#react-native-webview-guide) for more information on the API and its usage. But the following example (courtesy of that repo) is a quick way to get up and running!
 
 <SnackInline label="Basic Webview usage" dependencies={["react-native-webview", "expo-constants"]}>
 


### PR DESCRIPTION
There was a broken link in the documentation, therefore, I need to change the link so that other developers don't fall for that :)


- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
