### PR TITLE
[module-scripts] use correct TSConfig package in dependencies

### DIFF
--- a/packages/expo-module-scripts/CHANGELOG.md
+++ b/packages/expo-module-scripts/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### 💡 Others
 
+- Use the correct TSConfig package in dependencies to match one referred in `tsconfig.plugin.json`.
+
 ## 2.1.0 — 2022-08-04
 
 ### 🎉 New features

--- a/packages/expo-module-scripts/CHANGELOG.md
+++ b/packages/expo-module-scripts/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### 💡 Others
 
-- Use the correct TSConfig package in dependencies to match one referred in `tsconfig.plugin.json`.
+- Use the correct TSConfig package in dependencies to match one referred in `tsconfig.plugin.json`. ([#19670](https://github.com/expo/expo/pull/19670) by [@Simek](https://github.com/Simek))
 
 ## 2.1.0 — 2022-08-04
 

--- a/packages/expo-module-scripts/package.json
+++ b/packages/expo-module-scripts/package.json
@@ -29,7 +29,7 @@
     "@babel/cli": "^7.1.2",
     "@expo/npm-proofread": "^1.0.1",
     "@testing-library/react-hooks": "^7.0.1",
-    "@tsconfig/node12": "^1.0.9",
+    "@tsconfig/node14": "^1.0.3",
     "@types/jest": "^26.0.24",
     "babel-preset-expo": "~9.2.0",
     "commander": "^2.19.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3780,7 +3780,7 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.11.tgz#ee3def1f27d9ed66dac6e46a295cffb0152e058d"
   integrity sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==
 
-"@tsconfig/node14@^1.0.1":
+"@tsconfig/node14@^1.0.1", "@tsconfig/node14@^1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.3.tgz#e4386316284f00b98435bf40f72f75a09dabf6c1"
   integrity sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==


### PR DESCRIPTION
# Why

Refs #18204

# How

Change the TSConfig package listed in the `expo-module-scripts` to match one referred in `tsconfig.plugin.json`:
* https://github.com/expo/expo/blob/6445b96d7bf15cb32852c0bc89d30e646f2fadc7/packages/expo-module-scripts/tsconfig.plugin.json#L2

# Test Plan

The `expo-module-scripts` seems to work the same as before the change.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
