### PR TITLE
[facedetector][android] Try to fix `Invalid image data size`

### DIFF
--- a/packages/expo-face-detector/android/src/main/java/expo/modules/facedetector/ExpoFaceDetector.kt
+++ b/packages/expo-face-detector/android/src/main/java/expo/modules/facedetector/ExpoFaceDetector.kt
@@ -90,6 +90,10 @@ class ExpoFaceDetector(private val context: Context) : FaceDetectorInterface {
     error: FaceDetectionError,
     skipped: FaceDetectionSkipped
   ) {
+    if (imageData.isEmpty() || width <= 0 || height <= 0) {
+      skipped.onSkipped("Skipped frame due to invalid data.")
+      return
+    }
     if (faceDetector == null) {
       createFaceDetector()
     }


### PR DESCRIPTION
# Why

Tries to fix https://github.com/expo/expo/issues/15551.

# How

I've added some checks to be extra sure that the image data is valid. If not, we just skip the frame. 
However, I wasn't able to reproduce this problem. So I'm not sure if this fix will be good enough. 

# Test Plan

- none 😢 