### PR TITLE
[test-suite][barcode] Fix tests

### DIFF
--- a/apps/test-suite/tests/BarCodeScanner.js
+++ b/apps/test-suite/tests/BarCodeScanner.js
@@ -95,8 +95,8 @@ export async function test(t, { setPortalChild, cleanupPortal }) {
               height: 210,
             },
           },
-          1,
-          1
+          2,
+          2
         );
         t.expect(result[0].cornerPoints).toBeDefined();
         t.expect(result[0].cornerPoints.length).toEqual(4);
@@ -168,8 +168,8 @@ export async function test(t, { setPortalChild, cleanupPortal }) {
                 height: 141,
               },
             },
-            1,
-            1
+            2,
+            2
           );
           t.expect(result[0].cornerPoints).toBeDefined();
           t.expect(result[0].cornerPoints.length).toEqual(4);


### PR DESCRIPTION
# Why

Fixes:
```
- Barcode scanner
    - tests failed:
        - scans a QR code from asset
        - scans a Data Matrix code from asset
```

# How

It turns out that the results are one pixel higher than expected. In the case of calculating the bounding box of the image, it's not a huge difference. Probably something was changed in the underlying library. So changing the size inaccuracy should be fine in that case. Especially, in other tests, we're using much bigger inaccuracy. 

# Test Plan

- change the size inaccuracy. 