### PR TITLE
[NCL] Fix DateTimePicker keeps appearing on android

### DIFF
--- a/apps/native-component-list/src/screens/DateTimePickerScreen.tsx
+++ b/apps/native-component-list/src/screens/DateTimePickerScreen.tsx
@@ -83,6 +83,9 @@ const DateTimePickerScreen = () => {
   const scrollRef = useRef<ScrollView>(null);
 
   const onChange = (event: DateTimePickerEvent, selectedDate?: Date | undefined) => {
+    if (Platform.OS === 'android') {
+      setShow(false);
+    }
     const currentDate = selectedDate || date;
     if (event.type === 'neutralButtonPressed') {
       setDate(new Date(0));


### PR DESCRIPTION
# Why

fix android unversioned qa issues for sdk 47 - NCL DateTimePicker keeps appearing even after clicking the cancel or the confirm buttons.

# How

update the code as the [latest upstream example](https://github.com/react-native-datetimepicker/datetimepicker/blob/70c594271c0c877b43533b09f95f60b768851344/example/App.js#L100-L102)

# Test Plan

android unversioned expo go + ncl datetimepicker

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
