### PR TITLE
[bare-expo] Fix Flipper crash in release mode

### DIFF
--- a/apps/bare-expo/android/app/src/main/java/dev/expo/payments/MainApplication.java
+++ b/apps/bare-expo/android/app/src/main/java/dev/expo/payments/MainApplication.java
@@ -61,7 +61,9 @@ public class MainApplication extends Application implements ReactApplication {
     // If you opted-in for the New Architecture, we enable the TurboModule system
     ReactFeatureFlags.useTurboModules = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED;
     SoLoader.init(this, /* native exopackage */ false);
-    ReactNativeFlipper.initializeFlipper(this);
+    if (BuildConfig.DEBUG) {
+      ReactNativeFlipper.initializeFlipper(this);
+    }
     if (!USE_DEV_CLIENT) {
       DevLauncherPackageDelegate.enableAutoSetup = false;
       DevMenuPackageDelegate.enableAutoSetup = false;


### PR DESCRIPTION
# Why

Running `ReactNativeFlipper.initializeFlipper` in release mode causes the app to crash.

# How

Only call `ReactNativeFlipper.initializeFlipper` in debug

# Test Plan

`./gradlew installRelease` from `apps/bare-expo/android`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
