### PR TITLE
[tools] Fix hermes versioning

### DIFF
--- a/tools/src/versioning/ios/index.ts
+++ b/tools/src/versioning/ios/index.ts
@@ -384,7 +384,7 @@ async function generateReactNativePodScriptAsync(
     { find: /^\s+prepare_hermes[.\s\S]*abort unless prep_status == 0\n$/gm, replaceWith: '' },
     {
       find: `pod '${versionName}hermes-engine', :podspec => "#{react_native_path}/sdks/hermes/hermes-engine.podspec"`,
-      replaceWith: `pod '${versionName}hermes-engine', :path => "#{react_native_path}/sdks/hermes-engine", :project_name => '${versionName}'`,
+      replaceWith: `pod '${versionName}hermes-engine', :podspec => "#{react_native_path}/sdks/hermes-engine/${versionName}hermes-engine.podspec", :project_name => '${versionName}'`,
     },
     { find: new RegExp(`\\b${versionName}(libevent)\\b`, 'g'), replaceWith: '$1' },
   ];

--- a/tools/src/versioning/ios/transforms/podspecTransforms.ts
+++ b/tools/src/versioning/ios/transforms/podspecTransforms.ts
@@ -104,6 +104,12 @@ export function podspecTransforms(versionName: string): TransformPipeline {
       .replace(/_/g, '.')}/${versionName}hermes.tar.gz'
   end`,
       },
+      {
+        // Revert the previous podspec source transform
+        paths: 'hermes-engine.podspec',
+        replace: /(\.source\s*)= \{ :path => "." \}\n/g,
+        with: '$1= source\n',
+      },
     ],
   };
 }

--- a/tools/src/versioning/ios/versionHermes.ts
+++ b/tools/src/versioning/ios/versionHermes.ts
@@ -228,7 +228,7 @@ export async function createVersionedHermesTarball(
     const tarball = path.join(EXPO_DIR, `${versionName}hermes.tar.gz`);
     logger.log(`Archiving hermes tarball: ${tarball}`);
     await removeUnusedHeaders(hermesRoot, versionName);
-    await spawnAsync('tar', ['cvfz', tarball, 'destroot'], {
+    await spawnAsync('tar', ['cvfz', tarball, 'destroot', 'LICENSE'], {
       cwd: hermesRoot,
       stdio: options?.verbose ? 'inherit' : 'ignore',
     });

--- a/tools/src/versioning/ios/versionHermes.ts
+++ b/tools/src/versioning/ios/versionHermes.ts
@@ -228,6 +228,7 @@ export async function createVersionedHermesTarball(
     const tarball = path.join(EXPO_DIR, `${versionName}hermes.tar.gz`);
     logger.log(`Archiving hermes tarball: ${tarball}`);
     await removeUnusedHeaders(hermesRoot, versionName);
+    // NOTE(kudo): we should include the _LICENSE_ file in the tarball, otherwise CocoaPods will get empty result from tarball extraction.
     await spawnAsync('tar', ['cvfz', tarball, 'destroot', 'LICENSE'], {
       cwd: hermesRoot,
       stdio: options?.verbose ? 'inherit' : 'ignore',


### PR DESCRIPTION
# Why

fix the hermes versioning issue causing the versioned hermes cannot be downloaded

# How

- spec.source should not be `{ :path => "." }`
- in the pod statement, the `:path` cannot fetch remote artifacts, we should use `:podspec` instead.
- the tarball should contain a `LICENSE` file, otherwise, the extraction result will be empty.

# Test Plan

- versioning ci passed
- test the work on `@tsapeta/ios/add-sdk-47` branch

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
