### PR TITLE
[android][tools] fix vendored reanimated dependency toward react-native

### DIFF
--- a/android/vendored/unversioned/react-native-reanimated/android/CMakeLists.txt
+++ b/android/vendored/unversioned/react-native-reanimated/android/CMakeLists.txt
@@ -38,7 +38,7 @@ if(${IS_NEW_ARCHITECTURE_ENABLED})
 
     endif()
 else()
-    set (RN_SO_DIR ${REACT_NATIVE_DIR}/ReactAndroid/src/main/jni/first-party/react/jni)
+    set (RN_SO_DIR "${REACT_NATIVE_DIR}/ReactAndroid/build/intermediates/library_*/*/jni")
     set (FBJNI_HEADERS_DIR "${REACT_NATIVE_DIR}/ReactAndroid/src/main/jni/first-party/fbjni/headers")
 endif()
 
@@ -234,6 +234,7 @@ target_link_libraries(
 )
 
 if(${JS_RUNTIME} STREQUAL "hermes")
+    find_package(hermes-engine REQUIRED CONFIG)
     string(APPEND CMAKE_CXX_FLAGS " -DJS_RUNTIME_HERMES=1")
     if(${REACT_NATIVE_MINOR_VERSION} LESS 69)
         # From `hermes-engine` npm package
@@ -253,7 +254,7 @@ if(${JS_RUNTIME} STREQUAL "hermes")
     endif()
     target_link_libraries(
             ${PACKAGE_NAME}
-            "${BUILD_DIR}/third-party-ndk/hermes/jni/${ANDROID_ABI}/libhermes.so"
+            hermes-engine::libhermes
     )
 elseif(${JS_RUNTIME} STREQUAL "v8")
     string(APPEND CMAKE_CXX_FLAGS " -DJS_RUNTIME_V8=1")

--- a/android/vendored/unversioned/react-native-reanimated/android/build.gradle
+++ b/android/vendored/unversioned/react-native-reanimated/android/build.gradle
@@ -182,7 +182,7 @@ if (CLIENT_SIDE_BUILD) {
     configurations.maybeCreate("default")
 }
 
-def reactNativeRootDir = resolveReactNativeDirectory()
+def reactNativeRootDir = Paths.get(projectDir.getPath(), '../../../../../react-native-lab/react-native').toFile()
 
 def reactProperties = new Properties()
 file("$reactNativeRootDir/ReactAndroid/gradle.properties").withInputStream { reactProperties.load(it) }
@@ -786,6 +786,7 @@ if (REACT_NATIVE_MINOR_VERSION >= 69 && !isNewArchitectureEnabled()) {
 }
 
 task prepareHermes() {
+    return
     if (REACT_NATIVE_MINOR_VERSION >= 69) {
         if (!isNewArchitectureEnabled()) {
             dependsOn(unzipHermes)
@@ -930,11 +931,11 @@ dependencies {
     extractHeaders("com.facebook.fbjni:fbjni:" + FBJNI_VERSION + ":headers")
     extractSO("com.facebook.fbjni:fbjni:" + FBJNI_VERSION)
 
-    def jscAAR = fileTree("$reactNativeRootDir/../jsc-android/dist/org/webkit/android-jsc").matching({ it.include "**/**/*.aar" }).singleFile
-    extractSO(files(jscAAR))
+    
 }
 
 task unpackReactNativeAAR {
+    return
     def buildType = resolveBuildType()
     def rnAarMatcher = "**/react-native/**/*${buildType}.aar"
     if (REACT_NATIVE_MINOR_VERSION < 69) {
@@ -1013,4 +1014,21 @@ if (CLIENT_SIDE_BUILD) {
         throw GradleScriptException("AAR build failed. No AAR found in ${aarDir}.")
     }
     artifacts.add("default", aar)
+}
+
+tasks.whenTaskAdded { task ->
+  def buildType = task.name.endsWith('Debug') ? 'Debug' : 'Release'
+  if (!task.name.contains("Clean") && (task.name.contains('externalNativeBuild') || task.name.startsWith('configureCMake') || task.name.startsWith('buildCMake') || task.name.startsWith('generateJsonModel'))) {
+    task.dependsOn(":ReactAndroid:copy${buildType}JniLibsProjectOnly")
+  }
+}
+
+android {
+  buildFeatures {
+    prefab true
+  }
+}
+
+dependencies {
+  compileOnly(project(":ReactAndroid:hermes-engine"))
 }


### PR DESCRIPTION
# Why

reanimated references _node_modules/react-native_ to extract some libraries for linking its shared library. we should use _react-native-lab/react-native_ in our case.

# How

- [android] update build.gradle and cmake files to reference correct react-native and hermes-engine. since hermes-engine is building from source, we could use prefab in this case.
- [tools] update transforms to generate the correct build.gradle and cmake files. 

# Test Plan

unversioned expo go + reanimated NCL

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
