### PR TITLE
feat(cli): Make Expo Metro config for web resolve projects using same `package.json` main fields as Expo Webpack

### DIFF
--- a/docs/pages/workflow/expo-cli.mdx
+++ b/docs/pages/workflow/expo-cli.mdx
@@ -362,7 +362,7 @@ From here, you can choose to generate basic project files like:
 - `EDITOR` (**string**) name of the editor to open when pressing `o` in the Terminal UI. This value is used across many command line tools.
 - `EXPO_EDITOR` (**string**) an Expo-specific version of the `EDITOR` variable which takes higher priority when defined.
 - `EXPO_IMAGE_UTILS_NO_SHARP` (**boolean**) disable the usage of global Sharp CLI installation in favor of the slower Jimp package for image manipulation. This is used in places like `npx expo prebuild` for generating app icons.
-- `EXPO_METRO_NO_MAIN_FIELD_OVERRIDE` (**boolean**) force Expo CLI to use the [`resolver.resolverMainFields`](https://facebook.github.io/metro/docs/configuration/#resolvermainfields) from the project `metro.config.js` for all platforms. By default, Expo CLI will use `['browser', 'module', 'main']` (default for Webpack) for web and the user-defined main fields for other platforms.
+- `EXPO_METRO_NO_MAIN_FIELD_OVERRIDE` (**boolean**) force Expo CLI to use the [`resolver.resolverMainFields`](https://facebook.github.io/metro/docs/configuration/#resolvermainfields) from the project's **metro.config.js** for all platforms. By default, Expo CLI will use `['browser', 'module', 'main']`  which is the default for Webpack, for the web and the user-defined main fields for other platforms.
 
 ## Telemetry
 

--- a/docs/pages/workflow/expo-cli.mdx
+++ b/docs/pages/workflow/expo-cli.mdx
@@ -362,6 +362,7 @@ From here, you can choose to generate basic project files like:
 - `EDITOR` (**string**) name of the editor to open when pressing `o` in the Terminal UI. This value is used across many command line tools.
 - `EXPO_EDITOR` (**string**) an Expo-specific version of the `EDITOR` variable which takes higher priority when defined.
 - `EXPO_IMAGE_UTILS_NO_SHARP` (**boolean**) disable the usage of global Sharp CLI installation in favor of the slower Jimp package for image manipulation. This is used in places like `npx expo prebuild` for generating app icons.
+- `EXPO_METRO_NO_MAIN_FIELD_OVERRIDE` (**boolean**) force Expo CLI to use the [`resolver.resolverMainFields`](https://facebook.github.io/metro/docs/configuration/#resolvermainfields) from the project `metro.config.js` for all platforms. By default, Expo CLI will use `['browser', 'module', 'main']` (default for Webpack) for web and the user-defined main fields for other platforms.
 
 ## Telemetry
 

--- a/docs/pages/workflow/expo-cli.mdx
+++ b/docs/pages/workflow/expo-cli.mdx
@@ -362,7 +362,7 @@ From here, you can choose to generate basic project files like:
 - `EDITOR` (**string**) name of the editor to open when pressing `o` in the Terminal UI. This value is used across many command line tools.
 - `EXPO_EDITOR` (**string**) an Expo-specific version of the `EDITOR` variable which takes higher priority when defined.
 - `EXPO_IMAGE_UTILS_NO_SHARP` (**boolean**) disable the usage of global Sharp CLI installation in favor of the slower Jimp package for image manipulation. This is used in places like `npx expo prebuild` for generating app icons.
-- `EXPO_METRO_NO_MAIN_FIELD_OVERRIDE` (**boolean**) force Expo CLI to use the [`resolver.resolverMainFields`](https://facebook.github.io/metro/docs/configuration/#resolvermainfields) from the project's **metro.config.js** for all platforms. By default, Expo CLI will use `['browser', 'module', 'main']`  which is the default for Webpack, for the web and the user-defined main fields for other platforms.
+- `EXPO_METRO_NO_MAIN_FIELD_OVERRIDE` (**boolean**) force Expo CLI to use the [`resolver.resolverMainFields`](https://facebook.github.io/metro/docs/configuration/#resolvermainfields) from the project's **metro.config.js** for all platforms. By default, Expo CLI will use `['browser', 'module', 'main']`, which is the default for Webpack, for the web and the user-defined main fields for other platforms.
 
 ## Telemetry
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### 🐛 Bug fixes
 
+- Make Expo Metro config for web resolve projects using same `package.json` main fields as Expo Webpack. Behavior can be disabled with `EXPO_METRO_NO_MAIN_FIELD_OVERRIDE`.
 - Resolve bundle identifier / package from native project and then fallback to `app.json` when launching redirect page. ([#19260](https://github.com/expo/expo/pull/19260) by [@brentvatne](https://github.com/brentvatne))
 - Resolve bundle identifier from `app.json` correctly when using `npx expo start --dev-client --ios` with no local `ios` directory. ([#18747](https://github.com/expo/expo/pull/18747) by [@EvanBacon](https://github.com/EvanBacon))
 - Add web support check to metro web in `expo start`. ([#18428](https://github.com/expo/expo/pull/18428) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### 🐛 Bug fixes
 
-- Make Expo Metro config for web resolve projects using same `package.json` main fields as Expo Webpack. Behavior can be disabled with `EXPO_METRO_NO_MAIN_FIELD_OVERRIDE`.
+- Make Expo Metro config for web resolve projects using same `package.json` main fields as Expo Webpack. Behavior can be disabled with `EXPO_METRO_NO_MAIN_FIELD_OVERRIDE`. ([#19529](https://github.com/expo/expo/pull/19529) by [@EvanBacon](https://github.com/EvanBacon))
 - Resolve bundle identifier / package from native project and then fallback to `app.json` when launching redirect page. ([#19260](https://github.com/expo/expo/pull/19260) by [@brentvatne](https://github.com/brentvatne))
 - Resolve bundle identifier from `app.json` correctly when using `npx expo start --dev-client --ios` with no local `ios` directory. ([#18747](https://github.com/expo/expo/pull/18747) by [@EvanBacon](https://github.com/EvanBacon))
 - Add web support check to metro web in `expo start`. ([#18428](https://github.com/expo/expo/pull/18428) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/src/export/fork-bundleAsync.ts
+++ b/packages/@expo/cli/src/export/fork-bundleAsync.ts
@@ -14,9 +14,8 @@ import chalk from 'chalk';
 import Metro from 'metro';
 import { Terminal } from 'metro-core';
 
-import { WebSupportProjectPrerequisite } from '../start/doctor/web/WebSupportProjectPrerequisite';
 import { MetroTerminalReporter } from '../start/server/metro/MetroTerminalReporter';
-import { withMetroMultiPlatform } from '../start/server/metro/withMetroMultiPlatform';
+import { withMetroMultiPlatformAsync } from '../start/server/metro/withMetroMultiPlatform';
 import { getPlatformBundlers } from '../start/server/platformBundlers';
 
 export type MetroDevServerOptions = LoadOptions & {
@@ -110,11 +109,7 @@ export async function bundleAsync(
 
   const bundlerPlatforms = getPlatformBundlers(exp);
 
-  if (bundlerPlatforms.web === 'metro') {
-    await new WebSupportProjectPrerequisite(projectRoot).assertAsync();
-  }
-
-  config = withMetroMultiPlatform(projectRoot, config, bundlerPlatforms);
+  config = await withMetroMultiPlatformAsync(projectRoot, config, bundlerPlatforms);
 
   const metroServer = await metro.runMetro(config, {
     watch: false,

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -8,8 +8,7 @@ import { createDevServerMiddleware } from '../middleware/createDevServerMiddlewa
 import { getPlatformBundlers } from '../platformBundlers';
 import { MetroTerminalReporter } from './MetroTerminalReporter';
 import { importExpoMetroConfigFromProject, importMetroFromProject } from './resolveFromProject';
-import { getAppRouterRelativeEntryPath } from './router';
-import { withMetroMultiPlatform } from './withMetroMultiPlatform';
+import { withMetroMultiPlatformAsync } from './withMetroMultiPlatform';
 
 // From expo/dev-server but with ability to use custom logger.
 type MessageSocket = {
@@ -50,11 +49,7 @@ export async function instantiateMetroAsync(
     skipPlugins: true,
   });
   const platformBundlers = getPlatformBundlers(exp);
-  metroConfig = withMetroMultiPlatform(projectRoot, metroConfig, platformBundlers);
-
-  // Auto pick App entry: this is injected with Babel.
-  process.env.EXPO_ROUTER_APP_ROOT = getAppRouterRelativeEntryPath(projectRoot);
-  process.env.EXPO_PROJECT_ROOT = process.env.EXPO_PROJECT_ROOT ?? projectRoot;
+  metroConfig = await withMetroMultiPlatformAsync(projectRoot, metroConfig, platformBundlers);
 
   const {
     middleware,

--- a/packages/@expo/cli/src/utils/env.ts
+++ b/packages/@expo/cli/src/utils/env.ts
@@ -104,9 +104,18 @@ class Env {
    * Disable the enforced `:80` port when using custom dev server URLs.
    * This can break the incomplete Android WebSocket implementation but allows
    * `EXPO_PACKAGER_PROXY_URL` to work as expected.
-   * */
+   */
   get EXPO_NO_DEFAULT_PORT(): boolean {
     return boolish('EXPO_NO_DEFAULT_PORT', false);
+  }
+
+  /**
+   * Force Expo CLI to use the [`resolver.resolverMainFields`](https://facebook.github.io/metro/docs/configuration/#resolvermainfields) from the project `metro.config.js` for all platforms.
+   *
+   * By default, Expo CLI will use `['browser', 'module', 'main']` (default for Webpack) for web and the user-defined main fields for other platforms.
+   */
+  get EXPO_METRO_NO_MAIN_FIELD_OVERRIDE(): boolean {
+    return boolish('EXPO_METRO_NO_MAIN_FIELD_OVERRIDE', false);
   }
 }
 


### PR DESCRIPTION
# Why

fix https://github.com/expo/router/issues/37

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Metro web is resolving packages using the same policy as Metro for native. Most packages don't account for Metro web since it's new. This leads to confusing issues where certain web functionality is missing or broken.

Expo Webpack used the default Webpack main fields `['browser', 'module', 'main']` which worked well across a variety of projects. This PR adds a dynamic resolver that swaps the main field policy over to `['browser', 'module', 'main']` when bundling for `web`.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

In a project with `firebase@^9.12.0`:

```js
// index.js
import { browserLocalPersistence } from "firebase/auth";
console.log("browserLocalPersistence", browserLocalPersistence);
```

This should be defined on web, whereas it wasn't before. The total number of resolved files should go from 792 down to 72.
