### PR TITLE
[expo-updates][docs] Document native debugging of updates

### DIFF
--- a/docs/pages/bare/updating-your-app.mdx
+++ b/docs/pages/bare/updating-your-app.mdx
@@ -92,7 +92,7 @@ If your project is not using EAS Build or you are creating release builds with e
 In **AndroidManifest.xml**, you'll need to add the following, replacing `your-channel-name` with the channel that matches your project:
 
 ```xml
-<meta-data android:name="expo.modules.updates.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY" android:value="{'expo-channel-name':'your-channel-name'}"/>
+<meta-data android:name="expo.modules.updates.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY" android:value="{&quot;expo-channel-name&quot;:&quot;your-channel-name&quot;}"/>
 ```
 
 In **Expo.plist**, you'll need to add the following, replacing `your-channel-name` with the channel that matches your project:

--- a/docs/pages/eas-update/debug-updates.mdx
+++ b/docs/pages/eas-update/debug-updates.mdx
@@ -263,6 +263,74 @@ It may be helpful to see which assets are included in our update bundle. We can 
 
 <Terminal cmd={['$ npx expo export']} />
 
+### Debugging of native code in an app enabled for updates
+
+Normally, if we have a project with `expo-updates` installed, we need to make a release build for `expo-updates` to be enabled (debug builds behave like normal RN project debug builds).
+
+To make it easier to test and debug native code, we can follow these steps to create a debug build of the app with expo-updates enabled.
+
+#### iOS local builds
+
+- Set the environment variable
+```sh
+export EX_UPDATES_NATIVE_DEBUG=1
+```
+- Reinstall pods with `pod install` or `npx pod-install`. The `expo-updates` podspec now detects this environment variable, and makes changes so that the debug code that would normally load from the Metro packager is bypassed, and the app is built with the EXUpdates bundle and other dependencies needed to load updates from EAS.
+- Execute a debug build of the app with Xcode or from the command line.
+
+#### Android local builds
+
+- As above in the iOS build, set the environment variable
+```sh
+export EX_UPDATES_NATIVE_DEBUG=1
+```
+- Modify your app's `AndroidManifest.xml` to select a channel for which this app will receive updates, as in the example below. (In an EAS build, this value is set automatically to the channel for the EAS profile being built.)
+```diff
+diff --git a/android/app/src/main/AndroidManifest.xml b/android/app/src/main/AndroidManifest.xml
+index 143fa2d..36d5af2 100644
+--- a/android/app/src/main/AndroidManifest.xml
++++ b/android/app/src/main/AndroidManifest.xml
+@@ -17,6 +17,7 @@
+     <meta-data android:name="expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH" android:value="ALWAYS"/>
+     <meta-data android:name="expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS" android:value="0"/>
+     <meta-data android:name="expo.modules.updates.EXPO_RUNTIME_VERSION" android:value="1.0.0"/>
++    <meta-data android:name="expo.modules.updates.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY" android:value="{&quot;expo-channel-name&quot;:&quot;previewdebug&quot;}" />
+     <activity android:name=".MainActivity" android:label="@string/app_name" android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode" android:launchMode="singleTask" android:windowSoftInputMode="adjustResize" android:theme="@style/Theme.App.SplashScreen" android:exported="true">
+       <intent-filter>
+         <action android:name="android.intent.action.MAIN"/>
+```
+- Execute a debug build of the app with Android Studio or from the command line.
+
+#### EAS builds
+
+Alternatively, we can use EAS to create a debug build where `expo-updates` is enabled. The environment variable is set in `eas.json`, as in the example below:
+```json
+{
+  "cli": {
+    "version": ">= 2.1.0"
+  },
+  "build": {
+    "previewdebug": {
+      "env": {
+        "EX_UPDATES_NATIVE_DEBUG": "1"
+      },
+      "distribution": "internal",
+      "android": {
+        "buildType": "apk",
+        "gradleCommand": ":app:assembleDebug"
+      },
+      "channel": "previewdebug"
+    },
+    "production": {}
+  },
+  "submit": {
+    "production": {}
+  }
+}
+```
+
+
+
 ## Mitigation steps
 
 Once we've found the root cause of the issue, there are various mitigation steps we might want to take. One of the most common problems is pushing an update that has a bug inside it. When this happens, we can re-publish a previous update to resolve the issue.

--- a/docs/pages/eas-update/debug-updates.mdx
+++ b/docs/pages/eas-update/debug-updates.mdx
@@ -265,26 +265,26 @@ It may be helpful to see which assets are included in our update bundle. We can 
 
 ### Debugging of native code in an app enabled for updates
 
-Normally, if we have a project with `expo-updates` installed, we need to make a release build for `expo-updates` to be enabled (debug builds behave like normal RN project debug builds).
+Normally, if we have a project with `expo-updates` installed, we need to make a release build for `expo-updates` to be enabled (debug builds behave like normal React Native project debug builds).
 
-To make it easier to test and debug native code, we can follow these steps to create a debug build of the app with expo-updates enabled.
+To make it easier to test and debug native code, follow the steps below to create a debug build of the app with `expo-updates` enabled.
 
 #### iOS local builds
 
-- Set the environment variable
+- Set the environment variable:
 ```sh
 export EX_UPDATES_NATIVE_DEBUG=1
 ```
-- Reinstall pods with `pod install` or `npx pod-install`. The `expo-updates` podspec now detects this environment variable, and makes changes so that the debug code that would normally load from the Metro packager is bypassed, and the app is built with the EXUpdates bundle and other dependencies needed to load updates from EAS.
-- Execute a debug build of the app with Xcode or from the command line.
+- Reinstall pods with `npx pod-install`. The `expo-updates` podspec now detects this environment variable, and makes changes so that the debug code that would normally load from the Metro packager is bypassed, and the app is built with the EXUpdates bundle and other dependencies needed to load updates from EAS.
+- Execute a [debug build](/workflow/debugging/#native-debugging) of the app with Xcode or from the command line.
 
 #### Android local builds
 
-- As above in the iOS build, set the environment variable
+- As similar to the iOS build, set the environment variable:
 ```sh
 export EX_UPDATES_NATIVE_DEBUG=1
 ```
-- Modify your app's `AndroidManifest.xml` to select a channel for which this app will receive updates, as in the example below. (In an EAS build, this value is set automatically to the channel for the EAS profile being built.)
+- Modify your app's **AndroidManifest.xml** to select a channel for which this app will receive updates, as in the example below. (In an EAS build, this value is set automatically to the channel for the EAS profile being built.)
 ```diff
 diff --git a/android/app/src/main/AndroidManifest.xml b/android/app/src/main/AndroidManifest.xml
 index 143fa2d..36d5af2 100644
@@ -299,11 +299,11 @@ index 143fa2d..36d5af2 100644
        <intent-filter>
          <action android:name="android.intent.action.MAIN"/>
 ```
-- Execute a debug build of the app with Android Studio or from the command line.
+- Execute a [debug build](/workflow/debugging/#native-debugging) of the app with Android Studio or from the command line.
 
 #### EAS builds
 
-Alternatively, we can use EAS to create a debug build where `expo-updates` is enabled. The environment variable is set in `eas.json`, as in the example below:
+Alternatively, we can use EAS to create a debug build where `expo-updates` is enabled. The environment variable is set in **eas.json**, as shown in the example below:
 ```json
 {
   "cli": {

--- a/docs/pages/eas-update/debug-updates.mdx
+++ b/docs/pages/eas-update/debug-updates.mdx
@@ -263,73 +263,50 @@ It may be helpful to see which assets are included in our update bundle. We can 
 
 <Terminal cmd={['$ npx expo export']} />
 
-### Debugging of native code in an app enabled for updates
+### Debugging of native code while loading the app through expo-updates
 
-Normally, if we have a project with `expo-updates` installed, we need to make a release build for `expo-updates` to be enabled (debug builds behave like normal React Native project debug builds).
+By default, we need to make a release build for `expo-updates` to be enabled and to load updates rather than reading from a development server. This is because debug builds behave like normal React Native project debug builds.
 
-To make it easier to test and debug native code, follow the steps below to create a debug build of the app with `expo-updates` enabled.
+To make it easier to test and debug native code in an environment that is closer to production, follow the steps below to create a debug build of the app with `expo-updates` enabled.
 
 #### iOS local builds
 
-- Set the environment variable:
-```sh
-export EX_UPDATES_NATIVE_DEBUG=1
-```
+- Set the debug environment variable: `export EX_UPDATES_NATIVE_DEBUG=1`
 - Reinstall pods with `npx pod-install`. The `expo-updates` podspec now detects this environment variable, and makes changes so that the debug code that would normally load from the Metro packager is bypassed, and the app is built with the EXUpdates bundle and other dependencies needed to load updates from EAS.
+- [Ensure the desired channel is set in your **Expo.plist**](/bare/updating-your-app/#configuring-the-channel-manually)
 - Execute a [debug build](/workflow/debugging/#native-debugging) of the app with Xcode or from the command line.
 
 #### Android local builds
 
-- As similar to the iOS build, set the environment variable:
-```sh
-export EX_UPDATES_NATIVE_DEBUG=1
-```
-- Modify your app's **AndroidManifest.xml** to select a channel for which this app will receive updates, as in the example below. (In an EAS build, this value is set automatically to the channel for the EAS profile being built.)
-```diff
-diff --git a/android/app/src/main/AndroidManifest.xml b/android/app/src/main/AndroidManifest.xml
-index 143fa2d..36d5af2 100644
---- a/android/app/src/main/AndroidManifest.xml
-+++ b/android/app/src/main/AndroidManifest.xml
-@@ -17,6 +17,7 @@
-     <meta-data android:name="expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH" android:value="ALWAYS"/>
-     <meta-data android:name="expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS" android:value="0"/>
-     <meta-data android:name="expo.modules.updates.EXPO_RUNTIME_VERSION" android:value="1.0.0"/>
-+    <meta-data android:name="expo.modules.updates.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY" android:value="{&quot;expo-channel-name&quot;:&quot;previewdebug&quot;}" />
-     <activity android:name=".MainActivity" android:label="@string/app_name" android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode" android:launchMode="singleTask" android:windowSoftInputMode="adjustResize" android:theme="@style/Theme.App.SplashScreen" android:exported="true">
-       <intent-filter>
-         <action android:name="android.intent.action.MAIN"/>
-```
+- Set the debug environment variable: `export EX_UPDATES_NATIVE_DEBUG=1`
+- [Ensure the desired channel is set in your **AndroidManifest.xml**](/bare/updating-your-app/#configuring-the-channel-manually)
 - Execute a [debug build](/workflow/debugging/#native-debugging) of the app with Android Studio or from the command line.
 
-#### EAS builds
+#### EAS Build
 
 Alternatively, we can use EAS to create a debug build where `expo-updates` is enabled. The environment variable is set in **eas.json**, as shown in the example below:
+
 ```json
 {
-  "cli": {
-    "version": ">= 2.1.0"
-  },
   "build": {
-    "previewdebug": {
+    "preview_debug": {
       "env": {
         "EX_UPDATES_NATIVE_DEBUG": "1"
       },
-      "distribution": "internal",
       "android": {
-        "buildType": "apk",
+        "distribution": "internal",
+        "withoutCredentials": true,
         "gradleCommand": ":app:assembleDebug"
       },
-      "channel": "previewdebug"
-    },
-    "production": {}
-  },
-  "submit": {
-    "production": {}
+      "ios": {
+        "simulator": true,
+        "buildConfiguration": "Debug"
+      },
+      "channel": "preview_debug"
+    }
   }
 }
 ```
-
-
 
 ## Mitigation steps
 

--- a/docs/pages/versions/unversioned/sdk/updates.mdx
+++ b/docs/pages/versions/unversioned/sdk/updates.mdx
@@ -18,9 +18,7 @@ The expo-updates library allows you to programmatically control and respond to n
 
 ## Usage
 
-Most of the methods and constants in this module can only be used or tested in release mode; they do not make sense in debug builds where you always load the latest JavaScript from your computer while in development.
-
-> **info** It is possible to [build a debug version of your app where all these methods can be used](/eas-update/debug-updates/#debugging-of-native-code-in-an-app), but such an app will not open the latest JavaScript from your computer &mdash; it will load published updates just as a release build would.
+Most of the methods and constants in this module can only be used or tested in release mode. In debug builds, the default behavior is to always load the latest JavaScript from a development server. It is possible to [build a debug version of your app with the same updates behavior as a release build](/eas-update/debug-updates/#debugging-of-native-code-in-an-app). Such an app will not open the latest JavaScript from your development server &mdash; it will load published updates just as a release build does. This may be useful for debugging the behavior of your app when it is not connected to a development server.
 
 **To test manual updates in the Expo Go app**, run [`eas update`](/eas-update/introduction) and then open the published version of your app with Expo Go.
 

--- a/docs/pages/versions/unversioned/sdk/updates.mdx
+++ b/docs/pages/versions/unversioned/sdk/updates.mdx
@@ -20,7 +20,7 @@ The expo-updates library allows you to programmatically control and respond to n
 
 Most of the methods and constants in this module can only be used or tested in release mode; they do not make sense in debug builds where you always load the latest JavaScript from your computer while in development.
 
-(It is possible to [build a debug version of your app where all these methods can be used](/eas-update/debug-updates/#debugging-of-native-code-in-an-app), but such an app will not open the latest JavaScript from your computer -- it will load published updates just as a release build would.)
+> **info** It is possible to [build a debug version of your app where all these methods can be used](/eas-update/debug-updates/#debugging-of-native-code-in-an-app), but such an app will not open the latest JavaScript from your computer &mdash; it will load published updates just as a release build would.
 
 **To test manual updates in the Expo Go app**, run [`eas update`](/eas-update/introduction) and then open the published version of your app with Expo Go.
 

--- a/docs/pages/versions/unversioned/sdk/updates.mdx
+++ b/docs/pages/versions/unversioned/sdk/updates.mdx
@@ -20,6 +20,8 @@ The expo-updates library allows you to programmatically control and respond to n
 
 Most of the methods and constants in this module can only be used or tested in release mode; they do not make sense in debug builds where you always load the latest JavaScript from your computer while in development.
 
+(It is possible to [build a debug version of your app where all these methods can be used](/eas-update/debug-updates/#debugging-of-native-code-in-an-app), but such an app will not open the latest JavaScript from your computer -- it will load published updates just as a release build would.)
+
 **To test manual updates in the Expo Go app**, run [`eas update`](/eas-update/introduction) and then open the published version of your app with Expo Go.
 
 **To test manual updates with standalone apps**, you can create a [simulator build](/build-reference/simulators.mdx) or [APK](/build-reference/apk.mdx), or make a release build locally with `npx expo run:ios --configuration Release` and `npx expo run:android --variant release` (you don't need to submit this build to the store to test).


### PR DESCRIPTION
# Why

Docs for the features added in #19292 and #19441 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
