### PR TITLE
[ios] Rename EnumArgument to Enumerable and ConvertibleArgument to Convertible

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Convertible enums must inherit from `expo.modules.kotlin.types.Enumerable` on Android. ([#19551](https://github.com/expo/expo/pull/19551) by [@lukmccall](https://github.com/lukmccall))
 - `AppContext.currentActivity` is not longer returning `AppCompatActivity`, but an instance of `android.app.Activity` class. ([#19573](https://github.com/expo/expo/pull/19573) by [@lukmccall](https://github.com/lukmccall))
 
+### ⚠️ Notices
+
+- Deprecated `ConvertibleArgument` in favor of `Convertible` and `EnumArgument` in favor of `Enumerable`. ([#19612](https://github.com/expo/expo/pull/19612) by [@tsapeta](https://github.com/tsapeta))
+
 ### 🎉 New features
 
 - Implemented a mechanism for hooking into to the view lifecycle events (introduces new `OnViewDidUpdateProps` definition component). ([#19549](https://github.com/expo/expo/pull/19549) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo-modules-core/ios/Swift/Arguments/Convertible.swift
+++ b/packages/expo-modules-core/ios/Swift/Arguments/Convertible.swift
@@ -6,10 +6,13 @@
  value of `Any` type to the type implemented by this protocol. It should throw an error
  when the value is not recognized, is invalid or doesn't meet type requirements.
  */
-public protocol ConvertibleArgument: AnyArgument {
+public protocol Convertible: AnyArgument {
   /**
    Converts any value to the instance of its class (or struct).
    Throws an error when given value cannot be converted.
    */
   static func convert(from value: Any?) throws -> Self
 }
+
+@available(*, deprecated, renamed: "Convertible")
+public typealias ConvertibleArgument = Convertible

--- a/packages/expo-modules-core/ios/Swift/Arguments/Convertibles.swift
+++ b/packages/expo-modules-core/ios/Swift/Arguments/Convertibles.swift
@@ -3,7 +3,7 @@
 import UIKit
 import CoreGraphics
 
-// Here we extend some common iOS types to implement `ConvertibleArgument` protocol and
+// Here we extend some common iOS types to implement `Convertible` protocol and
 // describe how they can be converted from primitive types received from JavaScript runtime.
 // This allows these types to be used as argument types of functions callable from JavaScript.
 // As an example, when the `CGPoint` type is used as an argument type, its instance can be
@@ -11,7 +11,7 @@ import CoreGraphics
 
 // MARK: - Foundation
 
-extension URL: ConvertibleArgument {
+extension URL: Convertible {
   public static func convert(from value: Any?) throws -> Self {
     if let uri = value as? String, let url = URL(string: uri) {
       // `URL(string:)` is an optional init but it doesn't imply it's a valid URL,
@@ -25,7 +25,7 @@ extension URL: ConvertibleArgument {
 
 // MARK: - CoreGraphics
 
-extension CGPoint: ConvertibleArgument {
+extension CGPoint: Convertible {
   public static func convert(from value: Any?) throws -> CGPoint {
     if let value = value as? [Double], value.count == 2 {
       return CGPoint(x: value[0], y: value[1])
@@ -38,7 +38,7 @@ extension CGPoint: ConvertibleArgument {
   }
 }
 
-extension CGSize: ConvertibleArgument {
+extension CGSize: Convertible {
   public static func convert(from value: Any?) throws -> CGSize {
     if let value = value as? [Double], value.count == 2 {
       return CGSize(width: value[0], height: value[1])
@@ -51,7 +51,7 @@ extension CGSize: ConvertibleArgument {
   }
 }
 
-extension CGVector: ConvertibleArgument {
+extension CGVector: Convertible {
   public static func convert(from value: Any?) throws -> CGVector {
     if let value = value as? [Double], value.count == 2 {
       return CGVector(dx: value[0], dy: value[1])
@@ -64,7 +64,7 @@ extension CGVector: ConvertibleArgument {
   }
 }
 
-extension CGRect: ConvertibleArgument {
+extension CGRect: Convertible {
   public static func convert(from value: Any?) throws -> CGRect {
     if let value = value as? [Double], value.count == 4 {
       return CGRect(x: value[0], y: value[1], width: value[2], height: value[3])

--- a/packages/expo-modules-core/ios/Swift/Arguments/Enumerable.swift
+++ b/packages/expo-modules-core/ios/Swift/Arguments/Enumerable.swift
@@ -3,7 +3,7 @@
 /**
  A protocol that allows converting raw values to enum cases.
  */
-public protocol EnumArgument: AnyArgument {
+public protocol Enumerable: AnyArgument {
   /**
    Tries to create an enum case using given raw value.
    May throw errors, e.g. when the raw value doesn't match any case.
@@ -21,11 +21,14 @@ public protocol EnumArgument: AnyArgument {
   var anyRawValue: Any { get }
 }
 
+@available(*, deprecated, renamed: "Enumerable")
+public typealias EnumArgument = Enumerable
+
 /**
- Extension for `EnumArgument` that also conforms to `RawRepresentable`.
+ Extension for `Enumerable` that also conforms to `RawRepresentable`.
  This constraint allows us to reference the associated `RawValue` type.
  */
-public extension EnumArgument where Self: RawRepresentable, Self: Hashable {
+public extension Enumerable where Self: RawRepresentable, Self: Hashable {
   static func create<ArgType>(fromRawValue rawValue: ArgType) throws -> Self {
     guard let rawValue = rawValue as? RawValue else {
       throw EnumCastingException((type: RawValue.self, value: rawValue))
@@ -71,7 +74,7 @@ internal class EnumCastingException: GenericException<(type: Any.Type, value: An
 /**
  An error that is thrown when the value doesn't match any available case.
  */
-internal class EnumNoSuchValueException: GenericException<(type: EnumArgument.Type, value: Any)> {
+internal class EnumNoSuchValueException: GenericException<(type: Enumerable.Type, value: Any)> {
   var allRawValuesFormatted: String {
     return param.type.allRawValues
       .map { "'\($0)'" }

--- a/packages/expo-modules-core/ios/Swift/Convertibles/Convertibles+Color.swift
+++ b/packages/expo-modules-core/ios/Swift/Convertibles/Convertibles+Color.swift
@@ -1,6 +1,6 @@
 // Copyright 2022-present 650 Industries. All rights reserved.
 
-extension UIColor: ConvertibleArgument {
+extension UIColor: Convertible {
   public static func convert(from value: Any?) throws -> Self {
     // swiftlint:disable force_cast
     if let value = value as? String {
@@ -20,7 +20,7 @@ extension UIColor: ConvertibleArgument {
   }
 }
 
-extension CGColor: ConvertibleArgument {
+extension CGColor: Convertible {
   public static func convert(from value: Any?) throws -> Self {
     // swiftlint:disable force_cast
     do {

--- a/packages/expo-modules-core/ios/Swift/Convertibles/Either.swift
+++ b/packages/expo-modules-core/ios/Swift/Convertibles/Either.swift
@@ -3,7 +3,7 @@
 /*
  A convertible type wrapper for a value that should be either of two generic types.
  */
-open class Either<FirstType, SecondType>: ConvertibleArgument {
+open class Either<FirstType, SecondType>: Convertible {
   /**
    An array of dynamic equivalents for generic either types.
    */

--- a/packages/expo-modules-core/ios/Swift/DynamicTypes/AnyDynamicType.swift
+++ b/packages/expo-modules-core/ios/Swift/DynamicTypes/AnyDynamicType.swift
@@ -18,7 +18,7 @@ public protocol AnyDynamicType: CustomStringConvertible {
 
   /**
    Casts given any value to the wrapped type and returns as `Any`.
-   NOTE: It may not be just simple type-casting (e.g. when the wrapped type conforms to `ConvertibleArgument`).
+   NOTE: It may not be just simple type-casting (e.g. when the wrapped type conforms to `Convertible`).
    */
   func cast<ValueType>(_ value: ValueType) throws -> Any
 }

--- a/packages/expo-modules-core/ios/Swift/DynamicTypes/DynamicConvertibleType.swift
+++ b/packages/expo-modules-core/ios/Swift/DynamicTypes/DynamicConvertibleType.swift
@@ -1,10 +1,10 @@
 // Copyright 2021-present 650 Industries. All rights reserved.
 
 /**
- A dynamic type that wraps any type conforming to `ConvertibleArgument` protocol.
+ A dynamic type that wraps any type conforming to `Convertible` protocol.
  */
 internal struct DynamicConvertibleType: AnyDynamicType {
-  let innerType: ConvertibleArgument.Type
+  let innerType: Convertible.Type
 
   func wraps<InnerType>(_ type: InnerType.Type) -> Bool {
     return innerType == InnerType.self

--- a/packages/expo-modules-core/ios/Swift/DynamicTypes/DynamicEnumType.swift
+++ b/packages/expo-modules-core/ios/Swift/DynamicTypes/DynamicEnumType.swift
@@ -1,10 +1,10 @@
 // Copyright 2021-present 650 Industries. All rights reserved.
 
 /**
- A dynamic type representing an enum that conforms to `EnumArgument`.
+ A dynamic type representing an enum that conforms to `Enumerable`.
  */
 internal struct DynamicEnumType: AnyDynamicType {
-  let innerType: EnumArgument.Type
+  let innerType: Enumerable.Type
 
   func wraps<InnerType>(_ type: InnerType.Type) -> Bool {
     return innerType == InnerType.self

--- a/packages/expo-modules-core/ios/Swift/DynamicTypes/DynamicType.swift
+++ b/packages/expo-modules-core/ios/Swift/DynamicTypes/DynamicType.swift
@@ -15,10 +15,10 @@ internal func DynamicType<T>(_ type: T.Type) -> AnyDynamicType {
   if let OptionalType = T.self as? AnyOptional.Type {
     return DynamicOptionalType(wrappedType: OptionalType.getWrappedDynamicType())
   }
-  if let ConvertibleType = T.self as? ConvertibleArgument.Type {
+  if let ConvertibleType = T.self as? Convertible.Type {
     return DynamicConvertibleType(innerType: ConvertibleType)
   }
-  if let EnumType = T.self as? EnumArgument.Type {
+  if let EnumType = T.self as? Enumerable.Type {
     return DynamicEnumType(innerType: EnumType)
   }
   if let SharedObjectType = T.self as? SharedObject.Type {

--- a/packages/expo-modules-core/ios/Swift/Records/Record.swift
+++ b/packages/expo-modules-core/ios/Swift/Records/Record.swift
@@ -1,7 +1,7 @@
 /**
  A protocol that allows initializing the object with a dictionary.
  */
-public protocol Record: ConvertibleArgument {
+public protocol Record: Convertible {
   /**
    The dictionary type that the record can be created from or converted back.
    */

--- a/packages/expo-modules-core/ios/Tests/DynamicTypeSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/DynamicTypeSpec.swift
@@ -170,11 +170,11 @@ final class DynamicTypeSpec: ExpoSpec {
     // MARK: - DynamicEnumType
 
     describe("DynamicEnumType") {
-      enum StringTestEnum: String, EnumArgument {
+      enum StringTestEnum: String, Enumerable {
         case hello
         case expo
       }
-      enum IntTestEnum: Int, EnumArgument {
+      enum IntTestEnum: Int, Enumerable {
         case negative = -1
         case positive = 1
       }

--- a/packages/expo-modules-core/ios/Tests/EnumerableSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/EnumerableSpec.swift
@@ -4,7 +4,7 @@ import ExpoModulesTestCore
 
 @testable import ExpoModulesCore
 
-final class EnumArgumentSpec: ExpoSpec {
+final class EnumerableSpec: ExpoSpec {
   override func spec() {
     describe("static createFromRawValue") {
       it("succeeds") {
@@ -40,7 +40,7 @@ final class EnumArgumentSpec: ExpoSpec {
   }
 }
 
-fileprivate enum Position: String, EnumArgument {
+private enum Position: String, Enumerable {
   case top
   case right
   case bottom


### PR DESCRIPTION
# Why

We've decided to simply use `Convertible` and `Enumerable` protocols instead of `ConvertibleArgument` and `EnumArgument`.

# How

- Renamed these types in `expo-modules-core` on iOS (we'll rename them separately in the next release)
- Added type aliases for the deprecated names for backwards compatibility

# Test Plan

iOS unit tests are passing and that should be enough to be sure that change has no side effects
