### PR TITLE
[docs] Update limitations page

### DIFF
--- a/docs/pages/introduction/why-not-expo.mdx
+++ b/docs/pages/introduction/why-not-expo.mdx
@@ -37,7 +37,7 @@ Like any other tool, it too has its own limitations:
 
 ## Up next
 
-> We are either actively working on or planning to build solutions to all of the limitations listed above, and if you think anything is missing, please bring it to our attention by posting to our [feature requests board](https://expo.canny.io/feature-requests) or the [forums](https://forums.expo.dev/).
+We are either actively working on or planning to build solutions to all of the limitations listed above, and if you think anything is missing, please bring it to our attention by posting to our [feature requests board](https://expo.canny.io/feature-requests) or the [forums](https://forums.expo.dev/).
 
 - If you have heard enough and want to get to coding, jump ahead to [Installation](/get-started/installation).
 - If you have some unanswered questions, continue to the [Common Questions](/introduction/faq) page.

--- a/docs/pages/introduction/why-not-expo.mdx
+++ b/docs/pages/introduction/why-not-expo.mdx
@@ -14,7 +14,7 @@ For more information on what current limitations exist with EAS, see the followi
 
 <BoxLink
   title="EAS Build"
-  description="Some of the missing features from EAS could prevent you from being able to use the service for your applications. Learn more."
+  description="EAS Build is designed to work for any React Native project, whether or not you also use Expo Prebuild or manage your own native files. In some situations, you may need to change your project configuration, or it may be incompatible with your app. Learn more."
   href="/build-reference/limitations/"
 />
 
@@ -22,7 +22,7 @@ For more information on what current limitations exist with EAS, see the followi
 
 Similar to [Development builds](/development/introduction), bare workflow also provides access to the underlying native projects and any native code. It's a "bare" native project where you can make direct changes to the project's native **android/** and **ios/** directories rather than continuously generating them on demand using the [Expo config and prebuild](/workflow/prebuild/).
 
-EAS Build works with bare workflow projects if you check in the native directories but prebuild can no longer sync changes from the Expo config to the native directories. You'll have to configure the native directories on your own with native tools such as Android Studio or Xcode.
+EAS Build is compatible with bare workflow projects if you check in the native directories, but no longer runs prebuild, as that could overwrite any manual customizations you've made to the native project files. You'll have to configure the native directories on your own with native tools such as Android Studio or Xcode.
 
 ## Expo Go
 
@@ -33,7 +33,7 @@ Like any other tool, it too has its own limitations:
 - Using a third-party library that requires native code
 - Using a third-party push notification service
 
-**All of the above have been addressed with EAS Build which is compatible with all type of React Native projects. If you come across them, you can transition your project to use [development builds](/development/introduction/).**
+**We strongly recommend any projects that require additional libraries with native code to migrate to [development builds](/development/introduction/). It's like creating a version of Expo Go that is specifically customized to your app's needs.**
 
 ## Up next
 

--- a/docs/pages/introduction/why-not-expo.mdx
+++ b/docs/pages/introduction/why-not-expo.mdx
@@ -3,108 +3,110 @@ title: Limitations
 sidebar_title: Limitations
 ---
 
-import { InlineCode } from '~/components/base/code';
 import { Collapsible } from '~/ui/components/Collapsible';
 
-Your success will be limited if you don't know the limitations of your tools. A good software engineer strives to understand the tradeoffs in the decisions they make.
+Your success will be limited if you don't know the limitations of your tools. A good software engineer strives to understand the tradeoffs in their decisions.
 
-<Collapsible summary="Used Expo before? Here are some recent changes to the managed workflow you should be aware of…">
+## EAS
 
-With the release of Expo Application Services, the managed workflow has far fewer limitations, and can be used for any project no matter the complexity:
+**With the release of Expo Application Services (EAS)**, building your app with Expo has far fewer limitations, and it can be used for any project, no matter the complexity. With [EAS Build](/build/setup):
 
-- All libraries available to React Native apps are available to Expo managed workflow apps built with [EAS Build](/build/setup), but _some_ may require a [Prebuild Config Plugin](/guides/config-plugins/) to be added. The addition of config plugins means:
-  - Any 3rd party push notification service can support managed workflow apps.
-  - Native libraries that integrate with proprietary services can support managed workflow apps.
-- Apps built with EAS Build can be as small as you want since the entire Expo SDK is no longer bundled in by default.
-- Apps built with EAS Build can target children under 13 years old.
+<Collapsible summary="All libraries available to React Native apps are available in Expo">
 
-These changes mean Expo can fit many more use cases than before.
+All libraries available to React Native apps are available in Expo projects. Some libraries may require a [Prebuild Config Plugin](/guides/config-plugins/) to be added. The addition of config plugins means:
 
-</Collapsible>
-
-## Limitations of Expo Go and the classic `expo build` system
-
-If you're still using `expo build:ios` or `expo build:android`, or using Expo Go for development, it's important to be aware of the limitations that come with those features.
-
-> If you'd like to continue getting the same development experience that you have with Expo Go, but also use custom native libraries or custom native code, you should check out the [Expo Dev Client](/development/introduction/)!
-
-Expo Go comes with a pre-configured set of libraries, known as the Expo SDK. This makes development much faster, and essentially makes the mobile development experience much closer to the web development experience. However, additional native code cannot be added to Expo Go on the fly, so this means you are limited in terms of what dependencies you can add. This also applies to apps built with `expo build:android` and `expo build:ios`.
-
-<Collapsible summary="Not all iOS and Android APIs are available">
-
-Many device APIs are supported (check out the "SDK API Reference" in the sidebar), but **not all iOS and Android APIs are available yet**. We are constantly adding new APIs, so if we don't have something you need now, you can either use [EAS Build](/build/setup), the [bare workflow](managed-vs-bare#bare-workflow), or follow [our blog](https://blog.expo.dev) to see the release notes for our SDK updates. Feature prioritization isn't strictly based off of popular vote, but it certainly helps us to gauge what is important to users.
+- Any third-party push notification service, such as OneSignal, is supported.
+- Native libraries that integrate with proprietary services or require configuring native code are supported.
 
 </Collapsible>
 
-<Collapsible summary={<span>If you need to keep your app size extremely lean, <InlineCode>expo build:[android|ios]</InlineCode> may not be the best choice</span>}>
+<Collapsible summary="App size can be as small as you want">
 
-The size for an app built with `expo build` on iOS is approximately 20mb (download), and Android is about 15mb. This is because a bunch of APIs are included regardless of whether or not you are using them &mdash; this lets you publish updates that use new APIs, but comes at the cost of binary size. Some of the APIs that are included are tied to services that you may not be using, for example, the Facebook Mobile SDK is included to support Facebook Login and Facebook Ads, along with the Google Mobile SDK for similar reasons. [Read more about managing your app size here](https://expo.fyi/managed-app-size).
-
-If you'd like a smaller app size, you should use [EAS Build](/build/setup).
+Apps built with EAS Build can be as small as you want in size since [the entire Expo SDK is no longer bundled](https://expo.fyi/managed-app-size#app-size-with-eas-build) by default.
 
 </Collapsible>
 
-<Collapsible summary="Native libraries to integrate with proprietary services are usually not included in the SDK">
+<Collapsible summary="Native dependencies can be customized to target children under a particular age">
 
-Related to the previous point, we typically avoid adding native modules to the SDK if they are tied to external, proprietary services &mdash; we can't add something to the SDK just because a few users need it for their app, we have to think of the broader userbase. In these cases developers will want to use [EAS Build](/build/setup), or the [bare workflow](/introduction/managed-vs-bare).
+Both [Apple](https://developer.apple.com/app-store/review/guidelines/#kids) and [Google](https://support.google.com/googleplay/android-developer/answer/9285070?hl=en) provide strict guidelines for any apps that specifically target children under the age of 13.
 
-</Collapsible>
-
-<Collapsible summary="The only supported third-party push notification service is the Expo notification service">
-
-If you want to use another third-party push notification service, such as OneSignal, instead of the [Expo Push Notification service/API](/push-notifications/overview), you will need to use [EAS Build](/build/setup).
-
-Note that you can use the first-party push APIs (APNs and FCM) directly if you like. [Read "Sending Notifications with APNs & FCM"](/push-notifications/sending-notifications-custom)
+Apps built with EAS Build [include only your app's explicit native dependencies](https://blog.expo.dev/expo-managed-workflow-in-2021-d1c9b68aa10). See [Development builds](/build/introduction/) for more information on how to use it.
 
 </Collapsible>
 
-<Collapsible summary="The minimum supported OS versions are Android 5+ and iOS 10+">
+EAS Build is a new service and we plan to address many of the current limitations in time. See [EAS Build Limitations](/build-reference/limitations/) for more information on what are the current limitations.
 
-If you need to support older versions, you will not be able to use `expo build:ios` or `expo build:android`.
+## Expo Go and the classic `expo build` system
+
+> [The classic build service is sunset and will only run until 2023](https://blog.expo.dev/turtle-goes-out-to-sea-d334db2a6b60).
+
+If you're still using `expo build:ios` or `expo build:android`, or using Expo Go for development, it's important to be aware of the limitations of those features.
+
+[Expo Go](/workflow/expo-go/) comes with a pre-configured set of libraries known as the Expo SDK. This makes development much faster and makes the mobile development experience much closer to the web development experience. However, additional native code cannot be added to Expo Go on the fly, so you are limited in terms of what dependencies you can add. This also applies to apps built with `expo build:android` and `expo build:ios`.
+
+The following limitations only apply when you are using Expo Go for development with the classic build system. **If you are using [Development builds or EAS Build](#eas), the following limitations do not apply.**
+
+<Collapsible summary="Not all Android and iOS APIs are supported">
+
+Many [device APIs](/versions/latest/) are supported in Expo SDK. If any of the APIs you need is not supported, you can either use [EAS Build](/build/setup) or [Development builds](/development/introduction/) or follow [our blog](https://blog.expo.dev) to see the release notes for our SDK updates. Feature prioritization isn't strictly based on popular vote, but it certainly helps us to gauge what is important to users.
+
+</Collapsible>
+
+<Collapsible summary="Classic build are not a best choice to keep your app size extremely lean">
+
+The size for an app built with `expo build` on Android is about 15MB and on iOS is approximately 20MB (download). This is because some APIs are included regardless of whether or not you are using them &mdash; this lets you publish updates that use new APIs but comes at the cost of binary size.
+
+Some of the included APIs are tied to services you may not be using. For example, the Facebook Mobile SDK is included to support Facebook Login and Facebook Ads, along with the Google Mobile SDK, for similar reasons.
+
+</Collapsible>
+
+<Collapsible summary="Native libraries to integrate with proprietary services are not included in Expo Go">
+
+Related to the previous point, we typically avoid adding native modules to the Expo Go if they are tied to external, proprietary services. We can't add something to the SDK just because a few users need it for their app. We have to think of a broader base of users.
 
 </Collapsible>
 
 <Collapsible summary="Free builds can sometimes be queued">
 
-You can easily build your app for submission to stores without even installing Xcode or Android Studio by using the free [standalone build service](/archive/classic-updates/building-standalone-apps), but it occasionally has a queue depending on how many other folks are building a binary at that time. You can have access to dedicated build infrastructure with a ["Priority" plan](https://expo.dev/eas), or you can [run the builds on your own CI](/classic/turtle-cli) if you prefer.
+You can easily build your app for submission to stores without even installing Xcode or Android Studio by using the free [standalone build service](/archive/classic-updates/building-standalone-apps), but it occasionally has a queue depending on how many other folks are building a binary at that time.
+
+You can have access to dedicated build infrastructure with a ["Priority" plan](https://expo.dev/eas), or you can [run the builds on your own CI](/classic/turtle-cli) if you prefer.
 
 </Collapsible>
 
-<Collapsible summary="Your app cannot target only children under 13 years old without customizing native dependencies">
+<Collapsible summary="Your app cannot target children under 13 years old without customizing native dependencies">
 
-Both [Apple](https://developer.apple.com/app-store/review/guidelines/#kids) and [Google](https://support.google.com/googleplay/android-developer/answer/9285070?hl=en) provide strict guidelines for any apps that specifically target children under a particular age. One of these guidelines states that certain ad libraries, such as Facebook's Audience Network, cannot be used in the app.
-
-Apps built with `expo build:ios|android` [contain code for the entire Expo SDK](https://expo.fyi/managed-app-size), you cannot customize the native dependencies, including Facebook's Audience Network library, so if you build your app this way you cannot designated it as "designed primarily for children under 13" in the App Store or Play Store, _even though this code is never run unless you explicitly call it_.
-
-Apps built with `eas build -p ios|android` [include only your app's explicit native dependencies](https://blog.expo.dev/expo-managed-workflow-in-2021-d1c9b68aa10), and so this limitation does not apply if you use EAS Build. [Learn about how to use it](/build/introduction).
+Apps built with `expo build:ios|android` contain code for the entire Expo SDK. Unfortunately, you cannot customize the native dependencies, including Facebook's Audience Network library. So if you build your app this way, you cannot designate it as "designed primarily for children under 13" in the app stores, even though this code is never run unless you explicitly call it.
 
 </Collapsible>
 
-> We are either actively working on or planning to build solutions to all of the limitations listed above, and if you think anything is missing, please bring it to our attention by posting to our [feature requests board](https://expo.canny.io/feature-requests) or the [forums](https://forums.expo.dev/).
+## Bare workflow
 
-## Limitations of the bare workflow
+> If you'd like to continue getting the same development experience that you have with Expo Go, but also use custom native libraries or custom native code, you should check out the [Development builds]()
 
-In the bare workflow, we have full access to the underlying native projects and any native code. It's a "bare" native project with React Native and one or more packages from the Expo SDK installed. Anything that you can do in a native project is possible here.
+As similar to [Development builds], bare workflow also provides access to the underlying native projects and any native code. It's a "bare" native project where developers make direct changes to their native `android` and `ios` project directories rather than continuously generating them on demand using the [Expo config (**app.json**) and prebuild](/workflow/prebuild/).
 
-The following list is therefore specifically oriented towards the limitations that exist around using Expo tools and services in the bare workflow.
+The following list is specifically oriented towards the limitations that exist around using Expo tools and services in the bare workflow.
 
-<Collapsible summary={<span><span className="strike">Build service only works in the managed workflow</span> (✅ Resolved in December 2020)</span>}>
+<Collapsible summary={<span><span className="strike">Build service only works in the managed workflow</span> (Resolved in December 2020)</span>}>
 
 ~~To build your app binaries for distribution on the Apple App Store and Google Play Store you will need to follow the same steps that you would in any native project, the Expo build service can't handle it for you. We are working on bringing bare workflow support to the build service in the near future.~~
 
-You can now use [EAS Build](/build/introduction) to build and sign your apps just as easily as in the managed workflow! [Read the announcement blog post](https://blog.expo.dev/expo-application-services-eas-build-and-submit-fc1d1476aa2e).
+You can now use [EAS Build](/build/introduction) to build and sign your apps. [Read the announcement blog post](https://blog.expo.dev/expo-application-services-eas-build-and-submit-fc1d1476aa2e).
 
 </Collapsible>
 
-<Collapsible summary="Configuration must be done on each native project rather than once with app.json">
+<Collapsible summary="Configuration must be done on each native project rather than once with Expo config">
 
-Configuring app icons, launch screen, and so on must be configured in the native projects for each platform using the standard native tooling, rather than once using a simple JSON object.
+Configuring app icons, launch screen, and so on must be configured in the native projects for each platform using the standard native tooling rather than once using a simple JSON object.
 
 </Collapsible>
 
 ## Up next
 
-If you've been reading along each section of the introduction then you will have a pretty good high-level understanding of Expo tools.
+> We are either actively working on or planning to build solutions to all of the limitations listed above, and if you think anything is missing, please bring it to our attention by posting to our [feature requests board](https://expo.canny.io/feature-requests) or the [forums](https://forums.expo.dev/).
 
-- If you have heard enough and want to get to coding, [jump ahead to "Installation"](/get-started/installation).
-- If you have some unanswered questions, [continue to the "Common Questions" page](/introduction/faq).
+If you've been reading along each section of the introduction, you will have a pretty good high-level understanding of Expo tools.
+
+- If you have heard enough and want to get to coding, jump ahead to [Installation](/get-started/installation).
+- If you have some unanswered questions, continue to the [Common Questions](/introduction/faq) page.

--- a/docs/pages/introduction/why-not-expo.mdx
+++ b/docs/pages/introduction/why-not-expo.mdx
@@ -37,7 +37,7 @@ Like any other tool, it too has its own limitations:
 
 ## Up next
 
-We are either actively working on or planning to build solutions to all of the limitations listed above, and if you think anything is missing, please bring it to our attention by posting to our [feature requests board](https://expo.canny.io/feature-requests) or the [forums](https://forums.expo.dev/).
+We are either actively working on or planning to build solutions to all of the limitations listed above, and if you think anything is missing, please bring it to our attention by posting to our [feature requests board](https://expo.canny.io/feature-requests) or [GitHub discussions](https://github.com/expo/expo/discussions).
 
-- If you have heard enough and want to get to coding, jump ahead to [Installation](/get-started/installation).
+- If you have heard enough and want to get to coding, see [Installation](/get-started/installation).
 - If you have some unanswered questions, continue to the [Common Questions](/introduction/faq) page.

--- a/docs/pages/introduction/why-not-expo.mdx
+++ b/docs/pages/introduction/why-not-expo.mdx
@@ -3,107 +3,41 @@ title: Limitations
 sidebar_title: Limitations
 ---
 
-import { Collapsible } from '~/ui/components/Collapsible';
+import { InlineCode } from '~/components/base/code';
+import { BoxLink } from '~/ui/components/BoxLink';
 
 We believe Expo tools are a great option for anyone looking to create amazing cross-platform apps quickly. Nonetheless, everyone's project is unique, and there may be reasons Expo is not the right choice for what you're building. Read on for some reasons why you may _not_ want to use Expo tools.
 
-## Expo Application Services
+## EAS
 
-**With the release of Expo Application Services (EAS)**, building your app with Expo has far fewer limitations, and it can be used for any project, no matter the complexity. With [EAS Build](/build/setup):
+For more information on what current limitations exist with EAS, see the following:
 
-<Collapsible summary="All libraries available to React Native apps are available in Expo">
+<BoxLink
+  title="EAS Build"
+  description="Some of the missing features from EAS could prevent you from being able to use the service for your applications. Learn more."
+  href="/build-reference/limitations/"
+/>
 
-All libraries available to React Native apps are available in Expo projects. Some libraries may require a [Prebuild Config Plugin](/guides/config-plugins/) to be added. The addition of config plugins means:
+### Bare workflow
 
-- Any third-party push notification service, such as OneSignal, is supported.
-- Native libraries that integrate with proprietary services or require configuring native code are supported.
+Similar to [Development builds](/development/introduction), bare workflow also provides access to the underlying native projects and any native code. It's a "bare" native project where you can make direct changes to the project's native **android/** and **ios/** directories rather than continuously generating them on demand using the [Expo config and prebuild](/workflow/prebuild/).
 
-</Collapsible>
+EAS Build works with bare workflow projects if you check in the native directories but prebuild can no longer sync changes from the Expo config to the native directories. You'll have to configure the native directories on your own with native tools such as Android Studio or Xcode.
 
-<Collapsible summary="App size can be as small as you want">
+## Expo Go
 
-Apps built with EAS Build can be as small as you want in size since [the entire Expo SDK is no longer bundled](https://expo.fyi/managed-app-size#app-size-with-eas-build) by default.
+[Expo Go](/workflow/expo-go) provides a quick way to get started with your app development. It comes with a pre-configured set of libraries known as the Expo SDK. This makes development much faster and makes the mobile development experience much closer to the web development experience.
 
-</Collapsible>
+Like any other tool, it too has its own limitations:
 
-<Collapsible summary="Native dependencies can be customized to target children under a particular age">
+- Using a third-party library that requires native code
+- Using a third-party push notification service
 
-Both [Apple](https://developer.apple.com/app-store/review/guidelines/#kids) and [Google](https://support.google.com/googleplay/android-developer/answer/9285070?hl=en) provide strict guidelines for any apps that specifically target children under the age of 13.
-
-Apps built with EAS Build [include only your app's explicit native dependencies](https://blog.expo.dev/expo-managed-workflow-in-2021-d1c9b68aa10). See [Development builds](/build/introduction/) for more information on how to use it.
-
-</Collapsible>
-
-EAS Build is a new service and we plan to address many of the current limitations in time. See [EAS Build Limitations](/build-reference/limitations/) for more information on what are the current limitations.
-
-## Expo Go and the classic `expo build` system
-
-> [The classic build service is sunset and will only run until 2023](https://blog.expo.dev/turtle-goes-out-to-sea-d334db2a6b60).
-
-If you're still using `expo build:ios` or `expo build:android`, or using Expo Go for development, it's important to be aware of the limitations of those features.
-
-[Expo Go](/workflow/expo-go/) comes with a pre-configured set of libraries known as the Expo SDK. This makes development much faster and makes the mobile development experience much closer to the web development experience. However, additional native code cannot be added to Expo Go on the fly, so you are limited in terms of what dependencies you can add. This also applies to apps built with `expo build:android` and `expo build:ios`.
-
-The following limitations only apply when you are using Expo Go for development with the classic build system. **If you are using [Development builds or EAS Build](#eas), the following limitations do not apply.**
-
-<Collapsible summary="Not all Android and iOS APIs are supported">
-
-Many [device APIs](/versions/latest/) are supported in Expo SDK. If any of the APIs you need is not supported, you can either use [EAS Build](/build/setup) or [Development builds](/development/introduction/) or follow [our blog](https://blog.expo.dev) to see the release notes for our SDK updates. Feature prioritization isn't strictly based on popular vote, but it certainly helps us to gauge what is important to users.
-
-</Collapsible>
-
-<Collapsible summary="Classic build are not a best choice to keep your app size extremely lean">
-
-The size for an app built with `expo build` on Android is about 15MB and on iOS is approximately 20MB (download). This is because some APIs are included regardless of whether or not you are using them &mdash; this lets you publish updates that use new APIs but comes at the cost of binary size.
-
-Some of the included APIs are tied to services you may not be using. For example, the Facebook Mobile SDK is included to support Facebook Login and Facebook Ads, along with the Google Mobile SDK, for similar reasons.
-
-</Collapsible>
-
-<Collapsible summary="Native libraries to integrate with proprietary services are not included in Expo Go">
-
-Related to the previous point, we typically avoid adding native modules to the Expo Go if they are tied to external, proprietary services. We can't add something to the SDK just because a few users need it for their app. We have to think of a broader base of users.
-
-</Collapsible>
-
-<Collapsible summary="Free builds can sometimes be queued">
-
-You can easily build your app for submission to stores without even installing Xcode or Android Studio by using the free [standalone build service](/archive/classic-updates/building-standalone-apps), but it occasionally has a queue depending on how many other folks are building a binary at that time.
-
-You can have access to dedicated build infrastructure with a ["Priority" plan](https://expo.dev/eas), or you can [run the builds on your own CI](/classic/turtle-cli) if you prefer.
-
-</Collapsible>
-
-<Collapsible summary="Your app cannot target children under 13 years old without customizing native dependencies">
-
-Apps built with `expo build:ios|android` contain code for the entire Expo SDK. Unfortunately, you cannot customize the native dependencies, including Facebook's Audience Network library. So if you build your app this way, you cannot designate it as "designed primarily for children under 13" in the app stores, even though this code is never run unless you explicitly call it.
-
-</Collapsible>
-
-## Bare workflow
-
-> If you'd like to continue getting the same development experience that you have with Expo Go, but also use custom native libraries or custom native code, you should check out the [Development builds]()
-
-As similar to [Development builds], bare workflow also provides access to the underlying native projects and any native code. It's a "bare" native project where developers make direct changes to their native `android` and `ios` project directories rather than continuously generating them on demand using the [Expo config (**app.json**) and prebuild](/workflow/prebuild/).
-
-The following list is specifically oriented towards the limitations that exist around using Expo tools and services in the bare workflow.
-
-<Collapsible summary={<span><span className="strike">Build service only works in the managed workflow</span> (Resolved in December 2020)</span>}>
-
-
-
-</Collapsible>
-
-<Collapsible summary="Configuration must be done on each native project rather than once with Expo config">
-
-Configuring app icons, launch screen, and so on must be configured in the native projects for each platform using the standard native tooling rather than in one place via **app.json** or **app.config.js**.
-
-</Collapsible>
+**All of the above have been addressed with EAS Build which is compatible with all type of React Native projects. If you come across them, you can transition your project to use [development builds](/development/introduction/).**
 
 ## Up next
 
 > We are either actively working on or planning to build solutions to all of the limitations listed above, and if you think anything is missing, please bring it to our attention by posting to our [feature requests board](https://expo.canny.io/feature-requests) or the [forums](https://forums.expo.dev/).
-
 
 - If you have heard enough and want to get to coding, jump ahead to [Installation](/get-started/installation).
 - If you have some unanswered questions, continue to the [Common Questions](/introduction/faq) page.

--- a/docs/pages/introduction/why-not-expo.mdx
+++ b/docs/pages/introduction/why-not-expo.mdx
@@ -5,8 +5,9 @@ sidebar_title: Limitations
 
 import { InlineCode } from '~/components/base/code';
 import { BoxLink } from '~/ui/components/BoxLink';
+import { BuildIcon, EasMetadataIcon, UpdateIcon } from '@expo/styleguide';
 
-We believe Expo tools are a great option for anyone looking to create amazing cross-platform apps quickly. Nonetheless, everyone's project is unique, and there may be reasons Expo is not the right choice for what you're building. Read on for some reasons why you may _not_ want to use Expo tools.
+We believe Expo tools are a great option for anyone looking to create amazing cross-platform apps quickly. Nonetheless, everyone's project is unique, and there may be reasons Expo is not the right choice for what you're building. Read on for some reasons why you may **not** want to use Expo tools.
 
 ## EAS
 
@@ -16,6 +17,21 @@ For more information on what current limitations exist with EAS, see the followi
   title="EAS Build"
   description="EAS Build is designed to work for any React Native project, whether or not you also use Expo Prebuild or manage your own native files. In some situations, you may need to change your project configuration, or it may be incompatible with your app. Learn more."
   href="/build-reference/limitations/"
+  Icon={BuildIcon}
+/>
+
+<BoxLink
+  title="EAS Update"
+  description="EAS Update is a hosted service that allows you to serve bug fixes and pushing quick updates to the app stores. There are some known issues you may encounter using it. Learn more."
+  href="/eas-update/known-issues/"
+  Icon={UpdateIcon}
+/>
+
+<BoxLink
+  title="EAS Metadata"
+  description="EAS Metadata aims to make creating or maintaining an app in the stores as easy as possible by using one configuration file. In some situations, not be the right fit for a project. Learn more."
+  href="/eas/metadata/faq/#anti-pitch"
+  Icon={EasMetadataIcon}
 />
 
 ### Bare workflow

--- a/docs/pages/introduction/why-not-expo.mdx
+++ b/docs/pages/introduction/why-not-expo.mdx
@@ -7,7 +7,7 @@ import { InlineCode } from '~/components/base/code';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { BuildIcon, EasMetadataIcon } from '@expo/styleguide';
 
-We believe Expo tools are a great option for anyone looking to create amazing cross-platform apps quickly. Nonetheless, everyone's project is unique, and there may be reasons Expo is not the right choice for what you're building. Read on for some reasons why you may **not** want to use Expo tools.
+We believe Expo tools are a great option for anyone looking to create amazing cross-platform apps quickly. Nonetheless, everyone's project is unique, and there may be reasons Expo is not the right choice for what you're building. Read on for some reasons why you may **not** want to use certain Expo tools with your project.
 
 ## EAS
 
@@ -46,7 +46,6 @@ Like any other tool, it too has its own limitations:
 
 ## Up next
 
-We are either actively working on or planning to build solutions to all of the limitations listed above, and if you think anything is missing, please bring it to our attention by posting to our [feature requests board](https://expo.canny.io/feature-requests) or [GitHub discussions](https://github.com/expo/expo/discussions).
 
 - If you have heard enough and want to get to coding, see [Installation](/get-started/installation).
 - If you have some unanswered questions, continue to the [Common Questions](/introduction/faq) page.

--- a/docs/pages/introduction/why-not-expo.mdx
+++ b/docs/pages/introduction/why-not-expo.mdx
@@ -5,9 +5,9 @@ sidebar_title: Limitations
 
 import { Collapsible } from '~/ui/components/Collapsible';
 
-Your success will be limited if you don't know the limitations of your tools. A good software engineer strives to understand the tradeoffs in their decisions.
+We believe Expo tools are a great option for anyone looking to create amazing cross-platform apps quickly. Nonetheless, everyone's project is unique, and there may be reasons Expo is not the right choice for what you're building. Read on for some reasons why you may _not_ want to use Expo tools.
 
-## EAS
+## Expo Application Services
 
 **With the release of Expo Application Services (EAS)**, building your app with Expo has far fewer limitations, and it can be used for any project, no matter the complexity. With [EAS Build](/build/setup):
 

--- a/docs/pages/introduction/why-not-expo.mdx
+++ b/docs/pages/introduction/why-not-expo.mdx
@@ -5,7 +5,7 @@ sidebar_title: Limitations
 
 import { InlineCode } from '~/components/base/code';
 import { BoxLink } from '~/ui/components/BoxLink';
-import { BuildIcon, EasMetadataIcon, UpdateIcon } from '@expo/styleguide';
+import { BuildIcon, EasMetadataIcon } from '@expo/styleguide';
 
 We believe Expo tools are a great option for anyone looking to create amazing cross-platform apps quickly. Nonetheless, everyone's project is unique, and there may be reasons Expo is not the right choice for what you're building. Read on for some reasons why you may **not** want to use Expo tools.
 
@@ -18,13 +18,6 @@ For more information on what current limitations exist with EAS, see the followi
   description="EAS Build is designed to work for any React Native project, whether or not you also use Expo Prebuild or manage your own native files. In some situations, you may need to change your project configuration, or it may be incompatible with your app. Learn more."
   href="/build-reference/limitations/"
   Icon={BuildIcon}
-/>
-
-<BoxLink
-  title="EAS Update"
-  description="EAS Update is a hosted service that allows you to serve bug fixes and pushing quick updates to the app stores. There are some known issues you may encounter using it. Learn more."
-  href="/eas-update/known-issues/"
-  Icon={UpdateIcon}
 />
 
 <BoxLink

--- a/docs/pages/introduction/why-not-expo.mdx
+++ b/docs/pages/introduction/why-not-expo.mdx
@@ -90,15 +90,13 @@ The following list is specifically oriented towards the limitations that exist a
 
 <Collapsible summary={<span><span className="strike">Build service only works in the managed workflow</span> (Resolved in December 2020)</span>}>
 
-~~To build your app binaries for distribution on the Apple App Store and Google Play Store you will need to follow the same steps that you would in any native project, the Expo build service can't handle it for you. We are working on bringing bare workflow support to the build service in the near future.~~
 
-You can now use [EAS Build](/build/introduction) to build and sign your apps. [Read the announcement blog post](https://blog.expo.dev/expo-application-services-eas-build-and-submit-fc1d1476aa2e).
 
 </Collapsible>
 
 <Collapsible summary="Configuration must be done on each native project rather than once with Expo config">
 
-Configuring app icons, launch screen, and so on must be configured in the native projects for each platform using the standard native tooling rather than once using a simple JSON object.
+Configuring app icons, launch screen, and so on must be configured in the native projects for each platform using the standard native tooling rather than in one place via **app.json** or **app.config.js**.
 
 </Collapsible>
 
@@ -106,7 +104,6 @@ Configuring app icons, launch screen, and so on must be configured in the native
 
 > We are either actively working on or planning to build solutions to all of the limitations listed above, and if you think anything is missing, please bring it to our attention by posting to our [feature requests board](https://expo.canny.io/feature-requests) or the [forums](https://forums.expo.dev/).
 
-If you've been reading along each section of the introduction, you will have a pretty good high-level understanding of Expo tools.
 
 - If you have heard enough and want to get to coding, jump ahead to [Installation](/get-started/installation).
 - If you have some unanswered questions, continue to the [Common Questions](/introduction/faq) page.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently, the "Limitations" page has some outdated information, unorganized sections and an inaccurate reference to Expo SDK rather than Expo Go.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR 
- puts emphasis on the info around the the EAS Builds
- Links to EAS Build limitations page
- Remove some outdated limitations that are no longer relevant to Expo's ecosystem
- Updates reference of Expo SDK to Expo Go in classic build system limitations
- Updates overall verbiage

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes are tested by running docs locally and visiting http://localhost:3002/introduction/why-not-expo

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
