### PR TITLE
[docs] Android Studio Emulator: utilize helper components, update page

### DIFF
--- a/docs/pages/workflow/android-studio-emulator.mdx
+++ b/docs/pages/workflow/android-studio-emulator.mdx
@@ -3,55 +3,75 @@ title: Android Studio Emulator
 ---
 
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
+import { Step } from '~/ui/components/Step';
+import { Terminal } from '~/ui/components/Snippet';
 
-If you don't have an Android device available to test with, we recommend using the default emulator that comes with Android Studio. If you run into any problems setting it up, follow the steps in this guide.
+If you don't have an Android device available to test with, we recommend using the default emulator that comes with Android Studio.
+If you run into any problems setting it up, follow the steps in this guide.
 
-## Step 1: Set up Android Studio's tools
+## Set up Android Studio's tools
 
-- [Download](https://developer.android.com/studio) and install Android Studio 3.0+.
+<Step label="1">
+  [Download](https://developer.android.com/studio) and install Android Studio 3.0+.
+</Step>
 
-- Select "Standard" for the "Install Type" inside the wizard.
+<Step label="2">Select **"Standard"** for the **"Install Type"** inside the wizard.</Step>
 
-- Inside Android Studio, go to Preferences > Appearance & Behavior > System Settings > Android SDK. Click on the "SDK Tools" tab and make sure you have at least one version of the "Android SDK Build-Tools" installed.
+<Step label="3">
+Inside Android Studio, go to **Preferences > Appearance & Behavior > System Settings > Android SDK**.
+Click on the **"SDK Tools"** tab and make sure you have at least one version of the **"Android SDK Build-Tools"** installed.
 
 <ImageSpotlight
   alt="Android SDK build tools"
   src="/static/images/android-studio-build-tools.png"
-  containerStyle={{ paddingBottom: 0 }}
 />
+</Step>
 
-- Copy or remember the path listed in the box that says "Android SDK Location."
+<Step label="4">
+Copy or remember the path listed in the box that says **"Android SDK Location"**.
 
 <ImageSpotlight
   alt="Android SDK location"
   src="/static/images/android-studio-sdk-location.png"
-  containerStyle={{ paddingBottom: 0 }}
 />
+</Step>
 
-- If you are on macOS or Linux, add an [environment variable](https://developer.android.com/studio/command-line/variables#envar) pointing to the Android SDK location in `~/.bash_profile` (or `~/.zshenv` if you use Zsh) - eg. `export ANDROID_HOME=/your/path/here`. Copy and paste these two lines to do this automatically for Bash and Zsh:
+<Step label="5">
+If you are on macOS or Linux, add an [environment variable](https://developer.android.com/studio/command-line/variables#envar) pointing to the Android SDK location
+in `~/.bash_profile` (or `~/.zshenv` if you use Zsh) - eg. `export ANDROID_HOME=/your/path/here`. Copy and paste these two lines to do this automatically for Bash and Zsh:
 
 ```bash
 [ -d "$HOME/Library/Android/sdk" ] && ANDROID_HOME=$HOME/Library/Android/sdk || ANDROID_HOME=$HOME/Android/Sdk
 echo "export ANDROID_HOME=$ANDROID_HOME" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bash_profile'`
 ```
 
-- On macOS, you will also need to add `platform-tools` to your `~/.bash_profile` (or `~/.zshenv` if you use Zsh) - eg. `export PATH=/your/path/here:$PATH`. Copy and paste this line to do this automatically for Bash and Zsh:
+</Step>
+
+<Step label="6">
+On macOS, you will also need to add `platform-tools` to your `~/.bash_profile` (or `~/.zshenv` if you use Zsh) - eg. `export PATH=/your/path/here:$PATH`.
+Copy and paste this line to do this automatically for Bash and Zsh:
 
 ```bash
 echo "export PATH=$ANDROID_HOME/platform-tools:\$PATH" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bash_profile'`
 ```
 
-- Reload the path environment variables by running:
+</Step>
+
+<Step label="7">
+Reload the path environment variables by running:
 
 ```bash
 source ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bash_profile'`
 ```
 
-- Finally, make sure that you can run `adb` from your terminal.
+</Step>
 
-## Step 2: Set up a virtual device
+<Step label="7">Finally, make sure that you can run `adb` from your terminal.</Step>
 
-- On the Android Studio main screen, click "More Actions", then "Virtual Device Manager" in the dropdown.
+## Set up a virtual device
+
+<Step label="1">
+On the Android Studio main screen, click **"More Actions"**, then **"Virtual Device Manager"** in the dropdown.
 
 <ImageSpotlight
   alt="Android Studio configure"
@@ -66,42 +86,57 @@ If you already have a project, then the menu will show up under the three dots m
   src="/static/images/android-studio-configure-2.png"
   containerStyle={{ paddingBottom: 0 }}
 />
+</Step>
 
-- Press the "Create device" button.
+<Step label="2">
+Press the **"Create device"** button.
 
 <ImageSpotlight
   alt="Android Studio create virtual device"
   src="/static/images/android-studio-avd-manager.png"
   containerStyle={{ paddingBottom: 0 }}
 />
+</Step>
 
-- Choose the type of hardware you'd like to emulate. We recommend testing against a variety of devices, but if you're unsure where to start, the newest device in the Pixel line could be a good choice.
+<Step label="3">
+  Choose the type of hardware you'd like to emulate. We recommend testing against a variety of
+  devices, but if you're unsure where to start, the newest device in the Pixel line could be a good
+  choice.
+</Step>
 
-- Select an OS version to load on the emulator (probably one of the system images in the "Recommended" tab), and download the image.
+<Step label="4">
+  Select an OS version to load on the emulator (probably one of the system images in the
+  **"Recommended"** tab), and download the image.
+</Step>
 
-- Change any other settings you'd like, and press "Finish" to create the virtual device. You can now run this device anytime by pressing the Play button in the AVD Manager window.
+<Step label="5">
+  Change any other settings you'd like, and press **"Finish"** to create the virtual device. You can
+  now run this device anytime by pressing the Play button in the AVD Manager window.
+</Step>
 
-#### Multiple `adb` versions
+### Multiple `adb` versions
 
 Having multiple `adb` versions on your system can result in the error `adb server version (xx) doesn't match this client (xx); killing...`
 
 This is because the adb version on your system is different from the adb version on the android sdk platform-tools.
 
-- Open the terminal and check the `adb` version on the system:
+<Step label="1">
+Open the terminal and check the `adb` version on the system:
 
-```bash
-adb version
-```
+<Terminal cmd={['$ adb version']} />
+</Step>
 
-- And from the Android SDK platform-tool directory:
+<Step label="2">
+And from the Android SDK platform-tool directory:
 
-```bash
-cd ~/Library/Android/sdk/platform-tools
-./adb version
-```
+<Terminal cmd={[
+  '$ cd ~/Library/Android/sdk/platform-tools',
+  '$ ./adb version'
+]} cmdCopy="cd ~/Library/Android/sdk/platform-tools && ./adb version" />
+</Step>
 
-- Copy `adb` from Android SDK directory to `usr/bin` directory:
+<Step label="3">
+Copy `adb` from Android SDK directory to `usr/bin` directory:
 
-```bash
-sudo cp ~/Library/Android/sdk/platform-tools/adb /usr/bin
-```
+<Terminal cmd={['$ sudo cp ~/Library/Android/sdk/platform-tools/adb /usr/bin']} />
+</Step>

--- a/docs/pages/workflow/android-studio-emulator.mdx
+++ b/docs/pages/workflow/android-studio-emulator.mdx
@@ -12,10 +12,16 @@ If you run into any problems setting it up, follow the steps in this guide.
 ## Set up Android Studio's tools
 
 <Step label="1">
-  [Download](https://developer.android.com/studio) and install Android Studio 3.0+.
+
+[Download](https://developer.android.com/studio) and install Android Studio 3.0+.
+
 </Step>
 
-<Step label="2">Select **"Standard"** for the **"Install Type"** inside the wizard.</Step>
+<Step label="2">
+
+Select **"Standard"** for the **"Install Type"** inside the wizard.
+
+</Step>
 
 <Step label="3">
 Inside Android Studio, go to **Preferences > Appearance & Behavior > System Settings > Android SDK**.

--- a/docs/pages/workflow/android-studio-emulator.mdx
+++ b/docs/pages/workflow/android-studio-emulator.mdx
@@ -50,7 +50,6 @@ in `~/.bash_profile` (or `~/.zshenv` if you use Zsh) - eg. `export ANDROID_HOME=
 [ -d "$HOME/Library/Android/sdk" ] && ANDROID_HOME=$HOME/Library/Android/sdk || ANDROID_HOME=$HOME/Android/Sdk
 echo "export ANDROID_HOME=$ANDROID_HOME" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bash_profile'`
 ```
-
 </Step>
 
 <Step label="6">
@@ -60,7 +59,6 @@ Copy and paste this line to do this automatically for Bash and Zsh:
 ```bash
 echo "export PATH=$ANDROID_HOME/platform-tools:\$PATH" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bash_profile'`
 ```
-
 </Step>
 
 <Step label="7">
@@ -69,10 +67,13 @@ Reload the path environment variables by running:
 ```bash
 source ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bash_profile'`
 ```
-
 </Step>
 
-<Step label="8">Finally, make sure that you can run `adb` from your terminal.</Step>
+<Step label="8">
+
+Finally, make sure that you can run `adb` from your terminal.
+
+</Step>
 
 ## Set up a virtual device
 

--- a/docs/pages/workflow/android-studio-emulator.mdx
+++ b/docs/pages/workflow/android-studio-emulator.mdx
@@ -66,7 +66,7 @@ source ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bash_profile'`
 
 </Step>
 
-<Step label="7">Finally, make sure that you can run `adb` from your terminal.</Step>
+<Step label="8">Finally, make sure that you can run `adb` from your terminal.</Step>
 
 ## Set up a virtual device
 

--- a/docs/pages/workflow/android-studio-emulator.mdx
+++ b/docs/pages/workflow/android-studio-emulator.mdx
@@ -44,7 +44,7 @@ Copy or remember the path listed in the box that says **"Android SDK Location"**
 
 <Step label="5">
 If you are on macOS or Linux, add an [environment variable](https://developer.android.com/studio/command-line/variables#envar) pointing to the Android SDK location
-in `~/.bash_profile` (or `~/.zshenv` if you use Zsh) - eg. `export ANDROID_HOME=/your/path/here`. Copy and paste these two lines to do this automatically for Bash and Zsh:
+in `~/.bash_profile` (or `~/.zshenv` if you use Zsh) - for example:`export ANDROID_HOME=/your/path/here`. Copy and paste these two lines to do this automatically for Bash and Zsh:
 
 ```bash
 [ -d "$HOME/Library/Android/sdk" ] && ANDROID_HOME=$HOME/Library/Android/sdk || ANDROID_HOME=$HOME/Android/Sdk
@@ -53,7 +53,7 @@ echo "export ANDROID_HOME=$ANDROID_HOME" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.
 </Step>
 
 <Step label="6">
-On macOS, you will also need to add `platform-tools` to your `~/.bash_profile` (or `~/.zshenv` if you use Zsh) - eg. `export PATH=/your/path/here:$PATH`.
+On macOS, you will also need to add `platform-tools` to your `~/.bash_profile` (or `~/.zshenv` if you use Zsh) - for example: `export PATH=/your/path/here:$PATH`.
 Copy and paste this line to do this automatically for Bash and Zsh:
 
 ```bash


### PR DESCRIPTION
# Why

Let's update the Android Studio Emulator structure to discuss the optimal use case for Step component.

# How

This PR adds the steps for the given part of Android Studio Emulator configuration. Additionally I have utilized the Terminal components where applicable and updated a formatting in few paragraphs.

# Test Plan

The change shave been tested locally, but running docs app.

# Preview

<img width="1546" alt="Screenshot 2022-10-17 at 15 04 51" src="https://user-images.githubusercontent.com/719641/196184519-72e276d0-4635-40f1-b153-e66f4ddb1ee5.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
