### PR TITLE
[test-suite] Upgrade `@react-navigation`

### DIFF
--- a/apps/test-suite/App.js
+++ b/apps/test-suite/App.js
@@ -5,10 +5,12 @@ import * as React from 'react';
 import AppNavigator from './AppNavigator';
 
 const linking = {
-  prefixes: [Linking.makeUrl('/')],
-  screens: {
-    select: '',
-    run: 'run',
+  prefixes: [Linking.createURL('/')],
+  config: {
+    screens: {
+      select: '',
+      run: 'run',
+    },
   },
 };
 export default () => (

--- a/apps/test-suite/package.json
+++ b/apps/test-suite/package.json
@@ -11,6 +11,8 @@
   "license": "MIT",
   "dependencies": {
     "@expo/html-elements": "^0.2.0",
+    "@react-navigation/native": "~6.0.13",
+    "@react-navigation/stack": "~6.3.2",
     "async-retry": "^1.1.4",
     "expo": "~47.0.0-alpha.1",
     "expo-application": "~5.0.0",


### PR DESCRIPTION
# Why

Fixes:
```
I couldn’t make this project run without removing the linking prop from NavigationContainer in App.js. Got a Error: Found invalid properties in the configuration redbox.
```
Upgrades `react-navigation` to the newest version. 

# How

- Added a missing dependency 
- Changed linking config

# Test Plan

- test-suite ✅