### PR TITLE
[docs] fix few code blocks formatting

### DIFF
--- a/docs/pages/guides/using-sentry.mdx
+++ b/docs/pages/guides/using-sentry.mdx
@@ -190,7 +190,8 @@ Add `expo.plugins` to your project's `app.json` (or `app.config.js`) file:
 ```json app.json
 {
   "expo": {
-    /* @hide ... your existing configuration */ /* @end */ "plugins": ["sentry-expo"]
+    /* @hide ... your existing configuration */ /* @end */
+    "plugins": ["sentry-expo"]
   }
 }
 ```

--- a/docs/pages/tutorial/image.mdx
+++ b/docs/pages/tutorial/image.mdx
@@ -129,8 +129,8 @@ const styles = StyleSheet.create({
     color: '#888',
     fontSize: 18,
     marginHorizontal: 15,
-  }, /* @end */
-
+  },
+  /* @end */
 });
 ```
 


### PR DESCRIPTION
# Why

Fixes ENG-6809

# How

Correctly the formatting in few code blocks.

# Test Plan

The changes have been tested locally.

# Preview

<img width="263" alt="Screenshot 2022-10-24 122209" src="https://user-images.githubusercontent.com/719641/197505007-24c855bd-cb28-4e8b-a516-3d2c29b8616c.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
