### PR TITLE
[core] Fix Updates.reloadAsync crash issue

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/ModuleRegistryAdapter.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/ModuleRegistryAdapter.java
@@ -116,8 +116,9 @@ public class ModuleRegistryAdapter implements ReactPackage {
     ReactApplicationContext reactContext,
     @Nullable ModuleRegistry moduleRegistry
   ) {
-    if (mModulesProxy != null && mModulesProxy.getKotlinInteropModuleRegistry().shouldBeRecreated(reactContext)) {
+    if (mModulesProxy != null && mModulesProxy.getReactContext() != reactContext) {
       mModulesProxy = null;
+      mWrapperDelegateHolders = null;
     }
     if (mModulesProxy == null) {
       ModuleRegistry registry = moduleRegistry != null ? moduleRegistry : mModuleRegistryProvider.get(reactContext);

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/NativeModulesProxy.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/NativeModulesProxy.java
@@ -267,4 +267,8 @@ public class NativeModulesProxy extends ReactContextBaseJavaModule {
   ModuleRegistry getModuleRegistry() {
     return mModuleRegistry;
   }
+
+  /* package */ ReactApplicationContext getReactContext() {
+    return getReactApplicationContext();
+  }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KotlinInteropModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KotlinInteropModuleRegistry.kt
@@ -27,8 +27,6 @@ class KotlinInteropModuleRegistry(
   private val registry: ModuleRegistry
     get() = appContext.registry
 
-  private var wasDestroyed = false
-
   fun hasModule(name: String): Boolean = registry.hasModule(name)
 
   fun callMethod(moduleName: String, method: String, arguments: ReadableArray, promise: Promise) {
@@ -114,7 +112,6 @@ class KotlinInteropModuleRegistry(
 
   fun onDestroy() {
     appContext.onDestroy()
-    wasDestroyed = true
     logger.info("✅ KotlinInteropModuleRegistry was destroyed")
   }
 
@@ -124,9 +121,5 @@ class KotlinInteropModuleRegistry(
 
   fun setLegacyModulesProxy(proxyModule: NativeModulesProxy) {
     appContext.legacyModulesProxyHolder = WeakReference(proxyModule)
-  }
-
-  fun shouldBeRecreated(applicationContext: ReactApplicationContext): Boolean {
-    return wasDestroyed || appContext.reactContext != applicationContext
   }
 }


### PR DESCRIPTION
# Why

fix `Updates.reloadAsync` crashes on current sdk-46.
close ENG-6714

# How

following up with #19176, the NativeModulesProxy doesn't be recreated for other cases. the `Updates.reloadAsync` uses `ReactInstanceManager.recreateReactContextInBackground` in release build mode and more chance to come across the race condition issue. the ReactApplicationContext in NativeModulesProxy is old and destroyed, the `CatalystInstanceImpl.getJSCallInvokerHolder` will throw NPE and cause the crash.

basically, the issue should be resolved on main branch because the `KotlinInteropModuleRegistry.shouldBeRecreated` also checks the liveness of the underlying ReactApplicationContext. i think to check the context from NativeModulesProxy would be more straightforward.

i will create another pr for sdk-46 fix.

# Test Plan

based on https://github.com/keith-kurak/updates-reload-issue + patch-package

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
  - no user faced change
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
