### PR TITLE
Add iOS simulator fallback for UTType

### DIFF
--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🎉 New features
 
 ### 🐛 Bug fixes
+
 - Fix promise rejection on M1 iOS Simulator due to `UTTypeCreatePreferredIdentifierForTag` not working as expected. ([#19669](https://github.com/expo/expo/pull/19669) by [@aleqsio](https://github.com/aleqsio))
 
 ### 💡 Others

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🎉 New features
 
 ### 🐛 Bug fixes
-- Fix promise rejection on M1 iOS Simulator due to `UTTypeCreatePreferredIdentifierForTag` not working as expected.
+- Fix promise rejection on M1 iOS Simulator due to `UTTypeCreatePreferredIdentifierForTag` not working as expected. ([#19669](https://github.com/expo/expo/pull/19669) by [@aleqsio](https://github.com/aleqsio))
 
 ### 💡 Others
 

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🎉 New features
 
 ### 🐛 Bug fixes
+- Fix promise rejection on M1 iOS Simulator due to `UTTypeCreatePreferredIdentifierForTag` not working as expected.
 
 ### 💡 Others
 

--- a/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m
+++ b/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m
@@ -935,7 +935,7 @@ EX_EXPORT_METHOD_AS(getAssetsAsync,
   // https://developer.apple.com/forums/thread/702933
   if(fileUTI == nil){
     // List from https://stackoverflow.com/a/70102692
-    NSDictionary* kExtensionLookupFallback = @{@"jpeg": @(PHAssetMediaTypeImage),
+    NSDictionary *kExtensionLookupFallback = @{@"jpeg": @(PHAssetMediaTypeImage),
                                                @"jpg": @(PHAssetMediaTypeImage),
                                                @"jpe": @(PHAssetMediaTypeImage),
                                                @"png": @(PHAssetMediaTypeImage),
@@ -972,7 +972,7 @@ EX_EXPORT_METHOD_AS(getAssetsAsync,
                                                @"icns": @(PHAssetMediaTypeImage)};
 
     EXLogWarn(@"Asset media type is recognized from file extension and this behavior can differ on iOS Simulator and a physical device.");
-    NSNumber* fallbackMediaType = [kExtensionLookupFallback objectForKey:[localUri pathExtension]];
+    NSNumber *fallbackMediaType = [kExtensionLookupFallback objectForKey:[localUri pathExtension]];
     return fallbackMediaType ? [fallbackMediaType intValue] : PHAssetMediaTypeUnknown;
   }
   

--- a/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m
+++ b/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m
@@ -925,6 +925,51 @@ EX_EXPORT_METHOD_AS(getAssetsAsync,
 {
   CFStringRef fileExtension = (__bridge CFStringRef)[localUri pathExtension];
   CFStringRef fileUTI = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, fileExtension, NULL);
+
+  // A fix for promise rejection on M1 simulator when run in Rosetta (as is by default as we don't compile ARM64 yet)
+  // https://developer.apple.com/forums/thread/702933
+  if(fileUTI == nil){
+    // List from https://stackoverflow.com/a/70102692
+    NSDictionary* kExtensionLookupFallback = @{@"jpeg": @(PHAssetMediaTypeImage),
+                                               @"jpg": @(PHAssetMediaTypeImage),
+                                               @"jpe": @(PHAssetMediaTypeImage),
+                                               @"png": @(PHAssetMediaTypeImage),
+                                               @"mp3": @(PHAssetMediaTypeAudio),
+                                               @"mpga": @(PHAssetMediaTypeAudio),
+                                               @"mov": @(PHAssetMediaTypeVideo),
+                                               @"qt": @(PHAssetMediaTypeVideo),
+                                               @"mpg": @(PHAssetMediaTypeVideo),
+                                               @"mpeg": @(PHAssetMediaTypeVideo),
+                                               @"mpe": @(PHAssetMediaTypeVideo),
+                                               @"m75": @(PHAssetMediaTypeVideo),
+                                               @"m15": @(PHAssetMediaTypeVideo),
+                                               @"m2v": @(PHAssetMediaTypeVideo),
+                                               @"ts": @(PHAssetMediaTypeVideo),
+                                               @"mp4": @(PHAssetMediaTypeVideo),
+                                               @"mpg4": @(PHAssetMediaTypeVideo),
+                                               @"m4p": @(PHAssetMediaTypeVideo),
+                                               @"avi": @(PHAssetMediaTypeVideo),
+                                               @"vfw": @(PHAssetMediaTypeVideo),
+                                               @"aiff": @(PHAssetMediaTypeAudio),
+                                               @"aif": @(PHAssetMediaTypeAudio),
+                                               @"wav": @(PHAssetMediaTypeAudio),
+                                               @"wave": @(PHAssetMediaTypeAudio),
+                                               @"bwf": @(PHAssetMediaTypeAudio),
+                                               @"midi": @(PHAssetMediaTypeAudio),
+                                               @"mid": @(PHAssetMediaTypeAudio),
+                                               @"smf": @(PHAssetMediaTypeAudio),
+                                               @"kar": @(PHAssetMediaTypeAudio),
+                                               @"tiff": @(PHAssetMediaTypeImage),
+                                               @"tif": @(PHAssetMediaTypeImage),
+                                               @"gif": @(PHAssetMediaTypeImage),
+                                               @"qtif": @(PHAssetMediaTypeImage),
+                                               @"qti": @(PHAssetMediaTypeImage),
+                                               @"icns": @(PHAssetMediaTypeImage)};
+
+    EXLogWarn(@"Asset media type is recognized from file extension and this behavior can differ on iOS Simulator and a physical device.");
+    PHAssetMediaType fallbackMediaType = [kExtensionLookupFallback objectForKey:[localUri pathExtension]];
+    return fallbackMediaType ? fallbackMediaType : PHAssetMediaTypeUnknown;
+  }
   
   if (UTTypeConformsTo(fileUTI, kUTTypeImage)) {
     return PHAssetMediaTypeImage;

--- a/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m
+++ b/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m
@@ -924,7 +924,12 @@ EX_EXPORT_METHOD_AS(getAssetsAsync,
 + (PHAssetMediaType)_assetTypeForUri:(nonnull NSString *)localUri
 {
   CFStringRef fileExtension = (__bridge CFStringRef)[localUri pathExtension];
-  CFStringRef fileUTI = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, fileExtension, NULL);
+  CFStringRef fileUTI;
+  if (@available(iOS 14, *)) {
+    fileUTI = (__bridge CFStringRef)[[UTType typeWithFilenameExtension:(__bridge NSString*)fileExtension] identifier];
+  } else {
+    fileUTI = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, fileExtension, NULL);
+  }
 
   // A fix for promise rejection on M1 simulator when run in Rosetta (as is by default as we don't compile ARM64 yet)
   // https://developer.apple.com/forums/thread/702933

--- a/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m
+++ b/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m
@@ -921,6 +921,52 @@ EX_EXPORT_METHOD_AS(getAssetsAsync,
   return [NSString stringWithFormat:@"ph://%@", assetId];
 }
 
+// A fix for promise rejection on M1 simulator when run in Rosetta (as is by default as we don't compile ARM64 yet)
+// https://developer.apple.com/forums/thread/702933
++ (PHAssetMediaType)assetTypeForFileExtension:(nonnull NSString *)fileExtension
+{
+  // List from https://stackoverflow.com/a/70102692
+  NSDictionary *kExtensionLookupFallback = @{@"jpeg": @(PHAssetMediaTypeImage),
+                                             @"jpg": @(PHAssetMediaTypeImage),
+                                             @"jpe": @(PHAssetMediaTypeImage),
+                                             @"png": @(PHAssetMediaTypeImage),
+                                             @"mp3": @(PHAssetMediaTypeAudio),
+                                             @"mpga": @(PHAssetMediaTypeAudio),
+                                             @"mov": @(PHAssetMediaTypeVideo),
+                                             @"qt": @(PHAssetMediaTypeVideo),
+                                             @"mpg": @(PHAssetMediaTypeVideo),
+                                             @"mpeg": @(PHAssetMediaTypeVideo),
+                                             @"mpe": @(PHAssetMediaTypeVideo),
+                                             @"m75": @(PHAssetMediaTypeVideo),
+                                             @"m15": @(PHAssetMediaTypeVideo),
+                                             @"m2v": @(PHAssetMediaTypeVideo),
+                                             @"ts": @(PHAssetMediaTypeVideo),
+                                             @"mp4": @(PHAssetMediaTypeVideo),
+                                             @"mpg4": @(PHAssetMediaTypeVideo),
+                                             @"m4p": @(PHAssetMediaTypeVideo),
+                                             @"avi": @(PHAssetMediaTypeVideo),
+                                             @"vfw": @(PHAssetMediaTypeVideo),
+                                             @"aiff": @(PHAssetMediaTypeAudio),
+                                             @"aif": @(PHAssetMediaTypeAudio),
+                                             @"wav": @(PHAssetMediaTypeAudio),
+                                             @"wave": @(PHAssetMediaTypeAudio),
+                                             @"bwf": @(PHAssetMediaTypeAudio),
+                                             @"midi": @(PHAssetMediaTypeAudio),
+                                             @"mid": @(PHAssetMediaTypeAudio),
+                                             @"smf": @(PHAssetMediaTypeAudio),
+                                             @"kar": @(PHAssetMediaTypeAudio),
+                                             @"tiff": @(PHAssetMediaTypeImage),
+                                             @"tif": @(PHAssetMediaTypeImage),
+                                             @"gif": @(PHAssetMediaTypeImage),
+                                             @"qtif": @(PHAssetMediaTypeImage),
+                                             @"qti": @(PHAssetMediaTypeImage),
+                                             @"icns": @(PHAssetMediaTypeImage)};
+
+  EXLogWarn(@"Asset media type is recognized from file extension and this behavior can differ on iOS Simulator and a physical device.");
+  NSNumber *fallbackMediaType = [kExtensionLookupFallback objectForKey:fileExtension];
+  return fallbackMediaType ? [fallbackMediaType intValue] : PHAssetMediaTypeUnknown;
+}
+
 + (PHAssetMediaType)_assetTypeForUri:(nonnull NSString *)localUri
 {
   CFStringRef fileExtension = (__bridge CFStringRef)[localUri pathExtension];
@@ -931,51 +977,10 @@ EX_EXPORT_METHOD_AS(getAssetsAsync,
     fileUTI = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, fileExtension, NULL);
   }
 
-  // A fix for promise rejection on M1 simulator when run in Rosetta (as is by default as we don't compile ARM64 yet)
-  // https://developer.apple.com/forums/thread/702933
-  if(fileUTI == nil){
-    // List from https://stackoverflow.com/a/70102692
-    NSDictionary *kExtensionLookupFallback = @{@"jpeg": @(PHAssetMediaTypeImage),
-                                               @"jpg": @(PHAssetMediaTypeImage),
-                                               @"jpe": @(PHAssetMediaTypeImage),
-                                               @"png": @(PHAssetMediaTypeImage),
-                                               @"mp3": @(PHAssetMediaTypeAudio),
-                                               @"mpga": @(PHAssetMediaTypeAudio),
-                                               @"mov": @(PHAssetMediaTypeVideo),
-                                               @"qt": @(PHAssetMediaTypeVideo),
-                                               @"mpg": @(PHAssetMediaTypeVideo),
-                                               @"mpeg": @(PHAssetMediaTypeVideo),
-                                               @"mpe": @(PHAssetMediaTypeVideo),
-                                               @"m75": @(PHAssetMediaTypeVideo),
-                                               @"m15": @(PHAssetMediaTypeVideo),
-                                               @"m2v": @(PHAssetMediaTypeVideo),
-                                               @"ts": @(PHAssetMediaTypeVideo),
-                                               @"mp4": @(PHAssetMediaTypeVideo),
-                                               @"mpg4": @(PHAssetMediaTypeVideo),
-                                               @"m4p": @(PHAssetMediaTypeVideo),
-                                               @"avi": @(PHAssetMediaTypeVideo),
-                                               @"vfw": @(PHAssetMediaTypeVideo),
-                                               @"aiff": @(PHAssetMediaTypeAudio),
-                                               @"aif": @(PHAssetMediaTypeAudio),
-                                               @"wav": @(PHAssetMediaTypeAudio),
-                                               @"wave": @(PHAssetMediaTypeAudio),
-                                               @"bwf": @(PHAssetMediaTypeAudio),
-                                               @"midi": @(PHAssetMediaTypeAudio),
-                                               @"mid": @(PHAssetMediaTypeAudio),
-                                               @"smf": @(PHAssetMediaTypeAudio),
-                                               @"kar": @(PHAssetMediaTypeAudio),
-                                               @"tiff": @(PHAssetMediaTypeImage),
-                                               @"tif": @(PHAssetMediaTypeImage),
-                                               @"gif": @(PHAssetMediaTypeImage),
-                                               @"qtif": @(PHAssetMediaTypeImage),
-                                               @"qti": @(PHAssetMediaTypeImage),
-                                               @"icns": @(PHAssetMediaTypeImage)};
-
-    EXLogWarn(@"Asset media type is recognized from file extension and this behavior can differ on iOS Simulator and a physical device.");
-    NSNumber *fallbackMediaType = [kExtensionLookupFallback objectForKey:[localUri pathExtension]];
-    return fallbackMediaType ? [fallbackMediaType intValue] : PHAssetMediaTypeUnknown;
+  if (fileUTI == nil){
+    return [EXMediaLibrary assetTypeForFileExtension:[localUri pathExtension]];
   }
-  
+
   if (UTTypeConformsTo(fileUTI, kUTTypeImage)) {
     return PHAssetMediaTypeImage;
   }

--- a/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m
+++ b/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m
@@ -972,8 +972,8 @@ EX_EXPORT_METHOD_AS(getAssetsAsync,
                                                @"icns": @(PHAssetMediaTypeImage)};
 
     EXLogWarn(@"Asset media type is recognized from file extension and this behavior can differ on iOS Simulator and a physical device.");
-    PHAssetMediaType fallbackMediaType = [kExtensionLookupFallback objectForKey:[localUri pathExtension]];
-    return fallbackMediaType ? fallbackMediaType : PHAssetMediaTypeUnknown;
+    NSNumber* fallbackMediaType = [kExtensionLookupFallback objectForKey:[localUri pathExtension]];
+    return fallbackMediaType ? [fallbackMediaType intValue] : PHAssetMediaTypeUnknown;
   }
   
   if (UTTypeConformsTo(fileUTI, kUTTypeImage)) {


### PR DESCRIPTION
# Why

Closes https://github.com/expo/expo/issues/16383

It seems this line doesn't work on iOS simulator on M1 macs when the app is run through Rosetta (as Expo GO is):
```
expo/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m:927

CFStringRef fileUTI = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, fileExtension, NULL);**
```

It seems that this is a common issue:

https://github.com/ionic-team/capacitor/issues/4903

https://developer.apple.com/forums/thread/685968

https://developer.apple.com/forums/thread/702933

The `UTTypeCreatePreferredIdentifierForTag` method is also deprecated.

Unfortunately, changing to the non-deprecated `[UTType typeWithFilenameExtension]`  also returns nil on M1 simulator.


# How

We can do a lookup table for mapping extensions to media types if iOS functions return nil.


# Test Plan

I've tested the fallback code on iOS simulator.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
