### PR TITLE
[expo-updates] Add code signing logging

### DIFF
--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/codesigning/CodeSigningConfiguration.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/codesigning/CodeSigningConfiguration.kt
@@ -60,7 +60,7 @@ class CodeSigningConfiguration(
     )
   }
 
-  fun validateSignatureInternal(info: SignatureHeaderInfo, bodyBytes: ByteArray, manifestResponseCertificateChain: String?): SignatureValidationResult {
+  private fun validateSignatureInternal(info: SignatureHeaderInfo, bodyBytes: ByteArray, manifestResponseCertificateChain: String?): SignatureValidationResult {
     val certificateChain = if (includeManifestResponseCertificateChain) {
       CertificateChain(
         separateCertificateChain(manifestResponseCertificateChain ?: "") + embeddedCertificateString

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
@@ -255,7 +255,7 @@ open class FileDownloader(context: Context, private val client: OkHttpClient) {
             override fun onCompleted(isValid: Boolean) {
               if (isValid) {
                 try {
-                  checkCodeSigningAndCreateManifest(manifestBody, preManifest, manifestHeaderData, extensions, certificateChainFromManifestResponse, true, configuration, callback)
+                  checkCodeSigningAndCreateManifest(manifestBody, preManifest, manifestHeaderData, extensions, certificateChainFromManifestResponse, true, configuration, logger, callback)
                 } catch (e: Exception) {
                   callback.onFailure("Failed to parse manifest data", e)
                 }
@@ -271,7 +271,7 @@ open class FileDownloader(context: Context, private val client: OkHttpClient) {
           }
         )
       } else {
-        checkCodeSigningAndCreateManifest(manifestBody, preManifest, manifestHeaderData, extensions, certificateChainFromManifestResponse, false, configuration, callback)
+        checkCodeSigningAndCreateManifest(manifestBody, preManifest, manifestHeaderData, extensions, certificateChainFromManifestResponse, false, configuration, logger, callback)
       }
     } catch (e: Exception) {
       val message = "Failed to parse manifest data: ${e.localizedMessage}"
@@ -410,6 +410,7 @@ open class FileDownloader(context: Context, private val client: OkHttpClient) {
       certificateChainFromManifestResponse: String?,
       isVerified: Boolean,
       configuration: UpdatesConfiguration,
+      logger: UpdatesLogger,
       callback: ManifestDownloadCallback
     ) {
       if (configuration.expectsSignedManifest) {
@@ -448,10 +449,12 @@ open class FileDownloader(context: Context, private val client: OkHttpClient) {
               }
             }
 
+            logger.info("Update code signature verified successfully")
             preManifest.put("isVerified", true)
           }
         }
       } catch (e: Exception) {
+        logger.error(e.message!!, UpdatesErrorCode.UpdateCodeSigningError)
         callback.onFailure(e.message!!, e)
         return
       }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/logging/UpdatesErrorCode.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/logging/UpdatesErrorCode.kt
@@ -9,6 +9,7 @@ enum class UpdatesErrorCode(val code: String) {
   UpdateAssetsNotAvailable("UpdateAssetsNotAvailable"),
   UpdateServerUnreachable("UpdateServerUnreachable"),
   UpdateHasInvalidSignature("UpdateHasInvalidSignature"),
+  UpdateCodeSigningError("UpdateCodeSigningError"),
   UpdateFailedToLoad("UpdateFailedToLoad"),
   AssetsFailedToLoad("AssetsFailedToLoad"),
   JSRuntimeError("JSRuntimeError"),

--- a/packages/expo-updates/ios/EXUpdates/Logging/UpdatesErrorCode.swift
+++ b/packages/expo-updates/ios/EXUpdates/Logging/UpdatesErrorCode.swift
@@ -16,6 +16,7 @@ public enum UpdatesErrorCode: Int {
   case assetsFailedToLoad = 6
   case jsRuntimeError = 7
   case unknown = 8
+  case updateCodeSigningError = 9
 
   // Because this enum is exported to Objective-C,
   // the usual "\(UpdatesErrorCode.NoUpdatesAvailable)"
@@ -33,6 +34,8 @@ public enum UpdatesErrorCode: Int {
       return "UpdateServerUnreachable"
     case .updateHasInvalidSignature:
       return "UpdateHasInvalidSignature"
+    case .updateCodeSigningError:
+      return "UpdateCodeSigningError"
     case .updateFailedToLoad:
       return "UpdateFailedToLoad"
     case .assetsFailedToLoad:

--- a/packages/expo-updates/src/Updates.types.ts
+++ b/packages/expo-updates/src/Updates.types.ts
@@ -164,7 +164,7 @@ export enum UpdatesLogEntryCode {
   UPDATE_ASSETS_NOT_AVAILABLE = 'UpdateAssetsNotAvailable',
   UPDATE_SERVER_UNREACHABLE = 'UpdateServerUnreachable',
   UPDATE_HAS_INVALID_SIGNATURE = 'UpdateHasInvalidSignature',
-  UpdateCodeSigningError = 'UpdateCodeSigningError',
+  UPDATE_CODE_SIGNING_ERROR = 'UpdateCodeSigningError',
   UPDATE_FAILED_TO_LOAD = 'UpdateFailedToLoad',
   ASSETS_FAILED_TO_LOAD = 'AssetsFailedToLoad',
   JS_RUNTIME_ERROR = 'JSRuntimeError',

--- a/packages/expo-updates/src/Updates.types.ts
+++ b/packages/expo-updates/src/Updates.types.ts
@@ -164,6 +164,7 @@ export enum UpdatesLogEntryCode {
   UPDATE_ASSETS_NOT_AVAILABLE = 'UpdateAssetsNotAvailable',
   UPDATE_SERVER_UNREACHABLE = 'UpdateServerUnreachable',
   UPDATE_HAS_INVALID_SIGNATURE = 'UpdateHasInvalidSignature',
+  UpdateCodeSigningError = 'UpdateCodeSigningError',
   UPDATE_FAILED_TO_LOAD = 'UpdateFailedToLoad',
   ASSETS_FAILED_TO_LOAD = 'AssetsFailedToLoad',
   JS_RUNTIME_ERROR = 'JSRuntimeError',


### PR DESCRIPTION
# Why

This PR solves the problem of not being able to detect that code signing is working as expected once set up (without doing something like intercepting network traffic).

Closes ENG-6737.

# How

Add logging using the new logger classes to indicate both failures and successes.

# Test Plan

Build on both platforms. Inspect.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
