### PR TITLE
[core] Rename `callback` to `EventDispatcher`

### DIFF
--- a/packages/expo-av/android/src/main/java/expo/modules/av/video/VideoViewWrapper.kt
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/video/VideoViewWrapper.kt
@@ -5,7 +5,7 @@ import android.content.Context
 import android.os.Bundle
 import android.widget.FrameLayout
 import expo.modules.kotlin.AppContext
-import expo.modules.kotlin.callbacks.callback
+import expo.modules.kotlin.viewevent.Event
 
 /**
  * We need the wrapper to be able to remove the view from the React-managed tree
@@ -42,12 +42,12 @@ class VideoViewWrapper(context: Context, appContext: AppContext) : FrameLayout(c
 
   //region view callbacks
 
-  val onStatusUpdate by callback<Bundle>()
-  val onLoadStart by callback<Unit>()
-  val onLoad by callback<Bundle>()
-  val onError by callback<Bundle>()
-  val onReadyForDisplay by callback<Bundle>()
-  val onFullscreenUpdate by callback<Bundle>()
+  val onStatusUpdate by Event<Bundle>()
+  val onLoadStart by Event<Unit>()
+  val onLoad by Event<Bundle>()
+  val onError by Event<Bundle>()
+  val onReadyForDisplay by Event<Bundle>()
+  val onFullscreenUpdate by Event<Bundle>()
 
   //endregion
 }

--- a/packages/expo-av/android/src/main/java/expo/modules/av/video/VideoViewWrapper.kt
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/video/VideoViewWrapper.kt
@@ -5,7 +5,7 @@ import android.content.Context
 import android.os.Bundle
 import android.widget.FrameLayout
 import expo.modules.kotlin.AppContext
-import expo.modules.kotlin.viewevent.Event
+import expo.modules.kotlin.viewevent.EventDispatcher
 
 /**
  * We need the wrapper to be able to remove the view from the React-managed tree
@@ -42,12 +42,12 @@ class VideoViewWrapper(context: Context, appContext: AppContext) : FrameLayout(c
 
   //region view callbacks
 
-  val onStatusUpdate by Event<Bundle>()
-  val onLoadStart by Event<Unit>()
-  val onLoad by Event<Bundle>()
-  val onError by Event<Bundle>()
-  val onReadyForDisplay by Event<Bundle>()
-  val onFullscreenUpdate by Event<Bundle>()
+  val onStatusUpdate by EventDispatcher<Bundle>()
+  val onLoadStart by EventDispatcher<Unit>()
+  val onLoad by EventDispatcher<Bundle>()
+  val onError by EventDispatcher<Bundle>()
+  val onReadyForDisplay by EventDispatcher<Bundle>()
+  val onFullscreenUpdate by EventDispatcher<Bundle>()
 
   //endregion
 }

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
@@ -41,7 +41,7 @@ import expo.modules.camera.utils.mapY
 import kotlin.math.roundToInt
 import android.view.WindowManager
 import expo.modules.interfaces.barcodescanner.BarCodeScannerResult.BoundingBox
-import expo.modules.kotlin.viewevent.Event
+import expo.modules.kotlin.viewevent.EventDispatcher
 
 class ExpoCameraView(
   context: Context,
@@ -61,9 +61,9 @@ class ExpoCameraView(
   private var isPaused = false
   private var isNew = true
 
-  private val onCameraReady by Event<Unit>()
-  private val onMountError by Event<CameraMountErrorEvent>()
-  private val onBarCodeScanned by Event<BarCodeScannedEvent>(
+  private val onCameraReady by EventDispatcher<Unit>()
+  private val onMountError by EventDispatcher<CameraMountErrorEvent>()
+  private val onBarCodeScanned by EventDispatcher<BarCodeScannedEvent>(
     /**
      * We want every distinct barcode to be reported to the JS listener.
      * If we return some static value as a coalescing key there may be two barcode events
@@ -73,15 +73,15 @@ class ExpoCameraView(
      */
     coalescingKey = { event -> (event.data.hashCode() % Short.MAX_VALUE).toShort() }
   )
-  private val onFacesDetected by Event<FacesDetectedEvent>(
+  private val onFacesDetected by EventDispatcher<FacesDetectedEvent>(
     /**
      * Should events about detected faces coalesce, the best strategy will be
      * to ensure that events with different faces count are always being transmitted.
      */
     coalescingKey = { event -> (event.faces.size % Short.MAX_VALUE).toShort() }
   )
-  private val onFaceDetectionError by Event<FaceDetectionErrorEvent>()
-  private val onPictureSaved by Event<PictureSavedEvent>(
+  private val onFaceDetectionError by EventDispatcher<FaceDetectionErrorEvent>()
+  private val onPictureSaved by EventDispatcher<PictureSavedEvent>(
     coalescingKey = { event ->
       val uriHash = event.data.getString("uri")?.hashCode() ?: -1
       (uriHash % Short.MAX_VALUE).toShort()

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
@@ -30,7 +30,6 @@ import expo.modules.interfaces.facedetector.FaceDetectorInterface
 import expo.modules.interfaces.facedetector.FaceDetectorProviderInterface
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.Promise
-import expo.modules.kotlin.callbacks.callback
 import expo.modules.kotlin.views.ExpoView
 import java.io.File
 import java.io.IOException
@@ -42,6 +41,7 @@ import expo.modules.camera.utils.mapY
 import kotlin.math.roundToInt
 import android.view.WindowManager
 import expo.modules.interfaces.barcodescanner.BarCodeScannerResult.BoundingBox
+import expo.modules.kotlin.viewevent.Event
 
 class ExpoCameraView(
   context: Context,
@@ -61,9 +61,9 @@ class ExpoCameraView(
   private var isPaused = false
   private var isNew = true
 
-  private val onCameraReady by callback<Unit>()
-  private val onMountError by callback<CameraMountErrorEvent>()
-  private val onBarCodeScanned by callback<BarCodeScannedEvent>(
+  private val onCameraReady by Event<Unit>()
+  private val onMountError by Event<CameraMountErrorEvent>()
+  private val onBarCodeScanned by Event<BarCodeScannedEvent>(
     /**
      * We want every distinct barcode to be reported to the JS listener.
      * If we return some static value as a coalescing key there may be two barcode events
@@ -73,15 +73,15 @@ class ExpoCameraView(
      */
     coalescingKey = { event -> (event.data.hashCode() % Short.MAX_VALUE).toShort() }
   )
-  private val onFacesDetected by callback<FacesDetectedEvent>(
+  private val onFacesDetected by Event<FacesDetectedEvent>(
     /**
      * Should events about detected faces coalesce, the best strategy will be
      * to ensure that events with different faces count are always being transmitted.
      */
     coalescingKey = { event -> (event.faces.size % Short.MAX_VALUE).toShort() }
   )
-  private val onFaceDetectionError by callback<FaceDetectionErrorEvent>()
-  private val onPictureSaved by callback<PictureSavedEvent>(
+  private val onFaceDetectionError by Event<FaceDetectionErrorEvent>()
+  private val onPictureSaved by Event<PictureSavedEvent>(
     coalescingKey = { event ->
       val uriHash = event.data.getString("uri")?.hashCode() ?: -1
       (uriHash % Short.MAX_VALUE).toShort()

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/callbacks/Callback.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/callbacks/Callback.kt
@@ -1,5 +1,0 @@
-package expo.modules.kotlin.callbacks
-
-fun interface Callback<T> {
-  operator fun invoke(arg: T)
-}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/viewevent/ViewEvent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/viewevent/ViewEvent.kt
@@ -1,15 +1,16 @@
-package expo.modules.kotlin.callbacks
+package expo.modules.kotlin.viewevent
 
 import android.view.View
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.WritableMap
 import expo.modules.adapters.react.NativeModulesProxy
+import expo.modules.kotlin.callbacks.Callback
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.types.JSTypeConverter
 import expo.modules.kotlin.types.putGeneric
 import kotlin.reflect.KType
 
-class ViewCallback<T>(
+class ViewEvent<T>(
   private val name: String,
   private val type: KType,
   private val view: View,

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/viewevent/ViewEvent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/viewevent/ViewEvent.kt
@@ -4,18 +4,21 @@ import android.view.View
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.WritableMap
 import expo.modules.adapters.react.NativeModulesProxy
-import expo.modules.kotlin.callbacks.Callback
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.types.JSTypeConverter
 import expo.modules.kotlin.types.putGeneric
 import kotlin.reflect.KType
+
+fun interface ViewEventCallback<T> {
+  operator fun invoke(arg: T)
+}
 
 class ViewEvent<T>(
   private val name: String,
   private val type: KType,
   private val view: View,
   private val coalescingKey: CoalescingKey<T>?
-) : Callback<T> {
+) : ViewEventCallback<T> {
   internal lateinit var module: Module
 
   override operator fun invoke(arg: T) {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/viewevent/ViewEventDelegate.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/viewevent/ViewEventDelegate.kt
@@ -1,8 +1,9 @@
 @file:OptIn(ExperimentalStdlibApi::class)
 
-package expo.modules.kotlin.callbacks
+package expo.modules.kotlin.viewevent
 
 import android.view.View
+import expo.modules.kotlin.callbacks.Callback
 import java.lang.ref.WeakReference
 import kotlin.reflect.KProperty
 import kotlin.reflect.KType
@@ -10,7 +11,7 @@ import kotlin.reflect.typeOf
 
 typealias CoalescingKey<T> = (event: T) -> Short
 
-class ViewCallbackDelegate<T>(
+class ViewEventDelegate<T>(
   private val type: KType,
   view: View,
   private val coalescingKey: CoalescingKey<T>?
@@ -25,7 +26,7 @@ class ViewCallbackDelegate<T>(
 
     val view = viewHolder.get()
       ?: throw IllegalStateException("Can't send an event from the view that is deallocated.")
-    return ViewCallback(property.name, type, view, coalescingKey)
+    return ViewEvent(property.name, type, view, coalescingKey)
   }
 }
 
@@ -34,6 +35,11 @@ class ViewCallbackDelegate<T>(
  * @param coalescingKey a key generator used to determine which other events of this type this event can be coalesced with.
  * For example, touch move events should only be coalesced within a single gesture so a coalescing key there would be the unique gesture id.
  */
-inline fun <reified T> View.callback(noinline coalescingKey: CoalescingKey<T>? = null): ViewCallbackDelegate<T> {
-  return ViewCallbackDelegate(typeOf<T>(), this, coalescingKey)
+inline fun <reified T> View.Event(noinline coalescingKey: CoalescingKey<T>? = null): ViewEventDelegate<T> {
+  return ViewEventDelegate(typeOf<T>(), this, coalescingKey)
+}
+
+@JvmName("MapEvent")
+fun View.Event(coalescingKey: CoalescingKey<Map<String, Any>>? = null): ViewEventDelegate<Map<String, Any>> {
+  return ViewEventDelegate(typeOf<Map<String, Any>>(), this, coalescingKey)
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/viewevent/ViewEventDelegate.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/viewevent/ViewEventDelegate.kt
@@ -3,7 +3,6 @@
 package expo.modules.kotlin.viewevent
 
 import android.view.View
-import expo.modules.kotlin.callbacks.Callback
 import java.lang.ref.WeakReference
 import kotlin.reflect.KProperty
 import kotlin.reflect.KType
@@ -19,7 +18,7 @@ class ViewEventDelegate<T>(
   private val viewHolder = WeakReference(view)
   internal var isValidated = false
 
-  operator fun getValue(thisRef: View, property: KProperty<*>): Callback<T> {
+  operator fun getValue(thisRef: View, property: KProperty<*>): ViewEventCallback<T> {
     if (!isValidated) {
       throw IllegalStateException("You have to export this property as a callback in the `ViewManager`.")
     }
@@ -35,11 +34,13 @@ class ViewEventDelegate<T>(
  * @param coalescingKey a key generator used to determine which other events of this type this event can be coalesced with.
  * For example, touch move events should only be coalesced within a single gesture so a coalescing key there would be the unique gesture id.
  */
-inline fun <reified T> View.Event(noinline coalescingKey: CoalescingKey<T>? = null): ViewEventDelegate<T> {
+@Suppress("FunctionName")
+inline fun <reified T> View.EventDispatcher(noinline coalescingKey: CoalescingKey<T>? = null): ViewEventDelegate<T> {
   return ViewEventDelegate(typeOf<T>(), this, coalescingKey)
 }
 
-@JvmName("MapEvent")
-fun View.Event(coalescingKey: CoalescingKey<Map<String, Any>>? = null): ViewEventDelegate<Map<String, Any>> {
+@JvmName("MapEventDispatcher")
+@Suppress("FunctionName")
+fun View.EventDispatcher(coalescingKey: CoalescingKey<Map<String, Any>>? = null): ViewEventDelegate<Map<String, Any>> {
   return ViewEventDelegate(typeOf<Map<String, Any>>(), this, coalescingKey)
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerWrapperDelegate.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerWrapperDelegate.kt
@@ -6,9 +6,9 @@ import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.common.MapBuilder
 import expo.modules.core.utilities.ifNull
 import expo.modules.kotlin.ModuleHolder
-import expo.modules.kotlin.callbacks.ViewCallbackDelegate
 import expo.modules.kotlin.events.normalizeEventName
 import expo.modules.kotlin.logger
+import expo.modules.kotlin.viewevent.ViewEventDelegate
 import kotlin.reflect.full.declaredMemberProperties
 import kotlin.reflect.jvm.isAccessible
 
@@ -70,7 +70,7 @@ class ViewManagerWrapperDelegate(internal var moduleHolder: ModuleHolder) {
         return@forEach
       }
 
-      val viewDelegate = (delegate as? ViewCallbackDelegate<*>).ifNull {
+      val viewDelegate = (delegate as? ViewEventDelegate<*>).ifNull {
         logger.warn("⚠️ Property delegate for `$it` cannot be cased to `ViewCallbackDelegate`")
         return@forEach
       }


### PR DESCRIPTION
# Why

This's a follow-up to https://github.com/expo/expo/pull/19537.

# How

Renamed `callback` to `EventDispatcher`

# Test Plan

- NCL ✅