### PR TITLE
[modules][ios] Reject promises with a coded error instead of a plain object

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### 🐛 Bug fixes
 
 - Fixed records aren't correctly converted to JS objects in the release builds on Android. ([#19551](https://github.com/expo/expo/pull/19551) by [@lukmccall](https://github.com/lukmccall))
+- Reject promises with a `CodedError` instead of a plain object. ([#19605](https://github.com/expo/expo/pull/19605) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/JSI/EXJSIUtils.h
+++ b/packages/expo-modules-core/ios/JSI/EXJSIUtils.h
@@ -59,6 +59,10 @@ void defineProperty(jsi::Runtime &runtime, const jsi::Object *object, const char
  */
 void setDeallocator(jsi::Runtime &runtime, std::shared_ptr<jsi::Object> object, ObjectDeallocatorBlock deallocatorBlock);
 
+#pragma mark - Errors
+
+jsi::Value makeCodedError(jsi::Runtime &runtime, NSString *code, NSString *message);
+
 } // namespace expo
 
 #endif


### PR DESCRIPTION
# Why

Promises were being rejected with plain JS object (with `code` and `message`), but we rather want them to be instances of the `Error` class. It fixes the following test: https://github.com/expo/expo/blob/f13a19208dfe8ccab79563e2320b03626fab43cd/apps/test-suite/tests/Calendar.js#L440

# How

Fixed promise rejection block to call with an instance of our own `CodedError` class (that inherits from `Error`) instead of a plain object.

# Test Plan

Tests expecting errors to inherit from `Error` are now passing