### PR TITLE
[docs] introduce Step component

### DIFF
--- a/docs/pages/guides/using-sentry.mdx
+++ b/docs/pages/guides/using-sentry.mdx
@@ -32,7 +32,7 @@ It notifies you of exceptions or errors that your users run into while using you
 
 Before getting real-time updates on errors and making your app generally incredible, you'll need to make sure you've created a Sentry project. Here's how to do that:
 
-<Step label="1" connected>
+<Step label="1">
 [Sign up for Sentry](https://sentry.io/signup/) (it's free), and create a project in your Dashboard. Take note of your **organization name**, **project name**, and **`DSN`**; you'll need them later.
 - **organization name** is available in your `Organization settings` tab
 - **project name** is available in your project's `Settings` > `Projects` tab (find it in the list)

--- a/docs/pages/guides/using-sentry.mdx
+++ b/docs/pages/guides/using-sentry.mdx
@@ -7,6 +7,7 @@ import { ConfigReactNative, ConfigClassic } from '~/components/plugins/ConfigSec
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
+import { Step } from '~/ui/components/Step';
 
 [Sentry](http://getsentry.com/) is a crash reporting platform that provides you with "real-time insight into production deployments with info to reproduce and fix crashes".
 
@@ -31,13 +32,16 @@ It notifies you of exceptions or errors that your users run into while using you
 
 Before getting real-time updates on errors and making your app generally incredible, you'll need to make sure you've created a Sentry project. Here's how to do that:
 
-1. [Sign up for Sentry](https://sentry.io/signup/) (it's free), and create a project in your Dashboard. Take note of your **organization name**, **project name**, and **`DSN`**; you'll need them later.
+<Step label="1" connected>
+[Sign up for Sentry](https://sentry.io/signup/) (it's free), and create a project in your Dashboard. Take note of your **organization name**, **project name**, and **`DSN`**; you'll need them later.
+- **organization name** is available in your `Organization settings` tab
+- **project name** is available in your project's `Settings` > `Projects` tab (find it in the list)
+- **`DSN`** is available in your project's `Settings` > `Projects` > **Project name** > `Client Keys (DSN)` tab
+</Step>
 
-   - **organization name** is available in your `Organization settings` tab
-   - **project name** is available in your project's `Settings` > `Projects` tab (find it in the list)
-   - **`DSN`** is avalable in your project's `Settings` > `Projects` > **Project name** > `Client Keys (DSN)` tab
-
-2. Go to the [Sentry API section](https://sentry.io/settings/account/api/auth-tokens/), and create an **auth token**. The token requires the scopes: `org:read`, `project:releases`, and `project:write`. Save this, too.
+<Step label="2">
+Go to the [Sentry API section](https://sentry.io/settings/account/api/auth-tokens/), and create an **auth token**. The token requires the scopes: `org:read`, `project:releases`, and `project:write`. Save this, too.
+</Step>
 
 Once you have each of these: organization name, project name, DSN, and auth token, you're all set!
 
@@ -119,14 +123,14 @@ to your root project file (usually **App.js**), so make sure you remove it (but 
 
 </ConfigReactNative>
 
-#### 4.1: Configure a `postPublish` hook
+#### Configure a `postPublish` hook
 
 Add `expo.hooks` to your project's `app.json` (or `app.config.js`) file:
 
-```json
+```json app.json
 {
   "expo": {
-    // ... your existing configuration
+    /* @hide ... your existing configuration */ /* @end */
     "hooks": {
       "postPublish": [
         {
@@ -175,14 +179,14 @@ In addition to the required config fields above, you can also provide these **op
 
 </Collapsible>
 
-#### 4.2: Add the Config Plugin
+#### Add the Config Plugin
 
 Add `expo.plugins` to your project's `app.json` (or `app.config.js`) file:
 
-```json
+```json app.json
 {
   "expo": {
-    // ... your existing configuration
+    /* @hide ... your existing configuration */ /* @end */
     "plugins": ["sentry-expo"]
   }
 }
@@ -207,7 +211,7 @@ With `expo-updates`, release builds of both iOS and Android apps will create and
 - The configuration for build time sourcemaps comes from the `ios/sentry.properties` and `android/sentry.properties` files. For more information, refer to [Sentry's documentation](https://docs.sentry.io/clients/java/config/#configuration-via-properties-file). Manual configuration is only required for bare projects, the [sentry-expo config plugin handles it otherwise](#add-the-config-plugin).
 - Configuration for `expo publish` and `npx expo export` for projects is done via `app.json`, whether using bare workflow or not.
 
-Skipping or misconfiguring either of these can lead to invalid sourcemaps, and you won't see human readable stacktraces in your errors.
+Skipping or misconfiguring either of these can lead to invalid sourcemaps, and you won't see human-readable stacktraces in your errors.
 
 ### Self-hosting updates
 

--- a/docs/pages/workflow/ios-simulator.mdx
+++ b/docs/pages/workflow/ios-simulator.mdx
@@ -5,24 +5,30 @@ title: iOS Simulator
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 import Video from '~/components/plugins/Video';
 import { Terminal } from '~/ui/components/Snippet';
+import { Step } from '~/ui/components/Step';
 
 It's often convenient to develop your app directly on your computer rather than having to physically interact with an iPhone and iPad and load your app over the network, which may be slow under some conditions such as if you need to use a tunnel connection because LAN isn't possible on your network.
 
 This guide explains how you can install the iOS simulator on your Mac and use it for developing your app. It is not possible to install the iOS Simulator on any operating system except macOS. If you want to develop an app for iOS from a Windows machine then you will need to use a physical iOS device.
 
-## Step 1: Install Xcode
+<Step label="1">
+## Install Xcode
 
 Open up the Mac App Store, search for [Xcode](https://apps.apple.com/us/app/xcode/id497799835), and hit install (or update if you have it already).
 If you're unable to update, it is because your operating system might be out of date. We recommend updating your operating system to the latest version and then updating Xcode.
 You may run into issues further down the line if your Xcode version is out of date. For example, you may not be able to submit your app to the App Store.
+</Step>
 
-## Step 2: Install Xcode Command Line Tools
+<Step label="2">
+## Install Xcode Command Line Tools
 
 Open Xcode, then choose **Preferences...** from the Xcode menu (or press <kbd>Cmd ⌘</kbd> + <kbd>,</kbd>). Go to the Locations panel and install the tools by selecting the most recent version in the Command Line Tools dropdown.
 
 <ImageSpotlight alt="Xcode preferences" src="/static/images/xcode-command-line.png" />
+</Step>
 
-## Step 3: Try it out
+<Step label="3">
+## Try it out
 
 Run your app with `npx expo start` and press <kbd>I</kbd> from the command line.
 
@@ -34,6 +40,7 @@ If the troubleshooting tips are not helpful, seek help on [Expo Development Tool
 <Video file="open-in-ios-simulator.mp4" />
 
 > Pro Tip: Press <kbd>Shift</kbd> + <kbd>I</kbd> in the CLI UI to interactively select a simulator to open.
+</Step>
 
 ## Limitations
 

--- a/docs/ui/components/Step/Step.tsx
+++ b/docs/ui/components/Step/Step.tsx
@@ -1,18 +1,18 @@
 import { css } from '@emotion/react';
-import { spacing, theme, typography } from '@expo/styleguide';
+import { spacing, theme } from '@expo/styleguide';
 import { PropsWithChildren } from 'react';
+
+import { HEADLINE } from '~/ui/components/Text';
 
 type Props = PropsWithChildren<{
   label: string;
-  connected?: boolean;
 }>;
 
-export const Step = ({ children, label, connected }: Props) => {
+export const Step = ({ children, label }: Props) => {
   return (
     <div css={stepWrapperStyle}>
       <div>
-        <div css={stepLabelStyle}>{label}</div>
-        {connected && <div css={stepConnectionStyle} />}
+        <HEADLINE css={stepLabelStyle}>{label}</HEADLINE>
       </div>
       <div css={stepContentStyle}>{children}</div>
     </div>
@@ -36,16 +36,8 @@ const stepLabelStyle = css({
   margin: `0 auto`,
   width: spacing[9],
   height: spacing[9],
-  fontFamily: typography.fontStacks.semiBold,
-  color: theme.text.secondary,
   background: theme.background.tertiary,
   borderRadius: '100%',
-});
-
-const stepConnectionStyle = css({
-  width: '50%',
-  height: `calc(100% - ${spacing[5]}px)`,
-  borderRight: `1px solid ${theme.border.default}`,
 });
 
 const stepContentStyle = css({

--- a/docs/ui/components/Step/Step.tsx
+++ b/docs/ui/components/Step/Step.tsx
@@ -38,9 +38,8 @@ const stepLabelStyle = css({
   height: spacing[9],
   fontFamily: typography.fontStacks.semiBold,
   color: theme.text.secondary,
-  background: theme.background.secondary,
+  background: theme.background.tertiary,
   borderRadius: '100%',
-  border: `1px solid ${theme.border.default}`,
 });
 
 const stepConnectionStyle = css({

--- a/docs/ui/components/Step/Step.tsx
+++ b/docs/ui/components/Step/Step.tsx
@@ -18,7 +18,7 @@ export const Step = ({ children, label }: Props) => {
 };
 
 const stepWrapperStyle = css({
-  display: 'grid',
+  display: 'inline-grid',
   gridTemplateColumns: `${spacing[7]}px minmax(0, 1fr)`,
   gap: spacing[4],
   margin: `${spacing[2]}px 0`,

--- a/docs/ui/components/Step/Step.tsx
+++ b/docs/ui/components/Step/Step.tsx
@@ -25,6 +25,7 @@ const stepWrapperStyle = css({
   gap: spacing[4],
   margin: `${spacing[2]}px 0`,
   float: 'left',
+  width: '100%',
 });
 
 const stepLabelStyle = css({

--- a/docs/ui/components/Step/Step.tsx
+++ b/docs/ui/components/Step/Step.tsx
@@ -11,9 +11,7 @@ type Props = PropsWithChildren<{
 export const Step = ({ children, label }: Props) => {
   return (
     <div css={stepWrapperStyle}>
-      <div>
-        <HEADLINE css={stepLabelStyle}>{label}</HEADLINE>
-      </div>
+      <HEADLINE css={stepLabelStyle}>{label}</HEADLINE>
       <div css={stepContentStyle}>{children}</div>
     </div>
   );
@@ -21,10 +19,9 @@ export const Step = ({ children, label }: Props) => {
 
 const stepWrapperStyle = css({
   display: 'grid',
-  gridTemplateColumns: `${spacing[9]}px minmax(0, 1fr)`,
+  gridTemplateColumns: `${spacing[7]}px minmax(0, 1fr)`,
   gap: spacing[4],
   margin: `${spacing[2]}px 0`,
-  float: 'left',
   width: '100%',
 });
 
@@ -32,10 +29,9 @@ const stepLabelStyle = css({
   display: 'flex',
   justifyContent: 'center',
   alignItems: 'center',
-  alignSelf: 'center',
-  margin: `0 auto`,
-  width: spacing[9],
-  height: spacing[9],
+  margin: `${spacing[1]}px auto`,
+  width: spacing[7],
+  height: spacing[7],
   background: theme.background.tertiary,
   borderRadius: '100%',
 });

--- a/docs/ui/components/Step/Step.tsx
+++ b/docs/ui/components/Step/Step.tsx
@@ -52,8 +52,12 @@ const stepConnectionStyle = css({
 const stepContentStyle = css({
   paddingTop: spacing[1],
 
-  'h2:first-child, h3:first-child, h4:first-child': {
+  'h2:first-child': {
     marginTop: -spacing[1],
+  },
+
+  'h3:first-child, h4:first-child': {
+    marginTop: -spacing[0.5],
   },
 
   'ul, ol': {

--- a/docs/ui/components/Step/Step.tsx
+++ b/docs/ui/components/Step/Step.tsx
@@ -1,0 +1,61 @@
+import { css } from '@emotion/react';
+import { spacing, theme, typography } from '@expo/styleguide';
+import { PropsWithChildren } from 'react';
+
+type Props = PropsWithChildren<{
+  label: string;
+  connected?: boolean;
+}>;
+
+export const Step = ({ children, label, connected }: Props) => {
+  return (
+    <div css={stepWrapperStyle}>
+      <div>
+        <div css={stepLabelStyle}>{label}</div>
+        {connected && <div css={stepConnectionStyle} />}
+      </div>
+      <div css={stepContentStyle}>{children}</div>
+    </div>
+  );
+};
+
+const stepWrapperStyle = css({
+  display: 'grid',
+  gridTemplateColumns: `${spacing[9]}px minmax(0, 1fr)`,
+  gap: spacing[4],
+  margin: `${spacing[2]}px 0`,
+  float: 'left',
+});
+
+const stepLabelStyle = css({
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  alignSelf: 'center',
+  margin: `0 auto`,
+  width: spacing[9],
+  height: spacing[9],
+  fontFamily: typography.fontStacks.semiBold,
+  color: theme.text.secondary,
+  background: theme.background.secondary,
+  borderRadius: '100%',
+  border: `1px solid ${theme.border.default}`,
+});
+
+const stepConnectionStyle = css({
+  width: '50%',
+  height: `calc(100% - ${spacing[5]}px)`,
+  borderRight: `1px solid ${theme.border.default}`,
+});
+
+const stepContentStyle = css({
+  paddingTop: spacing[1],
+
+  'h2:first-child, h3:first-child, h4:first-child': {
+    marginTop: -spacing[1],
+  },
+
+  'ul, ol': {
+    marginBottom: 0,
+  },
+});

--- a/docs/ui/components/Step/index.ts
+++ b/docs/ui/components/Step/index.ts
@@ -1,0 +1,1 @@
+export { Step } from './Step';


### PR DESCRIPTION
# Why

The idea for the step component and visualization come from Jon mocks:
* https://www.figma.com/file/bCkjr1y9fTDjgAm3eM1AIa/Docs-design?node-id=1843%3A2251

# How

This PR adds the `Step` component, which can be used to visualize a bit better the sequential actions.

There are two variants, default one and connected one, so the visual aspect can be tweaked for the certain usecase.

~~I have added the additional border around the components, in comparison to the mock, to improve the contrast of step label element.~~

To demonstrate this component, I have updated two pages: "Using Sentry" and "iOS Simulator". Additionally I have fixed a spotted typos.

# Test Plan

The changes have been tested by running docs app locally.

# Preview
<img width="1197" alt="Screenshot 2022-10-13 at 16 32 09" src="https://user-images.githubusercontent.com/719641/195626175-b86f747f-93d4-4087-a596-8b5348e3396b.png">
<img width="1197" alt="Screenshot 2022-10-13 at 16 31 38" src="https://user-images.githubusercontent.com/719641/195626190-d0abe55d-09c9-4976-9fd9-d0812ad5958e.png">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
