### PR TITLE
[tools] update ios versioning script for sdk 47

### DIFF
--- a/tools/src/versioning/ios/transforms/postTransforms.ts
+++ b/tools/src/versioning/ios/transforms/postTransforms.ts
@@ -141,50 +141,6 @@ export function postTransforms(versionName: string): TransformPipeline {
         with: `${versionName}$1`,
       },
 
-      // react-native-svg
-      {
-        paths: 'RNSVGRenderable.m',
-        replace: /\b(saturate)\(/g,
-        with: `${versionName}$1(`,
-      },
-      {
-        paths: 'RNSVGPainter.m',
-        replace: /\b(PatternFunction)\b/g,
-        with: `${versionName}$1`,
-      },
-      {
-        paths: 'RNSVGFontData.m',
-        replace: /\b(AbsoluteFontWeight|bolder|lighter|nearestFontWeight)\(/gi,
-        with: `${versionName}$1(`,
-      },
-      {
-        paths: 'RNSVGTSpan.m',
-        replace: new RegExp(`\\b(${versionName}RNSVGTopAlignedLabel\\s*\\*\\s*label)\\b`, 'gi'),
-        with: 'static $1',
-      },
-      {
-        paths: 'RNSVGMarker.m',
-        replace: /\b(deg2rad)\b/g,
-        with: `${versionName}$1`,
-      },
-      {
-        paths: 'RNSVGMarkerPosition.m',
-        replace:
-          /\b(PathIsDone|rad2deg|SlopeAngleRadians|CurrentAngle|subtract|ExtractPathElementFeatures|UpdateFromPathElement)\b/g,
-        with: `${versionName}$1`,
-      },
-      {
-        paths: 'RNSVGMarkerPosition.m',
-        replace:
-          /\b(positions_|element_index_|origin_|subpath_start_|in_slope_|out_slope_|auto_start_reverse_)\b/g,
-        with: `${versionName}$1`,
-      },
-      {
-        paths: 'RNSVGPathMeasure.m',
-        replace: /\b(distance|subdivideBezierAtT)\b/g,
-        with: `${versionName}$1`,
-      },
-
       // react-native-webview
       {
         paths: 'RNCWebView.m',

--- a/tools/src/versioning/ios/transforms/vendoredModulesTransforms.ts
+++ b/tools/src/versioning/ios/transforms/vendoredModulesTransforms.ts
@@ -92,11 +92,6 @@ export default function vendoredModulesTransformsFactory(prefix: string): Config
         },
         {
           paths: 'REAAnimationsManager.m',
-          find: `UIView+${prefix}React.h`,
-          replaceWith: `UIView+React.h`,
-        },
-        {
-          paths: 'REAAnimationsManager.m',
           // `dataComponenetsByName[@"ABI44_0_0RCTView"];` -> `dataComponenetsByName[@"RCTView"];`
           // the RCTComponentData internal view name is not versioned
           find: new RegExp(`(RCTComponentData .+)\\[@"${prefix}(RCT.+)"\\];`, 'g'),
@@ -132,10 +127,6 @@ export default function vendoredModulesTransformsFactory(prefix: string): Config
       ],
       content: [
         {
-          find: `UIView+${prefix}React.h`,
-          replaceWith: `${prefix}UIView+React.h`,
-        },
-        {
           // `RNG*` symbols are already prefixed at this point,
           // but there are some new symbols in RNGH that don't have "G".
           paths: '*.{h,m,mm}',
@@ -163,20 +154,8 @@ export default function vendoredModulesTransformsFactory(prefix: string): Config
       ],
       content: [
         {
-          find: `UIView+${prefix}React.h`,
-          replaceWith: `${prefix}UIView+React.h`,
-        },
-        {
           find: `${prefix}JKBigInteger.h`,
           replaceWith: `JKBigInteger.h`,
-        },
-      ],
-    },
-    '@react-native-segmented-control/segmented-control': {
-      content: [
-        {
-          find: `UIView+${prefix}React.h`,
-          replaceWith: `${prefix}UIView+React.h`,
         },
       ],
     },
@@ -186,7 +165,7 @@ export default function vendoredModulesTransformsFactory(prefix: string): Config
     '@shopify/react-native-skia': {
       path: [
         {
-          find: /\b(DisplayLink|PlatformContext|SkiaDrawView|SkiaDrawViewManager|SkiaManager)/g,
+          find: /\b(DisplayLink|PlatformContext|SkiaDrawView|SkiaDrawViewManager|SkiaManager|SkiaUIView|SkiaPictureViewManager)/g,
           replaceWith: `${prefix}$1`,
         },
       ],
@@ -197,7 +176,7 @@ export default function vendoredModulesTransformsFactory(prefix: string): Config
           replaceWith: `ReactCommon/${prefix}`,
         },
         {
-          find: /\b(DisplayLink|PlatformContext|SkiaDrawView|SkiaDrawViewManager|SkiaManager|RNJsi)/g,
+          find: /\b(DisplayLink|PlatformContext|SkiaDrawView|SkiaDrawViewManager|SkiaManager|RNJsi|SkiaUIView|SkiaPictureViewManager)/g,
           replaceWith: `${prefix}$1`,
         },
         {
@@ -213,6 +192,54 @@ export default function vendoredModulesTransformsFactory(prefix: string): Config
             'gm'
           ),
           replaceWith: '$1$2',
+        },
+      ],
+    },
+    'react-native-svg': {
+      content: [
+        {
+          find: new RegExp(`\\b(${prefix}RCTConvert)\\+${prefix}(RNSVG\.h)`, 'g'),
+          replaceWith: `$1+$2`,
+        },
+        {
+          paths: 'RNSVGRenderable.mm',
+          find: /\b(saturate)\(/g,
+          replaceWith: `${prefix}$1(`,
+        },
+        {
+          paths: 'RNSVGPainter.mm',
+          find: /\b(PatternFunction)\b/g,
+          replaceWith: `${prefix}$1`,
+        },
+        {
+          paths: 'RNSVGFontData.mm',
+          find: /\b(AbsoluteFontWeight|bolder|lighter|nearestFontWeight)\(/gi,
+          replaceWith: `${prefix}$1(`,
+        },
+        {
+          paths: 'RNSVGTSpan.mm',
+          find: new RegExp(`\\b(${prefix}RNSVGTopAlignedLabel\\s*\\*\\s*label)\\b`, 'gi'),
+          replaceWith: 'static $1',
+        },
+        {
+          paths: 'RNSVGMarker.mm',
+          find: /\b(deg2rad)\b/g,
+          replaceWith: `${prefix}$1`,
+        },
+        {
+          paths: 'RNSVGMarkerPosition.mm',
+          find: /\b(PathIsDone|rad2deg|SlopeAngleRadians|CurrentAngle|subtract|ExtractPathElementFeatures|UpdateFromPathElement)\b/g,
+          replaceWith: `${prefix}$1`,
+        },
+        {
+          paths: 'RNSVGMarkerPosition.mm',
+          find: /\b(positions_|element_index_|origin_|subpath_start_|in_slope_|out_slope_|auto_start_reverse_)\b/g,
+          replaceWith: `${prefix}$1`,
+        },
+        {
+          paths: 'RNSVGPathMeasure.mm',
+          find: /\b(distance|subdivideBezierAtT)\b/g,
+          replaceWith: `${prefix}$1`,
         },
       ],
     },

--- a/tools/src/versioning/ios/versionVendoredModules.ts
+++ b/tools/src/versioning/ios/versionVendoredModules.ts
@@ -167,6 +167,10 @@ function baseTransformsFactory(prefix: string): Required<FileTransforms> {
         replaceWith: `Is${prefix}ReactRootView`,
       },
       {
+        find: `UIView+${prefix}React.h`,
+        replaceWith: `${prefix}UIView+React.h`,
+      },
+      {
         // Prefix only unindented `@objc` (notice `^` and `m` flag in the pattern). Method names shouldn't get prefixed.
         paths: '*.swift',
         find: /^@objc\(([^)]+)\)/gm,


### PR DESCRIPTION
# Why

fix ios versioning for sdk 47

# How

- move `UIView+${prefix}React.h -> ${prefix}UIView+React.h` as generic transform since there're more modules need this.
- react-native-svg is using new style vendoring. this pr moves its transforms from exponent transform to vendored transform.
- versioning more @shopify/react-native-skia files

# Test Plan

versioning expo go ci passed

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
