### PR TITLE
[Expo CLI] Change dev server manifest type to modern expo-updates

### DIFF
--- a/packages/@expo/cli/src/start/startAsync.ts
+++ b/packages/@expo/cli/src/start/startAsync.ts
@@ -74,9 +74,11 @@ export async function startAsync(
   const platformBundlers = getPlatformBundlers(exp);
 
   if (!options.forceManifestType) {
-    const easUpdatesUrlRegex = /^https:\/\/(staging-)?u\.expo\.dev/;
-    const isEasUpdatesUrl = exp.updates?.url ? easUpdatesUrlRegex.test(exp.updates.url) : false;
-    options.forceManifestType = isEasUpdatesUrl ? 'expo-updates' : 'classic';
+    const classicUpdatesUrlRegex = /^https:\/\/(staging-)?exp\.host/;
+    const isClassicUpdatesUrl = exp.updates?.url
+      ? classicUpdatesUrlRegex.test(exp.updates.url)
+      : false;
+    options.forceManifestType = isClassicUpdatesUrl ? 'classic' : 'expo-updates';
   }
 
   const [defaultOptions, startOptions] = await getMultiBundlerStartOptions(

--- a/packages/@expo/cli/src/start/startAsync.ts
+++ b/packages/@expo/cli/src/start/startAsync.ts
@@ -17,6 +17,8 @@ import { DevServerManager, MultiBundlerStartOptions } from './server/DevServerMa
 import { openPlatformsAsync } from './server/openPlatforms';
 import { getPlatformBundlers, PlatformBundlers } from './server/platformBundlers';
 
+const debug = require('debug')('expo:start:startAsync');
+
 async function getMultiBundlerStartOptions(
   projectRoot: string,
   { forceManifestType, ...options }: Options,
@@ -74,9 +76,17 @@ export async function startAsync(
   const platformBundlers = getPlatformBundlers(exp);
 
   if (!options.forceManifestType) {
-    const classicUpdatesUrlRegex = /^https:\/\/(staging-)?exp\.host/;
-    const isClassicUpdatesUrl = exp.updates?.url
-      ? classicUpdatesUrlRegex.test(exp.updates.url)
+    const classicUpdatesUrlRegex = /^(staging-)?exp\.host/;
+    let parsedUpdatesUrl = { hostname: '' };
+
+    try {
+      parsedUpdatesUrl = new URL(exp.updates?.url ?? '');
+    } catch {
+      debug(`Failed to parse \`updates.url\` in this project's app config.`);
+    }
+
+    const isClassicUpdatesUrl = parsedUpdatesUrl.hostname
+      ? classicUpdatesUrlRegex.test(parsedUpdatesUrl.hostname)
       : false;
     options.forceManifestType = isClassicUpdatesUrl ? 'classic' : 'expo-updates';
   }


### PR DESCRIPTION
# Why

Default to serving the modern manifest protocol instead of serving the classic manifest type.

# How

- If an `updates.url` in the project's app config matches a Classic Updates manifest endpoint (exp.host or staging-expo.host), then use the classic manifest type. To serve the classic manifest type, you'll need an `updates.url` of "https://exp.host", or to pass `--force-manifest-type=classic` when running `npx expo start`.
- This only affects the versioned CLI. The older CLI should remain unchanged.

# Test

Create project with an `updates.url` of "https://exp.host/@username/project". You should see a dev server manifest like on the left in the image below. Then, remove the URL and you should see a modern manifest, like on the right in the image below.

<img width="1690" alt="Screen Shot 2022-10-21 at 1 59 33 PM" src="https://user-images.githubusercontent.com/6455018/197259722-d9a52bb8-a36d-4081-a662-c503c36696b0.png">
