### PR TITLE
[ios] Fix errors thrown from SecureStore and other legacy modules

### DIFF
--- a/apps/native-component-list/src/screens/SecureStoreScreen.tsx
+++ b/apps/native-component-list/src/screens/SecureStoreScreen.tsx
@@ -12,6 +12,7 @@ import {
 } from 'react-native';
 
 import ListButton from '../components/ListButton';
+import Colors from '../constants/Colors';
 import { useResolvedValue } from '../utilities/useResolvedValue';
 
 export default function SecureStoreScreen() {
@@ -51,7 +52,6 @@ function SecureStoreView() {
 
   const _setValue = async (value: string, key: string) => {
     try {
-      console.log('SecureStore: ' + SecureStore);
       await SecureStore.setItemAsync(key, value, {
         keychainService: service,
         requireAuthentication: requireAuth,
@@ -94,18 +94,21 @@ function SecureStoreView() {
       <TextInput
         style={styles.textInput}
         placeholder="Enter a value to store (ex. pw123!)"
+        placeholderTextColor={Colors.secondaryText}
         value={value}
         onChangeText={setValue}
       />
       <TextInput
         style={styles.textInput}
         placeholder="Enter a key for the value (ex. password)"
+        placeholderTextColor={Colors.secondaryText}
         value={key}
         onChangeText={setKey}
       />
       <TextInput
         style={styles.textInput}
         placeholder="Enter a service name (may be blank)"
+        placeholderTextColor={Colors.secondaryText}
         value={service}
         onChangeText={setService}
       />

--- a/packages/expo-modules-core/ios/Swift/Conversions.swift
+++ b/packages/expo-modules-core/ios/Swift/Conversions.swift
@@ -173,7 +173,9 @@ internal final class Conversions {
    An exception that can be thrown by convertible types, when given value cannot be converted.
    */
   internal class ConvertingException<TargetType>: GenericException<Any?> {
-    var code: String = "ERR_CONVERTING_FAILED"
+    override var code: String {
+      "ERR_CONVERTING_FAILED"
+    }
     override var reason: String {
       "Cannot convert '\(String(describing: param))' to \(TargetType.self)"
     }
@@ -183,7 +185,9 @@ internal final class Conversions {
    An exception that is thrown when given value cannot be cast.
    */
   internal class CastingException<TargetType>: GenericException<Any> {
-    var code: String = "ERR_CASTING_FAILED"
+    override var code: String {
+      "ERR_CASTING_FAILED"
+    }
     override var reason: String {
       "Cannot cast '\(String(describing: param))' to \(TargetType.self)"
     }
@@ -194,7 +198,9 @@ internal final class Conversions {
    when the values in given dictionary cannot be cast to specific type.
    */
   internal class CastingValuesException<ValueType>: GenericException<[String]> {
-    var code: String = "ERR_CASTING_VALUES_FAILED"
+    override var code: String {
+      "ERR_CASTING_VALUES_FAILED"
+    }
     override var reason: String {
       "Cannot cast keys \(formatKeys(param)) to \(ValueType.self)"
     }

--- a/packages/expo-modules-core/ios/Swift/Exceptions/CodedError.swift
+++ b/packages/expo-modules-core/ios/Swift/Exceptions/CodedError.swift
@@ -17,14 +17,7 @@ public extension CodedError {
    To obtain the code, the class name is cut off from generics and `Error` suffix, then it's converted to snake case and uppercased.
    */
   var code: String {
-    let className = String(describing: type(of: self))
-      .replacingOccurrences(of: #"(Error|Exception)?(<.*>)?$"#, with: "", options: .regularExpression)
-    let regex = try! NSRegularExpression(pattern: "(.)([A-Z])", options: [])
-    let range = NSRange(location: 0, length: className.count)
-
-    return "ERR_" + regex
-      .stringByReplacingMatches(in: className, options: [], range: range, withTemplate: "$1_$2")
-      .uppercased()
+    return errorCodeFromString(String(describing: type(of: self)))
   }
 
   /**
@@ -47,4 +40,16 @@ public struct SimpleCodedError: CodedError {
     self.code = code
     self.description = description
   }
+}
+
+func errorCodeFromString(_ str: String) -> String {
+  let name = str.replacingOccurrences(of: #"(Error|Exception)?(<.*>)?$"#, with: "", options: .regularExpression)
+  // The pattern is valid, so it'll never throw
+  // swiftlint:disable:next force_try
+  let regex = try! NSRegularExpression(pattern: "(.)([A-Z])", options: [])
+  let range = NSRange(location: 0, length: name.count)
+
+  return "ERR_" + regex
+    .stringByReplacingMatches(in: name, options: [], range: range, withTemplate: "$1_$2")
+    .uppercased()
 }

--- a/packages/expo-modules-core/ios/Swift/Exceptions/Exception.swift
+++ b/packages/expo-modules-core/ios/Swift/Exceptions/Exception.swift
@@ -16,28 +16,41 @@ open class Exception: CodedError, ChainableException, CustomStringConvertible, C
   open var origin: ExceptionOrigin
 
   /**
+   A custom code of the exception. When unset, the `code` is calculated from the exception name or class name.
+   */
+  let customCode: String?
+
+  /**
    The default initializer that captures the place in the code where the exception was created.
    - Warning: Call it only without arguments!
    */
   public init(file: String = #fileID, line: UInt = #line, function: String = #function) {
     self.origin = ExceptionOrigin(file: file, line: line, function: function)
+    self.customCode = nil
   }
 
-  public init(name: String, description: String, file: String = #fileID, line: UInt = #line, function: String = #function) {
+  public init(name: String, description: String, code: String? = nil, file: String = #fileID, line: UInt = #line, function: String = #function) {
     self.origin = ExceptionOrigin(file: file, line: line, function: function)
+    self.customCode = code
     self.name = name
     self.description = description
   }
 
-  // MARK: ChainableException
+  // MARK: - CodedError
+
+  open var code: String {
+    customCode ?? errorCodeFromString(name)
+  }
+
+  // MARK: - ChainableException
 
   open var cause: Error?
 
-  // MARK: CustomStringConvertible
+  // MARK: - CustomStringConvertible
 
   open lazy var description: String = concatDescription(reason, withCause: cause, debug: false)
 
-  // MARK: CustomDebugStringConvertible
+  // MARK: - CustomDebugStringConvertible
 
   open var debugDescription: String {
     let debugDescription = "\(name): \(reason) (at \(origin.file):\(origin.line))"

--- a/packages/expo-modules-core/ios/Swift/Promise.swift
+++ b/packages/expo-modules-core/ios/Swift/Promise.swift
@@ -34,7 +34,7 @@ public struct Promise: AnyArgument {
   }
 
   public func reject(_ code: String, _ description: String) {
-    rejecter(Exception(name: code, description: description))
+    rejecter(Exception(name: code, description: description, code: code))
   }
 
   public func settle<ValueType, ExceptionType: Exception>(with result: Result<ValueType, ExceptionType>) {

--- a/packages/expo-secure-store/CHANGELOG.md
+++ b/packages/expo-secure-store/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Changelog
 
-### 🎉 New features
-
-- Added `requireAuthentication` and `authenticationPrompt` parameters to `SecureStoreOptions` options object used in `SecureStore.{deleteItemAsync, getItemAsync, setItemAsync}` methods to enable user authentication while accessing Secure Store. ([#14512](https://github.com/expo/expo/pull/14512) by [@j-piasecki](https://github.com/j-piasecki))
-
 ## Unpublished
 
 ### 🛠 Breaking changes
@@ -13,6 +9,8 @@
 ### 🎉 New features
 
 ### 🐛 Bug fixes
+
+- Fixed missing `code` and `message` in promise errors. ([#19555](https://github.com/expo/expo/pull/19555) by [@tsapeta](https://github.com/tsapeta))
 
 ### ⚠️ Notices
 

--- a/packages/expo-secure-store/ios/EXSecureStore/EXSecureStore.m
+++ b/packages/expo-secure-store/ios/EXSecureStore/EXSecureStore.m
@@ -229,7 +229,7 @@ EX_EXPORT_METHOD_AS(setValueWithKeyAsync,
 {
   NSString *validatedKey = [self validatedKey:key];
   if (!validatedKey) {
-    reject(@"E_SECURESTORE_SETVALUEFAIL", nil, EXErrorWithMessage(@"Invalid key."));
+    reject(@"E_SECURESTORE_SETVALUEFAIL", @"Invalid key", nil);
   } else {
     NSError *error;
     BOOL setValue = [self _setValue:value
@@ -239,7 +239,7 @@ EX_EXPORT_METHOD_AS(setValueWithKeyAsync,
     if (setValue) {
       resolve(nil);
     } else {
-      reject(@"E_SECURESTORE_SETVALUEFAIL", nil, EXErrorWithMessage([[self class] _messageForError:error]));
+      reject(@"E_SECURESTORE_SETVALUEFAIL", [[self class] _messageForError:error], nil);
     }
   }
 }
@@ -252,7 +252,7 @@ EX_EXPORT_METHOD_AS(getValueWithKeyAsync,
 {
   NSString *validatedKey = [self validatedKey:key];
   if (!validatedKey) {
-    reject(@"E_SECURESTORE_GETVALUEFAIL", nil, EXErrorWithMessage(@"Invalid key."));
+    reject(@"E_SECURESTORE_GETVALUEFAIL", @"Invalid key", nil);
   } else {
     NSError *error;
     NSString *value = [self _getValueWithKey:validatedKey
@@ -262,7 +262,7 @@ EX_EXPORT_METHOD_AS(getValueWithKeyAsync,
       if (error.code == errSecItemNotFound) {
         resolve([NSNull null]);
       } else {
-        reject(@"E_SECURESTORE_GETVALUEFAIL", nil, EXErrorWithMessage([[self class] _messageForError:error]));
+        reject(@"E_SECURESTORE_GETVALUEFAIL", [[self class] _messageForError:error], nil);
       }
     } else {
       resolve(value);
@@ -278,7 +278,7 @@ EX_EXPORT_METHOD_AS(deleteValueWithKeyAsync,
 {
   NSString *validatedKey = [self validatedKey:key];
   if (!validatedKey) {
-    reject(@"E_SECURESTORE_DELETEVALUEFAIL", nil, EXErrorWithMessage(@"Invalid key."));
+    reject(@"E_SECURESTORE_DELETEVALUEFAIL", @"Invalid key", nil);
   } else {
     [self _deleteValueWithKey:validatedKey
                   withOptions:options];


### PR DESCRIPTION
# Why

It basically fixes two things:
- Empty `message` in errors thrown by SecureStore module
- Unspecified `code` (actually `"ERR_"`) in all errors thrown from the legacy modules when the native function is called by the JSI proxy

But also fixes invisible placeholders on SecureStore screen in NCL

# How

- Fixed `reject` calls in `EXSecureStore.m` by passing error messages as the second argument (it was incorrectly passed as the third argument)
- Made it possible to override error codes when initializing the base `Exception` class (it's used when calling legacy module methods through the JSI)
- Added `placeholderTextColor` prop to text inputs on the NCL screen

# Test Plan

- Disabled permission for FaceID for bare-expo
- Tried to get/set/delete keys from SecureStore with authentication option enabled
- Confirmed that returned errors contain correct codes and messages

![IMG_0953](https://user-images.githubusercontent.com/1714764/195866479-4179769c-4a8c-42ae-83fb-dd4974a0b953.jpg)
