### PR TITLE
[docs] Fix link for Deep Linking Android

### DIFF
--- a/docs/pages/guides/deep-linking.mdx
+++ b/docs/pages/guides/deep-linking.mdx
@@ -158,7 +158,7 @@ It may be desirable for links to your domain to always open your app (without pr
   integrity** > **App Signing**. Under **Digital Asset Links JSON**, you will see a list of
   fingerprints for your app. Copy and paste the JSON into the **assetlinks.json**. For more
   information, see [Android's
-  documentation](https://developer.android.com/training/app-links/verify-site-associations#web-assoc).
+  documentation](https://developer.android.com/training/app-links/verify-android-applinks#web-assoc).
 </Step>
 
 <Step label="2">


### PR DESCRIPTION
# Why

The current link doesn't point to anything useful any more. 

# How

With my hands.

# Test Plan

Click the link.

# Checklist

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [X] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
