### PR TITLE
[modules][Android] Add `OnViewDidUpdateProps`

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewDefinitionBuilder.kt
@@ -21,17 +21,21 @@ class ViewDefinitionBuilder<T : View>(private val viewType: KClass<T>) {
   internal var onViewDestroys: ((View) -> Unit)? = null
 
   @PublishedApi
+  internal var onViewDidUpdateProps: ((View) -> Unit)? = null
+
+  @PublishedApi
   internal var viewGroupDefinition: ViewGroupDefinition? = null
   private var callbacksDefinition: CallbacksDefinition? = null
 
   fun build(): ViewManagerDefinition =
     ViewManagerDefinition(
-      createViewFactory(),
-      viewType.java,
-      props,
-      onViewDestroys,
-      callbacksDefinition,
-      viewGroupDefinition
+      viewFactory = createViewFactory(),
+      viewType = viewType.java,
+      props = props,
+      onViewDestroys = onViewDestroys,
+      callbacksDefinition = callbacksDefinition,
+      viewGroupDefinition = viewGroupDefinition,
+      onViewDidUpdateProps = onViewDidUpdateProps
     )
 
   /**
@@ -39,6 +43,13 @@ class ViewDefinitionBuilder<T : View>(private val viewType: KClass<T>) {
    */
   inline fun <reified ViewType : View> OnViewDestroys(noinline body: (view: ViewType) -> Unit) {
     onViewDestroys = { body(it as ViewType) }
+  }
+
+  /**
+   * Defines the view lifecycle method that is called when the view finished updating all props.
+   */
+  inline fun <reified ViewType : View> OnViewDidUpdateProps(noinline body: (view: ViewType) -> Unit) {
+    onViewDidUpdateProps = { body(it as ViewType) }
   }
 
   /**

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerDefinition.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerDefinition.kt
@@ -19,7 +19,8 @@ class ViewManagerDefinition(
   private val props: Map<String, AnyViewProp>,
   val onViewDestroys: ((View) -> Unit)? = null,
   val callbacksDefinition: CallbacksDefinition? = null,
-  val viewGroupDefinition: ViewGroupDefinition? = null
+  val viewGroupDefinition: ViewGroupDefinition? = null,
+  val onViewDidUpdateProps: ((View) -> Unit)? = null
 ) {
 
   fun createView(context: Context, appContext: AppContext): View = viewFactory(context, appContext)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerWrapperDelegate.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerWrapperDelegate.kt
@@ -32,6 +32,7 @@ class ViewManagerWrapperDelegate(internal var moduleHolder: ModuleHolder) {
 
   fun setProxiedProperties(view: View, proxiedProperties: ReadableMap) {
     definition.setProps(proxiedProperties, view)
+    definition.onViewDidUpdateProps?.invoke(view)
   }
 
   fun onDestroy(view: View) =


### PR DESCRIPTION
# Why

In https://github.com/expo/expo/pull/19549, `OnViewDidUpdateProps` was introduced. This PR aims to provide the same callback on Android. 

# How

Added another view callback. I think for future improvements, we should rewrite how information about the view lifecycle functions on Android is stored, but that would be done in a separate PR. 

# Test Plan

- NCL with modified native code for linear gradient 