### PR TITLE
[modules][ios] Introduce view lifecycle methods

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Implemented a mechanism for hooking into to the view lifecycle events (introduces new `OnViewDidUpdateProps` definition component). ([#19549](https://github.com/expo/expo/pull/19549) by [@tsapeta](https://github.com/tsapeta))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-modules-core/ios/Fabric/ExpoFabricView.swift
+++ b/packages/expo-modules-core/ios/Fabric/ExpoFabricView.swift
@@ -66,6 +66,16 @@ public class ExpoFabricView: ExpoFabricViewObjC {
   }
 
   /**
+   Calls lifecycle methods registered by `OnViewDidUpdateProps` definition component.
+   */
+  public override func viewDidUpdateProps() {
+    guard let view = contentView, let viewManager = moduleHolder?.definition.viewManager else {
+      return
+    }
+    viewManager.callLifecycleMethods(withType: .didUpdateProps, forView: view)
+  }
+
+  /**
    The function that is called by Fabric when the view is unmounted and is being enqueued for recycling.
    It can also be called on app reload, so be careful to wipe out any dependencies specific to the currently running AppContext.
    */

--- a/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.h
+++ b/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.h
@@ -35,6 +35,8 @@
 
 - (void)updateProp:(nonnull NSString *)propName withValue:(nonnull id)value;
 
+- (void)viewDidUpdateProps;
+
 - (void)prepareForRecycle;
 
 #pragma mark - Methods injected to the class in runtime

--- a/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.mm
+++ b/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.mm
@@ -150,6 +150,7 @@ static std::unordered_map<std::string, ExpoViewComponentDescriptor::Flavor> _com
   }
 
   [super updateProps:props oldProps:oldProps];
+  [self viewDidUpdateProps];
 }
 
 - (void)updateEventEmitter:(const react::EventEmitter::Shared &)eventEmitter
@@ -170,6 +171,11 @@ static std::unordered_map<std::string, ExpoViewComponentDescriptor::Flavor> _com
 #pragma mark - Methods to override in Swift
 
 - (void)updateProp:(nonnull NSString *)propName withValue:(nonnull id)value
+{
+  // Implemented in `ExpoFabricView.swift`
+}
+
+- (void)viewDidUpdateProps
 {
   // Implemented in `ExpoFabricView.swift`
 }

--- a/packages/expo-modules-core/ios/Swift/Views/ViewDefinition.swift
+++ b/packages/expo-modules-core/ios/Swift/Views/ViewDefinition.swift
@@ -45,12 +45,20 @@ public final class ViewDefinition<ViewType: UIView>: ViewManagerDefinition {
     public static func buildExpression<PropType: AnyArgument>(_ element: ConcreteViewProp<ViewType, PropType>) -> AnyViewDefinitionElement {
       return element
     }
+
+    /**
+     Accepts lifecycle methods (such as `OnViewDidUpdateProps`) as a definition element.
+     */
+    public static func buildExpression(_ element: ViewLifecycleMethod<ViewType>) -> AnyViewDefinitionElement {
+      return element
+    }
   }
 }
 
 public protocol AnyViewDefinitionElement: AnyDefinition {}
 extension ConcreteViewProp: AnyViewDefinitionElement {}
 extension EventsDefinition: AnyViewDefinitionElement {}
+extension ViewLifecycleMethod: AnyViewDefinitionElement {}
 
 /**
  Creates a view definition describing the native view exported to React.

--- a/packages/expo-modules-core/ios/Swift/Views/ViewLifecycleMethod.swift
+++ b/packages/expo-modules-core/ios/Swift/Views/ViewLifecycleMethod.swift
@@ -1,0 +1,48 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+/**
+ An enum that identifies lifecycle method types.
+ */
+internal enum ViewLifecycleMethodType {
+  case didUpdateProps
+}
+
+/**
+ Type-erased protocol for all view lifecycle methods.
+ */
+internal protocol AnyViewLifecycleMethod: AnyDefinition {
+  /**
+   Type of the lifecycle method.
+   */
+  var type: ViewLifecycleMethodType { get }
+
+  /**
+   Calls the lifecycle method for the given view.
+   */
+  func callAsFunction(_ view: UIView)
+}
+
+/**
+ Element of the view definition that represents a lifecycle method, such as `OnViewDidUpdateProps`.
+ */
+public final class ViewLifecycleMethod<ViewType: UIView>: AnyViewLifecycleMethod {
+  /**
+   The actual closure that gets called when the view signals an event in view's lifecycle.
+   */
+  let closure: (ViewType) -> Void
+
+  let type: ViewLifecycleMethodType
+
+  init(type: ViewLifecycleMethodType, closure: @escaping (ViewType) -> Void) {
+    self.type = type
+    self.closure = closure
+  }
+
+  func callAsFunction(_ view: UIView) {
+    guard let view = view as? ViewType else {
+      log.warn("Cannot call lifecycle method '\(type)', given view is not of type '\(ViewType.self)'")
+      return
+    }
+    closure(view)
+  }
+}

--- a/packages/expo-modules-core/ios/Swift/Views/ViewManagerDefinition.swift
+++ b/packages/expo-modules-core/ios/Swift/Views/ViewManagerDefinition.swift
@@ -20,6 +20,11 @@ public class ViewManagerDefinition: ObjectDefinition {
   let eventNames: [String]
 
   /**
+   An array of the view lifecycle methods.
+   */
+  let lifecycleMethods: [AnyViewLifecycleMethod]
+
+  /**
    Default initializer receiving children definitions from the result builder.
    */
   override init(definitions: [AnyDefinition]) {
@@ -35,6 +40,9 @@ public class ViewManagerDefinition: ObjectDefinition {
         .compactMap { ($0 as? EventsDefinition)?.names }
         .joined()
     )
+
+    self.lifecycleMethods = definitions
+      .compactMap { $0 as? AnyViewLifecycleMethod }
 
     super.init(definitions: definitions)
   }
@@ -52,6 +60,15 @@ public class ViewManagerDefinition: ObjectDefinition {
   func propsDict() -> [String: AnyViewProp] {
     return props.reduce(into: [String: AnyViewProp]()) { acc, prop in
       acc[prop.name] = prop
+    }
+  }
+
+  /**
+   Calls defined lifecycle methods with the given type.
+   */
+  func callLifecycleMethods(withType type: ViewLifecycleMethodType, forView view: UIView) {
+    for method in lifecycleMethods where method.type == type {
+      method(view)
     }
   }
 }

--- a/packages/expo-modules-core/ios/Swift/Views/ViewManagerDefinitionComponents.swift
+++ b/packages/expo-modules-core/ios/Swift/Views/ViewManagerDefinitionComponents.swift
@@ -24,3 +24,14 @@ public func Prop<ViewType: UIView, PropType: AnyArgument>(
     setter: setter
   )
 }
+
+// MARK: - View lifecycle
+
+/**
+ Defines the view lifecycle method that is called when the view finished updating all props.
+ */
+public func OnViewDidUpdateProps<ViewType: UIView>(
+  @_implicitSelfCapture _ closure: @escaping (_ view: ViewType) -> Void
+) -> ViewLifecycleMethod<ViewType> {
+  return ViewLifecycleMethod(type: .didUpdateProps, closure: closure)
+}

--- a/packages/expo-modules-core/ios/Swift/Views/ViewModuleWrapper.swift
+++ b/packages/expo-modules-core/ios/Swift/Views/ViewModuleWrapper.swift
@@ -104,10 +104,11 @@ public final class ViewModuleWrapper: RCTViewManager, DynamicModuleWrapperProtoc
    */
   @objc
   public func set_proxiedProperties(_ json: Any, forView view: UIView, withDefaultView defaultView: UIView) {
-    guard let json = json as? [String: Any],
-          let props = wrappedModuleHolder.definition.viewManager?.propsDict() else {
+    guard let json = json as? [String: Any], let viewManager = wrappedModuleHolder.definition.viewManager else {
       return
     }
+    let props = viewManager.propsDict()
+
     for (key, value) in json {
       if let prop = props[key] {
         let value = Conversions.fromNSObject(value)
@@ -118,6 +119,7 @@ public final class ViewModuleWrapper: RCTViewManager, DynamicModuleWrapperProtoc
         try? prop.set(value: value, onView: view)
       }
     }
+    viewManager.callLifecycleMethods(withType: .didUpdateProps, forView: view)
   }
 
   public static let viewManagerAdapterPrefix = "ViewManagerAdapter_"


### PR DESCRIPTION
# Why

Another missing piece in the view definition is the ability to react to some view lifecycle events, such as when all the props finished updating or when the view is mounted/unmounted/recycled.

# How

- Added a mechanism to hook into the view lifecycle events from the view definition (for both Paper and Fabric)
- Added `OnViewDidUpdateProps` as the first hook

# Test Plan

Tested in bare-expo with `OnViewDidUpdateProps` added to the definition of `LinearGradientModule`

# Future

My propositions to add in the future:
- `OnViewDidMount`
- `OnViewWillUnmount`
- `OnViewDidMountChild`
- `OnViewDidUnmountChild`
- `OnViewWillRecycle` (Fabric only)