### PR TITLE
[modules][Android] Fix records & enums in the release builds

### DIFF
--- a/docs/pages/modules/module-api.mdx
+++ b/docs/pages/modules/module-api.mdx
@@ -430,7 +430,7 @@ struct FileReadOptions: Record {
 
 ```kotlin
 // Note: the constructor must have an argument called value.
-enum class FileEncoding(val value: String) {
+enum class FileEncoding(val value: String) : EnumArgument {
   utf8("utf8"),
   base64("base64")
 }

--- a/packages/expo-battery/android/src/main/java/expo/modules/battery/BatteryModule.kt
+++ b/packages/expo-battery/android/src/main/java/expo/modules/battery/BatteryModule.kt
@@ -12,11 +12,12 @@ import expo.modules.core.Promise
 import expo.modules.core.interfaces.ExpoMethod
 import expo.modules.core.interfaces.RegistryLifecycleListener
 import expo.modules.core.interfaces.services.EventEmitter
+import expo.modules.kotlin.types.EnumArgument
 
 class BatteryModule(context: Context) : ExportedModule(context), RegistryLifecycleListener {
   private val NAME = "ExpoBattery"
 
-  enum class BatteryState(val value: Int) {
+  enum class BatteryState(val value: Int) : EnumArgument {
     UNKNOWN(0), UNPLUGGED(1), CHARGING(2), FULL(3);
   }
 

--- a/packages/expo-battery/android/src/main/java/expo/modules/battery/BatteryModule.kt
+++ b/packages/expo-battery/android/src/main/java/expo/modules/battery/BatteryModule.kt
@@ -12,12 +12,12 @@ import expo.modules.core.Promise
 import expo.modules.core.interfaces.ExpoMethod
 import expo.modules.core.interfaces.RegistryLifecycleListener
 import expo.modules.core.interfaces.services.EventEmitter
-import expo.modules.kotlin.types.EnumArgument
+import expo.modules.kotlin.types.Enumerable
 
 class BatteryModule(context: Context) : ExportedModule(context), RegistryLifecycleListener {
   private val NAME = "ExpoBattery"
 
-  enum class BatteryState(val value: Int) : EnumArgument {
+  enum class BatteryState(val value: Int) : Enumerable {
     UNKNOWN(0), UNPLUGGED(1), CHARGING(2), FULL(3);
   }
 

--- a/packages/expo-cellular/android/src/main/java/expo/modules/cellular/CellularGeneration.kt
+++ b/packages/expo-cellular/android/src/main/java/expo/modules/cellular/CellularGeneration.kt
@@ -1,6 +1,8 @@
 package expo.modules.cellular
 
-enum class CellularGeneration(val value: Int) {
+import expo.modules.kotlin.types.EnumArgument
+
+enum class CellularGeneration(val value: Int) : EnumArgument {
   UNKNOWN(0),
   CG_2G(1),
   CG_3G(2),

--- a/packages/expo-cellular/android/src/main/java/expo/modules/cellular/CellularGeneration.kt
+++ b/packages/expo-cellular/android/src/main/java/expo/modules/cellular/CellularGeneration.kt
@@ -1,8 +1,8 @@
 package expo.modules.cellular
 
-import expo.modules.kotlin.types.EnumArgument
+import expo.modules.kotlin.types.Enumerable
 
-enum class CellularGeneration(val value: Int) : EnumArgument {
+enum class CellularGeneration(val value: Int) : Enumerable {
   UNKNOWN(0),
   CG_2G(1),
   CG_3G(2),

--- a/packages/expo-crypto/android/src/main/java/expo/modules/crypto/DigestAlgorithm.kt
+++ b/packages/expo-crypto/android/src/main/java/expo/modules/crypto/DigestAlgorithm.kt
@@ -1,6 +1,8 @@
 package expo.modules.crypto
 
-enum class DigestAlgorithm(val value: String) {
+import expo.modules.kotlin.types.EnumArgument
+
+enum class DigestAlgorithm(val value: String) : EnumArgument {
   MD5("MD5"),
   SHA1("SHA-1"),
   SHA256("SHA-256"),

--- a/packages/expo-crypto/android/src/main/java/expo/modules/crypto/DigestAlgorithm.kt
+++ b/packages/expo-crypto/android/src/main/java/expo/modules/crypto/DigestAlgorithm.kt
@@ -1,8 +1,8 @@
 package expo.modules.crypto
 
-import expo.modules.kotlin.types.EnumArgument
+import expo.modules.kotlin.types.Enumerable
 
-enum class DigestAlgorithm(val value: String) : EnumArgument {
+enum class DigestAlgorithm(val value: String) : Enumerable {
   MD5("MD5"),
   SHA1("SHA-1"),
   SHA256("SHA-256"),

--- a/packages/expo-crypto/android/src/main/java/expo/modules/crypto/DigestOptions.kt
+++ b/packages/expo-crypto/android/src/main/java/expo/modules/crypto/DigestOptions.kt
@@ -2,13 +2,13 @@ package expo.modules.crypto
 
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
-import expo.modules.kotlin.types.EnumArgument
+import expo.modules.kotlin.types.Enumerable
 
 class DigestOptions : Record {
   @Field
   var encoding: Encoding = Encoding.HEX
 
-  enum class Encoding(val value: String) : EnumArgument {
+  enum class Encoding(val value: String) : Enumerable {
     HEX("hex"),
     BASE64("base64")
   }

--- a/packages/expo-crypto/android/src/main/java/expo/modules/crypto/DigestOptions.kt
+++ b/packages/expo-crypto/android/src/main/java/expo/modules/crypto/DigestOptions.kt
@@ -2,12 +2,13 @@ package expo.modules.crypto
 
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.types.EnumArgument
 
 class DigestOptions : Record {
   @Field
   var encoding: Encoding = Encoding.HEX
 
-  enum class Encoding(val value: String) {
+  enum class Encoding(val value: String) : EnumArgument {
     HEX("hex"),
     BASE64("base64")
   }

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
@@ -4,8 +4,8 @@ import android.Manifest
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
-import expo.modules.core.errors.ModuleNotFoundException
 import android.os.OperationCanceledException
+import expo.modules.core.errors.ModuleNotFoundException
 import expo.modules.imagepicker.contracts.CameraContract
 import expo.modules.imagepicker.contracts.CameraContractOptions
 import expo.modules.imagepicker.contracts.CropImageContract
@@ -21,7 +21,6 @@ import expo.modules.kotlin.functions.Coroutine
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.resume

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerOptions.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerOptions.kt
@@ -9,7 +9,7 @@ import expo.modules.imagepicker.contracts.CameraContractOptions
 import expo.modules.imagepicker.contracts.ImageLibraryContractOptions
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
-import expo.modules.kotlin.types.EnumArgument
+import expo.modules.kotlin.types.Enumerable
 
 internal class ImagePickerOptions : Record, Serializable {
   @Field
@@ -42,7 +42,7 @@ internal class ImagePickerOptions : Record, Serializable {
   fun toImageLibraryContractOptions() = ImageLibraryContractOptions(this)
 }
 
-internal enum class MediaTypes(val value: String) : EnumArgument {
+internal enum class MediaTypes(val value: String) : Enumerable {
   IMAGES("Images"),
   VIDEOS("Videos"),
   ALL("All");

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerOptions.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerOptions.kt
@@ -9,6 +9,7 @@ import expo.modules.imagepicker.contracts.CameraContractOptions
 import expo.modules.imagepicker.contracts.ImageLibraryContractOptions
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.types.EnumArgument
 
 internal class ImagePickerOptions : Record, Serializable {
   @Field
@@ -41,7 +42,7 @@ internal class ImagePickerOptions : Record, Serializable {
   fun toImageLibraryContractOptions() = ImageLibraryContractOptions(this)
 }
 
-internal enum class MediaTypes(val value: String) {
+internal enum class MediaTypes(val value: String) : EnumArgument {
   IMAGES("Images"),
   VIDEOS("Videos"),
   ALL("All");

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerResponse.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerResponse.kt
@@ -3,7 +3,7 @@ package expo.modules.imagepicker
 import android.os.Bundle
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
-import expo.modules.kotlin.types.EnumArgument
+import expo.modules.kotlin.types.Enumerable
 
 internal class ImagePickerCancelledResponse : Record {
   @Field
@@ -48,7 +48,7 @@ internal sealed class ImagePickerResponse : Record {
   ) : ImagePickerResponse()
 }
 
-enum class MediaType(val value: String) : EnumArgument {
+enum class MediaType(val value: String) : Enumerable {
   VIDEO("video"),
   IMAGE("image"),
 }

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerResponse.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerResponse.kt
@@ -3,6 +3,7 @@ package expo.modules.imagepicker
 import android.os.Bundle
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.types.EnumArgument
 
 internal class ImagePickerCancelledResponse : Record {
   @Field
@@ -47,7 +48,7 @@ internal sealed class ImagePickerResponse : Record {
   ) : ImagePickerResponse()
 }
 
-enum class MediaType(val value: String) {
+enum class MediaType(val value: String) : EnumArgument {
   VIDEO("video"),
   IMAGE("image"),
 }

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed records aren't correctly converted to js objects in the release builds on Android.
+- Fixed records aren't correctly converted to JS objects in the release builds on Android. ([#19551](https://github.com/expo/expo/pull/19551) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🛠 Breaking changes
 
-- Convertible enums must inherit from `expo.modules.kotlin.types.EnumArgument` on Android.
+- Convertible enums must inherit from `expo.modules.kotlin.types.Enumerable` on Android.
 
 ### 🎉 New features
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -4,9 +4,13 @@
 
 ### 🛠 Breaking changes
 
+- Convertible enums must inherit from `expo.modules.kotlin.types.EnumArgument` on Android.
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes
+
+- Fixed records aren't correctly converted to js objects in the release builds on Android.
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/proguard-rules.pro
+++ b/packages/expo-modules-core/android/proguard-rules.pro
@@ -11,3 +11,11 @@
 -keepclassmembers class * {
   @expo.modules.core.interfaces.DoNotStrip *;
 }
+
+-keep class * implements expo.modules.kotlin.records.Record {
+  *;
+}
+
+keepclassmembers enum * implements expo.modules.kotlin.records.EnumArgument { 
+  *; 
+}

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIAsyncFunctionsTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIAsyncFunctionsTest.kt
@@ -6,20 +6,21 @@ import com.google.common.truth.Truth
 import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.types.EnumArgument
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Assert
 import org.junit.Test
 
 class JSIAsyncFunctionsTest {
-  enum class SimpleEnumClass {
+  enum class SimpleEnumClass : EnumArgument {
     V1, V2
   }
 
-  enum class StringEnumClass(val value: String) {
+  enum class StringEnumClass(val value: String) : EnumArgument {
     K1("V1"), K2("V2")
   }
 
-  enum class IntEnumClass(val value: Int) {
+  enum class IntEnumClass(val value: Int) : EnumArgument {
     K1(1), K2(2)
   }
 

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIAsyncFunctionsTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIAsyncFunctionsTest.kt
@@ -6,21 +6,21 @@ import com.google.common.truth.Truth
 import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
-import expo.modules.kotlin.types.EnumArgument
+import expo.modules.kotlin.types.Enumerable
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Assert
 import org.junit.Test
 
 class JSIAsyncFunctionsTest {
-  enum class SimpleEnumClass : EnumArgument {
+  enum class SimpleEnumClass : Enumerable {
     V1, V2
   }
 
-  enum class StringEnumClass(val value: String) : EnumArgument {
+  enum class StringEnumClass(val value: String) : Enumerable {
     K1("V1"), K2("V2")
   }
 
-  enum class IntEnumClass(val value: Int) : EnumArgument {
+  enum class IntEnumClass(val value: Int) : Enumerable {
     K1(1), K2(2)
   }
 

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIFunctionsTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIFunctionsTest.kt
@@ -11,19 +11,20 @@ import expo.modules.kotlin.typedarray.Float32Array
 import expo.modules.kotlin.typedarray.Int32Array
 import expo.modules.kotlin.typedarray.Int8Array
 import expo.modules.kotlin.types.Either
+import expo.modules.kotlin.types.EnumArgument
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Test
 
 class JSIFunctionsTest {
-  enum class SimpleEnumClass {
+  enum class SimpleEnumClass : EnumArgument {
     V1, V2
   }
 
-  enum class StringEnumClass(val value: String) {
+  enum class StringEnumClass(val value: String) : EnumArgument {
     K1("V1"), K2("V2")
   }
 
-  enum class IntEnumClass(val value: Int) {
+  enum class IntEnumClass(val value: Int) : EnumArgument {
     K1(1), K2(2)
   }
 

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIFunctionsTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIFunctionsTest.kt
@@ -11,20 +11,20 @@ import expo.modules.kotlin.typedarray.Float32Array
 import expo.modules.kotlin.typedarray.Int32Array
 import expo.modules.kotlin.typedarray.Int8Array
 import expo.modules.kotlin.types.Either
-import expo.modules.kotlin.types.EnumArgument
+import expo.modules.kotlin.types.Enumerable
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Test
 
 class JSIFunctionsTest {
-  enum class SimpleEnumClass : EnumArgument {
+  enum class SimpleEnumClass : Enumerable {
     V1, V2
   }
 
-  enum class StringEnumClass(val value: String) : EnumArgument {
+  enum class StringEnumClass(val value: String) : Enumerable {
     K1("V1"), K2("V2")
   }
 
-  enum class IntEnumClass(val value: Int) : EnumArgument {
+  enum class IntEnumClass(val value: Int) : Enumerable {
     K1(1), K2(2)
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EnumArgument.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EnumArgument.kt
@@ -1,0 +1,9 @@
+package expo.modules.kotlin.types
+
+import expo.modules.core.interfaces.DoNotStrip
+
+/**
+ * A interface that allows converting raw values to enum cases.
+ */
+@DoNotStrip
+interface EnumArgument

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EnumTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EnumTypeConverter.kt
@@ -3,10 +3,12 @@ package expo.modules.kotlin.types
 import com.facebook.react.bridge.Dynamic
 import expo.modules.kotlin.exception.IncompatibleArgTypeException
 import expo.modules.kotlin.jni.ExpectedType
+import expo.modules.kotlin.logger
 import expo.modules.kotlin.toKType
 import kotlin.reflect.KClass
 import kotlin.reflect.full.createType
 import kotlin.reflect.full.declaredMemberProperties
+import kotlin.reflect.full.isSubclassOf
 import kotlin.reflect.full.primaryConstructor
 
 class EnumTypeConverter(
@@ -23,6 +25,12 @@ class EnumTypeConverter(
 
   private val primaryConstructor = requireNotNull(enumClass.primaryConstructor) {
     "Cannot convert js value to enum without the primary constructor"
+  }
+
+  init {
+    if (!enumClass.isSubclassOf(EnumArgument::class)) {
+      logger.warn("Enum '${enumClass}' should inherit from ${EnumArgument::class}.")
+    }
   }
 
   override fun getCppRequiredTypes(): ExpectedType = ExpectedType.forEnum()

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EnumTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EnumTypeConverter.kt
@@ -28,8 +28,8 @@ class EnumTypeConverter(
   }
 
   init {
-    if (!enumClass.isSubclassOf(EnumArgument::class)) {
-      logger.warn("Enum '${enumClass}' should inherit from ${EnumArgument::class}.")
+    if (!enumClass.isSubclassOf(Enumerable::class)) {
+      logger.warn("Enum '$enumClass' should inherit from ${Enumerable::class}.")
     }
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/Enumerable.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/Enumerable.kt
@@ -6,4 +6,4 @@ import expo.modules.core.interfaces.DoNotStrip
  * A interface that allows converting raw values to enum cases.
  */
 @DoNotStrip
-interface EnumArgument
+interface Enumerable

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/records/RecordTypeConverterTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/records/RecordTypeConverterTest.kt
@@ -4,6 +4,7 @@ import com.facebook.react.bridge.DynamicFromObject
 import com.facebook.react.bridge.JavaOnlyArray
 import com.facebook.react.bridge.JavaOnlyMap
 import com.google.common.truth.Truth
+import expo.modules.kotlin.types.EnumArgument
 import expo.modules.kotlin.types.convert
 import org.junit.Test
 
@@ -249,15 +250,15 @@ class RecordTypeConverterTest {
     Truth.assertThat(myRecord.points).isEqualTo(listOf(1.0, 2.0, 3.0))
   }
 
-  enum class EnumWithoutParameter {
+  enum class EnumWithoutParameter : EnumArgument {
     VALUE1, VALUE2, VALUE3
   }
 
-  enum class EnumWithInt(val value: Int) {
+  enum class EnumWithInt(val value: Int) : EnumArgument {
     VALUE1(1), VALUE2(2), VALUE3(3)
   }
 
-  enum class EnumWithString(val value: String) {
+  enum class EnumWithString(val value: String) : EnumArgument {
     VALUE1("value1"), VALUE2("value2"), VALUE3("value3")
   }
 

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/records/RecordTypeConverterTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/records/RecordTypeConverterTest.kt
@@ -4,7 +4,7 @@ import com.facebook.react.bridge.DynamicFromObject
 import com.facebook.react.bridge.JavaOnlyArray
 import com.facebook.react.bridge.JavaOnlyMap
 import com.google.common.truth.Truth
-import expo.modules.kotlin.types.EnumArgument
+import expo.modules.kotlin.types.Enumerable
 import expo.modules.kotlin.types.convert
 import org.junit.Test
 
@@ -250,15 +250,15 @@ class RecordTypeConverterTest {
     Truth.assertThat(myRecord.points).isEqualTo(listOf(1.0, 2.0, 3.0))
   }
 
-  enum class EnumWithoutParameter : EnumArgument {
+  enum class EnumWithoutParameter : Enumerable {
     VALUE1, VALUE2, VALUE3
   }
 
-  enum class EnumWithInt(val value: Int) : EnumArgument {
+  enum class EnumWithInt(val value: Int) : Enumerable {
     VALUE1(1), VALUE2(2), VALUE3(3)
   }
 
-  enum class EnumWithString(val value: String) : EnumArgument {
+  enum class EnumWithString(val value: String) : Enumerable {
     VALUE1("value1"), VALUE2("value2"), VALUE3("value3")
   }
 

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/EnumSerializerTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/EnumSerializerTest.kt
@@ -4,19 +4,19 @@ import com.google.common.truth.Truth
 import org.junit.Test
 
 class EnumSerializerTest {
-  enum class EnumWithoutParameter {
+  enum class EnumWithoutParameter : EnumArgument {
     VALUE1, VALUE2, VALUE3
   }
 
-  enum class EnumWithInt(val value: Int) {
+  enum class EnumWithInt(val value: Int) : EnumArgument {
     VALUE1(1), VALUE2(2), VALUE3(3)
   }
 
-  enum class EnumWithString(val value: String) {
+  enum class EnumWithString(val value: String) : EnumArgument {
     VALUE1("value1"), VALUE2("value2"), VALUE3("value3")
   }
 
-  enum class IncompatibleEnum(val v1: String, val v2: String) {
+  enum class IncompatibleEnum(val v1: String, val v2: String) : EnumArgument {
     SOME_VALUE("hello", "world")
   }
 

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/EnumSerializerTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/EnumSerializerTest.kt
@@ -4,19 +4,19 @@ import com.google.common.truth.Truth
 import org.junit.Test
 
 class EnumSerializerTest {
-  enum class EnumWithoutParameter : EnumArgument {
+  enum class EnumWithoutParameter : Enumerable {
     VALUE1, VALUE2, VALUE3
   }
 
-  enum class EnumWithInt(val value: Int) : EnumArgument {
+  enum class EnumWithInt(val value: Int) : Enumerable {
     VALUE1(1), VALUE2(2), VALUE3(3)
   }
 
-  enum class EnumWithString(val value: String) : EnumArgument {
+  enum class EnumWithString(val value: String) : Enumerable {
     VALUE1("value1"), VALUE2("value2"), VALUE3("value3")
   }
 
-  enum class IncompatibleEnum(val v1: String, val v2: String) : EnumArgument {
+  enum class IncompatibleEnum(val v1: String, val v2: String) : Enumerable {
     SOME_VALUE("hello", "world")
   }
 

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/EnumTypeConverterTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/EnumTypeConverterTest.kt
@@ -5,15 +5,15 @@ import com.google.common.truth.Truth
 import org.junit.Test
 
 class EnumTypeConverterTest {
-  enum class EnumWithoutParameter : EnumArgument {
+  enum class EnumWithoutParameter : Enumerable {
     VALUE1, VALUE2, VALUE3
   }
 
-  enum class EnumWithInt(val value: Int) : EnumArgument {
+  enum class EnumWithInt(val value: Int) : Enumerable {
     VALUE1(1), VALUE2(2), VALUE3(3)
   }
 
-  enum class EnumWithString(val value: String) : EnumArgument {
+  enum class EnumWithString(val value: String) : Enumerable {
     VALUE1("value1"), VALUE2("value2"), VALUE3("value3")
   }
 

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/EnumTypeConverterTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/EnumTypeConverterTest.kt
@@ -5,15 +5,15 @@ import com.google.common.truth.Truth
 import org.junit.Test
 
 class EnumTypeConverterTest {
-  enum class EnumWithoutParameter {
+  enum class EnumWithoutParameter : EnumArgument {
     VALUE1, VALUE2, VALUE3
   }
 
-  enum class EnumWithInt(val value: Int) {
+  enum class EnumWithInt(val value: Int) : EnumArgument {
     VALUE1(1), VALUE2(2), VALUE3(3)
   }
 
-  enum class EnumWithString(val value: String) {
+  enum class EnumWithString(val value: String) : EnumArgument {
     VALUE1("value1"), VALUE2("value2"), VALUE3("value3")
   }
 


### PR DESCRIPTION
# Why

Closes https://github.com/expo/expo/issues/19509.

# How

- Added missing proguard rules for records. 
- Enums classes from now have to inherit from `EnumArgument` class. 
> See https://github.com/expo/expo/issues/19509#issuecomment-1278014932 for more information

# Test Plan

- bare-expo in release build ✅