### PR TITLE
[core] Fix Updates.reloadAsync crash issue

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `Updates.reloadAsync` from `expo-updates` occasionally crashes the app. ([#19539](https://github.com/expo/expo/pull/19539) by [@kudo](https://github.com/kudo), [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 0.11.7 — 2022-10-06

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/ModuleRegistryAdapter.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/ModuleRegistryAdapter.java
@@ -111,8 +111,9 @@ public class ModuleRegistryAdapter implements ReactPackage {
     ReactApplicationContext reactContext,
     @Nullable ModuleRegistry moduleRegistry
   ) {
-    if (mModulesProxy != null && mModulesProxy.getKotlinInteropModuleRegistry().getWasDestroyed()) {
+    if (mModulesProxy != null && mModulesProxy.getReactContext() != reactContext) {
       mModulesProxy = null;
+      mWrapperDelegateHolders = null;
     }
     if (mModulesProxy == null) {
       ModuleRegistry registry = moduleRegistry != null ? moduleRegistry : mModuleRegistryProvider.get(reactContext);

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/NativeModulesProxy.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/NativeModulesProxy.java
@@ -255,4 +255,8 @@ public class NativeModulesProxy extends ReactContextBaseJavaModule {
   ModuleRegistry getModuleRegistry() {
     return mModuleRegistry;
   }
+
+  /* package */ ReactApplicationContext getReactContext() {
+    return getReactApplicationContext();
+  }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KotlinInteropModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KotlinInteropModuleRegistry.kt
@@ -25,9 +25,6 @@ class KotlinInteropModuleRegistry(
   private val registry: ModuleRegistry
     get() = appContext.registry
 
-  var wasDestroyed = false
-    private set
-
   fun hasModule(name: String): Boolean = registry.hasModule(name)
 
   fun callMethod(moduleName: String, method: String, arguments: ReadableArray, promise: Promise) {
@@ -111,7 +108,6 @@ class KotlinInteropModuleRegistry(
 
   fun onDestroy() {
     appContext.onDestroy()
-    wasDestroyed = true
   }
 
   fun installJSIInterop() {


### PR DESCRIPTION
# Why

same as #19538 but for sdk-46

# How

apply the same patch as #19538 and resolve conflict

# Test Plan

based on https://github.com/keith-kurak/updates-reload-issue + patch-package

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
