### PR TITLE
[docs] Update EAS Update code signing docs

### DIFF
--- a/docs/pages/eas-update/code-signing.mdx
+++ b/docs/pages/eas-update/code-signing.mdx
@@ -28,9 +28,9 @@ The `expo-updates` library supports end-to-end code signing. Code signing allows
 
    - The generated private key must be kept private and secure.
    - The certificate validity duration is a setting that may vary based on the security needs of your app.
-      - A shorter validity duration will require [key rotation](#key-rotation) more frequently, but is considered better practice since a compromised private key will have a sooner expiration which limits exposure.
+      - A shorter validity duration will require [key rotation](#key-rotation) more frequently but is considered better practice since a compromised private key will have a sooner expiration which limits exposure.
       - Shorter validity durations add overhead to your app's release process as the key must be rotated more frequently. Binaries with expired certificates won't apply new updates.
-      - As an example, Expo sets this value to 20 years for the public Expo Go app, but only 1 year for internal apps with binaries that are distributed more frequently. We plan to rotate our keys every 10 years.
+      - For example, Expo sets this value to 20 years for the public Expo Go app, but only 1 year for internal apps with binaries that are distributed more frequently. We plan to rotate our keys every 10 years.
 
 2. Configure your app's builds to use code signing:
 
@@ -62,8 +62,8 @@ Key rotation is the process by which the key pair used for signing updates is ch
 
 In any of these cases, the procedure is similar:
 1. Backup the old key and certificate that were generated in step (1) above.
-2. Generated a new key by following the steps above. To assist in debugging, you may wish to change the `keyid` of the new key by modifying the `updates.codeSigningMetadata.keyid` field in your app config (app.json).
-3. The certificate is part of the app's runtime, so a new runtime version should be set for builds using this certificate to ensure that only updates signed with the new key are run in the new build.
+2. Generate a new key by following the steps above. To assist in debugging, you may wish to change the `keyid` of the new key by modifying the `updates.codeSigningMetadata.keyid` field in your app config (app.json).
+3. The certificate is part of the app's runtime, so a new runtime version should be set for builds using this certificate to ensure that only updates signed with the new key run in the new build.
 4. Publish signed updates using the new key by following step (3) above.
 
 ## Removing Code Signing
@@ -71,5 +71,5 @@ In any of these cases, the procedure is similar:
 The process of removing code signing from an app is similar to [key rotation](#key-rotation) and can be thought of as a key rotation to a null key.
 
 1. Backup the old key and certificate that were generated in step (1) above.
-2. Remove the `updates.codeSigningMetadata` field from your app config (app.json).
-3. The new certificate-less app is a new distinct runtime, so a new runtime version should be set for builds to ensure that only unsigned updates are run in the new build.
+2. Remove the `updates.codeSigningMetadata` field from your Expo config (**app.json**).
+3. The new certificate-less app is a new distinct runtime, so a new runtime version should be set for builds to ensure that only unsigned updates run in the new build.

--- a/docs/pages/eas-update/code-signing.mdx
+++ b/docs/pages/eas-update/code-signing.mdx
@@ -26,7 +26,11 @@ The `expo-updates` library supports end-to-end code signing. Code signing allows
      --certificate-common-name "My App"
    ```
 
-   The generated private key must be kept private and secure.
+   - The generated private key must be kept private and secure.
+   - The certificate validity duration is a setting that may vary based on the security needs of your app.
+      - A shorter validity duration will require [key rotation](#key-rotation) more frequently, but is considered better practice since a compromised private key will have a sooner expiration which limits exposure.
+      - Shorter validity durations add overhead to your app's release process as the key must be rotated more frequently. Binaries with expired certificates won't apply new updates.
+      - As an example, Expo sets this value to 20 years for the public Expo Go app, but only 1 year for internal apps with binaries that are distributed more frequently. We plan to rotate our keys every 10 years.
 
 2. Configure your app's builds to use code signing:
 
@@ -46,14 +50,26 @@ The `expo-updates` library supports end-to-end code signing. Code signing allows
 
    During `eas update`, the EAS CLI automatically detects that code signing is configured for your app. It then verifies the integrity of the update and creates a digital signature using your private key. This process is performed locally so that your private key never leaves your machine. The generated signature is automatically sent to EAS to store alongside the update.
 
-4. Download the update on the client (this step is done automatically by the library). The build from step (2) that is configured for code signing checks if there is a new update available. The server responds with the update published in step (3) and its generated signature. After being downloaded but before being applied, the update is verified against the embedded certificate and included signature. The update is applied if the signature is valid, and rejected otherwise.
+4. Download the update on the client (this step is done automatically by the library). The build from step (2) that is configured for code signing checks if there is a new update available. The server responds with the update published in step (3) and its generated signature. After being downloaded but before being applied, the update is verified against the embedded certificate and included signature. The update is applied if the certificate and signature are valid, and rejected otherwise.
 
 ## Key Rotation
 
 Key rotation is the process by which the key pair used for signing updates is changed. This is most commonly done in a few cases:
 
-- Key expiration. In step (1) from the section above, we set `certificate-validity-duration-years` to 10 years (though it can be configured to any value). This means that after 10 years, updates signed with the private key corresponding to the certificate will no longer be valid.
-- Private key compromise. If the private key used to sign updates is accidentally exposed to the public, it can no longer be considered secure and therefore can no longer guarantee itegrity of updates it signed. For example, a malicious actor could craft a malicious update and sign it with the leaked private key.
+- Key expiration. In step (1) from the section above, we set `certificate-validity-duration-years` to 10 years (though it can be configured to any value). This means that after 10 years, updates signed with the private key corresponding to the certificate will no longer be applied after being downloaded by the app. Updates downloaded prior to the expiration of their signing certificate will continue to function normally. Rotating keys well before the certificate expires helps to preempt any potential key expiration issues and helps to guarantee all users are using the new certificate before the old certificate expires.
+- Private key compromise. If the private key used to sign updates is accidentally exposed to the public, it can no longer be considered secure and therefore can no longer guarantee integrity of updates it signed. For example, a malicious actor could craft a malicious update and sign it with the leaked private key.
 - Key rotation for security best practices. It is best practice to rotate keys periodically to ensure that a system is resilient to manual key rotation in response to one of the other reasons above.
 
-In any of these cases, a new key must be generated and new updates must be signed with the new key. To do this, backup the old key and certificate generated in step (1) and re-run the full set of steps above. A new runtime version must be used for the new build to ensure that only updates signed with the new key are run in the new build.
+In any of these cases, the procedure is similar:
+1. Backup the old key and certificate that were generated in step (1) above.
+2. Generated a new key by following the steps above. To assist in debugging, you may wish to change the `keyid` of the new key by modifying the `updates.codeSigningMetadata.keyid` field in your app config (app.json).
+3. The certificate is part of the app's runtime, so a new runtime version should be set for builds using this certificate to ensure that only updates signed with the new key are run in the new build.
+4. Publish signed updates using the new key by following step (3) above.
+
+## Removing Code Signing
+
+The process of removing code signing from an app is similar to [key rotation](#key-rotation) and can be thought of as a key rotation to a null key.
+
+1. Backup the old key and certificate that were generated in step (1) above.
+2. Remove the `updates.codeSigningMetadata` field from your app config (app.json).
+3. The new certificate-less app is a new distinct runtime, so a new runtime version should be set for builds to ensure that only unsigned updates are run in the new build.

--- a/docs/pages/eas-update/code-signing.mdx
+++ b/docs/pages/eas-update/code-signing.mdx
@@ -62,13 +62,13 @@ Key rotation is the process by which the key pair used for signing updates is ch
 
 In any of these cases, the procedure is similar:
 1. Backup the old key and certificate that were generated in step (1) above.
-2. Generate a new key by following the steps above. To assist in debugging, you may wish to change the `keyid` of the new key by modifying the `updates.codeSigningMetadata.keyid` field in your app config (app.json).
+2. Generate a new key by following the steps above. To assist in debugging, you may wish to change the `keyid` of the new key by modifying the `updates.codeSigningMetadata.keyid` field in your app config (**app.json**).
 3. The certificate is part of the app's runtime, so a new runtime version should be set for builds using this certificate to ensure that only updates signed with the new key run in the new build.
 4. Publish signed updates using the new key by following step (3) above.
 
 ## Removing Code Signing
 
-The process of removing code signing from an app is similar to [key rotation](#key-rotation) and can be thought of as a key rotation to a null key.
+The process of removing code signing from an app is similar to [key rotation](#key-rotation) and can be thought of as a key rotation to a `null` key.
 
 1. Backup the old key and certificate that were generated in step (1) above.
 2. Remove the `updates.codeSigningMetadata` field from your Expo config (**app.json**).


### PR DESCRIPTION
# Why

This PR improves the documentation around key rotation, validity duration selection, and removal of code signing.

Closes ENG-6739.
Closes ENG-6740.

# How

Update docs.

# Test Plan

Proofread?

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
