### PR TITLE
Update vendored modules that were patched since last update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Package-specific changes not released in any SDK will be added here just before 
 
 ### 📚 3rd party library updates
 
+- Updated `@react-native-community/netinfo` to `9.3.5`, `@react-native-picker/picker` to `2.4.8`, `@shopify/flash-list` to `1.3.1`, and `@shopify/react-native-skia` to `0.1.155` ([#19647](https://github.com/expo/expo/pull/19647) by [@brentvatne](https://github.com/brentvatne))
 - Updated `react-native-pager-view` from `5.4.245` to `6.0.1`. ([#19528](https://github.com/expo/expo/pull/19528) by [@brentvatne](https://github.com/brentvatne))
 - Updated `react-native-safe-area-context` from `4.3.1` to `4.4.1`. ([#19055](https://github.com/expo/expo/pull/19401) by [@brentvatne](https://github.com/brentvatne))
 - Updated `@stripe/stripe-react-native` from `0.13.1` to `0.19.0`. ([#19055](https://github.com/expo/expo/pull/19055) by [@tsapeta](https://github.com/tsapeta), [#19432](https://github.com/expo/expo/pull/19432) by [@kudo](https://github.com/kudo))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,17 @@ Package-specific changes not released in any SDK will be added here just before 
 
 ### 📚 3rd party library updates
 
-- Updated `@react-native-community/netinfo` to `9.3.5`, `@react-native-picker/picker` to `2.4.8`, `@shopify/flash-list` to `1.3.1`, and `@shopify/react-native-skia` to `0.1.155` ([#19647](https://github.com/expo/expo/pull/19647) by [@brentvatne](https://github.com/brentvatne))
 - Updated `react-native-pager-view` from `5.4.245` to `6.0.1`. ([#19528](https://github.com/expo/expo/pull/19528) by [@brentvatne](https://github.com/brentvatne))
 - Updated `react-native-safe-area-context` from `4.3.1` to `4.4.1`. ([#19055](https://github.com/expo/expo/pull/19401) by [@brentvatne](https://github.com/brentvatne))
 - Updated `@stripe/stripe-react-native` from `0.13.1` to `0.19.0`. ([#19055](https://github.com/expo/expo/pull/19055) by [@tsapeta](https://github.com/tsapeta), [#19432](https://github.com/expo/expo/pull/19432) by [@kudo](https://github.com/kudo))
-- Updated `@shopify/flash-list` from `1.1.0` to `1.3.0`. ([#19317](https://github.com/expo/expo/pull/19317) by [@kudo](https://github.com/kudo))
+- Updated `@shopify/flash-list` from `1.1.0` to `1.3.1`. ([#19317](https://github.com/expo/expo/pull/19317) by [@kudo](https://github.com/kudo)) ([#19647](https://github.com/expo/expo/pull/19647) by [@brentvatne](https://github.com/brentvatne))
 - Updated `react-native-view-shot` from `3.3.0` to `3.4.0`. ([#19405](https://github.com/expo/expo/pull/19405) by [@douglowder](https://github.com/douglowder))
 - Updated `react-native-webview` from `11.23.0` to `11.23.1`. ([#19375](https://github.com/expo/expo/pull/19375) by [@aleqsio](https://github.com/aleqsio))
 - Updated `react-native-gesture-handler` from `2.5.0` to `2.8.0`. ([#19362](https://github.com/expo/expo/pull/19362) & [#19654](https://github.com/expo/expo/pull/19654) by [@tsapeta](https://github.com/tsapeta) & [@lukmccall](https://github.com/lukmccall))
-- Updated `@react-native-community/netinfo` from `9.3.0` to `9.3.3`. ([#19421](https://github.com/expo/expo/pull/19421) by [@douglowder](https://github.com/douglowder))
-- Updated `@react-native-picker/picker` from `2.4.2` to `2.4.6`. ([#19390](https://github.com/expo/expo/pull/19390) by [@aleqsio](https://github.com/aleqsio))
+- Updated `@react-native-community/netinfo` from `9.3.0` to `9.3.5`. ([#19421](https://github.com/expo/expo/pull/19421) by [@douglowder](https://github.com/douglowder)) ([#19647](https://github.com/expo/expo/pull/19647) by [@brentvatne](https://github.com/brentvatne))
+- Updated `@react-native-picker/picker` from `2.4.2` to `2.4.8`. ([#19390](https://github.com/expo/expo/pull/19390) by [@aleqsio](https://github.com/aleqsio)) ([#19647](https://github.com/expo/expo/pull/19647) by [@brentvatne](https://github.com/brentvatne))
 - Updated `react-native-screens` from `3.15.0` to `3.18.0`. ([#19383](https://github.com/expo/expo/pull/19383) by [@tsapeta](https://github.com/tsapeta))
-- Updated `@shopify/react-native-skia` from `0.1.136` to `0.1.153`. ([#19360](https://github.com/expo/expo/pull/19360) by [@kudo](https://github.com/kudo))
+- Updated `@shopify/react-native-skia` from `0.1.136` to `0.1.155`. ([#19360](https://github.com/expo/expo/pull/19360) by [@kudo](https://github.com/kudo)) ([#19647](https://github.com/expo/expo/pull/19647) by [@brentvatne](https://github.com/brentvatne))
 - Updated `@react-native-community/datetimepicker` from `6.2.0` to `6.5.0`. ([#19419](https://github.com/expo/expo/pull/19419) by [@byCedric](https://github.com/byCedric))
 - Updated `react-native-maps` from `0.31.1` to `1.3.2`. ([#19414](https://github.com/expo/expo/pull/19414) by [@aleqsio](https://github.com/aleqsio))
 - Updated `lottie-react-native` from `5.1.3` to `5.1.4`. ([#19433](https://github.com/expo/expo/pull/19433) by [@kudo](https://github.com/kudo))

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/picker/ReactPicker.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/picker/ReactPicker.java
@@ -208,6 +208,12 @@ public class ReactPicker extends AppCompatSpinner {
     }
   }
 
+  public void clearFocus() {
+    super.setFocusableInTouchMode(true);
+    super.setFocusable(true);
+    super.onDetachedFromWindow();
+  }
+
   public void setOnSelectListener(@Nullable OnSelectListener onSelectListener) {
     mOnSelectListener = onSelectListener;
   }

--- a/android/vendored/unversioned/@shopify/react-native-skia/cpp/api/JsiSkCanvas.h
+++ b/android/vendored/unversioned/@shopify/react-native-skia/cpp/api/JsiSkCanvas.h
@@ -414,7 +414,7 @@ public:
   JSI_HOST_FUNCTION(saveLayer) {
     SkPaint *paint = (count >= 1 && !arguments[0].isUndefined()) ?
                          JsiSkPaint::fromValue(runtime, arguments[0]).get() : nullptr;
-    SkRect *bounds = count >= 2 && !arguments[1].isNull() && arguments[1].isUndefined() ? JsiSkRect::fromValue(runtime, arguments[1]).get() : nullptr;
+    SkRect *bounds = count >= 2 && !arguments[1].isNull() && !arguments[1].isUndefined() ? JsiSkRect::fromValue(runtime, arguments[1]).get() : nullptr;
     SkImageFilter *backdrop = count >= 3 && !arguments[2].isNull() && !arguments[2].isUndefined() ? JsiSkImageFilter::fromValue(runtime, arguments[2]).get() : nullptr;
     SkCanvas::SaveLayerFlags flags = count >= 4 ? arguments[3].asNumber() : 0;
     return jsi::Value(_canvas->saveLayer(

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -1360,7 +1360,7 @@ SPEC CHECKSUMS:
   RNCPicker: 2f71e09c52ab6327e2c393213368ea0e5bfbcb65
   RNDateTimePicker: 3f32aa2247836c12618d346113e5e82ea60ddd9c
   RNGestureHandler: 62232ba8f562f7dea5ba1b3383494eb5bf97a4d3
-  RNReanimated: 2e463924d627f7dc857eeecbfef25c4894978cd6
+  RNReanimated: f655ed50cad3a70b03bbaa1c5035aa1217f65dd5
   RNScreens: f3230dd008a7d0ce5c0a8bc78ff12cf2315bda24
   RNSharedElement: eb7d506733952d58634f34c82ec17e82f557e377
   RNSVG: 07dbd870b0dcdecc99b3a202fa37c8ca163caec2

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -97,7 +97,7 @@
     "@react-native-community/slider": "4.2.4",
     "@react-native-community/viewpager": "5.0.11",
     "@react-native-masked-view/masked-view": "0.2.8",
-    "@react-native-picker/picker": "2.4.6",
+    "@react-native-picker/picker": "2.4.8",
     "@react-native-segmented-control/segmented-control": "2.4.0",
     "expo": "~47.0.0-alpha.1",
     "expo-camera": "~13.0.0-beta.1",

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -93,7 +93,7 @@
     "@babel/runtime": "^7.14.0",
     "@react-native-async-storage/async-storage": "~1.17.3",
     "@react-native-community/datetimepicker": "6.5.2",
-    "@react-native-community/netinfo": "9.3.3",
+    "@react-native-community/netinfo": "9.3.5",
     "@react-native-community/slider": "4.2.4",
     "@react-native-community/viewpager": "5.0.11",
     "@react-native-masked-view/masked-view": "0.2.8",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -54,7 +54,7 @@
     "@react-navigation/native": "~6.0.13",
     "@react-navigation/stack": "~6.3.2",
     "@react-navigation/elements": "~1.3.6",
-    "@shopify/flash-list": "1.3.0",
+    "@shopify/flash-list": "1.3.1",
     "@shopify/react-native-skia": "0.1.155",
     "@use-expo/permissions": "^2.0.0",
     "date-format": "^2.0.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -46,7 +46,7 @@
     "@react-native-community/netinfo": "9.3.5",
     "@react-native-community/slider": "4.2.4",
     "@react-native-masked-view/masked-view": "0.2.8",
-    "@react-native-picker/picker": "2.4.6",
+    "@react-native-picker/picker": "2.4.8",
     "@react-native-segmented-control/segmented-control": "2.4.0",
     "@react-navigation/bottom-tabs": "~6.4.0",
     "@react-navigation/drawer": "6.5.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -55,7 +55,7 @@
     "@react-navigation/stack": "~6.3.2",
     "@react-navigation/elements": "~1.3.6",
     "@shopify/flash-list": "1.3.0",
-    "@shopify/react-native-skia": "0.1.153",
+    "@shopify/react-native-skia": "0.1.155",
     "@use-expo/permissions": "^2.0.0",
     "date-format": "^2.0.0",
     "deep-object-diff": "^1.1.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -43,7 +43,7 @@
     "@expo/react-native-action-sheet": "^3.8.0",
     "@react-native-async-storage/async-storage": "~1.17.3",
     "@react-native-community/datetimepicker": "6.5.2",
-    "@react-native-community/netinfo": "9.3.3",
+    "@react-native-community/netinfo": "9.3.5",
     "@react-native-community/slider": "4.2.4",
     "@react-native-masked-view/masked-view": "0.2.8",
     "@react-native-picker/picker": "2.4.6",

--- a/home/package.json
+++ b/home/package.json
@@ -23,7 +23,7 @@
     "@expo/vector-icons": "^13.0.0",
     "@graphql-codegen/introspection": "^2.1.1",
     "@react-native-async-storage/async-storage": "~1.17.3",
-    "@react-native-community/netinfo": "9.3.3",
+    "@react-native-community/netinfo": "9.3.5",
     "@react-navigation/bottom-tabs": "~6.4.0",
     "@react-navigation/material-bottom-tabs": "~6.2.4",
     "@react-navigation/native": "~6.0.13",

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2017,7 +2017,7 @@ PODS:
     - React-jsi (= 0.70.3)
     - React-logger (= 0.70.3)
     - React-perflogger (= 0.70.3)
-  - RNFlashList (1.3.0):
+  - RNFlashList (1.3.1):
     - React-Core
   - RNGestureHandler (2.8.0):
     - React-Core
@@ -3522,8 +3522,8 @@ SPEC CHECKSUMS:
   React-RCTVibration: b9a58ffdd18446f43d493a4b0ecd603ee86be847
   React-runtimeexecutor: e9b1f9310158a1e265bcdfdfd8c62d6174b947a2
   ReactCommon: 01064177e66d652192c661de899b1076da962fd9
-  RNFlashList: 5116f2de2f543f01bfc30b22d5942d5af84b43df
-  RNGestureHandler: 62232ba8f562f7dea5ba1b3383494eb5bf97a4d3
+  RNFlashList: 18d906a373da5ff16776e5013df9495d826edc7e
+  RNGestureHandler: 7673697e7c0e9391adefae4faa087442bc04af33
   RNReanimated: 590d19d77725fa713c2a0f7f656f6ac41b9ab3e8
   RNScreens: f3230dd008a7d0ce5c0a8bc78ff12cf2315bda24
   RNSVG: 07dbd870b0dcdecc99b3a202fa37c8ca163caec2

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -3523,7 +3523,7 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: e9b1f9310158a1e265bcdfdfd8c62d6174b947a2
   ReactCommon: 01064177e66d652192c661de899b1076da962fd9
   RNFlashList: 18d906a373da5ff16776e5013df9495d826edc7e
-  RNGestureHandler: 7673697e7c0e9391adefae4faa087442bc04af33
+  RNGestureHandler: 62232ba8f562f7dea5ba1b3383494eb5bf97a4d3
   RNReanimated: 590d19d77725fa713c2a0f7f656f6ac41b9ab3e8
   RNScreens: f3230dd008a7d0ce5c0a8bc78ff12cf2315bda24
   RNSVG: 07dbd870b0dcdecc99b3a202fa37c8ca163caec2

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1906,7 +1906,7 @@ PODS:
   - React-jsinspector (0.70.3)
   - React-logger (0.70.3):
     - glog
-  - react-native-netinfo (9.3.3):
+  - react-native-netinfo (9.3.5):
     - React-Core
   - react-native-pager-view (6.0.1):
     - React-Core
@@ -3503,7 +3503,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 7e2e1772ef7b97168c880eeaf3749d8c145ffd6e
   React-jsinspector: 0553c9fe7218e1f127be070bd5a4d2fc19fb8190
   React-logger: cffcc09e8aba8a3014be8d18da7f922802e9f19e
-  react-native-netinfo: b514dd6d9cd512b90e178c5b7158df1a1c568d47
+  react-native-netinfo: 85b2a435c4d3705c08b0c42ff2d6ef6b9622ea0a
   react-native-pager-view: 3051346698a0ba0c4e13e40097cc11b00ee03cca
   react-native-safe-area-context: 99b24a0c5acd0d5dcac2b1a7f18c49ea317be99a
   react-native-segmented-control: 06607462630512ff8eef652ec560e6235a30cc3e

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1918,32 +1918,32 @@ PODS:
     - ReactCommon/turbomodule/core
   - react-native-segmented-control (2.4.0):
     - React-Core
-  - react-native-skia (0.1.153):
+  - react-native-skia (0.1.155):
     - React
     - React-callinvoker
     - React-Core
-    - react-native-skia/Api (= 0.1.153)
-    - react-native-skia/Jsi (= 0.1.153)
-    - react-native-skia/RNSkia (= 0.1.153)
-    - react-native-skia/SkiaHeaders (= 0.1.153)
-    - react-native-skia/Utils (= 0.1.153)
-  - react-native-skia/Api (0.1.153):
+    - react-native-skia/Api (= 0.1.155)
+    - react-native-skia/Jsi (= 0.1.155)
+    - react-native-skia/RNSkia (= 0.1.155)
+    - react-native-skia/SkiaHeaders (= 0.1.155)
+    - react-native-skia/Utils (= 0.1.155)
+  - react-native-skia/Api (0.1.155):
     - React
     - React-callinvoker
     - React-Core
-  - react-native-skia/Jsi (0.1.153):
+  - react-native-skia/Jsi (0.1.155):
     - React
     - React-callinvoker
     - React-Core
-  - react-native-skia/RNSkia (0.1.153):
+  - react-native-skia/RNSkia (0.1.155):
     - React
     - React-callinvoker
     - React-Core
-  - react-native-skia/SkiaHeaders (0.1.153):
+  - react-native-skia/SkiaHeaders (0.1.155):
     - React
     - React-callinvoker
     - React-Core
-  - react-native-skia/Utils (0.1.153):
+  - react-native-skia/Utils (0.1.155):
     - React
     - React-callinvoker
     - React-Core
@@ -3507,7 +3507,7 @@ SPEC CHECKSUMS:
   react-native-pager-view: 3051346698a0ba0c4e13e40097cc11b00ee03cca
   react-native-safe-area-context: 99b24a0c5acd0d5dcac2b1a7f18c49ea317be99a
   react-native-segmented-control: 06607462630512ff8eef652ec560e6235a30cc3e
-  react-native-skia: 78330615997e720dd07db28f4b8dfff22e9dd031
+  react-native-skia: 687c7ec36501dbd38869ea132b1d2602cff7f518
   react-native-slider: cecabb58ecffad671d2ad3ccc58c7f4d2d029e95
   react-native-webview: d33e2db8925d090871ffeb232dfa50cb3a727581
   React-perflogger: 082b4293f0b3914ff41da35a6c06ac4490fcbcc8

--- a/ios/vendored/unversioned/@react-native-community/netinfo/react-native-netinfo.podspec.json
+++ b/ios/vendored/unversioned/@react-native-community/netinfo/react-native-netinfo.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-netinfo",
-  "version": "9.3.3",
+  "version": "9.3.5",
   "summary": "React Native Network Info API for iOS & Android",
   "license": "MIT",
   "authors": "Matt Oakes <hello@mattoakes.net>",
@@ -12,7 +12,7 @@
   },
   "source": {
     "git": "https://github.com/react-native-community/react-native-netinfo.git",
-    "tag": "v9.3.3"
+    "tag": "v9.3.5"
   },
   "source_files": "ios/**/*.{h,m}",
   "dependencies": {

--- a/ios/vendored/unversioned/@shopify/flash-list/RNFlashList.podspec.json
+++ b/ios/vendored/unversioned/@shopify/flash-list/RNFlashList.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "RNFlashList",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "summary": "FlashList is a more performant FlatList replacement",
   "homepage": "https://shopify.github.io/flash-list/",
   "license": "MIT",
@@ -11,7 +11,7 @@
   },
   "source": {
     "git": "https://github.com/shopify/flash-list.git",
-    "tag": "v1.3.0"
+    "tag": "v1.3.1"
   },
   "source_files": "ios/Sources/**/*",
   "requires_arc": true,

--- a/ios/vendored/unversioned/@shopify/react-native-skia/cpp/api/JsiSkCanvas.h
+++ b/ios/vendored/unversioned/@shopify/react-native-skia/cpp/api/JsiSkCanvas.h
@@ -414,7 +414,7 @@ public:
   JSI_HOST_FUNCTION(saveLayer) {
     SkPaint *paint = (count >= 1 && !arguments[0].isUndefined()) ?
                          JsiSkPaint::fromValue(runtime, arguments[0]).get() : nullptr;
-    SkRect *bounds = count >= 2 && !arguments[1].isNull() && arguments[1].isUndefined() ? JsiSkRect::fromValue(runtime, arguments[1]).get() : nullptr;
+    SkRect *bounds = count >= 2 && !arguments[1].isNull() && !arguments[1].isUndefined() ? JsiSkRect::fromValue(runtime, arguments[1]).get() : nullptr;
     SkImageFilter *backdrop = count >= 3 && !arguments[2].isNull() && !arguments[2].isUndefined() ? JsiSkImageFilter::fromValue(runtime, arguments[2]).get() : nullptr;
     SkCanvas::SaveLayerFlags flags = count >= 4 ? arguments[3].asNumber() : 0;
     return jsi::Value(_canvas->saveLayer(

--- a/ios/vendored/unversioned/@shopify/react-native-skia/react-native-skia.podspec.json
+++ b/ios/vendored/unversioned/@shopify/react-native-skia/react-native-skia.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-skia",
-  "version": "0.1.153",
+  "version": "0.1.155",
   "summary": "High-performance React Native Graphics using Skia",
   "description": "@shopify/react-native-skia",
   "homepage": "https://github.com/shopify/react-native-skia",
@@ -13,7 +13,7 @@
   },
   "source": {
     "git": "https://github.com/shopify/react-native-skia/react-native-skia.git",
-    "tag": "0.1.153"
+    "tag": "0.1.155"
   },
   "requires_arc": true,
   "pod_target_xcconfig": {

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -3,7 +3,7 @@
   "@react-native-async-storage/async-storage": "~1.17.3",
   "@react-native-community/datetimepicker": "6.5.2",
   "@react-native-masked-view/masked-view": "0.2.8",
-  "@react-native-community/netinfo": "9.3.3",
+  "@react-native-community/netinfo": "9.3.5",
   "@react-native-community/slider": "4.2.4",
   "@react-native-community/viewpager": "5.0.11",
   "@react-native-firebase/app": "~15.4.0",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -105,6 +105,6 @@
   "unimodules-app-loader": "~3.1.0",
   "unimodules-image-loader-interface": "~6.1.0",
   "@shopify/react-native-skia": "0.1.155",
-  "@shopify/flash-list": "1.3.0",
+  "@shopify/flash-list": "1.3.1",
   "@sentry/react-native": "4.2.2"
 }

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -7,7 +7,7 @@
   "@react-native-community/slider": "4.2.4",
   "@react-native-community/viewpager": "5.0.11",
   "@react-native-firebase/app": "~15.4.0",
-  "@react-native-picker/picker": "2.4.6",
+  "@react-native-picker/picker": "2.4.8",
   "@react-native-segmented-control/segmented-control": "2.4.0",
   "@stripe/stripe-react-native": "0.19.0",
   "expo-analytics-amplitude": "~11.3.0",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -104,7 +104,7 @@
   "sentry-expo": "~5.0.0",
   "unimodules-app-loader": "~3.1.0",
   "unimodules-image-loader-interface": "~6.1.0",
-  "@shopify/react-native-skia": "0.1.153",
+  "@shopify/react-native-skia": "0.1.155",
   "@shopify/flash-list": "1.3.0",
   "@sentry/react-native": "4.2.2"
 }


### PR DESCRIPTION
# Why

There are some useful easy to pull patches that we can sneak in before versioning.

# How

```
et uvm # etc..
```

- [x] netinfo: safe js-only bump, no native changes between 9.3.3 and 9.3.5 - just js/windows
- [x] picker: 2.4.6 → 2.4.8 adds a js fix and a very small android fix
- [x] flash-list: js-only change, safe update 1.4.1
- [x] skia: mostly js, one small c++ change 0.1.155
- [x] ~~datetimepicker: handled by @byCedric in #19642~~
- [x] masked-view: handled by @gabrieldonadel in #19645

# Test Plan

Run examples in NCL

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
