### PR TITLE
Upgrade @react-native-masked-view/masked-view to 0.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -641,6 +641,7 @@ Package-specific changes not released in any SDK will be added here just before 
 
 ### 📚 3rd party library updates
 
+- Updated `@react-native-masked-view/masked-view` from `0.2.6` to `0.2.8`. ([#19645](https://github.com/expo/expo/pull/19645) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Updated `react-native-webview` from `11.13.0` to `11.15.0`. ([#15330](https://github.com/expo/expo/pull/15330) by [@tsapeta](https://github.com/tsapeta))
 - Updated `react-native-shared-element` from `0.8.2` to `0.8.3`. ([#15338](https://github.com/expo/expo/pull/15338) by [@kudo](https://github.com/kudo))
 - Updated `lottie-react-native` from `4.0.3` to `5.0.1`. ([#15345](https://github.com/expo/expo/pull/15345) by [@kudo](https://github.com/kudo))

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maskedview/RNCMaskedView.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maskedview/RNCMaskedView.java
@@ -77,17 +77,14 @@ public class RNCMaskedView extends ReactViewGroup {
   }
 
   private void updateBitmapMask() {
-    if (this.mBitmapMask != null) {
-      this.mBitmapMask.recycle();
-    }
-
     View maskView = getChildAt(0);
     if (maskView != null) {
       maskView.setVisibility(View.VISIBLE);
+      if (this.mBitmapMask != null) {
+        this.mBitmapMask.recycle();
+      }
       this.mBitmapMask = getBitmapFromView(maskView);
       maskView.setVisibility(View.INVISIBLE);
-    } else{
-      this.mBitmapMask = null;
     }
   }
 

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -96,7 +96,7 @@
     "@react-native-community/netinfo": "9.3.3",
     "@react-native-community/slider": "4.2.4",
     "@react-native-community/viewpager": "5.0.11",
-    "@react-native-masked-view/masked-view": "0.2.6",
+    "@react-native-masked-view/masked-view": "0.2.8",
     "@react-native-picker/picker": "2.4.6",
     "@react-native-segmented-control/segmented-control": "2.4.0",
     "expo": "~47.0.0-alpha.1",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -45,7 +45,7 @@
     "@react-native-community/datetimepicker": "6.5.2",
     "@react-native-community/netinfo": "9.3.3",
     "@react-native-community/slider": "4.2.4",
-    "@react-native-masked-view/masked-view": "0.2.6",
+    "@react-native-masked-view/masked-view": "0.2.8",
     "@react-native-picker/picker": "2.4.6",
     "@react-native-segmented-control/segmented-control": "2.4.0",
     "@react-navigation/bottom-tabs": "~6.4.0",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -2,7 +2,7 @@
   "@expo/vector-icons": "^13.0.0",
   "@react-native-async-storage/async-storage": "~1.17.3",
   "@react-native-community/datetimepicker": "6.5.2",
-  "@react-native-masked-view/masked-view": "0.2.7",
+  "@react-native-masked-view/masked-view": "0.2.8",
   "@react-native-community/netinfo": "9.3.3",
   "@react-native-community/slider": "4.2.4",
   "@react-native-community/viewpager": "5.0.11",


### PR DESCRIPTION
# Why

`@react-native-masked-view/masked-view` has historically faced an issue on Android where `MaskedView` flickers showing only the underlying color when navigating on Android devices but this has been fixed on version 0.2.8. This PR upgrades `@react-native-masked-view/masked-view` to version 0.2.8 in order to mitigate this problem.

Closes https://github.com/expo/expo/issues/19644

# How

`et update-module -m @react-native-masked-view/masked-view --commit "v0.2.8"`

# Test Plan

Manually tested on Android and iOS 

# Checklist


- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
