### PR TITLE
[docs] Update PWA instructions to fix outdated command

### DIFF
--- a/docs/pages/guides/progressive-web-apps.mdx
+++ b/docs/pages/guides/progressive-web-apps.mdx
@@ -36,7 +36,7 @@ The following properties can be used to customize your PWA:
 | `web.barStyle`                                              |                               | `<meta name="apple-mobile-web-app-status-bar-style" />` |
 | <InlineCode>web.splash \| ios.splash \| splash</InlineCode> |                               | `<link rel="apple-touch-startup-image" >`               |
 
-If you need finer control on how the PWA is generated, you should generate the **web/index.html** with `npx expo customize` and add it manually.
+If you need finer control on how the PWA is generated, you should generate the **web/index.html** with `npx expo customize:web` and add it manually.
 
 ### Icons
 


### PR DESCRIPTION
# Why

When running the command edited, I was suggested to append `:web` since `customize` by itself does not exist.

# How

The updated command works for me, so hopefully it will be easier for future readers to follow the instructions.

# Test Plan

There should be no testing required for a doc update.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
