### PR TITLE
[packages] Fix expo-modules-core androidTest

### DIFF
--- a/.github/workflows/android-instrumentation-tests.yml
+++ b/.github/workflows/android-instrumentation-tests.yml
@@ -86,4 +86,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test-results
-          path: packages/**/build/outputs/androidTest-results/**/*xml
+          path: packages/**/build/outputs/androidTest-results/**/*

--- a/.github/workflows/android-instrumentation-tests.yml
+++ b/.github/workflows/android-instrumentation-tests.yml
@@ -35,7 +35,7 @@ concurrency:
 jobs:
   test:
     runs-on: macos-11
-    timeout-minutes: 100
+    timeout-minutes: 120
     env:
       ORG_GRADLE_PROJECT_reactNativeArchitectures: x86_64
       GRADLE_OPTS: -Dorg.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=1024m
@@ -72,7 +72,7 @@ jobs:
         if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
       - name: 📱 Run instrumented unit tests
-        timeout-minutes: 60
+        timeout-minutes: 80
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}

--- a/.github/workflows/android-instrumentation-tests.yml
+++ b/.github/workflows/android-instrumentation-tests.yml
@@ -86,4 +86,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test-results
-          path: packages/**/build/test-reports/**/*xml
+          path: packages/**/build/outputs/androidTest-results/**/*xml

--- a/packages/expo-av/android/build.gradle
+++ b/packages/expo-av/android/build.gradle
@@ -74,12 +74,12 @@ afterEvaluate {
 android {
   compileSdkVersion safeExtGet("compileSdkVersion", 31)
 
-  // This ndkVersion should align to react-native and fbjni building ndkVersion.
-  // Because the unwind library is different before NDK r23 and after,
-  // if we build this library with newer NDK, C++ exceptions are incompatible between these libraries.
-  // For example, C++ exceptions throwing from fbjni are not catchable from this library.
-  // Ref: https://android.googlesource.com/platform/ndk/+/master/docs/BuildSystemMaintainers.md#unwinding
-  ndkVersion = "21.4.7075529"
+  if (rootProject.hasProperty("ndkPath")) {
+    ndkPath rootProject.ext.ndkPath
+  }
+  if (rootProject.hasProperty("ndkVersion")) {
+    ndkVersion rootProject.ext.ndkVersion
+  }
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11

--- a/packages/expo-av/android/build.gradle
+++ b/packages/expo-av/android/build.gradle
@@ -74,12 +74,12 @@ afterEvaluate {
 android {
   compileSdkVersion safeExtGet("compileSdkVersion", 31)
 
-  if (rootProject.hasProperty("ndkPath")) {
-    ndkPath rootProject.ext.ndkPath
-  }
-  if (rootProject.hasProperty("ndkVersion")) {
-    ndkVersion rootProject.ext.ndkVersion
-  }
+  // This ndkVersion should align to react-native and fbjni building ndkVersion.
+  // Because the unwind library is different before NDK r23 and after,
+  // if we build this library with newer NDK, C++ exceptions are incompatible between these libraries.
+  // For example, C++ exceptions throwing from fbjni are not catchable from this library.
+  // Ref: https://android.googlesource.com/platform/ndk/+/master/docs/BuildSystemMaintainers.md#unwinding
+  ndkVersion = "21.4.7075529"
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11

--- a/packages/expo-gl/android/build.gradle
+++ b/packages/expo-gl/android/build.gradle
@@ -74,12 +74,12 @@ afterEvaluate {
 android {
   compileSdkVersion safeExtGet("compileSdkVersion", 31)
 
-  // This ndkVersion should align to react-native and fbjni building ndkVersion.
-  // Because the unwind library is different before NDK r23 and after,
-  // if we build this library with newer NDK, C++ exceptions are incompatible between these libraries.
-  // For example, C++ exceptions throwing from fbjni are not catchable from this library.
-  // Ref: https://android.googlesource.com/platform/ndk/+/master/docs/BuildSystemMaintainers.md#unwinding
-  ndkVersion = "21.4.7075529"
+  if (rootProject.hasProperty("ndkPath")) {
+    ndkPath rootProject.ext.ndkPath
+  }
+  if (rootProject.hasProperty("ndkVersion")) {
+    ndkVersion rootProject.ext.ndkVersion
+  }
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11

--- a/packages/expo-gl/android/build.gradle
+++ b/packages/expo-gl/android/build.gradle
@@ -74,12 +74,12 @@ afterEvaluate {
 android {
   compileSdkVersion safeExtGet("compileSdkVersion", 31)
 
-  if (rootProject.hasProperty("ndkPath")) {
-    ndkPath rootProject.ext.ndkPath
-  }
-  if (rootProject.hasProperty("ndkVersion")) {
-    ndkVersion rootProject.ext.ndkVersion
-  }
+  // This ndkVersion should align to react-native and fbjni building ndkVersion.
+  // Because the unwind library is different before NDK r23 and after,
+  // if we build this library with newer NDK, C++ exceptions are incompatible between these libraries.
+  // For example, C++ exceptions throwing from fbjni are not catchable from this library.
+  // Ref: https://android.googlesource.com/platform/ndk/+/master/docs/BuildSystemMaintainers.md#unwinding
+  ndkVersion = "21.4.7075529"
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -154,11 +154,22 @@ afterEvaluate {
 android {
   compileSdkVersion safeExtGet("compileSdkVersion", 31)
 
-  if (rootProject.hasProperty("ndkPath")) {
-    ndkPath rootProject.ext.ndkPath
-  }
-  if (rootProject.hasProperty("ndkVersion")) {
-    ndkVersion rootProject.ext.ndkVersion
+  if (REACT_NATIVE_BUILD_FROM_SOURCE) {
+    if (rootProject.hasProperty("ndkPath")) {
+      ndkPath rootProject.ext.ndkPath
+    }
+    if (rootProject.hasProperty("ndkVersion")) {
+      ndkVersion rootProject.ext.ndkVersion
+    }
+  } else {
+    // This ndkVersion should align to prebuilt react-native building ndkVersion.
+    // Because the unwind library is different before NDK r23 and after,
+    // if we build this library with newer NDK, C++ exceptions are incompatible between these libraries.
+    // For example, C++ exceptions throwing from hermes are not catchable from this library.
+    // Ref: https://android.googlesource.com/platform/ndk/+/master/docs/BuildSystemMaintainers.md#unwinding
+    //
+    // TODO: Revisit this version when upgrade react-native 0.71 (Expo SDK 48)
+    ndkVersion = "21.4.7075529"
   }
 
   compileOptions {

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -154,12 +154,12 @@ afterEvaluate {
 android {
   compileSdkVersion safeExtGet("compileSdkVersion", 31)
 
-  if (rootProject.hasProperty("ndkPath")) {
-    ndkPath rootProject.ext.ndkPath
-  }
-  if (rootProject.hasProperty("ndkVersion")) {
-    ndkVersion rootProject.ext.ndkVersion
-  }
+  // This ndkVersion should align to react-native and fbjni building ndkVersion.
+  // Because the unwind library is different before NDK r23 and after,
+  // if we build this library with newer NDK, C++ exceptions are incompatible between these libraries.
+  // For example, C++ exceptions throwing from fbjni are not catchable from this library.
+  // Ref: https://android.googlesource.com/platform/ndk/+/master/docs/BuildSystemMaintainers.md#unwinding
+  ndkVersion = "21.4.7075529"
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -183,7 +183,7 @@ android {
     externalNativeBuild {
       cmake {
         abiFilters (*reactNativeArchitectures())
-        arguments "-DANDROID_STL=${isExpoModulesCoreTests ? 'c++_static' : 'c++_shared'}",
+        arguments "-DANDROID_STL=c++_shared",
           "-DREACT_NATIVE_DIR=${REACT_NATIVE_DIR}",
           "-DREACT_NATIVE_SO_DIR=${REACT_NATIVE_SO_DIR}",
           "-DREACT_NATIVE_TARGET_VERSION=${REACT_NATIVE_TARGET_VERSION}",

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -154,12 +154,12 @@ afterEvaluate {
 android {
   compileSdkVersion safeExtGet("compileSdkVersion", 31)
 
-  // This ndkVersion should align to react-native and fbjni building ndkVersion.
-  // Because the unwind library is different before NDK r23 and after,
-  // if we build this library with newer NDK, C++ exceptions are incompatible between these libraries.
-  // For example, C++ exceptions throwing from fbjni are not catchable from this library.
-  // Ref: https://android.googlesource.com/platform/ndk/+/master/docs/BuildSystemMaintainers.md#unwinding
-  ndkVersion = "21.4.7075529"
+  if (rootProject.hasProperty("ndkPath")) {
+    ndkPath rootProject.ext.ndkPath
+  }
+  if (rootProject.hasProperty("ndkVersion")) {
+    ndkVersion rootProject.ext.ndkVersion
+  }
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIAsyncFunctionsTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIAsyncFunctionsTest.kt
@@ -4,6 +4,7 @@ package expo.modules.kotlin.jni
 
 import com.google.common.truth.Truth
 import expo.modules.kotlin.exception.CodedException
+import expo.modules.kotlin.exception.JavaScriptEvaluateException
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.Enumerable
@@ -197,15 +198,15 @@ class JSIAsyncFunctionsTest {
     Truth.assertThat(exception.message).contains("java.lang.IllegalStateException")
   }
 
-//  @Test(expected = JavaScriptEvaluateException::class)
-//  fun should_throw_if_js_value_cannnot_be_passed() = withJSIInterop(
-//    inlineModule {
-//      Name("TestModule")
-//      AsyncFunction("f") { _: Int -> }
-//    }
-//  ) { methodQueue ->
-//    waitForAsyncFunction(methodQueue, "expo.modules.TestModule.f(Symbol())")
-//  }
+  @Test(expected = JavaScriptEvaluateException::class)
+  fun should_throw_if_js_value_cannot_be_passed() = withJSIInterop(
+    inlineModule {
+      Name("TestModule")
+      AsyncFunction("f") { _: Int -> }
+    }
+  ) { methodQueue ->
+    waitForAsyncFunction(methodQueue, "expo.modules.TestModule.f(Symbol())")
+  }
 
   @Test
   fun int_array_should_be_convertible() = withJSIInterop(

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIAsyncFunctionsTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIAsyncFunctionsTest.kt
@@ -4,7 +4,6 @@ package expo.modules.kotlin.jni
 
 import com.google.common.truth.Truth
 import expo.modules.kotlin.exception.CodedException
-import expo.modules.kotlin.exception.JavaScriptEvaluateException
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.Enumerable
@@ -198,15 +197,15 @@ class JSIAsyncFunctionsTest {
     Truth.assertThat(exception.message).contains("java.lang.IllegalStateException")
   }
 
-  @Test(expected = JavaScriptEvaluateException::class)
-  fun should_throw_if_js_value_cannot_be_passed() = withJSIInterop(
-    inlineModule {
-      Name("TestModule")
-      AsyncFunction("f") { _: Int -> }
-    }
-  ) { methodQueue ->
-    waitForAsyncFunction(methodQueue, "expo.modules.TestModule.f(Symbol())")
-  }
+//  @Test(expected = JavaScriptEvaluateException::class)
+//  fun should_throw_if_js_value_cannot_be_passed() = withJSIInterop(
+//    inlineModule {
+//      Name("TestModule")
+//      AsyncFunction("f") { _: Int -> }
+//    }
+//  ) { methodQueue ->
+//    waitForAsyncFunction(methodQueue, "expo.modules.TestModule.f(Symbol())")
+//  }
 
   @Test
   fun int_array_should_be_convertible() = withJSIInterop(

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIAsyncFunctionsTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIAsyncFunctionsTest.kt
@@ -4,6 +4,7 @@ package expo.modules.kotlin.jni
 
 import com.google.common.truth.Truth
 import expo.modules.kotlin.exception.CodedException
+import expo.modules.kotlin.exception.JavaScriptEvaluateException
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.Enumerable
@@ -197,15 +198,15 @@ class JSIAsyncFunctionsTest {
     Truth.assertThat(exception.message).contains("java.lang.IllegalStateException")
   }
 
-//  @Test(expected = JavaScriptEvaluateException::class)
-//  fun should_throw_if_js_value_cannot_be_passed() = withJSIInterop(
-//    inlineModule {
-//      Name("TestModule")
-//      AsyncFunction("f") { _: Int -> }
-//    }
-//  ) { methodQueue ->
-//    waitForAsyncFunction(methodQueue, "expo.modules.TestModule.f(Symbol())")
-//  }
+  @Test(expected = JavaScriptEvaluateException::class)
+  fun should_throw_if_js_value_cannot_be_passed() = withJSIInterop(
+    inlineModule {
+      Name("TestModule")
+      AsyncFunction("f") { _: Int -> }
+    }
+  ) { methodQueue ->
+    waitForAsyncFunction(methodQueue, "expo.modules.TestModule.f(Symbol())")
+  }
 
   @Test
   fun int_array_should_be_convertible() = withJSIInterop(

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIFunctionsTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIFunctionsTest.kt
@@ -5,6 +5,7 @@ package expo.modules.kotlin.jni
 import com.google.common.truth.Truth
 import expo.modules.kotlin.apifeatures.EitherType
 import expo.modules.kotlin.exception.CodedException
+import expo.modules.kotlin.exception.JavaScriptEvaluateException
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.typedarray.Float32Array
@@ -303,17 +304,17 @@ class JSIFunctionsTest {
     Truth.assertThat(exception.getProperty("message").getString()).contains("java.lang.IllegalStateException")
   }
 
-//  @Test(expected = JavaScriptEvaluateException::class)
-//  fun uncaught_error_should_be_piped_to_host_language() = withJSIInterop(
-//    inlineModule {
-//      Name("TestModule")
-//      Function("f") { ->
-//        throw IllegalStateException()
-//      }
-//    }
-//  ) {
-//    evaluateScript("expo.modules.TestModule.f()")
-//  }
+  @Test(expected = JavaScriptEvaluateException::class)
+  fun uncaught_error_should_be_piped_to_host_language() = withJSIInterop(
+    inlineModule {
+      Name("TestModule")
+      Function("f") { ->
+        throw IllegalStateException()
+      }
+    }
+  ) {
+    evaluateScript("expo.modules.TestModule.f()")
+  }
 
   @Test
   fun typed_arrays_should_be_obtainable_as_function_argument() = withJSIInterop(
@@ -357,15 +358,15 @@ class JSIFunctionsTest {
     )
   }
 
-//  @Test(expected = JavaScriptEvaluateException::class)
-//  fun should_throw_if_js_value_cannnot_be_passed() = withJSIInterop(
-//    inlineModule {
-//      Name("TestModule")
-//      Function("f") { _: Int -> }
-//    }
-//  ) {
-//    evaluateScript("expo.modules.TestModule.f(Symbol())")
-//  }
+  @Test(expected = JavaScriptEvaluateException::class)
+  fun should_throw_if_js_value_cannot_be_passed() = withJSIInterop(
+    inlineModule {
+      Name("TestModule")
+      Function("f") { _: Int -> }
+    }
+  ) {
+    evaluateScript("expo.modules.TestModule.f(Symbol())")
+  }
 
   @Test
   fun int_array_should_be_convertible() = withJSIInterop(

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIFunctionsTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIFunctionsTest.kt
@@ -5,7 +5,6 @@ package expo.modules.kotlin.jni
 import com.google.common.truth.Truth
 import expo.modules.kotlin.apifeatures.EitherType
 import expo.modules.kotlin.exception.CodedException
-import expo.modules.kotlin.exception.JavaScriptEvaluateException
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.typedarray.Float32Array
@@ -304,17 +303,17 @@ class JSIFunctionsTest {
     Truth.assertThat(exception.getProperty("message").getString()).contains("java.lang.IllegalStateException")
   }
 
-  @Test(expected = JavaScriptEvaluateException::class)
-  fun uncaught_error_should_be_piped_to_host_language() = withJSIInterop(
-    inlineModule {
-      Name("TestModule")
-      Function("f") { ->
-        throw IllegalStateException()
-      }
-    }
-  ) {
-    evaluateScript("expo.modules.TestModule.f()")
-  }
+//  @Test(expected = JavaScriptEvaluateException::class)
+//  fun uncaught_error_should_be_piped_to_host_language() = withJSIInterop(
+//    inlineModule {
+//      Name("TestModule")
+//      Function("f") { ->
+//        throw IllegalStateException()
+//      }
+//    }
+//  ) {
+//    evaluateScript("expo.modules.TestModule.f()")
+//  }
 
   @Test
   fun typed_arrays_should_be_obtainable_as_function_argument() = withJSIInterop(
@@ -358,15 +357,15 @@ class JSIFunctionsTest {
     )
   }
 
-  @Test(expected = JavaScriptEvaluateException::class)
-  fun should_throw_if_js_value_cannot_be_passed() = withJSIInterop(
-    inlineModule {
-      Name("TestModule")
-      Function("f") { _: Int -> }
-    }
-  ) {
-    evaluateScript("expo.modules.TestModule.f(Symbol())")
-  }
+//  @Test(expected = JavaScriptEvaluateException::class)
+//  fun should_throw_if_js_value_cannot_be_passed() = withJSIInterop(
+//    inlineModule {
+//      Name("TestModule")
+//      Function("f") { _: Int -> }
+//    }
+//  ) {
+//    evaluateScript("expo.modules.TestModule.f(Symbol())")
+//  }
 
   @Test
   fun int_array_should_be_convertible() = withJSIInterop(

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIFunctionsTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIFunctionsTest.kt
@@ -5,6 +5,7 @@ package expo.modules.kotlin.jni
 import com.google.common.truth.Truth
 import expo.modules.kotlin.apifeatures.EitherType
 import expo.modules.kotlin.exception.CodedException
+import expo.modules.kotlin.exception.JavaScriptEvaluateException
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.typedarray.Float32Array
@@ -303,17 +304,17 @@ class JSIFunctionsTest {
     Truth.assertThat(exception.getProperty("message").getString()).contains("java.lang.IllegalStateException")
   }
 
-//  @Test(expected = JavaScriptEvaluateException::class)
-//  fun uncaught_error_should_be_piped_to_host_language() = withJSIInterop(
-//    inlineModule {
-//      Name("TestModule")
-//      Function("f") { ->
-//        throw IllegalStateException()
-//      }
-//    }
-//  ) {
-//    evaluateScript("expo.modules.TestModule.f()")
-//  }
+  @Test(expected = JavaScriptEvaluateException::class)
+  fun uncaught_error_should_be_piped_to_host_language() = withJSIInterop(
+    inlineModule {
+      Name("TestModule")
+      Function("f") { ->
+        throw IllegalStateException()
+      }
+    }
+  ) {
+    evaluateScript("expo.modules.TestModule.f()")
+  }
 
   @Test
   fun typed_arrays_should_be_obtainable_as_function_argument() = withJSIInterop(
@@ -357,15 +358,15 @@ class JSIFunctionsTest {
     )
   }
 
-//  @Test(expected = JavaScriptEvaluateException::class)
-//  fun should_throw_if_js_value_cannot_be_passed() = withJSIInterop(
-//    inlineModule {
-//      Name("TestModule")
-//      Function("f") { _: Int -> }
-//    }
-//  ) {
-//    evaluateScript("expo.modules.TestModule.f(Symbol())")
-//  }
+  @Test(expected = JavaScriptEvaluateException::class)
+  fun should_throw_if_js_value_cannot_be_passed() = withJSIInterop(
+    inlineModule {
+      Name("TestModule")
+      Function("f") { _: Int -> }
+    }
+  ) {
+    evaluateScript("expo.modules.TestModule.f(Symbol())")
+  }
 
   @Test
   fun int_array_should_be_convertible() = withJSIInterop(

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptRuntimeTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptRuntimeTest.kt
@@ -1,9 +1,7 @@
 package expo.modules.kotlin.jni
 
 import com.google.common.truth.Truth
-import expo.modules.kotlin.exception.JavaScriptEvaluateException
 import io.mockk.mockk
-import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 
@@ -17,19 +15,19 @@ class JavaScriptRuntimeTest {
     }
   }
 
-  @Test(expected = JavaScriptEvaluateException::class)
-  fun evaluate_should_throw_evaluate_exception() {
-    jsiInterop.evaluateScript("'")
-  }
+//  @Test(expected = JavaScriptEvaluateException::class)
+//  fun evaluate_should_throw_evaluate_exception() {
+//    jsiInterop.evaluateScript("'")
+//  }
 
-  @Test
-  fun evaluate_should_throw_evaluate_exception_with_stack() {
-    val exception = Assert.assertThrows(JavaScriptEvaluateException::class.java) {
-      jsiInterop.evaluateScript("function x() { global.nonExistingFunction(10); }; x();")
-    }
-
-    Truth.assertThat(exception.jsStack).isNotEmpty()
-  }
+//  @Test
+//  fun evaluate_should_throw_evaluate_exception_with_stack() {
+//    val exception = Assert.assertThrows(JavaScriptEvaluateException::class.java) {
+//      jsiInterop.evaluateScript("function x() { global.nonExistingFunction(10); }; x();")
+//    }
+//
+//    Truth.assertThat(exception.jsStack).isNotEmpty()
+//  }
 
   @Test
   fun evaluate_returns_undefined() {

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptRuntimeTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptRuntimeTest.kt
@@ -1,7 +1,9 @@
 package expo.modules.kotlin.jni
 
 import com.google.common.truth.Truth
+import expo.modules.kotlin.exception.JavaScriptEvaluateException
 import io.mockk.mockk
+import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 
@@ -15,19 +17,19 @@ class JavaScriptRuntimeTest {
     }
   }
 
-//  @Test(expected = JavaScriptEvaluateException::class)
-//  fun evaluate_should_throw_evaluate_exception() {
-//    jsiInterop.evaluateScript("'")
-//  }
+  @Test(expected = JavaScriptEvaluateException::class)
+  fun evaluate_should_throw_evaluate_exception() {
+    jsiInterop.evaluateScript("'")
+  }
 
-//  @Test
-//  fun evaluate_should_throw_evaluate_exception_with_stack() {
-//    val exception = Assert.assertThrows(JavaScriptEvaluateException::class.java) {
-//      jsiInterop.evaluateScript("function x() { global.nonExistingFunction(10); }; x();")
-//    }
-//
-//    Truth.assertThat(exception.jsStack).isNotEmpty()
-//  }
+  @Test
+  fun evaluate_should_throw_evaluate_exception_with_stack() {
+    val exception = Assert.assertThrows(JavaScriptEvaluateException::class.java) {
+      jsiInterop.evaluateScript("function x() { global.nonExistingFunction(10); }; x();")
+    }
+
+    Truth.assertThat(exception.jsStack).isNotEmpty()
+  }
 
   @Test
   fun evaluate_returns_undefined() {

--- a/packages/expo-modules-core/android/src/main/cpp/Exceptions.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/Exceptions.cpp
@@ -78,4 +78,24 @@ void rethrowAsCodedError(
   // Rethrow error if we can't wrap it.
   throw;
 }
+
+void throwPendingJniExceptionAsCppException() {
+  JNIEnv* env = jni::Environment::current();
+  if (env->ExceptionCheck() == JNI_FALSE) {
+    return;
+  }
+
+  auto throwable = env->ExceptionOccurred();
+  if (!throwable) {
+    throw std::runtime_error("Unable to get pending JNI exception.");
+  }
+  env->ExceptionClear();
+
+  throw jni::JniException(jni::adopt_local(throwable));
+}
+
+void throwNewJavaException(jthrowable throwable) {
+  throw jni::JniException(jni::wrap_alias(throwable));
+}
+
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/Exceptions.h
+++ b/packages/expo-modules-core/android/src/main/cpp/Exceptions.h
@@ -68,4 +68,16 @@ public:
   JSIInteropModuleRegistry *registry,
   jni::JniException &jniException
 );
+
+/**
+ * fbjni@0.2.2 is built by ndk r21, its exceptions are not catchable by expo-modules-core built by ndk r23+.
+ * To catch these excetptions, we copy the `facebook::jni::throwPendingJniExceptionAsCppException` here and throw exceptions on our own.
+ */
+void throwPendingJniExceptionAsCppException();
+
+/**
+ * Same as `facebook::jni::throwNewJavaException` but throwing exceptions on our own.
+ */
+[[noreturn]] void throwNewJavaException(jthrowable throwable);
+
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptValue.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptValue.cpp
@@ -78,7 +78,7 @@ std::string JavaScriptValue::kind() {
     return "object";
   }
 
-  jni::throwNewJavaException(
+  throwNewJavaException(
     UnexpectedException::create("Unknown type").get()
   );
 }

--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
@@ -114,7 +114,7 @@ jobjectArray MethodMetadata::convertJSIArgsToJNI(
         env->DeleteLocalRef(converterValue);
       } else {
         auto stringRepresentation = arg.toString(rt).utf8(rt);
-        jni::throwNewJavaException(
+        throwNewJavaException(
           UnexpectedException::create(
             "Cannot convert '" + stringRepresentation + "' to a Kotlin type.").get()
         );

--- a/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.cpp
@@ -197,7 +197,7 @@ jobject UnknownFrontendConverter::convert(
   const jsi::Value &value
 ) const {
   auto stringRepresentation = value.toString(rt).utf8(rt);
-  jni::throwNewJavaException(
+  throwNewJavaException(
     UnexpectedException::create(
       "Cannot convert '" + stringRepresentation + "' to a Kotlin type.").get()
   );
@@ -239,7 +239,7 @@ jobject PolyFrontendConverter::convert(
   }
   // That shouldn't happen.
   auto stringRepresentation = value.toString(rt).utf8(rt);
-  jni::throwNewJavaException(
+  throwNewJavaException(
     UnexpectedException::create(
       "Cannot convert '" + stringRepresentation + "' to a Kotlin type.").get()
   );

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIInteropModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIInteropModuleRegistry.kt
@@ -2,6 +2,7 @@ package expo.modules.kotlin.jni
 
 import com.facebook.jni.HybridData
 import com.facebook.react.turbomodule.core.CallInvokerHolderImpl
+import com.facebook.soloader.SoLoader
 import expo.modules.core.interfaces.DoNotStrip
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.JavaScriptEvaluateException
@@ -83,7 +84,7 @@ class JSIInteropModuleRegistry(appContext: AppContext) {
 
   companion object {
     init {
-      System.loadLibrary("expo-modules-core")
+      SoLoader.loadLibrary("expo-modules-core")
     }
   }
 }

--- a/tools/src/commands/AndroidNativeUnitTests.ts
+++ b/tools/src/commands/AndroidNativeUnitTests.ts
@@ -92,6 +92,11 @@ export async function androidNativeUnitTests({
 
   if (type === 'instrumented') {
     const testCommand = 'connectedAndroidTest';
+    const uninstallTestCommand = 'uninstallDebugAndroidTest';
+
+    // TODO: remove this once avd cache saved to storage
+    await runGradlew(androidPackagesTestedUsingExpoProject, uninstallTestCommand, ANDROID_DIR);
+    await runGradlew(androidPackagesTestedUsingBareProject, uninstallTestCommand, BARE_EXPO_DIR);
 
     // We should build and test expo-modules-core first
     // that to make the `isExpoModulesCoreTests` in _expo-modules-core/android/build.gradle_ working.
@@ -113,7 +118,6 @@ export async function androidNativeUnitTests({
     );
 
     // Cleanup installed test app
-    const uninstallTestCommand = 'uninstallDebugAndroidTest';
     await runGradlew(androidPackagesTestedUsingExpoProject, uninstallTestCommand, ANDROID_DIR);
     await runGradlew(androidPackagesTestedUsingBareProject, uninstallTestCommand, BARE_EXPO_DIR);
   } else {

--- a/tools/src/commands/AndroidNativeUnitTests.ts
+++ b/tools/src/commands/AndroidNativeUnitTests.ts
@@ -79,8 +79,6 @@ export async function androidNativeUnitTests({
     console.log(chalk.yellow(pkg.packageSlug));
   });
 
-  const testCommand = type === 'instrumented' ? 'connectedAndroidTest' : 'testDebugUnitTest';
-
   const partition = <T>(arr: T[], condition: (T) => boolean) => {
     const trues = arr.filter((el) => condition(el));
     const falses = arr.filter((el) => !condition(el));
@@ -93,14 +91,37 @@ export async function androidNativeUnitTests({
   );
 
   if (type === 'instrumented') {
-    // Uninstall tests first to fix the `INSTALL_FAILED_UPDATE_INCOMPATIBLE` error from cached AVD in CI environment.
+    const testCommand = 'connectedAndroidTest';
+
+    // We should build and test expo-modules-core first
+    // that to make the `isExpoModulesCoreTests` in _expo-modules-core/android/build.gradle_ working.
+    // Otherwise, the `./gradlew :expo-modules-core:connectedAndroidTest :expo-eas-client:connectedAndroidTest`
+    // will have duplicated fbjni.so when building expo-eas-client.
+    const isExpoModulesCore = (pkg: Packages.Package) => pkg.packageName === 'expo-modules-core';
+    const isNotExpoModulesCore = (pkg: Packages.Package) => pkg.packageName !== 'expo-modules-core';
+    await runGradlew(androidPackages.filter(isExpoModulesCore), testCommand, ANDROID_DIR);
+
+    await runGradlew(
+      androidPackagesTestedUsingExpoProject.filter(isNotExpoModulesCore),
+      testCommand,
+      ANDROID_DIR
+    );
+    await runGradlew(
+      androidPackagesTestedUsingBareProject.filter(isNotExpoModulesCore),
+      testCommand,
+      BARE_EXPO_DIR
+    );
+
+    // Cleanup installed test app
     const uninstallTestCommand = 'uninstallDebugAndroidTest';
     await runGradlew(androidPackagesTestedUsingExpoProject, uninstallTestCommand, ANDROID_DIR);
     await runGradlew(androidPackagesTestedUsingBareProject, uninstallTestCommand, BARE_EXPO_DIR);
+  } else {
+    const testCommand = 'testDebugUnitTest';
+    await runGradlew(androidPackagesTestedUsingExpoProject, testCommand, ANDROID_DIR);
+    await runGradlew(androidPackagesTestedUsingBareProject, testCommand, BARE_EXPO_DIR);
   }
 
-  await runGradlew(androidPackagesTestedUsingExpoProject, testCommand, ANDROID_DIR);
-  await runGradlew(androidPackagesTestedUsingBareProject, testCommand, BARE_EXPO_DIR);
   console.log(chalk.green('Finished android unit tests successfully.'));
 }
 


### PR DESCRIPTION
# Why

follow up with #19411 to make expo-modules-core androidTest correctly

# How

those commented test cases break because we try to catch exceptions across shared library boundaries. there are a couple  root causes actually:

## incompatible ndk versions

before ndk r23, the unwind library is libgcc, and after r23, the implementation is llvm libunwind. these two unwind implementation is incompatible. fbjni@0.2.2 and prebuilt react-native libs are all built from ndk r21. if we run the androidTest on m1 machine, we will use ndk r24 to build libraries. that's why we cannot catch fbjni exceptions in this situation. the pr tries to re-implement fbjni method calls and throw exceptions inline. that would make jni exceptions catchable. 

other than that, when targeting prebuilt react-native, we should also use the same ndk r21 to build expo-modules-core. even we are on m1 machines.

## jscexecutor missing `_Unwind_Resume` symbol

the case happens when ndk r21 + jsc only, and this is also our ci android instrumented test environment. as [the ndk document](https://android.googlesource.com/platform/ndk/+/master/docs/BuildSystemMaintainers.md#unwinding) mentioned, for ndk r21, we should take care linking order. [this react-native fork patch](https://github.com/expo/react-native/commit/3986a385502df3eb207ca05f0b558171a600166c) addressed the issue.

if we test jsc on bare-expo, these test cases will still crash. i don't want to fix it or proposing the fix to upstream in the meantime. the latest react-native with AGP 7.3, the side-by-side ndk is already r23. since these are actually error cases, it's just not crash with correct stacktrace (not from expo-modules-core, but jscexecutor)

## c++_static runtime in expo-modules-core androidTest

always uses c++_shared runtime: the c++_static runtime doesn't well support the throw exceptions between shared library boundaries. we used c++_static because we want to fix the `et android-native-unit-tests -t instrumented` failures where the `./gradlew :expo-modules-core:connectedAndroidTest :expo-eas-client:connectedAndroidTest` will have duplicated fbjni.so build errors. this pr also reorganizes `et android-native-unit-tests` to build expo-modules-core androidTest exclusively. 

# Test Plan

android instrumented ci passed

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
  - no user-faced changes
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
