### PR TITLE
[device] Fix deviceName exception on android sdk > 31

### DIFF
--- a/packages/expo-device/CHANGELOG.md
+++ b/packages/expo-device/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `<bluetooth_name> is only readable to apps with targetSdkVersion lower than or equal to: 31` error when the `targetSdkVersion` is set to 33. ([#19666](https://github.com/expo/expo/pull/19666) by [@kudo](https://github.com/kudo), [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 - Refactored inline emulator checks to use enhanced checking in `EmulatorUtilities.isRunningOnEmulator() `. ([#16177](https://github.com/expo/expo/pull/16177)) by [@kbrandwijk](https://github.com/kbrandwijk), [@keith-kurak](https://github.com/keith-kurak))

--- a/packages/expo-device/android/src/main/java/expo/modules/device/DeviceModule.kt
+++ b/packages/expo-device/android/src/main/java/expo/modules/device/DeviceModule.kt
@@ -63,7 +63,12 @@ class DeviceModule(private val mContext: Context) : ExportedModule(mContext) {
     "osInternalBuildId" to Build.ID,
     "osBuildFingerprint" to Build.FINGERPRINT,
     "platformApiLevel" to Build.VERSION.SDK_INT,
-    "deviceName" to Settings.Secure.getString(mContext.contentResolver, "bluetooth_name")
+    "deviceName" to run {
+      if (Build.VERSION.SDK_INT <= 31)
+        Settings.Secure.getString(mContext.contentResolver, "bluetooth_name")
+      else
+        Settings.Global.getString(mContext.contentResolver, Settings.Global.DEVICE_NAME)
+    },
   )
 
   private val deviceYearClass: Int


### PR DESCRIPTION
# Why

fix #18738

# How

`<bluetooth_name> is only readable to apps with targetSdkVersion lower than or equal to: 31`

for android sdk > 31, we get the device name from `Settings.Global(..., Settings.Global.DEVICE_NAME)`. this is from: https://stackoverflow.com/a/66651458

# Test Plan

bare-expo + targetSdkVersion 33 + android emulator 33 + NCL device

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
