### PR TITLE
[sharing][ios] Prevent missing attachment when sharing to app a second time

### DIFF
--- a/packages/expo-sharing/CHANGELOG.md
+++ b/packages/expo-sharing/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- On iOS, dismiss share sheet after sharing to an app is cancelled, so the file doesn't fail to attach when trying to share again ([#19656](https://github.com/expo/expo/pull/19656) by [@keith-kurak](https://github.com/keith-kurak))
+
 ### 💡 Others
 
 ## 10.3.0 — 2022-07-07

--- a/packages/expo-sharing/CHANGELOG.md
+++ b/packages/expo-sharing/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- On iOS, dismiss share sheet after sharing to an app is cancelled, so the file doesn't fail to attach when trying to share again ([#19656](https://github.com/expo/expo/pull/19656) by [@keith-kurak](https://github.com/keith-kurak))
+- On iOS, dismiss share sheet after sharing to an app is canceled, so the file doesn't fail to attach when trying to share again ([#19656](https://github.com/expo/expo/pull/19656) by [@keith-kurak](https://github.com/keith-kurak))
 
 ### 💡 Others
 

--- a/packages/expo-sharing/ios/EXSharing/EXSharingModule.m
+++ b/packages/expo-sharing/ios/EXSharing/EXSharingModule.m
@@ -68,7 +68,19 @@ EX_EXPORT_METHOD_AS(shareAsync,
   _pendingResolver(nil);
   _pendingResolver = nil;
 
-  _documentInteractionController = nil;
+  // This delegate method is called whenever:
+  // a) the share sheet is cancelled
+  // b) an app is chosen, it's dialog opened, and the share is confirmed/ sent
+  // c) an app is chosen, it's dialog opened, and that dialog is cancelled
+  // In case c), the share sheet remains open, even though the promise was resolved
+  // Future attempts to share without closing the sheet will fail to attach the file, so we need to close it
+  // No other delegate methods fire only when the share sheet is dismissed, unfortunately
+  EX_WEAKIFY(self);
+  dispatch_async(dispatch_get_main_queue(), ^{
+    EX_ENSURE_STRONGIFY(self);
+    [self.documentInteractionController dismissMenuAnimated:true];
+    self.documentInteractionController = nil;
+  });
 }
 
 @end

--- a/packages/expo-sharing/ios/EXSharing/EXSharingModule.m
+++ b/packages/expo-sharing/ios/EXSharing/EXSharingModule.m
@@ -68,7 +68,7 @@ EX_EXPORT_METHOD_AS(shareAsync,
   _pendingResolver = nil;
 
   // This delegate method is called whenever:
-  // a) the share sheet is cancelled
+  // a) the share sheet is canceled
   // b) an app is chosen, it's dialog opened, and the share is confirmed/ sent
   // c) an app is chosen, it's dialog opened, and that dialog is cancelled
   // In case c), the share sheet remains open, even though the promise was resolved

--- a/packages/expo-sharing/ios/EXSharing/EXSharingModule.m
+++ b/packages/expo-sharing/ios/EXSharing/EXSharingModule.m
@@ -48,11 +48,10 @@ EX_EXPORT_METHOD_AS(shareAsync,
   _documentInteractionController.delegate = self;
   _documentInteractionController.UTI = params[@"UTI"];
 
-  UIViewController *viewController = [[_moduleRegistry getModuleImplementingProtocol:@protocol(EXUtilitiesInterface)] currentViewController];
-
   EX_WEAKIFY(self);
   dispatch_async(dispatch_get_main_queue(), ^{
     EX_ENSURE_STRONGIFY(self);
+    UIViewController *viewController = [[_moduleRegistry getModuleImplementingProtocol:@protocol(EXUtilitiesInterface)] currentViewController];
     UIView *rootView = [viewController view];
     if ([self.documentInteractionController presentOpenInMenuFromRect:CGRectZero inView:rootView animated:YES]) {
       self.pendingResolver = resolve;

--- a/packages/expo-sharing/ios/EXSharing/EXSharingModule.m
+++ b/packages/expo-sharing/ios/EXSharing/EXSharingModule.m
@@ -70,7 +70,7 @@ EX_EXPORT_METHOD_AS(shareAsync,
   // This delegate method is called whenever:
   // a) the share sheet is canceled
   // b) an app is chosen, it's dialog opened, and the share is confirmed/ sent
-  // c) an app is chosen, it's dialog opened, and that dialog is cancelled
+  // c) an app is chosen, it's dialog opened, and that dialog is canceled
   // In case c), the share sheet remains open, even though the promise was resolved
   // Future attempts to share without closing the sheet will fail to attach the file, so we need to close it
   // No other delegate methods fire only when the share sheet is dismissed, unfortunately


### PR DESCRIPTION
# Why
`Sharing.shareAsync(uri)` opens the OS share sheet, and then tapping an app will open up that app's share dialog, automatically attaching the file corresponding to the `uri`. In iOS, if you cancel the app's dialog and then open it again, the file will **not** get attached. This happens because `documentInteractionControllerDidDismissOpenInMenu` is called after the first cancel, cleaning everything up and resolving. This also means that the share sheet is still open _after_ `shareAsync` has resolved.

This fix eliminates that error state by closing the share sheet after canceling the app dialog, which isn't ideal, but matches the Android behavior, and seems to be the only option iOS offers that doesn't involve changing this API to no longer return a promise.

This behavior can be reproduced with [snack here](https://snack.expo.dev/@keith-kurak/image-picker-with-sharing):
1. Pick an image from the camera roll
2. Tap "share image"
3. Choose an app (Twitter works great for this)
4. See that the image is attached to the tweet composer
5. Cancel the tweet composer
6. Tap the Twitter app again
7. See that the image is not attached

# How
I was hoping that `UIDocumentInteractionControllerDelegate` would offer another method that would be called _only_ after the share sheet is closed. Surprisingly, `documentInteractionControllerDidDismissOptionsMenu` is never called, nor are any other of the "dismiss" delegate methods (believe me, I tried them all!). Switching `presentOpenInMenuFromRect` to `presentOptionsMenuFromRect` merely transfers the same bug to another delegate method.

This left two options:
a) dismiss the share sheet itself after sharing to an app is canceled, or
b) change the API to no longer resolve a promise

b) could be the better option (and maybe what Apple intends, given this bugginess), but it would mean developers could no longer sequence something after the share sheet is closed. In the case of a), we're at least matching the behavior of Android, which always closes the share sheet after the user interacts with an app from it.

Also moved the `currentViewController` request inside the `dispatch_async` to eliminate a bunch of `Main Thread Checker: UI API called on a background thread` console spam, but as a separate commit in case this is a bad idea for Other Reasons.

# Test Plan
Tested the following scenarios on iOS 16 (via patch-package):
1. Share an image to Twitter and send tweet
2. Tap on twitter from the share sheet, but then cancel
3. Open the share sheet, and then cancel without choosing an app

In all cases, I was able to open the sheet again and the attachment would show up in whatever app I was sharing to.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
