### PR TITLE
[docs] Adds code signing under EAS Update

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -287,6 +287,7 @@ const eas = [
         makePage('eas-update/runtime-versions.mdx'),
         makePage('eas-update/environment-variables.mdx'),
         makePage('eas-update/expo-dev-client.mdx'),
+        makePage('eas-update/code-signing.mdx'),
         makePage('eas-update/known-issues.mdx'),
         makePage('eas-update/rollouts.mdx'),
         makePage('eas-update/faq.mdx'),


### PR DESCRIPTION
# Why

As we prepare to launch code signing more publicly, this PR moves the code-signing doc to the sidebar under EAS Update.

# Screenshot

<img width="297" alt="Screen Shot 2022-10-14 at 11 16 48 PM" src="https://user-images.githubusercontent.com/6455018/195966554-7e0db70a-7c76-423d-b09f-0194eef94d7f.png">


# Test Plan

Make sure that you can see code signing in the side bar like in the screenshot above.