### PR TITLE
[modules][Android] Fix exceptions handling in async functions

### DIFF
--- a/packages/expo-modules-core/android/src/main/cpp/Exceptions.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/Exceptions.cpp
@@ -46,9 +46,27 @@ jni::local_ref<UnexpectedException> UnexpectedException::create(const std::strin
   );
 }
 
+jsi::Value makeCodedError(
+  jsi::Runtime &rt,
+  jsi::String code,
+  jsi::String message
+) {
+  auto codedErrorConstructor = rt
+    .global()
+    .getProperty(rt, "ExpoModulesCore_CodedError")
+    .asObject(rt)
+    .asFunction(rt);
+
+  return codedErrorConstructor.callAsConstructor(
+    rt, {
+      jsi::Value(rt, code),
+      jsi::Value(rt, message)
+    }
+  );
+}
+
 void rethrowAsCodedError(
   jsi::Runtime &rt,
-  JSIInteropModuleRegistry *registry,
   jni::JniException &jniException
 ) {
   jni::local_ref<jni::JThrowable> unboxedThrowable = jniException.getThrowable();
@@ -57,22 +75,17 @@ void rethrowAsCodedError(
     auto code = codedException->getCode();
     auto message = codedException->getLocalizedMessage();
 
-    auto *codedErrorPointer = registry->jsRegistry->getOptionalObject<jsi::Function>(
-      JSReferencesCache::JSKeys::CODED_ERROR
+    auto codedError = makeCodedError(
+      rt,
+      jsi::String::createFromUtf8(rt, code),
+      jsi::String::createFromUtf8(rt, message.value_or(""))
     );
-    if (codedErrorPointer != nullptr) {
-      auto &jsCodedError = *codedErrorPointer;
 
-      throw jsi::JSError(
-        message.value_or(""),
-        rt,
-        jsCodedError.callAsConstructor(
-          rt,
-          jsi::String::createFromUtf8(rt, code),
-          jsi::String::createFromUtf8(rt, message.value_or(""))
-        )
-      );
-    }
+    throw jsi::JSError(
+      message.value_or(""),
+      rt,
+      std::move(codedError)
+    );
   }
 
   // Rethrow error if we can't wrap it.

--- a/packages/expo-modules-core/android/src/main/cpp/Exceptions.h
+++ b/packages/expo-modules-core/android/src/main/cpp/Exceptions.h
@@ -65,8 +65,13 @@ public:
  */
 [[noreturn]] void rethrowAsCodedError(
   jsi::Runtime &rt,
-  JSIInteropModuleRegistry *registry,
   jni::JniException &jniException
+);
+
+jsi::Value makeCodedError(
+  jsi::Runtime &runtime,
+  jsi::String code,
+  jsi::String message
 );
 
 /**
@@ -79,5 +84,4 @@ void throwPendingJniExceptionAsCppException();
  * Same as `facebook::jni::throwNewJavaException` but throwing exceptions on our own.
  */
 [[noreturn]] void throwNewJavaException(jthrowable throwable);
-
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JSReferencesCache.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JSReferencesCache.cpp
@@ -8,16 +8,6 @@ JSReferencesCache::JSReferencesCache(jsi::Runtime &runtime) {
       runtime.global().getPropertyAsFunction(runtime, "Promise")
     )
   );
-
-  if (runtime.global().hasProperty(runtime, "ExpoModulesCore_CodedError")) {
-    auto jsCodedError = runtime.global()
-      .getPropertyAsFunction(runtime, "ExpoModulesCore_CodedError");
-
-    jsObjectRegistry.emplace(
-      JSKeys::CODED_ERROR,
-      std::make_unique<jsi::Object>(std::move(jsCodedError))
-    );
-  }
 }
 
 jsi::PropNameID &JSReferencesCache::getPropNameID(

--- a/packages/expo-modules-core/android/src/main/cpp/JSReferencesCache.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JSReferencesCache.h
@@ -21,8 +21,7 @@ namespace expo {
 class JSReferencesCache {
 public:
   enum class JSKeys {
-    PROMISE,
-    CODED_ERROR
+    PROMISE
   };
 
   JSReferencesCache() = delete;


### PR DESCRIPTION
# Why

Fixes test-suites:
```
- Calendar
    - First run only: getEventsAsync() resolves to an array with an event of the correct shape (expected 0 to be 1)
    - Subsequent runs: deleteEventAsync(), deletes an event -expected false to be true
```

This is a follow-up to https://github.com/expo/expo/pull/19605.

# How

- Made sure that promises reject with a coded error instead of the plain js object.
- If something was thrown in the CPP code, the promise will also be rejected. 

# Test Plan

- test-suite ✅
- manually test some corner case behavior ✅