### PR TITLE
[modules][Android] `AppContext.currentActivity` is not longer returning `AppCompatActivity`

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🛠 Breaking changes
 
-- Convertible enums must inherit from `expo.modules.kotlin.types.Enumerable` on Android.
+- Convertible enums must inherit from `expo.modules.kotlin.types.Enumerable` on Android. ([#19551](https://github.com/expo/expo/pull/19551) by [@lukmccall](https://github.com/lukmccall))
 - `AppContext.currentActivity` is not longer returning `AppCompatActivity`, but an instance of `android.app.Activity` class. ([#19573](https://github.com/expo/expo/pull/19573) by [@lukmccall](https://github.com/lukmccall))
 
 ### 🎉 New features

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### 🛠 Breaking changes
 
 - Convertible enums must inherit from `expo.modules.kotlin.types.Enumerable` on Android.
-- `AppContext.currentActivity` is not longer returning `AppCompatActivity`, but an instance of `android.app.Activity` class.
+- `AppContext.currentActivity` is not longer returning `AppCompatActivity`, but an instance of `android.app.Activity` class. ([#19573](https://github.com/expo/expo/pull/19573) by [@lukmccall](https://github.com/lukmccall))
 
 ### 🎉 New features
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 🛠 Breaking changes
 
 - Convertible enums must inherit from `expo.modules.kotlin.types.Enumerable` on Android.
+- `AppContext.currentActivity` is not longer returning `AppCompatActivity`, but an instance of `android.app.Activity` class.
 
 ### 🎉 New features
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -240,11 +240,12 @@ class AppContext(
   }
 
   internal fun onHostResume() {
-    activityResultsManager.onHostResume(
-      requireNotNull(currentActivity) {
-        "Current Activity is not available at this moment. This is an invalid state and this should never happen"
-      }
-    )
+    val activity = currentActivity
+    check(activity is AppCompatActivity) {
+      "Current Activity is of incorrect class, expected AppCompatActivity, received ${currentActivity?.localClassName}"
+    }
+
+    activityResultsManager.onHostResume(activity)
     registry.post(EventName.ACTIVITY_ENTERS_FOREGROUND)
   }
 
@@ -254,6 +255,10 @@ class AppContext(
 
   internal fun onHostDestroy() {
     currentActivity?.let {
+      check(it is AppCompatActivity) {
+        "Current Activity is of incorrect class, expected AppCompatActivity, received ${currentActivity?.localClassName}"
+      }
+
       activityResultsManager.onHostDestroy(it)
     }
     registry.post(EventName.ACTIVITY_DESTROYS)
@@ -288,15 +293,9 @@ class AppContext(
 
 // region CurrentActivityProvider
 
-  override val currentActivity: AppCompatActivity?
+  override val currentActivity: Activity?
     get() {
-      val currentActivity = this.activityProvider?.currentActivity ?: return null
-
-      check(currentActivity is AppCompatActivity) {
-        "Current Activity is of incorrect class, expected AppCompatActivity, received ${currentActivity.localClassName}"
-      }
-
-      return currentActivity
+      return activityProvider?.currentActivity
     }
 
 // endregion

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/activityresult/AppContextActivityResultRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/activityresult/AppContextActivityResultRegistry.kt
@@ -86,7 +86,7 @@ class AppContextActivityResultRegistry(
   private val pendingResults = Bundle/*<String, ActivityResult>*/()
 
   private val activity: AppCompatActivity
-    get() = requireNotNull(currentActivityProvider.currentActivity) { "Current Activity is not available at the moment" }
+    get() = requireNotNull(currentActivityProvider.currentActivity as? AppCompatActivity) { "Current Activity is not available at the moment" }
 
   /**
    * This method body is adapted mainly from [ComponentActivity.mActivityResultRegistry]

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/providers/CurrentActivityProvider.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/providers/CurrentActivityProvider.kt
@@ -13,10 +13,9 @@ import android.app.Activity
 */
 interface CurrentActivityProvider {
   /**
-   * Returns the current [Activity] that should be an instance of [AppCompatActivity].
-   * This activity is most likely an instance of [ReactActivity], but it's been decided not to expose
-   * `react-native` symbols via `expo-module-core` public API.
+   * Returns the current [Activity] that should be an instance of  [ReactActivity],
+   * but it's been decided not to expose `react-native` symbols via `expo-module-core` public API.
    * @returns null if the [Activity] is not yet available (eg. Application has not yet fully started)
    */
-  val currentActivity: AppCompatActivity?
+  val currentActivity: Activity?
 }


### PR DESCRIPTION
# Why

We can't return `AppCompatActivity` from the `AppContext.currentActivity`, because that symbol may not be defined in the user library. In theory, we could reexport the androidx package from `e-m-c`, but I don't see a reason why. It doesn't sound like a good idea. 

# How

Replaced `AppCompatActivity` with pure `Activity` class

# Test Plan

- unit tests ✅