### PR TITLE
[expo-updates][cli] Add keyid flag to codesigning:configure

### DIFF
--- a/packages/expo-updates/cli/configureCodeSigning.ts
+++ b/packages/expo-updates/cli/configureCodeSigning.ts
@@ -12,6 +12,7 @@ export const configureCodeSigning: Command = async (argv) => {
       '--help': Boolean,
       '--certificate-input-directory': String,
       '--key-input-directory': String,
+      '--keyid': String,
       // Aliases
       '-h': '--help',
     },
@@ -40,9 +41,11 @@ Configure expo-updates code signing for this project and verify setup
 
   const certificateInput = requireArg(args, '--certificate-input-directory');
   const keyInput = requireArg(args, '--key-input-directory');
+  const keyid = args['--keyid'];
 
   return await configureCodeSigningAsync(getProjectRoot(args), {
     certificateInput,
     keyInput,
+    keyid,
   });
 };

--- a/packages/expo-updates/cli/configureCodeSigningAsync.ts
+++ b/packages/expo-updates/cli/configureCodeSigningAsync.ts
@@ -10,11 +10,11 @@ import path from 'path';
 import { log } from './utils/log';
 import { attemptModification } from './utils/modifyConfigAsync';
 
-type Options = { certificateInput: string; keyInput: string };
+type Options = { certificateInput: string; keyInput: string; keyid: string | undefined };
 
 export async function configureCodeSigningAsync(
   projectRoot: string,
-  { certificateInput, keyInput }: Options
+  { certificateInput, keyInput, keyid }: Options
 ) {
   const certificateInputDir = path.resolve(projectRoot, certificateInput);
   const keyInputDir = path.resolve(projectRoot, keyInput);
@@ -34,7 +34,7 @@ export async function configureCodeSigningAsync(
   const fields: ExpoConfig['updates'] = {
     codeSigningCertificate: `./${path.relative(projectRoot, certificateInputDir)}/certificate.pem`,
     codeSigningMetadata: {
-      keyid: 'main',
+      keyid: keyid ?? 'main',
       alg: 'rsa-v1_5-sha256',
     },
   };


### PR DESCRIPTION
# Why

This adds a keyid flag to the `expo-updates codesigning:configure` command so that key rotation can be done more simply with a command to reconfigure with a custom keyid.

Closes ENG-6738.

# How

Default this to main but allow overriding via flag. Add test for this behavior.

# Test Plan

Run test.

Then, use this in a sample project:
1. `npx create-expo-app blah && cd blah && npx expo install expo-updates`
2. Add local ref to `expo-updates` package to package.json dependencies: `"expo-updates": "../../expo/expo/packages/expo-updates",`, `yarn`
4. `yarn expo-updates codesigning:generate --key-output-directory keys --certificate-output-directory certs --certificate-validity-duration-years 10 --certificate-common-name "My App"`
5. `yarn expo-updates codesigning:configure --certificate-input-directory certs --key-input-directory keys`, see it configures app.json with "main" keyid
6. `yarn expo-updates codesigning:configure --certificate-input-directory certs --key-input-directory keys --keyid wat`, see it re-configures app.json with "wat" keyid

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
