### PR TITLE
Upgrade `@rnc/datetimepicker@6.5.0` ➡️ `@rnc/datetimepicker@6.5.2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Package-specific changes not released in any SDK will be added here just before 
 - Updated `@react-native-community/slider` from `4.2.3` to `4.2.4`. ([#19424](https://github.com/expo/expo/pull/19424)) by [@kudo](https://github.com/kudo))
 - Updated `react-native-svg` from `12.3.0` to `13.4.0`. ([#19434](https://github.com/expo/expo/pull/19434) by [@lukmccall](https://github.com/lukmccall))
 - Updated `react-native-reanimated` from `2.10.0` to `2.11.0`. ([#19602](https://github.com/expo/expo/pull/19602) by [@lukmccall](https://github.com/lukmccall))
+- Updated `@react-native-community/datetimepicker` from `6.5.0` to `6.5.2`. ([#19642](https://github.com/expo/expo/pull/19642) by [@byCedric](https://github.com/byCedric))
 
 ### 🛠 Breaking changes
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/MinuteIntervalSnappableTimePickerDialog.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/MinuteIntervalSnappableTimePickerDialog.java
@@ -34,6 +34,7 @@ class MinuteIntervalSnappableTimePickerDialog extends TimePickerDialog {
             RNTimePickerDisplay display
     ) {
         super(context, listener, hourOfDay, minute, is24HourView);
+		setCanceledOnTouchOutside(true);
         mTimePickerInterval = minuteInterval;
         mTimeSetListener = listener;
         mDisplay = display;
@@ -51,6 +52,7 @@ class MinuteIntervalSnappableTimePickerDialog extends TimePickerDialog {
             RNTimePickerDisplay display
     ) {
         super(context, theme, listener, hourOfDay, minute, is24HourView);
+		setCanceledOnTouchOutside(true);
         mTimePickerInterval = minuteInterval;
         mTimeSetListener = listener;
         mDisplay = display;

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDatePickerDialogFragment.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDatePickerDialogFragment.java
@@ -7,8 +7,6 @@
 
 package versioned.host.exp.exponent.modules.api.components.datetimepicker;
 
-import host.exp.expoview.R;
-
 import android.annotation.SuppressLint;
 import android.app.DatePickerDialog;
 import android.app.DatePickerDialog.OnDateSetListener;

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDatePickerDialogFragment.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDatePickerDialogFragment.java
@@ -7,6 +7,8 @@
 
 package versioned.host.exp.exponent.modules.api.components.datetimepicker;
 
+import host.exp.expoview.R;
+
 import android.annotation.SuppressLint;
 import android.app.DatePickerDialog;
 import android.app.DatePickerDialog.OnDateSetListener;

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDismissableDatePickerDialog.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDismissableDatePickerDialog.java
@@ -40,6 +40,7 @@ public class RNDismissableDatePickerDialog extends DatePickerDialog {
       int dayOfMonth,
       RNDatePickerDisplay display) {
     super(context, callback, year, monthOfYear, dayOfMonth);
+	setCanceledOnTouchOutside(true);
     fixSpinner(context, year, monthOfYear, dayOfMonth, display);
   }
 
@@ -52,6 +53,7 @@ public class RNDismissableDatePickerDialog extends DatePickerDialog {
       int dayOfMonth,
       RNDatePickerDisplay display) {
     super(context, theme, callback, year, monthOfYear, dayOfMonth);
+	setCanceledOnTouchOutside(true);
     fixSpinner(context, year, monthOfYear, dayOfMonth, display);
   }
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNTimePickerDialogFragment.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNTimePickerDialogFragment.java
@@ -8,6 +8,8 @@
 
 package versioned.host.exp.exponent.modules.api.components.datetimepicker;
 
+import host.exp.expoview.R;
+
 import android.app.Dialog;
 import android.app.TimePickerDialog;
 import android.app.TimePickerDialog.OnTimeSetListener;

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNTimePickerDialogFragment.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNTimePickerDialogFragment.java
@@ -8,8 +8,6 @@
 
 package versioned.host.exp.exponent.modules.api.components.datetimepicker;
 
-import host.exp.expoview.R;
-
 import android.app.Dialog;
 import android.app.TimePickerDialog;
 import android.app.TimePickerDialog.OnTimeSetListener;

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -92,7 +92,7 @@
   "dependencies": {
     "@babel/runtime": "^7.14.0",
     "@react-native-async-storage/async-storage": "~1.17.3",
-    "@react-native-community/datetimepicker": "6.5.0",
+    "@react-native-community/datetimepicker": "6.5.2",
     "@react-native-community/netinfo": "9.3.3",
     "@react-native-community/slider": "4.2.4",
     "@react-native-community/viewpager": "5.0.11",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@expo/react-native-action-sheet": "^3.8.0",
     "@react-native-async-storage/async-storage": "~1.17.3",
-    "@react-native-community/datetimepicker": "6.5.0",
+    "@react-native-community/datetimepicker": "6.5.2",
     "@react-native-community/netinfo": "9.3.3",
     "@react-native-community/slider": "4.2.4",
     "@react-native-masked-view/masked-view": "0.2.6",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -1,7 +1,7 @@
 {
   "@expo/vector-icons": "^13.0.0",
   "@react-native-async-storage/async-storage": "~1.17.3",
-  "@react-native-community/datetimepicker": "6.5.0",
+  "@react-native-community/datetimepicker": "6.5.2",
   "@react-native-masked-view/masked-view": "0.2.7",
   "@react-native-community/netinfo": "9.3.3",
   "@react-native-community/slider": "4.2.4",


### PR DESCRIPTION
# Why

A few bugfixes have landed, which might be nice to pick up in SDK 47 too.

# How

Ran `et update-vendored-module --module @react-native-community/datetimepicker --target expo-go --commit 70c594271c0c877b43533b09f95f60b768851344`

<details><summary>See update output</summary>

```log
 🧶 Yarning...
 🛠  Rebuilding expotools
 ✨ Successfully built expotools

📥 Cloning @react-native-community/datetimepicker#70c594271c0c877b43533b09f95f60b768851344 from https://github.com/react-native-community/react-native-datetimepicker.git
‼️  Using legacy vendoring for platform ios
NOTE: In Expo, native Android styles are prefixed with ReactAndroid. Please ensure that resourceNames used for grabbing style of dialogs are being resolved properly.

Cleaning up iOS files at Exponent/Versioned/Core/Api/Components/DateTimePicker ...

Copying iOS files ...
> ios/Exponent/Versioned/Core/Api/Components/DateTimePicker/RNDateTimePicker.h
> ios/Exponent/Versioned/Core/Api/Components/DateTimePicker/RNDateTimePicker.m
> ios/Exponent/Versioned/Core/Api/Components/DateTimePicker/RNDateTimePickerManager.h
> ios/Exponent/Versioned/Core/Api/Components/DateTimePicker/RNDateTimePickerManager.m
> ios/Exponent/Versioned/Core/Api/Components/DateTimePicker/RNDateTimePickerShadowView.h
> ios/Exponent/Versioned/Core/Api/Components/DateTimePicker/RNDateTimePickerShadowView.m

Updating pbxproj configuration ...
Saving updated pbxproj structure to the file Exponent.xcodeproj/project.pbxproj ...

Successfully updated iOS files, but please make sure Xcode project files are setup correctly in Exponent/Versioned/Core/Api/Components/DateTimePicker
‼️  Using legacy vendoring for platform android
NOTE: In Expo, native Android styles are prefixed with ReactAndroid. Please ensure that resourceNames used for grabbing style of dialogs are being resolved properly.

Cleaning up Android files at expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker ...

Copying Android files ...
> android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/Common.java
> android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/MinuteIntervalSnappableTimePickerDialog.java
> android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/ReflectionHelper.java
> android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNConstants.java
> android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDate.java
> android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDatePickerDialogFragment.java
> android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDatePickerDialogModule.java
> android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDatePickerDisplay.java
> android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDateTimePickerPackage.java
> android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDismissableDatePickerDialog.java
> android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDismissableTimePickerDialog.java
> android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNTimePickerDialogFragment.java
> android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNTimePickerDialogModule.java
> android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNTimePickerDisplay.java
✍️  Updating bundled native modules
✍️  Updating workspace dependencies
💪 Successfully updated @react-native-community/datetimepicker
```

</details>

# Test Plan

I believe [there are only Android changes](https://github.com/react-native-datetimepicker/datetimepicker/compare/v6.5.0...v6.5.2), so only need to test this on Android.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
