### PR TITLE
[docs] Footer: fix edit page link

### DIFF
--- a/docs/ui/components/Footer/Footer.test.tsx
+++ b/docs/ui/components/Footer/Footer.test.tsx
@@ -47,42 +47,42 @@ describe('githubUrl', () => {
   const EDIT_URL_PREFIX = 'https://github.com/expo/expo/edit/main/docs/pages';
 
   test('non-versioned page', () => {
-    expect(githubUrl('/guides')).toBe(EDIT_URL_PREFIX + '/guides.md');
+    expect(githubUrl('/guides')).toBe(EDIT_URL_PREFIX + '/guides.mdx');
   });
 
   test('nested non-versioned page', () => {
-    expect(githubUrl('/build/introduction')).toBe(EDIT_URL_PREFIX + '/build/introduction.md');
+    expect(githubUrl('/build/introduction')).toBe(EDIT_URL_PREFIX + '/build/introduction.mdx');
   });
 
   test('versioned index page', () => {
-    expect(githubUrl('/versions/v42.0.0')).toBe(EDIT_URL_PREFIX + '/versions/v42.0.0/index.md');
+    expect(githubUrl('/versions/v42.0.0')).toBe(EDIT_URL_PREFIX + '/versions/v42.0.0/index.mdx');
   });
 
   test('nested versioned page', () => {
     expect(githubUrl('/versions/v42.0.0/sdk/av')).toBe(
-      EDIT_URL_PREFIX + '/versions/v42.0.0/sdk/av.md'
+      EDIT_URL_PREFIX + '/versions/v42.0.0/sdk/av.mdx'
     );
   });
 
   test('latest index page', () => {
-    expect(githubUrl('/versions/latest')).toBe(EDIT_URL_PREFIX + '/versions/unversioned/index.md');
+    expect(githubUrl('/versions/latest')).toBe(EDIT_URL_PREFIX + '/versions/unversioned/index.mdx');
   });
 
   test('nested latest page', () => {
     expect(githubUrl('/versions/latest/sdk/av')).toBe(
-      EDIT_URL_PREFIX + '/versions/unversioned/sdk/av.md'
+      EDIT_URL_PREFIX + '/versions/unversioned/sdk/av.mdx'
     );
   });
 
   test('unversioned index page', () => {
     expect(githubUrl('/versions/unversioned')).toBe(
-      EDIT_URL_PREFIX + '/versions/unversioned/index.md'
+      EDIT_URL_PREFIX + '/versions/unversioned/index.mdx'
     );
   });
 
   test('nested unversioned page', () => {
     expect(githubUrl('/versions/unversioned/sdk/av')).toBe(
-      EDIT_URL_PREFIX + '/versions/unversioned/sdk/av.md'
+      EDIT_URL_PREFIX + '/versions/unversioned/sdk/av.mdx'
     );
   });
 });

--- a/docs/ui/components/Footer/utils.ts
+++ b/docs/ui/components/Footer/utils.ts
@@ -18,7 +18,7 @@ export function githubUrl(path: string) {
   }
 
   const filePath =
-    path.replace(/\/$/, '').replace('/versions/latest', '/versions/unversioned') + '.md';
+    path.replace(/\/$/, '').replace('/versions/latest', '/versions/unversioned') + '.mdx';
 
   return `https://github.com/expo/expo/edit/main/docs/pages${filePath}`;
 }


### PR DESCRIPTION
# Why

Fixes 404 GitHub links while clicking edit page in docs footer.

# How

All pages files have now `mdx` extension instead of `md`.

# Test Plan

The changes have been tested by running docs website locally. Also all tests are passing.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
