### PR TITLE
[expo-updates] proactively delete duplicate asset rows from SQLite

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Log various errors with the new Updates logger; add E2E tests for the logger. ([#18810](https://github.com/expo/expo/pull/18810) by [@douglowder](https://github.com/douglowder))
 - [iOS] Flag to enable native debugging of updates. ([#19292](https://github.com/expo/expo/pull/19292) by [@douglowder](https://github.com/douglowder))
 - [Android] Flag to enable native debugging of updates. ([#19441](https://github.com/expo/expo/pull/19441) by [@douglowder](https://github.com/douglowder))
+- Proactively delete duplicate asset rows from SQLite as soon as their corresponding updates are deleted, rather than keeping them all around until no updates are using the asset. ([#19590](https://github.com/expo/expo/pull/19590) by [@esamelson](https://github.com/esamelson))
 
 ### ⚠️ Notices
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/db/UpdatesDatabaseTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/db/UpdatesDatabaseTest.kt
@@ -172,13 +172,15 @@ class UpdatesDatabaseTest {
 
     val deletedAssets = assetDao.deleteUnusedAssets()
 
+    // asset2 should NOT be in the returned list of rows (files to delete)...
     Assert.assertEquals(1, deletedAssets.size)
     for (deletedAsset in deletedAssets) {
       Assert.assertEquals("asset1", deletedAsset.key)
     }
 
+    // ...but it should have been deleted anyway
     Assert.assertNull(assetDao.loadAssetWithKey("asset1"))
-    Assert.assertNotNull(assetDao.loadAssetWithKey("asset2"))
+    Assert.assertNull(assetDao.loadAssetWithKey("asset2"))
     Assert.assertNotNull(assetDao.loadAssetWithKey("asset3"))
   }
 }

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.m
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.m
@@ -308,8 +308,10 @@ static NSString * const EXUpdatesDatabaseStaticBuildDataKey = @"staticBuildData"
     return nil;
   }
 
-  // check for duplicate rows representing a single file on disk
-  NSString * const update3Sql = @"UPDATE assets SET marked_for_deletion = 0 WHERE relative_path IN (\
+  // find any duplicate rows representing a single file on disk where `marked_for_deletion` is 1
+  // in some cases but 0 in others, and delete the rows with 1 without returning them (so the file
+  // itself is not deleted)
+  NSString * const update3Sql = @"DELETE FROM assets WHERE marked_for_deletion = 1 AND relative_path IN (\
   SELECT relative_path\
   FROM assets\
   WHERE marked_for_deletion = 0\

--- a/packages/expo-updates/ios/Tests/EXUpdatesDatabaseTests.m
+++ b/packages/expo-updates/ios/Tests/EXUpdatesDatabaseTests.m
@@ -292,15 +292,15 @@
       return;
     }
 
-    // asset1 should have been deleted, but asset2 should have been kept
-    // since it shared a filename with asset3, which is still in use
+    // asset `key2` should NOT be in the returned list of rows (files to delete)...
     XCTAssertEqual(1, deletedAssets.count);
     for (EXUpdatesAsset *deletedAsset in deletedAssets) {
       XCTAssertEqualObjects(@"key1", deletedAsset.key);
     }
 
+    // ...but it should have been deleted anyway
     XCTAssertNil([_db assetWithKey:@"key1" error:nil]);
-    XCTAssertNotNil([_db assetWithKey:@"key2" error:nil]);
+    XCTAssertNil([_db assetWithKey:@"key2" error:nil]);
     XCTAssertNotNil([_db assetWithKey:@"key3" error:nil]);
   });
 }


### PR DESCRIPTION
# Why

Resolves ENG-2479

@wschurman @douglowder up to you whether to merge this. It’s a tiny, inconsequential change suggested in https://github.com/expo/expo/pull/15049#discussion_r743308981 to keep the SQLite database a bit cleaner in a weird edge case.

If we somehow end up with duplicate asset rows in SQLite — i.e. multiple rows that point to the same file on disk — we currently keep ALL rows in the database until none of them are needed anymore (i.e. no update uses the asset and it’s cleared from disk). This PR makes a small change to proactively delete each duplicate row as soon as its corresponding update is deleted, but still ensures the asset itself isn’t removed from disk until all rows have been deleted.

# How

In the reaper process, when looking for duplicate asset rows, rather than unmarking them all from deleting, simply delete the now-unused duplicate rows without returning them (and causing the file to be deleted).

# Test Plan

I updated the unit tests for this case (added in #15049) to match the slightly different expected outcome as a result of this PR.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
