### PR TITLE
Fix broken link in Expo's Webview docs

### DIFF
--- a/docs/pages/versions/unversioned/sdk/webview.mdx
+++ b/docs/pages/versions/unversioned/sdk/webview.mdx
@@ -14,7 +14,7 @@ import { SnackInline} from '~/ui/components/Snippet';
 
 ## Installation
 
-<APIInstallSection href="https://github.com/react-native-community/react-native-webview/blob/master/docs/Getting-Started.mdx#react-native-webview-getting-started-guide" />
+<APIInstallSection href="https://github.com/react-native-community/react-native-webview/blob/master/docs/Getting-Started.md#react-native-webview-getting-started-guide" />
 
 ## Usage
 


### PR DESCRIPTION
# Why

The link in the following section of the Expo docs is broken:
https://docs.expo.dev/versions/latest/sdk/webview/#usage

<img width="796" alt="Screenshot 2022-10-25 at 16 25 53" src="https://user-images.githubusercontent.com/5967956/197800643-6a1451d2-0974-4b19-b285-fb87bd124504.png">

<img width="1210" alt="Screenshot 2022-10-25 at 16 26 15" src="https://user-images.githubusercontent.com/5967956/197800747-70582db6-8cf7-4c6d-b437-8334e8f7cd1b.png">

# How

Replace the link url's `Guide.mdx` reference with `Guide.md` instead

```suggestion
https://github.com/react-native-webview/react-native-webview/blob/master/docs/Guide.mdx#react-native-webview-guide
https://github.com/react-native-webview/react-native-webview/blob/master/docs/Guide.md#react-native-webview-guide
```

# Test Plan

Preview change in (vscode) Markdown preview, click on `[react-native-webview docs](https://github.com/react-native-community/react-native-webview/blob/master/docs/Guide.md#react-native-webview-guide)` to see that the link is no longer broken

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
