### PR TITLE
[docs][get-started] Match list item styling for consistency

### DIFF
--- a/docs/pages/get-started/installation.mdx
+++ b/docs/pages/get-started/installation.mdx
@@ -18,7 +18,7 @@ To use Expo CLI, you need to have the following tools installed on your develope
 
 - [Node.js LTS release](https://nodejs.org/en/)
 - [Git](https://git-scm.com)
-- [Watchman](https://facebook.github.io/watchman/docs/install#buildinstall), required only for macOS or Linux users
+- [Watchman](https://facebook.github.io/watchman/docs/install#buildinstall) required only for macOS or Linux users
 
 > Only Node.js LTS releases (even-numbered) are recommended. As Node.js [officially states](https://nodejs.org/en/about/releases/), "Production applications should only use Active LTS or Maintenance LTS releases."
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fixes ENG-6451

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR removes extra `,` to match the list item writing style for consistency.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs via `yarn dev` and then visit http://http://localhost:3002/get-started/installation/#requirements

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
