### PR TITLE
[location][Android] Fix `trueHeading` is sometimes bigger then 360

### DIFF
--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `trueHeading` is sometimes bigger then 360 on Android.
+
 ### 💡 Others
 
 - [plugin] Migrate import from @expo/config-plugins to expo/config-plugins and @expo/config-types to expo/config. ([#18855](https://github.com/expo/expo/pull/18855) by [@brentvatne](https://github.com/brentvatne))

--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed `trueHeading` is sometimes bigger then 360 on Android.
+- Fixed `trueHeading` is sometimes bigger then 360 on Android. ([#19629](https://github.com/expo/expo/pull/19629) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.java
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.java
@@ -787,7 +787,7 @@ public class LocationModule extends ExportedModule implements LifecycleEventList
     if (isMissingForegroundPermissions() || mGeofield == null) {
       return -1;
     }
-    return magNorth + mGeofield.getDeclination();
+    return (magNorth + mGeofield.getDeclination()) % 360;
   }
 
   private void stopHeadingWatch() {


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/19071.
Fixes:
```
- expo-location
    - `getHeadingAsync`'s `trueHeading` reports a negative value right before rolling back to zero (present in SDK 46, reported here https://github.com/expo/expo/issues/19071)
```

# How

When we added a `declination` to calculate the true north angle, we forgot to ensure that the result was in the range from 0 to 360. 

# Test Plan

- https://snack.expo.dev/@amedeoofficial/petrified-peach ✅