### PR TITLE
[cli] Fix development code signing for dev client

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Present intended variadic argument when asserting flags in `npx expo install`. ([#19396](https://github.com/expo/expo/pull/19396) by [@bycedric](https://github.com/bycedric))
 - Disable API interaction when running in offline mode. ([#19418](https://github.com/expo/expo/pull/19418) by [@byCedric](https://github.com/byCedric))
 - Add "none" platform when running `--dev-client`. ([#19319](https://github.com/expo/expo/pull/19319) by [@jonsamp](https://github.com/jonsamp))
+- Fix development code signing for dev client. ([#19557](https://github.com/expo/expo/pull/19557) by [@wschurman](https://github.com/wschurman))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/resolveOptions.ts
+++ b/packages/@expo/cli/src/start/resolveOptions.ts
@@ -42,7 +42,7 @@ export async function resolveOptionsAsync(projectRoot: string, args: any): Promi
 
   return {
     forceManifestType,
-    privateKeyPath: args['private-key-path'] ?? null,
+    privateKeyPath: args['--private-key-path'] ?? null,
 
     android: !!args['--android'],
     web: !!args['--web'],

--- a/packages/@expo/cli/src/start/server/middleware/ExpoGoManifestHandlerMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/ExpoGoManifestHandlerMiddleware.ts
@@ -150,7 +150,7 @@ export class ExpoGoManifestHandlerMiddleware extends ManifestMiddleware<ExpoGoMa
       manifestPartHeaders = {
         'expo-signature': serializeDictionary(
           convertToDictionaryItemsRepresentation({
-            keyid: 'expo-go',
+            keyid: codeSigningInfo.keyId,
             sig: signature,
             alg: 'rsa-v1_5-sha256',
           })

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/ExpoGoManifestHandlerMiddleware-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/ExpoGoManifestHandlerMiddleware-test.ts
@@ -5,6 +5,7 @@ import {
   MultipartPart,
 } from '@expo/multipart-body-parser';
 import { vol } from 'memfs';
+import nullthrows from 'nullthrows';
 
 import { asMock } from '../../../../__tests__/asMock';
 import { getProjectAsync } from '../../../../api/getProject';
@@ -217,7 +218,7 @@ describe('_getManifestResponseAsync', () => {
       )
     );
 
-    const { body } = await getMultipartPartAsync('manifest', results);
+    const { body } = nullthrows(await getMultipartPartAsync('manifest', results));
     expect(JSON.parse(body)).toEqual({
       id: expect.any(String),
       createdAt: expect.any(String),
@@ -261,7 +262,7 @@ describe('_getManifestResponseAsync', () => {
     expect(results.version).toBe('45.0.0');
     expect(results.headers.get('expo-manifest-signature')).toEqual(expect.any(String));
 
-    const { body } = await getMultipartPartAsync('manifest', results);
+    const { body } = nullthrows(await getMultipartPartAsync('manifest', results));
     expect(JSON.parse(body)).toEqual({
       id: expect.any(String),
       createdAt: expect.any(String),
@@ -326,8 +327,8 @@ describe('_getManifestResponseAsync', () => {
     });
     expect(results.version).toBe('45.0.0');
 
-    const { body, headers } = await getMultipartPartAsync('manifest', results);
-    expect(headers.get('expo-signature')).toContain('keyid="expo-go"');
+    const { body, headers } = nullthrows(await getMultipartPartAsync('manifest', results));
+    expect(headers.get('expo-signature')).toContain('keyid="testkeyid"');
 
     expect(JSON.parse(body)).toEqual({
       id: expect.any(String),
@@ -366,9 +367,8 @@ describe('_getManifestResponseAsync', () => {
     });
     expect(results.version).toBe('45.0.0');
 
-    const { body: manifestPartBody, headers: manifestPartHeaders } = await getMultipartPartAsync(
-      'manifest',
-      results
+    const { body: manifestPartBody, headers: manifestPartHeaders } = nullthrows(
+      await getMultipartPartAsync('manifest', results)
     );
     expect(manifestPartHeaders.get('expo-signature')).toContain('keyid="expo-go"');
 
@@ -393,9 +393,8 @@ describe('_getManifestResponseAsync', () => {
       },
     });
 
-    const { body: certificateChainPartBody } = await getMultipartPartAsync(
-      'certificate_chain',
-      results
+    const { body: certificateChainPartBody } = nullthrows(
+      await getMultipartPartAsync('certificate_chain', results)
     );
     expect(certificateChainPartBody).toMatchSnapshot();
   });

--- a/packages/@expo/cli/src/utils/__tests__/__snapshots__/codesigning-test.ts.snap
+++ b/packages/@expo/cli/src/utils/__tests__/__snapshots__/codesigning-test.ts.snap
@@ -72,6 +72,7 @@ Object {
   Mna8PgGRUuyGaHJM47/f4/q5tMm7C03GgaTa2EHXQEzBLLoYRYhrmaLgmwviyiSG
   Cqi43mK/Fn7lD0Xwtg==
   -----END CERTIFICATE-----",
+  "keyId": "expo-go",
   "privateKey": "-----BEGIN RSA PRIVATE KEY-----
 MIIEowIBAAKCAQEAkQhFyqfo+lSGg1tPrUzRqlXDt2BnjAaQmENA7irD6TxKS83g
 IZAcYxwn2lWJZ85Omz/4uCjHdt6AjM2ZkFMCTShgVC5o/JOUIFtYw6idrUPhIzR0
@@ -124,6 +125,7 @@ Object {
   AJsADnJN0LEKDI4q0kDwl1v6U4cJ5Ru7VQv3xho03LPEA/fFKHK6OITDznspiXRs
   IA==
   -----END CERTIFICATE-----",
+  "keyId": "test",
   "privateKey": "-----BEGIN RSA PRIVATE KEY-----
   MIIEpAIBAAKCAQEAwUu28xC4lCjgfEDYdHtDore4+75O2SAncrwb/gAez2G4CJk7
   yUmdwiU35g2DreexDXfpHlf0Zw/W/LueYo66CQaEfEAElVbBGJoANXL/aMFGJCA8

--- a/packages/@expo/cli/src/utils/__tests__/codesigning-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/codesigning-test.ts
@@ -44,18 +44,18 @@ beforeEach(() => {
 
 describe(getCodeSigningInfoAsync, () => {
   it('returns null when no expo-expect-signature header is requested', async () => {
-    await expect(getCodeSigningInfoAsync({} as any, null, null)).resolves.toBeNull();
+    await expect(getCodeSigningInfoAsync({} as any, null, undefined)).resolves.toBeNull();
   });
 
   it('throws when expo-expect-signature header has invalid format', async () => {
-    await expect(getCodeSigningInfoAsync({} as any, 'hello', null)).rejects.toThrowError(
+    await expect(getCodeSigningInfoAsync({} as any, 'hello', undefined)).rejects.toThrowError(
       'keyid not present in expo-expect-signature header'
     );
-    await expect(getCodeSigningInfoAsync({} as any, 'keyid=1', null)).rejects.toThrowError(
+    await expect(getCodeSigningInfoAsync({} as any, 'keyid=1', undefined)).rejects.toThrowError(
       'Invalid value for keyid in expo-expect-signature header: 1'
     );
     await expect(
-      getCodeSigningInfoAsync({} as any, 'keyid="hello", alg=1', null)
+      getCodeSigningInfoAsync({} as any, 'keyid="hello", alg=1', undefined)
     ).rejects.toThrowError('Invalid value for alg in expo-expect-signature header');
   });
 
@@ -141,7 +141,7 @@ describe(getCodeSigningInfoAsync, () => {
   describe('expo-go keyid requested', () => {
     it('throws', async () => {
       await expect(
-        getCodeSigningInfoAsync({} as any, 'keyid="expo-go"', null)
+        getCodeSigningInfoAsync({} as any, 'keyid="expo-go"', undefined)
       ).rejects.toThrowError(
         'Invalid certificate requested: cannot sign with embedded keyid=expo-go key'
       );
@@ -245,6 +245,7 @@ describe(signManifestString, () => {
   it('generates signature', () => {
     expect(
       signManifestString('hello', {
+        keyId: 'test',
         certificateChainForResponse: [],
         certificateForPrivateKey: mockSelfSigned.certificate,
         privateKey: mockSelfSigned.privateKey,
@@ -254,6 +255,7 @@ describe(signManifestString, () => {
   it('validates generated signature against certificate', () => {
     expect(() =>
       signManifestString('hello', {
+        keyId: 'test',
         certificateChainForResponse: [],
         certificateForPrivateKey: '',
         privateKey: mockSelfSigned.privateKey,

--- a/packages/@expo/cli/src/utils/codesigning.ts
+++ b/packages/@expo/cli/src/utils/codesigning.ts
@@ -23,6 +23,7 @@ import * as Log from '../log';
 import { CommandError } from './errors';
 
 export type CodeSigningInfo = {
+  keyId: string;
   privateKey: string;
   certificateForPrivateKey: string;
   /**
@@ -257,6 +258,7 @@ async function getProjectCodeSigningCertificateAsync(
     });
 
   return {
+    keyId: keyid,
     privateKey: privateKeyPEM,
     certificateForPrivateKey: certificatePEM,
     certificateChainForResponse: [],
@@ -330,6 +332,7 @@ function validateStoredDevelopmentExpoRootCertificateCodeSigningInfo(
   // TODO(wschurman): maybe do more validation
 
   return {
+    keyId: 'expo-go',
     certificateChainForResponse: certificatePEMs,
     certificateForPrivateKey: certificatePEMs[0],
     privateKey: privateKeyPEM,
@@ -355,6 +358,7 @@ async function fetchAndCacheNewDevelopmentCodeSigningInfoAsync(
   });
 
   return {
+    keyId: 'expo-go',
     certificateChainForResponse: [developmentSigningCertificate, expoGoIntermediateCertificate],
     certificateForPrivateKey: developmentSigningCertificate,
     privateKey: keyPairPEM.privateKeyPEM,


### PR DESCRIPTION
# Why

While @jonsamp was testing this, we noticed that this was broken for dev clients configured to use code signing. This PR fixes the issues.

# How

- fix the flag parsing
- fix the returned keyid for developer's own certificates. This was erroneously always setting it to `expo-go` when it should have only done that when the `expo-root` certificate was requested.

# Test Plan

Run all tests.

With @jonsamp, run a dev client configured for code signing. Then run `nexpo start --private-key-path keys/private-key.pem --dev-client` and load a signed manifest (no longer see keyid mismatch error).

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
