### PR TITLE
[Android] Fix crash on the NCL GestureHandlerPinch example

### DIFF
--- a/android/vendored/unversioned/react-native-gesture-handler/android/lib/src/main/java/com/swmansion/gesturehandler/PinchGestureHandler.kt
+++ b/android/vendored/unversioned/react-native-gesture-handler/android/lib/src/main/java/com/swmansion/gesturehandler/PinchGestureHandler.kt
@@ -55,6 +55,11 @@ class PinchGestureHandler : GestureHandler<PinchGestureHandler>() {
       scaleGestureDetector = ScaleGestureDetector(context, gestureListener)
       val configuration = ViewConfiguration.get(context)
       spanSlop = configuration.scaledTouchSlop.toFloat()
+
+      // set the focal point to the position of the first pointer as NaN causes the event not to arrive
+      this.focalPointX = event.x
+      this.focalPointY = event.y
+
       begin()
     }
     scaleGestureDetector?.onTouchEvent(sourceEvent)

--- a/android/vendored/unversioned/react-native-gesture-handler/android/lib/src/main/java/com/swmansion/gesturehandler/RotationGestureHandler.kt
+++ b/android/vendored/unversioned/react-native-gesture-handler/android/lib/src/main/java/com/swmansion/gesturehandler/RotationGestureHandler.kt
@@ -45,6 +45,11 @@ class RotationGestureHandler : GestureHandler<RotationGestureHandler>() {
     if (state == STATE_UNDETERMINED) {
       resetProgress()
       rotationGestureDetector = RotationGestureDetector(gestureListener)
+
+      // set the anchor to the position of the first pointer as NaN causes the event not to arrive
+      this.anchorX = event.x
+      this.anchorY = event.y
+
       begin()
     }
     rotationGestureDetector?.onTouchEvent(sourceEvent)


### PR DESCRIPTION
# Why

Fixes:
![image](https://user-images.githubusercontent.com/9578601/196898378-c870dd3f-55da-4319-a448-e7e92508316f.png)

It is connected with https://github.com/software-mansion/react-native-gesture-handler/pull/2264.

# How

Applied unpublished path from the gesture handler repository.

# Test Plan

- expo-go with NCL ✅