### PR TITLE
[docs] Firebase: fix anchor tag

### DIFF
--- a/docs/pages/guides/using-firebase.mdx
+++ b/docs/pages/guides/using-firebase.mdx
@@ -11,7 +11,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 There are two different ways you can use Firebase in your projects:
 
 - Using [Firebase JS SDK](#using-firebase-js-sdk)
-- Using [React Native Firebase](#react-native-firebase)
+- Using [React Native Firebase](#using-react-native-firebase)
 
 React Native supports both the native SDK and the JS SDK. The following sections will guide you through when to use which SDK and all the configuration steps required to use Firebase in your Expo projects.
 


### PR DESCRIPTION
# Why

https://docs.expo.dev/guides/using-firebase/#react-native-firebase doesn't go anywhere

# How

https://docs.expo.dev/guides/using-firebase/#using-react-native-firebase fix the issue

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
