### PR TITLE
[docs] Fix link in Using Firebase guide

### DIFF
--- a/docs/pages/guides/using-firebase.mdx
+++ b/docs/pages/guides/using-firebase.mdx
@@ -33,7 +33,7 @@ You can consider using the Firebase JS SDK when you:
 
 #### Caveats
 
-Firebase JS SDK does not support all services for mobile apps. Some of these services are Dynamic Links and Crashlytics. See the [React Native Firebase](#react-native-firebase) section if you want to use these services.
+Firebase JS SDK does not support all services for mobile apps. Some of these services are Dynamic Links and Crashlytics. See the [React Native Firebase](#using-react-native-firebase) section if you want to use these services.
 
 ### Install and initialize Firebase JS SDK
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The link /guides/using-firebase/#react-native-firebase doesn't work.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR updates the link to /guides/using-firebase/#using-react-native-firebase which is the correct link.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
