### PR TITLE
[av][Android] Fix `Video` is crashing when the `resolveView` cannot find the underlaying view

### DIFF
--- a/packages/expo-av/android/src/main/java/expo/modules/av/ViewUtils.kt
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/ViewUtils.kt
@@ -25,7 +25,7 @@ object ViewUtils {
       } else {
         promise.reject("E_VIDEO_TAGINCORRECT", "Invalid view returned from registry.")
       }
-    } catch (e : IllegalViewOperationException) {
+    } catch (e: IllegalViewOperationException) {
       promise.reject("E_VIDEO_TAGINCORRECT", "Invalid view returned from registry.")
     }
   }

--- a/packages/expo-av/android/src/main/java/expo/modules/av/ViewUtils.kt
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/ViewUtils.kt
@@ -3,6 +3,7 @@ package expo.modules.av
 import androidx.annotation.AnyThread
 import androidx.annotation.UiThread
 import com.facebook.react.bridge.UiThreadUtil
+import com.facebook.react.uimanager.IllegalViewOperationException
 import expo.modules.av.video.VideoView
 import expo.modules.av.video.VideoViewWrapper
 import expo.modules.core.ModuleRegistry
@@ -16,11 +17,15 @@ object ViewUtils {
 
   @UiThread
   private fun tryRunWithVideoViewOnUiThread(moduleRegistry: ModuleRegistry, viewTag: Int, callback: VideoViewCallback, promise: Promise) {
-    val videoWrapperView = moduleRegistry.getModule(UIManager::class.java).resolveView(viewTag) as VideoViewWrapper?
-    val videoView = videoWrapperView?.videoViewInstance
-    if (videoView != null) {
-      callback.runWithVideoView(videoView)
-    } else {
+    try {
+      val videoWrapperView = moduleRegistry.getModule(UIManager::class.java).resolveView(viewTag) as VideoViewWrapper?
+      val videoView = videoWrapperView?.videoViewInstance
+      if (videoView != null) {
+        callback.runWithVideoView(videoView)
+      } else {
+        promise.reject("E_VIDEO_TAGINCORRECT", "Invalid view returned from registry.")
+      }
+    } catch (e : IllegalViewOperationException) {
       promise.reject("E_VIDEO_TAGINCORRECT", "Invalid view returned from registry.")
     }
   }
@@ -43,11 +48,15 @@ object ViewUtils {
 
   @UiThread
   private fun tryRunWithVideoViewOnUiThread(moduleRegistry: ModuleRegistry, viewTag: Int, callback: VideoViewCallback, promise: expo.modules.kotlin.Promise) {
-    val videoWrapperView = moduleRegistry.getModule(UIManager::class.java).resolveView(viewTag) as VideoViewWrapper?
-    val videoView = videoWrapperView?.videoViewInstance
-    if (videoView != null) {
-      callback.runWithVideoView(videoView)
-    } else {
+    try {
+      val videoWrapperView = moduleRegistry.getModule(UIManager::class.java).resolveView(viewTag) as VideoViewWrapper?
+      val videoView = videoWrapperView?.videoViewInstance
+      if (videoView != null) {
+        callback.runWithVideoView(videoView)
+      } else {
+        promise.reject("E_VIDEO_TAGINCORRECT", "Invalid view returned from registry.", null)
+      }
+    } catch (e: IllegalViewOperationException) {
       promise.reject("E_VIDEO_TAGINCORRECT", "Invalid view returned from registry.", null)
     }
   }


### PR DESCRIPTION
# Why

Fixes:
```
FATAL EXCEPTION: main
10-14 10:12:30.129  3694  3694 E AndroidRuntime: Process: host.exp.exponent, PID: 3694
10-14 10:12:30.129  3694  3694 E AndroidRuntime: com.facebook.react.uimanager.IllegalViewOperationException: Trying to resolve view with tag 2723 which doesn't exist
```

# How

In SDK-46, in the case where the view wasn't available, we rejected the promise. That behavior is expected by the js code. 

# Test Plan

- test-suite ✅
> Note: not all tests pass on each try. However, testing them one by one, I managed to run through all of them with success.