### PR TITLE
feat(cli): sign simulator builds

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🎉 New features
 
+- Added prompt for signing simulator builds that use entitlements that work on simulator builds like associated domains.
 - Added middleware for creating files. ([#19231](https://github.com/expo/expo/pull/19231) by [@EvanBacon](https://github.com/EvanBacon))
 - Enable `require.context` by default. ([#19257](https://github.com/expo/expo/pull/19257) by [@EvanBacon](https://github.com/EvanBacon))
 - Handle all development session errors. ([#18499](https://github.com/expo/expo/pull/18499) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🎉 New features
 
-- Added prompt for signing simulator builds that use entitlements that work on simulator builds like associated domains.
+- Added prompt for signing simulator builds that use entitlements that work on simulator builds like associated domains. ([#19505](https://github.com/expo/expo/pull/19505) by [@EvanBacon](https://github.com/EvanBacon))
 - Added middleware for creating files. ([#19231](https://github.com/expo/expo/pull/19231) by [@EvanBacon](https://github.com/EvanBacon))
 - Enable `require.context` by default. ([#19257](https://github.com/expo/expo/pull/19257) by [@EvanBacon](https://github.com/EvanBacon))
 - Handle all development session errors. ([#18499](https://github.com/expo/expo/pull/18499) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/src/run/ios/XcodeBuild.ts
+++ b/packages/@expo/cli/src/run/ios/XcodeBuild.ts
@@ -11,7 +11,10 @@ import { env } from '../../utils/env';
 import { AbortCommandError, CommandError } from '../../utils/errors';
 import { getUserTerminal } from '../../utils/terminal';
 import { BuildProps, ProjectInfo } from './XcodeBuild.types';
-import { ensureDeviceIsCodeSignedForDeploymentAsync } from './codeSigning/configureCodeSigning';
+import {
+  ensureDeviceIsCodeSignedForDeploymentAsync,
+  simulatorBuildRequiresCodeSigning,
+} from './codeSigning/configureCodeSigning';
 
 export function logPrettyItem(message: string) {
   Log.log(chalk`{whiteBright \u203A} ${message}`);
@@ -140,7 +143,7 @@ export async function getXcodeBuildArgsAsync(
     `id=${props.device.udid}`,
   ];
 
-  if (!props.isSimulator) {
+  if (!props.isSimulator || simulatorBuildRequiresCodeSigning(props.projectRoot)) {
     const developmentTeamId = await ensureDeviceIsCodeSignedForDeploymentAsync(props.projectRoot);
     if (developmentTeamId) {
       args.push(

--- a/packages/@expo/cli/src/run/ios/XcodeBuild.ts
+++ b/packages/@expo/cli/src/run/ios/XcodeBuild.ts
@@ -11,11 +11,8 @@ import { env } from '../../utils/env';
 import { AbortCommandError, CommandError } from '../../utils/errors';
 import { getUserTerminal } from '../../utils/terminal';
 import { BuildProps, ProjectInfo } from './XcodeBuild.types';
-import {
-  ensureDeviceIsCodeSignedForDeploymentAsync,
-  simulatorBuildRequiresCodeSigning,
-} from './codeSigning/configureCodeSigning';
-
+import { ensureDeviceIsCodeSignedForDeploymentAsync } from './codeSigning/configureCodeSigning';
+import { simulatorBuildRequiresCodeSigning } from './codeSigning/simulatorCodeSigning';
 export function logPrettyItem(message: string) {
   Log.log(chalk`{whiteBright \u203A} ${message}`);
 }

--- a/packages/@expo/cli/src/run/ios/codeSigning/__tests__/simulatorCodeSigning.test.ts
+++ b/packages/@expo/cli/src/run/ios/codeSigning/__tests__/simulatorCodeSigning.test.ts
@@ -1,0 +1,52 @@
+import { IOSConfig } from '@expo/config-plugins';
+import plist from '@expo/plist';
+import { vol } from 'memfs';
+
+import { asMock } from '../../../../__tests__/asMock';
+import { simulatorBuildRequiresCodeSigning } from '../simulatorCodeSigning';
+
+jest.mock('fs');
+
+jest.mock('@expo/config-plugins', () => ({
+  IOSConfig: {
+    Entitlements: {
+      getEntitlementsPath: jest.fn(),
+    },
+  },
+}));
+
+describe(simulatorBuildRequiresCodeSigning, () => {
+  const projectRoot = '/';
+  afterEach(() => vol.reset());
+
+  it(`returns false if the entitlements file cannot be found`, () => {
+    asMock(IOSConfig.Entitlements.getEntitlementsPath).mockReturnValue(null);
+    expect(simulatorBuildRequiresCodeSigning(projectRoot)).toBe(false);
+  });
+  it(`returns false if the entitlements file contains values which don't need to be signed`, () => {
+    vol.fromJSON(
+      {
+        'entitlements.xml': plist.build({
+          'aps-environment': 'development',
+        }),
+      },
+      projectRoot
+    );
+
+    asMock(IOSConfig.Entitlements.getEntitlementsPath).mockReturnValue('/entitlements.xml');
+    expect(simulatorBuildRequiresCodeSigning(projectRoot)).toBe(false);
+  });
+  it(`returns true if the entitlements file contains values which require signing`, () => {
+    vol.fromJSON(
+      {
+        'entitlements.xml': plist.build({
+          'com.apple.developer.associated-domains': ['applinks:example.com'],
+        }),
+      },
+      projectRoot
+    );
+
+    asMock(IOSConfig.Entitlements.getEntitlementsPath).mockReturnValue('/entitlements.xml');
+    expect(simulatorBuildRequiresCodeSigning(projectRoot)).toBe(true);
+  });
+});

--- a/packages/@expo/cli/src/run/ios/codeSigning/configureCodeSigning.ts
+++ b/packages/@expo/cli/src/run/ios/codeSigning/configureCodeSigning.ts
@@ -1,43 +1,9 @@
-import { getEntitlementsPath } from '@expo/config-plugins/build/ios/Entitlements';
-import plist from '@expo/plist';
 import chalk from 'chalk';
-import fs from 'fs';
 
 import * as Log from '../../../log';
-import { resolveCertificateSigningIdentityAsync } from './resolveCertificateSigningIdentity';
 import * as Security from './Security';
+import { resolveCertificateSigningIdentityAsync } from './resolveCertificateSigningIdentity';
 import { getCodeSigningInfoForPbxproj, setAutoCodeSigningInfoForPbxproj } from './xcodeCodeSigning';
-
-// These are entitlements that work on a simulator
-// but still require the project to have development code signing setup.
-// There may be more, but this is fine for now.
-const ENTITLEMENTS_THAT_REQUIRE_CODE_SIGNING = [
-  'com.apple.developer.associated-domains',
-  'com.apple.developer.applesignin',
-  'com.apple.developer.icloud-container-identifiers',
-  'com.apple.developer.icloud-services',
-  'com.apple.developer.ubiquity-kvstore-identifier',
-  'com.apple.developer.ubiquity-container-identifiers',
-];
-
-function getEntitlements(projectRoot: string) {
-  const entitlementsPath = getEntitlementsPath(projectRoot);
-  if (!entitlementsPath || !fs.existsSync(entitlementsPath)) {
-    return null;
-  }
-
-  const entitlementsContents = fs.readFileSync(entitlementsPath, 'utf8');
-  const entitlements = plist.parse(entitlementsContents);
-  return entitlements;
-}
-
-export function simulatorBuildRequiresCodeSigning(projectRoot: string): boolean {
-  const entitlements = getEntitlements(projectRoot);
-  if (!entitlements) {
-    return false;
-  }
-  return ENTITLEMENTS_THAT_REQUIRE_CODE_SIGNING.some((entitlement) => entitlement in entitlements);
-}
 
 export async function ensureDeviceIsCodeSignedForDeploymentAsync(
   projectRoot: string

--- a/packages/@expo/cli/src/run/ios/codeSigning/configureCodeSigning.ts
+++ b/packages/@expo/cli/src/run/ios/codeSigning/configureCodeSigning.ts
@@ -1,9 +1,43 @@
+import { getEntitlementsPath } from '@expo/config-plugins/build/ios/Entitlements';
+import plist from '@expo/plist';
 import chalk from 'chalk';
+import fs from 'fs';
 
 import * as Log from '../../../log';
-import * as Security from './Security';
 import { resolveCertificateSigningIdentityAsync } from './resolveCertificateSigningIdentity';
+import * as Security from './Security';
 import { getCodeSigningInfoForPbxproj, setAutoCodeSigningInfoForPbxproj } from './xcodeCodeSigning';
+
+// These are entitlements that work on a simulator
+// but still require the project to have development code signing setup.
+// There may be more, but this is fine for now.
+const ENTITLEMENTS_THAT_REQUIRE_CODE_SIGNING = [
+  'com.apple.developer.associated-domains',
+  'com.apple.developer.applesignin',
+  'com.apple.developer.icloud-container-identifiers',
+  'com.apple.developer.icloud-services',
+  'com.apple.developer.ubiquity-kvstore-identifier',
+  'com.apple.developer.ubiquity-container-identifiers',
+];
+
+function getEntitlements(projectRoot: string) {
+  const entitlementsPath = getEntitlementsPath(projectRoot);
+  if (!entitlementsPath || !fs.existsSync(entitlementsPath)) {
+    return null;
+  }
+
+  const entitlementsContents = fs.readFileSync(entitlementsPath, 'utf8');
+  const entitlements = plist.parse(entitlementsContents);
+  return entitlements;
+}
+
+export function simulatorBuildRequiresCodeSigning(projectRoot: string): boolean {
+  const entitlements = getEntitlements(projectRoot);
+  if (!entitlements) {
+    return false;
+  }
+  return ENTITLEMENTS_THAT_REQUIRE_CODE_SIGNING.some((entitlement) => entitlement in entitlements);
+}
 
 export async function ensureDeviceIsCodeSignedForDeploymentAsync(
   projectRoot: string

--- a/packages/@expo/cli/src/run/ios/codeSigning/simulatorCodeSigning.ts
+++ b/packages/@expo/cli/src/run/ios/codeSigning/simulatorCodeSigning.ts
@@ -1,0 +1,38 @@
+import { IOSConfig } from '@expo/config-plugins';
+import plist from '@expo/plist';
+import fs from 'fs';
+
+const debug = require('debug')('expo:customize:templates');
+
+// NOTE(EvanBacon): These are entitlements that work in a simulator
+// but still require the project to have development code signing setup.
+// There may be more, but this is fine for now.
+const ENTITLEMENTS_THAT_REQUIRE_CODE_SIGNING = [
+  'com.apple.developer.associated-domains',
+  'com.apple.developer.applesignin',
+];
+
+function getEntitlements(projectRoot: string): Record<string, any> | null {
+  try {
+    const entitlementsPath = IOSConfig.Entitlements.getEntitlementsPath(projectRoot);
+    if (!entitlementsPath || !fs.existsSync(entitlementsPath)) {
+      return null;
+    }
+
+    const entitlementsContents = fs.readFileSync(entitlementsPath, 'utf8');
+    const entitlements = plist.parse(entitlementsContents);
+    return entitlements;
+  } catch (error) {
+    debug('Failed to read entitlements', error);
+  }
+  return null;
+}
+
+/** @returns true if the simulator build should be code signed for development. */
+export function simulatorBuildRequiresCodeSigning(projectRoot: string): boolean {
+  const entitlements = getEntitlements(projectRoot);
+  if (!entitlements) {
+    return false;
+  }
+  return ENTITLEMENTS_THAT_REQUIRE_CODE_SIGNING.some((entitlement) => entitlement in entitlements);
+}

--- a/packages/@expo/cli/src/run/ios/codeSigning/simulatorCodeSigning.ts
+++ b/packages/@expo/cli/src/run/ios/codeSigning/simulatorCodeSigning.ts
@@ -2,7 +2,7 @@ import { IOSConfig } from '@expo/config-plugins';
 import plist from '@expo/plist';
 import fs from 'fs';
 
-const debug = require('debug')('expo:customize:templates');
+const debug = require('debug')('expo:run:ios:codeSigning:simulator');
 
 // NOTE(EvanBacon): These are entitlements that work in a simulator
 // but still require the project to have development code signing setup.


### PR DESCRIPTION
# Why

- when doing `npx expo run:ios` you need to have signing setup for the entitlements that work in the simulator. This makes it a bit easier to setup and test associated domains & universal links (part of Expo Router).

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

- Simulator builds will parse the entitlements file and prompt the user to sign the build if it's using known entitlements.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- Needs unit tests
- `npx expo run:ios` on a project with associated domains → you'll be prompted to sign the build.
- `npx expo run:ios` on a project with no entitlements → you won't be prompted to sign the build.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
