### PR TITLE
[tools] fix versioning script on ios

### DIFF
--- a/tools/src/versioning/ios/transforms/vendoredModulesTransforms.ts
+++ b/tools/src/versioning/ios/transforms/vendoredModulesTransforms.ts
@@ -116,6 +116,11 @@ export default function vendoredModulesTransformsFactory(prefix: string): Config
           ),
           replaceWith: `$1<${prefix}reacthermes/${prefix}HermesExecutorFactory.h>`,
         },
+        {
+          paths: '**/*.{h,mm}',
+          find: new RegExp(`${prefix}(REACT_NATIVE_MINOR_VERSION)`, 'g'),
+          replaceWith: '$1',
+        },
       ],
     },
     'react-native-gesture-handler': {


### PR DESCRIPTION
# Why

the versioning script is breaking because reanimated change a define from `RNVERSION -> REACT_NATIVE_MINOR_VERSION`. the `REACT_NATIVE_MINOR_VERSION` accidentally be versioned as `ABI47_0_0REACT_NATIVE_MINOR_VERSION`

# How

`ABI47_0_0REACT_NATIVE_MINOR_VERSION -> REACT_NATIVE_MINOR_VERSION`

# Test Plan

expo go versioning ci passed

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
