### PR TITLE
[docs] unify EAS Build and EAS Update starting guides

### DIFF
--- a/docs/pages/build/setup.mdx
+++ b/docs/pages/build/setup.mdx
@@ -2,9 +2,10 @@
 title: Creating your first build
 ---
 
-import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
+import { Step } from '~/ui/components/Step';
+import { Tabs, Tab } from '~/ui/components/Tabs';
 
 EAS Build allows you to build a ready-to-submit binary of your app for the Apple App Store or Google Play Store. In this guide, let's learn how to do that.
 
@@ -16,7 +17,7 @@ For a small app, builds for Android and iOS platforms trigger within a few minut
 
 EAS Build is a new and rapidly evolving service. Before you set out to create a build for your project we recommend consulting the [limitations](/build-reference/limitations) page and the other prerequisites below.
 
-<Collapsible summary="A React Native iOS and/or Android project that you want to build">
+<Collapsible summary="A React Native Android and/or iOS project that you want to build">
 
 Don't have a project yet? No problem. It's quick and easy to create a "Hello world" app that you can use with this guide.
 
@@ -40,7 +41,8 @@ Paid subscribers get quality improvements such as additional build concurrencies
 
 </Collapsible>
 
-## 1. Install the latest EAS CLI
+<Step label="1">
+## Install the latest EAS CLI
 
 EAS CLI is the command-line app that you will use to interact with EAS services from your terminal. To install it, run the command:
 
@@ -49,16 +51,20 @@ EAS CLI is the command-line app that you will use to interact with EAS services 
 You can also use the above command to check if a new version of EAS CLI is available. We encourage you to always stay up to date with the latest version.
 
 > We recommend using `npm` instead of `yarn` for global package installations. You may alternatively use `npx eas-cli`, just remember to use that instead of `eas` whenever it's called for in the documentation.
+</Step>
 
-## 2. Log in to your Expo account
+<Step label="2">
+## Log in to your Expo account
 
 If you are already signed in to an Expo account using Expo CLI, you can skip the steps described in this section. If you are not, run the following command to log in:
 
 <Terminal cmd={['$ eas login']} />
 
 You can check whether you are logged in by running `eas whoami`.
+</Step>
 
-## 3. Configure the project
+<Step label="3">
+## Configure the project
 
 To configure an iOS or an Android project for EAS Build, run the following command:
 
@@ -73,8 +79,10 @@ Additional configuration may be required for some scenarios:
 - Is your project inside of a monorepo? [Follow these instructions](/build-reference/how-tos#how-to-set-up-eas-build-with).
 - Do you use private npm packages? [Add your npm token](/build-reference/private-npm-packages).
 - Does your app depend on specific versions of tools like Node, Yarn, npm, CocoaPods, or Xcode? [Specify these versions in your build configuration](/build/eas-json).
+</Step>
 
-## 4. Run a build
+<Step label="4">
+## Run a build
 
 ### Build for Android device/emulator or iOS simulator
 
@@ -100,13 +108,14 @@ You can build and sign your app using EAS Build, but you can't upload it to the 
 
 After you have confirmed that you have an Apple App Store or a Google Play Store account and decided whether or not EAS CLI should handle app signing credentials, you can proceed with the following set of commands to build for the platform's store:
 
-- For Android:
-
-<Terminal cmd={['$ eas build --platform android']} />
-
-- For iOS:
-
-<Terminal cmd={['$ eas build --platform ios']} />
+<Tabs tabs={['Android', 'iOS']}>
+  <Tab>
+    <Terminal cmd={['$ eas build --platform android']} />
+  </Tab>
+  <Tab>
+    <Terminal cmd={['$ eas build --platform ios']} />
+  </Tab>
+</Tabs>
 
 > You can attach a message to the build by passing `--message` to the build command, for example, `eas build --platform ios --message "Some message"`. The message will appear on the website. It comes in handy when you want to leave a note with the purpose of the build for your team.
 
@@ -127,8 +136,10 @@ Alternatively, you can use `--platform all` option to build for Android and iOS 
 - If you have not generated a provisioning profile and/or distribution certificate yet, you can let EAS CLI take care of that for you by signing into your Apple Developer Program account and following the prompts.
 - If you have already built your app with `expo build:ios`, you can use the same credentials here.
 - If you want to rather manually generate your credentials, refer to the [manual iOS credentials guide](/app-signing/local-credentials#ios-credentials) for more information.
+</Step>
 
-## 5. Wait for the build to complete
+<Step label="5">
+## Wait for the build to complete
 
 By default, the `eas build` command will wait for your build to complete, but you can interrupt it if you prefer not to wait. Monitor the progress and read the logs by following the link to the build details page that EAS CLI prompts once the build process gets started. You can also find this page by visiting [your build dashboard](https://expo.dev/builds) or running the following command:
 
@@ -137,8 +148,10 @@ By default, the `eas build` command will wait for your build to complete, but yo
 If you are a member of an organization and your build is on its behalf, you will find the build details on [the build dashboard for that account](https://expo.dev/accounts/[account]/builds).
 
 > **Did your build fail?** Double check that you followed any applicable instructions in the [configuration step](#3-configure-the-project) and refer to the [troubleshooting guide](/build-reference/troubleshooting) if needed.
+</Step>
 
-## 6. Deploy the build
+<Step label="6">
+## Deploy the build
 
 If you have made it to this step, congratulations! Depending on which path you chose, you now either have a build that is ready to upload to an app store, or you have a build that you can install directly on an Android device/iOS simulator.
 
@@ -151,6 +164,7 @@ You will only be able to submit to an app store if you built specifically for th
 You will only be able to install the app directly to your Android device/iOS simulator if you explicitly built it for that purpose. If you built for app store distribution, you will need to upload to an app store and then install it from there (for example, from Apple's TestFlight app).
 
 To learn how to install the app directly to your Android device/iOS simulator, navigate to your build details page from [your build dashboard](https://expo.dev/accounts/[account]/builds) and click the "Install" button.
+</Step>
 
 ## Next steps
 

--- a/docs/pages/eas-update/getting-started.mdx
+++ b/docs/pages/eas-update/getting-started.mdx
@@ -3,6 +3,7 @@ title: Getting started
 ---
 
 import { Terminal } from '~/ui/components/Snippet';
+import { Step } from '~/ui/components/Step';
 
 Setting up EAS Update allows you to push critical bug fixes and improvements that your users need right away.
 
@@ -14,18 +15,27 @@ EAS Update requires the following versions or greater:
 - Expo SDK >= 45.0.0
 - expo-updates >= 0.13.0
 
-## Install EAS CLI
+<Step label="1">
+## Install the latest EAS CLI
 
-Install EAS CLI by running:
+EAS CLI is the command-line app that you will use to interact with EAS services from your terminal. To install it, run the command:
 
 <Terminal cmd={['$ npm install --global eas-cli']} />
 
+You can also use the above command to check if a new version of EAS CLI is available. We encourage you to always stay up to date with the latest version.
+
+> We recommend using `npm` instead of `yarn` for global package installations. You may alternatively use `npx eas-cli`, just remember to use that instead of `eas` whenever it's called for in the documentation.
+</Step>
+
+<Step label="2">
 ## Create a project
 
 Create a project by running:
 
 <Terminal cmd={['$ npx create-expo-app']} />
+</Step>
 
+<Step label="3">
 ## Configure your project
 
 To configure your project, run the following commands in the order they are specified:
@@ -48,7 +58,7 @@ After running these commands, **eas.json** file will be created in the root dire
 
 Inside the `preview` and `production` build profiles in **eas.json**, add a `channel` property for each:
 
-```json
+```json eas.json
 {
   "build": {
     "preview": {
@@ -65,8 +75,10 @@ Inside the `preview` and `production` build profiles in **eas.json**, add a `cha
 
 The `channel` allows you to point updates at builds. For example, if we set up a GitHub Action to publish changes on merge, it will make it so that we can merge code into the "production" Git branch. Then, each commit will trigger a GitHub Action that will publish an update that will be available to builds with the channel "production".
 
-**Optional**: If your project is a bare React Native project, see [Updating bare app](/bare/updating-your-app) for any additional configuration.
+> **Optional**: If your project is a bare React Native project, see [Updating bare app](/bare/updating-your-app) for any additional configuration.
+</Step>
 
+<Step label="4">
 ## Create a build for the project
 
 Next, we'll need to create a build for Android or iOS. [Learn more](/build/setup).
@@ -74,7 +86,9 @@ Next, we'll need to create a build for Android or iOS. [Learn more](/build/setup
 We recommend creating a build with the `preview` build profile first. [Learn more](/build/internal-distribution) about setting up your devices for internal distribution.
 
 Once you have a build running on your device or in a simulator, we'll be ready to send it an update.
+</Step>
 
+<Step label="5">
 ## Make changes locally
 
 Once we've created a build, we're ready to iterate on our project. Start a local development server with:
@@ -82,22 +96,28 @@ Once we've created a build, we're ready to iterate on our project. Start a local
 <Terminal cmd={['$ npx expo start']} />
 
 Then, make any desired changes to your project's JavaScript, styling, or image assets.
+</Step>
 
+<Step label="6">
 ## Publish an update
 
 Now we're ready to publish an update to the build created in the previous step.
 
 Then publish an update with the following command:
 
-```bash
-eas update --branch [branch] --message [message]
-
-# Example
-eas update --branch preview --message "Updating the app"
-```
+<Terminal
+  cmd={[
+    '$ eas update --branch [branch] --message [message]',
+    '',
+    '# Example',
+    '$ eas update --branch preview --message "Updating the app"',
+  ]}
+  cmdCopy={null}
+/>
 
 Once the update is built and uploaded to EAS and the command completes, force close and reopen your app up to two times to download and view the update.
+</Step>
 
-## Next
+## Next steps
 
 You can publish updates continuously with GitHub Actions. Learn more: [Using GitHub Actions with EAS Update](/eas-update/github-actions)


### PR DESCRIPTION
# Why

Fixes ENG-6767

# How

This PR aims to unify EAS Build and Update starting guides appearance (by using Step component), also unifying part of the content in the process.

However, I believe that we can streamline and unify content even more in the future.

# Test Plan

The changes have been tested by running docs app locally.

# Preview

<img width="1919" alt="Screenshot 2022-10-19 231751" src="https://user-images.githubusercontent.com/719641/196806851-39978710-6dca-4764-9f33-429895527f8e.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
