### PR TITLE
[docs] mark expo-firebase-* as deprecated

### DIFF
--- a/docs/pages/versions/unversioned/sdk/firebase-analytics.mdx
+++ b/docs/pages/versions/unversioned/sdk/firebase-analytics.mdx
@@ -10,7 +10,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { Terminal } from '~/ui/components/Snippet';
 import { InlineCode } from '~/components/base/code';
 
-> **warning** **Deprecated:** This module will be removed in SDK 48. Check out our [Migration Guide](https://expo.fyi/rnfs-migration-guide) for help migrating to [React Native Firebase](https://rnfirebase.io/).
+> **warning** **Deprecated:** This module will be removed in SDK 48. Check out our [Migration Guide](https://expo.fyi/firebase-migration-guide) for help migrating to [React Native Firebase](https://rnfirebase.io/).
 
 > **This is the only Firebase Analytics package for React Native that has universal platform support (iOS, Android, Web, and Electron).**
 

--- a/docs/pages/versions/unversioned/sdk/firebase-analytics.mdx
+++ b/docs/pages/versions/unversioned/sdk/firebase-analytics.mdx
@@ -10,6 +10,8 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { Terminal } from '~/ui/components/Snippet';
 import { InlineCode } from '~/components/base/code';
 
+> **warning** **Deprecated.** This module will be removed in SDK 48. Check out our [Migration Guide](/guides/migrating-to-react-native-firebase.mdx) for help migrating to [React Native Firebase](https://rnfirebase.io/).
+
 > **This is the only Firebase Analytics package for React Native that has universal platform support (iOS, Android, Web, and Electron).**
 
 `expo-firebase-analytics` provides a unified native and web API for Google Analytics for Firebase, including partial Expo Go compatibility. Google Analytics for Firebase is a free app measurement solution that provides insight on app usage and user engagement.

--- a/docs/pages/versions/unversioned/sdk/firebase-analytics.mdx
+++ b/docs/pages/versions/unversioned/sdk/firebase-analytics.mdx
@@ -10,7 +10,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { Terminal } from '~/ui/components/Snippet';
 import { InlineCode } from '~/components/base/code';
 
-> **warning** **Deprecated:** This module will be removed in SDK 48. Check out our [Migration Guide](https://expo.fyi/firebase-migration-guide) for help migrating to [React Native Firebase](https://rnfirebase.io/).
+> **warning** **Deprecated:** This module will no longer be available in SDK 48. [Learn how to migrate to React Native Firebase](https://expo.fyi/firebase-migration-guide).
 
 > **This is the only Firebase Analytics package for React Native that has universal platform support (iOS, Android, Web, and Electron).**
 

--- a/docs/pages/versions/unversioned/sdk/firebase-analytics.mdx
+++ b/docs/pages/versions/unversioned/sdk/firebase-analytics.mdx
@@ -10,7 +10,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { Terminal } from '~/ui/components/Snippet';
 import { InlineCode } from '~/components/base/code';
 
-> **warning** **Deprecated.** This module will be removed in SDK 48. Check out our [Migration Guide](https://expo.fyi/rnfs-migration-guide) for help migrating to [React Native Firebase](https://rnfirebase.io/).
+> **warning** **Deprecated:** This module will be removed in SDK 48. Check out our [Migration Guide](https://expo.fyi/rnfs-migration-guide) for help migrating to [React Native Firebase](https://rnfirebase.io/).
 
 > **This is the only Firebase Analytics package for React Native that has universal platform support (iOS, Android, Web, and Electron).**
 

--- a/docs/pages/versions/unversioned/sdk/firebase-analytics.mdx
+++ b/docs/pages/versions/unversioned/sdk/firebase-analytics.mdx
@@ -10,7 +10,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { Terminal } from '~/ui/components/Snippet';
 import { InlineCode } from '~/components/base/code';
 
-> **warning** **Deprecated.** This module will be removed in SDK 48. Check out our [Migration Guide](/guides/migrating-to-react-native-firebase.mdx) for help migrating to [React Native Firebase](https://rnfirebase.io/).
+> **warning** **Deprecated.** This module will be removed in SDK 48. Check out our [Migration Guide](https://expo.fyi/rnfs-migration-guide) for help migrating to [React Native Firebase](https://rnfirebase.io/).
 
 > **This is the only Firebase Analytics package for React Native that has universal platform support (iOS, Android, Web, and Electron).**
 

--- a/docs/pages/versions/unversioned/sdk/firebase-core.mdx
+++ b/docs/pages/versions/unversioned/sdk/firebase-core.mdx
@@ -8,7 +8,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-> **warning** **Deprecated.** This module will be removed in SDK 48. Check out our [Migration Guide](https://expo.fyi/rnfs-migration-guide) for help migrating to [React Native Firebase](https://rnfirebase.io/).
+> **warning** **Deprecated:** This module will be removed in SDK 48. Check out our [Migration Guide](https://expo.fyi/rnfs-migration-guide) for help migrating to [React Native Firebase](https://rnfirebase.io/).
 
 `expo-firebase-core` provides access to the Firebase configuration and performs initialization of the native Firebase App.
 

--- a/docs/pages/versions/unversioned/sdk/firebase-core.mdx
+++ b/docs/pages/versions/unversioned/sdk/firebase-core.mdx
@@ -8,7 +8,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-> **warning** **Deprecated:** This module will be removed in SDK 48. Check out our [Migration Guide](https://expo.fyi/rnfs-migration-guide) for help migrating to [React Native Firebase](https://rnfirebase.io/).
+> **warning** **Deprecated:** This module will be removed in SDK 48. Check out our [Migration Guide](https://expo.fyi/firebase-migration-guide) for help migrating to [React Native Firebase](https://rnfirebase.io/).
 
 `expo-firebase-core` provides access to the Firebase configuration and performs initialization of the native Firebase App.
 

--- a/docs/pages/versions/unversioned/sdk/firebase-core.mdx
+++ b/docs/pages/versions/unversioned/sdk/firebase-core.mdx
@@ -8,6 +8,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
+> **warning** **Deprecated.** This module will be removed in SDK 48. Check out our [Migration Guide](/guides/migrating-to-react-native-firebase.mdx) for help migrating to [React Native Firebase](https://rnfirebase.io/).
+
 `expo-firebase-core` provides access to the Firebase configuration and performs initialization of the native Firebase App.
 
 > **warning** You do not have to install this library directly in your project to use [Firebase](/guides/using-firebase). It is used as a peer dependency for the `expo-firebase-analytics` module when used with [React Native Firebase](/versions/latest/sdk/firebase-analytics/#with-native-firebase-sdk).

--- a/docs/pages/versions/unversioned/sdk/firebase-core.mdx
+++ b/docs/pages/versions/unversioned/sdk/firebase-core.mdx
@@ -8,7 +8,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-> **warning** **Deprecated:** This module will be removed in SDK 48. Check out our [Migration Guide](https://expo.fyi/firebase-migration-guide) for help migrating to [React Native Firebase](https://rnfirebase.io/).
+> **warning** **Deprecated:** This module will no longer be available in SDK 48. [Learn how to migrate to React Native Firebase](https://expo.fyi/firebase-migration-guide).
 
 `expo-firebase-core` provides access to the Firebase configuration and performs initialization of the native Firebase App.
 

--- a/docs/pages/versions/unversioned/sdk/firebase-core.mdx
+++ b/docs/pages/versions/unversioned/sdk/firebase-core.mdx
@@ -8,7 +8,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-> **warning** **Deprecated.** This module will be removed in SDK 48. Check out our [Migration Guide](/guides/migrating-to-react-native-firebase.mdx) for help migrating to [React Native Firebase](https://rnfirebase.io/).
+> **warning** **Deprecated.** This module will be removed in SDK 48. Check out our [Migration Guide](https://expo.fyi/rnfs-migration-guide) for help migrating to [React Native Firebase](https://rnfirebase.io/).
 
 `expo-firebase-core` provides access to the Firebase configuration and performs initialization of the native Firebase App.
 

--- a/docs/pages/versions/unversioned/sdk/firebase-recaptcha.mdx
+++ b/docs/pages/versions/unversioned/sdk/firebase-recaptcha.mdx
@@ -9,6 +9,8 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline} from '~/ui/components/Snippet';
 import { Terminal } from '~/ui/components/Snippet';
 
+> **warning** **Deprecated.** This module will be removed in SDK 48. Check out our [Migration Guide](/guides/migrating-to-react-native-firebase.mdx) for help migrating to [React Native Firebase](https://rnfirebase.io/).
+
 `expo-firebase-recaptcha` provides a set of building blocks for creating a reCAPTCHA verifier and using that with your Firebase Phone authentication workflow.
 
 > Firebase phone authentication is not possible out of the box using the Firebase JS SDK. This because an Application Verifier object (reCAPTCHA) is needed as an additional security measure to verify that the user is real and not a bot.

--- a/docs/pages/versions/unversioned/sdk/firebase-recaptcha.mdx
+++ b/docs/pages/versions/unversioned/sdk/firebase-recaptcha.mdx
@@ -9,7 +9,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline} from '~/ui/components/Snippet';
 import { Terminal } from '~/ui/components/Snippet';
 
-> **warning** **Deprecated.** This module will be removed in SDK 48. Check out our [Migration Guide](/guides/migrating-to-react-native-firebase.mdx) for help migrating to [React Native Firebase](https://rnfirebase.io/).
+> **warning** **Deprecated.** This module will be removed in SDK 48. Check out our [Migration Guide](https://expo.fyi/rnfs-migration-guide) for help migrating to [React Native Firebase](https://rnfirebase.io/).
 
 `expo-firebase-recaptcha` provides a set of building blocks for creating a reCAPTCHA verifier and using that with your Firebase Phone authentication workflow.
 

--- a/docs/pages/versions/unversioned/sdk/firebase-recaptcha.mdx
+++ b/docs/pages/versions/unversioned/sdk/firebase-recaptcha.mdx
@@ -9,7 +9,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline} from '~/ui/components/Snippet';
 import { Terminal } from '~/ui/components/Snippet';
 
-> **warning** **Deprecated:** This module will be removed in SDK 48. Check out our [Migration Guide](https://expo.fyi/rnfs-migration-guide) for help migrating to [React Native Firebase](https://rnfirebase.io/).
+> **warning** **Deprecated:** This module will be removed in SDK 48. Check out our [Migration Guide](https://expo.fyi/firebase-migration-guide) for help migrating to [React Native Firebase](https://rnfirebase.io/).
 
 `expo-firebase-recaptcha` provides a set of building blocks for creating a reCAPTCHA verifier and using that with your Firebase Phone authentication workflow.
 

--- a/docs/pages/versions/unversioned/sdk/firebase-recaptcha.mdx
+++ b/docs/pages/versions/unversioned/sdk/firebase-recaptcha.mdx
@@ -9,7 +9,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline} from '~/ui/components/Snippet';
 import { Terminal } from '~/ui/components/Snippet';
 
-> **warning** **Deprecated.** This module will be removed in SDK 48. Check out our [Migration Guide](https://expo.fyi/rnfs-migration-guide) for help migrating to [React Native Firebase](https://rnfirebase.io/).
+> **warning** **Deprecated:** This module will be removed in SDK 48. Check out our [Migration Guide](https://expo.fyi/rnfs-migration-guide) for help migrating to [React Native Firebase](https://rnfirebase.io/).
 
 `expo-firebase-recaptcha` provides a set of building blocks for creating a reCAPTCHA verifier and using that with your Firebase Phone authentication workflow.
 

--- a/docs/pages/versions/unversioned/sdk/firebase-recaptcha.mdx
+++ b/docs/pages/versions/unversioned/sdk/firebase-recaptcha.mdx
@@ -9,7 +9,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline} from '~/ui/components/Snippet';
 import { Terminal } from '~/ui/components/Snippet';
 
-> **warning** **Deprecated:** This module will be removed in SDK 48. Check out our [Migration Guide](https://expo.fyi/firebase-migration-guide) for help migrating to [React Native Firebase](https://rnfirebase.io/).
+> **warning** **Deprecated:** This module will no longer be available in SDK 48. [Learn how to migrate to React Native Firebase](https://expo.fyi/firebase-migration-guide).
 
 `expo-firebase-recaptcha` provides a set of building blocks for creating a reCAPTCHA verifier and using that with your Firebase Phone authentication workflow.
 

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -6,7 +6,6 @@
   "@react-native-community/netinfo": "9.3.5",
   "@react-native-community/slider": "4.2.4",
   "@react-native-community/viewpager": "5.0.11",
-  "@react-native-firebase/app": "~15.4.0",
   "@react-native-picker/picker": "2.4.8",
   "@react-native-segmented-control/segmented-control": "2.4.0",
   "@stripe/stripe-react-native": "0.19.0",


### PR DESCRIPTION
# Why

Fulfills [ENG-6457](https://linear.app/expo/issue/ENG-6457/mark-the-api-as-deprecated-in-the-documentation).

# How

Added deprecation notices to the three affected packages. Also removed RNFS from the `bundledNativeModules.json`, so those who are performing the [migration to RNFS](https://expo.fyi/rnfs-migration-guide) don't get warnings from using the latest version, which is totally fine if you don't use the `expo-firebase-*` packages.

# Test Plan

check the docs/ links

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
