### PR TITLE
[location] update play services location and smartlocation

### DIFF
--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 🛠 Breaking changes
 
 - Bumped iOS deployment target to 13.0 and deprecated support for iOS 12. ([#18873](https://github.com/expo/expo/pull/18873) by [@tsapeta](https://github.com/tsapeta))
+- Bumped play-services-location and smartlocation:library to latest versions
 
 ### 🎉 New features
 

--- a/packages/expo-location/android/build.gradle
+++ b/packages/expo-location/android/build.gradle
@@ -84,9 +84,9 @@ android {
 dependencies {
   implementation project(':expo-modules-core')
 
-  api 'com.google.android.gms:play-services-location:16.0.0'
+  api 'com.google.android.gms:play-services-location:21.0.0'
 
-  api('io.nlopez.smartlocation:library:3.2.11') {
+  api('io.nlopez.smartlocation:library:3.3.3') {
     transitive = false
   }
 


### PR DESCRIPTION
# Why

Updated Play Services Location and Smartlocation to latest available versions.

# How

Updated gradle files to latest versions and updated LocationHelper to remove deprecated stuff.

# Test Plan

Built an app and checked location on a real device.

# Checklist

- [-] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- Not required, just module internal changes, nothing changed on the exposed methods.
- [-] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- Not required, see above
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
